### PR TITLE
[Index] Force indexing of system modules to read only from swiftinterfaces

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1140,9 +1140,12 @@ public:
   ///
   /// \param ModulePath The module's \c ImportPath which describes
   /// the name of the module being loaded, possibly including submodules.
-
+  /// \param AllowMemoryCached Should we allow reuse of an already loaded
+  /// module or force reloading from disk, defaults to true.
+  ///
   /// \returns The requested module, or NULL if the module cannot be found.
-  ModuleDecl *getModule(ImportPath::Module ModulePath);
+  ModuleDecl *
+  getModule(ImportPath::Module ModulePath, bool AllowMemoryCached = true);
 
   /// Attempts to load the matching overlay module for the given clang
   /// module into this ASTContext.
@@ -1170,7 +1173,7 @@ public:
   void addLoadedModule(ModuleDecl *M);
 
   /// Change the behavior of all loaders to ignore swiftmodules next to
-  /// swiftinterfaces and clear the in-memory cache on a change of value.
+  /// swiftinterfaces.
   void setIgnoreAdjacentModules(bool value);
 
   /// Retrieve the current generation number, which reflects the

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -307,6 +307,10 @@ public:
   /// The name of the SwiftShims module "SwiftShims".
   Identifier SwiftShimsModuleName;
 
+  /// Should we globally ignore swiftmodule files adjacent to swiftinterface
+  /// files?
+  bool IgnoreAdjacentModules = false;
+
   // Define the set of known identifiers.
 #define IDENTIFIER_WITH_NAME(Name, IdStr) Identifier Id_##Name;
 #include "swift/AST/KnownIdentifiers.def"
@@ -1165,7 +1169,10 @@ public:
   /// in this context.
   void addLoadedModule(ModuleDecl *M);
 
-public:
+  /// Change the behavior of all loaders to ignore swiftmodules next to
+  /// swiftinterfaces and clear the in-memory cache on a change of value.
+  void setIgnoreAdjacentModules(bool value);
+
   /// Retrieve the current generation number, which reflects the
   /// number of times a module import has caused mass invalidation of
   /// lookup tables.

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -255,6 +255,10 @@ ERROR(error_index_failed_status_check,none,
       "failed file status check: %0", (StringRef))
 ERROR(error_index_inputs_more_than_outputs,none,
       "index output filenames do not match input source files", ())
+REMARK(remark_indexing_system_module,none,
+       "indexing system module at %0"
+       "%select{|; skipping because of a broken swiftinterface}1",
+       (StringRef, bool))
 
 ERROR(error_wrong_number_of_arguments,none,
       "wrong number of '%0' arguments (expected %1, got %2)",

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -545,7 +545,7 @@ public:
   }
 
   /// Returns true if the module was rebuilt from a module interface instead
-  /// of being build from the full source.
+  /// of being built from the full source.
   bool isBuiltFromInterface() const {
     return Bits.ModuleDecl.IsBuiltFromInterface;
   }

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -249,10 +249,14 @@ public:
   /// \param path A sequence of (identifier, location) pairs that denote
   /// the dotted module name to load, e.g., AppKit.NSWindow.
   ///
+  /// \param AllowMemoryCache Enables preserving the loaded module in the
+  /// in-memory cache for the next loading attempt.
+  ///
   /// \returns the module referenced, if it could be loaded. Otherwise,
   /// emits a diagnostic and returns NULL.
   virtual
-  ModuleDecl *loadModule(SourceLoc importLoc, ImportPath::Module path) = 0;
+  ModuleDecl *loadModule(SourceLoc importLoc, ImportPath::Module path,
+                         bool AllowMemoryCache = true) = 0;
 
   /// Load extensions to the given nominal type.
   ///

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -216,6 +216,9 @@ namespace swift {
 
     /// Emit a remark after loading a module.
     bool EnableModuleLoadingRemarks = false;
+
+    /// Emit a remark when indexing a system module.
+    bool EnableIndexingSystemModuleRemarks = false;
     
     /// Emit a remark on early exit in explicit interface build
     bool EnableSkipExplicitInterfaceModuleBuildRemarks = false;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -220,8 +220,8 @@ public:
   /// \param path A sequence of (identifier, location) pairs that denote
   /// the dotted module name to load, e.g., AppKit.NSWindow.
   ///
-  /// \param AllowMemoryCache Enables preserving the loaded module in the
-  /// in-memory cache for the next loading attempt.
+  /// \param AllowMemoryCache Affects only loading serialized Swift modules,
+  /// this parameter has no effect in the ClangImporter.
   ///
   /// \returns the module referenced, if it could be loaded. Otherwise,
   /// emits a diagnostic and returns NULL.

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -220,11 +220,15 @@ public:
   /// \param path A sequence of (identifier, location) pairs that denote
   /// the dotted module name to load, e.g., AppKit.NSWindow.
   ///
+  /// \param AllowMemoryCache Enables preserving the loaded module in the
+  /// in-memory cache for the next loading attempt.
+  ///
   /// \returns the module referenced, if it could be loaded. Otherwise,
   /// emits a diagnostic and returns NULL.
   virtual ModuleDecl *loadModule(
                         SourceLoc importLoc,
-                        ImportPath::Module path)
+                        ImportPath::Module path,
+                        bool AllowMemoryCache = true)
                       override;
 
   /// Determine whether \c overlayDC is within an overlay module for the

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -439,7 +439,8 @@ public:
       StringRef OutPath, StringRef ABIOutputPath,
       bool SerializeDependencyHashes,
       bool TrackSystemDependencies, ModuleInterfaceLoaderOptions Opts,
-      RequireOSSAModules_t RequireOSSAModules);
+      RequireOSSAModules_t RequireOSSAModules,
+      bool silenceInterfaceDiagnostics);
 
   /// Unconditionally build \p InPath (a swiftinterface file) to \p OutPath (as
   /// a swiftmodule file).

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -343,6 +343,10 @@ def remark_loading_module : Flag<["-"], "Rmodule-loading">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit a remark and file path of each loaded module">;
 
+def remark_indexing_system_module : Flag<["-"], "Rindexing-system-module">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Emit a remark when indexing a system module">;
+
 def remark_skip_explicit_interface_build : Flag<["-"], "Rskip-explicit-interface-build">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit a remark if an explicit module interface invocation has an early exit because the expected output is up-to-date">;

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -73,7 +73,8 @@ public:
   /// returns NULL.
   virtual ModuleDecl *
   loadModule(SourceLoc importLoc,
-             ImportPath::Module path) override;
+             ImportPath::Module path,
+             bool AllowMemoryCache) override;
 
   /// Load extensions to the given nominal type.
   ///

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -185,7 +185,8 @@ public:
   /// emits a diagnostic and returns a FailedImportModule object.
   virtual ModuleDecl *
   loadModule(SourceLoc importLoc,
-             ImportPath::Module path) override;
+             ImportPath::Module path,
+             bool AllowMemoryCache) override;
 
 
   virtual void loadExtensions(NominalTypeDecl *nominal,
@@ -294,7 +295,8 @@ public:
 
   ModuleDecl *
   loadModule(SourceLoc importLoc,
-             ImportPath::Module path) override;
+             ImportPath::Module path,
+             bool AllowMemoryCache = true) override;
 
   /// Register a memory buffer that contains the serialized module for the given
   /// access path. This API is intended to be used by LLDB to add swiftmodules

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2191,6 +2191,14 @@ void ASTContext::addLoadedModule(ModuleDecl *M) {
   getImpl().LoadedModules[M->getRealName()] = M;
 }
 
+void ASTContext::setIgnoreAdjacentModules(bool value) {
+  // Clear the cache if we expect a different view on the same modules.
+  if (IgnoreAdjacentModules != value)
+    getImpl().LoadedModules.clear();
+
+  IgnoreAdjacentModules = value;
+}
+
 rewriting::RewriteContext &
 ASTContext::getRewriteContext() {
   auto &rewriteCtx = getImpl().TheRewriteContext;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2456,7 +2456,8 @@ ASTContext::getModule(ImportPath::Module ModulePath, bool AllowMemoryCached) {
   if (PreModuleImportCallback)
     PreModuleImportCallback(moduleID.Item.str(), false /*=IsOverlay*/);
   for (auto &importer : getImpl().ModuleLoaders) {
-    if (ModuleDecl *M = importer->loadModule(moduleID.Loc, ModulePath)) {
+    if (ModuleDecl *M = importer->loadModule(moduleID.Loc, ModulePath,
+                                             AllowMemoryCached)) {
       if (LangOpts.EnableModuleLoadingRemarks) {
         Diags.diagnose(ModulePath.getSourceRange().Start,
                        diag::module_loaded,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2192,10 +2192,6 @@ void ASTContext::addLoadedModule(ModuleDecl *M) {
 }
 
 void ASTContext::setIgnoreAdjacentModules(bool value) {
-  // Clear the cache if we expect a different view on the same modules.
-  if (IgnoreAdjacentModules != value)
-    getImpl().LoadedModules.clear();
-
   IgnoreAdjacentModules = value;
 }
 
@@ -2449,11 +2445,12 @@ bool ASTContext::canImportModule(ImportPath::Module ModuleName,
 }
 
 ModuleDecl *
-ASTContext::getModule(ImportPath::Module ModulePath) {
+ASTContext::getModule(ImportPath::Module ModulePath, bool AllowMemoryCached) {
   assert(!ModulePath.empty());
 
-  if (auto *M = getLoadedModule(ModulePath))
-    return M;
+  if (AllowMemoryCached)
+    if (auto *M = getLoadedModule(ModulePath))
+      return M;
 
   auto moduleID = ModulePath[0];
   if (PreModuleImportCallback)

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2018,7 +2018,8 @@ ModuleDecl *ClangImporter::Implementation::loadModuleClang(
 
 ModuleDecl *
 ClangImporter::loadModule(SourceLoc importLoc,
-                          ImportPath::Module path) {
+                          ImportPath::Module path,
+                          bool AllowMemoryCache) {
   return Impl.loadModule(importLoc, path);
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -822,6 +822,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   Opts.EnableModuleLoadingRemarks = Args.hasArg(OPT_remark_loading_module);
 
+  Opts.EnableIndexingSystemModuleRemarks = Args.hasArg(OPT_remark_indexing_system_module);
+
   Opts.EnableSkipExplicitInterfaceModuleBuildRemarks = Args.hasArg(OPT_remark_skip_explicit_interface_build);
   
   llvm::Triple Target = Opts.Target;

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -320,11 +320,19 @@ bool ImplicitModuleInterfaceBuilder::buildSwiftModuleInternal(
       llvm::RestorePrettyStackState(savedInnerPrettyStackState);
     };
 
+    Optional<DiagnosticEngine> localDiags;
+    DiagnosticEngine *rebuildDiags = diags;
+    if (silenceInterfaceDiagnostics) {
+      // To silence diagnostics, use a local temporary engine.
+      localDiags.emplace(sourceMgr);
+      rebuildDiags = &*localDiags;
+    }
+
     SubError = (bool)subASTDelegate.runInSubCompilerInstance(
         moduleName, interfacePath, OutPath, diagnosticLoc,
         [&](SubCompilerInstanceInfo &info) {
           auto EBuilder = ExplicitModuleInterfaceBuilder(
-              *info.Instance, diags, sourceMgr, moduleCachePath, backupInterfaceDir,
+              *info.Instance, rebuildDiags, sourceMgr, moduleCachePath, backupInterfaceDir,
               prebuiltCachePath, ABIDescriptorPath, extraDependencies, diagnosticLoc,
               dependencyTracker);
           return EBuilder.buildSwiftModuleFromInterface(

--- a/lib/Frontend/ModuleInterfaceBuilder.h
+++ b/lib/Frontend/ModuleInterfaceBuilder.h
@@ -47,6 +47,7 @@ class ImplicitModuleInterfaceBuilder {
   const StringRef backupInterfaceDir;
   const StringRef ABIDescriptorPath;
   const bool disableInterfaceFileLock;
+  const bool silenceInterfaceDiagnostics;
   const SourceLoc diagnosticLoc;
   DependencyTracker *const dependencyTracker;
   SmallVector<StringRef, 3> extraDependencies;
@@ -87,6 +88,7 @@ public:
       StringRef moduleName, StringRef moduleCachePath,
       StringRef backupInterfaceDir, StringRef prebuiltCachePath,
       StringRef ABIDescriptorPath, bool disableInterfaceFileLock = false,
+      bool silenceInterfaceDiagnostics = false,
       SourceLoc diagnosticLoc = SourceLoc(),
       DependencyTracker *tracker = nullptr)
       : sourceMgr(sourceMgr), diags(diags), subASTDelegate(subASTDelegate),
@@ -95,6 +97,7 @@ public:
         backupInterfaceDir(backupInterfaceDir),
         ABIDescriptorPath(ABIDescriptorPath),
         disableInterfaceFileLock(disableInterfaceFileLock),
+        silenceInterfaceDiagnostics(silenceInterfaceDiagnostics),
         diagnosticLoc(diagnosticLoc), dependencyTracker(tracker) {}
 
   /// Ensures the requested file name is added as a dependency of the resulting

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -677,7 +677,7 @@ class ModuleInterfaceLoaderImpl {
   std::pair<std::string, std::string> getCompiledModuleCandidates() {
     std::pair<std::string, std::string> result;
     // Should we attempt to load a swiftmodule adjacent to the swiftinterface?
-    bool shouldLoadAdjacentModule = true;
+    bool shouldLoadAdjacentModule = !ctx.IgnoreAdjacentModules;
 
     // Don't use the adjacent swiftmodule for frameworks from the public
     // Frameworks folder of the SDK.
@@ -1031,7 +1031,8 @@ class ModuleInterfaceLoaderImpl {
         ctx.SourceMgr, diagsToUse,
         astDelegate, interfacePath, moduleName, cacheDir,
         prebuiltCacheDir, backupInterfaceDir, StringRef(),
-        Opts.disableInterfaceLock, diagnosticLoc,
+        Opts.disableInterfaceLock,
+        ctx.IgnoreAdjacentModules, diagnosticLoc,
         dependencyTracker);
       // If we found an out-of-date .swiftmodule, we still want to add it as
       // a dependency of the .swiftinterface. That way if it's updated, but
@@ -1063,7 +1064,8 @@ class ModuleInterfaceLoaderImpl {
       ImplicitModuleInterfaceBuilder fallbackBuilder(
         ctx.SourceMgr, &ctx.Diags, astDelegate, backupPath, moduleName, cacheDir,
         prebuiltCacheDir, backupInterfaceDir, StringRef(),
-        Opts.disableInterfaceLock, diagnosticLoc,
+        Opts.disableInterfaceLock,
+        ctx.IgnoreAdjacentModules, diagnosticLoc,
         dependencyTracker);
       if (rebuildInfo.sawOutOfDateModule(modulePath))
         fallbackBuilder.addExtraDependency(modulePath);
@@ -1247,7 +1249,8 @@ bool ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
     StringRef OutPath, StringRef ABIOutputPath,
     bool SerializeDependencyHashes,
     bool TrackSystemDependencies, ModuleInterfaceLoaderOptions LoaderOpts,
-    RequireOSSAModules_t RequireOSSAModules) {
+    RequireOSSAModules_t RequireOSSAModules,
+    bool silenceInterfaceDiagnostics) {
   InterfaceSubContextDelegateImpl astDelegate(
       SourceMgr, &Diags, SearchPathOpts, LangOpts, ClangOpts, LoaderOpts,
       /*CreateCacheDirIfAbsent*/ true, CacheDir, PrebuiltCacheDir,
@@ -1256,7 +1259,8 @@ bool ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
   ImplicitModuleInterfaceBuilder builder(SourceMgr, &Diags, astDelegate, InPath,
                                          ModuleName, CacheDir, PrebuiltCacheDir,
                                          BackupInterfaceDir, ABIOutputPath,
-                                         LoaderOpts.disableInterfaceLock);
+                                         LoaderOpts.disableInterfaceLock,
+                                         silenceInterfaceDiagnostics);
   // FIXME: We really only want to serialize 'important' dependencies here, if
   //        we want to ship the built swiftmodules to another machine.
   auto failed = builder.buildSwiftModule(OutPath, /*shouldSerializeDeps*/true,
@@ -1274,7 +1278,8 @@ bool ModuleInterfaceLoader::buildSwiftModuleFromSwiftInterface(
   ImplicitModuleInterfaceBuilder backupBuilder(SourceMgr, &Diags, astDelegate, backInPath,
                                                ModuleName, CacheDir, PrebuiltCacheDir,
                                                BackupInterfaceDir, ABIOutputPath,
-                                               LoaderOpts.disableInterfaceLock);
+                                               LoaderOpts.disableInterfaceLock,
+                                               silenceInterfaceDiagnostics);
   // Ensure we can rebuild module after user changed the original interface file.
   backupBuilder.addExtraDependency(InPath);
   // FIXME: We really only want to serialize 'important' dependencies here, if

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -423,6 +423,8 @@ static bool buildModuleFromInterface(CompilerInstance &Instance) {
   ModuleInterfaceLoaderOptions LoaderOpts(FEOpts);
   StringRef ABIPath = Instance.getPrimarySpecificPathsForAtMostOnePrimary()
                           .SupplementaryOutputs.ABIDescriptorOutputPath;
+  bool IgnoreAdjacentModules = Instance.hasASTContext() &&
+                               Instance.getASTContext().IgnoreAdjacentModules;
 
   // If an explicit interface build was requested, bypass the creation of a new
   // sub-instance from the interface which will build it in a separate thread,
@@ -444,7 +446,8 @@ static bool buildModuleFromInterface(CompilerInstance &Instance) {
       Invocation.getOutputFilename(), ABIPath,
       FEOpts.SerializeModuleInterfaceDependencyHashes,
       FEOpts.shouldTrackSystemDependencies(), LoaderOpts,
-      RequireOSSAModules_t(Invocation.getSILOptions()));
+      RequireOSSAModules_t(Invocation.getSILOptions()),
+      IgnoreAdjacentModules);
 }
 
 static bool compileLLVMIR(CompilerInstance &Instance) {

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -495,22 +495,6 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
                                  IndexUnitWriter &parentUnitWriter,
                                  const PathRemapper &pathRemapper,
                                  SourceFile *initialFile) {
-  // Reload resilient modules from swiftinterface to avoid indexing
-  // internal details.
-  if (module->getResilienceStrategy() == ResilienceStrategy::Resilient) {
-    module->getASTContext().setIgnoreAdjacentModules(true);
-
-    ImportPath::Module::Builder builder(module->getName());
-    auto reloadedModule = module->getASTContext().getModule(builder.get());
-
-    if (reloadedModule) {
-      module = reloadedModule;
-    } else {
-      // If we can't rebuild from the swiftinterface, don't index this module.
-      return true;
-    }
-  }
-
   StringRef filename = module->getModuleFilename();
   std::string moduleName = module->getNameStr().str();
 
@@ -528,6 +512,22 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
   }
   if (*isUptodateOpt)
     return false;
+
+  // Reload resilient modules from swiftinterface to avoid indexing
+  // internal details.
+  if (module->getResilienceStrategy() == ResilienceStrategy::Resilient) {
+    module->getASTContext().setIgnoreAdjacentModules(true);
+
+    ImportPath::Module::Builder builder(module->getName());
+    auto reloadedModule = module->getASTContext().getModule(builder.get());
+
+    if (reloadedModule) {
+      module = reloadedModule;
+    } else {
+      // If we can't rebuild from the swiftinterface, don't index this module.
+      return true;
+    }
+  }
 
   // FIXME: Would be useful for testing if swift had clang's -Rremark system so
   // we could output a remark here that we are going to create index data for

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -517,6 +517,7 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
   // internal details.
   bool skipIndexingModule = false;
   if (module->getResilienceStrategy() == ResilienceStrategy::Resilient &&
+      !module->isBuiltFromInterface() &&
       !module->isStdlibModule()) {
     module->getASTContext().setIgnoreAdjacentModules(true);
 

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -520,7 +520,9 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
     module->getASTContext().setIgnoreAdjacentModules(true);
 
     ImportPath::Module::Builder builder(module->getName());
-    auto reloadedModule = module->getASTContext().getModule(builder.get());
+    ASTContext &ctx = module->getASTContext();
+    auto reloadedModule = ctx.getModule(builder.get(),
+                                        /*AllowMemoryCached=*/false);
 
     if (reloadedModule) {
       module = reloadedModule;

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -516,7 +516,8 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
   // Reload resilient modules from swiftinterface to avoid indexing
   // internal details.
   bool skipIndexingModule = false;
-  if (module->getResilienceStrategy() == ResilienceStrategy::Resilient) {
+  if (module->getResilienceStrategy() == ResilienceStrategy::Resilient &&
+      !module->isStdlibModule()) {
     module->getASTContext().setIgnoreAdjacentModules(true);
 
     ImportPath::Module::Builder builder(module->getName());

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -530,6 +530,12 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
     }
   }
 
+  if (module->getASTContext().LangOpts.EnableIndexingSystemModuleRemarks) {
+    diags.diagnose(SourceLoc(),
+                   diag::remark_indexing_system_module,
+                   filename, skipIndexingModule);
+  }
+
   // FIXME: Would be useful for testing if swift had clang's -Rremark system so
   // we could output a remark here that we are going to create index data for
   // a module file.

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -536,10 +536,6 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
                    filename, skipIndexingModule);
   }
 
-  // FIXME: Would be useful for testing if swift had clang's -Rremark system so
-  // we could output a remark here that we are going to create index data for
-  // a module file.
-
   // Pairs of (recordFile, groupName).
   std::vector<std::pair<std::string, std::string>> records;
 

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -94,7 +94,8 @@ bool SourceLoader::canImportModule(ImportPath::Module path,
 }
 
 ModuleDecl *SourceLoader::loadModule(SourceLoc importLoc,
-                                     ImportPath::Module path) {
+                                     ImportPath::Module path,
+                                     bool AllowMemoryCache) {
   // FIXME: Swift submodules?
   if (path.size() > 1)
     return nullptr;

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -444,7 +444,8 @@ std::error_code ImplicitSerializedModuleLoader::findModuleFilesInDirectory(
           (!ModuleBuffer && !ModuleDocBuffer)) &&
          "Module and Module Doc buffer must both be initialized or NULL");
 
-  if (LoadMode == ModuleLoadingMode::OnlyInterface)
+  if (LoadMode == ModuleLoadingMode::OnlyInterface ||
+      Ctx.IgnoreAdjacentModules)
     return std::make_error_code(std::errc::not_supported);
 
   auto ModuleErr = openModuleFile(ModuleID, BaseName, ModuleBuffer);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1208,7 +1208,8 @@ bool MemoryBufferSerializedModuleLoader::canImportModule(
 
 ModuleDecl *
 SerializedModuleLoaderBase::loadModule(SourceLoc importLoc,
-                                       ImportPath::Module path) {
+                                       ImportPath::Module path,
+                                       bool AllowMemoryCache) {
   // FIXME: Swift submodules?
   if (path.size() > 1)
     return nullptr;
@@ -1233,7 +1234,8 @@ SerializedModuleLoaderBase::loadModule(SourceLoc importLoc,
 
   auto M = ModuleDecl::create(moduleID.Item, Ctx);
   M->setIsSystemModule(isSystemModule);
-  Ctx.addLoadedModule(M);
+  if (AllowMemoryCache)
+    Ctx.addLoadedModule(M);
   SWIFT_DEFER { M->setHasResolvedImports(); };
 
   llvm::sys::path::native(moduleInterfacePath);
@@ -1264,7 +1266,8 @@ SerializedModuleLoaderBase::loadModule(SourceLoc importLoc,
 
 ModuleDecl *
 MemoryBufferSerializedModuleLoader::loadModule(SourceLoc importLoc,
-                                               ImportPath::Module path) {
+                                               ImportPath::Module path,
+                                               bool AllowMemoryCache) {
   // FIXME: Swift submodules?
   if (path.size() > 1)
     return nullptr;
@@ -1300,7 +1303,8 @@ MemoryBufferSerializedModuleLoader::loadModule(SourceLoc importLoc,
   if (BypassResilience)
     M->setBypassResilience();
   M->addFile(*file);
-  Ctx.addLoadedModule(M);
+  if (AllowMemoryCache)
+    Ctx.addLoadedModule(M);
   return M;
 }
 

--- a/test/Driver/loaded_module_trace.swift
+++ b/test/Driver/loaded_module_trace.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-module -module-name Module %S/Inputs/loaded_module_trace_empty.swift -o %t/Module.swiftmodule
-// RUN: %target-build-swift -emit-module -module-name Module2 %S/Inputs/loaded_module_trace_imports_module.swift -o %t/Module2.swiftmodule -I %t
-// RUN: %target-build-swift %s -emit-loaded-module-trace -o %t/loaded_module_trace -I %t
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-build-swift -emit-module -module-name Module %S/Inputs/loaded_module_trace_empty.swift -o %t/Module.swiftmodule -module-cache-path %t/cache
+// RUN: %target-build-swift -emit-module -module-name Module2 %S/Inputs/loaded_module_trace_imports_module.swift -o %t/Module2.swiftmodule -I %t -module-cache-path %t/cache
+// RUN: %target-build-swift %s -emit-loaded-module-trace -o %t/loaded_module_trace -I %t -module-cache-path %t/cache
 // RUN: %FileCheck -check-prefix=CHECK %s < %t/loaded_module_trace.trace.json
 // RUN: %FileCheck -check-prefix=CHECK-CONFIRM-ONELINE %s < %t/loaded_module_trace.trace.json
 

--- a/test/Driver/loaded_module_trace_env.swift
+++ b/test/Driver/loaded_module_trace_env.swift
@@ -1,6 +1,7 @@
-// RUN: rm -f %t
-// RUN: env SWIFT_LOADED_MODULE_TRACE_FILE=%t %target-build-swift -module-name loaded_module_trace_env -c %s -o- > /dev/null
-// RUN: %FileCheck %s < %t
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/cache)
+// RUN: env SWIFT_LOADED_MODULE_TRACE_FILE=%t/trace %target-build-swift -module-name loaded_module_trace_env -c %s -o- -module-cache-path %t/cache > /dev/null
+// RUN: %FileCheck %s < %t/trace
 
 // CHECK: {
 // CHECK: "version":2

--- a/test/Driver/loaded_module_trace_foundation.swift
+++ b/test/Driver/loaded_module_trace_foundation.swift
@@ -1,4 +1,6 @@
-// RUN: %target-build-swift -o %t -module-name loaded_module_trace_foundation %s -emit-loaded-module-trace -emit-loaded-module-trace-path - 2>&1 | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-build-swift -o %t/trace -module-name loaded_module_trace_foundation %s -emit-loaded-module-trace -emit-loaded-module-trace-path - -module-cache-path %t/cache 2>&1 | %FileCheck %s
 
 // REQUIRES: objc_interop
 

--- a/test/Driver/loaded_module_trace_header.swift
+++ b/test/Driver/loaded_module_trace_header.swift
@@ -1,6 +1,7 @@
-// RUN: rm -f %t
-// RUN: env SWIFT_LOADED_MODULE_TRACE_FILE=%t %target-build-swift -module-name loaded_module_trace_header -c %s -o- -import-objc-header %S/Inputs/loaded_module_trace_header.h > /dev/null
-// RUN: %FileCheck %s < %t
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/cache)
+// RUN: env SWIFT_LOADED_MODULE_TRACE_FILE=%t/trace %target-build-swift -module-name loaded_module_trace_header -c %s -o- -import-objc-header %S/Inputs/loaded_module_trace_header.h -module-cache-path %t/cache > /dev/null
+// RUN: %FileCheck %s < %t/trace
 
 // REQUIRES: objc_interop
 

--- a/test/Driver/loaded_module_trace_multifile.swift
+++ b/test/Driver/loaded_module_trace_multifile.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -emit-module -module-name Module %S/Inputs/loaded_module_trace_empty.swift -o %t/Module.swiftmodule
-// RUN: %target-build-swift -emit-module -module-name Module2 %S/Inputs/loaded_module_trace_empty.swift -o %t/Module2.swiftmodule
-// RUN: %target-build-swift %s %S/Inputs/loaded_module_trace_imports_module.swift -emit-loaded-module-trace-path %t/multifile.trace.json -emit-library -o %t/loaded_module_trace_multifile -I %t
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-build-swift -emit-module -module-name Module %S/Inputs/loaded_module_trace_empty.swift -o %t/Module.swiftmodule -module-cache-path %t/cache
+// RUN: %target-build-swift -emit-module -module-name Module2 %S/Inputs/loaded_module_trace_empty.swift -o %t/Module2.swiftmodule -module-cache-path %t/cache
+// RUN: %target-build-swift %s %S/Inputs/loaded_module_trace_imports_module.swift -emit-loaded-module-trace-path %t/multifile.trace.json -emit-library -o %t/loaded_module_trace_multifile -I %t -module-cache-path %t/cache
 // RUN: %FileCheck %s < %t/multifile.trace.json
 
 // This file only imports Module2, but the other file imports Module: hopefully they both appear!

--- a/test/Index/index_system_modules_swiftinterfaces.swift
+++ b/test/Index/index_system_modules_swiftinterfaces.swift
@@ -1,0 +1,79 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/modulecache)
+// RUN: split-file %s %t
+
+/// Setup the SDK composed of SecretModule and SystemModule
+// RUN: %empty-directory(%t/SDK)
+// RUN: mkdir -p %t/SDK/Frameworks/SecretModule.framework/Modules/SecretModule.swiftmodule
+// RUN: %target-swift-frontend -emit-module -module-name SecretModule \
+// RUN:     -swift-version 5 -enable-library-evolution -parse-stdlib \
+// RUN:     -o %t/SDK/Frameworks/SecretModule.framework/Modules/SecretModule.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:     -emit-module-interface-path %t/SDK/Frameworks/SecretModule.framework/Modules/SecretModule.swiftmodule/%module-target-triple.swiftinterface \
+// RUN:     %t/SecretModule.swift
+// RUN: mkdir -p %t/SDK/Frameworks/SystemModule.framework/Modules/SystemModule.swiftmodule
+// RUN: %target-swift-frontend -emit-module -module-name SystemModule \
+// RUN:     -swift-version 5 -enable-library-evolution -parse-stdlib \
+// RUN:     -o %t/SDK/Frameworks/SystemModule.framework/Modules/SystemModule.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:     -emit-module-interface-path %t/SDK/Frameworks/SystemModule.framework/Modules/SystemModule.swiftmodule/%module-target-triple.swiftinterface \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     %t/SystemModule.swift
+
+/// Index a client of SystemModule reading from the swiftinterface.
+/// Because of disable-deserialization-recovery and leakyFunc, reading from
+/// the swiftmodule would crash.
+// RUN: %empty-directory(%t/idx)
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -swift-version 5 \
+// RUN:     -index-system-modules \
+// RUN:     -index-store-path %t/idx \
+// RUN:     -index-ignore-stdlib \
+// RUN:     -sdk %t/SDK \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -module-cache-path %t/modulecache \
+// RUN:     %t/Client.swift -disable-deserialization-recovery
+
+/// The index should have the public API of SystemModule
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck -check-prefix=UNIT %s
+// UNIT: Unit | system | SystemModule |
+// UNIT: Record | system | SystemModule |
+// RUN: c-index-test core -print-record %t/idx | %FileCheck -check-prefix=RECORD %s
+// RECORD: function/Swift | systemFunc()
+
+/// Index a client reading from a broken swiftinterface
+// RUN: %empty-directory(%t/idx)
+// RUN: %empty-directory(%t/modulecache)
+// RUN: echo "breaking_the_swifinterface" >> %t/SDK/Frameworks/SystemModule.framework/Modules/SystemModule.swiftmodule/%module-target-triple.swiftinterface
+// RUN: %target-swift-frontend -typecheck -parse-stdlib \
+// RUN:     -index-system-modules \
+// RUN:     -index-store-path %t/idx \
+// RUN:     -index-ignore-stdlib \
+// RUN:     -sdk %t/SDK \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -module-cache-path %t/modulecache \
+// RUN:     %t/Client.swift \
+// RUN:     2>&1 | %FileCheck -check-prefix=BROKEN-BUILD --allow-empty %s
+
+/// We don't expect so see the swiftinterface error for indexing
+// BROKEN-BUILD-NOT: error
+// BROKEN-BUILD-NOT: breaking_the_swifinterface
+
+/// We don't expect SystemModule to be indexed with a broken swiftinterface
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck -check-prefix=BROKEN-UNIT %s
+// BROKEN-UNIT: Unit | system | SystemModule |
+// BROKEN-UNIT-NOT: Record | system | SystemModule |
+// RUN: c-index-test core -print-record %t/idx | %FileCheck -check-prefix=BROKEN-RECORD %s
+// BROKEN-RECORD-NOT: function/Swift | systemFunc()
+
+//--- SecretModule.swift
+public struct SecretType {}
+
+//--- SystemModule.swift
+// Use this dependency to hit an easy deserialization failure when recovery is disabled.
+@_implementationOnly import SecretModule
+
+public func systemFunc() { }
+func leakyFunc(_ a: SecretType) { }
+
+//--- Client.swift
+import SystemModule
+
+public func clientFunc() {}

--- a/test/Index/index_system_modules_swiftinterfaces.swift
+++ b/test/Index/index_system_modules_swiftinterfaces.swift
@@ -42,6 +42,7 @@
 // RUN: %empty-directory(%t/idx)
 // RUN: %empty-directory(%t/modulecache)
 // RUN: echo "breaking_the_swifinterface" >> %t/SDK/Frameworks/SystemModule.framework/Modules/SystemModule.swiftmodule/%module-target-triple.swiftinterface
+
 // RUN: %target-swift-frontend -typecheck -parse-stdlib \
 // RUN:     -index-system-modules \
 // RUN:     -index-store-path %t/idx \
@@ -49,10 +50,12 @@
 // RUN:     -sdk %t/SDK \
 // RUN:     -Fsystem %t/SDK/Frameworks \
 // RUN:     -module-cache-path %t/modulecache \
+// RUN:     -Rindexing-system-module \
 // RUN:     %t/Client.swift \
-// RUN:     2>&1 | %FileCheck -check-prefix=BROKEN-BUILD --allow-empty %s
+// RUN:     2>&1 | %FileCheck -check-prefix=BROKEN-BUILD %s
 
 /// We don't expect so see the swiftinterface error for indexing
+// BROKEN-BUILD: indexing system module {{.*}} skipping
 // BROKEN-BUILD-NOT: error
 // BROKEN-BUILD-NOT: breaking_the_swifinterface
 
@@ -62,6 +65,18 @@
 // BROKEN-UNIT-NOT: Record | system | SystemModule |
 // RUN: c-index-test core -print-record %t/idx | %FileCheck -check-prefix=BROKEN-RECORD %s
 // BROKEN-RECORD-NOT: function/Swift | systemFunc()
+
+// RUN: %target-swift-frontend -typecheck -parse-stdlib \
+// RUN:     -index-system-modules \
+// RUN:     -index-store-path %t/idx \
+// RUN:     -index-ignore-stdlib \
+// RUN:     -sdk %t/SDK \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -module-cache-path %t/modulecache \
+// RUN:     -Rindexing-system-module \
+// RUN:     %t/Client.swift \
+// RUN:     2>&1 | %FileCheck -check-prefix=BROKEN-BUILD-2 --allow-empty %s
+// BROKEN-BUILD-2-NOT: indexing system module
 
 //--- SecretModule.swift
 public struct SecretType {}

--- a/test/Index/skip-loaded-internal.swift
+++ b/test/Index/skip-loaded-internal.swift
@@ -3,10 +3,10 @@
 // RUN: mkdir -p %t/Frameworks/lib2.framework/Modules/lib2.swiftmodule
 // RUN: split-file %s %t
 
-// RUN: %target-swift-frontend -emit-module -emit-module-source-info -module-name lib2 -o %t/Frameworks/lib2.framework/Modules/lib2.swiftmodule/%module-target-triple.swiftmodule %t/lib2.swift -disable-experimental-string-processing
-// RUN: %target-swift-frontend -emit-module -emit-module-source-info -module-name lib -o %t/Frameworks/lib.framework/Modules/lib.swiftmodule/%module-target-triple.swiftmodule %t/lib.swift -Fsystem %t/Frameworks -disable-experimental-string-processing
+// RUN: %target-swift-frontend -emit-module -emit-module-source-info -module-name lib2 -o %t/Frameworks/lib2.framework/Modules/lib2.swiftmodule/%module-target-triple.swiftmodule %t/lib2.swift -disable-experimental-string-processing -parse-stdlib
+// RUN: %target-swift-frontend -emit-module -emit-module-source-info -module-name lib -o %t/Frameworks/lib.framework/Modules/lib.swiftmodule/%module-target-triple.swiftmodule %t/lib.swift -Fsystem %t/Frameworks -disable-experimental-string-processing -parse-stdlib
 
-// RUN: %target-swift-frontend -typecheck -index-system-modules -index-ignore-stdlib -index-store-path %t/idx -Fsystem %t/Frameworks %t/main.swift -disable-deserialization-recovery -disable-experimental-string-processing
+// RUN: %target-swift-frontend -typecheck -index-system-modules -index-ignore-stdlib -index-store-path %t/idx -Fsystem %t/Frameworks %t/main.swift -disable-deserialization-recovery -disable-experimental-string-processing -parse-stdlib
 
 //--- main.swift
 import lib

--- a/test/ModuleInterface/loading-remarks.swift
+++ b/test/ModuleInterface/loading-remarks.swift
@@ -1,12 +1,13 @@
 /// Test the -Rmodule-loading flag.
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/cache)
 
 /// Create a simple module and interface.
 // RUN: echo 'public func publicFunction() {}' > %t/TestModule.swift
 // RUN: %target-swift-emit-module-interface(%t/TestModule.swiftinterface) %t/TestModule.swift
 
 /// Use -Rmodule-loading in a client and look for the diagnostics output.
-// RUN: %target-swift-frontend -typecheck %s -I %t -Rmodule-loading 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %s -I %t -Rmodule-loading -module-cache-path %t/cache 2>&1 | %FileCheck %s
 
 import TestModule
 // CHECK: remark: loaded module at {{.*}}SwiftShims-{{.*}}.pcm


### PR DESCRIPTION
Indexing system modules while building is a crash prone phase because it tries to read everything from swiftmodules in the SDK. We saw it crash often on reading implementation details relying on implementation-only imported types.

To rule out all of these issues, let's force indexing system modules to use only swiftinterfaces in the SDK and ignores the adjacent swiftmodule files. In the future, we want a similar behavior for all compilation, not just indexing, at that time we can revert this change.

rdar://100644036