### PR TITLE
Fix multiple commands produce ${SWIFTLIB_DIR}/${arch_subdir}

### DIFF
--- a/stdlib/public/Cxx/cxxshim/CMakeLists.txt
+++ b/stdlib/public/Cxx/cxxshim/CMakeLists.txt
@@ -30,10 +30,6 @@ foreach(sdk ${SWIFT_SDKS})
         list(APPEND outputs "${module_dir_static}/${source}")
       endif()
     endforeach()
-    list(APPEND outputs ${module_dir})
-    if(SWIFT_BUILD_STATIC_STDLIB)
-      list(APPEND outputs ${module_dir_static})
-    endif()
 
     add_custom_target(cxxshim-${sdk}-${arch} ALL
                       DEPENDS ${outputs}


### PR DESCRIPTION
<!-- What's in this pull request? -->

Currently, the Xcode project generated using `utils/build-script --xcode` will fail due to cxxshim trying to create the ${module_dir}:

![cxxshim](https://user-images.githubusercontent.com/10842684/197942325-a5f8e8e4-c2b6-4238-a6c6-c1e7451eea9e.png)

This PR removes this step from the build phases of cxxshim (update: in the generated Xcode project only). Removing ${module_dir} from outputs is okay because files inside the module directory exists implies that the module directory itself also exists.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
