### PR TITLE
[AddressLowering] Don't end_borrow trivial args.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -182,6 +182,37 @@ bool isFunctionSelectedForPrinting(SILFunction *F) {
   return true;
 }
 
+void printInliningDetails(StringRef passName, SILFunction *caller,
+                          SILFunction *callee, bool isCaller,
+                          bool alreadyInlined) {
+  if (!isFunctionSelectedForPrinting(caller))
+    return;
+  llvm::dbgs() << "  " << passName
+               << (alreadyInlined ? " has inlined " : " will inline ")
+               << callee->getName() << " into " << caller->getName() << ".\n";
+  auto *printee = isCaller ? caller : callee;
+  printee->dump(caller->getModule().getOptions().EmitVerboseSIL);
+  llvm::dbgs() << '\n';
+}
+
+void printInliningDetailsCallee(StringRef passName, SILFunction *caller,
+                                SILFunction *callee) {
+  printInliningDetails(passName, caller, callee, /*isCaller=*/false,
+                       /*alreadyInlined=*/false);
+}
+
+void printInliningDetailsCallerBefore(StringRef passName, SILFunction *caller,
+                                      SILFunction *callee) {
+  printInliningDetails(passName, caller, callee, /*isCaller=*/true,
+                       /*alreadyInlined=*/false);
+}
+
+void printInliningDetailsCallerAfter(StringRef passName, SILFunction *caller,
+                                     SILFunction *callee) {
+  printInliningDetails(passName, caller, callee, /*isCaller=*/true,
+                       /*alreadyInlined=*/true);
+}
+
 static bool functionSelectionEmpty() {
   return SILPrintFunction.empty() && SILPrintFunctions.empty();
 }

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -67,40 +67,16 @@ llvm::cl::opt<bool> SILPrintInliningCallerAfter(
 //                           Printing Helpers
 //===----------------------------------------------------------------------===//
 
-extern bool isFunctionSelectedForPrinting(SILFunction *F);
+extern void printInliningDetailsCallee(StringRef passName, SILFunction *caller,
+                                       SILFunction *callee);
 
-static void printInliningDetails(StringRef passName, SILFunction *caller,
-                                 SILFunction *callee, bool isCaller,
-                                 bool alreadyInlined) {
-  if (!isFunctionSelectedForPrinting(caller))
-    return;
-  llvm::dbgs() << "  " << passName
-               << (alreadyInlined ? " has inlined " : " will inline ")
-               << callee->getName() << " into " << caller->getName() << ".\n";
-  auto *printee = isCaller ? caller : callee;
-  printee->dump(caller->getModule().getOptions().EmitVerboseSIL);
-  llvm::dbgs() << '\n';
-}
-
-static void printInliningDetailsCallee(StringRef passName, SILFunction *caller,
-                                       SILFunction *callee) {
-  printInliningDetails(passName, caller, callee, /*isCaller=*/false,
-                       /*alreadyInlined=*/false);
-}
-
-static void printInliningDetailsCallerBefore(StringRef passName,
+extern void printInliningDetailsCallerBefore(StringRef passName,
                                              SILFunction *caller,
-                                             SILFunction *callee) {
-  printInliningDetails(passName, caller, callee, /*isCaller=*/true,
-                       /*alreadyInlined=*/false);
-}
+                                             SILFunction *callee);
 
-static void printInliningDetailsCallerAfter(StringRef passName,
+extern void printInliningDetailsCallerAfter(StringRef passName,
                                             SILFunction *caller,
-                                            SILFunction *callee) {
-  printInliningDetails(passName, caller, callee, /*isCaller=*/true,
-                       /*alreadyInlined=*/true);
-}
+                                            SILFunction *callee);
 
 //===----------------------------------------------------------------------===//
 //                           Performance Inliner

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1068,6 +1068,28 @@ bb3(%15 : @owned $T):
   return %15 : $T
 }
 
+// Verify that trivial arguments are loaded trivially and for which no
+// end_borrows were created.
+// CHECK-LABEL: sil [ossa] @f171_subtract_overflow : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[RETVAL:%[^,]+]] : $*Builtin.Int64, [[LHS_ADDR:%[^,]+]] : $*Builtin.Int64, [[RHS_ADDR:%[^,]+]] :
+// CHECK:         [[LHS:%[^,]+]] = load [trivial] [[LHS_ADDR]]
+// CHECK:         [[RHS:%[^,]+]] = load [trivial] [[RHS_ADDR]]
+// CHECK:         [[SUM_AND:%[^,]+]] = apply {{%[^,]+}}([[LHS]], [[RHS]])
+// CHECK-NOT:     end_borrow
+// CHECK:         ([[SUM:%[^,]+]], [[OVERFLOWED:%[^,]+]]) = destructure_tuple [[SUM_AND]]
+// CHECK:         store [[SUM]] to [trivial] [[RETVAL]]
+// CHECK:         return [[OVERFLOWED]]
+// CHECK-LABEL: } // end sil function 'f171_subtract_overflow'
+sil [ossa] @f171_subtract_overflow : $@convention(thin) (@in_guaranteed Int, @in_guaranteed Int) -> (@out Int, Bool) {
+bb0(%0 : $Int, %1 : $Int):
+  %2 = function_ref @f171_subtract_overflow_callee : $@convention(method) (Int, Int) -> (Int, Bool)
+  %3 = apply %2(%0, %1) : $@convention(method) (Int, Int) -> (Int, Bool)
+  (%4, %5) = destructure_tuple %3 : $(Int, Bool)
+  %6 = tuple (%4 : $Int, %5 : $Bool)
+  return %6 : $(Int, Bool)
+}
+sil [ossa] @f171_subtract_overflow_callee : $@convention(method) (Int, Int) -> (Int, Bool)
+
 // Test switching on a single opaque value.
 // CHECK-LABEL: sil [ossa] @f210_testSwitchEnum : $@convention(method) <T> (@in Optional<T>, @inout T) -> () {
 // CHECK: bb0(%0 : $*Optional<T>, %1 : $*T):


### PR DESCRIPTION
When loading an argument, first check whether its type is trivial.  If so, produce a `load [trivial]`.  Only then produce `load [take]`s or `load_borrow`s.  Fixes an issue where values passed @in_guaranteed were `load [trivial]`'d and then `end_borrow`'d.

Also added the inlining logging used in the performance inliner to the mandatory inliner.  It was used to track down this issue.
