### PR TITLE
[silgen] Verify protocol witnesses's SIL right after emitting them.

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -4617,4 +4617,7 @@ void SILGenFunction::emitProtocolWitness(
   formalEvalScope.pop();
   scope.pop();
   B.createReturn(loc, reqtResultValue);
+
+  // Now that we have finished emitting the function, verify it!
+  F.verify();
 }


### PR DESCRIPTION
These still get verified as part of SILGenModule's verification during SILGenModule's destructor. But moving this earlier catches the error earlier and makes it easier to debug any SIL issues immediately in the debugger rather than having to backtrack from the SILGenModule's destructor.
