### PR TITLE
Forcibly disable static constant array emission for now

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1858,6 +1858,12 @@ bool IRGenModule::shouldPrespecializeGenericMetadata() {
 }
 
 bool IRGenModule::canMakeStaticObjectsReadOnly() {
+  // Unconditionally disable this until we can fix the metadata.
+  // The trick of using the Empty array metadata for static arrays
+  // breaks Obj-C interop quite badly.
+  // rdar://101126543
+  return false;
+
   if (getOptions().DisableReadonlyStaticObjects)
     return false;
 


### PR DESCRIPTION
This code currently uses the "empty array" metadata for static arrays (because the "empty array" can never be freed and the metadata on the array storage is not actually used in Swift).

But that doesn't work if the array is passed to Objective-C, which does rely on the metadata.  So Objective-C code would see bridged arrays of this type as empty.

Workaround for: rdar://101126543 and rdar://100480289