### PR TITLE
[Distributed] Fix dist property being implicitly async after refactor

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4928,6 +4928,9 @@ ERROR(distributed_property_accessor_only_get_can_be_distributed,none,
 NOTE(distributed_actor_isolated_property,none,
       "access to %0 %1 is only permitted within distributed actor %2",
       (DescriptiveDeclKind, DeclName, DeclName))
+NOTE(distributed_actor_synchronous_access_distributed_computed_property,none,
+      "access to %0 %1 from outside the distributed actor %2 must be asynchronous",
+      (DescriptiveDeclKind, DeclName, DeclName))
 
 ERROR(concurrency_lib_missing,none,
       "missing '%0' declaration, probably because the '_Concurrency' "

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1302,11 +1302,19 @@ static void noteIsolatedActorMember(
   // FIXME: Make this diagnostic more sensitive to the isolation context of
   // the declaration.
   if (isDistributedActor) {
-    if (isa<VarDecl>(decl)) {
-      // Distributed actor properties are never accessible externally.
-      decl->diagnose(diag::distributed_actor_isolated_property,
-                     decl->getDescriptiveKind(), decl->getName(),
-                     nominal->getName());
+    if (auto varDecl = dyn_cast<VarDecl>(decl)) {
+      if (varDecl->isDistributed()) {
+        // This is an attempt to access a `distributed var` synchronously, so offer a more detailed error
+        decl->diagnose(diag::distributed_actor_synchronous_access_distributed_computed_property,
+                       decl->getDescriptiveKind(), decl->getName(),
+                       nominal->getName());
+      } else {
+        // Distributed actor properties are never accessible externally.
+        decl->diagnose(diag::distributed_actor_isolated_property,
+                       decl->getDescriptiveKind(), decl->getName(),
+                       nominal->getName());
+      }
+
     } else {
       // it's a function or subscript
       decl->diagnose(diag::note_distributed_actor_isolated_method,

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2483,18 +2483,22 @@ private:
                                   ConditionalEffectKind::Always,
                                   getKindOfEffectfulProp(member)));
 
-    } else if (E->isImplicitlyAsync()) {
+    } else {
       EffectList effects;
-      effects.push_back(EffectKind::Async); // implicitly async
+      if (E->isImplicitlyAsync()) {
+        effects.push_back(EffectKind::Async);
+      }
       if (E->isImplicitlyThrows()) {
         // E.g. it may be a distributed computed property, accessed across actors.
         effects.push_back(EffectKind::Throws);
       }
 
-      checkThrowAsyncSite(E, true,
-                          Classification::forEffect(effects,
-                                                    ConditionalEffectKind::Always,
-                                                    getKindOfEffectfulProp(member)));
+      if (!effects.empty()) {
+        checkThrowAsyncSite(E, true,
+                            Classification::forEffect(effects,
+                                                      ConditionalEffectKind::Always,
+                                                      getKindOfEffectfulProp(member)));
+      }
     }
 
     return ShouldRecurse;

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2485,16 +2485,18 @@ private:
 
     } else {
       EffectList effects;
+      bool requiresTry = false;
       if (E->isImplicitlyAsync()) {
         effects.push_back(EffectKind::Async);
       }
       if (E->isImplicitlyThrows()) {
         // E.g. it may be a distributed computed property, accessed across actors.
         effects.push_back(EffectKind::Throws);
+        requiresTry = true;
       }
 
       if (!effects.empty()) {
-        checkThrowAsyncSite(E, true,
+        checkThrowAsyncSite(E, requiresTry,
                             Classification::forEffect(effects,
                                                       ConditionalEffectKind::Always,
                                                       getKindOfEffectfulProp(member)));

--- a/lib/Sema/TypeCheckEffects.cpp
+++ b/lib/Sema/TypeCheckEffects.cpp
@@ -2477,15 +2477,24 @@ private:
         effects.push_back(EffectKind::Async);
       }
 
-      checkThrowAsyncSite(E, getter->hasThrows(),
+      bool requiresTry = getter->hasThrows();
+      checkThrowAsyncSite(E, requiresTry,
                           Classification::forEffect(effects,
                                   ConditionalEffectKind::Always,
                                   getKindOfEffectfulProp(member)));
 
     } else if (E->isImplicitlyAsync()) {
-      checkThrowAsyncSite(E, /*requiresTry=*/false,
-            Classification::forUnconditional(EffectKind::Async,
-                                             getKindOfEffectfulProp(member)));
+      EffectList effects;
+      effects.push_back(EffectKind::Async); // implicitly async
+      if (E->isImplicitlyThrows()) {
+        // E.g. it may be a distributed computed property, accessed across actors.
+        effects.push_back(EffectKind::Throws);
+      }
+
+      checkThrowAsyncSite(E, true,
+                          Classification::forEffect(effects,
+                                                    ConditionalEffectKind::Always,
+                                                    getKindOfEffectfulProp(member)));
     }
 
     return ShouldRecurse;

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -131,6 +131,7 @@ distributed actor DistributedActor_1 {
 
   func test_inside() async throws {
     _ = self.name
+    _ = self.computed
     _ = self.computedMutable
 
     _ = try await self.distInt()
@@ -157,6 +158,11 @@ func test_outside(
   // ==== properties
   _ = distributed.id // ok
   distributed.id = ActorAddress(parse: "mock://1.1.1.1:8080/#123121") // expected-error{{cannot assign to property: 'id' is immutable}}
+
+  // ==== computed properties
+  _ = try await distributed.computed
+  _ = await distributed.computed
+  _ = distributed.computed
 
   _ = local.name // ok, special case that let constants are okey
   let _: String = local.mutable // ok, special case that let constants are okey

--- a/test/Distributed/distributed_actor_isolation.swift
+++ b/test/Distributed/distributed_actor_isolation.swift
@@ -159,11 +159,6 @@ func test_outside(
   _ = distributed.id // ok
   distributed.id = ActorAddress(parse: "mock://1.1.1.1:8080/#123121") // expected-error{{cannot assign to property: 'id' is immutable}}
 
-  // ==== computed properties
-  _ = try await distributed.computed
-  _ = await distributed.computed
-  _ = distributed.computed
-
   _ = local.name // ok, special case that let constants are okey
   let _: String = local.mutable // ok, special case that let constants are okey
   _ = distributed.name // expected-error{{distributed actor-isolated property 'name' can not be accessed from a non-isolated context}}

--- a/test/Distributed/distributed_property_must_be_throws.swift
+++ b/test/Distributed/distributed_property_must_be_throws.swift
@@ -1,0 +1,57 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown -disable-availability-checking -I %t 2>&1 %s
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+import Distributed
+import FakeDistributedActorSystems
+
+let globalActorSystem = LocalTestingDistributedActorSystem()
+
+distributed actor MyDistributedActor {
+  typealias ActorSystem = LocalTestingDistributedActorSystem
+  distributed var distributedProperty: Set<Int> { [] }
+}
+
+actor MyActor {
+  init(distributedActor: MyDistributedActor) {
+    self.distributedActor = distributedActor
+  }
+
+  let distributedActor: MyDistributedActor
+
+  static func makeActor(actorSystem: LocalTestingDistributedActorSystem) async throws -> MyActor {
+    let distributedActor = try MyDistributedActor.resolve(id: LocalTestingActorID(id: "42"), using: actorSystem)
+    return MyActor(distributedActor: distributedActor)
+  }
+}
+
+class Caller {
+  public var value: Set<Int> {
+    get async {
+      var value: Set<Int>
+      do {
+        let actor = try await makeActor(actorSystem: globalActorSystem)
+        let da = actor.distributedActor
+
+        _ = await da.distributedProperty // expected-error{{property access can throw but is not marked with 'try'}}
+        // expected-note@-1{{did you mean to use 'try'?}}
+        // expected-note@-2{{did you mean to handle error as optional value?}}
+        // expected-note@-3{{did you mean to disable error propagation?}}
+
+        _ = try da.distributedProperty // expected-error{{expression is 'async' but is not marked with 'await'}}
+        // expected-note@-1{{property access is 'async'}}
+
+        value = try await da.distributedProperty // ok, implicitly async + throws
+      } catch {
+        fatalError("\(error)")
+      }
+      return value
+    }
+  }
+
+  func makeActor(actorSystem: LocalTestingDistributedActorSystem) async throws -> MyActor {
+    try await MyActor.makeActor(actorSystem: actorSystem)
+  }
+}


### PR DESCRIPTION
Resolves https://github.com/apple/swift/issues/61070

Resolves rdar://99864733
Resolves rdar://102061790

A refactoring of effect handling seems to have broken this and we didn't have good coverage for it somehow?