### PR TITLE
ConstraintSystem: Revert #61243

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -6540,7 +6540,7 @@ void ConstraintSystem::diagnoseFailureFor(SolutionApplicationTarget target) {
 bool ConstraintSystem::isDeclUnavailable(const Decl *D,
                                          ConstraintLocator *locator) const {
   // First check whether this declaration is universally unavailable.
-  if (AvailableAttr::isUnavailable(D))
+  if (D->getAttrs().isUnavailable(getASTContext()))
     return true;
 
   return TypeChecker::isDeclarationUnavailable(D, DC, [&] {

--- a/test/Constraints/availability.swift
+++ b/test/Constraints/availability.swift
@@ -43,25 +43,3 @@ func unavailableFunction(_ x: Int) -> Bool { true } // expected-note {{'unavaila
 func f_55700(_ arr: [Int]) {
   for x in arr where unavailableFunction(x) {} // expected-error {{'unavailableFunction' is unavailable}}
 }
-
-// rdar://92364955 - ambiguity with member declared in unavailable extension
- struct WithUnavailableExt {
- }
-
- @available(*, unavailable)
- extension WithUnavailableExt {
-   static var foo: WithUnavailableExt = WithUnavailableExt()
- }
-
- func test_no_ambiguity_with_unavailable_ext() {
-   struct A {
-     static var foo: A = A()
-   }
-
-   struct Test {
-     init(_: A) {}
-     init(_: WithUnavailableExt) {}
-   }
-
-   _ = Test(.foo) // Ok `A.foo` since `foo` from `WithUnavailableExt` is unavailable
- }

--- a/test/Constraints/availability.swift
+++ b/test/Constraints/availability.swift
@@ -43,3 +43,24 @@ func unavailableFunction(_ x: Int) -> Bool { true } // expected-note {{'unavaila
 func f_55700(_ arr: [Int]) {
   for x in arr where unavailableFunction(x) {} // expected-error {{'unavailableFunction' is unavailable}}
 }
+
+// rdar://101814209
+public struct Box<T> {
+  @usableFromInline
+  let value: T
+}
+
+@available(macOS, unavailable)
+extension Box where T == Int {
+  @usableFromInline
+  init(value: T) {
+    self.value = value
+  }
+}
+
+@available(macOS, unavailable)
+@_alwaysEmitIntoClient public func aeicFunction() {
+  // Select the unavailable @usableFromInline init over the synthesized internal
+  // memberwise initializer.
+  _ = Box(value: 42)
+}


### PR DESCRIPTION
Revert https://github.com/apple/swift/pull/61243 and add a test case for the regression it caused.

In unavailable contexts must not exclude equivalently unavailable overloads from consideration.