### PR TITLE
Remember nominal type decls for member lookup

### DIFF
--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -374,6 +374,10 @@ class VisibleDeclConsumer {
 public:
   virtual ~VisibleDeclConsumer() = default;
 
+  /// This method is called every time it look for members from a decl.
+  virtual void onLookupNominalTypeMembers(NominalTypeDecl *NTD,
+                                          DeclVisibilityKind Reason) {}
+
   /// This method is called by findVisibleDecls() every time it finds a decl.
   virtual void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason,
                          DynamicLookupInfo dynamicLookupInfo = {}) = 0;
@@ -420,6 +424,11 @@ public:
                               VisibleDeclConsumer &consumer)
     : DC(DC), ChainedConsumer(consumer) {}
 
+  void onLookupNominalTypeMembers(NominalTypeDecl *NTD,
+                                  DeclVisibilityKind Reason) override {
+    ChainedConsumer.onLookupNominalTypeMembers(NTD, Reason);
+  }
+
   void foundDecl(ValueDecl *D, DeclVisibilityKind reason,
                  DynamicLookupInfo dynamicLookupInfo = {}) override;
 };
@@ -440,6 +449,11 @@ public:
                               SourceLoc loc, VisibleDeclConsumer &consumer)
       : SM(SM), DC(DC), typeContext(DC->getInnermostTypeContext()), Loc(loc),
         ChainedConsumer(consumer) {}
+
+  void onLookupNominalTypeMembers(NominalTypeDecl *NTD,
+                                  DeclVisibilityKind Reason) override {
+    ChainedConsumer.onLookupNominalTypeMembers(NTD, Reason);
+  }
 
   void foundDecl(ValueDecl *D, DeclVisibilityKind reason,
                  DynamicLookupInfo dynamicLookupInfo) override;

--- a/include/swift/IDE/CodeCompletionContext.h
+++ b/include/swift/IDE/CodeCompletionContext.h
@@ -31,6 +31,9 @@ public:
   CodeCompletionCache &Cache;
   CompletionKind CodeCompletionKind = CompletionKind::None;
 
+  /// Module qualified nominal type decl names
+  SmallVector<NullTerminatedStringRef, 2> LookedupNominalTypeNames;
+
   enum class TypeContextKind {
     /// There is no known contextual type. All types are equally good.
     None,

--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -498,6 +498,9 @@ public:
   void foundDecl(ValueDecl *D, DeclVisibilityKind Reason,
                  DynamicLookupInfo dynamicLookupInfo) override;
 
+  void onLookupNominalTypeMembers(NominalTypeDecl *NTD,
+                                  DeclVisibilityKind Reason) override;
+
   bool handleEnumElement(ValueDecl *D, DeclVisibilityKind Reason,
                          DynamicLookupInfo dynamicLookupInfo);
 

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -1881,6 +1881,20 @@ bool CompletionLookup::addCompoundFunctionNameIfDesiable(
   return true;
 }
 
+void CompletionLookup::onLookupNominalTypeMembers(NominalTypeDecl *NTD,
+                                                  DeclVisibilityKind Reason) {
+
+  // Remember the decl name to
+  SmallString<32> buffer;
+  llvm::raw_svector_ostream OS(buffer);
+  PrintOptions PS = PrintOptions::printDocInterface();
+  PS.FullyQualifiedTypes = true;
+  NTD->getDeclaredType()->print(OS, PS);
+  NullTerminatedStringRef qualifiedName(
+      buffer, *CompletionContext->getResultSink().Allocator);
+  CompletionContext->LookedupNominalTypeNames.push_back(qualifiedName);
+}
+
 void CompletionLookup::foundDecl(ValueDecl *D, DeclVisibilityKind Reason,
                                  DynamicLookupInfo dynamicLookupInfo) {
   assert(Reason !=

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -273,6 +273,8 @@ static void lookupTypeMembers(Type BaseType, Type LookupType,
   NominalTypeDecl *D = LookupType->getAnyNominal();
   assert(D && "should have a nominal type");
 
+  Consumer.onLookupNominalTypeMembers(D, Reason);
+
   SmallVector<ValueDecl*, 2> FoundDecls;
   collectVisibleMemberDecls(CurrDC, LS, BaseType, D, FoundDecls);
 
@@ -464,6 +466,9 @@ static void lookupDeclsFromProtocolsBeingConformedTo(
 
     if (auto NormalConformance = dyn_cast<NormalProtocolConformance>(
           Conformance->getRootConformance())) {
+
+      Consumer.onLookupNominalTypeMembers(Proto, ReasonForThisProtocol);
+
       for (auto Member : Proto->getMembers()) {
         // Skip associated types and value requirements that aren't visible
         // or have a corresponding witness.
@@ -545,13 +550,13 @@ static void
   if (!Visited.insert(PD).second)
     return;
 
+  lookupTypeMembers(BaseTy, PD->getDeclaredInterfaceType(), Consumer, CurrDC,
+                    LS, Reason);
+
+  // Collect members from the inherited protocols.
   for (auto Proto : PD->getInheritedProtocols())
-    lookupVisibleProtocolMemberDecls(BaseTy, Proto,
-                                     Consumer, CurrDC, LS,
-                                     getReasonForSuper(Reason),
-                                     Sig, Visited);
-  lookupTypeMembers(BaseTy, PD->getDeclaredInterfaceType(),
-                    Consumer, CurrDC, LS, Reason);
+    lookupVisibleProtocolMemberDecls(BaseTy, Proto, Consumer, CurrDC, LS,
+                                     getReasonForSuper(Reason), Sig, Visited);
 }
 
 // Generate '$' and '_' prefixed variables for members that have attached property
@@ -862,6 +867,8 @@ namespace {
 
 class OverrideFilteringConsumer : public VisibleDeclConsumer {
 public:
+  llvm::SmallVector<std::pair<NominalTypeDecl *, DeclVisibilityKind>, 2>
+      nominals;
   llvm::SetVector<FoundDeclTy> Results;
   llvm::SmallVector<ValueDecl *, 8> Decls;
   llvm::SetVector<FoundDeclTy> FilteredResults;
@@ -876,6 +883,11 @@ public:
     assert(DC && BaseTy);
   }
 
+  void onLookupNominalTypeMembers(NominalTypeDecl *NTD,
+                                  DeclVisibilityKind Reason) override {
+    nominals.emplace_back(NTD, Reason);
+  }
+
   void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason,
                  DynamicLookupInfo dynamicLookupInfo) override {
     if (!Results.insert({VD, Reason, dynamicLookupInfo}))
@@ -886,6 +898,10 @@ public:
   }
 
   void filterDecls(VisibleDeclConsumer &Consumer) {
+    for (auto nominal : nominals) {
+      Consumer.onLookupNominalTypeMembers(nominal.first, nominal.second);
+    }
+
     removeOverriddenDecls(Decls);
     removeShadowedDecls(Decls, DC);
 
@@ -1040,6 +1056,11 @@ struct KeyPathDynamicMemberConsumer : public VisibleDeclConsumer {
     // other members.
     return !isa<SubscriptDecl>(VD) && seen.insert(VD->getBaseName()).second &&
            !seenStaticBaseName(VD->getBaseName());
+  }
+
+  void onLookupNominalTypeMembers(NominalTypeDecl *NTD,
+                                  DeclVisibilityKind Reason) override {
+    consumer.onLookupNominalTypeMembers(NTD, Reason);
   }
 
   void foundDecl(ValueDecl *VD, DeclVisibilityKind reason,

--- a/test/IDE/complete_member_basetypes.swift
+++ b/test/IDE/complete_member_basetypes.swift
@@ -1,0 +1,96 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t -module-name "Mod"
+
+protocol BaseP1 {}
+protocol BaseP2 {}
+
+func testBasicArchetype(arg: some BaseP1) {
+  arg.#^TestBaseP1^#
+// TestBaseP1: LookedupTypeNames: ['Mod.BaseP1']
+}
+
+
+protocol DerivedP1: BaseP1 {}
+protocol DerivedP2: BaseP2 {}
+protocol DerivedPComp: BaseP1, BaseP2 {}
+
+func testInheritedArchetype(arg: some DerivedP1) {
+  arg.#^TestDerivedP1^#
+// TestDerivedP1: LookedupTypeNames: ['Mod.DerivedP1', 'Mod.BaseP1']
+}
+
+func testMultiInheritedArchetype(arg: some DerivedPComp) {
+  arg.#^TestDerivedPComp^#
+// TestDerivedPComp: LookedupTypeNames: ['Mod.DerivedPComp', 'Mod.BaseP1', 'Mod.BaseP2']
+}
+
+func testCompositionArchetype(arg: some BaseP1 & BaseP2) {
+  arg.#^TestBaseP1AndBaseP2^#
+// TestBaseP1AndBaseP2: LookedupTypeNames: ['Mod.BaseP1', 'Mod.BaseP2']
+}
+
+protocol DiamondRoot {}
+protocol DiamondEdge1: DiamondRoot {}
+protocol DiamondEdge2: DiamondRoot {}
+protocol DiamondTop: DiamondEdge1, DiamondEdge2 {}
+
+func testDiamondProtocol(arg: some DiamondTop) {
+  arg.#^TestDiamondTop^#
+// TestDiamondTop: LookedupTypeNames: ['Mod.DiamondTop', 'Mod.DiamondEdge1', 'Mod.DiamondRoot', 'Mod.DiamondEdge2']
+}
+
+func testExistential(arg: any DiamondTop) {
+  arg.#^TestAnyDiamondTop^#
+// TestAnyDiamondTop: LookedupTypeNames: ['Mod.DiamondTop', 'Mod.DiamondEdge1', 'Mod.DiamondRoot', 'Mod.DiamondEdge2']
+}
+
+class BaseClass {}
+class DerivedClass: BaseClass {}
+
+func testBasicClass(arg: BaseClass) {
+  arg.#^TestBaseClass^#
+// TestBaseClass: LookedupTypeNames: ['Mod.BaseClass']
+}
+
+func testSubClass(arg: DerivedClass) {
+  arg.#^TestDerivedClass^#
+// TestDerivedClass: LookedupTypeNames: ['Mod.DerivedClass', 'Mod.BaseClass']
+}
+
+protocol BaseClassConstrainedP: BaseClass {}
+protocol DerivedClassConstrainedP: DerivedClass {}
+
+func testClassConstrainedProto(arg: some BaseClassConstrainedP) {
+  arg.#^TestBaseClassConstrainedP^#
+// TestBaseClassConstrainedP: LookedupTypeNames: ['Mod.BaseClassConstrainedP', 'Mod.BaseClass']
+}
+func testClassConstriainedProto2(arg: some DerivedClassConstrainedP) {
+  arg.#^TestDerivedClassConstrainedP^#
+// TestDerivedClassConstrainedP: LookedupTypeNames: ['Mod.DerivedClassConstrainedP', 'Mod.DerivedClass', 'Mod.BaseClass']
+}
+
+class BaseClassWithProto: BaseP1 {}
+class DerivedClassWithProto: BaseClassWithProto, BaseP2 {}
+
+func testBaseClassWithProto(arg: BaseClassWithProto) {
+  arg.#^TestBaseClassWithProto^#
+// TestBaseClassWithProto: LookedupTypeNames: ['Mod.BaseClassWithProto', 'Mod.BaseP1']
+}
+
+func testDerivedClassWithProto(arg: DerivedClassWithProto) {
+  arg.#^TestDerivedClassWithProto^#
+// TestDerivedClassWithProto: LookedupTypeNames: ['Mod.DerivedClassWithProto', 'Mod.BaseP2', 'Mod.BaseP1', 'Mod.BaseClassWithProto']
+}
+
+struct GenericS<T> {}
+extension GenericS: BaseP1 where T == Int {}
+
+func testConditionalConformanceNo(arg: GenericS<String>) {
+  arg.#^TestConditionalConformanceNo^#
+// TestConditionalConformanceNo: LookedupTypeNames: ['Mod.GenericS']
+}
+
+func testConditionalConformanceYes(arg: GenericS<Int>) {
+  arg.#^TestConditionalConformanceYes^#
+// TestConditionalConformanceYes: LookedupTypeNames: ['Mod.GenericS', 'Mod.BaseP1']
+}

--- a/test/IDE/complete_type.swift
+++ b/test/IDE/complete_type.swift
@@ -52,14 +52,14 @@ typealias FooTypealias = Int
 // WITH_GLOBAL_TYPES_EXPR-DAG: Decl[TypeAlias]/CurrModule: FooTypealias[#Int#]{{; name=.+$}}
 // WITH_GLOBAL_TYPES_EXPR: End completions
 
-// GLOBAL_NEGATIVE-NOT: fooObject
-// GLOBAL_NEGATIVE-NOT: fooFunc
+// GLOBAL_NEGATIVE-NOT: Decl.*: fooObject
+// GLOBAL_NEGATIVE-NOT: Decl.*: fooFunc
 
-// WITHOUT_GLOBAL_TYPES-NOT: FooStruct
-// WITHOUT_GLOBAL_TYPES-NOT: FooEnum
-// WITHOUT_GLOBAL_TYPES-NOT: FooClass
-// WITHOUT_GLOBAL_TYPES-NOT: FooProtocol
-// WITHOUT_GLOBAL_TYPES-NOT: FooTypealias
+// WITHOUT_GLOBAL_TYPES-NOT: Decl.*: FooStruct
+// WITHOUT_GLOBAL_TYPES-NOT: Decl.*: FooEnum
+// WITHOUT_GLOBAL_TYPES-NOT: Decl.*: FooClass
+// WITHOUT_GLOBAL_TYPES-NOT: Decl.*: FooProtocol
+// WITHOUT_GLOBAL_TYPES-NOT: Decl.*: FooTypealias
 
 // ERROR_COMMON: found code completion token
 // ERROR_COMMON-NOT: Begin completions

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -756,16 +756,16 @@ func testLookInProtoNoDot2() {
 func testLookInProtoNoDot3() {
   fooExBarExProtocolInstance#^PROTO_MEMBERS_NO_DOT_3^#
 // PROTO_MEMBERS_NO_DOT_3: Begin completions
+// PROTO_MEMBERS_NO_DOT_3-NEXT: Decl[InstanceMethod]/CurrNominal: .barExInstanceFunc0()[#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_NO_DOT_3-NEXT: Decl[InstanceVar]/Super:          .barInstanceVar[#Int#]{{; name=.+$}}
 // PROTO_MEMBERS_NO_DOT_3-NEXT: Decl[InstanceMethod]/Super:       .barInstanceFunc0()[#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_NO_DOT_3-NEXT: Decl[InstanceMethod]/Super:       .barInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
-// PROTO_MEMBERS_NO_DOT_3-NEXT: Decl[InstanceMethod]/CurrNominal: .barExInstanceFunc0()[#Double#]{{; name=.+$}}
+// PROTO_MEMBERS_NO_DOT_3-NEXT: Decl[InstanceMethod]/CurrNominal: .fooExInstanceFunc0()[#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_NO_DOT_3-NEXT: Decl[InstanceVar]/Super:          .fooInstanceVar1[#Int#]{{; name=.+$}}
 // PROTO_MEMBERS_NO_DOT_3-NEXT: Decl[InstanceVar]/Super:          .fooInstanceVar2[#Int#]{{; name=.+$}}
 // PROTO_MEMBERS_NO_DOT_3-NEXT: Decl[InstanceMethod]/Super:       .fooInstanceFunc0()[#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_NO_DOT_3-NEXT: Decl[InstanceMethod]/Super:       .fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_NO_DOT_3-NEXT: Decl[Subscript]/Super:            [{#(i): Int#}][#Double#]{{; name=.+$}}
-// PROTO_MEMBERS_NO_DOT_3-NEXT: Decl[InstanceMethod]/CurrNominal: .fooExInstanceFunc0()[#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_NO_DOT_3-NEXT: Keyword[self]/CurrNominal: .self[#BarExProtocol & FooExProtocol#]; name=self
 // PROTO_MEMBERS_NO_DOT_3-NEXT: End completions
 }
@@ -799,15 +799,15 @@ func testLookInProto3() {
   fooExBarExProtocolInstance.#^PROTO_MEMBERS_3^#
 // PROTO_MEMBERS_3: Begin completions
 // PROTO_MEMBERS_3-NEXT: Keyword[self]/CurrNominal: self[#BarExProtocol & FooExProtocol#]; name=self
+// PROTO_MEMBERS_3-NEXT: Decl[InstanceMethod]/CurrNominal: barExInstanceFunc0()[#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_3-NEXT: Decl[InstanceVar]/Super:          barInstanceVar[#Int#]{{; name=.+$}}
 // PROTO_MEMBERS_3-NEXT: Decl[InstanceMethod]/Super:       barInstanceFunc0()[#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_3-NEXT: Decl[InstanceMethod]/Super:       barInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
-// PROTO_MEMBERS_3-NEXT: Decl[InstanceMethod]/CurrNominal: barExInstanceFunc0()[#Double#]{{; name=.+$}}
+// PROTO_MEMBERS_3-NEXT: Decl[InstanceMethod]/CurrNominal: fooExInstanceFunc0()[#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_3-NEXT: Decl[InstanceVar]/Super:          fooInstanceVar1[#Int#]{{; name=.+$}}
 // PROTO_MEMBERS_3-NEXT: Decl[InstanceVar]/Super:          fooInstanceVar2[#Int#]{{; name=.+$}}
 // PROTO_MEMBERS_3-NEXT: Decl[InstanceMethod]/Super:       fooInstanceFunc0()[#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_3-NEXT: Decl[InstanceMethod]/Super:       fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
-// PROTO_MEMBERS_3-NEXT: Decl[InstanceMethod]/CurrNominal: fooExInstanceFunc0()[#Double#]{{; name=.+$}}
 // PROTO_MEMBERS_3-NEXT: End completions
 }
 
@@ -861,15 +861,15 @@ func testResolveFuncParam5<FooExBarEx : FooExProtocol & BarExProtocol>(_ a: FooE
   a.#^RESOLVE_FUNC_PARAM_5^#
 // RESOLVE_FUNC_PARAM_5: Begin completions
 // RESOLVE_FUNC_PARAM_5-NEXT: Keyword[self]/CurrNominal: self[#FooExBarEx#]; name=self
+// RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/CurrNominal: barExInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceVar]/Super: barInstanceVar[#Int#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/Super: barInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/Super: barInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/CurrNominal: barExInstanceFunc0()[#Double#]{{; name=.+$}}
+// RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/CurrNominal: fooExInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceVar]/Super: fooInstanceVar1[#Int#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceVar]/Super: fooInstanceVar2[#Int#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/Super: fooInstanceFunc1({#(a): Int#})[#Double#]{{; name=.+$}}
-// RESOLVE_FUNC_PARAM_5-NEXT: Decl[InstanceMethod]/CurrNominal: fooExInstanceFunc0()[#Double#]{{; name=.+$}}
 // RESOLVE_FUNC_PARAM_5-NEXT: End completions
 }
 
@@ -1311,13 +1311,12 @@ func testProtocol3(_ x: P3) {
 }
 // PROTOCOL_EXT_P3: Begin completions
 
-// FIXME: the next two should both be "CurrentNominal"
-// PROTOCOL_EXT_P3-DAG: Decl[InstanceMethod]/Super:   reqP1()[#Void#]{{; name=.+$}}
-// PROTOCOL_EXT_P3-DAG: Decl[InstanceMethod]/Super:   reqP2()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_P3-DAG: Decl[InstanceMethod]/CurrNominal:   reqP1()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_P3-DAG: Decl[InstanceMethod]/CurrNominal:   reqP2()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_P3-DAG: Decl[InstanceMethod]/CurrNominal:   extP3()[#Void#]{{; name=.+$}}
 
 // PROTOCOL_EXT_P3-DAG: Decl[InstanceMethod]/Super:   extP1()[#Void#]{{; name=.+$}}
 // PROTOCOL_EXT_P3-DAG: Decl[InstanceMethod]/Super:   extP2()[#Void#]{{; name=.+$}}
-// PROTOCOL_EXT_P3-DAG: Decl[InstanceMethod]/CurrNominal:   extP3()[#Void#]{{; name=.+$}}
 // PROTOCOL_EXT_P3: End completions
 
 func testConformingConcrete1(_ x: WillConformP1) {
@@ -1372,11 +1371,11 @@ func testGenericConforming3<T: P3>(x: T) {
   x.#^PROTOCOL_EXT_GENERICP3^#
 }
 // PROTOCOL_EXT_GENERICP3: Begin completions
-// PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/Super: reqP1()[#Void#]{{; name=.+$}}
-// PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/Super: reqP2()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/CurrNominal: reqP1()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/CurrNominal: reqP2()[#Void#]{{; name=.+$}}
+// PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/CurrNominal: extP3()[#Void#]{{; name=.+$}}
 // PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/Super: extP1()[#Void#]{{; name=.+$}}
 // PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/Super: extP2()[#Void#]{{; name=.+$}}
-// PROTOCOL_EXT_GENERICP3-DAG: Decl[InstanceMethod]/CurrNominal: extP3()[#Void#]{{; name=.+$}}
 // PROTOCOL_EXT_GENERICP3: End completions
 
 protocol NoDupReq1 {
@@ -1483,10 +1482,10 @@ func checkOverrideInclusion2(_ arg: Override3) {
 // CHECK_NODUP_RESTATED_REQ_NODOT: End completions
 
 // CHECK_NODUP_RESTATED_REQ_TYPE1: Begin completions, 6 items
-// CHECK_NODUP_RESTATED_REQ_TYPE1: Decl[InstanceMethod]/Super: roo({#(self): NoDupReq6#})[#(arg1: Int) -> Void#]; name=roo(:)
 // CHECK_NODUP_RESTATED_REQ_TYPE1: Decl[InstanceMethod]/CurrNominal: foo({#(self): NoDupReq6#})[#() -> Void#]; name=foo(:)
 // CHECK_NODUP_RESTATED_REQ_TYPE1: Decl[InstanceMethod]/CurrNominal: roo({#(self): NoDupReq6#})[#(arg2: Int) -> Void#]; name=roo(:)
 // CHECK_NODUP_RESTATED_REQ_TYPE1: Decl[AssociatedType]/CurrNominal: E; name=E
+// CHECK_NODUP_RESTATED_REQ_TYPE1: Decl[InstanceMethod]/Super: roo({#(self): NoDupReq6#})[#(arg1: Int) -> Void#]; name=roo(:)
 // CHECK_NODUP_RESTATED_REQ_TYPE1: End completions
 
 // CHECK_NODUP_RESTATED_REQ_TYPE2: Begin completions, 6 items
@@ -1503,8 +1502,8 @@ func checkOverrideInclusion2(_ arg: Override3) {
 // CHECK_NODUP_RESTATED_REQ_TYPE3: Decl[InstanceMethod]/CurrNominal: roo({#(self): NoDupReq1 & NoDupReq2 & NoDupReq3#})[#(arg2: Int) -> Void#]; name=roo(:)
 // CHECK_NODUP_RESTATED_REQ_TYPE3: End completions
 
-// CHECK_PROT_OVERRIDES: Decl[InstanceMethod]/{{Super|CurrNominal}}: foo({#(arg): NoDupReq1#})[#Void#]; name=foo(:)
-// CHECK_PROT_OVERRIDES: Decl[InstanceMethod]/{{Super|CurrNominal}}: foo({#(arg): NoDupReq2#})[#Void#]; name=foo(:)
+// CHECK_PROT_OVERRIDES-DAG: Decl[InstanceMethod]/{{Super|CurrNominal}}: foo({#(arg): NoDupReq1#})[#Void#]; name=foo(:)
+// CHECK_PROT_OVERRIDES-DAG: Decl[InstanceMethod]/{{Super|CurrNominal}}: foo({#(arg): NoDupReq2#})[#Void#]; name=foo(:)
 
 struct OnlyMe {}
 protocol P4 {


### PR DESCRIPTION
`lookupVisibleMemberDecls` visits nominal type decls to find visible members of the type. Remembering what decls are visited can be useful information for the clients.

* Add a 'VisibleDeclConsumer' callback function that is called when 'lookupVisibleDecls' visits each nominal type decls
* Remember the decl names in 'CodeCompletionContext' for future use
