### PR TITLE
[5.7] Add missing REQUIRES: executable_test to the test IRGen/98995607.swift.gyb

### DIFF
--- a/validation-test/IRGen/98995607.swift.gyb
+++ b/validation-test/IRGen/98995607.swift.gyb
@@ -1,5 +1,7 @@
 // RUN: %target-run-simple-swiftgyb
 
+// REQUIRES: executable_test
+
 %for N in range(0, 100):
 
 protocol P${N}<A, B> {


### PR DESCRIPTION
rdar://101876133