### PR TITLE
[test] NFC: Add missing `REQUIRES`

### DIFF
--- a/test/StringProcessing/Sema/regex_builder_unavailable.swift
+++ b/test/StringProcessing/Sema/regex_builder_unavailable.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift -enable-bare-slash-regex -target %target-cpu-apple-macosx12.0
 
+// REQUIRES: swift_in_compiler
 // REQUIRES: OS=macosx
 
 import RegexBuilder


### PR DESCRIPTION
This test uses regex literals, so needs the regex parsing code to be available.

rdar://101486764
