### PR TITLE
[TypeResolution] Enable local variable packs.

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4223,7 +4223,7 @@ NeverNullType TypeResolver::resolvePackExpansionType(PackExpansionTypeRepr *repr
     return ErrorType::get(ctx);
 
   // We might not allow variadic expansions here at all.
-  if (!options.isPackExpansionSupported()) {
+  if (!options.isPackExpansionSupported(getDeclContext())) {
     diagnose(repr->getLoc(), diag::expansion_not_allowed, pair.first);
     return ErrorType::get(ctx);
   }

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -311,13 +311,18 @@ public:
   }
 
   /// Whether pack expansion types are supported in this context.
-  bool isPackExpansionSupported() const {
+  bool isPackExpansionSupported(DeclContext *dc) const {
     switch (context) {
     case Context::FunctionInput:
     case Context::VariadicFunctionInput:
     case Context::TupleElement:
     case Context::GenericArgument:
       return true;
+
+    // Local variable packs are supported, but property packs
+    // are not.
+    case Context::PatternBindingDecl:
+      return !dc->isTypeContext();
 
     case Context::None:
     case Context::ProtocolGenericArgument:
@@ -333,7 +338,6 @@ public:
     case Context::InExpression:
     case Context::ExplicitCastExpr:
     case Context::ForEachStmt:
-    case Context::PatternBindingDecl:
     case Context::EditorPlaceholderExpr:
     case Context::ClosureExpr:
     case Context::InoutFunctionInput:

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -33,3 +33,10 @@ func coerceExpansion<T...>(_ value: T...) {
 
   promoteToOptional(value...)
 }
+
+func localValuePack<T...>(_ t: T...) -> (T..., T...) {
+  let local = t...
+  let localAnnotated: T... = t...
+
+  return (local..., localAnnotated...)
+}


### PR DESCRIPTION
Allow resolving type parameter pack references in `TypeResolverContext::PatternBindingDecl` if the pattern binding is in local scope. This is supported by the [parameter packs proposal](https://github.com/hborla/swift-evolution/blob/parameter-packs/proposals/NNNN-parameter-packs.md#pack-expansion-vs-postfix-closed-range-operator).