### PR TITLE
Add Missing _StringProcessing Dependencies

### DIFF
--- a/stdlib/private/OSLog/CMakeLists.txt
+++ b/stdlib/private/OSLog/CMakeLists.txt
@@ -1,7 +1,10 @@
 set(swift_oslog_darwin_dependencies "")
 if (SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
     list(APPEND swift_oslog_darwin_dependencies "_Concurrency")
-endif ()
+endif()
+if (SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)
+  list(APPEND swift_oslog_darwin_dependencies "_StringProcessing")
+endif()
 
 add_swift_target_library(swiftOSLogTestHelper
   IS_SDK_OVERLAY

--- a/stdlib/private/StdlibUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnittest/CMakeLists.txt
@@ -24,6 +24,9 @@ if (SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY)
   list(APPEND swift_stdlib_unittest_link_libraries "swift_Concurrency")
   list(APPEND swift_stdlib_unittest_modules "_Concurrency")
 endif()
+if (SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)
+  list(APPEND swift_stdlib_unittest_modules "_StringProcessing")
+endif()
 
 add_swift_target_library(swiftStdlibUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   # This file should be listed the first.  Module name is inferred from the


### PR DESCRIPTION
These two modules themselves depend on modules that implicitly import the _StringProcessing library. Take OSLog as an example, which imports ObjectiveC, which implicitly imports _StringProcessing. Thus, we can get into the following bad scenario:

- A compiler at module format X builds _StringProcessing
- A rebase is performed and the compiler is rebuilt at module format Y > X
- OSLog builds before _StringProcessing (since it has no dependency)
- But _StringProcessing is at module format X < Y, so we have to rebuild it

This normally manifests as an error at the desks of compiler engineers about a mismatch in the module format for _StringProcessing. Let's fix that by making CMake schedule _StringProcessing before them.