### PR TITLE
Tests: Add `REQUIRES: CPU=x86_64` in a few Interop tests

### DIFF
--- a/test/Interop/Cxx/class/constructors-copy-irgen-macosx.swift
+++ b/test/Interop/Cxx/class/constructors-copy-irgen-macosx.swift
@@ -3,9 +3,7 @@
 // RUN: %swift -module-name MySwift -target x86_64-apple-macosx10.9 -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_X64
 
 // REQUIRES: OS=macosx
-
-// REQUIRES: CODEGENERATOR=X86
-// REQUIRES: CODEGENERATOR=ARM
+// REQUIRES: CPU=x86_64
 
 
 import Constructors

--- a/test/Interop/Cxx/class/constructors-irgen-macosx.swift
+++ b/test/Interop/Cxx/class/constructors-irgen-macosx.swift
@@ -3,9 +3,7 @@
 // RUN: %swift -module-name MySwift -target x86_64-apple-macosx10.9 -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_X64
 
 // REQUIRES: OS=macosx
-
-// REQUIRES: CODEGENERATOR=X86
-// REQUIRES: CODEGENERATOR=ARM
+// REQUIRES: CPU=x86_64
 
 import Constructors
 import TypeClassification


### PR DESCRIPTION
These tests fail when run locally on Apple Silicon Macs because they specify `-target x86_64-apple-macosx10.9` instead of `-target %target-cpu-apple-macosx10.9`. Tests that have architecture specific output should require that architecture.
