### PR TITLE
NFC: add code owners for C++ interop

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,11 @@
 include/swift/Parse @ahoppen @bnbarham @CodaFi @DougGregor @rintaro
 lib/Parse           @ahoppen @bnbarham @CodaFi @DougGregor @rintaro
 test/Parse          @ahoppen @bnbarham @CodaFi @DougGregor @rintaro
+
+# C++ Interop
+include/swift/ClangImporter @zoecarver @hyp @egorzhdan
+include/swift/PrintAsClang  @zoecarver @hyp @egorzhdan
+lib/ClangImporter           @zoecarver @hyp @egorzhdan
+lib/PrintAsClang            @zoecarver @hyp @egorzhdan
+stdlib/public/Cxx           @zoecarver @hyp @egorzhdan
+test/Interop                @zoecarver @hyp @egorzhdan


### PR DESCRIPTION
This teaches GitHub to automatically add the three of us as reviewers to patches that alter the source files specific to C++ interop.

This doesn't mean that all of the people added as reviewers must necessarily review a patch, is just makes it more straightforward for folks who don't have commit access to request reviews for their patches.
