### PR TITLE
Allow a global-actor to be dropped for some non-async functions.

### DIFF
--- a/include/swift/AST/ActorIsolation.h
+++ b/include/swift/AST/ActorIsolation.h
@@ -238,6 +238,26 @@ bool isSameActorIsolated(ValueDecl *value, DeclContext *dc);
 /// Determines whether this function's body uses flow-sensitive isolation.
 bool usesFlowSensitiveIsolation(AbstractFunctionDecl const *fn);
 
+/// Check if it is safe for the \c globalActor qualifier to be removed from
+/// \c ty, when the function value of that type is isolated to that actor.
+///
+/// In general this is safe in a narrow but common case: a global actor
+/// qualifier can be dropped from a function type while in a DeclContext
+/// isolated to that same actor, as long as the value is not Sendable.
+///
+/// \param dc the innermost context in which the cast to remove the global actor
+///           is happening.
+/// \param globalActor global actor that was dropped from \c ty.
+/// \param ty a function type where \c globalActor was removed from it.
+/// \param getClosureActorIsolation function that knows how to produce accurate
+///        information about the isolation of a closure.
+/// \return true if it is safe to drop the global-actor qualifier.
+bool safeToDropGlobalActor(
+                DeclContext *dc, Type globalActor, Type ty,
+                llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>
+                    getClosureActorIsolation =
+                        _getRef__AbstractClosureExpr_getActorIsolation());
+
 void simple_display(llvm::raw_ostream &out, const ActorIsolation &state);
 
 } // end namespace swift

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -858,7 +858,7 @@ class MarkGlobalActorFunction final : public ContextualMismatch {
   }
 
 public:
-  std::string getName() const override { return "add @escaping"; }
+  std::string getName() const override { return "add global actor"; }
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -2750,7 +2750,7 @@ struct GetClosureType {
   Type operator()(const AbstractClosureExpr *expr) const;
 };
 
-/// Retrieve the closure type from the constraint system.
+/// Retrieve the closure's preconcurrency status from the constraint system.
 struct ClosureIsolatedByPreconcurrency {
   ConstraintSystem &cs;
 

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1526,6 +1526,41 @@ bool swift::isAsyncDecl(ConcreteDeclRef declRef) {
   return false;
 }
 
+bool swift::safeToDropGlobalActor(
+    DeclContext *dc, Type globalActor, Type ty,
+    llvm::function_ref<ClosureActorIsolation(AbstractClosureExpr *)>
+        getClosureActorIsolation) {
+  auto funcTy = ty->getAs<AnyFunctionType>();
+  if (!funcTy)
+    return false;
+
+  // can't add a different global actor
+  if (auto otherGA = funcTy->getGlobalActor()) {
+    assert(otherGA->getCanonicalType() != globalActor->getCanonicalType()
+           && "not even dropping the actor?");
+    return false;
+  }
+
+  // We currently allow unconditional dropping of global actors from
+  // async function types, despite this confusing Sendable checking
+  // in light of SE-338.
+  if (funcTy->isAsync())
+    return true;
+
+  // fundamentally cannot be sendable if we want to drop isolation info
+  if (funcTy->isSendable())
+    return false;
+
+  // finally, must be in a context with matching isolation.
+  auto dcIsolation = getActorIsolationOfContext(dc, getClosureActorIsolation);
+  if (dcIsolation.isGlobalActor())
+    if (dcIsolation.getGlobalActor()->getCanonicalType()
+        == globalActor->getCanonicalType())
+      return true;
+
+  return false;
+}
+
 static FuncDecl *findAnnotatableFunction(DeclContext *dc) {
   auto fn = dyn_cast<FuncDecl>(dc);
   if (!fn) return nullptr;
@@ -1735,6 +1770,41 @@ namespace {
       }
 
       return false;
+    }
+
+    /// Some function conversions synthesized by the constraint solver may not
+    /// be correct AND the solver doesn't know, so we must emit a diagnostic.
+    void checkFunctionConversion(FunctionConversionExpr *funcConv) {
+      auto subExprType = funcConv->getSubExpr()->getType();
+      if (auto fromType = subExprType->getAs<FunctionType>()) {
+        if (auto fromActor = fromType->getGlobalActor()) {
+          if (auto toType = funcConv->getType()->getAs<FunctionType>()) {
+
+            // ignore some kinds of casts, as they're diagnosed elsewhere.
+            if (toType->hasGlobalActor() || toType->isAsync())
+              return;
+
+            auto dc = const_cast<DeclContext*>(getDeclContext());
+            if (!safeToDropGlobalActor(dc, fromActor, toType)) {
+            // FIXME: this diagnostic is sometimes a duplicate of one emitted
+            // by the constraint solver. Difference is the solver doesn't use
+            // warnUntilSwiftVersion, which appends extra text on the end.
+            // So, I'm making the messages exactly the same so IDEs will
+            // hopefully ignore the second diagnostic!
+
+            // otherwise, it's not a safe cast.
+            dc->getASTContext()
+                .Diags
+                .diagnose(funcConv->getLoc(),
+                          diag::converting_func_loses_global_actor, fromType,
+                          toType, fromActor)
+                .limitBehavior(dc->getASTContext().isSwiftVersionAtLeast(6)
+                                   ? DiagnosticBehavior::Error
+                                   : DiagnosticBehavior::Warning);
+            }
+          }
+        }
+      }
     }
 
     /// Check closure captures for Sendable violations.
@@ -1992,6 +2062,11 @@ namespace {
         for (const auto &entry : captureList->getCaptureList()) {
           captureContexts[entry.getVar()].push_back(closure);
         }
+      }
+
+      // The constraint solver may not have chosen legal casts.
+      if (auto funcConv = dyn_cast<FunctionConversionExpr>(expr)) {
+        checkFunctionConversion(funcConv);
       }
 
       return Action::Continue(expr);

--- a/test/Concurrency/actor_call_implicitly_async.swift
+++ b/test/Concurrency/actor_call_implicitly_async.swift
@@ -298,7 +298,8 @@ func blender(_ peeler : () -> Void) {
   // expected-warning@-1 3{{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
 
   blender((peelBanana))
-  // expected-warning@-1{{converting function value of type '@BananaActor () -> ()' to '() -> Void' loses global actor 'BananaActor'}}
+  // expected-warning@-1 2{{converting function value of type '@BananaActor () -> ()' to '() -> Void' loses global actor 'BananaActor'}}
+
   await wisk(peelBanana)
   // expected-warning@-1{{non-sendable type 'Any' passed in call to global actor 'BananaActor'-isolated function cannot cross actor boundary}}
 

--- a/test/Concurrency/actor_isolation.swift
+++ b/test/Concurrency/actor_isolation.swift
@@ -463,7 +463,7 @@ func testGlobalActorClosures() {
     return 17
   }
 
-  acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-warning{{converting function value of type '@SomeGlobalActor @Sendable () -> Int' to '@Sendable () -> Int' loses global actor 'SomeGlobalActor'}}
+  acceptConcurrentClosure { @SomeGlobalActor in 5 } // expected-warning 2{{converting function value of type '@SomeGlobalActor @Sendable () -> Int' to '@Sendable () -> Int' loses global actor 'SomeGlobalActor'}}
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/test/Concurrency/global_actor_function_types.swift
+++ b/test/Concurrency/global_actor_function_types.swift
@@ -16,7 +16,7 @@ struct OtherGlobalActor {
 func testConversions(f: @escaping @SomeGlobalActor (Int) -> Void, g: @escaping (Int) -> Void) {
   let _: Int = f // expected-error{{cannot convert value of type '@SomeGlobalActor (Int) -> Void' to specified type 'Int'}}
 
-  let _: (Int) -> Void = f // expected-warning{{converting function value of type '@SomeGlobalActor (Int) -> Void' to '(Int) -> Void' loses global actor 'SomeGlobalActor'}}
+  let _: (Int) -> Void = f // expected-warning 2{{converting function value of type '@SomeGlobalActor (Int) -> Void' to '(Int) -> Void' loses global actor 'SomeGlobalActor'}}
   let _: @SomeGlobalActor (Int) -> Void = g // okay
 
   // FIXME: this could be better.
@@ -119,8 +119,18 @@ func testTypesNonConcurrencyContext() { // expected-note{{add '@SomeGlobalActor'
   let f1 = onSomeGlobalActor // expected-note{{calls to let 'f1' from outside of its actor context are implicitly asynchronous}}
   let f2 = onSomeGlobalActorUnsafe
 
-  let _: () -> Int = f1 // expected-warning{{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+  let _: () -> Int = f1 // expected-warning 2{{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
   let _: () -> Int = f2
+
+  _ = {
+    let _: () -> Int = f1 // expected-warning 2{{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+    let _: () -> Int = f2
+  }
+
+  @SomeGlobalActor func isolated() {
+    let _: () -> Int = f1
+    let _: () -> Int = f2
+  }
 
   _ = f1() // expected-error{{call to global actor 'SomeGlobalActor'-isolated let 'f1' in a synchronous nonisolated context}}
   _ = f2()
@@ -130,8 +140,26 @@ func testTypesConcurrencyContext() async {
   let f1 = onSomeGlobalActor
   let f2 = onSomeGlobalActorUnsafe
 
-  let _: () -> Int = f1 // expected-warning{{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
-  let _: () -> Int = f2 // expected-warning{{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+  let _: () -> Int = f1 // expected-warning 2{{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+  let _: () -> Int = f2 // expected-warning 2{{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+
+  _ = {
+    let _: () -> Int = f1 // expected-warning 2{{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+    let _: () -> Int = f2 // expected-warning 2{{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+  }
+
+  let _: @SomeGlobalActor () -> () = {
+    someGlobalActorFn()
+
+    // NOTE: false warnings. this closure has the correct isolation.
+    let _: () -> Int = f1 // expected-warning {{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+    let _: () -> Int = f2 // expected-warning {{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+  }
+
+  _ = { @SomeGlobalActor in
+    let _: () -> Int = f1
+    let _: () -> Int = f2
+  }
 
   // expected-error@+1{{expression is 'async' but is not marked with 'await'}}{{7-7=await }}
   _ = f1() //expected-note{{calls to let 'f1' from outside of its actor context are implicitly asynchronous}}
@@ -154,9 +182,164 @@ func test() {
   }
 }
 
+
 // https://github.com/apple/swift/issues/61436
 let x: @MainActor () -> Void
-
 let y: () -> Void = {}
-
 x = true ? y : y // Ok
+
+func noActor(_ unit: () -> ()) { unit() }
+@SomeGlobalActor func someGlobalActorFn() {}
+@MainActor func mainActorFn() {}
+
+@SomeGlobalActor func testDropActorInSameContext(_ f3: @SomeGlobalActor () -> (),
+                                                 _ sendable: @escaping @Sendable @SomeGlobalActor () -> ()) {
+  let f1 = onSomeGlobalActor
+  let f2 = onSomeGlobalActorUnsafe
+
+  let _: () -> Int = f1
+  let _: () -> Int = f2
+  noActor(f3)
+
+  // ok if you drop both sendable and the actor
+  noActor(sendable)
+  let _: () -> () = sendable
+  let _: @Sendable () -> () = sendable // expected-warning 2{{converting function value of type '@SomeGlobalActor @Sendable () -> ()' to '@Sendable () -> ()' loses global actor 'SomeGlobalActor'}}
+
+  _ = {
+    someGlobalActorFn()
+
+    // FIXME: false warnings. this closure is not @Sendable so it has matching isolation.
+    let _: () -> Int = f1 // expected-warning {{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+    let _: () -> Int = f2 // expected-warning {{converting function value of type '@SomeGlobalActor () -> Int' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+  }
+
+  _ = { @Sendable in
+    let _: () -> Int = sendable // expected-warning 2{{converting function value of type '@SomeGlobalActor @Sendable () -> ()' to '() -> Int' loses global actor 'SomeGlobalActor'}}
+  }
+}
+
+actor A {
+  func illegal(_ stillIllegal: @MainActor () -> ()) {
+    noActor(stillIllegal) // expected-warning 2{{converting function value of type '@MainActor () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+  }
+
+  func sendAndDrop(_ g: @escaping @Sendable @MainActor () -> ()) async {
+    _ = Task.detached { @MainActor in
+      // FIXME: this is a false warning, probably from the constraint solver.
+      noActor(g) // expected-warning {{converting function value of type '@MainActor @Sendable () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+    }
+
+    _ = Task {
+      // FIXME: this and many other warnings like this are emitted more than once, but are true warnings.
+      noActor(g) // expected-warning 2{{converting function value of type '@MainActor @Sendable () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+    }
+
+    _ = Task.detached {
+      noActor(g) // expected-warning 2{{converting function value of type '@MainActor @Sendable () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+    }
+  }
+}
+
+@MainActor func uhoh(_ f: @escaping @MainActor () -> (), _ sendableF: @escaping @Sendable @MainActor () -> ()) {
+
+  let _: () async -> () = f
+  let _: @Sendable () -> () = sendableF // expected-warning 2{{converting function value of type '@MainActor @Sendable () -> ()' to '@Sendable () -> ()' loses global actor 'MainActor'}}
+
+  let _: () -> () = {
+    noActor(f)
+  }
+
+  _ = { @Sendable in
+    noActor(mainActorFn) // expected-warning {{converting function value of type '@MainActor () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+  }
+
+  func local() {
+    noActor(f)
+    noActor(sendableF)
+    let _: () -> () = mainActorFn
+    let _: @Sendable () -> () = sendableF // expected-warning 2{{converting function value of type '@MainActor @Sendable () -> ()' to '@Sendable () -> ()' loses global actor 'MainActor'}}
+  }
+
+  _ = {
+    func localNested() {
+      noActor(f) // expected-warning 2{{converting function value of type '@MainActor () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+      noActor(sendableF) // expected-warning 2{{converting function value of type '@MainActor @Sendable () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+      let _: () -> () = mainActorFn // expected-warning 2{{converting function value of type '@MainActor () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+      let _: @Sendable () -> () = sendableF // expected-warning 2{{converting function value of type '@MainActor @Sendable () -> ()' to '@Sendable () -> ()' loses global actor 'MainActor'}}
+    }
+  }
+
+  defer {
+    noActor(f)
+    noActor(sendableF)
+    let _: () -> () = mainActorFn
+    let _: @Sendable () -> () = sendableF // expected-warning 2{{converting function value of type '@MainActor @Sendable () -> ()' to '@Sendable () -> ()' loses global actor 'MainActor'}}
+  }
+
+  @Sendable func localSendable() {
+    noActor(sendableF) // expected-warning 2{{converting function value of type '@MainActor @Sendable () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+    let _: () -> () = mainActorFn // expected-warning 2{{converting function value of type '@MainActor () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+  }
+
+  let _: () -> () = {
+    mainActorFn()  // FIXME: odd how this line alone causes the false warning below to be emitted.
+    noActor(f)  // expected-warning {{converting function value of type '@MainActor () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+  }
+
+  _ = {
+    // FIXME: more false warnings
+    noActor(f)  // expected-warning {{converting function value of type '@MainActor () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+    noActor(sendableF) // expected-warning {{converting function value of type '@MainActor @Sendable () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+  }
+
+  let _: () -> () = {
+    // FIXME: these are false warnings too.
+    noActor(f) // expected-warning {{converting function value of type '@MainActor () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+    let _: () -> () = mainActorFn // expected-warning {{converting function value of type '@MainActor () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+  }
+
+  let _: @SomeGlobalActor () -> () = {
+    noActor(sendableF) // expected-warning 2{{converting function value of type '@MainActor @Sendable () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+    let _: () -> () = mainActorFn // expected-warning 2{{converting function value of type '@MainActor () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+  }
+}
+
+func stripActor(_ expr: @Sendable @autoclosure () -> (() -> ())) async {
+  let f = expr()
+  return f()
+}
+
+// NOTE: this warning is correct, but is only being caught by TypeCheckConcurrency's extra check.
+@MainActor func exampleWhereConstraintSolverHasWrongDeclContext_v1() async {
+  return await stripActor(mainActorFn) // expected-warning {{converting function value of type '@MainActor () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+}
+
+// NOTE: this warning is correct, but is only being caught by TypeCheckConcurrency's extra check.
+@MainActor func exampleWhereConstraintSolverHasWrongDeclContext_v2() async -> Int {
+  async let a: () = noActor(mainActorFn) // expected-warning {{converting function value of type '@MainActor () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+  await a
+}
+
+@MainActor class MAIsolatedParent {}
+class SubClass: MAIsolatedParent {
+  func isoMethod() {
+    let _: () -> () = mainActorFn
+  }
+
+  nonisolated func exemptMethod() {
+    let _: () -> () = mainActorFn // expected-warning 2{{converting function value of type '@MainActor () -> ()' to '() -> ()' loses global actor 'MainActor'}}
+  }
+}
+
+@MainActor func forceRemovalOfMainActor() {
+  // expected to type-check as-is.
+  let f: () -> () = (true ? mainActorFn : {})
+  f()
+}
+
+@MainActor func forceAdditionOfMainActor() {
+  // expected to type-check as-is.
+  let f: @MainActor () -> () = (true ? mainActorFn : {})
+  f()
+}

--- a/test/Concurrency/predates_concurrency.swift
+++ b/test/Concurrency/predates_concurrency.swift
@@ -90,7 +90,7 @@ func testCallsWithAsync() async {
   onMainActorAlways() // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-1{{calls to global function 'onMainActorAlways()' from outside of its actor context are implicitly asynchronous}}
 
-  let _: () -> Void = onMainActorAlways // expected-warning{{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
+  let _: () -> Void = onMainActorAlways // expected-warning 2{{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
 
   let c = MyModelClass() // expected-error{{expression is 'async' but is not marked with 'await'}}
   // expected-note@-1{{calls to initializer 'init()' from outside of its actor context are implicitly asynchronous}}

--- a/validation-test/Sema/SwiftUI/rdar94462333.swift
+++ b/validation-test/Sema/SwiftUI/rdar94462333.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5
+
+// REQUIRES: concurrency
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+@MainActor func someMainActorFn() {}
+
+struct ContentView: View {
+  var body: some View {
+    VStack {
+      // In the future this warning should go away too, but it remains since the isolation of the closure
+      // passed to the VStack is not inferred yet during constraint solving.
+      // expected-warning@+1 {{converting function value of type '@MainActor () -> ()' to '() -> Void' loses global actor 'MainActor'}}
+      Button(action: someMainActorFn) {
+        Text("Sign In")
+      }
+    }
+  }
+}
+
+struct ContentViewExplicitAnnotation: View {
+  var body: some View {
+    VStack { @MainActor in
+      Button(action: someMainActorFn) {
+        Text("Sign In")
+      }
+    }
+  }
+}

--- a/validation-test/Sema/rdar94462333.swift
+++ b/validation-test/Sema/rdar94462333.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift  -disable-availability-checking
+
+// REQUIRES: concurrency
+// REQUIRES: OS=ios
+
+import UIKit
+
+@MainActor func issue(stackView: UIStackView) {
+  stackView.arrangedSubviews.forEach(stackView.removeArrangedSubview)
+}


### PR DESCRIPTION
It's ok to drop the global-actor qualifier `@G` from a function's type if:

- the cast is happening in a context isolated to global-actor `G`
- the function value will _not_ be `@Sendable`
- the function value is not async.

It's primarily safe to drop the attribute because we're already in the same isolation domain. So if we prevent the value from later leaving that isolation domain, it's OK to simply drop the global-actor. This means we no longer need to warn about code like this:

```
@MainActor func doIt(_ x: [Int], _ f: @MainActor (Int) -> ()) {
  x.forEach(f)
// warning: converting function value of type '@MainActor (Int) -> ()' to '(Int) throws -> Void' loses global actor 'MainActor'
}
```

resolves rdar://94462333

TODOs:
- [x] Resolve the tension between the constraint solver and TypeCheckConcurrency.
- [x] Break ties in the ranking of equivalent solutions in solver.