### PR TITLE
Instantiate pattern type when matching PackExpansionTypes

### DIFF
--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -443,7 +443,8 @@ protected:
 /// }
 /// ```
 ///
-/// `S.T` is not the same type as `Int`, which is required by `foo`.
+/// The generic parameter packs `T` and `U` are not known to have the same
+/// shape, which is required by `foo()`.
 class SameShapeRequirementFailure final : public RequirementFailure {
 public:
   SameShapeRequirementFailure(const Solution &solution, Type lhs, Type rhs,

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2888,6 +2888,7 @@ namespace {
 
       auto elementResultType = CS.getType(expr->getPatternExpr());
       auto patternTy = CS.createTypeVariable(CS.getConstraintLocator(expr),
+                                             TVO_CanBindToPack |
                                              TVO_CanBindToHole);
       CS.addConstraint(ConstraintKind::PackElementOf, elementResultType,
                        patternTy, CS.getConstraintLocator(expr));

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2943,7 +2943,8 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
     if (func1->getGlobalActor() && func2->getGlobalActor()) {
       // If both have a global actor, match them.
       TypeMatchOptions subflags = getDefaultDecompositionOptions(flags);
-      auto result = matchTypes(func1->getGlobalActor(), func2->getGlobalActor(), ConstraintKind::Equal, subflags, locator);
+      auto result = matchTypes(func1->getGlobalActor(), func2->getGlobalActor(),
+                               ConstraintKind::Equal, subflags, locator);
       if (result == SolutionKind::Error)
         return getTypeMatchFailure(locator);
     } else if (func1->getGlobalActor() && !func2->isAsync()) {

--- a/test/Constraints/pack_expansion_types.swift
+++ b/test/Constraints/pack_expansion_types.swift
@@ -8,13 +8,13 @@ func returnTupleLabel1<T...>() -> (x: T...) { fatalError() }
 
 func returnTupleLabel2<T...>() -> (Int, x: T...) { fatalError() }
 
-func returnTupleLabel3<T...>() -> (Int, T..., y: Float) { fatalError() } // expected-note {{in call to function 'returnTupleLabel3()'}}
+func returnTupleLabel3<T...>() -> (Int, T..., y: Float) { fatalError() }
 
-func returnTupleLabel4<T...>() -> (Int, x: T..., y: Float) { fatalError() }
+func returnTupleLabel4<T...>() -> (Int, x: T..., y: Float) { fatalError() } // expected-note {{in call to function 'returnTupleLabel4()'}}
 
-func returnTupleLabel5<T..., U...>() -> (Int, T..., y: U...) { fatalError() } // expected-note {{in call to function 'returnTupleLabel5()'}}
+func returnTupleLabel5<T..., U...>() -> (Int, T..., y: U...) { fatalError() }
 
-func returnTupleLabel6<T..., U...>() -> (Int, x: T..., y: U...) { fatalError() }
+func returnTupleLabel6<T..., U...>() -> (Int, x: T..., y: U...) { fatalError() } // expected-note {{in call to function 'returnTupleLabel6()'}}
 
 func concreteReturnTupleValid() {
   let _: () = returnTuple1()
@@ -103,20 +103,22 @@ func genericReturnTupleInvalid<T...>(_: T...) {
   let _: (x: T...) = returnTupleLabel2() // expected-error {{type of expression is ambiguous without more context}}
   let _: (Int, y: String, T...) = returnTupleLabel2() // expected-error {{type of expression is ambiguous without more context}}
 
-  let _: (T..., y: Float) = returnTupleLabel3() // expected-error {{'(Int, T..., y: Float)' is not convertible to '(T..., y: Float)', tuples have a different number of elements}}
-  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  let _: (T..., y: Float) = returnTupleLabel3() // expected-error {{type of expression is ambiguous without more context}}
 
   let _: (Int, String, T..., x: Float) = returnTupleLabel3() // expected-error {{type of expression is ambiguous without more context}}
 
-  let _: (T..., y: Float) = returnTupleLabel4() // expected-error {{cannot convert value of type '(Int, y: Float)' to specified type '(T..., y: Float)'}}
+  let _: (T..., y: Float) = returnTupleLabel4() // expected-error {{'(Int, x: T..., y: Float)' is not convertible to '(T..., y: Float)', tuples have a different number of elements}}
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+
   let _: (Int, x: String, y: T...) = returnTupleLabel4() // expected-error {{cannot convert value of type '(Int, x: String, y: Float)' to specified type '(Int, x: String, y: T...)'}}
 
   let _: (Int, T..., x: T...) = returnTupleLabel5() // expected-error {{type of expression is ambiguous without more context}}
 
-  let _: (T..., y: Float, T...) = returnTupleLabel5() // expected-error {{'(Int, T..., y: Float, T...)' is not convertible to '(T..., y: Float, T...)', tuples have a different number of elements}}
-  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  let _: (T..., y: Float, T...) = returnTupleLabel5() // expected-error {{type of expression is ambiguous without more context}}
 
-  let _: (T..., y: Int) = returnTupleLabel6() // expected-error {{cannot convert value of type '(Int, y: Int)' to specified type '(T..., y: Int)'}}
+  let _: (T..., y: Int) = returnTupleLabel6() // expected-error {{'(Int, x: T..., y: U...)' is not convertible to '(T..., y: Int)', tuples have a different number of elements}}
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-2 {{generic parameter 'U' could not be inferred}}
 }
 
 func returnFunction1<T...>() -> (T...) -> () {}

--- a/test/Constraints/pack_expansion_types.swift
+++ b/test/Constraints/pack_expansion_types.swift
@@ -8,13 +8,11 @@ func returnTupleLabel1<T...>() -> (x: T...) { fatalError() }
 
 func returnTupleLabel2<T...>() -> (Int, x: T...) { fatalError() }
 
-func returnTupleLabel3<T...>() -> (Int, T..., y: Float) { fatalError() }
-// expected-note@-1 {{in call to function 'returnTupleLabel3()'}}
+func returnTupleLabel3<T...>() -> (Int, T..., y: Float) { fatalError() } // expected-note {{in call to function 'returnTupleLabel3()'}}
 
 func returnTupleLabel4<T...>() -> (Int, x: T..., y: Float) { fatalError() }
 
-func returnTupleLabel5<T..., U...>() -> (Int, T..., y: U...) { fatalError() }
-// expected-note@-1 {{in call to function 'returnTupleLabel5()'}}
+func returnTupleLabel5<T..., U...>() -> (Int, T..., y: U...) { fatalError() } // expected-note {{in call to function 'returnTupleLabel5()'}}
 
 func returnTupleLabel6<T..., U...>() -> (Int, x: T..., y: U...) { fatalError() }
 
@@ -105,16 +103,18 @@ func genericReturnTupleInvalid<T...>(_: T...) {
   let _: (x: T...) = returnTupleLabel2() // expected-error {{type of expression is ambiguous without more context}}
   let _: (Int, y: String, T...) = returnTupleLabel2() // expected-error {{type of expression is ambiguous without more context}}
 
-  let _: (T..., y: Float) = returnTupleLabel3() // expected-error {{generic parameter 'T' could not be inferred}}
-  // expected-error@-1 {{'(Int, T..., y: Float)' is not convertible to '(T..., y: Float)', tuples have a different number of elements}}
+  let _: (T..., y: Float) = returnTupleLabel3() // expected-error {{'(Int, T..., y: Float)' is not convertible to '(T..., y: Float)', tuples have a different number of elements}}
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+
   let _: (Int, String, T..., x: Float) = returnTupleLabel3() // expected-error {{type of expression is ambiguous without more context}}
 
   let _: (T..., y: Float) = returnTupleLabel4() // expected-error {{cannot convert value of type '(Int, y: Float)' to specified type '(T..., y: Float)'}}
   let _: (Int, x: String, y: T...) = returnTupleLabel4() // expected-error {{cannot convert value of type '(Int, x: String, y: Float)' to specified type '(Int, x: String, y: T...)'}}
 
   let _: (Int, T..., x: T...) = returnTupleLabel5() // expected-error {{type of expression is ambiguous without more context}}
-  let _: (T..., y: Float, T...) = returnTupleLabel5() // expected-error {{generic parameter 'T' could not be inferred}}
-  // expected-error@-1 {{'(Int, T..., y: Float, T...)' is not convertible to '(T..., y: Float, T...)', tuples have a different number of elements}}
+
+  let _: (T..., y: Float, T...) = returnTupleLabel5() // expected-error {{'(Int, T..., y: Float, T...)' is not convertible to '(T..., y: Float, T...)', tuples have a different number of elements}}
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
 
   let _: (T..., y: Int) = returnTupleLabel6() // expected-error {{cannot convert value of type '(Int, y: Int)' to specified type '(T..., y: Int)'}}
 }
@@ -148,17 +148,83 @@ func concreteReturnFunctionValid() {
 func concreteReturnFunctionInvalid() {
   let _: () -> () = returnFunction2() // expected-error {{cannot convert value of type '(Int, T...) -> ()' to specified type '() -> ()'}}
   // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+
   let _: (String) -> () = returnFunction2() // expected-error {{cannot convert value of type '(Int) -> ()' to specified type '(String) -> ()'}}
   let _: (String, Int) -> () = returnFunction2() // expected-error {{cannot convert value of type '(Int, Int) -> ()' to specified type '(String, Int) -> ()'}}
 
   let _: () -> () = returnFunction3() // expected-error {{cannot convert value of type '(T..., Float) -> ()' to specified type '() -> ()'}}
   // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+
   let _: (Float, Int) -> () = returnFunction3() // expected-error {{cannot convert value of type '(Float, Float) -> ()' to specified type '(Float, Int) -> ()'}}
   let _: (Float, Double, String) -> () = returnFunction3() // expected-error {{cannot convert value of type '(Float, Double, Float) -> ()' to specified type '(Float, Double, String) -> ()'}}
 
   let _: () -> () = returnFunction4() // expected-error {{cannot convert value of type '(Int, T..., Float) -> ()' to specified type '() -> ()'}}
   // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+
   let _: (Int) -> () = returnFunction4() // expected-error {{cannot convert value of type '(Int, T..., Float) -> ()' to specified type '(Int) -> ()'}}
   // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+
   let _: (Float, Int) -> () = returnFunction4() // expected-error {{cannot convert value of type '(Int, Float) -> ()' to specified type '(Float, Int) -> ()'}}
+}
+
+func patternInstantiationTupleTest1<T...>() -> (Array<T>...) {} // expected-note {{in call to function 'patternInstantiationTupleTest1()'}}
+func patternInstantiationTupleTest2<T..., U...>() -> (Dictionary<T, U>...) {}
+
+func patternInstantiationFunctionTest1<T...>() -> (Array<T>...) -> () {}
+func patternInstantiationFunctionTest2<T..., U...>() -> (Dictionary<T, U>...) -> () {}
+
+func patternInstantiationConcreteValid() {
+  let _: () = patternInstantiationTupleTest1()
+  let _: (_: Array<Int>) = patternInstantiationTupleTest1()
+  let _: (Array<Int>, Array<String>) = patternInstantiationTupleTest1()
+  let _: (Array<Int>, Array<String>, Array<Float>) = patternInstantiationTupleTest1()
+
+  let _: () = patternInstantiationTupleTest2()
+  let _: (_: Dictionary<Int, String>) = patternInstantiationTupleTest2()
+  let _: (Dictionary<Int, String>, Dictionary<Float, Bool>) = patternInstantiationTupleTest2()
+  let _: (Dictionary<Int, String>, Dictionary<Float, Bool>, Dictionary<Double, Character>) = patternInstantiationTupleTest2()
+
+  let _: () -> () = patternInstantiationFunctionTest1()
+  let _: (_: Array<Int>) -> () = patternInstantiationFunctionTest1()
+  let _: (Array<Int>, Array<String>) -> () = patternInstantiationFunctionTest1()
+  let _: (Array<Int>, Array<String>, Array<Float>) -> () = patternInstantiationFunctionTest1()
+
+  let _: () -> () = patternInstantiationFunctionTest2()
+  let _: (_: Dictionary<Int, String>) -> () = patternInstantiationFunctionTest2()
+  let _: (Dictionary<Int, String>, Dictionary<Float, Bool>) -> () = patternInstantiationFunctionTest2()
+  let _: (Dictionary<Int, String>, Dictionary<Float, Bool>, Dictionary<Double, Character>) -> () = patternInstantiationFunctionTest2()
+}
+
+func patternInstantiationConcreteInvalid() {
+  let _: (_: Set<Int>) = patternInstantiationTupleTest1() // expected-error {{type of expression is ambiguous without more context}}
+  let _: (Array<Int>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{type of expression is ambiguous without more context}}
+}
+
+func patternInstantiationGenericValid<T..., U...>(t: T..., u: U...) where ((T, U)...): Any, T: Hashable {
+  let _: (Array<T>...) = patternInstantiationTupleTest1()
+  let _: (Array<T>..., Array<String>) = patternInstantiationTupleTest1()
+  let _: (Array<String>, Array<T>...) = patternInstantiationTupleTest1()
+  let _: (Array<Int>, Array<T>..., Array<Float>) = patternInstantiationTupleTest1()
+
+  let _: (Dictionary<T, U>...) = patternInstantiationTupleTest2()
+  let _: (Dictionary<T, U>..., Dictionary<Float, Bool>) = patternInstantiationTupleTest2()
+  let _: (Dictionary<Int, String>, Dictionary<T, U>...) = patternInstantiationTupleTest2()
+  let _: (Dictionary<Int, String>, Dictionary<T, U>..., Dictionary<Double, Character>) = patternInstantiationTupleTest2()
+
+  let _: (Array<T>...) -> () = patternInstantiationFunctionTest1()
+  let _: (Array<T>..., Array<String>) -> () = patternInstantiationFunctionTest1()
+  let _: (Array<String>, Array<T>...) -> () = patternInstantiationFunctionTest1()
+  let _: (Array<Int>, Array<T>..., Array<Float>) -> () = patternInstantiationFunctionTest1()
+
+  let _: (Dictionary<T, U>...) -> () = patternInstantiationFunctionTest2()
+  let _: (Dictionary<T, U>..., Dictionary<Float, Bool>) -> () = patternInstantiationFunctionTest2()
+  let _: (Dictionary<Int, String>, Dictionary<T, U>...) -> () = patternInstantiationFunctionTest2()
+  let _: (Dictionary<Int, String>, Dictionary<T, U>..., Dictionary<Double, Character>) -> () = patternInstantiationFunctionTest2()
+}
+
+func patternInstantiationGenericInvalid<T...>(t: T...) where T: Hashable {
+  let _: (Set<T>...) = patternInstantiationTupleTest1() // expected-error {{cannot convert value of type '(Array<T>...)' to specified type '(Set<T>...)}}
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+
+  let _: (Array<T>..., Set<String>) = patternInstantiationTupleTest1() // expected-error {{type of expression is ambiguous without more context}}
 }

--- a/test/Constraints/variadic_generic_constraints.swift
+++ b/test/Constraints/variadic_generic_constraints.swift
@@ -56,7 +56,7 @@ takesParallelSequences(t: Array<String>(), Set<Int>(), u: Array<Int>(), Set<Stri
 // Same-shape requirements
 
 func zip<T..., U...>(t: T..., u: U...) -> ((T, U)...) {}
-// expected-note@-1 {{where 'T' = 'U', 'U' = 'T'}}
+// expected-note@-1 {{where 'T' = 'T', 'U' = 'U'}}
 
 let _ = zip()  // ok
 let _ = zip(t: 1, u: "hi")  // ok
@@ -72,5 +72,5 @@ func goodCallToZip<T..., U...>(t: T..., u: U...) where ((T, U)...): Any {
 
 func badCallToZip<T..., U...>(t: T..., u: U...) {
   _ = zip(t: t..., u: u...)
-  // expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'U' and 'T' have the same shape}}
+  // expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'T' and 'U' have the same shape}}
 }

--- a/test/Constraints/variadic_generic_constraints.swift
+++ b/test/Constraints/variadic_generic_constraints.swift
@@ -56,7 +56,7 @@ takesParallelSequences(t: Array<String>(), Set<Int>(), u: Array<Int>(), Set<Stri
 // Same-shape requirements
 
 func zip<T..., U...>(t: T..., u: U...) -> ((T, U)...) {}
-// expected-note@-1 {{where 'T' = 'U', 'U' = 'Pack{T...}'}}
+// expected-note@-1 {{where 'T' = 'U', 'U' = 'T'}}
 
 let _ = zip()  // ok
 let _ = zip(t: 1, u: "hi")  // ok
@@ -72,5 +72,5 @@ func goodCallToZip<T..., U...>(t: T..., u: U...) where ((T, U)...): Any {
 
 func badCallToZip<T..., U...>(t: T..., u: U...) {
   _ = zip(t: t..., u: u...)
-  // expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'U' and 'Pack{T...}' have the same shape}}
+  // expected-error@-1 {{global function 'zip(t:u:)' requires the type packs 'U' and 'T' have the same shape}}
 }


### PR DESCRIPTION
This allows matching something like `(Array<$T0>...)` against `(Array<Int>, Array<String>)`, binding `$T0` to `{Int, String}`.