### PR TITLE
[AST/Sema] Add `@runtimeMetadata` attribute and experimental flag

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6756,6 +6756,14 @@ ERROR(moveonly_cannot_conform_to_protocol, none,
 ERROR(moveonly_cannot_conform_to_protocol_with_name, none,
      "move-only %0 %1 cannot conform to protocol %2",
      (DescriptiveDeclKind, DeclName, DeclName))
+
+//------------------------------------------------------------------------------
+// MARK: Runtime discoverable attributes (@runtimeMetadata)
+//------------------------------------------------------------------------------
+
+ERROR(runtime_discoverable_attrs_are_experimental,none,
+      "runtime discoverable attributes are an experimental feature", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -154,6 +154,10 @@ EXPERIMENTAL_FEATURE(Macros, false)
 /// corresponding syntax tree.
 EXPERIMENTAL_FEATURE(BuiltinMacros, false)
 
+/// Whether to enable experimental @runtimeMetadata feature which allows to
+/// declare an attribute which is discoverable and constructable at runtime.
+EXPERIMENTAL_FEATURE(RuntimeDiscoverableAttrs, false)
+
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE
 #undef SUPPRESSIBLE_LANGUAGE_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2930,6 +2930,10 @@ static bool usesFeatureTypeWrappers(Decl *decl) {
   return decl->getAttrs().hasAttribute<TypeWrapperAttr>();
 }
 
+static bool usesFeatureRuntimeDiscoverableAttrs(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureParserRoundTrip(Decl *decl) {
   return false;
 }

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2931,7 +2931,7 @@ static bool usesFeatureTypeWrappers(Decl *decl) {
 }
 
 static bool usesFeatureRuntimeDiscoverableAttrs(Decl *decl) {
-  return false;
+  return decl->getAttrs().hasAttribute<RuntimeMetadataAttr>();
 }
 
 static bool usesFeatureParserRoundTrip(Decl *decl) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -336,6 +336,8 @@ public:
   void visitKnownToBeLocalAttr(KnownToBeLocalAttr *attr);
 
   void visitSendableAttr(SendableAttr *attr);
+
+  void visitRuntimeMetadataAttr(RuntimeMetadataAttr *attr);
 };
 
 } // end anonymous namespace
@@ -6930,6 +6932,15 @@ void AttributeChecker::visitCompilerInitializedAttr(
   // focus just on the initialization in the init.
   if (!(var->getDeclContext()->getSelfClassDecl() && var->isInstanceMember())) {
     diagnose(attr->getLocation(), diag::instancemember_compilerinitialized);
+    return;
+  }
+}
+
+void AttributeChecker::visitRuntimeMetadataAttr(RuntimeMetadataAttr *attr) {
+  if (!Ctx.LangOpts.hasFeature(Feature::RuntimeDiscoverableAttrs)) {
+    diagnose(attr->getLocation(),
+             diag::runtime_discoverable_attrs_are_experimental);
+    attr->setInvalid();
     return;
   }
 }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1623,6 +1623,8 @@ namespace  {
 
     UNINTERESTING_ATTR(EagerMove)
     UNINTERESTING_ATTR(NoEagerMove)
+
+    UNINTERESTING_ATTR(RuntimeMetadata)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 719;  // isBuiltFromInterface
+const uint16_t SWIFTMODULE_VERSION_MINOR = 720;  // @runtimeMetadata attribute
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -118,6 +118,7 @@ actor MyGlobalActor {
 // KEYWORD3-NEXT:             Keyword/None:                       globalActor[#Class Attribute#]; name=globalActor
 // KEYWORD3-NEXT:             Keyword/None:                       preconcurrency[#Class Attribute#]; name=preconcurrency
 // KEYWORD3-NEXT:             Keyword/None:                       typeWrapper[#Class Attribute#]; name=typeWrapper
+// KEYWORD3-NEXT:             Keyword/None:                       runtimeMetadata[#Class Attribute#]; name=runtimeMetadata
 // KEYWORD3-NEXT:             End completions
 
 @#^KEYWORD3_2^#IB class C2 {}
@@ -153,6 +154,7 @@ actor MyGlobalActor {
 // KEYWORD5-NEXT:             Keyword/None:                       globalActor[#Struct Attribute#]; name=globalActor
 // KEYWORD5-NEXT:             Keyword/None:                       preconcurrency[#Struct Attribute#]; name=preconcurrency
 // KEYWORD5-NEXT:             Keyword/None:                       typeWrapper[#Struct Attribute#]; name=typeWrapper
+// KEYWORD5-NEXT:             Keyword/None:                       runtimeMetadata[#Struct Attribute#]; name=runtimeMetadata
 // KEYWORD5-NEXT:             End completions
 
 @#^ON_GLOBALVAR^# var globalVar
@@ -312,6 +314,7 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       preconcurrency[#Declaration Attribute#]; name=preconcurrency
 // ON_MEMBER_LAST-DAG: Keyword/None:                       typeWrapper[#Declaration Attribute#]; name=typeWrapper
 // ON_MEMBER_LAST-DAG: Keyword/None:                       typeWrapperIgnored[#Declaration Attribute#]; name=typeWrapperIgnored
+// ON_MEMBER_LAST-DAG: Keyword/None:                       runtimeMetadata[#Declaration Attribute#]; name=runtimeMetadata
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
@@ -383,6 +386,7 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       preconcurrency[#Declaration Attribute#]; name=preconcurrency
 // KEYWORD_LAST-DAG: Keyword/None:                       typeWrapper[#Declaration Attribute#]; name=typeWrapper
 // KEYWORD_LAST-DAG: Keyword/None:                       typeWrapperIgnored[#Declaration Attribute#]; name=typeWrapperIgnored
+// KEYWORD_LAST-DAG: Keyword/None:                       runtimeMetadata[#Declaration Attribute#]; name=runtimeMetadata
 // KEYWORD_LAST-NOT: Keyword
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper


### PR DESCRIPTION
An attribute that could be used to declare a runtime discoverable attribute and
an experimental flag that enables its use.

Depends on https://github.com/apple/swift-syntax/pull/1079

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
