### PR TITLE
tests: enable a couple of C++ value witness table tests

### DIFF
--- a/test/Interop/Cxx/value-witness-table/custom-destructors-virtual-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-virtual-irgen.swift
@@ -3,9 +3,6 @@
 // FIXME: Once we can link with libc++ we can start using RTTI.
 //
 // RUN: %target-swift-frontend -enable-experimental-cxx-interop -I %S/Inputs %s -emit-ir -Xcc -fno-rtti | %FileCheck %s
-//
-// Windows doesn't support -fno-rtti.
-// UNSUPPORTED: OS=windows-msvc
 
 import CustomDestructor
 

--- a/test/Interop/Cxx/value-witness-table/custom-destructors-virtual.swift
+++ b/test/Interop/Cxx/value-witness-table/custom-destructors-virtual.swift
@@ -6,8 +6,7 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xcc -fno-rtti -O)
 //
 // REQUIRES: executable_test
-// Windows doesn't support -fno-rtti.
-// UNSUPPORTED: OS=windows-msvc
+// XFAIL: OS=windows-msvc
 
 import CustomDestructor
 import StdlibUnittest


### PR DESCRIPTION
This enables the IRGen test and marks the dtor tests as XFAIL.  Two of the tests will currently abort (likely due to invalid CodeGen), so mark the test as XFAIL to at least get build coverage.
