### PR TITLE
Expose "isKnownCFTypeName" through ClangImporter

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -194,6 +194,8 @@ public:
       IntermoduleDepTrackingMode Mode,
       std::shared_ptr<llvm::FileCollectorBase> FileCollector);
 
+  static bool isKnownCFTypeName(llvm::StringRef name);
+
   /// Append visible module names to \p names. Note that names are possibly
   /// duplicated, and not guaranteed to be ordered in any way.
   void collectVisibleTopLevelModuleNames(

--- a/lib/ClangImporter/CFTypeInfo.cpp
+++ b/lib/ClangImporter/CFTypeInfo.cpp
@@ -43,7 +43,7 @@ static constexpr const llvm::StringLiteral KnownCFTypes[] = {
 const size_t NumKnownCFTypes = sizeof(KnownCFTypes) / sizeof(*KnownCFTypes);
 
 /// Maintain a set of known CF types.
-static bool isKnownCFTypeName(StringRef name) {
+bool CFPointeeInfo::isKnownCFTypeName(StringRef name) {
   return std::binary_search(KnownCFTypes, KnownCFTypes + NumKnownCFTypes,
                             name, SortByLengthComparator());
 }

--- a/lib/ClangImporter/CFTypeInfo.h
+++ b/lib/ClangImporter/CFTypeInfo.h
@@ -77,6 +77,8 @@ class CFPointeeInfo {
 public:
   static CFPointeeInfo classifyTypedef(const clang::TypedefNameDecl *decl);
 
+  static bool isKnownCFTypeName(llvm::StringRef name);
+
   bool isValid() const { return IsValid; }
   explicit operator bool() const { return isValid(); }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -14,6 +14,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "swift/ClangImporter/ClangImporter.h"
+#include "CFTypeInfo.h"
 #include "ClangDerivedConformances.h"
 #include "ClangDiagnosticConsumer.h"
 #include "ClangIncludePaths.h"
@@ -400,6 +401,10 @@ ClangImporter::createDependencyCollector(
     std::shared_ptr<llvm::FileCollectorBase> FileCollector) {
   return std::make_shared<ClangImporterDependencyCollector>(Mode,
                                                             FileCollector);
+}
+
+bool ClangImporter::isKnownCFTypeName(llvm::StringRef name) {
+  return CFPointeeInfo::isKnownCFTypeName(name);
 }
 
 void ClangImporter::Implementation::addBridgeHeaderTopLevelDecls(


### PR DESCRIPTION
LLDB needs to know if a type was specially handled by the compiler, so expose "isKnownCFTypeName" so LLDB can call it.

