### PR TITLE
tests: temporarily disable SILOptimizer/readonly_arrays.swift

### DIFF
--- a/test/SILOptimizer/readonly_arrays.swift
+++ b/test/SILOptimizer/readonly_arrays.swift
@@ -22,6 +22,8 @@
 // Currently, constant static arrays only work on Darwin platforms.
 // REQUIRES: VENDOR=apple
 
+// REQUIRES: rdar101126543
+
 public struct Str {
   public static let staticVariable = [ 200, 201, 202 ]
 }


### PR DESCRIPTION
This is a followup of https://github.com/apple/swift/pull/61830

rdar://101126543