### PR TITLE
[cxx-interop] Emit IR for virtual methods

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -201,6 +201,17 @@ void IRGenModule::emitClangDecl(const clang::Decl *decl) {
       }
     }
 
+    // If something from a C++ class is used, emit all virtual methods of this
+    // class because they might be emitted in the vtable even if not used
+    // directly from Swift.
+    if (auto *record = dyn_cast<clang::CXXRecordDecl>(next->getDeclContext())) {
+      for (auto *method : record->methods()) {
+        if (method->isVirtual()) {
+          callback(method);
+        }
+      }
+    }
+
     if (auto var = dyn_cast<clang::VarDecl>(next))
       if (!var->isFileVarDecl())
         continue;

--- a/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
@@ -13,3 +13,8 @@ module SubTypes {
 module TypeAliases {
   header "type-aliases.h"
 }
+
+module VirtualMethods {
+  header "virtual-methods.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/virtual-methods.h
@@ -1,0 +1,29 @@
+extern "C" void puts(const char *);
+
+inline void testFunctionCollected() {
+  puts("test\n");
+}
+
+struct Base {
+  virtual void foo() = 0;
+};
+
+template <class T>
+struct Derived : Base {
+  inline void foo() override {
+    testFunctionCollected();
+  }
+
+  void callMe() {
+  }
+};
+
+using DerivedInt = Derived<int>;
+
+template <class T>
+struct Unused : Base {
+  inline void foo() override {
+  }
+};
+
+using UnusedInt = Unused<int>;

--- a/test/Interop/Cxx/class/inheritance/virtual-methods-irgen.swift
+++ b/test/Interop/Cxx/class/inheritance/virtual-methods-irgen.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s -validate-tbd-against-ir=none | %FileCheck %s
+
+// FIXME: enable on Windows
+// XFAIL: OS=windows-msvc
+
+import VirtualMethods
+
+var x = DerivedInt()
+x.callMe()
+
+// CHECK: define {{.*}}void @{{_ZN7DerivedIiE3fooEv|"\?foo@\?$Derived@H@@UEAAXXZ"}}
+// CHECK:   call void @{{_Z21testFunctionCollectedv|"\?testFunctionCollected@@YAXXZ"}}
+
+// CHECK: define {{.*}}void @{{_Z21testFunctionCollectedv|"\?testFunctionCollected@@YAXXZ"}}
+
+// CHECK-NOT: _ZN6UnusedIiE3fooEv
+// CHECK-NOT: "\?foo@\?$Unused@H@@UEAAXXZ"


### PR DESCRIPTION
Even if a virtual method is not used directly from Swift, it might get emitted into the vtable, and in that case the IR for it should be emitted to avoid linker errors.

Fixes https://github.com/apple/swift/issues/61730.
