### PR TITLE
[Sema] Implement basic type checking for pack expansion expressions.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3531,14 +3531,16 @@ class PackExpansionExpr final : public Expr,
 
   Expr *PatternExpr;
   SourceLoc DotsLoc;
+  GenericEnvironment *Environment;
 
   PackExpansionExpr(Expr *patternExpr,
                     ArrayRef<OpaqueValueExpr *> opaqueValues,
                     ArrayRef<Expr *> bindings,
                     SourceLoc dotsLoc,
+                    GenericEnvironment *environment,
                     bool implicit, Type type)
     : Expr(ExprKind::PackExpansion, implicit, type),
-      PatternExpr(patternExpr), DotsLoc(dotsLoc) {
+      PatternExpr(patternExpr), DotsLoc(dotsLoc), Environment(environment) {
     assert(opaqueValues.size() == bindings.size());
     Bits.PackExpansionExpr.NumBindings = opaqueValues.size();
 
@@ -3569,6 +3571,7 @@ public:
                                    ArrayRef<OpaqueValueExpr *> opaqueValues,
                                    ArrayRef<Expr *> bindings,
                                    SourceLoc dotsLoc,
+                                   GenericEnvironment *environment,
                                    bool implicit = false,
                                    Type type = Type());
 
@@ -3592,6 +3595,10 @@ public:
 
   void setBinding(unsigned i, Expr *e) {
     getMutableBindings()[i] = e;
+  }
+
+  GenericEnvironment *getGenericEnvironment() {
+    return Environment;
   }
 
   SourceLoc getStartLoc() const {

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -350,6 +350,11 @@ protected:
     IsObjC : 1
   );
 
+  SWIFT_INLINE_BITFIELD_FULL(PackExpansionExpr, Expr, 32,
+    : NumPadBits,
+    NumBindings : 32
+  );
+
   SWIFT_INLINE_BITFIELD_FULL(SequenceExpr, Expr, 32,
     : NumPadBits,
     NumElements : 32
@@ -3519,19 +3524,50 @@ public:
 /// that naturally accept a comma-separated list of values, including
 /// call argument lists, the elements of a tuple value, and the source
 /// of a for-in loop.
-class PackExpansionExpr: public Expr {
+class PackExpansionExpr final : public Expr,
+    private llvm::TrailingObjects<PackExpansionExpr,
+                                  OpaqueValueExpr *, Expr *> {
+  friend TrailingObjects;
+
   Expr *PatternExpr;
   SourceLoc DotsLoc;
 
   PackExpansionExpr(Expr *patternExpr,
+                    ArrayRef<OpaqueValueExpr *> opaqueValues,
+                    ArrayRef<Expr *> bindings,
                     SourceLoc dotsLoc,
                     bool implicit, Type type)
     : Expr(ExprKind::PackExpansion, implicit, type),
-      PatternExpr(patternExpr), DotsLoc(dotsLoc) {}
+      PatternExpr(patternExpr), DotsLoc(dotsLoc) {
+    assert(opaqueValues.size() == bindings.size());
+    Bits.PackExpansionExpr.NumBindings = opaqueValues.size();
+
+    assert(Bits.PackExpansionExpr.NumBindings > 0 &&
+           "PackExpansionExpr must have pack references");
+
+    std::uninitialized_copy(opaqueValues.begin(), opaqueValues.end(),
+                            getTrailingObjects<OpaqueValueExpr *>());
+    std::uninitialized_copy(bindings.begin(), bindings.end(),
+                            getTrailingObjects<Expr *>());
+  }
+
+  size_t numTrailingObjects(OverloadToken<OpaqueValueExpr *>) const {
+    return getNumBindings();
+  }
+
+  size_t numTrailingObjects(OverloadToken<Expr *>) const {
+    return getNumBindings();
+  }
+
+  MutableArrayRef<Expr *> getMutableBindings() {
+    return {getTrailingObjects<Expr *>(), getNumBindings()};
+  }
 
 public:
   static PackExpansionExpr *create(ASTContext &ctx,
                                    Expr *patternExpr,
+                                   ArrayRef<OpaqueValueExpr *> opaqueValues,
+                                   ArrayRef<Expr *> bindings,
                                    SourceLoc dotsLoc,
                                    bool implicit = false,
                                    Type type = Type());
@@ -3540,6 +3576,22 @@ public:
 
   void setPatternExpr(Expr *patternExpr) {
     PatternExpr = patternExpr;
+  }
+
+  unsigned getNumBindings() const {
+    return Bits.PackExpansionExpr.NumBindings;
+  }
+
+  ArrayRef<OpaqueValueExpr *> getOpaqueValues() {
+    return {getTrailingObjects<OpaqueValueExpr *>(), getNumBindings()};
+  }
+
+  ArrayRef<Expr *> getBindings() {
+    return {getTrailingObjects<Expr *>(), getNumBindings()};
+  }
+
+  void setBinding(unsigned i, Expr *e) {
+    getMutableBindings()[i] = e;
   }
 
   SourceLoc getStartLoc() const {

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -179,6 +179,8 @@ public:
 
     RequiredProtocols protos;
     LayoutConstraint layout;
+
+    Type packShape;
   };
 
 private:

--- a/include/swift/AST/Identifier.h
+++ b/include/swift/AST/Identifier.h
@@ -128,6 +128,10 @@ public:
     return is("??");
   }
 
+  bool isExpansionOperator() const {
+    return is("...");
+  }
+
   /// isOperatorStartCodePoint - Return true if the specified code point is a
   /// valid start of an operator.
   static bool isOperatorStartCodePoint(uint32_t C) {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6035,9 +6035,7 @@ public:
       LayoutConstraint Layout);
 
   // Returns the reduced shape type for this pack archetype.
-  Type getShape() const {
-    return getTrailingObjects<PackShape>()->shapeType;
-  }
+  Type getShape() const;
 
   static bool classof(const TypeBase *T) {
     return T->getKind() == TypeKind::PackArchetype;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6009,11 +6009,17 @@ BEGIN_CAN_TYPE_WRAPPER(OpenedArchetypeType, ArchetypeType)
   }
 END_CAN_TYPE_WRAPPER(OpenedArchetypeType, ArchetypeType)
 
+/// A wrapper around a shape type to use in ArchetypeTrailingObjects
+/// for PackArchetypeType.
+struct PackShape {
+  Type shapeType;
+};
+
 /// An archetype that represents an opaque element of a type
 /// parameter pack in context.
 class PackArchetypeType final
     : public ArchetypeType,
-      private ArchetypeTrailingObjects<PackArchetypeType> {
+      private ArchetypeTrailingObjects<PackArchetypeType, PackShape> {
   friend TrailingObjects;
   friend ArchetypeType;
 
@@ -6024,9 +6030,14 @@ public:
   /// by this routine.
   static CanTypeWrapper<PackArchetypeType>
   get(const ASTContext &Ctx, GenericEnvironment *GenericEnv,
-      Type InterfaceType,
+      Type InterfaceType, Type ShapeType,
       SmallVectorImpl<ProtocolDecl *> &ConformsTo, Type Superclass,
       LayoutConstraint Layout);
+
+  // Returns the reduced shape type for this pack archetype.
+  Type getShape() const {
+    return getTrailingObjects<PackShape>()->shapeType;
+  }
 
   static bool classof(const TypeBase *T) {
     return T->getKind() == TypeKind::PackArchetype;
@@ -6035,7 +6046,7 @@ public:
 private:
   PackArchetypeType(const ASTContext &Ctx, GenericEnvironment *GenericEnv,
                     Type InterfaceType, ArrayRef<ProtocolDecl *> ConformsTo,
-                    Type Superclass, LayoutConstraint Layout);
+                    Type Superclass, LayoutConstraint Layout, PackShape Shape);
 };
 BEGIN_CAN_TYPE_WRAPPER(PackArchetypeType, ArchetypeType)
 END_CAN_TYPE_WRAPPER(PackArchetypeType, ArchetypeType)

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -215,6 +215,9 @@ enum class ConstraintKind : char {
   /// Represents an AST node contained in a body of a function/closure.
   /// It only has an AST node to generate constraints and infer the type for.
   SyntacticElement,
+  /// The first type is the opened pack element type of the second type, which
+  /// is the pattern of a pack expansion type.
+  PackElementOf,
   /// Do not add new uses of this, it only exists to retain compatibility for
   /// rdar://85263844.
   ///
@@ -686,6 +689,7 @@ public:
     case ConstraintKind::OneWayBindParam:
     case ConstraintKind::DefaultClosureType:
     case ConstraintKind::UnresolvedMemberChainBase:
+    case ConstraintKind::PackElementOf:
       return ConstraintClassification::Relational;
 
     case ConstraintKind::ValueMember:

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5501,6 +5501,18 @@ private:
                                               TypeMatchOptions flags,
                                               ConstraintLocatorBuilder locator);
 
+  /// Attempt to simplify a PackElementOf constraint.
+  ///
+  /// Solving this constraint is delayed until the element type is fully
+  /// resolved with no type variables. The element type is then mapped out
+  /// of the opened element context and into the context of the surrounding
+  /// function, effecively substituting opened element archetypes with their
+  /// corresponding pack archetypes, and bound to the second type.
+  SolutionKind
+  simplifyPackElementOfConstraint(Type first, Type second,
+                                  TypeMatchOptions flags,
+                                  ConstraintLocatorBuilder locator);
+
   /// Attempt to simplify the ApplicableFunction constraint.
   SolutionKind simplifyApplicableFnConstraint(
       Type type1, Type type2,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5602,8 +5602,8 @@ ASTContext::getOpenedElementSignature(CanGenericSignature baseGenericSig) {
 
   auto eraseParameterPack = [&](GenericTypeParamType *paramType) {
     return GenericTypeParamType::get(
-        paramType->getDepth(), paramType->getIndex(),
-        /*isParameterPack=*/false, *this);
+        /*isParameterPack=*/false, paramType->getDepth(),
+        paramType->getIndex(), *this);
   };
 
   for (auto paramType : baseGenericSig.getGenericParams()) {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3136,15 +3136,6 @@ TupleType *TupleType::get(ArrayRef<TupleTypeElt> Fields, const ASTContext &C) {
     properties |= eltTy->getRecursiveProperties();
   }
 
-  // Enforce an invariant.
-  for (unsigned i = 0, e = Fields.size(); i < e; ++i) {
-    if (Fields[i].getType()->is<PackExpansionType>()) {
-      assert(i == e - 1 || Fields[i + 1].hasName() &&
-             "Tuple element with pack expansion type cannot be followed "
-             "by an unlabeled element");
-    }
-  }
-
   auto arena = getArena(properties);
 
   void *InsertPos = nullptr;

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -824,12 +824,23 @@ public:
       if (!shouldVerify(cast<Expr>(expr)))
         return false;
 
+      Generics.push_back(expr->getGenericEnvironment()->getGenericSignature());
+
       for (auto *placeholder : expr->getOpaqueValues()) {
         assert(!OpaqueValues.count(placeholder));
         OpaqueValues[placeholder] = 0;
       }
 
       return true;
+    }
+
+    void verifyCheckedAlways(PackExpansionExpr *E) {
+      // Remove the element generic environment before verifying
+      // the pack expansion type, which contains pack archetypes.
+      assert(Generics.back().get<GenericSignature>().getPointer() ==
+             E->getGenericEnvironment()->getGenericSignature().getPointer());
+      Generics.pop_back();
+      verifyCheckedAlwaysBase(E);
     }
 
     void cleanup(PackExpansionExpr *expr) {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -820,6 +820,25 @@ public:
       OpenedExistentialArchetypes.erase(expr->getOpenedArchetype());
     }
 
+    bool shouldVerify(PackExpansionExpr *expr) {
+      if (!shouldVerify(cast<Expr>(expr)))
+        return false;
+
+      for (auto *placeholder : expr->getOpaqueValues()) {
+        assert(!OpaqueValues.count(placeholder));
+        OpaqueValues[placeholder] = 0;
+      }
+
+      return true;
+    }
+
+    void cleanup(PackExpansionExpr *expr) {
+      for (auto *placeholder : expr->getOpaqueValues()) {
+        assert(OpaqueValues.count(placeholder));
+        OpaqueValues.erase(placeholder);
+      }
+    }
+
     bool shouldVerify(MakeTemporarilyEscapableExpr *expr) {
       if (!shouldVerify(cast<Expr>(expr)))
         return false;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1239,10 +1239,17 @@ VarargExpansionExpr *VarargExpansionExpr::createArrayExpansion(ASTContext &ctx, 
 
 PackExpansionExpr *
 PackExpansionExpr::create(ASTContext &ctx, Expr *patternExpr,
+                          ArrayRef<OpaqueValueExpr *> opaqueValues,
+                          ArrayRef<Expr *> bindings,
                           SourceLoc dotsLoc, bool implicit,
                           Type type) {
-  return new (ctx) PackExpansionExpr(patternExpr, dotsLoc,
-                                     implicit, type);
+  size_t size =
+      totalSizeToAlloc<OpaqueValueExpr *, Expr *>(opaqueValues.size(),
+                                                  bindings.size());
+  void *mem = ctx.Allocate(size, alignof(PackExpansionExpr));
+  return ::new (mem) PackExpansionExpr(patternExpr, opaqueValues,
+                                       bindings, dotsLoc,
+                                       implicit, type);
 }
 
 SequenceExpr *SequenceExpr::create(ASTContext &ctx, ArrayRef<Expr*> elements) {

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1240,15 +1240,15 @@ VarargExpansionExpr *VarargExpansionExpr::createArrayExpansion(ASTContext &ctx, 
 PackExpansionExpr *
 PackExpansionExpr::create(ASTContext &ctx, Expr *patternExpr,
                           ArrayRef<OpaqueValueExpr *> opaqueValues,
-                          ArrayRef<Expr *> bindings,
-                          SourceLoc dotsLoc, bool implicit,
-                          Type type) {
+                          ArrayRef<Expr *> bindings, SourceLoc dotsLoc,
+                          GenericEnvironment *environment,
+                          bool implicit, Type type) {
   size_t size =
       totalSizeToAlloc<OpaqueValueExpr *, Expr *>(opaqueValues.size(),
                                                   bindings.size());
   void *mem = ctx.Allocate(size, alignof(PackExpansionExpr));
   return ::new (mem) PackExpansionExpr(patternExpr, opaqueValues,
-                                       bindings, dotsLoc,
+                                       bindings, dotsLoc, environment,
                                        implicit, type);
 }
 

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -365,6 +365,7 @@ GenericEnvironment::getOrCreateArchetypeFromInterfaceType(Type depType) {
   if (rootGP->isParameterPack()) {
     assert(getKind() == Kind::Primary);
     result = PackArchetypeType::get(ctx, this, requirements.anchor,
+                                    requirements.packShape,
                                     requirements.protos, superclass,
                                     requirements.layout);
   } else {

--- a/lib/AST/RequirementMachine/ConcreteContraction.cpp
+++ b/lib/AST/RequirementMachine/ConcreteContraction.cpp
@@ -371,8 +371,12 @@ ConcreteContraction::substRequirement(const Requirement &req) const {
   auto firstType = req.getFirstType();
 
   switch (req.getKind()) {
-  case RequirementKind::SameShape:
-    llvm_unreachable("Same-shape requirement not supported here");
+  case RequirementKind::SameShape: {
+    auto substFirstType = substType(firstType);
+    auto substSecondType = substType(req.getSecondType());
+
+    return Requirement(req.getKind(), substFirstType, substSecondType);
+  }
 
   case RequirementKind::Superclass:
   case RequirementKind::SameType: {

--- a/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
+++ b/lib/AST/RequirementMachine/GenericSignatureQueries.cpp
@@ -57,6 +57,7 @@ RequirementMachine::getLocalRequirements(
 
   GenericSignature::LocalRequirements result;
   result.anchor = Map.getTypeForTerm(term, genericParams);
+  result.packShape = getReducedShape(depType);
 
   auto *props = Map.lookUpProperties(term);
   if (!props)
@@ -789,13 +790,16 @@ void RequirementMachine::verify(const MutableTerm &term) const {
       erased.add(Symbol::forName(symbol.getName(), Context));
       break;
 
+    case Symbol::Kind::Shape:
+      erased.add(symbol);
+      break;
+
     case Symbol::Kind::Protocol:
     case Symbol::Kind::GenericParam:
     case Symbol::Kind::Layout:
     case Symbol::Kind::Superclass:
     case Symbol::Kind::ConcreteType:
     case Symbol::Kind::ConcreteConformance:
-    case Symbol::Kind::Shape:
       llvm::errs() << "Bad interior symbol " << symbol << " in " << term << "\n";
       abort();
       break;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3992,6 +3992,11 @@ PackArchetypeType::get(const ASTContext &Ctx,
       {ShapeType}));
 }
 
+Type PackArchetypeType::getShape() const {
+  auto shapeType = getTrailingObjects<PackShape>()->shapeType;
+  return getGenericEnvironment()->mapTypeIntoContext(shapeType);
+}
+
 ElementArchetypeType::ElementArchetypeType(
     const ASTContext &Ctx, GenericEnvironment *GenericEnv, Type InterfaceType,
     ArrayRef<ProtocolDecl *> ConformsTo, Type Superclass,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3959,17 +3959,18 @@ UUID OpenedArchetypeType::getOpenedExistentialID() const {
 PackArchetypeType::PackArchetypeType(
     const ASTContext &Ctx, GenericEnvironment *GenericEnv, Type InterfaceType,
     ArrayRef<ProtocolDecl *> ConformsTo, Type Superclass,
-    LayoutConstraint Layout)
+    LayoutConstraint Layout, PackShape Shape)
     : ArchetypeType(TypeKind::PackArchetype, Ctx,
                     RecursiveTypeProperties::HasArchetype, InterfaceType,
                     ConformsTo, Superclass, Layout, GenericEnv) {
   assert(InterfaceType->isParameterPack());
+  *getTrailingObjects<PackShape>() = Shape;
 }
 
 CanPackArchetypeType
 PackArchetypeType::get(const ASTContext &Ctx,
                        GenericEnvironment *GenericEnv,
-                       Type InterfaceType,
+                       Type InterfaceType, Type ShapeType,
                        SmallVectorImpl<ProtocolDecl *> &ConformsTo,
                        Type Superclass, LayoutConstraint Layout) {
   assert(!Superclass || Superclass->getClassOrBoundGenericClass());
@@ -3981,12 +3982,14 @@ PackArchetypeType::get(const ASTContext &Ctx,
   auto arena = AllocationArena::Permanent;
   void *mem =
       Ctx.Allocate(PackArchetypeType::totalSizeToAlloc<ProtocolDecl *, Type,
-                                                       LayoutConstraint>(
-                       ConformsTo.size(), Superclass ? 1 : 0, Layout ? 1 : 0),
+                                                       LayoutConstraint, PackShape>(
+                       ConformsTo.size(), Superclass ? 1 : 0, Layout ? 1 : 0,
+                       /*shapeSize*/1),
                    alignof(PackArchetypeType), arena);
 
   return CanPackArchetypeType(::new (mem) PackArchetypeType(
-      Ctx, GenericEnv, InterfaceType, ConformsTo, Superclass, Layout));
+      Ctx, GenericEnv, InterfaceType, ConformsTo, Superclass, Layout,
+      {ShapeType}));
 }
 
 ElementArchetypeType::ElementArchetypeType(

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7095,16 +7095,44 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     auto toExpansionType = toType->getAs<PackExpansionType>();
     auto *expansion = dyn_cast<PackExpansionExpr>(expr);
 
+    // FIXME: Duplicated code from `PackReferenceFinder` in PreCheckExpr.
+    auto toElementType = toExpansionType->getPatternType();
+    toElementType =
+        toElementType->mapTypeOutOfContext().transform([&](Type type) -> Type {
+          auto *genericParam = type->getAs<GenericTypeParamType>();
+          if (!genericParam || !genericParam->isParameterPack())
+            return type;
+
+          auto param = GenericTypeParamType::get(/*isParameterPack*/false,
+                                                 genericParam->getDepth(),
+                                                 genericParam->getIndex(), ctx);
+          return expansion->getGenericEnvironment()->mapTypeIntoContext(param);
+        });
+
     auto *pattern = coerceToType(expansion->getPatternExpr(),
-                                 toExpansionType->getPatternType(),
-                                 locator);
-    auto patternType = cs.getType(pattern);
+                                 toElementType, locator);
+
+    // FIXME: Duplicated code from `visitPackExpansionExpr` in CSGen.
+    auto patternType =
+        cs.getType(pattern).transform([&](Type type) -> Type {
+          auto *element = type->getAs<ElementArchetypeType>();
+          if (!element)
+            return type;
+
+          auto *elementParam = element->mapTypeOutOfContext()->getAs<GenericTypeParamType>();
+          auto *pack = GenericTypeParamType::get(/*isParameterPack*/true,
+                                                 elementParam->getDepth(),
+                                                 elementParam->getIndex(),
+                                                 ctx);
+          return cs.DC->mapTypeIntoContext(pack);
+        });
     auto shapeType = toExpansionType->getCountType();
     auto expansionTy = PackExpansionType::get(patternType, shapeType);
 
     return cs.cacheType(PackExpansionExpr::create(ctx, pattern,
         expansion->getOpaqueValues(), expansion->getBindings(),
-        expansion->getEndLoc(), expansion->isImplicit(), expansionTy));
+        expansion->getEndLoc(), expansion->getGenericEnvironment(),
+        expansion->isImplicit(), expansionTy));
   }
 
   case TypeKind::BuiltinTuple:

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1396,6 +1396,7 @@ void PotentialBindings::infer(Constraint *constraint) {
   case ConstraintKind::SyntacticElement:
   case ConstraintKind::Conjunction:
   case ConstraintKind::BindTupleOfFunctionParams:
+  case ConstraintKind::PackElementOf:
     // Constraints from which we can't do anything.
     break;
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7059,6 +7059,7 @@ bool ExtraneousCallFailure::diagnoseAsError() {
     }
   }
 
+  anchor.dump();
   auto diagnostic =
       emitDiagnostic(diag::cannot_call_non_function_value, getType(anchor));
   removeParensFixIt(diagnostic);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2886,21 +2886,11 @@ namespace {
         CS.setType(binding, type);
       }
 
-      // Replace opened element archetypes with pack archetypes
-      // for the resulting type of the pack expansion.
       auto elementResultType = CS.getType(expr->getPatternExpr());
-      auto patternTy = elementResultType.transform([&](Type type) -> Type {
-        auto *element = type->getAs<ElementArchetypeType>();
-        if (!element)
-          return type;
-
-        auto *elementParam = element->mapTypeOutOfContext()->getAs<GenericTypeParamType>();
-        auto *pack = GenericTypeParamType::get(/*isParameterPack*/true,
-                                               elementParam->getDepth(),
-                                               elementParam->getIndex(),
-                                               CS.getASTContext());
-        return CS.DC->mapTypeIntoContext(pack);
-      });
+      auto patternTy = CS.createTypeVariable(CS.getConstraintLocator(expr),
+                                             TVO_CanBindToHole);
+      CS.addConstraint(ConstraintKind::PackElementOf, elementResultType,
+                       patternTy, CS.getConstraintLocator(expr));
 
       // FIXME: Use a ShapeOf constraint here.
       Type shapeType;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2897,7 +2897,7 @@ namespace {
           return;
 
         if (auto archetype = type->getAs<PackArchetypeType>()) {
-          shapeType = CS.DC->mapTypeIntoContext(archetype->getShape());
+          shapeType = archetype->getShape();
         }
       });
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -79,6 +79,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
   case ConstraintKind::UnresolvedMemberChainBase:
   case ConstraintKind::PropertyWrapper:
   case ConstraintKind::BindTupleOfFunctionParams:
+  case ConstraintKind::PackElementOf:
     assert(!First.isNull());
     assert(!Second.isNull());
     break;
@@ -165,6 +166,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::PropertyWrapper:
   case ConstraintKind::SyntacticElement:
   case ConstraintKind::BindTupleOfFunctionParams:
+  case ConstraintKind::PackElementOf:
     llvm_unreachable("Wrong constructor");
 
   case ConstraintKind::KeyPath:
@@ -310,6 +312,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   case ConstraintKind::UnresolvedMemberChainBase:
   case ConstraintKind::PropertyWrapper:
   case ConstraintKind::BindTupleOfFunctionParams:
+  case ConstraintKind::PackElementOf:
     return create(cs, getKind(), getFirstType(), getSecondType(), getLocator());
 
   case ConstraintKind::ApplicableFunction:
@@ -546,6 +549,10 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm, unsigned inden
     Out << " bind tuple of function params to ";
     break;
 
+  case ConstraintKind::PackElementOf:
+    Out << " element of pack expansion pattern ";
+    break;
+
   case ConstraintKind::Disjunction:
     llvm_unreachable("disjunction handled above");
   case ConstraintKind::Conjunction:
@@ -710,6 +717,7 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::UnresolvedMemberChainBase:
   case ConstraintKind::PropertyWrapper:
   case ConstraintKind::BindTupleOfFunctionParams:
+  case ConstraintKind::PackElementOf:
     constraint->getFirstType()->getTypeVariables(typeVars);
     constraint->getSecondType()->getTypeVariables(typeVars);
     break;

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1378,7 +1378,8 @@ namespace {
       // references to PackExpansionExpr.
       if (auto *postfixExpr = dyn_cast<PostfixUnaryExpr>(expr)) {
         auto *op = dyn_cast<OverloadedDeclRefExpr>(postfixExpr->getFn());
-        if (op && op->getDecls()[0]->getBaseName().getIdentifier().isExpansionOperator()) {
+        if (op && Ctx.LangOpts.hasFeature(Feature::VariadicGenerics) &&
+            op->getDecls()[0]->getBaseName().getIdentifier().isExpansionOperator()) {
           auto *operand = postfixExpr->getOperand();
           if (auto *expansion = getPackExpansion(DC, operand, op->getLoc())) {
             return Action::Continue(expansion);

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/DiagnosticsParse.h"
+#include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/ParameterList.h"
@@ -414,15 +415,19 @@ static bool exprLooksLikeAType(Expr *expr) {
       getCompositionExpr(expr);
 }
 
-static Expr *getPackExpansion(ASTContext &ctx, Expr *expr, SourceLoc opLoc) {
+static Expr *getPackExpansion(DeclContext *dc, Expr *expr, SourceLoc opLoc) {
   struct PackReferenceFinder : public ASTWalker {
-    ASTContext &ctx;
+    DeclContext *dc;
     llvm::SmallVector<OpaqueValueExpr *, 2> opaqueValues;
     llvm::SmallVector<Expr *, 2> bindings;
+    GenericEnvironment *environment;
 
-    PackReferenceFinder(ASTContext &ctx) : ctx(ctx) {}
+    PackReferenceFinder(DeclContext *dc)
+      : dc(dc), environment(nullptr) {}
 
     virtual PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
+      auto &ctx = dc->getASTContext();
+
       if (auto *declRef = dyn_cast<DeclRefExpr>(E)) {
         auto *decl = dyn_cast<VarDecl>(declRef->getDecl());
         if (!decl)
@@ -431,11 +436,30 @@ static Expr *getPackExpansion(ASTContext &ctx, Expr *expr, SourceLoc opLoc) {
         if (auto expansionType = decl->getType()->getAs<PackExpansionType>()) {
           auto sourceRange = declRef->getSourceRange();
 
-          // FIXME: The OpaqueValueExpr should use the opened element
-          // type of the pattern.
+          // Map the pattern interface type to the element interface type
+          // by making all type parameter packs scalar type parameters.
           auto patternType = expansionType->getPatternType();
-          auto *opaqueValue = new (ctx) OpaqueValueExpr(sourceRange,
-                                                        patternType);
+          auto elementInterfaceType =
+              patternType->mapTypeOutOfContext().transform([&](Type type) -> Type {
+                auto *genericParam = type->getAs<GenericTypeParamType>();
+                if (!genericParam || !genericParam->isParameterPack())
+                  return type;
+
+                return GenericTypeParamType::get(/*isParameterPack*/false,
+                                                 genericParam->getDepth(),
+                                                 genericParam->getIndex(), ctx);
+              });
+
+          // Map the element interface type into the context of the opened
+          // element signature.
+          if (!environment) {
+            auto sig = ctx.getOpenedElementSignature(
+                dc->getGenericSignatureOfContext().getCanonicalSignature());
+            environment = GenericEnvironment::forOpenedElement(sig, UUID::fromTime());
+          }
+          auto elementType = environment->mapTypeIntoContext(elementInterfaceType);
+
+          auto *opaqueValue = new (ctx) OpaqueValueExpr(sourceRange, elementType);
           opaqueValues.push_back(opaqueValue);
           bindings.push_back(declRef);
           return Action::Continue(opaqueValue);
@@ -444,15 +468,15 @@ static Expr *getPackExpansion(ASTContext &ctx, Expr *expr, SourceLoc opLoc) {
 
       return Action::Continue(E);
     }
-  } packReferenceFinder(ctx);
+  } packReferenceFinder(dc);
 
   auto *pattern = expr->walk(packReferenceFinder);
 
   if (!packReferenceFinder.bindings.empty()) {
-    return PackExpansionExpr::create(ctx, pattern,
+    return PackExpansionExpr::create(dc->getASTContext(), pattern,
                                      packReferenceFinder.opaqueValues,
                                      packReferenceFinder.bindings,
-                                     opLoc);
+                                     opLoc, packReferenceFinder.environment);
   }
 
   return nullptr;
@@ -1356,7 +1380,7 @@ namespace {
         auto *op = dyn_cast<OverloadedDeclRefExpr>(postfixExpr->getFn());
         if (op && op->getDecls()[0]->getBaseName().getIdentifier().isExpansionOperator()) {
           auto *operand = postfixExpr->getOperand();
-          if (auto *expansion = getPackExpansion(Ctx, operand, op->getLoc())) {
+          if (auto *expansion = getPackExpansion(DC, operand, op->getLoc())) {
             return Action::Continue(expansion);
           }
         }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -648,8 +648,6 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
           typeRepr = specifier->getBase();
 
         if (auto *packExpansion = dyn_cast<PackExpansionTypeRepr>(typeRepr)) {
-          typeRepr = packExpansion->getPatternType();
-
           paramOptions.setContext(TypeResolverContext::VariadicFunctionInput);
         } else {
           paramOptions.setContext(TypeResolverContext::FunctionInput);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4240,6 +4240,12 @@ NeverNullType TypeResolver::resolvePackExpansionType(PackExpansionTypeRepr *repr
     return ErrorType::get(ctx);
   }
 
+  if (resolution.getStage() == TypeResolutionStage::Interface) {
+    auto genericSig = resolution.getGenericSignature();
+    auto shapeType = genericSig->getReducedShape(pair.second);
+    return PackExpansionType::get(pair.first, shapeType);
+  }
+
   return PackExpansionType::get(pair.first, pair.second);
 }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4228,8 +4228,13 @@ NeverNullType TypeResolver::resolvePackExpansionType(PackExpansionTypeRepr *repr
     return ErrorType::get(ctx);
   }
 
-  // The pattern type must contain at least one variadic generic parameter.
   if (!pair.second) {
+    // Non-pack variadic parameters parse as PackExpansionTypeReprs. These
+    // can only appear in variadic function parameter types.
+    if (options.getContext() == TypeResolverContext::VariadicFunctionInput)
+      return pair.first;
+
+    // Otherwise, the pattern type must contain at least one pack reference.
     diagnose(repr->getLoc(), diag::expansion_not_variadic, pair.first)
       .highlight(repr->getSourceRange());
     return ErrorType::get(ctx);

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -314,6 +314,7 @@ public:
   bool isPackExpansionSupported() const {
     switch (context) {
     case Context::FunctionInput:
+    case Context::VariadicFunctionInput:
     case Context::TupleElement:
     case Context::GenericArgument:
       return true;
@@ -335,7 +336,6 @@ public:
     case Context::PatternBindingDecl:
     case Context::EditorPlaceholderExpr:
     case Context::ClosureExpr:
-    case Context::VariadicFunctionInput:
     case Context::InoutFunctionInput:
     case Context::FunctionResult:
     case Context::SubscriptDecl:

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -1,0 +1,17 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-variadic-generics
+
+func tuplify<T...>(_ t: T...) -> (T...) {
+  return (t...)
+}
+
+func prepend<First, Rest...>(value: First, to rest: Rest...) -> (First, Rest...) {
+  return (value, rest...)
+}
+
+func concatenate<T..., U...>(_ first: T..., with second: U...) -> ((T, U)...) {
+  return ((first, second)...)
+}
+
+func zip<T..., U...>(_ first: T..., with second: U...) -> ((T, U)...) {
+  return ((first, second)...)
+}

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -20,14 +20,9 @@ func forward<U...>(_ u: U...) -> (U...) {
   return tuplify(u...)
 }
 
-// FIXME: This fails with opened element types. Add an ElementOf constraint to
-// handle cases where the pattern type is resolved after constraint generation
-// and mapped to pack archetypes in the solver.
-/*
 func forwardAndMap<U..., V...>(us u: U..., vs v: V...) -> ([(U, V)]...) {
   return tuplify([(u, v)]...)
 }
-*/
 
 func variadicMap<T..., Result...>(_ t: T..., transform: ((T) -> Result)...) -> (Result...) {
   return (transform(t)...)

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -15,3 +15,11 @@ func concatenate<T..., U...>(_ first: T..., with second: U...) -> ((T, U)...) {
 func zip<T..., U...>(_ first: T..., with second: U...) -> ((T, U)...) {
   return ((first, second)...)
 }
+
+func forward<U...>(_ u: U...) -> (U...) {
+  return tuplify(u...)
+}
+
+func forwardAndMap<U..., V...>(us u: U..., vs v: V...) -> ([(U, V)]...) {
+  return tuplify([(u, v)]...)
+}

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -8,8 +8,8 @@ func prepend<First, Rest...>(value: First, to rest: Rest...) -> (First, Rest...)
   return (value, rest...)
 }
 
-func concatenate<T..., U...>(_ first: T..., with second: U...) -> ((T, U)...) {
-  return ((first, second)...)
+func concatenate<T..., U...>(_ first: T..., with second: U...) -> (T..., U...) {
+  return (first..., second...)
 }
 
 func zip<T..., U...>(_ first: T..., with second: U...) -> ((T, U)...) {

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -23,3 +23,7 @@ func forward<U...>(_ u: U...) -> (U...) {
 func forwardAndMap<U..., V...>(us u: U..., vs v: V...) -> ([(U, V)]...) {
   return tuplify([(u, v)]...)
 }
+
+func variadicMap<T..., Result...>(_ t: T..., transform: ((T) -> Result)...) -> (Result...) {
+  return (transform(t)...)
+}

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -20,9 +20,14 @@ func forward<U...>(_ u: U...) -> (U...) {
   return tuplify(u...)
 }
 
+// FIXME: This fails with opened element types. Add an ElementOf constraint to
+// handle cases where the pattern type is resolved after constraint generation
+// and mapped to pack archetypes in the solver.
+/*
 func forwardAndMap<U..., V...>(us u: U..., vs v: V...) -> ([(U, V)]...) {
   return tuplify([(u, v)]...)
 }
+*/
 
 func variadicMap<T..., Result...>(_ t: T..., transform: ((T) -> Result)...) -> (Result...) {
   return (transform(t)...)

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -27,3 +27,9 @@ func forwardAndMap<U..., V...>(us u: U..., vs v: V...) -> ([(U, V)]...) {
 func variadicMap<T..., Result...>(_ t: T..., transform: ((T) -> Result)...) -> (Result...) {
   return (transform(t)...)
 }
+
+func coerceExpansion<T...>(_ value: T...) {
+  func promoteToOptional<Wrapped...>(_: Wrapped?...) {}
+
+  promoteToOptional(value...)
+}

--- a/test/Generics/pack-shape-requirements.swift
+++ b/test/Generics/pack-shape-requirements.swift
@@ -59,3 +59,9 @@ struct Ts<T...> {
     }
   }
 }
+
+// CHECK-LABEL: expandedParameters(_:transform:)
+// CHECK-NEXT: Generic signature: <T..., Result... where T.shape == Result.shape>
+func expandedParameters<T..., Result...>(_ t: T..., transform: ((T) -> Result)...) -> (Result...) {
+  fatalError()
+}


### PR DESCRIPTION
This change rewrites postfix `...` operator expressions to `PackExpansionExpr` when the operand contains pack references. Pack references are replaced with `OpaqueValueExpr`s, and the `PackExpansionExpr` stores the bindings from opaque values to pack references.

This is currently done while pre-checking an expression before constraint generation, but this could later be moved into the solver by rewriting the postfix operator expression to an `UnresolvedExpansionOperator` or similar that generates a disjunction between the between postfix `...` and expansion operator, and delaying constraint generation for the operand until after a disjunction choice is attempted.