### PR TITLE
Move 'ConstExtract' request from TypeCheckRequest into its own component's collection of requests.

### DIFF
--- a/include/swift/AST/ASTTypeIDZone.def
+++ b/include/swift/AST/ASTTypeIDZone.def
@@ -48,6 +48,7 @@ SWIFT_TYPEID_NAMED(CodeCompletionCallbacksFactory *,
                    CodeCompletionCallbacksFactory)
 SWIFT_TYPEID_NAMED(ConstructorDecl *, ConstructorDecl)
 SWIFT_TYPEID_NAMED(CustomAttr *, CustomAttr)
+SWIFT_TYPEID_NAMED(ConstValueTypeInfo *, ConstValueTypeInfo)
 SWIFT_TYPEID_NAMED(Decl *, Decl)
 SWIFT_TYPEID_NAMED(EnumDecl *, EnumDecl)
 SWIFT_TYPEID_NAMED(FuncDecl *, FuncDecl)

--- a/include/swift/AST/ASTTypeIDs.h
+++ b/include/swift/AST/ASTTypeIDs.h
@@ -82,6 +82,7 @@ enum class ImplicitMemberAction : uint8_t;
 struct FingerprintAndMembers;
 class Identifier;
 class BodyAndFingerprint;
+struct ConstValueTypeInfo;
 
 // Define the AST type zone (zone 1)
 #define SWIFT_TYPEID_ZONE AST

--- a/include/swift/AST/ConstTypeInfo.h
+++ b/include/swift/AST/ConstTypeInfo.h
@@ -21,7 +21,6 @@ namespace swift {
 class NominalTypeDecl;
 class VarDecl;
 class Type;
-} // namespace swift
 
 /// Representation of a compile-time-known value, for example
 /// in a type property initializer expression
@@ -43,7 +42,7 @@ private:
 class RawLiteralValue : public CompileTimeValue {
 public:
   RawLiteralValue(std::string Value)
-      : CompileTimeValue(ValueKind::RawLiteral), Value(Value) {}
+  : CompileTimeValue(ValueKind::RawLiteral), Value(Value) {}
 
   std::string getValue() const { return Value; }
 
@@ -70,8 +69,8 @@ private:
 class InitCallValue : public CompileTimeValue {
 public:
   InitCallValue(std::string Name, std::vector<FunctionParameter> Parameters)
-      : CompileTimeValue(ValueKind::InitCall), Name(Name),
-        Parameters(Parameters) {}
+  : CompileTimeValue(ValueKind::InitCall), Name(Name),
+  Parameters(Parameters) {}
 
   static bool classof(const CompileTimeValue *T) {
     return T->getKind() == ValueKind::InitCall;
@@ -127,5 +126,5 @@ struct ConstValueTypeInfo {
   swift::NominalTypeDecl *TypeDecl;
   std::vector<ConstValueTypePropertyInfo> Properties;
 };
-
+} // namespace swift
 #endif

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -18,7 +18,6 @@
 
 #include "swift/AST/ActorIsolation.h"
 #include "swift/AST/AnyFunctionRef.h"
-#include "swift/AST/ConstTypeInfo.h"
 #include "swift/AST/ASTNode.h"
 #include "swift/AST/ASTTypeIDs.h"
 #include "swift/AST/Effects.h"
@@ -707,26 +706,6 @@ private:
 
   // Evaluation.
   PropertyWrapperTypeInfo
-  evaluate(Evaluator &eval, NominalTypeDecl *nominal) const;
-
-public:
-  // Caching
-  bool isCached() const { return true; }
-};
-
-/// Retrieve information about compile-time-known
-class ConstantValueInfoRequest
-  : public SimpleRequest<ConstantValueInfoRequest,
-                         ConstValueTypeInfo(NominalTypeDecl *),
-                         RequestFlags::Cached> {
-public:
-  using SimpleRequest::SimpleRequest;
-
-private:
-  friend SimpleRequest;
-
-  // Evaluation.
-  ConstValueTypeInfo
   evaluate(Evaluator &eval, NominalTypeDecl *nominal) const;
 
 public:

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -260,9 +260,6 @@ SWIFT_REQUEST(TypeChecker, PropertyWrapperMutabilityRequest,
 SWIFT_REQUEST(TypeChecker, PropertyWrapperTypeInfoRequest,
               PropertyWrapperTypeInfo(NominalTypeDecl *), Cached,
               NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, ConstantValueInfoRequest,
-              ConstValueTypeInfo(NominalTypeDecl *), Cached,
-              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ProtocolRequiresClassRequest, bool(ProtocolDecl *),
               SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, PrimaryAssociatedTypesRequest,

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -261,6 +261,7 @@ FRONTEND_STATISTIC(Sema, NumUnloadedLazyIterableDeclContexts)
 #include "swift/Sema/IDETypeCheckingRequestIDZone.def"
 #include "swift/IDE/IDERequestIDZone.def"
 #include "swift/ClangImporter/ClangImporterTypeIDZone.def"
+#include "swift/ConstExtract/ConstExtractTypeIDZone.def"
 #undef SWIFT_REQUEST
 
 #define SWIFT_REQUEST(ZONE, NAME, Sig, Caching, LocOptions) FRONTEND_STATISTIC(SILGen, NAME)

--- a/include/swift/Basic/TypeIDZones.def
+++ b/include/swift/Basic/TypeIDZones.def
@@ -35,5 +35,7 @@ SWIFT_TYPEID_ZONE(IDE, 137)
 
 SWIFT_TYPEID_ZONE(ClangImporter, 139)
 
+SWIFT_TYPEID_ZONE(ConstExtract, 140)
+
 // N.B. This is not a formal zone and exists solely to support the unit tests.
 SWIFT_TYPEID_ZONE(ArithmeticEvaluator, 255)

--- a/include/swift/ConstExtract/ConstExtractRequests.h
+++ b/include/swift/ConstExtract/ConstExtractRequests.h
@@ -1,0 +1,79 @@
+//===------- ConstExtractRequests.h - Extraction  Requests ------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines const-extraction requests.
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_CONST_EXTRACT_REQUESTS_H
+#define SWIFT_CONST_EXTRACT_REQUESTS_H
+
+#include "swift/AST/SimpleRequest.h"
+#include "swift/AST/ASTTypeIDs.h"
+#include "swift/AST/ConstTypeInfo.h"
+#include "swift/AST/EvaluatorDependencies.h"
+#include "swift/AST/FileUnit.h"
+#include "swift/AST/Identifier.h"
+#include "swift/AST/NameLookup.h"
+#include "swift/Basic/Statistic.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/TinyPtrVector.h"
+
+namespace swift {
+
+class Decl;
+class DeclName;
+class EnumDecl;
+
+/// Retrieve information about compile-time-known values
+class ConstantValueInfoRequest
+  : public SimpleRequest<ConstantValueInfoRequest,
+                         ConstValueTypeInfo(NominalTypeDecl *),
+                         RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  ConstValueTypeInfo
+  evaluate(Evaluator &eval, NominalTypeDecl *nominal) const;
+
+public:
+  // Caching
+  bool isCached() const { return true; }
+};
+
+#define SWIFT_TYPEID_ZONE ConstExtract
+#define SWIFT_TYPEID_HEADER "swift/ConstExtract/ConstExtractTypeIDZone.def"
+#include "swift/Basic/DefineTypeIDZone.h"
+#undef SWIFT_TYPEID_ZONE
+#undef SWIFT_TYPEID_HEADER
+
+// Set up reporting of evaluated requests.
+template<typename Request>
+void reportEvaluatedRequest(UnifiedStatsReporter &stats,
+                            const Request &request);
+
+#define SWIFT_REQUEST(Zone, RequestType, Sig, Caching, LocOptions)             \
+  template <>                                                                  \
+  inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,              \
+                                     const RequestType &request) {             \
+    ++stats.getFrontendCounters().RequestType;                                 \
+  }
+#include "swift/ConstExtract/ConstExtractTypeIDZone.def"
+#undef SWIFT_REQUEST
+
+} // end namespace swift
+
+#endif // SWIFT_CONST_EXTRACT_REQUESTS_H
+

--- a/include/swift/ConstExtract/ConstExtractTypeIDZone.def
+++ b/include/swift/ConstExtract/ConstExtractTypeIDZone.def
@@ -1,0 +1,20 @@
+//===--- ConstExtractTypeIDZone.def ----------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This definition file describes the types in the const extract
+//  TypeID zone, for use with the TypeID template.
+//
+//===----------------------------------------------------------------------===//
+
+SWIFT_REQUEST(ConstExtract, ConstantValueInfoRequest,
+              ConstValueTypeInfo(NominalTypeDecl *), Cached,
+              NoLocationInfo)

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -386,6 +386,9 @@ namespace swift {
   /// after forming the ASTContext.
   void registerClangImporterRequestFunctions(Evaluator &evaluator);
 
+  /// Register constant value extraction request functons with the evaluator.
+  void registerConstExtractRequestFunctions(Evaluator &evaluator);
+
   /// Register SILOptimizer passes necessary for IRGen.
   void registerIRGenSILTransforms(ASTContext &ctx);
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -239,6 +239,7 @@ bool CompilerInstance::setUpASTContextIfNeeded() {
   registerParseRequestFunctions(Context->evaluator);
   registerTypeCheckerRequestFunctions(Context->evaluator);
   registerClangImporterRequestFunctions(Context->evaluator);
+  registerConstExtractRequestFunctions(Context->evaluator);
   registerSILGenRequestFunctions(Context->evaluator);
   registerSILOptimizerRequestFunctions(Context->evaluator);
   registerTBDGenRequestFunctions(Context->evaluator);

--- a/lib/IDETool/CompletionInstance.cpp
+++ b/lib/IDETool/CompletionInstance.cpp
@@ -247,6 +247,7 @@ bool CompletionInstance::performCachedOperationIfPossible(
   registerIDERequestFunctions(tmpCtx->evaluator);
   registerTypeCheckerRequestFunctions(tmpCtx->evaluator);
   registerClangImporterRequestFunctions(tmpCtx->evaluator);
+  registerConstExtractRequestFunctions(tmpCtx->evaluator);
   registerSILGenRequestFunctions(tmpCtx->evaluator);
   ModuleDecl *tmpM = ModuleDecl::create(Identifier(), *tmpCtx);
   SourceFile *tmpSF = new (*tmpCtx)


### PR DESCRIPTION
This helps make sure that components that do not genuinely do not depend on `libSwiftConstExtract` do not need to actually have a dependency edge to it. 