### PR TITLE
[GenericEnvironment] Add helper methods for mapping pack types to opened element types and vice versa.

### DIFF
--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -239,6 +239,14 @@ public:
   /// Map a generic parameter type to a contextual type.
   Type mapTypeIntoContext(GenericTypeParamType *type) const;
 
+  /// Map a type containing parameter packs to a contextual type
+  /// in the opened element generic context.
+  Type mapPackTypeIntoElementContext(Type type) const;
+
+  /// Map a type containing pack element type parameters to a contextual
+  /// type in the pack generic context.
+  Type mapElementTypeIntoPackContext(Type type) const;
+
   /// Map the given SIL interface type to a contextual type.
   ///
   /// This operation will also reabstract dependent types according to the

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6172,6 +6172,14 @@ public:
   /// \endcode
   bool isParameterPack() const;
 
+  /// Returns a new GenericTypeParamType with the same depth and index
+  /// as this one, with the type parameter pack bit set.
+  GenericTypeParamType *asParameterPack(ASTContext &ctx) const;
+
+  /// Returns a new GenericTypeParamType with the same depth and index
+  /// as this one, removing the type parameter pack bit.
+  GenericTypeParamType *asScalar(ASTContext &ctx) const;
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {
     return T->getKind() == TypeKind::GenericTypeParam;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5600,20 +5600,14 @@ ASTContext::getOpenedElementSignature(CanGenericSignature baseGenericSig) {
   SmallVector<GenericTypeParamType *, 2> genericParams;
   SmallVector<Requirement, 2> requirements;
 
-  auto eraseParameterPack = [&](GenericTypeParamType *paramType) {
-    return GenericTypeParamType::get(
-        /*isParameterPack=*/false, paramType->getDepth(),
-        paramType->getIndex(), *this);
-  };
-
   for (auto paramType : baseGenericSig.getGenericParams()) {
-    genericParams.push_back(eraseParameterPack(paramType));
+    genericParams.push_back(paramType->asScalar(*this));
   }
 
   auto eraseParameterPackRec = [&](Type type) -> Type {
     return type.transformRec([&](Type t) -> Optional<Type> {
       if (auto *paramType = t->getAs<GenericTypeParamType>())
-        return Type(eraseParameterPack(paramType));
+        return Type(paramType->asScalar(*this));
       return None;
     });
   };

--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -55,6 +55,20 @@ bool GenericTypeParamType::isParameterPack() const {
          GenericTypeParamType::TYPE_SEQUENCE_BIT;
 }
 
+GenericTypeParamType *
+GenericTypeParamType::asParameterPack(ASTContext &ctx) const {
+  return GenericTypeParamType::get(/*isParameterPack*/true,
+                                   getDepth(), getIndex(),
+                                   ctx);
+}
+
+GenericTypeParamType *
+GenericTypeParamType::asScalar(ASTContext &ctx) const {
+  return GenericTypeParamType::get(/*isParameterPack*/false,
+                                   getDepth(), getIndex(),
+                                   ctx);
+}
+
 /// G<{X1, ..., Xn}, {Y1, ..., Yn}>... => {G<X1, Y1>, ..., G<Xn, Yn>}...
 PackExpansionType *PackExpansionType::expand() {
   auto countType = getCountType();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7095,32 +7095,15 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     auto toExpansionType = toType->getAs<PackExpansionType>();
     auto *expansion = dyn_cast<PackExpansionExpr>(expr);
 
-    // FIXME: Duplicated code from `PackReferenceFinder` in PreCheckExpr.
-    auto toElementType = toExpansionType->getPatternType();
-    toElementType =
-        toElementType->mapTypeOutOfContext().transform([&](Type type) -> Type {
-          auto *genericParam = type->getAs<GenericTypeParamType>();
-          if (!genericParam || !genericParam->isParameterPack())
-            return type;
-
-          auto param = genericParam->asScalar(ctx);
-          return expansion->getGenericEnvironment()->mapTypeIntoContext(param);
-        });
+    auto *elementEnv = expansion->getGenericEnvironment();
+    auto toElementType = elementEnv->mapPackTypeIntoElementContext(
+        toExpansionType->getPatternType()->mapTypeOutOfContext());
 
     auto *pattern = coerceToType(expansion->getPatternExpr(),
                                  toElementType, locator);
-
-    // FIXME: Duplicated code from `visitPackExpansionExpr` in CSGen.
-    auto patternType =
-        cs.getType(pattern).transform([&](Type type) -> Type {
-          auto *element = type->getAs<ElementArchetypeType>();
-          if (!element)
-            return type;
-
-          auto *elementParam = element->mapTypeOutOfContext()->getAs<GenericTypeParamType>();
-          auto *pack = elementParam->asParameterPack(ctx);;
-          return cs.DC->mapTypeIntoContext(pack);
-        });
+    auto *packEnv = cs.DC->getGenericEnvironmentOfContext();
+    auto patternType = packEnv->mapElementTypeIntoPackContext(
+        toElementType->mapTypeOutOfContext());
     auto shapeType = toExpansionType->getCountType();
     auto expansionTy = PackExpansionType::get(patternType, shapeType);
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7103,9 +7103,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
           if (!genericParam || !genericParam->isParameterPack())
             return type;
 
-          auto param = GenericTypeParamType::get(/*isParameterPack*/false,
-                                                 genericParam->getDepth(),
-                                                 genericParam->getIndex(), ctx);
+          auto param = genericParam->asScalar(ctx);
           return expansion->getGenericEnvironment()->mapTypeIntoContext(param);
         });
 
@@ -7120,10 +7118,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
             return type;
 
           auto *elementParam = element->mapTypeOutOfContext()->getAs<GenericTypeParamType>();
-          auto *pack = GenericTypeParamType::get(/*isParameterPack*/true,
-                                                 elementParam->getDepth(),
-                                                 elementParam->getIndex(),
-                                                 ctx);
+          auto *pack = elementParam->asParameterPack(ctx);;
           return cs.DC->mapTypeIntoContext(pack);
         });
     auto shapeType = toExpansionType->getCountType();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8432,6 +8432,7 @@ ConstraintSystem::SolutionKind
 ConstraintSystem::simplifyPackElementOfConstraint(Type first, Type second,
                                                   TypeMatchOptions flags,
                                                   ConstraintLocatorBuilder locator) {
+  ASTContext &ctx = getASTContext();
   auto elementType = simplifyType(first, flags);
   auto *loc = getConstraintLocator(locator);
 
@@ -8454,10 +8455,7 @@ ConstraintSystem::simplifyPackElementOfConstraint(Type first, Type second,
       return type;
 
     auto *elementParam = element->mapTypeOutOfContext()->getAs<GenericTypeParamType>();
-    auto *pack = GenericTypeParamType::get(/*isParameterPack*/true,
-                                           elementParam->getDepth(),
-                                           elementParam->getIndex(),
-                                           this->getASTContext());
+    auto *pack = elementParam->asParameterPack(ctx);
     return this->DC->mapTypeIntoContext(pack);
   });
 

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -445,9 +445,7 @@ static Expr *getPackExpansion(DeclContext *dc, Expr *expr, SourceLoc opLoc) {
                 if (!genericParam || !genericParam->isParameterPack())
                   return type;
 
-                return GenericTypeParamType::get(/*isParameterPack*/false,
-                                                 genericParam->getDepth(),
-                                                 genericParam->getIndex(), ctx);
+                return genericParam->asScalar(ctx);
               });
 
           // Map the element interface type into the context of the opened


### PR DESCRIPTION
This change adds the following APIs
* `GenericTypeParamType::asScalar` to strip off the `isParameterPack` bit.
* `GenericTypeParamType::asParameterPack` to add the `isParameterPack` bit.
* `GenericEnvironment::mapPackTypeIntoElementContext` to map a pack interface type to its element archetype.
* `GenericEnvironment::mapElementTypeIntoPackContext` to map a pack element interface type to its pack archetype.