### PR TITLE
update_checkout: add Windows dependencies

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -798,13 +798,10 @@ setlocal enableextensions enabledelayedexpansion
 git config --global core.symlink true
 
 :: FIXME(compnerd) avoid the fresh clone
-rd /s /q zlib libxml2 sqlite icu curl
+rd /s /q sqlite icu
 
-git clone --quiet --no-tags --depth 1 --branch v1.2.11 https://github.com/madler/zlib
-git clone --quiet --no-tags --depth 1 --branch v2.9.12 https://github.com/gnome/libxml2
 git clone --quiet --no-tags --depth 1 --branch version-3.36.0 https://github.com/sqlite/sqlite
 git clone --quiet --no-tags --depth 1 --branch maint/maint-69 https://github.com/unicode-org/icu
-git clone --quiet --no-tags --depth 1 --branch curl-7_77_0 https://github.com/curl/curl
 
 goto :eof
 endlocal

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -57,6 +57,18 @@
             "remote": { "id": "KitWare/CMake" },
             "platforms": [ "Linux" ]
         },
+        "libxml2": {
+            "remote": { "id": "gnome/libxml2" },
+            "platforms": [ "Windows" ]
+        },
+        "curl": {
+            "remote": { "id": "curl/curl" },
+            "platforms": [ "Windows" ]
+        },
+        "zlib": {
+            "remote": { "id": "madler/zlib" },
+            "platforms": [ "Windows" ]
+        },
         "swift-cmark-gfm": {
              "remote": { "id": "apple/swift-cmark" } },
         "indexstore-db": {
@@ -120,6 +132,9 @@
                 "icu": "release-65-1",
                 "yams": "5.0.1",
                 "cmake": "v3.19.6",
+                "libxml2": "v2.9.14",
+                "curl": "curl-7_77_0",
+                "zlib": "v1.2.13",
                 "indexstore-db": "main",
                 "sourcekit-lsp": "main",
                 "swift-format": "main",


### PR DESCRIPTION
These dependencies are currently checked out for Windows manually. Let's check them out together with the rest of the repositories to unify the checkout process.