### PR TITLE
Make Xcode version check more lenient

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -17,6 +17,7 @@ The ultimate tool for building Swift.
 import json
 import os
 import platform
+import re
 import sys
 import time
 
@@ -42,24 +43,6 @@ from swift_build_support.swift_build_support.utils \
 from swift_build_support.swift_build_support.utils import fatal_error
 from swift_build_support.swift_build_support.utils import log_analyzer
 
-
-# -----------------------------------------------------------------------------
-# Constants
-
-# These versions are community sourced. At any given time only the Xcode
-# version used by Swift CI is officially supported. See ci.swift.org
-_SUPPORTED_XCODE_BUILDS = [
-    ("13.0 beta 4", "13A5201i"),
-    ("13.0", "13A233"),
-    ("13.1 RC 1", "13A1030d"),
-    ("13.2 beta", "13C5066c"),
-    ("13.2.1", "13C100"),
-    ("13.3", "13E113"),
-    ("13.3.1", "13E500a"),
-    ("13.4", "13F17a"),
-    ("13.4.1", "13F100"),
-    ("14.0.0", "14A309"),
-]
 
 # -----------------------------------------------------------------------------
 # Helpers
@@ -148,19 +131,24 @@ def validate_xcode_compatibility():
         print("note: skipping Xcode version check")
         return
 
-    version = shell.capture(
+    output = shell.capture(
         ['xcodebuild', '-version'], dry_run=False, echo=False).strip()
+    # Capture only version ex: '14.x' from full output
+    match = re.match(r"Xcode (\d+\.\d+(?:\.\d)?)", output)
+    if not match:
+        print(f"warning: unexpected xcodebuild output format: '{output}', "
+              "skipping Xcode compatibility check, please report this issue",
+              file=sys.stderr)
+        return
 
-    valid_build_numbers = tuple(x[1] for x in _SUPPORTED_XCODE_BUILDS)
-    if not version.endswith(valid_build_numbers):
-        valid_versions_string = "\n".join(
-            "{} ({})".format(*x) for x in _SUPPORTED_XCODE_BUILDS)
+    version_match = match.group(1)
+    current_version = tuple(int(v) for v in version_match.replace('.', ' ').split())
+    minimum_version = (13, 0)
+    if current_version < minimum_version:
         raise SystemExit(
-            "error: using unsupported Xcode version:\n\n{}\n\n"
-            "Install one of:\n{}\n\n"
-            "Or set 'SKIP_XCODE_VERSION_CHECK=1' in the environment".format(
-                version, valid_versions_string
-            )
+            f"error: using unsupported Xcode version '{version_match}'. "
+            f"Install Xcode {'.'.join(str(x) for x in minimum_version)} or newer, "
+            "or set 'SKIP_XCODE_VERSION_CHECK=1' in the environment"
         )
 
 


### PR DESCRIPTION
This allows any versions above a specific version, instead of requiring a specific list. Since it seems like many folks just disable this check entirely, this list definitely isn't kept up well. If we need to exclude a specific version, like if 1 Xcode beta didn't support it but the next did, we can add a new list using the old method to validate build numbers and disallow the bad version(s).

I don't recall why we didn't do this over a list originally, nor can I find any context on why in the original discussion https://github.com/apple/swift/pull/34227