### PR TITLE
[Dependency Scanning] Produce canonical output path for Swift binary modules.

### DIFF
--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -125,6 +125,9 @@ struct CommonSwiftTextualModuleDependencyDetails {
 class SwiftInterfaceModuleDependenciesStorage :
   public ModuleDependenciesStorageBase {
 public:
+  /// Destination output path
+  const std::string moduleOutputPath;
+
   /// The Swift interface file to be used to generate the module file.
   const std::string swiftInterfaceFile;
 
@@ -145,6 +148,7 @@ public:
   CommonSwiftTextualModuleDependencyDetails textualModuleDetails;
 
   SwiftInterfaceModuleDependenciesStorage(
+      const std::string moduleOutputPath,
       const std::string swiftInterfaceFile,
       ArrayRef<std::string> compiledModuleCandidates,
       ArrayRef<StringRef> buildCommandLine,
@@ -152,6 +156,7 @@ public:
       StringRef contextHash,
       bool isFramework
   ) : ModuleDependenciesStorageBase(ModuleDependenciesKind::SwiftInterface),
+      moduleOutputPath(moduleOutputPath),
       swiftInterfaceFile(swiftInterfaceFile),
       compiledModuleCandidates(compiledModuleCandidates.begin(),
                                compiledModuleCandidates.end()),
@@ -340,7 +345,8 @@ public:
   /// Describe the module dependencies for a Swift module that can be
   /// built from a Swift interface file (\c .swiftinterface).
   static ModuleDependencies forSwiftInterfaceModule(
-      std::string swiftInterfaceFile,
+      const std::string &moduleOutputPath,
+      const std::string &swiftInterfaceFile,
       ArrayRef<std::string> compiledCandidates,
       ArrayRef<StringRef> buildCommands,
       ArrayRef<StringRef> extraPCMArgs,
@@ -348,7 +354,7 @@ public:
       bool isFramework) {
     return ModuleDependencies(
         std::make_unique<SwiftInterfaceModuleDependenciesStorage>(
-          swiftInterfaceFile, compiledCandidates, buildCommands,
+          moduleOutputPath, swiftInterfaceFile, compiledCandidates, buildCommands,
           extraPCMArgs, contextHash, isFramework));
   }
 

--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -124,7 +124,8 @@ using ModuleInfoLayout =
 
 using SwiftInterfaceModuleDetailsLayout =
     BCRecordLayout<SWIFT_INTERFACE_MODULE_DETAILS_NODE, // ID
-                   FileIDField,                       // swiftInterfaceFile
+                   FileIDField,        // outputFilePath
+                   FileIDField,        // swiftInterfaceFile
                    FileIDArrayIDField, // compiledModuleCandidates
                    FlagIDArrayIDField, // buildCommandLine
                    FlagIDArrayIDField, // extraPCMArgs

--- a/include/swift/Serialization/ModuleDependencyScanner.h
+++ b/include/swift/Serialization/ModuleDependencyScanner.h
@@ -37,16 +37,21 @@ namespace swift {
           Twine moduleInterfacePath, bool isFramework);
 
       InterfaceSubContextDelegate &astDelegate;
+
+      /// Location where pre-built moduels are to be built into.
+      std::string moduleCachePath;
     public:
       Optional<ModuleDependencies> dependencies;
 
-      ModuleDependencyScanner(
-          ASTContext &ctx, ModuleLoadingMode LoadMode, Identifier moduleName,
-          InterfaceSubContextDelegate &astDelegate,
-          ScannerKind kind = MDS_plain)
+      ModuleDependencyScanner(ASTContext &ctx, ModuleLoadingMode LoadMode,
+                              Identifier moduleName,
+                              InterfaceSubContextDelegate &astDelegate,
+                              ScannerKind kind = MDS_plain)
           : SerializedModuleLoaderBase(ctx, nullptr, LoadMode,
                                        /*IgnoreSwiftSourceInfoFile=*/true),
-            kind(kind), moduleName(moduleName), astDelegate(astDelegate) {}
+            kind(kind), moduleName(moduleName), astDelegate(astDelegate),
+            moduleCachePath(getModuleCachePathFromClang(
+                ctx.getClangModuleLoader()->getClangInstance())) {}
 
       std::error_code findModuleFilesInDirectory(
           ImportPath::Element ModuleID,

--- a/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
+++ b/lib/DependencyScan/ModuleDependencyCacheSerialization.cpp
@@ -227,16 +227,19 @@ bool Deserializer::readGraph(GlobalModuleDependenciesCache &cache) {
         llvm::report_fatal_error(
             "Unexpected SWIFT_TEXTUAL_MODULE_DETAILS_NODE record");
       cache.configureForTriple(getTriple());
-      unsigned interfaceFileID, compiledModuleCandidatesArrayID,
+      unsigned outputPathFileID, interfaceFileID, compiledModuleCandidatesArrayID,
           buildCommandLineArrayID, extraPCMArgsArrayID, contextHashID,
           isFramework, bridgingHeaderFileID, sourceFilesArrayID,
           bridgingSourceFilesArrayID, bridgingModuleDependenciesArrayID;
       SwiftInterfaceModuleDetailsLayout::readRecord(
-          Scratch, interfaceFileID, compiledModuleCandidatesArrayID,
+          Scratch, outputPathFileID, interfaceFileID, compiledModuleCandidatesArrayID,
           buildCommandLineArrayID, extraPCMArgsArrayID, contextHashID,
           isFramework, bridgingHeaderFileID, sourceFilesArrayID,
           bridgingSourceFilesArrayID, bridgingModuleDependenciesArrayID);
 
+      auto outputModulePath = getIdentifier(outputPathFileID);
+      if (!outputModulePath)
+         llvm::report_fatal_error("Bad .swiftmodule output path");
       Optional<std::string> optionalSwiftInterfaceFile;
       if (interfaceFileID != 0) {
         auto swiftInterfaceFile = getIdentifier(interfaceFileID);
@@ -267,6 +270,7 @@ bool Deserializer::readGraph(GlobalModuleDependenciesCache &cache) {
 
       // Form the dependencies storage object
       auto moduleDep = ModuleDependencies::forSwiftInterfaceModule(
+          outputModulePath.getValue(),
           optionalSwiftInterfaceFile.getValue(), *compiledModuleCandidates,
           buildCommandRefs, extraPCMRefs, *contextHash, isFramework);
 
@@ -782,6 +786,8 @@ void Serializer::writeModuleInfo(ModuleDependencyID moduleID,
     assert(triple.hasValue() && "Expected triple for serializing MODULE_NODE");
     auto swiftTextDeps = dependencyInfo.getAsSwiftInterfaceModule();
     assert(swiftTextDeps);
+    unsigned outputModulePathFileId =
+        getIdentifier(swiftTextDeps->moduleOutputPath);
     unsigned swiftInterfaceFileId =
         getIdentifier(swiftTextDeps->swiftInterfaceFile);
     unsigned bridgingHeaderFileId =
@@ -791,6 +797,7 @@ void Serializer::writeModuleInfo(ModuleDependencyID moduleID,
             : 0;
     SwiftInterfaceModuleDetailsLayout::emitRecord(
         Out, ScratchRecord, AbbrCodes[SwiftInterfaceModuleDetailsLayout::Code],
+        outputModulePathFileId,
         swiftInterfaceFileId,
         getArray(moduleID, ModuleIdentifierArrayKind::CompiledModuleCandidates),
         getArray(moduleID, ModuleIdentifierArrayKind::BuildCommandLine),
@@ -981,6 +988,7 @@ void Serializer::collectStringsAndArrays(
         case swift::ModuleDependenciesKind::SwiftInterface: {
           auto swiftTextDeps = dependencyInfo.getAsSwiftInterfaceModule();
           assert(swiftTextDeps);
+          addIdentifier(swiftTextDeps->moduleOutputPath);
           addIdentifier(swiftTextDeps->swiftInterfaceFile);
           addArray(moduleID,
                    ModuleIdentifierArrayKind::CompiledModuleCandidates,

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -590,7 +590,7 @@ static void writeJSON(llvm::raw_ostream &out,
       modulePath = get_C_string(swiftPlaceholderDeps->compiled_module_path);
     else if (swiftBinaryDeps)
       modulePath = get_C_string(swiftBinaryDeps->compiled_module_path);
-    else if (clangDeps)
+    else if (clangDeps || swiftTextualDeps)
       modulePath = get_C_string(moduleInfo.module_path);
     else
       modulePath = moduleName + modulePathSuffix;
@@ -829,7 +829,9 @@ generateFullDependencyGraph(CompilerInstance &instance,
     const char *modulePathSuffix =
         moduleDeps.isSwiftModule() ? ".swiftmodule" : ".pcm";
     std::string modulePath;
-    if (swiftPlaceholderDeps)
+    if (swiftTextualDeps)
+      modulePath = swiftTextualDeps->moduleOutputPath;
+    else if (swiftPlaceholderDeps)
       modulePath = swiftPlaceholderDeps->compiledModulePath;
     else if (swiftBinaryDeps)
       modulePath = swiftBinaryDeps->compiledModulePath;
@@ -1260,6 +1262,9 @@ bool swift::dependencies::scanDependencies(CompilerInstance &instance) {
 
   if (opts.ReuseDependencyScannerCache)
     deserializeDependencyCache(instance, globalCache);
+
+  auto ModuleCachePath = getModuleCachePathFromClang(
+               Context.getClangModuleLoader()->getClangInstance());
 
   ModuleDependenciesCache cache(globalCache,
                                 instance.getMainModule()->getNameStr());

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -118,12 +118,15 @@ ErrorOr<ModuleDependencies> ModuleDependencyScanner::scanInterfaceFile(
     std::string InPath = moduleInterfacePath.str();
     auto compiledCandidates = getCompiledCandidates(Ctx, realModuleName.str(),
                                                     InPath);
-    Result = ModuleDependencies::forSwiftInterfaceModule(InPath,
-                                                   compiledCandidates,
-                                                   Args,
-                                                   PCMArgs,
-                                                   Hash,
-                                                   isFramework);
+
+    SmallString<128> outputPathBase(moduleCachePath);
+    llvm::sys::path::append(
+        outputPathBase,
+        moduleName.str() + "-" + Hash + "." +
+            file_types::getExtension(file_types::TY_SwiftModuleFile));
+    Result = ModuleDependencies::forSwiftInterfaceModule(
+        outputPathBase.str().str(), InPath, compiledCandidates, Args, PCMArgs,
+        Hash, isFramework);
     // Open the interface file.
     auto &fs = *Ctx.SourceMgr.getFileSystem();
     auto interfaceBuf = fs.getBufferForFile(moduleInterfacePath);

--- a/test/ModuleInterface/clang-args-transitive-availability.swift
+++ b/test/ModuleInterface/clang-args-transitive-availability.swift
@@ -25,7 +25,7 @@ import ImportsMacroSpecificClangModule
 //CHECK:      "swift": "ImportsMacroSpecificClangModule"
 //CHECK-NEXT:    },
 //CHECK-NEXT:    {
-//CHECK-NEXT:      "modulePath": "ImportsMacroSpecificClangModule.swiftmodule",
+//CHECK-NEXT:      "modulePath": "{{.*}}{{/|\\}}ImportsMacroSpecificClangModule-{{.*}}.swiftmodule",
 //CHECK-NEXT:      "sourceFiles": [
 //CHECK-NEXT:      ],
 //CHECK-NEXT:      "directDependencies": [

--- a/test/ModuleInterface/extension-transitive-availability.swift
+++ b/test/ModuleInterface/extension-transitive-availability.swift
@@ -27,7 +27,7 @@ func foo() {
 // CHECK:      "swift": "ExtensionAvailable"
 // CHECK-NEXT:    },
 // CHECK-NEXT:    {
-// CHECK-NEXT:      "modulePath": "ExtensionAvailable.swiftmodule",
+// CHECK-NEXT:      "modulePath": "{{.*}}{{/|\\}}ExtensionAvailable-{{.*}}.swiftmodule",
 // CHECK-NEXT:      "sourceFiles": [
 // CHECK-NEXT:      ],
 // CHECK-NEXT:      "directDependencies": [

--- a/test/ScanDependencies/batch_module_scan.swift
+++ b/test/ScanDependencies/batch_module_scan.swift
@@ -27,7 +27,7 @@
 // CHECK-PCM-NEXT:      "clang": "F"
 // CHECK-PCM-NEXT:    },
 // CHECK-PCM-NEXT:    {
-// CHECK-PCM-NEXT:      "modulePath": "{{.*}}F-{{.*}}.pcm",
+// CHECK-PCM-NEXT:      "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.pcm",
 // CHECK-PCM: "-I
 
 // CHECK-SWIFT: {
@@ -37,4 +37,4 @@
 // CHECK-SWIFT-NEXT:      "swift": "F"
 // CHECK-SWIFT-NEXT:    },
 // CHECK-SWIFT-NEXT:    {
-// CHECK-SWIFT-NEXT:      "modulePath": "F.swiftmodule",
+// CHECK-SWIFT-NEXT:      "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.swiftmodule",

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -96,7 +96,7 @@ import SubE
 // CHECK-NEXT: ]
 
 /// --------Swift module A
-// CHECK-LABEL: "modulePath": "A.swiftmodule",
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
 
 // CHECK: directDependencies
 // CHECK-NEXT: {
@@ -145,7 +145,7 @@ import SubE
 
 /// --------Swift module E
 // CHECK: "swift": "E"
-// CHECK-LABEL: modulePath": "E.swiftmodule"
+// CHECK-LABEL: modulePath": "{{.*}}{{/|\\}}E-{{.*}}.swiftmodule"
 // CHECK: "directDependencies"
 // CHECK-NEXT: {
 // CHECK-NEXT: "swift": "Swift"
@@ -154,7 +154,7 @@ import SubE
 // CHECK-SAME: E.swiftinterface
 
 /// --------Swift module F
-// CHECK:      "modulePath": "F.swiftmodule",
+// CHECK:      "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.swiftmodule",
 // CHECK-NEXT: "sourceFiles": [
 // CHECK-NEXT: ],
 // CHECK-NEXT: "directDependencies": [
@@ -170,7 +170,7 @@ import SubE
 // CHECK-NEXT: ],
 
 /// --------Swift module G
-// CHECK-LABEL: "modulePath": "G.swiftmodule"
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}G-{{.*}}.swiftmodule"
 // CHECK: "directDependencies"
 // CHECK-NEXT: {
 // CHECK-NEXT:   "clang": "G"
@@ -202,7 +202,7 @@ import SubE
 // CHECK_CLANG_TARGET-NEXT:   ]
 
 /// --------Swift module Swift
-// CHECK-LABEL: "modulePath": "Swift.swiftmodule",
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",
 
 // CHECK: directDependencies
 // CHECK-NEXT: {

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -83,7 +83,7 @@ import SubE
 // CHECK-NEXT: ]
 
 /// --------Swift module A
-// CHECK-LABEL: "modulePath": "A.swiftmodule",
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
 
 // CHECK: directDependencies
 // CHECK-NEXT: {
@@ -120,7 +120,7 @@ import SubE
 
 /// --------Swift module E
 // CHECK: "swift": "E"
-// CHECK-LABEL: modulePath": "E.swiftmodule"
+// CHECK-LABEL: modulePath": "{{.*}}{{/|\\}}E-{{.*}}.swiftmodule"
 // CHECK: "directDependencies"
 // CHECK-NEXT: {
 // CHECK-NEXT: "swift": "Swift"
@@ -129,7 +129,7 @@ import SubE
 // CHECK-SAME: E.swiftinterface
 
 /// --------Swift module F
-// CHECK-LABEL: "modulePath": "F.swiftmodule",
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.swiftmodule",
 // CHECK-NEXT: "sourceFiles": [
 // CHECK-NEXT: ],
 // CHECK-NEXT: "directDependencies": [
@@ -145,7 +145,7 @@ import SubE
 // CHECK-NEXT: ],
 
 /// --------Swift module G
-// CHECK-LABEL: "modulePath": "G.swiftmodule"
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}G-{{.*}}.swiftmodule"
 // CHECK: "directDependencies"
 // CHECK-NEXT: {
 // CHECK-NEXT:   "clang": "G"
@@ -174,7 +174,7 @@ import SubE
 // CHECK" ]
 
 /// --------Swift module Swift
-// CHECK-LABEL: "modulePath": "Swift.swiftmodule",
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",
 
 // CHECK: directDependencies
 // CHECK-NEXT: {

--- a/test/ScanDependencies/module_deps_different_paths_no_reuse.swift
+++ b/test/ScanDependencies/module_deps_different_paths_no_reuse.swift
@@ -16,7 +16,7 @@
 
 import A
 
-// CHECK-INITIAL-SCAN:           "modulePath": "A.swiftmodule",
+// CHECK-INITIAL-SCAN:           "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
 // CHECK-INITIAL-SCAN-NEXT:      "sourceFiles": [
 // CHECK-INITIAL-SCAN-NEXT:      ],
 // CHECK-INITIAL-SCAN-NEXT:      "directDependencies": [
@@ -34,7 +34,7 @@ import A
 // CHECK-INITIAL-SCAN-NEXT:        "swift": {
 // CHECK-INITIAL-SCAN-NEXT:          "moduleInterfacePath": "{{.*}}/Swift/A.swiftinterface",
 
-// CHECK-DIFFERENT:           "modulePath": "A.swiftmodule",
+// CHECK-DIFFERENT:           "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
 // CHECK-DIFFERENT-NEXT:      "sourceFiles": [
 // CHECK-DIFFERENT-NEXT:      ],
 // CHECK-DIFFERENT-NEXT:      "directDependencies": [

--- a/test/ScanDependencies/module_deps_external.swift
+++ b/test/ScanDependencies/module_deps_external.swift
@@ -82,14 +82,14 @@ import SomeExternalModule
 // CHECK-NEXT: ]
 
 /// --------Swift external module SomeExternalModule
-// CHECK-LABEL: "modulePath": "BUILD_DIR/{{.*}}/ScanDependencies/Output/module_deps_external.swift.tmp/inputs/SomeExternalModule.swiftmodule",
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}SomeExternalModule.swiftmodule",
 // CHECK-NEXT: "details": {
 // CHECK-NEXT: "swiftPlaceholder": {
 // CHECK-NEXT: "moduleDocPath": "BUILD_DIR/{{.*}}/ScanDependencies/Output/module_deps_external.swift.tmp/inputs/SomeExternalModule.swiftdoc",
 // CHECK-NEXT: "moduleSourceInfoPath": "BUILD_DIR/{{.*}}/ScanDependencies/Output/module_deps_external.swift.tmp/inputs/SomeExternalModule.swiftsourceinfo"
 
 /// --------Swift module Swift
-// CHECK-LABEL: "modulePath": "Swift.swiftmodule",
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}Swift-{{.*}}.swiftmodule",
 
 // CHECK: directDependencies
 // CHECK-NEXT: {

--- a/test/ScanDependencies/placholder_overlay_deps.swift
+++ b/test/ScanDependencies/placholder_overlay_deps.swift
@@ -23,7 +23,7 @@ import Metal
 
 // Ensure the dependency on Darwin is captured even though it is a placeholder
 
-// CHECK:   "modulePath": "Metal.swiftmodule",
+// CHECK:   "modulePath": "{{.*}}{{/|\\}}Metal-{{.*}}.swiftmodule",
 // CHECK-NEXT:   "sourceFiles": [
 // CHECK-NEXT:   ],
 // CHECK:     {


### PR DESCRIPTION
Instead of relying on the client (driver) to perform its own computation of the matching output path.
