### PR TITLE
build: fix syntax error in FreeBSD section of configure_sdk_unix

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -374,7 +374,7 @@ macro(configure_sdk_unix name architectures)
           message(FATAL_ERROR "unsupported arch for FreeBSD: ${arch}")
         endif()
 
-        if(CMAKE_HOST_SYSTEM_NAME NOT STREQUAL FreeBSD)
+        if(NOT CMAKE_HOST_SYSTEM_NAME STREQUAL FreeBSD)
           message(WARNING "CMAKE_SYSTEM_VERSION will not match target")
         endif()
 


### PR DESCRIPTION
Fix syntax error in the FreeBSD section of `configure_sdk_unix`.  The syntax error results in this error during configuration:

```
CMake Error at cmake/modules/SwiftConfigureSDK.cmake:336 (if):
  if given arguments:

    "CMAKE_HOST_SYSTEM_NAME" "NOT" "STREQUAL" "FreeBSD"

  Unknown arguments specified
Call Stack (most recent call first):
  CMakeLists.txt:854 (configure_sdk_unix)


-- Configuring incomplete, errors occurred!
```