### PR TITLE
Sema: Ensure that use of availability macros in closures in fragile functions is diagnosed

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -471,24 +471,6 @@ bool TypeChecker::typeCheckStmtConditionElement(StmtConditionElement &elt,
   // Typecheck a #available or #unavailable condition.
   if (elt.getKind() == StmtConditionElement::CK_Availability) {
     isFalsable = true;
-
-    // Reject inlinable code using availability macros.
-    PoundAvailableInfo *info = elt.getAvailability();
-    if (auto *decl = dc->getAsDecl()) {
-      auto fragileKind = dc->getFragileFunctionKind();
-      if (fragileKind.kind != FragileFunctionKind::None)
-        for (auto queries : info->getQueries())
-          if (auto availSpec =
-                  dyn_cast<PlatformVersionConstraintAvailabilitySpec>(queries))
-            if (availSpec->getMacroLoc().isValid()) {
-              Context.Diags.diagnose(
-                  availSpec->getMacroLoc(),
-                  swift::diag::availability_macro_in_inlinable,
-                  fragileKind.getSelector());
-              break;
-            }
-    }
-
     return false;
   }
 

--- a/test/Sema/availability_define.swift
+++ b/test/Sema/availability_define.swift
@@ -66,6 +66,10 @@ func client() {
   if #available(_unknownMacro, *) { } // expected-error {{expected version number}}
 }
 
+public func doIt(_ closure: () -> ()) {
+  closure()
+}
+
 @inlinable
 public func forbidMacrosInInlinableCode() {
   if #available(_iOS9Aligned, *) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
@@ -74,6 +78,9 @@ public func forbidMacrosInInlinableCode() {
   if #unavailable(_iOS9Aligned) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
   if #unavailable(_iOS9, _macOS10_11) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
   if #unavailable(iOS 9.0, _macOS10_11, tvOS 9.0) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
+  doIt {
+    if #available(_iOS9Aligned, *) { } // expected-error {{availability macro cannot be used in an '@inlinable' function}}
+  }
 }
 
 @_alwaysEmitIntoClient
@@ -84,6 +91,9 @@ public func forbidMacrosInInlinableCode1() {
   if #unavailable(_iOS9Aligned) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
   if #unavailable(_iOS9, _macOS10_11) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
   if #unavailable(iOS 9.0, _macOS10_11, tvOS 9.0) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+  doIt {
+    if #available(_iOS9Aligned, *) { } // expected-error {{availability macro cannot be used in an '@_alwaysEmitIntoClient' function}}
+  }
 }
 
 @available(_iOS8Aligned, *)
@@ -95,4 +105,7 @@ public func forbidMacrosInInlinableCode2() {
   if #unavailable(_iOS9Aligned) { } // expected-error {{availability macro cannot be used in a '@_backDeploy' function}}
   if #unavailable(_iOS9, _macOS10_11) { } // expected-error {{availability macro cannot be used in a '@_backDeploy' function}}
   if #unavailable(iOS 9.0, _macOS10_11, tvOS 9.0) { } // expected-error {{availability macro cannot be used in a '@_backDeploy' function}}
+  doIt {
+    if #available(_iOS9Aligned, *) { } // expected-error {{availability macro cannot be used in a '@_backDeploy' function}}
+  }
 }

--- a/test/Sema/has_symbol.swift
+++ b/test/Sema/has_symbol.swift
@@ -115,18 +115,21 @@ func testWhile() {
   while #_hasSymbol(localFunc) { break } // expected-warning {{global function 'localFunc()' is not a weakly linked declaration}}
 }
 
+func doIt(_ closure: () -> ()) {
+  closure()
+}
+
 @inlinable
 func testInlinable() {
   if #_hasSymbol(noArgFunc) {} // expected-error {{'#_hasSymbol' cannot be used in an '@inlinable' function}}
+  doIt {
+    if #_hasSymbol(noArgFunc) {} // expected-error {{'#_hasSymbol' cannot be used in an '@inlinable' function}}
+  }
 }
 
 @_alwaysEmitIntoClient
 func testAEIC() {
   if #_hasSymbol(noArgFunc) {} // expected-error {{'#_hasSymbol' cannot be used in an '@_alwaysEmitIntoClient' function}}
-}
-
-func doIt(_ closure: () -> ()) {
-  closure()
 }
 
 func testClosure() {


### PR DESCRIPTION
Type checking of closure bodies does not invoke `TypeChecker::typeCheckStmtConditionElement()` so use of availability macros inside closure bodies written in fragile (inlinable) functions was undiagnosed. Move the diagnostic logic to `MiscDiagnostics.cpp` which implements diagnostics that are emitted regardless of the typechecking model used.

Additionally, remove the `DC->getAsDecl() != nullptr` check from `diagnoseHasSymbolCondition()` which was preventing similar fragile function diagnostics for `if #_hasSymbol` from being emitted when a closure was involved.

Resolves rdar://100581013
