### PR TITLE
Stop building backdeploy concurrency in package bot

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1247,9 +1247,6 @@ indexstore-db
 sourcekit-lsp
 swiftdocc
 
-# Build concurrency back-deployment binaries
-back-deploy-concurrency
-
 # Don't generate the SwiftSyntax gyb files. Instead verify that up-to-date ones
 # are checked in.
 swiftsyntax-verify-generated-files
@@ -1291,7 +1288,6 @@ install-playgroundsupport
 install-libcxx
 install-sourcekit-lsp
 install-swiftformat
-install-back-deploy-concurrency
 install-swiftdocc
 
 install-destdir=%(install_destdir)s


### PR DESCRIPTION
The backdeploy concurrency library is slated for removal. Turning it off on the package OSX bot as it is currently failing to build since it's not linking against compiler-rt.