### PR TITLE
Use libcxx from Darwin SDKs when building LLVM and Swift (LLVM product)

### DIFF
--- a/utils/swift_build_support/swift_build_support/shell.py
+++ b/utils/swift_build_support/swift_build_support/shell.py
@@ -202,6 +202,15 @@ def symlink(source, dest, dry_run=None, echo=True):
     os.symlink(source, dest)
 
 
+def remove(path, dry_run=None, echo=True):
+    dry_run = _coerce_dry_run(dry_run)
+    if dry_run or echo:
+        _echo_command(dry_run, ['rm', path])
+    if dry_run:
+        return
+    os.remove(path)
+
+
 # Initialized later
 lock = None
 


### PR DESCRIPTION
Those are present since Xcode 12.5, so we don't need to copy them
anymore from the toolchain

In this scenario, clean up any existing symlink in incremental builds to
avoid masking or causing errors in the future.

Took the chance to extract this logic to a different function in an attempt to improve readability

To ease review, the PR has two commits -- the first to extract the logic as is (showing that I did not alter the existing logic) and the second one to change its behaviour for Darwin (and address a minor issue when printing about the creation of symlinks)

Addresses rdar://102387542