### PR TITLE
[ModuleInterface] Support loading an aliased module with an underlying module

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -371,7 +371,7 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
   Opts.AliasModuleNames |=
     Args.hasFlag(OPT_alias_module_names_in_module_interface,
                  OPT_disable_alias_module_names_in_module_interface,
-                 false);
+                 ::getenv("SWIFT_ALIAS_MODULE_NAMES_IN_INTERFACES"));
   Opts.PrintFullConvention |=
     Args.hasArg(OPT_experimental_print_full_convention);
   Opts.ExperimentalSPIImports |=

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -614,7 +614,8 @@ class ModuleInterfaceLoaderImpl {
     StringRef inParentDirName =
       path::filename(path::parent_path(interfacePath));
     if (path::extension(inParentDirName) == ".swiftmodule") {
-      assert(path::stem(inParentDirName) == moduleName);
+      assert(path::stem(inParentDirName) ==
+             ctx.getRealModuleName(ctx.getIdentifier(moduleName)).str());
       path::append(scratch, inParentDirName);
     }
     path::append(scratch, path::filename(modulePath));

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2359,8 +2359,9 @@ ModuleDecl *ModuleFile::getModule(ImportPath::Module name,
     return getContext().TheBuiltinModule;
 
   // FIXME: duplicated from ImportResolver::getModule
+  Identifier parentName = FileContext->getParentModule()->getName();
   if (name.size() == 1 &&
-      name.front().Item == FileContext->getParentModule()->getName()) {
+      name.front().Item == getContext().getRealModuleName(parentName)) {
     if (!UnderlyingModule && allowLoading) {
       auto importer = getContext().getClangModuleLoader();
       assert(importer && "no way to import shadowed module");

--- a/test/ModuleInterface/ambiguous-aliases-workaround.swift
+++ b/test/ModuleInterface/ambiguous-aliases-workaround.swift
@@ -18,6 +18,14 @@
 // RUN:     -alias-module-names-in-module-interface
 // RUN: %target-swift-typecheck-module-from-interface(%t/AmbiguousClientName.swiftinterface) -I%t
 
+// RUN: %target-swift-frontend -emit-module -module-name OverlayClient \
+// RUN:     -swift-version 5 -enable-library-evolution \
+// RUN:     -o %t/OverlayClient.swiftmodule \
+// RUN:     -emit-module-interface-path %t/OverlayClient.swiftinterface \
+// RUN:     %t/OverlayClient.swift -I%t \
+// RUN:     -alias-module-names-in-module-interface
+// RUN: %target-swift-typecheck-module-from-interface(%t/OverlayClient.swiftinterface) -I%t
+
 //--- module.modulemap
 module AmbiguousClientName {
     header "AmbiguousClientName.h"
@@ -64,3 +72,10 @@ public func refToNestedInLib(_ a: AmbiguousLib.Nested) {}
 public func refToStdlib(_ a: Swift.Int) {}
 public func refToUnderlying(_ a: UnderlyingType) {}
 public func refToC(_ a: CType) {}
+
+//--- OverlayClient.swift
+
+import AmbiguousClientName
+
+public func refToImportedType(_ a: SomeType) {}
+public func refToImportedUnderlying(_ a: UnderlyingType) {}


### PR DESCRIPTION
Ensure we can import a module given an alias (using `-module-alias`) in the case where it has an underlying clang module. Prior to this fix it was wrongfully reported as a cyclic dependency.

Also introduce an env var to test this feature before turning it on by default.

This is a fix for the workaround introduced in #61941.

rdar://102217790