### PR TITLE
Build LLVM with RISCV support

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1472,7 +1472,6 @@ mixin-preset=
 [preset: LLDB_Nested]
 skip-build-benchmarks
 install-destdir=%(swift_install_destdir)s
-llvm-targets-to-build=X86;ARM;AArch64;PowerPC;SystemZ;Mips
 
 [preset: LLDB_Swift_DebugAssert]
 mixin-preset=

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -1211,7 +1211,7 @@ def create_argument_parser():
     in_group('Build settings specific for LLVM')
 
     option('--llvm-targets-to-build', store,
-           default='X86;ARM;AArch64;PowerPC;SystemZ;Mips',
+           default='X86;ARM;AArch64;PowerPC;SystemZ;Mips;RISCV',
            help='LLVM target generators to build')
 
     option('--llvm-ninja-targets', append,


### PR DESCRIPTION
<!-- What's in this pull request? -->
Builds LLVM and Clang with RISCV target enabled, which is not the default. Without this patch I get the following error when trying to compile:

```
error: unable to create target: 'No available targets are compatible with triple "riscv64-unknown-linux-gnu"'
```

```
coleman@hp-laptop:~/Developer/swift-source/swift$ clang --version
clang version 13.0.0 (https://github.com/apple/llvm-project.git 3dade082a9b1989207a7fa7f3975868485d16a49)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
coleman@hp-laptop:~/Developer/swift-source/swift$ clang -print-targets
  Registered Targets:
    aarch64    - AArch64 (little endian)
    aarch64_32 - AArch64 (little endian ILP32)
    aarch64_be - AArch64 (big endian)
    arm        - ARM
    arm64      - ARM64 (little endian)
    arm64_32   - ARM64 (little endian ILP32)
    armeb      - ARM (big endian)
    mips       - MIPS (32-bit big endian)
    mips64     - MIPS (64-bit big endian)
    mips64el   - MIPS (64-bit little endian)
    mipsel     - MIPS (32-bit little endian)
    ppc32      - PowerPC 32
    ppc32le    - PowerPC 32 LE
    ppc64      - PowerPC 64
    ppc64le    - PowerPC 64 LE
    systemz    - SystemZ
    thumb      - Thumb
    thumbeb    - Thumb (big endian)
    x86        - 32-bit X86: Pentium-Pro and above
    x86-64     - 64-bit X86: EM64T and AMD64
```

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves [SR-16005](https://github.com/apple/swift/issues/58266).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
