### PR TITLE
[Runtime] Fix swift_bridgeObjectRetain on ARM64 Linux.

### DIFF
--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -609,7 +609,10 @@ void *swift::swift_bridgeObjectRetain(void *object) {
   // bit set.
   SWIFT_MUSTTAIL return objcRetainAndReturn(object);
 #else
-  return swift_retain(static_cast<HeapObject *>(objectRef));
+  // No tail call here. When !SWIFT_OBJC_INTEROP, the value of objectRef may be
+  // different from that of object, e.g. on Linux ARM64.
+  swift_retain(static_cast<HeapObject *>(objectRef));
+  return object;
 #endif
 }
 


### PR DESCRIPTION
The tail call of swift_retain isn't correct there. Revert back to a non-tail call for all !SWIFT_OBJC_INTEROP for now.

rdar://102152616