### PR TITLE
[stdlib][String] Optimise UTF8 validation

### DIFF
--- a/stdlib/public/core/StringUTF8Validation.swift
+++ b/stdlib/public/core/StringUTF8Validation.swift
@@ -84,6 +84,7 @@ internal func validateUTF8(_ buf: UnsafeBufferPointer<UInt8>) -> UTF8ValidationR
     while endOfInvalid < buf.endIndex, UTF8.isContinuation(buf[endOfInvalid]) {
       endOfInvalid &+= 1
     }
+    endOfInvalid &+= 1
     let illegalRange = Range(uncheckedBounds: (startOfInvalid, endOfInvalid))
     // FIXME: Remove the call to `_legacyNarrowIllegalRange` and return `illegalRange` directly
     return _legacyNarrowIllegalRange(buf: buf[illegalRange])


### PR DESCRIPTION
I was checking out the current implementation of this in Godbolt (https://swift.godbolt.org/z/nq91Thdvb), and a couple of things caught my eye:

1. Dynamic exclusivity enforcement

   The nested functions make a mutable capture of the iterator `iter`, which means a call in the runtime function `swift_beginAccess`. We can avoid this by instead passing the iterator as an `inout` variable, allowing for static enforcement instead.

2. Error allocations

   The control flow makes use of `try` and `catch`, which results in a bunch of runtime calls which shouldn't be necessary:

   ```
   call    (lazy protocol witness table accessor for type output.(UTF8ValidationError in _60494E8B9C642A7C4A26F3A3B6CECEB9) and conformance output.(UTF8ValidationError in _60494E8B9C642A7C4A26F3A3B6CECEB9) : Swift.Error in output)
   lea     rdi, [rip + (full type metadata for output.(UTF8ValidationError in _60494E8B9C642A7C4A26F3A3B6CECEB9))+8]
   mov     rsi, rax
   xor     edx, edx
   xor     ecx, ecx
   call    swift_allocError@PLT
   mov     r13, rax
   mov     r12, rax
   call    swift_willThrow@PLT
   mov     rdi, r13
   call    swift_release@PLT
   ```

   These can be avoided by simply having the `guaranteeX` functions return a boolean, and using `&&` to combine their values.

   
There are, of course, fancier ways of validating UTF-8 data (including SIMD). But these are some relatively simple changes, and checking the result in Godbolt (https://swift.godbolt.org/z/eqKPY3YbY), we can see that it avoids dynamic exclusivity enforcement and runtime calls for error handling. The `findInvalidRange` function is no longer inlined, but it is difficult to say why. In any case, that function itself could use some tweaking, but I figured I'd start with this smaller, more easily reviewable patch.