### PR TITLE
[cxx-interop] Do not instantiate templates in unevaluated contexts

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -75,6 +75,15 @@ public:
     return true;
   }
 
+  // Do not traverse unevaluated expressions. Doing to might result in compile
+  // errors if we try to instantiate an un-instantiatable template.
+
+  bool VisitCXXNoexceptExpr(clang::CXXNoexceptExpr *NEE) { return false; }
+
+  bool VisitCXXTypeidExpr(clang::CXXTypeidExpr *TIE) {
+    return TIE->isPotentiallyEvaluated();
+  }
+
   bool shouldVisitTemplateInstantiations() const { return true; }
   bool shouldVisitImplicitCode() const { return true; }
 };

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -137,3 +137,8 @@ module DependentTypes {
   header "dependent-types.h"
   requires cplusplus
 }
+
+module UnevaluatedContext {
+  header "unevaluated-context.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/templates/Inputs/unevaluated-context.h
+++ b/test/Interop/Cxx/templates/Inputs/unevaluated-context.h
@@ -1,0 +1,33 @@
+#ifndef TEST_INTEROP_CXX_TEMPLATES_INPUTS_UNEVALUATED_CONTEXT_H
+#define TEST_INTEROP_CXX_TEMPLATES_INPUTS_UNEVALUATED_CONTEXT_H
+
+template <typename _Tp>
+_Tp __declval(long);
+
+template <typename _Tp>
+struct __declval_protector {
+  static const bool __stop = false;
+};
+
+template <typename _Tp>
+auto declval() noexcept -> decltype(__declval<_Tp>(0)) {
+  static_assert(__declval_protector<_Tp>::__stop,
+                "declval() must not be used!");
+  return __declval<_Tp>(0);
+}
+
+template <class T>
+class Vec {
+public:
+  void push_back(const T &__x) {
+    if (!noexcept(declval<T *>()))
+      ;
+  }
+};
+
+inline void initVector() {
+  Vec<int> vv;
+  vv.push_back(0);
+}
+
+#endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_UNEVALUATED_CONTEXT_H

--- a/test/Interop/Cxx/templates/unevaluated-context.swift
+++ b/test/Interop/Cxx/templates/unevaluated-context.swift
@@ -1,0 +1,14 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+//
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import UnevaluatedContext
+
+var UnevaluatedTestSuite = TestSuite("UnevaluatedContext")
+
+UnevaluatedTestSuite.test("declval") {
+  initVector()
+}
+
+runAllTests()


### PR DESCRIPTION
Previously we tried to instantiate templates in unevaluated contexts. Some of these templates might not be instantiatable, which caused compile errors, while the equivalent C++ code compiles and runs with no issue.

This was problematic for `std::vector` with libstdc++ on Linux.

Fixes https://github.com/apple/swift/issues/61547.