### PR TITLE
Specified logo source for dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="https://www.swift.org/assets/images/swift~dark.svg">
-  <img src="https://swift.org/assets/images/swift.svg" alt="Swift logo" height="70" >
+  <img src="https://www.swift.org/assets/images/swift.svg" alt="Swift logo" height="70">
 </picture>
 
 # Swift Programming Language

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-<img src="https://swift.org/assets/images/swift.svg" alt="Swift logo" height="70" >
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://www.swift.org/assets/images/swift~dark.svg">
+  <img src="https://swift.org/assets/images/swift.svg" alt="Swift logo" height="70" >
+</picture>
 
 # Swift Programming Language
 


### PR DESCRIPTION
As per [GitHub's documentation on Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to) and [this post from the GitHub blog](https://github.blog/changelog/2022-05-19-specify-theme-context-for-images-in-markdown-beta/), it is now possible to specify different sources for images based on the user's theme preference.

The black "Swift" text was a little unreadable on grey background, so I've adjusted it to display the white logo in dark mode.

-----

Before:

![Screenshot 2022-10-19 at 18-02-57 apple_swift The Swift Programming Language](https://user-images.githubusercontent.com/35808275/196730347-f75ee194-bedb-4911-9b31-5b18804ab1e6.png)
![Screenshot 2022-10-19 at 18-03-29 apple_swift The Swift Programming Language](https://user-images.githubusercontent.com/35808275/196730388-f1a92557-1de6-4dd4-98e8-c5dcaf73eed9.png)

Now:

![Screenshot 2022-10-19 at 18-04-19 apple_swift at d6b9e8c8fd8337854c422d346913b2d7823de894](https://user-images.githubusercontent.com/35808275/196730494-c0a7294c-3c19-4ada-8715-7e5dbea65c87.png)
![Screenshot 2022-10-19 at 18-04-32 apple_swift at d6b9e8c8fd8337854c422d346913b2d7823de894](https://user-images.githubusercontent.com/35808275/196730523-cf6c1a6f-b8d9-4ca7-a1d0-ba2f1c96a5f2.png)
