### PR TITLE
[Parse] Restore a couple of StructureMarkerRAII

### DIFF
--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -776,6 +776,9 @@ Result Parser::parseIfConfigRaw(
     llvm::function_ref<Result(SourceLoc endLoc, bool hadMissingEnd)> finish) {
   assert(Tok.is(tok::pound_if));
 
+  Parser::StructureMarkerRAII ParsingDecl(
+      *this, Tok.getLoc(), Parser::StructureMarkerKind::IfConfig);
+
   // Find the region containing code completion token.
   SourceLoc codeCompletionClauseLoc;
   if (SourceMgr.hasCodeCompletionBuffer() &&

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -511,6 +511,10 @@ ParserResult<Stmt> Parser::parseStmt() {
     consumeToken(tok::colon);
   }
 
+  // Note that we're parsing a statement.
+  StructureMarkerRAII ParsingStmt(*this, Tok.getLoc(),
+                                  StructureMarkerKind::Statement);
+
   SourceLoc tryLoc;
   (void)consumeIf(tok::kw_try, tryLoc);
 


### PR DESCRIPTION
These are accidentally removed in 530d937879d2b490e7ef01f215d5a5ef44369eae
