### PR TITLE
Avoid concurrency-related adjustments during witness matching

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2427,8 +2427,9 @@ ConstraintSystem::getTypeOfMemberReference(
 
   // Adjust the opened type for concurrency.
   Type origOpenedType = openedType;
-  if ((isa<AbstractFunctionDecl>(value) || isa<EnumElementDecl>(value)) &&
-      !isRequirementOrWitness(locator)) {
+  if (isRequirementOrWitness(locator)) {
+    // Don't adjust when doing witness matching, because that can cause cycles.
+  } else if (isa<AbstractFunctionDecl>(value) || isa<EnumElementDecl>(value)) {
     unsigned numApplies = getNumApplications(
         value, hasAppliedSelf, functionRefKind);
     openedType = adjustFunctionTypeForConcurrency(

--- a/test/Concurrency/actor_isolation_cycle.swift
+++ b/test/Concurrency/actor_isolation_cycle.swift
@@ -10,3 +10,20 @@ public struct S : P {
   public func g(_: Int) {}
   public func f(_: T) {}
 }
+
+// https://github.com/apple/swift/issues/61602
+@available(SwiftStdlib 5.1, *)
+@MainActor protocol ProtocolWithAssociatedTypes {
+    associatedtype ID: Hashable
+    associatedtype Value
+
+    subscript(_ id: ID) -> Value { get set }
+}
+
+@available(SwiftStdlib 5.1, *)
+final class ClassConforming<ID: Hashable,Value>: ProtocolWithAssociatedTypes {
+    subscript(id: ID) -> Value {
+        get { fatalError() }
+        set { fatalError() }
+    }
+}


### PR DESCRIPTION
We were only applying this logic for some declaration types, not all, which is silly. Fixes https://github.com/apple/swift/issues/61602 / rdar://101243966.
