### PR TITLE
build: Fix Xcode project generation

### DIFF
--- a/utils/python_format.py
+++ b/utils/python_format.py
@@ -112,7 +112,7 @@ def parse_args():
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Don't format the file, just return the status.",
+        help="Don't write the files back, just return the status.",
     )
 
     parser.add_argument(
@@ -120,6 +120,19 @@ def parse_args():
         "--verbose",
         action="store_true",
         help="Emit messages to stderr about files that were not changed.",
+    )
+
+    parser.add_argument(
+        "--diff",
+        action="store_true",
+        help="Don't write the files back, just output a diff for each file on stdout.",
+    )
+
+    parser.add_argument(
+        "-S",
+        "--skip-string-normalization",
+        action="store_true",
+        help="Don't normalize string quotes or prefixes.",
     )
 
     return parser.parse_args()
@@ -144,6 +157,10 @@ def main():
         command.append("--check")
     if args.verbose:
         command.append("--verbose")
+    if args.diff:
+        command.append("--diff")
+    if args.skip_string_normalization:
+        command.append("--skip-string-normalization")
 
     requested_paths = [path.resolve() for path in args.paths]
 

--- a/utils/python_format.py
+++ b/utils/python_format.py
@@ -137,7 +137,7 @@ def main():
         "-m",
         "black",
         "--target-version",
-        "py27",
+        "py38",
     ]
 
     if args.check:

--- a/utils/swift_build_support/swift_build_support/products/cmake_product.py
+++ b/utils/swift_build_support/swift_build_support/products/cmake_product.py
@@ -71,7 +71,13 @@ class CMakeProduct(product.Product):
                            env=env)
 
         if not self.args.skip_build or self.product_name() == "llvm":
+            cmake_opts = [self.build_dir, "--config", build_type]
+
             if self.args.cmake_generator == "Xcode":
+                # CMake automatically adds "--target ALL_BUILD" if we don't
+                # pass this.
+                cmake_opts += ["--target", "ZERO_CHECK"]
+
                 # Xcode generator uses "ALL_BUILD" instead of "all".
                 # Also, xcodebuild uses -target instead of bare names.
                 build_targets = build_targets[:]
@@ -82,12 +88,11 @@ class CMakeProduct(product.Product):
 
                 # Xcode can't restart itself if it turns out we need to reconfigure.
                 # Do an advance build to handle that.
-                shell.call(["env"] + cmake_build
-                           + [self.build_dir, "--config", build_type])
+                shell.call(["env"] + cmake_build + cmake_opts)
 
-            shell.call(["env"] + cmake_build
-                       + [self.build_dir, "--config", build_type, "--"]
-                       + build_args + build_targets)
+            shell.call(
+                ["env"] + cmake_build + cmake_opts + ["--"] + build_args + build_targets
+            )
 
     def test_with_cmake(self, executable_target, results_targets,
                         build_type, build_args, test_env=None):

--- a/validation-test/BuildSystem/skip_build_xcode.test
+++ b/validation-test/BuildSystem/skip_build_xcode.test
@@ -1,0 +1,14 @@
+# RUN: %empty-directory(%t)
+# RUN: mkdir -p %t
+# RUN: SKIP_XCODE_VERSION_CHECK=1 SWIFT_BUILD_ROOT=%t %swift_src_root/utils/build-script --xcode --release --swift-darwin-supported-archs="$(uname -m)" --dry-run --cmake %cmake 2>&1 | %FileCheck %s
+
+# REQUIRES: standalone_build
+# REQUIRES: OS=macosx
+
+# Make sure we pass '--target ZERO_CHECK' (otherwise CMake automatically adds
+# '--target ALL_BUILD' and we end up building everything) and build the bare
+# minimum required to configure Swift.
+#
+# CHECK: --- Building llvm ---
+# CHECK: env {{.+}}/cmake --build {{.+}}/Xcode-ReleaseAssert/llvm-macosx-{{.+}} --config Release --target ZERO_CHECK{{$}}
+# CHECK-NEXT: env {{.+}}/cmake --build {{.+}}/Xcode-ReleaseAssert/llvm-macosx-{{.+}} --config Release --target ZERO_CHECK -- -target llvm-tblgen -target clang-resource-headers -target intrinsics_gen -target clang-tablegen-targets -target FileCheck -target not -target llvm-nm -target llvm-size{{$}}


### PR DESCRIPTION
Mirror some LLVM+Xcode-specific `build-script-impl` logic in the CMake `build-script` product file. This fixes the behavior of `--xcode`, which was relying on this logic and was compromised when LLVM became a `build-script` product. This time, add a test too.


Resolves #62205