### PR TITLE
Make emission of extension block symbols a formal feature

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1370,6 +1370,11 @@ def emit_extension_block_symbols: Flag<["-"], "emit-extension-block-symbols">,
         NoInteractiveOption, SupplementaryOutput, HelpHidden]>,
   HelpText<"Emit 'swift.extension' symbols for extensions to external types instead of directly associating members and conformances with the extended nominal when generating symbol graphs">;
 
+def omit_extension_block_symbols: Flag<["-"], "omit-extension-block-symbols">,
+  Flags<[SwiftSymbolGraphExtractOption, FrontendOption,
+        NoInteractiveOption, SupplementaryOutput, HelpHidden]>,
+  HelpText<"Directly associate members and conformances with the extended nominal when generating symbol graphs instead of emitting 'swift.extension' symbols for extensions to external types">;
+
 // swift-symbolgraph-extract-only options
 def output_dir : Separate<["-"], "output-dir">,
   Flags<[NoDriverOption, SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption,

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -617,7 +617,8 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     context.Args.AddLastArg(Arguments, options::OPT_emit_symbol_graph_dir);
   }
   context.Args.AddLastArg(Arguments, options::OPT_include_spi_symbols);
-  context.Args.AddLastArg(Arguments, options::OPT_emit_extension_block_symbols);
+  context.Args.AddLastArg(Arguments, options::OPT_emit_extension_block_symbols,
+                          options::OPT_omit_extension_block_symbols);
   context.Args.AddLastArg(Arguments, options::OPT_symbol_graph_minimum_access_level);
 
   return II;
@@ -1114,7 +1115,8 @@ ToolChain::constructInvocation(const MergeModuleJobAction &job,
   context.Args.AddLastArg(Arguments, options::OPT_emit_symbol_graph);
   context.Args.AddLastArg(Arguments, options::OPT_emit_symbol_graph_dir);
   context.Args.AddLastArg(Arguments, options::OPT_include_spi_symbols);
-  context.Args.AddLastArg(Arguments, options::OPT_emit_extension_block_symbols);
+  context.Args.AddLastArg(Arguments, options::OPT_emit_extension_block_symbols,
+                          options::OPT_omit_extension_block_symbols);
   context.Args.AddLastArg(Arguments, options::OPT_symbol_graph_minimum_access_level);
 
   context.Args.AddLastArg(Arguments, options::OPT_import_objc_header);

--- a/lib/DriverTool/swift_symbolgraph_extract_main.cpp
+++ b/lib/DriverTool/swift_symbolgraph_extract_main.cpp
@@ -172,7 +172,8 @@ int swift_symbolgraph_extract_main(ArrayRef<const char *> Args,
       ParsedArgs.hasArg(OPT_skip_inherited_docs),
       ParsedArgs.hasArg(OPT_include_spi_symbols),
       /*IncludeClangDocs=*/false,
-      ParsedArgs.hasArg(OPT_emit_extension_block_symbols),
+      ParsedArgs.hasFlag(OPT_emit_extension_block_symbols,
+                         OPT_omit_extension_block_symbols, /*default=*/false),
   };
 
   if (auto *A = ParsedArgs.getLastArg(OPT_minimum_access_level)) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1306,7 +1306,8 @@ static void ParseSymbolGraphArgs(symbolgraphgen::SymbolGraphOptions &Opts,
   Opts.SkipInheritedDocs = Args.hasArg(OPT_skip_inherited_docs);
   Opts.IncludeSPISymbols = Args.hasArg(OPT_include_spi_symbols);
   Opts.EmitExtensionBlockSymbols =
-      Args.hasArg(OPT_emit_extension_block_symbols);
+      Args.hasFlag(OPT_emit_extension_block_symbols,
+                   OPT_omit_extension_block_symbols, /*default=*/false);
 
   if (auto *A = Args.getLastArg(OPT_symbol_graph_minimum_access_level)) {
     Opts.MinimumAccessLevel =

--- a/lib/Option/features.json
+++ b/lib/Option/features.json
@@ -26,6 +26,9 @@
     },
     {
       "name": "emit-const-value-sidecar"
+    },
+    {
+      "name": "emit-extension-block-symbols"
     }
   ]
 }

--- a/test/SymbolGraph/Module/BasicExtension.swift
+++ b/test/SymbolGraph/Module/BasicExtension.swift
@@ -2,11 +2,11 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name BasicExtension -emit-module -emit-module-path %t/
-// RUN: %target-swift-symbolgraph-extract -module-name BasicExtension -I %t -pretty-print -output-dir %t
+// RUN: %target-swift-symbolgraph-extract -module-name BasicExtension -I %t -pretty-print -output-dir %t -omit-extension-block-symbols
 // RUN: %FileCheck %s --input-file %t/BasicExtension@Swift.symbols.json --check-prefixes ALL,EXTRACT,EBSOff,EBSOff_EXTRACT
 
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -module-name BasicExtension -emit-module -emit-module-path %t/ -emit-symbol-graph -emit-symbol-graph-dir %t
+// RUN: %target-build-swift %s -module-name BasicExtension -emit-module -emit-module-path %t/ -emit-symbol-graph -emit-symbol-graph-dir %t -omit-extension-block-symbols
 // RUN: %FileCheck %s --input-file %t/BasicExtension@Swift.symbols.json --check-prefixes ALL,BUILD,EBSOff,EBSOff_BUILD
 
 


### PR DESCRIPTION
This PR is a follow up to #59047 and #61406.

<!-- What's in this pull request? -->
This PR adds the `-omit-extension-block-symbols` flag for explicitly disabling the emission of `swift.extension` symbols in symbol graph files. Furthermore, it adds the emission of extension block symbols to the feature list [`lib/Option/features.json`](https://github.com/apple/swift/blob/main/lib/Option/features.json) [as requested by @d-ronnqvist  ](https://github.com/apple/swift/pull/59047#issuecomment-1247314631).

The `-omit-extension-block-symbols` has no effect yet (except for overriding preceding `-emit-extension-block-symbols` flags), as this PR does **not** change the default behavior.

This PR finally fixes apple/swift-docc#210.

 #61406 and apple/swift-driver#1205 should before/with this PR.