### PR TITLE
[Docs] Add note about debugging with --release-debuginfo build-script flag

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -250,9 +250,8 @@ Phew, that's a lot to digest! Now let's proceed to the actual build itself!
    > **Note:**
    > `--release-debuginfo` means that although debug information will be produced, all targets will
    > be compiled in release mode, meaning optimized code, which can affect your debugging experience.
-   > Consider using `--release-debuginfo --debug-swift` to have only the swift targets (that includes `swift-frontend`)
-   > built in debug mode.
-   > To know more about each flag being passed to build script run `utils/build-script --help`.
+   > Consider [`--debug-swift` to build a debug variant of swift component](#debugging-issues) to have 
+   > the swift targets (that includes `swift-frontend`) built in debug mode.
 
    If you would like to additionally build the Swift corelibs,
    ie swift-corelibs-libdispatch, swift-corelibs-foundation, and swift-corelibs-xctest,

--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -250,8 +250,8 @@ Phew, that's a lot to digest! Now let's proceed to the actual build itself!
    > **Note:**
    > `--release-debuginfo` means that although debug information will be produced, all targets will
    > be compiled in release mode, meaning optimized code, which can affect your debugging experience.
-   > Consider [`--debug-swift` to build a debug variant of swift component](#debugging-issues) to have 
-   > the swift targets (that includes `swift-frontend`) built in debug mode.
+   > Consider [`--debug-swift` to build a debug variant of the compiler](#debugging-issues) and have 
+   > the swift targets (including `swift-frontend`) built in debug mode.
 
    If you would like to additionally build the Swift corelibs,
    ie swift-corelibs-libdispatch, swift-corelibs-foundation, and swift-corelibs-xctest,

--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -247,6 +247,13 @@ Phew, that's a lot to digest! Now let's proceed to the actual build itself!
    containing the Swift compiler and standard library and clang/LLVM build artifacts.
    If the build fails, see [Troubleshooting build issues](#troubleshooting-build-issues).
 
+   > **Note:**
+   > `--release-debuginfo` means that although debug information will be produced, all targets will
+   > be compiled in release mode, meaning optimized code, which can affect your debugging experience.
+   > Consider using `--release-debuginfo --debug-swift` to have only the swift targets (that includes `swift-frontend`)
+   > built in debug mode.
+   > To know more about each flag being passed to build script run `utils/build-script --help`.
+
    If you would like to additionally build the Swift corelibs,
    ie swift-corelibs-libdispatch, swift-corelibs-foundation, and swift-corelibs-xctest,
    on Linux, add the `--xctest` flag to `build-script`.


### PR DESCRIPTION
<!-- What's in this pull request? -->
We currently have only `--release-debuginfo` in the starting guide for building the compiler, which is fine in most cases, but people may experience some debugging issues like `swift-frontend was compiled with optimization - stepping may behave oddly; variables may not be available`.
So adding a note section suggesting using `--debug-swift`. I thought about adding it directly to script snippet but adding as a note allows us to give a bit more context and kinda explain what the flag means. I think most people will add it anyways.