### PR TITLE
Frontend: add module interface flag to specify allowable clients. NFC

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1340,6 +1340,10 @@ def user_module_version : Separate<["-"], "user-module-version">,
   HelpText<"Module version specified from Swift module authors">,
   MetaVarName<"<vers>">;
 
+def allowable_client : Separate<["-"], "allowable-client">,
+  Flags<[FrontendOption, ModuleInterfaceOptionIgnorable, NewDriverOnlyOption]>,
+  HelpText<"Module names that are allowed to import this module">,
+  MetaVarName<"<vers>">;
 // VFS
 
 def vfsoverlay : JoinedOrSeparate<["-"], "vfsoverlay">,

--- a/test/ModuleInterface/allowable-client.swift
+++ b/test/ModuleInterface/allowable-client.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/textual)
+// RUN: %empty-directory(%t/binary)
+
+// RUN: %target-swift-frontend -emit-module %s -module-name Foo -swift-version 5 -disable-implicit-concurrency-module-import -allowable-client FooFriend1 -allowable-client FooFriend2 -allowable-client FooFriend3 -emit-module-interface-path %t/textual/Foo.swiftinterface -enable-library-evolution -emit-module-path %t/binary/Foo.swiftmodule
+
+// RUN: %FileCheck %s --check-prefix=INTERFACE-FLAG < %t/textual/Foo.swiftinterface
+
+// INTERFACE-FLAG: swift-module-flags-ignorable:
+// INTERFACE-FLAG: -allowable-client FooFriend1 -allowable-client FooFriend2 -allowable-client FooFriend3


### PR DESCRIPTION
This new flag should allow module authors to specify an allowable client list. This list is printed in the textual module interface. Diagnostics support can come later.