### PR TITLE
Revert "[Sema] Record opaque type decls for type reconstruction after creation instead of in the parser."

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -149,12 +149,9 @@ private:
   /// The set of validated opaque return type decls in the source file.
   llvm::SmallVector<OpaqueTypeDecl *, 4> OpaqueReturnTypes;
   llvm::StringMap<OpaqueTypeDecl *> ValidatedOpaqueReturnTypes;
-  /// The set of opaque type decls that have not yet been validated.
-  ///
-  /// \note This is populated as opaque type decls are created. Validation
-  /// requires mangling the naming decl, which would lead to circularity
-  /// if it were done from OpaqueResultTypeRequest.
-  llvm::SetVector<OpaqueTypeDecl *> UnvalidatedOpaqueReturnTypes;
+  /// The set of parsed decls with opaque return types that have not yet
+  /// been validated.
+  llvm::SetVector<ValueDecl *> UnvalidatedDeclsWithOpaqueReturnTypes;
 
   /// The list of top-level items in the source file. This is \c None if
   /// they have not yet been parsed.
@@ -646,8 +643,11 @@ public:
 
   OpaqueTypeDecl *lookupOpaqueResultType(StringRef MangledName) override;
 
-  void addOpaqueResultTypeDecl(OpaqueTypeDecl *decl) {
-    UnvalidatedOpaqueReturnTypes.insert(decl);
+  /// Do not call when inside an inactive clause (\c
+  /// InInactiveClauseEnvironment)) because it will later on result in a lookup
+  /// to something that won't be in the ASTScope tree.
+  void addUnvalidatedDeclWithOpaqueResultType(ValueDecl *vd) {
+    UnvalidatedDeclsWithOpaqueReturnTypes.insert(vd);
   }
 
   ArrayRef<OpaqueTypeDecl *> getOpaqueReturnTypeDecls();

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -177,7 +177,9 @@ public:
 
   bool InPoundLineEnvironment = false;
   bool InPoundIfEnvironment = false;
-  /// ASTScopes are not created in inactive clauses and lookups to decls will fail.
+  /// Do not call \c addUnvalidatedDeclWithOpaqueResultType when in an inactive
+  /// clause because ASTScopes are not created in those contexts and lookups to
+  /// those decls will fail.
   bool InInactiveClauseEnvironment = false;
   bool InSwiftKeyPath = false;
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3485,12 +3485,14 @@ void SourceFile::setTypeRefinementContext(TypeRefinementContext *Root) {
 }
 
 ArrayRef<OpaqueTypeDecl *> SourceFile::getOpaqueReturnTypeDecls() {
-  for (auto *opaqueDecl : UnvalidatedOpaqueReturnTypes.takeVector()) {
-    auto inserted = ValidatedOpaqueReturnTypes.insert(
-              {opaqueDecl->getOpaqueReturnTypeIdentifier().str(),
-               opaqueDecl});
-    if (inserted.second) {
-      OpaqueReturnTypes.push_back(opaqueDecl);
+  for (auto *vd : UnvalidatedDeclsWithOpaqueReturnTypes.takeVector()) {
+    if (auto opaqueDecl = vd->getOpaqueResultTypeDecl()) {
+      auto inserted = ValidatedOpaqueReturnTypes.insert(
+                {opaqueDecl->getOpaqueReturnTypeIdentifier().str(),
+                 opaqueDecl});
+      if (inserted.second) {
+        OpaqueReturnTypes.push_back(opaqueDecl);
+      }
     }
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7235,6 +7235,12 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
       pattern = patternRes.get();
     }
     
+    bool hasOpaqueReturnTy = false;
+    if (auto typedPattern = dyn_cast<TypedPattern>(pattern)) {
+      hasOpaqueReturnTy = typedPattern->getTypeRepr()->hasOpaque();
+    }
+    auto sf = CurDeclContext->getParentSourceFile();
+    
     // Configure all vars with attributes, 'static' and parent pattern.
     pattern->forEachVariable([&](VarDecl *VD) {
       VD->setStatic(StaticLoc.isValid());
@@ -7246,6 +7252,9 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
       setOriginalDeclarationForDifferentiableAttributes(Attributes, VD);
 
       Decls.push_back(VD);
+      if (hasOpaqueReturnTy && sf && !InInactiveClauseEnvironment) {
+        sf->addUnvalidatedDeclWithOpaqueResultType(VD);
+      }
     });
 
     // Check whether we have already established an initializer context.
@@ -7532,6 +7541,14 @@ ParserResult<FuncDecl> Parser::parseDeclFunc(SourceLoc StaticLoc,
                               GenericParams,
                               BodyParams, FuncRetTy,
                               CurDeclContext);
+
+  // Let the source file track the opaque return type mapping, if any.
+  if (FuncRetTy && FuncRetTy->hasOpaque() &&
+      !InInactiveClauseEnvironment) {
+    if (auto sf = CurDeclContext->getParentSourceFile()) {
+      sf->addUnvalidatedDeclWithOpaqueResultType(FD);
+    }
+  }
   
   // Parse a 'where' clause if present.
   if (Tok.is(tok::kw_where)) {
@@ -8495,6 +8512,14 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
       Context, name, StaticLoc, StaticSpelling, SubscriptLoc, Indices.get(),
       ArrowLoc, ElementTy.get(), CurDeclContext, GenericParams);
   Subscript->getAttrs() = Attributes;
+  
+  // Let the source file track the opaque return type mapping, if any.
+  if (ElementTy.get() && ElementTy.get()->hasOpaque() &&
+      !InInactiveClauseEnvironment) {
+    if (auto sf = CurDeclContext->getParentSourceFile()) {
+      sf->addUnvalidatedDeclWithOpaqueResultType(Subscript);
+    }
+  }
 
   DefaultArgs.setFunctionContext(Subscript, Subscript->getIndices());
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -251,13 +251,6 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
 
   auto metatype = MetatypeType::get(interfaceType);
   opaqueDecl->setInterfaceType(metatype);
-
-  // Record the opaque return type decl in the parent source file,
-  // which will be used in IRGen to emit all opaque type decls
-  // in a Swift module for type reconstruction.
-  if (auto *sourceFile = dc->getParentSourceFile())
-    sourceFile->addOpaqueResultTypeDecl(opaqueDecl);
-
   return opaqueDecl;
 }
 


### PR DESCRIPTION
Reverts apple/swift#62075

There is still a reason not to populate the list of all opaque types in a source file in `OpaqueResultTypeRequest`, which is that `_opaqueReturnTypeOf` relies on it being populated during type resolution. The failing tests from https://github.com/apple/swift/pull/62089 are a manifestation of this.

I'll fix the type resolution code and re-land this once that's done.