### PR TITLE
[cxx-interop] Avoid side-effects in member lookup when conforming types to `CxxSequence`

### DIFF
--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -27,7 +27,7 @@ lookupDirectWithoutExtensions(NominalTypeDecl *decl, Identifier id) {
       decl->getASTContext().evaluator, ClangRecordMemberLookup({decl, id}), {});
 
   // Check if there are any synthesized Swift members that match the name.
-  for (auto member : decl->getMembers()) {
+  for (auto member : decl->getCurrentMembersWithoutLoading()) {
     if (auto namedMember = dyn_cast<ValueDecl>(member)) {
       if (namedMember->hasName() && !namedMember->getName().isSpecial() &&
           namedMember->getName().getBaseIdentifier().is(id.str()) &&

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -1,30 +1,30 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -enable-experimental-cxx-interop -module-cache-path %t | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: struct ConstIterator : UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ConstIterator
-// CHECK:   static func == (lhs: ConstIterator, other: ConstIterator) -> Bool
 // CHECK:   typealias Pointee = Int32
+// CHECK:   static func == (lhs: ConstIterator, other: ConstIterator) -> Bool
 // CHECK: }
 
 // CHECK: struct ConstRACIterator : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ConstRACIterator
+// CHECK:   typealias Pointee = Int32
+// CHECK:   typealias Distance = Int32
 // CHECK:   static func += (lhs: inout ConstRACIterator, v: ConstRACIterator.difference_type)
 // CHECK:   static func - (lhs: ConstRACIterator, other: ConstRACIterator) -> Int32
 // CHECK:   static func == (lhs: ConstRACIterator, other: ConstRACIterator) -> Bool
-// CHECK:   typealias Pointee = Int32
-// CHECK:   typealias Distance = Int32
 // CHECK: }
 
 // CHECK: struct ConstRACIteratorRefPlusEq : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ConstRACIterator
+// CHECK:   typealias Pointee = Int32
+// CHECK:   typealias Distance = Int32
 // CHECK:   static func += (lhs: inout ConstRACIteratorRefPlusEq, v: ConstRACIteratorRefPlusEq.difference_type)
 // CHECK:   static func - (lhs: ConstRACIteratorRefPlusEq, other: ConstRACIteratorRefPlusEq) -> Int32
 // CHECK:   static func == (lhs: ConstRACIteratorRefPlusEq, other: ConstRACIteratorRefPlusEq) -> Bool
-// CHECK:   typealias Pointee = Int32
-// CHECK:   typealias Distance = Int32
 // CHECK: }
 
 // CHECK: struct ConstIteratorOutOfLineEq : UnsafeCxxInputIterator {
@@ -36,46 +36,46 @@
 // CHECK: struct MinimalIterator : UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> MinimalIterator
-// CHECK:   static func == (lhs: MinimalIterator, other: MinimalIterator) -> Bool
 // CHECK:   typealias Pointee = Int32
+// CHECK:   static func == (lhs: MinimalIterator, other: MinimalIterator) -> Bool
 // CHECK: }
 
 // CHECK: struct ForwardIterator : UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> ForwardIterator
-// CHECK:   static func == (lhs: ForwardIterator, other: ForwardIterator) -> Bool
 // CHECK:   typealias Pointee = Int32
+// CHECK:   static func == (lhs: ForwardIterator, other: ForwardIterator) -> Bool
 // CHECK: }
 
 // CHECK: struct HasCustomIteratorTag : UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> HasCustomIteratorTag
-// CHECK:   static func == (lhs: HasCustomIteratorTag, other: HasCustomIteratorTag) -> Bool
 // CHECK:   typealias Pointee = Int32
+// CHECK:   static func == (lhs: HasCustomIteratorTag, other: HasCustomIteratorTag) -> Bool
 // CHECK: }
 
 // CHECK: struct HasCustomRACIteratorTag : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> HasCustomRACIteratorTag
+// CHECK:   typealias Pointee = Int32
+// CHECK:   typealias Distance = Int32
 // CHECK:   static func += (lhs: inout HasCustomRACIteratorTag, x: Int32)
 // CHECK:   static func - (lhs: HasCustomRACIteratorTag, x: HasCustomRACIteratorTag) -> Int32
 // CHECK:   static func == (lhs: HasCustomRACIteratorTag, other: HasCustomRACIteratorTag) -> Bool
-// CHECK:   typealias Pointee = Int32
-// CHECK:   typealias Distance = Int32
 // CHECK: }
 
 // CHECK: struct HasCustomIteratorTagInline : UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> HasCustomIteratorTagInline
-// CHECK:   static func == (lhs: HasCustomIteratorTagInline, other: HasCustomIteratorTagInline) -> Bool
 // CHECK:   typealias Pointee = Int32
+// CHECK:   static func == (lhs: HasCustomIteratorTagInline, other: HasCustomIteratorTagInline) -> Bool
 // CHECK: }
 
 // CHECK: struct HasTypedefIteratorTag : UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
 // CHECK:   func successor() -> HasTypedefIteratorTag
-// CHECK:   static func == (lhs: HasTypedefIteratorTag, other: HasTypedefIteratorTag) -> Bool
 // CHECK:   typealias Pointee = Int32
+// CHECK:   static func == (lhs: HasTypedefIteratorTag, other: HasTypedefIteratorTag) -> Bool
 // CHECK: }
 
 // CHECK-NOT: struct HasNoIteratorCategory : UnsafeCxxInputIterator


### PR DESCRIPTION
This became an issue in rebranch: multiple interop tests started failing (e.g. `Interop/Cxx/foreign-reference/pod.swift`). The problem is not specific to rebranch though.

rdar://102151836