### PR TITLE
[ShrinkBorrowScope] Leave under rewritten copies.

### DIFF
--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -13,7 +13,7 @@
 // TO ADD A NEW TEST, search in this file for [new_tests]
 //
 // Provides a mechanism for doing faux unit tests.  The idea is to emulate the
-// basic function of calling a function and validating its results/effects.
+// basic functionality of calling a function and validating its results/effects.
 //
 // This is done via the test_specification instruction.  Using one or more
 // instances of it in your function, you can specify which test (i.e. UnitTest

--- a/test/SILOptimizer/copy_propagation_opaque.sil
+++ b/test/SILOptimizer/copy_propagation_opaque.sil
@@ -413,8 +413,8 @@ bb0:
 
 // CHECK-TRACE-LABEL: *** CopyPropagation: testBorrowCopy
 // CHECK-TRACE:        Canonicalizing: %1
-// CHECK-TRACE:        Removing   destroy_value %4 : $T
-// CHECK-TRACE:        Removing   %4 = copy_value %1 : $T
+// CHECK-TRACE:        Removing   destroy_value %3 : $T
+// CHECK-TRACE:        Removing   %3 = copy_value %1 : $T
 //
 // CHECK-LABEL: sil [ossa] @testBorrowCopy : {{.*}} {
 // CHECK-LABEL: bb0:

--- a/test/SILOptimizer/shrink_borrow_scope.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.sil
@@ -804,12 +804,12 @@ entry(%instance : @owned $C):
   %_ = apply %callee_guaranteed(%lifetime_1) : $@convention(thin) (@guaranteed C) -> ()
   %synchronized = apply %synchronization_point() : $@convention(thin) () -> ()
   %copy_2 = copy_value %copy_1 : $C
+  %result = tuple ()
   end_borrow %lifetime_1 : $C
   %0 = apply %callee_owned(%instance) : $@convention(thin) (@owned C) -> ()
   %1 = apply %callee_owned(%copy_1) : $@convention(thin) (@owned C) -> ()
   %2 = apply %callee_owned(%copy_2) : $@convention(thin) (@owned C) -> ()
 
-  %result = tuple ()
   return %result : $()
 }
 
@@ -1120,6 +1120,54 @@ entry:
   destroy_value %c : $C
   %retval = tuple ()
   return %retval : $()
+}
+
+// Don't hoist over a copy_value that is rewritten.
+//
+// The borrowee's lifetime will be canonicalized again regardless.
+//
+// CHECK-LABEL: sil [ossa] @nohoist_over_rewritten_copy : {{.*}} { 
+// CHECK:       [[INSTANCE:%[^,]+]] = apply
+// CHECK:       [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:       [[COPY:%[^,]+]] = copy_value [[INSTANCE]]
+// CHECK:       end_borrow [[LIFETIME]]
+// CHECK:       tuple ([[COPY]] : $C, [[INSTANCE]] : $C)
+// CHECK-LABEL: } // end sil function 'nohoist_over_rewritten_copy'
+sil [ossa] @nohoist_over_rewritten_copy : $@convention(thin) () -> (@owned C, @owned C) {
+  %get_owned_c = function_ref @get_owned_c : $@convention(thin) () -> (@owned C)
+  %instance = apply %get_owned_c() : $@convention(thin) () -> (@owned C)
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  apply %callee_guaranteed(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+  %copy = copy_value %lifetime : $C
+  end_borrow %lifetime : $C
+  %retval = tuple (%copy : $C, %instance : $C)
+  return %retval : $(C, C)
+}
+
+// Don't hoist over multiple copy_values that are rewritten.
+//
+// The borrowee's lifetime will be canonicalized again regardless.
+//
+// CHECK-LABEL: sil [ossa] @nohoist_over_rewritten_copy_multiple : {{.*}} { 
+// CHECK:       [[INSTANCE:%[^,]+]] = apply
+// CHECK:       [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
+// CHECK:       [[COPY1:%[^,]+]] = copy_value [[INSTANCE]]
+// CHECK:       [[COPY2:%[^,]+]] = copy_value [[INSTANCE]]
+// CHECK:       end_borrow [[LIFETIME]]
+// CHECK:       tuple ([[COPY2]] : $C, [[COPY1]] : $C, [[INSTANCE]] : $C)
+// CHECK-LABEL: } // end sil function 'nohoist_over_rewritten_copy_multiple'
+sil [ossa] @nohoist_over_rewritten_copy_multiple : $@convention(thin) () -> (@owned C, @owned C, @owned C) {
+  %get_owned_c = function_ref @get_owned_c : $@convention(thin) () -> (@owned C)
+  %instance = apply %get_owned_c() : $@convention(thin) () -> (@owned C)
+  %lifetime = begin_borrow [lexical] %instance : $C
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  apply %callee_guaranteed(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+  %copy1 = copy_value %lifetime : $C
+  %copy2 = copy_value %lifetime : $C
+  end_borrow %lifetime : $C
+  %retval = tuple (%copy2 : $C, %copy1 : $C, %instance : $C)
+  return %retval : $(C, C, C)
 }
 
 // =============================================================================

--- a/test/SILOptimizer/shrink_borrow_scope.unit.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.unit.sil
@@ -1,0 +1,30 @@
+// RUN: %target-sil-opt -unit-test-runner %s 2>&1 | %FileCheck %s
+
+import Builtin
+import Swift
+
+class C {}
+
+sil [ossa] @get_owned_c : $@convention(thin) () -> (@owned C)
+sil [ossa] @callee_guaranteed: $@convention(thin) (@guaranteed C) -> ()
+
+// CHECK-LABEL: begin running test 1 of {{[^,]+}} on nohoist_over_rewritten_copy
+// CHECK-NOT: DELETED:
+// CHECK-NOT: end_borrow
+// CHECK-LABEL: end running test 1 of {{[^,]+}} on nohoist_over_rewritten_copy
+sil [ossa] @nohoist_over_rewritten_copy : $@convention(thin) () -> (@owned C, @owned C) {
+entry:
+  test_specification "shrink-borrow-scope @trace true @trace[1]"
+  %get_owned_c = function_ref @get_owned_c : $@convention(thin) () -> (@owned C)
+  %instance = apply %get_owned_c() : $@convention(thin) () -> (@owned C)
+  %lifetime = begin_borrow [lexical] %instance : $C
+  debug_value [trace] %lifetime : $C
+  %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
+  apply %callee_guaranteed(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+  %copy = copy_value %lifetime : $C
+  debug_value [trace] %copy : $C
+  end_borrow %lifetime : $C
+  %retval = tuple (%copy : $C, %instance : $C)
+  return %retval : $(C, C)
+}
+


### PR DESCRIPTION
When shrinking a borrow scope like

```
%borrow = begin_borrow %value
barrier
%copy = copy_value %borrow
end_borrow %borrow
```

the copy will be rewritten to be a copy of the borrowee:

```
%borrow = begin_borrow %value
barrier
%copy = copy_value %value
                   ^^^^^^
end_borrow %borrow
```

If, as here, shrinking next encounters a barrier, then the insertion point will be that rewritten `copy_value` instruction.

In such a case, rather than creating a new `end_borrow` there and deleting the old, just reuse the old one.  The lifetime of the value being copied will be canonicalized by `CopyPropagation` regardless.
