### PR TITLE
[ConstraintSystem] Add locator path elements for pack expansion patterns and pack shapes.

### DIFF
--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -198,6 +198,9 @@ CUSTOM_LOCATOR_PATH_ELT(PackElement)
 /// The shape of a parameter pack.
 SIMPLE_LOCATOR_PATH_ELT(PackShape)
 
+/// The pattern  of a pack expansion.
+SIMPLE_LOCATOR_PATH_ELT(PackExpansionPattern)
+
 /// An unresolved member.
 SIMPLE_LOCATOR_PATH_ELT(UnresolvedMember)
 

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -195,6 +195,9 @@ CUSTOM_LOCATOR_PATH_ELT(PackType)
 /// An element of a pack type - the T in <T, U, V, ...>
 CUSTOM_LOCATOR_PATH_ELT(PackElement)
 
+/// The shape of a parameter pack.
+SIMPLE_LOCATOR_PATH_ELT(PackShape)
+
 /// An unresolved member.
 SIMPLE_LOCATOR_PATH_ELT(UnresolvedMember)
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6407,8 +6407,6 @@ public:
   void visitElementArchetypeType(ElementArchetypeType *T) {
     if (Options.PrintForSIL) {
       Printer << "@element(\"" << T->getOpenedElementID() << ") ";
-      visit(T->getGenericEnvironment()->getOpenedExistentialType());
-      Printer << ") ";
 
       auto interfaceTy = T->getInterfaceType();
       visit(interfaceTy);

--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -314,14 +314,35 @@ CanPackType PackType::getReducedShape() {
 }
 
 CanType TypeBase::getReducedShape() {
-  if (auto *packArchetype = getAs<PackArchetypeType>())
-    return packArchetype->getReducedShape();
-
   if (auto *packType = getAs<PackType>())
     return packType->getReducedShape();
 
   if (auto *expansionType = getAs<PackExpansionType>())
     return expansionType->getReducedShape();
+
+  struct PatternTypeWalker : public TypeWalker {
+    CanType shapeType;
+
+    Action walkToTypePre(Type type) override {
+      // Don't consider pack references inside nested pack
+      // expansion types.
+      if (type->is<PackExpansionType>()) {
+        return Action::Stop;
+      }
+
+      if (auto *archetype = type->getAs<PackArchetypeType>()) {
+        shapeType = archetype->getReducedShape();
+        return Action::Stop;
+      }
+
+      return Action::Continue;
+    }
+  } patternTypeWalker;
+
+  Type(this).walk(patternTypeWalker);
+
+  if (patternTypeWalker.shapeType)
+    return patternTypeWalker.shapeType;
 
   assert(!isTypeVariableOrMember());
   assert(!hasTypeParameter());

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2918,10 +2918,12 @@ namespace {
         CS.setType(binding, type);
       }
 
-      auto elementResultType = CS.getType(expr->getPatternExpr());
-      auto patternTy = CS.createTypeVariable(CS.getConstraintLocator(expr),
+      auto *patternLoc =
+          CS.getConstraintLocator(expr, ConstraintLocator::PackExpansionPattern);
+      auto patternTy = CS.createTypeVariable(patternLoc,
                                              TVO_CanBindToPack |
                                              TVO_CanBindToHole);
+      auto elementResultType = CS.getType(expr->getPatternExpr());
       CS.addConstraint(ConstraintKind::PackElementOf, elementResultType,
                        patternTy, CS.getConstraintLocator(expr));
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2925,20 +2925,15 @@ namespace {
       CS.addConstraint(ConstraintKind::PackElementOf, elementResultType,
                        patternTy, CS.getConstraintLocator(expr));
 
-      // FIXME: Use a ShapeOf constraint here.
-      Type shapeType;
-      auto *binding = expr->getBindings().front();
-      auto type = CS.simplifyType(CS.getType(binding));
-      type.visit([&](Type type) {
-        if (shapeType)
-          return;
+      auto *shapeLoc =
+          CS.getConstraintLocator(expr, ConstraintLocator::PackShape);
+      auto *shapeTypeVar = CS.createTypeVariable(shapeLoc,
+                                                 TVO_CanBindToPack |
+                                                 TVO_CanBindToHole);
+      CS.addConstraint(ConstraintKind::ShapeOf, patternTy, shapeTypeVar,
+                       CS.getConstraintLocator(expr));
 
-        if (auto archetype = type->getAs<PackArchetypeType>()) {
-          shapeType = archetype->getReducedShape();
-        }
-      });
-
-      return PackExpansionType::get(patternTy, shapeType);
+      return PackExpansionType::get(patternTy, shapeTypeVar);
     }
 
     Type visitDynamicTypeExpr(DynamicTypeExpr *expr) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2423,14 +2423,17 @@ static PackType *replaceTypeVariablesWithFreshPacks(ConstraintSystem &cs,
       // wrapping a pack type variable. Otherwise, create a new scalar
       // type variable.
       //
-      // FIXME: Locator for diagnostics
       // FIXME: Other TVO_* flags for type variables?
+      auto elementLoc = cs.getConstraintLocator(loc,
+          LocatorPathElt::PackElement(freshTypeVars.size()));
       if (packExpansionElt != nullptr) {
-        auto *freshTypeVar = cs.createTypeVariable(loc, TVO_CanBindToPack);
+        auto *freshTypeVar =
+            cs.createTypeVariable(elementLoc, TVO_CanBindToPack);
         freshTypeVars.push_back(PackExpansionType::get(
             freshTypeVar, packExpansionElt->getCountType()));
       } else {
-        freshTypeVars.push_back(cs.createTypeVariable(loc, /*options=*/0));
+        freshTypeVars.push_back(
+            cs.createTypeVariable(elementLoc, /*options=*/0));
       }
     }
   }
@@ -2483,7 +2486,6 @@ static PackType *replaceTypeVariablesWithFreshPacks(ConstraintSystem &cs,
   // Bind each pack type variable occurring in the pattern type to its
   // binding pack that was constructed above.
   for (const auto &pair : typeVars) {
-    // FIXME: Locator for diagnostics
     cs.addConstraint(ConstraintKind::Bind,
                      pair.first, PackType::get(ctx, pair.second), locator);
   }
@@ -2521,7 +2523,6 @@ ConstraintSystem::matchPackExpansionTypes(PackExpansionType *expansion1,
     if (auto *pack2 = pattern2->getAs<PackType>()) {
       if (auto *pack1 = replaceTypeVariablesWithFreshPacks(
              *this, pattern1, pack2, locator)) {
-        // FIXME: Locator for diagnostics.
         addConstraint(kind, pack1, pack2, locator);
         return getTypeMatchSuccess();
       }
@@ -2537,7 +2538,6 @@ ConstraintSystem::matchPackExpansionTypes(PackExpansionType *expansion1,
     if (auto *pack1 = pattern1->getAs<PackType>()) {
       if (auto *pack2 = replaceTypeVariablesWithFreshPacks(
               *this, pattern2, pack1, locator)) {
-        // FIXME: Locator for diagnostics.
         addConstraint(kind, pack1, pack2, locator);
         return getTypeMatchSuccess();
       }
@@ -6849,8 +6849,6 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                             kind, subflags, packLoc);
     }
     case TypeKind::PackExpansion: {
-      // FIXME: Need a new locator element
-
       auto expansion1 = cast<PackExpansionType>(desugar1);
       auto expansion2 = cast<PackExpansionType>(desugar2);
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -7559,9 +7559,10 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifySubclassOfConstraint(
     for (unsigned i = 0, e = packType->getNumElements(); i < e; ++i) {
       auto eltType = packType->getElementType(i);
       if (auto *packExpansionType = eltType->getAs<PackExpansionType>()) {
-        // FIXME: Locator element for pack expansion pattern
+        auto patternLoc =
+            locator.withPathElement(ConstraintLocator::PackExpansionPattern);
         addConstraint(ConstraintKind::SubclassOf, packExpansionType->getPatternType(),
-                      classType, locator.withPathElement(LocatorPathElt::PackElement(i)));
+                      classType, patternLoc);
       } else {
         addConstraint(ConstraintKind::SubclassOf, eltType,
                       classType, locator.withPathElement(LocatorPathElt::PackElement(i)));
@@ -7677,11 +7678,12 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     for (unsigned i = 0, e = packType->getNumElements(); i < e; ++i) {
       auto eltType = packType->getElementType(i);
       if (auto *packExpansionType = eltType->getAs<PackExpansionType>()) {
-        // FIXME: Locator element for pack expansion pattern
+        auto patternLoc =
+            locator.withPathElement(ConstraintLocator::PackExpansionPattern);
         addConstraint(ConstraintKind::ConformsTo,
                       packExpansionType->getPatternType(),
                       protocol->getDeclaredInterfaceType(),
-                      locator.withPathElement(LocatorPathElt::PackElement(i)));
+                      patternLoc);
       } else {
         addConstraint(ConstraintKind::ConformsTo, eltType,
                       protocol->getDeclaredInterfaceType(),

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2498,10 +2498,9 @@ ConstraintSystem::matchPackExpansionTypes(PackExpansionType *expansion1,
                                           ConstraintKind kind, TypeMatchOptions flags,
                                           ConstraintLocatorBuilder locator) {
   // The count types of two pack expansion types must have the same shape.
-  //
-  // FIXME: Locator for diagnostics.
-  auto *loc = getConstraintLocator(locator);
-  auto *shapeTypeVar = createTypeVariable(loc, TVO_CanBindToPack);
+  auto *shapeLoc = getConstraintLocator(
+      locator.withPathElement(ConstraintLocator::PackShape));
+  auto *shapeTypeVar = createTypeVariable(shapeLoc, TVO_CanBindToPack);
   addConstraint(ConstraintKind::ShapeOf,
                 expansion1->getCountType(), shapeTypeVar, locator);
   addConstraint(ConstraintKind::ShapeOf,
@@ -14156,8 +14155,9 @@ void ConstraintSystem::addConstraint(Requirement req,
     auto type1 = req.getFirstType();
     auto type2 = req.getSecondType();
 
-    // FIXME: Locator for diagnostics
-    auto typeVar = createTypeVariable(getConstraintLocator(locator),
+    auto *shapeLoc = getConstraintLocator(
+        locator.withPathElement(ConstraintLocator::PackShape));
+    auto typeVar = createTypeVariable(shapeLoc,
                                       TVO_CanBindToPack);
 
     addConstraint(ConstraintKind::ShapeOf, type1, typeVar, locator);

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -97,6 +97,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::SyntacticElement:
   case ConstraintLocator::PackType:
   case ConstraintLocator::PackElement:
+  case ConstraintLocator::PackShape:
   case ConstraintLocator::PatternBindingElement:
   case ConstraintLocator::NamedPatternDecl:
   case ConstraintLocator::AnyPatternDecl:
@@ -441,6 +442,11 @@ void LocatorPathElt::dump(raw_ostream &out) const {
   case ConstraintLocator::PackElement: {
     auto packElt = elt.castTo<LocatorPathElt::PackElement>();
     out << "pack element #" << llvm::utostr(packElt.getIndex());
+    break;
+  }
+
+  case ConstraintLocator::PackShape: {
+    out << "pack shape";
     break;
   }
 

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -436,9 +436,11 @@ void LocatorPathElt::dump(raw_ostream &out) const {
     break;
   }
 
-  case ConstraintLocator::ConstraintLocator::PackType:
-    out << "pack type";
+  case ConstraintLocator::ConstraintLocator::PackType: {
+    auto packElt = elt.castTo<LocatorPathElt::PackType>();
+    out << "pack type '" << packElt.getType()->getString(PO) << "'";
     break;
+  }
 
   case ConstraintLocator::PackElement: {
     auto packElt = elt.castTo<LocatorPathElt::PackElement>();

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -98,6 +98,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::PackType:
   case ConstraintLocator::PackElement:
   case ConstraintLocator::PackShape:
+  case ConstraintLocator::PackExpansionPattern:
   case ConstraintLocator::PatternBindingElement:
   case ConstraintLocator::NamedPatternDecl:
   case ConstraintLocator::AnyPatternDecl:
@@ -447,6 +448,11 @@ void LocatorPathElt::dump(raw_ostream &out) const {
 
   case ConstraintLocator::PackShape: {
     out << "pack shape";
+    break;
+  }
+
+  case ConstraintLocator::PackExpansionPattern: {
+    out << "pack expansion pattern";
     break;
   }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5330,6 +5330,14 @@ void constraints::simplifyLocator(ASTNode &anchor,
     case ConstraintLocator::PackShape:
       break;
 
+    case ConstraintLocator::PackExpansionPattern: {
+      if (auto *expansion = getAsExpr<PackExpansionExpr>(anchor))
+        anchor = expansion->getPatternExpr();
+
+      path = path.slice(1);
+      break;
+    }
+
     case ConstraintLocator::PatternBindingElement: {
       auto pattern = path[0].castTo<LocatorPathElt::PatternBindingElement>();
       auto *patternBinding = cast<PatternBindingDecl>(anchor.get<Decl *>());

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5327,6 +5327,7 @@ void constraints::simplifyLocator(ASTNode &anchor,
       break;
 
     case ConstraintLocator::PackElement:
+    case ConstraintLocator::PackShape:
       break;
 
     case ConstraintLocator::PatternBindingElement: {


### PR DESCRIPTION
Attach these locators to type variables created for pack expansion patterns and pack shapes, as well as a few other pack-specific constraints. Note that `matchTypes` already appends two `PackType` path elements before calling `matchPackTypes`, which covers the other FIXME comments about adding specific locators.