### PR TITLE
[Backdeploy5.6] Hide task_future_wait[_throwing]

### DIFF
--- a/include/swift/Runtime/Exclusivity.h
+++ b/include/swift/Runtime/Exclusivity.h
@@ -75,12 +75,12 @@ void swift_dumpTrackedAccesses();
 #ifdef SWIFT_COMPATIBILITY56
 /// Backdeploy56 shim calls swift_task_enterThreadLocalContext if it is
 /// available in the underlying runtime, otherwise does nothing
-SWIFT_RUNTIME_EXPORT
+__attribute__((visibility("hidden"), weak))
 void swift_task_enterThreadLocalContextBackdeploy56(char *state);
 
 /// Backdeploy56 shim calls swift_task_exitThreadLocalContext if it is available
 /// in the underlying runtime, otherwise does nothing
-SWIFT_RUNTIME_EXPORT
+__attribute__((visibility("hidden"), weak))
 void swift_task_exitThreadLocalContextBackdeploy56(char *state);
 #else
 

--- a/stdlib/toolchain/Compatibility56/Overrides.h
+++ b/stdlib/toolchain/Compatibility56/Overrides.h
@@ -37,6 +37,7 @@ using TaskFutureWaitThrowing_t = SWIFT_CC(swiftasync) void(
                               ThrowingTaskFutureWaitContinuationFunction *resumeFn,
                               AsyncContext *callContext);
 
+__attribute__((weak, visibility("hidden")))
 void SWIFT_CC(swiftasync) swift56override_swift_task_future_wait(
                                             OpaqueValue *,
                                             SWIFT_ASYNC_CONTEXT AsyncContext *,
@@ -45,6 +46,7 @@ void SWIFT_CC(swiftasync) swift56override_swift_task_future_wait(
                                             AsyncContext *,
                                             TaskFutureWait_t *original);
 
+__attribute__((weak, visibility("hidden")))
 void SWIFT_CC(swiftasync) swift56override_swift_task_future_wait_throwing(
                                             OpaqueValue *,
                                             SWIFT_ASYNC_CONTEXT AsyncContext *,
@@ -52,10 +54,4 @@ void SWIFT_CC(swiftasync) swift56override_swift_task_future_wait_throwing(
                                             ThrowingTaskFutureWaitContinuationFunction *,
                                             AsyncContext *,
                                             TaskFutureWaitThrowing_t *original);
-
-
-using AsyncMainDrainQueue_t = SWIFT_CC(swift) void();
-
-void SWIFT_CC(swift) swift56override_swift_asyncMainDrainQueue(AsyncMainDrainQueue_t *);
-
 } // namespace swift

--- a/stdlib/toolchain/Compatibility56/include/Concurrency/TaskStatus.h
+++ b/stdlib/toolchain/Compatibility56/include/Concurrency/TaskStatus.h
@@ -159,7 +159,7 @@ public:
 };
 
 /// Return the current thread's active task reference.
-SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
+SWIFT_CC(swift)
 AsyncTask *swift_task_getCurrent(void);
 } // namespace swift
 

--- a/stdlib/toolchain/Compatibility56/include/Runtime/Concurrency.h
+++ b/stdlib/toolchain/Compatibility56/include/Runtime/Concurrency.h
@@ -81,14 +81,9 @@ using FutureAsyncSignature =
 ///
 /// This has no effect if the task already has at least the given priority.
 /// Returns the priority of the task.
-SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-JobPriority
-swift_task_escalateBackdeploy56(AsyncTask *task, JobPriority newPriority);
-
-/// Return the current thread's active task reference.
-SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-AsyncTask *swift_task_getCurrent(void);
-
+SWIFT_CC(swift)
+JobPriority swift_task_escalateBackdeploy56(AsyncTask *task,
+                                            JobPriority newPriority);
 } // namespace swift
 
 #pragma clang diagnostic pop

--- a/stdlib/toolchain/Compatibility56/include/Runtime/Threading/Once.h
+++ b/stdlib/toolchain/Compatibility56/include/Runtime/Threading/Once.h
@@ -46,7 +46,6 @@ typedef std::once_flag swift_once_t;
 /// Runs the given function with the given context argument exactly once.
 /// The predicate argument must point to a global or static variable of static
 /// extent of type swift_once_t.
-SWIFT_RUNTIME_EXPORT
 void swift_once(swift_once_t *predicate, void (*fn)(void *), void *context);
 
 }


### PR DESCRIPTION
Symbols from the backdeploy libraries shouldn't be exported by dylibs.

Also found an undefined declaration (asyncMainDrainQueue) and a duplicate declaration for `swift_task_getCurrent`, so those were cleaned up.

This prevents the symbols from showing up in the exported symbol tables.

rdar://101002568