### PR TITLE
[CMake] Fix issues when running `build-tooling-libs`

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -127,9 +127,10 @@ function(add_swift_compiler_modules_library name)
       ${SWIFT_HOST_VARIANT_ARCH} "${deployment_version}")
 
   # Let Swift discover SwiftShims headers which are included by some headers
-  # under `include/swift`.
+  # under `include/swift`. These are either located next to the compiler (in case of open source toolchains) or
+  # in the SDK (in case a Swift compiler from Xcode)
   get_filename_component(swift_exec_bin_dir ${ALS_SWIFT_EXEC} DIRECTORY)
-  set(sdk_option ${sdk_option} "-I" "${swift_exec_bin_dir}/../lib")
+  set(sdk_option ${sdk_option} "-I" "${swift_exec_bin_dir}/../lib" "-I" "${sdk_path}/usr/lib")
 
   set(all_obj_files)
   set(all_module_targets)

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -274,6 +274,10 @@ macro(swift_common_unified_build_config product)
   set(${product}_NATIVE_CLANG_TOOLS_PATH "${CMAKE_BINARY_DIR}/bin")
   set(LLVM_PACKAGE_VERSION ${PACKAGE_VERSION})
   set(LLVM_CMAKE_DIR "${CMAKE_SOURCE_DIR}/cmake/modules")
+  set(CLANG_INCLUDE_DIRS 
+    "${CLANG_MAIN_INCLUDE_DIR}"
+    "${CLANG_BUILD_INCLUDE_DIR}"
+  )
 
   # If cmark was checked out into tools/cmark, expect to build it as
   # part of the unified build.

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -179,7 +179,7 @@ endif()
 # where intrinsics and attributes are declared. swiftAST depends on these
 # headers.
 # For more information see the comment at the top of lib/CMakeLists.txt.
-add_dependencies(swiftAST intrinsics_gen clang-tablegen-targets)
+add_dependencies(swift-ast-generated-headers intrinsics_gen clang-tablegen-targets)
 add_dependencies(swiftAST swift-ast-generated-headers)
 
 set_swift_llvm_is_available(swiftAST)


### PR DESCRIPTION
There were three different issues going on here, all of these were triggered by https://github.com/apple/swift/pull/61618 which stared including `AST/AnyFunctionRef.h` from the ASTBridging modulemap

- We did not find the clang include dirs because the unified build that build-tooling-libs is using does not import ClangConfig, setting `CLANG_INCLUDE_DIRS` in `swift_common_unified_build_config` fixed this problem.
- Some of the headers in `swift-ast-generated-headers` import generated headers from clang that might not have been created yet. Making `swift-ast-generated-headers` depend on the clang generated headers fixes this problem. This just lowers the dependency because `swiftAST` depends on `swift-ast-generated-headers`
- If a Swift compiler from Xcode is used, the SwiftShims don’t live next to the compiler but in the SDK. Adding the SDKs lib to the include paths fixes this problem