### PR TITLE
[cxx-interop] Test typed and untyped enums cannot be assigned to each other

### DIFF
--- a/test/Interop/Cxx/enum/Inputs/module.modulemap
+++ b/test/Interop/Cxx/enum/Inputs/module.modulemap
@@ -22,3 +22,8 @@ module CenumsNSOptions {
   header "c-enums-NS_OPTIONS.h"
   requires cplusplus
 }
+
+module TypedUntypedEnums {
+  header "typed-untyped-enums.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/enum/Inputs/typed-untyped-enums.h
+++ b/test/Interop/Cxx/enum/Inputs/typed-untyped-enums.h
@@ -1,0 +1,15 @@
+#ifndef TEST_INTEROP_CXX_ENUM_INPUTS_TYPED_UNTYPED_ENUMS_H
+#define TEST_INTEROP_CXX_ENUM_INPUTS_TYPED_UNTYPED_ENUMS_H
+
+
+// Typed enum.
+enum Color { kRed = 0, kBlue, kGreen, kYellow = 10 };
+
+// Untyped enum.
+enum { kOne = 1, kTwo, kThree, kFour };
+
+// enum class.
+enum class Pet { goat = 5, cat = 15, dogcow, rabbit };
+
+
+#endif // TEST_INTEROP_CXX_ENUM_INPUTS_TYPED_UNTYPED_ENUMS_H

--- a/test/Interop/Cxx/enum/typed-untyped-enums.swift
+++ b/test/Interop/Cxx/enum/typed-untyped-enums.swift
@@ -1,0 +1,20 @@
+// Test that typed and untyped enums cannot be assigned to each other. 
+
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
+
+import TypedUntypedEnums
+
+// Implicit type. |x| is an |Int|.
+let x = kThree
+
+// Implicit type, |myColor| is a |Color|.
+var myColor = kYellow
+
+// These correctly fail. Cannot convert |Int| <-> |Color| (an enum).
+myColor = kTwo // expected-error {{cannot assign value of type 'Int' to type 'Color'}}
+myColor = x // expected-error {{cannot assign value of type 'Int' to type 'Color'}}
+let integer : Int = kBlue // expected-error {{cannot convert value of type 'Color' to specified type 'Int'}}
+
+// These correctly fail. Cannot convert |Int| <-> |Pet| (an enum class).
+let animal : Pet = 7 // expected-error {{cannot convert value of type 'Int' to specified type 'Pet'}}
+let number : Int = Pet.goat // expected-error {{cannot convert value of type 'Pet' to specified type 'Int'}}


### PR DESCRIPTION
Check that untyped C++ enums (which import into Swift as `Int`) cannot be assigned to an imported C++ type that is a typed enum or an `enum class`. 

