### PR TITLE
[github] Auto-add the `triage needed` label to new issues for discoverability

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
+labels: bug, triage needed
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Share an idea
 title: ''
-labels: feature request
+labels: feature request, triage needed
 assignees: ''
 
 ---


### PR DESCRIPTION
I’ve already created the label. [This repo](https://github.com/MicrosoftDocs/edge-developer/issues/2317) does this via an automation feature called GitHub Actions, which we can explore in the future. This is a temporary solution to help us retroactively discover issues that are in need of a proper set of labels, especially since regular users cannot add them on their own. Thoughts? 