### PR TITLE
Swift Optimizer: make the RunUnitTests a module pass

### DIFF
--- a/SwiftCompilerSources/Sources/Basic/Utils.swift
+++ b/SwiftCompilerSources/Sources/Basic/Utils.swift
@@ -24,7 +24,6 @@ import std
 public func assert(_ condition: Bool, _ message: @autoclosure () -> String,
                    file: StaticString = #fileID, line: UInt = #line) {
   if !condition {
-    print("### basic")
     fatalError(message(), file: file, line: line)
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/RunUnitTests.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/RunUnitTests.swift
@@ -14,8 +14,8 @@ import SIL
 
 /// This pass should only be used by sil-opt to run all the unit tests.
 ///
-let runUnitTests = FunctionPass(name: "run-unit-tests", {
-  (function: Function, context: PassContext) in
+let runUnitTests = ModulePass(name: "run-unit-tests", {
+    (context: ModulePassContext) in
 
   print("--- Run unit tests ---")
   

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -401,7 +401,7 @@ PASS(SILDebugInfoGenerator, "sil-debuginfo-gen",
      "Generate Debug Information with Source Locations into Textual SIL")
 PASS(EarlySROA, "early-sroa",
      "Scalar Replacement of Aggregate Stack Objects on high-level SIL")
-SWIFT_FUNCTION_PASS(RunUnitTests, "run-unit-tests",
+SWIFT_MODULE_PASS(RunUnitTests, "run-unit-tests",
      "Runs the compiler internal unit tests")
 SWIFT_FUNCTION_PASS(SILPrinter, "sil-printer",
      "Test pass which prints the SIL of a function")

--- a/test/SILOptimizer/swift-unit-tests.sil
+++ b/test/SILOptimizer/swift-unit-tests.sil
@@ -2,10 +2,3 @@
 
 // REQUIRES: swift_in_compiler
 
-// The RunUnitTests is a function pass. Therefore we need one function is this file to trigger the pass run.
-sil @trigger_test_run : $@convention(thin) () -> () {
-bb0:
-  %r = tuple()
-  return %r : $()
-}
-


### PR DESCRIPTION
Which makes more sense. At the time RunUnitTests was added, there were no module passes, yet.