### PR TITLE
[NFC] Shortened SIL [init] flag.

### DIFF
--- a/docs/DifferentiableProgrammingImplementation.md
+++ b/docs/DifferentiableProgrammingImplementation.md
@@ -885,7 +885,7 @@ sil hidden [ossa] @$s4main7genericyxxlF : $@convention(thin) <T> (@in_guaranteed
 // %1                                             // users: %3, %2
 bb0(%0 : $*T, %1 : $*T):
   debug_value_addr %1 : $*T, let, name "x", argno 1 // id: %2
-  copy_addr %1 to [initialization] %0 : $*T       // id: %3
+  copy_addr %1 to [init] %0 : $*T       // id: %3
   %4 = tuple ()                                   // user: %5
   return %4 : $()                                 // id: %5
 } // end sil function '$s4main7genericyxxlF'

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -4169,7 +4169,7 @@ assign_by_wrapper
 
   sil-instruction ::= 'assign_by_wrapper' sil-operand 'to' mode? sil-operand ',' 'init' sil-operand ',' 'set' sil-operand
 
-  mode ::= '[initialization]' | '[assign]' | '[assign_wrapped_value]'
+  mode ::= '[init]' | '[assign]' | '[assign_wrapped_value]'
 
   assign_by_wrapper %0 : $S to %1 : $*T, init %2 : $F, set %3 : $G
   // $S can be a value or address type
@@ -4286,9 +4286,9 @@ copy_addr
 ::
 
   sil-instruction ::= 'copy_addr' '[take]'? sil-value
-                        'to' '[initialization]'? sil-operand
+                        'to' '[init]'? sil-operand
 
-  copy_addr [take] %0 to [initialization] %1 : $*T
+  copy_addr [take] %0 to [init] %1 : $*T
   // %0 and %1 must be of the same $*T address type
 
 Loads the value at address ``%0`` from memory and assigns a copy of it back into
@@ -4307,11 +4307,11 @@ is equivalent to::
 
 except that ``copy_addr`` may be used even if ``%0`` is of an address-only
 type. The ``copy_addr`` may be given one or both of the ``[take]`` or
-``[initialization]`` attributes:
+``[init]`` attributes:
 
 * ``[take]`` destroys the value at the source address in the course of the
   copy.
-* ``[initialization]`` indicates that the destination address is uninitialized.
+* ``[init]`` indicates that the destination address is uninitialized.
   Without the attribute, the destination address is treated as already
   initialized, and the existing value will be destroyed before the new value
   is stored.
@@ -4329,7 +4329,7 @@ operations::
     store %new to %1 : $*T
 
   // copy-initialization
-    copy_addr %0 to [initialization] %1 : $*T
+    copy_addr %0 to [init] %1 : $*T
   // is equivalent to:
     %new = load %0 : $*T
     strong_retain %new : $T
@@ -4337,7 +4337,7 @@ operations::
     store %new to %1 : $*T
 
   // take-initialization
-    copy_addr [take] %0 to [initialization] %1 : $*T
+    copy_addr [take] %0 to [init] %1 : $*T
   // is equivalent to:
     %new = load %0 : $*T
     // no retain of %new!
@@ -4355,9 +4355,9 @@ explicit_copy_addr
 ::
 
   sil-instruction ::= 'explicit_copy_addr' '[take]'? sil-value
-                        'to' '[initialization]'? sil-operand
+                        'to' '[init]'? sil-operand
 
-  explicit_copy_addr [take] %0 to [initialization] %1 : $*T
+  explicit_copy_addr [take] %0 to [init] %1 : $*T
   // %0 and %1 must be of the same $*T address type
 
 This instruction is exactly the same as `copy_addr`_ except that it has special
@@ -4789,14 +4789,14 @@ store_weak
 
 ::
 
-  sil-instruction ::= 'store_weak' sil-value 'to' '[initialization]'? sil-operand
+  sil-instruction ::= 'store_weak' sil-value 'to' '[init]'? sil-operand
 
-  store_weak %0 to [initialization] %1 : $*@sil_weak Optional<T>
+  store_weak %0 to [init] %1 : $*@sil_weak Optional<T>
   // $T must be an optional wrapping a reference type
 
 Initializes or reassigns a weak reference.  The operand may be ``nil``.
 
-If ``[initialization]`` is given, the weak reference must currently either be
+If ``[init]`` is given, the weak reference must currently either be
 uninitialized or destroyed.  If it is not given, the weak reference must
 currently be initialized. After the evaluation:
 
@@ -6019,7 +6019,7 @@ an `inject_enum_addr`_ instruction::
   entry(%0 : $*AddressOnlyEnum, %1 : $*AddressOnlyType):
     // Store the data argument for the case.
     %2 = init_enum_data_addr %0 : $*AddressOnlyEnum, #AddressOnlyEnum.HasData!enumelt
-    copy_addr [take] %2 to [initialization] %1 : $*AddressOnlyType
+    copy_addr [take] %2 to [init] %1 : $*AddressOnlyType
     // Inject the tag.
     inject_enum_addr %0 : $*AddressOnlyEnum, #AddressOnlyEnum.HasData!enumelt
     return

--- a/docs/proposals/InoutCOWOptimization.rst
+++ b/docs/proposals/InoutCOWOptimization.rst
@@ -202,7 +202,7 @@ To work with opaque types, ``copy_addr`` must also be able to perform an
 an original value. This can be an additional attribute on the source, mutually
 exclusive with ``[take]``::
 
-  copy_addr [inout] %a to [initialization] %b
+  copy_addr [inout] %a to [init] %b
 
 This implies that value witness tables will need witnesses for
 inout-initialization and inout-reassignment.

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1706,7 +1706,7 @@ public:
     case AssignByWrapperInst::Unknown:
       break;
     case AssignByWrapperInst::Initialization:
-      *this << "[initialization] ";
+      *this << "[init] ";
       break;
     case AssignByWrapperInst::Assign:
       *this << "[assign] ";
@@ -1771,7 +1771,7 @@ public:
   void visitStore##Name##Inst(Store##Name##Inst *SI) { \
     *this << Ctx.getID(SI->getSrc()) << " to "; \
     if (SI->isInitializationOfDest()) \
-      *this << "[initialization] "; \
+      *this << "[init] "; \
     *this << getIDAndType(SI->getDest()); \
   }
 #include "swift/AST/ReferenceStorage.def"
@@ -1781,7 +1781,7 @@ public:
       *this << "[take] ";
     *this << Ctx.getID(CI->getSrc()) << " to ";
     if (CI->isInitializationOfDest())
-      *this << "[initialization] ";
+      *this << "[init] ";
     *this << getIDAndType(CI->getDest());
   }
 
@@ -1790,7 +1790,7 @@ public:
       *this << "[take] ";
     *this << Ctx.getID(CI->getSrc()) << " to ";
     if (CI->isInitializationOfDest())
-      *this << "[initialization] ";
+      *this << "[init] ";
     *this << getIDAndType(CI->getDest());
   }
 

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -2241,7 +2241,7 @@ static bool parseAssignByWrapperMode(AssignByWrapperInst::Mode &Result,
   // Then try to parse one of our other initialization kinds. We do not support
   // parsing unknown here so we use that as our fail value.
   auto Tmp = llvm::StringSwitch<AssignByWrapperInst::Mode>(Str)
-        .Case("initialization", AssignByWrapperInst::Initialization)
+        .Case("init", AssignByWrapperInst::Initialization)
         .Case("assign", AssignByWrapperInst::Assign)
         .Case("assign_wrapped_value", AssignByWrapperInst::AssignWrappedValue)
         .Default(AssignByWrapperInst::Unknown);
@@ -4403,7 +4403,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     if (parseValueName(from) ||
         parseSILIdentifier(toToken, toLoc, diag::expected_tok_in_sil_instr,
                            "to") ||
-        (isRefStorage && parseSILOptional(isInit, *this, "initialization")) ||
+        (isRefStorage && parseSILOptional(isInit, *this, "init")) ||
         parseTypedValueRef(addrVal, addrLoc, B) ||
         parseSILDebugLocation(InstLoc, B))
       return true;
@@ -5011,7 +5011,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       if (parseSILOptional(IsTake, *this, "take") || parseValueName(SrcLName) ||
           parseSILIdentifier(ToToken, ToLoc, diag::expected_tok_in_sil_instr,
                              "to") ||
-          parseSILOptional(IsInit, *this, "initialization") ||
+          parseSILOptional(IsInit, *this, "init") ||
           parseTypedValueRef(DestLVal, DestLoc, B) ||
           parseSILDebugLocation(InstLoc, B))
         return true;
@@ -5041,7 +5041,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       if (parseSILOptional(IsTake, *this, "take") || parseValueName(SrcLName) ||
           parseSILIdentifier(ToToken, ToLoc, diag::expected_tok_in_sil_instr,
                              "to") ||
-          parseSILOptional(IsInit, *this, "initialization") ||
+          parseSILOptional(IsInit, *this, "init") ||
           parseTypedValueRef(DestLVal, DestLoc, B) ||
           parseSILDebugLocation(InstLoc, B))
         return true;

--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -2289,7 +2289,7 @@ void PullbackCloner::Implementation::accumulateAdjointForOptional(
     //                                 #Optional.some!enumelt
     auto *enumAddr = builder.createInitEnumDataAddr(
         pbLoc, optArgBuf, someEltDecl, wrappedTanType.getAddressType());
-    // copy_addr %wrappedAdjoint to [initialization] %enumAddr
+    // copy_addr %wrappedAdjoint to [init] %enumAddr
     builder.createCopyAddr(pbLoc, wrappedAdjoint, enumAddr, IsNotTake,
                            IsInitialization);
     // inject_enum_addr %optArgBuf : $*Optional<T.TangentVector>,

--- a/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/ExistentialTransform.cpp
@@ -198,7 +198,7 @@ void ExistentialSpecializerCloner::cloneArguments(
       /// bb0(%0 : $*T):
       /// %3 = alloc_stack $P
       /// %4 = init_existential_addr %3 : $*P, $T
-      /// copy_addr [take] %0 to [initialization] %4 : $*T
+      /// copy_addr [take] %0 to [init] %4 : $*T
       /// %7 = open_existential_addr immutable_access %3 : $*P to
       /// $*@opened P
       auto *ASI =

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -1581,9 +1581,9 @@ namespace {
 //     br bb3(val0, val1)
 //   bb2:
 //     temp = alloc_stack
-//     copy_addr [take] addr0 to [initialization] temp
-//     copy_addr [take] addr1 to [initialization] addr0
-//     copy_addr [take] temp to [initialization] addr1
+//     copy_addr [take] addr0 to [init] temp
+//     copy_addr [take] addr1 to [init] addr0
+//     copy_addr [take] temp to [init] addr1
 //     dealloc_stack temp
 //     br bb3(val1, val1)
 //   bb3(phi0, phi1):

--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -26,7 +26,7 @@
 // Useless copies of address-only types look like this:
 //
 // %copy = alloc_stack $T
-// copy_addr %arg to [initialization] %copy : $*T
+// copy_addr %arg to [init] %copy : $*T
 // %ret = apply %callee<T>(%copy) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
 // dealloc_stack %copy : $*T
 // destroy_addr %arg : $*T
@@ -927,7 +927,7 @@ static DeallocStackInst *getSingleDealloc(AllocStackInst *ASI) {
 /// %copy = alloc_stack $T
 /// ...
 /// CurrentBlock:
-/// copy_addr %arg to [initialization] %copy : $*T
+/// copy_addr %arg to [init] %copy : $*T
 /// ...
 /// %ret = apply %callee<T>(%copy) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
 /// \endcode
@@ -1252,7 +1252,7 @@ void CopyForwarding::forwardCopiesOf(SILValue Def, SILFunction *F) {
 ///   %2 = alloc_stack $T
 /// ... // arbitrary control flow, but no other uses of %0
 /// bbN:
-///   copy_addr [take] %2 to [initialization] %0 : $*T
+///   copy_addr [take] %2 to [init] %0 : $*T
 ///   ... // no writes
 ///   return
 static bool canNRVO(CopyAddrInst *CopyInst) {
@@ -1264,7 +1264,7 @@ static bool canNRVO(CopyAddrInst *CopyInst) {
   //   bb0(%in : $*T, %out : $T):
   //     %local = alloc_stack $T
   //     store %in to %local : $*T
-  //     copy_addr %local to [initialization] %out : $*T
+  //     copy_addr %local to [init] %out : $*T
   if (!CopyInst->isTakeOfSrc())
     return false;
 
@@ -1350,7 +1350,7 @@ class CopyForwardingPass : public SILFunctionTransform
     //   %ref = load %objaddr : $*AnyObject
     //   %alloc2 = alloc_stack $ObjWrapper
     //   # The in-memory reference is destroyed before retaining the loaded ref.
-    //   copy_addr [take] %alloc1 to [initialization] %alloc2 : $*ObjWrapper
+    //   copy_addr [take] %alloc1 to [init] %alloc2 : $*ObjWrapper
     //   retain_value %ref : $AnyObject
     //   destroy_addr %alloc2 : $*ObjWrapper
     if (!getFunction()->hasOwnership())

--- a/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
+++ b/lib/SILOptimizer/Transforms/SILLowerAggregateInstrs.cpp
@@ -87,7 +87,7 @@ static bool shouldExpandShim(SILFunction *fn, SILType type) {
 ///     strong_release %old : $T
 ///     store %new to %1 : $*T
 ///
-/// copy_addr %0 to [initialization] %1 : $*T
+/// copy_addr %0 to [init] %1 : $*T
 /// ->
 ///     %new = load [copy] %0 : $*T
 ///     store %new to [init] %1 : $*T
@@ -97,7 +97,7 @@ static bool shouldExpandShim(SILFunction *fn, SILType type) {
 ///     // no load/release of %old!
 ///     store %new to %1 : $*T
 ///
-/// copy_addr [take] %0 to [initialization] %1 : $*T
+/// copy_addr [take] %0 to [init] %1 : $*T
 /// ->
 ///     %new = load [take] %0 : $*T
 ///     store %new to [init] %1 : $*T

--- a/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
@@ -943,7 +943,7 @@ void SSADestroyHoisting::run() {
   // instruction into
   //
   //     destroy_addr
-  //     copy_addr to [initialization]
+  //     copy_addr to [init]
   //
   // sequences to create still more destroy_addrs to hoist.
   //

--- a/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
+++ b/lib/SILOptimizer/Transforms/TempRValueElimination.cpp
@@ -55,7 +55,7 @@ namespace {
 /// are emitted as copies...
 ///
 ///   %temp = alloc_stack $T
-///   copy_addr %src to [initialization] %temp : $*T
+///   copy_addr %src to [init] %temp : $*T
 ///   // no writes to %src or %temp
 ///   destroy_addr %temp : $*T
 ///   dealloc_stack %temp : $*T
@@ -70,7 +70,7 @@ namespace {
 /// a simple form of redundant-load-elimination (RLE).
 ///
 ///   %temp = alloc_stack $T
-///   store %src to [initialization] %temp : $*T
+///   store %src to [init] %temp : $*T
 ///   // no writes to %temp
 ///   %v = load [take] %temp : $*T
 ///   dealloc_stack %temp : $*T
@@ -379,7 +379,7 @@ SILInstruction *TempRValueOptPass::getLastUseWhileSourceIsNotModified(
 /// of the temporary. For example:
 ///
 ///   %a = begin_access %src
-///   copy_addr %a to [initialization] %temp : $*T
+///   copy_addr %a to [init] %temp : $*T
 ///   end_access %a
 ///   use %temp
 ///
@@ -586,8 +586,8 @@ void TempRValueOptPass::tryOptimizeCopyIntoTemp(CopyAddrInst *copyInst) {
   // re-initialized by exactly this instruction.
   // This is a corner case, but can happen if lastLoadInst is a copy_addr.
   // Example:
-  //   copy_addr [take] %copySrc to [initialization] %tempObj   // copyInst
-  //   copy_addr [take] %tempObj to [initialization] %copySrc   // lastLoadInst
+  //   copy_addr [take] %copySrc to [init] %tempObj   // copyInst
+  //   copy_addr [take] %tempObj to [init] %copySrc   // lastLoadInst
   if (needToInsertDestroy && lastLoadInst != copyInst &&
       !isa<DestroyAddrInst>(lastLoadInst) &&
       aa->mayWriteToMemory(lastLoadInst, copySrc))

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -1531,9 +1531,9 @@ ConstExprFunctionState::initializeAddressFromSingleWriter(SILValue addr) {
       // Try finding a writer among the users of `teai`. For example:
       //   %179 = alloc_stack $(Int32, Int32, Int32, Int32)
       //   %183 = tuple_element_addr %179 : $*(Int32, Int32, Int32, Int32), 3
-      //   copy_addr %114 to [initialization] %183 : $*Int32
+      //   copy_addr %114 to [init] %183 : $*Int32
       //   %191 = tuple_element_addr %179 : $*(Int32, Int32, Int32, Int32), 3
-      //   copy_addr [take] %191 to [initialization] %178 : $*Int32
+      //   copy_addr [take] %191 to [init] %178 : $*Int32
       //
       // The workflow is: when const-evaluating %178, we const-evaluate %191,
       // which in turn triggers const-evaluating %179, thereby enter this

--- a/lib/SILOptimizer/Utils/Existential.cpp
+++ b/lib/SILOptimizer/Utils/Existential.cpp
@@ -27,7 +27,7 @@ using namespace swift;
 /// %5 = alloc_ref $SomeC
 /// store %5 to %4 : $*SomeC
 /// %8 = alloc_stack $SomeP
-/// copy_addr %3 to [initialization] %8 : $*SomeP
+/// copy_addr %3 to [init] %8 : $*SomeP
 /// %10 = apply %9(%3) : $@convention(thin) (@in_guaranteed SomeP)
 /// Assumptions: Insn is a direct user of GAI (e.g., copy_addr or 
 /// apply pattern shown above) and that a valid init_existential_addr 

--- a/test/AutoDiff/SIL/sil_differentiability_witness.sil
+++ b/test/AutoDiff/SIL/sil_differentiability_witness.sil
@@ -137,7 +137,7 @@ sil_differentiability_witness [reverse] [parameters 0] [results 0] @foo : $@conv
 
 sil hidden [ossa] @generic : $@convention(thin) <T> (@in_guaranteed T, Float) -> @out T {
 bb0(%0 : $*T, %1 : $*T, %2 : $Float):
-  copy_addr %1 to [initialization] %0 : $*T
+  copy_addr %1 to [init] %0 : $*T
   %void = tuple ()
   return %void : $()
 }

--- a/test/AutoDiff/SILGen/autodiff_builtins.swift
+++ b/test/AutoDiff/SILGen/autodiff_builtins.swift
@@ -81,7 +81,7 @@ func applyDerivative_f1_vjp<T: AdditiveArithmetic & Differentiable>(t0: T) -> (T
 // CHECK: [[D_RESULT_BUFFER_0_FOR_LOAD:%.*]] = tuple_element_addr [[D_RESULT_BUFFER]] : ${{.*}}, 0
 // CHECK: [[D_RESULT_BUFFER_1_FOR_LOAD:%.*]] = tuple_element_addr [[D_RESULT_BUFFER]] : ${{.*}}, 1
 // CHECK: [[PULLBACK:%.*]] = load [take] [[D_RESULT_BUFFER_1_FOR_LOAD]]
-// CHECK: copy_addr [take] [[D_RESULT_BUFFER_0_FOR_LOAD]] to [initialization] [[ORIG_RESULT_OUT_PARAM]]
+// CHECK: copy_addr [take] [[D_RESULT_BUFFER_0_FOR_LOAD]] to [init] [[ORIG_RESULT_OUT_PARAM]]
 // CHECK: return [[PULLBACK]]
 
 struct ExamplePullbackStruct<T: Differentiable> {

--- a/test/AutoDiff/SILOptimizer/differentiation_control_flow_sil.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_control_flow_sil.swift
@@ -199,7 +199,7 @@ func enum_addr_notactive<T>(_ e: AddressOnlyEnum<T>, _ x: Float) -> Float {
 // CHECK-SIL-LABEL: sil hidden [ossa] @enum_addr_notactivelTJrUSpSr : $@convention(thin) <τ_0_0> (@in_guaranteed AddressOnlyEnum<τ_0_0>, Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
 // CHECK-SIL: bb0([[ENUM_ARG:%.*]] : $*AddressOnlyEnum<τ_0_0>, [[X_ARG:%.*]] : $Float):
 // CHECK-SIL:   [[ENUM_ADDR:%.*]] = alloc_stack $AddressOnlyEnum<τ_0_0>
-// CHECK-SIL:   copy_addr [[ENUM_ARG]] to [initialization] [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>
+// CHECK-SIL:   copy_addr [[ENUM_ARG]] to [init] [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>
 // CHECK-SIL:   [[BB0_PB_STRUCT:%.*]] = struct $_AD__enum_addr_notactive_bb0__PB__src_0_wrt_1_l<τ_0_0> ()
 // CHECK-SIL:   switch_enum_addr [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>, case #AddressOnlyEnum.none!enumelt: bb1, case #AddressOnlyEnum.some!enumelt: bb2
 

--- a/test/AutoDiff/SILOptimizer/differentiation_function_canonicalization.sil
+++ b/test/AutoDiff/SILOptimizer/differentiation_function_canonicalization.sil
@@ -84,9 +84,9 @@ bb0(%0 : $*T):
 // CHECK: bb0([[ARG:%.*]] : $*T):
 // CHECK:  [[ORIG_FN:%.*]] = witness_method $T, #Protocol.method
 // CHECK:  [[ARGCOPY1:%.*]] = alloc_stack $T
-// CHECK:  copy_addr [[ARG]] to [initialization] [[ARGCOPY1]] : $*T
+// CHECK:  copy_addr [[ARG]] to [init] [[ARGCOPY1]] : $*T
 // CHECK:  [[ARGCOPY2:%.*]] = alloc_stack $T
-// CHECK:  copy_addr [[ARG]] to [initialization] [[ARGCOPY2]] : $*T
+// CHECK:  copy_addr [[ARG]] to [init] [[ARGCOPY2]] : $*T
 // CHECK:  [[ORIG_FN_PARTIALLY_APPLIED:%.*]] = partial_apply [callee_guaranteed] [[ORIG_FN]]<T>([[ARG]])
 // CHECK:  [[JVP_FN:%.*]] = witness_method $T, #Protocol.method!jvp.SU
 // CHECK:  [[JVP_FN_PARTIALLY_APPLIED:%.*]] = partial_apply [callee_guaranteed] [[JVP_FN]]<T>([[ARGCOPY1]])

--- a/test/AutoDiff/SILOptimizer/semantic_member_accessors_sil.swift
+++ b/test/AutoDiff/SILOptimizer/semantic_member_accessors_sil.swift
@@ -55,7 +55,7 @@ func trigger<T: Differentiable>(_ x: T.Type) {
 // CHECK:   destroy_addr [[ADJ_X]] : $*τ_0_0.TangentVector
 // CHECK:   [[ZERO_FN:%.*]] = witness_method $τ_0_0.TangentVector, #AdditiveArithmetic.zero!getter
 // CHECK:   apply [[ZERO_FN]]<τ_0_0.TangentVector>([[ADJ_X]], {{.*}})
-// CHECK:   copy_addr [take] [[ADJ_X_TMP]] to [initialization] [[ADJ_X_RESULT]] : $*τ_0_0.TangentVector
+// CHECK:   copy_addr [take] [[ADJ_X_TMP]] to [init] [[ADJ_X_RESULT]] : $*τ_0_0.TangentVector
 // CHECK:   dealloc_stack [[ADJ_X_TMP]] : $*τ_0_0.TangentVector
 // CHECK:   return {{.*}} : $()
 // CHECK: }
@@ -64,13 +64,13 @@ func trigger<T: Differentiable>(_ x: T.Type) {
 // CHECK: bb0([[ADJ_SELF_RESULT:%.*]] : $*Generic<τ_0_0>.TangentVector, [[SEED:%.*]] : $*τ_0_0.TangentVector, {{.*}} : ${{.*}}):
 // CHECK:   [[ADJ_SELF_TMP:%.*]] = alloc_stack $Generic<τ_0_0>.TangentVector
 // CHECK:   [[SEED_COPY:%.*]] = alloc_stack $τ_0_0.TangentVector
-// CHECK:   copy_addr [[SEED]] to [initialization] [[SEED_COPY]] : $*τ_0_0.TangentVector
+// CHECK:   copy_addr [[SEED]] to [init] [[SEED_COPY]] : $*τ_0_0.TangentVector
 // CHECK:   [[ADJ_X:%.*]] = struct_element_addr [[ADJ_SELF_TMP]] : $*Generic<τ_0_0>.TangentVector, #Generic.TangentVector.x
-// CHECK:   copy_addr [take] [[SEED_COPY]] to [initialization] [[ADJ_X]] : $*τ_0_0.TangentVector
+// CHECK:   copy_addr [take] [[SEED_COPY]] to [init] [[ADJ_X]] : $*τ_0_0.TangentVector
 // CHECK:   [[ADJ_Y:%.*]] = struct_element_addr [[ADJ_SELF_TMP]] : $*Generic<τ_0_0>.TangentVector, #Generic.TangentVector.y
 // CHECK:   [[ZERO_FN:%.*]] = witness_method $τ_0_0.TangentVector, #AdditiveArithmetic.zero!getter
 // CHECK:   apply [[ZERO_FN]]<τ_0_0.TangentVector>([[ADJ_Y]], {{.*}})
-// CHECK:   copy_addr [take] [[ADJ_SELF_TMP]] to [initialization] [[ADJ_SELF_RESULT]] : $*Generic<τ_0_0>.TangentVector
+// CHECK:   copy_addr [take] [[ADJ_SELF_TMP]] to [init] [[ADJ_SELF_RESULT]] : $*Generic<τ_0_0>.TangentVector
 // CHECK:   dealloc_stack [[SEED_COPY]] : $*τ_0_0.TangentVector
 // CHECK:   dealloc_stack [[ADJ_SELF_TMP]] : $*Generic<τ_0_0>.TangentVector
 // CHECK:   return {{.*}} : $()

--- a/test/IRGen/access_markers.sil
+++ b/test/IRGen/access_markers.sil
@@ -153,7 +153,7 @@ bb0(%0 : $A):
   %1 = alloc_stack $Any
   %2 = ref_element_addr %0 : $A, #A.exProperty
   %3 = begin_access [dynamic] [read] %2 : $*Any
-  copy_addr %2 to [initialization] %1 : $*Any
+  copy_addr %2 to [init] %1 : $*Any
   end_access %3 : $*Any
   destroy_addr %1 : $*Any
   dealloc_stack %1 : $*Any
@@ -169,7 +169,7 @@ bb0(%0 : $A):
   %2 = ref_element_addr %0 : $A, #A.property
   // CHECK: call void @swift_beginAccess(i8* %{{.*}}, [[BUFFER]]* %{{.*}}, [[SIZE]] 0, i8* null)
   %3 = begin_access [read] [dynamic] [no_nested_conflict] %2 : $*Int64
-  copy_addr %3 to [initialization] %1 : $*Int64
+  copy_addr %3 to [init] %1 : $*Int64
   // CHECK-NOT: end_access
   end_access %3 : $*Int64
   %9 = alloc_stack $Builtin.UnsafeValueBuffer

--- a/test/IRGen/archetype_resilience.sil
+++ b/test/IRGen/archetype_resilience.sil
@@ -22,7 +22,7 @@ public enum EnumWithClassArchetypeAndDynamicSize<T : AnyObject> {
 sil [ossa] @copyDynamicMultiEnum : $@convention(method) <T, U where T: AnyObject> (@in_guaranteed EnumWithClassArchetypeAndDynamicSize<T>) -> () {
 bb0(%0 : $*EnumWithClassArchetypeAndDynamicSize<T>):
   %1 = alloc_stack $EnumWithClassArchetypeAndDynamicSize<T> 
-  copy_addr %0 to [initialization] %1 : $*EnumWithClassArchetypeAndDynamicSize<T>
+  copy_addr %0 to [init] %1 : $*EnumWithClassArchetypeAndDynamicSize<T>
   destroy_addr %1 : $*EnumWithClassArchetypeAndDynamicSize<T>
   dealloc_stack %1 : $*EnumWithClassArchetypeAndDynamicSize<T>
   %ret = tuple ()

--- a/test/IRGen/async/partial_apply.sil
+++ b/test/IRGen/async/partial_apply.sil
@@ -563,9 +563,9 @@ entry(%0 : $EmptyType, %1: $*SomeType):
   store %0 to %5 : $*EmptyType
   %31 = function_ref @foo : $@async @convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Proto1, τ_0_1 : Proto2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> ()
   %32 = alloc_stack $EmptyType
-  copy_addr %5 to [initialization] %32 : $*EmptyType
+  copy_addr %5 to [init] %32 : $*EmptyType
   %34 = alloc_stack $SomeType
-  copy_addr %1 to [initialization] %34 : $*SomeType // id: %35
+  copy_addr %1 to [init] %34 : $*SomeType // id: %35
   %36 = partial_apply [callee_guaranteed] %31<EmptyType, SomeType>(%32, %34) : $@async @convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Proto1, τ_0_1 : Proto2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> ()
   release_value %36: $@async @callee_guaranteed () ->()
   dealloc_stack %34 : $*SomeType
@@ -593,9 +593,9 @@ entry(%0 : $EmptyType, %1: $*SomeType, %3: $FixedType):
   store %3 to %7 : $*FixedType
   %31 = function_ref @foo2 : $@async @convention(thin) <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1, @in_guaranteed τ_0_2) -> ()
   %32 = alloc_stack $EmptyType
-  copy_addr %5 to [initialization] %32 : $*EmptyType
+  copy_addr %5 to [init] %32 : $*EmptyType
   %34 = alloc_stack $SomeType
-  copy_addr %1 to [initialization] %34 : $*SomeType // id: %35
+  copy_addr %1 to [init] %34 : $*SomeType // id: %35
   %36 = partial_apply [callee_guaranteed] %31<FixedType, EmptyType, SomeType>(%7, %32, %34) : $@async @convention(thin) <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1, @in_guaranteed τ_0_2) -> ()
   release_value %36: $@async @callee_guaranteed () ->()
   dealloc_stack %34 : $*SomeType

--- a/test/IRGen/async/run-call-existential-to-void.sil
+++ b/test/IRGen/async/run-call-existential-to-void.sil
@@ -45,7 +45,7 @@ bb0(%existential : $*P):
   %existential_addr = open_existential_addr immutable_access %existential : $*P to $*@opened("B2796A9C-FEBE-11EA-84BB-D0817AD71B77", P) Self
   %any = alloc_stack $Any
   %any_addr = init_existential_addr %any : $*Any, $@opened("B2796A9C-FEBE-11EA-84BB-D0817AD71B77", P) Self
-  copy_addr %existential_addr to [initialization] %any_addr : $*@opened("B2796A9C-FEBE-11EA-84BB-D0817AD71B77", P) Self
+  copy_addr %existential_addr to [init] %any_addr : $*@opened("B2796A9C-FEBE-11EA-84BB-D0817AD71B77", P) Self
   %printAny = function_ref @printAny : $@convention(thin) (@in_guaranteed Any) -> ()
   %result = apply %printAny(%any) : $@convention(thin) (@in_guaranteed Any) -> ()
   destroy_addr %any : $*Any

--- a/test/IRGen/async/run-call-generic-to-generic.sil
+++ b/test/IRGen/async/run-call-generic-to-generic.sil
@@ -24,7 +24,7 @@ sil public_external @printInt64 : $@convention(thin) (Int64) -> ()
 // CHECK-LL: define hidden swift{{(tail)?}}cc void @genericToGeneric(
 sil hidden @genericToGeneric : $@async @convention(thin) <T> (@in_guaranteed T) -> @out T {
 bb0(%out : $*T, %in : $*T):
-  copy_addr %in to [initialization] %out : $*T
+  copy_addr %in to [init] %out : $*T
   %result = tuple ()
   return %result : $()
 }

--- a/test/IRGen/async/run-call-void-to-existential.sil
+++ b/test/IRGen/async/run-call-void-to-existential.sil
@@ -49,7 +49,7 @@ bb0(%out : $*P):
   %existential = alloc_stack $P
   %existential_addr = init_existential_addr %existential : $*P, $S
   store %instance to %existential_addr : $*S
-  copy_addr %existential to [initialization] %out : $*P
+  copy_addr %existential to [init] %out : $*P
   destroy_addr %existential : $*P
   dealloc_stack %existential : $*P
   %result = tuple ()
@@ -64,7 +64,7 @@ bb0:
   %existential_addr = open_existential_addr immutable_access %existential : $*P to $*@opened("1819CC6E-FEC6-11EA-876D-D0817AD71B77", P) Self
   %any = alloc_stack $Any
   %any_addr = init_existential_addr %any : $*Any, $@opened("1819CC6E-FEC6-11EA-876D-D0817AD71B77", P) Self
-  copy_addr %existential_addr to [initialization] %any_addr : $*@opened("1819CC6E-FEC6-11EA-876D-D0817AD71B77", P) Self
+  copy_addr %existential_addr to [init] %any_addr : $*@opened("1819CC6E-FEC6-11EA-876D-D0817AD71B77", P) Self
   %printAny = function_ref @printAny : $@convention(thin) (@in_guaranteed Any) -> ()
   %result = apply %printAny(%any) : $@convention(thin) (@in_guaranteed Any) -> ()
   destroy_addr %any : $*Any

--- a/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
+++ b/test/IRGen/async/run-call_generic-protocolwitness_instance-generic-to-int64-and-generic.sil
@@ -42,7 +42,7 @@ bb0(%out_addr : $*T, %in_addr : $*T, %self : $I):
   %printGeneric_result = apply %printGeneric<I>(%self_addr) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
   dealloc_stack %self_addr : $*I
   %value = struct_extract %self : $I, #I.int
-  copy_addr %in_addr to [initialization] %out_addr : $*T
+  copy_addr %in_addr to [init] %out_addr : $*T
   return %value : $Int64
 }
 

--- a/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-inout-generic-and-in-generic-to-generic.sil
@@ -28,7 +28,7 @@ entry(%out : $*T, %in : $*T, %inout : $*T):
   %printGeneric = function_ref @printGeneric : $@convention(thin) <T> (@in_guaranteed T) -> ()
   %printGeneric_result1 = apply %printGeneric<T>(%in) : $@convention(thin) <T> (@in_guaranteed T) -> () // CHECK: 876
   %printGeneric_result2 = apply %printGeneric<T>(%inout) : $@convention(thin) <T> (@in_guaranteed T) -> () // CHECK: 678
-  copy_addr %inout to [initialization] %out : $*T
+  copy_addr %inout to [init] %out : $*T
   %result = tuple ()
   return %result : $()
 }

--- a/test/IRGen/async/run-partialapply-capture-int64-to-generic.sil
+++ b/test/IRGen/async/run-partialapply-capture-int64-to-generic.sil
@@ -33,7 +33,7 @@ entry(%out_t : $*T, %x : $Int32, %in_t : $*T):
   %printInt32 = function_ref @printInt32 : $@convention(thin) (Int32) -> ()
   %result = apply %printGeneric<T>(%in_t) : $@convention(thin) <T> (@in_guaranteed T) -> () // CHECK: 1
   %printInt32_result = apply %printInt32(%x) : $@convention(thin) (Int32) -> () // CHECK: 6789
-  copy_addr %in_t to [initialization] %out_t : $*T
+  copy_addr %in_t to [init] %out_t : $*T
   return %result : $()
 }
 

--- a/test/IRGen/big_types_coroutine.sil
+++ b/test/IRGen/big_types_coroutine.sil
@@ -100,7 +100,7 @@ bb2:
 
 // CHECK-LABEL: sil @test_yield_and_retain
 // CHECK:   [[S:%[0-9]+]] = alloc_stack $BigStruct
-// CHECK:   copy_addr [take] %0 to [initialization] [[S]]
+// CHECK:   copy_addr [take] %0 to [init] [[S]]
 // CHECK:   retain_value_addr [[S]]
 // CHECK:   yield [[S]] : $*BigStruct
 // CHECK: // end sil function 'test_yield_and_retain'

--- a/test/IRGen/bitcast.sil
+++ b/test/IRGen/bitcast.sil
@@ -122,7 +122,7 @@ bb0(%0 : $Int, %1 : $Int):
 sil @unchecked_ref_cast_addr : $@convention(thin) <T, U> (@in T) -> @out U {
 bb0(%0 : $*U, %1 : $*T):
   %a = alloc_stack $T
-  copy_addr %1 to [initialization] %a : $*T
+  copy_addr %1 to [init] %a : $*T
   unchecked_ref_cast_addr T in %a : $*T to U in %0 : $*U
   dealloc_stack %a : $*T
   destroy_addr %1 : $*T

--- a/test/IRGen/boxed_existential.sil
+++ b/test/IRGen/boxed_existential.sil
@@ -27,7 +27,7 @@ entry(%x : $*T):
   %b = alloc_existential_box $Error, $T
   %p = project_existential_box $T in %b : $Error
   // CHECK: call %swift.opaque* %initializeWithTake(%swift.opaque* noalias [[ADDR]], %swift.opaque* noalias %0, %swift.type* %T)
-  copy_addr [take] %x to [initialization] %p : $*T
+  copy_addr [take] %x to [init] %p : $*T
   // CHECK: ret %swift.error* [[BOX]]
   return %b : $Error
 }

--- a/test/IRGen/dynamic_self.sil
+++ b/test/IRGen/dynamic_self.sil
@@ -16,7 +16,7 @@ sil @_TF12dynamic_self23testExistentialDispatchFT1pPS_1P__T_ : $@convention(thin
 bb0(%0 : $*P):
   debug_value %0 : $*P, let, name "p", expr op_deref // id: %1
   %2 = alloc_stack $P                             // users: %3, %4, %12
-  copy_addr %0 to [initialization] %2 : $*P     // id: %3
+  copy_addr %0 to [init] %2 : $*P     // id: %3
   // CHECK: call %swift.opaque*
   // CHECK: call %swift.opaque*
   %4 = open_existential_addr immutable_access %2 : $*P to $*@opened("01234567-89ab-cdef-0123-000000000000", P) Self // users: %8, %10

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -2658,7 +2658,7 @@ enum MyOptional {
 sil @test_large_optional : $@convention(thin) (@in MyOptional) -> () {
 entry(%x : $*MyOptional):
  %stk = alloc_stack $MyOptional
- copy_addr %x to [initialization] %stk : $*MyOptional
+ copy_addr %x to [init] %stk : $*MyOptional
  dealloc_stack %stk: $*MyOptional
  %tuple = tuple ()
  return %tuple : $()

--- a/test/IRGen/enum_dynamic_multi_payload.sil
+++ b/test/IRGen/enum_dynamic_multi_payload.sil
@@ -358,10 +358,10 @@ entry(%a : $*EitherOr<T, Builtin.Int64>, %b : $*EitherOr<T, Builtin.Int64>):
   // CHECK:        call void @llvm.memcpy
   // CHECK:        br label %[[DONE]]
   // CHECK:      [[DONE]]:
-  copy_addr [take] %a to [initialization] %b : $*EitherOr<T, Builtin.Int64>
+  copy_addr [take] %a to [init] %b : $*EitherOr<T, Builtin.Int64>
 
   copy_addr [take] %a to                  %b : $*EitherOr<T, Builtin.Int64>
-  copy_addr        %a to [initialization] %b : $*EitherOr<T, Builtin.Int64>
+  copy_addr        %a to [init] %b : $*EitherOr<T, Builtin.Int64>
   copy_addr        %a to                  %b : $*EitherOr<T, Builtin.Int64>
 
   return undef : $()
@@ -395,7 +395,7 @@ entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
   // CHECK:        call void @llvm.memcpy
   // CHECK:        br label %[[DONE]]
   // CHECK:      [[DONE]]:
-  copy_addr [take] %a to [initialization] %b : $*EitherOr<T, C>
+  copy_addr [take] %a to [init] %b : $*EitherOr<T, C>
 
   // CHECK:        [[TAG:%.*]] = call i32 @swift_getEnumCaseMultiPayload
   // CHECK:        switch i32 [[TAG]], label %[[TRIVIAL:[0-9]+]] [
@@ -413,7 +413,7 @@ entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
   // CHECK:        call void @llvm.memcpy
   // CHECK:        br label %[[DONE]]
   // CHECK:      [[DONE]]:
-  copy_addr        %a to [initialization] %b : $*EitherOr<T, C>
+  copy_addr        %a to [init] %b : $*EitherOr<T, C>
 
   return undef : $()
 }

--- a/test/IRGen/enum_future.sil
+++ b/test/IRGen/enum_future.sil
@@ -2662,7 +2662,7 @@ enum MyOptional {
 sil @test_large_optional : $@convention(thin) (@in MyOptional) -> () {
 entry(%x : $*MyOptional):
  %stk = alloc_stack $MyOptional
- copy_addr %x to [initialization] %stk : $*MyOptional
+ copy_addr %x to [init] %stk : $*MyOptional
  dealloc_stack %stk: $*MyOptional
  %tuple = tuple ()
  return %tuple : $()

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -59,7 +59,7 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: store i8** [[SRC_WITNESS]], i8*** [[DEST_WITNESS_ADDR]]
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
   // CHECK: call %swift.weak* @swift_weakInit(%swift.weak* returned [[DEST_REF_ADDR]], %swift.refcounted* [[SRC_REF]])
-  store_weak %a to [initialization] %w : $*@sil_weak CP?
+  store_weak %a to [init] %w : $*@sil_weak CP?
 
   // CHECK: [[SRC_REF:%.*]] = inttoptr {{.*}} %swift.refcounted*
   // CHECK: [[SRC_WITNESS:%.*]] = inttoptr {{.*}} i8**
@@ -82,13 +82,13 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
   %c = load_weak        %w : $*@sil_weak CP?
 
   // CHECK: call { %swift.weak, i8** }* @"$s12existentials2CP_pSgXwWOb"({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
-  copy_addr [take] %w to [initialization] %v : $*@sil_weak CP?
+  copy_addr [take] %w to [init] %v : $*@sil_weak CP?
 
   // CHECK: call { %swift.weak, i8** }* @"$s12existentials2CP_pSgXwWOd"({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr [take] %w to                  %v : $*@sil_weak CP?
 
   // CHECK: call { %swift.weak, i8** }* @"$s12existentials2CP_pSgXwWOc"({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
-  copy_addr        %w to [initialization] %v : $*@sil_weak CP?
+  copy_addr        %w to [init] %v : $*@sil_weak CP?
 
   // CHECK: call { %swift.weak, i8** }* @"$s12existentials2CP_pSgXwWOf"({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr        %w to                  %v : $*@sil_weak CP?
@@ -111,7 +111,7 @@ entry(%arg : $*any Constrained<Int>):
 
   %dst = alloc_stack $any Constrained<Int>
 
-  copy_addr %arg to [initialization] %dst : $*any Constrained<Int>
+  copy_addr %arg to [init] %dst : $*any Constrained<Int>
 
   %fn = function_ref @keep_alive : $@convention(thin)(@inout any Constrained<Int>) -> ()
   apply %fn(%dst) : $@convention(thin)(@inout any Constrained<Int>) -> ()

--- a/test/IRGen/existentials_objc.sil
+++ b/test/IRGen/existentials_objc.sil
@@ -33,7 +33,7 @@ bb0(%0 : $*Any, %1 : $T):
 
 sil @take_opaque_existential : $@convention(thin) (@in Any) -> @out Any {
 bb0(%0 : $*Any, %1 : $*Any):
-  copy_addr [take] %1 to [initialization] %0 : $*Any
+  copy_addr [take] %1 to [init] %0 : $*Any
   %3 = tuple ()
   return %3 : $()
 }
@@ -70,7 +70,7 @@ entry(%s : $CP):
   // CHECK: [[U1:%.*]] = alloca [[UREF:{ %swift.unowned, i8.. }]], align 8
   // CHECK: [[U2:%.*]] = alloca [[UREF]], align 8
 
-  store_unowned %s to [initialization] %u1 : $*@sil_unowned CP
+  store_unowned %s to [init] %u1 : $*@sil_unowned CP
   // CHECK: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[U1]], i32 0, i32 1
   // CHECK: store i8** %1, i8*** [[T0]], align 8
   // CHECK: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[U1]], i32 0, i32 0
@@ -112,7 +112,7 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: store i8** [[SRC_WITNESS]], i8*** [[DEST_WITNESS_ADDR]]
   // CHECK: [[DEST_REF_ADDR:%.*]] = getelementptr inbounds { %swift.weak, i8** }, { %swift.weak, i8** }* %0, i32 0, i32 0
   // CHECK: call %swift.weak* @swift_unknownObjectWeakInit(%swift.weak* returned [[DEST_REF_ADDR]], %objc_object* [[SRC_REF]])
-  store_weak %a to [initialization] %w : $*@sil_weak CP?
+  store_weak %a to [init] %w : $*@sil_weak CP?
 
   // CHECK: [[SRC_REF:%.*]] = inttoptr {{.*}} %objc_object*
   // CHECK: [[SRC_WITNESS:%.*]] = inttoptr {{.*}} i8**
@@ -135,13 +135,13 @@ entry(%w : $*@sil_weak CP?, %a : $CP?):
   %c = load_weak        %w : $*@sil_weak CP?
 
   // CHECK: call { %swift.weak, i8** }* @"$s17existentials_objc2CP_pSgXwWOb"({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
-  copy_addr [take] %w to [initialization] %v : $*@sil_weak CP?
+  copy_addr [take] %w to [init] %v : $*@sil_weak CP?
 
   // CHECK: call { %swift.weak, i8** }* @"$s17existentials_objc2CP_pSgXwWOd"({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr [take] %w to                  %v : $*@sil_weak CP?
 
   // CHECK: call { %swift.weak, i8** }* @"$s17existentials_objc2CP_pSgXwWOc"({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
-  copy_addr        %w to [initialization] %v : $*@sil_weak CP?
+  copy_addr        %w to [init] %v : $*@sil_weak CP?
 
   // CHECK: call { %swift.weak, i8** }* @"$s17existentials_objc2CP_pSgXwWOf"({ %swift.weak, i8** }* %0, { %swift.weak, i8** }* [[V]])
   copy_addr        %w to                  %v : $*@sil_weak CP?

--- a/test/IRGen/existentials_opaque_boxed.sil
+++ b/test/IRGen/existentials_opaque_boxed.sil
@@ -537,7 +537,7 @@ bb0(%0 : $*OtherExistential):
 sil @test_initWithTake_existential_addr : $@convention(thin) (@in Existential) -> () {
 bb0(%0 : $*Existential):
   %s = alloc_stack $Existential
-  copy_addr [take] %0 to [initialization] %s : $*Existential
+  copy_addr [take] %0 to [init] %s : $*Existential
   dealloc_stack %s : $*Existential
 	%t = tuple()
   return %t : $()
@@ -546,7 +546,7 @@ bb0(%0 : $*Existential):
 sil @test_initWithTake_other_existential_addr : $@convention(thin) (@in OtherExistential) -> () {
 bb0(%0 : $*OtherExistential):
   %s = alloc_stack $OtherExistential
-  copy_addr [take] %0 to [initialization] %s : $*OtherExistential
+  copy_addr [take] %0 to [init] %s : $*OtherExistential
   dealloc_stack %s : $*OtherExistential
 	%t = tuple()
   return %t : $()
@@ -577,7 +577,7 @@ bb0(%0 : $*OtherExistential):
 sil @test_initWithCopy_existential_addr : $@convention(thin) (@in Existential) -> () {
 bb0(%0 : $*Existential):
   %s = alloc_stack $Existential
-  copy_addr %0 to [initialization] %s : $*Existential
+  copy_addr %0 to [init] %s : $*Existential
   dealloc_stack %s : $*Existential
 	%t = tuple()
   return %t : $()
@@ -586,7 +586,7 @@ bb0(%0 : $*Existential):
 sil @test_initWithCopy_other_existential_addr : $@convention(thin) (@in OtherExistential) -> () {
 bb0(%0 : $*OtherExistential):
   %s = alloc_stack $OtherExistential
-  copy_addr %0 to [initialization] %s : $*OtherExistential
+  copy_addr %0 to [init] %s : $*OtherExistential
   dealloc_stack %s : $*OtherExistential
 	%t = tuple()
   return %t : $()

--- a/test/IRGen/fixed_size_buffer_peepholes.sil
+++ b/test/IRGen/fixed_size_buffer_peepholes.sil
@@ -20,7 +20,7 @@ entry(%p : $*P):
   %0 = alloc_stack $P
   %1 = open_existential_addr immutable_access %p : $*P to $*@opened("4E4E7668-C798-11E6-9B9F-685B3589058E", P) Self
   %2 = init_existential_addr %0 : $*P, $@opened("4E4E7668-C798-11E6-9B9F-685B3589058E", P) Self
-  copy_addr %1 to [initialization] %2 : $*@opened("4E4E7668-C798-11E6-9B9F-685B3589058E", P) Self
+  copy_addr %1 to [init] %2 : $*@opened("4E4E7668-C798-11E6-9B9F-685B3589058E", P) Self
   destroy_addr %2 : $*@opened("4E4E7668-C798-11E6-9B9F-685B3589058E", P) Self
   deinit_existential_addr %0 : $*P
   dealloc_stack %0 : $*P

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -297,7 +297,7 @@ entry(%c : $RootGeneric<F>):
 sil @RootGeneric_concrete_fragile_dependent_member_access_y : $<F> (RootGeneric<F>) -> @out F {
 entry(%z : $*F, %c : $RootGeneric<F>):
   %p = ref_element_addr %c : $RootGeneric<F>, #RootGeneric.y
-  copy_addr %p to [initialization] %z : $*F
+  copy_addr %p to [init] %z : $*F
   %t = tuple ()
   return %t : $()
 }
@@ -308,7 +308,7 @@ entry(%z : $*F, %c : $RootGeneric<F>):
 sil @RootGeneric_subst_concrete_fragile_dependent_member_access_y : $(RootGeneric<Int>) -> @out Int {
 entry(%z : $*Int, %c : $RootGeneric<Int>):
   %p = ref_element_addr %c : $RootGeneric<Int>, #RootGeneric.y
-  copy_addr %p to [initialization] %z : $*Int
+  copy_addr %p to [init] %z : $*Int
   %t = tuple ()
   return %t : $()
 }

--- a/test/IRGen/lifetime.sil
+++ b/test/IRGen/lifetime.sil
@@ -10,7 +10,7 @@ import Builtin
 sil @generic : $@convention(thin) <T> (@in T) -> () {
 bb0(%x : $*T):
   %y = alloc_stack $T
-  copy_addr %x to [initialization] %y : $*T
+  copy_addr %x to [init] %y : $*T
   destroy_addr %y : $*T
   dealloc_stack %y : $*T
   destroy_addr %x : $*T
@@ -52,9 +52,9 @@ bb0(%x : $*T):
 sil @generic_with_reuse : $@convention(thin) <T> (@in T) -> () {
 bb0(%x : $*T):
   %y = alloc_stack $T
-  copy_addr %x to [initialization] %y : $*T
+  copy_addr %x to [init] %y : $*T
   destroy_addr %y : $*T
-  copy_addr [take] %x to [initialization] %y : $*T
+  copy_addr [take] %x to [init] %y : $*T
   destroy_addr %y : $*T
   dealloc_stack %y : $*T
   %0 = tuple ()
@@ -102,7 +102,7 @@ bb0(%x : $*T):
 sil @fixed_size : $@convention(thin) (@in Builtin.Int64) -> () {
 bb0(%x : $*Builtin.Int64):
   %y = alloc_stack $Builtin.Int64
-  copy_addr %x to [initialization] %y : $*Builtin.Int64
+  copy_addr %x to [init] %y : $*Builtin.Int64
   destroy_addr %y : $*Builtin.Int64
   dealloc_stack %y : $*Builtin.Int64
   destroy_addr %x : $*Builtin.Int64

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -784,9 +784,9 @@ entry(%0 : $EmptyType, %1: $*SomeType):
   store %0 to %5 : $*EmptyType
   %31 = function_ref @foo : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Proto1, τ_0_1 : Proto2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> ()
   %32 = alloc_stack $EmptyType
-  copy_addr %5 to [initialization] %32 : $*EmptyType
+  copy_addr %5 to [init] %32 : $*EmptyType
   %34 = alloc_stack $SomeType
-  copy_addr %1 to [initialization] %34 : $*SomeType // id: %35
+  copy_addr %1 to [init] %34 : $*SomeType // id: %35
   %36 = partial_apply [callee_guaranteed] %31<EmptyType, SomeType>(%32, %34) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : Proto1, τ_0_1 : Proto2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> ()
   release_value %36: $@callee_guaranteed () ->()
   dealloc_stack %34 : $*SomeType
@@ -818,9 +818,9 @@ entry(%0 : $EmptyType, %1: $*SomeType, %3: $FixedType):
   store %3 to %7 : $*FixedType
   %31 = function_ref @foo2 : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1, @in_guaranteed τ_0_2) -> ()
   %32 = alloc_stack $EmptyType
-  copy_addr %5 to [initialization] %32 : $*EmptyType
+  copy_addr %5 to [init] %32 : $*EmptyType
   %34 = alloc_stack $SomeType
-  copy_addr %1 to [initialization] %34 : $*SomeType // id: %35
+  copy_addr %1 to [init] %34 : $*SomeType // id: %35
   %36 = partial_apply [callee_guaranteed] %31<FixedType, EmptyType, SomeType>(%7, %32, %34) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1, @in_guaranteed τ_0_2) -> ()
   release_value %36: $@callee_guaranteed () ->()
   dealloc_stack %34 : $*SomeType

--- a/test/IRGen/partial_apply_run_generic_method1.sil
+++ b/test/IRGen/partial_apply_run_generic_method1.sil
@@ -63,7 +63,7 @@ sil hidden [ossa] @generic_function : $@convention(method) <T> (@in_guaranteed T
 bb0(%0 : $*T, %1 : $*T, %2 : @guaranteed $C):
   debug_value %1 : $*T, let, name "t", argno 1 , expr op_deref
   debug_value %2 : $C, let, name "self", argno 2  
-  copy_addr %1 to [initialization] %0 : $*T       
+  copy_addr %1 to [init] %0 : $*T       
   %6 = tuple ()                                   
   return %6 : $()                                 
 } 

--- a/test/IRGen/protocol_extensions.sil
+++ b/test/IRGen/protocol_extensions.sil
@@ -31,7 +31,7 @@ bb0(%0 : $*Self):
   // function_ref protocol_extensions.P1.extP1a <A : protocol_extensions.P1>(protocol_extensions.P1.Self)() -> ()
   %2 = function_ref @_TFP19protocol_extensions2P16extP1aUS0___fQPS0_FT_T_ : $@convention(method) <τ_0_0 where τ_0_0 : P1> (@in τ_0_0) -> () // user: %5
   %3 = alloc_stack $Self                          // users: %4, %5, %6
-  copy_addr %0 to [initialization] %3 : $*Self  // id: %4
+  copy_addr %0 to [init] %3 : $*Self  // id: %4
   // CHECK: call swiftcc void @_TFP19protocol_extensions2P16extP1aUS0___fQPS0_FT_T_
   %5 = apply %2<Self>(%3) : $@convention(method) <τ_0_0 where τ_0_0 : P1> (@in τ_0_0) -> ()
   dealloc_stack %3 : $*Self      // id: %6

--- a/test/IRGen/ptrauth-value-witnesses.sil
+++ b/test/IRGen/ptrauth-value-witnesses.sil
@@ -33,7 +33,7 @@ bb0(%0 : $*T):
 
 sil @test_copy_init : $@convention(thin) <T> (@in_guaranteed T) -> (@out T) {
 bb0(%0 : $*T, %1 : $*T):
-  copy_addr %1 to [initialization] %0 : $*T
+  copy_addr %1 to [init] %0 : $*T
   %result = tuple ()
   return %result : $()
 }
@@ -49,7 +49,7 @@ bb0(%0 : $*T, %1 : $*T):
 
 sil @test_take_init : $@convention(thin) <T> (@in T) -> (@out T) {
 bb0(%0 : $*T, %1 : $*T):
-  copy_addr [take] %1 to [initialization] %0 : $*T
+  copy_addr [take] %1 to [init] %0 : $*T
   %result = tuple ()
   return %result : $()
 }

--- a/test/IRGen/typelayout_based_value_operation.sil
+++ b/test/IRGen/typelayout_based_value_operation.sil
@@ -63,7 +63,7 @@ entry(%arg : $*A<Builtin.Int32>):
 sil @testValue : $@convention(thin) (@in A<C>) -> ()  {
 entry(%arg : $*A<C>):
   %loc = alloc_stack $A<C>
-  copy_addr %arg to [initialization] %loc : $*A<C>
+  copy_addr %arg to [init] %loc : $*A<C>
   destroy_addr %arg : $*A<C>
   destroy_addr %loc : $*A<C>
   dealloc_stack %loc: $*A<C>

--- a/test/IRGen/unowned_objc.sil
+++ b/test/IRGen/unowned_objc.sil
@@ -58,10 +58,10 @@ bb0(%p : $P, %q : $P):
   // CHECK-NEXT: store i8** [[PP:%1]], i8*** [[T0]], align 8
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 0
   // CHECK-NEXT: call %swift.unowned* @swift_unknownObjectUnownedInit(%swift.unowned* returned [[T0]], [[UNKNOWN]]* [[PV:%0]])
-  store_unowned %p to [initialization] %x : $*@sil_unowned P
+  store_unowned %p to [init] %x : $*@sil_unowned P
 
   // CHECK-NEXT: call { %swift.unowned, i8** }* @"$s12unowned_objc1P_pXoWOc"({ %swift.unowned, i8** }* [[X]], { %swift.unowned, i8** }* [[Y]])
-  copy_addr %x to [initialization] %y : $*@sil_unowned P
+  copy_addr %x to [init] %y : $*@sil_unowned P
 
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 0
   // CHECK-NEXT: [[TV:%.*]] = call [[UNKNOWN]]* @swift_unknownObjectUnownedLoadStrong(%swift.unowned* [[T0]])
@@ -85,7 +85,7 @@ bb0(%p : $P, %q : $P):
   copy_addr [take] %x to %y : $*@sil_unowned P
 
   // CHECK-NEXT: call { %swift.unowned, i8** }* @"$s12unowned_objc1P_pXoWOb"({ %swift.unowned, i8** }* [[Y]], { %swift.unowned, i8** }* [[X]])
-  copy_addr [take] %y to [initialization] %x : $*@sil_unowned P
+  copy_addr [take] %y to [init] %x : $*@sil_unowned P
 
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[Y]], i32 0, i32 0
   // CHECK-NEXT: [[TV:%.*]] = call [[UNKNOWN]]* @swift_unknownObjectUnownedTakeStrong(%swift.unowned* [[T0]])
@@ -97,7 +97,7 @@ bb0(%p : $P, %q : $P):
   // CHECK-NEXT: store i8** [[TP]], i8*** [[T0]], align 8
   // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds [[UREF]], [[UREF]]* [[X]], i32 0, i32 0
   // CHECK-NEXT: call %swift.unowned* @swift_unknownObjectUnownedInit(%swift.unowned* returned [[T0]], [[UNKNOWN]]* [[TV]])
-  store_unowned %t1 to [initialization] %x : $*@sil_unowned P
+  store_unowned %t1 to [init] %x : $*@sil_unowned P
 
   // CHECK-NEXT: call void @swift_unknownObjectRelease([[UNKNOWN]]* [[TV]])
   strong_release %t1 : $P

--- a/test/IRGen/unowned_store.sil
+++ b/test/IRGen/unowned_store.sil
@@ -6,7 +6,7 @@ class C {}
 
 sil @foo : $@convention(thin) (@inout @sil_unowned C, @owned C) -> () {
 entry(%0 : $*@sil_unowned C, %1 : $C):
-  store_unowned %1 to [initialization] %0 : $*@sil_unowned C
+  store_unowned %1 to [init] %0 : $*@sil_unowned C
   store_unowned %1 to %0 : $*@sil_unowned C
   return undef : $()
 }

--- a/test/IRGen/weak.sil
+++ b/test/IRGen/weak.sil
@@ -81,7 +81,7 @@ bb0(%0 : $*B, %1 : $Optional<P>):
 sil @test_weak_alloc_stack : $@convention(thin) (Optional<P>) -> () {
 bb0(%0 : $Optional<P>):
   %1 = alloc_stack $@sil_weak Optional<P>
-  store_weak %0 to [initialization] %1 : $*@sil_weak Optional<P>
+  store_weak %0 to [init] %1 : $*@sil_weak Optional<P>
   destroy_addr %1 : $*@sil_weak Optional<P>
   dealloc_stack %1 : $*@sil_weak Optional<P>
   %4 = tuple ()

--- a/test/Interop/Cxx/class/type-classification-non-trivial-silgen.swift
+++ b/test/Interop/Cxx/class/type-classification-non-trivial-silgen.swift
@@ -59,12 +59,12 @@ public func testStructWithCopyConstructorAndValue() -> Bool {
 // CHECK: [[AS:%.*]] = alloc_stack [lexical] $StructWithSubobjectCopyConstructorAndValue
 // CHECK: [[META:%.*]] = metatype $@thin StructWithSubobjectCopyConstructorAndValue.Type
 // CHECK: [[MEMBER_1:%.*]] = alloc_stack $StructWithCopyConstructorAndValue
-// CHECK: copy_addr %0 to [initialization] [[MEMBER_1]] : $*StructWithCopyConstructorAndValue
+// CHECK: copy_addr %0 to [init] [[MEMBER_1]] : $*StructWithCopyConstructorAndValue
 // CHECK: [[FN:%.*]] = function_ref @$sSo42StructWithSubobjectCopyConstructorAndValueV6memberABSo0abdefG0V_tcfC : $@convention(method) (@in StructWithCopyConstructorAndValue, @thin StructWithSubobjectCopyConstructorAndValue.Type) -> @out StructWithSubobjectCopyConstructorAndValue
 // CHECK: apply [[FN]]([[AS]], [[MEMBER_1]], [[META]]) : $@convention(method) (@in StructWithCopyConstructorAndValue, @thin StructWithSubobjectCopyConstructorAndValue.Type) -> @out StructWithSubobjectCopyConstructorAndValue
 // CHECK: [[OBJ_MEMBER:%.*]] = struct_element_addr [[AS]] : $*StructWithSubobjectCopyConstructorAndValue, #StructWithSubobjectCopyConstructorAndValue.member
 // CHECK: [[MEMBER_2:%.*]] = alloc_stack $StructWithCopyConstructorAndValue
-// CHECK: copy_addr [[OBJ_MEMBER]] to [initialization] [[MEMBER_2]] : $*StructWithCopyConstructorAndValue
+// CHECK: copy_addr [[OBJ_MEMBER]] to [init] [[MEMBER_2]] : $*StructWithCopyConstructorAndValue
 // CHECK: [[OBJ_VALUE_ADDR:%.*]] = struct_element_addr [[MEMBER_2]] : $*StructWithCopyConstructorAndValue, #StructWithCopyConstructorAndValue.value
 // CHECK: [[OBJ_VALUE:%.*]] = load [trivial] [[OBJ_VALUE_ADDR]] : $*Int32
 // CHECK: [[MAKE_INT:%.*]] = function_ref @$ss5Int32V22_builtinIntegerLiteralABBI_tcfC : $@convention(method) (Builtin.IntLiteral, @thin Int32.Type) -> Int32
@@ -82,7 +82,7 @@ public func testStructWithSubobjectCopyConstructorAndValue() -> Bool {
 // StructWithSubobjectCopyConstructorAndValue.init(member:)
 // CHECK-LABEL: sil shared [transparent] [serialized] [ossa] @$sSo42StructWithSubobjectCopyConstructorAndValueV6memberABSo0abdefG0V_tcfC : $@convention(method) (@in StructWithCopyConstructorAndValue, @thin StructWithSubobjectCopyConstructorAndValue.Type) -> @out StructWithSubobjectCopyConstructorAndValue
 // CHECK: [[MEMBER:%.*]] = struct_element_addr %0 : $*StructWithSubobjectCopyConstructorAndValue, #StructWithSubobjectCopyConstructorAndValue.member
-// CHECK: copy_addr [take] %1 to [initialization] [[MEMBER]] : $*StructWithCopyConstructorAndValue
+// CHECK: copy_addr [take] %1 to [init] [[MEMBER]] : $*StructWithCopyConstructorAndValue
 // CHECK-LABEL: end sil function '$sSo42StructWithSubobjectCopyConstructorAndValueV6memberABSo0abdefG0V_tcfC'
 
 // testStructWithCopyConstructorAndSubobjectCopyConstructorAndValue()
@@ -92,12 +92,12 @@ public func testStructWithSubobjectCopyConstructorAndValue() -> Bool {
 // CHECK: apply [[CREATE_MEMBER_FN]]([[MEMBER_0]], %{{.*}}) : $@convention(c) (Int32) -> @out StructWithCopyConstructorAndValue
 // CHECK: [[AS:%.*]] = alloc_stack [lexical] $StructWithCopyConstructorAndSubobjectCopyConstructorAndValue
 // CHECK: [[MEMBER_1:%.*]] = alloc_stack $StructWithCopyConstructorAndValue
-// CHECK: copy_addr [[MEMBER_0]] to [initialization] [[MEMBER_1]] : $*StructWithCopyConstructorAndValue
+// CHECK: copy_addr [[MEMBER_0]] to [init] [[MEMBER_1]] : $*StructWithCopyConstructorAndValue
 // CHECK: [[FN:%.*]] = function_ref @{{_ZN60StructWithCopyConstructorAndSubobjectCopyConstructorAndValueC1E33StructWithCopyConstructorAndValue|\?\?0StructWithCopyConstructorAndSubobjectCopyConstructorAndValue@@QEAA@UStructWithCopyConstructorAndValue@@@Z}} : $@convention(c) (@in StructWithCopyConstructorAndValue) -> @out StructWithCopyConstructorAndSubobjectCopyConstructorAndValue
 // CHECK: apply [[FN]]([[AS]], [[MEMBER_1]]) : $@convention(c) (@in StructWithCopyConstructorAndValue) -> @out StructWithCopyConstructorAndSubobjectCopyConstructorAndValue
 // CHECK: [[OBJ_MEMBER_ADDR:%.*]] = struct_element_addr [[AS]] : $*StructWithCopyConstructorAndSubobjectCopyConstructorAndValue, #StructWithCopyConstructorAndSubobjectCopyConstructorAndValue.member
 // CHECK: [[MEMBER_2:%.*]] = alloc_stack $StructWithCopyConstructorAndValue
-// CHECK: copy_addr [[OBJ_MEMBER_ADDR]] to [initialization] [[MEMBER_2]] : $*StructWithCopyConstructorAndValue
+// CHECK: copy_addr [[OBJ_MEMBER_ADDR]] to [init] [[MEMBER_2]] : $*StructWithCopyConstructorAndValue
 // CHECK: [[OBJ_MEMBER_VALUE_ADDR:%.*]] = struct_element_addr [[MEMBER_2]] : $*StructWithCopyConstructorAndValue, #StructWithCopyConstructorAndValue.value
 // CHECK: [[OBJ_MEMBER_VALUE:%.*]] = load [trivial] [[OBJ_MEMBER_VALUE_ADDR]] : $*Int32
 // CHECK: [[ICMP:%.*]] = function_ref @$ss5Int32V2eeoiySbAB_ABtFZ : $@convention(method) (Int32, Int32, @thin Int32.Type) -> Bool
@@ -133,7 +133,7 @@ public func test(obj: StructWithCopyConstructorAndValue) -> Bool {
 // CHECK: [[INT_META:%.*]] = metatype $@thin Int32.Type
 // CHECK: [[OBJ_MEMBER:%.*]] = struct_element_addr %0 : $*StructWithSubobjectCopyConstructorAndValue, #StructWithSubobjectCopyConstructorAndValue.member
 // CHECK: [[MEMBER_TMP:%.*]] = alloc_stack $StructWithCopyConstructorAndValue
-// CHECK: copy_addr [[OBJ_MEMBER]] to [initialization] [[MEMBER_TMP]] : $*StructWithCopyConstructorAndValue
+// CHECK: copy_addr [[OBJ_MEMBER]] to [init] [[MEMBER_TMP]] : $*StructWithCopyConstructorAndValue
 // CHECK: [[OBJ_MEMBER_VALUE_ADDR:%.*]] = struct_element_addr [[MEMBER_TMP]] : $*StructWithCopyConstructorAndValue, #StructWithCopyConstructorAndValue.value
 // CHECK: [[OBJ_MEMBER_VALUE:%.*]] = load [trivial] [[OBJ_MEMBER_VALUE_ADDR]] : $*Int32
 // CHECK: destroy_addr [[MEMBER_TMP]] : $*StructWithCopyConstructorAndValue
@@ -154,7 +154,7 @@ public func test(obj: StructWithSubobjectCopyConstructorAndValue) -> Bool {
 // CHECK: [[META_INT_1:%.*]] = metatype $@thin Int32.Type
 // CHECK: [[OBJ_MEMBER:%.*]] = struct_element_addr %0 : $*StructWithCopyConstructorAndSubobjectCopyConstructorAndValue, #StructWithCopyConstructorAndSubobjectCopyConstructorAndValue.member
 // CHECK: [[MEMBER_TMP:%.*]] = alloc_stack $StructWithCopyConstructorAndValue
-// CHECK: copy_addr [[OBJ_MEMBER]] to [initialization] [[MEMBER_TMP]] : $*StructWithCopyConstructorAndValue
+// CHECK: copy_addr [[OBJ_MEMBER]] to [init] [[MEMBER_TMP]] : $*StructWithCopyConstructorAndValue
 // CHECK: [[OBJ_MEMBER_VAL_ADDR:%.*]] = struct_element_addr [[MEMBER_TMP]] : $*StructWithCopyConstructorAndValue, #StructWithCopyConstructorAndValue.value
 // CHECK: [[OBJ_MEMBER_VAL:%.*]] = load [trivial] [[OBJ_MEMBER_VAL_ADDR]] : $*Int32
 // CHECK: destroy_addr [[MEMBER_TMP]] : $*StructWithCopyConstructorAndValue

--- a/test/SIL/OwnershipVerifier/definite_init.sil
+++ b/test/SIL/OwnershipVerifier/definite_init.sil
@@ -72,8 +72,8 @@ bb0(%0 : $*T, %1 : $*T):
   %3 = alloc_box $<τ_0_0> { var τ_0_0 } <T>
   %3a = mark_uninitialized [var] %3 : $<τ_0_0> { var τ_0_0 } <T>
   %4 = project_box %3a : $<τ_0_0> { var τ_0_0 } <T>, 0
-  copy_addr [take] %1 to [initialization] %4 : $*T
-  copy_addr %4 to [initialization] %0 : $*T
+  copy_addr [take] %1 to [init] %4 : $*T
+  copy_addr %4 to [init] %0 : $*T
   destroy_value %3a : $<τ_0_0> { var τ_0_0 } <T>
   %9 = tuple ()
   return %9 : $()
@@ -128,7 +128,7 @@ bb0(%0 : $*T, %1 : $*T):
   %2 = project_box %ba : $<τ_0_0> { var τ_0_0 } <T>, 0
   copy_addr %1 to %2 : $*T
   copy_addr [take] %1 to %2 : $*T
-  copy_addr %2 to [initialization] %0 : $*T
+  copy_addr %2 to [init] %0 : $*T
   destroy_value %ba : $<τ_0_0> { var τ_0_0 } <T>
   %9 = tuple ()
   return %9 : $()
@@ -246,7 +246,7 @@ entry(%a : $*C):
   %p = alloc_stack $P
   %b = mark_uninitialized [var] %p : $*P
   %q = init_existential_addr %b : $*P, $C
-  copy_addr %a to [initialization] %q : $*C
+  copy_addr %a to [init] %q : $*C
   %u = function_ref @use : $@convention(thin) (@in P) -> ()
   %v = apply %u(%b) : $@convention(thin) (@in P) -> ()
   dealloc_stack %p : $*P
@@ -400,7 +400,7 @@ bb0(%0 : $*MyStruct2, %1 : $@thin MyStruct2.Type):
   apply %7(%8, %6) : $@convention(thin) (@thin MyStruct2.Type) -> @out MyStruct2
   copy_addr [take] %8 to %3 : $*MyStruct2
   dealloc_stack %8 : $*MyStruct2
-  copy_addr [take] %3 to [initialization] %0 : $*MyStruct2
+  copy_addr [take] %3 to [init] %0 : $*MyStruct2
   dealloc_stack %2 : $*MyStruct2
   %13 = tuple ()
   return %13 : $()

--- a/test/SIL/OwnershipVerifier/interior_pointer.sil
+++ b/test/SIL/OwnershipVerifier/interior_pointer.sil
@@ -76,7 +76,7 @@ bb0(%0 : @owned $OptionalBox<T>, %1 : $*T):
   %2 = begin_borrow %0 : $OptionalBox<T>
   %3 = ref_element_addr %2 : $OptionalBox<T>, #OptionalBox.t
   %4 = init_enum_data_addr %3 : $*FakeOptional<T>, #FakeOptional.some!enumelt
-  copy_addr %1 to [initialization] %4 : $*T
+  copy_addr %1 to [init] %4 : $*T
   end_borrow %2 : $OptionalBox<T>
   destroy_value %0 : $OptionalBox<T>
   %5 = tuple ()

--- a/test/SIL/Parser/apply_with_substitution.sil
+++ b/test/SIL/Parser/apply_with_substitution.sil
@@ -15,7 +15,7 @@ bb0(%0 : $Optional<@callee_guaranteed @substituted <A> () -> @out A for <()>>):
   %3 = alloc_stack $Optional<()>                  // users: %22, %28, %30, %31
   %4 = alloc_stack $()                            // users: %12, %22, %25
   %5 = alloc_stack $Optional<@callee_guaranteed @substituted <A> () -> @out A for <()>>            // users: %6, %8, %10, %11, %16, %24
-  copy_addr %1a to [initialization] %5 : $*Optional<@callee_guaranteed @substituted <A> () -> @out A for <()>> // id: %6
+  copy_addr %1a to [init] %5 : $*Optional<@callee_guaranteed @substituted <A> () -> @out A for <()>> // id: %6
   %7 = function_ref @_TFs22_doesOptionalHaveValueU__FT1vRGSqQ___Bi1_ : $@convention(thin) <τ_0_0> (@inout Optional<τ_0_0>) -> Builtin.Int1 // user: %8
   %8 = apply %7<() -> ()>(%5) : $@convention(thin) <τ_0_0> (@inout Optional<τ_0_0>) -> Builtin.Int1 // user: %9
   br bb2                                          // id: %13

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -293,12 +293,12 @@ bb0(%0 : $*Runcible, %1 : $*Bendable & Runcible):
   // CHECK: alloc_box
   %2 = alloc_box $<τ_0_0> { var τ_0_0 } <Bendable & Runcible>
   %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <Bendable & Runcible>, 0
-  // CHECK: copy_addr [take] {{.*}} to [initialization] {{.*}} : $*any Bendable & Runcible
-  copy_addr [take] %1 to [initialization] %2a : $*Bendable & Runcible
+  // CHECK: copy_addr [take] {{.*}} to [init] {{.*}} : $*any Bendable & Runcible
+  copy_addr [take] %1 to [init] %2a : $*Bendable & Runcible
   // CHECK: alloc_stack
   %4 = alloc_stack $Bendable & Runcible
-  // CHECK: copy_addr {{.*}} to [initialization] {{.*}} : $*any Bendable & Runcible
-  copy_addr %2a to [initialization] %4 : $*Bendable & Runcible
+  // CHECK: copy_addr {{.*}} to [init] {{.*}} : $*any Bendable & Runcible
+  copy_addr %2a to [init] %4 : $*Bendable & Runcible
   %7 = tuple ()
   // CHECK: destroy_addr
   destroy_addr %4 : $*Bendable & Runcible
@@ -417,7 +417,7 @@ sil @test_union_addr_data_case : $(@in Q) -> (@out Gimel) {
 bb0(%0 : $*Gimel, %1 : $*Q):
   // CHECK: {{%.*}} = init_enum_data_addr {{%.*}} : $*Gimel, #Gimel.DataCase!enumelt
   %p = init_enum_data_addr %0 : $*Gimel, #Gimel.DataCase!enumelt
-  copy_addr [take] %1 to [initialization] %p : $*Q
+  copy_addr [take] %1 to [init] %p : $*Q
   inject_enum_addr %0 : $*Gimel, #Gimel.DataCase!enumelt
   %t = tuple ()
   return %t : $()
@@ -616,10 +616,10 @@ sil @test_value_metatype : $@convention(thin) <T> (@in T) -> (@thick T.Type, @th
 bb0(%0 : $*T):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <T>                               // CHECK: alloc_box
   %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <T>, 0
-  copy_addr [take] %0 to [initialization] %1a : $*T
+  copy_addr [take] %0 to [init] %1a : $*T
   %3 = metatype $@thick T.Type                       // CHECK: metatype
   %5 = alloc_stack $T                               // CHECK: alloc_stack
-  copy_addr %1a to [initialization] %5 : $*T
+  copy_addr %1a to [init] %5 : $*T
   // CHECK: value_metatype $@thick T.Type, {{%.*}} : $*T
   %7 = value_metatype $@thick T.Type, %5 : $*T
   %8 = tuple (%3 : $@thick T.Type, %7 : $@thick T.Type) // CHECK: tuple
@@ -633,9 +633,9 @@ sil @test_existential_metatype : $@convention(thin) (@in SomeProtocol) -> @thick
 bb0(%0 : $*SomeProtocol):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <SomeProtocol>                    // CHECK: alloc_box
   %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <SomeProtocol>, 0
-  copy_addr [take] %0 to [initialization] %1a : $*SomeProtocol
+  copy_addr [take] %0 to [init] %1a : $*SomeProtocol
   %4 = alloc_stack $SomeProtocol                    // CHECK: alloc_stack
-  copy_addr %1a to [initialization] %4 : $*SomeProtocol
+  copy_addr %1a to [init] %4 : $*SomeProtocol
   // CHECK: existential_metatype $@thick any SomeProtocol.Type, {{%.*}} : $*any SomeProtocol
   %6 = existential_metatype $@thick SomeProtocol.Type, %4 : $*SomeProtocol
   destroy_addr %4 : $*SomeProtocol
@@ -1674,7 +1674,7 @@ bb0(%0 : $A):
   %1 = alloc_stack $Any
   %2 = ref_element_addr %0 : $A, #A.property
   %3 = begin_access [dynamic] [read] %2 : $*Any
-  copy_addr %3 to [initialization] %1 : $*Any
+  copy_addr %3 to [init] %1 : $*Any
   end_access %3 : $*Any
   %6 = begin_access [read] [dynamic] [no_nested_conflict] %2 : $*Any
   copy_addr %6 to %1 : $*Any

--- a/test/SIL/Parser/basic2.sil
+++ b/test/SIL/Parser/basic2.sil
@@ -115,8 +115,8 @@ bb0(%0 : @owned $@moveOnly Builtin.NativeObject):
 }
 
 // CHECK-LABEL: sil [ossa] @test_explicit_copy_addr : $@convention(thin) (@owned Builtin.NativeObject) -> () {
-// CHECK: explicit_copy_addr %{{[0-9]+}} to [initialization] %{{[0-9]+}} :
-// CHECK: explicit_copy_addr [take] %{{[0-9]+}} to [initialization] %{{[0-9]+}} :
+// CHECK: explicit_copy_addr %{{[0-9]+}} to [init] %{{[0-9]+}} :
+// CHECK: explicit_copy_addr [take] %{{[0-9]+}} to [init] %{{[0-9]+}} :
 // CHECK: explicit_copy_addr [take] %{{[0-9]+}} to %{{[0-9]+}} :
 // CHECK: explicit_copy_addr %{{[0-9]+}} to %{{[0-9]+}} :
 // CHECK: } // end sil function 'test_explicit_copy_addr'
@@ -128,8 +128,8 @@ bb0(%0 : @owned $Builtin.NativeObject):
 
   %0a = copy_value %0 : $Builtin.NativeObject
   store %0a to [init] %1 : $*Builtin.NativeObject
-  explicit_copy_addr %1 to [initialization] %2 : $*Builtin.NativeObject  
-  explicit_copy_addr [take] %2 to [initialization] %3 : $*Builtin.NativeObject
+  explicit_copy_addr %1 to [init] %2 : $*Builtin.NativeObject  
+  explicit_copy_addr [take] %2 to [init] %3 : $*Builtin.NativeObject
   explicit_copy_addr [take] %3 to %1 : $*Builtin.NativeObject
 
   store %0 to [init] %2 : $*Builtin.NativeObject

--- a/test/SIL/Parser/bound_generic.sil
+++ b/test/SIL/Parser/bound_generic.sil
@@ -15,7 +15,7 @@ bb0(%0 : $Optional<@callee_guaranteed @substituted <A> () -> @out A for <()>>):
   %3 = alloc_stack $Optional<()>
   %4 = alloc_stack $()
   %5 = alloc_stack $Optional<@callee_guaranteed @substituted <A> () -> @out A for <()>>
-  copy_addr %1a to [initialization] %5 : $*Optional<@callee_guaranteed @substituted <A> () -> @out A for <()>>
+  copy_addr %1a to [init] %5 : $*Optional<@callee_guaranteed @substituted <A> () -> @out A for <()>>
   // function_ref Swift._doesOptionalHaveValue <A>(v : @inout Swift.Optional<A>) -> Builtin.Int1
   %7 = function_ref @_TFs22_doesOptionalHaveValueU__FT1vRGSqQ___Bi1_ : $@convention(thin) <τ_0_0> (@inout Optional<τ_0_0>) -> Builtin.Int1
   // CHECK: apply %{{[0-9]+}}<() -> ()>(%{{[0-9]+}}) : $@convention(thin) <τ_0_0> (@inout Optional<τ_0_0>) -> Builtin.Int1

--- a/test/SIL/Parser/generics.sil
+++ b/test/SIL/Parser/generics.sil
@@ -5,12 +5,12 @@ import Builtin
 
 // CHECK-LABEL: sil [ossa] @foo : $@convention(thin) <T> (@in T) -> @out T {
 // CHECK: bb0(%0 : $*T, %1 : $*T):
-// CHECK:   copy_addr [take] %1 to [initialization] %0 : $*T
+// CHECK:   copy_addr [take] %1 to [init] %0 : $*T
 // CHECK:   return undef : $()
 // CHECK: }
 sil [ossa] @foo : $@convention(thin) <T> (@in T) -> @out T {
 entry(%o : $*T, %i : $*T):
-  copy_addr [take] %i to [initialization] %o : $*T
+  copy_addr [take] %i to [init] %o : $*T
   return undef : $()
 }
 
@@ -99,7 +99,7 @@ protocol FooProto {
 sil [ossa] @protocol_extension_with_constrained_associated_type : $@convention(method) <Self where Self : FooProto, Self.Assoc : FooProtoHelper><I where I : FooProto, I.Assoc == Self.Assoc> (@in I, @in_guaranteed Self) -> () {
 bb0(%0 : $*I, %1 : $*Self):
   %2 = alloc_stack $I                             // users: %3, %6, %7, %9
-  copy_addr %0 to [initialization] %2 : $*I     // id: %3
+  copy_addr %0 to [init] %2 : $*I     // id: %3
   %4 = witness_method $I, #FooProto.value!getter : $@convention(witness_method: FooProto) <τ_0_0 where τ_0_0 : FooProto, τ_0_0.Assoc : FooProtoHelper> (@in_guaranteed τ_0_0) -> @out τ_0_0.Assoc // user: %6
   %5 = alloc_stack $Self.Assoc                    // users: %6, %8
   %6 = apply %4<I>(%5, %2) : $@convention(witness_method: FooProto) <τ_0_0 where τ_0_0 : FooProto, τ_0_0.Assoc : FooProtoHelper> (@in_guaranteed τ_0_0) -> @out τ_0_0.Assoc

--- a/test/SIL/Parser/subst_function_type.sil
+++ b/test/SIL/Parser/subst_function_type.sil
@@ -18,6 +18,6 @@ entry(%0 : $@callee_guaranteed @substituted <C, D> (@in C, @in D) -> () for <X, 
 
 sil @test_substituted_generic : $@convention(thin) <X, Y> @substituted <Z> (@in Z) -> (@out Z) for <(X, Y)> {
 entry(%0 : $*(X, Y), %1 : $*(X, Y)):
-  copy_addr [take] %1 to [initialization] %0 : $*(X,Y)
+  copy_addr [take] %1 to [init] %0 : $*(X,Y)
   return undef : $()
 }

--- a/test/SIL/Parser/undef.sil
+++ b/test/SIL/Parser/undef.sil
@@ -59,8 +59,8 @@ bb0:
   mark_uninitialized [var] undef : $*()
   // CHECK: mark_function_escape undef : $*()
   mark_function_escape undef : $*()
-  // CHECK: copy_addr undef to [initialization] undef : $*()
-  copy_addr undef to [initialization] undef : $*()
+  // CHECK: copy_addr undef to [init] undef : $*()
+  copy_addr undef to [init] undef : $*()
   // CHECK: destroy_addr undef : $*()
   destroy_addr undef : $*()
   // CHECK: index_addr undef : $*(), undef : $Builtin.Int64
@@ -84,8 +84,8 @@ bb0:
   unowned_release undef : $@sil_unowned C
   // CHECK: load_weak undef : $*@sil_weak Optional<C>
   load_weak undef : $*@sil_weak Optional<C>
-  // CHECK: store_weak undef to [initialization] undef : $*@sil_weak Optional<C>
-  store_weak undef to [initialization] undef : $*@sil_weak Optional<C>
+  // CHECK: store_weak undef to [init] undef : $*@sil_weak Optional<C>
+  store_weak undef to [init] undef : $*@sil_weak Optional<C>
   // CHECK: fix_lifetime undef : $C
   fix_lifetime undef : $C
   // CHECK: mark_dependence undef : $C on undef : $C

--- a/test/SIL/Serialization/Inputs/function_param_convention_input.sil
+++ b/test/SIL/Serialization/Inputs/function_param_convention_input.sil
@@ -11,7 +11,7 @@ struct X {
 // conventions.
 sil [serialized] [ossa] @foo : $@convention(thin) (@in X, @inout X, @in_guaranteed X, @owned X, X, @guaranteed X) -> @out X {
 bb0(%0 : $*X, %1 : $*X, %2 : $*X, %3 : $*X, %4 : @owned $X, %5 : @unowned $X, %6 : @guaranteed $X):
-  copy_addr [take] %1 to [initialization] %0 : $*X
+  copy_addr [take] %1 to [init] %0 : $*X
   destroy_value %4 : $X
   %9999 = tuple()
   return %9999 : $()

--- a/test/SIL/Serialization/basic2.sil
+++ b/test/SIL/Serialization/basic2.sil
@@ -27,8 +27,8 @@ bb0(%0 : @owned $Builtin.NativeObject):
 }
 
 // CHECK-LABEL: sil [ossa] @test_explicit_copy_addr : $@convention(thin) (@owned Builtin.NativeObject) -> () {
-// CHECK: explicit_copy_addr %{{[0-9]+}} to [initialization] %{{[0-9]+}} :
-// CHECK: explicit_copy_addr [take] %{{[0-9]+}} to [initialization] %{{[0-9]+}} :
+// CHECK: explicit_copy_addr %{{[0-9]+}} to [init] %{{[0-9]+}} :
+// CHECK: explicit_copy_addr [take] %{{[0-9]+}} to [init] %{{[0-9]+}} :
 // CHECK: explicit_copy_addr [take] %{{[0-9]+}} to %{{[0-9]+}} :
 // CHECK: explicit_copy_addr %{{[0-9]+}} to %{{[0-9]+}} :
 // CHECK: } // end sil function 'test_explicit_copy_addr'
@@ -40,8 +40,8 @@ bb0(%0 : @owned $Builtin.NativeObject):
 
   %0a = copy_value %0 : $Builtin.NativeObject
   store %0a to [init] %1 : $*Builtin.NativeObject
-  explicit_copy_addr %1 to [initialization] %2 : $*Builtin.NativeObject  
-  explicit_copy_addr [take] %2 to [initialization] %3 : $*Builtin.NativeObject
+  explicit_copy_addr %1 to [init] %2 : $*Builtin.NativeObject  
+  explicit_copy_addr [take] %2 to [init] %3 : $*Builtin.NativeObject
   explicit_copy_addr [take] %3 to %1 : $*Builtin.NativeObject
 
   store %0 to [init] %2 : $*Builtin.NativeObject

--- a/test/SIL/concurrentclosure_capture_verify_canonical_addressonly.sil
+++ b/test/SIL/concurrentclosure_capture_verify_canonical_addressonly.sil
@@ -57,7 +57,7 @@ bb0(%0 : $*T):
   store %5 to [init] %2 : $*F                     // id: %7
   %8 = alloc_box $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T>, var, name "i2" // users: %32, %14, %9
   %9 = project_box %8 : $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T>, 0 // users: %24, %10
-  copy_addr %0 to [initialization] %9 : $*T       // id: %10
+  copy_addr %0 to [init] %9 : $*T       // id: %10
   %11 = copy_value %6 : $F                        // users: %23, %18
   destroy_value %6 : $F                           // id: %12
   // function_ref closure #1 in testCaseAddressOnly2<A>(i:)

--- a/test/SIL/concurrentclosure_capture_verify_raw.sil
+++ b/test/SIL/concurrentclosure_capture_verify_raw.sil
@@ -90,7 +90,7 @@ bb0(%0 : $*T):
   store %5 to [init] %2 : $*F                     // id: %7
   %8 = alloc_box $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T>, var, name "i2" // users: %32, %14, %9
   %9 = project_box %8 : $<τ_0_0 where τ_0_0 : MyProt> { var τ_0_0 } <T>, 0 // users: %24, %10
-  copy_addr %0 to [initialization] %9 : $*T       // id: %10
+  copy_addr %0 to [init] %9 : $*T       // id: %10
   %11 = copy_value %6 : $F                        // users: %23, %18
   destroy_value %6 : $F                           // id: %12
   // function_ref closure #1 in testCaseAddressOnly2<A>(i:)

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -89,7 +89,7 @@ bb2(%4 : @owned $Error):
 sil [ossa] @test_alloc_stack_simple : $@convention(thin) (@in_guaranteed T) -> () {
 bb0(%0 : $*T):
   %2 = alloc_stack $T
-  copy_addr %0 to [initialization] %2 : $*T
+  copy_addr %0 to [init] %2 : $*T
   br bb1
 
 bb1:
@@ -102,17 +102,17 @@ bb1:
 sil [ossa] @test_alloc_stack_nested : $@convention(thin) (@in_guaranteed T) -> () {
 bb0(%0 : $*T):
   %1 = alloc_stack $T
-  copy_addr %0 to [initialization] %1 : $*T
+  copy_addr %0 to [init] %1 : $*T
   %2 = alloc_stack $T
-  copy_addr %0 to [initialization] %2 : $*T
+  copy_addr %0 to [init] %2 : $*T
   destroy_addr %2 : $*T
   dealloc_stack %2 : $*T
   cond_br undef, bb1, bb2
 bb1:
   %3 = alloc_stack $T
   %4 = alloc_stack $T
-  copy_addr %0 to [initialization] %3 : $*T
-  copy_addr %0 to [initialization] %4 : $*T
+  copy_addr %0 to [init] %3 : $*T
+  copy_addr %0 to [init] %4 : $*T
   destroy_addr %3 : $*T
   destroy_addr %4 : $*T
   dealloc_stack %4 : $*T
@@ -169,23 +169,23 @@ sil [ossa] @test_many_locations_in_block : $@convention(thin) <A, B, C, D, E, G,
 bb0(%0 : $*A, %1 : $*B, %2 : $*C, %3 : $*D, %4 : $*E, %5 : $*G, %6 : $*H, %7 : $*I, %9 : $*A, %10 : $*B, %11 : $*C, %12 : $*D, %13 : $*E, %14 : $*G, %15 : $*H, %16 : $*I):
   %18 = alloc_stack $(A, B, C, D, E, G, H, I), let, name "a", argno 1
   %19 = tuple_element_addr %18 : $*(A, B, C, D, E, G, H, I), 0
-  copy_addr %9 to [initialization] %19 : $*A
+  copy_addr %9 to [init] %19 : $*A
   %21 = tuple_element_addr %18 : $*(A, B, C, D, E, G, H, I), 1
-  copy_addr %10 to [initialization] %21 : $*B
+  copy_addr %10 to [init] %21 : $*B
   %23 = tuple_element_addr %18 : $*(A, B, C, D, E, G, H, I), 2
-  copy_addr %11 to [initialization] %23 : $*C
+  copy_addr %11 to [init] %23 : $*C
   %25 = tuple_element_addr %18 : $*(A, B, C, D, E, G, H, I), 3
-  copy_addr %12 to [initialization] %25 : $*D
+  copy_addr %12 to [init] %25 : $*D
   %27 = tuple_element_addr %18 : $*(A, B, C, D, E, G, H, I), 4
-  copy_addr %13 to [initialization] %27 : $*E
+  copy_addr %13 to [init] %27 : $*E
   %29 = tuple_element_addr %18 : $*(A, B, C, D, E, G, H, I), 5
-  copy_addr %14 to [initialization] %29 : $*G
+  copy_addr %14 to [init] %29 : $*G
   %31 = tuple_element_addr %18 : $*(A, B, C, D, E, G, H, I), 6
-  copy_addr %15 to [initialization] %31 : $*H
+  copy_addr %15 to [init] %31 : $*H
   %33 = tuple_element_addr %18 : $*(A, B, C, D, E, G, H, I), 7
-  copy_addr %16 to [initialization] %33 : $*I
+  copy_addr %16 to [init] %33 : $*I
   %41 = alloc_stack $(A, B, C, D, E, G, H, I)
-  copy_addr %18 to [initialization] %41 : $*(A, B, C, D, E, G, H, I)
+  copy_addr %18 to [init] %41 : $*(A, B, C, D, E, G, H, I)
   %43 = tuple_element_addr %41 : $*(A, B, C, D, E, G, H, I), 0
   %44 = tuple_element_addr %41 : $*(A, B, C, D, E, G, H, I), 1
   %45 = tuple_element_addr %41 : $*(A, B, C, D, E, G, H, I), 2
@@ -194,9 +194,9 @@ bb0(%0 : $*A, %1 : $*B, %2 : $*C, %3 : $*D, %4 : $*E, %5 : $*G, %6 : $*H, %7 : $
   %48 = tuple_element_addr %41 : $*(A, B, C, D, E, G, H, I), 5
   %49 = tuple_element_addr %41 : $*(A, B, C, D, E, G, H, I), 6
   %50 = tuple_element_addr %41 : $*(A, B, C, D, E, G, H, I), 7
-  copy_addr [take] %43 to [initialization] %0 : $*A
+  copy_addr [take] %43 to [init] %0 : $*A
   %52 = alloc_stack $(A, B, C, D, E, G, H, I)
-  copy_addr %18 to [initialization] %52 : $*(A, B, C, D, E, G, H, I)
+  copy_addr %18 to [init] %52 : $*(A, B, C, D, E, G, H, I)
   %54 = tuple_element_addr %52 : $*(A, B, C, D, E, G, H, I), 0
   %55 = tuple_element_addr %52 : $*(A, B, C, D, E, G, H, I), 1
   %56 = tuple_element_addr %52 : $*(A, B, C, D, E, G, H, I), 2
@@ -205,9 +205,9 @@ bb0(%0 : $*A, %1 : $*B, %2 : $*C, %3 : $*D, %4 : $*E, %5 : $*G, %6 : $*H, %7 : $
   %59 = tuple_element_addr %52 : $*(A, B, C, D, E, G, H, I), 5
   %60 = tuple_element_addr %52 : $*(A, B, C, D, E, G, H, I), 6
   %61 = tuple_element_addr %52 : $*(A, B, C, D, E, G, H, I), 7
-  copy_addr [take] %55 to [initialization] %1 : $*B
+  copy_addr [take] %55 to [init] %1 : $*B
   %63 = alloc_stack $(A, B, C, D, E, G, H, I)
-  copy_addr %18 to [initialization] %63 : $*(A, B, C, D, E, G, H, I)
+  copy_addr %18 to [init] %63 : $*(A, B, C, D, E, G, H, I)
   %65 = tuple_element_addr %63 : $*(A, B, C, D, E, G, H, I), 0
   %66 = tuple_element_addr %63 : $*(A, B, C, D, E, G, H, I), 1
   %67 = tuple_element_addr %63 : $*(A, B, C, D, E, G, H, I), 2
@@ -216,9 +216,9 @@ bb0(%0 : $*A, %1 : $*B, %2 : $*C, %3 : $*D, %4 : $*E, %5 : $*G, %6 : $*H, %7 : $
   %70 = tuple_element_addr %63 : $*(A, B, C, D, E, G, H, I), 5
   %71 = tuple_element_addr %63 : $*(A, B, C, D, E, G, H, I), 6
   %72 = tuple_element_addr %63 : $*(A, B, C, D, E, G, H, I), 7
-  copy_addr [take] %67 to [initialization] %2 : $*C
+  copy_addr [take] %67 to [init] %2 : $*C
   %74 = alloc_stack $(A, B, C, D, E, G, H, I)
-  copy_addr %18 to [initialization] %74 : $*(A, B, C, D, E, G, H, I)
+  copy_addr %18 to [init] %74 : $*(A, B, C, D, E, G, H, I)
   %76 = tuple_element_addr %74 : $*(A, B, C, D, E, G, H, I), 0
   %77 = tuple_element_addr %74 : $*(A, B, C, D, E, G, H, I), 1
   %78 = tuple_element_addr %74 : $*(A, B, C, D, E, G, H, I), 2
@@ -227,9 +227,9 @@ bb0(%0 : $*A, %1 : $*B, %2 : $*C, %3 : $*D, %4 : $*E, %5 : $*G, %6 : $*H, %7 : $
   %81 = tuple_element_addr %74 : $*(A, B, C, D, E, G, H, I), 5
   %82 = tuple_element_addr %74 : $*(A, B, C, D, E, G, H, I), 6
   %83 = tuple_element_addr %74 : $*(A, B, C, D, E, G, H, I), 7
-  copy_addr [take] %79 to [initialization] %3 : $*D
+  copy_addr [take] %79 to [init] %3 : $*D
   %85 = alloc_stack $(A, B, C, D, E, G, H, I)
-  copy_addr %18 to [initialization] %85 : $*(A, B, C, D, E, G, H, I)
+  copy_addr %18 to [init] %85 : $*(A, B, C, D, E, G, H, I)
   %87 = tuple_element_addr %85 : $*(A, B, C, D, E, G, H, I), 0
   %88 = tuple_element_addr %85 : $*(A, B, C, D, E, G, H, I), 1
   %89 = tuple_element_addr %85 : $*(A, B, C, D, E, G, H, I), 2
@@ -238,9 +238,9 @@ bb0(%0 : $*A, %1 : $*B, %2 : $*C, %3 : $*D, %4 : $*E, %5 : $*G, %6 : $*H, %7 : $
   %92 = tuple_element_addr %85 : $*(A, B, C, D, E, G, H, I), 5
   %93 = tuple_element_addr %85 : $*(A, B, C, D, E, G, H, I), 6
   %94 = tuple_element_addr %85 : $*(A, B, C, D, E, G, H, I), 7
-  copy_addr [take] %91 to [initialization] %4 : $*E
+  copy_addr [take] %91 to [init] %4 : $*E
   %96 = alloc_stack $(A, B, C, D, E, G, H, I)
-  copy_addr %18 to [initialization] %96 : $*(A, B, C, D, E, G, H, I)
+  copy_addr %18 to [init] %96 : $*(A, B, C, D, E, G, H, I)
   %98 = tuple_element_addr %96 : $*(A, B, C, D, E, G, H, I), 0
   %99 = tuple_element_addr %96 : $*(A, B, C, D, E, G, H, I), 1
   %100 = tuple_element_addr %96 : $*(A, B, C, D, E, G, H, I), 2
@@ -249,9 +249,9 @@ bb0(%0 : $*A, %1 : $*B, %2 : $*C, %3 : $*D, %4 : $*E, %5 : $*G, %6 : $*H, %7 : $
   %103 = tuple_element_addr %96 : $*(A, B, C, D, E, G, H, I), 5
   %104 = tuple_element_addr %96 : $*(A, B, C, D, E, G, H, I), 6
   %105 = tuple_element_addr %96 : $*(A, B, C, D, E, G, H, I), 7
-  copy_addr [take] %103 to [initialization] %5 : $*G
+  copy_addr [take] %103 to [init] %5 : $*G
   %107 = alloc_stack $(A, B, C, D, E, G, H, I)
-  copy_addr %18 to [initialization] %107 : $*(A, B, C, D, E, G, H, I)
+  copy_addr %18 to [init] %107 : $*(A, B, C, D, E, G, H, I)
   %109 = tuple_element_addr %107 : $*(A, B, C, D, E, G, H, I), 0
   %110 = tuple_element_addr %107 : $*(A, B, C, D, E, G, H, I), 1
   %111 = tuple_element_addr %107 : $*(A, B, C, D, E, G, H, I), 2
@@ -260,9 +260,9 @@ bb0(%0 : $*A, %1 : $*B, %2 : $*C, %3 : $*D, %4 : $*E, %5 : $*G, %6 : $*H, %7 : $
   %114 = tuple_element_addr %107 : $*(A, B, C, D, E, G, H, I), 5
   %115 = tuple_element_addr %107 : $*(A, B, C, D, E, G, H, I), 6
   %116 = tuple_element_addr %107 : $*(A, B, C, D, E, G, H, I), 7
-  copy_addr [take] %115 to [initialization] %6 : $*H
+  copy_addr [take] %115 to [init] %6 : $*H
   %118 = alloc_stack $(A, B, C, D, E, G, H, I)
-  copy_addr %18 to [initialization] %118 : $*(A, B, C, D, E, G, H, I)
+  copy_addr %18 to [init] %118 : $*(A, B, C, D, E, G, H, I)
   %120 = tuple_element_addr %118 : $*(A, B, C, D, E, G, H, I), 0
   %121 = tuple_element_addr %118 : $*(A, B, C, D, E, G, H, I), 1
   %122 = tuple_element_addr %118 : $*(A, B, C, D, E, G, H, I), 2
@@ -271,7 +271,7 @@ bb0(%0 : $*A, %1 : $*B, %2 : $*C, %3 : $*D, %4 : $*E, %5 : $*G, %6 : $*H, %7 : $
   %125 = tuple_element_addr %118 : $*(A, B, C, D, E, G, H, I), 5
   %126 = tuple_element_addr %118 : $*(A, B, C, D, E, G, H, I), 6
   %127 = tuple_element_addr %118 : $*(A, B, C, D, E, G, H, I), 7
-  copy_addr [take] %127 to [initialization] %7 : $*I
+  copy_addr [take] %127 to [init] %7 : $*I
   destroy_addr %126 : $*H
   destroy_addr %125 : $*G
   destroy_addr %124 : $*E
@@ -442,7 +442,7 @@ bb1:
 
 bb2:
   %5 = init_enum_data_addr %0 : $*Optional<T>, #Optional.some!enumelt
-  copy_addr %1 to [initialization] %5 : $*T
+  copy_addr %1 to [init] %5 : $*T
   inject_enum_addr %0 : $*Optional<T>, #Optional.some!enumelt
   br bb3
 
@@ -587,10 +587,10 @@ sil [ossa] @test_existentials : $@convention(thin) <U: P> (@in_guaranteed U) -> 
 bb0(%0 : $*U):
   %s = alloc_stack $P
   %i = init_existential_addr %s : $*P, $U
-  copy_addr %0 to [initialization] %i : $*U
+  copy_addr %0 to [init] %i : $*U
   %o = open_existential_addr immutable_access %s : $*P to $*@opened("5B62392E-7C62-11EB-BF90-D0817AD9985D", P) Self
   %s2 = alloc_stack $@opened("5B62392E-7C62-11EB-BF90-D0817AD9985D", P) Self
-  copy_addr %o to [initialization] %s2 : $*@opened("5B62392E-7C62-11EB-BF90-D0817AD9985D", P) Self
+  copy_addr %o to [init] %s2 : $*@opened("5B62392E-7C62-11EB-BF90-D0817AD9985D", P) Self
   destroy_addr %s2 : $*@opened("5B62392E-7C62-11EB-BF90-D0817AD9985D", P) Self
   dealloc_stack %s2 : $*@opened("5B62392E-7C62-11EB-BF90-D0817AD9985D", P) Self
   destroy_addr %s : $*P
@@ -603,10 +603,10 @@ sil [ossa] @test_init_two_existentials : $@convention(thin) <U: P, V: P> (@in_gu
 bb0(%0 : $*U, %1 : $*V):
   %s = alloc_stack $P
   %t = init_existential_addr %s : $*P, $U
-  copy_addr %0 to [initialization] %t : $*U
+  copy_addr %0 to [init] %t : $*U
   destroy_addr %s : $*P
   %v = init_existential_addr %s : $*P, $V
-  copy_addr %1 to [initialization] %v : $*V
+  copy_addr %1 to [init] %v : $*V
   destroy_addr %s : $*P
   dealloc_stack %s : $*P
   %5 = tuple ()

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -66,10 +66,10 @@ bb0(%0 : $*T):
   cond_br undef, bb1, bb2
 
 bb1:
-  copy_addr %0 to [initialization] %2 : $*T
+  copy_addr %0 to [init] %2 : $*T
   br bb3
 bb2:
-  copy_addr %0 to [initialization] %2 : $*T
+  copy_addr %0 to [init] %2 : $*T
   destroy_addr %2 : $*T
   br bb3
 
@@ -330,7 +330,7 @@ sil [ossa] @test_store_borrow_copy_src : $@convention(thin) (@guaranteed T) -> @
 bb0(%0 :  $*T, %1 :  @guaranteed $T):
   %s = alloc_stack $T
   %sb = store_borrow %1 to %s : $*T
-  copy_addr [take] %sb to [initialization] %0 : $*T
+  copy_addr [take] %sb to [init] %0 : $*T
   end_borrow %sb : $*T
   dealloc_stack %s : $*T
   %res = tuple ()
@@ -488,7 +488,7 @@ bb0(%0 : $*U):
   %s = alloc_stack $P
   %o = open_existential_addr immutable_access %s : $*P to $*@opened("5B62392E-7C62-11EB-BF90-D0817AD9985D", P) Self
   %s2 = alloc_stack $@opened("5B62392E-7C62-11EB-BF90-D0817AD9985D", P) Self
-  copy_addr %o to [initialization] %s2 : $*@opened("5B62392E-7C62-11EB-BF90-D0817AD9985D", P) Self
+  copy_addr %o to [init] %s2 : $*@opened("5B62392E-7C62-11EB-BF90-D0817AD9985D", P) Self
   destroy_addr %s2 : $*@opened("5B62392E-7C62-11EB-BF90-D0817AD9985D", P) Self
   dealloc_stack %s2 : $*@opened("5B62392E-7C62-11EB-BF90-D0817AD9985D", P) Self
   destroy_addr %s : $*P

--- a/test/SIL/verifier-init-existential.sil
+++ b/test/SIL/verifier-init-existential.sil
@@ -10,7 +10,7 @@ sil  @test : $@convention(thin) (@in Proto) -> @out Any {
 bb0(%0 : $*Any, %1 : $*Proto):
   // init_existential_addr should be able to put an existential container inside an existential container
   %2 = init_existential_addr %0 : $*Any, $Proto
-  copy_addr [take] %1 to [initialization] %2 : $*Proto
+  copy_addr [take] %1 to [init] %2 : $*Proto
   %4 = tuple ()
   return %4 : $()
 }

--- a/test/SILGen/address_only_types.swift
+++ b/test/SILGen/address_only_types.swift
@@ -33,7 +33,7 @@ func address_only_return(_ x: Unloadable, y: Int) -> Unloadable {
   // CHECK: bb0([[RET:%[0-9]+]] : $*any Unloadable, [[XARG:%[0-9]+]] : $*any Unloadable, [[YARG:%[0-9]+]] : $Builtin.Int64):
   // CHECK-NEXT: debug_value [[XARG]] : $*any Unloadable, let, name "x", {{.*}} expr op_deref
   // CHECK-NEXT: debug_value [[YARG]] : $Builtin.Int64, let, name "y"
-  // CHECK-NEXT: copy_addr [[XARG]] to [initialization] [[RET]]
+  // CHECK-NEXT: copy_addr [[XARG]] to [init] [[RET]]
   // CHECK-NEXT: [[VOID:%[0-9]+]] = tuple ()
   // CHECK-NEXT: return [[VOID]]
   return x
@@ -51,7 +51,7 @@ func address_only_conditional_missing_return(_ x: Unloadable) -> Unloadable {
   switch Bool.true_ {
   case .true_:
   // CHECK: [[TRUE]]:
-    // CHECK:   copy_addr %1 to [initialization] %0 : $*any Unloadable
+    // CHECK:   copy_addr %1 to [init] %0 : $*any Unloadable
   // CHECK:   return
     return x
   case .false_:
@@ -168,11 +168,11 @@ func address_only_assignment_from_lv(_ dest: inout Unloadable, v: Unloadable) {
   // CHECK: [[VBOX:%.*]] = alloc_box ${ var any Unloadable }
   // CHECK: [[V_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[VBOX]]
   // CHECK: [[PBOX:%[0-9]+]] = project_box [[V_LIFETIME]]
-  // CHECK: copy_addr [[VARG]] to [initialization] [[PBOX]] : $*any Unloadable
+  // CHECK: copy_addr [[VARG]] to [init] [[PBOX]] : $*any Unloadable
   dest = v
   // CHECK: [[READBOX:%.*]] = begin_access [read] [unknown] [[PBOX]] :
   // CHECK: [[TEMP:%[0-9]+]] = alloc_stack $any Unloadable
-  // CHECK: copy_addr [[READBOX]] to [initialization] [[TEMP]] :
+  // CHECK: copy_addr [[READBOX]] to [init] [[TEMP]] :
   // CHECK: [[RET:%.*]] = begin_access [modify] [unknown] %0 :
   // CHECK: copy_addr [take] [[TEMP]] to [[RET]] :
   // CHECK: destroy_value [[VBOX]]
@@ -200,7 +200,7 @@ func address_only_assignment_from_lv_to_property(_ v: Unloadable) {
   // CHECK: bb0([[VARG:%[0-9]+]] : $*any Unloadable):
   // CHECK: debug_value [[VARG]] : $*any Unloadable, {{.*}} expr op_deref
   // CHECK: [[TEMP:%[0-9]+]] = alloc_stack $any Unloadable
-  // CHECK: copy_addr [[VARG]] to [initialization] [[TEMP]]
+  // CHECK: copy_addr [[VARG]] to [init] [[TEMP]]
   // CHECK: [[SETTER:%[0-9]+]] = function_ref @$s18address_only_types11global_propAA10Unloadable_pvs
   // CHECK: apply [[SETTER]]([[TEMP]])
   // CHECK: dealloc_stack [[TEMP]]
@@ -217,7 +217,7 @@ func address_only_var() -> Unloadable {
   // CHECK: apply {{%.*}}([[XPB]])
   return x
   // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[XPB]] :
-  // CHECK: copy_addr [[ACCESS]] to [initialization] %0
+  // CHECK: copy_addr [[ACCESS]] to [init] %0
   // CHECK: destroy_value [[XBOX]]
   // CHECK: return
 }

--- a/test/SILGen/async_builtins.swift
+++ b/test/SILGen/async_builtins.swift
@@ -80,7 +80,7 @@ public func usesWithUnsafeContinuation() async {
 
   // CHECK: bb3:
   // CHECK: [[COPY:%.*]] = alloc_stack $Any
-  // CHECK: copy_addr [take] [[BOX]] to [initialization] [[COPY]]
+  // CHECK: copy_addr [take] [[BOX]] to [init] [[COPY]]
   // CHECK: destroy_addr [[COPY]]
   // CHECK: dealloc_stack [[COPY]]
   // CHECK: dealloc_stack [[BOX]]

--- a/test/SILGen/back_deploy_attribute_generic_func.swift
+++ b/test/SILGen/back_deploy_attribute_generic_func.swift
@@ -8,7 +8,7 @@
 // -- Fallback definition of genericFunc()
 // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy11genericFuncyxxlFTwB : $@convention(thin) <T> (@in_guaranteed T) -> @out T
 // CHECK: bb0([[OUT_ARG:%.*]] : $*T, [[IN_ARG:%.*]] : $*T):
-// CHECK:   copy_addr [[IN_ARG]] to [initialization] [[OUT_ARG]] : $*T
+// CHECK:   copy_addr [[IN_ARG]] to [init] [[OUT_ARG]] : $*T
 // CHECK:   [[RESULT:%.*]] = tuple ()
 // CHECK:   return [[RESULT]] : $()
 

--- a/test/SILGen/boxed_existentials.swift
+++ b/test/SILGen/boxed_existentials.swift
@@ -38,7 +38,7 @@ func test_composition_erasure(_ x: HairType & Error) -> Error {
 // CHECK:         [[NEW_EXISTENTIAL:%.*]] = alloc_existential_box $any Error, $[[VALUE_TYPE]]
 // CHECK:         [[ADDR:%.*]] = project_existential_box $[[VALUE_TYPE]] in [[NEW_EXISTENTIAL]] : $any Error
 // CHECK:         store [[NEW_EXISTENTIAL]] to [init] [[NEW_EXISTENTIALBUF:%.*]] :
-// CHECK:         copy_addr [[VALUE_ADDR]] to [initialization] [[ADDR]]
+// CHECK:         copy_addr [[VALUE_ADDR]] to [init] [[ADDR]]
 // CHECK-NOT:         destroy_addr [[OLD_EXISTENTIAL]]
 // CHECK:         [[NEW_EXISTENTIAL2:%.*]] = load [take] [[NEW_EXISTENTIALBUF]]
 // CHECK:         return [[NEW_EXISTENTIAL2]]
@@ -66,7 +66,7 @@ func test_property(_ x: Error) -> String {
 // CHECK:         [[VALUE:%.*]] = open_existential_box [[ARG]] : $any Error to $*[[VALUE_TYPE:@opened\(.*, any Error\) Self]]
 // FIXME: Extraneous copy here
 // CHECK-NEXT:    [[COPY:%[0-9]+]] = alloc_stack $[[VALUE_TYPE]]
-// CHECK-NEXT:    copy_addr [[VALUE]] to [initialization] [[COPY]] : $*[[VALUE_TYPE]]
+// CHECK-NEXT:    copy_addr [[VALUE]] to [init] [[COPY]] : $*[[VALUE_TYPE]]
 // CHECK:         [[METHOD:%.*]] = witness_method $[[VALUE_TYPE]], #Error._domain!getter
 // -- self parameter of witness is @in_guaranteed; no need to copy since
 //    value in box is immutable and box is guaranteed
@@ -91,10 +91,10 @@ func test_property_of_lvalue(_ x: Error) -> String {
 // CHECK:         [[BORROWED_VALUE_BOX:%.*]] = begin_borrow [[VALUE_BOX]]
 // CHECK:         [[VALUE:%.*]] = open_existential_box [[BORROWED_VALUE_BOX]] : $any Error to $*[[VALUE_TYPE:@opened\(.*, any Error\) Self]]
 // CHECK:         [[COPY:%.*]] = alloc_stack $[[VALUE_TYPE]]
-// CHECK:         copy_addr [[VALUE]] to [initialization] [[COPY]]
+// CHECK:         copy_addr [[VALUE]] to [init] [[COPY]]
 // CHECK:         destroy_value [[VALUE_BOX]]
 // CHECK:         [[BORROW:%.*]] = alloc_stack $[[VALUE_TYPE]]
-// CHECK:         copy_addr [[COPY]] to [initialization] [[BORROW]]
+// CHECK:         copy_addr [[COPY]] to [init] [[BORROW]]
 // CHECK:         [[METHOD:%.*]] = witness_method $[[VALUE_TYPE]], #Error._domain!getter
 // CHECK:         [[RESULT:%.*]] = apply [[METHOD]]<[[VALUE_TYPE]]>([[BORROW]])
 // CHECK:         destroy_addr [[COPY]]
@@ -210,7 +210,7 @@ func erasure_to_any(_ guaranteed: Error, _ immediate: Error) -> Any {
     // CHECK-NOT: copy_value [[GUAR]]
     // CHECK:     [[FROM_VALUE:%.*]] = open_existential_box [[GUAR:%.*]]
     // CHECK:     [[TO_VALUE:%.*]] = init_existential_addr [[OUT]]
-    // CHECK:     copy_addr [[FROM_VALUE]] to [initialization] [[TO_VALUE]]
+    // CHECK:     copy_addr [[FROM_VALUE]] to [init] [[TO_VALUE]]
     // CHECK-NOT: destroy_value [[GUAR]]
     return guaranteed
   } else if true {
@@ -219,7 +219,7 @@ func erasure_to_any(_ guaranteed: Error, _ immediate: Error) -> Any {
     // CHECK:     [[BORROWED_IMMEDIATE:%.*]] = begin_borrow [[IMMEDIATE]]
     // CHECK:     [[FROM_VALUE:%.*]] = open_existential_box [[BORROWED_IMMEDIATE]]
     // CHECK:     [[TO_VALUE:%.*]] = init_existential_addr [[OUT]]
-    // CHECK:     copy_addr [[FROM_VALUE]] to [initialization] [[TO_VALUE]]
+    // CHECK:     copy_addr [[FROM_VALUE]] to [init] [[TO_VALUE]]
     // CHECK:     destroy_value [[IMMEDIATE]]
     return immediate
   } else if true {
@@ -228,7 +228,7 @@ func erasure_to_any(_ guaranteed: Error, _ immediate: Error) -> Any {
     // CHECK:     [[BORROWED_PLUS_ONE:%.*]] = begin_borrow [[PLUS_ONE]]
     // CHECK:     [[FROM_VALUE:%.*]] = open_existential_box [[BORROWED_PLUS_ONE]]
     // CHECK:     [[TO_VALUE:%.*]] = init_existential_addr [[OUT]]
-    // CHECK:     copy_addr [[FROM_VALUE]] to [initialization] [[TO_VALUE]]
+    // CHECK:     copy_addr [[FROM_VALUE]] to [init] [[TO_VALUE]]
     // CHECK:     destroy_value [[PLUS_ONE]]
 
     return plusOneError()

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -66,7 +66,7 @@ func load_invariant_obj(_ x: Builtin.RawPointer) -> Builtin.NativeObject {
 // CHECK-LABEL: sil hidden [ossa] @$s8builtins8load_gen{{[_0-9a-zA-Z]*}}F
 func load_gen<T>(_ x: Builtin.RawPointer) -> T {
   // CHECK: [[ADDR:%.*]] = pointer_to_address {{%.*}} to [strict] $*T
-  // CHECK: copy_addr [[ADDR]] to [initialization] {{%.*}}
+  // CHECK: copy_addr [[ADDR]] to [init] {{%.*}}
   return Builtin.load(x)
 }
 
@@ -90,7 +90,7 @@ func move_obj(_ x: Builtin.RawPointer) -> Builtin.NativeObject {
 // CHECK-LABEL: sil hidden [ossa] @$s8builtins8move_gen{{[_0-9a-zA-Z]*}}F
 func move_gen<T>(_ x: Builtin.RawPointer) -> T {
   // CHECK: [[ADDR:%.*]] = pointer_to_address {{%.*}} to [strict] $*T
-  // CHECK: copy_addr [take] [[ADDR]] to [initialization] {{%.*}}
+  // CHECK: copy_addr [take] [[ADDR]] to [init] {{%.*}}
   return Builtin.take(x)
 }
 
@@ -188,7 +188,7 @@ func init_obj(_ x: Builtin.NativeObject, y: Builtin.RawPointer) {
 // CHECK-LABEL: sil hidden [ossa] @$s8builtins8init_gen{{[_0-9a-zA-Z]*}}F
 func init_gen<T>(_ x: T, y: Builtin.RawPointer) {
   // CHECK: [[ADDR:%.*]] = pointer_to_address {{%.*}} to [strict] $*T
-  // CHECK: copy_addr [[OTHER_LOC:%.*]] to [initialization]  [[ADDR]]
+  // CHECK: copy_addr [[OTHER_LOC:%.*]] to [init]  [[ADDR]]
   // CHECK-NOT: destroy_addr [[OTHER_LOC]]
   Builtin.initialize(x, y)
 }
@@ -593,7 +593,7 @@ func reinterpretAddrOnly<T, U>(_ t: T) -> U {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8builtins28reinterpretAddrOnlyToTrivial{{[_0-9a-zA-Z]*}}F
 func reinterpretAddrOnlyToTrivial<T>(_ t: T) -> Int {
-  // CHECK: copy_addr %0 to [initialization] [[INPUT:%.*]] : $*T
+  // CHECK: copy_addr %0 to [init] [[INPUT:%.*]] : $*T
   // CHECK: [[ADDR:%.*]] = unchecked_addr_cast [[INPUT]] : $*T to $*Int
   // CHECK: [[VALUE:%.*]] = load [trivial] [[ADDR]]
   // CHECK: destroy_addr [[INPUT]]
@@ -605,7 +605,7 @@ func reinterpretAddrOnlyLoadable<T>(_ a: Int, _ b: T) -> (T, Int) {
   // CHECK: [[BUF:%.*]] = alloc_stack $Int
   // CHECK: store {{%.*}} to [trivial] [[BUF]]
   // CHECK: [[RES1:%.*]] = unchecked_addr_cast [[BUF]] : $*Int to $*T
-  // CHECK: copy_addr [[RES1]] to [initialization]
+  // CHECK: copy_addr [[RES1]] to [init]
   return (Builtin.reinterpretCast(a) as T,
   // CHECK: [[RES:%.*]] = unchecked_addr_cast {{%.*}} : $*T to $*Int
   // CHECK: load [trivial] [[RES]]

--- a/test/SILGen/capture_list.swift
+++ b/test/SILGen/capture_list.swift
@@ -17,7 +17,7 @@ class Bar {
   // CHECK: [[PAYLOAD:%.*]] = project_box [[BOX]]
   // CHECK: [[COPY:%.*]] = copy_value %0
   // CHECK: [[OPTIONAL_COPY:%.*]] = enum $Optional<Bar>, #Optional.some!enumelt
-  // CHECK: store_weak [[OPTIONAL_COPY]] to [initialization] [[PAYLOAD]]
+  // CHECK: store_weak [[OPTIONAL_COPY]] to [init] [[PAYLOAD]]
   // CHECK: destroy_value [[OPTIONAL_COPY]]
   // CHECK: [[CLOSURE_FN:%.*]] = function_ref @$s12capture_list3BarC4testyyFSiycfU_ : $@convention(thin) (@owned { var @sil_weak Optional<Bar> }) -> Int
   // CHECK: [[BOX_COPY:%.*]] = copy_value [[BOX]]

--- a/test/SILGen/casts.swift
+++ b/test/SILGen/casts.swift
@@ -79,7 +79,7 @@ struct S : P {}
 // CHECK: sil hidden [ossa] @$s5casts32downcast_existential_conditional{{[_0-9a-zA-Z]*}}F
 // CHECK: bb0([[IN:%.*]] : $*any P):
 // CHECK:   [[COPY:%.*]] = alloc_stack $any P
-// CHECK:   copy_addr [[IN]] to [initialization] [[COPY]]
+// CHECK:   copy_addr [[IN]] to [init] [[COPY]]
 // CHECK:   [[TMP:%.*]] = alloc_stack $S
 // CHECK:   checked_cast_addr_br take_always any P in [[COPY]] : $*any P to S in [[TMP]] : $*S, bb1, bb2
 //   Success block.

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -71,7 +71,7 @@ func write_to_capture(_ x: Int) -> Int {
   // CHECK:   [[X2BOX:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK:   [[X2BOX_PB:%.*]] = project_box [[X2BOX]]
   // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[XBOX_PB]] : $*Int
-  // CHECK:   copy_addr [[ACCESS]] to [initialization] [[X2BOX_PB]]
+  // CHECK:   copy_addr [[ACCESS]] to [init] [[X2BOX_PB]]
   // CHECK:   [[X2LIFETIME:%[0-9]+]] = begin_borrow [[X2BOX]]
   // CHECK:   mark_function_escape [[X2BOX_PB]]
   var x2 = x

--- a/test/SILGen/copy_lvalue_peepholes.swift
+++ b/test/SILGen/copy_lvalue_peepholes.swift
@@ -13,7 +13,7 @@ func getInt() -> Int { return zero }
 // CHECK:   [[Y:%.*]] = alloc_box ${ var Builtin.Int64 }
 // CHECK:   [[PBY:%.*]] = project_box [[Y]]
 // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] [[PBX]]
-// CHECK:   copy_addr [[READ]] to [initialization] [[PBY]] : $*Builtin.Int64
+// CHECK:   copy_addr [[READ]] to [init] [[PBY]] : $*Builtin.Int64
 func init_var_from_lvalue(x: Int) {
   var x = x
   var y = x

--- a/test/SILGen/decls.swift
+++ b/test/SILGen/decls.swift
@@ -44,9 +44,9 @@ func tuple_patterns() {
   // CHECK: [[DADDR:%[0-9]+]] = alloc_box ${ var Float }
   // CHECK: [[PBD:%.*]] = project_box [[DADDR]]
   // CHECK: [[READA:%.*]] = begin_access [read] [unknown] [[PBA]] : $*Int
-  // CHECK: copy_addr [[READA]] to [initialization] [[PBC]]
+  // CHECK: copy_addr [[READA]] to [init] [[PBC]]
   // CHECK: [[READB:%.*]] = begin_access [read] [unknown] [[PBB]] : $*Float
-  // CHECK: copy_addr [[READB]] to [initialization] [[PBD]]
+  // CHECK: copy_addr [[READB]] to [init] [[PBD]]
   // CHECK: [[EADDR:%[0-9]+]] = alloc_box ${ var Int }
   // CHECK: [[PBE:%.*]] = project_box [[EADDR]]
   // CHECK: [[FADDR:%[0-9]+]] = alloc_box ${ var Float }
@@ -65,7 +65,7 @@ func tuple_patterns() {
   // CHECK: [[PBI:%.*]] = project_box [[IADDR]]
   // CHECK-NOT: alloc_box ${ var Float }
   // CHECK: [[READA:%.*]] = begin_access [read] [unknown] [[PBA]] : $*Int
-  // CHECK: copy_addr [[READA]] to [initialization] [[PBI]]
+  // CHECK: copy_addr [[READA]] to [init] [[PBI]]
   // CHECK: [[READB:%.*]] = begin_access [read] [unknown] [[PBB]] : $*Float
   // CHECK: [[B:%[0-9]+]] = load [trivial] [[READB]]
   // CHECK-NOT: store [[B]]

--- a/test/SILGen/didset_oldvalue_not_accessed_silgen.swift
+++ b/test/SILGen/didset_oldvalue_not_accessed_silgen.swift
@@ -23,7 +23,7 @@ let foo = Foo(value: "Hello")
 // CHECK: debug_value [[VALUE:%.*]] : $*T, let, name "value", argno {{[0-9+]}}, {{.*}} expr op_deref
 // CHECK-NEXT: debug_value [[SELF:%.*]] : $Foo<T>, let, name "self", argno {{[0-9+]}}
 // CHECK-NEXT: [[ALLOC_STACK:%.*]] = alloc_stack $T
-// CHECK-NEXT: copy_addr [[VALUE]] to [initialization] [[ALLOC_STACK]] : $*T
+// CHECK-NEXT: copy_addr [[VALUE]] to [init] [[ALLOC_STACK]] : $*T
 // CHECK-NEXT: [[REF_ADDR:%.*]] = ref_element_addr [[SELF]] : $Foo<T>, #Foo.value
 // CHECK-NEXT: [[BEGIN_ACCESS:%.*]] = begin_access [modify] [dynamic] [[REF_ADDR]] : $*T
 // CHECK-NEXT: copy_addr [take] [[ALLOC_STACK]] to [[BEGIN_ACCESS]] : $*T

--- a/test/SILGen/dynamic_self.swift
+++ b/test/SILGen/dynamic_self.swift
@@ -97,7 +97,7 @@ func testExistentialDispatch(p: P) {
 // CHECK:   [[PCOPY_ADDR:%[0-9]+]] = open_existential_addr immutable_access [[P]] : $*any P to $*@opened([[N:".*"]], any P) Self
 // CHECK:   [[P_RESULT:%[0-9]+]] = alloc_stack $any P
 // CHECK:   [[PCOPY_ADDR_1:%[0-9]+]] = alloc_stack $@opened([[N]], any P) Self
-// CHECK:   copy_addr [[PCOPY_ADDR]] to [initialization] [[PCOPY_ADDR_1]] : $*@opened([[N]], any P) Self
+// CHECK:   copy_addr [[PCOPY_ADDR]] to [init] [[PCOPY_ADDR_1]] : $*@opened([[N]], any P) Self
 // CHECK:   [[P_P_GETTER:%[0-9]+]] = witness_method $@opened([[N]], any P) Self, #P.p!getter : {{.*}}, [[PCOPY_ADDR]]{{.*}} : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
 // CHECK:   [[P_RESULT_ADDR2:%[0-9]+]] = init_existential_addr [[P_RESULT]] : $*any P, $@opened([[N]], any P) Self
 // CHECK:   apply [[P_P_GETTER]]<@opened([[N]], any P) Self>([[P_RESULT_ADDR2]], [[PCOPY_ADDR_1]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
@@ -110,7 +110,7 @@ func testExistentialDispatch(p: P) {
 // CHECK:   [[PCOPY_ADDR:%[0-9]+]] = open_existential_addr immutable_access [[P]] : $*any P to $*@opened([[N:".*"]], any P) Self
 // CHECK:   [[P_RESULT:%[0-9]+]] = alloc_stack $any P
 // CHECK:   [[PCOPY_ADDR_1:%[0-9]+]] = alloc_stack $@opened([[N]], any P) Self
-// CHECK:   copy_addr [[PCOPY_ADDR]] to [initialization] [[PCOPY_ADDR_1]] : $*@opened([[N]], any P) Self
+// CHECK:   copy_addr [[PCOPY_ADDR]] to [init] [[PCOPY_ADDR_1]] : $*@opened([[N]], any P) Self
 // CHECK:   [[P_SUBSCRIPT_GETTER:%[0-9]+]] = witness_method $@opened([[N]], any P) Self, #P.subscript!getter : {{.*}}, [[PCOPY_ADDR]]{{.*}} : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
 // CHECK:   [[P_RESULT_ADDR:%[0-9]+]] = init_existential_addr [[P_RESULT]] : $*any P, $@opened([[N]], any P) Self
 // CHECK:   apply [[P_SUBSCRIPT_GETTER]]<@opened([[N]], any P) Self>([[P_RESULT_ADDR]], [[PCOPY_ADDR_1]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0

--- a/test/SILGen/enum.swift
+++ b/test/SILGen/enum.swift
@@ -68,7 +68,7 @@ func AddressOnly_cases(_ s: S) {
   // CHECK-NEXT:  store %0 to [trivial] [[PAYLOAD_ADDR]]
   // CHECK-NEXT:  [[MERE:%.*]] = alloc_stack $AddressOnly
   // CHECK-NEXT:  [[PAYLOAD:%.*]] = init_enum_data_addr [[MERE]]
-  // CHECK-NEXT:  copy_addr [take] [[P_BUF]] to [initialization] [[PAYLOAD]] : $*any P
+  // CHECK-NEXT:  copy_addr [take] [[P_BUF]] to [init] [[PAYLOAD]] : $*any P
   // CHECK-NEXT:  inject_enum_addr [[MERE]]
   // CHECK-NEXT:  destroy_addr [[MERE]]
   // CHECK-NEXT:  dealloc_stack [[MERE]]
@@ -106,10 +106,10 @@ func PolyOptionable_cases<T>(_ t: T) {
 
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin PolyOptionable<T>.Type
 // CHECK-NEXT:    [[T_BUF:%.*]] = alloc_stack $T
-// CHECK-NEXT:    copy_addr %0 to [initialization] [[T_BUF]]
+// CHECK-NEXT:    copy_addr %0 to [init] [[T_BUF]]
 // CHECK-NEXT:    [[MERE:%.*]] = alloc_stack $PolyOptionable<T>
 // CHECK-NEXT:    [[PAYLOAD:%.*]] = init_enum_data_addr [[MERE]]
-// CHECK-NEXT:    copy_addr [take] [[T_BUF]] to [initialization] [[PAYLOAD]] : $*T
+// CHECK-NEXT:    copy_addr [take] [[T_BUF]] to [init] [[PAYLOAD]] : $*T
 // CHECK-NEXT:    inject_enum_addr [[MERE]]
 // CHECK-NEXT:    destroy_addr [[MERE]]
 // CHECK-NEXT:    dealloc_stack [[MERE]]

--- a/test/SILGen/enum_resilience.swift
+++ b/test/SILGen/enum_resilience.swift
@@ -11,7 +11,7 @@ import resilient_enum
 
 // CHECK-LABEL: sil hidden [ossa] @$s15enum_resilience15resilientSwitchyy0c1_A06MediumOF : $@convention(thin) (@in_guaranteed Medium) -> ()
 // CHECK:         [[BOX:%.*]] = alloc_stack $Medium
-// CHECK-NEXT:    copy_addr %0 to [initialization] [[BOX]]
+// CHECK-NEXT:    copy_addr %0 to [init] [[BOX]]
 // CHECK-NEXT:    [[METATYPE:%.+]] = value_metatype $@thick Medium.Type, [[BOX]] : $*Medium
 // CHECK-NEXT:    switch_enum_addr [[BOX]] : $*Medium, case #Medium.Paper!enumelt: bb1, case #Medium.Canvas!enumelt: bb2, case #Medium.Pamphlet!enumelt: bb3, case #Medium.Postcard!enumelt: bb4, default bb5
 // CHECK:       bb1:
@@ -124,7 +124,7 @@ public enum MyResilientEnum {
   // CHECK:       [[ACCESS:%.*]] = begin_access [modify] [unknown] [[SELF_ADDR]] : $*MyResilientEnum
   // CHECK:       assign [[NEW_SELF]] to [[ACCESS]] : $*MyResilientEnum
   // CHECK:       end_access [[ACCESS]] : $*MyResilientEnum
-  // CHECK:       copy_addr [[SELF_ADDR]] to [initialization] %0 : $*MyResilientEnum
+  // CHECK:       copy_addr [[SELF_ADDR]] to [init] %0 : $*MyResilientEnum
   // CHECK:       destroy_value [[SELF_TMP]] : ${ var MyResilientEnum }
   // CHECK:       return
   init() {
@@ -157,7 +157,7 @@ public enum MoreHorses {
   // CHECK:       [[ACCESS:%.*]] = begin_access [modify] [unknown] [[SELF_ADDR]] : $*MoreHorses
   // CHECK:       assign [[NEW_SELF]] to [[ACCESS]] : $*MoreHorses
   // CHECK:       end_access [[ACCESS]] : $*MoreHorses
-  // CHECK:       copy_addr [[SELF_ADDR]] to [initialization] %0 : $*MoreHorses
+  // CHECK:       copy_addr [[SELF_ADDR]] to [init] %0 : $*MoreHorses
   // CHECK:       destroy_value [[SELF_TMP]] : ${ var MoreHorses }
   // CHECK:       return
   init() {
@@ -197,7 +197,7 @@ public func resilientIfCase(_ e: MyResilientEnum) -> Bool {
 
 // CHECK-LABEL: sil [serialized] [ossa] @$s15enum_resilience15inlinableSwitchyyAA15MyResilientEnumOF : $@convention(thin) (@in_guaranteed MyResilientEnum) -> ()
 // CHECK:      [[ENUM:%.*]] = alloc_stack $MyResilientEnum
-// CHECK:      copy_addr %0 to [initialization] [[ENUM]] : $*MyResilientEnum
+// CHECK:      copy_addr %0 to [init] [[ENUM]] : $*MyResilientEnum
 // CHECK:      switch_enum_addr [[ENUM]] : $*MyResilientEnum, case #MyResilientEnum.kevin!enumelt: bb1, case #MyResilientEnum.loki!enumelt: bb2, default bb3
 // CHECK:      return
 @inlinable public func inlinableSwitch(_ e: MyResilientEnum) {

--- a/test/SILGen/enum_resilience_testable.swift
+++ b/test/SILGen/enum_resilience_testable.swift
@@ -16,7 +16,7 @@
 
 // CHECK-LABEL: sil hidden [ossa] @$s24enum_resilience_testable15resilientSwitchyy0d1_A06MediumOF : $@convention(thin) (@in_guaranteed Medium) -> ()
 // CHECK:         [[BOX:%.*]] = alloc_stack $Medium
-// CHECK-NEXT:    copy_addr %0 to [initialization] [[BOX]]
+// CHECK-NEXT:    copy_addr %0 to [init] [[BOX]]
 // CHECK-NEXT:    [[METATYPE:%.+]] = value_metatype $@thick Medium.Type, [[BOX]] : $*Medium
 // CHECK-NEXT:    switch_enum_addr [[BOX]] : $*Medium, case #Medium.Paper!enumelt: bb1, case #Medium.Canvas!enumelt: bb2, case #Medium.Pamphlet!enumelt: bb3, case #Medium.Postcard!enumelt: bb4, default bb5
 // CHECK:       bb1:

--- a/test/SILGen/errors.swift
+++ b/test/SILGen/errors.swift
@@ -996,7 +996,7 @@ func testOptionalTryNeverFailsVar() {
 // CHECK: bb0(%0 : $*T):
 // CHECK:   [[BOX:%.+]] = alloc_stack $Optional<T>
 // CHECK-NEXT:   [[BOX_DATA:%.+]] = init_enum_data_addr [[BOX]] : $*Optional<T>, #Optional.some!enumelt
-// CHECK-NEXT:   copy_addr %0 to [initialization] [[BOX_DATA]] : $*T
+// CHECK-NEXT:   copy_addr %0 to [init] [[BOX_DATA]] : $*T
 // CHECK-NEXT:   inject_enum_addr [[BOX]] : $*Optional<T>, #Optional.some!enumelt
 // CHECK-NEXT:   destroy_addr [[BOX]] : $*Optional<T>
 // CHECK-NEXT:   dealloc_stack [[BOX]] : $*Optional<T>
@@ -1014,7 +1014,7 @@ func testOptionalTryNeverFailsAddressOnly<T>(_ obj: T) {
 // CHECK-NEXT:   [[LIFETIME:%.+]] = begin_borrow [lexical] [[BOX]]
 // CHECK-NEXT:   [[PB:%.*]] = project_box [[LIFETIME]]
 // CHECK-NEXT:   [[BOX_DATA:%.+]] = init_enum_data_addr [[PB]] : $*Optional<T>, #Optional.some!enumelt
-// CHECK-NEXT:   copy_addr %0 to [initialization] [[BOX_DATA]] : $*T
+// CHECK-NEXT:   copy_addr %0 to [init] [[BOX_DATA]] : $*T
 // CHECK-NEXT:   inject_enum_addr [[PB]] : $*Optional<T>, #Optional.some!enumelt
 // CHECK-NEXT:   end_borrow [[LIFETIME]]
 // CHECK-NEXT:   destroy_value [[BOX]] : $<τ_0_0> { var Optional<τ_0_0> } <T>

--- a/test/SILGen/existential_erasure.swift
+++ b/test/SILGen/existential_erasure.swift
@@ -27,7 +27,7 @@ func throwingFunc() throws -> Bool { return true }
 func PQtoP() {
   // CHECK: [[PQ_PAYLOAD:%.*]] = open_existential_addr immutable_access [[PQ:%.*]] : $*any P & Q to $*[[OPENED_TYPE:@opened\(.*, any P & Q\) Self]]
   // CHECK: [[P_PAYLOAD:%.*]] = init_existential_addr [[P:%.*]] : $*any P, $[[OPENED_TYPE]]
-  // CHECK: copy_addr [[PQ_PAYLOAD]] to [initialization] [[P_PAYLOAD]]
+  // CHECK: copy_addr [[PQ_PAYLOAD]] to [init] [[P_PAYLOAD]]
   // CHECK: destroy_addr [[PQ]]
   // CHECK-NOT: destroy_addr [[P]]
   // CHECK-NOT: destroy_addr [[P_PAYLOAD]]

--- a/test/SILGen/existential_member_accesses_self_assoctype.swift
+++ b/test/SILGen/existential_member_accesses_self_assoctype.swift
@@ -152,7 +152,7 @@ func testCovariantSelfMethod8(p: any P) {
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // FIXME: What's this copy for?
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantSelfProperty1!getter : <Self where Self : P> (Self) -> () -> Self
 // CHECK: [[DEST:%[0-9]+]] = init_existential_addr [[LET]] : $*any P, $@opened([[OPENED_ID]], any P) Self
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[DEST]], [[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
@@ -163,7 +163,7 @@ func testCovariantSelfProperty1(p: any P) {
 // CHECK: [[LET:%[0-9]+]] = alloc_stack [lexical] $Optional<any P>, let, name "x"
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantSelfProperty2!getter : <Self where Self : P> (Self) -> () -> Self?
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPTIONAL:%[0-9]+]], [[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
 // CHECK: init_existential_addr %{{[0-9]+}} : $*any P, $@opened([[OPENED_ID]], any P) Self
@@ -173,7 +173,7 @@ func testCovariantSelfProperty2(p: any P) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype26testCovariantSelfProperty31pyAA1P_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantSelfProperty3!getter : <Self where Self : P> (Self) -> () -> Self.Type
 // CHECK: [[META:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @thick τ_0_0.Type
 // CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick (@opened([[OPENED_ID]], any P) Self).Type, $@thick any P.Type
@@ -185,7 +185,7 @@ func testCovariantSelfProperty3(p: any P) {
 // CHECK: [[LET:%[0-9]+]] = alloc_stack [lexical] $(any P, any P), let, name "x"
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantSelfProperty4!getter : <Self where Self : P> (Self) -> () -> (Self, Self)
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[SRC_0:%[0-9]+]], [[SRC_1:%[0-9]+]], [[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @out τ_0_0)
 // CHECK: [[DEST_0_INITED:%[0-9]+]] = init_existential_addr %{{[0-9]+}} : $*any P, $@opened([[OPENED_ID]], any P) Self
@@ -196,7 +196,7 @@ func testCovariantSelfProperty4(p: any P) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype26testCovariantSelfProperty51pyAA1P_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantSelfProperty5!getter : <Self where Self : P> (Self) -> () -> Array<Self>
 // CHECK: [[ARRAY:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned Array<τ_0_0>
 // CHECK: [[ARRAY_UPCAST_FN:%[0-9]+]] = function_ref @$ss15_arrayForceCastySayq_GSayxGr0_lF : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
@@ -208,7 +208,7 @@ func testCovariantSelfProperty5(p: any P) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype26testCovariantSelfProperty61pyAA1P_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantSelfProperty6!getter : <Self where Self : P> (Self) -> () -> [String : Self]
 // CHECK: [[DICT:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned Dictionary<String, τ_0_0>
 // CHECK: [[DICT_UPCAST_FN:%[0-9]+]] = function_ref @$ss17_dictionaryUpCastySDyq0_q1_GSDyxq_GSHRzSHR0_r2_lF : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
@@ -220,7 +220,7 @@ func testCovariantSelfProperty6(p: any P) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype26testCovariantSelfProperty71pyAA1P_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self,  #P.covariantSelfProperty7!getter : <Self where Self : P> (Self) -> () -> ((Self) -> ()) -> ()
 // CHECK: [[RESULT_FN:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned @callee_guaranteed @substituted <τ_0_0> (@noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>) -> () for <τ_0_0>
 // CHECK: [[STEP1:%[0-9]+]] = convert_function [[RESULT_FN]] : $@callee_guaranteed @substituted <τ_0_0> (@noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>) -> () for <@opened([[OPENED_ID]], any P) Self> to $@callee_guaranteed (@noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <@opened([[OPENED_ID]], any P) Self>) -> ()
@@ -233,7 +233,7 @@ func testCovariantSelfProperty7(p: any P) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype26testCovariantSelfProperty81pyAA1P_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*[[OPENED_TY:@opened\("[0-9A-F-]+", any P\) Self]]
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $[[OPENED_TY]]
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*[[OPENED_TY]]
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*[[OPENED_TY]]
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $[[OPENED_TY]],  #P.covariantSelfProperty8!getter : <Self where Self : P> (Self) -> () -> ((Self...) -> ()) -> ()
 // CHECK: [[RESULT_FN:%[0-9]+]] = apply [[WITNESS]]<[[OPENED_TY]]>([[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 == τ_0_1> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 == τ_0_1> (@guaranteed Array<τ_0_0>) -> () for <τ_0_0, τ_0_0>) -> () for <τ_0_0, τ_0_0>
 // CHECK: [[STEP1:%[0-9]+]] = convert_function [[RESULT_FN]] : $@callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 == τ_0_1> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 == τ_0_1> (@guaranteed Array<τ_0_0>) -> () for <τ_0_0, τ_0_0>) -> () for <[[OPENED_TY]], [[OPENED_TY]]> to $@callee_guaranteed (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 == τ_0_1> (@guaranteed Array<τ_0_0>) -> () for <[[OPENED_TY]], [[OPENED_TY]]>) -> ()
@@ -253,7 +253,7 @@ func testCovariantSelfProperty8(p: any P) {
 // CHECK: [[LET:%[0-9]+]] = alloc_stack [lexical] $any P, let, name "x"
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> Self
 // CHECK: [[DEST:%[0-9]+]] = init_existential_addr [[LET]] : $*any P, $@opened([[OPENED_ID]], any P) Self
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[DEST]], [[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0
@@ -264,7 +264,7 @@ func testCovariantSelfSubscript1(p: any P) {
 // CHECK: [[LET:%[0-9]+]] = alloc_stack [lexical] $Optional<any P>, let, name "x"
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> Self?
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPTIONAL:%[0-9]+]], [[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
 // CHECK: init_existential_addr %{{[0-9]+}} : $*any P, $@opened([[OPENED_ID]], any P) Self
@@ -274,7 +274,7 @@ func testCovariantSelfSubscript2(p: any P) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype27testCovariantSelfSubscript31pyAA1P_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> Self.Type
 // CHECK: [[META:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @thick τ_0_0.Type
 // CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick (@opened([[OPENED_ID]], any P) Self).Type, $@thick any P.Type
@@ -286,7 +286,7 @@ func testCovariantSelfSubscript3(p: any P) {
 // CHECK: [[LET:%[0-9]+]] = alloc_stack [lexical] $(any P, any P), let, name "x"
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> (Self, Self)
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[SRC_0:%[0-9]+]], [[SRC_1:%[0-9]+]], [[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> (@out τ_0_0, @out τ_0_0)
 // CHECK: init_existential_addr %{{[0-9]+}} : $*any P, $@opened([[OPENED_ID]], any P) Self
@@ -297,7 +297,7 @@ func testCovariantSelfSubscript4(p: any P) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype27testCovariantSelfSubscript51pyAA1P_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> Array<Self>
 // CHECK: [[ARRAY:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned Array<τ_0_0>
 // CHECK: [[ARRAY_UPCAST_FN:%[0-9]+]] = function_ref @$ss15_arrayForceCastySayq_GSayxGr0_lF : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
@@ -309,7 +309,7 @@ func testCovariantSelfSubscript5(p: any P) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype27testCovariantSelfSubscript61pyAA1P_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> [String : Self]
 // CHECK: [[DICT:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned Dictionary<String, τ_0_0>
 // CHECK: [[DICT_UPCAST_FN:%[0-9]+]] = function_ref @$ss17_dictionaryUpCastySDyq0_q1_GSDyxq_GSHRzSHR0_r2_lF : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
@@ -325,7 +325,7 @@ func testCovariantSelfSubscript6(p: any P) {
 // CHECK: [[STEP2:%[0-9]+]] = convert_function [[STEP1]] : $@callee_guaranteed (@in_guaranteed @opened([[OPENED_ID]], any P) Self) -> () to $@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <@opened([[OPENED_ID]], any P) Self>
 // CHECK: [[STEP3:%[0-9]+]] = convert_escape_to_noescape [not_guaranteed] [[STEP2]]
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> ((Self) -> ()) -> ()
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[STEP3]], [[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>, @in_guaranteed τ_0_0) -> ()
 func testCovariantSelfSubscript7(p: any P) {
@@ -338,7 +338,7 @@ func testCovariantSelfSubscript7(p: any P) {
 // CHECK: [[STEP2:%[0-9]+]] = convert_function [[STEP1]] : $@callee_guaranteed (@guaranteed Array<[[OPENED_TY]]>) -> () to $@callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 == τ_0_1> (@guaranteed Array<τ_0_0>) -> () for <[[OPENED_TY]], [[OPENED_TY]]>
 // CHECK: [[STEP3:%[0-9]+]] = convert_escape_to_noescape [not_guaranteed] [[STEP2]]
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $[[OPENED_TY]]
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*[[OPENED_TY]]
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*[[OPENED_TY]]
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $[[OPENED_TY]], #P.subscript!getter : <Self where Self : P> (Self) -> ((Self...) -> ()) -> ()
 // CHECK: apply [[WITNESS]]<[[OPENED_TY]]>([[STEP3]], [[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 == τ_0_1> (@guaranteed Array<τ_0_0>) -> () for <τ_0_0, τ_0_0>, @in_guaranteed τ_0_0) -> ()
 func testCovariantSelfSubscript8(p: any P) {
@@ -435,7 +435,7 @@ func testCovariantAssocMethod8(p: any P) {
 // CHECK: [[LET:%[0-9]+]] = alloc_stack [lexical] $Any, let, name "x"
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocProperty1!getter : <Self where Self : P> (Self) -> () -> Self.A
 // CHECK: [[DEST:%[0-9]+]] = init_existential_addr [[LET]] : $*Any, $@opened([[OPENED_ID]], any P) Self.A
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[DEST]], [[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0.A
@@ -446,7 +446,7 @@ func testCovariantAssocProperty1(p: any P) {
 // CHECK: [[LET:%[0-9]+]] = alloc_stack [lexical] $Optional<Any>, let, name "x"
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocProperty2!getter : <Self where Self : P> (Self) -> () -> Self.A?
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>(%{{[0-9]+}}, [[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0.A>
 // CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $@opened([[OPENED_ID]], any P) Self.A
@@ -456,7 +456,7 @@ func testCovariantAssocProperty2(p: any P) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype27testCovariantAssocProperty31pyAA1P_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocProperty3!getter : <Self where Self : P> (Self) -> () -> Self.A.Type
 // CHECK: [[META:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @thick τ_0_0.A.Type
 // CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick (@opened([[OPENED_ID]], any P) Self.A).Type, $@thick any Any.Type
@@ -468,7 +468,7 @@ func testCovariantAssocProperty3(p: any P) {
 // CHECK: [[LET:%[0-9]+]] = alloc_stack [lexical] $(Any, Any), let, name "x"
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocProperty4!getter : <Self where Self : P> (Self) -> () -> (Self.A, Self.A)
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>(%{{[0-9]+}}, %{{[0-9]+}}, [[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> (@out τ_0_0.A, @out τ_0_0.A)
 // CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $@opened([[OPENED_ID]], any P) Self.A
@@ -479,7 +479,7 @@ func testCovariantAssocProperty4(p: any P) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype27testCovariantAssocProperty51pyAA1P_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocProperty5!getter : <Self where Self : P> (Self) -> () -> Array<Self.A>
 // CHECK: [[ARRAY:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned Array<τ_0_0.A>
 // CHECK: [[ARRAY_UPCAST_FN:%[0-9]+]] = function_ref @$ss15_arrayForceCastySayq_GSayxGr0_lF : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
@@ -491,7 +491,7 @@ func testCovariantAssocProperty5(p: any P) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype27testCovariantAssocProperty61pyAA1P_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.covariantAssocProperty6!getter : <Self where Self : P> (Self) -> () -> [String : Self.A]
 // CHECK: [[DICT:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned Dictionary<String, τ_0_0.A>
 // CHECK: [[DICT_UPCAST_FN:%[0-9]+]] = function_ref @$ss17_dictionaryUpCastySDyq0_q1_GSDyxq_GSHRzSHR0_r2_lF : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
@@ -503,7 +503,7 @@ func testCovariantAssocProperty6(p: any P) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype27testCovariantAssocProperty71pyAA1P_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self,  #P.covariantAssocProperty7!getter : <Self where Self : P> (Self) -> () -> ((Self.A) -> ()) -> ()
 // CHECK: [[RESULT_FN:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned @callee_guaranteed @substituted <τ_0_0> (@noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>) -> () for <τ_0_0.A>
 // CHECK: [[STEP1:%[0-9]+]] = convert_function [[RESULT_FN]] : $@callee_guaranteed @substituted <τ_0_0> (@noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0>) -> () for <@opened([[OPENED_ID]], any P) Self.A> to $@callee_guaranteed (@noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <@opened([[OPENED_ID]], any P) Self.A>) -> ()
@@ -516,7 +516,7 @@ func testCovariantAssocProperty7(p: any P) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype27testCovariantAssocProperty81pyAA1P_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*[[OPENED_TY:@opened\("[0-9A-F-]+", any P\) Self]]
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $[[OPENED_TY]]
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*[[OPENED_TY]]
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*[[OPENED_TY]]
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $[[OPENED_TY]],  #P.covariantAssocProperty8!getter : <Self where Self : P> (Self) -> () -> ((Self.A...) -> ()) -> ()
 // CHECK: [[RESULT_FN:%[0-9]+]] = apply [[WITNESS]]<[[OPENED_TY]]>([[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 == τ_0_1> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 == τ_0_1> (@guaranteed Array<τ_0_0>) -> () for <τ_0_0, τ_0_0>) -> () for <τ_0_0.A, τ_0_0.A>
 // CHECK: [[STEP1:%[0-9]+]] = convert_function [[RESULT_FN]] : $@callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 == τ_0_1> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 == τ_0_1> (@guaranteed Array<τ_0_0>) -> () for <τ_0_0, τ_0_0>) -> () for <[[OPENED_TY]].A, [[OPENED_TY]].A> to $@callee_guaranteed (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 == τ_0_1> (@guaranteed Array<τ_0_0>) -> () for <[[OPENED_TY]].A, [[OPENED_TY]].A>) -> ()
@@ -536,7 +536,7 @@ func testCovariantAssocProperty8(p: any P) {
 // CHECK: [[LET:%[0-9]+]] = alloc_stack [lexical] $Any, let, name "x"
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> Self.A
 // CHECK: [[DEST:%[0-9]+]] = init_existential_addr [[LET]] : $*Any, $@opened([[OPENED_ID]], any P) Self.A
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[DEST]], [[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out τ_0_0.A
@@ -547,7 +547,7 @@ func testCovariantAssocSubscript1(p: any P) {
 // CHECK: [[LET:%[0-9]+]] = alloc_stack [lexical] $Optional<Any>, let, name "x"
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> Self.A?
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>(%{{[0-9]+}}, [[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0.A>
 // CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $@opened([[OPENED_ID]], any P) Self.A
@@ -557,7 +557,7 @@ func testCovariantAssocSubscript2(p: any P) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype28testCovariantAssocSubscript31pyAA1P_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> Self.A.Type
 // CHECK: [[META:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @thick τ_0_0.A.Type
 // CHECK: [[EXIST_META:%[0-9]+]] = init_existential_metatype [[META]] : $@thick (@opened([[OPENED_ID]], any P) Self.A).Type, $@thick any Any.Type
@@ -569,7 +569,7 @@ func testCovariantAssocSubscript3(p: any P) {
 // CHECK: [[LET:%[0-9]+]] = alloc_stack [lexical] $(Any, Any), let, name "x"
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> (Self.A, Self.A)
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>(%{{[0-9]+}}, %{{[0-9]+}}, [[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> (@out τ_0_0.A, @out τ_0_0.A)
 // CHECK: init_existential_addr %{{[0-9]+}} : $*Any, $@opened([[OPENED_ID]], any P) Self.A
@@ -580,7 +580,7 @@ func testCovariantAssocSubscript4(p: any P) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype28testCovariantAssocSubscript51pyAA1P_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> Array<Self.A>
 // CHECK: [[ARRAY:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned Array<τ_0_0.A>
 // CHECK: [[ARRAY_UPCAST_FN:%[0-9]+]] = function_ref @$ss15_arrayForceCastySayq_GSayxGr0_lF : $@convention(thin) <τ_0_0, τ_0_1> (@guaranteed Array<τ_0_0>) -> @owned Array<τ_0_1>
@@ -592,7 +592,7 @@ func testCovariantAssocSubscript5(p: any P) {
 // CHECK-LABEL: sil hidden [ossa] @$s42existential_member_accesses_self_assoctype28testCovariantAssocSubscript61pyAA1P_p_tF
 // CHECK: [[OPENED:%[0-9]+]] = open_existential_addr immutable_access %0 : $*any P to $*@opened([[OPENED_ID:"[0-9A-F-]+"]], any P) Self
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> (()) -> [String : Self.A]
 // CHECK: [[DICT:%[0-9]+]] = apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> @owned Dictionary<String, τ_0_0.A>
 // CHECK: [[DICT_UPCAST_FN:%[0-9]+]] = function_ref @$ss17_dictionaryUpCastySDyq0_q1_GSDyxq_GSHRzSHR0_r2_lF : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2, τ_0_3 where τ_0_0 : Hashable, τ_0_2 : Hashable> (@guaranteed Dictionary<τ_0_0, τ_0_1>) -> @owned Dictionary<τ_0_2, τ_0_3>
@@ -608,7 +608,7 @@ func testCovariantAssocSubscript6(p: any P) {
 // CHECK: [[STEP2:%[0-9]+]] = convert_function [[STEP1]] : $@callee_guaranteed (@in_guaranteed @opened([[OPENED_ID]], any P) Self.A) -> () to $@callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <@opened([[OPENED_ID]], any P) Self.A>
 // CHECK: [[STEP3:%[0-9]+]] = convert_escape_to_noescape [not_guaranteed] [[STEP2]]
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $@opened([[OPENED_ID]], any P) Self
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*@opened([[OPENED_ID]], any P) Self
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $@opened([[OPENED_ID]], any P) Self, #P.subscript!getter : <Self where Self : P> (Self) -> ((Self.A) -> ()) -> ()
 // CHECK: apply [[WITNESS]]<@opened([[OPENED_ID]], any P) Self>([[STEP3]], [[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@noescape @callee_guaranteed @substituted <τ_0_0> (@in_guaranteed τ_0_0) -> () for <τ_0_0.A>, @in_guaranteed τ_0_0) -> ()
 func testCovariantAssocSubscript7(p: any P) {
@@ -621,7 +621,7 @@ func testCovariantAssocSubscript7(p: any P) {
 // CHECK: [[STEP2:%[0-9]+]] = convert_function [[STEP1]] : $@callee_guaranteed (@guaranteed Array<[[OPENED_TY]].A>) -> () to $@callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 == τ_0_1> (@guaranteed Array<τ_0_0>) -> () for <[[OPENED_TY]].A, [[OPENED_TY]].A>
 // CHECK: [[STEP3:%[0-9]+]] = convert_escape_to_noescape [not_guaranteed] [[STEP2]]
 // CHECK: [[OPENED_COPY:%[0-9]+]] = alloc_stack $[[OPENED_TY]]
-// CHECK: copy_addr [[OPENED]] to [initialization] [[OPENED_COPY]] : $*[[OPENED_TY]]
+// CHECK: copy_addr [[OPENED]] to [init] [[OPENED_COPY]] : $*[[OPENED_TY]]
 // CHECK: [[WITNESS:%[0-9]+]] = witness_method $[[OPENED_TY]], #P.subscript!getter : <Self where Self : P> (Self) -> ((Self.A...) -> ()) -> ()
 // CHECK: apply [[WITNESS]]<[[OPENED_TY]]>([[STEP3]], [[OPENED_COPY]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1 where τ_0_0 == τ_0_1> (@guaranteed Array<τ_0_0>) -> () for <τ_0_0.A, τ_0_0.A>, @in_guaranteed τ_0_0) -> ()
 func testCovariantAssocSubscript8(p: any P) {

--- a/test/SILGen/expressions.swift
+++ b/test/SILGen/expressions.swift
@@ -296,7 +296,7 @@ func archetype_member_ref<T : Runcible>(_ x: T) {
   x.free_method()
   // CHECK:      [[READ:%.*]] = begin_access [read] [unknown] [[X:%.*]]
   // CHECK-NEXT: [[TEMP:%.*]] = alloc_stack $T
-  // CHECK-NEXT: copy_addr [[READ]] to [initialization] [[TEMP]]
+  // CHECK-NEXT: copy_addr [[READ]] to [init] [[TEMP]]
   // CHECK-NEXT: end_access [[READ]]
   // CHECK-NEXT: witness_method $T, #Runcible.free_method :
   // CHECK-NEXT: apply
@@ -635,7 +635,7 @@ func evaluateIgnoredKeyPathExpr(_ s: inout NonTrivialStruct, _ kp: WritableKeyPa
 // CHECK-NEXT: [[S_READ:%[0-9]+]] = begin_access [read] [unknown] %0
 // CHECK-NEXT: [[KP:%[0-9]+]] = upcast [[KP_TEMP]]
 // CHECK-NEXT: [[S_TEMP:%[0-9]+]] = alloc_stack $NonTrivialStruct
-// CHECK-NEXT: copy_addr [[S_READ]] to [initialization] [[S_TEMP]]
+// CHECK-NEXT: copy_addr [[S_READ]] to [init] [[S_TEMP]]
 // CHECK-NEXT: // function_ref
 // CHECK-NEXT: [[PROJECT_FN:%[0-9]+]] = function_ref @swift_getAtKeyPath :
 // CHECK-NEXT: [[RESULT:%[0-9]+]] = alloc_stack $Int

--- a/test/SILGen/extensions.swift
+++ b/test/SILGen/extensions.swift
@@ -59,14 +59,14 @@ struct Box<T> {
 // CHECK-NEXT: apply [[INIT]]<T>([[RESULT]]) : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
 // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $Optional<T>
 // CHECK-NEXT: [[RESULT_ADDR:%.*]] = init_enum_data_addr [[RESULT]] : $*Optional<T>, #Optional.some!enumelt
-// CHECK-NEXT: copy_addr %1 to [initialization] [[RESULT_ADDR]] : $*T
+// CHECK-NEXT: copy_addr %1 to [init] [[RESULT_ADDR]] : $*T
 // CHECK-NEXT: inject_enum_addr [[RESULT]] : $*Optional<T>, #Optional.some!enumelt
 // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[SELF_ADDR]] : $*Box<T>
 // CHECK-NEXT: [[T_ADDR:%.*]] = struct_element_addr [[WRITE]] : $*Box<T>, #Box.t
 // CHECK-NEXT: copy_addr [take] [[RESULT]] to [[T_ADDR:%.*]] : $*Optional<T>
 // CHECK-NEXT: end_access [[WRITE]]
 // CHECK-NEXT: dealloc_stack [[RESULT]] : $*Optional<T>
-// CHECK-NEXT: copy_addr [[SELF_ADDR]] to [initialization] %0 : $*Box<T>
+// CHECK-NEXT: copy_addr [[SELF_ADDR]] to [init] %0 : $*Box<T>
 // CHECK-NEXT: destroy_addr %1 : $*T
 // CHECK-NEXT: end_borrow [[UNINIT_SELF_BOX_LIFETIME]]
 // CHECK-NEXT: destroy_value [[UNINIT_SELF_BOX]] : $<τ_0_0> { var Box<τ_0_0> } <T>

--- a/test/SILGen/foreach.swift
+++ b/test/SILGen/foreach.swift
@@ -227,7 +227,7 @@ func existentialBreak(_ xx: [P]) {
 // CHECK: [[SOME_BB]]:
 // CHECK:   [[T0:%.*]] = alloc_stack [lexical] $any P, let, name "x"
 // CHECK:   [[ELT_STACK_TAKE:%.*]] = unchecked_take_enum_data_addr [[ELT_STACK]] : $*Optional<any P>, #Optional.some!enumelt
-// CHECK:   copy_addr [take] [[ELT_STACK_TAKE]] to [initialization] [[T0]]
+// CHECK:   copy_addr [take] [[ELT_STACK_TAKE]] to [init] [[T0]]
 // CHECK:   cond_br {{%.*}}, [[LOOP_BREAK_END_BLOCK:bb[0-9]+]], [[CONTINUE_CHECK_BLOCK:bb[0-9]+]]
 //
 // CHECK: [[LOOP_BREAK_END_BLOCK]]:
@@ -389,7 +389,7 @@ func genericStructBreak<T>(_ xx: [GenericStruct<T>]) {
 // CHECK: [[SOME_BB]]:
 // CHECK:   [[T0:%.*]] = alloc_stack [lexical] $GenericStruct<T>, let, name "x"
 // CHECK:   [[ELT_STACK_TAKE:%.*]] = unchecked_take_enum_data_addr [[ELT_STACK]] : $*Optional<GenericStruct<T>>, #Optional.some!enumelt
-// CHECK:   copy_addr [take] [[ELT_STACK_TAKE]] to [initialization] [[T0]]
+// CHECK:   copy_addr [take] [[ELT_STACK_TAKE]] to [init] [[T0]]
 // CHECK:   cond_br {{%.*}}, [[LOOP_BREAK_END_BLOCK:bb[0-9]+]], [[CONTINUE_CHECK_BLOCK:bb[0-9]+]]
 //
 // CHECK: [[LOOP_BREAK_END_BLOCK]]:
@@ -497,7 +497,7 @@ func genericCollectionBreak<T : Collection>(_ xx: T) {
 // CHECK: [[SOME_BB]]:
 // CHECK:   [[T0:%.*]] = alloc_stack [lexical] $T.Element, let, name "x"
 // CHECK:   [[ELT_STACK_TAKE:%.*]] = unchecked_take_enum_data_addr [[ELT_STACK]] : $*Optional<T.Element>, #Optional.some!enumelt
-// CHECK:   copy_addr [take] [[ELT_STACK_TAKE]] to [initialization] [[T0]]
+// CHECK:   copy_addr [take] [[ELT_STACK_TAKE]] to [init] [[T0]]
 // CHECK:   cond_br {{%.*}}, [[LOOP_BREAK_END_BLOCK:bb[0-9]+]], [[CONTINUE_CHECK_BLOCK:bb[0-9]+]]
 //
 // CHECK: [[LOOP_BREAK_END_BLOCK]]:
@@ -630,13 +630,13 @@ func injectForEachElementIntoOptional(_ xs: [Int]) {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s7foreach32injectForEachElementIntoOptionalyySayxGlF
-// CHECK: copy_addr [take] [[NEXT_RESULT:%.*]] to [initialization] [[NEXT_RESULT_COPY:%.*]] : $*Optional<T>
+// CHECK: copy_addr [take] [[NEXT_RESULT:%.*]] to [init] [[NEXT_RESULT_COPY:%.*]] : $*Optional<T>
 // CHECK: switch_enum_addr [[NEXT_RESULT_COPY]] : $*Optional<T>, case #Optional.some!enumelt: [[BB_SOME:bb.*]], case
 // CHECK: [[BB_SOME]]:
 // CHECK: [[X_BINDING:%.*]] = alloc_stack [lexical] $Optional<T>, let, name "x"
 // CHECK: [[ADDR:%.*]] = unchecked_take_enum_data_addr [[NEXT_RESULT_COPY]] : $*Optional<T>, #Optional.some!enumelt
 // CHECK: [[X_ADDR:%.*]] = init_enum_data_addr [[X_BINDING]] : $*Optional<T>, #Optional.some!enumelt
-// CHECK: copy_addr [take] [[ADDR]] to [initialization] [[X_ADDR]] : $*T
+// CHECK: copy_addr [take] [[ADDR]] to [init] [[X_ADDR]] : $*T
 // CHECK: inject_enum_addr [[X_BINDING]] : $*Optional<T>, #Optional.some!enumelt
 func injectForEachElementIntoOptional<T>(_ xs: [T]) {
   for x : T? in xs {}

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -162,7 +162,7 @@ func convOptionalAddrOnly(_ a1: @escaping (AddrOnly?) -> AddrOnly) {
 // CHECK:         [[TEMP:%.*]] = alloc_stack $AddrOnly
 // CHECK-NEXT:    apply %2([[TEMP]], %1)
 // CHECK-NEXT:    init_enum_data_addr %0 : $*Optional<AddrOnly>
-// CHECK-NEXT:    copy_addr [take] {{.*}} to [initialization] {{.*}} : $*AddrOnly
+// CHECK-NEXT:    copy_addr [take] {{.*}} to [init] {{.*}} : $*AddrOnly
 // CHECK-NEXT:    inject_enum_addr %0 : $*Optional<AddrOnly>
 // CHECK-NEXT:    tuple ()
 // CHECK-NEXT:    dealloc_stack {{.*}} : $*AddrOnly
@@ -223,7 +223,7 @@ func convExistentialTrivial(_ t2: @escaping (Q) -> Trivial, t3: @escaping (Q?) -
 // CHECK:         [[TMP:%.*]] = alloc_stack $any Q
 // CHECK-NEXT:    open_existential_addr immutable_access %1 : $*any P
 // CHECK-NEXT:    init_existential_addr [[TMP]] : $*any Q
-// CHECK-NEXT:    copy_addr {{.*}} to [initialization] {{.*}}
+// CHECK-NEXT:    copy_addr {{.*}} to [init] {{.*}}
 // CHECK-NEXT:    apply
 // CHECK-NEXT:    init_existential_addr
 // CHECK-NEXT:    store
@@ -576,7 +576,7 @@ func convTupleAny(_ f1: @escaping () -> (),
 // CHECK-NEXT:    store %1 to [trivial] [[RIGHT_ADDR]]
 // CHECK-NEXT:    [[OPTIONAL_VALUE:%.*]] = alloc_stack $Optional<Any>
 // CHECK-NEXT:    [[OPTIONAL_PAYLOAD:%.*]] = init_enum_data_addr [[OPTIONAL_VALUE]]
-// CHECK-NEXT:    copy_addr [take] [[ANY_VALUE]] to [initialization] [[OPTIONAL_PAYLOAD]]
+// CHECK-NEXT:    copy_addr [take] [[ANY_VALUE]] to [init] [[OPTIONAL_PAYLOAD]]
 // CHECK-NEXT:    inject_enum_addr [[OPTIONAL_VALUE]]
 // CHECK-NEXT:    apply %2([[OPTIONAL_VALUE]])
 // CHECK-NEXT:    tuple ()

--- a/test/SILGen/functions.swift
+++ b/test/SILGen/functions.swift
@@ -236,7 +236,7 @@ func calls(_ i:Int, j:Int, k:Int) {
 
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PADDR]]
   // CHECK: [[TEMP:%.*]] = alloc_stack $any SomeProtocol
-  // CHECK: copy_addr [[READ]] to [initialization] [[TEMP]]
+  // CHECK: copy_addr [[READ]] to [init] [[TEMP]]
   // CHECK: [[PVALUE:%[0-9]+]] = open_existential_addr immutable_access [[TEMP]] : $*any SomeProtocol to $*[[OPENED:@opened\(.*, any SomeProtocol\) Self]]
   // CHECK: [[READI:%.*]] = begin_access [read] [unknown] [[IADDR]]
   // CHECK: [[I:%[0-9]+]] = load [trivial] [[READI]]

--- a/test/SILGen/generic_casts.swift
+++ b/test/SILGen/generic_casts.swift
@@ -124,7 +124,7 @@ func opaque_existential_to_opaque_archetype
   return p as! T
   // CHECK: bb0([[RET:%.*]] : $*T, [[ARG:%.*]] : $*any NotClassBound):
   // CHECK:      [[TEMP:%.*]] = alloc_stack $any NotClassBound
-  // CHECK-NEXT: copy_addr [[ARG]] to [initialization] [[TEMP]]
+  // CHECK-NEXT: copy_addr [[ARG]] to [init] [[TEMP]]
   // CHECK-NEXT: unconditional_checked_cast_addr any NotClassBound in [[TEMP]] : $*any NotClassBound to T in [[RET]] : $*T
   // CHECK-NEXT: dealloc_stack [[TEMP]]
   // CHECK-NEXT: [[T0:%.*]] = tuple ()

--- a/test/SILGen/generic_property_base_lifetime.swift
+++ b/test/SILGen/generic_property_base_lifetime.swift
@@ -59,7 +59,7 @@ func setIntPropGeneric<T: ProtocolA>(_ a: T) {
 // CHECK-LABEL: sil hidden [ossa] @$s30generic_property_base_lifetime21getIntPropExistentialySiAA9ProtocolB_pF
 // CHECK:         [[PROJECTION:%.*]] = open_existential_addr immutable_access %0
 // CHECK:         [[STACK:%[0-9]+]] = alloc_stack $@opened({{".*"}}, any ProtocolB) Self
-// CHECK:         copy_addr [[PROJECTION]] to [initialization] [[STACK]]
+// CHECK:         copy_addr [[PROJECTION]] to [init] [[STACK]]
 // CHECK:         apply {{%.*}}([[STACK]])
 // CHECK:         destroy_addr [[STACK]]
 // CHECK:         dealloc_stack [[STACK]]
@@ -69,7 +69,7 @@ func getIntPropExistential(_ a: ProtocolB) -> Int {
 
 // CHECK-LABEL: sil hidden [ossa] @$s30generic_property_base_lifetime17getIntPropGeneric{{[_0-9a-zA-Z]*}}F
 // CHECK:         [[STACK:%[0-9]+]] = alloc_stack $T
-// CHECK:         copy_addr %0 to [initialization] [[STACK]]
+// CHECK:         copy_addr %0 to [init] [[STACK]]
 // CHECK:         apply {{%.*}}<T>([[STACK]])
 // CHECK:         destroy_addr [[STACK]]
 // CHECK:         dealloc_stack [[STACK]]

--- a/test/SILGen/generic_tuples.swift
+++ b/test/SILGen/generic_tuples.swift
@@ -6,8 +6,8 @@ func dup<T>(_ x: T) -> (T, T) { return (x,x) }
 // CHECK-LABEL:      sil hidden [ossa] @$s14generic_tuples3dup{{[_0-9a-zA-Z]*}}F
 // CHECK:      ([[RESULT_0:%.*]] : $*T, [[RESULT_1:%.*]] : $*T, [[XVAR:%.*]] : $*T):
 // CHECK-NEXT: debug_value [[XVAR]] : $*T, let, name "x", {{.*}} expr op_deref
-// CHECK-NEXT: copy_addr [[XVAR]] to [initialization] [[RESULT_0]]
-// CHECK-NEXT: copy_addr [[XVAR]] to [initialization] [[RESULT_1]]
+// CHECK-NEXT: copy_addr [[XVAR]] to [init] [[RESULT_0]]
+// CHECK-NEXT: copy_addr [[XVAR]] to [init] [[RESULT_1]]
 // CHECK-NEXT: [[T0:%.*]] = tuple ()
 // CHECK-NEXT: return [[T0]]
 

--- a/test/SILGen/guaranteed_normal_args.swift
+++ b/test/SILGen/guaranteed_normal_args.swift
@@ -176,19 +176,19 @@ extension FakeDictionary {
   // CHECK:   [[INDUCTION_VAR_1:%.*]] = tuple_element_addr [[INDUCTION_VAR]] : $*(Key, Value), 1
   // CHECK:   [[X_0:%.*]] = tuple_element_addr [[X]] : $*(Key, Value), 0
   // CHECK:   [[X_1:%.*]] = tuple_element_addr [[X]] : $*(Key, Value), 1
-  // CHECK:   copy_addr [take] [[INDUCTION_VAR_0]] to [initialization] [[X_0]]
-  // CHECK:   copy_addr [take] [[INDUCTION_VAR_1]] to [initialization] [[X_1]]
+  // CHECK:   copy_addr [take] [[INDUCTION_VAR_0]] to [init] [[X_0]]
+  // CHECK:   copy_addr [take] [[INDUCTION_VAR_1]] to [init] [[X_1]]
   // CHECK:   [[X_0:%.*]] = tuple_element_addr [[X]] : $*(Key, Value), 0
   // CHECK:   [[X_1:%.*]] = tuple_element_addr [[X]] : $*(Key, Value), 1
   // CHECK:   [[TMP_X:%.*]] = alloc_stack $(Key, Value)
   // CHECK:   [[TMP_X_0:%.*]] = tuple_element_addr [[TMP_X]] : $*(Key, Value), 0
   // CHECK:   [[TMP_X_1:%.*]] = tuple_element_addr [[TMP_X]] : $*(Key, Value), 1
   // CHECK:   [[TMP_0:%.*]] = alloc_stack $Key
-  // CHECK:   copy_addr [[X_0]] to [initialization] [[TMP_0]]
-  // CHECK:   copy_addr [take] [[TMP_0]] to [initialization] [[TMP_X_0]]
+  // CHECK:   copy_addr [[X_0]] to [init] [[TMP_0]]
+  // CHECK:   copy_addr [take] [[TMP_0]] to [init] [[TMP_X_0]]
   // CHECK:   [[TMP_1:%.*]] = alloc_stack $Value
-  // CHECK:   copy_addr [[X_1]] to [initialization] [[TMP_1]]
-  // CHECK:   copy_addr [take] [[TMP_1]] to [initialization] [[TMP_X_1]]
+  // CHECK:   copy_addr [[X_1]] to [init] [[TMP_1]]
+  // CHECK:   copy_addr [take] [[TMP_1]] to [init] [[TMP_X_1]]
   // CHECK:   [[FUNC:%.*]] = function_ref @$ss9FakeArrayV6appendyyxF : $@convention(method) <τ_0_0> (@in_guaranteed τ_0_0, @inout FakeArray<τ_0_0>) -> ()
   // CHECK:   apply [[FUNC]]<(Key, Value)>([[TMP_X]],
   // CHECK: } // end sil function '$ss14FakeDictionaryV20makeSureToCopyTuplesyyF'

--- a/test/SILGen/if_while_binding.swift
+++ b/test/SILGen/if_while_binding.swift
@@ -111,7 +111,7 @@ func while_loop() {
 // CHECK:         switch_enum_addr {{.*}}, case #Optional.some!enumelt: [[LOOPBODY:bb.*]], case #Optional.none!enumelt: [[OUT:bb[0-9]+]]
 // CHECK:       [[LOOPBODY]]:
 // CHECK:         [[ENUMVAL:%.*]] = unchecked_take_enum_data_addr
-// CHECK:         copy_addr [take] [[ENUMVAL]] to [initialization] [[X]]
+// CHECK:         copy_addr [take] [[ENUMVAL]] to [init] [[X]]
 // CHECK:         destroy_addr [[X]]
 // CHECK:         dealloc_stack [[X]]
 // CHECK:         br [[COND]]

--- a/test/SILGen/indirect_enum.swift
+++ b/test/SILGen/indirect_enum.swift
@@ -17,10 +17,10 @@ func TreeA_cases<T>(_ t: T, l: TreeA<T>, r: TreeA<T>) {
 
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeA<T>.Type
 // CHECK-NEXT:    [[T_BUF:%.*]] = alloc_stack $T
-// CHECK-NEXT:    copy_addr [[ARG1]] to [initialization] [[T_BUF]] : $*T
+// CHECK-NEXT:    copy_addr [[ARG1]] to [init] [[T_BUF]] : $*T
 // CHECK-NEXT:    [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <T>
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
-// CHECK-NEXT:    copy_addr [take] [[T_BUF]] to [initialization] [[PB]]
+// CHECK-NEXT:    copy_addr [take] [[T_BUF]] to [init] [[PB]]
 // CHECK-NEXT:    [[LEAF:%.*]] = enum $TreeA<T>, #TreeA.Leaf!enumelt, [[BOX]]
 // CHECK-NEXT:    destroy_value [[LEAF]]
 // CHECK-NEXT:    dealloc_stack [[T_BUF]] : $*T
@@ -78,10 +78,10 @@ func TreeB_cases<T>(_ t: T, l: TreeB<T>, r: TreeB<T>) {
 
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeB<T>.Type
 // CHECK-NEXT:    [[T_BUF:%.*]] = alloc_stack $T
-// CHECK-NEXT:    copy_addr %0 to [initialization] [[T_BUF]]
+// CHECK-NEXT:    copy_addr %0 to [init] [[T_BUF]]
 // CHECK-NEXT:    [[LEAF:%.*]] = alloc_stack $TreeB<T>
 // CHECK-NEXT:    [[PAYLOAD:%.*]] = init_enum_data_addr [[LEAF]] : $*TreeB<T>, #TreeB.Leaf!enumelt
-// CHECK-NEXT:    copy_addr [take] [[T_BUF]] to [initialization] [[PAYLOAD]]
+// CHECK-NEXT:    copy_addr [take] [[T_BUF]] to [init] [[PAYLOAD]]
 // CHECK-NEXT:    inject_enum_addr [[LEAF]] : $*TreeB<T>, #TreeB.Leaf!enumelt
 // CHECK-NEXT:    destroy_addr [[LEAF]]
 // CHECK-NEXT:    dealloc_stack [[LEAF]]
@@ -90,15 +90,15 @@ func TreeB_cases<T>(_ t: T, l: TreeB<T>, r: TreeB<T>) {
 
 // CHECK-NEXT:    [[METATYPE:%.*]] = metatype $@thin TreeB<T>.Type
 // CHECK-NEXT:    [[ARG1_COPY:%.*]] = alloc_stack $TreeB<T>
-// CHECK-NEXT:    copy_addr %1 to [initialization] [[ARG1_COPY]] : $*TreeB<T>
+// CHECK-NEXT:    copy_addr %1 to [init] [[ARG1_COPY]] : $*TreeB<T>
 // CHECK-NEXT:    [[ARG2_COPY:%.*]] = alloc_stack $TreeB<T>
-// CHECK-NEXT:    copy_addr %2 to [initialization] [[ARG2_COPY]] : $*TreeB<T>
+// CHECK-NEXT:    copy_addr %2 to [init] [[ARG2_COPY]] : $*TreeB<T>
 // CHECK-NEXT:    [[BOX:%.*]] = alloc_box $<τ_0_0> { var (left: TreeB<τ_0_0>, right: TreeB<τ_0_0>) } <T>
 // CHECK-NEXT:    [[PB:%.*]] = project_box [[BOX]]
 // CHECK-NEXT:    [[LEFT:%.*]] = tuple_element_addr [[PB]]
 // CHECK-NEXT:    [[RIGHT:%.*]] = tuple_element_addr [[PB]]
-// CHECK-NEXT:    copy_addr [take] [[ARG1_COPY]] to [initialization] [[LEFT]] : $*TreeB<T>
-// CHECK-NEXT:    copy_addr [take] [[ARG2_COPY]] to [initialization] [[RIGHT]] : $*TreeB<T>
+// CHECK-NEXT:    copy_addr [take] [[ARG1_COPY]] to [init] [[LEFT]] : $*TreeB<T>
+// CHECK-NEXT:    copy_addr [take] [[ARG2_COPY]] to [init] [[RIGHT]] : $*TreeB<T>
 // CHECK-NEXT:    [[BRANCH:%.*]] = alloc_stack $TreeB<T>
 // CHECK-NEXT:    [[PAYLOAD:%.*]] = init_enum_data_addr [[BRANCH]]
 // CHECK-NEXT:    store [[BOX]] to [init] [[PAYLOAD]]
@@ -173,7 +173,7 @@ func switchTreeA<T>(_ x: TreeA<T>) {
     a()
   // CHECK:     [[LEAF_CASE]]([[LEAF_BOX:%.*]] : @guaranteed $<τ_0_0> { var τ_0_0 } <T>):
   // CHECK:       [[VALUE:%.*]] = project_box [[LEAF_BOX]]
-  // CHECK:       copy_addr [[VALUE]] to [initialization] [[X:%.*]] : $*T
+  // CHECK:       copy_addr [[VALUE]] to [init] [[X:%.*]] : $*T
   // CHECK:       function_ref @$s13indirect_enum1b{{[_0-9a-zA-Z]*}}F
   // CHECK:       destroy_addr [[X]]
   // CHECK:       dealloc_stack [[X]]
@@ -225,7 +225,7 @@ func switchTreeA<T>(_ x: TreeA<T>) {
 
 // CHECK-LABEL: sil hidden [ossa] @$s13indirect_enum11switchTreeB{{[_0-9a-zA-Z]*}}F
 func switchTreeB<T>(_ x: TreeB<T>) {
-  // CHECK:       copy_addr %0 to [initialization] [[SCRATCH:%.*]] :
+  // CHECK:       copy_addr %0 to [init] [[SCRATCH:%.*]] :
   // CHECK:       switch_enum_addr [[SCRATCH]]
   switch x {
 
@@ -238,9 +238,9 @@ func switchTreeB<T>(_ x: TreeB<T>) {
     a()
 
   // CHECK:     bb{{.*}}:
-  // CHECK:       copy_addr [[SCRATCH]] to [initialization] [[LEAF_COPY:%.*]] :
+  // CHECK:       copy_addr [[SCRATCH]] to [init] [[LEAF_COPY:%.*]] :
   // CHECK:       [[LEAF_ADDR:%.*]] = unchecked_take_enum_data_addr [[LEAF_COPY]]
-  // CHECK:       copy_addr [take] [[LEAF_ADDR]] to [initialization] [[LEAF:%.*]] :
+  // CHECK:       copy_addr [take] [[LEAF_ADDR]] to [init] [[LEAF:%.*]] :
   // CHECK:       function_ref @$s13indirect_enum1b{{[_0-9a-zA-Z]*}}F
   // CHECK:       destroy_addr [[LEAF]]
   // CHECK:       dealloc_stack [[LEAF]]
@@ -253,7 +253,7 @@ func switchTreeB<T>(_ x: TreeB<T>) {
     b(x)
 
   // CHECK:     bb{{.*}}:
-  // CHECK:       copy_addr [[SCRATCH]] to [initialization] [[TREE_COPY:%.*]] :
+  // CHECK:       copy_addr [[SCRATCH]] to [init] [[TREE_COPY:%.*]] :
   // CHECK:       [[TREE_ADDR:%.*]] = unchecked_take_enum_data_addr [[TREE_COPY]]
   // --           box +1 immutable
   // CHECK:       [[BOX:%.*]] = load [take] [[TREE_ADDR]]
@@ -263,15 +263,15 @@ func switchTreeB<T>(_ x: TreeB<T>) {
   // CHECK:       switch_enum_addr [[LEFT]] {{.*}}, default [[LEFT_FAIL:bb[0-9]+]]
 
   // CHECK:     bb{{.*}}:
-  // CHECK:       copy_addr [[LEFT]] to [initialization] [[LEFT_COPY:%.*]] :
+  // CHECK:       copy_addr [[LEFT]] to [init] [[LEFT_COPY:%.*]] :
   // CHECK:       [[LEFT_LEAF:%.*]] = unchecked_take_enum_data_addr [[LEFT_COPY]] : $*TreeB<T>, #TreeB.Leaf
   // CHECK:       switch_enum_addr [[RIGHT]] {{.*}}, default [[RIGHT_FAIL:bb[0-9]+]]
 
   // CHECK:     bb{{.*}}:
-  // CHECK:       copy_addr [[RIGHT]] to [initialization] [[RIGHT_COPY:%.*]] :
+  // CHECK:       copy_addr [[RIGHT]] to [init] [[RIGHT_COPY:%.*]] :
   // CHECK:       [[RIGHT_LEAF:%.*]] = unchecked_take_enum_data_addr [[RIGHT_COPY]] : $*TreeB<T>, #TreeB.Leaf
-  // CHECK:       copy_addr [take] [[LEFT_LEAF]] to [initialization] [[X:%.*]] :
-  // CHECK:       copy_addr [take] [[RIGHT_LEAF]] to [initialization] [[Y:%.*]] :
+  // CHECK:       copy_addr [take] [[LEFT_LEAF]] to [init] [[X:%.*]] :
+  // CHECK:       copy_addr [take] [[RIGHT_LEAF]] to [init] [[Y:%.*]] :
   // CHECK:       function_ref @$s13indirect_enum1c{{[_0-9a-zA-Z]*}}F
   // CHECK:       destroy_addr [[Y]]
   // CHECK:       dealloc_stack [[Y]]
@@ -353,8 +353,8 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK: [[YES]]([[BOX:%.*]] : @owned $<τ_0_0> { var τ_0_0 } <T>):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   [[TMP:%.*]] = alloc_stack
-    // CHECK:   copy_addr [[VALUE_ADDR]] to [initialization] [[TMP]]
-    // CHECK:   copy_addr [take] [[TMP]] to [initialization] [[X]]
+    // CHECK:   copy_addr [[VALUE_ADDR]] to [init] [[TMP]]
+    // CHECK:   copy_addr [take] [[TMP]] to [init] [[X]]
     // CHECK:   destroy_value [[BOX]]
     guard case .Leaf(let x) = tree else { return }
 
@@ -391,8 +391,8 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
     // CHECK: [[YES]]([[BOX:%.*]] : @owned $<τ_0_0> { var τ_0_0 } <T>):
     // CHECK:   [[VALUE_ADDR:%.*]] = project_box [[BOX]]
     // CHECK:   [[TMP:%.*]] = alloc_stack
-    // CHECK:   copy_addr [[VALUE_ADDR]] to [initialization] [[TMP]]
-    // CHECK:   copy_addr [take] [[TMP]] to [initialization] [[X]]
+    // CHECK:   copy_addr [[VALUE_ADDR]] to [init] [[TMP]]
+    // CHECK:   copy_addr [take] [[TMP]] to [init] [[X]]
     // CHECK:   destroy_value [[BOX]]
     // CHECK:   destroy_addr [[X]]
     if case .Leaf(let x) = tree { }
@@ -423,34 +423,34 @@ func guardTreeA<T>(_ tree: TreeA<T>) {
 // CHECK-LABEL: sil hidden [ossa] @$s13indirect_enum10guardTreeB{{[_0-9a-zA-Z]*}}F
 func guardTreeB<T>(_ tree: TreeB<T>) {
   do {
-    // CHECK:   copy_addr %0 to [initialization] [[TMP1:%.*]] :
+    // CHECK:   copy_addr %0 to [init] [[TMP1:%.*]] :
     // CHECK:   switch_enum_addr [[TMP1]] : $*TreeB<T>, case #TreeB.Nil!enumelt: [[YES:bb[0-9]+]], default [[NO2:bb[0-9]+]]
     // CHECK: [[YES]]:
     // CHECK:   destroy_addr [[TMP1]]
     guard case .Nil = tree else { return }
 
     // CHECK:   [[X:%.*]] = alloc_stack [lexical] $T
-    // CHECK:   copy_addr %0 to [initialization] [[TMP2:%.*]] :
+    // CHECK:   copy_addr %0 to [init] [[TMP2:%.*]] :
     // CHECK:   switch_enum_addr [[TMP2]] : $*TreeB<T>, case #TreeB.Leaf!enumelt: [[YES:bb[0-9]+]], default [[NO2:bb[0-9]+]]
     // CHECK: [[YES]]:
     // CHECK:   [[VALUE:%.*]] = unchecked_take_enum_data_addr [[TMP2]]
-    // CHECK:   copy_addr [take] [[VALUE]] to [initialization] [[X]]
+    // CHECK:   copy_addr [take] [[VALUE]] to [init] [[X]]
     // CHECK:   dealloc_stack [[TMP2]]
     guard case .Leaf(let x) = tree else { return }
 
     // CHECK:   [[L:%.*]] = alloc_stack [lexical] $TreeB
     // CHECK:   [[R:%.*]] = alloc_stack [lexical] $TreeB
-    // CHECK:   copy_addr %0 to [initialization] [[TMP3:%.*]] :
+    // CHECK:   copy_addr %0 to [init] [[TMP3:%.*]] :
     // CHECK:   switch_enum_addr [[TMP3]] : $*TreeB<T>, case #TreeB.Branch!enumelt: [[YES:bb[0-9]+]], default [[NO3:bb[0-9]+]]
     // CHECK: [[YES]]:
     // CHECK:   [[BOX_ADDR:%.*]] = unchecked_take_enum_data_addr [[TMP3]]
     // CHECK:   [[BOX:%.*]] = load [take] [[BOX_ADDR]]
     // CHECK:   [[TUPLE_ADDR:%.*]] = project_box [[BOX]]
-    // CHECK:   copy_addr [[TUPLE_ADDR]] to [initialization] [[TUPLE_COPY:%.*]] :
+    // CHECK:   copy_addr [[TUPLE_ADDR]] to [init] [[TUPLE_COPY:%.*]] :
     // CHECK:   [[L_COPY:%.*]] = tuple_element_addr [[TUPLE_COPY]]
     // CHECK:   [[R_COPY:%.*]] = tuple_element_addr [[TUPLE_COPY]]
-    // CHECK:   copy_addr [take] [[L_COPY]] to [initialization] [[L]]
-    // CHECK:   copy_addr [take] [[R_COPY]] to [initialization] [[R]]
+    // CHECK:   copy_addr [take] [[L_COPY]] to [init] [[L]]
+    // CHECK:   copy_addr [take] [[R_COPY]] to [init] [[R]]
     // CHECK:   destroy_value [[BOX]]
     guard case .Branch(left: let l, right: let r) = tree else { return }
 
@@ -460,7 +460,7 @@ func guardTreeB<T>(_ tree: TreeB<T>) {
   }
 
   do {
-    // CHECK:   copy_addr %0 to [initialization] [[TMP:%.*]] :
+    // CHECK:   copy_addr %0 to [init] [[TMP:%.*]] :
     // CHECK:   switch_enum_addr [[TMP]] : $*TreeB<T>, case #TreeB.Nil!enumelt: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
     // CHECK: [[NO]]:
     // CHECK:   destroy_addr [[TMP]]
@@ -469,20 +469,20 @@ func guardTreeB<T>(_ tree: TreeB<T>) {
     if case .Nil = tree { }
 
     // CHECK:   [[X:%.*]] = alloc_stack [lexical] $T
-    // CHECK:   copy_addr %0 to [initialization] [[TMP:%.*]] :
+    // CHECK:   copy_addr %0 to [init] [[TMP:%.*]] :
     // CHECK:   switch_enum_addr [[TMP]] : $*TreeB<T>, case #TreeB.Leaf!enumelt: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
     // CHECK: [[NO]]:
     // CHECK:   destroy_addr [[TMP]]
     // CHECK: [[YES]]:
     // CHECK:   [[VALUE:%.*]] = unchecked_take_enum_data_addr [[TMP]]
-    // CHECK:   copy_addr [take] [[VALUE]] to [initialization] [[X]]
+    // CHECK:   copy_addr [take] [[VALUE]] to [init] [[X]]
     // CHECK:   dealloc_stack [[TMP]]
     // CHECK:   destroy_addr [[X]]
     if case .Leaf(let x) = tree { }
 
     // CHECK:   [[L:%.*]] = alloc_stack [lexical] $TreeB
     // CHECK:   [[R:%.*]] = alloc_stack [lexical] $TreeB
-    // CHECK:   copy_addr %0 to [initialization] [[TMP:%.*]] :
+    // CHECK:   copy_addr %0 to [init] [[TMP:%.*]] :
     // CHECK:   switch_enum_addr [[TMP]] : $*TreeB<T>, case #TreeB.Branch!enumelt: [[YES:bb[0-9]+]], default [[NO:bb[0-9]+]]
     // CHECK: [[NO]]:
     // CHECK:   destroy_addr [[TMP]]
@@ -490,11 +490,11 @@ func guardTreeB<T>(_ tree: TreeB<T>) {
     // CHECK:   [[BOX_ADDR:%.*]] = unchecked_take_enum_data_addr [[TMP]]
     // CHECK:   [[BOX:%.*]] = load [take] [[BOX_ADDR]]
     // CHECK:   [[TUPLE_ADDR:%.*]] = project_box [[BOX]]
-    // CHECK:   copy_addr [[TUPLE_ADDR]] to [initialization] [[TUPLE_COPY:%.*]] :
+    // CHECK:   copy_addr [[TUPLE_ADDR]] to [init] [[TUPLE_COPY:%.*]] :
     // CHECK:   [[L_COPY:%.*]] = tuple_element_addr [[TUPLE_COPY]]
     // CHECK:   [[R_COPY:%.*]] = tuple_element_addr [[TUPLE_COPY]]
-    // CHECK:   copy_addr [take] [[L_COPY]] to [initialization] [[L]]
-    // CHECK:   copy_addr [take] [[R_COPY]] to [initialization] [[R]]
+    // CHECK:   copy_addr [take] [[L_COPY]] to [init] [[L]]
+    // CHECK:   copy_addr [take] [[R_COPY]] to [init] [[R]]
     // CHECK:   destroy_value [[BOX]]
     // CHECK:   destroy_addr [[R]]
     // CHECK:   destroy_addr [[L]]

--- a/test/SILGen/init_delegation_optional.swift
+++ b/test/SILGen/init_delegation_optional.swift
@@ -23,7 +23,7 @@ extension Optional {
     self.init(nonFailable1: ())
     // CHECK-NEXT: copy_addr [take] [[RESULT_ADDR]] to [[PB]]
     // CHECK-NEXT: dealloc_stack [[RESULT_ADDR]]
-    // CHECK-NEXT: copy_addr [[PB]] to [initialization] [[OUT]]
+    // CHECK-NEXT: copy_addr [[PB]] to [init] [[OUT]]
     // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
     // CHECK-NEXT: [[RET:%[0-9]+]] = tuple ()
@@ -45,7 +45,7 @@ extension Optional {
     // CHECK-NEXT: copy_addr [take] [[RESULT_ADDR]] to [[PB]]
     // CHECK-NEXT: dealloc_stack [[RESULT_ADDR]]
     // CHECK-NEXT: [[OUT_SOME_ADDR:%[0-9]+]] = init_enum_data_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
-    // CHECK-NEXT: copy_addr [[PB]] to [initialization] [[OUT_SOME_ADDR]]
+    // CHECK-NEXT: copy_addr [[PB]] to [init] [[OUT_SOME_ADDR]]
     // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
     // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
@@ -84,7 +84,7 @@ extension Optional {
     // CHECK-NEXT: copy_addr [take] [[RESULT_ADDR]] to [[PB]]
     // CHECK-NEXT: dealloc_stack [[OPT_RESULT_ADDR]]
     // CHECK-NEXT: [[OUT_SOME_ADDR:%[0-9]+]] = init_enum_data_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
-    // CHECK-NEXT: copy_addr [[PB]] to [initialization] [[OUT_SOME_ADDR]]
+    // CHECK-NEXT: copy_addr [[PB]] to [init] [[OUT_SOME_ADDR]]
     // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
     // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
@@ -137,7 +137,7 @@ extension Optional {
     // CHECK-NEXT: copy_addr [take] [[RESULT_ADDR]] to [[PB]]
     // CHECK-NEXT: dealloc_stack [[OPT_RESULT_ADDR]]
     // CHECK-NEXT: [[OUT_DATA_ADDR:%[0-9]+]] = init_enum_data_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
-    // CHECK-NEXT: copy_addr [[PB]] to [initialization] [[OUT_DATA_ADDR]]
+    // CHECK-NEXT: copy_addr [[PB]] to [init] [[OUT_DATA_ADDR]]
     // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
     // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
@@ -190,7 +190,7 @@ extension Optional {
     //
     // CHECK: [[OPT_OPT_SOME_BB]]:
     // CHECK-NEXT: [[DATA_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[OPT_OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
-    // CHECK-NEXT: copy_addr [[DATA_ADDR]] to [initialization] [[OPT_RESULT_ADDR]]
+    // CHECK-NEXT: copy_addr [[DATA_ADDR]] to [init] [[OPT_RESULT_ADDR]]
     // CHECK-NEXT: destroy_addr [[DATA_ADDR]]
     // CHECK-NEXT: br bb5
     //
@@ -214,7 +214,7 @@ extension Optional {
     // CHECK-NEXT: dealloc_stack [[OPT_RESULT_ADDR]]
     // CHECK-NEXT: dealloc_stack [[OPT_OPT_RESULT_ADDR]]
     // CHECK-NEXT: [[OUT_DATA_ADDR:%[0-9]+]] = init_enum_data_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
-    // CHECK-NEXT: copy_addr [[PB]] to [initialization] [[OUT_DATA_ADDR]]
+    // CHECK-NEXT: copy_addr [[PB]] to [init] [[OUT_DATA_ADDR]]
     // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
     // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
@@ -262,7 +262,7 @@ extension Optional {
     //
     // CHECK: [[SOME_BB]]:
     // CHECK-NEXT: [[TMP_RESULT_ADDR:%[0-9]+]] = unchecked_take_enum_data_addr [[TMP_OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
-    // CHECK-NEXT: copy_addr [take] [[TMP_RESULT_ADDR]] to [initialization] [[OPT_RESULT_DATA_ADDR]]
+    // CHECK-NEXT: copy_addr [take] [[TMP_RESULT_ADDR]] to [init] [[OPT_RESULT_DATA_ADDR]]
     // CHECK-NEXT: inject_enum_addr [[OPT_RESULT_ADDR]] : {{.*}}, #Optional.some!enumelt
     // CHECK-NEXT: dealloc_stack [[TMP_OPT_RESULT_ADDR]]
     // CHECK-NEXT: br bb4
@@ -281,7 +281,7 @@ extension Optional {
     // CHECK-NEXT: copy_addr [take] [[RESULT_ADDR]] to [[PB]]
     // CHECK-NEXT: dealloc_stack [[OPT_RESULT_ADDR]]
     // CHECK-NEXT: [[OUT_DATA_ADDR:%[0-9]+]] = init_enum_data_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
-    // CHECK-NEXT: copy_addr [[PB]] to [initialization] [[OUT_DATA_ADDR]]
+    // CHECK-NEXT: copy_addr [[PB]] to [init] [[OUT_DATA_ADDR]]
     // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
     // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]
@@ -334,7 +334,7 @@ extension Optional {
     // CHECK-NEXT: copy_addr [take] [[RESULT_ADDR]] to [[PB]]
     // CHECK-NEXT: dealloc_stack [[OPT_RESULT_ADDR]]
     // CHECK-NEXT: [[OUT_DATA_ADDR:%[0-9]+]] = init_enum_data_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
-    // CHECK-NEXT: copy_addr [[PB]] to [initialization] [[OUT_DATA_ADDR]]
+    // CHECK-NEXT: copy_addr [[PB]] to [init] [[OUT_DATA_ADDR]]
     // CHECK-NEXT: inject_enum_addr [[OUT]] : {{.*}}, #Optional.some!enumelt
     // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
     // CHECK-NEXT: destroy_value [[MARKED_SELF_BOX]]

--- a/test/SILGen/let_decls.swift
+++ b/test/SILGen/let_decls.swift
@@ -112,7 +112,7 @@ func testAddressOnlyStructElt<T>(_ a : T) -> T {
   // CHECK: [[PRODFN:%[0-9]+]] = function_ref @{{.*}}produceAddressOnlyStruct
   // CHECK: apply [[PRODFN]]<T>([[TMPSTRUCT]], [[ARG1]])
   // CHECK-NEXT: [[ELTADDR:%[0-9]+]] = struct_element_addr [[TMPSTRUCT]] : $*AddressOnlyStruct<T>, #AddressOnlyStruct.elt
-  // CHECK-NEXT: copy_addr [[ELTADDR]] to [initialization] %0 : $*T
+  // CHECK-NEXT: copy_addr [[ELTADDR]] to [init] %0 : $*T
   // CHECK-NEXT: destroy_addr [[TMPSTRUCT]]
 }
 
@@ -255,7 +255,7 @@ func test_weird_property(_ v : WeirdPropertyTest, i : Int) -> Int {
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}generic_identity
 // CHECK: bb0(%0 : $*T, %1 : $*T):
 // CHECK-NEXT: debug_value %1 : $*T, {{.*}} expr op_deref
-// CHECK-NEXT: copy_addr %1 to [initialization] %0 : $*T
+// CHECK-NEXT: copy_addr %1 to [init] %0 : $*T
 // CHECK-NOT: destroy_addr %1
 // CHECK: } // end sil function '{{.*}}generic_identity{{.*}}'
 func generic_identity<T>(_ a : T) -> T {
@@ -342,7 +342,7 @@ func testAddressOnlyTupleArgument(_ bounds: (start: SimpleProtocol, pastEnd: Int
 // CHECK:       bb0(%0 : $*any SimpleProtocol, %1 : $Int):
 // CHECK-NEXT:    %2 = alloc_stack [lexical] $(start: any SimpleProtocol, pastEnd: Int), let, name "bounds", argno 1
 // CHECK-NEXT:    %3 = tuple_element_addr %2 : $*(start: any SimpleProtocol, pastEnd: Int), 0
-// CHECK-NEXT:    copy_addr %0 to [initialization] %3 : $*any SimpleProtocol
+// CHECK-NEXT:    copy_addr %0 to [init] %3 : $*any SimpleProtocol
 // CHECK-NEXT:    %5 = tuple_element_addr %2 : $*(start: any SimpleProtocol, pastEnd: Int), 1
 // CHECK-NEXT:    store %1 to [trivial] %5 : $*Int
 // CHECK-NEXT:    destroy_addr %2 : $*(start: any SimpleProtocol, pastEnd: Int)
@@ -440,7 +440,7 @@ struct GenericStruct<T> {
   // CHECK: bb0(%0 : $*T, %1 : $*GenericStruct<T>):
   // CHECK-NEXT: debug_value %1 : $*GenericStruct<T>, let, name "self", {{.*}} expr op_deref
   // CHECK-NEXT: %3 = struct_element_addr %1 : $*GenericStruct<T>, #GenericStruct.a
-  // CHECK-NEXT: copy_addr %3 to [initialization] %0 : $*T
+  // CHECK-NEXT: copy_addr %3 to [init] %0 : $*T
   // CHECK-NEXT: %5 = tuple ()
   // CHECK-NEXT: return %5 : $()
 

--- a/test/SILGen/lifetime.swift
+++ b/test/SILGen/lifetime.swift
@@ -261,7 +261,7 @@ struct Daleth {
   // CHECK-NEXT:   [[B_ADDR:%.*]] = struct_element_addr [[THIS]] : $*Daleth, #Daleth.b
   // CHECK-NEXT:   store [[B]] to [init] [[B_ADDR]]
   // CHECK-NEXT:   [[C_ADDR:%.*]] = struct_element_addr [[THIS]] : $*Daleth, #Daleth.c
-  // CHECK-NEXT:   copy_addr [take] [[C]] to [initialization] [[C_ADDR]]
+  // CHECK-NEXT:   copy_addr [take] [[C]] to [init] [[C_ADDR]]
   // CHECK-NEXT:   tuple ()
   // CHECK-NEXT:   return
 }
@@ -313,10 +313,10 @@ struct Zayin {
   // CHECK-NEXT:   [[THIS_A_ADDR:%.*]] = struct_element_addr [[THIS]] : $*Zayin, #Zayin.a
   // CHECK-NEXT:   [[THIS_A0_ADDR:%.*]] = tuple_element_addr [[THIS_A_ADDR]] : {{.*}}, 0
   // CHECK-NEXT:   [[THIS_A1_ADDR:%.*]] = tuple_element_addr [[THIS_A_ADDR]] : {{.*}}, 1
-  // CHECK-NEXT:   copy_addr [take] [[A0]] to [initialization] [[THIS_A0_ADDR]]
+  // CHECK-NEXT:   copy_addr [take] [[A0]] to [init] [[THIS_A0_ADDR]]
   // CHECK-NEXT:   store [[A1]] to [trivial] [[THIS_A1_ADDR]]
   // CHECK-NEXT:   [[THIS_B_ADDR:%.*]] = struct_element_addr [[THIS]] : $*Zayin, #Zayin.b
-  // CHECK-NEXT:   copy_addr [take] [[B]] to [initialization] [[THIS_B_ADDR]]
+  // CHECK-NEXT:   copy_addr [take] [[B]] to [init] [[THIS_B_ADDR]]
   // CHECK-NEXT:   tuple ()
   // CHECK-NEXT:   return
 }

--- a/test/SILGen/literals.swift
+++ b/test/SILGen/literals.swift
@@ -101,7 +101,7 @@ struct Foo<T> {
 // CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<Foo<T>>([[ARRAY_LENGTH]])
 // CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
 // CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
-// CHECK: copy_addr %0 to [initialization] [[POINTER]] : $*Foo<T>
+// CHECK: copy_addr %0 to [init] [[POINTER]] : $*Foo<T>
 // CHECK: [[FIN_FN:%.*]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
 // CHECK: [[FIN_ARR:%.*]] = apply [[FIN_FN]]<Foo<T>>([[ARR]])
 // CHECK: [[METATYPE:%.*]] = metatype $@thick TakesArrayLiteral<Foo<T>>.Type
@@ -118,7 +118,7 @@ func returnsAddressOnlyElementArray<T>(t: Foo<T>) -> TakesArrayLiteral<Foo<T>> {
 // CHECK: [[ARR_TMP:%.*]] = apply [[ALLOCATE_VARARGS]]<Foo<T>>([[ARRAY_LENGTH]])
 // CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
 // CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
-// CHECK: copy_addr %0 to [initialization] [[POINTER]] : $*Foo<T>
+// CHECK: copy_addr %0 to [init] [[POINTER]] : $*Foo<T>
 // CHECK: [[FIN_FN:%.*]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
 // CHECK: [[FIN_ARR:%.*]] = apply [[FIN_FN]]<Foo<T>>([[ARR]])
 // CHECK: [[METATYPE:%.*]] = metatype $@thick TakesArrayLiteral<Foo<T>>.Type
@@ -138,7 +138,7 @@ extension Foo {
 // CHECK: ([[ARR:%.*]], [[ADDRESS:%.*]]) = destructure_tuple [[ARR_TMP]]
 // CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] %0 : $*Foo<T>
-// CHECK: copy_addr [[ACCESS]] to [initialization] [[POINTER]] : $*Foo<T>
+// CHECK: copy_addr [[ACCESS]] to [init] [[POINTER]] : $*Foo<T>
 // CHECK: end_access [[ACCESS]] : $*Foo<T>
 // CHECK: [[FIN_FN:%.*]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
 // CHECK: [[FIN_ARR:%.*]] = apply [[FIN_FN]]<Foo<T>>([[ARR]])
@@ -226,7 +226,7 @@ protocol WrapsSelfInArray {}
 // CHECK: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] %0 : $*Self
 // CHECK: [[EXISTENTIAL:%.*]] = init_existential_addr [[POINTER]] : $*any WrapsSelfInArray, $Self
-// CHECK: copy_addr [[ACCESS]] to [initialization] [[EXISTENTIAL]] : $*Self
+// CHECK: copy_addr [[ACCESS]] to [init] [[EXISTENTIAL]] : $*Self
 // CHECK: end_access [[ACCESS]] : $*Self
 // CHECK: [[FIN_FN:%.*]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
 // CHECK: [[FIN_ARR:%.*]] = apply [[FIN_FN]]<any WrapsSelfInArray>([[ARR]])

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -82,7 +82,7 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   // These cases perform a universal bridging conversion.
 
   // CHECK:   [[COPY:%.*]] = alloc_stack $U
-  // CHECK:   copy_addr [[GENERIC]] to [initialization] [[COPY]]
+  // CHECK:   copy_addr [[GENERIC]] to [init] [[COPY]]
   // CHECK:   // function_ref _bridgeAnythingToObjectiveC
   // CHECK:   [[BRIDGE_ANYTHING:%.*]] = function_ref
   // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<U>([[COPY]])
@@ -93,10 +93,10 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   receiver.takesId(generic)
 
   // CHECK:   [[COPY:%.*]] = alloc_stack $any P
-  // CHECK:   copy_addr [[EXISTENTIAL]] to [initialization] [[COPY]]
+  // CHECK:   copy_addr [[EXISTENTIAL]] to [init] [[COPY]]
   // CHECK:   [[OPENED_COPY:%.*]] = open_existential_addr immutable_access [[COPY]] : $*any P to $*[[OPENED_TYPE:@opened\(.*, any P\) Self]],
   // CHECK:   [[TMP:%.*]] = alloc_stack $[[OPENED_TYPE]]
-  // CHECK:   copy_addr [[OPENED_COPY]] to [initialization] [[TMP]]
+  // CHECK:   copy_addr [[OPENED_COPY]] to [init] [[TMP]]
   // CHECK:   // function_ref _bridgeAnythingToObjectiveC
   // CHECK:   [[BRIDGE_ANYTHING:%.*]] = function_ref
   // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[TMP]])
@@ -112,7 +112,7 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   // CHECK:   [[BORROWED_ERROR_COPY:%.*]] = begin_borrow [[ERROR_COPY]]
   // CHECK:   [[ERROR_BOX:%[0-9]+]] = open_existential_box [[BORROWED_ERROR_COPY]] : $any Error to $*@opened([[ERROR_ARCHETYPE:"[^"]*"]], any Error) Self
   // CHECK:   [[ERROR_STACK:%[0-9]+]] = alloc_stack $@opened([[ERROR_ARCHETYPE]], any Error) Self
-  // CHECK:   copy_addr [[ERROR_BOX]] to [initialization] [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]], any Error) Self
+  // CHECK:   copy_addr [[ERROR_BOX]] to [init] [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]], any Error) Self
   // CHECK:   [[BRIDGE_FUNCTION:%[0-9]+]] = function_ref @$ss27_bridgeAnythingToObjectiveCyyXlxlF
   // CHECK:   [[BRIDGED_ERROR:%[0-9]+]] = apply [[BRIDGE_FUNCTION]]<@opened([[ERROR_ARCHETYPE]], any Error) Self>([[ERROR_STACK]])
   // CHECK:   dealloc_stack [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]], any Error) Self
@@ -123,10 +123,10 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   receiver.takesId(error)
 
   // CHECK:   [[COPY:%.*]] = alloc_stack $Any
-  // CHECK:   copy_addr [[ANY]] to [initialization] [[COPY]]
+  // CHECK:   copy_addr [[ANY]] to [init] [[COPY]]
   // CHECK:   [[OPENED_COPY:%.*]] = open_existential_addr immutable_access [[COPY]] : $*Any to $*[[OPENED_TYPE:@opened\(.*, Any\) Self]],
   // CHECK:   [[TMP:%.*]] = alloc_stack $[[OPENED_TYPE]]
-  // CHECK:   copy_addr [[OPENED_COPY]] to [initialization] [[TMP]]
+  // CHECK:   copy_addr [[OPENED_COPY]] to [init] [[TMP]]
   // CHECK:   // function_ref _bridgeAnythingToObjectiveC
   // CHECK:   [[BRIDGE_ANYTHING:%.*]] = function_ref
   // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[TMP]])
@@ -170,7 +170,7 @@ func passingToId<T: CP, U>(receiver: NSIdLover,
   receiver.takesId(optionalB)
 
   // CHECK:   [[TMP:%.*]] = alloc_stack $Optional<Any>
-  // CHECK:   copy_addr [[OPT_ANY]] to [initialization] [[TMP]]
+  // CHECK:   copy_addr [[OPT_ANY]] to [init] [[TMP]]
   // CHECK:   [[BRIDGE_OPTIONAL:%.*]] = function_ref @$sSq19_bridgeToObjectiveCyXlyF
   // CHECK:   [[ANYOBJECT:%.*]] = apply [[BRIDGE_OPTIONAL]]<Any>([[TMP]])
   // CHECK:   [[METHOD:%.*]] = objc_method [[SELF]] : $NSIdLover,
@@ -290,7 +290,7 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   receiver.takesNullableId(classExistential)
 
   // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $U
-  // CHECK-NEXT: copy_addr [[GENERIC]] to [initialization] [[COPY]]
+  // CHECK-NEXT: copy_addr [[GENERIC]] to [init] [[COPY]]
   // CHECK-NEXT: // function_ref _bridgeAnythingToObjectiveC
   // CHECK-NEXT: [[BRIDGE_ANYTHING:%.*]] = function_ref
   // CHECK-NEXT: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<U>([[COPY]])
@@ -303,10 +303,10 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   receiver.takesNullableId(generic)
 
   // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $any P
-  // CHECK-NEXT: copy_addr [[EXISTENTIAL]] to [initialization] [[COPY]]
+  // CHECK-NEXT: copy_addr [[EXISTENTIAL]] to [init] [[COPY]]
   // CHECK-NEXT: [[OPENED_COPY:%.*]] = open_existential_addr immutable_access [[COPY]] : $*any P to $*[[OPENED_TYPE:@opened\(.*, any P\) Self]],
   // CHECK: [[TMP:%.*]] = alloc_stack $[[OPENED_TYPE]]
-  // CHECK: copy_addr [[OPENED_COPY]] to [initialization] [[TMP]]
+  // CHECK: copy_addr [[OPENED_COPY]] to [init] [[TMP]]
   // CHECK-NEXT: // function_ref _bridgeAnythingToObjectiveC
   // CHECK-NEXT: [[BRIDGE_ANYTHING:%.*]] = function_ref
   // CHECK-NEXT: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[TMP]])
@@ -324,7 +324,7 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   // CHECK-NEXT: [[BORROWED_ERROR_COPY:%.*]] = begin_borrow [[ERROR_COPY]]
   // CHECK-NEXT: [[ERROR_BOX:%[0-9]+]] = open_existential_box [[BORROWED_ERROR_COPY]] : $any Error to $*@opened([[ERROR_ARCHETYPE:"[^"]*"]], any Error) Self
   // CHECK-NEXT: [[ERROR_STACK:%[0-9]+]] = alloc_stack $@opened([[ERROR_ARCHETYPE]], any Error) Self
-  // CHECK-NEXT: copy_addr [[ERROR_BOX]] to [initialization] [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]], any Error) Self
+  // CHECK-NEXT: copy_addr [[ERROR_BOX]] to [init] [[ERROR_STACK]] : $*@opened([[ERROR_ARCHETYPE]], any Error) Self
   // CHECK-NEXT: end_borrow [[BORROWED_ERROR_COPY]]
   // CHECK: [[BRIDGE_FUNCTION:%[0-9]+]] = function_ref @$ss27_bridgeAnythingToObjectiveCyyXlxlF
   // CHECK-NEXT: [[BRIDGED_ERROR:%[0-9]+]] = apply [[BRIDGE_FUNCTION]]<@opened([[ERROR_ARCHETYPE]], any Error) Self>([[ERROR_STACK]])
@@ -338,10 +338,10 @@ func passingToNullableId<T: CP, U>(receiver: NSIdLover,
   receiver.takesNullableId(error)
 
   // CHECK-NEXT: [[COPY:%.*]] = alloc_stack $Any
-  // CHECK-NEXT: copy_addr [[ANY]] to [initialization] [[COPY]]
+  // CHECK-NEXT: copy_addr [[ANY]] to [init] [[COPY]]
   // CHECK-NEXT: [[OPENED_COPY:%.*]] = open_existential_addr immutable_access [[COPY]] : $*Any to $*[[OPENED_TYPE:@opened\(.*, Any\) Self]],
   // CHECK: [[TMP:%.*]] = alloc_stack $[[OPENED_TYPE]]
-  // CHECK: copy_addr [[OPENED_COPY]] to [initialization] [[TMP]]
+  // CHECK: copy_addr [[OPENED_COPY]] to [init] [[TMP]]
   // CHECK-NEXT: // function_ref _bridgeAnythingToObjectiveC
   // CHECK-NEXT: [[BRIDGE_ANYTHING:%.*]] = function_ref
   // CHECK-NEXT: [[ANYOBJECT:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[TMP]])
@@ -436,7 +436,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK:   destroy_value [[SELF_COPY]]
   // CHECK:   [[OPEN_RESULT:%.*]] = open_existential_addr immutable_access [[NATIVE_RESULT]]
 	// CHECK:   [[TMP:%.*]] = alloc_stack
-  // CHECK:   copy_addr [[OPEN_RESULT]] to [initialization] [[TMP]]
+  // CHECK:   copy_addr [[OPEN_RESULT]] to [init] [[TMP]]
   // CHECK:   [[BRIDGE_ANYTHING:%.*]] = function_ref @$ss27_bridgeAnythingToObjectiveC{{.*}}F
   // CHECK:   [[OBJC_RESULT:%.*]] = apply [[BRIDGE_ANYTHING]]<{{.*}}>([[TMP]])
   // CHECK:   return [[OBJC_RESULT]]
@@ -481,7 +481,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK:     bb0([[ANY:%.*]] : $*Any, [[BLOCK:%.*]] : @guaranteed $@convention(block) @noescape (AnyObject) -> ()):
   // CHECK-NEXT:  [[OPENED_ANY:%.*]] = open_existential_addr immutable_access [[ANY]] : $*Any to $*[[OPENED_TYPE:@opened\(.*, Any\) Self]],
 	// CHECK:   [[TMP:%.*]] = alloc_stack
-  // CHECK:   copy_addr [[OPENED_ANY]] to [initialization] [[TMP]]
+  // CHECK:   copy_addr [[OPENED_ANY]] to [init] [[TMP]]
   // CHECK-NEXT:  // function_ref _bridgeAnythingToObjectiveC
   // CHECK-NEXT:  [[BRIDGE_ANYTHING:%.*]] = function_ref
   // CHECK-NEXT:  [[BRIDGED:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[TMP]])
@@ -603,7 +603,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  end_borrow [[BORROW_FUN]]
   // CHECK-NEXT:  [[OPENED:%.*]] = open_existential_addr immutable_access [[RESULT]] : $*Any to $*[[OPENED_TYPE:@opened\(.*, Any\) Self]],
   // CHECK:       [[TMP:%.*]] = alloc_stack $[[OPENED_TYPE]]
-  // CHECK:       copy_addr [[OPENED]] to [initialization] [[TMP]]
+  // CHECK:       copy_addr [[OPENED]] to [init] [[TMP]]
   // CHECK-NEXT:  // function_ref _bridgeAnythingToObjectiveC
   // CHECK-NEXT:  [[BRIDGE_ANYTHING:%.*]] = function_ref
   // CHECK-NEXT:  [[BRIDGED:%.*]] = apply [[BRIDGE_ANYTHING]]<[[OPENED_TYPE]]>([[TMP]])

--- a/test/SILGen/objc_error.swift
+++ b/test/SILGen/objc_error.swift
@@ -141,9 +141,9 @@ extension Error {
   // CHECK: bb0([[SELF:%[0-9]+]] : $*Self)
 	func convertToNSError() -> NSError {
     // CHECK: [[COPY:%.*]] = alloc_stack $Self
-    // CHECK: copy_addr [[SELF]] to [initialization] [[COPY]]
+    // CHECK: copy_addr [[SELF]] to [init] [[COPY]]
     // CHECK: [[COPY2:%.*]] = alloc_stack $Self
-    // CHECK: copy_addr [[COPY]] to [initialization] [[COPY2]]
+    // CHECK: copy_addr [[COPY]] to [init] [[COPY2]]
     // CHECK: [[GET_EMBEDDED_FN:%[0-9]+]] = function_ref @$ss24_getErrorEmbeddedNSErroryyXlSgxs0B0RzlF
     // CHECK: [[EMBEDDED_RESULT_OPT:%[0-9]+]] = apply [[GET_EMBEDDED_FN]]<Self>([[COPY2]])
     // CHECK: switch_enum [[EMBEDDED_RESULT_OPT]] : $Optional<AnyObject>,
@@ -160,7 +160,7 @@ extension Error {
     // CHECK: [[ERROR_BOX:%[0-9]+]] = alloc_existential_box $any Error, $Self
     // CHECK: [[ERROR_PROJECTED:%[0-9]+]] = project_existential_box $Self in [[ERROR_BOX]] : $any Error
     // CHECK: store [[ERROR_BOX]] to [init] [[ERROR_BUF:%.*]] :
-    // CHECK: copy_addr [take] [[COPY]] to [initialization] [[ERROR_PROJECTED]] : $*Self
+    // CHECK: copy_addr [take] [[COPY]] to [init] [[ERROR_PROJECTED]] : $*Self
     // CHECK: [[ERROR_BOX2:%.*]] = load [take] [[ERROR_BUF]]
     // CHECK: br [[CONTINUATION]]([[ERROR_BOX2]] : $any Error)
 

--- a/test/SILGen/opaque_result_type.swift
+++ b/test/SILGen/opaque_result_type.swift
@@ -23,14 +23,14 @@ func valueToAddr(x: String) -> some P {
 // CHECK-LABEL: sil hidden {{.*}}10addrToAddr1xQr
 func addrToAddr(x: AddrOnly) -> some P {
   // CHECK: bb0([[ARG0:%.*]] : $*AddrOnly, [[ARG1:%.*]] : $*AddrOnly):
-  // CHECK: copy_addr [[ARG1]] to [initialization] [[ARG0]]
+  // CHECK: copy_addr [[ARG1]] to [init] [[ARG0]]
   return x
 }
 
 // CHECK-LABEL: sil hidden {{.*}}13genericAddrToE01xQr
 func genericAddrToAddr<T: P>(x: T) -> some P {
   // CHECK: bb0([[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
-  // CHECK: copy_addr [[ARG1]] to [initialization] [[ARG0]]
+  // CHECK: copy_addr [[ARG1]] to [init] [[ARG0]]
   return x
 }
 

--- a/test/SILGen/optional-cast.swift
+++ b/test/SILGen/optional-cast.swift
@@ -180,7 +180,7 @@ func opt_to_opt_reference(_ x : C!) -> C? { return x }
 // CHECK-LABEL: sil hidden [ossa] @$s4main07opt_to_B12_addressOnly{{[_0-9a-zA-Z]*}}F
 // CHECK:       bb0(%0 : $*Optional<T>, %1 : $*Optional<T>):
 // CHECK-NEXT:  debug_value %1 : $*Optional<T>, let, name "x", {{.*}} expr op_deref
-// CHECK-NEXT:  copy_addr %1 to [initialization] %0
+// CHECK-NEXT:  copy_addr %1 to [init] %0
 // CHECK-NOT:  destroy_addr %1
 func opt_to_opt_addressOnly<T>(_ x : T!) -> T? { return x }
 

--- a/test/SILGen/parameterized_existentials.swift
+++ b/test/SILGen/parameterized_existentials.swift
@@ -35,7 +35,7 @@ func upcast(_ x: S) -> any P {
   // CHECK: store [[CONCRETE_VAL]] to [trivial] [[INIT_Q_INT_STRING_FLOAT]] : $*S
   // CHECK: [[OPEN_Q_INT_STRING_FLOAT:%.*]] = open_existential_addr immutable_access [[Q_INT_STRING_FLOAT]] : $*any Q<Int, String, Float> to $*[[OPENED_Q_INT_STRING_FLOAT:@opened\(.*, any Q<Int, String, Float>\) Self]]
   // CHECK: [[RESULT_INIT:%.*]] = init_existential_addr [[RESULT_PARAM]] : $*any P, $[[OPENED_Q_INT_STRING_FLOAT]]
-  // CHECK: copy_addr [[OPEN_Q_INT_STRING_FLOAT]] to [initialization] [[RESULT_INIT]] : $*[[OPENED_Q_INT_STRING_FLOAT]]
+  // CHECK: copy_addr [[OPEN_Q_INT_STRING_FLOAT]] to [init] [[RESULT_INIT]] : $*[[OPENED_Q_INT_STRING_FLOAT]]
 
   return x as any Q<Int, String, Float> as any P
 }
@@ -50,7 +50,7 @@ func upupupupcast(_ x: S) -> any P {
   // CHECK: [[OPEN_INT_STRING_FLOAT:%.*]] = open_existential_addr immutable_access %3 : $*any P<Int, String, Float> to $*[[OPENED_P_INT_STRING_FLOAT:@opened\(.*, any P<Int, String, Float>\) Self]]
 
   // CHECK: [[RESULT_INIT:%.*]] = init_existential_addr [[RESULT_PARAM]] : $*any P, $[[OPENED_P_INT_STRING_FLOAT]]
-  // CHECK: copy_addr [[OPEN_INT_STRING_FLOAT]] to [initialization] [[RESULT_INIT]] : $*[[OPENED_P_INT_STRING_FLOAT]]
+  // CHECK: copy_addr [[OPEN_INT_STRING_FLOAT]] to [init] [[RESULT_INIT]] : $*[[OPENED_P_INT_STRING_FLOAT]]
   return x as any P<Int, String, Float> as any P
 }
 

--- a/test/SILGen/partial_apply_protocol.swift
+++ b/test/SILGen/partial_apply_protocol.swift
@@ -47,7 +47,7 @@ func testClonable(c: Clonable) {
 // CHECK-NEXT:    [[INNER_RESULT:%.*]] = alloc_stack $τ_0_0
 // CHECK-NEXT:    apply %1([[INNER_RESULT]])
 // CHECK-NEXT:    [[OUTER_RESULT:%.*]] = init_existential_addr %0
-// CHECK-NEXT:    copy_addr [take] [[INNER_RESULT]] to [initialization] [[OUTER_RESULT]]
+// CHECK-NEXT:    copy_addr [take] [[INNER_RESULT]] to [init] [[OUTER_RESULT]]
 // CHECK-NEXT:    [[EMPTY:%.*]] = tuple ()
 // CHECK-NEXT:    dealloc_stack [[INNER_RESULT]]
 // CHECK-NEXT:    return [[EMPTY]]

--- a/test/SILGen/polymorphic_builtins.swift
+++ b/test/SILGen/polymorphic_builtins.swift
@@ -12,9 +12,9 @@ func concreteAddTest(_ x: Builtin.Vec4xInt32, _ y: Builtin.Vec4xInt32) -> Builti
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericAddTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_add"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericAddTest{{.*}}'
 func genericAddTest<T>(_ x : T, _ y : T) -> T {
@@ -33,9 +33,9 @@ func concreteAndTest(_ x: Builtin.Vec4xInt32, _ y: Builtin.Vec4xInt32) -> Builti
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericAndTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_and"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericAndTest{{.*}}'
 func genericAndTest<T>(_ x : T, _ y : T) -> T {
@@ -54,9 +54,9 @@ func concreteAshrTest(_ x: Builtin.Vec4xInt32, _ y: Builtin.Vec4xInt32) -> Built
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericAshrTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_ashr"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericAshrTest{{.*}}'
 func genericAshrTest<T>(_ x : T, _ y : T) -> T {
@@ -75,9 +75,9 @@ func concreteLshrTest(_ x: Builtin.Vec4xInt32, _ y: Builtin.Vec4xInt32) -> Built
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericLshrTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_lshr"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericLshrTest{{.*}}'
 func genericLshrTest<T>(_ x : T, _ y : T) -> T {
@@ -96,9 +96,9 @@ func concreteMulTest(_ x: Builtin.Vec4xInt32, _ y: Builtin.Vec4xInt32) -> Builti
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericMulTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_mul"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericMulTest{{.*}}'
 func genericMulTest<T>(_ x : T, _ y : T) -> T {
@@ -117,9 +117,9 @@ func concreteOrTest(_ x: Builtin.Vec4xInt32, _ y: Builtin.Vec4xInt32) -> Builtin
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericOrTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_or"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericOrTest{{.*}}'
 func genericOrTest<T>(_ x : T, _ y : T) -> T {
@@ -138,9 +138,9 @@ func concreteSdivTest(_ x: Builtin.Vec4xInt32, _ y: Builtin.Vec4xInt32) -> Built
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericSdivTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_sdiv"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericSdivTest{{.*}}'
 func genericSdivTest<T>(_ x : T, _ y : T) -> T {
@@ -159,9 +159,9 @@ func concreteSdivExactTest(_ x: Builtin.Vec4xInt32, _ y: Builtin.Vec4xInt32) -> 
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericSdivExactTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_sdiv_exact"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericSdivExactTest{{.*}}'
 func genericSdivExactTest<T>(_ x : T, _ y : T) -> T {
@@ -180,9 +180,9 @@ func concreteShlTest(_ x: Builtin.Vec4xInt32, _ y: Builtin.Vec4xInt32) -> Builti
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericShlTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_shl"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericShlTest{{.*}}'
 func genericShlTest<T>(_ x : T, _ y : T) -> T {
@@ -201,9 +201,9 @@ func concreteSremTest(_ x: Builtin.Vec4xInt32, _ y: Builtin.Vec4xInt32) -> Built
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericSremTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_srem"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericSremTest{{.*}}'
 func genericSremTest<T>(_ x : T, _ y : T) -> T {
@@ -222,9 +222,9 @@ func concreteSubTest(_ x: Builtin.Vec4xInt32, _ y: Builtin.Vec4xInt32) -> Builti
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericSubTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_sub"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericSubTest{{.*}}'
 func genericSubTest<T>(_ x : T, _ y : T) -> T {
@@ -243,9 +243,9 @@ func concreteUdivTest(_ x: Builtin.Vec4xInt32, _ y: Builtin.Vec4xInt32) -> Built
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericUdivTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_udiv"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericUdivTest{{.*}}'
 func genericUdivTest<T>(_ x : T, _ y : T) -> T {
@@ -264,9 +264,9 @@ func concreteUdivExactTest(_ x: Builtin.Vec4xInt32, _ y: Builtin.Vec4xInt32) -> 
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericUdivExactTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_udiv_exact"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericUdivExactTest{{.*}}'
 func genericUdivExactTest<T>(_ x : T, _ y : T) -> T {
@@ -285,9 +285,9 @@ func concreteXorTest(_ x: Builtin.Vec4xInt32, _ y: Builtin.Vec4xInt32) -> Builti
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericXorTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_xor"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericXorTest{{.*}}'
 func genericXorTest<T>(_ x : T, _ y : T) -> T {
@@ -306,9 +306,9 @@ func concreteFaddTest(_ x: Builtin.Vec4xFPIEEE32, _ y: Builtin.Vec4xFPIEEE32) ->
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericFaddTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_fadd"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericFaddTest{{.*}}'
 func genericFaddTest<T>(_ x : T, _ y : T) -> T {
@@ -327,9 +327,9 @@ func concreteFdivTest(_ x: Builtin.Vec4xFPIEEE32, _ y: Builtin.Vec4xFPIEEE32) ->
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericFdivTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_fdiv"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericFdivTest{{.*}}'
 func genericFdivTest<T>(_ x : T, _ y : T) -> T {
@@ -348,9 +348,9 @@ func concreteFmulTest(_ x: Builtin.Vec4xFPIEEE32, _ y: Builtin.Vec4xFPIEEE32) ->
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericFmulTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_fmul"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericFmulTest{{.*}}'
 func genericFmulTest<T>(_ x : T, _ y : T) -> T {
@@ -369,9 +369,9 @@ func concreteFremTest(_ x: Builtin.Vec4xFPIEEE32, _ y: Builtin.Vec4xFPIEEE32) ->
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericFremTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_frem"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericFremTest{{.*}}'
 func genericFremTest<T>(_ x : T, _ y : T) -> T {
@@ -390,9 +390,9 @@ func concreteFsubTest(_ x: Builtin.Vec4xFPIEEE32, _ y: Builtin.Vec4xFPIEEE32) ->
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericFsubTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_fsub"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericFsubTest{{.*}}'
 func genericFsubTest<T>(_ x : T, _ y : T) -> T {
@@ -411,9 +411,9 @@ func concreteUremTest(_ x: Builtin.Int64, _ y: Builtin.Int64) -> Builtin.Int64 {
 // CHECK-LABEL: sil hidden [ossa] @$s20polymorphic_builtins{{.*}}genericUremTest{{.*}} : $@convention(thin) <T> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0([[RESULT:%.*]] : $*T, [[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK_SLOT_0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG0]] to [initialization] [[STACK_SLOT_0]]
+// CHECK:   copy_addr [[ARG0]] to [init] [[STACK_SLOT_0]]
 // CHECK:   [[STACK_SLOT_1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[STACK_SLOT_1]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[STACK_SLOT_1]]
 // CHECK:   builtin "generic_urem"<T>([[RESULT]] : $*T, [[STACK_SLOT_0]] : $*T, [[STACK_SLOT_1]] : $*T) : $()
 // CHECK: } // end sil function '$s20polymorphic_builtins{{.*}}genericUremTest{{.*}}'
 func genericUremTest<T>(_ x : T, _ y : T) -> T {

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -760,8 +760,8 @@ struct AddressOnlyReadOnlySubscript {
 
 // CHECK-LABEL: sil hidden [ossa] @$s10properties015addressOnlyReadC24SubscriptFromMutableBase
 // CHECK:         [[BASE:%.*]] = alloc_box ${ var AddressOnlyReadOnlySubscript }
-// CHECK:         copy_addr [[BASE:%.*]] to [initialization] [[COPY:%.*]] :
-// CHECK:         copy_addr [[COPY:%.*]] to [initialization] [[COPY2:%.*]] :
+// CHECK:         copy_addr [[BASE:%.*]] to [init] [[COPY:%.*]] :
+// CHECK:         copy_addr [[COPY:%.*]] to [init] [[COPY2:%.*]] :
 // CHECK:         [[GETTER:%.*]] = function_ref @$s10properties015AddressOnlyReadC9SubscriptV{{[_0-9a-zA-Z]*}}ig
 // CHECK:         apply [[GETTER]]({{%.*}}, [[COPY2]])
 func addressOnlyReadOnlySubscriptFromMutableBase(_ x: Int) {
@@ -828,10 +828,10 @@ protocol NonmutatingProtocol {
 
 // CHECK-NEXT:   [[C_FIELD_PAYLOAD:%.*]] = open_existential_addr immutable_access [[C_FIELD_BOX]] : $*any NonmutatingProtocol to $*@opened("{{.*}}", any NonmutatingProtocol) Self
 // CHECK-NEXT:   [[C_FIELD_COPY:%.*]] = alloc_stack $@opened("{{.*}}", any NonmutatingProtocol) Self
-// CHECK-NEXT:   copy_addr [[C_FIELD_PAYLOAD]] to [initialization] [[C_FIELD_COPY]] : $*@opened("{{.*}}", any NonmutatingProtocol) Self
+// CHECK-NEXT:   copy_addr [[C_FIELD_PAYLOAD]] to [init] [[C_FIELD_COPY]] : $*@opened("{{.*}}", any NonmutatingProtocol) Self
 // CHECK-NEXT:   destroy_value [[C]] : $ReferenceType
 // CHECK-NEXT:   [[C_FIELD_BORROW:%.*]] = alloc_stack
-// CHECK-NEXT:   copy_addr [[C_FIELD_COPY]] to [initialization] [[C_FIELD_BORROW]]
+// CHECK-NEXT:   copy_addr [[C_FIELD_COPY]] to [init] [[C_FIELD_BORROW]]
 // CHECK-NEXT:   [[GETTER:%.*]] = witness_method $@opened("{{.*}}", any NonmutatingProtocol) Self, #NonmutatingProtocol.x!getter : <Self where Self : NonmutatingProtocol> (Self) -> () -> Int, [[C_FIELD_PAYLOAD]] : $*@opened("{{.*}}", any NonmutatingProtocol) Self : $@convention(witness_method: NonmutatingProtocol) <τ_0_0 where τ_0_0 : NonmutatingProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK-NEXT:   [[RESULT_VALUE:%.*]] = apply [[GETTER]]<@opened("{{.*}}", any NonmutatingProtocol) Self>([[C_FIELD_BORROW]]) : $@convention(witness_method: NonmutatingProtocol) <τ_0_0 where τ_0_0 : NonmutatingProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK-NEXT:   destroy_addr [[C_FIELD_BORROW]]

--- a/test/SILGen/properties_swift4.swift
+++ b/test/SILGen/properties_swift4.swift
@@ -104,7 +104,7 @@ struct DidSetWillSetTests: ForceAccessors {
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "other"
       // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[READ_SELF:%.*]] = begin_access [read] [unknown] %0 : $*DidSetWillSetTests
-      // CHECK-NEXT: copy_addr [[READ_SELF]] to [initialization] [[BOXADDR]] : $*DidSetWillSetTests
+      // CHECK-NEXT: copy_addr [[READ_SELF]] to [init] [[BOXADDR]] : $*DidSetWillSetTests
       // CHECK-NEXT: end_access [[READ_SELF]] : $*DidSetWillSetTests
 
       other.a = zero

--- a/test/SILGen/properties_swift5.swift
+++ b/test/SILGen/properties_swift5.swift
@@ -108,7 +108,7 @@ struct DidSetWillSetTests: ForceAccessors {
       // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "other"
       // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
       // CHECK-NEXT: [[READ_SELF:%.*]] = begin_access [read] [unknown] %0 : $*DidSetWillSetTests
-      // CHECK-NEXT: copy_addr [[READ_SELF]] to [initialization] [[BOXADDR]] : $*DidSetWillSetTests
+      // CHECK-NEXT: copy_addr [[READ_SELF]] to [init] [[BOXADDR]] : $*DidSetWillSetTests
       // CHECK-NEXT: end_access [[READ_SELF]] : $*DidSetWillSetTests
 
       other.a = zero

--- a/test/SILGen/property_wrapper_parameter.swift
+++ b/test/SILGen/property_wrapper_parameter.swift
@@ -492,7 +492,7 @@ func testImplicitWrapperWithResilientStruct() {
   // implicit closure #1 in testImplicitWrapperWithResilientStruct()
   // CHECK-LABEL: sil private [ossa] @$s26property_wrapper_parameter38testImplicitWrapperWithResilientStructyyFyAA010ProjectionF0Vy11def_structA1AVGcfu_ : $@convention(thin) (@in_guaranteed ProjectionWrapper<A>) -> ()
   // CHECK: [[P:%.*]] = alloc_stack $ProjectionWrapper<A>
-  // CHECK: copy_addr %0 to [initialization] [[P]]
+  // CHECK: copy_addr %0 to [init] [[P]]
   // CHECK: [[I:%.*]] = function_ref @$s26property_wrapper_parameter38testImplicitWrapperWithResilientStructyyFyAA010ProjectionF0Vy11def_structA1AVGcfu_yAHcfU_6$valueL_AHvpfW : $@convention(thin) (@in ProjectionWrapper<A>) -> @out ProjectionWrapper<A>
   // CHECK: apply [[I]]({{.*}}, [[P]]) : $@convention(thin) (@in ProjectionWrapper<A>) -> @out ProjectionWrapper<A>
 

--- a/test/SILGen/protocol_extensions.swift
+++ b/test/SILGen/protocol_extensions.swift
@@ -507,7 +507,7 @@ func testExistentials1(_ p1: P1, b: Bool, i: Int64) {
   p1.f1()
 
   // CHECK: [[POPENED:%[0-9]+]] = open_existential_addr immutable_access [[P]] : $*any P1 to $*@opened([[UUID:".*"]], any P1) Self
-  // CHECK: copy_addr [[POPENED]] to [initialization] [[POPENED_COPY:%.*]] :
+  // CHECK: copy_addr [[POPENED]] to [init] [[POPENED_COPY:%.*]] :
   // CHECK: [[GETTER:%[0-9]+]] = function_ref @$s19protocol_extensions2P1PAAEySbs5Int64Vcig
   // CHECK: apply [[GETTER]]<@opened([[UUID]], any P1) Self>([[I]], [[POPENED_COPY]]) : $@convention(method) <τ_0_0 where τ_0_0 : P1> (Int64, @in_guaranteed τ_0_0) -> Bool
   // CHECK: store{{.*}} : $*Bool
@@ -516,7 +516,7 @@ func testExistentials1(_ p1: P1, b: Bool, i: Int64) {
   var b2 = p1[i]
 
   // CHECK: [[POPENED:%[0-9]+]] = open_existential_addr immutable_access [[P]] : $*any P1 to $*@opened([[UUID:".*"]], any P1) Self
-  // CHECK: copy_addr [[POPENED]] to [initialization] [[POPENED_COPY:%.*]] :
+  // CHECK: copy_addr [[POPENED]] to [init] [[POPENED_COPY:%.*]] :
   // CHECK: [[GETTER:%[0-9]+]] = function_ref @$s19protocol_extensions2P1PAAE4propSbvg
   // CHECK: apply [[GETTER]]<@opened([[UUID]], any P1) Self>([[POPENED_COPY]]) : $@convention(method) <τ_0_0 where τ_0_0 : P1> (@in_guaranteed τ_0_0) -> Bool
   // CHECK: store{{.*}} : $*Bool
@@ -541,13 +541,13 @@ func testExistentials2(_ p1: P1) {
 // CHECK: bb0([[P:%[0-9]+]] : $*any P1):
 func testExistentialsGetters(_ p1: P1) {
   // CHECK: [[POPENED:%[0-9]+]] = open_existential_addr immutable_access [[P]] : $*any P1 to $*@opened([[UUID:".*"]], any P1) Self
-  // CHECK: copy_addr [[POPENED]] to [initialization] [[POPENED_COPY:%.*]] :
+  // CHECK: copy_addr [[POPENED]] to [init] [[POPENED_COPY:%.*]] :
   // CHECK: [[FN:%[0-9]+]] = function_ref @$s19protocol_extensions2P1PAAE5prop2Sbvg
   // CHECK: [[B:%[0-9]+]] = apply [[FN]]<@opened([[UUID]], any P1) Self>([[POPENED_COPY]]) : $@convention(method) <τ_0_0 where τ_0_0 : P1> (@in_guaranteed τ_0_0) -> Bool
   let b: Bool = p1.prop2
 
   // CHECK: [[POPENED:%[0-9]+]] = open_existential_addr immutable_access [[P]] : $*any P1 to $*@opened([[UUID:".*"]], any P1) Self
-  // CHECK: copy_addr [[POPENED]] to [initialization] [[POPENED_COPY:%.*]] :
+  // CHECK: copy_addr [[POPENED]] to [init] [[POPENED_COPY:%.*]] :
   // CHECK: [[GETTER:%[0-9]+]] = function_ref @$s19protocol_extensions2P1PAAEyS2bcig
   // CHECK: apply [[GETTER]]<@opened([[UUID]], any P1) Self>([[B]], [[POPENED_COPY]]) : $@convention(method) <τ_0_0 where τ_0_0 : P1> (Bool, @in_guaranteed τ_0_0) -> Bool
   let b2: Bool = p1[b]
@@ -560,7 +560,7 @@ func testExistentialSetters(_ p1: P1, b: Bool) {
   // CHECK: [[PBOX:%[0-9]+]] = alloc_box ${ var any P1 }
   // CHECK: [[PLIFETIME:%[0-9]+]] = begin_borrow [lexical] [[PBOX]]
   // CHECK: [[PBP:%[0-9]+]] = project_box [[PLIFETIME]]
-  // CHECK-NEXT: copy_addr [[P]] to [initialization] [[PBP]] : $*any P1
+  // CHECK-NEXT: copy_addr [[P]] to [init] [[PBP]] : $*any P1
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PBP]]
   // CHECK: [[POPENED:%[0-9]+]] = open_existential_addr mutable_access [[WRITE]] : $*any P1 to $*@opened([[UUID:".*"]], any P1) Self
   // CHECK: [[GETTER:%[0-9]+]] = function_ref @$s19protocol_extensions2P1PAAE5prop2Sbvs
@@ -594,11 +594,11 @@ func testLogicalExistentialSetters(_ hasAP1: HasAP1, _ b: Bool) {
   // CHECK: [[HASP1_BOX:%[0-9]+]] = alloc_box ${ var HasAP1 }
   // CHECK: [[HASP1_LIFETIME:%[0-9]+]] = begin_borrow [lexical] [[HASP1_BOX]]
   // CHECK: [[PBHASP1:%[0-9]+]] = project_box [[HASP1_LIFETIME]]
-  // CHECK-NEXT: copy_addr [[HASP1]] to [initialization] [[PBHASP1]] : $*HasAP1
+  // CHECK-NEXT: copy_addr [[HASP1]] to [init] [[PBHASP1]] : $*HasAP1
   // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] [[PBHASP1]]
   // CHECK: [[P1_COPY:%[0-9]+]] = alloc_stack $any P1
   // CHECK-NEXT: [[HASP1_COPY:%[0-9]+]] = alloc_stack $HasAP1
-  // CHECK-NEXT: copy_addr [[WRITE]] to [initialization] [[HASP1_COPY]] : $*HasAP1
+  // CHECK-NEXT: copy_addr [[WRITE]] to [init] [[HASP1_COPY]] : $*HasAP1
   // CHECK: [[SOMEP1_GETTER:%[0-9]+]] = function_ref @$s19protocol_extensions6HasAP1V6someP1AA0F0_pvg : $@convention(method) (@in_guaranteed HasAP1) -> @out any P1
   // CHECK: [[RESULT:%[0-9]+]] = apply [[SOMEP1_GETTER]]([[P1_COPY]], [[HASP1_COPY]]) : $@convention(method) (@in_guaranteed HasAP1) -> @out any P1
   // CHECK: [[P1_OPENED:%[0-9]+]] = open_existential_addr mutable_access [[P1_COPY]] : $*any P1 to $*@opened([[UUID:".*"]], any P1) Self
@@ -628,7 +628,7 @@ func test_open_existential_semantics_opaque(_ guaranteed: P1,
   
   // -- Need a guaranteed copy because it's immutable
   // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PB]]
-  // CHECK: copy_addr [[READ]] to [initialization] [[IMMEDIATE:%.*]] :
+  // CHECK: copy_addr [[READ]] to [init] [[IMMEDIATE:%.*]] :
   // CHECK: [[VALUE:%.*]] = open_existential_addr immutable_access [[IMMEDIATE]]
   // CHECK: [[METHOD:%.*]] = function_ref
   // -- Can consume the value from our own copy
@@ -712,7 +712,7 @@ extension InitRequirement {
     // CHECK-NEXT: apply [[DELEGATEE]]<Self>([[SELF_BOX]], [[ARG_COPY_CAST]], [[SELF_TYPE]])
     // CHECK-NEXT: copy_addr [take] [[SELF_BOX]] to [[SELF_BOX_ADDR]]
     // CHECK-NEXT: dealloc_stack [[SELF_BOX]]
-    // CHECK-NEXT: copy_addr [[SELF_BOX_ADDR]] to [initialization] [[OUT]]
+    // CHECK-NEXT: copy_addr [[SELF_BOX_ADDR]] to [init] [[OUT]]
     // CHECK-NEXT: end_borrow [[BORROWED_ARG]]
     // CHECK-NEXT: destroy_value [[ARG]]
     // CHECK-NEXT: end_borrow [[SELF_BOX_LIFETIME]]
@@ -735,7 +735,7 @@ extension InitRequirement {
     // CHECK-NEXT: apply [[DELEGATEE]]<Self>([[SELF_BOX]], [[ARG_COPY]], [[SELF_TYPE]])
     // CHECK-NEXT: copy_addr [take] [[SELF_BOX]] to [[SELF_BOX_ADDR]]
     // CHECK-NEXT: dealloc_stack [[SELF_BOX]]
-    // CHECK-NEXT: copy_addr [[SELF_BOX_ADDR]] to [initialization] [[OUT]]
+    // CHECK-NEXT: copy_addr [[SELF_BOX_ADDR]] to [init] [[OUT]]
     // CHECK-NEXT: end_borrow [[BORROWED_ARG]]
     // CHECK-NEXT: destroy_value [[ARG]]
     // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]
@@ -761,7 +761,7 @@ extension InitRequirement {
     // CHECK-NEXT: copy_addr [take] [[SELF_BOX]] to [[ACCESS]]
     // CHECK-NEXT: end_access [[ACCESS]]
     // CHECK-NEXT: dealloc_stack [[SELF_BOX]]
-    // CHECK-NEXT: copy_addr [[SELF_BOX_ADDR]] to [initialization] [[OUT]]
+    // CHECK-NEXT: copy_addr [[SELF_BOX_ADDR]] to [init] [[OUT]]
     // CHECK-NEXT: end_borrow [[BORROWED_ARG]]
     // CHECK-NEXT: destroy_value [[ARG]]
     // CHECK-NEXT: end_borrow [[SELF_LIFETIME]]

--- a/test/SILGen/protocols.swift
+++ b/test/SILGen/protocols.swift
@@ -26,10 +26,10 @@ func use_subscript_rvalue_get(_ i : Int) -> Int {
 // CHECK: [[READ:%.*]] = begin_access [read] [dynamic] [[GLOB]] : $*any SubscriptableGet
 // CHECK: [[PROJ:%[0-9]+]] = open_existential_addr immutable_access [[READ]] : $*any SubscriptableGet to $*[[OPENED:@opened\(.*, any SubscriptableGet\) Self]]
 // CHECK: [[ALLOCSTACK:%[0-9]+]] = alloc_stack $[[OPENED]]
-// CHECK: copy_addr [[PROJ]] to [initialization] [[ALLOCSTACK]] : $*[[OPENED]]
+// CHECK: copy_addr [[PROJ]] to [init] [[ALLOCSTACK]] : $*[[OPENED]]
 // CHECK-NEXT: end_access [[READ]] : $*any SubscriptableGet
 // CHECK-NEXT: [[TMP:%.*]] = alloc_stack
-// CHECK-NEXT: copy_addr [[ALLOCSTACK]] to [initialization] [[TMP]]
+// CHECK-NEXT: copy_addr [[ALLOCSTACK]] to [init] [[TMP]]
 // CHECK-NEXT: [[METH:%[0-9]+]] = witness_method $[[OPENED]], #SubscriptableGet.subscript!getter
 // CHECK-NEXT: [[RESULT:%[0-9]+]] = apply [[METH]]<[[OPENED]]>(%0, [[TMP]])
 // CHECK-NEXT: destroy_addr [[TMP]]
@@ -48,7 +48,7 @@ func use_subscript_lvalue_get(_ i : Int) -> Int {
 // CHECK: [[READ:%.*]] = begin_access [read] [dynamic] [[GLOB]] : $*any SubscriptableGetSet
 // CHECK: [[PROJ:%[0-9]+]] = open_existential_addr immutable_access [[READ]] : $*any SubscriptableGetSet to $*[[OPENED:@opened\(.*, any SubscriptableGetSet\) Self]]
 // CHECK: [[ALLOCSTACK:%[0-9]+]] = alloc_stack $[[OPENED]]
-// CHECK: copy_addr [[PROJ]] to [initialization] [[ALLOCSTACK]] : $*[[OPENED]]
+// CHECK: copy_addr [[PROJ]] to [init] [[ALLOCSTACK]] : $*[[OPENED]]
 // CHECK-NEXT: [[METH:%[0-9]+]] = witness_method $[[OPENED]], #SubscriptableGetSet.subscript!getter
 // CHECK-NEXT: [[RESULT:%[0-9]+]] = apply [[METH]]<[[OPENED]]>(%0, [[ALLOCSTACK]])
 // CHECK-NEXT: destroy_addr [[ALLOCSTACK]] : $*[[OPENED]]
@@ -79,7 +79,7 @@ func use_subscript_archetype_rvalue_get<T : SubscriptableGet>(_ generic : T, idx
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}use_subscript_archetype_rvalue_get
 // CHECK: bb0(%0 : $*T, %1 : $Int):
 // CHECK: [[STACK:%[0-9]+]] = alloc_stack $T
-// CHECK: copy_addr %0 to [initialization] [[STACK]]
+// CHECK: copy_addr %0 to [init] [[STACK]]
 // CHECK: [[METH:%[0-9]+]] = witness_method $T, #SubscriptableGet.subscript!getter
 // CHECK-NEXT: apply [[METH]]<T>(%1, [[STACK]])
 // CHECK-NEXT: destroy_addr [[STACK]] : $*T
@@ -94,7 +94,7 @@ func use_subscript_archetype_lvalue_get<T : SubscriptableGetSet>(_ generic: inou
 // CHECK: bb0(%0 : $*T, %1 : $Int):
 // CHECK: [[READ:%.*]] = begin_access [read] [unknown] %0 : $*T
 // CHECK: [[GUARANTEEDSTACK:%[0-9]+]] = alloc_stack $T
-// CHECK: copy_addr [[READ]] to [initialization] [[GUARANTEEDSTACK]] : $*T
+// CHECK: copy_addr [[READ]] to [init] [[GUARANTEEDSTACK]] : $*T
 // CHECK: [[METH:%[0-9]+]] = witness_method $T, #SubscriptableGetSet.subscript!getter
 // CHECK-NEXT: [[APPLYRESULT:%[0-9]+]] = apply [[METH]]<T>(%1, [[GUARANTEEDSTACK]])
 // CHECK-NEXT: destroy_addr [[GUARANTEEDSTACK]] : $*T
@@ -137,10 +137,10 @@ func use_property_rvalue_get() -> Int {
 // CHECK: [[READ:%.*]] = begin_access [read] [dynamic] [[GLOB]] : $*any PropertyWithGetter
 // CHECK: [[PROJ:%[0-9]+]] = open_existential_addr immutable_access [[READ]] : $*any PropertyWithGetter to $*[[OPENED:@opened\(.*, any PropertyWithGetter\) Self]]
 // CHECK: [[COPY:%.*]] = alloc_stack $[[OPENED]]
-// CHECK-NEXT: copy_addr [[PROJ]] to [initialization] [[COPY]] : $*[[OPENED]]
+// CHECK-NEXT: copy_addr [[PROJ]] to [init] [[COPY]] : $*[[OPENED]]
 // CHECK-NEXT: end_access [[READ]] : $*any PropertyWithGetter
 // CHECK: [[BORROW:%.*]] = alloc_stack $[[OPENED]]
-// CHECK-NEXT: copy_addr [[COPY]] to [initialization] [[BORROW]] : $*[[OPENED]]
+// CHECK-NEXT: copy_addr [[COPY]] to [init] [[BORROW]] : $*[[OPENED]]
 // CHECK-NEXT: [[METH:%[0-9]+]] = witness_method $[[OPENED]], #PropertyWithGetter.a!getter
 // CHECK-NEXT: apply [[METH]]<[[OPENED]]>([[BORROW]])
 
@@ -152,7 +152,7 @@ func use_property_lvalue_get() -> Int {
 // CHECK: [[READ:%.*]] = begin_access [read] [dynamic] [[GLOB]] : $*any PropertyWithGetterSetter
 // CHECK: [[PROJ:%[0-9]+]] = open_existential_addr immutable_access [[READ]] : $*any PropertyWithGetterSetter to $*[[OPENED:@opened\(.*, any PropertyWithGetterSetter\) Self]]
 // CHECK: [[STACK:%[0-9]+]] = alloc_stack $[[OPENED]]
-// CHECK: copy_addr [[PROJ]] to [initialization] [[STACK]]
+// CHECK: copy_addr [[PROJ]] to [init] [[STACK]]
 // CHECK-NEXT: [[METH:%[0-9]+]] = witness_method $[[OPENED]], #PropertyWithGetterSetter.b!getter
 // CHECK-NEXT: apply [[METH]]<[[OPENED]]>([[STACK]])
 
@@ -179,7 +179,7 @@ func use_property_archetype_rvalue_get<T : PropertyWithGetter>(_ generic : T) ->
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}use_property_archetype_rvalue_get
 // CHECK: bb0(%0 : $*T):
 // CHECK: [[STACK:%[0-9]+]] = alloc_stack $T
-// CHECK: copy_addr %0 to [initialization] [[STACK]]
+// CHECK: copy_addr %0 to [init] [[STACK]]
 // CHECK: [[METH:%[0-9]+]] = witness_method $T, #PropertyWithGetter.a!getter
 // CHECK-NEXT: apply [[METH]]<T>([[STACK]])
 // CHECK-NEXT: destroy_addr [[STACK]]
@@ -194,7 +194,7 @@ func use_property_archetype_lvalue_get<T : PropertyWithGetterSetter>(_ generic :
 // CHECK-LABEL: sil hidden [ossa] @{{.*}}use_property_archetype_lvalue_get
 // CHECK: bb0(%0 : $*T):
 // CHECK: [[STACK:%[0-9]+]] = alloc_stack $T
-// CHECK: copy_addr %0 to [initialization] [[STACK]] : $*T
+// CHECK: copy_addr %0 to [init] [[STACK]] : $*T
 // CHECK: [[METH:%[0-9]+]] = witness_method $T, #PropertyWithGetterSetter.b!getter
 // CHECK-NEXT: apply [[METH]]<T>([[STACK]])
 // CHECK-NEXT: destroy_addr [[STACK]] : $*T
@@ -383,13 +383,13 @@ func testExistentialPropertyRead<T: ExistentialProperty>(_ t: inout T) {
 // CHECK:      [[READ:%.*]] = begin_access [read] [unknown] %0 : $*T
 // CHECK:      [[P_TEMP:%.*]] = alloc_stack $any PropertyWithGetterSetter
 // CHECK:      [[T_TEMP:%.*]] = alloc_stack $T
-// CHECK:      copy_addr [[READ]] to [initialization] [[T_TEMP]] : $*T
+// CHECK:      copy_addr [[READ]] to [init] [[T_TEMP]] : $*T
 // CHECK:      [[P_GETTER:%.*]] = witness_method $T, #ExistentialProperty.p!getter :
 // CHECK-NEXT: apply [[P_GETTER]]<T>([[P_TEMP]], [[T_TEMP]])
 // CHECK-NEXT: destroy_addr [[T_TEMP]]
 // CHECK-NEXT: [[OPEN:%.*]] = open_existential_addr immutable_access [[P_TEMP]] : $*any PropertyWithGetterSetter to $*[[P_OPENED:@opened\(.*, any PropertyWithGetterSetter\) Self]]
 // CHECK-NEXT: [[T0:%.*]] = alloc_stack $[[P_OPENED]]
-// CHECK-NEXT: copy_addr [[OPEN]] to [initialization] [[T0]]
+// CHECK-NEXT: copy_addr [[OPEN]] to [init] [[T0]]
 // CHECK-NEXT: [[B_GETTER:%.*]] = witness_method $[[P_OPENED]], #PropertyWithGetterSetter.b!getter
 // CHECK-NEXT: apply [[B_GETTER]]<[[P_OPENED]]>([[T0]])
 // CHECK-NEXT: debug_value
@@ -439,7 +439,7 @@ public func testSelfReturningSubscript() {
   // CHECK-LABEL: sil private [ossa] @$s9protocols26testSelfReturningSubscriptyyFAA0cdE0_pAaC_pXEfU_
   // CHECK: [[OPEN:%.*]] = open_existential_addr immutable_access
   // CHECK: [[OPEN_ADDR:%.*]] = alloc_stack $@opened("{{.*}}", any SelfReturningSubscript) Self
-  // CHECK: copy_addr [[OPEN]] to [initialization] [[OPEN_ADDR]] : $*@opened("{{.*}}", any SelfReturningSubscript) Self
+  // CHECK: copy_addr [[OPEN]] to [init] [[OPEN_ADDR]] : $*@opened("{{.*}}", any SelfReturningSubscript) Self
   // CHECK: [[WIT_M:%.*]] = witness_method $@opened("{{.*}}", any SelfReturningSubscript) Self, #SelfReturningSubscript.subscript!getter
   // CHECK: apply [[WIT_M]]<@opened("{{.*}}", any SelfReturningSubscript) Self>({{%.*}}, {{%.*}}, [[OPEN_ADDR]])
   _ = [String: SelfReturningSubscript]().mapValues { $0[2] }

--- a/test/SILGen/result_builder_memberwise.swift
+++ b/test/SILGen/result_builder_memberwise.swift
@@ -42,7 +42,7 @@ struct MyTupleStruct<T, U> {
 // CHECK-NEXT:   [[SECOND_ADDR:%.*]] = struct_element_addr [[SELF]] : $*MyTupleStruct<T, U>, #MyTupleStruct.second
 // CHECK-NEXT:   [[CALL_RESULT:%.*]] = alloc_stack $U
 // CHECK-NEXT:   apply [[SECOND]]([[CALL_RESULT]]) : $@noescape @callee_guaranteed @substituted <τ_0_0> () -> @out τ_0_0 for <U>
-// CHECK-NEXT:   copy_addr [take] [[CALL_RESULT]] to [initialization] [[SECOND_ADDR]] : $*U
+// CHECK-NEXT:   copy_addr [take] [[CALL_RESULT]] to [init] [[SECOND_ADDR]] : $*U
 func trigger(cond: Bool) {
   _ = MyTupleStruct {
     1

--- a/test/SILGen/scalar_to_tuple_args.swift
+++ b/test/SILGen/scalar_to_tuple_args.swift
@@ -57,7 +57,7 @@ tupleWithDefaults(x: (x,x))
 // CHECK: ([[ARRAY:%.*]], [[MEMORY:%.*]]) = destructure_tuple [[ALLOC_ARRAY]]
 // CHECK: [[ADDR:%.*]] = pointer_to_address [[MEMORY]]
 // CHECK: [[READ:%.*]] = begin_access [read] [dynamic] [[X_ADDR]] : $*Int
-// CHECK: copy_addr [[READ]] to [initialization] [[ADDR]]
+// CHECK: copy_addr [[READ]] to [init] [[ADDR]]
 // CHECK: [[FIN_FN:%.*]] = function_ref @$ss27_finalizeUninitializedArrayySayxGABnlF
 // CHECK: [[FIN_ARR:%.*]] = apply [[FIN_FN]]<Int>([[ARRAY]])
 // CHECK: [[VARIADIC_FIRST:%.*]] = function_ref @$s20scalar_to_tuple_args13variadicFirstyySid_tF

--- a/test/SILGen/struct_resilience.swift
+++ b/test/SILGen/struct_resilience.swift
@@ -13,10 +13,10 @@ func functionWithResilientTypes(_ s: Size, f: (Size) -> Size) -> Size {
   // Stored properties of resilient structs from outside our resilience
   // domain are accessed through accessors
 
-// CHECK:         copy_addr %1 to [initialization] [[OTHER_SIZE_BOX:%[0-9]*]] : $*Size
+// CHECK:         copy_addr %1 to [init] [[OTHER_SIZE_BOX:%[0-9]*]] : $*Size
   var s2 = s
 
-// CHECK:         copy_addr %1 to [initialization] [[SIZE_BOX:%.*]] : $*Size
+// CHECK:         copy_addr %1 to [init] [[SIZE_BOX:%.*]] : $*Size
 // CHECK:         [[GETTER:%.*]] = function_ref @$s16resilient_struct4SizeV1wSivg : $@convention(method) (@in_guaranteed Size) -> Int
 // CHECK:         [[RESULT:%.*]] = apply [[GETTER]]([[SIZE_BOX]])
 // CHECK:         [[WRITE:%.*]] = begin_access [modify] [unknown] [[OTHER_SIZE_BOX]] : $*Size
@@ -24,7 +24,7 @@ func functionWithResilientTypes(_ s: Size, f: (Size) -> Size) -> Size {
 // CHECK:         apply [[SETTER]]([[RESULT]], [[WRITE]])
   s2.w = s.w
 
-// CHECK:         copy_addr %1 to [initialization] [[SIZE_BOX:%.*]] : $*Size
+// CHECK:         copy_addr %1 to [init] [[SIZE_BOX:%.*]] : $*Size
 // CHECK:         [[FN:%.*]] = function_ref @$s16resilient_struct4SizeV1hSivg : $@convention(method) (@in_guaranteed Size) -> Int
 // CHECK:         [[RESULT:%.*]] = apply [[FN]]([[SIZE_BOX]])
   _ = s.h
@@ -138,7 +138,7 @@ public func functionWithMyResilientTypes(_ s: MySize, f: (MySize) -> MySize) -> 
   // Stored properties of resilient structs from inside our resilience
   // domain are accessed directly
 
-// CHECK:         copy_addr %1 to [initialization] [[SIZE_BOX:%[0-9]*]] : $*MySize
+// CHECK:         copy_addr %1 to [init] [[SIZE_BOX:%[0-9]*]] : $*MySize
   var s2 = s
 
 // CHECK:         [[SRC_ADDR:%.*]] = struct_element_addr %1 : $*MySize, #MySize.w
@@ -165,7 +165,7 @@ public func functionWithMyResilientTypes(_ s: MySize, f: (MySize) -> MySize) -> 
   // other resilience domains, we have to use accessors
 
 // CHECK:         [[SELF:%.*]] = alloc_stack $MySize
-// CHECK-NEXT:    copy_addr %0 to [initialization] [[SELF]]
+// CHECK-NEXT:    copy_addr %0 to [init] [[SELF]]
 
 // CHECK:         [[GETTER:%.*]] = function_ref @$s17struct_resilience6MySizeV1wSivg
 // CHECK-NEXT:    [[RESULT:%.*]] = apply [[GETTER]]([[SELF]])
@@ -206,7 +206,7 @@ public func functionWithMyResilientTypes(_ s: MySize, f: (MySize) -> MySize) -> 
   // other resilience domains, we have to use accessors
 
 // CHECK:         [[SELF:%.*]] = alloc_stack $MySize
-// CHECK-NEXT:    copy_addr %0 to [initialization] [[SELF]]
+// CHECK-NEXT:    copy_addr %0 to [init] [[SELF]]
 
 // CHECK:         [[GETTER:%.*]] = function_ref @$s17struct_resilience6MySizeV1wSivg
 // CHECK-NEXT:    [[RESULT:%.*]] = apply [[GETTER]]([[SELF]])

--- a/test/SILGen/struct_resilience_testable.swift
+++ b/test/SILGen/struct_resilience_testable.swift
@@ -6,7 +6,7 @@
 
 // CHECK-LABEL: sil [ossa] @$s26struct_resilience_testable37takesResilientStructWithInternalFieldySi010resilient_A00eghI0VF : $@convention(thin) (@in_guaranteed ResilientWithInternalField) -> Int
 // CHECK: [[COPY:%.*]] = alloc_stack $ResilientWithInternalField
-// CHECK: copy_addr %0 to [initialization] [[COPY]] : $*ResilientWithInternalField
+// CHECK: copy_addr %0 to [init] [[COPY]] : $*ResilientWithInternalField
 // CHECK: [[FN:%.*]] = function_ref @$s16resilient_struct26ResilientWithInternalFieldV1xSivg : $@convention(method) (@in_guaranteed ResilientWithInternalField) -> Int
 // CHECK: [[RESULT:%.*]] = apply [[FN]]([[COPY]])
 // CHECK: destroy_addr [[COPY]]

--- a/test/SILGen/subclass_existentials.swift
+++ b/test/SILGen/subclass_existentials.swift
@@ -376,25 +376,25 @@ func archetypeDowncasts<S,
   // CHECK: ([[ARG0:%.*]] : $*S, [[ARG1:%.*]] : $*T, [[ARG2:%.*]] : $*PT, [[ARG3:%.*]] : @guaranteed $BaseT, [[ARG4:%.*]] : @guaranteed $BaseInt, [[ARG5:%.*]] : @guaranteed $BaseTAndP, [[ARG6:%.*]] : @guaranteed $BaseIntAndP, [[ARG7:%.*]] : @guaranteed $DerivedT, [[ARG8:%.*]] : @guaranteed $any Derived & R, [[ARG9:%.*]] : @guaranteed $any Base<T> & P, [[ARG10:%.*]] : @guaranteed $any Base<Int> & P)
 
   // CHECK:      [[COPY:%.*]] = alloc_stack $S
-  // CHECK-NEXT: copy_addr %0 to [initialization] [[COPY]] : $*S
+  // CHECK-NEXT: copy_addr %0 to [init] [[COPY]] : $*S
   // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $any Base<T> & P
   // CHECK-NEXT: checked_cast_addr_br take_always S in [[COPY]] : $*S to any Base<T> & P in [[RESULT]] : $*any Base<T> & P
   let _ = s as? (Base<T> & P)
 
   // CHECK:      [[COPY:%.*]] = alloc_stack $S
-  // CHECK-NEXT: copy_addr [[ARG0]] to [initialization] [[COPY]] : $*S
+  // CHECK-NEXT: copy_addr [[ARG0]] to [init] [[COPY]] : $*S
   // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $any Base<T> & P
   // CHECK-NEXT: unconditional_checked_cast_addr S in [[COPY]] : $*S to any Base<T> & P in [[RESULT]] : $*any Base<T> & P
   let _ = s as! (Base<T> & P)
 
   // CHECK:      [[COPY:%.*]] = alloc_stack $S
-  // CHECK-NEXT: copy_addr [[ARG0]] to [initialization] [[COPY]] : $*S
+  // CHECK-NEXT: copy_addr [[ARG0]] to [init] [[COPY]] : $*S
   // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $any Base<Int> & P
   // CHECK-NEXT: checked_cast_addr_br take_always S in [[COPY]] : $*S to any Base<Int> & P in [[RESULT]] : $*any Base<Int> & P
   let _ = s as? (Base<Int> & P)
 
   // CHECK:      [[COPY:%.*]] = alloc_stack $S
-  // CHECK-NEXT: copy_addr [[ARG0]] to [initialization] [[COPY]] : $*S
+  // CHECK-NEXT: copy_addr [[ARG0]] to [init] [[COPY]] : $*S
   // CHECK-NEXT: [[RESULT:%.*]] = alloc_stack $any Base<Int> & P
   // CHECK-NEXT: unconditional_checked_cast_addr S in [[COPY]] : $*S to any Base<Int> & P in [[RESULT]] : $*any Base<Int> & P
   let _ = s as! (Base<Int> & P)

--- a/test/SILGen/switch.swift
+++ b/test/SILGen/switch.swift
@@ -337,7 +337,7 @@ struct Z : P { func p() {} }
 // CHECK-LABEL: sil hidden [ossa] @$s6switch10test_isa_11pyAA1P_p_tF
 func test_isa_1(p: P) {
   // CHECK: [[PTMPBUF:%[0-9]+]] = alloc_stack $any P
-  // CHECK-NEXT: copy_addr %0 to [initialization] [[PTMPBUF]] : $*any P
+  // CHECK-NEXT: copy_addr %0 to [init] [[PTMPBUF]] : $*any P
   switch p {
     // CHECK: [[TMPBUF:%[0-9]+]] = alloc_stack $X
   // CHECK:   checked_cast_addr_br copy_on_success any P in [[P:%.*]] : $*any P to X in [[TMPBUF]] : $*X, [[IS_X:bb[0-9]+]], [[IS_NOT_X:bb[0-9]+]]
@@ -1125,7 +1125,7 @@ func testUninhabitedSwitchScrutinee() {
 // CHECK: [[INIT_TUP_0:%.*]] = tuple_element_addr [[MEM]] : $*(TrivialSingleCaseEnum, Any), 0
 // CHECK: [[INIT_TUP_1:%.*]] = tuple_element_addr [[MEM]] : $*(TrivialSingleCaseEnum, Any), 1
 // CHECK: store {{%.*}} to [trivial] [[INIT_TUP_0]]
-// CHECK: copy_addr [take] {{%.*}} to [initialization] [[INIT_TUP_1]]
+// CHECK: copy_addr [take] {{%.*}} to [init] [[INIT_TUP_1]]
 // CHECK: [[TUP_0:%.*]] = tuple_element_addr [[MEM]] : $*(TrivialSingleCaseEnum, Any), 0
 // CHECK: [[TUP_0_VAL:%.*]] = load [trivial] [[TUP_0]]
 // CHECK: [[TUP_1:%.*]] = tuple_element_addr [[MEM]] : $*(TrivialSingleCaseEnum, Any), 1
@@ -1146,7 +1146,7 @@ func address_only_with_trivial_subtype(_ a: TrivialSingleCaseEnum, _ value: Any)
 // CHECK: [[INIT_TUP_0:%.*]] = tuple_element_addr [[MEM]] : $*(NonTrivialSingleCaseEnum, Any), 0
 // CHECK: [[INIT_TUP_1:%.*]] = tuple_element_addr [[MEM]] : $*(NonTrivialSingleCaseEnum, Any), 1
 // CHECK: store {{%.*}} to [init] [[INIT_TUP_0]]
-// CHECK: copy_addr [take] {{%.*}} to [initialization] [[INIT_TUP_1]]
+// CHECK: copy_addr [take] {{%.*}} to [init] [[INIT_TUP_1]]
 // CHECK: [[TUP_0:%.*]] = tuple_element_addr [[MEM]] : $*(NonTrivialSingleCaseEnum, Any), 0
 // CHECK: [[TUP_0_VAL:%.*]] = load_borrow [[TUP_0]]
 // CHECK: [[TUP_1:%.*]] = tuple_element_addr [[MEM]] : $*(NonTrivialSingleCaseEnum, Any), 1
@@ -1178,12 +1178,12 @@ func address_only_with_nontrivial_subtype(_ a: NonTrivialSingleCaseEnum, _ value
 // CHECK: bb0([[ARG0:%.*]] : @guaranteed $Klass, [[ARG1:%.*]] : $*Optional<Any>):
 // CHECK:   [[ARG0_COPY:%.*]] = copy_value [[ARG0]]
 // CHECK:   [[ARG1_COPY:%.*]] = alloc_stack $Optional<Any>
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[ARG1_COPY]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[ARG1_COPY]]
 // CHECK:   [[TUP:%.*]] = alloc_stack $(Klass, Optional<Any>)
 // CHECK:   [[TUP_0:%.*]] = tuple_element_addr [[TUP]] : $*(Klass, Optional<Any>), 0
 // CHECK:   [[TUP_1:%.*]] = tuple_element_addr [[TUP]] : $*(Klass, Optional<Any>), 1
 // CHECK:   store [[ARG0_COPY]] to [init] [[TUP_0]]
-// CHECK:   copy_addr [take] [[ARG1_COPY]] to [initialization] [[TUP_1]]
+// CHECK:   copy_addr [take] [[ARG1_COPY]] to [init] [[TUP_1]]
 // CHECK:   [[TUP_0:%.*]] = tuple_element_addr [[TUP]] : $*(Klass, Optional<Any>), 0
 // CHECK:   [[TUP_0_VAL:%.*]] = load_borrow [[TUP_0]]
 // CHECK:   [[TUP_1:%.*]] = tuple_element_addr [[TUP]] : $*(Klass, Optional<Any>), 1
@@ -1210,12 +1210,12 @@ func partial_address_only_tuple_dispatch(_ name: Klass, _ value: Any?) {
 // CHECK: bb0([[ARG0:%.*]] : @guaranteed $Klass, [[ARG1:%.*]] : $*Optional<Any>):
 // CHECK:   [[ARG0_COPY:%.*]] = copy_value [[ARG0]]
 // CHECK:   [[ARG1_COPY:%.*]] = alloc_stack $Optional<Any>
-// CHECK:   copy_addr [[ARG1]] to [initialization] [[ARG1_COPY]]
+// CHECK:   copy_addr [[ARG1]] to [init] [[ARG1_COPY]]
 // CHECK:   [[TUP:%.*]] = alloc_stack $(Klass, Optional<Any>)
 // CHECK:   [[TUP_0:%.*]] = tuple_element_addr [[TUP]] : $*(Klass, Optional<Any>), 0
 // CHECK:   [[TUP_1:%.*]] = tuple_element_addr [[TUP]] : $*(Klass, Optional<Any>), 1
 // CHECK:   store [[ARG0_COPY]] to [init] [[TUP_0]]
-// CHECK:   copy_addr [take] [[ARG1_COPY]] to [initialization] [[TUP_1]]
+// CHECK:   copy_addr [take] [[ARG1_COPY]] to [init] [[TUP_1]]
 // CHECK:   [[TUP_0:%.*]] = tuple_element_addr [[TUP]] : $*(Klass, Optional<Any>), 0
 // CHECK:   [[TUP_0_VAL:%.*]] = load_borrow [[TUP_0]]
 // CHECK:   [[TUP_1:%.*]] = tuple_element_addr [[TUP]] : $*(Klass, Optional<Any>), 1
@@ -1235,7 +1235,7 @@ func partial_address_only_tuple_dispatch(_ name: Klass, _ value: Any?) {
 //
 // CHECK: [[HAS_TUP_1_BB]]:
 // CHECK-NEXT: [[OPT_ANY_ADDR:%.*]] = alloc_stack $Optional<Any>
-// CHECK-NEXT: copy_addr [[TUP_1]] to [initialization] [[OPT_ANY_ADDR]]
+// CHECK-NEXT: copy_addr [[TUP_1]] to [init] [[OPT_ANY_ADDR]]
 // CHECK-NEXT: [[SOME_ANY_ADDR:%.*]] = unchecked_take_enum_data_addr [[OPT_ANY_ADDR]]
 // CHECK-NEXT: [[ANYOBJECT_ADDR:%.*]] = alloc_stack $AnyObject
 // CHECK-NEXT: checked_cast_addr_br copy_on_success Any in {{%.*}} : $*Any to AnyObject in {{%.*}} : $*AnyObject, [[IS_ANY_BB:bb[0-9]+]], [[ISNOT_ANY_BB:bb[0-9]+]]
@@ -1335,54 +1335,54 @@ func testVoidType() {
 // CHECK:   [[ABB_PHI:%.*]] = alloc_stack $T, let, name "x"
 // CHECK:   [[ABBC_PHI:%.*]] = alloc_stack $T, let, name "x"
 // CHECK:   [[SWITCH_ENUM_ARG:%.*]] = alloc_stack $MultipleAddressOnlyCaseEnum<T>
-// CHECK:   copy_addr [[ARG]] to [initialization] [[SWITCH_ENUM_ARG]]
+// CHECK:   copy_addr [[ARG]] to [init] [[SWITCH_ENUM_ARG]]
 // CHECK:   switch_enum_addr [[SWITCH_ENUM_ARG]] : $*MultipleAddressOnlyCaseEnum<T>, case #MultipleAddressOnlyCaseEnum.a!enumelt: [[BB_A:bb[0-9]+]], case #MultipleAddressOnlyCaseEnum.b!enumelt: [[BB_B:bb[0-9]+]], case #MultipleAddressOnlyCaseEnum.c!enumelt: [[BB_C:bb[0-9]+]]
 //
 // CHECK: [[BB_A]]:
 // CHECK:   [[SWITCH_ENUM_ARG_PROJ:%.*]] = unchecked_take_enum_data_addr [[SWITCH_ENUM_ARG]]
 // CHECK:   [[CASE_BODY_VAR_A:%.*]] = alloc_stack [lexical] $T, let, name "x"
-// CHECK:   copy_addr [take] [[SWITCH_ENUM_ARG_PROJ]] to [initialization] [[CASE_BODY_VAR_A]]
-// CHECK:   copy_addr [[CASE_BODY_VAR_A]] to [initialization] [[AB_PHI]]
+// CHECK:   copy_addr [take] [[SWITCH_ENUM_ARG_PROJ]] to [init] [[CASE_BODY_VAR_A]]
+// CHECK:   copy_addr [[CASE_BODY_VAR_A]] to [init] [[AB_PHI]]
 // CHECK:   destroy_addr [[CASE_BODY_VAR_A]]
 // CHECK:   br [[BB_AB:bb[0-9]+]]
 //
 // CHECK: [[BB_B]]:
 // CHECK:   [[SWITCH_ENUM_ARG_PROJ:%.*]] = unchecked_take_enum_data_addr [[SWITCH_ENUM_ARG]]
 // CHECK:   [[CASE_BODY_VAR_B:%.*]] = alloc_stack [lexical] $T, let, name "x"
-// CHECK:   copy_addr [[SWITCH_ENUM_ARG_PROJ]] to [initialization] [[CASE_BODY_VAR_B]]
+// CHECK:   copy_addr [[SWITCH_ENUM_ARG_PROJ]] to [init] [[CASE_BODY_VAR_B]]
 // CHECK:   [[FUNC_CMP:%.*]] = function_ref @$sSzsE2eeoiySbx_qd__tSzRd__lFZ :
 // CHECK:   [[GUARD_RESULT:%.*]] = apply [[FUNC_CMP]]<T, Int>([[CASE_BODY_VAR_B]], {{%.*}}, {{%.*}})
 // CHECK:   [[GUARD_RESULT_EXT:%.*]] = struct_extract [[GUARD_RESULT]]
 // CHECK:   cond_br [[GUARD_RESULT_EXT]], [[BB_B_GUARD_SUCC:bb[0-9]+]], [[BB_B_GUARD_FAIL:bb[0-9]+]]
 //
 // CHECK: [[BB_B_GUARD_SUCC]]:
-// CHECK:   copy_addr [[CASE_BODY_VAR_B]] to [initialization] [[AB_PHI]]
+// CHECK:   copy_addr [[CASE_BODY_VAR_B]] to [init] [[AB_PHI]]
 // CHECK:   destroy_addr [[CASE_BODY_VAR_B]]
 // CHECK:   destroy_addr [[SWITCH_ENUM_ARG_PROJ]]
 // CHECK:   br [[BB_AB]]
 //
 // CHECK: [[BB_AB]]:
-// CHECK:   copy_addr [[AB_PHI]] to [initialization] [[ABB_PHI]]
+// CHECK:   copy_addr [[AB_PHI]] to [init] [[ABB_PHI]]
 // CHECK:   destroy_addr [[AB_PHI]]
 // CHECK:   br [[BB_AB_CONT:bb[0-9]+]]
 //
 // CHECK: [[BB_AB_CONT]]:
-// CHECK:   copy_addr [[ABB_PHI]] to [initialization] [[ABBC_PHI]]
+// CHECK:   copy_addr [[ABB_PHI]] to [init] [[ABBC_PHI]]
 // CHECK:   destroy_addr [[ABB_PHI]]
 // CHECK:   br [[BB_FINAL_CONT:bb[0-9]+]]
 //
 // CHECK: [[BB_B_GUARD_FAIL]]:
 // CHECK:   destroy_addr [[CASE_BODY_VAR_B]]
 // CHECK:   [[CASE_BODY_VAR_B_2:%.*]] = alloc_stack [lexical] $T, let, name "x"
-// CHECK:   copy_addr [take] [[SWITCH_ENUM_ARG_PROJ]] to [initialization] [[CASE_BODY_VAR_B_2]]
-// CHECK:   copy_addr [[CASE_BODY_VAR_B_2]] to [initialization] [[ABB_PHI]]
+// CHECK:   copy_addr [take] [[SWITCH_ENUM_ARG_PROJ]] to [init] [[CASE_BODY_VAR_B_2]]
+// CHECK:   copy_addr [[CASE_BODY_VAR_B_2]] to [init] [[ABB_PHI]]
 // CHECK:   br [[BB_AB_CONT]]
 //
 // CHECK: [[BB_C]]:
 // CHECK:   [[SWITCH_ENUM_ARG_PROJ:%.*]] = unchecked_take_enum_data_addr [[SWITCH_ENUM_ARG]]
 // CHECK:   [[CASE_BODY_VAR_C:%.*]] = alloc_stack [lexical] $T, let, name "x"
-// CHECK:   copy_addr [take] [[SWITCH_ENUM_ARG_PROJ]] to [initialization] [[CASE_BODY_VAR_C]]
-// CHECK:   copy_addr [[CASE_BODY_VAR_C]] to [initialization] [[ABBC_PHI]]
+// CHECK:   copy_addr [take] [[SWITCH_ENUM_ARG_PROJ]] to [init] [[CASE_BODY_VAR_C]]
+// CHECK:   copy_addr [[CASE_BODY_VAR_C]] to [init] [[ABBC_PHI]]
 // CHECK:   destroy_addr [[CASE_BODY_VAR_C]]
 // CHECK:   br [[BB_FINAL_CONT]]
 //

--- a/test/SILGen/switch_default.swift
+++ b/test/SILGen/switch_default.swift
@@ -11,12 +11,12 @@ enum Enum {
 // CHECK-LABEL: sil hidden [ossa] @$s14switch_default33testAddressOnlySubjectDefaultCaseyyAA4EnumOSgF : $@convention(thin) (@in_guaranteed Optional<Enum>) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[STACK:%.*]] = alloc_stack $Optional<Enum>
-// CHECK:   copy_addr [[ARG]] to [initialization] [[STACK]]
+// CHECK:   copy_addr [[ARG]] to [init] [[STACK]]
 // CHECK:   switch_enum_addr [[STACK]] : $*Optional<Enum>, case #Optional.some!enumelt: [[SOME_BB:bb[0-9]*]], default [[DEFAULT_BB:bb[0-9]*]]
 //
 // CHECK: [[SOME_BB]]:
 // CHECK:    [[STACK_1:%.*]] = alloc_stack $Optional<Enum>
-// CHECK:    copy_addr [[STACK]] to [initialization] [[STACK_1]]
+// CHECK:    copy_addr [[STACK]] to [init] [[STACK_1]]
 // CHECK:    [[TAKEN_ADDR:%.*]] = unchecked_take_enum_data_addr [[STACK_1]]
 // CHECK:    switch_enum_addr [[TAKEN_ADDR]] : $*Enum, case #Enum.value2!enumelt: [[VALUE2_BB:bb[0-9]*]], default [[DEFAULT_BB_2:bb[0-9]*]]
 //

--- a/test/SILGen/switch_isa.swift
+++ b/test/SILGen/switch_isa.swift
@@ -14,7 +14,7 @@ func testSwitchOnExistential(_ value: Any) {
 
 // CHECK-LABEL: sil hidden [ossa] @$s10switch_isa23testSwitchOnExistentialyyypF :
 // CHECK:   [[ANY:%.*]] = alloc_stack $Any
-// CHECK:   copy_addr %0 to [initialization] [[ANY]]
+// CHECK:   copy_addr %0 to [init] [[ANY]]
 // CHECK:   [[BOOL:%.*]] = alloc_stack $Bool
 // CHECK:   checked_cast_addr_br copy_on_success Any in [[ANY]] : $*Any to Bool in [[BOOL]] : $*Bool, [[IS_BOOL:bb[0-9]+]], [[IS_NOT_BOOL:bb[0-9]+]]
 // CHECK: [[IS_BOOL]]:

--- a/test/SILGen/switch_multiple_entry_address_only.swift
+++ b/test/SILGen/switch_multiple_entry_address_only.swift
@@ -15,14 +15,14 @@ func multipleLabelsLet(e: E) {
   // CHECK:      bb0
   // CHECK:      [[X_PHI:%.*]] = alloc_stack $Any
   // CHECK-NEXT: [[E_COPY:%.*]] = alloc_stack $E
-  // CHECK-NEXT: copy_addr %0 to [initialization] [[E_COPY]]
+  // CHECK-NEXT: copy_addr %0 to [init] [[E_COPY]]
   // CHECK-NEXT: switch_enum_addr [[E_COPY]] : $*E, case #E.a!enumelt: bb1, case #E.b!enumelt: bb2, default bb4
 
   // CHECK:      bb1:
   // CHECK-NEXT: [[E_PAYLOAD:%.*]] = unchecked_take_enum_data_addr [[E_COPY]] : $*E, #E.a!enumelt
   // CHECK-NEXT: [[ANY_BOX:%.*]] = alloc_stack [lexical] $Any
-  // CHECK-NEXT: copy_addr [take] [[E_PAYLOAD]] to [initialization] [[ANY_BOX]]
-  // CHECK-NEXT: copy_addr [[ANY_BOX]] to [initialization] [[X_PHI]]
+  // CHECK-NEXT: copy_addr [take] [[E_PAYLOAD]] to [init] [[ANY_BOX]]
+  // CHECK-NEXT: copy_addr [[ANY_BOX]] to [init] [[X_PHI]]
   // CHECK-NEXT: destroy_addr [[ANY_BOX]]
   // CHECK-NEXT: dealloc_stack [[ANY_BOX]]
   // CHECK-NEXT: dealloc_stack [[E_COPY]]
@@ -31,8 +31,8 @@ func multipleLabelsLet(e: E) {
   // CHECK:      bb2:
   // CHECK-NEXT: [[E_PAYLOAD:%.*]] = unchecked_take_enum_data_addr [[E_COPY]] : $*E, #E.b!enumelt
   // CHECK-NEXT: [[ANY_BOX:%.*]] = alloc_stack [lexical] $Any
-  // CHECK-NEXT: copy_addr [take] [[E_PAYLOAD]] to [initialization] [[ANY_BOX]]
-  // CHECK-NEXT: copy_addr [[ANY_BOX]] to [initialization] [[X_PHI]]
+  // CHECK-NEXT: copy_addr [take] [[E_PAYLOAD]] to [init] [[ANY_BOX]]
+  // CHECK-NEXT: copy_addr [[ANY_BOX]] to [init] [[X_PHI]]
   // CHECK-NEXT: destroy_addr [[ANY_BOX]]
   // CHECK-NEXT: dealloc_stack [[ANY_BOX]]
   // CHECK-NEXT: dealloc_stack [[E_COPY]]
@@ -67,14 +67,14 @@ func multipleLabelsVar(e: E) {
   // CHECK:      bb0
   // CHECK:      [[X_PHI:%.*]] = alloc_stack $Any
   // CHECK-NEXT: [[E_COPY:%.*]] = alloc_stack $E
-  // CHECK-NEXT: copy_addr %0 to [initialization] [[E_COPY]]
+  // CHECK-NEXT: copy_addr %0 to [init] [[E_COPY]]
   // CHECK-NEXT: switch_enum_addr [[E_COPY]] : $*E, case #E.a!enumelt: bb1, case #E.b!enumelt: bb2, default bb4
 
   // CHECK:      bb1:
   // CHECK-NEXT: [[E_PAYLOAD:%.*]] = unchecked_take_enum_data_addr [[E_COPY]] : $*E, #E.a!enumelt
   // CHECK-NEXT: [[ANY_BOX:%.*]] = alloc_stack [lexical] $Any
-  // CHECK-NEXT: copy_addr [take] [[E_PAYLOAD]] to [initialization] [[ANY_BOX]]
-  // CHECK-NEXT: copy_addr [[ANY_BOX]] to [initialization] [[X_PHI]]
+  // CHECK-NEXT: copy_addr [take] [[E_PAYLOAD]] to [init] [[ANY_BOX]]
+  // CHECK-NEXT: copy_addr [[ANY_BOX]] to [init] [[X_PHI]]
   // CHECK-NEXT: destroy_addr [[ANY_BOX]]
   // CHECK-NEXT: dealloc_stack [[ANY_BOX]]
   // CHECK-NEXT: dealloc_stack [[E_COPY]]
@@ -83,8 +83,8 @@ func multipleLabelsVar(e: E) {
   // CHECK:      bb2:
   // CHECK-NEXT: [[E_PAYLOAD:%.*]] = unchecked_take_enum_data_addr [[E_COPY]] : $*E, #E.b!enumelt
   // CHECK-NEXT: [[ANY_BOX:%.*]] = alloc_stack [lexical] $Any
-  // CHECK-NEXT: copy_addr [take] [[E_PAYLOAD]] to [initialization] [[ANY_BOX]]
-  // CHECK-NEXT: copy_addr [[ANY_BOX]] to [initialization] [[X_PHI]]
+  // CHECK-NEXT: copy_addr [take] [[E_PAYLOAD]] to [init] [[ANY_BOX]]
+  // CHECK-NEXT: copy_addr [[ANY_BOX]] to [init] [[X_PHI]]
   // CHECK-NEXT: destroy_addr [[ANY_BOX]]
   // CHECK-NEXT: dealloc_stack [[ANY_BOX]]
   // CHECK-NEXT: dealloc_stack [[E_COPY]]
@@ -95,10 +95,10 @@ func multipleLabelsVar(e: E) {
   // CHECK-NEXT: [[ANY_BOX:%.*]] = alloc_box ${ var Any }, var, name "x"
   // CHECK-NEXT: [[ANY_BOX_LIFETIME:%[^,]+]] = begin_borrow [lexical] [[ANY_BOX]]
   // CHECK-NEXT: [[BOX_PAYLOAD:%.*]] = project_box [[ANY_BOX_LIFETIME]] : ${ var Any }, 0
-  // CHECK-NEXT: copy_addr [take] [[X_PHI]] to [initialization] [[BOX_PAYLOAD]]
+  // CHECK-NEXT: copy_addr [take] [[X_PHI]] to [init] [[BOX_PAYLOAD]]
   // CHECK-NEXT: [[ACCESS:%.*]] = begin_access [read] [unknown] [[BOX_PAYLOAD]]
   // CHECK-NEXT: [[ANY_STACK:%.*]] = alloc_stack $Any
-  // CHECK-NEXT: copy_addr [[ACCESS]] to [initialization] [[ANY_STACK]]
+  // CHECK-NEXT: copy_addr [[ACCESS]] to [init] [[ANY_STACK]]
   // CHECK-NEXT: end_access [[ACCESS]]
   // CHECK:      [[FN:%.*]] = function_ref @$s34switch_multiple_entry_address_only8takesAnyyyypF
   // CHECK-NEXT: apply [[FN]]([[ANY_STACK]]
@@ -131,16 +131,16 @@ func fallthroughWithValue(e: E) {
   // CHECK:      bb0
   // CHECK:      [[X_PHI:%.*]] = alloc_stack $Any
   // CHECK-NEXT: [[E_COPY:%.*]] = alloc_stack $E
-  // CHECK-NEXT: copy_addr %0 to [initialization] [[E_COPY]]
+  // CHECK-NEXT: copy_addr %0 to [init] [[E_COPY]]
   // CHECK-NEXT: switch_enum_addr [[E_COPY]] : $*E, case #E.a!enumelt: bb1, case #E.b!enumelt: bb2, default bb4
   
   // CHECK:      bb1:
   // CHECK-NEXT: [[E_PAYLOAD:%.*]] = unchecked_take_enum_data_addr [[E_COPY]] : $*E, #E.a!enumelt
   // CHECK-NEXT: [[ORIGINAL_ANY_BOX:%.*]] = alloc_stack [lexical] $Any
-  // CHECK-NEXT: copy_addr [take] [[E_PAYLOAD]] to [initialization] [[ORIGINAL_ANY_BOX]]
+  // CHECK-NEXT: copy_addr [take] [[E_PAYLOAD]] to [init] [[ORIGINAL_ANY_BOX]]
   // CHECK:      [[FN1:%.*]] = function_ref @$s34switch_multiple_entry_address_only8takesAnyyyypF
   // CHECK-NEXT: apply [[FN1]]([[ORIGINAL_ANY_BOX]]
-  // CHECK-NEXT: copy_addr [[ORIGINAL_ANY_BOX]] to [initialization] [[X_PHI]]
+  // CHECK-NEXT: copy_addr [[ORIGINAL_ANY_BOX]] to [init] [[X_PHI]]
   // CHECK-NEXT: destroy_addr [[ORIGINAL_ANY_BOX]]
   // CHECK-NEXT: dealloc_stack [[ORIGINAL_ANY_BOX]]
   // CHECK-NEXT: dealloc_stack [[E_COPY]]
@@ -149,8 +149,8 @@ func fallthroughWithValue(e: E) {
   // CHECK:      bb2:
   // CHECK-NEXT: [[E_PAYLOAD:%.*]] = unchecked_take_enum_data_addr [[E_COPY]] : $*E, #E.b!enumelt
   // CHECK-NEXT: [[ANY_BOX:%.*]] = alloc_stack [lexical] $Any
-  // CHECK-NEXT: copy_addr [take] [[E_PAYLOAD]] to [initialization] [[ANY_BOX]]
-  // CHECK-NEXT: copy_addr [[ANY_BOX]] to [initialization] [[X_PHI]]
+  // CHECK-NEXT: copy_addr [take] [[E_PAYLOAD]] to [init] [[ANY_BOX]]
+  // CHECK-NEXT: copy_addr [[ANY_BOX]] to [init] [[X_PHI]]
   // CHECK-NEXT: destroy_addr [[ANY_BOX]]
   // CHECK-NEXT: dealloc_stack [[ANY_BOX]]
   // CHECK-NEXT: dealloc_stack [[E_COPY]]

--- a/test/SILGen/switch_resilience.swift
+++ b/test/SILGen/switch_resilience.swift
@@ -11,7 +11,7 @@ import resilient_struct
 // CHECK: bb1:
 // CHECK:   [[VALUE:%.*]] = unchecked_take_enum_data_addr [[STACK_SLOT]] : $*Enum
 // CHECK:   [[STACK_SLOT_COPY:%.*]] = alloc_stack [lexical] $(url: ResilientRef, void: ()), let, name "value"
-// CHECK:   copy_addr [[VALUE]] to [initialization] [[STACK_SLOT_COPY]]
+// CHECK:   copy_addr [[VALUE]] to [init] [[STACK_SLOT_COPY]]
 // CHECK:   cond_br {{%.*}}, bb2, bb3
 //
 // CHECK: bb2:

--- a/test/SILGen/ternary_expr.swift
+++ b/test/SILGen/ternary_expr.swift
@@ -44,11 +44,11 @@ func addr_only_ternary_1(x: Bool) -> AddressOnly {
   // CHECK:   cond_br {{%.*}}, [[TRUE:bb[0-9]+]], [[FALSE:bb[0-9]+]]
   // CHECK: [[TRUE]]:
   // CHECK:   [[READa:%.*]] = begin_access [read] [unknown] [[PBa]]
-  // CHECK:   copy_addr [[READa]] to [initialization] [[RET]]
+  // CHECK:   copy_addr [[READa]] to [init] [[RET]]
   // CHECK:   br [[CONT:bb[0-9]+]]
   // CHECK: [[FALSE]]:
   // CHECK:   [[READb:%.*]] = begin_access [read] [unknown] [[PBb]]
-  // CHECK:   copy_addr [[READb]] to [initialization] [[RET]]
+  // CHECK:   copy_addr [[READb]] to [init] [[RET]]
   // CHECK:   br [[CONT]]
   return x ? a : b
 }

--- a/test/SILGen/tuples.swift
+++ b/test/SILGen/tuples.swift
@@ -33,7 +33,7 @@ func testShuffleOpaque() {
 
   // CHECK:      [[T0:%.*]] = function_ref @$s6tuples7make_xySi1x_AA1P_p1ytyF
   // CHECK-NEXT: [[T1:%.*]] = apply [[T0]]([[TMP]])
-  // CHECK-NEXT: copy_addr [take] [[TMP]] to [initialization] [[PBX]] : $*any P
+  // CHECK-NEXT: copy_addr [take] [[TMP]] to [init] [[PBX]] : $*any P
   // CHECK-NEXT: store [[T1]] to [trivial] [[PBY]]
   // CHECK-NEXT: dealloc_stack [[TMP]]
   var (x,y) : (y:P, x:Int) = make_xy()
@@ -47,7 +47,7 @@ func testShuffleOpaque() {
   // CHECK-NEXT: [[T1:%.*]] = apply [[T0]]([[TMP]])
   // CHECK-NEXT: [[PAIR_0:%.*]] = tuple_element_addr [[PBPAIR]] : $*(y: any P, x: Int), 0
   // CHECK-NEXT: [[PAIR_1:%.*]] = tuple_element_addr [[PBPAIR]] : $*(y: any P, x: Int), 1
-  // CHECK-NEXT: copy_addr [take] [[TMP]] to [initialization] [[PAIR_0]] : $*any P
+  // CHECK-NEXT: copy_addr [take] [[TMP]] to [init] [[PAIR_0]] : $*any P
   // CHECK-NEXT: store [[T1]] to [trivial] [[PAIR_1]]
   // CHECK-NEXT: dealloc_stack [[TMP]]
   var pair : (y:P, x:Int) = make_xy()
@@ -80,7 +80,7 @@ func testShuffleTuple() {
   // CHECK-NEXT: // function_ref
   // CHECK-NEXT: [[T0:%.*]] = function_ref @$s6tuples6make_pAA1P_pyF 
   // CHECK-NEXT: apply [[T0]]([[TMP]])
-  // CHECK-NEXT: copy_addr [take] [[TMP]] to [initialization] [[PBX]]
+  // CHECK-NEXT: copy_addr [take] [[TMP]] to [init] [[PBX]]
   // CHECK-NEXT: store [[T1]] to [trivial] [[PBY]]
   // CHECK-NEXT: dealloc_stack [[TMP]]
   var (x,y) : (y:P, x:Int) = (x: make_int(), y: make_p())
@@ -97,7 +97,7 @@ func testShuffleTuple() {
   // CHECK-NEXT: apply [[T0]]([[TMP]])
   // CHECK-NEXT: [[PAIR_0:%.*]] = tuple_element_addr [[PBPAIR]] : $*(y: any P, x: Int), 0
   // CHECK-NEXT: [[PAIR_1:%.*]] = tuple_element_addr [[PBPAIR]] : $*(y: any P, x: Int), 1
-  // CHECK-NEXT: copy_addr [take] [[TMP]] to [initialization] [[PBX]]
+  // CHECK-NEXT: copy_addr [take] [[TMP]] to [init] [[PBX]]
   // CHECK-NEXT: store [[T1]] to [trivial] [[PAIR_1]]
   // CHECK-NEXT: dealloc_stack [[TMP]]
   var pair : (y:P, x:Int) = (x: make_int(), y: make_p())
@@ -155,7 +155,7 @@ extension P {
   // CHECK:   [[TUP0_COPY:%.*]] = copy_value [[TUP0]]
   // CHECK:   store [[TUP0_COPY]] to [init] [[ZERO_ADDR]]
   // CHECK:   [[ONE_ADDR:%.*]] = tuple_element_addr [[RVALUE]] : $*(index: C, value: Self), 1
-  // CHECK:   copy_addr [[TUP1]] to [initialization] [[ONE_ADDR]]
+  // CHECK:   copy_addr [[TUP1]] to [init] [[ONE_ADDR]]
   //
   // What we are actually trying to check. Note that there is no actual use of
   // LOADED_CLASS. This is b/c of the nature of the RValue we are working with.

--- a/test/SILGen/vtable_thunks.swift
+++ b/test/SILGen/vtable_thunks.swift
@@ -163,12 +163,12 @@ class H: G {
 // CHECK-LABEL: sil private [thunk] [ossa] @$s13vtable_thunks1DC1g{{[_0-9a-zA-Z]*}}FTV
 // TODO: extra copies here
 // CHECK:         [[WRAPPED_X_ADDR:%.*]] = init_enum_data_addr [[WRAP_X_ADDR:%.*]] :
-// CHECK:         copy_addr [take] {{%.*}} to [initialization] [[WRAPPED_X_ADDR]]
+// CHECK:         copy_addr [take] {{%.*}} to [init] [[WRAPPED_X_ADDR]]
 // CHECK:         inject_enum_addr [[WRAP_X_ADDR]]
 // CHECK:         [[RES_ADDR:%.*]] = alloc_stack
 // CHECK:         apply {{%.*}}([[RES_ADDR]], [[WRAP_X_ADDR]], %2, %3)
 // CHECK:         [[DEST_ADDR:%.*]] = init_enum_data_addr %0
-// CHECK:         copy_addr [take] [[RES_ADDR]] to [initialization] [[DEST_ADDR]]
+// CHECK:         copy_addr [take] [[RES_ADDR]] to [init] [[DEST_ADDR]]
 // CHECK:         inject_enum_addr %0
 
 class ThrowVariance {

--- a/test/SILGen/weak.swift
+++ b/test/SILGen/weak.swift
@@ -34,7 +34,7 @@ func test0(c c: C) {
 // CHECK-NEXT: [[TMP:%.*]] = load [copy] [[READ]] : $*C
 // CHECK-NEXT: end_access [[READ]]
 // CHECK-NEXT: [[OPTVAL:%.*]] = enum $Optional<C>, #Optional.some!enumelt, [[TMP]] : $C
-// CHECK-NEXT: store_weak [[OPTVAL]] to [initialization] [[PBX]] : $*@sil_weak Optional<C>
+// CHECK-NEXT: store_weak [[OPTVAL]] to [init] [[PBX]] : $*@sil_weak Optional<C>
 // CHECK-NEXT: destroy_value [[OPTVAL]] : $Optional<C>
 
   a.x = c

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -272,7 +272,7 @@ func testInitLValue(p: HasIntGetter) -> Int {
 // CHECK:   [[OPENED:%.*]] = open_existential_addr immutable_access %0
 // CHECK:   [[X:%.*]] = alloc_stack $@opened
 // CHECK-NOT: begin_access
-// CHECK:   copy_addr %{{.*}} to [initialization] [[X]] : $*@opened
+// CHECK:   copy_addr %{{.*}} to [init] [[X]] : $*@opened
 // CHECK:   witness_method $@opened
 // CHECK:   apply %{{.*}}<@opened("{{.*}}", any HasIntGetter) Self>([[X]]) : $@convention(witness_method: HasIntGetter) <τ_0_0 where τ_0_0 : HasIntGetter> (@in_guaranteed τ_0_0) -> Int
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unsafe] [[PROJ]] : $*Int
@@ -334,11 +334,11 @@ func testInitGenericEnum<T>(t: T) -> GenericEnum<T>? {
 // CHECK:   [[PROJ:%.*]] = project_box
 // CHECK:   [[ADR1:%.*]] = alloc_stack $T
 // CHECK-NOT: begin_access
-// CHECK:   copy_addr %1 to [initialization] [[ADR1]] : $*T
+// CHECK:   copy_addr %1 to [init] [[ADR1]] : $*T
 // CHECK:   [[STK:%.*]] = alloc_stack $GenericEnum<T>
 // CHECK:   [[ENUMDATAADDR:%.*]] = init_enum_data_addr [[STK]]
 // CHECK:   [[ACCESSENUM:%.*]] = begin_access [modify] [unsafe] [[ENUMDATAADDR]] : $*T
-// CHECK:   copy_addr [take] [[ADR1]] to [initialization] [[ACCESSENUM]] : $*T
+// CHECK:   copy_addr [take] [[ADR1]] to [init] [[ACCESSENUM]] : $*T
 // CHECK:   end_access [[ACCESSENUM]] : $*T
 // CHECK:   inject_enum_addr
 // CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJ]]
@@ -346,7 +346,7 @@ func testInitGenericEnum<T>(t: T) -> GenericEnum<T>? {
 // CHECK:   end_access [[ACCESS]] : $*GenericEnum<T>
 // CHECK:   [[ADR2:%.*]] = init_enum_data_addr %0
 // CHECK-NOT: begin_access
-// CHECK:   copy_addr %{{.*}} to [initialization] [[ADR2]] : $*GenericEnum<T>
+// CHECK:   copy_addr %{{.*}} to [init] [[ADR2]] : $*GenericEnum<T>
 // CHECK:   inject_enum_addr %0 : $*Optional<GenericEnum<T>>, #Optional.some!enumelt
 // CHECK-LABEL: } // end sil function '$s20access_marker_verify11GenericEnumO1tACyxGSgx_tcfC'
 
@@ -566,7 +566,7 @@ enum OptionalWithMap<Wrapped> {
 // CHECK-LABEL: sil hidden [ossa] @$s20access_marker_verify15OptionalWithMapO3mapyqd__Sgqd__xKXEKlF : $@convention(method) <Wrapped><U> (@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0) -> (@out τ_0_1, @error any Error) for <Wrapped, U>, @in_guaranteed OptionalWithMap<Wrapped>) -> (@out Optional<U>, @error any Error)
 // CHECK: [[STK:%.]] = alloc_stack $OptionalWithMap<Wrapped>
 // CHECK-NOT: begin_access
-// CHECK: copy_addr %2 to [initialization] [[STK]] : $*OptionalWithMap<Wrapped>
+// CHECK: copy_addr %2 to [init] [[STK]] : $*OptionalWithMap<Wrapped>
 // CHECK: switch_enum_addr [[STK]] : $*OptionalWithMap<Wrapped>, case #OptionalWithMap.some!enumelt: [[BBSOME:bb.*]], case #OptionalWithMap.none!enumelt: bb
 //
 // CHECK: [[BBSOME]]:
@@ -574,7 +574,7 @@ enum OptionalWithMap<Wrapped> {
 // CHECK: [[ADR:%.*]] = unchecked_take_enum_data_addr [[STK]]
 // CHECK: alloc_stack [lexical] $Wrapped, let, name "y"
 // CHECK-NOT: begin_access
-// CHECK: copy_addr [take] [[ADR]] to [initialization]
+// CHECK: copy_addr [take] [[ADR]] to [init]
 // ----- call transform.
 // CHECK: try_apply
 // CHECK-LABEL: } // end sil function '$s20access_marker_verify15OptionalWithMapO3mapyqd__Sgqd__xKXEKlF'
@@ -649,7 +649,7 @@ var globalString2 = globalString1
 // CHECK: [[PTR:%.*]] = pointer_to_address
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[PTR]] : $*String
 // CHECK: [[INIT:%.*]] = begin_access [modify] [unsafe] [[GA]] : $*String
-// CHECK: copy_addr [[ACCESS]] to [initialization] [[INIT]] : $*String
+// CHECK: copy_addr [[ACCESS]] to [init] [[INIT]] : $*String
 // CHECK: end_access [[INIT]] : $*String
 // CHECK: end_access [[ACCESS]] : $*String
 // CHECK-NOT: end_access
@@ -871,13 +871,13 @@ func testMixedTuple(p: HasClassGetter) -> (BaseClass, Any) {
 // CHECK: [[P1:%.*]] = open_existential_addr immutable_access %1 : $*any HasClassGetter to $*@opened
 // CHECK: [[TEMP1:%.*]] = alloc_stack $@opened
 // CHECK-NOT: begin_access
-// CHECK: copy_addr [[P1]] to [initialization] [[TEMP1]] : $*@opened
+// CHECK: copy_addr [[P1]] to [init] [[TEMP1]] : $*@opened
 // CHECK-NOT: begin_access
 // CHECK: [[OUTC:%.*]] = apply {{.*}} $@convention(witness_method: HasClassGetter) <τ_0_0 where τ_0_0 : HasClassGetter> (@in_guaranteed τ_0_0) -> @owned BaseClass
 // CHECK: [[P2:%.*]] = open_existential_addr immutable_access %1 : $*any HasClassGetter to $*@opened
 // CHECK: [[TEMP2:%.*]] = alloc_stack $@opened
 // CHECK-NOT: begin_access
-// CHECK: copy_addr [[P2]] to [initialization] [[TEMP2]] : $*@opened
+// CHECK: copy_addr [[P2]] to [init] [[TEMP2]] : $*@opened
 // CHECK-NOT: begin_access
 // CHECK: apply {{.*}} $@convention(witness_method: HasClassGetter) <τ_0_0 where τ_0_0 : HasClassGetter> (@in_guaranteed τ_0_0) -> @owned BaseClass
 // CHECK: [[OUTANY:%.*]] = init_existential_addr %0 : $*Any, $BaseClass
@@ -904,7 +904,7 @@ internal struct CanCastStruct<Base : Hashable> : CanCast {
 // CHECK: [[TEMP_BASE:%.*]] = alloc_stack $any CanCast
 // CHECK: [[TEMP_BASE_ADR:%.*]] = init_existential_addr [[TEMP_BASE]] : $*any CanCast, $CanCastStruct<Base>
 // CHECK-NOT: begin_access
-// CHECK: copy_addr %1 to [initialization] [[TEMP_BASE_ADR]] : $*CanCastStruct<Base>
+// CHECK: copy_addr %1 to [init] [[TEMP_BASE_ADR]] : $*CanCastStruct<Base>
 // CHECK-NOT: begin_access
 // CHECK: [[TEMP_SUB_ADR:%.*]] = init_enum_data_addr [[TEMP_SUB]] : $*Optional<CanCastStruct<T>>, #Optional.some!enumelt
 // CHECK-NOT: begin_access
@@ -913,7 +913,7 @@ internal struct CanCastStruct<Base : Hashable> : CanCast {
 // CHECK: [[TEMP_DATA:%.*]] = unchecked_take_enum_data_addr [[TEMP_SUB]] : $*Optional<CanCastStruct<T>>, #Optional.some!enumelt
 // CHECK-NOT: begin_access
 // CHECK: [[BASE_ADR:%.*]] = struct_element_addr [[TEMP_DATA]] : $*CanCastStruct<T>, #CanCastStruct.base
-// CHECK: copy_addr [[BASE_ADR]] to [initialization] [[OUT_ENUM]] : $*T
+// CHECK: copy_addr [[BASE_ADR]] to [init] [[OUT_ENUM]] : $*T
 // CHECK-NOT: begin_access
 // CHECK: inject_enum_addr %0 : $*Optional<T>, #Optional.some!enumelt
 // CHECK-LABEL: } // end sil function '$s20access_marker_verify13CanCastStructV5unboxqd__SgySHRd__lF'
@@ -932,7 +932,7 @@ func testOpenExistential(p: PBar) {
 // CHECK: [[Q0:%.*]] = alloc_stack [lexical] $Optional<any Q>, let, name "q0"
 // CHECK: [[PBAR:%.*]] = alloc_stack $any PBar
 // CHECK-NOT: begin_access
-// CHECK: copy_addr %0 to [initialization] [[PBAR]] : $*any PBar
+// CHECK: copy_addr %0 to [init] [[PBAR]] : $*any PBar
 // CHECK-NOT: begin_access
 // CHECK: [[Q0_DATA:%.*]] = init_enum_data_addr [[Q0]] : $*Optional<any Q>, #Optional.some!enumelt
 // CHECK-NOT: begin_access
@@ -944,13 +944,13 @@ func testOpenExistential(p: PBar) {
 // CHECK: [[Q:%.*]] = alloc_stack [lexical] $any Q, let, name "q"
 // CHECK: [[OPT_Q:%.*]] = alloc_stack $Optional<any Q>
 // CHECK-NOT: begin_access
-// CHECK: copy_addr [[Q0]] to [initialization] [[OPT_Q]] : $*Optional<any Q>
+// CHECK: copy_addr [[Q0]] to [init] [[OPT_Q]] : $*Optional<any Q>
 // CHECK-NOT: begin_access
 // CHECK: switch_enum_addr [[OPT_Q]] : $*Optional<any Q>, case #Optional.some!enumelt: bb
 // CHECK-NOT: begin_access
 // CHECK: [[OPT_Q_ADR:%.*]] = unchecked_take_enum_data_addr [[OPT_Q]] : $*Optional<any Q>, #Optional.some!enumelt
 // CHECK-NOT: begin_access
-// CHECK: copy_addr [take] [[OPT_Q_ADR]] to [initialization] [[Q]] : $*any Q
+// CHECK: copy_addr [take] [[OPT_Q_ADR]] to [init] [[Q]] : $*any Q
 // CHECK-NOT: begin_access
 // CHECK: [[Q_ADR:%.*]] = open_existential_addr immutable_access [[Q]] : $*any Q to $*@opened("{{.*}}", any Q) Self
 // CHECK: witness_method $@opened("{{.*}}", any Q) Self, #PBar.bar
@@ -980,7 +980,7 @@ func testLocalExistential() {
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJ]] : $*any P
 // CHECK: [[COPY:%.*]] = alloc_stack $any P
 // CHECK-NOT: begin_access
-// CHECK: copy_addr [[ACCESS]] to [initialization] [[COPY]] : $*any P
+// CHECK: copy_addr [[ACCESS]] to [init] [[COPY]] : $*any P
 // CHECK: end_access
 // CHECK-NOT: begin_access
 // CHECK-LABEL: } // end sil function '$s20access_marker_verify20testLocalExistentialyyF'

--- a/test/SILOptimizer/access_storage_analysis.sil
+++ b/test/SILOptimizer/access_storage_analysis.sil
@@ -439,7 +439,7 @@ bb0(%0 : $*TreeB<T>, %1 : $*TreeB<T>):
   %boxAddr = project_box %box : $<τ_0_0> { var (left: TreeB<τ_0_0>, right: TreeB<τ_0_0>) } <T>, 0
   %boxAccess = begin_access [read] [dynamic] %boxAddr : $*(left: TreeB<T>, right: TreeB<T>)
   %leftAddr = tuple_element_addr %boxAccess : $*(left: TreeB<T>, right: TreeB<T>), 0
-  copy_addr %leftAddr to [initialization] %0 : $*TreeB<T>
+  copy_addr %leftAddr to [init] %0 : $*TreeB<T>
   end_access %boxAccess : $*(left: TreeB<T>, right: TreeB<T>)
   %v = tuple ()
   return %v : $()

--- a/test/SILOptimizer/access_storage_analysis_ossa.sil
+++ b/test/SILOptimizer/access_storage_analysis_ossa.sil
@@ -455,7 +455,7 @@ bb0(%0 : $*TreeB<T>, %1 : $*TreeB<T>):
   %boxAddr = project_box %box : $<τ_0_0> { var (left: TreeB<τ_0_0>, right: TreeB<τ_0_0>) } <T>, 0
   %boxAccess = begin_access [read] [dynamic] %boxAddr : $*(left: TreeB<T>, right: TreeB<T>)
   %leftAddr = tuple_element_addr %boxAccess : $*(left: TreeB<T>, right: TreeB<T>), 0
-  copy_addr %leftAddr to [initialization] %0 : $*TreeB<T>
+  copy_addr %leftAddr to [init] %0 : $*TreeB<T>
   end_access %boxAccess : $*(left: TreeB<T>, right: TreeB<T>)
   destroy_value %box : $<τ_0_0> { var (left: TreeB<τ_0_0>, right: TreeB<τ_0_0>) } <T>
   %v = tuple ()

--- a/test/SILOptimizer/accesspath_uses_ossa.sil
+++ b/test/SILOptimizer/accesspath_uses_ossa.sil
@@ -412,25 +412,25 @@ enum IntTEnum<T> {
 }
 
 // CHECK-LABEL: @testEnumUses
-// CHECK: ###For MemOp:   copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK: ###For MemOp:   copy_addr %0 to [init] %2 : $*IntTEnum<T>
 // CHECK: Storage: Argument %0 = argument of bb0 : $*IntTEnum<T>
 // CHECK: Path: ()
 // CHECK: Exact Uses {
 // CHECK-NEXT:  debug_value %0 : $*IntTEnum<T>, let, name "self", argno 1, expr op_deref
 // CHECK-NEXT:  Path: ()
-// CHECK-NEXT:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK-NEXT:  copy_addr %0 to [init] %2 : $*IntTEnum<T>
 // CHECK-NEXT:  Path: ()
 // CHECK-NEXT: }
 // CHECK: Overlapping Uses {
 // CHECK-NEXT:  debug_value %0 : $*IntTEnum<T>, let, name "self", argno 1, expr op_deref
 // CHECK-NEXT:  Path: ()
-// CHECK-NEXT:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK-NEXT:  copy_addr %0 to [init] %2 : $*IntTEnum<T>
 // CHECK-NEXT:  Path: ()
 // CHECK-NEXT: }
 // CHECK: Storage: Stack   %2 = alloc_stack $IntTEnum<T>
 // CHECK: Path: ()
 // CHECK: Exact Uses {
-// CHECK-NEXT:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK-NEXT:  copy_addr %0 to [init] %2 : $*IntTEnum<T>
 // CHECK-NEXT:  Path: ()
 // CHECK-NEXT:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
 // CHECK-NEXT:  Path: ()
@@ -450,7 +450,7 @@ enum IntTEnum<T> {
 // CHECK-NEXT:  Path: ()
 // CHECK-NEXT: }
 // CHECK: Overlapping Uses {
-// CHECK-NEXT:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK-NEXT:  copy_addr %0 to [init] %2 : $*IntTEnum<T>
 // CHECK-NEXT:  Path: ()
 // CHECK-NEXT:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
 // CHECK-NEXT:  Path: ()
@@ -473,7 +473,7 @@ enum IntTEnum<T> {
 // CHECK: Storage: Stack   %2 = alloc_stack $IntTEnum<T>
 // CHECK: Path: ()
 // CHECK: Exact Uses {
-// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  copy_addr %0 to [init] %2 : $*IntTEnum<T>
 // CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
 // CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
 // CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
@@ -481,7 +481,7 @@ enum IntTEnum<T> {
 // CHECK:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
 // CHECK: }
 // CHECK: Overlapping Uses {
-// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  copy_addr %0 to [init] %2 : $*IntTEnum<T>
 // CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
 // CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
 // CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
@@ -492,7 +492,7 @@ enum IntTEnum<T> {
 // CHECK: Storage: Stack   %2 = alloc_stack $IntTEnum<T>
 // CHECK: Path: ()
 // CHECK: Exact Uses {
-// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  copy_addr %0 to [init] %2 : $*IntTEnum<T>
 // CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
 // CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
 // CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
@@ -500,7 +500,7 @@ enum IntTEnum<T> {
 // CHECK:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
 // CHECK: }
 // CHECK: Overlapping Uses {
-// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  copy_addr %0 to [init] %2 : $*IntTEnum<T>
 // CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
 // CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
 // CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
@@ -511,7 +511,7 @@ enum IntTEnum<T> {
 // CHECK: Storage: Stack   %2 = alloc_stack $IntTEnum<T>
 // CHECK: Path: ()
 // CHECK: Exact Uses {
-// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  copy_addr %0 to [init] %2 : $*IntTEnum<T>
 // CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
 // CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
 // CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
@@ -519,7 +519,7 @@ enum IntTEnum<T> {
 // CHECK:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
 // CHECK: }
 // CHECK: Overlapping Uses {
-// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  copy_addr %0 to [init] %2 : $*IntTEnum<T>
 // CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
 // CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
 // CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
@@ -530,7 +530,7 @@ enum IntTEnum<T> {
 // CHECK: Storage: Stack   %2 = alloc_stack $IntTEnum<T>
 // CHECK: Path: ()
 // CHECK: Exact Uses {
-// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  copy_addr %0 to [init] %2 : $*IntTEnum<T>
 // CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
 // CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
 // CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
@@ -538,7 +538,7 @@ enum IntTEnum<T> {
 // CHECK:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
 // CHECK: }
 // CHECK: Overlapping Uses {
-// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  copy_addr %0 to [init] %2 : $*IntTEnum<T>
 // CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
 // CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
 // CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
@@ -549,7 +549,7 @@ enum IntTEnum<T> {
 // CHECK: Storage: Stack   %2 = alloc_stack $IntTEnum<T>
 // CHECK: Path: ()
 // CHECK: Exact Uses {
-// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  copy_addr %0 to [init] %2 : $*IntTEnum<T>
 // CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
 // CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
 // CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
@@ -557,7 +557,7 @@ enum IntTEnum<T> {
 // CHECK:  %13 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.other!enumelt
 // CHECK: }
 // CHECK: Overlapping Uses {
-// CHECK:  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+// CHECK:  copy_addr %0 to [init] %2 : $*IntTEnum<T>
 // CHECK:  switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
 // CHECK:  %5 = unchecked_take_enum_data_addr %2 : $*IntTEnum<T>, #IntTEnum.int!enumelt
 // CHECK:  %6 = load [take] %5 : $*<τ_0_0> { var Int } <T>
@@ -568,7 +568,7 @@ sil hidden [ossa] @testEnumUses : $@convention(method) <T> (@in_guaranteed IntTE
 bb0(%0 : $*IntTEnum<T>):
   debug_value %0 : $*IntTEnum<T>, let, name "self", argno 1, expr op_deref
   %2 = alloc_stack $IntTEnum<T>
-  copy_addr %0 to [initialization] %2 : $*IntTEnum<T>
+  copy_addr %0 to [init] %2 : $*IntTEnum<T>
   switch_enum_addr %2 : $*IntTEnum<T>, case #IntTEnum.int!enumelt: bb1, case #IntTEnum.other!enumelt: bb2
 
 bb1:
@@ -632,23 +632,23 @@ bb0(%0 : @guaranteed $Storage):
 }
 
 // CHECK-LABEL: @testBeginAccessUses
-// CHECK: ###For MemOp:   copy_addr [take] %1 to [initialization] %{{.*}} : $*T
+// CHECK: ###For MemOp:   copy_addr [take] %1 to [init] %{{.*}} : $*T
 // CHECK: Storage: Argument %1 = argument of bb0 : $*T
 // CHECK: Path: ()
 // CHECK: Exact Uses {
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] %{{.*}} : $*T
+// CHECK-NEXT:   copy_addr [take] %1 to [init] %{{.*}} : $*T
 // CHECK-NEXT:   Path: ()
 // CHECK-NEXT: }
 // CHECK: Overlapping Uses {
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] %{{.*}} : $*T
+// CHECK-NEXT:   copy_addr [take] %1 to [init] %{{.*}} : $*T
 // CHECK-NEXT:   Path: ()
 // CHECK-NEXT: }
 // CHECK: Storage: Stack   %{{.*}} = alloc_stack $T, var, name "$value"
 // CHECK: Path: ()
 // CHECK: Exact Uses {
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] %{{.*}} : $*T
+// CHECK-NEXT:   copy_addr [take] %1 to [init] %{{.*}} : $*T
 // CHECK-NEXT:   Path: ()
-// CHECK-NEXT:   copy_addr %{{.*}} to [initialization] %0 : $*T
+// CHECK-NEXT:   copy_addr %{{.*}} to [init] %0 : $*T
 // CHECK-NEXT:   Path: ()
 // CHECK-NEXT:   end_access %{{.*}} : $*T
 // CHECK-NEXT:   Path: ()
@@ -658,9 +658,9 @@ bb0(%0 : @guaranteed $Storage):
 // CHECK-NEXT:   Path: ()
 // CHECK-NEXT: }
 // CHECK: Overlapping Uses {
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] %{{.*}} : $*T
+// CHECK-NEXT:   copy_addr [take] %1 to [init] %{{.*}} : $*T
 // CHECK-NEXT:   Path: ()
-// CHECK-NEXT:   copy_addr %{{.*}} to [initialization] %0 : $*T
+// CHECK-NEXT:   copy_addr %{{.*}} to [init] %0 : $*T
 // CHECK-NEXT:   Path: ()
 // CHECK-NEXT:   end_access %{{.*}} : $*T
 // CHECK-NEXT:   Path: ()
@@ -669,13 +669,13 @@ bb0(%0 : @guaranteed $Storage):
 // CHECK-NEXT:   dealloc_stack %{{.*}} : $*T
 // CHECK-NEXT:   Path: ()
 // CHECK-NEXT: }
-// CHECK: ###For MemOp:   copy_addr %{{.*}} to [initialization] %0 : $*T
+// CHECK: ###For MemOp:   copy_addr %{{.*}} to [init] %0 : $*T
 // CHECK: Storage: Stack   %{{.*}} = alloc_stack $T, var, name "$value"
 // CHECK: Path: ()
 // CHECK: Exact Uses {
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] %{{.*}} : $*T
+// CHECK-NEXT:   copy_addr [take] %1 to [init] %{{.*}} : $*T
 // CHECK-NEXT:   Path: ()
-// CHECK-NEXT:   copy_addr %{{.*}} to [initialization] %0 : $*T
+// CHECK-NEXT:   copy_addr %{{.*}} to [init] %0 : $*T
 // CHECK-NEXT:   Path: ()
 // CHECK-NEXT:   end_access %{{.*}} : $*T
 // CHECK-NEXT:   Path: ()
@@ -685,9 +685,9 @@ bb0(%0 : @guaranteed $Storage):
 // CHECK-NEXT:   Path: ()
 // CHECK-NEXT: }
 // CHECK: Overlapping Uses {
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] %{{.*}} : $*T
+// CHECK-NEXT:   copy_addr [take] %1 to [init] %{{.*}} : $*T
 // CHECK-NEXT:   Path: ()
-// CHECK-NEXT:   copy_addr %{{.*}} to [initialization] %0 : $*T
+// CHECK-NEXT:   copy_addr %{{.*}} to [init] %0 : $*T
 // CHECK-NEXT:   Path: ()
 // CHECK-NEXT:   end_access %{{.*}} : $*T
 // CHECK-NEXT:   Path: ()
@@ -699,9 +699,9 @@ bb0(%0 : @guaranteed $Storage):
 sil [ossa] @testBeginAccessUses : $@convention(thin) <T where T : Comparable> (@in T) -> @out T {
 bb0(%0 : $*T, %1 : $*T):
   %2 = alloc_stack $T, var, name "$value"
-  copy_addr [take] %1 to [initialization] %2 : $*T
+  copy_addr [take] %1 to [init] %2 : $*T
   %4 = begin_access [modify] [static] %2 : $*T
-  copy_addr %4 to [initialization] %0 : $*T
+  copy_addr %4 to [init] %0 : $*T
   end_access %4 : $*T
   destroy_addr %2 : $*T
   dealloc_stack %2 : $*T

--- a/test/SILOptimizer/addr_escape_info.sil
+++ b/test/SILOptimizer/addr_escape_info.sil
@@ -240,7 +240,7 @@ bb0:
   %1 = ref_element_addr %0 : $X, #X.s
   fix_lifetime %1 : $*Str
   %3 = alloc_stack $Str
-  copy_addr %1 to [initialization] %3 : $*Str
+  copy_addr %1 to [init] %3 : $*Str
   %5 = function_ref @indirect_struct_argument : $@convention(thin) (@in Str) -> ()
   %6 = apply %5(%3) : $@convention(thin) (@in Str) -> ()
   strong_release %0 : $X

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -77,7 +77,7 @@ sil [ossa] @returnTuple : $@convention(thin) <T> (@in T) -> (@out T, Int, @out I
 
 // CHECK-LABEL: sil [ossa] @f010_addrlower_identity : $@convention(thin) <T> (@in T) -> @out T {
 // CHECK: bb0(%0 : $*T, %1 : $*T):
-// CHECK: copy_addr [take] %1 to [initialization] %0 : $*T
+// CHECK: copy_addr [take] %1 to [init] %0 : $*T
 // CHECK: return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function 'f010_addrlower_identity'
 sil [ossa] @f010_addrlower_identity : $@convention(thin) <T> (@in T) -> @out T {
@@ -92,7 +92,7 @@ bb0(%0 : @owned $T):
 //
 // CHECK-LABEL: sil [ossa] @f011_identity_tuple : $@convention(thin) <T> (@in (T, T)) -> @out (T, T) {
 // CHECK: bb0(%0 : $*(T, T), %1 : $*(T, T)):
-// CHECK:   copy_addr [take] %1 to [initialization] %0 : $*(T, T)
+// CHECK:   copy_addr [take] %1 to [init] %0 : $*(T, T)
 // CHECK-LABEL: } // end sil function 'f011_identity_tuple'
 sil [ossa] @f011_identity_tuple : $@convention(thin) <T> (@in (T, T)) -> @out (T, T) {
 bb0(%0 : @owned $(T, T)):
@@ -106,7 +106,7 @@ bb0(%0 : @owned $(T, T)):
 // CHECK:   [[RET0:%.*]] = tuple_element_addr %0 : $*(T, T), 0
 // CHECK:   apply %{{.*}}<T>([[RET0]], [[ARG0]]) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
 // CHECK:   [[RET1:%.*]] = tuple_element_addr %0 : $*(T, T), 1
-// CHECK:   copy_addr [take] [[ARG1]] to [initialization] [[RET1]] : $*T
+// CHECK:   copy_addr [take] [[ARG1]] to [init] [[RET1]] : $*T
 // CHECK-LABEL: } // end sil function 'f012_decompose_tuple_arg'
 sil [ossa] @f012_decompose_tuple_arg : $@convention(thin) <T> (@in (T, T)) -> @out (T, T) {
 bb0(%0 : @owned $(T, T)):
@@ -122,14 +122,14 @@ bb0(%0 : @owned $(T, T)):
 // CHECK:   [[IN:%.*]] = alloc_stack $(T, T)
 // CHECK:   [[OUT:%.*]] = alloc_stack $(T, T)
 // CHECK:   [[IN1:%.*]] = tuple_element_addr [[IN]] : $*(T, T), 1
-// CHECK:   copy_addr %1 to [initialization] [[IN1]] : $*T
+// CHECK:   copy_addr %1 to [init] [[IN1]] : $*T
 // CHECK:   [[IN0:%.*]] = tuple_element_addr %2 : $*(T, T), 0
-// CHECK:   copy_addr [take] %1 to [initialization] [[IN0]] : $*T
+// CHECK:   copy_addr [take] %1 to [init] [[IN0]] : $*T
 // CHECK:   apply %{{.*}}<T>([[OUT]], [[IN]]) : $@convention(thin) <τ_0_0> (@in (τ_0_0, τ_0_0)) -> @out (τ_0_0, τ_0_0)
 // CHECK:   [[RET:%.*]] = tuple_element_addr [[OUT]] : $*(T, T), 0
 // CHECK:   [[DEAD:%.*]] = tuple_element_addr [[OUT]] : $*(T, T), 1
 // CHECK:   destroy_addr [[DEAD]] : $*T
-// CHECK:   copy_addr [take] [[RET]] to [initialization] %0 : $*T
+// CHECK:   copy_addr [take] [[RET]] to [init] %0 : $*T
 // CHECK-LABEL: } // end sil function 'f013_pass_tuple_arg'
 sil [ossa] @f013_pass_tuple_arg : $@convention(thin) <T> (@in T) -> @out T {
 bb0(%0 : @owned $T):
@@ -147,9 +147,9 @@ bb0(%0 : @owned $T):
 // CHECK: %1 "$return_value"
 // CHECK: %2 "$return_value"
 // CHECK: bb0(%0 : $*T, %1 : $*T, %2 : $*T, %3 : $*T):
-// CHECK:   copy_addr %3 to [initialization] %1 : $*T
-// CHECK:   copy_addr %3 to [initialization] %2 : $*T
-// CHECK:   copy_addr [take] %3 to [initialization] %0 : $*T
+// CHECK:   copy_addr %3 to [init] %1 : $*T
+// CHECK:   copy_addr %3 to [init] %2 : $*T
+// CHECK:   copy_addr [take] %3 to [init] %0 : $*T
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function 'f020_multiResult'
 sil [ossa] @f020_multiResult : $@convention(thin) <T> (@in T) -> (@out T, @out T, @out T) {
@@ -193,8 +193,8 @@ bb0(%0 : $Int):
 
 // CHECK-LABEL: sil [ossa] @f030_returnPair : $@convention(thin) <T> (@in T) -> (@out T, @out T) {
 // CHECK: bb0(%0 : $*T, %1 : $*T, %2 : $*T):
-// CHECK:   copy_addr %2 to [initialization] %1 : $*T
-// CHECK:   copy_addr [take] %2 to [initialization] %0 : $*T
+// CHECK:   copy_addr %2 to [init] %1 : $*T
+// CHECK:   copy_addr [take] %2 to [init] %0 : $*T
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function 'f030_returnPair'
 sil [ossa] @f030_returnPair : $@convention(thin) <T> (@in T) -> (@out T, @out T) {
@@ -236,7 +236,7 @@ bb0(%0 : @owned $T):
 // CHECK: bb0(%0 : $*T):
 // CHECK:  %[[LOC:.*]] = alloc_stack $T
 // CHECK:  %[[FN:.*]] = function_ref @f040_consumeArg : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
-// CHECK:  copy_addr %0 to [initialization] %[[LOC]] : $*T
+// CHECK:  copy_addr %0 to [init] %[[LOC]] : $*T
 // CHECK:  %{{.*}} = apply %[[FN]]<T>(%[[LOC]]) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
 // CHECK:  destroy_addr %0 : $*T
 // CHECK:  %[[R:.*]] = tuple ()
@@ -314,10 +314,10 @@ bb0(%0 : @guaranteed $T):
 // CHECK:   debug_value %0 : $*T, var, name "t", argno 1
 // CHECK:   debug_value %1 : $*T, var, name "u", argno 2
 // CHECK:   debug_value %2 : $*T
-// CHECK:   copy_addr [take] %0 to [initialization] %[[PREV1]] : $*T
-// CHECK:   copy_addr %2 to [initialization] %0 : $*T
+// CHECK:   copy_addr [take] %0 to [init] %[[PREV1]] : $*T
+// CHECK:   copy_addr %2 to [init] %0 : $*T
 // CHECK:   destroy_addr %[[PREV1]] : $*T
-// CHECK:   copy_addr %1 to [initialization] %[[PREV2]] : $*T
+// CHECK:   copy_addr %1 to [init] %[[PREV2]] : $*T
 // CHECK:   copy_addr %2 to %1 : $*T
 // CHECK:   destroy_addr %[[PREV2]] : $*T
 // CHECK:   destroy_addr %2 : $*T
@@ -346,8 +346,8 @@ bb0(%0 : $*T, %1 : $*T, %2 : @owned $T):
 // CHECK-LABEL: sil [ossa] @f060_mutate : $@convention(thin) <T> (@inout T, @in T) -> () {
 // CHECK: bb0(%0 : $*T, %1 : $*T):
 // CHECK:   [[A0:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [take] %0 to [initialization] [[A0]] : $*T
-// CHECK:   copy_addr %1 to [initialization] %0 : $*T
+// CHECK:   copy_addr [take] %0 to [init] [[A0]] : $*T
+// CHECK:   copy_addr %1 to [init] %0 : $*T
 // CHECK:   destroy_addr [[A0]] : $*T
 // CHECK:   destroy_addr %1 : $*T
 // CHECK:   dealloc_stack [[A0]] : $*T
@@ -367,9 +367,9 @@ bb0(%0 : $*T, %1 : @owned $T):
 // CHECK: bb0(%0 : $*T):
 // CHECK:   %[[LOC1:.*]] = alloc_stack $T
 // CHECK:   %[[INOUT:.*]] = alloc_stack $T, var, name "u"
-// CHECK:   copy_addr %0 to [initialization] %[[INOUT]] : $*T
+// CHECK:   copy_addr %0 to [init] %[[INOUT]] : $*T
 // CHECK:   %[[FN:.*]] = function_ref @f060_mutate : $@convention(thin) <τ_0_0> (@inout τ_0_0, @in τ_0_0) -> ()
-// CHECK:   copy_addr %0 to [initialization] %[[LOC1]] : $*T
+// CHECK:   copy_addr %0 to [init] %[[LOC1]] : $*T
 // CHECK:   %{{.*}} = apply %[[FN]]<T>(%[[INOUT]], %[[LOC1]]) : $@convention(thin) <τ_0_0> (@inout τ_0_0, @in τ_0_0) -> ()
 // CHECK:   destroy_addr %[[INOUT]] : $*T
 // CHECK:   destroy_addr %0 : $*T
@@ -394,7 +394,7 @@ bb0(%0 : @owned $T):
 
 // CHECK-LABEL: sil [ossa] @f070_mixedResult1 : $@convention(thin) <T> (@in T, @owned any C) -> (@out T, @owned any C) {
 // CHECK: bb0(%0 : $*T, %1 : $*T, %2 : @owned $any C):
-// CHECK:   copy_addr [take] %1 to [initialization] %0 : $*T
+// CHECK:   copy_addr [take] %1 to [init] %0 : $*T
 // CHECK:   return %2 : $any C
 // CHECK-LABEL: } // end sil function 'f070_mixedResult1'
 sil [ossa] @f070_mixedResult1 : $@convention(thin) <T> (@in T, @owned C) -> (@out T, @owned C) {
@@ -405,9 +405,9 @@ bb0(%0 : @owned $T, %1 : @owned $C):
 
 // CHECK-LABEL: sil [ossa] @f071_mixedResult2 : $@convention(thin) <T> (@in T, @owned any C) -> (@out T, @out T, @owned any C, @owned any C) {
 // CHECK: bb0(%0 : $*T, %1 : $*T, %2 : $*T, %3 : @owned $any C):
-// CHECK:   copy_addr %2 to [initialization] %0 : $*T
+// CHECK:   copy_addr %2 to [init] %0 : $*T
 // CHECK:   [[C:%.*]] = copy_value %3 : $any C
-// CHECK:   copy_addr [take] %2 to [initialization] %1 : $*T
+// CHECK:   copy_addr [take] %2 to [init] %1 : $*T
 // CHECK:   [[T:%.*]] = tuple ([[C]] : $any C, %3 : $any C)
 // CHECK:   return [[T]] : $(any C, any C)
 // CHECK-LABEL: } // end sil function 'f071_mixedResult2'
@@ -424,7 +424,7 @@ bb0(%0 : @owned $T, %1 : @owned $C):
 // CHECK:   [[IN:%.*]] = alloc_stack $T
 // CHECK:   // function_ref f070_mixedResult1
 // CHECK:   [[F:%.*]] = function_ref @f070_mixedResult1 : $@convention(thin) <τ_0_0> (@in τ_0_0, @owned any C) -> (@out τ_0_0, @owned any C)
-// CHECK:   copy_addr %1 to [initialization] [[IN]] : $*T
+// CHECK:   copy_addr %1 to [init] [[IN]] : $*T
 // CHECK:   [[C:%.*]] = copy_value %2 : $any C
 // CHECK:   [[R:%.*]] = apply [[F]]<T>(%0, [[IN]], [[C]]) : $@convention(thin) <τ_0_0> (@in τ_0_0, @owned any C) -> (@out τ_0_0, @owned any C)
 // CHECK:   destroy_value %2 : $any C
@@ -449,7 +449,7 @@ bb0(%0 : @owned $T, %1 : @owned $C):
 // CHECK: bb0(%0 : $*T, %1 : $*T, %2 : $*T, %3 : @owned $any C):
 // CHECK:   [[IN:%.*]] = alloc_stack $T
 // CHECK:   [[F:%.*]] = function_ref @f071_mixedResult2 : $@convention(thin) <τ_0_0> (@in τ_0_0, @owned any C) -> (@out τ_0_0, @out τ_0_0, @owned any C, @owned any C)
-// CHECK:   copy_addr %2 to [initialization] [[IN]] : $*T
+// CHECK:   copy_addr %2 to [init] [[IN]] : $*T
 // CHECK:   [[C:%.*]] = copy_value %3 : $any C
 // CHECK:   [[T:%.*]] = apply [[F]]<T>(%0, %1, [[IN]], [[C]]) : $@convention(thin) <τ_0_0> (@in τ_0_0, @owned any C) -> (@out τ_0_0, @out τ_0_0, @owned any C, @owned any C)
 // CHECK:   ([[OUT0:%.*]], [[OUT1:%.*]]) = destructure_tuple [[T]] : $(any C, any C)
@@ -501,14 +501,14 @@ bb0:
 // CHECK: bb0(%0 : $*T, %1 : $*T, %2 : @owned $any C):
 // CHECK:   [[TUPLE:%.*]] = alloc_stack $(T, any C)
 // CHECK:   [[E1:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, any C), 0
-// CHECK:   copy_addr [take] %1 to [initialization] [[E1]] : $*T
+// CHECK:   copy_addr [take] %1 to [init] [[E1]] : $*T
 // CHECK:   [[E2:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, any C), 1
 // CHECK:   store %2 to [init] [[E2]] : $*any C
 // CHECK:   apply %{{.*}}<T>([[TUPLE]]) : $@convention(thin) <τ_0_0> (@in_guaranteed (τ_0_0, any C)) -> ()
 // CHECK:   [[E1:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, any C), 0
 // CHECK:   [[E2:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, any C), 1
 // CHECK:   [[LD:%.*]] = load [take] [[E2]] : $*any C
-// CHECK:   copy_addr [take] [[E1]] to [initialization] %0 : $*T
+// CHECK:   copy_addr [take] [[E1]] to [init] %0 : $*T
 // CHECK:   dealloc_stack [[TUPLE]] : $*(T, any C)
 // CHECK:   return [[LD]] : $any C
 // CHECK-LABEL: } // end sil function 'f075_reusedResult'
@@ -523,7 +523,7 @@ bb0(%0 : @owned $T, %1 : @owned $C):
 // CHECK-LABEL: sil [ossa] @f080_optional : $@convention(thin) <T> (@in T) -> @out Optional<T> {
 // CHECK: bb0(%0 : $*Optional<T>, %1 : $*T):
 // CHECK:   [[DATA:%.*]] = init_enum_data_addr %0 : $*Optional<T>, #Optional.some!enumelt
-// CHECK:   copy_addr %1 to [initialization] [[DATA]] : $*T
+// CHECK:   copy_addr %1 to [init] [[DATA]] : $*T
 // CHECK:   inject_enum_addr %0 : $*Optional<T>, #Optional.some!enumelt
 // CHECK:   destroy_addr %1 : $*T
 // CHECK:   return %{{.*}} : $()
@@ -611,7 +611,7 @@ bb0(%0 : @owned $Any):
 // CHECK:   %[[A:.*]] = alloc_stack $Any
 // CHECK:   %[[F:.*]] = function_ref @f100_any : $@convention(thin) (@in Any) -> ()
 // CHECK:   %[[T2:.*]] = init_existential_addr %[[A]] : $*Any, $T
-// CHECK:   copy_addr %0 to [initialization] %[[T2]] : $*T
+// CHECK:   copy_addr %0 to [init] %[[T2]] : $*T
 // CHECK:   %{{.*}} = apply %[[F]](%[[A]]) : $@convention(thin) (@in Any) -> ()
 // CHECK:   destroy_addr %0 : $*T
 // CHECK:   dealloc_stack %[[A]] : $*Any
@@ -673,7 +673,7 @@ bb0:
 // CHECK:   [[ELT_ADR:%.*]] = struct_element_addr %2 : $*SI<Element>, #SI.element
 // CHECK:   [[IDX_ADR:%.*]] = struct_element_addr %2 : $*SI<Element>, #SI.index
 // CHECK:   [[IDX:%.*]] = load [trivial] [[IDX_ADR]] : $*I
-// CHECK:   copy_addr [take] [[ELT_ADR]] to [initialization] %0 : $*Element // id: %6
+// CHECK:   copy_addr [take] [[ELT_ADR]] to [init] %0 : $*Element // id: %6
 // CHECK:   store [[IDX]] to [trivial] %1 : $*I
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function 'f120_testDestructure'
@@ -714,7 +714,7 @@ bb0(%0 : @owned $SI<AnyObject>):
 // CHECK:   [[E0:%.*]] = struct_element_addr %2 : $*SRef<T>, #SRef.object
 // CHECK:   [[C:%.*]] = load [copy] [[E0]] : $*AnyObject
 // CHECK:   [[E1:%.*]] = struct_element_addr %2 : $*SRef<T>, #SRef.element
-// CHECK:   copy_addr [[E1]] to [initialization] %1 : $*T
+// CHECK:   copy_addr [[E1]] to [init] %1 : $*T
 // CHECK:   destroy_addr %2 : $*SRef<T>
 // CHECK:   store [[C]] to [init] %0 : $*AnyObject
 // CHECK-NOT: dealloc_stack
@@ -741,7 +741,7 @@ bb0(%0 : @owned $SRef<T>):
 // CHECK:   [[C:%.*]] = copy_value [[L]] : $AnyObject
 // CHECK:   end_borrow [[L]] : $AnyObject
 // CHECK:   [[E1:%.*]] = struct_element_addr %2 : $*SRef<T>, #SRef.element
-// CHECK:   copy_addr [[E1]] to [initialization] %1 : $*T
+// CHECK:   copy_addr [[E1]] to [init] %1 : $*T
 // CHECK:   destroy_addr %2 : $*SRef<T>
 // CHECK:   store [[C]] to [init] %0 : $*AnyObject
 // CHECK-NOT: dealloc_stack
@@ -767,7 +767,7 @@ bb0(%0 : @owned $SRef<T>):
 // CHECK:   [[E0:%.*]] = tuple_element_addr %2 : $*(AnyObject, T), 0
 // CHECK:   [[C:%.*]] = load [copy] [[E0]] : $*AnyObject
 // CHECK:   [[E1:%.*]] = tuple_element_addr %2 : $*(AnyObject, T), 1
-// CHECK:   copy_addr [[E1]] to [initialization] %1 : $*T
+// CHECK:   copy_addr [[E1]] to [init] %1 : $*T
 // CHECK:   destroy_addr %2 : $*(AnyObject, T)
 // CHECK:   store [[C]] to [init] %0 : $*AnyObject
 // CHECK-NOT: dealloc_stack
@@ -793,7 +793,7 @@ bb0(%0 : @owned $(AnyObject, T)):
 // CHECK:   [[C:%.*]] = copy_value [[L]] : $AnyObject
 // CHECK:   end_borrow [[L]] : $AnyObject
 // CHECK:   [[E1:%.*]] = tuple_element_addr %2 : $*(AnyObject, T), 1
-// CHECK:   copy_addr [[E1]] to [initialization] %1 : $*T
+// CHECK:   copy_addr [[E1]] to [init] %1 : $*T
 // CHECK:   destroy_addr %2 : $*(AnyObject, T)
 // CHECK:   store [[C]] to [init] %0 : $*AnyObject
 // CHECK-NOT: dealloc_stack
@@ -819,7 +819,7 @@ bb0(%0 : @owned $(AnyObject, T)):
 // CHECK:   [[I:%.*]] = tuple_element_addr %2 : $*(SI<Element>, I), 1
 // CHECK:   [[LD:%.*]] = load [trivial] [[I]] : $*I
 // CHECK:   [[E:%.*]] = struct_element_addr [[SI]] : $*SI<Element>, #SI.element
-// CHECK:   copy_addr [[E]] to [initialization] %0 : $*Element
+// CHECK:   copy_addr [[E]] to [init] %0 : $*Element
 // CHECK:   destroy_addr [[SI]] : $*SI<Element>
 // CHECK:   store [[LD]] to [trivial] %1 : $*I
 // CHECK-LABEL: } // end sil function 'f126_testDestructureAndBorrow'
@@ -852,11 +852,11 @@ bb0(%0 : @owned $T):
 // CHECK:   [[LOCAL:%.*]] = alloc_stack $((T, T), T)
 // CHECK:   [[ELT0:%.*]] = tuple_element_addr [[LOCAL]] : $*((T, T), T), 0
 // CHECK:   [[ELT0_0:%.*]] = tuple_element_addr [[ELT0]] : $*(T, T), 0
-// CHECK:   copy_addr %0 to [initialization] [[ELT0_0]] : $*T
+// CHECK:   copy_addr %0 to [init] [[ELT0_0]] : $*T
 // CHECK:   [[ELT1:%.*]] = tuple_element_addr [[LOCAL]] : $*((T, T), T), 1
-// CHECK:   copy_addr %0 to [initialization] [[ELT1]] : $*T
+// CHECK:   copy_addr %0 to [init] [[ELT1]] : $*T
 // CHECK:   [[ELT0_1:%.*]] = tuple_element_addr [[ELT0]] : $*(T, T), 1
-// CHECK:   copy_addr [take] %0 to [initialization] [[ELT0_1]] : $*T
+// CHECK:   copy_addr [take] %0 to [init] [[ELT0_1]] : $*T
 // CHECK:   destroy_addr [[LOCAL]] : $*((T, T), T)
 // CHECK:   dealloc_stack [[LOCAL]] : $*((T, T), T)
 // CHECK:   return %{{.*}} : $()
@@ -877,11 +877,11 @@ bb0(%0 : @owned $T):
 // CHECK:   [[ALLOC:%.*]] = alloc_stack $Pair<Pair<T>>
 // CHECK:   [[ELT_X:%.*]] = struct_element_addr [[ALLOC]] : $*Pair<Pair<T>>, #Pair.x
 // CHECK:   [[ELT_XY:%.*]] = struct_element_addr [[ELT_X]] : $*Pair<T>, #Pair.y
-// CHECK:   copy_addr %0 to [initialization] [[ELT_XY]] : $*T
+// CHECK:   copy_addr %0 to [init] [[ELT_XY]] : $*T
 // CHECK:   [[ELT_XX:%.*]] = struct_element_addr [[ELT_X]] : $*Pair<T>, #Pair.x
-// CHECK:   copy_addr [take] %0 to [initialization] [[ELT_XX]] : $*T
+// CHECK:   copy_addr [take] %0 to [init] [[ELT_XX]] : $*T
 // CHECK:   [[ELT_Y:%.*]] = struct_element_addr [[ALLOC]] : $*Pair<Pair<T>>, #Pair.y
-// CHECK:   copy_addr [[ELT_X]] to [initialization] [[ELT_Y]] : $*Pair<T>
+// CHECK:   copy_addr [[ELT_X]] to [init] [[ELT_Y]] : $*Pair<T>
 // CHECK:   destroy_addr [[ALLOC]] : $*Pair<Pair<T>>
 // CHECK:   dealloc_stack [[ALLOC]] : $*Pair<Pair<T>>
 // CHECK:   return %{{.*}} : $()
@@ -900,11 +900,11 @@ bb0(%0 : @owned $T):
 // CHECK-LABEL: sil [ossa] @f160_testOpenedArchetype : $@convention(thin) (@in any P) -> () {
 // CHECK: bb0(%0 : $*any P):
 // CHECK:   [[ALLOC:%.*]] = alloc_stack $any P, var, name "q"
-// CHECK:   copy_addr %0 to [initialization] [[ALLOC]] : $*any P
+// CHECK:   copy_addr %0 to [init] [[ALLOC]] : $*any P
 // CHECK:   [[OPEN:%.*]] = open_existential_addr immutable_access %0 : $*any P to $*[[ARCHETYPE:@opened\(.*, any P\) Self]]
 // CHECK:   [[CP:%.*]] = alloc_stack $[[ARCHETYPE]] // type-defs: [[OPEN]];
 // CHECK:   [[WT:%.*]] = witness_method $[[ARCHETYPE]], #P.foo : <Self where Self : P> (Self) -> () -> (), [[OPEN]] : $*[[ARCHETYPE]] : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
-// CHECK:   copy_addr [[OPEN]] to [initialization] [[CP]] : $*[[ARCHETYPE]]
+// CHECK:   copy_addr [[OPEN]] to [init] [[CP]] : $*[[ARCHETYPE]]
 // CHECK:   %{{.*}} = apply [[WT]]<[[ARCHETYPE]]>([[CP]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
 // CHECK:   destroy_addr [[CP]] : $*[[ARCHETYPE]]
 // CHECK:   destroy_addr [[ALLOC]] : $*any P
@@ -937,12 +937,12 @@ bb0(%0 : @owned $P):
 // CHECK-LABEL: sil [ossa] @f161_testOpenedArchetype : $@convention(thin) (@in any P) -> () {
 // CHECK: bb0(%0 : $*any P):
 // CHECK:   [[ALLOCP:%.*]] = alloc_stack $any P, var, name "q"
-// CHECK:   copy_addr %0 to [initialization] [[ALLOCP]] : $*any P
+// CHECK:   copy_addr %0 to [init] [[ALLOCP]] : $*any P
 // CHECK:   [[OPEN:%.*]] = open_existential_addr immutable_access %0 : $*any P to $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
 // CHECK:   [[OPTIONAL:%.*]] = alloc_stack $Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>
 // CHECK:   witness_method $@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self, #P.foo : <Self where Self : P> (Self) -> () -> (), [[OPEN]] : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
 // CHECK:   [[INIT:%.*]] = init_enum_data_addr [[OPTIONAL]] : $*Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>, #Optional.some!enumelt
-// CHECK:   copy_addr [[OPEN]] to [initialization] [[INIT]] : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
+// CHECK:   copy_addr [[OPEN]] to [init] [[INIT]] : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
 // CHECK:   inject_enum_addr [[OPTIONAL]] : $*Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>, #Optional.some!enumelt
 // CHECK:   [[DATA:%.*]] = unchecked_take_enum_data_addr [[OPTIONAL]] : $*Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>, #Optional.some!enumelt
 // CHECK:   %10 = apply %{{.*}}<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>([[DATA]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
@@ -1029,10 +1029,10 @@ bb7:
 // CHECK:   [[COND:%.*]] = apply [[WT]]<T>(%1, %2, [[MT]]) : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Builtin.Int1
 // CHECK:   cond_br [[COND]], bb2, bb1
 // CHECK: bb1:
-// CHECK:   copy_addr %1 to [initialization] %0 : $*T
+// CHECK:   copy_addr %1 to [init] %0 : $*T
 // CHECK:   br bb3
 // CHECK: bb2:
-// CHECK:   copy_addr %2 to [initialization] %0 : $*T
+// CHECK:   copy_addr %2 to [init] %0 : $*T
 // CHECK:   br bb3
 // CHECK-LABEL: } // end sil function 'f170_compare'
 sil [ossa] @f170_compare : $@convention(thin) <T where T : Comparable> (@in_guaranteed T, @in_guaranteed T) -> @out T {
@@ -1062,7 +1062,7 @@ bb3(%15 : @owned $T):
 // CHECK:   br [[RETBB:bb[0-9]+]]
 // CHECK: [[SOMEBB]]:
 // CHECK:   [[CAST:%.*]] = unchecked_take_enum_data_addr %0 : $*Optional<T>, #Optional.some!enumelt
-// CHECK:   copy_addr [take] [[CAST]] to [initialization] %1 : $*T
+// CHECK:   copy_addr [take] [[CAST]] to [init] %1 : $*T
 // CHECK:   br [[RETBB]]
 // CHECK: [[RETBB]]:
 // CHECK-LABEL: } // end sil function 'f210_testSwitchEnum'
@@ -1095,7 +1095,7 @@ bb3:
 // CHECK: [[TBB]]:
 // CHECK:   [[CAST:%.*]] = unchecked_take_enum_data_addr %0 : $*Mixed<T>, #Mixed.t!enumelt
 // CHECK:   destroy_addr %2 : $*T
-// CHECK:   copy_addr [take] [[CAST]] to [initialization] %2 : $*T
+// CHECK:   copy_addr [take] [[CAST]] to [init] %2 : $*T
 // CHECK:   br [[RBB]]
 // CHECK: [[IBB]]:
 // CHECK:   [[CAST:%.*]] = unchecked_take_enum_data_addr %0 : $*Mixed<T>, #Mixed.i!enumelt
@@ -1241,7 +1241,7 @@ class Klass {}
 // CHECK:   [[STK:%.*]] = alloc_stack $Klass
 // CHECK:   [[METH:%.*]] = class_method %0 : $TestGeneric<Klass>, #TestGeneric.borrowedGeneric!read : <T> (TestGeneric<T>) -> () -> (), $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
 // CHECK:   ([[Y:%.*]], [[TOK:%.*]]) = begin_apply [[METH]]<Klass>(%0) : $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
-// CHECK:   copy_addr [[Y]] to [initialization] [[STK]] : $*Klass
+// CHECK:   copy_addr [[Y]] to [init] [[STK]] : $*Klass
 // CHECK:   end_apply [[TOK]]
 // CHECK:   destroy_addr [[STK]] : $*Klass
 // CHECK-LABEL: }
@@ -1261,7 +1261,7 @@ bb0(%0 : @guaranteed $TestGeneric<Klass>):
 // CHECK:   [[STK:%.*]] = alloc_stack $T
 // CHECK:   [[M:%.*]] = class_method %0 : $TestGeneric<T>, #TestGeneric.borrowedGeneric!read : <T> (TestGeneric<T>) -> () -> (), $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
 // CHECK:   ([[Y:%.*]], [[TOK:%.*]]) = begin_apply %2<T>(%0) : $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
-// CHECK:   copy_addr [[Y]] to [initialization] [[STK]] : $*T
+// CHECK:   copy_addr [[Y]] to [init] [[STK]] : $*T
 // CHECK:   end_apply [[TOK]]
 // CHECK:   destroy_addr [[STK]] : $*T
 // CHECK-LABEL: } // end sil function 'testBeginApplyOpaqueYield'
@@ -1424,9 +1424,9 @@ bb3:
 // CHECK-LABEL: sil hidden [ossa] @test_unchecked_bitwise_cast :
 // CHECK: bb0(%0 : $*U, %1 : $*T, %2 : $@thick U.Type):
 // CHECK:   [[STK:%.*]] = alloc_stack $T
-// CHECK:   copy_addr %1 to [initialization] [[STK]] : $*T
+// CHECK:   copy_addr %1 to [init] [[STK]] : $*T
 // CHECK:   [[CAST:%.*]] = unchecked_addr_cast [[STK]] : $*T to $*U
-// CHECK:   copy_addr [[CAST]] to [initialization] %0 : $*U
+// CHECK:   copy_addr [[CAST]] to [init] %0 : $*U
 // CHECK:   destroy_addr [[STK]] : $*T
 // CHECK:   dealloc_stack [[STK]] : $*T
 // CHECK-LABEL: } // end sil function 'test_unchecked_bitwise_cast'
@@ -1457,7 +1457,7 @@ bb0(%0 : $Int):
 // CHECK: sil hidden [ossa] @test_unconditional_checked_cast2 : $@convention(thin) <T> (@in_guaranteed T) -> Builtin.Int64 {
 // CHECK: bb0(%0 : $*T):
 // CHECK:   [[SRC:%.*]] = alloc_stack $T
-// CHECK:   copy_addr %0 to [initialization] [[SRC]] : $*T
+// CHECK:   copy_addr %0 to [init] [[SRC]] : $*T
 // CHECK:   [[INT:%.*]] = alloc_stack $Builtin.Int64
 // CHECK:   unconditional_checked_cast_addr T in [[SRC]] : $*T to Builtin.Int64 in [[INT]] : $*Builtin.Int64
 // CHECK:   [[RES:%.*]] = load [trivial] [[INT]] : $*Builtin.Int64
@@ -1474,9 +1474,9 @@ bb0(%0 : @guaranteed $T):
 // CHECK: bb0(%0 : $*U, %1 : $*T):
 // CHECK:   [[TTMP:%.*]] = alloc_stack $T
 // CHECK:   [[UTMP:%.*]] = alloc_stack [lexical] $U
-// CHECK:   copy_addr %1 to [initialization] [[TTMP]] : $*T
+// CHECK:   copy_addr %1 to [init] [[TTMP]] : $*T
 // CHECK:   unconditional_checked_cast_addr T in [[TTMP]] : $*T to U in [[UTMP]] : $*U
-// CHECK:   copy_addr [[UTMP]] to [initialization] %0 : $*U
+// CHECK:   copy_addr [[UTMP]] to [init] %0 : $*U
 // CHECK:   destroy_addr [[UTMP]] : $*U
 // CHECK:   %8 = tuple ()
 // CHECK:   dealloc_stack [[UTMP]] : $*U

--- a/test/SILOptimizer/address_lowering_lib.sil
+++ b/test/SILOptimizer/address_lowering_lib.sil
@@ -11,7 +11,7 @@ sil_stage raw
 // CHECK: [[BORROW:%.*]] = begin_borrow [lexical] [[VAL]] : $any Error
 // CHECK: [[OPENADDR:%.*]] = open_existential_box [[BORROW]] : $any Error to $*@opened("169A6848-B636-11EC-83C4-D0817AD59B9D", any Error) Self
 // CHECK: [[INIT:%.*]] = init_existential_addr [[ALLOC]] : $*Any, $@opened("169A6848-B636-11EC-83C4-D0817AD59B9D", any Error) Self
-// CHECK: copy_addr [[OPENADDR]] to [initialization] [[INIT]] : $*@opened("169A6848-B636-11EC-83C4-D0817AD59B9D", any Error) Self
+// CHECK: copy_addr [[OPENADDR]] to [init] [[INIT]] : $*@opened("169A6848-B636-11EC-83C4-D0817AD59B9D", any Error) Self
 // CHECK: destroy_addr [[ALLOC]] : $*Any
 // CHECK: end_borrow [[BORROW]] : $any Error
 // CHECK: destroy_value [[VAL]] : $any Error

--- a/test/SILOptimizer/address_lowering_phi.sil
+++ b/test/SILOptimizer/address_lowering_phi.sil
@@ -84,7 +84,7 @@ bb3(%15 : @owned $T):
 // CHECK:   cond_br undef, bb2, bb1
 // CHECK: bb1:
 // CHECK:   destroy_addr %0 : $*T
-// CHECK:   copy_addr [take] %1 to [initialization] %0 : $*T
+// CHECK:   copy_addr [take] %1 to [init] %0 : $*T
 // CHECK:   br bb3
 // CHECK: bb2:
 // CHECK:   destroy_addr %1 : $*T
@@ -118,11 +118,11 @@ bb3(%arg : @owned $T):
 // CHECK:   cond_br undef, bb2, bb1
 // CHECK: bb1:
 // CHECK:   destroy_addr %2 : $*T
-// CHECK:   copy_addr [take] %1 to [initialization] %0 : $*T
+// CHECK:   copy_addr [take] %1 to [init] %0 : $*T
 // CHECK:   br bb3
 // CHECK: bb2:
 // CHECK:   destroy_addr %1 : $*T
-// CHECK:   copy_addr [take] %2 to [initialization] %0 : $*T
+// CHECK:   copy_addr [take] %2 to [init] %0 : $*T
 // CHECK:   br bb3
 // CHECK: bb3:
 // CHECK-LABEL: } // end sil function 'f030_testBBArgProjectIn'
@@ -146,12 +146,12 @@ bb3(%arg : @owned $T):
 // CHECK: bb0(%0 : $*T, %1 : $*T, %2 : $*T, %3 : $*T):
 // CHECK:   cond_br undef, bb2, bb1
 // CHECK: bb1:
-// CHECK:   copy_addr [take] %2 to [initialization] %1 : $*T
-// CHECK:   copy_addr [take] %3 to [initialization] %0 : $*T
+// CHECK:   copy_addr [take] %2 to [init] %1 : $*T
+// CHECK:   copy_addr [take] %3 to [init] %0 : $*T
 // CHECK:   br bb3
 // CHECK: bb2:
-// CHECK:   copy_addr [take] %2 to [initialization] %0 : $*T
-// CHECK:   copy_addr [take] %3 to [initialization] %1 : $*T
+// CHECK:   copy_addr [take] %2 to [init] %0 : $*T
+// CHECK:   copy_addr [take] %3 to [init] %1 : $*T
 // CHECK:   br bb3
 // CHECK-LABEL: } // end sil function 'f040_testInSwapOut'
 sil [ossa] @f040_testInSwapOut : $@convention(thin) <T> (@in T, @in T) -> (@out T, @out T) {
@@ -173,13 +173,13 @@ bb3(%arg0 : @owned $T, %arg1 : @owned $T):
 // CHECK: bb0(%0 : $*T, %1 : $*T, %2 : $*T, %3 : $*T):
 // CHECK:   cond_br undef, bb2, bb1
 // CHECK: bb1:
-// CHECK:   copy_addr [take] %2 to [initialization] %0 : $*T
-// CHECK:   copy_addr [take] %3 to [initialization] %1 : $*T
+// CHECK:   copy_addr [take] %2 to [init] %0 : $*T
+// CHECK:   copy_addr [take] %3 to [init] %1 : $*T
 // CHECK:   br bb3
 // CHECK: bb2:
-// CHECK:   copy_addr %2 to [initialization] %1 : $*T
+// CHECK:   copy_addr %2 to [init] %1 : $*T
 // CHECK:   destroy_addr %3 : $*T
-// CHECK:   copy_addr [take] %2 to [initialization] %0 : $*T
+// CHECK:   copy_addr [take] %2 to [init] %0 : $*T
 // CHECK:   br bb3
 // CHECK: bb3:
 // CHECK-LABEL: } // end sil function 'f050_testCombine'
@@ -206,21 +206,21 @@ bb3(%arg0 : @owned $T, %arg1 : @owned $T):
 // CHECK: bb0(%0 : $*T, %1 : $*T):
 // CHECK:   [[ALLOC0:%.*]] = alloc_stack $T
 // CHECK:   [[ALLOC1:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [take] %0 to [initialization] [[ALLOC1]] : $*T
-// CHECK:   copy_addr [take] %1 to [initialization] [[ALLOC0]] : $*T
+// CHECK:   copy_addr [take] %0 to [init] [[ALLOC1]] : $*T
+// CHECK:   copy_addr [take] %1 to [init] [[ALLOC0]] : $*T
 // CHECK:   cond_br undef, bb2, bb1
 // CHECK: bb1:
 // CHECK:   [[TMP:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [take] [[ALLOC0]] to [initialization] [[TMP]] : $*T
-// CHECK:   copy_addr [take] [[ALLOC1]] to [initialization] [[ALLOC0]] : $*T
-// CHECK:   copy_addr [take] [[TMP]] to [initialization] [[ALLOC1]] : $*T
+// CHECK:   copy_addr [take] [[ALLOC0]] to [init] [[TMP]] : $*T
+// CHECK:   copy_addr [take] [[ALLOC1]] to [init] [[ALLOC0]] : $*T
+// CHECK:   copy_addr [take] [[TMP]] to [init] [[ALLOC1]] : $*T
 // CHECK:   dealloc_stack [[TMP]] : $*T
 // CHECK:   br bb3
 // CHECK: bb2:
 // CHECK:   br bb3
 // CHECK: bb3:
-// CHECK:   copy_addr [take] [[ALLOC0]] to [initialization] %0 : $*T
-// CHECK:   copy_addr [take] [[ALLOC1]] to [initialization] %1 : $*T
+// CHECK:   copy_addr [take] [[ALLOC0]] to [init] %0 : $*T
+// CHECK:   copy_addr [take] [[ALLOC1]] to [init] %1 : $*T
 // CHECK:   dealloc_stack [[ALLOC1]] : $*T
 // CHECK:   dealloc_stack [[ALLOC0]] : $*T
 // CHECK-LABEL: } // end sil function 'f060_testInoutSwap'
@@ -251,8 +251,8 @@ bb3(%phi0 : @owned $T, %phi1 : @owned $T):
 // CHECK:   [[ALLOCB:%.*]] = alloc_stack $SRef<T>
 // CHECK:   [[ALLOCSA:%.*]] = alloc_stack $SRef<T>
 // CHECK:   [[ALLOCSB:%.*]] = alloc_stack $SRef<T>
-// CHECK:   copy_addr [take] %0 to [initialization] [[ALLOCA]] : $*SRef<T>
-// CHECK:   copy_addr [take] %1 to [initialization] [[ALLOCB]] : $*SRef<T>
+// CHECK:   copy_addr [take] %0 to [init] [[ALLOCA]] : $*SRef<T>
+// CHECK:   copy_addr [take] %1 to [init] [[ALLOCB]] : $*SRef<T>
 // CHECK:   cond_br undef, bb2, bb1
 // CHECK: bb1:
 // CHECK:   [[A1OADR:%.*]] = struct_element_addr [[ALLOCA]] : $*SRef<T>, #SRef.object
@@ -264,9 +264,9 @@ bb3(%phi0 : @owned $T, %phi1 : @owned $T):
 // CHECK:   destroy_value [[B1O]] : $AnyObject
 // CHECK:   [[CP1:%.*]] = copy_value [[A1O]] : $AnyObject
 // CHECK:   [[SA1EADR:%.*]] = struct_element_addr [[ALLOCSA]] : $*SRef<T>, #SRef.element
-// CHECK:   copy_addr [take] [[A1EADR]] to [initialization] [[SA1EADR]] : $*T
+// CHECK:   copy_addr [take] [[A1EADR]] to [init] [[SA1EADR]] : $*T
 // CHECK:   [[SB1EADR:%.*]] = struct_element_addr [[ALLOCSB]] : $*SRef<T>, #SRef.element
-// CHECK:   copy_addr [take] [[B1EADR]] to [initialization] [[SB1EADR]] : $*T
+// CHECK:   copy_addr [take] [[B1EADR]] to [init] [[SB1EADR]] : $*T
 // CHECK:   br bb3([[A1O]] : $AnyObject, [[CP1]] : $AnyObject)
 // CHECK: bb2:
 // CHECK:   [[A2OADR:%.*]] = struct_element_addr [[ALLOCA]] : $*SRef<T>, #SRef.object
@@ -278,17 +278,17 @@ bb3(%phi0 : @owned $T, %phi1 : @owned $T):
 // CHECK:   destroy_value [[B2O]] : $AnyObject
 // CHECK:   [[CP2:%.*]] = copy_value [[A2O]] : $AnyObject
 // CHECK:   [[SB2EADR:%.*]] = struct_element_addr [[ALLOCSB]] : $*SRef<T>, #SRef.element
-// CHECK:   copy_addr [take] [[A2EADR]] to [initialization] [[SB2EADR]] : $*T
+// CHECK:   copy_addr [take] [[A2EADR]] to [init] [[SB2EADR]] : $*T
 // CHECK:   [[SA2EADR:%.*]] = struct_element_addr [[ALLOCSA]] : $*SRef<T>, #SRef.element
-// CHECK:   copy_addr [take] [[B2EADR]] to [initialization] [[SA2EADR]] : $*T
+// CHECK:   copy_addr [take] [[B2EADR]] to [init] [[SA2EADR]] : $*T
 // CHECK:   br bb3([[A2O]] : $AnyObject, [[CP2]] : $AnyObject)
 // CHECK: bb3([[PHI0:%.*]] : @owned $AnyObject, [[PHI1:%.*]] : @owned $AnyObject):
 // CHECK:   [[SA3EADR:%.*]] = struct_element_addr [[ALLOCSA]] : $*SRef<T>, #SRef.object
 // CHECK:   store [[PHI0]] to [init] [[SA3EADR]] : $*AnyObject
 // CHECK:   [[SA3EADR:%.*]] = struct_element_addr [[ALLOCSB]] : $*SRef<T>, #SRef.object
 // CHECK:   store [[PHI1]] to [init] [[SA3EADR]] : $*AnyObject
-// CHECK:   copy_addr [take] [[ALLOCSA]] to [initialization] %0 : $*SRef<T>
-// CHECK:   copy_addr [take] [[ALLOCSB]] to [initialization] %1 : $*SRef<T>
+// CHECK:   copy_addr [take] [[ALLOCSA]] to [init] %0 : $*SRef<T>
+// CHECK:   copy_addr [take] [[ALLOCSB]] to [init] %1 : $*SRef<T>
 // CHECK-LABEL: } // end sil function 'f070_testInoutFieldSwap'
 sil [ossa] @f070_testInoutFieldSwap : $@convention(thin) <T> (@inout SRef<T>, @inout SRef<T>) -> () {
 bb0(%0 : $*SRef<T>, %1 : $*SRef<T>):
@@ -326,35 +326,35 @@ bb3(%phio0 : @owned $AnyObject, %phio1 : @owned $AnyObject, %phie0 : @owned $T, 
 // CHECK:   destroy_addr %2 : $*T
 // CHECK:   [[TUPLE1:%.*]] = init_enum_data_addr [[INNER1:%.*]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
 // CHECK:   [[TUPLE1_0:%.*]] = tuple_element_addr [[TUPLE1]] : $*(T, AnyObject), 0
-// CHECK:   copy_addr [take] %1 to [initialization] [[TUPLE1_0]] : $*T
+// CHECK:   copy_addr [take] %1 to [init] [[TUPLE1_0]] : $*T
 // CHECK:   [[TUPLE1_1:%.*]] = tuple_element_addr [[TUPLE1]] : $*(T, AnyObject), 1
 // CHECK:   store %3 to [init] [[TUPLE1_1]] : $*AnyObject
 // CHECK:   inject_enum_addr [[INNER1]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
-// CHECK:   copy_addr [take] [[INNER1]] to [initialization] [[PHI6:%.*]] : $*InnerEnum<T>
+// CHECK:   copy_addr [take] [[INNER1]] to [init] [[PHI6:%.*]] : $*InnerEnum<T>
 // CHECK:   br bb6
 // CHECK: bb2:
 // CHECK:   cond_br undef, bb4, bb3
 // CHECK: bb3:
 // CHECK:   destroy_addr %1 : $*T
-// CHECK:   copy_addr [take] %2 to [initialization] [[PHI5:%.*]] : $*T
+// CHECK:   copy_addr [take] %2 to [init] [[PHI5:%.*]] : $*T
 // CHECK:   br bb5
 // CHECK: bb4:
 // CHECK:   destroy_addr %2 : $*T
-// CHECK:   copy_addr [take] %1 to [initialization] [[PHI5]] : $*T
+// CHECK:   copy_addr [take] %1 to [init] [[PHI5]] : $*T
 // CHECK:   br bb5
 // CHECK: bb5:
 // CHECK:   [[TUPLE5:%.*]] = init_enum_data_addr [[INNER5:%.*]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
 // CHECK:   [[TUPLE5_0:%.*]] = tuple_element_addr [[TUPLE5]] : $*(T, AnyObject), 0
-// CHECK:   copy_addr [take] [[PHI5]] to [initialization] [[TUPLE5_0]] : $*T
+// CHECK:   copy_addr [take] [[PHI5]] to [init] [[TUPLE5_0]] : $*T
 // CHECK:   [[TUPLE5_1:%.*]] = tuple_element_addr [[TUPLE5]] : $*(T, AnyObject), 1
 // CHECK:   store %3 to [init] [[TUPLE5_1]] : $*AnyObject
 // CHECK:   inject_enum_addr [[INNER5]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
-// CHECK:   copy_addr [take] [[INNER5]] to [initialization] [[PHI6:%.*]] : $*InnerEnum<T>
+// CHECK:   copy_addr [take] [[INNER5]] to [init] [[PHI6:%.*]] : $*InnerEnum<T>
 // CHECK:   br bb6
 // CHECK: bb6:
 // CHECK:   [[TUPLE6:%.*]] = init_enum_data_addr %0 : $*OuterEnum<T>, #OuterEnum.inner!enumelt
 // CHECK:   [[TUPLE6_0:%.*]] = tuple_element_addr [[TUPLE6]] : $*(InnerEnum<T>, AnyObject), 0
-// CHECK:   copy_addr [take] [[PHI6]] to [initialization] [[TUPLE6_0]] : $*InnerEnum<T>
+// CHECK:   copy_addr [take] [[PHI6]] to [init] [[TUPLE6_0]] : $*InnerEnum<T>
 // CHECK:   [[TUPLE6_1:%.*]] = tuple_element_addr [[TUPLE6]] : $*(InnerEnum<T>, AnyObject), 1
 // CHECK:   store %4 to [init] [[TUPLE6_1]] : $*AnyObject
 // CHECK:   inject_enum_addr %0 : $*OuterEnum<T>, #OuterEnum.inner!enumelt
@@ -393,7 +393,7 @@ bb6(%phi6 : @owned $InnerEnum<T>):
 // CHECK:   destroy_addr %2 : $*T
 // CHECK:   [[INNER1:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
 // CHECK:   [[T2:%.*]] = struct_element_addr [[INNER1]] : $*InnerStruct<T>, #InnerStruct.t
-// CHECK:   copy_addr [take] %1 to [initialization] [[T2]] : $*T
+// CHECK:   copy_addr [take] %1 to [init] [[T2]] : $*T
 // CHECK:   [[O2:%.*]] = struct_element_addr [[INNER1]] : $*InnerStruct<T>, #InnerStruct.object
 // CHECK:   store %3 to [init] [[O2]] : $*AnyObject
 // CHECK:   br bb6
@@ -403,13 +403,13 @@ bb6(%phi6 : @owned $InnerEnum<T>):
 // CHECK:   destroy_addr %1 : $*T
 // CHECK:   [[INNER3:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
 // CHECK:   [[T3:%.*]] = struct_element_addr [[INNER3]] : $*InnerStruct<T>, #InnerStruct.t
-// CHECK:   copy_addr [take] %2 to [initialization] [[T3]] : $*T
+// CHECK:   copy_addr [take] %2 to [init] [[T3]] : $*T
 // CHECK:   br bb5
 // CHECK: bb4:
 // CHECK:   destroy_addr %2 : $*T
 // CHECK:   [[INNER4:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
 // CHECK:   [[T4:%.*]] = struct_element_addr [[INNER4]] : $*InnerStruct<T>, #InnerStruct.t
-// CHECK:   copy_addr [take] %1 to [initialization] [[T4]] : $*T
+// CHECK:   copy_addr [take] %1 to [init] [[T4]] : $*T
 // CHECK:   br bb5
 // CHECK: bb5:
 // CHECK:   [[INNER5:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
@@ -450,11 +450,11 @@ bb6(%phi6 : @owned $InnerStruct<T>):
 // CHECK: bb1:
 // CHECK:   destroy_addr %2 : $*T
 // CHECK:   [[P:%.*]] = unchecked_take_enum_data_addr %1 : $*Optional<T>, #Optional.some!enumelt
-// CHECK:   copy_addr [take] [[P]] to [initialization] %0 : $*T
+// CHECK:   copy_addr [take] [[P]] to [init] %0 : $*T
 // CHECK:   br bb3
 // CHECK: bb2:
 // CHECK:   destroy_addr %1 : $*Optional<T>
-// CHECK:   copy_addr [take] %2 to [initialization] %0 : $*T
+// CHECK:   copy_addr [take] %2 to [init] %0 : $*T
 // CHECK:   br bb3
 // CHECK-LABEL: } // end sil function 'f090_payloadPhiOperand'
 sil [ossa] @f090_payloadPhiOperand : $@convention(thin) <T> (@in Optional<T>, @in T) -> @out T {

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -191,7 +191,7 @@ bb0(%0 : $*LogicValue, %1 : $@thin Bool.Type):
   %2 = alloc_box ${ var LogicValue }
   %2a = project_box %2 : ${ var LogicValue }, 0
 // CHECK:  %2 = alloc_stack $any LogicValue
-  copy_addr [take] %0 to [initialization] %2a : $*LogicValue
+  copy_addr [take] %0 to [init] %2a : $*LogicValue
   %6 = open_existential_addr mutable_access %2a : $*LogicValue to $*@opened("01234567-89ab-cdef-0123-000000000000", LogicValue) Self
   %7 = witness_method $@opened("01234567-89ab-cdef-0123-000000000000", LogicValue) Self, #LogicValue.getLogicValue, %6 : $*@opened("01234567-89ab-cdef-0123-000000000000", LogicValue) Self : $@convention(witness_method: LogicValue) <T: LogicValue> (@in_guaranteed T) -> Bool
   %8 = apply %7<@opened("01234567-89ab-cdef-0123-000000000000", LogicValue) Self>(%6) : $@convention(witness_method: LogicValue) <T: LogicValue> (@in_guaranteed T) -> Bool
@@ -513,8 +513,8 @@ bb0(%0 : $*T):
   // CHECK: [[STACK:%[0-9a-zA-Z_]+]] = alloc_stack $T
   %4 = alloc_box $<τ_0_0> { var τ_0_0 } <T>
   %4a = project_box %4 : $<τ_0_0> { var τ_0_0 } <T>, 0
-  // CHECK: copy_addr %0 to [initialization] [[STACK]] : $*T
-  copy_addr %0 to [initialization] %4a : $*T
+  // CHECK: copy_addr %0 to [init] [[STACK]] : $*T
+  copy_addr %0 to [init] %4a : $*T
   // CHECK: [[CLOSURE:%[0-9a-zA-Z]+]] = function_ref @$s21closure_to_specializeTf0ns_n
   // CHECK: partial_apply [[CLOSURE]]<T>([[STACK]])
   %6 = partial_apply %3<T>(%4) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
@@ -542,8 +542,8 @@ bb0(%0 : $*T):
   %4 = alloc_box $<τ_0_0> { var τ_0_0 } <T>
   %4a = project_box %4 : $<τ_0_0> { var τ_0_0 } <T>, 0
   strong_retain %4 : $<τ_0_0> { var τ_0_0 } <T>
-  // CHECK: copy_addr %0 to [initialization] [[STACK]] : $*T
-  copy_addr %0 to [initialization] %4a : $*T
+  // CHECK: copy_addr %0 to [init] [[STACK]] : $*T
+  copy_addr %0 to [init] %4a : $*T
   // CHECK: [[CLOSURE:%[0-9a-zA-Z]+]] = function_ref @$s21closure_to_specializeTf0ns_n
   // CHECK: partial_apply [[CLOSURE]]<T>([[STACK]])
   %6 = partial_apply %3<T>(%4) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
@@ -564,7 +564,7 @@ sil private @closure_to_specialize : $@convention(thin) <T where T : P> (@owned 
 bb0(%0 : $*T, %1 : $<τ_0_0> { var τ_0_0 } <T>):
   %2 = project_box %1 : $<τ_0_0> { var τ_0_0 } <T>, 0
   // CHECK-NEXT: copy_addr
-  copy_addr %2 to [initialization] %0 : $*T
+  copy_addr %2 to [init] %0 : $*T
   // CHECK-NOT: strong_release
   strong_release %1 : $<τ_0_0> { var τ_0_0 } <T>
   %5 = tuple ()
@@ -625,7 +625,7 @@ bb0(%0 : $Int, %1 : $*S<Q>):
   %5 = function_ref @closure1 : $@convention(thin) <T where T : Count> (Int, @owned <τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>) -> Bool
   %6 = alloc_box $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <Q>
   %6a = project_box %6 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <Q>, 0
-  copy_addr %1 to [initialization] %6a : $*S<Q>
+  copy_addr %1 to [init] %6a : $*S<Q>
   %8 = partial_apply %5<Q>(%0, %6) : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <τ_0_0>) -> Bool
   %9 = apply %4(%8) : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
   destroy_addr %1 : $*S<Q>
@@ -643,7 +643,7 @@ bb0(%0 : $Int, %1 : $*S<T>):
   %5 = function_ref @closure1 : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <τ_0_0>) -> Bool
   %6 = alloc_box $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>
   %6a = project_box %6 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>, 0
-  copy_addr %1 to [initialization] %6a : $*S<T>
+  copy_addr %1 to [init] %6a : $*S<T>
   %8 = partial_apply %5<T>(%0, %6) : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <τ_0_0>) -> Bool
   %9 = apply %4(%8) : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
   destroy_addr %1 : $*S<T>
@@ -660,7 +660,7 @@ bb0(%0 : $Int, %1 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>):
   %4 = function_ref @closure2 : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <τ_0_0>) -> Bool
   %5 = alloc_box $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>
   %5a = project_box %5 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>, 0
-  copy_addr %2 to [initialization] %5a : $*S<T>
+  copy_addr %2 to [init] %5a : $*S<T>
   %7 = partial_apply %4<T>(%0, %5) : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <τ_0_0>) -> Bool
   %8 = apply %3(%7) : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
   strong_release %1 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>
@@ -680,7 +680,7 @@ bb0(%0 : $Int, %1 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>):
   %2 = project_box %1 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>, 0
   %3 = function_ref @binary : $@convention(thin) (Int, Int) -> Bool
   %4 = alloc_stack $S<T>
-  copy_addr %2 to [initialization] %4 : $*S<T>
+  copy_addr %2 to [init] %4 : $*S<T>
   %6 = function_ref @get : $@convention(method) <τ_0_0 where τ_0_0 : Count> (@in S<τ_0_0>) -> Int
   %7 = apply %6<T>(%4) : $@convention(method) <τ_0_0 where τ_0_0 : Count> (@in S<τ_0_0>) -> Int
   %8 = apply %3(%0, %7) : $@convention(thin) (Int, Int) -> Bool
@@ -698,12 +698,12 @@ sil @destroy_stack_value_after_closure : $@convention(thin) <T> (@in T) -> @out 
 // CHECK: bb0
 bb0(%0 : $*T, %1 : $*T):
   // CHECK: [[STACK:%.*]] = alloc_stack
-  // CHECK: copy_addr %1 to [initialization] [[STACK]]
+  // CHECK: copy_addr %1 to [init] [[STACK]]
   // CHECK: [[APPLIED:%.*]] = function_ref
   %3 = function_ref @applied : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> ()
   %4 = alloc_box $<τ_0_0> { var τ_0_0 } <T>
   %4a = project_box %4 : $<τ_0_0> { var τ_0_0 } <T>, 0
-  copy_addr %1 to [initialization] %4a : $*T
+  copy_addr %1 to [init] %4a : $*T
   // CHECK: [[PARTIAL:%.*]] = partial_apply [[APPLIED]]<T>([[STACK]])
   %6 = partial_apply %3<T>(%4) : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> ()
   // CHECK: debug_value [[PARTIAL]]
@@ -712,7 +712,7 @@ bb0(%0 : $*T, %1 : $*T):
   strong_retain %6 : $@callee_owned () -> ()
   // CHECK: apply [[PARTIAL]]
   %9 = apply %6() : $@callee_owned () -> ()
-  copy_addr %1 to [initialization] %0 : $*T
+  copy_addr %1 to [init] %0 : $*T
   // CHECK: strong_release [[PARTIAL]]
   strong_release %6 : $@callee_owned () -> ()
   // CHECK: destroy_addr [[STACK]]
@@ -727,7 +727,7 @@ bb0(%0 : $<τ_0_0> { var τ_0_0 } <T>):
   %1 = project_box %0 : $<τ_0_0> { var τ_0_0 } <T>, 0
   %2 = function_ref @consume : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   %3 = alloc_stack $T
-  copy_addr %1 to [initialization] %3 : $*T
+  copy_addr %1 to [init] %3 : $*T
   %5 = apply %2<T>(%3) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   dealloc_stack %3 : $*T
   strong_release %0 : $<τ_0_0> { var τ_0_0 } <T>

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -188,7 +188,7 @@ bb0(%0 : $*LogicValue, %1 : $@thin Bool.Type):
   %2 = alloc_box ${ var LogicValue }
   %2a = project_box %2 : ${ var LogicValue }, 0
 // CHECK:  %2 = alloc_stack $any LogicValue
-  copy_addr [take] %0 to [initialization] %2a : $*LogicValue
+  copy_addr [take] %0 to [init] %2a : $*LogicValue
   %6 = open_existential_addr mutable_access %2a : $*LogicValue to $*@opened("01234567-89ab-cdef-0123-000000000000", LogicValue) Self
   %7 = witness_method $@opened("01234567-89ab-cdef-0123-000000000000", LogicValue) Self, #LogicValue.getLogicValue, %6 : $*@opened("01234567-89ab-cdef-0123-000000000000", LogicValue) Self : $@convention(witness_method: LogicValue) <T: LogicValue> (@in_guaranteed T) -> Bool
   %8 = apply %7<@opened("01234567-89ab-cdef-0123-000000000000", LogicValue) Self>(%6) : $@convention(witness_method: LogicValue) <T: LogicValue> (@in_guaranteed T) -> Bool
@@ -549,8 +549,8 @@ bb0(%0 : $*T):
   // CHECK: [[STACK:%[0-9a-zA-Z_]+]] = alloc_stack $T
   %4 = alloc_box $<τ_0_0> { var τ_0_0 } <T>
   %4a = project_box %4 : $<τ_0_0> { var τ_0_0 } <T>, 0
-  // CHECK: copy_addr %0 to [initialization] [[STACK]] : $*T
-  copy_addr %0 to [initialization] %4a : $*T
+  // CHECK: copy_addr %0 to [init] [[STACK]] : $*T
+  copy_addr %0 to [init] %4a : $*T
   // CHECK: [[CLOSURE:%[0-9a-zA-Z]+]] = function_ref @$s21closure_to_specializeTf0ns_n
   // CHECK: partial_apply [[CLOSURE]]<T>([[STACK]])
   %6 = partial_apply %3<T>(%4) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
@@ -577,8 +577,8 @@ bb0(%0 : $*T):
   %4 = alloc_box $<τ_0_0> { var τ_0_0 } <T>
   %4a = project_box %4 : $<τ_0_0> { var τ_0_0 } <T>, 0
   %4copy = copy_value %4 : $<τ_0_0> { var τ_0_0 } <T>
-  // CHECK: copy_addr %0 to [initialization] [[STACK]] : $*T
-  copy_addr %0 to [initialization] %4a : $*T
+  // CHECK: copy_addr %0 to [init] [[STACK]] : $*T
+  copy_addr %0 to [init] %4a : $*T
   // CHECK: [[CLOSURE:%[0-9a-zA-Z]+]] = function_ref @$s21closure_to_specializeTf0ns_n
   // CHECK: partial_apply [[CLOSURE]]<T>([[STACK]])
   %6 = partial_apply %3<T>(%4copy) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
@@ -609,8 +609,8 @@ bb0(%0 : $*T):
   %4c = mark_uninitialized [var] %4 : $<τ_0_0> { var τ_0_0 } <T>
   %4a = project_box %4c : $<τ_0_0> { var τ_0_0 } <T>, 0
   %4copy = copy_value %4c : $<τ_0_0> { var τ_0_0 } <T>
-  // CHECK: copy_addr %0 to [initialization] [[STACK]] : $*T
-  copy_addr %0 to [initialization] %4a : $*T
+  // CHECK: copy_addr %0 to [init] [[STACK]] : $*T
+  copy_addr %0 to [init] %4a : $*T
   // CHECK: [[CLOSURE:%[0-9a-zA-Z]+]] = function_ref @$s21closure_to_specializeTf0ns_n
   // CHECK: partial_apply [[CLOSURE]]<T>([[STACK]])
   %6 = partial_apply %3<T>(%4copy) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
@@ -632,7 +632,7 @@ sil shared [ossa] @closure_to_specialize : $@convention(thin) <T where T : P> (@
 bb0(%0 : $*T, %1 : @owned $<τ_0_0> { var τ_0_0 } <T>):
   %2 = project_box %1 : $<τ_0_0> { var τ_0_0 } <T>, 0
   // CHECK-NEXT: copy_addr
-  copy_addr %2 to [initialization] %0 : $*T
+  copy_addr %2 to [init] %0 : $*T
   // CHECK-NOT: destroy_value
   destroy_value %1 : $<τ_0_0> { var τ_0_0 } <T>
   %5 = tuple ()
@@ -693,7 +693,7 @@ bb0(%0 : $Int, %1 : $*S<Q>):
   %5 = function_ref @closure1 : $@convention(thin) <T where T : Count> (Int, @owned <τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>) -> Bool
   %6 = alloc_box $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <Q>
   %6a = project_box %6 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <Q>, 0
-  copy_addr %1 to [initialization] %6a : $*S<Q>
+  copy_addr %1 to [init] %6a : $*S<Q>
   %8 = partial_apply %5<Q>(%0, %6) : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <τ_0_0>) -> Bool
   %9 = apply %4(%8) : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
   destroy_addr %1 : $*S<Q>
@@ -711,7 +711,7 @@ bb0(%0 : $Int, %1 : $*S<T>):
   %5 = function_ref @closure1 : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <τ_0_0>) -> Bool
   %6 = alloc_box $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>
   %6a = project_box %6 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>, 0
-  copy_addr %1 to [initialization] %6a : $*S<T>
+  copy_addr %1 to [init] %6a : $*S<T>
   %8 = partial_apply %5<T>(%0, %6) : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <τ_0_0>) -> Bool
   %9 = apply %4(%8) : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
   destroy_addr %1 : $*S<T>
@@ -728,7 +728,7 @@ bb0(%0 : $Int, %1 : @owned $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>)
   %4 = function_ref @closure2 : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <τ_0_0>) -> Bool
   %5 = alloc_box $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>
   %5a = project_box %5 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>, 0
-  copy_addr %2 to [initialization] %5a : $*S<T>
+  copy_addr %2 to [init] %5a : $*S<T>
   %7 = partial_apply %4<T>(%0, %5) : $@convention(thin) <τ_0_0 where τ_0_0 : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <τ_0_0>) -> Bool
   %8 = apply %3(%7) : $@convention(thin) (@owned @callee_owned () -> Bool) -> Bool
   destroy_value %1 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>
@@ -748,13 +748,13 @@ bb0(%0 : $Int, %1 : @owned $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>)
   %2 = project_box %1 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>, 0
   %3 = function_ref @binary : $@convention(thin) (Int, Int) -> Bool
   %4 = alloc_stack $S<T>
-  copy_addr %2 to [initialization] %4 : $*S<T>
+  copy_addr %2 to [init] %4 : $*S<T>
   %6 = function_ref @get : $@convention(method) <τ_0_0 where τ_0_0 : Count> (@in S<τ_0_0>) -> Int
   %7 = apply %6<T>(%4) : $@convention(method) <τ_0_0 where τ_0_0 : Count> (@in S<τ_0_0>) -> Int
   %8 = apply %3(%0, %7) : $@convention(thin) (Int, Int) -> Bool
   %9 = copy_value %1 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>
   %10 = project_box %9 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>, 0
-  copy_addr %10 to [initialization] %4 : $*S<T>
+  copy_addr %10 to [init] %4 : $*S<T>
   destroy_value %9 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>
   destroy_addr %4 : $*S<T>
   dealloc_stack %4 : $*S<T>
@@ -771,12 +771,12 @@ sil [ossa] @destroy_stack_value_after_closure : $@convention(thin) <T> (@in T) -
 // CHECK: bb0
 bb0(%0 : $*T, %1 : $*T):
   // CHECK: [[STACK:%.*]] = alloc_stack
-  // CHECK: copy_addr %1 to [initialization] [[STACK]]
+  // CHECK: copy_addr %1 to [init] [[STACK]]
   // CHECK: [[APPLIED:%.*]] = function_ref
   %3 = function_ref @applied : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> ()
   %4 = alloc_box $<τ_0_0> { var τ_0_0 } <T>
   %4a = project_box %4 : $<τ_0_0> { var τ_0_0 } <T>, 0
-  copy_addr %1 to [initialization] %4a : $*T
+  copy_addr %1 to [init] %4a : $*T
   // CHECK: [[PARTIAL:%.*]] = partial_apply [[APPLIED]]<T>([[STACK]])
   %6 = partial_apply %3<T>(%4) : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> ()
   // CHECK: debug_value [[PARTIAL]]
@@ -785,7 +785,7 @@ bb0(%0 : $*T, %1 : $*T):
   %7 = copy_value %6 : $@callee_owned () -> ()
   // CHECK: apply [[COPIED_PARTIAL]]() : $@callee_owned () -> ()
   %9 = apply %7() : $@callee_owned () -> ()
-  copy_addr %1 to [initialization] %0 : $*T
+  copy_addr %1 to [init] %0 : $*T
   // CHECK: destroy_value [[PARTIAL]]
   destroy_value %6 : $@callee_owned () -> ()
   // CHECK: destroy_addr [[STACK]]
@@ -800,7 +800,7 @@ bb0(%0 : @owned $<τ_0_0> { var τ_0_0 } <T>):
   %1 = project_box %0 : $<τ_0_0> { var τ_0_0 } <T>, 0
   %2 = function_ref @consume : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   %3 = alloc_stack $T
-  copy_addr %1 to [initialization] %3 : $*T
+  copy_addr %1 to [init] %3 : $*T
   %5 = apply %2<T>(%3) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   dealloc_stack %3 : $*T
   destroy_value %0 : $<τ_0_0> { var τ_0_0 } <T>
@@ -1102,12 +1102,12 @@ bb2:
 // CHECK-LABEL: sil [ossa] @deinit_access : $@convention(thin) <T> (@in T) -> (@out T, @out T) {
 // CHECK: bb0(%0 : $*T, %1 : $*T, %2 : $*T):
 // CHECK: [[STK:%.*]] = alloc_stack $T, var, name "x"
-// CHECK: copy_addr %2 to [initialization] [[STK]] : $*T
+// CHECK: copy_addr %2 to [init] [[STK]] : $*T
 // CHECK: [[READ:%.*]] = begin_access [read] [static] [[STK]] : $*T
-// CHECK: copy_addr [[READ]] to [initialization] %0 : $*T
+// CHECK: copy_addr [[READ]] to [init] %0 : $*T
 // CHECK: end_access [[READ]] : $*T
 // CHECK: [[READ:%.*]] = begin_access [deinit] [static] [[STK]] : $*T
-// CHECK: copy_addr [take] [[READ]] to [initialization] %1 : $*T
+// CHECK: copy_addr [take] [[READ]] to [init] %1 : $*T
 // CHECK: end_access [[READ]] : $*T
 // CHECK-NOT: destroy_addr
 // CHECK: dealloc_stack [[STK]] : $*T
@@ -1118,12 +1118,12 @@ sil [ossa] @deinit_access : $@convention(thin) <T> (@in T) -> (@out T, @out T) {
 bb0(%0 : $*T, %1 : $*T, %2 : $*T):
   %4 = alloc_box $<τ_0_0> { var τ_0_0 } <T>, var, name "x"
   %5 = project_box %4 : $<τ_0_0> { var τ_0_0 } <T>, 0
-  copy_addr %2 to [initialization] %5 : $*T
+  copy_addr %2 to [init] %5 : $*T
   %7 = begin_access [read] [static] %5 : $*T
-  copy_addr %7 to [initialization] %0 : $*T
+  copy_addr %7 to [init] %0 : $*T
   end_access %7 : $*T
   %10 = begin_access [read] [static] %5 : $*T
-  copy_addr %10 to [initialization] %1 : $*T
+  copy_addr %10 to [init] %1 : $*T
   end_access %10 : $*T
   destroy_value %4 : $<τ_0_0> { var τ_0_0 } <T>
   destroy_addr %2 : $*T
@@ -1139,14 +1139,14 @@ bb0(%0 : $*T, %1 : $*T, %2 : $*T):
 // CHECK-LABEL: sil [ossa] @nodeinit_access : $@convention(thin) <T> (@in T) -> (@out T, @out T) {
 // CHECK: bb0(%0 : $*T, %1 : $*T, %2 : $*T):
 // CHECK: [[STK:%.*]] = alloc_stack $T, var, name "x"
-// CHECK: copy_addr %2 to [initialization] [[STK]] : $*T
+// CHECK: copy_addr %2 to [init] [[STK]] : $*T
 // CHECK: [[READ:%.*]] = begin_access [read] [static] [[STK]] : $*T
-// CHECK: copy_addr [[READ]] to [initialization] %0 : $*T
+// CHECK: copy_addr [[READ]] to [init] %0 : $*T
 // CHECK: end_access [[READ]] : $*T
 // CHECK: [[READ:%.*]] = begin_access [read] [static] [[STK]] : $*T
 // CHECK: [[INNER:%.*]] = begin_access [read] [static] [[READ]] : $*T
 // CHECK: end_access [[INNER]] : $*T
-// CHECK: copy_addr [[READ]] to [initialization] %1 : $*T
+// CHECK: copy_addr [[READ]] to [init] %1 : $*T
 // CHECK: end_access [[READ]] : $*T
 // CHECK: destroy_addr [[STK]] : $*T
 // CHECK: dealloc_stack [[STK]] : $*T
@@ -1157,14 +1157,14 @@ sil [ossa] @nodeinit_access : $@convention(thin) <T> (@in T) -> (@out T, @out T)
 bb0(%0 : $*T, %1 : $*T, %2 : $*T):
   %4 = alloc_box $<τ_0_0> { var τ_0_0 } <T>, var, name "x"
   %5 = project_box %4 : $<τ_0_0> { var τ_0_0 } <T>, 0
-  copy_addr %2 to [initialization] %5 : $*T
+  copy_addr %2 to [init] %5 : $*T
   %7 = begin_access [read] [static] %5 : $*T
-  copy_addr %7 to [initialization] %0 : $*T
+  copy_addr %7 to [init] %0 : $*T
   end_access %7 : $*T
   %10 = begin_access [read] [static] %5 : $*T
   %innerAccess = begin_access [read] [static] %10 : $*T
   end_access %innerAccess : $*T
-  copy_addr %10 to [initialization] %1 : $*T
+  copy_addr %10 to [init] %1 : $*T
   end_access %10 : $*T
   destroy_value %4 : $<τ_0_0> { var τ_0_0 } <T>
   destroy_addr %2 : $*T

--- a/test/SILOptimizer/allocbox_to_stack_ownership_attrs.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership_attrs.sil
@@ -14,7 +14,7 @@ bb0(%0 : $*T):
   %4c = mark_uninitialized [var] %4 : $<τ_0_0> { var τ_0_0 } <T>
   %4a = project_box %4c : $<τ_0_0> { var τ_0_0 } <T>, 0
   %4copy = copy_value %4c : $<τ_0_0> { var τ_0_0 } <T>
-  copy_addr %0 to [initialization] %4a : $*T
+  copy_addr %0 to [init] %4a : $*T
   %6 = partial_apply %3<T>(%4copy) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
   %7 = apply %2<T>(%6) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@owned @callee_owned () -> @out τ_0_0) -> ()
   destroy_addr %0 : $*T
@@ -29,7 +29,7 @@ bb0(%0 : $*T):
 sil shared [ossa] @closure_to_specialize : $@convention(thin) <T where T : P> (@owned <τ_0_0> { var τ_0_0 } <T>) -> @out T {
 bb0(%0 : @_eagerMove $*T, %1 : @_eagerMove @owned $<τ_0_0> { var τ_0_0 } <T>):
   %2 = project_box %1 : $<τ_0_0> { var τ_0_0 } <T>, 0
-  copy_addr %2 to [initialization] %0 : $*T
+  copy_addr %2 to [init] %0 : $*T
   destroy_value %1 : $<τ_0_0> { var τ_0_0 } <T>
   %5 = tuple ()
   return %5 : $()

--- a/test/SILOptimizer/allocstack_hoisting.sil
+++ b/test/SILOptimizer/allocstack_hoisting.sil
@@ -33,7 +33,7 @@ bb0(%0 : $*T, %1: $Builtin.Int1):
   cond_br %1, bb1, bb2
 bb1:
   %2 = alloc_stack $T
-  copy_addr [take] %0 to [initialization] %2 : $*T
+  copy_addr [take] %0 to [init] %2 : $*T
   destroy_addr %2 : $*T
   dealloc_stack %2 : $*T
   br bb3
@@ -68,7 +68,7 @@ bb0(%0 : $*T, %1: $Builtin.Int1):
   cond_br %1, bb1, bb2
 bb1:
   %2 = alloc_stack $T
-  copy_addr [take] %0 to [initialization] %2 : $*T
+  copy_addr [take] %0 to [init] %2 : $*T
   destroy_addr %2 : $*T
   dealloc_stack %2 : $*T
   br bb3
@@ -103,7 +103,7 @@ bb0(%0 : $*Generic<T>, %1: $Builtin.Int1):
   cond_br %1, bb1, bb2
 bb1:
   %2 = alloc_stack $Generic<T>
-  copy_addr [take] %0 to [initialization] %2 : $*Generic<T>
+  copy_addr [take] %0 to [init] %2 : $*Generic<T>
   destroy_addr %2 : $*Generic<T>
   dealloc_stack %2 : $*Generic<T>
   br bb3
@@ -137,7 +137,7 @@ bb0(%0 : $*T, %1: $Builtin.Int1):
 bb1:
   %3 = alloc_stack $T
   %4 = alloc_stack $T
-  copy_addr [take] %0 to [initialization] %3 : $*T
+  copy_addr [take] %0 to [init] %3 : $*T
   destroy_addr %3 : $*T
   dealloc_stack %4: $*T
   dealloc_stack %3 : $*T
@@ -167,7 +167,7 @@ bb0(%0 : $*P, %1: $Builtin.Int1):
 bb1:
   %2 = open_existential_addr mutable_access %0 : $*P to $*@opened("1B6851A6-4796-11E6-B7DF-B8E856428C60", P) Self
   %3 = alloc_stack $@opened("1B6851A6-4796-11E6-B7DF-B8E856428C60", P) Self
-	copy_addr [take] %2 to [initialization] %3 : $*@opened("1B6851A6-4796-11E6-B7DF-B8E856428C60", P) Self
+	copy_addr [take] %2 to [init] %3 : $*@opened("1B6851A6-4796-11E6-B7DF-B8E856428C60", P) Self
   destroy_addr %3 : $*@opened("1B6851A6-4796-11E6-B7DF-B8E856428C60", P) Self
   dealloc_stack %3 : $*@opened("1B6851A6-4796-11E6-B7DF-B8E856428C60", P) Self
   br bb3
@@ -194,7 +194,7 @@ bb0(%0 : $*P, %1: $Builtin.Int1):
   cond_br %1, bb1, bb2
 bb1:
   %2 = alloc_stack $P
-	copy_addr [take] %0 to [initialization] %2 : $*P
+	copy_addr [take] %0 to [init] %2 : $*P
   destroy_addr %2 : $*P
   dealloc_stack %2 : $*P
   br bb3
@@ -220,7 +220,7 @@ bb0(%0 : $*T, %1: $Builtin.Int1):
   cond_br %1, bb1, bb2
 bb1:
   %2 = alloc_stack $T
-  copy_addr [take] %0 to [initialization] %2 : $*T
+  copy_addr [take] %0 to [init] %2 : $*T
   destroy_addr %2 : $*T
   br bb3
 bb2:
@@ -245,7 +245,7 @@ bb0(%0 : $*T, %1: $Builtin.Int1):
   cond_br %8, bb1, bb2
 bb1:
   %2 = alloc_stack $T
-  copy_addr [take] %0 to [initialization] %2 : $*T
+  copy_addr [take] %0 to [init] %2 : $*T
   destroy_addr %2 : $*T
   dealloc_stack %2 : $*T
   br bb3

--- a/test/SILOptimizer/allocstack_hoisting_debuginfo.sil
+++ b/test/SILOptimizer/allocstack_hoisting_debuginfo.sil
@@ -27,7 +27,7 @@ bb0(%0 : $*T, %1: $Builtin.Int1):
 
 bb1:
   %2 = alloc_stack [moved] $T, let, name "x"
-  copy_addr [take] %0 to [initialization] %2 : $*T
+  copy_addr [take] %0 to [init] %2 : $*T
   destroy_addr %2 : $*T
   dealloc_stack %2 : $*T
   br bb3
@@ -53,7 +53,7 @@ bb3:
 // CHECK-NEXT:   br bb3
 //
 // CHECK: bb3:
-// CHECK-NEXT:   copy_addr [[ARG]] to [initialization] [[STACK]]
+// CHECK-NEXT:   copy_addr [[ARG]] to [init] [[STACK]]
 // CHECK-NEXT:   destroy_addr [[STACK]]
 // CHECK-NEXT:   destroy_addr [[ARG]]
 // CHECK-NEXT:   br bb5
@@ -76,11 +76,11 @@ bb0(%0 : $*T, %1: $Builtin.Int1):
 
 bb1:
   %2 = alloc_stack [moved] $T, let, name "x"
-  copy_addr %0 to [initialization] %2 : $*T
+  copy_addr %0 to [init] %2 : $*T
   destroy_addr %2 : $*T
   dealloc_stack %2 : $*T
   %3 = alloc_stack [moved] $T, let, name "y"
-  copy_addr %0 to [initialization] %3 : $*T
+  copy_addr %0 to [init] %3 : $*T
   destroy_addr %3 : $*T
   dealloc_stack %3 : $*T
   destroy_addr %0 : $*T
@@ -112,11 +112,11 @@ bb0(%0 : $*T, %1: $Builtin.Int1):
 
 bb1:
   %2 = alloc_stack $T, let, name "x"
-  copy_addr %0 to [initialization] %2 : $*T
+  copy_addr %0 to [init] %2 : $*T
   destroy_addr %2 : $*T
   dealloc_stack %2 : $*T
   %3 = alloc_stack $T, let, name "y"
-  copy_addr %0 to [initialization] %3 : $*T
+  copy_addr %0 to [init] %3 : $*T
   destroy_addr %3 : $*T
   dealloc_stack %3 : $*T
   destroy_addr %0 : $*T
@@ -152,7 +152,7 @@ bb4:
 // CHECK-NEXT:   br bb3
 //
 // CHECK: bb3:
-// CHECK-NEXT:   copy_addr [[ARG]] to [initialization] [[STACK]]
+// CHECK-NEXT:   copy_addr [[ARG]] to [init] [[STACK]]
 // CHECK-NEXT:   destroy_addr [[STACK]]
 // CHECK-NEXT:   destroy_addr [[ARG]]
 // CHECK-NEXT:   br bb5
@@ -175,11 +175,11 @@ bb0(%0 : $*T, %1: $Builtin.Int1):
 
 bb1:
   %2 = alloc_stack $T, let, name "x"
-  copy_addr %0 to [initialization] %2 : $*T
+  copy_addr %0 to [init] %2 : $*T
   destroy_addr %2 : $*T
   dealloc_stack %2 : $*T
   %3 = alloc_stack [moved] $T, let, name "y"
-  copy_addr %0 to [initialization] %3 : $*T
+  copy_addr %0 to [init] %3 : $*T
   destroy_addr %3 : $*T
   dealloc_stack %3 : $*T
   destroy_addr %0 : $*T
@@ -211,7 +211,7 @@ bb4:
 // CHECK-NEXT:   br bb3
 //
 // CHECK: bb3:
-// CHECK-NEXT:   copy_addr [[ARG]] to [initialization] [[STACK]]
+// CHECK-NEXT:   copy_addr [[ARG]] to [init] [[STACK]]
 // CHECK-NEXT:   destroy_addr [[STACK]]
 // CHECK-NEXT:   destroy_addr [[ARG]]
 // CHECK-NEXT:   br bb5
@@ -234,11 +234,11 @@ bb0(%0 : $*T, %1: $Builtin.Int1):
 
 bb1:
   %2 = alloc_stack [moved] $T, let, name "x"
-  copy_addr %0 to [initialization] %2 : $*T
+  copy_addr %0 to [init] %2 : $*T
   destroy_addr %2 : $*T
   dealloc_stack %2 : $*T
   %3 = alloc_stack $T, let, name "y"
-  copy_addr %0 to [initialization] %3 : $*T
+  copy_addr %0 to [init] %3 : $*T
   destroy_addr %3 : $*T
   dealloc_stack %3 : $*T
   destroy_addr %0 : $*T

--- a/test/SILOptimizer/bridged_casts_folding.swift
+++ b/test/SILOptimizer/bridged_casts_folding.swift
@@ -906,7 +906,7 @@ var anyHashable: AnyHashable = 0
 // CHECK: [[GLOBAL:%[0-9]+]] = global_addr @$s21bridged_casts_folding11anyHashables03AnyE0Vv
 // CHECK: [[TMP:%[0-9]+]] = alloc_stack $AnyHashable
 // CHECK: [[ACCESS:%[0-9]+]] = begin_access [read] [static] [no_nested_conflict] [[GLOBAL]]
-// CHECK: copy_addr [[ACCESS]] to [initialization] [[TMP]]
+// CHECK: copy_addr [[ACCESS]] to [init] [[TMP]]
 // CHECK: [[FUNC:%.*]] = function_ref @$ss11AnyHashableV10FoundationE19_bridgeToObjectiveCSo8NSObjectCyF
 // CHECK-NEXT: apply [[FUNC]]([[TMP]])
 // CHECK-NEXT: destroy_addr [[TMP]]
@@ -937,7 +937,7 @@ class MyThing: Hashable {
 
 // CHECK-LABEL: sil hidden [noinline] @$s21bridged_casts_folding26doSomethingWithAnyHashableyys0gH0VF : $@convention(thin) (@in_guaranteed AnyHashable) -> () {
 // CHECK: %2 = alloc_stack $AnyHashable
-// CHECK: copy_addr %0 to [initialization] %2 : $*AnyHashable
+// CHECK: copy_addr %0 to [init] %2 : $*AnyHashable
 // CHECK: checked_cast_addr_br take_always AnyHashable in %2 : $*AnyHashable to MyThing
 @inline(never)
 func doSomethingWithAnyHashable(_ item: AnyHashable) {

--- a/test/SILOptimizer/canonicalize_switch_enum.sil
+++ b/test/SILOptimizer/canonicalize_switch_enum.sil
@@ -47,7 +47,7 @@ bb4(%8 : $Builtin.Int32):
 sil @test_switch_enum_addr : $@convention(thin) <T> (@in GenE<T>) -> Int32 {
 bb0(%0 : $*GenE<T>):
   %1 = alloc_stack $GenE<T>
-  copy_addr %0 to [initialization] %1 : $*GenE<T>
+  copy_addr %0 to [init] %1 : $*GenE<T>
   // CHECK: switch_enum_addr %1 : $*GenE<T>, case #GenE.A!enumelt: bb1, case #GenE.B!enumelt: bb2, case #GenE.C!enumelt: bb3
   switch_enum_addr %1 : $*GenE<T>, case #GenE.A!enumelt: bb1, case #GenE.B!enumelt: bb2, default bb3
 

--- a/test/SILOptimizer/capture_promotion_generic_context.sil
+++ b/test/SILOptimizer/capture_promotion_generic_context.sil
@@ -119,7 +119,7 @@ entry(%0 : $*R<T>, %1 : $*E<(R<U>)->Int>, %2 : $*Int):
   %f = function_ref @generic_promotable_box2 : $@convention(thin) <V> (@in_guaranteed R<V>, @in_guaranteed Int, @guaranteed <τ_0_0> { var E<(R<τ_0_0>)->Int> } <V>) -> @out Int
   %b = alloc_box $<τ_0_0> { var E<(R<τ_0_0>)->Int> } <U>
   %a = project_box %b : $<τ_0_0> { var E<(R<τ_0_0>)->Int> } <U>, 0
-  copy_addr %1 to [initialization] %a : $*E<(R<U>)->Int>
+  copy_addr %1 to [init] %a : $*E<(R<U>)->Int>
   %k = partial_apply [callee_guaranteed] %f<U>(%2, %b) : $@convention(thin) <V> (@in_guaranteed R<V>, @in_guaranteed Int, @guaranteed <τ_0_0> { var E<(R<τ_0_0>)->Int> } <V>) -> @out Int
   return %k : $@callee_guaranteed (@in_guaranteed R<U>) -> @out Int
 }

--- a/test/SILOptimizer/capture_promotion_generic_context_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_generic_context_ownership.sil
@@ -125,7 +125,7 @@ entry(%0 : $*R<T>, %1 : $*E<(R<U>)->Int>, %2 : $*Int):
   %f = function_ref @generic_promotable_box2 : $@convention(thin) <V> (@in R<V>, @in Int, @owned <τ_0_0> { var E<(R<τ_0_0>)->Int> } <V>) -> ()
   %b = alloc_box $<τ_0_0> { var E<(R<τ_0_0>)->Int> } <U>
   %a = project_box %b : $<τ_0_0> { var E<(R<τ_0_0>)->Int> } <U>, 0
-  copy_addr [take] %1 to [initialization] %a : $*E<(R<U>)->Int>
+  copy_addr [take] %1 to [init] %a : $*E<(R<U>)->Int>
   %k = partial_apply [callee_guaranteed] %f<U>(%2, %b) : $@convention(thin) <V> (@in R<V>, @in Int, @owned <τ_0_0> { var E<(R<τ_0_0>)->Int> } <V>) -> ()
   return %k : $@callee_guaranteed (@in R<U>) -> ()
 }

--- a/test/SILOptimizer/capture_promotion_ownership.sil
+++ b/test/SILOptimizer/capture_promotion_ownership.sil
@@ -272,10 +272,10 @@ sil [ossa] @captureWithinGeneric : $@convention(thin) <T> (@inout Int, @inout In
 bb0(%0 : $*Int, %1 : $*Int):
   %2 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <Int>, 0
-  copy_addr %0 to [initialization] %2a : $*Int
+  copy_addr %0 to [init] %2a : $*Int
   %4 = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %4a = project_box %4 : $<τ_0_0> { var τ_0_0 } <Int>, 0
-  copy_addr %1 to [initialization] %4a : $*Int
+  copy_addr %1 to [init] %4a : $*Int
   %6 = function_ref @apply : $@convention(thin) (@owned @callee_owned () -> ()) -> ()
   // CHECK: [[PROMOTED:%[0-9a-zA-Z]+]] = function_ref @$s27closureWithGenericSignatureTf2ni_n : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <Int>, Int) -> ()
   %7 = function_ref @closureWithGenericSignature : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <Int>, @owned <τ_0_0> { var τ_0_0 } <Int>) -> ()

--- a/test/SILOptimizer/capture_promotion_resilient.sil
+++ b/test/SILOptimizer/capture_promotion_resilient.sil
@@ -27,7 +27,7 @@ bb0(%0 : @guaranteed $<τ_0_0> { var τ_0_0 } <ResilientStruct>):
 // CHECK:   [[BOX:%.*]] = alloc_box $<τ_0_0> { var τ_0_0 } <ResilientStruct>
 // CHECK:   [[F1:%.*]] = project_box [[BOX]]
 // CHECK:   [[F2:%.*]] = project_box [[BOX]]
-// CHECK:   copy_addr [[ARG]] to [initialization] [[F2]] : $*ResilientStruct
+// CHECK:   copy_addr [[ARG]] to [init] [[F2]] : $*ResilientStruct
 // CHECK:   [[F:%.*]] = function_ref @$s8closure0Tf2i_n : $@convention(thin) (ResilientStruct) -> () // user: %8
 // CHECK:   [[R:%.*]] = load [trivial] [[F1]] : $*ResilientStruct
 // CHECK:   [[C:%.*]] = partial_apply [callee_guaranteed] [[F]]([[R]])
@@ -37,7 +37,7 @@ sil [ossa] @test_capture_promotion : $@convention(thin) (@in_guaranteed Resilien
 bb0(%0 : $*ResilientStruct):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <ResilientStruct>
   %2 = project_box %1 : $<τ_0_0> { var τ_0_0 } <ResilientStruct>, 0
-  copy_addr %0 to [initialization] %2 : $*ResilientStruct
+  copy_addr %0 to [init] %2 : $*ResilientStruct
   %4 = function_ref @closure0 : $@convention(thin) (@guaranteed <τ_0_0> { var τ_0_0 } <ResilientStruct>) -> ()
   %5 = partial_apply [callee_guaranteed] %4(%1) : $@convention(thin) (@guaranteed <τ_0_0> { var τ_0_0 } <ResilientStruct>) -> ()
   return %5 : $@callee_guaranteed () -> ()
@@ -52,7 +52,7 @@ sil [serialized] [ossa] @test_capture_promotion_2 : $@convention(thin) (@in_guar
 bb0(%0 : $*ResilientStruct):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <ResilientStruct>
   %2 = project_box %1 : $<τ_0_0> { var τ_0_0 } <ResilientStruct>, 0
-  copy_addr %0 to [initialization] %2 : $*ResilientStruct
+  copy_addr %0 to [init] %2 : $*ResilientStruct
   %4 = function_ref @closure0 : $@convention(thin) (@guaranteed <τ_0_0> { var τ_0_0 } <ResilientStruct>) -> ()
   %5 = partial_apply [callee_guaranteed] %4(%1) : $@convention(thin) (@guaranteed <τ_0_0> { var τ_0_0 } <ResilientStruct>) -> ()
   return %5 : $@callee_guaranteed () -> ()

--- a/test/SILOptimizer/cast_folding_no_bridging.sil
+++ b/test/SILOptimizer/cast_folding_no_bridging.sil
@@ -23,7 +23,7 @@ import Foundation
 sil @testSwiftToSwift : $@convention(thin) (@in Set<Int>, @guaranteed Set<Int>) -> @owned Set<Int> {
 bb0(%0 : $*Set<Int>, %1 : $Set<Int>):
   %3 = alloc_stack $Set<Int>
-  copy_addr %0 to [initialization] %3 : $*Set<Int>
+  copy_addr %0 to [init] %3 : $*Set<Int>
   %5 = alloc_stack $Set<Int>
   checked_cast_addr_br take_always Set<Int> in %3 : $*Set<Int> to Set<Int> in %5 : $*Set<Int>, bb1, bb3
 

--- a/test/SILOptimizer/cast_optimizer_conditional_conformance.sil
+++ b/test/SILOptimizer/cast_optimizer_conditional_conformance.sil
@@ -37,8 +37,8 @@ extension S1 : HasFoo where T == UInt8 {
 // CHECK: store %0 to [[S1]] : $*S1<UInt8>
 // CHECK: [[HASFOO:%.*]] = alloc_stack $any HasFoo
 // CHECK: [[EXIS_ADDR:%.*]] = init_existential_addr [[HASFOO]] : $*any HasFoo, $S1<UInt8>
-// CHECK: copy_addr [take] [[S1]] to [initialization] [[EXIS_ADDR]] : $*S1<UInt8>
-// CHECK: copy_addr [take] [[HASFOO]] to [initialization] [[EXIS]] : $*any HasFoo
+// CHECK: copy_addr [take] [[S1]] to [init] [[EXIS_ADDR]] : $*S1<UInt8>
+// CHECK: copy_addr [take] [[HASFOO]] to [init] [[EXIS]] : $*any HasFoo
 // CHECK: [[OPEN_EXIS_ADDR:%.*]] = open_existential_addr immutable_access [[EXIS]] : $*any HasFoo to $*@opened("4E16CBC0-FD9F-11E8-A311-D0817AD9F6DD", any HasFoo) Self
 // CHECK: [[OPEN_ADDR:%.*]] = unchecked_addr_cast [[OPEN_EXIS_ADDR]] : $*@opened("4E16CBC0-FD9F-11E8-A311-D0817AD9F6DD", any HasFoo) Self to $*S1<UInt8>
 // CHECK: [[F:%.*]] = function_ref @witnessS1 : $@convention(witness_method: HasFoo) (@in_guaranteed S1<UInt8>) -> ()
@@ -68,7 +68,7 @@ bb3:
 
 bb4:
   %14 = unchecked_take_enum_data_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt
-  copy_addr [take] %14 to [initialization] %3 : $*HasFoo
+  copy_addr [take] %14 to [init] %3 : $*HasFoo
   dealloc_stack %6 : $*Optional<HasFoo>
   dealloc_stack %4 : $*S1<UInt8>
   %18 = open_existential_addr immutable_access %3 : $*HasFoo to $*@opened("4E16CBC0-FD9F-11E8-A311-D0817AD9F6DD", HasFoo) Self
@@ -99,7 +99,7 @@ bb6:
 // CHECK: checked_cast_addr_br take_always S1<Int8> in [[VAL]] : $*S1<Int8> to any HasFoo in [[IEDA]] : $*any HasFoo, bb1, bb2
 // bbs...
 // CHECK: [[UNWRAP:%.*]] = unchecked_take_enum_data_addr [[OPT]] : $*Optional<any HasFoo>, #Optional.some!enumelt
-// CHECK: copy_addr [take] [[UNWRAP]] to [initialization] [[EXIS]] : $*any HasFoo
+// CHECK: copy_addr [take] [[UNWRAP]] to [init] [[EXIS]] : $*any HasFoo
 // CHECK: [[OPEN:%.*]] = open_existential_addr immutable_access [[EXIS]] : $*any HasFoo to $*@opened("5E16CBC0-FD9F-11E8-A311-D0817AD9F6DD", any HasFoo) Self
 // CHECK: [[WM:%.*]] = witness_method $@opened("5E16CBC0-FD9F-11E8-A311-D0817AD9F6DD", any HasFoo) Self, #HasFoo.foo : <Self where Self : HasFoo> (Self) -> () -> (), [[OPEN]] : $*@opened("5E16CBC0-FD9F-11E8-A311-D0817AD9F6DD", any HasFoo) Self : $@convention(witness_method: HasFoo) <τ_0_0 where τ_0_0 : HasFoo> (@in_guaranteed τ_0_0) -> ()
 // CHECK: apply [[WM]]<@opened("5E16CBC0-FD9F-11E8-A311-D0817AD9F6DD", any HasFoo) Self>([[OPEN]]) : $@convention(witness_method: HasFoo) <τ_0_0 where τ_0_0 : HasFoo> (@in_guaranteed τ_0_0) -> ()
@@ -128,7 +128,7 @@ bb3:
 
 bb4:
   %14 = unchecked_take_enum_data_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt
-  copy_addr [take] %14 to [initialization] %3 : $*HasFoo
+  copy_addr [take] %14 to [init] %3 : $*HasFoo
   dealloc_stack %6 : $*Optional<HasFoo>
   dealloc_stack %4 : $*S1<Int8>
   %18 = open_existential_addr immutable_access %3 : $*HasFoo to $*@opened("5E16CBC0-FD9F-11E8-A311-D0817AD9F6DD", HasFoo) Self
@@ -168,8 +168,8 @@ struct IsP : P {}
 // CHECK: store %0 to [[S2]] : $*S2<IsP>
 // CHECK: [[HASFOO:%.*]] = alloc_stack $any HasFoo
 // CHECK: [[EXIS_ADDR:%.*]] = init_existential_addr [[HASFOO]] : $*any HasFoo, $S2<IsP>
-// CHECK: copy_addr [take] [[S2]] to [initialization] [[EXIS_ADDR]] : $*S2<IsP>
-// CHECK: copy_addr [take] [[HASFOO]] to [initialization] [[EXIS]] : $*any HasFoo
+// CHECK: copy_addr [take] [[S2]] to [init] [[EXIS_ADDR]] : $*S2<IsP>
+// CHECK: copy_addr [take] [[HASFOO]] to [init] [[EXIS]] : $*any HasFoo
 // CHECK: [[OPEN_EXIS_ADDR:%.*]] = open_existential_addr immutable_access [[EXIS]] : $*any HasFoo to $*@opened("4E16D1CE-FD9F-11E8-A311-D0817AD9F6DD", any HasFoo) Self
 // CHECK: [[OPEN_ADDR:%.*]] = unchecked_addr_cast [[OPEN_EXIS_ADDR]] : $*@opened("4E16D1CE-FD9F-11E8-A311-D0817AD9F6DD", any HasFoo) Self to $*S2<IsP>
 // CHECK: [[F:%.*]] = function_ref @$s9witnessS24main3IsPV_Tg5 : $@convention(witness_method: HasFoo) (S2<IsP>) -> ()
@@ -200,7 +200,7 @@ bb3:
 
 bb4:
   %14 = unchecked_take_enum_data_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt
-  copy_addr [take] %14 to [initialization] %3 : $*HasFoo
+  copy_addr [take] %14 to [init] %3 : $*HasFoo
   dealloc_stack %6 : $*Optional<HasFoo>
   dealloc_stack %4 : $*S2<IsP>
   %18 = open_existential_addr immutable_access %3 : $*HasFoo to $*@opened("4E16D1CE-FD9F-11E8-A311-D0817AD9F6DD", HasFoo) Self
@@ -240,8 +240,8 @@ extension S3 : HasFoo where T : AnyObject {
 // CHECK: store %0 to [[S3]] : $*S3<C>
 // CHECK: [[HASFOO:%.*]] = alloc_stack $any HasFoo
 // CHECK: [[EXIS_ADDR:%.*]] = init_existential_addr [[HASFOO]] : $*any HasFoo, $S3<C>
-// CHECK: copy_addr [take] [[S3]] to [initialization] [[EXIS_ADDR]] : $*S3<C>
-// CHECK: copy_addr [take] [[HASFOO]] to [initialization] [[EXIS]] : $*any HasFoo
+// CHECK: copy_addr [take] [[S3]] to [init] [[EXIS_ADDR]] : $*S3<C>
+// CHECK: copy_addr [take] [[HASFOO]] to [init] [[EXIS]] : $*any HasFoo
 // CHECK: [[OPEN_EXIS_ADDR:%.*]] = open_existential_addr immutable_access [[EXIS]] : $*any HasFoo to $*@opened("4E16D5E8-FD9F-11E8-A311-D0817AD9F6DD", any HasFoo) Self
 // CHECK: [[OPEN_ADDR:%.*]] = unchecked_addr_cast [[OPEN_EXIS_ADDR]] : $*@opened("4E16D5E8-FD9F-11E8-A311-D0817AD9F6DD", any HasFoo) Self to $*S3<C>
 // CHECK: [[F:%.*]] = function_ref @$s9witnessS34main1CC_Tg5 : $@convention(witness_method: HasFoo) (S3<C>) -> ()
@@ -272,7 +272,7 @@ bb3:
 
 bb4:
   %14 = unchecked_take_enum_data_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt
-  copy_addr [take] %14 to [initialization] %3 : $*HasFoo
+  copy_addr [take] %14 to [init] %3 : $*HasFoo
   dealloc_stack %6 : $*Optional<HasFoo>
   dealloc_stack %4 : $*S3<C>
   %18 = open_existential_addr immutable_access %3 : $*HasFoo to $*@opened("4E16D5E8-FD9F-11E8-A311-D0817AD9F6DD", HasFoo) Self
@@ -310,8 +310,8 @@ extension S4 : HasFoo where T : C {
 // CHECK: store %0 to [[S3]] : $*S4<SubC>
 // CHECK: [[HASFOO:%.*]] = alloc_stack $any HasFoo
 // CHECK: [[EXIS_ADDR:%.*]] = init_existential_addr [[HASFOO]] : $*any HasFoo, $S4<SubC>
-// CHECK: copy_addr [take] [[S3]] to [initialization] [[EXIS_ADDR]] : $*S4<SubC>
-// CHECK: copy_addr [take] [[HASFOO]] to [initialization] [[EXIS]] : $*any HasFoo
+// CHECK: copy_addr [take] [[S3]] to [init] [[EXIS_ADDR]] : $*S4<SubC>
+// CHECK: copy_addr [take] [[HASFOO]] to [init] [[EXIS]] : $*any HasFoo
 // CHECK: [[OPEN_EXIS_ADDR:%.*]] = open_existential_addr immutable_access [[EXIS]] : $*any HasFoo to $*@opened("4E16E402-FD9F-11E8-A311-D0817AD9F6DD", any HasFoo) Self
 // CHECK: [[OPEN_ADDR:%.*]] = unchecked_addr_cast [[OPEN_EXIS_ADDR]] : $*@opened("4E16E402-FD9F-11E8-A311-D0817AD9F6DD", any HasFoo) Self to $*S4<SubC>
 // CHECK: [[F:%.*]] = function_ref @$s9witnessS44main4SubCC_Tg5 : $@convention(witness_method: HasFoo) (S4<SubC>) -> ()
@@ -342,7 +342,7 @@ bb3:
 
 bb4:
   %14 = unchecked_take_enum_data_addr %6 : $*Optional<HasFoo>, #Optional.some!enumelt
-  copy_addr [take] %14 to [initialization] %3 : $*HasFoo
+  copy_addr [take] %14 to [init] %3 : $*HasFoo
   dealloc_stack %6 : $*Optional<HasFoo>
   dealloc_stack %4 : $*S4<SubC>
   %18 = open_existential_addr immutable_access %3 : $*HasFoo to $*@opened("4E16E402-FD9F-11E8-A311-D0817AD9F6DD", HasFoo) Self

--- a/test/SILOptimizer/castoptimizer-wrongscope.swift
+++ b/test/SILOptimizer/castoptimizer-wrongscope.swift
@@ -7,7 +7,7 @@
 
 // CHECK: alloc_stack $any R, loc {{.*}}, scope 2
 // CHECK-NEXT: init_existential_addr {{.*}} : $*any R, $Float, loc {{.*}}, scope 2
-// CHECK-NEXT: copy_addr [take] %8 to [initialization] {{.*}} : $*Float, loc {{.*}}, scope 2
+// CHECK-NEXT: copy_addr [take] %8 to [init] {{.*}} : $*Float, loc {{.*}}, scope 2
 
 protocol R {}
 extension Float: R {}

--- a/test/SILOptimizer/closure_specialize_consolidated.sil
+++ b/test/SILOptimizer/closure_specialize_consolidated.sil
@@ -285,9 +285,9 @@ sil @address_closure_out_result : $@convention(thin) (@in Q, @inout_aliasable Q,
 bb0(%0 : $*Q, %1 : $*Q, %2 : $*Q, %3 : $*Q):
   %7 = function_ref @address_closure_body_out_result : $@convention(thin) (@in Q, @in Q) -> @out Q
   %8 = alloc_stack $Q
-  copy_addr %2 to [initialization] %8 : $*Q
+  copy_addr %2 to [init] %8 : $*Q
   %10 = alloc_stack $Q
-  copy_addr %3 to [initialization] %10 : $*Q
+  copy_addr %3 to [init] %10 : $*Q
   %12 = apply %7(%0, %8, %10) : $@convention(thin) (@in Q, @in Q) -> @out Q
   dealloc_stack %10 : $*Q
   dealloc_stack %8 : $*Q
@@ -352,7 +352,7 @@ bb0(%0 : $*Q, %1 : $*Q, %2 : $*Q):
 sil @address_caller_existential : $@convention(thin) (@in P, @in P, Int32) -> @out P {
 bb0(%0 : $*P, %1 : $*P, %2 : $*P, %3 : $Int32):
   %7 = alloc_stack $P
-  copy_addr %1 to [initialization] %7 : $*P
+  copy_addr %1 to [init] %7 : $*P
   %9 = function_ref @address_closure_existential : $@convention(thin) (@inout_aliasable P) -> ()
   %10 = partial_apply %9(%7) : $@convention(thin) (@inout_aliasable P) -> ()
   %10b = convert_escape_to_noescape %10 : $@callee_owned () -> () to $@noescape @callee_owned () -> ()
@@ -368,14 +368,14 @@ bb0(%0 : $*P, %1 : $*P, %2 : $*P, %3 : $Int32):
 
 bb1:
   destroy_addr %2 : $*P
-  copy_addr %1 to [initialization] %0 : $*P
+  copy_addr %1 to [init] %0 : $*P
   destroy_addr %1 : $*P
   strong_release %10 : $@callee_owned () -> ()
   br bb3
 
 bb2:
   destroy_addr %1 : $*P
-  copy_addr %2 to [initialization] %0 : $*P
+  copy_addr %2 to [init] %0 : $*P
   destroy_addr %2 : $*P
   strong_release %10 : $@callee_owned () -> ()
   br bb3

--- a/test/SILOptimizer/constant_evaluator_skip_test.sil
+++ b/test/SILOptimizer/constant_evaluator_skip_test.sil
@@ -258,7 +258,7 @@ bb0:
   %9 = function_ref @skipConstructInnerProto : $@convention(thin) () -> @out InnerProto
   %10 = apply %9(%8) : $@convention(thin) () -> @out InnerProto
   %12 = struct_element_addr %1 : $*OuterWithProto, #OuterWithProto.second
-  copy_addr [take] %8 to [initialization] %12 : $*InnerProto
+  copy_addr [take] %8 to [init] %12 : $*InnerProto
   dealloc_stack %8 : $*InnerProto
   %19 = struct_element_addr %1 : $*OuterWithProto, #OuterWithProto.first
   %20 = load %19 : $*Int64

--- a/test/SILOptimizer/constant_propagation.sil
+++ b/test/SILOptimizer/constant_propagation.sil
@@ -908,7 +908,7 @@ bb0(%0 : $*MyError, %1 : $*E2<X>):
 // CHECK-NOT: unconditional_checked_cast_addr
 // CHECK: [[ALLOC_BOX:%.*]] = alloc_existential_box $any Error, $E1
 // CHECK: [[PROJ:%.*]] = project_existential_box $E1 in [[ALLOC_BOX]] : $any Error
-// CHECK: copy_addr [take] %1 to [initialization] [[PROJ]]
+// CHECK: copy_addr [take] %1 to [init] [[PROJ]]
 // CHECK: store [[ALLOC_BOX]] to %0 : $*any Error
 // CHECK: return
 sil @replace_unconditional_check_cast_addr_for_type_to_error_existential : $@convention(thin) (@in E1) -> (@out Error) {

--- a/test/SILOptimizer/constant_propagation_objc.sil
+++ b/test/SILOptimizer/constant_propagation_objc.sil
@@ -31,7 +31,7 @@ sil @guaranteed_swift_array_user : $@convention(thin) <τ_0_0> (@guaranteed Arra
 //
 // CHECK: [[SUCCESS_TRAMPOLINE_BB]]:
 // CHECK:   [[PROJ_ENUM:%.*]] = unchecked_take_enum_data_addr [[CAST_TMP]]
-// CHECK:   copy_addr [take] [[PROJ_ENUM]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[PROJ_ENUM]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_TMP]]
 // CHECK:   br [[SUCCESS_BB:bb[0-9]+]]
 //
@@ -103,7 +103,7 @@ bb4:
 //
 // CHECK: [[SUCCESS_TRAMPOLINE_BB]]:
 // CHECK:   [[PROJ_ENUM:%.*]] = unchecked_take_enum_data_addr [[CAST_TMP]]
-// CHECK:   copy_addr [take] [[PROJ_ENUM]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[PROJ_ENUM]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_TMP]]
 // CHECK:   br [[SUCCESS_BB:bb[0-9]+]]
 //
@@ -174,7 +174,7 @@ bb4:
 //
 // CHECK: [[SUCCESS_TRAMPOLINE_BB]]:
 // CHECK:   [[PROJ_ENUM:%.*]] = unchecked_take_enum_data_addr [[CAST_TMP]]
-// CHECK:   copy_addr [take] [[PROJ_ENUM]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[PROJ_ENUM]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_TMP]]
 // CHECK:   br [[SUCCESS_BB]]
 //
@@ -252,7 +252,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
@@ -318,7 +318,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   strong_release [[CASTED_INPUT]]
 // CHECK:   destroy_addr [[OUTPUT]]
@@ -387,7 +387,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   destroy_addr [[INPUT]]
@@ -458,7 +458,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
@@ -524,7 +524,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   strong_release [[CASTED_INPUT]]
 // CHECK:   destroy_addr [[OUTPUT]]
@@ -593,7 +593,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   destroy_addr [[INPUT]]
@@ -664,7 +664,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
@@ -730,7 +730,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   strong_release [[CASTED_INPUT]]
 // CHECK:   destroy_addr [[OUTPUT]]
@@ -799,7 +799,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   destroy_addr [[INPUT]]
@@ -870,7 +870,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
@@ -936,7 +936,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   strong_release [[CASTED_INPUT]]
 // CHECK:   destroy_addr [[OUTPUT]]
@@ -1005,7 +1005,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   destroy_addr [[INPUT]]

--- a/test/SILOptimizer/constant_propagation_ownership.sil
+++ b/test/SILOptimizer/constant_propagation_ownership.sil
@@ -1078,7 +1078,7 @@ bb0(%0 : $*MyError, %1 : $*E2<X>):
 // CHECK-NOT: unconditional_checked_cast_addr
 // CHECK: [[ALLOC_BOX:%.*]] = alloc_existential_box $any Error, $E1
 // CHECK: [[PROJ:%.*]] = project_existential_box $E1 in [[ALLOC_BOX]] : $any Error
-// CHECK: copy_addr [take] %1 to [initialization] [[PROJ]]
+// CHECK: copy_addr [take] %1 to [init] [[PROJ]]
 // CHECK: store [[ALLOC_BOX]] to [init] %0 : $*any Error
 // CHECK: return
 sil [ossa] @replace_unconditional_check_cast_addr_for_type_to_error_existential : $@convention(thin) (@in E1) -> (@out Error) {

--- a/test/SILOptimizer/constant_propagation_ownership_objc.sil
+++ b/test/SILOptimizer/constant_propagation_ownership_objc.sil
@@ -159,7 +159,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
@@ -226,7 +226,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_value [[CASTED_INPUT]]
 // CHECK:   destroy_addr [[OUTPUT]]
@@ -298,7 +298,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   destroy_addr [[INPUT]]
@@ -369,7 +369,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
@@ -436,7 +436,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_value [[CASTED_INPUT]]
 // CHECK:   destroy_addr [[OUTPUT]]
@@ -508,7 +508,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   destroy_addr [[INPUT]]
@@ -579,7 +579,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
@@ -646,7 +646,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_value [[CASTED_INPUT]]
 // CHECK:   destroy_addr [[OUTPUT]]
@@ -718,7 +718,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   destroy_addr [[INPUT]]
@@ -789,7 +789,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   br [[EXIT_BB:bb[0-9]+]]
@@ -856,7 +856,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_value [[CASTED_INPUT]]
 // CHECK:   destroy_addr [[OUTPUT]]
@@ -928,7 +928,7 @@ bb4:
 //
 // CHECK: [[COND_CAST_SUCC]]:
 // CHECK:   [[UNWRAPPED_CAST_RESULT:%.*]] = unchecked_take_enum_data_addr [[CAST_RESULT]]
-// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [initialization] [[OUTPUT]]
+// CHECK:   copy_addr [take] [[UNWRAPPED_CAST_RESULT]] to [init] [[OUTPUT]]
 // CHECK:   dealloc_stack [[CAST_RESULT]]
 // CHECK:   destroy_addr [[OUTPUT]]
 // CHECK:   destroy_addr [[INPUT]]

--- a/test/SILOptimizer/copyforward.sil
+++ b/test/SILOptimizer/copyforward.sil
@@ -38,7 +38,7 @@ bb0(%0 : $AnyObject):
   %alloc2 = alloc_stack $ObjWrapper
   // The location loaded from is destroyed here with no corresponding
   // retain.
-  copy_addr [take] %alloc1 to [initialization] %alloc2 : $*ObjWrapper
+  copy_addr [take] %alloc1 to [init] %alloc2 : $*ObjWrapper
   cond_br undef, bb1, bb2
 bb1:
   // This retain and destroy are not obviously related but need to
@@ -47,7 +47,7 @@ bb1:
   destroy_addr %alloc2 : $*ObjWrapper
   br bb3
 bb2:
-  copy_addr [take] %alloc2 to [initialization] %alloc1 : $*ObjWrapper
+  copy_addr [take] %alloc2 to [init] %alloc1 : $*ObjWrapper
   br bb3
 bb3:
   dealloc_stack %alloc2 : $*ObjWrapper

--- a/test/SILOptimizer/copyforward_ossa.sil
+++ b/test/SILOptimizer/copyforward_ossa.sil
@@ -51,7 +51,7 @@ bb2:                                              // Preds: bb0
   br bb3                                          // id: %16
 
 bb3:                                              // Preds: bb1 bb2
-  copy_addr [take] %2 to [initialization] %0 : $*T // id: %17
+  copy_addr [take] %2 to [init] %0 : $*T // id: %17
   %18 = tuple ()                                  // user: %20
   debug_value %0 : $*T, expr op_deref
   dealloc_stack %2 : $*T         // id: %19
@@ -66,7 +66,7 @@ sil hidden [ossa] @forward_takeinit : $@convention(thin) <T> (@in T) -> () {
 bb0(%0 : $*T):
   debug_value %0 : $*T, expr op_deref
   %l1 = alloc_stack $T
-  copy_addr [take] %0 to [initialization] %l1 : $*T
+  copy_addr [take] %0 to [init] %l1 : $*T
   %f1 = function_ref @f_in : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   %c1 = apply %f1<T>(%l1) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   dealloc_stack %l1 : $*T
@@ -120,7 +120,7 @@ bb0(%0 : $*T):
   %f1 = function_ref @f_out : $@convention(thin) <τ_0_0> () -> @out τ_0_0
   %c1 = apply %f1<T>(%l1) : $@convention(thin) <τ_0_0> () -> @out τ_0_0
   debug_value %l1 : $*T, expr op_deref
-  copy_addr [take] %l1 to [initialization] %0 : $*T
+  copy_addr [take] %l1 to [init] %0 : $*T
   debug_value %0 : $*T, expr op_deref
   dealloc_stack %l1 : $*T
   %t = tuple ()
@@ -151,7 +151,7 @@ bb0(%0 : $*T):
   %1 = alloc_stack $T, let, name "t"                   // users: %3, %4, %5
   %2 = function_ref @f_out : $@convention(thin) <τ_0_0> () -> @out τ_0_0 // user: %3
   %3 = apply %2<T>(%1) : $@convention(thin) <τ_0_0> () -> @out τ_0_0
-  copy_addr [take] %1 to [initialization] %0 : $*T // id: %4
+  copy_addr [take] %1 to [init] %0 : $*T // id: %4
   dealloc_stack %1 : $*T         // id: %5
   %6 = tuple ()                                   // user: %7
   return %6 : $()                                 // id: %7
@@ -193,15 +193,15 @@ bb0(%0 : $*AnyObject):
   %g1 = alloc_stack $IteratorOverOne<AnyObject> // 850
   %s1 = struct_element_addr %g1 : $*IteratorOverOne<AnyObject>, #IteratorOverOne._elements
   // We can't backward propagate this yet because we can't analyze struct_element_addr copy dest.
-  copy_addr [take] %l0 to [initialization] %s1 : $*Optional<AnyObject>
+  copy_addr [take] %l0 to [init] %s1 : $*Optional<AnyObject>
   // We ignore this copy because its Def is used by struct_element_addr
-  copy_addr [take] %g1 to [initialization] %g0 : $*IteratorOverOne<AnyObject>
+  copy_addr [take] %g1 to [init] %g0 : $*IteratorOverOne<AnyObject>
 
   %l1 = alloc_stack $Optional<AnyObject> // 869
 
   %l2 = alloc_stack $Optional<AnyObject> // 873
   // We ignore this copy because its Def is used by struct_element_addr
-  copy_addr %s0 to [initialization] %l2 : $*Optional<AnyObject>
+  copy_addr %s0 to [init] %l2 : $*Optional<AnyObject>
 
   %l3 = alloc_stack $Optional<AnyObject> // 877
   %o1 = enum $Optional<AnyObject>, #Optional.none!enumelt
@@ -210,7 +210,7 @@ bb0(%0 : $*AnyObject):
   copy_addr [take] %l3 to %s0 : $*Optional<AnyObject>
   dealloc_stack %l3 : $*Optional<AnyObject>
   // We can't forward propagate this because l2 is deallocated, but we can backward propagate l1.
-  copy_addr [take] %l2 to [initialization] %l1 : $*Optional<AnyObject>
+  copy_addr [take] %l2 to [init] %l1 : $*Optional<AnyObject>
   dealloc_stack %l2 : $*Optional<AnyObject>
   %l4 = alloc_stack $Optional<AnyObject> // 889
   %o2 = load [copy] %l1 : $*Optional<AnyObject>
@@ -248,7 +248,7 @@ bb0:
   %f0 = function_ref @f_out : $@convention(thin) <A> () -> @out A
   %c0 = apply %f0<AClass?>(%v0) : $@convention(thin) <τ_0_0> () -> @out τ_0_0
 
-  copy_addr %v0 to [initialization] %v1 : $*Optional<AClass>
+  copy_addr %v0 to [init] %v1 : $*Optional<AClass>
 
   %f1 = function_ref @f_in : $@convention(thin) <A> (@in A) -> ()
   %c1 = apply %f1<AClass?>(%v1) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
@@ -293,13 +293,13 @@ bb0(%0 : $*Optional<T>, %1 : $*Optional<T>, %3 : $Bool):
   cond_br %5, bb1, bb2
 
 bb1:
-  copy_addr [take] %0 to [initialization] %4 : $*Optional<T>
+  copy_addr [take] %0 to [init] %4 : $*Optional<T>
   %r1 = apply %f<Optional<T>>(%4) : $@convention(thin) <T2> (@inout T2) -> ()
   destroy_addr %1 : $*Optional<T>
   br bb3
 
 bb2:
-  copy_addr [take] %1 to  [initialization] %4 : $*Optional<T>
+  copy_addr [take] %1 to [init] %4 : $*Optional<T>
   %r2 = apply %f<Optional<T>>(%4) : $@convention(thin) <T2> (@inout T2) -> ()
   destroy_addr %0 : $*Optional<T>
   br bb3
@@ -322,7 +322,7 @@ bb0(%0 : $*AClass, %1 : $*AnyObject):
   %4 = alloc_stack $AnyObject                     // user: %9
   %5 = alloc_stack $AClass                        // users: %6, %7, %8
   unchecked_ref_cast_addr  AnyObject in %1 : $*AnyObject to AClass in %5 : $*AClass // id: %6
-  copy_addr [take] %5 to [initialization] %0 : $*AClass // id: %7
+  copy_addr [take] %5 to [init] %0 : $*AClass // id: %7
   dealloc_stack %5 : $*AClass    // id: %8
   dealloc_stack %4 : $*AnyObject // id: %9
   dealloc_stack %3 : $*AnyObject // id: %10
@@ -348,7 +348,7 @@ sil [ossa] @deadtemp : $@convention(thin) <T> (@inout S<T>) -> () {
 bb0(%0 : $*S<T>):
   %1 = struct_element_addr %0 : $*S<T>, #S.g
   %2 = alloc_stack $T
-  copy_addr %1 to [initialization] %2 : $*T
+  copy_addr %1 to [init] %2 : $*T
   debug_value %2 : $*T, expr op_deref
   %4 = struct_element_addr %0 : $*S<T>, #S.f
   copy_addr [take] %2 to %4 : $*T
@@ -368,7 +368,7 @@ sil [ossa] @deadtemp_assign : $@convention(thin) <T> (@inout S<T>) -> () {
 bb0(%0 : $*S<T>):
   %1 = struct_element_addr %0 : $*S<T>, #S.g
   %2 = alloc_stack $T
-  copy_addr %1 to [initialization] %2 : $*T
+  copy_addr %1 to [init] %2 : $*T
   %4 = struct_element_addr %0 : $*S<T>, #S.f
   copy_addr [take] %2 to %4 : $*T
   dealloc_stack %2 : $*T
@@ -380,13 +380,13 @@ bb0(%0 : $*S<T>):
 // taking the source, and initializing the destination.
 // CHECK-LABEL: sil [ossa] @deadtemp_take_init :
 // CHECK-NOT: copy_addr
-// CHECK: copy_addr [take] %1 to [initialization] %0 : $*T
+// CHECK: copy_addr [take] %1 to [init] %0 : $*T
 // CHECK-LABEL: } // end sil function 'deadtemp_take_init'
 sil [ossa] @deadtemp_take_init : $@convention(thin) <T> (@in T) -> @out T {
 bb0(%0 : $*T, %1 : $*T):
   %2 = alloc_stack $T
-  copy_addr [take] %1 to [initialization] %2 : $*T
-  copy_addr [take] %2 to [initialization] %0 : $*T
+  copy_addr [take] %1 to [init] %2 : $*T
+  copy_addr [take] %2 to [init] %0 : $*T
   dealloc_stack %2 : $*T
   %7 = tuple ()
   return %7 : $()
@@ -406,10 +406,10 @@ struct ObjWrapper {
 // CHECK-LABEL: sil [ossa] @testLoadDestroy : $@convention(thin) (@in_guaranteed ObjWrapper, @in_guaranteed ObjWrapper) -> () {
 // CHECK: bb0(%0 : $*ObjWrapper, %1 : $*ObjWrapper):
 // CHECK:   [[ALLOC:%.*]] = alloc_stack $ObjWrapper, var, name "o"
-// CHECK:   copy_addr %0 to [initialization] [[ALLOC]] : $*ObjWrapper
+// CHECK:   copy_addr %0 to [init] [[ALLOC]] : $*ObjWrapper
 // CHECK:   [[ELT_ADDR:%.*]] = struct_element_addr [[ALLOC]] : $*ObjWrapper, #ObjWrapper.obj
 // CHECK:   [[TEMP:%.*]] = alloc_stack $ObjWrapper
-// CHECK:   copy_addr %1 to [initialization] [[TEMP]] : $*ObjWrapper
+// CHECK:   copy_addr %1 to [init] [[TEMP]] : $*ObjWrapper
 // CHECK:   [[LD:%.*]] = load [copy] [[ELT_ADDR]] : $*AnyObject
 // CHECK:   destroy_value [[LD]] : $AnyObject
 // CHECK:   destroy_addr [[ALLOC]] : $*ObjWrapper
@@ -423,20 +423,20 @@ sil [ossa] @testLoadDestroy : $@convention(thin) (@in_guaranteed ObjWrapper, @in
 bb(%0 : $*ObjWrapper, %1 : $*ObjWrapper):
   // Fully initialize a new stack var to arg0.
   %alloc = alloc_stack $ObjWrapper, var, name "o"
-  copy_addr %0 to [initialization] %alloc : $*ObjWrapper
+  copy_addr %0 to [init] %alloc : $*ObjWrapper
   %objadr = struct_element_addr %alloc : $*ObjWrapper, #ObjWrapper.obj
 
   // Fully initialize a temporary to arg1.
   // Rewriting this to %alloc would alias with the subsequent load.
   %temp = alloc_stack $ObjWrapper
-  copy_addr %1 to [initialization] %temp : $*ObjWrapper
+  copy_addr %1 to [init] %temp : $*ObjWrapper
 
   // Load and release an reference from arg0 inside the stack var.
   %obj = load [copy] %objadr : $*AnyObject
   destroy_value %obj : $AnyObject  
   destroy_addr %alloc : $*ObjWrapper
   // Move `temp` copy of arg1 into the stack var.
-  copy_addr [take] %temp to [initialization] %alloc : $*ObjWrapper
+  copy_addr [take] %temp to [init] %alloc : $*ObjWrapper
 
   destroy_addr %alloc : $*ObjWrapper
   dealloc_stack %temp : $*ObjWrapper
@@ -458,25 +458,25 @@ bb0(%0 : $*T, %1 : $*T):
 // CHECK-LABEL: sil hidden [ossa] @multipleUse : $@convention(thin) <T> (@in T, @in T) -> () {
 // CHECK: bb0(%0 : $*T, %1 : $*T):
 // CHECK:   [[A:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [take] %0 to [initialization] [[A]] : $*T
+// CHECK:   copy_addr [take] %0 to [init] [[A]] : $*T
 // CHECK:   [[F:%.*]] = function_ref @multipleArg : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> ()
 // CHECK:   [[C:%.*]] = apply [[F]]<T>([[A]], [[A]]) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> ()
 // CHECK:   destroy_addr [[A]] : $*T
 // CHECK:   dealloc_stack [[A]] : $*T
-// CHECK:   copy_addr [take] %1 to [initialization] %0 : $*T
+// CHECK:   copy_addr [take] %1 to [init] %0 : $*T
 // CHECK:   %{{.*}} = tuple ()
 // CHECK:   return %{{.*}} : $()
 // CHECK-LABEL: } // end sil function 'multipleUse'
 sil hidden [ossa] @multipleUse : $@convention(thin) <T> (@in T, @in T) -> () {
 bb0(%0 : $*T, %1 : $*T):
   %l1 = alloc_stack $T
-  copy_addr [take] %0 to [initialization] %l1 : $*T
+  copy_addr [take] %0 to [init] %l1 : $*T
   %f1 = function_ref @multipleArg : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> ()
   %c1 = apply %f1<T>(%l1, %l1) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> ()
   destroy_addr %l1 : $*T
   dealloc_stack %l1 : $*T
   // Reinitialize copy's source to avoid a fast isSourceDeadAtCopy check.
-  copy_addr [take] %1 to [initialization] %0 : $*T
+  copy_addr [take] %1 to [init] %0 : $*T
   destroy_addr %0 : $*T
   %r1 = tuple ()
   return %r1 : $()
@@ -517,7 +517,7 @@ bb1:
 
 // CHECK-LABEL: sil [ossa] @test_dynamic_lifetime : 
 // CHECK: [[STK:%.*]] = alloc_stack [dynamic_lifetime] $NonTrivialStruct
-// CHECK: copy_addr [take] {{.*}} to [initialization] [[STK]] : $*NonTrivialStruct
+// CHECK: copy_addr [take] {{.*}} to [init] [[STK]] : $*NonTrivialStruct
 // CHECK-LABEL: } // end sil function 'test_dynamic_lifetime'
 sil [ossa] @test_dynamic_lifetime : $@convention(thin) () -> @out NonTrivialStruct {
 bb0(%0 : $*NonTrivialStruct):
@@ -544,7 +544,7 @@ bb4:
   %13 = alloc_stack $NonTrivialStruct
   %14 = function_ref @get_nontrivialstruct : $@convention(thin) () -> @out NonTrivialStruct
   %15 = apply %14(%13) : $@convention(thin) () -> @out NonTrivialStruct
-  copy_addr [take] %13 to [initialization] %2 : $*NonTrivialStruct
+  copy_addr [take] %13 to [init] %2 : $*NonTrivialStruct
   dealloc_stack %13 : $*NonTrivialStruct
   %18 = struct_element_addr %2 : $*NonTrivialStruct, #NonTrivialStruct.cls
   %19 = function_ref @use_aclass : $@convention(thin) (@in_guaranteed AClass) -> ()
@@ -564,7 +564,7 @@ bb11:
   br bb1
 
 bb12:
-  copy_addr [take] %2 to [initialization] %0 : $*NonTrivialStruct
+  copy_addr [take] %2 to [init] %0 : $*NonTrivialStruct
   dealloc_stack %2 : $*NonTrivialStruct
   %33 = tuple ()
   dealloc_stack %1 : $*Builtin.Int1

--- a/test/SILOptimizer/cse.sil
+++ b/test/SILOptimizer/cse.sil
@@ -1039,7 +1039,7 @@ bb0(%0 : $Airplane):
 sil hidden [transparent] [thunk] @_TTWV2p28AirplaneS_7FlyableS_FS1_3flyuRq_S1__fq_FT_T_ : $@convention(witness_method: Flyable) (@in_guaranteed Airplane) -> () {
 bb0(%0 : $*Airplane):
   %1 = alloc_stack $Airplane                      // users: %2, %6
-  copy_addr %0 to [initialization] %1 : $*Airplane // id: %2
+  copy_addr %0 to [init] %1 : $*Airplane // id: %2
   %3 = struct $Airplane ()                        // user: %5
   // function_ref p2.Airplane.fly (p2.Airplane)() -> ()
   %4 = function_ref @_TFV2p28Airplane3flyfS0_FT_T_ : $@convention(method) (Airplane) -> () // user: %5

--- a/test/SILOptimizer/cse_ossa.sil
+++ b/test/SILOptimizer/cse_ossa.sil
@@ -941,7 +941,7 @@ bb0(%0 : $Airplane):
 sil hidden [ossa] [transparent] [thunk] @_TTWV2p28AirplaneS_7FlyableS_FS1_3flyuRq_S1__fq_FT_T_ : $@convention(witness_method: Flyable) (@in_guaranteed Airplane) -> () {
 bb0(%0 : $*Airplane):
   %1 = alloc_stack $Airplane
-  copy_addr %0 to [initialization] %1 : $*Airplane
+  copy_addr %0 to [init] %1 : $*Airplane
   %3 = struct $Airplane ()
   // function_ref p2.Airplane.fly (p2.Airplane)() -> ()
   %4 = function_ref @_TFV2p28Airplane3flyfS0_FT_T_ : $@convention(method) (Airplane) -> ()

--- a/test/SILOptimizer/definite_init_failable_initializers.swift
+++ b/test/SILOptimizer/definite_init_failable_initializers.swift
@@ -209,7 +209,7 @@ struct FailableAddrOnlyStruct<T : Pachyderm> {
 // CHECK-NEXT:    apply [[T_INIT_FN]]<T>([[X_BOX]], [[T_TYPE]])
 // CHECK-NEXT:    [[WRITE:%.*]] = begin_access [modify] [static] [[SELF_BOX]] : $*FailableAddrOnlyStruct<T>
 // CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[WRITE]]
-// CHECK-NEXT:    copy_addr [take] [[X_BOX]] to [initialization] [[X_ADDR]]
+// CHECK-NEXT:    copy_addr [take] [[X_BOX]] to [init] [[X_ADDR]]
 // CHECK-NEXT:    end_access [[WRITE]] : $*FailableAddrOnlyStruct<T>
 // CHECK-NEXT:    dealloc_stack [[X_BOX]]
 // CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[SELF_BOX]]
@@ -231,7 +231,7 @@ struct FailableAddrOnlyStruct<T : Pachyderm> {
 // CHECK-NEXT:    apply [[T_INIT_FN]]<T>([[X_BOX]], [[T_TYPE]])
 // CHECK-NEXT:    [[WRITE:%.*]] = begin_access [modify] [static] [[SELF_BOX]] : $*FailableAddrOnlyStruct<T>
 // CHECK-NEXT:    [[X_ADDR:%.*]] = struct_element_addr [[WRITE]]
-// CHECK-NEXT:    copy_addr [take] [[X_BOX]] to [initialization] [[X_ADDR]]
+// CHECK-NEXT:    copy_addr [take] [[X_BOX]] to [init] [[X_ADDR]]
 // CHECK-NEXT:    end_access [[WRITE]] : $*FailableAddrOnlyStruct<T>
 // CHECK-NEXT:    dealloc_stack [[X_BOX]]
 // CHECK-NEXT:    [[Y_BOX:%.*]] = alloc_stack $T
@@ -240,7 +240,7 @@ struct FailableAddrOnlyStruct<T : Pachyderm> {
 // CHECK-NEXT:    apply [[T_INIT_FN]]<T>([[Y_BOX]], [[T_TYPE]])
 // CHECK-NEXT:    [[WRITE:%.*]] = begin_access [modify] [static] [[SELF_BOX]] : $*FailableAddrOnlyStruct<T>
 // CHECK-NEXT:    [[Y_ADDR:%.*]] = struct_element_addr [[WRITE]]
-// CHECK-NEXT:    copy_addr [take] [[Y_BOX]] to [initialization] [[Y_ADDR]]
+// CHECK-NEXT:    copy_addr [take] [[Y_BOX]] to [init] [[Y_ADDR]]
 // CHECK-NEXT:    end_access [[WRITE]] : $*FailableAddrOnlyStruct<T>
 // CHECK-NEXT:    dealloc_stack [[Y_BOX]]
 // CHECK-NEXT:    destroy_addr [[SELF_BOX]]

--- a/test/SILOptimizer/definite_init_markuninitialized_delegatingself.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_delegatingself.sil
@@ -70,10 +70,10 @@ bb0(%0 : $*MyStruct2, %1 : $@thin MyStruct2.Type):
   dealloc_stack %8 : $*MyStruct2
 
   // CHECK: apply
-  // CHECK-NEXT: copy_addr [take] {{.*}} to [initialization] [[SELF]] : $*MyStruct2
+  // CHECK-NEXT: copy_addr [take] {{.*}} to [init] [[SELF]] : $*MyStruct2
   // CHECK-NEXT: dealloc_stack
 
-  copy_addr [take] %3 to [initialization] %0 : $*MyStruct2
+  copy_addr [take] %3 to [init] %0 : $*MyStruct2
   %13 = tuple ()
   dealloc_stack %2 : $*MyStruct2
   return %13 : $()

--- a/test/SILOptimizer/definite_init_markuninitialized_var.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_var.sil
@@ -123,8 +123,8 @@ bb0(%0 : $*T, %1 : $*T):
   %3 = alloc_box $<τ_0_0> { var τ_0_0 } <T>
   %3a = mark_uninitialized [var] %3 : $<τ_0_0> { var τ_0_0 } <T>
   %4 = project_box %3a : $<τ_0_0> { var τ_0_0 } <T>, 0
-  copy_addr [take] %1 to [initialization] %4 : $*T
-  copy_addr %4 to [initialization] %0 : $*T
+  copy_addr [take] %1 to [init] %4 : $*T
+  copy_addr %4 to [init] %0 : $*T
   destroy_value %3a : $<τ_0_0> { var τ_0_0 } <T>
   %9 = tuple ()
   return %9 : $()
@@ -136,7 +136,7 @@ bb0(%0 : $*T, %1 : $*T):
   %3 = alloc_box $<τ_0_0> { var τ_0_0 } <T>
   %3a = mark_uninitialized [var] %3 : $<τ_0_0> { var τ_0_0 } <T> // expected-note {{variable defined here}}
   %4 = project_box %3a : $<τ_0_0> { var τ_0_0 } <T>, 0
-  copy_addr %4 to [initialization] %0 : $*T   // expected-error {{variable '<unknown>' used before being initialized}}
+  copy_addr %4 to [init] %0 : $*T   // expected-error {{variable '<unknown>' used before being initialized}}
   destroy_value %3a : $<τ_0_0> { var τ_0_0 } <T>
   %9 = tuple ()
   return %9 : $()
@@ -233,15 +233,15 @@ bb0(%0 : $*T, %1 : $*T):
 
   // This should become an initialization of %4
   copy_addr %1 to %2 : $*T
-  // CHECK-NEXT: copy_addr %1 to [initialization] [[PB]] : $*T
+  // CHECK-NEXT: copy_addr %1 to [init] [[PB]] : $*T
 
   // This should stay an assignment of %4
   copy_addr [take] %1 to %2 : $*T
   // CHECK-NEXT: copy_addr [take] %1 to [[PB]] : $*T
 
   // This is a load, and shouldn't be changed.
-  copy_addr %2 to [initialization] %0 : $*T
-  // CHECK-NEXT: copy_addr [[PB]] to [initialization] %0 : $*T
+  copy_addr %2 to [init] %0 : $*T
+  // CHECK-NEXT: copy_addr [[PB]] to [init] %0 : $*T
 
   destroy_value %ba : $<τ_0_0> { var τ_0_0 } <T>
   // CHECK-NEXT: destroy_value %2
@@ -266,7 +266,7 @@ bb0:
 
   // This should become an initialization.
   store_weak %4 to %c : $*@sil_weak Optional<SomeClass>
-  // CHECK-NEXT: store_weak [[C1]] to [initialization] %1
+  // CHECK-NEXT: store_weak [[C1]] to [init] %1
 
   destroy_value %4 : $Optional<SomeClass>
   // CHECK-NEXT: destroy_value [[C1]]
@@ -445,8 +445,8 @@ entry(%a : $*C):
 
   %q = init_existential_addr %b : $*P, $C
 
-  // CHECK: copy_addr {{.*}} to [initialization] %2 : $*C
-  copy_addr %a to [initialization] %q : $*C
+  // CHECK: copy_addr {{.*}} to [init] %2 : $*C
+  copy_addr %a to [init] %q : $*C
   %u = function_ref @use : $@convention(thin) (@in P) -> ()
   %v = apply %u(%b) : $@convention(thin) (@in P) -> ()
   dealloc_stack %p : $*P

--- a/test/SILOptimizer/definite_init_protocol_init.swift
+++ b/test/SILOptimizer/definite_init_protocol_init.swift
@@ -97,9 +97,9 @@ struct AddressOnlyStruct : TriviallyConstructible {
 // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thick AddressOnlyStruct.Type
 // CHECK:      [[FN:%.*]] = function_ref @$s023definite_init_protocol_B022TriviallyConstructiblePAAE6middlexSi_tcfC
 // CHECK-NEXT: apply [[FN]]<AddressOnlyStruct>([[SELF_BOX]], %1, [[METATYPE]])
-// CHECK-NEXT: copy_addr [take] [[SELF_BOX]] to [initialization] [[SELF]]
+// CHECK-NEXT: copy_addr [take] [[SELF_BOX]] to [init] [[SELF]]
 // CHECK-NEXT: dealloc_stack [[SELF_BOX]]
-// CHECK-NEXT: copy_addr [take] [[SELF]] to [initialization] %0
+// CHECK-NEXT: copy_addr [take] [[SELF]] to [init] %0
 // CHECK-NEXT: dealloc_stack [[SELF]]
 // CHECK-NEXT: [[RESULT:%.*]] = tuple ()
 // CHECK-NEXT: return [[RESULT]]

--- a/test/SILOptimizer/definite_init_tuple.sil
+++ b/test/SILOptimizer/definite_init_tuple.sil
@@ -20,7 +20,7 @@ bb0(%0 : $*S<T>, %1 : $@thin S<T>.Type):
   %7 = tuple_element_addr %5 : $*(T, T), 0
   %8 = tuple_element_addr %5 : $*(T, T), 1
   %9 = apply %6<T>(%7, %8) : $@convention(thin) <τ_0_0> () -> (@out τ_0_0, @out τ_0_0)
-  copy_addr %4 to [initialization] %0 : $*S<T>
+  copy_addr %4 to [init] %0 : $*S<T>
   destroy_value %3 : $<τ_0_0> { var S<τ_0_0> } <T>
   %12 = tuple ()
   return %12 : $()

--- a/test/SILOptimizer/destroy_hoisting.sil
+++ b/test/SILOptimizer/destroy_hoisting.sil
@@ -86,14 +86,14 @@ bb1:
 
 // CHECK-LABEL: sil [ossa] @combine_copy_addr
 // CHECK:      bb0(%0 : $*S, %1 : $*S):
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] %0
+// CHECK-NEXT:   copy_addr [take] %1 to [init] %0
 // CHECK-NEXT:   br bb1
 // CHECK:      bb1:
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
 sil [ossa] @combine_copy_addr : $@convention(thin) (@in S) -> @out S {
 bb0(%0 : $*S, %1 : $*S):
-  copy_addr %1 to [initialization] %0 : $*S
+  copy_addr %1 to [init] %0 : $*S
   br bb1
 bb1:
   destroy_addr %1 : $*S
@@ -355,7 +355,7 @@ bb0(%0 :  $*X):
 sil [ossa] @test_switch_enum_addr : $@convention(thin) (@in TwoCases) -> () {
 bb0(%0 : $*TwoCases):
   %2 = alloc_stack $TwoCases
-  copy_addr %0 to [initialization] %2 : $*TwoCases
+  copy_addr %0 to [init] %2 : $*TwoCases
   switch_enum_addr %2 : $*TwoCases, case #TwoCases.A!enumelt: bb1, case #TwoCases.B!enumelt: bb2
 
 bb1:
@@ -381,7 +381,7 @@ bb3:
 sil [ossa] @test_load_borrow1 : $@convention(thin) (@in TwoCases) -> () {
 bb0(%0 : $*TwoCases):
   %2 = alloc_stack $TwoCases
-  copy_addr %0 to [initialization] %2 : $*TwoCases
+  copy_addr %0 to [init] %2 : $*TwoCases
   %ld = load_borrow %2 : $*TwoCases
   br bb1(%ld : $TwoCases)
 
@@ -407,7 +407,7 @@ bb3:
 sil [ossa] @test_load_borrow2 : $@convention(thin) (@in TwoCases) -> () {
 bb0(%0 : $*TwoCases):
   %2 = alloc_stack $TwoCases
-  copy_addr %0 to [initialization] %2 : $*TwoCases
+  copy_addr %0 to [init] %2 : $*TwoCases
   %ld = load_borrow %2 : $*TwoCases
   cond_br undef, bb1, bb2
 

--- a/test/SILOptimizer/devirt_jump_thread_crasher.sil
+++ b/test/SILOptimizer/devirt_jump_thread_crasher.sil
@@ -50,7 +50,7 @@ bb3:                                              // Preds: bb1 bb6 bb8 bb10
 
 bb4:                                              // Preds: bb3
   %13 = unchecked_take_enum_data_addr %3 : $*MyOptional<R>, #MyOptional.some!enumelt // user: %14
-  copy_addr [take] %13 to [initialization] %0 : $*R // id: %14
+  copy_addr [take] %13 to [init] %0 : $*R // id: %14
   dealloc_stack %3 : $*MyOptional<R> // id: %15
   strong_release %2 : $Base // id: %16
   strong_release %1 : $@callee_owned (S) -> @out R // id: %17

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -154,7 +154,7 @@ bb0(%0 : $*T, %1 : $*T, %2 : $*T):
   // function_ref static != infix<A where ...> (A, A) -> Bool
   %5 = function_ref @$ss2neoiySbx_xts9EquatableRzlFZ : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool
   %6 = alloc_stack $T
-  copy_addr %2 to [initialization] %6 : $*T
+  copy_addr %2 to [init] %6 : $*T
   %8 = witness_method $T, #_ExpressibleByBuiltinIntegerLiteral.init!allocator : $@convention(witness_method: _ExpressibleByBuiltinIntegerLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.IntLiteral, @thick τ_0_0.Type) -> @out τ_0_0
   %9 = metatype $@thick T.Type
   %10 = integer_literal $Builtin.IntLiteral, 0
@@ -350,7 +350,7 @@ bb0(%0 : $*T):
 // copyValueAndReturn<A> (A, s : inout A) -> A
 sil [noinline] [_specialize where S : _Trivial(32)] [_specialize where S : _Trivial(64)] @$s16eager_specialize18copyValueAndReturn_1sxx_xztlF : $@convention(thin) <S> (@in S, @inout S) -> @out S {
 bb0(%0 : $*S, %1 : $*S, %2 : $*S):
-  copy_addr %2 to [initialization] %0 : $*S
+  copy_addr %2 to [init] %0 : $*S
   destroy_addr %1 : $*S
   %7 = tuple ()
   return %7 : $()
@@ -361,7 +361,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 // specialized copyValueAndReturn<A>(A, s : inout A) -> A
 // CHECK-LABEL: sil shared [noinline] @$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze31_lIetilr_Tp5 : $@convention(thin) <S where S : _Trivial(32)> (@in S, @inout S) -> @out S
 // CHECK: bb0(%0 : $*S, %1 : $*S, %2 : $*S):
-// CHECK:  copy_addr %2 to [initialization] %0 : $*S
+// CHECK:  copy_addr %2 to [init] %0 : $*S
 // CHECK:  destroy_addr %1 : $*S
 // CHECK:  %{{.*}} = tuple ()
 // CHECK:  return %{{.*}} : $()
@@ -371,7 +371,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 // specialized copyValueAndReturn<A>(A, s : inout A) -> A
 // CHECK-LABEL: sil shared [noinline] @$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze63_lIetilr_Tp5 : $@convention(thin) <S where S : _Trivial(64)> (@in S, @inout S) -> @out S
 // CHECK: bb0(%0 : $*S, %1 : $*S, %2 : $*S):
-// CHECK:  copy_addr %2 to [initialization] %0 : $*S
+// CHECK:  copy_addr %2 to [init] %0 : $*S
 // CHECK:  destroy_addr %1 : $*S
 // CHECK:  %{{.*}} = tuple ()
 // CHECK:  return %{{.*}} : $()
@@ -397,7 +397,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 
 // None of the constraint checks was successful, perform a generic copy.
 // CHECK: bb6:
-// CHECK:  copy_addr %{{.*}} to [initialization] %0 : $*S
+// CHECK:  copy_addr %{{.*}} to [init] %0 : $*S
 // CHECK:  destroy_addr %1 : $*S
 // CHECK:  br bb7
 
@@ -447,7 +447,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 // copyValueAndReturn2<A> (A, s : inout A) -> A
 sil [noinline] [_specialize where S : _Trivial] @$s16eager_specialize19copyValueAndReturn2_1sxx_xztlF : $@convention(thin) <S> (@in S, @inout S) -> @out S {
 bb0(%0 : $*S, %1 : $*S, %2 : $*S):
-  copy_addr %2 to [initialization] %0 : $*S
+  copy_addr %2 to [init] %0 : $*S
   destroy_addr %1 : $*S
   %7 = tuple ()
   return %7 : $()
@@ -457,7 +457,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 // specialized copyValueAndReturn2<A> (A, s : inout A) -> A
 // CHECK-LABEL: sil shared [noinline] @$s16eager_specialize19copyValueAndReturn2_1sxx_xztlFxxxRlzTlIetilr_Tp5 : $@convention(thin) <S where S : _Trivial> (@in S, @inout S) -> @out S
 // CHECK: bb0(%0 : $*S, %1 : $*S, %2 : $*S):
-// CHECK:  copy_addr %2 to [initialization] %0 : $*S
+// CHECK:  copy_addr %2 to [init] %0 : $*S
 // CHECK:  destroy_addr %1 : $*S
 // CHECK:  %5 = tuple ()
 // CHECK:  return %5 : $()
@@ -473,7 +473,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 
 // None of the constraint checks was successful, perform a generic copy.
 // CHECK: bb2:
-// CHECK:  copy_addr %2 to [initialization] %0 : $*S
+// CHECK:  copy_addr %2 to [init] %0 : $*S
 // CHECK:  destroy_addr %1 : $*S
 // CHECK:  br bb3
 
@@ -501,7 +501,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 // copyValueAndReturn3<A> (A, s : inout A) -> A
 sil [noinline] [_specialize where S : _RefCountedObject] @$s16eager_specialize19copyValueAndReturn3_1sxx_xztlF : $@convention(thin) <S> (@in S, @inout S) -> @out S {
 bb0(%0 : $*S, %1 : $*S, %2 : $*S):
-  copy_addr %2 to [initialization] %0 : $*S
+  copy_addr %2 to [init] %0 : $*S
   destroy_addr %1 : $*S
   %7 = tuple ()
   return %7 : $()
@@ -512,7 +512,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 // specialized copyValueAndReturn3<A> (A, s : inout A) -> A
 // CHECK-LABEL: sil shared [noinline] @$s16eager_specialize19copyValueAndReturn3_1sxx_xztlFxxxRlzRlIetilr_Tp5 : $@convention(thin) <S where S : _RefCountedObject> (@in S, @inout S) -> @out S
 // CHECK: bb0(%0 : $*S, %1 : $*S, %2 : $*S):
-// CHECK:   copy_addr %2 to [initialization] %0 : $*S
+// CHECK:   copy_addr %2 to [init] %0 : $*S
 // CHECK:   destroy_addr %1 : $*S
 // CHECK:   %5 = tuple ()
 // CHECK:   return %5 : $()
@@ -532,7 +532,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 // CHECK:   cond_br %6, bb5, bb8
 
 // CHECK: bb3:
-// CHECK:   copy_addr %2 to [initialization] %0 : $*S
+// CHECK:   copy_addr %2 to [init] %0 : $*S
 // CHECK:   destroy_addr %1 : $*S
 // CHECK:   br bb4
 

--- a/test/SILOptimizer/eager_specialize_ossa.sil
+++ b/test/SILOptimizer/eager_specialize_ossa.sil
@@ -269,7 +269,7 @@ bb0(%0 : $*T, %1 : $*G<T>, %2 : $*T.Elt):
 sil [_specialize where T == ContainerKlass] [ossa] @$s16eager_specialize30getGenericContainer_guaranteed_1exAA1GVyxG_3EltQztAA03HasF0RzAA02AnF0AHRQlF : $@convention(thin) <T where T : HasElt, T.Elt : AnElt> (@in_guaranteed G<T>, @in_guaranteed T.Elt) -> @out T {
 bb0(%0 : $*T, %1 : $*G<T>, %2 : $*T.Elt):
   %a = alloc_stack $*T.Elt
-  copy_addr %2 to [initialization] %a : $*T.Elt
+  copy_addr %2 to [init] %a : $*T.Elt
   // function_ref G.getContainer(A.Elt) -> A
   %5 = function_ref @$s16eager_specialize1GV12getContaineryx3EltQzF : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, @in_guaranteed G<τ_0_0>) -> @out τ_0_0
   %6 = apply %5<T>(%0, %a, %1) : $@convention(method) <τ_0_0 where τ_0_0 : HasElt> (@in τ_0_0.Elt, @in_guaranteed G<τ_0_0>) -> @out τ_0_0
@@ -314,7 +314,7 @@ bb0(%0 : $*T, %1 : $*T, %2 : $*T):
   // function_ref static != infix<A where ...> (A, A) -> Bool
   %5 = function_ref @$ss2neoiySbx_xts9EquatableRzlFZ : $@convention(thin) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0) -> Bool
   %6 = alloc_stack $T
-  copy_addr %2 to [initialization] %6 : $*T
+  copy_addr %2 to [init] %6 : $*T
   %8 = witness_method $T, #_ExpressibleByBuiltinIntegerLiteral.init!allocator : $@convention(witness_method: _ExpressibleByBuiltinIntegerLiteral) <τ_0_0 where τ_0_0 : _ExpressibleByBuiltinIntegerLiteral> (Builtin.IntLiteral, @thick τ_0_0.Type) -> @out τ_0_0
   %9 = metatype $@thick T.Type
   %10 = integer_literal $Builtin.IntLiteral, 0
@@ -527,7 +527,7 @@ bb0(%0 : $*T):
 // copyValueAndReturn<A> (A, s : inout A) -> A
 sil [noinline] [_specialize where S : _Trivial(32)] [_specialize where S : _Trivial(64)] [ossa] @$s16eager_specialize18copyValueAndReturn_1sxx_xztlF : $@convention(thin) <S> (@in S, @inout S) -> @out S {
 bb0(%0 : $*S, %1 : $*S, %2 : $*S):
-  copy_addr %2 to [initialization] %0 : $*S
+  copy_addr %2 to [init] %0 : $*S
   destroy_addr %1 : $*S
   %7 = tuple ()
   return %7 : $()
@@ -538,7 +538,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 // specialized copyValueAndReturn<A>(A, s : inout A) -> A
 // CHECK-LABEL: sil shared [noinline] [ossa] @$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze31_lIetilr_Tp5 : $@convention(thin) <S where S : _Trivial(32)> (@in S, @inout S) -> @out S
 // CHECK: bb0(%0 : $*S, %1 : $*S, %2 : $*S):
-// CHECK:  copy_addr %2 to [initialization] %0 : $*S
+// CHECK:  copy_addr %2 to [init] %0 : $*S
 // CHECK:  destroy_addr %1 : $*S
 // CHECK:  %{{.*}} = tuple ()
 // CHECK:  return %{{.*}} : $()
@@ -548,7 +548,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 // specialized copyValueAndReturn<A>(A, s : inout A) -> A
 // CHECK-LABEL: sil shared [noinline] [ossa] @$s16eager_specialize18copyValueAndReturn_1sxx_xztlFxxxRlze63_lIetilr_Tp5 : $@convention(thin) <S where S : _Trivial(64)> (@in S, @inout S) -> @out S
 // CHECK: bb0(%0 : $*S, %1 : $*S, %2 : $*S):
-// CHECK:  copy_addr %2 to [initialization] %0 : $*S
+// CHECK:  copy_addr %2 to [init] %0 : $*S
 // CHECK:  destroy_addr %1 : $*S
 // CHECK:  %5 = tuple ()
 // CHECK:  return %5 : $()
@@ -580,7 +580,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 
 // None of the constraint checks was successful, perform a generic copy.
 // CHECK: bb6:
-// CHECK:  copy_addr %2 to [initialization] %0 : $*S
+// CHECK:  copy_addr %2 to [init] %0 : $*S
 // CHECK:  destroy_addr %1 : $*S
 // CHECK:  br bb7
 
@@ -630,7 +630,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 // copyValueAndReturn2<A> (A, s : inout A) -> A
 sil [noinline] [_specialize where S : _Trivial] [ossa] @$s16eager_specialize19copyValueAndReturn2_1sxx_xztlF : $@convention(thin) <S> (@in S, @inout S) -> @out S {
 bb0(%0 : $*S, %1 : $*S, %2 : $*S):
-  copy_addr %2 to [initialization] %0 : $*S
+  copy_addr %2 to [init] %0 : $*S
   destroy_addr %1 : $*S
   %7 = tuple ()
   return %7 : $()
@@ -640,7 +640,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 // specialized copyValueAndReturn2<A> (A, s : inout A) -> A
 // CHECK-LABEL: sil shared [noinline] [ossa] @$s16eager_specialize19copyValueAndReturn2_1sxx_xztlFxxxRlzTlIetilr_Tp5 : $@convention(thin) <S where S : _Trivial> (@in S, @inout S) -> @out S
 // CHECK: bb0(%0 : $*S, %1 : $*S, %2 : $*S):
-// CHECK:  copy_addr %2 to [initialization] %0 : $*S
+// CHECK:  copy_addr %2 to [init] %0 : $*S
 // CHECK:  destroy_addr %1 : $*S
 // CHECK:  %5 = tuple ()
 // CHECK:  return %5 : $()
@@ -656,7 +656,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 
 // None of the constraint checks was successful, perform a generic copy.
 // CHECK: bb2:
-// CHECK:  copy_addr %2 to [initialization] %0 : $*S
+// CHECK:  copy_addr %2 to [init] %0 : $*S
 // CHECK:  destroy_addr %1 : $*S
 // CHECK:  br bb3
 
@@ -684,7 +684,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 // copyValueAndReturn3<A> (A, s : inout A) -> A
 sil [noinline] [_specialize where S : _RefCountedObject] [ossa] @$s16eager_specialize19copyValueAndReturn3_1sxx_xztlF : $@convention(thin) <S> (@in S, @inout S) -> @out S {
 bb0(%0 : $*S, %1 : $*S, %2 : $*S):
-  copy_addr %2 to [initialization] %0 : $*S
+  copy_addr %2 to [init] %0 : $*S
   destroy_addr %1 : $*S
   %7 = tuple ()
   return %7 : $()
@@ -695,7 +695,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 // specialized copyValueAndReturn3<A> (A, s : inout A) -> A
 // CHECK-LABEL: sil shared [noinline] [ossa] @$s16eager_specialize19copyValueAndReturn3_1sxx_xztlFxxxRlzRlIetilr_Tp5 : $@convention(thin) <S where S : _RefCountedObject> (@in S, @inout S) -> @out S
 // CHECK: bb0(%0 : $*S, %1 : $*S, %2 : $*S):
-// CHECK:   copy_addr %2 to [initialization] %0 : $*S
+// CHECK:   copy_addr %2 to [init] %0 : $*S
 // CHECK:   destroy_addr %1 : $*S
 // CHECK:   %{{.*}} = tuple ()
 // CHECK:   return %{{.*}} : $()
@@ -715,7 +715,7 @@ bb0(%0 : $*S, %1 : $*S, %2 : $*S):
 // CHECK:   cond_br %{{.*}}, bb5, bb8
 
 // CHECK: bb3:
-// CHECK:   copy_addr %2 to [initialization] %0 : $*S
+// CHECK:   copy_addr %2 to [init] %0 : $*S
 // CHECK:   destroy_addr %1 : $*S
 // CHECK:   br bb4
 

--- a/test/SILOptimizer/earlycodemotion.sil
+++ b/test/SILOptimizer/earlycodemotion.sil
@@ -1457,7 +1457,7 @@ bb0(%0 : $*T, %1 : $*T, %2 : $B):
 sil hidden @retain_not_blocked_by_copyaddrinit : $@convention(thin) <T> (@in T, B) -> @out T {
 bb0(%0 : $*T, %1 : $*T, %2 : $B):
   retain_value %2 : $B
-  copy_addr [take] %1 to [initialization] %0 : $*T // id: %3
+  copy_addr [take] %1 to [init] %0 : $*T // id: %3
   %4 = tuple ()                                   // user: %5
   return %4 : $()                                 // id: %5
 }
@@ -1473,7 +1473,7 @@ bb0(%0 : $*T, %1 : $*T, %2 : $B):
 sil hidden @retain_not_blocked_by_copyaddr_notake_init : $@convention(thin) <T> (@in T, B) -> @out T {
 bb0(%0 : $*T, %1 : $*T, %2 : $B):
   retain_value %2 : $B
-  copy_addr %1 to [initialization] %0 : $*T // id: %3
+  copy_addr %1 to [init] %0 : $*T // id: %3
   %4 = tuple ()                                   // user: %5
   return %4 : $()                                 // id: %5
 }

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -362,7 +362,7 @@ bb0(%0 : $Pointer):
 // CHECK-NEXT:  End
 sil @copy_addr_content : $@convention(thin) (@in_guaranteed Int32) -> @out Int32 {
 bb0(%0: $*Int32, %1: $*Int32):
-  copy_addr %1 to [initialization] %0 : $*Int32
+  copy_addr %1 to [init] %0 : $*Int32
   %2 = tuple()
   return %2 : $()
 }
@@ -375,7 +375,7 @@ bb0(%0: $*Int32, %1: $*Int32):
 // CHECK-NEXT:  End
 sil @copy_addr_take_content : $@convention(thin) (@in Int32) -> @out Int32 {
 bb0(%0: $*Int32, %1: $*Int32):
-  copy_addr [take] %1 to [initialization] %0 : $*Int32
+  copy_addr [take] %1 to [init] %0 : $*Int32
   %2 = tuple()
   return %2 : $()
 }

--- a/test/SILOptimizer/escape_analysis_invalidate.sil
+++ b/test/SILOptimizer/escape_analysis_invalidate.sil
@@ -52,7 +52,7 @@ bb0(%0 : $*SomeProtocol, %1 : $SomeClass):
   // querying EscapeAnalysis.
   %localRef = alloc_ref $SomeClass
   %localPropAdr = ref_element_addr %localRef : $SomeClass, #SomeClass.someProperty
-  copy_addr %0 to [initialization] %localPropAdr : $*SomeProtocol
+  copy_addr %0 to [init] %localPropAdr : $*SomeProtocol
   %stk0 = alloc_stack $SomeStruct
   %stk0Ref = struct_element_addr %stk0 : $*SomeStruct, #SomeStruct.someRef
   store %localRef to %stk0Ref : $*SomeClass
@@ -66,7 +66,7 @@ bb0(%0 : $*SomeProtocol, %1 : $SomeClass):
   // EscapeAnalysis for only a few special instructions, like
   // init_existential_addr.
   %stkAdr1 = alloc_stack $SomeProtocol
-  copy_addr %0 to [initialization] %stkAdr1 : $*SomeProtocol
+  copy_addr %0 to [init] %stkAdr1 : $*SomeProtocol
   %instanceAdr = init_existential_addr %indirectLocalPropAdr : $*SomeProtocol, $SomeInstance
   %openadr1 = open_existential_addr immutable_access %stkAdr1 : $*SomeProtocol to $*@opened("6419340C-0B14-11EA-9897-ACDE48001122", SomeProtocol) Self
   %witness1 = witness_method $@opened("6419340C-0B14-11EA-9897-ACDE48001122", SomeProtocol) Self, #SomeProtocol.foo : <Self where Self : SomeProtocol> (Self) -> () -> (), %openadr1 : $*@opened("6419340C-0B14-11EA-9897-ACDE48001122", SomeProtocol) Self : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> ()
@@ -77,7 +77,7 @@ bb0(%0 : $*SomeProtocol, %1 : $SomeClass):
   // creates a content node that refers back to the dead stack
   // location.
   %stkAdr2 = alloc_stack $SomeProtocol
-  copy_addr %propAdr1 to [initialization] %stkAdr2 : $*SomeProtocol
+  copy_addr %propAdr1 to [init] %stkAdr2 : $*SomeProtocol
   %openadr2 = open_existential_addr immutable_access %stkAdr2 : $*SomeProtocol to $*@opened("6419340C-0B14-11EA-9897-ACDE48001123", SomeProtocol) Self
   %witness2 = witness_method $@opened("6419340C-0B14-11EA-9897-ACDE48001123", SomeProtocol) Self, #SomeProtocol.foo : <Self where Self : SomeProtocol> (Self) -> () -> (), %openadr2 : $*@opened("6419340C-0B14-11EA-9897-ACDE48001123", SomeProtocol) Self : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> ()
   %call2 = apply %witness2<@opened("6419340C-0B14-11EA-9897-ACDE48001123", SomeProtocol) Self>(%openadr2) : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> ()

--- a/test/SILOptimizer/escape_analysis_reduced.sil
+++ b/test/SILOptimizer/escape_analysis_reduced.sil
@@ -252,13 +252,13 @@ bb0(%0 : $Array<Int64>):
   %6 = alloc_stack $Int64, var, name "length"
   release_value %0 : $Array<Int64>
   %8 = alloc_stack $Int64
-  copy_addr %6 to [initialization] %8 : $*Int64
+  copy_addr %6 to [init] %8 : $*Int64
   destroy_addr %8 : $*Int64
   dealloc_stack %8 : $*Int64
   %12 = alloc_stack $Int64
-  copy_addr %6 to [initialization] %12 : $*Int64
+  copy_addr %6 to [init] %12 : $*Int64
   %14 = struct_element_addr %1 : $*Poly, #Poly.length
-  copy_addr [take] %12 to [initialization] %14 : $*Int64
+  copy_addr [take] %12 to [init] %14 : $*Int64
   dealloc_stack %12 : $*Int64
   destroy_addr %6 : $*Int64
   dealloc_stack %6 : $*Int64
@@ -487,12 +487,12 @@ bb1:
 
 bb2:
   %160 = struct_element_addr %6 : $*AssignmentNode, #AssignmentNode.variable
-  copy_addr [take] %1 to [initialization] %160 : $*ASTNode
+  copy_addr [take] %1 to [init] %160 : $*ASTNode
   %162 = struct_element_addr %6 : $*AssignmentNode, #AssignmentNode.value
   %164 = struct_element_addr %6 : $*AssignmentNode, #AssignmentNode.range
   %166 = struct_element_addr %6 : $*AssignmentNode, #AssignmentNode.documentation
   store %4 to %166 : $*Optional<String>
-  copy_addr [take] %6 to [initialization] %0 : $*AssignmentNode
+  copy_addr [take] %6 to [init] %0 : $*AssignmentNode
   dealloc_stack %6 : $*AssignmentNode
   %171 = tuple ()
   return %171 : $()
@@ -531,7 +531,7 @@ bb12:
 bb13(%125 : $()):
   dealloc_stack %115 : $*ASTNode
   %128 = init_existential_addr %0 : $*ASTNode, $AssignmentNode
-  copy_addr %113 to [initialization] %128 : $*AssignmentNode
+  copy_addr %113 to [init] %128 : $*AssignmentNode
   destroy_addr %113 : $*AssignmentNode
   dealloc_stack %113 : $*AssignmentNode
   release_value %1 : $VariableNode

--- a/test/SILOptimizer/escape_effects.sil
+++ b/test/SILOptimizer/escape_effects.sil
@@ -140,7 +140,7 @@ bb0(%0 : $Z):
   %1 = ref_element_addr %0 : $Z, #Z.y
   %2 = global_addr @globalY : $*Y
   // Even a store does not make the argument escaping.
-  copy_addr %2 to [initialization] %1 : $*Y
+  copy_addr %2 to [init] %1 : $*Y
   %4 = tuple ()
   return %4 : $()
 }
@@ -246,7 +246,7 @@ sil [ossa] @test_content_to_arg_addr : $@convention(thin) (@guaranteed Y) -> @ou
 bb0(%0 : $*Str, %1 : @guaranteed $Y):
   %2 = ref_element_addr %1 : $Y, #Y.s
   %3 = begin_access [read] [dynamic] %2 : $*Str
-  copy_addr %3 to [initialization] %0 : $*Str
+  copy_addr %3 to [init] %0 : $*Str
   end_access %3 : $*Str
   %6 = tuple ()
   return %6 : $()

--- a/test/SILOptimizer/escape_info.sil
+++ b/test/SILOptimizer/escape_info.sil
@@ -570,7 +570,7 @@ bb2:
 
 bb3:
   %13 = unchecked_take_enum_data_addr %3 : $*E, #E.B!enumelt
-  copy_addr [take] %13 to [initialization] %0 : $*Z
+  copy_addr [take] %13 to [init] %0 : $*Z
   dealloc_stack %3 : $*E
   %15 = tuple ()
   return %15 : $()
@@ -709,10 +709,10 @@ bb1:
   br bb3
 bb2:
   destroy_value %2 : $X
-  copy_addr %1 to [initialization] %4 : $*X
+  copy_addr %1 to [init] %4 : $*X
   br bb3
 bb3:
-  copy_addr %4 to [initialization] %0 : $*X
+  copy_addr %4 to [init] %0 : $*X
   destroy_addr %4 : $*X
   dealloc_stack %4 : $*X
 
@@ -730,7 +730,7 @@ bb0:
   %1 = alloc_ref $Y
   %2 = enum $Optional<Y>, #Optional.some!enumelt, %1 : $Y
   %3 = ref_element_addr %0 : $WZ, #WZ.w
-  store_weak %2 to [initialization] %3 : $*@sil_weak Optional<Y>
+  store_weak %2 to [init] %3 : $*@sil_weak Optional<Y>
   %5 = load_weak %3 : $*@sil_weak Optional<Y>
   return %5 : $Optional<Y>
 }
@@ -744,7 +744,7 @@ bb0:
   %0 = alloc_ref $WZ
   %1 = alloc_ref $Y
   %2 = ref_element_addr %0 : $WZ, #WZ.u
-  store_unowned %1 to [initialization] %2 : $*@sil_unowned Y
+  store_unowned %1 to [init] %2 : $*@sil_unowned Y
   %4 = load_unowned %2 : $*@sil_unowned Y
   return %4 : $Y
 }

--- a/test/SILOptimizer/existential_specializer_soletype.sil
+++ b/test/SILOptimizer/existential_specializer_soletype.sil
@@ -199,7 +199,7 @@ public struct S : P {
 // CHECK: [[F:%.*]] = function_ref @$s6test2_6storePyyAA1P_p_AaC_pztFTf4en_n : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0, @inout any P) -> ()
 // CHECK: [[ADR:%.*]] = open_existential_addr mutable_access %0 : $*any P to $*@opened([[TY:".*"]], any P) Self
 // CHECK: [[ALLOC:%.*]] = alloc_stack $@opened([[TY]], any P) Self
-// CHECK: copy_addr [[ADR]] to [initialization] [[ALLOC]] : $*@opened([[TY]], any P) Self
+// CHECK: copy_addr [[ADR]] to [init] [[ALLOC]] : $*@opened([[TY]], any P) Self
 // CHECK: apply [[F]]<@opened("{{.*}}", any P) Self>([[ALLOC]], %1) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0, @inout any P) -> ()
 // CHECK: destroy_addr %0 : $*any P
 // CHECK: dealloc_stack [[ALLOC]] : $*@opened([[TY]], any P) Self
@@ -212,9 +212,9 @@ public struct S : P {
 // CHECK: bb0(%0 : $*τ_0_0, %1 : $*any P):
 // CHECK:   [[ALLOC:%.*]] = alloc_stack $any P
 // CHECK:   [[IEA:%.*]] = init_existential_addr [[ALLOC]] : $*any P, $τ_0_0
-// CHECK:   copy_addr [take] %0 to [initialization] [[IEA]] : $*τ_0_0
+// CHECK:   copy_addr [take] %0 to [init] [[IEA]] : $*τ_0_0
 // CHECK-NOT: destroy
-// CHECK:   copy_addr [[ALLOC]] to [initialization] %1 : $*any P
+// CHECK:   copy_addr [[ALLOC]] to [init] %1 : $*any P
 // CHECK-NOT: destroy
 // CHECK:   destroy_addr [[ALLOC]] : $*any P
 // CHECK-NOT: destroy
@@ -226,16 +226,16 @@ public struct S : P {
 // CHECK:   [[ALLOCS:%.*]] = alloc_stack $S
 // CHECK:   [[ALLOCP:%.*]] = alloc_stack $any P
 // CHECK:   [[IEA:%.*]] = init_existential_addr [[ALLOCP]] : $*any P, $S
-// CHECK:   copy_addr [take] [[ALLOCS]] to [initialization] [[IEA]] : $*S
+// CHECK:   copy_addr [take] [[ALLOCS]] to [init] [[IEA]] : $*S
 // CHECK-NOT: destroy
-// CHECK:   copy_addr [[ALLOCP]] to [initialization] %1 : $*any P
+// CHECK:   copy_addr [[ALLOCP]] to [init] %1 : $*any P
 // CHECK:   destroy_addr [[ALLOCP]] : $*any P
 // CHECK:   dealloc_stack [[ALLOCP]]
 // CHECK:   dealloc_stack [[ALLOCS]]
 // CHECK-LABEL: } // end sil function '$s6test2_6storePyyAA1P_p_AaC_pztFTf4en_n4main1SV_Tg5'
 sil hidden [noinline] @$s6test2_6storePyyAA1P_p_AaC_pztF : $@convention(thin) (@in P, @inout P) -> () {
 bb0(%0 : $*P, %1 : $*P):
-  copy_addr %0 to [initialization] %1 : $*P
+  copy_addr %0 to [init] %1 : $*P
   destroy_addr %0 : $*P
   %5 = tuple ()
   return %5 : $()
@@ -246,7 +246,7 @@ bb0(%0 : $*P, %1 : $*P):
 // CHECK:   [[ALLOCS1:%.*]] = alloc_stack $S
 // CHECK:   store %0 to [[ALLOCS1]] : $*S
 // CHECK:   [[ALLOCS2:%.*]] = alloc_stack $S
-// CHECK:   copy_addr [[ALLOCS1]] to [initialization] [[ALLOCS2]] : $*S
+// CHECK:   copy_addr [[ALLOCS1]] to [init] [[ALLOCS2]] : $*S
 // CHECK:   [[F:%.*]] = function_ref @$s6test2_6storePyyAA1P_p_AaC_pztFTf4en_n4main1SV_Tg5 : $@convention(thin) (@owned S, @inout any P) -> ()
 // CHECK:   [[S:%.*]] = load [[ALLOCS2]] : $*S
 // CHECK:   apply [[F]]([[S]], %1) : $@convention(thin) (@owned S, @inout any P) -> ()
@@ -289,9 +289,9 @@ sil_witness_table S: P module test {}
 // CHECK: bb0(%0 : $*τ_0_0, %1 : $*any P):
 // CHECK:   [[ALLOCP1:%.*]] = alloc_stack $any P
 // CHECK:   [[ADR:%.*]] = init_existential_addr [[ALLOCP1]] : $*any P, $τ_0_0
-// CHECK:   copy_addr %0 to [initialization] [[ADR]] : $*τ_0_0
+// CHECK:   copy_addr %0 to [init] [[ADR]] : $*τ_0_0
 // CHECK:   [[ALLOCP2:%.*]] = alloc_stack $any P
-// CHECK:   copy_addr [[ALLOCP1]] to [initialization] [[ALLOCP2]] : $*any P
+// CHECK:   copy_addr [[ALLOCP1]] to [init] [[ALLOCP2]] : $*any P
 // CHECK:   copy_addr [take] [[ALLOCP2]] to %1 : $*any P
 // CHECK:   destroy_addr [[ALLOCP1]] : $*any P
 // CHECK:   dealloc_stack [[ALLOCP1]] : $*any P
@@ -299,7 +299,7 @@ sil_witness_table S: P module test {}
 sil hidden @$s6test3_6storePyyAA1P_pz_AaC_pztF : $@convention(thin) (@in_guaranteed P, @inout P) -> () {
 bb0(%0 : $*P, %1 : $*P):
   %5 = alloc_stack $P
-  copy_addr %0 to [initialization] %5 : $*P
+  copy_addr %0 to [init] %5 : $*P
   copy_addr [take] %5 to %1 : $*P
   dealloc_stack %5 : $*P
   %12 = tuple ()
@@ -312,9 +312,9 @@ bb0(%0 : $*P, %1 : $*P):
 // CHECK: store %0 to [[ALLOC1]] : $*S
 // CHECK: [[ALLOC2:%.*]] = alloc_stack $any P
 // CHECK: [[ADR:%.*]] = init_existential_addr [[ALLOC2]] : $*any P, $S
-// CHECK: copy_addr [[ALLOC1]] to [initialization] [[ADR]] : $*S
+// CHECK: copy_addr [[ALLOC1]] to [init] [[ADR]] : $*S
 // CHECK: [[ALLOC3:%.*]] = alloc_stack $any P
-// CHECK: copy_addr [[ALLOC2]] to [initialization] [[ALLOC3]] : $*any P
+// CHECK: copy_addr [[ALLOC2]] to [init] [[ALLOC3]] : $*any P
 // CHECK: copy_addr [take] [[ALLOC3]] to %1 : $*any P
 // CHECK: dealloc_stack [[ALLOC3]] : $*any P
 // CHECK: destroy_addr [[ALLOC2]] : $*any P
@@ -342,14 +342,14 @@ bb0(%0 : $S, %1 : $*P):
 // CHECK-LABEL: sil hidden @$s6test4_6storePyyAA1P_pz_AaC_pztF : $@convention(thin) (@inout any P, @inout any P) -> () {
 // CHECK: bb0(%0 : $*any P, %1 : $*any P):
 // CHECK: [[ALLOC:%.*]] = alloc_stack $any P
-// CHECK:   copy_addr %0 to [initialization] [[ALLOC]] : $*any P
+// CHECK:   copy_addr %0 to [init] [[ALLOC]] : $*any P
 // CHECK:   copy_addr [take] [[ALLOC]] to %1 : $*any P
 // CHECK:   dealloc_stack [[ALLOC]] : $*any P
 // CHECK-LABEL: } // end sil function '$s6test4_6storePyyAA1P_pz_AaC_pztF'
 sil hidden @$s6test4_6storePyyAA1P_pz_AaC_pztF : $@convention(thin) (@inout P, @inout P) -> () {
 bb0(%0 : $*P, %1 : $*P):
   %5 = alloc_stack $P
-  copy_addr %0 to [initialization] %5 : $*P
+  copy_addr %0 to [init] %5 : $*P
   copy_addr [take] %5 to %1 : $*P
   dealloc_stack %5 : $*P
   %12 = tuple ()
@@ -363,7 +363,7 @@ bb0(%0 : $*P, %1 : $*P):
 // CHECK:   [[ADR1:%.*]] = init_existential_addr [[ALLOC]] : $*any P, $S
 // CHECK:   store %0 to [[ADR1]] : $*S
 // CHECK:   [[ALLOC2:%.*]] = alloc_stack $any P
-// CHECK:   copy_addr %2 to [initialization] %5 : $*any P
+// CHECK:   copy_addr %2 to [init] %5 : $*any P
 // CHECK:   copy_addr [take] %5 to %1 : $*any P
 // CHECK:   destroy_addr [[ALLOC]] : $*any P
 // CHECK:   dealloc_stack [[ALLOC]] : $*any P

--- a/test/SILOptimizer/existential_transform_extras.sil
+++ b/test/SILOptimizer/existential_transform_extras.sil
@@ -74,7 +74,7 @@ sil public_external [serialized] @$s7dealloc20wrap_foo_ncp_another1aSiAA1P_pz_tF
 bb0(%0 : $*P):
   debug_value %0 : $*P, var, name "a", argno 1, expr op_deref
   %2 = alloc_stack $P                             
-  copy_addr %0 to [initialization] %2 : $*P      
+  copy_addr %0 to [init] %2 : $*P      
   %4 = open_existential_addr immutable_access %2 : $*P to $*@opened("EE9F89E4-ECF4-11E8-8DDF-D0817AD4059B", P) Self
   %5 = witness_method $@opened("EE9F89E4-ECF4-11E8-8DDF-D0817AD4059B", P) Self, #P.foo : <Self where Self : P> (Self) -> () -> Int32, %4 : $*@opened("EE9F89E4-ECF4-11E8-8DDF-D0817AD4059B", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int32
   %6 = apply %5<@opened("EE9F89E4-ECF4-11E8-8DDF-D0817AD4059B", P) Self>(%4) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int32
@@ -108,7 +108,7 @@ sil hidden [noinline] @$helper : $@convention(thin) (@in P) -> Int32 {
 bb0(%0 : $*P):
   debug_value %0 : $*P, var, name "a", argno 1, expr op_deref
   %4 = alloc_stack $P
-  copy_addr %0 to [initialization] %4 : $*P
+  copy_addr %0 to [init] %4 : $*P
   destroy_addr %0 : $*P
   %6 = open_existential_addr immutable_access %4 : $*P to $*@opened("3CB58EC4-ECED-11E8-9798-D0817AD4059B", P) Self
   %7 = witness_method $@opened("3CB58EC4-ECED-11E8-9798-D0817AD4059B", P) Self, #P.foo : <Self where Self : P> (Self) -> () -> Int32, %6 : $*@opened("3CB58EC4-ECED-11E8-9798-D0817AD4059B", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int32
@@ -172,13 +172,13 @@ bb0(%0 : $*P, %1 : $*P):
   debug_value %0 : $*P, var, name "a", argno 1, expr op_deref
   debug_value %1 : $*P, var, name "b", argno 2, expr op_deref
   %4 = alloc_stack $P
-  copy_addr %0 to [initialization] %4 : $*P
+  copy_addr %0 to [init] %4 : $*P
   destroy_addr %0 : $*P
   %6 = open_existential_addr immutable_access %4 : $*P to $*@opened("4CB58EC4-ECED-11E8-9798-D0817AD4059B", P) Self
   %7 = witness_method $@opened("4CB58EC4-ECED-11E8-9798-D0817AD4059B", P) Self, #P.foo : <Self where Self : P> (Self) -> () -> Int32, %6 : $*@opened("4CB58EC4-ECED-11E8-9798-D0817AD4059B", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int32
   %8 = apply %7<@opened("4CB58EC4-ECED-11E8-9798-D0817AD4059B", P) Self>(%6) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int32
   %9 = alloc_stack $P
-  copy_addr %1 to [initialization] %9 : $*P
+  copy_addr %1 to [init] %9 : $*P
   destroy_addr %1 : $*P
   %11 = open_existential_addr immutable_access %9 : $*P to $*@opened("3CB58FAA-ECED-11E8-9798-D0817AD4059B", P) Self
   %12 = witness_method $@opened("3CB58FAA-ECED-11E8-9798-D0817AD4059B", P) Self, #P.foo : <Self where Self : P> (Self) -> () -> Int32, %11 : $*@opened("3CB58FAA-ECED-11E8-9798-D0817AD4059B", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int32

--- a/test/SILOptimizer/existential_transform_extras_ossa.sil
+++ b/test/SILOptimizer/existential_transform_extras_ossa.sil
@@ -94,7 +94,7 @@ sil public_external [ossa] [serialized] @$s7dealloc20wrap_foo_ncp_another1aSiAA1
 bb0(%0 : $*P):
   debug_value %0 : $*P, var, name "a", argno 1, expr op_deref
   %2 = alloc_stack $P
-  copy_addr %0 to [initialization] %2 : $*P
+  copy_addr %0 to [init] %2 : $*P
   %4 = open_existential_addr immutable_access %2 : $*P to $*@opened("EE9F89E4-ECF4-11E8-8DDF-D0817AD4059B", P) Self
   %5 = witness_method $@opened("EE9F89E4-ECF4-11E8-8DDF-D0817AD4059B", P) Self, #P.foo : <Self where Self : P> (Self) -> () -> Int32, %4 : $*@opened("EE9F89E4-ECF4-11E8-8DDF-D0817AD4059B", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int32
   %6 = apply %5<@opened("EE9F89E4-ECF4-11E8-8DDF-D0817AD4059B", P) Self>(%4) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int32
@@ -128,7 +128,7 @@ sil hidden [ossa] [noinline] @$helper : $@convention(thin) (@in P) -> Int32 {
 bb0(%0 : $*P):
   debug_value %0 : $*P, var, name "a", argno 1, expr op_deref
   %4 = alloc_stack $P
-  copy_addr %0 to [initialization] %4 : $*P
+  copy_addr %0 to [init] %4 : $*P
   destroy_addr %0 : $*P
   %6 = open_existential_addr immutable_access %4 : $*P to $*@opened("3CB58EC4-ECED-11E8-9798-D0817AD4059B", P) Self
   %7 = witness_method $@opened("3CB58EC4-ECED-11E8-9798-D0817AD4059B", P) Self, #P.foo : <Self where Self : P> (Self) -> () -> Int32, %6 : $*@opened("3CB58EC4-ECED-11E8-9798-D0817AD4059B", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int32
@@ -193,13 +193,13 @@ bb0(%0 : $*P, %1 : $*P):
   debug_value %0 : $*P, var, name "a", argno 1, expr op_deref
   debug_value %1 : $*P, var, name "b", argno 2, expr op_deref
   %4 = alloc_stack $P
-  copy_addr %0 to [initialization] %4 : $*P
+  copy_addr %0 to [init] %4 : $*P
   destroy_addr %0 : $*P
   %6 = open_existential_addr immutable_access %4 : $*P to $*@opened("4CB58EC4-ECED-11E8-9798-D0817AD4059B", P) Self
   %7 = witness_method $@opened("4CB58EC4-ECED-11E8-9798-D0817AD4059B", P) Self, #P.foo : <Self where Self : P> (Self) -> () -> Int32, %6 : $*@opened("4CB58EC4-ECED-11E8-9798-D0817AD4059B", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int32
   %8 = apply %7<@opened("4CB58EC4-ECED-11E8-9798-D0817AD4059B", P) Self>(%6) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int32
   %9 = alloc_stack $P
-  copy_addr %1 to [initialization] %9 : $*P
+  copy_addr %1 to [init] %9 : $*P
   destroy_addr %1 : $*P
   %11 = open_existential_addr immutable_access %9 : $*P to $*@opened("3CB58FAA-ECED-11E8-9798-D0817AD4059B", P) Self
   %12 = witness_method $@opened("3CB58FAA-ECED-11E8-9798-D0817AD4059B", P) Self, #P.foo : <Self where Self : P> (Self) -> () -> Int32, %11 : $*@opened("3CB58FAA-ECED-11E8-9798-D0817AD4059B", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int32

--- a/test/SILOptimizer/existential_type_propagation.sil
+++ b/test/SILOptimizer/existential_type_propagation.sil
@@ -91,7 +91,7 @@ bb0:
   %6 = apply %4(%5) : $@convention(thin) (@thick ArrayClassReaderWriter.Type) -> @owned ArrayClassReaderWriter
   store %6 to %3 : $*ArrayClassReaderWriter
   // Check that the type information set for %1 is propagated here to %2.
-  copy_addr %1 to [initialization] %2 : $*ReaderWriterType
+  copy_addr %1 to [init] %2 : $*ReaderWriterType
   %9 = open_existential_addr immutable_access %2 : $*ReaderWriterType to $*@opened("4305E696-5685-11E5-9393-B8E856428C60", ReaderWriterType) Self
   // Check that the type information reaches the witness_method instruction and allows for devirtualization.
   %10 = witness_method $@opened("4305E696-5685-11E5-9393-B8E856428C60", ReaderWriterType) Self, #ReaderWriterType.read, %9 : $*@opened("4305E696-5685-11E5-9393-B8E856428C60", ReaderWriterType) Self : $@convention(witness_method: ReaderWriterType) <τ_0_0 where τ_0_0 : ReaderWriterType> (Int32, @in_guaranteed τ_0_0) -> Int32
@@ -322,12 +322,12 @@ bb0(%0 : $*P, %1 : $Q):
   %opened = open_existential_addr immutable_access %adr : $*P to $*@opened("A66B9398-D800-11E7-8432-0A0000BBF6C0", P) Self
   %p1 = alloc_stack $P
   %v1 = init_existential_addr %p1 : $*P, $@opened("A66B9398-D800-11E7-8432-0A0000BBF6C0", P) Self
-  copy_addr %opened to [initialization] %v1 : $*@opened("A66B9398-D800-11E7-8432-0A0000BBF6C0", P) Self
-  copy_addr [take] %p1 to [initialization] %p0 : $*P
+  copy_addr %opened to [init] %v1 : $*@opened("A66B9398-D800-11E7-8432-0A0000BBF6C0", P) Self
+  copy_addr [take] %p1 to [init] %p0 : $*P
   destroy_addr %0 : $*P
   %v0 = open_existential_addr immutable_access %p0 : $*P to $*@opened("B66B9398-D800-11E7-8432-0A0000BBF6C0", P) Self
   %p2 = alloc_stack $@opened("B66B9398-D800-11E7-8432-0A0000BBF6C0", P) Self
-  copy_addr %v0 to [initialization] %p2 : $*@opened("B66B9398-D800-11E7-8432-0A0000BBF6C0", P) Self
+  copy_addr %v0 to [init] %p2 : $*@opened("B66B9398-D800-11E7-8432-0A0000BBF6C0", P) Self
   %wm = witness_method $@opened("B66B9398-D800-11E7-8432-0A0000BBF6C0", P) Self, #P.foo : <T where T : P> (T) -> () -> Int64, %opened : $*@opened("A66B9398-D800-11E7-8432-0A0000BBF6C0", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
   %call2 = apply %wm<@opened("B66B9398-D800-11E7-8432-0A0000BBF6C0", P) Self>(%p2) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> Int64
   destroy_addr %p2 : $*@opened("B66B9398-D800-11E7-8432-0A0000BBF6C0", P) Self

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -1667,7 +1667,7 @@ sil @generic_in_to_guaranteed_caller : $@convention(thin) <T where T : P> (@in T
 bb0(%0 : $*T):
   %2 = function_ref @generic_in_to_guaranteed : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> Int64
   %3 = alloc_stack $T
-  copy_addr %0 to [initialization] %3 : $*T
+  copy_addr %0 to [init] %3 : $*T
   %5 = apply %2<T>(%3) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> Int64
   dealloc_stack %3 : $*T
   %7 = apply %2<T>(%0) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in τ_0_0) -> Int64
@@ -1798,9 +1798,9 @@ bb0(%0 : $*T, %1 : $*S):
 sil [noinline] @generic_func_with_multple_generic_args_and_dead_generic_arg_caller : $@convention(thin) <T> (@in T) -> () {
 bb0(%0 : $*T):
   %2 = alloc_stack $T
-  copy_addr %0 to [initialization] %2 : $*T
+  copy_addr %0 to [init] %2 : $*T
   %4 = alloc_stack $T
-  copy_addr %0 to [initialization] %4 : $*T
+  copy_addr %0 to [init] %4 : $*T
   %f = function_ref @generic_func_with_multple_generic_args_and_dead_generic_arg : $@convention(thin) <T, S> (@in T, @in S) -> ()
   apply %f<T, T>(%2, %4) : $@convention(thin) <T, S> (@in T, @in S) -> () 
   dealloc_stack %4 : $*T

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -122,14 +122,14 @@ bb1:
 
 // CHECK-LABEL: sil [ossa] @combine_copy_addr
 // CHECK:      bb0(%0 : $*S, %1 : $*S):
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] %0
+// CHECK-NEXT:   copy_addr [take] %1 to [init] %0
 // CHECK-NEXT:   br bb1
 // CHECK:      bb1:
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
 sil [ossa] @combine_copy_addr : $@convention(thin) (@in S) -> @out S {
 bb0(%0 : $*S, %1 : $*S):
-  copy_addr %1 to [initialization] %0 : $*S
+  copy_addr %1 to [init] %0 : $*S
   br bb1
 bb1:
   destroy_addr %1 : $*S
@@ -170,10 +170,10 @@ bb4:
 // CHECK: [[A:%.*]] = alloc_stack $T
 // CHECK: apply
 // CHECK: debug_value [[A]] : $*T, expr op_deref
-// CHECK-OPT: copy_addr [take] [[A]] to [initialization] %0 : $*T
+// CHECK-OPT: copy_addr [take] [[A]] to [init] %0 : $*T
 // CHECKOPT-NOT: destroy_addr
 // CHECKOPT-NOT: debug_value [[A]]
-// CHECKDEB: copy_addr [[A]] to [initialization] %0 : $*T
+// CHECKDEB: copy_addr [[A]] to [init] %0 : $*T
 // CHECKDEB: debug_value [[A]]
 // CHECKDEB-NEXT: destroy_addr [[A]] : $*T
 // CHECK-LABEL: } // end sil function 'backward_init'
@@ -183,7 +183,7 @@ bb0(%0 : $*T):
   %f1 = function_ref @f_out : $@convention(thin) <τ_0_0> () -> @out τ_0_0
   %c1 = apply %f1<T>(%l1) : $@convention(thin) <τ_0_0> () -> @out τ_0_0
   debug_value %l1 : $*T, expr op_deref
-  copy_addr %l1 to [initialization] %0 : $*T
+  copy_addr %l1 to [init] %0 : $*T
   debug_value %0 : $*T, expr op_deref
   debug_value %l1 : $*T, expr op_deref
   destroy_addr %l1 : $*T
@@ -218,7 +218,7 @@ bb0(%0 : $*T, %1 : $Builtin.Int1):
   debug_value %0 : $*T, let, name "arg", argno 1, expr op_deref
   debug_value %1 : $Builtin.Int1, let, name "z", argno 2
   %4 = alloc_stack [lexical] $T, var, name "t"
-  copy_addr %0 to [initialization] %4 : $*T
+  copy_addr %0 to [init] %4 : $*T
   cond_br %1, bb1, bb2
 
 bb1:
@@ -265,7 +265,7 @@ bb0(%0 : $*T, %1 : $Builtin.Int1):
   debug_value %0 : $*T, let, name "arg", argno 1, expr op_deref
   debug_value %1 : $Builtin.Int1, let, name "z", argno 2
   %4 = alloc_stack $T, var, name "t"
-  copy_addr %0 to [initialization] %4 : $*T
+  copy_addr %0 to [init] %4 : $*T
   cond_br %1, bb1, bb2
 
 bb1:
@@ -301,7 +301,7 @@ bb3:
 sil hidden [ossa] @destroyLoop_lexical : $@convention(thin) <T> (@in_guaranteed T) -> () {
 bb0(%0 : $*T):
   %a = alloc_stack [lexical] $T, var, name "t"
-  copy_addr %0 to [initialization] %a : $*T
+  copy_addr %0 to [init] %a : $*T
   br bb1
 
 bb1:
@@ -338,7 +338,7 @@ bb3:
 sil hidden [ossa] @destroyLoop_nonlexical : $@convention(thin) <T> (@in_guaranteed T) -> () {
 bb0(%0 : $*T):
   %a = alloc_stack $T, var, name "t"
-  copy_addr %0 to [initialization] %a : $*T
+  copy_addr %0 to [init] %a : $*T
   br bb1
 
 bb1:
@@ -573,7 +573,7 @@ exit:
 sil [ossa] @hoist_over_load_from_stack : $@convention(thin) (@in X) -> @owned X {
 entry(%in_addr : $*X):
   %stack_addr = alloc_stack $X
-  copy_addr %in_addr to [initialization] %stack_addr : $*X
+  copy_addr %in_addr to [init] %stack_addr : $*X
   %unknown = function_ref @unknown : $@convention(thin) () -> ()
   apply %unknown() : $@convention(thin) () -> ()
   %retval = load [take] %stack_addr : $*X
@@ -739,7 +739,7 @@ entry(%instance : @owned $S):
   %inner = begin_access [read] [static] %outer : $*S
   %field_addr = struct_element_addr %inner : $*S, #S.x
   %field_addr_2 =  struct_element_addr %addr_2 : $*S, #S.x
-  copy_addr %field_addr to [initialization] %field_addr_2 : $*X
+  copy_addr %field_addr to [init] %field_addr_2 : $*X
   end_access %inner : $*S
   destroy_addr %outer : $*S
   end_access %outer : $*S
@@ -764,7 +764,7 @@ entry(%instance : @owned $S):
   %outer = begin_access [read] [static] %addr : $*S
   apply undef(%outer) : $@convention(thin) (@inout S) -> ()
   %inner = begin_access [read] [static] %outer : $*S
-  copy_addr %inner to [initialization] %addr_2 : $*S
+  copy_addr %inner to [init] %addr_2 : $*S
   end_access %inner : $*S
   destroy_addr %outer : $*S
   end_access %outer : $*S
@@ -867,8 +867,8 @@ entry(%instance : @owned $SXXI):
     store %instance to [init] %addr : $*SXXI
     %x_1_addr = struct_element_addr %addr : $*SXXI, #SXXI.x_1
     %x_2_addr = struct_element_addr %addr : $*SXXI, #SXXI.x_2
-    copy_addr %x_1_addr to [initialization] %x_1_alone : $*X
-    copy_addr %x_2_addr to [initialization] %x_2_alone : $*X
+    copy_addr %x_1_addr to [init] %x_1_alone : $*X
+    copy_addr %x_2_addr to [init] %x_2_alone : $*X
     destroy_addr %addr : $*SXXI
     %barrier = function_ref @unknown : $@convention(thin) () -> ()
     apply %barrier() : $@convention(thin) () -> ()
@@ -904,9 +904,9 @@ entry(%instance : @owned $STXXITXXII):
     %txxi_2_x_0_addr = tuple_element_addr %txxi_2_addr : $*(X, X, I), 0
     %txxi_2_x_1_addr = tuple_element_addr %txxi_2_addr : $*(X, X, I), 1
 
-    copy_addr %txxi_1_x_0_addr to [initialization] %txxi_1_alone : $*X
+    copy_addr %txxi_1_x_0_addr to [init] %txxi_1_alone : $*X
     %x1x1 = load [copy] %txxi_1_x_1_addr : $*X
-    copy_addr %txxi_2_x_0_addr to [initialization] %txxi_2_alone : $*X
+    copy_addr %txxi_2_x_0_addr to [init] %txxi_2_alone : $*X
     %x2x1 = load [copy] %txxi_2_x_1_addr : $*X
     destroy_addr %addr : $*STXXITXXII
     %barrier = function_ref @unknown : $@convention(thin) () -> ()
@@ -939,7 +939,7 @@ entry(%instance : @owned $STXXITXXII):
     %txxi_1_x_0_addr = tuple_element_addr %txxi_1_addr : $*(X, X, I), 0
     %txxi_1_x_1_addr = tuple_element_addr %txxi_1_addr : $*(X, X, I), 1
 
-    copy_addr %txxi_1_x_0_addr to [initialization] %txxi_1_alone : $*X
+    copy_addr %txxi_1_x_0_addr to [init] %txxi_1_alone : $*X
     %x1x1 = load [copy] %txxi_1_x_1_addr : $*X
     %txxi2 = load [copy] %txxi_2_addr : $*(X, X, I)
     destroy_addr %addr : $*STXXITXXII
@@ -1048,7 +1048,7 @@ entry(%out : $*T, %instance : @owned $AnyObject):
     %addr = alloc_stack $AnyObject
     store %instance to [init] %addr : $*AnyObject
     %cast_addr = unchecked_addr_cast %addr : $*AnyObject to $*T
-    copy_addr %cast_addr to [initialization] %out : $*T
+    copy_addr %cast_addr to [init] %out : $*T
     destroy_addr %addr : $*AnyObject
     dealloc_stack %addr : $*AnyObject
     %retval = tuple ()

--- a/test/SILOptimizer/hoist_destroy_addr_resilient.sil
+++ b/test/SILOptimizer/hoist_destroy_addr_resilient.sil
@@ -31,7 +31,7 @@ bb0:
   apply %get_range_out(%range_addr) : $@convention(thin) () -> @out Twople<Size>
   %range_upperBound_addr = struct_element_addr %range_addr : $*Twople<Size>, #Twople.upperBound
   %date_addr = alloc_stack $Size
-  copy_addr %range_upperBound_addr to [initialization] %date_addr : $*Size
+  copy_addr %range_upperBound_addr to [init] %date_addr : $*Size
   destroy_addr %range_addr : $*Twople<Size>
   destroy_addr %date_addr : $*Size
   dealloc_stack %date_addr : $*Size
@@ -58,8 +58,8 @@ bb0:
   %range_lowerBound_addr = struct_element_addr %range_addr : $*Twople<Size>, #Twople.lowerBound
   %date_addr_1 = alloc_stack $Size
   %date_addr_2 = alloc_stack $Size
-  copy_addr %range_upperBound_addr to [initialization] %date_addr_1 : $*Size
-  copy_addr %range_lowerBound_addr to [initialization] %date_addr_2 : $*Size
+  copy_addr %range_upperBound_addr to [init] %date_addr_1 : $*Size
+  copy_addr %range_lowerBound_addr to [init] %date_addr_2 : $*Size
   destroy_addr %range_addr : $*Twople<Size>
   destroy_addr %date_addr_1 : $*Size
   destroy_addr %date_addr_2 : $*Size

--- a/test/SILOptimizer/inline_generics.sil
+++ b/test/SILOptimizer/inline_generics.sil
@@ -24,7 +24,7 @@ public func callClosure<T>(arg: P) -> (T) -> Bool where T : P
 
 sil @genericFoo : $@convention(thin) <T> (@in T) -> @out T {
 bb0(%0 : $*T, %1 : $*T):
-  copy_addr [take] %1 to [initialization] %0 : $*T
+  copy_addr [take] %1 to [init] %0 : $*T
   %4 = tuple ()
   return %4 : $()
 } // end sil function 'genericFoo'
@@ -39,7 +39,7 @@ bb0(%0 : $*T, %1 : $*T):
   // function_ref genericFoo<A> (A) -> A
   %3 = function_ref @genericFoo : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
   %4 = alloc_stack $T
-  copy_addr %1 to [initialization] %4 : $*T
+  copy_addr %1 to [init] %4 : $*T
   %6 = apply %3<T>(%0, %4) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
   dealloc_stack %4 : $*T
   destroy_addr %1 : $*T
@@ -68,14 +68,14 @@ bb0(%0 : $T, %1 : $@callee_owned (@owned P) -> Bool):
 
 sil [always_inline] @alwaysInlineGenericCallee : $@convention(thin) <T> (@in T) -> @out T {
 bb0(%0 : $*T, %1 : $*T):
-  copy_addr [take] %1 to [initialization] %0 : $*T
+  copy_addr [take] %1 to [init] %0 : $*T
   %4 = tuple ()
   return %4 : $()
 } // end sil function 'alwaysInlineGenericCallee'
 
 sil [transparent] @transparentGenericCallee : $@convention(thin) <T> (@in T) -> @out T {
 bb0(%0 : $*T, %1 : $*T):
-  copy_addr [take] %1 to [initialization] %0 : $*T
+  copy_addr [take] %1 to [init] %0 : $*T
   %4 = tuple ()
   return %4 : $()
 } // end sil function 'transparentInlineGenericCallee'
@@ -103,14 +103,14 @@ bb0(%0 : $*T, %1 : $*T):
   // Call an [always_inline] function.
   %3 = function_ref @alwaysInlineGenericCallee : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
   %4 = alloc_stack $T
-  copy_addr %1 to [initialization] %4 : $*T
+  copy_addr %1 to [init] %4 : $*T
   %6 = apply %3<T>(%0, %4) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
   dealloc_stack %4 : $*T
 
   // Call a [transparent] function.
   %8 = function_ref @transparentGenericCallee : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
   %9 = alloc_stack $T
-  copy_addr %1 to [initialization] %9 : $*T
+  copy_addr %1 to [init] %9 : $*T
   %10 = apply %8<T>(%0, %9) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
   dealloc_stack %9 : $*T
 
@@ -118,7 +118,7 @@ bb0(%0 : $*T, %1 : $*T):
   // function_ref genericFoo<A> (A) -> A
   %12 = function_ref @genericFoo : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
   %13 = alloc_stack $T
-  copy_addr %1 to [initialization] %13 : $*T
+  copy_addr %1 to [init] %13 : $*T
   %15 = apply %12<T>(%0, %13) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
   dealloc_stack %13 : $*T
 

--- a/test/SILOptimizer/inline_heuristics.sil
+++ b/test/SILOptimizer/inline_heuristics.sil
@@ -402,7 +402,7 @@ bb0(%0 : $*T, %1 : $*U):
   // function_ref action<A> (A) -> ()
   %4 = function_ref @action : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   %5 = alloc_stack $T
-  copy_addr %0 to [initialization] %5 : $*T
+  copy_addr %0 to [init] %5 : $*T
   %7 = apply %4<T>(%5) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   dealloc_stack %5 : $*T
   destroy_addr %1 : $*U
@@ -420,7 +420,7 @@ bb0(%0 : $*U):
   %5 = alloc_stack $Int64
   store %4 to %5 : $*Int64
   %7 = alloc_stack $U
-  copy_addr %0 to [initialization] %7 : $*U
+  copy_addr %0 to [init] %7 : $*U
   %9 = apply %2<Int64, U>(%5, %7) : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_1) -> ()
   dealloc_stack %7 : $*U
   dealloc_stack %5 : $*Int64

--- a/test/SILOptimizer/inline_lifetime.sil
+++ b/test/SILOptimizer/inline_lifetime.sil
@@ -644,7 +644,7 @@ bb2:
 sil hidden [ossa] [always_inline] @callee_coro_inguaranteed : $@yield_once @convention(thin) <T> (@in_guaranteed T) -> @yields @inout T {
 bb0(%instance : $*T):
   %addr = alloc_stack $T
-  copy_addr %instance to [initialization] %addr : $*T
+  copy_addr %instance to [init] %addr : $*T
   yield %addr : $*T, resume bb1, unwind bb2
 bb1:
   destroy_addr %addr : $*T

--- a/test/SILOptimizer/issue-47644.sil
+++ b/test/SILOptimizer/issue-47644.sil
@@ -62,10 +62,10 @@ sil @GetOptionalModel : $@convention(method) (@in ReadonlyExternalFramework, @th
 // CHECK: [[ALLOC:%.*]] = alloc_stack $any ReadonlyExternalFramework, let, name "ExternalFramework"
 // CHECK-NEXT: [[INITE:%.*]] = init_existential_addr [[ALLOC]] : $*any ReadonlyExternalFramework, $ExternalFramework
 // CHECK: [[TALLOC1:%.*]] = alloc_stack $any ReadonlyExternalFramework
-// CHECK-NEXT: copy_addr [[ALLOC]] to [initialization] [[TALLOC1]] : $*any ReadonlyExternalFramework
+// CHECK-NEXT: copy_addr [[ALLOC]] to [init] [[TALLOC1]] : $*any ReadonlyExternalFramework
 // CHECK-NEXT: apply {{%.*}}([[TALLOC1]], {{%.*}}) : $@convention(method) (@in any ReadonlyExternalFramework, @thin ModelDataService.Type) -> @owned Optional<Model>
 // CHECK: [[TALLOC2:%.*]] = alloc_stack $any ReadonlyExternalFramework
-// CHECK-NEXT: copy_addr [[ALLOC]] to [initialization] [[TALLOC2]] : $*any ReadonlyExternalFramework
+// CHECK-NEXT: copy_addr [[ALLOC]] to [init] [[TALLOC2]] : $*any ReadonlyExternalFramework
 // CHECK-NEXT: destroy_addr [[ALLOC]]
 // CHECK: [[OEADDR:%.*]] = open_existential_addr immutable_access [[TALLOC2]] : $*any ReadonlyExternalFramework
 sil hidden @BuggyFunction : $@convention(thin) () -> @owned Model {
@@ -84,7 +84,7 @@ bb1(%5 : $ExternalFramework):                                 // Preds: bb0
   %7 = function_ref @GetOptionalModel : $@convention(method) (@in ReadonlyExternalFramework, @thin ModelDataService.Type) -> @owned Optional<Model> // user: %11
   %8 = metatype $@thin ModelDataService.Type      // user: %11
   %9 = alloc_stack $ReadonlyExternalFramework                 // users: %12, %11, %10
-  copy_addr %0 to [initialization] %9 : $*ReadonlyExternalFramework // id: %10
+  copy_addr %0 to [init] %9 : $*ReadonlyExternalFramework // id: %10
   %11 = apply %7(%9, %8) : $@convention(method) (@in ReadonlyExternalFramework, @thin ModelDataService.Type) -> @owned Optional<Model> // user: %13
   dealloc_stack %9 : $*ReadonlyExternalFramework              // id: %12
   switch_enum %11 : $Optional<Model>, case #Optional.some!enumelt: bb4, case #Optional.none!enumelt: bb3 // id: %13
@@ -100,7 +100,7 @@ bb3:                                              // Preds: bb1
   %18 = apply %17() : $@convention(thin) () -> Builtin.RawPointer // user: %19
   %19 = pointer_to_address %18 : $Builtin.RawPointer to [strict] $*Array<String> // users: %158, %156, %152, %151
   %70 = alloc_stack $ReadonlyExternalFramework                // users: %106, %99, %73, %107, %71
-  copy_addr %0 to [initialization] %70 : $*ReadonlyExternalFramework // id: %71
+  copy_addr %0 to [init] %70 : $*ReadonlyExternalFramework // id: %71
   destroy_addr %0 : $*ReadonlyExternalFramework               // id: %72
   debug_value %70 : $*ReadonlyExternalFramework, let, name "ExternalFramework", argno 1, expr op_deref // id: %73
   %75 = integer_literal $Builtin.Word, 1          // user: %78

--- a/test/SILOptimizer/lexical_lifetime_elim.sil
+++ b/test/SILOptimizer/lexical_lifetime_elim.sil
@@ -26,7 +26,7 @@ bb0(%0 : @owned $Klass):
 // CHECK-LABEL: sil [ossa] @lexical_lifetime_address : $@convention(thin) (@in Klass) -> () {
 // CHECK: bb0(%0 : $*Klass):
 // CHECK-NEXT:   %1 = alloc_stack $Klass
-// CHECK-NEXT:   copy_addr [take] %0 to [initialization] %1 : $*Klass
+// CHECK-NEXT:   copy_addr [take] %0 to [init] %1 : $*Klass
 // CHECK-NEXT:   destroy_addr %1 : $*Klass
 // CHECK-NEXT:   dealloc_stack %1 : $*Klass
 // CHECK-NEXT:   tuple ()
@@ -35,7 +35,7 @@ bb0(%0 : @owned $Klass):
 sil [ossa] @lexical_lifetime_address : $@convention(thin) (@in Klass) -> () {
 bb0(%0 : $*Klass):
   %1 = alloc_stack [lexical] $Klass
-  copy_addr [take] %0 to [initialization] %1 : $*Klass
+  copy_addr [take] %0 to [init] %1 : $*Klass
   destroy_addr %1 : $*Klass
   dealloc_stack %1 : $*Klass
   %9999 = tuple()

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -271,7 +271,7 @@ bb0(%0 : $*P):
   br bb1
 
 bb1:
-  copy_addr %0 to [initialization] %1 : $*P
+  copy_addr %0 to [init] %1 : $*P
   %2 = existential_metatype $@thick P.Type, %1 : $*P
   cond_br undef, bb1, bb2
 

--- a/test/SILOptimizer/loweraggregateinstrs_expandall.sil
+++ b/test/SILOptimizer/loweraggregateinstrs_expandall.sil
@@ -164,7 +164,7 @@ bb0(%0 : $*E):
 // CHECK: return
 sil @expand_copy_addr_takeinit : $@convention(thin) (@inout S, @inout S) -> () {
 bb0(%0 : $*S, %1 : $*S):
-  copy_addr [take] %0 to [initialization] %1 : $*S
+  copy_addr [take] %0 to [init] %1 : $*S
   %2 = tuple()
   return %2 : $()
 }
@@ -185,7 +185,7 @@ bb0(%0 : $*S, %1 : $*S):
 // CHECK: } // end sil function 'expand_copy_addr_init'
 sil @expand_copy_addr_init : $@convention(thin) (@inout S, @inout S) -> () {
 bb0(%0 : $*S, %1 : $*S):
-  copy_addr %0 to [initialization] %1 : $*S
+  copy_addr %0 to [init] %1 : $*S
   %2 = tuple()
   return %2 : $()
 }
@@ -330,7 +330,7 @@ bb0(%0 : $*(S, S2, C1, E), %1 : $*(S, S2, C1, E)):
 // CHECK: } // end sil function 'expand_copy_addr_addressonly'
 sil @expand_copy_addr_addressonly : $@convention(thin) <T> (@inout T) -> () {
 bb0(%0 : $*T):
-  copy_addr [take] %0 to [initialization] %0 : $*T
+  copy_addr [take] %0 to [init] %0 : $*T
   %1 = tuple()
   return %1 : $()
 }

--- a/test/SILOptimizer/loweraggregateinstrs_expandall_ossa.sil
+++ b/test/SILOptimizer/loweraggregateinstrs_expandall_ossa.sil
@@ -149,7 +149,7 @@ bb0(%0 : $*E):
 // CHECK: } // end sil function 'expand_copy_addr_takeinit'
 sil [ossa] @expand_copy_addr_takeinit : $@convention(thin) (@in S) -> @out S {
 bb0(%0 : $*S, %1 : $*S):
-  copy_addr [take] %1 to [initialization] %0 : $*S
+  copy_addr [take] %1 to [init] %0 : $*S
   %2 = tuple()
   return %2 : $()
 }
@@ -161,7 +161,7 @@ bb0(%0 : $*S, %1 : $*S):
 // CHECK: } // end sil function 'expand_copy_addr_init'
 sil [ossa] @expand_copy_addr_init : $@convention(thin) (@in_guaranteed S) -> @out S {
 bb0(%0 : $*S, %1 : $*S):
-  copy_addr %1 to [initialization] %0 : $*S
+  copy_addr %1 to [init] %0 : $*S
   %2 = tuple()
   return %2 : $()
 }

--- a/test/SILOptimizer/loweraggregateinstrs_ossa.sil
+++ b/test/SILOptimizer/loweraggregateinstrs_ossa.sil
@@ -77,7 +77,7 @@ bb0(%0 : @owned $LargeStruct, %1 : $*LargeStruct):
   %0a = copy_value %0 : $LargeStruct
   destroy_value %0 : $LargeStruct
   %2 = alloc_stack $LargeStruct
-  copy_addr %1 to [initialization] %2 : $*LargeStruct
+  copy_addr %1 to [init] %2 : $*LargeStruct
   destroy_addr %1 : $*LargeStruct
   destroy_addr %2 : $*LargeStruct
   dealloc_stack %2 : $*LargeStruct
@@ -108,7 +108,7 @@ bb0(%0 : @guaranteed $S2, %1 : $*S2):
   %0a = copy_value %0 : $S2
   destroy_value %0a : $S2
   %2 = alloc_stack $S2
-  copy_addr %1 to [initialization] %2 : $*S2
+  copy_addr %1 to [init] %2 : $*S2
   destroy_addr %1 : $*S2
   destroy_addr %2 : $*S2
   dealloc_stack %2 : $*S2

--- a/test/SILOptimizer/mandatory_combiner.sil
+++ b/test/SILOptimizer/mandatory_combiner.sil
@@ -287,10 +287,10 @@ bb0(%0 : $*A):
  { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
   %10 = alloc_box $<τ_0_0 where τ_0_0 : Addable> { var τ_0_0 } <A>
   %11 = project_box %10 : $<τ_0_0 where τ_0_0 : Addable> { var τ_0_0 } <A>, 0
-  copy_addr %5 to [initialization] %11 : $*A
+  copy_addr %5 to [init] %11 : $*A
   %13 = alloc_box $<τ_0_0 where τ_0_0 : Addable> { var τ_0_0 } <A>
   %14 = project_box %13 : $<τ_0_0 where τ_0_0 : Addable> { var τ_0_0 } <A>, 0
-  copy_addr %1 to [initialization] %14 : $*A
+  copy_addr %1 to [init] %14 : $*A
   %16 = partial_apply [callee_guaranteed] %9<A>(%10, %13) : $@convention(thin) <τ_0_0 where τ_0_0 : Addable> (@in_guaranteed τ_0_0, @guaranteed <τ_0_0 where τ_0_0 : Addable> { var τ_0_0 } <τ_0_0>, @guaranteed <τ_0_0 where τ_0_0 : Addable> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
   strong_retain %16 : $@callee_guaranteed (@in_guaranteed A) -> @out A
   %19 = metatype $@thick A.Type
@@ -366,10 +366,10 @@ bb0(%0 : $*Proto):
   %7 = function_ref @first_of_three_protos : $@convention(thin) (@in_guaranteed Proto, @guaranteed { var Proto }, @guaranteed { var Proto }) -> @out Proto
   %8 = alloc_box ${ var Proto }
   %9 = project_box %8 : ${ var Proto }, 0
-  copy_addr %1 to [initialization] %9 : $*Proto
+  copy_addr %1 to [init] %9 : $*Proto
   %11 = alloc_box ${ var Proto }
   %12 = project_box %11 : ${ var Proto }, 0
-  copy_addr %4 to [initialization] %12 : $*Proto
+  copy_addr %4 to [init] %12 : $*Proto
   %14 = partial_apply [callee_guaranteed] %7(%8, %11) : $@convention(thin) (@in_guaranteed Proto, @guaranteed { var Proto }, @guaranteed { var Proto }) -> @out Proto
   strong_retain %14 : $@callee_guaranteed (@in_guaranteed Proto) -> @out Proto
   %17 = alloc_stack $Proto
@@ -434,7 +434,7 @@ bb0:
   %3 = function_ref @myint_from_myint_and_proto : $@convention(thin) (MyInt, @guaranteed { var Proto }) -> MyInt
   %4 = alloc_box ${ var Proto }
   %5 = project_box %4 : ${ var Proto }, 0
-  copy_addr %0 to [initialization] %5 : $*Proto
+  copy_addr %0 to [init] %5 : $*Proto
   %7 = partial_apply [callee_guaranteed] %3(%4) : $@convention(thin) (MyInt, @guaranteed { var Proto }) -> MyInt
   strong_retain %7 : $@callee_guaranteed (MyInt) -> MyInt
   %10 = integer_literal $Builtin.Int64, 5
@@ -464,7 +464,7 @@ bb0:
   %6 = function_ref @myint_from_proto_and_myint : $@convention(thin) (@guaranteed { var Proto }, MyInt) -> MyInt
   %7 = alloc_box ${ var Proto }
   %8 = project_box %7 : ${ var Proto }, 0
-  copy_addr %3 to [initialization] %8 : $*Proto
+  copy_addr %3 to [init] %8 : $*Proto
   %10 = partial_apply [callee_guaranteed] %6(%7, %1) : $@convention(thin) (@guaranteed { var Proto }, MyInt) -> MyInt
   strong_retain %10 : $@callee_guaranteed () -> MyInt
   %13 = apply %10() : $@callee_guaranteed () -> MyInt
@@ -492,7 +492,7 @@ bb0:
   %6 = function_ref @myint_from_proto_and_myint : $@convention(thin) (@guaranteed { var Proto }, MyInt) -> MyInt
   %7 = alloc_box ${ var Proto }
   %8 = project_box %7 : ${ var Proto }, 0
-  copy_addr %3 to [initialization] %8 : $*Proto
+  copy_addr %3 to [init] %8 : $*Proto
   %10 = partial_apply [callee_guaranteed] %6() : $@convention(thin) (@guaranteed { var Proto }, MyInt) -> MyInt
   strong_retain %10 : $@callee_guaranteed (@guaranteed { var Proto }, MyInt) -> MyInt
   %13 = apply %10(%7, %1) : $@callee_guaranteed (@guaranteed { var Proto }, MyInt) -> MyInt
@@ -692,10 +692,10 @@ bb0(%0 : $*A):
  { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
   %10 = alloc_box $<τ_0_0 where τ_0_0 : Addable> { var τ_0_0 } <A>
   %11 = project_box %10 : $<τ_0_0 where τ_0_0 : Addable> { var τ_0_0 } <A>, 0
-  copy_addr %5 to [initialization] %11 : $*A
+  copy_addr %5 to [init] %11 : $*A
   %13 = alloc_box $<τ_0_0 where τ_0_0 : Addable> { var τ_0_0 } <A>
   %14 = project_box %13 : $<τ_0_0 where τ_0_0 : Addable> { var τ_0_0 } <A>, 0
-  copy_addr %1 to [initialization] %14 : $*A
+  copy_addr %1 to [init] %14 : $*A
   %16 = partial_apply [callee_guaranteed] %9<A>(%10, %13) : $@convention(thin) <τ_0_0 where τ_0_0 : Addable> (@in_guaranteed τ_0_0, @guaranteed <τ_0_0 where τ_0_0 : Addable> { var τ_0_0 } <τ_0_0>, @guaranteed <τ_0_0 where τ_0_0 : Addable> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0
   %19 = metatype $@thick A.Type
   %20 = alloc_stack $A
@@ -766,10 +766,10 @@ bb0(%0 : $*Proto):
   %7 = function_ref @first_of_three_protos : $@convention(thin) (@in_guaranteed Proto, @guaranteed { var Proto }, @guaranteed { var Proto }) -> @out Proto
   %8 = alloc_box ${ var Proto }
   %9 = project_box %8 : ${ var Proto }, 0
-  copy_addr %1 to [initialization] %9 : $*Proto
+  copy_addr %1 to [init] %9 : $*Proto
   %11 = alloc_box ${ var Proto }
   %12 = project_box %11 : ${ var Proto }, 0
-  copy_addr %4 to [initialization] %12 : $*Proto
+  copy_addr %4 to [init] %12 : $*Proto
   %14 = partial_apply [callee_guaranteed] %7(%8, %11) : $@convention(thin) (@in_guaranteed Proto, @guaranteed { var Proto }, @guaranteed { var Proto }) -> @out Proto
   %17 = alloc_stack $Proto
   %19 = apply %2(%17) : $@convention(thin) () -> @out Proto
@@ -830,7 +830,7 @@ bb0:
   %3 = function_ref @myint_from_myint_and_proto : $@convention(thin) (MyInt, @guaranteed { var Proto }) -> MyInt
   %4 = alloc_box ${ var Proto }
   %5 = project_box %4 : ${ var Proto }, 0
-  copy_addr %0 to [initialization] %5 : $*Proto
+  copy_addr %0 to [init] %5 : $*Proto
   %7 = partial_apply [callee_guaranteed] %3(%4) : $@convention(thin) (MyInt, @guaranteed { var Proto }) -> MyInt
   %10 = integer_literal $Builtin.Int64, 5
   %11 = struct $MyInt (%10 : $Builtin.Int64)
@@ -858,7 +858,7 @@ bb0:
   %6 = function_ref @myint_from_proto_and_myint : $@convention(thin) (@guaranteed { var Proto }, MyInt) -> MyInt
   %7 = alloc_box ${ var Proto }
   %8 = project_box %7 : ${ var Proto }, 0
-  copy_addr %3 to [initialization] %8 : $*Proto
+  copy_addr %3 to [init] %8 : $*Proto
   %10 = partial_apply [callee_guaranteed] %6(%7, %1) : $@convention(thin) (@guaranteed { var Proto }, MyInt) -> MyInt
   %13 = apply %10() : $@callee_guaranteed () -> MyInt
   destroy_value %10 : $@callee_guaranteed () -> MyInt
@@ -884,7 +884,7 @@ bb0:
   %6 = function_ref @myint_from_proto_and_myint : $@convention(thin) (@guaranteed { var Proto }, MyInt) -> MyInt
   %7 = alloc_box ${ var Proto }
   %8 = project_box %7 : ${ var Proto }, 0
-  copy_addr %3 to [initialization] %8 : $*Proto
+  copy_addr %3 to [init] %8 : $*Proto
   %10 = partial_apply [callee_guaranteed] %6() : $@convention(thin) (@guaranteed { var Proto }, MyInt) -> MyInt
   %13 = apply %10(%7, %1) : $@callee_guaranteed (@guaranteed { var Proto }, MyInt) -> MyInt
   destroy_value %10 : $@callee_guaranteed (@guaranteed { var Proto }, MyInt) -> MyInt

--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -187,9 +187,9 @@ sil [transparent] @test_existential_metatype : $@convention(thin) (@in SomeProto
 bb0(%0 : $*SomeProtocol):
   %1 = alloc_box ${ var SomeProtocol }
   %1a = project_box %1 : ${ var SomeProtocol }, 0
-  copy_addr [take] %0 to [initialization] %1a : $*SomeProtocol
+  copy_addr [take] %0 to [init] %1a : $*SomeProtocol
   %4 = alloc_stack $SomeProtocol
-  copy_addr %1a to [initialization] %4 : $*SomeProtocol
+  copy_addr %1a to [init] %4 : $*SomeProtocol
   %6 = existential_metatype $@thick SomeProtocol.Type, %4 : $*SomeProtocol
   destroy_addr %4 : $*SomeProtocol
   dealloc_stack %4 : $*SomeProtocol
@@ -202,9 +202,9 @@ sil @inline_test_existential_metatype : $@convention(thin) (@in SomeProtocol) ->
 // CHECK: [[BB0:.*]]([[VAL0:%.*]] : $*any SomeProtocol):
   // CHECK: [[VAL1:%.*]] = alloc_box ${ var any SomeProtocol }
   // CHECK: [[PB1:%.*]] = project_box [[VAL1]]
-  // CHECK: copy_addr [take] %0 to [initialization] [[PB1]]
+  // CHECK: copy_addr [take] %0 to [init] [[PB1]]
   // CHECK: [[VAL4:%.*]] = alloc_stack $any SomeProtocol
-  // CHECK: copy_addr [[PB1]] to [initialization] [[VAL4]]
+  // CHECK: copy_addr [[PB1]] to [init] [[VAL4]]
   // CHECK: [[VAL6:%.*]] = existential_metatype $@thick any SomeProtocol.Type, [[VAL4]]
   // CHECK: destroy_addr [[VAL4]]
   // CHECK: dealloc_stack [[VAL4]]
@@ -772,7 +772,7 @@ sil [transparent] @inner : $@convention(thin) <T1, T2> (@in T1, @in T2) -> @out 
 bb0(%0 : $*T2, %1 : $*T1, %2 : $*T2):
   debug_value %1 : $*T1, expr op_deref
   debug_value %2 : $*T2, expr op_deref
-  copy_addr [take] %2 to [initialization] %0 : $*T2
+  copy_addr [take] %2 to [init] %0 : $*T2
   destroy_addr %1 : $*T1
   %7 = tuple ()
   return %7 : $()
@@ -790,7 +790,7 @@ bb0(%0 : $*T, %1 : $Int, %2 : $*T):
   %6 = alloc_stack $Int
   store %1 to %6 : $*Int
   %8 = alloc_stack $T
-  copy_addr %2 to [initialization] %8 : $*T
+  copy_addr %2 to [init] %8 : $*T
   // CHECK-NOT: apply
   %10 = apply %5<Int, T>(%0, %6, %8) : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_1) -> @out τ_0_1
   dealloc_stack %8 : $*T
@@ -852,7 +852,7 @@ bb0(%0 : $Foo):
 sil [transparent] @identity : $@convention(thin) <T> (@in T) -> @out T {
 bb0(%0 : $*T, %1 : $*T):
   debug_value %1 : $*T, expr op_deref
-  copy_addr [take] %1 to [initialization] %0 : $*T
+  copy_addr [take] %1 to [init] %0 : $*T
   %4 = tuple ()
   // CHECK: return
   return %4 : $()
@@ -864,7 +864,7 @@ bb0(%0 : $*T, %1 : $*T):
   debug_value %1 : $*T, expr op_deref
   %3 = function_ref @identity : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
   %4 = alloc_stack $T
-  copy_addr %1 to [initialization] %4 : $*T
+  copy_addr %1 to [init] %4 : $*T
   // CHECK-NOT: apply
   %6 = apply %3<T>(%0, %4) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
   dealloc_stack %4 : $*T
@@ -881,7 +881,7 @@ bb0(%0 : $*U, %1 : $*T, %2 : $@callee_owned (@in T) -> @out U):
   debug_value %2 : $@callee_owned (@in T) -> @out U
   strong_retain %2 : $@callee_owned (@in T) -> @out U
   %6 = alloc_stack $T
-  copy_addr %1 to [initialization] %6 : $*T
+  copy_addr %1 to [init] %6 : $*T
   // CHECK: apply %2
   %8 = apply %2(%0, %6) : $@callee_owned (@in T) -> @out U
   dealloc_stack %6 : $*T
@@ -969,7 +969,7 @@ bb0(%0 : $Builtin.Int8):
 sil [transparent] @P2_s : $@convention(method) <Self where Self : P2> (@in_guaranteed Self) -> Int32 {
 bb0(%0 : $*Self):
   %2 = alloc_stack $Self
-  copy_addr %0 to [initialization] %2 : $*Self
+  copy_addr %0 to [init] %2 : $*Self
   %4 = witness_method $Self, #P2.c!getter : $@convention(witness_method: P2) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
   %5 = apply %4<Self>(%2) : $@convention(witness_method: P2) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
   destroy_addr %2 : $*Self
@@ -995,7 +995,7 @@ sil hidden @L_start : $@convention(method) (@in_guaranteed L) -> Int32 {
 bb0(%0 : $*L):
   %2 = struct_element_addr %0 : $*L, #L.o
   %3 = alloc_stack $P2
-  copy_addr %2 to [initialization] %3 : $*P2
+  copy_addr %2 to [init] %3 : $*P2
   %5 = open_existential_addr immutable_access %3 : $*P2 to $*@opened("5C6E227C-235E-11E6-AA98-B8E856428C60", P2) Self
   %6 = function_ref @P2_s : $@convention(method) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
   %7 = apply %6<@opened("5C6E227C-235E-11E6-AA98-B8E856428C60", P2) Self>(%5) : $@convention(method) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
@@ -1452,7 +1452,7 @@ sil [ossa] @partial_apply_with_indirect_param : $@convention(thin) (@in_guarante
 bb0(%0 : $*Mystruct, %1 : $Bool):
   %216 = function_ref @callee_with_guaranteed : $@convention(thin) (Bool, @in_guaranteed Mystruct) -> ()
   %217 = alloc_stack $Mystruct
-  copy_addr %0 to [initialization] %217 : $*Mystruct
+  copy_addr %0 to [init] %217 : $*Mystruct
   %219 = partial_apply [callee_guaranteed] %216(%217) : $@convention(thin) (Bool, @in_guaranteed Mystruct) -> ()
   %220 = apply %219(%1) : $@callee_guaranteed (Bool) -> ()
   destroy_value %219 : $@callee_guaranteed (Bool) -> ()

--- a/test/SILOptimizer/mandatory_inlining_open_existential.sil
+++ b/test/SILOptimizer/mandatory_inlining_open_existential.sil
@@ -34,7 +34,7 @@ bb0(%0 : $*P, %1 : @owned $@callee_owned () -> @out τ_0_0):
   %2 = alloc_stack $τ_0_0
   %3 = apply %1(%2) : $@callee_owned () -> @out τ_0_0
   %4 = init_existential_addr %0 : $*P, $τ_0_0
-  copy_addr [take] %2 to [initialization] %4 : $*τ_0_0
+  copy_addr [take] %2 to [init] %4 : $*τ_0_0
   %6 = tuple ()
   dealloc_stack %2 : $*τ_0_0
   return %6 : $()

--- a/test/SILOptimizer/mandatory_inlining_ownership2.sil
+++ b/test/SILOptimizer/mandatory_inlining_ownership2.sil
@@ -185,9 +185,9 @@ sil [transparent] [ossa] @test_existential_metatype : $@convention(thin) (@in So
 bb0(%0 : $*SomeProtocol):
   %1 = alloc_box ${ var SomeProtocol }
   %1a = project_box %1 : ${ var SomeProtocol }, 0
-  copy_addr [take] %0 to [initialization] %1a : $*SomeProtocol
+  copy_addr [take] %0 to [init] %1a : $*SomeProtocol
   %4 = alloc_stack $SomeProtocol
-  copy_addr %1a to [initialization] %4 : $*SomeProtocol
+  copy_addr %1a to [init] %4 : $*SomeProtocol
   %6 = existential_metatype $@thick SomeProtocol.Type, %4 : $*SomeProtocol
   destroy_addr %4 : $*SomeProtocol
   dealloc_stack %4 : $*SomeProtocol
@@ -200,9 +200,9 @@ sil [ossa] @inline_test_existential_metatype : $@convention(thin) (@in SomeProto
 // CHECK: [[BB0:.*]]([[VAL0:%.*]] : $*any SomeProtocol):
   // CHECK: [[VAL1:%.*]] = alloc_box ${ var any SomeProtocol }
   // CHECK: [[PB1:%.*]] = project_box [[VAL1]]
-  // CHECK: copy_addr [take] %0 to [initialization] [[PB1]]
+  // CHECK: copy_addr [take] %0 to [init] [[PB1]]
   // CHECK: [[VAL4:%.*]] = alloc_stack $any SomeProtocol
-  // CHECK: copy_addr [[PB1]] to [initialization] [[VAL4]]
+  // CHECK: copy_addr [[PB1]] to [init] [[VAL4]]
   // CHECK: [[VAL6:%.*]] = existential_metatype $@thick any SomeProtocol.Type, [[VAL4]]
   // CHECK: destroy_addr [[VAL4]]
   // CHECK: dealloc_stack [[VAL4]]
@@ -781,7 +781,7 @@ sil [transparent] [ossa] @inner : $@convention(thin) <T1, T2> (@in T1, @in T2) -
 bb0(%0 : $*T2, %1 : $*T1, %2 : $*T2):
   debug_value %1 : $*T1, expr op_deref
   debug_value %2 : $*T2, expr op_deref
-  copy_addr [take] %2 to [initialization] %0 : $*T2
+  copy_addr [take] %2 to [init] %0 : $*T2
   destroy_addr %1 : $*T1
   %7 = tuple ()
   return %7 : $()
@@ -799,7 +799,7 @@ bb0(%0 : $*T, %1 : $Int, %2 : $*T):
   %6 = alloc_stack $Int
   store %1 to [trivial] %6 : $*Int
   %8 = alloc_stack $T
-  copy_addr %2 to [initialization] %8 : $*T
+  copy_addr %2 to [init] %8 : $*T
   // CHECK-NOT: apply
   %10 = apply %5<Int, T>(%0, %6, %8) : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_1) -> @out τ_0_1
   dealloc_stack %8 : $*T
@@ -867,7 +867,7 @@ bb0(%0 : @owned $Foo):
 sil [transparent] [ossa] @identity : $@convention(thin) <T> (@in T) -> @out T {
 bb0(%0 : $*T, %1 : $*T):
   debug_value %1 : $*T, expr op_deref
-  copy_addr [take] %1 to [initialization] %0 : $*T
+  copy_addr [take] %1 to [init] %0 : $*T
   %4 = tuple ()
   // CHECK: return
   return %4 : $()
@@ -879,7 +879,7 @@ bb0(%0 : $*T, %1 : $*T):
   debug_value %1 : $*T, expr op_deref
   %3 = function_ref @identity : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
   %4 = alloc_stack $T
-  copy_addr %1 to [initialization] %4 : $*T
+  copy_addr %1 to [init] %4 : $*T
   // CHECK-NOT: apply
   %6 = apply %3<T>(%0, %4) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
   dealloc_stack %4 : $*T
@@ -900,7 +900,7 @@ bb0(%0 : $*U, %1 : $*T, %2 : @owned $@callee_owned (@in T) -> @out U):
   debug_value %2 : $@callee_owned (@in T) -> @out U
   %2copy = copy_value %2 : $@callee_owned (@in T) -> @out U
   %6 = alloc_stack $T
-  copy_addr %1 to [initialization] %6 : $*T
+  copy_addr %1 to [init] %6 : $*T
   %8 = apply %2copy(%0, %6) : $@callee_owned (@in T) -> @out U
   dealloc_stack %6 : $*T
   destroy_value %2 : $@callee_owned (@in T) -> @out U
@@ -991,7 +991,7 @@ bb0(%0 : $Builtin.Int8):
 sil [transparent] [ossa] @P2_s : $@convention(method) <Self where Self : P2> (@in_guaranteed Self) -> Int32 {
 bb0(%0 : $*Self):
   %2 = alloc_stack $Self
-  copy_addr %0 to [initialization] %2 : $*Self
+  copy_addr %0 to [init] %2 : $*Self
   %4 = witness_method $Self, #P2.c!getter : $@convention(witness_method: P2) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
   %5 = apply %4<Self>(%2) : $@convention(witness_method: P2) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
   destroy_addr %2 : $*Self
@@ -1017,7 +1017,7 @@ sil hidden [ossa] @L_start : $@convention(method) (@in_guaranteed L) -> Int32 {
 bb0(%0 : $*L):
   %2 = struct_element_addr %0 : $*L, #L.o
   %3 = alloc_stack $P2
-  copy_addr %2 to [initialization] %3 : $*P2
+  copy_addr %2 to [init] %3 : $*P2
   %5 = open_existential_addr immutable_access %3 : $*P2 to $*@opened("5C6E227C-235E-11E6-AA98-B8E856428C60", P2) Self
   %6 = function_ref @P2_s : $@convention(method) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32
   %7 = apply %6<@opened("5C6E227C-235E-11E6-AA98-B8E856428C60", P2) Self>(%5) : $@convention(method) <τ_0_0 where τ_0_0 : P2> (@in_guaranteed τ_0_0) -> Int32

--- a/test/SILOptimizer/mem-behavior-cache-bug.sil
+++ b/test/SILOptimizer/mem-behavior-cache-bug.sil
@@ -35,7 +35,7 @@ bb0(%0 : $*Complex<RealType>, %1 : $*Complex<RealType>, %2 : $Bool, %3 : $@thin 
   debug_value %3 : $@thin Complex<RealType>.Type, let, name "self", argno 3
   %7 = alloc_stack $RealType, let, name "θ"
   %8 = alloc_stack $Complex<RealType>
-  copy_addr %1 to [initialization] %8 : $*Complex<RealType>
+  copy_addr %1 to [init] %8 : $*Complex<RealType>
   %10 = function_ref @callee : $@convention(method) <τ_0_0 where τ_0_0 : FloatingPoint> (@in_guaranteed Complex<τ_0_0>) -> @out τ_0_0
   %11 = apply %10<RealType>(%7, %8) : $@convention(method) <τ_0_0 where τ_0_0 : FloatingPoint> (@in_guaranteed Complex<τ_0_0>) -> @out τ_0_0
   destroy_addr %8 : $*Complex<RealType>
@@ -51,19 +51,19 @@ bb1:
   %20 = witness_method $RealType, #FloatingPoint.infinity!getter : <Self where Self : FloatingPoint> (Self.Type) -> () -> Self : $@convention(witness_method: FloatingPoint) <τ_0_0 where τ_0_0 : FloatingPoint> (@thick τ_0_0.Type) -> @out τ_0_0
   %21 = apply %20<RealType>(%19, %18) : $@convention(witness_method: FloatingPoint) <τ_0_0 where τ_0_0 : FloatingPoint> (@thick τ_0_0.Type) -> @out τ_0_0
   %22 = alloc_stack $RealType
-  copy_addr [take] %7 to [initialization] %22 : $*RealType
+  copy_addr [take] %7 to [init] %22 : $*RealType
   %24 = alloc_stack $Complex<RealType>
   %25 = alloc_stack $RealType
-  copy_addr [take] %19 to [initialization] %25 : $*RealType
+  copy_addr [take] %19 to [init] %25 : $*RealType
   %27 = struct_element_addr %24 : $*Complex<RealType>, #Complex.x
-  copy_addr [take] %25 to [initialization] %27 : $*RealType
+  copy_addr [take] %25 to [init] %27 : $*RealType
   dealloc_stack %25 : $*RealType
   %30 = alloc_stack $RealType
-  copy_addr [take] %22 to [initialization] %30 : $*RealType
+  copy_addr [take] %22 to [init] %30 : $*RealType
   %32 = struct_element_addr %24 : $*Complex<RealType>, #Complex.y
-  copy_addr [take] %30 to [initialization] %32 : $*RealType
+  copy_addr [take] %30 to [init] %32 : $*RealType
   dealloc_stack %30 : $*RealType
-  copy_addr %24 to [initialization] %0 : $*Complex<RealType>
+  copy_addr %24 to [init] %0 : $*Complex<RealType>
   destroy_addr %24 : $*Complex<RealType>
   dealloc_stack %24 : $*Complex<RealType>
   %38 = tuple ()
@@ -78,19 +78,19 @@ bb2:
   %45 = witness_method $RealType, #FloatingPoint.infinity!getter : <Self where Self : FloatingPoint> (Self.Type) -> () -> Self : $@convention(witness_method: FloatingPoint) <τ_0_0 where τ_0_0 : FloatingPoint> (@thick τ_0_0.Type) -> @out τ_0_0
   %46 = apply %45<RealType>(%44, %43) : $@convention(witness_method: FloatingPoint) <τ_0_0 where τ_0_0 : FloatingPoint> (@thick τ_0_0.Type) -> @out τ_0_0
   %47 = alloc_stack $RealType
-  copy_addr [take] %7 to [initialization] %47 : $*RealType
+  copy_addr [take] %7 to [init] %47 : $*RealType
   %49 = alloc_stack $Complex<RealType>
   %50 = alloc_stack $RealType
-  copy_addr [take] %44 to [initialization] %50 : $*RealType
+  copy_addr [take] %44 to [init] %50 : $*RealType
   %52 = struct_element_addr %49 : $*Complex<RealType>, #Complex.x
-  copy_addr [take] %50 to [initialization] %52 : $*RealType
+  copy_addr [take] %50 to [init] %52 : $*RealType
   dealloc_stack %50 : $*RealType
   %55 = alloc_stack $RealType
-  copy_addr [take] %47 to [initialization] %55 : $*RealType
+  copy_addr [take] %47 to [init] %55 : $*RealType
   %57 = struct_element_addr %49 : $*Complex<RealType>, #Complex.y
-  copy_addr [take] %55 to [initialization] %57 : $*RealType
+  copy_addr [take] %55 to [init] %57 : $*RealType
   dealloc_stack %55 : $*RealType
-  copy_addr %49 to [initialization] %0 : $*Complex<RealType>
+  copy_addr %49 to [init] %0 : $*Complex<RealType>
   destroy_addr %49 : $*Complex<RealType>
   dealloc_stack %49 : $*Complex<RealType>
   %63 = tuple ()

--- a/test/SILOptimizer/mem-behavior.sil
+++ b/test/SILOptimizer/mem-behavior.sil
@@ -789,20 +789,20 @@ bb0(%0 : $*Int64Wrapper):
 
 // CHECK-LABEL: @test_copy_addr_initialize
 // CHECK:      PAIR #0.
-// CHECK-NEXT:   copy_addr %1 to [initialization] %0 : $*C
+// CHECK-NEXT:   copy_addr %1 to [init] %0 : $*C
 // CHECK-NEXT:   %0 = argument of bb0 : $*C
 // CHECK-NEXT:   r=0,w=1
 // CHECK:      PAIR #1.
-// CHECK-NEXT:    copy_addr %1 to [initialization] %0 : $*C
+// CHECK-NEXT:    copy_addr %1 to [init] %0 : $*C
 // CHECK-NEXT:    %1 = argument of bb0 : $*C
 // CHECK-NEXT:    r=1,w=0
 // CHECK:      PAIR #2.
-// CHECK-NEXT:   copy_addr %1 to [initialization] %0 : $*C
+// CHECK-NEXT:   copy_addr %1 to [init] %0 : $*C
 // CHECK-NEXT:   %2 = argument of bb0 : $*C
 // CHECK-NEXT:   r=0,w=0
 sil @test_copy_addr_initialize : $@convention(thin) (@inout C, @inout C) -> @out C {
 bb0(%0 : $*C, %1 : $*C, %2: $*C):
-  copy_addr %1 to [initialization] %0 : $*C
+  copy_addr %1 to [init] %0 : $*C
   %6 = tuple ()
   return %6 : $()
 }
@@ -829,20 +829,20 @@ bb0(%0 : $*C, %1 : $*C, %2: $*C):
 
 // CHECK-LABEL: @test_copy_addr_take
 // CHECK:      PAIR #0.
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] %0 : $*C
+// CHECK-NEXT:   copy_addr [take] %1 to [init] %0 : $*C
 // CHECK-NEXT:   %0 = argument of bb0 : $*C
 // CHECK-NEXT:   r=0,w=1
 // CHECK:      PAIR #1.
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] %0 : $*C
+// CHECK-NEXT:   copy_addr [take] %1 to [init] %0 : $*C
 // CHECK-NEXT:   %1 = argument of bb0 : $*C
 // CHECK-NEXT:   r=1,w=1
 // CHECK:      PAIR #2.
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] %0 : $*C
+// CHECK-NEXT:   copy_addr [take] %1 to [init] %0 : $*C
 // CHECK-NEXT:   %2 = argument of bb0 : $*C
 // CHECK-NEXT:   r=0,w=0
 sil @test_copy_addr_take : $@convention(thin) (@in C, @inout C) -> @out C {
 bb0(%0 : $*C, %1 : $*C, %2: $*C):
-  copy_addr [take] %1 to [initialization] %0 : $*C
+  copy_addr [take] %1 to [init] %0 : $*C
   %6 = tuple ()
   return %6 : $()
 }

--- a/test/SILOptimizer/move_function_kills_addresses_dbginfo.sil
+++ b/test/SILOptimizer/move_function_kills_addresses_dbginfo.sil
@@ -34,7 +34,7 @@ case none
 // CHECK-LABEL: sil [ossa] @singleBlock : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 // CHECK:   [[SRC_ADDR:%.*]] = alloc_stack [lexical] [moved] $Builtin.NativeObject, let, name "[[VAR_NAME:.*]]"
 // CHECK:   [[DEST_ADDR:%.*]] = alloc_stack $Builtin.NativeObject
-// CHECK:   copy_addr [take] [[SRC_ADDR]] to [initialization] [[DEST_ADDR]]
+// CHECK:   copy_addr [take] [[SRC_ADDR]] to [init] [[DEST_ADDR]]
 // CHECK-NEXT: debug_value [moved] undef
 // CHECK: } // end sil function 'singleBlock'
 sil [ossa] @singleBlock : $@convention(thin) (@owned Builtin.NativeObject) -> () {
@@ -64,7 +64,7 @@ bb0(%0 : @owned $Builtin.NativeObject):
 // CHECK:   cond_br undef, [[LHS:bb[0-9]+]], [[RHS:bb[0-9]+]]
 //
 // CHECK: [[LHS]]:
-// CHECK:   copy_addr [take] [[SRC_ADDR]] to [initialization] [[DEST_ADDR]]
+// CHECK:   copy_addr [take] [[SRC_ADDR]] to [init] [[DEST_ADDR]]
 // CHECK:   debug_value [moved] undef : $*Builtin.NativeObject, let, name "[[VAR_NAME]]"
 // CHECK:   br bb
 //

--- a/test/SILOptimizer/opaque_values_Onone.swift
+++ b/test/SILOptimizer/opaque_values_Onone.swift
@@ -3,7 +3,7 @@
 // CHECK-LABEL: sil hidden @$s19opaque_values_Onone16generic_identity1txx_tlF : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
 // CHECK: bb0(%0 : $*T, %1 : $*T):
 // CHECK:   debug_value %1 : $*T, let, name "t", argno 1
-// CHECK:   copy_addr %1 to [initialization] %0 : $*T
+// CHECK:   copy_addr %1 to [init] %0 : $*T
 // CHECK-LABEL: } // end sil function '$s19opaque_values_Onone16generic_identity1txx_tlF'
 func generic_identity<T>(t: T) -> T {
   return t

--- a/test/SILOptimizer/opened_archetype_operands_tracking.sil
+++ b/test/SILOptimizer/opened_archetype_operands_tracking.sil
@@ -106,7 +106,7 @@ bb0(%0 : $*Self):
   %2 = function_ref @ItemStorage_alloc_init : $@convention(method) <τ_0_0 where τ_0_0 : View> (@in τ_0_0, @thick ItemStorage<τ_0_0>.Type) -> @owned ItemStorage<τ_0_0>
   %3 = metatype $@thick ItemStorage<Self>.Type
   %4 = alloc_stack $Self
-  copy_addr %0 to [initialization] %4 : $*Self
+  copy_addr %0 to [init] %4 : $*Self
   %6 = apply %2<Self>(%4, %3) : $@convention(method) <τ_0_0 where τ_0_0 : View> (@in τ_0_0, @thick ItemStorage<τ_0_0>.Type) -> @owned ItemStorage<τ_0_0>
   dealloc_stack %4 : $*Self
   %8 = upcast %6 : $ItemStorage<Self> to $DynamicStorage
@@ -163,14 +163,14 @@ bb0(%0 : $*T, %1 : $@thick Foo<T>.Type):
 sil @Foo_init : $@convention(method) <T where T : P> (@in T, @owned Foo<T>) -> @owned Foo<T> {
 bb0(%0 : $*T, %1 : $Foo<T>):
   %4 = alloc_stack $T
-  copy_addr %0 to [initialization] %4 : $*T
+  copy_addr %0 to [init] %4 : $*T
   %6 = ref_element_addr %1 : $Foo<T>, #Foo.x
-  copy_addr [take] %4 to [initialization] %6 : $*T
+  copy_addr [take] %4 to [init] %6 : $*T
   dealloc_stack %4 : $*T
   %9 = alloc_stack $T
-  copy_addr %0 to [initialization] %9 : $*T
+  copy_addr %0 to [init] %9 : $*T
   %11 = ref_element_addr %1 : $Foo<T>, #Foo.y
-  copy_addr [take] %9 to [initialization] %11 : $*T
+  copy_addr [take] %9 to [init] %11 : $*T
   dealloc_stack %9 : $*T
   destroy_addr %0 : $*T
   return %1 : $Foo<T>
@@ -183,21 +183,21 @@ bb0(%0 : $*Self):
   %2 = function_ref @Foo_alloc_init : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in τ_0_0, @thick Foo<τ_0_0>.Type) -> @owned Foo<τ_0_0>
   %3 = metatype $@thick Foo<Self>.Type
   %4 = alloc_stack $Self 
-  copy_addr %0 to [initialization] %4 : $*Self
+  copy_addr %0 to [init] %4 : $*Self
   %6 = apply %2<Self>(%4, %3) : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in τ_0_0, @thick Foo<τ_0_0>.Type) -> @owned Foo<τ_0_0>
   dealloc_stack %4 : $*Self 
   // function_ref use
   %9 = function_ref @use : $@convention(thin) <τ_0_0> (@in τ_0_0) -> () 
   %10 = ref_element_addr %6 : $Foo<Self>, #Foo.x 
   %11 = alloc_stack $Self
-  copy_addr %10 to [initialization] %11 : $*Self
+  copy_addr %10 to [init] %11 : $*Self
   %13 = apply %9<Self>(%11) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   dealloc_stack %11 : $*Self
   // function_ref use
   %15 = function_ref @use : $@convention(thin) <τ_0_0> (@in τ_0_0) -> () 
   %16 = ref_element_addr %6 : $Foo<Self>, #Foo.y
   %17 = alloc_stack $Self
-  copy_addr %16 to [initialization] %17 : $*Self
+  copy_addr %16 to [init] %17 : $*Self
   %19 = apply %15<Self>(%17) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   dealloc_stack %17 : $*Self
   strong_release %6 : $Foo<Self> 

--- a/test/SILOptimizer/optimize_keypath.swift
+++ b/test/SILOptimizer/optimize_keypath.swift
@@ -119,7 +119,7 @@ struct SimpleStruct: P {
 
 // CHECK-LABEL: sil {{.*}}testGenStructRead
 // CHECK: [[A:%[0-9]+]] = struct_element_addr %1
-// CHECK: copy_addr [[A]] to [initialization] %0
+// CHECK: copy_addr [[A]] to [init] %0
 // CHECK: return
 @inline(never)
 @_semantics("optimize.sil.specialize.generic.never")
@@ -131,7 +131,7 @@ func testGenStructRead<T>(_ s: GenStruct<T>) -> T {
 // CHECK-LABEL: sil {{.*}}testGenStructWrite
 // CHECK: [[A:%[0-9]+]] = struct_element_addr %0
 // CHECK: destroy_addr [[A]]
-// CHECK: copy_addr {{.*}} to [initialization] [[A]]
+// CHECK: copy_addr {{.*}} to [init] [[A]]
 // CHECK: return
 @inline(never)
 @_semantics("optimize.sil.specialize.generic.never")
@@ -143,7 +143,7 @@ func testGenStructWrite<T>(_ s: inout GenStruct<T>, _ t: T) {
 // CHECK-LABEL: sil {{.*}}testGenClassRead
 // CHECK: [[E:%[0-9]+]] = ref_element_addr %1
 // CHECK: [[A:%[0-9]+]] = begin_access [read] [dynamic] [no_nested_conflict] [[E]]
-// CHECK: copy_addr [[A]] to [initialization] %0
+// CHECK: copy_addr [[A]] to [init] %0
 // CHECK: end_access [[A]]
 // CHECK: return
 @inline(never)
@@ -185,7 +185,7 @@ func testDerivedClass2Read(_ c: DerivedClass2) -> Int {
 // CHECK: [[E:%[0-9]+]] = ref_element_addr %0
 // CHECK: [[A:%[0-9]+]] = begin_access [modify] [dynamic] [[E]]
 // CHECK: destroy_addr [[A]]
-// CHECK: copy_addr [take] [[S]] to [initialization] [[A]]
+// CHECK: copy_addr [take] [[S]] to [init] [[A]]
 // CHECK: end_access [[A]]
 // CHECK: return
 @inline(never)
@@ -252,7 +252,7 @@ func testNestedRead1(_ s: GenStruct<GenClass<GenStruct<SimpleClass>>>) -> Int {
 // CHECK: [[E1:%[0-9]+]] = ref_element_addr [[R]]
 // CHECK: [[A:%[0-9]+]] = begin_access [read] [dynamic] [no_nested_conflict] [[E1]]
 // CHECK: [[E2:%[0-9]+]] = struct_element_addr [[A]]
-// CHECK: copy_addr [[E2]] to [initialization] %0
+// CHECK: copy_addr [[E2]] to [init] %0
 // CHECK: end_access [[A]]
 // CHECK: return
 @inline(never)

--- a/test/SILOptimizer/optimize_never.sil
+++ b/test/SILOptimizer/optimize_never.sil
@@ -183,7 +183,7 @@ sil [Onone] @$s14optimize_never4foo1ys5Int32Vx_AA1CCtlF : $@convention(thin) <T>
 bb0(%0 : $*T, %1 : $C):
   %4 = function_ref @$s14optimize_never10transform1ys5Int32VxlF : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int32
   %5 = alloc_stack $T
-  copy_addr %0 to [initialization] %5 : $*T
+  copy_addr %0 to [init] %5 : $*T
   %7 = apply %4<T>(%5) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int32
   %8 = class_method %1 : $C, #C.foo : (C) -> () -> Int32, $@convention(method) (@guaranteed C) -> Int32
   %9 = apply %8(%1) : $@convention(method) (@guaranteed C) -> Int32
@@ -299,7 +299,7 @@ sil @$s14optimize_never4foo3ys5Int32Vx_AA1CCtlF : $@convention(thin) <T> (@in T,
 bb0(%0 : $*T, %1 : $C):
   %4 = function_ref @$s14optimize_never10transform3ys5Int32VxlF : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int32
   %5 = alloc_stack $T
-  copy_addr %0 to [initialization] %5 : $*T
+  copy_addr %0 to [init] %5 : $*T
   %7 = apply %4<T>(%5) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> Int32
   %8 = class_method %1 : $C, #C.foo : (C) -> () -> Int32, $@convention(method) (@guaranteed C) -> Int32
   %9 = apply %8(%1) : $@convention(method) (@guaranteed C) -> Int32

--- a/test/SILOptimizer/partial_specialization.sil
+++ b/test/SILOptimizer/partial_specialization.sil
@@ -37,13 +37,13 @@ bb0(%0 : $*U, %1 : $*V):
   // function_ref use
   %4 = function_ref @use : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   %5 = alloc_stack $U
-  copy_addr %0 to [initialization] %5 : $*U
+  copy_addr %0 to [init] %5 : $*U
   %7 = apply %4<U>(%5) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   dealloc_stack %5 : $*U
   // function_ref use
   %9 = function_ref @use : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   %10 = alloc_stack $V
-  copy_addr %1 to [initialization] %10 : $*V
+  copy_addr %1 to [init] %10 : $*V
   %12 = apply %9<V>(%10) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   dealloc_stack %10 : $*V
   destroy_addr %1 : $*V
@@ -58,7 +58,7 @@ bb0(%0 : $*U):
   // function_ref simple_generic_callee<A, B>(_:_:)
   %2 = function_ref @simple_generic_callee : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_1) -> ()
   %3 = alloc_stack $U
-  copy_addr %0 to [initialization] %3 : $*U
+  copy_addr %0 to [init] %3 : $*U
   %5 = integer_literal $Builtin.Int32, 1
   %6 = struct $Int32 (%5 : $Builtin.Int32)
   %7 = alloc_stack $Int32
@@ -80,7 +80,7 @@ bb0(%0 : $*U):
   %3 = function_ref @$s22partial_specialization1SVyACyxGxcfC : $@convention(method) <τ_0_0> (@in τ_0_0, @thin S<τ_0_0>.Type) -> S<τ_0_0>
   %4 = metatype $@thin S<U>.Type
   %5 = alloc_stack $U
-  copy_addr %0 to [initialization] %5 : $*U
+  copy_addr %0 to [init] %5 : $*U
   %7 = apply %3<U>(%5, %4) : $@convention(method) <τ_0_0> (@in τ_0_0, @thin S<τ_0_0>.Type) -> S<τ_0_0>
   dealloc_stack %5 : $*U
   %9 = alloc_stack $S<U>
@@ -117,7 +117,7 @@ bb0(%0 : $*U):
   // function_ref simple_generic_callee<A, B>(_:_:)
   %2 = function_ref @simple_generic_callee : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_1) -> ()
   %3 = alloc_stack $U
-  copy_addr %0 to [initialization] %3 : $*U
+  copy_addr %0 to [init] %3 : $*U
   %5 = apply %2<U, U>(%3, %0) : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_1) -> ()
   dealloc_stack %3 : $*U
   %7 = tuple ()
@@ -135,7 +135,7 @@ bb0(%0 : $*P, %1: $Builtin.Int1):
 bb1:
   %2 = open_existential_addr mutable_access %0 : $*P to $*@opened("1B6851A6-4796-11E6-B7DF-B8E856428C60", P) Self
   %3 = alloc_stack $@opened("1B6851A6-4796-11E6-B7DF-B8E856428C60", P) Self
-	copy_addr [take] %2 to [initialization] %3 : $*@opened("1B6851A6-4796-11E6-B7DF-B8E856428C60", P) Self
+	copy_addr [take] %2 to [init] %3 : $*@opened("1B6851A6-4796-11E6-B7DF-B8E856428C60", P) Self
   %5 = alloc_stack $Builtin.Int1
   store %1 to %5 : $*Builtin.Int1
   // function_ref simple_generic_callee<A, B>(_:_:)

--- a/test/SILOptimizer/partial_specialization_debug.sil
+++ b/test/SILOptimizer/partial_specialization_debug.sil
@@ -30,13 +30,13 @@ bb0(%0 : $*U, %1 : $*V):
   // function_ref use
   %4 = function_ref @use : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   %5 = alloc_stack $U
-  copy_addr %0 to [initialization] %5 : $*U
+  copy_addr %0 to [init] %5 : $*U
   %7 = apply %4<U>(%5) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   dealloc_stack %5 : $*U
   // function_ref use
   %9 = function_ref @use : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   %10 = alloc_stack $V
-  copy_addr %1 to [initialization] %10 : $*V
+  copy_addr %1 to [init] %10 : $*V
   %12 = apply %9<V>(%10) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   dealloc_stack %10 : $*V
   destroy_addr %1 : $*V
@@ -51,7 +51,7 @@ bb0(%0 : $*U):
   // function_ref simple_generic_callee<A, B>(_:_:)
   %2 = function_ref @simple_generic_callee : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_1) -> ()
   %3 = alloc_stack $U
-  copy_addr %0 to [initialization] %3 : $*U
+  copy_addr %0 to [init] %3 : $*U
   %5 = integer_literal $Builtin.Int32, 1
   %6 = struct $Int32 (%5 : $Builtin.Int32)
   %7 = alloc_stack $Int32

--- a/test/SILOptimizer/performance_inliner.sil
+++ b/test/SILOptimizer/performance_inliner.sil
@@ -886,7 +886,7 @@ bb2:
   return %10 : $()
 
 bb3:
-  copy_addr %1 to [initialization] %0 : $*T
+  copy_addr %1 to [init] %0 : $*T
   strong_release %15 : $Error
   br bb2
 

--- a/test/SILOptimizer/predictable_deadalloc_elim_ownership.sil
+++ b/test/SILOptimizer/predictable_deadalloc_elim_ownership.sil
@@ -144,7 +144,7 @@ bb0(%0 : @owned $Builtin.NativeObject, %1 : $*Builtin.NativeObject):
   %2 = alloc_stack $Builtin.NativeObject
   store %0 to [init] %2 : $*Builtin.NativeObject
   destroy_addr %2 : $*Builtin.NativeObject
-  copy_addr %1 to [initialization] %2 : $*Builtin.NativeObject
+  copy_addr %1 to [init] %2 : $*Builtin.NativeObject
   destroy_addr %2 : $*Builtin.NativeObject
   dealloc_stack %2 : $*Builtin.NativeObject
   %9999 = tuple()
@@ -164,7 +164,7 @@ bb0(%0 : @owned $Builtin.NativeObject, %1 : $*Builtin.NativeObject):
   %2 = alloc_stack $Builtin.NativeObject
   store %0 to [init] %2 : $*Builtin.NativeObject
   destroy_addr %2 : $*Builtin.NativeObject
-  copy_addr [take] %1 to [initialization] %2 : $*Builtin.NativeObject
+  copy_addr [take] %1 to [init] %2 : $*Builtin.NativeObject
   destroy_addr %2 : $*Builtin.NativeObject
   dealloc_stack %2 : $*Builtin.NativeObject
   %9999 = tuple()
@@ -275,7 +275,7 @@ bb0(%0 : @owned $Builtin.NativeObject, %1 : $*Builtin.NativeObject):
 
 bb1:
   destroy_addr %2 : $*Builtin.NativeObject
-  copy_addr [take] %1 to [initialization] %2 : $*Builtin.NativeObject
+  copy_addr [take] %1 to [init] %2 : $*Builtin.NativeObject
   br bb3
 
 bb2:

--- a/test/SILOptimizer/predictable_memopt.sil
+++ b/test/SILOptimizer/predictable_memopt.sil
@@ -334,7 +334,7 @@ bb0(%0 : $Int):               // CHECK: bb0(%0 : $Int):
   store %0 to %1 : $*Int
   %2 = alloc_stack $Int
 
-  copy_addr %1 to [initialization] %2 : $*Int
+  copy_addr %1 to [init] %2 : $*Int
 
   %3 = load %2 : $*Int
 
@@ -351,7 +351,7 @@ bb0(%0 : $Bool):  // CHECK: bb0(%0 :
   %1 = alloc_stack $Bool
   store %0 to %1 : $*Bool
   %3 = alloc_stack $Bool
-  copy_addr %1 to [initialization] %3 : $*Bool
+  copy_addr %1 to [init] %3 : $*Bool
   %5 = load %3 : $*Bool
   copy_addr %3 to %1 : $*Bool
   %12 = load %1 : $*Bool
@@ -497,7 +497,7 @@ sil @dead_allocation_1 : $@convention(thin) (Optional<AnyObject>) -> () {
   %2 = alloc_stack $Optional<AnyObject>
   store %0 to %2 : $*Optional<AnyObject>
 // CHECK-NOT: copy_addr
-  copy_addr %2 to [initialization] %1 : $*Optional<AnyObject>
+  copy_addr %2 to [init] %1 : $*Optional<AnyObject>
   dealloc_stack %2 : $*Optional<AnyObject>
   dealloc_stack %1 : $*Optional<AnyObject>
   %3 = tuple ()
@@ -513,7 +513,7 @@ sil @dead_allocation_2 : $@convention(thin) (Optional<AnyObject>) -> () {
   %2 = alloc_stack $Optional<AnyObject>
   store %0 to %1 : $*Optional<AnyObject>
 // CHECK-NOT: copy_addr
-  copy_addr %1 to [initialization] %2 : $*Optional<AnyObject>
+  copy_addr %1 to [init] %2 : $*Optional<AnyObject>
   dealloc_stack %2 : $*Optional<AnyObject>
   dealloc_stack %1 : $*Optional<AnyObject>
   %3 = tuple ()

--- a/test/SILOptimizer/predictable_memopt_ownership.sil
+++ b/test/SILOptimizer/predictable_memopt_ownership.sil
@@ -270,7 +270,7 @@ bb0(%0 : $Int):
   store %0 to [trivial] %1 : $*Int
   %2 = alloc_stack $Int
 
-  copy_addr %1 to [initialization] %2 : $*Int
+  copy_addr %1 to [init] %2 : $*Int
 
   %3 = load [trivial] %2 : $*Int
 
@@ -288,7 +288,7 @@ bb0(%0 : $Bool):
   %1 = alloc_stack $Bool
   store %0 to [trivial] %1 : $*Bool
   %3 = alloc_stack $Bool
-  copy_addr %1 to [initialization] %3 : $*Bool
+  copy_addr %1 to [init] %3 : $*Bool
   %5 = load [trivial] %3 : $*Bool
   copy_addr %3 to %1 : $*Bool
   %12 = load [trivial] %1 : $*Bool
@@ -433,7 +433,7 @@ bb0(%0 : @owned $Optional<AnyObject>):
   %2 = alloc_stack $Optional<AnyObject>
   store %0 to [init] %2 : $*Optional<AnyObject>
 // CHECK-NOT: copy_addr
-  copy_addr %2 to [initialization] %1 : $*Optional<AnyObject>
+  copy_addr %2 to [init] %1 : $*Optional<AnyObject>
   destroy_addr %2 : $*Optional<AnyObject>
   dealloc_stack %2 : $*Optional<AnyObject>
   destroy_addr %1 : $*Optional<AnyObject>
@@ -451,7 +451,7 @@ bb0(%0 : @owned $Optional<AnyObject>):
   %2 = alloc_stack $Optional<AnyObject>
   store %0 to [init] %1 : $*Optional<AnyObject>
 // CHECK-NOT: copy_addr
-  copy_addr %1 to [initialization] %2 : $*Optional<AnyObject>
+  copy_addr %1 to [init] %2 : $*Optional<AnyObject>
   destroy_addr %2 : $*Optional<AnyObject>
   dealloc_stack %2 : $*Optional<AnyObject>
   destroy_addr %1 : $*Optional<AnyObject>
@@ -1226,7 +1226,7 @@ bb1:
 
 bb2:
   %n = alloc_stack $Builtin.NativeObject
-  copy_addr [take] %1 to [initialization] %n : $*Builtin.NativeObject
+  copy_addr [take] %1 to [init] %n : $*Builtin.NativeObject
   %2 = load [take] %n : $*Builtin.NativeObject
   %3 = unchecked_ref_cast %2 : $Builtin.NativeObject to $Builtin.NativeObject
   %func = function_ref @owned_user : $@convention(thin) (@owned Builtin.NativeObject) -> @owned Builtin.NativeObject

--- a/test/SILOptimizer/raw_sil_inst_lowering.sil
+++ b/test/SILOptimizer/raw_sil_inst_lowering.sil
@@ -108,7 +108,7 @@ bb0(%0 : @owned $SomeClass):
   %9 = partial_apply [callee_guaranteed] %8() : $@convention(thin) (@owned SomeClass) -> @owned Wrapper<SomeClass>
   %10 = function_ref @set_closure : $@convention(method) (@owned SomeClass, @inout RefStruct) -> ()
   %11 = partial_apply [callee_guaranteed] %10(%1) : $@convention(method) (@owned SomeClass, @inout RefStruct) -> ()
-  assign_by_wrapper origin property_wrapper, %0 : $SomeClass to [initialization] %7 : $*Wrapper<SomeClass>, init %9 : $@callee_guaranteed (@owned SomeClass) -> @owned Wrapper<SomeClass>, set %11 : $@callee_guaranteed (@owned SomeClass) -> ()
+  assign_by_wrapper origin property_wrapper, %0 : $SomeClass to [init] %7 : $*Wrapper<SomeClass>, init %9 : $@callee_guaranteed (@owned SomeClass) -> @owned Wrapper<SomeClass>, set %11 : $@callee_guaranteed (@owned SomeClass) -> ()
   destroy_value %11 : $@callee_guaranteed (@owned SomeClass) -> ()
   destroy_value %9 : $@callee_guaranteed (@owned SomeClass) -> @owned Wrapper<SomeClass>
   %16 = load [take] %1 : $*RefStruct
@@ -132,7 +132,7 @@ bb0(%0 : @owned $SomeClass):
   %9 = partial_apply [callee_guaranteed] %8() : $@convention(thin) (@owned SomeClass) -> @out Wrapper<SomeClass>
   %10 = function_ref @set_closure : $@convention(method) (@owned SomeClass, @inout RefStruct) -> ()
   %11 = partial_apply [callee_guaranteed] %10(%1) : $@convention(method) (@owned SomeClass, @inout RefStruct) -> ()
-  assign_by_wrapper origin property_wrapper, %0 : $SomeClass to [initialization] %7 : $*Wrapper<SomeClass>, init %9 : $@callee_guaranteed (@owned SomeClass) -> @out Wrapper<SomeClass>, set %11 : $@callee_guaranteed (@owned SomeClass) -> ()
+  assign_by_wrapper origin property_wrapper, %0 : $SomeClass to [init] %7 : $*Wrapper<SomeClass>, init %9 : $@callee_guaranteed (@owned SomeClass) -> @out Wrapper<SomeClass>, set %11 : $@callee_guaranteed (@owned SomeClass) -> ()
   destroy_value %11 : $@callee_guaranteed (@owned SomeClass) -> ()
   destroy_value %9 : $@callee_guaranteed (@owned SomeClass) -> @out Wrapper<SomeClass>
   %16 = load [take] %1 : $*RefStruct

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -205,7 +205,7 @@ sil hidden @retain_not_blocked_by_copyaddrinit : $@convention(thin) <T> (@in T, 
 bb0(%0 : $*T, %1 : $*T, %2 : $B):
   strong_release %2 : $B
   strong_retain %2 : $B
-  copy_addr [take] %1 to [initialization] %0 : $*T // id: %3
+  copy_addr [take] %1 to [init] %0 : $*T // id: %3
   %4 = tuple ()                                   // user: %5
   return %4 : $()                                 // id: %5
 }

--- a/test/SILOptimizer/semantic-arc-opts-loadcopy-to-loadborrow.sil
+++ b/test/SILOptimizer/semantic-arc-opts-loadcopy-to-loadborrow.sil
@@ -1518,7 +1518,7 @@ bb3:
 // Make sure we don't crash on this code. We used to crash for @out args on the access path to the load
 sil [ossa] @test_opt_out_arg : $@convention(thin)(@in NonTrivialStruct) -> (@out NonTrivialStruct) {
 bb0(%0 : $*NonTrivialStruct, %1 : $*NonTrivialStruct):
-  copy_addr %1 to [initialization] %0 : $*NonTrivialStruct
+  copy_addr %1 to [init] %0 : $*NonTrivialStruct
   %ele = struct_element_addr %0 : $*NonTrivialStruct, #NonTrivialStruct.val
   %ld = load [copy] %ele : $*Klass
   destroy_value %ld : $Klass

--- a/test/SILOptimizer/semantic-arc-opts.sil
+++ b/test/SILOptimizer/semantic-arc-opts.sil
@@ -1210,7 +1210,7 @@ bb3(%14 : @owned $FakeOptional<Klass>):
 bb4(%16 : @owned $Klass):
   %17 = begin_borrow %16 : $Klass
   %18 = ref_element_addr %17 : $Klass, #Klass.base
-  copy_addr %18 to [initialization] %3 : $*Klass
+  copy_addr %18 to [init] %3 : $*Klass
   end_borrow %17 : $Klass
   destroy_value %16 : $Klass
   inject_enum_addr %0 : $*FakeOptional<Klass>, #FakeOptional.some!enumelt

--- a/test/SILOptimizer/shrink_borrow_scope.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.sil
@@ -657,7 +657,7 @@ entry(%instance : @owned $DBox):
   %d_addr = ref_element_addr %lifetime : $DBox, #DBox.d
   %d = load [copy] %d_addr : $*D
   %some_d = enum $Optional<D>, #Optional.some!enumelt, %d : $D
-  store_weak %some_d to [initialization] %addr : $*@sil_weak Optional<D>
+  store_weak %some_d to [init] %addr : $*@sil_weak Optional<D>
   destroy_value %some_d : $Optional<D>
 
   %loaded = load_weak %addr : $*@sil_weak Optional<D>

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -489,7 +489,7 @@ bb0(%0 : $*X, %1 : $*X):
 // CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @copy_doesnt_destoy : $@convention(thin) (@in_guaranteed X) -> @out X {
 bb0(%0 : $*X, %1 : $*X):
-  copy_addr %1 to [initialization] %0 : $*X
+  copy_addr %1 to [init] %0 : $*X
   %2 = tuple ()
   return %2 : $()
 }
@@ -593,7 +593,7 @@ bb0(%0 : $*X):
 sil [ossa] @copy_addr_take_and_destroy : $@convention(thin) (@in X) -> () {
 bb0(%0 : $*X):
   %1 = alloc_stack $X
-  copy_addr [take] %0 to [initialization] %1 : $*X
+  copy_addr [take] %0 to [init] %1 : $*X
   destroy_addr %1 : $*X
   dealloc_stack %1 : $*X
   %r = tuple ()
@@ -607,7 +607,7 @@ bb0(%0 : $*X):
 // CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @copy_addr_take_and_init : $@convention(thin) (@in X) -> @out X {
 bb0(%0 : $*X, %1 : $*X):
-  copy_addr [take] %1 to [initialization] %0 : $*X
+  copy_addr [take] %1 to [init] %0 : $*X
   %r = tuple ()
   return %r : $()
 }
@@ -619,7 +619,7 @@ bb0(%0 : $*X, %1 : $*X):
 sil [ossa] @copy_addr_and_destroy : $@convention(thin) (@in_guaranteed X) -> () {
 bb0(%0 : $*X):
   %1 = alloc_stack $X
-  copy_addr %0 to [initialization] %1 : $*X
+  copy_addr %0 to [init] %1 : $*X
   destroy_addr %1 : $*X
   dealloc_stack %1 : $*X
   %r = tuple ()
@@ -646,7 +646,7 @@ bb0(%0 : $*TwoSPs):
 sil [ossa] @copy_addr_and_consume_by_unknown_func : $@convention(thin) (@in X) -> () {
 bb0(%0 : $*X):
   %1 = alloc_stack $X
-  copy_addr [take] %0 to [initialization] %1 : $*X
+  copy_addr [take] %0 to [init] %1 : $*X
   %f = function_ref @unknown_func_with_in_arg : $@convention(thin) (@in X) -> ()
   %a = apply %f(%1) : $@convention(thin) (@in X) -> ()
   dealloc_stack %1 : $*X

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2295,7 +2295,7 @@ bb0:
   %0 = alloc_stack $FloatingPointRoundingRule
   inject_enum_addr %0 : $*FloatingPointRoundingRule, #FloatingPointRoundingRule.toNearestOrEven!enumelt
   %2 = alloc_stack $FloatingPointRoundingRule
-  copy_addr %0 to [initialization] %2 : $*FloatingPointRoundingRule
+  copy_addr %0 to [init] %2 : $*FloatingPointRoundingRule
   destroy_addr %0 : $*FloatingPointRoundingRule
   switch_enum_addr %2 : $*FloatingPointRoundingRule, case #FloatingPointRoundingRule.toNearestOrAwayFromZero!enumelt: bb1, default bb2
 
@@ -2601,7 +2601,7 @@ bb3 (%10: $Builtin.Int32):
 sil @delete_dead_alloc_stack : $(@inout B) -> () {
 bb0(%0 : $*B):
   %1 = alloc_stack $B
-  copy_addr %0 to [initialization] %1 : $*B
+  copy_addr %0 to [init] %1 : $*B
   destroy_addr %1 : $*B
   dealloc_stack %1 : $*B
   %2 = tuple()
@@ -2630,7 +2630,7 @@ bb0:
 sil @delete_dead_alloc_stack2 : $(@in B) -> () {
 bb0(%0 : $*B):
   %1 = alloc_stack $B
-  copy_addr [take] %0 to [initialization] %1 : $*B
+  copy_addr [take] %0 to [init] %1 : $*B
   destroy_addr %1 : $*B
   dealloc_stack %1 : $*B
   %2 = tuple()
@@ -2647,7 +2647,7 @@ sil @use_b : $@convention(thin) (@inout B) -> ()
 sil @dont_delete_dead_alloc_stack : $(@inout B) -> () {
 bb0(%0 : $*B):
   %1 = alloc_stack $B
-  copy_addr %0 to [initialization] %1 : $*B
+  copy_addr %0 to [init] %1 : $*B
   %2 = function_ref @use_b : $@convention(thin) (@inout B) -> ()
   %3 = apply %2(%1) : $@convention(thin) (@inout B) -> ()
   destroy_addr %1 : $*B
@@ -2666,7 +2666,7 @@ bb0(%0 : $B):
   %3 = alloc_stack $B
   %4 = alloc_stack $B
   store %0 to %4 : $*B
-  copy_addr [take] %4 to [initialization] %3 : $*B
+  copy_addr [take] %4 to [init] %3 : $*B
   dealloc_stack %4 : $*B
   strong_retain %0 : $B
   destroy_addr %3 : $*B
@@ -2689,7 +2689,7 @@ bb0(%0 : $B):
   %3 = alloc_stack $B
   %4 = alloc_stack $B
   store %0 to %4 : $*B
-  copy_addr [take] %4 to [initialization] %3 : $*B
+  copy_addr [take] %4 to [init] %3 : $*B
   dealloc_stack %4 : $*B
   cond_br undef, bb1, bb2
 bb1:
@@ -2715,7 +2715,7 @@ bb0(%0 : $B):
   %3 = alloc_stack $B
   %4 = alloc_stack $B
   store %0 to %4 : $*B
-  copy_addr [take] %4 to [initialization] %3 : $*B
+  copy_addr [take] %4 to [init] %3 : $*B
   dealloc_stack %4 : $*B
   cond_br undef, bb1, bb2
 bb1:
@@ -2744,7 +2744,7 @@ bb0(%0 : $B):
   %3 = alloc_stack $B
   %4 = alloc_stack $B
   store %0 to %4 : $*B
-  copy_addr [take] %4 to [initialization] %3 : $*B
+  copy_addr [take] %4 to [init] %3 : $*B
   dealloc_stack %4 : $*B
   br bb1
 bb1:
@@ -2773,7 +2773,7 @@ sil @witness_archetype : $@convention(thin) <T where T : someProtocol> (@in T) -
 bb0(%0 : $*T):
   %3 = alloc_stack $someProtocol                  // users: %4, %7, %10, %13, %15
   %4 = init_existential_addr %3 : $*someProtocol, $T // user: %5
-  copy_addr %0 to [initialization] %4 : $*T       // id: %5
+  copy_addr %0 to [init] %4 : $*T       // id: %5
   destroy_addr %0 : $*T                           // id: %6
   %7 = open_existential_addr immutable_access %3 : $*someProtocol to $*@opened("105977B0-D8EB-11E4-AC00-3C0754644993", someProtocol) Self // users: %8, %9
   %8 = witness_method $@opened("105977B0-D8EB-11E4-AC00-3C0754644993", someProtocol) Self, #someProtocol.i!getter, %7 : $*@opened("105977B0-D8EB-11E4-AC00-3C0754644993", someProtocol) Self : $@convention(witness_method: someProtocol) <τ_0_0 where τ_0_0 : someProtocol> (@in_guaranteed τ_0_0) -> Int // user: %9
@@ -3469,7 +3469,7 @@ bb0(%0 : $VV):
   %8 = alloc_stack $PM, let, name "x"
   %9 = ref_element_addr %0 : $VV, #VV.m
   %10 = alloc_stack $PM
-  copy_addr %9 to [initialization] %10 : $*PM
+  copy_addr %9 to [init] %10 : $*PM
   %12 = open_existential_addr immutable_access %10 : $*PM to $*@opened("090C3DB0-1C76-11E6-81C4-B8E856428C60", PM) Self
   %13 = init_existential_addr %8 : $*PM, $@opened("090C3DB0-1C76-11E6-81C4-B8E856428C60", PM) Self
   %14 = function_ref @plus : $@convention(method) <τ_0_0 where τ_0_0 : PM> (@in_guaranteed τ_0_0) -> @out τ_0_0

--- a/test/SILOptimizer/sil_combine_apply.sil
+++ b/test/SILOptimizer/sil_combine_apply.sil
@@ -62,13 +62,13 @@ sil @sil_combine_partial_apply_callee : $@convention(thin) (@in S1, @in S2, @in_
 //
 // CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
 // CHECK: [[IN_ADDRESS_1:%.*]] = alloc_stack $S1
-// CHECK: copy_addr [take] [[IN_ADDRESS]] to [initialization] [[IN_ADDRESS_1]]
+// CHECK: copy_addr [take] [[IN_ADDRESS]] to [init] [[IN_ADDRESS_1]]
 // CHECK: [[IN_ARG_1:%.*]] = alloc_stack $S2
-// CHECK: copy_addr [take] [[IN_ARG]] to [initialization] [[IN_ARG_1]]
+// CHECK: copy_addr [take] [[IN_ARG]] to [init] [[IN_ARG_1]]
 // CHECK: [[INGUARANTEED_ADDRESS_1:%.*]] = alloc_stack $S3
-// CHECK: copy_addr [take] [[INGUARANTEED_ADDRESS]] to [initialization] [[INGUARANTEED_ADDRESS_1]]
+// CHECK: copy_addr [take] [[INGUARANTEED_ADDRESS]] to [init] [[INGUARANTEED_ADDRESS_1]]
 // CHECK: [[INGUARANTEED_ARG_1:%.*]] = alloc_stack $S4
-// CHECK: copy_addr [take] [[INGUARANTEED_ARG]] to [initialization] [[INGUARANTEED_ARG_1]]
+// CHECK: copy_addr [take] [[INGUARANTEED_ARG]] to [init] [[INGUARANTEED_ARG_1]]
 //
 // Then make sure that the destroys are placed after the destroy_value of the
 // partial_apply (which is after this apply)...
@@ -142,7 +142,7 @@ sil @sil_combine_partial_apply_callee_2 : $@convention(thin) (@in S1) -> ()
 // CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
 // CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
 // CHECK-NEXT: [[NEW_ALLOC_STACK:%.*]] = alloc_stack $S1
-// CHECK-NEXT: copy_addr [take] [[ORIGINAL_ALLOC_STACK]] to [initialization] [[NEW_ALLOC_STACK]]
+// CHECK-NEXT: copy_addr [take] [[ORIGINAL_ALLOC_STACK]] to [init] [[NEW_ALLOC_STACK]]
 // CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
 // CHECK-NEXT: apply
 // CHECK-NEXT: cond_br undef, bb2, bb3
@@ -279,10 +279,10 @@ bb0:
 // CHECK-LABEL: sil @test_generic_partial_apply_apply_in :
 // CHECK: bb0([[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [take] [[ARG1]] to [initialization] [[STACK]]
+// CHECK:   copy_addr [take] [[ARG1]] to [init] [[STACK]]
 // CHECK: bb1:
 // CHECK:   [[STACK3:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[STACK]] to [initialization] [[STACK3]]
+// CHECK:   copy_addr [[STACK]] to [init] [[STACK3]]
 // CHECK:   apply {{%.*}}<T, T>([[ARG0]], [[STACK3]])
 // CHECK:   dealloc_stack [[STACK3]]
 // CHECK: bb2:
@@ -307,7 +307,7 @@ bb2:
 // CHECK-LABEL: sil @test_generic_partial_apply_apply_inguaranteed : $@convention(thin) <T> (@in T, @in T) -> () {
 // CHECK: bb0([[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [take] [[ARG1]] to [initialization] [[STACK]]
+// CHECK:   copy_addr [take] [[ARG1]] to [init] [[STACK]]
 // CHECK:   apply {{%.*}}<T, T>([[ARG0]], [[STACK]])
 // CHECK:   destroy_addr [[STACK]]
 // CHECK:   destroy_addr [[ARG0]]
@@ -327,9 +327,9 @@ bb0(%0 : $*T, %1 : $*T):
 // CHECK:   [[EX:%.*]] = open_existential_addr
 // CHECK:   [[METHOD:%.*]] = witness_method
 // CHECK:   [[STACK1:%.*]] = alloc_stack $@opened
-// CHECK:   copy_addr [[EX]] to [initialization] [[STACK1]]
+// CHECK:   copy_addr [[EX]] to [init] [[STACK1]]
 // CHECK:   [[STACK2:%.*]] = alloc_stack $@opened
-// CHECK:   copy_addr [take] [[STACK1]] to [initialization] [[STACK2]]
+// CHECK:   copy_addr [take] [[STACK1]] to [init] [[STACK2]]
 // CHECK:   apply [[METHOD]]<@opened{{.*}}>([[STACK2]])
 // CHECK:   destroy_addr [[STACK2]]
 // CHECK:   dealloc_stack [[STACK2]]
@@ -340,7 +340,7 @@ bb0(%0 : $*SwiftP):
   %1 = open_existential_addr immutable_access %0 : $*SwiftP to $*@opened("4305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self
   %2 = witness_method $@opened("4305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self, #SwiftP.foo, %1 : $*@opened("4305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self : $@convention(witness_method: SwiftP) <τ_0_0 where τ_0_0 : SwiftP> (@in_guaranteed τ_0_0) -> ()
   %0c = alloc_stack $@opened("4305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self
-  copy_addr %1 to [initialization] %0c : $*@opened("4305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self
+  copy_addr %1 to [init] %0c : $*@opened("4305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self
   %3 = partial_apply %2<@opened("4305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self>(%0c) : $@convention(witness_method: SwiftP) <τ_0_0 where τ_0_0 : SwiftP> (@in_guaranteed τ_0_0) -> ()
   dealloc_stack %0c : $*@opened("4305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self
   %4 = apply %3() : $@callee_owned () -> ()
@@ -366,7 +366,7 @@ bb0(%0 : $*MutatingProto, %1 : $MStruct):
   %4 = init_existential_addr %2 : $*MutatingProto, $MStruct
   store %1 to %4 : $*MStruct
   %9 = alloc_stack $MutatingProto
-  copy_addr %2 to [initialization] %9 : $*MutatingProto
+  copy_addr %2 to [init] %9 : $*MutatingProto
   // CHECK: [[E:%[0-9]+]] = open_existential_addr
   %11 = open_existential_addr mutable_access %9 : $*MutatingProto to $*@opened("FC5F3CFA-A7A4-11E7-911F-685B35C48C83", MutatingProto) Self
   // CHECK: [[M:%[0-9]+]] = witness_method $MStruct,
@@ -374,7 +374,7 @@ bb0(%0 : $*MutatingProto, %1 : $MStruct):
   // CHECK:  [[C:%[0-9]+]] = unchecked_addr_cast [[E]] : $*@opened("FC5F3CFA-A7A4-11E7-911F-685B35C48C83", any MutatingProto) Self to $*MStruct
   // CHECK: apply [[M]]<MStruct>([[C]]) :
   %13 = apply %12<@opened("FC5F3CFA-A7A4-11E7-911F-685B35C48C83", MutatingProto) Self>(%11) : $@convention(witness_method: MutatingProto) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> ()
-  copy_addr [take] %9 to [initialization] %0 : $*MutatingProto
+  copy_addr [take] %9 to [init] %0 : $*MutatingProto
   dealloc_stack %9 : $*MutatingProto
   destroy_addr %2 : $*MutatingProto
   dealloc_stack %2 : $*MutatingProto
@@ -389,7 +389,7 @@ bb0(%0 : $*MutatingProto, %1 : $@thick MutatingProto.Type):
   %openType = open_existential_metatype %1 : $@thick MutatingProto.Type to $@thick (@opened("66A6DAFC-AF78-11E7-8F3B-28CFE9213F4F", MutatingProto) Self).Type
   %initType =  init_existential_addr %alloc1 : $*MutatingProto, $@opened("66A6DAFC-AF78-11E7-8F3B-28CFE9213F4F", MutatingProto) Self
   %alloc2 = alloc_stack $MutatingProto
-  copy_addr %alloc1 to [initialization] %alloc2 : $*MutatingProto
+  copy_addr %alloc1 to [init] %alloc2 : $*MutatingProto
   %oeaddr = open_existential_addr mutable_access %alloc2 : $*MutatingProto to $*@opened("6E02DCF6-AF78-11E7-8F3B-28CFE9213F4F", MutatingProto) Self
   %witmethod = witness_method $@opened("66A6DAFC-AF78-11E7-8F3B-28CFE9213F4F", MutatingProto) Self, #MutatingProto.mutatingMethod : <Self where Self : MutatingProto> (inout Self) -> () -> (), %openType : $@thick (@opened("66A6DAFC-AF78-11E7-8F3B-28CFE9213F4F", MutatingProto) Self).Type : $@convention(witness_method: MutatingProto) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> ()
   // CHECK: apply {{%.*}}<@opened("6E02DCF6-AF78-11E7-8F3B-28CFE9213F4F", any MutatingProto) Self>({{%.*}}) : $@convention(witness_method: MutatingProto) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> () // type-defs
@@ -769,14 +769,14 @@ sil @closure_with_guaranteed_args : $@convention(method) (@guaranteed CC1) -> ()
 // CHECK-LABEL: sil @test_apply_of_partial_apply_in : $@convention(thin) (@in CC1) -> () {
 // CHECK:   [[FUNC:%.*]] = function_ref
 // CHECK:   [[STACK1:%.*]] = alloc_stack $CC1
-// CHECK:   copy_addr [take] %0 to [initialization] [[STACK1]]
+// CHECK:   copy_addr [take] %0 to [init] [[STACK1]]
 // CHECK:   cond_br undef, bb1, bb2
 // CHECK: bb1:
 // CHECK:   destroy_addr [[STACK1]]
 // CHECK:   dealloc_stack [[STACK1]]
 // CHECK: bb2:
 // CHECK:   [[STACK2:%.*]] = alloc_stack $CC1
-// CHECK:   copy_addr [[STACK1]] to [initialization] [[STACK2]]
+// CHECK:   copy_addr [[STACK1]] to [init] [[STACK2]]
 // CHECK:   apply [[FUNC]]([[STACK2]])
 // CHECK:   dealloc_stack [[STACK2]]
 // CHECK:   destroy_addr [[STACK1]]
@@ -805,9 +805,9 @@ bb3:
 // CHECK-LABEL: sil @test_apply_of_partial_apply_inguaranteed : $@convention(thin) (@in CC1) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[STACK1:%.*]] = alloc_stack $CC1
-// CHECK:   copy_addr [take] [[ARG]] to [initialization] [[STACK1]]
+// CHECK:   copy_addr [take] [[ARG]] to [init] [[STACK1]]
 // CHECK:   [[STACK2:%.*]] = alloc_stack $CC1
-// CHECK:   copy_addr [take] [[STACK1]] to [initialization] [[STACK2]]
+// CHECK:   copy_addr [take] [[STACK1]] to [init] [[STACK2]]
 // CHECK:   cond_br undef, bb1, bb2
 //
 // CHECK: bb1:
@@ -828,7 +828,7 @@ sil @test_apply_of_partial_apply_inguaranteed : $@convention(thin) (@in CC1) -> 
 bb0(%0 : $*CC1):
   %1 = function_ref @closure_with_inguaranteed_args : $@convention(method) (@in_guaranteed CC1) -> ()
   %2 = alloc_stack $CC1
-  copy_addr [take] %0 to [initialization] %2 : $*CC1
+  copy_addr [take] %0 to [init] %2 : $*CC1
   %3 = partial_apply %1(%2) : $@convention(method) (@in_guaranteed CC1) -> ()
   cond_br undef, bb1, bb2
 
@@ -928,7 +928,7 @@ bb3:
 // CHECK-NEXT:  [[S1:%[0-9]+]] = alloc_stack $Int
 // CHECK:       store %0 to [[S1]]
 // CHECK:       [[S2:%[0-9]+]] = alloc_stack $Int
-// CHECK:       copy_addr [[S1]] to [initialization] [[S2]]
+// CHECK:       copy_addr [[S1]] to [init] [[S2]]
 // CHECK:       apply {{.*}}(%1, [[S2]])
 // CHECK:       destroy_addr [[S2]] : $*Int
 // CHECK:       dealloc_stack [[S2]] : $*Int

--- a/test/SILOptimizer/sil_combine_apply_ossa.sil
+++ b/test/SILOptimizer/sil_combine_apply_ossa.sil
@@ -67,13 +67,13 @@ sil @sil_combine_partial_apply_callee : $@convention(thin) (@in S1, @in S2, @in_
 //
 // CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
 // CHECK: [[IN_ADDRESS_1:%.*]] = alloc_stack $S1
-// CHECK: copy_addr [take] [[IN_ADDRESS]] to [initialization] [[IN_ADDRESS_1]]
+// CHECK: copy_addr [take] [[IN_ADDRESS]] to [init] [[IN_ADDRESS_1]]
 // CHECK: [[IN_ARG_1:%.*]] = alloc_stack $S2
-// CHECK: copy_addr [take] [[IN_ARG]] to [initialization] [[IN_ARG_1]]
+// CHECK: copy_addr [take] [[IN_ARG]] to [init] [[IN_ARG_1]]
 // CHECK: [[INGUARANTEED_ADDRESS_1:%.*]] = alloc_stack $S3
-// CHECK: copy_addr [take] [[INGUARANTEED_ADDRESS]] to [initialization] [[INGUARANTEED_ADDRESS_1]]
+// CHECK: copy_addr [take] [[INGUARANTEED_ADDRESS]] to [init] [[INGUARANTEED_ADDRESS_1]]
 // CHECK: [[INGUARANTEED_ARG_1:%.*]] = alloc_stack $S4
-// CHECK: copy_addr [take] [[INGUARANTEED_ARG]] to [initialization] [[INGUARANTEED_ARG_1]]
+// CHECK: copy_addr [take] [[INGUARANTEED_ARG]] to [init] [[INGUARANTEED_ARG_1]]
 //
 // Then make sure that the destroys are placed after the destroy_value of the
 // partial_apply (which is after this apply)...
@@ -149,11 +149,11 @@ sil [ossa] @sil_combine_partial_apply_callee_2 : $@convention(thin) (@in S1) -> 
 //
 // CHECK: bb1:
 // CHECK:   [[ORIGINAL_ALLOC_STACK:%.*]] = alloc_stack $S1
-// CHECK-NEXT: copy_addr [take] [[ARG]] to [initialization] [[ORIGINAL_ALLOC_STACK]]
+// CHECK-NEXT: copy_addr [take] [[ARG]] to [init] [[ORIGINAL_ALLOC_STACK]]
 // CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
 // CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
 // CHECK-NEXT: [[NEW_ALLOC_STACK:%.*]] = alloc_stack $S1
-// CHECK-NEXT: copy_addr [take] [[ORIGINAL_ALLOC_STACK]] to [initialization] [[NEW_ALLOC_STACK]]
+// CHECK-NEXT: copy_addr [take] [[ORIGINAL_ALLOC_STACK]] to [init] [[NEW_ALLOC_STACK]]
 // CHECK-NEXT: apply [[UNKNOWN_FUNC]]()
 // CHECK-NEXT: apply
 // CHECK-NEXT: cond_br undef, bb2, bb3
@@ -187,7 +187,7 @@ bb0(%s1 : $*S1):
 
 bb1:
   %0 = alloc_stack $S1
-  copy_addr [take] %s1 to [initialization] %0 : $*S1
+  copy_addr [take] %s1 to [init] %0 : $*S1
   apply %3() : $@convention(thin) () -> ()
   %1 = function_ref @sil_combine_partial_apply_callee_2 : $@convention(thin) (@in S1) -> ()
   apply %3() : $@convention(thin) () -> ()
@@ -222,7 +222,7 @@ sil [ossa] @try_apply_func : $@convention(thin) () -> (Builtin.Int32, @error Err
 // CHECK: bb0([[ARG:%.*]] : $*S1):
 // CHECK: bb1:
 // CHECK-NEXT: [[ORIGINAL_ALLOC_STACK:%.*]] = alloc_stack $S1
-// CHECK-NEXT: copy_addr [take] [[ARG]] to [initialization] [[ORIGINAL_ALLOC_STACK]]
+// CHECK-NEXT: copy_addr [take] [[ARG]] to [init] [[ORIGINAL_ALLOC_STACK]]
 // CHECK-NEXT: [[NEW_ALLOC_STACK:%.*]] = alloc_stack $S1
 // CHECK: bb2:
 // CHECK-NEXT: destroy_addr [[NEW_ALLOC_STACK]]
@@ -245,7 +245,7 @@ bb0(%0a : $*S1):
 
 bb1:
   %0 = alloc_stack $S1
-  copy_addr [take] %0a to [initialization] %0 : $*S1
+  copy_addr [take] %0a to [init] %0 : $*S1
   %1 = function_ref @sil_combine_partial_apply_callee_2 : $@convention(thin) (@in S1) -> ()
   %2 = partial_apply %1(%0) : $@convention(thin) (@in S1) -> ()
   dealloc_stack %0 : $*S1
@@ -280,11 +280,11 @@ bb6(%5 : $Error):
 sil [ossa] @sil_combine_dead_partial_apply_with_opened_existential : $@convention(thin) (@in SwiftP) -> ((), @error Error) {
 bb0(%arg : $*SwiftP):
   %0b = alloc_stack $SwiftP
-  copy_addr [take] %arg to [initialization] %0b : $*SwiftP
+  copy_addr [take] %arg to [init] %0b : $*SwiftP
   %1 = open_existential_addr mutable_access %0b : $*SwiftP to $*@opened("3305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self
   %2 = witness_method $@opened("3305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self, #SwiftP.foo, %1 : $*@opened("3305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self : $@convention(witness_method: SwiftP) <τ_0_0 where τ_0_0 : SwiftP> (@in_guaranteed τ_0_0) -> ()
   %0c = alloc_stack $@opened("3305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self
-  copy_addr %1 to [initialization] %0c : $*@opened("3305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self
+  copy_addr %1 to [init] %0c : $*@opened("3305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self
   %3 = partial_apply %2<@opened("3305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self>(%0c) : $@convention(witness_method: SwiftP) <τ_0_0 where τ_0_0 : SwiftP> (@in_guaranteed τ_0_0) -> ()
   dealloc_stack %0c : $*@opened("3305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self
   destroy_value %3 : $@callee_owned () -> ()
@@ -297,10 +297,10 @@ bb0(%arg : $*SwiftP):
 // CHECK-LABEL: sil [ossa] @test_generic_partial_apply_apply_in :
 // CHECK: bb0([[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [take] [[ARG1]] to [initialization] [[STACK]]
+// CHECK:   copy_addr [take] [[ARG1]] to [init] [[STACK]]
 // CHECK: bb1:
 // CHECK:   [[STACK3:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [[STACK]] to [initialization] [[STACK3]]
+// CHECK:   copy_addr [[STACK]] to [init] [[STACK3]]
 // CHECK:   apply {{%.*}}<T, T>([[ARG0]], [[STACK3]])
 // CHECK:   dealloc_stack [[STACK3]]
 // CHECK: bb2:
@@ -327,7 +327,7 @@ bb2:
 // CHECK-LABEL: sil [ossa] @test_generic_partial_apply_apply_inguaranteed : $@convention(thin) <T> (@in T, @in T) -> () {
 // CHECK: bb0([[ARG0:%.*]] : $*T, [[ARG1:%.*]] : $*T):
 // CHECK:   [[STACK:%.*]] = alloc_stack $T
-// CHECK:   copy_addr [take] [[ARG1]] to [initialization] [[STACK]]
+// CHECK:   copy_addr [take] [[ARG1]] to [init] [[STACK]]
 // CHECK:   apply {{%.*}}<T, T>([[ARG0]], [[STACK]])
 // CHECK:   destroy_addr [[STACK]]
 // CHECK:   destroy_addr [[ARG0]]
@@ -347,9 +347,9 @@ bb0(%0 : $*T, %1 : $*T):
 // CHECK:   [[EX:%.*]] = open_existential_addr
 // CHECK:   [[METHOD:%.*]] = witness_method
 // CHECK:   [[STACK1:%.*]] = alloc_stack $@opened
-// CHECK:   copy_addr [[EX]] to [initialization] [[STACK1]]
+// CHECK:   copy_addr [[EX]] to [init] [[STACK1]]
 // CHECK:   [[STACK2:%.*]] = alloc_stack $@opened
-// CHECK:   copy_addr [take] [[STACK1]] to [initialization] [[STACK2]]
+// CHECK:   copy_addr [take] [[STACK1]] to [init] [[STACK2]]
 // CHECK:   apply [[METHOD]]<@opened{{.*}}>([[STACK2]])
 // CHECK:   destroy_addr [[STACK2]]
 // CHECK:   dealloc_stack [[STACK2]]
@@ -360,7 +360,7 @@ bb0(%0 : $*SwiftP):
   %1 = open_existential_addr immutable_access %0 : $*SwiftP to $*@opened("4305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self
   %2 = witness_method $@opened("4305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self, #SwiftP.foo, %1 : $*@opened("4305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self : $@convention(witness_method: SwiftP) <τ_0_0 where τ_0_0 : SwiftP> (@in_guaranteed τ_0_0) -> ()
   %0c = alloc_stack $@opened("4305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self
-  copy_addr %1 to [initialization] %0c : $*@opened("4305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self
+  copy_addr %1 to [init] %0c : $*@opened("4305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self
   %3 = partial_apply %2<@opened("4305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self>(%0c) : $@convention(witness_method: SwiftP) <τ_0_0 where τ_0_0 : SwiftP> (@in_guaranteed τ_0_0) -> ()
   dealloc_stack %0c : $*@opened("4305E696-5685-11E5-9393-B8E856428C60", SwiftP) Self
   %4 = apply %3() : $@callee_owned () -> ()
@@ -390,11 +390,11 @@ bb0(%0 : $*MutatingProto, %1 : $MStruct):
   %4 = init_existential_addr %2 : $*MutatingProto, $MStruct
   store %1 to [trivial] %4 : $*MStruct
   %9 = alloc_stack $MutatingProto
-  copy_addr %2 to [initialization] %9 : $*MutatingProto
+  copy_addr %2 to [init] %9 : $*MutatingProto
   %11 = open_existential_addr mutable_access %9 : $*MutatingProto to $*@opened("FC5F3CFA-A7A4-11E7-911F-685B35C48C83", MutatingProto) Self
   %12 = witness_method $@opened("FC5F3CFA-A7A4-11E7-911F-685B35C48C83", MutatingProto) Self, #MutatingProto.mutatingMethod : <Self where Self : MutatingProto> (inout Self) -> () -> (), %11 : $*@opened("FC5F3CFA-A7A4-11E7-911F-685B35C48C83", MutatingProto) Self : $@convention(witness_method: MutatingProto) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> ()
   %13 = apply %12<@opened("FC5F3CFA-A7A4-11E7-911F-685B35C48C83", MutatingProto) Self>(%11) : $@convention(witness_method: MutatingProto) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> ()
-  copy_addr [take] %9 to [initialization] %0 : $*MutatingProto
+  copy_addr [take] %9 to [init] %0 : $*MutatingProto
   dealloc_stack %9 : $*MutatingProto
   destroy_addr %2 : $*MutatingProto
   dealloc_stack %2 : $*MutatingProto
@@ -407,12 +407,12 @@ sil [ossa] @dont_replace_copied_self_in_mutating_method_call2 : $@convention(thi
 bb0(%0 : $*MutatingProto, %1 : $@thick MutatingProto.Type, %2 : $*MutatingProto):
   %openType = open_existential_metatype %1 : $@thick MutatingProto.Type to $@thick (@opened("66A6DAFC-AF78-11E7-8F3B-28CFE9213F4F", MutatingProto) Self).Type
   %alloc2 = alloc_stack $MutatingProto
-  copy_addr %2 to [initialization] %alloc2 : $*MutatingProto
+  copy_addr %2 to [init] %alloc2 : $*MutatingProto
   %oeaddr = open_existential_addr mutable_access %alloc2 : $*MutatingProto to $*@opened("6E02DCF6-AF78-11E7-8F3B-28CFE9213F4F", MutatingProto) Self
   %witmethod = witness_method $@opened("66A6DAFC-AF78-11E7-8F3B-28CFE9213F4F", MutatingProto) Self, #MutatingProto.mutatingMethod : <Self where Self : MutatingProto> (inout Self) -> () -> (), %openType : $@thick (@opened("66A6DAFC-AF78-11E7-8F3B-28CFE9213F4F", MutatingProto) Self).Type : $@convention(witness_method: MutatingProto) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> ()
   // CHECK: apply {{%.*}}<@opened("6E02DCF6-AF78-11E7-8F3B-28CFE9213F4F", any MutatingProto) Self>({{%.*}}) : $@convention(witness_method: MutatingProto) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> () // type-defs
   %apply = apply %witmethod<@opened("6E02DCF6-AF78-11E7-8F3B-28CFE9213F4F", MutatingProto) Self>(%oeaddr) : $@convention(witness_method: MutatingProto) <τ_0_0 where τ_0_0 : MutatingProto> (@inout τ_0_0) -> ()
-  copy_addr [take] %alloc2 to [initialization] %0 : $*MutatingProto
+  copy_addr [take] %alloc2 to [init] %0 : $*MutatingProto
   dealloc_stack %alloc2 : $*MutatingProto
   %27 = tuple ()
   return %27 : $()
@@ -591,7 +591,7 @@ bb0:
 
 sil shared [ossa] [transparent] [thunk] @genericClosure : $@convention(thin) <T> (@in T) -> @out T {
 bb0(%0 : $*T, %1 : $*T):
-  copy_addr [take] %1 to [initialization] %0 : $*T
+  copy_addr [take] %1 to [init] %0 : $*T
   %12 = tuple ()
   return %12 : $()
 }
@@ -860,14 +860,14 @@ sil [ossa] @closure_with_guaranteed_args : $@convention(method) (@guaranteed CC1
 // CHECK-LABEL: sil [ossa] @test_apply_of_partial_apply_in : $@convention(thin) (@in CC1) -> () {
 // CHECK:   [[FUNC:%.*]] = function_ref
 // CHECK:   [[STACK1:%.*]] = alloc_stack $CC1
-// CHECK:   copy_addr [take] %0 to [initialization] [[STACK1]]
+// CHECK:   copy_addr [take] %0 to [init] [[STACK1]]
 // CHECK:   cond_br undef, bb1, bb2
 // CHECK: bb1:
 // CHECK:   destroy_addr [[STACK1]]
 // CHECK:   dealloc_stack [[STACK1]]
 // CHECK: bb2:
 // CHECK:   [[STACK2:%.*]] = alloc_stack $CC1
-// CHECK:   copy_addr [[STACK1]] to [initialization] [[STACK2]]
+// CHECK:   copy_addr [[STACK1]] to [init] [[STACK2]]
 // CHECK:   apply [[FUNC]]([[STACK2]])
 // CHECK:   dealloc_stack [[STACK2]]
 // CHECK:   destroy_addr [[STACK1]]
@@ -896,9 +896,9 @@ bb3:
 // CHECK-LABEL: sil [ossa] @test_apply_of_partial_apply_inguaranteed : $@convention(thin) (@in CC1) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[STACK1:%.*]] = alloc_stack $CC1
-// CHECK:   copy_addr [take] [[ARG]] to [initialization] [[STACK1]]
+// CHECK:   copy_addr [take] [[ARG]] to [init] [[STACK1]]
 // CHECK:   [[STACK2:%.*]] = alloc_stack $CC1
-// CHECK:   copy_addr [take] [[STACK1]] to [initialization] [[STACK2]]
+// CHECK:   copy_addr [take] [[STACK1]] to [init] [[STACK2]]
 // CHECK:   cond_br undef, bb1, bb2
 //
 // CHECK: bb1:
@@ -919,7 +919,7 @@ sil [ossa] @test_apply_of_partial_apply_inguaranteed : $@convention(thin) (@in C
 bb0(%0 : $*CC1):
   %1 = function_ref @closure_with_inguaranteed_args : $@convention(method) (@in_guaranteed CC1) -> ()
   %2 = alloc_stack $CC1
-  copy_addr [take] %0 to [initialization] %2 : $*CC1
+  copy_addr [take] %0 to [init] %2 : $*CC1
   %3 = partial_apply %1(%2) : $@convention(method) (@in_guaranteed CC1) -> ()
   cond_br undef, bb1, bb2
 
@@ -1017,7 +1017,7 @@ bb3:
 // CHECK-NEXT:  [[S1:%[0-9]+]] = alloc_stack $Int
 // CHECK:       store %0 to [trivial] [[S1]]
 // CHECK:       [[S2:%[0-9]+]] = alloc_stack $Int
-// CHECK:       copy_addr [[S1]] to [initialization] [[S2]]
+// CHECK:       copy_addr [[S1]] to [init] [[S2]]
 // CHECK:       apply {{.*}}(%1, [[S2]])
 // CHECK:       destroy_addr [[S2]] : $*Int
 // CHECK:       dealloc_stack [[S2]] : $*Int
@@ -1056,7 +1056,7 @@ bb2:
 // CHECK-NEXT:  [[S1:%[0-9]+]] = alloc_stack $Klass
 // CHECK:       store %0 to [init] [[S1]]
 // CHECK:       [[S2:%[0-9]+]] = alloc_stack $Klass
-// CHECK:       copy_addr [take] [[S1]] to [initialization] [[S2]]
+// CHECK:       copy_addr [take] [[S1]] to [init] [[S2]]
 // CHECK:       apply {{.*}}(%1, [[S2]])
 // CHECK:       destroy_addr [[S2]] : $*Klass
 // CHECK:       dealloc_stack [[S2]] : $*Klass

--- a/test/SILOptimizer/sil_combine_casts.sil
+++ b/test/SILOptimizer/sil_combine_casts.sil
@@ -219,7 +219,7 @@ bb0(%0 : @owned $Optional<Klass>):
 // CHECK-NOT: integer_literal
 // CHECK-NOT: builtin "assumeAlignment"
 // CHECK: [[PTR:%.*]] = pointer_to_address %1 : $Builtin.RawPointer to $*T
-// CHECK: copy_addr [[PTR]] to [initialization] %0 : $*T
+// CHECK: copy_addr [[PTR]] to [init] %0 : $*T
 // CHECK-LABEL: } // end sil function 'test_zero_alignment'
 sil @test_zero_alignment : $@convention(thin) <T> (Builtin.RawPointer, @thick T.Type) -> @out T {
 bb0(%0 : $*T, %1 : $Builtin.RawPointer, %2 : $@thick T.Type):
@@ -229,7 +229,7 @@ bb0(%0 : $*T, %1 : $Builtin.RawPointer, %2 : $@thick T.Type):
   %6 = builtin "assumeAlignment"(%1 : $Builtin.RawPointer, %5 : $Builtin.Word) : $Builtin.RawPointer
   debug_value %6 : $Builtin.RawPointer, let, name "alignedPointer"
   %8 = pointer_to_address %6 : $Builtin.RawPointer to [align=1] $*T
-  copy_addr %8 to [initialization] %0 : $*T
+  copy_addr %8 to [init] %0 : $*T
   %10 = tuple ()
   return %10 : $()
 }
@@ -248,7 +248,7 @@ bb0(%0 : $*T, %1 : $Builtin.RawPointer, %2 : $@thick T.Type):
 // CHECK-NOT: integer_literal
 // CHECK-NOT: builtin "assumeAlignment"
 // CHECK:     [[PTR:%.*]] = pointer_to_address %1 : $Builtin.RawPointer to [align=8] $*T
-// CHECK:     copy_addr [[PTR]] to [initialization] %0 : $*T
+// CHECK:     copy_addr [[PTR]] to [init] %0 : $*T
 // CHECK-LABEL: } // end sil function 'test_nonzero_alignment'
 sil @test_nonzero_alignment : $@convention(thin) <T> (Builtin.RawPointer, @thick T.Type) -> @out T {
 bb0(%0 : $*T, %1 : $Builtin.RawPointer, %2 : $@thick T.Type):
@@ -258,7 +258,7 @@ bb0(%0 : $*T, %1 : $Builtin.RawPointer, %2 : $@thick T.Type):
   %6 = builtin "assumeAlignment"(%1 : $Builtin.RawPointer, %5 : $Builtin.Word) : $Builtin.RawPointer
   debug_value %6 : $Builtin.RawPointer, let, name "alignedPointer"
   %8 = pointer_to_address %6 : $Builtin.RawPointer to [align=1] $*T
-  copy_addr %8 to [initialization] %0 : $*T
+  copy_addr %8 to [init] %0 : $*T
   %10 = tuple ()
   return %10 : $()
 }
@@ -278,7 +278,7 @@ bb0(%0 : $*T, %1 : $Builtin.RawPointer, %2 : $@thick T.Type):
 // CHECK-NOT: builtin "alignOf"
 // CHECK-NOT: builtin "assumeAlignment"
 // CHECK:     [[PTR:%.*]] = pointer_to_address %1 : $Builtin.RawPointer to $*T
-// CHECK:     copy_addr [[PTR]] to [initialization] %0 : $*T
+// CHECK:     copy_addr [[PTR]] to [init] %0 : $*T
 // CHECK-LABEL: } // end sil function 'test_dynamic_alignment'
 sil @test_dynamic_alignment : $@convention(thin) <T> (Builtin.RawPointer, @thick T.Type) -> @out T {
 bb0(%0 : $*T, %1 : $Builtin.RawPointer, %2 : $@thick T.Type):
@@ -293,7 +293,7 @@ bb0(%0 : $*T, %1 : $Builtin.RawPointer, %2 : $@thick T.Type):
   %11 = builtin "assumeAlignment"(%1 : $Builtin.RawPointer, %10 : $Builtin.Word) : $Builtin.RawPointer
   debug_value %11 : $Builtin.RawPointer, let, name "alignedPointer"
   %13 = pointer_to_address %11 : $Builtin.RawPointer to [align=1] $*T
-  copy_addr %13 to [initialization] %0 : $*T
+  copy_addr %13 to [init] %0 : $*T
   %15 = tuple ()
   return %15 : $()
 }
@@ -313,7 +313,7 @@ bb0(%0 : $*T, %1 : $Builtin.RawPointer, %2 : $@thick T.Type):
 // CHECK-NOT: builtin "alignOf"
 // CHECK-NOT: builtin "assumeAlignment"
 // CHECK:     [[PTR:%.*]] = pointer_to_address %1 : $Builtin.RawPointer to $*T
-// CHECK:     copy_addr [[PTR]] to [initialization] %0 : $*T
+// CHECK:     copy_addr [[PTR]] to [init] %0 : $*T
 // CHECK-LABEL: } // end sil function 'test_dynamic_alignment32'
 sil @test_dynamic_alignment32 : $@convention(thin) <T> (Builtin.RawPointer, @thick T.Type) -> @out T {
 bb0(%0 : $*T, %1 : $Builtin.RawPointer, %2 : $@thick T.Type):
@@ -328,7 +328,7 @@ bb0(%0 : $*T, %1 : $Builtin.RawPointer, %2 : $@thick T.Type):
   %11 = builtin "assumeAlignment"(%1 : $Builtin.RawPointer, %10 : $Builtin.Word) : $Builtin.RawPointer
   debug_value %11 : $Builtin.RawPointer, let, name "alignedPointer"
   %13 = pointer_to_address %11 : $Builtin.RawPointer to [align=1] $*T
-  copy_addr %13 to [initialization] %0 : $*T
+  copy_addr %13 to [init] %0 : $*T
   %15 = tuple ()
   return %15 : $()
 }

--- a/test/SILOptimizer/sil_combine_concrete_existential.sil
+++ b/test/SILOptimizer/sil_combine_concrete_existential.sil
@@ -210,7 +210,7 @@ bb0:
   %12 = witness_method $@opened("83DE9694-7315-11E8-955C-ACDE48001122", PPP) Self, #PPP.returnsOptionalIndirect : <Self where Self : PPP> (Self) -> () -> Self?, %8 : $*@opened("83DE9694-7315-11E8-955C-ACDE48001122", PPP) Self : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
   %13 = apply %12<@opened("83DE9694-7315-11E8-955C-ACDE48001122", PPP) Self>(%11, %8) : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
   %14 = unchecked_take_enum_data_addr %11 : $*Optional<@opened("83DE9694-7315-11E8-955C-ACDE48001122", PPP) Self>, #Optional.some!enumelt
-  copy_addr [take] %14 to [initialization] %10 : $*@opened("83DE9694-7315-11E8-955C-ACDE48001122", PPP) Self
+  copy_addr [take] %14 to [init] %10 : $*@opened("83DE9694-7315-11E8-955C-ACDE48001122", PPP) Self
   inject_enum_addr %7 : $*Optional<PPP>, #Optional.some!enumelt
   dealloc_stack %11 : $*Optional<@opened("83DE9694-7315-11E8-955C-ACDE48001122", PPP) Self>
   %28 = unchecked_take_enum_data_addr %7 : $*Optional<PPP>, #Optional.some!enumelt
@@ -221,7 +221,7 @@ bb0:
   %33 = witness_method $@opened("83DE97CA-7315-11E8-955C-ACDE48001122", PPP) Self, #PPP.returnsOptionalIndirect : <Self where Self : PPP> (Self) -> () -> Self?, %29 : $*@opened("83DE97CA-7315-11E8-955C-ACDE48001122", PPP) Self : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
   %34 = apply %33<@opened("83DE97CA-7315-11E8-955C-ACDE48001122", PPP) Self>(%32, %29) : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> @out Optional<τ_0_0>
   %41 = unchecked_take_enum_data_addr %32 : $*Optional<@opened("83DE97CA-7315-11E8-955C-ACDE48001122", PPP) Self>, #Optional.some!enumelt
-  copy_addr [take] %41 to [initialization] %31 : $*@opened("83DE97CA-7315-11E8-955C-ACDE48001122", PPP) Self
+  copy_addr [take] %41 to [init] %31 : $*@opened("83DE97CA-7315-11E8-955C-ACDE48001122", PPP) Self
   inject_enum_addr %6 : $*Optional<PPP>, #Optional.some!enumelt
   dealloc_stack %32 : $*Optional<@opened("83DE97CA-7315-11E8-955C-ACDE48001122", PPP) Self>
   destroy_addr %28 : $*PPP
@@ -273,7 +273,7 @@ bb0(%0 : $CCCC):
 
   %optional = alloc_stack $Optional<@opened("A6DDDAF6-70BD-11E8-ADF1-ACDE48001122", PPPP) Self>
   %someadr = init_enum_data_addr %optional : $*Optional<@opened("A6DDDAF6-70BD-11E8-ADF1-ACDE48001122", PPPP) Self>, #Optional.some!enumelt
-  copy_addr %oe to [initialization] %someadr : $*@opened("A6DDDAF6-70BD-11E8-ADF1-ACDE48001122", PPPP) Self
+  copy_addr %oe to [init] %someadr : $*@opened("A6DDDAF6-70BD-11E8-ADF1-ACDE48001122", PPPP) Self
   inject_enum_addr %optional : $*Optional<@opened("A6DDDAF6-70BD-11E8-ADF1-ACDE48001122", PPPP) Self>, #Optional.some!enumelt
 
   %f = function_ref @takeOptionalSelf : $@convention(method) <τ_0_0 where τ_0_0 : PPPP> (@in_guaranteed Optional<τ_0_0>, @in_guaranteed τ_0_0) -> ()
@@ -401,7 +401,7 @@ bb0:
   %a0 = alloc_stack $AnyP
   %ie0 = init_existential_addr %a0 : $*AnyP, $StructOfAnyP
   %a1 = alloc_stack $AnyP
-  copy_addr %a0 to [initialization] %a1 : $*AnyP
+  copy_addr %a0 to [init] %a1 : $*AnyP
   %o0 = open_existential_addr immutable_access %a1 : $*AnyP to $*@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD", AnyP) Self
   %a2 = alloc_stack $StructOfAnyP
   %w0 = witness_method $@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD", AnyP) Self, #AnyP.returnsSelf : <Self where Self : AnyP> (Self) -> () -> Self, %o0 : $*@opened("7C4DAF8E-D722-11E8-920A-D0817AD9F6DD", AnyP) Self : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
@@ -429,7 +429,7 @@ bb0:
   %f1 = function_ref @takeany :  $@convention(thin) (@in_guaranteed AnyP) -> ()
   %c1 = apply %f1(%a0) :  $@convention(thin) (@in_guaranteed AnyP) -> ()
   %a1 = alloc_stack $AnyP
-  copy_addr %a0 to [initialization] %a1 : $*AnyP
+  copy_addr %a0 to [init] %a1 : $*AnyP
   %o0 = open_existential_addr immutable_access %a1 : $*AnyP to $*@opened("8C4DAF8E-D722-11E8-920A-D0817AD9F6DD", AnyP) Self
   %a2 = alloc_stack $StructOfAnyP
   %w0 = witness_method $@opened("8C4DAF8E-D722-11E8-920A-D0817AD9F6DD", AnyP) Self, #AnyP.returnsSelf : <Self where Self : AnyP> (Self) -> () -> Self, %o0 : $*@opened("8C4DAF8E-D722-11E8-920A-D0817AD9F6DD", AnyP) Self : $@convention(witness_method: AnyP) <τ_0_0 where τ_0_0 : AnyP> (@in_guaranteed τ_0_0) -> @out StructOfAnyP
@@ -468,7 +468,7 @@ sil [transparent] [reabstraction_thunk] @testDevirtExistentialEnumThunk : $@conv
 // CHECK: [[ALLOC_ENUM:%.*]] = alloc_stack $any ContiguousBytes
 // CHECK: [[INIT_DATA:%.*]] = init_existential_addr [[ALLOC_ENUM]] : $*any ContiguousBytes, $Array<Int>
 // CHECK: store %0 to [[INIT_DATA]] : $*Array<Int>
-// CHECK: copy_addr [take] [[ALLOC_ENUM]] to [initialization] [[ALLOC_EXISTENTIAL]] : $*any ContiguousBytes
+// CHECK: copy_addr [take] [[ALLOC_ENUM]] to [init] [[ALLOC_EXISTENTIAL]] : $*any ContiguousBytes
 // CHECK: [[OPENED:%.*]] = open_existential_addr immutable_access [[ALLOC_EXISTENTIAL]] : $*any ContiguousBytes to $*@opened("8402EC1A-F35D-11E8-950A-D0817AD9F6DD", any ContiguousBytes) Self
 // CHECK: [[THUNK:%.*]] = function_ref @testDevirtExistentialEnumThunk : $@convention(thin) (UnsafeRawBufferPointer) -> (@out (), @error any Error)
 // CHECK: [[TTF:%.*]] = thin_to_thick_function [[THUNK:%.*]] : $@convention(thin) (UnsafeRawBufferPointer) -> (@out (), @error any Error) to $@noescape @callee_guaranteed (UnsafeRawBufferPointer) -> (@out (), @error any Error)
@@ -486,7 +486,7 @@ bb0(%0 : $Array<Int>):
   store %0 to %6 : $*Array<Int>
   inject_enum_addr %4 : $*Optional<ContiguousBytes>, #Optional.some!enumelt
   %9 = unchecked_take_enum_data_addr %4 : $*Optional<ContiguousBytes>, #Optional.some!enumelt
-  copy_addr [take] %9 to [initialization] %3 : $*ContiguousBytes
+  copy_addr [take] %9 to [init] %3 : $*ContiguousBytes
   dealloc_stack %4 : $*Optional<ContiguousBytes>
   %12 = open_existential_addr immutable_access %3 : $*ContiguousBytes to $*@opened("8402EC1A-F35D-11E8-950A-D0817AD9F6DD", ContiguousBytes) Self
   %13 = alloc_stack $()
@@ -513,10 +513,10 @@ sil @in_guaranteed_arg_test_callee : $@convention(thin) <τ_0_0 where τ_0_0 : I
 // CHECK-LABEL: sil @in_guaranteed_arg_test_caller : $@convention(thin) <τ_0_0 where τ_0_0 : InGuaranteedArgTestProtocol> (@in τ_0_0) -> () {
 // CHECK: bb0(%0 : $*τ_0_0):
 // CHECK: [[ALLOC1:%.*]] = alloc_stack $τ_0_0
-// CHECK: copy_addr [take] %0 to [initialization] [[ALLOC1]] : $*τ_0_0
+// CHECK: copy_addr [take] %0 to [init] [[ALLOC1]] : $*τ_0_0
 // CHECK: [[F:%.*]] = function_ref @in_guaranteed_arg_test_callee : $@convention(thin) <τ_0_0 where τ_0_0 : InGuaranteedArgTestProtocol> (@in τ_0_0) -> ()
 // CHECK: [[ALLOC2:%.*]] = alloc_stack $τ_0_0
-// CHECK: copy_addr %1 to [initialization] [[ALLOC2]] : $*τ_0_0
+// CHECK: copy_addr %1 to [init] [[ALLOC2]] : $*τ_0_0
 // CHECK: apply [[F]]<τ_0_0>(%4) : $@convention(thin) <τ_0_0 where τ_0_0 : InGuaranteedArgTestProtocol> (@in τ_0_0) -> ()
 // CHECK: dealloc_stack [[ALLOC2]] : $*τ_0_0
 // CHECK: destroy_addr [[ALLOC1]] : $*τ_0_0
@@ -526,10 +526,10 @@ sil @in_guaranteed_arg_test_caller : $@convention(thin) <τ_0_0 where τ_0_0 : I
 bb0(%0 : $*τ_0_0):
   %1 = alloc_stack $InGuaranteedArgTestProtocol
   %2 = init_existential_addr %1 : $*InGuaranteedArgTestProtocol, $τ_0_0
-  copy_addr [take] %0 to [initialization] %2 : $*τ_0_0
+  copy_addr [take] %0 to [init] %2 : $*τ_0_0
   %3 = function_ref @in_guaranteed_arg_test_callee : $@convention(thin) <τ_0_0 where τ_0_0 : InGuaranteedArgTestProtocol> (@in τ_0_0) -> ()
   %4 = alloc_stack $InGuaranteedArgTestProtocol
-  copy_addr %1 to [initialization] %4 : $*InGuaranteedArgTestProtocol
+  copy_addr %1 to [init] %4 : $*InGuaranteedArgTestProtocol
   %5 = open_existential_addr mutable_access %4 : $*InGuaranteedArgTestProtocol to $*@opened("C494A60E-71EA-11E9-B8C0-D0817AD3F8AD", InGuaranteedArgTestProtocol) Self
   apply %3<@opened("C494A60E-71EA-11E9-B8C0-D0817AD3F8AD", InGuaranteedArgTestProtocol) Self>(%5) : $@convention(thin) <τ_0_0 where τ_0_0 : InGuaranteedArgTestProtocol> (@in τ_0_0) -> ()
   dealloc_stack %4 : $*InGuaranteedArgTestProtocol
@@ -587,23 +587,23 @@ sil @test_multiple_propagated_args : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 
 bb0(%0 : $*τ_0_0, %1 : $*τ_0_2, %2 : $*τ_0_1):
   %5 = alloc_stack $P1
   %6 = init_existential_addr %5 : $*P1, $τ_0_0
-  copy_addr [take] %0 to [initialization] %6 : $*τ_0_0
+  copy_addr [take] %0 to [init] %6 : $*τ_0_0
   %8 = alloc_stack $P3
   %9 = init_existential_addr %8 : $*P3, $τ_0_2
-  copy_addr [take] %1 to [initialization] %9 : $*τ_0_2
+  copy_addr [take] %1 to [init] %9 : $*τ_0_2
   %11 = alloc_stack $P2
   %12 = init_existential_addr %11 : $*P2, $τ_0_1
-  copy_addr [take] %2 to [initialization] %12 : $*τ_0_1
+  copy_addr [take] %2 to [init] %12 : $*τ_0_1
   %15 = function_ref @callee : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : P1, τ_0_1 : P2, τ_0_2 : P3> (@in τ_0_0, @in τ_0_2, @in τ_0_1) -> ()
   %16 = open_existential_addr mutable_access %5 : $*P1 to $*@opened("76D54B80-FF66-11E9-B604-8C8590A6A134", P1) Self
   %17 = alloc_stack $@opened("76D54B80-FF66-11E9-B604-8C8590A6A134", P1) Self
-  copy_addr %16 to [initialization] %17 : $*@opened("76D54B80-FF66-11E9-B604-8C8590A6A134", P1) Self
+  copy_addr %16 to [init] %17 : $*@opened("76D54B80-FF66-11E9-B604-8C8590A6A134", P1) Self
   %19 = open_existential_addr mutable_access %8 : $*P3 to $*@opened("76D54C34-FF66-11E9-B604-8C8590A6A134", P3) Self
   %20 = alloc_stack $@opened("76D54C34-FF66-11E9-B604-8C8590A6A134", P3) Self
-  copy_addr %19 to [initialization] %20 : $*@opened("76D54C34-FF66-11E9-B604-8C8590A6A134", P3) Self
+  copy_addr %19 to [init] %20 : $*@opened("76D54C34-FF66-11E9-B604-8C8590A6A134", P3) Self
   %22 = open_existential_addr mutable_access %11 : $*P2 to $*@opened("76D54C84-FF66-11E9-B604-8C8590A6A134", P2) Self
   %23 = alloc_stack $@opened("76D54C84-FF66-11E9-B604-8C8590A6A134", P2) Self
-  copy_addr %22 to [initialization] %23 : $*@opened("76D54C84-FF66-11E9-B604-8C8590A6A134", P2) Self
+  copy_addr %22 to [init] %23 : $*@opened("76D54C84-FF66-11E9-B604-8C8590A6A134", P2) Self
   %25 = apply %15<@opened("76D54B80-FF66-11E9-B604-8C8590A6A134", P1) Self, @opened("76D54C84-FF66-11E9-B604-8C8590A6A134", P2) Self, @opened("76D54C34-FF66-11E9-B604-8C8590A6A134", P3) Self>(%17, %20, %23) : $@convention(thin) <τ_0_0, τ_0_1, τ_0_2 where τ_0_0 : P1, τ_0_1 : P2, τ_0_2 : P3> (@in τ_0_0, @in τ_0_2, @in τ_0_1) -> ()
   destroy_addr %11 : $*P2
   dealloc_stack %23 : $*@opened("76D54C84-FF66-11E9-B604-8C8590A6A134", P2) Self
@@ -669,7 +669,7 @@ sil @callee2 : $@convention(thin) <τ_0_0 where τ_0_0 : SubscriptionViewControl
 // CHECK:   store [[T2]] to [[T4]] : $*@opened("E4D92D2A-8893-11EA-9C89-ACDE48001122", any ResourceKitProtocol) Self
 // CHECK:   [[T5:%.*]] = function_ref @callee2 : $@convention(thin) <τ_0_0 where τ_0_0 : SubscriptionViewControllerDelegate> (@in τ_0_0, @thick SubscriptionViewControllerBuilder.Type) -> @owned SubscriptionViewControllerBuilder
 // CHECK:   [[T6:%.*]] = alloc_stack $@opened("E4D92D2A-8893-11EA-9C89-ACDE48001122", any ResourceKitProtocol) Self
-// CHECK:   copy_addr [[T4]] to [initialization] [[T6]] : $*@opened("E4D92D2A-8893-11EA-9C89-ACDE48001122", any ResourceKitProtocol) Self
+// CHECK:   copy_addr [[T4]] to [init] [[T6]] : $*@opened("E4D92D2A-8893-11EA-9C89-ACDE48001122", any ResourceKitProtocol) Self
 // CHECK: Generic specialization information for call-site callee2 <ResourceKitProtocol> conformances <(inherited_conformance type=ResourceKitProtocol protocol=SubscriptionViewControllerDelegate
 // CHECK:  (normal_conformance type=MyObject protocol=SubscriptionViewControllerDelegate))>:
 // CHECK:   apply [[T5]]<@opened("E4D92D2A-8893-11EA-9C89-ACDE48001122", any ResourceKitProtocol) Self>([[T6]], [[T1]])
@@ -685,7 +685,7 @@ bb0(%0 : $ResourceKitProtocol, %1 : $ViewController):
   %10 = function_ref @callee2: $@convention(thin) <τ_0_0 where τ_0_0 : SubscriptionViewControllerDelegate> (@in τ_0_0, @thick SubscriptionViewControllerBuilder.Type) -> @owned SubscriptionViewControllerBuilder
   %11 = open_existential_addr mutable_access %6 : $*SubscriptionViewControllerDelegate to $*@opened("FAA82796-8893-11EA-9C89-ACDE48001122", SubscriptionViewControllerDelegate) Self
   %12 = alloc_stack $@opened("FAA82796-8893-11EA-9C89-ACDE48001122", SubscriptionViewControllerDelegate) Self
-  copy_addr %11 to [initialization] %12 : $*@opened("FAA82796-8893-11EA-9C89-ACDE48001122", SubscriptionViewControllerDelegate) Self
+  copy_addr %11 to [init] %12 : $*@opened("FAA82796-8893-11EA-9C89-ACDE48001122", SubscriptionViewControllerDelegate) Self
   %14 = apply %10<@opened("FAA82796-8893-11EA-9C89-ACDE48001122", SubscriptionViewControllerDelegate) Self>(%12, %4) : $@convention(thin) <τ_0_0 where τ_0_0 : SubscriptionViewControllerDelegate> (@in τ_0_0, @thick SubscriptionViewControllerBuilder.Type) -> @owned SubscriptionViewControllerBuilder
   destroy_addr %6 : $*SubscriptionViewControllerDelegate
   dealloc_stack %12 : $*@opened("FAA82796-8893-11EA-9C89-ACDE48001122", SubscriptionViewControllerDelegate) Self
@@ -736,7 +736,7 @@ bb3(%20 : $Error):
 //   apply mutatingFunc(%3)
 //   %5 = open_existential_addr %1
 //   %6 = alloc_stack $@opened P
-//   copy_addr %5 to [initialization] %6 : $*@opened("381F6B6A-89A1-11EC-999A-D0817AD9985D", PPP) Self
+//   copy_addr %5 to [init] %6 : $*@opened("381F6B6A-89A1-11EC-999A-D0817AD9985D", PPP) Self
 //   apply callee3(%5)
 //
 // When ConcreteExistentialInfo identified the initialization of:
@@ -756,7 +756,7 @@ sil @callee3 : $@convention(thin) <τ_0_0 where τ_0_0 : PPP> (@in τ_0_0) -> ()
 // CHECK:   apply %{{.*}} : $@convention(method) (@inout S) -> ()
 // CHECK:   [[OPENED:%.*]] = open_existential_addr mutable_access [[EXISCP]] : $*any PPP to $*@opened("381F6B6A-89A1-11EC-999A-D0817AD9985D", any PPP) Self
 // CHECK:   [[OPENEDCP:%.*]] = alloc_stack $@opened("381F6B6A-89A1-11EC-999A-D0817AD9985D", any PPP) Self
-// CHECK:   copy_addr [[OPENED]] to [initialization] [[OPENEDCP]] : $*@opened("381F6B6A-89A1-11EC-999A-D0817AD9985D", any PPP) Self
+// CHECK:   copy_addr [[OPENED]] to [init] [[OPENEDCP]] : $*@opened("381F6B6A-89A1-11EC-999A-D0817AD9985D", any PPP) Self
 // CHECK:   [[CALLEE3:%.*]] = function_ref @callee3 : $@convention(thin) <τ_0_0 where τ_0_0 : PPP> (@in τ_0_0) -> ()
 // CHECK:   apply [[CALLEE3]]<@opened("381F6B6A-89A1-11EC-999A-D0817AD9985D", any PPP) Self>([[OPENEDCP]]) : $@convention(thin) <τ_0_0 where τ_0_0 : PPP> (@in τ_0_0) -> ()
 // CHECK-LABEL: } // end sil function 'testMutatingCopiedOpenExistential'
@@ -766,7 +766,7 @@ bb0(%0 : $S):
   %2 = init_existential_addr %1 : $*PPP, $S
   store %0 to %2 : $*S
   %4 = alloc_stack [lexical] $PPP, var, name "mergedCommand"
-  copy_addr %1 to [initialization] %4 : $*PPP
+  copy_addr %1 to [init] %4 : $*PPP
   %6 = open_existential_addr mutable_access %4 : $*PPP to $*@opened("3818BC52-89A1-11EC-999A-D0817AD9985D", PPP) Self
   %7 = unchecked_addr_cast %6 : $*@opened("3818BC52-89A1-11EC-999A-D0817AD9985D", PPP) Self to $*S
 
@@ -774,7 +774,7 @@ bb0(%0 : $S):
   %9 = apply %8(%7) : $@convention(method) (@inout S) -> ()
   %10 = open_existential_addr mutable_access %4 : $*PPP to $*@opened("381F6B6A-89A1-11EC-999A-D0817AD9985D", PPP) Self
   %11 = alloc_stack $@opened("381F6B6A-89A1-11EC-999A-D0817AD9985D", PPP) Self
-  copy_addr %10 to [initialization] %11 : $*@opened("381F6B6A-89A1-11EC-999A-D0817AD9985D", PPP) Self
+  copy_addr %10 to [init] %11 : $*@opened("381F6B6A-89A1-11EC-999A-D0817AD9985D", PPP) Self
 
   %13 = function_ref @callee3 : $@convention(thin) <τ_0_0 where τ_0_0 : PPP> (@in τ_0_0) -> ()
   %14 = apply %13<@opened("381F6B6A-89A1-11EC-999A-D0817AD9985D", PPP) Self>(%11) : $@convention(thin) <τ_0_0 where τ_0_0 : PPP> (@in τ_0_0) -> ()

--- a/test/SILOptimizer/sil_combine_enum_addr.sil
+++ b/test/SILOptimizer/sil_combine_enum_addr.sil
@@ -36,7 +36,7 @@ bb1:
 
 bb2:
   %19 = unchecked_take_enum_data_addr %3 : $*Optional<CustomStringConvertible>, #Optional.some!enumelt
-  copy_addr [take] %19 to [initialization] %2 : $*CustomStringConvertible
+  copy_addr [take] %19 to [init] %2 : $*CustomStringConvertible
   br bb1
 }
 
@@ -72,7 +72,7 @@ bb2:
 
 bb3:
   %19 = unchecked_take_enum_data_addr %3 : $*Optional<CustomStringConvertible>, #Optional.some!enumelt
-  copy_addr [take] %19 to [initialization] %2 : $*CustomStringConvertible
+  copy_addr [take] %19 to [init] %2 : $*CustomStringConvertible
   br bb1
 }
 

--- a/test/SILOptimizer/sil_combine_enum_addr_ossa.sil
+++ b/test/SILOptimizer/sil_combine_enum_addr_ossa.sil
@@ -30,7 +30,7 @@ bb0(%0 : $*Int, %1 : $*_Stdout, %1a : $*CustomStringConvertible):
 
 bb1a:
   destroy_addr %3 : $*Optional<CustomStringConvertible>
-  copy_addr %1a to [initialization] %2 : $*CustomStringConvertible
+  copy_addr %1a to [init] %2 : $*CustomStringConvertible
   br bb1
 
 bb1:
@@ -42,7 +42,7 @@ bb1:
 
 bb2:
   %19 = unchecked_take_enum_data_addr %3 : $*Optional<CustomStringConvertible>, #Optional.some!enumelt
-  copy_addr [take] %19 to [initialization] %2 : $*CustomStringConvertible
+  copy_addr [take] %19 to [init] %2 : $*CustomStringConvertible
   br bb1
 }
 
@@ -75,12 +75,12 @@ bb1:
   return %15 : $()
 
 bb2:
-  copy_addr %1a to [initialization] %2 : $*CustomStringConvertible
+  copy_addr %1a to [init] %2 : $*CustomStringConvertible
   br bb1
 
 bb3:
   %19 = unchecked_take_enum_data_addr %3 : $*Optional<CustomStringConvertible>, #Optional.some!enumelt
-  copy_addr [take] %19 to [initialization] %2 : $*CustomStringConvertible
+  copy_addr [take] %19 to [init] %2 : $*CustomStringConvertible
   br bb1
 }
 

--- a/test/SILOptimizer/sil_combine_global_addr.sil
+++ b/test/SILOptimizer/sil_combine_global_addr.sil
@@ -47,7 +47,7 @@ bb0:
   %5 = alloc_ref $SomeClass
   store %5 to %4 : $*SomeClass
   %8 = alloc_stack $SomeProtocol
-  copy_addr %3 to [initialization] %8 : $*SomeProtocol
+  copy_addr %3 to [init] %8 : $*SomeProtocol
   %9 = open_existential_addr immutable_access %8 : $*SomeProtocol to $*@opened("1B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self
   %10 = witness_method $@opened("1B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self, #SomeProtocol.foo : <Self where Self : SomeProtocol> (Self) -> () -> Int, %9 : $*@opened("1B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> Int
   %11 = apply %10<@opened("1B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self>(%9) : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> Int
@@ -87,7 +87,7 @@ bb3:
   %7 = alloc_ref $SomeClass
   store %7 to %6 : $*SomeClass
   %8 = alloc_stack $SomeProtocol
-  copy_addr %3 to [initialization] %8 : $*SomeProtocol
+  copy_addr %3 to [init] %8 : $*SomeProtocol
   %9 = open_existential_addr immutable_access %8 : $*SomeProtocol to $*@opened("2B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self
   %10 = witness_method $@opened("2B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self, #SomeProtocol.foo : <Self where Self : SomeProtocol> (Self) -> () -> Int, %9 : $*@opened("2B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> Int
   %11 = apply %10<@opened("2B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self>(%9) : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> Int
@@ -122,7 +122,7 @@ bb0:
   store %5 to %4 : $*SomeClass
   %6 = init_existential_addr %3 : $*SomeProtocol, $SomeClass
   %8 = alloc_stack $SomeProtocol
-  copy_addr %3 to [initialization] %8 : $*SomeProtocol
+  copy_addr %3 to [init] %8 : $*SomeProtocol
   %9 = open_existential_addr immutable_access %8 : $*SomeProtocol to $*@opened("3B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self
   %10 = witness_method $@opened("3B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self, #SomeProtocol.foo : <Self where Self : SomeProtocol> (Self) -> () -> Int, %9 : $*@opened("3B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> Int
   %11 = apply %10<@opened("3B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self>(%9) : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> Int

--- a/test/SILOptimizer/sil_combine_global_addr_ossa.sil
+++ b/test/SILOptimizer/sil_combine_global_addr_ossa.sil
@@ -48,7 +48,7 @@ bb0:
   %5 = alloc_ref $SomeClass
   store %5 to [init] %4 : $*SomeClass
   %8 = alloc_stack $SomeProtocol
-  copy_addr %3 to [initialization] %8 : $*SomeProtocol
+  copy_addr %3 to [init] %8 : $*SomeProtocol
   %9 = open_existential_addr immutable_access %8 : $*SomeProtocol to $*@opened("1B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self
   %10 = witness_method $@opened("1B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self, #SomeProtocol.foo : <Self where Self : SomeProtocol> (Self) -> () -> Int, %9 : $*@opened("1B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> Int
   %11 = apply %10<@opened("1B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self>(%9) : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> Int
@@ -83,7 +83,7 @@ bb0:
   store %5 to [init] %4 : $*SomeClass
   %6 = init_existential_addr %3 : $*SomeProtocol, $SomeClass
   %8 = alloc_stack $SomeProtocol
-  copy_addr %3 to [initialization] %8 : $*SomeProtocol
+  copy_addr %3 to [init] %8 : $*SomeProtocol
   %9 = open_existential_addr immutable_access %8 : $*SomeProtocol to $*@opened("2B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self
   %10 = witness_method $@opened("2B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self, #SomeProtocol.foo : <Self where Self : SomeProtocol> (Self) -> () -> Int, %9 : $*@opened("2B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> Int
   %11 = apply %10<@opened("2B0A5B84-3441-11E8-AC03-DCA9048B1C6D", SomeProtocol) Self>(%9) : $@convention(witness_method: SomeProtocol) <τ_0_0 where τ_0_0 : SomeProtocol> (@in_guaranteed τ_0_0) -> Int

--- a/test/SILOptimizer/sil_combine_objc_bridge.sil
+++ b/test/SILOptimizer/sil_combine_objc_bridge.sil
@@ -21,7 +21,7 @@ import Foundation
 sil shared @bridge_from_swift_array_to_NSObject_cast: $@convention(thin) (@in Array<String>) -> @out NSObject {
 bb0(%0 : $*NSObject, %1 : $*Array<String>):
   %2 = alloc_stack $Array<String>
-  copy_addr %1 to [initialization] %2 : $*Array<String>
+  copy_addr %1 to [init] %2 : $*Array<String>
   unconditional_checked_cast_addr Array<String> in %2 : $*Array<String> to NSObject in %0 : $*NSObject
   dealloc_stack %2 : $*Array<String>
   destroy_addr %1 : $*Array<String>
@@ -48,7 +48,7 @@ sil @unconditional_checked_cast_addr_address_only_type: $@convention(thin) (@in_
 bb0(%0 : $*AddressOnlyError):
   %1 = alloc_stack $Error
   %2 = alloc_stack $AddressOnlyError
-  copy_addr %0 to [initialization] %2 : $*AddressOnlyError
+  copy_addr %0 to [init] %2 : $*AddressOnlyError
   unconditional_checked_cast_addr AddressOnlyError in %2 : $*AddressOnlyError to Error in %1 : $*Error
   dealloc_stack %2 : $*AddressOnlyError
   %8 = tuple ()

--- a/test/SILOptimizer/sil_combine_objc_bridge_ossa.sil
+++ b/test/SILOptimizer/sil_combine_objc_bridge_ossa.sil
@@ -21,7 +21,7 @@ import Foundation
 sil shared [ossa] @bridge_from_swift_array_to_NSObject_cast: $@convention(thin) (@in Array<String>) -> @out NSObject {
 bb0(%0 : $*NSObject, %1 : $*Array<String>):
   %2 = alloc_stack $Array<String>
-  copy_addr %1 to [initialization] %2 : $*Array<String>
+  copy_addr %1 to [init] %2 : $*Array<String>
   unconditional_checked_cast_addr Array<String> in %2 : $*Array<String> to NSObject in %0 : $*NSObject
   dealloc_stack %2 : $*Array<String>
   destroy_addr %1 : $*Array<String>
@@ -48,7 +48,7 @@ sil [ossa] @unconditional_checked_cast_addr_address_only_type: $@convention(thin
 bb0(%0 : $*AddressOnlyError):
   %1 = alloc_stack $Error
   %2 = alloc_stack $AddressOnlyError
-  copy_addr %0 to [initialization] %2 : $*AddressOnlyError
+  copy_addr %0 to [init] %2 : $*AddressOnlyError
   unconditional_checked_cast_addr AddressOnlyError in %2 : $*AddressOnlyError to Error in %1 : $*Error
   dealloc_stack %2 : $*AddressOnlyError
   %8 = tuple ()

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -1398,17 +1398,17 @@ bb0(%0 : $*FakeOptional<T>, %1 : $*T, %2 : $Builtin.Int1):
   inject_enum_addr %3 : $*FakeOptional<T>, #FakeOptional.none!enumelt
   %4 = alloc_stack $FakeOptional<T>
   %5 = init_enum_data_addr %4 : $*FakeOptional<T>, #FakeOptional.some!enumelt
-  copy_addr %1 to [initialization] %5 : $*T
+  copy_addr %1 to [init] %5 : $*T
   inject_enum_addr %4 : $*FakeOptional<T>, #FakeOptional.some!enumelt
   cond_br %2, bb1, bb2
 
 bb1:
-  copy_addr [take] %3 to [initialization] %0 : $*FakeOptional<T>
+  copy_addr [take] %3 to [init] %0 : $*FakeOptional<T>
   destroy_addr %4 : $*FakeOptional<T>
   br bb3
 
 bb2:
-  copy_addr [take] %4 to [initialization] %0 : $*FakeOptional<T>
+  copy_addr [take] %4 to [init] %0 : $*FakeOptional<T>
   destroy_addr %3 : $*FakeOptional<T>
   br bb3
 
@@ -2697,7 +2697,7 @@ bb0:
   %0 = alloc_stack $FloatingPointRoundingRule
   inject_enum_addr %0 : $*FloatingPointRoundingRule, #FloatingPointRoundingRule.toNearestOrEven!enumelt
   %2 = alloc_stack $FloatingPointRoundingRule
-  copy_addr %0 to [initialization] %2 : $*FloatingPointRoundingRule
+  copy_addr %0 to [init] %2 : $*FloatingPointRoundingRule
   destroy_addr %0 : $*FloatingPointRoundingRule
   switch_enum_addr %2 : $*FloatingPointRoundingRule, case #FloatingPointRoundingRule.toNearestOrAwayFromZero!enumelt: bb1, default bb2
 
@@ -3131,7 +3131,7 @@ bb3 (%10: $Builtin.Int32):
 sil [ossa] @delete_dead_alloc_stack : $(@inout B) -> () {
 bb0(%0 : $*B):
   %1 = alloc_stack $B
-  copy_addr %0 to [initialization] %1 : $*B
+  copy_addr %0 to [init] %1 : $*B
   destroy_addr %1 : $*B
   dealloc_stack %1 : $*B
   %2 = tuple()
@@ -3161,7 +3161,7 @@ bb0:
 sil [ossa] @delete_dead_alloc_stack2 : $(@in B) -> () {
 bb0(%0 : $*B):
   %1 = alloc_stack $B
-  copy_addr [take] %0 to [initialization] %1 : $*B
+  copy_addr [take] %0 to [init] %1 : $*B
   destroy_addr %1 : $*B
   dealloc_stack %1 : $*B
   %2 = tuple()
@@ -3179,7 +3179,7 @@ sil [ossa] @use_b : $@convention(thin) (@inout B) -> ()
 sil [ossa] @dont_delete_dead_alloc_stack : $(@inout B) -> () {
 bb0(%0 : $*B):
   %1 = alloc_stack $B
-  copy_addr %0 to [initialization] %1 : $*B
+  copy_addr %0 to [init] %1 : $*B
   %2 = function_ref @use_b : $@convention(thin) (@inout B) -> ()
   %3 = apply %2(%1) : $@convention(thin) (@inout B) -> ()
   destroy_addr %1 : $*B
@@ -3204,7 +3204,7 @@ sil [ossa] @witness_archetype : $@convention(thin) <T where T : someProtocol> (@
 bb0(%0 : $*T):
   %3 = alloc_stack $someProtocol                  // users: %4, %7, %10, %13, %15
   %4 = init_existential_addr %3 : $*someProtocol, $T // user: %5
-  copy_addr %0 to [initialization] %4 : $*T       // id: %5
+  copy_addr %0 to [init] %4 : $*T       // id: %5
   destroy_addr %0 : $*T                           // id: %6
   %7 = open_existential_addr immutable_access %3 : $*someProtocol to $*@opened("105977B0-D8EB-11E4-AC00-3C0754644993", someProtocol) Self // users: %8, %9
   %8 = witness_method $@opened("105977B0-D8EB-11E4-AC00-3C0754644993", someProtocol) Self, #someProtocol.i!getter, %7 : $*@opened("105977B0-D8EB-11E4-AC00-3C0754644993", someProtocol) Self : $@convention(witness_method: someProtocol) <τ_0_0 where τ_0_0 : someProtocol> (@in_guaranteed τ_0_0) -> Int // user: %9
@@ -3945,7 +3945,7 @@ bb0(%0 : @owned $VV):
   %0b = begin_borrow %0 : $VV
   %9 = ref_element_addr %0b : $VV, #VV.m
   %10 = alloc_stack $PM
-  copy_addr %9 to [initialization] %10 : $*PM
+  copy_addr %9 to [init] %10 : $*PM
   end_borrow %0b : $VV
   %12 = open_existential_addr immutable_access %10 : $*PM to $*@opened("090C3DB0-1C76-11E6-81C4-B8E856428C60", PM) Self
   %13 = init_existential_addr %8 : $*PM, $@opened("090C3DB0-1C76-11E6-81C4-B8E856428C60", PM) Self

--- a/test/SILOptimizer/sil_combine_protocol_conf.swift
+++ b/test/SILOptimizer/sil_combine_protocol_conf.swift
@@ -248,7 +248,7 @@ public class OtherClass {
 // CHECK: [[ACC2:%.*]] = begin_access [read] [static] [no_nested_conflict] [[R2]]
 // CHECK: [[O2:%.*]] = open_existential_addr immutable_access [[ACC2]] : $*any GenericPropProtocol to $*@opened("{{.*}}", any GenericPropProtocol) Self
 // CHECK: [[T1:%.*]] = alloc_stack $@opened
-// CHECK: copy_addr [[O2]] to [initialization] [[T1]]
+// CHECK: copy_addr [[O2]] to [init] [[T1]]
 // CHECK: [[W2:%.*]] = witness_method $@opened("{{.*}}", any GenericPropProtocol) Self, #GenericPropProtocol.val!getter : <Self where Self : GenericPropProtocol> (Self) -> () -> Int, [[O2]] : $*@opened("{{.*}}", any GenericPropProtocol) Self : $@convention(witness_method: GenericPropProtocol) <τ_0_0 where τ_0_0 : GenericPropProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: apply [[W2]]<@opened("{{.*}}", any GenericPropProtocol) Self>([[T1]]) : $@convention(witness_method: GenericPropProtocol) <τ_0_0 where τ_0_0 : GenericPropProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: struct_extract
@@ -272,7 +272,7 @@ public class OtherClass {
 // CHECK: [[ACC5:%.*]] = begin_access [read] [static] [no_nested_conflict] [[R5]]
 // CHECK: [[O5:%.*]] = open_existential_addr immutable_access [[ACC5]] : $*any GenericNestedPropProtocol to $*@opened("{{.*}}", any GenericNestedPropProtocol) Self
 // CHECK: [[T2:%.*]] = alloc_stack $@opened
-// CHECK: copy_addr [[O5]] to [initialization] [[T2]]
+// CHECK: copy_addr [[O5]] to [init] [[T2]]
 // CHECK: [[W5:%.*]] = witness_method $@opened("{{.*}}", any GenericNestedPropProtocol) Self, #GenericNestedPropProtocol.val!getter : <Self where Self : GenericNestedPropProtocol> (Self) -> () -> Int, [[O5:%.*]] : $*@opened("{{.*}}", any GenericNestedPropProtocol) Self : $@convention(witness_method: GenericNestedPropProtocol) <τ_0_0 where τ_0_0 : GenericNestedPropProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: apply [[W5]]<@opened("{{.*}}", any GenericNestedPropProtocol) Self>([[T2]]) : $@convention(witness_method: GenericNestedPropProtocol) <τ_0_0 where τ_0_0 : GenericNestedPropProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: struct_extract
@@ -343,7 +343,7 @@ public class OtherKlass {
 // CHECK: [[ACC1:%.*]] = begin_access [read] [static] [no_nested_conflict] [[R1]]
 // CHECK: [[O1:%.*]] = open_existential_addr immutable_access [[ACC1]] : $*any AGenericProtocol to $*@opened("{{.*}}", any AGenericProtocol) Self
 // CHECK: [[T1:%.*]] = alloc_stack $@opened
-// CHECK: copy_addr [[O1]] to [initialization] [[T1]]
+// CHECK: copy_addr [[O1]] to [init] [[T1]]
 // CHECK: [[W1:%.*]] = witness_method $@opened("{{.*}}", any AGenericProtocol) Self, #AGenericProtocol.val!getter : <Self where Self : AGenericProtocol> (Self) -> () -> Int, [[O1]] : $*@opened("{{.*}}", any AGenericProtocol) Self : $@convention(witness_method: AGenericProtocol) <τ_0_0 where τ_0_0 : AGenericProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: apply [[W1]]<@opened("{{.*}}", any AGenericProtocol) Self>([[T1]]) : $@convention(witness_method: AGenericProtocol) <τ_0_0 where τ_0_0 : AGenericProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK: struct_extract

--- a/test/SILOptimizer/sil_combiner_concrete_prop_all_args.sil
+++ b/test/SILOptimizer/sil_combiner_concrete_prop_all_args.sil
@@ -615,7 +615,7 @@ bb0(%0 : $*τ_0_0):
 sil shared [noinline] @$s21existential_transform14wrap_inout_ncp1as5Int32VAA3PPP_pz_tFTf4e_n : $@convention(thin) <τ_0_0 where τ_0_0 : PPP> (@inout τ_0_0) -> Int32 {
 bb0(%0 : $*τ_0_0):
   %1 = alloc_stack $τ_0_0                        
-  copy_addr [take] %0 to [initialization] %1 : $*τ_0_0 
+  copy_addr [take] %0 to [init] %1 : $*τ_0_0 
   %3 = witness_method $τ_0_0, #PPP.foo : <Self where Self : PPP> (Self) -> () -> Int32 : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> Int32 
   %4 = apply %3<τ_0_0>(%1) : $@convention(witness_method: PPP) <τ_0_0 where τ_0_0 : PPP> (@in_guaranteed τ_0_0) -> Int32 
   dealloc_stack %1 : $*τ_0_0                     
@@ -629,7 +629,7 @@ bb0(%0 : $*τ_0_0):
 sil shared [noinline] @$s21existential_transform21wrap_struct_inout_ncp1as5Int32VAA4PPPP_pz_tFTf4e_n : $@convention(thin) <τ_0_0 where τ_0_0 : PPPP> (@inout τ_0_0) -> Int32 {
 bb0(%0 : $*τ_0_0):
   %1 = alloc_stack $τ_0_0                        
-  copy_addr [take] %0 to [initialization] %1 : $*τ_0_0 
+  copy_addr [take] %0 to [init] %1 : $*τ_0_0 
   %3 = witness_method $τ_0_0, #PPPP.foo : <Self where Self : PPPP> (Self) -> () -> Int32 : $@convention(witness_method: PPPP) <τ_0_0 where τ_0_0 : PPPP> (@in_guaranteed τ_0_0) -> Int32 
   %4 = apply %3<τ_0_0>(%1) : $@convention(witness_method: PPPP) <τ_0_0 where τ_0_0 : PPPP> (@in_guaranteed τ_0_0) -> Int32 
   dealloc_stack %1 : $*τ_0_0                     

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -2992,7 +2992,7 @@ bb3(%11 : $Int):
 // CHECK:   store %0 to [[SRC]]
 // CHECK:   [[DST:%.*]] = alloc_stack $String
 // CHECK:   [[TEMP:%.*]] = alloc_stack $String
-// CHECK:   copy_addr [[SRC]] to [initialization] [[TEMP]]
+// CHECK:   copy_addr [[SRC]] to [init] [[TEMP]]
 // CHECK:   [[LD1:%.*]] = load [[TEMP]]
 // CHECK:   store [[LD1]] to [[DST]]
 // CHECK:   [[LD2:%.*]] = load [[DST]]

--- a/test/SILOptimizer/specialize.sil
+++ b/test/SILOptimizer/specialize.sil
@@ -75,12 +75,12 @@ bb0(%0 : $*XXX<T>, %1 : $*T, %2 : $@thin XXX<T>.Type):
   %3 = alloc_stack $XXX<T>, var, name "sf"           // users: %7, %11, %13
   debug_value %1 : $*T, let, name "t", expr op_deref // id: %4
   %5 = alloc_stack $T                             // users: %6, %8, %9
-  copy_addr %1 to [initialization] %5 : $*T     // id: %6
+  copy_addr %1 to [init] %5 : $*T     // id: %6
   %7 = struct_element_addr %3 : $*XXX<T>, #XXX.m_t // user: %8
-  copy_addr [take] %5 to [initialization] %7 : $*T // id: %8
+  copy_addr [take] %5 to [init] %7 : $*T // id: %8
   dealloc_stack %5 : $*T         // id: %9
   destroy_addr %1 : $*T                           // id: %10
-  copy_addr [take] %3 to [initialization] %0 : $*XXX<T> // id: %11
+  copy_addr [take] %3 to [init] %0 : $*XXX<T> // id: %11
   %12 = tuple ()                                  // user: %14
   dealloc_stack %3 : $*XXX<T>    // id: %13
   return %12 : $()                                // id: %14
@@ -91,7 +91,7 @@ sil [noinline] @XXX_foo : $@convention(method) <T> (@in T, @inout XXX<T>) -> Int
 bb0(%0 : $*T, %1 : $*XXX<T>):
   debug_value %0 : $*T, let, name "t", expr op_deref // id: %2
   %3 = alloc_stack $T                             // users: %4, %6, %7
-  copy_addr %0 to [initialization] %3 : $*T     // id: %4
+  copy_addr %0 to [init] %3 : $*T     // id: %4
   %5 = struct_element_addr %1 : $*XXX<T>, #XXX.m_t // user: %6
   copy_addr [take] %3 to %5 : $*T               // id: %6
   dealloc_stack %3 : $*T         // id: %7
@@ -195,7 +195,7 @@ bb0(%0 : $*T):
   %2 = function_ref @getGenericClosure_closure : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0 // user: %5
   %3 = alloc_box $<τ_0_0> { var τ_0_0 } <T>                               // users: %4, %5, %5
   %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <T>, 0
-  copy_addr %0 to [initialization] %3a : $*T     // id: %4
+  copy_addr %0 to [init] %3a : $*T     // id: %4
   %5 = partial_apply %2<T>(%3) : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0 // user: %7
   destroy_addr %0 : $*T                           // id: %6
   return %5 : $@callee_owned () -> @out T       // id: %7
@@ -205,7 +205,7 @@ bb0(%0 : $*T):
 sil shared @getGenericClosure_closure : $@convention(thin) <T> (@owned <τ_0_0> { var τ_0_0 } <T>) -> @out T {
 bb0(%0 : $*T, %1 : $<τ_0_0> { var τ_0_0 } <T>):
   %2 = project_box %1 : $<τ_0_0> { var τ_0_0 } <T>, 0
-  copy_addr %2 to [initialization] %0 : $*T       // id: %3
+  copy_addr %2 to [init] %0 : $*T       // id: %3
   strong_release %1 : $<τ_0_0> { var τ_0_0 } <T>       // id: %4
   %5 = tuple ()                                   // user: %6
   return %5 : $()                                 // id: %6
@@ -339,7 +339,7 @@ bb0(%0 : $*U):
   %2 = function_ref @boo_closure : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P> (Int32, @in τ_0_1, @owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> Int32 // user: %5
   %3 = alloc_box $<τ_0_0> { var τ_0_0 } <U>                               // users: %4, %5, %5
   %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <U>, 0
-  copy_addr %0 to [initialization] %3a : $*U     // id: %4
+  copy_addr %0 to [init] %3a : $*U     // id: %4
   %5 = partial_apply %2<U, T>(%3) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P> (Int32, @in τ_0_1, @owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> Int32 // user: %7
   destroy_addr %0 : $*U                           // id: %6
   return %5 : $@callee_owned (Int32, @in T) -> Int32 // id: %7
@@ -388,7 +388,7 @@ bb0(%0 : $*T, %1 : $*U):
   // function_ref test4.boo <A : test4.P, B>(A) -> (Swift.Int32, B) -> Swift.Int32
   %4 = function_ref @boo : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P> (@in τ_0_0) -> @owned @callee_owned (Int32, @in τ_0_1) -> Int32 // user: %7
   %5 = alloc_stack $U                             // users: %6, %7, %10
-  copy_addr %1 to [initialization] %5 : $*U     // id: %6
+  copy_addr %1 to [init] %5 : $*U     // id: %6
   %7 = apply %4<U, Float>(%5) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P> (@in τ_0_0) -> @owned @callee_owned (Int32, @in τ_0_1) -> Int32 // user: %9
   // function_ref reabstraction thunk helper <T_0_0, T_0_1 where T_0_0: test4.P, T_0_1: test4.P> from @callee_owned (@unowned Swift.Int32, @in Swift.Float) -> (@unowned Swift.Int32) to @callee_owned (@unowned Swift.Int32, @unowned Swift.Float) -> (@unowned Swift.Int32)
   %8 = function_ref @_TTRG1_RPq_P5test41P_Pq0_PS0___XFo_dVs5Int32iSf_dS1__XFo_dS1_dSf_dS1__ : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P, τ_0_1 : P> (Int32, Float, @owned @callee_owned (Int32, @in Float) -> Int32) -> Int32 // user: %9
@@ -417,7 +417,7 @@ bb0(%0 : $*T):
   %2 = function_ref @gen1_closure : $@convention(thin) <τ_0_0 where τ_0_0 : P> (Int32, @owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> Int32 // user: %5
   %3 = alloc_box $<τ_0_0> { var τ_0_0 } <T>                               // users: %4, %5, %5
   %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <T>, 0
-  copy_addr %0 to [initialization] %3a : $*T     // id: %4
+  copy_addr %0 to [init] %3a : $*T     // id: %4
   %5 = partial_apply %2<T>(%3) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (Int32, @owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> Int32 // user: %7
   destroy_addr %0 : $*T                           // id: %6
   return %5 : $@callee_owned (Int32) -> Int32     // id: %7
@@ -695,7 +695,7 @@ bb0(%0 : $*T):
 
 sil @id : $@convention(thin) <T> (@in T) -> @out T {
 bb0(%0 : $*T, %1 :$*T):
-  copy_addr [take] %1 to [initialization] %0 : $*T
+  copy_addr [take] %1 to [init] %0 : $*T
   %t = tuple ()
   return %t : $()
 }

--- a/test/SILOptimizer/specialize_inherited_ossa.sil
+++ b/test/SILOptimizer/specialize_inherited_ossa.sil
@@ -57,8 +57,8 @@ bb0(%0 : $*Key, %1 : $Int, %2 : @owned $MMStorage<Key, Value>):
   %26 = witness_method $Key, #Equatable."==" : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> Bool
   %27 = alloc_stack $Key
   %33 = alloc_stack $Key
-  copy_addr %0 to [initialization] %27 : $*Key
-  copy_addr %0 to [initialization] %33 : $*Key
+  copy_addr %0 to [init] %27 : $*Key
+  copy_addr %0 to [init] %33 : $*Key
   // CHECK: apply [[ID2]]<Key>
   %35 = apply %26<Key>(%27, %33, %25) : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in τ_0_0, @in τ_0_0, @thick τ_0_0.Type) -> Bool
   dealloc_stack %33 : $*Key

--- a/test/SILOptimizer/specialize_opaque_result_types.sil
+++ b/test/SILOptimizer/specialize_opaque_result_types.sil
@@ -37,7 +37,7 @@ bb0(%0 : $Test):
 // CHECK: alloc_stack $Optional<Int64>
 // CHECK:  ([[RES:%.*]], %{{.*}}) = begin_apply {{.*}}<Test>({{.*}}) : $@yield_once @convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @yields @in_guaranteed τ_0_0.Element
 // CHECK:  [[DEST:%.*]] = init_enum_data_addr %1 : $*Optional<Int64>, #Optional.some!enumelt
-// CHECK:  copy_addr [[RES]] to [initialization] {{.*}} : $*Int64
+// CHECK:  copy_addr [[RES]] to [init] {{.*}} : $*Int64
 // CHECK: } // end sil function '$s4next8External4TestV_Tg5'
 
 sil @next : $@convention(witness_method: IteratorProtocol) <τ_0_0 where τ_0_0 : Collection> (@inout IndexingIterator<τ_0_0>) -> @out Optional<τ_0_0.Element> {
@@ -45,14 +45,14 @@ bb0(%0 : $*Optional<τ_0_0.Element>, %1 : $*IndexingIterator<τ_0_0>):
   %2 = metatype $@thick τ_0_0.Index.Type
   %3 = struct_element_addr %1 : $*IndexingIterator<τ_0_0>, #IndexingIterator._position
   %4 = alloc_stack $τ_0_0.Index
-  copy_addr %3 to [initialization] %4 : $*τ_0_0.Index
+  copy_addr %3 to [init] %4 : $*τ_0_0.Index
   %6 = struct_element_addr %1 : $*IndexingIterator<τ_0_0>, #IndexingIterator._elements
   %20 = alloc_stack $τ_0_0
-  copy_addr %6 to [initialization] %20 : $*τ_0_0
+  copy_addr %6 to [init] %20 : $*τ_0_0
   %22 = alloc_stack $τ_0_0.Index
-  copy_addr %3 to [initialization] %22 : $*τ_0_0.Index
+  copy_addr %3 to [init] %22 : $*τ_0_0.Index
   %24 = alloc_stack $τ_0_0
-  copy_addr [take] %20 to [initialization] %24 : $*τ_0_0
+  copy_addr [take] %20 to [init] %24 : $*τ_0_0
   %26 = witness_method $τ_0_0, #Collection.subscript!read : <Self where Self : Collection> (Self) -> (Self.Index) -> () : $@yield_once @convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @yields @in_guaranteed τ_0_0.Element
 
   // The specialized begin apply %26<Test> has a result type of t_0_0.Element
@@ -61,7 +61,7 @@ bb0(%0 : $*Optional<τ_0_0.Element>, %1 : $*IndexingIterator<τ_0_0>):
   (%27, %28) = begin_apply %26<τ_0_0>(%22, %24) : $@yield_once @convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @yields @in_guaranteed τ_0_0.Element
 
   %29 = init_enum_data_addr %0 : $*Optional<τ_0_0.Element>, #Optional.some!enumelt
-  copy_addr %27 to [initialization] %29 : $*τ_0_0.Element
+  copy_addr %27 to [init] %29 : $*τ_0_0.Element
   end_apply %28
   destroy_addr %22 : $*τ_0_0.Index
   destroy_addr %24 : $*τ_0_0

--- a/test/SILOptimizer/specialize_opaque_result_types2.sil
+++ b/test/SILOptimizer/specialize_opaque_result_types2.sil
@@ -29,7 +29,7 @@ bb0(%0 : $*T):
   %2 = function_ref @getGenericClosure_closure : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0 // user: %5
   %3 = alloc_box $<τ_0_0> { var τ_0_0 } <T>                               // users: %4, %5, %5
   %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <T>, 0
-  copy_addr %0 to [initialization] %3a : $*T     // id: %4
+  copy_addr %0 to [init] %3a : $*T     // id: %4
   %5 = partial_apply %2<T>(%3) : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0 // user: %7
   destroy_addr %0 : $*T                           // id: %6
   return %5 : $@callee_owned () -> @out T       // id: %7

--- a/test/SILOptimizer/specialize_opaque_result_types_ossa.sil
+++ b/test/SILOptimizer/specialize_opaque_result_types_ossa.sil
@@ -37,21 +37,21 @@ bb0(%0 : @owned $Test):
 // CHECK: alloc_stack $Optional<Int64>
 // CHECK:  ([[RES:%.*]], %{{.*}}) = begin_apply {{.*}}<Test>({{.*}}) : $@yield_once @convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @yields @in_guaranteed τ_0_0.Element
 // CHECK:  [[DEST:%.*]] = init_enum_data_addr %1 : $*Optional<Int64>, #Optional.some!enumelt
-// CHECK:  copy_addr [[RES]] to [initialization] {{.*}} : $*Int64
+// CHECK:  copy_addr [[RES]] to [init] {{.*}} : $*Int64
 // CHECK: } // end sil function '$s4next8External4TestV_Tg5'
 sil [ossa] @next : $@convention(witness_method: IteratorProtocol) <τ_0_0 where τ_0_0 : Collection> (@inout IndexingIterator<τ_0_0>) -> @out Optional<τ_0_0.Element> {
 bb0(%0 : $*Optional<τ_0_0.Element>, %1 : $*IndexingIterator<τ_0_0>):
   %2 = metatype $@thick τ_0_0.Index.Type
   %3 = struct_element_addr %1 : $*IndexingIterator<τ_0_0>, #IndexingIterator._position
   %4 = alloc_stack $τ_0_0.Index
-  copy_addr %3 to [initialization] %4 : $*τ_0_0.Index
+  copy_addr %3 to [init] %4 : $*τ_0_0.Index
   %6 = struct_element_addr %1 : $*IndexingIterator<τ_0_0>, #IndexingIterator._elements
   %20 = alloc_stack $τ_0_0
-  copy_addr %6 to [initialization] %20 : $*τ_0_0
+  copy_addr %6 to [init] %20 : $*τ_0_0
   %22 = alloc_stack $τ_0_0.Index
-  copy_addr %3 to [initialization] %22 : $*τ_0_0.Index
+  copy_addr %3 to [init] %22 : $*τ_0_0.Index
   %24 = alloc_stack $τ_0_0
-  copy_addr [take] %20 to [initialization] %24 : $*τ_0_0
+  copy_addr [take] %20 to [init] %24 : $*τ_0_0
   %26 = witness_method $τ_0_0, #Collection.subscript!read : <Self where Self : Collection> (Self) -> (Self.Index) -> () : $@yield_once @convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @yields @in_guaranteed τ_0_0.Element
 
   // The specialized begin apply %26<Test> has a result type of t_0_0.Element
@@ -60,7 +60,7 @@ bb0(%0 : $*Optional<τ_0_0.Element>, %1 : $*IndexingIterator<τ_0_0>):
   (%27, %28) = begin_apply %26<τ_0_0>(%22, %24) : $@yield_once @convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @yields @in_guaranteed τ_0_0.Element
 
   %29 = init_enum_data_addr %0 : $*Optional<τ_0_0.Element>, #Optional.some!enumelt
-  copy_addr %27 to [initialization] %29 : $*τ_0_0.Element
+  copy_addr %27 to [init] %29 : $*τ_0_0.Element
   end_apply %28
   destroy_addr %22 : $*τ_0_0.Index
   destroy_addr %24 : $*τ_0_0

--- a/test/SILOptimizer/specialize_ossa.sil
+++ b/test/SILOptimizer/specialize_ossa.sil
@@ -60,12 +60,12 @@ bb0(%0 : $*XXX<T>, %1 : $*T, %2 : $@thin XXX<T>.Type):
   %3 = alloc_stack $XXX<T>, var, name "sf"           // users: %7, %11, %13
   debug_value %1 : $*T, let, name "t", expr op_deref // id: %4
   %5 = alloc_stack $T                             // users: %6, %8, %9
-  copy_addr %1 to [initialization] %5 : $*T     // id: %6
+  copy_addr %1 to [init] %5 : $*T     // id: %6
   %7 = struct_element_addr %3 : $*XXX<T>, #XXX.m_t // user: %8
-  copy_addr [take] %5 to [initialization] %7 : $*T // id: %8
+  copy_addr [take] %5 to [init] %7 : $*T // id: %8
   dealloc_stack %5 : $*T         // id: %9
   destroy_addr %1 : $*T                           // id: %10
-  copy_addr [take] %3 to [initialization] %0 : $*XXX<T> // id: %11
+  copy_addr [take] %3 to [init] %0 : $*XXX<T> // id: %11
   %12 = tuple ()                                  // user: %14
   dealloc_stack %3 : $*XXX<T>    // id: %13
   return %12 : $()                                // id: %14
@@ -76,7 +76,7 @@ sil [ossa] [noinline] @XXX_foo : $@convention(method) <T> (@in T, @inout XXX<T>)
 bb0(%0 : $*T, %1 : $*XXX<T>):
   debug_value %0 : $*T, let, name "t", expr op_deref // id: %2
   %3 = alloc_stack $T                             // users: %4, %6, %7
-  copy_addr %0 to [initialization] %3 : $*T     // id: %4
+  copy_addr %0 to [init] %3 : $*T     // id: %4
   %5 = struct_element_addr %1 : $*XXX<T>, #XXX.m_t // user: %6
   copy_addr [take] %3 to %5 : $*T               // id: %6
   dealloc_stack %3 : $*T         // id: %7
@@ -91,11 +91,11 @@ bb0(%0 : $*XXX<T>, %1 : $*T, %2 : $@thin XXX<T>.Type):
   %3 = alloc_stack $XXX<T>, var, name "sf"           // users: %7, %11, %13
   debug_value %1 : $*T, let, name "t", expr op_deref // id: %4
   %5 = alloc_stack $T                             // users: %6, %8, %9
-  copy_addr %1 to [initialization] %5 : $*T     // id: %6
+  copy_addr %1 to [init] %5 : $*T     // id: %6
   %7 = struct_element_addr %3 : $*XXX<T>, #XXX.m_t // user: %8
-  copy_addr [take] %5 to [initialization] %7 : $*T // id: %8
+  copy_addr [take] %5 to [init] %7 : $*T // id: %8
   dealloc_stack %5 : $*T         // id: %9
-  copy_addr [take] %3 to [initialization] %0 : $*XXX<T> // id: %11
+  copy_addr [take] %3 to [init] %0 : $*XXX<T> // id: %11
   %12 = tuple ()                                  // user: %14
   dealloc_stack %3 : $*XXX<T>    // id: %13
   return %12 : $()                                // id: %14
@@ -106,7 +106,7 @@ sil [ossa] [noinline] @XXX_foo_guaranteed : $@convention(method) <T> (@in_guaran
 bb0(%0 : $*T, %1 : $*XXX<T>):
   debug_value %0 : $*T, let, name "t", expr op_deref // id: %2
   %3 = alloc_stack $T                             // users: %4, %6, %7
-  copy_addr %0 to [initialization] %3 : $*T     // id: %4
+  copy_addr %0 to [init] %3 : $*T     // id: %4
   %5 = struct_element_addr %1 : $*XXX<T>, #XXX.m_t // user: %6
   copy_addr [take] %3 to %5 : $*T               // id: %6
   dealloc_stack %3 : $*T         // id: %7
@@ -121,7 +121,7 @@ bb0(%0 : $*T, %1 : $*T, %2 : $*XXX<T>):
   %3 = address_to_pointer %1 : $*T to $Builtin.RawPointer
   %4 = alloc_stack $T
   %5 = struct_element_addr %2 : $*XXX<T>, #XXX.m_t
-  copy_addr [take] %5 to [initialization] %0 : $*T
+  copy_addr [take] %5 to [init] %0 : $*T
   dealloc_stack %4 : $*T
   %t = tuple ()
   return %t : $()
@@ -280,7 +280,7 @@ bb0(%0 : $*T):
   %3 = alloc_box $<τ_0_0> { var τ_0_0 } <T>
   %3b = begin_borrow %3 : $<τ_0_0> { var τ_0_0 } <T>
   %3a = project_box %3b : $<τ_0_0> { var τ_0_0 } <T>, 0
-  copy_addr %0 to [initialization] %3a : $*T     // id: %4
+  copy_addr %0 to [init] %3a : $*T     // id: %4
   end_borrow %3b : $<τ_0_0> { var τ_0_0 } <T>
   %5 = partial_apply %2<T>(%3) : $@convention(thin) <τ_0_0> (@owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> @out τ_0_0 // user: %7
   destroy_addr %0 : $*T                           // id: %6
@@ -292,7 +292,7 @@ sil shared [ossa] @getGenericClosure_closure : $@convention(thin) <T> (@owned <�
 bb0(%0 : $*T, %1 : @owned $<τ_0_0> { var τ_0_0 } <T>):
   %1a = begin_borrow %1 : $<τ_0_0> { var τ_0_0 } <T>
   %2 = project_box %1a : $<τ_0_0> { var τ_0_0 } <T>, 0
-  copy_addr %2 to [initialization] %0 : $*T       // id: %3
+  copy_addr %2 to [init] %0 : $*T       // id: %3
   end_borrow %1a : $<τ_0_0> { var τ_0_0 } <T>
   destroy_value %1 : $<τ_0_0> { var τ_0_0 } <T>       // id: %4
   %5 = tuple ()                                   // user: %6
@@ -412,7 +412,7 @@ bb0(%0 : $*U):
   %2 = function_ref @boo_closure : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P> (Int32, @in τ_0_1, @owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> Int32 // user: %5
   %3 = alloc_box $<τ_0_0> { var τ_0_0 } <U>                               // users: %4, %5, %5
   %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <U>, 0
-  copy_addr %0 to [initialization] %3a : $*U     // id: %4
+  copy_addr %0 to [init] %3a : $*U     // id: %4
   %5 = partial_apply %2<U, T>(%3) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P> (Int32, @in τ_0_1, @owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> Int32 // user: %7
   destroy_addr %0 : $*U                           // id: %6
   return %5 : $@callee_owned (Int32, @in T) -> Int32 // id: %7
@@ -461,7 +461,7 @@ bb0(%0 : $*T, %1 : $*U):
   // function_ref test4.boo <A : test4.P, B>(A) -> (Swift.Int32, B) -> Swift.Int32
   %4 = function_ref @boo : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P> (@in τ_0_0) -> @owned @callee_owned (Int32, @in τ_0_1) -> Int32 // user: %7
   %5 = alloc_stack $U                             // users: %6, %7, %10
-  copy_addr %1 to [initialization] %5 : $*U     // id: %6
+  copy_addr %1 to [init] %5 : $*U     // id: %6
   %7 = apply %4<U, Float>(%5) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P> (@in τ_0_0) -> @owned @callee_owned (Int32, @in τ_0_1) -> Int32 // user: %9
   // function_ref reabstraction thunk helper <T_0_0, T_0_1 where T_0_0: test4.P, T_0_1: test4.P> from @callee_owned (@unowned Swift.Int32, @in Swift.Float) -> (@unowned Swift.Int32) to @callee_owned (@unowned Swift.Int32, @unowned Swift.Float) -> (@unowned Swift.Int32)
   %8 = function_ref @_TTRG1_RPq_P5test41P_Pq0_PS0___XFo_dVs5Int32iSf_dS1__XFo_dS1_dSf_dS1__ : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 : P, τ_0_1 : P> (Int32, Float, @owned @callee_owned (Int32, @in Float) -> Int32) -> Int32 // user: %9
@@ -490,7 +490,7 @@ bb0(%0 : $*T):
   %2 = function_ref @gen1_closure : $@convention(thin) <τ_0_0 where τ_0_0 : P> (Int32, @owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> Int32 // user: %5
   %3 = alloc_box $<τ_0_0> { var τ_0_0 } <T>                               // users: %4, %5, %5
   %3a = project_box %3 : $<τ_0_0> { var τ_0_0 } <T>, 0
-  copy_addr %0 to [initialization] %3a : $*T     // id: %4
+  copy_addr %0 to [init] %3a : $*T     // id: %4
   %5 = partial_apply %2<T>(%3) : $@convention(thin) <τ_0_0 where τ_0_0 : P> (Int32, @owned <τ_0_0> { var τ_0_0 } <τ_0_0>) -> Int32 // user: %7
   destroy_addr %0 : $*T                           // id: %6
   return %5 : $@callee_owned (Int32) -> Int32     // id: %7
@@ -726,7 +726,7 @@ bb1:
   store %val to [trivial] %val_storage : $*Builtin.Int64
   %fn = function_ref @selfReferringGenericClosure : $@convention(thin) <U, V> (@in_guaranteed U, @in_guaranteed V, Builtin.Int64) -> () 
   %s = alloc_stack $R
-  copy_addr %0 to [initialization] %s : $*R
+  copy_addr %0 to [init] %s : $*R
   %7 = partial_apply %fn<R, Builtin.Int64>(%s, %val_storage, %4) : $@convention(thin) <U, V> (@in_guaranteed U, @in_guaranteed V, Builtin.Int64) -> ()
   dealloc_stack %s : $*R
   dealloc_stack %val_storage : $*Builtin.Int64
@@ -752,7 +752,7 @@ bb1:
   store %val to [init] %val_storage : $*Builtin.NativeObject
   %fn = function_ref @selfReferringGenericClosure_nontrivial_guaranteed : $@convention(thin) <U, V> (@in_guaranteed U, @in_guaranteed V, @guaranteed Builtin.NativeObject) -> () 
   %s = alloc_stack $R
-  copy_addr %0 to [initialization] %s : $*R
+  copy_addr %0 to [init] %s : $*R
   %7 = partial_apply %fn<R, Builtin.NativeObject>(%s, %val_storage, %val2) : $@convention(thin) <U, V> (@in_guaranteed U, @in_guaranteed V, @guaranteed Builtin.NativeObject) -> ()
   dealloc_stack %s : $*R
   dealloc_stack %val_storage : $*Builtin.NativeObject
@@ -778,7 +778,7 @@ bb1:
   store %val to [init] %val_storage : $*Builtin.NativeObject
   %fn = function_ref @selfReferringGenericClosure_nontrivial_guaranteed_applied : $@convention(thin) <U, V> (@in_guaranteed U, @in_guaranteed V, @guaranteed Builtin.NativeObject) -> () 
   %s = alloc_stack $R
-  copy_addr %0 to [initialization] %s : $*R
+  copy_addr %0 to [init] %s : $*R
   %7 = partial_apply %fn<R, Builtin.NativeObject>(%s, %val_storage, %val2) : $@convention(thin) <U, V> (@in_guaranteed U, @in_guaranteed V, @guaranteed Builtin.NativeObject) -> ()
   dealloc_stack %s : $*R
   apply %7() :$@callee_owned () -> ()
@@ -880,7 +880,7 @@ bb0(%0 : $*T):
 
 sil [ossa] @id : $@convention(thin) <T> (@in T) -> @out T {
 bb0(%0 : $*T, %1 :$*T):
-  copy_addr [take] %1 to [initialization] %0 : $*T
+  copy_addr [take] %1 to [init] %0 : $*T
   %t = tuple ()
   return %t : $()
 }
@@ -893,7 +893,7 @@ bb0(%0 : $*T, %1 :$*T):
 sil [ossa] @specialize_no_return_apply: $@convention(thin) <T> (@thick T.Type) -> () {
 bb0(%0 : $@thick T.Type):
   %in = alloc_stack $T
-  copy_addr [take] undef to [initialization] %in : $*T
+  copy_addr [take] undef to [init] %in : $*T
   %out = alloc_stack $T
   %f = function_ref @id : $@convention(thin) <T> (@in T) -> @out T
   %r = apply %f<T>(%out, %in) : $@convention(thin) <T> (@in T) -> @out T
@@ -956,7 +956,7 @@ bb1:
   throw %e : $Error
 
 bb2:
-  copy_addr %1 to [initialization] %0 : $*T
+  copy_addr %1 to [init] %0 : $*T
   %9999 = tuple()
   return %9999 : $()
 }
@@ -1156,7 +1156,7 @@ bb0(%0 : $*Klass, %1 : @guaranteed $Klass):
 sil [ossa] @generic_begin_apply_callee_inguaranteed : $@yield_once @convention(thin) <T> (@in_guaranteed T) -> @yields @in_guaranteed T {
 bb0(%0 : $*T):
   %1 = alloc_stack $*T
-  copy_addr %0 to [initialization] %1 : $*T
+  copy_addr %0 to [init] %1 : $*T
   yield %1 : $*T, resume bb1, unwind bb2
 
 bb1:
@@ -1174,7 +1174,7 @@ bb2:
 sil [ossa] @generic_begin_apply_callee_in : $@yield_once @convention(thin) <T> (@in_guaranteed T) -> @yields @in T {
 bb0(%0 : $*T):
   %1 = alloc_stack $*T
-  copy_addr %0 to [initialization] %1 : $*T
+  copy_addr %0 to [init] %1 : $*T
   yield %1 : $*T, resume bb1, unwind bb2
 
 bb1:
@@ -1190,7 +1190,7 @@ bb2:
 sil [ossa] @generic_begin_apply_callee_inout : $@yield_once @convention(thin) <T> (@in_guaranteed T) -> @yields @inout T {
 bb0(%0 : $*T):
   %1 = alloc_stack $*T
-  copy_addr %0 to [initialization] %1 : $*T
+  copy_addr %0 to [init] %1 : $*T
   yield %1 : $*T, resume bb1, unwind bb2
 
 bb1:

--- a/test/SILOptimizer/specialize_reabstraction.sil
+++ b/test/SILOptimizer/specialize_reabstraction.sil
@@ -141,7 +141,7 @@ bb0(%0 : $Bool):
 sil @arg_escapes_to_return : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
 [%1: escape => %0] 
 bb0(%0 : $*T, %1 : $*T):
-  copy_addr %1 to [initialization] %0 : $*T
+  copy_addr %1 to [init] %0 : $*T
   %4 = tuple ()
   return %4 : $()
 }

--- a/test/SILOptimizer/specialize_recursive_generics.sil
+++ b/test/SILOptimizer/specialize_recursive_generics.sil
@@ -18,7 +18,7 @@ bb0(%0 : $*T):
   // function_ref specialize_recursive_generics.recursive_generics <A>(A) -> ()
   %2 = function_ref @_TF29specialize_recursive_generics18recursive_genericsU__FQ_T_ : $@convention(thin) <τ_0_0> (@in τ_0_0) -> () // user: %5
   %3 = alloc_stack $T                             // users: %4, %5, %6
-  copy_addr %0 to [initialization] %3 : $*T     // id: %4
+  copy_addr %0 to [init] %3 : $*T     // id: %4
   %5 = apply %2<T>(%3) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   dealloc_stack %3 : $*T         // id: %6
   destroy_addr %0 : $*T                           // id: %7
@@ -44,9 +44,9 @@ bb0(%0 : $*T, %1 : $*U):
   // function_ref specialize_recursive_generics.recursive_generics_with_different_substitutions <A, B>(A, B) -> ()
   %4 = function_ref @_TF29specialize_recursive_generics47recursive_generics_with_different_substitutionsU___FTQ_Q0__T_ : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_1) -> () // user: %9
   %5 = alloc_stack $U                             // users: %6, %9, %11
-  copy_addr %1 to [initialization] %5 : $*U     // id: %6
+  copy_addr %1 to [init] %5 : $*U     // id: %6
   %7 = alloc_stack $T                             // users: %8, %9, %10
-  copy_addr %0 to [initialization] %7 : $*T     // id: %8
+  copy_addr %0 to [init] %7 : $*T     // id: %8
   %9 = apply %4<U, T>(%5, %7) : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_1) -> ()
   dealloc_stack %7 : $*T         // id: %10
   dealloc_stack %5 : $*U         // id: %11
@@ -98,7 +98,7 @@ public protocol P {}
 sil hidden [noinline] @helper : $@convention(thin) <T> (@in T, @in P) -> @owned Optional<C> {
 bb0(%0 : $*T, %1 : $*P):
   %4 = alloc_stack $P
-  copy_addr %1 to [initialization] %4 : $*P
+  copy_addr %1 to [init] %4 : $*P
   %6 = alloc_stack $C
   checked_cast_addr_br take_always P in %4 : $*P to C in %6 : $*C, bb1, bb2
 bb1:
@@ -129,7 +129,7 @@ bb0(%0 : $C, %1 : $*Self):
   store %6 to %7 : $*Int32
   %9 = alloc_stack $P
   %10 = init_existential_addr %9 : $*P, $Self
-  copy_addr %1 to [initialization] %10 : $*Self
+  copy_addr %1 to [init] %10 : $*Self
   // CHECK: apply [[HELPER]]
   // CHECK-NOT: apply [[HELPER]]
   %12 = apply %4<Int32>(%7, %9) : $@convention(thin) <τ_0_0> (@in τ_0_0, @in P) -> @owned Optional<C>

--- a/test/SILOptimizer/specialize_recursive_generics_ossa.sil
+++ b/test/SILOptimizer/specialize_recursive_generics_ossa.sil
@@ -18,7 +18,7 @@ bb0(%0 : $*T):
   // function_ref specialize_recursive_generics.recursive_generics <A>(A) -> ()
   %2 = function_ref @_TF29specialize_recursive_generics18recursive_genericsU__FQ_T_ : $@convention(thin) <τ_0_0> (@in τ_0_0) -> () // user: %5
   %3 = alloc_stack $T                             // users: %4, %5, %6
-  copy_addr %0 to [initialization] %3 : $*T     // id: %4
+  copy_addr %0 to [init] %3 : $*T     // id: %4
   %5 = apply %2<T>(%3) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> ()
   dealloc_stack %3 : $*T         // id: %6
   destroy_addr %0 : $*T                           // id: %7
@@ -44,9 +44,9 @@ bb0(%0 : $*T, %1 : $*U):
   // function_ref specialize_recursive_generics.recursive_generics_with_different_substitutions <A, B>(A, B) -> ()
   %4 = function_ref @_TF29specialize_recursive_generics47recursive_generics_with_different_substitutionsU___FTQ_Q0__T_ : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_1) -> () // user: %9
   %5 = alloc_stack $U                             // users: %6, %9, %11
-  copy_addr %1 to [initialization] %5 : $*U     // id: %6
+  copy_addr %1 to [init] %5 : $*U     // id: %6
   %7 = alloc_stack $T                             // users: %8, %9, %10
-  copy_addr %0 to [initialization] %7 : $*T     // id: %8
+  copy_addr %0 to [init] %7 : $*T     // id: %8
   %9 = apply %4<U, T>(%5, %7) : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0, @in τ_0_1) -> ()
   dealloc_stack %7 : $*T         // id: %10
   dealloc_stack %5 : $*U         // id: %11
@@ -98,7 +98,7 @@ public protocol P {}
 sil hidden [ossa] [noinline] @helper : $@convention(thin) <T> (@in T, @in P) -> @owned Optional<C> {
 bb0(%0 : $*T, %1 : $*P):
   %4 = alloc_stack $P
-  copy_addr %1 to [initialization] %4 : $*P
+  copy_addr %1 to [init] %4 : $*P
   %6 = alloc_stack $C
   checked_cast_addr_br take_always P in %4 : $*P to C in %6 : $*C, bb1, bb2
 bb1:
@@ -130,7 +130,7 @@ bb0(%0 : @owned $C, %1 : $*Self):
   store %6 to [trivial] %7 : $*Int32
   %9 = alloc_stack $P
   %10 = init_existential_addr %9 : $*P, $Self
-  copy_addr %1 to [initialization] %10 : $*Self
+  copy_addr %1 to [init] %10 : $*Self
   // CHECK: apply [[HELPER]]
   // CHECK-NOT: apply [[HELPER]]
   %12 = apply %4<Int32>(%7, %9) : $@convention(thin) <τ_0_0> (@in τ_0_0, @in P) -> @owned Optional<C>

--- a/test/SILOptimizer/stack_protection.sil
+++ b/test/SILOptimizer/stack_protection.sil
@@ -91,9 +91,9 @@ bb0:
 
 // CHECK-LABEL: sil [stack_protection] @inout_with_unknown_callers1
 // CHECK:         [[T:%[0-9]+]] = alloc_stack $Int64
-// CHECK:         copy_addr [take] %0 to [initialization] [[T]] : $*Int64
+// CHECK:         copy_addr [take] %0 to [init] [[T]] : $*Int64
 // CHECK:         address_to_pointer [stack_protection] [[T]]
-// CHECK:         copy_addr [take] [[T]] to [initialization] %0 : $*Int64
+// CHECK:         copy_addr [take] [[T]] to [init] %0 : $*Int64
 // CHECK:         dealloc_stack [[T]] : $*Int64
 // CHECK:       } // end sil function 'inout_with_unknown_callers1'
 sil @inout_with_unknown_callers1 : $@convention(thin) (@inout Int64) -> () {
@@ -117,9 +117,9 @@ bb0(%0 : $*Int64):
 // CHECK-LABEL: sil [stack_protection] @inout_with_modify_access
 // CHECK:         [[A:%[0-9]+]] = begin_access [modify] [dynamic] %0 : $*Int64
 // CHECK:         [[T:%[0-9]+]] = alloc_stack $Int64
-// CHECK:         copy_addr [take] [[A]] to [initialization] [[T]] : $*Int64
+// CHECK:         copy_addr [take] [[A]] to [init] [[T]] : $*Int64
 // CHECK:         address_to_pointer [stack_protection] [[T]]
-// CHECK:         copy_addr [take] [[T]] to [initialization] [[A]] : $*Int64
+// CHECK:         copy_addr [take] [[T]] to [init] [[A]] : $*Int64
 // CHECK:         dealloc_stack [[T]] : $*Int64
 // CHECK:       } // end sil function 'inout_with_modify_access'
 sil @inout_with_modify_access : $@convention(thin) (@inout Int64) -> () {
@@ -147,12 +147,12 @@ bb0(%0 : $*Int64):
 
 // CHECK-LABEL: sil [stack_protection] @inout_with_unknown_callers2
 // CHECK:         [[T:%[0-9]+]] = alloc_stack $S
-// CHECK:         copy_addr [take] %0 to [initialization] [[T]] : $*S
+// CHECK:         copy_addr [take] %0 to [init] [[T]] : $*S
 // CHECK:         [[A:%[0-9]+]] = struct_element_addr [[T]] : $*S, #S.a
 // CHECK:         address_to_pointer [stack_protection] [[A]]
 // CHECK:         [[B:%[0-9]+]] = struct_element_addr [[T]] : $*S, #S.b
 // CHECK:         address_to_pointer [stack_protection] [[B]]
-// CHECK:         copy_addr [take] [[T]] to [initialization] %0 : $*S
+// CHECK:         copy_addr [take] [[T]] to [init] %0 : $*S
 // CHECK:         dealloc_stack [[T]] : $*S
 // CHECK:       } // end sil function 'inout_with_unknown_callers2'
 sil @inout_with_unknown_callers2 : $@convention(thin) (@inout S) -> () {
@@ -169,9 +169,9 @@ bb0(%0 : $*S):
 // CHECK:         [[I:%[0-9]+]] = ref_element_addr %0 : $C, #C.i
 // CHECK:         [[A:%[0-9]+]] = begin_access [modify] [static] [[I]] : $*Int64
 // CHECK:         [[T:%[0-9]+]] = alloc_stack $Int64
-// CHECK:         copy_addr [take] [[A]] to [initialization] [[T]] : $*Int64
+// CHECK:         copy_addr [take] [[A]] to [init] [[T]] : $*Int64
 // CHECK:         address_to_pointer [stack_protection] [[T]]
-// CHECK:         copy_addr [take] [[T]] to [initialization] [[A]] : $*Int64
+// CHECK:         copy_addr [take] [[T]] to [init] [[A]] : $*Int64
 // CHECK:         dealloc_stack [[T]] : $*Int64
 // CHECK:         end_access [[A]] : $*Int64
 // CHECK:       } // end sil function 'object_with_unknown_callers1'
@@ -189,10 +189,10 @@ bb0(%0 : $C):
 // CHECK:         [[I:%[0-9]+]] = ref_element_addr %0 : $C, #C.i
 // CHECK:         [[A:%[0-9]+]] = begin_access [modify] [static] [[I]] : $*Int64
 // CHECK:         [[T:%[0-9]+]] = alloc_stack $Int64
-// CHECK:         copy_addr [take] [[A]] to [initialization] [[T]] : $*Int64
+// CHECK:         copy_addr [take] [[A]] to [init] [[T]] : $*Int64
 // CHECK:         address_to_pointer [stack_protection] [[T]]
 // CHECK:         address_to_pointer [stack_protection] [[T]]
-// CHECK:         copy_addr [take] [[T]] to [initialization] [[A]] : $*Int64
+// CHECK:         copy_addr [take] [[T]] to [init] [[A]] : $*Int64
 // CHECK:         dealloc_stack [[T]] : $*Int64
 // CHECK:         end_access [[A]] : $*Int64
 // CHECK:       } // end sil function 'object_with_unknown_callers2'
@@ -211,16 +211,16 @@ bb0(%0 : $C):
 // CHECK:         [[I:%[0-9]+]] = ref_element_addr %0 : $C, #C.i
 // CHECK:         [[AI:%[0-9]+]] = begin_access [modify] [static] [[I]] : $*Int64
 // CHECK:         [[TI:%[0-9]+]] = alloc_stack $Int64
-// CHECK:         copy_addr [take] [[AI]] to [initialization] [[TI]] : $*Int64
+// CHECK:         copy_addr [take] [[AI]] to [init] [[TI]] : $*Int64
 // CHECK:         address_to_pointer [stack_protection] [[TI]]
 // CHECK:         [[J:%[0-9]+]] = ref_element_addr %0 : $C, #C.j
 // CHECK:         [[AJ:%[0-9]+]] = begin_access [modify] [static] [[J]] : $*Int64
 // CHECK:         [[TJ:%[0-9]+]] = alloc_stack $Int64
-// CHECK:         copy_addr [take] [[AJ]] to [initialization] [[TJ]] : $*Int64
-// CHECK:         copy_addr [take] [[TI]] to [initialization] [[AI]] : $*Int64
+// CHECK:         copy_addr [take] [[AJ]] to [init] [[TJ]] : $*Int64
+// CHECK:         copy_addr [take] [[TI]] to [init] [[AI]] : $*Int64
 // CHECK:         end_access [[AI]] : $*Int64
 // CHECK:         address_to_pointer [stack_protection] [[TJ]]
-// CHECK:         copy_addr [take] [[TJ]] to [initialization] [[AJ]] : $*Int64
+// CHECK:         copy_addr [take] [[TJ]] to [init] [[AJ]] : $*Int64
 // CHECK:         dealloc_stack [[TJ]] : $*Int64
 // CHECK:         dealloc_stack [[TI]] : $*Int64
 // CHECK:         end_access [[AJ]] : $*Int64

--- a/test/SILOptimizer/stack_protection.swift
+++ b/test/SILOptimizer/stack_protection.swift
@@ -72,8 +72,8 @@ public func callOverflowInoutPointer() {
 }
 
 // CHECK-LABEL: sil [stack_protection] @$s4test22inoutWithUnknownCalleryySizF
-// CHECK:         copy_addr [take] {{.*}} to [initialization]
-// CHECK:         copy_addr [take] {{.*}} to [initialization]
+// CHECK:         copy_addr [take] {{.*}} to [init]
+// CHECK:         copy_addr [take] {{.*}} to [init]
 // CHECK:       } // end sil function '$s4test22inoutWithUnknownCalleryySizF'
 public func inoutWithUnknownCaller(_ x: inout Int) {
   withUnsafeMutablePointer(to: &x) {

--- a/test/SILOptimizer/temp_rvalue_opt.sil
+++ b/test/SILOptimizer/temp_rvalue_opt.sil
@@ -35,7 +35,7 @@ bb0(%0 : $*Klass):
 
 sil @inguaranteed_user_with_result : $@convention(thin) (@in_guaranteed Klass) -> @out Klass {
 bb0(%0 : $*Klass, %1 : $*Klass):
-  copy_addr %1 to [initialization] %0 : $*Klass
+  copy_addr %1 to [init] %0 : $*Klass
   %9999 = tuple()
   return %9999 : $()
 }
@@ -66,7 +66,7 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>):
   %2 = struct_element_addr %0 : $*GS<B>, #GS._value
   %3 = load %2 : $*Builtin.Int64
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   %7 = load %6 : $*Builtin.Int64
   %8 = builtin "cmp_slt_Int64"(%3 : $Builtin.Int64, %7 : $Builtin.Int64) : $Builtin.Int1
@@ -79,15 +79,15 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>):
 // CHECK-LABEL: sil @copy_from_temp
 // CHECK:      bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
 // CHECK-NEXT:   builtin
-// CHECK-NEXT:   copy_addr %1 to [initialization] %0 : $*GS<B>
+// CHECK-NEXT:   copy_addr %1 to [init] %0 : $*GS<B>
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
 sil @copy_from_temp : $@convention(thin) <B> (@inout GS<B>, @inout GS<B>, Builtin.Int64) -> () {
 bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %8 = builtin "cmp_slt_Int64"(%2 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int1
-  copy_addr %4 to [initialization] %0 : $*GS<B>
+  copy_addr %4 to [init] %0 : $*GS<B>
   destroy_addr %4 : $*GS<B>
   dealloc_stack %4 : $*GS<B>
   %9999 = tuple()
@@ -104,7 +104,7 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
 sil @copy_back_to_src : $@convention(thin) <B> (@in GS<B>, @inout GS<B>) -> () {
 bb0(%0 : $*GS<B>, %1 : $*GS<B>):
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   %7 = load %6 : $*Builtin.Int64
   %8 = builtin "cmp_slt_Int64"(%7 : $Builtin.Int64, %7 : $Builtin.Int64) : $Builtin.Int1
@@ -118,7 +118,7 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>):
 // CHECK-LABEL: sil @take_from_temp
 // CHECK:      bb0(%0 : $*B, %1 : $*GS<B>):
 // CHECK-NEXT:   [[STK:%.*]] = alloc_stack
-// CHECK-NEXT:   copy_addr %1 to [initialization] [[STK]]
+// CHECK-NEXT:   copy_addr %1 to [init] [[STK]]
 // CHECK-NEXT:   [[INNER:%.*]] = struct_element_addr
 // CHECK-NEXT:   copy_addr [take] [[INNER]]
 // CHECK-NEXT:   dealloc_stack
@@ -127,7 +127,7 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>):
 sil @take_from_temp : $@convention(thin) <B> (@inout B, @inout GS<B>) -> () {
 bb0(%0 : $*B, %1 : $*GS<B>):
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %7 = struct_element_addr %4 : $*GS<B>, #GS._base
   copy_addr [take] %7 to %0: $*B
   dealloc_stack %4 : $*GS<B>
@@ -146,7 +146,7 @@ bb0(%0 : $*B, %1 : $*GS<B>):
 sil [ossa] @take_from_source : $@convention(thin) (@in Str) -> @owned Str {
 bb0(%0 : $*Str):
   %1 = alloc_stack $Str
-  copy_addr %0 to [initialization] %1 : $*Str
+  copy_addr %0 to [init] %1 : $*Str
   %3 = load [take] %0 : $*Str
   %4 = load [copy] %1 : $*Str
   %f = function_ref @takeStr : $@convention(thin) (@owned Str) -> ()
@@ -165,7 +165,7 @@ bb0(%0 : $*Str):
 sil @load_in_wrong_block : $@convention(thin) <B> (@in GS<B>) -> () {
 bb0(%0 : $*GS<B>):
   %4 = alloc_stack $GS<B>
-  copy_addr %0 to [initialization] %4 : $*GS<B>
+  copy_addr %0 to [init] %4 : $*GS<B>
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   br bb1
 
@@ -187,7 +187,7 @@ bb1:
 sil @projection_in_wrong_block : $@convention(thin) <B> (@in GS<B>) -> () {
 bb0(%0 : $*GS<B>):
   %4 = alloc_stack $GS<B>
-  copy_addr %0 to [initialization] %4 : $*GS<B>
+  copy_addr %0 to [init] %4 : $*GS<B>
   br bb1
 
 bb1:
@@ -213,7 +213,7 @@ sil @store_after_load : $@convention(thin) <B> (@in GS<B>, @inout GS<B>, Builtin
 bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
   %3 = struct_element_addr %1 : $*GS<B>, #GS._value
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   %7 = load %6 : $*Builtin.Int64
   store %2 to %3 : $*Builtin.Int64
@@ -238,7 +238,7 @@ sil @store_after_two_loads : $@convention(thin) <B> (@in GS<B>, @inout GS<B>, Bu
 bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
   %3 = struct_element_addr %1 : $*GS<B>, #GS._value
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   %7 = load %6 : $*Builtin.Int64
   %8 = load %6 : $*Builtin.Int64
@@ -254,7 +254,7 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
 // CHECK:      bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
 // CHECK-NEXT:   struct_element_addr %1
 // CHECK-NEXT:   [[T:%.*]] = alloc_stack
-// CHECK-NEXT:   copy_addr %1 to [initialization] [[T]]
+// CHECK-NEXT:   copy_addr %1 to [init] [[T]]
 // CHECK-NEXT:   [[A:%.*]] = struct_element_addr [[T]]
 // CHECK-NEXT:   store
 // CHECK-NEXT:   load [[A]]
@@ -267,7 +267,7 @@ sil @store_before_load : $@convention(thin) <B> (@in GS<B>, @inout GS<B>, Builti
 bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
   %3 = struct_element_addr %1 : $*GS<B>, #GS._value
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   store %2 to %3 : $*Builtin.Int64
   %7 = load %6 : $*Builtin.Int64
@@ -282,7 +282,7 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
 // CHECK:      bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
 // CHECK-NEXT:   struct_element_addr %1
 // CHECK-NEXT:   [[T:%.*]] = alloc_stack
-// CHECK-NEXT:   copy_addr %1 to [initialization] [[T]]
+// CHECK-NEXT:   copy_addr %1 to [init] [[T]]
 // CHECK-NEXT:   [[A:%.*]] = struct_element_addr [[T]]
 // CHECK-NEXT:   load [[A]]
 // CHECK-NEXT:   store
@@ -296,7 +296,7 @@ sil @store_between_loads : $@convention(thin) <B> (@in GS<B>, @inout GS<B>, Buil
 bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
   %3 = struct_element_addr %1 : $*GS<B>, #GS._value
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   %7 = load %6 : $*Builtin.Int64
   store %2 to %3 : $*Builtin.Int64
@@ -312,7 +312,7 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
 // CHECK:      bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
 // CHECK-NEXT:   struct_element_addr %1
 // CHECK-NEXT:   [[T:%.*]] = alloc_stack
-// CHECK-NEXT:   copy_addr %1 to [initialization] [[T]]
+// CHECK-NEXT:   copy_addr %1 to [init] [[T]]
 // CHECK-NEXT:   [[A:%.*]] = struct_element_addr [[T]]
 // CHECK:        apply
 // CHECK-NEXT:   load [[A]]
@@ -325,7 +325,7 @@ sil @potential_store_before_load : $@convention(thin) <B> (@in GS<B>, @inout_ali
 bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
   %3 = struct_element_addr %1 : $*GS<B>, #GS._value
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   %f = function_ref @unknown : $@convention(thin) () -> ()
   %a = apply %f() : $@convention(thin) () -> ()
@@ -346,7 +346,7 @@ sil [ossa] @consider_implicit_aliases_in_callee : $@convention(thin) (@guarantee
 bb0(%0 : @guaranteed $Klass):
   %1 = ref_element_addr %0 : $Klass, #Klass.a
   %2 = alloc_stack $String
-  copy_addr %1 to [initialization] %2 : $*String
+  copy_addr %1 to [init] %2 : $*String
   %f = function_ref @load_string : $@convention(thin) (@in_guaranteed String) -> String
   %a = apply %f(%2) : $@convention(thin) (@in_guaranteed String) -> String
   destroy_addr %2 : $*String
@@ -370,7 +370,7 @@ bb0(%0 : $*Optional<Element>, %1 : $*UnfoldSequence<Element, State>):
 
 bb1:
   %6 = alloc_stack $UnfoldSequence<Element, State>
-  copy_addr %1 to [initialization] %6 : $*UnfoldSequence<Element, State>
+  copy_addr %1 to [init] %6 : $*UnfoldSequence<Element, State>
   %8 = struct_element_addr %6 : $*UnfoldSequence<Element, State>, #UnfoldSequence._next
   %9 = load %8 : $*@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2 where τ_0_1 == τ_0_2> (@inout τ_0_0) -> @out Optional<τ_0_1> for <State, Element, Element>
   %10 = alloc_stack $Optional<Element>
@@ -389,14 +389,14 @@ bb2:
   store %20 to %2 : $*Bool
   %22 = alloc_stack $Optional<Element>
   inject_enum_addr %22 : $*Optional<Element>, #Optional.none!enumelt
-  copy_addr [take] %22 to [initialization] %0 : $*Optional<Element>
+  copy_addr [take] %22 to [init] %0 : $*Optional<Element>
   dealloc_stack %22 : $*Optional<Element>
   br bb5
 
 bb3:
   %27 = unchecked_take_enum_data_addr %10 : $*Optional<Element>, #Optional.some!enumelt
   %28 = init_enum_data_addr %0 : $*Optional<Element>, #Optional.some!enumelt
-  copy_addr [take] %27 to [initialization] %28 : $*Element
+  copy_addr [take] %27 to [init] %28 : $*Element
   dealloc_stack %10 : $*Optional<Element>
   destroy_addr %6 : $*UnfoldSequence<Element, State>
   dealloc_stack %6 : $*UnfoldSequence<Element, State>
@@ -406,7 +406,7 @@ bb3:
 bb4:
   %35 = alloc_stack $Optional<Element>
   inject_enum_addr %35 : $*Optional<Element>, #Optional.none!enumelt
-  copy_addr [take] %35 to [initialization] %0 : $*Optional<Element>
+  copy_addr [take] %35 to [init] %0 : $*Optional<Element>
   dealloc_stack %35 : $*Optional<Element>
   br bb5
 
@@ -427,7 +427,7 @@ bb5:
 sil @inguaranteed_no_result : $@convention(thin) (@inout Klass) -> () {
 bb0(%0 : $*Klass):
   %1 = alloc_stack $Klass
-  copy_addr %0 to [initialization] %1 : $*Klass
+  copy_addr %0 to [init] %1 : $*Klass
   %5 = function_ref @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> ()
   %6 = apply %5(%1) : $@convention(thin) (@in_guaranteed Klass) -> ()
   destroy_addr %1 : $*Klass
@@ -443,7 +443,7 @@ bb0(%0 : $*Klass):
 sil @try_apply_argument : $@convention(thin) (@inout Klass) -> () {
 bb0(%0 : $*Klass):
   %1 = alloc_stack $Klass
-  copy_addr %0 to [initialization] %1 : $*Klass
+  copy_addr %0 to [init] %1 : $*Klass
   %5 = function_ref @throwing_function : $@convention(thin) (@in_guaranteed Klass) -> ((), @error Error)
   try_apply %5(%1) : $@convention(thin) (@in_guaranteed Klass) -> ((), @error Error), normal bb1, error bb2
 bb1(%r : $()):
@@ -466,7 +466,7 @@ bb3:
 sil @lifetime_beyond_last_use : $@convention(thin) (@in Klass) -> () {
 bb0(%0 : $*Klass):
   %2 = alloc_stack $Klass
-  copy_addr [take] %0 to [initialization] %2 : $*Klass
+  copy_addr [take] %0 to [init] %2 : $*Klass
   %4 = load %2 : $*Klass
   %5 = function_ref @guaranteed_user : $@convention(thin) (@guaranteed Klass) -> ()
   %6 = apply %5(%4) : $@convention(thin) (@guaranteed Klass) -> ()
@@ -493,7 +493,7 @@ sil @inguaranteed_with_result : $@convention(thin) (@inout Klass) -> () {
 bb0(%0 : $*Klass):
   %1 = alloc_stack $Klass
   %1a = alloc_stack $Klass
-  copy_addr %0 to [initialization] %1 : $*Klass
+  copy_addr %0 to [init] %1 : $*Klass
   %5 = function_ref @inguaranteed_user_with_result : $@convention(thin) (@in_guaranteed Klass) -> @out Klass
   %6 = apply %5(%1a, %1) : $@convention(thin) (@in_guaranteed Klass) -> @out Klass
   destroy_addr %1a : $*Klass
@@ -507,7 +507,7 @@ bb0(%0 : $*Klass):
 // CHECK-LABEL: sil @non_overlapping_lifetime : $@convention(thin) (@in Klass) -> () {
 // CHECK:      bb0([[ARG:%.*]] : $*Klass):
 // CHECK-NEXT:   [[TMP:%.*]] = alloc_stack $Klass
-// CHECK-NEXT:   copy_addr [[ARG]] to [initialization] [[TMP]]
+// CHECK-NEXT:   copy_addr [[ARG]] to [init] [[TMP]]
 // CHECK-NEXT:   destroy_addr [[ARG]]
 // CHECK:        apply %{{[0-9]*}}([[TMP]])
 // CHECK-NEXT:   destroy_addr [[TMP]]
@@ -521,10 +521,10 @@ bb0(%0 : $*Klass):
 
   %1 = alloc_stack $Klass
   %2 = alloc_stack $Klass
-  copy_addr %0 to [initialization] %2 : $*Klass
-  copy_addr [take] %2 to [initialization] %1 : $*Klass
+  copy_addr %0 to [init] %2 : $*Klass
+  copy_addr [take] %2 to [init] %1 : $*Klass
   dealloc_stack %2 : $*Klass
-  copy_addr %1 to [initialization] %1a : $*Klass
+  copy_addr %1 to [init] %1a : $*Klass
   destroy_addr %0 : $*Klass
   destroy_addr %1 : $*Klass
   dealloc_stack %1 : $*Klass
@@ -543,7 +543,7 @@ sil @$appendKlass : $@convention(method) (@in_guaranteed Klass, @inout Klass) ->
 // CHECK-LABEL: sil @$overlapping_lifetime_in_function_all : $@convention(thin) () -> @out Klass {
 // CHECK: [[S1:%.*]] = alloc_stack $Klass
 // CHECK: [[S2:%.*]] = alloc_stack $Klass
-// CHECK: copy_addr [[S1]] to [initialization] [[S2]]
+// CHECK: copy_addr [[S1]] to [init] [[S2]]
 // CHECK: apply {{%.*}}([[S2]], [[S1]])
 // CHECK: }
 sil @$overlapping_lifetime_in_function_all : $@convention(thin) () -> @out Klass {
@@ -552,12 +552,12 @@ bb0(%0 : $*Klass):
   %2 = function_ref @$createKlass : $@convention(thin) () -> @out Klass
   %3 = apply %2(%1) : $@convention(thin) () -> @out Klass
   %4 = alloc_stack $Klass
-  copy_addr %1 to [initialization] %4 : $*Klass
+  copy_addr %1 to [init] %4 : $*Klass
   %6 = function_ref @$appendKlass : $@convention(method) (@in_guaranteed Klass, @inout Klass) -> ()
   %7 = apply %6(%4, %1) : $@convention(method) (@in_guaranteed Klass, @inout Klass) -> ()
   destroy_addr %4 : $*Klass
   dealloc_stack %4 : $*Klass
-  copy_addr [take] %1 to [initialization] %0 : $*Klass
+  copy_addr [take] %1 to [init] %0 : $*Klass
   dealloc_stack %1 : $*Klass
   %12 = tuple ()
   return %12 : $()
@@ -584,7 +584,7 @@ bb0:
 bb1:
   %9 = unchecked_take_enum_data_addr %2 : $*Optional<P>, #Optional.some!enumelt
   %10 = alloc_stack $P
-  copy_addr %9 to [initialization] %10 : $*P
+  copy_addr %9 to [init] %10 : $*P
   %13 = open_existential_addr immutable_access %10 : $*P to $*@opened("5E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self
   %14 = witness_method $@opened("5E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self, #P.foo : <Self where Self : P> (Self) -> () -> (), %13 : $*@opened("5E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
   %15 = apply %14<@opened("5E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self>(%13) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
@@ -605,7 +605,7 @@ bb3:
 }
 // CHECK-LABEL: sil @open_existential_addr_blocks_optimization : $@convention(thin) () -> () {
 // CHECK: [[P:%.*]] = alloc_stack $any P
-// CHECK: copy_addr {{.*}} to [initialization] [[P]]
+// CHECK: copy_addr {{.*}} to [init] [[P]]
 // CHECK: }
 sil @open_existential_addr_blocks_optimization : $@convention(thin) () -> () {
 bb0:
@@ -617,7 +617,7 @@ bb0:
 bb1:
   %9 = unchecked_take_enum_data_addr %2 : $*Optional<P>, #Optional.some!enumelt
   %10 = alloc_stack $P
-  copy_addr %9 to [initialization] %10 : $*P
+  copy_addr %9 to [init] %10 : $*P
   destroy_addr %2 : $*Optional<P>
   %13 = open_existential_addr immutable_access %10 : $*P to $*@opened("6E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self
   %14 = witness_method $@opened("6E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self, #P.foo : <Self where Self : P> (Self) -> () -> (), %13 : $*@opened("6E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
@@ -639,7 +639,7 @@ bb3:
 
 // CHECK-LABEL: sil @witness_method_blocks_optimization : $@convention(thin) () -> () {
 // CHECK: [[P:%.*]] = alloc_stack $any P
-// CHECK: copy_addr {{.*}} to [initialization] [[P]]
+// CHECK: copy_addr {{.*}} to [init] [[P]]
 // CHECK: }
 sil @witness_method_blocks_optimization : $@convention(thin) () -> () {
 bb0:
@@ -651,7 +651,7 @@ bb0:
 bb1:
   %9 = unchecked_take_enum_data_addr %2 : $*Optional<P>, #Optional.some!enumelt
   %10 = alloc_stack $P
-  copy_addr %9 to [initialization] %10 : $*P
+  copy_addr %9 to [init] %10 : $*P
   %13 = open_existential_addr immutable_access %10 : $*P to $*@opened("7E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self
   destroy_addr %2 : $*Optional<P>
   %14 = witness_method $@opened("7E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self, #P.foo : <Self where Self : P> (Self) -> () -> (), %13 : $*@opened("7E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
@@ -684,7 +684,7 @@ sil @takeGuaranteedObj : $@convention(thin) (@guaranteed Builtin.NativeObject) -
 // CHECK-LABEL: sil @copyWithLoadRelease : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> () {
 // CHECK: bb0(%0 : $*Builtin.NativeObject):
 // CHECK:   [[STK:%.*]] = alloc_stack $Builtin.NativeObject
-// CHECK:   copy_addr %0 to [initialization] [[STK]] : $*Builtin.NativeObject
+// CHECK:   copy_addr %0 to [init] [[STK]] : $*Builtin.NativeObject
 // CHECK:   [[VAL:%.*]] = load [[STK]] : $*Builtin.NativeObject
 // CHECK:   apply %{{.*}}([[VAL]]) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 // CHECK:   release_value [[VAL]] : $Builtin.NativeObject
@@ -693,7 +693,7 @@ sil @takeGuaranteedObj : $@convention(thin) (@guaranteed Builtin.NativeObject) -
 sil @copyWithLoadRelease : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : $*Builtin.NativeObject):
   %stk = alloc_stack $Builtin.NativeObject
-  copy_addr %0 to [initialization] %stk : $*Builtin.NativeObject
+  copy_addr %0 to [init] %stk : $*Builtin.NativeObject
   %obj = load %stk : $*Builtin.NativeObject
   %f = function_ref @takeGuaranteedObj : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   %call = apply %f(%obj) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
@@ -706,7 +706,7 @@ bb0(%0 : $*Builtin.NativeObject):
 // CHECK-LABEL: sil @takeWithLoadRelease : $@convention(thin) (@in Builtin.NativeObject) -> () {
 // CHECK: bb0(%0 : $*Builtin.NativeObject):
 // CHECK:   [[STK:%.*]] = alloc_stack $Builtin.NativeObject
-// CHECK:   copy_addr [take] %0 to [initialization] [[STK]] : $*Builtin.NativeObject
+// CHECK:   copy_addr [take] %0 to [init] [[STK]] : $*Builtin.NativeObject
 // CHECK:   [[VAL:%.*]] = load [[STK]] : $*Builtin.NativeObject
 // CHECK:   apply %{{.*}}([[VAL]]) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 // CHECK:   release_value [[VAL]] : $Builtin.NativeObject
@@ -714,7 +714,7 @@ bb0(%0 : $*Builtin.NativeObject):
 sil @takeWithLoadRelease : $@convention(thin) (@in Builtin.NativeObject) -> () {
 bb0(%0 : $*Builtin.NativeObject):
   %stk = alloc_stack $Builtin.NativeObject
-  copy_addr [take] %0 to [initialization] %stk : $*Builtin.NativeObject
+  copy_addr [take] %0 to [init] %stk : $*Builtin.NativeObject
   %obj = load %stk : $*Builtin.NativeObject
   %f = function_ref @takeGuaranteedObj : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   %call = apply %f(%obj) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
@@ -732,7 +732,7 @@ bb0(%0 : $*Builtin.NativeObject):
 sil @eliminate_fix_lifetime_on_dest_copyaddr : $@convention(thin) (@inout Klass) -> () {
 bb0(%0 : $*Klass):
   %3 = alloc_stack $Klass
-  copy_addr %0 to [initialization] %3 : $*Klass
+  copy_addr %0 to [init] %3 : $*Klass
   fix_lifetime %3 : $*Klass
   destroy_addr %3 : $*Klass
   dealloc_stack %3 : $*Klass
@@ -750,7 +750,7 @@ sil @test_aliasing_modify_access : $@convention(thin) (@guaranteed Klass, @guara
 bb0(%0 : $Klass, %1 : $Klass):
   %2 = ref_element_addr [immutable] %0 : $Klass, #Klass.a
   %3 = alloc_stack $String
-  copy_addr %2 to [initialization] %3 : $*String
+  copy_addr %2 to [init] %3 : $*String
   %4 = ref_element_addr %1 : $Klass, #Klass.a
   %5 = begin_access [modify] [dynamic] [no_nested_conflict] %4 : $*String
   end_access %5 : $*String

--- a/test/SILOptimizer/temp_rvalue_opt_ossa.sil
+++ b/test/SILOptimizer/temp_rvalue_opt_ossa.sil
@@ -50,7 +50,7 @@ bb0(%0 : $*Klass):
 
 sil [ossa] @inguaranteed_user_with_result : $@convention(thin) (@in_guaranteed Klass) -> @out Klass {
 bb0(%0 : $*Klass, %1 : $*Klass):
-  copy_addr %1 to [initialization] %0 : $*Klass
+  copy_addr %1 to [init] %0 : $*Klass
   %9999 = tuple()
   return %9999 : $()
 }
@@ -83,7 +83,7 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>):
   %2 = struct_element_addr %0 : $*GS<B>, #GS._value
   %3 = load [trivial] %2 : $*Builtin.Int64
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   %7 = load [trivial] %6 : $*Builtin.Int64
   %8 = builtin "cmp_slt_Int64"(%3 : $Builtin.Int64, %7 : $Builtin.Int64) : $Builtin.Int1
@@ -96,15 +96,15 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>):
 // CHECK-LABEL: sil [ossa] @copy_from_temp
 // CHECK:      bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
 // CHECK-NEXT:   builtin
-// CHECK-NEXT:   copy_addr %1 to [initialization] %0 : $*GS<B>
+// CHECK-NEXT:   copy_addr %1 to [init] %0 : $*GS<B>
 // CHECK-NEXT:   tuple
 // CHECK-NEXT:   return
 sil [ossa] @copy_from_temp : $@convention(thin) <B> (@inout GS<B>, Builtin.Int64) -> @out GS<B> {
 bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %8 = builtin "cmp_slt_Int64"(%2 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int1
-  copy_addr %4 to [initialization] %0 : $*GS<B>
+  copy_addr %4 to [init] %0 : $*GS<B>
   destroy_addr %4 : $*GS<B>
   dealloc_stack %4 : $*GS<B>
   %9999 = tuple()
@@ -121,7 +121,7 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
 sil [ossa] @copy_back_to_src : $@convention(thin) <B> (@in_guaranteed GS<B>, @inout GS<B>) -> () {
 bb0(%0 : $*GS<B>, %1 : $*GS<B>):
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   %7 = load [trivial] %6 : $*Builtin.Int64
   %8 = builtin "cmp_slt_Int64"(%7 : $Builtin.Int64, %7 : $Builtin.Int64) : $Builtin.Int1
@@ -135,7 +135,7 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>):
 // CHECK-LABEL: sil [ossa] @take_from_temp
 // CHECK:      bb0(%0 : $*B, %1 : $*GS<B>):
 // CHECK-NEXT:   [[STK:%.*]] = alloc_stack
-// CHECK-NEXT:   copy_addr %1 to [initialization] [[STK]]
+// CHECK-NEXT:   copy_addr %1 to [init] [[STK]]
 // CHECK-NEXT:   [[INNER:%.*]] = struct_element_addr
 // CHECK-NEXT:   copy_addr [take] [[INNER]]
 // CHECK-NEXT:   dealloc_stack
@@ -144,7 +144,7 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>):
 sil [ossa] @take_from_temp : $@convention(thin) <B> (@inout B, @inout GS<B>) -> () {
 bb0(%0 : $*B, %1 : $*GS<B>):
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %7 = struct_element_addr %4 : $*GS<B>, #GS._base
   copy_addr [take] %7 to %0: $*B
   dealloc_stack %4 : $*GS<B>
@@ -154,7 +154,7 @@ bb0(%0 : $*B, %1 : $*GS<B>):
 
 // CHECK-LABEL: sil [ossa] @store_before_load_take
 // CHECK:   [[STK:%[0-9]+]] = alloc_stack
-// CHECK:   copy_addr [take] %0 to [initialization] [[STK]]
+// CHECK:   copy_addr [take] %0 to [init] [[STK]]
 // CHECK:   store
 // CHECK:   load [take] [[STK]]
 // CHECK:   return
@@ -162,7 +162,7 @@ bb0(%0 : $*B, %1 : $*GS<B>):
 sil [ossa] @store_before_load_take : $@convention(thin) (@inout Builtin.NativeObject, @owned Builtin.NativeObject) -> @owned Builtin.NativeObject {
 bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
   %stk = alloc_stack $Builtin.NativeObject
-  copy_addr [take] %0 to [initialization] %stk : $*Builtin.NativeObject
+  copy_addr [take] %0 to [init] %stk : $*Builtin.NativeObject
   store %1 to [init] %0 : $*Builtin.NativeObject
   %obj = load [take] %stk : $*Builtin.NativeObject
   dealloc_stack %stk : $*Builtin.NativeObject
@@ -172,15 +172,15 @@ bb0(%0 : $*Builtin.NativeObject, %1 : @owned $Builtin.NativeObject):
 // CHECK-LABEL: sil [ossa] @copy_with_take_and_copy_from_src
 // CHECK:       bb0({{.*}}):
 // CHECK-NEXT:    destroy_addr %0
-// CHECK-NEXT:    copy_addr [take] %1 to [initialization] %0
+// CHECK-NEXT:    copy_addr [take] %1 to [init] %0
 // CHECK-NEXT:    tuple
 // CHECK-NEXT:    return
 // CHECK:       } // end sil function 'copy_with_take_and_copy_from_src'
 sil [ossa] @copy_with_take_and_copy_from_src : $@convention(thin) (@inout Builtin.NativeObject, @in Builtin.NativeObject) -> () {
 bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.NativeObject):
   %stk = alloc_stack $Builtin.NativeObject
-  copy_addr [take] %0 to [initialization] %stk : $*Builtin.NativeObject
-  copy_addr [take] %1 to [initialization] %0 : $*Builtin.NativeObject
+  copy_addr [take] %0 to [init] %stk : $*Builtin.NativeObject
+  copy_addr [take] %1 to [init] %0 : $*Builtin.NativeObject
   destroy_addr %stk : $*Builtin.NativeObject
   dealloc_stack %stk : $*Builtin.NativeObject
   %v = tuple ()
@@ -200,7 +200,7 @@ bb0(%0 : $*Builtin.NativeObject, %1 : $*Builtin.NativeObject):
 sil [ossa] @copy_take_and_try_apply : $@convention(thin) (@inout Klass, @owned Klass) -> () {
 bb0(%0 : $*Klass, %1 : @owned $Klass):
   %2 = alloc_stack $Klass
-  copy_addr [take] %0 to [initialization] %2 : $*Klass
+  copy_addr [take] %0 to [init] %2 : $*Klass
   %5 = function_ref @throwing_function : $@convention(thin) (@in_guaranteed Klass) -> ((), @error Error)
   try_apply %5(%2) : $@convention(thin) (@in_guaranteed Klass) -> ((), @error Error), normal bb1, error bb2
 bb1(%r : $()):
@@ -220,14 +220,14 @@ bb3:
 //
 // CHECK-LABEL: sil [ossa] @copy_and_copy_back
 // CHECK:   [[STK:%[0-9]+]] = alloc_stack
-// CHECK:   copy_addr [take] %0 to [initialization] [[STK]]
-// CHECK:   copy_addr [take] [[STK]] to [initialization] %0
+// CHECK:   copy_addr [take] %0 to [init] [[STK]]
+// CHECK:   copy_addr [take] [[STK]] to [init] %0
 // CHECK: } // end sil function 'copy_and_copy_back'
 sil [ossa] @copy_and_copy_back : $@convention(thin) (@inout Builtin.NativeObject) -> () {
 bb0(%0 : $*Builtin.NativeObject):
   %stk = alloc_stack $Builtin.NativeObject
-  copy_addr [take] %0 to [initialization] %stk : $*Builtin.NativeObject
-  copy_addr [take] %stk to [initialization] %0 : $*Builtin.NativeObject
+  copy_addr [take] %0 to [init] %stk : $*Builtin.NativeObject
+  copy_addr [take] %stk to [init] %0 : $*Builtin.NativeObject
   dealloc_stack %stk : $*Builtin.NativeObject
   %v = tuple ()
   return %v : $()
@@ -235,18 +235,18 @@ bb0(%0 : $*Builtin.NativeObject):
 
 // CHECK-LABEL: sil [ossa] @dont_allow_copy_take_from_projection
 // CHECK:   [[STK:%[0-9]+]] = alloc_stack
-// CHECK:   copy_addr [take] %1 to [initialization] [[STK]]
+// CHECK:   copy_addr [take] %1 to [init] [[STK]]
 // CHECK: } // end sil function 'dont_allow_copy_take_from_projection'
 sil [ossa] @dont_allow_copy_take_from_projection : $@convention(thin) (@in Two) -> @out Two {
 bb0(%0 : $*Two, %1 : $*Two):
   %a0 = struct_element_addr %0 : $*Two, #Two.a
   %b0 = struct_element_addr %0 : $*Two, #Two.b
   %s = alloc_stack $Two
-  copy_addr [take] %1 to [initialization] %s : $*Two
+  copy_addr [take] %1 to [init] %s : $*Two
   %as = struct_element_addr %s : $*Two, #Two.a
   %bs = struct_element_addr %s : $*Two, #Two.b
-  copy_addr [take] %as to [initialization] %a0 : $*Klass
-  copy_addr [take] %bs to [initialization] %b0 : $*Klass
+  copy_addr [take] %as to [init] %a0 : $*Klass
+  copy_addr [take] %bs to [init] %b0 : $*Klass
   dealloc_stack %s : $*Two
   %r = tuple ()
   return %r : $()
@@ -262,7 +262,7 @@ bb0(%0 : $*Two, %1 : $*Two):
 sil [ossa] @load_in_wrong_block : $@convention(thin) <B> (@in_guaranteed GS<B>) -> () {
 bb0(%0 : $*GS<B>):
   %4 = alloc_stack $GS<B>
-  copy_addr %0 to [initialization] %4 : $*GS<B>
+  copy_addr %0 to [init] %4 : $*GS<B>
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   br bb1
 
@@ -284,7 +284,7 @@ bb1:
 sil [ossa] @projection_in_wrong_block : $@convention(thin) <B> (@in_guaranteed GS<B>) -> () {
 bb0(%0 : $*GS<B>):
   %4 = alloc_stack $GS<B>
-  copy_addr %0 to [initialization] %4 : $*GS<B>
+  copy_addr %0 to [init] %4 : $*GS<B>
   br bb1
 
 bb1:
@@ -310,7 +310,7 @@ sil [ossa] @store_after_load : $@convention(thin) <B> (@in_guaranteed GS<B>, @in
 bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
   %3 = struct_element_addr %1 : $*GS<B>, #GS._value
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   %7 = load [trivial] %6 : $*Builtin.Int64
   store %2 to [trivial] %3 : $*Builtin.Int64
@@ -335,7 +335,7 @@ sil [ossa] @store_after_two_loads : $@convention(thin) <B> (@in_guaranteed GS<B>
 bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
   %3 = struct_element_addr %1 : $*GS<B>, #GS._value
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   %7 = load [trivial] %6 : $*Builtin.Int64
   %8 = load [trivial] %6 : $*Builtin.Int64
@@ -351,7 +351,7 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
 // CHECK:      bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
 // CHECK-NEXT:   struct_element_addr %1
 // CHECK-NEXT:   [[T:%.*]] = alloc_stack
-// CHECK-NEXT:   copy_addr %1 to [initialization] [[T]]
+// CHECK-NEXT:   copy_addr %1 to [init] [[T]]
 // CHECK-NEXT:   [[A:%.*]] = struct_element_addr [[T]]
 // CHECK-NEXT:   store
 // CHECK-NEXT:   load [trivial] [[A]]
@@ -364,7 +364,7 @@ sil [ossa] @store_before_load : $@convention(thin) <B> (@in_guaranteed GS<B>, @i
 bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
   %3 = struct_element_addr %1 : $*GS<B>, #GS._value
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   store %2 to [trivial] %3 : $*Builtin.Int64
   %7 = load [trivial] %6 : $*Builtin.Int64
@@ -379,7 +379,7 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
 // CHECK:      bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
 // CHECK-NEXT:   struct_element_addr %1
 // CHECK-NEXT:   [[T:%.*]] = alloc_stack
-// CHECK-NEXT:   copy_addr %1 to [initialization] [[T]]
+// CHECK-NEXT:   copy_addr %1 to [init] [[T]]
 // CHECK-NEXT:   [[A:%.*]] = struct_element_addr [[T]]
 // CHECK-NEXT:   load [trivial] [[A]]
 // CHECK-NEXT:   store
@@ -393,7 +393,7 @@ sil [ossa] @store_between_loads : $@convention(thin) <B> (@in_guaranteed GS<B>, 
 bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
   %3 = struct_element_addr %1 : $*GS<B>, #GS._value
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   %7 = load [trivial] %6 : $*Builtin.Int64
   store %2 to [trivial] %3 : $*Builtin.Int64
@@ -409,7 +409,7 @@ bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
 // CHECK:      bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
 // CHECK-NEXT:   struct_element_addr %1
 // CHECK-NEXT:   [[T:%.*]] = alloc_stack
-// CHECK-NEXT:   copy_addr %1 to [initialization] [[T]]
+// CHECK-NEXT:   copy_addr %1 to [init] [[T]]
 // CHECK-NEXT:   [[A:%.*]] = struct_element_addr [[T]]
 // CHECK:        apply
 // CHECK-NEXT:   load [trivial] [[A]]
@@ -422,7 +422,7 @@ sil [ossa] @potential_store_before_load : $@convention(thin) <B> (@in_guaranteed
 bb0(%0 : $*GS<B>, %1 : $*GS<B>, %2 : $Builtin.Int64):
   %3 = struct_element_addr %1 : $*GS<B>, #GS._value
   %4 = alloc_stack $GS<B>
-  copy_addr %1 to [initialization] %4 : $*GS<B>
+  copy_addr %1 to [init] %4 : $*GS<B>
   %6 = struct_element_addr %4 : $*GS<B>, #GS._value
   %f = function_ref @unknown : $@convention(thin) () -> ()
   %a = apply %f() : $@convention(thin) () -> ()
@@ -450,7 +450,7 @@ bb0(%0 : $*Optional<Element>, %1 : $*UnfoldSequence<Element, State>):
 
 bb1:
   %6 = alloc_stack $UnfoldSequence<Element, State>
-  copy_addr %1 to [initialization] %6 : $*UnfoldSequence<Element, State>
+  copy_addr %1 to [init] %6 : $*UnfoldSequence<Element, State>
   %8 = struct_element_addr %6 : $*UnfoldSequence<Element, State>, #UnfoldSequence._next
   %9 = load [copy] %8 : $*@callee_guaranteed @substituted <τ_0_0, τ_0_1, τ_0_2 where τ_0_1 == τ_0_2> (@inout τ_0_0) -> @out Optional<τ_0_1> for <State, Element, Element>
   %10 = alloc_stack $Optional<Element>
@@ -469,14 +469,14 @@ bb2:
   store %20 to [trivial] %2 : $*Bool
   %22 = alloc_stack $Optional<Element>
   inject_enum_addr %22 : $*Optional<Element>, #Optional.none!enumelt
-  copy_addr [take] %22 to [initialization] %0 : $*Optional<Element>
+  copy_addr [take] %22 to [init] %0 : $*Optional<Element>
   dealloc_stack %22 : $*Optional<Element>
   br bb5
 
 bb3:
   %27 = unchecked_take_enum_data_addr %10 : $*Optional<Element>, #Optional.some!enumelt
   %28 = init_enum_data_addr %0 : $*Optional<Element>, #Optional.some!enumelt
-  copy_addr [take] %27 to [initialization] %28 : $*Element
+  copy_addr [take] %27 to [init] %28 : $*Element
   dealloc_stack %10 : $*Optional<Element>
   destroy_addr %6 : $*UnfoldSequence<Element, State>
   dealloc_stack %6 : $*UnfoldSequence<Element, State>
@@ -486,7 +486,7 @@ bb3:
 bb4:
   %35 = alloc_stack $Optional<Element>
   inject_enum_addr %35 : $*Optional<Element>, #Optional.none!enumelt
-  copy_addr [take] %35 to [initialization] %0 : $*Optional<Element>
+  copy_addr [take] %35 to [init] %0 : $*Optional<Element>
   dealloc_stack %35 : $*Optional<Element>
   br bb5
 
@@ -507,7 +507,7 @@ bb5:
 sil [ossa] @inguaranteed_no_result : $@convention(thin) (@inout Klass) -> () {
 bb0(%0 : $*Klass):
   %1 = alloc_stack $Klass
-  copy_addr %0 to [initialization] %1 : $*Klass
+  copy_addr %0 to [init] %1 : $*Klass
   %5 = function_ref @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> ()
   %6 = apply %5(%1) : $@convention(thin) (@in_guaranteed Klass) -> ()
   destroy_addr %1 : $*Klass
@@ -523,7 +523,7 @@ bb0(%0 : $*Klass):
 sil [ossa] @try_apply_argument : $@convention(thin) (@inout Klass) -> () {
 bb0(%0 : $*Klass):
   %1 = alloc_stack $Klass
-  copy_addr %0 to [initialization] %1 : $*Klass
+  copy_addr %0 to [init] %1 : $*Klass
   %5 = function_ref @throwing_function : $@convention(thin) (@in_guaranteed Klass) -> ((), @error Error)
   try_apply %5(%1) : $@convention(thin) (@in_guaranteed Klass) -> ((), @error Error), normal bb1, error bb2
 bb1(%r : $()):
@@ -554,7 +554,7 @@ sil [ossa] @inguaranteed_with_result : $@convention(thin) (@inout Klass) -> () {
 bb0(%0 : $*Klass):
   %1 = alloc_stack $Klass
   %1a = alloc_stack $Klass
-  copy_addr %0 to [initialization] %1 : $*Klass
+  copy_addr %0 to [init] %1 : $*Klass
   %5 = function_ref @inguaranteed_user_with_result : $@convention(thin) (@in_guaranteed Klass) -> @out Klass
   %6 = apply %5(%1a, %1) : $@convention(thin) (@in_guaranteed Klass) -> @out Klass
   destroy_addr %1a : $*Klass
@@ -568,7 +568,7 @@ bb0(%0 : $*Klass):
 // CHECK-LABEL: sil [ossa] @non_overlapping_lifetime : $@convention(thin) (@in Klass) -> () {
 // CHECK:      bb0([[ARG:%.*]] : $*Klass):
 // CHECK-NEXT:   [[TMP:%.*]] = alloc_stack $Klass
-// CHECK-NEXT:   copy_addr [[ARG]] to [initialization] [[TMP]]
+// CHECK-NEXT:   copy_addr [[ARG]] to [init] [[TMP]]
 // CHECK-NEXT:   destroy_addr [[ARG]]
 // CHECK:        apply %{{[0-9]*}}([[TMP]])
 // CHECK-NEXT:   destroy_addr [[TMP]]
@@ -582,10 +582,10 @@ bb0(%0 : $*Klass):
 
   %1 = alloc_stack $Klass
   %2 = alloc_stack $Klass
-  copy_addr %0 to [initialization] %2 : $*Klass
-  copy_addr [take] %2 to [initialization] %1 : $*Klass
+  copy_addr %0 to [init] %2 : $*Klass
+  copy_addr [take] %2 to [init] %1 : $*Klass
   dealloc_stack %2 : $*Klass
-  copy_addr %1 to [initialization] %1a : $*Klass
+  copy_addr %1 to [init] %1a : $*Klass
   destroy_addr %0 : $*Klass
   destroy_addr %1 : $*Klass
   dealloc_stack %1 : $*Klass
@@ -604,7 +604,7 @@ sil [ossa] @$appendKlass : $@convention(method) (@in_guaranteed Klass, @inout Kl
 // CHECK-LABEL: sil [ossa] @$overlapping_lifetime_in_function_all : $@convention(thin) () -> @out Klass {
 // CHECK: [[S1:%.*]] = alloc_stack $Klass
 // CHECK: [[S2:%.*]] = alloc_stack $Klass
-// CHECK: copy_addr [[S1]] to [initialization] [[S2]]
+// CHECK: copy_addr [[S1]] to [init] [[S2]]
 // CHECK: apply {{%.*}}([[S2]], [[S1]])
 // CHECK: }
 sil [ossa] @$overlapping_lifetime_in_function_all : $@convention(thin) () -> @out Klass {
@@ -613,12 +613,12 @@ bb0(%0 : $*Klass):
   %2 = function_ref @$createKlass : $@convention(thin) () -> @out Klass
   %3 = apply %2(%1) : $@convention(thin) () -> @out Klass
   %4 = alloc_stack $Klass
-  copy_addr %1 to [initialization] %4 : $*Klass
+  copy_addr %1 to [init] %4 : $*Klass
   %6 = function_ref @$appendKlass : $@convention(method) (@in_guaranteed Klass, @inout Klass) -> ()
   %7 = apply %6(%4, %1) : $@convention(method) (@in_guaranteed Klass, @inout Klass) -> ()
   destroy_addr %4 : $*Klass
   dealloc_stack %4 : $*Klass
-  copy_addr [take] %1 to [initialization] %0 : $*Klass
+  copy_addr [take] %1 to [init] %0 : $*Klass
   dealloc_stack %1 : $*Klass
   %12 = tuple ()
   return %12 : $()
@@ -645,7 +645,7 @@ bb0:
 bb1:
   %9 = unchecked_take_enum_data_addr %2 : $*Optional<P>, #Optional.some!enumelt
   %10 = alloc_stack $P
-  copy_addr %9 to [initialization] %10 : $*P
+  copy_addr %9 to [init] %10 : $*P
   %13 = open_existential_addr immutable_access %10 : $*P to $*@opened("5E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self
   %14 = witness_method $@opened("5E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self, #P.foo : <Self where Self : P> (Self) -> () -> (), %13 : $*@opened("5E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
   %15 = apply %14<@opened("5E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self>(%13) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
@@ -666,7 +666,7 @@ bb3:
 }
 // CHECK-LABEL: sil [ossa] @open_existential_addr_blocks_optimization : $@convention(thin) () -> () {
 // CHECK: [[P:%.*]] = alloc_stack $any P
-// CHECK: copy_addr {{.*}} to [initialization] [[P]]
+// CHECK: copy_addr {{.*}} to [init] [[P]]
 // CHECK: }
 sil [ossa] @open_existential_addr_blocks_optimization : $@convention(thin) () -> () {
 bb0:
@@ -678,7 +678,7 @@ bb0:
 bb1:
   %9 = unchecked_take_enum_data_addr %2 : $*Optional<P>, #Optional.some!enumelt
   %10 = alloc_stack $P
-  copy_addr %9 to [initialization] %10 : $*P
+  copy_addr %9 to [init] %10 : $*P
   destroy_addr %2 : $*Optional<P>
   %13 = open_existential_addr immutable_access %10 : $*P to $*@opened("6E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self
   %14 = witness_method $@opened("6E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self, #P.foo : <Self where Self : P> (Self) -> () -> (), %13 : $*@opened("6E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
@@ -700,7 +700,7 @@ bb3:
 
 // CHECK-LABEL: sil [ossa] @witness_method_blocks_optimization : $@convention(thin) () -> () {
 // CHECK: [[P:%.*]] = alloc_stack $any P
-// CHECK: copy_addr {{.*}} to [initialization] [[P]]
+// CHECK: copy_addr {{.*}} to [init] [[P]]
 // CHECK: }
 sil [ossa] @witness_method_blocks_optimization : $@convention(thin) () -> () {
 bb0:
@@ -712,7 +712,7 @@ bb0:
 bb1:
   %9 = unchecked_take_enum_data_addr %2 : $*Optional<P>, #Optional.some!enumelt
   %10 = alloc_stack $P
-  copy_addr %9 to [initialization] %10 : $*P
+  copy_addr %9 to [init] %10 : $*P
   %13 = open_existential_addr immutable_access %10 : $*P to $*@opened("7E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self
   destroy_addr %2 : $*Optional<P>
   %14 = witness_method $@opened("7E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self, #P.foo : <Self where Self : P> (Self) -> () -> (), %13 : $*@opened("7E7A6328-EF75-11E9-A383-D0817AD3F637", P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
@@ -747,7 +747,7 @@ sil [ossa] @takeGuaranteedObj : $@convention(thin) (@guaranteed Builtin.NativeOb
 sil [ossa] @copyWithLoadRelease : $@convention(thin) (@in_guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : $*Builtin.NativeObject):
   %stk = alloc_stack $Builtin.NativeObject
-  copy_addr %0 to [initialization] %stk : $*Builtin.NativeObject
+  copy_addr %0 to [init] %stk : $*Builtin.NativeObject
   %obj = load [take] %stk : $*Builtin.NativeObject
   %f = function_ref @takeGuaranteedObj : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   %call = apply %f(%obj) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
@@ -770,7 +770,7 @@ bb0(%0 : $*Builtin.NativeObject):
 sil [ossa] @takeWithLoadRelease : $@convention(thin) (@in Builtin.NativeObject) -> () {
 bb0(%0 : $*Builtin.NativeObject):
   %stk = alloc_stack $Builtin.NativeObject
-  copy_addr [take] %0 to [initialization] %stk : $*Builtin.NativeObject
+  copy_addr [take] %0 to [init] %stk : $*Builtin.NativeObject
   %obj = load [take] %stk : $*Builtin.NativeObject
   %f = function_ref @takeGuaranteedObj : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
   %call = apply %f(%obj) : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
@@ -789,7 +789,7 @@ bb0(%0 : $*Builtin.NativeObject):
 sil [ossa] @takeWithLoadReleaseOfProjection : $@convention(thin) (@in GS<Builtin.NativeObject>) -> () {
 bb0(%0 : $*GS<Builtin.NativeObject>):
   %stk = alloc_stack $GS<Builtin.NativeObject>
-  copy_addr [take] %0 to [initialization] %stk : $*GS<Builtin.NativeObject>
+  copy_addr [take] %0 to [init] %stk : $*GS<Builtin.NativeObject>
   %proj = struct_element_addr %stk : $*GS<Builtin.NativeObject>, #GS._base
   %obj = load [take] %proj : $*Builtin.NativeObject
   %f = function_ref @takeGuaranteedObj : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
@@ -820,7 +820,7 @@ bb0(%0 : @owned $GS<Builtin.NativeObject>):
 
 // CHECK-LABEL: sil [ossa] @dont_optimize_with_load_in_different_block
 // CHECK:   [[STK:%[0-9]+]] = alloc_stack
-// CHECK:   copy_addr %0 to [initialization] [[STK]]
+// CHECK:   copy_addr %0 to [init] [[STK]]
 // CHECK: bb1:
 // CHECK:   load [take] [[STK]]
 // CHECK: bb2:
@@ -831,7 +831,7 @@ sil [ossa] @dont_optimize_with_load_in_different_block : $@convention(thin) (@in
 bb0(%0 : $*GS<Builtin.NativeObject>, %1 : $*GS<Builtin.NativeObject>):
   %f = function_ref @use_gsbase_builtinnativeobject : $@convention(thin) (@guaranteed GS<Builtin.NativeObject>) -> ()
   %stk = alloc_stack $GS<Builtin.NativeObject>
-  copy_addr %0 to [initialization] %stk : $*GS<Builtin.NativeObject>
+  copy_addr %0 to [init] %stk : $*GS<Builtin.NativeObject>
   cond_br undef, bb1, bb2
 
 bb1:
@@ -861,7 +861,7 @@ bb0:
   %1 = global_addr @globalString : $*String
   %3 = begin_access [read] [dynamic] %1 : $*String
   %4 = alloc_stack $String
-  copy_addr %3 to [initialization] %4 : $*String
+  copy_addr %3 to [init] %4 : $*String
   end_access %3 : $*String
   %6 = load [copy] %4 : $*String
   destroy_addr %4 : $*String
@@ -887,7 +887,7 @@ bb0:
   %1 = global_addr @globalString : $*String
   %3 = begin_access [read] [dynamic] %1 : $*String
   %4 = alloc_stack $String
-  copy_addr %3 to [initialization] %4 : $*String
+  copy_addr %3 to [init] %4 : $*String
   end_access %3 : $*String
   %f = function_ref @loadString : $@convention(thin) (@in_guaranteed String) -> @owned String
   %a = apply %f(%4) : $@convention(thin) (@in_guaranteed String) -> @owned String
@@ -908,7 +908,7 @@ bb0:
   %1 = global_addr @globalString : $*String
   %3 = begin_access [modify] [dynamic] %1 : $*String
   %4 = alloc_stack $String
-  copy_addr %3 to [initialization] %4 : $*String
+  copy_addr %3 to [init] %4 : $*String
   end_access %3 : $*String
   %6 = load [copy] %4 : $*String
   destroy_addr %4 : $*String
@@ -931,7 +931,7 @@ bb0(%0 : $*Int):
   %2 = begin_access [read] [dynamic] %0 : $*Int
   %3 = begin_access [read] [dynamic] %1 : $*String
   %4 = alloc_stack $String
-  copy_addr %3 to [initialization] %4 : $*String
+  copy_addr %3 to [init] %4 : $*String
   end_access %3 : $*String
   end_access %2 : $*Int
   %6 = load [copy] %4 : $*String
@@ -951,7 +951,7 @@ sil [ossa] @dontExtendAccessScopeOverBeginAccess : $@convention(thin) (@in Klass
 bb0(%0 : $*Klass):
   %stack = alloc_stack $Klass
   %access = begin_access [read] [static] %0 : $*Klass
-  copy_addr [take] %access to [initialization] %stack : $*Klass
+  copy_addr [take] %access to [init] %stack : $*Klass
   end_access %access : $*Klass
   %f = function_ref @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> ()
   %access2 = begin_access [read] [static] %stack : $*Klass
@@ -966,13 +966,13 @@ bb0(%0 : $*Klass):
 
 // CHECK-LABEL: sil [ossa] @dont_optimize_with_modify_inside_access
 // CHECK:   [[STK:%[0-9]+]] = alloc_stack $Klass
-// CHECK:   copy_addr %0 to [initialization] [[STK]]
+// CHECK:   copy_addr %0 to [init] [[STK]]
 // CHECK:   begin_access [read] [static] [[STK]]
 // CHECK-LABEL: } // end sil function 'dont_optimize_with_modify_inside_access'
 sil [ossa] @dont_optimize_with_modify_inside_access : $@convention(thin) (@inout Klass, @owned Klass) -> () {
 bb0(%0 : $*Klass, %1 : @owned $Klass):
   %stack = alloc_stack $Klass
-  copy_addr %0 to [initialization] %stack : $*Klass
+  copy_addr %0 to [init] %stack : $*Klass
   %f = function_ref @inguaranteed_user_without_result : $@convention(thin) (@in_guaranteed Klass) -> ()
   %access = begin_access [read] [static] %stack : $*Klass
   store %1 to [assign] %0 : $*Klass // This store prevents the optimization
@@ -991,7 +991,7 @@ bb0(%0 : @guaranteed $Klass):
   %1 = ref_element_addr %0 : $Klass, #Klass.i
   %2 = begin_access [read] [dynamic] %1 : $*Int
   %3 = alloc_stack $Int
-  copy_addr %2 to [initialization] %3 : $*Int
+  copy_addr %2 to [init] %3 : $*Int
   end_access %2 : $*Int
   %6 = function_ref @readonly_throwing_func : $@convention(thin) (@in_guaranteed Int) -> @error Error
   try_apply %6(%3) : $@convention(thin) (@in_guaranteed Int) -> @error Error, normal bb1, error bb2
@@ -1046,7 +1046,7 @@ bb0(%0 : $*GS<Klass>, %1 : @owned $GS<Klass>, %2 : $Builtin.Int64):
   %4 = alloc_stack $GS<Klass>
   store %1 to [init] %4 : $*GS<Klass>
   %8 = builtin "cmp_slt_Int64"(%2 : $Builtin.Int64, %2 : $Builtin.Int64) : $Builtin.Int1
-  copy_addr %4 to [initialization] %0 : $*GS<Klass>
+  copy_addr %4 to [init] %0 : $*GS<Klass>
   destroy_addr %4 : $*GS<Klass>
   dealloc_stack %4 : $*GS<Klass>
   %9999 = tuple()
@@ -1218,9 +1218,9 @@ bb0(%0 : @owned $Klass):
   %2 = alloc_stack $Klass
   %0a = copy_value %0 : $Klass
   store %0a to [init] %2 : $*Klass
-  copy_addr [take] %2 to [initialization] %1 : $*Klass
+  copy_addr [take] %2 to [init] %1 : $*Klass
   dealloc_stack %2 : $*Klass
-  copy_addr %1 to [initialization] %1a : $*Klass
+  copy_addr %1 to [init] %1a : $*Klass
   destroy_value %0 : $Klass
   destroy_addr %1 : $*Klass
   dealloc_stack %1 : $*Klass
@@ -1258,7 +1258,7 @@ bb0(%0 : $*Klass):
   %7 = apply %6(%4, %1) : $@convention(method) (@in_guaranteed Klass, @inout Klass) -> ()
   destroy_addr %4 : $*Klass
   dealloc_stack %4 : $*Klass
-  copy_addr [take] %1 to [initialization] %0 : $*Klass
+  copy_addr [take] %1 to [init] %0 : $*Klass
   dealloc_stack %1 : $*Klass
   %12 = tuple ()
   return %12 : $()
@@ -1392,7 +1392,7 @@ bb0(%0 : $*Optional<GS<B>>, %1 : $*Optional<GS<B>>):
   %2 = struct_element_addr %0a : $*GS<B>, #GS._value
   %3 = load [trivial] %2 : $*Builtin.Int64
   %4 = alloc_stack $Optional<GS<B>>
-  copy_addr %1 to [initialization] %4 : $*Optional<GS<B>>
+  copy_addr %1 to [init] %4 : $*Optional<GS<B>>
   %4a = unchecked_take_enum_data_addr %4 : $*Optional<GS<B>>, #Optional.some!enumelt
   %6 = struct_element_addr %4a : $*GS<B>, #GS._value
   %7 = load [trivial] %6 : $*Builtin.Int64
@@ -1433,7 +1433,7 @@ bb0(%0 : $*Optional<GS<Klass>>, %1 : @owned $Optional<GS<Klass>>):
 sil [ossa] @eliminate_fix_lifetime_on_dest_copyaddr : $@convention(thin) (@inout Klass) -> () {
 bb0(%0 : $*Klass):
   %3 = alloc_stack $Klass
-  copy_addr %0 to [initialization] %3 : $*Klass
+  copy_addr %0 to [init] %3 : $*Klass
   fix_lifetime %3 : $*Klass
   destroy_addr %3 : $*Klass
   dealloc_stack %3 : $*Klass
@@ -1487,7 +1487,7 @@ sil [ossa] @test_yield : $@yield_once @convention(thin) (@guaranteed Klass) -> @
 bb0(%0 : @guaranteed $Klass):
   %1 = alloc_stack $Two
   %2 = ref_tail_addr [immutable] %0 : $Klass, $Two
-  copy_addr %2 to [initialization] %1 : $*Two
+  copy_addr %2 to [init] %1 : $*Two
   yield %1 : $*Two, resume bb1, unwind bb2
 
 bb1:
@@ -1517,7 +1517,7 @@ sil [ossa] @test_temprvoborrowboundary1 : $@convention(thin) (@in FakeOptional<N
 bb0(%0 : $*FakeOptional<NonTrivialStruct>):
   %1 = alloc_stack $NonTrivialStruct
   %2 = unchecked_take_enum_data_addr %0 : $*FakeOptional<NonTrivialStruct>, #FakeOptional.some!enumelt
-  copy_addr [take] %2 to [initialization] %1 : $*NonTrivialStruct
+  copy_addr [take] %2 to [init] %1 : $*NonTrivialStruct
   %4 = struct_element_addr %1 : $*NonTrivialStruct, #NonTrivialStruct.val
   %5 = load_borrow %4 : $*Klass
   end_borrow %5 : $Klass
@@ -1535,7 +1535,7 @@ sil [ossa] @test_temprvoborrowboundary2 : $@convention(thin) (@in FakeOptional<N
 bb0(%0 : $*FakeOptional<NonTrivialStruct>):
   %1 = alloc_stack $NonTrivialStruct
   %2 = unchecked_take_enum_data_addr %0 : $*FakeOptional<NonTrivialStruct>, #FakeOptional.some!enumelt
-  copy_addr [take] %2 to [initialization] %1 : $*NonTrivialStruct
+  copy_addr [take] %2 to [init] %1 : $*NonTrivialStruct
   %4 = struct_element_addr %1 : $*NonTrivialStruct, #NonTrivialStruct.val
   %5 = load_borrow %4 : $*Klass
   br bb1(%5 : $Klass)
@@ -1558,7 +1558,7 @@ sil [ossa] @copy_addr__lexical_alloc_stack_temporary__guaranteed_function_arg : 
 entry(%instance : @guaranteed $OtherClass):
   %field_ptr = ref_element_addr %instance : $OtherClass, #OtherClass.klass
   %addr = alloc_stack [lexical] $Klass
-  copy_addr %field_ptr to [initialization] %addr : $*Klass
+  copy_addr %field_ptr to [init] %addr : $*Klass
   destroy_addr %addr : $*Klass
   dealloc_stack %addr : $*Klass
   %retval = tuple ()
@@ -1574,7 +1574,7 @@ sil [ossa] @copy_addr__lexical_alloc_stack_temporary__inout_function_arg : $@con
 entry(%instance : $*NonTrivialStruct):
   %field_ptr = struct_element_addr %instance : $*NonTrivialStruct, #NonTrivialStruct.val
   %addr = alloc_stack [lexical] $Klass
-  copy_addr %field_ptr to [initialization] %addr : $*Klass
+  copy_addr %field_ptr to [init] %addr : $*Klass
   destroy_addr %addr : $*Klass
   dealloc_stack %addr : $*Klass
   %retval = tuple ()

--- a/test/SILOptimizer/templvalueopt.sil
+++ b/test/SILOptimizer/templvalueopt.sil
@@ -6,7 +6,7 @@ import Builtin
 // CHECK-LABEL: sil @test_enum_with_initialize :
 // CHECK:      bb0(%0 : $*Optional<Any>, %1 : $*Any):
 // CHECK-NEXT:   [[E:%[0-9]+]] = init_enum_data_addr %0
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] [[E]]
+// CHECK-NEXT:   copy_addr [take] %1 to [init] [[E]]
 // CHECK-NEXT:   inject_enum_addr %0 : $*Optional<Any>, #Optional.some!enumelt
 // CHECK-NOT:    copy_addr
 // CHECK: } // end sil function 'test_enum_with_initialize'
@@ -14,9 +14,9 @@ sil @test_enum_with_initialize : $@convention(thin) (@in Any) -> @out Optional<A
 bb0(%0 : $*Optional<Any>, %1 : $*Any):
   %2 = alloc_stack $Optional<Any>
   %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %1 to [initialization] %3 : $*Any
+  copy_addr [take] %1 to [init] %3 : $*Any
   inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %2 to [initialization] %0 : $*Optional<Any>
+  copy_addr [take] %2 to [init] %0 : $*Optional<Any>
   dealloc_stack %2 : $*Optional<Any>
   %6 = tuple ()
   return %6 : $()
@@ -26,7 +26,7 @@ bb0(%0 : $*Optional<Any>, %1 : $*Any):
 // CHECK:      bb0(%0 : $*Optional<Any>, %1 : $*Any):
 // CHECK-NEXT:   destroy_addr %0
 // CHECK-NEXT:   [[E:%[0-9]+]] = init_enum_data_addr %0
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] [[E]]
+// CHECK-NEXT:   copy_addr [take] %1 to [init] [[E]]
 // CHECK-NEXT:   inject_enum_addr %0 : $*Optional<Any>, #Optional.some!enumelt
 // CHECK-NOT:    copy_addr
 // CHECK: } // end sil function 'test_enum_without_initialize'
@@ -34,7 +34,7 @@ sil @test_enum_without_initialize : $@convention(thin) (@in Any) -> @out Optiona
 bb0(%0 : $*Optional<Any>, %1 : $*Any):
   %2 = alloc_stack $Optional<Any>
   %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %1 to [initialization] %3 : $*Any
+  copy_addr [take] %1 to [init] %3 : $*Any
   inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
   copy_addr [take] %2 to %0 : $*Optional<Any>
   dealloc_stack %2 : $*Optional<Any>
@@ -51,15 +51,15 @@ struct ConformingStruct : Proto {
 // CHECK-LABEL: sil @test_existential :
 // CHECK:      bb0(%0 : $*any Proto, %1 : $*ConformingStruct):
 // CHECK-NEXT:   [[E:%[0-9]+]] = init_existential_addr %0
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] [[E]]
+// CHECK-NEXT:   copy_addr [take] %1 to [init] [[E]]
 // CHECK-NOT:    copy_addr
 // CHECK: } // end sil function 'test_existential'
 sil @test_existential : $@convention(thin) (@in ConformingStruct) -> @out Proto {
 bb0(%0 : $*Proto, %1 : $*ConformingStruct):
   %2 = alloc_stack $Proto
   %3 = init_existential_addr %2 : $*Proto, $ConformingStruct
-  copy_addr [take] %1 to [initialization] %3 : $*ConformingStruct
-  copy_addr [take] %2 to [initialization] %0 : $*Proto
+  copy_addr [take] %1 to [init] %3 : $*ConformingStruct
+  copy_addr [take] %2 to [init] %0 : $*Proto
   dealloc_stack %2 : $*Proto
   %6 = tuple ()
   return %6 : $()
@@ -85,7 +85,7 @@ struct AddressOnlyPayload {
 // CHECK-NEXT:   [[E:%[0-9]+]] = struct_element_addr %0
 // CHECK-NEXT:   [[LEFT:%[0-9]+]] = init_enum_data_addr [[E]]
 // CHECK-NEXT:   [[A:%[0-9]+]] = struct_element_addr [[LEFT]]
-// CHECK-NEXT:   copy_addr %1 to [initialization] [[A]]
+// CHECK-NEXT:   copy_addr %1 to [init] [[A]]
 // CHECK-NEXT:   [[I:%[0-9]+]] = struct_element_addr [[LEFT]]
 // CHECK-NEXT:   store %2 to [[I]]
 // CHECK-NEXT:   inject_enum_addr [[E]]
@@ -97,17 +97,17 @@ bb0(%0 : $*TestStruct, %1 : $*Any, %2 : $Int):
   %4 = alloc_stack $Either<AddressOnlyPayload, Int>
   %5 = alloc_stack $AddressOnlyPayload
   %6 = struct_element_addr %5 : $*AddressOnlyPayload, #AddressOnlyPayload.a
-  copy_addr %1 to [initialization] %6 : $*Any
+  copy_addr %1 to [init] %6 : $*Any
   %8 = struct_element_addr %5 : $*AddressOnlyPayload, #AddressOnlyPayload.i
   store %2 to %8 : $*Int
   %10 = init_enum_data_addr %4 : $*Either<AddressOnlyPayload, Int>, #Either.left!enumelt
-  copy_addr [take] %5 to [initialization] %10 : $*AddressOnlyPayload
+  copy_addr [take] %5 to [init] %10 : $*AddressOnlyPayload
   inject_enum_addr %4 : $*Either<AddressOnlyPayload, Int>, #Either.left!enumelt
   dealloc_stack %5 : $*AddressOnlyPayload
   %14 = struct_element_addr %3 : $*TestStruct, #TestStruct.e
-  copy_addr [take] %4 to [initialization] %14 : $*Either<AddressOnlyPayload, Int>
+  copy_addr [take] %4 to [init] %14 : $*Either<AddressOnlyPayload, Int>
   dealloc_stack %4 : $*Either<AddressOnlyPayload, Int>
-  copy_addr %3 to [initialization] %0 : $*TestStruct
+  copy_addr %3 to [init] %0 : $*TestStruct
   destroy_addr %3 : $*TestStruct
   dealloc_stack %3 : $*TestStruct
   %20 = tuple ()
@@ -123,10 +123,10 @@ sil @bail_on_write_to_dest : $@convention(thin) (@inout Optional<Any>, @in Any) 
 bb0(%0 : $*Optional<Any>, %1 : $*Any):
   %2 = alloc_stack $Optional<Any>
   %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %1 to [initialization] %3 : $*Any
+  copy_addr [take] %1 to [init] %3 : $*Any
   inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
   destroy_addr %0 : $*Optional<Any>
-  copy_addr [take] %2 to [initialization] %0 : $*Optional<Any>
+  copy_addr [take] %2 to [init] %0 : $*Optional<Any>
   dealloc_stack %2 : $*Optional<Any>
   %6 = tuple ()
   return %6 : $()
@@ -145,9 +145,9 @@ bb0(%0 : $*Optional<Any>, %1 : $*Any):
   %2 = alloc_stack $Optional<Any>
   destroy_addr %0 : $*Optional<Any>
   %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %1 to [initialization] %3 : $*Any
+  copy_addr [take] %1 to [init] %3 : $*Any
   inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %2 to [initialization] %0 : $*Optional<Any>
+  copy_addr [take] %2 to [init] %0 : $*Optional<Any>
   dealloc_stack %2 : $*Optional<Any>
   %6 = tuple ()
   return %6 : $()
@@ -167,7 +167,7 @@ struct StructWithEnum : Proto {
 // CHECK-NEXT:   [[E:%[0-9]+]] = struct_element_addr [[S]] : $*StructWithEnum, #StructWithEnum.e
 // CHECK-NEXT:   [[ENUMA:%[0-9]+]] = init_enum_data_addr [[E]] : $*Enum, #Enum.A!enumelt
 // CHECK-NEXT:   [[OPTIONAL:%[0-9]+]] = init_enum_data_addr [[ENUMA]] : $*Optional<Any>, #Optional.some!enumelt
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] [[OPTIONAL]] : $*Any
+// CHECK-NEXT:   copy_addr [take] %1 to [init] [[OPTIONAL]] : $*Any
 // CHECK-NEXT:   inject_enum_addr [[ENUMA]] : $*Optional<Any>, #Optional.some!enumelt
 // CHECK-NEXT:   inject_enum_addr [[E]] : $*Enum, #Enum.A!enumelt
 // CHECK-NOT:    copy_addr
@@ -176,12 +176,12 @@ sil @move_projections : $@convention(thin) (@in Any) -> @out Proto {
 bb0(%0 : $*Proto, %1 : $*Any):
   %2 = alloc_stack $Optional<Any>
   %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %1 to [initialization] %3 : $*Any
+  copy_addr [take] %1 to [init] %3 : $*Any
   inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
   %4 = init_existential_addr %0 : $*Proto, $StructWithEnum
   %5 = struct_element_addr %4 : $*StructWithEnum, #StructWithEnum.e
   %6 = init_enum_data_addr %5 : $*Enum, #Enum.A!enumelt
-  copy_addr [take] %2 to [initialization] %6 : $*Optional<Any>
+  copy_addr [take] %2 to [init] %6 : $*Optional<Any>
   inject_enum_addr %5 : $*Enum, #Enum.A!enumelt
   dealloc_stack %2 : $*Optional<Any>
   %10 = tuple ()
@@ -198,11 +198,11 @@ sil @cant_move_projections : $@convention(thin) (@in Any, @in_guaranteed Builtin
 bb0(%0 : $*Any, %1 : $*Builtin.RawPointer):
   %2 = alloc_stack $Optional<Any>
   %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %0 to [initialization] %3 : $*Any
+  copy_addr [take] %0 to [init] %3 : $*Any
   inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
   %4 = load %1 : $*Builtin.RawPointer
   %5 = pointer_to_address %4 : $Builtin.RawPointer to $*Optional<Any>
-  copy_addr [take] %2 to [initialization] %5 : $*Optional<Any>
+  copy_addr [take] %2 to [init] %5 : $*Optional<Any>
   dealloc_stack %2 : $*Optional<Any>
   %10 = tuple ()
   return %10 : $()
@@ -220,9 +220,9 @@ sil @instructions_after_copy_addr : $@convention(thin) (@in Any) -> @out Optiona
 bb0(%0 : $*Optional<Any>, %1 : $*Any):
   %2 = alloc_stack $Optional<Any>
   %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %1 to [initialization] %3 : $*Any
+  copy_addr [take] %1 to [init] %3 : $*Any
   inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %2 to [initialization] %0 : $*Optional<Any>
+  copy_addr [take] %2 to [init] %0 : $*Optional<Any>
   %4 = function_ref @init_optional : $@convention(thin) () -> @out Optional<Any>
   %5 = apply %4(%2) : $@convention(thin) () -> @out Optional<Any>
   destroy_addr %2 : $*Optional<Any>
@@ -241,9 +241,9 @@ bb0(%0 : $*Optional<Any>, %1 : $*Any):
 sil @dont_optimize_swap : $@convention(thin) <T> (@inout T, @inout T) -> () {
 bb0(%0 : $*T, %1 : $*T):
   %2 = alloc_stack $T
-  copy_addr [take] %0 to [initialization] %2 : $*T
-  copy_addr [take] %1 to [initialization] %0 : $*T
-  copy_addr [take] %2 to [initialization] %1 : $*T
+  copy_addr [take] %0 to [init] %2 : $*T
+  copy_addr [take] %1 to [init] %0 : $*T
+  copy_addr [take] %2 to [init] %1 : $*T
   dealloc_stack %2 : $*T
   %78 = tuple ()
   return %78 : $()

--- a/test/SILOptimizer/templvalueopt.swift
+++ b/test/SILOptimizer/templvalueopt.swift
@@ -25,7 +25,7 @@ public struct TestStruct {
   // CHECK: [[E:%[0-9]+]] = struct_element_addr %0 : $*TestStruct, #TestStruct.e
   // CHECK: [[LEFT:%[0-9]+]] = init_enum_data_addr [[E]] : $*Either<AddressOnlyPayload, Int>, #Either.left!enumelt
   // CHECK: [[A:%[0-9]+]] = struct_element_addr [[LEFT]] : $*AddressOnlyPayload, #AddressOnlyPayload.a
-  // CHECK: copy_addr [take] %1 to [initialization] [[A]] : $*Any
+  // CHECK: copy_addr [take] %1 to [init] [[A]] : $*Any
   // CHECK: [[I:%[0-9]+]] = struct_element_addr [[LEFT]] : $*AddressOnlyPayload, #AddressOnlyPayload.i
   // CHECK: store %2 to [[I]] : $*Int
   // CHECK: inject_enum_addr [[E]] : $*Either<AddressOnlyPayload, Int>, #Either.left!enumelt
@@ -39,7 +39,7 @@ public struct TestStruct {
 // CHECK-LABEL: sil [noinline] {{.*}}@$s4test13createAnyLeftyAA6EitherOyypSgSiGypF
 // CHECK:  [[E:%[0-9]+]] = init_enum_data_addr %0 : $*Either<Optional<Any>, Int>, #Either.left!enumelt
 // CHECK:  [[SOME:%[0-9]+]] = init_enum_data_addr [[E]] : $*Optional<Any>, #Optional.some!enumelt
-// CHECK:  copy_addr %1 to [initialization] [[SOME]] : $*Any
+// CHECK:  copy_addr %1 to [init] [[SOME]] : $*Any
 // CHECK:  inject_enum_addr [[E]] : $*Optional<Any>, #Optional.some!enumelt
 // CHECK:  inject_enum_addr %0 : $*Either<Optional<Any>, Int>, #Either.left!enumelt
 // CHECK: } // end sil function '$s4test13createAnyLeftyAA6EitherOyypSgSiGypF'

--- a/test/SILOptimizer/templvalueopt_ossa.sil
+++ b/test/SILOptimizer/templvalueopt_ossa.sil
@@ -6,7 +6,7 @@ import Builtin
 // CHECK-LABEL: sil [ossa] @test_enum_with_initialize :
 // CHECK:      bb0(%0 : $*Optional<Any>, %1 : $*Any):
 // CHECK-NEXT:   [[E:%[0-9]+]] = init_enum_data_addr %0
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] [[E]]
+// CHECK-NEXT:   copy_addr [take] %1 to [init] [[E]]
 // CHECK-NEXT:   inject_enum_addr %0 : $*Optional<Any>, #Optional.some!enumelt
 // CHECK-NOT:    copy_addr
 // CHECK: } // end sil function 'test_enum_with_initialize'
@@ -14,9 +14,9 @@ sil [ossa] @test_enum_with_initialize : $@convention(thin) (@in Any) -> @out Opt
 bb0(%0 : $*Optional<Any>, %1 : $*Any):
   %2 = alloc_stack $Optional<Any>
   %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %1 to [initialization] %3 : $*Any
+  copy_addr [take] %1 to [init] %3 : $*Any
   inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %2 to [initialization] %0 : $*Optional<Any>
+  copy_addr [take] %2 to [init] %0 : $*Optional<Any>
   dealloc_stack %2 : $*Optional<Any>
   %6 = tuple ()
   return %6 : $()
@@ -26,7 +26,7 @@ bb0(%0 : $*Optional<Any>, %1 : $*Any):
 // CHECK:      bb0(%0 : $*Optional<Any>, %1 : $*Any):
 // CHECK-NEXT:   destroy_addr %0
 // CHECK-NEXT:   [[E:%[0-9]+]] = init_enum_data_addr %0
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] [[E]]
+// CHECK-NEXT:   copy_addr [take] %1 to [init] [[E]]
 // CHECK-NEXT:   inject_enum_addr %0 : $*Optional<Any>, #Optional.some!enumelt
 // CHECK-NOT:    copy_addr
 // CHECK: } // end sil function 'test_enum_without_initialize'
@@ -34,7 +34,7 @@ sil [ossa] @test_enum_without_initialize : $@convention(thin) (@inout Optional<A
 bb0(%0 : $*Optional<Any>, %1 : $*Any):
   %2 = alloc_stack $Optional<Any>
   %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %1 to [initialization] %3 : $*Any
+  copy_addr [take] %1 to [init] %3 : $*Any
   inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
   copy_addr [take] %2 to %0 : $*Optional<Any>
   dealloc_stack %2 : $*Optional<Any>
@@ -51,15 +51,15 @@ struct ConformingStruct : Proto {
 // CHECK-LABEL: sil [ossa] @test_existential :
 // CHECK:      bb0(%0 : $*any Proto, %1 : $*ConformingStruct):
 // CHECK-NEXT:   [[E:%[0-9]+]] = init_existential_addr %0
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] [[E]]
+// CHECK-NEXT:   copy_addr [take] %1 to [init] [[E]]
 // CHECK-NOT:    copy_addr
 // CHECK: } // end sil function 'test_existential'
 sil [ossa] @test_existential : $@convention(thin) (@in ConformingStruct) -> @out Proto {
 bb0(%0 : $*Proto, %1 : $*ConformingStruct):
   %2 = alloc_stack $Proto
   %3 = init_existential_addr %2 : $*Proto, $ConformingStruct
-  copy_addr [take] %1 to [initialization] %3 : $*ConformingStruct
-  copy_addr [take] %2 to [initialization] %0 : $*Proto
+  copy_addr [take] %1 to [init] %3 : $*ConformingStruct
+  copy_addr [take] %2 to [init] %0 : $*Proto
   dealloc_stack %2 : $*Proto
   %6 = tuple ()
   return %6 : $()
@@ -85,7 +85,7 @@ struct AddressOnlyPayload {
 // CHECK-NEXT:   [[E:%[0-9]+]] = struct_element_addr %0
 // CHECK-NEXT:   [[LEFT:%[0-9]+]] = init_enum_data_addr [[E]]
 // CHECK-NEXT:   [[A:%[0-9]+]] = struct_element_addr [[LEFT]]
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] [[A]]
+// CHECK-NEXT:   copy_addr [take] %1 to [init] [[A]]
 // CHECK-NEXT:   [[I:%[0-9]+]] = struct_element_addr [[LEFT]]
 // CHECK-NEXT:   store %2 to [trivial] [[I]]
 // CHECK-NEXT:   inject_enum_addr [[E]]
@@ -97,17 +97,17 @@ bb0(%0 : $*TestStruct, %1 : $*Any, %2 : $Int):
   %4 = alloc_stack $Either<AddressOnlyPayload, Int>
   %5 = alloc_stack $AddressOnlyPayload
   %6 = struct_element_addr %5 : $*AddressOnlyPayload, #AddressOnlyPayload.a
-  copy_addr [take] %1 to [initialization] %6 : $*Any
+  copy_addr [take] %1 to [init] %6 : $*Any
   %8 = struct_element_addr %5 : $*AddressOnlyPayload, #AddressOnlyPayload.i
   store %2 to [trivial] %8 : $*Int
   %10 = init_enum_data_addr %4 : $*Either<AddressOnlyPayload, Int>, #Either.left!enumelt
-  copy_addr [take] %5 to [initialization] %10 : $*AddressOnlyPayload
+  copy_addr [take] %5 to [init] %10 : $*AddressOnlyPayload
   inject_enum_addr %4 : $*Either<AddressOnlyPayload, Int>, #Either.left!enumelt
   dealloc_stack %5 : $*AddressOnlyPayload
   %14 = struct_element_addr %3 : $*TestStruct, #TestStruct.e
-  copy_addr [take] %4 to [initialization] %14 : $*Either<AddressOnlyPayload, Int>
+  copy_addr [take] %4 to [init] %14 : $*Either<AddressOnlyPayload, Int>
   dealloc_stack %4 : $*Either<AddressOnlyPayload, Int>
-  copy_addr %3 to [initialization] %0 : $*TestStruct
+  copy_addr %3 to [init] %0 : $*TestStruct
   destroy_addr %3 : $*TestStruct
   dealloc_stack %3 : $*TestStruct
   %20 = tuple ()
@@ -123,10 +123,10 @@ sil [ossa] @bail_on_write_to_dest : $@convention(thin) (@inout Optional<Any>, @i
 bb0(%0 : $*Optional<Any>, %1 : $*Any):
   %2 = alloc_stack $Optional<Any>
   %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %1 to [initialization] %3 : $*Any
+  copy_addr [take] %1 to [init] %3 : $*Any
   inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
   destroy_addr %0 : $*Optional<Any>
-  copy_addr [take] %2 to [initialization] %0 : $*Optional<Any>
+  copy_addr [take] %2 to [init] %0 : $*Optional<Any>
   dealloc_stack %2 : $*Optional<Any>
   %6 = tuple ()
   return %6 : $()
@@ -145,9 +145,9 @@ bb0(%0 : $*Optional<Any>, %1 : $*Any):
   %2 = alloc_stack $Optional<Any>
   destroy_addr %0 : $*Optional<Any>
   %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %1 to [initialization] %3 : $*Any
+  copy_addr [take] %1 to [init] %3 : $*Any
   inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %2 to [initialization] %0 : $*Optional<Any>
+  copy_addr [take] %2 to [init] %0 : $*Optional<Any>
   dealloc_stack %2 : $*Optional<Any>
   %6 = tuple ()
   return %6 : $()
@@ -167,7 +167,7 @@ struct StructWithEnum : Proto {
 // CHECK-NEXT:   [[E:%[0-9]+]] = struct_element_addr [[S]] : $*StructWithEnum, #StructWithEnum.e
 // CHECK-NEXT:   [[ENUMA:%[0-9]+]] = init_enum_data_addr [[E]] : $*Enum, #Enum.A!enumelt
 // CHECK-NEXT:   [[OPTIONAL:%[0-9]+]] = init_enum_data_addr [[ENUMA]] : $*Optional<Any>, #Optional.some!enumelt
-// CHECK-NEXT:   copy_addr [take] %1 to [initialization] [[OPTIONAL]] : $*Any
+// CHECK-NEXT:   copy_addr [take] %1 to [init] [[OPTIONAL]] : $*Any
 // CHECK-NEXT:   inject_enum_addr [[ENUMA]] : $*Optional<Any>, #Optional.some!enumelt
 // CHECK-NEXT:   inject_enum_addr [[E]] : $*Enum, #Enum.A!enumelt
 // CHECK-NOT:    copy_addr
@@ -176,12 +176,12 @@ sil [ossa] @move_projections : $@convention(thin) (@in Any) -> @out Proto {
 bb0(%0 : $*Proto, %1 : $*Any):
   %2 = alloc_stack $Optional<Any>
   %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %1 to [initialization] %3 : $*Any
+  copy_addr [take] %1 to [init] %3 : $*Any
   inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
   %4 = init_existential_addr %0 : $*Proto, $StructWithEnum
   %5 = struct_element_addr %4 : $*StructWithEnum, #StructWithEnum.e
   %6 = init_enum_data_addr %5 : $*Enum, #Enum.A!enumelt
-  copy_addr [take] %2 to [initialization] %6 : $*Optional<Any>
+  copy_addr [take] %2 to [init] %6 : $*Optional<Any>
   inject_enum_addr %5 : $*Enum, #Enum.A!enumelt
   dealloc_stack %2 : $*Optional<Any>
   %10 = tuple ()
@@ -198,11 +198,11 @@ sil [ossa] @cant_move_projections : $@convention(thin) (@in Any, @in_guaranteed 
 bb0(%0 : $*Any, %1 : $*Builtin.RawPointer):
   %2 = alloc_stack $Optional<Any>
   %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %0 to [initialization] %3 : $*Any
+  copy_addr [take] %0 to [init] %3 : $*Any
   inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
   %4 = load [trivial] %1 : $*Builtin.RawPointer
   %5 = pointer_to_address %4 : $Builtin.RawPointer to $*Optional<Any>
-  copy_addr [take] %2 to [initialization] %5 : $*Optional<Any>
+  copy_addr [take] %2 to [init] %5 : $*Optional<Any>
   dealloc_stack %2 : $*Optional<Any>
   %10 = tuple ()
   return %10 : $()
@@ -220,9 +220,9 @@ sil [ossa] @instructions_after_copy_addr : $@convention(thin) (@in Any) -> @out 
 bb0(%0 : $*Optional<Any>, %1 : $*Any):
   %2 = alloc_stack $Optional<Any>
   %3 = init_enum_data_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %1 to [initialization] %3 : $*Any
+  copy_addr [take] %1 to [init] %3 : $*Any
   inject_enum_addr %2 : $*Optional<Any>, #Optional.some!enumelt
-  copy_addr [take] %2 to [initialization] %0 : $*Optional<Any>
+  copy_addr [take] %2 to [init] %0 : $*Optional<Any>
   %4 = function_ref @init_optional : $@convention(thin) () -> @out Optional<Any>
   %5 = apply %4(%2) : $@convention(thin) () -> @out Optional<Any>
   destroy_addr %2 : $*Optional<Any>
@@ -241,9 +241,9 @@ bb0(%0 : $*Optional<Any>, %1 : $*Any):
 sil [ossa] @dont_optimize_swap : $@convention(thin) <T> (@inout T, @inout T) -> () {
 bb0(%0 : $*T, %1 : $*T):
   %2 = alloc_stack $T
-  copy_addr [take] %0 to [initialization] %2 : $*T
-  copy_addr [take] %1 to [initialization] %0 : $*T
-  copy_addr [take] %2 to [initialization] %1 : $*T
+  copy_addr [take] %0 to [init] %2 : $*T
+  copy_addr [take] %1 to [init] %0 : $*T
+  copy_addr [take] %2 to [init] %1 : $*T
   dealloc_stack %2 : $*T
   %78 = tuple ()
   return %78 : $()
@@ -272,7 +272,7 @@ bb0(%0 :@owned  $Child):
   %func = function_ref @gen_child : $@convention(thin) () -> @out Child
   %10 = apply %func(%7) : $@convention(thin)() -> @out Child
   %11 = struct_element_addr %2 : $*Parent, #Parent.c
-  copy_addr [take] %7 to [initialization] %11 : $*Child
+  copy_addr [take] %7 to [init] %11 : $*Child
   dealloc_stack %7 : $*Child
   copy_addr [take] %4 to %11 : $*Child
   %17 = tuple ()
@@ -291,7 +291,7 @@ sil [ossa] @cleanup_debuginsts : $@convention(thin) <T> (@in T) -> () {
 bb0(%0 : $*T):
   %2 = alloc_stack $T
   debug_value %0 : $*T, expr op_deref
-  copy_addr %0 to [initialization] %2 : $*T
+  copy_addr %0 to [init] %2 : $*T
   debug_value %0 : $*T, expr op_deref
   destroy_addr %0 : $*T
   destroy_addr %2 : $*T

--- a/test/SILOptimizer/type_wrapper_in_user_defined_init_lowering.sil
+++ b/test/SILOptimizer/type_wrapper_in_user_defined_init_lowering.sil
@@ -45,10 +45,10 @@ bb0(%0 : $*T, %1 : $*Test1<T>):
 // CHECK: store [[ARG_0:%.*]] to [trivial] [[A_REF]] : $*Int
 //
 // CHECK: [[T:%.*]] = alloc_stack $T
-// CHECK: copy_addr [[ARG_1:%.*]] to [initialization] [[T]] : $*T
+// CHECK: copy_addr [[ARG_1:%.*]] to [init] [[T]] : $*T
 // CHECK: [[B_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE]] : $*(a: Int, b: T), 1
 // CHECK-NOT: {{.*}} = assign_by_wrapper {{.*}}
-// CHECK: copy_addr [take] [[T]] to [initialization] [[B_REF]] : $*T
+// CHECK: copy_addr [take] [[T]] to [init] [[B_REF]] : $*T
 sil hidden [ossa] @$s4main5Test1V1a1bACyxGSi_xtcfC : $@convention(method) <T> (Int, @in T, @thin Test1<T>.Type) -> @owned Test1<T> {
 bb0(%0 : $Int, %1 : $*T, %2 : $@thin Test1<T>.Type):
   %3 = alloc_box $<τ_0_0> { var Test1<τ_0_0> } <T>, var, name "self"
@@ -64,17 +64,17 @@ bb0(%0 : $Int, %1 : $*T, %2 : $@thin Test1<T>.Type):
   // function_ref Test1.a.setter
   %15 = function_ref @$s4main5Test1V1aSivs : $@convention(method) <τ_0_0> (Int, @inout Test1<τ_0_0>) -> ()
   %16 = partial_apply [callee_guaranteed] %15<T>(%13) : $@convention(method) <τ_0_0> (Int, @inout Test1<τ_0_0>) -> ()
-  assign_by_wrapper origin type_wrapper, %0 : $Int to [initialization] %14 : $*Int, set %16 : $@callee_guaranteed (Int) -> ()
+  assign_by_wrapper origin type_wrapper, %0 : $Int to [init] %14 : $*Int, set %16 : $@callee_guaranteed (Int) -> ()
   end_access %13 : $*Test1<T>
   destroy_value %16 : $@callee_guaranteed (Int) -> ()
   %20 = alloc_stack $T
-  copy_addr %1 to [initialization] %20 : $*T
+  copy_addr %1 to [init] %20 : $*T
   %22 = begin_access [modify] [unknown] %6 : $*Test1<T>
   %23 = tuple_element_addr %12 : $*(a: Int, b: T), 1
   // function_ref Test1.b.setter
   %24 = function_ref @$s4main5Test1V1bxvs : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Test1<τ_0_0>) -> ()
   %25 = partial_apply [callee_guaranteed] %24<T>(%22) : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Test1<τ_0_0>) -> ()
-  assign_by_wrapper origin type_wrapper, %20 : $*T to [initialization] %23 : $*T, set %25 : $@callee_guaranteed (@in T) -> ()
+  assign_by_wrapper origin type_wrapper, %20 : $*T to [init] %23 : $*T, set %25 : $@callee_guaranteed (@in T) -> ()
   end_access %22 : $*Test1<T>
   destroy_value %25 : $@callee_guaranteed (@in T) -> ()
   dealloc_stack %20 : $*T
@@ -97,19 +97,19 @@ bb0(%0 : $Int, %1 : $*T, %2 : $@thin Test1<T>.Type):
 // CHECK: store [[ARG_0:%.*]] to [trivial] [[A_REF]] : $*Int
 //
 // CHECK: [[T:%.*]] = alloc_stack $T
-// CHECK-NEXT: copy_addr [[ARG_1:%.*]] to [initialization] [[T]] : $*T
+// CHECK-NEXT: copy_addr [[ARG_1:%.*]] to [init] [[T]] : $*T
 // CHECK: [[B_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE]] : $*(a: Int, b: T), 1
 // CHECK-NOT: {{.*}} = assign_by_wrapper {{.*}}
-// CHECK: copy_addr [take] [[T]] to [initialization] [[B_REF]] : $*T
+// CHECK: copy_addr [take] [[T]] to [init] [[B_REF]] : $*T
 //
 // CHECK: [[OTHER_T:%.*]] = alloc_stack $T
-// CHECK-NEXT: copy_addr [[ARG_2:%.*]] to [initialization] %19 : $*T
+// CHECK-NEXT: copy_addr [[ARG_2:%.*]] to [init] %19 : $*T
 // CHECK: [[B_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE]] : $*(a: Int, b: T), 1
 // CHECK-NOT: {{.*}} = assign_by_wrapper {{.*}}
 // CHECK: copy_addr [take] [[OTHER_T]] to [[B_REF]] : $*T
 //
 // CHECK: [[T:%.*]] = alloc_stack $T
-// copy_addr [[ARG_1]] to [initialization] [[T]] : $*T
+// copy_addr [[ARG_1]] to [init] [[T]] : $*T
 // CHECK: [[B_SETTER:%.*]] = function_ref @$s4main5Test1V1bxvs : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Test1<τ_0_0>) -> ()
 // CHECK-NEXT: [[PARTIALY_APPLIED_SETTER:%.*]] = partial_apply [callee_guaranteed] [[B_SETTER]]<T>({{.*}}) : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Test1<τ_0_0>) -> ()
 // CHECK-NOT: {{.*}} = assign_by_wrapper {{.*}}
@@ -129,22 +129,22 @@ bb0(%0 : $Int, %1 : $*T, %2 : $*T, %3 : $@thin Test1<T>.Type):
   // function_ref Test1.a.setter
   %17 = function_ref @$s4main5Test1V1aSivs : $@convention(method) <τ_0_0> (Int, @inout Test1<τ_0_0>) -> ()
   %18 = partial_apply [callee_guaranteed] %17<T>(%15) : $@convention(method) <τ_0_0> (Int, @inout Test1<τ_0_0>) -> ()
-  assign_by_wrapper origin type_wrapper, %0 : $Int to [initialization] %16 : $*Int, set %18 : $@callee_guaranteed (Int) -> ()
+  assign_by_wrapper origin type_wrapper, %0 : $Int to [init] %16 : $*Int, set %18 : $@callee_guaranteed (Int) -> ()
   end_access %15 : $*Test1<T>
   destroy_value %18 : $@callee_guaranteed (Int) -> ()
   %22 = alloc_stack $T
-  copy_addr %1 to [initialization] %22 : $*T
+  copy_addr %1 to [init] %22 : $*T
   %24 = begin_access [modify] [unknown] %7 : $*Test1<T>
   %25 = tuple_element_addr %14 : $*(a: Int, b: T), 1
   // function_ref Test1.b.setter
   %26 = function_ref @$s4main5Test1V1bxvs : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Test1<τ_0_0>) -> ()
   %27 = partial_apply [callee_guaranteed] %26<T>(%24) : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Test1<τ_0_0>) -> ()
-  assign_by_wrapper origin type_wrapper, %22 : $*T to [initialization] %25 : $*T, set %27 : $@callee_guaranteed (@in T) -> ()
+  assign_by_wrapper origin type_wrapper, %22 : $*T to [init] %25 : $*T, set %27 : $@callee_guaranteed (@in T) -> ()
   end_access %24 : $*Test1<T>
   destroy_value %27 : $@callee_guaranteed (@in T) -> ()
   dealloc_stack %22 : $*T
   %32 = alloc_stack $T
-  copy_addr %2 to [initialization] %32 : $*T
+  copy_addr %2 to [init] %32 : $*T
   %34 = begin_access [modify] [unknown] %7 : $*Test1<T>
   %35 = tuple_element_addr %14 : $*(a: Int, b: T), 1
   // function_ref Test1.b.setter
@@ -155,7 +155,7 @@ bb0(%0 : $Int, %1 : $*T, %2 : $*T, %3 : $@thin Test1<T>.Type):
   destroy_value %37 : $@callee_guaranteed (@in T) -> ()
   dealloc_stack %32 : $*T
   %42 = alloc_stack $T
-  copy_addr %1 to [initialization] %42 : $*T
+  copy_addr %1 to [init] %42 : $*T
   %44 = begin_access [modify] [unknown] %7 : $*Test1<T>
   %45 = tuple_element_addr %14 : $*(a: Int, b: T), 1
   // function_ref Test1.b.setter

--- a/test/SILOptimizer/type_wrapper_init_transform.swift
+++ b/test/SILOptimizer/type_wrapper_init_transform.swift
@@ -42,7 +42,7 @@ struct TrivialStruct {
   // CHECK: [[WRAPPER_INST:%.*]] = alloc_stack $Wrapper<TrivialStruct, TrivialStruct.$Storage>
   // CHECK: {{.*}} = apply [[WRAPPER_INIT_REF]]<TrivialStruct, TrivialStruct.$Storage>([[WRAPPER_INST]], [[WRAPPED_METATYPE]], [[STORAGE_INST]], [[WRAPPER_METATYPE]])
   // CHECK: [[STORAGE_VAR_ACCESS:%.*]] = begin_access [modify] [dynamic] [[STORAGE_VAR_REF]] : $*Wrapper<TrivialStruct, TrivialStruct.$Storage>
-  // CHECK: copy_addr [take] [[WRAPPER_INST]] to [initialization] [[STORAGE_VAR_ACCESS]] : $*Wrapper<TrivialStruct, TrivialStruct.$Storage>
+  // CHECK: copy_addr [take] [[WRAPPER_INST]] to [init] [[STORAGE_VAR_ACCESS]] : $*Wrapper<TrivialStruct, TrivialStruct.$Storage>
   // CHECK: end_access [[STORAGE_VAR_ACCESS]] : $*Wrapper<TrivialStruct, TrivialStruct.$Storage>
   // CHECK: end_access [[SELF_ACCESS]] : $*TrivialStruct
   // CHECK: dealloc_stack [[WRAPPER_INST]] : $*Wrapper<TrivialStruct, TrivialStruct.$Storage>
@@ -59,13 +59,13 @@ struct GenericStruct<T: Collection> {
   // CHECK: [[SELF:%.*]] = alloc_stack [lexical] $GenericStruct<T>, var, name "self", implicit
   // CHECK: [[LOCAL_STORAGE:%.*]] = alloc_stack [lexical] $(test: T), var, name "_storage", implicit
   // CHECK: [[TEST_PROP:%.*]] = tuple_element_addr [[LOCAL_STORAGE]] : $*(test: T), 0
-  // CHECK: assign_by_wrapper origin type_wrapper, [[FIELD_VALUE:%.*]] : $*T to [initialization] [[TEST_PROP]] : $*T, set {{.*}}
+  // CHECK: assign_by_wrapper origin type_wrapper, [[FIELD_VALUE:%.*]] : $*T to [init] [[TEST_PROP]] : $*T, set {{.*}}
   // CHECK-NEXT: [[STORAGE_INST:%.*]] = alloc_stack $GenericStruct<T>.$Storage
   // CHECK: [[STORAGE_INIT_REF:%.*]] = function_ref @$s4test13GenericStructV8$StorageVAaEyx_Gx_tcfC : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (@in τ_0_0, @thin GenericStruct<τ_0_0>.$Storage.Type) -> @out GenericStruct<τ_0_0>.$Storage
   // CHECK: [[LOCAL_STORAGE_ACCESS:%.*]] = begin_access [read] [unsafe] [[LOCAL_STORAGE]] : $*(test: T)
   // CHECK: [[T_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE_ACCESS]] : $*(test: T), 0
   // CHECK: [[T_VAL:%.*]] = alloc_stack $T
-  // CHECK: copy_addr [[T_REF]] to [initialization] [[T_VAL]] : $*T
+  // CHECK: copy_addr [[T_REF]] to [init] [[T_VAL]] : $*T
   // CHECK: end_access [[LOCAL_STORAGE_ACCESS]] : $*(test: T)
   // CHECK: [[STORAGE_METATYPE:%.*]] = metatype $@thin GenericStruct<T>.$Storage.Type
   // CHECK: {{.*}} = apply [[STORAGE_INIT_REF]]<T>([[STORAGE_INST]], [[T_VAL]], [[STORAGE_METATYPE]]) : $@convention(method) <τ_0_0 where τ_0_0 : Collection> (@in τ_0_0, @thin GenericStruct<τ_0_0>.$Storage.Type) -> @out GenericStruct<τ_0_0>.$Storage
@@ -77,7 +77,7 @@ struct GenericStruct<T: Collection> {
   // CHECK: [[WRAPPER_INST:%.*]] = alloc_stack $Wrapper<GenericStruct<T>, GenericStruct<T>.$Storage>
   // CHECK: {{.*}} = apply [[WRAPPER_INIT_REF]]<GenericStruct<T>, GenericStruct<T>.$Storage>([[WRAPPER_INST]], [[WRAPPED_METATYPE]], [[STORAGE_INST]], [[WRAPPER_METATYPE]])
   // CHECK: [[STORAGE_VAR_ACCESS:%.*]] = begin_access [modify] [dynamic] [[STORAGE_VAR]] : $*Wrapper<GenericStruct<T>, GenericStruct<T>.$Storage>
-  // CHECK: copy_addr [take] [[WRAPPER_INST]] to [initialization] [[STORAGE_VAR_ACCESS]] : $*Wrapper<GenericStruct<T>, GenericStruct<T>.$Storage>
+  // CHECK: copy_addr [take] [[WRAPPER_INST]] to [init] [[STORAGE_VAR_ACCESS]] : $*Wrapper<GenericStruct<T>, GenericStruct<T>.$Storage>
   // CHECK: end_access [[STORAGE_VAR_ACCESS]] : $*Wrapper<GenericStruct<T>, GenericStruct<T>.$Storage>
   init(v: T) {
     self.test = v
@@ -92,13 +92,13 @@ class GenericClass<T: Collection> {
   // CHECK-LABEL: sil hidden [ossa] @$s4test12GenericClassC1vACyxGx_tcfc : $@convention(method) <T where T : Collection> (@in T, @owned GenericClass<T>) -> @owned GenericClass<T>
   // CHECK: [[LOCAL_STORAGE:%.*]] = alloc_stack [lexical] $(test: T), var, name "_storage", implicit
   // CHECK: [[TEST_PROP:%.*]] = tuple_element_addr [[LOCAL_STORAGE]] : $*(test: T), 0
-  // CHECK: assign_by_wrapper origin type_wrapper, [[TEST_VAL:%.*]] : $*T to [initialization] [[TEST_PROP]] : $*T, set {{.*}}
+  // CHECK: assign_by_wrapper origin type_wrapper, [[TEST_VAL:%.*]] : $*T to [init] [[TEST_PROP]] : $*T, set {{.*}}
   // CHECK: [[SELF_ACCESS:%.*]] = begin_borrow [[SELF:%.*]] : $GenericClass<T>
   // CHECK-NEXT: [[STORAGE_VAR_REF:%.*]] = ref_element_addr [[SELF_ACCESS]] : $GenericClass<T>, #GenericClass.$storage
   // CHECK: [[WRAPPED_METATYPE:%.*]] = metatype $@thick GenericClass<T>.Type
   // CHECK: {{.*}} = apply [[WRAPPER_INIT_REF:%.*]]<GenericClass<T>, GenericClass<T>.$Storage>([[WRAPPER_INST:%.*]], [[WRAPPED_METATYPE]], [[STORAGE_INST:%.*]], {{.*}})
   // CHECK: [[STORAGE_VAR_ACCESS:%.*]] = begin_access [modify] [dynamic] [[STORAGE_VAR_REF]] : $*Wrapper<GenericClass<T>, GenericClass<T>.$Storage>
-  // CHECK-NEXT: copy_addr [take] [[WRAPPER_INST]] to [initialization] [[STORAGE_VAR_ACCESS]] : $*Wrapper<GenericClass<T>, GenericClass<T>.$Storage>
+  // CHECK-NEXT: copy_addr [take] [[WRAPPER_INST]] to [init] [[STORAGE_VAR_ACCESS]] : $*Wrapper<GenericClass<T>, GenericClass<T>.$Storage>
   // CHECK-NEXT: end_access [[STORAGE_VAR_ACCESS]]
   // CHECK-NEXT: end_borrow [[SELF_ACCESS]]
   init(v: T) {
@@ -119,13 +119,13 @@ struct TupleFlatteningTest<K: Collection & Hashable, V> {
   // CHECK-LABEL: sil hidden [ossa] @$s4test19TupleFlatteningTestV1a1b1c1dACyxq_GSi_SS_Si_xttSDyxq_Gq_SgtcfC
   // CHECK: [[LOCAL_STORAGE:%.*]] = alloc_stack [lexical] $(a: Int, b: (String, (Int, K)), c: Dictionary<K, V>, d: Optional<V>), var, name "_storage", implicit
   // CHECK: [[A_PROP:%.*]] = tuple_element_addr [[LOCAL_STORAGE]] : $*(a: Int, b: (String, (Int, K)), c: Dictionary<K, V>, d: Optional<V>), 0
-  // CHECK: assign_by_wrapper origin type_wrapper, {{.*}} : $Int to [initialization] [[A_PROP]] : $*Int, set {{.*}} : $@callee_guaranteed (Int) -> ()
+  // CHECK: assign_by_wrapper origin type_wrapper, {{.*}} : $Int to [init] [[A_PROP]] : $*Int, set {{.*}} : $@callee_guaranteed (Int) -> ()
   // CHECK: [[B_PROP:%.*]] = tuple_element_addr [[LOCAL_STORAGE]] : $*(a: Int, b: (String, (Int, K)), c: Dictionary<K, V>, d: Optional<V>), 1
-  // CHECK: assign_by_wrapper origin type_wrapper, {{.*}} : $*(String, (Int, K)) to [initialization] [[B_PROP]] : $*(String, (Int, K)), set {{.*}} : $@callee_guaranteed (@owned String, Int, @in K) -> ()
+  // CHECK: assign_by_wrapper origin type_wrapper, {{.*}} : $*(String, (Int, K)) to [init] [[B_PROP]] : $*(String, (Int, K)), set {{.*}} : $@callee_guaranteed (@owned String, Int, @in K) -> ()
   // CHECK: [[C_PROP:%.*]] = tuple_element_addr [[LOCAL_STORAGE]] : $*(a: Int, b: (String, (Int, K)), c: Dictionary<K, V>, d: Optional<V>), 2
-  // CHECK: assign_by_wrapper origin type_wrapper, {{.*}} : $Dictionary<K, V> to [initialization] [[C_PROP]] : $*Dictionary<K, V>, set {{.*}} : $@callee_guaranteed (@owned Dictionary<K, V>) -> ()
+  // CHECK: assign_by_wrapper origin type_wrapper, {{.*}} : $Dictionary<K, V> to [init] [[C_PROP]] : $*Dictionary<K, V>, set {{.*}} : $@callee_guaranteed (@owned Dictionary<K, V>) -> ()
   // CHECK: [[D_PROP:%.*]] = tuple_element_addr [[LOCAL_STORAGE]] : $*(a: Int, b: (String, (Int, K)), c: Dictionary<K, V>, d: Optional<V>), 3
-  // CHECK: assign_by_wrapper origin type_wrapper, {{.*}} : $*Optional<V> to [initialization] [[D_PROP]] : $*Optional<V>, set {{.*}} : $@callee_guaranteed (@in Optional<V>) -> ()
+  // CHECK: assign_by_wrapper origin type_wrapper, {{.*}} : $*Optional<V> to [init] [[D_PROP]] : $*Optional<V>, set {{.*}} : $@callee_guaranteed (@in Optional<V>) -> ()
   // CHECK: [[STORAGE_VAR:%.*]] = alloc_stack $TupleFlatteningTest<K, V>.$Storage
   // CHECK: [[STORAGE_INIT_REF:%.*]] = function_ref @$s4test19TupleFlatteningTestV8$StorageV1a1b1c1dAEyxq__GSi_SS_Si_xttSDyxq_Gq_SgtcfC
   // CHECK: [[LOCAL_STORAGE_ACCESS:%.*]] = begin_access [read] [unsafe] [[LOCAL_STORAGE:%.*]] : $*(a: Int, b: (String, (Int, K)), c: Dictionary<K, V>, d: Optional<V>)
@@ -139,12 +139,12 @@ struct TupleFlatteningTest<K: Collection & Hashable, V> {
   // CHECK: [[B_ELT_1_0_VAL:%.*]] = load [trivial] [[B_ELT_1_0_REF]] : $*Int
   // CHECK: [[B_ELT_1_1_REF:%.*]] = tuple_element_addr [[B_ELT_1_REF]] : $*(Int, K), 1
   // CHECK: [[K:%.*]] = alloc_stack $K
-  // CHECK: copy_addr [[B_ELT_1_1_REF]] to [initialization] [[K]] : $*K
+  // CHECK: copy_addr [[B_ELT_1_1_REF]] to [init] [[K]] : $*K
   // CHECK: [[C_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE_ACCESS]] : $*(a: Int, b: (String, (Int, K)), c: Dictionary<K, V>, d: Optional<V>), 2
   // CHECK: [[C_VAL:%.*]] = load [copy] [[C_REF]] : $*Dictionary<K, V>
   // CHECK: [[D_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE_ACCESS]] : $*(a: Int, b: (String, (Int, K)), c: Dictionary<K, V>, d: Optional<V>), 3
   // CHECK: [[D_VAL:%.*]] = alloc_stack $Optional<V>
-  // CHECK: copy_addr [[D_REF]] to [initialization] [[D_VAL]] : $*Optional<V>
+  // CHECK: copy_addr [[D_REF]] to [init] [[D_VAL]] : $*Optional<V>
   // CHECK: end_access [[LOCAL_STORAGE_ACCESS]] : $*(a: Int, b: (String, (Int, K)), c: Dictionary<K, V>, d: Optional<V>)
   // CHECK: [[STORAGE_METATYPE:%.*]] = metatype $@thin TupleFlatteningTest<K, V>.$Storage.Type
   // CHECK: {{.*}} = apply [[STORAGE_INIT_REF]]<K, V>([[STORAGE_INST:%.*]], [[A]], [[B_ELT_0_VAL]], [[B_ELT_1_0_VAL]], [[K]], [[C_VAL]], [[D_VAL]], [[STORAGE_METATYPE]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Collection, τ_0_0 : Hashable> (Int, @owned String, Int, @in τ_0_0, @owned Dictionary<τ_0_0, τ_0_1>, @in Optional<τ_0_1>, @thin TupleFlatteningTest<τ_0_0, τ_0_1>.$Storage.Type) -> @out TupleFlatteningTest<τ_0_0, τ_0_1>.$Storage
@@ -172,7 +172,7 @@ class TestConditionalInjection<T> {
   // CHECK-NEXT: cond_br [[COND]], [[COND_TRUE:bb[0-9]+]], [[COND_FALSE:bb[0-9]+]]
 
   // CHECK: [[COND_TRUE]]:
-  // CHECK: copy_addr [[V_ARG:%.*]] to [initialization] [[V:%.*]] : $*Optional<T>
+  // CHECK: copy_addr [[V_ARG:%.*]] to [init] [[V:%.*]] : $*Optional<T>
   // CHECK: switch_enum_addr [[V]] : $*Optional<T>, case #Optional.some!enumelt: [[V_SOME:bb[0-9]+]], case #Optional.none!enumelt: [[V_NONE:bb[0-9]+]]
 
   // CHECK: [[V_NONE]]:
@@ -183,17 +183,17 @@ class TestConditionalInjection<T> {
 
   // CHECK: [[V_SOME]]:
   // CHECK: [[V_VAL:%.*]] = unchecked_take_enum_data_addr [[V]] : $*Optional<T>, #Optional.some!enumelt
-  // CHECK: copy_addr [take] [[V_VAL:%.*]] to [initialization] [[T:%.*]] : $*T
+  // CHECK: copy_addr [take] [[V_VAL:%.*]] to [init] [[T:%.*]] : $*T
   // CHECK: br [[STORAGE_INIT_SOME:bb[0-9]+]]
 
   // CHECK: [[STORAGE_INIT_SOME]]:
   // CHECK: [[B_PROP:%.*]] = tuple_element_addr [[LOCAL_STORAGE]] : $*(b: Optional<T>), 0
-  // CHECK: assign_by_wrapper origin type_wrapper, {{.*}} : $*Optional<T> to [initialization] [[B_PROP]] : $*Optional<T>, set {{.*}} : $@callee_guaranteed (@in Optional<T>) -> ()
+  // CHECK: assign_by_wrapper origin type_wrapper, {{.*}} : $*Optional<T> to [init] [[B_PROP]] : $*Optional<T>, set {{.*}} : $@callee_guaranteed (@in Optional<T>) -> ()
   // CHECK: [[STORAGE_INIT_REF:%.*]] = function_ref @$s4test24TestConditionalInjectionC8$StorageV1bAEyx_GxSg_tcfC
   // CHECK: [[LOCAL_STORAGE_ACCESS:%.*]] = begin_access [read] [unsafe] [[LOCAL_STORAGE:%.*]] : $*(b: Optional<T>)
   // CHECK: [[B_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE_ACCESS]] : $*(b: Optional<T>), 0
   // CHECK: [[B_VAL:%.*]] = alloc_stack $Optional<T>
-  // CHECK: copy_addr [[B_REF]] to [initialization] [[B_VAL]] : $*Optional<T>
+  // CHECK: copy_addr [[B_REF]] to [init] [[B_VAL]] : $*Optional<T>
   // CHECK: end_access [[LOCAL_STORAGE_ACCESS]] : $*(b: Optional<T>)
   // CHECK: {{.*}} = apply [[STORAGE_INIT_REF]]<T>([[STORAGE_INST:%.*]], [[B_VAL]], {{.*}}) : $@convention(method) <τ_0_0> (@in Optional<τ_0_0>, @thin TestConditionalInjection<τ_0_0>.$Storage.Type) -> @out TestConditionalInjection<τ_0_0>.$Storage
   // CHECK: [[SELF_ACCESS:%.*]] = begin_borrow [[SELF:%.*]] : $TestConditionalInjection<T>
@@ -202,7 +202,7 @@ class TestConditionalInjection<T> {
   // CHECK: [[WRAPPER_INST:%.*]] = alloc_stack $Wrapper<TestConditionalInjection<T>, TestConditionalInjection<T>.$Storage>
   // CHECK: {{.*}} = apply [[WRAPPER_INIT_REF:%.*]]<TestConditionalInjection<T>, TestConditionalInjection<T>.$Storage>([[WRAPPER_INST]], [[WRAPPED_METATYPE]], [[STORAGE_INST]], {{.*}})
   // CHECK: [[STORAGE_PROP_ACCESS:%.*]] = begin_access [modify] [dynamic] [[STORAGE_PROP]]
-  // CHECK: copy_addr [take] [[WRAPPER_INST]] to [initialization] [[STORAGE_PROP_ACCESS]]
+  // CHECK: copy_addr [take] [[WRAPPER_INST]] to [init] [[STORAGE_PROP_ACCESS]]
   // CHECK: end_access [[STORAGE_PROP_ACCESS]]
   // CHECK: end_borrow [[SELF_ACCESS]]
   // CHECK: dealloc_stack [[B_VAL]]
@@ -210,12 +210,12 @@ class TestConditionalInjection<T> {
 
   // CHECK: [[STORAGE_INIT_NIL]]:
   // CHECK: [[B_PROP:%.*]] = tuple_element_addr [[LOCAL_STORAGE]] : $*(b: Optional<T>), 0
-  // CHECK: assign_by_wrapper origin type_wrapper, {{.*}} : $*Optional<T> to [initialization] [[B_PROP]] : $*Optional<T>, set {{.*}} : $@callee_guaranteed (@in Optional<T>) -> ()
+  // CHECK: assign_by_wrapper origin type_wrapper, {{.*}} : $*Optional<T> to [init] [[B_PROP]] : $*Optional<T>, set {{.*}} : $@callee_guaranteed (@in Optional<T>) -> ()
   // CHECK: [[STORAGE_INIT_REF:%.*]] = function_ref @$s4test24TestConditionalInjectionC8$StorageV1bAEyx_GxSg_tcfC
   // CHECK: [[LOCAL_STORAGE_ACCESS:%.*]] = begin_access [read] [unsafe] [[LOCAL_STORAGE:%.*]] : $*(b: Optional<T>)
   // CHECK: [[B_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE_ACCESS]] : $*(b: Optional<T>), 0
   // CHECK: [[B_VAL:%.*]] = alloc_stack $Optional<T>
-  // CHECK: copy_addr [[B_REF]] to [initialization] [[B_VAL]] : $*Optional<T>
+  // CHECK: copy_addr [[B_REF]] to [init] [[B_VAL]] : $*Optional<T>
   // CHECK: end_access [[LOCAL_STORAGE_ACCESS]] : $*(b: Optional<T>)
   // CHECK: {{.*}} = apply [[STORAGE_INIT_REF]]<T>([[STORAGE_INST:%.*]], [[B_VAL]], {{.*}}) : $@convention(method) <τ_0_0> (@in Optional<τ_0_0>, @thin TestConditionalInjection<τ_0_0>.$Storage.Type) -> @out TestConditionalInjection<τ_0_0>.$Storage
   // CHECK: [[SELF_ACCESS:%.*]] = begin_borrow [[SELF:%.*]] : $TestConditionalInjection<T>
@@ -224,7 +224,7 @@ class TestConditionalInjection<T> {
   // CHECK: [[WRAPPER_INST:%.*]] = alloc_stack $Wrapper<TestConditionalInjection<T>, TestConditionalInjection<T>.$Storage>
   // CHECK: {{.*}} = apply [[WRAPPER_INIT_REF:%.*]]<TestConditionalInjection<T>, TestConditionalInjection<T>.$Storage>([[WRAPPER_INST]], [[WRAPPED_METATYPE]], [[STORAGE_INST]], {{.*}})
   // CHECK: [[STORAGE_PROP_ACCESS:%.*]] = begin_access [modify] [dynamic] [[STORAGE_PROP]]
-  // CHECK: copy_addr [take] [[WRAPPER_INST]] to [initialization] [[STORAGE_PROP_ACCESS]]
+  // CHECK: copy_addr [take] [[WRAPPER_INST]] to [init] [[STORAGE_PROP_ACCESS]]
   // CHECK: end_access [[STORAGE_PROP_ACCESS]]
   // CHECK: end_borrow [[SELF_ACCESS]]
   // CHECK: dealloc_stack [[B_VAL]]
@@ -244,17 +244,17 @@ class TestConditionalInjection<T> {
 
   // CHECK: [[V_SOME]]:
   // CHECK: [[V_VAL:%.*]] = unchecked_take_enum_data_addr [[V]] : $*Optional<T>, #Optional.some!enumelt
-  // CHECK: copy_addr [take] [[V_VAL:%.*]] to [initialization] [[T:%.*]] : $*T
+  // CHECK: copy_addr [take] [[V_VAL:%.*]] to [init] [[T:%.*]] : $*T
   // CHECK: br [[STORAGE_INIT_SOME:bb[0-9]+]]
 
   // CHECK: [[STORAGE_INIT_SOME]]:
   // CHECK: [[B_PROP:%.*]] = tuple_element_addr [[LOCAL_STORAGE]] : $*(b: Optional<T>), 0
-  // CHECK: assign_by_wrapper origin type_wrapper, {{.*}} : $*Optional<T> to [initialization] [[B_PROP]] : $*Optional<T>, set {{.*}} : $@callee_guaranteed (@in Optional<T>) -> ()
+  // CHECK: assign_by_wrapper origin type_wrapper, {{.*}} : $*Optional<T> to [init] [[B_PROP]] : $*Optional<T>, set {{.*}} : $@callee_guaranteed (@in Optional<T>) -> ()
   // CHECK: [[STORAGE_INIT_REF:%.*]] = function_ref @$s4test24TestConditionalInjectionC8$StorageV1bAEyx_GxSg_tcfC
   // CHECK: [[LOCAL_STORAGE_ACCESS:%.*]] = begin_access [read] [unsafe] [[LOCAL_STORAGE:%.*]] : $*(b: Optional<T>)
   // CHECK: [[B_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE_ACCESS]] : $*(b: Optional<T>), 0
   // CHECK: [[B_VAL:%.*]] = alloc_stack $Optional<T>
-  // CHECK: copy_addr [[B_REF]] to [initialization] [[B_VAL]] : $*Optional<T>
+  // CHECK: copy_addr [[B_REF]] to [init] [[B_VAL]] : $*Optional<T>
   // CHECK: end_access [[LOCAL_STORAGE_ACCESS]] : $*(b: Optional<T>)
   // CHECK: {{.*}} = apply [[STORAGE_INIT_REF]]<T>([[STORAGE_INST:%.*]], [[B_VAL]], {{.*}}) : $@convention(method) <τ_0_0> (@in Optional<τ_0_0>, @thin TestConditionalInjection<τ_0_0>.$Storage.Type) -> @out TestConditionalInjection<τ_0_0>.$Storage
   // CHECK: [[SELF_ACCESS:%.*]] = begin_borrow [[SELF:%.*]] : $TestConditionalInjection<T>
@@ -263,7 +263,7 @@ class TestConditionalInjection<T> {
   // CHECK: [[WRAPPER_INST:%.*]] = alloc_stack $Wrapper<TestConditionalInjection<T>, TestConditionalInjection<T>.$Storage>
   // CHECK: {{.*}} = apply [[WRAPPER_INIT_REF:%.*]]<TestConditionalInjection<T>, TestConditionalInjection<T>.$Storage>([[WRAPPER_INST]], [[WRAPPED_METATYPE]], [[STORAGE_INST]], {{.*}})
   // CHECK: [[STORAGE_PROP_ACCESS:%.*]] = begin_access [modify] [dynamic] [[STORAGE_PROP]]
-  // CHECK: copy_addr [take] [[WRAPPER_INST]] to [initialization] [[STORAGE_PROP_ACCESS]]
+  // CHECK: copy_addr [take] [[WRAPPER_INST]] to [init] [[STORAGE_PROP_ACCESS]]
   // CHECK: end_access [[STORAGE_PROP_ACCESS]]
   // CHECK: end_borrow [[SELF_ACCESS]]
   // CHECK: dealloc_stack [[B_VAL]]
@@ -271,12 +271,12 @@ class TestConditionalInjection<T> {
 
   // CHECK: [[STORAGE_INIT_NIL]]:
   // CHECK: [[B_PROP:%.*]] = tuple_element_addr [[LOCAL_STORAGE]] : $*(b: Optional<T>), 0
-  // CHECK: assign_by_wrapper origin type_wrapper, {{.*}} : $*Optional<T> to [initialization] [[B_PROP]] : $*Optional<T>, set {{.*}} : $@callee_guaranteed (@in Optional<T>) -> ()
+  // CHECK: assign_by_wrapper origin type_wrapper, {{.*}} : $*Optional<T> to [init] [[B_PROP]] : $*Optional<T>, set {{.*}} : $@callee_guaranteed (@in Optional<T>) -> ()
   // CHECK: [[STORAGE_INIT_REF:%.*]] = function_ref @$s4test24TestConditionalInjectionC8$StorageV1bAEyx_GxSg_tcfC
   // CHECK: [[LOCAL_STORAGE_ACCESS:%.*]] = begin_access [read] [unsafe] [[LOCAL_STORAGE:%.*]] : $*(b: Optional<T>)
   // CHECK: [[B_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE_ACCESS]] : $*(b: Optional<T>), 0
   // CHECK: [[B_VAL:%.*]] = alloc_stack $Optional<T>
-  // CHECK: copy_addr [[B_REF]] to [initialization] [[B_VAL]] : $*Optional<T>
+  // CHECK: copy_addr [[B_REF]] to [init] [[B_VAL]] : $*Optional<T>
   // CHECK: end_access [[LOCAL_STORAGE_ACCESS]] : $*(b: Optional<T>)
   // CHECK: {{.*}} = apply [[STORAGE_INIT_REF]]<T>([[STORAGE_INST:%.*]], [[B_VAL]], {{.*}}) : $@convention(method) <τ_0_0> (@in Optional<τ_0_0>, @thin TestConditionalInjection<τ_0_0>.$Storage.Type) -> @out TestConditionalInjection<τ_0_0>.$Storage
   // CHECK: [[SELF_ACCESS:%.*]] = begin_borrow [[SELF:%.*]] : $TestConditionalInjection<T>
@@ -285,7 +285,7 @@ class TestConditionalInjection<T> {
   // CHECK: [[WRAPPER_INST:%.*]] = alloc_stack $Wrapper<TestConditionalInjection<T>, TestConditionalInjection<T>.$Storage>
   // CHECK: {{.*}} = apply [[WRAPPER_INIT_REF:%.*]]<TestConditionalInjection<T>, TestConditionalInjection<T>.$Storage>([[WRAPPER_INST]], [[WRAPPED_METATYPE]], [[STORAGE_INST]], {{.*}})
   // CHECK: [[STORAGE_PROP_ACCESS:%.*]] = begin_access [modify] [dynamic] [[STORAGE_PROP]]
-  // CHECK: copy_addr [take] [[WRAPPER_INST]] to [initialization] [[STORAGE_PROP_ACCESS]]
+  // CHECK: copy_addr [take] [[WRAPPER_INST]] to [init] [[STORAGE_PROP_ACCESS]]
   // CHECK: end_access [[STORAGE_PROP_ACCESS]]
   // CHECK: dealloc_stack [[B_VAL]]
   // CHECK: dealloc_stack [[STORAGE_INST]]
@@ -354,7 +354,7 @@ struct TypeWithLetProperties<T> {
   public init(a: T, b: Int? = nil, onSet: (() -> Void)? = nil) {
     // CHECK: [[LOCAL_STORAGE_ACCESS:%.*]] = begin_access [modify] [static] [[LOCAL_STORAGE]] : $*(a: T, b: Int)
     // CHECK-NEXT: [[A_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE_ACCESS]] : $*(a: T, b: Int), 0
-    // CHECK-NEXT: copy_addr [take] %11 to [initialization] [[A_REF]] : $*T
+    // CHECK-NEXT: copy_addr [take] %11 to [init] [[A_REF]] : $*T
     // CHECK-NOT: {{.*}} = assign_by_wrapper {{.*}}
     // CHECK-NEXT: end_access [[LOCAL_STORAGE_ACCESS]]
     self.a = a
@@ -371,7 +371,7 @@ struct TypeWithLetProperties<T> {
       // CHECK: [[LOCAL_STORAGE_ACCESS:%.*]] = begin_access [read] [unsafe] [[LOCAL_STORAGE]] : $*(a: T, b: Int)
       // CHECK-NEXT: [[A_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE_ACCESS]] : $*(a: T, b: Int), 0
       // CHECK-NEXT: [[T:%.*]] = alloc_stack $T
-      // CHECK-NEXT: copy_addr [[A_REF]] to [initialization] [[T]] : $*T
+      // CHECK-NEXT: copy_addr [[A_REF]] to [init] [[T]] : $*T
       // CHECK-NEXT: [[B_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE_ACCESS]] : $*(a: T, b: Int), 1
       // CHECK-NEXT: [[B_VAL:%.*]] = load [trivial] [[B_REF]] : $*Int
       // CHECK-NEXT: end_access [[LOCAL_STORAGE_ACCESS]] : $*(a: T, b: Int)
@@ -386,7 +386,7 @@ struct TypeWithLetProperties<T> {
       // CHECK-NEXT: {{.*}} = apply [[WRAPPER_INIT_REF]]<TypeWithLetProperties<T>, TypeWithLetProperties<T>.$Storage>([[WRAPPER_INST]], [[WRAPPED_METATYPE]], [[STORAGE]], [[WRAPPER_METATYPE:%.*]])
 
       // CHECK: [[STORAGE_PROP_ACCESS:%.*]] = begin_access [modify] [dynamic] [[STORAGE_PROP]]
-      // CHECK-NEXT: copy_addr [take] [[WRAPPER_INST]] to [initialization] [[STORAGE_PROP_ACCESS]]
+      // CHECK-NEXT: copy_addr [take] [[WRAPPER_INST]] to [init] [[STORAGE_PROP_ACCESS]]
       // CHECK-NEXT: end_access [[STORAGE_PROP_ACCESS]]
       self.b = b
     } else {
@@ -402,7 +402,7 @@ struct TypeWithLetProperties<T> {
       // CHECK: [[LOCAL_STORAGE_ACCESS:%.*]] = begin_access [read] [unsafe] [[LOCAL_STORAGE]] : $*(a: T, b: Int)
       // CHECK-NEXT: [[A_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE_ACCESS]] : $*(a: T, b: Int), 0
       // CHECK-NEXT: [[T:%.*]] = alloc_stack $T
-      // CHECK-NEXT: copy_addr [[A_REF]] to [initialization] [[T]] : $*T
+      // CHECK-NEXT: copy_addr [[A_REF]] to [init] [[T]] : $*T
       // CHECK-NEXT: [[B_REF:%.*]] = tuple_element_addr [[LOCAL_STORAGE_ACCESS]] : $*(a: T, b: Int), 1
       // CHECK-NEXT: [[B_VAL:%.*]] = load [trivial] [[B_REF]] : $*Int
       // CHECK-NEXT: end_access [[LOCAL_STORAGE_ACCESS]] : $*(a: T, b: Int)
@@ -417,7 +417,7 @@ struct TypeWithLetProperties<T> {
       // CHECK-NEXT: {{.*}} = apply [[WRAPPER_INIT_REF]]<TypeWithLetProperties<T>, TypeWithLetProperties<T>.$Storage>([[WRAPPER_INST]], [[WRAPPED_METATYPE]], [[STORAGE]], [[WRAPPER_METATYPE:%.*]])
 
       // CHECK: [[STORAGE_PROP_ACCESS:%.*]] = begin_access [modify] [dynamic] [[STORAGE_PROP]]
-      // CHECK-NEXT: copy_addr [take] [[WRAPPER_INST]] to [initialization] [[STORAGE_PROP_ACCESS]]
+      // CHECK-NEXT: copy_addr [take] [[WRAPPER_INST]] to [init] [[STORAGE_PROP_ACCESS]]
       // CHECK-NEXT: end_access [[STORAGE_PROP_ACCESS]]
       self.b = 0
     }

--- a/test/Serialization/Inputs/def_basic.sil
+++ b/test/Serialization/Inputs/def_basic.sil
@@ -249,12 +249,12 @@ bb0(%0 : $*Runcible, %1 : $*Bendable & Runcible):
   // CHECK: alloc_box
   %2 = alloc_box $<τ_0_0> { var τ_0_0 } <(Bendable & Runcible)>
   %2a = project_box %2 : $<τ_0_0> { var τ_0_0 } <Bendable & Runcible>, 0
-  // CHECK: copy_addr [take] {{.*}} to [initialization] {{.*}} : $*any Bendable & Runcible
-  copy_addr [take] %1 to [initialization] %2a : $*Bendable & Runcible
+  // CHECK: copy_addr [take] {{.*}} to [init] {{.*}} : $*any Bendable & Runcible
+  copy_addr [take] %1 to [init] %2a : $*Bendable & Runcible
   // CHECK: alloc_stack
   %4 = alloc_stack $Bendable & Runcible
-  // CHECK: copy_addr {{.*}} to [initialization] {{.*}} : $*any Bendable & Runcible
-  copy_addr %2a to [initialization] %4 : $*Bendable & Runcible
+  // CHECK: copy_addr {{.*}} to [init] {{.*}} : $*any Bendable & Runcible
+  copy_addr %2a to [init] %4 : $*Bendable & Runcible
   %7 = tuple ()
   // CHECK: destroy_addr
   destroy_addr %4 : $*Bendable & Runcible
@@ -372,7 +372,7 @@ sil [transparent] [serialized] @test_union_addr_data_case : $@convention(thin) (
 bb0(%0 : $*Gimel, %1 : $*Q):
   // CHECK: {{%.*}} = init_enum_data_addr {{%.*}} : $*Gimel, #Gimel.DataCase!enumelt
   %p = init_enum_data_addr %0 : $*Gimel, #Gimel.DataCase!enumelt
-  copy_addr [take] %1 to [initialization] %p : $*Q
+  copy_addr [take] %1 to [init] %p : $*Q
   inject_enum_addr %0 : $*Gimel, #Gimel.DataCase!enumelt
   %t = tuple ()
   return %t : $()
@@ -560,12 +560,12 @@ sil [transparent] [serialized] @test_existential_metatype : $@convention(thin) (
 bb0(%0 : $*SomeProtocol):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <SomeProtocol>
   %1a = project_box %1 : $<τ_0_0> { var τ_0_0 } <SomeProtocol>, 0
-  // CHECK: copy_addr [take] %0 to [initialization] %{{.*}} : $*any SomeProtocol
-  copy_addr [take] %0 to [initialization] %1a : $*SomeProtocol
+  // CHECK: copy_addr [take] %0 to [init] %{{.*}} : $*any SomeProtocol
+  copy_addr [take] %0 to [init] %1a : $*SomeProtocol
   // CHECK: alloc_stack
   %4 = alloc_stack $SomeProtocol
-  // CHECK: copy_addr %{{.*}} to [initialization] %{{.*}} : $*any SomeProtocol
-  copy_addr %1a to [initialization] %4 : $*SomeProtocol
+  // CHECK: copy_addr %{{.*}} to [init] %{{.*}} : $*any SomeProtocol
+  copy_addr %1a to [init] %4 : $*SomeProtocol
   // CHECK: existential_metatype $@thick any SomeProtocol.Type, {{%.*}} : $*any SomeProtocol
   %6 = existential_metatype $@thick SomeProtocol.Type, %4 : $*SomeProtocol
   destroy_addr %4 : $*SomeProtocol
@@ -1329,7 +1329,7 @@ bb0(%0 : $A):
   %1 = alloc_stack $Any
   %2 = ref_element_addr %0 : $A, #A.property
   %3 = begin_access [dynamic] [read] %2 : $*Any
-  copy_addr %3 to [initialization] %1 : $*Any
+  copy_addr %3 to [init] %1 : $*Any
   end_access %3 : $*Any
   %6 = begin_access [dynamic] [read] [no_nested_conflict] %2 : $*Any
   copy_addr %6 to %1 : $*Any

--- a/validation-test/SILOptimizer/hoist_destroy_addr.sil
+++ b/validation-test/SILOptimizer/hoist_destroy_addr.sil
@@ -156,9 +156,9 @@ bb0(%0 : $Int, %1 : $Range<Int>, %2 : $Range<Int>):
   debug_value %7 : $*Range<Int>, let, name "bounds", argno 2, expr op_deref
   debug_value %10 : $*Range<Int>, let, name "self", argno 3, implicit, expr op_deref
   %15 = alloc_stack $Range<Int>
-  copy_addr %7 to [initialization] %15 : $*Range<Int>
+  copy_addr %7 to [init] %15 : $*Range<Int>
   %17 = alloc_stack $Int
-  copy_addr %4 to [initialization] %17 : $*Int
+  copy_addr %4 to [init] %17 : $*Int
   %19 = string_literal utf8 "Index out of bounds"
   %20 = integer_literal $Builtin.Word, 19
   %21 = builtin "ptrtoint_Word"(%19 : $Builtin.RawPointer) : $Builtin.Word
@@ -192,15 +192,15 @@ bb5:
   %39 = metatype $@thick Int.Type
   %40 = struct_element_addr %15 : $*Range<Int>, #Range.lowerBound
   %41 = alloc_stack $Int
-  copy_addr %40 to [initialization] %41 : $*Int
+  copy_addr %40 to [init] %41 : $*Int
   %43 = witness_method $Int, #Comparable."<=" : <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
   %44 = apply %43<Int>(%41, %17, %39) : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
   destroy_addr %41 : $*Int
   dealloc_stack %41 : $*Int
   %47 = alloc_stack $Int
-  copy_addr %17 to [initialization] %47 : $*Int
+  copy_addr %17 to [init] %47 : $*Int
   %49 = alloc_stack $Range<Int>
-  copy_addr %15 to [initialization] %49 : $*Range<Int>
+  copy_addr %15 to [init] %49 : $*Range<Int>
   %51 = struct_extract %44 : $Bool, #Bool._value
   cond_br %51, bb7, bb8
 
@@ -214,7 +214,7 @@ bb7:
   %57 = metatype $@thick Int.Type
   %58 = struct_element_addr %49 : $*Range<Int>, #Range.upperBound
   %59 = alloc_stack $Int
-  copy_addr %58 to [initialization] %59 : $*Int
+  copy_addr %58 to [init] %59 : $*Int
   %61 = witness_method $Int, #Comparable."<" : <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
   %62 = apply %61<Int>(%47, %59, %57) : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
   destroy_addr %59 : $*Int
@@ -289,15 +289,15 @@ bb18:
   %112 = metatype $@thick Int.Type
   %113 = struct_element_addr %15 : $*Range<Int>, #Range.lowerBound
   %114 = alloc_stack $Int
-  copy_addr %113 to [initialization] %114 : $*Int
+  copy_addr %113 to [init] %114 : $*Int
   %116 = witness_method $Int, #Comparable."<=" : <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
   %117 = apply %116<Int>(%114, %17, %112) : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
   destroy_addr %114 : $*Int
   dealloc_stack %114 : $*Int
   %120 = alloc_stack $Int
-  copy_addr [take] %17 to [initialization] %120 : $*Int
+  copy_addr [take] %17 to [init] %120 : $*Int
   %122 = alloc_stack $Range<Int>
-  copy_addr [take] %15 to [initialization] %122 : $*Range<Int>
+  copy_addr [take] %15 to [init] %122 : $*Range<Int>
   %124 = struct_extract %117 : $Bool, #Bool._value
   cond_br %124, bb20, bb21
 
@@ -310,7 +310,7 @@ bb20:
   %129 = metatype $@thick Int.Type
   %130 = struct_element_addr %122 : $*Range<Int>, #Range.upperBound
   %131 = alloc_stack $Int
-  copy_addr %130 to [initialization] %131 : $*Int
+  copy_addr %130 to [init] %131 : $*Int
   %133 = witness_method $Int, #Comparable."<" : <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
   %134 = apply %133<Int>(%120, %131, %129) : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
   destroy_addr %131 : $*Int
@@ -537,7 +537,7 @@ bb25:
   %147 = metatype $@thin Int64.Type
   %148 = metatype $@thick Int64.Type
   %149 = alloc_stack $Int8
-  copy_addr %4 to [initialization] %149 : $*Int8
+  copy_addr %4 to [init] %149 : $*Int8
   %151 = function_ref @$ss17FixedWidthIntegerPsE18truncatingIfNeededxqd___tcSzRd__lufC : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
   %152 = apply %151<Int64, Int8>(%146, %149, %148) : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
   dealloc_stack %149 : $*Int8
@@ -552,7 +552,7 @@ bb26:
   %160 = metatype $@thin UInt64.Type
   %161 = metatype $@thick UInt64.Type
   %162 = alloc_stack $Int8
-  copy_addr %4 to [initialization] %162 : $*Int8
+  copy_addr %4 to [init] %162 : $*Int8
   %164 = function_ref @$ss17FixedWidthIntegerPsE18truncatingIfNeededxqd___tcSzRd__lufC : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
   %165 = apply %164<UInt64, Int8>(%159, %162, %161) : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
   dealloc_stack %162 : $*Int8
@@ -601,7 +601,7 @@ bb30:
   %203 = witness_method $Int8, #BinaryInteger.isSigned!getter : <Self where Self : BinaryInteger> (Self.Type) -> () -> Bool : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
   %204 = apply %203<Int8>(%202) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
   %205 = alloc_stack $Int8
-  copy_addr %4 to [initialization] %205 : $*Int8
+  copy_addr %4 to [init] %205 : $*Int8
   %207 = struct_extract %204 : $Bool, #Bool._value
   cond_br %207, bb31, bb32
 
@@ -647,14 +647,14 @@ bb33(%230 : $Bool):
 
 bb34:
   %245 = alloc_stack $UInt8
-  copy_addr %233 to [initialization] %245 : $*UInt8
+  copy_addr %233 to [init] %245 : $*UInt8
   %247 = integer_literal $Builtin.Int64, 0
   %248 = struct $Int (%247 : $Builtin.Int64)
   %249 = metatype $@thick UInt8.Type
   %250 = witness_method $UInt8, #BinaryInteger.isSigned!getter : <Self where Self : BinaryInteger> (Self.Type) -> () -> Bool : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
   %251 = apply %250<UInt8>(%249) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
   %252 = alloc_stack $UInt8
-  copy_addr %245 to [initialization] %252 : $*UInt8
+  copy_addr %245 to [init] %252 : $*UInt8
   %254 = struct_extract %251 : $Bool, #Bool._value
   cond_br %254, bb35, bb36
 
@@ -743,7 +743,7 @@ bb44:
   %322 = alloc_stack $UInt8, let, name "quotient"
   %323 = alloc_stack $UInt8, let, name "remainder"
   %324 = alloc_stack $UInt8
-  copy_addr %233 to [initialization] %324 : $*UInt8
+  copy_addr %233 to [init] %324 : $*UInt8
   %326 = function_ref @$sSzsE12_description5radix9uppercaseSSSi_SbtF21_quotientAndRemainderL_y9MagnitudeQz_AFtAFSzRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0.Magnitude, Bool, Int, @in_guaranteed τ_0_0.Magnitude) -> (@out τ_0_0.Magnitude, @out τ_0_0.Magnitude)
   %327 = apply %326<Int8>(%322, %323, %324, %188, %0, %190) : $@convention(thin) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0.Magnitude, Bool, Int, @in_guaranteed τ_0_0.Magnitude) -> (@out τ_0_0.Magnitude, @out τ_0_0.Magnitude)
   destroy_addr %324 : $*UInt8
@@ -752,7 +752,7 @@ bb44:
   %331 = metatype $@thin UInt8.Type
   %332 = metatype $@thick UInt8.Type
   %333 = alloc_stack $UInt8
-  copy_addr %323 to [initialization] %333 : $*UInt8
+  copy_addr %323 to [init] %333 : $*UInt8
   %335 = function_ref @$ss17FixedWidthIntegerPsE18truncatingIfNeededxqd___tcSzRd__lufC : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
   %336 = apply %335<UInt8, UInt8>(%330, %333, %332) : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
   dealloc_stack %333 : $*UInt8
@@ -766,7 +766,7 @@ bb44:
   %345 = apply %344<UInt8>(%342, %236) : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Array<τ_0_0>) -> ()
   dealloc_stack %342 : $*UInt8
   destroy_addr %233 : $*UInt8
-  copy_addr %322 to [initialization] %233 : $*UInt8
+  copy_addr %322 to [init] %233 : $*UInt8
   destroy_addr %323 : $*UInt8
   dealloc_stack %323 : $*UInt8
   destroy_addr %322 : $*UInt8
@@ -837,7 +837,7 @@ bb51:
   %404 = alloc_stack $Int
   %405 = metatype $@thick Int.Type
   %406 = alloc_stack $UInt8
-  copy_addr %245 to [initialization] %406 : $*UInt8
+  copy_addr %245 to [init] %406 : $*UInt8
   %408 = function_ref @$ss17FixedWidthIntegerPsE18truncatingIfNeededxqd___tcSzRd__lufC : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
   %409 = apply %408<Int, UInt8>(%404, %406, %405) : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
   %410 = tuple ()
@@ -890,7 +890,7 @@ bb55:
   %449 = alloc_stack $Int
   %450 = metatype $@thick Int.Type
   %451 = alloc_stack $UInt8
-  copy_addr %245 to [initialization] %451 : $*UInt8
+  copy_addr %245 to [init] %451 : $*UInt8
   %453 = function_ref @$ss17FixedWidthIntegerPsE18truncatingIfNeededxqd___tcSzRd__lufC : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
   %454 = apply %453<Int, UInt8>(%449, %451, %450) : $@convention(method) <τ_0_0 where τ_0_0 : FixedWidthInteger><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick τ_0_0.Type) -> @out τ_0_0
   %455 = tuple ()
@@ -1174,7 +1174,7 @@ bb18:
   %149 = witness_method $T, #BinaryInteger.isSigned!getter : <Self where Self : BinaryInteger> (Self.Type) -> () -> Bool : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
   %150 = apply %149<T>(%148) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
   %151 = alloc_stack $T
-  copy_addr %0 to [initialization] %151 : $*T
+  copy_addr %0 to [init] %151 : $*T
   %153 = struct_extract %150 : $Bool, #Bool._value
   cond_br %153, bb19, bb20
 
@@ -1223,14 +1223,14 @@ bb21(%176 : $Bool):
 
 bb22:
   %198 = alloc_stack $T.Magnitude
-  copy_addr %179 to [initialization] %198 : $*T.Magnitude
+  copy_addr %179 to [init] %198 : $*T.Magnitude
   %200 = integer_literal $Builtin.Int64, 0
   %201 = struct $Int (%200 : $Builtin.Int64)
   %202 = metatype $@thick T.Magnitude.Type
   %203 = witness_method $T.Magnitude, #BinaryInteger.isSigned!getter : <Self where Self : BinaryInteger> (Self.Type) -> () -> Bool : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
   %204 = apply %203<T.Magnitude>(%202) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@thick τ_0_0.Type) -> Bool
   %205 = alloc_stack $T.Magnitude
-  copy_addr %198 to [initialization] %205 : $*T.Magnitude
+  copy_addr %198 to [init] %205 : $*T.Magnitude
   %207 = struct_extract %204 : $Bool, #Bool._value
   cond_br %207, bb23, bb24
 
@@ -1334,8 +1334,8 @@ bb31:
   destroy_addr %179 : $*T.Magnitude
   %296 = tuple_element_addr %254 : $*(T.Magnitude, T.Magnitude), 0
   %297 = tuple_element_addr %254 : $*(T.Magnitude, T.Magnitude), 1
-  copy_addr [take] %291 to [initialization] %296 : $*T.Magnitude
-  copy_addr [take] %292 to [initialization] %297 : $*T.Magnitude
+  copy_addr [take] %291 to [init] %296 : $*T.Magnitude
+  copy_addr [take] %292 to [init] %297 : $*T.Magnitude
   dealloc_stack %292 : $*T.Magnitude
   dealloc_stack %291 : $*T.Magnitude
   br bb32
@@ -1343,8 +1343,8 @@ bb31:
 bb32:
   %303 = tuple_element_addr %254 : $*(T.Magnitude, T.Magnitude), 0
   %304 = tuple_element_addr %254 : $*(T.Magnitude, T.Magnitude), 1
-  copy_addr [take] %303 to [initialization] %248 : $*T.Magnitude
-  copy_addr [take] %304 to [initialization] %249 : $*T.Magnitude
+  copy_addr [take] %303 to [init] %248 : $*T.Magnitude
+  copy_addr [take] %304 to [init] %249 : $*T.Magnitude
   dealloc_stack %254 : $*(T.Magnitude, T.Magnitude)
   %309 = witness_method $T.Magnitude, #BinaryInteger._lowWord!getter : <Self where Self : BinaryInteger> (Self) -> () -> UInt : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> UInt
   %310 = apply %309<T.Magnitude>(%249) : $@convention(witness_method: BinaryInteger) <τ_0_0 where τ_0_0 : BinaryInteger> (@in_guaranteed τ_0_0) -> UInt
@@ -1489,7 +1489,7 @@ bb47:
   %441 = apply %440(%435, %343, %182) : $@convention(method) (Int, UInt8, @inout Array<UInt8>) -> ()
   %442 = function_ref @$sSa12_endMutationyyFs5UInt8V_Tg5 : $@convention(method) (@inout Array<UInt8>) -> ()
   %443 = apply %442(%182) : $@convention(method) (@inout Array<UInt8>) -> ()
-  copy_addr [take] %248 to [initialization] %179 : $*T.Magnitude
+  copy_addr [take] %248 to [init] %179 : $*T.Magnitude
   dealloc_stack %249 : $*T.Magnitude
   dealloc_stack %248 : $*T.Magnitude
   br bb22
@@ -1820,9 +1820,9 @@ bb0(%0 : $*LazyPrefixWhileSequence<Base>.Index, %1 : $*Base, %2 : $@thin LazyPre
   inject_enum_addr %7 : $*LazyPrefixWhileSequence<Base>._IndexRepresentation, #LazyPrefixWhileSequence._IndexRepresentation.pastEnd!enumelt 
   %9 = struct_element_addr %4 : $*LazyPrefixWhileSequence<Base>.Index, #LazyPrefixWhileSequence.Index._value 
   destroy_addr %1 : $*Base                        
-  copy_addr [take] %7 to [initialization] %9 : $*LazyPrefixWhileSequence<Base>._IndexRepresentation 
+  copy_addr [take] %7 to [init] %9 : $*LazyPrefixWhileSequence<Base>._IndexRepresentation 
   dealloc_stack %7 : $*LazyPrefixWhileSequence<Base>._IndexRepresentation 
-  copy_addr [take] %4 to [initialization] %0 : $*LazyPrefixWhileSequence<Base>.Index 
+  copy_addr [take] %4 to [init] %0 : $*LazyPrefixWhileSequence<Base>.Index 
   dealloc_stack %4 : $*LazyPrefixWhileSequence<Base>.Index 
   %14 = tuple ()                                  
   return %14 : $()                                
@@ -1844,15 +1844,15 @@ bb0(%0 : $Range<Int>, %1 : $Int, %2 : $@noescape @callee_guaranteed @substituted
   debug_value %3 : $*Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>, var, name "self", argno 4, implicit, expr op_deref
   debug_value undef : $Error, var, name "$error", argno 5
   %15 = alloc_stack $Int, var, name "sortedEnd"
-  copy_addr %8 to [initialization] %15 : $*Int
+  copy_addr %8 to [init] %15 : $*Int
   br bb1
 
 bb1:
   %18 = alloc_stack $Int
-  copy_addr %15 to [initialization] %18 : $*Int
+  copy_addr %15 to [init] %18 : $*Int
   %20 = struct_element_addr %5 : $*Range<Int>, #Range.upperBound
   %21 = alloc_stack $Int
-  copy_addr %20 to [initialization] %21 : $*Int
+  copy_addr %20 to [init] %21 : $*Int
   %23 = metatype $@thick Int.Type
   %24 = witness_method $Int, #Equatable."==" : <Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
   %25 = apply %24<Int>(%18, %21, %23) : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
@@ -1867,7 +1867,7 @@ bb1:
 
 bb2:
   %34 = alloc_stack $Int, var, name "i"
-  copy_addr %15 to [initialization] %34 : $*Int
+  copy_addr %15 to [init] %34 : $*Int
   br bb4
 
 bb3:
@@ -1885,12 +1885,12 @@ bb4:
   %46 = witness_method $Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>, #Collection.subscript!read : <Self where Self : Collection> (Self) -> (Self.Index) -> () : $@yield_once @convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @yields @in_guaranteed τ_0_0.Element
   (%47, %48) = begin_apply %46<Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>>(%34, %3) : $@yield_once @convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @yields @in_guaranteed τ_0_0.Element
   %49 = alloc_stack $(scalar: Unicode.Scalar, normData: Unicode._NormData)
-  copy_addr %47 to [initialization] %49 : $*(scalar: Unicode.Scalar, normData: Unicode._NormData)
+  copy_addr %47 to [init] %49 : $*(scalar: Unicode.Scalar, normData: Unicode._NormData)
   end_apply %48
   %52 = witness_method $Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>, #Collection.subscript!read : <Self where Self : Collection> (Self) -> (Self.Index) -> () : $@yield_once @convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @yields @in_guaranteed τ_0_0.Element
   (%53, %54) = begin_apply %52<Array<(scalar: Unicode.Scalar, normData: Unicode._NormData)>>(%43, %3) : $@yield_once @convention(witness_method: Collection) <τ_0_0 where τ_0_0 : Collection> (@in_guaranteed τ_0_0.Index, @in_guaranteed τ_0_0) -> @yields @in_guaranteed τ_0_0.Element
   %55 = alloc_stack $(scalar: Unicode.Scalar, normData: Unicode._NormData)
-  copy_addr %53 to [initialization] %55 : $*(scalar: Unicode.Scalar, normData: Unicode._NormData)
+  copy_addr %53 to [init] %55 : $*(scalar: Unicode.Scalar, normData: Unicode._NormData)
   end_apply %54
   try_apply %2(%49, %55) : $@noescape @callee_guaranteed @substituted <τ_0_0, τ_0_1> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_1) -> (Bool, @error Error) for <(scalar: Unicode.Scalar, normData: Unicode._NormData), (scalar: Unicode.Scalar, normData: Unicode._NormData)>, normal bb5, error bb6
 
@@ -1931,10 +1931,10 @@ bb8:
   destroy_addr %43 : $*Int
   dealloc_stack %43 : $*Int
   %90 = alloc_stack $Int
-  copy_addr %34 to [initialization] %90 : $*Int
+  copy_addr %34 to [init] %90 : $*Int
   %92 = struct_element_addr %5 : $*Range<Int>, #Range.lowerBound
   %93 = alloc_stack $Int
-  copy_addr %92 to [initialization] %93 : $*Int
+  copy_addr %92 to [init] %93 : $*Int
   %95 = metatype $@thick Int.Type
   %96 = witness_method $Int, #Equatable."==" : <Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool
   %97 = apply %96<Int>(%90, %93, %95) : $@convention(witness_method: Equatable) <τ_0_0 where τ_0_0 : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Bool


### PR DESCRIPTION
Instead of writing out `[initalization]` for some instructions, use `[init]` everywhere.
