### PR TITLE
Deprecate Application-Specific Main Entrypoint Attributes

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3601,6 +3601,11 @@ ERROR(attr_ApplicationMain_with_script,none,
       "%" SELECT_APPLICATION_MAIN "0 attribute cannot be used in a module that contains "
       "top-level code",
       (unsigned))
+ERROR(attr_ApplicationMain_deprecated,none,
+      "%" SELECT_APPLICATION_MAIN "0 is deprecated",
+      (unsigned))
+NOTE(attr_ApplicationMain_deprecated_use_attr_main,none,
+     "use @main instead", ())
 
 NOTE(attr_ApplicationMain_parse_as_library,none,
      "pass '-parse-as-library' to compiler invocation if this is intentional",

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2340,6 +2340,16 @@ void AttributeChecker::checkApplicationMainAttribute(DeclAttribute *attr,
     attr->setInvalid();
   }
 
+  diagnose(attr->getLocation(),
+           diag::attr_ApplicationMain_deprecated,
+           applicationMainKind)
+    .warnUntilSwiftVersion(6);
+
+  diagnose(attr->getLocation(),
+           diag::attr_ApplicationMain_deprecated_use_attr_main)
+    .fixItReplace(attr->getRange(), "@main");
+
+
   if (attr->isInvalid())
     return;
 

--- a/test/TBD/objc-entry-point.swift
+++ b/test/TBD/objc-entry-point.swift
@@ -5,10 +5,11 @@
 import AppKit
 
 // Globals in non-script mode files that still have entry points
-// (via NSApplicationMain) _do_ have lazy initializers. Ensure the symbols are
+// (via `@NSApplicationMain`) _do_ have lazy initializers. Ensure the symbols are
 // present in the TBD.
 let globalConstantWithLazyInitializer: String = "hello, world"
 
-@NSApplicationMain
+@NSApplicationMain // expected-warning {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-1 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, NSApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_NSApplicationMain.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain.swift
@@ -4,6 +4,7 @@
 
 import AppKit
 
-@NSApplicationMain
+@NSApplicationMain // expected-warning {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-1 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, NSApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_inherited.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_inherited.swift
@@ -6,6 +6,7 @@ import AppKit
 
 class DelegateBase : NSObject, NSApplicationDelegate { }
 
-@NSApplicationMain
+@NSApplicationMain // expected-warning {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-1 {{use @main instead}} {{1-19=@main}}
 class MyDelegate : DelegateBase { }
 

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_multi_file/another_delegate.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_multi_file/another_delegate.swift
@@ -9,6 +9,8 @@
 import AppKit
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute can only apply to one class in a module}}
+// expected-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-2 {{use @main instead}} {{1-19=@main}}
 class EvilDelegate: NSObject, NSApplicationDelegate {
 }
 

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_multi_file/delegate.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_multi_file/delegate.swift
@@ -8,6 +8,8 @@
 import AppKit
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute can only apply to one class in a module}}
+// expected-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, NSApplicationDelegate {
 }
 

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_multiple.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_multiple.swift
@@ -5,13 +5,19 @@
 import AppKit
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute can only apply to one class in a module}}
+// expected-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate1: NSObject, NSApplicationDelegate {
 }
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute can only apply to one class in a module}}
+// expected-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate2: NSObject, NSApplicationDelegate {
 }
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute can only apply to one class in a module}}
+// expected-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate3: NSObject, NSApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_not_NSApplicationDelegate.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_not_NSApplicationDelegate.swift
@@ -5,5 +5,7 @@
 import AppKit
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' class must conform to the 'NSApplicationDelegate' protocol}}
+// expected-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyNonDelegate {
 }

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_swift6.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_swift6.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -swift-version 6 -typecheck -parse-as-library -verify %s
+
+// REQUIRES: objc_interop
+
+import AppKit
+
+@NSApplicationMain // expected-error {{'NSApplicationMain' is deprecated}}
+// expected-note@-1 {{use @main instead}} {{1-19=@main}}
+class MyDelegate: NSObject, NSApplicationDelegate {
+}

--- a/test/attr/ApplicationMain/attr_NSApplicationMain_with_main/delegate.swift
+++ b/test/attr/ApplicationMain/attr_NSApplicationMain_with_main/delegate.swift
@@ -8,6 +8,8 @@
 import AppKit
 
 @NSApplicationMain // expected-error{{'NSApplicationMain' attribute cannot be used in a module that contains top-level code}}
+// expected-warning@-1 {{'NSApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, NSApplicationDelegate {
 }
 

--- a/test/attr/ApplicationMain/attr_UIApplicationMain.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain.swift
@@ -4,6 +4,7 @@
 
 import UIKit
 
-@UIApplicationMain
+@UIApplicationMain // expected-warning {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-1 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, UIApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_UIApplicationMain_inherited.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain_inherited.swift
@@ -6,6 +6,7 @@ import UIKit
 
 class DelegateBase : NSObject, UIApplicationDelegate { }
 
-@UIApplicationMain
+@UIApplicationMain // expected-warning {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-1 {{use @main instead}} {{1-19=@main}}
 class MyDelegate : DelegateBase { }
 

--- a/test/attr/ApplicationMain/attr_UIApplicationMain_multiple.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain_multiple.swift
@@ -5,13 +5,19 @@
 import UIKit
 
 @UIApplicationMain // expected-error{{'UIApplicationMain' attribute can only apply to one class in a module}}
+// expected-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate1: NSObject, UIApplicationDelegate {
 }
 
 @UIApplicationMain // expected-error{{'UIApplicationMain' attribute can only apply to one class in a module}}
+// expected-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate2: NSObject, UIApplicationDelegate {
 }
 
 @UIApplicationMain // expected-error{{'UIApplicationMain' attribute can only apply to one class in a module}}
+// expected-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate3: NSObject, UIApplicationDelegate {
 }

--- a/test/attr/ApplicationMain/attr_UIApplicationMain_not_UIApplicationDelegate.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain_not_UIApplicationDelegate.swift
@@ -5,5 +5,7 @@
 import UIKit
 
 @UIApplicationMain // expected-error{{'UIApplicationMain' class must conform to the 'UIApplicationDelegate' protocol}}
+// expected-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyNonDelegate {
 }

--- a/test/attr/ApplicationMain/attr_UIApplicationMain_swift6.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain_swift6.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -swift-version 6 -typecheck -parse-as-library -verify %s
+
+// REQUIRES: objc_interop
+
+import UIKit
+
+@UIApplicationMain // expected-error {{'UIApplicationMain' is deprecated}}
+// expected-note@-1 {{use @main instead}} {{1-19=@main}}
+class MyDelegate: NSObject, UIApplicationDelegate {
+}

--- a/test/attr/ApplicationMain/attr_UIApplicationMain_with_main/delegate.swift
+++ b/test/attr/ApplicationMain/attr_UIApplicationMain_with_main/delegate.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 @UIApplicationMain // expected-error{{'UIApplicationMain' attribute cannot be used in a module that contains top-level code}}
+// expected-warning@-1 {{'UIApplicationMain' is deprecated; this is an error in Swift 6}}
+// expected-note@-2 {{use @main instead}} {{1-19=@main}}
 class MyDelegate: NSObject, UIApplicationDelegate {
 }
 


### PR DESCRIPTION
Issue a deprecation warning in Swift 5 and an error in Swift 6 when we encounter @UIApplicationMain and @NSApplicationMain. These attributes are unnecessary now that @main works with UIApplicationDelegate and NSApplicationDelegate. As these conformances are required when working with the corresponding attributes, we can migrate users off of them by replacing them with @main.