### PR TITLE
[Dependency Scanning] Configure the Clang dependency scanner to generate PCM output paths

### DIFF
--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -230,7 +230,7 @@ GlobalModuleDependenciesCache::GlobalModuleDependenciesCache()
                          clang::tooling::dependencies::ScanningMode::DependencyDirectivesScan,
                          clang::tooling::dependencies::ScanningOutputFormat::Full,
                          clang::CASOptions(),
-                         /* Cache */ nullptr,
+                         /* Cache (llvm::cas::ActionCache) */ nullptr,
                          /* SharedFS */ nullptr,
                          /* ReuseFileManager */ false,
                          /* OptimizeArgs */ false) {}

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -210,6 +210,10 @@ import SubE
 
 /// --------Clang module B
 // CHECK-LABEL: "modulePath": "B.pcm"
+// CHECK: "contextHash": [[B_CONTEXT:"{{.*}}"]],
+// CHECK: "-o"
+// CHECK-NEXT: "-Xcc"
+// CHECK-NEXT: "%t/clang-module-cache/B-[[B_CONTEXT]].pcm",
 
 // CHECK-NEXT: sourceFiles
 // CHECK-DAG: module.modulemap
@@ -222,7 +226,11 @@ import SubE
 
 /// --------Clang module SwiftShims
 // CHECK-LABEL: "modulePath": "SwiftShims.pcm",
-
+// CHECK: "contextHash": [[SHIMS_CONTEXT:"{{.*}}"]],
+// CHECK: "-o"
+// CHECK-NEXT: "-Xcc"
+// CHECK-NEXT: "%t/clang-module-cache/SwiftShims-[[SHIMS_CONTEXT]].pcm",
+// CHECK: "-fmodule-file=A=%t/clang-module-cache/A-{{.*}}.pcm"
 // CHECK-NO-SEARCH-PATHS-NOT: "-prebuilt-module-cache-path"
 
 // Check make-style dependencies


### PR DESCRIPTION
Using the convention of : `<Module_Cache_Path> + "/" + <Module_Name> + "-" + <Context_Hash> + ".pcm"`.

Instead of relying on a placeholder string of `<replace-me>` to be fixed up by the driver. 

Corresponding driver change in: https://github.com/apple/swift-driver/pull/1219
