### PR TITLE
Test various nodiscard return cases.

### DIFF
--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -63,6 +63,11 @@ module MutabilityAnnotations {
   requires cplusplus
 }
 
+module NoDiscard {
+ header "nodiscard.h"
+ requires cplusplus  
+}
+
 module ProtocolConformance {
   header "protocol-conformance.h"
   requires cplusplus

--- a/test/Interop/Cxx/class/Inputs/nodiscard.h
+++ b/test/Interop/Cxx/class/Inputs/nodiscard.h
@@ -1,0 +1,24 @@
+#ifndef TEST_INTEROP_CXX_CLASS_NODISCARD_H
+#define TEST_INTEROP_CXX_CLASS_NODISCARD_H
+
+[[nodiscard]] int NoDiscardAdd(int x, int y);
+
+class NoDiscardMultiply {
+ public:
+  NoDiscardMultiply() {}
+  ~NoDiscardMultiply() {}
+
+  [[nodiscard]] int Multiply(int x, int y) { return x * y; }
+
+  int Divide(int x, int y) { return x / y; }
+};
+
+struct [[nodiscard]] NoDiscardError {
+ public:
+  NoDiscardError(int value) : value_(value) {}
+  int value_;
+};
+
+NoDiscardError NoDiscardReturnError(int x, int y);
+
+#endif

--- a/test/Interop/Cxx/class/nodiscard-typechecker.swift
+++ b/test/Interop/Cxx/class/nodiscard-typechecker.swift
@@ -1,0 +1,39 @@
+// Test various aspects of the C++ `nodiscard` keyword.
+
+// RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
+
+import NoDiscard
+
+// Test a function.
+
+// CORRECT: return value not discarded.  
+var value = NoDiscardAdd(5, 10)
+
+// CORRECT: warning when return value is discarded.
+NoDiscardAdd(10, 10) // expected-warning {{result of call to 'NoDiscardAdd' is unused}}
+
+
+// Test methods in a class.
+
+// CORRECT: return value not discarded.
+var multiplier = NoDiscardMultiply()
+value = multiplier.Multiply(10, 10)
+
+// CORRECT: warning when return value is discarded
+multiplier.Multiply(50, 50)  // expected-warning {{result of call to 'Multiply' is unused}}
+
+// CORRECT: return value not discarded.  
+value = multiplier.Divide(100, 10)
+
+// CORRECT: method has no annotation, thus no warning
+multiplier.Divide(100, 10)
+
+
+// Test a struct marked with nodiscard as a return value from a function.
+
+let error: NoDiscardError = NoDiscardReturnError(10, 10)
+
+// INCORRECT: NoDiscardError is declared nodiscard, so ignoring the 
+// return value of NoDiscardReturnError() should be a warning, but isn't.
+// Filed as: https://github.com/apple/swift/issues/59002
+NoDiscardReturnError(50, 50)


### PR DESCRIPTION
Test several situations of using `nodiscard` in interop with C++ headers and ensure they are correct — or fail — as expected. There is one case that does not work correctly, and the corresponding gitHub issue (59002) is linked. 
