### PR TITLE
[Diagnostics] Diagnose type with mismatching generic arguments in ternary expr

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -794,6 +794,10 @@ bool GenericArgumentsMismatchFailure::diagnoseAsError() {
   } else {
     const auto &last = path.back();
     switch (last.getKind()) {
+    case ConstraintLocator::TernaryBranch:
+      diagnostic = diag::ternary_expr_cases_mismatch;
+      break;
+
     case ConstraintLocator::ContextualType: {
       auto purpose = getContextualTypePurpose();
       assert(!(purpose == CTP_Unused || purpose == CTP_CannotFail));

--- a/validation-test/Sema/SwiftUI/rdar98862079.swift
+++ b/validation-test/Sema/SwiftUI/rdar98862079.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+struct NewBounds {
+  var minBinding: Binding<Double>!
+  var maxBinding: Binding<Double>!
+}
+
+func test<V>(
+  value: Binding<V>,
+  in bounds: ClosedRange<V>
+) -> some View where V : BinaryFloatingPoint, V.Stride : BinaryFloatingPoint {
+  EmptyView()
+}
+
+struct MyView : View {
+  @State var newBounds: NewBounds
+  var bounds: ClosedRange<Double>
+
+  var body: some View {
+    test(value: true ? $newBounds.maxBinding : $newBounds.minBinding, in: bounds)
+    // expected-error@-1 2 {{result values in '? :' expression have mismatching types 'Binding<Binding<Double>?>' and 'Binding<Double>'}}
+    // expected-note@-2 2 {{arguments to generic parameter 'Value' ('Binding<Double>?' and 'Double') are expected to be equal}}
+  }
+}


### PR DESCRIPTION
Fixes a missing diagnostic related to types with mismatched 
generic arguments in one of both ternary branches.

Resolves: rdar://98862079

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
