### PR TITLE
[cxx-interop] Avoid a ClangImporter dependency on Sema

### DIFF
--- a/lib/ClangImporter/CMakeLists.txt
+++ b/lib/ClangImporter/CMakeLists.txt
@@ -28,7 +28,6 @@ add_swift_host_library(swiftClangImporter STATIC
 target_link_libraries(swiftClangImporter PRIVATE
   swiftAST
   swiftParse
-  swiftSema
   clangTooling
   LLVMBitstreamReader)
 

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -4,7 +4,9 @@ target_link_libraries(swiftSIL PUBLIC
   swiftDemangling)
 target_link_libraries(swiftSIL PRIVATE
   swiftAST
-  swiftClangImporter)
+  swiftClangImporter
+  swiftSema
+  swiftSerialization)
 
 add_subdirectory(IR)
 add_subdirectory(Utils)

--- a/lib/SILGen/CMakeLists.txt
+++ b/lib/SILGen/CMakeLists.txt
@@ -36,6 +36,7 @@ add_swift_host_library(swiftSILGen STATIC
   SILGenThunk.cpp
   SILGenType.cpp)
 target_link_libraries(swiftSILGen PRIVATE
+  swiftSerialization
   swiftSIL)
 
 set_swift_llvm_is_available(swiftSILGen)

--- a/tools/sil-passpipeline-dumper/CMakeLists.txt
+++ b/tools/sil-passpipeline-dumper/CMakeLists.txt
@@ -5,6 +5,7 @@ add_swift_host_tool(sil-passpipeline-dumper
 target_link_libraries(sil-passpipeline-dumper PRIVATE
   swiftFrontend
   swiftIRGen
+  swiftSema
   swiftSILGen
   swiftSILOptimizer
   # Clang libraries included to appease the linker on linux.


### PR DESCRIPTION
My recent change started linking ClangImporter with Sema, which accidentally introduced a circular dependency between the two.

This patch avoid the usage of type checker logic from ClangImporter's automatic protocol conformance logic.

rdar://101763817