### PR TITLE
[android][test] Disable new SwiftToCxxToSwift Interop test

### DIFF
--- a/test/Interop/SwiftToCxxToSwift/hide-swift-module-namespace-in-swift.swift
+++ b/test/Interop/SwiftToCxxToSwift/hide-swift-module-namespace-in-swift.swift
@@ -10,6 +10,8 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/swiftMod2.h -Wno-error)
 
+// XFAIL: OS=linux-android, OS=linux-androideabi
+
 //--- header.h
 #include "swiftMod.h"
 


### PR DESCRIPTION
@drodriguez, this should get the Android CI green again, we've already disabled several Interop tests that show this `mbstate_t` error.