### PR TITLE
[Serialization] Write in the binary swiftmodule file whether it was rebuilt from a swiftinterface

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -617,7 +617,7 @@ protected:
     HasAnyUnavailableValues : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1,
     /// If the module is compiled as static library.
     StaticLibrary : 1,
 
@@ -631,6 +631,10 @@ protected:
     ///
     /// \sa ResilienceStrategy
     RawResilienceStrategy : 1,
+
+    /// Whether the module was rebuilt from a module interface instead of being
+    /// build from the full source.
+    IsBuiltFromInterface : 1,
 
     /// Whether all imports have been resolved. Used to detect circular imports.
     HasResolvedImports : 1,

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -544,6 +544,15 @@ public:
     Bits.ModuleDecl.IsSystemModule = flag;
   }
 
+  /// Returns true if the module was rebuilt from a module interface instead
+  /// of being build from the full source.
+  bool isBuiltFromInterface() const {
+    return Bits.ModuleDecl.IsBuiltFromInterface;
+  }
+  void setIsBuiltFromInterface(bool flag = true) {
+    Bits.ModuleDecl.IsBuiltFromInterface = flag;
+  }
+
   /// Returns true if this module is a non-Swift module that was imported into
   /// Swift.
   ///

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -114,6 +114,7 @@ class ExtendedValidationInfo {
     unsigned IsTestable : 1;
     unsigned ResilienceStrategy : 2;
     unsigned IsImplicitDynamicEnabled : 1;
+    unsigned IsBuiltFromInterface : 1;
     unsigned IsAllowModuleWithCompilerErrorsEnabled : 1;
     unsigned IsConcurrencyChecked : 1;
   } Bits;
@@ -162,6 +163,10 @@ public:
   }
   void setResilienceStrategy(ResilienceStrategy resilience) {
     Bits.ResilienceStrategy = unsigned(resilience);
+  }
+  bool isBuiltFromInterface() const { return Bits.IsBuiltFromInterface; }
+  void setIsBuiltFromInterface(bool val) {
+    Bits.IsBuiltFromInterface = val;
   }
   bool isAllowModuleWithCompilerErrorsEnabled() {
     return Bits.IsAllowModuleWithCompilerErrorsEnabled;

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -249,6 +249,7 @@ std::error_code ExplicitModuleInterfaceBuilder::buildSwiftModuleFromInterface(
 
   SILOptions &SILOpts = Invocation.getSILOptions();
   auto Mod = Instance.getMainModule();
+  Mod->setIsBuiltFromInterface(true);
   auto &TC = Instance.getSILTypes();
   auto SILMod = performASTLowering(Mod, TC, SILOpts);
   if (!SILMod) {

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -517,6 +517,10 @@ public:
     return ResilienceStrategy(Core->Bits.ResilienceStrategy);
   }
 
+  bool isBuiltFromInterface() const {
+    return Core->Bits.IsBuiltFromInterface;
+  }
+
   /// Whether this module is compiled with implicit dynamic.
   bool isImplicitDynamicEnabled() const {
     return Core->Bits.IsImplicitDynamicEnabled;

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -151,6 +151,9 @@ static bool readOptionsBlock(llvm::BitstreamCursor &cursor,
       options_block::ResilienceStrategyLayout::readRecord(scratch, Strategy);
       extendedInfo.setResilienceStrategy(ResilienceStrategy(Strategy));
       break;
+    case options_block::IS_BUILT_FROM_INTERFACE:
+      extendedInfo.setIsBuiltFromInterface(true);
+      break;
     case options_block::IS_ALLOW_MODULE_WITH_COMPILER_ERRORS_ENABLED:
       extendedInfo.setAllowModuleWithCompilerErrorsEnabled(true);
       break;
@@ -1319,6 +1322,7 @@ ModuleFileSharedCore::ModuleFileSharedCore(
       Bits.IsTestable = extInfo.isTestable();
       Bits.ResilienceStrategy = unsigned(extInfo.getResilienceStrategy());
       Bits.IsImplicitDynamicEnabled = extInfo.isImplicitDynamicEnabled();
+      Bits.IsBuiltFromInterface = extInfo.isBuiltFromInterface();
       Bits.IsAllowModuleWithCompilerErrorsEnabled =
           extInfo.isAllowModuleWithCompilerErrorsEnabled();
       Bits.IsConcurrencyChecked = extInfo.isConcurrencyChecked();

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -584,12 +584,17 @@ void ModuleFileSharedCore::fatal(llvm::Error error) const {
 }
 
 void ModuleFileSharedCore::outputDiagnosticInfo(llvm::raw_ostream &os) const {
-  os << "module '" << Name << "' with full misc version '" << MiscVersion
-      << "'";
+  bool resilient = ResilienceStrategy(Bits.ResilienceStrategy) ==
+                   ResilienceStrategy::Resilient;
+  os << "module '" << Name
+     << "', builder version '" << MiscVersion
+     << "', built from "
+     << (Bits.IsBuiltFromInterface? "swiftinterface": "source")
+     << ", " << (resilient? "resilient": "non-resilient");
   if (Bits.IsAllowModuleWithCompilerErrorsEnabled)
-    os << " (built with -experimental-allow-module-with-compiler-errors)";
+    os << ", built with -experimental-allow-module-with-compiler-errors";
   if (ModuleInputBuffer)
-    os << " at '" << ModuleInputBuffer->getBufferIdentifier() << "'";
+    os << ", loaded from '" << ModuleInputBuffer->getBufferIdentifier() << "'";
 }
 
 ModuleFileSharedCore::~ModuleFileSharedCore() { }

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -347,6 +347,10 @@ private:
     /// Discriminator for resilience strategy.
     unsigned ResilienceStrategy : 2;
 
+    /// Whether the module was rebuilt from a module interface instead of being
+    /// build from the full source.
+    unsigned IsBuiltFromInterface: 1;
+
     /// Whether this module is compiled with implicit dynamic.
     unsigned IsImplicitDynamicEnabled: 1;
 
@@ -357,7 +361,7 @@ private:
     unsigned IsConcurrencyChecked: 1;
 
     // Explicitly pad out to the next word boundary.
-    unsigned : 5;
+    unsigned : 4;
   } Bits = {};
   static_assert(sizeof(ModuleBits) <= 8, "The bit set should be small");
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 718;  // element archetype
+const uint16_t SWIFTMODULE_VERSION_MINOR = 719;  // isBuiltFromInterface
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -826,6 +826,7 @@ namespace options_block {
     RESILIENCE_STRATEGY,
     ARE_PRIVATE_IMPORTS_ENABLED,
     IS_IMPLICIT_DYNAMIC_ENABLED,
+    IS_BUILT_FROM_INTERFACE,
     IS_ALLOW_MODULE_WITH_COMPILER_ERRORS_ENABLED,
     MODULE_ABI_NAME,
     IS_CONCURRENCY_CHECKED,
@@ -869,6 +870,10 @@ namespace options_block {
   using ResilienceStrategyLayout = BCRecordLayout<
     RESILIENCE_STRATEGY,
     BCFixed<2>
+  >;
+
+  using IsBuiltFromInterfaceLayout = BCRecordLayout<
+    IS_BUILT_FROM_INTERFACE
   >;
 
   using IsAllowModuleWithCompilerErrorsEnabledLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1049,6 +1049,11 @@ void Serializer::writeHeader(const SerializationOptions &options) {
         Strategy.emit(ScratchRecord, unsigned(M->getResilienceStrategy()));
       }
 
+      if (M->isBuiltFromInterface()) {
+        options_block::IsBuiltFromInterfaceLayout BuiltFromInterface(Out);
+        BuiltFromInterface.emit(ScratchRecord);
+      }
+
       if (allowCompilerErrors()) {
         options_block::IsAllowModuleWithCompilerErrorsEnabledLayout
             AllowErrors(Out);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -770,6 +770,8 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
       M.setImplicitDynamicEnabled();
     if (loadedModuleFile->hasIncrementalInfo())
       M.setHasIncrementalInfo();
+    if (loadedModuleFile->isBuiltFromInterface())
+      M.setIsBuiltFromInterface();
     if (!loadedModuleFile->getModuleABIName().empty())
       M.setABIName(Ctx.getIdentifier(loadedModuleFile->getModuleABIName()));
     if (loadedModuleFile->isConcurrencyChecked())

--- a/test/Serialization/Recovery/crash-recovery.swift
+++ b/test/Serialization/Recovery/crash-recovery.swift
@@ -19,5 +19,5 @@ public class Sub: Base {
 // CHECK-CRASH-LABEL: *** DESERIALIZATION FAILURE ***
 // CHECK-CRASH-LABEL: *** If any module named here was modified in the SDK, please delete the ***
 // CHECK-CRASH-LABEL: *** new swiftmodule files from the SDK and keep only swiftinterfaces.   ***
-// CHECK-CRASH: module 'Lib' with full misc version {{.*}}4.1.50
+// CHECK-CRASH: module 'Lib', builder version {{.*}}4.1.50
 // CHECK-CRASH: could not find 'disappearingMethod()' in parent class

--- a/test/Serialization/Recovery/crash-xref.swift
+++ b/test/Serialization/Recovery/crash-xref.swift
@@ -4,14 +4,21 @@
 // RUN: %empty-directory(%t/partials)
 // RUN: %empty-directory(%t/normal)
 // RUN: %empty-directory(%t/errors)
+// RUN: %empty-directory(%t/cache)
 
 /// Compile module A with a type and an empty module B.
-// RUN: %target-swift-frontend %s -emit-module-path %t/partials/A.swiftmodule -module-name A -D LIB
-// RUN: %target-swift-frontend %s -emit-module-path %t/partials/B.swiftmodule -module-name B
+// RUN: %target-swift-frontend %s -emit-module-path %t/partials/A.swiftmodule -module-name A -D LIB -enable-library-evolution
+// RUN: %target-swift-frontend %s -emit-module-path %t/partials/B.swiftmodule -module-name B -enable-library-evolution
 
 /// Compile a client using the type from A.
-// RUN: %target-swift-frontend %s -emit-module-path %t/normal/Client.swiftmodule -module-name Client -D CLIENT -I %t/partials
+// RUN: %target-swift-frontend %s -emit-module-path %t/normal/Client.swiftmodule -module-name Client -D CLIENT -I %t/partials -enable-library-evolution -emit-module-interface-path  %t/normal/Client.swiftinterface
 // RUN: %target-swift-frontend %s -emit-module-path %t/errors/Client.swiftmodule -module-name Client -D CLIENT -I %t/partials -experimental-allow-module-with-compiler-errors
+
+/// Force rebuilding from the swiftinterface.
+// RUN: mv %t/normal/Client.swiftmodule %t/swap-Client.swiftmodule
+// RUN: echo "import Client" | %target-swift-frontend -typecheck - -I %t/partials -I %t/normal -module-cache-path %t/cache/
+//2> /dev/null
+// RUN: mv %t/swap-Client.swiftmodule %t/normal/Client.swiftmodule
 
 /// Swap A and B around! A is now empty and B defines the type.
 // RUN: %target-swift-frontend %s -emit-module-path %t/partials/A.swiftmodule -module-name A
@@ -25,7 +32,7 @@
 // NORMALFAILURE-LABEL: *** DESERIALIZATION FAILURE ***
 // NORMALFAILURE-LABEL: *** If any module named here was modified in the SDK, please delete the ***
 // NORMALFAILURE-LABEL: *** new swiftmodule files from the SDK and keep only swiftinterfaces.   ***
-// NORMALFAILURE-NEXT: module 'Client' with full misc version {{.*}}'
+// NORMALFAILURE-NEXT: module 'Client', builder version {{.*}}', built from source, resilient, loaded from
 // NORMALFAILURE-NEXT: Could not deserialize type for 'foo()'
 // NORMALFAILURE-NEXT: Caused by: top-level value not found
 // NORMALFAILURE-NEXT: Cross-reference to module 'A'
@@ -37,13 +44,18 @@
 // ALLOWFAILURE-LABEL: *** DESERIALIZATION FAILURE ***
 // ALLOWFAILURE-LABEL: *** If any module named here was modified in the SDK, please delete the ***
 // ALLOWFAILURE-LABEL: *** new swiftmodule files from the SDK and keep only swiftinterfaces.   ***
-// ALLOWFAILURE-NEXT: module 'Client' with full misc version {{.*}}' (built with -experimental-allow-module-with-compiler-errors)
+// ALLOWFAILURE-NEXT: module 'Client', builder version {{.*}}', built from source, non-resilient, built with -experimental-allow-module-with-compiler-errors, loaded from
 // ALLOWFAILURE-NEXT: Could not deserialize type for 'foo()'
 // ALLOWFAILURE-NEXT: Caused by: top-level value not found
 // ALLOWFAILURE-NEXT: Cross-reference to module 'A'
 // ALLOWFAILURE-NEXT: ... SomeType
 // ALLOWFAILURE-NEXT: Notes:
 // ALLOWFAILURE-NEXT: * There is a matching 'SomeType' in module 'B'. If this is imported from clang, please make sure the header is part of a single clang module.
+
+/// Test a swiftmodule rebuilt from the swiftinterface.
+// RUN: not --crash %target-swift-frontend -emit-sil %t/cache/Client-*.swiftmodule -module-name Client -I %t/partials -disable-deserialization-recovery 2> %t/cache_stderr
+// RUN: cat %t/cache_stderr | %FileCheck %s -check-prefixes=CACHEFAILURE
+// CACHEFAILURE: module 'Client', builder version {{.*}}', built from swiftinterface, resilient
 
 #if LIB
 public struct SomeType {


### PR DESCRIPTION
Keep track of whether a swiftmodule was built from a swiftinterface or from source. This information will be used to change how the compiler deals with those dependencies.

Also tweak the fan favorite DESERIALIZATION FAILURE error message to add whether the swiftmodule was rebuilt and if it's library-evolution enabled.

Extracting this logic in this PR as it's used by both #61649 and #61765.