### PR TITLE
[stdlib][String] Remove unnecessary ASCII check

### DIFF
--- a/stdlib/public/core/StringUTF8Validation.swift
+++ b/stdlib/public/core/StringUTF8Validation.swift
@@ -101,10 +101,11 @@ internal func validateUTF8(_ buf: UnsafeBufferPointer<UInt8>) -> UTF8ValidationR
   }
 
   do {
-    var isASCII = true
     while let cu = iter.next() {
-      if UTF8.isASCII(cu) { lastValidIndex &+= 1; continue }
-      isASCII = false
+      if UTF8.isASCII(cu) { 
+        lastValidIndex &+= 1
+        continue 
+      }
       if _slowPath(!_isUTF8MultiByteLeading(cu)) {
         throw UTF8ValidationError()
       }
@@ -147,7 +148,7 @@ internal func validateUTF8(_ buf: UnsafeBufferPointer<UInt8>) -> UTF8ValidationR
         Builtin.unreachable()
       }
     }
-    return .success(UTF8ExtraInfo(isASCII: isASCII))
+    return .success(UTF8ExtraInfo(isASCII: false))
   } catch {
     return .error(toBeReplaced: findInvalidRange(buf[lastValidIndex...]))
   }


### PR DESCRIPTION
Removes an unnecessary variable used for tracking whether a string is ASCII during UTF-8 validation.

The very first thing this function does is to check whether the string is ASCII - if we proceed to actually validate UTF-8 code-units, at least 1 of them must be non-ASCII.