### PR TITLE
[ASTDumper] Print type variables that appear in substitution maps

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3520,6 +3520,7 @@ static void dumpSubstitutionMapRec(
     if (replacementTypes[i]) {
       PrintOptions opts;
       opts.PrintForSIL = true;
+      opts.PrintTypesForDebugging = true;
       replacementTypes[i]->print(out, opts);
     }
     else


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
