### PR TITLE
Remove is_unique invariant we don't guarantee

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1097,7 +1097,6 @@ extension Array: RangeReplaceableCollection {
   internal mutating func _createNewBuffer(
     bufferIsUnique: Bool, minimumCapacity: Int, growForAppend: Bool
   ) {
-    _internalInvariant(!bufferIsUnique || _buffer.isUniquelyReferenced())
     _buffer = _buffer._consumeAndCreateNew(bufferIsUnique: bufferIsUnique,
                                            minimumCapacity: minimumCapacity,
                                            growForAppend: growForAppend)


### PR DESCRIPTION
The invariant is checking if the "cached" `isUniquelyReferenced` result is still valid. The compiler can insert copies for lifetime adjustment during optimizations between the time `isUniquelyReferenced` is first "cached" to the invariant, such copies don't escape and don't really matter for COW. In such cases, this invariant will fire.

This PR turns off this invariant.

rdar://100530373

