### PR TITLE
[AST] `getParameterAt` should check index before retrieving it

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7815,7 +7815,7 @@ const ParamDecl *swift::getParameterAt(ConcreteDeclRef declRef,
 const ParamDecl *swift::getParameterAt(const ValueDecl *source,
                                        unsigned index) {
   if (auto *params = getParameterList(const_cast<ValueDecl *>(source))) {
-    return params->get(index);
+    return index < params->size() ? params->get(index) : nullptr;
   }
   return nullptr;
 }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -907,6 +907,8 @@ void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {
   case SILDeclRef::Kind::DefaultArgGenerator: {
     auto *decl = constant.getDecl();
     auto *param = getParameterAt(decl, constant.defaultArgIndex);
+    assert(param);
+
     auto *initDC = param->getDefaultArgumentInitContext();
 
     switch (param->getDefaultArgumentKind()) {

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -254,6 +254,7 @@ void SILGenFunction::emitCaptures(SILLocation loc,
       if (closure.kind == SILDeclRef::Kind::DefaultArgGenerator) {
         auto *param = getParameterAt(closure.getDecl(),
                                      closure.defaultArgIndex);
+        assert(param);
         loc = param->getLoc();
       } else {
         auto f = *closure.getAnyFunctionRef();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5497,6 +5497,7 @@ Solution::resolveLocatorToDecl(ConstraintLocator *locator) const {
 static ConcreteDeclRef getDefaultArgOwner(ConcreteDeclRef owner,
                                           unsigned index) {
   auto *param = getParameterAt(owner.getDecl(), index);
+  assert(param);
   if (param->getDefaultArgumentKind() == DefaultArgumentKind::Inherited) {
     return getDefaultArgOwner(owner.getOverriddenDecl(), index);
   }
@@ -6034,6 +6035,8 @@ ArgumentList *ExprRewriter::coerceCallArguments(
 
     if (paramInfo.hasExternalPropertyWrapper(paramIdx)) {
       auto *paramDecl = getParameterAt(callee.getDecl(), paramIdx);
+      assert(paramDecl);
+
       auto appliedWrapper = appliedPropertyWrappers[appliedWrapperIndex++];
       auto wrapperType = solution.simplifyType(appliedWrapper.wrapperType);
       auto initKind = appliedWrapper.initKind;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1898,6 +1898,7 @@ static ConstraintSystem::TypeMatchResult matchCallArguments(
       auto argLabel = argument.getLabel();
       if (paramInfo.hasExternalPropertyWrapper(argIdx) || argLabel.hasDollarPrefix()) {
         auto *param = getParameterAt(callee, argIdx);
+        assert(param);
         if (cs.applyPropertyWrapperToParameter(paramTy, argTy, const_cast<ParamDecl *>(param),
                                                argLabel, subKind, loc).isFailure()) {
           return cs.getTypeMatchFailure(loc);
@@ -10535,6 +10536,8 @@ static Type getOpenedResultBuilderTypeFor(ConstraintSystem &cs,
     return Type();
 
   auto *PD = getParameterAt(choice, argToParamElt->getParamIdx());
+  assert(PD);
+
   auto builderType = PD->getResultBuilderType();
   if (!builderType)
     return Type();

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -697,12 +697,16 @@ CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current) const {
                 
                 if (currParams[i].getPlainType()->getOptionalObjectType()) {
                   optionalRedecl = true;
-                  if (swift::getParameterAt(current, i)->isImplicitlyUnwrappedOptional())
+                  auto *param = swift::getParameterAt(current, i);
+                  assert(param);
+                  if (param->isImplicitlyUnwrappedOptional())
                     currIsIUO = true;
                 }
                 
                 if (otherParams[i].getPlainType()->getOptionalObjectType()) {
-                  if (swift::getParameterAt(other, i)->isImplicitlyUnwrappedOptional())
+                  auto *param = swift::getParameterAt(other, i);
+                  assert(param);
+                  if (param->isImplicitlyUnwrappedOptional())
                     otherIsIUO = true;
                 }
                 else {

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar102085039.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar102085039.swift
@@ -1,0 +1,40 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol ResultType {
+  associatedtype E
+  associatedtype F
+
+  func failure() -> F?
+}
+
+extension Result: ResultType {
+  typealias E = Success
+  typealias F = Failure
+
+  func failure() -> F? { fatalError() }
+}
+
+protocol ObservableType {
+    associatedtype Element
+}
+
+class Observable<Element> : ObservableType {
+  func flatMap<Source: ObservableType>(_ selector: @escaping (Element) throws -> Source) -> Observable<Source.Element> {
+    fatalError()
+  }
+
+  static func just(_ element: Element) -> Observable<Element> {
+    fatalError()
+  }
+}
+
+extension Observable where Element: ResultType {
+  func mapGenericError() -> Observable<Result<Element.E, Error>> {
+    flatMap { result -> Observable<Result<Element.E, Error>> in
+      if let error = result.failure() as? Error {
+        return .just(Result.failure(error)) // Ok
+      }
+      fatalError()
+    }
+  }
+}


### PR DESCRIPTION
`getParameterAt` needs to be more defensive about the input 
because caller cannot always perform all the checks upfront.

Resolves: rdar://102085039

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
