### PR TITLE
Fix SwiftMergeFunctions pass for opaque pointers

### DIFF
--- a/lib/LLVMPasses/LLVMMergeFunctions.cpp
+++ b/lib/LLVMPasses/LLVMMergeFunctions.cpp
@@ -1264,6 +1264,9 @@ static llvm::AttributeList
 fixUpTypesInByValAndStructRetAttributes(llvm::FunctionType *fnType,
                                         llvm::AttributeList attrList) {
   auto &context = fnType->getContext();
+  if (!context.supportsTypedPointers())
+    return attrList;
+
   for (unsigned i = 0; i < fnType->getNumParams(); ++i) {
     auto paramTy = fnType->getParamType(i);
     auto attrListIndex = llvm::AttributeList::FirstArgIndex + i;


### PR DESCRIPTION
Under opaque pointers there is not need to fix-up byval and structret attributes.
