### PR TITLE
[CSSyntaxElement] Detect type variables in sequence expressions of `for-in` loops

### DIFF
--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2226,6 +2226,22 @@ void ConjunctionElement::findReferencedVariables(
 
   TypeVariableRefFinder refFinder(cs, locator->getAnchor(), typeVars);
 
+  // If this is a pattern of `for-in` statement, let's walk into `for-in`
+  // sequence expression because both elements are type-checked together.
+  //
+  // Correct expressions wouldn't have any type variables in sequence but
+  // they could appear due to circular references or other incorrect syntax.
+  if (element.is<Pattern *>()) {
+    if (auto parent =
+            locator->getLastElementAs<LocatorPathElt::SyntacticElement>()) {
+      if (auto *forEach = getAsStmt<ForEachStmt>(parent->getElement())) {
+        if (auto *sequence = forEach->getParsedSequence())
+          sequence->walk(refFinder);
+        return;
+      }
+    }
+  }
+
   if (auto *patternBinding =
           dyn_cast_or_null<PatternBindingDecl>(element.dyn_cast<Decl *>())) {
     // Let's not walk into placeholder variable initializers, since they

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar100753270.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar100753270.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Location {
+  var host: String?
+}
+
+struct Data: Hashable {
+  func location() -> Location {
+    fatalError()
+  }
+}
+
+struct Test { // expected-note {{to match this opening '{'}}
+  private struct Info {
+    var data = Set<Data>()
+    var desc: String
+  }
+
+  static func print(data: [Data]) {
+    var infos = [Info]()
+
+    for (index, info) in infos.enumerated() {
+      let dataPerHost = Dictionary(grouping: info.data) { data in
+        let location = data.location()
+        guard let host = location.host else {
+          return 0
+        }
+
+        for character in host {
+        // Missing paren!
+      }
+
+      for _ in dataPerHost { // `dataPerHost` is inside of the closure!
+      }
+    }
+  }
+} // expected-error@+1 {{expected '}' in struct}}


### PR DESCRIPTION
Invalid syntax could introduce type variables into sequence 
which have to be brought into scope otherwise solver is going to crash.

Resolves: rdar://100753270

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
