### PR TITLE
Bridge Parser Diagnostics into the C++ Diagnostic Engine

### DIFF
--- a/SwiftCompilerSources/Sources/Parse/Regex.swift
+++ b/SwiftCompilerSources/Sources/Parse/Regex.swift
@@ -66,7 +66,7 @@ private func _RegexLiteralLexingFn(
       let diagEngine = DiagnosticEngine(bridged: bridged)
       let startLoc = SourceLoc(
         locationInFile: error.location.assumingMemoryBound(to: UInt8.self))!
-      diagEngine.diagnose(startLoc, .regex_literal_parsing_error, error.message)
+      diagEngine.diagnose(startLoc, .foreign_diagnostic, error.message)
     }
     return error.completelyErroneous
   }
@@ -113,7 +113,7 @@ public func _RegexLiteralParsingFn(
       let offset = str.utf8.distance(from: str.startIndex, to: errorLoc)
       diagLoc = _diagLoc.advanced(by: offset)
     }
-    diagEngine.diagnose(diagLoc, .regex_literal_parsing_error, error.message)
+    diagEngine.diagnose(diagLoc, .foreign_diagnostic, error.message)
     return true
   } catch {
     fatalError("Expected CompilerParseError")

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -91,9 +91,6 @@ ERROR(forbidden_interpolated_string,none,
 ERROR(forbidden_extended_escaping_string,none,
       "%0 cannot be an extended escaping string literal", (StringRef))
 
-ERROR(regex_literal_parsing_error,none,
-      "%0", (StringRef))
-
 //------------------------------------------------------------------------------
 // MARK: Lexer diagnostics
 //------------------------------------------------------------------------------
@@ -1993,6 +1990,13 @@ ERROR(expected_closure_literal,none,
 
 ERROR(expected_multiple_closures_block_rbrace,none,
       "expected '}' at the end of a trailing closures block", ())
+
+//------------------------------------------------------------------------------
+// MARK: diagnostics emitted by Swift libraries
+//------------------------------------------------------------------------------
+
+ERROR(foreign_diagnostic,none,
+      "%0", (StringRef))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"


### PR DESCRIPTION
Add a hook so the Swift parser can emit diagnostics that go through the normal diagnostics engine.