### PR TITLE
[SymbolGraph] Output custom attributes

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -72,9 +72,6 @@ PrintOptions SymbolGraph::getDeclarationFragmentsPrintOptions() const {
 
   llvm::StringMap<AnyAttrKind> ExcludeAttrs;
 
-#define DECL_ATTR(SPELLING, CLASS, OPTIONS, CODE) \
-  if (StringRef(#SPELLING).startswith("_")) \
-    ExcludeAttrs.insert(std::make_pair("DAK_" #CLASS, DAK_##CLASS));
 #define TYPE_ATTR(X) ExcludeAttrs.insert(std::make_pair("TAK_" #X, TAK_##X));
 #include "swift/AST/Attr.def"
 
@@ -98,6 +95,7 @@ PrintOptions SymbolGraph::getDeclarationFragmentsPrintOptions() const {
   // In "emit modules separately" jobs, access modifiers show up as attributes,
   // but we don't want them to be printed in declarations
   ExcludeAttrs.insert(std::make_pair("DAK_AccessControl", DAK_AccessControl));
+  ExcludeAttrs.insert(std::make_pair("DAK_SetterAccess", DAK_SetterAccess));
 
   for (const auto &Entry : ExcludeAttrs) {
     Opts.ExcludeAttrList.push_back(Entry.getValue());

--- a/test/IDE/print_set_accessor.swift
+++ b/test/IDE/print_set_accessor.swift
@@ -1,0 +1,6 @@
+public struct SomeType {
+  public private(set) var privateSetter: Int
+}
+// CHECK: public private(set) var privateSetter: Int
+
+// RUN: %target-swift-ide-test -print-swift-file-interface -source-filename %s | %FileCheck %s

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/CustomAttr.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/CustomAttr.swift
@@ -1,0 +1,63 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -module-name CustomAttr -emit-module -emit-module-path %t/
+// RUN: %target-swift-symbolgraph-extract -module-name CustomAttr -I %t -pretty-print -output-dir %t
+// RUN: %FileCheck %s --input-file %t/CustomAttr.symbols.json
+
+@propertyWrapper
+public struct SomeWrapper {
+  public var wrappedValue: Int { 0 }
+  public init(wrappedValue: Int) {}
+}
+
+public func wrapped(@SomeWrapper arg: Int) {}
+
+// CHECK-LABEL: "precise": "s:10CustomAttr7wrapped3argySi_tF"
+// CHECK: "declarationFragments": [
+// CHECK: "declarationFragments": [
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "kind": "keyword",
+// CHECK-NEXT:    "spelling": "func"
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "kind": "text",
+// CHECK-NEXT:    "spelling": " "
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "kind": "identifier",
+// CHECK-NEXT:    "spelling": "wrapped"
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "kind": "text",
+// CHECK-NEXT:    "spelling": "("
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "kind": "attribute",
+// CHECK-NEXT:    "spelling": "@"
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "kind": "typeIdentifier",
+// CHECK-NEXT:    "spelling": "SomeWrapper",
+// CHECK-NEXT:    "preciseIdentifier": "s:10CustomAttr11SomeWrapperV"
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "kind": "text",
+// CHECK-NEXT:    "spelling": " "
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "kind": "externalParam",
+// CHECK-NEXT:    "spelling": "arg"
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "kind": "text",
+// CHECK-NEXT:    "spelling": ": "
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "kind": "typeIdentifier",
+// CHECK-NEXT:    "spelling": "Int",
+// CHECK-NEXT:    "preciseIdentifier": "s:Si"
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "kind": "text",
+// CHECK-NEXT:    "spelling": ")"
+// CHECK-NEXT:  }
+// CHECK-NEXT:]


### PR DESCRIPTION
Custom attributes were being skipped as their attribute name started with a "_". Underscored attributes are typically unstable and thus shouldn't be printed, but "_" is not being used for that purpose in the case of "_custom".

Rather than checking for "_" or "__", just use `UserInaccessible`. This property is used for attributes that shouldn't be shown to users in eg. completion/printing/etc.

Resolves rdar://99029554.