### PR TITLE
[cxx-interop] Emit IR for custom `operator new`

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -82,6 +82,11 @@ public:
     return true;
   }
 
+  bool VisitCXXNewExpr(clang::CXXNewExpr *NE) {
+    callback(NE->getOperatorNew());
+    return true;
+  }
+
   // Do not traverse unevaluated expressions. Doing to might result in compile
   // errors if we try to instantiate an un-instantiatable template.
 

--- a/test/Interop/Cxx/class/Inputs/custom-new-operator.h
+++ b/test/Interop/Cxx/class/Inputs/custom-new-operator.h
@@ -1,0 +1,20 @@
+#ifndef TEST_INTEROP_CXX_CLASS_CUSTOM_NEW_OPERATOR_H
+#define TEST_INTEROP_CXX_CLASS_CUSTOM_NEW_OPERATOR_H
+
+#include <cstddef>
+#include <cstdint>
+
+struct container_new_t {};
+
+inline void *operator new(size_t, void *p, container_new_t) { return p; }
+
+struct MakeMe {
+  int x;
+};
+
+inline MakeMe *callsCustomNew() {
+  char buffer[8];
+  return new (buffer, container_new_t()) MakeMe;
+}
+
+#endif // TEST_INTEROP_CXX_CLASS_CUSTOM_NEW_OPERATOR_H

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -18,6 +18,11 @@ module ConstructorsObjC {
   requires cplusplus
 }
 
+module CustomNewOperator {
+  header "custom-new-operator.h"
+  requires cplusplus
+}
+
 module Destructors {
   header "destructors.h"
   requires cplusplus

--- a/test/Interop/Cxx/class/custom-new-operator-irgen.swift
+++ b/test/Interop/Cxx/class/custom-new-operator-irgen.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swiftxx-frontend -I %S/Inputs %s -emit-ir | %FileCheck %s
+
+import CustomNewOperator
+
+var x = callsCustomNew()
+
+// Make sure the definition of `operator new` is emitted.
+// CHECK: define {{.*}} @{{_ZnwmPv15container_new_t|"\?\?2@YAPEAX_KPEAXUcontainer_new_t@@@Z"}}


### PR DESCRIPTION
Fixes https://github.com/apple/swift/issues/62182