### PR TITLE
Enable this test only when assertions are available.

### DIFF
--- a/test/Macros/builtin_macros.swift
+++ b/test/Macros/builtin_macros.swift
@@ -15,7 +15,7 @@ func f(a: Int, b: Int) {
 
   // CHECK: macro_expansion_expr implicit type='Int'
   // CHECK-NEXT: magic_identifier_literal_expr{{.*}}kind=#line
-  // CHECK-NEXT: integer_literal_expr{{.*}}Macro expansion of #line in{{.*}}value=10
+  // CHECK-NEXT: integer_literal_expr{{.*}}Macro expansion of #line in{{.*}}value=11
 
   // CHECK: macro_expansion_expr implicit type='Int'
   // CHECK-NEXT: magic_identifier_literal_expr{{.*}}kind=#column

--- a/test/Macros/builtin_macros.swift
+++ b/test/Macros/builtin_macros.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -enable-experimental-feature BuiltinMacros -dump-ast %s -module-name MacrosTest 2>&1 | %FileCheck %s
 // REQUIRES: OS=macosx
+// REQUIRES: asserts
 
 // CHECK: macro_expansion_expr implicit type='String'
 // CHECK-NEXT: magic_identifier_literal_expr{{.*}}kind=#function


### PR DESCRIPTION
Experimental features are generally not available in non-asserts build, so narrow this test. Fixes rdar://101494565.
