### PR TITLE
[AddressLowering] Create copy_addr after store.

### DIFF
--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3076,7 +3076,9 @@ void UseRewriter::rewriteStore(SILValue srcVal, SILValue destAddr,
       isTake = IsNotTake;
     }
   }
-  builder.createCopyAddr(loc, srcAddr, destAddr, isTake, isInit);
+  SILBuilderWithScope::insertAfter(storeInst, [&](auto &builder) {
+    builder.createCopyAddr(loc, srcAddr, destAddr, isTake, isInit);
+  });
   pass.deleter.forceDelete(storeInst);
 }
 

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -950,8 +950,8 @@ bb0(%0 : @owned $P):
 // CHECK-LABEL: sil [ossa] @f161_testOpenedArchetype : $@convention(thin) (@in any P) -> () {
 // CHECK: bb0(%0 : $*any P):
 // CHECK:   [[ALLOCP:%.*]] = alloc_stack $any P, var, name "q"
-// CHECK:   copy_addr %0 to [init] [[ALLOCP]] : $*any P
 // CHECK:   debug_value %0 : $*any P, var, name "q"
+// CHECK:   copy_addr %0 to [init] [[ALLOCP]] : $*any P
 // CHECK:   [[OPEN:%.*]] = open_existential_addr immutable_access %0 : $*any P to $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
 // CHECK:   [[OPTIONAL:%.*]] = alloc_stack $Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>
 // CHECK:   witness_method $@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self, #P.foo : <Self where Self : P> (Self) -> () -> (), [[OPEN]] : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
@@ -1897,6 +1897,29 @@ failure(%original : @owned $T):
   destroy_value %original : $T
   br exit
 exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @test_store_1 : {{.*}} {
+// CHECK:         [[MAYBE_ADDR:%[^,]+]] = alloc_stack $Optional<Self>
+// CHECK:         [[LOAD_ADDR:%[^,]+]] = alloc_stack $Self
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack $Self, var, name "self"
+// CHECK:         [[INSTANCE_ADDR:%[^,]+]] = unchecked_take_enum_data_addr [[MAYBE_ADDR]] : $*Optional<Self>, #Optional.some!enumelt
+// CHECK:         debug_value [[INSTANCE_ADDR]] : $*Self, var, name "self", expr op_deref
+// CHECK:         copy_addr [take] [[INSTANCE_ADDR]] to [init] [[ADDR]]
+// CHECK:         copy_addr [[ADDR]] to [init] [[LOAD_ADDR]]
+// CHECK-LABEL: } // end sil function 'test_store_1'
+sil hidden [ossa] @test_store_1 : $@convention(thin) <Self> () -> () {
+bb0:
+  %addr = alloc_stack $Self, var, name "self"
+  %maybe = apply undef<Self>() : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
+  %instance = unchecked_enum_data %maybe : $Optional<Self>, #Optional.some!enumelt
+  store %instance to [init] %addr : $*Self
+  %load = load [copy] %addr : $*Self
+  destroy_addr %addr : $*Self
+  dealloc_stack %addr : $*Self
+  destroy_value %load : $Self
   %retval = tuple ()
   return %retval : $()
 }

--- a/test/SILOptimizer/address_lowering_phi.sil
+++ b/test/SILOptimizer/address_lowering_phi.sil
@@ -481,8 +481,8 @@ bb3(%phi : @owned $T):
 // CHECK:         [[VAR:%[^,]+]] = alloc_stack [lexical] $Value, var, name "value"
 // CHECK:         cond_br undef, bb2, bb1
 // CHECK:       bb3:
-// CHECK:         copy_addr [take] [[TEMP]] to [init] [[VAR]]
 // CHECK:         debug_value [[TEMP]] : $*Value, var, name "value"
+// CHECK:         copy_addr [take] [[TEMP]] to [init] [[VAR]]
 // CHECK-LABEL: } // end sil function 'f100_store_phi'
 sil [ossa] @f100_store_phi : $@convention(thin) <Value> (@in Value) -> () {
 entry(%instance : @owned $Value):


### PR DESCRIPTION
When rewriting a store, insert the copy_addr after it rather than before
it.





Previously, after the copy_addr is created,

```
alloc_stack %target_addr $Ty, var, name "something"
...
copy_addr [take] %source_addr to [init] %target_addr
store %instance to [init] %addr
```

when deleting the store, debug info salvaging may result in a
debug_value instruction being created before the store,

```
alloc_stack %target_addr $Ty, var, name "something"
...
copy_addr [take] %source_addr to [init] %target_addr
debug_value %source_addr : $*Ty, var, name "something"
store %instance to [init] %addr
```

using the %source_addr.  If the created copy_addr is a [take], this
results in the debug_value being a use-after-consume in the final SIL:

```
alloc_stack %target_addr $Ty, var, name "something"
...
copy_addr [take] %source_addr to [init] %target_addr
debug_value %source_addr : $*Ty, var, name "something"
```





Instead, now, the copy_addr is created after:

```
alloc_stack %target_addr $Ty, var, name "something"
...
store %instance to [init] %addr
copy_addr [take] %source_addr to [init] %target_addr
```

So when the debug_value instruction is created before the store during
debug info salvaging

```
alloc_stack %target_addr $Ty, var, name "something"
...
debug_value %source_addr : $*Ty, var, name "something"
store %instance to [init] %addr
copy_addr [take] %source_addr to [init] %target_addr
```

it is also before the newly added copy_addr.  The result is that when
the store is deleted, we have valid SIL:

```
alloc_stack %target_addr $Ty, var, name "something"
...
debug_value %source_addr : $*Ty, var, name "something"
copy_addr [take] %source_addr to [init] %target_addr
```

Based on https://github.com/apple/swift/pull/62074 .
