### PR TITLE
[stdlib] Do not allocate when creating a Set from a generic Sequence which happens to be another Set

### DIFF
--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -671,13 +671,12 @@ extension Set: SetAlgebra {
   @inlinable
   public init<Source: Sequence>(_ sequence: __owned Source)
   where Source.Element == Element {
-    self.init(minimumCapacity: sequence.underestimatedCount)
     if let s = sequence as? Set<Element> {
-      // If this sequence is actually a native `Set`, then we can quickly
-      // adopt its native buffer and let COW handle uniquing only
-      // if necessary.
-      self._variant = s._variant
+      // If this sequence is actually a `Set`, then we can quickly
+      // adopt its storage and let COW handle uniquing only if necessary.
+      self = s
     } else {
+      self.init(minimumCapacity: sequence.underestimatedCount)
       for item in sequence {
         insert(item)
       }


### PR DESCRIPTION
Previous implementation calls `.init(minimumCapacity:)`, allocating storage, and then sets the `_variant`, which deallocates that storage.

Also, the comment made it sound like this only applied to native `Set`s (perhaps excluding bridged sets?), but that does not appear to be the case. `_variant` is a plain, stored property - it will always be overwritten with the downcasted `Set`'s variant.