### PR TITLE
[cxx-interop] Add explicit typealiases to `CxxRandomAccessCollection`

### DIFF
--- a/stdlib/public/Cxx/CxxRandomAccessCollection.swift
+++ b/stdlib/public/Cxx/CxxRandomAccessCollection.swift
@@ -31,6 +31,9 @@ extension UnsafeMutablePointer: UnsafeCxxRandomAccessIterator {}
 public protocol CxxRandomAccessCollection: CxxSequence, RandomAccessCollection {
   override associatedtype RawIterator: UnsafeCxxRandomAccessIterator
   override associatedtype Element = RawIterator.Pointee
+  override associatedtype Index = Int
+  override associatedtype Indices = Range<Int>
+  override associatedtype SubSequence = Slice<Self>
 
   /// Do not implement this function manually in Swift.
   func __beginUnsafe() -> RawIterator


### PR DESCRIPTION
This will help us to auto-generate conformances to `CxxRandomAccessCollection`, since synthesized conformances must have all of their witnesses explicitly provided.