### PR TITLE
stdlib: define RTLD_DEFAULT for FreeBSD

### DIFF
--- a/stdlib/private/StdlibUnittest/SymbolLookup.swift
+++ b/stdlib/private/StdlibUnittest/SymbolLookup.swift
@@ -23,7 +23,7 @@
 #error("Unsupported platform")
 #endif
 
-#if canImport(Darwin) || os(OpenBSD)
+#if canImport(Darwin) || os(OpenBSD) || os(FreeBSD)
   let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: -2)
 #elseif os(Linux) || os(WASI)
   let RTLD_DEFAULT = UnsafeMutableRawPointer(bitPattern: 0)


### PR DESCRIPTION
It's defined the same as on Darwin and OpenBSD.

<dlfcn.h>:

```
#define RTLD_DEFAULT    ((void *) -2)   /* Use default search algorithm. */
```