### PR TITLE
Serialization: Break the cycle between Serialization and SymbolGraphGen

### DIFF
--- a/include/swift/Serialization/Serialization.h
+++ b/include/swift/Serialization/Serialization.h
@@ -1,0 +1,39 @@
+//===--- Serialization.h - Swiftmodule emission -----------------*- C++ -*-===//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SERIALIZATION_H
+#define SWIFT_SERIALIZATION_H
+
+#include "swift/Subsystems.h"
+
+namespace swift {
+
+class SILModule;
+
+namespace serialization {
+
+/// Serialize a module to the given stream.
+void writeToStream(
+    raw_ostream &os, ModuleOrSourceFile DC, const SILModule *M,
+    const SerializationOptions &options,
+    const fine_grained_dependencies::SourceFileDepGraph *DepGraph);
+
+/// Serialize module documentation to the given stream.
+void writeDocToStream(raw_ostream &os, ModuleOrSourceFile DC,
+                      StringRef GroupInfoPath);
+
+/// Serialize module source info to the given stream.
+void writeSourceInfoToStream(raw_ostream &os, ModuleOrSourceFile DC);
+
+} // end namespace serialization
+} // end namespace swift
+
+#endif // SWIFT_SERIALIZATION_H

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -13,10 +13,12 @@ add_swift_host_library(swiftFrontend STATIC
   ModuleInterfaceLoader.cpp
   ModuleInterfaceSupport.cpp
   PrintingDiagnosticConsumer.cpp
+  Serialization.cpp
   SerializedDiagnosticConsumer.cpp)
 add_dependencies(swiftFrontend
   SwiftOptions)
 target_link_libraries(swiftFrontend PRIVATE
+  swiftAPIDigester
   swiftAST
   swiftConstExtract
   swiftIDE
@@ -28,6 +30,6 @@ target_link_libraries(swiftFrontend PRIVATE
   swiftLocalization
   swiftSema
   swiftSerialization
-  swiftAPIDigester)
+  swiftSymbolGraphGen)
 
 set_swift_llvm_is_available(swiftFrontend)

--- a/lib/Frontend/Serialization.cpp
+++ b/lib/Frontend/Serialization.cpp
@@ -1,0 +1,165 @@
+//===--- Serialization.cpp - Write Swift modules --------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Serialization/Serialization.h"
+#include "swift/APIDigester/ModuleAnalyzerNodes.h"
+#include "swift/AST/FileSystem.h"
+#include "swift/Subsystems.h"
+#include "swift/SymbolGraphGen/SymbolGraphGen.h"
+#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
+#include "llvm/Support/SmallVectorMemoryBuffer.h"
+
+using namespace swift;
+
+static ModuleDecl *getModule(ModuleOrSourceFile DC) {
+  if (auto M = DC.dyn_cast<ModuleDecl *>())
+    return M;
+  return DC.get<SourceFile *>()->getParentModule();
+}
+
+static ASTContext &getContext(ModuleOrSourceFile DC) {
+  return getModule(DC)->getASTContext();
+}
+
+static void emitABIDescriptor(ModuleOrSourceFile DC,
+                              const SerializationOptions &options) {
+  using namespace swift::ide::api;
+  if (!options.ABIDescriptorPath.empty()) {
+    if (DC.is<ModuleDecl *>()) {
+      dumpModuleContent(DC.get<ModuleDecl *>(), options.ABIDescriptorPath, true,
+                        options.emptyABIDescriptor);
+    }
+  }
+}
+
+void swift::serializeToBuffers(
+    ModuleOrSourceFile DC, const SerializationOptions &options,
+    std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
+    const SILModule *M) {
+
+  assert(!options.OutputPath.empty());
+  {
+    FrontendStatsTracer tracer(getContext(DC).Stats,
+                               "Serialization, swiftmodule, to buffer");
+    llvm::SmallString<1024> buf;
+    llvm::raw_svector_ostream stream(buf);
+    serialization::writeToStream(stream, DC, M, options,
+                                 /*dependency info*/ nullptr);
+    bool hadError = withOutputFile(getContext(DC).Diags, options.OutputPath,
+                                   [&](raw_ostream &out) {
+      out << stream.str();
+      return false;
+    });
+    if (hadError)
+      return;
+
+    emitABIDescriptor(DC, options);
+    if (moduleBuffer)
+      *moduleBuffer = std::make_unique<llvm::SmallVectorMemoryBuffer>(
+          std::move(buf), options.OutputPath,
+          /*RequiresNullTerminator=*/false);
+  }
+
+  if (!options.DocOutputPath.empty()) {
+    FrontendStatsTracer tracer(getContext(DC).Stats,
+                               "Serialization, swiftdoc, to buffer");
+    llvm::SmallString<1024> buf;
+    llvm::raw_svector_ostream stream(buf);
+    serialization::writeDocToStream(stream, DC, options.GroupInfoPath);
+    (void)withOutputFile(getContext(DC).Diags, options.DocOutputPath,
+                         [&](raw_ostream &out) {
+      out << stream.str();
+      return false;
+    });
+    if (moduleDocBuffer)
+      *moduleDocBuffer = std::make_unique<llvm::SmallVectorMemoryBuffer>(
+          std::move(buf), options.DocOutputPath,
+          /*RequiresNullTerminator=*/false);
+  }
+
+  if (!options.SourceInfoOutputPath.empty()) {
+    FrontendStatsTracer tracer(getContext(DC).Stats,
+                               "Serialization, swiftsourceinfo, to buffer");
+    llvm::SmallString<1024> buf;
+    llvm::raw_svector_ostream stream(buf);
+    serialization::writeSourceInfoToStream(stream, DC);
+    (void)withOutputFile(getContext(DC).Diags, options.SourceInfoOutputPath,
+                         [&](raw_ostream &out) {
+      out << stream.str();
+      return false;
+    });
+    if (moduleSourceInfoBuffer)
+      *moduleSourceInfoBuffer = std::make_unique<llvm::SmallVectorMemoryBuffer>(
+          std::move(buf), options.SourceInfoOutputPath,
+          /*RequiresNullTerminator=*/false);
+  }
+}
+
+void swift::serialize(
+    ModuleOrSourceFile DC, const SerializationOptions &options,
+    const symbolgraphgen::SymbolGraphOptions &symbolGraphOptions,
+    const SILModule *M,
+    const fine_grained_dependencies::SourceFileDepGraph *DG) {
+  assert(!options.OutputPath.empty());
+
+  if (options.OutputPath == "-") {
+    // Special-case writing to stdout.
+    serialization::writeToStream(llvm::outs(), DC, M, options, DG);
+    assert(options.DocOutputPath.empty());
+    return;
+  }
+
+  bool hadError = withOutputFile(getContext(DC).Diags,
+                                 options.OutputPath,
+                                 [&](raw_ostream &out) {
+    FrontendStatsTracer tracer(getContext(DC).Stats,
+                               "Serialization, swiftmodule");
+    serialization::writeToStream(out, DC, M, options, DG);
+    return false;
+  });
+  if (hadError)
+    return;
+
+  if (!options.DocOutputPath.empty()) {
+    (void)withOutputFile(getContext(DC).Diags,
+                         options.DocOutputPath,
+                         [&](raw_ostream &out) {
+      FrontendStatsTracer tracer(getContext(DC).Stats,
+                                 "Serialization, swiftdoc");
+      serialization::writeDocToStream(out, DC, options.GroupInfoPath);
+      return false;
+    });
+  }
+
+  if (!options.SourceInfoOutputPath.empty()) {
+    (void)withOutputFile(getContext(DC).Diags,
+                         options.SourceInfoOutputPath,
+                         [&](raw_ostream &out) {
+      FrontendStatsTracer tracer(getContext(DC).Stats,
+                                 "Serialization, swiftsourceinfo");
+      serialization::writeSourceInfoToStream(out, DC);
+      return false;
+    });
+  }
+
+  if (!symbolGraphOptions.OutputDir.empty()) {
+    if (DC.is<ModuleDecl *>()) {
+      auto *M = DC.get<ModuleDecl *>();
+      FrontendStatsTracer tracer(getContext(DC).Stats,
+                                 "Serialization, symbolgraph");
+      symbolgraphgen::emitSymbolGraphForModule(M, symbolGraphOptions);
+    }
+  }
+  emitABIDescriptor(DC, options);
+}

--- a/lib/Serialization/CMakeLists.txt
+++ b/lib/Serialization/CMakeLists.txt
@@ -16,7 +16,7 @@ add_swift_host_library(swiftSerialization STATIC
   )
 target_link_libraries(swiftSerialization PRIVATE
   swiftClangImporter
-  swiftSIL
-  swiftSymbolGraphGen)
+  swiftOption
+  swiftSIL)
 
 set_swift_llvm_is_available(swiftSerialization)

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -36,7 +36,6 @@
 #include "swift/AST/SynthesizedFileUnit.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeVisitor.h"
-#include "swift/APIDigester/ModuleAnalyzerNodes.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Dwarf.h"
 #include "swift/Basic/FileSystem.h"
@@ -47,10 +46,9 @@
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/ClangImporter/SwiftAbstractBasicWriter.h"
 #include "swift/Demangling/ManglingMacros.h"
+#include "swift/Serialization/Serialization.h"
 #include "swift/Serialization/SerializationOptions.h"
 #include "swift/Strings.h"
-#include "swift/SymbolGraphGen/SymbolGraphGen.h"
-#include "swift/SymbolGraphGen/SymbolGraphOptions.h"
 #include "clang/AST/DeclTemplate.h"
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallString.h"
@@ -67,7 +65,6 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/OnDiskHashTable.h"
 #include "llvm/Support/Path.h"
-#include "llvm/Support/SmallVectorMemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <vector>
@@ -484,10 +481,6 @@ static ModuleDecl *getModule(ModuleOrSourceFile DC) {
   if (auto M = DC.dyn_cast<ModuleDecl *>())
     return M;
   return DC.get<SourceFile *>()->getParentModule();
-}
-
-static ASTContext &getContext(ModuleOrSourceFile DC) {
-  return getModule(DC)->getASTContext();
 }
 
 static bool shouldSerializeAsLocalContext(const DeclContext *DC) {
@@ -6003,139 +5996,9 @@ bool Serializer::allowCompilerErrors() const {
   return getASTContext().LangOpts.AllowModuleWithCompilerErrors;
 }
 
-
-static void emitABIDescriptor(ModuleOrSourceFile DC,
-                              const SerializationOptions &options) {
-  using namespace swift::ide::api;
-  if (!options.ABIDescriptorPath.empty()) {
-    if (DC.is<ModuleDecl*>()) {
-      dumpModuleContent(DC.get<ModuleDecl*>(), options.ABIDescriptorPath, true,
-                        options.emptyABIDescriptor);
-    }
-  }
-}
-
-void swift::serializeToBuffers(
-  ModuleOrSourceFile DC, const SerializationOptions &options,
-  std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
-  std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
-  std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
-  const SILModule *M) {
-
-  assert(!options.OutputPath.empty());
-  {
-    FrontendStatsTracer tracer(getContext(DC).Stats,
-                               "Serialization, swiftmodule, to buffer");
-    llvm::SmallString<1024> buf;
-    llvm::raw_svector_ostream stream(buf);
-    Serializer::writeToStream(stream, DC, M, options,
-                              /*dependency info*/ nullptr);
-    bool hadError = withOutputFile(getContext(DC).Diags,
-                                   options.OutputPath,
-                                   [&](raw_ostream &out) {
-      out << stream.str();
-      return false;
-    });
-    if (hadError)
-      return;
-    emitABIDescriptor(DC, options);
-    if (moduleBuffer)
-      *moduleBuffer = std::make_unique<llvm::SmallVectorMemoryBuffer>(
-          std::move(buf), options.OutputPath,
-          /*RequiresNullTerminator=*/false);
-  }
-
-  if (!options.DocOutputPath.empty()) {
-    FrontendStatsTracer tracer(getContext(DC).Stats,
-                               "Serialization, swiftdoc, to buffer");
-    llvm::SmallString<1024> buf;
-    llvm::raw_svector_ostream stream(buf);
-    writeDocToStream(stream, DC, options.GroupInfoPath);
-    (void)withOutputFile(getContext(DC).Diags,
-                         options.DocOutputPath,
-                         [&](raw_ostream &out) {
-      out << stream.str();
-      return false;
-    });
-    if (moduleDocBuffer)
-      *moduleDocBuffer = std::make_unique<llvm::SmallVectorMemoryBuffer>(
-          std::move(buf), options.DocOutputPath,
-          /*RequiresNullTerminator=*/false);
-  }
-
-  if (!options.SourceInfoOutputPath.empty()) {
-    FrontendStatsTracer tracer(getContext(DC).Stats,
-                               "Serialization, swiftsourceinfo, to buffer");
-    llvm::SmallString<1024> buf;
-    llvm::raw_svector_ostream stream(buf);
-    writeSourceInfoToStream(stream, DC);
-    (void)withOutputFile(getContext(DC).Diags,
-                         options.SourceInfoOutputPath,
-                         [&](raw_ostream &out) {
-      out << stream.str();
-      return false;
-    });
-    if (moduleSourceInfoBuffer)
-      *moduleSourceInfoBuffer = std::make_unique<llvm::SmallVectorMemoryBuffer>(
-          std::move(buf), options.SourceInfoOutputPath,
-          /*RequiresNullTerminator=*/false);
-  }
-}
-
-void swift::serialize(ModuleOrSourceFile DC,
-                      const SerializationOptions &options,
-                      const symbolgraphgen::SymbolGraphOptions &symbolGraphOptions,
-                      const SILModule *M,
-                      const fine_grained_dependencies::SourceFileDepGraph *DG) {
-  assert(!options.OutputPath.empty());
-
-  if (options.OutputPath == "-") {
-    // Special-case writing to stdout.
-    Serializer::writeToStream(llvm::outs(), DC, M, options, DG);
-    assert(options.DocOutputPath.empty());
-    return;
-  }
-
-  bool hadError = withOutputFile(getContext(DC).Diags,
-                                 options.OutputPath,
-                                 [&](raw_ostream &out) {
-    FrontendStatsTracer tracer(getContext(DC).Stats,
-                               "Serialization, swiftmodule");
-    Serializer::writeToStream(out, DC, M, options, DG);
-    return false;
-  });
-  if (hadError)
-    return;
-
-  if (!options.DocOutputPath.empty()) {
-    (void)withOutputFile(getContext(DC).Diags,
-                         options.DocOutputPath,
-                         [&](raw_ostream &out) {
-      FrontendStatsTracer tracer(getContext(DC).Stats,
-                                 "Serialization, swiftdoc");
-      writeDocToStream(out, DC, options.GroupInfoPath);
-      return false;
-    });
-  }
-
-  if (!options.SourceInfoOutputPath.empty()) {
-    (void)withOutputFile(getContext(DC).Diags,
-                         options.SourceInfoOutputPath,
-                         [&](raw_ostream &out) {
-      FrontendStatsTracer tracer(getContext(DC).Stats,
-                                 "Serialization, swiftsourceinfo");
-      writeSourceInfoToStream(out, DC);
-      return false;
-    });
-  }
-
-  if (!symbolGraphOptions.OutputDir.empty()) {
-    if (DC.is<ModuleDecl *>()) {
-      auto *M = DC.get<ModuleDecl*>();
-      FrontendStatsTracer tracer(getContext(DC).Stats,
-                                 "Serialization, symbolgraph");
-      symbolgraphgen::emitSymbolGraphForModule(M, symbolGraphOptions);
-    }
-  }
-  emitABIDescriptor(DC, options);
+void serialization::writeToStream(
+    raw_ostream &os, ModuleOrSourceFile DC, const SILModule *M,
+    const SerializationOptions &options,
+    const fine_grained_dependencies::SourceFileDepGraph *DepGraph) {
+  Serializer::writeToStream(os, DC, M, options, DepGraph);
 }

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -560,12 +560,6 @@ public:
   bool allowCompilerErrors() const;
 };
 
-/// Serialize module documentation to the given stream.
-void writeDocToStream(raw_ostream &os, ModuleOrSourceFile DC,
-                      StringRef GroupInfoPath);
-
-/// Serialize module source info to the given stream.
-void writeSourceInfoToStream(raw_ostream &os, ModuleOrSourceFile DC);
 } // end namespace serialization
 } // end namespace swift
 #endif

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/USRGeneration.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/SourceManager.h"
+#include "swift/Serialization/Serialization.h"
 #include "llvm/ADT/StringSet.h"
 #include "llvm/Support/DJB.h"
 #include "llvm/Support/EndianStream.h"

--- a/lib/SymbolGraphGen/CMakeLists.txt
+++ b/lib/SymbolGraphGen/CMakeLists.txt
@@ -10,5 +10,5 @@ add_swift_host_library(swiftSymbolGraphGen STATIC
 
 target_link_libraries(swiftSymbolGraphGen PRIVATE
   swiftAST
-  swiftFrontend
+  swiftIDE
   swiftMarkup)

--- a/tools/swift-dependency-tool/CMakeLists.txt
+++ b/tools/swift-dependency-tool/CMakeLists.txt
@@ -7,5 +7,6 @@ target_link_libraries(swift-dependency-tool
                       PRIVATE
                         swiftAST
                         swiftParse
+                        swiftSerialization
                         swiftClangImporter)
 


### PR DESCRIPTION
Push the top level logic for writing out swiftmodules and associated files into the frontend library which has access to all the necessary dependencies.

Fixes the circular dependency between Serialization and SymbolGraphGen that was introduced with https://github.com/apple/swift/pull/35110.
