### PR TITLE
[silgen] Eliminate lifetime gap caused by AutoreleasingUnsafeMutablePointer's LValue component set.

### DIFF
--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5556,8 +5556,14 @@ public:
               unowned->getType().castTo<UnmanagedStorageType>().getReferentType());
     auto owned = SGF.B.createUnmanagedToRef(loc, unowned, strongType);
     auto ownedMV = SGF.emitManagedRetain(loc, owned);
-    
-    // Reassign the +1 storage with it.
+
+    // Then create a mark dependence in between the base and the ownedMV. This
+    // is important to ensure that the destroy of the assign is not hoisted
+    // above the retain. We are doing unmanaged things here so we need to be
+    // extra careful.
+    ownedMV = SGF.B.createMarkDependence(loc, ownedMV, base);
+
+    // Then reassign the mark dependence into the +1 storage.
     ownedMV.assignInto(SGF, loc, base.getUnmanagedValue());
   }
   

--- a/test/SILGen/pointer_conversion.swift
+++ b/test/SILGen/pointer_conversion.swift
@@ -250,7 +250,13 @@ func classInoutToPointer() {
   // CHECK: [[UNOWNED_OUT:%.*]] = load [trivial] [[WRITEBACK]]
   // CHECK: [[OWNED_OUT:%.*]] = unmanaged_to_ref [[UNOWNED_OUT]]
   // CHECK: [[OWNED_OUT_COPY:%.*]] = copy_value [[OWNED_OUT]]
-  // CHECK: assign [[OWNED_OUT_COPY]] to [[WRITE2]]
+  //
+  // DISCUSSION: We need a mark_dependence here to ensure that the destroy of
+  // the value in WRITE2 is not hoisted above the copy of OWNED_OUT. Otherwise,
+  // we may have a use-after-free if ref counts are low enough.
+  //
+  // CHECK: [[OWNED_OUT_COPY_DEP:%.*]] = mark_dependence [[OWNED_OUT_COPY]] : $C on [[WRITE2]]
+  // CHECK: assign [[OWNED_OUT_COPY_DEP]] to [[WRITE2]]
 
   var cq: C? = C()
   takesPlusZeroOptionalPointer(&cq)


### PR DESCRIPTION
The problem here is that the AutoreleasingUnsafeMutablePointer's LValue component would given the following Swift:

```
public class C {}

@inline(never)
func updateC(_ p: AutoreleasingUnsafeMutablePointer<C>) -> () {
  p.pointee = C()
}

public func test() -> C {
  var cVar = C()
  updateC(&cVar)
  return cVar
}
```

generate the following SIL as part of setting cVar after returning from updateC.

```
  %18 = function_ref @$s11autorelease7updateCyySAyAA1CCGF : $@convention(thin) (AutoreleasingUnsafeMutablePointer<C>) -> () // user: %19
  %19 = apply %18(%17) : $@convention(thin) (AutoreleasingUnsafeMutablePointer<C>) -> ()
  %20 = load [trivial] %8 : $*@sil_unmanaged C    // user: %21
  %21 = unmanaged_to_ref %20 : $@sil_unmanaged C to $C // user: %22
  %22 = copy_value %21 : $C                       // user: %23
  assign %22 to %7 : $*C                          // id: %23
  end_access %7 : $*C                             // id: %24
```

Once we are in Canonical SIL, we get the following SIL:

```
  %18 = function_ref @$s11autorelease7updateCyySAyAA1CCGF : $@convention(thin) (AutoreleasingUnsafeMutablePointer<C>) -> () // user: %19
  %19 = apply %18(%17) : $@convention(thin) (AutoreleasingUnsafeMutablePointer<C>) -> ()
  %20 = load [trivial] %8 : $*@sil_unmanaged C    // user: %21
  %21 = unmanaged_to_ref %20 : $@sil_unmanaged C to $C // user: %22
  %22 = copy_value %21 : $C                       // user: %23
  store %22 to [assign] %7 : $*C                          // id: %23
  end_access %7 : $*C                             // id: %24
```

which destroy hoisting then modifies by hoisting the destroy by the store assign before the copy_value:

```
  %18 = function_ref @$s11autorelease7updateCyySAyAA1CCGF : $@convention(thin) (AutoreleasingUnsafeMutablePointer<C>) -> () // user: %19
  %19 = apply %18(%17) : $@convention(thin) (AutoreleasingUnsafeMutablePointer<C>) -> ()
  destroy_addr %7 : $*C
  %20 = load [trivial] %8 : $*@sil_unmanaged C    // user: %21
  %21 = unmanaged_to_ref %20 : $@sil_unmanaged C to $C // user: %22
  %22 = copy_value %21 : $C                       // user: %23
  store %22 to [init] %7 : $*C                          // id: %23
  end_access %7 : $*C                             // id: %24
```

Given the appropriate Swift code, one could have that %21 is actually already stored in %7 and has a ref count of 1. In such a case, the destroy_addr would cause %21 to be deallocated before we can retain the value.

In order to fix this edge case as a bug fix, in the setter for AutoreleasingUnsafeMutablePointer, we introduce a mark_dependence from the copied value onto the memory. This ensures that destroy hoisting does not hoist the destroy_addr past the mark_dependence, yielding correctness. That is we generate the following SIL:

```
  %18 = function_ref @$s11autorelease7updateCyySAyAA1CCGF : $@convention(thin) (AutoreleasingUnsafeMutablePointer<C>) -> () // user: %19
  %19 = apply %18(%17) : $@convention(thin) (AutoreleasingUnsafeMutablePointer<C>) -> ()
  %20 = load [trivial] %8 : $*@sil_unmanaged C    // user: %21
  %21 = unmanaged_to_ref %20 : $@sil_unmanaged C to $C // user: %22
  %22 = copy_value %21 : $C                       // user: %23
  %23 = mark_dependence %22 : $C on %7 : $*C
  assign %23 to %7 : $*C                          // id: %23
  end_access %7 : $*C                             // id: %24
```

For those unfamiliar, mark_dependence specifies that any destroy of the memory in %7 can not move before any use of %23.

rdar://99402398

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
