### PR TITLE
[CSApply] For-in: Extend `try` injector to handle erasure and opened …

### DIFF
--- a/test/Concurrency/async_sequence_syntax.swift
+++ b/test/Concurrency/async_sequence_syntax.swift
@@ -87,3 +87,13 @@ func forAwaitWithConcreteType(_ seq: ThrowingAsyncSequence) throws { // expected
     _ = elt
   }
 }
+
+@available(SwiftStdlib 5.1, *)
+func forTryAwaitReturningExistentialType() async throws {
+  struct S {
+    func seq() -> any AsyncSequence { fatalError() }
+  }
+
+  for try await _ in S().seq() { // Ok
+  }
+}


### PR DESCRIPTION
…existential

For synthesized `<async iterator>.next()` calls expression rewriter 
has to check whether witness is throwing and add `try` when necessary, 
in order to do that injector needs to look through opened existentials, 
erasures, and other implicitly injected AST nodes.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
