### PR TITLE
Fix ASTGen/verify-parse.swift in the release build

### DIFF
--- a/test/ASTGen/verify-parse.swift
+++ b/test/ASTGen/verify-parse.swift
@@ -2,6 +2,9 @@
 
 // REQUIRES: executable_test
 
+// -enable-experimental-feature requires and asserts build
+// REQUIRES: asserts
+
 func test1(x: Int, fn: (Int) -> Int) -> Int {
   let xx = fn(42)
   return fn(x)


### PR DESCRIPTION
-enable-experimental-feature requires and asserts build
