### PR TITLE
Improve indentation in type checker debugging output

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1708,7 +1708,7 @@ public:
   SWIFT_DEBUG_DUMP;
 
   /// Dump this solution.
-  void dump(raw_ostream &OS) const LLVM_ATTRIBUTE_USED;
+  void dump(raw_ostream &OS, unsigned indent) const LLVM_ATTRIBUTE_USED;
 };
 
 /// Describes the differences between several solutions to the same
@@ -6433,9 +6433,10 @@ public:
   bool isSymmetricOperator() const;
   bool isUnaryOperator() const;
 
-  void print(llvm::raw_ostream &Out, SourceManager *SM, unsigned indent = 0) const {
+  void print(llvm::raw_ostream &Out, SourceManager *SM,
+             unsigned indent = 0) const {
     Out << "disjunction choice ";
-    Choice->print(Out, SM);
+    Choice->print(Out, SM, indent);
   }
 
   operator Constraint *() { return Choice; }

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -2370,9 +2370,10 @@ Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
   }
 
   if (cs.isDebugMode()) {
-    auto &log = llvm::errs();
+    auto indent = cs.solverState ? cs.solverState->getCurrentIndent() : 0;
+    auto &log = llvm::errs().indent(indent);
     log << "--- Applying Solution ---\n";
-    solutions.front().dump(log);
+    solutions.front().dump(log, indent);
     log << '\n';
   }
 
@@ -2387,7 +2388,8 @@ Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
     auto *body = result->getFunctionBody();
 
     if (cs.isDebugMode()) {
-      auto &log = llvm::errs();
+      auto indent = cs.solverState ? cs.solverState->getCurrentIndent() : 0;
+      auto &log = llvm::errs().indent(indent);
       log << "--- Type-checked function body ---\n";
       body->dump(log);
       log << '\n';

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -55,8 +55,8 @@ void ConstraintSystem::increaseScore(ScoreKind kind, unsigned value) {
   if (isDebugMode() && value > 0) {
     if (solverState)
       llvm::errs().indent(solverState->getCurrentIndent());
-    llvm::errs() << "(increasing '" << Score::getNameFor(kind) << "' score by "  << value 
-                 << ")\n";
+    llvm::errs() << "(increasing '" << Score::getNameFor(kind) << "' score by "
+                 << value << ")\n";
   }
 
   unsigned index = static_cast<unsigned>(kind);
@@ -73,7 +73,7 @@ bool ConstraintSystem::worseThanBestSolution() const {
 
   if (isDebugMode()) {
     llvm::errs().indent(solverState->getCurrentIndent())
-      << "(solution is worse than the best solution)\n";
+        << "(solution is worse than the best solution)\n";
   }
 
   return true;
@@ -804,7 +804,7 @@ SolutionCompareResult ConstraintSystem::compareSolutions(
     const SolutionDiff &diff, unsigned idx1, unsigned idx2) {
   if (cs.isDebugMode()) {
     llvm::errs().indent(cs.solverState->getCurrentIndent())
-      << "comparing solutions " << idx1 << " and " << idx2 <<"\n";
+        << "comparing solutions " << idx1 << " and " << idx2 << "\n";
   }
 
   // Whether the solutions are identical.
@@ -1360,13 +1360,15 @@ ConstraintSystem::findBestSolution(SmallVectorImpl<Solution> &viable,
     return 0;
 
   if (isDebugMode()) {
-    llvm::errs().indent(solverState->getCurrentIndent())
-        << "Comparing " << viable.size() << " viable solutions\n";
+    auto indent = solverState->getCurrentIndent();
+    auto &log = llvm::errs();
 
+    log.indent(indent) << "Comparing " << viable.size()
+                       << " viable solutions\n";
     for (unsigned i = 0, n = viable.size(); i != n; ++i) {
-      llvm::errs().indent(solverState->getCurrentIndent())
-          << "\n--- Solution #" << i << " ---\n";
-      viable[i].dump(llvm::errs().indent(solverState->getCurrentIndent()));
+      log << "\n";
+      log.indent(indent) << "--- Solution #" << i << " ---\n";
+      viable[i].dump(llvm::errs(), indent);
     }
   }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -353,6 +353,10 @@ bool ConstraintSystem::simplify() {
     auto *constraint = &ActiveConstraints.front();
     deactivateConstraint(constraint);
 
+    auto isSimplifiable =
+        constraint->getKind() != ConstraintKind::Disjunction &&
+        constraint->getKind() != ConstraintKind::Conjunction;
+
     if (isDebugMode()) {
       auto &log = llvm::errs();
       log.indent(solverState->getCurrentIndent());
@@ -362,8 +366,7 @@ bool ConstraintSystem::simplify() {
 
       // {Dis, Con}junction are returned unsolved in \c simplifyConstraint() and
       // handled separately by solver steps.
-      if (constraint->getKind() != ConstraintKind::Disjunction &&
-          constraint->getKind() != ConstraintKind::Conjunction) {
+      if (isSimplifiable) {
         log.indent(solverState->getCurrentIndent() + 2)
             << "(simplification result:\n";
       }
@@ -375,7 +378,9 @@ bool ConstraintSystem::simplify() {
       retireFailedConstraint(constraint);
       if (isDebugMode()) {
         auto &log = llvm::errs();
-        log.indent(solverState->getCurrentIndent() + 2) << ")\n";
+        if (isSimplifiable) {
+          log.indent(solverState->getCurrentIndent() + 2) << ")\n";
+        }
         log.indent(solverState->getCurrentIndent() + 2) << "(outcome: error)\n";
       }
       break;
@@ -386,7 +391,9 @@ bool ConstraintSystem::simplify() {
       retireConstraint(constraint);
       if (isDebugMode()) {
         auto &log = llvm::errs();
-        log.indent(solverState->getCurrentIndent() + 2) << ")\n";
+        if (isSimplifiable) {
+          log.indent(solverState->getCurrentIndent() + 2) << ")\n";
+        }
         log.indent(solverState->getCurrentIndent() + 2)
             << "(outcome: simplified)\n";
       }
@@ -397,7 +404,9 @@ bool ConstraintSystem::simplify() {
         ++solverState->NumUnsimplifiedConstraints;
       if (isDebugMode()) {
         auto &log = llvm::errs();
-        log.indent(solverState->getCurrentIndent() + 2) << ")\n";
+        if (isSimplifiable) {
+          log.indent(solverState->getCurrentIndent() + 2) << ")\n";
+        }
         log.indent(solverState->getCurrentIndent() + 2)
             << "(outcome: unsolved)\n";
       }

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -105,13 +105,14 @@ void SplitterStep::computeFollowupSteps(
 
   if (CS.isDebugMode()) {
     auto &log = getDebugLogger();
+    auto indent = CS.solverState->getCurrentIndent();
     // Verify that the constraint graph is valid.
     CG.verify();
 
-    log << "---Constraint graph---\n";
+    log.indent(indent) << "---Constraint graph---\n";
     CG.print(CS.getTypeVariables(), log);
 
-    log << "---Connected components---\n";
+    log.indent(indent) << "---Connected components---\n";
     CG.printConnectedComponents(CS.getTypeVariables(), log);
   }
 
@@ -382,7 +383,7 @@ StepResult ComponentStep::take(bool prevFailed) {
 
     if (!overloadDisjunctions.empty()) {
       auto &log = getDebugLogger();
-      log.indent(2);
+      log.indent(CS.solverState->getCurrentIndent() + 2);
       log << "Disjunction(s) = [";
       interleave(overloadDisjunctions, log, ", ");
       log << "]\n";
@@ -429,7 +430,9 @@ StepResult ComponentStep::take(bool prevFailed) {
 
   auto printConstraints = [&](const ConstraintList &constraints) {
     for (auto &constraint : constraints)
-      constraint.print(getDebugLogger(), &CS.getASTContext().SourceMgr);
+      constraint.print(
+          getDebugLogger().indent(CS.solverState->getCurrentIndent()),
+          &CS.getASTContext().SourceMgr, CS.solverState->getCurrentIndent());
   };
 
   // If we don't have any disjunction or type variable choices left, we're done
@@ -671,7 +674,7 @@ bool DisjunctionStep::shouldSkip(const DisjunctionChoice &choice) const {
     if (CS.isDebugMode()) {
       auto &log = getDebugLogger();
       log << "(skipping " + reason + " ";
-      choice.print(log, &ctx.SourceMgr);
+      choice.print(log, &ctx.SourceMgr, CS.solverState->getCurrentIndent());
       log << ")\n";
     }
 

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -361,12 +361,6 @@ StepResult ComponentStep::take(bool prevFailed) {
   auto *disjunction = CS.selectDisjunction();
 
   if (CS.isDebugMode()) {
-    if (!potentialBindings.empty()) {
-      auto &log = getDebugLogger();
-      log << "(Potential Binding(s): " << '\n';
-      log << potentialBindings;
-    }
-
     SmallVector<Constraint *, 4> disjunctions;
     CS.collectDisjunctions(disjunctions);
     std::vector<std::string> overloadDisjunctions;
@@ -379,17 +373,24 @@ StepResult ComponentStep::take(bool prevFailed) {
         overloadDisjunctions.push_back(
             constraints[0]->getFirstType()->getString(PO));
     }
+
+    if (!potentialBindings.empty() || !overloadDisjunctions.empty()) {
+      auto &log = getDebugLogger();
+      log << "(Potential Binding(s): " << '\n';
+      log << potentialBindings;
+    }
+
     if (!overloadDisjunctions.empty()) {
       auto &log = getDebugLogger();
       log.indent(2);
       log << "Disjunction(s) = [";
       interleave(overloadDisjunctions, log, ", ");
       log << "]\n";
+    }
 
-      if (!potentialBindings.empty() || !overloadDisjunctions.empty()) {
-        auto &log = getDebugLogger();
-        log << ")\n";
-      }
+    if (!potentialBindings.empty() || !overloadDisjunctions.empty()) {
+      auto &log = getDebugLogger();
+      log << ")\n";
     }
   }
 
@@ -671,7 +672,7 @@ bool DisjunctionStep::shouldSkip(const DisjunctionChoice &choice) const {
       auto &log = getDebugLogger();
       log << "(skipping " + reason + " ";
       choice.print(log, &ctx.SourceMgr);
-      log << '\n';
+      log << ")\n";
     }
 
     return true;

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -707,7 +707,8 @@ public:
 
   void print(llvm::raw_ostream &Out) override {
     Out << "DisjunctionStep for ";
-    Disjunction->print(Out, &CS.getASTContext().SourceMgr);
+    Disjunction->print(Out, &CS.getASTContext().SourceMgr,
+                       CS.solverState->getCurrentIndent());
     Out << '\n';
   }
 
@@ -1013,7 +1014,8 @@ public:
 
   void print(llvm::raw_ostream &Out) override {
     Out << "ConjunctionStep for ";
-    Conjunction->print(Out, &CS.getASTContext().SourceMgr);
+    Conjunction->print(Out, &CS.getASTContext().SourceMgr,
+                       CS.solverState->getCurrentIndent());
     Out << '\n';
   }
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -360,7 +360,8 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   llvm_unreachable("Unhandled ConstraintKind in switch.");
 }
 
-void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm, unsigned indent, bool skipLocator) const {
+void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm,
+                       unsigned indent, bool skipLocator) const {
   // Print all type variables as $T0 instead of _ here.
   PrintOptions PO;
   PO.PrintTypesForDebugging = true;
@@ -395,19 +396,21 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm, unsigned inden
                  return false;
                });
 
-    interleave(sortedConstraints,
-               [&](Constraint *constraint) {
-                Out.indent(indent);
-                 if (constraint->isDisabled())
-                   Out << ">  [disabled] ";
-                 else if (constraint->isFavored())
-                   Out << ">  [favored]  ";
-                 else
-                   Out << ">             ";
-                 constraint->print(Out, sm, indent,
-                   /*skipLocator=*/constraint->getLocator() == Locator);
-               },
-               [&] { Out << "\n"; });
+    interleave(
+        sortedConstraints,
+        [&](Constraint *constraint) {
+          Out.indent(indent + 2);
+          if (constraint->isDisabled())
+            Out << ">  [disabled] ";
+          else if (constraint->isFavored())
+            Out << ">  [favored]  ";
+          else
+            Out << ">             ";
+          constraint->print(Out, sm, indent,
+                            /*skipLocator=*/constraint->getLocator() ==
+                                Locator);
+        },
+        [&] { Out << "\n"; });
     return;
   }
 

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1438,12 +1438,12 @@ bool ConstraintGraph::contractEdges() {
     auto rep2 = CS.getRepresentative(tyvar2);
 
     if (CS.isDebugMode()) {
-      auto &log = llvm::errs();
-      if (CS.solverState)
-        log.indent(CS.solverState->getCurrentIndent());
+      auto indent = CS.solverState ? CS.solverState->getCurrentIndent() : 0;
+      auto &log = llvm::errs().indent(indent);
 
       log << "Contracting constraint ";
-      constraint->print(log, &CS.getASTContext().SourceMgr);
+      constraint->print(log.indent(indent), &CS.getASTContext().SourceMgr,
+                        indent);
       log << "\n";
     }
 
@@ -1488,7 +1488,7 @@ void ConstraintGraphNode::print(llvm::raw_ostream &out, unsigned indent,
 
     for (auto constraint : sortedConstraints) {
       out.indent(indent + 4);
-      constraint->print(out, &TypeVar->getASTContext().SourceMgr);
+      constraint->print(out, &TypeVar->getASTContext().SourceMgr, indent + 4);
       out << "\n";
     }
   }
@@ -1545,7 +1545,8 @@ void ConstraintGraph::print(ArrayRef<TypeVariableType *> typeVars,
   PO.PrintTypesForDebugging = true;
 
   for (auto typeVar : typeVars) {
-    (*this)[typeVar].print(out, 2, PO);
+    (*this)[typeVar].print(
+        out, (CS.solverState ? CS.solverState->getCurrentIndent() : 0) + 2, PO);
     out << "\n";
   }
 }
@@ -1682,7 +1683,7 @@ void ConstraintGraph::printConnectedComponents(
   PrintOptions PO;
   PO.PrintTypesForDebugging = true;
   for (const auto& component : components) {
-    out.indent(2);
+    out.indent((CS.solverState ? CS.solverState->getCurrentIndent() : 0) + 2);
     out << component.solutionIndex << ": ";
     SWIFT_DEFER {
       out << '\n';

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3958,7 +3958,7 @@ SolutionResult ConstraintSystem::salvage() {
         int i = 0;
         for (auto &solution : viable) {
           log << "---Ambiguous solution #" << i++ << "---\n";
-          solution.dump(log);
+          solution.dump(log, solverState->getCurrentIndent());
           log << "\n";
         }
       }
@@ -4692,13 +4692,15 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
     return true;
 
   if (isDebugMode()) {
-    auto &log = llvm::errs();
+    auto indent = solverState->getCurrentIndent();
+    auto &log = llvm::errs().indent(indent);
     log << "--- Ambiguity: Considering #" << solutions.size()
         << " solutions with fixes ---\n";
     int i = 0;
     for (auto &solution : solutions) {
-      log << "\n--- Solution #" << i++ << "---\n";
-      solution.dump(log);
+      log << "\n";
+      log.indent(indent) << "--- Solution #" << i++ << "---\n";
+      solution.dump(log, indent);
       log << "\n";
     }
   }

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -410,8 +410,10 @@ getTypeOfCompletionOperatorImpl(DeclContext *DC, Expr *expr,
 
   if (CS.isDebugMode()) {
     auto &log = llvm::errs();
-    log << "---Initial constraints for the given expression---\n";
-    expr->dump(log);
+    auto indent = CS.solverState ? CS.solverState->getCurrentIndent() : 0;
+    log.indent(indent)
+        << "---Initial constraints for the given expression---\n";
+    expr->dump(log, indent);
     log << "\n";
     CS.print(log);
   }
@@ -424,8 +426,9 @@ getTypeOfCompletionOperatorImpl(DeclContext *DC, Expr *expr,
   auto &solution = viable[0];
   if (CS.isDebugMode()) {
     auto &log = llvm::errs();
-    log << "---Solution---\n";
-    solution.dump(log);
+    auto indent = CS.solverState ? CS.solverState->getCurrentIndent() : 0;
+    log.indent(indent) << "---Solution---\n";
+    solution.dump(log, indent);
   }
 
   // Fill the results.


### PR DESCRIPTION
I was looking at the reason behind the performance bug in #58955 and found that the compiler was spending most of the time in the type checker. While investing, I found the `DebugConstraints` flag very useful; however, the output of this flag was not always indented, which made the debugging log hard to fold and read.

This PR improves indentation in some of the debugging output.

I noticed the debugging output is mostly untested. Should I try to add tests for the indentation?

