### PR TITLE
[ASTDump] NFC: Remove double printing of `pattern` component

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1702,8 +1702,6 @@ public:
       OS << ")\n";
       Indent -= 2;
     }
-    printRec(S->getPattern());
-    OS << '\n';
     printRec(S->getParsedSequence());
     OS << '\n';
     if (S->getIteratorVar()) {


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
