### PR TITLE
[Interop] [SwiftToCxx] Introduce Dynamic Cast to swift::Error

### DIFF
--- a/lib/PrintAsClang/ModuleContentsWriter.cpp
+++ b/lib/PrintAsClang/ModuleContentsWriter.cpp
@@ -561,7 +561,8 @@ public:
 
     SmallVector<ProtocolConformance *, 1> conformances;
     auto errorTypeProto = ctx.getProtocol(KnownProtocolKind::Error);
-    if (ED->lookupConformance(errorTypeProto, conformances)) {
+    if (outputLangMode != OutputLanguageMode::Cxx
+        && ED->lookupConformance(errorTypeProto, conformances)) {
       bool hasDomainCase = std::any_of(ED->getAllElements().begin(),
                                        ED->getAllElements().end(),
                                        [](const EnumElementDecl *elem) {

--- a/lib/PrintAsClang/_SwiftCxxInteroperability.h
+++ b/lib/PrintAsClang/_SwiftCxxInteroperability.h
@@ -217,7 +217,7 @@ struct SymbolicP {
   uint8_t _4;
 } __attribute__((packed));
 
-inline const void *_Nullable testErrorCall() {
+inline const void *_Nullable getErrorMetadata() {
   static swift::SymbolicP errorSymbol;
   static int *_Nonnull got_ss5ErrorMp = &$ss5ErrorMp;
   errorSymbol._1 = 2;
@@ -257,7 +257,7 @@ public:
   template<class T>
   T as() {
     alignas(alignof(T)) char buffer[sizeof(T)];
-    const void *em = testErrorCall();
+    const void *em = getErrorMetadata();
     void *ep = getPointerToOpaquePointer();
     auto metadata = swift::TypeMetadataTrait<T>::getTypeMetadata();
 

--- a/lib/PrintAsClang/_SwiftCxxInteroperability.h
+++ b/lib/PrintAsClang/_SwiftCxxInteroperability.h
@@ -21,8 +21,13 @@
 
 #include <cstdint>
 #include <stdlib.h>
+#include <cstdint>
+#include <optional>
 #if defined(_WIN32)
 #include <malloc.h>
+#endif
+#if !defined(SWIFT_CALL)
+# define SWIFT_CALL __attribute__((swiftcall))
 #endif
 
 // FIXME: Use always_inline, artificial.
@@ -191,6 +196,47 @@ extern "C" void *_Nonnull swift_errorRetain(void *_Nonnull swiftError) noexcept;
 
 extern "C" void swift_errorRelease(void *_Nonnull swiftError) noexcept;
 
+extern "C" int $ss5ErrorMp; // external global %swift.protocol, align 4
+
+extern "C" int *_Nonnull got_ss5ErrorMp = &$ss5ErrorMp;
+
+extern "C"
+    const void * _Nullable
+    swift_getTypeByMangledNameInContext(
+        const char *_Nullable typeNameStart,
+        size_t typeNameLength,
+        const void *_Nullable context,
+        const void *_Nullable const *_Nullable genericArgs) SWIFT_CALL;
+
+extern "C" bool swift_dynamicCast(void *_Nullable dest, void *_Nullable src,
+                                  const void *_Nullable srcType,
+                                  const void * _Nullable targetType,
+                                  uint32_t flags);
+
+struct SymbolicP {
+  alignas(2) uint8_t _1;
+  uint32_t _2;
+  uint8_t _3[2];
+  uint8_t _4;
+} __attribute__((packed));
+
+inline const void *_Nullable testErrorCall() {
+  static swift::SymbolicP errorSymbol;
+  errorSymbol._1 = 2;
+  errorSymbol._2 = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(&got_ss5ErrorMp) - reinterpret_cast<uintptr_t>(&errorSymbol._2));
+  errorSymbol._3[0] = '_';
+  errorSymbol._3[1] = 'p';
+  errorSymbol._4 = 0;
+  static_assert(sizeof(errorSymbol) == 8, "");
+  auto charErrorSymbol = reinterpret_cast<const char *>(&errorSymbol);
+
+  const void *ptr2 =
+      swift::swift_getTypeByMangledNameInContext(charErrorSymbol,
+                                                 sizeof(errorSymbol) - 1,
+                                                 nullptr, nullptr);
+  return ptr2;
+}
+
 class Error {
 public:
   Error() {}
@@ -207,6 +253,26 @@ public:
     if (other.opaqueValue)
       swift_errorRetain(other.opaqueValue);
     opaqueValue = other.opaqueValue;
+  }
+
+  template<class T, class U>
+  std::optional<T> as() {
+    char *ptr = (char*)malloc(100);
+    const void *em = testErrorCall();
+    void *ep = getPointerToOpaquePointer();
+    auto metadata = swift::TypeMetadataTrait<T>::getTypeMetadata();
+
+    // Dynamic cast will release the error, so we need to retain it.
+    swift::swift_errorRetain(ep);
+    bool dynamicCast = swift::swift_dynamicCast(ptr, &ep, em, metadata,/*take on success  destroy on failure*/ 6);
+
+    if (dynamicCast) {
+      //swift::_impl::implClassFor<T>::initializeWithTake
+      auto result =
+          U::returnNewValue([&](char *dest) { U::initializeWithTake(dest, ptr); });
+      return std::optional(result);
+    }
+    return std::nullopt;
   }
 
 private:

--- a/lib/PrintAsClang/_SwiftCxxInteroperability.h
+++ b/lib/PrintAsClang/_SwiftCxxInteroperability.h
@@ -255,7 +255,7 @@ public:
     opaqueValue = other.opaqueValue;
   }
 
-  template<class T, class U>
+  template<class T>
   std::optional<T> as() {
     char *ptr = (char*)malloc(100);
     const void *em = testErrorCall();
@@ -264,12 +264,15 @@ public:
 
     // Dynamic cast will release the error, so we need to retain it.
     swift::swift_errorRetain(ep);
-    bool dynamicCast = swift::swift_dynamicCast(ptr, &ep, em, metadata,/*take on success  destroy on failure*/ 6);
+    bool dynamicCast =
+        swift::swift_dynamicCast(ptr, &ep, em, metadata,
+                                 /*take on success  destroy on failure*/ 6);
 
     if (dynamicCast) {
-      //swift::_impl::implClassFor<T>::initializeWithTake
       auto result =
-          U::returnNewValue([&](char *dest) { U::initializeWithTake(dest, ptr); });
+          swift::_impl::implClassFor<T>::type::returnNewValue([&](char *dest) {
+            swift::_impl::implClassFor<T>::type::initializeWithTake(dest, ptr);
+          });
       return std::optional(result);
     }
     return std::nullopt;

--- a/lib/PrintAsClang/_SwiftCxxInteroperability.h
+++ b/lib/PrintAsClang/_SwiftCxxInteroperability.h
@@ -21,7 +21,6 @@
 
 #include <cstdint>
 #include <stdlib.h>
-#include <cstdint>
 #if defined(_WIN32)
 #include <malloc.h>
 #endif

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %S/swift-functions-errors.swift -typecheck -module-name Functions -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/functions.h
 
-// RUN: %target-interop-build-clangxx -std=c++17 -x objective-c++ -c %s -I %t -o %t/swift-functions-errors-execution.o
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-functions-errors-execution.o
 // RUN: %target-interop-build-swift %S/swift-functions-errors.swift -o %t/swift-functions-errors-execution -Xlinker %t/swift-functions-errors-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain
 
 // RUN: %target-codesign %t/swift-functions-errors-execution

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
@@ -46,7 +46,7 @@ int main() {
 
 // CHECK: passEmptyThrowFunction
 // CHECK-NEXT: passThrowFunction
-// CHECK-NEXT: throwError!
+// CHECK-NEXT: throwError
 // CHECK-NEXT: passThrowFunctionWithReturn
 // CHECK-NEXT: Exception
 // CHECK-NEXT: Test destroyed

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
@@ -27,7 +27,7 @@ int main() {
   try {
     Functions::throwFunction();
   } catch (swift::Error& e) {
-      auto errorVal = e.as<Functions::NaiveErrors, Functions::_impl::_impl_NaiveErrors>();
+      auto errorVal = e.as<Functions::NaiveErrors>();
       if (errorVal) {
         assert(errorVal == Functions::NaiveErrors::throwError);
         errorVal->getMessage();

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
@@ -28,10 +28,8 @@ int main() {
     Functions::throwFunction();
   } catch (swift::Error& e) {
       auto errorVal = e.as<Functions::NaiveErrors>();
-      if (errorVal) {
-        assert(errorVal == Functions::NaiveErrors::throwError);
-        errorVal->getMessage();
-      }
+      assert(errorVal == Functions::NaiveErrors::throwError);
+      errorVal.getMessage();
   }
   try {
     Functions::throwFunctionWithReturn();

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
@@ -9,6 +9,7 @@
 // RUN: %target-run %t/swift-functions-errors-execution | %FileCheck %s
 
 // REQUIRES: executable_test
+// UNSUPPORTED: OS=windows-msvc
 
 #include <cassert>
 #include <cstdio>
@@ -45,7 +46,7 @@ int main() {
 
 // CHECK: passEmptyThrowFunction
 // CHECK-NEXT: passThrowFunction
-// CHECK-NEXT: throwError
+// CHECK-NEXT: throwError!
 // CHECK-NEXT: passThrowFunctionWithReturn
 // CHECK-NEXT: Exception
 // CHECK-NEXT: Test destroyed

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=all-public -emit-clang-header-path %t/functions.h
+// RUN: %target-swift-frontend %s -typecheck -module-name Functions -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
@@ -13,11 +13,19 @@
 
 // CHECK: }
 
-enum NaiveErrors : Error {
+// XFAIL: *
+
+@_expose(Cxx)
+public enum NaiveErrors : Error {
     case returnError
     case throwError
+
+    public func getMessage() {
+        print(self)
+    }
 }
 
+@_expose(Cxx)
 public func emptyThrowFunction() throws { print("passEmptyThrowFunction") }
 
 // CHECK: inline void emptyThrowFunction() {
@@ -34,10 +42,12 @@ class TestDestroyed {
   }
 }
 
+@_expose(Cxx)
 public struct DestroyedError : Error {
   let t = TestDestroyed()
 }
 
+@_expose(Cxx)
 public func testDestroyedError() throws { throw DestroyedError() }
 
 // CHECK: inline void testDestroyedError() {
@@ -48,6 +58,7 @@ public func testDestroyedError() throws { throw DestroyedError() }
 // CHECK: throw (swift::Error(opaqueError))
 // CHECK: }
 
+@_expose(Cxx)
 public func throwFunction() throws {
     print("passThrowFunction")
     throw NaiveErrors.throwError
@@ -61,6 +72,7 @@ public func throwFunction() throws {
 // CHECK: throw (swift::Error(opaqueError))
 // CHECK: }
 
+@_expose(Cxx)
 public func throwFunctionWithReturn() throws -> Int {
     print("passThrowFunctionWithReturn")
     throw NaiveErrors.returnError

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
@@ -13,8 +13,6 @@
 
 // CHECK: }
 
-// XFAIL: *
-
 @_expose(Cxx)
 public enum NaiveErrors : Error {
     case returnError


### PR DESCRIPTION
This modification allow the user to cast a generic `swift::Error` to its own Error and identify which case was catch!