### PR TITLE
update_checkout: fix `scheme_map` not reloaded

### DIFF
--- a/utils/update_checkout/update_checkout/update_checkout.py
+++ b/utils/update_checkout/update_checkout/update_checkout.py
@@ -717,6 +717,7 @@ repositories.
                 with open(args.config) as f:
                     config = json.load(f)
                 validate_config(config)
+                scheme_map = get_scheme_map(config, scheme_name)
 
     if args.dump_hashes:
         dump_repo_hashes(args, config)


### PR DESCRIPTION
A one line follow-up fix for #62004. We re-read the config, but didn't check out correct branches after that, because `scheme_map` dictionary was loaded from the old config.