### PR TITLE
utils: Python 3 is required, avoid using old Python

### DIFF
--- a/utils/build_swift/README.md
+++ b/utils/build_swift/README.md
@@ -8,5 +8,5 @@ the Swift build-script.
 You may run the unit test suite using the command:
 
 ```sh
-$ python utils/build_swift/run_tests.py
+$ python3 utils/build_swift/run_tests.py
 ```

--- a/utils/pygments/README.txt
+++ b/utils/pygments/README.txt
@@ -30,7 +30,7 @@ Copy the `swift.py` file to this directory.
 
 Execute the Pygments config script:
 
-    $ python _mapping.py
+    $ python3 _mapping.py
 
 Usage
 =====

--- a/utils/swift_build_support/README.md
+++ b/utils/swift_build_support/README.md
@@ -6,5 +6,5 @@ structures used by the Swift build script.
 You may run unit tests for `swift_build_support` from the command line:
 
 ```sh
-$ python utils/swift_build_support/run_tests.py
+$ python3 utils/swift_build_support/run_tests.py
 ```


### PR DESCRIPTION
On both macOS and Linux `python` is not symlinked to `python3` by default. To avoid confusion, we should update our documentation that instructs users to run scripts with `python` to use `python3` instead.