### PR TITLE
[5.7] add missing `@_unsafeInheritExecutor`'s to backdeploy library

### DIFF
--- a/stdlib/public/BackDeployConcurrency/CheckedContinuation.swift
+++ b/stdlib/public/BackDeployConcurrency/CheckedContinuation.swift
@@ -262,6 +262,7 @@ extension CheckedContinuation {
 ///   - body: A closure that takes a `CheckedContinuation` parameter.
 ///     You must resume the continuation exactly once.
 @available(SwiftStdlib 5.1, *)
+@_unsafeInheritExecutor // ABI compatibility with Swift 5.1
 public func withCheckedContinuation<T>(
     function: String = #function,
     _ body: (CheckedContinuation<T, Never>) -> Void
@@ -284,6 +285,7 @@ public func withCheckedContinuation<T>(
 /// If `resume(throwing:)` is called on the continuation,
 /// this function throws that error.
 @available(SwiftStdlib 5.1, *)
+@_unsafeInheritExecutor // ABI compatibility with Swift 5.1
 public func withCheckedThrowingContinuation<T>(
     function: String = #function,
     _ body: (CheckedContinuation<T, Error>) -> Void

--- a/stdlib/public/BackDeployConcurrency/PartialAsyncTask.swift
+++ b/stdlib/public/BackDeployConcurrency/PartialAsyncTask.swift
@@ -254,6 +254,7 @@ internal func _resumeUnsafeThrowingContinuationWithError<T>(
 ///
 /// - Returns: The value passed to the continuation by the closure.
 @available(SwiftStdlib 5.1, *)
+@_unsafeInheritExecutor
 @_alwaysEmitIntoClient
 public func withUnsafeContinuation<T>(
   _ fn: (UnsafeContinuation<T, Never>) -> Void
@@ -274,6 +275,7 @@ public func withUnsafeContinuation<T>(
 /// If `resume(throwing:)` is called on the continuation,
 /// this function throws that error.
 @available(SwiftStdlib 5.1, *)
+@_unsafeInheritExecutor
 @_alwaysEmitIntoClient
 public func withUnsafeThrowingContinuation<T>(
   _ fn: (UnsafeContinuation<T, Error>) -> Void

--- a/stdlib/public/BackDeployConcurrency/TaskGroup.swift
+++ b/stdlib/public/BackDeployConcurrency/TaskGroup.swift
@@ -65,6 +65,7 @@ import Swift
 /// use the `withThrowingTaskGroup(of:returning:body:)` method instead.
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("$ss13withTaskGroup2of9returning4bodyq_xm_q_mq_ScGyxGzYaXEtYar0_lF")
+@_unsafeInheritExecutor
 @inlinable
 public func withTaskGroup<ChildTaskResult, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type,
@@ -157,6 +158,7 @@ public func withTaskGroup<ChildTaskResult, GroupResult>(
 /// or to let the group rethrow the error.
 @available(SwiftStdlib 5.1, *)
 @_silgen_name("$ss21withThrowingTaskGroup2of9returning4bodyq_xm_q_mq_Scgyxs5Error_pGzYaKXEtYaKr0_lF")
+@_unsafeInheritExecutor
 @inlinable
 public func withThrowingTaskGroup<ChildTaskResult, GroupResult>(
   of childTaskResultType: ChildTaskResult.Type,


### PR DESCRIPTION
resolves rdar://101934420