### PR TITLE
[PoC][Concurrency] Proof out and simulate "send" semantics

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -531,7 +531,7 @@ extension Actor {
     @_inheritActorContext @_implicitSelfCapture operation: __owned @Sendable @escaping (isolated Self) async -> Void
   ) {
     let flags = taskCreateFlags(
-            priority: nil, isChildTask: false, copyTaskLocals: false,
+            priority: nil, isChildTask: false, copyTaskLocals: true,
             inheritContext: true, enqueueJob: false,
             addPendingGroupTaskUnconditionally: false)
 

--- a/test/Concurrency/Runtime/task_deterministic_scheduling.swift
+++ b/test/Concurrency/Runtime/task_deterministic_scheduling.swift
@@ -1,0 +1,38 @@
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library)
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+// REQUIRES: concurrency_runtime
+
+import Darwin
+
+actor DeterministicOrderThanksToSend {
+    var counter = 0
+
+    func test_mainActor_taskOrdering() async {
+        var tasks = [(Int, Task<Void, Never>)]()
+        for iteration in 1...100 {
+            fputs("spawn:\(iteration)\n", stderr)
+
+
+            self.send {
+                fputs("run:\(iteration)\n", stderr)
+                self.counter += 1
+                precondition(counter == iteration, "counter:\(counter) != iteration:\(iteration)") // often fails
+            }
+        }
+
+        while self.counter < 100 {
+            try? await Task.sleep(until: .now.advanced(by: .milliseconds(100)), clock: .continuous)
+        }
+    }
+}
+
+
+@available(SwiftStdlib 5.1, *)
+@main struct Main {
+    static func main() async {
+        let deterministicOrderThanksToSend = DeterministicOrderThanksToSend()
+        await deterministicOrderThanksToSend.test_mainActor_taskOrdering()
+    }
+}


### PR DESCRIPTION
The same test if implemented with `Task{}` _will_ crash as the order of the enqueues is not guaranteed.

This is just a silly PoC to showcase how a send-like semantics enqueue order improves on the status quo of working with actors when deterministic order is expected.