### PR TITLE
[Reflection] Fix premature deallocation of string memory in buildContextDescriptor.

### DIFF
--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -210,6 +210,16 @@ public:
     Capacity += Growth;
   }
 
+  /// Copy a std::string to memory managed by the NodeFactory, returning a
+  /// StringRef pointing to the copied string data.
+  StringRef copyString(const std::string &str) {
+    size_t stringSize = str.size() + 1; // + 1 for terminating NUL.
+
+    char *copiedString = Allocate<char>(stringSize);
+    memcpy(copiedString, str.data(), stringSize);
+    return {copiedString, str.size()};
+  }
+
   /// Creates a node of kind \p K.
   NodePointer createNode(Node::Kind K);
 

--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -515,11 +515,9 @@ public:
                                  const std::string &mangledName,
                                  MangledNameKind kind,
                                  Demangler &dem) {
-    size_t stringSize = mangledName.size() + 1; // + 1 for terminating NUL.
-
-    char *copiedString = dem.Allocate<char>(stringSize);
-    memcpy(copiedString, mangledName.data(), stringSize);
-    return demangle(RemoteRef<char>(remoteAddress, copiedString), kind, dem);
+    StringRef mangledNameCopy = dem.copyString(mangledName);
+    return demangle(RemoteRef<char>(remoteAddress, mangledNameCopy.data()),
+                    kind, dem);
   }
 
   /// Given a demangle tree, attempt to turn it into a type.
@@ -1495,7 +1493,12 @@ public:
   
     return demangledSymbol;
   }
-  
+
+  Demangle::NodePointer buildContextManglingForSymbol(const std::string &symbol,
+                                                      Demangler &dem) {
+    return buildContextManglingForSymbol(dem.copyString(symbol), dem);
+  }
+
   /// Given a read context descriptor, attempt to build a demangling tree
   /// for it.
   Demangle::NodePointer


### PR DESCRIPTION
This function demangles a std::string, but the demangler can create interior pointers into the string being demangled. Solve this by copying the string into the Demangler first.

readMangledName does the same thing. Consolidate the string copying code into a method on NodeFactory, then make both functions use it.

rdar://102275748