### PR TITLE
IRGen: Add `#_hasSymbol` support for async declarations

### DIFF
--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -1140,6 +1140,7 @@ Alignment LinkEntity::getAlignment(IRGenModule &IGM) const {
   case Kind::PartialApplyForwarderAsyncFunctionPointer:
   case Kind::DistributedAccessorAsyncPointer:
   case Kind::KnownAsyncFunctionPointer:
+  case Kind::AsyncFunctionPointerAST:
   case Kind::ObjCClassRef:
   case Kind::ObjCClass:
   case Kind::TypeMetadataLazyCacheVariable:

--- a/test/IRGen/Inputs/has_symbol_helper.swift
+++ b/test/IRGen/Inputs/has_symbol_helper.swift
@@ -1,11 +1,23 @@
 public let global: Int = 0
 
+#if CONCURRENCY
+@globalActor
+public struct GA {
+  public actor A {}
+  public static let shared = A()
+}
+#endif
+
 public func function(with argument: Int) {}
 public func throwingFunc() throws {}
 public func genericFunc<T: P>(_ t: T) {}
 public func funcWithOpaqueResult() -> some P { return S(member: 0) }
 @_cdecl("cdecl_func") public func cdeclFunc() {}
 @_silgen_name("forward_declared_func") public func forwardDeclaredFunc()
+#if CONCURRENCY
+@GA public func isolatedFunc() {}
+public func asyncFunc() async {}
+#endif
 
 public protocol P {
   func requirement()
@@ -33,3 +45,10 @@ public enum E {
   case basicCase
   case payloadCase(_: S)
 }
+
+#if CONCURRENCY
+public actor A {
+  public init() {}
+  public func asyncMethod() async {}
+}
+#endif

--- a/test/IRGen/has_symbol_async.swift
+++ b/test/IRGen/has_symbol_async.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/has_symbol_helper.swiftmodule -parse-as-library %S/Inputs/has_symbol_helper.swift -enable-library-evolution -disable-availability-checking -DCONCURRENCY
+// RUN: %target-swift-frontend -emit-irgen %s -I %t -module-name test | %FileCheck %s
+
+// REQUIRES: concurrency
+// REQUIRES: VENDOR=apple
+
+@_weakLinked import has_symbol_helper
+
+func testGlobalFunctions() {
+  if #_hasSymbol(asyncFunc) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper9asyncFuncyyYaFTwS"()
+  // CHECK:   ret i1 and (i1 icmp ne (void (%swift.context*)* @"$s17has_symbol_helper9asyncFuncyyYaF", void (%swift.context*)* null), i1 icmp ne (%swift.async_func_pointer* @"$s17has_symbol_helper9asyncFuncyyYaFTu", %swift.async_func_pointer* null))
+
+  if #_hasSymbol(isolatedFunc) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper12isolatedFuncyyFTwS"()
+  // CHECK:   ret i1 icmp ne (void ()* @"$s17has_symbol_helper12isolatedFuncyyF", void ()* null)
+}
+
+func testActor(_ a: A) {
+  if #_hasSymbol(A.init) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper1ACACycfcTwS"()
+  // CHECK:   ret i1 and (i1 icmp ne (%T17has_symbol_helper1AC* (%T17has_symbol_helper1AC*)* @"$s17has_symbol_helper1ACACycfc", %T17has_symbol_helper1AC* (%T17has_symbol_helper1AC*)* null), i1 icmp ne (%T17has_symbol_helper1AC* (%swift.type*)* @"$s17has_symbol_helper1ACACycfC", %T17has_symbol_helper1AC* (%swift.type*)* null))
+
+  if #_hasSymbol(a.asyncMethod) {}
+  // CHECK: define linkonce_odr hidden swiftcc i1 @"$s17has_symbol_helper1AC11asyncMethodyyYaFTwS"()
+  // CHECK:   ret i1 and (i1 and (i1 icmp ne (void (%swift.context*, %T17has_symbol_helper1AC*)* @"$s17has_symbol_helper1AC11asyncMethodyyYaFTj", void (%swift.context*, %T17has_symbol_helper1AC*)* null), i1 icmp ne (%swift.async_func_pointer* @"$s17has_symbol_helper1AC11asyncMethodyyYaFTjTu", %swift.async_func_pointer* null)), i1 icmp ne (%swift.method_descriptor* @"$s17has_symbol_helper1AC11asyncMethodyyYaFTq", %swift.method_descriptor* null))
+
+  // FIXME: Add support for actor isolated methods
+}


### PR DESCRIPTION
Actor isolated methods are still not supported, though, because typechecking doesn't allow a partial application of those.

Resolves rdar://102094672
