### PR TITLE
[Sema] Restrict reexported SPIs to modules with an `export_as` relationship

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -877,6 +877,10 @@ public:
   /// Returns the associated clang module if one exists.
   const clang::Module *findUnderlyingClangModule() const;
 
+  /// Does this module or the underlying clang module defines export_as with
+  /// a value corresponding to the \p other module?
+  bool isExportedAs(const ModuleDecl *other) const;
+
   /// Returns a generator with the components of this module's full,
   /// hierarchical name.
   ///

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2861,7 +2861,8 @@ void SourceFile::lookupImportedSPIGroups(
   for (auto &import : *Imports) {
     if (import.options.contains(ImportFlags::SPIAccessControl) &&
         (importedModule == import.module.importedModule ||
-         imports.isImportedBy(importedModule, import.module.importedModule))) {
+         (imports.isImportedBy(importedModule, import.module.importedModule) &&
+          importedModule->isExportedAs(import.module.importedModule)))) {
       spiGroups.insert(import.spiGroups.begin(), import.spiGroups.end());
     }
   }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2175,6 +2175,14 @@ const clang::Module *ModuleDecl::findUnderlyingClangModule() const {
   return nullptr;
 }
 
+bool ModuleDecl::isExportedAs(const ModuleDecl *other) const {
+  auto clangModule = findUnderlyingClangModule();
+  if (!clangModule)
+    return false;
+
+  return other->getRealName().str() == clangModule->ExportAsModule;
+}
+
 void ModuleDecl::collectBasicSourceFileInfo(
     llvm::function_ref<void(const BasicSourceFileInfo &)> callback) const {
   for (const FileUnit *fileUnit : getFiles()) {

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1494,7 +1494,8 @@ void SerializedASTFile::lookupImportedSPIGroups(
       continue;
 
     if (dep.Import->importedModule == importedModule ||
-        imports.isImportedBy(importedModule, dep.Import->importedModule)) {
+        (imports.isImportedBy(importedModule, dep.Import->importedModule) &&
+         importedModule->isExportedAs(dep.Import->importedModule))) {
       spiGroups.insert(dep.spiGroups.begin(), dep.spiGroups.end());
     }
   }


### PR DESCRIPTION
This PR limits which `@_exported` imports exports SPI, SPIs are exported only when there's an `export_as` relationship between the two modules. This is to prevent SPI reexporting to get out of hands with the wide reexports of the Objective-C world.

Followup to https://github.com/apple/swift/pull/62029.

rdar://102335473