### PR TITLE
[AddressLowering] Storage root inherits lexical.

### DIFF
--- a/lib/SIL/IR/SILInstructions.cpp
+++ b/lib/SIL/IR/SILInstructions.cpp
@@ -2884,6 +2884,9 @@ ReturnInst::ReturnInst(SILFunction &func, SILDebugLocation debugLoc,
 
 bool OwnershipForwardingMixin::hasSameRepresentation(SILInstruction *inst) {
   switch (inst->getKind()) {
+  // Explicitly list instructions which definitely involve a representation
+  // change.
+  case SILInstructionKind::SwitchEnumInst:
   default:
     // Conservatively assume that a conversion changes representation.
     // Operations can be added as needed to participate in SIL opaque values.

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2041,6 +2041,11 @@ void PatternMatchEmission::emitEnumElementDispatch(
     // be passed take_on_success if src is an address only type.
     assert(src.getFinalConsumption() != CastConsumptionKind::TakeOnSuccess &&
            "Can only have take_on_success with address only values");
+    if (src.getType().isAddressOnly(SGF.F) &&
+        src.getOwnershipKind() == OwnershipKind::Guaranteed) {
+      // If it's an opaque value with guaranteed ownership, we need to copy.
+      src = src.copy(SGF, PatternMatchStmt);
+    }
 
     // Finally perform the enum element dispatch.
     return emitEnumElementObjectDispatch(rows, src, handleCase, outerFailure,

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -925,7 +925,7 @@ void ValueStorageMap::recordComposingUseProjection(Operand *oper,
 
   storage.isUseProjection = true;
 
-  if (EnumDecl *enumDecl = userValue->getType().getEnumOrBoundGenericEnum()) {
+  if (userValue->getType().getEnumOrBoundGenericEnum()) {
     storage.initializesEnum = true;
   }
   assert(!storage.isPhiProjection());

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -1140,7 +1140,7 @@ bool OpaqueStorageAllocation::checkStorageDominates(
     }
     // Handle both phis and terminator results.
     auto *bbArg = cast<SILPhiArgument>(incomingValue);
-    // The storage block must strictly dominate the phi.
+    // The storage block must strictly dominate the argument block.
     if (!pass.domInfo->properlyDominates(allocInst->getParent(),
                                          bbArg->getParent())) {
       return false;

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -2772,13 +2772,15 @@ void UseRewriter::visitBeginBorrowInst(BeginBorrowInst *borrow) {
 
   // Borrows are irrelevant unless they are marked lexical.
   if (borrow->isLexical()) {
-    if (auto *allocStack = dyn_cast<AllocStackInst>(address)) {
-      allocStack->setIsLexical();
-      return;
+    if (auto base = getAccessBase(address)) {
+      if (auto *allocStack = dyn_cast<AllocStackInst>(base)) {
+        allocStack->setIsLexical();
+        return;
+      }
+      // Function arguments are inherently lexical.
+      if (isa<SILFunctionArgument>(base))
+        return;
     }
-    // Function arguments are inherently lexical.
-    if (isa<SILFunctionArgument>(address))
-      return;
 
     SWIFT_ASSERT_ONLY(address->dump());
     llvm_unreachable("^^^ unknown lexical address producer");

--- a/lib/SILOptimizer/Mandatory/AddressLowering.h
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.h
@@ -32,7 +32,7 @@ namespace swift {
 ///
 /// 4. Rewritten. The definition of this opaque value is fully translated
 /// into lowered SIL. Instructions are typically materialized and rewritten at
-/// the same time. A indirect result, however, is materialized as soon as its
+/// the same time. An indirect result, however, is materialized as soon as its
 /// alloc_stack is emitted, but only rewritten once the call itself is
 /// rewritten.
 ///

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -62,6 +62,9 @@ public protocol Comparable {
   static func < (lhs: Self, rhs: Self) -> Bool
 }
 
+sil [ossa] @unknown : $@convention(thin) () -> ()
+sil [ossa] @getT : $@convention(thin) <T> () -> @out T
+sil [ossa] @getPair : $@convention(thin) <T> () -> @out Pair<T>
 sil [ossa] @takeGuaranteedObject : $@convention(thin) (@guaranteed AnyObject) -> ()
 sil [ossa] @takeIndirectClass : $@convention(thin) (@in_guaranteed C) -> ()
 sil [ossa] @takeTuple : $@convention(thin) <τ_0_0> (@in_guaranteed (τ_0_0, C)) -> ()
@@ -1225,6 +1228,51 @@ bb2(%9 : $Error):
   throw %9 : $Error
 }
 
+// CHECK-LABEL: sil [ossa] @lexical_borrow_struct_extract {{.*}} {
+// CHECK:         [[PAIR_ADDR:%[^,]+]] = alloc_stack [lexical]
+// CHECK:         [[X_ADDR:%[^,]+]] = struct_element_addr [[PAIR_ADDR]]
+// CHECK:         apply {{%[^,]+}}<T>([[X_ADDR]])
+// CHECK:         destroy_addr [[PAIR_ADDR]]
+// CHECK:         dealloc_stack [[PAIR_ADDR]]
+// CHECK-LABEL: } // end sil function 'lexical_borrow_struct_extract'
+sil [ossa] @lexical_borrow_struct_extract : $@convention(thin) <T> () -> () {
+  %getPair = function_ref @getPair : $@convention(thin) <Tee> () -> @out Pair<Tee>
+  %instance = apply %getPair<T>() : $@convention(thin) <Tee> () -> @out Pair<Tee>
+  %scope = begin_borrow %instance : $Pair<T>
+  %x = struct_extract %scope : $Pair<T>, #Pair.x
+  %lifetime = begin_borrow [lexical] %x : $T
+  %takeInGuaranteed = function_ref @takeInGuaranteed : $@convention(thin) <Tee> (@in_guaranteed Tee) -> ()
+  apply %takeInGuaranteed<T>(%lifetime) : $@convention(thin) <Tee> (@in_guaranteed Tee) -> ()
+  %unknown = function_ref @unknown : $@convention(thin) () -> ()
+  apply %unknown() : $@convention(thin) () -> ()
+  end_borrow %lifetime : $T
+  end_borrow %scope : $Pair<T>
+  destroy_value %instance : $Pair<T>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil [ossa] @lexical_borrow_struct_extract_arg {{.*}} {
+// CHECK:         [[X_ADDR:%[^,]+]] = struct_element_addr [[PAIR_ADDR]]
+// CHECK:         apply {{%[^,]+}}<T>([[X_ADDR]])
+// CHECK:         destroy_addr [[PAIR_ADDR]]
+// CHECK-LABEL: } // end sil function 'lexical_borrow_struct_extract_arg'
+sil [ossa] @lexical_borrow_struct_extract_arg : $@convention(thin) <T> (@in Pair<T>) -> () {
+entry(%instance : @owned $Pair<T>):
+  %scope = begin_borrow %instance : $Pair<T>
+  %x = struct_extract %scope : $Pair<T>, #Pair.x
+  %lifetime = begin_borrow [lexical] %x : $T
+  %takeInGuaranteed = function_ref @takeInGuaranteed : $@convention(thin) <Tee> (@in_guaranteed Tee) -> ()
+  apply %takeInGuaranteed<T>(%lifetime) : $@convention(thin) <Tee> (@in_guaranteed Tee) -> ()
+  %unknown = function_ref @unknown : $@convention(thin) () -> ()
+  apply %unknown() : $@convention(thin) () -> ()
+  end_borrow %lifetime : $T
+  end_borrow %scope : $Pair<T>
+  destroy_value %instance : $Pair<T>
+  %retval = tuple ()
+  return %retval : $()
+}
+
 sil hidden [ossa] @testBeginApplyDeadYield : $@convention(thin) <T> (@guaranteed TestGeneric<T>) -> () {
 bb0(%0 : @guaranteed $TestGeneric<T>):
   %2 = class_method %0 : $TestGeneric<T>, #TestGeneric.borrowedGeneric!read : <T> (TestGeneric<T>) -> () -> (), $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
@@ -1493,4 +1541,3 @@ bb0(%0 : @guaranteed $T):
   destroy_value %3 : $U
   return %6 : $U
 }
-

--- a/test/SILOptimizer/opaque_values_Onone.swift
+++ b/test/SILOptimizer/opaque_values_Onone.swift
@@ -8,3 +8,57 @@
 func generic_identity<T>(t: T) -> T {
   return t
 }
+
+
+enum Maybe1<T : Equatable> {
+  case nope
+  case yep(T)
+  // CHECK-LABEL: sil hidden @maybe1_compare {{.*}} {
+  // CHECK:         [[LHS_ADDR:%[^,]+]] = alloc_stack [lexical] $Maybe1
+  // CHECK:         [[RHS_ADDR:%[^,]+]] = alloc_stack [lexical] $Maybe1
+  // CHECK:         switch_enum_addr [[LHS_ADDR]] : $*Maybe1<T>, case #Maybe1.yep!enumelt: [[L_YEP:bb[0-9]+]], case #Maybe1.nope!enumelt: {{bb[0-9]+}}
+  // CHECK:       [[L_YEP]]:
+  // CHECK:         unchecked_take_enum_data_addr [[LHS_ADDR]] : $*Maybe1<T>, #Maybe1.yep!enumelt
+  // CHECK:         switch_enum_addr [[RHS_ADDR]] : $*Maybe1<T>, case #Maybe1.yep!enumelt: [[L_AND_R_YEP:bb[0-9]+]], default {{bb[0-9]+}}
+  // CHECK:       [[L_AND_R_YEP]]:
+  // CHECK:         unchecked_take_enum_data_addr [[RHS_ADDR]] : $*Maybe1<T>, #Maybe1.yep!enumelt
+  // CHECK-LABEL: } // end sil function 'maybe1_compare'
+  @_silgen_name("maybe1_compare")
+  static func compare(_ lhs: Maybe1, _ rhs: Maybe1) -> Bool {
+    switch (lhs, rhs) {
+    case (.yep(let l), .yep(let r)):
+      return l == r
+    case (.nope, .nope):
+      return true
+    default:
+      return false
+    }
+  }
+}
+
+enum Maybe2<T : Equatable> {
+  case nope
+  case yep(T, T)
+
+  // CHECK-LABEL: sil hidden @maybe2_compare {{.*}} {
+  // CHECK:         [[LHS_ADDR:%[^,]+]] = alloc_stack [lexical] $Maybe2<T>
+  // CHECK:         [[RHS_ADDR:%[^,]+]] = alloc_stack [lexical] $Maybe2<T>
+  // CHECK:         switch_enum_addr [[LHS_ADDR]] : $*Maybe2<T>, case #Maybe2.yep!enumelt: [[L_YEP:bb[0-9]+]], case #Maybe2.nope!enumelt: {{bb[0-9]+}}
+  // CHECK:       [[L_YEP]]:
+  // CHECK:         unchecked_take_enum_data_addr [[LHS_ADDR]] : $*Maybe2<T>, #Maybe2.yep!enumelt
+  // CHECK:         switch_enum_addr [[RHS_ADDR]] : $*Maybe2<T>, case #Maybe2.yep!enumelt: [[R_YEP:bb[0-9]+]], default {{bb[0-9]+}}
+  // CHECK:       [[L_AND_R_YEP]]:
+  // CHECK:         unchecked_take_enum_data_addr [[RHS_ADDR]] : $*Maybe2<T>, #Maybe2.yep!enumelt
+  // CHECK-LABEL: } // end sil function 'maybe2_compare'
+  @_silgen_name("maybe2_compare")
+  static func compare(_ lhs: Maybe2, _ rhs: Maybe2) -> Bool {
+    switch (lhs, rhs) {
+    case (.yep(let l, _), .yep(let r, _)):
+      return l == r
+    case (.nope, .nope):
+      return true
+    default:
+      return false
+    }
+  }
+}


### PR DESCRIPTION
When a `begin_borrow [lexical]` is lowered, the lifetime that it describes can't be shortened (or eliminated) when lowering.  In some cases, though, there will not be an alloc_stack corresponding directly to the value being borrowed.

In these cases, mark the whole aggregate lexical.