### PR TITLE
Sema: Relax the availability requirements for `@_spi` protocol witnesses

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1707,6 +1707,20 @@ bool TypeChecker::isAvailabilitySafeForConformance(
   AvailabilityContext infoForConformingDecl =
       overApproximateAvailabilityAtLocation(dc->getAsDecl()->getLoc(), dc);
 
+  // Relax the requirements for @_spi witnesses by treating the requirement as
+  // if it were introduced at the deployment target. This is not strictly sound
+  // since clients of SPI do not necessarily have the same deployment target as
+  // the module declaring the requirement. However, now that the public
+  // declarations in API libraries are checked according to the minimum possible
+  // deployment target of their clients this relaxation is needed for source
+  // compatibility with some existing code and is reasonably safe for the
+  // majority of cases.
+  if (witness->isSPI()) {
+    AvailabilityContext deploymentTarget =
+        AvailabilityContext::forDeploymentTarget(Context);
+    requirementInfo.constrainWith(deploymentTarget);
+  }
+
   // Constrain over-approximates intersection of version ranges.
   witnessInfo.constrainWith(infoForConformingDecl);
   requirementInfo.constrainWith(infoForConformingDecl);

--- a/test/Interpreter/spi_witness_availability.swift
+++ b/test/Interpreter/spi_witness_availability.swift
@@ -1,0 +1,69 @@
+// RUN: %target-run-simple-swift(-target %target-cpu-macos10.15) | \
+// RUN:   %FileCheck %s --check-prefix=CHECK-CONFORMANCES-NOT-AVAILABLE
+// RUN: %target-run-simple-swift(-target %target-cpu-macos10.15.4) | \
+// RUN:   %FileCheck %s --check-prefix=CHECK-CONFORMANCES-AVAILABLE
+// RUN: %target-run-simple-swift(-target %target-cpu-macos10.15.4 -library-level api) | \
+// RUN:   %FileCheck %s --check-prefix=CHECK-CONFORMANCES-AVAILABLE-API
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+
+@available(macOS 10.15, *)
+public protocol BaseProto {
+  static var foo: String { get }
+}
+
+@available(macOS 10.15, *)
+extension BaseProto {
+  public static var foo: String { return "Base" }
+}
+
+@available(macOS 10.15.4, *)
+public protocol DerivedProto: BaseProto {}
+
+@available(macOS 10.15.4, *)
+extension DerivedProto {
+  public static var foo: String { return "Derived" }
+}
+
+@_spi(Private)
+@available(macOS 10.15.4, *)
+public protocol SecretDerivedProto: BaseProto {
+}
+
+@_spi(Private)
+@available(macOS 10.15.4, *)
+extension SecretDerivedProto {
+  public static var foo: String { return "Secret" }
+}
+
+@available(macOS 10.15, *)
+public struct NoSecrets: BaseProto {
+  public init() {}
+}
+
+@available(macOS 10.15.4, *)
+extension NoSecrets: DerivedProto {}
+
+@available(macOS 10.15, *)
+public struct HasSecrets: BaseProto {
+  public init() {}
+}
+
+@_spi(Private)
+@available(macOS 10.15.4, *)
+extension HasSecrets: SecretDerivedProto {}
+
+@available(macOS 10.15, *)
+func doIt<T: BaseProto>(_: T) {
+  print(T.foo)
+}
+
+// CHECK-CONFORMANCES-NOT-AVAILABLE:  Base
+// CHECK-CONFORMANCES-AVAILABLE:      Derived
+// CHECK-CONFORMANCES-AVAILABLE-API:  Base
+doIt(NoSecrets())
+// CHECK-CONFORMANCES-NOT-AVAILABLE:  Base
+// CHECK-CONFORMANCES-AVAILABLE:      Secret
+// CHECK-CONFORMANCES-AVAILABLE-API:  Secret
+doIt(HasSecrets())


### PR DESCRIPTION
Now that the public declarations in API libraries are checked according to the minimum possible deployment target of their clients this relaxation is needed for source compatibility with some existing code.

Resolves rdar://100904631
