### PR TITLE
[Macros] Type check user-defined macro plugins

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -44,7 +44,6 @@
 #include "llvm/ADT/TinyPtrVector.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/DataTypes.h"
-#include "llvm/Support/DynamicLibrary.h"
 #include <functional>
 #include <memory>
 #include <utility>
@@ -1456,10 +1455,9 @@ public:
   /// Finds the loaded compiler plugin given its name.
   CompilerPlugin *getLoadedPlugin(StringRef name);
 
-  /// Finds the address of the given symbol. If `libraryHint` is non-null,
+  /// Finds the address of the given symbol. If `libraryHandleHint` is non-null,
   /// search within the library.
-  void *getAddressOfSymbol(StringRef name,
-                           llvm::sys::DynamicLibrary *libraryHint = nullptr);
+  void *getAddressOfSymbol(const char *name, void *libraryHandleHint = nullptr);
 
 private:
   friend Decl;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6696,8 +6696,8 @@ ERROR(experimental_no_metadata_feature_can_only_be_used_when_enabled,
 ERROR(expected_macro_expansion_expr,PointsToFirstBadToken,
       "expected macro expansion to produce an expression", ())
 ERROR(macro_undefined,PointsToFirstBadToken,
-      "macro '%0' is undefined; use `-load-plugin-library` to specify dynamic "
-      "libraries that contain this macro", (StringRef))
+      "macro %0 is undefined; use `-load-plugin-library` to specify dynamic "
+      "libraries that contain this macro", (Identifier))
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -73,6 +73,10 @@
 #include <queue>
 #include <memory>
 
+#if !defined(_WIN32)
+#include <dlfcn.h>
+#endif
+
 #include "RequirementMachine/RewriteContext.h"
 
 using namespace swift;
@@ -6055,16 +6059,15 @@ CompilerPlugin *ASTContext::getLoadedPlugin(StringRef name) {
   return &lookup->second;
 }
 
-void *ASTContext::getAddressOfSymbol(StringRef name,
-                                     llvm::sys::DynamicLibrary *libraryHint) {
+void *ASTContext::getAddressOfSymbol(const char *name,
+                                     void *libraryHandleHint) {
   auto lookup = LoadedSymbols.try_emplace(name, nullptr);
   void *&address = lookup.first->getValue();
+#if !defined(_WIN32)
   if (lookup.second) {
-    if (libraryHint && libraryHint->isValid())
-      address = libraryHint->getAddressOfSymbol(name.data());
-    else
-      address = llvm::sys::DynamicLibrary::
-          SearchForAddressOfSymbol(name.data());
+    auto *handle = libraryHandleHint ? libraryHandleHint : RTLD_DEFAULT;
+    address = dlsym(handle, name);
   }
+#endif
   return address;
 }

--- a/lib/CompilerPluginSupport/CompilerPluginSupport.swift
+++ b/lib/CompilerPluginSupport/CompilerPluginSupport.swift
@@ -57,4 +57,16 @@ public protocol _CompilerPlugin {
     localSourceText: UnsafePointer<UInt8>,
     localSourceTextCount: Int
   ) -> (UnsafePointer<UInt8>?, count: Int)
+
+  /// Returns the generic signature of the plugin.
+  ///
+  /// - Returns: A newly allocated buffer containing the generic signature.
+  ///   The caller is responsible for managing the memory.
+  static func _genericSignature() -> (UnsafePointer<UInt8>?, count: Int)
+
+  /// Returns the type signature of the plugin.
+  ///
+  /// - Returns: A newly allocated buffer containing the type signature. The
+  ///   caller is responsible for managing the memory.
+  static func _typeSignature() -> (UnsafePointer<UInt8>, count: Int)
 }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3635,10 +3635,10 @@ namespace {
         auto macroIdent = expr->getMacroName().getBaseIdentifier();
         auto refType = CS.getTypeOfMacroReference(macroIdent.str(), expr);
         if (!refType) {
-          // FIXME: This is currently hard-coded to (Int, String) just for
-          // testing Stringify, before we can parse a type signature from the
-          // macro plugin.
-          return TupleType::get({ctx.getIntType(), ctx.getStringType()}, ctx);
+          ctx.Diags.diagnose(expr->getMacroNameLoc(), diag::macro_undefined,
+                             macroIdent)
+              .highlight(expr->getMacroNameLoc().getSourceRange());
+          return Type();
         }
         if (expr->getArgs()) {
           CS.associateArgumentList(CS.getConstraintLocator(expr), expr->getArgs());

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -42,22 +42,44 @@ extern "C" ptrdiff_t swift_ASTGen_evaluateMacro(
     const char **evaluatedSource, ptrdiff_t *evaluatedSourceLength);
 
 extern "C" void
-swift_ASTGen_getMacroTypeSignature(void *macro, const char **genericSignature,
-                                   ptrdiff_t *genericSignatureLength);
+swift_ASTGen_getMacroTypeSignature(void *macro,
+                                   const char **evaluationContextPtr,
+                                   ptrdiff_t *evaluationContextLengthPtr);
+
+static NullTerminatedStringRef
+getPluginMacroTypeSignature(CompilerPlugin *plugin, ASTContext &ctx) {
+  auto genSig = plugin->invokeGenericSignature();
+  auto typeSig = plugin->invokeTypeSignature();
+  std::string source;
+  llvm::raw_string_ostream out(source);
+  out << "struct __MacroEvaluationContext" << (genSig ? *genSig : "") << " {\n"
+      << "  typealias SignatureType = " << typeSig << "\n"
+      << "}";
+  auto len = source.length();
+  auto *buffer = (char *)malloc(len + 1);
+  memcpy(buffer, source.data(), len + 1);
+  return {buffer, len};
+}
 
 StructDecl *MacroContextRequest::evaluate(Evaluator &evaluator,
                                           std::string macroName,
                                           ModuleDecl *mod) const {
 #if SWIFT_SWIFT_PARSER
   auto &ctx = mod->getASTContext();
-  auto *macro = swift_ASTGen_lookupMacro(macroName.c_str());
-  if (!macro)
+  auto *builtinMacro = swift_ASTGen_lookupMacro(macroName.c_str());
+  NullTerminatedStringRef evaluatedSource;
+  if (builtinMacro) {
+    const char *evaluatedSourcePtr;
+    ptrdiff_t evaluatedSourceLength;
+    swift_ASTGen_getMacroTypeSignature(builtinMacro, &evaluatedSourcePtr,
+                                       &evaluatedSourceLength);
+    evaluatedSource = NullTerminatedStringRef(
+        evaluatedSourcePtr, (size_t)evaluatedSourceLength);
+  } else if (auto *plugin = ctx.getLoadedPlugin(macroName)) {
+    evaluatedSource = getPluginMacroTypeSignature(plugin, ctx);
+  } else {
     return nullptr;
-
-  const char *evaluatedSource;
-  ptrdiff_t evaluatedSourceLength;
-  swift_ASTGen_getMacroTypeSignature(macro, &evaluatedSource,
-                                     &evaluatedSourceLength);
+  }
 
   // Create a new source buffer with the contents of the macro's
   // signature.
@@ -68,7 +90,7 @@ StructDecl *MacroContextRequest::evaluate(Evaluator &evaluator,
     out << "Macro signature of #" << macroName;
   }
   auto macroBuffer = llvm::MemoryBuffer::getMemBuffer(
-      StringRef(evaluatedSource, evaluatedSourceLength), bufferName);
+      evaluatedSource, bufferName);
   unsigned macroBufferID =
       sourceMgr.addNewSourceBuffer(std::move(macroBuffer));
   auto macroSourceFile = new (ctx) SourceFile(
@@ -78,13 +100,23 @@ StructDecl *MacroContextRequest::evaluate(Evaluator &evaluator,
 
   auto *start = sourceMgr.getLocForBufferStart(macroBufferID)
                     .getOpaquePointerValue();
-  void *context = nullptr;
-  swift_ASTGen_getMacroEvaluationContext(
-      (const void *)start, (void *)(DeclContext *)macroSourceFile,
-      (void *)&ctx, macro, &context);
-
-  ctx.addCleanup([macro]() { swift_ASTGen_destroyMacro(macro); });
-  return dyn_cast<StructDecl>((Decl *)context);
+  if (builtinMacro) {
+    void *context = nullptr;
+    swift_ASTGen_getMacroEvaluationContext(
+        (const void *)start, (void *)(DeclContext *)macroSourceFile,
+        (void *)&ctx, builtinMacro, &context);
+    ctx.addCleanup([builtinMacro]() { swift_ASTGen_destroyMacro(builtinMacro); });
+    return dyn_cast<StructDecl>((Decl *)context);
+  } else {
+    Parser parser(macroBufferID, *macroSourceFile, &ctx.Diags, nullptr,
+                  nullptr);
+    parser.consumeTokenWithoutFeedingReceiver();
+    DeclAttributes attrs;
+    auto parsedResult = parser.parseDeclStruct(Parser::PD_Default, attrs);
+    if (parsedResult.isParseError() || parsedResult.isNull())
+      return nullptr; // TODO: Diagnose this properly.
+    return parsedResult.get();
+  }
 #else
   return nullptr;
 #endif // SWIFT_SWIFT_PARSER
@@ -130,12 +162,7 @@ Expr *swift::expandMacroExpr(
   else {
     auto mee = cast<MacroExpansionExpr>(expr);
     auto *plugin = ctx.getLoadedPlugin(macroName);
-    if (!plugin) {
-      ctx.Diags.diagnose(
-          mee->getLoc(), diag::macro_undefined, macroName)
-      .highlight(mee->getMacroNameLoc().getSourceRange());
-      return nullptr;
-    }
+    assert(plugin && "Should have been checked during earlier type checking");
     auto bufferID = sourceFile->getBufferID();
     auto sourceFileText = sourceMgr.getEntireTextForBuffer(*bufferID);
     auto evaluated = plugin->invokeRewrite(

--- a/test/Macros/Inputs/macro_definition.swift
+++ b/test/Macros/Inputs/macro_definition.swift
@@ -10,6 +10,24 @@ struct StringifyMacro: _CompilerPlugin {
     }
   }
 
+  static func _genericSignature() -> (UnsafePointer<UInt8>?, count: Int) {
+    var genSig = "<T>"
+    return genSig.withUTF8 { buffer in
+      let result = UnsafeMutablePointer<UInt8>.allocate(capacity: buffer.count)
+      result.initialize(from: buffer.baseAddress!, count: buffer.count)
+      return (UnsafePointer(result), count: buffer.count)
+    }
+  }
+
+  static func _typeSignature() -> (UnsafePointer<UInt8>, count: Int) {
+    var typeSig = "(T) -> (T, String)"
+    return typeSig.withUTF8 { buffer in
+      let result = UnsafeMutablePointer<UInt8>.allocate(capacity: buffer.count)
+      result.initialize(from: buffer.baseAddress!, count: buffer.count)
+      return (UnsafePointer(result), count: buffer.count)
+    }
+  }
+
   static func _kind() -> _CompilerPluginKind {
     .expressionMacro
   }

--- a/test/Macros/Inputs/macro_definition_missing_allmacros.swift
+++ b/test/Macros/Inputs/macro_definition_missing_allmacros.swift
@@ -11,6 +11,24 @@ struct DummyMacro: _CompilerPlugin {
     }
   }
 
+  static func _genericSignature() -> (UnsafePointer<UInt8>?, count: Int) {
+    var genSig = "<T>"
+    return genSig.withUTF8 { buffer in
+      let result = UnsafeMutablePointer<UInt8>.allocate(capacity: buffer.count)
+      result.initialize(from: buffer.baseAddress!, count: buffer.count)
+      return (UnsafePointer(result), count: buffer.count)
+    }
+  }
+
+  static func _typeSignature() -> (UnsafePointer<UInt8>, count: Int) {
+    var typeSig = "(T) -> (T, String)"
+    return typeSig.withUTF8 { buffer in
+      let result = UnsafeMutablePointer<UInt8>.allocate(capacity: buffer.count)
+      result.initialize(from: buffer.baseAddress!, count: buffer.count)
+      return (UnsafePointer(result), count: buffer.count)
+    }
+  }
+
   static func _kind() -> _CompilerPluginKind {
     .expressionMacro
   }

--- a/test/Macros/macro_plugin.swift
+++ b/test/Macros/macro_plugin.swift
@@ -13,3 +13,21 @@ let _ = #customStringify(1.byteSwapped + 2.advanced(by: 10))
 // CHECK:   (tuple_expr type='(Int, String)'
 // CHECK:     (binary_expr type='Int'
 // CHECK:     (string_literal_expr type='String'
+
+let _ = #customStringify(1.0.truncatingRemainder(dividingBy: 1.0) + 3.0)
+
+// CHECK: (macro_expansion_expr type='(Double, String)' {{.*}} name=customStringify
+// CHECK:   (argument_list
+// EXPANSION BEGINS
+// CHECK:   (tuple_expr type='(Double, String)'
+// CHECK:     (binary_expr type='Double'
+// CHECK:     (string_literal_expr type='String'
+
+let _ = #customStringify(["a", "b", "c"] + ["d", "e", "f"])
+
+// CHECK: (macro_expansion_expr type='([String], String)' {{.*}} name=customStringify
+// CHECK:   (argument_list
+// EXPANSION BEGINS
+// CHECK:   (tuple_expr type='([String], String)'
+// CHECK:     (binary_expr type='[String]'
+// CHECK:     (string_literal_expr type='String'

--- a/test/Macros/macro_plugin_exec.swift
+++ b/test/Macros/macro_plugin_exec.swift
@@ -7,5 +7,8 @@
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx
 
-let (result, code) = #customStringify(3 + 2 - 1)
-print(result, code)
+print(#customStringify(3 + 2 - 1))
+
+print(#customStringify(1.0.truncatingRemainder(dividingBy: 1.0) + 3.0))
+
+print(#customStringify(["a", "b", "c"] + ["d", "e", "f"]))


### PR DESCRIPTION
Type check user-defined macros plugins with user-provided type signatures.

Also, load plugin libraries with `RTLD_LOCAL` instead of `RTLD_GLOBAL` to prevent symbol collision between plugins. `llvm::sys::DynamicLibrary` only supports `RTLD_GLOBAL` so we use the plain `dlopen` instead. This does not work on Windows and needs to be fixed.

Friend PR: apple/swift-syntax#1042