### PR TITLE
[cxx-interop] Disable auto-conformance to `CxxSequence` for non-random-access collections

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -381,7 +381,11 @@ void swift::conformToCxxSequenceIfNeeded(
   impl.addSynthesizedTypealias(decl, ctx.Id_Iterator, iteratorTy);
   impl.addSynthesizedTypealias(decl, ctx.getIdentifier("RawIterator"),
                                rawIteratorTy);
-  impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::CxxSequence});
+  // Not conforming the type to CxxSequence protocol here:
+  // The current implementation of CxxSequence triggers extra copies of the C++
+  // collection when creating a CxxIterator instance. It needs a more efficient
+  // implementation, which is not possible with the existing Swift features.
+  // impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::CxxSequence});
 
   // Try to conform to CxxRandomAccessCollection if possible.
 

--- a/test/Interop/Cxx/stdlib/overlay/custom-collection-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-collection-module-interface.swift
@@ -1,18 +1,18 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -enable-experimental-cxx-interop -module-cache-path %t | %FileCheck %s
 
-// CHECK: struct SimpleArrayWrapper : CxxRandomAccessCollection, CxxSequence {
+// CHECK: struct SimpleArrayWrapper : CxxRandomAccessCollection {
 // CHECK:   typealias Element = UnsafePointer<Int32>.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleArrayWrapper>
 // CHECK:   typealias RawIterator = UnsafePointer<Int32>
 // CHECK: }
 
-// CHECK: struct SimpleCollectionNoSubscript : CxxRandomAccessCollection, CxxSequence {
+// CHECK: struct SimpleCollectionNoSubscript : CxxRandomAccessCollection {
 // CHECK:   typealias Element = ConstRACIterator.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleCollectionNoSubscript>
 // CHECK:   typealias RawIterator = SimpleCollectionNoSubscript.iterator
 // CHECK: }
 
-// CHECK: struct SimpleCollectionReadOnly : CxxRandomAccessCollection, CxxSequence {
+// CHECK: struct SimpleCollectionReadOnly : CxxRandomAccessCollection {
 // CHECK:   typealias Element = ConstRACIteratorRefPlusEq.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleCollectionReadOnly>
 // CHECK:   typealias RawIterator = SimpleCollectionReadOnly.iterator

--- a/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
@@ -1,30 +1,30 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -enable-experimental-cxx-interop -module-cache-path %t | %FileCheck %s
 
-// CHECK: struct SimpleSequence : CxxSequence {
+// CHECK: struct SimpleSequence {
 // CHECK:   typealias Element = ConstIterator.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleSequence>
 // CHECK:   typealias RawIterator = ConstIterator
 // CHECK: }
 
-// CHECK: struct SimpleSequenceWithOutOfLineEqualEqual : CxxSequence {
+// CHECK: struct SimpleSequenceWithOutOfLineEqualEqual {
 // CHECK:   typealias Element = ConstIteratorOutOfLineEq.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleSequenceWithOutOfLineEqualEqual>
 // CHECK:   typealias RawIterator = ConstIteratorOutOfLineEq
 // CHECK: }
 
-// CHECK: struct SimpleArrayWrapperNullableIterators : CxxSequence {
+// CHECK: struct SimpleArrayWrapperNullableIterators {
 // CHECK:   typealias Element = Optional<UnsafePointer<Int32>>.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleArrayWrapperNullableIterators>
 // CHECK:   typealias RawIterator = UnsafePointer<Int32>?
 // CHECK: }
 
-// CHECK: struct SimpleEmptySequence : CxxSequence {
+// CHECK: struct SimpleEmptySequence {
 // CHECK:   typealias Element = Optional<UnsafePointer<Int32>>.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleEmptySequence>
 // CHECK:   typealias RawIterator = UnsafePointer<Int32>?
 // CHECK: }
 
-// CHECK: struct HasMutatingBeginEnd : CxxSequence {
+// CHECK: struct HasMutatingBeginEnd {
 // CHECK:   typealias Element = ConstIterator.Pointee
 // CHECK:   typealias Iterator = CxxIterator<HasMutatingBeginEnd>
 // CHECK:   typealias RawIterator = ConstIterator

--- a/test/Interop/Cxx/stdlib/overlay/custom-sequence-typechecker.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-sequence-typechecker.swift
@@ -1,5 +1,7 @@
 // RUN: %target-typecheck-verify-swift -I %S/Inputs -enable-experimental-cxx-interop
 
+// REQUIRES: rdar102364960
+
 import CustomSequence
 
 func checkIntSequence<S>(_ seq: S) where S: Sequence, S.Element == Int32 {

--- a/test/Interop/Cxx/stdlib/overlay/custom-sequence.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-sequence.swift
@@ -3,6 +3,8 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx || OS=linux-gnu
 
+// REQUIRES: rdar102364960
+
 import StdlibUnittest
 import CustomSequence
 


### PR DESCRIPTION
Iterating over a `CxxSequence` that is not a `CxxRandomAccessCollection` triggers a copy of the C++ collection. Let's disable the automatic conformances until we find a more efficient solution.

This means that for now developers won't be able to iterate over a `std::set` or `std::list` with a Swift for-in loop. I will submit a separate patch with an alternative solution for such types.

C++ random access collections, such as `std::vector` or `std::string`, are not affected.
