### PR TITLE
Remove uses of `std::iterator` and `llvm::empty`

### DIFF
--- a/include/swift/APIDigester/ModuleAnalyzerNodes.h
+++ b/include/swift/APIDigester/ModuleAnalyzerNodes.h
@@ -520,11 +520,16 @@ public:
   ViewerIterator end();
 };
 
-class SDKNodeVectorViewer::ViewerIterator :
-    public std::iterator<std::input_iterator_tag, VectorIt> {
+class SDKNodeVectorViewer::ViewerIterator {
   SDKNodeVectorViewer &Viewer;
   VectorIt P;
 public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = VectorIt;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type*;
+  using reference = value_type&;    
+
   ViewerIterator(SDKNodeVectorViewer &Viewer, VectorIt P) : Viewer(Viewer), P(P) {}
   ViewerIterator(const ViewerIterator& mit) : Viewer(mit.Viewer), P(mit.P) {}
   ViewerIterator& operator++();

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2377,9 +2377,15 @@ public:
                     const Decl *D = nullptr);
 
   template <typename T, typename DERIVED>
-  class iterator_base : public std::iterator<std::forward_iterator_tag, T *> {
+  class iterator_base {
     T *Impl;
   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = T*;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;    
+
     explicit iterator_base(T *Impl) : Impl(Impl) {}
     DERIVED &operator++() { Impl = Impl->Next; return (DERIVED&)*this; }
     bool operator==(const iterator_base &X) const { return X.Impl == Impl; }
@@ -2678,11 +2684,16 @@ public:
   }
 
   // Iterator for the custom type attributes.
-  class iterator
-      : public std::iterator<std::forward_iterator_tag, CustomAttr *> {
+  class iterator {
     CustomAttr *attr;
 
   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = CustomAttr*;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;    
+
     iterator() : attr(nullptr) { }
     explicit iterator(CustomAttr *attr) : attr(attr) { }
 

--- a/include/swift/Basic/FrozenMultiMap.h
+++ b/include/swift/Basic/FrozenMultiMap.h
@@ -143,9 +143,12 @@ public:
   unsigned size() const { return storage.size(); }
   bool empty() const { return storage.empty(); }
 
-  struct iterator
-      : std::iterator<std::forward_iterator_tag,
-                      std::pair<Key, Optional<PairToSecondEltRange>>> {
+  struct iterator {
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = std::pair<Key, Optional<PairToSecondEltRange>>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;    
     using base_iterator = typename decltype(storage)::iterator;
 
     FrozenMultiMap &map;

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -87,14 +87,19 @@ public:
 };
 
 template<typename Self, typename Descriptor>
-class ReflectionSectionIteratorBase
-  : public std::iterator<std::forward_iterator_tag, Descriptor> {
+class ReflectionSectionIteratorBase {
   uint64_t OriginalSize;
 protected:
   Self &asImpl() {
     return *static_cast<Self *>(this);
   }
 public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = Descriptor;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type*;
+  using reference = value_type&;    
+
   RemoteRef<void> Cur;
   uint64_t Size;
   std::string Name;

--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -65,9 +65,15 @@ inline void deleteAllDebugUses(SILInstruction *inst) {
 /// of uses, provided by the underlying ValueBaseUseIterator.
 /// If \p nonDebugInsts is true, then the iterator provides a view to all non-
 /// debug instructions. Otherwise it provides a view ot all debug-instructions.
-template <bool nonDebugInsts> class DebugUseIterator
-: public std::iterator<std::forward_iterator_tag, Operand *, ptrdiff_t> {
-  
+template <bool nonDebugInsts> class DebugUseIterator {
+public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = Operand*;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type*;
+  using reference = value_type&;    
+
+private:
   ValueBaseUseIterator BaseIterator;
   
   // Skip any debug or non-debug instructions (depending on the nonDebugInsts

--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -1160,11 +1160,16 @@ inline SILValue getSILValueType(const Operand &op) {
 using OperandValueArrayRef = ArrayRefView<Operand, SILValue, getSILValueType>;
 
 /// An iterator over all uses of a ValueBase.
-class ValueBaseUseIterator : public std::iterator<std::forward_iterator_tag,
-                                                  Operand*, ptrdiff_t> {
+class ValueBaseUseIterator {
 protected:
   Operand *Cur;
 public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = Operand*;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type*;
+  using reference = value_type&;    
+
   ValueBaseUseIterator() = default;
   explicit ValueBaseUseIterator(Operand *cur) : Cur(cur) {}
   Operand *operator->() const { return Cur; }

--- a/include/swift/SILOptimizer/Analysis/ClosureScope.h
+++ b/include/swift/SILOptimizer/Analysis/ClosureScope.h
@@ -173,7 +173,7 @@ public:
 
   ArrayRef<SILFunction *> getTopDownFunctions() const {
     assert(!topDownFunctions.empty()
-           || llvm::empty(csa->getModule()->getFunctions()));
+           || csa->getModule()->getFunctions().empty());
     return topDownFunctions;
   }
 

--- a/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/LoopRegionAnalysis.h
@@ -237,8 +237,7 @@ public:
 
   /// An iterator that knows how to iterate over the subregion indices of a
   /// region.
-  class subregion_iterator :
-    public std::iterator<std::bidirectional_iterator_tag, unsigned> {
+  class subregion_iterator {
     friend struct SubregionData;
     llvm::SmallVectorImpl<SubregionID>::const_iterator InnerIter;
     const llvm::SmallVectorImpl<std::pair<unsigned, unsigned>> *Subloops;
@@ -323,8 +322,7 @@ public:
 
   /// An iterator that knows how to iterate over the backedge indices of a
   /// region.
-  class backedge_iterator
-      : public std::iterator<std::bidirectional_iterator_tag, unsigned> {
+  class backedge_iterator {
     friend struct SubregionData;
     using InnerIterTy = llvm::SmallVectorImpl<unsigned>::const_iterator;
     llvm::Optional<InnerIterTy> InnerIter;

--- a/include/swift/SILOptimizer/Utils/InstOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/InstOptUtils.h
@@ -288,8 +288,15 @@ void insertDeallocOfCapturedArguments(
 /// users of the looked through builtin expect instruction i.e it presents a
 /// view that shows all users as if there were no builtin expect instructions
 /// interposed.
-class IgnoreExpectUseIterator
-    : public std::iterator<std::forward_iterator_tag, Operand *, ptrdiff_t> {
+class IgnoreExpectUseIterator {
+public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = Operand*;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type*;
+  using reference = value_type&;    
+
+private:
   ValueBaseUseIterator origUseChain;
   ValueBaseUseIterator currentIter;
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -689,7 +689,7 @@ static void printDifferentiableAttrArguments(
             return false;
         return true;
       });
-  if (!llvm::empty(requirementsToPrint)) {
+  if (!requirementsToPrint.empty()) {
     if (!isLeadingClause)
       stream << ' ';
     stream << "where ";

--- a/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/LoopRegionAnalysis.cpp
@@ -929,8 +929,13 @@ struct LoopRegionWrapper {
 
 /// An iterator on Regions that first iterates over subregions and then over
 /// successors.
-struct alledge_iterator
-    : std::iterator<std::forward_iterator_tag, LoopRegionWrapper> {
+struct alledge_iterator {
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = LoopRegionWrapper;
+  using difference_type = std::ptrdiff_t;
+  using pointer = value_type*;
+  using reference = value_type&;    
+
   LoopRegionWrapper *Wrapper;
   LoopRegion::subregion_iterator SubregionIter;
   LoopRegion::backedge_iterator BackedgeIter;


### PR DESCRIPTION
They are deprecated in C++17/rebranch.
In swift/rebranch uses of those declarations will cause warnings.
