### PR TITLE
[Sema] TypeWrappers: Improve use of multiple type wrappers diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6615,7 +6615,8 @@ ERROR(type_wrapper_requires_two_generic_params,none,
       "wrapped and storage types", ())
 
 ERROR(cannot_use_multiple_type_wrappers,none,
-      "type %0 cannot use more than one type wrapper", ())
+      "%0 %1 cannot use more than one type wrapper",
+      (DescriptiveDeclKind, DeclName))
 
 ERROR(type_wrapper_requires_memberwise_init,none,
       "type wrapper type %0 does not contain a required initializer"

--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -116,7 +116,14 @@ NominalTypeDecl *GetTypeWrapper::evaluate(Evaluator &evaluator,
     return nullptr;
 
   if (typeWrappers.size() != 1) {
-    ctx.Diags.diagnose(decl, diag::cannot_use_multiple_type_wrappers);
+    ctx.Diags.diagnose(decl, diag::cannot_use_multiple_type_wrappers,
+                       decl->getDescriptiveKind(), decl->getName());
+
+    for (const auto &attr : typeWrappers) {
+      ctx.Diags.diagnose(attr.first->getLocation(), diag::decl_declared_here,
+                         attr.second->getName());
+    }
+
     return nullptr;
   }
 

--- a/test/type/type_wrapper.swift
+++ b/test/type/type_wrapper.swift
@@ -641,3 +641,15 @@ do {
   // expected-error@-1 {{missing arguments for parameters 'a', 'b' in call}}
   // expected-error@-2 {{extra argument 'storageWrapper' in call}}
 }
+
+func test_multiple_wrapper_attributes() {
+  @Parent.Wrapper @NoopWrapper
+  // expected-note@-1 {{'Wrapper' declared here}}
+  // expected-note@-2 {{'NoopWrapper' declared here}}
+  struct Test1 {} // expected-error {{struct 'Test1' cannot use more than one type wrapper}}
+
+  @Parent.Wrapper @NoopWrapper
+  // expected-note@-1 {{'Wrapper' declared here}}
+  // expected-note@-2 {{'NoopWrapper' declared here}}
+  class Test2 {} // expected-error {{class 'Test2' cannot use more than one type wrapper}}
+}


### PR DESCRIPTION
Adds a kind of the declaration and mentions all of the wrappers. 
This is going to be expended by type wrapper inference from 
protocols to distinguish between direct and inferred wrappers.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
