### PR TITLE
Fix diagnostics message for conditional conformance with marker protocol

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6447,7 +6447,7 @@ ERROR(marker_protocol_cast,none,
       "marker protocol %0 cannot be used in a conditional cast", (DeclName))
 ERROR(marker_protocol_conditional_conformance,none,
       "conditional conformance to non-marker protocol %0 cannot depend on "
-      "conformance of %1 to non-marker protocol %2",
+      "conformance of %1 to marker protocol %2",
       (Identifier, Type, Identifier))
 
 //------------------------------------------------------------------------------

--- a/test/attr/attr_marker_protocol.swift
+++ b/test/attr/attr_marker_protocol.swift
@@ -66,4 +66,4 @@ extension Array: P9 where Element: P9 { }
 protocol P10 { }
 
 extension Array: P10 where Element: P10, Element: P8 { }
-// expected-error@-1{{conditional conformance to non-marker protocol 'P10' cannot depend on conformance of 'Element' to non-marker protocol 'P8'}}
+// expected-error@-1{{conditional conformance to non-marker protocol 'P10' cannot depend on conformance of 'Element' to marker protocol 'P8'}}


### PR DESCRIPTION
Current:

```swift
protocol P { }
struct S<T> {}
extension S: P where T: Sendable {}
// Conditional conformance to non-marker protocol 'P' cannot depend on conformance of 'T' to non-marker protocol 'Sendable'
```

Second `non-marker` is typo of `marker`.

It should be:

```
Conditional conformance to non-marker protocol 'P' cannot depend on conformance of 'T' to marker protocol 'Sendable'
```

---

I fixed diagnostics message template.