### PR TITLE
[Sema] Check for availability of result type of implicit literal initializer

### DIFF
--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3256,13 +3256,15 @@ public:
     }
 
     if (auto *LE = dyn_cast<LiteralExpr>(E)) {
-      auto Range = LE->getSourceRange();
-      if (auto *RLE = dyn_cast<RegexLiteralExpr>(LE)) {
-        // Regex literals require both the Regex<Output> type to be available,
-        // as well as the initializer that is implicitly called.
-        diagnoseDeclRefAvailability(Context.getRegexDecl(), Range);
+      if (auto literalType = LE->getType()) {
+        // Check availability of the type produced by implicit literal
+        // initializer.
+        if (auto *nominalDecl = literalType->getAnyNominal()) {
+          diagnoseDeclAvailability(nominalDecl, LE->getSourceRange(),
+                                   /*call=*/nullptr, Where);
+        }
       }
-      diagnoseDeclRefAvailability(LE->getInitializer(), Range);
+      diagnoseDeclRefAvailability(LE->getInitializer(), LE->getSourceRange());
     }
 
     if (auto *CE = dyn_cast<CollectionExpr>(E)) {

--- a/test/Sema/availability_literals_inferred.swift
+++ b/test/Sema/availability_literals_inferred.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+// https://github.com/apple/swift/issues/61890
+
+@available(*, unavailable)
+struct S: ExpressibleByStringLiteral { // expected-note{{'S' has been explicitly marked unavailable here}}
+  init(stringLiteral value: String) {}
+}
+@available(*, unavailable)
+typealias StringLiteralType = S
+
+let i = "" // expected-error{{'S' is unavailable}}
+
+@available(*, unavailable)
+struct S1<T>: ExpressibleByIntegerLiteral { // expected-note{{'S1' has been explicitly marked unavailable here}}
+  init(integerLiteral value: Int) {}
+}
+@available(*, unavailable)
+typealias IntegerLiteralType = S1<Int>
+
+let a = 0 // expected-error{{'S1' is unavailable}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
For literal expressions check availability of the resulting type of the implicit literal as well in addition to the initializer checking.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves  https://github.com/apple/swift/issues/61890

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
