### PR TITLE
[Macros] Ensure that macro expansion parsing has appropriate context.

### DIFF
--- a/include/swift/Parse/LocalContext.h
+++ b/include/swift/Parse/LocalContext.h
@@ -58,7 +58,12 @@ public:
   /// True if we saw any anonymous closures.  This is useful when
   /// parsing an initializer context, because such contexts only
   /// need to exist if the initializer contains closures.
-  bool hasClosures() const { return NextClosureDiscriminator != 0; }    
+  bool hasClosures() const { return NextClosureDiscriminator != 0; }
+
+  /// Override the next closure discriminator value.
+  void overrideNextClosureDiscriminator(unsigned discriminator) {
+    NextClosureDiscriminator = discriminator;
+  }
 };
 
 /// Information associated with parsing the top-level context.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1499,6 +1499,22 @@ diagnoseAndRemoveAttr(const Decl *D, const DeclAttribute *attr,
   return diagnoseAttrWithRemovalFixIt(D, attr, std::forward<ArgTypes>(Args)...);
 }
 
+/// Look for closure discriminators within an AST.
+class DiscriminatorFinder : public ASTWalker {
+  unsigned FirstDiscriminator = AbstractClosureExpr::InvalidDiscriminator;
+  unsigned NextDiscriminator = 0;
+
+public:
+  PostWalkResult<Expr *> walkToExprPost(Expr *E) override;
+
+  // Get the next available closure discriminator.
+  unsigned getNextDiscriminator();
+
+  unsigned getFirstDiscriminator() const {
+    return FirstDiscriminator;
+  }
+};
+
 } // end namespace swift
 
 #endif

--- a/test/Macros/macros.swift
+++ b/test/Macros/macros.swift
@@ -7,4 +7,9 @@ func test(a: Int, b: Int) {
   // CHECK: macro_expansion_expr type='(Int, String)'{{.*}}name=stringify
   // CHECK-NEXT: argument_list
   // CHECK: tuple_expr type='(Int, String)' location=Macro expansion of #stringify
+
+  let (b, s2) = #stringify({ () -> Bool in return true })
+  // CHECK: macro_expansion_expr type='(() -> Bool, String)'{{.*}}name=stringify
+  // CHECK-NEXT: argument_list
+  // CHECK: tuple_expr type='(() -> Bool, String)' location=Macro expansion of #stringify
 }


### PR DESCRIPTION
The parser needs context to do completely reasonable things like... parse closures.
