### PR TITLE
[Basic] Make it possible to access some experimental features in production compilers

### DIFF
--- a/include/swift/Basic/Feature.h
+++ b/include/swift/Basic/Feature.h
@@ -40,6 +40,9 @@ FeatureName,
 /// Determine whether the given feature is suppressible.
 bool isSuppressibleFeature(Feature feature);
 
+/// Check whether the given feature is available in production compilers.
+bool isFeatureAvailableInProduction(Feature feature);
+
 /// Determine the in-source name of the given feature.
 llvm::StringRef getFeatureName(Feature feature);
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -55,7 +55,9 @@
 #endif
 
 #ifndef EXPERIMENTAL_FEATURE
-#  define EXPERIMENTAL_FEATURE(FeatureName)  \
+// Warning: setting `AvailableInProd` to `true` on a feature means that the flag
+//          cannot be dropped in the future.
+#  define EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)  \
      LANGUAGE_FEATURE(FeatureName, 0, #FeatureName, \
                       langOpts.hasFeature(#FeatureName))
 #endif
@@ -94,63 +96,63 @@ UPCOMING_FEATURE(ForwardTrailingClosures, 286, 6)
 UPCOMING_FEATURE(BareSlashRegexLiterals, 354, 6)
 UPCOMING_FEATURE(ExistentialAny, 335, 6)
 
-EXPERIMENTAL_FEATURE(StaticAssert)
-EXPERIMENTAL_FEATURE(VariadicGenerics)
-EXPERIMENTAL_FEATURE(NamedOpaqueTypes)
-EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures)
-EXPERIMENTAL_FEATURE(MoveOnly)
-EXPERIMENTAL_FEATURE(OneWayClosureParameters)
-EXPERIMENTAL_FEATURE(TypeWitnessSystemInference)
-EXPERIMENTAL_FEATURE(ResultBuilderASTTransform)
-EXPERIMENTAL_FEATURE(LayoutPrespecialization)
+EXPERIMENTAL_FEATURE(StaticAssert, false)
+EXPERIMENTAL_FEATURE(VariadicGenerics, false)
+EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)
+EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures, false)
+EXPERIMENTAL_FEATURE(MoveOnly, false)
+EXPERIMENTAL_FEATURE(OneWayClosureParameters, false)
+EXPERIMENTAL_FEATURE(TypeWitnessSystemInference, false)
+EXPERIMENTAL_FEATURE(ResultBuilderASTTransform, false)
+EXPERIMENTAL_FEATURE(LayoutPrespecialization, false)
 
 /// Whether to enable experimental differentiable programming features:
 /// `@differentiable` declaration attribute, etc.
-EXPERIMENTAL_FEATURE(DifferentiableProgramming)
+EXPERIMENTAL_FEATURE(DifferentiableProgramming, false)
 
 /// Whether to enable forward mode differentiation.
-EXPERIMENTAL_FEATURE(ForwardModeDifferentiation)
+EXPERIMENTAL_FEATURE(ForwardModeDifferentiation, false)
 
 /// Whether to enable experimental `AdditiveArithmetic` derived
 /// conformances.
-EXPERIMENTAL_FEATURE(AdditiveArithmeticDerivedConformances)
+EXPERIMENTAL_FEATURE(AdditiveArithmeticDerivedConformances, false)
 
 /// Whether Objective-C completion handler parameters are imported as
 /// @Sendable.
-EXPERIMENTAL_FEATURE(SendableCompletionHandlers)
+EXPERIMENTAL_FEATURE(SendableCompletionHandlers, false)
 
 /// Enables opaque type erasure without also enabling implict dynamic
-EXPERIMENTAL_FEATURE(OpaqueTypeErasure)
+EXPERIMENTAL_FEATURE(OpaqueTypeErasure, false)
 
 /// Whether to enable experimental @typeWrapper feature which allows to
 /// declare a type that controls access to all stored properties of the
 /// wrapped type.
-EXPERIMENTAL_FEATURE(TypeWrappers)
+EXPERIMENTAL_FEATURE(TypeWrappers, false)
 
 /// Whether to perform round-trip testing of the Swift Swift parser.
-EXPERIMENTAL_FEATURE(ParserRoundTrip)
+EXPERIMENTAL_FEATURE(ParserRoundTrip, false)
 
 /// Whether to perform validation of the parse tree produced by the Swift
 /// Swift parser.
-EXPERIMENTAL_FEATURE(ParserValidation)
+EXPERIMENTAL_FEATURE(ParserValidation, false)
 
 /// Whether to fold sequence expressions in the syntax tree produced by the
 /// Swift Swift parser.
-EXPERIMENTAL_FEATURE(ParserSequenceFolding)
+EXPERIMENTAL_FEATURE(ParserSequenceFolding, false)
 
 /// Enables implicit some while also enabling existential `any`
-EXPERIMENTAL_FEATURE(ImplicitSome)
+EXPERIMENTAL_FEATURE(ImplicitSome, false)
 
 /// Parse using the Swift (swift-syntax) parser and use ASTGen to generate the
 /// corresponding syntax tree.
-EXPERIMENTAL_FEATURE(ParserASTGen)
+EXPERIMENTAL_FEATURE(ParserASTGen, false)
 
 /// Enable the experimental macros feature.
-EXPERIMENTAL_FEATURE(Macros)
+EXPERIMENTAL_FEATURE(Macros, false)
 
 /// Parse using the Swift (swift-syntax) parser and use ASTGen to generate the
 /// corresponding syntax tree.
-EXPERIMENTAL_FEATURE(BuiltinMacros)
+EXPERIMENTAL_FEATURE(BuiltinMacros, false)
 
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -103,7 +103,7 @@ EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures, false)
 EXPERIMENTAL_FEATURE(MoveOnly, false)
 EXPERIMENTAL_FEATURE(OneWayClosureParameters, false)
 EXPERIMENTAL_FEATURE(TypeWitnessSystemInference, false)
-EXPERIMENTAL_FEATURE(ResultBuilderASTTransform, false)
+EXPERIMENTAL_FEATURE(ResultBuilderASTTransform, true)
 EXPERIMENTAL_FEATURE(LayoutPrespecialization, false)
 
 /// Whether to enable experimental differentiable programming features:

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -443,6 +443,17 @@ bool swift::isSuppressibleFeature(Feature feature) {
   llvm_unreachable("covered switch");
 }
 
+bool swift::isFeatureAvailableInProduction(Feature feature) {
+  switch (feature) {
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)  \
+  case Feature::FeatureName: return true;
+#define EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)            \
+  case Feature::FeatureName: return AvailableInProd;
+#include "swift/Basic/Features.def"
+  }
+  llvm_unreachable("covered switch");
+}
+
 llvm::Optional<Feature> swift::getUpcomingFeature(llvm::StringRef name) {
   return llvm::StringSwitch<Optional<Feature>>(name)
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)
@@ -455,7 +466,7 @@ llvm::Optional<Feature> swift::getUpcomingFeature(llvm::StringRef name) {
 llvm::Optional<Feature> swift::getExperimentalFeature(llvm::StringRef name) {
   return llvm::StringSwitch<Optional<Feature>>(name)
 #define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)
-#define EXPERIMENTAL_FEATURE(FeatureName) \
+#define EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)                  \
                    .Case(#FeatureName, Feature::FeatureName)
 #include "swift/Basic/Features.def"
                    .Default(None);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -635,9 +635,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     // (non-release) builds for testing purposes.
     if (auto feature = getExperimentalFeature(A->getValue())) {
 #ifdef NDEBUG
-      Diags.diagnose(SourceLoc(),
-                     diag::error_experimental_feature_not_available,
-                     A->getValue());
+      if (!isFeatureAvailableInProduction(*feature)) {
+        Diags.diagnose(SourceLoc(),
+                       diag::error_experimental_feature_not_available,
+                       A->getValue());
+      }
 #endif
 
       Opts.Features.insert(*feature);


### PR DESCRIPTION
Resolves: rdar://99884335

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
