### PR TITLE
Create symlinks for `swift-frontend` only once

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -958,6 +958,11 @@ endfunction()
 
 macro(add_swift_tool_symlink name dest component)
   add_llvm_tool_symlink(${name} ${dest} ALWAYS_GENERATE)
+  # This relies on the value of LLVM_TOOLS_INSTALL_DIR
+  # which is exported by LLVM in LLVMConfig.cmake
+  # (and currently set to "bin")
+  # TODO: This will stop working when we will pick up
+  # an llvm branch that contains https://reviews.llvm.org/D117977
   llvm_install_symlink(${name} ${dest} ALWAYS_GENERATE COMPONENT ${component})
 endmacro()
 

--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -120,27 +120,6 @@ add_swift_tool_symlink(swift-indent swift-frontend editor-integration)
 add_swift_tool_symlink(swift-api-digester swift-frontend compiler)
 
 add_dependencies(compiler swift-frontend)
-swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift${CMAKE_EXECUTABLE_SUFFIX}"
-                           DESTINATION "bin"
-                           COMPONENT compiler)
-swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swiftc${CMAKE_EXECUTABLE_SUFFIX}"
-                           DESTINATION "bin"
-                           COMPONENT compiler)
-swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-symbolgraph-extract${CMAKE_EXECUTABLE_SUFFIX}"
-                           DESTINATION "bin"
-                           COMPONENT compiler)
-swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-api-extract${CMAKE_EXECUTABLE_SUFFIX}"
-                           DESTINATION "bin"
-                           COMPONENT compiler)
-swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-api-digester${CMAKE_EXECUTABLE_SUFFIX}"
-                           DESTINATION "bin"
-                           COMPONENT compiler)
 add_dependencies(autolink-driver swift-frontend)
-swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-autolink-extract${CMAKE_EXECUTABLE_SUFFIX}"
-                           DESTINATION "bin"
-                           COMPONENT autolink-driver)
 add_dependencies(editor-integration swift-frontend)
-swift_install_in_component(FILES "${SWIFT_RUNTIME_OUTPUT_INTDIR}/swift-indent${CMAKE_EXECUTABLE_SUFFIX}"
-                           DESTINATION "bin"
-                           COMPONENT editor-integration)
 


### PR DESCRIPTION
To achieve to, rely solely on `add_swift_tool_symlink` and
 remove usages of `swift_install_in_component`.

This follows the intent of https://github.com/apple/swift/pull/6053.

Addresses rdar://101755409, supports rdar://101396797