### PR TITLE
IRGen: Disable Interpreter/has_symbol.swift for optimized builds

### DIFF
--- a/test/Interpreter/has_symbol.swift
+++ b/test/Interpreter/has_symbol.swift
@@ -28,6 +28,9 @@
 // REQUIRES: executable_test
 // REQUIRES: VENDOR=apple
 
+// rdar://102159307 - #_hasSymbol needs to be implemented with a SILInstruction
+// REQUIRES: swift_test_mode_optimize_none
+
 @_weakLinked import helper
 
 // HAS-ANSWER: 42


### PR DESCRIPTION
Resolves rdar://102158765