### PR TITLE
Add matching operator!= for asymmetric operator==

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -274,8 +274,12 @@ struct ValueOwnershipKind {
   bool operator==(ValueOwnershipKind other) const {
     return value == other.value;
   }
+  bool operator!=(ValueOwnershipKind other) const {
+    return !(value == other.value);
+  }
 
   bool operator==(innerty other) const { return value == other; }
+  bool operator!=(innerty other) const { return !(value == other); }
 
   /// We merge by moving down the lattice.
   ValueOwnershipKind merge(ValueOwnershipKind rhs) const {


### PR DESCRIPTION
This helps clang to compile target in C++20 mode.

Context: https://github.com/llvm/llvm-project/issues/57711
