### PR TITLE
[AddressLowering] Rewrite indirect begin_applies

### DIFF
--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -2120,6 +2120,10 @@ void ApplyRewriter::rewriteApply(ArrayRef<SILValue> newCallArgs) {
   // will be deleted with its destructure_tuple.
 }
 
+/// Emit end_borrows for a an incomplete BorrowedValue with only nonlifetime
+/// ending uses.
+static void emitEndBorrows(SILValue value, AddressLoweringState &pass);
+
 void ApplyRewriter::convertBeginApplyWithOpaqueYield() {
   auto *origCall = cast<BeginApplyInst>(apply.getInstruction());
   SmallVector<SILValue, 4> opValues;
@@ -2762,10 +2766,6 @@ protected:
 
   void visitStoreInst(StoreInst *storeInst);
 
-  /// Emit end_borrows for a an incomplete BorrowedValue with only nonlifetime
-  /// ending uses.
-  void emitEndBorrows(SILValue value);
-
   void emitExtract(SingleValueInstruction *extractInst);
 
   void visitSelectEnumInst(SelectEnumInst *sei) {
@@ -2832,7 +2832,7 @@ protected:
         builder.emitLoadBorrowOperation(uncheckedCastInst->getLoc(), destAddr);
     uncheckedCastInst->replaceAllUsesWith(load);
     pass.deleter.forceDelete(uncheckedCastInst);
-    emitEndBorrows(load);
+    emitEndBorrows(load, pass);
   }
 
   void visitUnconditionalCheckedCastInst(
@@ -2944,7 +2944,7 @@ void UseRewriter::visitStoreInst(StoreInst *storeInst) {
 
 /// Emit end_borrows for a an incomplete BorrowedValue with only nonlifetime
 /// ending uses. This function inserts end_borrows on the lifetime boundary.
-void UseRewriter::emitEndBorrows(SILValue value) {
+static void emitEndBorrows(SILValue value, AddressLoweringState &pass) {
   assert(BorrowedValue(value));
 
   // Place end_borrows that cover the load_borrow uses. It is not necessary to
@@ -3002,7 +3002,7 @@ void UseRewriter::emitExtract(SingleValueInstruction *extractInst) {
   SILValue loadElement =
       builder.emitLoadBorrowOperation(extractInst->getLoc(), extractAddr);
   replaceUsesWithLoad(extractInst, loadElement);
-  emitEndBorrows(loadElement);
+  emitEndBorrows(loadElement, pass);
 }
 
 void UseRewriter::visitStructExtractInst(StructExtractInst *extractInst) {

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -29,6 +29,14 @@ struct I {}
 
 class Klass {}
 
+struct LoadableTrivialExtractable {
+    var i: I
+}
+
+struct LoadableNontrivial {
+    var x: Klass
+}
+
 struct SI<T> {
   var element: T
   var index: I
@@ -1466,6 +1474,202 @@ bb0(%0 : @guaranteed $TestGeneric<T>):
   destroy_value %5 : $T
   %10 = tuple ()
   return %10 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @testBeginApply4YieldLoadableTrivial : {{.*}} {
+// CHECK:         ([[ADDR:%[^,]+]], {{%[^,]+}}) = begin_apply
+// CHECK:         [[INSTANCE:%[^,]+]] = load [trivial] [[ADDR]]
+// CHECK:         struct_extract [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'testBeginApply4YieldLoadableTrivial'
+sil [ossa] @testBeginApply4YieldLoadableTrivial : $@convention(thin) () -> I {
+entry:
+  (%instance, %token) = begin_apply undef<LoadableTrivialExtractable>() : $@yield_once @convention(thin) <U> () -> @yields @in_guaranteed U
+  end_apply %token
+  %extract = struct_extract %instance : $LoadableTrivialExtractable, #LoadableTrivialExtractable.i
+  return %extract : $I
+}
+
+// CHECK-LABEL: sil [ossa] @testBeginApply5Yield2LoadableTrivial : {{.*}} {
+// CHECK:         ([[ADDR_1:%[^,]+]], [[ADDR_2:%[^,]+]], {{%[^,]+}}) = begin_apply
+// CHECK:         [[INSTANCE_1:%[^,]+]] = load [trivial] [[ADDR_1]]
+// CHECK:         [[INSTANCE_2:%[^,]+]] = load [trivial] [[ADDR_2]]
+// CHECK:         struct_extract [[INSTANCE_1]]
+// CHECK:         struct_extract [[INSTANCE_2]]
+// CHECK-LABEL: } // end sil function 'testBeginApply5Yield2LoadableTrivial'
+sil [ossa] @testBeginApply5Yield2LoadableTrivial : $@convention(thin) () -> (I, I) {
+entry:
+  (%instance_1, %instance_2, %token) = begin_apply undef<LoadableTrivialExtractable>() : $@yield_once @convention(thin) <U> () -> (@yields @in_guaranteed U, @yields @in_guaranteed U)
+  end_apply %token
+  %i_1 = struct_extract %instance_1 : $LoadableTrivialExtractable, #LoadableTrivialExtractable.i
+  %i_2 = struct_extract %instance_2 : $LoadableTrivialExtractable, #LoadableTrivialExtractable.i
+  %tuple = tuple (%i_1 : $I, %i_2 : $I)
+  return %tuple : $(I, I)
+}
+
+// CHECK-LABEL: sil [ossa] @testBeginApply6Yield1LoadableTrivial1OpaqueGuaranteed : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[TRIV_OUT:%[^,]+]] : $*I, [[OPAQUE_OUT:%[^,]+]] : $*T):
+// CHECK:         ([[ADDR_1:%[^,]+]], [[ADDR_2:%[^,]+]], {{%[^,]+}}) = begin_apply
+// CHECK:         [[INSTANCE_1:%[^,]+]] = load [trivial] [[ADDR_1]]
+// CHECK:         copy_addr [[ADDR_2]] to [init] [[OPAQUE_OUT]]
+// CHECK:         [[EXTRACT:%[^,]+]]  = struct_extract [[INSTANCE_1]]
+// CHECK:         store [[EXTRACT]] to [trivial] [[TRIV_OUT]]
+// CHECK-LABEL: } // end sil function 'testBeginApply6Yield1LoadableTrivial1OpaqueGuaranteed'
+sil [ossa] @testBeginApply6Yield1LoadableTrivial1OpaqueGuaranteed : $@convention(thin) <T> () -> (@out I, @out T) {
+entry:
+  (%instance_1, %instance_2, %token) = begin_apply undef<LoadableTrivialExtractable, T>() : $@yield_once @convention(thin) <U, T> () -> (@yields @in_guaranteed U, @yields @in_guaranteed T)
+  %copy = copy_value %instance_2 : $T
+  end_apply %token
+  %i = struct_extract %instance_1 : $LoadableTrivialExtractable, #LoadableTrivialExtractable.i
+  %tuple = tuple (%i : $I, %copy : $T)
+  return %tuple : $(I, T)
+}
+
+// CHECK-LABEL: sil [ossa] @testBeginApply7YieldLoadableNontrivialGuaranteed : {{.*}} {
+// CHECK:         ([[ADDR:%[^,]+]], {{%[^,]+}}) = begin_apply
+// CHECK:         [[BORROW:%[^,]+]] = load_borrow [[ADDR]]
+// CHECK:         end_borrow [[BORROW]]
+// CHECK-LABEL: } // end sil function 'testBeginApply7YieldLoadableNontrivialGuaranteed'
+sil [ossa] @testBeginApply7YieldLoadableNontrivialGuaranteed : $@convention(thin) () -> @owned Klass {
+entry:
+  (%instance, %token) = begin_apply undef<LoadableNontrivial>() : $@yield_once @convention(thin) <U> () -> @yields @in_guaranteed U
+  %extract = struct_extract %instance : $LoadableNontrivial, #LoadableNontrivial.x
+  %retval = copy_value %extract : $Klass
+  end_apply %token
+  return %retval : $Klass
+}
+
+// CHECK-LABEL: sil [ossa] @testBeginApply8Yield2LoadableNontrivialGuaranteed : {{.*}} {
+// CHECK:         ([[ADDR_1:%[^,]+]], [[ADDR_2:%[^,]+]], {{%[^,]+}}) = begin_apply
+// CHECK:         [[INSTANCE_1:%[^,]+]] = load_borrow [[ADDR_1]]
+// CHECK:         [[INSTANCE_2:%[^,]+]] = load_borrow [[ADDR_2]]
+// CHECK:         struct_extract [[INSTANCE_1]]
+// CHECK:         struct_extract [[INSTANCE_2]]
+// CHECK:         end_borrow [[INSTANCE_1]]
+// CHECK:         end_borrow [[INSTANCE_2]]
+// CHECK-LABEL: } // end sil function 'testBeginApply8Yield2LoadableNontrivialGuaranteed'
+sil [ossa] @testBeginApply8Yield2LoadableNontrivialGuaranteed : $@convention(thin) () -> @owned (Klass, Klass) {
+entry:
+  (%instance_1, %instance_2, %token) = begin_apply undef<LoadableNontrivial>() : $@yield_once @convention(thin) <U> () -> (@yields @in_guaranteed U, @yields @in_guaranteed U)
+  %extract_1 = struct_extract %instance_1 : $LoadableNontrivial, #LoadableNontrivial.x
+  %extract_2 = struct_extract %instance_2 : $LoadableNontrivial, #LoadableNontrivial.x
+  %copy_1 = copy_value %extract_1 : $Klass
+  %copy_2 = copy_value %extract_2 : $Klass
+  end_apply %token
+  %retval = tuple (%copy_1 : $Klass, %copy_2 : $Klass)
+  return %retval : $(Klass, Klass)
+}
+
+// CHECK-LABEL: sil [ossa] @testBeginApply9Yield1LoadableNontrivialGuaranteed1OpaqueGuaranteed : {{.*}} {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : $*Klass, [[OPAQUE_OUT:%[^,]+]] : $*T):
+// CHECK:         ([[ADDR_1:%[^,]+]], [[ADDR_2:%[^,]+]], {{%[^,]+}}) = begin_apply
+// CHECK:         [[BORROW_1:%[^,]+]] = load_borrow [[ADDR_1]] : $*LoadableNontrivial
+// CHECK:         struct_extract [[BORROW_1]] : $LoadableNontrivial, #LoadableNontrivial.x
+// CHECK:         end_borrow [[BORROW_1]] : $LoadableNontrivial
+// CHECK:         copy_addr [[ADDR_2]] to [init] [[OPAQUE_OUT]] : $*T
+// CHECK-LABEL: } // end sil function 'testBeginApply9Yield1LoadableNontrivialGuaranteed1OpaqueGuaranteed'
+sil [ossa] @testBeginApply9Yield1LoadableNontrivialGuaranteed1OpaqueGuaranteed : $@convention(thin) <T> () -> (@out Klass, @out T) {
+entry:
+  (%instance_1, %instance_2, %token) = begin_apply undef<LoadableNontrivial, T>() : $@yield_once @convention(thin) <U, T> () -> (@yields @in_guaranteed U, @yields @in_guaranteed T)
+  %extract_1 = struct_extract %instance_1 : $LoadableNontrivial, #LoadableNontrivial.x
+  %copy_1 = copy_value %extract_1 : $Klass
+  %copy_2 = copy_value %instance_2 : $T
+  end_apply %token
+  %retval = tuple (%copy_1 : $Klass, %copy_2 : $T)
+  return %retval : $(Klass, T)
+}
+
+// CHECK-LABEL: sil [ossa] @testBeginApplyAYieldLoadableNontrivialOwned : {{.*}} {
+// CHECK:         ([[ADDR:%[^,]+]], {{%[^,]+}}) = begin_apply
+// CHECK:         [[INSTANCE:%[^,]+]] = load [take] [[ADDR]] : $*LoadableNontrivial
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[INSTANCE]] : $LoadableNontrivial
+// CHECK:         struct_extract [[BORROW]] : $LoadableNontrivial, #LoadableNontrivial.x
+// CHECK:         end_borrow [[BORROW]] : $LoadableNontrivial
+// CHECK-LABEL: } // end sil function 'testBeginApplyAYieldLoadableNontrivialOwned'
+sil [ossa] @testBeginApplyAYieldLoadableNontrivialOwned : $@convention(thin) () -> @owned Klass {
+entry:
+  (%instance, %token) = begin_apply undef<LoadableNontrivial>() : $@yield_once @convention(thin) <U> () -> @yields @in U
+  end_apply %token
+  %borrow = begin_borrow %instance : $LoadableNontrivial
+  %extract = struct_extract %borrow : $LoadableNontrivial, #LoadableNontrivial.x
+  %retval = copy_value %extract : $Klass
+  end_borrow %borrow : $LoadableNontrivial
+  destroy_value %instance : $LoadableNontrivial
+  return %retval : $Klass
+}
+
+// CHECK-LABEL: sil [ossa] @testBeginApplyBYield2LoadableNontrivialOwned : {{.*}} {
+// CHECK:         ([[ADDR_1:%[^,]+]], [[ADDR_2:%[^,]+]], {{%[^,]+}}) = begin_apply
+// CHECK:         [[INSTANCE_1:%[^,]+]] = load [take] [[ADDR_1]]
+// CHECK:         [[INSTANCE_2:%[^,]+]] = load [take] [[ADDR_2]]
+// CHECK:         begin_borrow [[INSTANCE_1]]
+// CHECK:         begin_borrow [[INSTANCE_2]]
+// CHECK-LABEL: } // end sil function 'testBeginApplyBYield2LoadableNontrivialOwned'
+sil [ossa] @testBeginApplyBYield2LoadableNontrivialOwned : $@convention(thin) () -> @owned (Klass, Klass) {
+entry:
+  (%instance_1, %instance_2, %token) = begin_apply undef<LoadableNontrivial>() : $@yield_once @convention(thin) <U> () -> (@yields @in U, @yields @in U)
+  end_apply %token
+  %borrow_1 = begin_borrow %instance_1 : $LoadableNontrivial
+  %extract_1 = struct_extract %borrow_1 : $LoadableNontrivial, #LoadableNontrivial.x
+  %copy_1 = copy_value %extract_1 : $Klass
+  end_borrow %borrow_1 : $LoadableNontrivial
+  destroy_value %instance_1 : $LoadableNontrivial
+  %borrow_2 = begin_borrow %instance_2 : $LoadableNontrivial
+  %extract_2 = struct_extract %borrow_2 : $LoadableNontrivial, #LoadableNontrivial.x
+  %copy_2 = copy_value %extract_2 : $Klass
+  end_borrow %borrow_2 : $LoadableNontrivial
+  destroy_value %instance_2 : $LoadableNontrivial
+  %retval = tuple (%copy_1 : $Klass, %copy_2 : $Klass)
+  return %retval : $(Klass, Klass)
+}
+
+// CHECK-LABEL: sil [ossa] @testBeginApplyCYield1LoadableNontrivialOwned1OpaqueOwned : $@convention(thin) <T> () -> (@out Klass, @out T) {
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}} : $*Klass, [[OPAQUE_OUT:%[^,]+]] : $*T):
+// CHECK:         ([[ADDR_1:%[^,]+]], [[ADDR_2:%[^,]+]], {{%[^,]+}}) = begin_apply
+// CHECK:         [[INSTANCE_1:%[^,]+]] = load [take] [[ADDR_1]]
+// CHECK:         begin_borrow [[INSTANCE_1]]
+// CHECK:         copy_addr [take] [[ADDR_2]] to [init] [[OPAQUE_OUT]]
+// CHECK-LABEL: } // end sil function 'testBeginApplyCYield1LoadableNontrivialOwned1OpaqueOwned'
+sil [ossa] @testBeginApplyCYield1LoadableNontrivialOwned1OpaqueOwned : $@convention(thin) <T> () -> (@out Klass, @out T) {
+entry:
+  (%instance_1, %instance_2, %token) = begin_apply undef<LoadableNontrivial, T>() : $@yield_once @convention(thin) <U, T> () -> (@yields @in U, @yields @in T)
+  end_apply %token
+  %borrow_1 = begin_borrow %instance_1 : $LoadableNontrivial
+  %extract_1 = struct_extract %borrow_1 : $LoadableNontrivial, #LoadableNontrivial.x
+  %copy_1 = copy_value %extract_1 : $Klass
+  end_borrow %borrow_1 : $LoadableNontrivial
+  destroy_value %instance_1 : $LoadableNontrivial
+  %retval = tuple (%copy_1 : $Klass, %instance_2 : $T)
+  return %retval : $(Klass, T)
+}
+
+// CHECK-LABEL: sil [ossa] @testBeginApplyDYieldOpaqueInout : {{.*}} {
+// CHECK:         begin_apply undef<T>() : $@yield_once @convention(method) <τ_0_0> () -> @yields @inout τ_0_0
+// CHECK-LABEL: } // end sil function 'testBeginApplyDYieldOpaqueInout'
+sil [ossa] @testBeginApplyDYieldOpaqueInout : $@yield_once @convention(thin) <T> () -> () {
+entry:
+  (%addr, %token) = begin_apply undef<T>() : $@yield_once @convention(method) <U> () -> @yields @inout U
+  end_apply %token
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @testBeginApplyEYieldOpaqueInoutAndYield : {{.*}}{
+// CHECK:         ([[REGISTER_0:%[^,]+]], {{%[^,]+}}) = begin_apply
+// CHECK:         yield [[REGISTER_0]] : $*T
+// CHECK-LABEL: } // end sil function 'testBeginApplyEYieldOpaqueInoutAndYield'
+sil [ossa] @testBeginApplyEYieldOpaqueInoutAndYield : $@yield_once @convention(thin) <T> () -> @yields @inout T {
+entry:
+  (%addr, %token) = begin_apply undef<T>() : $@yield_once @convention(method) <U> () -> @yields @inout U
+  yield %addr : $*T, resume bb1, unwind bb2
+
+bb1:
+  end_apply %token
+  %8 = tuple ()
+  return %8 : $()
+
+bb2:
+  abort_apply %token
+  unwind
 }
 
 // CHECK-LABEL: sil hidden [ossa] @testOpaqueYield :

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1763,6 +1763,39 @@ bb0(%0 : @guaranteed $T):
   return %6 : $U
 }
 
+// Verify lowering of unconditional_checked_cast not involving address-only
+// values.
+// CHECK-LABEL: sil hidden [ossa] @test_unconditional_checked_cast4 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[SRC:%[^,]+]] :
+// CHECK:         [[SRC_ADDR:%[^,]+]] = alloc_stack $AnyObject
+// CHECK:         store [[SRC]] to [init] [[SRC_ADDR]] : $*AnyObject
+// CHECK:         [[DEST_ADDR:%[^,]+]] = alloc_stack $@thick any AnyObject.Type
+// CHECK:         unconditional_checked_cast_addr AnyObject in [[SRC_ADDR]] {{.*}} to @thick any AnyObject.Type in [[DEST_ADDR]]
+// CHECK:         load [trivial] [[DEST_ADDR]] : $*@thick any AnyObject.Type
+// CHECK-LABEL: } // end sil function 'test_unconditional_checked_cast4'
+sil hidden [ossa] @test_unconditional_checked_cast4 : $@convention(thin) (@owned AnyObject) -> () {
+entry(%instance : @owned $AnyObject):
+  %casted = unconditional_checked_cast %instance : $AnyObject to any AnyObject.Type
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Verify lowering of unconditional_checked_cast that involves address-only
+// values and also non-address-only values which on its own requires lowering
+// to unconditional_checked_cast_addr.
+// CHECK-LABEL: sil [ossa] @test_unconditional_checked_cast5 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[SRC_ADDR:%[^,]+]] :
+// CHECK:         [[DEST_ADDR:%[^,]+]] = alloc_stack $@thick any AnyObject.Type
+// CHECK:         unconditional_checked_cast_addr T in [[SRC_ADDR]] {{.*}} to @thick any AnyObject.Type in [[DEST_ADDR]]
+// CHECK:         load [trivial] [[DEST_ADDR]] : $*@thick any AnyObject.Type
+// CHECK-LABEL: } // end sil function 'test_unconditional_checked_cast5'
+sil [ossa] @test_unconditional_checked_cast5 : $@convention(thin) <T> (@in T) -> () {
+entry(%instance : @owned $T):
+  %casted = unconditional_checked_cast %instance : $T to any AnyObject.Type
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // CHECK-LABEL: sil [ossa] @yield_two : {{.*}} {
 // CHECK:         tuple_element_addr
 // CHECK:         tuple_element_addr

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1613,6 +1613,36 @@ bb3:
   return %31 : $()
 }
 
+// Test the result being stored into an @out enum.
+// CHECK-LABEL: sil [ossa] @test_checked_cast_br4 : $@convention(method) <Element><T> (@owned TestGeneric<Element>) -> @out Optional<T> {
+// CHECK:       {{bb[0-9]+}}([[OUT_ADDR:%[^,]+]] : $*Optional<T>, [[INSTANCE:%[^,]+]] : @owned $TestGeneric<Element>):
+// CHECK:         [[TEMP:%[^,]+]] = alloc_stack $Optional<T>
+// CHECK:         [[CAST_DEST_ADDR:%[^,]+]] = init_enum_data_addr [[TEMP]] : $*Optional<T>, #Optional.some!enumelt
+// CHECK:         [[CAST_SOURCE_ADDR:%[^,]+]] = alloc_stack $TestGeneric<Element>
+// CHECK:         store [[INSTANCE]] to [init] [[CAST_SOURCE_ADDR]]
+// CHECK:         checked_cast_addr_br take_on_success TestGeneric<Element> in [[CAST_SOURCE_ADDR]] : $*TestGeneric<Element> to T in [[CAST_DEST_ADDR]] : $*T, [[SUCCESS:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         dealloc_stack [[CAST_SOURCE_ADDR]]
+// CHECK:         inject_enum_addr [[TEMP]] : $*Optional<T>, #Optional.some!enumelt
+// CHECK:         copy_addr [take] [[TEMP]] to [init] [[OUT_ADDR]]
+// CHECK-LABEL: } // end sil function 'test_checked_cast_br4'
+sil [ossa] @test_checked_cast_br4 : $@convention(method) <Element><T> (@owned TestGeneric<Element>) -> @out Optional<T> {
+bb0(%3 : @owned $TestGeneric<Element>):
+  checked_cast_br %3 : $TestGeneric<Element> to T, bb1, bb2
+
+bb1(%5 : @owned $T):
+  %6 = enum $Optional<T>, #Optional.some!enumelt, %5 : $T
+  br bb3(%6 : $Optional<T>)
+
+bb2(%8 : @owned $TestGeneric<Element>):
+  destroy_value %8 : $TestGeneric<Element>
+  %10 = enum $Optional<T>, #Optional.none!enumelt
+  br bb3(%10 : $Optional<T>)
+
+bb3(%12 : @owned $Optional<T>):
+  return %12 : $Optional<T>
+}
+
 // CHECK-LABEL: sil hidden [ossa] @test_unchecked_bitwise_cast :
 // CHECK: bb0(%0 : $*U, %1 : $*T, %2 : $@thick U.Type):
 // CHECK:   [[STK:%.*]] = alloc_stack $T

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1643,6 +1643,60 @@ bb3(%12 : @owned $Optional<T>):
   return %12 : $Optional<T>
 }
 
+// Verify that checked_cast_br neither from nor to an address-only value but
+// whose operands require rewriting to checked_cast_addr_br gets rewritten.
+// CHECK-LABEL: sil [ossa] @test_checked_cast_br5 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[SRC:%[^,]+]] :
+// CHECK:         [[SRC_ADDR:%[^,]+]] = alloc_stack $AnyObject
+// CHECK:         store [[SRC]] to [init] [[SRC_ADDR]]
+// CHECK:         [[DEST_ADDR:%[^,]+]] = alloc_stack $@thick any AnyObject.Type
+// CHECK:         checked_cast_addr_br take_on_success AnyObject in [[SRC_ADDR]] {{.*}} to any AnyObject.Type in [[DEST_ADDR]] {{.*}}, [[SUCCESS:bb[0-9]+]], [[FAILURE:bb[0-9]+]]
+// CHECK:       [[FAILURE]]:
+// CHECK:         load [take] [[SRC_ADDR]] : $*AnyObject
+// CHECK:       [[SUCCESS]]:
+// CHECK:         load [trivial] [[DEST_ADDR]] : $*@thick any AnyObject.Type
+// CHECK-LABEL: } // end sil function 'test_checked_cast_br5'
+sil [ossa] @test_checked_cast_br5 : $@convention(thin) (@owned AnyObject) -> () {
+entry(%instance : @owned $AnyObject):
+  checked_cast_br %instance : $AnyObject to any AnyObject.Type, success, failure
+
+success(%metatype : $@thick any AnyObject.Type):
+  br exit
+
+failure(%original : @owned $AnyObject):
+  destroy_value %original : $AnyObject
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Verify that checked_cast_br which both has an address-only value and also
+// produces a value whose type would anyway require rewriting but is not
+// address-only gets lowered properly.
+// CHECK-LABEL: sil [ossa] @test_checked_cast_br6 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[SRC:%[^,]+]] :
+// CHECK:         [[DEST_ADDR:%[^,]+]] = alloc_stack $@thick any AnyObject.Type     
+// CHECK:         checked_cast_addr_br take_on_success T in [[SRC]] {{.*}} to any AnyObject.Type in [[DEST_ADDR]] {{.*}}, [[SUCCESS]], [[FAILURE]] 
+// CHECK:       [[FAILURE]]:                                              
+// CHECK:         destroy_addr [[SRC]] : $*T                           
+// CHECK:       [[SUCCESS]]:                                              
+// CHECK:         [[REGISTER_3:%[^,]+]] = load [trivial] [[DEST_ADDR]] : $*@thick any AnyObject.Type
+// CHECK-LABEL: } // end sil function 'test_checked_cast_br6'
+sil [ossa] @test_checked_cast_br6 : $@convention(thin) <T> (@in T) -> () {
+entry(%instance : @owned $T):
+  checked_cast_br %instance : $T to any AnyObject.Type, success, failure
+success(%metatype : $@thick any AnyObject.Type):
+  br exit
+failure(%original : @owned $T):
+  destroy_value %original : $T
+  br exit
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // CHECK-LABEL: sil hidden [ossa] @test_unchecked_bitwise_cast :
 // CHECK: bb0(%0 : $*U, %1 : $*T, %2 : $@thick U.Type):
 // CHECK:   [[STK:%.*]] = alloc_stack $T

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -27,6 +27,8 @@ protocol Error {}
 
 struct I {}
 
+class Klass {}
+
 struct SI<T> {
   var element: T
   var index: I
@@ -1425,8 +1427,6 @@ bb0(%0 : @guaranteed $TestGeneric<T>):
   %10 = tuple ()
   return %10 : $()
 }
-
-class Klass {}
 
 // CHECK-LABEL: sil hidden [ossa] @testBeginApply2LoadableYieldWithIndirectConv :
 // CHECK: bb0(%0 : @guaranteed $TestGeneric<Klass>):

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1417,7 +1417,7 @@ bb0:
   return %retval : $()
 } // end sil function '$ss17FixedWidthIntegerPsEyxSgSScfC'
 
-sil hidden [ossa] @testBeginApplyDeadYield : $@convention(thin) <T> (@guaranteed TestGeneric<T>) -> () {
+sil hidden [ossa] @testBeginApply1DeadYield : $@convention(thin) <T> (@guaranteed TestGeneric<T>) -> () {
 bb0(%0 : @guaranteed $TestGeneric<T>):
   %2 = class_method %0 : $TestGeneric<T>, #TestGeneric.borrowedGeneric!read : <T> (TestGeneric<T>) -> () -> (), $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
   (%3, %4) = begin_apply %2<T>(%0) : $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
@@ -1428,7 +1428,7 @@ bb0(%0 : @guaranteed $TestGeneric<T>):
 
 class Klass {}
 
-// CHECK-LABEL: sil hidden [ossa] @testBeginApplyLoadableYieldWithIndirectConv :
+// CHECK-LABEL: sil hidden [ossa] @testBeginApply2LoadableYieldWithIndirectConv :
 // CHECK: bb0(%0 : @guaranteed $TestGeneric<Klass>):
 // CHECK:   [[STK:%.*]] = alloc_stack $Klass
 // CHECK:   [[METH:%.*]] = class_method %0 : $TestGeneric<Klass>, #TestGeneric.borrowedGeneric!read : <T> (TestGeneric<T>) -> () -> (), $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
@@ -1437,7 +1437,7 @@ class Klass {}
 // CHECK:   end_apply [[TOK]]
 // CHECK:   destroy_addr [[STK]] : $*Klass
 // CHECK-LABEL: }
-sil hidden [ossa] @testBeginApplyLoadableYieldWithIndirectConv : $@convention(thin) <Klass> (@guaranteed TestGeneric<Klass>) -> () {
+sil hidden [ossa] @testBeginApply2LoadableYieldWithIndirectConv : $@convention(thin) <Klass> (@guaranteed TestGeneric<Klass>) -> () {
 bb0(%0 : @guaranteed $TestGeneric<Klass>):
   %2 = class_method %0 : $TestGeneric<Klass>, #TestGeneric.borrowedGeneric!read : <Klass> (TestGeneric<Klass>) -> () -> (), $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
   (%3, %4) = begin_apply %2<Klass>(%0) : $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
@@ -1448,7 +1448,7 @@ bb0(%0 : @guaranteed $TestGeneric<Klass>):
   return %10 : $()
 }
 
-// CHECK-LABEL: sil hidden [ossa] @testBeginApplyOpaqueYield :
+// CHECK-LABEL: sil hidden [ossa] @testBeginApply3OpaqueYield :
 // CHECK: bb0(%0 : @guaranteed $TestGeneric<T>):
 // CHECK:   [[STK:%.*]] = alloc_stack $T
 // CHECK:   [[M:%.*]] = class_method %0 : $TestGeneric<T>, #TestGeneric.borrowedGeneric!read : <T> (TestGeneric<T>) -> () -> (), $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
@@ -1456,8 +1456,8 @@ bb0(%0 : @guaranteed $TestGeneric<Klass>):
 // CHECK:   copy_addr [[Y]] to [init] [[STK]] : $*T
 // CHECK:   end_apply [[TOK]]
 // CHECK:   destroy_addr [[STK]] : $*T
-// CHECK-LABEL: } // end sil function 'testBeginApplyOpaqueYield'
-sil hidden [ossa] @testBeginApplyOpaqueYield : $@convention(thin) <T> (@guaranteed TestGeneric<T>) -> () {
+// CHECK-LABEL: } // end sil function 'testBeginApply3OpaqueYield'
+sil hidden [ossa] @testBeginApply3OpaqueYield : $@convention(thin) <T> (@guaranteed TestGeneric<T>) -> () {
 bb0(%0 : @guaranteed $TestGeneric<T>):
   %2 = class_method %0 : $TestGeneric<T>, #TestGeneric.borrowedGeneric!read : <T> (TestGeneric<T>) -> () -> (), $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0
   (%3, %4) = begin_apply %2<T>(%0) : $@yield_once @convention(method) <τ_0_0> (@guaranteed TestGeneric<τ_0_0>) -> @yields @in_guaranteed τ_0_0

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1351,9 +1351,9 @@ entry(%instance : @owned $Pair<T>):
 // CHECK:       {{bb[0-9]+}}([[INDEX_OUT:%[^,]+]] : $*Self.Index, [[SELF:%[^,]+]] : $*Self):
 // CHECK:         [[MAYBE_INDEX_ADDR:%[^,]+]] = alloc_stack $Optional<Builtin.Int64>
 // CHECK:         try_apply {{%[^,]+}}<Self, Builtin.Int64>([[MAYBE_INDEX_ADDR]], [[SELF]]) : $@convention(thin) <τ_0_0 where τ_0_0 : MyCollection><τ_1_0> (@inout τ_0_0) -> (@out Optional<τ_1_0>, @error any Error), normal [[YES_BLOCK:bb[0-9]+]], error [[NO_BLOCK:bb[0-9]+]]
-// CHECK:       [[NO_BLOCK]]([[REGISTER_16:%[^,]+]] : @owned $any Error):
+// CHECK:       [[NO_BLOCK]]([[ERROR:%[^,]+]] : @owned $any Error):
 // CHECK:         dealloc_stack [[MAYBE_INDEX_ADDR]]
-// CHECK:         br [[EXIT_ERROR:bb[0-9]+]]([[REGISTER_16]] : $any Error)
+// CHECK:         br [[EXIT_ERROR:bb[0-9]+]]([[ERROR]] : $any Error)
 // CHECK:       [[EXIT_ERROR]]([[ERROR_TO_THROW:%[^,]+]] : @owned $any Error):
 // CHECK:         throw [[ERROR_TO_THROW]]
 // CHECK:       [[YES_BLOCK]]
@@ -1682,7 +1682,7 @@ exit:
 // CHECK:       [[FAILURE]]:                                              
 // CHECK:         destroy_addr [[SRC]] : $*T                           
 // CHECK:       [[SUCCESS]]:                                              
-// CHECK:         [[REGISTER_3:%[^,]+]] = load [trivial] [[DEST_ADDR]] : $*@thick any AnyObject.Type
+// CHECK:         load [trivial] [[DEST_ADDR]] : $*@thick any AnyObject.Type
 // CHECK-LABEL: } // end sil function 'test_checked_cast_br6'
 sil [ossa] @test_checked_cast_br6 : $@convention(thin) <T> (@in T) -> () {
 entry(%instance : @owned $T):

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1614,7 +1614,7 @@ bb3:
 }
 
 // Test the result being stored into an @out enum.
-// CHECK-LABEL: sil [ossa] @test_checked_cast_br4 : $@convention(method) <Element><T> (@owned TestGeneric<Element>) -> @out Optional<T> {
+// CHECK-LABEL: sil [ossa] @test_checked_cast_br4 : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[OUT_ADDR:%[^,]+]] : $*Optional<T>, [[INSTANCE:%[^,]+]] : @owned $TestGeneric<Element>):
 // CHECK:         [[TEMP:%[^,]+]] = alloc_stack $Optional<T>
 // CHECK:         [[CAST_DEST_ADDR:%[^,]+]] = init_enum_data_addr [[TEMP]] : $*Optional<T>, #Optional.some!enumelt

--- a/test/SILOptimizer/opaque_values_Onone.swift
+++ b/test/SILOptimizer/opaque_values_Onone.swift
@@ -212,3 +212,41 @@ func castAnyObjectToMeta(_ ao: any AnyObject) -> AnyObject.Type {
 func castGenericToMeta<T>(_ t: T) -> AnyObject.Type {
   t as! AnyObject.Type
 }
+
+// CHECK-LABEL: sil hidden @maybeCastAnyObjectToMeta : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[SRC:%[^,]+]] :
+// CHECK:         [[SRC_ADDR:%[^,]+]] = alloc_stack $AnyObject
+// CHECK:         store [[SRC]] to [[SRC_ADDR]] : $*AnyObject
+// CHECK:         [[DEST_ADDR:%[^,]+]] = alloc_stack $@thick any AnyObject.Type
+// CHECK:         checked_cast_addr_br take_on_success AnyObject in [[SRC_ADDR]] {{.*}} to any AnyObject.Type in [[DEST_ADDR]] {{.*}}, [[SUCCESS:bb[0-9]+]], [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         load [[DEST_ADDR]] : $*@thick any AnyObject.Type
+// CHECK:       [[FAILURE]]:
+// CHECK:         load [[SRC_ADDR]] : $*AnyObject
+// CHECK-LABEL: } // end sil function 'maybeCastAnyObjectToMeta'
+@_silgen_name("maybeCastAnyObjectToMeta")
+func maybeCastAnyObjectToMeta(_ ao: any AnyObject) -> AnyObject.Type? {
+  if let m = ao as? AnyObject.Type {
+    return m
+  }
+  return nil
+}
+
+// CHECK-LABEL: sil hidden @maybeCastGenericToMeta : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[SRC:%[^,]+]] :
+// CHECK:         [[SRC_ADDR:%[^,]+]] = alloc_stack $T
+// CHECK:         copy_addr [[SRC]] to [init] [[SRC_ADDR]]
+// CHECK:         [[DEST_ADDR:%[^,]+]] = alloc_stack $@thick any AnyObject.Type
+// CHECK:         checked_cast_addr_br take_on_success T in [[SRC_ADDR]] {{.*}} to any AnyObject.Type in [[DEST_ADDR]] {{.*}}, [[SUCCESS:bb[0-9]+]], [[FAILURE:bb[0-9]+]]
+// CHECK:       [[SUCCESS]]:
+// CHECK:         load [[DEST_ADDR]]
+// CHECK:       [[FAILURE]]:
+// CHECK:         destroy_addr [[SRC_ADDR]]
+// CHECK-LABEL: } // end sil function 'maybeCastGenericToMeta'
+@_silgen_name("maybeCastGenericToMeta")
+func maybeCastGenericToMeta<T>(_ t: T) -> AnyObject.Type? {
+  if let m = t as? AnyObject.Type {
+    return m
+  }
+  return nil
+}

--- a/test/SILOptimizer/opaque_values_Onone.swift
+++ b/test/SILOptimizer/opaque_values_Onone.swift
@@ -180,3 +180,35 @@ func give_a_generic_tuple<This>(of ty: This.Type) -> (This, This)
 func get_a_generic_tuple<This>(ty: This.Type) {
   let p = give_a_generic_tuple(of: ty)
 }
+
+// CHECK-LABEL: sil hidden @castAnyObjectToMeta {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[SRC:%[^,]+]] :
+// CHECK:         [[SRC_ADDR:%[^,]+]] = alloc_stack $AnyObject
+// CHECK:         store [[SRC]] to [[SRC_ADDR]]
+// CHECK:         [[DEST_ADDR:%[^,]+]] = alloc_stack $@thick any AnyObject.Type
+// CHECK:         unconditional_checked_cast_addr AnyObject in [[SRC_ADDR]] {{.*}} to @thick any AnyObject.Type in [[DEST_ADDR]]
+// CHECK:         [[DEST:%[^,]+]] = load [[DEST_ADDR]]
+// CHECK:         dealloc_stack [[DEST_ADDR]]
+// CHECK:         dealloc_stack [[SRC_ADDR]]
+// CHECK:         return [[DEST]]
+// CHECK-LABEL: } // end sil function 'castAnyObjectToMeta'
+@_silgen_name("castAnyObjectToMeta")
+func castAnyObjectToMeta(_ ao: any AnyObject) -> AnyObject.Type {
+  ao as! AnyObject.Type
+}
+
+// CHECK-LABEL: sil hidden @castGenericToMeta : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[SRC:%[^,]+]] :
+// CHECK:         [[SRC_ADDR:%[^,]+]] = alloc_stack $T
+// CHECK:         copy_addr [[SRC]] to [init] [[SRC_ADDR]]
+// CHECK:         [[DEST_ADDR:%[^,]+]] = alloc_stack $@thick any AnyObject.Type
+// CHECK:         unconditional_checked_cast_addr T in [[SRC_ADDR]] {{.*}} to @thick any AnyObject.Type in [[DEST_ADDR]]
+// CHECK:         [[DEST:%[^,]+]] = load [[DEST_ADDR]]
+// CHECK:         dealloc_stack [[DEST_ADDR]]
+// CHECK:         dealloc_stack [[SRC_ADDR]]
+// CHECK:         return [[DEST]]
+// CHECK-LABEL: } // end sil function 'castGenericToMeta'
+@_silgen_name("castGenericToMeta")
+func castGenericToMeta<T>(_ t: T) -> AnyObject.Type {
+  t as! AnyObject.Type
+}


### PR DESCRIPTION
While visiting the function, record not only applies which have indirect formal _results_ but also applies which have indirect formal _yields_.

When rewriting indirect applies, check the apply site kind and rewrite according to it.

Taught ApplyRewriter to handle rewriting indirect loadable yields.

Based on https://github.com/apple/swift/pull/62018 .
