### PR TITLE
test: enable C++ class inheritance test on Windows

### DIFF
--- a/test/Interop/Cxx/class/inheritance/fields.swift
+++ b/test/Interop/Cxx/class/inheritance/fields.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
 //
 // REQUIRES: executable_test
-//
-// Windows doesn't support -lc++ or -lstdc++.
-// UNSUPPORTED: OS=windows-msvc
 
 import CxxShim
 import StdlibUnittest


### PR DESCRIPTION
Now that this test builds on Windows, we can finally unmark it as UNSUPPORTED on windows.