### PR TITLE
CMake: Break some dependency cycles between compiler libraries

### DIFF
--- a/lib/FrontendTool/CMakeLists.txt
+++ b/lib/FrontendTool/CMakeLists.txt
@@ -17,7 +17,6 @@ target_link_libraries(swiftFrontendTool PRIVATE
     swiftDemangling
     swiftDependencyScan
     swiftFrontend
-    swiftIDE
     swiftImmediate
     swiftIndex
     swiftIRGen

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -73,7 +73,6 @@ target_link_libraries(swiftIRGen PRIVATE
   swiftLLVMPasses
   swiftSIL
   swiftSILGen
-  swiftSILOptimizer
-  swiftTBDGen)
+  swiftSILOptimizer)
 
 set_swift_llvm_is_available(swiftIRGen)

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -3,8 +3,7 @@ add_swift_host_library(swiftSIL STATIC
 target_link_libraries(swiftSIL PUBLIC
   swiftDemangling)
 target_link_libraries(swiftSIL PRIVATE
-  swiftSema
-  swiftSerialization)
+  swiftSema)
 
 add_subdirectory(IR)
 add_subdirectory(Utils)


### PR DESCRIPTION
- Remove cycle between `swiftIRGen` and `swiftTBGen`.
- Remove cycle between `swiftSIL` and `swiftSerialization`.
- Remove cycle between `swiftFrontendTool` and `swiftIDE`.
