### PR TITLE
SIL: Move the implementation of `Lowering::usesObjCAllocator()` to SIL

### DIFF
--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -953,3 +953,9 @@ SourceLoc swift::extractNearestSourceLoc(const SILModule *M) {
     return SourceLoc();
   return extractNearestSourceLoc(M->getSwiftModule());
 }
+
+bool Lowering::usesObjCAllocator(ClassDecl *theClass) {
+  // If the root class was implemented in Objective-C, use Objective-C's
+  // allocation methods because they may have been overridden.
+  return theClass->getObjectModel() == ReferenceCounting::ObjC;
+}

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -611,12 +611,6 @@ void SILGenFunction::emitEnumConstructor(EnumElementDecl *element) {
   }
 }
 
-bool Lowering::usesObjCAllocator(ClassDecl *theClass) {
-  // If the root class was implemented in Objective-C, use Objective-C's
-  // allocation methods because they may have been overridden.
-  return theClass->getObjectModel() == ReferenceCounting::ObjC;
-}
-
 void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
   assert(!ctor->isFactoryInit() && "factories should not be emitted here");
 


### PR DESCRIPTION
The definition of `Lowering::usesObjCAllocator()` was previously implemented in SILGen, which does not match the library membership of the declaration. The implementation of `SILSymbolVisitor` in the SIL library uses this and since SIL is a dependency of SILGen instead of vice-versa this resulted in a linker error.
