### PR TITLE
[SILOptimizer] Add faux unit testing mechanism.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -3924,6 +3924,52 @@ SIL DIExpression can have elements with various types, like AST nodes or strings
 
 The ``[trace]`` flag is available for compiler unit testing. It is not produced during normal compilation. It is used combination with internal logging and optimization controls to select specific values to trace or to transform. For example, liveness analysis combines all "traced" values into a single live range with multiple definitions. This exposes corner cases that cannot be represented by passing valid SIL through the pipeline.
 
+Testing
+~~~~~~~
+
+test_specification
+``````````````````
+::
+
+  sil-instruction ::= 'test_specification' string-literal
+
+  test_specification "parsing @trace[3] @function[other].block[2].instruction[1]"
+
+Exists only for writing FileCheck tests.  Specifies a list of test arguments
+which should be used in order to run a particular test "in the context" of the
+function containing the instruction.
+
+Parsing of these test arguments is done via ``parseTestArgumentsFromSpecification``.
+
+The following types of test arguments are supported:
+
+- boolean: true false
+- unsigned integer: 0...ULONG_MAX
+- string
+- function: @function <-- the current function
+            @function[uint] <-- function at index ``uint``
+            @function[name] <-- function named ``name``
+- block: @block <-- the first block
+         @block[uint] <-- the block at index ``uint``
+         @{function}.{block} <-- the indicated block in the indicated function
+         Example: @function[foo].block[2]
+- trace: @trace <-- the first ``debug_value [trace]`` in the current function
+         @trace[uint] <-- the ``debug_value [trace]`` at index ``uint``
+         @{function}.{trace} <-- the indicated trace in the indicated function
+         Example: @function[bar].trace
+- instruction: @instruction <-- the first instruction
+               @instruction[uint] <-- the instruction at index ``uint``
+               @{function}.{instruction} <-- the indicated instruction in the indicated function
+               Example: @function[baz].instruction[19]
+               @{block}.{instruction} <-- the indicated instruction in the indicated block
+               Example: @function[bam].block.instruction
+- operand: @operand <-- the first operand
+           @operand[uint] <-- the operand at index ``uint``
+           @{instruction}.{operand} <-- the indicated operand of the indicated instruction
+           Example: @block[19].instruction[2].operand[3]
+           Example: @function[2].instruction.operand
+
+
 Profiling
 ~~~~~~~~~
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -539,6 +539,8 @@ ERROR(expected_sil_profiler_counter_total,none,
       "expected profiler counter total", ())
 ERROR(expected_sil_profiler_counter_hash,none,
       "expected profiler counter hash", ())
+ERROR(expected_sil_test_specification_body,none,
+      "expected a string consisting of the space-separated test arguments", ())
 
 // SIL Values
 ERROR(sil_value_redefinition,none,

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -988,6 +988,13 @@ public:
     return createDebugValue(Loc, src, Var);
   }
 
+  TestSpecificationInst *
+  createTestSpecificationInst(SILLocation Loc,
+                              StringRef ArgumentsSpecification) {
+    return insert(TestSpecificationInst::create(
+        getSILDebugLocation(Loc), ArgumentsSpecification, getModule()));
+  }
+
 #define NEVER_LOADABLE_CHECKED_REF_STORAGE(Name, ...) \
   Load##Name##Inst *createLoad##Name(SILLocation Loc, \
                                      SILValue src, \

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -2631,6 +2631,15 @@ void SILCloner<ImplClass>::visitIncrementProfilerCounterInst(
                               Inst->getNumCounters(), Inst->getPGOFuncHash()));
 }
 
+template <typename ImplClass>
+void SILCloner<ImplClass>::visitTestSpecificationInst(
+    TestSpecificationInst *Inst) {
+  getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
+  recordClonedInstruction(Inst, getBuilder().createTestSpecificationInst(
+                                    getOpLocation(Inst->getLoc()),
+                                    Inst->getArgumentsSpecification()));
+}
+
 template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitIndexAddrInst(IndexAddrInst *Inst) {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -4933,6 +4933,32 @@ public:
   }
 };
 
+class TestSpecificationInst final
+    : public InstructionBase<SILInstructionKind::TestSpecificationInst,
+                             NonValueInstruction>,
+      private llvm::TrailingObjects<TestSpecificationInst, char> {
+  friend TrailingObjects;
+  friend SILBuilder;
+
+  unsigned ArgumentsSpecificationLength;
+
+  TestSpecificationInst(SILDebugLocation Loc,
+                        unsigned ArgumentsSpecificationLength)
+      : InstructionBase(Loc),
+        ArgumentsSpecificationLength(ArgumentsSpecificationLength) {}
+
+  static TestSpecificationInst *
+  create(SILDebugLocation Loc, StringRef argumentsSpecification, SILModule &M);
+
+public:
+  StringRef getArgumentsSpecification() const {
+    return StringRef(getTrailingObjects<char>(), ArgumentsSpecificationLength);
+  }
+
+  ArrayRef<Operand> getAllOperands() const { return {}; }
+  MutableArrayRef<Operand> getAllOperands() { return {}; }
+};
+
 /// An abstract class representing a load from some kind of reference storage.
 template <SILInstructionKind K>
 class LoadReferenceInstBase

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -765,6 +765,8 @@ NON_VALUE_INST(MarkFunctionEscapeInst, mark_function_escape,
                SILInstruction, None, DoesNotRelease)
 NON_VALUE_INST(DebugValueInst, debug_value,
                SILInstruction, None, DoesNotRelease)
+NON_VALUE_INST(TestSpecificationInst, test_specification,
+               SILInstruction, None, DoesNotRelease)
 #define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, name, ...) \
   NON_VALUE_INST(Store##Name##Inst, store_##name, \
                  SILInstruction, MayWrite, DoesNotRelease)

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -445,6 +445,8 @@ PASS(SimplifyUnreachableContainingBlocks, "simplify-unreachable-containing-block
      "Utility pass. Removes all non-term insts from blocks with unreachable terms")
 PASS(SerializeSILPass, "serialize-sil",
      "Utility pass. Serializes the current SILModule")
+PASS(UnitTestRunner, "unit-test-runner",
+     "Utility pass.  Parses arguments and runs code with them.")
 PASS(YieldOnceCheck, "yield-once-check",
     "Check correct usage of yields in yield-once coroutines")
 PASS(OSLogOptimization, "os-log-optimization", "Optimize os log calls")

--- a/include/swift/SILOptimizer/Utils/ParseTestSpecification.h
+++ b/include/swift/SILOptimizer/Utils/ParseTestSpecification.h
@@ -1,0 +1,169 @@
+//===- ParseTestSpecification.h - Parsing for test instructions -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines Test::Argument.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_PARSETESTSPECIFICATION
+#define SWIFT_SIL_PARSETESTSPECIFICATION
+
+#include "swift/Basic/TaggedUnion.h"
+#include "swift/SIL/SILValue.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace llvm {
+template <class T>
+class SmallVectorImpl;
+}
+using llvm::StringRef;
+
+namespace swift {
+
+class SILFunction;
+
+namespace test {
+
+struct Argument {
+  enum class Kind {
+    String,
+    Bool,
+    UInt,
+    Value,
+    Operand,
+    Instruction,
+    Block,
+    Function,
+  };
+  using Union = TaggedUnion<StringRef,          // StringArgument
+                            bool,               // BoolArgument
+                            unsigned long long, // UIntArgument
+                            SILValue,           // ValueArgument
+                            Operand *,          // OperandArgument
+                            SILInstruction *,   // InstructionArgument
+                            SILBasicBlock *,    // BlockArgument
+                            SILFunction *       // FunctionArgument
+                            >;
+
+private:
+  Kind kind;
+
+protected:
+  Argument(Union storage, Kind kind) : kind(kind), storage(storage) {}
+  Union storage;
+
+public:
+  Kind getKind() const { return kind; }
+};
+
+template <typename Stored, Argument::Kind TheKind>
+struct ConcreteArgument : Argument {
+  using Super = ConcreteArgument<Stored, TheKind>;
+  ConcreteArgument(Stored stored) : Argument(Union{stored}, TheKind) {}
+  Stored getValue() { return storage.get<Stored>(); }
+  static bool classof(const Argument *argument) {
+    return argument->getKind() == TheKind;
+  }
+};
+
+struct ValueArgument : ConcreteArgument<SILValue, Argument::Kind::Value> {
+  ValueArgument(SILValue stored) : Super(stored) {}
+};
+
+struct OperandArgument : ConcreteArgument<Operand *, Argument::Kind::Operand> {
+  OperandArgument(Operand *stored) : Super(stored) {}
+};
+
+struct InstructionArgument
+    : ConcreteArgument<SILInstruction *, Argument::Kind::Instruction> {
+  InstructionArgument(SILInstruction *stored) : Super(stored) {}
+};
+
+struct BlockArgument
+    : ConcreteArgument<SILBasicBlock *, Argument::Kind::Block> {
+  BlockArgument(SILBasicBlock *stored) : Super(stored) {}
+};
+
+struct FunctionArgument
+    : ConcreteArgument<SILFunction *, Argument::Kind::Function> {
+  FunctionArgument(SILFunction *stored) : Super(stored) {}
+};
+
+struct BoolArgument : ConcreteArgument<bool, Argument::Kind::Bool> {
+  BoolArgument(bool stored) : Super(stored) {}
+};
+
+struct UIntArgument
+    : ConcreteArgument<unsigned long long, Argument::Kind::UInt> {
+  UIntArgument(unsigned long long stored) : Super(stored) {}
+};
+
+struct StringArgument : ConcreteArgument<StringRef, Argument::Kind::String> {
+  StringArgument(StringRef stored) : Super(stored) {}
+};
+
+struct Arguments {
+  llvm::SmallVector<Argument, 8> storage;
+  unsigned untakenIndex = 0;
+
+  void assertUsed() {
+    assert(untakenIndex == storage.size() && "arguments remain!");
+  }
+
+  void clear() {
+    assertUsed();
+    storage.clear();
+    untakenIndex = 0;
+  }
+
+  Arguments() {}
+  Arguments(Arguments const &) = delete;
+  Arguments &operator=(Arguments const &) = delete;
+  ~Arguments() { assertUsed(); }
+  Argument &takeArgument() { return storage[untakenIndex++]; }
+  StringRef takeString() {
+    return cast<StringArgument>(takeArgument()).getValue();
+  }
+  bool takeBool() { return cast<BoolArgument>(takeArgument()).getValue(); }
+  unsigned long long takeUInt() {
+    return cast<UIntArgument>(takeArgument()).getValue();
+  }
+  SILValue takeValue() {
+    return cast<ValueArgument>(takeArgument()).getValue();
+  }
+  Operand *takeOperand() {
+    return cast<OperandArgument>(takeArgument()).getValue();
+  }
+  SILInstruction *takeInstruction() {
+    return cast<InstructionArgument>(takeArgument()).getValue();
+  }
+  SILBasicBlock *takeBlock() {
+    return cast<BlockArgument>(takeArgument()).getValue();
+  }
+  SILFunction *takeFunction() {
+    return cast<FunctionArgument>(takeArgument()).getValue();
+  }
+};
+
+/// Finds and deletes each test_specification instruction in \p function and
+/// appends its string payload to the provided vector.
+void getTestSpecifications(SILFunction *function,
+                           SmallVectorImpl<std::string> &specifications);
+
+void parseTestArgumentsFromSpecification(
+    SILFunction *, StringRef specification, Arguments &arguments,
+    SmallVectorImpl<StringRef> &argumentStrings);
+
+} // namespace test
+} // namespace swift
+
+#endif

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1384,6 +1384,9 @@ public:
   void visitLinearFunctionExtractInst(LinearFunctionExtractInst *i);
   void visitDifferentiabilityWitnessFunctionInst(
       DifferentiabilityWitnessFunctionInst *i);
+  void visitTestSpecificationInst(TestSpecificationInst *i) {
+    llvm_unreachable("test-only instruction in Lowered SIL?!");
+  }
 
 #define LOADABLE_REF_STORAGE_HELPER(Name)                                      \
   void visitRefTo##Name##Inst(RefTo##Name##Inst *i);                           \

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -120,6 +120,7 @@ SHOULD_NEVER_VISIT_INST(ReleaseValueAddr)
 SHOULD_NEVER_VISIT_INST(StrongRelease)
 SHOULD_NEVER_VISIT_INST(GetAsyncContinuation)
 SHOULD_NEVER_VISIT_INST(IncrementProfilerCounter)
+SHOULD_NEVER_VISIT_INST(TestSpecification)
 
 #define ALWAYS_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)            \
   SHOULD_NEVER_VISIT_INST(StrongRetain##Name)                                  \

--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -456,6 +456,21 @@ IncrementProfilerCounterInst *IncrementProfilerCounterInst::create(
   return Inst;
 }
 
+TestSpecificationInst *
+TestSpecificationInst::create(SILDebugLocation Loc,
+                              StringRef ArgumentsSpecification, SILModule &M) {
+  auto ArgumentsSpecificationLength = ArgumentsSpecification.size();
+  auto Size = totalSizeToAlloc<char>(ArgumentsSpecificationLength);
+  auto Buffer = M.allocateInst(Size, alignof(TestSpecificationInst));
+
+  auto *Inst =
+      ::new (Buffer) TestSpecificationInst(Loc, ArgumentsSpecificationLength);
+  std::uninitialized_copy(ArgumentsSpecification.begin(),
+                          ArgumentsSpecification.end(),
+                          Inst->getTrailingObjects<char>());
+  return Inst;
+}
+
 InitBlockStorageHeaderInst *
 InitBlockStorageHeaderInst::create(SILFunction &F,
                                SILDebugLocation DebugLoc, SILValue BlockStorage,

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2410,7 +2410,11 @@ public:
   void visitReturnInst(ReturnInst *RI) {
     *this << getIDAndType(RI->getOperand());
   }
-  
+
+  void visitTestSpecificationInst(TestSpecificationInst *TSI) {
+    *this << QuotedString(TSI->getArgumentsSpecification());
+  }
+
   void visitThrowInst(ThrowInst *TI) {
     *this << getIDAndType(TI->getOperand());
   }

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3406,6 +3406,19 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     break;
   }
 
+  case SILInstructionKind::TestSpecificationInst: {
+    // Parse the specification string.
+    if (P.Tok.getKind() != tok::string_literal) {
+      P.diagnose(P.Tok, diag::expected_sil_test_specification_body);
+      return true;
+    }
+    // Drop the double quotes.
+    auto ArgumentsSpecification = P.Tok.getText().drop_front().drop_back();
+    P.consumeToken(tok::string_literal);
+    ResultVal = B.createTestSpecificationInst(InstLoc, ArgumentsSpecification);
+    break;
+  }
+
     // unchecked_ownership_conversion <reg> : <type>, <ownership> to <ownership>
   case SILInstructionKind::UncheckedOwnershipConversionInst: {
     ValueOwnershipKind LHSKind = OwnershipKind::None;

--- a/lib/SIL/Utils/InstructionUtils.cpp
+++ b/lib/SIL/Utils/InstructionUtils.cpp
@@ -487,6 +487,9 @@ RuntimeEffect swift::getRuntimeEffect(SILInstruction *inst, SILType &impactType)
   case SILInstructionKind::DebugValueInst:
     // Ignore runtime calls of debug_value
     return RuntimeEffect::NoEffect;
+  case SILInstructionKind::TestSpecificationInst:
+    // Ignore runtime calls of test-only instructions
+    return RuntimeEffect::NoEffect;
 
   case SILInstructionKind::GetAsyncContinuationInst:
   case SILInstructionKind::GetAsyncContinuationAddrInst:

--- a/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
+++ b/lib/SILOptimizer/UtilityPasses/CMakeLists.txt
@@ -34,5 +34,8 @@ target_sources(swiftSILOptimizer PRIVATE
   SideEffectsDumper.cpp
   SimplifyUnreachableContainingBlocks.cpp
   StripDebugInfo.cpp
+  UnitTestRunner.cpp
   OwnershipDumper.cpp
-  OwnershipVerifierTextualErrorDumper.cpp)
+  OwnershipVerifierTextualErrorDumper.cpp
+  ParseTestSpecification.cpp)
+  

--- a/lib/SILOptimizer/UtilityPasses/OSSALifetimeAnalysis.cpp
+++ b/lib/SILOptimizer/UtilityPasses/OSSALifetimeAnalysis.cpp
@@ -110,6 +110,8 @@ void OSSALifetimeAnalysis::run() {
     for (auto &block : function) {
       for (SILInstruction *inst : deleter.updatingRange(&block)) {
         if (auto *debugValue = dyn_cast<DebugValueInst>(inst)) {
+          if (!debugValue->hasTrace())
+            continue;
           traceValues.push_back(debugValue->getOperand());
           deleter.forceDelete(debugValue);
         }

--- a/lib/SILOptimizer/UtilityPasses/ParseTestSpecification.cpp
+++ b/lib/SILOptimizer/UtilityPasses/ParseTestSpecification.cpp
@@ -1,0 +1,430 @@
+//== ParseTestSpecification.cpp - Parsing for test instructions -*- C++ -*- ==//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SILOptimizer/Utils/ParseTestSpecification.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SILOptimizer/Utils/InstructionDeleter.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+
+using namespace swift;
+using namespace swift::test;
+
+namespace {
+
+// Helpers: Finding marker instructions
+
+void findAndDeleteTraceValues(SILFunction *function,
+                              SmallVectorImpl<SILValue> &values) {
+  InstructionDeleter deleter;
+  for (auto &block : *function) {
+    for (SILInstruction *inst : deleter.updatingRange(&block)) {
+      if (auto *debugValue = dyn_cast<DebugValueInst>(inst)) {
+        if (!debugValue->hasTrace())
+          continue;
+        values.push_back(debugValue->getOperand());
+        deleter.forceDelete(debugValue);
+      }
+    }
+  }
+}
+
+// Helpers: Looking up subobjects by index
+
+SILInstruction *getInstruction(SILFunction *function, unsigned long index) {
+  unsigned long i = 0;
+  for (auto &block : *function) {
+    for (auto &instruction : block) {
+      if (i == index) {
+        return &instruction;
+      }
+      ++i;
+    }
+  }
+  llvm_unreachable("bad index!?");
+}
+
+SILInstruction *getInstruction(SILBasicBlock *block, unsigned long index) {
+  unsigned long i = 0;
+  for (auto &instruction : *block) {
+    if (i == index) {
+      return &instruction;
+    }
+    ++i;
+  }
+  llvm_unreachable("bad index!?");
+}
+
+SILBasicBlock *getBlock(SILFunction *function, unsigned long index) {
+  auto iterator = function->begin();
+  for (unsigned long i = 0; i < index; ++i) {
+    iterator = std::next(iterator);
+  }
+  return &*iterator;
+}
+
+SILFunction *getFunction(SILModule *module, unsigned long long index) {
+  auto &list = module->getFunctionList();
+  auto iter = list.begin();
+  for (unsigned long i = 0; i < index; ++i) {
+    iter = std::next(iter);
+  }
+  return &*iter;
+}
+
+// Parsing:
+
+class ParseTestSpecification;
+
+class ParseArgumentSpecification {
+  ParseTestSpecification &outer;
+  StringRef specification;
+
+  SILFunction *getFunction();
+  SILValue getTraceValue(unsigned index, SILFunction *function);
+
+public:
+  ParseArgumentSpecification(ParseTestSpecification &outer,
+                             StringRef specification)
+      : outer(outer), specification(specification) {}
+
+  Argument parse() {
+    auto argument = parseArgument();
+    demandEmpty();
+    return argument;
+  }
+
+private:
+  // String parsing helpers:
+
+  bool empty() { return specification.empty(); }
+
+  bool peekPrefix(StringRef prefix) { return specification.startswith(prefix); }
+
+  bool consumePrefix(StringRef prefix) {
+    return specification.consume_front(prefix);
+  }
+
+  bool consumeAll(StringRef remainder) {
+    if (specification.size() == remainder.size())
+      return specification.consume_front(remainder);
+    return false;
+  }
+
+  bool consumeThrough(char separator, StringRef &substring) {
+    unsigned long index = 0;
+    if ((index = specification.find(separator)) == StringRef::npos)
+      return false;
+    substring = specification.slice(0, index);
+    specification = specification.slice(index + 1, specification.size());
+    return true;
+  }
+
+  void demandPrefix(StringRef prefix) {
+    if (consumePrefix(prefix))
+      return;
+    llvm_unreachable("failed to find prefix in specification");
+  }
+
+  void demandEmpty() {
+    assert(empty() && "specification unexpectedly inhabited?!");
+  }
+
+  // Argument parsing: Primitives
+
+  Optional<BoolArgument> parseBool() {
+    if (consumeAll("true")) {
+      return BoolArgument{true};
+    } else if (consumeAll("false")) {
+      return BoolArgument{false};
+    }
+    return llvm::None;
+  }
+
+  Optional<UIntArgument> parseUInt() {
+    unsigned long long value;
+    if (llvm::consumeUnsignedInteger(specification, /*radix=*/10, value))
+      return llvm::None;
+    return UIntArgument{value};
+  }
+
+  Optional<StringArgument> parseString() {
+    auto retval = StringArgument{specification};
+    specification = specification.drop_front(specification.size());
+    return retval;
+  }
+
+  Optional<TaggedUnion<unsigned long long, StringRef>> parseSubscript() {
+    if (!consumePrefix("["))
+      return llvm::None;
+    unsigned long long index = 0;
+    if (!llvm::consumeUnsignedInteger(specification, /*radix=*/10, index)) {
+      demandPrefix("]");
+      return {index};
+    }
+    StringRef string;
+    if (!consumeThrough(']', string))
+      llvm_unreachable("missing ] to end subscript operation!?");
+    return {string};
+  }
+
+  // Argument parsing: References
+
+  SILValue parseTraceComponent(SILFunction *within) {
+    if (!consumePrefix("trace"))
+      return SILValue();
+    if (empty() || peekPrefix("."))
+      return getTraceValue(0, within);
+    if (auto subscript = parseSubscript()) {
+      auto index = subscript->get<unsigned long long>();
+      return getTraceValue(index, within);
+    }
+    llvm_unreachable("bad suffix after 'trace'!?");
+  }
+
+  Optional<Argument> parseTraceReference(SILFunction *within) {
+    auto trace = parseTraceComponent(within);
+    if (!trace)
+      return llvm::None;
+    if (!consumePrefix("."))
+      return ValueArgument{trace};
+    auto *instruction = trace.getDefiningInstruction();
+    assert(instruction &&
+           "attempting to access operand of non-instruction value!?");
+    if (auto arg = parseOperandReference(instruction))
+      return *arg;
+    llvm_unreachable("bad suffix after 'trace'!?");
+  }
+
+  Operand *parseOperandComponent(SILInstruction *within) {
+    if (!consumePrefix("operand"))
+      return nullptr;
+    if (empty()) {
+      auto &operand = within->getOperandRef(0);
+      return &operand;
+    }
+    if (auto subscript = parseSubscript()) {
+      auto index = subscript->get<unsigned long long>();
+      auto &operand = within->getOperandRef(index);
+      return &operand;
+    }
+    llvm_unreachable("bad suffix after 'operand'!?");
+  }
+
+  Optional<Argument> parseOperandReference(SILInstruction *within) {
+    auto *operand = parseOperandComponent(within);
+    if (!operand)
+      return llvm::None;
+    return OperandArgument{operand};
+  }
+
+  SILInstruction *parseInstructionComponent(
+      TaggedUnion<SILFunction *, SILBasicBlock *> within) {
+    if (!consumePrefix("instruction"))
+      return nullptr;
+    auto getInstructionAtIndex = [within](unsigned index) {
+      if (within.isa<SILFunction *>()) {
+        auto *function = within.get<SILFunction *>();
+        return getInstruction(function, index);
+      }
+      auto *block = within.get<SILBasicBlock *>();
+      return getInstruction(block, index);
+    };
+    if (empty() || peekPrefix(".")) {
+      return getInstructionAtIndex(0);
+    }
+    if (auto subscript = parseSubscript()) {
+      auto index = subscript->get<unsigned long long>();
+      return getInstructionAtIndex(index);
+    }
+    llvm_unreachable("bad suffix after 'instruction'!?");
+  }
+
+  Optional<Argument> parseInstructionReference(
+      TaggedUnion<SILFunction *, SILBasicBlock *> within) {
+    auto *instruction = parseInstructionComponent(within);
+    if (!instruction)
+      return llvm::None;
+    if (!consumePrefix("."))
+      return InstructionArgument{instruction};
+    if (auto arg = parseOperandReference(instruction))
+      return arg;
+    llvm_unreachable("unhandled suffix after 'instruction'!?");
+  }
+
+  SILBasicBlock *parseBlockComponent(SILFunction *within) {
+    if (!consumePrefix("block"))
+      return nullptr;
+    if (empty() || peekPrefix(".")) {
+      auto *block = getBlock(within, 0);
+      return block;
+    }
+    if (auto subscript = parseSubscript()) {
+      auto index = subscript->get<unsigned long long>();
+      auto *block = getBlock(within, index);
+      return block;
+    }
+    llvm_unreachable("bad suffix after 'block'!?");
+  }
+
+  Optional<Argument> parseBlockReference(SILFunction *within) {
+    auto *block = parseBlockComponent(within);
+    if (!block)
+      return llvm::None;
+    if (!consumePrefix("."))
+      return BlockArgument{block};
+    if (auto arg = parseInstructionReference(block))
+      return *arg;
+    llvm_unreachable("unhandled suffix after 'block'!?");
+  }
+
+  SILFunction *parseFunctionComponent(SILModule *within) {
+    if (!consumePrefix("function"))
+      return nullptr;
+    if (empty() || peekPrefix(".")) {
+      return getFunction();
+    }
+    if (auto subscript = parseSubscript()) {
+      if (subscript->isa<unsigned long long>()) {
+        auto index = subscript->get<unsigned long long>();
+        auto *fn = ::getFunction(within, index);
+        return fn;
+      } else {
+        auto name = subscript->get<StringRef>();
+        auto *specified = getFunction()->getModule().lookUpFunction(name);
+        if (!specified)
+          llvm_unreachable("unknown function name!?");
+        return specified;
+      }
+    }
+    llvm_unreachable("bad suffix after 'function'!?");
+  }
+
+  Optional<Argument> parseFunctionReference(SILModule *within) {
+    auto *function = parseFunctionComponent(within);
+    if (!function)
+      return llvm::None;
+    if (!consumePrefix("."))
+      return FunctionArgument{function};
+    if (auto arg = parseInstructionReference(function))
+      return *arg;
+    if (auto arg = parseTraceReference(function))
+      return *arg;
+    if (auto arg = parseBlockReference(function))
+      return *arg;
+    llvm_unreachable("unhandled suffix after 'function'!?");
+  }
+
+  Optional<Argument> parseReference() {
+    if (!consumePrefix("@"))
+      return llvm::None;
+    if (auto arg = parseTraceReference(getFunction()))
+      return *arg;
+    if (auto arg = parseOperandReference(getInstruction(getFunction(), 0)))
+      return *arg;
+    if (auto arg = parseInstructionReference(getFunction()))
+      return *arg;
+    if (auto arg = parseBlockReference(getFunction()))
+      return *arg;
+    if (auto arg = parseFunctionReference(&getFunction()->getModule()))
+      return *arg;
+    return llvm::None;
+  }
+
+  Argument parseArgument() {
+    if (auto arg = parseBool())
+      return *arg;
+    if (auto arg = parseUInt())
+      return *arg;
+    if (auto arg = parseReference())
+      return *arg;
+    // Parse strings last--everything parses as a string.
+    if (auto arg = parseString())
+      return *arg;
+    llvm_unreachable("bad argument specification");
+  }
+};
+
+using TraceValueMap =
+    llvm::SmallDenseMap<SILFunction *, llvm::SmallVector<SILValue, 4>, 32>;
+/// A global map from functions to the trace instructions that they once
+/// contained.
+static TraceValueMap traceValues;
+
+class ParseTestSpecification {
+  friend class ParseArgumentSpecification;
+  SILFunction *function;
+  SmallVectorImpl<StringRef> &components;
+
+  SILValue getTraceValue(unsigned index, SILFunction *function) {
+    auto iterator = traceValues.find(function);
+    if (iterator == traceValues.end()) {
+      // llvm::SmallVector<SILValue, 4> values;
+      auto &values = traceValues[function];
+      findAndDeleteTraceValues(function, values);
+      // auto pair = traceValues.insert({function, values});
+      // assert(pair.second);
+      iterator = traceValues.find(function);
+    }
+    return iterator->getSecond()[index];
+  }
+
+public:
+  ParseTestSpecification(SILFunction *function,
+                         SmallVectorImpl<StringRef> &components)
+      : function(function), components(components) {}
+
+  void parse(StringRef specification, Arguments &arguments) {
+    specification.split(components, " ");
+    for (unsigned long index = 0, size = components.size(); index < size;
+         ++index) {
+      auto component = components[index];
+      ParseArgumentSpecification parser(*this, component);
+      auto argument = parser.parse();
+      arguments.storage.push_back(argument);
+    }
+  }
+};
+
+SILFunction *ParseArgumentSpecification::getFunction() {
+  return outer.function;
+}
+SILValue ParseArgumentSpecification::getTraceValue(unsigned index,
+                                                   SILFunction *function) {
+  return outer.getTraceValue(index, function);
+}
+
+} // anonymous namespace
+
+// API
+
+void swift::test::getTestSpecifications(
+    SILFunction *function, SmallVectorImpl<std::string> &specifications) {
+  InstructionDeleter deleter;
+  for (auto &block : *function) {
+    for (SILInstruction *inst : deleter.updatingRange(&block)) {
+      if (auto *tsi = dyn_cast<TestSpecificationInst>(inst)) {
+        auto ref = tsi->getArgumentsSpecification();
+        specifications.push_back(std::string(ref.begin(), ref.end()));
+        deleter.forceDelete(tsi);
+      }
+    }
+  }
+}
+
+void swift::test::parseTestArgumentsFromSpecification(
+    SILFunction *function, StringRef specification, Arguments &arguments,
+    SmallVectorImpl<StringRef> &argumentStrings) {
+  ParseTestSpecification parser(function, argumentStrings);
+  parser.parse(specification, arguments);
+}

--- a/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SerializeSILPass.cpp
@@ -314,6 +314,7 @@ static bool hasOpaqueArchetype(TypeExpansionContext context,
   case SILInstructionKind::AssignByWrapperInst:
   case SILInstructionKind::MarkFunctionEscapeInst:
   case SILInstructionKind::DebugValueInst:
+  case SILInstructionKind::TestSpecificationInst:
 #define NEVER_OR_SOMETIMES_LOADABLE_CHECKED_REF_STORAGE(Name, ...)             \
   case SILInstructionKind::Store##Name##Inst:
 #include "swift/AST/ReferenceStorage.def"

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -1,0 +1,255 @@
+//===------------------------ UnitTestRunner.cpp --------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// TO ADD A NEW TEST, search in this file for [new_tests]
+//
+// Provides a mechanism for doing faux unit tests.  The idea is to emulate the
+// basic function of calling a function and validating its results/effects.
+//
+// This is done via the test_specification instruction.  Using one or more
+// instances of it in your function, you can specify which test (i.e. UnitTest
+// subclass) should be run and what arguments should be provided to it.  The
+// test grabs the arguments it expects out of the test::Arguments instance it is
+// provided.  It calls some function or functions.  It then prints out
+// interesting results.  These results can then be FileCheck'd.
+//
+// CASE STUDY:
+// Here's an example of how it works:
+// 1) A test test/SILOptimizer/interesting_functionality.sil runs this pass:
+//     // RUN: %target-sil-opt -unit-test-runner %s 2>&1 | %FileCheck %s
+// 2) A function in interesting_functionality.sil contains the
+//    test_specification instruction.
+//      sil @f : $() -> () {
+//      ...
+//      test_specification "my-neato-utility 43 @trace[2] @function[other_fun]"
+//      ...
+//      }
+// 3) UnitTestRunner sees the name "my-neato-utility", instantiates the
+//    corresponding UnitTest subclass MyNeatoUtilityTest, and calls ::invoke()
+//    on it, passing an test::Arguments that contains
+//      (43 : unsigned long, someValue : SILValue, other_fun : SILFunction *)
+//
+// 4) MyNeatoUtilityTest calls takeUInt(), takeValue(), and takeFunction() on
+//    the test::Arguments instance.
+//      auto count = arguments.takeUInt();
+//      auto target = arguments.takeValue();
+//      auto callee = arguments.takeFunction();
+// 5) MyNeatoUtilityTest calls myNeatoUtility, passing these values along.
+//      myNeatoUtility(count, target, callee);
+// 6) MyNeatoUtilityTest then dumps out the current function, which was modified
+//    in the process.
+//      getFunction()->dump();
+// 7) The test file test/SILOptimizer/interesting_functionality.sil matches the
+//    expected contents of the modified function:
+//    // CHECK-LABEL: sil @f
+//    // CHECK-NOT:     function_ref @other_fun
+//
+// [new_tests] TESTING MORE FUNCTIONALITY:
+//
+// 1) Add a new UnitTest subclass.
+//    - Add a constructor: NewTest(UnitTestRunner *pass) : UnitTest(pass) {}
+//    - Implement invoke: void invoke(test::Arguments &arguments) override {...}
+//    - Call the take{TYPE} methods to get the arguments you need.
+//    - Call your function with those arguments.
+// 2) Add a new ADD_UNIT_TEST_SUBCLASS line.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/Type.h"
+#include "swift/Basic/TaggedUnion.h"
+#include "swift/SIL/SILArgumentArrayRef.h"
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/InstructionDeleter.h"
+#include "swift/SILOptimizer/Utils/ParseTestSpecification.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/raw_ostream.h"
+#include <iterator>
+#include <memory>
+
+using namespace swift;
+using namespace swift::test;
+
+namespace {
+
+class UnitTestRunner;
+
+class UnitTest {
+  UnitTestRunner *pass;
+
+protected:
+  template <typename Analysis>
+  Analysis *getAnalysis();
+  UnitTestRunner *getPass() { return pass; }
+  SILFunction *getFunction();
+
+public:
+  UnitTest(UnitTestRunner *pass) : pass(pass){};
+  virtual ~UnitTest() {}
+  virtual void invoke(Arguments &arguments) = 0;
+};
+
+// Arguments:
+// - string: list of characters, each of which specifies subsequent arguments
+//           - F: function
+//           - B: block
+//           - I: instruction
+//           - V: value
+//           - O: operand
+//           - b: boolean
+//           - u: unsigned
+//           - s: string
+// - ...
+// - an argument of the type specified in the initial string
+// - ...
+// Dumps:
+// - for each argument (after the initial string)
+//   - its type
+//   - something to identify the instance (mostly this means calling dump)
+struct TestSpecificationTest : UnitTest {
+  TestSpecificationTest(UnitTestRunner *pass) : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    auto expectedFields = arguments.takeString();
+    for (auto expectedField : expectedFields) {
+      switch (expectedField) {
+      case 'F': {
+        auto *function = arguments.takeFunction();
+        llvm::errs() << "function: " << function->getName() << "\n";
+        break;
+      }
+      case 'B': {
+        auto *block = arguments.takeBlock();
+        llvm::errs() << "block:\n";
+        block->dump();
+        break;
+      }
+      case 'I': {
+        auto *instruction = arguments.takeInstruction();
+        llvm::errs() << "instruction: ";
+        instruction->dump();
+        break;
+      }
+      case 'V': {
+        auto value = arguments.takeValue();
+        llvm::errs() << "value: ";
+        value->dump();
+        break;
+      }
+      case 'O': {
+        auto *operand = arguments.takeOperand();
+        llvm::errs() << "operand: ";
+        operand->print(llvm::errs());
+        break;
+      }
+      case 'u': {
+        auto u = arguments.takeUInt();
+        llvm::errs() << "uint: " << u << "\n";
+        break;
+      }
+      case 'b': {
+        auto b = arguments.takeBool();
+        llvm::errs() << "bool: " << b << "\n";
+        break;
+      }
+      case 's': {
+        auto s = arguments.takeString();
+        llvm::errs() << "string: " << s << "\n";
+        break;
+      }
+      default:
+        llvm_unreachable("unknown field type was expected?!");
+      }
+    }
+  }
+};
+
+/// [new_tests] Add the new UnitTest subclass above this line.
+
+class UnitTestRunner : public SILFunctionTransform {
+  void printTestLifetime(bool begin, unsigned testIndex, unsigned testCount,
+                         StringRef name, ArrayRef<StringRef> components) {
+    StringRef word = begin ? "begin" : "end";
+    llvm::errs() << word << " running test " << testIndex + 1 << " of "
+                 << testCount << " on " << getFunction()->getName() << ": "
+                 << name << " with: ";
+    for (unsigned long index = 0, size = components.size(); index < size;
+         ++index) {
+      llvm::errs() << components[index];
+      if (index != size - 1) {
+        llvm::errs() << ", ";
+      } else {
+        llvm::errs() << "\n";
+      }
+    }
+  }
+
+  template <typename Doit>
+  void withTest(StringRef name, Doit doit) {
+#define ADD_UNIT_TEST_SUBCLASS(STRING, SUBCLASS)                               \
+  if (name == STRING) {                                                        \
+    SUBCLASS it{this};                                                         \
+    doit(&it);                                                                 \
+    return;                                                                    \
+  }
+
+    ADD_UNIT_TEST_SUBCLASS("test-specification-parsing", TestSpecificationTest)
+    /// [new_tests] Add the new mapping from string to subclass above this line.
+
+#undef ADD_UNIT_TEST_SUBCLASS
+  }
+
+  void runTest(StringRef name, Arguments &arguments) {
+    withTest(name, [&](auto *test) { test->invoke(arguments); });
+  }
+
+  void run() override {
+    llvm::SmallVector<std::string, 2> testSpecifications;
+    getTestSpecifications(getFunction(), testSpecifications);
+    Arguments arguments;
+    SmallVector<StringRef, 4> components;
+    for (unsigned long index = 0, size = testSpecifications.size();
+         index < size; ++index) {
+      components.clear();
+      arguments.clear();
+      auto testSpecification = testSpecifications[index];
+      test::parseTestArgumentsFromSpecification(
+          getFunction(), testSpecification, arguments, components);
+      auto name = arguments.takeString();
+      ArrayRef<StringRef> argumentStrings = components;
+      argumentStrings = argumentStrings.drop_front();
+      printTestLifetime(/*begin=*/true, /*index=*/index, /*size=*/size, name,
+                        argumentStrings);
+      runTest(name, arguments);
+      printTestLifetime(/*begin=*/false, /*index=*/index, /*size=*/size, name,
+                        argumentStrings);
+    }
+  }
+  friend class UnitTest;
+};
+
+template <typename Analysis>
+Analysis *UnitTest::getAnalysis() {
+  return pass->getAnalysis<Analysis>();
+}
+
+SILFunction *UnitTest::getFunction() { return getPass()->getFunction(); }
+
+} // anonymous namespace
+
+//===----------------------------------------------------------------------===//
+//                           Top Level Entry Point
+//===----------------------------------------------------------------------===//
+
+SILTransform *swift::createUnitTestRunner() { return new UnitTestRunner(); }

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -199,7 +199,23 @@ struct CanonicalizeOSSALifetimeTest : UnitTest {
   }
 };
 
-/// [new_tests] Add the new UnitTest subclass below this line.
+// Arguments:
+// - SILValue: phi
+// Dumps:
+// - function
+// - the adjacent phis
+struct VisitAdjacentReborrowsOfPhiTest : UnitTest {
+  VisitAdjacentReborrowsOfPhiTest(UnitTestRunner *pass) : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    getFunction()->dump();
+    visitAdjacentReborrowsOfPhi(cast<SILPhiArgument>(arguments.takeValue()),
+                                [](auto *argument) -> bool {
+                                  argument->dump();
+                                  return true;
+                                });
+  }
+};
+
 /// [new_tests] Add the new UnitTest subclass above this line.
 
 class UnitTestRunner : public SILFunctionTransform {
@@ -232,6 +248,8 @@ class UnitTestRunner : public SILFunctionTransform {
     ADD_UNIT_TEST_SUBCLASS("test-specification-parsing", TestSpecificationTest)
     ADD_UNIT_TEST_SUBCLASS("canonicalize-ossa-lifetime",
                            CanonicalizeOSSALifetimeTest)
+    ADD_UNIT_TEST_SUBCLASS("visit-adjacent-reborrows-of-phi",
+                           VisitAdjacentReborrowsOfPhiTest)
     /// [new_tests] Add the new mapping from string to subclass above this line.
 
 #undef ADD_UNIT_TEST_SUBCLASS

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -782,6 +782,7 @@ InlineCost swift::instructionInlineCost(SILInstruction &I) {
   case SILInstructionKind::MarkMustCheckInst:
   case SILInstructionKind::CopyableToMoveOnlyWrapperValueInst:
   case SILInstructionKind::MoveOnlyWrapperToCopyableValueInst:
+  case SILInstructionKind::TestSpecificationInst:
     return InlineCost::Free;
 
   // Typed GEPs are free.

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1288,6 +1288,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn,
   SILInstruction *ResultInst;
   switch (OpCode) {
   case SILInstructionKind::DebugValueInst:
+  case SILInstructionKind::TestSpecificationInst:
     llvm_unreachable("not supported");
 
   case SILInstructionKind::AllocBoxInst:

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,8 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 714; // New flag in SIL_ARG_EFFECTS_ATTR
+const uint16_t SWIFTMODULE_VERSION_MINOR =
+    715; // New test_specification instruction
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -914,6 +914,9 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     // sense to write the instruction at all.
     // TODO: decide if we want to serialize those instructions.
     return;
+  case SILInstructionKind::TestSpecificationInst:
+    // Instruction exists only for tests.  Ignore it.
+    return;
 
   case SILInstructionKind::UnwindInst:
   case SILInstructionKind::UnreachableInst: {

--- a/test/SIL/Parser/test_instructions.sil
+++ b/test/SIL/Parser/test_instructions.sil
@@ -1,0 +1,19 @@
+// RUN: %target-sil-opt %s | %target-sil-opt | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+// Test round-tripping the instruction through the SIL parser.
+//
+// In particular, this doesn't test parsing the components that make up the test
+// specification.
+// CHECK-LABEL: sil [ossa] @for_test_specification : {{.*}} {
+// CHECK:       test_specification "try-running-it foo bar 18 false baz"
+// CHECK-LABEL: } // end sil function 'for_test_specification'
+sil [ossa] @for_test_specification : $@convention(thin) () -> () {
+entry:
+  test_specification "try-running-it foo bar 18 false baz"
+  %4 = tuple()
+  return %4 : $()
+}

--- a/test/SIL/cloning.sil
+++ b/test/SIL/cloning.sil
@@ -107,3 +107,19 @@ entry(%0 : @owned $X):
   %res = apply %callee_debug_value(%0) : $@convention(thin) (@owned X) -> @owned X
   return %res : $X
 }
+
+// CHECK-LABEL: sil [ossa] @caller_test_specification : {{.*}} {
+// CHECK:         test_specification "foo bar baz"
+// CHECK-LABEL: } // end sil function 'caller_test_specification'
+sil [always_inline] [ossa] @callee_test_specification : $@convention(thin) () -> () {
+entry:
+  test_specification "foo bar baz"
+  %retval = tuple ()
+  return %retval : $()
+}
+
+sil [ossa] @caller_test_specification : $@convention(thin) () -> () {
+  %callee = function_ref @callee_test_specification : $@convention(thin) () -> ()
+  %retval = apply %callee() : $@convention(thin) () -> ()
+  return %retval : $()
+}

--- a/test/SILOptimizer/unit_test.sil
+++ b/test/SILOptimizer/unit_test.sil
@@ -83,3 +83,26 @@ bb1:
   debug_value [trace] %three : $(_ : (), (_ : ()), ((), (_ : ())))
   return %zero : $()
 }
+
+class C {}
+
+sil [ossa] @getC : $@convention(thin) () -> @owned C
+sil [ossa] @borrowC : $@convention(thin) (@guaranteed C) -> ()
+sil [ossa] @takeC : $@convention(thin) (@owned C) -> ()
+
+// CHECK-LABEL: begin running test 1 of 1 on fn: canonicalize-ossa-lifetime with: true, true, @trace
+// CHECK-LABEL: end running test 1 of 1 on fn: canonicalize-ossa-lifetime with: true, true, @trace
+sil [ossa] @fn : $@convention(thin) () -> () {
+entry:
+    test_specification "canonicalize-ossa-lifetime true true @trace"
+    %getC = function_ref @getC : $@convention(thin) () -> @owned C
+    %c = apply %getC() : $@convention(thin) () -> @owned C
+    debug_value [trace] %c : $C
+    %borrowC = function_ref @borrowC : $@convention(thin) (@guaranteed C) -> ()
+    apply %borrowC(%c) : $@convention(thin) (@guaranteed C) -> ()
+    debug_value %c : $C
+    destroy_value %c : $C
+    %retval = tuple ()
+    return %retval : $()
+}
+

--- a/test/SILOptimizer/unit_test.sil
+++ b/test/SILOptimizer/unit_test.sil
@@ -1,0 +1,85 @@
+// RUN: %target-sil-opt -unit-test-runner %s 2>&1 | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+
+// CHECK-LABEL: begin running test 1 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
+// CHECK: test_arg_parsing_reference
+// CHECK: test_arg_parsing_referenceable
+// CHECK: test_arg_parsing
+// CHECK: bool: 1
+// CHECK: bool: 0
+// CHECK-LABEL: end running test 1 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
+// CHECK-LABEL: begin running test 2 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
+// CHECK: block:
+// CHECK: bb0:
+// CHECK: function_ref @something_remarkable
+// CHECK: uint: 42
+// CHECK: instruction: {{%[^,]+}} = tuple ({{%[^,]+}}, {{%[^,]+}}, {{%[^,]+}})
+// CHECK-LABEL: end running test 2 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
+// CHECK-LABEL: begin running test 3 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
+// CHECK: function: test_arg_parsing
+// CHECK: function: test_arg_parsing
+// CHECK-LABEL: end running test 3 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
+// CHECK-LABEL: begin running test 4 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
+// CHECK: block:
+// CHECK: function_ref @something_remarkable
+// CHECK: block:
+// CHECK: function_ref @something_remarkable
+// CHECK: block:
+// CHECK: function_ref @something_remarkable
+// CHECK: block:
+// CHECK: function_ref @something_remarkable
+// CHECK: block:
+// CHECK: function_ref @something_remarkable
+// CHECK-LABEL: end running test 4 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
+// CHECK-LABEL: begin running test 5 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
+// CHECK: instruction: // function_ref something_remarkable
+// CHECK: instruction: // function_ref something_remarkable
+// CHECK: instruction: // function_ref something_remarkable
+// CHECK: instruction: // function_ref something_remarkable
+// CHECK: instruction: // function_ref something_remarkable
+// CHECK: instruction: // function_ref something_remarkable
+// CHECK: instruction: // function_ref something_remarkable
+// CHECK: instruction: // function_ref something_remarkable
+// CHECK-LABEL: end running test 5 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
+// CHECK-LABEL: begin running test 6 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
+// CHECK: operand: 
+// CHECK: Owner:   return {{%[^,]+}} : $()
+// CHECK: operand:
+// CHECK: Value:   {{%[^,]+}} = tuple ({{%[^,]+}} : $())
+// CHECK-LABEL: end running test 6 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
+// CHECK-LABEL: begin running test 7 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
+// CHECK: value: {{%[^,]+}} = tuple ({{%[^,]+}} : $(), {{%[^,]+}} : $(_: ()), {{%[^,]+}} : $((), (_: ())))
+// CHECK: string: howdy
+// CHECK-LABEL: end running test 7 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
+sil [ossa] @test_arg_parsing : $() -> () {
+entry:
+  test_specification "test-specification-parsing FFFbb @function[test_arg_parsing_reference] @function[2] @function true false"
+  test_specification "test-specification-parsing BuI @block[0] 42 @function[test_arg_parsing_callee].block[1].instruction[3]"
+  test_specification "test-specification-parsing FF @function @function[0]"
+  test_specification "test-specification-parsing BBBBB @block @function.block @function.block[0] @function[0].block @function[0].block[0]"
+  test_specification "test-specification-parsing IIIIIIII @function.block.instruction @function[0].block.instruction @function.block[0].instruction @function.block.instruction[0] @function[0].block[0].instruction @function[0].block.instruction[0] @function.block[0].instruction[0] @function[0].block[0].instruction[0]"
+  test_specification "test-specification-parsing OO @instruction[2].operand @function[test_arg_parsing_callee].trace.operand[1]"
+  test_specification "test-specification-parsing Vs @function[4].trace[0] howdy"
+  %something_remarkable = function_ref @something_remarkable : $@convention(thin) () -> ()
+  %retval = tuple ()
+  return %retval : $()
+}
+
+sil [ossa] @test_arg_parsing_reference : $() -> ()
+sil [ossa] @test_arg_parsing_referenceable : $() -> ()
+sil [ossa] @something_remarkable : $() -> ()
+
+sil [ossa] @test_arg_parsing_callee : $() -> () {
+bb0:
+  br bb1
+bb1:
+  %zero = tuple ()
+  %one = tuple (%zero : $())
+  %two = tuple (%zero : $(), %one : $(_ : ()))
+  %three = tuple (%zero : $(), %one : $(_ : ()), %two : $((), (_ : ())))
+  debug_value [trace] %three : $(_ : (), (_ : ()), ((), (_ : ())))
+  return %zero : $()
+}

--- a/test/SILOptimizer/unit_test.sil
+++ b/test/SILOptimizer/unit_test.sil
@@ -106,3 +106,36 @@ entry:
     return %retval : $()
 }
 
+// CHECK-LABEL: begin running test 1 of 1 on pay_the_phi: visit-adjacent-reborrows-of-phi with: @trace[2]
+// CHECK: sil [ossa] @pay_the_phi : {{.*}} {
+// CHECK:   [[C:%[^,]+]] = apply
+// CHECK:   [[BORROW1:%[^,]+]] = begin_borrow %1
+// CHECK:   [[BORROW2:%[^,]+]] = begin_borrow %1
+// CHECK:   br [[EXIT:bb[0-9]+]]([[C]] : $C, [[BORROW1]] : $C, [[BORROW2]] :
+// CHECK: [[EXIT]]({{%[^,]+}} : @owned $C, [[GUARANTEED1:%[^,]+]] : @guaranteed $C, [[GUARANTEED2:%[^,]+]] :
+// CHECK: } // end sil function 'pay_the_phi'
+
+// CHECK:[[GUARANTEED1]] = argument of [[EXIT]]
+// CHECK:[[GUARANTEED2]] = argument of [[EXIT]]
+// CHECK-LABEL: end running test 1 of 1 on pay_the_phi: visit-adjacent-reborrows-of-phi with: @trace[2]
+sil [ossa] @pay_the_phi : $@convention(thin) () -> () {
+entry:
+  test_specification "visit-adjacent-reborrows-of-phi @trace[2]"
+  %getC = function_ref @getC : $@convention(thin) () -> @owned C
+  %c = apply %getC() : $@convention(thin) () -> @owned C
+  debug_value [trace] %c : $C
+  %borrow1 = begin_borrow %c : $C
+  %borrow2 = begin_borrow %c : $C
+  debug_value [trace] %borrow2 : $C
+  %borrow3 = begin_borrow %borrow2 : $C
+  br exit(%c : $C, %borrow1 : $C, %borrow2 : $C, %borrow3 : $C)
+
+exit(%owned : @owned $C, %guaranteed_1 : @guaranteed $C, %guaranteed_2 : @guaranteed $C, %guaranteed_3 : @guaranteed $C):
+  debug_value [trace] %owned : $C
+  end_borrow %guaranteed_3 : $C
+  end_borrow %guaranteed_2 : $C
+  end_borrow %guaranteed_1 : $C
+  destroy_value %owned : $C
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
The testing works by way of a new pass `UnitTestRunner` and a new instruction `test_specification`.  When a function contains `test_specification` instructions, it invokes the UnitTest subclass named in the `test_specification` instruction with the arguments specified in that instruction.

For example, when running the unit-test-runner pass, having the instructions

```
test_specification "my-neato-utility 19 @function[callee].block[2] @trace[2]"
test_specification "my-neato-utility 43 @block @trace"
```

would result in the test associated with `"my-neato-utility"` in `UnitTestRunner.cpp` being invoked twice.  Once with `(19, aBlock, aValue)`, and once with `(43, anotherBlock, someOtherValue)`.  That `UnitTest` subclass class would need to call `takeUInt`, `takeBlock`, and `takeValue` on the `Arguments` struct it is invoked with.  It would then pass those arguments along to `myNeatoUtility` and dump out interesting results.  The results would then be FileCheck'd.
