### PR TITLE
IRGen: Fix usage of clang generated objective-c protocol metadata

### DIFF
--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -433,6 +433,67 @@ getProtocolRefsList(llvm::Constant *protocol) {
   return std::make_pair(size, protocolRefsList);
 }
 
+// Get runtime protocol list used during emission of objective-c protocol
+// metadata taking non-runtime protocols into account.
+static std::vector<clang::ObjCProtocolDecl *>
+getRuntimeProtocolList(clang::ObjCProtocolDecl::protocol_range protocols) {
+
+  llvm::DenseSet<clang::ObjCProtocolDecl *> nonRuntimeProtocols;
+  std::vector<clang::ObjCProtocolDecl*> runtimeProtocols;
+  for (auto p: protocols) {
+    auto *proto = p->getCanonicalDecl();
+    if (proto->isNonRuntimeProtocol())
+      nonRuntimeProtocols.insert(proto);
+    else
+      runtimeProtocols.push_back(proto);
+  }
+
+  if (nonRuntimeProtocols.empty())
+    return runtimeProtocols;
+
+  // Find the non-runtime implied protocols: protocols that occur in the closest
+  // ancestry of a non-runtime protocol.
+  llvm::SetVector<clang::ObjCProtocolDecl *> nonRuntimeImpliedProtos;
+  std::vector<clang::ObjCProtocolDecl *> worklist;
+  llvm::DenseSet<clang::ObjCProtocolDecl*> seen;
+  for (auto *nonRuntimeProto : nonRuntimeProtocols) {
+    worklist.push_back(nonRuntimeProto);
+    while(!worklist.empty()) {
+       auto *item = worklist.back();
+       worklist.pop_back();
+       if (!seen.insert(item).second)
+         continue;
+
+       if (item->isNonRuntimeProtocol()) {
+         for (auto *parent : item->protocols())
+           worklist.push_back(parent);
+       } else {
+         nonRuntimeImpliedProtos.insert(item->getCanonicalDecl());
+       }
+    }
+  }
+
+  // Subtract the implied protocols of the runtime protocols and non runtime
+  // protoocls implied protocols form the non runtime implied protocols.
+  llvm::DenseSet<const clang::ObjCProtocolDecl *> impliedProtocols;
+  for (auto *p : runtimeProtocols) {
+    impliedProtocols.insert(p);
+    p->getImpliedProtocols(impliedProtocols);
+  }
+
+  for (auto *p : nonRuntimeImpliedProtos) {
+    p->getImpliedProtocols(impliedProtocols);
+  }
+
+  for (auto *p : nonRuntimeImpliedProtos) {
+    if (!impliedProtocols.contains(p)) {
+      runtimeProtocols.push_back(p);
+    }
+  }
+
+  return runtimeProtocols;
+}
+
 static void updateProtocolRefs(IRGenModule &IGM,
                                const clang::ObjCProtocolDecl *objcProtocol,
                                llvm::Constant *protocol) {
@@ -448,7 +509,8 @@ static void updateProtocolRefs(IRGenModule &IGM,
   llvm::ConstantArray *protocolRefs;
   std::tie(protocolRefsSize, protocolRefs) = getProtocolRefsList(protocol);
   unsigned currentIdx = 0;
-  for (auto inheritedObjCProtocol : objcProtocol->protocols()) {
+  auto inheritedObjCProtocols = getRuntimeProtocolList(objcProtocol->protocols());
+  for (auto inheritedObjCProtocol : inheritedObjCProtocols) {
     assert(currentIdx < protocolRefsSize);
     auto oldVar = protocolRefs->getOperand(currentIdx);
     // Map the objc protocol to swift protocol.

--- a/test/IRGen/Inputs/usr/include/Gizmo.h
+++ b/test/IRGen/Inputs/usr/include/Gizmo.h
@@ -171,3 +171,32 @@ __attribute__((swift_name("OuterType.InnerType")))
 
 @interface FungingArray <Element: id<NSFunging>> : NSObject
 @end
+
+__attribute__((objc_non_runtime_protocol))
+@protocol NonRuntimeP
+@end
+
+@protocol RuntimeP<NonRuntimeP>
+@end
+
+@protocol P1
+@end
+@protocol P2
+@end
+@protocol P3
+@end
+
+__attribute__((objc_non_runtime_protocol))
+@protocol AnotherNonRuntimeP<P1, P2, P3>
+@end
+
+__attribute__((objc_non_runtime_protocol))
+@protocol AnotherNonRuntime2P<P1, P2>
+@end
+
+__attribute__((objc_non_runtime_protocol))
+@protocol OtherNonRuntimeP <AnotherNonRuntimeP, AnotherNonRuntime2P>
+@end
+
+@protocol Runtime2P<NonRuntimeP, OtherNonRuntimeP, P3>
+@end

--- a/test/IRGen/objc_protocols.swift
+++ b/test/IRGen/objc_protocols.swift
@@ -218,3 +218,7 @@ func gallop<T : Vanner>(_ t: Stirrup<T>) {
 func triggerDoubleInheritedFunging() -> AnyObject {
   return NSDoubleInheritedFunging.self as AnyObject
 }
+
+class TestNonRuntimeProto : RuntimeP { }
+
+class TestNonRuntime2Proto : Runtime2P {}


### PR DESCRIPTION
When updating the inherited protocol list we need to compute the list of runtime protocols (excludes non-runtime protocols).

rdar://101876133