### PR TITLE
Type-check and use the result of macro-expanding an expression macro

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6666,5 +6666,12 @@ ERROR(experimental_no_metadata_feature_can_only_be_used_when_enabled,
       " -enable-experimental-feature LayoutPrespecialization to swift to enable "
       " the usage of this language feature", ())
 
+
+//------------------------------------------------------------------------------
+// MARK: Macros
+//------------------------------------------------------------------------------
+ERROR(expected_macro_expansion_expr,PointsToFirstBadToken,
+      "expected macro expansion to produce an expression", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2982,6 +2982,10 @@ public:
       OS << '\n';
       printArgumentList(E->getArgs());
     }
+    if (auto rewritten = E->getRewritten()) {
+      OS << '\n';
+      printRec(rewritten);
+    }
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 };

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -83,7 +83,7 @@ public func evaluateMacro(
       evaluatedResultPtr[utf8.count] = 0
 
       expandedSourcePointer.pointee = UnsafePointer(evaluatedResultPtr)
-      expandedSourceLength.pointee = utf8.count + 1
+      expandedSourceLength.pointee = utf8.count
     }
 
     return 0

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -58,6 +58,7 @@ add_swift_host_library(swiftSema STATIC
   TypeCheckExpr.cpp
   TypeCheckExprObjC.cpp
   TypeCheckGeneric.cpp
+  TypeCheckMacros.cpp
   TypeCheckNameLookup.cpp
   TypeCheckPattern.cpp
   TypeCheckPropertyWrapper.cpp

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2977,8 +2977,14 @@ namespace {
         auto kind = MagicIdentifierLiteralExpr::getKindString(expr->getKind())
             .drop_front();
         auto expandedType = solution.simplifyType(solution.getType(expr));
-        if (auto newExpr = expandMacroExpr(dc, expr, kind, expandedType))
-          return newExpr;
+        if (auto newExpr = expandMacroExpr(dc, expr, kind, expandedType)) {
+          auto expansion = new (ctx) MacroExpansionExpr(
+              expr->getStartLoc(), expr, nullptr, /*isImplicit=*/true,
+              expandedType);
+          expansion->setRewritten(newExpr);
+          cs.cacheExprTypes(expansion);
+          return expansion;
+        }
 
         // Fall through to use old implementation.
       }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1,0 +1,98 @@
+//===--- TypeCheckMacros.cpp -  Macro Handling ----------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements support for the evaluation of macros.
+//
+//===----------------------------------------------------------------------===//
+
+#include "TypeCheckMacros.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Expr.h"
+#include "swift/AST/SourceFile.h"
+#include "swift/Basic/SourceManager.h"
+#include "swift/Parse/Lexer.h"
+
+using namespace swift;
+
+extern "C" ptrdiff_t swift_ASTGen_evaluateMacro(
+    void *sourceFile, const void *sourceLocation,
+    const char **evaluatedSource, ptrdiff_t *evaluatedSourceLength);
+
+#if SWIFT_SWIFT_PARSER
+Expr *swift::expandMacroExpr(
+    DeclContext *dc, Expr *expr, StringRef macroName, Type expandedType
+) {
+  ASTContext &ctx = dc->getASTContext();
+
+  // FIXME: Introduce a more robust way to ensure that we can get the "exported"
+  // source file for a given context. If it's within a macro expansion, it
+  // may not have a C++ SourceFile, but will have a Syntax tree.
+  //
+  // FIXME^2: And find a better name for "exportedSourceFile".
+  auto sourceFile = dc->getParentSourceFile();
+  if (!sourceFile)
+    return nullptr;
+
+  auto astGenSourceFile = sourceFile->exportedSourceFile;
+  if (!astGenSourceFile)
+    return nullptr;
+
+  // Evaluate the macro.
+  const char *evaluatedSource;
+  ptrdiff_t evaluatedSourceLength;
+  swift_ASTGen_evaluateMacro(
+      astGenSourceFile, expr->getStartLoc().getOpaquePointerValue(),
+      &evaluatedSource, &evaluatedSourceLength);
+  if (!evaluatedSource)
+    return nullptr;
+
+  SourceManager &sourceMgr = ctx.SourceMgr;
+
+  // Figure out a reasonable name for the macro expansion buffer.
+  std::string bufferName;
+  {
+    llvm::raw_string_ostream out(bufferName);
+
+    out << "Macro expansion of #" << macroName;
+    if (auto bufferID = sourceFile->getBufferID()) {
+      unsigned startLine, startColumn;
+      std::tie(startLine, startColumn) =
+          sourceMgr.getLineAndColumnInBuffer(expr->getStartLoc(), *bufferID);
+
+      SourceLoc endLoc =
+          Lexer::getLocForEndOfToken(sourceMgr, expr->getEndLoc());
+      unsigned endLine, endColumn;
+      std::tie(endLine, endColumn) =
+          sourceMgr.getLineAndColumnInBuffer(endLoc, *bufferID);
+
+      out << sourceMgr.getIdentifierForBuffer(*bufferID) << ":"
+          << startLine << ":" << startColumn
+          << "-" << endLine << ":" << endColumn;
+    }
+  }
+
+  // Create a new source buffer with the contents of the expanded macro.
+  auto macroBuffer =
+      llvm::MemoryBuffer::getMemBuffer(
+          StringRef(evaluatedSource, evaluatedSourceLength), bufferName);
+  unsigned macroBufferID = sourceMgr.addNewSourceBuffer(std::move(macroBuffer));
+
+  // FIXME: Debug output.
+  llvm::outs() << "Macro rewrite: "
+    << "#" << macroName
+    << " --> " << sourceMgr.getEntireTextForBuffer(macroBufferID)
+    << "\n";
+
+  return nullptr;
+}
+
+#endif // SWIFT_SWIFT_PARSER

--- a/lib/Sema/TypeCheckMacros.h
+++ b/lib/Sema/TypeCheckMacros.h
@@ -1,0 +1,36 @@
+//===--- TypeCheckConcurrency.h - Concurrency -------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides type checking support for macros.
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_SEMA_TYPECHECKMACROS_H
+#define SWIFT_SEMA_TYPECHECKMACROS_H
+
+#include "swift/AST/Type.h"
+
+namespace swift {
+
+class Expr;
+  
+/// Expands the given macro expression and type-check the result with
+/// the given expanded type.
+///
+/// \returns the type-checked replacement expression, or NULL if the
+// macro could not be expanded.
+Expr *expandMacroExpr(
+    DeclContext *dc, Expr *expr, StringRef macroName, Type expandedType);
+
+} // end namespace swift
+
+#endif /* SWIFT_SEMA_TYPECHECKMACROS_H */
+

--- a/test/Macros/builtin_macros.swift
+++ b/test/Macros/builtin_macros.swift
@@ -1,12 +1,22 @@
-// RUN: %target-swift-frontend -enable-experimental-feature BuiltinMacros -typecheck %s -module-name MacrosTest 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-feature BuiltinMacros -dump-ast %s -module-name MacrosTest 2>&1 | %FileCheck %s
 // REQUIRES: OS=macosx
 
-// CHECK: #function --> "MacrosTest"
+// CHECK: macro_expansion_expr implicit type='String'
+// CHECK-NEXT: magic_identifier_literal_expr{{.*}}kind=#function
+// CHECK-NEXT: string_literal_expr{{.*}}Macro expansion of #function in{{.*}}value="MacrosTest"
 print(#function)
 
 func f(a: Int, b: Int) {
   print(#function, #line, #column)
-  // CHECK-NEXT: #function --> "f(a:b:)"
-  // CHECK-NEXT: #line --> 8
-  // CHECK-NEXT: #column --> 27
+  // CHECK: macro_expansion_expr implicit type='String'
+  // CHECK-NEXT: magic_identifier_literal_expr{{.*}}kind=#function
+  // CHECK-NEXT: string_literal_expr{{.*}}Macro expansion of #function in{{.*}}value="f(a:b:)"
+
+  // CHECK: macro_expansion_expr implicit type='Int'
+  // CHECK-NEXT: magic_identifier_literal_expr{{.*}}kind=#line
+  // CHECK-NEXT: integer_literal_expr{{.*}}Macro expansion of #line in{{.*}}value=10
+
+  // CHECK: macro_expansion_expr implicit type='Int'
+  // CHECK-NEXT: magic_identifier_literal_expr{{.*}}kind=#column
+  // CHECK-NEXT: integer_literal_expr{{.*}}Macro expansion of #column in{{.*}}value=27
 }


### PR DESCRIPTION
Once we have expanded an expression macro, create a source buffer with its contents, then parse and type-check the
result given a priori knowledge of the expanded type. Then, create an implicit macro-expansion expression to capture the result of the rewrite.

With `-enable-experimental-feature BuiltinMacros`, we now use the syntactic macro transforms for the implementation, replacing the AST with a macro expansion backed by the appropriate string or integer literal.