### PR TITLE
[TypeResolver] Enable 'some' elision for opaque result types.

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -727,9 +727,11 @@ validateTypedPattern(TypedPattern *TP, DeclContext *dc,
   // property definition.
   auto &Context = dc->getASTContext();
   auto *Repr = TP->getTypeRepr();
-  if (Repr && Repr->hasOpaque()) {
+  if (Repr && (Repr->hasOpaque() ||
+               (Context.LangOpts.hasFeature(Feature::ImplicitSome) &&
+                Repr->isProtocol(dc)))) {
     auto named = dyn_cast<NamedPattern>(
-                           TP->getSubPattern()->getSemanticsProvidingPattern());
+        TP->getSubPattern()->getSemanticsProvidingPattern());
     if (!named) {
       Context.Diags.diagnose(TP->getLoc(),
                              diag::opaque_type_unsupported_pattern);

--- a/test/type/implicit_some/opaque_return.swift
+++ b/test/type/implicit_some/opaque_return.swift
@@ -103,3 +103,11 @@ func eat(_ myfruit: inout Basket) -> Basket {
   return myfruit
 }
 
+protocol P {
+  associatedtype A: P
+  var value: A { get }
+}
+
+struct S: P {
+  var value: P { self }
+}


### PR DESCRIPTION
Allows `some` to be elided for opaque return types under the `ImplicitSome` experimental feature flag.

```swift
protocol P {
  associatedtype A: P
  var value: A { get }
}

struct S: P {
  var value: P { self } // implicit 'some P'
}
```