### PR TITLE
[NFC] Add a test case for missing 'try' diagnostics with existential opening.

### DIFF
--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -650,3 +650,12 @@ func callsOptionalRethrowsDefaultArg2() throws {
   optionalRethrowsDefaultArg2(nil)
   try optionalRethrowsDefaultArg2 { throw SomeError.Badness }
 }
+
+protocol P1 {
+  var id: Int { get }
+  func test(_: some Sequence) -> [any P1]
+}
+
+func open(p: any P1, s: any Sequence) throws {
+  _ = p.test(s).map(\.id)
+}


### PR DESCRIPTION
This test case broke on `main` because the `open_existential_expr` wrapped the reference to `.map`, and was subsequently fixed with https://github.com/apple/swift/pull/61609.