### PR TITLE
Handle scoped address in PrunedLiveness

### DIFF
--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -83,6 +83,34 @@
 /// | Use | [LiveWithin]
 ///  -----
 ///
+/// ---------------------------------------------------------------------------
+///
+/// "Use points" are the instructions that "generate" liveness for a given
+/// operand. A generalized use point visitor would look like this:
+///
+/// Given an \p operand, visit the use points relevant for liveness. For most
+/// operands, this is simply the user instruction. For scoped operands, each
+/// scope-ending instruction is a separate use point.
+/// template<typename Operation>
+/// inline bool visitUsePoints(Operand *use, Operation visitUsePoint) {
+///   // Handle TrivialUse operands: begin_access & store_borrow address
+///   // Handle InteriorPointer operands: store_borrow source
+///   if (auto scopedAddress = ScopedAddressValue::forUse(use)) {
+///     return scopedAddress.visitScopeEndingUses(visitUsePoint);
+///   }
+///   // Handle Borrow operands...
+///   // Handles borrow scope introducers: begin_borrow & load_borrow.
+///   // Handles guaranteed return values: begin_apply.
+///   if (!BorrowingOperand(operand).visitScopeEndingUses([this](Operand *end) {
+///     if (!visitUsePoint(end))
+///       return false;
+///     return true;
+///   }
+///   return visitUsePoint(use);
+/// }
+///
+/// The visitors that switch on OperandOwnership use a specialized
+/// implementation because each case above is specific to an ownership case.
 //===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_SILOPTIMIZER_UTILS_PRUNEDLIVENESS_H

--- a/include/swift/SIL/ScopedAddressUtils.h
+++ b/include/swift/SIL/ScopedAddressUtils.h
@@ -74,6 +74,15 @@ struct ScopedAddressValue {
     return kind != ScopedAddressValueKind::Invalid && value;
   }
 
+  // Both the store_borrow source and address operands are effectively used for
+  // the duration of the address scope.
+  static ScopedAddressValue forUse(Operand *use) {
+    if (auto svi = dyn_cast<SingleValueInstruction>(use->getUser()))
+      return ScopedAddressValue(svi);
+
+    return ScopedAddressValue();
+  }
+
   void print(llvm::raw_ostream &os) const;
   SWIFT_DEBUG_DUMP { print(llvm::dbgs()); }
 

--- a/test/SILOptimizer/ossa_lifetime_analysis.sil
+++ b/test/SILOptimizer/ossa_lifetime_analysis.sil
@@ -22,6 +22,7 @@ case some(T)
 class C {}
 class D {
   var object: C
+  @_borrowed @_hasStorage var borrowed: C { get set }
 }
 
 // CHECK-LABEL: @testSelfLoop
@@ -129,6 +130,48 @@ bb0(%0 : @owned $D):
   end_borrow %borrow0 : $D
   destroy_value %o : $C
   destroy_value %0 : $D
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: @testGuaranteedResult
+// CHECK: SSA lifetime analysis: %0 = argument of bb0 : $D
+// CHECK: bb0: LiveWithin
+// CHECK: last user:   end_apply
+sil [ossa] @testGuaranteedResult : $@convention(thin) (@guaranteed D) -> () {
+bb0(%0 : @guaranteed $D):
+  debug_value [trace] %0 : $D
+  %2 = class_method %0 : $D, #D.borrowed!read : (D) -> () -> (), $@yield_once @convention(method) (@guaranteed D) -> @yields @guaranteed C
+  (%3, %4) = begin_apply %2(%0) : $@yield_once @convention(method) (@guaranteed D) -> @yields @guaranteed C
+  end_apply %4
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: @testScopedAddress
+// CHECK: SSA lifetime analysis: %{{.*}} = ref_element_addr %0
+// CHECK: bb0: LiveWithin
+// CHECK: last user: end_access
+sil [ossa] @testScopedAddress : $@convention(thin) (@guaranteed D) -> () {
+bb0(%0 : @guaranteed $D):
+  %f = ref_element_addr %0 : $D, #D.object
+  debug_value [trace] %f : $*C
+  %access = begin_access [read] [static] %f : $*C
+  %o = load [copy] %access : $*C
+  end_access %access : $*C
+  destroy_value %o : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: @testDeadAddress
+// CHECK: SSA lifetime analysis: %0 = argument of bb0 : $D
+// CHECK: bb0: LiveWithin
+// CHECK: last user: %{{.*}} = ref_element_addr
+sil [ossa] @testDeadAddress : $@convention(thin) (@guaranteed D) -> () {
+bb0(%0 : @guaranteed $D):
+  debug_value [trace] %0 : $D
+  %f = ref_element_addr %0 : $D, #D.object
   %99 = tuple()
   return %99 : $()
 }


### PR DESCRIPTION
Makes PrunedLiveness more complete in case it is used for the liveness of addresses.

Now handles dead addresses which could come up when a ref_element_address is not surrounded by a borrow scope.

Now handles address scopes. InteriorPointer uses were already being handled correctly. This just makes the utility complete in case we directly ask for address liveness.