### PR TITLE
[stdlib] Make collections (of changes) of all sizes binary-searchable in `CollectionDifference`

### DIFF
--- a/stdlib/public/core/CollectionDifference.swift
+++ b/stdlib/public/core/CollectionDifference.swift
@@ -133,7 +133,7 @@ public struct CollectionDifference<ChangeElement> {
     } else {
       var range = 0...sortedChanges.count
       while range.lowerBound != range.upperBound {
-        let i = (range.lowerBound + range.upperBound) / 2
+        let i = range.lowerBound + (range.upperBound &- range.lowerBound) / 2
         switch sortedChanges[i] {
         case .insert(_, _, _):
           range = range.lowerBound...i


### PR DESCRIPTION
This changes the algorithm from `middle = (low+ high) / 2` to `middle = low + (high &- low) / 2`, allowing binary search on collections of any amount of changes, instead of hitting the overflow error at 2^(bitWidth - 2).