### PR TITLE
[Compile Time Constant Extraction] Add extraction of single statement returns for computed properties

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -133,6 +133,20 @@ extractPropertyInitializationValue(VarDecl *propertyDecl) {
     }
   }
 
+  if (auto accessorDecl = propertyDecl->getAccessor(AccessorKind::Get)) {
+    auto node = accessorDecl->getTypecheckedBody()->getFirstElement();
+    if (node.is<Stmt *>()) {
+      if (auto returnStmt = dyn_cast<ReturnStmt>(node.get<Stmt *>())) {
+        auto expr = returnStmt->getResult();
+        std::string LiteralOutput;
+        llvm::raw_string_ostream OutputStream(LiteralOutput);
+        expr->printConstExprValue(&OutputStream, nullptr);
+        if (!LiteralOutput.empty())
+          return std::make_shared<RawLiteralValue>(LiteralOutput);
+      }
+    }
+  }
+
   return std::make_shared<RuntimeValue>();
 }
 

--- a/test/ConstExtraction/fields.swift
+++ b/test/ConstExtraction/fields.swift
@@ -71,14 +71,14 @@
 // CHECK-NEXT:        "type": "Swift.Int",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
-// CHECK-NEXT:        "value": "Unknown"
+// CHECK-NEXT:        "value": "3"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "p4",
 // CHECK-NEXT:        "type": "Swift.Int",
 // CHECK-NEXT:        "isStatic": "true",
 // CHECK-NEXT:        "isComputed": "true",
-// CHECK-NEXT:        "value": "Unknown"
+// CHECK-NEXT:        "value": "3"
 // CHECK-NEXT:      }
 // CHECK-NEXT:    ]
 // CHECK-NEXT:  }
@@ -91,7 +91,7 @@ public struct Foo {
     let p1: String = "Hello, World"
     static let p2: Float = 42.2
     var p3: Int {3}
-    static var p4: Int {3}
+    static var p4: Int { return 3 }
     let p5: [Int] = [1,2,3,4,5,6,7,8,9]
     let p6: Bool = false
     let p7: Bool? = nil


### PR DESCRIPTION
Add extract single statement computed literal properties.

For computed properties in which the first statement is a `ReturnStmt`, emit literal output if available.
