### PR TITLE
[DNM] Iterate on Swift compiler source avoiding Xcode project rebuild times.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -518,7 +518,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
 
     # Workaround to make lldb happy: we have to explicitly add all swift compiler modules
     # to the linker command line.
-    set(swift_ast_path_flags " -Wl")
+    set(swift_ast_path_flags " -Xlinker -interposable -Wl")
     get_property(modules GLOBAL PROPERTY swift_compiler_modules)
     foreach(module ${modules})
       get_target_property(module_file "SwiftModule${module}" "module_file")

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2724,12 +2724,20 @@ static bool ParseMigratorArgs(MigratorOptions &Opts,
   return false;
 }
 
+#if DEBUG
+#include "../../../Compilertron/Compilertron/compilertron.cpp"
+#endif
+
 bool CompilerInvocation::parseArgs(
     ArrayRef<const char *> Args, DiagnosticEngine &Diags,
     SmallVectorImpl<std::unique_ptr<llvm::MemoryBuffer>>
         *ConfigurationFileBuffers,
     StringRef workingDirectory, StringRef mainExecutablePath) {
   using namespace options;
+
+  #if DEBUG
+  dyload_patches();
+  #endif
 
   if (Args.empty())
     return false;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2724,7 +2724,8 @@ static bool ParseMigratorArgs(MigratorOptions &Opts,
   return false;
 }
 
-#if DEBUG
+#ifndef NDEBUG
+// repo: https://github.com/johnno1962/Compilertron
 #include "../../../Compilertron/Compilertron/compilertron.cpp"
 #endif
 
@@ -2735,7 +2736,7 @@ bool CompilerInvocation::parseArgs(
     StringRef workingDirectory, StringRef mainExecutablePath) {
   using namespace options;
 
-  #if DEBUG
+  #ifndef NDEBUG
   dyload_patches();
   #endif
 


### PR DESCRIPTION
Hi Apple,

An interesting option for people working intensively on the Swift compiler that avoids having to wait for the Xcode build/compile/link to complete every iteration by using interposing to patch incremental changes into the swift-frontend executable. In this way the wait time is only that taken to compile the source file edited. 

Used in conjunction with the https://github.com/johnno1962/Compilertron project which you clone alongside the swift project source and run. This app, watches for C++ source file changes and prepares dynamic libraries that a small stub of code interposes new implementations into place the next time you control-run the compiler. See the project README.md and sources for more details.