### PR TITLE
[Index] Use original arguments for indexing memberwise init labels

### DIFF
--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -661,7 +661,7 @@ private:
         LabelIndex++;
       }
     } else if (auto *CallParent = dyn_cast_or_null<CallExpr>(getParentExpr())) {
-      auto *args = CallParent->getArgs();
+      auto *args = CallParent->getArgs()->getOriginalArgs();
       Args.append(args->begin(), args->end());
     }
 

--- a/test/Index/index_memberwise_init.swift
+++ b/test/Index/index_memberwise_init.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
+
+struct DefaultedStruct {
+  var x = 17
+  var y = true
+  var z = "hello"
+}
+
+// Make sure indexing uses the original arguments when adding references to
+// the properties in a memberwise initializer
+func useDefaultInits() {
+  // CHECK-NOT: s:14swift_ide_test15DefaultedStructV1xSbvp
+  // CHECK-NOT: s:14swift_ide_test15DefaultedStructV1zSbvp
+  // CHECK: [[@LINE+2]]:23 | instance-property/Swift | y | s:14swift_ide_test15DefaultedStructV1ySbvp | Ref,RelCont
+  // CHECK: [[@LINE+1]]:7 | constructor/Swift | init(x:y:z:) | s:14swift_ide_test15DefaultedStructV1x1y1zACSi_SbSStcfc | Ref,Call,RelCall,RelCont | rel: 1
+  _ = DefaultedStruct(y: false)
+}
+

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -474,19 +474,6 @@ _ = \StructWithKeypath.[0]
 // CHECK: [[@LINE-1]]:24 | instance-property/subscript/Swift | subscript(_:) | s:14swift_ide_test17StructWithKeypathVyS2icip | Ref,Read | rel: 0
 // CHECK: [[@LINE-2]]:24 | instance-method/acc-get/Swift | getter:subscript(_:) | s:14swift_ide_test17StructWithKeypathVyS2icig | Ref,Call,Impl | rel: 0
 
-
-struct BStruct {
-  var x = 17
-  var y = true
-  var z = "hello"
-}
-
-func useDefaultInits() {
-  _ = BStruct(y: false)
-  // CHECK: [[@LINE-1]]:15 | instance-property/Swift | y | s:14swift_ide_test7BStructV1ySbvp | Ref,RelCont
-  // CHECK: [[@LINE-2]]:7 | constructor/Swift | init(x:y:z:) | s:14swift_ide_test7BStructV1x1y1zACSi_SbSStcfc | Ref,Call,RelCall,RelCont | rel: 1
-}
-
 internal protocol FromInt {
     init(_ uint64: Int)
 }


### PR DESCRIPTION
This isn't actually an issue any more because we return early when the location is invalid, but we shouldn't be attempting to add a reference to a label that wasn't actually written in the first place.