### PR TITLE
ARCAnalysis: fix `canApplyOfBuiltinUseNonTrivialValues`

### DIFF
--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -110,9 +110,9 @@ static bool canApplyOfBuiltinUseNonTrivialValues(BuiltinInst *BInst) {
           return true;
         }
       }
+      return false;
     }
-
-    return false;
+    return true;
   }
 
   auto &BI = BInst->getBuiltinInfo();

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -820,6 +820,28 @@ bb0(%0 : $_ContiguousArrayBuffer<AnyObject>, %1 : $Builtin.Word, %2 : $Builtin.W
   return %newptr : $Builtin.RawPointer
 }
 
+// CHECK-RELEASE-HOISTING-LABEL: sil @testMemcpy
+// CHECK-RELEASE-HOISTING:       bb0(%0 : $_ContiguousArrayBuffer<UInt64>, %1 : $Builtin.Word):
+// CHECK-RELEASE-HOISTING:         builtin "int_memcpy_RawPointer_RawPointer_Word"
+// CHECK-RELEASE-HOISTING:         release_value %0 : $_ContiguousArrayBuffer<UInt64>
+// CHECK-RELEASE-HOISTING:       } // end sil function 'testMemcpy'
+sil @testMemcpy : $@convention(thin) (_ContiguousArrayBuffer<UInt64>, Builtin.Word) -> Builtin.RawPointer {
+bb0(%0 : $_ContiguousArrayBuffer<UInt64>, %1 : $Builtin.Word):
+  %newptr = builtin "allocRaw"(%1 : $Builtin.Word, %1 : $Builtin.Word) : $Builtin.RawPointer
+  %token = bind_memory %newptr : $Builtin.RawPointer, %1 : $Builtin.Word to $*UInt64
+  %storage = struct_extract %0 : $_ContiguousArrayBuffer<UInt64>, #_ContiguousArrayBuffer._storage
+  %elements = ref_tail_addr %storage : $__ContiguousArrayStorageBase, $UInt64
+  %eltptr = address_to_pointer %elements : $*UInt64 to $Builtin.RawPointer
+  %objptr = struct $UnsafePointer<UInt64> (%eltptr : $Builtin.RawPointer)
+  %ptrdep = mark_dependence %objptr : $UnsafePointer<UInt64> on %storage : $__ContiguousArrayStorageBase
+  %rawptr = struct_extract %ptrdep : $UnsafePointer<UInt64>, #UnsafePointer._rawValue
+  %f = integer_literal $Builtin.Int1, 0
+  %move = builtin "int_memcpy_RawPointer_RawPointer_Word"(%newptr : $Builtin.RawPointer, %rawptr : $Builtin.RawPointer, %1 : $Builtin.Word, %f : $Builtin.Int1) : $()
+  release_value %0 : $_ContiguousArrayBuffer<UInt64>
+  return %newptr : $Builtin.RawPointer
+}
+
+
 // CHECK-LABEL: sil @dontMoveOverExistentialToClassCast : $@convention(thin) (@guaranteed AnyObject) -> Optional<fuzz>
 // CHECK:    strong_retain %0
 // CHECK:    checked_cast_br %0


### PR DESCRIPTION
Fix a return-true-false logic error when handling LLVM intrinsics.
This bug was introduced by https://github.com/apple/swift/pull/25985

