### PR TITLE
Rename module aliasing terms to avoid confusion

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -372,13 +372,13 @@ private:
   /// Cache of module names that fail the 'canImport' test in this context.
   mutable llvm::StringSet<> FailedModuleImportNames;
 
-  /// Set if a `-module-alias` was passed. Used to store mapping between module aliases and
-  /// their corresponding real names, and vice versa for a reverse lookup, which is needed to check
-  /// if the module names appearing in source files are aliases or real names.
-  /// \see ASTContext::getRealModuleName.
+  /// Set if a `-module-alias` was passed. Used to store mapping between module syntax names and
+  /// their corresponding binary names, and vice versa for a reverse lookup, which is needed to check
+  /// if the module names appearing in source files are syntax names or binary names.
+  /// \see ASTContext::getBinaryModuleName.
   ///
-  /// The boolean in the value indicates whether or not the entry is keyed by an alias vs real name,
-  /// i.e. true if the entry is [key: alias_name, value: (real_name, true)].
+  /// The boolean in the value indicates whether or not the entry is keyed by a syntax name vs binary name,
+  /// i.e. true if the entry is [key: syntax_name, value: (binary_name, true)].
   mutable llvm::DenseMap<Identifier, std::pair<Identifier, bool>> ModuleAliasMap;
 
   /// Retrieve the allocator for the given arena.
@@ -512,30 +512,30 @@ public:
   /// Convert a given alias map to a map of Identifiers between module aliases and their actual names.
   /// For example, if '-module-alias Foo=X -module-alias Bar=Y' input is passed in, the aliases Foo and Bar are
   /// the names of the imported or referenced modules in source files in the main module, and X and Y
-  /// are the real (physical) module names on disk.
+  /// are the binary module names on disk.
   void setModuleAliases(const llvm::StringMap<StringRef> &aliasMap);
 
-  /// Look up option used in \c getRealModuleName when module aliasing is applied.
+  /// Look up option used in \c getBinaryModuleName when module aliasing is applied.
   enum class ModuleAliasLookupOption {
-    alwaysRealName,
-    realNameFromAlias,
-    aliasFromRealName
+    alwaysBinaryName,
+    binaryNameFromSyntaxName,
+    syntaxNameFromBinaryName
   };
 
   /// Look up the module alias map by the given \p key and a lookup \p option.
   ///
-  /// \param key A module alias or real name to look up the map by.
-  /// \param option A look up option \c ModuleAliasLookupOption. Defaults to alwaysRealName.
+  /// \param key A module syntax name or binary name to look up the map by.
+  /// \param option A look up option \c ModuleAliasLookupOption. Defaults to alwaysBinaryName.
   ///
-  /// \return The real name or alias mapped to the key.
+  /// \return The binary name or syntax name mapped to the key.
   ///         If no aliasing is used, return \p key regardless of \p option.
-  ///         If \p option is alwaysRealName, return the real module name whether the \p key is an alias
-  ///         or a real name.
-  ///         If \p option is realNameFromAlias, only return a real name if \p key is an alias.
-  ///         If \p option is aliasFromRealName, only return an alias if \p key is a real name.
-  ///         Else return a real name or an alias mapped to the \p key.
-  Identifier getRealModuleName(Identifier key,
-                               ModuleAliasLookupOption option = ModuleAliasLookupOption::alwaysRealName) const;
+  ///         If \p option is alwaysBinaryName, return the binary module name whether the \p key is a syntax name
+  ///         or a binary name.
+  ///         If \p option is binaryNameFromSyntaxName, only return a binary name if \p key is a syntax name.
+  ///         If \p option is syntaxNameFromBinaryName, only return a syntax name if \p key is a binary name.
+  ///         Else return a binary name or a syntax name mapped to the \p key.
+  Identifier getBinaryModuleName(Identifier key,
+                               ModuleAliasLookupOption option = ModuleAliasLookupOption::alwaysBinaryName) const;
 
   /// Decide how to interpret two precedence groups.
   Associativity associateInfixOperators(PrecedenceGroupDecl *left,

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1244,10 +1244,10 @@ class ImportDecl final : public Decl,
 
   SourceLoc ImportLoc;
   SourceLoc KindLoc;
-  /// Used to store the real module name corresponding to this import decl in
+  /// Used to store the binary module name corresponding to this import decl in
   /// case module aliasing is used. For example if '-module-alias Foo=Bar' was
-  /// passed and this decl is 'import Foo', the real name 'Bar' will be stored.
-  Identifier RealModuleName;
+  /// passed and this decl is 'import Foo', the binary name 'Bar' will be stored.
+  Identifier BinaryModuleName;
 
   /// The resolved module.
   ModuleDecl *Mod = nullptr;
@@ -1289,17 +1289,17 @@ public:
                         static_cast<size_t>(Bits.ImportDecl.NumPathElements) });
   }
 
-  /// Retrieves the import path, replacing any module aliases with real names.
+  /// Retrieves the import path, replacing any module aliases with binary names.
   /// 
   /// \param scratch An \c ImportPath::Builder which may, if necessary, be used to
   ///        construct the return value. It may go unused, so you should not try to
   ///        read the result from it; use the return value instead.
   /// \returns An \c ImportPath corresponding to this import decl. If module aliasing
-  ///          was used, this will contain the real name of the module; for instance,
+  ///          was used, this will contain the binary name of the module; for instance,
   ///          if you wrote 'import Foo' but passed '-module-alias Foo=Bar', this import
   ///          path will include 'Bar'. This return value may be owned by \p scratch,
   ///          so it should not be used after \p scratch is destroyed.
-  ImportPath getRealImportPath(ImportPath::Builder &scratch) const;
+  ImportPath getBinaryImportPath(ImportPath::Builder &scratch) const;
 
   /// Retrieves the part of the import path that contains the module name,
   /// as written in the source code.
@@ -1314,18 +1314,18 @@ public:
   }
 
   /// Retrieves the part of the import path that contains the module name,
-  /// replacing any module aliases with real names.
+  /// replacing any module aliases with binary names.
   /// 
   /// \param scratch An \c ImportPath::Builder which may, if necessary, be used to
   ///        construct the return value. It may go unused, so you should not try to
   ///        read the result from it; use the return value instead.
   /// \returns An \c ImportPath::Module corresponding to this import decl. If module
-  ///          aliasing was used, this will contain the real name of the module; for
+  ///          aliasing was used, this will contain the binary name of the module; for
   ///          instance, if you wrote 'import Foo' but passed '-module-alias Foo=Bar',
   ///          the returned path will contain 'Bar'. This return value may be owned
   ///          by \p scratch, so it should not be used after \p scratch is destroyed.
-  ImportPath::Module getRealModulePath(ImportPath::Builder &scratch) const {
-    return getRealImportPath(scratch).getModulePath(getImportKind());
+  ImportPath::Module getBinaryModulePath(ImportPath::Builder &scratch) const {
+    return getBinaryImportPath(scratch).getModulePath(getImportKind());
   }
 
   ImportPath::Access getAccessPath() const {

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -183,11 +183,11 @@ ERROR(error_stdlib_module_name,none,
 ERROR(error_stdlib_not_found,Fatal,
       "unable to load standard library for target '%0'", (StringRef))
 ERROR(error_module_alias_invalid_format,none,
-      "invalid module alias format \"%0\"; make sure to use the format '-module-alias alias_name=underlying_name'", (StringRef))
+      "invalid module alias format \"%0\"; make sure to use the format '-module-alias syntax_name=binary_name'", (StringRef))
 ERROR(error_module_alias_forbidden_name,none,
-      "invalid module alias \"%0\"; make sure the alias differs from the module name, module ABI name, module link name, and a standard library name", (StringRef))
+      "invalid module alias \"%0\"; make sure the binary name differs from the module syntax name, module ABI name, module link name, and a standard library name", (StringRef))
 ERROR(error_module_alias_duplicate,none,
-      "duplicate module alias; the name \"%0\" is already used for a module alias or an underlying name", (StringRef))
+      "duplicate module alias; the name \"%0\" is already used for a module syntax name or a module binary name", (StringRef))
 
 ERROR(error_unable_to_load_supplementary_output_file_map, none,
       "unable to load supplementary output file map '%0': %1",

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -318,14 +318,14 @@ public:
     return nullptr;
   }
 
-  /// Returns the real name of the enclosing module to use when referencing entities in this file.
-  /// The 'real name' is the actual binary name of the module, which can be different from the 'name'
+  /// Returns the binary name of the enclosing module to use when referencing entities in this file.
+  /// The 'binary name' is the actual binary name of the module, which can be different from the 'name'
   /// if module aliasing was used (via -module-alias flag).
   ///
-  /// Usually this is the module real name itself, but certain Clang features allow
+  /// Usually this is the module binary name itself, but certain Clang features allow
   /// substituting another name instead.
   virtual StringRef getExportedModuleName() const {
-    return getParentModule()->getRealName().str();
+    return getParentModule()->getBinaryName().str();
   }
 
   SWIFT_DEBUG_DUMPER(dumpDisplayDecls());

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -204,7 +204,7 @@ public:
     }
 
     /// Returns the name of the current module.
-    /// Note that for a Swift module, it returns the current module's real (binary) name,
+    /// Note that for a Swift module, it returns the current module's binary name,
     /// which can be different from the name if module aliasing was used (see `-module-alias`).
     StringRef operator*() const;
     ReverseFullNameIterator &operator++();
@@ -408,10 +408,10 @@ public:
   ///
   /// For example, if '-module-alias Foo=Bar' is passed in when building the main module,
   /// and this module is (a) not the main module and (b) is named Foo, then it returns
-  /// the real (physically on-disk) module name Bar.
+  /// the binary module name Bar.
   ///
   /// If no module aliasing is set, it will return getName(), i.e. Foo.
-  Identifier getRealName() const;
+  Identifier getBinaryName() const;
 
   /// User-defined module version number.
   llvm::VersionTuple UserModuleVersion;
@@ -949,19 +949,19 @@ public:
   ModuleEntity(const ModuleDecl *Mod) : Mod(Mod) {}
   ModuleEntity(const clang::Module *Mod) : Mod(static_cast<const void *>(Mod)){}
 
-  /// @param useRealNameIfAliased Whether to use the module's real name in case
+  /// @param useBinaryNameIfAliased Whether to use the module's binary name in case
   ///                             module aliasing is used. For example, if a file
   ///                             has `import Foo` and `-module-alias Foo=Bar` is
-  ///                             passed, treat Foo as an alias and Bar as the real
+  ///                             passed, treat Foo as the syntax name and Bar as the binary
   ///                             module name as its dependency. This only applies
   ///                             to Swift modules.
-  /// @return The module name; for Swift modules, the real module name could be
+  /// @return The module name; for Swift modules, the binary module name could be
   ///         different from the name if module aliasing is used.
-  StringRef getName(bool useRealNameIfAliased = false) const;
+  StringRef getName(bool useBinaryNameIfAliased = false) const;
 
   /// For Swift modules, it returns the same result as \c ModuleEntity::getName(bool).
   /// For Clang modules, it returns the result of \c clang::Module::getFullModuleName.
-  std::string getFullName(bool useRealNameIfAliased = false) const;
+  std::string getFullName(bool useBinaryNameIfAliased = false) const;
 
   bool isSystemModule() const;
   bool isBuiltinModule() const;

--- a/include/swift/AST/USRGeneration.h
+++ b/include/swift/AST/USRGeneration.h
@@ -47,9 +47,9 @@ bool printDeclTypeUSR(const ValueDecl *D, raw_ostream &OS);
 bool printValueDeclUSR(const ValueDecl *D, raw_ostream &OS);
 
 /// Prints out the USR for the given ModuleEntity.
-/// In case module aliasing is used, it prints the real module name. For example,
+/// In case module aliasing is used, it prints the binary module name. For example,
 /// if a file has `import Foo` and `-module-alias Foo=Bar` is passed, treat Foo as
-/// an alias and Bar as the real module name as its dependency. Note that the
+/// the module syntax name and Bar as the binary module name as its dependency. Note that the
 /// aliasing only applies to Swift modules.
 /// \returns true if it failed, false on success.
 bool printModuleUSR(ModuleEntity Mod, raw_ostream &OS);

--- a/include/swift/ClangImporter/ClangModule.h
+++ b/include/swift/ClangImporter/ClangModule.h
@@ -59,7 +59,7 @@ public:
   ModuleDecl *getOverlayModule() const override;
 
   /// Retrieve the "exported" name of the module, which is usually the module
-  /// real name, but might be the name of the public module through which this
+  /// binary name, but might be the name of the public module through which this
   /// (private) module is re-exported.
   StringRef getExportedModuleName() const override;
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -467,8 +467,8 @@ def module_name_EQ : Joined<["-"], "module-name=">, Flags<[FrontendOption]>,
 
 def module_alias : Separate<["-"], "module-alias">,
   Flags<[FrontendOption, ModuleInterfaceOption]>,
-  MetaVarName<"<alias_name=underlying_name>">,
-  HelpText<"If a source file imports or references module <alias_name>, the <underlying_name> is used for the contents of the file">;
+  MetaVarName<"<syntax_name=binary_name>">,
+  HelpText<"If a source file imports or references module <syntax_name>, the <binary_name> is used for the contents of the file">;
 
 def module_link_name : Separate<["-"], "module-link-name">,
   Flags<[FrontendOption, ModuleInterfaceOption]>,

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -591,9 +591,9 @@ namespace {
       OS << " '";
       // Check if module aliasing was used for the given imported module; for
       // example, if '-module-alias Foo=Bar' was passed and this module has
-      // 'import Foo', its corresponding real module name 'Bar' should be printed.
+      // 'import Foo', its corresponding binary module name 'Bar' should be printed.
       ImportPath::Builder scratch;
-      ID->getRealImportPath(scratch).print(OS);
+      ID->getBinaryImportPath(scratch).print(OS);
       OS << "')";
     }
 
@@ -1366,7 +1366,7 @@ void swift::printContext(raw_ostream &os, DeclContext *dc) {
 
   switch (dc->getContextKind()) {
   case DeclContextKind::Module:
-    printName(os, cast<ModuleDecl>(dc)->getRealName());
+    printName(os, cast<ModuleDecl>(dc)->getBinaryName());
     break;
 
   case DeclContextKind::FileUnit:
@@ -1454,7 +1454,7 @@ void ValueDecl::dumpRef(raw_ostream &os) const {
     // Print name.
     getName().printPretty(os);
   } else {
-    auto moduleName = cast<ModuleDecl>(this)->getRealName();
+    auto moduleName = cast<ModuleDecl>(this)->getBinaryName();
     os << moduleName;
   }
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -2391,13 +2391,13 @@ void ASTMangler::appendModule(const ModuleDecl *module,
                               StringRef useModuleName) {
   assert(!module->getParent() && "cannot mangle nested modules!");
 
-  // Use the module real name in mangling; this is the physical name
+  // Use the module binary name in mangling; this is the physical name
   // of the module on-disk, which can be different if -module-alias is
   // used.
   //
   // For example, if a module Foo has 'import Bar', and '-module-alias Bar=Baz'
   // was passed, the name 'Baz' will be used for mangling besides loading.
-  StringRef ModName = module->getRealName().str();
+  StringRef ModName = module->getBinaryName().str();
   if (RespectOriginallyDefinedIn &&
       module->getABIName() != module->getName()) { // check if the ABI name is set
     ModName = module->getABIName().str();

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2495,16 +2495,16 @@ void PrintAST::visitImportDecl(ImportDecl *decl) {
   llvm::interleave(decl->getImportPath(),
                    [&](const ImportPath::Element &Elem) {
                      if (!Mods.empty()) {
-                       // Should print the module real name in case module
+                       // Should print the module binary name in case module
                        // aliasing is used (see -module-alias), since that's
                        // the actual binary name.
-                       Identifier Name = decl->getASTContext().getRealModuleName(Elem.Item);
+                       Identifier Name = decl->getASTContext().getBinaryModuleName(Elem.Item);
                        if (Options.MapCrossImportOverlaysToDeclaringModule) {
                          if (auto *MD = Mods.front().getAsSwiftModule()) {
                            ModuleDecl *Declaring = const_cast<ModuleDecl*>(MD)
                              ->getDeclaringModuleIfCrossImportOverlay();
                            if (Declaring)
-                             Name = Declaring->getRealName();
+                             Name = Declaring->getBinaryName();
                          }
                        }
                        Printer.printModuleRef(Mods.front(), Name, Options);
@@ -5382,9 +5382,9 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
         Mod = Declaring;
     }
 
-    // Should use the module real (binary) name here and everywhere else the
+    // Should use the module binary name here and everywhere else the
     // module is printed in case module aliasing is used (see -module-alias)
-    Identifier Name = Mod->getRealName();
+    Identifier Name = Mod->getBinaryName();
     if (Options.UseExportedModuleNames && !ExportedModuleName.empty()) {
       Name = Mod->getASTContext().getIdentifier(ExportedModuleName);
     }
@@ -5415,7 +5415,7 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
   bool isLLDBExpressionModule(ModuleDecl *M) {
     if (!M)
       return false;
-    return M->getRealName().str().startswith(LLDB_EXPRESSIONS_MODULE_NAME_PREFIX);
+    return M->getBinaryName().str().startswith(LLDB_EXPRESSIONS_MODULE_NAME_PREFIX);
   }
 
   bool shouldPrintFullyQualified(TypeBase *T) {
@@ -5446,7 +5446,7 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
 
     // Don't print qualifiers for types from the standard library.
     if (M->isStdlibModule() ||
-        M->getRealName() == M->getASTContext().Id_ObjectiveC ||
+        M->getBinaryName() == M->getASTContext().Id_ObjectiveC ||
         M->isSystemModule() ||
         isLLDBExpressionModule(M))
       return false;
@@ -5744,9 +5744,9 @@ public:
 
   void visitModuleType(ModuleType *T) {
     Printer << "module<";
-    // Should print the module real name in case module aliasing is
+    // Should print the module binary name in case module aliasing is
     // used (see -module-alias), since that's the actual binary name.
-    Printer.printModuleRef(T->getModule(), T->getModule()->getRealName(),
+    Printer.printModuleRef(T->getModule(), T->getModule()->getBinaryName(),
                            Options);
     Printer << ">";
   }
@@ -6900,13 +6900,13 @@ void ProtocolConformance::printName(llvm::raw_ostream &os,
   case ProtocolConformanceKind::Normal: {
     auto normal = cast<NormalProtocolConformance>(this);
     os << normal->getProtocol()->getName()
-       << " module " << normal->getDeclContext()->getParentModule()->getRealName();
+       << " module " << normal->getDeclContext()->getParentModule()->getBinaryName();
     break;
   }
   case ProtocolConformanceKind::Self: {
     auto self = cast<SelfProtocolConformance>(this);
     os << self->getProtocol()->getName()
-       << " module " << self->getDeclContext()->getParentModule()->getRealName();
+       << " module " << self->getDeclContext()->getParentModule()->getBinaryName();
     break;
   }
   case ProtocolConformanceKind::Specialized: {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1161,10 +1161,10 @@ ImportDecl *ImportDecl::create(ASTContext &Ctx, DeclContext *DC,
   auto D = new (ptr) ImportDecl(DC, ImportLoc, Kind, KindLoc, Path);
   if (ClangN)
     D->setClangNode(ClangN);
-  auto realNameIfExists = Ctx.getRealModuleName(Path.front().Item,
-                                                ASTContext::ModuleAliasLookupOption::realNameFromAlias);
-  if (!realNameIfExists.empty()) {
-    D->RealModuleName = realNameIfExists;
+  auto binaryNameIfExists = Ctx.getBinaryModuleName(Path.front().Item,
+                                                ASTContext::ModuleAliasLookupOption::binaryNameFromSyntaxName);
+  if (!binaryNameIfExists.empty()) {
+    D->BinaryModuleName = binaryNameIfExists;
   }
   return D;
 }
@@ -1263,16 +1263,16 @@ ImportDecl::findBestImportKind(ArrayRef<ValueDecl *> Decls) {
   return FirstKind;
 }
 
-ImportPath ImportDecl::getRealImportPath(ImportPath::Builder &scratch) const {
+ImportPath ImportDecl::getBinaryImportPath(ImportPath::Builder &scratch) const {
   assert(scratch.empty() && "scratch ImportPath::Builder must be initially empty");
   auto path = getImportPath();
-  if (RealModuleName.empty())
+  if (BinaryModuleName.empty())
     return path;
 
   for (auto elem : path) {
     if (scratch.empty()) {
-      // Add the real module name instead of its alias
-      scratch.push_back(RealModuleName);
+      // Add the binary module name instead of its syntax name
+      scratch.push_back(BinaryModuleName);
     } else {
       // Add the rest if any (access path elements)
       scratch.push_back(elem.Item);

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1860,11 +1860,11 @@ ModuleDecl::ReverseFullNameIterator::ReverseFullNameIterator(
 
 StringRef ModuleDecl::ReverseFullNameIterator::operator*() const {
   assert(current && "all name components exhausted");
-  // Return the module's real (binary) name, which can be different from
-  // the name if module aliasing was used (-module-alias flag). The real
+  // Return the module's binary name, which can be different from
+  // the syntax name if module aliasing was used (-module-alias flag). The binary
   // name is used for serialization and loading.
   if (auto *swiftModule = current.dyn_cast<const ModuleDecl *>())
-    return swiftModule->getRealName().str();
+    return swiftModule->getBinaryName().str();
 
   auto *clangModule =
       static_cast<const clang::Module *>(current.get<const void *>());
@@ -1926,9 +1926,9 @@ ImportedModule::removeDuplicates(SmallVectorImpl<ImportedModule> &imports) {
   imports.erase(last, imports.end());
 }
 
-Identifier ModuleDecl::getRealName() const {
-  // This will return the real name for an alias (if used) or getName()
-  return getASTContext().getRealModuleName(getName());
+Identifier ModuleDecl::getBinaryName() const {
+  // This will return the binary name for its syntax name (if used) or getName()
+  return getASTContext().getBinaryModuleName(getName());
 }
 
 Identifier ModuleDecl::getABIName() const {
@@ -2180,7 +2180,7 @@ bool ModuleDecl::isExportedAs(const ModuleDecl *other) const {
   if (!clangModule)
     return false;
 
-  return other->getRealName().str() == clangModule->ExportAsModule;
+  return other->getBinaryName().str() == clangModule->ExportAsModule;
 }
 
 void ModuleDecl::collectBasicSourceFileInfo(
@@ -3680,17 +3680,17 @@ getClangModule(llvm::PointerUnion<const ModuleDecl *, const void *> Union) {
   return static_cast<const clang::Module *>(Union.get<const void *>());
 }
 
-StringRef ModuleEntity::getName(bool useRealNameIfAliased) const {
+StringRef ModuleEntity::getName(bool useBinaryNameIfAliased) const {
   assert(!Mod.isNull());
   if (auto SwiftMod = Mod.dyn_cast<const ModuleDecl*>())
-    return useRealNameIfAliased ? SwiftMod->getRealName().str() : SwiftMod->getName().str();
+    return useBinaryNameIfAliased ? SwiftMod->getBinaryName().str() : SwiftMod->getName().str();
   return getClangModule(Mod)->Name;
 }
 
-std::string ModuleEntity::getFullName(bool useRealNameIfAliased) const {
+std::string ModuleEntity::getFullName(bool useBinaryNameIfAliased) const {
   assert(!Mod.isNull());
   if (auto SwiftMod = Mod.dyn_cast<const ModuleDecl*>())
-    return std::string(useRealNameIfAliased ? SwiftMod->getRealName() : SwiftMod->getName());
+    return std::string(useBinaryNameIfAliased ? SwiftMod->getBinaryName() : SwiftMod->getName());
   return getClangModule(Mod)->getFullModuleName();
 }
 

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -101,8 +101,8 @@ void ModuleDependencies::addModuleDependencies(
       continue;
 
     ImportPath::Builder scratch;
-    auto realPath = importDecl->getRealModulePath(scratch);
-    addModuleDependency(realPath, &alreadyAddedModules);
+    auto binaryModulePath = importDecl->getBinaryModulePath(scratch);
+    addModuleDependency(binaryModulePath, &alreadyAddedModules);
   }
 
   auto fileName = sf.getFilename();

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -280,7 +280,7 @@ swift::MangleLocalTypeDeclRequest::evaluate(Evaluator &evaluator,
 
 bool ide::printModuleUSR(ModuleEntity Mod, raw_ostream &OS) {
   if (auto *D = Mod.getAsSwiftModule()) {
-    StringRef moduleName = D->getRealName().str();
+    StringRef moduleName = D->getBinaryName().str();
     return clang::index::generateFullUSRForTopLevelModuleName(moduleName, OS);
   } else if (auto ClangM = Mod.getAsClangModule()) {
     return clang::index::generateFullUSRForModule(ClangM, OS);

--- a/lib/AST/UnqualifiedLookup.cpp
+++ b/lib/AST/UnqualifiedLookup.cpp
@@ -579,14 +579,14 @@ void UnqualifiedLookupFactory::lookForAModuleWithTheGivenName(
   ModuleDecl *desiredModule = nullptr;
   auto givenName = Name.getBaseIdentifier();
   // Check if the given name appearing in the source file is a module
-  // real name or alias; for example, if `-module-alias Foo=Bar` was
-  // passed, the alias 'Foo' should appear in source files, not 'Bar'.
-  // If the real name 'Bar' was used, looking up getRealModuleName with
-  // the real name 'Bar' and realNameFromAlias option should return
+  // binary name or syntax name; for example, if `-module-alias Foo=Bar` was
+  // passed, the syntax name 'Foo' should appear in source files, not 'Bar'.
+  // If the binary name 'Bar' was used, looking up getBinaryModuleName with
+  // the binary name 'Bar' and binaryNameFromSyntaxName option should return
   // an empty Identifier.
-  if (!Ctx.getRealModuleName(givenName, ASTContext::ModuleAliasLookupOption::realNameFromAlias).empty()) {
+  if (!Ctx.getBinaryModuleName(givenName, ASTContext::ModuleAliasLookupOption::binaryNameFromSyntaxName).empty()) {
     // Only load the module if the lookup value is not empty, i.e. given
-    // name is a module alias, not a real module name.
+    // name is a module syntax name, not a binary module name.
     desiredModule = Ctx.getLoadedModule(givenName);
   }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1926,7 +1926,7 @@ bool ClangImporter::canImportModule(ImportPath::Module modulePath,
 ModuleDecl *ClangImporter::Implementation::loadModuleClang(
     SourceLoc importLoc, ImportPath::Module path) {
   auto &clangHeaderSearch = getClangPreprocessor().getHeaderSearchInfo();
-  auto realModuleName = SwiftContext.getRealModuleName(path.front().Item).str();
+  auto realModuleName = SwiftContext.getBinaryModuleName(path.front().Item).str();
 
   // Look up the top-level module first, to see if it exists at all.
   clang::Module *clangModule = clangHeaderSearch.lookupModule(
@@ -3783,8 +3783,8 @@ StringRef ClangModuleUnit::getExportedModuleName() const {
   if (clangModule && !clangModule->ExportAsModule.empty())
     return clangModule->ExportAsModule;
 
-  // Return module real name (see FileUnit::getExportedModuleName)
-  return getParentModule()->getRealName().str();
+  // Return module binary name (see FileUnit::getExportedModuleName)
+  return getParentModule()->getBinaryName().str();
 }
 
 ModuleDecl *ClangModuleUnit::getOverlayModule() const {

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -615,7 +615,7 @@ class ModuleInterfaceLoaderImpl {
       path::filename(path::parent_path(interfacePath));
     if (path::extension(inParentDirName) == ".swiftmodule") {
       assert(path::stem(inParentDirName) ==
-             ctx.getRealModuleName(ctx.getIdentifier(moduleName)).str());
+             ctx.getBinaryModuleName(ctx.getIdentifier(moduleName)).str());
       path::append(scratch, inParentDirName);
     }
     path::append(scratch, path::filename(modulePath));
@@ -1028,7 +1028,7 @@ class ModuleInterfaceLoaderImpl {
       }
       // Set up a builder if we need to build the module. It'll also set up
       // the genericSubInvocation we'll need to use to compute the cache paths.
-      Identifier realName = ctx.getRealModuleName(ctx.getIdentifier(moduleName));
+      Identifier realName = ctx.getBinaryModuleName(ctx.getIdentifier(moduleName));
       ImplicitModuleInterfaceBuilder builder(
         ctx.SourceMgr, diagsToUse,
         astDelegate, interfacePath, realName.str(), cacheDir,
@@ -1898,8 +1898,8 @@ bool ExplicitSwiftModuleLoader::findModule(ImportPath::Element ModuleID,
   // -module-alias is used (otherwise same).
   //
   // For example, if '-module-alias Foo=Bar' is passed in to the frontend, and an
-  // input file has 'import Foo', a module called Bar (real name) should be searched.
-  StringRef moduleName = Ctx.getRealModuleName(ModuleID.Item).str();
+  // input file has 'import Foo', a module called Bar (binary name) should be searched.
+  StringRef moduleName = Ctx.getBinaryModuleName(ModuleID.Item).str();
 
   auto it = Impl.ExplicitModuleMap.find(moduleName);
   // If no explicit module path is given matches the name, return with an
@@ -1982,12 +1982,12 @@ bool ExplicitSwiftModuleLoader::canImportModule(
   if (path.hasSubmodule())
     return false;
   ImportPath::Element mID = path.front();
-  // Look up the module with the real name (physical name on disk);
+  // Look up the module with the binary name;
   // in case `-module-alias` is used, the name appearing in source files
-  // and the real module name are different. For example, '-module-alias Foo=Bar'
-  // maps Foo appearing in source files, e.g. 'import Foo', to the real module
+  // and the binary module name are different. For example, '-module-alias Foo=Bar'
+  // maps Foo appearing in source files, e.g. 'import Foo', to the binary module
   // name Bar (on-disk name), which should be searched for loading.
-  StringRef moduleName = Ctx.getRealModuleName(mID.Item).str();
+  StringRef moduleName = Ctx.getBinaryModuleName(mID.Item).str();
   auto it = Impl.ExplicitModuleMap.find(moduleName);
   // If no provided explicit module matches the name, then it cannot be imported.
   if (it == Impl.ExplicitModuleMap.end()) {

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -69,7 +69,7 @@ bool swift::emitImportedModules(ModuleDecl *mainModule,
       continue;
 
     ImportPath::Builder scratch;
-    auto modulePath = ID->getRealModulePath(scratch);
+    auto modulePath = ID->getBinaryModulePath(scratch);
     // only the top-level name is needed (i.e. A in A.B.C)
     Modules.insert(modulePath[0].Item.str());
   }

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -334,8 +334,8 @@ void CompletionLookup::addModuleName(
   // `import ...`, and `-module-alias Foo=Bar` was passed, we want to show
   // Foo as an option to import, instead of Bar (name of the binary), as
   // Foo is the name that should appear in source files.
-  auto aliasedName = Ctx.getRealModuleName(
-      moduleName, ASTContext::ModuleAliasLookupOption::aliasFromRealName);
+  auto aliasedName = Ctx.getBinaryModuleName(
+      moduleName, ASTContext::ModuleAliasLookupOption::syntaxNameFromBinaryName);
   if (aliasedName != moduleName && // check if module aliasing was applied
       !aliasedName.empty()) { // check an alias mapped to the binary name exists
     moduleName = aliasedName; // if so, use the aliased name

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -804,12 +804,12 @@ private:
     if (Optional<ASTSourceDescriptor> ModuleDesc = getClangModule(*M))
       return getOrCreateModule(*ModuleDesc, ModuleDesc->getModuleOrNull());
     StringRef Path = getFilenameFromDC(M);
-    // Use the module 'real' name, which can be different from the name if module
+    // Use the module 'binary' name, which can be different from the name if module
     // aliasing was used (swift modules only). For example, if a source file has
-    // 'import Foo', and '-module-alias Foo=Bar' was passed in, the real name of
+    // 'import Foo', and '-module-alias Foo=Bar' was passed in, the binary name of
     // the module on disk is Bar (.swiftmodule or .swiftinterface), and is used
     // for loading and mangling.
-    StringRef Name = M->getRealName().str();
+    StringRef Name = M->getBinaryName().str();
     return getOrCreateModule(M, TheCU, Name, Path);
   }
 

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -491,7 +491,7 @@ class IndexSwiftASTWalker : public SourceEntityWalker {
       storage.clear();
       {
         llvm::raw_svector_ostream OS(storage);
-        OS << Mod.getFullName(/*useRealNameIfAliased=*/true);
+        OS << Mod.getFullName(/*useBinaryNameIfAliased=*/true);
         result.name = stringStorage.copyString(OS.str());
       }
     }
@@ -1119,11 +1119,11 @@ bool IndexSwiftASTWalker::visitImports(
     if (!IsClangModuleOpt.hasValue())
       continue;
     bool IsClangModule = *IsClangModuleOpt;
-    // Use module real name in case module aliasing is used.
+    // Use module binary name in case module aliasing is used.
     // For example, if a file being indexed has `import Foo`
-    // and `-module-alias Foo=Bar` is passed, treat Foo as an
-    // alias and Bar as the real module name as its dependency.
-    StringRef ModuleName = Mod->getRealName().str();
+    // and `-module-alias Foo=Bar` is passed, treat Foo as the module
+    // syntax name and Bar as the binary module name as its dependency.
+    StringRef ModuleName = Mod->getBinaryName().str();
 
     // If this module is an underscored cross-import overlay, use the name
     // of the underlying module that declared it instead.

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -426,11 +426,11 @@ static void addModuleDependencies(ArrayRef<ImportedModule> imports,
       case FileUnitKind::ClangModule: {
         auto *LFU = cast<LoadedFile>(FU);
         if (auto F = fileMgr.getFile(LFU->getFilename())) {
-          // Use module real name for unit writer in case module aliasing
+          // Use module binary name for unit writer in case module aliasing
           // is used. For example, if a file being indexed has `import Foo`
-          // and `-module-alias Foo=Bar` is passed, treat Foo as an alias
-          // and Bar as the real module name as its dependency.
-          StringRef moduleName = mod->getRealName().str();
+          // and `-module-alias Foo=Bar` is passed, treat Foo as the module syntax name
+          // and Bar as the binary module name as its dependency.
+          StringRef moduleName = mod->getBinaryName().str();
           bool withoutUnitName = true;
           if (FU->getKind() == FileUnitKind::ClangModule) {
             auto clangModUnit = cast<ClangModuleUnit>(LFU);

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5332,12 +5332,12 @@ ParserResult<ImportDecl> Parser::parseDeclImport(ParseDeclOptions Flags,
 
   // Look up if the imported module is being aliased via -module-alias,
   // and check that the module alias appeared in source files instead of
-  // its corresponding real name
+  // its corresponding binary name
   auto parsedModuleID = importPath.get().front().Item;
-  if (Context.getRealModuleName(parsedModuleID, ASTContext::ModuleAliasLookupOption::realNameFromAlias).empty()) {
-    // If reached here, it means the parsed module name is a real module name
+  if (Context.getBinaryModuleName(parsedModuleID, ASTContext::ModuleAliasLookupOption::binaryNameFromSyntaxName).empty()) {
+    // If reached here, it means the parsed module name is a binary module name
     // which appeared in the source file; only a module alias should be allowed
-    auto aliasName = Context.getRealModuleName(parsedModuleID, ASTContext::ModuleAliasLookupOption::aliasFromRealName);
+    auto aliasName = Context.getBinaryModuleName(parsedModuleID, ASTContext::ModuleAliasLookupOption::syntaxNameFromBinaryName);
     diagnose(importPath.front().Loc, diag::expected_module_alias,
                      parsedModuleID, aliasName)
       .fixItReplace(importPath.front().Loc, aliasName.str());

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -371,7 +371,7 @@ getModuleImpl(ImportPath::Module modulePath, ModuleDecl *loadingModule,
   //
   // FIXME: We'd like to only use this in SIL mode, but unfortunately we use it
   // for clang overlays as well.
-  if (ctx.getRealModuleName(moduleID.Item) == loadingModule->getName() &&
+  if (ctx.getBinaryModuleName(moduleID.Item) == loadingModule->getName() &&
       modulePath.size() == 1) {
     if (auto importer = ctx.getClangModuleLoader())
       return importer->loadModule(moduleID.Loc, modulePath);

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -42,9 +42,9 @@ static FileOrError findModule(ASTContext &ctx, Identifier moduleID,
   // -module-alias is used (otherwise same).
   //
   // For example, if '-module-alias Foo=Bar' is passed in to the frontend,
-  // and a source file has 'import Foo', a module called Bar (real name)
+  // and a source file has 'import Foo', a module called Bar (binary name)
   // should be searched.
-  StringRef moduleNameRef = ctx.getRealModuleName(moduleID).str();
+  StringRef moduleNameRef = ctx.getBinaryModuleName(moduleID).str();
 
   for (const auto &Path : ctx.SearchPathOpts.getImportSearchPaths()) {
     inputFilename = Path;

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2362,7 +2362,7 @@ ModuleDecl *ModuleFile::getModule(ImportPath::Module name,
   // FIXME: duplicated from ImportResolver::getModule
   Identifier parentName = FileContext->getParentModule()->getName();
   if (name.size() == 1 &&
-      name.front().Item == getContext().getRealModuleName(parentName)) {
+      name.front().Item == getContext().getBinaryModuleName(parentName)) {
     if (!UnderlyingModule && allowLoading) {
       auto importer = getContext().getClangModuleLoader();
       assert(importer && "no way to import shadowed module");

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -76,7 +76,7 @@ bool PlaceholderSwiftModuleScanner::findModule(
     std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
     bool skipBuildingInterface, bool &isFramework, bool &isSystemModule) {
-  StringRef moduleName = Ctx.getRealModuleName(moduleID.Item).str();
+  StringRef moduleName = Ctx.getBinaryModuleName(moduleID.Item).str();
   auto it = PlaceholderDependencyModuleMap.find(moduleName);
   if (it == PlaceholderDependencyModuleMap.end()) {
     return false;
@@ -102,7 +102,7 @@ ErrorOr<ModuleDependencies> ModuleDependencyScanner::scanInterfaceFile(
   // FIXME: Query the module interface loader to determine an appropriate
   // name for the module, which includes an appropriate hash.
   auto newExt = file_types::getExtension(file_types::TY_SwiftModuleFile);
-  auto realModuleName = Ctx.getRealModuleName(moduleName);
+  auto realModuleName = Ctx.getBinaryModuleName(moduleName);
   llvm::SmallString<32> modulePath = realModuleName.str();
   llvm::sys::path::replace_extension(modulePath, newExt);
   Optional<ModuleDependencies> Result;

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -136,9 +136,9 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc,
   // actually loaded module. In case module aliasing is used when building the main
   // module, e.g. -module-name MyModule -module-alias Foo=Bar, the loaded module
   // that maps to 'Foo' is actually Bar.swiftmodule|.swiftinterface (applies to swift
-  // modules only), which is retrieved via M->getRealName(). If no module aliasing is
-  // used, M->getRealName() will return the same value as M->getName(), which is 'Foo'.
-  if (M->getRealName().str() != Core->Name) {
+  // modules only), which is retrieved via M->getBinaryName(). If no module aliasing is
+  // used, M->getBinaryName() will return the same value as M->getName(), which is 'Foo'.
+  if (M->getBinaryName().str() != Core->Name) {
     return error(Status::NameMismatch);
   }
 

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -528,7 +528,7 @@ public:
   /// may not be exactly the same as the name of the module containing DC;
   /// instead, it will match the containing file's "exported module name".
   ///
-  /// \param ignoreExport When true, register the real module name,
+  /// \param ignoreExport When true, register the binary module name,
   /// ignoring exported_as definitions.
   /// \returns The ID for the identifier for the module's name, or one of the
   /// special module codes defined above.

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -540,9 +540,9 @@ SerializedModuleLoaderBase::findModule(ImportPath::Element moduleID,
   // -module-alias is used (otherwise same).
   //
   // For example, if '-module-alias Foo=Bar' is passed in to the frontend,
-  // and a source file has 'import Foo', a module called Bar (real name)
+  // and a source file has 'import Foo', a module called Bar (binary name)
   // should be searched.
-  StringRef moduleNameRef = Ctx.getRealModuleName(moduleID.Item).str();
+  StringRef moduleNameRef = Ctx.getBinaryModuleName(moduleID.Item).str();
   SmallString<32> moduleName(moduleNameRef);
   SerializedModuleBaseName genericBaseName(moduleName);
 

--- a/test/Frontend/load-module-with-alias-mangling.swift
+++ b/test/Frontend/load-module-with-alias-mangling.swift
@@ -17,11 +17,11 @@
 /// Check Foo.swiftmodule is created
 // RUN: test -f %t/Foo.swiftmodule
 
-/// Check the mangled name for func meow contains the real module name Bar
+/// Check the mangled name for func meow contains the binary module name Bar
 // RUN: llvm-objdump -t %t/ResultFoo.o | %FileCheck %s -check-prefix=CHECK-A
 // CHECK-A: s3Foo4meow3Bar5KlassCSgyF
 
-/// Check demangling shows the real module name Bar
+/// Check demangling shows the binary module name Bar
 // RUN: llvm-objdump -t %t/ResultFoo.o | swift-demangle | %FileCheck %s -check-prefix=CHECK-B
 // CHECK-B: Foo.meow() -> Bar.Klass?
 

--- a/test/Frontend/module-alias-diags.swift
+++ b/test/Frontend/module-alias-diags.swift
@@ -1,6 +1,6 @@
 /// Test diagnostics with module aliasing.
 ///
-/// Module 'Lib' imports module 'XLogging', and 'XLogging' is aliased 'AppleLogging'.
+/// Module 'Lib' imports module 'XLogging', and 'XLogging' (syntax name) is aliased 'AppleLogging' (binary name).
 
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/split_file.py -o %t %s
@@ -22,31 +22,31 @@
 // RUN: %FileCheck %s -input-file %t/result-LibB.output -check-prefix CHECK-NO-MEMBER
 // CHECK-NO-MEMBER: error: module 'XLogging' has no member named 'setupErr'
 
-/// 3. Fail: importing the real module name that's being aliased should fail
+/// 3. Fail: importing the binary module name that's being aliased should fail
 /// Create module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
 // RUN: not %target-swift-frontend -module-name LibC %t/FileLibImportRealName.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibC.swiftmodule 2> %t/result-LibC.output
 // RUN: %FileCheck %s -input-file %t/result-LibC.output -check-prefix CHECK-NOT-IMPORT
 // CHECK-NOT-IMPORT: error: cannot refer to module as 'AppleLogging' because it has been aliased; use 'XLogging' instead
 
-/// 4-1. Fail: referencing the real module name that's aliased should fail
+/// 4-1. Fail: referencing the binary module name that's aliased should fail
 /// Create module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
 // RUN: not %target-swift-frontend -module-name LibD %t/FileLibRefRealName1.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibD.swiftmodule 2> %t/result-LibD.output
 // RUN: %FileCheck %s -input-file %t/result-LibD.output -check-prefix CHECK-NOT-REF1
 // CHECK-NOT-REF1: error: cannot find 'AppleLogging' in scope
 
-/// 4-2. Fail: referencing the real module name that's aliased should fail
+/// 4-2. Fail: referencing the binary module name that's aliased should fail
 /// Create module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
 // RUN: not %target-swift-frontend -module-name LibE %t/FileLibRefRealName2.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibE.swiftmodule 2> %t/result-LibE.output
 // RUN: %FileCheck %s -input-file %t/result-LibE.output -check-prefix CHECK-NOT-REF2
 // CHECK-NOT-REF2: error: cannot find type 'AppleLogging' in scope
 
-/// 4-3. Fail: referencing the real module name that's aliased should fail
+/// 4-3. Fail: referencing the binary module name that's aliased should fail
 /// Create module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
 // RUN: not %target-swift-frontend -module-name LibF %t/FileLibRefRealName3.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibF.swiftmodule 2> %t/result-LibF.output
 // RUN: %FileCheck %s -input-file %t/result-LibF.output -check-prefix CHECK-NOT-REF3
 // CHECK-NOT-REF3: error: cannot find type 'AppleLogging' in scope
 
-/// 4-4. Fail: referencing the real module name that's aliased should fail
+/// 4-4. Fail: referencing the binary module name that's aliased should fail
 /// Create module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging
 // RUN: not %target-swift-frontend -module-name LibG %t/FileLibRefRealName4.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibG.swiftmodule 2> %t/result-LibG.output
 // RUN: %FileCheck %s -input-file %t/result-LibG.output -check-prefix CHECK-NOT-REF4

--- a/test/Frontend/module-alias-emit-sil-reingest.swift
+++ b/test/Frontend/module-alias-emit-sil-reingest.swift
@@ -9,7 +9,7 @@
 /// Emit SIL with module aliasing
 // RUN: %target-swift-frontend -emit-sil %t/FileBar.swift  -module-alias Coffee=Tea -I %t -o %t/Bar-output1.sil
 
-/// Verify the module real name 'Tea' is contained in the generated SIL
+/// Verify the module binary name 'Tea' is contained in the generated SIL
 // RUN: %FileCheck %s -input-file %t/Bar-output1.sil
 
 /// Reingest the SIL file and verify it contains the same result

--- a/test/Frontend/module-alias-invalid-input.swift
+++ b/test/Frontend/module-alias-invalid-input.swift
@@ -8,10 +8,10 @@
 // RUN: %target-swift-frontend -emit-silgen -parse-as-library %s -module-name foo -module-alias Bar=Swift -verify
 
 // RUN: not %target-swift-frontend -emit-silgen -parse-as-library %s -module-name foo -module-alias bar=bar 2>&1 | %FileCheck -check-prefix=INVALID_MODULE_ALIAS2 %s
-// INVALID_MODULE_ALIAS2: error: duplicate module alias; the name "bar" is already used for a module alias or an underlying name
+// INVALID_MODULE_ALIAS2: error: duplicate module alias; the name "bar" is already used for a module syntax name or a module binary name
 
 // RUN: not %target-swift-frontend -emit-silgen -parse-as-library %s -module-name foo -module-alias bar=baz -module-alias baz=cat 2>&1 | %FileCheck -check-prefix=INVALID_MODULE_ALIAS3 %s
-// INVALID_MODULE_ALIAS3: error: duplicate module alias; the name "baz" is already used for a module alias or an underlying name
+// INVALID_MODULE_ALIAS3: error: duplicate module alias; the name "baz" is already used for a module syntax name or a module binary name
 
 // RUN: not %target-swift-frontend -emit-silgen -parse-as-library %s -module-name foo -module-alias bar 2>&1 | %FileCheck -check-prefix=INVALID_MODULE_ALIAS4 %s
 // INVALID_MODULE_ALIAS4: error: invalid module alias format "bar"; make sure to use the format '-module-alias alias_name=underlying_name'

--- a/test/Frontend/module-alias-scan-deps.swift
+++ b/test/Frontend/module-alias-scan-deps.swift
@@ -10,7 +10,7 @@
 // RUN: %target-swift-frontend -module-name AppleLogging -module-alias XLogging=AppleLogging %t/FileLogging.swift -emit-module -emit-module-path %t/AppleLogging.swiftmodule
 // RUN: test -f %t/AppleLogging.swiftmodule
 
-/// Scanned dependencies should contain real name AppleLogging
+/// Scanned dependencies should contain binary name AppleLogging
 // RUN: %target-swift-frontend -scan-dependencies  %t/FileLib.swift -module-alias XLogging=AppleLogging -I %t > %t/scandump.output
 // RUN: %FileCheck %s -check-prefix=CHECK-REAL-NAME -input-file  %t/scandump.output
 // CHECK-REAL-NAME-NOT: "swiftPrebuiltExternal": "XLogging"
@@ -23,7 +23,7 @@
 // RUN: %target-swift-frontend -module-name AppleLoggingIF %t/FileLogging.swift -module-alias XLogging=AppleLoggingIF -I %t -emit-module -emit-module-interface-path %t/AppleLoggingIF.swiftinterface -swift-version 5 -enable-library-evolution -I %t
 // RUN: test -f %t/AppleLoggingIF.swiftinterface
 
-/// Scanned dependencies should contain real name AppleLoggingIF
+/// Scanned dependencies should contain binary name AppleLoggingIF
 // RUN: %target-swift-frontend -scan-dependencies  %t/FileLib.swift -module-alias XLogging=AppleLoggingIF -I %t > %t/scandumpIF.output
 // RUN: %FileCheck %s -check-prefix=CHECK-REAL-NAME-IF -input-file  %t/scandumpIF.output
 // CHECK-REAL-NAME-IF-NOT: "swift": "XLogging"

--- a/test/Frontend/module-alias-serialize-swiftinterface.swift
+++ b/test/Frontend/module-alias-serialize-swiftinterface.swift
@@ -1,4 +1,4 @@
-/// Test a serialized interface contains the module real names when -module-alias flag is passed.
+/// Test a serialized interface contains the module binary names when -module-alias flag is passed.
 ///
 /// 'Lib' imports module 'XLogging', and 'XLogging' is aliased 'AppleLogging'.
 

--- a/test/Frontend/module-alias-serialize-swiftmodule.swift
+++ b/test/Frontend/module-alias-serialize-swiftmodule.swift
@@ -1,4 +1,4 @@
-/// Test a serialized module contains the module real names when -module-alias flag is passed.
+/// Test a serialized module contains the module binary names when -module-alias flag is passed.
 ///
 /// Module 'ClientN' imports 'Lib', and 'Lib' imports module 'XLogging'.
 /// 'XLogging' needs to be aliased due to a collision, so it's aliased 'AppleLogging'.

--- a/test/IDE/module-aliasing-code-complete.swift
+++ b/test/IDE/module-aliasing-code-complete.swift
@@ -1,8 +1,8 @@
 /// Test code completion with module aliasing
-/// When -module-alias <alias_name>=<real_name> is applied, code completion should show
-/// the <alias_name> as that's the name which should appear in source files including import statements,
-/// decls, expressions, etc. while getting visible decls come from the module of <real_name>.
-/// Below, XLogging is the alias and mapped to the real name AppleLogging. Note that the real name
+/// When -module-alias <syntax_name>=<binary_name> is applied, code completion should show
+/// the <syntax_name> as that's the name which should appear in source files including import statements,
+/// decls, expressions, etc. while getting visible decls come from the module of <binary_name>.
+/// Below, XLogging is the syntax name and mapped to the binary name AppleLogging. Note that the binary name
 /// AppleLogging should not appear in the code completion results.
 ///
 // RUN: %empty-directory(%t)
@@ -48,7 +48,7 @@
 // CHECK4-DAG: Decl[FreeFunction]/OtherModule[XLogging]: setupLogger()[#Logger?#]; name=setupLogger()
 // CHECK4: End completions
 
-/// In the following, the module alias name should be shown as a module that can be imported instead of the real name
+/// In the following, the module alias name should be shown as a module that can be imported instead of the binary name
 ///
 // RUN: %target-swift-ide-test -code-completion -code-completion-token=MODULE_NAME -source-filename %t/FileLib5.swift -module-alias XLogging=AppleLogging -I %t > %t/result5.txt
 // RUN: %FileCheck %s -check-prefix CHECK5 < %t/result5.txt

--- a/test/IDE/module-aliasing-repl-code-complete.swift
+++ b/test/IDE/module-aliasing-repl-code-complete.swift
@@ -1,9 +1,9 @@
 /// Test REPL code completion with module aliasing
-/// When -module-alias <alias_name>=<real_name> is applied, code completion should show
-/// the <alias_name> as that's the name which should appear in source files including import statements,
-/// decls, expressions, etc. while getting visible decls come from the module of <real_name>, which
+/// When -module-alias <syntax_name>=<binary_name> is applied, code completion should show
+/// the <syntax_name> as that's the name which should appear in source files including import statements,
+/// decls, expressions, etc. while getting visible decls come from the module of <binary_name>, which
 /// is the name of the binary.
-/// Below, XLogging is the alias and mapped to the real name AppleLogging. Note that the binary name
+/// Below, XLogging is the syntax name and mapped to the binary name AppleLogging. Note that the binary name
 /// AppleLogging should not appear in the code completion results.
 ///
 // RUN: %empty-directory(%t)


### PR DESCRIPTION
The term 'real' and 'alias' cause confusion so rename them to clarify as follows:
s/real/binary
s/alias/syntaxName
