### PR TITLE
[Sema] Fix an issue with existential return types when implicit some is enabled.

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3079,8 +3079,11 @@ TypeRepr *ValueDecl::getOpaqueResultTypeRepr() const {
   
   if (returnRepr && returnRepr->hasOpaque()) {
     return returnRepr;
-  } else if (returnRepr && ctx.LangOpts.hasFeature(Feature::ImplicitSome) && returnRepr->isProtocol(dc)) {
-    return returnRepr;
+  } else if (returnRepr && ctx.LangOpts.hasFeature(Feature::ImplicitSome)) {
+    auto opaqueReprs = collectOpaqueReturnTypeReprs(returnRepr,
+                                                    getASTContext(),
+                                                    getDeclContext());
+    return opaqueReprs.empty() ? nullptr : returnRepr;
   } else {
     return nullptr;
   }

--- a/test/type/implicit_some/opaque_return.swift
+++ b/test/type/implicit_some/opaque_return.swift
@@ -112,4 +112,6 @@ protocol P {
 
 struct S: P {
   var value: P { self }
+
+  var asExistential: any P { self }
 }


### PR DESCRIPTION
Previously, `ValueDecl::getOpaqueResultTypeRepr` would return the type repr for an `any P` result type because the result type references protocols. Use `collectOpaqueReturnTypeReprs` instead, which already knows how to handle `ExistentialTypeRepr`.