### PR TITLE
Prefer `add_swift_tool_symlink` to install symlink for `swift-frontend`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,10 @@ if(SWIFT_PROFDATA_FILE AND EXISTS ${SWIFT_PROFDATA_FILE})
   add_definitions("-fprofile-instr-use=${SWIFT_PROFDATA_FILE}")
 endif()
 
+set(SWIFT_TOOLS_INSTALL_DIR "bin" CACHE PATH
+  "Path for binary subdirectory to use during installation.
+  Used by add_swift_tool_symlink in AddSwift.cmake so that llvm_install_symlink generates the installation script properly.")
+
 #
 # User-configurable Swift Standard Library specific options.
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ include(SwiftUtils)
 include(CheckSymbolExists)
 include(CMakeDependentOption)
 include(CheckLanguage)
+include(GNUInstallDirs)
 
 # Enable Swift for the host compiler build if we have the language. It is
 # optional until we have a bootstrap story.
@@ -320,6 +321,10 @@ if(SWIFT_PROFDATA_FILE AND EXISTS ${SWIFT_PROFDATA_FILE})
   endif()
   add_definitions("-fprofile-instr-use=${SWIFT_PROFDATA_FILE}")
 endif()
+
+set(SWIFT_TOOLS_INSTALL_DIR "${CMAKE_INSTALL_BINDIR}" CACHE PATH
+  "Path for binary subdirectory to use during installation.
+  Used by add_swift_tool_symlink in AddSwift.cmake so that llvm_install_symlink generates the installation script properly.")
 
 #
 # User-configurable Swift Standard Library specific options.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,10 +321,6 @@ if(SWIFT_PROFDATA_FILE AND EXISTS ${SWIFT_PROFDATA_FILE})
   add_definitions("-fprofile-instr-use=${SWIFT_PROFDATA_FILE}")
 endif()
 
-set(SWIFT_TOOLS_INSTALL_DIR "bin" CACHE PATH
-  "Path for binary subdirectory to use during installation.
-  Used by add_swift_tool_symlink in AddSwift.cmake so that llvm_install_symlink generates the installation script properly.")
-
 #
 # User-configurable Swift Standard Library specific options.
 #

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -957,8 +957,8 @@ function(add_swift_fuzzer_host_tool executable)
 endfunction()
 
 macro(add_swift_tool_symlink name dest component)
-  add_llvm_tool_symlink(${name} ${dest} ALWAYS_GENERATE)
-  llvm_install_symlink(${name} ${dest} ALWAYS_GENERATE COMPONENT ${component})
+  llvm_add_tool_symlink(SWIFT ${name} ${dest} ALWAYS_GENERATE)
+  llvm_install_symlink(SWIFT ${name} ${dest} ALWAYS_GENERATE COMPONENT ${component})
 endmacro()
 
 # Declare that files in this library are built with LLVM's support

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -956,16 +956,9 @@ function(add_swift_fuzzer_host_tool executable)
   target_link_libraries(${executable} PRIVATE "-fsanitize=fuzzer")
 endfunction()
 
-macro(add_swift_tool_symlink name dest component install_dir)
-  # This is used by llvm_install_symlink to determine where
-  # to put the target link
-  # we decide to define this "locally" to the macro instead of the
-  # main CMakeLists.txt so to align with how we configure installation
-  # across our scripts (i.e. granular control for each program in a component)
-  set(SWIFT_TOOLS_INSTALL_DIR ${install_dir})
+macro(add_swift_tool_symlink name dest component)
   llvm_add_tool_symlink(SWIFT ${name} ${dest} ALWAYS_GENERATE)
   llvm_install_symlink(SWIFT ${name} ${dest} ALWAYS_GENERATE COMPONENT ${component})
-  unset(SWIFT_TOOLS_INSTALL_DIR)
 endmacro()
 
 # Declare that files in this library are built with LLVM's support

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -956,13 +956,13 @@ function(add_swift_fuzzer_host_tool executable)
   target_link_libraries(${executable} PRIVATE "-fsanitize=fuzzer")
 endfunction()
 
-macro(add_swift_tool_symlink name dest component destination)
+macro(add_swift_tool_symlink name dest component install_dir)
   # This is used by llvm_install_symlink to determine where
   # to put the target link
   # we decide to define this "locally" to the macro instead of the
   # main CMakeLists.txt so to align with how we configure installation
   # across our scripts (i.e. granular control for each program in a component)
-  set(SWIFT_TOOLS_INSTALL_DIR destination)
+  set(SWIFT_TOOLS_INSTALL_DIR ${install_dir})
   llvm_add_tool_symlink(SWIFT ${name} ${dest} ALWAYS_GENERATE)
   llvm_install_symlink(SWIFT ${name} ${dest} ALWAYS_GENERATE COMPONENT ${component})
   unset(SWIFT_TOOLS_INSTALL_DIR)

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -956,9 +956,16 @@ function(add_swift_fuzzer_host_tool executable)
   target_link_libraries(${executable} PRIVATE "-fsanitize=fuzzer")
 endfunction()
 
-macro(add_swift_tool_symlink name dest component)
+macro(add_swift_tool_symlink name dest component destination)
+  # This is used by llvm_install_symlink to determine where
+  # to put the target link
+  # we decide to define this "locally" to the macro instead of the
+  # main CMakeLists.txt so to align with how we configure installation
+  # across our scripts (i.e. granular control for each program in a component)
+  set(SWIFT_TOOLS_INSTALL_DIR destination)
   llvm_add_tool_symlink(SWIFT ${name} ${dest} ALWAYS_GENERATE)
   llvm_install_symlink(SWIFT ${name} ${dest} ALWAYS_GENERATE COMPONENT ${component})
+  unset(SWIFT_TOOLS_INSTALL_DIR)
 endmacro()
 
 # Declare that files in this library are built with LLVM's support

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -958,7 +958,7 @@ endfunction()
 
 macro(add_swift_tool_symlink name dest component)
   llvm_add_tool_symlink(SWIFT ${name} ${dest} ALWAYS_GENERATE)
-  llvm_install_symlink(SWIFT ${name} ${dest} ALWAYS_GENERATE COMPONENT ${component})
+  llvm_install_symlink(SWIFT ${name} ${dest} COMPONENT ${component})
 endmacro()
 
 # Declare that files in this library are built with LLVM's support

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -111,13 +111,14 @@ swift_create_post_build_symlink(swift-frontend
   DESTINATION "swift-api-digester${CMAKE_EXECUTABLE_SUFFIX}"
   WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
 
-add_swift_tool_symlink(swift swift-frontend compiler "bin")
-add_swift_tool_symlink(swiftc swift-frontend compiler "bin")
-add_swift_tool_symlink(swift-symbolgraph-extract swift-frontend compiler "bin")
-add_swift_tool_symlink(swift-api-extract swift-frontend compiler "bin")
-add_swift_tool_symlink(swift-autolink-extract swift-frontend autolink-driver "bin")
-add_swift_tool_symlink(swift-indent swift-frontend editor-integration "bin")
-add_swift_tool_symlink(swift-api-digester swift-frontend compiler "bin")
+add_swift_tool_symlink(swift swift-frontend compiler)
+add_swift_tool_symlink(swiftc swift-frontend compiler)
+add_swift_tool_symlink(swift-symbolgraph-extract swift-frontend compiler)
+add_swift_tool_symlink(swift-api-extract swift-frontend compiler)
+add_swift_tool_symlink(swift-autolink-extract swift-frontend autolink-driver)
+add_swift_tool_symlink(swift-indent swift-frontend editor-integration)
+add_swift_tool_symlink(swift-api-digester swift-frontend compiler)
 
 add_dependencies(compiler swift-frontend)
-
+add_dependencies(autolink-driver swift-frontend)
+add_dependencies(editor-integration swift-frontend)

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -111,36 +111,13 @@ swift_create_post_build_symlink(swift-frontend
   DESTINATION "swift-api-digester${CMAKE_EXECUTABLE_SUFFIX}"
   WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
 
-add_swift_tool_symlink(swift swift-frontend compiler)
-add_swift_tool_symlink(swiftc swift-frontend compiler)
-add_swift_tool_symlink(swift-symbolgraph-extract swift-frontend compiler)
-add_swift_tool_symlink(swift-api-extract swift-frontend compiler)
-add_swift_tool_symlink(swift-autolink-extract swift-frontend autolink-driver)
-add_swift_tool_symlink(swift-indent swift-frontend editor-integration)
-add_swift_tool_symlink(swift-api-digester swift-frontend compiler)
+add_swift_tool_symlink(swift swift-frontend compiler "bin")
+add_swift_tool_symlink(swiftc swift-frontend compiler "bin")
+add_swift_tool_symlink(swift-symbolgraph-extract swift-frontend compiler "bin")
+add_swift_tool_symlink(swift-api-extract swift-frontend compiler "bin")
+add_swift_tool_symlink(swift-autolink-extract swift-frontend autolink-driver "bin")
+add_swift_tool_symlink(swift-indent swift-frontend editor-integration "bin")
+add_swift_tool_symlink(swift-api-digester swift-frontend compiler "bin")
 
 add_dependencies(compiler swift-frontend)
-swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift${CMAKE_EXECUTABLE_SUFFIX}"
-                           DESTINATION "bin"
-                           COMPONENT compiler)
-swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swiftc${CMAKE_EXECUTABLE_SUFFIX}"
-                           DESTINATION "bin"
-                           COMPONENT compiler)
-swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-symbolgraph-extract${CMAKE_EXECUTABLE_SUFFIX}"
-                           DESTINATION "bin"
-                           COMPONENT compiler)
-swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-api-extract${CMAKE_EXECUTABLE_SUFFIX}"
-                           DESTINATION "bin"
-                           COMPONENT compiler)
-swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-api-digester${CMAKE_EXECUTABLE_SUFFIX}"
-                           DESTINATION "bin"
-                           COMPONENT compiler)
-add_dependencies(autolink-driver swift-frontend)
-swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-autolink-extract${CMAKE_EXECUTABLE_SUFFIX}"
-                           DESTINATION "bin"
-                           COMPONENT autolink-driver)
-add_dependencies(editor-integration swift-frontend)
-swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-indent${CMAKE_EXECUTABLE_SUFFIX}"
-                           DESTINATION "bin"
-                           COMPONENT editor-integration)
 

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -111,6 +111,13 @@ swift_create_post_build_symlink(swift-frontend
   DESTINATION "swift-api-digester${CMAKE_EXECUTABLE_SUFFIX}"
   WORKING_DIRECTORY "${SWIFT_RUNTIME_OUTPUT_INTDIR}")
 
+# This is needed to be able to use the LLVM functions
+# to create symlinks to swift-frontend
+add_llvm_install_targets(install-swift-frontend
+  DEPENDS swift-frontend)
+add_dependencies(install-compiler install-swift-frontend)
+add_dependencies(install-compiler-stripped install-swift-frontend-stripped)
+
 add_swift_tool_symlink(swift swift-frontend compiler)
 add_swift_tool_symlink(swiftc swift-frontend compiler)
 add_swift_tool_symlink(swift-symbolgraph-extract swift-frontend compiler)


### PR DESCRIPTION
Also adapt to new signature for `llvm_install_symlink` and match the usage pattern employed by other LLVM projects.

Addresses rdar://101396797