### PR TITLE
[Macros] "Expand" builtin macros for magic literals. 

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -316,6 +316,10 @@ public:
   /// this source file.
   llvm::SmallVector<Located<StringRef>, 0> VirtualFilePaths;
 
+  /// The \c ExportedSourceFile instance produced by ASTGen, which includes
+  /// the SourceFileSyntax node corresponding to this source file.
+  void *exportedSourceFile = nullptr;
+
   /// Returns information about the file paths used for diagnostics and magic
   /// identifiers in this source file, including virtual filenames introduced by
   /// \c #sourceLocation(file:) declarations.

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -145,7 +145,12 @@ EXPERIMENTAL_FEATURE(ImplicitSome)
 /// corresponding syntax tree.
 EXPERIMENTAL_FEATURE(ParserASTGen)
 
+/// Enable the experimental macros feature.
 EXPERIMENTAL_FEATURE(Macros)
+
+/// Parse using the Swift (swift-syntax) parser and use ASTGen to generate the
+/// corresponding syntax tree.
+EXPERIMENTAL_FEATURE(BuiltinMacros)
 
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3098,6 +3098,10 @@ static bool usesFeatureParserASTGen(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureBuiltinMacros(Decl *decl) {
+  return false;
+}
+
 static void
 suppressingFeatureNoAsyncAvailability(PrintOptions &options,
                                       llvm::function_ref<void()> action) {

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -5,6 +5,7 @@ if (SWIFT_SWIFT_PARSER)
     Sources/ASTGen/Exprs.swift
     Sources/ASTGen/Literals.swift
     Sources/ASTGen/Misc.swift
+    Sources/ASTGen/SourceFile.swift
     Sources/ASTGen/Stmts.swift
   )
 

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -40,6 +40,8 @@ if (SWIFT_SWIFT_PARSER)
     $<TARGET_OBJECTS:SwiftSyntax::SwiftDiagnostics>
     $<TARGET_OBJECTS:SwiftSyntax::SwiftSyntax>
     $<TARGET_OBJECTS:SwiftSyntax::SwiftOperators>
+    $<TARGET_OBJECTS:SwiftSyntax::SwiftSyntaxBuilder>
+    $<TARGET_OBJECTS:SwiftSyntax::_SwiftSyntaxMacros>
     $<TARGET_OBJECTS:SwiftSyntax::SwiftCompilerSupport>
 
     swiftAST
@@ -54,6 +56,8 @@ if (SWIFT_SWIFT_PARSER)
     SwiftSyntax::SwiftDiagnostics
     SwiftSyntax::SwiftSyntax
     SwiftSyntax::SwiftOperators
+    SwiftSyntax::SwiftSyntaxBuilder
+    SwiftSyntax::_SwiftSyntaxMacros
     SwiftSyntax::SwiftCompilerSupport
     swiftAST
   )

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -4,6 +4,7 @@ if (SWIFT_SWIFT_PARSER)
     Sources/ASTGen/Decls.swift
     Sources/ASTGen/Exprs.swift
     Sources/ASTGen/Literals.swift
+    Sources/ASTGen/Macros.swift
     Sources/ASTGen/Misc.swift
     Sources/ASTGen/SourceFile.swift
     Sources/ASTGen/Stmts.swift

--- a/lib/ASTGen/Package.swift
+++ b/lib/ASTGen/Package.swift
@@ -25,7 +25,8 @@ let package = Package(
             name: "swiftASTGen",
             dependencies: [
               .product(name: "SwiftSyntax", package: "swift-syntax"),
-              .product(name: "SwiftParser", package: "swift-syntax")
+              .product(name: "SwiftParser", package: "swift-syntax"),
+              .product(name: "_SwiftSyntaxMacros", package: "swift-syntax")
             ],
             path: ".",
             exclude: ["CMakeLists.txt"],

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -69,53 +69,6 @@ struct ASTGenVisitor: SyntaxTransformVisitor {
   }
 }
 
-/// Describes a source file that has been "exported" to the C++ part of the
-/// compiler, with enough information to interface with the C++ layer.
-struct ExportedSourceFile {
-  /// The underlying buffer within the C++ SourceManager, which is used
-  /// for computations of source locations.
-  let buffer: UnsafeBufferPointer<UInt8>
-
-  /// The name of the enclosing module.
-  let moduleName: String
-
-  /// The name of the source file being parsed.
-  let fileName: String
-
-  /// The syntax tree for the complete source file.
-  let syntax: SourceFileSyntax
-}
-
-/// Parses the given source file and produces a pointer to a new
-/// ExportedSourceFile instance.
-@_cdecl("swift_ASTGen_parseSourceFile")
-public func parseSourceFile(
-  buffer: UnsafePointer<UInt8>, bufferLength: Int,
-  moduleName: UnsafePointer<UInt8>, filename: UnsafePointer<UInt8>
-) -> UnsafeRawPointer {
-  let buffer = UnsafeBufferPointer(start: buffer, count: bufferLength)
-  let sourceFile = Parser.parse(source: buffer)
-
-  let exportedPtr = UnsafeMutablePointer<ExportedSourceFile>.allocate(capacity: 1)
-  exportedPtr.initialize(to: .init(
-    buffer: buffer, moduleName: String(cString: moduleName),
-    fileName: String(cString: filename), syntax: sourceFile)
-  )
-
-  return UnsafeRawPointer(exportedPtr)
-}
-
-/// Deallocate a parsed source file.
-@_cdecl("swift_ASTGen_destroySourceFile")
-public func destroySourceFile(
-  sourceFilePtr: UnsafeMutableRawPointer
-) {
-  sourceFilePtr.withMemoryRebound(to: ExportedSourceFile.self, capacity: 1) { sourceFile in
-    sourceFile.deinitialize(count: 1)
-    sourceFile.deallocate()
-  }
-}
-
 /// Generate AST nodes for all top-level entities in the given source file.
 @_cdecl("swift_ASTGen_buildTopLevelASTNodes")
 public func buildTopLevelASTNodes(

--- a/lib/ASTGen/Sources/ASTGen/ASTGen.swift
+++ b/lib/ASTGen/Sources/ASTGen/ASTGen.swift
@@ -72,7 +72,7 @@ struct ASTGenVisitor: SyntaxTransformVisitor {
 /// Generate AST nodes for all top-level entities in the given source file.
 @_cdecl("swift_ASTGen_buildTopLevelASTNodes")
 public func buildTopLevelASTNodes(
-  sourceFilePtr: UnsafeRawPointer,
+  sourceFilePtr: UnsafePointer<UInt8>,
   dc: UnsafeMutableRawPointer,
   ctx: UnsafeMutableRawPointer,
   outputContext: UnsafeMutableRawPointer,

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -1,0 +1,75 @@
+import SwiftSyntax
+@_spi(Testing) import _SwiftSyntaxMacros
+
+extension SyntaxProtocol {
+  func token(at position: AbsolutePosition) -> TokenSyntax? {
+    // If the position isn't within this node at all, return early.
+    guard position >= self.position && position < self.endPosition else {
+      return nil
+    }
+
+    // If we are a token syntax, that's it!
+    if let token = Syntax(self).as(TokenSyntax.self) {
+      return token
+    }
+
+    // Otherwise, it must be one of our children.
+    return children(viewMode: .sourceAccurate).lazy.compactMap { child in
+      child.token(at: position)
+    }.first
+  }
+}
+
+@_cdecl("swift_ASTGen_printMacroResult")
+public func printMacroResult(
+  sourceFilePtr: UnsafeRawPointer,
+  sourceLocationPtr: UnsafePointer<UInt8>?
+) -> Int {
+  guard let sourceLocationPtr = sourceLocationPtr else {
+    print("NULL source location")
+    return -1
+  }
+
+  return sourceFilePtr.withMemoryRebound(
+    to: ExportedSourceFile.self, capacity: 1
+  ) { (sourceFile: UnsafePointer<ExportedSourceFile>) -> Int in
+    // Find the offset.
+    let buffer = sourceFile.pointee.buffer
+    let offset = sourceLocationPtr - buffer.baseAddress!
+    if offset < 0 || offset >= buffer.count {
+      print("source location isn't inside this buffer")
+      return -1
+    }
+
+    let sf = sourceFile.pointee.syntax
+    guard let token = sf.token(at: AbsolutePosition(utf8Offset: offset)) else {
+      print("couldn't find token at offset \(offset)")
+      return -1
+    }
+
+    guard let parentSyntax = token.parent,
+          parentSyntax.is(MacroExpansionExprSyntax.self) else {
+      print("not on a macro expansion node: \(token.recursiveDescription)")
+      return -1
+    }
+
+    let macroSystem = MacroSystem.exampleSystem
+    let converter = SourceLocationConverter(
+      file: sourceFile.pointee.fileName, tree: sf
+    )
+    let context = MacroEvaluationContext(
+      moduleName: sourceFile.pointee.moduleName,
+      sourceLocationConverter: converter
+    )
+
+    let evaluatedSyntax = parentSyntax.evaluateMacro(
+      with: macroSystem, context: context
+    ) { error in
+      /* TODO: Report errors */
+    }
+
+    print("Macro rewrite: \(parentSyntax.withoutTrivia()) --> \(evaluatedSyntax.withoutTrivia())")
+
+    return 0
+  }
+}

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -40,7 +40,7 @@ public func parseSourceFile(
 /// Deallocate a parsed source file.
 @_cdecl("swift_ASTGen_destroySourceFile")
 public func destroySourceFile(
-  sourceFilePtr: UnsafeMutableRawPointer
+  sourceFilePtr: UnsafeMutablePointer<UInt8>
 ) {
   sourceFilePtr.withMemoryRebound(to: ExportedSourceFile.self, capacity: 1) { sourceFile in
     sourceFile.deinitialize(count: 1)

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -1,0 +1,49 @@
+import SwiftParser
+import SwiftSyntax
+
+/// Describes a source file that has been "exported" to the C++ part of the
+/// compiler, with enough information to interface with the C++ layer.
+struct ExportedSourceFile {
+  /// The underlying buffer within the C++ SourceManager, which is used
+  /// for computations of source locations.
+  let buffer: UnsafeBufferPointer<UInt8>
+
+  /// The name of the enclosing module.
+  let moduleName: String
+
+  /// The name of the source file being parsed.
+  let fileName: String
+
+  /// The syntax tree for the complete source file.
+  let syntax: SourceFileSyntax
+}
+
+/// Parses the given source file and produces a pointer to a new
+/// ExportedSourceFile instance.
+@_cdecl("swift_ASTGen_parseSourceFile")
+public func parseSourceFile(
+  buffer: UnsafePointer<UInt8>, bufferLength: Int,
+  moduleName: UnsafePointer<UInt8>, filename: UnsafePointer<UInt8>
+) -> UnsafeRawPointer {
+  let buffer = UnsafeBufferPointer(start: buffer, count: bufferLength)
+  let sourceFile = Parser.parse(source: buffer)
+
+  let exportedPtr = UnsafeMutablePointer<ExportedSourceFile>.allocate(capacity: 1)
+  exportedPtr.initialize(to: .init(
+    buffer: buffer, moduleName: String(cString: moduleName),
+    fileName: String(cString: filename), syntax: sourceFile)
+  )
+
+  return UnsafeRawPointer(exportedPtr)
+}
+
+/// Deallocate a parsed source file.
+@_cdecl("swift_ASTGen_destroySourceFile")
+public func destroySourceFile(
+  sourceFilePtr: UnsafeMutableRawPointer
+) {
+  sourceFilePtr.withMemoryRebound(to: ExportedSourceFile.self, capacity: 1) { sourceFile in
+    sourceFile.deinitialize(count: 1)
+    sourceFile.deallocate()
+  }
+}

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -54,6 +54,8 @@ if (SWIFT_SWIFT_PARSER)
     $<TARGET_OBJECTS:SwiftSyntax::SwiftDiagnostics>
     $<TARGET_OBJECTS:SwiftSyntax::SwiftSyntax>
     $<TARGET_OBJECTS:SwiftSyntax::SwiftOperators>
+    $<TARGET_OBJECTS:SwiftSyntax::SwiftSyntaxBuilder>
+    $<TARGET_OBJECTS:SwiftSyntax::_SwiftSyntaxMacros>
     $<TARGET_OBJECTS:SwiftSyntax::SwiftCompilerSupport>
     $<TARGET_OBJECTS:swiftASTGen>
   )
@@ -64,6 +66,8 @@ if (SWIFT_SWIFT_PARSER)
     SwiftSyntax::SwiftDiagnostics
     SwiftSyntax::SwiftSyntax
     SwiftSyntax::SwiftOperators
+    SwiftSyntax::SwiftSyntaxBuilder
+    SwiftSyntax::_SwiftSyntaxMacros
     SwiftSyntax::SwiftCompilerSupport
     swiftASTGen
   )

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -199,7 +199,8 @@ extern "C" void swift_ASTGen_buildTopLevelASTNodes(void *sourceFile,
 /// \endverbatim
 void Parser::parseTopLevel(SmallVectorImpl<Decl *> &decls) {
 #ifdef SWIFT_SWIFT_PARSER
-  if (Context.LangOpts.hasFeature(Feature::ParserASTGen) &&
+  if ((Context.LangOpts.hasFeature(Feature::BuiltinMacros) ||
+       Context.LangOpts.hasFeature(Feature::ParserASTGen)) &&
       !SourceMgr.hasCodeCompletionBuffer() &&
       SF.Kind != SourceFileKind::SIL) {
     StringRef contents =

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -173,6 +173,22 @@ static void appendToVector(void *declPtr, void *vecPtr) {
   vec->push_back(decl);
 }
 
+/// Parse a source file.
+extern "C" void *swift_ASTGen_parseSourceFile(const char *buffer,
+                                              size_t bufferLength,
+                                              const char *moduleName,
+                                              const char *filename);
+
+/// Destroy a source file parsed with swift_ASTGen_parseSourceFile.
+extern "C" void swift_ASTGen_destroySourceFile(void *sourceFile);
+
+// Build AST nodes for the top-level entities in the syntax.
+extern "C" void swift_ASTGen_buildTopLevelASTNodes(void *sourceFile,
+                                                   void *declContext,
+                                                   void *astContext,
+                                                   void *outputContext,
+                                                   void (*)(void *, void *));
+
 /// Main entrypoint for the parser.
 ///
 /// \verbatim
@@ -182,20 +198,35 @@ static void appendToVector(void *declPtr, void *vecPtr) {
 ///     decl-sil-stage [[only in SIL mode]
 /// \endverbatim
 void Parser::parseTopLevel(SmallVectorImpl<Decl *> &decls) {
-  StringRef contents =
-      SourceMgr.extractText(SourceMgr.getRangeForBuffer(L->getBufferID()));
-
 #ifdef SWIFT_SWIFT_PARSER
   if (Context.LangOpts.hasFeature(Feature::ParserASTGen) &&
       !SourceMgr.hasCodeCompletionBuffer() &&
       SF.Kind != SourceFileKind::SIL) {
-    parseTopLevelSwift(contents.data(), CurDeclContext, &Context, &decls, appendToVector);
+    StringRef contents =
+        SourceMgr.extractText(SourceMgr.getRangeForBuffer(L->getBufferID()));
 
-    // Spin the C++ parser to the end; we won't be using it.
-    while (!Tok.is(tok::eof)) {
-      consumeToken();
+    // Parse the source file.
+    auto exportedSourceFile = swift_ASTGen_parseSourceFile(
+        contents.begin(), contents.size(),
+        SF.getParentModule()->getName().str().str().c_str(),
+        SF.getFilename().str().c_str());
+    SF.exportedSourceFile = exportedSourceFile;
+    Context.addCleanup([exportedSourceFile] {
+      swift_ASTGen_destroySourceFile(exportedSourceFile);
+    });
+
+    // If we want to do ASTGen, do so now.
+    if (Context.LangOpts.hasFeature(Feature::ParserASTGen)) {
+      swift_ASTGen_buildTopLevelASTNodes(
+          exportedSourceFile, CurDeclContext, &Context, &decls, appendToVector);
+
+      // Spin the C++ parser to the end; we won't be using it.
+      while (!Tok.is(tok::eof)) {
+        consumeToken();
+      }
+
+      return;
     }
-    return;
   }
 #endif
   

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -79,6 +79,14 @@ if(SWIFT_FORCE_OPTIMIZED_TYPECHECKER)
     target_compile_options(swiftSema PRIVATE -O3)
   endif()
 endif()
+
+if (SWIFT_SWIFT_PARSER)
+  target_compile_definitions(swiftSema
+    PRIVATE
+    SWIFT_SWIFT_PARSER
+  )
+endif()
+
 target_link_libraries(swiftSema PRIVATE
   swiftAST
   swiftParse

--- a/test/Macros/builtin_macros.swift
+++ b/test/Macros/builtin_macros.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -enable-experimental-feature BuiltinMacros -typecheck %s -module-name MacrosTest 2>&1 | %FileCheck %s
+// REQUIRES: OS=macosx
+
+// CHECK: #function --> "MacrosTest"
+print(#function)
+
+func f(a: Int, b: Int) {
+  print(#function, #line, #column)
+  // CHECK-NEXT: #function --> "f(a:b:)"
+  // CHECK-NEXT: #line --> 8
+  // CHECK-NEXT: #column --> 27
+}


### PR DESCRIPTION
Introduce an experimental option `BuiltinMacros` that takes the magic
literals (`#file`, `#line`, `#function`, etc.) after type checking and
processes the original source for the expression using the build
syntactic macro system in the swift-syntax library. At present, the
result of expansion is printed to standard output, and type checking
is otherwise unaffected.

This serves primarily to make sure that, given a C++ AST node,
we can find the corresponding syntax node (as parsed by the new
parser) and perform expansion on it.