### PR TITLE
[AddressLowering] Handle non-opaque checked casts.

### DIFF
--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1763,6 +1763,39 @@ bb0(%0 : @guaranteed $T):
   return %6 : $U
 }
 
+// Verify lowering of unconditional_checked_cast not involving address-only
+// values.
+// CHECK-LABEL: sil hidden [ossa] @test_unconditional_checked_cast4 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[SRC:%[^,]+]] :
+// CHECK:         [[SRC_ADDR:%[^,]+]] = alloc_stack $AnyObject
+// CHECK:         store [[SRC]] to [init] [[SRC_ADDR]] : $*AnyObject
+// CHECK:         [[DEST_ADDR:%[^,]+]] = alloc_stack $@thick any AnyObject.Type
+// CHECK:         unconditional_checked_cast_addr AnyObject in [[SRC_ADDR]] {{.*}} to @thick any AnyObject.Type in [[DEST_ADDR]]
+// CHECK:         load [trivial] [[DEST_ADDR]] : $*@thick any AnyObject.Type
+// CHECK-LABEL: } // end sil function 'test_unconditional_checked_cast4'
+sil hidden [ossa] @test_unconditional_checked_cast4 : $@convention(thin) (@owned AnyObject) -> () {
+entry(%instance : @owned $AnyObject):
+  %casted = unconditional_checked_cast %instance : $AnyObject to any AnyObject.Type
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Verify lowering of unconditional_checked_cast that involves address-only
+// values and also non-address-only values which on its own requires lowering
+// to unconditional_checked_cast_addr.
+// CHECK-LABEL: sil [ossa] @test_unconditional_checked_cast5 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[SRC_ADDR:%[^,]+]] :
+// CHECK:         [[DEST_ADDR:%[^,]+]] = alloc_stack $@thick any AnyObject.Type
+// CHECK:         unconditional_checked_cast_addr T in [[SRC_ADDR]] {{.*}} to @thick any AnyObject.Type in [[DEST_ADDR]]
+// CHECK:         load [trivial] [[DEST_ADDR]] : $*@thick any AnyObject.Type
+// CHECK-LABEL: } // end sil function 'test_unconditional_checked_cast5'
+sil [ossa] @test_unconditional_checked_cast5 : $@convention(thin) <T> (@in T) -> () {
+entry(%instance : @owned $T):
+  %casted = unconditional_checked_cast %instance : $T to any AnyObject.Type
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // CHECK-LABEL: sil [ossa] @yield_two : {{.*}} {
 // CHECK:         tuple_element_addr
 // CHECK:         tuple_element_addr

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1613,6 +1613,36 @@ bb3:
   return %31 : $()
 }
 
+// Test the result being stored into an @out enum.
+// CHECK-LABEL: sil [ossa] @test_checked_cast_br4 : $@convention(method) <Element><T> (@owned TestGeneric<Element>) -> @out Optional<T> {
+// CHECK:       {{bb[0-9]+}}([[OUT_ADDR:%[^,]+]] : $*Optional<T>, [[INSTANCE:%[^,]+]] : @owned $TestGeneric<Element>):
+// CHECK:         [[TEMP:%[^,]+]] = alloc_stack $Optional<T>
+// CHECK:         [[CAST_DEST_ADDR:%[^,]+]] = init_enum_data_addr [[TEMP]] : $*Optional<T>, #Optional.some!enumelt
+// CHECK:         [[CAST_SOURCE_ADDR:%[^,]+]] = alloc_stack $TestGeneric<Element>
+// CHECK:         store [[INSTANCE]] to [init] [[CAST_SOURCE_ADDR]]
+// CHECK:         checked_cast_addr_br take_on_success TestGeneric<Element> in [[CAST_SOURCE_ADDR]] : $*TestGeneric<Element> to T in [[CAST_DEST_ADDR]] : $*T, [[SUCCESS:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         dealloc_stack [[CAST_SOURCE_ADDR]]
+// CHECK:         inject_enum_addr [[TEMP]] : $*Optional<T>, #Optional.some!enumelt
+// CHECK:         copy_addr [take] [[TEMP]] to [init] [[OUT_ADDR]]
+// CHECK-LABEL: } // end sil function 'test_checked_cast_br4'
+sil [ossa] @test_checked_cast_br4 : $@convention(method) <Element><T> (@owned TestGeneric<Element>) -> @out Optional<T> {
+bb0(%3 : @owned $TestGeneric<Element>):
+  checked_cast_br %3 : $TestGeneric<Element> to T, bb1, bb2
+
+bb1(%5 : @owned $T):
+  %6 = enum $Optional<T>, #Optional.some!enumelt, %5 : $T
+  br bb3(%6 : $Optional<T>)
+
+bb2(%8 : @owned $TestGeneric<Element>):
+  destroy_value %8 : $TestGeneric<Element>
+  %10 = enum $Optional<T>, #Optional.none!enumelt
+  br bb3(%10 : $Optional<T>)
+
+bb3(%12 : @owned $Optional<T>):
+  return %12 : $Optional<T>
+}
+
 // CHECK-LABEL: sil hidden [ossa] @test_unchecked_bitwise_cast :
 // CHECK: bb0(%0 : $*U, %1 : $*T, %2 : $@thick U.Type):
 // CHECK:   [[STK:%.*]] = alloc_stack $T

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1643,6 +1643,60 @@ bb3(%12 : @owned $Optional<T>):
   return %12 : $Optional<T>
 }
 
+// Verify that checked_cast_br neither from nor to an address-only value but
+// whose operands require rewriting to checked_cast_addr_br gets rewritten.
+// CHECK-LABEL: sil [ossa] @test_checked_cast_br5 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[SRC:%[^,]+]] :
+// CHECK:         [[SRC_ADDR:%[^,]+]] = alloc_stack $AnyObject
+// CHECK:         store [[SRC]] to [init] [[SRC_ADDR]]
+// CHECK:         [[DEST_ADDR:%[^,]+]] = alloc_stack $@thick any AnyObject.Type
+// CHECK:         checked_cast_addr_br take_on_success AnyObject in [[SRC_ADDR]] {{.*}} to any AnyObject.Type in [[DEST_ADDR]] {{.*}}, [[SUCCESS:bb[0-9]+]], [[FAILURE:bb[0-9]+]]
+// CHECK:       [[FAILURE]]:
+// CHECK:         load [take] [[SRC_ADDR]] : $*AnyObject
+// CHECK:       [[SUCCESS]]:
+// CHECK:         load [trivial] [[DEST_ADDR]] : $*@thick any AnyObject.Type
+// CHECK-LABEL: } // end sil function 'test_checked_cast_br5'
+sil [ossa] @test_checked_cast_br5 : $@convention(thin) (@owned AnyObject) -> () {
+entry(%instance : @owned $AnyObject):
+  checked_cast_br %instance : $AnyObject to any AnyObject.Type, success, failure
+
+success(%metatype : $@thick any AnyObject.Type):
+  br exit
+
+failure(%original : @owned $AnyObject):
+  destroy_value %original : $AnyObject
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Verify that checked_cast_br which both has an address-only value and also
+// produces a value whose type would anyway require rewriting but is not
+// address-only gets lowered properly.
+// CHECK-LABEL: sil [ossa] @test_checked_cast_br6 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[SRC:%[^,]+]] :
+// CHECK:         [[DEST_ADDR:%[^,]+]] = alloc_stack $@thick any AnyObject.Type     
+// CHECK:         checked_cast_addr_br take_on_success T in [[SRC]] {{.*}} to any AnyObject.Type in [[DEST_ADDR]] {{.*}}, [[SUCCESS]], [[FAILURE]] 
+// CHECK:       [[FAILURE]]:                                              
+// CHECK:         destroy_addr [[SRC]] : $*T                           
+// CHECK:       [[SUCCESS]]:                                              
+// CHECK:         [[REGISTER_3:%[^,]+]] = load [trivial] [[DEST_ADDR]] : $*@thick any AnyObject.Type
+// CHECK-LABEL: } // end sil function 'test_checked_cast_br6'
+sil [ossa] @test_checked_cast_br6 : $@convention(thin) <T> (@in T) -> () {
+entry(%instance : @owned $T):
+  checked_cast_br %instance : $T to any AnyObject.Type, success, failure
+success(%metatype : $@thick any AnyObject.Type):
+  br exit
+failure(%original : @owned $T):
+  destroy_value %original : $T
+  br exit
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // CHECK-LABEL: sil hidden [ossa] @test_unchecked_bitwise_cast :
 // CHECK: bb0(%0 : $*U, %1 : $*T, %2 : $@thick U.Type):
 // CHECK:   [[STK:%.*]] = alloc_stack $T

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1614,7 +1614,7 @@ bb3:
 }
 
 // Test the result being stored into an @out enum.
-// CHECK-LABEL: sil [ossa] @test_checked_cast_br4 : $@convention(method) <Element><T> (@owned TestGeneric<Element>) -> @out Optional<T> {
+// CHECK-LABEL: sil [ossa] @test_checked_cast_br4 : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[OUT_ADDR:%[^,]+]] : $*Optional<T>, [[INSTANCE:%[^,]+]] : @owned $TestGeneric<Element>):
 // CHECK:         [[TEMP:%[^,]+]] = alloc_stack $Optional<T>
 // CHECK:         [[CAST_DEST_ADDR:%[^,]+]] = init_enum_data_addr [[TEMP]] : $*Optional<T>, #Optional.some!enumelt

--- a/test/SILOptimizer/opaque_values_Onone.swift
+++ b/test/SILOptimizer/opaque_values_Onone.swift
@@ -212,3 +212,41 @@ func castAnyObjectToMeta(_ ao: any AnyObject) -> AnyObject.Type {
 func castGenericToMeta<T>(_ t: T) -> AnyObject.Type {
   t as! AnyObject.Type
 }
+
+// CHECK-LABEL: sil hidden @maybeCastAnyObjectToMeta : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[SRC:%[^,]+]] :
+// CHECK:         [[SRC_ADDR:%[^,]+]] = alloc_stack $AnyObject
+// CHECK:         store [[SRC]] to [[SRC_ADDR]] : $*AnyObject
+// CHECK:         [[DEST_ADDR:%[^,]+]] = alloc_stack $@thick any AnyObject.Type
+// CHECK:         checked_cast_addr_br take_on_success AnyObject in [[SRC_ADDR]] {{.*}} to any AnyObject.Type in [[DEST_ADDR]] {{.*}}, [[SUCCESS:bb[0-9]+]], [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         load [[DEST_ADDR]] : $*@thick any AnyObject.Type
+// CHECK:       [[FAILURE]]:
+// CHECK:         load [[SRC_ADDR]] : $*AnyObject
+// CHECK-LABEL: } // end sil function 'maybeCastAnyObjectToMeta'
+@_silgen_name("maybeCastAnyObjectToMeta")
+func maybeCastAnyObjectToMeta(_ ao: any AnyObject) -> AnyObject.Type? {
+  if let m = ao as? AnyObject.Type {
+    return m
+  }
+  return nil
+}
+
+// CHECK-LABEL: sil hidden @maybeCastGenericToMeta : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[SRC:%[^,]+]] :
+// CHECK:         [[SRC_ADDR:%[^,]+]] = alloc_stack $T
+// CHECK:         copy_addr [[SRC]] to [init] [[SRC_ADDR]]
+// CHECK:         [[DEST_ADDR:%[^,]+]] = alloc_stack $@thick any AnyObject.Type
+// CHECK:         checked_cast_addr_br take_on_success T in [[SRC_ADDR]] {{.*}} to any AnyObject.Type in [[DEST_ADDR]] {{.*}}, [[SUCCESS:bb[0-9]+]], [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         load [[DEST_ADDR]]
+// CHECK:       [[FAILURE]]:
+// CHECK:         destroy_addr [[SRC_ADDR]]
+// CHECK-LABEL: } // end sil function 'maybeCastGenericToMeta'
+@_silgen_name("maybeCastGenericToMeta")
+func maybeCastGenericToMeta<T>(_ t: T) -> AnyObject.Type? {
+  if let m = t as? AnyObject.Type {
+    return m
+  }
+  return nil
+}

--- a/test/SILOptimizer/opaque_values_Onone.swift
+++ b/test/SILOptimizer/opaque_values_Onone.swift
@@ -180,3 +180,35 @@ func give_a_generic_tuple<This>(of ty: This.Type) -> (This, This)
 func get_a_generic_tuple<This>(ty: This.Type) {
   let p = give_a_generic_tuple(of: ty)
 }
+
+// CHECK-LABEL: sil hidden @castAnyObjectToMeta {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[SRC:%[^,]+]] :
+// CHECK:         [[SRC_ADDR:%[^,]+]] = alloc_stack $AnyObject
+// CHECK:         store [[SRC]] to [[SRC_ADDR]]
+// CHECK:         [[DEST_ADDR:%[^,]+]] = alloc_stack $@thick any AnyObject.Type
+// CHECK:         unconditional_checked_cast_addr AnyObject in [[SRC_ADDR]] {{.*}} to @thick any AnyObject.Type in [[DEST_ADDR]]
+// CHECK:         [[DEST:%[^,]+]] = load [[DEST_ADDR]]
+// CHECK:         dealloc_stack [[DEST_ADDR]]
+// CHECK:         dealloc_stack [[SRC_ADDR]]
+// CHECK:         return [[DEST]]
+// CHECK-LABEL: } // end sil function 'castAnyObjectToMeta'
+@_silgen_name("castAnyObjectToMeta")
+func castAnyObjectToMeta(_ ao: any AnyObject) -> AnyObject.Type {
+  ao as! AnyObject.Type
+}
+
+// CHECK-LABEL: sil hidden @castGenericToMeta : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[SRC:%[^,]+]] :
+// CHECK:         [[SRC_ADDR:%[^,]+]] = alloc_stack $T
+// CHECK:         copy_addr [[SRC]] to [init] [[SRC_ADDR]]
+// CHECK:         [[DEST_ADDR:%[^,]+]] = alloc_stack $@thick any AnyObject.Type
+// CHECK:         unconditional_checked_cast_addr T in [[SRC_ADDR]] {{.*}} to @thick any AnyObject.Type in [[DEST_ADDR]]
+// CHECK:         [[DEST:%[^,]+]] = load [[DEST_ADDR]]
+// CHECK:         dealloc_stack [[DEST_ADDR]]
+// CHECK:         dealloc_stack [[SRC_ADDR]]
+// CHECK:         return [[DEST]]
+// CHECK-LABEL: } // end sil function 'castGenericToMeta'
+@_silgen_name("castGenericToMeta")
+func castGenericToMeta<T>(_ t: T) -> AnyObject.Type {
+  t as! AnyObject.Type
+}


### PR DESCRIPTION
All checked casts are emitted as `unconditional_checked_cast`/`checked_cast_br` instructions.  More than just the instructions which produce or consume an opaque value must be rewritten as `unconditional_checked_cast_addr`/`checked_cast_addr_br` instructions.  In particular, all those instructions for which `canIRGenUseScalarCheckedCastInstructions` is `false` must be rewritten as `unconditional_checked_cast_addr`/`checked_cast_addr_br` instructions.

Note such instructions to rewrite while visiting values and then rewrite them near the end of rewriting.

Based on https://github.com/apple/swift/pull/61992 .