### PR TITLE
[move-only] Enable the move-only address transform and a small additional fix

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -735,6 +735,8 @@ ERROR(sil_moveonlychecker_inout_not_reinitialized_before_end_of_function, none,
       "'%0' consumed but not reinitialized before end of function", (StringRef))
 ERROR(sil_moveonlychecker_value_consumed_in_a_loop, none,
       "'%0' consumed by a use in a loop", (StringRef))
+ERROR(sil_moveonlychecker_exclusivity_violation, none,
+      "'%0' has consuming use that cannot be eliminated due to a tight exclusivity scope", (StringRef))
 
 NOTE(sil_moveonlychecker_consuming_use_here, none,
      "consuming use", ())

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -339,35 +339,43 @@ public func classAssignToVar5Arg2(_ x: Klass, _ x2: inout Klass) { // expected-e
 
 public func classAccessAccessField(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-note {{consuming use}}
+    // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
+    // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     x2 = Klass()
-    classUseMoveOnlyWithoutEscaping(x2.k!)
+    classUseMoveOnlyWithoutEscaping(x2.k!) // expected-note {{consuming use}}
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.k!)
+        classUseMoveOnlyWithoutEscaping(x2.k!) // expected-note {{consuming use}}
     }
 }
 
 public func classAccessAccessFieldArg(_ x2: inout Klass) {
-    classUseMoveOnlyWithoutEscaping(x2.k!)
+    // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
+    // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
+    classUseMoveOnlyWithoutEscaping(x2.k!) // expected-note {{consuming use}}
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.k!)
+        classUseMoveOnlyWithoutEscaping(x2.k!) // expected-note {{consuming use}}
     }
 }
 
 public func classAccessConsumeField(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-note {{consuming use}}
+    // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
+    // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     x2 = Klass()
     // Since a class is a reference type, we do not emit an error here.
-    classConsume(x2.k!)
+    classConsume(x2.k!) // expected-note {{consuming use}}
     for _ in 0..<1024 {
-        classConsume(x2.k!)
+        classConsume(x2.k!) // expected-note {{consuming use}}
     }
 }
 
 public func classAccessConsumeFieldArg(_ x2: inout Klass) {
+    // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
+    // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     // Since a class is a reference type, we do not emit an error here.
-    classConsume(x2.k!)
+    classConsume(x2.k!) // expected-note {{consuming use}}
     for _ in 0..<1024 {
-        classConsume(x2.k!)
+        classConsume(x2.k!) // expected-note {{consuming use}}
     }
 }
 
@@ -628,34 +636,42 @@ public func finalClassAssignToVar5Arg(_ x2: inout FinalKlass) { // expected-erro
 
 public func finalClassAccessField() {
     var x2 = FinalKlass()
+    // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
+    // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     x2 = FinalKlass()
-    classUseMoveOnlyWithoutEscaping(x2.k!)
+    classUseMoveOnlyWithoutEscaping(x2.k!) // expected-note {{consuming use}}
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.k!)
+        classUseMoveOnlyWithoutEscaping(x2.k!) // expected-note {{consuming use}}
     }
 }
 
 public func finalClassAccessFieldArg(_ x2: inout FinalKlass) {
-    classUseMoveOnlyWithoutEscaping(x2.k!)
+    // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
+    // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
+    classUseMoveOnlyWithoutEscaping(x2.k!) // expected-note {{consuming use}}
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.k!)
+        classUseMoveOnlyWithoutEscaping(x2.k!) // expected-note {{consuming use}}
     }
 }
 
 public func finalClassConsumeField() {
     var x2 = FinalKlass()
+    // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
+    // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     x2 = FinalKlass()
 
-    classConsume(x2.k!)
+    classConsume(x2.k!) // expected-note {{consuming use}}
     for _ in 0..<1024 {
-        classConsume(x2.k!)
+        classConsume(x2.k!) // expected-note {{consuming use}}
     }
 }
 
 public func finalClassConsumeFieldArg(_ x2: inout FinalKlass) {
-    classConsume(x2.k!)
+    // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
+    // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
+    classConsume(x2.k!) // expected-note {{consuming use}}
     for _ in 0..<1024 {
-        classConsume(x2.k!)
+        classConsume(x2.k!) // expected-note {{consuming use}}
     }
 }
 

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -2067,10 +2067,18 @@ public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
 /////////////////////////////
 
 func moveOperatorTest(_ k: __owned Klass) {
-    var k2 = k // expected-error {{'k2' consumed more than once}}
+    var k2 = k
+    // expected-error @-1 {{'k2' consumed more than once}}
+    // expected-error @-2 {{'k2' consumed more than once}}
+    // expected-error @-3 {{'k2' consumed more than once}}
     k2 = Klass()
     let k3 = _move k2 // expected-note {{consuming use}}
     let _ = _move k2 // expected-note {{consuming use}}
+    _ = k2 // expected-note {{consuming use}}
+    let _ = k2
+    // expected-note @-1 {{consuming use}}
+    // expected-note @-2 {{consuming use}}
+    // expected-note @-3 {{consuming use}}
     let _ = k3
 }
 
@@ -2078,13 +2086,22 @@ func moveOperatorTest(_ k: __owned Klass) {
 // Black hole initialization test case//
 /////////////////////////////////////////
 
-func blackHoleTestCase(_ k: __owned Klass) {
-    var k2 = k // expected-error {{'k2' consumed more than once}}
+func blackHoleKlassTestCase(_ k: __owned Klass) {
+    var k2 = k
     // expected-error @-1 {{'k2' consumed more than once}}
+    // expected-error @-2 {{'k2' consumed more than once}}
+    // expected-error @-3 {{'k2' consumed more than once}}
+    // expected-error @-4 {{'k2' consumed more than once}}
     let _ = k2 // expected-note {{consuming use}}
     let _ = k2 // expected-note {{consuming use}}
 
     k2 = Klass()
     var _ = k2 // expected-note {{consuming use}}
     var _ = k2 // expected-note {{consuming use}}
+
+    _ = k2 // expected-note {{consuming use}}
+    _ = k2
+    // expected-note @-1 {{consuming use}}
+    // expected-note @-2 {{consuming use}}
+    // expected-note @-3 {{consuming use}}
 }

--- a/test/SILOptimizer/moveonly_deinits.swift
+++ b/test/SILOptimizer/moveonly_deinits.swift
@@ -32,12 +32,11 @@ enum MoveOnlyEnum {
     deinit { // expected-error {{'self' consumed more than once}}
         let x = self // expected-note {{consuming use}}
         _ = x
-        var y = MoveOnlyEnum.lhs(Klass()) // expected-error {{'y' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
+        var y = MoveOnlyEnum.lhs(Klass())
         y = self // expected-note {{consuming use}}
         // We get an infinite recursion since we are going to call our own
         // deinit here. We are just testing diagnostics here though.
         _ = y // expected-warning {{function call causes an infinite recursion}}
-        // expected-note @-1 {{consuming use}}
         globalMoveOnlyEnum = self // expected-note {{consuming use}}
     } // expected-note {{consuming use}}
 }

--- a/test/SILOptimizer/moveonly_deinits.swift
+++ b/test/SILOptimizer/moveonly_deinits.swift
@@ -12,11 +12,14 @@ struct MoveOnlyStruct {
     deinit { // expected-error {{'self' consumed more than once}}
         let x = self // expected-note {{consuming use}}
         _ = x
-        var y = MoveOnlyStruct()
+        var y = MoveOnlyStruct() // expected-error {{'y' consumed more than once}}
         y = self // expected-note {{consuming use}}
         // We get an infinite recursion since we are going to call our own
         // deinit here. We are just testing diagnostics here though.
         _ = y // expected-warning {{function call causes an infinite recursion}}
+        // expected-note @-1 {{consuming use}}
+        let z = y // expected-note {{consuming use}}
+        let _ = z
         globalMoveOnlyStruct = self // expected-note {{consuming use}}
     } // expected-note {{consuming use}}
 }

--- a/test/SILOptimizer/moveonly_deinits.swift
+++ b/test/SILOptimizer/moveonly_deinits.swift
@@ -32,11 +32,12 @@ enum MoveOnlyEnum {
     deinit { // expected-error {{'self' consumed more than once}}
         let x = self // expected-note {{consuming use}}
         _ = x
-        var y = MoveOnlyEnum.lhs(Klass())
+        var y = MoveOnlyEnum.lhs(Klass()) // expected-error {{'y' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
         y = self // expected-note {{consuming use}}
         // We get an infinite recursion since we are going to call our own
         // deinit here. We are just testing diagnostics here though.
         _ = y // expected-warning {{function call causes an infinite recursion}}
+        // expected-note @-1 {{consuming use}}
         globalMoveOnlyEnum = self // expected-note {{consuming use}}
     } // expected-note {{consuming use}}
 }


### PR DESCRIPTION
This enables the full move only address transform. I was waiting for 525ba8c07bf2a48fc104a6589e0d007ec4da8a69 to land before landing this.

I also discovered a small problem around simple assignment when writing tests for this. (I thought that `let _ = x` and `_ = x` were codegened the same... but they are not).