### PR TITLE
build: build SwiftSyntax as shared on Windows

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -612,6 +612,7 @@ cmake --build %BuildRoot%\15 --target install || (exit /b)
 cmake ^
   -B %BuildRoot%\16 ^
 
+  -D BUILD_SHARED_LIBS=YES ^
   -D CMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^
   -D CMAKE_C_COMPILER=%BuildRoot%/1/bin/clang-cl.exe ^
   -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" ^


### PR DESCRIPTION
It is unclear what the costs of static linking are yet, and the packaging depends on that currently.  Use shared builds until we can investigate this.