### PR TITLE
Remove swiftCompilerModules_SwiftSyntax library

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -16,7 +16,7 @@
 #
 function(add_swift_compiler_module module)
   cmake_parse_arguments(ALSM
-                        "ADD_TO_SYNTAXPARSE"
+                        ""
                         ""
                         "DEPENDS;SOURCES"
                         ${ARGN})
@@ -35,7 +35,6 @@ function(add_swift_compiler_module module)
 
   set_property(TARGET ${target_name} PROPERTY module_name ${module})
   set_property(TARGET ${target_name} PROPERTY module_depends ${ALSM_DEPENDS})
-  set_property(TARGET ${target_name} PROPERTY add_to_syntaxparse ${ALSM_ADD_TO_SYNTAXPARSE})
 
   get_property(modules GLOBAL PROPERTY swift_compiler_modules)
   set_property(GLOBAL PROPERTY swift_compiler_modules ${modules} ${module})
@@ -134,8 +133,6 @@ function(add_swift_compiler_modules_library name)
 
   set(all_obj_files)
   set(all_module_targets)
-  set(syntaxparse_obj_files)
-  set(syntaxparse_module_targets)
   get_property(modules GLOBAL PROPERTY "swift_compiler_modules")
   foreach(module ${modules})
 
@@ -143,7 +140,6 @@ function(add_swift_compiler_modules_library name)
     get_target_property(module ${module_target} "module_name")
     get_target_property(sources ${module_target} SOURCES)
     get_target_property(dependencies ${module_target} "module_depends")
-    get_target_property(add_to_syntaxparse ${module_target} "add_to_syntaxparse")
     set(deps, "")
     if (dependencies)
       foreach(dep_module ${dependencies})
@@ -163,9 +159,6 @@ function(add_swift_compiler_modules_library name)
     set_property(TARGET ${module_target} PROPERTY "module_file" "${module_file}")
 
     set(all_obj_files ${all_obj_files} ${module_obj_file})
-    if (add_to_syntaxparse)
-      set(syntaxparse_obj_files ${syntaxparse_obj_files} ${module_obj_file})
-    endif()
     set(c_include_paths
       # LLVM modules and headers.
       "${LLVM_MAIN_INCLUDE_DIR}"
@@ -201,9 +194,6 @@ function(add_swift_compiler_modules_library name)
 
     set("${module}_dep_target" ${dep_target})
     set(all_module_targets ${all_module_targets} ${dep_target})
-    if (add_to_syntaxparse)
-      set(syntaxparse_module_targets ${syntaxparse_module_targets} ${dep_target})
-    endif()
   endforeach()
 
   # Create a static library containing all module object files.
@@ -217,15 +207,6 @@ function(add_swift_compiler_modules_library name)
   add_dependencies(${name} ${all_module_targets})
   set_target_properties(${name} PROPERTIES LINKER_LANGUAGE CXX)
   set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${name})
-
-  if (XCODE)
-    set(syntaxparse_obj_files force_lib.c ${syntaxparse_obj_files})
-  endif()
-  add_library("${name}_SwiftSyntax" STATIC ${syntaxparse_obj_files})
-  add_dependencies("${name}_SwiftSyntax" ${syntaxparse_module_targets})
-  set_target_properties("${name}_SwiftSyntax" PROPERTIES LINKER_LANGUAGE CXX)
-  set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS "${name}_SwiftSyntax")
-
 endfunction()
 
 
@@ -235,7 +216,6 @@ add_swift_host_library(swiftCompilerStub OBJECT stubs.cpp)
 if (NOT BOOTSTRAPPING_MODE)
 
   add_library(swiftCompilerModules ALIAS swiftCompilerStub)
-  add_library(swiftCompilerModules_SwiftSyntax ALIAS swiftCompilerStub)
 
 else()
   # Note: "Swift" is not added intentionally here, because it would break

--- a/SwiftCompilerSources/Sources/AST/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/AST/CMakeLists.txt
@@ -7,7 +7,6 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_swift_compiler_module(AST
-  ADD_TO_SYNTAXPARSE
   DEPENDS
     Basic
   SOURCES

--- a/SwiftCompilerSources/Sources/Basic/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Basic/CMakeLists.txt
@@ -7,7 +7,6 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_swift_compiler_module(Basic
-  ADD_TO_SYNTAXPARSE
   SOURCES
     SourceLoc.swift
     Utils.swift)

--- a/SwiftCompilerSources/Sources/Parse/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/Parse/CMakeLists.txt
@@ -14,7 +14,6 @@ endif()
 add_swift_compiler_module(Parse
   DEPENDS
     ${dependencies}
-  ADD_TO_SYNTAXPARSE
   SOURCES
     Parse.swift
     Regex.swift)

--- a/SwiftCompilerSources/Sources/_RegexParser/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/_RegexParser/CMakeLists.txt
@@ -16,6 +16,5 @@ endforeach()
 message(STATUS "Using Experimental String Processing library for libswift _RegexParser (${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}).")
 
 add_swift_compiler_module(_CompilerRegexParser
-  ADD_TO_SYNTAXPARSE
   SOURCES
   "${LIBSWIFT_REGEX_PARSER_SOURCES}")


### PR DESCRIPTION
This was used by `_InternalSwiftSyntaxParser` which was removed some time ago.
