### PR TITLE
[AddressLowering] Fix synthesized ParamDecl.

### DIFF
--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -553,6 +553,12 @@ static unsigned insertIndirectReturnArgs(AddressLoweringState &pass) {
   auto &astCtx = pass.getModule()->getASTContext();
   auto typeCtx = pass.function->getTypeExpansionContext();
   auto *declCtx = pass.function->getDeclContext();
+  if (!declCtx) {
+    // Fall back to using the module as the decl context if the function
+    // doesn't have one.  The can happen with default argument getters, for
+    // example.
+    declCtx = pass.function->getModule().getSwiftModule();
+  }
 
   unsigned argIdx = 0;
   for (auto resultTy : pass.loweredFnConv.getIndirectSILResultTypes(typeCtx)) {

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -135,6 +135,7 @@
 #define DEBUG_TYPE "address-lowering"
 
 #include "PhiStorageOptimizer.h"
+#include "swift/AST/Decl.h"
 #include "swift/Basic/BlotSetVector.h"
 #include "swift/Basic/Range.h"
 #include "swift/SIL/BasicBlockUtils.h"
@@ -559,6 +560,7 @@ static unsigned insertIndirectReturnArgs(AddressLoweringState &pass) {
     auto var = new (astCtx) ParamDecl(
         SourceLoc(), SourceLoc(), astCtx.getIdentifier("$return_value"),
         SourceLoc(), astCtx.getIdentifier("$return_value"), declCtx);
+    var->setSpecifier(ParamSpecifier::InOut);
 
     SILFunctionArgument *funcArg =
         pass.function->begin()->insertFunctionArgument(

--- a/test/SILOptimizer/opaque_values_O.swift
+++ b/test/SILOptimizer/opaque_values_O.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -enable-sil-opaque-values -parse-as-library -emit-sil -O %s | %FileCheck %s
+
+// Verify the arguments.  When AccessPathVerification runs, it will be checked
+// that the ParamDecl that AddressLowering synthesizes has a specifier
+// (ParamSpecifier) set.
+// CHECK-LABEL: sil @$s15opaque_values_O3minyxx_xtSLRzlF : {{.*}} {
+// CHECK:       bb0(%0 : $*T, %1 : $*T, %2 : $*T):
+// CHECK-LABEL: } // end sil function '$s15opaque_values_O3minyxx_xtSLRzlF'
+public func min<T: Comparable>(_ x: T, _ y: T) -> T {
+  return y < x ? y : x
+}

--- a/test/SILOptimizer/opaque_values_O_resilient.swift
+++ b/test/SILOptimizer/opaque_values_O_resilient.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend -enable-sil-opaque-values -parse-as-library -emit-sil -O -enable-library-evolution %s | %FileCheck %s
+
+public struct Gadget {
+// Verify the default accessor's arguments.  When AccessPathVerification runs,
+// it will be checked that the ParamDecl that AddressLowering synthesizes has a
+// non-null decl context.
+// CHECK-LABEL: sil @$s25opaque_values_O_resilient6GadgetV5whichA2C5WhichO_tcfC : {{.*}} {
+// CHECK:       bb0(%0 : $*Gadget, %1 : $*Gadget.Which, %2 : $@thin Gadget.Type):
+// CHECK-LABEL: } // end sil function '$s25opaque_values_O_resilient6GadgetV5whichA2C5WhichO_tcfC'
+  public init(which: Which = .that) {
+    fatalError()
+  }
+
+  public enum Which {
+    case that
+    case this(() -> Gadget)
+    case theOther
+  }
+}


### PR DESCRIPTION
AddressLowering creates a ParamDecl when rewriting indirect returns.  Fix that ParamDecl by
- setting its specifier to be InOut (matching SILGen)
- using the function's module as a fallback decl context if the function doesn't have a decl context
