### PR TITLE
driver: on FreeBSD, use lld, not gold

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -357,7 +357,7 @@ Driver::buildToolChain(const llvm::opt::InputArgList &ArgList) {
       return std::make_unique<toolchains::Android>(*this, target);
     return std::make_unique<toolchains::GenericUnix>(*this, target);
   case llvm::Triple::FreeBSD:
-    return std::make_unique<toolchains::GenericUnix>(*this, target);
+    return std::make_unique<toolchains::FreeBSD>(*this, target);
   case llvm::Triple::OpenBSD:
     return std::make_unique<toolchains::OpenBSD>(*this, target);
   case llvm::Triple::Win32:

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -194,6 +194,16 @@ public:
   ~OpenBSD() = default;
 };
 
+class LLVM_LIBRARY_VISIBILITY FreeBSD : public GenericUnix {
+protected:
+  std::string getDefaultLinker() const override;
+
+public:
+  FreeBSD(const Driver &D, const llvm::Triple &Triple)
+      : GenericUnix(D, Triple) {}
+  ~FreeBSD() = default;
+};
+
 } // end namespace toolchains
 } // end namespace driver
 } // end namespace swift

--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -429,3 +429,7 @@ std::string toolchains::Cygwin::getDefaultLinker() const {
 std::string toolchains::OpenBSD::getDefaultLinker() const {
   return "lld";
 }
+
+std::string toolchains::FreeBSD::getDefaultLinker() const {
+  return "lld";
+}


### PR DESCRIPTION
This is equivalent to passing `-use-ld=lld` to the driver.