### PR TITLE
[swift-reflection-dump] Make ObjC interoperability configurable.

### DIFF
--- a/include/swift/StaticMirror/ObjectFileContext.h
+++ b/include/swift/StaticMirror/ObjectFileContext.h
@@ -144,10 +144,12 @@ T unwrap(llvm::Expected<T> value) {
 }
 
 std::unique_ptr<ReflectionContextHolder> makeReflectionContextForObjectFiles(
-    const std::vector<const llvm::object::ObjectFile *> &objectFiles);
+    const std::vector<const llvm::object::ObjectFile *> &objectFiles,
+    bool objcInterOp);
 
 std::unique_ptr<ReflectionContextHolder> makeReflectionContextForMetadataReader(
-    std::shared_ptr<ObjectMemoryReader> reader);
+    std::shared_ptr<ObjectMemoryReader> reader,
+    bool objcInterOp);
 
 } // end namespace static_mirror
 } // end namespace swift

--- a/lib/StaticMirror/BinaryScanningTool.cpp
+++ b/lib/StaticMirror/BinaryScanningTool.cpp
@@ -52,7 +52,13 @@ BinaryScanningTool::BinaryScanningTool(
     ObjectOwners.push_back(std::move(ObjectOwner));
     ObjectFiles.push_back(O);
   }
-  Context = makeReflectionContextForObjectFiles(ObjectFiles);
+  // FIXME: This could/should be configurable.
+#if SWIFT_OBJC_INTEROP
+  bool ObjCInterop = true;
+#else
+  bool ObjCInterop = false;
+#endif
+  Context = makeReflectionContextForObjectFiles(ObjectFiles, ObjCInterop);
   PointerSize = Context->PointerSize;
 }
 

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -78,6 +78,12 @@ static llvm::cl::opt<std::string>
     Architecture("arch",
                  llvm::cl::desc("Architecture to inspect in the binary"),
                  llvm::cl::Required);
+
+#if SWIFT_OBJC_INTEROP
+static llvm::cl::opt<bool> DisableObjCInterop(
+    "no-objc-interop",
+    llvm::cl::desc("Disable Objective-C interoperability support"));
+#endif
 } // end namespace options
 
 static int doDumpReflectionSections(ArrayRef<std::string> BinaryFilenames,
@@ -109,7 +115,12 @@ static int doDumpReflectionSections(ArrayRef<std::string> BinaryFilenames,
     ObjectFiles.push_back(O);
   }
 
-  auto context = makeReflectionContextForObjectFiles(ObjectFiles);
+#if SWIFT_OBJC_INTEROP
+  bool ObjCInterop = !options::DisableObjCInterop;
+#else
+  bool ObjCInterop = false;
+#endif
+  auto context = makeReflectionContextForObjectFiles(ObjectFiles, ObjCInterop);
   auto &builder = context->Builder;
 
   switch (Action) {
@@ -117,17 +128,21 @@ static int doDumpReflectionSections(ArrayRef<std::string> BinaryFilenames,
     // Dump everything
     switch (context->PointerSize) {
     case 4:
-      // FIXME: This could/should be configurable.
 #if SWIFT_OBJC_INTEROP
-      builder.dumpAllSections<WithObjCInterop, 4>(stream);
+      if (!options::DisableObjCInterop)
+        builder.dumpAllSections<WithObjCInterop, 4>(stream);
+      else
+        builder.dumpAllSections<NoObjCInterop, 4>(stream);
 #else
       builder.dumpAllSections<NoObjCInterop, 4>(stream);
 #endif
       break;
     case 8:
-      // FIXME: This could/should be configurable.
 #if SWIFT_OBJC_INTEROP
-      builder.dumpAllSections<WithObjCInterop, 8>(stream);
+      if (!options::DisableObjCInterop)
+        builder.dumpAllSections<WithObjCInterop, 8>(stream);
+      else
+        builder.dumpAllSections<NoObjCInterop, 8>(stream);
 #else
       builder.dumpAllSections<NoObjCInterop, 8>(stream);
 #endif


### PR DESCRIPTION
This addresses a FIXME in the code. This allows running swift-reflection-dump on macOS to dump the contents of an ELF binary.
