### PR TITLE
 [Sema] TypeWrappers: Allow type wrappers on protocols and inference from them

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3909,8 +3909,9 @@ public:
 
   /// If this declaration has a type wrapper, return `$Storage`
   /// declaration that contains all the stored properties managed
-  /// by the wrapper.
-  NominalTypeDecl *getTypeWrapperStorageDecl() const;
+  /// by the wrapper. Note that if this type is a protocol them
+  /// this method returns an associated type for $Storage.
+  TypeDecl *getTypeWrapperStorageDecl() const;
 
   /// If this declaration is a type wrapper, retrieve
   /// its required initializer - `init(storageWrapper:)`.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6605,7 +6605,7 @@ ERROR(type_wrappers_are_experimental,none,
       "type wrappers are an experimental feature", ())
 
 ERROR(type_wrapper_attribute_not_allowed_here,none,
-      "type wrapper attribute %0 can only be applied to a class, struct",
+      "type wrapper attribute %0 can only be applied to a class, struct, or protocol",
       (Identifier))
 
 ERROR(type_wrapper_requires_two_generic_params,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6616,6 +6616,10 @@ ERROR(cannot_use_multiple_type_wrappers,none,
       "%0 %1 cannot use more than one type wrapper",
       (DescriptiveDeclKind, DeclName))
 
+NOTE(type_wrapper_inferred_from,none,
+     "type wrapper %0 inferred from %1 %2",
+     (DeclName, DescriptiveDeclKind, DeclName))
+
 ERROR(type_wrapper_requires_memberwise_init,none,
       "type wrapper type %0 does not contain a required initializer"
       " - init(for:storage:)",

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3552,8 +3552,7 @@ public:
 /// Inject or get `$Storage` type which has all of the stored properties
 /// of the given type with a type wrapper.
 class GetTypeWrapperStorage
-    : public SimpleRequest<GetTypeWrapperStorage,
-                           NominalTypeDecl *(NominalTypeDecl *),
+    : public SimpleRequest<GetTypeWrapperStorage, TypeDecl *(NominalTypeDecl *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -3561,7 +3560,7 @@ public:
 private:
   friend SimpleRequest;
 
-  NominalTypeDecl *evaluate(Evaluator &evaluator, NominalTypeDecl *) const;
+  TypeDecl *evaluate(Evaluator &evaluator, NominalTypeDecl *) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -408,7 +408,7 @@ SWIFT_REQUEST(TypeChecker, GetTypeWrapperType,
               Type(NominalTypeDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetTypeWrapperStorage,
-              NominalTypeDecl *(NominalTypeDecl *),
+              TypeDecl *(NominalTypeDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetTypeWrapperProperty,
               VarDecl *(NominalTypeDecl *),

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -480,7 +480,8 @@ bool DIMemoryObjectInfo::isElementLetProperty(unsigned Element) const {
     assert(Element < storageVarType->getNumElements());
     auto propertyName = storageVarType->getElement(Element).getName();
 
-    auto *storageDecl = wrappedType->getTypeWrapperStorageDecl();
+    auto *storageDecl =
+        cast<NominalTypeDecl>(wrappedType->getTypeWrapperStorageDecl());
     auto *property = storageDecl->lookupDirect(propertyName).front();
     return cast<VarDecl>(property)->isLet();
   }

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1093,7 +1093,8 @@ void LifetimeChecker::injectTypeWrapperStorageInitalization() {
 
   auto *ctor = cast<ConstructorDecl>(storageVar->getDeclContext()->getAsDecl());
   auto *parentType = ctor->getDeclContext()->getSelfNominalTypeDecl();
-  auto *storageDecl = parentType->getTypeWrapperStorageDecl();
+  auto *storageDecl =
+      cast<NominalTypeDecl>(parentType->getTypeWrapperStorageDecl());
 
   for (auto *point : points) {
     SILBuilderWithScope::insertAfter(point, [&](SILBuilder &b) {

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1646,6 +1646,9 @@ synthesizeTypeWrappedTypeStorageWrapperInitializerBody(
 
 ConstructorDecl *SynthesizeTypeWrappedTypeStorageWrapperInitializer::evaluate(
     Evaluator &evaluator, NominalTypeDecl *wrappedType) const {
+  if (isa<ProtocolDecl>(wrappedType))
+    return nullptr;
+
   if (!wrappedType->hasTypeWrapper())
     return nullptr;
 
@@ -1673,8 +1676,11 @@ synthesizeTypeWrappedTypeMemberwiseInitializerBody(AbstractFunctionDecl *decl,
   auto &ctx = ctor->getASTContext();
   auto *parent = ctor->getDeclContext()->getSelfNominalTypeDecl();
 
+  assert(!isa<ProtocolDecl>(parent));
+
   // self.$storage = .init(storage: $Storage(...))
-  auto *storageType = parent->getTypeWrapperStorageDecl();
+  auto *storageType =
+      cast<NominalTypeDecl>(parent->getTypeWrapperStorageDecl());
   assert(storageType);
 
   auto *typeWrapperVar = parent->getTypeWrapperProperty();
@@ -1775,6 +1781,9 @@ synthesizeTypeWrappedTypeMemberwiseInitializerBody(AbstractFunctionDecl *decl,
 
 ConstructorDecl *SynthesizeTypeWrappedTypeMemberwiseInitializer::evaluate(
     Evaluator &evaluator, NominalTypeDecl *wrappedType) const {
+  if (isa<ProtocolDecl>(wrappedType))
+    return nullptr;
+
   if (!wrappedType->hasTypeWrapper())
     return nullptr;
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3597,7 +3597,7 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
   }
 
   if (nominal->getAttrs().hasAttribute<TypeWrapperAttr>()) {
-    if (!(isa<ClassDecl>(D) || isa<StructDecl>(D))) {
+    if (!(isa<ClassDecl>(D) || isa<StructDecl>(D) || isa<ProtocolDecl>(D))) {
       diagnose(attr->getLocation(),
                diag::type_wrapper_attribute_not_allowed_here,
                nominal->getName());

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2748,15 +2748,22 @@ static ArrayRef<Decl *> evaluateMembersRequest(
     TypeChecker::checkConformance(conformance->getRootNormalConformance());
   }
 
-  // If the type conforms to Encodable or Decodable, even via an extension,
-  // the CodingKeys enum is synthesized as a member of the type itself.
-  // Force it into existence.
   if (nominal) {
+    // If the type conforms to Encodable or Decodable, even via an extension,
+    // the CodingKeys enum is synthesized as a member of the type itself.
+    // Force it into existence.
     (void) evaluateOrDefault(
       ctx.evaluator,
       ResolveImplicitMemberRequest{nominal,
                  ImplicitMemberAction::ResolveCodingKeys},
       {});
+
+    // Synthesize $Storage type and `var $storage` associated with
+    // type wrapped type.
+    if (nominal->hasTypeWrapper()) {
+      (void)nominal->getTypeWrapperStorageDecl();
+      (void)nominal->getTypeWrapperProperty();
+    }
   }
 
   // If the decl has a @main attribute, we need to force synthesis of the

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3424,6 +3424,12 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
       readWriteImpl = ReadWriteImplKind::MaterializeToTemporary;
     } else if (storage->getParsedAccessor(AccessorKind::Get)) {
       readImpl = ReadImplKind::Get;
+    } else if (storage->getName() ==
+               storage->getASTContext().Id_TypeWrapperProperty) {
+      // Type wrapper `$storage` property is `get set` requirement.
+      readImpl = ReadImplKind::Get;
+      writeImpl = WriteImplKind::Set;
+      readWriteImpl = ReadWriteImplKind::Modify;
     }
 
     StorageImplInfo info(readImpl, writeImpl, readWriteImpl);

--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -83,11 +83,18 @@ NominalTypeDecl *NominalTypeDecl::getTypeWrapper() const {
                            GetTypeWrapper{mutableSelf}, nullptr);
 }
 
-static void getTypeWrappers(
-    NominalTypeDecl *decl,
-    SmallVectorImpl<std::pair<CustomAttr *, NominalTypeDecl *>> &typeWrappers) {
+struct TypeWrapperAttrInfo {
+  CustomAttr *Attr;
+  NominalTypeDecl *Wrapper;
+  NominalTypeDecl *AttachedTo;
+};
+
+static void
+getTypeWrappers(NominalTypeDecl *decl,
+                SmallVectorImpl<TypeWrapperAttrInfo> &typeWrappers) {
   auto &ctx = decl->getASTContext();
 
+  // Attributes applied directly to the type.
   for (auto *attr : decl->getAttrs().getAttributes<CustomAttr>()) {
     auto *mutableAttr = const_cast<CustomAttr *>(attr);
     auto *nominal = evaluateOrDefault(
@@ -98,7 +105,39 @@ static void getTypeWrappers(
 
     auto *typeWrapper = nominal->getAttrs().getAttribute<TypeWrapperAttr>();
     if (typeWrapper && typeWrapper->isValid())
-      typeWrappers.push_back({mutableAttr, nominal});
+      typeWrappers.push_back({mutableAttr, nominal, decl});
+  }
+
+  // Do not allow transitive protocol inference between protocols.
+  if (isa<ProtocolDecl>(decl))
+    return;
+
+  // Attributes inferred from (explicit) protocol conformances
+  // associated with the declaration of the type.
+  for (unsigned i : indices(decl->getInherited())) {
+    auto inheritedType = evaluateOrDefault(
+        ctx.evaluator,
+        InheritedTypeRequest{decl, i, TypeResolutionStage::Interface}, Type());
+
+    if (!(inheritedType && inheritedType->isConstraintType()))
+      continue;
+
+    auto *protocol = inheritedType->getAnyNominal();
+    if (!protocol)
+      continue;
+
+    SmallVector<TypeWrapperAttrInfo, 2> inferredAttrs;
+    getTypeWrappers(protocol, inferredAttrs);
+
+    // De-duplicate inferred type wrappers. This also makes sure
+    // that if both protocol and conforming type explicitly declare
+    // the same type wrapper there is no clash between them.
+    for (const auto &inferredAttr : inferredAttrs) {
+      if (llvm::find_if(typeWrappers, [&](const TypeWrapperAttrInfo &attr) {
+            return attr.Wrapper == inferredAttr.Wrapper;
+          }) == typeWrappers.end())
+        typeWrappers.push_back(inferredAttr);
+    }
   }
 }
 
@@ -108,7 +147,7 @@ NominalTypeDecl *GetTypeWrapper::evaluate(Evaluator &evaluator,
 
   // Note that we don't actually care whether there are duplicates,
   // using the same type wrapper multiple times is still an error.
-  SmallVector<std::pair<CustomAttr *, NominalTypeDecl *>, 2> typeWrappers;
+  SmallVector<TypeWrapperAttrInfo, 2> typeWrappers;
 
   getTypeWrappers(decl, typeWrappers);
 
@@ -119,27 +158,34 @@ NominalTypeDecl *GetTypeWrapper::evaluate(Evaluator &evaluator,
     ctx.Diags.diagnose(decl, diag::cannot_use_multiple_type_wrappers,
                        decl->getDescriptiveKind(), decl->getName());
 
-    for (const auto &attr : typeWrappers) {
-      ctx.Diags.diagnose(attr.first->getLocation(), diag::decl_declared_here,
-                         attr.second->getName());
+    for (const auto &entry : typeWrappers) {
+      if (entry.AttachedTo == decl) {
+        ctx.Diags.diagnose(entry.Attr->getLocation(), diag::decl_declared_here,
+                           entry.Wrapper->getName());
+      } else {
+        ctx.Diags.diagnose(decl, diag::type_wrapper_inferred_from,
+                           entry.Wrapper->getName(),
+                           entry.AttachedTo->getDescriptiveKind(),
+                           entry.AttachedTo->getName());
+      }
     }
 
     return nullptr;
   }
 
-  return typeWrappers.front().second;
+  return typeWrappers.front().Wrapper;
 }
 
 Type GetTypeWrapperType::evaluate(Evaluator &evaluator,
                                   NominalTypeDecl *decl) const {
-  SmallVector<std::pair<CustomAttr *, NominalTypeDecl *>, 2> typeWrappers;
+  SmallVector<TypeWrapperAttrInfo, 2> typeWrappers;
 
   getTypeWrappers(decl, typeWrappers);
 
   if (typeWrappers.size() != 1)
     return Type();
 
-  auto *typeWrapperAttr = typeWrappers.front().first;
+  auto *typeWrapperAttr = typeWrappers.front().Attr;
   auto type = evaluateOrDefault(
       evaluator,
       CustomAttrTypeRequest{typeWrapperAttr, decl->getDeclContext(),

--- a/test/Interpreter/Inputs/type_wrapper_defs.swift
+++ b/test/Interpreter/Inputs/type_wrapper_defs.swift
@@ -394,3 +394,10 @@ public class TypeWithSomeDefaultedLetProperties<T> {
     print(self.c)
   }
 }
+
+@Wrapper
+public protocol WrappedProtocol {
+  associatedtype T : RangeReplaceableCollection
+
+  var v: T { get set }
+}

--- a/test/Interpreter/type_wrappers.swift
+++ b/test/Interpreter/type_wrappers.swift
@@ -666,3 +666,26 @@ do {
   // CHECK-NEXT: in getter storage: \$Storage.b
   // CHECK-NEXT: 42
 }
+
+// Type wrapper inference from protocols
+do {
+  struct Test<T> : WrappedProtocol {
+    var v: [T?]
+
+    init(_ value: T? = nil) {
+      v = [value]
+    }
+  }
+
+  func run_test<T: WrappedProtocol>(_ test: T) {
+    print(test.v)
+    print(test.v.count)
+  }
+
+  run_test(Test(Optional("Hello")))
+  // CHECK: Wrapper.init(for: Test<String>, storage: $Storage(v: [Optional("Hello")]))
+  // CHECK-NEXT: in getter storage: \$Storage.v
+  // CHECK-NEXT: [Optional("Hello")]
+  // CHECK-NEXT: in getter storage: \$Storage.v
+  // CHECK-NEXT: 1
+}

--- a/test/Serialization/AllowErrors/invalid-inheritance.swift
+++ b/test/Serialization/AllowErrors/invalid-inheritance.swift
@@ -32,9 +32,8 @@ extension undefined: SomeProto {} // expected-error {{cannot find type 'undefine
 
 public extension undefined { // expected-error {{cannot find type 'undefined' in scope}}
   protocol SomeProtoInner: undefined {} // expected-error {{cannot find type 'undefined' in scope}}
-  // TODO: Why don't these have errors?
-  class SomeClassInner: undefined {}
-  struct SomeStructInner: undefined {}
+  class SomeClassInner: undefined {} // expected-error {{cannot find type 'undefined' in scope}}
+  struct SomeStructInner: undefined {} // expected-error {{cannot find type 'undefined' in scope}}
   enum SomeEnumInner: undefined { // expected-error {{cannot find type 'undefined' in scope}}
     case a
   }

--- a/test/type/type_wrapper.swift
+++ b/test/type/type_wrapper.swift
@@ -172,8 +172,8 @@ class GenericA<K: Hashable, V> {
   var data: [K: V]
 }
 
-@NoopWrapper // expected-error {{type wrapper attribute 'NoopWrapper' can only be applied to a class, struct}}
-protocol P {
+@NoopWrapper
+protocol P { // Ok
 }
 
 @NoopWrapper // expected-error {{type wrapper attribute 'NoopWrapper' can only be applied to a class, struct}}


### PR DESCRIPTION
Type wrappers on protocols:

Adding a type wrapper attribute to a protocol declaration triggers
synthesis of:

- internal associated type `$Storage` requirement
- internal property `$storage` with type `<#Wrapper#><Self, Self.$Storage>`

Inference: 

- Infer type wrappers only from direct (declared on type) protocols
- Inferences from protocol to protocol is not allowed
- If type specifies a type wrapper attribute explicitly it has to
  match the one associated with a declared protocol, otherwise the
  declaration is going to be rejected as having multiple wrappers.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
