### PR TITLE
IRGen: objc_direct method calls have a different convention

### DIFF
--- a/lib/IRGen/Callee.h
+++ b/lib/IRGen/Callee.h
@@ -569,6 +569,7 @@ namespace irgen {
     /// Given that this callee is an ObjC method, return the receiver
     /// argument.  This might not be 'self' anymore.
     llvm::Value *getObjCMethodSelector() const;
+    bool isDirectObjCMethod() const;
   };
 
   FunctionPointer::Kind classifyFunctionPointerKind(SILFunction *fn);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3264,10 +3264,12 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
   // This might generate new functions, so we should do it before computing
   // the insert-before point.
   llvm::Constant *clangAddr = nullptr;
+  bool isObjCDirect = false;
   if (auto clangDecl = f->getClangDecl()) {
     // If we have an Objective-C Clang declaration, it must be a direct
     // method and we want to generate the IR declaration ourselves.
     if (auto objcDecl = dyn_cast<clang::ObjCMethodDecl>(clangDecl)) {
+      isObjCDirect = true; 
       assert(objcDecl->isDirectMethod());
     } else {
       auto globalDecl = getClangGlobalDeclForFunction(clangDecl);
@@ -3340,7 +3342,7 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(
   }
   auto fpKind = irgen::classifyFunctionPointerKind(f);
   Signature signature =
-      getSignature(f->getLoweredFunctionType(), fpKind);
+      getSignature(f->getLoweredFunctionType(), fpKind, isObjCDirect);
   addLLVMFunctionAttributes(f, signature);
 
   fn = createFunction(*this, link, signature, insertBefore,

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -120,43 +120,51 @@ using namespace irgen;
 namespace {
   /// Information about the IR-level signature of a function type.
   class FuncSignatureInfo {
-  private:
+  protected:
     /// The SIL function type being represented.
     const CanSILFunctionType FormalType;
-    
+
     mutable Signature TheSignature;
-    
+
   public:
     FuncSignatureInfo(CanSILFunctionType formalType)
       : FormalType(formalType) {}
-    
+
     Signature getSignature(IRGenModule &IGM) const;
   };
 
+  class ObjCFuncSignatureInfo : public FuncSignatureInfo {
+  private:
+    mutable Signature TheDirectSignature;
+
+  public:
+    ObjCFuncSignatureInfo(CanSILFunctionType formalType)
+      : FuncSignatureInfo(formalType) {}
+
+    Signature getDirectSignature(IRGenModule &IGM) const;
+  };
+
   /// The @thin function type-info class.
-  class ThinFuncTypeInfo : public PODSingleScalarTypeInfo<ThinFuncTypeInfo,
-                                                          LoadableTypeInfo>,
-                           public FuncSignatureInfo {
-    ThinFuncTypeInfo(CanSILFunctionType formalType, llvm::Type *storageType,
+  template <class Derived>
+  class ThinFuncTypeInfoImpl :
+    public PODSingleScalarTypeInfo<Derived, LoadableTypeInfo> {
+
+  protected:
+    const Derived &asDerived() const {
+      return static_cast<const Derived &>(*this);
+    }
+
+    ThinFuncTypeInfoImpl(CanSILFunctionType formalType, llvm::Type *storageType,
                      Size size, Alignment align,
                      const SpareBitVector &spareBits)
-      : PODSingleScalarTypeInfo(storageType, size, spareBits, align),
-        FuncSignatureInfo(formalType)
+      : PODSingleScalarTypeInfo<Derived, LoadableTypeInfo>(storageType, size, spareBits, align)
     {
     }
 
   public:
-    static const ThinFuncTypeInfo *create(CanSILFunctionType formalType,
-                                          llvm::Type *storageType,
-                                          Size size, Alignment align,
-                                          const SpareBitVector &spareBits) {
-      return new ThinFuncTypeInfo(formalType, storageType, size, align,
-                                  spareBits);
-    }
-
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {
-      return IGM.typeLayoutCache.getOrCreateScalarEntry(*this, T);
+      return IGM.typeLayoutCache.getOrCreateScalarEntry(asDerived(), T);
     }
 
     bool mayHaveExtraInhabitants(IRGenModule &IGM) const override {
@@ -188,6 +196,49 @@ namespace {
                .storeExtraInhabitant(IGF, index, dest);
     }
   };
+
+  /// The @thin function type-info class.
+  class ThinFuncTypeInfo : public ThinFuncTypeInfoImpl<ThinFuncTypeInfo>,
+                           public FuncSignatureInfo {
+  public:
+
+    ThinFuncTypeInfo(CanSILFunctionType formalType, llvm::Type *storageType,
+                     Size size, Alignment align,
+                     const SpareBitVector &spareBits) :
+      ThinFuncTypeInfoImpl(formalType, storageType, size, align, spareBits),
+      FuncSignatureInfo(formalType) {}
+
+
+    static const ThinFuncTypeInfo *create(CanSILFunctionType formalType,
+                                          llvm::Type *storageType,
+                                          Size size, Alignment align,
+                                          const SpareBitVector &spareBits) {
+      return new ThinFuncTypeInfo(formalType, storageType, size, align,
+                                  spareBits);
+    }
+  };
+
+  /// The (objc_method) function type-info class.
+  class ObjCFuncTypeInfo : public ThinFuncTypeInfoImpl<ThinFuncTypeInfo>,
+                           public ObjCFuncSignatureInfo {
+  public:
+
+    ObjCFuncTypeInfo(CanSILFunctionType formalType, llvm::Type *storageType,
+                     Size size, Alignment align,
+                     const SpareBitVector &spareBits) :
+      ThinFuncTypeInfoImpl(formalType, storageType, size, align, spareBits),
+      ObjCFuncSignatureInfo(formalType) {}
+
+
+    static const ObjCFuncTypeInfo *create(CanSILFunctionType formalType,
+                                          llvm::Type *storageType,
+                                          Size size, Alignment align,
+                                          const SpareBitVector &spareBits) {
+      return new ObjCFuncTypeInfo(formalType, storageType, size, align,
+                                  spareBits);
+    }
+  };
+
 
   /// The @thick function type-info class.
   class FuncTypeInfo :
@@ -530,10 +581,15 @@ const TypeInfo *TypeConverter::convertFunctionType(SILFunctionType *T) {
   case SILFunctionType::Representation::Method:
   case SILFunctionType::Representation::CXXMethod:
   case SILFunctionType::Representation::WitnessMethod:
-  case SILFunctionType::Representation::ObjCMethod:
   case SILFunctionType::Representation::CFunctionPointer:
   case SILFunctionType::Representation::Closure:
     return ThinFuncTypeInfo::create(CanSILFunctionType(T),
+                                    IGM.FunctionPtrTy,
+                                    IGM.getPointerSize(),
+                                    IGM.getPointerAlignment(),
+                                    IGM.getFunctionPointerSpareBits());
+  case SILFunctionType::Representation::ObjCMethod:
+    return ObjCFuncTypeInfo::create(CanSILFunctionType(T),
                                     IGM.FunctionPtrTy,
                                     IGM.getPointerSize(),
                                     IGM.getPointerAlignment(),
@@ -575,6 +631,19 @@ Signature FuncSignatureInfo::getSignature(IRGenModule &IGM) const {
   return TheSignature;
 }
 
+Signature ObjCFuncSignatureInfo::getDirectSignature(IRGenModule &IGM) const {
+  // If it's already been filled in, we're done.
+  if (TheDirectSignature.isValid())
+    return TheDirectSignature;
+
+  // Update the cache and return.
+  TheDirectSignature = Signature::getUncached(IGM, FormalType,
+                                        FunctionPointerKind(FormalType),
+                                        /*forStaticCall*/ true);
+  assert(TheDirectSignature.isValid());
+  return TheDirectSignature;
+}
+
 static const FuncSignatureInfo &
 getFuncSignatureInfoForLowered(IRGenModule &IGM, CanSILFunctionType type) {
   auto &ti = IGM.getTypeInfoForLowered(type);
@@ -586,9 +655,10 @@ getFuncSignatureInfoForLowered(IRGenModule &IGM, CanSILFunctionType type) {
   case SILFunctionType::Representation::Method:
   case SILFunctionType::Representation::CXXMethod:
   case SILFunctionType::Representation::WitnessMethod:
-  case SILFunctionType::Representation::ObjCMethod:
   case SILFunctionType::Representation::Closure:
     return ti.as<ThinFuncTypeInfo>();
+  case SILFunctionType::Representation::ObjCMethod:
+    return static_cast<const FuncSignatureInfo &>(ti.as<ObjCFuncTypeInfo>());
   case SILFunctionType::Representation::Thick:
     return ti.as<FuncTypeInfo>();
   }
@@ -600,12 +670,19 @@ Signature IRGenModule::getSignature(CanSILFunctionType type) {
 }
 
 Signature IRGenModule::getSignature(CanSILFunctionType type,
-                                    FunctionPointerKind kind) {
+                                    FunctionPointerKind kind,
+                                    bool forStaticCall) {
   // Don't bother caching if we're working with a special kind.
   if (kind.isSpecial())
     return Signature::getUncached(*this, type, kind);
 
   auto &sigInfo = getFuncSignatureInfoForLowered(*this, type);
+
+  if (forStaticCall &&
+      type->getRepresentation() == SILFunctionType::Representation::ObjCMethod) {
+    auto &objcSigInfo = static_cast<const ObjCFuncSignatureInfo &>(sigInfo);
+    return objcSigInfo.getDirectSignature(*this);
+  }
   return sigInfo.getSignature(*this);
 }
 

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -817,10 +817,8 @@ Callee irgen::getObjCMethodCallee(IRGenFunction &IGF,
 
 Callee irgen::getObjCDirectMethodCallee(CalleeInfo &&info, const FunctionPointer &fn,
                                         llvm::Value *selfValue) {
-  // Direct calls to Objective-C methods have a selector value of `undef`.
-  auto selectorType = fn.getFunctionType()->getParamType(1);
-  auto selectorValue = llvm::UndefValue::get(selectorType);
-  return Callee(std::move(info), fn, selfValue, selectorValue);
+  // Direct calls to Objective-C methods don't have a selector value.
+  return Callee(std::move(info), fn, selfValue, nullptr);
 }
 
 /// Call [self allocWithZone: nil].

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1499,7 +1499,8 @@ public:
 
   Signature getSignature(CanSILFunctionType fnType);
   Signature getSignature(CanSILFunctionType fnType,
-                         FunctionPointerKind kind);
+                         FunctionPointerKind kind,
+                         bool forStaticCall = false);
   llvm::FunctionType *getFunctionType(CanSILFunctionType type,
                                       llvm::AttributeList &attrs,
                                       ForeignFunctionInfo *foreignInfo=nullptr);

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2651,7 +2651,7 @@ void IRGenSILFunction::visitFunctionRefBaseInst(FunctionRefBaseInst *i) {
 
   auto fpKind = irgen::classifyFunctionPointerKind(fn);
 
-  auto sig = IGM.getSignature(fnType, fpKind);
+  auto sig = IGM.getSignature(fnType, fpKind, true /*forStaticCall*/);
 
   // Note that the pointer value returned by getAddrOfSILFunction doesn't
   // necessarily have element type sig.getType(), e.g. if it's imported.

--- a/lib/IRGen/Signature.h
+++ b/lib/IRGen/Signature.h
@@ -201,7 +201,8 @@ public:
   /// IRGenModule::getSignature(CanSILFunctionType), which is what
   /// clients should generally be using.
   static Signature getUncached(IRGenModule &IGM, CanSILFunctionType formalType,
-                               FunctionPointerKind kind);
+                               FunctionPointerKind kind,
+                               bool forStaticCall = false);
 
   static SignatureExpansionABIDetails
   getUncachedABIDetails(IRGenModule &IGM, CanSILFunctionType formalType,

--- a/test/IRGen/objc_direct.swift
+++ b/test/IRGen/objc_direct.swift
@@ -13,28 +13,28 @@ extension Bar: BarProtocol {}
 let bar = Bar()
 
 bar.directProperty = 123
-// CHECK: call void @"\01-[Bar setDirectProperty:]"({{.*}}, i8* undef, i32 {{.*}})
+// CHECK: call void @"\01-[Bar setDirectProperty:]"(%{{[0-9]+}}* %{{[0-9]+}}, i32 {{.*}})
 
 markUsed(bar.directProperty)
-// CHECK: call i32 @"\01-[Bar directProperty]"({{.*}}, i8* undef)
+// CHECK: call i32 @"\01-[Bar directProperty]"(%{{[0-9]+}}* %{{[0-9]+}})
 
 bar.directProperty2 = 456
-// CHECK: call void @"\01-[Bar setDirectProperty2:]"({{.*}}, i8* undef, i32 {{.*}})
+// CHECK: call void @"\01-[Bar setDirectProperty2:]"(%{{[0-9]+}}* %{{[0-9]+}}, i32 {{.*}})
 
 markUsed(bar.directProperty2)
-// CHECK: call i32 @"\01-[Bar directProperty2]"({{.*}}, i8* undef)
+// CHECK: call i32 @"\01-[Bar directProperty2]"(%{{[0-9]+}}* %{{[0-9]+}})
 
 bar[0] = 789
-// CHECK: call void @"\01-[Bar setObject:atIndexedSubscript:]"({{.*}}, i8* undef, i32 789, i32 0)
+// CHECK: call void @"\01-[Bar setObject:atIndexedSubscript:]"(%{{[0-9]+}}* %{{[0-9]+}}, i32 789, i32 0)
 
 markUsed(bar[0])
-// CHECK: call i32 @"\01-[Bar objectAtIndexedSubscript:]"({{.*}}, i8* undef, i32 0)
+// CHECK: call i32 @"\01-[Bar objectAtIndexedSubscript:]"(%{{[0-9]+}}* %{{[0-9]+}}, i32 0)
 
 markUsed(bar.directMethod())
-// CHECK: call {{.*}} @"\01-[Bar directMethod]"({{.*}}, i8* undef)
+// CHECK: call {{.*}} @"\01-[Bar directMethod]"(%{{[0-9]+}}* %{{[0-9]+}})
 
 markUsed(bar.directMethod2())
-// CHECK: call {{.*}} @"\01-[Bar directMethod2]"({{.*}}, i8* undef)
+// CHECK: call {{.*}} @"\01-[Bar directMethod2]"(%{{[0-9]+}}* %{{[0-9]+}})
 
 markUsed(Bar.directClassMethod())
 // NOTE: The class must be realized before calling objc_direct class methods, even if
@@ -42,16 +42,16 @@ markUsed(Bar.directClassMethod())
 // CHECK: [[R0:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_Bar"
 // CHECK: [[R1:%.*]] = call %objc_class*  @{{(swift_getInitializedObjCClass|objc_opt_self)}}(%objc_class* [[R0]])
 // CHECK: [[R2:%.*]] = bitcast %objc_class* [[R1]] to i8*
-// CHECK: call {{.*}} @"\01+[Bar directClassMethod]"(i8* [[R2]], i8* undef)
+// CHECK: call {{.*}} @"\01+[Bar directClassMethod]"(i8* [[R2]])
 
 markUsed(Bar.directClassMethod2())
 // CHECK: [[R3:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_Bar"
 // CHECK: [[R4:%.*]] = call %objc_class* @{{(swift_getInitializedObjCClass|objc_opt_self)}}(%objc_class* [[R3]])
 // CHECK: [[R5:%.*]] = bitcast %objc_class* [[R4]] to i8*
-// CHECK: call {{.*}} @"\01+[Bar directClassMethod2]"(i8* [[R5]], i8* undef)
+// CHECK: call {{.*}} @"\01+[Bar directClassMethod2]"(i8* [[R5]])
 
 markUsed(bar.directProtocolMethod())
-// CHECK: call {{.*}} @"\01-[Bar directProtocolMethod]"({{.*}}, i8* undef)
+// CHECK: call {{.*}} @"\01-[Bar directProtocolMethod]"({{.*}})
 
 // CHECK-DAG: declare i32 @"\01-[Bar directProperty]"
 // CHECK-DAG: declare void @"\01-[Bar setDirectProperty:]"


### PR DESCRIPTION
objc_direct methods no longer have the CMD argument.

rdar://102151993