### PR TITLE
IRGen: Workaround for inadvertent mangling of opened archetypes in keypath descriptors

### DIFF
--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -887,6 +887,15 @@ emitKeyPathComponent(IRGenModule &IGM,
             componentCanSig, [&](GenericRequirement reqt) {
               auto substType =
                   reqt.TypeParameter.subst(subs)->getCanonicalType();
+
+              // FIXME: This seems wrong. We used to just mangle opened archetypes as
+              // their interface type. Let's make that explicit now.
+              substType = substType.transformRec([](Type t) -> Optional<Type> {
+                if (auto *openedExistential = t->getAs<OpenedArchetypeType>())
+                  return openedExistential->getInterfaceType();
+                return None;
+              })->getCanonicalType();
+
               if (!reqt.Protocol) {
                 // Type requirement.
                 externalSubArgs.push_back(emitMetadataTypeRefForKeyPath(

--- a/test/IRGen/Inputs/keypath_objc_protocol_extension_other.swift
+++ b/test/IRGen/Inputs/keypath_objc_protocol_extension_other.swift
@@ -1,0 +1,5 @@
+@objc public protocol P {}
+
+extension P {
+  public var value: Bool { true }
+}

--- a/test/IRGen/keypath_objc_protocol_extension.swift
+++ b/test/IRGen/keypath_objc_protocol_extension.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/keypath_objc_protocol_extension_other.swift -emit-module-path %t/keypath_objc_protocol_extension_other.swiftmodule -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -emit-ir %s -I %t
+
+// REQUIRES: objc_interop
+
+import keypath_objc_protocol_extension_other
+
+public func foo(array: [any P]) {
+  _ = array.filter(\.value)
+}


### PR DESCRIPTION
Fixes rdar://problem/101825468.