### PR TITLE
[cxx-interop][rebranch] Handle clang elaborated types properly

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5659,6 +5659,8 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
       getAccessorPropertyType(getter, false, getterName.getSelfIndex());
   if (propertyType.isNull())
     return nullptr;
+  if (auto elaborated = dyn_cast<clang::ElaboratedType>(propertyType))
+    propertyType = elaborated->desugar();
 
   // If there is a setter, check that the property it implies
   // matches that of the getter.
@@ -7133,6 +7135,8 @@ canSkipOverTypedef(ClangImporter::Implementation &Impl,
     return nullptr;
 
   clang::QualType UnderlyingType = ClangTypedef->getUnderlyingType();
+  if (auto elaborated = dyn_cast<clang::ElaboratedType>(UnderlyingType))
+    UnderlyingType = elaborated->desugar();
 
   // A typedef to a typedef should get imported as a typealias.
   auto *TypedefT = UnderlyingType->getAs<clang::TypedefType>();
@@ -8456,6 +8460,8 @@ void ClangImporter::Implementation::loadAllMembersOfRecordDecl(
       clang::QualType baseType = base.getType();
       if (auto spectType = dyn_cast<clang::TemplateSpecializationType>(baseType))
         baseType = spectType->desugar();
+      if (auto elaborated = dyn_cast<clang::ElaboratedType>(baseType))
+        baseType = elaborated->desugar();
       if (!isa<clang::RecordType>(baseType))
         continue;
 

--- a/lib/ClangImporter/ImportEnumInfo.h
+++ b/lib/ClangImporter/ImportEnumInfo.h
@@ -159,6 +159,10 @@ StringRef getCommonWordPrefix(StringRef a, StringRef b,
 ///
 /// \see getCommonWordPrefix
 StringRef getCommonPluralPrefix(StringRef singular, StringRef plural);
+
+/// Returns the underlying integer type of an enum. If clang treats the type as
+/// an elaborated type, an unwrapped type is returned.
+const clang::Type *getUnderlyingType(const clang::EnumDecl *decl);
 }
 }
 

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -645,7 +645,7 @@ findSwiftNameAttr(const clang::Decl *decl, ImportNameVersion version) {
 
     if (auto enumDecl = dyn_cast<clang::EnumDecl>(decl)) {
       // Intentionally don't get the canonical type here.
-      if (auto typedefType = dyn_cast<clang::TypedefType>(enumDecl->getIntegerType().getTypePtr())) {
+      if (auto typedefType = dyn_cast<clang::TypedefType>(getUnderlyingType(enumDecl))) {
         // If the typedef is available in Swift, the user will get ambiguity.
         // It also means they may not have intended this API to be imported like this.
         if (importer::isUnavailableInSwift(typedefType->getDecl(), nullptr, true)) {
@@ -1796,7 +1796,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
     // typedef (even if it's an anonymous enum).
     if (auto enumDecl = dyn_cast<clang::EnumDecl>(D)) {
       // Intentionally don't get the canonical type here.
-      if (auto typedefType = dyn_cast<clang::TypedefType>(enumDecl->getIntegerType().getTypePtr())) {
+      if (auto typedefType = dyn_cast<clang::TypedefType>(getUnderlyingType(enumDecl))) {
         // If the typedef is available in Swift, the user will get ambiguity.
         // It also means they may not have intended this API to be imported like this.
         if (importer::isUnavailableInSwift(typedefType->getDecl(), nullptr, true)) {

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2086,10 +2086,14 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
     OptionalityOfReturn = OTK_ImplicitlyUnwrappedOptional;
   }
 
+  clang::QualType returnType = clangDecl->getReturnType();
+  if (auto elaborated =
+          dyn_cast<clang::ElaboratedType>(returnType))
+    returnType = elaborated->desugar();
+
   // Specialized templates need to match the args/result exactly (i.e.,
   // ptr -> ptr not ptr -> Optional<ptr>).
-  if (clangDecl->getReturnType()->isPointerType() &&
-      clangDecl->getPrimaryTemplate() &&
+  if (returnType->isPointerType() && clangDecl->getPrimaryTemplate() &&
       clangDecl
           ->getPrimaryTemplate()
           ->getAsFunction()
@@ -2097,7 +2101,7 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
           ->isTemplateTypeParmType())
     OptionalityOfReturn = OTK_None;
 
-  if (auto typedefType = dyn_cast<clang::TypedefType>(clangDecl->getReturnType().getTypePtr())) {
+  if (auto typedefType = dyn_cast<clang::TypedefType>(returnType)) {
     if (isUnavailableInSwift(typedefType->getDecl())) {
       if (auto clangEnum = findAnonymousEnumForTypedef(SwiftContext, typedefType)) {
         // If this fails, it means that we need a stronger predicate for
@@ -2112,7 +2116,7 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
   }
 
   // Import the result type.
-  return importType(clangDecl->getReturnType(),
+  return importType(returnType,
                     (isAuditedResult ? ImportTypeKind::AuditedResult
                                      : ImportTypeKind::Result),
                     ImportDiagnosticAdder(*this, clangDecl,
@@ -2159,7 +2163,11 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
   ImportedType importedType;
   ImportDiagnosticAdder addDiag(*this, clangDecl,
                                 clangDecl->getSourceRange().getBegin());
-  if (auto typedefType = dyn_cast<clang::TypedefType>(clangDecl->getReturnType().getTypePtr())) {
+  clang::QualType returnType = clangDecl->getReturnType();
+  if (auto elaborated = dyn_cast<clang::ElaboratedType>(returnType))
+    returnType = elaborated->desugar();
+
+  if (auto typedefType = dyn_cast<clang::TypedefType>(returnType)) {
     if (isUnavailableInSwift(typedefType->getDecl())) {
       if (auto clangEnum = findAnonymousEnumForTypedef(SwiftContext, typedefType)) {
         // If this fails, it means that we need a stronger predicate for
@@ -2174,15 +2182,15 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
   }
 
   if (auto templateType =
-          dyn_cast<clang::TemplateTypeParmType>(clangDecl->getReturnType())) {
+          dyn_cast<clang::TemplateTypeParmType>(returnType)) {
     importedType = {findGenericTypeInGenericDecls(
                         *this, templateType, genericParams,
                         getImportTypeAttrs(clangDecl), addDiag),
                     false};
-  } else if ((isa<clang::PointerType>(clangDecl->getReturnType()) ||
-          isa<clang::ReferenceType>(clangDecl->getReturnType())) &&
-         isa<clang::TemplateTypeParmType>(clangDecl->getReturnType()->getPointeeType())) {
-    auto pointeeType = clangDecl->getReturnType()->getPointeeType();
+  } else if ((isa<clang::PointerType>(returnType) ||
+          isa<clang::ReferenceType>(returnType)) &&
+         isa<clang::TemplateTypeParmType>(returnType->getPointeeType())) {
+    auto pointeeType = returnType->getPointeeType();
     auto templateParamType = cast<clang::TemplateTypeParmType>(pointeeType);
     PointerTypeKind pointerKind = pointeeType.getQualifiers().hasConst()
                                       ? PTK_UnsafePointer
@@ -2191,13 +2199,13 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
         findGenericTypeInGenericDecls(*this, templateParamType, genericParams,
                                       getImportTypeAttrs(clangDecl), addDiag);
     importedType = {genericType->wrapInPointer(pointerKind), false};
-  } else if (!(isa<clang::RecordType>(clangDecl->getReturnType()) ||
-               isa<clang::TemplateSpecializationType>(clangDecl->getReturnType())) ||
+  } else if (!(isa<clang::RecordType>(returnType) ||
+               isa<clang::TemplateSpecializationType>(returnType)) ||
              // TODO: we currently don't lazily load operator return types, but
              // this should be trivial to add.
              clangDecl->isOverloadedOperator() ||
              // Dependant types are trivially mapped as Any.
-             clangDecl->getReturnType()->isDependentType()) {
+             returnType->isDependentType()) {
     // If importedType is already initialized, it means we found the enum that
     // was supposed to be used (instead of the typedef type).
     if (!importedType) {
@@ -2244,6 +2252,8 @@ ClangImporter::Implementation::importParameterType(
     ArrayRef<GenericTypeParamDecl *> genericParams,
     llvm::function_ref<void(Diagnostic &&)> addImportDiagnosticFn) {
   auto paramTy = param->getType();
+  if (auto elaborated = dyn_cast<clang::ElaboratedType>(paramTy))
+    paramTy = elaborated->desugar();
 
   ImportTypeKind importKind = getImportTypeKindForParam(param);
 
@@ -2845,7 +2855,8 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
   ImportDiagnosticAdder addImportDiag(*this, clangDecl,
                                       clangDecl->getLocation());
   clang::QualType resultType = clangDecl->getReturnType();
-
+  if (auto elaborated = dyn_cast<clang::ElaboratedType>(resultType))
+    resultType = elaborated->desugar();
 
   ImportedType importedType;
   if (auto typedefType = dyn_cast<clang::TypedefType>(resultType.getTypePtr())) {


### PR DESCRIPTION
Clang recently started wrapping more types in `clang::ElaboratedType` after this change: https://reviews.llvm.org/D112374

This broke some assumptions in ClangImporter, specifically in enum handling logic. This change adjusts those.

Fixes these tests in rebranch:
* `Interop/Cxx/enum/anonymous-with-swift-name-module-interface.swift`
* `Interop/Cxx/enum/anonymous-with-swift-name-objc-module-interface.swift`
* `Interop/Cxx/enum/anonymous-with-swift-name.swift`
* `Interop/Cxx/enum/c-enums-NS_OPTIONS-NS_REFINED_FOR_SWIFT.swift`
* `Interop/Cxx/enum/c-enums-NS_OPTIONS.swift`
* `Interop/Cxx/enum/c-enums-withOptions-omit.swift`
* `Interop/Cxx/class/inheritance/fields-module-interface.swift`
* `Interop/Cxx/class/inheritance/fields.swift`
* `Interop/Cxx/class/inheritance/functions-module-interface.swift`
* `Interop/Cxx/class/inheritance/sub-types-module-interface.swift`
* `Interop/Cxx/class/inheritance/type-aliases-module-interface.swift`