### PR TITLE
[Demangler] Remove and replace DEMANGLER_ALWAYS_ASSERT

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -343,7 +343,7 @@ Node::iterator Node::end() const {
 }
 
 void Node::addChild(NodePointer Child, NodeFactory &Factory) {
-  DEMANGLER_ALWAYS_ASSERT(Child, this);
+  assert(Child);
   switch (NodePayloadKind) {
     case PayloadKind::None:
       InlineChildren[0] = Child;

--- a/lib/Demangling/DemanglerAssert.h
+++ b/lib/Demangling/DemanglerAssert.h
@@ -47,13 +47,6 @@
 
 #endif
 
-// DEMANGLER_ALWAYS_ASSERT() *always* fails the program, even in the runtime
-#define DEMANGLER_ALWAYS_ASSERT(expr, node)                                    \
-  do {                                                                         \
-    if (!(expr))                                                               \
-      swift::Demangle::failAssert(__FILE__, __LINE__, node, #expr);            \
-  } while (0)
-
 namespace swift {
 namespace Demangle {
 SWIFT_BEGIN_INLINE_NAMESPACE


### PR DESCRIPTION
Originally added in https://github.com/apple/swift/pull/41452, `DEMANGLER_ALWAYS_ASSERT` is resulting in crashes in LLDB. This reverts to a regular `assert`.

rdar://97035347