### PR TITLE
Sema: Fix crash when pre-checking expression of the form P(<<literal>>) where P is a protocol

### DIFF
--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -2119,8 +2119,7 @@ Expr *PreCheckExpression::simplifyTypeConstructionWithLiteralArg(Expr *E) {
       return nullptr;
   }
 
-  SmallVector<ProtocolConformance *, 2> conformances;
-  return castTy->getAnyNominal()->lookupConformance(protocol, conformances)
+  return DC->getParentModule()->lookupConformance(castTy, protocol)
              ? CoerceExpr::forLiteralInit(getASTContext(), literal,
                                           call->getSourceRange(),
                                           typeExpr->getTypeRepr())

--- a/test/Constraints/protocols.swift
+++ b/test/Constraints/protocols.swift
@@ -533,3 +533,16 @@ func f1_58231(x: Int) -> P_58231 {
 func f2_58231(x: Int) -> P_58231? {
   return S_58231() // expected-error{{return expression of type 'S_58231' does not conform to 'P_58231'}}
 }
+
+// https://github.com/apple/swift/issues/61517
+
+protocol P_61517 {
+  init()
+  init(_: Bool)
+}
+
+_ = P_61517() // expected-error{{type 'any P_61517' cannot be instantiated}}
+_ = P_61517(false) // expected-error{{type 'any P_61517' cannot be instantiated}}
+
+_ = P_61517.init() // expected-error{{type 'any P_61517' cannot be instantiated}}
+_ = P_61517.init(false) // expected-error{{type 'any P_61517' cannot be instantiated}}


### PR DESCRIPTION
Fixes https://github.com/apple/swift/issues/61517