### PR TITLE
[AddressLowering] Handle guaranteed destructures.

### DIFF
--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3076,7 +3076,9 @@ void UseRewriter::rewriteStore(SILValue srcVal, SILValue destAddr,
       isTake = IsNotTake;
     }
   }
-  builder.createCopyAddr(loc, srcAddr, destAddr, isTake, isInit);
+  SILBuilderWithScope::insertAfter(storeInst, [&](auto &builder) {
+    builder.createCopyAddr(loc, srcAddr, destAddr, isTake, isInit);
+  });
   pass.deleter.forceDelete(storeInst);
 }
 

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3298,7 +3298,7 @@ void UseRewriter::visitUnconditionalCheckedCastInst(
       uncondCheckedCast->getLoc(), destAddr,
       destAddr->getType().isTrivial(*uncondCheckedCast->getFunction())
           ? LoadOwnershipQualifier::Trivial
-          : LoadOwnershipQualifier::Copy);
+          : LoadOwnershipQualifier::Take);
   nextBuilder.createDeallocStack(uncondCheckedCast->getLoc(), destAddr);
   uncondCheckedCast->replaceAllUsesWith(dest);
 }

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -2077,6 +2077,20 @@ entry(%instance : @owned $T):
   return %retval : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_unconditional_checked_cast6 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack $Klass
+// CHECK:         unconditional_checked_cast_addr T in [[INSTANCE]]
+// CHECK:         [[KLASS:%[^,]+]] = load [take] [[ADDR]]
+// CHECK:         dealloc_stack [[ADDR]]
+// CHECK-LABEL: } // end sil function 'test_unconditional_checked_cast6'
+sil [ossa] @test_unconditional_checked_cast6 : $@convention(method) <T> (@in T) -> () {
+bb0(%instance : @owned $T):
+  %klass = unconditional_checked_cast %instance : $T to Klass
+  destroy_value %klass : $Klass
+  %retval = tuple ()
+  return %retval : $()
+}
 // CHECK-LABEL: sil [ossa] @test_yield_1_two_values : {{.*}} {
 // CHECK:         tuple_element_addr
 // CHECK:         tuple_element_addr

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -950,8 +950,8 @@ bb0(%0 : @owned $P):
 // CHECK-LABEL: sil [ossa] @f161_testOpenedArchetype : $@convention(thin) (@in any P) -> () {
 // CHECK: bb0(%0 : $*any P):
 // CHECK:   [[ALLOCP:%.*]] = alloc_stack $any P, var, name "q"
-// CHECK:   copy_addr %0 to [init] [[ALLOCP]] : $*any P
 // CHECK:   debug_value %0 : $*any P, var, name "q"
+// CHECK:   copy_addr %0 to [init] [[ALLOCP]] : $*any P
 // CHECK:   [[OPEN:%.*]] = open_existential_addr immutable_access %0 : $*any P to $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
 // CHECK:   [[OPTIONAL:%.*]] = alloc_stack $Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>
 // CHECK:   witness_method $@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self, #P.foo : <Self where Self : P> (Self) -> () -> (), [[OPEN]] : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
@@ -1897,6 +1897,29 @@ failure(%original : @owned $T):
   destroy_value %original : $T
   br exit
 exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: sil hidden [ossa] @test_store_1 : {{.*}} {
+// CHECK:         [[MAYBE_ADDR:%[^,]+]] = alloc_stack $Optional<Self>
+// CHECK:         [[LOAD_ADDR:%[^,]+]] = alloc_stack $Self
+// CHECK:         [[ADDR:%[^,]+]] = alloc_stack $Self, var, name "self"
+// CHECK:         [[INSTANCE_ADDR:%[^,]+]] = unchecked_take_enum_data_addr [[MAYBE_ADDR]] : $*Optional<Self>, #Optional.some!enumelt
+// CHECK:         debug_value [[INSTANCE_ADDR]] : $*Self, var, name "self", expr op_deref
+// CHECK:         copy_addr [take] [[INSTANCE_ADDR]] to [init] [[ADDR]]
+// CHECK:         copy_addr [[ADDR]] to [init] [[LOAD_ADDR]]
+// CHECK-LABEL: } // end sil function 'test_store_1'
+sil hidden [ossa] @test_store_1 : $@convention(thin) <Self> () -> () {
+bb0:
+  %addr = alloc_stack $Self, var, name "self"
+  %maybe = apply undef<Self>() : $@convention(thin) <τ_0_0> () -> @out Optional<τ_0_0>
+  %instance = unchecked_enum_data %maybe : $Optional<Self>, #Optional.some!enumelt
+  store %instance to [init] %addr : $*Self
+  %load = load [copy] %addr : $*Self
+  destroy_addr %addr : $*Self
+  dealloc_stack %addr : $*Self
+  destroy_value %load : $Self
   %retval = tuple ()
   return %retval : $()
 }

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1901,6 +1901,36 @@ exit:
   return %retval : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test_destructure_tuple_1_guaranteed : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = unchecked_take_enum_data_addr
+// CHECK:         [[KLASS_ADDR:%[^,]+]] = tuple_element_addr [[INSTANCE]] {{.*}}, 0
+// CHECK:         [[KLASS:%[^,]+]] = load_borrow [[KLASS_ADDR]]
+// CHECK:         end_borrow [[KLASS]]
+// CHECK:         [[ANY_ADDR:%[^,]+]] = tuple_element_addr [[INSTANCE]] {{.*}}, 1
+// CHECK:         apply undef<Any>([[ANY_ADDR]])
+// CHECK:         destroy_addr [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'test_destructure_tuple_1_guaranteed'
+sil [ossa] @test_destructure_tuple_1_guaranteed : $@convention(thin) () -> () {
+bb0:
+  %maybe = apply undef<(Klass?, Any)>() : $@convention(method) <τ_0_0> () -> @out Optional<τ_0_0>
+  switch_enum %maybe : $Optional<(Optional<Klass>, Any)>, case #Optional.some!enumelt: success, case #Optional.none!enumelt: failure
+success(%instance : @owned $(Optional<Klass>, Any)):
+  %borrow = begin_borrow [lexical] %instance : $(Optional<Klass>, Any)
+  (%klass, %any) = destructure_tuple %borrow : $(Optional<Klass>, Any)
+  apply undef<Any>(%any) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> ()
+  end_borrow %borrow : $(Optional<Klass>, Any)
+  destroy_value %instance : $(Optional<Klass>, Any)
+  br exit
+
+failure:
+  br exit
+
+exit:
+  %505 = tuple ()
+  return %505 : $()
+}
+
+
 // CHECK-LABEL: sil hidden [ossa] @test_store_1 : {{.*}} {
 // CHECK:         [[MAYBE_ADDR:%[^,]+]] = alloc_stack $Optional<Self>
 // CHECK:         [[LOAD_ADDR:%[^,]+]] = alloc_stack $Self

--- a/test/SILOptimizer/address_lowering_phi.sil
+++ b/test/SILOptimizer/address_lowering_phi.sil
@@ -481,8 +481,8 @@ bb3(%phi : @owned $T):
 // CHECK:         [[VAR:%[^,]+]] = alloc_stack [lexical] $Value, var, name "value"
 // CHECK:         cond_br undef, bb2, bb1
 // CHECK:       bb3:
-// CHECK:         copy_addr [take] [[TEMP]] to [init] [[VAR]]
 // CHECK:         debug_value [[TEMP]] : $*Value, var, name "value"
+// CHECK:         copy_addr [take] [[TEMP]] to [init] [[VAR]]
 // CHECK-LABEL: } // end sil function 'f100_store_phi'
 sil [ossa] @f100_store_phi : $@convention(thin) <Value> (@in Value) -> () {
 entry(%instance : @owned $Value):


### PR DESCRIPTION
Previously, when lowering `destructure_tuple` and `destructure_struct` instructions, either a `load [trivial]` or `load [take]` was always created for each loadable field.  When the operand to the destructure instruction was `@owned`, this was the correct behavior; but when the operand was `@guaranteed`, it was not.  It would result in SIL like

```
(..., %elt_addr, ...) = destructure_ %addr
%value = load [take] %elt_addr
destroy_addr %addr
```

where (1) `%elt_addr` was destroyed twice (once by the `load [take]` and once by the `destroy_addr` of the aggregate and (2) the loaded value was leaked.

Here, this is fixed by creating `load_borrow`s for this case.

