### PR TITLE
Reapply "Implement several peephole optimizations to unblock further optimizations of autodiff code" with correctness fix

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4699,6 +4699,17 @@ public:
   /// differentiability from all parameters.
   CanSILFunctionType getWithoutDifferentiability();
 
+  /// Given that `this` is a `@differentiable` function type, returns the type
+  /// of the given `@differentiable` function type component.
+  CanSILFunctionType getDifferentiableComponentType(
+      NormalDifferentiableFunctionTypeComponent component, SILModule &module);
+
+  /// Given that `this` is a `@differentiable(linear)` function type, returns
+  /// the type of the given `@differentiable(linear)` function type component.
+  CanSILFunctionType
+  getLinearComponentType(LinearDifferentiableFunctionTypeComponent component,
+                         SILModule &module);
+
   /// Returns the type of the derivative function for the given parameter
   /// indices, result indices, derivative function kind, derivative function
   /// generic signature (optional), and other auxiliary parameters.

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -9628,6 +9628,34 @@ public:
     }
     llvm_unreachable("invalid derivative kind");
   }
+
+  
+  /// Returns true iff the operand corresponding to the given extractee kind
+  /// exists.
+  bool hasExtractee(NormalDifferentiableFunctionTypeComponent extractee) const {
+    switch (extractee) {
+    case NormalDifferentiableFunctionTypeComponent::Original:
+      return true;
+    case NormalDifferentiableFunctionTypeComponent::JVP:
+    case NormalDifferentiableFunctionTypeComponent::VJP:
+      return hasDerivativeFunctions();
+    }
+    llvm_unreachable("invalid extractee kind");
+  }
+
+  /// Returns the operand corresponding to the given extractee kind.
+  SILValue
+  getExtractee(NormalDifferentiableFunctionTypeComponent extractee) const {
+    switch (extractee) {
+    case NormalDifferentiableFunctionTypeComponent::Original:
+      return getOriginalFunction();
+    case NormalDifferentiableFunctionTypeComponent::JVP:
+      return getJVPFunction();
+    case NormalDifferentiableFunctionTypeComponent::VJP:
+      return getVJPFunction();
+    }
+    llvm_unreachable("invalid extractee kind");
+  }
 };
 
 /// LinearFunctionInst - given a function, its derivative and transpose functions,
@@ -9667,6 +9695,31 @@ public:
   SILValue getTransposeFunction() const {
     assert(HasTransposeFunction);
     return getOperand(1);
+  }
+
+  
+  /// Returns true iff the operand corresponding to the given extractee kind
+  /// exists.
+  bool hasExtractee(LinearDifferentiableFunctionTypeComponent extractee) const {
+    switch (extractee) {
+    case LinearDifferentiableFunctionTypeComponent::Original:
+      return true;
+    case LinearDifferentiableFunctionTypeComponent::Transpose:
+      return hasTransposeFunction();
+    }
+    llvm_unreachable("invalid extractee kind");
+  }
+
+  /// Returns the operand corresponding to the given extractee kind.
+  SILValue
+  getExtractee(LinearDifferentiableFunctionTypeComponent extractee) const {
+    switch (extractee) {
+    case LinearDifferentiableFunctionTypeComponent::Original:
+      return getOriginalFunction();
+    case LinearDifferentiableFunctionTypeComponent::Transpose:
+      return getTransposeFunction();
+    }
+    llvm_unreachable("invalid extractee kind");
   }
 };
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -263,6 +263,35 @@ IndexSubset *SILFunctionType::getDifferentiabilityResultIndices() {
   return IndexSubset::get(getASTContext(), numSemanticResults, resultIndices);
 }
 
+CanSILFunctionType SILFunctionType::getDifferentiableComponentType(
+    NormalDifferentiableFunctionTypeComponent component, SILModule &module) {
+  assert(getDifferentiabilityKind() == DifferentiabilityKind::Reverse &&
+         "Must be a `@differentiable(reverse)` function");
+  auto originalFnTy = getWithoutDifferentiability();
+  if (auto derivativeKind = component.getAsDerivativeFunctionKind()) {
+    return originalFnTy->getAutoDiffDerivativeFunctionType(
+        getDifferentiabilityParameterIndices(),
+        getDifferentiabilityResultIndices(), *derivativeKind, module.Types,
+        LookUpConformanceInModule(module.getSwiftModule()));
+  }
+  return originalFnTy;
+}
+
+CanSILFunctionType SILFunctionType::getLinearComponentType(
+    LinearDifferentiableFunctionTypeComponent component, SILModule &module) {
+  assert(getDifferentiabilityKind() == DifferentiabilityKind::Linear &&
+         "Must be a `@differentiable(linear)` function");
+  auto originalFnTy = getWithoutDifferentiability();
+  switch (component) {
+  case LinearDifferentiableFunctionTypeComponent::Original:
+    return originalFnTy;
+  case LinearDifferentiableFunctionTypeComponent::Transpose:
+    return originalFnTy->getAutoDiffTransposeFunctionType(
+        getDifferentiabilityParameterIndices(), module.Types,
+        LookUpConformanceInModule(module.getSwiftModule()));
+  }
+}
+
 CanSILFunctionType
 SILFunctionType::getWithDifferentiability(DifferentiabilityKind kind,
                                           IndexSubset *parameterIndices,

--- a/lib/SILOptimizer/Mandatory/Differentiation.cpp
+++ b/lib/SILOptimizer/Mandatory/Differentiation.cpp
@@ -62,12 +62,6 @@ using llvm::SmallSet;
 static llvm::cl::opt<bool> EnableExperimentalLinearMapTransposition(
     "enable-experimental-linear-map-transposition", llvm::cl::init(false));
 
-/// This flag is used to disable `differentiable_function_extract` instruction
-/// folding for SIL testing purposes.
-static llvm::cl::opt<bool> SkipFoldingDifferentiableFunctionExtraction(
-    "differentiation-skip-folding-differentiable-function-extraction",
-    llvm::cl::init(true));
-
 //===----------------------------------------------------------------------===//
 // Helpers
 //===----------------------------------------------------------------------===//
@@ -127,17 +121,6 @@ public:
   /// Process the given `linear_function` instruction, filling in the missing
   /// transpose function if necessary.
   bool processLinearFunctionInst(LinearFunctionInst *lfi);
-
-  /// Fold `differentiable_function_extract` users of the given
-  /// `differentiable_function` instruction, directly replacing them with
-  /// `differentiable_function` instruction operands. If the
-  /// `differentiable_function` instruction has no remaining uses, delete the
-  /// instruction itself after folding.
-  ///
-  /// Folding can be disabled by the
-  /// `SkipFoldingDifferentiableFunctionExtraction` flag for SIL testing
-  /// purposes.
-  void foldDifferentiableFunctionExtraction(DifferentiableFunctionInst *source);
 };
 
 } // end anonymous namespace
@@ -1239,51 +1222,6 @@ SILValue DifferentiationTransformer::promoteToLinearFunction(
   return newLinearFn;
 }
 
-/// Fold `differentiable_function_extract` users of the given
-/// `differentiable_function` instruction, directly replacing them with
-/// `differentiable_function` instruction operands. If the
-/// `differentiable_function` instruction has no remaining uses, delete the
-/// instruction itself after folding.
-///
-/// Folding can be disabled by the `SkipFoldingDifferentiableFunctionExtraction`
-/// flag for SIL testing purposes.
-// FIXME: This function is not correctly detecting the foldable pattern and
-// needs to be rewritten.
-void DifferentiationTransformer::foldDifferentiableFunctionExtraction(
-    DifferentiableFunctionInst *source) {
-  // Iterate through all `differentiable_function` instruction uses.
-  for (auto use : source->getUses()) {
-    auto *dfei = dyn_cast<DifferentiableFunctionExtractInst>(use->getUser());
-    // If user is not an `differentiable_function_extract` instruction, set flag
-    // to false.
-    if (!dfei)
-      continue;
-    // Fold original function extractors.
-    if (dfei->getExtractee() ==
-        NormalDifferentiableFunctionTypeComponent::Original) {
-      auto originalFnValue = source->getOriginalFunction();
-      dfei->replaceAllUsesWith(originalFnValue);
-      dfei->eraseFromParent();
-      continue;
-    }
-    // Fold derivative function extractors.
-    auto derivativeFnValue =
-        source->getDerivativeFunction(dfei->getDerivativeFunctionKind());
-    dfei->replaceAllUsesWith(derivativeFnValue);
-    dfei->eraseFromParent();
-  }
-  // If the `differentiable_function` instruction has no remaining uses, erase
-  // it.
-  if (isInstructionTriviallyDead(source)) {
-    SILBuilder builder(source);
-    builder.emitDestroyAddrAndFold(source->getLoc(), source->getJVPFunction());
-    builder.emitDestroyAddrAndFold(source->getLoc(), source->getVJPFunction());
-    source->eraseFromParent();
-  }
-  // Mark `source` as processed so that it won't be reprocessed after deletion.
-  context.markDifferentiableFunctionInstAsProcessed(source);
-}
-
 bool DifferentiationTransformer::processDifferentiableFunctionInst(
     DifferentiableFunctionInst *dfi) {
   PrettyStackTraceSILNode dfiTrace("canonicalizing `differentiable_function`",
@@ -1312,14 +1250,6 @@ bool DifferentiationTransformer::processDifferentiableFunctionInst(
   // Destroy the original operand.
   builder.emitDestroyValueOperation(loc, dfi->getOriginalFunction());
   dfi->eraseFromParent();
-  // If the promoted `@differentiable` function-typed value is an
-  // `differentiable_function` instruction, fold
-  // `differentiable_function_extract` instructions. If
-  // `differentiable_function_extract` folding is disabled, return.
-  if (!SkipFoldingDifferentiableFunctionExtraction)
-    if (auto *newDFI =
-            dyn_cast<DifferentiableFunctionInst>(differentiableFnValue))
-      foldDifferentiableFunctionExtraction(newDFI);
   transform.invalidateAnalysis(parent,
                                SILAnalysis::InvalidationKind::FunctionBody);
   return false;

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -294,7 +294,9 @@ public:
   SILInstruction *visitConvertFunctionInst(ConvertFunctionInst *CFI);
   SILInstruction *
   visitConvertEscapeToNoEscapeInst(ConvertEscapeToNoEscapeInst *Cvt);
-
+  SILInstruction *
+  visitDifferentiableFunctionExtractInst(DifferentiableFunctionExtractInst *DFEI);
+  
   SILInstruction *legacyVisitGlobalValueInst(GlobalValueInst *globalValue);
 
 #define PASS(ID, TAG, DESCRIPTION)

--- a/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
@@ -1074,18 +1074,20 @@ SILInstruction *SILCombiner::visitConvertEscapeToNoEscapeInst(
   //
   // This unblocks the `thin_to_thick_function` peephole optimization below.
   if (auto *CFI = dyn_cast<ConvertFunctionInst>(Cvt->getConverted())) {
-    if (auto *TTTFI = dyn_cast<ThinToThickFunctionInst>(CFI->getConverted())) {
-      if (TTTFI->getSingleUse()) {
-        auto convertedThickType = CFI->getType().castTo<SILFunctionType>();
-        auto convertedThinType = convertedThickType->getWithRepresentation(
+    if (CFI->getSingleUse()) {
+      if (auto *TTTFI = dyn_cast<ThinToThickFunctionInst>(CFI->getConverted())) {
+        if (TTTFI->getSingleUse()) {
+          auto convertedThickType = CFI->getType().castTo<SILFunctionType>();
+          auto convertedThinType = convertedThickType->getWithRepresentation(
             SILFunctionTypeRepresentation::Thin);
-        auto *newCFI = Builder.createConvertFunction(
+          auto *newCFI = Builder.createConvertFunction(
             CFI->getLoc(), TTTFI->getConverted(),
             SILType::getPrimitiveObjectType(convertedThinType),
             CFI->withoutActuallyEscaping());
-        auto *newTTTFI = Builder.createThinToThickFunction(
+          auto *newTTTFI = Builder.createThinToThickFunction(
             TTTFI->getLoc(), newCFI, CFI->getType());
-        replaceInstUsesWith(*CFI, newTTTFI);
+          replaceInstUsesWith(*CFI, newTTTFI);
+        }
       }
     }
   }

--- a/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerCastVisitors.cpp
@@ -1065,16 +1065,92 @@ visitCheckedCastAddrBranchInst(CheckedCastAddrBranchInst *CCABI) {
 
 SILInstruction *SILCombiner::visitConvertEscapeToNoEscapeInst(
     ConvertEscapeToNoEscapeInst *Cvt) {
-  auto *OrigThinToThick =
-      dyn_cast<ThinToThickFunctionInst>(Cvt->getConverted());
-  if (!OrigThinToThick)
-    return nullptr;
-  auto origFunType = OrigThinToThick->getType().getAs<SILFunctionType>();
-  auto NewTy = origFunType->getWithExtInfo(origFunType->getExtInfo().withNoEscape(true));
+  // Rewrite conversion of `convert_function` of `thin_to_thick_function` as
+  // conversion of `thin_to_thick_function` of `convert_function`.
+  //
+  // (convert_escape_to_noescape (convert_function (thin_to_thick_function x)))
+  // =>
+  // (convert_escape_to_noescape (thin_to_thick_function (convert_function x)))
+  //
+  // This unblocks the `thin_to_thick_function` peephole optimization below.
+  if (auto *CFI = dyn_cast<ConvertFunctionInst>(Cvt->getConverted())) {
+    if (auto *TTTFI = dyn_cast<ThinToThickFunctionInst>(CFI->getConverted())) {
+      if (TTTFI->getSingleUse()) {
+        auto convertedThickType = CFI->getType().castTo<SILFunctionType>();
+        auto convertedThinType = convertedThickType->getWithRepresentation(
+            SILFunctionTypeRepresentation::Thin);
+        auto *newCFI = Builder.createConvertFunction(
+            CFI->getLoc(), TTTFI->getConverted(),
+            SILType::getPrimitiveObjectType(convertedThinType),
+            CFI->withoutActuallyEscaping());
+        auto *newTTTFI = Builder.createThinToThickFunction(
+            TTTFI->getLoc(), newCFI, CFI->getType());
+        replaceInstUsesWith(*CFI, newTTTFI);
+      }
+    }
+  }
 
-  return Builder.createThinToThickFunction(
+  // Rewrite conversion of `thin_to_thick_function` as `thin_to_thick_function`
+  // with a noescape function type.
+  //
+  // (convert_escape_to_noescape (thin_to_thick_function x)) =>
+  // (thin_to_thick_function [noescape] x)
+  if (auto *OrigThinToThick = dyn_cast<ThinToThickFunctionInst>(Cvt->getConverted())) {
+    auto origFunType = OrigThinToThick->getType().getAs<SILFunctionType>();
+    auto NewTy = origFunType->getWithExtInfo(origFunType->getExtInfo().withNoEscape(true));
+
+    return Builder.createThinToThickFunction(
       OrigThinToThick->getLoc(), OrigThinToThick->getOperand(),
       SILType::getPrimitiveObjectType(NewTy));
+  }
+
+  // Push conversion instructions inside `differentiable_function`. This
+  // unblocks more optimizations.
+  //
+  // Before:
+  // %x = differentiable_function(%orig, %jvp, %vjp)
+  // %y = convert_escape_to_noescape %x
+  //
+  // After:
+  // %orig' = convert_escape_to_noescape %orig
+  // %jvp' = convert_escape_to_noescape %jvp
+  // %vjp' = convert_escape_to_noescape %vjp
+  // %y = differentiable_function(%orig', %jvp', %vjp')
+  if (auto *DFI = dyn_cast<DifferentiableFunctionInst>(Cvt->getConverted())) {
+    auto createConvertEscapeToNoEscape = [&](NormalDifferentiableFunctionTypeComponent extractee) {
+      if (!DFI->hasExtractee(extractee))
+        return SILValue();
+        
+      auto operand = DFI->getExtractee(extractee);
+      auto fnType = operand->getType().castTo<SILFunctionType>();
+      auto noEscapeFnType =
+        fnType->getWithExtInfo(fnType->getExtInfo().withNoEscape());
+      auto noEscapeType = SILType::getPrimitiveObjectType(noEscapeFnType);
+      return Builder.createConvertEscapeToNoEscape(
+        operand.getLoc(), operand, noEscapeType, Cvt->isLifetimeGuaranteed())->getResult(0);
+    };
+    
+    SILValue originalNoEscape =
+      createConvertEscapeToNoEscape(NormalDifferentiableFunctionTypeComponent::Original);
+    SILValue convertedJVP = createConvertEscapeToNoEscape(
+      NormalDifferentiableFunctionTypeComponent::JVP);
+    SILValue convertedVJP = createConvertEscapeToNoEscape(
+      NormalDifferentiableFunctionTypeComponent::VJP);
+
+    Optional<std::pair<SILValue, SILValue>> derivativeFunctions;
+    if (convertedJVP && convertedVJP)
+      derivativeFunctions = std::make_pair(convertedJVP, convertedVJP);
+
+    auto *newDFI = Builder.createDifferentiableFunction(
+      DFI->getLoc(), DFI->getParameterIndices(), DFI->getResultIndices(),
+      originalNoEscape, derivativeFunctions);
+    assert(newDFI->getType() == Cvt->getType() &&
+           "New `@differentiable` function instruction should have same type "
+           "as the old `convert_escape_to_no_escape` instruction");
+    return newDFI;
+  }  
+  
+  return nullptr;
 }
 
 SILInstruction *
@@ -1207,6 +1283,54 @@ SILCombiner::visitConvertFunctionInst(ConvertFunctionInst *cfi) {
       return std::move(folder).optimizeWithSetValue(subCFI->getConverted());
   }
 
+  // Push conversion instructions inside `differentiable_function`. This
+  // unblocks more optimizations.
+  //
+  // Before:
+  // %x = differentiable_function(%orig, %jvp, %vjp)
+  // %y = convert_function %x
+  //
+  // After:
+  // %orig' = convert_function %orig
+  // %jvp' = convert_function %jvp
+  // %vjp' = convert_function %vjp
+  // %y = differentiable_function(%orig', %jvp', %vjp')
+  if (auto *DFI = dyn_cast<DifferentiableFunctionInst>(cfi->getConverted())) {
+    auto createConvertFunctionOfComponent =
+      [&](NormalDifferentiableFunctionTypeComponent extractee) {
+        if (!DFI->hasExtractee(extractee))
+          return SILValue();
+        
+        auto operand = DFI->getExtractee(extractee);
+        auto convertInstType =
+            cfi->getType().castTo<SILFunctionType>();
+        auto convertedComponentFnType =
+            convertInstType->getDifferentiableComponentType(
+                extractee, Builder.getModule());
+        auto convertedComponentType =
+        SILType::getPrimitiveObjectType(convertedComponentFnType);
+        return Builder.createConvertFunction(
+            operand.getLoc(), operand, convertedComponentType,
+            cfi->withoutActuallyEscaping())->getResult(0);
+      };
+      SILValue convertedOriginal = createConvertFunctionOfComponent(
+          NormalDifferentiableFunctionTypeComponent::Original);
+      SILValue convertedJVP = createConvertFunctionOfComponent(
+          NormalDifferentiableFunctionTypeComponent::JVP);
+      SILValue convertedVJP = createConvertFunctionOfComponent(
+          NormalDifferentiableFunctionTypeComponent::VJP);
+      Optional<std::pair<SILValue, SILValue>> derivativeFunctions;
+      if (convertedJVP && convertedVJP)
+        derivativeFunctions = std::make_pair(convertedJVP, convertedVJP);
+      auto *newDFI = Builder.createDifferentiableFunction(
+          DFI->getLoc(), DFI->getParameterIndices(), DFI->getResultIndices(),
+          convertedOriginal, derivativeFunctions);
+      assert(newDFI->getType() == cfi->getType() &&
+             "New `@differentiable` function instruction should have same type "
+             "as the old `convert_function` instruction");
+      return newDFI;
+  }
+  
   // Replace a convert_function that only has refcounting uses with its
   // operand.
   tryEliminateOnlyOwnershipUsedForwardingInst(cfi, getInstModCallbacks());

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -2337,4 +2337,42 @@ SILCombiner::legacyVisitGlobalValueInst(GlobalValueInst *globalValue) {
     eraseInstFromFunction(*inst);
   }
   return nullptr;
+
+}
+
+// Simplify `differentiable_function_extract` of `differentiable_function`.
+//
+// Before:
+// %diff_func = differentiable_function(%orig, %jvp, %vjp)
+// %orig' = differentiable_function_extract [original] %diff_func
+// %jvp'  = differentiable_function_extract [jvp]      %diff_func
+// %vjp'  = differentiable_function_extract [vjp]      %diff_func
+//
+// After:
+// %orig' = %orig
+// %jvp' = %jvp
+// %vjp' = %vjp
+SILInstruction *
+SILCombiner::visitDifferentiableFunctionExtractInst(DifferentiableFunctionExtractInst *DFEI) {
+  auto *DFI = dyn_cast<DifferentiableFunctionInst>(DFEI->getOperand());
+  if (!DFI)
+    return nullptr;
+
+  if (!DFI->hasExtractee(DFEI->getExtractee()))
+    return nullptr;
+
+  SILValue newValue = DFI->getExtractee(DFEI->getExtractee());
+
+  // If the type of the `differentiable_function` operand does not precisely
+  // match the type of the original `differentiable_function_extract`,
+  // create a `convert_function`.
+  if (newValue->getType() != DFEI->getType()) {
+    std::tie(newValue, std::ignore) =
+      castValueToABICompatibleType(&Builder, DFEI->getLoc(),
+                                   newValue,
+                                   newValue->getType(), DFEI->getType(), {});
+  }
+
+  replaceInstUsesWith(*DFEI, newValue);
+  return eraseInstFromFunction(*DFEI);
 }

--- a/test/AutoDiff/e2e_optimizations.swift
+++ b/test/AutoDiff/e2e_optimizations.swift
@@ -1,0 +1,118 @@
+// RUN: %target-swift-frontend -emit-sil -O %s | %FileCheck %s
+import _Differentiation
+
+@_silgen_name("blackHole")
+@inline(never)
+@discardableResult
+func blackHole<T>(_ x: T) -> T { x }
+
+func float(_ x0: Float) -> Float {
+  let x1 = x0 * x0
+  let x2 = x1 + x1
+  let x3 = x2 - x1
+  let x4 = x3 / x2
+  return x4
+}
+
+@_silgen_name("test_gradient_float")
+func test_gradient_float() {
+  blackHole(gradient(at: 10, of: float))
+}
+
+// Check that `apply`s are fully inlined.
+// CHECK-LABEL: sil hidden @test_gradient_float : $@convention(thin) () -> ()
+// CHECK-NOT: apply
+// CHECK: [[GRADIENT_RESULT:%.*]] = struct $Float ({{.*}} : $Builtin.FPIEEE32)
+// CHECK: [[FN_REF:%.*]] = function_ref @$s9blackHoleSf_Tg5 : $@convention(thin) (Float) -> Float
+// CHECK-NEXT: apply [[FN_REF:%.*]]([[GRADIENT_RESULT]])
+// CHECK-NOT: apply
+// CHECK-LABEL: } // end sil function 'test_gradient_float'
+func float_mutation(_ x: Float) -> Float {
+  var result = x * x
+  result = result + result
+  result = result - x
+  result = result / x
+  return result
+}
+
+@_silgen_name("test_gradient_float_mutation")
+func test_gradient_float_mutation() {
+  blackHole(gradient(at: 10, of: float_mutation))
+}
+
+// Check that `apply`s are fully inlined.
+// CHECK-LABEL: sil hidden @test_gradient_float_mutation : $@convention(thin) () -> ()
+// CHECK-NOT: apply
+// CHECK: [[GRADIENT_RESULT:%.*]] = struct $Float ({{.*}} : $Builtin.FPIEEE32)
+// CHECK: [[FN_REF:%.*]] = function_ref @$s9blackHoleSf_Tg5 : $@convention(thin) (Float) -> Float
+// CHECK-NEXT: apply [[FN_REF:%.*]]([[GRADIENT_RESULT]])
+// CHECK-NOT: apply
+// CHECK-LABEL: } // end sil function 'test_gradient_float_mutation'
+func float_conditional(_ x: Float, _ bool: Bool) -> Float {
+  var result = x * x
+  if bool {
+    result = result + result
+    result = result - x
+  } else {
+    result = result / x
+  }
+  return result
+}
+
+@_silgen_name("test_gradient_float_conditional")
+func test_gradient_float_conditional() {
+  blackHole(gradient(at: 10, of: { float_conditional($0, true) }))
+}
+
+// Check that `apply`s are fully inlined.
+// CHECK-LABEL: sil hidden @test_gradient_float_conditional : $@convention(thin) () -> ()
+// CHECK-NOT: apply
+// CHECK: [[GRADIENT_RESULT:%.*]] = struct $Float ({{.*}} : $Builtin.FPIEEE32)
+// CHECK: [[FN_REF:%.*]] = function_ref @$s9blackHoleSf_Tg5 : $@convention(thin) (Float) -> Float
+// CHECK-NEXT: apply [[FN_REF:%.*]]([[GRADIENT_RESULT]])
+// CHECK-NOT: apply
+// CHECK-LABEL: } // end sil function 'test_gradient_float_conditional'
+func float_loop(_ x: Float, count: Int) -> Float {
+  var result: Float = 0
+  for _ in 0..<count {
+    result = result * x
+  }
+  return result
+}
+
+@_silgen_name("test_gradient_float_loop")
+func test_gradient_float_loop() {
+  blackHole(gradient(at: 10, of: { float_loop($0, count: 10) }))
+}
+
+// Check whether `apply`s are inlined.
+// Currently, the VJP is inlined but the pullback is not.
+// CHECK-LABEL: sil hidden @test_gradient_float_loop : $@convention(thin) () -> ()
+// CHECK: [[PB_FN_REF:%.*]] = function_ref @{{.*}}24test_gradient_float_loopyyFS2fcfU_TJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK: [[GRADIENT_RESULT:%.*]] = apply [[PB_FN_REF]]
+// CHECK: [[EXTRACT:%.*]] = tuple_extract [[GRADIENT_RESULT]]
+// CHECK: [[GRADIENT_RESULT2:%.*]] = apply [[EXTRACT]]
+// CHECK: [[FN_REF:%.*]] = function_ref @$s9blackHoleSf_Tg5 : $@convention(thin) (Float) -> Float
+// CHECK-NEXT: apply [[FN_REF:%.*]]([[GRADIENT_RESULT2]])
+// CHECK-NOT: apply
+// CHECK-LABEL: } // end sil function 'test_gradient_float_loop'
+func array_loop(_ array: [Float]) -> Float {
+  var result: Float = 0
+  for i in withoutDerivative(at: array.indices) {
+    result += array[i]
+  }
+  return result
+}
+
+@_silgen_name("test_gradient_array_loop")
+func test_gradient_array_loop() {
+  blackHole(gradient(at: [3, 4, 5], of: array_loop))
+}
+
+// Check whether `apply`s are inlined.
+// Currently, the VJP is not inlined.
+// CHECK-LABEL: sil hidden @test_gradient_array_loop : $@convention(thin) () -> ()
+// CHECK: [[VJP_FN_REF:%.*]] = function_ref @{{.*}}10array_loopySfSaySfGFTJrSpSr : $@convention(thin) (@guaranteed Array<Float>) -> (Float, @owned @callee_guaranteed (Float) -> @owned Array<Float>.DifferentiableView)
+// CHECK: [[VJP_RESULT:%.*]] = apply [[VJP_FN_REF]]
+// CHECK-LABEL: } // end sil function 'test_gradient_array_loop' 
+

--- a/test/AutoDiff/e2e_optimizations.swift
+++ b/test/AutoDiff/e2e_optimizations.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -O %s | %FileCheck %s
+// REQUIRES: swift_in_compiler
 import _Differentiation
 
 @_silgen_name("blackHole")

--- a/test/AutoDiff/sil_combine.sil
+++ b/test/AutoDiff/sil_combine.sil
@@ -1,0 +1,61 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -sil-combine | %FileCheck %s
+
+// SILCombine tests for differentiation-related instructions.
+
+sil_stage canonical
+
+import Swift
+import _Differentiation
+
+// MARK: `differentiable_function_extract` folding
+
+sil @differentiable_function_extract_orig : $@convention(thin) (@callee_guaranteed (Float) -> Float) -> (@callee_guaranteed (Float) -> Float) {
+bb0(%orig : $@callee_guaranteed (Float) -> Float):
+  %diff_fn = differentiable_function [parameters 0] [results 0] %orig : $@callee_guaranteed (Float) -> Float
+  %extracted_orig = differentiable_function_extract [original] %diff_fn : $@callee_guaranteed @differentiable(reverse) (Float) -> Float
+  return %extracted_orig : $@callee_guaranteed (Float) -> Float
+}
+
+// CHECK-LABEL: sil @differentiable_function_extract_orig : $@convention(thin) (@callee_guaranteed (Float) -> Float) -> @callee_guaranteed (Float) -> Float {
+// CHECK: bb0([[ORIG_FN:%.*]] : $@callee_guaranteed (Float) -> Float):
+// CHECK:   return [[ORIG_FN]] : $@callee_guaranteed (Float) -> Float
+// CHECK-LABEL: } // end sil function 'differentiable_function_extract_orig'
+
+sil @differentiable_function_extract_jvp : $@convention(thin) (@callee_guaranteed (Float) -> Float, @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> (@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) {
+bb0(%orig : $@callee_guaranteed (Float) -> Float, %jvp : $@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)):
+  %diff_fn = differentiable_function [parameters 0] [results 0] %orig : $@callee_guaranteed (Float) -> Float with_derivative {%jvp : $@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), undef : $@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
+  %extracted_jvp = differentiable_function_extract [jvp] %diff_fn : $@callee_guaranteed @differentiable(reverse) (Float) -> Float
+  return %extracted_jvp : $@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+}
+
+// CHECK-LABEL: sil @differentiable_function_extract_jvp : $@convention(thin) (@callee_guaranteed (Float) -> Float, @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+// CHECK: bb0([[ORIG_FN:%.*]] : $@callee_guaranteed (Float) -> Float, [[JVP_FN:%.*]] : $@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)):
+// CHECK:   return [[JVP_FN]] : $@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK-LABEL: } // end sil function 'differentiable_function_extract_jvp'
+
+sil @differentiable_function_extract_vjp : $@convention(thin) (@callee_guaranteed (Float) -> Float, @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> (@callee_guaranteed  (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) {
+bb0(%orig : $@callee_guaranteed (Float) -> Float, %vjp : $@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)):
+  %diff_fn = differentiable_function [parameters 0] [results 0] %orig : $@callee_guaranteed (Float) -> Float with_derivative {undef : $@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float), %vjp : $@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)}
+  %extracted_vjp = differentiable_function_extract [vjp] %diff_fn : $@callee_guaranteed @differentiable(reverse) (Float) -> Float
+  return %extracted_vjp : $@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+}
+
+// CHECK-LABEL: sil @differentiable_function_extract_vjp : $@convention(thin) (@callee_guaranteed (Float) -> Float, @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) -> @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+// CHECK: bb0([[ORIG_FN:%.*]] : $@callee_guaranteed (Float) -> Float, [[VJP_FN:%.*]] : $@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)):
+// CHECK:   return [[VJP_FN]] : $@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK-LABEL: } // end sil function 'differentiable_function_extract_vjp'
+
+// Test `differentiatiable_function_extract [vjp] %diff_fn` where `%diff_fn` does not have a VJP function operand.
+sil @differentiable_function_extract_vjp_undefined : $@convention(thin) (@callee_guaranteed (Float) -> Float) -> (@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)) {
+bb0(%orig : $@callee_guaranteed (Float) -> Float):
+  %diff_fn = differentiable_function [parameters 0] [results 0] %orig : $@callee_guaranteed (Float) -> Float
+  %extracted_vjp = differentiable_function_extract [vjp] %diff_fn : $@callee_guaranteed @differentiable(reverse) (Float) -> Float
+  return %extracted_vjp : $@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+}
+
+// CHECK-LABEL: sil @differentiable_function_extract_vjp_undefined : $@convention(thin) (@callee_guaranteed (Float) -> Float) -> @callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
+// CHECK: bb0([[ORIG_FN:%.*]] : $@callee_guaranteed (Float) -> Float):
+// CHECK:   [[DIFF_FN:%.*]] = differentiable_function [parameters 0] [results 0] [[ORIG_FN]] : $@callee_guaranteed (Float) -> Float
+// CHECK:   [[EXTRACTED_VJP:%.*]] = differentiable_function_extract [vjp] [[DIFF_FN]] : $@differentiable(reverse) @callee_guaranteed (Float) -> Float
+// CHECK:   return [[EXTRACTED_VJP]] : $@callee_guaranteed (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float)
+// CHECK-LABEL: } // end sil function 'differentiable_function_extract_vjp_undefined' 

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -3843,6 +3843,34 @@ bb0:
   return %4 : $Builtin.Int32
 }
 
+// Test the following transformation:
+// (convert_escape_to_noescape (convert_function (thin_to_thick_function x))) =>
+// (thin_to_thick_function (convert_function x))
+
+sil @returnIndirectInt : $@convention(thin) () -> @out Builtin.Int32
+
+// CHECK-LABEL: sil @optimize_convert_escape_to_noescape_convert_function : $@convention(thin) () -> Builtin.Int32
+// CHECK:   [[FN_REF:%.*]] = function_ref @returnIndirectInt : $@convention(thin) () -> @out Builtin.Int32
+// CHECK:   [[INDIRECT_RESULT:%.*]] = alloc_stack $Builtin.Int32
+// CHECK:   apply [[FN_REF]]([[INDIRECT_RESULT]]) : $@convention(thin) () -> @out Builtin.Int32
+// CHECK:   [[RESULT:%.*]] = load [[INDIRECT_RESULT]] : $*Builtin.Int32
+// CHECK:   dealloc_stack [[INDIRECT_RESULT]] : $*Builtin.Int32
+// CHECK:   return [[RESULT]] : $Builtin.Int32
+
+sil @optimize_convert_escape_to_noescape_convert_function : $@convention(thin) () -> Builtin.Int32 {
+bb0:
+  %0 = function_ref @returnIndirectInt : $@convention(thin) () -> @out Builtin.Int32
+  %1 = thin_to_thick_function %0 : $@convention(thin) () -> @out Builtin.Int32 to $@callee_guaranteed () -> @out Builtin.Int32
+  %2 = convert_function %1 : $@callee_guaranteed () -> @out Builtin.Int32 to $@callee_guaranteed @substituted <A> () -> @out A for <Builtin.Int32>
+  %3 = convert_escape_to_noescape %2: $@callee_guaranteed @substituted <A> () -> @out A for <Builtin.Int32> to $@noescape @callee_guaranteed @substituted <A> () -> @out A for <Builtin.Int32>
+  %4 = alloc_stack $Builtin.Int32
+  %5 = apply %3(%4) : $@noescape @callee_guaranteed @substituted <A> () -> @out A for <Builtin.Int32>
+  %6 = load %4 : $*Builtin.Int32
+  dealloc_stack %4 : $*Builtin.Int32
+  return %6 : $Builtin.Int32
+}
+
+
 // CHECK-LABEL: sil @optimize_arc_with_value_to_bridge_object
 // CHECK:      bb0(%0 : $Builtin.Int64):
 // CHECK-NEXT: struct $UInt64

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -3845,11 +3845,11 @@ bb0:
 
 // Test the following transformation:
 // (convert_escape_to_noescape (convert_function (thin_to_thick_function x))) =>
-// (thin_to_thick_function (convert_function x))
+// (convert_escape_to_noescape (thin_to_thick_function (convert_function x)))
 
 sil @returnIndirectInt : $@convention(thin) () -> @out Builtin.Int32
 
-// CHECK-LABEL: sil @optimize_convert_escape_to_noescape_convert_function : $@convention(thin) () -> Builtin.Int32
+// CHECK-LABEL: sil @optimize_convert_escape_to_noescape_convert_function1 : $@convention(thin) () -> Builtin.Int32
 // CHECK:   [[FN_REF:%.*]] = function_ref @returnIndirectInt : $@convention(thin) () -> @out Builtin.Int32
 // CHECK:   [[INDIRECT_RESULT:%.*]] = alloc_stack $Builtin.Int32
 // CHECK:   apply [[FN_REF]]([[INDIRECT_RESULT]]) : $@convention(thin) () -> @out Builtin.Int32
@@ -3857,7 +3857,7 @@ sil @returnIndirectInt : $@convention(thin) () -> @out Builtin.Int32
 // CHECK:   dealloc_stack [[INDIRECT_RESULT]] : $*Builtin.Int32
 // CHECK:   return [[RESULT]] : $Builtin.Int32
 
-sil @optimize_convert_escape_to_noescape_convert_function : $@convention(thin) () -> Builtin.Int32 {
+sil @optimize_convert_escape_to_noescape_convert_function1 : $@convention(thin) () -> Builtin.Int32 {
 bb0:
   %0 = function_ref @returnIndirectInt : $@convention(thin) () -> @out Builtin.Int32
   %1 = thin_to_thick_function %0 : $@convention(thin) () -> @out Builtin.Int32 to $@callee_guaranteed () -> @out Builtin.Int32
@@ -3870,6 +3870,45 @@ bb0:
   return %6 : $Builtin.Int32
 }
 
+sil @dummyUser : $(@callee_guaranteed @substituted<A> () -> @out A for <Builtin.Int32>) -> ()
+
+// CHECK-LABEL: sil @optimize_convert_escape_to_noescape_convert_function2 : $@convention(thin) () -> Builtin.Int32
+// CHECK: thin_to_thick_function
+// CHECK: convert_function
+sil @optimize_convert_escape_to_noescape_convert_function2 : $@convention(thin) () -> Builtin.Int32 {
+bb0:
+  %0 = function_ref @returnIndirectInt : $@convention(thin) () -> @out Builtin.Int32
+  %1 = thin_to_thick_function %0 : $@convention(thin) () -> @out Builtin.Int32 to $@callee_guaranteed () -> @out Builtin.Int32
+  %2 = convert_function %1 : $@callee_guaranteed () -> @out Builtin.Int32 to $@callee_guaranteed @substituted <A> () -> @out A for <Builtin.Int32>
+  %3 = function_ref @dummyUser : $@convention(thin) (@callee_guaranteed @substituted<A> () -> @out A for <Builtin.Int32>) -> ()
+  apply %3(%2) : $@convention(thin) (@callee_guaranteed @substituted<A> () -> @out A for <Builtin.Int32>) -> ()
+  %5 = convert_escape_to_noescape %2: $@callee_guaranteed @substituted <A> () -> @out A for <Builtin.Int32> to $@noescape @callee_guaranteed @substituted <A> () -> @out A for <Builtin.Int32>
+  %6 = alloc_stack $Builtin.Int32
+  %7 = apply %5(%6) : $@noescape @callee_guaranteed @substituted <A> () -> @out A for <Builtin.Int32>
+  %8 = load %6 : $*Builtin.Int32
+  dealloc_stack %6 : $*Builtin.Int32
+  return %8 : $Builtin.Int32
+}
+
+sil @dummyUser2 : $(@noescape @callee_guaranteed @substituted<A> () -> @out A for <Builtin.Int32>) -> ()
+
+// CHECK-LABEL: sil @optimize_convert_escape_to_noescape_convert_function3 : $@convention(thin) () -> Builtin.Int32
+// CHECK: thin_to_thick_function
+// CHECK: convert_function
+sil @optimize_convert_escape_to_noescape_convert_function3 : $@convention(thin) () -> Builtin.Int32 {
+bb0:
+  %0 = function_ref @returnIndirectInt : $@convention(thin) () -> @out Builtin.Int32
+  %1 = thin_to_thick_function %0 : $@convention(thin) () -> @out Builtin.Int32 to $@callee_guaranteed () -> @out Builtin.Int32
+  %2 = convert_function %1 : $@callee_guaranteed () -> @out Builtin.Int32 to $@callee_guaranteed @substituted <A> () -> @out A for <Builtin.Int32>
+  %3 = convert_escape_to_noescape %2: $@callee_guaranteed @substituted <A> () -> @out A for <Builtin.Int32> to $@noescape @callee_guaranteed @substituted <A> () -> @out A for <Builtin.Int32>
+  %4 = function_ref @dummyUser2 : $@convention(thin) (@noescape @callee_guaranteed @substituted<A> () -> @out A for <Builtin.Int32>) -> ()
+  apply %4(%3) : $@convention(thin) (@noescape @callee_guaranteed @substituted<A> () -> @out A for <Builtin.Int32>) -> ()
+  %6 = alloc_stack $Builtin.Int32
+  %7 = apply %3(%6) : $@noescape @callee_guaranteed @substituted <A> () -> @out A for <Builtin.Int32>
+  %8 = load %6 : $*Builtin.Int32
+  dealloc_stack %6 : $*Builtin.Int32
+  return %8 : $Builtin.Int32
+}
 
 // CHECK-LABEL: sil @optimize_arc_with_value_to_bridge_object
 // CHECK:      bb0(%0 : $Builtin.Int64):


### PR DESCRIPTION
The PR reapplies https://github.com/apple/swift/pull/60520 along with correctness fix – we only do the transformation when it is safe (the inner values have single use)

Fixes #61731