### PR TITLE
[swift][TBDGen] Stop adding redundant ObjC Classes

### DIFF
--- a/include/swift/SIL/SILSymbolVisitor.h
+++ b/include/swift/SIL/SILSymbolVisitor.h
@@ -107,7 +107,6 @@ public:
   virtual void addMethodDescriptor(SILDeclRef declRef) {}
   virtual void addMethodLookupFunction(ClassDecl *CD) {}
   virtual void addNominalTypeDescriptor(NominalTypeDecl *NTD) {}
-  virtual void addObjCClass(ClassDecl *CD) {}
   virtual void addObjCInterface(ClassDecl *CD) {}
   virtual void addObjCMetaclass(ClassDecl *CD) {}
   virtual void addObjCMethod(AbstractFunctionDecl *AFD) {}

--- a/lib/IRGen/IRSymbolVisitor.cpp
+++ b/lib/IRGen/IRSymbolVisitor.cpp
@@ -158,12 +158,7 @@ public:
     addLinkEntity(LinkEntity::forNominalTypeDescriptor(NTD));
   }
 
-  void addObjCClass(ClassDecl *CD) override {
-    addLinkEntity(LinkEntity::forObjCClass(CD));
-  }
-
   void addObjCInterface(ClassDecl *CD) override {
-    // Pass through; Obj-C interfaces don't have linkable symbols.
     Visitor.addObjCInterface(CD);
   }
 

--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -607,6 +607,11 @@ PublicSymbolsRequest::evaluate(Evaluator &evaluator,
   auto addSymbol = [&](StringRef symbol, SymbolKind kind, SymbolSource source) {
     if (kind == SymbolKind::GlobalSymbol)
       symbols.push_back(symbol.str());
+    // TextAPI ObjC Class Kinds represents two symbols.
+    else if (kind == SymbolKind::ObjectiveCClass) {
+      symbols.push_back((llvm::MachO::ObjC2ClassNamePrefix + symbol).str());
+      symbols.push_back((llvm::MachO::ObjC2MetaClassNamePrefix + symbol).str());
+    }
   };
   SimpleAPIRecorder recorder(addSymbol);
   TBDGenVisitor visitor(desc, recorder);

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -318,21 +318,16 @@ class SILSymbolVisitorImpl : public ASTVisitor<SILSymbolVisitorImpl> {
     // Metaclasses and ObjC classes (duh) are an ObjC thing, and so are not
     // needed in build artifacts/for classes which can't touch ObjC.
     if (objCCompatible) {
-      bool addObjCClass = false;
-      if (isObjC) {
-        addObjCClass = true;
-        Visitor.addObjCClass(CD);
-      }
+      if (isObjC)
+        Visitor.addObjCInterface(CD);
 
       if (CD->getMetaclassKind() == ClassDecl::MetaclassKind::ObjC) {
-        addObjCClass = true;
-        Visitor.addObjCMetaclass(CD);
+        // If an ObjCInterface was not added, ObjC Metaclass may still need to
+        // be included.
+        if (!isObjC)
+          Visitor.addObjCMetaclass(CD);
       } else
         Visitor.addSwiftMetaclassStub(CD);
-
-      if (addObjCClass) {
-        Visitor.addObjCInterface(CD);
-      }
     }
 
     // Some members of classes get extra handling, beyond members of

--- a/test/APIJSON/apigen.swift
+++ b/test/APIJSON/apigen.swift
@@ -316,42 +316,6 @@ public func myFunction2() {}
 // CHECK-NEXT:     "access": "public",
 // CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
 // CHECK-NEXT:     "linkage": "exported"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "name": "_OBJC_CLASS_$__TtC8MyModule4Test",
-// CHECK-NEXT:     "access": "public",
-// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "name": "_OBJC_CLASS_$__TtC8MyModule5Test3",
-// CHECK-NEXT:     "access": "public",
-// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "name": "_OBJC_CLASS_$__TtC8MyModule7Derived",
-// CHECK-NEXT:     "access": "public",
-// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "name": "_OBJC_METACLASS_$__TtC8MyModule4Test",
-// CHECK-NEXT:     "access": "public",
-// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "name": "_OBJC_METACLASS_$__TtC8MyModule5Test3",
-// CHECK-NEXT:     "access": "public",
-// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "name": "_OBJC_METACLASS_$__TtC8MyModule7Derived",
-// CHECK-NEXT:     "access": "public",
-// CHECK-NEXT:     "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:     "linkage": "exported"
 // CHECK-NEXT:   }
 // CHECK-NEXT: ],
 // CHECK-NEXT: "interfaces": [

--- a/test/APIJSON/spi.swift
+++ b/test/APIJSON/spi.swift
@@ -72,18 +72,6 @@ public func spiAvailableFunc() {}
 // CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
 // CHECK-NEXT:       "linkage": "exported",
 // CHECK-NEXT:       "unavailable": true
-// CHECK-NEXT:     },
-// CHECK-NEXT:     {
-// CHECK-NEXT:       "name": "_OBJC_CLASS_$__TtC8MyModule8MyClass2",
-// CHECK-NEXT:       "access": "public",
-// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:       "linkage": "exported"
-// CHECK-NEXT:     },
-// CHECK-NEXT:     {
-// CHECK-NEXT:       "name": "_OBJC_METACLASS_$__TtC8MyModule8MyClass2",
-// CHECK-NEXT:       "access": "public",
-// CHECK-NEXT:       "file": "/@input/MyModule.swiftinterface",
-// CHECK-NEXT:       "linkage": "exported"
 // CHECK-NEXT:     }
 // CHECK-NEXT:   ],
 // CHECK-NEXT:   "interfaces": [
@@ -242,30 +230,6 @@ public func spiAvailableFunc() {}
 // CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
 // CHECK-SPI-NEXT:       "linkage": "exported",
 // CHECK-SPI-NEXT:       "introduced": "10.10"
-// CHECK-SPI-NEXT:     },
-// CHECK-SPI-NEXT:     {
-// CHECK-SPI-NEXT:       "name": "_OBJC_CLASS_$__TtC8MyModule7MyClass",
-// CHECK-SPI-NEXT:       "access": "private",
-// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
-// CHECK-SPI-NEXT:       "linkage": "exported"
-// CHECK-SPI-NEXT:     },
-// CHECK-SPI-NEXT:     {
-// CHECK-SPI-NEXT:       "name": "_OBJC_CLASS_$__TtC8MyModule8MyClass2",
-// CHECK-SPI-NEXT:       "access": "public",
-// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
-// CHECK-SPI-NEXT:       "linkage": "exported"
-// CHECK-SPI-NEXT:     },
-// CHECK-SPI-NEXT:     {
-// CHECK-SPI-NEXT:       "name": "_OBJC_METACLASS_$__TtC8MyModule7MyClass",
-// CHECK-SPI-NEXT:       "access": "private",
-// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
-// CHECK-SPI-NEXT:       "linkage": "exported"
-// CHECK-SPI-NEXT:     },
-// CHECK-SPI-NEXT:     {
-// CHECK-SPI-NEXT:       "name": "_OBJC_METACLASS_$__TtC8MyModule8MyClass2",
-// CHECK-SPI-NEXT:       "access": "public",
-// CHECK-SPI-NEXT:       "file": "/@input/MyModule.swiftmodule",
-// CHECK-SPI-NEXT:       "linkage": "exported"
 // CHECK-SPI-NEXT:     },
 // CHECK-SPI-NEXT:     {
 // CHECK-SPI-NEXT:       "name": "_main",

--- a/test/TBD/implied_objc_symbols.swift
+++ b/test/TBD/implied_objc_symbols.swift
@@ -7,4 +7,7 @@
 
 // RUN: %FileCheck %s < %t/main.tbd
 
+// CHECK-NOT: '_OBJC_CLASS_$_CApi'
+// CHECK-NOT: '_OBJC_METACLASS_$_CApi' 
+
 // CHECK: objc-classes: [ CApi ]


### PR DESCRIPTION
TBD files contain a section reserved for obj-c classes. Previously, TBDGen was adding symbols with this + normal globals with objc class prefixes. This patch removes the extra globals being added.

This also accounts for this behavior for `validate-tbd-against-ir` checking.

Resolves: rdar://101442087