### PR TITLE
[cxx-interop] Add conversions between `std::u16string` and `Swift.String`

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// MARK: Initializing C++ string from a Swift String
+
 extension std.string {
   public init(_ string: String) {
     self.init()
@@ -19,11 +21,30 @@ extension std.string {
   }
 }
 
+extension std.u16string {
+  public init(_ string: String) {
+    self.init()
+    for char in string.utf16 {
+      self.push_back(char)
+    }
+  }
+}
+
+// MARK: Initializing C++ string from a Swift String literal
+
 extension std.string: ExpressibleByStringLiteral {
   public init(stringLiteral value: String) {
     self.init(value)
   }
 }
+
+extension std.u16string: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) {
+    self.init(value)
+  }
+}
+
+// MARK: Initializing Swift String from a C++ string
 
 extension String {
   public init(cxxString: std.string) {
@@ -34,5 +55,13 @@ extension String {
       String(decoding: $0, as: UTF8.self)
     }
     withExtendedLifetime(cxxString) {}
+  }
+
+  public init(cxxU16String: std.u16string) {
+    let buffer = UnsafeBufferPointer<UInt16>(
+      start: cxxU16String.__dataUnsafe(),
+      count: cxxU16String.size())
+    self = String(decoding: buffer, as: UTF16.self)
+    withExtendedLifetime(cxxU16String) {}
   }
 }

--- a/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
+++ b/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
@@ -37,6 +37,36 @@ StdStringOverlayTestSuite.test("std::string <=> Swift.String") {
   expectEqual(swift6, "xyz\0abc")
 }
 
+StdStringOverlayTestSuite.test("std::u16string <=> Swift.String") {
+  let cxx1 = std.u16string()
+  let swift1 = String(cxxU16String: cxx1)
+  expectEqual(swift1, "")
+
+  let cxx2 = std.u16string("something123")
+  expectEqual(cxx2.size(), 12)
+  let swift2 = String(cxxU16String: cxx2)
+  expectEqual(swift2, "something123")
+
+  let cxx3: std.u16string = "literal"
+  expectEqual(cxx3.size(), 7)
+
+  let cxx4: std.u16string = "тест"
+  expectEqual(cxx4.size(), 4)
+  let swift4 = String(cxxU16String: cxx4)
+  expectEqual(swift4, "тест")
+
+  // Emojis are represented by more than one CWideChar.
+  let cxx5: std.u16string = "emoji_🤖"
+  expectEqual(cxx5.size(), 8)
+  let swift5 = String(cxxU16String: cxx5)
+  expectEqual(swift5, "emoji_🤖")
+
+  let cxx6 = std.u16string("xyz\0abc")
+  expectEqual(cxx6.size(), 7)
+  let swift6 = String(cxxU16String: cxx6)
+  expectEqual(swift6, "xyz\0abc")
+}
+
 extension std.string.const_iterator: UnsafeCxxInputIterator {
   // This func should not be required.
   public static func ==(lhs: std.string.const_iterator,


### PR DESCRIPTION
This change adds a few extensions to the C++ stdlib overlay to allow convenient conversions between C++ UTF-16 strings and Swift strings.