### PR TITLE
[cxx-interop] Specify `Iterator` explicitly for `CxxRandomAccessCollection`

### DIFF
--- a/stdlib/public/Cxx/CxxRandomAccessCollection.swift
+++ b/stdlib/public/Cxx/CxxRandomAccessCollection.swift
@@ -30,6 +30,7 @@ extension UnsafeMutablePointer: UnsafeCxxRandomAccessIterator {}
 
 public protocol CxxRandomAccessCollection: CxxSequence, RandomAccessCollection {
   override associatedtype RawIterator: UnsafeCxxRandomAccessIterator
+  override associatedtype Iterator = CxxIterator<Self>
   override associatedtype Element = RawIterator.Pointee
   override associatedtype Index = Int
   override associatedtype Indices = Range<Int>


### PR DESCRIPTION
This helps to avoid ambiguity errors when manually conforming a type to `CxxRandomAccessCollection` protocol.