### PR TITLE
[CSSolver] Don't drop bindings with type variables while applying sol…

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -90,7 +90,7 @@ Solution ConstraintSystem::finalize() {
 
     case FreeTypeVariableBinding::Allow:
       break;
-        
+
     case FreeTypeVariableBinding::UnresolvedType:
       assignFixedType(tv, ctx.TheUnresolvedType);
       break;
@@ -99,6 +99,12 @@ Solution ConstraintSystem::finalize() {
 
   // For each of the type variables, get its fixed type.
   for (auto tv : getTypeVariables()) {
+    // This type variable has no binding. Allowed only
+    // when `FreeTypeVariableBinding::Allow` is set,
+    // which is checked above.
+    if (!getFixedType(tv))
+      continue;
+
     solution.typeBindings[tv] = simplifyType(tv)->reconstituteSugar(false);
   }
 
@@ -221,8 +227,10 @@ void ConstraintSystem::applySolution(const Solution &solution) {
 
     // If we don't already have a fixed type for this type variable,
     // assign the fixed type from the solution.
-    if (!getFixedType(binding.first) && !binding.second->hasTypeVariable())
-      assignFixedType(binding.first, binding.second, /*updateState=*/false);
+    if (getFixedType(binding.first))
+      continue;
+
+    assignFixedType(binding.first, binding.second, /*updateState=*/false);
   }
 
   // Register overload choices.

--- a/validation-test/Sema/SwiftUI/inner_closure_with_opaque_value_result.swift
+++ b/validation-test/Sema/SwiftUI/inner_closure_with_opaque_value_result.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -enable-experimental-feature ResultBuilderASTTransform -swift-version 5
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+struct Configuration {
+}
+
+struct Reader<Content: View> : View {
+  struct Result {
+    var view: AnyView?
+  }
+
+  var content: (Result) -> (Content)
+
+  var body: some View { EmptyView() }
+}
+
+struct MyLayout {
+  func callAsFunction<V: View>(@ViewBuilder content: () -> V) -> some View { content() }
+}
+
+struct Test<SubView: View>: View {
+  var subView: SubView
+  var body: some View { EmptyView() }
+}
+
+func test() -> some View {
+  Reader { result in
+    MyLayout().callAsFunction {
+      Test(subView: result.view)
+    }
+  }
+}


### PR DESCRIPTION
…utions

If a (partial) solution has a type variable it could only be unbound
if `FreeTypeVariableBinding` is set to `Allow`, in all other cases 
solution would either have a fully resolved type or a hole.

`applySolution` shouldn't second guess `finalize()` and just apply
 a solution as given. This is very important for multi-statement closures
 because their elements are solved in isolation and opaque value types
 inferred for their result could contain not-yet-resolved type variables
 from outer context in their substitution maps (which it totally legal
under bi-directional inference).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
