### PR TITLE
[cxx-interop] Synthesize conformances to `UnsafeCxxInputIterator`

### DIFF
--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -107,6 +107,7 @@ PROTOCOL(DistributedTargetInvocationResultHandler)
 // C++ Standard Library Overlay:
 PROTOCOL(CxxSequence)
 PROTOCOL(UnsafeCxxInputIterator)
+PROTOCOL(UnsafeCxxRandomAccessIterator)
 
 PROTOCOL(AsyncSequence)
 PROTOCOL(AsyncIteratorProtocol)

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1114,6 +1114,7 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
     break;
   case KnownProtocolKind::CxxSequence:
   case KnownProtocolKind::UnsafeCxxInputIterator:
+  case KnownProtocolKind::UnsafeCxxRandomAccessIterator:
     M = getLoadedModule(Id_Cxx);
     break;
   default:

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5814,6 +5814,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::DistributedTargetInvocationResultHandler:
   case KnownProtocolKind::CxxSequence:
   case KnownProtocolKind::UnsafeCxxInputIterator:
+  case KnownProtocolKind::UnsafeCxxRandomAccessIterator:
   case KnownProtocolKind::SerialExecutor:
   case KnownProtocolKind::Sendable:
   case KnownProtocolKind::UnsafeSendable:

--- a/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
+++ b/test/Interop/Cxx/stdlib/overlay/Inputs/custom-iterator.h
@@ -240,6 +240,25 @@ struct HasCustomIteratorTag {
   }
 };
 
+struct HasCustomRACIteratorTag {
+  struct CustomTag : public std::random_access_iterator_tag {};
+
+  int value;
+  using iterator_category = CustomTag;
+  const int &operator*() const { return value; }
+  HasCustomRACIteratorTag &operator++() {
+    value++;
+    return *this;
+  }
+  void operator+=(int x) { value += x; }
+  int operator-(const HasCustomRACIteratorTag &x) const {
+    return value - x.value;
+  }
+  bool operator==(const HasCustomRACIteratorTag &other) const {
+    return value == other.value;
+  }
+};
+
 struct HasCustomIteratorTagInline {
   struct iterator_category : public std::input_iterator_tag {};
 

--- a/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
@@ -11,9 +11,6 @@ var CxxCollectionTestSuite = TestSuite("CxxCollection")
 
 // === SimpleCollectionNoSubscript ===
 
-extension SimpleCollectionNoSubscript.iterator : UnsafeCxxRandomAccessIterator {
-  public typealias Distance = difference_type
-}
 extension SimpleCollectionNoSubscript : CxxRandomAccessCollection {
 }
 
@@ -25,9 +22,6 @@ CxxCollectionTestSuite.test("SimpleCollectionNoSubscript as Swift.Collection") {
 
 // === SimpleCollectionReadOnly ===
 
-extension SimpleCollectionReadOnly.iterator : UnsafeCxxRandomAccessIterator {
-  public typealias Distance = difference_type
-}
 extension SimpleCollectionReadOnly : CxxRandomAccessCollection {
 }
 

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -7,6 +7,26 @@
 // CHECK:   typealias Pointee = Int32
 // CHECK: }
 
+// CHECK: struct ConstRACIterator : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK:   var pointee: Int32 { get }
+// CHECK:   func successor() -> ConstRACIterator
+// CHECK:   static func += (lhs: inout ConstRACIterator, v: ConstRACIterator.difference_type)
+// CHECK:   static func - (lhs: ConstRACIterator, other: ConstRACIterator) -> Int32
+// CHECK:   static func == (lhs: ConstRACIterator, other: ConstRACIterator) -> Bool
+// CHECK:   typealias Pointee = Int32
+// CHECK:   typealias Distance = Int32
+// CHECK: }
+
+// CHECK: struct ConstRACIteratorRefPlusEq : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK:   var pointee: Int32 { get }
+// CHECK:   func successor() -> ConstRACIterator
+// CHECK:   static func += (lhs: inout ConstRACIteratorRefPlusEq, v: ConstRACIteratorRefPlusEq.difference_type)
+// CHECK:   static func - (lhs: ConstRACIteratorRefPlusEq, other: ConstRACIteratorRefPlusEq) -> Int32
+// CHECK:   static func == (lhs: ConstRACIteratorRefPlusEq, other: ConstRACIteratorRefPlusEq) -> Bool
+// CHECK:   typealias Pointee = Int32
+// CHECK:   typealias Distance = Int32
+// CHECK: }
+
 // CHECK: struct ConstIteratorOutOfLineEq : UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ConstIteratorOutOfLineEq
@@ -32,6 +52,16 @@
 // CHECK:   func successor() -> HasCustomIteratorTag
 // CHECK:   static func == (lhs: HasCustomIteratorTag, other: HasCustomIteratorTag) -> Bool
 // CHECK:   typealias Pointee = Int32
+// CHECK: }
+
+// CHECK: struct HasCustomRACIteratorTag : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK:   var pointee: Int32 { get }
+// CHECK:   func successor() -> HasCustomRACIteratorTag
+// CHECK:   static func += (lhs: inout HasCustomRACIteratorTag, x: Int32)
+// CHECK:   static func - (lhs: HasCustomRACIteratorTag, x: HasCustomRACIteratorTag) -> Int32
+// CHECK:   static func == (lhs: HasCustomRACIteratorTag, other: HasCustomRACIteratorTag) -> Bool
+// CHECK:   typealias Pointee = Int32
+// CHECK:   typealias Distance = Int32
 // CHECK: }
 
 // CHECK: struct HasCustomIteratorTagInline : UnsafeCxxInputIterator {


### PR DESCRIPTION
This makes ClangImporter automatically conform C++ sequence types to `Cxx.UnsafeCxxInputIterator` protocol.

We consider a C++ type to be a random access iterator type if conforms to `UnsafeCxxInputIterator`, and additionally defines `operator-` and `operator+=`.