### PR TITLE
[FrontendOptions] Remove bespoke experimental feature flags in favor of `-enable-experimental-feature X`.

### DIFF
--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -571,17 +571,9 @@ def disable_experimental_string_processing :
   Flag<["-"], "disable-experimental-string-processing">,
   HelpText<"Disable experimental string processing">;
 
-def enable_experimental_variadic_generics :
-  Flag<["-"], "enable-experimental-variadic-generics">,
-  HelpText<"Enable experimental support for variadic generic types">;
-
 def enable_experimental_associated_type_inference :
   Flag<["-"], "enable-experimental-associated-type-inference">,
   HelpText<"Enable experimental associated type inference via type witness systems">;
-
-def enable_experimental_implicit_some :
-  Flag<["-"], "enable-experimental-implicit-some">,
-  HelpText<"Enable experimental implicit some">;
 
 def disable_availability_checking : Flag<["-"],
   "disable-availability-checking">,

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -693,8 +693,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
 
   // Map historical flags over to experimental features. We do this for all
   // compilers because that's how existing experimental feature flags work.
-  if (Args.hasArg(OPT_enable_experimental_variadic_generics))
-    Opts.Features.insert(Feature::VariadicGenerics);
   if (Args.hasArg(OPT_enable_experimental_static_assert))
     Opts.Features.insert(Feature::StaticAssert);
   if (Args.hasArg(OPT_enable_experimental_named_opaque_types))
@@ -714,10 +712,6 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   
   if (Args.hasArg(OPT_enable_experimental_opaque_type_erasure))
     Opts.Features.insert(Feature::OpaqueTypeErasure);
-  if (Args.hasArg(OPT_enable_experimental_implicit_some)){
-      Opts.Features.insert(Feature::ImplicitSome);
-      Opts.Features.insert(Feature::ExistentialAny);
-  }
 
   Opts.EnableAppExtensionRestrictions |= Args.hasArg(OPT_enable_app_extension);
 

--- a/test/Constraints/one_element_tuple.swift
+++ b/test/Constraints/one_element_tuple.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-variadic-generics
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature VariadicGenerics
+
+// REQUIRES: asserts
 
 let t1: (_: Int) = (_: 3)
 let t2: (x: Int) = (x: 3)

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-variadic-generics
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature VariadicGenerics
+
+// REQUIRES: asserts
 
 func tuplify<T...>(_ t: T...) -> (T...) {
   return (t...)

--- a/test/Constraints/pack_expansion_types.swift
+++ b/test/Constraints/pack_expansion_types.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-variadic-generics
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature VariadicGenerics
+
+// REQUIRES: asserts
 
 func returnTuple1<T...>() -> (T...) { fatalError() }
 

--- a/test/Constraints/variadic_generic_constraints.swift
+++ b/test/Constraints/variadic_generic_constraints.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-variadic-generics
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature VariadicGenerics
+
+// REQUIRES: asserts
 
 // Test instantiation of constraint solver constraints from generic requirements
 // involving type pack parameters

--- a/test/Constraints/variadic_generic_functions.swift
+++ b/test/Constraints/variadic_generic_functions.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-variadic-generics
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature VariadicGenerics
+
+// REQUIRES: asserts
 
 func debugPrint<T...>(_ items: T...)
   where T: CustomDebugStringConvertible

--- a/test/Generics/pack-shape-requirements.swift
+++ b/test/Generics/pack-shape-requirements.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -typecheck -enable-experimental-variadic-generics %s -debug-generic-signatures 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck -enable-experimental-feature VariadicGenerics %s -debug-generic-signatures 2>&1 | %FileCheck %s
+
+// REQUIRES: asserts
 
 protocol P {
   associatedtype A

--- a/test/Generics/tuple-conformances.swift
+++ b/test/Generics/tuple-conformances.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-variadic-generics -parse-stdlib
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature VariadicGenerics -parse-stdlib
+
+// REQUIRES: asserts
 
 import Swift
 

--- a/test/Generics/variadic_generic_types.swift
+++ b/test/Generics/variadic_generic_types.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-variadic-generics
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature VariadicGenerics
+
+// REQUIRES: asserts
 
 struct TupleStruct<First, Rest...> {
   var first: First

--- a/test/Parse/type_parameter_packs.swift
+++ b/test/Parse/type_parameter_packs.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-variadic-generics
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature VariadicGenerics
+
+// REQUIRES: asserts
 
 protocol P {}
 

--- a/test/type/implicit_some/opaque_parameters.swift
+++ b/test/type/implicit_some/opaque_parameters.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -warn-redundant-requirements  -enable-experimental-implicit-some
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -warn-redundant-requirements  -enable-experimental-feature ImplicitSome
+
+// REQUIRES: asserts
 
 protocol P { }
 

--- a/test/type/implicit_some/opaque_return.swift
+++ b/test/type/implicit_some/opaque_return.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -warn-redundant-requirements  -enable-experimental-implicit-some
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -warn-redundant-requirements  -enable-experimental-feature ImplicitSome
+
+// REQUIRES: asserts
 
 protocol Eatery {
   func lunch()

--- a/test/type/opaque_parameterized_existential.swift
+++ b/test/type/opaque_parameterized_existential.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swift-frontend -disable-availability-checking -typecheck -verify %s
-// RUN: %target-swift-frontend -disable-availability-checking -enable-experimental-implicit-some -typecheck -verify %s
+// RUN: %target-swift-frontend -disable-availability-checking -enable-experimental-feature ImplicitSome -typecheck -verify %s
+
+// REQUIRES: asserts
 
 // I do not like nested some type params,
 // I do not like them Σam-i-am

--- a/test/type/pack_expansion.swift
+++ b/test/type/pack_expansion.swift
@@ -1,4 +1,6 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-variadic-generics
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature VariadicGenerics
+
+// REQUIRES: asserts
 
 func f1<T...>() -> T... {}
 // expected-error@-1 {{variadic expansion 'T' cannot appear outside of a function parameter list, function result, tuple element or generic argument list}}


### PR DESCRIPTION
* Replace `-enable-experimental-variadic-generics` with `-enable-experimental-feature VariadicGenerics`
* Replace `-enable-experimental-implicit-some` with `-enable-experimental-feature ImplicitSome`