### PR TITLE
IRGen: Workaround for mangling of opened archetypes

### DIFF
--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -368,9 +368,6 @@ IRGenModule::getLoweredTypeRef(SILType loweredType,
   auto substTy =
     substOpaqueTypesWithUnderlyingTypes(loweredType, genericSig);
   auto type = substTy.getASTType();
-  if (substTy.hasArchetype())
-    type = type->mapTypeOutOfContext()->getCanonicalType();
-
   return getTypeRefImpl(*this, type, genericSig, role);
 }
 
@@ -1324,7 +1321,7 @@ public:
 
     // Now add typerefs of all of the captures.
     for (auto CaptureType : CaptureTypes) {
-      addLoweredTypeRef(CaptureType, sig);
+      addLoweredTypeRef(CaptureType.mapTypeOutOfContext(), sig);
     }
 
     // Add the pairs that make up the generic param -> metadata source map

--- a/test/Reflection/box_descriptor_with_opened_archetype.swift
+++ b/test/Reflection/box_descriptor_with_opened_archetype.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -emit-ir %s -disable-availability-checking
+
+public protocol P {}
+
+struct S<T>: P {
+  var x: Any
+  init() { fatalError() }
+}
+
+public func mangleArchetype(_ p: any P) -> any P {
+  p.open
+}
+
+extension P {
+  var open: some P {
+    S<Self>()
+  }
+}


### PR DESCRIPTION
We used to silently mangle opened archetypes as their interface type, which is wrong because it is not unique. Changing it to crash surfaced some bugs. Work around one of the bugs temporarily in IRGen.