### PR TITLE
IRGen: Fix outlined value operations for (constraint) existentials.

### DIFF
--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -210,6 +210,12 @@ static bool canUseValueWitnessForValueOp(IRGenModule &IGM, SILType T) {
   if (!IGM.getSILModule().isTypeMetadataForLayoutAccessible(T))
     return false;
 
+  // It is not a good code size trade-off to instantiate a metatype for
+  // existentials, and also does not back-deploy gracefully in the case of
+  // constrained protocols.
+  if (T.getASTType()->isExistentialType())
+    return false;
+
   if (needsSpecialOwnershipHandling(T))
     return false;
   if (T.getASTType()->hasDynamicSelfType())

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-ir -disable-objc-interop | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -disable-objc-interop -O | %FileCheck %s --check-prefix=OPT
 
 // REQUIRES: CPU=x86_64
 
@@ -99,3 +100,39 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
 
   return undef : $()
 }
+
+protocol Constrained<T> {
+  associatedtype T
+}
+
+sil @keep_alive : $@convention(thin)(@inout any Constrained<Int>) -> ()
+sil @constrained_protocol : $@convention(thin) (@inout any Constrained<Int>) -> () {
+entry(%arg : $*any Constrained<Int>):
+
+  %dst = alloc_stack $any Constrained<Int>
+
+  copy_addr %arg to [initialization] %dst : $*any Constrained<Int>
+
+  %fn = function_ref @keep_alive : $@convention(thin)(@inout any Constrained<Int>) -> ()
+  apply %fn(%dst) : $@convention(thin)(@inout any Constrained<Int>) -> ()
+
+  destroy_addr %dst : $*any Constrained<Int>
+
+  dealloc_stack  %dst : $*any Constrained<Int>
+  %t = tuple ()
+  return %t : $()
+}
+
+// Make sure we don't instantiate metadata for constrained existentials. Metadata
+// instatiation is not supported on older runtimes.
+
+// OPT: define{{.*}} void @constrained_protocol(
+// OPT: call {{.*}} @"$s12existentials11Constrained_pSi1TAaBPRts_XPWOc"
+
+// OPT: define{{.*}} @"$s12existentials11Constrained_pSi1TAaBPRts_XPWOc"
+// OPT-NOT: call {{.*}} instantiate
+// OPT-NOT: ret
+// OPT: load
+// OPT: store
+// OPT:  call
+// OPT: ret


### PR DESCRIPTION
In the case of constraint existentials metadata instantiation was not supported pre 5.7, so using metadata for value operations is prohibited.

rdar://101250193