### PR TITLE
SIL: Perform move-only diag passes after ClosureLifetimeFixup.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -129,27 +129,6 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   P.addNoReturnFolding();
   addDefiniteInitialization(P);
 
-  //===---
-  // Begin Ownership Optimizations
-  //
-
-  // Check noImplicitCopy and move only types for addresses.
-  P.addMoveOnlyAddressChecker();
-  // Check noImplicitCopy and move only types for objects
-  P.addMoveOnlyObjectChecker();
-  // Convert last destroy_value to deinits.
-  P.addMoveOnlyDeinitInsertion();
-  // Lower move only wrapped trivial types.
-  P.addTrivialMoveOnlyTypeEliminator();
-  // Check no uses after _move of a value in an address.
-  P.addMoveKillsCopyableAddressesChecker();
-  // No uses after _move of copyable value.
-  P.addMoveKillsCopyableValuesChecker();
-
-  //
-  // End Ownership Optimizations
-  //===---
-
   P.addAddressLowering();
 
   P.addFlowIsolation();
@@ -167,6 +146,30 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   // there.
   const auto &Options = P.getOptions();
   P.addClosureLifetimeFixup();
+
+  //===---
+  // Begin Ownership Optimizations
+  //
+  // These happen after ClosureLifetimeFixup because they depend on the
+  // resolution of nonescaping closure lifetimes to correctly check the use
+  // of move-only values as captures in nonescaping closures as borrows.
+
+  // Check noImplicitCopy and move only types for addresses.
+  P.addMoveOnlyAddressChecker();
+  // Check noImplicitCopy and move only types for objects
+  P.addMoveOnlyObjectChecker();
+  // Convert last destroy_value to deinits.
+  P.addMoveOnlyDeinitInsertion();
+  // Lower move only wrapped trivial types.
+  P.addTrivialMoveOnlyTypeEliminator();
+  // Check no uses after _move of a value in an address.
+  P.addMoveKillsCopyableAddressesChecker();
+  // No uses after _move of copyable value.
+  P.addMoveKillsCopyableValuesChecker();
+
+  //
+  // End Ownership Optimizations
+  //===---
 
 #ifndef NDEBUG
   // Add a verification pass to check our work when skipping


### PR DESCRIPTION
ClosureLifetimeFixup finalizes the lifetimes of nonescaping closures, which allows us to analyze their captures as borrows and permit move- only types to be captured by them.
