### PR TITLE
Only enable macro and result-builder tests in +Asserts builds.

### DIFF
--- a/test/Constraints/result_builder_ast_transform.swift
+++ b/test/Constraints/result_builder_ast_transform.swift
@@ -4,6 +4,7 @@
 // RUN: %target-run %t/main | %FileCheck %s
 
 // REQUIRES: executable_test
+// REQUIRES: asserts
 
 @propertyWrapper
 struct Wrapper<Value> {

--- a/test/Macros/macro_plugin.swift
+++ b/test/Macros/macro_plugin.swift
@@ -4,6 +4,7 @@
 
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx
+// REQUIRES: asserts
 
 let _ = #customStringify(1.byteSwapped + 2.advanced(by: 10))
 

--- a/test/Macros/macro_plugin_exec.swift
+++ b/test/Macros/macro_plugin_exec.swift
@@ -6,6 +6,7 @@
 
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx
+// REQUIRES: asserts
 
 print(#customStringify(3 + 2 - 1))
 


### PR DESCRIPTION
These tests depend on experimental features, which are not present in production compilers.

Fixes rdar://101790243