### PR TITLE
[Reflection] Put a recursion limit on readTypeFromMetadata.

### DIFF
--- a/validation-test/Reflection/reflect_deep_generic.swift
+++ b/validation-test/Reflection/reflect_deep_generic.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -g -lswiftSwiftReflectionTest %s -o %t/reflect_deep_generic
+// RUN: %target-codesign %t/reflect_deep_generic
+
+// RUN: %target-run %target-swift-reflection-test %t/reflect_deep_generic | %FileCheck %s
+
+// REQUIRES: reflection_test_support
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+
+import SwiftReflectionTest
+
+protocol Nester {
+  func nest() -> Nester
+}
+
+class C<T>: Nester {
+  func nest() -> Nester {
+    return C<Self>()
+  }
+}
+
+var nester: Nester = C<Int>()
+for _ in 0..<10000 {
+  nester = nester.nest()
+}
+
+// This will fail due to the excessively nested type, but we're making sure it
+// fails gracefully and doesn't crash.
+reflect(object: nester as AnyObject)
+
+doneReflecting()
+
+// CHECK: Done.


### PR DESCRIPTION
We can end up with a stack overflow if we encounter a very deeply nested type, or bad data that looks like one. Fail gracefully for types that are nested beyond a limit. By default, the limit is 50.

rdar://100847548