### PR TITLE
SILGen: Forward declare SIL functions referenced by `#_hasSymbol` query helpers

### DIFF
--- a/include/swift/IRGen/IRSymbolVisitor.h
+++ b/include/swift/IRGen/IRSymbolVisitor.h
@@ -58,7 +58,8 @@ public:
                     const IRSymbolVisitorContext &ctx);
 
   /// Override to prepare for enumeration of the symbols for a specific decl.
-  virtual void willVisitDecl(Decl *D) {}
+  /// Return \c true to proceed with visiting the decl or \c false to skip it.
+  virtual bool willVisitDecl(Decl *D) { return true; }
 
   /// Override to clean up after enumeration of the symbols for a specific decl.
   virtual void didVisitDecl(Decl *D) {}

--- a/include/swift/SIL/SILLinkage.h
+++ b/include/swift/SIL/SILLinkage.h
@@ -74,7 +74,7 @@ enum class SILLinkage : uint8_t {
   ///
   /// This linkage is used e.g. for thunks and for specialized functions.
   ///
-  /// Public functions must be definitions, i.e. must have a body, except the
+  /// Shared functions must be definitions, i.e. must have a body, except the
   /// body is emitted by clang.
   Shared,
 

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -315,6 +315,9 @@ private:
   /// This is the set of undef values we've created, for uniquing purposes.
   llvm::DenseMap<SILType, SILUndef *> UndefValues;
 
+  /// The list of decls that require query functions for #_hasSymbol conditions.
+  llvm::SetVector<ValueDecl *> hasSymbolDecls;
+
   llvm::DenseMap<std::pair<Decl *, VarDecl *>, unsigned> fieldIndices;
   llvm::DenseMap<EnumElementDecl *, unsigned> enumCaseIndices;
 
@@ -698,6 +701,12 @@ public:
   }
   bool isExternallyVisibleDecl(ValueDecl *decl) {
     return externallyVisible.count(decl) != 0;
+  }
+
+  void addHasSymbolDecl(ValueDecl *decl) { hasSymbolDecls.insert(decl); }
+
+  ArrayRef<ValueDecl *> getHasSymbolDecls() {
+    return hasSymbolDecls.getArrayRef();
   }
 
   using sil_global_iterator = GlobalListType::iterator;

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -279,7 +279,7 @@ private:
   llvm::DenseMap<const NominalTypeDecl *, SILMoveOnlyDeinit *>
       MoveOnlyDeinitMap;
 
-  /// The list of SILVTables in the module.
+  /// The list of move only deinits in the module.
   std::vector<SILMoveOnlyDeinit *> moveOnlyDeinits;
 
   /// Declarations which are externally visible.

--- a/include/swift/SIL/SILSymbolVisitor.h
+++ b/include/swift/SIL/SILSymbolVisitor.h
@@ -76,7 +76,8 @@ public:
                     const SILSymbolVisitorContext &ctx);
 
   /// Override to prepare for enumeration of the symbols for a specific decl.
-  virtual void willVisitDecl(Decl *D) {}
+  /// Return \c true to proceed with visiting the decl or \c false to skip it.
+  virtual bool willVisitDecl(Decl *D) { return true; }
 
   /// Override to clean up after enumeration of the symbols for a specific decl.
   virtual void didVisitDecl(Decl *D) {}

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -85,13 +85,6 @@ static llvm::StructType *createStructType(IRGenModule &IGM,
                                   name, packed);
 }
 
-/// A helper for creating pointer-to-struct types.
-static llvm::PointerType *createStructPointerType(IRGenModule &IGM,
-                                                  StringRef name,
-                                  std::initializer_list<llvm::Type*> types) {
-  return createStructType(IGM, name, types)->getPointerTo(DefaultAS);
-}
-
 static clang::CodeGenerator *createClangCodeGenerator(ASTContext &Context,
                                                  llvm::LLVMContext &LLVMContext,
                                                       const IRGenOptions &Opts,

--- a/lib/IRGen/IRSymbolVisitor.cpp
+++ b/lib/IRGen/IRSymbolVisitor.cpp
@@ -72,8 +72,8 @@ public:
       : Visitor{Visitor}, Ctx{Ctx},
         PublicSymbolsOnly{Ctx.getSILCtx().getOpts().PublicSymbolsOnly} {}
 
-  void willVisitDecl(Decl *D) override {
-    Visitor.willVisitDecl(D);
+  bool willVisitDecl(Decl *D) override {
+    return Visitor.willVisitDecl(D);
   }
 
   void didVisitDecl(Decl *D) override {

--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -400,8 +400,15 @@ void TBDGenVisitor::addSymbol(StringRef name, SymbolSource source,
   }
 }
 
-void TBDGenVisitor::willVisitDecl(Decl *D) {
+bool TBDGenVisitor::willVisitDecl(Decl *D) {
+  // A @_silgen_name("...") function without a body only exists to
+  // forward-declare a symbol from another library.
+  if (auto AFD = dyn_cast<AbstractFunctionDecl>(D))
+    if (!AFD->hasBody() && AFD->getAttrs().hasAttribute<SILGenNameAttr>())
+      return false;
+
   DeclStack.push_back(D);
+  return true;
 }
 
 void TBDGenVisitor::didVisitDecl(Decl *D) {

--- a/lib/IRGen/TBDGenVisitor.h
+++ b/lib/IRGen/TBDGenVisitor.h
@@ -139,7 +139,7 @@ public:
 
   // --- IRSymbolVisitor ---
 
-  void willVisitDecl(Decl *D) override;
+  bool willVisitDecl(Decl *D) override;
   void didVisitDecl(Decl *D) override;
 
   void addFunction(SILDeclRef declRef) override;

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -362,7 +362,8 @@ public:
       : Visitor{Visitor}, Ctx{Ctx} {}
 
   void visit(Decl *D) {
-    Visitor.willVisitDecl(D);
+    if (!Visitor.willVisitDecl(D))
+      return;
     ASTVisitor::visit(D);
     Visitor.didVisitDecl(D);
   }
@@ -408,12 +409,6 @@ public:
   }
 
   void visitAbstractFunctionDecl(AbstractFunctionDecl *AFD) {
-    // A @_silgen_name("...") function without a body only exists to
-    // forward-declare a symbol from another library.
-    if (!AFD->hasBody() && AFD->getAttrs().hasAttribute<SILGenNameAttr>()) {
-      return;
-    }
-
     // Add exported prespecialized symbols.
     for (auto *attr : AFD->getAttrs().getAttributes<SpecializeAttr>()) {
       if (!attr->isExported())

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1602,7 +1602,15 @@ void SILGenFunction::emitStmtCondition(StmtCondition Cond, JumpDest FalseDest,
 
     case StmtConditionElement::CK_HasSymbol: {
       auto info = elt.getHasSymbolInfo();
-      assert(!info->isInvalid());
+      if (info->isInvalid()) {
+        // This condition may have referenced a decl that isn't valid in some
+        // way but for developer convenience wasn't treated as an error. Just
+        // emit a 'true' condition value.
+        SILType i1 = SILType::getBuiltinIntegerType(1, getASTContext());
+        booleanTestValue = B.createIntegerLiteral(loc, i1, 1);
+        break;
+      }
+
       auto expr = info->getSymbolExpr();
       auto declRef = info->getReferencedDecl();
       assert(declRef);

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -30,6 +30,7 @@
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILDebuggerClient.h"
 #include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILSymbolVisitor.h"
 #include "swift/SIL/SILType.h"
 #include "swift/SIL/TypeLowering.h"
 #include "llvm/ADT/SmallString.h"
@@ -1617,8 +1618,33 @@ void SILGenFunction::emitStmtCondition(StmtCondition Cond, JumpDest FalseDest,
       booleanTestValue = emitUnwrapIntegerResult(expr, booleanTestValue);
       booleanTestLoc = expr;
 
-      // FIXME: Add decl to list of decls that need a has symbol query
-      //        function to be emitted during IRGen.
+      // Ensure that function declarations for each function associated with
+      // the decl are emitted so that they can be referenced during IRGen.
+      class SymbolVisitor : public SILSymbolVisitor {
+        SILGenModule &SGM;
+
+      public:
+        SymbolVisitor(SILGenModule &SGM) : SGM{SGM} {};
+
+        void addFunction(SILDeclRef declRef) override {
+          (void)SGM.getFunction(declRef, NotForDefinition);
+        }
+
+        virtual void addFunction(StringRef name, SILDeclRef declRef) override {
+          // The kinds of functions which go through this callback (e.g.
+          // differentiability witnesses) can't be forward declared with a
+          // SILDeclRef alone. For now, just ignore them.
+          //
+          // Ideally, this callback will be removed entirely in favor of
+          // SILDeclRef being able to represent all function variants.
+        }
+      };
+
+      SILSymbolVisitorOptions opts;
+      opts.VisitMembers = false;
+      auto visitorCtx =
+          SILSymbolVisitorContext(getModule().getSwiftModule(), opts);
+      SymbolVisitor(SGM).visitDecl(decl, visitorCtx);
       break;
     }
     }

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1606,9 +1606,12 @@ void SILGenFunction::emitStmtCondition(StmtCondition Cond, JumpDest FalseDest,
       auto declRef = info->getReferencedDecl();
       assert(declRef);
 
-      auto queryFunc = declRef.getDecl()->getHasSymbolQueryDecl();
+      auto decl = declRef.getDecl();
+      getModule().addHasSymbolDecl(decl);
+
       SILFunction *silFn = SGM.getFunction(
-          SILDeclRef(queryFunc, SILDeclRef::Kind::Func), NotForDefinition);
+          SILDeclRef(decl->getHasSymbolQueryDecl(), SILDeclRef::Kind::Func),
+          NotForDefinition);
       SILValue fnRef = B.createFunctionRefFor(loc, silFn);
       booleanTestValue = B.createApply(loc, fnRef, {}, {});
       booleanTestValue = emitUnwrapIntegerResult(expr, booleanTestValue);

--- a/test/AutoDiff/SILGen/has_symbol.swift
+++ b/test/AutoDiff/SILGen/has_symbol.swift
@@ -1,0 +1,46 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Library.swiftmodule -parse-as-library %t/Library.swift -enable-library-evolution
+// RUN: %target-swift-frontend -emit-silgen %t/Client.swift -I %t -module-name test | %FileCheck %t/Client.swift
+
+// REQUIRES: VENDOR=apple
+
+//--- Library.swift
+
+import _Differentiation
+
+@differentiable(reverse)
+public func foo(_ x: Float) -> Float { x }
+
+@derivative(of: foo)
+public func bar(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+  fatalError()
+}
+
+//--- Client.swift
+
+@_weakLinked import Library
+
+// CHECK: sil hidden [ossa] @$s4test0A15GlobalFunctionsyyF : $@convention(thin) () -> ()
+func testGlobalFunctions() {
+  // CHECK: [[QUERY:%[0-9]+]] = function_ref @$s7Library3fooyS2fFTwS : $@convention(thin) () -> Builtin.Int1
+  // CHECK: [[RES:%[0-9]+]] = apply [[QUERY]]() : $@convention(thin) () -> Builtin.Int1
+  // CHECK: cond_br [[RES]], bb{{[0-9]+}}, bb{{[0-9]+}}
+  if #_hasSymbol(foo(_:)) {}
+
+  // CHECK: [[QUERY:%[0-9]+]] = function_ref @$s7Library3barySf5value_S2fc8pullbacktSfFTwS : $@convention(thin) () -> Builtin.Int1
+  // CHECK: [[RES:%[0-9]+]] = apply [[QUERY]]() : $@convention(thin) () -> Builtin.Int1
+  // CHECK: cond_br [[RES]], bb{{[0-9]+}}, bb{{[0-9]+}}
+  if #_hasSymbol(bar(_:)) {}
+}
+
+// --- foo(_:) ---
+// CHECK: sil @$s7Library3fooyS2fF : $@convention(thin) (Float) -> Float
+// CHECK: sil @$s7Library3fooyS2fFTJfSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK: sil @$s7Library3fooyS2fFTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// FIXME: missing reverse-mode differentiability witness for foo(_:)
+
+// --- bar(_:) ---
+// CHECK: sil hidden_external @$s7Library3barySf5value_S2fc8pullbacktSfFTwS : $@convention(thin) () -> Builtin.Int1
+// CHECK: sil @$s7Library3barySf5value_S2fc8pullbacktSfF : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// FIXME: missing reverse-mode differentiability witness for foo(_:)

--- a/test/SILGen/has_symbol.swift
+++ b/test/SILGen/has_symbol.swift
@@ -26,9 +26,23 @@ func testGlobalFunctions() {
   if #_hasSymbol(forwardDeclaredFunc) {}
 }
 
+// --- function(with:) ---
 // CHECK: sil hidden_external @$s17has_symbol_helper8function4withySi_tFTwS : $@convention(thin) () -> Builtin.Int1
+// CHECK: sil @$s17has_symbol_helper8function4withySi_tF : $@convention(thin) (Int) -> ()
+
+// --- genericFunc<A>(_:) ---
 // CHECK: sil hidden_external @$s17has_symbol_helper11genericFuncyyxAA1PRzlFTwS : $@convention(thin) () -> Builtin.Int1
+// CHECK: sil @$s17has_symbol_helper11genericFuncyyxAA1PRzlF : $@convention(thin) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+
+// --- cdeclFunc() ---
 // CHECK: sil hidden_external @$s17has_symbol_helper9cdeclFuncyyFTwS : $@convention(thin) () -> Builtin.Int1
+// CHECK: sil @$s17has_symbol_helper9cdeclFuncyyF : $@convention(thin) () -> ()
+// CHECK: sil [serialized] @cdecl_func : $@convention(c) () -> ()
+
+// --- forwardDeclaredFunc() ---
+// CHECK: sil hidden_external @$s17has_symbol_helper19forwardDeclaredFuncyyFTwS : $@convention(thin) () -> Builtin.Int1
+// FIXME: missing forward declared function
+
 
 // CHECK: sil hidden [ossa] @$s4test0A4VarsyyF : $@convention(thin) () -> ()
 func testVars() {
@@ -38,7 +52,10 @@ func testVars() {
   if #_hasSymbol(global) {}
 }
 
+// --- global ---
 // CHECK: sil hidden_external @$s17has_symbol_helper6globalSivpTwS : $@convention(thin) () -> Builtin.Int1
+// CHECK: sil @$s17has_symbol_helper6globalSivg : $@convention(thin) () -> Int
+
 
 // CHECK: sil hidden [ossa] @$s4test0A6Structyy17has_symbol_helper1SVF : $@convention(thin) (@in_guaranteed S) -> ()
 func testStruct(_ s: S) {
@@ -68,12 +85,34 @@ func testStruct(_ s: S) {
   if #_hasSymbol(S.init(member:)) {}
 }
 
+// --- S.member ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1SV6memberSivpTwS : $@convention(thin) () -> Builtin.Int1
+// CHECK: sil @$s17has_symbol_helper1SV6memberSivg : $@convention(method) (@in_guaranteed S) -> Int
+// CHECK: sil @$s17has_symbol_helper1SV6memberSivs : $@convention(method) (Int, @inout S) -> ()
+// CHECK: sil @$s17has_symbol_helper1SV6memberSivM : $@yield_once @convention(method) (@inout S) -> @yields @inout Int
+
+// --- S.method(with:) ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1SV6method4withySi_tFTwS : $@convention(thin) () -> Builtin.Int1
+// CHECK: sil @$s17has_symbol_helper1SV6method4withySi_tF : $@convention(method) (Int, @in_guaranteed S) -> ()
+
+// --- S.genericFunc<A>(_:) ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1SV11genericFuncyyxAA1PRzlFTwS : $@convention(thin) () -> Builtin.Int1
+// CHECK: sil @$s17has_symbol_helper1SV11genericFuncyyxAA1PRzlF : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0, @in_guaranteed S) -> ()
+
+// --- S.staticFunc() ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1SV10staticFuncyyFZTwS : $@convention(thin) () -> Builtin.Int1
+// CHECK: sil @$s17has_symbol_helper1SV10staticFuncyyFZ : $@convention(method) (@thin S.Type) -> ()
+
+// --- S.staticMember ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1SV12staticMemberSivpZTwS : $@convention(thin) () -> Builtin.Int1
+// CHECK: sil @$s17has_symbol_helper1SV12staticMemberSivgZ : $@convention(method) (@thin S.Type) -> Int
+// CHECK: sil @$s17has_symbol_helper1SV12staticMemberSivsZ : $@convention(method) (Int, @thin S.Type) -> ()
+// CHECK: sil @$s17has_symbol_helper1SV12staticMemberSivMZ : $@yield_once @convention(method) (@thin S.Type) -> @yields @inout Int
+
+// --- S.init(member:) ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1SV6memberACSi_tcfcTwS : $@convention(thin) () -> Builtin.Int1
+// sil @$s17has_symbol_helper1SV6memberACSi_tcfC : $@convention(method) (Int, @thin S.Type) -> @out S
+
 
 // CHECK: sil hidden [ossa] @$s4test0A13GenericStructyy17has_symbol_helper0B1SVyAC1SVGF : $@convention(thin) (@in_guaranteed GenericS<S>) -> ()
 func testGenericStruct(_ s: GenericS<S>) {
@@ -87,8 +126,16 @@ func testGenericStruct(_ s: GenericS<S>) {
   if #_hasSymbol(s.method(with:)) {}
 }
 
+// --- GenericS.member ---
 // CHECK: sil hidden_external @$s17has_symbol_helper8GenericSV6memberxvpTwS : $@convention(thin) () -> Builtin.Int1
+// CHECK: sil @$s17has_symbol_helper8GenericSV6memberxvg : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed GenericS<τ_0_0>) -> @out τ_0_0
+// CHECK: sil @$s17has_symbol_helper8GenericSV6memberxvs : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in τ_0_0, @inout GenericS<τ_0_0>) -> ()
+// CHECK: sil @$s17has_symbol_helper8GenericSV6memberxvM : $@yield_once @convention(method) <τ_0_0 where τ_0_0 : P> (@inout GenericS<τ_0_0>) -> @yields @inout τ_0_0
+
+// --- GenericS.method(with:) ---
 // CHECK: sil hidden_external @$s17has_symbol_helper8GenericSV6method4withyx_tFTwS : $@convention(thin) () -> Builtin.Int1
+// CHECK: sil @$s17has_symbol_helper8GenericSV6method4withyx_tF : $@convention(method) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0, @in_guaranteed GenericS<τ_0_0>) -> ()
+
 
 // CHECK: sil hidden [ossa] @$s4test0A5Classyy17has_symbol_helper1CCF : $@convention(thin) (@guaranteed C) -> () {
 func testClass(_ c: C) {
@@ -114,11 +161,29 @@ func testClass(_ c: C) {
   if #_hasSymbol(C.init(member:)) {}
 }
 
+// --- C.member ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1CC6memberSivpTwS : $@convention(thin) () -> Builtin.Int1
+// Method dispatch thunks are generated in IRGen so no SIL decls are expected.
+
+// --- C.method(with:) ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1CC6method4withySi_tFTwS : $@convention(thin) () -> Builtin.Int1
+// Method dispatch thunks are generated in IRGen so no SIL decls are expected.
+
+// --- C.classFunc() ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1CC9classFuncyyFZTwS : $@convention(thin) () -> Builtin.Int1
+// Method dispatch thunks are generated in IRGen so no SIL decls are expected.
+
+// --- C.staticMember ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1CC12staticMemberSivpZTwS : $@convention(thin) () -> Builtin.Int1
+// CHECK: sil @$s17has_symbol_helper1CC12staticMemberSivgZ : $@convention(method) (@thick C.Type) -> Int
+// CHECK: sil @$s17has_symbol_helper1CC12staticMemberSivsZ : $@convention(method) (Int, @thick C.Type) -> ()
+// CHECK: sil @$s17has_symbol_helper1CC12staticMemberSivMZ : $@yield_once @convention(method) (@thick C.Type) -> @yields @inout Int
+
+// --- C.init(member:) ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1CC6memberACSi_tcfcTwS : $@convention(thin) () -> Builtin.Int1
+// CHECK: sil @$s17has_symbol_helper1CC6memberACSi_tcfc : $@convention(method) (Int, @owned C) -> @owned C
+// CHECK: sil [serialized] @$s17has_symbol_helper1CC6memberACSi_tcfC : $@convention(method) (Int, @thick C.Type) -> @owned C
+
 
 // CHECK: sil hidden [ossa] @$s4test0A4Enumyy17has_symbol_helper1EOF : $@convention(thin) (@in_guaranteed E) -> ()
 func testEnum(_ e: E) {
@@ -136,9 +201,16 @@ func testEnum(_ e: E) {
   if #_hasSymbol(e.method) {}
 }
 
+// --- E.basicCase(_:) ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1EO9basicCaseyA2CmFTwS : $@convention(thin) () -> Builtin.Int1
+
+// --- E.payloadCase(_:) ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1EO11payloadCaseyAcA1SVcACmFTwS : $@convention(thin) () -> Builtin.Int1
+
+// --- E.method() ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1EO6methodyyFTwS : $@convention(thin) () -> Builtin.Int1
+// CHECK: sil @$s17has_symbol_helper1EO6methodyyF : $@convention(method) (@in_guaranteed E) -> ()
+
 
 // CHECK: sil hidden [ossa] @$s4test0A8Protocolyyx17has_symbol_helper1PRzlF : $@convention(thin) <T where T : P> (@in_guaranteed T) -> ()
 func testProtocol<T: P>(_ p: T) {
@@ -147,6 +219,11 @@ func testProtocol<T: P>(_ p: T) {
   // CHECK: cond_br [[RES]], bb{{[0-9]+}}, bb{{[0-9]+}}
   if #_hasSymbol(p.requirement) {}
 }
+
+// --- P.requirement() ---
+// CHECK: sil hidden_external @$s17has_symbol_helper1PP11requirementyyFTwS : $@convention(thin) () -> Builtin.Int1
+// CHECK: sil @$s17has_symbol_helper1PP11requirementyyF : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+
 
 // CHECK: sil hidden [ossa] @$s4test0A9MetatypesyyF : $@convention(thin) () -> ()
 func testMetatypes() {
@@ -172,8 +249,17 @@ func testMetatypes() {
   if #_hasSymbol(E.self) {}
 }
 
+// --- P.self ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1PPTwS : $@convention(thin) () -> Builtin.Int1
+
+// --- S.self ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1SVTwS : $@convention(thin) () -> Builtin.Int1
+
+// --- GenericS.self ---
 // CHECK: sil hidden_external @$s17has_symbol_helper8GenericSVTwS : $@convention(thin) () -> Builtin.Int1
+
+// --- C.self ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1CCTwS : $@convention(thin) () -> Builtin.Int1
+
+// --- E.self ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1EOTwS : $@convention(thin) () -> Builtin.Int1

--- a/test/SILGen/has_symbol.swift
+++ b/test/SILGen/has_symbol.swift
@@ -263,3 +263,15 @@ func testMetatypes() {
 
 // --- E.self ---
 // CHECK: sil hidden_external @$s17has_symbol_helper1EOTwS : $@convention(thin) () -> Builtin.Int1
+
+// CHECK: sil hidden [ossa] @$s4test0A15NotWeaklyLinkedyyF : $@convention(thin) () -> ()
+func testNotWeaklyLinked() {
+  // `Swift.Int` is not weakly imported so this check is a no-op.
+
+  // CHECK: [[RES:%[0-9]+]] = integer_literal $Builtin.Int1, -1
+  // CHECK: cond_br [[RES]], bb{{[0-9]+}}, bb{{[0-9]+}}
+  if #_hasSymbol(Swift.Int.self) {}
+}
+
+// We should not generate a #_hasSymbol query helper for Swift.Int.
+// CHECK-NOT: sSiTwS

--- a/test/SILGen/has_symbol.swift
+++ b/test/SILGen/has_symbol.swift
@@ -41,7 +41,7 @@ func testGlobalFunctions() {
 
 // --- forwardDeclaredFunc() ---
 // CHECK: sil hidden_external @$s17has_symbol_helper19forwardDeclaredFuncyyFTwS : $@convention(thin) () -> Builtin.Int1
-// FIXME: missing forward declared function
+// CHECK: sil @forward_declared_func : $@convention(thin) () -> ()
 
 
 // CHECK: sil hidden [ossa] @$s4test0A4VarsyyF : $@convention(thin) () -> ()


### PR DESCRIPTION
For a `#_hasSymbol` condition check, such as the following:

```swift
if #_hasSymbol(foo) { ... }
```

the compiler will generate a binary that implements something roughly equivalent to this pseudo-code:

```swift
// Call to helper function (and branch on its result) emitted during SILGen
if hasSymbolHelperForFoo() { ... }

func hasSymbolHelperForFoo() -> Bool {
  // Return true if the address of each linkable symbol associated with
  // the declaration `foo()` is non-null. This body is emitted by IRGen.
}
```

This pull request establishes the preconditions necessary for IRGen to do its part, which is to emit the function bodies for each `#_hasSymbol` helper function required by the program. Each unique declaration that needs an associated helper function is recorded on `SILModule` during SILGen and any SIL function prototypes that will be referenced by the helper function implementations are also emitted.