### PR TITLE
[AST] Fix circular reference with implicit some

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2767,6 +2767,9 @@ public:
   /// some Q), or we might have a `NamedOpaqueReturnTypeRepr`.
   TypeRepr *getOpaqueResultTypeRepr() const;
 
+  /// Get the representative for this value's result type, if it has one.
+  TypeRepr *getResultTypeRepr() const;
+
   /// Retrieve the attribute associating this declaration with a
   /// result builder, if there is one.
   CustomAttr *getAttachedResultBuilder() const;

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -893,7 +893,7 @@ namespace {
   /// Retrieve the opaque generic parameter list if present, otherwise the normal generic parameter list.
   template<typename T>
   GenericParamList *getPotentiallyOpaqueGenericParams(T *decl) {
-    if (auto opaqueRepr = decl->getOpaqueResultTypeRepr()) {
+    if (auto opaqueRepr = decl->getResultTypeRepr()) {
       if (auto namedOpaque = dyn_cast<NamedOpaqueReturnTypeRepr>(opaqueRepr)) {
         return namedOpaque->getGenericParams();
       }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3088,9 +3088,7 @@ TypeRepr *ValueDecl::getResultTypeRepr() const {
 }
 
 TypeRepr *ValueDecl::getOpaqueResultTypeRepr() const {
-  TypeRepr *returnRepr = nullptr;
-
-  returnRepr = this->getResultTypeRepr();
+  auto *returnRepr = this->getResultTypeRepr();
 
   auto *dc = getDeclContext();
   auto &ctx = dc->getASTContext();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3058,7 +3058,8 @@ void ValueDecl::setOverriddenDecls(ArrayRef<ValueDecl *> overridden) {
   request.cacheResult(overriddenVec);
 }
 
-TypeRepr *ValueDecl::getOpaqueResultTypeRepr() const {
+// To-Do: Replce calls to getOpaqueResultTypeRepr with getResultTypeRepr()
+TypeRepr *ValueDecl::getResultTypeRepr() const {
   TypeRepr *returnRepr = nullptr;
   if (auto *VD = dyn_cast<VarDecl>(this)) {
     if (auto *P = VD->getParentPattern()) {
@@ -3069,7 +3070,7 @@ TypeRepr *ValueDecl::getOpaqueResultTypeRepr() const {
         P = P->getSemanticsProvidingPattern();
         if (auto *NP = dyn_cast<NamedPattern>(P)) {
           assert(NP->getDecl() == VD);
-          (void) NP;
+          (void)NP;
 
           returnRepr = TP->getTypeRepr();
         }
@@ -3082,6 +3083,14 @@ TypeRepr *ValueDecl::getOpaqueResultTypeRepr() const {
   } else if (auto *SD = dyn_cast<SubscriptDecl>(this)) {
     returnRepr = SD->getElementTypeRepr();
   }
+
+  return returnRepr;
+}
+
+TypeRepr *ValueDecl::getOpaqueResultTypeRepr() const {
+  TypeRepr *returnRepr = nullptr;
+
+  returnRepr = this->getResultTypeRepr();
 
   auto *dc = getDeclContext();
   auto &ctx = dc->getASTContext();

--- a/test/type/implicit_some/opaque_return.swift
+++ b/test/type/implicit_some/opaque_return.swift
@@ -115,3 +115,13 @@ struct S: P {
 
   var asExistential: any P { self }
 }
+
+enum E {
+    func f() -> Int {
+        1
+    }
+}
+
+protocol Q {
+    func f() -> Int
+}


### PR DESCRIPTION
getPotentiallyOpaqueGenericParams has a redundant call to check if declarations contain any opaque type representations. We don't need to check this here. Instead we can simply collect the result type representaions without the additional checks.

rdar://102279814