### PR TITLE
Don't require a strict revision match in LLDB

### DIFF
--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -198,6 +198,8 @@ public:
 /// compiled with -enable-ossa-modules.
 /// \param requiredSDK If not empty, only accept modules built with
 /// a compatible SDK. The StringRef represents the canonical SDK name.
+/// \param requiresRevisionMatch if true, expects the swift tag to match in
+/// addition to the module format version number.
 /// \param[out] extendedInfo If present, will be populated with additional
 /// compilation options serialized into the AST at build time that may be
 /// necessary to load it properly.
@@ -205,6 +207,7 @@ public:
 /// input files the module depends on, if present in INPUT_BLOCK.
 ValidationInfo validateSerializedAST(
     StringRef data, bool requiresOSSAModules, StringRef requiredSDK,
+    bool requiresRevisionMatch = true,
     ExtendedValidationInfo *extendedInfo = nullptr,
     SmallVectorImpl<SerializationOptions::FileDependency> *dependencies =
         nullptr);

--- a/lib/ASTSectionImporter/ASTSectionImporter.cpp
+++ b/lib/ASTSectionImporter/ASTSectionImporter.cpp
@@ -36,7 +36,8 @@ bool swift::parseASTSection(MemoryBufferSerializedModuleLoader &Loader,
   // headers. Iterate over all AST modules.
   while (!buf.empty()) {
     auto info = serialization::validateSerializedAST(
-        buf, Loader.isRequiredOSSAModules(), /*requiredSDK*/StringRef());
+        buf, Loader.isRequiredOSSAModules(), /*requiredSDK*/ StringRef(),
+        /*requiresRevisionMatch*/ false);
 
     assert(info.name.size() < (2 << 10) && "name failed sanity check");
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2634,7 +2634,8 @@ serialization::Status
 CompilerInvocation::loadFromSerializedAST(StringRef data) {
   serialization::ExtendedValidationInfo extendedInfo;
   serialization::ValidationInfo info = serialization::validateSerializedAST(
-      data, getSILOptions().EnableOSSAModules, LangOpts.SDKName, &extendedInfo);
+      data, getSILOptions().EnableOSSAModules, LangOpts.SDKName,
+      !LangOpts.DebuggerSupport, &extendedInfo);
 
   if (info.status != serialization::Status::Valid)
     return info.status;
@@ -2670,7 +2671,7 @@ CompilerInvocation::setUpInputForSILTool(
 
   auto result = serialization::validateSerializedAST(
       fileBufOrErr.get()->getBuffer(), getSILOptions().EnableOSSAModules,
-      LangOpts.SDKName, &extendedInfo);
+      LangOpts.SDKName, !LangOpts.DebuggerSupport, &extendedInfo);
   bool hasSerializedAST = result.status == serialization::Status::Valid;
 
   if (hasSerializedAST) {

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -470,7 +470,7 @@ bool serialization::isSerializedAST(StringRef data) {
 
 ValidationInfo serialization::validateSerializedAST(
     StringRef data, bool requiresOSSAModules, StringRef requiredSDK,
-    ExtendedValidationInfo *extendedInfo,
+    bool requiresRevisionMatch, ExtendedValidationInfo *extendedInfo,
     SmallVectorImpl<SerializationOptions::FileDependency> *dependencies) {
   ValidationInfo result;
 
@@ -512,7 +512,7 @@ ValidationInfo serialization::validateSerializedAST(
       result = validateControlBlock(
           cursor, scratch,
           {SWIFTMODULE_VERSION_MAJOR, SWIFTMODULE_VERSION_MINOR},
-          requiresOSSAModules, /*requiresRevisionMatch=*/true,
+          requiresOSSAModules, requiresRevisionMatch,
           requiredSDK,
           extendedInfo, localObfuscator);
       if (result.status == Status::Malformed)

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1173,7 +1173,7 @@ bool SerializedModuleLoaderBase::canImportModule(
   if (swiftInterfaceVersion.empty() && *unusedModuleBuffer) {
     auto metaData = serialization::validateSerializedAST(
         (*unusedModuleBuffer)->getBuffer(), Ctx.SILOpts.EnableOSSAModules,
-        Ctx.LangOpts.SDKName);
+        Ctx.LangOpts.SDKName, !Ctx.LangOpts.DebuggerSupport);
     versionInfo->setVersion(metaData.userModuleVersion,
                             ModuleVersionSourceKind::SwiftBinaryModule);
   } else {

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -48,9 +48,10 @@ static bool
 validateModule(llvm::StringRef data, bool Verbose, bool requiresOSSAModules,
                swift::serialization::ValidationInfo &info,
                swift::serialization::ExtendedValidationInfo &extendedInfo) {
-  info = swift::serialization::validateSerializedAST(data, requiresOSSAModules,
-                                                     /*requiredSDK*/StringRef(),
-                                                     &extendedInfo);
+  info = swift::serialization::validateSerializedAST(
+      data, requiresOSSAModules,
+      /*requiredSDK*/ StringRef(), /*requiresRevisionMatch*/ false,
+      &extendedInfo);
   if (info.status != swift::serialization::Status::Valid) {
     llvm::outs() << "error: validateSerializedAST() failed\n";
     return false;


### PR DESCRIPTION
For release-management purposes during development, LLDB's embedded Swift compiler's version number can sometimes be off-by-one in the last digit compared to the Swift compiler.

This patch restores the old behavior from before 17183629e4bd60efe3db79f8f1ff6fb927fe5d00.

rdar://101299168
