### PR TITLE
[Sema] Adapt force optional fix to handle multiple levels of optional

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -936,17 +936,26 @@ public:
 
 /// Introduce a '!' to force an optional unwrap.
 class ForceOptional final : public ContextualMismatch {
+  unsigned int UnwrapCount;
+
   ForceOptional(ConstraintSystem &cs, Type fromType, Type toType,
                 ConstraintLocator *locator)
       : ContextualMismatch(cs, FixKind::ForceOptional, fromType, toType,
                            locator) {
     assert(fromType && "Base type must not be null");
     assert(fromType->getOptionalObjectType() &&
-           "Unwrapped type must not be null");
+           "From type must be optional");
+
+    auto fromOptionals = fromType->getOptionalityDepth();
+    auto toOptionals = toType->getOptionalityDepth();
+    assert(fromOptionals > toOptionals);
+
+    UnwrapCount = fromOptionals - toOptionals;
   }
 
 public:
   std::string getName() const override { return "force optional"; }
+  unsigned int getUnwrapCount() const { return UnwrapCount; }
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4586,10 +4586,11 @@ public:
   /// Attempt to repair typing failures and record fixes if needed.
   /// \return true if at least some of the failures has been repaired
   /// successfully, which allows type matcher to continue.
-  bool repairFailures(Type lhs, Type rhs, ConstraintKind matchKind,
-                      TypeMatchOptions flags,
-                      SmallVectorImpl<RestrictionOrFix> &conversionsOrFixes,
-                      ConstraintLocatorBuilder locator);
+  TypeMatchResult
+  repairFailures(Type lhs, Type rhs, ConstraintKind matchKind,
+                 TypeMatchOptions flags,
+                 SmallVectorImpl<RestrictionOrFix> &conversionsOrFixes,
+                 ConstraintLocatorBuilder locator);
 
   TypeMatchResult
   matchPackTypes(PackType *pack1, PackType *pack2,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1525,6 +1525,12 @@ void MissingOptionalUnwrapFailure::offerDefaultValueUnwrapFixIt(
     DeclContext *DC, const Expr *expr) const {
   assert(expr);
 
+  // More than one level of optionality requires a default value 
+  // for each level which makes it complicated chain of defaults 
+  // to suggest, so we skip default note and fix-it.
+  if (UnwrapCount != 1) 
+    return;
+
   auto *anchor = getAsExpr(getAnchor());
   // If anchor is n explicit address-of, or expression which produces
   // an l-value (e.g. first argument of `+=` operator), let's not
@@ -1568,6 +1574,8 @@ void MissingOptionalUnwrapFailure::offerForceUnwrapFixIt(
     const Expr *expr) const {
   auto diag = emitDiagnosticAt(expr->getLoc(), diag::unwrap_with_force_value);
 
+  std::string forceUnwrapStr = getForceUnwrapString();
+
   // If expr is optional as the result of an optional chain and this last
   // dot isn't a member returning optional, then offer to force the last
   // link in the chain, rather than an ugly parenthesized postfix force.
@@ -1576,17 +1584,17 @@ void MissingOptionalUnwrapFailure::offerForceUnwrapFixIt(
         dyn_cast<UnresolvedDotExpr>(optionalChain->getSubExpr())) {
       auto bind = dyn_cast<BindOptionalExpr>(dotExpr->getBase());
       if (bind && !getType(dotExpr)->getOptionalObjectType()) {
-        diag.fixItReplace(SourceRange(bind->getLoc()), "!");
+        diag.fixItReplace(SourceRange(bind->getLoc()), forceUnwrapStr);
         return;
       }
     }
   }
 
   if (expr->canAppendPostfixExpression(true)) {
-    diag.fixItInsertAfter(expr->getEndLoc(), "!");
+    diag.fixItInsertAfter(expr->getEndLoc(), forceUnwrapStr);
   } else {
     diag.fixItInsert(expr->getStartLoc(), "(")
-        .fixItInsertAfter(expr->getEndLoc(), ")!");
+        .fixItInsertAfter(expr->getEndLoc(), ")" + forceUnwrapStr);
   }
 }
 
@@ -2596,7 +2604,7 @@ bool ContextualFailure::diagnoseAsError() {
       // it could assume a type from context.
       if (objectType && objectType->isEqual(toType)) {
         MissingOptionalUnwrapFailure failure(getSolution(), getType(anchor),
-                                             toType,
+                                             toType, /*unwrapCount=*/1,
                                              getConstraintLocator(anchor));
         if (failure.diagnoseAsError())
           return true;

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -89,7 +89,7 @@ ForceDowncast *ForceDowncast::create(ConstraintSystem &cs, Type fromType,
 
 bool ForceOptional::diagnose(const Solution &solution, bool asNote) const {
   MissingOptionalUnwrapFailure failure(solution, getFromType(), getToType(),
-                                       getLocator());
+                                       getUnwrapCount(), getLocator());
   return failure.diagnose(asNote);
 }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4660,6 +4660,11 @@ repairViaOptionalUnwrap(ConstraintSystem &cs, Type fromType, Type toType,
                         ConstraintLocatorBuilder locator) {
   fromType = fromType->getWithoutSpecifierType();
 
+  {
+    fromType = cs.simplifyType(fromType);
+    toType = cs.simplifyType(toType);
+  }
+
   if (!fromType->getOptionalObjectType() || toType->is<TypeVariableType>())
     return cs.getTypeMatchFailure(locator);
 
@@ -4783,10 +4788,10 @@ repairViaOptionalUnwrap(ConstraintSystem &cs, Type fromType, Type toType,
   // bound to `Int?` and there is no need to unwrap. Solver has to wait
   // until more information becomes available about what `T0` is expected
   // to be before taking action.
-  if (matchKind == ConstraintKind::Equal &&
-      (fromObjectType->is<TypeVariableType>() ||
-       toObjectType->is<TypeVariableType>())) {
-    return cs.getTypeMatchFailure(locator);
+  if (fromObjectType->is<TypeVariableType>() ||
+      toObjectType->is<TypeVariableType>()) {
+    return matchKind == ConstraintKind::Equal ? cs.getTypeMatchFailure(locator)
+                                              : cs.getTypeMatchAmbiguous();
   }
 
   // If `from` is not less optional than `to`, force unwrap is
@@ -5354,8 +5359,8 @@ ConstraintSystem::repairFailures(
       {
         auto result = repairViaOptionalUnwrap(*this, lhs, rhs, matchKind,
                                               conversionsOrFixes, locator);
-        if (result.isSuccess())
-          return getTypeMatchSuccess();
+        if (!result.isFailure())
+          return result;
       }
 
       // `rhs` - is an assignment destination and `lhs` is its source.
@@ -5686,8 +5691,8 @@ ConstraintSystem::repairFailures(
     {
       auto result = repairViaOptionalUnwrap(*this, lhs, rhs, matchKind,
                                             conversionsOrFixes, locator);
-      if (result.isSuccess())
-        break;
+      if (!result.isFailure())
+        return result;
     }
 
     {
@@ -5953,8 +5958,8 @@ ConstraintSystem::repairFailures(
     {
       auto result = repairViaOptionalUnwrap(*this, lhs, rhs, matchKind,
                                             conversionsOrFixes, locator);
-      if (result.isSuccess())
-        return getTypeMatchSuccess();
+      if (!result.isFailure())
+        return result;
     }
 
     // If we could record a generic arguments mismatch instead of this fix,
@@ -6083,8 +6088,8 @@ ConstraintSystem::repairFailures(
         {
           auto result = repairViaOptionalUnwrap(*this, lhs, rhs, matchKind,
                                               conversionsOrFixes, locator);
-          if (result.isSuccess())
-            return getTypeMatchSuccess();
+          if (!result.isFailure())
+            return result;
         }
 
         conversionsOrFixes.push_back(
@@ -6303,8 +6308,8 @@ ConstraintSystem::repairFailures(
   case ConstraintLocator::Condition: {
     auto result = repairViaOptionalUnwrap(*this, lhs, rhs, matchKind,
                                           conversionsOrFixes, locator);
-    if (result.isSuccess())
-      return getTypeMatchSuccess();
+    if (!result.isFailure())
+      return result;
 
     conversionsOrFixes.push_back(IgnoreContextualType::create(
         *this, lhs, rhs, getConstraintLocator(locator)));
@@ -6360,8 +6365,8 @@ ConstraintSystem::repairFailures(
   case ConstraintLocator::OptionalPayload: {
     auto result = repairViaOptionalUnwrap(*this, lhs, rhs, matchKind,
                                           conversionsOrFixes, locator);
-    if (result.isSuccess())
-      return getTypeMatchSuccess();
+    if (!result.isFailure())
+      return result;
 
     break;
   }
@@ -6592,8 +6597,8 @@ ConstraintSystem::repairFailures(
       auto result = repairViaOptionalUnwrap(
           *this, lhs, rhs, matchKind, conversionsOrFixes,
           getConstraintLocator(coercion->getSubExpr()));
-      if (result.isSuccess())
-        return getTypeMatchSuccess();
+      if (!result.isFailure())
+        return result;
     }
 
     // If the result type of the coercion has an value to optional conversion

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5737,13 +5737,13 @@ ConstraintSystem::repairFailures(
       // detected a tuple splat issue.
       if (hasFixFor(loc,
                     FixKind::DestructureTupleToMatchPackExpansionParameter))
-        return true;
+        return getTypeMatchSuccess();
 
       // Path would end with `ApplyArgument`.
       auto *argsLoc = getConstraintLocator(anchor, tmpPath.drop_back());
       if (hasFixFor(argsLoc, FixKind::RemoveExtraneousArguments) ||
           hasFixFor(argsLoc, FixKind::AddMissingArguments))
-        return true;
+        return getTypeMatchSuccess();
     }
 
     // If the argument couldn't be found, this could be a default value
@@ -6412,7 +6412,7 @@ ConstraintSystem::repairFailures(
   case ConstraintLocator::EnumPatternImplicitCastMatch: {
     // If either type is a placeholder, consider this fixed.
     if (lhs->isPlaceholder() || rhs->isPlaceholder())
-      return true;
+      return getTypeMatchSuccess();
 
     conversionsOrFixes.push_back(ContextualMismatch::create(
         *this, lhs, rhs, getConstraintLocator(locator)));

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -534,8 +534,7 @@ singleOptionalClosure()
 doubleOptionalClosure()
 // expected-error@-1 {{value of optional type}}
 // expected-note@-2 {{use optional chaining to call this value of function type when optional is non-'nil'}} {{22-22=??}}
-// expected-note@-3 {{coalesce}}
-// expected-note@-4 {{force-unwrap}}
+// expected-note@-3 {{force-unwrap}}
 
 doubleOptionalClosure?()
 // expected-error@-1 {{value of optional type}}
@@ -573,15 +572,13 @@ do {
   func passOptional(value: (any P)?) {
     takesP(value)
     // expected-error@-1 {{value of optional type '(any P)?' must be unwrapped to a value of type 'any P'}}
-    // expected-note@-2 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
-    // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+    // expected-note@-2 {{coalesce using '??' to provide a default when the optional value contains 'nil'}} {{17-17= ?? <#default value#>}}
+    // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}} {{17-17=!}} 
   }
   func passLayersOfOptional(value: (any P)??) {
-    // FIXME(diagnostics): Consider recording multiple ForceUnwrap fixes based on number of optionals 
     takesP(value)
-    // expected-error@-1 {{value of optional type '(any P)??' must be unwrapped to a value of type '(any P)?}}
-    // expected-note@-2 {{coalesce using '??' to provide a default when the optional value contains 'nil'}}
-    // expected-note@-3 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}}
+    // expected-error@-1 {{value of optional type '(any P)??' must be unwrapped to a value of type 'any P'}}
+    // expected-note@-2 {{force-unwrap using '!' to abort execution if the optional value contains 'nil'}} {{17-17=!!}} 
   }
   func passNonConformingValue(value: (any BinaryInteger)?){
     takesP(value)


### PR DESCRIPTION
<!-- What's in this pull request? -->
Adapt force optional fix to handle multiple levels of optional changing signature to take only optional type and unwrap count(instead of from and to types) which make sense since the force optional is to unwrap an optional to produce the unwrapped type. So let me know what you think =]

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
