### PR TITLE
[cxx-interop] Correctly check iterator conformances

### DIFF
--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -28,6 +28,7 @@ add_swift_host_library(swiftClangImporter STATIC
 target_link_libraries(swiftClangImporter PRIVATE
   swiftAST
   swiftParse
+  swiftSema
   clangTooling
   LLVMBitstreamReader)
 

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -228,9 +228,9 @@ void swift::conformToCxxSequenceIfNeeded(
     return;
 
   // Check if RawIterator conforms to UnsafeCxxInputIterator.
-  auto rawIteratorConformanceRef = decl->getModuleContext()->lookupConformance(
+  auto rawIteratorConformanceRef = decl->getModuleContext()->conformsToProtocol(
       rawIteratorTy, cxxIteratorProto);
-  if (!rawIteratorConformanceRef.isConcrete())
+  if (!rawIteratorConformanceRef || !rawIteratorConformanceRef.isConcrete())
     return;
   auto rawIteratorConformance = rawIteratorConformanceRef.getConcrete();
   auto pointeeDecl =

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-sequence.h
@@ -86,4 +86,16 @@ public:
   const ConstIterator &end() const { return e; }
 };
 
+template <typename A> struct NoDefinition;
+
+template <typename A, typename NoDef = NoDefinition<A>>
+struct HasTemplatedIterator {
+  typedef NoDef* iterator; // OpaquePointer
+
+  iterator begin() const;
+  iterator end() const;
+};
+
+typedef HasTemplatedIterator<int> HasUninstantiatableIterator;
+
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_CUSTOM_SEQUENCE_H

--- a/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
@@ -58,3 +58,9 @@
 // CHECK-NOT:   typealias Iterator
 // CHECK-NOT:   typealias RawIterator
 // CHECK: }
+// CHECK: struct __CxxTemplateInst20HasTemplatedIteratorIi12NoDefinitionIiEE {
+// CHECK-NOT:   typealias Element
+// CHECK-NOT:   typealias Iterator
+// CHECK-NOT:   typealias RawIterator
+// CHECK: }
+// CHECK: typealias HasUninstantiatableIterator = __CxxTemplateInst20HasTemplatedIteratorIi12NoDefinitionIiEE


### PR DESCRIPTION
To determine whether to conform a C++ type to `CxxSequence` protocol automatically, ClangImporter checks if the corresponding iterator type conforms to `UnsafeCxxInputIterator`.

This logic had false-positives, e.g. `Optional<OpaquePointer>` was treated as if it conforms to `UnsafeCxxInputIterator` while it actually doesn't. This happened because `lookupConformance` returned a conformance with a conditional requirement (`Wrapped : UnsafeCxxInputIterator`) that is not satisfied for `OpaquePointer`.

rdar://100265664