### PR TITLE
Test: Add `UNSUPPORTED: remote_run` to Interpreter/has_symbol.swift

### DIFF
--- a/test/Interpreter/has_symbol.swift
+++ b/test/Interpreter/has_symbol.swift
@@ -27,6 +27,7 @@
 
 // REQUIRES: executable_test
 // REQUIRES: VENDOR=apple
+// UNSUPPORTED: remote_run
 
 // rdar://102159307 - #_hasSymbol needs to be implemented with a SILInstruction
 // REQUIRES: swift_test_mode_optimize_none


### PR DESCRIPTION
This test involves dylib manipulation so it doesn't support device testing.
