### PR TITLE
[Macros] Support user-defined macros as compiler plugins

### DIFF
--- a/include/swift/AST/CompilerPlugin.h
+++ b/include/swift/AST/CompilerPlugin.h
@@ -1,0 +1,100 @@
+//===--- CompilerPlugin.h - Compiler Plugin Support -------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines supporting data structures for compiler plugins.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/Type.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/StringExtras.h"
+#include "llvm/Support/DynamicLibrary.h"
+
+#ifndef SWIFT_AST_COMPILER_PLUGIN_H
+#define SWIFT_AST_COMPILER_PLUGIN_H
+
+namespace swift {
+
+class ASTContext;
+
+/// A compiler plugin that corresponds to a dynamically loaded Swift type that
+/// conforms to the `_CompilerPluginSupport._CompilerPlugin` protocol.
+class CompilerPlugin {
+  friend class ASTContext;
+
+public:
+  // Must be modified together with `_CompilerPluginKind` in
+  // stdlib/toolchain/CompilerPluginSupport.swift.
+  enum class Kind: uint32_t {
+    ExpressionMacro,
+  };
+
+private:
+  // Must be modified together with `_CompilerPlugin` in
+  // stdlib/toolchain/CompilerPluginSupport.swift.
+  enum class WitnessTableEntry: unsigned {
+    ConformanceDescriptor = 0,
+    // static func _name() -> (UnsafePointer<UInt8>, count: Int8)
+    Name = 1,
+    // static func _kind() -> _CompilerPluginKind
+    Kind = 2,
+    // static func _rewrite(...) -> (UnsafePointer<UInt8>?, count: Int)
+    Rewrite = 3,
+  };
+
+  /// The plugin type metadata.
+  const void *metadata;
+  /// The parent dynamic library containing the plugin.
+  llvm::sys::DynamicLibrary parentLibrary;
+  /// The witness table proving that the plugin conforms to `_CompilerPlugin`.
+  const void *witnessTable;
+  /// The plugin name, aka. result of the `_name()` method.
+  StringRef name;
+  /// The plugin's kind, aka. result of the `_kind()` method.
+  Kind kind;
+
+  template<typename Func>
+  const Func *getWitnessMethodUnsafe(WitnessTableEntry entry) const {
+    return reinterpret_cast<const Func *const *>(witnessTable)[(unsigned)entry];
+  }
+
+protected:
+  CompilerPlugin(const void *metadata, llvm::sys::DynamicLibrary parentLibrary,
+                 ASTContext &ctx);
+
+private:
+  /// Invoke the `_name` method. The caller assumes ownership of the result
+  /// string buffer.
+  StringRef invokeName() const;
+
+  /// Invoke the `_kind` method.
+  Kind invokeKind() const;
+
+public:
+  /// Invoke the `_rewrite` method. Invoke the `_name` method. The caller
+  /// assumes ownership of the result string buffer.
+  Optional<NullTerminatedStringRef> invokeRewrite(
+      StringRef targetModuleName, StringRef filePath, StringRef sourceFileText,
+      CharSourceRange range,  ASTContext &ctx) const;
+
+  StringRef getName() const {
+    return name;
+  }
+
+  Kind getKind() const {
+    return kind;
+  }
+};
+
+} // end namespace swift
+
+#endif // SWIFT_AST_COMPILER_PLUGIN_H

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -472,6 +472,12 @@ REMARK(warning_in_access_notes_file,none,
        "ignored invalid content in access notes file: %0",
        (StringRef))
 
+WARNING(compiler_plugin_not_loaded,none,
+        "compiler plugin not loaded: %0; loader error: %1", (StringRef, StringRef))
+WARNING(compiler_plugin_missing_macro_declaration,none,
+        "compiler plugin module '%0' (in %1) is missing a top-level computed "
+        "property 'public var %2: [Any.Type]' to declare all macros; "
+        "undeclared macros will be ignored", (StringRef, StringRef, StringRef))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6696,8 +6696,12 @@ ERROR(experimental_no_metadata_feature_can_only_be_used_when_enabled,
 //------------------------------------------------------------------------------
 // MARK: Macros
 //------------------------------------------------------------------------------
+
 ERROR(expected_macro_expansion_expr,PointsToFirstBadToken,
       "expected macro expansion to produce an expression", ())
+ERROR(macro_undefined,PointsToFirstBadToken,
+      "macro '%0' is undefined; use `-load-plugin-library` to specify dynamic "
+      "libraries that contain this macro", (StringRef))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -333,6 +333,9 @@ IDENTIFIER(unsafe)
 // The singleton instance of TupleTypeDecl in the Builtin module
 IDENTIFIER(TheTupleType)
 
+// Macros / compiler plugins
+IDENTIFIER_(CompilerPluginSupport)
+
 #undef IDENTIFIER
 #undef IDENTIFIER_
 #undef IDENTIFIER_WITH_NAME

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -114,6 +114,9 @@ PROTOCOL(AsyncIteratorProtocol)
 
 PROTOCOL(FloatingPoint)
 
+// Compiler Plugins
+PROTOCOL_(CompilerPlugin)
+
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByArrayLiteral, "Array", false)
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByBooleanLiteral, "BooleanLiteralType", true)
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByDictionaryLiteral, "Dictionary", false)

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -34,6 +34,7 @@ enum class ModuleSearchPathKind {
   Framework,
   DarwinImplicitFramework,
   RuntimeLibrary,
+  CompilerPlugin,
 };
 
 /// A single module search path that can come from different sources, e.g.
@@ -230,6 +231,9 @@ private:
   /// \c ModuleSearchPath.
   std::vector<std::string> DarwinImplicitFrameworkSearchPaths;
 
+  /// Compiler plugin library search paths.
+  std::vector<std::string> CompilerPluginLibraryPaths;
+
   /// Add a single import search path. Must only be called from
   /// \c ASTContext::addSearchPath.
   void addImportSearchPath(StringRef Path, llvm::vfs::FileSystem *FS) {
@@ -237,6 +241,14 @@ private:
     Lookup.searchPathAdded(FS, ImportSearchPaths.back(),
                            ModuleSearchPathKind::Import, /*isSystem=*/false,
                            ImportSearchPaths.size() - 1);
+  }
+
+  void addCompilerPluginLibraryPath(StringRef Path, llvm::vfs::FileSystem *FS) {
+    CompilerPluginLibraryPaths.push_back(Path.str());
+    Lookup.searchPathAdded(FS, CompilerPluginLibraryPaths.back(),
+                           ModuleSearchPathKind::CompilerPlugin,
+                           /*isSystem=*/false,
+                           CompilerPluginLibraryPaths.size() - 1);
   }
 
   /// Add a single framework search path. Must only be called from
@@ -300,6 +312,16 @@ public:
       std::vector<std::string> NewRuntimeLibraryImportPaths) {
     RuntimeLibraryImportPaths = NewRuntimeLibraryImportPaths;
     Lookup.searchPathsDidChange();
+  }
+
+  void setCompilerPluginLibraryPaths(
+      std::vector<std::string> NewCompilerPluginLibraryPaths) {
+    CompilerPluginLibraryPaths = NewCompilerPluginLibraryPaths;
+    Lookup.searchPathsDidChange();
+  }
+
+  ArrayRef<std::string> getCompilerPluginLibraryPaths() const {
+    return CompilerPluginLibraryPaths;
   }
 
   /// Path(s) to virtual filesystem overlay YAML files.

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -192,6 +192,14 @@ public:
     return SearchPathOpts.getFrameworkSearchPaths();
   }
 
+  void setCompilerPluginLibraryPaths(const std::vector<std::string> &Paths) {
+    SearchPathOpts.setCompilerPluginLibraryPaths(Paths);
+  }
+
+  ArrayRef<std::string> getCompilerPluginLibraryPaths() {
+    return SearchPathOpts.getCompilerPluginLibraryPaths();
+  }
+
   void setExtraClangArgs(const std::vector<std::string> &Args) {
     ClangImporterOpts.ExtraArgs = Args;
   }

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1695,4 +1695,11 @@ def nostartfiles:
 
 // END ONLY SUPPORTED IN NEW DRIVER
 
+def load_plugin_library:
+  Separate<["-"], "load-plugin-library">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
+  HelpText<"Path to a dynamic library containing compiler plugins such as "
+           "macros">,
+  MetaVarName<"<path>">;
+
 include "FrontendOptions.td"

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -37,6 +37,7 @@ add_swift_host_library(swiftAST STATIC
   CaptureInfo.cpp
   ClangSwiftTypeCorrespondence.cpp
   ClangTypeConverter.cpp
+  CompilerPlugin.cpp
   ConcreteDeclRef.cpp
   ConformanceLookupTable.cpp
   Decl.cpp
@@ -154,6 +155,13 @@ if(NOT SWIFT_BUILD_ONLY_SYNTAXPARSERLIB)
     clangLex
     clangAPINotes
     clangBasic)
+endif()
+
+if(SWIFT_SWIFT_PARSER)
+  target_compile_definitions(swiftAST
+    PRIVATE
+    SWIFT_SWIFT_PARSER
+  )
 endif()
 
 target_link_libraries(swiftAST

--- a/lib/AST/CompilerPlugin.cpp
+++ b/lib/AST/CompilerPlugin.cpp
@@ -1,0 +1,282 @@
+//===--- CompilerPlugin.cpp - Compile Plugin Support ----------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Compiler plugin support
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/CompilerPlugin.h"
+
+#include "swift/AST/ASTMangler.h"
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/Demangling/Demangle.h"
+#include "swift/Demangling/Demangler.h"
+#include "swift/Parse/Lexer.h"
+#include "swift/Subsystems.h"
+#include "llvm/Config/config.h"
+#include "llvm/Support/DynamicLibrary.h"
+#include <cstdlib>
+
+using namespace swift;
+
+#define ALLMACROS_PROPERTY_NAME "allMacros"
+#define COMPILER_PLUGIN_PROTOCOL_DESCRIPTOR "$s22_CompilerPluginSupport01_aB0Mp"
+
+#if __clang__
+#define SWIFT_CC __attribute__((swiftcall))
+#define SWIFT_CONTEXT __attribute__((swift_context))
+#endif
+
+namespace {
+struct MetadataArrayRef {
+  const void *const *metadataArray;
+  ptrdiff_t size;
+
+  ArrayRef<const void *> array() const {
+    return ArrayRef<const void *>(metadataArray, (size_t)size);
+  }
+};
+} // end anonymous namespace
+
+#if __clang__ && SWIFT_SWIFT_PARSER
+extern "C"
+void swift_ASTGen_getMacroTypes(const void *getter,
+                                const void *const **resultMetatypes,
+                                ptrdiff_t *resultCount);
+#endif
+
+static const void *
+getMacroRegistrationPropertyGetter(llvm::sys::DynamicLibrary library,
+                                   StringRef moduleName,
+                                   ASTContext &ctx) {
+  assert(!moduleName.empty());
+  // TODO: Consider using runtime lookup to get all types that conform to the
+  // macro protocol instead of finding a global `allMacros` property.
+  std::string name;
+  // Build a mangling tree for
+  // "<module name>.allMacros.getter : [Any.Type]".
+  // Example:
+  //   kind=Global
+  //   kind=Getter
+  //     kind=Variable
+  //       kind=Module, text="StringifyMacro"
+  //       kind=Identifier, text="allMacros"
+  //       kind=Type
+  //         kind=BoundGenericStructure
+  //           kind=Type
+  //             kind=Structure
+  //               kind=Module, text="Swift"
+  //               kind=Identifier, text="Array"
+  //           kind=TypeList
+  //             kind=Type
+  //               kind=ExistentialMetatype
+  //                 kind=Type
+  //                   kind=ProtocolList
+  //                     kind=TypeList
+  {
+    Demangle::Demangler D;
+    auto *global = D.createNode(Node::Kind::Global);
+    {
+      auto *getter = D.createNode(Node::Kind::Getter);
+      {
+        auto *variable = D.createNode(Node::Kind::Variable);
+        {
+          auto *module = D.createNode(Node::Kind::Module, moduleName);
+          auto *identifier = D.createNode(Node::Kind::Identifier,
+                                          ALLMACROS_PROPERTY_NAME);
+          auto *type = D.createNode(Node::Kind::Type);
+          {
+            auto *boundGenric = D.createNode(Node::Kind::BoundGenericStructure);
+            {
+              auto *type = D.createNode(Node::Kind::Type);
+              {
+                auto *structure = D.createNode(Node::Kind::Structure);
+                {
+                  auto *module = D.createNode(Node::Kind::Module, "Swift");
+                  auto *identifier = D.createNode(Node::Kind::Identifier, "Array");
+                  structure->addChild(module, D);
+                  structure->addChild(identifier, D);
+                }
+                type->addChild(structure, D);
+              }
+              auto *typeList = D.createNode(Node::Kind::TypeList);
+              {
+                auto *type = D.createNode(Node::Kind::Type);
+                {
+                  auto *exMetatype = D.createNode(Node::Kind::ExistentialMetatype);
+                  {
+                    auto *type = D.createNode(Node::Kind::Type);
+                    {
+                      auto *protocolList = D.createNode(Node::Kind::ProtocolList);
+                      {
+                        auto *typeList = D.createNode(Node::Kind::TypeList);
+                        protocolList->addChild(typeList, D);
+                      }
+                      type->addChild(protocolList, D);
+                    }
+                    exMetatype->addChild(type, D);
+                  }
+                  type->addChild(exMetatype, D);
+                }
+                typeList->addChild(type, D);
+              }
+              boundGenric->addChild(type, D);
+              boundGenric->addChild(typeList, D);
+            }
+            type->addChild(boundGenric, D);
+          }
+          variable->addChild(module, D);
+          variable->addChild(identifier, D);
+          variable->addChild(type, D);
+        }
+        getter->addChild(variable, D);
+      }
+      global->addChild(getter, D);
+    }
+    auto mangleResult = mangleNode(global);
+    assert(mangleResult.isSuccess());
+    name = mangleResult.result();
+  }
+  return ctx.getAddressOfSymbol(name, &library);
+}
+
+void ASTContext::loadCompilerPlugins() {
+  for (StringRef path : SearchPathOpts.getCompilerPluginLibraryPaths()) {
+    std::string errorMsg;
+    auto lib = llvm::sys::DynamicLibrary::getPermanentLibrary(
+        path.data(), &errorMsg);
+    if (!lib.isValid()) {
+      Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
+                     errorMsg);
+      continue;
+    }
+    auto moduleName = llvm::sys::path::filename(path);
+    #if !defined(_WIN32)
+    moduleName.consume_front("lib");
+    #endif
+    moduleName.consume_back(LTDL_SHLIB_EXT);
+    auto *getter = getMacroRegistrationPropertyGetter(lib, moduleName, *this);
+    if (!getter) {
+      Diags.diagnose(SourceLoc(),
+                     diag::compiler_plugin_missing_macro_declaration,
+                     moduleName, path, ALLMACROS_PROPERTY_NAME);
+      continue;
+    }
+    // Note: We don't currently have a way to poke at the contents of a Swift
+    // array `[Any.Type]` from C++. But this should not be an issue for release
+    // toolchains where user-defined macros will be used.
+    #if SWIFT_SWIFT_PARSER
+    const void *const *metatypesAddress;
+    ptrdiff_t metatypeCount;
+    swift_ASTGen_getMacroTypes(getter, &metatypesAddress, &metatypeCount);
+    ArrayRef<const void *> metatypes(metatypesAddress, metatypeCount);
+    for (const void *metatype : metatypes) {
+      CompilerPlugin plugin(metatype, lib, *this);
+      auto name = plugin.getName();
+      LoadedPlugins.try_emplace(name, std::move(plugin));
+    }
+    free(const_cast<void *>((const void *)metatypes.data()));
+    #endif
+  }
+}
+
+using WitnessTableLookupFn = const void *(const void *type,
+                                          const void *protocol);
+
+#if SWIFT_SWIFT_PARSER
+extern "C" WitnessTableLookupFn swift_conformsToProtocol;
+#endif
+
+CompilerPlugin::CompilerPlugin(const void *metadata,
+                               llvm::sys::DynamicLibrary parentLibrary,
+                               ASTContext &ctx)
+   : metadata(metadata), parentLibrary(parentLibrary)
+{
+#if !SWIFT_SWIFT_PARSER
+  auto *swift_conformsToProtocol = reinterpret_cast<WitnessTableLookupFn *>(
+      ctx.getAddressOfSymbol("swift_conformsToProtocol"));
+#endif
+  void *protocolDescriptor =
+      ctx.getAddressOfSymbol(COMPILER_PLUGIN_PROTOCOL_DESCRIPTOR);
+  witnessTable = swift_conformsToProtocol(metadata, protocolDescriptor);
+  assert(witnessTable && "Type does not conform to _CompilerPlugin");
+  auto returnedName = invokeName();
+  name = ctx.getIdentifier(returnedName).str();
+  free(const_cast<void *>((const void *)returnedName.data()));
+  kind = invokeKind();
+}
+
+namespace {
+struct CharBuffer {
+  const char *data;
+  ptrdiff_t size;
+
+  StringRef str() const {
+    return StringRef(data, (size_t)size);
+  }
+
+  NullTerminatedStringRef cstr() const {
+    return NullTerminatedStringRef(data, (size_t)size);
+  }
+};
+}
+
+StringRef CompilerPlugin::invokeName() const {
+#if __clang__
+  using Method = SWIFT_CC CharBuffer(
+      SWIFT_CONTEXT const void *, const void *, const void *);
+  auto method = getWitnessMethodUnsafe<Method>(WitnessTableEntry::Name);
+  return method(metadata, metadata, witnessTable).str();
+#else
+  llvm_unreachable("Incompatible host compiler");
+#endif
+}
+
+CompilerPlugin::Kind CompilerPlugin::invokeKind() const {
+#if __clang__
+  using Method = SWIFT_CC Kind(
+      SWIFT_CONTEXT const void *, const void *, const void *);
+  auto method = getWitnessMethodUnsafe<Method>(WitnessTableEntry::Kind);
+  return method(metadata, metadata, witnessTable);
+#else
+  llvm_unreachable("Incompatible host compiler");
+#endif
+}
+
+Optional<NullTerminatedStringRef>
+CompilerPlugin::invokeRewrite(StringRef targetModuleName,
+                              StringRef filePath,
+                              StringRef sourceFileText,
+                              CharSourceRange range,
+                              ASTContext &ctx) const {
+#if __clang__
+  using Method = SWIFT_CC CharBuffer(
+      const char *, ptrdiff_t,
+      const char *, ptrdiff_t,
+      const char *, ptrdiff_t,
+      const char *, ptrdiff_t,
+      SWIFT_CONTEXT const void *, const void *, const void *);
+  auto method = getWitnessMethodUnsafe<Method>(WitnessTableEntry::Rewrite);
+  auto result = method(
+      targetModuleName.data(), (ptrdiff_t)targetModuleName.size(),
+      filePath.data(), (ptrdiff_t)filePath.size(),
+      sourceFileText.data(), (ptrdiff_t)sourceFileText.size(),
+      range.str().data(), (ptrdiff_t)range.getByteLength(),
+      metadata, metadata, witnessTable);
+  if (!result.data)
+    return None;
+  return result.cstr();
+#else
+  llvm_unreachable("Incompatible host compiler");
+#endif
+}

--- a/lib/AST/SearchPathOptions.cpp
+++ b/lib/AST/SearchPathOptions.cpp
@@ -72,6 +72,13 @@ void ModuleSearchPathLookup::rebuildLookupTable(const SearchPathOptions *Opts,
                                 ModuleSearchPathKind::RuntimeLibrary,
                                 /*isSystem=*/true, Entry.index());
   }
+
+  for (auto Entry : llvm::enumerate(Opts->getCompilerPluginLibraryPaths())) {
+    addFilesInPathToLookupTable(FS, Entry.value(),
+                                ModuleSearchPathKind::CompilerPlugin,
+                                /*isSystem=*/false, Entry.index());
+  }
+
   State.FileSystem = FS;
   State.IsOSDarwin = IsOSDarwin;
   State.Opts = Opts;

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -55,4 +55,4 @@ add_subdirectory(SymbolGraphGen)
 add_subdirectory(Syntax)
 add_subdirectory(SyntaxParse)
 add_subdirectory(Threading)
-
+add_subdirectory(CompilerPluginSupport)

--- a/lib/CompilerPluginSupport/CMakeLists.txt
+++ b/lib/CompilerPluginSupport/CMakeLists.txt
@@ -1,0 +1,59 @@
+#===--- CMakeLists.txt - Compiler plugin support library -------------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2021 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+#===------------------------------------------------------------------------===#
+
+if(SWIFT_SWIFT_PARSER)
+
+  set(module_name "_CompilerPluginSupport")
+  set(library_name "swift${module_name}")
+
+  add_library("${library_name}" SHARED
+    CompilerPluginSupport.swift)
+
+  if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
+    set(DEPLOYMENT_VERSION "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_DEPLOYMENT_VERSION}")
+  endif()
+
+  if(SWIFT_HOST_VARIANT_SDK STREQUAL ANDROID)
+    set(DEPLOYMENT_VERSION ${SWIFT_ANDROID_API_LEVEL})
+  endif()
+
+  get_target_triple(target target_variant "${SWIFT_HOST_VARIANT_SDK}" "${SWIFT_HOST_VARIANT_ARCH}"
+    MACCATALYST_BUILD_FLAVOR ""
+    DEPLOYMENT_VERSION "${DEPLOYMENT_VERSION}")
+
+  target_compile_options("${library_name}" PRIVATE
+    $<$<COMPILE_LANGUAGE:Swift>:
+      -module-name;${module_name};
+      -enable-library-evolution;
+      -emit-module-interface;
+      -target;${target}>)
+
+  target_link_libraries("${library_name}"
+    PRIVATE
+    swiftCore
+  )
+
+  swift_install_in_component(TARGETS "${library_name}"
+    RUNTIME
+      DESTINATION "bin"
+      COMPONENT compiler
+    FRAMEWORK
+      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
+      COMPONENT compiler
+    LIBRARY
+      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
+      COMPONENT compiler
+    ARCHIVE
+      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
+      COMPONENT compiler)
+
+endif()

--- a/lib/CompilerPluginSupport/CompilerPluginSupport.swift
+++ b/lib/CompilerPluginSupport/CompilerPluginSupport.swift
@@ -1,0 +1,60 @@
+//===--- CompilerPlugin.swift - Compiler plugin library support -----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Do not modify without modifying swift::CompilerPlugin::Kind in
+// include/swift/AST/CompilerPlugin.h.
+@frozen
+public struct _CompilerPluginKind {
+  @usableFromInline
+  enum RawValue: UInt32 {
+    case expressionMacro
+  }
+  @usableFromInline var rawValue: RawValue
+
+  public static var expressionMacro: Self {
+    Self(rawValue: .expressionMacro)
+  }
+}
+
+/// A compiler plugin that can be loaded by the Swift compiler for code rewrite
+/// and custom compilation.
+public protocol _CompilerPlugin {
+  // Note:
+  // - Do not modify the protocol layout without updating
+  //   `CompilerPlugin::WitnessTableEntry`.
+  // - Use C-compatible types and tuples thereof to ensure that we can invoke
+  //   these methods from C.
+
+  static func _name() -> (UnsafePointer<UInt8>, count: Int)
+
+  static func _kind() -> _CompilerPluginKind
+
+  /// Returns new source code by transforming the given source code, or nil if
+  /// there's no transform.
+  ///
+  /// - Parameters:
+  ///   - code: A buffer containing the source code in UTF-8.
+  ///   - context: The compiler context.
+  /// - Returns: A newly allocated, null-terminated buffer containing the
+  ///   transformed source code. The caller is responsible for managing the
+  ///   memory.
+  static func _rewrite(
+    targetModuleName: UnsafePointer<UInt8>,
+    targetModuleNameCount: Int,
+    filePath: UnsafePointer<UInt8>,
+    filePathCount: Int,
+    sourceFileText: UnsafePointer<UInt8>,
+    sourceFileTextCount: Int,
+    localSourceText: UnsafePointer<UInt8>,
+    localSourceTextCount: Int
+  ) -> (UnsafePointer<UInt8>?, count: Int)
+}

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -301,6 +301,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_library_level);
   inputArgs.AddLastArg(arguments, options::OPT_enable_bare_slash_regex);
   inputArgs.AddLastArg(arguments, options::OPT_enable_experimental_cxx_interop);
+  inputArgs.AddLastArg(arguments, options::OPT_load_plugin_library);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1404,6 +1404,13 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
   // is called before setTargetTriple() and parseArgs().
   // TODO: improve the handling of RuntimeIncludePath.
 
+  std::vector<std::string> CompilerPluginLibraryPaths(
+      Opts.getCompilerPluginLibraryPaths());
+  for (const Arg *A : Args.filtered(OPT_load_plugin_library)) {
+    CompilerPluginLibraryPaths.push_back(resolveSearchPath(A->getValue()));
+  }
+  Opts.setCompilerPluginLibraryPaths(CompilerPluginLibraryPaths);
+
   return false;
 }
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5892,6 +5892,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::UnsafeSendable:
   case KnownProtocolKind::RangeReplaceableCollection:
   case KnownProtocolKind::GlobalActor:
+  case KnownProtocolKind::CompilerPlugin:
     return SpecialProtocol::None;
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -198,7 +198,7 @@ extern "C" void swift_ASTGen_buildTopLevelASTNodes(void *sourceFile,
 ///     decl-sil-stage [[only in SIL mode]
 /// \endverbatim
 void Parser::parseTopLevel(SmallVectorImpl<Decl *> &decls) {
-#ifdef SWIFT_SWIFT_PARSER
+#if SWIFT_SWIFT_PARSER
   if ((Context.LangOpts.hasFeature(Feature::Macros) ||
        Context.LangOpts.hasFeature(Feature::BuiltinMacros) ||
        Context.LangOpts.hasFeature(Feature::ParserASTGen)) &&

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -26,7 +26,7 @@
 #include "swift/Syntax/SyntaxNodes.h"
 #include "swift/SyntaxParse/SyntaxTreeCreator.h"
 
-#ifdef SWIFT_SWIFT_PARSER
+#if SWIFT_SWIFT_PARSER
 #include "SwiftCompilerSupport.h"
 #endif
 
@@ -193,7 +193,7 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
   if (auto tokens = parser.takeTokenReceiver()->finalize())
     tokensRef = ctx.AllocateCopy(*tokens);
 
-#ifdef SWIFT_SWIFT_PARSER
+#if SWIFT_SWIFT_PARSER
   if ((ctx.LangOpts.hasFeature(Feature::ParserRoundTrip) ||
        ctx.LangOpts.hasFeature(Feature::ParserValidation)) &&
       ctx.SourceMgr.getCodeCompletionBufferID() != bufferID &&

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5400,7 +5400,6 @@ namespace {
           cs.cacheExprTypes(E);
           return E;
         }
-
         // Fall through to use old implementation.
       }
 #endif

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3633,6 +3633,12 @@ namespace {
       if (ctx.LangOpts.hasFeature(Feature::Macros)) {
         auto macroIdent = expr->getMacroName().getBaseIdentifier();
         auto refType = CS.getTypeOfMacroReference(macroIdent.str(), expr);
+        if (!refType) {
+          // FIXME: This is currently hard-coded to (Int, String) just for
+          // testing Stringify, before we can parse a type signature from the
+          // macro plugin.
+          return TupleType::get({ctx.getIntType(), ctx.getStringType()}, ctx);
+        }
         if (expr->getArgs()) {
           CS.associateArgumentList(CS.getConstraintLocator(expr), expr->getArgs());
           // FIXME: Do we have object-like vs. function-like macros?

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -203,7 +203,8 @@ void SerializedModuleLoaderBase::collectVisibleTopLevelModuleNamesImpl(
       });
       return None;
     }
-    case ModuleSearchPathKind::RuntimeLibrary: {
+    case ModuleSearchPathKind::RuntimeLibrary:
+    case ModuleSearchPathKind::CompilerPlugin: {
       // Look for:
       // (Darwin OS) $PATH/{name}.swiftmodule/{arch}.{extension}
       // (Other OS)  $PATH/{name}.{extension}
@@ -613,7 +614,8 @@ SerializedModuleLoaderBase::findModule(ImportPath::Element moduleID,
 
     switch (searchPath->getKind()) {
     case ModuleSearchPathKind::Import:
-    case ModuleSearchPathKind::RuntimeLibrary: {
+    case ModuleSearchPathKind::RuntimeLibrary:
+    case ModuleSearchPathKind::CompilerPlugin: {
       isFramework = false;
 
       // On Apple platforms, we can assume that the runtime libraries use

--- a/test/Macros/Inputs/macro_definition.swift
+++ b/test/Macros/Inputs/macro_definition.swift
@@ -1,0 +1,65 @@
+import _CompilerPluginSupport
+
+struct StringifyMacro: _CompilerPlugin {
+  static func _name() -> (UnsafePointer<UInt8>, count: Int) {
+    var name = "customStringify"
+    return name.withUTF8 { buffer in
+      let result = UnsafeMutablePointer<UInt8>.allocate(capacity: buffer.count)
+      result.initialize(from: buffer.baseAddress!, count: buffer.count)
+      return (UnsafePointer(result), count: buffer.count)
+    }
+  }
+
+  static func _kind() -> _CompilerPluginKind {
+    .expressionMacro
+  }
+
+  static func _rewrite(
+    targetModuleName: UnsafePointer<UInt8>,
+    targetModuleNameCount: Int,
+    filePath: UnsafePointer<UInt8>,
+    filePathCount: Int,
+    sourceFileText: UnsafePointer<UInt8>,
+    sourceFileTextCount: Int,
+    localSourceText: UnsafePointer<UInt8>,
+    localSourceTextCount: Int
+  ) -> (UnsafePointer<UInt8>?, count: Int) {
+    let meeTextBuffer = UnsafeBufferPointer(
+      start: localSourceText, count: localSourceTextCount)
+    let meeText = String(decoding: meeTextBuffer, as: UTF8.self)
+    let prefix = "#customStringify("
+    guard meeText.starts(with: prefix), meeText.last == ")" else {
+      return (nil, 0)
+    }
+    let expr = meeText.dropFirst(prefix.count).dropLast()
+    // Or use regex...
+    //   let match = meeText.firstMatch {
+    //     "#customStringify"
+    //     ZeroOrMore {
+    //       CharacterClass(.whitespace, .newlineSequence)
+    //     }
+    //     "("
+    //     Capture(OneOrMore(.any))
+    //     ")"
+    //     ZeroOrMore {
+    //       CharacterClass(.whitespace, .newlineSequence)
+    //     }
+    //   }
+    //   guard let expr = match?.1 else {
+    //     return (nil, count: 0)
+    //   }
+
+    var resultString = "(\(expr), #\"\(expr)\"#)"
+    return resultString.withUTF8 { buffer in
+      let result = UnsafeMutableBufferPointer<UInt8>.allocate(
+          capacity: buffer.count + 1)
+      _ = result.initialize(from: buffer)
+      result[buffer.count] = 0
+      return (UnsafePointer(result.baseAddress), buffer.count)
+    }
+  }
+}
+
+public var allMacros: [Any.Type] {
+  [StringifyMacro.self]
+}

--- a/test/Macros/Inputs/macro_definition_missing_allmacros.swift
+++ b/test/Macros/Inputs/macro_definition_missing_allmacros.swift
@@ -1,0 +1,36 @@
+import _CompilerPluginSupport
+import RegexBuilder
+
+struct DummyMacro: _CompilerPlugin {
+  static func _name() -> (UnsafePointer<UInt8>, count: Int) {
+    var name = "dummy"
+    return name.withUTF8 { buffer in
+      let result = UnsafeMutablePointer<UInt8>.allocate(capacity: buffer.count)
+      result.initialize(from: buffer.baseAddress!, count: buffer.count)
+      return (UnsafePointer(result), count: buffer.count)
+    }
+  }
+
+  static func _kind() -> _CompilerPluginKind {
+    .expressionMacro
+  }
+
+  static func _rewrite(
+    targetModuleName: UnsafePointer<UInt8>,
+    targetModuleNameCount: Int,
+    filePath: UnsafePointer<UInt8>,
+    filePathCount: Int,
+    sourceFileText: UnsafePointer<UInt8>,
+    sourceFileTextCount: Int,
+    localSourceText: UnsafePointer<UInt8>,
+    localSourceTextCount: Int
+  ) -> (UnsafePointer<UInt8>?, count: Int) {
+    (nil, 0)
+  }
+}
+
+// Intentionally missing `allMacros`.
+//
+// public var allMacros: [Any.Type] {
+//   [DummyMacro.self]
+// }

--- a/test/Macros/macro_plugin.swift
+++ b/test/Macros/macro_plugin.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -I%platform-module-dir/../.. -L%platform-dylib-dir/../.. -emit-library -emit-library-path=%t/%target-library-name(MacroDefinition) -working-directory=%t -module-name=MacroDefinition %S/Inputs/macro_definition.swift
+// RUN: %target-swift-frontend -L%platform-dylib-dir/../.. -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -disable-availability-checking -dump-ast -primary-file %s | %FileCheck %s
+
+// FIXME: Swift parser is not enabled on Linux CI yet.
+// REQUIRES: OS=macosx
+
+let _ = #customStringify(1.byteSwapped + 2.advanced(by: 10))
+
+// CHECK: (macro_expansion_expr type='(Int, String)' {{.*}} name=customStringify
+// CHECK:   (argument_list
+// EXPANSION BEGINS
+// CHECK:   (tuple_expr type='(Int, String)'
+// CHECK:     (binary_expr type='Int'
+// CHECK:     (string_literal_expr type='String'

--- a/test/Macros/macro_plugin_diagnostics.swift
+++ b/test/Macros/macro_plugin_diagnostics.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -I%platform-module-dir/../.. -L%platform-dylib-dir/../.. -emit-library -emit-library-path=%t/%target-library-name(MacroDefinitionMissingAllMacros) -working-directory=%t -module-name=MacroDefinitionMissingAllMacros %S/Inputs/macro_definition_missing_allmacros.swift
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -I%platform-module-dir/../.. -L%platform-dylib-dir/../.. -emit-library -emit-library-path=%t/%target-library-name(MacroDefinition) -working-directory=%t -module-name=MacroDefinition %S/Inputs/macro_definition.swift
+// RUN: %target-swift-frontend -L%%platform-dylib-dir/../.. -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -load-plugin-library %t/%target-library-name(MacroDefinitionMissingAllMacros) -disable-availability-checking -typecheck -verify -primary-file %s 2>&1 | %FileCheck %s
+
+// FIXME: Swift parser is not enabled on Linux CI yet.
+// REQUIRES: OS=macosx
+
+// CHECK: <unknown>:{{.*}}: warning: compiler plugin module 'MacroDefinitionMissingAllMacros' (in {{.*}}/libMacroDefinitionMissingAllMacros.dylib) is missing a top-level computed property 'public var allMacros: [Any.Type]' to declare all macros; undeclared macros will be ignored
+
+let _ = #customStringify(1.byteSwapped + 2.advanced(by: 10))
+
+// expected-error @+1 {{macro 'notDefined' is undefined; use `-load-plugin-library` to specify dynamic libraries that contain this macro}}
+let _ = #notDefined
+
+// expected-error @+1 {{macro 'dummy' is undefined; use `-load-plugin-library` to specify dynamic libraries that contain this macro}}
+let _ = #dummy

--- a/test/Macros/macro_plugin_exec.swift
+++ b/test/Macros/macro_plugin_exec.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -I%platform-module-dir/../.. -L%platform-dylib-dir/../.. -emit-library -emit-library-path=%t/%target-library-name(MacroDefinition) -working-directory=%t -module-name=MacroDefinition %S/Inputs/macro_definition.swift
+// RUN: %target-build-swift -L%platform-module-dir/../.. -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) %s -o %t/main
+// RUN: %target-run %t/main
+// REQUIRES: executable_test
+
+// FIXME: Swift parser is not enabled on Linux CI yet.
+// REQUIRES: OS=macosx
+
+let (result, code) = #customStringify(3 + 2 - 1)
+print(result, code)


### PR DESCRIPTION
Allow user-defined macros to be loaded from dynamic libraries and evaluated.

- Introduce a _CompilerPluginSupport module installed into the toolchain. Its `_CompilerPlugin` protocol acts as a stable interface between the compiler and user-defined macros.
- Introduce a `-load-plugin-library <path>` attribute which allows users to specify dynamic libraries to be loaded into the compiler.

A macro library must declare a public top-level computed property `public var allMacros: [Any.Type]` and be compiled to a dynamic library. The compiler will call the getter of this property to obtain and register all macros.

Known issues:
- We current do not have a way to strip out unnecessary symbols from the plugin dylib, i.e. produce a plugin library that does not contain SwiftSyntax symbols that will collide with the compiler itself.
- `MacroExpansionExpr`'s type is hard-coded as `(Int, String)`. It should instead be specified by the macro via protocol requirements such as `signature` and `genericSignature`. We need more protocol requirements in `_CompilerPlugin` to handle this.
- `dlopen` is not secure and is only for prototyping use here.

Friend PR: apple/swift-syntax#1022