### PR TITLE
[IRGen] Generate proper TypeLayout for singleton enums

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -382,16 +382,21 @@ namespace {
 
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
-       if (ElementsWithPayload.empty())
-         return IGM.typeLayoutCache.getEmptyEntry();
-       if (!ElementsAreABIAccessible)
-         return IGM.typeLayoutCache.getOrCreateResilientEntry(T);
-       if (TIK >= Loadable) {
-         return IGM.typeLayoutCache.getOrCreateScalarEntry(getTypeInfo(), T);
-       }
+      if (ElementsWithPayload.empty())
+        return IGM.typeLayoutCache.getEmptyEntry();
+      if (!ElementsAreABIAccessible)
+        return IGM.typeLayoutCache.getOrCreateResilientEntry(T);
+      if (TIK >= Loadable) {
+        return IGM.typeLayoutCache.getOrCreateScalarEntry(getTypeInfo(), T);
+      }
 
-       return getSingleton()->buildTypeLayoutEntry(IGM,
-                                                   getSingletonType(IGM, T));
+      unsigned emptyCases = 0;
+      std::vector<TypeLayoutEntry *> nonEmptyCases;
+      nonEmptyCases.push_back(
+        getSingleton()->buildTypeLayoutEntry(IGM,
+                                             getSingletonType(IGM, T)));
+      return IGM.typeLayoutCache.getOrCreateEnumEntry(emptyCases,
+                                                      nonEmptyCases);
     }
 
     llvm::Value *

--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -1457,6 +1457,8 @@ EnumTypeLayoutEntry::CopyDestroyStrategy
 EnumTypeLayoutEntry::copyDestroyKind(IRGenFunction &IGF) const {
   if (isPOD()) {
     return POD;
+  } else if (isSingleton()) {
+    return ForwardToPayload;
   } else if (cases.size() == 1 && numEmptyCases <= 1 &&
              cases[0]->isSingleRetainablePointer()) {
     return NullableRefcounted;
@@ -2490,7 +2492,7 @@ void EnumTypeLayoutEntry::destructiveInjectEnumTag(IRGenFunction &IGF,
   if (isSingleton()) {
     // No tag, nothing to do
     return;
-  } if (cases.size() == 1) {
+  } else if (cases.size() == 1) {
     auto payload = cases[0];
     auto emptyCases = IGF.IGM.getInt32(numEmptyCases);
     payload->storeEnumTagSinglePayload(IGF, tag, emptyCases, enumAddr);

--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -1478,7 +1478,9 @@ llvm::Value *EnumTypeLayoutEntry::size(IRGenFunction &IGF) const {
   auto &ctx = IGM.getLLVMContext();
 
   auto emptyCaseCount = IGM.getInt32(numEmptyCases);
-  if (cases.size() == 1) {
+  if (cases.size() == 1 && numEmptyCases == 0) {
+    return cases[0]->size(IGF);
+  } else if (cases.size() == 1) {
     // Single payload enum.
     // // If there are enough extra inhabitants for all of the cases, then the
     // // size of the enum is the same as its payload.
@@ -1572,7 +1574,10 @@ llvm::Optional<Size> EnumTypeLayoutEntry::fixedSize(IRGenModule &IGM) const {
   if (_fixedSize)
     return *_fixedSize;
   assert(!cases.empty());
-  if (cases.size() == 1) {
+
+  if (cases.size() == 1 && numEmptyCases == 0) {
+    return cases[0]->fixedSize(IGM);
+  } else if (cases.size() == 1) {
     // Single payload enum.
     //
     // If there are enough extra inhabitants for all of the cases, then the
@@ -1634,7 +1639,9 @@ EnumTypeLayoutEntry::fixedXICount(IRGenModule &IGM) const {
     return *_fixedXICount;
   assert(!cases.empty());
 
-  if (cases.size() == 1) {
+  if (cases.size() == 1 && numEmptyCases == 0) {
+    return cases[0]->fixedXICount(IGM);
+  } else if (cases.size() == 1) {
     // Single payload enum.
     // unsigned unusedExtraInhabitants =
     //   payloadNumExtraInhabitants >= emptyCases ?
@@ -1679,7 +1686,9 @@ llvm::Value *EnumTypeLayoutEntry::extraInhabitantCount(IRGenFunction &IGF) const
   auto &IGM = IGF.IGM;
   auto &Builder = IGF.Builder;
 
-  if (cases.size() == 1) {
+  if (cases.size() == 1 && numEmptyCases == 0) {
+    return cases[0]->extraInhabitantCount(IGF);
+  } else if (cases.size() == 1) {
     // Single payload enum.
     // unsigned unusedExtraInhabitants =
     //   payloadNumExtraInhabitants >= emptyCases ?
@@ -2213,7 +2222,9 @@ llvm::Value *EnumTypeLayoutEntry::getEnumTagSinglePayloadForSinglePayloadEnum(
 llvm::Value *EnumTypeLayoutEntry::getEnumTagSinglePayload(
     IRGenFunction &IGF, llvm::Value *emptyCases, Address addr) const {
   assert(!cases.empty());
-  if (cases.size() == 1) {
+  if (cases.size() == 1 && numEmptyCases == 0) {
+    return cases[0]->getEnumTagSinglePayload(IGF, emptyCases, addr);
+  } else if (cases.size() == 1) {
     return getEnumTagSinglePayloadForSinglePayloadEnum(IGF, addr, emptyCases);
   }
   return getEnumTagSinglePayloadForMultiPayloadEnum(IGF, addr, emptyCases);
@@ -2292,7 +2303,9 @@ void EnumTypeLayoutEntry::storeEnumTagSinglePayload(IRGenFunction &IGF,
                                                     llvm::Value *emptyCases,
                                                     Address addr) const {
   assert(!cases.empty());
-  if (cases.size() == 1) {
+  if (cases.size() == 1 && numEmptyCases == 0) {
+    return cases[0]->storeEnumTagSinglePayload(IGF, tag, emptyCases, addr);
+  } else if (cases.size() == 1) {
     storeEnumTagSinglePayloadForSinglePayloadEnum(IGF, tag, emptyCases, addr);
     return;
   }

--- a/lib/IRGen/TypeLayout.h
+++ b/lib/IRGen/TypeLayout.h
@@ -474,6 +474,7 @@ public:
                                 Address enumAddr) const;
 
   bool isMultiPayloadEnum() const;
+  bool isSingleton() const;
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   void dump() const override;

--- a/test/IRGen/enum_singleton.swift
+++ b/test/IRGen/enum_singleton.swift
@@ -31,6 +31,11 @@ public enum SingletonEnum {
 // CHECK-OPT:   ret %swift.opaque* [[R2]]
 // CHECK: }
 
+// CHECK: define internal i32 @"$s14enum_singleton13SingletonEnumOwet"
+// CHECK-OPT:   [[R2:%.*]] = tail call i32 @"{{.*}}OwetTm"
+// CHECK-OPT:   ret i32 [[R2]]
+// CHECK: }
+
 // CHECK: define internal void @"$s14enum_singleton13SingletonEnumOwst"
 // CHECK-OPT:   tail call void @"{{.*}}OwstTm"
 // CHECK-OPT:   ret void

--- a/test/IRGen/enum_singleton.swift
+++ b/test/IRGen/enum_singleton.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK
+// RUN: %target-swift-frontend -emit-ir -O %s | %FileCheck %s --check-prefix=CHECK
+
+public enum Payload {
+  case c1(Bool)
+  case c2(Bool)
+  case c3(Any)
+}
+
+public enum SingletonEnum {
+  case c1(Payload)
+}
+
+// CHECK: define internal i32 @"$s14enum_singleton13SingletonEnumOwug"
+// CHECK:   ret i32 0
+// CHECK: }
+
+// CHECK: define internal void @"$s14enum_singleton13SingletonEnumOwup"
+// CHECK:   ret void
+// CHECK: }

--- a/test/IRGen/enum_singleton.swift
+++ b/test/IRGen/enum_singleton.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK
-// RUN: %target-swift-frontend -emit-ir -O %s | %FileCheck %s --check-prefix=CHECK
+// RUN: %target-swift-frontend -emit-ir -O %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-OPT
 
 public enum Payload {
   case c1(Bool)
@@ -11,10 +11,39 @@ public enum SingletonEnum {
   case c1(Payload)
 }
 
+// CHECK: define internal void @"$s14enum_singleton13SingletonEnumOwxx"
+// CHECK-OPT:   tail call void @"{{.*}}OwxxTm"
+// CHECK:   ret void
+// CHECK: }
+
+// CHECK: define internal %swift.opaque* @"$s14enum_singleton13SingletonEnumOwcp"
+// CHECK-OPT:   [[R0:%.*]] = tail call %swift.opaque* @"{{.*}}OwcpTm"
+// CHECK-OPT:   ret %swift.opaque* [[R0]]
+// CHECK: }
+
+// CHECK: define internal %swift.opaque* @"$s14enum_singleton13SingletonEnumOwca"
+// CHECK-OPT:   [[R1:%.*]] = tail call %swift.opaque* @"{{.*}}OwcaTm"
+// CHECK-OPT:   ret %swift.opaque* [[R1]]
+// CHECK: }
+
+// CHECK: define internal %swift.opaque* @"$s14enum_singleton13SingletonEnumOwta"
+// CHECK-OPT:   [[R2:%.*]] = tail call %swift.opaque* @"{{.*}}OwtaTm"
+// CHECK-OPT:   ret %swift.opaque* [[R2]]
+// CHECK: }
+
+// CHECK: define internal void @"$s14enum_singleton13SingletonEnumOwst"
+// CHECK-OPT:   tail call void @"{{.*}}OwstTm"
+// CHECK-OPT:   ret void
+// CHECK: }
+
 // CHECK: define internal i32 @"$s14enum_singleton13SingletonEnumOwug"
 // CHECK:   ret i32 0
 // CHECK: }
 
 // CHECK: define internal void @"$s14enum_singleton13SingletonEnumOwup"
+// CHECK:   ret void
+// CHECK: }
+
+// CHECK: define internal void @"$s14enum_singleton13SingletonEnumOwui"
 // CHECK:   ret void
 // CHECK: }


### PR DESCRIPTION
rdar://101587387

Instead of creating a proper TypeLayout, we returned the layout for the singleton case, which caused the tags for the nested cases cases to be returned, instead of the expected `0` for singleton enums.

