### PR TITLE
ClangImporter: don't pass `-nostdsysteminc` to clang on FreeBSD

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -657,8 +657,14 @@ importer::getNormalInvocationArguments(
   }
 
   if (searchPathOpts.getSDKPath().empty()) {
-    invocationArgStrs.push_back("-Xclang");
-    invocationArgStrs.push_back("-nostdsysteminc");
+    // On FreeBSD, passing `-nostdsysteminc` breaks most header module imports,
+    // since clang adds the default header search paths in its frontend, not
+    // its driver.  (This is different from the behavior on Darwin, Linux, and
+    // OpenBSD.)
+    if (!triple.isOSFreeBSD()) {
+      invocationArgStrs.push_back("-Xclang");
+      invocationArgStrs.push_back("-nostdsysteminc");
+    }
   } else {
     if (triple.isWindowsMSVCEnvironment()) {
       llvm::SmallString<261> path; // MAX_PATH + 1


### PR DESCRIPTION
## Background

When `-sdk` is specified to the Swift frontend, Swift's ClangImporter uses its value to specify the `-sysroot` to Clang.

In cases where no (or an empty string) `-sdk` is specified, ClangImporter currently passes `-nostdsysteminc` to the Clang frontend, in an attempt to prevent any system headers from being included.

## Where Clang adds include paths

Clang adds "standard" include paths in two places: in the driver, and in the frontend.  The driver's behavior can be disabled with `-nostdinc`, and the frontend's behavior can be disabled with `-nostdsysteminc`.  (The clang driver passes `-nostdsysteminc` to the frontend when it receives `-nostdinc`.)

But *which* paths are added *where* varies from target to target.

On Linux and OpenBSD, all standard include paths are added by the driver.

On Darwin, the driver adds `$ISYSROOT/usr/local/include`, clang's builtin header dir, and `$ISYSROOT/usr/include`, whereas the frontend adds `$ISYSROOT/{System/,}/Library/Frameworks`.

On FreeBSD, all standard include paths are added by the frontend.

## Effective behavior without an `-sdk`

Put together, this means that the behavior of Swift when no (or empty) `-sdk` is provided is highly target-dependent.

On Linux and OpenBSD, nothing changes.

On Darwin, it has the effect of removing `{/System,}/Library/Frameworks` from the standard include paths.  Additionally, non-SDK-prefixed `/usr/local/include` and `/usr/include` do not usually exist in the filesystem on Darwin, so only clang's builtin header dir is left as a standard include path.

(Note, however, that Darwin almost never runs without an `-sdk`, because the `xcrun`-invoking `swiftc` wrapper specifies one before re-execing to the real `swiftc`.)

On FreeBSD, it inhibits *all* standard include paths.  This means that importing clang modules on FreeBSD without specifying `-sdk /` is basically always broken, because the module is imported with no standard include paths.

## The actual fix

Fix clang module import by omitting `-nostdsysteminc` for FreeBSD targets.