### PR TITLE
Allow ObjC superclass to disable init inheritance

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1231,7 +1231,8 @@ InheritsSuperclassInitializersRequest::evaluate(Evaluator &eval,
 
   // If the superclass has known-missing designated initializers, inheriting
   // is unsafe.
-  if (superclassDecl->getModuleContext() != decl->getParentModule() &&
+  if ((superclassDecl->hasClangNode() ||
+       superclassDecl->getModuleContext() != decl->getParentModule()) &&
       superclassDecl->hasMissingDesignatedInitializers())
     return false;
 

--- a/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
@@ -260,3 +260,10 @@ struct TrivialToCopy {
 @interface SuperclassWithDesignatedInitInCategory ()
 -(instancetype) initWithI:(NSInteger)i __attribute__((objc_designated_initializer));
 @end
+
+__attribute__((swift_attr("@_hasMissingDesignatedInitializers")))
+@interface NoConvenienceInitInheritanceBase : NSObject
+@end
+
+@interface NoConvenienceInitInheritance : NoConvenienceInitInheritanceBase
+@end

--- a/test/ClangImporter/objc_init.swift
+++ b/test/ClangImporter/objc_init.swift
@@ -210,3 +210,14 @@ extension SuperclassWithDesignatedInitInCategory {
 func testConvenienceInitInheritance() {
   _ = SubclassWithSwiftPrivateDesignatedInit(y: 5)
 }
+
+// ...unless the superclass has been marked with
+// @_hasMissingDesignatedInitializers to disable this behavior.
+extension NoConvenienceInitInheritanceBase {
+  convenience init(y: Int) { self.init() }
+}
+
+func testNoConvenienceInitInheritance() {
+  _ = NoConvenienceInitInheritanceBase(y: 42)
+  _ = NoConvenienceInitInheritance(y: 42) // expected-error {{argument passed to call that takes no arguments}}
+}


### PR DESCRIPTION
ObjC classes which have only factory and convenience initializers cannot allow their convenience inits to be inherited. To provide these classes with a reliable opt-out, tweak support for `@_hasMissingDesignatedInitializers` so that it affects ObjC classes even if they’re in the same module as one another.

Fixes rdar://48511013.