### PR TITLE
[ASTGen] Disable implicit import of _StringProcessing in ASTGen.

### DIFF
--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -1,4 +1,23 @@
 if (SWIFT_SWIFT_PARSER)
+  # Ensure that we do not link the _StringProcessing module. But we can
+  # only pass this flag for new-enough compilers that support it.
+  file(WRITE "${CMAKE_BINARY_DIR}/tmp/empty-check-string-processing.swift" "")
+  execute_process(
+    COMMAND
+      "${CMAKE_Swift_COMPILER}"
+      -Xfrontend -disable-implicit-string-processing-module-import
+      -c - -o /dev/null
+    INPUT_FILE
+      "${CMAKE_BINARY_DIR}/tmp/empty-check-string-processing.swift"
+    OUTPUT_QUIET ERROR_QUIET
+    RESULT_VARIABLE
+      SWIFT_SUPPORTS_DISABLE_IMPLICIT_STRING_PROCESSING_MODULE_IMPORT)
+  if (NOT SWIFT_SUPPORTS_DISABLE_IMPLICIT_STRING_PROCESSING_MODULE_IMPORT)
+    add_compile_options(
+      $<$<COMPILE_LANGUAGE:Swift>:-Xfrontend>
+      $<$<COMPILE_LANGUAGE:Swift>:-disable-implicit-string-processing-module-import>)
+  endif()
+
   add_library(swiftASTGen STATIC
     Sources/ASTGen/ASTGen.swift
     Sources/ASTGen/Decls.swift


### PR DESCRIPTION
Reduce dependencies for rdar://101819413 .
