### PR TITLE
Revert "Revert "[cxx-interop][SwiftCompilerSources] Use C++ enums directly from Swift""

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/DataStructures/FunctionUses.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/DataStructures/FunctionUses.swift
@@ -134,7 +134,7 @@ struct FunctionUses {
 
     for witnessTable in context.witnessTables {
       for entry in witnessTable.entries {
-        if entry.kind == .method, let f = entry.methodFunction {
+        if entry.kind == .Method, let f = entry.methodFunction {
           markUnknown(f)
         }
       }
@@ -142,7 +142,7 @@ struct FunctionUses {
 
     for witnessTable in context.defaultWitnessTables {
       for entry in witnessTable.entries {
-        if entry.kind == .method, let f = entry.methodFunction {
+        if entry.kind == .Method, let f = entry.methodFunction {
           markUnknown(f)
         }
       }

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
@@ -124,7 +124,7 @@ private struct StackProtectionOptimization {
                                 mustFixStackNesting: inout Bool, _ context: PassContext) {
 
     // `withUnsafeTemporaryAllocation(of:capacity:_:)` is compiled to a `builtin "stackAlloc"`.
-    if let bi = instruction as? BuiltinInst, bi.id == .stackAlloc {
+    if let bi = instruction as? BuiltinInst, bi.id == .StackAlloc {
       function.setNeedsStackProtection(context)
       return
     }
@@ -332,7 +332,7 @@ private struct StackProtectionOptimization {
   /// Moves the value of a `beginAccess` to a temporary stack location, if possible.
   private func moveToTemporary(scope beginAccess: BeginAccessInst, mustFixStackNesting: inout Bool,
                                _ context: PassContext) {
-    if beginAccess.accessKind != .modify {
+    if beginAccess.accessKind != .Modify {
       // We can only move from a `modify` access.
       // Also, read-only accesses shouldn't be subject to buffer overflows (because
       // no one should ever write to such a storage).

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -441,7 +441,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
       return walkDownUses(ofAddress: pta, path: path.with(knownType: nil))
     case let bi as BuiltinInst:
       switch bi.id {
-      case .destroyArray:
+      case .DestroyArray:
         // If it's not the array base pointer operand -> bail. Though, that shouldn't happen
         // because the other operands (metatype, count) shouldn't be visited anyway.
         if operand.index != 1 { return isEscaping }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -334,19 +334,10 @@ final public class LoadUnownedInst : SingleValueInstruction, UnaryInstruction {}
 final public class LoadBorrowInst : SingleValueInstruction, UnaryInstruction {}
 
 final public class BuiltinInst : SingleValueInstruction {
-  // TODO: find a way to directly reuse the BuiltinValueKind enum
-  public enum ID  {
-    case none
-    case destroyArray
-    case stackAlloc
-  }
+  public typealias ID = swift.BuiltinValueKind
 
   public var id: ID {
-    switch BuiltinInst_getID(bridged) {
-      case DestroyArrayBuiltin: return .destroyArray
-      case StackAllocBuiltin: return .stackAlloc
-      default: return .none
-    }
+    return BuiltinInst_getID(bridged)
   }
 }
 
@@ -557,34 +548,12 @@ final public class BridgeObjectToRefInst : SingleValueInstruction,
 final public class BridgeObjectToWordInst : SingleValueInstruction,
                                            UnaryInstruction {}
 
-public enum AccessKind {
-  case initialize
-  case read
-  case modify
-  case deinitialize
-}
-
-extension BridgedAccessKind {
-  var kind: AccessKind {
-    switch self {
-    case AccessKind_Init:
-      return .initialize
-    case AccessKind_Read:
-      return .read
-    case AccessKind_Modify:
-      return .modify
-    case AccessKind_Deinit:
-      return .deinitialize
-    default:
-      fatalError("unsupported access kind")
-    }
-  }
-}
+public typealias AccessKind = swift.SILAccessKind
 
 
 // TODO: add support for begin_unpaired_access
 final public class BeginAccessInst : SingleValueInstruction, UnaryInstruction {
-  public var accessKind: AccessKind { BeginAccessInst_getAccessKind(bridged).kind }
+  public var accessKind: AccessKind { BeginAccessInst_getAccessKind(bridged) }
 
   public var isStatic: Bool { BeginAccessInst_isStatic(bridged) != 0 }
 }

--- a/SwiftCompilerSources/Sources/SIL/WitnessTable.swift
+++ b/SwiftCompilerSources/Sources/SIL/WitnessTable.swift
@@ -20,28 +20,14 @@ public struct WitnessTable : CustomStringConvertible, NoReflectionChildren {
   public struct Entry : CustomStringConvertible, NoReflectionChildren {
     fileprivate let bridged: BridgedWitnessTableEntry
     
-    public enum Kind {
-      case invalid
-      case method
-      case associatedType
-      case associatedTypeProtocol
-      case baseProtocol
-    }
+    public typealias Kind = swift.SILWitnessTable.WitnessKind
     
     public var kind: Kind {
-      switch SILWitnessTableEntry_getKind(bridged) {
-        case SILWitnessTableEntry_Invalid:                return .invalid
-        case SILWitnessTableEntry_Method:                 return .method
-        case SILWitnessTableEntry_AssociatedType:         return .associatedType
-        case SILWitnessTableEntry_AssociatedTypeProtocol: return .associatedTypeProtocol
-        case SILWitnessTableEntry_BaseProtocol:           return .baseProtocol
-        default:
-          fatalError("unknown witness table kind")
-      }
+      return SILWitnessTableEntry_getKind(bridged)
     }
     
     public var methodFunction: Function? {
-      assert(kind == .method)
+      assert(kind == .Method)
       return SILWitnessTableEntry_getMethodFunction(bridged).function
     }
 

--- a/include/swift/AST/ASTBridging.h
+++ b/include/swift/AST/ASTBridging.h
@@ -25,13 +25,6 @@ SWIFT_BEGIN_NULLABILITY_ANNOTATIONS
 // Diagnostic Engine
 //===----------------------------------------------------------------------===//
 
-// TODO: Move this to somewhere common header.
-#if __has_attribute(enum_extensibility)
-#define ENUM_EXTENSIBILITY_ATTR(arg) __attribute__((enum_extensibility(arg)))
-#else
-#define ENUM_EXTENSIBILITY_ATTR(arg)
-#endif
-
 // NOTE: This must be the same underlying value as C++ 'swift::DiagID' defined
 // in 'DiagnosticList.cpp'.
 typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedDiagID : uint32_t {

--- a/include/swift/Basic/Compiler.h
+++ b/include/swift/Basic/Compiler.h
@@ -187,4 +187,10 @@
 #define SWIFT_IMPORT_REFERENCE
 #endif
 
+#if __has_attribute(enum_extensibility)
+#define ENUM_EXTENSIBILITY_ATTR(arg) __attribute__((enum_extensibility(arg)))
+#else
+#define ENUM_EXTENSIBILITY_ATTR(arg)
+#endif
+
 #endif // SWIFT_BASIC_COMPILER_H

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -15,8 +15,11 @@
 
 #include "swift/Basic/BasicBridging.h"
 #include "swift/Basic/BridgedSwiftObject.h"
+#include "swift/AST/Builtins.h"
 #include "swift/AST/SubstitutionMap.h"
+#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILLocation.h"
+#include "swift/SIL/SILWitnessTable.h"
 #include <stdbool.h>
 #include <stddef.h>
 #include <string>
@@ -93,14 +96,6 @@ typedef struct {
 typedef struct {
   const void * _Nonnull ptr;
 } BridgedWitnessTableEntry;
-
-typedef enum {
-  SILWitnessTableEntry_Invalid,
-  SILWitnessTableEntry_Method,
-  SILWitnessTableEntry_AssociatedType,
-  SILWitnessTableEntry_AssociatedTypeProtocol,
-  SILWitnessTableEntry_BaseProtocol
-} SILWitnessTableEntryKind;
 
 typedef struct {
   SwiftObject obj;
@@ -183,13 +178,6 @@ typedef enum {
 } BridgedEffectAttributeKind;
 
 typedef enum {
-  AccessKind_Init,
-  AccessKind_Read,
-  AccessKind_Modify,
-  AccessKind_Deinit
-} BridgedAccessKind;
-
-typedef enum {
   Ownership_Unowned,
   Ownership_Owned,
   Ownership_Guaranteed,
@@ -209,12 +197,6 @@ typedef enum {
 } BridgedArgumentConvention;
 
 // AST bridging
-
-typedef enum {
-  UnknownBuiltin = 0,
-#define BUILTIN(Id, Name, Attrs) Id##Builtin,
-#include "swift/AST/Builtins.def"
-} BridgedBuiltinID;
 
 struct BridgedEffectInfo {
   SwiftInt argumentIndex;
@@ -295,7 +277,7 @@ BridgedArrayRef SILWitnessTable_getEntries(BridgedWitnessTable table);
 std::string SILDefaultWitnessTable_debugDescription(BridgedDefaultWitnessTable table);
 BridgedArrayRef SILDefaultWitnessTable_getEntries(BridgedDefaultWitnessTable table);
 std::string SILWitnessTableEntry_debugDescription(BridgedWitnessTableEntry entry);
-SILWitnessTableEntryKind SILWitnessTableEntry_getKind(BridgedWitnessTableEntry entry);
+swift::SILWitnessTable::WitnessKind SILWitnessTableEntry_getKind(BridgedWitnessTableEntry entry);
 OptionalBridgedFunction SILWitnessTableEntry_getMethodFunction(BridgedWitnessTableEntry entry);
 
 OptionalBridgedBasicBlock SILBasicBlock_next(BridgedBasicBlock block);
@@ -375,7 +357,7 @@ BridgedArrayRef TermInst_getSuccessors(BridgedInstruction term);
 
 llvm::StringRef CondFailInst_getMessage(BridgedInstruction cfi);
 SwiftInt LoadInst_getLoadOwnership(BridgedInstruction load);
-BridgedBuiltinID BuiltinInst_getID(BridgedInstruction bi);
+swift::BuiltinValueKind BuiltinInst_getID(BridgedInstruction bi);
 SwiftInt AddressToPointerInst_needsStackProtection(BridgedInstruction atp);
 SwiftInt IndexAddrInst_needsStackProtection(BridgedInstruction ia);
 BridgedGlobalVar GlobalAccessInst_getGlobal(BridgedInstruction globalInst);
@@ -406,7 +388,7 @@ BridgedBasicBlock BranchInst_getTargetBlock(BridgedInstruction bi);
 SwiftInt SwitchEnumInst_getNumCases(BridgedInstruction se);
 SwiftInt SwitchEnumInst_getCaseIndex(BridgedInstruction se, SwiftInt idx);
 SwiftInt StoreInst_getStoreOwnership(BridgedInstruction store);
-BridgedAccessKind BeginAccessInst_getAccessKind(BridgedInstruction beginAccess);
+swift::SILAccessKind BeginAccessInst_getAccessKind(BridgedInstruction beginAccess);
 SwiftInt BeginAccessInst_isStatic(BridgedInstruction beginAccess);
 SwiftInt CopyAddrInst_isTakeOfSrc(BridgedInstruction copyAddr);
 SwiftInt CopyAddrInst_isInitializationOfDest(BridgedInstruction copyAddr);

--- a/include/swift/SIL/SILWitnessTable.h
+++ b/include/swift/SIL/SILWitnessTable.h
@@ -90,7 +90,7 @@ public:
     AssociatedType,
     AssociatedTypeProtocol,
     BaseProtocol
-  };
+  } ENUM_EXTENSIBILITY_ATTR(open);
   
   /// A witness table entry.
   class Entry {

--- a/include/swift/module.modulemap
+++ b/include/swift/module.modulemap
@@ -7,10 +7,17 @@ module BasicBridging {
 }
 
 module ASTBridging {
+  header "AST/AnyFunctionRef.h"
   header "AST/ASTBridging.h"
+  header "AST/Builtins.h"
   header "AST/DiagnosticEngine.h"
   header "AST/DiagnosticConsumer.h"
+  header "AST/ForeignAsyncConvention.h"
+  header "AST/ForeignErrorConvention.h"
   header "AST/SubstitutionMap.h"
+
+  textual header "AST/Builtins.def"
+
   requires cplusplus
   export *
 }

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -711,19 +711,9 @@ std::string SILWitnessTableEntry_debugDescription(BridgedWitnessTableEntry entry
   return str;
 }
 
-SILWitnessTableEntryKind SILWitnessTableEntry_getKind(BridgedWitnessTableEntry entry) {
-  switch (castToWitnessTableEntry(entry)->getKind()) {
-    case SILWitnessTable::Invalid:
-      return SILWitnessTableEntry_Invalid;
-    case SILWitnessTable::Method:
-      return SILWitnessTableEntry_Method;
-    case SILWitnessTable::AssociatedType:
-      return SILWitnessTableEntry_AssociatedType;
-    case SILWitnessTable::AssociatedTypeProtocol:
-      return SILWitnessTableEntry_AssociatedTypeProtocol;
-    case SILWitnessTable::BaseProtocol:
-      return SILWitnessTableEntry_BaseProtocol;
-  }
+SILWitnessTable::WitnessKind
+SILWitnessTableEntry_getKind(BridgedWitnessTableEntry entry) {
+  return castToWitnessTableEntry(entry)->getKind();
 }
 
 OptionalBridgedFunction SILWitnessTableEntry_getMethodFunction(BridgedWitnessTableEntry entry) {
@@ -817,8 +807,8 @@ SwiftInt LoadInst_getLoadOwnership(BridgedInstruction load) {
   return (SwiftInt)castToInst<LoadInst>(load)->getOwnershipQualifier();
 }
 
-BridgedBuiltinID BuiltinInst_getID(BridgedInstruction bi) {
-  return (BridgedBuiltinID)castToInst<BuiltinInst>(bi)->getBuiltinInfo().ID;
+BuiltinValueKind BuiltinInst_getID(BridgedInstruction bi) {
+  return castToInst<BuiltinInst>(bi)->getBuiltinInfo().ID;
 }
 
 SwiftInt AddressToPointerInst_needsStackProtection(BridgedInstruction atp) {
@@ -943,18 +933,8 @@ SwiftInt StoreInst_getStoreOwnership(BridgedInstruction store) {
   return (SwiftInt)castToInst<StoreInst>(store)->getOwnershipQualifier();
 }
 
-BridgedAccessKind BeginAccessInst_getAccessKind(BridgedInstruction beginAccess) {
-  auto kind = castToInst<BeginAccessInst>(beginAccess)->getAccessKind();
-  switch (kind) {
-    case SILAccessKind::Init:
-      return BridgedAccessKind::AccessKind_Init;
-    case SILAccessKind::Read:
-      return BridgedAccessKind::AccessKind_Read;
-    case SILAccessKind::Modify:
-      return BridgedAccessKind::AccessKind_Modify;
-    case SILAccessKind::Deinit:
-      return BridgedAccessKind::AccessKind_Deinit;
-  }
+SILAccessKind BeginAccessInst_getAccessKind(BridgedInstruction beginAccess) {
+  return castToInst<BeginAccessInst>(beginAccess)->getAccessKind();
 }
 
 SwiftInt BeginAccessInst_isStatic(BridgedInstruction beginAccess) {


### PR DESCRIPTION
The hosttools build issue is fixed in a recent trunk toolchain: `swift-DEVELOPMENT-SNAPSHOT-2022-10-16-a`.
The compiler bug that was causing it was fixed in https://github.com/apple/swift/pull/61540.

This reverts commit 69431f00
