### PR TITLE
Interop: Untangle circular dependency introduced by #59787

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -520,8 +520,6 @@ public:
     return ReplacedFunction;
   }
 
-  static SILFunction *getFunction(SILDeclRef ref, SILModule &M);
-
   void setDynamicallyReplacedFunction(SILFunction *f) {
     assert(ReplacedFunction == nullptr && "already set");
     assert(!hasObjCReplacement());

--- a/lib/IRGen/IRABIDetailsProvider.cpp
+++ b/lib/IRGen/IRABIDetailsProvider.cpp
@@ -20,6 +20,10 @@
 #include "IRGenModule.h"
 #include "NativeConventionSchema.h"
 
+// FIXME: This include should removed once getFunctionLoweredSignature() is
+//        updated to take a different approach.
+#include "../SILGen/SILGen.h"
+
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/IRGenOptions.h"
 #include "swift/AST/ParameterList.h"
@@ -126,7 +130,10 @@ public:
 
   llvm::Optional<LoweredFunctionSignature>
   getFunctionLoweredSignature(AbstractFunctionDecl *fd) {
-    auto function = SILFunction::getFunction(SILDeclRef(fd), *silMod);
+    auto declRef = SILDeclRef(fd);
+    auto function = Lowering::SILGenModule(*silMod, declRef.getModuleContext())
+                        .getFunction(declRef, swift::NotForDefinition);
+
     IGM.lowerSILFunction(function);
     auto silFuncType = function->getLoweredFunctionType();
     // FIXME: Async function support.

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -16,16 +16,18 @@
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILBridgingUtils.h"
 #include "swift/SIL/SILCloner.h"
+#include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILProfiler.h"
 #include "swift/SIL/CFG.h"
 #include "swift/SIL/PrettyStackTrace.h"
-#include "../../SILGen/SILGen.h"
 #include "swift/AST/Availability.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/Expr.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/Stmt.h"
 #include "swift/Basic/OptimizationMode.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Basic/BridgingUtils.h"
@@ -1029,9 +1031,4 @@ SILInstruction::MemoryBehavior SILFunction::getMemoryBehavior(bool observeRetain
 
   auto b = getMemBehvaiorFunction({this}, observeRetains);
   return (SILInstruction::MemoryBehavior)b;
-}
-
-SILFunction *SILFunction::getFunction(SILDeclRef ref, SILModule &M) {
-  swift::Lowering::SILGenModule SILGenModule(M, ref.getModuleContext());
-  return SILGenModule.getFunction(ref, swift::NotForDefinition);
 }


### PR DESCRIPTION
The changes for https://github.com/apple/swift/pull/59787 introduced a circular depenendcy between the SIL library and the SILGen library. I have undone this in the cheapest way possible as I don't have bandwidth to look into a more correct fix at the moment.
