### PR TITLE
IRGen: Fix the computation of the number of type metadata pointers for distributed thunks under opaque pointer IR

### DIFF
--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -101,7 +101,8 @@ namespace irgen {
 
   /// Add the witness parameters necessary for calling a function with
   /// the given generics clause.
-  void expandPolymorphicSignature(
+  /// Returns the number of type metadata pointers added to `types`.
+  unsigned expandPolymorphicSignature(
       IRGenModule &IGM, CanSILFunctionType type,
       SmallVectorImpl<llvm::Type *> &types,
       SmallVectorImpl<PolymorphicSignatureExpandedTypeSource> *outReqs =


### PR DESCRIPTION
When using opaque pointers we can no longer depend on the LLVM IR type to perform the computation. Instead compute the number while we are building a signature.