### PR TITLE
[move-only] When passing a move only struct address, pass it as a true borrowed parameter.

### DIFF
--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -223,6 +223,7 @@ public:
   }
 
   Expr *findStorageReferenceExprForBorrow() &&;
+  Expr *findStorageReferenceExprForMoveOnlyBorrow() &&;
 
   /// Given that this source is an expression, extract and clear
   /// that expression.

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -25,11 +25,12 @@
 #include "Varargs.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/DiagnosticsSIL.h"
+#include "swift/AST/DistributedDecl.h"
 #include "swift/AST/Effects.h"
+#include "swift/AST/Expr.h"
 #include "swift/AST/ForeignAsyncConvention.h"
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
-#include "swift/AST/DistributedDecl.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ModuleLoader.h"
@@ -37,14 +38,14 @@
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/ExternalUnion.h"
 #include "swift/Basic/Range.h"
-#include "swift/Basic/SourceManager.h"
 #include "swift/Basic/STLExtras.h"
+#include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Unicode.h"
 #include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILArgument.h"
 #include "clang/AST/DeclCXX.h"
-#include "llvm/Support/Compiler.h"
 #include "clang/AST/DeclObjC.h"
+#include "llvm/Support/Compiler.h"
 
 using namespace swift;
 using namespace Lowering;
@@ -2921,6 +2922,25 @@ static Expr *findStorageReferenceExprForBorrow(Expr *e) {
   return nullptr;
 }
 
+Expr *ArgumentSource::findStorageReferenceExprForMoveOnlyBorrow() && {
+  if (!isExpr())
+    return nullptr;
+
+  auto argExpr = asKnownExpr();
+  auto *li = dyn_cast<LoadExpr>(argExpr);
+  if (!li)
+    return nullptr;
+
+  auto lvExpr = ::findStorageReferenceExprForBorrow(li->getSubExpr());
+
+  // Claim the value of this argument if we found a storage reference.
+  if (lvExpr) {
+    (void)std::move(*this).asKnownExpr();
+  }
+
+  return lvExpr;
+}
+
 Expr *ArgumentSource::findStorageReferenceExprForBorrow() && {
   if (!isExpr()) return nullptr;
 
@@ -3054,6 +3074,13 @@ private:
     if (IsYield && param.isGuaranteed()) {
       if (tryEmitBorrowed(std::move(arg), loweredSubstArgType,
                           loweredSubstParamType, origParamType, paramSlice))
+        return;
+    }
+
+    if (loweredSubstArgType.isPureMoveOnly() && param.isGuaranteed()) {
+      if (tryEmitBorrowedMoveOnly(std::move(arg), loweredSubstArgType,
+                                  loweredSubstParamType, origParamType,
+                                  paramSlice))
         return;
     }
 
@@ -3220,6 +3247,23 @@ private:
     // Try to find an expression we can emit as an l-value.
     auto lvExpr = std::move(arg).findStorageReferenceExprForBorrow();
     if (!lvExpr) return false;
+
+    emitBorrowed(lvExpr, loweredSubstArgType, loweredSubstParamType,
+                 origParamType, paramsSlice);
+    return true;
+  }
+
+  bool tryEmitBorrowedMoveOnly(ArgumentSource &&arg,
+                               SILType loweredSubstArgType,
+                               SILType loweredSubstParamType,
+                               AbstractionPattern origParamType,
+                               ClaimedParamsRef paramsSlice) {
+    assert(paramsSlice.size() == 1);
+
+    // Try to find an expression we can emit as an l-value.
+    auto lvExpr = std::move(arg).findStorageReferenceExprForMoveOnlyBorrow();
+    if (!lvExpr)
+      return false;
 
     emitBorrowed(lvExpr, loweredSubstArgType, loweredSubstParamType,
                  origParamType, paramsSlice);


### PR DESCRIPTION
This ensures that the address move checker does not have to perform any unsound access scope expansions. One note is that the current approach does not work for class member refs since in SILGenLValue, a class is considered a base of the SILGenLValue access which is immediately evaluated (causing a copy) rather than evaluated later at formal evaluation time. I have a few ways of working around this issue but am going to fix it in a subsequent commit when I fix this for classes and also read coroutines.

rdar://99616492
