### PR TITLE
runtime: fix compile failure from use of _Unwind_Backtrace() on FreeBSD 13.0

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -22,6 +22,22 @@
 #include <mutex>
 #endif
 
+#if defined(__ELF__)
+# if defined(__FreeBSD__) && !defined(_GNU_SOURCE)
+// In order to access _Unwind_Backtrace() from (the non-LLVM, non-GCC)
+// <unwind.h> in FreeBSD, define _GNU_SOURCE around the include.  Do this
+// before including other headers which may in turn include <unwind.h>, which
+// has a header guard.
+#  define _GNU_SOURCE
+#  define _SHOULD_UNDEFINE_GNU_SOURCE
+# endif
+# include <unwind.h>
+# ifdef _SHOULD_UNDEFINE_GNU_SOURCE
+#  undef _GNU_SOURCE
+#  undef _SHOULD_UNDEFINE_GNU_SOURCE
+# endif
+#endif
+
 #include <inttypes.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -54,10 +70,6 @@
 #include <asl.h>
 #elif defined(__ANDROID__)
 #include <android/log.h>
-#endif
-
-#if defined(__ELF__)
-#include <unwind.h>
 #endif
 
 #include <inttypes.h>


### PR DESCRIPTION
FreeBSD's libunwind situation is complex.  It uses LLVM's libunwind library, built as part of FreeBSD's libgcc_s.so.  (The latter, despite its name, does not actually come from gcc in modern FreeBSD.)

However, it *also* uses libcxxrt (not LLVM's libcxxabi).  libcxxrt installs an <unwind.h> originally from <https://github.com/libunwind/libunwind>.  That <unwind.h> surrounds its declaration of _Unwind_Backtrace with _GNU_SOURCE guards.

Therefore: on FreeBSD, define _GNU_SOURCE so that withCurrentBacktraceImpl() can access _Unwind_Backtrace.

For posterity, a (probably partial) list of the various <unwind.h>s (and how they relate to this change):

1. gcc provides one as part of its libgcc (FreeBSD does not use gcc and provides its own libgcc that does not have an <unwind.h>)
2. LLVM's libunwind provides one (but FreeBSD does not install it)
3. <https://github.com/libunwind/libunwind> provides one (FreeBSD has this one, via its libc++, via its libcxxrt)
4. clang provides one (FreeBSD *has* this one, but the header search path for C++ source files prefers number 3)