### PR TITLE
Allow StoredIntegerElement to use full storage when necessary.

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -558,7 +558,7 @@ public:
   template <unsigned Index = 0,
             typename = typename std::enable_if<(Index < NumValues)>::type>
   uint64_t getValue() const {
-    // We pack values into 16 bit components of the storage, with value0
+    // We pack values into equally-sized components of the storage, with value0
     // being stored in the upper bits, valueN in the lower bits. Therefore we
     // need to shift out any extra values in the lower bits.
     auto extraValues = NumValues - Index - 1;

--- a/test/Sema/large_int_array.swift.gyb
+++ b/test/Sema/large_int_array.swift.gyb
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %gyb %s -o %t/large_int_array.swift
+// RUN: %target-swift-frontend -typecheck -verify %t/large_int_array.swift
+
+% num_elements = 65537
+
+public let largeIntArray = [
+% for i in range(num_elements):
+  0,
+% end
+]

--- a/test/Sema/large_int_array.swift.gyb
+++ b/test/Sema/large_int_array.swift.gyb
@@ -4,8 +4,9 @@
 
 % num_elements = 65537
 
-public let largeIntArray = [
+let v = 0
+let _ : [Int] = [
 % for i in range(num_elements):
-  0,
+  v,
 % end
 ]


### PR DESCRIPTION
This way we will be able to store whole 64-bit number when we store only a single value, or two 32-bit numbers or 3 16-bit.

Fixes #61723