### PR TITLE
swift_build_support: unify CMake toolchain code

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/cmark.py
+++ b/utils/swift_build_support/swift_build_support/products/cmark.py
@@ -54,7 +54,7 @@ class CMark(cmake_product.CMakeProduct):
 
         self.cmake_options.define('CMARK_THREADING', 'ON')
 
-        host_toolchain = self.generate_toolchain_file(host_target)
+        host_toolchain = self.generate_toolchain_file_for_darwin_or_linux(host_target)
 
         (platform, _) = host_target.split('-')
         if not host_toolchain and platform == "openbsd":

--- a/utils/swift_build_support/swift_build_support/products/cmark.py
+++ b/utils/swift_build_support/swift_build_support/products/cmark.py
@@ -54,22 +54,10 @@ class CMark(cmake_product.CMakeProduct):
 
         self.cmake_options.define('CMARK_THREADING', 'ON')
 
-        (platform, arch) = host_target.split('-')
+        host_toolchain = self.generate_toolchain_file(host_target)
 
-        common_c_flags = ' '.join(self.common_cross_c_flags(platform, arch))
-        self.cmake_options.define('CMAKE_C_FLAGS', common_c_flags)
-        self.cmake_options.define('CMAKE_CXX_FLAGS', common_c_flags)
-
-        if host_target.startswith("macosx") or \
-           host_target.startswith("iphone") or \
-           host_target.startswith("appletv") or \
-           host_target.startswith("watch"):
-            toolchain_file = self.generate_darwin_toolchain_file(platform, arch)
-            self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
-        elif platform == "linux":
-            toolchain_file = self.generate_linux_toolchain_file(platform, arch)
-            self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
-        elif platform == "openbsd":
+        (platform, _) = host_target.split('-')
+        if not host_toolchain and platform == "openbsd":
             toolchain_file = self.get_openbsd_toolchain_file()
             if toolchain_file:
                 self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)

--- a/utils/swift_build_support/swift_build_support/products/curl.py
+++ b/utils/swift_build_support/swift_build_support/products/curl.py
@@ -109,20 +109,7 @@ class LibCurl(cmake_product.CMakeProduct):
         self.cmake_options.define('ENABLE_UNIX_SOCKETS', 'NO')
         self.cmake_options.define('ENABLE_THREADED_RESOLVER', 'NO')
 
-        (platform, arch) = host_target.split('-')
-        common_c_flags = ' '.join(self.common_cross_c_flags(platform, arch))
-        self.cmake_options.define('CMAKE_C_FLAGS', common_c_flags)
-        self.cmake_options.define('CMAKE_CXX_FLAGS', common_c_flags)
-
-        if host_target.startswith("macosx") or \
-           host_target.startswith("iphone") or \
-           host_target.startswith("appletv") or \
-           host_target.startswith("watch"):
-            toolchain_file = self.generate_darwin_toolchain_file(platform, arch)
-            self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
-        elif platform == "linux":
-            toolchain_file = self.generate_linux_toolchain_file(platform, arch)
-            self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
+        self.generate_toolchain_file(host_target)
 
         if self.args.build_zlib:
             # If we're building zlib, make cmake search in the built toolchain

--- a/utils/swift_build_support/swift_build_support/products/curl.py
+++ b/utils/swift_build_support/swift_build_support/products/curl.py
@@ -109,7 +109,7 @@ class LibCurl(cmake_product.CMakeProduct):
         self.cmake_options.define('ENABLE_UNIX_SOCKETS', 'NO')
         self.cmake_options.define('ENABLE_THREADED_RESOLVER', 'NO')
 
-        self.generate_toolchain_file(host_target)
+        self.generate_toolchain_file_for_darwin_or_linux(host_target)
 
         if self.args.build_zlib:
             # If we're building zlib, make cmake search in the built toolchain

--- a/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
@@ -51,21 +51,7 @@ class EarlySwiftSyntax(cmake_product.CMakeProduct):
                                   self.args.swift_build_variant)
         self.cmake_options.define('BUILD_SHARED_LIBS:STRING', 'NO')
 
-        (platform, arch) = host_target.split('-')
-
-        common_c_flags = ' '.join(self.common_cross_c_flags(platform, arch))
-        self.cmake_options.define('CMAKE_C_FLAGS', common_c_flags)
-        self.cmake_options.define('CMAKE_CXX_FLAGS', common_c_flags)
-
-        if host_target.startswith("macosx") or \
-           host_target.startswith("iphone") or \
-           host_target.startswith("appletv") or \
-           host_target.startswith("watch"):
-            toolchain_file = self.generate_darwin_toolchain_file(platform, arch)
-            self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
-        elif platform == "linux":
-            toolchain_file = self.generate_linux_toolchain_file(platform, arch)
-            self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
+        self.generate_toolchain_file(host_target)
 
         self.build_with_cmake(["all"], self.args.swift_build_variant, [])
 

--- a/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
@@ -51,7 +51,7 @@ class EarlySwiftSyntax(cmake_product.CMakeProduct):
                                   self.args.swift_build_variant)
         self.cmake_options.define('BUILD_SHARED_LIBS:STRING', 'NO')
 
-        self.generate_toolchain_file(host_target)
+        self.generate_toolchain_file_for_darwin_or_linux(host_target)
 
         self.build_with_cmake(["all"], self.args.swift_build_variant, [])
 

--- a/utils/swift_build_support/swift_build_support/products/libxml2.py
+++ b/utils/swift_build_support/swift_build_support/products/libxml2.py
@@ -85,5 +85,5 @@ class LibXML2(cmake_product.CMakeProduct):
         self.cmake_options.define('LIBXML2_WITH_TESTS', 'NO')
         self.cmake_options.define('LIBXML2_WITH_ZLIB', 'NO')
 
-        self.generate_toolchain_file(host_target)
+        self.generate_toolchain_file_for_darwin_or_linux(host_target)
         self.build_with_cmake(["LibXml2"], self.args.libxml2_build_variant, [])

--- a/utils/swift_build_support/swift_build_support/products/libxml2.py
+++ b/utils/swift_build_support/swift_build_support/products/libxml2.py
@@ -85,18 +85,5 @@ class LibXML2(cmake_product.CMakeProduct):
         self.cmake_options.define('LIBXML2_WITH_TESTS', 'NO')
         self.cmake_options.define('LIBXML2_WITH_ZLIB', 'NO')
 
-        (platform, arch) = host_target.split('-')
-        common_c_flags = ' '.join(self.common_cross_c_flags(platform, arch))
-        self.cmake_options.define('CMAKE_C_FLAGS', common_c_flags)
-        self.cmake_options.define('CMAKE_CXX_FLAGS', common_c_flags)
-
-        if host_target.startswith("macosx") or \
-           host_target.startswith("iphone") or \
-           host_target.startswith("appletv") or \
-           host_target.startswith("watch"):
-            toolchain_file = self.generate_darwin_toolchain_file(platform, arch)
-            self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
-        elif platform == "linux":
-            toolchain_file = self.generate_linux_toolchain_file(platform, arch)
-            self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
+        self.generate_toolchain_file(host_target)
         self.build_with_cmake(["LibXml2"], self.args.libxml2_build_variant, [])

--- a/utils/swift_build_support/swift_build_support/products/product.py
+++ b/utils/swift_build_support/swift_build_support/products/product.py
@@ -411,14 +411,16 @@ class Product(object):
 
         return toolchain_file
 
-    def generate_toolchain_file(self, host_target):
+    def generate_toolchain_file_for_darwin_or_linux(self, host_target):
         """
         Checks `host_target` platform and generates a new CMake tolchain file
-        appropriate for that target plaftorm. Defines `CMAKE_C_FLAGS` and
-        `CMAKE_CXX_FLAGS` as CMake options. Also defines `CMAKE_TOOLCHAIN_FILE`
-        with the path of the generated toolchain file as a CMake option.
+        appropriate for that target plaftorm (either Darwin or Linux). Defines
+        `CMAKE_C_FLAGS` and `CMAKE_CXX_FLAGS` as CMake options. Also defines
+        `CMAKE_TOOLCHAIN_FILE` with the path of the generated toolchain file
+        as a CMake option.
 
-            Returns: path to the newly generated toolchain file on the filesystem.
+            Returns: path to the newly generated toolchain file on the
+            filesystem.
         """
 
         (platform, arch) = host_target.split('-')

--- a/utils/swift_build_support/swift_build_support/products/zlib.py
+++ b/utils/swift_build_support/swift_build_support/products/zlib.py
@@ -81,18 +81,5 @@ class Zlib(cmake_product.CMakeProduct):
         self.cmake_options.define('SKIP_INSTALL_FILES', 'YES')
         self.cmake_options.define('CMAKE_INSTALL_PREFIX', '/usr')
 
-        (platform, arch) = host_target.split('-')
-        common_c_flags = ' '.join(self.common_cross_c_flags(platform, arch))
-        self.cmake_options.define('CMAKE_C_FLAGS', common_c_flags)
-        self.cmake_options.define('CMAKE_CXX_FLAGS', common_c_flags)
-
-        if host_target.startswith("macosx") or \
-           host_target.startswith("iphone") or \
-           host_target.startswith("appletv") or \
-           host_target.startswith("watch"):
-            toolchain_file = self.generate_darwin_toolchain_file(platform, arch)
-            self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
-        elif platform == "linux":
-            toolchain_file = self.generate_linux_toolchain_file(platform, arch)
-            self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
+        self.generate_toolchain_file(host_target)
         self.build_with_cmake(["all"], self.args.zlib_build_variant, [])

--- a/utils/swift_build_support/swift_build_support/products/zlib.py
+++ b/utils/swift_build_support/swift_build_support/products/zlib.py
@@ -81,5 +81,5 @@ class Zlib(cmake_product.CMakeProduct):
         self.cmake_options.define('SKIP_INSTALL_FILES', 'YES')
         self.cmake_options.define('CMAKE_INSTALL_PREFIX', '/usr')
 
-        self.generate_toolchain_file(host_target)
+        self.generate_toolchain_file_for_darwin_or_linux(host_target)
         self.build_with_cmake(["all"], self.args.zlib_build_variant, [])


### PR DESCRIPTION
Currently, a lot of products defined in `utils/swift_build_support` contain duplicated code that checks for Darwin/Linux triples and generates an appropriate CMake toolchain file. Since all of these products inherit from the `Product` class, it makes sense to reduce this code duplication by refactoring it into a single function.