### PR TITLE
CI: repair the build of swift-syntax

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -622,6 +622,9 @@ cmake ^
 
   -D CMAKE_INSTALL_PREFIX=%InstallRoot% ^
 
+  -D dispatch_DIR=%BuildRoot%\3\cmake\modules ^
+  -D Foundation_DIR=%BuildRoot%\4\cmake\modules ^
+
   -G Ninja ^
   -S %SourceRoot%\swift-syntax || (exit /b)
 cmake --build %BuildRoot%\16 || (exit /b)


### PR DESCRIPTION
SwiftSyntax has grown a dependency on Foundation, ensure that we wire up the dispatch and Foundation builds into the project.  This should hopefully allow us to build the toolchain on Windows again.