### PR TITLE
Augment maybeDiagnoseCallToKeyValueObserveMethod() and add support for a @_semantics attribute to trigger it rather than just hard-coding the name of the Foundation method.

### DIFF
--- a/include/swift/AST/SemanticAttrs.def
+++ b/include/swift/AST/SemanticAttrs.def
@@ -97,6 +97,7 @@ SEMANTICS_ATTR(PROGRAMTERMINATION_POINT, "programtermination_point")
 SEMANTICS_ATTR(CONVERT_TO_OBJECTIVE_C, "convertToObjectiveC")
 
 SEMANTICS_ATTR(KEYPATH_KVC_KEY_PATH_STRING, "keypath.kvcKeyPathString")
+SEMANTICS_ATTR(KEYPATH_MUST_BE_VALID_FOR_KVO, "keypath.mustBeValidForKVO")
 
 /// The prefix used to force opt-remarks to be emitted in a specific function.
 ///

--- a/test/expr/primary/keypath/keypath-observe-objc.swift
+++ b/test/expr/primary/keypath/keypath-observe-objc.swift
@@ -45,3 +45,11 @@ class Bar: NSObject {
     }
   }
 }
+
+@_semantics("keypath.mustBeValidForKVO")
+func quux<T, V, U>(_ object: T, at keyPath: KeyPath<T, V>, _ keyPath2: KeyPath<T, U>) { }
+
+// The presence of a valid keypath should not prevent detection of invalid ones
+// later in the argument list, so start with a valid one here.
+quux(Foo(), at: \.number4, \.number1)
+// expected-warning@-1 {{passing reference to non-'@objc dynamic' property 'number1' to KVO method 'quux(_:at:_:)' may lead to unexpected behavior or runtime trap}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR augments `maybeDiagnoseCallToKeyValueObserveMethod()` and adds support for a `@_semantics` attribute that will trigger it rather than just hard-coding the name of the Foundation method.

The existing hard-coded method name check should remain in place until such time as Foundation adopts the attribute.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
<!-- Resolves #NNNNN, fix apple/llvm-project#MMMMM. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
