### PR TITLE
Correct effective context translation for NS_OPTIONS anon C++ enums attempt 2

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -212,6 +212,17 @@ translateDeclToContext(clang::NamedDecl *decl) {
     if (auto typedefDecl = tag->getTypedefNameForAnonDecl())
       return std::make_pair(SwiftLookupTable::ContextKind::Tag,
                             typedefDecl->getName());
+    if (auto enumDecl = dyn_cast<clang::EnumDecl>(tag)) {
+      if (auto typedefType = dyn_cast<clang::TypedefType>(
+              enumDecl->getIntegerType().getTypePtr())) {
+        if (importer::isUnavailableInSwift(typedefType->getDecl(), nullptr,
+                                           true)) {
+          return std::make_pair(SwiftLookupTable::ContextKind::Tag,
+                                typedefType->getDecl()->getName());
+        }
+      }
+    }
+
     return None;
   }
 

--- a/test/Interop/Cxx/enum/Inputs/CenumsNSOptions.apinotes
+++ b/test/Interop/Cxx/enum/Inputs/CenumsNSOptions.apinotes
@@ -1,0 +1,10 @@
+Name: CenumsNSOptions
+Enumerators:
+- Name: API_NOTES_NAMED_OptionOne
+  SwiftName: SwiftOptionOneApiNotes
+- Name: API_NOTES_NAMED_OptionTwo
+  SwiftName: SwiftOptionTwoApiNotes
+- Name: API_NOTES_NAMED_OptionThree
+  SwiftName: SwiftOptionThreeApiNotes
+- Name: API_NOTES_NAMED_OptionFour
+  SwiftName: SwiftOptionFourApiNotes

--- a/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
@@ -40,3 +40,22 @@ typedef NS_OPTIONS(NSUInteger, NSAttributedStringFormattingOptions) {
     NS_REFINED_FOR_SWIFT;
 @end
 }
+
+typedef NS_OPTIONS(NSUInteger, Foo) {
+  NS_SWIFT_NAMED_OptionOne __attribute__((swift_name("SwiftOptionOne"))) = 0,
+  NS_SWIFT_NAMED_OptionTwo __attribute__((swift_name("SwiftOptionTwo"))) = 1
+                                                                           << 0,
+  NS_SWIFT_NAMED_OptionThree
+  __attribute__((swift_name("SwiftOptionThree"))) = 1 << 1,
+  NS_SWIFT_NAMED_OptionFour
+  __attribute__((swift_name("SwiftOptionFour"))) = NS_SWIFT_NAMED_OptionOne |
+                                                   NS_SWIFT_NAMED_OptionTwo
+};
+
+typedef NS_OPTIONS(NSUInteger, Bar) {
+  API_NOTES_NAMED_OptionOne = 0,
+  API_NOTES_NAMED_OptionTwo = 1 << 0,
+  API_NOTES_NAMED_OptionThree = 1 << 1,
+  API_NOTES_NAMED_OptionFour = API_NOTES_NAMED_OptionOne |
+                               API_NOTES_NAMED_OptionTwo
+};

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-api-notes-renamed-options.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-api-notes-renamed-options.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-swift-frontend %s -I %S/Inputs -typecheck -module-cache-path %t/cache -enable-experimental-cxx-interop 2>&1 | %FileCheck --allow-empty %s
+
+// REQUIRES: objc_interop
+
+import CenumsNSOptions
+
+// CHECK-NOT: warning: imported declaration 'API_NOTES_NAMED_OptionOne' could not be mapped to 'SwiftOptionOneApiNotes'
+// CHECK-NOT: warning: imported declaration 'API_NOTES_NAMED_OptionTwo' could not be mapped to 'SwiftOptionTwoApiNotes'
+// CHECK-NOT: warning: imported declaration 'API_NOTES_NAMED_OptionThree' could not be mapped to 'SwiftOptionThreeApiNotes'
+// CHECK-NOT: warning: imported declaration 'API_NOTES_NAMED_OptionFour' could not be mapped to 'SwiftOptionFourApiNotes'

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-swift-named-options.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-swift-named-options.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-swift-frontend %s -I %S/Inputs -typecheck -module-cache-path %t/cache -enable-experimental-cxx-interop 2>&1 | %FileCheck --allow-empty %s
+
+// REQUIRES: objc_interop
+
+import CenumsNSOptions
+
+// CHECK-NOT: warning: imported declaration 'NS_SWIFT_NAMED_OptionOne' could not be mapped to 'SwiftOptionOne'
+// CHECK-NOT: warning: imported declaration 'NS_SWIFT_NAMED_OptionTwo' could not be mapped to 'SwiftOptionTwo'
+// CHECK-NOT: warning: imported declaration 'NS_SWIFT_NAMED_OptionThree' could not be mapped to 'SwiftOptionThree'
+// CHECK-NOT: warning: imported declaration 'NS_SWIFT_NAMED_OptionFour' could not be mapped to 'SwiftOptionFour'


### PR DESCRIPTION
Second attempt at: [62058](https://github.com/apple/swift/pull/62058)