### PR TITLE
Sema: Avoid adding `nonisolated` twice to synthesized `Hashable` methods

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1605,13 +1605,14 @@ bool swift::hasLetStoredPropertyWithInitialValue(NominalTypeDecl *nominal) {
   });
 }
 
-void swift::addNonIsolatedToSynthesized(
-    NominalTypeDecl *nominal, ValueDecl *value) {
+bool swift::addNonIsolatedToSynthesized(NominalTypeDecl *nominal,
+                                        ValueDecl *value) {
   if (!getActorIsolation(nominal).isActorIsolated())
-    return;
+    return false;
 
   ASTContext &ctx = nominal->getASTContext();
   value->getAttrs().add(new (ctx) NonisolatedAttr(/*isImplicit=*/true));
+  return true;
 }
 
 static std::pair<BraceStmt *, /*isTypeChecked=*/bool>

--- a/lib/Sema/CodeSynthesis.h
+++ b/lib/Sema/CodeSynthesis.h
@@ -85,8 +85,9 @@ ValueDecl *getProtocolRequirement(ProtocolDecl *protocol, Identifier name);
 // with an initial value.
 bool hasLetStoredPropertyWithInitialValue(NominalTypeDecl *nominal);
 
-/// Add 'nonisolated' to the synthesized declaration when needed.
-void addNonIsolatedToSynthesized(NominalTypeDecl *nominal, ValueDecl *value);
+/// Add 'nonisolated' to the synthesized declaration when needed. Returns true
+/// if an attribute was added.
+bool addNonIsolatedToSynthesized(NominalTypeDecl *nominal, ValueDecl *value);
 
 } // end namespace swift
 

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -554,15 +554,13 @@ deriveHashable_hashInto(
       /*Throws=*/false,
       /*GenericParams=*/nullptr, params, returnType, parentDC);
   hashDecl->setBodySynthesizer(bodySynthesizer);
-  addNonIsolatedToSynthesized(derived.Nominal, hashDecl);
   hashDecl->copyFormalAccessFrom(derived.Nominal,
                                  /*sourceIsParentContext=*/true);
 
   // The derived hash(into:) for an actor must be non-isolated.
-  if (derived.Nominal->isActor() ||
-      getActorIsolation(derived.Nominal) == ActorIsolation::GlobalActor) {
-    hashDecl->getAttrs().add(new (C) NonisolatedAttr(/*IsImplicit*/true));
-  }
+  if (!addNonIsolatedToSynthesized(derived.Nominal, hashDecl) &&
+      derived.Nominal->isActor())
+    hashDecl->getAttrs().add(new (C) NonisolatedAttr(/*IsImplicit*/ true));
 
   derived.addMembersToConformanceContext({hashDecl});
 
@@ -891,7 +889,6 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
                     SourceLoc(), C.Id_hashValue, parentDC);
   hashValueDecl->setInterfaceType(intType);
   hashValueDecl->setSynthesized();
-  addNonIsolatedToSynthesized(derived.Nominal, hashValueDecl);
 
   ParameterList *params = ParameterList::createEmpty(C);
 
@@ -918,10 +915,9 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
                                       /*sourceIsParentContext*/ true);
 
   // The derived hashValue of an actor must be nonisolated.
-  if (derived.Nominal->isActor() ||
-      getActorIsolation(derived.Nominal) == ActorIsolation::GlobalActor) {
-    hashValueDecl->getAttrs().add(new (C) NonisolatedAttr(/*IsImplicit*/true));
-  }
+  if (!addNonIsolatedToSynthesized(derived.Nominal, hashValueDecl) &&
+      derived.Nominal->isActor())
+    hashValueDecl->getAttrs().add(new (C) NonisolatedAttr(/*IsImplicit*/ true));
 
   Pattern *hashValuePat = NamedPattern::createImplicit(C, hashValueDecl);
   hashValuePat->setType(intType);

--- a/test/ModuleInterface/derived_conformances_nonisolated.swift
+++ b/test/ModuleInterface/derived_conformances_nonisolated.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -disable-availability-checking -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -disable-availability-checking -module-name Library
+// RUN: %FileCheck %s < %t/Library.swiftinterface
+
+// REQUIRES: concurrency
+
+// CHECK: @_Concurrency.MainActor public struct X1 : Swift.Equatable, Swift.Hashable, Swift.Codable
+@MainActor public struct X1: Equatable, Hashable, Codable {
+  let x: Int
+  let y: String
+
+  // CHECK: nonisolated public static func == (a: Library.X1, b: Library.X1) -> Swift.Bool
+  // CHECK: nonisolated public func hash(into hasher: inout Swift.Hasher)
+  // CHECK: nonisolated public func encode(to encoder: any Swift.Encoder) throws
+  // CHECK: nonisolated public var hashValue: Swift.Int
+  // CHECK: nonisolated public init(from decoder: any Swift.Decoder) throws
+}


### PR DESCRIPTION
https://github.com/apple/swift/pull/42041 introduced a centralized mechanism for adding the `nonisolated` attribute to synthesized decls but did not clean up the existing code that was already doing so for `Hashable` conformances.

Resolves rdar://102106591
