### PR TITLE
CMake: Break cycle between Sema and SIL

### DIFF
--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -3,7 +3,8 @@ add_swift_host_library(swiftSIL STATIC
 target_link_libraries(swiftSIL PUBLIC
   swiftDemangling)
 target_link_libraries(swiftSIL PRIVATE
-  swiftSema)
+  swiftAST
+  swiftClangImporter)
 
 add_subdirectory(IR)
 add_subdirectory(Utils)

--- a/lib/SIL/IR/SILInstruction.cpp
+++ b/lib/SIL/IR/SILInstruction.cpp
@@ -24,7 +24,6 @@
 #include "swift/SIL/SILVisitor.h"
 #include "swift/SIL/DynamicCasts.h"
 #include "swift/Basic/AssertImplements.h"
-#include "swift/ClangImporter/ClangModule.h"
 #include "swift/SIL/SILModule.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallString.h"

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -23,7 +23,6 @@
 #include "swift/AST/Types.h"
 #include "swift/Basic/Range.h"
 #include "swift/Basic/STLExtras.h"
-#include "swift/ClangImporter/ClangModule.h"
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/DynamicCasts.h"


### PR DESCRIPTION
The dependency edge from SIL to Sema is completely superfluous.