### PR TITLE
IRGen: fix and re-enable static read-only arrays

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -949,9 +949,9 @@ public:
   /// for extended existential types.
   AvailabilityContext getParameterizedExistentialRuntimeAvailability();
 
-  /// Get the runtime availability of immortal ref-count symbols, which are
-  /// needed to place array buffers into constant data sections.
-  AvailabilityContext getImmortalRefCountSymbolsAvailability();
+  /// Get the runtime availability of array buffers placed in constant data
+  /// sections.
+  AvailabilityContext getStaticReadOnlyArraysAvailability();
 
   /// Get the runtime availability of runtime functions for
   /// variadic generic types.

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -567,10 +567,8 @@ ASTContext::getParameterizedExistentialRuntimeAvailability() {
 }
 
 AvailabilityContext
-ASTContext::getImmortalRefCountSymbolsAvailability() {
-  // TODO: replace this with a concrete swift version once we have it.
-  // rdar://94185998
-  return getSwiftFutureAvailability();
+ASTContext::getStaticReadOnlyArraysAvailability() {
+  return getSwift511Availability();
 }
 
 AvailabilityContext

--- a/lib/IRGen/GenConstant.cpp
+++ b/lib/IRGen/GenConstant.cpp
@@ -438,13 +438,10 @@ llvm::Constant *irgen::emitConstantObject(IRGenModule &IGM, ObjectInst *OI,
       IGM.swiftImmortalRefCount = var;
     }
     if (!IGM.swiftStaticArrayMetadata) {
-
-      // Static arrays can only contain trivial elements. Therefore we can reuse
-      // the metadata of the empty array buffer. The important thing is that its
-      // deinit is a no-op and does not actually destroy any elements.
+      // type metadata for class __StaticArrayStorage
       auto *var = new llvm::GlobalVariable(IGM.Module, IGM.TypeMetadataStructTy,
                                         /*constant*/ true, llvm::GlobalValue::ExternalLinkage,
-                                        /*initializer*/ nullptr, "$ss19__EmptyArrayStorageCN");
+                                        /*initializer*/ nullptr, "$ss20__StaticArrayStorageCN");
       IGM.swiftStaticArrayMetadata = var;
     }
     elements[0].add(llvm::ConstantStruct::get(ObjectHeaderTy, {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -2038,13 +2038,6 @@ bool IRGenModule::canUseObjCSymbolicReferences() {
 }
 
 bool IRGenModule::canMakeStaticObjectsReadOnly() {
-  // Unconditionally disable this until we can fix the metadata.
-  // The trick of using the Empty array metadata for static arrays
-  // breaks Obj-C interop quite badly.
-  // rdar://101126543
-  return false;
-
-#if 0
   if (getOptions().DisableReadonlyStaticObjects)
     return false;
 
@@ -2054,8 +2047,7 @@ bool IRGenModule::canMakeStaticObjectsReadOnly() {
     return false;
 
   return getAvailabilityContext().isContainedIn(
-          Context.getImmortalRefCountSymbolsAvailability());
-#endif
+          Context.getStaticReadOnlyArraysAvailability());
 }
 
 void IRGenerator::addGenModule(SourceFile *SF, IRGenModule *IGM) {

--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -68,6 +68,49 @@ public var _swiftEmptyArrayStorage: (Int, Int, Int, Int) =
     (/*isa*/0, /*refcount*/-1, /*count*/0, /*flags*/1)
 #endif
 
+/// The storage for static read-only arrays.
+///
+/// In contrast to `_ContiguousArrayStorage` this class is _not_ generic over
+/// the element type, because the metatype for static read-only arrays cannot
+/// be instantiated at runtime.
+///
+/// Static read-only arrays can only contain non-verbatim bridged element types.
+@_fixed_layout
+@usableFromInline
+@_objc_non_lazy_realization
+internal final class __StaticArrayStorage
+  : __ContiguousArrayStorageBase {
+
+  @inlinable
+  @nonobjc
+  internal init(_doNotCallMe: ()) {
+    _internalInvariantFailure("creating instance of __StaticArrayStorage")
+  }
+
+#if _runtime(_ObjC)
+  override internal func _withVerbatimBridgedUnsafeBuffer<R>(
+    _ body: (UnsafeBufferPointer<AnyObject>) throws -> R
+  ) rethrows -> R? {
+    return nil
+  }
+
+  override internal func _getNonVerbatimBridgingBuffer() -> _BridgingBuffer {
+    fatalError("__StaticArrayStorage._withVerbatimBridgedUnsafeBuffer must not be called")
+  }
+#endif
+
+  @inlinable
+  override internal func canStoreElements(ofDynamicType _: Any.Type) -> Bool {
+    return false
+  }
+
+  @inlinable
+  @_unavailableInEmbedded
+  override internal var staticElementType: Any.Type {
+    fatalError("__StaticArrayStorage.staticElementType must not be called")
+  }
+}
+
 /// The empty array prototype.  We use the same object for all empty
 /// `[Native]Array<Element>`s.
 @inlinable
@@ -848,6 +891,9 @@ internal struct _ContiguousArrayBuffer<Element>: _ArrayBufferProtocol {
                                     onObject: _storage)
       }
       return _storage
+    }
+    if _storage is __StaticArrayStorage {
+      return __SwiftDeferredStaticNSArray<Element>(_nativeStorage: _storage)
     }
     return __SwiftDeferredNSArray(_nativeStorage: _storage)
   }

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -53,10 +53,8 @@ swift::_SwiftEmptyArrayStorage swift::_swiftEmptyArrayStorage = {
   }
 };
 
-// Define required symbols to be used by constant static arrays.
-// * `__swiftImmortalRefCount`:    The bit pattern for the ref-count field of
-//                                 the array buffer.
-// * `__swiftStaticArrayMetadata`: The isa-pointer for the array buffer.
+// Define `__swiftImmortalRefCount` which is used by constant static arrays.
+// It is the bit pattern for the ref-count field of the array buffer.
 //
 // TODO: Support constant static arrays on other platforms, too.
 // This needs a bit more work because the tricks with absolute symbols and

--- a/test/SILOptimizer/readonly_arrays.swift
+++ b/test/SILOptimizer/readonly_arrays.swift
@@ -9,12 +9,12 @@
 
 // Check if the optimizer is able to convert array literals to constant statically initialized arrays.
 
-// CHECK: @"$s4test11arrayLookupyS2iFTv_r" = {{.*}} constant {{.*}} @"$ss19__EmptyArrayStorageCN", {{.*}} @_swiftImmortalRefCount
-// CHECK: @"$s4test11returnArraySaySiGyFTv_r" = {{.*}} constant {{.*}} @"$ss19__EmptyArrayStorageCN", {{.*}} @_swiftImmortalRefCount
-// CHECK: @"$s4test9passArrayyyFTv_r" = {{.*}} constant {{.*}} @"$ss19__EmptyArrayStorageCN", {{.*}} @_swiftImmortalRefCount
-// CHECK: @"$s4test9passArrayyyFTv0_r" = {{.*}} constant {{.*}} @"$ss19__EmptyArrayStorageCN", {{.*}} @_swiftImmortalRefCount
-// CHECK: @"$s4test10storeArrayyyFTv_r" = {{.*}} constant {{.*}} @"$ss19__EmptyArrayStorageCN", {{.*}} @_swiftImmortalRefCount
-// CHECK: @"$s4test3StrV14staticVariable_WZTv_r" = {{.*}} constant {{.*}} @"$ss19__EmptyArrayStorageCN", {{.*}} @_swiftImmortalRefCount
+// CHECK-DAG: @"$s4test11arrayLookupyS2iFTv_r" = {{.*}} constant {{.*}} @"$ss20__StaticArrayStorageCN", {{.*}} @_swiftImmortalRefCount
+// CHECK-DAG: @"$s4test11returnArraySaySiGyFTv_r" = {{.*}} constant {{.*}} @"$ss20__StaticArrayStorageCN", {{.*}} @_swiftImmortalRefCount
+// CHECK-DAG: @"$s4test9passArrayyyFTv_r" = {{.*}} constant {{.*}} @"$ss20__StaticArrayStorageCN", {{.*}} @_swiftImmortalRefCount
+// CHECK-DAG: @"$s4test9passArrayyyFTv0_r" = {{.*}} constant {{.*}} @"$ss20__StaticArrayStorageCN", {{.*}} @_swiftImmortalRefCount
+// CHECK-DAG: @"$s4test10storeArrayyyFTv_r" = {{.*}} constant {{.*}} @"$ss20__StaticArrayStorageCN", {{.*}} @_swiftImmortalRefCount
+// CHECK-DAG: @"$s4test3StrV14staticVariable_WZTv_r" = {{.*}} constant {{.*}} @"$ss20__StaticArrayStorageCN", {{.*}} @_swiftImmortalRefCount
 // CHECK-NOT: swift_initStaticObject
 
 // UNSUPPORTED: use_os_stdlib
@@ -22,7 +22,6 @@
 // Currently, constant static arrays only work on Darwin platforms.
 // REQUIRES: VENDOR=apple
 
-// REQUIRES: rdar101126543
 
 public struct Str {
   public static let staticVariable = [ 200, 201, 202 ]

--- a/test/SILOptimizer/readonly_arrays_objc.swift
+++ b/test/SILOptimizer/readonly_arrays_objc.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -target %target-future-triple -O %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: executable_test,swift_stdlib_no_asserts,optimized_stdlib
+// REQUIRES: objc_interop
+
+// UNSUPPORTED: use_os_stdlib
+
+import Foundation
+
+@inline(never)
+func createArray() -> [Int] {
+  return [1, 2, 3]
+}
+
+@inline(never)
+func printNSArray(_ a: NSArray) {
+  // CHECK: 1
+  print(a[0])
+  // CHECK: 2
+  print(a[1])
+  // CHECK: 3
+  print(a[2])
+}
+
+
+@inline(never)
+func testit() {
+  let a = createArray()
+  printNSArray(a as NSArray)
+}
+
+testit()

--- a/test/abi/macOS/arm64/stdlib-asserts.swift
+++ b/test/abi/macOS/arm64/stdlib-asserts.swift
@@ -40,4 +40,23 @@
 
 // Standard Library Symbols
 
+// class __StaticArrayStorage
+Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfC
+Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfCTj
+Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfCTq
+Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfc
+Added: _$ss20__StaticArrayStorageC16_doNotCallMeBaseAByt_tcfC
+Added: _$ss20__StaticArrayStorageC16_doNotCallMeBaseAByt_tcfc
+Added: _$ss20__StaticArrayStorageC16canStoreElements13ofDynamicTypeSbypXp_tF
+Added: _$ss20__StaticArrayStorageC17staticElementTypeypXpvg
+Added: _$ss20__StaticArrayStorageCMa
+Added: _$ss20__StaticArrayStorageCMn
+Added: _$ss20__StaticArrayStorageCMo
+Added: _$ss20__StaticArrayStorageCMu
+Added: _$ss20__StaticArrayStorageCN
+Added: _$ss20__StaticArrayStorageCfD
+Added: _$ss20__StaticArrayStorageCfd
+Added: _OBJC_CLASS_$__TtCs20__StaticArrayStorage
+Added: _OBJC_METACLASS_$__TtCs20__StaticArrayStorage
+
 // Runtime Symbols

--- a/test/abi/macOS/arm64/stdlib.swift
+++ b/test/abi/macOS/arm64/stdlib.swift
@@ -45,4 +45,23 @@ Added: _$ss19_getWeakRetainCountySuyXlF
 // Swift._getUnownedRetainCount(Swift.AnyObject) -> Swift.UInt
 Added: _$ss22_getUnownedRetainCountySuyXlF
 
+// class __StaticArrayStorage
+Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfC
+Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfCTj
+Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfCTq
+Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfc
+Added: _$ss20__StaticArrayStorageC16_doNotCallMeBaseAByt_tcfC
+Added: _$ss20__StaticArrayStorageC16_doNotCallMeBaseAByt_tcfc
+Added: _$ss20__StaticArrayStorageC16canStoreElements13ofDynamicTypeSbypXp_tF
+Added: _$ss20__StaticArrayStorageC17staticElementTypeypXpvg
+Added: _$ss20__StaticArrayStorageCMa
+Added: _$ss20__StaticArrayStorageCMn
+Added: _$ss20__StaticArrayStorageCMo
+Added: _$ss20__StaticArrayStorageCMu
+Added: _$ss20__StaticArrayStorageCN
+Added: _$ss20__StaticArrayStorageCfD
+Added: _$ss20__StaticArrayStorageCfd
+Added: _OBJC_CLASS_$__TtCs20__StaticArrayStorage
+Added: _OBJC_METACLASS_$__TtCs20__StaticArrayStorage
+
 // Runtime Symbols

--- a/test/abi/macOS/x86_64/stdlib-asserts.swift
+++ b/test/abi/macOS/x86_64/stdlib-asserts.swift
@@ -40,4 +40,23 @@
 
 // Standard Library Symbols
 
+// class __StaticArrayStorage
+Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfC
+Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfCTj
+Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfCTq
+Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfc
+Added: _$ss20__StaticArrayStorageC16_doNotCallMeBaseAByt_tcfC
+Added: _$ss20__StaticArrayStorageC16_doNotCallMeBaseAByt_tcfc
+Added: _$ss20__StaticArrayStorageC16canStoreElements13ofDynamicTypeSbypXp_tF
+Added: _$ss20__StaticArrayStorageC17staticElementTypeypXpvg
+Added: _$ss20__StaticArrayStorageCMa
+Added: _$ss20__StaticArrayStorageCMn
+Added: _$ss20__StaticArrayStorageCMo
+Added: _$ss20__StaticArrayStorageCMu
+Added: _$ss20__StaticArrayStorageCN
+Added: _$ss20__StaticArrayStorageCfD
+Added: _$ss20__StaticArrayStorageCfd
+Added: _OBJC_CLASS_$__TtCs20__StaticArrayStorage
+Added: _OBJC_METACLASS_$__TtCs20__StaticArrayStorage
+
 // Runtime Symbols

--- a/test/abi/macOS/x86_64/stdlib.swift
+++ b/test/abi/macOS/x86_64/stdlib.swift
@@ -45,4 +45,23 @@ Added: _$ss19_getWeakRetainCountySuyXlF
 // Swift._getUnownedRetainCount(Swift.AnyObject) -> Swift.UInt
 Added: _$ss22_getUnownedRetainCountySuyXlF
 
+// class __StaticArrayStorage
+Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfC
+Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfCTj
+Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfCTq
+Added: _$ss20__StaticArrayStorageC12_doNotCallMeAByt_tcfc
+Added: _$ss20__StaticArrayStorageC16_doNotCallMeBaseAByt_tcfC
+Added: _$ss20__StaticArrayStorageC16_doNotCallMeBaseAByt_tcfc
+Added: _$ss20__StaticArrayStorageC16canStoreElements13ofDynamicTypeSbypXp_tF
+Added: _$ss20__StaticArrayStorageC17staticElementTypeypXpvg
+Added: _$ss20__StaticArrayStorageCMa
+Added: _$ss20__StaticArrayStorageCMn
+Added: _$ss20__StaticArrayStorageCMo
+Added: _$ss20__StaticArrayStorageCMu
+Added: _$ss20__StaticArrayStorageCN
+Added: _$ss20__StaticArrayStorageCfD
+Added: _$ss20__StaticArrayStorageCfd
+Added: _OBJC_CLASS_$__TtCs20__StaticArrayStorage
+Added: _OBJC_METACLASS_$__TtCs20__StaticArrayStorage
+
 // Runtime Symbols


### PR DESCRIPTION
Static read-only arrays didn't work when passed to ObjectiveC as NSArray. The storage class of static read-only arrays doesn't carry information about the Element type. The new `__SwiftDeferredStaticNSArray` is generic over the element type and doesn't have to rely on the element type information of the array storage.

This is a follow-up of https://github.com/apple/swift/pull/59612

rdar://94185998
