### PR TITLE
[ASTDumper] Special handling for init kind in pre-typecheck dump

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9104,6 +9104,20 @@ Type ConstructorDecl::getInitializerInterfaceType() {
 }
 
 CtorInitializerKind ConstructorDecl::getInitKind() const {
+  const auto *ED =
+      dyn_cast_or_null<ExtensionDecl>(getDeclContext()->getAsDecl());
+  if (ED && !ED->hasBeenBound()) {
+    // When the declaration context is an extension and this is called when the
+    // extended nominal hasn't be bound yet, e.g. dumping pre-typechecked AST,
+    // there is not enough information about extended nominal to use for
+    // computing init kind on InitKindRequest as bindExtensions is done at
+    // typechecking, so in that case just look to parsed attribute in init
+    // declaration.
+    return getAttrs().hasAttribute<ConvenienceAttr>()
+               ? CtorInitializerKind::Convenience
+               : CtorInitializerKind::Designated;
+  }
+
   return evaluateOrDefault(getASTContext().evaluator,
     InitKindRequest{const_cast<ConstructorDecl *>(this)},
     CtorInitializerKind::Designated);

--- a/validation-test/compiler_crashers_2_fixed/issue-61086.swift
+++ b/validation-test/compiler_crashers_2_fixed/issue-61086.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift -dump-parse
+
+// https://github.com/apple/swift/issues/61806
+
+struct I61806 {}
+extension I61806 {
+  init() { }
+}
+
+class I61806_C { 
+  init() {}
+}
+extension I61806_C {
+  convenience init(a: Int) {}
+}
+
+protocol I61806_P {}
+extension I61806_P {
+ init() {}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
From my current understanding, when dumping `ConstructorDecl` in pre-typechecked AST there is not enough information about extended nominal(as bindExtensions is done at typechecking) for `getInitKind` which has rules based on that extended nominal to compute the kind, so in that `dump-parse` case, just look to parsed attribute in init declaration.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves https://github.com/apple/swift/issues/61806

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
