### PR TITLE
[android][test] Fix two C++ Interop tests that were split off for Android and enable two more new ones

### DIFF
--- a/docs/Android.md
+++ b/docs/Android.md
@@ -133,7 +133,7 @@ $ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libBlo
 In addition, you'll also need to copy the Android NDK's libc++:
 
 ```
-$ adb push /path/to/android-ndk-r25b/sources/cxx-stl/llvm-libc++/libs/arm64-v8a/libc++_shared.so /data/local/tmp
+$ adb push /path/to/android-ndk-r25b/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so /data/local/tmp
 ```
 
 Finally, you'll need to copy the `hello` executable you built in the

--- a/test/ASTGen/verify-parse.swift
+++ b/test/ASTGen/verify-parse.swift
@@ -1,5 +1,7 @@
 // RUN: %target-run-simple-swift(-enable-experimental-feature SwiftParser -enable-experimental-feature ParserASTGen)
 
+// REQUIRES: executable_test
+
 func test1(x: Int, fn: (Int) -> Int) -> Int {
   let xx = fn(42)
   return fn(x)

--- a/test/Interop/Cxx/class/constructors-copy-irgen-android.swift
+++ b/test/Interop/Cxx/class/constructors-copy-irgen-android.swift
@@ -1,23 +1,21 @@
 // Target-specific tests for C++ copy constructor code generation.
 
-// RUN: %swift -module-name MySwift -target armv7-none-linux-androideabi -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
+// RUN: %swift -module-name MySwift -target aarch64-unknown-linux-android -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
 
-// REQUIRES: OS=linux-android || OS=linux-androideabi
-
-// REQUIRES: CODEGENERATOR=X86
-// REQUIRES: CODEGENERATOR=ARM
+// REQUIRES: OS=linux-android
+// REQUIRES: CPU=aarch64
 
 import Constructors
 import TypeClassification
 
-// ITANIUM_ARM-LABEL: define protected swiftcc void @"$s7MySwift35copyWithUserProvidedCopyConstructorySo03HascdeF0V_ACtACF"
+// ITANIUM_ARM-LABEL: define protected swiftcc void @"$s7MySwift35copyWithUserProvidedCopyConstructorySo03Has{{cdeF0V_ACtACF|efgH0V_ADtADF}}"
 // ITANIUM_ARM-SAME: (%TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG0:%.*]], %TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG1:%.*]], %TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG2:%.*]])
 // ITANIUM_ARM: [[ARG0_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG0]] to %struct.HasUserProvidedCopyConstructor*
 // ITANIUM_ARM: [[ARG2_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG2]] to %struct.HasUserProvidedCopyConstructor*
-// ITANIUM_ARM: call %struct.HasUserProvidedCopyConstructor* @_ZN30HasUserProvidedCopyConstructorC2ERKS_(%struct.HasUserProvidedCopyConstructor* [[ARG0_AS_STRUCT]], %struct.HasUserProvidedCopyConstructor* [[ARG2_AS_STRUCT]])
+// ITANIUM_ARM: call void @_ZN30HasUserProvidedCopyConstructorC2ERKS_(%struct.HasUserProvidedCopyConstructor* [[ARG0_AS_STRUCT]], %struct.HasUserProvidedCopyConstructor* [[ARG2_AS_STRUCT]])
 // ITANIUM_ARM: [[ARG1_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG1]] to %struct.HasUserProvidedCopyConstructor*
 // ITANIUM_ARM: [[ARG2_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG2]] to %struct.HasUserProvidedCopyConstructor*
-// ITANIUM_ARM: call %struct.HasUserProvidedCopyConstructor* @_ZN30HasUserProvidedCopyConstructorC2ERKS_(%struct.HasUserProvidedCopyConstructor* [[ARG1_AS_STRUCT]], %struct.HasUserProvidedCopyConstructor* [[ARG2_AS_STRUCT]])
+// ITANIUM_ARM: call void @_ZN30HasUserProvidedCopyConstructorC2ERKS_(%struct.HasUserProvidedCopyConstructor* [[ARG1_AS_STRUCT]], %struct.HasUserProvidedCopyConstructor* [[ARG2_AS_STRUCT]])
 // ITANIUM_ARM: ret void
 
 public func copyWithUserProvidedCopyConstructor(_ x: HasUserProvidedCopyConstructor)

--- a/test/Interop/Cxx/class/constructors-copy-irgen-windows.swift
+++ b/test/Interop/Cxx/class/constructors-copy-irgen-windows.swift
@@ -3,10 +3,7 @@
 // RUN: %swift -module-name MySwift -target x86_64-unknown-windows-msvc -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64
 
 // REQUIRES: OS=windows-msvc
-
-// REQUIRES: CODEGENERATOR=X86
-// REQUIRES: CODEGENERATOR=ARM
-
+// REQUIRES: CPU=x86_64
 
 import Constructors
 import TypeClassification

--- a/test/Interop/Cxx/class/constructors-irgen-android.swift
+++ b/test/Interop/Cxx/class/constructors-irgen-android.swift
@@ -1,31 +1,29 @@
 // Target-specific tests for C++ constructor call code generation.
 
-// RUN: %swift -module-name MySwift -target armv7-unknown-linux-androideabi -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
+// RUN: %swift -module-name MySwift -target aarch64-unknown-linux-android -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
 
-// REQUIRES: OS=linux-android || OS=linux-androideabi
-
-// REQUIRES: CODEGENERATOR=X86
-// REQUIRES: CODEGENERATOR=ARM
+// REQUIRES: OS=linux-android
+// REQUIRES: CPU=aarch64
 
 import Constructors
 import TypeClassification
 
 public func createHasVirtualBase() -> HasVirtualBase {
-  // ITANIUM_ARM: define protected swiftcc void @"$s7MySwift20createHasVirtualBaseSo0bcD0VyF"(%TSo14HasVirtualBaseV* noalias nocapture sret({{.*}}) %0)
+  // ITANIUM_ARM: define protected swiftcc void @"$s7MySwift20createHasVirtualBaseSo0deF0VyF"(%TSo14HasVirtualBaseV* noalias nocapture sret({{.*}}) %0)
   // To verify that the thunk is inlined, make sure there's no intervening
   // `define`, i.e. the call to the C++ constructor happens in
   // createHasVirtualBase(), not some later function.
   // ITANIUM_ARM-NOT: define
   // Note `this` return type.
-  // ITANIUM_ARM: call %struct.HasVirtualBase* @_ZN14HasVirtualBaseC1E7ArgType(%struct.HasVirtualBase* %{{[0-9]+}}, [1 x i32] %{{[0-9]+}})
+  // ITANIUM_ARM: call void @_ZN14HasVirtualBaseC1E7ArgType(%struct.HasVirtualBase* %{{[0-9]+}}, i64 %{{[0-9]+}})
   return HasVirtualBase(ArgType())
 }
 
 public func createImplicitDefaultConstructor() -> ImplicitDefaultConstructor {
-  // ITANIUM_ARM: define protected swiftcc i32 @"$s7MySwift32createImplicitDefaultConstructorSo0bcD0VyF"()
+  // ITANIUM_ARM: define protected swiftcc i32 @"$s7MySwift32createImplicitDefaultConstructorSo0deF0VyF"()
   // ITANIUM_ARM-NOT: define
   // Note `this` return type.
-  // ITANIUM_ARM: call %struct.ImplicitDefaultConstructor* @_ZN26ImplicitDefaultConstructorC2Ev(%struct.ImplicitDefaultConstructor* %{{[0-9]+}})
+  // ITANIUM_ARM: call void @_ZN26ImplicitDefaultConstructorC2Ev(%struct.ImplicitDefaultConstructor* %{{[0-9]+}})
   return ImplicitDefaultConstructor()
 }
 
@@ -35,10 +33,10 @@ public func createStructWithSubobjectCopyConstructorAndValue() {
   // ITANIUM_ARM: [[OBJ:%.*]] = alloca %TSo42StructWithSubobjectCopyConstructorAndValueV
   // ITANIUM_ARM: [[TMP:%.*]] = alloca %TSo33StructWithCopyConstructorAndValueV
   // ITANIUM_ARM: [[MEMBER_AS_STRUCT:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[MEMBER]] to %struct.StructWithCopyConstructorAndValue*
-  // ITANIUM_ARM: call %struct.StructWithCopyConstructorAndValue* @_ZN33StructWithCopyConstructorAndValueC2Ev(%struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT]])
+  // ITANIUM_ARM: call void @_ZN33StructWithCopyConstructorAndValueC2Ev(%struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT]])
   // ITANIUM_ARM: [[TMP_STRUCT:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[TMP]] to %struct.StructWithCopyConstructorAndValue*
   // ITANIUM_ARM: [[MEMBER_AS_STRUCT_2:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[MEMBER]] to %struct.StructWithCopyConstructorAndValue*
-  // ITANIUM_ARM: call %struct.StructWithCopyConstructorAndValue* @_ZN33StructWithCopyConstructorAndValueC2ERKS_(%struct.StructWithCopyConstructorAndValue* [[TMP_STRUCT]], %struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT_2]])
+  // ITANIUM_ARM: call void @_ZN33StructWithCopyConstructorAndValueC2ERKS_(%struct.StructWithCopyConstructorAndValue* [[TMP_STRUCT]], %struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT_2]])
   // ITANIUM_ARM: ret void
   let member = StructWithCopyConstructorAndValue()
   let obj = StructWithSubobjectCopyConstructorAndValue(member: member)
@@ -47,11 +45,11 @@ public func createStructWithSubobjectCopyConstructorAndValue() {
 public func createTemplatedConstructor() {
   // ITANIUM_ARM-LABEL: define protected swiftcc void @"$s7MySwift26createTemplatedConstructoryyF"()
   // ITANIUM_ARM: [[OBJ:%.*]] = alloca %TSo20TemplatedConstructorV
-  // ITANIUM_ARM: [[IVAL:%.*]] = load [1 x i32], [1 x i32]*
+  // ITANIUM_ARM: [[IVAL:%.*]] = load i64, i64*
   // ITANIUM_ARM: [[OBJ_AS_STRUCT:%.*]] = bitcast %TSo20TemplatedConstructorV* [[OBJ]] to %struct.TemplatedConstructor*
-  // ITANIUM_ARM:  call %struct.TemplatedConstructor* @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* [[OBJ_AS_STRUCT]], [1 x i32] [[IVAL]])
+  // ITANIUM_ARM:  call void @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* [[OBJ_AS_STRUCT]], i64 [[IVAL]])
   // ITANIUM_ARM: ret void
   
-  // ITANIUM_ARM-LABEL: define {{.*}}%struct.TemplatedConstructor* @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* {{.*}}, [1 x i32] {{.*}})
+  // ITANIUM_ARM-LABEL: define {{.*}}void @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* {{.*}}, i64 {{.*}})
   let templated = TemplatedConstructor(ArgType())
 }

--- a/test/Interop/Cxx/class/constructors-irgen-windows.swift
+++ b/test/Interop/Cxx/class/constructors-irgen-windows.swift
@@ -3,9 +3,7 @@
 // RUN: %swift -module-name MySwift -target x86_64-unknown-windows-msvc -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64
 
 // REQUIRES: OS=windows-msvc
-
-// REQUIRES: CODEGENERATOR=X86
-// REQUIRES: CODEGENERATOR=ARM
+// REQUIRES: CPU=x86_64
 
 import Constructors
 import TypeClassification

--- a/test/Interop/Cxx/foreign-reference/base-class-layout-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/base-class-layout-irgen.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -module-name=test  | %FileCheck %s
-//
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import MemberLayout
 

--- a/test/Interop/Cxx/foreign-reference/unimportable-member-layout-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/unimportable-member-layout-irgen.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -module-name=test | %FileCheck %s
-//
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import MemberLayout
 

--- a/test/Parse/ConditionalCompilation/aarch64AndroidTarget.swift
+++ b/test/Parse/ConditionalCompilation/aarch64AndroidTarget.swift
@@ -1,5 +1,5 @@
-// RUN: %swift -typecheck %s -verify -target aarch64-none-linux-android -disable-objc-interop -parse-stdlib
-// RUN: %swift-ide-test -test-input-complete -source-filename=%s -target aarch64-none-linux-android
+// RUN: %swift -typecheck %s -verify -target aarch64-unknown-linux-android -disable-objc-interop -parse-stdlib
+// RUN: %swift-ide-test -test-input-complete -source-filename=%s -target aarch64-unknown-linux-android
 
 #if os(Linux)
 // This block should not parse.


### PR DESCRIPTION
Also, make some related changes, like updating a path in the Android doc, making sure the `unknown` vendor is always used, and using `CPU` instead of `CODEGENERATOR`.

I fixed the two constructor tests by restricting them to only be built on Android AArch64 instead, where I natively ran the tests, as the stdlib Cxx.swiftmodule has to be built for these two tests to run now. Since the Android CI only builds each Android ARM arch separately, these two tests will now only run on the AArch64 CI, otherwise you'll see errors about not being able to find the Cxx module, [as can be seen with the second one on the Android armv7 CI now](https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android/2084/consoleText) ~(though that CI currently appears to be down)~.

@egorzhdan, you split the constructor tests off in #60603 a couple weeks ago, please review.

@drodriguez, this should get the Android CI green again.

The two new tests were added in #61535 and assumed they wouldn't work on Android, but the CI reports that they do.