### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ More options may be added over time. Please pass ``--help`` to
 On macOS if one wants to install such a toolchain into Xcode:
 
 1. Untar and copy the toolchain to one of `/Library/Developer/Toolchains/` or
-   `~/Library/Developer/Toolchains/`. E.x.:
+   `~/Library/Developer/Toolchains/`. E.g.:
 
 ```
   $ sudo tar -xzf swift-LOCAL-YYYY-MM-DD-a-osx.tar.gz -C /


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fix typo: “e.x.” -> “e.g.” (https://en.wiktionary.org/wiki/e.g.)