### PR TITLE
Add note to stop trying to fix compat tsan syms

### DIFF
--- a/stdlib/toolchain/Compatibility56/Concurrency/ThreadSanitizer.cpp
+++ b/stdlib/toolchain/Compatibility56/Concurrency/ThreadSanitizer.cpp
@@ -23,6 +23,12 @@ namespace {
 using TSanFunc = void(void *);
 } // anonymous namespace
 
+// Note: We can't use a proper interface to get the `__tsan_acquire` and
+// `__tsan_release` from the public/Concurrency/ThreadSanitizer.cpp.
+// Unfortunately, we can't do this because there is no interface in the runtimes
+// we are backdeploying to. So we're stuck using this lazy dlsym game.
+// Number of times I've tried to fix this: 3
+
 void swift::_swift_tsan_acquire(void *addr) {
   const auto backdeploy_tsan_acquire =
     reinterpret_cast<TSanFunc *>(SWIFT_LAZY_CONSTANT(dlsym(RTLD_DEFAULT, "__tsan_acquire")));


### PR DESCRIPTION
I keep trying to fix the tsan symbol dance, avoiding duplicate symbols for initializing the tsan acquire and release function pointers. The idea this time was to expose an API from the runtime to return the function pointers for the compatibility library. This won't work because the compatibility library would need to backdeploy to a version of the library that doesn't have those symbols, so it would fail to link.

Now, if I really wanted to increment the counter again, an idea might be to pull the swift_tsan_acquire/swift_tsan_release symbols out of the Swift concurrency runtime and make them into a toolchain static library which would get linked by the driver when doing an ASAN build. The sanitizer libraries are already shipped like this, so it wouldn't be too weird to do this.