### PR TITLE
Fix asyncMainDrainQueue noreturn warning

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -770,6 +770,19 @@ SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swift) void (*swift_task_enqueueMainExecutor_hook)(
     Job *job, swift_task_enqueueMainExecutor_original original);
 
+/// A hook to override the entrypoint to the main runloop used to drive the
+/// concurrency runtime and drain the main queue. This function must not return.
+/// Note: If the hook is wrapping the original function and the `compatOverride`
+///       is passed in, the `original` function pointer must be passed into the
+///       compatibility override function as the original function.
+typedef SWIFT_CC(swift) void (*swift_task_asyncMainDrainQueue_original)();
+typedef SWIFT_CC(swift) void (*swift_task_asyncMainDrainQueue_override)(
+    swift_task_asyncMainDrainQueue_original original);
+SWIFT_EXPORT_FROM(swift_Concurrency)
+SWIFT_CC(swift) void (*swift_task_asyncMainDrainQueue_hook)(
+    swift_task_asyncMainDrainQueue_original original,
+    swift_task_asyncMainDrainQueue_override compatOverride);
+
 /// Initialize the runtime storage for a default actor.
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_defaultActor_initialize(DefaultActor *actor);

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverride.cpp
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverride.cpp
@@ -89,6 +89,15 @@ static OverrideSection *getOverrideSectionPtr() {
       return nullptr;                                               \
     return Section->name;                                           \
   }
+
+#define OVERRIDE_NORETURN(name, attrs, ccAttrs, namespace, typedArgs, namedArgs) \
+  Override_ ## name swift::getOverride_ ## name() {                 \
+    auto *Section = getOverrideSectionPtr();                        \
+    if (Section == nullptr)                                         \
+      nullptr;                                               \
+    Section->name;                                           \
+  }
+
 #include COMPATIBILITY_OVERRIDE_INCLUDE_PATH
 
 #endif // #ifdef SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -77,9 +77,9 @@
 #  define OVERRIDE_TASK_GROUP OVERRIDE
 #  define OVERRIDE_TASK_LOCAL OVERRIDE
 #  define OVERRIDE_TASK_STATUS OVERRIDE
-#ifndef OVERRIDE_TASK_NORETURN
-# define OVERRIDE_TASK_NORETURN(name, attrs, ccAttrs, namespace, typedArgs, \
-                                namedArgs) \
+#ifndef HOOKED_OVERRIDE_TASK_NORETURN
+# define HOOKED_OVERRIDE_TASK_NORETURN(name, attrs, ccAttrs, namespace,       \
+                                      typedArgs, namedArgs)                   \
   OVERRIDE(name, void, attrs, ccAttrs, namespace, typedArgs, namedArgs)
 #endif
 #else
@@ -101,8 +101,8 @@
 #  ifndef OVERRIDE_TASK_STATUS
 #    define OVERRIDE_TASK_STATUS(...)
 #  endif
-#  ifndef OVERRIDE_TASK_NORETURN
-#    define OVERRIDE_TASK_NORETURN(...)
+#  ifndef HOOKED_OVERRIDE_TASK_NORETURN
+#    define HOOKED_OVERRIDE_TASK_NORETURN(...)
 #  endif
 #endif
 
@@ -189,9 +189,10 @@ OVERRIDE_TASK(task_createNullaryContinuationJob, NullaryContinuationJob *,
               (size_t priority,
                AsyncTask *continuation), (priority, continuation))
 
-OVERRIDE_TASK_NORETURN(task_asyncMainDrainQueue,
-              SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift), swift::,
-              , )
+HOOKED_OVERRIDE_TASK_NORETURN(task_asyncMainDrainQueue,
+              SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+              swift::, ,)
+
 
 OVERRIDE_TASK(task_suspend, AsyncTask *,
               SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
@@ -388,4 +389,4 @@ OVERRIDE_TASK_STATUS(task_escalate, JobPriority,
 #undef OVERRIDE_TASK_GROUP
 #undef OVERRIDE_TASK_LOCAL
 #undef OVERRIDE_TASK_STATUS
-#undef OVERRIDE_TASK_NORETURN
+#undef HOOKED_OVERRIDE_TASK_NORETURN

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -77,6 +77,11 @@
 #  define OVERRIDE_TASK_GROUP OVERRIDE
 #  define OVERRIDE_TASK_LOCAL OVERRIDE
 #  define OVERRIDE_TASK_STATUS OVERRIDE
+#ifndef OVERRIDE_TASK_NORETURN
+# define OVERRIDE_TASK_NORETURN(name, attrs, ccAttrs, namespace, typedArgs, \
+                                namedArgs) \
+  OVERRIDE(name, void, attrs, ccAttrs, namespace, typedArgs, namedArgs)
+#endif
 #else
 #  ifndef OVERRIDE_ACTOR
 #    define OVERRIDE_ACTOR(...)
@@ -95,6 +100,9 @@
 #  endif
 #  ifndef OVERRIDE_TASK_STATUS
 #    define OVERRIDE_TASK_STATUS(...)
+#  endif
+#  ifndef OVERRIDE_TASK_NORETURN
+#    define OVERRIDE_TASK_NORETURN(...)
 #  endif
 #endif
 
@@ -181,7 +189,7 @@ OVERRIDE_TASK(task_createNullaryContinuationJob, NullaryContinuationJob *,
               (size_t priority,
                AsyncTask *continuation), (priority, continuation))
 
-OVERRIDE_TASK(task_asyncMainDrainQueue, void,
+OVERRIDE_TASK_NORETURN(task_asyncMainDrainQueue,
               SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift), swift::,
               , )
 
@@ -380,3 +388,4 @@ OVERRIDE_TASK_STATUS(task_escalate, JobPriority,
 #undef OVERRIDE_TASK_GROUP
 #undef OVERRIDE_TASK_LOCAL
 #undef OVERRIDE_TASK_STATUS
+#undef OVERRIDE_TASK_NORETURN

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1589,6 +1589,11 @@ static void swift_task_asyncMainDrainQueueImpl() {
 #endif
 }
 
+SWIFT_CC(swift)
+void (*swift::swift_task_asyncMainDrainQueue_hook)(
+    swift_task_asyncMainDrainQueue_original original,
+    swift_task_asyncMainDrainQueue_override compatOverride) = nullptr;
+
 #define OVERRIDE_TASK COMPATIBILITY_OVERRIDE
 
 #ifdef SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT
@@ -1596,13 +1601,19 @@ static void swift_task_asyncMainDrainQueueImpl() {
 /// returns the result of the impl function and override function. This results
 /// in a warning emitted for noreturn functions. Overriding the override macro
 /// to not return.
-#define OVERRIDE_TASK_NORETURN(name, attrs, ccAttrs, namespace, typedArgs,     \
-                               namedArgs)                                      \
+#define HOOKED_OVERRIDE_TASK_NORETURN(name, attrs, ccAttrs, namespace,         \
+                                      typedArgs, namedArgs)                    \
   attrs ccAttrs void namespace swift_##name COMPATIBILITY_PAREN(typedArgs) {   \
     static Override_##name Override;                                           \
     static swift_once_t Predicate;                                             \
     swift_once(                                                                \
         &Predicate, [](void *) { Override = getOverride_##name(); }, nullptr); \
+    if (swift_##name##_hook) {                                                 \
+      swift_##name##_hook(COMPATIBILITY_UNPAREN_WITH_COMMA(namedArgs)          \
+                              swift_##name##Impl,                              \
+                          Override);                                           \
+      abort();                                                                 \
+    }                                                                          \
     if (Override != nullptr)                                                   \
       Override(COMPATIBILITY_UNPAREN_WITH_COMMA(namedArgs)                     \
                    swift_##name##Impl);                                        \
@@ -1612,11 +1623,15 @@ static void swift_task_asyncMainDrainQueueImpl() {
 #else // ifndef SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT
 // Call directly through to the original implementation when we don't support
 // overrides.
-#define OVERRIDE_TASK_NORETURN(name, attrs, ccAttrs, namespace, typedArgs,     \
-                               namedArgs)                                      \
+#define HOOKED_OVERRIDE_TASK_NORETURN(name, attrs, ccAttrs, namespace,         \
+                                      typedArgs, namedArgs)                    \
   attrs ccAttrs void namespace swift_##name COMPATIBILITY_PAREN(typedArgs) {   \
-      swift_##name##Impl COMPATIBILITY_PAREN(namedArgs);                       \
-    }
+    if (swift_##name##_hook) {                                                 \
+      swift_##name##_hook(swift_##name##Impl, nullptr);                        \
+      abort();                                                                 \
+    }                                                                          \
+    swift_##name##Impl COMPATIBILITY_PAREN(namedArgs);                         \
+  }
 #endif // #else SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT
 
 #include COMPATIBILITY_OVERRIDE_INCLUDE_PATH

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -44,6 +44,15 @@ ExecutorRef getEmptyValue() {
     Ran = true;                                                                \
     return getEmptyValue<ret>();                                               \
   }
+#define OVERRIDE_TASK_NORETURN(name, attrs, ccAttrs, namespace, typedArgs,     \
+                               namedArgs)                                      \
+  static ccAttrs void name##Override(COMPATIBILITY_UNPAREN_WITH_COMMA(         \
+      typedArgs) Original_##name originalImpl) {                               \
+    if (!EnableOverride)                                                       \
+      originalImpl COMPATIBILITY_PAREN(namedArgs);                             \
+    Ran = true;                                                                \
+  }
+
 #include "../../stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def"
 
 struct OverrideSection {

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -18,6 +18,12 @@
 #include "swift/Runtime/Concurrency.h"
 #include "gtest/gtest.h"
 
+#if __has_include("pthread.h")
+
+#define RUN_ASYNC_MAIN_DRAIN_QUEUE_TEST 1
+#include <pthread.h>
+#endif // HAVE_PTHREAD_H
+
 #include <stdio.h>
 
 using namespace swift;
@@ -91,6 +97,16 @@ static void swift_task_enqueueMainExecutor_override(
   Ran = true;
 }
 
+#ifdef RUN_ASYNC_MAIN_DRAIN_QUEUE_TEST
+[[noreturn]] SWIFT_CC(swift)
+static void swift_task_asyncMainDrainQueue_override_fn(
+    swift_task_asyncMainDrainQueue_original original,
+    swift_task_asyncMainDrainQueue_override compatOverride) {
+  Ran = true;
+  pthread_exit(nullptr); // noreturn function
+}
+#endif
+
 class CompatibilityOverrideConcurrencyTest : public ::testing::Test {
 protected:
   virtual void SetUp() {
@@ -109,6 +125,10 @@ protected:
         swift_task_enqueueGlobalWithDelay_override;
     swift_task_enqueueMainExecutor_hook =
         swift_task_enqueueMainExecutor_override;
+#ifdef RUN_ASYNC_MAIN_DRAIN_QUEUE_TEST
+    swift_task_asyncMainDrainQueue_hook =
+        swift_task_asyncMainDrainQueue_override_fn;
+#endif
   }
 
   virtual void TearDown() {
@@ -263,5 +283,28 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_cancel_group_child_
 TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_escalate) {
   swift_task_escalate(nullptr, {});
 }
+
+#if RUN_ASYNC_MAIN_DRAIN_QUEUE_TEST
+TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_asyncMainDrainQueue) {
+
+  auto runner = [](void *) -> void * {
+    swift_task_asyncMainDrainQueue();
+    return nullptr;
+  };
+
+  int ret = 0;
+  pthread_t thread;
+  pthread_attr_t attrs;
+  ret = pthread_attr_init(&attrs);
+  ASSERT_EQ(ret, 0);
+  ret = pthread_create(&thread, &attrs, runner, nullptr);
+  ASSERT_EQ(ret, 0);
+  void * result = nullptr;
+  ret = pthread_join(thread, &result);
+  ASSERT_EQ(ret, 0);
+  pthread_attr_destroy(&attrs);
+  ASSERT_EQ(ret, 0);
+}
+#endif
 
 #endif


### PR DESCRIPTION
The async main drain queue function is noreturn, but was emitting a warning due to the override compatibility returning the result of the overridden function in the wrapper override function. To work around this, I've added the `OVERRIDE_TASK_NORETURN` macro, which provides an override point for noreturn functions in the concurrency library that doesn't return the result from the wrapped function, avoiding the warning. In the event that the function is not set, the macro is set to the normal `OVERRIDE` with the return type set to `void`.

rdar://85521851