### PR TITLE
Temporarily disable an Interop test on 32-bit

### DIFF
--- a/test/Interop/SwiftToC/structs/small-structs-pass-return-direct-in-c.swift
+++ b/test/Interop/SwiftToC/structs/small-structs-pass-return-direct-in-c.swift
@@ -4,6 +4,9 @@
 
 // RUN: %check-interop-c-header-in-clang(%t/structs.h -Wno-unused-function)
 
+// 32-bit disabled because of rdar://102147255
+// REQUIRES: PTRSIZE=64
+
 public struct StructOneI64 {
     let x: Int64
 }


### PR DESCRIPTION
See rdar://102147255
(Swift CI: [main] 1. OSS - Swift (Tools Opt+Assert, Stdlib DebInfo+Assert, Test Device non_executable)
TEST 'Swift(watchos-armv7k) :: Interop/SwiftToC/structs/small-structs-pass-return-direct-in-c.swift' FAILED)
