### PR TITLE
tests: fix misspelled check prefixes

### DIFF
--- a/test/AutoDiff/SILOptimizer/activity_analysis.swift
+++ b/test/AutoDiff/SILOptimizer/activity_analysis.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -verify -Xllvm -debug-only=differentiation 2>&1 %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -verify -Xllvm -debug-only=differentiation %s  2>&1 | %FileCheck %s
 // REQUIRES: asserts
 
 import _Differentiation
@@ -456,7 +456,7 @@ func activeInoutArgMutatingMethodVar(_ nonactive: inout Mut, _ x: Mut) {
   nonactive = result
 }
 
-// CHECK_LABEL: [AD] Activity info for ${{.*}}31activeInoutArgMutatingMethodVaryyAA3MutVz_ADtF at (parameters=(1) results=(0))
+// CHECK-LABEL: [AD] Activity info for ${{.*}}31activeInoutArgMutatingMethodVaryyAA3MutVz_ADtF at parameter indices (1) and result indices (0)
 // CHECK: [ACTIVE] %0 = argument of bb0 : $*Mut
 // CHECK: [ACTIVE] %1 = argument of bb0 : $Mut
 // CHECK: [ACTIVE]   %4 = alloc_stack $Mut, var, name "result"

--- a/test/Concurrency/Runtime/exclusivity.swift
+++ b/test/Concurrency/Runtime/exclusivity.swift
@@ -479,8 +479,8 @@ struct Runner {
         // CHECK-NEXT: SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): (0x0, 0x0)
         // CHECK-NEXT: Access. Pointer: [[ACCESS]]. PC:
         // CHECK: Exiting Thread Local Context. After Swizzle. Task: [[TASK]]
-        // CHECK_NEXT: SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): ([[LLNODE]], [[LLNODE]])
-        // CHECK_NEXT: No Accesses.
+        // CHECK-NEXT: SwiftTaskThreadLocalContext: (FirstAccess,LastAccess): ([[LLNODE]], [[LLNODE]])
+        // CHECK-NEXT: No Accesses.
         //
         // CHECK-NOT: Removing access:
         // CHECK: ==> End Inner Task Handle

--- a/test/Concurrency/async_main.swift
+++ b/test/Concurrency/async_main.swift
@@ -40,7 +40,7 @@ func asyncFunc() async {
 
 
 // async_Main
-// CHECK-SIL_LABEL: sil hidden @async_Main : $@convention(thin) @async () -> () {
+// CHECK-SIL-LABEL: sil hidden @async_Main : $@convention(thin) @async () -> () {
 // call main
 // CHECK-SIL:  %0 = metatype $@thin MyProgram.Type             // user: %2
 // CHECK-SIL-NEXT:  // function_ref static MyProgram.$main()

--- a/test/DebugInfo/fnptr.swift
+++ b/test/DebugInfo/fnptr.swift
@@ -36,7 +36,7 @@ func main() -> Int64 {
     baz_fnptr(2.89)
 
     // CHECK-DAG: !DILocalVariable(name: "barz_fnptr",{{.*}} type: ![[BARZPT:[0-9]+]]
-    // AST_DAG: !DILocalVariable(name: "barz_fnptr",{{.*}} type: ![[BARZ_T:[0-9]+]]
+    // AST-DAG: !DILocalVariable(name: "barz_fnptr",{{.*}} type: ![[BARZ_T:[0-9]+]]
     // AST-DAG: ![[BARZ_T:[0-9]+]] = !DICompositeType({{.*}}, identifier: "$sS2fs5Int64VIegyyd_D")
     // CHECK-DAG: ![[BARZPT]] = !DICompositeType(tag: DW_TAG_structure_type,{{.*}} elements: ![[BARZMEMBERS:[0-9]+]]
     // CHECK-DAG: ![[BARZMEMBERS]] = !{![[BARZMEMBER:.*]], {{.*}}}

--- a/test/IDE/complete_func_reference.swift
+++ b/test/IDE/complete_func_reference.swift
@@ -121,7 +121,7 @@ do {
 }
 
 // ANY_INT: Begin completions
-// ANY_INT_DAG: Decl{{.*}}/TypeRelation[Convertible]: anyToInt(a:); name=anyToInt(a:)
+// ANY_INT-DAG: Decl{{.*}}/TypeRelation[Convertible]: anyToInt(a:)[#(Any) -> Int#]; name=anyToInt(a:)
 // ANY_INT-DAG: Decl{{.*}}/TypeRelation[Invalid]: intToVoid({#a: Int#})[#Void#];
 // ANY_INT-DAG: Decl{{.*}}/TypeRelation[Invalid]: anyToVoid({#a: Any#})[#Void#];
 // ANY_INT-DAG: Decl{{.*}}/TypeRelation[Invalid]: voidToVoid()[#Void#];

--- a/test/IDE/complete_keywords.swift
+++ b/test/IDE/complete_keywords.swift
@@ -30,7 +30,7 @@
 // KW_DECL-DAG: Keyword/None: override{{; name=.+$}}
 // KW_DECL-DAG: Keyword/None: postfix{{; name=.+$}}
 // KW_DECL-DAG: Keyword/None: prefix{{; name=.+$}}
-// KW_DECL_DAG: Keyword[precedencegroup]: precedencegroup{{; name=.+$}}
+// KW_DECL-DAG: Keyword[precedencegroup]: precedencegroup{{; name=.+$}}
 // KW_DECL-DAG: Keyword[private]/None: private{{; name=.+$}}
 // KW_DECL-DAG: Keyword[protocol]/None: protocol{{; name=.+$}}
 // KW_DECL-DAG: Keyword[public]/None: public{{; name=.+$}}

--- a/test/IDE/complete_property_delegate_attribute.swift
+++ b/test/IDE/complete_property_delegate_attribute.swift
@@ -47,12 +47,12 @@ struct TestStruct {
   // FIXME: No call patterns are suggested if we are completing in variable with multiple property wrappers (rdar://91480982)
   func sync1() {}
 
-  @MyStruct(arg1: MyEnum.east, #^SECOND_ARG_LABEL^#) var test4
-// SECOND_ARG_LABEL: Begin completions, 1 items
-// SECOND_ARG_LABEL-DAG: Pattern/Local/Flair[ArgLabels]:     {#arg2: Int#}[#Int#];
-// SECOND_ARG_LABEL: End completions
+  @MyStruct(arg1: MyEnum.east, #^SECOND_ARG1^#) var test4
+// SECOND_ARG1: Begin completions, 1 items
+// SECOND_ARG1-DAG: Pattern/Local/Flair[ArgLabels]:     {#arg2: Int#}[#Int#];
+// SECOND_ARG1: End completions
 
-  @MyStruct(arg1: MyEnum.east, #^SECOND_ARG_LABEL_NO_VAR?check=SECOND_ARG_LABEL^#)
+  @MyStruct(arg1: MyEnum.east, #^SECOND_ARG1_LABEL_NO_VAR?check=SECOND_ARG1^#)
 
   // FIXME: No call patterns are suggested if we are completing in variable with multiple property wrappers (rdar://91480982)
   func sync2() {}

--- a/test/IDE/conforming-methods-basic.swift
+++ b/test/IDE/conforming-methods-basic.swift
@@ -40,10 +40,10 @@ func testing(obj: C) {
 }
 
 // CHECK_1:      -----BEGIN CONFORMING METHOD LIST-----
-// CHECK_1_NEXT: - TypeName: C
-// CHECK_1_NEXT: - Members:
-// CHECK_1_NEXT:    - Name: returnsConcreteTarget1()
-// CHECK_1_NEXT:      TypeName: ConcreteTarget1
-// CHECK_1_NEXT:    - Name: returnsConcreteTarget1()
-// CHECK_1_NEXT:      TypeName: ConcreteTarget1
-// CHECK_1_NEXT: -----END CONFORMING METHOD LIST-----
+// CHECK_1-NEXT: - TypeName: C
+// CHECK_1-NEXT: - Members:
+// CHECK_1-NEXT:    - Name: returnsConcreteTarget1()
+// CHECK_1-NEXT:      TypeName: ConcreteTarget1
+// CHECK_1-NEXT:    - Name: returnsConcreteTarget2()
+// CHECK_1-NEXT:      TypeName: ConcreteTarget2
+// CHECK_1-NEXT: -----END CONFORMING METHOD LIST-----

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -69,7 +69,7 @@ func no_capture_descriptor(_ c: C, _ d: C, _ e: C, _ f: C, _ g: C) {
 // CHECK-LABEL: define hidden swiftcc { i8*, %swift.refcounted* } @"$s7closure9letEscape1fyycyyXE_tF"(i8* %0, %swift.opaque* %1)
 // CHECK: call zeroext i1 @swift_isEscapingClosureAtFileLocation(%swift.refcounted* {{.*}}, i8* getelementptr inbounds ({{.*}} [[FILENAME]]
 // OPT-LABEL: define hidden swiftcc { i8*, %swift.refcounted* } @"$s7closure9letEscape1fyycyyXE_tF"(i8* %0, %swift.opaque* %1)
-// OPT: call zeroext i1 @swift_isEscapingClosureAtFileLocation(%swift.refcounted* {{.*}}, i8* getelementptr inbounds ({{.*}} [[FILENAME]]
+// OPT: call zeroext i1 @swift_isEscapingClosureAtFileLocation(%swift.refcounted* {{.*}}, i8* {{(nonnull )?}}getelementptr inbounds ({{.*}} [[FILENAME]]
 func letEscape(f: () -> ()) -> () -> () {
   return withoutActuallyEscaping(f) { return $0 }
 }

--- a/test/IRGen/dllexport.swift
+++ b/test/IRGen/dllexport.swift
@@ -36,7 +36,7 @@ open class d {
 // CHECK-DAG: define dllexport swiftcc %swift.refcounted* @"$s9dllexport1cCfd"(%T9dllexport1cC*{{.*}})
 // CHECK-DAG-NO-OPT: define dllexport swiftcc %T9dllexport1cC* @"$s9dllexport1cCACycfc"(%T9dllexport1cC* %0)
 // CHECK-DAG-NO-OPT: define dllexport swiftcc %T9dllexport1cC* @"$s9dllexport1cCACycfC"(%swift.type* %0)
-// CHECK-DAG: define dllexport swiftcc i8* @"$s9dllexport2ciAA1cCvau"()
+// CHECK-DAG: define dllexport swiftcc {{(nonnull )?}}i8* @"$s9dllexport2ciAA1cCvau"()
 // CHECK-DAG-NO-OPT: define dllexport swiftcc void @"$s9dllexport1dC1m33_C57BA610BA35E21738CC992438E660E9LLyyF"(%T9dllexport1dC* %0)
 // CHECK-DAG-NO-OPT: define dllexport swiftcc void @"$s9dllexport1dCfD"(%T9dllexport1dC* %0)
 // CHECK-DAG: define dllexport swiftcc %swift.refcounted* @"$s9dllexport1dCfd"(%T9dllexport1dC*{{.*}})

--- a/test/IRGen/reflection_metadata.swift
+++ b/test/IRGen/reflection_metadata.swift
@@ -2,9 +2,7 @@
 // RUN: %target-swift-frontend -disable-reflection-names -emit-ir %s | %FileCheck %s --check-prefix=STRIP_REFLECTION_NAMES
 // RUN: %target-swift-frontend -disable-reflection-metadata -emit-ir %s | %FileCheck %s --check-prefix=STRIP_REFLECTION_METADATA
 
-// STRIP_REFLECTION_NAMES_DAG: section "{{[^"]*swift5_reflect|.sw5rfst\$B}}
-// STRIP_REFLECTION_NAMES_DAG: section "{{[^"]*swift5_fieldmd|.sw5flmd\$B}}
-// STRIP_REFLECTION_NAMES_DAG: section "{{[^"]*swift5_assocty|.sw5asty\$B}}
+// STRIP_REFLECTION_NAMES-DAG: section "{{[^"]*swift5_assocty|.sw5asty\$B}}
 // STRIP_REFLECTION_NAMES-DAG: section "{{[^"]*swift5_capture|.sw5cptr\$B}}
 // STRIP_REFLECTION_NAMES-DAG: section "{{[^"]*swift5_typeref|.sw5tyrf\$B}}
 // STRIP_REFLECTION_NAMES-DAG: private constant [6 x i8] c"Inner\00", section "{{[^"]*swift5_reflstr|.sw5rfst\$B}}

--- a/test/Interop/SwiftToC/structs/large-structs-pass-return-indirect-in-c.swift
+++ b/test/Interop/SwiftToC/structs/large-structs-pass-return-indirect-in-c.swift
@@ -11,7 +11,7 @@ public struct StructSeveralI64 {
 // CHECK-NEXT:   _Alignas(8) char _storage[40];
 // CHECK-NEXT: };
 
-// CHECK_NOT: swift_interop
+// CHECK-NOT: swift_interop
 
 public func returnNewStructSeveralI64(i: Int64) -> StructSeveralI64 {
     return StructSeveralI64(x1: i, x2: 0, x3: -17, x4: 12345612, x5: -0xFFFF)

--- a/test/Interop/SwiftToC/structs/small-structs-64-bit-pass-return-direct-in-c.swift
+++ b/test/Interop/SwiftToC/structs/small-structs-64-bit-pass-return-direct-in-c.swift
@@ -22,16 +22,16 @@ public struct StructI8AndU32AndI16 {
 }
 
 // CHECK:      struct Structs_StructI8AndU32AndI16 {
-// CHECK_NEXT:   _Alignas(4) char _storage[10];
-// CHECK_NEXT: };
+// CHECK-NEXT:   _Alignas(4) char _storage[10];
+// CHECK-NEXT: };
 
 // CHECK:      struct Structs_StructOneI16AndOneStruct {
-// CHECK_NEXT:   _Alignas(4) char _storage[12];
-// CHECK_NEXT: };
+// CHECK-NEXT:   _Alignas(4) char _storage[12];
+// CHECK-NEXT: };
 
 // CHECK:      struct Structs_StructTwoI32 {
-// CHECK_NEXT:   _Alignas(4) char _storage[8];
-// CHECK_NEXT: };
+// CHECK-NEXT:   _Alignas(4) char _storage[8];
+// CHECK-NEXT: };
 
 public func returnNewStructTwoI32(_ x: Int32) -> StructTwoI32 { return StructTwoI32(x: x, y: x * 2) }
 

--- a/test/Interop/SwiftToC/structs/small-structs-pass-return-direct-in-c.swift
+++ b/test/Interop/SwiftToC/structs/small-structs-pass-return-direct-in-c.swift
@@ -19,16 +19,16 @@ public struct StructDoubleAndFloat {
 }
 
 // CHECK:      struct Structs_StructDoubleAndFloat {
-// CHECK_NEXT:   _Alignas(8) char _storage[12];
-// CHECK_NEXT: };
+// CHECK-NEXT:   _Alignas(8) char _storage[12];
+// CHECK-NEXT: };
 
 // CHECK:      struct Structs_StructOneI64 {
-// CHECK_NEXT:   _Alignas(8) char _storage[8];
-// CHECK_NEXT: };
+// CHECK-NEXT:   _Alignas(8) char _storage[8];
+// CHECK-NEXT: };
 
 // CHECK:      struct Structs_StructU16AndPointer {
-// CHECK_NEXT:   _Alignas(8) char _storage[16];
-// CHECK_NEXT: };
+// CHECK-NEXT:   _Alignas(8) char _storage[16];
+// CHECK-NEXT: };
 
 public func returnNewStructOneI64() -> StructOneI64 { return StructOneI64(x: 42 ) }
 

--- a/test/SIL/Parser/stored_property.sil
+++ b/test/SIL/Parser/stored_property.sil
@@ -8,7 +8,7 @@ class Rect {
   init(orgx: Double)
 }
 
-// CHECK_LABEL: sil @_TFC4rect4Rectg4orgxSd
+// CHECK-LABEL: sil @_TFC4rect4Rectg4orgxSd
 sil @_TFC4rect4Rectg4orgxSd : $@convention(method) (@guaranteed Rect) -> Double {
 bb0(%0 : $Rect):
   debug_value %0 : $Rect
@@ -19,7 +19,7 @@ bb0(%0 : $Rect):
   return %3 : $Double
 }
 
-// CHECK_LABEL: sil_vtable Rect
+// CHECK-LABEL: sil_vtable Rect
 sil_vtable Rect {
   // CHECK: #Rect.orgx!getter
   #Rect.orgx!getter: @_TFC4rect4Rectg4orgxSd

--- a/test/SILGen/capture_resilience.swift
+++ b/test/SILGen/capture_resilience.swift
@@ -29,7 +29,7 @@ public func hasClosureVar() -> () -> ResilientStruct {
 @inlinable public func hasInlinableClosureLet() -> () -> ResilientStruct {
   let s = ResilientStruct()
 
-  // CHECK_LABEL: sil shared [serialized] [ossa] @$s18capture_resilience22hasInlinableClosureLetAA15ResilientStructVycyFADycfU_ : $@convention(thin) (@in_guaranteed ResilientStruct) -> @out ResilientStruct
+  // CHECK-LABEL: sil shared [serialized] [ossa] @$s18capture_resilience22hasInlinableClosureLetAA15ResilientStructVycyFADycfU_ : $@convention(thin) (@in_guaranteed ResilientStruct) -> @out ResilientStruct
   return { s }
 }
 

--- a/test/SILGen/init_delegation_optional.swift
+++ b/test/SILGen/init_delegation_optional.swift
@@ -423,7 +423,7 @@ extension Optional where Wrapped == Optional<Bool> {
     self = .none
   }
 
-  // CHECK_LABEL: sil hidden [ossa] @$sSq24init_delegation_optionalSbSgRszlE13SpecFailable3ABSgSgyt_tcfC
+  // CHECK-LABEL: sil hidden [ossa] @$sSq24init_delegation_optionalSbSgRszlE13SpecFailable3ABSgSgyt_tcfC
   init?(SpecFailable3: ()) {
     // CHECK: bb0([[SELF_META:%[0-9]+]] : $@thin Optional<Optional<Bool>>.Type):
     // CHECK-NEXT: [[SELF_BOX:%[0-9]+]] = alloc_box ${ var Optional<Optional<Bool>> }, var

--- a/test/SILGen/sil_locations.swift
+++ b/test/SILGen/sil_locations.swift
@@ -313,7 +313,7 @@ func printSinglePayloadAddressOnly(_ v:SinglePayloadAddressOnly) {
   }
   
   
-  // CHECK_LABEL: sil hidden [ossa] @$s13sil_locations29printSinglePayloadAddressOnly{{[_0-9a-zA-Z]*}}F
+  // CHECK-LABEL: sil hidden [ossa] @$s13sil_locations29printSinglePayloadAddressOnly{{[_0-9a-zA-Z]*}}F
   // CHECK: bb0
   // CHECK: switch_enum_addr {{.*}} [[FALSE_BB:bb[0-9]+]], {{.*}}line:[[@LINE-10]]:3
   // CHECK: [[FALSE_BB]]:

--- a/test/SILGen/sil_locations_top_level.swift
+++ b/test/SILGen/sil_locations_top_level.swift
@@ -31,7 +31,7 @@ var topLevelObject2:TopLevelObjectTyWithoutDestructor
 // CHECK: return {{.*}}// {{.*}} line:5:12
 
 // Check explicit destructor
-// CHECK_LABEL: sil hidden [ossa] @$s23sil_locations_top_level16TopLevelObjectTyCfd
+// CHECK-LABEL: sil hidden [ossa] @$s23sil_locations_top_level16TopLevelObjectTyCfd
 // CHECK:   return {{.*}}// {{.*}} line:8:3
 
 // Check allocating constructor
@@ -44,5 +44,5 @@ var topLevelObject2:TopLevelObjectTyWithoutDestructor
 // CHECK: return {{.*}}// {{.*}} line:14:3:imp_return
 
 // Check implicit destructor
-// CHECK_LABEL: sil hidden [ossa] @$s23sil_locations_top_level33TopLevelObjectTyWithoutDestructorCfd
+// CHECK-LABEL: sil hidden [ossa] @$s23sil_locations_top_level33TopLevelObjectTyWithoutDestructorCfd
 // CHECK:   return {{.*}}// {{.*}} line:12:7:imp_return:auto_gen

--- a/test/SILOptimizer/OSLogFullOptTest.swift
+++ b/test/SILOptimizer/OSLogFullOptTest.swift
@@ -5,9 +5,6 @@
 // REQUIRES: PTRSIZE=64
 // REQUIRES: swift_in_compiler
 
-// Temporarily disabled because fixing ARCAnalysis broke a critical optimization.
-// REQUIRES: rdar102078974
-
 // This tests the optimality of the IR generated for the new os log APIs. This
 // is not testing the output of a specific optimization pass (which has separate
 // tests) but that all optimizations together result in optimal IR. If this test
@@ -55,8 +52,8 @@ func testSimpleInterpolation() {
     // CHECK-NEXT: [[BITCASTED:%.+]] = bitcast i8* [[OFFSET4]] to i{{.*}}*
     // CHECK-64-NEXT: store i64 -9223372036854775808, i64* [[BITCASTED]], align 1
     // CHECK-32-NEXT: store i32 -2147483648, i32* [[BITCASTED]], align 1
-    // CHECK-64-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([27 x i8], [27 x i8]* @{{.*}}, i64 0, i64 0), i8* {{(nonnull )?}}[[BUFFER]], i32 12)
-    // CHECK-32-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([27 x i8], [27 x i8]* @{{.*}}, i32 0, i32 0), i8* {{(nonnull )?}}[[BUFFER]], i32 8)
+    // CHECK-64-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* {{(nonnull )?}}getelementptr inbounds ([27 x i8], [27 x i8]* @{{.*}}, i64 0, i64 0), i8* {{(nonnull )?}}[[BUFFER]], i32 12)
+    // CHECK-32-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* {{(nonnull )?}}getelementptr inbounds ([27 x i8], [27 x i8]* @{{.*}}, i32 0, i32 0), i8* {{(nonnull )?}}[[BUFFER]], i32 8)
     // CHECK-NEXT: tail call void @swift_slowDealloc(i8* {{(nonnull )?}}[[BUFFER]]
     // CHECK-NEXT: br label %[[NOT_ENABLED]]
   
@@ -120,7 +117,7 @@ func testInterpolationWithMultipleArguments() {
     // CHECK-NEXT: store i32 511, i32* [[BITCASTED3]], align 1
     //
     // os_log_impl call.
-    // CHECK-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([106 x i8], [106 x i8]* @{{.*}}, i{{.*}} 0, i{{.*}} 0), i8* {{(nonnull )?}}[[BUFFER]], i32 20)
+    // CHECK-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* {{(nonnull )?}}getelementptr inbounds ([106 x i8], [106 x i8]* @{{.*}}, i{{.*}} 0, i{{.*}} 0), i8* {{(nonnull )?}}[[BUFFER]], i32 20)
     // CHECK-NEXT: tail call void @swift_slowDealloc(i8* {{(nonnull )?}}[[BUFFER]]
     // CHECK-NEXT: br label %[[NOT_ENABLED]]
 
@@ -174,8 +171,8 @@ func testNSObjectInterpolation(nsArray: NSArray) {
     // CHECK-64-NEXT: store %TSo7NSArrayC* [[BITCASTED_SRC2]], %TSo7NSArrayC** [[BITCASTED_DEST2]], align 8
     // CHECK-32-NEXT: store %TSo7NSArrayC* [[BITCASTED_SRC2]], %TSo7NSArrayC** [[BITCASTED_DEST2]], align 4
     // CHECK-NEXT: tail call void @llvm.objc.release(i8* [[NSARRAY_ARG]])
-    // CHECK-64: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @{{.*}}, i64 0, i64 0), i8* {{(nonnull )?}}[[BUFFER]], i32 12)
-    // CHECK-32: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @{{.*}}, i32 0, i32 0), i8* {{(nonnull )?}}[[BUFFER]], i32 8)
+    // CHECK-64: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* {{(nonnull )?}}getelementptr inbounds ([20 x i8], [20 x i8]* @{{.*}}, i64 0, i64 0), i8* {{(nonnull )?}}[[BUFFER]], i32 12)
+    // CHECK-32: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* {{(nonnull )?}}getelementptr inbounds ([20 x i8], [20 x i8]* @{{.*}}, i32 0, i32 0), i8* {{(nonnull )?}}[[BUFFER]], i32 8)
     // CHECK:      [[BITCASTED_OBJ_STORAGE:%.+]] = bitcast i8* [[OBJ_STORAGE]] to %swift.opaque*
     // CHECK-NEXT: tail call void @swift_arrayDestroy(%swift.opaque* [[BITCASTED_OBJ_STORAGE]]
     // CHECK-NEXT: tail call void @swift_slowDealloc(i8* {{(nonnull )?}}[[OBJ_STORAGE]]
@@ -212,7 +209,7 @@ func testFloatInterpolation(doubleValue: Double) {
     // CHECK-NEXT: [[OFFSET4:%.+]] = getelementptr inbounds i8, i8* [[BUFFER]], i{{.*}} 4
     // CHECK-NEXT: [[BITCASTED:%.+]] = bitcast i8* [[OFFSET4]] to double*
     // CHECK-NEXT: store double %0, double* [[BITCASTED]], align 1
-    // CHECK-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([17 x i8], [17 x i8]* @{{.*}}, i{{.*}} 0, i{{.*}} 0), i8* {{(nonnull )?}}[[BUFFER]], i32 12)
+    // CHECK-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* {{(nonnull )?}}getelementptr inbounds ([17 x i8], [17 x i8]* @{{.*}}, i{{.*}} 0, i{{.*}} 0), i8* {{(nonnull )?}}[[BUFFER]], i32 12)
     // CHECK-NEXT: tail call void @swift_slowDealloc(i8* {{(nonnull )?}}[[BUFFER]]
     // CHECK-NEXT: br label %[[NOT_ENABLED]]
 
@@ -274,7 +271,7 @@ func testDynamicPrecisionAndAlignment() {
     // CHECK-NEXT: store i32 2147483647, i32* [[BITCASTED3]], align 1
     //
     // os_log_impl call.
-    // CHECK-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([28 x i8], [28 x i8]* @{{.*}}, i{{.*}} 0, i{{.*}} 0), i8* {{(nonnull )?}}[[BUFFER]], i32 20)
+    // CHECK-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* {{(nonnull )?}}getelementptr inbounds ([28 x i8], [28 x i8]* @{{.*}}, i{{.*}} 0, i{{.*}} 0), i8* {{(nonnull )?}}[[BUFFER]], i32 20)
     // CHECK-NEXT: tail call void @swift_slowDealloc(i8* {{(nonnull )?}}[[BUFFER]]
     // CHECK-NEXT: br label %[[NOT_ENABLED]]
 
@@ -327,8 +324,8 @@ func testStringInterpolation(stringValue: String) {
     // CHECK-NEXT: store i8* [[STR_POINTER]], i8** [[OFFSET_BUFFER_PTR]]
 
     // os_log_impl call.
-    // CHECK-64-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([17 x i8], [17 x i8]* @{{.*}}, i64 0, i64 0), i8* {{(nonnull )?}}[[BUFFER]], i32 12)
-    // CHECK-32-NEXT: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([17 x i8], [17 x i8]* @{{.*}}, i32 0, i32 0), i8* {{(nonnull )?}}[[BUFFER]], i32 8)
+    // CHECK-64: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* {{(nonnull )?}}getelementptr inbounds ([17 x i8], [17 x i8]* @{{.*}}, i64 0, i64 0), i8* {{(nonnull )?}}[[BUFFER]], i32 12)
+    // CHECK-32: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* {{(nonnull )?}}getelementptr inbounds ([17 x i8], [17 x i8]* @{{.*}}, i32 0, i32 0), i8* {{(nonnull )?}}[[BUFFER]], i32 8)
     // CHECK-NEXT: [[BITCASTED_STR_STORAGE:%.*]] = bitcast i8* [[STR_STORAGE]] to %swift.opaque*
     // CHECK-NEXT: tail call void @swift_arrayDestroy(%swift.opaque* [[BITCASTED_STR_STORAGE]]
     // CHECK-NEXT: tail call void @swift_slowDealloc(i8* {{(nonnull )?}}[[STR_STORAGE]]
@@ -378,8 +375,8 @@ func testMetatypeInterpolation<T>(of type: T.Type) {
     // CHECK: [[STR_POINTER:%.*]] = call swiftcc i8* @"${{.*}}getNullTerminatedUTF8Pointer{{.*}}"(i{{.*}} [[TYPENAME_0]], {{.*}} [[TYPENAME_1]]
 
     // os_log_impl call.
-    // CHECK-64: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([19 x i8], [19 x i8]* @{{.*}}, i64 0, i64 0), i8* {{(nonnull )?}}[[BUFFER]], i32 12)
-    // CHECK-32: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* getelementptr inbounds ([19 x i8], [19 x i8]* @{{.*}}, i32 0, i32 0), i8* {{(nonnull )?}}[[BUFFER]], i32 8)
+    // CHECK-64: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* {{(nonnull )?}}getelementptr inbounds ([19 x i8], [19 x i8]* @{{.*}}, i64 0, i64 0), i8* {{(nonnull )?}}[[BUFFER]], i32 12)
+    // CHECK-32: tail call swiftcc void @"${{.*}}_os_log_impl_test{{.*}}"({{.*}}, {{.*}}, {{.*}}, {{.*}}, i8* {{(nonnull )?}}getelementptr inbounds ([19 x i8], [19 x i8]* @{{.*}}, i32 0, i32 0), i8* {{(nonnull )?}}[[BUFFER]], i32 8)
     // CHECK-NEXT: [[BITCASTED_STR_STORAGE:%.*]] = bitcast i8* [[STR_STORAGE]] to %swift.opaque*
     // CHECK-NEXT: tail call void @swift_arrayDestroy(%swift.opaque* [[BITCASTED_STR_STORAGE]]
     // CHECK-NEXT: tail call void @swift_slowDealloc(i8* {{(nonnull )?}}[[STR_STORAGE]]

--- a/test/SILOptimizer/access_marker_verify_objc.swift
+++ b/test/SILOptimizer/access_marker_verify_objc.swift
@@ -12,7 +12,7 @@ import Foundation
 // --- initializer `let` of CFString.
 // The verifier should ignore this.
 
-// CHECK_LABEL: sil private @{{.*}}WZ : $@convention(c) (Builtin.RawPointer) -> () {
+// CHECK-LABEL: sil private {{.*}}WZ : $@convention(c) (Builtin.RawPointer) -> () {
 // CHECK: bb0(%0 : $Builtin.RawPointer):
 // CHECK:   alloc_global @$s25access_marker_verify_objc12testCFStringC8cfStringSo0F3RefavpZ
 // CHECK:   [[GA:%.*]] = global_addr @$s25access_marker_verify_objc12testCFStringC8cfStringSo0F3RefavpZ : $*CFString
@@ -62,7 +62,7 @@ class HasBlockImpl: HasBlock {
 // CHECK: switch_enum [[STR]] : $Optional<CFString>, case #Optional.some!enumelt: [[SOMEBB:bb.*]], case #Optional.none!enumelt: bb{{.*}}
 // CHECK:   [[SOMEBB]]([[R:%.*]] : @owned $CFString):
 // CHECK:   return [[R]] : $CFString
-// CHECK_LABEL: } // end sil function '$s25access_marker_verify_objc14GlobalPropertyC14globalCFStringSo0H3RefavgZ'
+// CHECK-LABEL: } // end sil function '$s25access_marker_verify_objc14GlobalPropertyC14globalCFStringSo0H3RefavgZ'
 class GlobalProperty {
   public class var globalCFString: CFString { return constCGlobal }
 }

--- a/test/SILOptimizer/arcsequenceopts.sil
+++ b/test/SILOptimizer/arcsequenceopts.sil
@@ -411,13 +411,13 @@ bb0(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int64>):
   return %1 : $()
 }
 
-// CHECK_LABEL: sil hidden [noinline] @$test_guaranteed_call :
+// CHECK-LABEL: sil hidden [noinline] @$test_guaranteed_call :
 // CHECK: bb1{{.*}}:
 // CHECK-NOT: strong_retain
 // CHECK: apply
 // CHECK-NOT: strong_release
 // CHECK: bb2:
-// CHECK_LABEL: } // end sil function '$test_guaranteed_call'
+// CHECK-LABEL: } // end sil function '$test_guaranteed_call'
 sil hidden [noinline] @$test_guaranteed_call : $@convention(thin) () -> () {
 bb0:
   %box = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int64>
@@ -2172,10 +2172,10 @@ bb2(%4 : $Error):
   throw %4 : $Error
 }
 
-// CHECK_LABEL: sil hidden [noinline] @$try_apply_test_3 :
+// CHECK-LABEL: sil hidden [noinline] @$try_apply_test_3 :
 // CHECK-NOT: strong_retain
 // CHECK-NOT: strong_release
-// CHECK_LABEL: } // end sil function '$try_apply_test_3'
+// CHECK-LABEL: } // end sil function '$try_apply_test_3'
 sil hidden [noinline] @$try_apply_test_3 : $@convention(thin) () -> @error any Error {
 bb0:
   %box = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int64>

--- a/test/SILOptimizer/array_property_opt.sil
+++ b/test/SILOptimizer/array_property_opt.sil
@@ -31,7 +31,7 @@ class MyClass {
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'clone_switch_enum_exit'
+// CHECK-LABEL: } // end sil function 'clone_switch_enum_exit'
 
 /// We need to split the loop exit edge from bb1 to bb3 before updating ssa form
 /// after cloning.
@@ -124,7 +124,7 @@ sil @throwing_fun : $@convention(thin) () -> (MyBool, @error any Error)
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'clone_try_apply_exit'
+// CHECK-LABEL: } // end sil function 'clone_try_apply_exit'
 sil @clone_try_apply_exit : $@convention(thin) (@inout MyArray<MyClass>, @inout MyBool) -> (MyBool, @error any Error) {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*MyBool):
   %3 = load %0 : $*MyArray<MyClass>
@@ -162,7 +162,7 @@ bb6(%9 : $Error):
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'dominator_update_outside_non_exit_block'
+// CHECK-LABEL: } // end sil function 'dominator_update_outside_non_exit_block'
 sil @dominator_update_outside_non_exit_block : $@convention(thin) (@inout MyArray<MyClass>, @inout Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*Builtin.Int1):
   %3 = load %0 : $*MyArray<MyClass>
@@ -214,7 +214,7 @@ bb10:
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'dominator_update_outside_non_exit_block_2'
+// CHECK-LABEL: } // end sil function 'dominator_update_outside_non_exit_block_2'
 sil @dominator_update_outside_non_exit_block_2 : $@convention(thin) (@inout MyArray<MyClass>, @inout Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*Builtin.Int1):
   %3 = load %0 : $*MyArray<MyClass>

--- a/test/SILOptimizer/array_property_opt_ossa_guaranteed.sil
+++ b/test/SILOptimizer/array_property_opt_ossa_guaranteed.sil
@@ -36,7 +36,7 @@ bb0(%0: @guaranteed $MyArray<MyClass>):
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'load_and_copy_within_loop'
+// CHECK-LABEL: } // end sil function 'load_and_copy_within_loop'
 sil [ossa] @load_and_copy_within_loop : $@convention(thin) (@inout MyArray<MyClass>, @inout MyBool) -> MyBool {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*MyBool):
   %3 = load [copy] %0 : $*MyArray<MyClass>
@@ -66,7 +66,7 @@ bb3:
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'test_simple'
+// CHECK-LABEL: } // end sil function 'test_simple'
 sil [ossa] @test_simple : $@convention(thin) (@inout MyArray<MyClass>, @inout MyBool) -> MyBool {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*MyBool):
   %3 = load [copy] %0 : $*MyArray<MyClass>
@@ -96,7 +96,7 @@ bb3:
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'clone_switch_enum_exit'
+// CHECK-LABEL: } // end sil function 'clone_switch_enum_exit'
 /// We need to split the loop exit edge from bb1 to bb3 before updating ssa form
 /// after cloning.
 sil [ossa] @clone_switch_enum_exit : $@convention(thin) (@inout MyArray<MyClass>, @inout MyBool) -> MyBool {
@@ -145,7 +145,7 @@ sil [ossa] @throwing_fun : $@convention(thin) () -> (MyBool, @error any Error)
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'clone_try_apply_exit'
+// CHECK-LABEL: } // end sil function 'clone_try_apply_exit'
 sil [ossa] @clone_try_apply_exit : $@convention(thin) (@inout MyArray<MyClass>, @inout MyBool) -> (MyBool, @error any Error) {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*MyBool):
   %3 = load [copy] %0 : $*MyArray<MyClass>
@@ -184,7 +184,7 @@ bb5(%9 : $Error):
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'dominator_update_outside_non_exit_block'
+// CHECK-LABEL: } // end sil function 'dominator_update_outside_non_exit_block'
 sil [ossa] @dominator_update_outside_non_exit_block : $@convention(thin) (@inout MyArray<MyClass>, @inout Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*Builtin.Int1):
   %3 = load [copy] %0 : $*MyArray<MyClass>
@@ -236,7 +236,7 @@ bb10:
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'dominator_update_outside_non_exit_block_2'
+// CHECK-LABEL: } // end sil function 'dominator_update_outside_non_exit_block_2'
 sil [ossa] @dominator_update_outside_non_exit_block_2 : $@convention(thin) (@inout MyArray<MyClass>, @inout Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*Builtin.Int1):
   %3 = load [copy] %0 : $*MyArray<MyClass>

--- a/test/SILOptimizer/array_property_opt_ossa_owned.sil
+++ b/test/SILOptimizer/array_property_opt_ossa_owned.sil
@@ -36,7 +36,7 @@ bb0(%0: @owned $MyArray<MyClass>):
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'load_and_copy_within_loop'
+// CHECK-LABEL: } // end sil function 'load_and_copy_within_loop'
 sil [ossa] @load_and_copy_within_loop : $@convention(thin) (@inout MyArray<MyClass>, @inout MyBool) -> MyBool {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*MyBool):
   %3 = load [copy] %0 : $*MyArray<MyClass>
@@ -69,7 +69,7 @@ bb3:
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'loadcopy_within_loop'
+// CHECK-LABEL: } // end sil function 'loadcopy_within_loop'
 sil [ossa] @loadcopy_within_loop : $@convention(thin) (@inout MyArray<MyClass>, @inout MyBool) -> MyBool {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*MyBool):
   %3 = load [copy] %0 : $*MyArray<MyClass>
@@ -100,7 +100,7 @@ bb3:
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'copy_within_loop'
+// CHECK-LABEL: } // end sil function 'copy_within_loop'
 sil [ossa] @copy_within_loop : $@convention(thin) (@inout MyArray<MyClass>, @inout MyBool) -> MyBool {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*MyBool):
   %3 = load [copy] %0 : $*MyArray<MyClass>
@@ -131,7 +131,7 @@ bb3:
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'clone_switch_enum_exit'
+// CHECK-LABEL: } // end sil function 'clone_switch_enum_exit'
 /// We need to split the loop exit edge from bb1 to bb3 before updating ssa form
 /// after cloning.
 sil [ossa] @clone_switch_enum_exit : $@convention(thin) (@inout MyArray<MyClass>, @inout MyBool) -> MyBool {
@@ -181,7 +181,7 @@ sil [ossa] @throwing_fun : $@convention(thin) () -> (MyBool, @error any Error)
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'clone_try_apply_exit'
+// CHECK-LABEL: } // end sil function 'clone_try_apply_exit'
 sil [ossa] @clone_try_apply_exit : $@convention(thin) (@inout MyArray<MyClass>, @inout MyBool) -> (MyBool, @error any Error) {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*MyBool):
   %3 = load [copy] %0 : $*MyArray<MyClass>
@@ -221,7 +221,7 @@ bb5(%9 : $Error):
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'dominator_update_outside_non_exit_block'
+// CHECK-LABEL: } // end sil function 'dominator_update_outside_non_exit_block'
 sil [ossa] @dominator_update_outside_non_exit_block : $@convention(thin) (@inout MyArray<MyClass>, @inout Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*Builtin.Int1):
   %3 = load [copy] %0 : $*MyArray<MyClass>
@@ -274,7 +274,7 @@ bb10:
 // CHECK: bb3:
 // CHECK: [[FUNC2:%.*]] = function_ref @arrayPropertyIsNative
 // CHECK: apply [[FUNC2]]
-// CHECK_LABEL: } // end sil function 'dominator_update_outside_non_exit_block_2'
+// CHECK-LABEL: } // end sil function 'dominator_update_outside_non_exit_block_2'
 sil [ossa] @dominator_update_outside_non_exit_block_2 : $@convention(thin) (@inout MyArray<MyClass>, @inout Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $*MyArray<MyClass>, %1 : $*Builtin.Int1):
   %3 = load [copy] %0 : $*MyArray<MyClass>

--- a/test/SILOptimizer/constant_propagation.sil
+++ b/test/SILOptimizer/constant_propagation.sil
@@ -331,9 +331,9 @@ bb0:
 // CHECK-LABEL: sil @fold_binary_bitwise
 // CHECK: bb0:
 // CHECK-NEXT: %0 = integer_literal $Builtin.Int64, 0
-// CHECK_NEXT: %1 = integer_literal $Builtin.Int64, 1
-// CHECK_NEXT: %2 = integer_literal $Builtin.Int64, 1
-// CHECK_NEXT: return %2 : $Builtin.Int64
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int64, 1
+// CHECK-NEXT: %2 = integer_literal $Builtin.Int64, 1
+// CHECK-NEXT: return %2 : $Builtin.Int64
 }
 
 // For any x of the same size as Int.max and n>=1 , (x>>n) is always <= Int.max,

--- a/test/SILOptimizer/constant_propagation_ownership.sil
+++ b/test/SILOptimizer/constant_propagation_ownership.sil
@@ -400,9 +400,9 @@ bb0:
 // CHECK-LABEL: sil [ossa] @fold_binary_bitwise
 // CHECK: bb0:
 // CHECK-NEXT: %0 = integer_literal $Builtin.Int64, 0
-// CHECK_NEXT: %1 = integer_literal $Builtin.Int64, 1
-// CHECK_NEXT: %2 = integer_literal $Builtin.Int64, 1
-// CHECK_NEXT: return %2 : $Builtin.Int64
+// CHECK-NEXT: %1 = integer_literal $Builtin.Int64, 1
+// CHECK-NEXT: %2 = integer_literal $Builtin.Int64, 1
+// CHECK-NEXT: return %2 : $Builtin.Int64
 }
 
 // For any x of the same size as Int.max and n>=1 , (x>>n) is always <= Int.max,

--- a/test/SILOptimizer/dead_store_elim.sil
+++ b/test/SILOptimizer/dead_store_elim.sil
@@ -318,7 +318,7 @@ bb3:
 // CHECK: bb0(
 // CHECK-NOT: {{ store}}
 // CHECK: bb1:
-// CHECK_NOT: store
+// CHECK-NOT: store
 // CHECK: bb2:
 // CHECK: bb3:
 // CHECK: {{ store}}

--- a/test/SILOptimizer/devirt_value_metatypes.swift
+++ b/test/SILOptimizer/devirt_value_metatypes.swift
@@ -54,7 +54,7 @@ public final class E : C {
 
 // CHECK-LABEL: sil {{.*}}@$s22devirt_value_metatypes5testEySiAA1ECF
 // CHECK-NOT: value_metatype $@thick E.Type
-// CHECK_NOT: checked_cast_br
+// CHECK-NOT: checked_cast_br
 // CHECK: function_ref
 // CHECK: apply
 // CHECK: return

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2767,7 +2767,7 @@ protocol someProtocol {
 // CHECK-NEXT: copy_addr
 // CHECK-NEXT: destroy_addr
 // CHECK-NEXT: [[T0:%.*]] = witness_method $T
-// CHECK_NEXT: apply [[T0]]<T>
+// CHECK-NEXT: apply [[T0]]<T>
 // CHECK: return
 sil @witness_archetype : $@convention(thin) <T where T : someProtocol> (@in T) -> () {
 bb0(%0 : $*T):

--- a/test/SILOptimizer/sil_combine_ossa.sil
+++ b/test/SILOptimizer/sil_combine_ossa.sil
@@ -3198,7 +3198,7 @@ protocol someProtocol {
 // XHECK-NEXT: copy_addr
 // XHECK-NEXT: destroy_addr
 // XHECK-NEXT: [[T0:%.*]] = witness_method $T
-// XHECK_NEXT: apply [[T0]]<T>
+// XHECK-NEXT: apply [[T0]]<T>
 // XHECK: return
 sil [ossa] @witness_archetype : $@convention(thin) <T where T : someProtocol> (@in T) -> () {
 bb0(%0 : $*T):

--- a/test/SourceKit/CompileNotifications/diagnostics.swift
+++ b/test/SourceKit/CompileNotifications/diagnostics.swift
@@ -94,4 +94,6 @@
 // But ignore syntactic-only requests with no arguments.
 // RUN: %sourcekitd-test -req=track-compiles == -req=syntax-map %s | %FileCheck %s -check-prefix=SYNTACTIC
 // SYNTACTIC: key.syntaxmap:
-// SYNTACTIC_NOT: key.notification: source.notification.compile-did-finish
+
+// TODO: Is this correct?  this correct? rdar://102092136
+// SYNTACTIC: key.notification: source.notification.compile-did-finish


### PR DESCRIPTION
In the rebranch this is an error (lit got more picky), but it also makes sense to fix the tests in the main branch

Also match optional `nonnull` attributes. They are inserted by the new LLVM (rebranch). It doesn't harm to match those attributes conditionally also in the main branch.

Also fix SILOptimizer/OSLogFullOptTest.swift and re-enable it. rdar://102078974