### PR TITLE
[caller-analysis] fix typo in CallerAnalysis.h

### DIFF
--- a/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/CallerAnalysis.h
@@ -180,7 +180,7 @@ private:
   void verify(SILFunction *caller, const FunctionInfo &callerInfo) const;
 };
 
-/// Auxillary information that we store about a specific caller.
+/// Auxiliary information that we store about a specific caller.
 struct CallerAnalysis::CallerInfo {
   /// Given a SILFunction F that contains at least one partial apply of the
   /// given function, map F to the minimum number of partial applied


### PR DESCRIPTION
Auxillary -> Auxiliary

