### PR TITLE
implicit_weak_capture test requires Concurrency

### DIFF
--- a/test/expr/closure/implicit_weak_capture.swift
+++ b/test/expr/closure/implicit_weak_capture.swift
@@ -1,5 +1,7 @@
 // RUN: %target-run-simple-swift(-Xfrontend -disable-availability-checking)
 
+// REQUIRES: concurrency
+
 // REQUIRES: executable_test
 
 func runIn10ms(_ closure: @escaping @Sendable () -> Void) {


### PR DESCRIPTION
Fixes rdar://101942652 (macOS 10.14.4) (Swift in the OS) libswift_Concurrency; Symbol not found:
_swift_task_enterThreadLocalContext)
