### PR TITLE
Add workaround for implicit copy constructor generation problem.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -70,10 +70,21 @@ public:
   explicit RemoteRef(StoredPointer address, const T *localBuffer)
     : Address((uint64_t)address), LocalBuffer(localBuffer) {}
 
+  // <rdar://99715218> Some versions of clang++ sometimes fail to generate the
+  // copy constructor for this type correctly - add a workaround
+  RemoteRef(const RemoteRef &other)
+    : Address(other.Address), LocalBuffer(other.LocalBuffer) {}
+
+  RemoteRef& operator=(const RemoteRef &other) {
+    Address = other.Address;
+    LocalBuffer = other.LocalBuffer;
+    return *this;
+  }
+
   uint64_t getAddressData() const {
     return Address;
   }
-  
+
   const T *getLocalBuffer() const {
     return LocalBuffer;
   }


### PR DESCRIPTION
Some versions of Clang seem to generate a non-working implicit copy constructor for `RemoteRef<BuiltinTypeDescriptor>`, which results in all the reflection tests failing.  Fix by declaring it explicitly.

rdar://101240198
