### PR TITLE
[Macros] Provide the Declared Type of Macros to the Constraint System

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -124,6 +124,7 @@ namespace swift {
   class DiagnosticEngine;
   struct RawComment;
   class DocComment;
+  class StructDecl;
   class SILBoxType;
   class SILTransform;
   class TypeAliasDecl;
@@ -1434,6 +1435,14 @@ public:
 
   /// The declared interface type of Builtin.TheTupleType.
   BuiltinTupleType *getBuiltinTupleType();
+
+  /// Look up a macro's evaluation context by name.
+  ///
+  /// If no such macro or evaluation context is found under this name, this
+  /// method returns \c nullptr.
+  StructDecl *getOrCreateASTGenMacroContext(
+      StringRef macroName,
+      llvm::function_ref<StructDecl *(StringRef)> createMacro);
 
 private:
   friend Decl;

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -124,7 +124,6 @@ namespace swift {
   class DiagnosticEngine;
   struct RawComment;
   class DocComment;
-  class StructDecl;
   class SILBoxType;
   class SILTransform;
   class TypeAliasDecl;
@@ -1435,14 +1434,6 @@ public:
 
   /// The declared interface type of Builtin.TheTupleType.
   BuiltinTupleType *getBuiltinTupleType();
-
-  /// Look up a macro's evaluation context by name.
-  ///
-  /// If no such macro or evaluation context is found under this name, this
-  /// method returns \c nullptr.
-  StructDecl *getOrCreateASTGenMacroContext(
-      StringRef macroName,
-      llvm::function_ref<StructDecl *(StringRef)> createMacro);
 
 private:
   friend Decl;

--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -191,7 +191,6 @@ void TopLevelCodeDecl_dump(void *);
 void Expr_dump(void *);
 void Decl_dump(void *);
 void Stmt_dump(void *);
-void TypeRepr_dump(void *);
 
 #ifdef __cplusplus
 }

--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -58,6 +58,33 @@ typedef struct {
   void *Type;
   void *_Nullable TrailingCommaLoc;
 } BridgedTupleTypeElement;
+
+typedef enum __attribute__((enum_extensibility(open))) BridgedRequirementReprKind : long {
+  /// A type bound T : P, where T is a type that depends on a generic
+  /// parameter and P is some type that should bound T, either as a concrete
+  /// supertype or a protocol to which T must conform.
+  BridgedRequirementReprKindTypeConstraint,
+
+  /// A same-type requirement T == U, where T and U are types that shall be
+  /// equivalent.
+  BridgedRequirementReprKindSameType,
+
+  /// A layout bound T : L, where T is a type that depends on a generic
+  /// parameter and L is some layout specification that should bound T.
+  BridgedRequirementReprKindLayoutConstraint,
+
+  // Note: there is code that packs this enum in a 2-bit bitfield.  Audit users
+  // when adding enumerators.
+} BridgedRequirementReprKind;
+
+typedef struct {
+  void *_Nullable SeparatorLoc;
+  BridgedRequirementReprKind Kind;
+  void *FirstType;
+  void *SecondType;
+  // FIXME: Handle Layout Requirements
+} BridgedRequirementRepr;
+
 #ifdef __cplusplus
 extern "C" {
 
@@ -133,7 +160,7 @@ struct DeclContextAndDecl {
 };
 
 struct DeclContextAndDecl StructDecl_create(
-    void *ctx, void *loc, BridgedIdentifier name, void *nameLoc, void *dc);
+    void *ctx, void *loc, BridgedIdentifier name, void *nameLoc, void *_Nullable genericParams, void *dc);
 struct DeclContextAndDecl ClassDecl_create(
     void *ctx, void *loc, BridgedIdentifier name, void *nameLoc, void *dc);
 
@@ -152,11 +179,19 @@ void *FunctionTypeRepr_create(void *ctx, void *argsTy, void *_Nullable asyncLoc,
 void *NamedOpaqueReturnTypeRepr_create(void *ctx, void *baseTy);
 void *OpaqueReturnTypeRepr_create(void *ctx, void *opaqueLoc, void *baseTy);
 void *ExistentialTypeRepr_create(void *ctx, void *anyLoc, void *baseTy);
+void *GenericParamList_create(void *ctx, void *lAngleLoc, BridgedArrayRef params, void *_Nullable whereLoc, BridgedArrayRef reqs, void *rAngleLoc);
+void *GenericTypeParamDecl_create(void *ctx, void *declContext, BridgedIdentifier name, void *nameLoc, void *_Nullable ellipsisLoc, long index, _Bool isParameterPack);
+void GenericTypeParamDecl_setInheritedType(void *ctx, void *Param, void *ty);
+
+struct DeclContextAndDecl TypeAliasDecl_create(void *ctx, void *declContext, void *aliasLoc, void *equalLoc, BridgedIdentifier name, void *nameLoc, void *_Nullable genericParams);
+void TypeAliasDecl_setUnderlyingTypeRepr(void *decl, void *underlyingType);
+
 
 void TopLevelCodeDecl_dump(void *);
 void Expr_dump(void *);
 void Decl_dump(void *);
 void Stmt_dump(void *);
+void TypeRepr_dump(void *);
 
 #ifdef __cplusplus
 }

--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -14,6 +14,7 @@
 #define SWIFT_C_AST_ASTBRIDGING_H
 
 #include <inttypes.h>
+#include "swift/Basic/Compiler.h"
 
 #if __clang__
 // Provide macros to temporarily suppress warning about the use of
@@ -59,7 +60,7 @@ typedef struct {
   void *_Nullable TrailingCommaLoc;
 } BridgedTupleTypeElement;
 
-typedef enum __attribute__((enum_extensibility(open))) BridgedRequirementReprKind : long {
+typedef enum ENUM_EXTENSIBILITY_ATTR(open) BridgedRequirementReprKind : long {
   /// A type bound T : P, where T is a type that depends on a generic
   /// parameter and P is some type that should bound T, either as a concrete
   /// supertype or a protocol to which T must conform.

--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -48,6 +48,16 @@ typedef struct {
 
 typedef void *BridgedIdentifier;
 
+typedef struct {
+  BridgedIdentifier _Nullable Name;
+  void *_Nullable NameLoc;
+  BridgedIdentifier _Nullable SecondName;
+  void *_Nullable SecondNameLoc;
+  void *_Nullable UnderscoreLoc;
+  void *_Nullable ColonLoc;
+  void *Type;
+  void *_Nullable TrailingCommaLoc;
+} BridgedTupleTypeElement;
 #ifdef __cplusplus
 extern "C" {
 
@@ -126,6 +136,22 @@ struct DeclContextAndDecl StructDecl_create(
     void *ctx, void *loc, BridgedIdentifier name, void *nameLoc, void *dc);
 struct DeclContextAndDecl ClassDecl_create(
     void *ctx, void *loc, BridgedIdentifier name, void *nameLoc, void *dc);
+
+void *ArrayTypeRepr_create(void *ctx, void *base, void *lsquareLoc, void *rsquareLoc);
+void *DictionaryTypeRepr_create(void *ctx, void *keyType, void *valueType, void *lsquareLoc, void *colonloc, void *rsquareLoc);
+void *OptionalTypeRepr_create(void *ctx, void *base, void *questionLoc);
+void *ImplicitlyUnwrappedOptionalTypeRepr_create(void *ctx, void *base, void *exclamationLoc);
+void *MetatypeTypeRepr_create(void *ctx, void *baseType, void *typeLoc);
+void *ProtocolTypeRepr_create(void *ctx, void *baseType, void *protoLoc);
+void *PackExpansionTypeRepr_create(void *ctx, void *base, void *ellipsisLoc);
+void *TupleTypeRepr_create(void *ctx, BridgedArrayRef elements, void *lParenLoc, void *rParenLoc);
+void *IdentTypeRepr_create(void *ctx, BridgedArrayRef components);
+void *GenericIdentTypeRepr_create(void *ctx, BridgedIdentifier name, void *nameLoc, BridgedArrayRef genericArgs, void *lAngle, void *rAngle);
+void *CompositionTypeRepr_create(void *ctx, BridgedArrayRef types, void *firstTypeLoc);
+void *FunctionTypeRepr_create(void *ctx, void *argsTy, void *_Nullable asyncLoc, void *_Nullable throwsLoc, void *arrowLoc, void *returnType);
+void *NamedOpaqueReturnTypeRepr_create(void *ctx, void *baseTy);
+void *OpaqueReturnTypeRepr_create(void *ctx, void *opaqueLoc, void *baseTy);
+void *ExistentialTypeRepr_create(void *ctx, void *anyLoc, void *baseTy);
 
 void TopLevelCodeDecl_dump(void *);
 void Expr_dump(void *);

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -6013,20 +6013,23 @@ public:
 
 class MacroExpansionExpr final : public Expr {
 private:
-  Expr *Macro;
-  Expr *Rewritten;
-  ArgumentList *ArgList;
   SourceLoc PoundLoc;
+  DeclNameRef MacroName;
+  DeclNameLoc MacroNameLoc;
+  ArgumentList *ArgList;
+  Expr *Rewritten;
 
 public:
-  explicit MacroExpansionExpr(SourceLoc poundLoc, Expr *macro,
+  explicit MacroExpansionExpr(SourceLoc poundLoc, DeclNameRef macroName,
+                              DeclNameLoc macroNameLoc,
                               ArgumentList *argList, bool isImplicit = false,
                               Type ty = Type())
-      : Expr(ExprKind::MacroExpansion, isImplicit, ty), Macro(macro),
-        Rewritten(nullptr), ArgList(argList), PoundLoc(poundLoc) {}
+      : Expr(ExprKind::MacroExpansion, isImplicit, ty), PoundLoc(poundLoc),
+        MacroName(macroName), MacroNameLoc(macroNameLoc), ArgList(argList),
+        Rewritten(nullptr) { }
 
-  Expr *getMacro() const { return Macro; }
-  void setMacro(Expr *macro) { Macro = macro; }
+  DeclNameRef getMacroName() const { return MacroName; }
+  DeclNameLoc getMacroNameLoc() const { return MacroNameLoc; }
 
   Expr *getRewritten() const { return Rewritten; }
   void setRewritten(Expr *rewritten) { Rewritten = rewritten; }
@@ -6038,7 +6041,7 @@ public:
 
   SourceRange getSourceRange() const {
     return SourceRange(
-        PoundLoc, ArgList ? ArgList->getEndLoc() : Macro->getEndLoc());
+        PoundLoc, ArgList ? ArgList->getEndLoc() : MacroNameLoc.getEndLoc());
   }
 
   static bool classof(const Expr *E) {

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3754,6 +3754,40 @@ public:
   bool isCached() const { return true; }
 };
 
+
+/// Retrieves the evaluation context of a macro with the given name.
+///
+/// The macro evaluation context is a user-defined generic signature and return
+/// type that serves as the "interface type" of references to the macro. The
+/// current implementation takes those pieces of syntax from the macro itself,
+/// then inserts them into a Swift struct that looks like
+///
+/// \code
+/// struct __MacroEvaluationContext\(macro.genericSignature) {
+///   typealias SignatureType = \(macro.signature)
+/// }
+/// \endcode
+///
+/// So that we can use all of Swift's native name lookup and type resolution
+/// facilities to map the parsed signature type back into a semantic \c Type
+/// AST and a set of requiremnets.
+class MacroContextRequest
+    : public SimpleRequest<MacroContextRequest,
+                           StructDecl *(std::string, ModuleDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  StructDecl *evaluate(Evaluator &evaluator,
+                       std::string macroName, ModuleDecl *mod) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 void simple_display(llvm::raw_ostream &out, ASTNode node);
 void simple_display(llvm::raw_ostream &out, Type value);
 void simple_display(llvm::raw_ostream &out, const TypeRepr *TyR);

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -443,3 +443,6 @@ SWIFT_REQUEST(TypeChecker, GetTypeWrapperInitializer,
 SWIFT_REQUEST(TypeChecker, SynthesizeHasSymbolQueryRequest,
               FuncDecl *(ValueDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, MacroContextRequest,
+              StructDecl *(std::string, ModuleDecl *),
+              Cached, NoLocationInfo)

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4906,6 +4906,12 @@ public:
                           ConstraintLocator *locator,
                           OpenedTypeMap *replacements = nullptr);
 
+  /// Retrieve the opened type of a macro with the given name.
+  ///
+  /// \returns The opened type of the macro with this name, or the null \c Type
+  /// if no such macro exists.
+  Type getTypeOfMacroReference(StringRef macro, Expr *anchor);
+
   /// Retrieve a list of generic parameter types solver has "opened" (replaced
   /// with a type variable) at the given location.
   ArrayRef<OpenedType> getOpenedTypes(ConstraintLocator *locator) const {

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4906,11 +4906,13 @@ public:
                           ConstraintLocator *locator,
                           OpenedTypeMap *replacements = nullptr);
 
+#if SWIFT_SWIFT_PARSER
   /// Retrieve the opened type of a macro with the given name.
   ///
   /// \returns The opened type of the macro with this name, or the null \c Type
   /// if no such macro exists.
   Type getTypeOfMacroReference(StringRef macro, Expr *anchor);
+#endif
 
   /// Retrieve a list of generic parameter types solver has "opened" (replaced
   /// with a type variable) at the given location.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -394,9 +394,6 @@ struct ASTContext::Implementation {
   /// is populated if the body is reparsed from other source buffers.
   llvm::DenseMap<const AbstractFunctionDecl *, SourceRange> OriginalBodySourceRanges;
 
-  /// A mapping of all the registered ASTGen macros keyed by name.
-  llvm::StringMap<StructDecl *> ASTGenMacros;
-
   /// Structure that captures data that is segregated into different
   /// arenas.
   struct Arena {
@@ -6034,18 +6031,4 @@ BuiltinTupleType *ASTContext::getBuiltinTupleType() {
   result = new (*this) BuiltinTupleType(getBuiltinTupleDecl(), *this);
 
   return result;
-}
-
-StructDecl *ASTContext::getOrCreateASTGenMacroContext(
-    StringRef macroName,
-    llvm::function_ref<StructDecl *(StringRef)> createMacro) {
-  auto &impl = getImpl();
-  auto found = impl.ASTGenMacros.find(macroName);
-  if (found != impl.ASTGenMacros.end()) {
-    return found->second;
-  } else {
-    auto macroAndContext = createMacro(macroName);
-    impl.ASTGenMacros.insert({macroName, macroAndContext});
-    return macroAndContext;
-  }
 }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -394,6 +394,9 @@ struct ASTContext::Implementation {
   /// is populated if the body is reparsed from other source buffers.
   llvm::DenseMap<const AbstractFunctionDecl *, SourceRange> OriginalBodySourceRanges;
 
+  /// A mapping of all the registered ASTGen macros keyed by name.
+  llvm::StringMap<StructDecl *> ASTGenMacros;
+
   /// Structure that captures data that is segregated into different
   /// arenas.
   struct Arena {
@@ -6031,4 +6034,18 @@ BuiltinTupleType *ASTContext::getBuiltinTupleType() {
   result = new (*this) BuiltinTupleType(getBuiltinTupleDecl(), *this);
 
   return result;
+}
+
+StructDecl *ASTContext::getOrCreateASTGenMacroContext(
+    StringRef macroName,
+    llvm::function_ref<StructDecl *(StringRef)> createMacro) {
+  auto &impl = getImpl();
+  auto found = impl.ASTGenMacros.find(macroName);
+  if (found != impl.ASTGenMacros.end()) {
+    return found->second;
+  } else {
+    auto macroAndContext = createMacro(macroName);
+    impl.ASTGenMacros.insert({macroName, macroAndContext});
+    return macroAndContext;
+  }
 }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2976,8 +2976,7 @@ public:
 
   void visitMacroExpansionExpr(MacroExpansionExpr *E) {
     printCommon(E, "macro_expansion_expr");
-    OS << '\n';
-    printRec(E->getMacro());
+    PrintWithColorRAII(OS, IdentifierColor) << " name=" << E->getMacroName();
     if (E->getArgs()) {
       OS << '\n';
       printArgumentList(E->getArgs());

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1247,8 +1247,6 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   Expr *visitMacroExpansionExpr(MacroExpansionExpr *E) {
-    auto *macro = doIt(E->getMacro());
-    if (!macro) return nullptr;
     Expr *rewritten = nullptr;
     if (E->getRewritten()) {
       rewritten = doIt(E->getRewritten());
@@ -1259,7 +1257,6 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
       args = doIt(E->getArgs());
       if (!args) return nullptr;
     }
-    E->setMacro(macro);
     E->setRewritten(rewritten);
     E->setArgs(args);
     return E;

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -458,4 +458,3 @@ void TopLevelCodeDecl_dump(void *decl) { ((TopLevelCodeDecl *)decl)->dump(llvm::
 void Expr_dump(void *expr) { ((Expr *)expr)->dump(llvm::errs()); }
 void Decl_dump(void *expr) { ((Decl *)expr)->dump(llvm::errs()); }
 void Stmt_dump(void *expr) { ((Stmt *)expr)->dump(llvm::errs()); }
-void TypeRepr_dump(void *repr) { ((TypeRepr *)repr)->dump(); }

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -226,8 +226,9 @@ void *SimpleIdentTypeRepr_create(void *ctx, void *loc, BridgedIdentifier id) {
       DeclNameRef(Identifier::getFromOpaquePointer(id)));
 }
 
-
-void *GenericIdentTypeRepr_create(void *ctx, BridgedIdentifier name, void *nameLoc, BridgedArrayRef genericArgs, void *lAngle, void *rAngle) {
+void *GenericIdentTypeRepr_create(void *ctx, BridgedIdentifier name,
+                                  void *nameLoc, BridgedArrayRef genericArgs,
+                                  void *lAngle, void *rAngle) {
   ASTContext &Context = *static_cast<ASTContext *>(ctx);
   auto Loc = DeclNameLoc(getSourceLocFromPointer(nameLoc));
   auto Name = DeclNameRef(Identifier::getFromOpaquePointer(name));
@@ -268,8 +269,9 @@ void NominalTypeDecl_setMembers(void *decl, BridgedArrayRef members) {
     ((NominalTypeDecl *)decl)->addMember(m);
 }
 
-DeclContextAndDecl StructDecl_create(
-    void *ctx, void *loc, BridgedIdentifier name, void *nameLoc, void *_Nullable genericParams, void *dc) {
+DeclContextAndDecl StructDecl_create(void *ctx, void *loc,
+                                     BridgedIdentifier name, void *nameLoc,
+                                     void *_Nullable genericParams, void *dc) {
   ASTContext &Context = *static_cast<ASTContext *>(ctx);
   auto *out = new (Context) StructDecl(getSourceLocFromPointer(loc),
                                        Identifier::getFromOpaquePointer(name),
@@ -310,7 +312,9 @@ void *ArrayTypeRepr_create(void *ctx, void *base, void *lsquareLoc, void *rsquar
   return new (Context) ArrayTypeRepr((TypeRepr *)base, SourceRange{lSquareLoc, rSquareLoc});
 }
 
-void *DictionaryTypeRepr_create(void *ctx, void *keyType, void *valueType, void *lsquareLoc, void *colonloc, void *rsquareLoc) {
+void *DictionaryTypeRepr_create(void *ctx, void *keyType, void *valueType,
+                                void *lsquareLoc, void *colonloc,
+                                void *rsquareLoc) {
   ASTContext &Context = *static_cast<ASTContext *>(ctx);
   SourceLoc lSquareLoc = getSourceLocFromPointer(lsquareLoc);
   SourceLoc colonLoc = getSourceLocFromPointer(colonloc);
@@ -367,7 +371,9 @@ void *CompositionTypeRepr_create(void *ctx, BridgedArrayRef types, void *firstTy
   return CompositionTypeRepr::create(Context, getArrayRef<TypeRepr *>(types), firstType, SourceRange{});
 }
 
-void *FunctionTypeRepr_create(void *ctx, void *argsTy, void *_Nullable asyncLoc, void *_Nullable throwsLoc, void *arrowLoc, void *returnType) {
+void *FunctionTypeRepr_create(void *ctx, void *argsTy, void *_Nullable asyncLoc,
+                              void *_Nullable throwsLoc, void *arrowLoc,
+                              void *returnType) {
   ASTContext &Context = *static_cast<ASTContext *>(ctx);
   return new (Context) FunctionTypeRepr(nullptr,
                                         (TupleTypeRepr *)argsTy,
@@ -391,25 +397,27 @@ void *ExistentialTypeRepr_create(void *ctx, void *anyLoc, void *baseTy) {
   return new (Context) ExistentialTypeRepr(getSourceLocFromPointer(anyLoc), (TypeRepr *)baseTy);
 }
 
-void *GenericParamList_create(void *ctx, void *lAngleLoc, BridgedArrayRef params, void *_Nullable whereLoc, BridgedArrayRef reqs, void *rAngleLoc) {
+void *GenericParamList_create(void *ctx, void *lAngleLoc,
+                              BridgedArrayRef params, void *_Nullable whereLoc,
+                              BridgedArrayRef reqs, void *rAngleLoc) {
   ASTContext &Context = *static_cast<ASTContext *>(ctx);
   SmallVector<RequirementRepr> requirements;
   for (auto req : getArrayRef<BridgedRequirementRepr>(reqs)) {
     switch (req.Kind) {
     case BridgedRequirementReprKindTypeConstraint:
-        requirements.push_back(
-            RequirementRepr::getTypeConstraint((TypeRepr *)req.FirstType,
-                                               getSourceLocFromPointer(req.SeparatorLoc),
-                                               (TypeRepr *)req.SecondType));
-        break;
+      requirements.push_back(
+          RequirementRepr::getTypeConstraint((TypeRepr *)req.FirstType,
+                                             getSourceLocFromPointer(req.SeparatorLoc),
+                                             (TypeRepr *)req.SecondType));
+      break;
     case BridgedRequirementReprKindSameType:
-        requirements.push_back(
-            RequirementRepr::getSameType((TypeRepr *)req.FirstType,
-                                         getSourceLocFromPointer(req.SeparatorLoc),
-                                         (TypeRepr *)req.SecondType));
-        break;
+      requirements.push_back(
+          RequirementRepr::getSameType((TypeRepr *)req.FirstType,
+                                       getSourceLocFromPointer(req.SeparatorLoc),
+                                       (TypeRepr *)req.SecondType));
+      break;
     case BridgedRequirementReprKindLayoutConstraint:
-        llvm_unreachable("cannot handle layout constraints!");
+      llvm_unreachable("cannot handle layout constraints!");
     }
   }
   return GenericParamList::create(Context,
@@ -420,7 +428,10 @@ void *GenericParamList_create(void *ctx, void *lAngleLoc, BridgedArrayRef params
                                   getSourceLocFromPointer(rAngleLoc));
 }
 
-void *GenericTypeParamDecl_create(void *ctx, void *declContext, BridgedIdentifier name, void *nameLoc, void *_Nullable ellipsisLoc, long index, bool isParameterPack) {
+void *GenericTypeParamDecl_create(void *ctx, void *declContext,
+                                  BridgedIdentifier name, void *nameLoc,
+                                  void *_Nullable ellipsisLoc, long index,
+                                  bool isParameterPack) {
   return GenericTypeParamDecl::createParsed(static_cast<DeclContext *>(declContext),
                                             Identifier::getFromOpaquePointer(name),
                                             getSourceLocFromPointer(nameLoc),
@@ -437,8 +448,10 @@ void GenericTypeParamDecl_setInheritedType(void *ctx, void *Param, void *ty) {
   ((GenericTypeParamDecl *)Param)->setInherited(entries);
 }
 
-
-DeclContextAndDecl TypeAliasDecl_create(void *ctx, void *declContext, void *aliasLoc, void *equalLoc, BridgedIdentifier name, void *nameLoc, void *_Nullable genericParams) {
+DeclContextAndDecl TypeAliasDecl_create(void *ctx, void *declContext,
+                                        void *aliasLoc, void *equalLoc,
+                                        BridgedIdentifier name, void *nameLoc,
+                                        void *_Nullable genericParams) {
   ASTContext &Context = *static_cast<ASTContext *>(ctx);
   auto *out = new (Context) TypeAliasDecl(getSourceLocFromPointer(aliasLoc),
                                           getSourceLocFromPointer(equalLoc),

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -8,6 +8,7 @@ if (SWIFT_SWIFT_PARSER)
     Sources/ASTGen/Misc.swift
     Sources/ASTGen/SourceFile.swift
     Sources/ASTGen/Stmts.swift
+    Sources/ASTGen/Types.swift
   )
 
   # Set the appropriate target triple.

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -3,6 +3,7 @@ if (SWIFT_SWIFT_PARSER)
     Sources/ASTGen/ASTGen.swift
     Sources/ASTGen/Decls.swift
     Sources/ASTGen/Exprs.swift
+    Sources/ASTGen/Generics.swift
     Sources/ASTGen/Literals.swift
     Sources/ASTGen/Macros.swift
     Sources/ASTGen/Misc.swift

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -41,17 +41,6 @@ extension ASTGenVisitor {
     return SwiftIdentifierExpr_create(ctx, id, loc)
   }
 
-  public func visit(_ node: SimpleTypeIdentifierSyntax) -> UnsafeMutableRawPointer {
-    let loc = self.base.advanced(by: node.position.utf8Offset).raw
-    
-    var text = node.name.text
-    let id = text.withUTF8 { buf in
-      return SwiftASTContext_getIdentifier(ctx, buf.baseAddress, buf.count)
-    }
-
-    return SimpleIdentTypeRepr_create(ctx, loc, id)
-  }
-
   public func visit(_ node: IdentifierPatternSyntax) -> UnsafeMutableRawPointer {
     let loc = self.base.advanced(by: node.position.utf8Offset).raw
     

--- a/lib/ASTGen/Sources/ASTGen/Generics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Generics.swift
@@ -1,0 +1,79 @@
+import SwiftParser
+import SwiftSyntax
+
+import CASTBridging
+
+extension ASTGenVisitor {
+  func visit(_ node: GenericParameterClauseSyntax) -> UnsafeMutableRawPointer {
+    let lAngleLoc = self.base.advanced(by: node.leftAngleBracket.position.utf8Offset).raw
+    let whereLoc = node.genericWhereClause.map { self.base.advanced(by: $0.whereKeyword.position.utf8Offset).raw }
+    let rAngleLoc = self.base.advanced(by: node.rightAngleBracket.position.utf8Offset).raw
+    return self.withBridgedParametersAndRequirements(node) { params, reqs in
+      return GenericParamList_create(self.ctx, lAngleLoc, params, whereLoc, reqs, rAngleLoc)
+    }
+  }
+
+  func visit(_ node: GenericParameterSyntax) -> UnsafeMutableRawPointer {
+    var nodeName = node.name.text
+    let name = nodeName.withUTF8 { buf in
+      return SwiftASTContext_getIdentifier(ctx, buf.baseAddress, buf.count)
+    }
+    let nameLoc = self.base.advanced(by: node.name.position.utf8Offset).raw
+    let ellipsisLoc = node.ellipsis.map { self.base.advanced(by: $0.position.utf8Offset).raw }
+
+    return GenericTypeParamDecl_create(self.ctx, self.declContext, name, nameLoc, ellipsisLoc, node.indexInParent / 2, ellipsisLoc != nil)
+  }
+}
+
+extension ASTGenVisitor {
+  private func withBridgedParametersAndRequirements<T>(
+    _ node: GenericParameterClauseSyntax,
+    action: (BridgedArrayRef, BridgedArrayRef) -> T
+  ) -> T {
+    var params = [UnsafeMutableRawPointer]()
+    var requirements = [BridgedRequirementRepr]()
+    for param in node.genericParameterList {
+      let loweredParameter = self.visit(param)
+      params.append(loweredParameter)
+
+      guard let requirement = param.inheritedType else {
+        continue
+      }
+
+      let loweredRequirement = self.visit(requirement)
+      GenericTypeParamDecl_setInheritedType(self.ctx, loweredParameter, loweredRequirement);
+    }
+
+    if let nodeRequirements = node.genericWhereClause?.requirementList {
+      for requirement in nodeRequirements {
+        switch requirement.body {
+        case .conformanceRequirement(let conformance):
+          let firstType = self.visit(conformance.leftTypeIdentifier)
+          let separatorLoc = self.base.advanced(by: conformance.colon.position.utf8Offset).raw
+          let secondType = self.visit(conformance.rightTypeIdentifier)
+          requirements.append(BridgedRequirementRepr(
+            SeparatorLoc: separatorLoc,
+            Kind: .typeConstraint,
+            FirstType: firstType,
+            SecondType: secondType))
+        case .sameTypeRequirement(let sameType):
+          let firstType = self.visit(sameType.leftTypeIdentifier)
+          let separatorLoc = self.base.advanced(by: sameType.equalityToken.position.utf8Offset).raw
+          let secondType = self.visit(sameType.rightTypeIdentifier)
+          requirements.append(BridgedRequirementRepr(
+            SeparatorLoc: separatorLoc,
+            Kind: .sameType,
+            FirstType: firstType,
+            SecondType: secondType))
+        case .layoutRequirement(_):
+          fatalError("Cannot handle layout requirements!")
+        }
+      }
+    }
+    return params.withBridgedArrayRef { params in
+      return requirements.withBridgedArrayRef { reqs in
+        return action(params, reqs)
+      }
+    }
+  }
+}

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -77,7 +77,7 @@ private func allocateUTF8String(
       ptr[utf8.count] = 0
     }
 
-    return (UnsafePointer<UInt8>(ptr), capacity)
+    return (UnsafePointer<UInt8>(ptr), utf8.count)
   }
 }
 

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -20,6 +20,106 @@ extension SyntaxProtocol {
   }
 }
 
+/// Describes a macro that has been "exported" to the C++ part of the
+/// compiler, with enough information to interface with the C++ layer.
+struct ExportedMacro {
+  var macro: Macro.Type
+}
+
+/// Look up a macro with the given name.
+///
+/// Returns an unmanaged pointer to an ExportedMacro instance that describes
+/// the specified macro. If there is no macro with the given name, produces
+/// nil.
+@_cdecl("swift_ASTGen_lookupMacro")
+public func lookupMacro(
+  macroNamePtr: UnsafePointer<UInt8>
+) -> UnsafeRawPointer? {
+  let macroSystem = MacroSystem.exampleSystem
+
+  // Look for a macro with this name.
+  let macroName = String(cString: macroNamePtr)
+  guard let macro = macroSystem.lookup(macroName) else { return nil }
+
+  // Allocate and initialize the exported macro.
+  let exportedPtr = UnsafeMutablePointer<ExportedMacro>.allocate(capacity: 1)
+  exportedPtr.initialize(to: .init(macro: macro))
+  return UnsafeRawPointer(exportedPtr)
+}
+
+/// Destroys the given macro.
+@_cdecl("swift_ASTGen_destroyMacro")
+public func destroyMacro(
+  macroPtr: UnsafeMutablePointer<UInt8>
+) {
+  macroPtr.withMemoryRebound(to: ExportedMacro.self, capacity: 1) { macro in
+    macro.deinitialize(count: 1)
+    macro.deallocate()
+  }
+}
+
+/// Allocate a copy of the given string as a UTF-8 string.
+private func allocateUTF8String(
+  _ string: String,
+  nullTerminated: Bool = false
+) -> (UnsafePointer<UInt8>, Int) {
+  var string = string
+  return string.withUTF8 { utf8 in
+    let capacity = utf8.count + (nullTerminated ? 1 : 0)
+    let ptr = UnsafeMutablePointer<UInt8>.allocate(
+      capacity: capacity
+    )
+    if let baseAddress = utf8.baseAddress {
+      ptr.initialize(from: baseAddress, count: utf8.count)
+    }
+
+    if nullTerminated {
+      ptr[utf8.count] = 0
+    }
+
+    return (UnsafePointer<UInt8>(ptr), capacity)
+  }
+}
+
+/// Query the type signature of the given macro.
+@_cdecl("swift_ASTGen_getMacroTypeSignature")
+public func getMacroTypeSignature(
+  macroPtr: UnsafeMutablePointer<UInt8>,
+  evaluationContextPtr: UnsafeMutablePointer<UnsafePointer<UInt8>?>,
+  evaluationContextLengthPtr: UnsafeMutablePointer<Int>
+) {
+  macroPtr.withMemoryRebound(to: ExportedMacro.self, capacity: 1) { macro in
+    (evaluationContextPtr.pointee, evaluationContextLengthPtr.pointee) =
+      allocateUTF8String(macro.pointee.evaluationContext, nullTerminated: true)
+  }
+}
+
+extension ExportedMacro {
+  var evaluationContext: String {
+    """
+    struct __MacroEvaluationContext\(self.macro.genericSignature?.description ?? "") {
+      typealias SignatureType = \(self.macro.signature)
+    }
+    """
+  }
+}
+
+/// Query the macro evaluation context of the given macro.
+@_cdecl("swift_ASTGen_getMacroEvaluationContext")
+public func getMacroEvaluationContext(
+  sourceFilePtr: UnsafePointer<UInt8>,
+  declContext: UnsafeMutableRawPointer,
+  context: UnsafeMutableRawPointer,
+  macroPtr: UnsafeMutablePointer<UInt8>,
+  contextPtr: UnsafeMutablePointer<UnsafeMutableRawPointer?>
+) {
+  contextPtr.pointee = macroPtr.withMemoryRebound(to: ExportedMacro.self, capacity: 1) { macro in
+    return ASTGenVisitor(ctx: context, base: sourceFilePtr, declContext: declContext)
+      .visit(StructDeclSyntax(stringLiteral: macro.pointee.evaluationContext))
+  }
+}
+
+
 @_cdecl("swift_ASTGen_evaluateMacro")
 public func evaluateMacro(
   sourceFilePtr: UnsafePointer<UInt8>,

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -1,0 +1,178 @@
+import SwiftParser
+import SwiftSyntax
+
+import CASTBridging
+
+extension ASTGenVisitor {
+  public func visit(_ node: SimpleTypeIdentifierSyntax) -> UnsafeMutableRawPointer {
+    let loc = self.base.advanced(by: node.position.utf8Offset).raw
+
+    var text = node.name.text
+    let id = text.withUTF8 { buf in
+      return SwiftASTContext_getIdentifier(ctx, buf.baseAddress, buf.count)
+    }
+
+    return SimpleIdentTypeRepr_create(ctx, loc, id)
+  }
+
+  public func visit(_ node: MemberTypeIdentifierSyntax) -> UnsafeMutableRawPointer {
+    var path = [(TokenSyntax, GenericArgumentClauseSyntax?)]()
+    var memberRef: Syntax? = Syntax(node)
+    while let nestedMember = memberRef?.as(MemberTypeIdentifierSyntax.self) {
+      path.append((nestedMember.name, nestedMember.genericArgumentClause))
+      memberRef = Syntax(nestedMember.baseType)
+    }
+
+    if let base = memberRef?.as(SimpleTypeIdentifierSyntax.self) {
+      path.append((base.name, base.genericArgumentClause))
+    }
+
+    var elements = [UnsafeMutableRawPointer]()
+    for (pathElement, generics) in path.reversed() {
+      var nameText = pathElement.text
+      let name = nameText.withUTF8 { buf in
+        return SwiftASTContext_getIdentifier(ctx, buf.baseAddress, buf.count)
+      }
+      let nameLoc = self.base.advanced(by: pathElement.position.utf8Offset).raw
+
+        elements.append(SimpleIdentTypeRepr_create(self.ctx, nameLoc, name))
+    }
+
+    return elements.withBridgedArrayRef { elements in
+      return IdentTypeRepr_create(self.ctx, elements)
+    }
+  }
+
+  public func visit(_ node: ArrayTypeSyntax) -> UnsafeMutableRawPointer {
+    let elementType = visit(node.elementType)
+    let lSquareLoc = self.base.advanced(by: node.leftSquareBracket.position.utf8Offset).raw
+    let rSquareLoc = self.base.advanced(by: node.rightSquareBracket.position.utf8Offset).raw
+    return ArrayTypeRepr_create(self.ctx, elementType, lSquareLoc, rSquareLoc)
+  }
+
+  public func visit(_ node: DictionaryTypeSyntax) -> UnsafeMutableRawPointer {
+    let keyType = visit(node.keyType)
+    let valueType = visit(node.valueType)
+    let colonLoc = self.base.advanced(by: node.colon.position.utf8Offset).raw
+    let lSquareLoc = self.base.advanced(by: node.leftSquareBracket.position.utf8Offset).raw
+    let rSquareLoc = self.base.advanced(by: node.rightSquareBracket.position.utf8Offset).raw
+    return DictionaryTypeRepr_create(self.ctx, keyType, valueType, colonLoc, lSquareLoc, rSquareLoc)
+  }
+
+  public func visit(_ node: MetatypeTypeSyntax) -> UnsafeMutableRawPointer {
+    let baseType = visit(node.baseType)
+    let tyLoc = self.base.advanced(by: node.typeOrProtocol.position.utf8Offset).raw
+    if node.typeOrProtocol.text == "Type" {
+      return MetatypeTypeRepr_create(self.ctx, baseType, tyLoc)
+    } else {
+      assert(node.typeOrProtocol.text == "Protocol")
+      return ProtocolTypeRepr_create(self.ctx, baseType, tyLoc)
+    }
+  }
+
+  public func visit(_ node: ImplicitlyUnwrappedOptionalTypeSyntax) -> UnsafeMutableRawPointer {
+    let base = visit(node.wrappedType)
+    let exclaimLoc = self.base.advanced(by: node.exclamationMark.position.utf8Offset).raw
+    return ImplicitlyUnwrappedOptionalTypeRepr_create(self.ctx, base, exclaimLoc)
+  }
+
+  public func visit(_ node: OptionalTypeSyntax) -> UnsafeMutableRawPointer {
+    let base = visit(node.wrappedType)
+    let questionLoc = self.base.advanced(by: node.questionMark.position.utf8Offset).raw
+    return OptionalTypeRepr_create(self.ctx, base, questionLoc)
+  }
+
+  public func visit(_ node: PackExpansionTypeSyntax) -> UnsafeMutableRawPointer {
+    let base = visit(node.patternType)
+    let ellipsisLoc = self.base.advanced(by: node.ellipsis.position.utf8Offset).raw
+    return PackExpansionTypeRepr_create(self.ctx, base, ellipsisLoc)
+  }
+
+  public func visit(_ node: TupleTypeSyntax) -> UnsafeMutableRawPointer {
+    return self.withBridgedTupleElements(node.elements) { elements in
+      let lParenLoc = self.base.advanced(by: node.leftParen.position.utf8Offset).raw
+      let rParenLoc = self.base.advanced(by: node.rightParen.position.utf8Offset).raw
+      return TupleTypeRepr_create(self.ctx, elements, lParenLoc, rParenLoc)
+    }
+  }
+
+  public func visit(_ node: CompositionTypeSyntax) -> UnsafeMutableRawPointer {
+    assert(node.elements.count > 1)
+    let types = node.elements.map { visit($0.type) }
+    let firstTypeLoc = self.base.advanced(by: node.elements.first!.type.position.utf8Offset).raw
+    return types.withBridgedArrayRef { types in
+      return CompositionTypeRepr_create(self.ctx, types, firstTypeLoc)
+    }
+  }
+  
+  public func visit(_ node: FunctionTypeSyntax) -> UnsafeMutableRawPointer {
+    return self.withBridgedTupleElements(node.arguments) { elements in
+      let lParenLoc = self.base.advanced(by: node.leftParen.position.utf8Offset).raw
+      let rParenLoc = self.base.advanced(by: node.rightParen.position.utf8Offset).raw
+      let args = TupleTypeRepr_create(self.ctx, elements, lParenLoc, rParenLoc)
+      let asyncLoc = node.asyncKeyword.map { self.base.advanced(by: $0.position.utf8Offset).raw }
+      let throwsLoc = node.throwsOrRethrowsKeyword.map { self.base.advanced(by: $0.position.utf8Offset).raw }
+      let arrowLoc = self.base.advanced(by: node.arrow.position.utf8Offset).raw
+      let retTy = visit(node.returnType)
+      return FunctionTypeRepr_create(self.ctx, args, asyncLoc, throwsLoc, arrowLoc, retTy)
+    }
+  }
+
+  public func visit(_ node: NamedOpaqueReturnTypeSyntax) -> UnsafeMutableRawPointer {
+    let baseTy = visit(node.baseType)
+    return NamedOpaqueReturnTypeRepr_create(self.ctx, baseTy)
+  }
+
+  public func visit(_ node: ConstrainedSugarTypeSyntax) -> UnsafeMutableRawPointer {
+    let someOrAnyLoc = self.base.advanced(by: node.someOrAnySpecifier.position.utf8Offset).raw
+    let baseTy = visit(node.baseType)
+    if node.someOrAnySpecifier.text == "some" {
+      return OpaqueReturnTypeRepr_create(self.ctx, someOrAnyLoc, baseTy)
+    } else {
+      assert(node.someOrAnySpecifier.text == "any")
+      return ExistentialTypeRepr_create(self.ctx, someOrAnyLoc, baseTy)
+    }
+  }
+
+  public func visit(_ node: AttributedTypeSyntax) -> UnsafeMutableRawPointer {
+    // FIXME: Respect the attributes
+    return visit(node.baseType)
+  }
+}
+
+extension ASTGenVisitor {
+  private func withBridgedTupleElements<T>(
+    _ elementList: TupleTypeElementListSyntax,
+    action: (BridgedArrayRef) -> T
+  ) -> T {
+    var elements = [BridgedTupleTypeElement]()
+    for element in elementList {
+      var nameText = element.name?.text
+      let name = nameText?.withUTF8 { buf in
+        return SwiftASTContext_getIdentifier(ctx, buf.baseAddress, buf.count)
+      }
+      let nameLoc = element.name.map { self.base.advanced(by: $0.position.utf8Offset).raw }
+      var secondNameText = element.secondName?.text
+      let secondName = secondNameText?.withUTF8 { buf in
+        return SwiftASTContext_getIdentifier(ctx, buf.baseAddress, buf.count)
+      }
+      let secondNameLoc = element.secondName.map { self.base.advanced(by: $0.position.utf8Offset).raw }
+      let colonLoc = element.colon.map { self.base.advanced(by: $0.position.utf8Offset).raw }
+      let type = visit(element.type)
+      let trailingCommaLoc = element.trailingComma.map { self.base.advanced(by: $0.position.utf8Offset).raw }
+
+      elements.append(BridgedTupleTypeElement(
+        Name: name,
+        NameLoc: nameLoc,
+        SecondName: secondName,
+        SecondNameLoc: secondNameLoc,
+        UnderscoreLoc: nil, /*N.B. Only important for SIL*/
+        ColonLoc: colonLoc,
+        Type: type,
+        TrailingCommaLoc: trailingCommaLoc))
+    }
+    return elements.withBridgedArrayRef { elements in
+      return action(elements)
+    }
+  }
+}

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -35,7 +35,15 @@ extension ASTGenVisitor {
       }
       let nameLoc = self.base.advanced(by: pathElement.position.utf8Offset).raw
 
+      if let generics = generics {
+        let lAngle = self.base.advanced(by: generics.leftAngleBracket.position.utf8Offset).raw
+        let rAngle = self.base.advanced(by: generics.rightAngleBracket.position.utf8Offset).raw
+        elements.append(generics.arguments.map({ self.visit($0.argumentType) }).withBridgedArrayRef { genericArgs in
+          GenericIdentTypeRepr_create(self.ctx, name, nameLoc, genericArgs, lAngle, rAngle)
+        })
+      } else {
         elements.append(SimpleIdentTypeRepr_create(self.ctx, nameLoc, name))
+      }
     }
 
     return elements.withBridgedArrayRef { elements in

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -199,7 +199,8 @@ extern "C" void swift_ASTGen_buildTopLevelASTNodes(void *sourceFile,
 /// \endverbatim
 void Parser::parseTopLevel(SmallVectorImpl<Decl *> &decls) {
 #ifdef SWIFT_SWIFT_PARSER
-  if ((Context.LangOpts.hasFeature(Feature::BuiltinMacros) ||
+  if ((Context.LangOpts.hasFeature(Feature::Macros) ||
+       Context.LangOpts.hasFeature(Feature::BuiltinMacros) ||
        Context.LangOpts.hasFeature(Feature::ParserASTGen)) &&
       !SourceMgr.hasCodeCompletionBuffer() &&
       SF.Kind != SourceFileKind::SIL) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3643,8 +3643,6 @@ ParserResult<Expr> Parser::parseExprMacroExpansion(bool isExprBasic) {
       DeclNameOptions());
   if (!macroNameRef)
     return makeParserError();
-  auto *macroExpr = new (Context) UnresolvedDeclRefExpr(
-      macroNameRef, DeclRefKind::Ordinary, macroNameLoc);
 
   ArgumentList *argList = nullptr;
   if (Tok.isFollowingLParen()) {
@@ -3669,7 +3667,8 @@ ParserResult<Expr> Parser::parseExprMacroExpansion(bool isExprBasic) {
   }
 
   return makeParserResult(
-      new (Context) MacroExpansionExpr(poundLoc, macroExpr, argList));
+      new (Context) MacroExpansionExpr(
+          poundLoc, macroNameRef, macroNameLoc, argList));
 }
 
 /// parseExprCollection - Parse a collection literal expression.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3630,7 +3630,7 @@ namespace {
     Type visitMacroExpansionExpr(MacroExpansionExpr *expr) {
 #if SWIFT_SWIFT_PARSER
       auto &ctx = CS.getASTContext();
-      if (ctx.LangOpts.hasFeature(Feature::BuiltinMacros)) {
+      if (ctx.LangOpts.hasFeature(Feature::Macros)) {
         auto *UDRE = dyn_cast<UnresolvedDeclRefExpr>(expr->getMacro());
         if (!UDRE)
           return Type();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2471,6 +2471,7 @@ ConstraintSystem::getTypeOfMemberReference(
   return { origOpenedType, openedType, origType, type };
 }
 
+#if SWIFT_SWIFT_PARSER
 Type ConstraintSystem::getTypeOfMacroReference(StringRef macroName,
                                                Expr *anchor) {
   auto macroCtx = swift::macro_context::lookup(macroName, DC);
@@ -2480,17 +2481,17 @@ Type ConstraintSystem::getTypeOfMacroReference(StringRef macroName,
   auto *locator = getConstraintLocator(anchor);
   // Dig through to __MacroEvaluationContext.SignatureType
   auto sig = getASTContext().getIdentifier("SignatureType");
-  auto *signature = macroCtx->lookupDirect(sig).front();
-  auto type = cast<TypeAliasDecl>(signature)->getUnderlyingType();
+  auto *signature = cast<TypeAliasDecl>(macroCtx->lookupDirect(sig).front());
+  auto type = signature->getUnderlyingType();
 
-  // Open up the generic type.
+  // Open any the generic types.
   OpenedTypeMap replacements;
-  openGeneric(cast<TypeAliasDecl>(signature)->getParent(),
-              cast<TypeAliasDecl>(signature)->getGenericSignature(), locator,
-              replacements);
+  openGeneric(signature->getParent(), signature->getGenericSignature(),
+              locator, replacements);
 
   return openType(type, replacements);
 }
+#endif
 
 Type ConstraintSystem::getEffectiveOverloadType(ConstraintLocator *locator,
                                                 const OverloadChoice &overload,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -2474,7 +2474,8 @@ ConstraintSystem::getTypeOfMemberReference(
 #if SWIFT_SWIFT_PARSER
 Type ConstraintSystem::getTypeOfMacroReference(StringRef macroName,
                                                Expr *anchor) {
-  auto macroCtx = swift::macro_context::lookup(macroName, DC);
+  auto req = MacroContextRequest{macroName.str(), DC->getParentModule()};
+  auto *macroCtx = evaluateOrDefault(getASTContext().evaluator, req, nullptr);
   if (!macroCtx)
     return Type();
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -15,13 +15,15 @@
 // inference for expressions.
 //
 //===----------------------------------------------------------------------===//
+#include "swift/Sema/ConstraintSystem.h"
 #include "CSDiagnostics.h"
-#include "TypeChecker.h"
 #include "TypeCheckAvailability.h"
 #include "TypeCheckConcurrency.h"
+#include "TypeCheckMacros.h"
 #include "TypeCheckType.h"
-#include "swift/AST/Initializer.h"
+#include "TypeChecker.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/Initializer.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/TypeCheckRequests.h"
@@ -29,7 +31,6 @@
 #include "swift/Basic/Statistic.h"
 #include "swift/Sema/CSFix.h"
 #include "swift/Sema/ConstraintGraph.h"
-#include "swift/Sema/ConstraintSystem.h"
 #include "swift/Sema/SolutionResult.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallSet.h"
@@ -2468,6 +2469,27 @@ ConstraintSystem::getTypeOfMemberReference(
   recordOpenedTypes(locator, replacements);
 
   return { origOpenedType, openedType, origType, type };
+}
+
+Type ConstraintSystem::getTypeOfMacroReference(StringRef macroName,
+                                               Expr *anchor) {
+  auto macroCtx = swift::macro_context::lookup(macroName, DC);
+  if (!macroCtx)
+    return Type();
+
+  auto *locator = getConstraintLocator(anchor);
+  // Dig through to __MacroEvaluationContext.SignatureType
+  auto sig = getASTContext().getIdentifier("SignatureType");
+  auto *signature = macroCtx->lookupDirect(sig).front();
+  auto type = cast<TypeAliasDecl>(signature)->getUnderlyingType();
+
+  // Open up the generic type.
+  OpenedTypeMap replacements;
+  openGeneric(cast<TypeAliasDecl>(signature)->getParent(),
+              cast<TypeAliasDecl>(signature)->getGenericSignature(), locator,
+              replacements);
+
+  return openType(type, replacements);
 }
 
 Type ConstraintSystem::getEffectiveOverloadType(ConstraintLocator *locator,

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -88,8 +88,6 @@ swift::macro_context::lookup(StringRef macroName, DeclContext *DC) {
       });
 }
 
-#endif // SWIFT_SWIFT_PARSER
-
 Expr *swift::expandMacroExpr(
     DeclContext *dc, Expr *expr, StringRef macroName, Type expandedType
 ) {
@@ -182,3 +180,5 @@ Expr *swift::expandMacroExpr(
          "Type checking changed the result type?");
   return expandedExpr;
 }
+
+#endif // SWIFT_SWIFT_PARSER

--- a/lib/Sema/TypeCheckMacros.h
+++ b/lib/Sema/TypeCheckMacros.h
@@ -26,27 +26,28 @@ class TypeRepr;
 
 #if SWIFT_SWIFT_PARSER
 
-struct ASTGenMacroRAII {
-private:
-  void *opaqueMacro;
-  TypeRepr *signature;
-  GenericParamList *genericSignature;
-
-  ASTGenMacroRAII(void *macro, TypeRepr *sig, GenericParamList *genericSig)
-  : opaqueMacro(macro), signature(sig),
-    genericSignature(genericSig) {}
-
-public:
-  static llvm::Optional<ASTGenMacroRAII> lookup(StringRef macroName,
-                                                void *sourceFile,
-                                                DeclContext *DC,
-                                                ASTContext &ctx);
-
-  TypeRepr *getSignature() const { return signature; }
-  GenericParamList *getGenericSignature() const { return genericSignature; }
-
-  ~ASTGenMacroRAII();
-};
+namespace macro_context {
+/// Retrieves the evaluation context of a macro with the given name.
+///
+/// The macro evaluation context is a user-defined generic signature and return
+/// type that serves as the "interface type" of references to the macro. The
+/// current implementation takes those pieces of syntax from the macro itself,
+/// then inserts them into a Swift struct that looks like
+///
+/// \code
+/// struct __MacroEvaluationContext\(macro.genericSignature) {
+///   typealias SignatureType = \(macro.signature)
+/// }
+/// \endcode
+///
+/// So that we can use all of Swift's native name lookup and type resolution
+/// facilities to map the parsed signature type back into a semantic \c Type
+/// AST and a set of requiremnets.
+///
+/// \param macroName The name of the macro to look up.
+/// \param useDC The decl context of the use of this macro.
+StructDecl *lookup(StringRef macroName, DeclContext *useDC);
+}
 
 #endif
 

--- a/lib/Sema/TypeCheckMacros.h
+++ b/lib/Sema/TypeCheckMacros.h
@@ -49,8 +49,6 @@ namespace macro_context {
 StructDecl *lookup(StringRef macroName, DeclContext *useDC);
 }
 
-#endif
-
 /// Expands the given macro expression and type-check the result with
 /// the given expanded type.
 ///
@@ -61,5 +59,6 @@ Expr *expandMacroExpr(
 
 } // end namespace swift
 
+#endif // SWIFT_SWIFT_PARSER
 #endif /* SWIFT_SEMA_TYPECHECKMACROS_H */
 

--- a/lib/Sema/TypeCheckMacros.h
+++ b/lib/Sema/TypeCheckMacros.h
@@ -17,11 +17,39 @@
 #define SWIFT_SEMA_TYPECHECKMACROS_H
 
 #include "swift/AST/Type.h"
+#include "llvm/ADT/StringRef.h"
 
 namespace swift {
 
 class Expr;
-  
+class TypeRepr;
+
+#if SWIFT_SWIFT_PARSER
+
+struct ASTGenMacroRAII {
+private:
+  void *opaqueMacro;
+  TypeRepr *signature;
+  GenericParamList *genericSignature;
+
+  ASTGenMacroRAII(void *macro, TypeRepr *sig, GenericParamList *genericSig)
+  : opaqueMacro(macro), signature(sig),
+    genericSignature(genericSig) {}
+
+public:
+  static llvm::Optional<ASTGenMacroRAII> lookup(StringRef macroName,
+                                                void *sourceFile,
+                                                DeclContext *DC,
+                                                ASTContext &ctx);
+
+  TypeRepr *getSignature() const { return signature; }
+  GenericParamList *getGenericSignature() const { return genericSignature; }
+
+  ~ASTGenMacroRAII();
+};
+
+#endif
+
 /// Expands the given macro expression and type-check the result with
 /// the given expanded type.
 ///

--- a/lib/Sema/TypeCheckMacros.h
+++ b/lib/Sema/TypeCheckMacros.h
@@ -26,29 +26,6 @@ class TypeRepr;
 
 #if SWIFT_SWIFT_PARSER
 
-namespace macro_context {
-/// Retrieves the evaluation context of a macro with the given name.
-///
-/// The macro evaluation context is a user-defined generic signature and return
-/// type that serves as the "interface type" of references to the macro. The
-/// current implementation takes those pieces of syntax from the macro itself,
-/// then inserts them into a Swift struct that looks like
-///
-/// \code
-/// struct __MacroEvaluationContext\(macro.genericSignature) {
-///   typealias SignatureType = \(macro.signature)
-/// }
-/// \endcode
-///
-/// So that we can use all of Swift's native name lookup and type resolution
-/// facilities to map the parsed signature type back into a semantic \c Type
-/// AST and a set of requiremnets.
-///
-/// \param macroName The name of the macro to look up.
-/// \param useDC The decl context of the use of this macro.
-StructDecl *lookup(StringRef macroName, DeclContext *useDC);
-}
-
 /// Expands the given macro expression and type-check the result with
 /// the given expanded type.
 ///
@@ -57,8 +34,9 @@ StructDecl *lookup(StringRef macroName, DeclContext *useDC);
 Expr *expandMacroExpr(
     DeclContext *dc, Expr *expr, StringRef macroName, Type expandedType);
 
+#endif // SWIFT_SWIFT_PARSER
+
 } // end namespace swift
 
-#endif // SWIFT_SWIFT_PARSER
 #endif /* SWIFT_SEMA_TYPECHECKMACROS_H */
 

--- a/test/Macros/builtin_macros.swift
+++ b/test/Macros/builtin_macros.swift
@@ -2,22 +2,19 @@
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 
+
 // CHECK: macro_expansion_expr implicit type='String'
-// CHECK-NEXT: magic_identifier_literal_expr{{.*}}kind=#function
 // CHECK-NEXT: string_literal_expr{{.*}}Macro expansion of #function in{{.*}}value="MacrosTest"
 print(#function)
 
 func f(a: Int, b: Int) {
   print(#function, #line, #column)
   // CHECK: macro_expansion_expr implicit type='String'
-  // CHECK-NEXT: magic_identifier_literal_expr{{.*}}kind=#function
   // CHECK-NEXT: string_literal_expr{{.*}}Macro expansion of #function in{{.*}}value="f(a:b:)"
 
   // CHECK: macro_expansion_expr implicit type='Int'
-  // CHECK-NEXT: magic_identifier_literal_expr{{.*}}kind=#line
   // CHECK-NEXT: integer_literal_expr{{.*}}Macro expansion of #line in{{.*}}value=11
 
   // CHECK: macro_expansion_expr implicit type='Int'
-  // CHECK-NEXT: magic_identifier_literal_expr{{.*}}kind=#column
   // CHECK-NEXT: integer_literal_expr{{.*}}Macro expansion of #column in{{.*}}value=27
 }

--- a/test/Macros/macros.swift
+++ b/test/Macros/macros.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -enable-experimental-feature Macros -dump-ast %s -module-name MacrosTest 2>&1 | %FileCheck %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+let a = 1, b = 1
+let s = #stringify(a + b)
+// CHECK: macro_expansion_expr type='(Int, String)'{{.*}}name=stringify
+// CHECK-NEXT: argument_list
+// CHECK: tuple_expr type='(Int, String)' location=Macro expansion of #stringify
+


### PR DESCRIPTION
Come with @CodaFi  on a magical journey of the layering of this patch.

We begin with a humble macro for `#line`, which has the declared interface type of `<T: ExpressibleByIntegerLiteral>` and returns said `T`. However, we cannot merely parse these signatures independently. Because there is no link between the two buffers, name lookup has very little hope of finding `T` (let alone the right `T`). So, instead, we invent a magical struct that binds them together - and thus the Macro Evaluation Context was born.

A macro evaluation context currently looks like this:

    struct __MacroEvaluationContext\(self.macro.genericSignature?.description ?? "") {
      typealias SignatureType = \(self.macro.signature)
    }

And so out pops a struct with the return type in context in a useful position for us. But we're not done yet. In order for this declaration to transit back to the compiler, it needs to run through the Swift parser, then be lowered through ASTGen, and finally passed back along the C interface and cached down in the AST context. All of this necessitated fixing up ASTGen to be able to handle generics, structs, and types in general.

Then, given that signature, we can generate constraints for a macro expansion declaration, whether something builtin like `#line` or part of the example set like `#stringify`, to type-check the inputs and determine the output type. Finally, when it comes time to apply the solution to the constraint system, we expand the macro and type-check the resulting output type. Huzzah!

Slightly cleaned up and finish off https://github.com/apple/swift/pull/61760, wherein @CodaFi did most all of the heavy lifting.