### PR TITLE
Sema: Instantiate constraints for RequirementKind::SameShape

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2104,6 +2104,9 @@ NOTE(type_does_not_inherit_or_conform_requirement,none,
 ERROR(types_not_equal,none,
       "%0 requires the types %1 and %2 be equivalent",
       (Type, Type, Type))
+ERROR(types_not_same_shape,none,
+      "%0 requires the type packs %1 and %2 have the same shape",
+      (Type, Type, Type))
 ERROR(type_does_not_conform_owner,none,
       "%0 requires that %1 conform to %2", (Type, Type, Type))
 ERROR(type_does_not_conform_in_decl_ref,none,
@@ -2133,6 +2136,12 @@ ERROR(types_not_equal_decl,none,
 ERROR(types_not_equal_in_decl_ref,none,
       "referencing %0 %1 on %2 requires the types %3 and %4 be equivalent",
       (DescriptiveDeclKind, DeclName, Type, Type, Type))
+ERROR(types_not_same_shape_decl,none,
+      "%0 %1 requires the type packs %2 and %3 have the same shape",
+      (DescriptiveDeclKind, DeclName, Type, Type))
+ERROR(types_not_same_shape_in_decl_ref,none,
+      "referencing %0 %1 on %2 requires the type packs %3 and %4 have the same shape",
+      (DescriptiveDeclKind, DeclName, Type, Type, Type))
 ERROR(types_not_inherited_decl,none,
       "%0 %1 requires that %2 inherit from %3",
       (DescriptiveDeclKind, DeclName, Type, Type))
@@ -2154,6 +2163,10 @@ NOTE(candidate_types_conformance_requirement,none,
 NOTE(candidate_types_equal_requirement,none,
      "candidate requires that the types %0 and %1 be equivalent "
      "(requirement specified as %2 == %3)",
+     (Type, Type, Type, Type))
+NOTE(candidate_types_same_shape_requirement,none,
+     "candidate requires that the type packs %0 and %1 have the same shape "
+     "(requirement specified as %2.shape == %3.shape)",
      (Type, Type, Type, Type))
 NOTE(candidate_types_inheritance_requirement,none,
      "candidate requires that %1 inherit from %2 "

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -93,6 +93,10 @@ enum class FixKind : uint8_t {
   /// and assume that types are equal.
   SkipSameTypeRequirement,
 
+  /// Skip same-shape generic requirement constraint,
+  /// and assume that pack types have the same shape.
+  SkipSameShapeRequirement,
+
   /// Skip superclass generic requirement constraint,
   /// and assume that types are related.
   SkipSuperclassRequirement,
@@ -649,6 +653,34 @@ public:
 
   static SkipSameTypeRequirement *create(ConstraintSystem &cs, Type lhs,
                                          Type rhs, ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::SkipSameTypeRequirement;
+  }
+};
+
+/// Skip same-shape generic requirement constraint,
+/// and assume that types are equal.
+class SkipSameShapeRequirement final : public ConstraintFix {
+  Type LHS, RHS;
+
+  SkipSameShapeRequirement(ConstraintSystem &cs, Type lhs, Type rhs,
+                           ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::SkipSameShapeRequirement, locator), LHS(lhs),
+        RHS(rhs) {}
+
+public:
+  std::string getName() const override {
+    return "skip same-shape generic requirement";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  Type lhsType() { return LHS; }
+  Type rhsType() { return RHS; }
+
+  static SkipSameShapeRequirement *create(ConstraintSystem &cs, Type lhs,
+                                          Type rhs, ConstraintLocator *locator);
 
   static bool classof(ConstraintFix *fix) {
     return fix->getKind() == FixKind::SkipSameTypeRequirement;

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -223,7 +223,9 @@ enum class ConstraintKind : char {
   ///
   /// Binds the RHS type to a tuple of the params of a function typed LHS. Note
   /// this discards function parameter flags.
-  BindTupleOfFunctionParams
+  BindTupleOfFunctionParams,
+  /// The first type is a type pack, and the second type is its reduced shape.
+  ShapeOf,
 };
 
 /// Classification of the different kinds of constraints.
@@ -705,6 +707,7 @@ public:
     case ConstraintKind::KeyPathApplication:
     case ConstraintKind::Defaultable:
     case ConstraintKind::BindTupleOfFunctionParams:
+    case ConstraintKind::ShapeOf:
       return ConstraintClassification::TypeProperty;
 
     case ConstraintKind::Disjunction:

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5613,6 +5613,12 @@ private:
       ASTNode element, ContextualTypeInfo context, bool isDiscarded,
       TypeMatchOptions flags, ConstraintLocatorBuilder locator);
 
+  /// Simplify a shape constraint by binding the reduced shape of the
+  /// left hand side to the right hand side.
+  SolutionKind simplifyShapeOfConstraint(
+      Type type1, Type type2, TypeMatchOptions flags,
+      ConstraintLocatorBuilder locator);
+
 public: // FIXME: Public for use by static functions.
   /// Simplify a conversion constraint with a fix applied to it.
   SolutionKind simplifyFixConstraint(ConstraintFix *fix, Type type1, Type type2,

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1397,6 +1397,7 @@ void PotentialBindings::infer(Constraint *constraint) {
   case ConstraintKind::Conjunction:
   case ConstraintKind::BindTupleOfFunctionParams:
   case ConstraintKind::PackElementOf:
+  case ConstraintKind::ShapeOf:
     // Constraints from which we can't do anything.
     break;
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7059,7 +7059,6 @@ bool ExtraneousCallFailure::diagnoseAsError() {
     }
   }
 
-  anchor.dump();
   auto diagnostic =
       emitDiagnostic(diag::cannot_call_non_function_value, getType(anchor));
   removeParensFixIt(diagnostic);

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -435,6 +435,40 @@ protected:
   }
 };
 
+/// Diagnose failures related to same-shape generic requirements, e.g.
+/// ```swift
+/// func foo<T..., U...>(t: T..., u: U...) -> (T, U)... {}
+/// func bar<T..., U...>(t: T..., u: U...) {
+///   foo(t: t..., u: u...)
+/// }
+/// ```
+///
+/// `S.T` is not the same type as `Int`, which is required by `foo`.
+class SameShapeRequirementFailure final : public RequirementFailure {
+public:
+  SameShapeRequirementFailure(const Solution &solution, Type lhs, Type rhs,
+                              ConstraintLocator *locator)
+      : RequirementFailure(solution, lhs, rhs, locator) {
+#ifndef NDEBUG
+    auto reqElt = locator->castLastElementTo<LocatorPathElt::AnyRequirement>();
+    assert(reqElt.getRequirementKind() == RequirementKind::SameShape);
+#endif
+  }
+
+protected:
+  DiagOnDecl getDiagnosticOnDecl() const override {
+    return diag::types_not_same_shape_decl;
+  }
+
+  DiagInReference getDiagnosticInRereference() const override {
+    return diag::types_not_same_shape_in_decl_ref;
+  }
+
+  DiagAsNote getDiagnosticAsNote() const override {
+    return diag::candidate_types_same_shape_requirement;
+  }
+};
+
 /// Diagnose failures related to superclass generic requirements, e.g.
 /// ```swift
 /// class A {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -465,6 +465,18 @@ SkipSameTypeRequirement::create(ConstraintSystem &cs, Type lhs, Type rhs,
   return new (cs.getAllocator()) SkipSameTypeRequirement(cs, lhs, rhs, locator);
 }
 
+bool SkipSameShapeRequirement::diagnose(const Solution &solution,
+                                       bool asNote) const {
+  SameShapeRequirementFailure failure(solution, LHS, RHS, getLocator());
+  return failure.diagnose(asNote);
+}
+
+SkipSameShapeRequirement *
+SkipSameShapeRequirement::create(ConstraintSystem &cs, Type lhs, Type rhs,
+                                 ConstraintLocator *locator) {
+  return new (cs.getAllocator()) SkipSameShapeRequirement(cs, lhs, rhs, locator);
+}
+
 bool SkipSuperclassRequirement::diagnose(const Solution &solution,
                                          bool asNote) const {
   SuperclassRequirementFailure failure(solution, LHS, RHS, getLocator());

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2425,6 +2425,7 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
   case ConstraintKind::SyntacticElement:
   case ConstraintKind::BindTupleOfFunctionParams:
   case ConstraintKind::PackElementOf:
+  case ConstraintKind::ShapeOf:
     llvm_unreachable("Bad constraint kind in matchTupleTypes()");
   }
 
@@ -2597,6 +2598,7 @@ static bool matchFunctionRepresentations(FunctionType::ExtInfo einfo1,
   case ConstraintKind::SyntacticElement:
   case ConstraintKind::BindTupleOfFunctionParams:
   case ConstraintKind::PackElementOf:
+  case ConstraintKind::ShapeOf:
     return true;
   }
 
@@ -3013,6 +3015,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   case ConstraintKind::SyntacticElement:
   case ConstraintKind::BindTupleOfFunctionParams:
   case ConstraintKind::PackElementOf:
+  case ConstraintKind::ShapeOf:
     llvm_unreachable("Not a relational constraint");
   }
 
@@ -6366,6 +6369,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     case ConstraintKind::SyntacticElement:
     case ConstraintKind::BindTupleOfFunctionParams:
     case ConstraintKind::PackElementOf:
+    case ConstraintKind::ShapeOf:
       llvm_unreachable("Not a relational constraint");
     }
   }
@@ -7442,17 +7446,14 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifySubclassOfConstraint(
     return SolutionKind::Solved;
   }
 
-  auto formUnsolved = [&](bool activate = false) {
+  auto formUnsolved = [&]() {
     // If we're supposed to generate constraints, do so.
     if (flags.contains(TMF_GenerateConstraints)) {
-      auto *conformance = Constraint::create(
+      auto *subclassOf = Constraint::create(
           *this, ConstraintKind::SubclassOf, type, classType,
           getConstraintLocator(locator));
 
-      addUnsolvedConstraint(conformance);
-      if (activate)
-        activateConstraint(conformance);
-
+      addUnsolvedConstraint(subclassOf);
       return SolutionKind::Solved;
     }
 
@@ -12510,6 +12511,74 @@ ConstraintSystem::simplifyDynamicCallableApplicableFnConstraint(
   return SolutionKind::Solved;
 }
 
+static Type getReducedShape(Type type) {
+  // Pack archetypes know their reduced shape
+  if (auto *packArchetype = type->getAs<PackArchetypeType>())
+    return packArchetype->getShape();
+
+  // Reduced shape of pack is computed recursively
+  if (auto *packType = type->getAs<PackType>()) {
+    auto &ctx = type->getASTContext();
+    SmallVector<Type, 2> elts;
+
+    for (auto elt : packType->getElementTypes()) {
+      // T... => shape(T)...
+      if (auto *packExpansionType = elt->getAs<PackExpansionType>()) {
+        auto shapeType = getReducedShape(packExpansionType->getCountType());
+        assert(shapeType && "Should not end up here if pack type's shape "
+                            "is still potentially unknown");
+        elts.push_back(PackExpansionType::get(shapeType, shapeType));
+      }
+
+      // Use () as a placeholder for scalar shape
+      elts.push_back(ctx.TheEmptyTupleType);
+    }
+
+    return PackType::get(ctx, elts);
+  }
+
+  // Getting the shape of any other type is an error.
+  return Type();
+}
+
+ConstraintSystem::SolutionKind ConstraintSystem::simplifyShapeOfConstraint(
+    Type type1, Type type2, TypeMatchOptions flags,
+    ConstraintLocatorBuilder locator) {
+  // Recursively replace all type variables with fixed bindings if
+  // possible.
+  type1 = simplifyType(type1, flags);
+
+  auto formUnsolved = [&]() {
+    // If we're supposed to generate constraints, do so.
+    if (flags.contains(TMF_GenerateConstraints)) {
+      auto *shapeOf = Constraint::create(
+          *this, ConstraintKind::ShapeOf, type1, type2,
+          getConstraintLocator(locator));
+
+      addUnsolvedConstraint(shapeOf);
+      return SolutionKind::Solved;
+    }
+
+    return SolutionKind::Unsolved;
+  };
+
+  // We can't compute a reduced shape if the input type still
+  // contains type variables that might bind to pack archetypes.
+  SmallPtrSet<TypeVariableType *, 2> typeVars;
+  type1->getTypeVariables(typeVars);
+  for (auto *typeVar : typeVars) {
+    if (typeVar->getImpl().canBindToPack())
+      return formUnsolved();
+  }
+
+  if (Type shape = getReducedShape(type1)) {
+    addConstraint(ConstraintKind::Bind, shape, type2, locator);
+    return SolutionKind::Solved;
+  }
+
+  return SolutionKind::Error;
+}
+
 static llvm::PointerIntPair<Type, 3, unsigned>
 getBaseTypeForPointer(TypeBase *type) {
   unsigned unwrapCount = 0;
@@ -13847,6 +13916,9 @@ ConstraintSystem::addConstraintImpl(ConstraintKind kind, Type first,
   case ConstraintKind::PackElementOf:
     return simplifyPackElementOfConstraint(first, second, subflags, locator);
 
+  case ConstraintKind::ShapeOf:
+    return simplifyShapeOfConstraint(first, second, subflags, locator);
+
   case ConstraintKind::ValueMember:
   case ConstraintKind::UnresolvedValueMember:
   case ConstraintKind::ValueWitness:
@@ -14010,8 +14082,18 @@ void ConstraintSystem::addConstraint(Requirement req,
   bool conformsToAnyObject = false;
   Optional<ConstraintKind> kind;
   switch (req.getKind()) {
-  case RequirementKind::SameShape:
-    llvm_unreachable("Same-shape requirement not supported here");
+  case RequirementKind::SameShape: {
+    auto type1 = req.getFirstType();
+    auto type2 = req.getSecondType();
+
+    // FIXME: Locator for diagnostics
+    auto typeVar = createTypeVariable(getConstraintLocator(locator),
+                                      TVO_CanBindToPack);
+
+    addConstraint(ConstraintKind::ShapeOf, type1, typeVar, locator);
+    addConstraint(ConstraintKind::ShapeOf, type2, typeVar, locator);
+    return;
+  }
 
   case RequirementKind::Conformance:
     kind = ConstraintKind::ConformsTo;
@@ -14420,6 +14502,11 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
   case ConstraintKind::PackElementOf:
     return simplifyPackElementOfConstraint(
         constraint.getFirstType(), constraint.getSecondType(), /*flags*/None,
+        constraint.getLocator());
+
+  case ConstraintKind::ShapeOf:
+    return simplifyShapeOfConstraint(
+        constraint.getFirstType(), constraint.getSecondType(), /*flags*/ None,
         constraint.getLocator());
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4222,16 +4222,14 @@ static ConstraintFix *fixRequirementFailure(ConstraintSystem &cs, Type type1,
   auto *reqLoc = cs.getConstraintLocator(anchor, path);
 
   switch (req.getRequirementKind()) {
-  case RequirementKind::SameShape:
-    llvm_unreachable("Same-shape requirement not supported here");
-
-  case RequirementKind::SameType: {
+  case RequirementKind::SameType:
     return SkipSameTypeRequirement::create(cs, type1, type2, reqLoc);
-  }
 
-  case RequirementKind::Superclass: {
+  case RequirementKind::SameShape:
+    return SkipSameShapeRequirement::create(cs, type1, type2, reqLoc);
+
+  case RequirementKind::Superclass:
     return SkipSuperclassRequirement::create(cs, type1, type2, reqLoc);
-  }
 
   case RequirementKind::Layout:
   case RequirementKind::Conformance:
@@ -13642,6 +13640,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
 
   case FixKind::AddConformance:
   case FixKind::SkipSameTypeRequirement:
+  case FixKind::SkipSameShapeRequirement:
   case FixKind::SkipSuperclassRequirement: {
     return recordFix(fix, assessRequirementFailureImpact(*this, type1,
                                                          fix->getLocator()))

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -80,6 +80,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
   case ConstraintKind::PropertyWrapper:
   case ConstraintKind::BindTupleOfFunctionParams:
   case ConstraintKind::PackElementOf:
+  case ConstraintKind::ShapeOf:
     assert(!First.isNull());
     assert(!Second.isNull());
     break;
@@ -167,6 +168,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::SyntacticElement:
   case ConstraintKind::BindTupleOfFunctionParams:
   case ConstraintKind::PackElementOf:
+  case ConstraintKind::ShapeOf:
     llvm_unreachable("Wrong constructor");
 
   case ConstraintKind::KeyPath:
@@ -313,6 +315,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   case ConstraintKind::PropertyWrapper:
   case ConstraintKind::BindTupleOfFunctionParams:
   case ConstraintKind::PackElementOf:
+  case ConstraintKind::ShapeOf:
     return create(cs, getKind(), getFirstType(), getSecondType(), getLocator());
 
   case ConstraintKind::ApplicableFunction:
@@ -553,6 +556,10 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm, unsigned inden
     Out << " element of pack expansion pattern ";
     break;
 
+  case ConstraintKind::ShapeOf:
+    Out << " shape of ";
+    break;
+
   case ConstraintKind::Disjunction:
     llvm_unreachable("disjunction handled above");
   case ConstraintKind::Conjunction:
@@ -718,6 +725,7 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::PropertyWrapper:
   case ConstraintKind::BindTupleOfFunctionParams:
   case ConstraintKind::PackElementOf:
+  case ConstraintKind::ShapeOf:
     constraint->getFirstType()->getTypeVariables(typeVars);
     constraint->getSecondType()->getTypeVariables(typeVars);
     break;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1773,8 +1773,6 @@ void ConstraintSystem::openGenericRequirement(
 
   auto kind = req.getKind();
   switch (kind) {
-  case RequirementKind::SameShape:
-    llvm_unreachable("Same-shape requirement not supported here");
   case RequirementKind::Conformance: {
     auto protoDecl = req.getProtocolDecl();
     // Determine whether this is the protocol 'Self' constraint we should
@@ -1788,6 +1786,7 @@ void ConstraintSystem::openGenericRequirement(
   }
   case RequirementKind::Superclass:
   case RequirementKind::SameType:
+  case RequirementKind::SameShape:
     openedReq = Requirement(kind, openedFirst, substFn(req.getSecondType()));
     break;
   case RequirementKind::Layout:

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -910,6 +910,13 @@ static Optional<RequirementMatch> findMissingGenericRequirementForSolutionFix(
     missingType = requirementFix->rhsType();
     break;
   }
+  case FixKind::SkipSameShapeRequirement: {
+    requirementKind = RequirementKind::SameShape;
+    auto requirementFix = (SkipSameShapeRequirement *)fix;
+    type = requirementFix->lhsType();
+    missingType = requirementFix->rhsType();
+    break;
+  }
   case FixKind::SkipSuperclassRequirement: {
     requirementKind = RequirementKind::Superclass;
     auto requirementFix = (SkipSuperclassRequirement *)fix;

--- a/test/Constraints/variadic_generic_constraints.swift
+++ b/test/Constraints/variadic_generic_constraints.swift
@@ -52,3 +52,15 @@ takesParallelSequences()  // ok
 takesParallelSequences(t: Array<Int>(), u: Set<Int>())  // ok
 takesParallelSequences(t: Array<String>(), Set<Int>(), u: Set<String>(), Array<Int>())  // ok
 takesParallelSequences(t: Array<String>(), Set<Int>(), u: Array<Int>(), Set<String>())  // expected-error {{global function 'takesParallelSequences(t:u:)' requires the types 'String' and 'Int' be equivalent}}
+
+// Same-shape requirements
+
+func zip<T..., U...>(t: T..., u: U...) -> ((T, U)...) {}
+
+let _ = zip()  // ok
+let _ = zip(t: 1, u: "hi")  // ok
+let _ = zip(t: 1, 2, u: "hi", "hello")  // ok
+let _ = zip(t: 1, 2, 3, u: "hi", "hello", "greetings")  // ok
+
+// FIXME: Bad diagnostic
+let _ = zip(t: 1, u: "hi", "hello", "greetings")  // expected-error {{type of expression is ambiguous without more context}}

--- a/test/Constraints/variadic_generic_constraints.swift
+++ b/test/Constraints/variadic_generic_constraints.swift
@@ -56,6 +56,7 @@ takesParallelSequences(t: Array<String>(), Set<Int>(), u: Array<Int>(), Set<Stri
 // Same-shape requirements
 
 func zip<T..., U...>(t: T..., u: U...) -> ((T, U)...) {}
+// expected-note@-1 {{where 'T' = 'U', 'U' = 'Pack{T...}'}}
 
 let _ = zip()  // ok
 let _ = zip(t: 1, u: "hi")  // ok
@@ -64,3 +65,12 @@ let _ = zip(t: 1, 2, 3, u: "hi", "hello", "greetings")  // ok
 
 // FIXME: Bad diagnostic
 let _ = zip(t: 1, u: "hi", "hello", "greetings")  // expected-error {{type of expression is ambiguous without more context}}
+
+func goodCallToZip<T..., U...>(t: T..., u: U...) where ((T, U)...): Any {
+  _ = zip(t: t..., u: u...)
+}
+
+func badCallToZip<T..., U...>(t: T..., u: U...) {
+  _ = zip(t: t..., u: u...)
+  // expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'U' and 'Pack{T...}' have the same shape}}
+}


### PR DESCRIPTION
`shape(T) == shape(U)` creates a new type variable `$T` and two constraints: `T ShapeOf $T`, `U ShapeOf $T`. `$X ShapeOf $Y` solves once $X has a fixed type, by binding the reduced shape of $X to $Y.