### PR TITLE
Disable 0022-rdar21625478.swift entirely on noassert builds

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -4483,6 +4483,8 @@ void SILGenFunction::emitProtocolWitness(
                                           ->getCanonicalType());
   }
 
+  assert(!witnessSubstTy->hasError());
+
   if (auto genericFnType = dyn_cast<GenericFunctionType>(reqtSubstTy)) {
     auto forwardingSubs = F.getForwardingSubstitutionMap();
     reqtSubstTy = cast<FunctionType>(genericFnType
@@ -4492,6 +4494,8 @@ void SILGenFunction::emitProtocolWitness(
     reqtSubstTy = cast<FunctionType>(F.mapTypeIntoContext(reqtSubstTy)
                                           ->getCanonicalType());
   }
+
+  assert(!reqtSubstTy->hasError());
 
   // Get the lowered type of the witness.
   auto origWitnessFTy = getWitnessFunctionType(getTypeExpansionContext(), SGM,

--- a/validation-test/compiler_crashers_2_fixed/0022-rdar21625478.swift
+++ b/validation-test/compiler_crashers_2_fixed/0022-rdar21625478.swift
@@ -3,6 +3,9 @@
 // rdar://80395274 tracks getting this to pass with the requirement machine.
 // XFAIL: *
 
+// The test hangs in a noassert build:
+// REQUIRES: asserts
+
 import StdlibUnittest
 
 public struct MyRange<Bound : ForwardIndex> {


### PR DESCRIPTION
This test sometimes hangs on noasserts builds, because type substitution produces an ErrorType. Either there's a bug in type substitution, or Sema should reject the conformance here, but until I figure it out let's disable the test in noasserts builds.

Fixes rdar://problem/99800538.