### PR TITLE
[Property Wrappers] Ignore `IBOutlet` optionality diagnostics if the property has an attached property wrapper.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -828,6 +828,11 @@ void AttributeChecker::visitIBOutletAttr(IBOutletAttr *attr) {
     diagnoseAndRemoveAttr(attr, isError.getValue(),
                                  /*array=*/isArray, type);
 
+  // Skip remaining diagnostics if the property has an
+  // attached wrapper.
+  if (VD->hasAttachedPropertyWrapper())
+    return;
+
   // If the type wasn't optional, an array, or unowned, complain.
   if (!wasOptional && !isArray) {
     diagnose(attr->getLocation(), diag::iboutlet_non_optional, type);

--- a/test/attr/attr_iboutlet.swift
+++ b/test/attr/attr_iboutlet.swift
@@ -171,3 +171,16 @@ class NonObjC {}
   @IBOutlet weak var something: OX
   init() { }
 }
+
+@propertyWrapper
+struct MyWrapper {
+  var wrappedValue: AnyObject {
+    get { fatalError() }
+    set { }
+  }
+}
+
+@objc class WrappedIBOutlet {
+  // Non-optional types are okay with property wrappers.
+  @IBOutlet @MyWrapper var value: AnyObject
+}


### PR DESCRIPTION
Resolves rdar://99404208