### PR TITLE
IRGen: Gracefully handle protocol forward declaration references without definitions

### DIFF
--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -515,6 +515,12 @@ static void updateProtocolRefs(IRGenModule &IGM,
     auto oldVar = protocolRefs->getOperand(currentIdx);
     // Map the objc protocol to swift protocol.
     auto optionalDecl = clangImporter->importDeclCached(inheritedObjCProtocol);
+    // This should not happen but the compiler currently silently accepts
+    // protocol forward declarations without definitions (102058759).
+    if (!optionalDecl || *optionalDecl == nullptr) {
+      ++currentIdx;
+      continue;
+    }
     auto inheritedSwiftProtocol = cast<ProtocolDecl>(*optionalDecl);
     // Get the objc protocol record we use in Swift.
     auto record = IGM.getAddrOfObjCProtocolRecord(inheritedSwiftProtocol,

--- a/test/IRGen/Inputs/usr/include/Gizmo.h
+++ b/test/IRGen/Inputs/usr/include/Gizmo.h
@@ -200,3 +200,10 @@ __attribute__((objc_non_runtime_protocol))
 
 @protocol Runtime2P<NonRuntimeP, OtherNonRuntimeP, P3>
 @end
+
+
+@protocol DeclarationOnly;
+
+@protocol DeclarationOnlyUser<DeclarationOnly>
+- (void) printIt;
+@end

--- a/test/IRGen/objc_protocols.swift
+++ b/test/IRGen/objc_protocols.swift
@@ -222,3 +222,9 @@ func triggerDoubleInheritedFunging() -> AnyObject {
 class TestNonRuntimeProto : RuntimeP { }
 
 class TestNonRuntime2Proto : Runtime2P {}
+
+public class SomeImpl : DeclarationOnlyUser {
+    public func printIt() {
+        print("hello")
+    }
+}


### PR DESCRIPTION
```
 @protocol DeclarationOnly;

 @protocol DeclarationOnlyUser<DeclarationOnly>
 - (void) printIt;
 @end
```

This should not be neccessary, but the compiler currently accepts cases like the one in the test case added.

rdar://101828847
