### PR TITLE
swift-api-extract: extract decls with @_spi_available attributes as SPI

### DIFF
--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -1354,6 +1354,10 @@ void swift::writeTBDFile(ModuleDecl *M, llvm::raw_ostream &os,
 }
 
 class APIGenRecorder final : public APIRecorder {
+  bool isSPI(const ValueDecl* VD) {
+    assert(VD);
+    return VD->isSPI() || VD->isAvailableAsSPI();
+  }
 public:
   APIGenRecorder(apigen::API &api, ModuleDecl *module)
       : api(api), module(module) {
@@ -1373,13 +1377,13 @@ public:
       auto ref = source.getSILDeclRef();
       if (ref.hasDecl()) {
         availability = getAvailability(ref.getDecl());
-        if (ref.getDecl()->isSPI())
+        if (isSPI(ref.getDecl()))
           access = apigen::APIAccess::Private;
       }
     } else if (source.kind == SymbolSource::Kind::IR) {
       auto ref = source.getIRLinkEntity();
       if (ref.hasDecl()) {
-        if (ref.getDecl()->isSPI())
+        if (isSPI(ref.getDecl()))
           access = apigen::APIAccess::Private;
       }
     }

--- a/test/APIJSON/spi.swift
+++ b/test/APIJSON/spi.swift
@@ -17,6 +17,10 @@ public class MyClass2 : NSObject {
   @_spi(Experimental) @objc public func spiMethod() {}
 }
 
+@_spi_available(macOS 10.10, tvOS 14.0, *)
+@available(iOS 8.0, *)
+public func spiAvailableFunc() {}
+
 // CHECK:      {
 // CHECK-NEXT:   "target":
 // CHECK-NEXT:   "globals": [
@@ -61,6 +65,13 @@ public class MyClass2 : NSObject {
 // CHECK-NEXT:       "access": "public",
 // CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
 // CHECK-NEXT:       "linkage": "exported"
+// CHECK-NEXT:     },
+// CHECK-NEXT:     {
+// CHECK-NEXT:       "name": "_$s8MyModule16spiAvailableFuncyyF",
+// CHECK-NEXT:       "access": "public",
+// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
+// CHECK-NEXT:       "linkage": "exported",
+// CHECK-NEXT:       "unavailable": true
 // CHECK-NEXT:     },
 // CHECK-NEXT:     {
 // CHECK-NEXT:       "name": "_OBJC_CLASS_$__TtC8MyModule8MyClass2",
@@ -224,6 +235,13 @@ public class MyClass2 : NSObject {
 // CHECK-SPI-NEXT:       "access": "private",
 // CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
 // CHECK-SPI-NEXT:       "linkage": "exported"
+// CHECK-SPI-NEXT:     },
+// CHECK-SPI-NEXT:    {
+// CHECK-SPI-NEXT:       "name": "_$s8MyModule16spiAvailableFuncyyF",
+// CHECK-SPI-NEXT:       "access": "private",
+// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
+// CHECK-SPI-NEXT:       "linkage": "exported",
+// CHECK-SPI-NEXT:       "introduced": "10.10"
 // CHECK-SPI-NEXT:     },
 // CHECK-SPI-NEXT:     {
 // CHECK-SPI-NEXT:       "name": "_OBJC_CLASS_$__TtC8MyModule7MyClass",


### PR DESCRIPTION
Working similarly as SPI_AVAILABLE in Clang, Swift decls marked with @_spi_available should be considered private
