### PR TITLE
Run all Swift tests in SwiftSyntax PR testing

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1810,6 +1810,7 @@ swiftsyntax
 swiftsyntax-verify-generated-files
 skstresstester
 swiftevolve
+skip-test-swift=false
 
 [preset: buildbot_swiftsyntax_linux]
 mixin-preset=mixin_swiftpm_package_linux_platform


### PR DESCRIPTION
Since we assert that a valid parse of the old parser also results in a valid parse of the new parser, a change in the new parser can break the Swift test suite. We should thus run the test full Swift test suite in SwiftSyntax’s PR testing.