### PR TITLE
[CMake] Use an absolute path when adding Swift runtime paths.

### DIFF
--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -341,7 +341,7 @@ macro(add_sourcekit_executable name)
   endif()
 
   set(RPATH_LIST)
-  add_sourcekit_swift_runtime_link_flags(${name} "../../../.." ${SKEXEC_HAS_SWIFT_MODULES})
+  add_sourcekit_swift_runtime_link_flags(${name} ${SOURCEKIT_LIBRARY_OUTPUT_INTDIR} ${SKEXEC_HAS_SWIFT_MODULES})
 
 endmacro()
 


### PR DESCRIPTION
The SourceKit version of these operations takes an absolute path, whereas the primary one takes a relative path.

Fixes rdar://100976577
