### PR TITLE
CrossModuleOptimization: don't serialize functions referencing imported C functions/variables

### DIFF
--- a/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
+++ b/lib/SILOptimizer/IPO/CrossModuleOptimization.cpp
@@ -264,6 +264,11 @@ bool CrossModuleOptimization::canSerializeInstruction(SILInstruction *inst,
       return false;
     }
 
+    // In some project configurations imported C functions are not necessarily
+    // public in their modules.
+    if (conservative && callee->hasClangNode())
+      return false;
+
     // Recursively walk down the call graph.
     if (canSerializeFunction(callee, canSerializeFlags, maxDepth - 1))
       return true;
@@ -284,6 +289,12 @@ bool CrossModuleOptimization::canSerializeInstruction(SILInstruction *inst,
         !hasPublicVisibility(global->getLinkage())) {
       return false;
     }
+
+    // In some project configurations imported C variables are not necessarily
+    // public in their modules.
+    if (conservative && global->hasClangNode())
+      return false;
+
     return true;
   }
   if (auto *KPI = dyn_cast<KeyPathInst>(inst)) {

--- a/test/SILOptimizer/Inputs/cross-module/c-module.c
+++ b/test/SILOptimizer/Inputs/cross-module/c-module.c
@@ -5,3 +5,4 @@ long privateCFunc() {
   return 123;
 }
 
+long privateCVar = 27;

--- a/test/SILOptimizer/Inputs/cross-module/c-module.h
+++ b/test/SILOptimizer/Inputs/cross-module/c-module.h
@@ -1,3 +1,4 @@
 
 long privateCFunc();
 
+long privateCVar;

--- a/test/SILOptimizer/Inputs/cross-module/default-module.swift
+++ b/test/SILOptimizer/Inputs/cross-module/default-module.swift
@@ -1,5 +1,6 @@
 
 import Submodule
+import PrivateCModule
 
 public func incrementByThree(_ x: Int) -> Int {
   return incrementByOne(x) + 2
@@ -32,3 +33,10 @@ public struct ModuleStruct {
   public static var privateFunctionPointer: (Int) -> (Int) = { $0 }
 }
 
+public func callPrivateCFunc() -> Int {
+  return Int(privateCFunc())
+}
+
+public func usePrivateCVar() -> Int {
+  return Int(privateCVar);
+}

--- a/test/SILOptimizer/default-cmo.swift
+++ b/test/SILOptimizer/default-cmo.swift
@@ -5,7 +5,7 @@
 // RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo -parse-as-library -emit-module -emit-module-path=%t/Module.swiftmodule -module-name=Module -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/module.o
 // RUN: %target-build-swift -O -wmo -Xfrontend -enable-default-cmo -parse-as-library -emit-tbd -emit-tbd-path %t/ModuleTBD.tbd -emit-module -emit-module-path=%t/ModuleTBD.swiftmodule -module-name=ModuleTBD -I%t -I%S/Inputs/cross-module %S/Inputs/cross-module/default-module.swift -c -o %t/moduletbd.o
 
-// RUN: %target-build-swift -O -wmo -module-name=Main -I%t %s -emit-sil | %FileCheck %s
+// RUN: %target-build-swift -O -wmo -module-name=Main -I%t -I%S/Inputs/cross-module %s -emit-sil | %FileCheck %s
 
 
 import Module
@@ -22,6 +22,20 @@ public func callPublicFunctionPointer(_ x: Int) -> Int {
 
 public func callPrivateFunctionPointer(_ x: Int) -> Int {
   return Module.ModuleStruct.privateFunctionPointer(x)
+}
+
+// CHECK-LABEL: sil @$s4Main24callPrivateCFuncInModuleSiyF : $@convention(thin) () -> Int {
+// CHECK:         function_ref @$s6Module16callPrivateCFuncSiyF
+// CHECK:       } // end sil function '$s4Main24callPrivateCFuncInModuleSiyF'
+public func callPrivateCFuncInModule() -> Int {
+  return Module.callPrivateCFunc()
+}
+
+// CHECK-LABEL: sil @$s4Main22usePrivateCVarInModuleSiyF : $@convention(thin) () -> Int {
+// CHECK:         function_ref @$s6Module14usePrivateCVarSiyF
+// CHECK:       } // end sil function '$s4Main22usePrivateCVarInModuleSiyF'
+public func usePrivateCVarInModule() -> Int {
+  return Module.usePrivateCVar()
 }
 
 // CHECK-LABEL: sil @$s4Main11doIncrementyS2iF


### PR DESCRIPTION
Imported C functions and variables are not necessarily public in their modules.

rdar://100874714
