### PR TITLE
[cxx-interop] Fix crash when lowering self arg in foriegn reference t…

### DIFF
--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1526,7 +1526,10 @@ private:
       convention = Convs.getIndirect(ownership, forSelf, origParamIndex,
                                      origType, substTLConv);
       assert(isIndirectFormalParameter(convention));
-    } else if (substTL.isTrivial()) {
+    } else if (substTL.isTrivial() ||
+               // Foreign reference types are passed trivially.
+               (substType->getClassOrBoundGenericClass() &&
+                substType->isForeignReferenceType())) {
       convention = ParameterConvention::Direct_Unowned;
     } else {
       // If we are no implicit copy, our ownership is always Owned.

--- a/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
+++ b/test/Interop/Cxx/foreign-reference/Inputs/reference-counted.h
@@ -21,6 +21,9 @@ __attribute__((swift_attr("release:LCRelease"))) LocalCount {
   static LocalCount *create() {
     return new (malloc(sizeof(LocalCount))) LocalCount();
   }
+
+  int returns42() { return 42; }
+  int constMethod() const { return 42; }
 };
 
 }

--- a/test/Interop/Cxx/foreign-reference/reference-counted.swift
+++ b/test/Interop/Cxx/foreign-reference/reference-counted.swift
@@ -19,6 +19,9 @@ func localTest() {
     var x = NS.LocalCount.create()
     expectEqual(x.value, 6) // This is 6 because of "var x" "x.value" * 2 and "(x, x, x)".
 
+    expectEqual(x.returns42(), 42)
+    expectEqual(x.constMethod(), 42)
+
     let t = (x, x, x)
     expectEqual(x.value, 5)
 }


### PR DESCRIPTION
…ype method call.

Fixes https://github.com/apple/swift/issues/61627