### PR TITLE
[Dependency Scanning] Produce canonical output path for Clang PCMs.

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -237,6 +237,9 @@ public:
 /// This class is mostly an implementation detail for \c ModuleDependencies.
 class ClangModuleDependenciesStorage : public ModuleDependenciesStorageBase {
 public:
+  /// Destination output path
+  const std::string pcmOutputPath;
+  
   /// The module map file used to generate the Clang module.
   const std::string moduleMapFile;
 
@@ -254,12 +257,14 @@ public:
   const std::vector<std::string> capturedPCMArgs;
 
   ClangModuleDependenciesStorage(
+      const std::string &pcmOutputPath,
       const std::string &moduleMapFile,
       const std::string &contextHash,
       const std::vector<std::string> &nonPathCommandLine,
       const std::vector<std::string> &fileDependencies,
       const std::vector<std::string> &capturedPCMArgs
   ) : ModuleDependenciesStorageBase(ModuleDependenciesKind::Clang),
+      pcmOutputPath(pcmOutputPath),
       moduleMapFile(moduleMapFile),
       contextHash(contextHash),
       nonPathCommandLine(nonPathCommandLine),
@@ -367,6 +372,7 @@ public:
   /// Describe the module dependencies for a Clang module that can be
   /// built from a module map and headers.
   static ModuleDependencies forClangModule(
+      const std::string &pcmOutputPath,
       const std::string &moduleMapFile,
       const std::string &contextHash,
       const std::vector<std::string> &nonPathCommandLine,
@@ -374,8 +380,8 @@ public:
       const std::vector<std::string> &capturedPCMArgs) {
     return ModuleDependencies(
         std::make_unique<ClangModuleDependenciesStorage>(
-          moduleMapFile, contextHash, nonPathCommandLine,
-          fileDependencies, capturedPCMArgs));
+          pcmOutputPath, moduleMapFile, contextHash,
+          nonPathCommandLine, fileDependencies, capturedPCMArgs));
   }
 
   /// Describe a placeholder dependency swift module.

--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -162,6 +162,7 @@ using SwiftPlaceholderModuleDetailsLayout =
 
 using ClangModuleDetailsLayout =
     BCRecordLayout<CLANG_MODULE_DETAILS_NODE, // ID
+                   FileIDField,               // pcmOutputPath
                    FileIDField,               // moduleMapPath
                    ContextHashField,          // contextHash
                    FlagIDArrayIDField,        // commandLine

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -159,6 +159,12 @@ void ClangImporter::recordModuleDependencies(
     swiftArgs.push_back("-emit-pcm");
     swiftArgs.push_back("-module-name");
     swiftArgs.push_back(clangModuleDep.ID.ModuleName);
+    
+    auto pcmPath = moduleCacheRelativeLookupModuleOutput(clangModuleDep.ID,
+                                                         ModuleOutputKind::ModuleFile,
+                                                         getModuleCachePathFromClang(getClangInstance()));
+    swiftArgs.push_back("-o");
+    swiftArgs.push_back(pcmPath);
 
     // Ensure that the resulting PCM build invocation uses Clang frontend directly
     swiftArgs.push_back("-direct-clang-cc1-module-build");
@@ -186,6 +192,7 @@ void ClangImporter::recordModuleDependencies(
     // Module-level dependencies.
     llvm::StringSet<> alreadyAddedModules;
     auto dependencies = ModuleDependencies::forClangModule(
+        pcmPath,
         clangModuleDep.ClangModuleMapFile,
         clangModuleDep.ID.ContextHash,
         swiftArgs,

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -590,6 +590,8 @@ static void writeJSON(llvm::raw_ostream &out,
       modulePath = get_C_string(swiftPlaceholderDeps->compiled_module_path);
     else if (swiftBinaryDeps)
       modulePath = get_C_string(swiftBinaryDeps->compiled_module_path);
+    else if (clangDeps)
+      modulePath = get_C_string(moduleInfo.module_path);
     else
       modulePath = moduleName + modulePathSuffix;
 
@@ -831,6 +833,8 @@ generateFullDependencyGraph(CompilerInstance &instance,
       modulePath = swiftPlaceholderDeps->compiledModulePath;
     else if (swiftBinaryDeps)
       modulePath = swiftBinaryDeps->compiledModulePath;
+    else if (clangDeps)
+      modulePath = clangDeps->pcmOutputPath;
     else
       modulePath = module.first + modulePathSuffix;
 

--- a/test/ModuleInterface/clang-args-transitive-availability.swift
+++ b/test/ModuleInterface/clang-args-transitive-availability.swift
@@ -35,7 +35,7 @@ import ImportsMacroSpecificClangModule
 // CHECK:      "clang": "OnlyWithMacro"
 // CHECK-NEXT:    },
 // CHECK-NEXT:    {
-// CHECK-NEXT:      "modulePath": "OnlyWithMacro.pcm",
+// CHECK-NEXT:      "modulePath": "{{.*}}{{/|\\}}OnlyWithMacro-{{.*}}.pcm",
 // CHECK-NEXT:      "sourceFiles": [
 // CHECK-DAG:        "{{.*}}OnlyWithMacro.h"
 // CHECK-DAG:        "{{.*}}module.modulemap"

--- a/test/ScanDependencies/batch_module_scan.swift
+++ b/test/ScanDependencies/batch_module_scan.swift
@@ -27,7 +27,7 @@
 // CHECK-PCM-NEXT:      "clang": "F"
 // CHECK-PCM-NEXT:    },
 // CHECK-PCM-NEXT:    {
-// CHECK-PCM-NEXT:      "modulePath": "F.pcm",
+// CHECK-PCM-NEXT:      "modulePath": "{{.*}}F-{{.*}}.pcm",
 // CHECK-PCM: "-I
 
 // CHECK-SWIFT: {

--- a/test/ScanDependencies/batch_module_scan_versioned.swift
+++ b/test/ScanDependencies/batch_module_scan_versioned.swift
@@ -27,7 +27,7 @@
 // CHECK-PCM109-NEXT:      "clang": "G"
 // CHECK-PCM109-NEXT:    },
 // CHECK-PCM109-NEXT:    {
-// CHECK-PCM109-NEXT:      "modulePath": "G.pcm",
+// CHECK-PCM109-NEXT:      "modulePath": "{{.*}}{{/|\\}}G-{{.*}}.pcm",
 // CHECK-PCM109:       "directDependencies": [
 // CHECK-PCM109-NEXT:    {
 // CHECK-PCM109-NEXT:      "clang": "X"
@@ -42,7 +42,7 @@
 // CHECK-PCM110-NEXT:      "clang": "G"
 // CHECK-PCM110-NEXT:    },
 // CHECK-PCM110-NEXT:    {
-// CHECK-PCM110-NEXT:      "modulePath": "G.pcm",
+// CHECK-PCM110-NEXT:      "modulePath": "{{.*}}{{/|\\}}G-{{.*}}.pcm",
 // CHECK-PCM110:       "directDependencies": [
 // CHECK-PCM110-NEXT:  ],
 // CHECK-PCM110-NOT: "clang": "X"

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -94,7 +94,7 @@ import SubE
 // CHECK-NEXT: },
 
 /// --------Clang module C
-// CHECK-LABEL: "modulePath": "C.pcm",
+// CHECK-LABEL: "modulePath": "{{.*}}/C-{{.*}}.pcm",
 
 // CHECK: "sourceFiles": [
 // CHECK-DAG: module.modulemap
@@ -181,7 +181,7 @@ import SubE
 // CHECK-NEXT: "clang": "SwiftShims"
 
 /// --------Clang module B
-// CHECK-LABEL: "modulePath": "B.pcm"
+// CHECK-LABEL: "modulePath": "{{.*}}/B-{{.*}}.pcm",
 
 // CHECK-NEXT: sourceFiles
 // CHECK-DAG: module.modulemap
@@ -193,4 +193,4 @@ import SubE
 // CHECK-NEXT: }
 
 /// --------Clang module SwiftShims
-// CHECK-LABEL: "modulePath": "SwiftShims.pcm",
+// CHECK-LABEL: "modulePath": "{{.*}}/SwiftShims-{{.*}}.pcm",

--- a/test/ScanDependencies/module_deps_external.swift
+++ b/test/ScanDependencies/module_deps_external.swift
@@ -96,7 +96,7 @@ import SomeExternalModule
 // CHECK-NEXT: "clang": "SwiftShims"
 
 /// --------Clang module SwiftShims
-// CHECK-LABEL: "modulePath": "SwiftShims.pcm",
+// CHECK-LABEL: "modulePath": "{{.*}}/SwiftShims-{{.*}}.pcm",
 
 // Check make-style dependencies
 // CHECK-MAKE-DEPS: module_deps_external.swift


### PR DESCRIPTION
Instead of relying on the client (driver) to perform its own computation of the matching output path.
