### PR TITLE
[Sema] printConstExprValue should consider negative signal when print number literals

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -215,8 +215,12 @@ bool Expr::printConstExprValue(llvm::raw_ostream *OS,
   }
   case ExprKind::IntegerLiteral:
   case ExprKind::FloatLiteral:  {
-    auto digits = cast<NumberLiteralExpr>(E)->getDigitsText();
+    const auto *NE = cast<NumberLiteralExpr>(E);
+    auto digits = NE->getDigitsText();
     assert(!digits.empty());
+    if (NE->getMinusLoc().isValid()) {
+      print("-");
+    }
     print(digits);
     return true;
   }

--- a/test/Sema/diag_dictionary_keys_duplicated.swift
+++ b/test/Sema/diag_dictionary_keys_duplicated.swift
@@ -227,3 +227,20 @@ let _: [Int: String] = [
   #column: "A", // expected-warning{{dictionary literal of type '[Int : String]' has duplicate entries for #column literal key}}
   #column: "B"  // expected-note{{duplicate key declared here}} {{3-16=}} {{227:15-16=}}
 ]
+
+// https://github.com/apple/swift/issues/62117
+_ = [
+  -1: "",
+  1: "",
+]
+
+_ = [
+  -1.0: "",
+  1.0: "",
+]
+
+_ = [
+  // expected-note@+1{{duplicate key declared}} {{3-9=}} {{9-10=}} 
+  -1: "", // expected-warning{{dictionary literal of type '[Int : String]' has duplicate entries for integer literal key '-1'}}
+  -1: "", // expected-note{{duplicate key declared}} {{3-9=}} {{9-10=}}
+]


### PR DESCRIPTION
<!-- What's in this pull request? -->
Method that print number literal(integer and floating point literals) as string value should consider negative numbers as well, otherwise string representation of expression value is incorrect. 

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves: https://github.com/apple/swift/issues/62117
Resolves: rdar://102171833

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
