### PR TITLE
[ModuleInterface] AliasModuleNames workaround support for indirect dependencies and missing imports

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -166,8 +166,7 @@ public:
       PrintNameContext NameContext = PrintNameContext::Normal);
 
   /// Called when printing the referenced name of a module.
-  virtual void printModuleRef(ModuleEntity Mod, Identifier Name,
-                              const PrintOptions &Options);
+  virtual void printModuleRef(ModuleEntity Mod, Identifier Name);
 
   /// Called before printing a synthesized extension.
   virtual void printSynthesizedExtensionPre(const ExtensionDecl *ED,

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -19,6 +19,7 @@
 #include "swift/AST/TypeOrExtensionDecl.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallSet.h"
 #include <limits.h>
 #include <vector>
 
@@ -470,6 +471,14 @@ struct PrintOptions {
   /// with types sharing a name with a module.
   bool AliasModuleNames = false;
 
+  /// Name of the modules that have been aliased in AliasModuleNames mode.
+  /// Ideally we would use something other than a string to identify a module,
+  /// but since one alias can apply to more than one module, strings happen
+  /// to be pretty reliable. That is, unless there's an unexpected name
+  /// collision between two modules, which isn't supported by this workaround
+  /// yet.
+  llvm::SmallSet<StringRef, 4> *AliasModuleNamesTargets = nullptr;
+
   /// When printing an Optional<T>, rather than printing 'T?', print
   /// 'T!'. Used as a modifier only when we know we're printing
   /// something that was declared as an implicitly unwrapped optional
@@ -641,7 +650,10 @@ struct PrintOptions {
                                               bool preferTypeRepr,
                                               bool printFullConvention,
                                               bool printSPIs,
-                                              bool aliasModuleNames);
+                                              bool aliasModuleNames,
+                                              llvm::SmallSet<StringRef, 4>
+                                                *aliasModuleNamesTargets
+                                              );
 
   /// Retrieve the set of options suitable for "Generated Interfaces", which
   /// are a prettified representation of the public API of a module, to be

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -132,7 +132,10 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
                                                    bool preferTypeRepr,
                                                    bool printFullConvention,
                                                    bool printSPIs,
-                                                   bool aliasModuleNames) {
+                                                   bool aliasModuleNames,
+                                                   llvm::SmallSet<StringRef, 4>
+                                                     *aliasModuleNamesTargets
+                                                   ) {
   PrintOptions result;
   result.IsForSwiftInterface = true;
   result.PrintLongAttrsOnSeparateLines = true;
@@ -154,6 +157,7 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
       OpaqueReturnTypePrintingMode::StableReference;
   result.PreferTypeRepr = preferTypeRepr;
   result.AliasModuleNames = aliasModuleNames;
+  result.AliasModuleNamesTargets = aliasModuleNamesTargets;
   if (printFullConvention)
     result.PrintFunctionRepresentationAttrs =
       PrintOptions::FunctionRepresentationMode::Full;
@@ -5393,7 +5397,8 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
       }
     }
 
-    if (Options.AliasModuleNames) {
+    if (Options.AliasModuleNames && Options.AliasModuleNamesTargets &&
+        Options.AliasModuleNamesTargets->contains(Name.str())) {
       auto nameTwine = MODULE_DISAMBIGUATING_PREFIX + Name.str();
       Name = Mod->getASTContext().getIdentifier(nameTwine.str());
     }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -367,11 +367,7 @@ void ASTPrinter::printTypeRef(Type T, const TypeDecl *RefTo, Identifier Name,
   printName(Name, Context);
 }
 
-void ASTPrinter::printModuleRef(ModuleEntity Mod, Identifier Name,
-                                const PrintOptions &Options) {
-  if (Options.AliasModuleNames)
-    printTextImpl(MODULE_DISAMBIGUATING_PREFIX);
-
+void ASTPrinter::printModuleRef(ModuleEntity Mod, Identifier Name) {
   printName(Name);
 }
 
@@ -2509,7 +2505,7 @@ void PrintAST::visitImportDecl(ImportDecl *decl) {
                              Name = Declaring->getRealName();
                          }
                        }
-                       Printer.printModuleRef(Mods.front(), Name, Options);
+                       Printer.printModuleRef(Mods.front(), Name);
                        Mods = Mods.slice(1);
                      } else {
                        Printer << Elem.Item.str();
@@ -5397,7 +5393,12 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
       }
     }
 
-    Printer.printModuleRef(Mod, Name, Options);
+    if (Options.AliasModuleNames) {
+      auto nameTwine = MODULE_DISAMBIGUATING_PREFIX + Name.str();
+      Name = Mod->getASTContext().getIdentifier(nameTwine.str());
+    }
+
+    Printer.printModuleRef(Mod, Name);
     Printer << ".";
   }
 
@@ -5748,8 +5749,7 @@ public:
     Printer << "module<";
     // Should print the module real name in case module aliasing is
     // used (see -module-alias), since that's the actual binary name.
-    Printer.printModuleRef(T->getModule(), T->getModule()->getRealName(),
-                           Options);
+    Printer.printModuleRef(T->getModule(), T->getModule()->getRealName());
     Printer << ">";
   }
 

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -269,7 +269,7 @@ void ComponentIdentTypeRepr::printImpl(ASTPrinter &Printer,
                                        const PrintOptions &Opts) const {
   if (auto *TD = dyn_cast_or_null<TypeDecl>(getBoundDecl())) {
     if (auto MD = dyn_cast<ModuleDecl>(TD))
-      Printer.printModuleRef(MD, getNameRef().getBaseIdentifier(), Opts);
+      Printer.printModuleRef(MD, getNameRef().getBaseIdentifier());
     else
       Printer.printTypeRef(Type(), TD, getNameRef().getBaseIdentifier());
   } else {

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -49,7 +49,9 @@ version::Version swift::InterfaceFormatVersion({1, 0});
 /// construct \p M.
 static void printToolVersionAndFlagsComment(raw_ostream &out,
                                             ModuleInterfaceOptions const &Opts,
-                                            ModuleDecl *M) {
+                                            ModuleDecl *M,
+                                            llvm::SmallSet<StringRef, 4>
+                                              &AliasModuleNamesTargets) {
   auto &Ctx = M->getASTContext();
   auto ToolsVersion =
       getSwiftInterfaceCompilerVersionForCurrentCompiler(Ctx);
@@ -62,9 +64,8 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
 
   // Insert additional -module-alias flags
   if (Opts.AliasModuleNames) {
-    llvm::SmallSet<StringRef, 2> aliasTargets;
     StringRef moduleName = M->getNameStr();
-    aliasTargets.insert(M->getNameStr());
+    AliasModuleNamesTargets.insert(M->getNameStr());
     out << " -module-alias " << MODULE_DISAMBIGUATING_PREFIX <<
            moduleName << "=" << moduleName;
 
@@ -77,7 +78,7 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
     M->getMissingImportedModules(imports);
     for (ImportedModule import: imports) {
       StringRef importedName = import.importedModule->getNameStr();
-      if (aliasTargets.insert(importedName).second) {
+      if (AliasModuleNamesTargets.insert(importedName).second) {
         out << " -module-alias " << MODULE_DISAMBIGUATING_PREFIX <<
                importedName << "=" << importedName;
       }
@@ -782,12 +783,14 @@ bool swift::emitSwiftInterface(raw_ostream &out,
                                ModuleDecl *M) {
   assert(M);
 
-  printToolVersionAndFlagsComment(out, Opts, M);
+  llvm::SmallSet<StringRef, 4> aliasModuleNamesTargets;
+  printToolVersionAndFlagsComment(out, Opts, M, aliasModuleNamesTargets);
+
   printImports(out, Opts, M);
 
   const PrintOptions printOptions = PrintOptions::printSwiftInterfaceFile(
       M, Opts.PreserveTypesAsWritten, Opts.PrintFullConvention, Opts.PrintSPIs,
-      Opts.AliasModuleNames);
+      Opts.AliasModuleNames, &aliasModuleNamesTargets);
   InheritedProtocolCollector::PerTypeMap inheritedProtocolMap;
 
   SmallVector<Decl *, 16> topLevelDecls;

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -74,6 +74,7 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
                            ModuleDecl::ImportFilterKind::Exported,
                            ModuleDecl::ImportFilterKind::SPIOnly,
                            ModuleDecl::ImportFilterKind::SPIAccessControl});
+    M->getMissingImportedModules(imports);
     for (ImportedModule import: imports) {
       StringRef importedName = import.importedModule->getNameStr();
       if (aliasTargets.insert(importedName).second) {

--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -80,9 +80,8 @@ private:
                     PrintNameContext NameContext) override {
     return OtherPrinter.printTypeRef(T, TD, Name, NameContext);
   }
-  void printModuleRef(ModuleEntity Mod, Identifier Name,
-                      const PrintOptions &Options) override {
-    return OtherPrinter.printModuleRef(Mod, Name, Options);
+  void printModuleRef(ModuleEntity Mod, Identifier Name) override {
+    return OtherPrinter.printModuleRef(Mod, Name);
   }
   void printSynthesizedExtensionPre(const ExtensionDecl *ED,
                                     TypeOrExtensionDecl Target,

--- a/test/Sema/missing-import-inlinable-code.swift
+++ b/test/Sema/missing-import-inlinable-code.swift
@@ -24,6 +24,12 @@
 // RUN: %target-swift-emit-module-interface(%t/ClientFixed.swiftinterface)  %t/clientFileA-Swift5.swift %t/clientFileB.swift -I %t
 // RUN: %target-swift-typecheck-module-from-interface(%t/ClientFixed.swiftinterface) -I %t
 
+/// The inserted missing imports should be aliased.
+// RUN: %target-swift-emit-module-interface(%t/ClientFixed.swiftinterface) %t/clientFileA-Swift5.swift %t/clientFileB.swift -I %t -alias-module-names-in-module-interface
+// RUN: %target-swift-typecheck-module-from-interface(%t/ClientFixed.swiftinterface) -I %t
+// RUN: cat %t/ClientFixed.swiftinterface | %FileCheck -check-prefix ALIASED %s
+// ALIASED: import Module___libB
+
 // REQUIRES: asserts
 
 // BEGIN empty.swift

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -185,11 +185,10 @@ public:
     StreamPrinter::printTypeRef(T, TD, Name, NameContext);
   }
 
-  void printModuleRef(ModuleEntity Mod, Identifier Name,
-                      const PrintOptions &Options) override {
+  void printModuleRef(ModuleEntity Mod, Identifier Name) override {
     unsigned StartOffset = OS.tell();
     Info.References.emplace_back(Mod, StartOffset, Name.str().size());
-    StreamPrinter::printModuleRef(Mod, Name, Options);
+    StreamPrinter::printModuleRef(Mod, Name);
   }
 };
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2841,10 +2841,9 @@ public:
     StreamPrinter::printTypeRef(T, TD, Name, NameContext);
     OS << "</ref>";
   }
-  void printModuleRef(ModuleEntity Mod, Identifier Name,
-                      const PrintOptions &Options) override {
+  void printModuleRef(ModuleEntity Mod, Identifier Name) override {
     OS << "<ref:module>";
-    StreamPrinter::printModuleRef(Mod, Name, Options);
+    StreamPrinter::printModuleRef(Mod, Name);
     OS << "</ref>";
   }
 };


### PR DESCRIPTION
- In AliasModuleNames, avoid wrongfully printing aliased names for modules that
were not aliased, just use the real name in that case. This can happen in the case of modules indirectly
imported via a reexport.
- If there's a reference in API to a module that's not imported, the
import is inserted automatically in the swiftinterface. This PR ensures the
inserted import is correctly aliased in AliasModuleNames mode.

rdar://102262019