### PR TITLE
Improve error message when a C++ projection is unavailable in Swift

### DIFF
--- a/include/swift/AST/DiagnosticsClangImporter.def
+++ b/include/swift/AST/DiagnosticsClangImporter.def
@@ -157,17 +157,24 @@ NOTE(reference_passed_by_value, none, "function uses foreign reference type "
                                       "'import_reference' contract (outlined in "
                                       "C++ Interop User Manual).",
      (StringRef, StringRef))
+
 NOTE(record_not_automatically_importable, none, "record '%0' is not "
                                                 "automatically importable: %1. "
                                                 "Refer to the C++ Interop User "
                                                 "Manual to classify this type.",
      (StringRef, StringRef))
-NOTE(projection_not_imported, none, "C++ method '%0' that returns unsafe "
-                                    "projection of type '%1' not imported",
-     (StringRef, StringRef))
-NOTE(dont_use_iterator_api, none, "C++ method '%0' that returns an unsafe "
-                                  "iterator not imported: use Swift Sequence "
-                                  "APIs instead",
+
+NOTE(projection_not_imported, none, "C++ method '%0' is unavailable in Swift "
+                                    "as it returns an address (or struct containing an address).",
+     (StringRef))
+
+NOTE(projection_not_imported_because, none, "the address returned by '%0' may outlive the value it "
+                                    "references resulting in an use-after-free.",
+     (StringRef))
+
+NOTE(dont_use_iterator_api, none, "'%0' is unavailable in Swift as it returns a C++ iterator; "
+                                   "Use 'for-in' loop or 'Sequence' methods such as 'map', "
+                                   "'reduce' to iterate over the collection",
      (StringRef))
 
 ERROR(reference_type_must_have_retain_attr,none,

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -3711,7 +3711,7 @@ static void diagnoseUnsafeCxxMethod(SourceLoc loc, Type baseType,
   auto &ctx = baseType->getASTContext();
 
   if (baseType->getAnyNominal() == nullptr ||
-      // Don't waist time on non-cxx-methods.
+      // The following diagnostics only apply to C++ methods.
       !isa_and_nonnull<clang::CXXRecordDecl>(
           baseType->getAnyNominal()->getClangDecl()))
     return;
@@ -3729,21 +3729,20 @@ static void diagnoseUnsafeCxxMethod(SourceLoc loc, Type baseType,
         name.getBaseIdentifier().str() == "end") {
       ctx.Diags.diagnose(loc, diag::dont_use_iterator_api,
                          name.getBaseIdentifier().str());
-    } else if (cxxMethod->getReturnType()->isPointerType())
+    } else if (cxxMethod->getReturnType()->isPointerType()) {
       ctx.Diags.diagnose(loc, diag::projection_not_imported,
-                         name.getBaseIdentifier().str(), "pointer");
-    else if (cxxMethod->getReturnType()->isReferenceType())
-      ctx.Diags.diagnose(loc, diag::projection_not_imported,
-                         name.getBaseIdentifier().str(), "reference");
-    else if (cxxMethod->getReturnType()->isRecordType()) {
+                         name.getBaseIdentifier().str());
+    } else if (cxxMethod->getReturnType()->isReferenceType()) {
+      ctx.Diags.diagnose(loc, diag::projection_not_imported_because,
+                         name.getBaseIdentifier().str());
+    } else if (cxxMethod->getReturnType()->isRecordType()) {
       if (auto cxxRecord = dyn_cast<clang::CXXRecordDecl>(
               cxxMethod->getReturnType()->getAsRecordDecl())) {
         assert(evaluateOrDefault(ctx.evaluator,
                                  CxxRecordSemantics({cxxRecord, ctx}), {}) ==
                CxxRecordSemanticsKind::UnsafePointerMember);
         ctx.Diags.diagnose(loc, diag::projection_not_imported,
-                           name.getBaseIdentifier().str(),
-                           cxxRecord->getNameAsString());
+                           name.getBaseIdentifier().str());
       }
     }
   }


### PR DESCRIPTION
This commit improves the error message when a C++ projection is unavailable in Swift.
Original message:
```
error: Value of type 'Players' (aka 'std.__1.__CxxTemplateInstNSt3__16vectorI6PlayerNS_9allocatorIS1_EEEE') has no member 'begin'
note: C++ method 'begin' that returns an unsafe iterator not imported: use Swift Sequence APIs instead
```
Changed to:
```
error: 'begin' is unavailable in Swift as it returns a C++ iterator. Use 'for-in' loop or 'Sequence' methods such as 'map', 'reduce' to iterate over the collection.
```