### PR TITLE
Removed deinit barrier workaround.

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -112,35 +112,16 @@ public class Instruction : ListNode, CustomStringConvertible, Hashable {
     return swift_mayAccessPointer(bridged)
   }
 
-  /// Whether this instruction loads or copies a value whose storage does not
-  /// increment the stored value's reference count.
   public final var mayLoadWeakOrUnowned: Bool {
-    switch self {
-    case is LoadWeakInst, is LoadUnownedInst, is StrongCopyUnownedValueInst, is StrongCopyUnmanagedValueInst:
-      return true
-    default:
-      return false
-    }
+    return swift_mayLoadWeakOrUnowned(bridged)
   }
 
-  /// Conservatively, whether this instruction could involve a synchronization
-  /// point like a memory barrier, lock or syscall.
   public final var maySynchronizeNotConsideringSideEffects: Bool {
-    switch self {
-    case is FullApplySite, is EndApplyInst, is AbortApplyInst:
-      return true
-    default:
-      return false
-    }
+    return swift_maySynchronizeNotConsideringSideEffects(bridged)
   }
 
-  /// Conservatively, whether this instruction could be a barrier to hoisting
-  /// destroys.
-  ///
-  /// Does not consider function so effects, so every apply is treated as a
-  /// barrier.
   public final var mayBeDeinitBarrierNotConsideringSideEffects: Bool {
-    return mayAccessPointer || mayLoadWeakOrUnowned || maySynchronizeNotConsideringSideEffects
+    return swift_mayBeDeinitBarrierNotConsideringSideEffects(bridged)
   }
 
   public func visitReferencedFunctions(_ cl: (Function) -> ()) {

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -236,6 +236,21 @@ inline bool accessKindMayConflict(SILAccessKind a, SILAccessKind b) {
 /// such as by reading a pointer.
 bool mayAccessPointer(SILInstruction *instruction);
 
+/// Whether this instruction loads or copies a value whose storage does not
+/// increment the stored value's reference count.
+bool mayLoadWeakOrUnowned(SILInstruction* instruction);
+
+/// Conservatively, whether this instruction could involve a synchronization
+/// point like a memory barrier, lock or syscall.
+bool maySynchronizeNotConsideringSideEffects(SILInstruction* instruction);
+
+/// Conservatively, whether this instruction could be a barrier to hoisting
+/// destroys.
+///
+/// Does not consider function so effects, so every apply is treated as a
+/// barrier.
+bool mayBeDeinitBarrierNotConsideringSideEffects(SILInstruction *instruction);
+
 } // end namespace swift
 
 //===----------------------------------------------------------------------===//

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -365,6 +365,9 @@ BridgedMemoryBehavior SILInstruction_getMemBehavior(BridgedInstruction inst);
 bool SILInstruction_mayRelease(BridgedInstruction inst);
 bool SILInstruction_hasUnspecifiedSideEffects(BridgedInstruction inst);
 bool swift_mayAccessPointer(BridgedInstruction inst);
+bool swift_mayLoadWeakOrUnowned(BridgedInstruction inst);
+bool swift_maySynchronizeNotConsideringSideEffects(BridgedInstruction inst);
+bool swift_mayBeDeinitBarrierNotConsideringSideEffects(BridgedInstruction inst);
 
 BridgedInstruction MultiValueInstResult_getParent(BridgedMultiValueResult result);
 SwiftInt MultiValueInstResult_getIndex(BridgedMultiValueResult result);

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -418,6 +418,41 @@ bool swift_mayAccessPointer(BridgedInstruction inst) {
   return mayAccessPointer(castToInst(inst));
 }
 
+bool swift::mayLoadWeakOrUnowned(SILInstruction *instruction) {
+  return isa<LoadWeakInst>(instruction) 
+      || isa<LoadUnownedInst>(instruction) 
+      || isa<StrongCopyUnownedValueInst>(instruction)
+      || isa<StrongCopyUnmanagedValueInst>(instruction);
+}
+
+bool swift_mayLoadWeakOrUnowned(BridgedInstruction inst) {
+  return mayLoadWeakOrUnowned(castToInst(inst));
+}
+
+/// Conservatively, whether this instruction could involve a synchronization
+/// point like a memory barrier, lock or syscall.
+bool swift::maySynchronizeNotConsideringSideEffects(SILInstruction *instruction) {
+  return FullApplySite::isa(instruction) 
+      || isa<EndApplyInst>(instruction)
+      || isa<AbortApplyInst>(instruction);
+}
+
+bool swift_maySynchronizeNotConsideringSideEffects(BridgedInstruction inst) {
+  return maySynchronizeNotConsideringSideEffects(castToInst(inst));
+}
+
+bool swift::mayBeDeinitBarrierNotConsideringSideEffects(SILInstruction *instruction) {
+  bool retval = mayAccessPointer(instruction)
+             || mayLoadWeakOrUnowned(instruction)
+             || maySynchronizeNotConsideringSideEffects(instruction);
+  assert(!retval || !isa<BranchInst>(instruction) && "br as deinit barrier!?");
+  return retval;
+}
+
+bool swift_mayBeDeinitBarrierNotConsideringSideEffects(BridgedInstruction inst) {
+  return mayBeDeinitBarrierNotConsideringSideEffects(castToInst(inst));
+}
+
 //===----------------------------------------------------------------------===//
 //                         MARK: AccessRepresentation
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -373,30 +373,10 @@ void CalleeAnalysis_register(
   instructionIsDeinitBarrierFunction = instructionIsDeinitBarrierFn;
 }
 
-/// Implementation of mayBeDeinitBarrierNotConsideringSideEffects for use only
-/// during bootstrapping or in compilers that lack Swift sources.
-///
-/// TODO: Remove.
-static bool
-isDeinitBarrierWithoutEffectsCpp(SILInstruction *const instruction) {
-  auto mayLoadWeakOrUnowned = [](SILInstruction *const instruction) {
-    return isa<LoadWeakInst>(instruction) ||
-           isa<LoadUnownedInst>(instruction) ||
-           isa<StrongCopyUnownedValueInst>(instruction) ||
-           isa<StrongCopyUnmanagedValueInst>(instruction);
-  };
-  auto maySynchronize = [](SILInstruction *const instruction) {
-    return isa<FullApplySite>(instruction) || isa<EndApplyInst>(instruction) ||
-           isa<AbortApplyInst>(instruction);
-  };
-  return mayAccessPointer(instruction) || mayLoadWeakOrUnowned(instruction) ||
-         maySynchronize(instruction);
-}
-
 bool swift::isDeinitBarrier(SILInstruction *const instruction,
                             BasicCalleeAnalysis *bca) {
   if (!instructionIsDeinitBarrierFunction) {
-    return isDeinitBarrierWithoutEffectsCpp(instruction);
+    return mayBeDeinitBarrierNotConsideringSideEffects(instruction);
   }
   BridgedInstruction inst = {
       cast<SILNode>(const_cast<SILInstruction *>(instruction))};

--- a/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
@@ -399,10 +399,11 @@ bool Rewriter::run() {
   // don't have multiple predecessors) whose end was not reachable (because
   // reachability was not able to make it to the top of some other successor).
   //
-  // In other words, a control flow boundary is the target edge from a block B
-  // to its single predecessor P not all of whose successors S in succ(P) had
-  // reachable beginnings.  We witness that fact about P's successors by way of
-  // P not having a reachable end--see BackwardReachability::meetOverSuccessors.
+  // In other words, a control flow boundary is the target block of the edge
+  // to a block B from its single predecessor P not all of whose successors S
+  // in succ(P) had reachable beginnings.  We witness that fact about P's
+  // successors by way of P not having a reachable end--see
+  // IterativeBackwardReachability::meetOverSuccessors.
   //
   // control-flow-boundary(B) := beginning-reachable(B) && !end-reachable(P)
   for (auto *block : barriers.blocks) {


### PR DESCRIPTION
Previously, to workaround an issue with ShrinkBorrowScope (where it assumed a reasonable definition of isDeinitBarrier), a placeholder version of the function was added.  It is now removed by moving the implementation of a version of that predicate back to C++.