### PR TITLE
[move-only] Emit a nice error if a move only type is imported into a module that does not have experimental-move-only enabled.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6528,6 +6528,11 @@ ERROR(experimental_moveonly_feature_can_only_be_used_when_enabled,
       none, "Can not use feature when experimental move only is disabled! Pass"
       " the frontend flag -enable-experimental-move-only to swift to enable "
       "the usage of this language feature", ())
+ERROR(experimental_moveonly_feature_can_only_be_imported_when_enabled,
+      none, "Can not import module %0 that uses move only features when "
+      "experimental move only is disabled! Pass the frontend flag "
+      "-enable-experimental-move-only to swift to enable the usage of this "
+      "language feature", (Identifier))
 ERROR(noimplicitcopy_attr_valid_only_on_local_let_params,
       none, "'@_noImplicitCopy' attribute can only be applied to local lets and params", ())
 ERROR(noimplicitcopy_attr_invalid_in_generic_context,

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -16,6 +16,7 @@
 #include "ModuleFormat.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Attr.h"
+#include "swift/AST/AttrKind.h"
 #include "swift/AST/AutoDiff.h"
 #include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/Expr.h"
@@ -24,18 +25,18 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/NameLookupRequests.h"
-#include "swift/AST/Pattern.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/Pattern.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/TypeCheckRequests.h"
+#include "swift/Basic/Defer.h"
+#include "swift/Basic/Statistic.h"
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/ClangImporter/SwiftAbstractBasicReader.h"
 #include "swift/Serialization/SerializedModuleLoader.h"
-#include "swift/Basic/Defer.h"
-#include "swift/Basic/Statistic.h"
 #include "clang/AST/DeclTemplate.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Compiler.h"
@@ -5129,6 +5130,17 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
       default:
         // We don't know how to deserialize this kind of attribute.
         MF.fatal(llvm::make_error<InvalidRecordKindError>(recordID));
+      }
+
+      // Do a quick check to see if this attribute is a move only attribute. If
+      // so, emit a nice error if we don't have experimental move only enabled.
+      if (Attr->getKind() == DeclAttrKind::DAK_MoveOnly &&
+          !MF.getContext().LangOpts.Features.contains(Feature::MoveOnly)) {
+        MF.getContext().Diags.diagnose(
+            SourceLoc(),
+            diag::
+                experimental_moveonly_feature_can_only_be_imported_when_enabled,
+            MF.getAssociatedModule()->getName());
       }
 
       if (!skipAttr) {

--- a/test/Serialization/Inputs/moveonly_klass.swift
+++ b/test/Serialization/Inputs/moveonly_klass.swift
@@ -1,0 +1,3 @@
+
+@_moveOnly
+public class Klass {}

--- a/test/Serialization/moveonly.swift
+++ b/test/Serialization/moveonly.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t/Library.swiftmodule -module-name Library %S/Inputs/moveonly_klass.swift -enable-experimental-move-only
+// RUN: not %target-swift-frontend -I %t %s -emit-sil -o /dev/null 2>&1 | %FileCheck %s
+
+// This test makes sure that if we import a move only type and do not set the
+// experimental move only flag, we get a nice error.
+
+import Library
+
+// CHECK: error: Can not import module 'Library' that uses move only features when experimental move only is disabled! Pass the frontend flag -enable-experimental-move-only to swift to enable the usage of this language feature
+
+func f(_ k: Klass) {
+}


### PR DESCRIPTION
This just prevents user confusion when they forget to do this since weird behavior /could/ result.

rdar://102062737
