### PR TITLE
[PrunedLiveness] Addressed boundary TODO.

### DIFF
--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -66,6 +66,7 @@
 
 #include "swift/AST/Type.h"
 #include "swift/Basic/TaggedUnion.h"
+#include "swift/SIL/PrunedLiveness.h"
 #include "swift/SIL/SILArgumentArrayRef.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILBridging.h"
@@ -217,6 +218,24 @@ struct VisitAdjacentReborrowsOfPhiTest : UnitTest {
   }
 };
 
+// Arguments:
+// - variadic list of - instruction: a last user
+// Dumps:
+// - the insertion points
+struct PrunedLivenessBoundaryWithListOfLastUsersInsertionPointsTest : UnitTest {
+  PrunedLivenessBoundaryWithListOfLastUsersInsertionPointsTest(
+      UnitTestRunner *pass)
+      : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    PrunedLivenessBoundary boundary;
+    while (arguments.hasUntaken()) {
+      boundary.lastUsers.push_back(arguments.takeInstruction());
+    }
+    boundary.visitInsertionPoints(
+        [](SILBasicBlock::iterator point) { point->dump(); });
+  }
+};
+
 // Arguments: NONE
 // Dumps:
 // - the function
@@ -273,6 +292,9 @@ class UnitTestRunner : public SILFunctionTransform {
                            VisitAdjacentReborrowsOfPhiTest)
     ADD_UNIT_TEST_SUBCLASS("function-get-self-argument-index",
                            FunctionGetSelfArgumentIndex)
+    ADD_UNIT_TEST_SUBCLASS(
+        "pruned-liveness-boundary-with-list-of-last-users-insertion-points",
+        PrunedLivenessBoundaryWithListOfLastUsersInsertionPointsTest)
     /// [new_tests] Add the new mapping from string to subclass above this line.
 
 #undef ADD_UNIT_TEST_SUBCLASS

--- a/test/SILOptimizer/pruned_liveness_boundary.sil
+++ b/test/SILOptimizer/pruned_liveness_boundary.sil
@@ -1,0 +1,22 @@
+// RUN: %target-sil-opt -unit-test-runner %s 2>&1 | %FileCheck %s
+
+// CHECK: begin running test 1 of {{[^,]+}} on last_uses_merge_points: dump-function
+// CHECK: [[REGISTER_3:%[^,]+]] = tuple ()
+// CHECK: return [[REGISTER_3]]
+// CHECK: end running test 1 of {{[^,]+}} on last_uses_merge_points: dump-function
+// CHECK: begin running test 2 of {{[^,]+}} on last_uses_merge_points: pruned-liveness-boundary-with-list-of-last-users-insertion-points
+// CHECK: [[REGISTER_3]] = tuple ()
+// CHECK: end running test 2 of {{[^,]+}} on last_uses_merge_points: pruned-liveness-boundary-with-list-of-last-users-insertion-points
+sil [ossa] @last_uses_merge_points : $@convention(thin) () -> () {
+entry:
+  test_specification "dump-function"
+  test_specification "pruned-liveness-boundary-with-list-of-last-users-insertion-points @block[1].instruction[0] @block[2].instruction[0]"
+  cond_br undef, left, right
+left:
+  br bottom
+right:
+  br bottom
+bottom:
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
 With guaranteed phis, we'll be able to encounter cases where the last users are BranchInsts which use but don't consume a value.  But even without them, we can still test the API.
