### PR TITLE
[Runtime] Add register-specific entrypoints for retain/release calls on ARM64.

### DIFF
--- a/include/swift/Runtime/CustomRRABI.h
+++ b/include/swift/Runtime/CustomRRABI.h
@@ -1,0 +1,90 @@
+//===--- CustomRRABI.h - Custom retain/release ABI support ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Utilities for creating register-specific retain/release entrypoints.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_CUSTOMRRABI_H
+#define SWIFT_RUNTIME_CUSTOMRRABI_H
+
+namespace swift {
+
+#if __arm64__ || defined(_M_ARM64)
+
+// Invoke the macro X on the number of each register we support for a custom ABI
+// entrypoint, along with a custom parameter. We don't support all 31 registers:
+// - x0 is already covered by the standard entrypoints.
+// - x16/x17 are scratch registers that can be used by procedure call glue.
+// - x18 is reserved.
+// - x29 is the frame pointer.
+// - x30 is the link register and gets overwritten when making a call.
+#define CUSTOM_RR_ENTRYPOINTS_FOREACH_REG(X, param)                            \
+  X(1, param)                                                                  \
+  X(2, param)                                                                  \
+  X(3, param)                                                                  \
+  X(4, param)                                                                  \
+  X(5, param)                                                                  \
+  X(6, param)                                                                  \
+  X(7, param)                                                                  \
+  X(8, param)                                                                  \
+  X(9, param)                                                                  \
+  X(10, param)                                                                 \
+  X(11, param)                                                                 \
+  X(12, param)                                                                 \
+  X(13, param)                                                                 \
+  X(14, param)                                                                 \
+  X(15, param)                                                                 \
+  X(19, param)                                                                 \
+  X(20, param)                                                                 \
+  X(21, param)                                                                 \
+  X(22, param)                                                                 \
+  X(23, param)                                                                 \
+  X(24, param)                                                                 \
+  X(25, param)                                                                 \
+  X(26, param)                                                                 \
+  X(27, param)                                                                 \
+  X(28, param)
+
+// Helper template for deducing the parameter type of a one-parameter function.
+template <typename Ret, typename Param>
+Param returnTypeHelper(Ret (*)(Param)) {}
+
+// Helper macro that defines one entrypoint that takes the parameter in reg and
+// calls through to function.
+#define CUSTOM_RR_ENTRYPOINTS_DEFINE_ONE_ENTRYPOINT(reg, function)             \
+  extern "C" SWIFT_RUNTIME_EXPORT decltype(function(                           \
+      nullptr)) function##_x##reg() {                                          \
+    decltype(returnTypeHelper(function)) ptr;                                  \
+    asm(".ifnc %0, x" #reg "\n"                                                \
+        "mov %0, x" #reg "\n"                                                  \
+        ".endif"                                                               \
+        : "=r"(ptr));                                                          \
+    return function(ptr);                                                      \
+  }
+
+// A macro that defines all register-specific entrypoints for the given
+// retain/release function.
+#define CUSTOM_RR_ENTRYPOINTS_DEFINE_ENTRYPOINTS(function)                     \
+  CUSTOM_RR_ENTRYPOINTS_FOREACH_REG(                                           \
+      CUSTOM_RR_ENTRYPOINTS_DEFINE_ONE_ENTRYPOINT, function)
+
+#else
+
+// No custom entrypoints on other architectures.
+#define CUSTOM_RR_ENTRYPOINTS_DEFINE_ENTRYPOINTS(function)
+
+#endif
+
+} // namespace swift
+
+#endif // SWIFT_RUNTIME_CUSTOMRRABI_H

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -25,6 +25,7 @@
 #include "RuntimeInvocationsTracking.h"
 #include "WeakReference.h"
 #include "swift/Runtime/Debug.h"
+#include "swift/Runtime/CustomRRABI.h"
 #include "swift/Runtime/InstrumentsSupport.h"
 #include "swift/shims/GlobalObjects.h"
 #include "swift/shims/RuntimeShims.h"
@@ -359,6 +360,8 @@ HeapObject *swift::swift_retain(HeapObject *object) {
 #endif
 }
 
+CUSTOM_RR_ENTRYPOINTS_DEFINE_ENTRYPOINTS(swift_retain)
+
 SWIFT_RUNTIME_EXPORT
 HeapObject *(*SWIFT_RT_DECLARE_ENTRY _swift_retain)(HeapObject *object) =
     _swift_retain_;
@@ -411,6 +414,8 @@ void swift::swift_release(HeapObject *object) {
   CALL_IMPL(swift_release, (object));
 #endif
 }
+
+CUSTOM_RR_ENTRYPOINTS_DEFINE_ENTRYPOINTS(swift_release)
 
 SWIFT_RUNTIME_EXPORT
 void (*SWIFT_RT_DECLARE_ENTRY _swift_release)(HeapObject *object) =

--- a/test/Runtime/Inputs/custom_rr_abi_utilities.h
+++ b/test/Runtime/Inputs/custom_rr_abi_utilities.h
@@ -1,0 +1,111 @@
+#define NUM_REGS 30
+
+// Apply `macro` to "all" registers. Skip x18 since it's reserved, and x30 since
+// it's the link register.
+#define ALL_REGS(macro)                                                        \
+  macro( 0)                                                                    \
+  macro( 1)                                                                    \
+  macro( 2)                                                                    \
+  macro( 3)                                                                    \
+  macro( 4)                                                                    \
+  macro( 5)                                                                    \
+  macro( 6)                                                                    \
+  macro( 7)                                                                    \
+  macro( 8)                                                                    \
+  macro( 9)                                                                    \
+  macro(10)                                                                    \
+  macro(11)                                                                    \
+  macro(12)                                                                    \
+  macro(13)                                                                    \
+  macro(14)                                                                    \
+  macro(15)                                                                    \
+  macro(16)                                                                    \
+  macro(17)                                                                    \
+  macro(19)                                                                    \
+  macro(20)                                                                    \
+  macro(21)                                                                    \
+  macro(22)                                                                    \
+  macro(23)                                                                    \
+  macro(24)                                                                    \
+  macro(25)                                                                    \
+  macro(26)                                                                    \
+  macro(27)                                                                    \
+  macro(28)                                                                    \
+  macro(29)
+
+// Apply `macro` with the given parameters to all registers that have
+// specialized entrypoints. That's the same as ALL_REGS, minus x0 (the standard
+// entrypoint covers that), x16/x17 (temporary registers used as linker glue),
+// and x29 (the link register).
+#define FUNCTION_REGS(macro, ...)                                              \
+  macro( 1, __VA_ARGS__)                                                       \
+  macro( 2, __VA_ARGS__)                                                       \
+  macro( 3, __VA_ARGS__)                                                       \
+  macro( 4, __VA_ARGS__)                                                       \
+  macro( 5, __VA_ARGS__)                                                       \
+  macro( 6, __VA_ARGS__)                                                       \
+  macro( 7, __VA_ARGS__)                                                       \
+  macro( 8, __VA_ARGS__)                                                       \
+  macro( 9, __VA_ARGS__)                                                       \
+  macro(10, __VA_ARGS__)                                                       \
+  macro(11, __VA_ARGS__)                                                       \
+  macro(12, __VA_ARGS__)                                                       \
+  macro(13, __VA_ARGS__)                                                       \
+  macro(14, __VA_ARGS__)                                                       \
+  macro(15, __VA_ARGS__)                                                       \
+  macro(19, __VA_ARGS__)                                                       \
+  macro(20, __VA_ARGS__)                                                       \
+  macro(21, __VA_ARGS__)                                                       \
+  macro(22, __VA_ARGS__)                                                       \
+  macro(23, __VA_ARGS__)                                                       \
+  macro(24, __VA_ARGS__)                                                       \
+  macro(25, __VA_ARGS__)                                                       \
+  macro(26, __VA_ARGS__)                                                       \
+  macro(27, __VA_ARGS__)                                                       \
+  macro(28, __VA_ARGS__)
+
+// Apply `macro` to each function that gets specialized entrypoints. Also pass
+// 1 if the function is a retain variant, and 0 if it's a release variant.
+#define ALL_FUNCTIONS(macro)                                                   \
+  macro(swift_retain, 1)                                                       \
+  macro(swift_release, 0)                                                      \
+  macro(swift_bridgeObjectRetain, 1)                                           \
+  macro(swift_bridgeObjectRelease, 0)
+
+// Emit declarations for variables called xN stored in xN, initialized with
+// regs[N].
+#define PASS_REGS_HELPER(num) \
+  register void *x ## num asm ("x" #num) = regs[num];
+#define PASS_REGS ALL_REGS(PASS_REGS_HELPER)
+
+// Emit an entry in an asm inputs list containing "r" (xN).
+#define REG_INPUTS_HELPER(num) \
+  "r" (x ## num),
+#define REG_INPUTS ALL_REGS(REG_INPUTS_HELPER)
+
+// Make a function called call_function_xN that calls function_xN with registers
+// set to the contents of the given registers array.
+#define MAKE_CALL_FUNC(reg, func)                                              \
+  static inline void call_##func##_x##reg(void **regs) {                       \
+    PASS_REGS                                                                  \
+    asm("bl _" #func "_x" #reg : : REG_INPUTS "i"(0));                         \
+  }
+
+// Make a call_function_xN for each specialized function and register.
+#define MAKE_ALL_CALL_FUNCS(function, isRetain)                                \
+  FUNCTION_REGS(MAKE_CALL_FUNC, function)
+ALL_FUNCTIONS(MAKE_ALL_CALL_FUNCS)
+
+// Call `call` with each call_function_xN function created above, as well as the
+// base function name, the register it operates on, and whether it's a retain
+// function.
+static inline void foreachRRFunction(void (*call)(void (*)(void **regs),
+                                                  const char *name, int reg,
+                                                  int isRetain)) {
+#define CALL_ONE_FUNCTION(reg, function, isRetain)                             \
+  call(call_##function##_x##reg, #function, reg, isRetain);
+#define CALL_WITH_FUNCTIONS(function, isRetain)                                \
+  FUNCTION_REGS(CALL_ONE_FUNCTION, function, isRetain)
+
+  ALL_FUNCTIONS(CALL_WITH_FUNCTIONS)
+}

--- a/test/Runtime/custom_rr_abi.swift
+++ b/test/Runtime/custom_rr_abi.swift
@@ -1,0 +1,86 @@
+// RUN: %target-run-simple-swift(-import-objc-header %S/Inputs/custom_rr_abi_utilities.h)
+
+// REQUIRES: CPU=arm64 || CPU=arm64e
+
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import StdlibUnittest
+
+// A class that can provider a retainable pointer and determine whether it's
+// been retained or released. This creates a helper object that will be retained
+// or released. We don't attempt to clean up the helper so it leaks if not released,
+// but this is only used for this one test so that's OK.
+class RetainReleaseChecker {
+  var pointerValue: UnsafeMutableRawPointer
+
+  private class Helper {}
+
+  private weak var weakRef: Helper?
+
+  private let originalRetainCount: UInt
+
+  init() {
+    do {
+      // Make a helper object, retain it so it stays alive, and put it into
+      // pointerValue and weakRef.
+      let helper = Helper()
+      pointerValue = Unmanaged.passRetained(helper).toOpaque()
+      weakRef = helper
+    }
+    // Record the original retain count before anything happens. Then we can
+    // detect changes without needing to know exactly what the count is supposed
+    // to be.
+    originalRetainCount = _getRetainCount(weakRef!)
+  }
+
+  // If helper was retained, then weakRef will still point to it, and the retain
+  // count will have increased.
+  var retained: Bool {
+    weakRef != nil && _getRetainCount(weakRef!) > originalRetainCount
+  }
+
+  // weakRef is the only reference we had to the helper, aside from the retain we put
+  // on it to create pointerValue. If helper was released, then it will be destroyed
+  // and weakRef will be nil.
+  var released: Bool {
+    weakRef == nil
+  }
+}
+
+var CustomRRABITestSuite = TestSuite("CustomRRABI")
+
+CustomRRABITestSuite.test("retain") {
+  foreachRRFunction { function, cname, register, isRetain in
+    let name = String(cString: cname!)
+    let fullname = "\(name)_x\(register)"
+
+    // Create a set of RR checker objects.
+    var checkers = (0..<NUM_REGS).map{ _ in RetainReleaseChecker() }
+
+    // Fill out a registers array with the pointers from the RR checkers.
+    var regs: [UnsafeMutableRawPointer?] = checkers.map{ $0.pointerValue }
+
+    // Call the RR function.
+    function!(&regs)
+
+    // Make sure all the checkers report what they're supposed to. All registers
+    // aside from `register` should be untouched, and `register` should have been
+    // either retained or released.
+    for (i, checker) in checkers.enumerated() {
+      if i == register {
+        if isRetain != 0 {
+          expectTrue(checker.retained, "\(fullname) must retain x\(i)")
+        } else {
+          expectTrue(checker.released, "\(fullname) must release x\(i)")
+        }
+      } else {
+        expectFalse(checker.retained, "\(fullname) must not retain x\(i)")
+        expectFalse(checker.released, "\(fullname) must not retain x\(i)")
+      }
+    }
+  }
+}
+
+runAllTests()


### PR DESCRIPTION
This will allow emitted code to condense a sequence like:

    mov x0, x21
    bl swift_retain

To:

    bl swift_retain_x21

Saving code size.

rdar://98884198