### PR TITLE
[ModuleInterface] Report importing modules built from a swiftinterface without resilience

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -988,6 +988,11 @@ ERROR(module_allowable_client_violation,none,
       "module %0 doesn't allow importation from module %1",
       (Identifier, Identifier))
 
+ERROR(import_not_compiled_with_library_evolution_but_rebuilt,none,
+      "module %0 was rebuilt from a swiftinterface without library evolution; "
+      "it cannot be used to build a binary",
+      (Identifier))
+
 REMARK(cross_import_added,none,
        "import of %0 and %1 triggered a cross-import of %2",
        (Identifier, Identifier, Identifier))

--- a/test/DebugInfo/ParseableInterfaceImports.swift
+++ b/test/DebugInfo/ParseableInterfaceImports.swift
@@ -1,9 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-typecheck %S/basic.swift \
 // RUN:    -emit-module-interface-path %t/basic.swiftinterface
-// RUN: %target-swift-frontend -emit-ir -module-name Foo %s -I %t -g -o - \
+// RUN: env SWIFT_ACCEPT_NON_RESILIENT_INTERFACES=1 \
+// RUN:    %target-swift-frontend -emit-ir -module-name Foo %s -I %t -g -o - \
 // RUN:    | %FileCheck %s
-// RUN: %target-swift-frontend -emit-ir -module-name Foo %s -I %t -g -o - \
+// RUN: env SWIFT_ACCEPT_NON_RESILIENT_INTERFACES=1 \
+// RUN:     %target-swift-frontend -emit-ir -module-name Foo %s -I %t -g -o - \
 // RUN:    -sdk %t | %FileCheck %s --check-prefix=SDK
 
 import basic

--- a/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_nongeneric-external-nonresilient.swift
+++ b/test/IRGen/prespecialized-metadata/class-fileprivate-inmodule-1argument-1ancestor-1distinct_use-1st_ancestor_nongeneric-external-nonresilient.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -emit-library -module-name TestModule -module-link-name TestModule %S/Inputs/class-open-0argument.swift -emit-module-interface -swift-version 5 -o %t/%target-library-name(TestModule)
-// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
+// RUN: env SWIFT_ACCEPT_NON_RESILIENT_INTERFACES=1 %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment --check-prefix=CHECK --check-prefix=CHECK-%target-vendor
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios

--- a/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_nonresilient-1distinct_use.swift
+++ b/test/IRGen/prespecialized-metadata/enum-inmodule-1argument-1conformance-external_nonresilient-1distinct_use.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -emit-library -module-name TestModule -module-link-name TestModule %S/Inputs/protocol-public-empty.swift -emit-module-interface -swift-version 5 -o %t/%target-library-name(TestModule)
-// RUN: %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
+// RUN: env SWIFT_ACCEPT_NON_RESILIENT_INTERFACES=1 \
+// RUN:   %target-swift-frontend -prespecialize-generic-metadata -target %module-target-future -emit-ir -I %t -L %t %s | %FileCheck %s -DINT=i%target-ptrsize -DALIGNMENT=%target-alignment
 
 // REQUIRES: VENDOR=apple || OS=linux-gnu
 // UNSUPPORTED: CPU=i386 && OS=ios

--- a/test/Misc/stats_dir_module_interface.swift
+++ b/test/Misc/stats_dir_module_interface.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir %t/stats
 // RUN: mkdir %t/cache
-// RUN: %target-swift-frontend -typecheck %s -I %S/Inputs -stats-output-dir %t/stats -module-cache-path %t/cache
+// RUN: env SWIFT_ACCEPT_NON_RESILIENT_INTERFACES=1 \
+// RUN:   %target-swift-frontend -typecheck %s -I %S/Inputs -stats-output-dir %t/stats -module-cache-path %t/cache
 
 import empty

--- a/test/ModuleInterface/Inputs/implicit-options-inheritance/SIMod.swiftinterface
+++ b/test/ModuleInterface/Inputs/implicit-options-inheritance/SIMod.swiftinterface
@@ -1,4 +1,4 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -swift-version 5 -enforce-exclusivity=checked -module-name SIMod 
+// swift-module-flags: -swift-version 5 -enforce-exclusivity=checked -module-name SIMod -enable-library-evolution
 import CIMod
 

--- a/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/OtherModule.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/OtherModule.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,4 +1,4 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -target x86_64-apple-macos10.9 -module-name OtherModule -O
+// swift-module-flags: -target x86_64-apple-macos10.9 -module-name OtherModule -O -enable-library-evolution
 
 import Swift

--- a/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/Swift.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,4 +1,4 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -target x86_64-apple-macos10.9 -module-name Swift -parse-stdlib
+// swift-module-flags: -target x86_64-apple-macos10.9 -module-name Swift -parse-stdlib -enable-library-evolution
 
 public struct Int {}

--- a/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/_Concurrency.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/test/ModuleInterface/Inputs/stdlib_rebuild/usr/lib/swift/_Concurrency.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,4 +1,4 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -target x86_64-apple-macos10.9 -module-name _Concurrency -parse-stdlib
+// swift-module-flags: -target x86_64-apple-macos10.9 -module-name _Concurrency -parse-stdlib -enable-library-evolution
 
 @frozen public enum Task {}

--- a/test/ModuleInterface/ModuleCache/Inputs/mock-sdk/ExportedLib.swiftinterface
+++ b/test/ModuleInterface/ModuleCache/Inputs/mock-sdk/ExportedLib.swiftinterface
@@ -1,10 +1,10 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -parse-stdlib -module-name ExportedLib
+// swift-module-flags: -parse-stdlib -module-name ExportedLib -enable-library-evolution
 
 @_exported import SomeCModule
 
 public struct ExportedInterface {
-  @inlinable public init() {}
+  @inlinable public init() { self.init() }
 }
 public var testValue: ExportedInterface {
   @inlinable get { return ExportedInterface() }

--- a/test/ModuleInterface/ModuleCache/Inputs/mock-sdk/SdkLib.swiftinterface
+++ b/test/ModuleInterface/ModuleCache/Inputs/mock-sdk/SdkLib.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -parse-stdlib -module-name SdkLib
+// swift-module-flags: -parse-stdlib -module-name SdkLib -enable-library-evolution
 
 @_exported import ExportedLib
 

--- a/test/ModuleInterface/ModuleCache/Inputs/prebuilt-module-cache/Lib.swiftinterface
+++ b/test/ModuleInterface/ModuleCache/Inputs/prebuilt-module-cache/Lib.swiftinterface
@@ -1,8 +1,8 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -parse-stdlib -module-name Lib
+// swift-module-flags: -parse-stdlib -module-name Lib -enable-library-evolution
 
 public struct FromInterface {
-  @inlinable public init() {}
+  @inlinable public init() { self.init() }
 }
 public var testValue: FromInterface {
   @inlinable get { return FromInterface() }

--- a/test/ModuleInterface/ModuleCache/Inputs/prebuilt-module-cache/LibExporter.swiftinterface
+++ b/test/ModuleInterface/ModuleCache/Inputs/prebuilt-module-cache/LibExporter.swiftinterface
@@ -1,4 +1,4 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -parse-stdlib -module-name LibExporter
+// swift-module-flags: -parse-stdlib -module-name LibExporter -enable-library-evolution
 
 @_exported import Lib

--- a/test/ModuleInterface/ModuleCache/RebuildRemarks/malformed-compiled-module.swift
+++ b/test/ModuleInterface/ModuleCache/RebuildRemarks/malformed-compiled-module.swift
@@ -6,7 +6,7 @@
 // RUN: echo 'public func publicFunction() {}' > %t/TestModule.swift
 
 // 2. Create an interface for it
-// RUN: %target-swift-frontend -typecheck %t/TestModule.swift -emit-module-interface-path %t/Build/TestModule.swiftinterface -swift-version 5
+// RUN: %target-swift-frontend -typecheck %t/TestModule.swift -emit-module-interface-path %t/Build/TestModule.swiftinterface -swift-version 5 -enable-library-evolution
 
 // 3. Create an empty .swiftmodule, which will force recompiling from the interface
 // RUN: touch %t/Build/TestModule.swiftmodule

--- a/test/ModuleInterface/ModuleCache/RebuildRemarks/missing-dependency.swift
+++ b/test/ModuleInterface/ModuleCache/RebuildRemarks/missing-dependency.swift
@@ -5,7 +5,7 @@
 // RUN: echo 'public func publicFunction() {}' > %t/TestModule.swift
 
 // 2. Create both an interface and a compiled module for it
-// RUN: %target-swift-frontend -emit-module -o %t/Build/TestModule.swiftmodule %t/TestModule.swift -emit-module-interface-path %t/Build/TestModule.swiftinterface -swift-version 5 -module-name TestModule
+// RUN: %target-swift-frontend -emit-module -o %t/Build/TestModule.swiftmodule %t/TestModule.swift -emit-module-interface-path %t/Build/TestModule.swiftinterface -swift-version 5 -module-name TestModule -enable-library-evolution
 
 // 3. Make the compiled module unreadable so it gets added as a dependency but is not used
 // RUN: mv %t/Build/TestModule.swiftmodule %t/Build/TestModule.swiftmodule.moved-aside

--- a/test/ModuleInterface/ModuleCache/RebuildRemarks/out-of-date-cached-module.swift
+++ b/test/ModuleInterface/ModuleCache/RebuildRemarks/out-of-date-cached-module.swift
@@ -5,7 +5,7 @@
 // RUN: echo 'public func publicFunction() {}' > %t/TestModule.swift
 
 // 2. Create an interface for it
-// RUN: %target-swift-frontend -typecheck %t/TestModule.swift -emit-module-interface-path %t/Build/TestModule.swiftinterface -swift-version 5
+// RUN: %target-swift-frontend -typecheck %t/TestModule.swift -emit-module-interface-path %t/Build/TestModule.swiftinterface -swift-version 5 -enable-library-evolution
 
 // 3. Try to import the interface, which will pass and create a cached module
 // RUN: %target-swift-frontend -typecheck %s -I %t/Build -module-cache-path %t/ModuleCache

--- a/test/ModuleInterface/ModuleCache/RebuildRemarks/out-of-date-compiled-module.swift
+++ b/test/ModuleInterface/ModuleCache/RebuildRemarks/out-of-date-compiled-module.swift
@@ -5,7 +5,7 @@
 // RUN: echo 'public func publicFunction() {}' > %t/TestModule.swift
 
 // 2. Create an interface for it
-// RUN: %target-swift-frontend -typecheck %t/TestModule.swift -emit-module-interface-path %t/Build/TestModule.swiftinterface -swift-version 5
+// RUN: %target-swift-frontend -typecheck %t/TestModule.swift -emit-module-interface-path %t/Build/TestModule.swiftinterface -swift-version 5 -enable-library-evolution
 
 // 3. Build the .swiftinterface to a .swiftmodule, which will have a dependency on the interface
 // RUN: %target-swift-frontend -compile-module-from-interface -o %t/Build/TestModule.swiftmodule %t/Build/TestModule.swiftinterface

--- a/test/ModuleInterface/ModuleCache/RebuildRemarks/out-of-date-forwarding-module.swift
+++ b/test/ModuleInterface/ModuleCache/RebuildRemarks/out-of-date-forwarding-module.swift
@@ -10,7 +10,7 @@
 // RUN: echo 'public func publicFunction() {}' > %t/TestModule.swift
 
 // 2. Create an interface for it
-// RUN: %target-swift-frontend -typecheck %t/TestModule.swift -emit-module-interface-path %t/Build/TestModule.swiftinterface -swift-version 5
+// RUN: %target-swift-frontend -typecheck %t/TestModule.swift -emit-module-interface-path %t/Build/TestModule.swiftinterface -swift-version 5 -enable-library-evolution
 
 // 3. Build the .swiftinterface to a .swiftmodule in the prebuilt cache, which will have a dependency on the interface
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Build/TestModule.swiftinterface -o %t/PrebuiltCache/TestModule.swiftmodule

--- a/test/ModuleInterface/ModuleCache/SystemDependencies.swiftinterface
+++ b/test/ModuleInterface/ModuleCache/SystemDependencies.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name SystemDependencies
+// swift-module-flags: -module-name SystemDependencies -enable-library-evolution
 
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/mock-sdk %t/mock-sdk

--- a/test/ModuleInterface/ModuleCache/module-cache-deployment-target-irrelevant.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-deployment-target-irrelevant.swift
@@ -12,11 +12,11 @@
 //
 // Phase 1: build LeafModule into a .swiftinterface file with -target %target-cpu-macosx-10.9:
 //
-// RUN: %swift -target %target-cpu-apple-macosx10.9 -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -typecheck
+// RUN: %swift -target %target-cpu-apple-macosx10.9 -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -typecheck -enable-library-evolution
 //
 // Phase 2: build OtherModule into a .swiftinterface file with -target %target-cpu-macosx-10.10:
 //
-// RUN: %swift -target %target-cpu-apple-macosx10.10 -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -typecheck
+// RUN: %swift -target %target-cpu-apple-macosx10.10 -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -typecheck -enable-library-evolution
 //
 // Phase 3: build TestModule in -target %target-cpu-apple-macosx10.11 and import both of these:
 //

--- a/test/ModuleInterface/ModuleCache/module-cache-diagnostics.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-diagnostics.swift
@@ -26,9 +26,9 @@
 // Setup phase 2: build modules, pushing timestamps of inputs and intermediates into the past as we go.
 //
 // RUN: %{python} %S/Inputs/make-old.py %t/leaf.swift %t/other.swift
-// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %t -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %t -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null -enable-library-evolution
 // RUN: %{python} %S/Inputs/make-old.py %t/LeafModule.swiftinterface
-// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null -enable-library-evolution
 // RUN: %{python} %S/Inputs/make-old.py %t/modulecache/LeafModule-*.swiftmodule %t/OtherModule.swiftinterface
 // RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -I %t -module-cache-path %t/modulecache -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
 // RUN: %{python} %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule

--- a/test/ModuleInterface/ModuleCache/module-cache-effective-version-irrelevant.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-effective-version-irrelevant.swift
@@ -9,11 +9,11 @@
 //
 // Phase 1: build LeafModule into a .swiftinterface file with -swift-version 4:
 //
-// RUN: %target-swift-frontend -swift-version 4 -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -typecheck
+// RUN: %target-swift-frontend -swift-version 4 -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -typecheck -enable-library-evolution
 //
 // Phase 2: build OtherModule into a .swiftinterface file with -swift-version 4.2:
 //
-// RUN: %target-swift-frontend -swift-version 4.2 -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -typecheck
+// RUN: %target-swift-frontend -swift-version 4.2 -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -typecheck -enable-library-evolution
 //
 // Phase 3: build TestModule in -swift-version 5 and import both of these:
 //

--- a/test/ModuleInterface/ModuleCache/module-cache-errors-in-importing-file.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-errors-in-importing-file.swift
@@ -10,7 +10,7 @@
 
 // Setup phase 2: build the module.
 //
-// RUN: %target-swift-frontend -I %t -emit-module-interface-path %t/SomeModule.swiftinterface -module-name SomeModule %t/some-module.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -I %t -emit-module-interface-path %t/SomeModule.swiftinterface -module-name SomeModule %t/some-module.swift -emit-module -o /dev/null -enable-library-evolution
 
 // Actual test: compile and verify the import succeeds (i.e. we only report the error in this file)
 //

--- a/test/ModuleInterface/ModuleCache/module-cache-init.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-init.swift
@@ -9,7 +9,7 @@
 //
 // Phase 1: build LeafModule into a .swiftinterface file:
 //
-// RUN: %target-swift-frontend -I %t -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -I %t -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null -enable-library-evolution
 // RUN: test -f %t/LeafModule.swiftinterface
 // RUN: %FileCheck %s -check-prefix=CHECK-LEAFINTERFACE <%t/LeafModule.swiftinterface
 // CHECK-LEAFINTERFACE: LeafFunc
@@ -17,7 +17,7 @@
 //
 // Phase 2: build OtherModule into a .swiftinterface _using_ LeafModule via LeafModule.swiftinterface, creating LeafModule-*.swiftmodule along the way.
 //
-// RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null -enable-library-evolution
 // RUN: test -f %t/OtherModule.swiftinterface
 // RUN: %FileCheck %s -check-prefix=CHECK-OTHERINTERFACE <%t/OtherModule.swiftinterface
 // CHECK-OTHERINTERFACE: OtherFunc

--- a/test/ModuleInterface/ModuleCache/module-cache-intermediate-mtime-change-rebuilds-only-intermediate.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-intermediate-mtime-change-rebuilds-only-intermediate.swift
@@ -19,9 +19,9 @@
 // Setup phase 2: build modules, pushing timestamps of inputs and intermediates into the past as we go.
 //
 // RUN: %{python} %S/Inputs/make-old.py %t/leaf.swift %t/other.swift
-// RUN: %target-swift-frontend -I %t -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -I %t -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null -enable-library-evolution
 // RUN: %{python} %S/Inputs/make-old.py %t/LeafModule.swiftinterface
-// RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null -enable-library-evolution
 // RUN: %{python} %S/Inputs/make-old.py %t/modulecache/LeafModule-*.swiftmodule %t/OtherModule.swiftinterface
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
 // RUN: %{python} %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule

--- a/test/ModuleInterface/ModuleCache/module-cache-intermediate-size-change-rebuilds-only-intermediate.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-intermediate-size-change-rebuilds-only-intermediate.swift
@@ -18,9 +18,9 @@
 // Setup phase 2: build modules, pushing timestamps of inputs and intermediates into the past as we go.
 //
 // RUN: %{python} %S/Inputs/make-old.py %t/leaf.swift %t/other.swift
-// RUN: %target-swift-frontend -I %t -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -I %t -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null -enable-library-evolution
 // RUN: %{python} %S/Inputs/make-old.py %t/LeafModule.swiftinterface
-// RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null -enable-library-evolution
 // RUN: %{python} %S/Inputs/make-old.py %t/modulecache/LeafModule-*.swiftmodule %t/OtherModule.swiftinterface
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
 // RUN: %{python} %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule

--- a/test/ModuleInterface/ModuleCache/module-cache-leaf-mtime-change-rebuilds-all.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-leaf-mtime-change-rebuilds-all.swift
@@ -19,9 +19,9 @@
 // Setup phase 2: build modules, pushing timestamps of inputs and intermediates into the past as we go.
 //
 // RUN: %{python} %S/Inputs/make-old.py %t/leaf.swift %t/other.swift
-// RUN: %target-swift-frontend -I %t -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -I %t -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null -enable-library-evolution
 // RUN: %{python} %S/Inputs/make-old.py %t/LeafModule.swiftinterface
-// RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null -enable-library-evolution
 // RUN: %{python} %S/Inputs/make-old.py %t/modulecache/LeafModule-*.swiftmodule %t/OtherModule.swiftinterface
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
 // RUN: %{python} %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule

--- a/test/ModuleInterface/ModuleCache/module-cache-leaf-size-change-rebuilds-all.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-leaf-size-change-rebuilds-all.swift
@@ -18,9 +18,9 @@
 // Setup phase 2: build modules, pushing timestamps of inputs and intermediates into the past as we go.
 //
 // RUN: %{python} %S/Inputs/make-old.py %t/leaf.swift %t/other.swift
-// RUN: %target-swift-frontend -I %t -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -I %t -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null -enable-library-evolution
 // RUN: %{python} %S/Inputs/make-old.py %t/LeafModule.swiftinterface
-// RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null -enable-library-evolution
 // RUN: %{python} %S/Inputs/make-old.py %t/modulecache/LeafModule-*.swiftmodule %t/OtherModule.swiftinterface
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
 // RUN: %{python} %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule

--- a/test/ModuleInterface/ModuleCache/module-cache-no-rebuild.swift
+++ b/test/ModuleInterface/ModuleCache/module-cache-no-rebuild.swift
@@ -18,9 +18,9 @@
 // Setup phase 2: build modules, pushing timestamps of inputs and intermediates into the past as we go.
 //
 // RUN: %{python} %S/Inputs/make-old.py %t/leaf.swift %t/other.swift
-// RUN: %target-swift-frontend -I %t -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -I %t -emit-module-interface-path %t/LeafModule.swiftinterface -module-name LeafModule %t/leaf.swift -emit-module -o /dev/null -enable-library-evolution
 // RUN: %{python} %S/Inputs/make-old.py %t/LeafModule.swiftinterface
-// RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null
+// RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module-interface-path %t/OtherModule.swiftinterface -module-name OtherModule %t/other.swift -emit-module -o /dev/null -enable-library-evolution
 // RUN: %{python} %S/Inputs/make-old.py %t/modulecache/LeafModule-*.swiftmodule %t/OtherModule.swiftinterface
 // RUN: %target-swift-frontend -I %t -module-cache-path %t/modulecache -emit-module -o %t/TestModule.swiftmodule -module-name TestModule %s
 // RUN: %{python} %S/Inputs/make-old.py %t/modulecache/OtherModule-*.swiftmodule

--- a/test/ModuleInterface/can-import.swift
+++ b/test/ModuleInterface/can-import.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: echo 'public func externalFunc() {}' | %target-swift-frontend -typecheck -emit-module-interface-path %t/Library.swiftinterface -
+// RUN: echo 'public func externalFunc() {}' | %target-swift-frontend -typecheck -emit-module-interface-path %t/Library.swiftinterface - -enable-library-evolution
 // RUN: %empty-directory(%t/LibraryWithoutThisArchitecture.swiftmodule)
-// RUN: echo 'public func externalFunc() {}' | %target-swift-frontend -typecheck -emit-module-interface-path %t/LibraryWithoutThisArchitecture.swiftmodule/arm40000-apple-ios.swiftinterface -
+// RUN: echo 'public func externalFunc() {}' | %target-swift-frontend -typecheck -emit-module-interface-path %t/LibraryWithoutThisArchitecture.swiftmodule/arm40000-apple-ios.swiftinterface - -enable-library-evolution
 // RUN: %target-swift-frontend -typecheck %s -I %t
 
 #if canImport(Library)

--- a/test/ModuleInterface/default-prebuilt-module-location-sdk-versioned.swift
+++ b/test/ModuleInterface/default-prebuilt-module-location-sdk-versioned.swift
@@ -11,12 +11,12 @@
 // 3. Compile this into a module and put it into the default SKD-versioned prebuilt cache
 //    location relative to the fake resource dir. Also drop an interface into
 //    the build dir.
-// RUN: %target-swift-frontend -emit-module %t/PrebuiltModule.swift -o %t/ResourceDir/%target-sdk-name/prebuilt-modules/10.15/PrebuiltModule.swiftmodule/%target-swiftmodule-name -module-name PrebuiltModule -parse-stdlib -emit-module-interface-path %t/PrebuiltModule.swiftmodule/%target-swiftinterface-name
+// RUN: %target-swift-frontend -emit-module %t/PrebuiltModule.swift -o %t/ResourceDir/%target-sdk-name/prebuilt-modules/10.15/PrebuiltModule.swiftmodule/%target-swiftmodule-name -module-name PrebuiltModule -parse-stdlib -emit-module-interface-path %t/PrebuiltModule.swiftmodule/%target-swiftinterface-name -enable-library-evolution
 
 // 4. Compile this into a module and put it into the default non-versioned prebuilt cache
 //    location relative to the fake resource dir. Also drop an interface into
 //    the build dir.
-// RUN: %target-swift-frontend -emit-module %t/PrebuiltModule.swift -o %t/ResourceDir/%target-sdk-name/prebuilt-modules/PrebuiltModule.swiftmodule/%target-swiftmodule-name -module-name PrebuiltModule -parse-stdlib -emit-module-interface-path %t/PrebuiltModule.swiftmodule/%target-swiftinterface-name
+// RUN: %target-swift-frontend -emit-module %t/PrebuiltModule.swift -o %t/ResourceDir/%target-sdk-name/prebuilt-modules/PrebuiltModule.swiftmodule/%target-swiftmodule-name -module-name PrebuiltModule -parse-stdlib -emit-module-interface-path %t/PrebuiltModule.swiftmodule/%target-swiftinterface-name -enable-library-evolution
 
 // 5. Import this prebuilt module, but DON'T pass in -prebuilt-module-cache-path, it should use the implicit one from the SDK-versioned prebuilt module cache dir.
 // RUN: %target-swift-frontend -typecheck -resource-dir %t/ResourceDir -I %t %s -parse-stdlib -module-cache-path %t/ModuleCache -sdk %t -target-sdk-version 10.15

--- a/test/ModuleInterface/disable-availability-checking.swift
+++ b/test/ModuleInterface/disable-availability-checking.swift
@@ -3,7 +3,7 @@
 // RUN: %empty-directory(%t/inputs)
 // RUN: %empty-directory(%t/modulecache)
 // RUN: echo "// swift-interface-format-version: 1.0" > %t/inputs/Foo.swiftinterface
-// RUN: echo "// swift-module-flags: -module-name Foo" >> %t/inputs/Foo.swiftinterface
+// RUN: echo "// swift-module-flags: -module-name Foo -enable-library-evolution" >> %t/inputs/Foo.swiftinterface
 // RUN: echo "@available(macOS 11, *)" >> %t/inputs/Foo.swiftinterface
 // RUN: echo "public class Foo {}" >> %t/inputs/Foo.swiftinterface
 // RUN: echo "public extension Foo { public func f() {} }" >> %t/inputs/Foo.swiftinterface

--- a/test/ModuleInterface/disable-building-interface.swift
+++ b/test/ModuleInterface/disable-building-interface.swift
@@ -6,7 +6,7 @@
 // RUN: echo 'public struct InPrebuiltModule {}' > %t/PrebuiltModule.swift
 
 // 3. Compile textual interface only into a directory
-// RUN: %target-swift-frontend -emit-module %t/PrebuiltModule.swift -module-name PrebuiltModule -emit-module-interface-path %t/PrebuiltModule.swiftmodule/%target-swiftinterface-name
+// RUN: %target-swift-frontend -emit-module %t/PrebuiltModule.swift -module-name PrebuiltModule -emit-module-interface-path %t/PrebuiltModule.swiftmodule/%target-swiftinterface-name -enable-library-evolution
 
 // 4. Import this module with -disable-building-interface should fail
 // RUN: not %target-swift-frontend -typecheck -I %t %s -module-cache-path %t/ModuleCache -sdk %t -disable-building-interface

--- a/test/ModuleInterface/inherited-defaults-execution.swift
+++ b/test/ModuleInterface/inherited-defaults-execution.swift
@@ -6,7 +6,7 @@
 
 // 1) Build the 'Inherited' library and its interface from this file
 //
-// RUN: %target-build-swift-dylib(%t/%target-library-name(Inherited)) -emit-module-path %t/Inherited.swiftmodule -emit-module-interface-path %t/Inherited.swiftinterface -module-name Inherited %s
+// RUN: %target-build-swift-dylib(%t/%target-library-name(Inherited)) -emit-module-path %t/Inherited.swiftmodule -emit-module-interface-path %t/Inherited.swiftinterface -module-name Inherited %s -enable-library-evolution
 // RUN: rm %t/Inherited.swiftmodule
 // RUN: %target-swift-typecheck-module-from-interface(%t/Inherited.swiftinterface)
 

--- a/test/ModuleInterface/linking-to-module.swift
+++ b/test/ModuleInterface/linking-to-module.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift -emit-library -module-name TestModule -module-link-name coreTestModuleKitUtilsTool %S/Inputs/TestModule.swift -emit-module-interface -o %t/%target-library-name(coreTestModuleKitUtilsTool)
+// RUN: %target-build-swift -emit-library -module-name TestModule -module-link-name coreTestModuleKitUtilsTool %S/Inputs/TestModule.swift -emit-module-interface -o %t/%target-library-name(coreTestModuleKitUtilsTool) -enable-library-evolution
 // RUN: %target-swift-frontend -emit-ir -I %t -L %t %s | %FileCheck %s
 
 import TestModule

--- a/test/ModuleInterface/loading-order.swift
+++ b/test/ModuleInterface/loading-order.swift
@@ -18,7 +18,7 @@
 // RUN: echo 'public func prebuiltModule() {}' > %t/PrebuiltModule.swift
 
 /// Compile this into a module in the SDK.
-// RUN: %target-swift-frontend -emit-module %t/NextToSwiftinterface.swift -o %t/MyModule.swiftmodule/%target-swiftmodule-name -module-name MyModule -parse-stdlib -emit-module-interface-path %t/MyModule.swiftmodule/%target-swiftinterface-name -emit-private-module-interface-path %t/MyModule.swiftmodule/%target-private-swiftinterface-name
+// RUN: %target-swift-frontend -emit-module %t/NextToSwiftinterface.swift -o %t/MyModule.swiftmodule/%target-swiftmodule-name -module-name MyModule -parse-stdlib -emit-module-interface-path %t/MyModule.swiftmodule/%target-swiftinterface-name -emit-private-module-interface-path %t/MyModule.swiftmodule/%target-private-swiftinterface-name -enable-library-evolution
 
 /// Also put a module with a different API into the default prebuilt cache under the same name to detect when its picked.
 // RUN: %target-swift-frontend -emit-module %t/PrebuiltModule.swift -o %t/ResourceDir/%target-sdk-name/prebuilt-modules/MyModule.swiftmodule/%target-swiftmodule-name -module-name MyModule -parse-stdlib

--- a/test/ModuleInterface/multiple-targets-same-interface.swift
+++ b/test/ModuleInterface/multiple-targets-same-interface.swift
@@ -7,7 +7,7 @@
 
 // 1. Build a .swiftinterface for a dummy module.
 
-// RUN: %target-swift-frontend -typecheck -target x86_64-apple-macosx10.9 -emit-module-interface-path %t/SwiftModule.swiftinterface.tmp -parse-stdlib %s -module-name SwiftModule
+// RUN: %target-swift-frontend -typecheck -target x86_64-apple-macosx10.9 -emit-module-interface-path %t/SwiftModule.swiftinterface.tmp -parse-stdlib %s -module-name SwiftModule -enable-library-evolution
 
 // 2. Remove the -target line from the .swiftinterface. Clients will build using their target.
 

--- a/test/ModuleInterface/no-implicit-extra-clang-opts.swift
+++ b/test/ModuleInterface/no-implicit-extra-clang-opts.swift
@@ -18,7 +18,7 @@ import SIMod
 // RUN: touch %t/test-dummy.modulemap
 
 // Step 3: Re-build this file, and ensure we are not re-building SIMod due to a dependency on the dummy file
-// RUN: %target-swift-frontend -emit-module -module-name no-implicit-extra-clang-maps -o %t/no-implicit-extra-clang-maps.swiftmodule %s -I %t -Xcc -fmodule-map-file=%t/test-dummy.modulemap -module-cache-path %t/ModuleCache -Rmodule-interface-rebuild 2>&1 | %FileCheck -allow-empty %s
+// RUN: %target-swift-frontend -emit-module -module-name no-implicit-extra-clang-maps -o %t/no-implicit-extra-clang-maps.swiftmodule %s -I %t -Xcc -fmodule-map-file=%t/test-dummy.modulemap -module-cache-path %t/ModuleCache -Rmodule-interface-rebuild -enable-library-evolution 2>&1 | %FileCheck -allow-empty %s
 
 // Step 4: Ensure that SIMod was not re-built
 // CHECK-NOT: remark: rebuilding module 'SIMod' from interface

--- a/test/ModuleInterface/non-resilient-swiftinterface-loading.swift
+++ b/test/ModuleInterface/non-resilient-swiftinterface-loading.swift
@@ -1,0 +1,59 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module %t/NonResilientLib.swift \
+// RUN:   -module-name NonResilientLib -swift-version 5 \
+// RUN:   -emit-module-path %t/NonResilientLib.swiftmodule \
+// RUN:   -emit-module-interface-path %t/NonResilientLib.swiftinterface 2>&1 \
+// RUN:   | grep "warning: module interfaces are only supported with -enable-library-evolution"
+
+// RUN: %target-swift-frontend -emit-module %t/ResilientLib.swift \
+// RUN:   -module-name ResilientLib -swift-version 5 \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-path %t/ResilientLib.swiftmodule \
+// RUN:   -emit-module-interface-path %t/ResilientLib.swiftinterface
+
+/// Expecting no diagnostics when importing the swiftmodule.
+// RUN: %target-swift-frontend -typecheck %t/ClientClean.swift \
+// RUN:   -swift-version 5 -I %t -verify
+
+/// Expecting diagnostics when importing the non-resilient swiftinterface.
+// RUN: rm %t/*.swiftmodule
+// RUN: %target-swift-frontend -typecheck %t/ClientError.swift \
+// RUN:   -swift-version 5 -I %t -verify
+
+// RUN: env SWIFT_ACCEPT_NON_RESILIENT_INTERFACES=1 \
+// RUN:   %target-swift-frontend -typecheck %t/ClientWarning.swift \
+// RUN:   -swift-version 5 -I %t -verify
+
+//--- NonResilientLib.swift
+
+public func NonResilientFunc() {}
+
+//--- ResilientLib.swift
+
+public func ResilientFunc() {}
+
+//--- ClientClean.swift
+
+import NonResilientLib
+import ResilientLib
+
+NonResilientFunc()
+ResilientFunc()
+
+//--- ClientError.swift
+
+import NonResilientLib // expected-error {{module 'NonResilientLib' was rebuilt from a swiftinterface without library evolution; it cannot be used to build a binary}}
+import ResilientLib
+
+NonResilientFunc()
+ResilientFunc()
+
+//--- ClientWarning.swift
+
+import NonResilientLib // expected-warning {{module 'NonResilientLib' was rebuilt from a swiftinterface without library evolution; it cannot be used to build a binary}}
+import ResilientLib
+
+NonResilientFunc()
+ResilientFunc()

--- a/test/ModuleInterface/stored-properties-client.swift
+++ b/test/ModuleInterface/stored-properties-client.swift
@@ -9,7 +9,8 @@
 
 // 2. Build this file and link with StoredProperties
 
-// RUN: %target-build-swift %s -I %t -L %t -lStoredProperties -o %t/stored-properties-client %target-rpath(%t)
+// RUN: env SWIFT_ACCEPT_NON_RESILIENT_INTERFACES=1 \
+// RUN:   %target-build-swift %s -I %t -L %t -lStoredProperties -o %t/stored-properties-client %target-rpath(%t)
 
 // 3. Codesign and run this, and ensure it exits successfully.
 

--- a/test/ModuleInterface/swift_build_sdk_interfaces/check-only-mode.swift
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/check-only-mode.swift
@@ -2,9 +2,9 @@
 // RUN: mkdir -p %t/sdk/usr/lib/swift/Normal.swiftmodule
 // RUN: mkdir -p %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule
 
-// RUN: echo 'public func normal() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-swiftinterface-name -emit-module -o /dev/null -module-name Normal
-// RUN: echo 'public func flat() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Flat.swiftinterface -emit-module -o /dev/null -module-name Flat
-// RUN: echo 'public func fmwk() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule/%target-swiftinterface-name -emit-module -o /dev/null -module-name FMWK
+// RUN: echo 'public func normal() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-swiftinterface-name -emit-module -o /dev/null -module-name Normal -enable-library-evolution
+// RUN: echo 'public func flat() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Flat.swiftinterface -emit-module -o /dev/null -module-name Flat -enable-library-evolution
+// RUN: echo 'public func fmwk() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule/%target-swiftinterface-name -emit-module -o /dev/null -module-name FMWK -enable-library-evolution
 
 // RUN: %swift_build_sdk_interfaces -sdk %t/sdk -Fsystem %t/sdk/System/Library/Frameworks -v -o %t/prebuilt -check-only
 // RUN: ls %t/prebuilt | %FileCheck %s

--- a/test/ModuleInterface/swift_build_sdk_interfaces/compiler-uses-prebuilt.swift
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/compiler-uses-prebuilt.swift
@@ -2,9 +2,9 @@
 // RUN: mkdir -p %t/sdk/usr/lib/swift/Normal.swiftmodule
 // RUN: mkdir -p %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule
 
-// RUN: echo 'public func normal() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-swiftinterface-name -emit-module -o /dev/null -module-name Normal
-// RUN: echo 'public func flat() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Flat.swiftinterface -emit-module -o /dev/null -module-name Flat
-// RUN: echo 'public func fmwk() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule/%target-swiftinterface-name -emit-module -o /dev/null -module-name FMWK
+// RUN: echo 'public func normal() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Normal.swiftmodule/%target-swiftinterface-name -emit-module -o /dev/null -module-name Normal -enable-library-evolution
+// RUN: echo 'public func flat() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Flat.swiftinterface -emit-module -o /dev/null -module-name Flat -enable-library-evolution
+// RUN: echo 'public func fmwk() {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/System/Library/Frameworks/FMWK.framework/Modules/FMWK.swiftmodule/%target-swiftinterface-name -emit-module -o /dev/null -module-name FMWK -enable-library-evolution
 
 // RUN: %swift_build_sdk_interfaces -sdk %t/sdk -Fsystem %t/sdk/System/Library/Frameworks -v -o %t/prebuilt
 // RUN: ls %t/prebuilt | %FileCheck %s

--- a/test/ModuleInterface/swift_build_sdk_interfaces/track-system-dependencies.swift
+++ b/test/ModuleInterface/swift_build_sdk_interfaces/track-system-dependencies.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/system-dependencies-sdk %t/sdk
-// RUN: echo 'import Platform; public func usesCStruct(_: SomeCStruct?) {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Swifty.swiftmodule/%target-swiftinterface-name -emit-module -o /dev/null -module-name Swifty -sdk %t/sdk
+// RUN: echo 'import Platform; public func usesCStruct(_: SomeCStruct?) {}' | %target-swift-frontend - -emit-module-interface-path %t/sdk/usr/lib/swift/Swifty.swiftmodule/%target-swiftinterface-name -emit-module -o /dev/null -module-name Swifty -sdk %t/sdk -enable-library-evolution
 
 // RUN: %swift_build_sdk_interfaces -sdk %t/sdk -v -o %t/prebuilt
 // RUN: ls %t/prebuilt | %FileCheck %s

--- a/test/ScanDependencies/Inputs/Swift/A.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/A.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name A
+// swift-module-flags: -module-name A -enable-library-evolution
 import Swift
 @_exported import A
 public func overlayFuncA() { }

--- a/test/ScanDependencies/Inputs/Swift/CycleOne.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/CycleOne.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name CycleOne
+// swift-module-flags: -module-name CycleOne -enable-library-evolution
 import Swift
 import CycleTwo
 

--- a/test/ScanDependencies/Inputs/Swift/CycleThree.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/CycleThree.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name CycleThree
+// swift-module-flags: -module-name CycleThree -enable-library-evolution
 import Swift
 import CycleOne
 

--- a/test/ScanDependencies/Inputs/Swift/CycleTwo.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/CycleTwo.swiftinterface
@@ -1,4 +1,4 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name CycleTwo
+// swift-module-flags: -module-name CycleTwo -enable-library-evolution
 import Swift
 import CycleThree

--- a/test/ScanDependencies/Inputs/Swift/E.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/E.swiftinterface
@@ -1,4 +1,4 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name E
+// swift-module-flags: -module-name E -enable-library-evolution
 import Swift
 public func funcE() { }

--- a/test/ScanDependencies/Inputs/Swift/EWrapper.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/EWrapper.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name EWrapper
+// swift-module-flags: -module-name EWrapper -enable-library-evolution
 import Swift
 import E
 public func funcEWrapper() { }

--- a/test/ScanDependencies/Inputs/Swift/F.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/F.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name F
+// swift-module-flags: -module-name F -enable-library-evolution
 import Swift
 @_exported import F
 public func funcF() { }

--- a/test/ScanDependencies/Inputs/Swift/Foo.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/Foo.swiftinterface
@@ -1,4 +1,4 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name Foo
+// swift-module-flags: -module-name Foo -enable-library-evolution
 import Swift
 

--- a/test/ScanDependencies/Inputs/Swift/G.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/G.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name G -swift-version 5
+// swift-module-flags: -module-name G -swift-version 5 -enable-library-evolution
 
 #if swift(>=5.0)
 import Swift

--- a/test/ScanDependencies/Inputs/Swift/P.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/P.swiftinterface
@@ -1,4 +1,4 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name P
+// swift-module-flags: -module-name P -enable-library-evolution
 import Y
 public func funcP() { }

--- a/test/ScanDependencies/Inputs/Swift/SubE.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/SubE.swiftinterface
@@ -1,4 +1,4 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name SubE
+// swift-module-flags: -module-name SubE -enable-library-evolution
 import Swift
 public func funcSubE() {}

--- a/test/ScanDependencies/Inputs/Swift/SubEWrapper.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/SubEWrapper.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name SubEWrapper
+// swift-module-flags: -module-name SubEWrapper -enable-library-evolution
 import Swift
 import SubE
 public func funcSubEWrapper() { }

--- a/test/ScanDependencies/Inputs/Swift/XWithTarget.swiftmodule/arm64-apple-macos.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/XWithTarget.swiftmodule/arm64-apple-macos.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name XWithTarget -target arm64-apple-macosx10.9
+// swift-module-flags: -module-name XWithTarget -target arm64-apple-macosx10.9 -enable-library-evolution
 import Swift
 @_exported import X
 public func overlayFuncX() { }

--- a/test/ScanDependencies/Inputs/Swift/XWithTarget.swiftmodule/arm64e-apple-macos.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/XWithTarget.swiftmodule/arm64e-apple-macos.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name XWithTarget -target arm64e-apple-macosx10.9
+// swift-module-flags: -module-name XWithTarget -target arm64e-apple-macosx10.9 -enable-library-evolution
 import Swift
 @_exported import X
 public func overlayFuncX() { }

--- a/test/ScanDependencies/Inputs/Swift/XWithTarget.swiftmodule/x86_64-apple-macos.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/XWithTarget.swiftmodule/x86_64-apple-macos.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name XWithTarget  -target x86_64-apple-macosx10.9
+// swift-module-flags: -module-name XWithTarget  -target x86_64-apple-macosx10.9 -enable-library-evolution
 import Swift
 @_exported import X
 public func overlayFuncX() { }

--- a/test/ScanDependencies/Inputs/Swift/Y.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/Y.swiftinterface
@@ -1,4 +1,4 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name Y
+// swift-module-flags: -module-name Y -enable-library-evolution
 import Z
 public func funcY() { }

--- a/test/ScanDependencies/Inputs/Swift/Z.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/Z.swiftinterface
@@ -1,4 +1,4 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name Z
+// swift-module-flags: -module-name Z -enable-library-evolution
 import missing_module
 public func funcZ() { }

--- a/test/ScanDependencies/Inputs/Swift/_cross_import_E.swiftinterface
+++ b/test/ScanDependencies/Inputs/Swift/_cross_import_E.swiftinterface
@@ -1,5 +1,5 @@
 // swift-interface-format-version: 1.0
-// swift-module-flags: -module-name _cross_import_E
+// swift-module-flags: -module-name _cross_import_E -enable-library-evolution
 import Swift
 import E
 import SubE

--- a/test/Serialization/interface-module-nested-types.swift
+++ b/test/Serialization/interface-module-nested-types.swift
@@ -9,7 +9,7 @@
 // RUN: echo 'public protocol Nest { associatedtype Egg }' > %t/TestModule.swift
 
 // 2. Create an interface for it
-// RUN: %target-swift-frontend -typecheck %t/TestModule.swift -emit-module-interface-path %t/Build/TestModule.swiftinterface -swift-version 5
+// RUN: %target-swift-frontend -typecheck %t/TestModule.swift -emit-module-interface-path %t/Build/TestModule.swiftinterface -swift-version 5 -enable-library-evolution
 
 // 3. Build a .swiftmodule from the .swiftinterface and put it in the module cache
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Build/TestModule.swiftinterface -o %t/PrebuiltCache/TestModule.swiftmodule
@@ -18,7 +18,7 @@
 // RUN: echo 'import TestModule; extension Nest where Egg == Int { public func robin() -> Egg { return 3 } }' > %t/NestModule.swift
 
 // 5. Create an interface for it
-// RUN: %target-swift-frontend -typecheck %t/NestModule.swift -I %t/PrebuiltCache -sdk %t -prebuilt-module-cache-path %t/PrebuiltCache -module-cache-path %t/ModuleCache -emit-module-interface-path %t/Build/NestModule.swiftinterface -swift-version 5
+// RUN: %target-swift-frontend -typecheck %t/NestModule.swift -I %t/PrebuiltCache -sdk %t -prebuilt-module-cache-path %t/PrebuiltCache -module-cache-path %t/ModuleCache -emit-module-interface-path %t/Build/NestModule.swiftinterface -swift-version 5 -enable-library-evolution
 
 // 6. Build a .swiftmodule from the .swiftinterface and put it in the module cache
 // RUN: %target-swift-frontend -compile-module-from-interface -I %t/PrebuiltCache -sdk %t %t/Build/NestModule.swiftinterface -o %t/PrebuiltCache/NestModule.swiftmodule

--- a/test/SourceKit/CodeComplete/complete_swiftinterface.swift
+++ b/test/SourceKit/CodeComplete/complete_swiftinterface.swift
@@ -2,8 +2,8 @@
 // RUN: %empty-directory(%t/modulecache)
 
 // 1) Build .swiftinterface files for MyPoint and MyExtensions, using a non-default module cache path
-// RUN: %target-swift-frontend -emit-module-interface-path %t/MyPointModule.swiftinterface -module-name MyPointModule -emit-module -o /dev/null %S/Inputs/parseable-interface/MyPoint.swift
-// RUN: %target-swift-frontend -emit-module-interface-path %t/MyPointExtensions.swiftinterface -module-name MyPointExtensions -emit-module -o /dev/null -module-cache-path %t/modulecache -I %t %S/Inputs/parseable-interface/MyPointExtensions.swift
+// RUN: %target-swift-frontend -emit-module-interface-path %t/MyPointModule.swiftinterface -module-name MyPointModule -emit-module -o /dev/null %S/Inputs/parseable-interface/MyPoint.swift -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module-interface-path %t/MyPointExtensions.swiftinterface -module-name MyPointExtensions -emit-module -o /dev/null -module-cache-path %t/modulecache -I %t %S/Inputs/parseable-interface/MyPointExtensions.swift -enable-library-evolution
 // RUN: %empty-directory(%t/modulecache)
 
 // 2) Check completion using the default (cold) module cache


### PR DESCRIPTION
Generating a swiftinterface for a module without library-evolution is not currently a recommended configuration, and it leads to a warning at  building the module. We’re now considering generating more swiftinterfaces even without library-evolution as the swiftinterface can be useful for documentation tools. However, while we can build against  such a swiftinterface we shouldn’t expect the executable to work reliably.
    
This PR adds the infrastructure necessary to detect when we’re importing a module from a swiftinterface without it having enabled library-evoluation. It is reported as an error which can be downgraded to a warning with an env var. Compiler engineers may still want a full build even if the binary is unusable.

rdar://101637436

---

The diagnostic is mostly to test the underlying information about modules built from interfaces, so there's room for improvement here. The check only catches local imports and won't report this issue on implicit or indirect imports. While it would be useful for compiler engineers to disable that check we may prefer an alternative to the env var.