### PR TITLE
[move-only] Change type lowering to ensure we use {retain,release}_value instead of strong_{retain,release}

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -622,6 +622,10 @@ public:
   /// wrapped type.
   bool isMoveOnly() const;
 
+  /// Is this a type that is a first class move only type. This returns false
+  /// for a move only wrapped type.
+  bool isPureMoveOnly() const;
+
   /// Returns true if and only if this type is a first class move only
   /// type. NOTE: Returns false if the type is a move only wrapped type.
   bool isMoveOnlyType() const;

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -948,3 +948,10 @@ bool SILType::isMoveOnlyType() const {
       return true;
   return false;
 }
+
+bool SILType::isPureMoveOnly() const {
+  if (auto *nom = getNominalOrBoundGenericNominal())
+    if (nom->isMoveOnly())
+      return true;
+  return false;
+}

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4248,6 +4248,7 @@ RValue CallEmission::applyEnumElementConstructor(SGFContext C) {
       uncurriedLoc, std::move(payload),
       SGF.getLoweredType(formalResultType),
       element, uncurriedContext);
+
   return RValue(SGF, uncurriedLoc, formalResultType, resultMV);
 }
 

--- a/test/IRGen/moveonly_deinits.swift
+++ b/test/IRGen/moveonly_deinits.swift
@@ -61,7 +61,7 @@ var value: Bool { false }
 // Struct Tests //
 //////////////////
 
-// IR-LABEL: define swiftcc void @"$s16moveonly_deinits24testIntPairWithoutDeinityyF"()
+// IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits24testIntPairWithoutDeinityyF"()
 // IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
 //
 // IR: [[BB1]]:
@@ -81,7 +81,7 @@ public func testIntPairWithoutDeinit() {
     }
 }
 
-// IR-LABEL: define swiftcc void @"$s16moveonly_deinits21testIntPairWithDeinityyF"()
+// IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits21testIntPairWithDeinityyF"()
 // IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
 //
 // IR: [[BB1]]:
@@ -102,7 +102,7 @@ public func testIntPairWithDeinit() {
     }
 }
 
-// IR-LABEL: define swiftcc void @"$s16moveonly_deinits26testKlassPairWithoutDeinityyF"()
+// IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits26testKlassPairWithoutDeinityyF"()
 // IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
 //
 // IR: [[BB1]]:
@@ -124,7 +124,7 @@ public func testKlassPairWithoutDeinit() {
     }
 }
 
-// IR-LABEL: define swiftcc void @"$s16moveonly_deinits23testKlassPairWithDeinityyF"()
+// IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits23testKlassPairWithDeinityyF"()
 // IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
 //
 // IR: [[BB1]]:
@@ -190,7 +190,7 @@ func consumeKlassEnumPairWithDeinit(_ x: __owned KlassEnumPairWithDeinit) { }
 // Enum Tests //
 ////////////////
 
-// IR-LABEL: define swiftcc void @"$s16moveonly_deinits28testIntEnumPairWithoutDeinityyF"()
+// IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits28testIntEnumPairWithoutDeinityyF"()
 // IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
 //
 // IR: [[BB1]]:
@@ -210,7 +210,7 @@ public func testIntEnumPairWithoutDeinit() {
     }
 }
 
-// IR-LABEL: define swiftcc void @"$s16moveonly_deinits25testIntEnumPairWithDeinityyF"()
+// IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits25testIntEnumPairWithDeinityyF"()
 // IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
 //
 // IR: [[BB1]]:
@@ -231,7 +231,7 @@ public func testIntEnumPairWithDeinit() {
     }
 }
 
-// IR-LABEL: define swiftcc void @"$s16moveonly_deinits30testKlassEnumPairWithoutDeinityyF"()
+// IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits30testKlassEnumPairWithoutDeinityyF"()
 // IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
 //
 // IR: [[BB1]]:
@@ -290,7 +290,7 @@ public func testKlassEnumPairWithoutDeinit() {
 // SIL-NOT: release_value
 // SIL: } // end sil function '$s16moveonly_deinits27testKlassEnumPairWithDeinityyF'
 
-// IR-LABEL: define swiftcc void @"$s16moveonly_deinits27testKlassEnumPairWithDeinityyF"()
+// IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits27testKlassEnumPairWithDeinityyF"()
 // IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
 //
 // IR: [[BB1]]:

--- a/test/IRGen/moveonly_deinits.swift
+++ b/test/IRGen/moveonly_deinits.swift
@@ -1,0 +1,312 @@
+// RUN: %target-swift-emit-ir -enable-experimental-move-only %s | %FileCheck -check-prefix=IR %s
+
+// Test that makes sure that at IRGen time we properly handle conditional
+// releases for trivial and non-trivial move only types. The SIL/SILGen part of
+// this test is in test/SILGen/moveonly_deinits. We have a separate test so that
+// we can test on other platforms the other behavior.
+
+// REQUIRES: asserts
+// REQUIRES: CPU=x86_64
+
+//////////////////////
+// Misc Declaration //
+//////////////////////
+
+class Klass {}
+
+/////////////////////////
+// Struct Declarations //
+/////////////////////////
+
+@_moveOnly
+struct KlassPairWithoutDeinit {
+    var lhs = Klass()
+    var rhs = Klass()
+}
+
+@_moveOnly
+struct KlassPairWithDeinit {
+    var lhs = Klass()
+    var rhs = Klass()
+
+    deinit {
+        print("123")
+    }
+}
+
+@_moveOnly
+struct IntPairWithoutDeinit {
+    var k: Int = 5
+    var k2: Int = 6
+}
+
+@_moveOnly
+struct IntPairWithDeinit {
+    var k: Int = 5
+    var k2: Int = 6
+
+    deinit {
+        print("123")
+    }
+}
+
+func consumeIntPairWithoutDeinit(_ x: __owned IntPairWithoutDeinit) { }
+func consumeIntPairWithDeinit(_ x: __owned IntPairWithDeinit) { }
+func consumeKlassPairWithoutDeinit(_ x: __owned KlassPairWithoutDeinit) { }
+func consumeKlassPairWithDeinit(_ x: __owned KlassPairWithDeinit) { }
+
+var value: Bool { false }
+
+//////////////////
+// Struct Tests //
+//////////////////
+
+// IR-LABEL: define swiftcc void @"$s16moveonly_deinits24testIntPairWithoutDeinityyF"()
+// IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
+//
+// IR: [[BB1]]:
+// IR-NEXT:   call swiftcc void @"$s16moveonly_deinits27consumeIntPairWithoutDeinityyAA0defG0VnF"
+// IR-NEXT:   br label %[[CONT:[0-9]+]]
+//
+// IR: [[BB2]]:
+// IR-NEXT:   br label %[[CONT]]
+//
+// IR: [[CONT]]:
+// IR-NEXT: ret void
+// IR-NEXT: }
+public func testIntPairWithoutDeinit() {
+    let f = IntPairWithoutDeinit()
+    if value {
+        consumeIntPairWithoutDeinit(f)
+    }
+}
+
+// IR-LABEL: define swiftcc void @"$s16moveonly_deinits21testIntPairWithDeinityyF"()
+// IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
+//
+// IR: [[BB1]]:
+// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits24consumeIntPairWithDeinityyAA0defG0VnF"(
+// IR-NEXT:  br label %[[CONT:[0-9]+]]
+//
+// IR: [[BB2]]:
+// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits17IntPairWithDeinitVfD"(
+// IR-NEXT:  br label %[[CONT]]
+//
+// IR: [[CONT]]
+// IR-NEXT: ret void
+// IR-NEXT: }
+public func testIntPairWithDeinit() {
+    let f = IntPairWithDeinit()
+    if value {
+        consumeIntPairWithDeinit(f)
+    }
+}
+
+// IR-LABEL: define swiftcc void @"$s16moveonly_deinits26testKlassPairWithoutDeinityyF"()
+// IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
+//
+// IR: [[BB1]]:
+// IR-NEXT:   call swiftcc void @"$s16moveonly_deinits29consumeKlassPairWithoutDeinityyAA0defG0VnF"
+// IR-NEXT:   br label %[[CONT:[0-9]+]]
+//
+// IR: [[BB2]]:
+// IR-NEXT:   call void bitcast {{.*}} @swift_release
+// IR-NEXT:   call void bitcast {{.*}} @swift_release
+// IR-NEXT:   br label %[[CONT]]
+//
+// IR: [[CONT]]:
+// IR-NEXT: ret void
+// IR-NEXT: }
+public func testKlassPairWithoutDeinit() {
+    let f = KlassPairWithoutDeinit()
+    if value {
+        consumeKlassPairWithoutDeinit(f)
+    }
+}
+
+// IR-LABEL: define swiftcc void @"$s16moveonly_deinits23testKlassPairWithDeinityyF"()
+// IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
+//
+// IR: [[BB1]]:
+// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits26consumeKlassPairWithDeinityyAA0defG0VnF"(
+// IR-NEXT:  br label %[[CONT:[0-9]+]]
+//
+// IR: [[BB2]]:
+// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits19KlassPairWithDeinitVfD"(
+// IR-NEXT:  br label %[[CONT]]
+//
+// IR: [[CONT]]
+// IR-NEXT: ret void
+// IR-NEXT: }
+public func testKlassPairWithDeinit() {
+    let f = KlassPairWithDeinit()
+    if value {
+        consumeKlassPairWithDeinit(f)
+    }
+}
+
+///////////////////////
+// Enum Declarations //
+///////////////////////
+
+@_moveOnly
+enum KlassEnumPairWithoutDeinit {
+    case lhs(Klass)
+    case rhs(Klass)
+}
+
+@_moveOnly
+enum KlassEnumPairWithDeinit {
+    case lhs(Klass)
+    case rhs(Klass)
+
+    deinit {
+        print("123")
+    }
+}
+
+@_moveOnly
+enum IntEnumPairWithoutDeinit {
+case lhs(Int)
+case rhs(Int)
+}
+
+@_moveOnly
+enum IntEnumPairWithDeinit {
+    case lhs(Int)
+    case rhs(Int)
+
+    deinit {
+        print("123")
+    }
+}
+
+func consumeIntEnumPairWithoutDeinit(_ x: __owned IntEnumPairWithoutDeinit) { }
+func consumeIntEnumPairWithDeinit(_ x: __owned IntEnumPairWithDeinit) { }
+func consumeKlassEnumPairWithoutDeinit(_ x: __owned KlassEnumPairWithoutDeinit) { }
+func consumeKlassEnumPairWithDeinit(_ x: __owned KlassEnumPairWithDeinit) { }
+
+////////////////
+// Enum Tests //
+////////////////
+
+// IR-LABEL: define swiftcc void @"$s16moveonly_deinits28testIntEnumPairWithoutDeinityyF"()
+// IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
+//
+// IR: [[BB1]]:
+// IR-NEXT:   call swiftcc void @"$s16moveonly_deinits31consumeIntEnumPairWithoutDeinityyAA0defgH0OnF"
+// IR-NEXT:   br label %[[CONT:[0-9]+]]
+//
+// IR: [[BB2]]:
+// IR-NEXT:   br label %[[CONT]]
+//
+// IR: [[CONT]]:
+// IR-NEXT: ret void
+// IR-NEXT: }
+public func testIntEnumPairWithoutDeinit() {
+    let f = IntEnumPairWithoutDeinit.lhs(5)
+    if value {
+        consumeIntEnumPairWithoutDeinit(f)
+    }
+}
+
+// IR-LABEL: define swiftcc void @"$s16moveonly_deinits25testIntEnumPairWithDeinityyF"()
+// IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
+//
+// IR: [[BB1]]:
+// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits28consumeIntEnumPairWithDeinityyAA0defgH0OnF"(
+// IR-NEXT:  br label %[[CONT:[0-9]+]]
+//
+// IR: [[BB2]]:
+// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits21IntEnumPairWithDeinitOfD"(
+// IR-NEXT:  br label %[[CONT]]
+//
+// IR: [[CONT]]
+// IR-NEXT: ret void
+// IR-NEXT: }
+public func testIntEnumPairWithDeinit() {
+    let f = IntEnumPairWithDeinit.rhs(6)
+    if value {
+        consumeIntEnumPairWithDeinit(f)
+    }
+}
+
+// IR-LABEL: define swiftcc void @"$s16moveonly_deinits30testKlassEnumPairWithoutDeinityyF"()
+// IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
+//
+// IR: [[BB1]]:
+// IR-NEXT:   call swiftcc void @"$s16moveonly_deinits33consumeKlassEnumPairWithoutDeinityyAA0defgH0OnF"
+// IR-NEXT:   br label %[[CONT:[0-9]+]]
+//
+// IR: [[BB2]]:
+// IR-NEXT:   and i64
+// IR-NEXT:   inttoptr i64
+// IR-NEXT:   call void{{.*}} @swift_release
+// IR-NEXT:   br label %[[CONT]]
+//
+// IR: [[CONT]]:
+// IR-NEXT: ret void
+// IR-NEXT: }
+public func testKlassEnumPairWithoutDeinit() {
+    let f = KlassEnumPairWithoutDeinit.lhs(Klass())
+    if value {
+        consumeKlassEnumPairWithoutDeinit(f)
+    }
+}
+
+// SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits27testKlassEnumPairWithDeinityyF : $@convention(thin) () -> () {
+// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: cond_br {{%.*}}, bb1, bb2
+//
+// SILGEN: bb1:
+// SILGEN:   br bb3
+//
+// SILGEN: bb2:
+// SILGEN:   br bb3
+//
+// SILGEN: bb3:
+// SILGEN:   destroy_value [[VALUE]]
+// SILGEN: } // end sil function '$s16moveonly_deinits27testKlassEnumPairWithDeinityyF'
+
+// SIL-LABEL: sil @$s16moveonly_deinits27testKlassEnumPairWithDeinityyF : $@convention(thin) () -> () {
+// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: cond_br {{%.*}}, bb1, bb2
+//
+// SIL: bb1:
+// SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits30consumeKlassEnumPairWithDeinityyAA0defgH0OnF : $@convention(thin) (@owned KlassEnumPairWithDeinit) -> ()
+// SIL:   apply [[FUNC_REF]]([[VALUE]])
+// SIL-NOT: release_value
+// SIL-NOT: apply
+// SIL:   br bb3
+//
+// SIL: bb2:
+// SIL: [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits23KlassEnumPairWithDeinitOfD : $@convention(method) (@owned KlassEnumPairWithDeinit) -> ()
+// SIL: apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned KlassEnumPairWithDeinit) -> ()
+// SIL-NOT: apply
+// SIL-NOT: release_value
+// SIL:   br bb3
+//
+// SIL: bb3:
+// SIL-NOT: release_value
+// SIL: } // end sil function '$s16moveonly_deinits27testKlassEnumPairWithDeinityyF'
+
+// IR-LABEL: define swiftcc void @"$s16moveonly_deinits27testKlassEnumPairWithDeinityyF"()
+// IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
+//
+// IR: [[BB1]]:
+// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits30consumeKlassEnumPairWithDeinityyAA0defgH0OnF"(
+// IR-NEXT:  br label %[[CONT:[0-9]+]]
+//
+// IR: [[BB2]]:
+// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits23KlassEnumPairWithDeinitOfD"(
+// IR-NEXT:  br label %[[CONT]]
+//
+// IR: [[CONT]]
+// IR-NEXT: ret void
+// IR-NEXT: }
+public func testKlassEnumPairWithDeinit() {
+    let f = KlassEnumPairWithDeinit.rhs(Klass())
+    if value {
+        consumeKlassEnumPairWithDeinit(f)
+    }
+}

--- a/test/Interpreter/moveonly_bufferview.swift
+++ b/test/Interpreter/moveonly_bufferview.swift
@@ -8,14 +8,14 @@
 
 @_moveOnly
 public struct BufferView<T> {
-    var ptr: UnsafeMutableBufferPointer<T>
+    var ptr: UnsafeBufferPointer<T>
 
     deinit {}
 }
 
 extension BufferView : Sequence {
-    public typealias Iterator = UnsafeMutableBufferPointer<T>.Iterator
-    public typealias Element = UnsafeMutableBufferPointer<T>.Element
+    public typealias Iterator = UnsafeBufferPointer<T>.Iterator
+    public typealias Element = UnsafeBufferPointer<T>.Element
 
     public func makeIterator() -> Self.Iterator {
         return ptr.makeIterator()
@@ -24,7 +24,7 @@ extension BufferView : Sequence {
 
 extension Array {
     public mutating func withBufferView<U>(_ f: (BufferView<Element>) -> U) -> U {
-        return withUnsafeMutableBufferPointer {
+        return withUnsafeBufferPointer {
             return f(BufferView(ptr: $0))
         }
     }
@@ -42,8 +42,26 @@ func testBufferView(_ x: __owned [Int]) {
     }
 }
 
+@inline(never)
+func getBool() -> Bool { return true }
+
+func testConditionalBufferView(_ x: __owned [Int]) {
+    (_move x).withUnsafeBufferPointer {
+        let y = BufferView(ptr: $0)
+        // CHECK: 4
+        // CHECK: 5
+        // CHECK: 6
+        if getBool() {
+            for z in y {
+                print(z)
+            }
+        }
+    }
+}
+
 func main() {
     testBufferView([1,2,3])
+    testConditionalBufferView([4,5,6])
 }
 
 main()

--- a/test/SILGen/moveonly_deinits.swift
+++ b/test/SILGen/moveonly_deinits.swift
@@ -1,0 +1,435 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-move-only %s | %FileCheck -check-prefix=SILGEN %s
+// RUN: %target-swift-emit-sil -enable-experimental-move-only %s | %FileCheck -check-prefix=SIL %s
+
+// Test that makes sure that throughout the pipeline we properly handle
+// conditional releases for trivial and non-trivial move only types.
+
+//////////////////////
+// Misc Declaration //
+//////////////////////
+
+class Klass {}
+
+/////////////////////////
+// Struct Declarations //
+/////////////////////////
+
+@_moveOnly
+struct KlassPairWithoutDeinit {
+    var lhs = Klass()
+    var rhs = Klass()
+}
+
+@_moveOnly
+struct KlassPairWithDeinit {
+    var lhs = Klass()
+    var rhs = Klass()
+
+    deinit {
+        print("123")
+    }
+}
+
+@_moveOnly
+struct IntPairWithoutDeinit {
+    var k: Int = 5
+    var k2: Int = 6
+}
+
+@_moveOnly
+struct IntPairWithDeinit {
+    var k: Int = 5
+    var k2: Int = 6
+
+    deinit {
+        print("123")
+    }
+}
+
+func consumeIntPairWithoutDeinit(_ x: __owned IntPairWithoutDeinit) { }
+func consumeIntPairWithDeinit(_ x: __owned IntPairWithDeinit) { }
+func consumeKlassPairWithoutDeinit(_ x: __owned KlassPairWithoutDeinit) { }
+func consumeKlassPairWithDeinit(_ x: __owned KlassPairWithDeinit) { }
+
+var value: Bool { false }
+
+//////////////////
+// Struct Tests //
+//////////////////
+
+// SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits24testIntPairWithoutDeinityyF : $@convention(thin) () -> () {
+// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: cond_br {{%.*}}, bb1, bb2
+//
+// SILGEN: bb1:
+// SILGEN:   br bb3
+//
+// SILGEN: bb2:
+// SILGEN:   br bb3
+//
+// SILGEN: bb3:
+// SILGEN:   destroy_value [[VALUE]]
+// SILGEN: } // end sil function '$s16moveonly_deinits24testIntPairWithoutDeinityyF'
+
+// SIL-LABEL: sil @$s16moveonly_deinits24testIntPairWithoutDeinityyF : $@convention(thin) () -> () {
+// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: cond_br {{%.*}}, bb1, bb2
+//
+// SIL: bb1:
+// SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits27consumeIntPairWithoutDeinityyAA0defG0VnF : $@convention(thin) (@owned IntPairWithoutDeinit) -> ()
+// SIL:   apply [[FUNC_REF]]([[VALUE]])
+// SIL-NOT: release_value
+// SIL-NOT: apply
+// SIL:   br bb3
+//
+// SIL: bb2:
+// SIL-NOT: apply
+// SIL:   release_value [[VALUE]]
+// SIL-NOT: apply
+// SIL:   br bb3
+//
+// SIL: bb3:
+// SIL-NOT: release_value
+// SIL: } // end sil function '$s16moveonly_deinits24testIntPairWithoutDeinityyF'
+public func testIntPairWithoutDeinit() {
+    let f = IntPairWithoutDeinit()
+    if value {
+        consumeIntPairWithoutDeinit(f)
+    }
+}
+
+// SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits21testIntPairWithDeinityyF : $@convention(thin) () -> () {
+// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: cond_br {{%.*}}, bb1, bb2
+//
+// SILGEN: bb1:
+// SILGEN:   br bb3
+//
+// SILGEN: bb2:
+// SILGEN:   br bb3
+//
+// SILGEN: bb3:
+// SILGEN:   destroy_value [[VALUE]]
+// SILGEN: } // end sil function '$s16moveonly_deinits21testIntPairWithDeinityyF'
+
+// SIL-LABEL: sil @$s16moveonly_deinits21testIntPairWithDeinityyF : $@convention(thin) () -> () {
+// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: cond_br {{%.*}}, bb1, bb2
+//
+// SIL: bb1:
+// SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits24consumeIntPairWithDeinityyAA0defG0VnF : $@convention(thin) (@owned IntPairWithDeinit) -> ()
+// SIL:   apply [[FUNC_REF]]([[VALUE]])
+// SIL-NOT: release_value
+// SIL-NOT: apply
+// SIL:   br bb3
+//
+// SIL: bb2:
+// SIL: [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits17IntPairWithDeinitVfD : $@convention(method) (@owned IntPairWithDeinit) -> ()
+// SIL: apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned IntPairWithDeinit) -> ()
+// SIL-NOT: apply
+// SIL-NOT: release_value
+// SIL:   br bb3
+//
+// SIL: bb3:
+// SIL-NOT: release_value
+// SIL: } // end sil function '$s16moveonly_deinits21testIntPairWithDeinityyF'
+public func testIntPairWithDeinit() {
+    let f = IntPairWithDeinit()
+    if value {
+        consumeIntPairWithDeinit(f)
+    }
+}
+
+// SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits26testKlassPairWithoutDeinityyF : $@convention(thin) () -> () {
+// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: cond_br {{%.*}}, bb1, bb2
+//
+// SILGEN: bb1:
+// SILGEN:   br bb3
+//
+// SILGEN: bb2:
+// SILGEN:   br bb3
+//
+// SILGEN: bb3:
+// SILGEN:   destroy_value [[VALUE]]
+// SILGEN: } // end sil function '$s16moveonly_deinits26testKlassPairWithoutDeinityyF'
+
+// SIL-LABEL: sil @$s16moveonly_deinits26testKlassPairWithoutDeinityyF : $@convention(thin) () -> () {
+// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: cond_br {{%.*}}, bb1, bb2
+//
+// SIL: bb1:
+// SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits29consumeKlassPairWithoutDeinityyAA0defG0VnF : $@convention(thin) (@owned KlassPairWithoutDeinit) -> ()
+// SIL:   apply [[FUNC_REF]]([[VALUE]])
+// SIL-NOT: release_value
+// SIL-NOT: apply
+// SIL:   br bb3
+//
+// SIL: bb2:
+// SIL-NOT: apply
+// SIL:   release_value [[VALUE]]
+// SIL-NOT: apply
+// SIL:   br bb3
+//
+// SIL: bb3:
+// SIL-NOT: release_value
+// SIL: } // end sil function '$s16moveonly_deinits26testKlassPairWithoutDeinityyF'
+public func testKlassPairWithoutDeinit() {
+    let f = KlassPairWithoutDeinit()
+    if value {
+        consumeKlassPairWithoutDeinit(f)
+    }
+}
+
+// SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits23testKlassPairWithDeinityyF : $@convention(thin) () -> () {
+// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: cond_br {{%.*}}, bb1, bb2
+//
+// SILGEN: bb1:
+// SILGEN:   br bb3
+//
+// SILGEN: bb2:
+// SILGEN:   br bb3
+//
+// SILGEN: bb3:
+// SILGEN:   destroy_value [[VALUE]]
+// SILGEN: } // end sil function '$s16moveonly_deinits23testKlassPairWithDeinityyF'
+
+// SIL-LABEL: sil @$s16moveonly_deinits23testKlassPairWithDeinityyF : $@convention(thin) () -> () {
+// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: cond_br {{%.*}}, bb1, bb2
+//
+// SIL: bb1:
+// SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits26consumeKlassPairWithDeinityyAA0defG0VnF : $@convention(thin) (@owned KlassPairWithDeinit) -> ()
+// SIL:   apply [[FUNC_REF]]([[VALUE]])
+// SIL-NOT: release_value
+// SIL-NOT: apply
+// SIL:   br bb3
+//
+// SIL: bb2:
+// SIL: [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits19KlassPairWithDeinitVfD : $@convention(method) (@owned KlassPairWithDeinit) -> ()
+// SIL: apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned KlassPairWithDeinit) -> ()
+// SIL-NOT: apply
+// SIL-NOT: release_value
+// SIL:   br bb3
+//
+// SIL: bb3:
+// SIL-NOT: release_value
+// SIL: } // end sil function '$s16moveonly_deinits23testKlassPairWithDeinityyF'
+public func testKlassPairWithDeinit() {
+    let f = KlassPairWithDeinit()
+    if value {
+        consumeKlassPairWithDeinit(f)
+    }
+}
+
+///////////////////////
+// Enum Declarations //
+///////////////////////
+
+@_moveOnly
+enum KlassEnumPairWithoutDeinit {
+    case lhs(Klass)
+    case rhs(Klass)
+}
+
+@_moveOnly
+enum KlassEnumPairWithDeinit {
+    case lhs(Klass)
+    case rhs(Klass)
+
+    deinit {
+        print("123")
+    }
+}
+
+@_moveOnly
+enum IntEnumPairWithoutDeinit {
+case lhs(Int)
+case rhs(Int)
+}
+
+@_moveOnly
+enum IntEnumPairWithDeinit {
+    case lhs(Int)
+    case rhs(Int)
+
+    deinit {
+        print("123")
+    }
+}
+
+func consumeIntEnumPairWithoutDeinit(_ x: __owned IntEnumPairWithoutDeinit) { }
+func consumeIntEnumPairWithDeinit(_ x: __owned IntEnumPairWithDeinit) { }
+func consumeKlassEnumPairWithoutDeinit(_ x: __owned KlassEnumPairWithoutDeinit) { }
+func consumeKlassEnumPairWithDeinit(_ x: __owned KlassEnumPairWithDeinit) { }
+
+////////////////
+// Enum Tests //
+////////////////
+
+// SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits28testIntEnumPairWithoutDeinityyF : $@convention(thin) () -> () {
+// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: cond_br {{%.*}}, bb1, bb2
+//
+// SILGEN: bb1:
+// SILGEN:   br bb3
+//
+// SILGEN: bb2:
+// SILGEN:   br bb3
+//
+// SILGEN: bb3:
+// SILGEN:   destroy_value [[VALUE]]
+// SILGEN: } // end sil function '$s16moveonly_deinits28testIntEnumPairWithoutDeinityyF'
+
+// SIL-LABEL: sil @$s16moveonly_deinits28testIntEnumPairWithoutDeinityyF : $@convention(thin) () -> () {
+// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: cond_br {{%.*}}, bb1, bb2
+//
+// SIL: bb1:
+// SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits31consumeIntEnumPairWithoutDeinityyAA0defgH0OnF : $@convention(thin) (@owned IntEnumPairWithoutDeinit) -> ()
+// SIL:   apply [[FUNC_REF]]([[VALUE]])
+// SIL-NOT: release_value
+// SIL-NOT: apply
+// SIL:   br bb3
+//
+// SIL: bb2:
+// SIL-NOT: apply
+// SIL:   release_value [[VALUE]]
+// SIL-NOT: apply
+// SIL:   br bb3
+//
+// SIL: bb3:
+// SIL-NOT: release_value
+// SIL: } // end sil function '$s16moveonly_deinits28testIntEnumPairWithoutDeinityyF'
+public func testIntEnumPairWithoutDeinit() {
+    let f = IntEnumPairWithoutDeinit.lhs(5)
+    if value {
+        consumeIntEnumPairWithoutDeinit(f)
+    }
+}
+
+// SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits25testIntEnumPairWithDeinityyF : $@convention(thin) () -> () {
+// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: cond_br {{%.*}}, bb1, bb2
+//
+// SILGEN: bb1:
+// SILGEN:   br bb3
+//
+// SILGEN: bb2:
+// SILGEN:   br bb3
+//
+// SILGEN: bb3:
+// SILGEN:   destroy_value [[VALUE]]
+// SILGEN: } // end sil function '$s16moveonly_deinits25testIntEnumPairWithDeinityyF'
+
+// SIL-LABEL: sil @$s16moveonly_deinits25testIntEnumPairWithDeinityyF : $@convention(thin) () -> () {
+// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: cond_br {{%.*}}, bb1, bb2
+//
+// SIL: bb1:
+// SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits28consumeIntEnumPairWithDeinityyAA0defgH0OnF : $@convention(thin) (@owned IntEnumPairWithDeinit) -> ()
+// SIL:   apply [[FUNC_REF]]([[VALUE]])
+// SIL-NOT: release_value
+// SIL-NOT: apply
+// SIL:   br bb3
+//
+// SIL: bb2:
+// SIL: [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits21IntEnumPairWithDeinitOfD : $@convention(method) (@owned IntEnumPairWithDeinit) -> ()
+// SIL: apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned IntEnumPairWithDeinit) -> ()
+// SIL-NOT: apply
+// SIL-NOT: release_value
+// SIL:   br bb3
+//
+// SIL: bb3:
+// SIL-NOT: release_value
+// SIL: } // end sil function '$s16moveonly_deinits25testIntEnumPairWithDeinityyF'
+public func testIntEnumPairWithDeinit() {
+    let f = IntEnumPairWithDeinit.rhs(6)
+    if value {
+        consumeIntEnumPairWithDeinit(f)
+    }
+}
+
+// SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits30testKlassEnumPairWithoutDeinityyF : $@convention(thin) () -> () {
+// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: cond_br {{%.*}}, bb1, bb2
+//
+// SILGEN: bb1:
+// SILGEN:   br bb3
+//
+// SILGEN: bb2:
+// SILGEN:   br bb3
+//
+// SILGEN: bb3:
+// SILGEN:   destroy_value [[VALUE]]
+// SILGEN: } // end sil function '$s16moveonly_deinits30testKlassEnumPairWithoutDeinityyF'
+
+// SIL-LABEL: sil @$s16moveonly_deinits30testKlassEnumPairWithoutDeinityyF : $@convention(thin) () -> () {
+// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: cond_br {{%.*}}, bb1, bb2
+//
+// SIL: bb1:
+// SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits33consumeKlassEnumPairWithoutDeinityyAA0defgH0OnF : $@convention(thin) (@owned KlassEnumPairWithoutDeinit) -> ()
+// SIL:   apply [[FUNC_REF]]([[VALUE]])
+// SIL-NOT: release_value
+// SIL-NOT: apply
+// SIL:   br bb3
+//
+// SIL: bb2:
+// SIL-NOT: apply
+// SIL:   release_value [[VALUE]]
+// SIL-NOT: apply
+// SIL:   br bb3
+//
+// SIL: bb3:
+// SIL-NOT: release_value
+// SIL: } // end sil function '$s16moveonly_deinits30testKlassEnumPairWithoutDeinityyF'
+public func testKlassEnumPairWithoutDeinit() {
+    let f = KlassEnumPairWithoutDeinit.lhs(Klass())
+    if value {
+        consumeKlassEnumPairWithoutDeinit(f)
+    }
+}
+
+// SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits27testKlassEnumPairWithDeinityyF : $@convention(thin) () -> () {
+// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: cond_br {{%.*}}, bb1, bb2
+//
+// SILGEN: bb1:
+// SILGEN:   br bb3
+//
+// SILGEN: bb2:
+// SILGEN:   br bb3
+//
+// SILGEN: bb3:
+// SILGEN:   destroy_value [[VALUE]]
+// SILGEN: } // end sil function '$s16moveonly_deinits27testKlassEnumPairWithDeinityyF'
+
+// SIL-LABEL: sil @$s16moveonly_deinits27testKlassEnumPairWithDeinityyF : $@convention(thin) () -> () {
+// SIL: [[VALUE:%.*]] = move_value [lexical]
+// SIL: cond_br {{%.*}}, bb1, bb2
+//
+// SIL: bb1:
+// SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits30consumeKlassEnumPairWithDeinityyAA0defgH0OnF : $@convention(thin) (@owned KlassEnumPairWithDeinit) -> ()
+// SIL:   apply [[FUNC_REF]]([[VALUE]])
+// SIL-NOT: release_value
+// SIL-NOT: apply
+// SIL:   br bb3
+//
+// SIL: bb2:
+// SIL: [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits23KlassEnumPairWithDeinitOfD : $@convention(method) (@owned KlassEnumPairWithDeinit) -> ()
+// SIL: apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned KlassEnumPairWithDeinit) -> ()
+// SIL-NOT: apply
+// SIL-NOT: release_value
+// SIL:   br bb3
+//
+// SIL: bb3:
+// SIL-NOT: release_value
+// SIL: } // end sil function '$s16moveonly_deinits27testKlassEnumPairWithDeinityyF'
+public func testKlassEnumPairWithDeinit() {
+    let f = KlassEnumPairWithDeinit.rhs(Klass())
+    if value {
+        consumeKlassEnumPairWithDeinit(f)
+    }
+}

--- a/test/SILGen/moveonly_enum_literal.swift
+++ b/test/SILGen/moveonly_enum_literal.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -enable-experimental-move-only -emit-silgen %s | %FileCheck %s
+
+// This test makes sure that we properly setup enums when we construct moveonly
+// enums from literals.
+
+@_moveOnly
+enum MoveOnlyIntPair {
+case lhs(Int)
+case rhs(Int)
+}
+
+func consumeMoveIntPair(_ x: __owned MoveOnlyIntPair) {}
+
+var value: Bool { false }
+
+// CHECK-LABEL: sil hidden [ossa] @$s21moveonly_enum_literal4testyyF : $@convention(thin) () -> () {
+// CHECK: [[VALUE:%.*]] = enum $MoveOnlyIntPair, #MoveOnlyIntPair.lhs!enumelt,
+// CHECK: [[MV:%.*]] = move_value [lexical] [[VALUE]]
+// CHECK: [[MARKED_VALUE:%.*]] = mark_must_check [no_implicit_copy] [[MV]]
+// CHECK: debug_value [[MARKED_VALUE]]
+// CHECK: } // end sil function '$s21moveonly_enum_literal4testyyF'
+func test() {
+    let x = MoveOnlyIntPair.lhs(5)
+    if value {
+        consumeMoveIntPair(x)
+    }
+}


### PR DESCRIPTION
This is the last thing stopping the prototype from buffer view from working. I also fixed a small issue around SILGen for move only enums constructed from trivial literals in let initialization. Added tests for all of the relevant parts.