### PR TITLE
Add an `_unsafeAssumeOnMainActor` utility

### DIFF
--- a/test/Concurrency/Runtime/unsafe_assume_executor.swift
+++ b/test/Concurrency/Runtime/unsafe_assume_executor.swift
@@ -1,0 +1,41 @@
+// RUN: %target-run-simple-swift(-parse-as-library -Xfrontend -disable-availability-checking %import-libdispatch) 2>&1 | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: libdispatch
+
+// REQUIRES: concurrency_runtime
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: single_threaded_concurrency
+
+import Foundation
+
+enum SomeError: Error {
+  case whatever
+}
+
+@MainActor func expectOnMainThreadIs(_ expectation: Bool) {
+  assert(expectation == Thread.isMainThread)
+}
+
+@main
+struct Main {
+  static func main() async {
+    do {
+      try _unsafeAssumeOnMainActor {
+        expectOnMainThreadIs(true)
+        throw SomeError.whatever
+      }
+      fatalError("bug")
+    } catch {}
+
+    _ = await (Task.detached {
+      // CHECK: warning: data race detected: @MainActor function at {{.*}}unsafe_assume_executor.swift:34 was not called on the main thread
+      _unsafeAssumeOnMainActor {
+        expectOnMainThreadIs(false)
+      }
+    }).result
+    // CHECK-NOT: warning
+
+  }
+}


### PR DESCRIPTION
This unofficial stdlib utility is designed to help you
adopt Swift concurrency progressively. You can use this
to help introduce a (totally) unsafe context which is allowed
to access things that are MainActor-isolated _without_ having
to `await` the MainActor operation closure.

This is totally unsafe in the sense that the runtime check
prior to invoking the MainActor operation is primarily there
for debugging purposes. You can customize its behavior to range
from ignoring failures, logging them, or triggering a fatal error.

So, even if you're not on the main thread, the operation may be
called anyway, which creates a race. I suggest not having this
utility appear in production releases of your software.

resolves rdar://101047674