### PR TITLE
macro_plugin tests requires asserts

### DIFF
--- a/test/Macros/builtin_macros.swift
+++ b/test/Macros/builtin_macros.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend -enable-experimental-feature BuiltinMacros -dump-ast %s -module-name MacrosTest 2>&1 | %FileCheck %s
 // REQUIRES: OS=macosx
-// REQUIRES: asserts
-
 
 // CHECK: macro_expansion_expr implicit type='String'
 // CHECK-NEXT: string_literal_expr{{.*}}Macro expansion of #function in{{.*}}value="MacrosTest"
@@ -13,7 +11,7 @@ func f(a: Int, b: Int) {
   // CHECK-NEXT: string_literal_expr{{.*}}Macro expansion of #function in{{.*}}value="f(a:b:)"
 
   // CHECK: macro_expansion_expr implicit type='Int'
-  // CHECK-NEXT: integer_literal_expr{{.*}}Macro expansion of #line in{{.*}}value=11
+  // CHECK-NEXT: integer_literal_expr{{.*}}Macro expansion of #line in{{.*}}value=9
 
   // CHECK: macro_expansion_expr implicit type='Int'
   // CHECK-NEXT: integer_literal_expr{{.*}}Macro expansion of #column in{{.*}}value=27

--- a/test/Macros/lit.local.cfg
+++ b/test/Macros/lit.local.cfg
@@ -1,0 +1,3 @@
+# '-enable-experimental-feature Macros' requires an asserts build.
+if 'asserts' not in config.available_features:
+    config.unsupported = True

--- a/test/Macros/macros.swift
+++ b/test/Macros/macros.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-frontend -enable-experimental-feature Macros -dump-ast %s -module-name MacrosTest 2>&1 | %FileCheck %s
 // REQUIRES: OS=macosx
-// REQUIRES: asserts
 
 func test(a: Int, b: Int) {
   let s = #stringify(a + b)


### PR DESCRIPTION
Experimental features require an asserts build.

Fixes rdar://101790243 (Swift CI: experimental feature 'Macros'
cannot be enabled in a production compiler!