### PR TITLE
Fix inconsistencies with `isolated` parameters.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4832,6 +4832,9 @@ NOTE(protocol_isolated_to_global_actor_here,none,
 
 ERROR(isolated_parameter_not_actor,none,
       "'isolated' parameter has non-actor type %0", (Type))
+ERROR(isolated_parameter_second_isolated_param,none,
+      "function cannot have more than one 'isolated' parameter (%0 and %1)",
+      (DeclName, DeclName))
 
 WARNING(non_sendable_param_type,none,
         "non-sendable type %0 %select{passed in call to %4 %2 %3|"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4832,9 +4832,22 @@ NOTE(protocol_isolated_to_global_actor_here,none,
 
 ERROR(isolated_parameter_not_actor,none,
       "'isolated' parameter has non-actor type %0", (Type))
-ERROR(isolated_parameter_second_isolated_param,none,
-      "function cannot have more than one 'isolated' parameter (%0 and %1)",
-      (DeclName, DeclName))
+ERROR(isolated_parameter_duplicate,none,
+      "cannot have more than one 'isolated' parameter", ())
+ERROR(isolated_parameter_duplicate_type,none,
+      "function type cannot have more than one 'isolated' parameter", ())
+NOTE(isolated_parameter_previous_note,none,
+     "previous 'isolated' parameter %0", (DeclName))
+ERROR(isolated_parameter_combined_global_actor_attr,none,
+      "%0 with 'isolated' parameter cannot have a global actor",
+      (DescriptiveDeclKind))
+ERROR(isolated_parameter_closure_combined_global_actor_attr,none,
+      "closure with 'isolated' parameter %0 cannot have a global actor", (DeclName))
+ERROR(isolated_parameter_global_actor_type,none,
+      "function type cannot have global actor and 'isolated' parameter", ())
+ERROR(isolated_parameter_combined_nonisolated,none,
+      "%0 with 'isolated' parameter cannot be 'nonisolated'",
+      (DescriptiveDeclKind))
 
 WARNING(non_sendable_param_type,none,
         "non-sendable type %0 %select{passed in call to %4 %2 %3|"

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3086,30 +3086,6 @@ void swift::checkTopLevelActorIsolation(TopLevelCodeDecl *decl) {
     body->walk(checker);
 }
 
-static bool checkDuplicateIsolatedParameter(AbstractFunctionDecl *decl) {
-  // If we have already seen at least one 'isolated' parameter,
-  // and we see another one, this is invalid as only one 'isolated' param
-  // per function is allowed.
-  // See:
-  // https://github.com/apple/swift-evolution/blob/main/proposals/0313-actor-isolation-control.md#multiple-isolated-parameters
-  ParamDecl* previousIsolatedParam = nullptr;
-  for (size_t i = 0; i < decl->getParameters()->size(); ++i) {
-    auto param = decl->getParameters()->get(i);
-    if (param->isIsolated()) {
-      if (auto previous = previousIsolatedParam) {
-        decl->diagnose(diag::isolated_parameter_second_isolated_param,
-                       previous->getParameterName(),
-                       param->getParameterName());
-        return true;
-      }
-
-      previousIsolatedParam = const_cast<ParamDecl*>(param);
-    }
-  }
-
-  return false;
-}
-
 void swift::checkFunctionActorIsolation(AbstractFunctionDecl *decl) {
   // Disable this check for @LLDBDebuggerFunction functions.
   if (decl->getAttrs().hasAttribute<LLDBDebuggerFunctionAttr>())
@@ -3124,7 +3100,6 @@ void swift::checkFunctionActorIsolation(AbstractFunctionDecl *decl) {
       superInit->walk(checker);
   }
 
-  checkDuplicateIsolatedParameter(decl);
   if (decl->getAttrs().hasAttribute<DistributedActorAttr>()) {
     if (auto func = dyn_cast<FuncDecl>(decl)) {
       checkDistributedFunction(func);
@@ -3734,6 +3709,39 @@ static Optional<unsigned> getIsolatedParamIndex(ValueDecl *value) {
   return None;
 }
 
+/// Verifies rules about `isolated` parameters for the given decl. There is more
+/// checking about these in TypeChecker::checkParameterList.
+///
+/// This function is focused on rules that apply when it's a declaration with
+/// an isolated parameter, rather than some generic parameter list in a
+/// DeclContext.
+///
+/// This function assumes the value already contains an isolated parameter.
+static void checkDeclWithIsolatedParameter(ValueDecl *value) {
+  // assume there is an isolated parameter.
+  assert(getIsolatedParamIndex(value));
+
+  // Suggest removing global-actor attributes written on it, as its ignored.
+  if (auto attr = value->getGlobalActorAttr()) {
+    if (!attr->first->isImplicit()) {
+      value->diagnose(diag::isolated_parameter_combined_global_actor_attr,
+                      value->getDescriptiveKind())
+          .fixItRemove(attr->first->getRangeWithAt())
+          .warnUntilSwiftVersion(6);
+    }
+  }
+
+  // Suggest removing `nonisolated` as it is also ignored
+  if (auto attr = value->getAttrs().getAttribute<NonisolatedAttr>()) {
+    if (!attr->isImplicit()) {
+      value->diagnose(diag::isolated_parameter_combined_nonisolated,
+                      value->getDescriptiveKind())
+          .fixItRemove(attr->getRangeWithAt())
+          .warnUntilSwiftVersion(6);
+    }
+  }
+}
+
 ActorIsolation ActorIsolationRequest::evaluate(
     Evaluator &evaluator, ValueDecl *value) const {
   // If this declaration has actor-isolated "self", it's isolated to that
@@ -3747,6 +3755,8 @@ ActorIsolation ActorIsolationRequest::evaluate(
   // If this declaration has an isolated parameter, it's isolated to that
   // parameter.
   if (auto paramIdx = getIsolatedParamIndex(value)) {
+    checkDeclWithIsolatedParameter(value);
+
     // FIXME: This doesn't allow us to find an Actor or DistributedActor
     // bound on the parameter type effectively.
     auto param = getParameterList(value)->get(*paramIdx);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -3086,6 +3086,30 @@ void swift::checkTopLevelActorIsolation(TopLevelCodeDecl *decl) {
     body->walk(checker);
 }
 
+static bool checkDuplicateIsolatedParameter(AbstractFunctionDecl *decl) {
+  // If we have already seen at least one 'isolated' parameter,
+  // and we see another one, this is invalid as only one 'isolated' param
+  // per function is allowed.
+  // See:
+  // https://github.com/apple/swift-evolution/blob/main/proposals/0313-actor-isolation-control.md#multiple-isolated-parameters
+  ParamDecl* previousIsolatedParam = nullptr;
+  for (size_t i = 0; i < decl->getParameters()->size(); ++i) {
+    auto param = decl->getParameters()->get(i);
+    if (param->isIsolated()) {
+      if (auto previous = previousIsolatedParam) {
+        decl->diagnose(diag::isolated_parameter_second_isolated_param,
+                       previous->getParameterName(),
+                       param->getParameterName());
+        return true;
+      }
+
+      previousIsolatedParam = const_cast<ParamDecl*>(param);
+    }
+  }
+
+  return false;
+}
+
 void swift::checkFunctionActorIsolation(AbstractFunctionDecl *decl) {
   // Disable this check for @LLDBDebuggerFunction functions.
   if (decl->getAttrs().hasAttribute<LLDBDebuggerFunctionAttr>())
@@ -3099,6 +3123,8 @@ void swift::checkFunctionActorIsolation(AbstractFunctionDecl *decl) {
     if (auto superInit = ctor->getSuperInitCall())
       superInit->walk(checker);
   }
+
+  checkDuplicateIsolatedParameter(decl);
   if (decl->getAttrs().hasAttribute<DistributedActorAttr>()) {
     if (auto func = dyn_cast<FuncDecl>(decl)) {
       checkDistributedFunction(func);

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3480,6 +3480,8 @@ void TypeChecker::typeCheckDecl(Decl *D, bool LeaveClosureBodiesUnchecked) {
 
 void TypeChecker::checkParameterList(ParameterList *params,
                                      DeclContext *owner) {
+  Optional<ParamDecl*> firstIsolatedParam;
+  bool diagnosedDuplicateIsolatedParam = false;
   for (auto param: *params) {
     checkDeclAttributes(param);
 
@@ -3492,6 +3494,32 @@ void TypeChecker::checkParameterList(ParameterList *params,
           param->diagnose(diag::async_autoclosure_nonasync_function);
           if (auto func = dyn_cast<FuncDecl>(owner))
             addAsyncNotes(func);
+        }
+      }
+    }
+
+    // check for well-formed isolated parameters.
+    if (!diagnosedDuplicateIsolatedParam) {
+      if (param->isIsolated()) {
+        if (firstIsolatedParam) {
+          // cannot have more than one isolated parameter (SE-0313)
+          param->diagnose(diag::isolated_parameter_duplicate)
+              .highlight(param->getSourceRange())
+              .warnUntilSwiftVersion(6);
+          // I'd love to describe the context in which there is an isolated parameter,
+          // we had a DescriptiveDeclContextKind, but that only
+          // exists for Decls.
+
+          auto prevIso = firstIsolatedParam.value();
+          prevIso
+              ->diagnose(diag::isolated_parameter_previous_note,
+                         prevIso->getName())
+              .highlight(prevIso->getSourceRange());
+
+          // no need to complain about any further `isolated` params
+          diagnosedDuplicateIsolatedParam = true;
+        } else {
+          firstIsolatedParam = param; // save first one we've seen.
         }
       }
     }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2516,6 +2516,20 @@ TypeResolver::resolveOpenedExistentialArchetype(
   return archetypeType;
 }
 
+/// \returns true iff the # of isolated params is > \c lowerBound
+static bool hasMoreIsolatedParamsThan(FunctionTypeRepr* fnTy, unsigned lowerBound) {
+  unsigned count = 0;
+  for (auto arg : fnTy->getArgsTypeRepr()->getElements()) {
+    if (isa<IsolatedTypeRepr>(arg.Type))
+      count += 1;
+
+    if (count > lowerBound)
+      break;
+  }
+
+  return count > lowerBound;
+}
+
 NeverNullType
 TypeResolver::resolveAttributedType(TypeAttributes &attrs, TypeRepr *repr,
                                     TypeResolutionOptions options) {
@@ -2545,7 +2559,7 @@ TypeResolver::resolveAttributedType(TypeAttributes &attrs, TypeRepr *repr,
   // Resolve global actor.
   CustomAttr *globalActorAttr = nullptr;
   Type globalActor;
-  if (isa<FunctionTypeRepr>(repr)) {
+  if (auto fnTy = dyn_cast<FunctionTypeRepr>(repr)) {
     auto foundGlobalActor = checkGlobalActorAttributes(
         repr->getLoc(), getDeclContext(),
         std::vector<CustomAttr *>(
@@ -2555,6 +2569,15 @@ TypeResolver::resolveAttributedType(TypeAttributes &attrs, TypeRepr *repr,
       globalActor = resolveType(globalActorAttr->getTypeRepr(), options);
       if (globalActor->hasError())
         globalActor = Type();
+
+      // make sure there is no `isolated` parameter in the type
+      if (globalActorAttr->isValid()) {
+        if (globalActor && hasMoreIsolatedParamsThan(fnTy, 0)) {
+          diagnose(repr->getLoc(), diag::isolated_parameter_global_actor_type)
+              .warnUntilSwiftVersion(6);
+          globalActorAttr->setInvalid();
+        }
+      }
     }
   }
 
@@ -3297,6 +3320,17 @@ NeverNullType TypeResolver::resolveASTFunctionType(
 
   if (auto *genericParams = repr->getGenericParams())
     saveGenericParams.emplace(this->genericParams, genericParams);
+
+  // can't have more than 1 isolated parameter.
+  if (!repr->isWarnedAbout() && hasMoreIsolatedParamsThan(repr, 1)) {
+    diagnose(repr->getLoc(), diag::isolated_parameter_duplicate_type)
+        .warnUntilSwiftVersion(6);
+
+    if (getASTContext().LangOpts.isSwiftVersionAtLeast(6))
+      return ErrorType::get(getASTContext());
+    else
+      repr->setWarned();
+  }
 
   // Diagnose a couple of things that we can parse in SIL mode but we don't
   // allow in formal types.

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -3,7 +3,7 @@
 
 @available(SwiftStdlib 5.1, *)
 actor A {
-  func f() { }
+  func f() { } // expected-note 5{{calls to instance method 'f()' from outside of its actor context are implicitly asynchronous}}
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -11,11 +11,13 @@ extension Actor {
   func g() { }
 }
 
+@MainActor func mainActorFn() {}
+
 @available(SwiftStdlib 5.1, *)
-func testA<T: Actor>( // expected-error{{function cannot have more than one 'isolated' parameter ('a' and 'b')}}
-  a: isolated A,
-  b: isolated T,
-  c: isolated Int // expected-error{{'isolated' parameter has non-actor type 'Int'}}
+func testA<T: Actor>(
+  a: isolated A,  // expected-note{{previous 'isolated' parameter 'a'}}
+  b: isolated T,  // expected-warning{{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+  c: isolated Int // expected-error {{'isolated' parameter has non-actor type 'Int'}}
 ) {
   a.f()
   a.g()
@@ -32,7 +34,9 @@ actor Counter {
 }
 
 @available(SwiftStdlib 5.1, *)
-func testDoubleIsolatedParams(a: isolated Counter, b: isolated Other) async { // expected-error{{function cannot have more than one 'isolated' parameter ('a' and 'b')}}
+// expected-note@+2 {{previous 'isolated' parameter 'a'}}
+// expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+func testDoubleIsolatedParams(a: isolated Counter, b: isolated Other) async {
   a.inc()
   b.inc()
 }
@@ -59,7 +63,8 @@ func globalFuncIsolated(_: isolated A) { // expected-note{{calls to global funct
 }
 
 @available(SwiftStdlib 5.1, *)
-func testIsolatedParamCalls(a: isolated A, b: A) {
+// expected-warning@+1 {{global function with 'isolated' parameter cannot have a global actor; this is an error in Swift 6}}{{1-12=}}
+@MainActor func testIsolatedParamCalls(a: isolated A, b: A) {
   globalFunc(a)
   globalFunc(b)
 
@@ -78,8 +83,28 @@ func testIsolatedParamCallsAsync(a: isolated A, b: A) async {
   await globalFuncIsolated(b)
 }
 
+@available(SwiftStdlib 5.1, *)
+func testIsolatedParamCaptures(a: isolated A) async {
+  let _ = { @MainActor in
+    a.f() // expected-error {{actor-isolated instance method 'f()' can not be referenced from the main actor}}
+  }
+
+  let _: @MainActor () -> () = {
+    a.f() // expected-error {{actor-isolated instance method 'f()' can not be referenced from the main actor}}
+  }
+
+  let _ = {
+    a.f()
+  }
+
+  let _ = { @Sendable in
+    a.f() // expected-error {{actor-isolated instance method 'f()' can not be referenced from a Sendable closure}}
+  }
+
+}
+
 actor MyActor {
-  func hello() {}
+  func hello() {} // expected-note {{calls to instance method 'hello()' from outside of its actor context are implicitly asynchronous}}
 }
 
 typealias MyFn = (isolated: Int) -> Void // expected-error {{function types cannot have argument labels; use '_' before 'isolated'}}
@@ -102,6 +127,7 @@ protocol P {
   func j(isolated: Int) -> Int
   func k(isolated y: Int) -> Int
   func l(isolated _: Int) -> Int
+  func m(thing: isolated MyActor)
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -113,6 +139,12 @@ struct S: P {
   func j(isolated: Int) -> Int { return isolated }
   func k(isolated y: Int) -> Int { return j(isolated: y) }
   func l(isolated _: Int) -> Int { return k(isolated: 0) }
+  func m(thing: MyActor) { thing.hello() } // expected-error {{actor-isolated instance method 'hello()' can not be referenced from a non-isolated context}}
+}
+
+func checkConformer(_ s: S, _ p: any P, _ ma: MyActor) async {
+  s.m(thing: ma)
+  await p.m(thing: ma)
 }
 
 
@@ -130,7 +162,10 @@ func redecl(_: isolated TestActor) { } // expected-error{{invalid redeclaration 
 func tuplify<Ts>(_ fn: (Ts) -> Void) {} // expected-note {{in call to function 'tuplify'}}
 
 @available(SwiftStdlib 5.1, *)
-func testTuplingIsolated(_ a: isolated A, _ b: isolated A) { // expected-error{{function cannot have more than one 'isolated' parameter ('a' and 'b')}}
+func testTuplingIsolated(
+                         _ a: isolated A, // expected-note {{previous 'isolated' parameter 'a'}}
+                         _ b: isolated A  // expected-warning {{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+                        ) {
   tuplify(testTuplingIsolated)
   // expected-error@-1 {{generic parameter 'Ts' could not be inferred}}
   // expected-error@-2 {{cannot convert value of type '(isolated A, isolated A) -> ()' to expected argument type '(Ts) -> Void'}}
@@ -138,7 +173,7 @@ func testTuplingIsolated(_ a: isolated A, _ b: isolated A) { // expected-error{{
 
 // Inference of "isolated" on closure parameters.
 @available(SwiftStdlib 5.1, *)
-func testIsolatedClosureInference(a: A) {
+func testIsolatedClosureInference(one: A, two: A) async {
   let _: (isolated A) -> Void = {
     $0.f()
   }
@@ -153,6 +188,61 @@ func testIsolatedClosureInference(a: A) {
 
   let _: (isolated A) -> Void = { (a2: isolated A) in
     a2.f()
+  }
+
+  let f: (isolated A, isolated A) -> Void = // expected-warning {{function type cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+      // expected-note@+2 {{previous 'isolated' parameter 'a1'}}
+      // expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+      { (a1, a2) in
+        a1.f()
+        a2.f()
+      }
+
+  await f(one, two)
+
+  let g: (isolated A, isolated A) -> Void = // expected-warning {{function type cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+      // expected-note@+2 {{previous 'isolated' parameter '$0'}}
+      // expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+      {
+        $0.f()
+        $1.f()
+      }
+
+  await g(one, two)
+}
+
+struct CheckIsolatedFunctionTypes {
+  // expected-warning@+2 {{function type cannot have global actor and 'isolated' parameter; this is an error in Swift 6}}
+  // expected-warning@+1 {{function type cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+  func a(_ f: @MainActor @Sendable (isolated A, isolated A) -> ()) {}
+
+  // expected-note@+2 {{calls to parameter 'callback' from outside of its actor context are implicitly asynchronous}}
+  // expected-warning@+1 {{function type cannot have global actor and 'isolated' parameter; this is an error in Swift 6}}
+  @MainActor func update<R>(_ callback: @Sendable @escaping @MainActor (isolated A) -> R) -> R {
+    callback(A()) // expected-error {{call to actor-isolated parameter 'callback' in a synchronous main actor-isolated context}}
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+func checkIsolatedAndGlobalClosures(_ a: A) {
+  let _: @MainActor (isolated A) -> Void // expected-warning {{function type cannot have global actor and 'isolated' parameter; this is an error in Swift 6}}
+      = {
+    $0.f()
+    mainActorFn()
+  }
+
+  let _: @MainActor (isolated A) -> Void // expected-warning {{function type cannot have global actor and 'isolated' parameter; this is an error in Swift 6}}
+      = { @MainActor in // expected-warning {{closure with 'isolated' parameter '$0' cannot have a global actor; this is an error in Swift 6}}{{11-22=}}
+    $0.f()
+    mainActorFn()
+  }
+
+  let _ = { @MainActor (a: isolated A, // expected-warning {{closure with 'isolated' parameter 'a' cannot have a global actor; this is an error in Swift 6}}{{13-24=}}
+                                       // expected-note@-1 {{previous 'isolated' parameter 'a'}}
+                        b: isolated A, // expected-warning {{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+                        c: isolated A) async in
+    a.f()
+    mainActorFn()
   }
 }
 
@@ -174,7 +264,8 @@ extension TestActor {
   func isolatedMethod() { }
   // expected-note@-1{{calls to instance method 'isolatedMethod()' from outside of its actor context are implicitly asynchronous}}
 
-  func isolatedToParameter(_ other: isolated TestActor) {
+  // expected-warning@+1 {{instance method with 'isolated' parameter cannot be 'nonisolated'; this is an error in Swift 6}}{{3-15=}}
+  nonisolated func isolatedToParameter(_ other: isolated TestActor) {
     isolatedMethod()
     // expected-error@-1{{actor-isolated instance method 'isolatedMethod()' can not be referenced on a non-isolated actor instance}}
 
@@ -190,5 +281,37 @@ func isolatedClosures() {
     _ = {
       ta.isolatedMethod() // okay, isolated to ta
     }
+  }
+}
+
+// expected-warning@+2 {{global function with 'isolated' parameter cannot be 'nonisolated'; this is an error in Swift 6}}{{12-24=}}
+// expected-warning@+1 {{global function with 'isolated' parameter cannot have a global actor; this is an error in Swift 6}}{{1-12=}}
+@MainActor nonisolated func allOfEm(_ a: isolated A) {
+  a.f()
+}
+
+@MainActor class MAClass {
+
+  // expected-note@+2 {{previous 'isolated' parameter 'a'}}
+  // expected-warning@+1 {{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+  init(_ a: isolated A, _ b: isolated A) {
+    // FIXME: wrong isolation. should be isolated to `a` only!
+    a.f()
+    b.f()
+  }
+
+  // expected-note@+3 {{previous 'isolated' parameter 'a'}}
+  // expected-warning@+2 {{cannot have more than one 'isolated' parameter; this is an error in Swift 6}}
+  // expected-warning@+1 {{subscript with 'isolated' parameter cannot be 'nonisolated'; this is an error in Swift 6}}{{3-15=}}
+  nonisolated subscript(_ a: isolated A, _ b: isolated A) -> Int {
+    // FIXME: wrong isolation. should be isolated to `a`.
+    a.f() // expected-error {{actor-isolated instance method 'f()' can not be referenced on a non-isolated actor instance}}
+    b.f() // expected-error {{actor-isolated instance method 'f()' can not be referenced on a non-isolated actor instance}}
+    return 0
+  }
+
+  // expected-warning@+1 {{instance method with 'isolated' parameter cannot be 'nonisolated'; this is an error in Swift 6}}{{3-15=}}
+  nonisolated func millionDollars(_ a: isolated A) {
+    a.f()
   }
 }

--- a/test/Concurrency/isolated_parameters.swift
+++ b/test/Concurrency/isolated_parameters.swift
@@ -12,7 +12,7 @@ extension Actor {
 }
 
 @available(SwiftStdlib 5.1, *)
-func testA<T: Actor>(
+func testA<T: Actor>( // expected-error{{function cannot have more than one 'isolated' parameter ('a' and 'b')}}
   a: isolated A,
   b: isolated T,
   c: isolated Int // expected-error{{'isolated' parameter has non-actor type 'Int'}}
@@ -20,6 +20,29 @@ func testA<T: Actor>(
   a.f()
   a.g()
   b.g()
+}
+
+actor Other {
+  func inc() {}
+  func pass(_ f: @Sendable  (Self) async -> Void) {}
+}
+actor Counter {
+  func inc() {}
+  func pass(_ f: @Sendable  (Self) async -> Void) {}
+}
+
+@available(SwiftStdlib 5.1, *)
+func testDoubleIsolatedParams(a: isolated Counter, b: isolated Other) async { // expected-error{{function cannot have more than one 'isolated' parameter ('a' and 'b')}}
+  a.inc()
+  b.inc()
+}
+
+func taaaa() async {
+  await Counter().pass { isoC in
+    await Other().pass { isoO in
+      await testDoubleIsolatedParams(a: isoC, b: isoO)
+    }
+  }
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -107,7 +130,7 @@ func redecl(_: isolated TestActor) { } // expected-error{{invalid redeclaration 
 func tuplify<Ts>(_ fn: (Ts) -> Void) {} // expected-note {{in call to function 'tuplify'}}
 
 @available(SwiftStdlib 5.1, *)
-func testTuplingIsolated(_ a: isolated A, _ b: isolated A) {
+func testTuplingIsolated(_ a: isolated A, _ b: isolated A) { // expected-error{{function cannot have more than one 'isolated' parameter ('a' and 'b')}}
   tuplify(testTuplingIsolated)
   // expected-error@-1 {{generic parameter 'Ts' could not be inferred}}
   // expected-error@-2 {{cannot convert value of type '(isolated A, isolated A) -> ()' to expected argument type '(Ts) -> Void'}}


### PR DESCRIPTION
subsumes https://github.com/apple/swift/pull/60483

There are a whole bunch of ways the rules about `isolated` parameters are either not being enforced, or the wrong isolation is being used for such functions. This PR tries to sharpen the definition and rules so they make sense.

TODOs:
- [x] maybe move the check to `TypeChecker::checkParameterList`
- ~fix isolation for `subscript` (seems to default to nonisolated)~ deferred.
- ~make sure isolation for initializers is working / covered (doesn't check isolation at all?)~ deferred.
- [x] fix isolation for function values like this:
```swift
@MainActor
func update<R>(_ callback: @Sendable @escaping @MainActor (isolated Foo) -> R) -> R {
  callback(Foo()) // error: call to actor-isolated parameter 'callback' in a synchronous main actor-isolated context
}
```
- [x] enforce the rules for closures

resolves rdar://100039019
