### PR TITLE
Make the option sil-stop-optzns-before-lowering-ownership work at -On one

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -986,6 +986,10 @@ SILPassPipelinePlan::getOnonePassPipeline(const SILOptions &Options) {
   // Now that we have serialized, propagate debug info.
   P.addMovedAsyncVarDebugInfoPropagator();
 
+  // If we are asked to stop optimizing before lowering ownership, do so now.
+  if (P.Options.StopOptimizationBeforeLoweringOwnership)
+    return P;
+
   // Now strip any transparent functions that still have ownership.
   P.addOwnershipModelEliminator();
 

--- a/test/SILOptimizer/stop_optzns_before_lowering_ownership_at_onone.swift
+++ b/test/SILOptimizer/stop_optzns_before_lowering_ownership_at_onone.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend %s -emit-sil -sil-stop-optzns-before-lowering-ownership | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-sil | %FileCheck -check-prefix=NEGATIVE %s
+
+// CHECK: sil hidden [ossa] @$s46stop_optzns_before_lowering_ownership_at_onone4testyyF : $@convention(thin) () -> () {
+// NEGATIVE: sil hidden @$s46stop_optzns_before_lowering_ownership_at_onone4testyyF : $@convention(thin) () -> () {
+func test() {
+
+}


### PR DESCRIPTION
Just wanted to look at -Onone codegen before ownership was lowered and realized that this optimization did not work at -Onone.
