### PR TITLE
swift-dependency-tool: avoid redefinition of ScalarTraits<unsigned> on FreeBSD

### DIFF
--- a/tools/swift-dependency-tool/swift-dependency-tool.cpp
+++ b/tools/swift-dependency-tool/swift-dependency-tool.cpp
@@ -28,9 +28,9 @@ using namespace fine_grained_dependencies;
 // MARK: SourceFileDepGraph YAML reading & writing
 //==============================================================================
 
-// This introduces a redefinition where ever std::is_same_t<size_t, uint64_t>
-// holds
-#if !(defined(__linux__) || defined(_WIN64))
+// This introduces a redefinition wherever std::is_same_t<size_t, uint64_t>
+// holds.
+#if !(defined(__linux__) || defined(_WIN64) || defined(__FreeBSD__))
 LLVM_YAML_DECLARE_SCALAR_TRAITS(size_t, QuotingType::None)
 #endif
 LLVM_YAML_DECLARE_ENUM_TRAITS(swift::fine_grained_dependencies::NodeKind)
@@ -88,8 +88,9 @@ LLVM_YAML_DECLARE_MAPPING_TRAITS(
 
 namespace llvm {
 namespace yaml {
-// This introduces a redefinition for Linux.
-#if !(defined(__linux__) || defined(_WIN64))
+// This introduces a redefinition wherever std::is_same_t<size_t, uint64_t>
+// holds.
+#if !(defined(__linux__) || defined(_WIN64) || defined(__FreeBSD__))
 void ScalarTraits<size_t>::output(const size_t &Val, void *, raw_ostream &out) {
   out << Val;
 }


### PR DESCRIPTION
On FreeBSD, `size_t` and `uint64_t` are both typedefs of `unsigned long`.