### PR TITLE
[Runtime] Fatal error if self escapes from deinit.

### DIFF
--- a/test/Runtime/deinit_escape.swift
+++ b/test/Runtime/deinit_escape.swift
@@ -1,0 +1,26 @@
+// RUN: %target-run-simple-swift
+
+// REQUIRES: executable_test
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+import StdlibUnittest
+
+var DeinitEscapeTestSuite = TestSuite("DeinitEscape")
+
+var globalObjects: [AnyObject] = []
+
+DeinitEscapeTestSuite.test("deinit escapes self") {
+  expectCrashLater()
+
+  class C {
+    deinit {
+      globalObjects.append(self)
+    }
+  }
+  _ = C()
+
+  expectUnreachable()
+}
+
+runAllTests()


### PR DESCRIPTION
When deallocating a class instance, we check the retain count of the instance and error if it's greater than 1.

Self is allowed to be temporarily passed to other code from deinit, but there's no way to extend the lifetime of the object. Retaining it no longer extensd the lifetime. If self escapes from deinit, the result is a dangling pointer and eventual crash.

Instead of crashing randomly due to a dangling pointer, crash deliberately when destroying an object that has escaped.

rdar://93848484