### PR TITLE
[AddressLowering] Handle multidefault switch_enum.

### DIFF
--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3053,6 +3053,20 @@ void UseRewriter::visitSwitchEnumInst(SwitchEnumInst * switchEnum) {
     defaultCounter = switchEnum->getDefaultCount();
     if (auto defaultDecl = switchEnum->getUniqueCaseForDefault()) {
       rewriteCase(defaultDecl.get(), defaultBB);
+    } else {
+      assert(defaultBB->getArguments().size() == 1);
+      SILArgument *arg = defaultBB->getArgument(0);
+      assert(arg->getType().isAddressOnly(*pass.function));
+      auto builder = pass.getBuilder(defaultBB->begin());
+      auto addr = enumAddr;
+      auto *load = builder.createTrivialLoadOr(switchEnum->getLoc(), addr,
+                                               LoadOwnershipQualifier::Take);
+      // Remap arg to the new dummy load which will be deleted during
+      // deleteRewrittenInstructions.
+      arg->replaceAllUsesWith(load);
+      pass.valueStorageMap.replaceValue(arg, load);
+      markRewritten(load, addr);
+      defaultBB->eraseArgument(0);
     }
   }
   auto builder = pass.getTermBuilder(switchEnum);

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3409,7 +3409,7 @@ static void filterDeadArgs(OperandValueArrayRef origArgs,
                            SmallVectorImpl<SILValue> &newArgs) {
   auto nextDeadArgI = deadArgIndices.begin();
   for (unsigned i : indices(origArgs)) {
-    if (i == *nextDeadArgI) {
+    if (i == *nextDeadArgI && nextDeadArgI != deadArgIndices.end()) {
       ++nextDeadArgI;
       continue;
     }

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -1159,7 +1159,7 @@ void OpaqueStorageAllocation::allocatePhi(PhiValue phi) {
   coalescedPhi.coalesce(phi, pass.valueStorageMap);
 
   SmallVector<SILValue, 4> coalescedValues;
-  coalescedValues.resize(coalescedPhi.getCoalescedOperands().size());
+  coalescedValues.reserve(coalescedPhi.getCoalescedOperands().size());
   for (SILValue value : coalescedPhi.getCoalescedValues())
     coalescedValues.push_back(value);
 

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3011,7 +3011,7 @@ void UseRewriter::visitSwitchEnumInst(SwitchEnumInst * switchEnum) {
       return;
 
     assert(caseBB->getArguments().size() == 1);
-    SILArgument *caseArg = caseBB->getArguments()[0];
+    SILArgument *caseArg = caseBB->getArgument(0);
 
     assert(&switchEnum->getOperandRef(0) == getReusedStorageOperand(caseArg));
     assert(caseDecl->hasAssociatedValues() && "caseBB has a payload argument");

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -948,8 +948,8 @@ bb0(%0 : @owned $P):
 // CHECK:   copy_addr [[OPEN]] to [init] [[INIT]] : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
 // CHECK:   inject_enum_addr [[OPTIONAL]] : $*Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>, #Optional.some!enumelt
 // CHECK:   [[DATA:%.*]] = unchecked_take_enum_data_addr [[OPTIONAL]] : $*Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>, #Optional.some!enumelt
-// CHECK:   %10 = apply %{{.*}}<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>([[DATA]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
-// CHECK:   destroy_addr %9 : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
+// CHECK:   apply %{{.*}}<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>([[DATA]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+// CHECK:   destroy_addr [[DATA:%[^,]+]] : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
 // CHECK:   destroy_addr [[ALLOCP]] : $*any P
 // CHECK:   destroy_addr %0 : $*any P
 // CHECK:   dealloc_stack [[OPTIONAL]] : $*Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -941,6 +941,7 @@ bb0(%0 : @owned $P):
 // CHECK: bb0(%0 : $*any P):
 // CHECK:   [[ALLOCP:%.*]] = alloc_stack $any P, var, name "q"
 // CHECK:   copy_addr %0 to [init] [[ALLOCP]] : $*any P
+// CHECK:   debug_value %0 : $*any P, var, name "q"
 // CHECK:   [[OPEN:%.*]] = open_existential_addr immutable_access %0 : $*any P to $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
 // CHECK:   [[OPTIONAL:%.*]] = alloc_stack $Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>
 // CHECK:   witness_method $@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self, #P.foo : <Self where Self : P> (Self) -> () -> (), [[OPEN]] : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1130,6 +1130,24 @@ bb4:
   return %31 : $()
 }
 
+// Verify the handling of non-unique default case blocks when there is more
+// than one case handled by default.
+// CHECK-LABEL: sil [ossa] @f221_testSwitchDefault : $@convention(thin) <T> (@in Optional<T>) -> () {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : $*Optional<T>):
+// CHECK:         switch_enum_addr [[INSTANCE]] : $*Optional<T>, default [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_addr [[INSTANCE]] : $*Optional<T>
+// CHECK-LABEL: } // end sil function 'f221_testSwitchDefault'
+sil [ossa] @f221_testSwitchDefault : $@convention(thin) <T> (@in Optional<T>) -> () {
+entry(%instance : @owned $Optional<T>):
+  switch_enum %instance : $Optional<T>, default exit
+
+exit(%instance_2 : @owned $Optional<T>):
+  destroy_value %instance_2 : $Optional<T>
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // CHECK-LABEL: sil [ossa] @f230_testTryApply : $@convention(thin) <T> (@in T) -> (@out T, @error any Error) {
 // CHECK: bb0(%0 : $*T, %1 : $*T):
 // CHECK:   [[F:%.*]] = function_ref @throwsError : $@convention(thin) <τ_0_0> (@in τ_0_0) -> (@out τ_0_0, @error any Error)

--- a/test/SILOptimizer/address_lowering_phi.sil
+++ b/test/SILOptimizer/address_lowering_phi.sil
@@ -500,3 +500,20 @@ merge(%34 : @owned $Value):
   %43 = tuple ()
   return %43 : $()
 }
+
+// CHECK-LABEL: sil [ossa] @f105_phi_into_tuple : {{.*}} {
+// CHECK:         [[STORAGE:%[^,]+]] = alloc_stack $(Self, Builtin.Int1)          
+// CHECK:         [[SELF_ADDR:%[^,]+]] = tuple_element_addr [[STORAGE]]
+// CHECK:         apply {{%[^,]+}}<Self>([[SELF_ADDR]])
+// CHECK-LABEL: } // end sil function 'f105_phi_into_tuple'
+sil [ossa] @f105_phi_into_tuple : $@convention(thin) <Self> () -> () {
+  %getOut = function_ref @getOut : $@convention(thin) <T> () -> @out T
+  %self = apply %getOut<Self>() : $@convention(thin) <τ_0_0> () -> @out τ_0_0
+  br exit(%self : $Self)
+
+exit(%self_2 : @owned $Self):
+  %tuple = tuple (%self_2 : $Self, undef : $Bool)
+  destroy_value %tuple : $(Self, Bool)
+  %retval = tuple ()
+  return %retval : $()
+}

--- a/test/SILOptimizer/address_lowering_phi.sil
+++ b/test/SILOptimizer/address_lowering_phi.sil
@@ -470,3 +470,33 @@ bb2:
 bb3(%phi : @owned $T):
   return %phi : $T
 }
+
+// Check that the debug_value instruction that is created when deleting a load
+// gets rewritten and doesn't obstruct the deletion of the phi.
+// CHECK-LABEL: sil [ossa] @f100_store_phi : {{.*}} {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : $*Value):
+// CHECK:         [[TEMP:%[^,]+]] = alloc_stack $Value
+// CHECK:         [[VAR:%[^,]+]] = alloc_stack [lexical] $Value, var, name "value"
+// CHECK:         cond_br undef, bb2, bb1
+// CHECK:       bb3:
+// CHECK:         copy_addr [take] [[TEMP]] to [init] [[VAR]]
+// CHECK:         debug_value [[TEMP]] : $*Value, var, name "value"
+// CHECK-LABEL: } // end sil function 'f100_store_phi'
+sil [ossa] @f100_store_phi : $@convention(thin) <Value> (@in Value) -> () {
+entry(%instance : @owned $Value):
+  %14 = alloc_stack [lexical] $Value, var, name "value"
+  cond_br undef, left, right
+
+left:
+  br merge(%instance : $Value)
+
+right:
+  br merge(%instance : $Value)
+
+merge(%34 : @owned $Value):
+  store %34 to [init] %14 : $*Value
+  destroy_addr %14 : $*Value
+  dealloc_stack %14 : $*Value
+  %43 = tuple ()
+  return %43 : $()
+}

--- a/test/SILOptimizer/address_lowering_phi.sil
+++ b/test/SILOptimizer/address_lowering_phi.sil
@@ -15,6 +15,8 @@ enum Optional<T> {
   case some(T)
 }
 
+struct S {}
+
 struct SRef<T> {
   @_hasStorage var object: AnyObject { get set }
   @_hasStorage var element: T { get set }
@@ -514,6 +516,23 @@ sil [ossa] @f105_phi_into_tuple : $@convention(thin) <Self> () -> () {
 exit(%self_2 : @owned $Self):
   %tuple = tuple (%self_2 : $Self, undef : $Bool)
   destroy_value %tuple : $(Self, Bool)
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Check deleting the first of multiple block arguments.
+// CHECK-LABEL: sil [ossa] @f110_nonfinal_argument : {{.*}} {
+// CHECK:       bb3({{%[^,]+}} : $S):
+// CHECK-LABEL: } // end sil function 'f110_nonfinal_argument'
+sil [ossa] @f110_nonfinal_argument : $@convention(thin) <T> (@in T, S) -> () {
+entry(%instance : @owned $T, %s : $S):
+  cond_br undef, left, right
+left:
+  br exit(%instance : $T, %s : $S)
+right:
+  br exit(%instance : $T, %s : $S)
+exit(%instance_2 : @owned $T, %s_2 : $S):
+  destroy_value %instance_2 : $T
   %retval = tuple ()
   return %retval : $()
 }


### PR DESCRIPTION
If a `switch_enum` instruction (1) exhaustively handles all cases, there is no default case or block corresponding to it.  If (2) it handles all cases but one, the default case corresponds to the unique unhandled case. Otherwise, (3) the default case corresponds to all the unhandled cases.

The first two scenarios were already handled by address lowering.

Here, handling is added for scenario (3).  It is similar to what is already done for rewriting cases except that no `unchecked_take_enum_data_addr` must be created and that the argument is always address-only (being the same type as the operand of the switch_enum which is only being rewritten because it was address-only).

Based on https://github.com/apple/swift/pull/61945 .