### PR TITLE
SILOptimizer: Break circular dependency with SIL library by moving `canDuplicate()`

### DIFF
--- a/include/swift/SIL/LoopInfo.h
+++ b/include/swift/SIL/LoopInfo.h
@@ -46,10 +46,6 @@ public:
     return make_range(begin(), end());
   }
 
-  /// Check whether it is safe to duplicate this instruction when duplicating
-  /// this loop by unrolling or versioning.
-  bool canDuplicate(SILInstruction *Inst) const;
-
   void getExitingAndLatchBlocks(
     SmallVectorImpl<SILBasicBlock *> &ExitingAndLatchBlocks) const {
     this->getExitingBlocks(ExitingAndLatchBlocks);

--- a/include/swift/SILOptimizer/Utils/LoopUtils.h
+++ b/include/swift/SILOptimizer/Utils/LoopUtils.h
@@ -24,6 +24,7 @@ namespace swift {
 
 class SILFunction;
 class SILBasicBlock;
+class SILInstruction;
 class SILLoop;
 class DominanceInfo;
 class SILLoopInfo;
@@ -36,6 +37,10 @@ bool canonicalizeLoop(SILLoop *L, DominanceInfo *DT, SILLoopInfo *LI);
 /// Canonicalize all loops in the function F for which \p LI contains loop
 /// information. We update loop info and dominance info while we do this.
 bool canonicalizeAllLoops(DominanceInfo *DT, SILLoopInfo *LI);
+
+/// Check whether it is safe to duplicate this instruction when duplicating
+/// this loop by unrolling or versioning.
+bool canDuplicateLoopInstruction(SILLoop *L, SILInstruction *Inst);
 
 /// A visitor that visits loops in a function in a bottom up order. It only
 /// performs the visit.

--- a/lib/SIL/Utils/LoopInfo.cpp
+++ b/lib/SIL/Utils/LoopInfo.cpp
@@ -11,11 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/SIL/LoopInfo.h"
-#include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/Dominance.h"
-#include "swift/SIL/SILFunction.h"
-#include "swift/SIL/CFG.h"
-#include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
 #include "llvm/Analysis/LoopInfoImpl.h"
 #include "llvm/Support/Debug.h"
 
@@ -34,105 +30,6 @@ void SILLoop::dump() const {
 
 SILLoopInfo::SILLoopInfo(SILFunction *F, DominanceInfo *DT) : Dominance(DT) {
   LI.analyze(*Dominance);
-}
-
-bool SILLoop::canDuplicate(SILInstruction *I) const {
-  SinkAddressProjections sinkProj;
-  for (auto res : I->getResults()) {
-    if (!res->getType().isAddress()) {
-      continue;
-    }
-    auto canSink = sinkProj.analyzeAddressProjections(I);
-    if (!canSink) {
-      return false;
-    }
-  }
-
-  // The deallocation of a stack allocation must be in the loop, otherwise the
-  // deallocation will be fed by a phi node of two allocations.
-  if (I->isAllocatingStack()) {
-    for (auto *UI : cast<SingleValueInstruction>(I)->getUses()) {
-      if (UI->getUser()->isDeallocatingStack()) {
-        if (!contains(UI->getUser()->getParent()))
-          return false;
-      }
-    }
-    return true;
-  }
-  if (I->isDeallocatingStack()) {
-    SILInstruction *alloc = nullptr;
-    if (auto *dealloc = dyn_cast<DeallocStackInst>(I)) {
-      SILValue address = dealloc->getOperand();
-      if (isa<AllocStackInst>(address) || isa<PartialApplyInst>(address))
-        alloc = cast<SingleValueInstruction>(address);
-    }
-    if (auto *dealloc = dyn_cast<DeallocStackRefInst>(I))
-      alloc = dealloc->getAllocRef();
-
-    return alloc && contains(alloc);
-  }
-
-  // CodeGen can't build ssa for objc methods.
-  if (auto *Method = dyn_cast<MethodInst>(I)) {
-    if (Method->getMember().isForeign) {
-      for (auto *UI : Method->getUses()) {
-        if (!contains(UI->getUser()))
-          return false;
-      }
-    }
-    return true;
-  }
-
-  // We can't have a phi of two openexistential instructions of different UUID.
-  if (isa<OpenExistentialAddrInst>(I) || isa<OpenExistentialRefInst>(I) ||
-      isa<OpenExistentialMetatypeInst>(I) ||
-      isa<OpenExistentialValueInst>(I) || isa<OpenExistentialBoxInst>(I) ||
-      isa<OpenExistentialBoxValueInst>(I)) {
-    SingleValueInstruction *OI = cast<SingleValueInstruction>(I);
-    for (auto *UI : OI->getUses())
-      if (!contains(UI->getUser()))
-        return false;
-    return true;
-  }
-
-  if (isa<ThrowInst>(I))
-    return false;
-
-  // The entire access must be within the loop.
-  if (auto BAI = dyn_cast<BeginAccessInst>(I)) {
-    for (auto *UI : BAI->getUses()) {
-      if (!contains(UI->getUser()))
-        return false;
-    }
-    return true;
-  }
-  // The entire coroutine execution must be within the loop.
-  // Note that we don't have to worry about the reverse --- a loop which
-  // contains an end_apply or abort_apply of an external begin_apply ---
-  // because that wouldn't be structurally valid in the first place.
-  if (auto BAI = dyn_cast<BeginApplyInst>(I)) {
-    for (auto UI : BAI->getTokenResult()->getUses()) {
-      auto User = UI->getUser();
-      assert(isa<EndApplyInst>(User) || isa<AbortApplyInst>(User));
-      if (!contains(User))
-        return false;
-    }
-    return true;
-  }
-
-  if (isa<DynamicMethodBranchInst>(I))
-    return false;
-
-  // Can't duplicate get/await_async_continuation.
-  if (isa<AwaitAsyncContinuationInst>(I) ||
-      isa<GetAsyncContinuationAddrInst>(I) || isa<GetAsyncContinuationInst>(I))
-    return false;
-
-  // Some special cases above that aren't considered isTriviallyDuplicatable
-  // return true early.
-  assert(I->isTriviallyDuplicatable() &&
-    "Code here must match isTriviallyDuplicatable in SILInstruction");
-  return true;
 }
 
 void SILLoopInfo::verify() const {

--- a/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/ArrayPropertyOpt.cpp
@@ -57,6 +57,7 @@
 #include "swift/SILOptimizer/Analysis/LoopAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
+#include "swift/SILOptimizer/Utils/LoopUtils.h"
 #include "swift/SILOptimizer/Utils/SILSSAUpdater.h"
 #include "swift/SIL/CFG.h"
 #include "swift/SIL/DebugUtils.h"
@@ -172,7 +173,7 @@ public:
       for (auto &Inst : *BB) {
         // Can't clone alloc_stack instructions whose dealloc_stack is outside
         // the loop.
-        if (!Loop->canDuplicate(&Inst))
+        if (!canDuplicateLoopInstruction(Loop, &Inst))
           return false;
 
         ArraySemanticsCall ArrayPropsInst(&Inst, "array.props", true);

--- a/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopUnroll.cpp
@@ -20,6 +20,7 @@
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
+#include "swift/SILOptimizer/Utils/LoopUtils.h"
 #include "swift/SILOptimizer/Utils/PerformanceInlinerUtils.h"
 #include "swift/SILOptimizer/Utils/SILInliner.h"
 #include "swift/SILOptimizer/Utils/SILSSAUpdater.h"
@@ -213,7 +214,7 @@ static bool canAndShouldUnrollLoop(SILLoop *Loop, uint64_t TripCount) {
     (Loop->getBlocks())[0]->getParent()->getModule().getOptions().UnrollThreshold;
   for (auto *BB : Loop->getBlocks()) {
     for (auto &Inst : *BB) {
-      if (!Loop->canDuplicate(&Inst))
+      if (!canDuplicateLoopInstruction(Loop, &Inst))
         return false;
       if (instructionInlineCost(Inst) != InlineCost::Free)
         ++Cost;

--- a/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/BasicBlockOptUtils.cpp
@@ -15,6 +15,7 @@
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "swift/SILOptimizer/Utils/OwnershipOptUtils.h"
 #include "swift/SILOptimizer/Utils/SILSSAUpdater.h"
+#include "swift/SIL/LoopInfo.h"
 
 using namespace swift;
 

--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -12,6 +12,7 @@
 
 #define DEBUG_TYPE "sil-loop-utils"
 #include "swift/SILOptimizer/Utils/LoopUtils.h"
+#include "swift/SILOptimizer/Utils/BasicBlockOptUtils.h"
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/LoopInfo.h"
@@ -214,6 +215,106 @@ bool swift::canonicalizeAllLoops(DominanceInfo *DT, SILLoopInfo *LI) {
 
   return MadeChange;
 }
+
+bool swift::canDuplicateLoopInstruction(SILLoop *L, SILInstruction *I) {
+  SinkAddressProjections sinkProj;
+  for (auto res : I->getResults()) {
+    if (!res->getType().isAddress()) {
+      continue;
+    }
+    auto canSink = sinkProj.analyzeAddressProjections(I);
+    if (!canSink) {
+      return false;
+    }
+  }
+
+  // The deallocation of a stack allocation must be in the loop, otherwise the
+  // deallocation will be fed by a phi node of two allocations.
+  if (I->isAllocatingStack()) {
+    for (auto *UI : cast<SingleValueInstruction>(I)->getUses()) {
+      if (UI->getUser()->isDeallocatingStack()) {
+        if (!L->contains(UI->getUser()->getParent()))
+          return false;
+      }
+    }
+    return true;
+  }
+  if (I->isDeallocatingStack()) {
+    SILInstruction *alloc = nullptr;
+    if (auto *dealloc = dyn_cast<DeallocStackInst>(I)) {
+      SILValue address = dealloc->getOperand();
+      if (isa<AllocStackInst>(address) || isa<PartialApplyInst>(address))
+        alloc = cast<SingleValueInstruction>(address);
+    }
+    if (auto *dealloc = dyn_cast<DeallocStackRefInst>(I))
+      alloc = dealloc->getAllocRef();
+
+    return alloc && L->contains(alloc);
+  }
+
+  // CodeGen can't build ssa for objc methods.
+  if (auto *Method = dyn_cast<MethodInst>(I)) {
+    if (Method->getMember().isForeign) {
+      for (auto *UI : Method->getUses()) {
+        if (!L->contains(UI->getUser()))
+          return false;
+      }
+    }
+    return true;
+  }
+
+  // We can't have a phi of two openexistential instructions of different UUID.
+  if (isa<OpenExistentialAddrInst>(I) || isa<OpenExistentialRefInst>(I) ||
+      isa<OpenExistentialMetatypeInst>(I) ||
+      isa<OpenExistentialValueInst>(I) || isa<OpenExistentialBoxInst>(I) ||
+      isa<OpenExistentialBoxValueInst>(I)) {
+    SingleValueInstruction *OI = cast<SingleValueInstruction>(I);
+    for (auto *UI : OI->getUses())
+      if (!L->contains(UI->getUser()))
+        return false;
+    return true;
+  }
+
+  if (isa<ThrowInst>(I))
+    return false;
+
+  // The entire access must be within the loop.
+  if (auto BAI = dyn_cast<BeginAccessInst>(I)) {
+    for (auto *UI : BAI->getUses()) {
+      if (!L->contains(UI->getUser()))
+        return false;
+    }
+    return true;
+  }
+  // The entire coroutine execution must be within the loop.
+  // Note that we don't have to worry about the reverse --- a loop which
+  // contains an end_apply or abort_apply of an external begin_apply ---
+  // because that wouldn't be structurally valid in the first place.
+  if (auto BAI = dyn_cast<BeginApplyInst>(I)) {
+    for (auto UI : BAI->getTokenResult()->getUses()) {
+      auto User = UI->getUser();
+      assert(isa<EndApplyInst>(User) || isa<AbortApplyInst>(User));
+      if (!L->contains(User))
+        return false;
+    }
+    return true;
+  }
+
+  if (isa<DynamicMethodBranchInst>(I))
+    return false;
+
+  // Can't duplicate get/await_async_continuation.
+  if (isa<AwaitAsyncContinuationInst>(I) ||
+      isa<GetAsyncContinuationAddrInst>(I) || isa<GetAsyncContinuationInst>(I))
+    return false;
+
+  // Some special cases above that aren't considered isTriviallyDuplicatable
+  // return true early.
+  assert(I->isTriviallyDuplicatable() &&
+    "Code here must match isTriviallyDuplicatable in SILInstruction");
+  return true;
+}
+
 
 //===----------------------------------------------------------------------===//
 //                                Loop Visitor


### PR DESCRIPTION
Fixes a cycle introduced by https://github.com/apple/swift/pull/61051.
