### PR TITLE
Remove erroneous ELF note.

### DIFF
--- a/stdlib/public/runtime/ImageInspectionCommon.h
+++ b/stdlib/public/runtime/ImageInspectionCommon.h
@@ -42,10 +42,6 @@
 
 #else
 
-#if defined(__ELF__)
-#define SWIFT_REFLECTION_METADATA_ELF_NOTE_MAGIC_STRING "swift_reflection_metadata_magic_string"
-#endif // defined(__ELF__)
-
 #include "swift/shims/Visibility.h"
 #include <cstdint>
 #include <cstddef>

--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -83,14 +83,3 @@ static void swift_image_constructor() {
 
   swift_addNewDSOImage(&sections);
 }
-
-__asm__(".section \".note.swift_reflection_metadata\", \"aw\"");
-
-static __attribute__((__used__))
-__attribute__((__section__(".note.swift_reflection_metadata")))
-__attribute__((__aligned__(1)))
-struct {
-  const char MagicString[sizeof(SWIFT_REFLECTION_METADATA_ELF_NOTE_MAGIC_STRING)];
-  const swift::MetadataSections *Sections;
-} __attribute__((__packed__))
-Note = {SWIFT_REFLECTION_METADATA_ELF_NOTE_MAGIC_STRING, &sections};


### PR DESCRIPTION
On ELF platforms we currently output an ELF note but with totally invalid contents.  I tried experimenting to see whether it was possible to do it properly and tie the result into `ReflectionContext`, but it turns out to be a hard problem because of issues to do with cross-segment symbol references and relocations.

The upshot is that I think for now it's best just to remove it.

We might revisit this in future at some point; it would be good to be able to reliably find the Swift metadata just from the ELF `Phdr`s.

rdar://101749382
