### PR TITLE
[Profiler] Fix over-eager assert

### DIFF
--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -191,8 +191,8 @@ namespace {
 template <typename F>
 ASTWalker::PreWalkAction
 visitFunctionDecl(ASTWalker &Walker, AbstractFunctionDecl *AFD, F Func) {
-  assert(AFD->hasBody());
   if (Walker.Parent.isNull()) {
+    assert(AFD->hasBody());
     Func();
     return ASTWalker::Action::Continue();
   }
@@ -207,14 +207,14 @@ shouldWalkIntoExpr(Expr *E, ASTWalker::ParentTy Parent, SILDeclRef Constant) {
   // Profiling for closures should be handled separately. Do not visit
   // closure expressions twice.
   if (auto *CE = dyn_cast<AbstractClosureExpr>(E)) {
-    assert(CE->hasBody());
-
     // A non-null parent means we have a closure child, which we will visit
     // separately. Even if the parent is null, don't walk into a closure if the
     // SILDeclRef is not for a closure, as it could be for a property
     // initializer instead.
     if (!Parent.isNull() || !Constant || !Constant.getAbstractClosureExpr())
       return Action::SkipChildren(E);
+
+    assert(CE->hasBody());
   }
   return Action::Continue(E);
 }

--- a/test/Profiler/rdar102405053.swift
+++ b/test/Profiler/rdar102405053.swift
@@ -1,0 +1,4 @@
+// rdar://102405053 – Make sure we can handle skipped bodies at the top level.
+// RUN: %target-swift-frontend -emit-module -experimental-skip-non-inlinable-function-bodies-without-types -profile-generate -profile-coverage-mapping %s
+
+func foo() {}


### PR DESCRIPTION
We may have a skipped function body when walking over a SourceFile to profile top-level code, adjust the assertion so we ignore cases that we don't want to profile anyway.

rdar://102405053