### PR TITLE
[cxx-interop] Emit IR for destructors of temporary C++ values

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -75,6 +75,13 @@ public:
     return true;
   }
 
+  bool VisitCXXBindTemporaryExpr(clang::CXXBindTemporaryExpr *BTE) {
+    // This is a temporary value with a custom destructor. C++ will implicitly
+    // call the destructor at some point. Make sure we emit IR for it.
+    callback(BTE->getTemporary()->getDestructor());
+    return true;
+  }
+
   // Do not traverse unevaluated expressions. Doing to might result in compile
   // errors if we try to instantiate an un-instantiatable template.
 

--- a/test/Interop/Cxx/class/Inputs/destructors-with-temporary-values.h
+++ b/test/Interop/Cxx/class/Inputs/destructors-with-temporary-values.h
@@ -1,0 +1,25 @@
+#ifndef TEST_INTEROP_CXX_CLASS_INPUTS_DESTRUCTORS_WITH_TEMPORARY_VALUES_H
+#define TEST_INTEROP_CXX_CLASS_INPUTS_DESTRUCTORS_WITH_TEMPORARY_VALUES_H
+
+struct Value {
+  void referencedByDestructor() { r(); }
+
+  double r();
+};
+
+void referencedByDestructor(Value *ptr) { ptr->referencedByDestructor(); }
+
+struct Reference {
+  ~Reference() {
+    if (ptr)
+      referencedByDestructor(ptr);
+  }
+  Value *ptr;
+};
+
+inline Reference getRef();
+inline void takeDouble(double);
+
+inline void testFunction() { takeDouble(getRef().ptr->r()); }
+
+#endif // TEST_INTEROP_CXX_CLASS_INPUTS_DESTRUCTORS_WITH_TEMPORARY_VALUES_H

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -23,6 +23,11 @@ module Destructors {
   requires cplusplus
 }
 
+module DestructorsWithTemporaryValues {
+  header "destructors-with-temporary-values.h"
+  requires cplusplus
+}
+
 module Extensions {
   header "extensions.h"
   requires cplusplus

--- a/test/Interop/Cxx/class/destructors-with-temporary-values-irgen.swift
+++ b/test/Interop/Cxx/class/destructors-with-temporary-values-irgen.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swiftxx-frontend -emit-ir -I %S/Inputs -validate-tbd-against-ir=none %s | %FileCheck %s
+
+import DestructorsWithTemporaryValues
+
+public func test() {
+  testFunction()
+}
+
+// Make sure that we emit IR for functions that are called from the custom
+// destructor of a temporary value created on the C++ side.
+
+// CHECK: define{{( dso_local)?}} void @{{_Z22referencedByDestructorP5Value|"\?referencedByDestructor@@YAXPEAUValue@@@Z"}}
+// CHECK: define linkonce_odr{{( dso_local)?}} void @{{_ZN5Value22referencedByDestructorEv|"\?referencedByDestructor@Value@@QEAAXXZ"}}


### PR DESCRIPTION
This fixes the "undefined reference" linker errors.

rdar://101092732