### PR TITLE
[DebugInfo] Respect debug-prefix-map when emitting path to PCM in Skeleton CUs

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -725,6 +725,7 @@ private:
       return cast<llvm::DIModule>(Val->second);
 
     std::string RemappedIncludePath = DebugPrefixMap.remapPath(IncludePath);
+    std::string RemappedASTFile = DebugPrefixMap.remapPath(ASTFile);
 
     // For Clang modules / PCH, create a Skeleton CU pointing to the PCM/PCH.
     if (!Opts.DisableClangModuleSkeletonCUs) {
@@ -736,7 +737,7 @@ private:
                                               : llvm::dwarf::DW_LANG_C99,
                               DIB.createFile(Name, RemappedIncludePath),
                               TheCU->getProducer(), true, StringRef(), 0,
-                              ASTFile, llvm::DICompileUnit::FullDebug,
+                              RemappedASTFile, llvm::DICompileUnit::FullDebug,
                               Signature);
         DIB.finalize();
       }

--- a/test/DebugInfo/ClangModuleBreadcrumbs.swift
+++ b/test/DebugInfo/ClangModuleBreadcrumbs.swift
@@ -4,6 +4,12 @@
 // RUN: %target-swift-frontend -emit-ir %s -g -I %S/Inputs \
 // RUN:   -Xcc -DFOO="foo" -Xcc -UBAR -o - -no-clang-module-breadcrumbs \
 // RUN:   | %FileCheck %s --check-prefix=NONE
+//
+// RUN: %target-swift-frontend -module-cache-path %t.mcp -emit-ir %s \
+// RUN:   -g -I %S/Inputs -Xcc -DFOO="foo" -Xcc -UBAR \
+// RUN:   -debug-prefix-map %t.mcp=PREFIX \
+// RUN:   -o - | %FileCheck %s --check-prefix=REMAP
+
 import ClangModule.SubModule
 import OtherClangModule.SubModule
 
@@ -24,3 +30,15 @@ let _ = someFunc(0)
 
 // NONE: DICompileUnit({{.*}}
 // NONE-NOT: DICompileUnit({{.*}}ClangModule
+
+// REMAP: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},{{.*}} producer: "{{.*}}Swift
+// REMAP-SAME:           PREFIX{{/|\\\\}}{{.*}}{{/|\\\\}}ClangModule
+// REMAP-SAME:           dwoId:
+
+// REMAP: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},{{.*}} producer: "{{.*}}Swift
+// REMAP-SAME:           PREFIX{{/|\\\\}}{{.*}}{{/|\\\\}}OtherClangModule
+// REMAP-SAME:           dwoId:
+
+// REMAP: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},{{.*}} producer: "{{.*}}clang
+// REMAP-SAME:           PREFIX{{/|\\\\}}{{.*}}{{/|\\\\}}ClangModule
+// REMAP-SAME:           dwoId:


### PR DESCRIPTION
The `splitDebugFilename` field doesn't respect the debug-prefix-map, making it difficult to produce relocatable debug info.