### PR TITLE
[github] Misc improvements to issue templates 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,14 @@ assignees: ''
 
 ---
 
+<!--
+This repository tracks issues related to the implementation of the Swift
+compiler, standard library, runtime, and tools that provide IDE support for
+Swift (e.g. code completion). If the bug relates to the implementation of a
+proprietary (closed-source) Apple framework such as UIKit, SwiftUI, Combine,
+etc., please report it to https://feedbackassistant.apple.com instead.
+-->
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,25 +15,31 @@ proprietary (closed-source) Apple framework such as UIKit, SwiftUI, Combine,
 etc., please report it to https://feedbackassistant.apple.com instead.
 -->
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**Description**
+<!-- Describe clearly and concisely what the bug is. -->
 
-**Steps To Reproduce**
-Steps to reproduce the behavior:
-1.
-2.
-...
+**Steps to reproduce**
+<!--
+Explain how to reproduce the problem (in steps if seen fit) and include either
+an inline test case (preferred) or a project that reproduces it. Consider
+reducing the sample to the smallest amount of code possible — a smaller test
+case is easier to reason about and more appealing to сontributors.
+-->
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- Describe what you expected to happen. -->
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+<!-- If deemed helpful, add screenshots that showcase the problem. -->
+<!-- **Screenshots** -->
 
-**Environment (please fill out the following information)**
- - OS: [e.g. macOS 11.0]
- - Xcode Version/Tag/Branch:
+<!--
+Include information about the Swift compiler version and, if applicable, the
+Xcode version you are observing the problem in and the deployment target.
+-->
+**Environment**
+- Swift compiler version info <!-- replace with the output of 'swiftc -version' -->
+- Xcode version info <!-- replace with the output of 'xcodebuild -version' -->
+- Deployment target: <!-- e.g. iOS 12.3 -->
 
-
-**Additional context**
-Add any other context about the problem here.
+<!-- Add any other context about the problem as appropriate. -->
+<!-- **Additional context** -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest an idea for this project
+about: Share an idea
 title: ''
 labels: feature request
 assignees: ''
@@ -14,6 +14,17 @@ for Swift (e.g. code completion). If your feature request relates to the
 implementation of a proprietary (closed-source) Apple framework such as UIKit,
 SwiftUI, Combine, etc., please report it to https://feedbackassistant.apple.com
 instead.
+
+If you haven't found or started a thread on the Swift forums yet, consider
+socializing your idea in the "Discussion" subcategory
+(https://forums.swift.org/c/evolution/discuss) after submitting this request.
+This is an essential step toward the official review of any proposal concerning
+language or library design, and while GitHub issues do great for tracking
+purposes, the forums are far better ground for drawing attention to ideas and
+gauging interest from the community.
+
+For more information on how ideas are proposed, discussed, and reviewed, see
+https://swift.org/swift-evolution
 -->
 
 **Motivation**
@@ -31,5 +42,8 @@ Describe any alternative approaches or features that you have considered in
 addressing the problem, and why you chose this approach instead.
 -->
 
-<!-- Add any other context about your feature as appropriate. -->
+<!--
+Add any other context about your feature as appropriate. For example, link out
+to a discussion on the Swift forums (https://forums.swift.org).
+-->
 <!-- **Additional context** -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: New Feature
+labels: feature request
 assignees: ''
 
 ---
@@ -16,14 +16,20 @@ SwiftUI, Combine, etc., please report it to https://feedbackassistant.apple.com
 instead.
 -->
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Motivation**
+<!-- Describe the problem that your feature seeks to address. -->
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**Solution**
+<!--
+Describe your solution to the problem. Provide examples and describe how
+they work.
+-->
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Alternatives considered**
+<!--
+Describe any alternative approaches or features that you have considered in
+addressing the problem, and why you chose this approach instead.
+-->
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+<!-- Add any other context about your feature as appropriate. -->
+<!-- **Additional context** -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,6 +7,15 @@ assignees: ''
 
 ---
 
+<!--
+This repository tracks issues and requests related to the implementation of the
+Swift compiler, standard library, runtime, and tools that provide IDE support
+for Swift (e.g. code completion). If your feature request relates to the
+implementation of a proprietary (closed-source) Apple framework such as UIKit,
+SwiftUI, Combine, etc., please report it to https://feedbackassistant.apple.com
+instead.
+-->
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 


### PR DESCRIPTION
* Link out to Apple’s Feedback Assistant for issues that relate to proprietary frameworks.
* Reword and comment out placeholder text.
* Use the `language feature request` label for the feature request template; `new feature` is somewhat ambiguous and needs to be replaced.
* Add hints for obtaining exhaustive information about the compiler/Xcode version.
* Encourage reporters to share their ideas on the forums.