### PR TITLE
Test: Adjust bridged known types tests for the macOS 13 SDK

### DIFF
--- a/test/PrintAsObjC/bridged-known-types-cf-cgfloat.swift
+++ b/test/PrintAsObjC/bridged-known-types-cf-cgfloat.swift
@@ -3,8 +3,8 @@
 // their bridged type.
 //
 // This is particularly important for `CGFloat`, which has a native Swift decl
-// in the CoreGraphics overlay that shadows the imported Clang decl, so relying
-// solely on whether or not the decl has a Clang node is not sufficient.
+// in the CoreFoundation overlay that shadows the imported Clang decl, so
+// relying solely on whether or not the decl has a Clang node is not sufficient.
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -typecheck %s -parse-as-library -emit-objc-header-path %t/swift.h
@@ -17,8 +17,6 @@
 
 import CoreGraphics
 import Foundation
-
-// CHECK: @import CoreGraphics;
 
 // CHECK-NOT: @class NSNumber;
 

--- a/test/PrintAsObjC/bridged-known-types.swift
+++ b/test/PrintAsObjC/bridged-known-types.swift
@@ -3,8 +3,8 @@
 // their bridged type.
 //
 // This is particularly important for `CGFloat`, which has a native Swift decl
-// in the CoreGraphics overlay that shadows the imported Clang decl, so relying
-// solely on whether or not the decl has a Clang node is not sufficient.
+// in the CoreFoundation overlay that shadows the imported Clang decl, so
+// relying solely on whether or not the decl has a Clang node is not sufficient.
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -typecheck %s -parse-as-library -emit-objc-header-path %t/swift.h
@@ -17,8 +17,6 @@
 
 import CoreGraphics
 import Foundation
-
-// CHECK: @import CoreGraphics;
 
 // CHECK-NOT: @class NSNumber;
 


### PR DESCRIPTION
In the macOS 13 SDK the definition of `CGFloat` moved from the CoreGraphics Swift overlay to the CoreFoundation overlay. This test should therefore no longer check that a `@import CoreGraphics` directive is emitted since this check fails for compiler developers using newer SDKs.
