### PR TITLE
benchmarks: fix the Fibonacci and Ackermann benchmarks

### DIFF
--- a/benchmark/single-source/Ackermann.swift
+++ b/benchmark/single-source/Ackermann.swift
@@ -16,7 +16,7 @@ import TestsUtils
 
 public let benchmarks =
   BenchmarkInfo(
-    name: "Ackermann",
+    name: "Ackermann2",
     runFunction: run_Ackermann,
     tags: [.algorithm])
 
@@ -39,10 +39,10 @@ func ackermann(_ m: Int, _ n : Int) -> Int {
 let ref_result = [5, 13, 29, 61, 125, 253, 509, 1021, 2045, 4093, 8189, 16381, 32765, 65533, 131069]
 
 @inline(never)
-public func run_Ackermann(_ n: Int) {
+public func run_Ackermann(_ N: Int) {
   let (m, n) = (3, 6)
   var result = 0
-  for _ in 1...n {
+  for _ in 1...N {
     result = ackermann(m, n)
     if result != ref_result[n] {
       break

--- a/benchmark/single-source/Fibonacci.swift
+++ b/benchmark/single-source/Fibonacci.swift
@@ -14,7 +14,7 @@ import TestsUtils
 
 public let benchmarks =
   BenchmarkInfo(
-    name: "Fibonacci",
+    name: "Fibonacci2",
     runFunction: run_Fibonacci,
     tags: [.algorithm])
 
@@ -34,11 +34,11 @@ func fibonacci(_ n: Int) -> Int {
 }
 
 @inline(never)
-public func run_Fibonacci(_ n: Int) {
+public func run_Fibonacci(_ N: Int) {
   let n = 24
   let ref_result = 46368
   var result = 0
-  for _ in 1...n {
+  for _ in 1...N {
     result = fibonacci(n)
     if result != ref_result {
       break

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -307,6 +307,7 @@ public func autoreleasepool<Result>(
 }
 #endif
 
+@_semantics("optimize.no.crossmodule")
 public func getFalse() -> Bool { return false }
 
 @available(*, deprecated, renamed: "getFalse()")


### PR DESCRIPTION
The `getFalse` utility function was not excluded from cross-module-optimization, which led the optimizer to completely eliminate the main loop body Also, the passed `N` was shadowed by a local `n`.
