### PR TITLE
[Test] Added a few conveniences.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -3949,7 +3949,7 @@ The following types of test arguments are supported:
 - function: @function <-- the current function
             @function[uint] <-- function at index ``uint``
             @function[name] <-- function named ``name``
-- block: @block <-- the first block
+- block: @block <-- the block containing the test_specification instruction
          @block[uint] <-- the block at index ``uint``
          @{function}.{block} <-- the indicated block in the indicated function
          Example: @function[foo].block[2]
@@ -3957,7 +3957,7 @@ The following types of test arguments are supported:
          @trace[uint] <-- the ``debug_value [trace]`` at index ``uint``
          @{function}.{trace} <-- the indicated trace in the indicated function
          Example: @function[bar].trace
-- instruction: @instruction <-- the first instruction
+- instruction: @instruction <-- the instruction after* the test_specification instruction
                @instruction[uint] <-- the instruction at index ``uint``
                @{function}.{instruction} <-- the indicated instruction in the indicated function
                Example: @function[baz].instruction[19]
@@ -3968,6 +3968,11 @@ The following types of test arguments are supported:
            @{instruction}.{operand} <-- the indicated operand of the indicated instruction
            Example: @block[19].instruction[2].operand[3]
            Example: @function[2].instruction.operand
+
+* The first instruction that isn't deleted when processing functions for tests.
+  The following instructions currently are deleted:
+    test_specification
+    debug_value [trace]
 
 
 Profiling

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -3950,6 +3950,8 @@ The following types of test arguments are supported:
             @function[uint] <-- function at index ``uint``
             @function[name] <-- function named ``name``
 - block: @block <-- the block containing the test_specification instruction
+         @block[+uint] <-- the block ``uint`` blocks after the containing block
+         @block[-uint] <-- the block ``uint`` blocks before the containing block
          @block[uint] <-- the block at index ``uint``
          @{function}.{block} <-- the indicated block in the indicated function
          Example: @function[foo].block[2]

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -3958,6 +3958,8 @@ The following types of test arguments are supported:
          @{function}.{trace} <-- the indicated trace in the indicated function
          Example: @function[bar].trace
 - instruction: @instruction <-- the instruction after* the test_specification instruction
+               @instruction[+uint] <-- the instruction ``uint`` instructions after* the test_specification instruction
+               @instruction[-uint] <-- the instruction ``uint`` instructions before* the test_specification instruction
                @instruction[uint] <-- the instruction at index ``uint``
                @{function}.{instruction} <-- the indicated instruction in the indicated function
                Example: @function[baz].instruction[19]
@@ -3969,7 +3971,7 @@ The following types of test arguments are supported:
            Example: @block[19].instruction[2].operand[3]
            Example: @function[2].instruction.operand
 
-* The first instruction that isn't deleted when processing functions for tests.
+* Not counting instructions that are deleted when processing functions for tests.
   The following instructions currently are deleted:
     test_specification
     debug_value [trace]

--- a/include/swift/SILOptimizer/Utils/ParseTestSpecification.h
+++ b/include/swift/SILOptimizer/Utils/ParseTestSpecification.h
@@ -18,6 +18,7 @@
 #define SWIFT_SIL_PARSETESTSPECIFICATION
 
 #include "swift/Basic/TaggedUnion.h"
+#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILValue.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -140,7 +141,13 @@ struct Arguments {
     return cast<UIntArgument>(takeArgument()).getValue();
   }
   SILValue takeValue() {
-    return cast<ValueArgument>(takeArgument()).getValue();
+    auto argument = takeArgument();
+    if (isa<InstructionArgument>(argument)) {
+      auto *instruction = cast<InstructionArgument>(argument).getValue();
+      auto *svi = cast<SingleValueInstruction>(instruction);
+      return svi;
+    }
+    return cast<ValueArgument>(argument).getValue();
   }
   Operand *takeOperand() {
     return cast<OperandArgument>(takeArgument()).getValue();

--- a/include/swift/SILOptimizer/Utils/ParseTestSpecification.h
+++ b/include/swift/SILOptimizer/Utils/ParseTestSpecification.h
@@ -163,17 +163,32 @@ struct Arguments {
   }
 };
 
+/// The specification for a test which has not yet been parsed.
+struct UnparsedSpecification {
+  /// The string which specifies the test.
+  ///
+  /// Not a StringRef because the TestSpecificationInst whose payload is of
+  /// interest gets deleted.
+  std::string string;
+  /// The next non-debug instruction.
+  ///
+  /// Provides an "anchor" for the specification.  Contextual arguments
+  /// (@instruction, @block, @function) can be parsed in terms of this anchor.
+  SILInstruction *context;
+};
+
 /// Finds and deletes each test_specification instruction in \p function and
 /// appends its string payload to the provided vector.
-void getTestSpecifications(SILFunction *function,
-                           SmallVectorImpl<std::string> &specifications);
+void getTestSpecifications(
+    SILFunction *function,
+    SmallVectorImpl<UnparsedSpecification> &specifications);
 
 /// Given the string \p specification operand of a test_specification
 /// instruction from \p function, parse the arguments which it refers to into
 /// \p arguments and the component strings into \p argumentStrings.
 void parseTestArgumentsFromSpecification(
-    SILFunction *function, StringRef specification, Arguments &arguments,
-    SmallVectorImpl<StringRef> &argumentStrings);
+    SILFunction *function, UnparsedSpecification const &specification,
+    Arguments &arguments, SmallVectorImpl<StringRef> &argumentStrings);
 
 } // namespace test
 } // namespace swift

--- a/lib/SILOptimizer/UtilityPasses/ParseTestSpecification.cpp
+++ b/lib/SILOptimizer/UtilityPasses/ParseTestSpecification.cpp
@@ -39,6 +39,25 @@ void findAndDeleteTraceValues(SILFunction *function,
   }
 }
 
+bool isDeleteableTestInstruction(SILInstruction const *instruction) {
+  if (auto *dvi = dyn_cast<DebugValueInst>(instruction))
+    return dvi->hasTrace();
+  if (isa<TestSpecificationInst>(instruction))
+    return true;
+  return false;
+}
+
+SILInstruction *findAnchorInstructionAfter(TestSpecificationInst *tsi) {
+  for (auto *instruction = tsi->getNextInstruction(); instruction;
+       instruction = instruction->getNextInstruction()) {
+    if (!isDeleteableTestInstruction(instruction))
+      return instruction;
+  }
+  // This can't happen because a TestSpecificationInst isn't a terminator itself
+  // nor are any deleteable instructions.
+  llvm_unreachable("found no anchor after TestSpecificationInst!?");
+}
+
 // Helpers: Looking up subobjects by index
 
 SILInstruction *getInstruction(SILFunction *function, unsigned long index) {
@@ -89,14 +108,14 @@ class ParseTestSpecification;
 class ParseArgumentSpecification {
   ParseTestSpecification &outer;
   StringRef specification;
+  SILInstruction *context;
 
-  SILFunction *getFunction();
   SILValue getTraceValue(unsigned index, SILFunction *function);
 
 public:
   ParseArgumentSpecification(ParseTestSpecification &outer,
-                             StringRef specification)
-      : outer(outer), specification(specification) {}
+                             StringRef specification, SILInstruction *context)
+      : outer(outer), specification(specification), context(context) {}
 
   Argument parse() {
     auto argument = parseArgument();
@@ -183,6 +202,10 @@ private:
   SILValue parseTraceComponent(SILFunction *within) {
     if (!consumePrefix("trace"))
       return SILValue();
+    // TODO: Use a bare @trace (i.e. within == nullptr) to refer to the value
+    //       which appears in the debug_value [trace] instruction.
+    if (!within)
+      within = context->getFunction();
     if (empty() || peekPrefix("."))
       return getTraceValue(0, within);
     if (auto subscript = parseSubscript()) {
@@ -228,11 +251,13 @@ private:
     return OperandArgument{operand};
   }
 
-  SILInstruction *parseInstructionComponent(
-      TaggedUnion<SILFunction *, SILBasicBlock *> within) {
+  using InstructionContext = TaggedUnion<SILFunction *, SILBasicBlock *>;
+
+  SILInstruction *
+  parseInstructionComponent(Optional<InstructionContext> within) {
     if (!consumePrefix("instruction"))
       return nullptr;
-    auto getInstructionAtIndex = [within](unsigned index) {
+    auto getInstructionAtIndex = [](unsigned index, InstructionContext within) {
       if (within.isa<SILFunction *>()) {
         auto *function = within.get<SILFunction *>();
         return getInstruction(function, index);
@@ -241,17 +266,23 @@ private:
       return getInstruction(block, index);
     };
     if (empty() || peekPrefix(".")) {
-      return getInstructionAtIndex(0);
+      if (!within) {
+        // If this is a bare @instruction reference, it refers to to the
+        // context of the test_specification.
+        return context;
+      }
+      return getInstructionAtIndex(0, *within);
     }
     if (auto subscript = parseSubscript()) {
       auto index = subscript->get<unsigned long long>();
-      return getInstructionAtIndex(index);
+      return getInstructionAtIndex(index,
+                                   within.getValueOr(context->getFunction()));
     }
     llvm_unreachable("bad suffix after 'instruction'!?");
   }
 
-  Optional<Argument> parseInstructionReference(
-      TaggedUnion<SILFunction *, SILBasicBlock *> within) {
+  Optional<Argument>
+  parseInstructionReference(Optional<InstructionContext> within) {
     auto *instruction = parseInstructionComponent(within);
     if (!instruction)
       return llvm::None;
@@ -266,10 +297,18 @@ private:
     if (!consumePrefix("block"))
       return nullptr;
     if (empty() || peekPrefix(".")) {
+      // If this is a bare @block reference, it refers to the block containing
+      // the test_specification instruction.
+      if (!within) {
+        return context->getParent();
+      }
       auto *block = getBlock(within, 0);
       return block;
     }
     if (auto subscript = parseSubscript()) {
+      if (!within) {
+        within = context->getFunction();
+      }
       auto index = subscript->get<unsigned long long>();
       auto *block = getBlock(within, index);
       return block;
@@ -283,7 +322,7 @@ private:
       return llvm::None;
     if (!consumePrefix("."))
       return BlockArgument{block};
-    if (auto arg = parseInstructionReference(block))
+    if (auto arg = parseInstructionReference({block}))
       return *arg;
     llvm_unreachable("unhandled suffix after 'block'!?");
   }
@@ -292,16 +331,24 @@ private:
     if (!consumePrefix("function"))
       return nullptr;
     if (empty() || peekPrefix(".")) {
-      return getFunction();
+      // If this is a bare @function reference, it refers to the function
+      // containing the test_specification instruction.
+      if (!within) {
+        return context->getFunction();
+      }
+      return ::getFunction(within, 0);
     }
     if (auto subscript = parseSubscript()) {
+      if (!within) {
+        within = &context->getFunction()->getModule();
+      }
       if (subscript->isa<unsigned long long>()) {
         auto index = subscript->get<unsigned long long>();
         auto *fn = ::getFunction(within, index);
         return fn;
       } else {
         auto name = subscript->get<StringRef>();
-        auto *specified = getFunction()->getModule().lookUpFunction(name);
+        auto *specified = within->lookUpFunction(name);
         if (!specified)
           llvm_unreachable("unknown function name!?");
         return specified;
@@ -316,7 +363,7 @@ private:
       return llvm::None;
     if (!consumePrefix("."))
       return FunctionArgument{function};
-    if (auto arg = parseInstructionReference(function))
+    if (auto arg = parseInstructionReference({function}))
       return *arg;
     if (auto arg = parseTraceReference(function))
       return *arg;
@@ -328,15 +375,16 @@ private:
   Optional<Argument> parseReference() {
     if (!consumePrefix("@"))
       return llvm::None;
-    if (auto arg = parseTraceReference(getFunction()))
+    if (auto arg = parseTraceReference(nullptr))
       return *arg;
-    if (auto arg = parseOperandReference(getInstruction(getFunction(), 0)))
+    if (auto arg =
+            parseOperandReference(getInstruction(context->getFunction(), 0)))
       return *arg;
-    if (auto arg = parseInstructionReference(getFunction()))
+    if (auto arg = parseInstructionReference(llvm::None))
       return *arg;
-    if (auto arg = parseBlockReference(getFunction()))
+    if (auto arg = parseBlockReference(nullptr))
       return *arg;
-    if (auto arg = parseFunctionReference(&getFunction()->getModule()))
+    if (auto arg = parseFunctionReference(nullptr))
       return *arg;
     return llvm::None;
   }
@@ -384,21 +432,20 @@ public:
                          SmallVectorImpl<StringRef> &components)
       : function(function), components(components) {}
 
-  void parse(StringRef specification, Arguments &arguments) {
-    specification.split(components, " ");
+  void parse(UnparsedSpecification const &specification, Arguments &arguments) {
+    StringRef specificationString = specification.string;
+    specificationString.split(components, " ");
     for (unsigned long index = 0, size = components.size(); index < size;
          ++index) {
-      auto component = components[index];
-      ParseArgumentSpecification parser(*this, component);
+      auto componentString = components[index];
+      ParseArgumentSpecification parser(*this, componentString,
+                                        specification.context);
       auto argument = parser.parse();
       arguments.storage.push_back(argument);
     }
   }
 };
 
-SILFunction *ParseArgumentSpecification::getFunction() {
-  return outer.function;
-}
 SILValue ParseArgumentSpecification::getTraceValue(unsigned index,
                                                    SILFunction *function) {
   return outer.getTraceValue(index, function);
@@ -409,13 +456,15 @@ SILValue ParseArgumentSpecification::getTraceValue(unsigned index,
 // API
 
 void swift::test::getTestSpecifications(
-    SILFunction *function, SmallVectorImpl<std::string> &specifications) {
+    SILFunction *function,
+    SmallVectorImpl<UnparsedSpecification> &specifications) {
   InstructionDeleter deleter;
   for (auto &block : *function) {
     for (SILInstruction *inst : deleter.updatingRange(&block)) {
       if (auto *tsi = dyn_cast<TestSpecificationInst>(inst)) {
         auto ref = tsi->getArgumentsSpecification();
-        specifications.push_back(std::string(ref.begin(), ref.end()));
+        auto *anchor = findAnchorInstructionAfter(tsi);
+        specifications.push_back({std::string(ref.begin(), ref.end()), anchor});
         deleter.forceDelete(tsi);
       }
     }
@@ -423,8 +472,8 @@ void swift::test::getTestSpecifications(
 }
 
 void swift::test::parseTestArgumentsFromSpecification(
-    SILFunction *function, StringRef specification, Arguments &arguments,
-    SmallVectorImpl<StringRef> &argumentStrings) {
+    SILFunction *function, UnparsedSpecification const &specification,
+    Arguments &arguments, SmallVectorImpl<StringRef> &argumentStrings) {
   ParseTestSpecification parser(function, argumentStrings);
   parser.parse(specification, arguments);
 }

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -325,7 +325,7 @@ class UnitTestRunner : public SILFunctionTransform {
   }
 
   void run() override {
-    llvm::SmallVector<std::string, 2> testSpecifications;
+    llvm::SmallVector<UnparsedSpecification, 2> testSpecifications;
     getTestSpecifications(getFunction(), testSpecifications);
     Arguments arguments;
     SmallVector<StringRef, 4> components;

--- a/test/SILOptimizer/unit_test.sil
+++ b/test/SILOptimizer/unit_test.sil
@@ -89,6 +89,32 @@ bb1:
   return %zero : $()
 }
 
+// CHECK-LABEL: begin running test 1 of {{[^,]+}} on test_contextual_arg_parsing: test-specification-parsing
+// CHECK: block:
+// CHECK: bb1
+// CHECK-LABEL: end running test 1 of {{[^,]+}} on test_contextual_arg_parsing: test-specification-parsing
+// CHECK-LABEL: begin running test 2 of {{[^,]+}} on test_contextual_arg_parsing: test-specification-parsing
+// CHECK: instruction:
+// CHECK: tuple
+// CHECK-LABEL: end running test 2 of {{[^,]+}} on test_contextual_arg_parsing: test-specification-parsing
+// CHECK-LABEL: begin running test 3 of {{[^,]+}} on test_contextual_arg_parsing: test-specification-parsing
+// CHECK: function: test_contextual_arg_parsing
+// CHECK-LABEL: end running test 3 of {{[^,]+}} on test_contextual_arg_parsing: test-specification-parsing
+sil [ossa] @test_contextual_arg_parsing : $() -> () {
+entry:
+  br one
+one:
+  test_specification "test-specification-parsing B @block"
+  br two
+two:
+  test_specification "test-specification-parsing I @instruction"
+  %retval = tuple ()
+  br exit
+exit:
+  test_specification "test-specification-parsing F @function"
+  return %retval : $()
+}
+
 class C {}
 
 sil [ossa] @getC : $@convention(thin) () -> @owned C

--- a/test/SILOptimizer/unit_test.sil
+++ b/test/SILOptimizer/unit_test.sil
@@ -98,8 +98,14 @@ bb1:
 // CHECK: tuple
 // CHECK-LABEL: end running test 2 of {{[^,]+}} on test_contextual_arg_parsing: test-specification-parsing
 // CHECK-LABEL: begin running test 3 of {{[^,]+}} on test_contextual_arg_parsing: test-specification-parsing
-// CHECK: function: test_contextual_arg_parsing
+// CHECK: instruction: br bb2
+// CHECK: instruction: {{%[^,]+}} = tuple ()
+// CHECK: instruction: br bb3
+// CHECK: instruction: return
 // CHECK-LABEL: end running test 3 of {{[^,]+}} on test_contextual_arg_parsing: test-specification-parsing
+// CHECK-LABEL: begin running test 4 of {{[^,]+}} on test_contextual_arg_parsing: test-specification-parsing
+// CHECK: function: test_contextual_arg_parsing
+// CHECK-LABEL: end running test 4 of {{[^,]+}} on test_contextual_arg_parsing: test-specification-parsing
 sil [ossa] @test_contextual_arg_parsing : $() -> () {
 entry:
   br one
@@ -108,6 +114,7 @@ one:
   br two
 two:
   test_specification "test-specification-parsing I @instruction"
+  test_specification "test-specification-parsing IIII @instruction[-1] @instruction[+0] @instruction[+1] @instruction[+2]"
   %retval = tuple ()
   br exit
 exit:

--- a/test/SILOptimizer/unit_test.sil
+++ b/test/SILOptimizer/unit_test.sil
@@ -104,8 +104,18 @@ bb1:
 // CHECK: instruction: return
 // CHECK-LABEL: end running test 3 of {{[^,]+}} on test_contextual_arg_parsing: test-specification-parsing
 // CHECK-LABEL: begin running test 4 of {{[^,]+}} on test_contextual_arg_parsing: test-specification-parsing
-// CHECK: function: test_contextual_arg_parsing
+// CHECK: block
+// CHECK: bb0
+// CHECK: block
+// CHECK: bb1
+// CHECK: block
+// CHECK: bb2
+// CHECK: block
+// CHECK: bb3
 // CHECK-LABEL: end running test 4 of {{[^,]+}} on test_contextual_arg_parsing: test-specification-parsing
+// CHECK-LABEL: begin running test 5 of {{[^,]+}} on test_contextual_arg_parsing: test-specification-parsing
+// CHECK: function: test_contextual_arg_parsing
+// CHECK-LABEL: end running test 5 of {{[^,]+}} on test_contextual_arg_parsing: test-specification-parsing
 sil [ossa] @test_contextual_arg_parsing : $() -> () {
 entry:
   br one
@@ -115,6 +125,7 @@ one:
 two:
   test_specification "test-specification-parsing I @instruction"
   test_specification "test-specification-parsing IIII @instruction[-1] @instruction[+0] @instruction[+1] @instruction[+2]"
+  test_specification "test-specification-parsing BBBB @block[-2] @block[-1] @block[+0] @block[+1]"
   %retval = tuple ()
   br exit
 exit:

--- a/test/SILOptimizer/unit_test.sil
+++ b/test/SILOptimizer/unit_test.sil
@@ -54,6 +54,10 @@ import Builtin
 // CHECK: value: {{%[^,]+}} = tuple ({{%[^,]+}} : $(), {{%[^,]+}} : $(_: ()), {{%[^,]+}} : $((), (_: ())))
 // CHECK: string: howdy
 // CHECK-LABEL: end running test 7 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
+// CHECK-LABEL: begin running test 8 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
+// CHECK: value: 
+// CHECK: function_ref @something_remarkable
+// CHECK-LABEL: end running test 8 of {{[^,]+}} on test_arg_parsing: test-specification-parsing
 sil [ossa] @test_arg_parsing : $() -> () {
 entry:
   test_specification "test-specification-parsing FFFbb @function[test_arg_parsing_reference] @function[2] @function true false"
@@ -63,6 +67,7 @@ entry:
   test_specification "test-specification-parsing IIIIIIII @function.block.instruction @function[0].block.instruction @function.block[0].instruction @function.block.instruction[0] @function[0].block[0].instruction @function[0].block.instruction[0] @function.block[0].instruction[0] @function[0].block[0].instruction[0]"
   test_specification "test-specification-parsing OO @instruction[2].operand @function[test_arg_parsing_callee].trace.operand[1]"
   test_specification "test-specification-parsing Vs @function[4].trace[0] howdy"
+  test_specification "test-specification-parsing V @instruction[0]"
   %something_remarkable = function_ref @something_remarkable : $@convention(thin) () -> ()
   %retval = tuple ()
   return %retval : $()


### PR DESCRIPTION
The new conveniences:
- let instruction references which reference SingleValueInstructions be taken as values
- let "bare" instruction and block references (i.e. `@instruction` and `@block`) refer to the "current" instruction and block respectively
- allow referring to instructions and blocks offset from the "current" instruction and block (e.g. `@instruction[+2]` and `@block[-1]`)
