### PR TITLE
[cxx-interop] Drop return values of `+=`, `-=`, `*=`, `/=`

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2084,6 +2084,15 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
      clangDecl->hasAttr<clang::CFReturnsRetainedAttr>() ||
      clangDecl->hasAttr<clang::CFReturnsNotRetainedAttr>());
 
+  // C++ operators +=, -=, *=, /= may return a reference to self. This is not
+  // idiomatic in Swift, let's drop these return values.
+  clang::OverloadedOperatorKind op = clangDecl->getOverloadedOperator();
+  if (op == clang::OverloadedOperatorKind::OO_PlusEqual ||
+      op == clang::OverloadedOperatorKind::OO_MinusEqual ||
+      op == clang::OverloadedOperatorKind::OO_StarEqual ||
+      op == clang::OverloadedOperatorKind::OO_SlashEqual)
+    return {SwiftContext.getVoidType(), false};
+
   // Fix up optionality.
   OptionalTypeKind OptionalityOfReturn;
   if (clangDecl->hasAttr<clang::ReturnsNonNullAttr>()) {

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -3,6 +3,7 @@
 // CHECK: struct LoadableIntWrapper {
 // CHECK:   func successor() -> LoadableIntWrapper
 // CHECK:   static func - (lhs: inout LoadableIntWrapper, rhs: LoadableIntWrapper) -> LoadableIntWrapper
+// CHECK:   static func += (lhs: inout LoadableIntWrapper, rhs: LoadableIntWrapper)
 // CHECK:   mutating func callAsFunction() -> Int32
 // CHECK:   mutating func callAsFunction(_ x: Int32) -> Int32
 // CHECK:   mutating func callAsFunction(_ x: Int32, _ y: Int32) -> Int32

--- a/test/Interop/Cxx/operators/member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/member-inline-typechecker.swift
@@ -6,6 +6,7 @@ var lhs = LoadableIntWrapper(value: 42)
 let rhs = LoadableIntWrapper(value: 23)
 
 let resultPlus = lhs - rhs
+lhs += rhs
 let resultCall0 = lhs()
 let resultCall1 = lhs(1)
 let resultCall2 = lhs(1, 2)

--- a/test/Interop/Cxx/operators/member-inline.swift
+++ b/test/Interop/Cxx/operators/member-inline.swift
@@ -1,8 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
-// TODO: Fix CxxShim for Windows.
-// XFAIL: OS=windows-msvc
 
 import MemberInline
 import StdlibUnittest
@@ -42,20 +40,18 @@ OperatorsTestSuite.test("LoadableIntWrapper.plusEqual (inline)") {
   var lhs = LoadableIntWrapper(value: 42)
   let rhs = LoadableIntWrapper(value: 42)
 
-  let result = lhs += rhs
+  lhs += rhs
 
   expectEqual(lhs.value, 84)
-  expectEqual(result.value, 84)
 }
 
 OperatorsTestSuite.test("LoadableIntWrapper.minusEqual (inline)") {
   var lhs = LoadableIntWrapper(value: 42)
   let rhs = LoadableIntWrapper(value: 42)
 
-  let result = lhs -= rhs
+  lhs -= rhs
 
   expectEqual(lhs.value, 0)
-  expectEqual(result.value, 0)
 }
 
 OperatorsTestSuite.test("LoadableIntWrapper.unaryMinus (inline)") {

--- a/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
+++ b/test/Interop/Cxx/operators/non-member-inline-typechecker.swift
@@ -22,6 +22,9 @@ let resultExclaimEqual = lhs != rhs
 let resultLessEqual = lhs <= rhs
 let resultGreaterEqual = lhs >= rhs
 
+var lhsMutable = LoadableIntWrapper(value: 42)
+lhsMutable /= rhs
+
 public func ==(ptr: UnsafePointer<UInt8>, count: Int) -> Bool {
   let lhs = UnsafeBufferPointer<UInt8>(start: ptr, count: count)
   let rhs = UnsafeBufferPointer<UInt8>(start: ptr, count: count)

--- a/test/Interop/Cxx/operators/non-member-inline.swift
+++ b/test/Interop/Cxx/operators/non-member-inline.swift
@@ -155,20 +155,18 @@ OperatorsTestSuite.test("slash equal (/=)") {
   var lhs = LoadableIntWrapper(value: 8)
   let rhs = LoadableIntWrapper(value: 2)
 
-  let result = lhs /= rhs
+  lhs /= rhs
 
   expectEqual(lhs.value, 4)
-  expectEqual(result.value, 4)
 }
 
 OperatorsTestSuite.test("star equal (*=)") {
   var lhs = LoadableIntWrapper(value: 8)
   let rhs = LoadableIntWrapper(value: 2)
 
-  let result = lhs *= rhs
+  lhs *= rhs
 
   expectEqual(lhs.value, 16)
-  expectEqual(result.value, 16)
 }
 
 OperatorsTestSuite.test("amp amp (&&)") {


### PR DESCRIPTION
These operators return `Void` in Swift, let's drop the return type of these operators when importing them from C++.

This is needed for the upcoming `UnsafeCxxRandomAccessIterator` protocol: if a protocol declares `func +=` returning `Void`, but the implementation non-`Void`, that causes a typechecker error.