### PR TITLE
build: add missing `REGEX` to properly strip {Free,Open}BSD version suffixes

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -378,7 +378,7 @@ macro(configure_sdk_unix name architectures)
           message(WARNING "CMAKE_SYSTEM_VERSION will not match target")
         endif()
 
-        string(REPLACE "[-].*" "" freebsd_system_version ${CMAKE_SYSTEM_VERSION})
+        string(REGEX REPLACE "[-].*" "" freebsd_system_version ${CMAKE_SYSTEM_VERSION})
         message(STATUS "FreeBSD Version: ${freebsd_system_version}")
 
         set(SWIFT_SDK_FREEBSD_ARCH_x86_64_TRIPLE "x86_64-unknown-freebsd${freebsd_system_version}")
@@ -387,7 +387,7 @@ macro(configure_sdk_unix name architectures)
           message(FATAL_ERROR "unsupported arch for OpenBSD: ${arch}")
         endif()
 
-        string(REPLACE "[-].*" "" openbsd_system_version ${CMAKE_SYSTEM_VERSION})
+        set(openbsd_system_version ${CMAKE_SYSTEM_VERSION})
         message(STATUS "OpenBSD Version: ${openbsd_system_version}")
 
         set(SWIFT_SDK_OPENBSD_ARCH_amd64_TRIPLE "amd64-unknown-openbsd${openbsd_system_version}")


### PR DESCRIPTION
`CMAKE_SYSTEM_VERSION` is populated from `uname -r` on Unix.  FreeBSD suffixes this with "-RELEASE" (or "-STABLE", or "-CURRENT").