### PR TITLE
[NFC][AST] Change TypeBase::getOptionalityDepth() implementation to not use a vector

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -906,9 +906,13 @@ Type TypeBase::lookThroughAllOptionalTypes(SmallVectorImpl<Type> &optionals){
 }
 
 unsigned int TypeBase::getOptionalityDepth() {
-  SmallVector<Type> types;
-  lookThroughAllOptionalTypes(types);
-  return types.size();
+  Type type(this);
+  unsigned int depth = 0;
+  while (auto objType = type->getOptionalObjectType()) {
+    type = objType;
+    ++depth;
+  }
+  return depth;
 }
 
 Type TypeBase::stripConcurrency(bool recurse, bool dropGlobalActor) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Just an NFC, improving implementation of TypeBase::getOptionalityDepth() to now use a vector, since is not needed.

