### PR TITLE
RequirementMachine: Better error recovery from invalid protocol inheritance clauses

### DIFF
--- a/test/Generics/issue-61020.swift
+++ b/test/Generics/issue-61020.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift -debug-generic-signatures 2>&1 | %FileCheck %s
+
+protocol Base<T> {
+  associatedtype T
+}
+
+// CHECK-LABEL: .Derived@
+// CHECK-NEXT: Requirement signature: <Self where Self : Base>
+protocol Derived: Base & DoesNotExist { // expected-error {{cannot find type 'DoesNotExist' in scope}}
+  func position(_: T)
+}
+
+// CHECK-LABEL: .OtherDerived@
+// CHECK-NEXT: Requirement signature: <Self where Self : Base>
+protocol OtherDerived: Base<DoesNotExist> {} // expected-error {{cannot find type 'DoesNotExist' in scope}}


### PR DESCRIPTION
getInheritedProtocols() skips type resolution and directly resolves TypeReprs to TypeDecls.

On the other hand, when building a protocol requirement signature, we use type resolution to resolve inheritance clause entries so that we can properly support parameterized protocol types, and protocol compositions that contain classes.

Since a TypeRepr with an invalid sub-component resolves to an ErrorType, this meant that in invalid code, the first list of protocols might contain protocols that don't appear in the second.

This broke rewrite system invariants. Fix this by checking if type resolution failed when building the requirement signature of a protocol, and if so, also look at getInheritedProtocols().

Fixes https://github.com/apple/swift/issues/61020.