### PR TITLE
[move-only] When the move only experimental option is disabled do not run the move passes.

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveKillsCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveKillsCopyableAddressesChecker.cpp
@@ -2427,6 +2427,10 @@ class MoveKillsCopyableAddressesCheckerPass : public SILFunctionTransform {
     auto *fn = getFunction();
     auto &astContext = fn->getASTContext();
 
+    // Only run this pass if the move only language feature is enabled.
+    if (!astContext.LangOpts.Features.contains(Feature::MoveOnly))
+      return;
+
     // Don't rerun diagnostics on deserialized functions.
     if (getFunction()->wasDeserializedCanonical())
       return;

--- a/lib/SILOptimizer/Mandatory/MoveKillsCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveKillsCopyableValuesChecker.cpp
@@ -524,8 +524,12 @@ class MoveKillsCopyableValuesCheckerPass : public SILFunctionTransform {
   void run() override {
     auto *fn = getFunction();
 
+    // Only run this pass if the move only language feature is enabled.
+    if (!fn->getASTContext().LangOpts.Features.contains(Feature::MoveOnly))
+      return;
+
     // Don't rerun diagnostics on deserialized functions.
-    if (getFunction()->wasDeserializedCanonical())
+    if (fn->wasDeserializedCanonical())
       return;
 
     assert(fn->getModule().getStage() == SILStage::Raw &&

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
@@ -1729,6 +1729,10 @@ class MoveOnlyCheckerPass : public SILFunctionTransform {
   void run() override {
     auto *fn = getFunction();
 
+    // Only run this pass if the move only language feature is enabled.
+    if (!fn->getASTContext().LangOpts.Features.contains(Feature::MoveOnly))
+      return;
+
     // Don't rerun diagnostics on deserialized functions.
     if (getFunction()->wasDeserializedCanonical())
       return;

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
@@ -542,6 +542,10 @@ class MoveOnlyCheckerPass : public SILFunctionTransform {
   void run() override {
     auto *fn = getFunction();
 
+    // Only run this pass if the move only language feature is enabled.
+    if (!fn->getASTContext().LangOpts.Features.contains(Feature::MoveOnly))
+      return;
+
     // Don't rerun diagnostics on deserialized functions.
     if (getFunction()->wasDeserializedCanonical())
       return;

--- a/test/SILOptimizer/move_function_kills_addresses_dbginfo.sil
+++ b/test/SILOptimizer/move_function_kills_addresses_dbginfo.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt %s -sil-move-kills-copyable-addresses-checker | %FileCheck %s
+// RUN: %target-sil-opt %s -enable-experimental-move-only -sil-move-kills-copyable-addresses-checker | %FileCheck %s
 
 // REQUIRES: optimized_stdlib
 

--- a/test/SILOptimizer/move_function_kills_copyable_addresses.sil
+++ b/test/SILOptimizer/move_function_kills_copyable_addresses.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -o - -sil-move-kills-copyable-addresses-checker -verify %s
+// RUN: %target-sil-opt -enable-experimental-move-only -enable-sil-verify-all -o - -sil-move-kills-copyable-addresses-checker -verify %s
 
 // This file is meant for specific SIL patterns that may be hard to produce with
 // the current swift frontend but have reproduced before and we want to make

--- a/test/SILOptimizer/move_function_kills_copyable_values.sil
+++ b/test/SILOptimizer/move_function_kills_copyable_values.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-verify-all -o - -sil-move-kills-copyable-values-checker -verify %s
+// RUN: %target-sil-opt -enable-experimental-move-only -enable-sil-verify-all -o - -sil-move-kills-copyable-values-checker -verify %s
 
 // This file is meant for specific SIL patterns that may be hard to produce with
 // the current swift frontend but have reproduced before and we want to make

--- a/test/SILOptimizer/move_function_kills_values_dbginfo.sil
+++ b/test/SILOptimizer/move_function_kills_values_dbginfo.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt %s -sil-move-kills-copyable-values-checker | %FileCheck %s
+// RUN: %target-sil-opt %s -enable-experimental-move-only -sil-move-kills-copyable-values-checker | %FileCheck %s
 
 // REQUIRES: optimized_stdlib
 


### PR DESCRIPTION
Just trying to prevent crashy behavior that can occur if a user tries to use move only without passing in the flag.

rdar://102059799
