### PR TITLE
[AddressLowering] Handle try_apply with enum'd return.

### DIFF
--- a/docs/Android.md
+++ b/docs/Android.md
@@ -133,7 +133,7 @@ $ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libBlo
 In addition, you'll also need to copy the Android NDK's libc++:
 
 ```
-$ adb push /path/to/android-ndk-r25b/sources/cxx-stl/llvm-libc++/libs/arm64-v8a/libc++_shared.so /data/local/tmp
+$ adb push /path/to/android-ndk-r25b/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/lib/aarch64-linux-android/libc++_shared.so /data/local/tmp
 ```
 
 Finally, you'll need to copy the `hello` executable you built in the

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -173,6 +173,7 @@ struct InterfaceSubContextDelegate {
                                                    StringRef interfacePath,
                                                    StringRef outputPath,
                                                    SourceLoc diagLoc,
+                                                   bool silenceErrors,
     llvm::function_ref<std::error_code(SubCompilerInstanceInfo&)> action) = 0;
 
   virtual ~InterfaceSubContextDelegate() = default;

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -523,6 +523,7 @@ public:
                                            StringRef interfacePath,
                                            StringRef outputPath,
                                            SourceLoc diagLoc,
+                                           bool silenceErrors,
     llvm::function_ref<std::error_code(SubCompilerInstanceInfo&)> action) override;
 
   ~InterfaceSubContextDelegateImpl() = default;

--- a/lib/Frontend/ModuleInterfaceBuilder.cpp
+++ b/lib/Frontend/ModuleInterfaceBuilder.cpp
@@ -330,6 +330,7 @@ bool ImplicitModuleInterfaceBuilder::buildSwiftModuleInternal(
 
     SubError = (bool)subASTDelegate.runInSubCompilerInstance(
         moduleName, interfacePath, OutPath, diagnosticLoc,
+        silenceInterfaceDiagnostics,
         [&](SubCompilerInstanceInfo &info) {
           auto EBuilder = ExplicitModuleInterfaceBuilder(
               *info.Instance, rebuildDiags, sourceMgr, moduleCachePath, backupInterfaceDir,

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1724,7 +1724,8 @@ InterfaceSubContextDelegateImpl::runInSubContext(StringRef moduleName,
                                                  SourceLoc diagLoc,
     llvm::function_ref<std::error_code(ASTContext&, ModuleDecl*, ArrayRef<StringRef>,
                             ArrayRef<StringRef>, StringRef)> action) {
-  return runInSubCompilerInstance(moduleName, interfacePath, outputPath, diagLoc,
+  return runInSubCompilerInstance(moduleName, interfacePath, outputPath,
+                                  diagLoc, /*silenceErrors=*/false,
                                   [&](SubCompilerInstanceInfo &info){
     return action(info.Instance->getASTContext(),
                   info.Instance->getMainModule(),
@@ -1739,6 +1740,7 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
                                                           StringRef interfacePath,
                                                           StringRef outputPath,
                                                           SourceLoc diagLoc,
+                                                          bool silenceErrors,
                   llvm::function_ref<std::error_code(SubCompilerInstanceInfo&)> action) {
   // We are about to mess up the compiler invocation by using the compiler
   // arguments in the textual interface file. So copy to use a new compiler
@@ -1833,7 +1835,8 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
   subInstance.getSourceMgr().setFileSystem(SM.getFileSystem());
 
   ForwardingDiagnosticConsumer FDC(*Diags);
-  subInstance.addDiagnosticConsumer(&FDC);
+  if (!silenceErrors)
+    subInstance.addDiagnosticConsumer(&FDC);
   std::string InstanceSetupError;
   if (subInstance.setup(subInvocation, InstanceSetupError)) {
     return std::make_error_code(std::errc::not_supported);

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -1073,6 +1073,8 @@ static bool canSpecializeFullApplySite(FullApplySiteKind kind) {
   llvm_unreachable("covered switch");
 }
 
+const int SpecializationLevelLimit = 2;
+
 static int getSpecializationLevelRecursive(StringRef funcName, Demangler &parent) {
   using namespace Demangle;
 
@@ -1098,23 +1100,44 @@ static int getSpecializationLevelRecursive(StringRef funcName, Demangler &parent
     return 0;
   if (funcSpec->getKind() != Node::Kind::FunctionSignatureSpecialization)
     return 0;
-  Node *param = funcSpec->getChild(1);
-  if (param->getKind() != Node::Kind::FunctionSignatureSpecializationParam)
-    return 0;
-  if (param->getNumChildren() < 2)
-    return 0;
-  Node *kindNd = param->getChild(0);
-  if (kindNd->getKind() != Node::Kind::FunctionSignatureSpecializationParamKind)
-    return 0;
-  auto kind = FunctionSigSpecializationParamKind(kindNd->getIndex());
-  if (kind != FunctionSigSpecializationParamKind::ConstantPropFunction)
-    return 0;
-    
-  Node *payload = param->getChild(1);
-  if (payload->getKind() != Node::Kind::FunctionSignatureSpecializationParamPayload)
-    return 1;
-  // Check if the specialized function is a specialization itself.
-  return 1 + getSpecializationLevelRecursive(payload->getText(), demangler);
+
+  // Match any function specialization. We check for constant propagation at the
+  // parameter level.
+  Node *param = funcSpec->getChild(0);
+  if (param->getKind() != Node::Kind::SpecializationPassID)
+    return SpecializationLevelLimit + 1; // unrecognized format
+
+  unsigned maxParamLevel = 0;
+  for (unsigned paramIdx = 1; paramIdx < funcSpec->getNumChildren();
+       ++paramIdx) {
+    Node *param = funcSpec->getChild(paramIdx);
+    if (param->getKind() != Node::Kind::FunctionSignatureSpecializationParam)
+      return SpecializationLevelLimit + 1; // unrecognized format
+
+    // A parameter is recursive if it has a kind with index and type payload
+    if (param->getNumChildren() < 2)
+      continue;
+
+    Node *kindNd = param->getChild(0);
+    if (kindNd->getKind()
+        != Node::Kind::FunctionSignatureSpecializationParamKind) {
+      return SpecializationLevelLimit + 1; // unrecognized format
+    }
+    auto kind = FunctionSigSpecializationParamKind(kindNd->getIndex());
+    if (kind != FunctionSigSpecializationParamKind::ConstantPropFunction)
+      continue;
+    Node *payload = param->getChild(1);
+    if (payload->getKind()
+        != Node::Kind::FunctionSignatureSpecializationParamPayload) {
+      return SpecializationLevelLimit + 1; // unrecognized format
+    }
+    // Check if the specialized function is a specialization itself.
+    unsigned paramLevel =
+      1 + getSpecializationLevelRecursive(payload->getText(), demangler);
+    if (paramLevel > maxParamLevel)
+      maxParamLevel = paramLevel;
+  }
+  return maxParamLevel;
 }
 
 /// If \p function is a function-signature specialization for a constant-
@@ -1328,9 +1351,10 @@ bool SILClosureSpecializerTransform::gatherCallSites(
         //
         // A limit of 2 is good enough and will not be exceed in "regular"
         // optimization scenarios.
-        if (getSpecializationLevel(getClosureCallee(ClosureInst)) > 2)
+        if (getSpecializationLevel(getClosureCallee(ClosureInst))
+            > SpecializationLevelLimit) {
           continue;
-
+        }
         // Compute the final release points of the closure. We will insert
         // release of the captured arguments here.
         if (!CInfo)
@@ -1395,6 +1419,8 @@ bool SILClosureSpecializerTransform::specialize(SILFunction *Caller,
       if (!NewF) {
         NewF = ClosureSpecCloner::cloneFunction(FuncBuilder, CSDesc, NewFName);
         addFunctionToPassManagerWorklist(NewF, CSDesc.getApplyCallee());
+        LLVM_DEBUG(llvm::dbgs() << "\nThe rewritten callee is:\n";
+                   NewF->dump());
       }
 
       // Rewrite the call
@@ -1404,6 +1430,10 @@ bool SILClosureSpecializerTransform::specialize(SILFunction *Caller,
       Changed = true;
     }
   }
+  LLVM_DEBUG(if (Changed) {
+      llvm::dbgs() << "\nThe rewritten caller is:\n";
+      Caller->dump();
+    });
   return Changed;
 }
 

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3053,6 +3053,20 @@ void UseRewriter::visitSwitchEnumInst(SwitchEnumInst * switchEnum) {
     defaultCounter = switchEnum->getDefaultCount();
     if (auto defaultDecl = switchEnum->getUniqueCaseForDefault()) {
       rewriteCase(defaultDecl.get(), defaultBB);
+    } else {
+      assert(defaultBB->getArguments().size() == 1);
+      SILArgument *arg = defaultBB->getArgument(0);
+      assert(arg->getType().isAddressOnly(*pass.function));
+      auto builder = pass.getBuilder(defaultBB->begin());
+      auto addr = enumAddr;
+      auto *load = builder.createTrivialLoadOr(switchEnum->getLoc(), addr,
+                                               LoadOwnershipQualifier::Take);
+      // Remap arg to the new dummy load which will be deleted during
+      // deleteRewrittenInstructions.
+      arg->replaceAllUsesWith(load);
+      pass.valueStorageMap.replaceValue(arg, load);
+      markRewritten(load, addr);
+      defaultBB->eraseArgument(0);
     }
   }
   auto builder = pass.getTermBuilder(switchEnum);

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3409,7 +3409,7 @@ static void filterDeadArgs(OperandValueArrayRef origArgs,
                            SmallVectorImpl<SILValue> &newArgs) {
   auto nextDeadArgI = deadArgIndices.begin();
   for (unsigned i : indices(origArgs)) {
-    if (i == *nextDeadArgI) {
+    if (i == *nextDeadArgI && nextDeadArgI != deadArgIndices.end()) {
       ++nextDeadArgI;
       continue;
     }

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3377,6 +3377,9 @@ static void rewriteFunction(AddressLoweringState &pass) {
       DefRewriter::rewriteValue(valueDef, pass);
       valueAndStorage.storage.markRewritten();
     }
+    // The def of interest may have been changed by rewriteValue.  Get that
+    // redefinition back out of the ValueStoragePair.
+    valueDef = valueAndStorage.value;
     // Rewrite a use of any non-address value mapped to storage (does not
     // include the already rewritten uses of indirect arguments).
     if (valueDef->getType().isAddress())

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -1159,7 +1159,7 @@ void OpaqueStorageAllocation::allocatePhi(PhiValue phi) {
   coalescedPhi.coalesce(phi, pass.valueStorageMap);
 
   SmallVector<SILValue, 4> coalescedValues;
-  coalescedValues.resize(coalescedPhi.getCoalescedOperands().size());
+  coalescedValues.reserve(coalescedPhi.getCoalescedOperands().size());
   for (SILValue value : coalescedPhi.getCoalescedValues())
     coalescedValues.push_back(value);
 

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3172,6 +3172,12 @@ public:
 protected:
   // Set the storage address for an opaque block arg and mark it rewritten.
   void rewriteArg(SILPhiArgument *arg) {
+    if (auto *tai =
+            dyn_cast_or_null<TryApplyInst>(arg->getTerminatorForResult())) {
+      CallArgRewriter(tai, pass).rewriteArguments();
+      ApplyRewriter(tai, pass).convertApplyWithIndirectResults();
+      return;
+    }
     LLVM_DEBUG(llvm::dbgs() << "REWRITE ARG "; arg->dump());
     if (storage.storageAddress)
       LLVM_DEBUG(llvm::dbgs() << "  STORAGE "; storage.storageAddress->dump());

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3011,7 +3011,7 @@ void UseRewriter::visitSwitchEnumInst(SwitchEnumInst * switchEnum) {
       return;
 
     assert(caseBB->getArguments().size() == 1);
-    SILArgument *caseArg = caseBB->getArguments()[0];
+    SILArgument *caseArg = caseBB->getArgument(0);
 
     assert(&switchEnum->getOperandRef(0) == getReusedStorageOperand(caseArg));
     assert(caseDecl->hasAssociatedValues() && "caseBB has a payload argument");

--- a/test/ASTGen/verify-parse.swift
+++ b/test/ASTGen/verify-parse.swift
@@ -1,5 +1,7 @@
 // RUN: %target-run-simple-swift(-enable-experimental-feature SwiftParser -enable-experimental-feature ParserASTGen)
 
+// REQUIRES: executable_test
+
 func test1(x: Int, fn: (Int) -> Int) -> Int {
   let xx = fn(42)
   return fn(x)

--- a/test/Index/index_system_modules_swiftinterfaces.swift
+++ b/test/Index/index_system_modules_swiftinterfaces.swift
@@ -55,9 +55,9 @@
 // RUN:     2>&1 | %FileCheck -check-prefix=BROKEN-BUILD %s
 
 /// We don't expect so see the swiftinterface error for indexing
-// BROKEN-BUILD: indexing system module {{.*}} skipping
 // BROKEN-BUILD-NOT: error
 // BROKEN-BUILD-NOT: breaking_the_swifinterface
+// BROKEN-BUILD: indexing system module {{.*}} skipping
 
 /// We don't expect SystemModule to be indexed with a broken swiftinterface
 // RUN: c-index-test core -print-unit %t/idx | %FileCheck -check-prefix=BROKEN-UNIT %s

--- a/test/Interop/Cxx/class/constructors-copy-irgen-android.swift
+++ b/test/Interop/Cxx/class/constructors-copy-irgen-android.swift
@@ -1,23 +1,21 @@
 // Target-specific tests for C++ copy constructor code generation.
 
-// RUN: %swift -module-name MySwift -target armv7-none-linux-androideabi -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
+// RUN: %swift -module-name MySwift -target aarch64-unknown-linux-android -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
 
-// REQUIRES: OS=linux-android || OS=linux-androideabi
-
-// REQUIRES: CODEGENERATOR=X86
-// REQUIRES: CODEGENERATOR=ARM
+// REQUIRES: OS=linux-android
+// REQUIRES: CPU=aarch64
 
 import Constructors
 import TypeClassification
 
-// ITANIUM_ARM-LABEL: define protected swiftcc void @"$s7MySwift35copyWithUserProvidedCopyConstructorySo03HascdeF0V_ACtACF"
+// ITANIUM_ARM-LABEL: define protected swiftcc void @"$s7MySwift35copyWithUserProvidedCopyConstructorySo03Has{{cdeF0V_ACtACF|efgH0V_ADtADF}}"
 // ITANIUM_ARM-SAME: (%TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG0:%.*]], %TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG1:%.*]], %TSo30HasUserProvidedCopyConstructorV* {{.*}}[[ARG2:%.*]])
 // ITANIUM_ARM: [[ARG0_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG0]] to %struct.HasUserProvidedCopyConstructor*
 // ITANIUM_ARM: [[ARG2_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG2]] to %struct.HasUserProvidedCopyConstructor*
-// ITANIUM_ARM: call %struct.HasUserProvidedCopyConstructor* @_ZN30HasUserProvidedCopyConstructorC2ERKS_(%struct.HasUserProvidedCopyConstructor* [[ARG0_AS_STRUCT]], %struct.HasUserProvidedCopyConstructor* [[ARG2_AS_STRUCT]])
+// ITANIUM_ARM: call void @_ZN30HasUserProvidedCopyConstructorC2ERKS_(%struct.HasUserProvidedCopyConstructor* [[ARG0_AS_STRUCT]], %struct.HasUserProvidedCopyConstructor* [[ARG2_AS_STRUCT]])
 // ITANIUM_ARM: [[ARG1_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG1]] to %struct.HasUserProvidedCopyConstructor*
 // ITANIUM_ARM: [[ARG2_AS_STRUCT:%.*]] = bitcast %TSo30HasUserProvidedCopyConstructorV* [[ARG2]] to %struct.HasUserProvidedCopyConstructor*
-// ITANIUM_ARM: call %struct.HasUserProvidedCopyConstructor* @_ZN30HasUserProvidedCopyConstructorC2ERKS_(%struct.HasUserProvidedCopyConstructor* [[ARG1_AS_STRUCT]], %struct.HasUserProvidedCopyConstructor* [[ARG2_AS_STRUCT]])
+// ITANIUM_ARM: call void @_ZN30HasUserProvidedCopyConstructorC2ERKS_(%struct.HasUserProvidedCopyConstructor* [[ARG1_AS_STRUCT]], %struct.HasUserProvidedCopyConstructor* [[ARG2_AS_STRUCT]])
 // ITANIUM_ARM: ret void
 
 public func copyWithUserProvidedCopyConstructor(_ x: HasUserProvidedCopyConstructor)

--- a/test/Interop/Cxx/class/constructors-copy-irgen-windows.swift
+++ b/test/Interop/Cxx/class/constructors-copy-irgen-windows.swift
@@ -3,10 +3,7 @@
 // RUN: %swift -module-name MySwift -target x86_64-unknown-windows-msvc -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64
 
 // REQUIRES: OS=windows-msvc
-
-// REQUIRES: CODEGENERATOR=X86
-// REQUIRES: CODEGENERATOR=ARM
-
+// REQUIRES: CPU=x86_64
 
 import Constructors
 import TypeClassification

--- a/test/Interop/Cxx/class/constructors-irgen-android.swift
+++ b/test/Interop/Cxx/class/constructors-irgen-android.swift
@@ -1,31 +1,29 @@
 // Target-specific tests for C++ constructor call code generation.
 
-// RUN: %swift -module-name MySwift -target armv7-unknown-linux-androideabi -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
+// RUN: %swift -module-name MySwift -target aarch64-unknown-linux-android -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
 
-// REQUIRES: OS=linux-android || OS=linux-androideabi
-
-// REQUIRES: CODEGENERATOR=X86
-// REQUIRES: CODEGENERATOR=ARM
+// REQUIRES: OS=linux-android
+// REQUIRES: CPU=aarch64
 
 import Constructors
 import TypeClassification
 
 public func createHasVirtualBase() -> HasVirtualBase {
-  // ITANIUM_ARM: define protected swiftcc void @"$s7MySwift20createHasVirtualBaseSo0bcD0VyF"(%TSo14HasVirtualBaseV* noalias nocapture sret({{.*}}) %0)
+  // ITANIUM_ARM: define protected swiftcc void @"$s7MySwift20createHasVirtualBaseSo0deF0VyF"(%TSo14HasVirtualBaseV* noalias nocapture sret({{.*}}) %0)
   // To verify that the thunk is inlined, make sure there's no intervening
   // `define`, i.e. the call to the C++ constructor happens in
   // createHasVirtualBase(), not some later function.
   // ITANIUM_ARM-NOT: define
   // Note `this` return type.
-  // ITANIUM_ARM: call %struct.HasVirtualBase* @_ZN14HasVirtualBaseC1E7ArgType(%struct.HasVirtualBase* %{{[0-9]+}}, [1 x i32] %{{[0-9]+}})
+  // ITANIUM_ARM: call void @_ZN14HasVirtualBaseC1E7ArgType(%struct.HasVirtualBase* %{{[0-9]+}}, i64 %{{[0-9]+}})
   return HasVirtualBase(ArgType())
 }
 
 public func createImplicitDefaultConstructor() -> ImplicitDefaultConstructor {
-  // ITANIUM_ARM: define protected swiftcc i32 @"$s7MySwift32createImplicitDefaultConstructorSo0bcD0VyF"()
+  // ITANIUM_ARM: define protected swiftcc i32 @"$s7MySwift32createImplicitDefaultConstructorSo0deF0VyF"()
   // ITANIUM_ARM-NOT: define
   // Note `this` return type.
-  // ITANIUM_ARM: call %struct.ImplicitDefaultConstructor* @_ZN26ImplicitDefaultConstructorC2Ev(%struct.ImplicitDefaultConstructor* %{{[0-9]+}})
+  // ITANIUM_ARM: call void @_ZN26ImplicitDefaultConstructorC2Ev(%struct.ImplicitDefaultConstructor* %{{[0-9]+}})
   return ImplicitDefaultConstructor()
 }
 
@@ -35,10 +33,10 @@ public func createStructWithSubobjectCopyConstructorAndValue() {
   // ITANIUM_ARM: [[OBJ:%.*]] = alloca %TSo42StructWithSubobjectCopyConstructorAndValueV
   // ITANIUM_ARM: [[TMP:%.*]] = alloca %TSo33StructWithCopyConstructorAndValueV
   // ITANIUM_ARM: [[MEMBER_AS_STRUCT:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[MEMBER]] to %struct.StructWithCopyConstructorAndValue*
-  // ITANIUM_ARM: call %struct.StructWithCopyConstructorAndValue* @_ZN33StructWithCopyConstructorAndValueC2Ev(%struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT]])
+  // ITANIUM_ARM: call void @_ZN33StructWithCopyConstructorAndValueC2Ev(%struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT]])
   // ITANIUM_ARM: [[TMP_STRUCT:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[TMP]] to %struct.StructWithCopyConstructorAndValue*
   // ITANIUM_ARM: [[MEMBER_AS_STRUCT_2:%.*]] = bitcast %TSo33StructWithCopyConstructorAndValueV* [[MEMBER]] to %struct.StructWithCopyConstructorAndValue*
-  // ITANIUM_ARM: call %struct.StructWithCopyConstructorAndValue* @_ZN33StructWithCopyConstructorAndValueC2ERKS_(%struct.StructWithCopyConstructorAndValue* [[TMP_STRUCT]], %struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT_2]])
+  // ITANIUM_ARM: call void @_ZN33StructWithCopyConstructorAndValueC2ERKS_(%struct.StructWithCopyConstructorAndValue* [[TMP_STRUCT]], %struct.StructWithCopyConstructorAndValue* [[MEMBER_AS_STRUCT_2]])
   // ITANIUM_ARM: ret void
   let member = StructWithCopyConstructorAndValue()
   let obj = StructWithSubobjectCopyConstructorAndValue(member: member)
@@ -47,11 +45,11 @@ public func createStructWithSubobjectCopyConstructorAndValue() {
 public func createTemplatedConstructor() {
   // ITANIUM_ARM-LABEL: define protected swiftcc void @"$s7MySwift26createTemplatedConstructoryyF"()
   // ITANIUM_ARM: [[OBJ:%.*]] = alloca %TSo20TemplatedConstructorV
-  // ITANIUM_ARM: [[IVAL:%.*]] = load [1 x i32], [1 x i32]*
+  // ITANIUM_ARM: [[IVAL:%.*]] = load i64, i64*
   // ITANIUM_ARM: [[OBJ_AS_STRUCT:%.*]] = bitcast %TSo20TemplatedConstructorV* [[OBJ]] to %struct.TemplatedConstructor*
-  // ITANIUM_ARM:  call %struct.TemplatedConstructor* @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* [[OBJ_AS_STRUCT]], [1 x i32] [[IVAL]])
+  // ITANIUM_ARM:  call void @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* [[OBJ_AS_STRUCT]], i64 [[IVAL]])
   // ITANIUM_ARM: ret void
   
-  // ITANIUM_ARM-LABEL: define {{.*}}%struct.TemplatedConstructor* @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* {{.*}}, [1 x i32] {{.*}})
+  // ITANIUM_ARM-LABEL: define {{.*}}void @_ZN20TemplatedConstructorC2I7ArgTypeEET_(%struct.TemplatedConstructor* {{.*}}, i64 {{.*}})
   let templated = TemplatedConstructor(ArgType())
 }

--- a/test/Interop/Cxx/class/constructors-irgen-windows.swift
+++ b/test/Interop/Cxx/class/constructors-irgen-windows.swift
@@ -3,9 +3,7 @@
 // RUN: %swift -module-name MySwift -target x86_64-unknown-windows-msvc -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=MICROSOFT_X64
 
 // REQUIRES: OS=windows-msvc
-
-// REQUIRES: CODEGENERATOR=X86
-// REQUIRES: CODEGENERATOR=ARM
+// REQUIRES: CPU=x86_64
 
 import Constructors
 import TypeClassification

--- a/test/Interop/Cxx/foreign-reference/base-class-layout-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/base-class-layout-irgen.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -module-name=test  | %FileCheck %s
-//
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import MemberLayout
 

--- a/test/Interop/Cxx/foreign-reference/unimportable-member-layout-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/unimportable-member-layout-irgen.swift
@@ -1,6 +1,4 @@
 // RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -module-name=test | %FileCheck %s
-//
-// XFAIL: OS=linux-android, OS=linux-androideabi
 
 import MemberLayout
 

--- a/test/Parse/ConditionalCompilation/aarch64AndroidTarget.swift
+++ b/test/Parse/ConditionalCompilation/aarch64AndroidTarget.swift
@@ -1,5 +1,5 @@
-// RUN: %swift -typecheck %s -verify -target aarch64-none-linux-android -disable-objc-interop -parse-stdlib
-// RUN: %swift-ide-test -test-input-complete -source-filename=%s -target aarch64-none-linux-android
+// RUN: %swift -typecheck %s -verify -target aarch64-unknown-linux-android -disable-objc-interop -parse-stdlib
+// RUN: %swift-ide-test -test-input-complete -source-filename=%s -target aarch64-unknown-linux-android
 
 #if os(Linux)
 // This block should not parse.

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1266,6 +1266,28 @@ nopers(%error : @owned $any Error):
   throw %error : $any Error
 }
 
+// CHECK-LABEL: sil [ossa] @f262_testTryApplyIntoPhi : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] :
+// CHECK:         try_apply undef<R>([[ADDR]]) {{.*}}, normal [[NORMAL:bb[0-9]+]]
+// CHECK:       [[NORMAL]](%2 : $()):                                    
+// CHECK:         br [[EXIT:bb[0-9]+]]                                          
+// CHECK:       [[EXIT]]:                                              
+// CHECK:         return {{%[^,]+}} : $()                                 
+// CHECK-LABEL: } // end sil function 'f262_testTryApplyIntoPhi'
+sil [ossa] @f262_testTryApplyIntoPhi : $@convention(thin) <R> () -> (@out R, @error any Error) {
+entry:
+  try_apply undef<R>() : $@convention(thin) <U> () -> (@out U, @error any Error), normal good, error bad
+
+good(%instance : @owned $R):
+  br exit(%instance : $R)
+
+exit(%instance_2 : @owned $R):
+  return %instance_2 : $R
+
+bad(%41 : @owned $any Error):
+  throw %41 : $any Error
+}
+
 // CHECK-LABEL: sil [ossa] @fixeeLifetime : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] : $*T):
 // CHECK:         fix_lifetime [[ADDR]]

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -948,8 +948,8 @@ bb0(%0 : @owned $P):
 // CHECK:   copy_addr [[OPEN]] to [init] [[INIT]] : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
 // CHECK:   inject_enum_addr [[OPTIONAL]] : $*Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>, #Optional.some!enumelt
 // CHECK:   [[DATA:%.*]] = unchecked_take_enum_data_addr [[OPTIONAL]] : $*Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>, #Optional.some!enumelt
-// CHECK:   %10 = apply %{{.*}}<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>([[DATA]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
-// CHECK:   destroy_addr %9 : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
+// CHECK:   apply %{{.*}}<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>([[DATA]]) : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+// CHECK:   destroy_addr [[DATA:%[^,]+]] : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
 // CHECK:   destroy_addr [[ALLOCP]] : $*any P
 // CHECK:   destroy_addr %0 : $*any P
 // CHECK:   dealloc_stack [[OPTIONAL]] : $*Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1247,6 +1247,25 @@ bb2(%9 : $Error):
   throw %9 : $Error
 }
 
+// CHECK-LABEL: sil [ossa] @f261_testTryApplyIntoEnum : $@convention(thin) <T> () -> (@out Optional<T>, @error any Error) {
+// CHECK:       {{bb[0-9]+}}([[OUT_ADDR:%[^,]+]] : $*Optional<T>):
+// CHECK:         [[SOME_ADDR:%[^,]+]] = init_enum_data_addr %0 : $*Optional<T>, #Optional.some!enumelt
+// CHECK:         try_apply undef<T>([[SOME_ADDR]]) {{.*}}, normal [[NORMAL:bb[0-9]+]], error {{bb[0-9]+}}
+// CHECK:       [[NORMAL]]
+// CHECK:         inject_enum_addr [[OUT_ADDR]] : $*Optional<T>, #Optional.some!enumelt
+// CHECK-LABEL: } // end sil function 'f261_testTryApplyIntoEnum'
+sil [ossa] @f261_testTryApplyIntoEnum : $@convention(thin) <T> () -> (@out Optional<T>, @error any Error) {
+entry:
+  try_apply undef<T>() : $@convention(thin) <T> () -> (@out T, @error any Error), normal okay, error nopers
+
+okay(%instance : @owned $T):
+  %some = enum $Optional<T>, #Optional.some!enumelt, %instance : $T
+  return %some : $Optional<T>
+
+nopers(%error : @owned $any Error):
+  throw %error : $any Error
+}
+
 // CHECK-LABEL: sil [ossa] @fixeeLifetime : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] : $*T):
 // CHECK:         fix_lifetime [[ADDR]]

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -941,6 +941,7 @@ bb0(%0 : @owned $P):
 // CHECK: bb0(%0 : $*any P):
 // CHECK:   [[ALLOCP:%.*]] = alloc_stack $any P, var, name "q"
 // CHECK:   copy_addr %0 to [init] [[ALLOCP]] : $*any P
+// CHECK:   debug_value %0 : $*any P, var, name "q"
 // CHECK:   [[OPEN:%.*]] = open_existential_addr immutable_access %0 : $*any P to $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
 // CHECK:   [[OPTIONAL:%.*]] = alloc_stack $Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>
 // CHECK:   witness_method $@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self, #P.foo : <Self where Self : P> (Self) -> () -> (), [[OPEN]] : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1130,6 +1130,24 @@ bb4:
   return %31 : $()
 }
 
+// Verify the handling of non-unique default case blocks when there is more
+// than one case handled by default.
+// CHECK-LABEL: sil [ossa] @f221_testSwitchDefault : $@convention(thin) <T> (@in Optional<T>) -> () {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : $*Optional<T>):
+// CHECK:         switch_enum_addr [[INSTANCE]] : $*Optional<T>, default [[EXIT:bb[0-9]+]]
+// CHECK:       [[EXIT]]:
+// CHECK:         destroy_addr [[INSTANCE]] : $*Optional<T>
+// CHECK-LABEL: } // end sil function 'f221_testSwitchDefault'
+sil [ossa] @f221_testSwitchDefault : $@convention(thin) <T> (@in Optional<T>) -> () {
+entry(%instance : @owned $Optional<T>):
+  switch_enum %instance : $Optional<T>, default exit
+
+exit(%instance_2 : @owned $Optional<T>):
+  destroy_value %instance_2 : $Optional<T>
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // CHECK-LABEL: sil [ossa] @f230_testTryApply : $@convention(thin) <T> (@in T) -> (@out T, @error any Error) {
 // CHECK: bb0(%0 : $*T, %1 : $*T):
 // CHECK:   [[F:%.*]] = function_ref @throwsError : $@convention(thin) <τ_0_0> (@in τ_0_0) -> (@out τ_0_0, @error any Error)

--- a/test/SILOptimizer/address_lowering_phi.sil
+++ b/test/SILOptimizer/address_lowering_phi.sil
@@ -500,3 +500,20 @@ merge(%34 : @owned $Value):
   %43 = tuple ()
   return %43 : $()
 }
+
+// CHECK-LABEL: sil [ossa] @f105_phi_into_tuple : {{.*}} {
+// CHECK:         [[STORAGE:%[^,]+]] = alloc_stack $(Self, Builtin.Int1)          
+// CHECK:         [[SELF_ADDR:%[^,]+]] = tuple_element_addr [[STORAGE]]
+// CHECK:         apply {{%[^,]+}}<Self>([[SELF_ADDR]])
+// CHECK-LABEL: } // end sil function 'f105_phi_into_tuple'
+sil [ossa] @f105_phi_into_tuple : $@convention(thin) <Self> () -> () {
+  %getOut = function_ref @getOut : $@convention(thin) <T> () -> @out T
+  %self = apply %getOut<Self>() : $@convention(thin) <τ_0_0> () -> @out τ_0_0
+  br exit(%self : $Self)
+
+exit(%self_2 : @owned $Self):
+  %tuple = tuple (%self_2 : $Self, undef : $Bool)
+  destroy_value %tuple : $(Self, Bool)
+  %retval = tuple ()
+  return %retval : $()
+}

--- a/test/SILOptimizer/address_lowering_phi.sil
+++ b/test/SILOptimizer/address_lowering_phi.sil
@@ -470,3 +470,33 @@ bb2:
 bb3(%phi : @owned $T):
   return %phi : $T
 }
+
+// Check that the debug_value instruction that is created when deleting a load
+// gets rewritten and doesn't obstruct the deletion of the phi.
+// CHECK-LABEL: sil [ossa] @f100_store_phi : {{.*}} {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : $*Value):
+// CHECK:         [[TEMP:%[^,]+]] = alloc_stack $Value
+// CHECK:         [[VAR:%[^,]+]] = alloc_stack [lexical] $Value, var, name "value"
+// CHECK:         cond_br undef, bb2, bb1
+// CHECK:       bb3:
+// CHECK:         copy_addr [take] [[TEMP]] to [init] [[VAR]]
+// CHECK:         debug_value [[TEMP]] : $*Value, var, name "value"
+// CHECK-LABEL: } // end sil function 'f100_store_phi'
+sil [ossa] @f100_store_phi : $@convention(thin) <Value> (@in Value) -> () {
+entry(%instance : @owned $Value):
+  %14 = alloc_stack [lexical] $Value, var, name "value"
+  cond_br undef, left, right
+
+left:
+  br merge(%instance : $Value)
+
+right:
+  br merge(%instance : $Value)
+
+merge(%34 : @owned $Value):
+  store %34 to [init] %14 : $*Value
+  destroy_addr %14 : $*Value
+  dealloc_stack %14 : $*Value
+  %43 = tuple ()
+  return %43 : $()
+}

--- a/test/SILOptimizer/address_lowering_phi.sil
+++ b/test/SILOptimizer/address_lowering_phi.sil
@@ -15,6 +15,8 @@ enum Optional<T> {
   case some(T)
 }
 
+struct S {}
+
 struct SRef<T> {
   @_hasStorage var object: AnyObject { get set }
   @_hasStorage var element: T { get set }
@@ -514,6 +516,23 @@ sil [ossa] @f105_phi_into_tuple : $@convention(thin) <Self> () -> () {
 exit(%self_2 : @owned $Self):
   %tuple = tuple (%self_2 : $Self, undef : $Bool)
   destroy_value %tuple : $(Self, Bool)
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Check deleting the first of multiple block arguments.
+// CHECK-LABEL: sil [ossa] @f110_nonfinal_argument : {{.*}} {
+// CHECK:       bb3({{%[^,]+}} : $S):
+// CHECK-LABEL: } // end sil function 'f110_nonfinal_argument'
+sil [ossa] @f110_nonfinal_argument : $@convention(thin) <T> (@in T, S) -> () {
+entry(%instance : @owned $T, %s : $S):
+  cond_br undef, left, right
+left:
+  br exit(%instance : $T, %s : $S)
+right:
+  br exit(%instance : $T, %s : $S)
+exit(%instance_2 : @owned $T, %s_2 : $S):
+  destroy_value %instance_2 : $T
   %retval = tuple ()
   return %retval : $()
 }

--- a/test/SILOptimizer/closure_specialize_loop.swift
+++ b/test/SILOptimizer/closure_specialize_loop.swift
@@ -14,3 +14,68 @@ public func testit(c: @escaping () -> Bool) {
   }
 }
 
+// PR: https://github.com/apple/swift/pull/61956
+// Optimizing Expression.contains(where:) should not timeout.
+//
+// Repeated capture propagation leads to:
+//   func contains$termPred@arg0$[termPred$falsePred@arg1]@arg1(expr) {
+//     closure = termPred$[termPred$falsePred@arg1]@arg1
+//     falsePred(expr)
+//     contains$termPred@arg0$termPred$[termPred$falsePred@arg1]@arg1(expr)
+//   }
+//
+//   func contains$termPred@arg0$termPred$[termPred$falsePred@arg1]@arg1(expr) {
+//   closure = [termPred(termPred$[termPred$falsePred@arg1]@arg1)]
+//   closure(expr)
+//   contains$termPred@arg0(expr, closure)
+// }
+// The Demangled type tree looks like:
+//   kind=FunctionSignatureSpecialization
+//     kind=SpecializationPassID, index=3
+//     kind=FunctionSignatureSpecializationParam
+//     kind=FunctionSignatureSpecializationParam
+//       kind=FunctionSignatureSpecializationParamKind, index=0
+//       kind=FunctionSignatureSpecializationParamPayload, text="$s4test10ExpressionO8contains5whereS3bXE_tFSbACXEfU_S2bXEfU_36$s4test12IndirectEnumVACycfcS2bXEfU_Tf3npf_n"
+//
+// CHECK-LABEL: $s23closure_specialize_loop10ExpressionO8contains5whereS3bXE_tFSbACXEfU_S2bXEfU_012$s23closure_b7_loop10d44O8contains5whereS3bXE_tFSbACXEfU_S2bXEfU_012g13_b7_loop10d44ijk2_tlm2U_no52U_012g30_B34_loop12IndirectEnumVACycfcnO10U_Tf3npf_nY2_nTf3npf_n
+// ---> function signature specialization
+//     <Arg[1] = [Constant Propagated Function : function signature specialization
+//                <Arg[1] = [Constant Propagated Function : function signature specialization
+//                           <Arg[1] = [Constant Propagated Function : closure #1 (Swift.Bool) -> Swift.Bool
+//                                      in closure_specialize_loop.IndirectEnum.init() -> closure_specialize_loop.IndirectEnum]>
+//                           of closure #1 (Swift.Bool) -> Swift.Bool
+//                           in closure #1 (closure_specialize_loop.Expression) -> Swift.Bool
+//                           in closure_specialize_loop.Expression.contains(where: (Swift.Bool) -> Swift.Bool) -> Swift.Bool]>
+//                of closure #1 (Swift.Bool) -> Swift.Bool
+//                in closure #1 (closure_specialize_loop.Expression) -> Swift.Bool
+//                in closure_specialize_loop.Expression.contains(where: (Swift.Bool) -> Swift.Bool) -> Swift.Bool]>
+//     of closure #1 (Swift.Bool) -> Swift.Bool
+//     in closure #1 (closure_specialize_loop.Expression) -> Swift.Bool
+//     in closure_specialize_loop.Expression.contains(where: (Swift.Bool) -> Swift.Bool) -> Swift.Bool
+//
+public indirect enum Expression {
+    case term(Bool)
+    case list(_ expressions: [Expression])
+
+    public func contains(where predicate: (Bool) -> Bool) -> Bool {
+        switch self {
+        case let .term(term):
+            return predicate(term)
+        case let .list(expressions):
+            return expressions.contains { expression in
+                expression.contains { term in
+                    predicate(term)
+                }
+            }
+        }
+    }
+}
+
+public struct IndirectEnum {
+    public init() {
+        let containsFalse = Expression.list([.list([.term(true), .term(false)]), .term(true)]).contains { term in
+            term == false
+        }
+        print(containsFalse)
+    }
+}


### PR DESCRIPTION
When a block argument is a terminator result from a `try_apply`, use the ApplyRewriter to convert the `try_apply`.

In the case where the result is stored into an enum, with this change, the `init_enum_data_addr` instruction is created prior to the `try_apply`, which is necessary in order for it to be passed as an argument to the `try_apply`.

Based on https://github.com/apple/swift/pull/61950 .
