### PR TITLE
Optimize empty Sets which are initialized with array literals

### DIFF
--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -212,11 +212,17 @@ extension Set: ExpressibleByArrayLiteral {
   ///
   /// - Parameter elements: A variadic list of elements of the new set.
   @inlinable
+  @inline(__always)
   public init(arrayLiteral elements: Element...) {
     if elements.isEmpty {
       self.init()
       return
     }
+    self.init(_nonEmptyArrayLiteral: elements)
+  }
+
+  @_alwaysEmitIntoClient
+  internal init(_nonEmptyArrayLiteral elements: [Element]) {
     let native = _NativeSet<Element>(capacity: elements.count)
     for element in elements {
       let (bucket, found) = native.find(element)

--- a/test/SILOptimizer/set.swift
+++ b/test/SILOptimizer/set.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend  -parse-as-library -primary-file %s -O -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend  -parse-as-library -primary-file %s -Osize -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+// REQUIRES: swift_in_compiler
+
+// Test optimal code generation for creating empty sets.
+
+// CHECK-LABEL: sil @$s4test30createEmptySetFromArrayLiteralShySiGyF
+// CHECK:         global_addr @_swiftEmptySetSingleton
+// CHECK-NOT:     apply
+// CHECK:       } // end sil function '$s4test30createEmptySetFromArrayLiteralShySiGyF'
+public func createEmptySetFromArrayLiteral() -> Set<Int> {
+    return []
+}
+
+// CHECK-LABEL: sil @$s4test29createEmptySetWithInitializerShySiGyF
+// CHECK:         global_addr @_swiftEmptySetSingleton
+// CHECK-NOT:     apply
+// CHECK:       } // end sil function '$s4test29createEmptySetWithInitializerShySiGyF'
+public func createEmptySetWithInitializer() -> Set<Int> {
+    return Set<Int>()
+}
+
+// CHECK-LABEL: sil @$s4test17createNonEmptySetShySiGyF
+// CHECK:         global_value
+// CHECK:         [[F:%[0-9]+]] = function_ref @$sSh21_nonEmptyArrayLiteralShyxGSayxG_tcfCSi_Tg5
+// CHECK:         apply [[F]]
+// CHECK:       } // end sil function '$s4test17createNonEmptySetShySiGyF'
+public func createNonEmptySet() -> Set<Int> {
+    return [1, 2, 3]
+}
+


### PR DESCRIPTION
For example:
```
func foo() -> Set<Int> {
  return []
}
```

Initializing a set with an empty array literal boils down to very minimal code - if the corresponding Set initializer is inlined.

rdar://53509655