### PR TITLE
[CXX-Interop] Improve support for anon enums with attributes

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5683,7 +5683,8 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
   // use the enum, not the typedef here.
   if (auto typedefType = dyn_cast<clang::TypedefType>(propertyType.getTypePtr())) {
     if (Impl.isUnavailableInSwift(typedefType->getDecl())) {
-      if (auto clangEnum = findAnonymousEnumForTypedef(Impl.SwiftContext, typedefType)) {
+      if (auto clangEnum = findAnonymousEnumForTypedef(
+              Impl.SwiftContext, Impl.getNameImporter(), typedefType)) {
         // If this fails, it means that we need a stronger predicate for
         // determining the relationship between an enum and typedef.
         assert(clangEnum.getValue()->getIntegerType()->getCanonicalTypeInternal() ==

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -399,6 +399,11 @@ public:
                           clang::DeclarationName preferredName =
                             clang::DeclarationName());
 
+  ImportedName importNameWithAttrs(
+      const clang::NamedDecl *decl, ImportNameVersion version,
+      const clang::AttrVec &attrs,
+      clang::DeclarationName preferredName = clang::DeclarationName());
+
   /// Attempts to import the name of \p decl with each possible
   /// ImportNameVersion. \p action will be called with each unique name.
   ///
@@ -496,6 +501,14 @@ private:
   ImportedName importNameImpl(const clang::NamedDecl *,
                               ImportNameVersion version,
                               clang::DeclarationName);
+
+  // Performs importNameImpl, but with additional attributes attached to the
+  // ClangNode. To be used when the name of one Clang node is to be
+  // imported in terms of the name of another, but with additional attributes.
+  ImportedName importNameImplWithAttrs(const clang::NamedDecl *decl,
+                                       ImportNameVersion version,
+                                       clang::DeclarationName givenName,
+                                       const clang::AttrVec &attrs);
 };
 
 }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2114,7 +2114,8 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
 
   if (auto typedefType = dyn_cast<clang::TypedefType>(clangDecl->getReturnType().getTypePtr())) {
     if (isUnavailableInSwift(typedefType->getDecl())) {
-      if (auto clangEnum = findAnonymousEnumForTypedef(SwiftContext, typedefType)) {
+      if (auto clangEnum = findAnonymousEnumForTypedef(
+              SwiftContext, getNameImporter(), typedefType)) {
         // If this fails, it means that we need a stronger predicate for
         // determining the relationship between an enum and typedef.
         assert(clangEnum.getValue()->getIntegerType()->getCanonicalTypeInternal() ==
@@ -2176,7 +2177,8 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
                                 clangDecl->getSourceRange().getBegin());
   if (auto typedefType = dyn_cast<clang::TypedefType>(clangDecl->getReturnType().getTypePtr())) {
     if (isUnavailableInSwift(typedefType->getDecl())) {
-      if (auto clangEnum = findAnonymousEnumForTypedef(SwiftContext, typedefType)) {
+      if (auto clangEnum = findAnonymousEnumForTypedef(
+              SwiftContext, getNameImporter(), typedefType)) {
         // If this fails, it means that we need a stronger predicate for
         // determining the relationship between an enum and typedef.
         assert(clangEnum.getValue()->getIntegerType()->getCanonicalTypeInternal() ==
@@ -2272,8 +2274,8 @@ ClangImporter::Implementation::importParameterType(
   // use the enum, not the typedef here.
   if (auto typedefType = dyn_cast<clang::TypedefType>(paramTy.getTypePtr())) {
     if (isUnavailableInSwift(typedefType->getDecl())) {
-      if (auto clangEnum =
-              findAnonymousEnumForTypedef(SwiftContext, typedefType)) {
+      if (auto clangEnum = findAnonymousEnumForTypedef(
+              SwiftContext, getNameImporter(), typedefType)) {
         // If this fails, it means that we need a stronger predicate for
         // determining the relationship between an enum and typedef.
         assert(clangEnum.getValue()
@@ -2865,7 +2867,8 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
   ImportedType importedType;
   if (auto typedefType = dyn_cast<clang::TypedefType>(resultType.getTypePtr())) {
     if (isUnavailableInSwift(typedefType->getDecl())) {
-      if (auto clangEnum = findAnonymousEnumForTypedef(SwiftContext, typedefType)) {
+      if (auto clangEnum = findAnonymousEnumForTypedef(
+              SwiftContext, getNameImporter(), typedefType)) {
         // If this fails, it means that we need a stronger predicate for
         // determining the relationship between an enum and typedef.
         assert(clangEnum.getValue()->getIntegerType()->getCanonicalTypeInternal() ==

--- a/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
@@ -18,6 +18,7 @@ extern "C" {
 #define CF_OPTIONS(_type, _name) _type __attribute__((availability(swift, unavailable))) _name; enum __CF_OPTIONS_ATTRIBUTES : _name
 #define NS_OPTIONS(_type, _name) CF_OPTIONS(_type, _name)
 #define NS_REFINED_FOR_SWIFT __attribute__((swift_private))
+#define NS_SWIFT_NAME(_name) __attribute__((swift_name(#_name)))
 
 typedef unsigned long NSUInteger;
 
@@ -32,11 +33,18 @@ typedef NS_OPTIONS(NSUInteger, NSAttributedStringFormattingOptions) {
   NSAttributedStringFormattingApplyReplacementIndexAttribute = 1 << 1,
 } NS_REFINED_FOR_SWIFT;
 
+typedef NS_OPTIONS(NSUInteger, NSNameThatWillNotBeUsed) {
+  NSNameThatWillNotBeUsedMemberOne = 1 << 0,
+  NSNameThatWillNotBeUsedMemberTwo = 1 << 1,
+} NS_SWIFT_NAME(SomeCustomName);
+
 @interface NSAttributedString
 @end
 
 @interface NSAttributedString (NSAttributedStringFormatting)
 - (instancetype)initWithOptions:(NSAttributedStringFormattingOptions)options
+    NS_REFINED_FOR_SWIFT;
+- (instancetype)initWithOtherOptions:(NSNameThatWillNotBeUsed)options
     NS_REFINED_FOR_SWIFT;
 @end
 }

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-with-attributes.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-with-attributes.swift
@@ -18,6 +18,26 @@ import CenumsNSOptions
 // CHECK-NEXT:   static var ApplyReplacementIndexAttribute: __NSAttributedStringFormattingOptions { get }
 // CHECK-NEXT: }
 
+// CHECK:      @available(*, unavailable, message: "Not available in Swift")
+// CHECK-NEXT: typealias NSNameThatWillNotBeUsed = UInt
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "SomeCustomName")
+// CHECK-NEXT: typealias NSNameThatWillNotBeUsed = SomeCustomName
+// CHECK-NEXT: struct SomeCustomName : OptionSet, @unchecked Sendable {
+// CHECK-NEXT:   init(rawValue: UInt)
+// CHECK-NEXT:   let rawValue: UInt
+// CHECK-NEXT:   typealias RawValue = UInt
+// CHECK-NEXT:   typealias Element = SomeCustomName
+// CHECK-NEXT:   typealias ArrayLiteralElement = SomeCustomName
+// CHECK-NEXT:   static var memberOne: SomeCustomName { get }
+// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "memberOne")
+// CHECK-NEXT:   static var MemberOne: SomeCustomName { get }
+// CHECK-NEXT:   static var memberTwo: SomeCustomName { get }
+// CHECK-NEXT:   @available(swift, obsoleted: 3, renamed: "memberTwo")
+// CHECK-NEXT:   static var MemberTwo: SomeCustomName { get }
+// CHECK-NEXT: }
+
 // CHECK:      extension NSAttributedString {
 // CHECK-NEXT:   init!(__options options: __NSAttributedStringFormattingOptions = [])
+// CHECK-NEXT:   init!(__otherOptions options: SomeCustomName)
 // CHECK-NEXT: }
+


### PR DESCRIPTION
When cxx-interop is enabled, the NS_OPTIONS macro expands to a typedef for a NSUInteger and an anonymous enum backed by this new type. To achieve the intended semantics of NS_OPTION when imported into Swift, the anonymous enum is imported under the typedef's name, and references to the typedef are resolved to the enum.

Prior to this patch, the imported name for the two entities would not respect some attributes attached to the anonymous enum. This patch fixes this and stops associating the two by Swift name, which allows us to respect attributes such as swift_name that produce an arbitrary Swift name.