### PR TITLE
Avoid using strndup in TupleImpl::childMetadata

### DIFF
--- a/stdlib/public/runtime/ReflectionMirror.cpp
+++ b/stdlib/public/runtime/ReflectionMirror.cpp
@@ -40,24 +40,6 @@
 #include "SwiftObject.h"
 #endif
 
-#if defined(_WIN32)
-#include <stdarg.h>
-
-namespace {
-char *strndup(const char *s, size_t n) {
-  size_t length = std::min(strlen(s), n);
-
-  char *buffer = reinterpret_cast<char *>(malloc(length + 1));
-  if (buffer == nullptr)
-    return buffer;
-
-  strncpy(buffer, s, length);
-  buffer[length] = '\0';
-  return buffer;
-}
-}
-#endif
-
 using namespace swift;
 
 namespace {
@@ -261,7 +243,12 @@ struct TupleImpl : ReflectionMirrorImpl {
 
       // If we have a label, create it.
       if (labels && space && labels != space) {
-        *outName = strndup(labels, space - labels);
+        size_t labelLen = space - labels;
+        char *label = (char *)malloc(labelLen + 1);
+        memcpy(label, labels, labelLen);
+        label[labelLen] = '\0'; // 0-terminate the string
+
+        *outName = label;
         hasLabel = true;
       }
     }


### PR DESCRIPTION
This is the only instance of using strndup in the runtime. Eliminating it enables us to remove the Windows-compat re-implementation of strndup as well. The motivation is to enable building the freestanding/standalone Swift runtime *with reflection enabled* (which is not the case in the existing freestanding preset) in environments that might not provide strndup.