### PR TITLE
swift_build_support: make build duration more readable

### DIFF
--- a/utils/swift_build_support/swift_build_support/utils.py
+++ b/utils/swift_build_support/swift_build_support/utils.py
@@ -98,7 +98,20 @@ def log_analyzer():
             print(event_row.format(duration_percentage,
                                    build_event["duration"],
                                    build_event["command"]))
-        print("Total Duration: {}".format(total_duration))
+
+        hours, remainder = divmod(total_duration, 3600)
+        minutes, seconds = divmod(remainder, 60)
+
+        if hours > 0:
+            formatted_duration = " ({}h {}m {}s)".format(
+                int(hours), int(minutes), int(seconds))
+        elif minutes > 0:
+            formatted_duration = " ({}m {}s)".format(int(minutes), int(seconds))
+        else:
+            formatted_duration = ""
+
+        print("Total Duration: {:.2f} seconds".format(
+            total_duration) + formatted_duration)
     else:
         print("Skip build script analyzer")
         print(".build_script_log file not found at {}".format(build_script_log_path))


### PR DESCRIPTION
`build-script` invocations print a total duration summary at the end of the build, like this:
```
Total Duration: 4558.030000000001
```
With this change build duration summary is printed as
```
Total Duration: 487.93 seconds (8m 7s)
```
