### PR TITLE
Propagate '-application-extension' to module interface loader sub-invocations.

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1559,6 +1559,11 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
     genericSubInvocation.getFrontendOptions().DisableImplicitModules = true;
     GenericArgs.push_back("-disable-implicit-swift-modules");
   }
+  // If building an application extension, make sure API use
+  // is restricted accordingly in downstream dependnecies.
+  if (langOpts.EnableAppExtensionRestrictions) {
+    GenericArgs.push_back("-application-extension");
+  }
   // Save the parent invocation's Target Triple
   ParentInvocationTarget = langOpts.Target;
 

--- a/test/ModuleInterface/Inputs/extension-available.swift
+++ b/test/ModuleInterface/Inputs/extension-available.swift
@@ -1,0 +1,3 @@
+@available(macOS 10.0, *)
+public func extensionAvailable() {
+}

--- a/test/ModuleInterface/extension-transitive-availability.swift
+++ b/test/ModuleInterface/extension-transitive-availability.swift
@@ -1,0 +1,48 @@
+// This test ensures that the parent invocation's '-application-extension' flag is inherited when building dependency modules
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-emit-module-interface(%t/ExtensionAvailable.swiftinterface) %S/Inputs/extension-available.swift -module-name ExtensionAvailable -I%t -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
+
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -I%t -application-extension -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import
+// RUN: %FileCheck %s < %t/deps.json
+
+import ExtensionAvailable
+func foo() {
+    extensionAvailable()
+}
+
+// CHECK:      "directDependencies": [
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "swift": "ExtensionAvailable"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "swift": "Swift"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "swift": "SwiftOnoneSupport"
+// CHECK-NEXT:        }
+// CHECK-NEXT:      ],
+
+
+// CHECK:      "swift": "ExtensionAvailable"
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "modulePath": "ExtensionAvailable.swiftmodule",
+// CHECK-NEXT:      "sourceFiles": [
+// CHECK-NEXT:      ],
+// CHECK-NEXT:      "directDependencies": [
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "swift": "Swift"
+// CHECK-NEXT:        },
+// CHECK-NEXT:        {
+// CHECK-NEXT:          "swift": "SwiftOnoneSupport"
+// CHECK-NEXT:        }
+// CHECK-NEXT:      ],
+// CHECK-NEXT:      "details": {
+// CHECK-NEXT:        "swift": {
+// CHECK-NEXT:          "moduleInterfacePath": 
+// CHECK-NEXT:          "contextHash":
+// CHECK-NEXT:          "commandLine": [
+// CHECK-NEXT:            "-frontend",
+// CHECK-NEXT:            "-compile-module-from-interface",
+// CHECK:            "-application-extension",


### PR DESCRIPTION
This flag restricts availability of certain symbols to ensure the code cannot use declarations that are explicitly unavalable to extensions. This restriction should be passed down to dependency modules also.
