### PR TITLE
Improve `-Rmodule-loading` to show both the path to the source and to the cached file actually loaded

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -989,8 +989,9 @@ REMARK(cross_import_added,none,
        (Identifier, Identifier, Identifier))
 
 REMARK(module_loaded,none,
-       "loaded module at %0",
-       (StringRef))
+       "loaded module at %0"
+       "%select{|; overlay for a clang dependency}1",
+       (StringRef, unsigned))
        
 REMARK(explicit_interface_build_skipped,none,
        "Skipped rebuilding module at %0 - up-to-date",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -989,9 +989,10 @@ REMARK(cross_import_added,none,
        (Identifier, Identifier, Identifier))
 
 REMARK(module_loaded,none,
-       "loaded module at %0"
-       "%select{|; overlay for a clang dependency}1",
-       (StringRef, unsigned))
+       "loaded module %0"
+       "%select{| (overlay for a clang dependency)}1"
+       "; source: '%2', loaded: '%3'",
+       (Identifier, unsigned, StringRef, StringRef))
        
 REMARK(explicit_interface_build_skipped,none,
        "Skipped rebuilding module at %0 - up-to-date",

--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -404,6 +404,11 @@ public:
   /// This is usually a filesystem path.
   virtual StringRef getFilename() const;
 
+  /// Get the path to the file loaded by the compiler. Usually the binary
+  /// swiftmodule file or a pcm in the cache. Returns an empty string if not
+  /// applicable.
+  virtual StringRef getLoadedFilename() const { return StringRef(); }
+
   virtual StringRef getFilenameForPrivateDecl(const ValueDecl *decl) const {
     return StringRef();
   }

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -840,6 +840,17 @@ public:
   /// string if this is not applicable.
   StringRef getModuleFilename() const;
 
+  /// Get the path to the file defining this module, what we consider the
+  /// source of truth about the module. Usually a swiftinterface file for a
+  /// resilient module, a swiftmodule for a non-resilient module, or the
+  /// modulemap for a clang module. Returns an empty string if not applicable.
+  StringRef getModuleSourceFilename() const;
+
+  /// Get the path to the file loaded by the compiler. Usually the binary
+  /// swiftmodule file or a pcm in the cache. Returns an empty string if not
+  /// applicable.
+  StringRef getModuleLoadedFilename() const;
+
   /// \returns true if this module is the "swift" standard library module.
   bool isStdlibModule() const;
 

--- a/include/swift/ClangImporter/ClangModule.h
+++ b/include/swift/ClangImporter/ClangModule.h
@@ -110,6 +110,8 @@ public:
 
   virtual StringRef getFilename() const override;
 
+  virtual StringRef getLoadedFilename() const override;
+
   virtual const clang::Module *getUnderlyingClangModule() const override {
     return getClangModule();
   }

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -451,6 +451,8 @@ public:
 
   virtual StringRef getFilename() const override;
 
+  virtual StringRef getLoadedFilename() const override;
+
   virtual StringRef getModuleDefiningPath() const override;
 
   ValueDecl *getMainDecl() const override;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2471,7 +2471,8 @@ ASTContext::getModule(ImportPath::Module ModulePath, bool AllowMemoryCached) {
       if (LangOpts.EnableModuleLoadingRemarks) {
         Diags.diagnose(ModulePath.getSourceRange().Start,
                        diag::module_loaded,
-                       M->getModuleFilename());
+                       M->getModuleFilename(),
+                       /*overlay=*/false);
       }
       return M;
     }
@@ -2499,8 +2500,15 @@ ModuleDecl *ASTContext::getOverlayModule(const FileUnit *FU) {
   for (auto &importer : getImpl().ModuleLoaders) {
     if (importer.get() == getClangModuleLoader())
       continue;
-    if (ModuleDecl *M = importer->loadModule(SourceLoc(), ModPath))
+    if (ModuleDecl *M = importer->loadModule(SourceLoc(), ModPath)) {
+      if (LangOpts.EnableModuleLoadingRemarks) {
+        Diags.diagnose(SourceLoc(),
+                       diag::module_loaded,
+                       M->getModuleFilename(),
+                       /*overlay=*/true);
+      }
       return M;
+    }
   }
 
   return nullptr;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2471,8 +2471,10 @@ ASTContext::getModule(ImportPath::Module ModulePath, bool AllowMemoryCached) {
       if (LangOpts.EnableModuleLoadingRemarks) {
         Diags.diagnose(ModulePath.getSourceRange().Start,
                        diag::module_loaded,
-                       M->getModuleFilename(),
-                       /*overlay=*/false);
+                       M->getName(),
+                       /*overlay=*/false,
+                       M->getModuleSourceFilename(),
+                       M->getModuleLoadedFilename());
       }
       return M;
     }
@@ -2504,8 +2506,10 @@ ModuleDecl *ASTContext::getOverlayModule(const FileUnit *FU) {
       if (LangOpts.EnableModuleLoadingRemarks) {
         Diags.diagnose(SourceLoc(),
                        diag::module_loaded,
-                       M->getModuleFilename(),
-                       /*overlay=*/true);
+                       M->getName(),
+                       /*overlay=*/true,
+                       M->getModuleSourceFilename(),
+                       M->getModuleLoadedFilename());
       }
       return M;
     }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1973,6 +1973,25 @@ StringRef ModuleDecl::getModuleFilename() const {
   return Result;
 }
 
+StringRef ModuleDecl::getModuleSourceFilename() const {
+  for (auto F : getFiles()) {
+    if (auto *SFU = dyn_cast<SynthesizedFileUnit>(F))
+      continue;
+    return F->getModuleDefiningPath();
+  }
+
+  return StringRef();
+}
+
+StringRef ModuleDecl::getModuleLoadedFilename() const {
+  for (auto F : getFiles()) {
+    if (auto LF = dyn_cast<LoadedFile>(F)) {
+      return LF->getLoadedFilename();
+    }
+  }
+  return StringRef();
+}
+
 bool ModuleDecl::isStdlibModule() const {
   return !getParent() && getName() == getASTContext().StdlibModuleName;
 }

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3625,6 +3625,12 @@ StringRef ClangModuleUnit::getFilename() const {
   return StringRef();
 }
 
+StringRef ClangModuleUnit::getLoadedFilename() const {
+  if (const clang::FileEntry *F = clangModule->getASTFile())
+    return F->getName();
+  return StringRef();
+}
+
 clang::TargetInfo &ClangImporter::getTargetInfo() const {
   return Impl.Instance->getTarget();
 }

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -718,6 +718,10 @@ public:
     return Core->ModuleInputBuffer->getBufferIdentifier();
   }
 
+  StringRef getModuleLoadedFilename() const {
+    return Core->ModuleInputBuffer->getBufferIdentifier();
+  }
+
   StringRef getTargetTriple() const {
     return Core->TargetTriple;
   }

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -1570,6 +1570,10 @@ StringRef SerializedASTFile::getFilename() const {
   return File.getModuleFilename();
 }
 
+StringRef SerializedASTFile::getLoadedFilename() const {
+  return File.getModuleLoadedFilename();
+}
+
 StringRef SerializedASTFile::getTargetTriple() const {
   return File.getTargetTriple();
 }

--- a/test/Frontend/module-alias-diags.swift
+++ b/test/Frontend/module-alias-diags.swift
@@ -14,7 +14,7 @@
 // RUN: %target-swift-frontend -module-name LibA %t/FileLib.swift -module-alias XLogging=AppleLogging -I %t -emit-module -emit-module-path %t/LibA.swiftmodule -Rmodule-loading 2> %t/result-LibA.output
 // RUN: test -f %t/LibA.swiftmodule
 // RUN: %FileCheck %s -input-file %t/result-LibA.output -check-prefix CHECK-LOAD
-// CHECK-LOAD: remark: loaded module at {{.*}}AppleLogging.swiftmodule
+// CHECK-LOAD: remark: loaded module {{.*}}AppleLogging.swiftmodule
 
 /// 2. Fail: trying to access a non-member of a module (with module aliasing) should fail with the module alias in the diags
 /// Try building module Lib that imports XLogging WITH -module-alias XLogging=AppleLogging

--- a/test/Frontend/module-alias-explicit-build.swift
+++ b/test/Frontend/module-alias-explicit-build.swift
@@ -48,4 +48,4 @@
 // RUN: not test -f %t/inputs/Cat.swiftmodule
 
 // RUN: %FileCheck %s -input-file %t/outputs/load-result.output -check-prefix CHECK
-// CHECK: remark: loaded module at {{.*}}Bar.swiftmodule
+// CHECK: remark: loaded module {{.*}}Bar.swiftmodule

--- a/test/Frontend/module-alias-for-client.swift
+++ b/test/Frontend/module-alias-for-client.swift
@@ -22,7 +22,7 @@
 /// Check Lib.swiftmodule is created and AppleLogging.swiftmodule is loaded
 // RUN: test -f %t/Lib.swiftmodule
 // RUN: %FileCheck %s -input-file %t/result-Lib.output -check-prefix CHECK-Lib
-// CHECK-Lib: remark: loaded module at {{.*}}AppleLogging.swiftmodule
+// CHECK-Lib: remark: loaded module {{.*}}AppleLogging.swiftmodule
 
 /// 3a. Client1
 /// Create module Client1 that imports Lib and XLogging, WITHOUT module aliasing for XLogging
@@ -31,8 +31,8 @@
 /// Check Client1.swiftmodule is created and Lib.swiftmodule and XLogging.swiftmodule are loaded
 // RUN: test -f %t/Client1.swiftmodule
 // RUN: %FileCheck %s -input-file %t/result-Client1.output -check-prefix CHECK-1
-// CHECK-1: remark: loaded module at {{.*}}XLogging.swiftmodule
-// CHECK-1: remark: loaded module at {{.*}}Lib.swiftmodule
+// CHECK-1: remark: loaded module {{.*}}XLogging.swiftmodule
+// CHECK-1: remark: loaded module {{.*}}Lib.swiftmodule
 
 /// 3b. Client2
 /// Create a module Client2 that imports Lib and XLogging, WITH module aliasing for XLogging
@@ -42,10 +42,10 @@
 /// loaded but XLogging.swiftmodule is not loaded.
 // RUN: test -f %t/Client2.swiftmodule
 // RUN: %FileCheck %s -input-file %t/result-Client2.output -check-prefix CHECK-2A
-// CHECK-2A: remark: loaded module at {{.*}}AppleLogging.swiftmodule
-// CHECK-2A: remark: loaded module at {{.*}}Lib.swiftmodule
+// CHECK-2A: remark: loaded module {{.*}}AppleLogging.swiftmodule
+// CHECK-2A: remark: loaded module {{.*}}Lib.swiftmodule
 // RUN: not %FileCheck %s -input-file %t/result-Client2.output -check-prefix CHECK-2B
-// CHECK-2B: remark: loaded module at {{.*}}XLogging.swiftmodule
+// CHECK-2B: remark: loaded module {{.*}}XLogging.swiftmodule
 
 
 // BEGIN FileLogging.swift

--- a/test/Frontend/module-alias-for-lib-and-client.swift
+++ b/test/Frontend/module-alias-for-lib-and-client.swift
@@ -23,9 +23,9 @@
 // RUN: not test -f %t/XLogging.swiftmodule
 
 // RUN: %FileCheck %s -input-file %t/result-Lib.output -check-prefix CHECK-Lib
-// CHECK-Lib: remark: loaded module at {{.*}}AppleLogging.swiftmodule
+// CHECK-Lib: remark: loaded module {{.*}}AppleLogging.swiftmodule
 // RUN: not %FileCheck %s -input-file %t/result-Lib.output -check-prefix CHECK-NOT-Lib
-// CHECK-NOT-Lib: remark: loaded module at {{.*}}XLogging.swiftmodule
+// CHECK-NOT-Lib: remark: loaded module {{.*}}XLogging.swiftmodule
 
 /// 3a. Client1
 /// Create module Client1 that imports Lib and XLogging, WITH module aliasing for XLogging
@@ -37,10 +37,10 @@
 // RUN: test -f %t/AppleLogging.swiftmodule
 // RUN: not test -f %t/XLogging.swiftmodule
 // RUN: %FileCheck %s -input-file %t/result-Client1.output -check-prefix CHECK-CLIENT1
-// CHECK-CLIENT1: remark: loaded module at {{.*}}AppleLogging.swiftmodule
-// CHECK-CLIENT1: remark: loaded module at {{.*}}Lib.swiftmodule
+// CHECK-CLIENT1: remark: loaded module {{.*}}AppleLogging.swiftmodule
+// CHECK-CLIENT1: remark: loaded module {{.*}}Lib.swiftmodule
 // RUN: not %FileCheck %s -input-file %t/result-Client1.output -check-prefix CHECK-NOT-CLIENT1
-// CHECK-NOT-CLIENT1: remark: loaded module at {{.*}}XLogging.swiftmodule
+// CHECK-NOT-CLIENT1: remark: loaded module {{.*}}XLogging.swiftmodule
 
 /// 3b. Client2
 /// Try creating module Client2 that imports Lib and XLogging, WITHOUT module aliasing
@@ -61,10 +61,10 @@
 // RUN: not test -f %t/XLogging.swiftmodule
 
 // RUN: %FileCheck %s -input-file %t/result-Client3.output -check-prefix CHECK-CLIENT3
-// CHECK-CLIENT3: remark: loaded module at {{.*}}AppleLogging.swiftmodule
-// CHECK-CLIENT3: remark: loaded module at {{.*}}Lib.swiftmodule
+// CHECK-CLIENT3: remark: loaded module {{.*}}AppleLogging.swiftmodule
+// CHECK-CLIENT3: remark: loaded module {{.*}}Lib.swiftmodule
 // RUN: not %FileCheck %s -input-file %t/result-Client3.output -check-prefix CHECK-NOT-CLIENT3
-// CHECK-NOT-CLIENT3: remark: loaded module at {{.*}}XLogging.swiftmodule
+// CHECK-NOT-CLIENT3: remark: loaded module {{.*}}XLogging.swiftmodule
 
 // BEGIN FileLogging.swift
 public struct Logger {

--- a/test/Frontend/module-alias-load.swift
+++ b/test/Frontend/module-alias-load.swift
@@ -18,7 +18,7 @@
 // RUN: not test -f %t/Cat.swiftmodule
 
 // RUN: %FileCheck %s -input-file %t/load-result-foo.output -check-prefix CHECK-FOO
-// CHECK-FOO: remark: loaded module at {{.*}}Bar.swiftmodule
+// CHECK-FOO: remark: loaded module {{.*}}Bar.swiftmodule
 
 /// Create a module Zoo that imports Cat with -module-alias Cat=Bar with a source loader
 // RUN: %target-swift-frontend -module-name Zoo %t/FileFoo.swift -module-alias Cat=Bar -I %t -emit-module -emit-module-path %t/Zoo.swiftmodule -enable-source-import -Rmodule-loading 2> %t/load-result-zoo.output
@@ -28,7 +28,7 @@
 // RUN: not test -f %t/Cat.swiftmodule
 
 // RUN: %FileCheck %s -input-file %t/load-result-zoo.output -check-prefix CHECK-ZOO
-// CHECK-ZOO: remark: loaded module at {{.*}}Bar.swiftmodule
+// CHECK-ZOO: remark: loaded module {{.*}}Bar.swiftmodule
 
 
 // BEGIN FileBar.swift

--- a/test/Frontend/module-alias-serialize-swiftinterface.swift
+++ b/test/Frontend/module-alias-serialize-swiftinterface.swift
@@ -30,9 +30,9 @@
 
 /// Check AppleLogging.swiftmodule is loaded
 // RUN: %FileCheck %s -input-file %t/result-Lib.output -check-prefix CHECK-LOAD
-// CHECK-LOAD: remark: loaded module at {{.*}}AppleLogging.swiftmodule
+// CHECK-LOAD: remark: loaded module {{.*}}AppleLogging.swiftmodule
 // RUN: not %FileCheck %s -input-file %t/result-Lib.output -check-prefix CHECK-NOT-LOAD1
-// CHECK-NOT-LOAD1: remark: loaded module at {{.*}}XLogging.swiftmodule
+// CHECK-NOT-LOAD1: remark: loaded module {{.*}}XLogging.swiftmodule
 
 /// Check imported modules contain AppleLogging, not XLogging
 // RUN: %FileCheck %s -input-file %t/Lib.swiftinterface -check-prefix CHECK-IMPORT

--- a/test/Frontend/module-alias-serialize-swiftmodule.swift
+++ b/test/Frontend/module-alias-serialize-swiftmodule.swift
@@ -31,9 +31,9 @@
 
 /// Check AppleLogging.swiftmodule is loaded, and XLogging.swiftmodule is not loaded
 // RUN: %FileCheck %s -input-file %t/result-Lib.output -check-prefix CHECK-LOAD1
-// CHECK-LOAD1: remark: loaded module at {{.*}}AppleLogging.swiftmodule
+// CHECK-LOAD1: remark: loaded module {{.*}}AppleLogging.swiftmodule
 // RUN: not %FileCheck %s -input-file %t/result-Lib.output -check-prefix CHECK-NOT-LOAD1
-// CHECK-NOT-LOAD1: remark: loaded module at {{.*}}XLogging.swiftmodule
+// CHECK-NOT-LOAD1: remark: loaded module {{.*}}XLogging.swiftmodule
 
 /// Check Lib.swiftmodule contains AppleLogging and NOT XLogging as an imported module
 /// in the binary
@@ -52,7 +52,7 @@
 // RUN: not test -f %t/XLogging.swiftmodule
 
 // RUN: %FileCheck %s -input-file %t/result-Client.output -check-prefix CHECK-LOAD2
-// CHECK-LOAD2: remark: loaded module at {{.*}}Lib.swiftmodule
+// CHECK-LOAD2: remark: loaded module {{.*}}Lib.swiftmodule
 
 /// Check Client.swiftmodule contains Lib as an imported module in the binary
 // RUN: llvm-bcanalyzer --dump %t/Client.swiftmodule | %FileCheck %s -check-prefix=BCANALYZER-IMPORT2

--- a/test/ModuleInterface/loading-remarks.swift
+++ b/test/ModuleInterface/loading-remarks.swift
@@ -1,15 +1,57 @@
 /// Test the -Rmodule-loading flag.
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/cache)
+// RUN: split-file %s %t
 
-/// Create a simple module and interface.
-// RUN: echo 'public func publicFunction() {}' > %t/TestModule.swift
-// RUN: %target-swift-emit-module-interface(%t/TestModule.swiftinterface) %t/TestModule.swift
+/// Create Swift modules to import.
+// RUN: %target-swift-emit-module-interface(%t/SwiftDependency.swiftinterface) \
+// RUN:   %t/SwiftDependency.swift
+// RUN: %target-swift-frontend -emit-module -o %t/SwiftNonResilientDependency.swiftmodule \
+// RUN:   -module-name SwiftNonResilientDependency %t/SwiftDependency.swift
+// RUN: %target-swift-emit-module-interface(%t/IndirectMixedDependency.swiftinterface) \
+// RUN:   %t/IndirectMixedDependency.swift -I %t
 
 /// Use -Rmodule-loading in a client and look for the diagnostics output.
-// RUN: %target-swift-frontend -typecheck %s -I %t -Rmodule-loading -module-cache-path %t/cache 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -Rmodule-loading \
+// RUN:   -I %t -module-cache-path %t/cache 2>&1 | %FileCheck %s
 
-import TestModule
-// CHECK: remark: loaded module at {{.*}}SwiftShims-{{.*}}.pcm
-// CHECK: remark: loaded module at {{.*}}Swift.swiftmodule{{.*}}.swiftmodule
-// CHECK: remark: loaded module at {{.*}}TestModule.swiftinterface
+//--- module.modulemap
+module IndirectMixedDependency {
+  header "IndirectMixedDependency.h"
+}
+
+module DirectMixedDependency {
+  header "DirectMixedDependency.h"
+  export *
+}
+
+//--- IndirectMixedDependency.h
+
+//--- IndirectMixedDependency.swift
+
+@_exported import IndirectMixedDependency
+
+//--- DirectMixedDependency.h
+
+#include "IndirectMixedDependency.h"
+
+//--- DirectMixedDependency.swift
+
+@_exported import DirectMixedDependency
+
+//--- SwiftDependency.swift
+
+public func publicFunction() {}
+
+//--- Client.swift
+
+import SwiftDependency
+import SwiftNonResilientDependency
+import DirectMixedDependency
+
+// CHECK: remark: loaded module 'SwiftShims'; source: '{{.*}}module.modulemap', loaded: '{{.*}}SwiftShims-{{.*}}.pcm'
+// CHECK: remark: loaded module 'Swift'; source: '{{.*}}Swift.swiftmodule', loaded: '{{.*}}Swift.swiftmodule{{.*}}.swiftmodule'
+// CHECK: remark: loaded module 'SwiftDependency'; source: '{{.*}}SwiftDependency.swiftinterface', loaded: '{{.*}}SwiftDependency-{{.*}}.swiftmodule'
+// CHECK: remark: loaded module 'SwiftNonResilientDependency'; source: '{{.*}}SwiftNonResilientDependency.swiftmodule', loaded: '{{.*}}SwiftNonResilientDependency.swiftmodule'
+// CHECK: remark: loaded module 'IndirectMixedDependency' (overlay for a clang dependency); source: '{{.*}}IndirectMixedDependency.swiftinterface', loaded: '{{.*}}IndirectMixedDependency-{{.*}}.swiftmodule'
+// CHECK: remark: loaded module 'DirectMixedDependency'; source: '{{.*}}module.modulemap', loaded: '{{.*}}DirectMixedDependency-{{.*}}.pcm'


### PR DESCRIPTION
Improve the `-Rmodule-loading` feature:
1. For each loaded module, show both the source path (swiftinterface, modulemap, or non-resilient swiftmodule) and the path to the loaded file (adjacent or cached swiftmodule, or pcm file in a cache).
2. Report the loading of a Swift overlay for a module imported indirectly via clang.