### PR TITLE
[NFC] Correct grammar in documentation for `AsyncStream.Continuation.finish()`

### DIFF
--- a/stdlib/public/Concurrency/AsyncStream.swift
+++ b/stdlib/public/Concurrency/AsyncStream.swift
@@ -200,8 +200,8 @@ public struct AsyncStream<Element> {
     /// nil, which signifies the end of the iteration.
     ///
     /// Calling this function more than once has no effect. After calling
-    /// finish, the stream enters a terminal state and doesn't produces any additional
-    /// elements.
+    /// finish, the stream enters a terminal state and doesn't produce any
+    /// additional elements.
     public func finish() {
       storage.finish()
     }


### PR DESCRIPTION
Before: doesn't produces any
After: doesn't produce any