### PR TITLE
 Consider is_unique as a barrier for optimization in OSSA RLE

### DIFF
--- a/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
+++ b/lib/SILOptimizer/Transforms/RedundantLoadElimination.cpp
@@ -152,7 +152,6 @@ static bool isRLEInertInstruction(SILInstruction *Inst) {
   case SILInstructionKind::DeallocStackInst:
   case SILInstructionKind::CondFailInst:
   case SILInstructionKind::IsEscapingClosureInst:
-  case SILInstructionKind::IsUniqueInst:
   case SILInstructionKind::EndCOWMutationInst:
   case SILInstructionKind::FixLifetimeInst:
   case SILInstructionKind::EndAccessInst:
@@ -162,6 +161,9 @@ static bool isRLEInertInstruction(SILInstruction *Inst) {
   case SILInstructionKind::BeginBorrowInst:
   case SILInstructionKind::EndBorrowInst:
     return true;
+  case SILInstructionKind::IsUniqueInst:
+    // TODO: Consider is_unique to be a barrier for optimization.
+    return !Inst->getFunction()->hasOwnership();
   default:
     return false;
   }

--- a/test/SILOptimizer/redundant_load_elim_nontrivial_ossa.sil
+++ b/test/SILOptimizer/redundant_load_elim_nontrivial_ossa.sil
@@ -75,6 +75,17 @@ final class NewHalfOpenRangeGenerator : NewRangeGenerator1 {
   override init(start: NonTrivialStruct, end: NonTrivialStruct)
 }
 
+struct ArrayIntBuffer {
+  var storage : Builtin.NativeObject
+}
+
+struct MyArray<T> {
+  var buffer : ArrayIntBuffer
+}
+
+struct MyStruct {
+}
+
 sil_global @total_klass : $Klass
 sil_global @total_nontrivialstruct : $NonTrivialStruct
 
@@ -85,6 +96,7 @@ sil @use_a : $@convention(thin) (@owned A) -> ()
 sil @use_twofield : $@convention(thin) (@owned TwoField) -> ()
 sil @init_twofield : $@convention(thin) (@thin TwoField.Type) -> @owned TwoField
 sil @get_nontrivialstruct : $@convention(thin) () -> @owned NonTrivialStruct
+sil [ossa] @get_array : $@convention(thin) () -> @owned MyArray<MyStruct>
 
 // We have a bug in the old projection code which this test case exposes.
 // Make sure its handled properly in the new projection.
@@ -1250,3 +1262,18 @@ bb14:
   return %26 : $()
 }
 
+// CHECK-LABEL: @test_is_unique :
+// CHECK:   load
+// CHECK: } // end sil function 'test_is_unique'
+sil [ossa] @test_is_unique : $@convention(thin) (@in MyArray<MyStruct>) -> () {
+bb0(%0 : $*MyArray<MyStruct>):
+  %1 = function_ref @get_array : $@convention(thin) () -> @owned MyArray<MyStruct>
+  %2 = apply %1() : $@convention(thin) () -> @owned MyArray<MyStruct>
+  store %2 to [assign] %0 : $*MyArray<MyStruct>
+  %4 = struct_element_addr %0 : $*MyArray<MyStruct>, #MyArray.buffer
+  %5 = is_unique %4 : $*ArrayIntBuffer
+  %7 = load [take] %0 : $*MyArray<MyStruct>
+  destroy_value %7 : $MyArray<MyStruct>
+  %t = tuple ()
+  return %t : $() 
+}


### PR DESCRIPTION
RLE was looking through is_unique instruction while finding redundant loads. OSSA RLE can create copies to eliminate redundancies invalidating uniqueness. This PR avoids looking through is_unique in OSSA RLE.