### PR TITLE
IRGen: Generate `#_hasSymbol` query functions

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -685,6 +685,8 @@ class LinkEntity {
             isa<ProtocolDecl>(decl->getDeclContext()));
   }
 
+  SILDeclRef::Kind getSILDeclRefKind() const;
+
 public:
   static LinkEntity forDispatchThunk(SILDeclRef declRef) {
     assert(isValidResilientMethodRef(declRef));
@@ -1537,6 +1539,15 @@ public:
   }
   bool isDynamicallyReplaceableFunctionKey() const {
     return getKind() == Kind::DynamicallyReplaceableFunctionKey;
+  }
+  bool isTypeMetadataAccessFunction() const {
+    return getKind() == Kind::TypeMetadataAccessFunction;
+  }
+  bool isDispatchThunk() const {
+    return getKind() == Kind::DispatchThunk ||
+           getKind() == Kind::DispatchThunkInitializer ||
+           getKind() == Kind::DispatchThunkAllocator ||
+           getKind() == Kind::DispatchThunkDerivative;
   }
 
   /// Determine whether this entity will be weak-imported.

--- a/lib/IRGen/CMakeLists.txt
+++ b/lib/IRGen/CMakeLists.txt
@@ -25,6 +25,7 @@ add_swift_host_library(swiftIRGen STATIC
   GenEnum.cpp
   GenExistential.cpp
   GenFunc.cpp
+  GenHasSymbol.cpp
   GenHeap.cpp
   GenInit.cpp
   GenIntegerLiteral.cpp

--- a/lib/IRGen/GenHasSymbol.cpp
+++ b/lib/IRGen/GenHasSymbol.cpp
@@ -1,0 +1,133 @@
+//===--- GenHasSymbol.cpp - IR Generation for #_hasSymbol queries ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements IR generation for `if #_hasSymbol` condition queries.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/ASTMangler.h"
+#include "swift/AST/PrettyStackTrace.h"
+#include "swift/IRGen/IRSymbolVisitor.h"
+#include "swift/IRGen/Linking.h"
+#include "swift/SIL/SILFunctionBuilder.h"
+#include "swift/SIL/SILModule.h"
+#include "swift/SIL/SILSymbolVisitor.h"
+
+#include "GenDecl.h"
+#include "IRGenFunction.h"
+#include "IRGenModule.h"
+
+using namespace swift;
+using namespace irgen;
+
+/// Wrapper for IRGenModule::getAddrOfLLVMVariable() that also handles a few
+/// additional types of entities that the main utility cannot.
+static llvm::Constant *getAddrOfLLVMVariable(IRGenModule &IGM,
+                                             LinkEntity entity) {
+  if (entity.isTypeMetadataAccessFunction())
+    return IGM.getAddrOfTypeMetadataAccessFunction(entity.getType(),
+                                                   NotForDefinition);
+  if (entity.isDispatchThunk())
+    return IGM.getAddrOfDispatchThunk(entity.getSILDeclRef(), NotForDefinition);
+
+  return IGM.getAddrOfLLVMVariable(entity, ConstantInit(), DebugTypeInfo());
+}
+
+class HasSymbolIRGenVisitor : public IRSymbolVisitor {
+  IRGenModule &IGM;
+  llvm::SmallVector<llvm::Constant *, 4> &Addrs;
+
+  void addFunction(StringRef name) {
+    SILFunction *silFn = IGM.getSILModule().lookUpFunction(name);
+    // Definitions for each SIL function should have been emitted by SILGen.
+    assert(silFn && "missing SIL function?");
+    if (silFn) {
+      Addrs.emplace_back(IGM.getAddrOfSILFunction(silFn, NotForDefinition));
+    }
+  }
+
+public:
+  HasSymbolIRGenVisitor(IRGenModule &IGM,
+                        llvm::SmallVector<llvm::Constant *, 4> &Addrs)
+      : IGM{IGM}, Addrs{Addrs} {};
+
+  void addFunction(SILDeclRef declRef) override {
+    addFunction(declRef.mangle());
+  }
+
+  void addFunction(StringRef name, SILDeclRef declRef) override {
+    addFunction(name);
+  }
+
+  void addGlobalVar(VarDecl *VD) override {
+    // FIXME: Handle global vars
+    llvm::report_fatal_error("unhandled global var");
+  }
+
+  void addLinkEntity(LinkEntity entity) override {
+    auto constant = getAddrOfLLVMVariable(IGM, entity);
+    auto global = cast<llvm::GlobalValue>(constant);
+    Addrs.emplace_back(global);
+  }
+
+  void addProtocolWitnessThunk(RootProtocolConformance *C,
+                               ValueDecl *requirementDecl) override {
+    // FIXME: Handle protocol witness thunks
+    llvm::report_fatal_error("unhandled protocol witness thunk");
+  }
+};
+
+void IRGenModule::emitHasSymbolFunctions() {
+  SILSymbolVisitorOptions opts;
+  opts.VisitMembers = false;
+  auto silCtx = SILSymbolVisitorContext(getSwiftModule(), opts);
+  auto linkInfo = UniversalLinkageInfo(*this);
+  auto symbolVisitorCtx = IRSymbolVisitorContext(linkInfo, silCtx);
+
+  for (ValueDecl *decl : getSILModule().getHasSymbolDecls()) {
+    PrettyStackTraceDecl trace("emitting #_hasSymbol query for", decl);
+    Mangle::ASTMangler mangler;
+
+    auto func = cast<llvm::Function>(getOrCreateHelperFunction(
+        mangler.mangleHasSymbolQuery(decl), Int1Ty, {},
+        [decl, this, symbolVisitorCtx](IRGenFunction &IGF) {
+          auto &Builder = IGF.Builder;
+          llvm::SmallVector<llvm::Constant *, 4> addrs;
+          HasSymbolIRGenVisitor(*this, addrs).visit(decl, symbolVisitorCtx);
+
+          llvm::Value *ret = nullptr;
+          for (llvm::Constant *addr : addrs) {
+            assert(cast<llvm::GlobalValue>(addr)->hasExternalWeakLinkage());
+
+            auto isNonNull = IGF.Builder.CreateIsNotNull(addr);
+            ret = (ret) ? IGF.Builder.CreateAnd(ret, isNonNull) : isNonNull;
+          }
+
+          if (ret) {
+            Builder.CreateRet(ret);
+          } else {
+            // There were no addresses produced by the visitor, return true.
+            Builder.CreateRet(llvm::ConstantInt::get(Int1Ty, 1));
+          }
+        },
+        /*IsNoInline*/ false));
+
+    func->setDoesNotThrow();
+    func->setCallingConv(SwiftCC);
+    func->addFnAttr(llvm::Attribute::ReadOnly);
+  }
+}
+
+void IRGenerator::emitHasSymbolFunctions() {
+  for (auto &IGM : *this)
+    IGM.second->emitHasSymbolFunctions();
+}

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -1348,6 +1348,9 @@ GeneratedModule IRGenRequest::evaluate(Evaluator &evaluator,
     // Okay, emit any definitions that we suddenly need.
     irgen.emitLazyDefinitions();
 
+    // Emit functions supporting `if #_hasSymbol(...)` conditions.
+    IGM.emitHasSymbolFunctions();
+
     // Register our info with the runtime if needed.
     if (Opts.UseJIT) {
       IGM.emitBuiltinReflectionMetadata();

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -432,6 +432,9 @@ public:
   /// Emit coverage mapping info.
   void emitCoverageMapping();
 
+  /// Emit helper functions for `if #_hasSymbol(...)` conditions.
+  void emitHasSymbolFunctions();
+
   /// Checks if metadata for this type can be emitted lazily. This is true for
   /// non-public types as well as imported types, except for classes and
   /// protocols which are always emitted eagerly.
@@ -1738,6 +1741,14 @@ public:
   ConstantReference
   getAddrOfLLVMVariableOrGOTEquivalent(LinkEntity entity);
 
+  llvm::Constant *getAddrOfLLVMVariable(LinkEntity entity,
+                                        ConstantInit definition,
+                                        DebugTypeInfo debugType,
+                                        llvm::Type *overrideDeclType = nullptr);
+  llvm::Constant *getAddrOfLLVMVariable(LinkEntity entity,
+                                        ForDefinition_t forDefinition,
+                                        DebugTypeInfo debugType);
+
   llvm::Constant *emitRelativeReference(ConstantReference target,
                                         llvm::GlobalValue *base,
                                         ArrayRef<unsigned> baseIndices);
@@ -1790,14 +1801,7 @@ private:
   getAddrOfSharedContextDescriptor(LinkEntity entity,
                                    ConstantInit definition,
                                    llvm::function_ref<void()> emit);
-  
-  llvm::Constant *getAddrOfLLVMVariable(LinkEntity entity,
-                                        ConstantInit definition,
-                                        DebugTypeInfo debugType,
-                                        llvm::Type *overrideDeclType = nullptr);
-  llvm::Constant *getAddrOfLLVMVariable(LinkEntity entity,
-                                        ForDefinition_t forDefinition,
-                                        DebugTypeInfo debugType);
+
   ConstantReference getAddrOfLLVMVariable(LinkEntity entity,
                                         ConstantInit definition,
                                         DebugTypeInfo debugType,
@@ -1826,6 +1830,7 @@ public:
   void emitRuntimeRegistration();
   void emitVTableStubs();
   void emitTypeVerifier();
+  void emitHasSymbolFunctions();
 
   /// Create llvm metadata which encodes the branch weights given by
   /// \p TrueCount and \p FalseCount.

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -540,13 +540,28 @@ std::string LinkEntity::mangleAsString() const {
   llvm_unreachable("bad entity kind!");
 }
 
-SILDeclRef LinkEntity::getSILDeclRef() const {
-  assert(getKind() == Kind::DistributedThunkAsyncFunctionPointer ||
-         getKind() == Kind::AsyncFunctionPointerAST);
+SILDeclRef::Kind LinkEntity::getSILDeclRefKind() const {
+  switch (getKind()) {
+  case Kind::DispatchThunk:
+  case Kind::MethodDescriptor:
+    return SILDeclRef::Kind::Func;
+  case Kind::DispatchThunkInitializer:
+  case Kind::MethodDescriptorInitializer:
+    return SILDeclRef::Kind::Initializer;
+  case Kind::MethodDescriptorAllocator:
+  case Kind::DispatchThunkAllocator:
+    return SILDeclRef::Kind::Allocator;
+  case Kind::DistributedThunkAsyncFunctionPointer:
+  case Kind::AsyncFunctionPointerAST:
+    return static_cast<SILDeclRef::Kind>(
+        reinterpret_cast<uintptr_t>(SecondaryPointer));
+  default:
+    llvm_unreachable("unhandled kind");
+  }
+}
 
-  return SILDeclRef(const_cast<ValueDecl *>(getDecl()),
-             static_cast<SILDeclRef::Kind>(
-                 reinterpret_cast<uintptr_t>(SecondaryPointer)));
+SILDeclRef LinkEntity::getSILDeclRef() const {
+  return SILDeclRef(const_cast<ValueDecl *>(getDecl()), getSILDeclRefKind());
 }
 
 SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {

--- a/test/IRGen/Inputs/has_symbol_helper.swift
+++ b/test/IRGen/Inputs/has_symbol_helper.swift
@@ -1,0 +1,35 @@
+public let global: Int = 0
+
+public func function(with argument: Int) {}
+public func throwingFunc() throws {}
+public func genericFunc<T: P>(_ t: T) {}
+public func funcWithOpaqueResult() -> some P { return S(member: 0) }
+@_cdecl("cdecl_func") public func cdeclFunc() {}
+@_silgen_name("forward_declared_func") public func forwardDeclaredFunc()
+
+public protocol P {
+  func requirement()
+}
+
+public struct S {
+  public var member: Int
+
+  public init(member: Int) {
+    self.member = member
+  }
+  public func method(with argument: Int) {}
+}
+
+extension S: P {
+  public func requirement() {}
+}
+
+public class C {
+  public init() {}
+  public func method(with argument: Int) {}
+}
+
+public enum E {
+  case basicCase
+  case payloadCase(_: S)
+}

--- a/test/IRGen/has_symbol.swift
+++ b/test/IRGen/has_symbol.swift
@@ -1,0 +1,78 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/has_symbol_helper.swiftmodule -parse-as-library %S/Inputs/has_symbol_helper.swift -enable-library-evolution -disable-availability-checking
+// RUN: %target-swift-frontend -emit-irgen %s -I %t -module-name test | %FileCheck %s
+
+// REQUIRES: VENDOR=apple
+
+@_weakLinked import has_symbol_helper
+
+func testGlobalFunctions() {
+  if #_hasSymbol(function(with:)) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper8function4withySi_tFTwS"()
+  // CHECK:   ret i1 icmp ne (void (i64)* @"$s17has_symbol_helper8function4withySi_tF", void (i64)* null)
+
+  if #_hasSymbol(throwingFunc) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper12throwingFuncyyKFTwS"()
+  // CHECK:   ret i1 icmp ne (void (%swift.refcounted*, %swift.error**)* @"$s17has_symbol_helper12throwingFuncyyKF", void (%swift.refcounted*, %swift.error**)* null)
+
+  if #_hasSymbol(genericFunc(_:) as (S) -> Void) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper11genericFuncyyxAA1PRzlFTwS"()
+  // CHECK:   ret i1 icmp ne (void (%swift.opaque*, %swift.type*, i8**)* @"$s17has_symbol_helper11genericFuncyyxAA1PRzlF", void (%swift.opaque*, %swift.type*, i8**)* null)
+
+  if #_hasSymbol(funcWithOpaqueResult) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper20funcWithOpaqueResultQryFTwS"()
+  // CHECK:   ret i1 and (i1 icmp ne (%swift.type_descriptor* @"$s17has_symbol_helper20funcWithOpaqueResultQryFQOMQ", %swift.type_descriptor* null), i1 icmp ne (void (%swift.opaque*)* @"$s17has_symbol_helper20funcWithOpaqueResultQryF", void (%swift.opaque*)* null))
+
+  if #_hasSymbol(cdeclFunc) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper9cdeclFuncyyFTwS"()
+  // CHECK:   ret i1 and (i1 icmp ne (void ()* @"$s17has_symbol_helper9cdeclFuncyyF", void ()* null), i1 icmp ne (void ()* @cdecl_func, void ()* null))
+
+  if #_hasSymbol(forwardDeclaredFunc) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper19forwardDeclaredFuncyyFTwS"()
+  // CHECK:   ret i1 icmp ne (void ()* @forward_declared_func, void ()* null)
+  
+  // FIXME: Test `dynamic` functions
+  // FIXME: Test `dynamic` functions with opaque return types
+}
+
+func testVars() {
+  if #_hasSymbol(global) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper6globalSivpTwS"()
+  // CHECK:   ret i1 icmp ne (i64 ()* @"$s17has_symbol_helper6globalSivg", i64 ()* null)
+}
+
+func testClass(_ c: C) {
+  if #_hasSymbol(C.init) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper1CCACycfcTwS"()
+  // CHECK:   ret i1 and (i1 icmp ne (%T17has_symbol_helper1CC* (%T17has_symbol_helper1CC*)* @"$s17has_symbol_helper1CCACycfc", %T17has_symbol_helper1CC* (%T17has_symbol_helper1CC*)* null), i1 icmp ne (%T17has_symbol_helper1CC* (%swift.type*)* @"$s17has_symbol_helper1CCACycfC", %T17has_symbol_helper1CC* (%swift.type*)* null))
+
+  if #_hasSymbol(c.method(with:)) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper1CC6method4withySi_tFTwS"()
+  // CHECK:   ret i1 and (i1 icmp ne (void (i64, %T17has_symbol_helper1CC*)* @"$s17has_symbol_helper1CC6method4withySi_tFTj", void (i64, %T17has_symbol_helper1CC*)* null), i1 icmp ne (%swift.method_descriptor* @"$s17has_symbol_helper1CC6method4withySi_tFTq", %swift.method_descriptor* null))
+}
+
+func testStruct(_ s: S) {
+  if #_hasSymbol(s.member) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper1SV6memberSivpTwS"()
+  // CHECK:   ret i1 and (i1 and (i1 and (i1 icmp ne (%swift.type_descriptor* @"$s17has_symbol_helper1SV6memberSivpMV", %swift.type_descriptor* null), i1 icmp ne (i64 (%swift.opaque*)* @"$s17has_symbol_helper1SV6memberSivg", i64 (%swift.opaque*)* null)), i1 icmp ne (void (i64, %swift.opaque*)* @"$s17has_symbol_helper1SV6memberSivs", void (i64, %swift.opaque*)* null)), i1 icmp ne ({ i8*, %TSi* } (i8*, %swift.opaque*)* @"$s17has_symbol_helper1SV6memberSivM", { i8*, %TSi* } (i8*, %swift.opaque*)* null))
+
+  if #_hasSymbol(s.method(with:)) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper1SV6method4withySi_tFTwS"()
+  // CHECK:   ret i1 icmp ne (void (i64, %swift.opaque*)* @"$s17has_symbol_helper1SV6method4withySi_tF", void (i64, %swift.opaque*)* null)
+}
+
+func testEnum(_ e: E) {
+  if #_hasSymbol(E.basicCase) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper1EO9basicCaseyA2CmFTwS"()
+  // CHECK:   ret i1 icmp ne (i32* @"$s17has_symbol_helper1EO9basicCaseyA2CmFWC", i32* null)
+
+  if #_hasSymbol(E.payloadCase) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper1EO11payloadCaseyAcA1SVcACmFTwS"()
+  // CHECK:   ret i1 icmp ne (i32* @"$s17has_symbol_helper1EO11payloadCaseyAcA1SVcACmFWC", i32* null)
+}
+
+func testMetatypes() {
+  if #_hasSymbol(S.self) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper1SVTwS"()
+  // CHECK:   ret i1 and (i1 and (i1 icmp ne (%swift.type_descriptor* @"$s17has_symbol_helper1SVMn", %swift.type_descriptor* null), i1 icmp ne (%swift.type* @"$s17has_symbol_helper1SVN", %swift.type* null)), i1 icmp ne (%swift.metadata_response (i64)* @"$s17has_symbol_helper1SVMa", %swift.metadata_response (i64)* null))
+}

--- a/test/Interpreter/has_symbol.swift
+++ b/test/Interpreter/has_symbol.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+
+// ---- (1) Build a simple library
+// RUN: echo "public func theAnswer() -> Int { 42 }" > %t/helper.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(helper)) \
+// RUN:   -emit-module-path %t/helper.swiftmodule \
+// RUN:   -parse-as-library -enable-library-evolution \
+// RUN:   %t/helper.swift
+
+// ---- (2) Build executable
+// RUN: %target-build-swift -emit-executable %s -g -o %t/test \
+// RUN:   -I %t/ -L %t/ %target-rpath(%t/) -lhelper
+// RUN: %target-codesign %t/test
+
+// ---- (3) Run the executable
+// RUN: %target-run %t/test %t/%target-library-name(helper) | %FileCheck %s --check-prefix=HAS-ANSWER
+
+// ---- (4) Re-build the library with empty input
+// RUN: echo "" > %t/empty.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(helper)) \
+// RUN:   -emit-module-path %t/helper.swiftmodule \
+// RUN:   -parse-as-library -enable-library-evolution \
+// RUN:   %t/empty.swift
+
+// ---- (5) Run the executable
+// RUN: %target-run %t/test %t/%target-library-name(helper) | %FileCheck %s --check-prefix=NO-ANSWER
+
+// REQUIRES: executable_test
+// REQUIRES: VENDOR=apple
+
+@_weakLinked import helper
+
+// HAS-ANSWER: 42
+// NO-ANSWER: No answer
+if #_hasSymbol(theAnswer) {
+  print(theAnswer())
+} else {
+  print("No answer")
+}


### PR DESCRIPTION
For each decl that needs a `#_hasSymbol()` query function, emit the corresponding helper function body during IRGen. Use `IRSymbolVisitor` to collect linkable symbols associated with the decl and return true from the helper function if the address of every associated symbol is non-null.

Resolves rdar://101884587
