### PR TITLE
Add option to suppress emission of remarks ('-suppress-remarks')

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -707,6 +707,9 @@ namespace swift {
 
     /// Don't emit any warnings
     bool suppressWarnings = false;
+    
+    /// Don't emit any remarks
+    bool suppressRemarks = false;
 
     /// Emit all warnings as errors
     bool warningsAsErrors = false;
@@ -745,6 +748,10 @@ namespace swift {
     /// Whether to skip emitting warnings
     void setSuppressWarnings(bool val) { suppressWarnings = val; }
     bool getSuppressWarnings() const { return suppressWarnings; }
+    
+    /// Whether to skip emitting remarks
+    void setSuppressRemarks(bool val) { suppressRemarks = val; }
+    bool getSuppressRemarks() const { return suppressRemarks; }
 
     /// Whether to treat warnings as errors
     void setWarningsAsErrors(bool val) { warningsAsErrors = val; }
@@ -763,6 +770,7 @@ namespace swift {
     void swap(DiagnosticState &other) {
       std::swap(showDiagnosticsAfterFatalError, other.showDiagnosticsAfterFatalError);
       std::swap(suppressWarnings, other.suppressWarnings);
+      std::swap(suppressRemarks, other.suppressRemarks);
       std::swap(warningsAsErrors, other.warningsAsErrors);
       std::swap(fatalErrorOccurred, other.fatalErrorOccurred);
       std::swap(anyErrorOccurred, other.anyErrorOccurred);
@@ -878,6 +886,12 @@ namespace swift {
     void setSuppressWarnings(bool val) { state.setSuppressWarnings(val); }
     bool getSuppressWarnings() const {
       return state.getSuppressWarnings();
+    }
+
+    /// Whether to skip emitting remarks
+    void setSuppressRemarks(bool val) { state.setSuppressRemarks(val); }
+    bool getSuppressRemarks() const {
+      return state.getSuppressRemarks();
     }
 
     /// Whether to treat warnings as errors

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -54,6 +54,9 @@ public:
 
   /// Suppress all warnings
   bool SuppressWarnings = false;
+  
+  /// Suppress all remarks
+  bool SuppressRemarks = false;
 
   /// Treat all warnings as errors
   bool WarningsAsErrors = false;

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -478,7 +478,7 @@ private:
   }
   void
   inheritOptionsForBuildingInterface(const SearchPathOptions &SearchPathOpts,
-                                     const LangOptions &LangOpts,
+                                     const LangOptions &LangOpts, bool suppressRemarks,
                                      RequireOSSAModules_t requireOSSAModules);
   bool extractSwiftInterfaceVersionAndArgs(CompilerInvocation &subInvocation,
                                            SmallVectorImpl<const char *> &SubArgs,

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -657,6 +657,10 @@ def warnings_as_errors : Flag<["-"], "warnings-as-errors">,
 def no_warnings_as_errors : Flag<["-"], "no-warnings-as-errors">,
   Flags<[FrontendOption]>,
   HelpText<"Don't treat warnings as errors">;
+  
+def suppress_remarks : Flag<["-"], "suppress-remarks">,
+  Flags<[FrontendOption]>,
+  HelpText<"Suppress all remarks">;
 
 def continue_building_after_errors : Flag<["-"], "continue-building-after-errors">,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1027,6 +1027,11 @@ DiagnosticBehavior DiagnosticState::determineBehavior(const Diagnostic &diag) {
     if (suppressWarnings)
       lvl = DiagnosticBehavior::Ignore;
   }
+  
+  if (lvl == DiagnosticBehavior::Remark) {
+    if (suppressRemarks)
+      lvl = DiagnosticBehavior::Ignore;
+  }
 
   //   5) Update current state for use during the next diagnostic
   if (lvl == DiagnosticBehavior::Fatal) {

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -261,6 +261,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_Rpass_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_Rpass_missed_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_suppress_warnings);
+  inputArgs.AddLastArg(arguments, options::OPT_suppress_remarks);
   inputArgs.AddLastArg(arguments, options::OPT_profile_generate);
   inputArgs.AddLastArg(arguments, options::OPT_profile_use);
   inputArgs.AddLastArg(arguments, options::OPT_profile_coverage_mapping);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1444,6 +1444,7 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
 
   Opts.FixitCodeForAllDiagnostics |= Args.hasArg(OPT_fixit_all);
   Opts.SuppressWarnings |= Args.hasArg(OPT_suppress_warnings);
+  Opts.SuppressRemarks |= Args.hasArg(OPT_suppress_remarks);
   Opts.WarningsAsErrors = Args.hasFlag(options::OPT_warnings_as_errors,
                                        options::OPT_no_warnings_as_errors,
                                        false);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -454,6 +454,9 @@ void CompilerInstance::setUpDiagnosticOptions() {
   if (Invocation.getDiagnosticOptions().SuppressWarnings) {
     Diagnostics.setSuppressWarnings(true);
   }
+  if (Invocation.getDiagnosticOptions().SuppressRemarks) {
+    Diagnostics.setSuppressRemarks(true);
+  }
   if (Invocation.getDiagnosticOptions().WarningsAsErrors) {
     Diagnostics.setWarningsAsErrors(true);
   }

--- a/test/Frontend/SuppressRemarks.swift
+++ b/test/Frontend/SuppressRemarks.swift
@@ -1,0 +1,15 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/../Concurrency/Inputs/OtherActors.swift -disable-availability-checking
+
+// RUN: not %target-swift-frontend -typecheck -I %t %s 2>&1 | %FileCheck -check-prefix=DEFAULT %s
+// RUN: not %target-swift-frontend -typecheck -I %t %s -suppress-remarks 2>&1 | %FileCheck -check-prefix=NOREMARK %s
+
+@preconcurrency import OtherActors
+// DEFAULT:    error: cannot find 'xyz' in scope
+// DEFAULT:    remark: '@preconcurrency' attribute on module 'OtherActors' is unused
+// NORMEARK:    error: cannot find 'xyz' in scope
+// NOREMARK-NOT:    remark: '@preconcurrency' attribute on module 'OtherActors' is unused
+
+func bar() {
+    xyz
+}


### PR DESCRIPTION
And enforce it especially in downstream contexts such as building interfaces of SDK dependencies, where the remarks are not actionable by the user.
