### PR TITLE
[OpaqueValues] Fixed index of self argument.

### DIFF
--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -183,10 +183,12 @@ SwiftInt SILFunction_numParameterArguments(BridgedFunction function) {
 }
 
 SwiftInt SILFunction_getSelfArgumentIndex(BridgedFunction function) {
+  SILFunction *f = castToFunction(function);
+  SILFunctionConventions conv(f->getConventionsInContext());
   CanSILFunctionType fTy = castToFunction(function)->getLoweredFunctionType();
   if (!fTy->hasSelfParam())
     return -1;
-  return fTy->getNumParameters() + fTy->getNumIndirectFormalResults() - 1;
+  return conv.getNumParameters() + conv.getNumIndirectSILResults() - 1;
 }
 
 SwiftInt SILFunction_getNumSILArguments(BridgedFunction function) {

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -238,10 +238,9 @@ class UnitTestRunner : public SILFunctionTransform {
       llvm::errs() << components[index];
       if (index != size - 1) {
         llvm::errs() << ", ";
-      } else {
-        llvm::errs() << "\n";
       }
     }
+    llvm::errs() << "\n";
   }
 
   template <typename Doit>

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -68,6 +68,7 @@
 #include "swift/Basic/TaggedUnion.h"
 #include "swift/SIL/SILArgumentArrayRef.h"
 #include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILBridging.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
@@ -224,6 +225,17 @@ struct DumpFunction : UnitTest {
   void invoke(Arguments &arguments) override { getFunction()->dump(); }
 };
 
+// Arguments: NONE
+// Dumps: the index of the self argument of the current function
+struct FunctionGetSelfArgumentIndex : UnitTest {
+  FunctionGetSelfArgumentIndex(UnitTestRunner *pass) : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    auto index =
+        SILFunction_getSelfArgumentIndex(BridgedFunction{getFunction()});
+    llvm::errs() << "self argument index = " << index << "\n";
+  }
+};
+
 /// [new_tests] Add the new UnitTest subclass above this line.
 
 class UnitTestRunner : public SILFunctionTransform {
@@ -259,6 +271,8 @@ class UnitTestRunner : public SILFunctionTransform {
                            CanonicalizeOSSALifetimeTest)
     ADD_UNIT_TEST_SUBCLASS("visit-adjacent-reborrows-of-phi",
                            VisitAdjacentReborrowsOfPhiTest)
+    ADD_UNIT_TEST_SUBCLASS("function-get-self-argument-index",
+                           FunctionGetSelfArgumentIndex)
     /// [new_tests] Add the new mapping from string to subclass above this line.
 
 #undef ADD_UNIT_TEST_SUBCLASS

--- a/test/SILOptimizer/opaque_values_unit.sil
+++ b/test/SILOptimizer/opaque_values_unit.sil
@@ -1,0 +1,21 @@
+// RUN: %target-sil-opt -enable-sil-opaque-values -unit-test-runner %s 2>&1 | %FileCheck %s
+
+import Builtin
+
+class C {}
+
+// Verify that SILFunction_getSelfArgumentIndex respects SILFunctionConventions
+// and returns right value even in the presence of indirect results.
+//
+// CHECK-LABEL: begin running test 1 of {{[^,]+}} on f: function-get-self-argument-index
+// The correct value is 0 here when opaque values are enabled because the result
+// is just returned.  It could mistakenly be calculated as 1 though because
+// after AddressLowering there will be a new argument at index 0 for the
+// indirect result.
+// CHECK:       self argument index = 0
+// CHECK-LABEL: end running test 1 of {{[^,]+}} on f: function-get-self-argument-index
+sil [ossa] @f : $@convention(method) <T> (@guaranteed C) -> @out T {
+entry(%instance : @guaranteed $C):
+    test_specification "function-get-self-argument-index"
+    unreachable
+}


### PR DESCRIPTION
Previously, SILFunction_getSelfArgumentIndex was directly using the function type rather than interacting with the function convention. Here, it is made to interact with the convention.
