### PR TITLE
Don't build TSan interception for libdispatch on non-Apple platforms

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1811,7 +1811,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DLLVM_TOOL_LLD_BUILD:BOOL=TRUE
                     -DLLVM_INCLUDE_DOCS:BOOL=TRUE
                     -DLLVM_ENABLE_LTO:STRING="${LLVM_ENABLE_LTO}"
-                    -DCOMPILER_RT_INTERCEPT_LIBDISPATCH=ON
                     "${llvm_cmake_options[@]}"
                 )
 


### PR DESCRIPTION
This will also support transitioning to `LLVM_USE_RUNTIMES` to build compiler-rt