### PR TITLE
[CSSimplify] Diagnose contextual mismatch between fully resolved depe…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6343,6 +6343,23 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       if (desugar1->isEqual(desugar2))
         return getTypeMatchSuccess();
 
+      if (shouldAttemptFixes()) {
+        if (!desugar1->hasTypeVariable() && !desugar2->hasTypeVariable()) {
+          auto *loc = getConstraintLocator(locator);
+
+          auto *fix =
+              loc->isLastElement<LocatorPathElt::TypeParameterRequirement>()
+                  ? fixRequirementFailure(*this, type1, type2, loc->getAnchor(),
+                                          loc->getPath())
+                  : ContextualMismatch::create(*this, type1, type2, loc);
+
+          if (!fix || recordFix(fix))
+            return getTypeMatchFailure(locator);
+
+          return getTypeMatchSuccess();
+        }
+      }
+
       // If one of the dependent member types has no type variables,
       // this comparison is effectively illformed, because dependent
       // member couldn't be simplified down to the actual type, and

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -983,3 +983,16 @@ func testOverloadGenericVarFn() {
   S<((String) -> Void)?>().foo?("")
   S<((String) -> Void)?>().foo!("")
 }
+
+do {
+  func foo<T, U>(_: T, _: U) where T: Sequence, U: Sequence, T.Element == U.Element {}
+  // expected-note@-1 {{required by local function 'foo' where 'T' = 'Set<Int>.Type'}}
+  // expected-note@-2 {{required by local function 'foo' where 'U' = 'Array<String>.Type'}}
+  // expected-note@-3 {{where 'T.Element' = 'Set<Int>.Type.Element', 'U.Element' = 'Array<String>.Type.Element'}}
+
+  foo(Set<Int>, Array<String>)
+  // expected-error@-1 {{type 'Set<Int>.Type' cannot conform to 'Sequence'}}
+  // expected-error@-2 {{type 'Array<String>.Type' cannot conform to 'Sequence'}}
+  // expected-error@-3 {{local function 'foo' requires the types 'Set<Int>.Type.Element' and 'Array<String>.Type.Element' be equivalent}}
+  // expected-note@-4 2 {{only concrete types such as structs, enums and classes can conform to protocols}}
+}


### PR DESCRIPTION
…ndent member types

If a constraint has fully resolved but incorrect (not simplifiable) dependent member types, let's diagnose that as a contextual mismatch instead of failing (which sometimes leads to a fallback diagnostic).

Resolves: rdar://101412179

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
