### PR TITLE
[5.7] Don't target arm64/arm64e for the back-deployed Concurrency dyl…

### DIFF
--- a/stdlib/public/BackDeployConcurrency/CMakeLists.txt
+++ b/stdlib/public/BackDeployConcurrency/CMakeLists.txt
@@ -29,6 +29,10 @@ list(REMOVE_ITEM SWIFT_SDK_IOS_SIMULATOR_ARCHITECTURES "i386")
 list(REMOVE_ITEM SWIFT_SDK_IOS_ARCHITECTURES "arm64e")
 list(REMOVE_ITEM SWIFT_SDK_OSX_ARCHITECTURES "arm64e")
 
+# Don't build the libraries for 64-bit watchOS targets;
+# there is no back-deployment to them.
+list(REMOVE_ITEM SWIFT_SDK_WATCHOS_ARCHITECTURES "arm64" "arm64e")
+
 # The back-deployed library can only be shared.
 list(APPEND SWIFT_STDLIB_LIBRARY_BUILD_TYPES SHARED)
 


### PR DESCRIPTION
…ib for watchOS

Addresses rdar://101389307

(cherry picked from commit 67402e2552b1a5d5d2e6f3f9d1ee5562ad7fd2b9)