### PR TITLE
[TypeChecker] SE-0347: Perform syntactic diagnostics after inference

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -732,6 +732,8 @@ Type TypeChecker::typeCheckParameterDefault(Expr *&defaultValue,
   cs.applySolution(solution);
 
   if (auto result = cs.applySolution(solution, defaultExprTarget)) {
+    // Perform syntactic diagnostics on the type-checked target.
+    performSyntacticDiagnosticsForTarget(*result, /*isExprStmt=*/false);
     defaultValue = result->getAsExpr();
     return defaultValue->getType();
   }

--- a/test/Constraints/type_inference_from_default_exprs.swift
+++ b/test/Constraints/type_inference_from_default_exprs.swift
@@ -208,7 +208,7 @@ protocol StorageType {
   var identifier: String { get }
 }
 
-class Storage {
+class Storage { // expected-note {{class 'Storage' is not public}}
 }
 
 extension Storage {
@@ -252,4 +252,17 @@ struct S61061_2<T> where T:Hashable {
 
 struct S61061_3<T> where T:Hashable {
   init(x:[(T, T)] = [(1, 1)]) {} // OK
+}
+
+// https://github.com/apple/swift/issues/62025
+// Syntactic checks are not run on the default argument expressions
+public struct MyStruct {} // expected-note {{initializer 'init()' is not public}}
+public func issue62025_with_init<T>(_: T = MyStruct()) {}
+// expected-error@-1 {{initializer 'init()' is internal and cannot be referenced from a default argument value}}
+public func issue62025_with_type<T>(_: T = Storage.self) {}
+// expected-error@-1 {{class 'Storage' is internal and cannot be referenced from a default argument value}}
+do {
+  func default_with_dup_keys<T>(_: T = ["a": 1, "a": 2]) {}
+  // expected-warning@-1 {{dictionary literal of type '[String : Int]' has duplicate entries for string literal key 'a'}}
+  // expected-note@-2 2 {{duplicate key declared here}}
 }


### PR DESCRIPTION
Implementation of type inference from default expressions (SE-0347) 
omitted running syntactic diagnostics on the type-checked default
expression which leads to invalid code being accepted by the type-checker.

Resolves: https://github.com/apple/swift/issues/62025

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
