### PR TITLE
[DebugInfo] Respect -fmodule-file-home-is-cwd when generating clang skeleton CUs

### DIFF
--- a/test/DebugInfo/ClangModuleBreadcrumbs.swift
+++ b/test/DebugInfo/ClangModuleBreadcrumbs.swift
@@ -9,6 +9,13 @@
 // RUN:   -g -I %S/Inputs -Xcc -DFOO="foo" -Xcc -UBAR \
 // RUN:   -debug-prefix-map %t.mcp=PREFIX \
 // RUN:   -o - | %FileCheck %s --check-prefix=REMAP
+//
+// RUN: %empty-directory(%t.mcp)
+// RUN: cd %S && %target-swift-frontend -module-cache-path %t.mcp -emit-ir %s \
+// RUN:   -g -I %S/Inputs -Xcc -DFOO="foo" -Xcc -UBAR \
+// RUN:   -debug-prefix-map %S=. \
+// RUN:   -Xcc -Xclang -Xcc -fmodule-file-home-is-cwd \
+// RUN:   -o - | %FileCheck %s --check-prefix=CWD
 
 import ClangModule.SubModule
 import OtherClangModule.SubModule
@@ -42,3 +49,5 @@ let _ = someFunc(0)
 // REMAP: !DICompileUnit(language: DW_LANG_{{ObjC|C99}},{{.*}} producer: "{{.*}}clang
 // REMAP-SAME:           PREFIX{{/|\\\\}}{{.*}}{{/|\\\\}}ClangModule
 // REMAP-SAME:           dwoId:
+
+// CWD: !DIFile(filename: "ClangModule", directory: ".{{/|\\\\}}Inputs")


### PR DESCRIPTION
The idea here is when doing a build with explicit module builds, we would like the debug information for said modules to respect the option `-fmodule-file-home-is-cwd` for portability reasons.

The current test doesn't work so I'd like some feedback on how I could produce a working test. My current understanding of the reason the test doesn't work is because it is relying on implicit module build behavior. The `MODULE_DIRECTORY` for SwiftShims points to the directory `%S` but when performing verification it implicitly finds SwiftShims modulemap file in `$BUILD_DIR/lib/swift/shims`. If my understanding is correct, we would then need to produce a test which explicitly builds every module relied upon and then pass the appropriate options to the compiler to ensure that modules can be not only built explicitly but validated in the same manner.

