### PR TITLE
[GenericEnvironment] Include original parameter packs in opened pack element signatures.

### DIFF
--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -190,6 +190,16 @@ public:
   /// Retrieve the UUID for an opened element environment.
   UUID getOpenedElementUUID() const;
 
+  using PackElementBinding =
+      std::pair<ElementArchetypeType *, PackArchetypeType *>;
+
+  /// Retrieve the bindings for the opened pack element archetypes in this
+  /// generic environment to the pack archetypes that contain them.
+  ///
+  /// \param bindings The vector to populate with the pack element bindings.
+  void getPackElementBindings(
+      SmallVectorImpl<PackElementBinding> &bindings) const;
+
   /// Create a new, primary generic environment.
   static GenericEnvironment *forPrimary(GenericSignature signature);
 

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -64,9 +64,10 @@ struct OpenedExistentialEnvironmentData {
   UUID uuid;
 };
 
-/// Extra data in a generic environment for an opened element.
+/// Extra data in a generic environment for an opened pack element.
 struct OpenedElementEnvironmentData {
   UUID uuid;
+  SubstitutionMap outerSubstitutions;
 };
 
 /// Describes the mapping between archetypes and interface types for the
@@ -139,7 +140,8 @@ private:
       Type existential, GenericSignature parentSig, UUID uuid);
 
   /// Private constructor for opened element environments.
-  explicit GenericEnvironment(GenericSignature signature, UUID uuid);
+  explicit GenericEnvironment(GenericSignature signature, UUID uuid,
+                              SubstitutionMap outerSubs);
 
   friend ArchetypeType;
   friend QueryInterfaceTypeSubstitutions;
@@ -181,6 +183,10 @@ public:
   /// create a generic environment.
   SubstitutionMap getOpaqueSubstitutions() const;
 
+  /// Retrieve the substitutions for the outer generic parameters of an
+  /// opened pack element generic environment.
+  SubstitutionMap getPackElementContextSubstitutions() const;
+
   /// Retrieve the UUID for an opened element environment.
   UUID getOpenedElementUUID() const;
 
@@ -206,8 +212,11 @@ public:
   /// signature of the context whose element type is being opened, but with
   /// the pack parameter bit erased from one or more generic parameters
   /// \param uuid The unique identifier for this opened element
+  /// \param outerSubs The substitution map containing archetypes from the
+  /// outer generic context.
   static GenericEnvironment *
-  forOpenedElement(GenericSignature signature, UUID uuid);
+  forOpenedElement(GenericSignature signature, UUID uuid,
+                   SubstitutionMap outerSubs);
 
   /// Make vanilla new/delete illegal.
   void *operator new(size_t Bytes) = delete;
@@ -219,8 +228,9 @@ public:
     return Mem; 
   }
 
-  /// For an opaque archetype environment, apply the substitutions.
-  Type maybeApplyOpaqueTypeSubstitutions(Type type) const;
+  /// For an opaque or pack element archetype environment, apply the
+  /// substitutions.
+  Type maybeApplyOuterContextSubstitutions(Type type) const;
 
   /// Compute the canonical interface type within this environment.
   Type getCanonicalInterfaceType(Type interfaceType);

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6188,14 +6188,6 @@ public:
   /// \endcode
   bool isParameterPack() const;
 
-  /// Returns a new GenericTypeParamType with the same depth and index
-  /// as this one, with the type parameter pack bit set.
-  GenericTypeParamType *asParameterPack(ASTContext &ctx) const;
-
-  /// Returns a new GenericTypeParamType with the same depth and index
-  /// as this one, removing the type parameter pack bit.
-  GenericTypeParamType *asScalar(ASTContext &ctx) const;
-
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {
     return T->getKind() == TypeKind::GenericTypeParam;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5016,7 +5016,8 @@ GenericEnvironment::forOpenedExistential(
 
 /// Create a new generic environment for an element archetype.
 GenericEnvironment *
-GenericEnvironment::forOpenedElement(GenericSignature signature, UUID uuid) {
+GenericEnvironment::forOpenedElement(GenericSignature signature, UUID uuid,
+                                     SubstitutionMap outerSubs) {
   auto &ctx = signature->getASTContext();
 
   auto &openedElementEnvironments =
@@ -5038,7 +5039,8 @@ GenericEnvironment::forOpenedElement(GenericSignature signature, UUID uuid) {
                                   OpenedElementEnvironmentData, Type>(
       0, 0, 1, numGenericParams);
   void *mem = ctx.Allocate(bytes, alignof(GenericEnvironment));
-  auto *genericEnv = new (mem) GenericEnvironment(signature, uuid);
+  auto *genericEnv = new (mem) GenericEnvironment(signature, uuid,
+                                                  outerSubs);
 
   openedElementEnvironments[uuid] = genericEnv;
 

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -196,7 +196,7 @@ class Verifier : public ASTWalker {
   SmallVector<ScopeLike, 4> Scopes;
 
   /// The stack of generic contexts.
-  using GenericLike = llvm::PointerUnion<DeclContext *, GenericSignature>;
+  using GenericLike = llvm::PointerUnion<DeclContext *, GenericEnvironment *>;
   SmallVector<GenericLike, 2> Generics;
 
   /// The stack of optional evaluations active at this point.
@@ -634,10 +634,21 @@ public:
 
           auto genericCtx = Generics.back();
           GenericSignature genericSig;
-          if (auto *genericDC = genericCtx.dyn_cast<DeclContext *>())
+          if (auto *genericDC = genericCtx.dyn_cast<DeclContext *>()) {
             genericSig = genericDC->getGenericSignatureOfContext();
-          else
-            genericSig = genericCtx.get<GenericSignature>();
+          } else {
+            auto *genericEnv = genericCtx.get<GenericEnvironment *>();
+            genericSig = genericEnv->getGenericSignature();
+
+            // Check whether this archetype is a substitution from the
+            // outer generic context of an opened element environment.
+            if (genericEnv->getKind() == GenericEnvironment::Kind::OpenedElement) {
+              auto contextSubs = genericEnv->getPackElementContextSubstitutions();
+              QuerySubstitutionMap isInContext{contextSubs};
+              if (isInContext(root->getInterfaceType()->getAs<GenericTypeParamType>()))
+                return false;
+            }
+          }
 
           if (genericSig.getPointer() != archetypeSig.getPointer()) {
             Out << "Archetype " << root->getString() << " not allowed "
@@ -824,7 +835,7 @@ public:
       if (!shouldVerify(cast<Expr>(expr)))
         return false;
 
-      Generics.push_back(expr->getGenericEnvironment()->getGenericSignature());
+      Generics.push_back(expr->getGenericEnvironment());
 
       for (auto *placeholder : expr->getOpaqueValues()) {
         assert(!OpaqueValues.count(placeholder));
@@ -837,8 +848,8 @@ public:
     void verifyCheckedAlways(PackExpansionExpr *E) {
       // Remove the element generic environment before verifying
       // the pack expansion type, which contains pack archetypes.
-      assert(Generics.back().get<GenericSignature>().getPointer() ==
-             E->getGenericEnvironment()->getGenericSignature().getPointer());
+      assert(Generics.back().get<GenericEnvironment *>() ==
+             E->getGenericEnvironment());
       Generics.pop_back();
       verifyCheckedAlwaysBase(E);
     }

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -645,7 +645,7 @@ public:
             if (genericEnv->getKind() == GenericEnvironment::Kind::OpenedElement) {
               auto contextSubs = genericEnv->getPackElementContextSubstitutions();
               QuerySubstitutionMap isInContext{contextSubs};
-              if (isInContext(root->getInterfaceType()->getAs<GenericTypeParamType>()))
+              if (isInContext(root->getInterfaceType()->castTo<GenericTypeParamType>()))
                 return false;
             }
           }

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -404,78 +404,82 @@ GenericEnvironment::getOrCreateArchetypeFromInterfaceType(Type depType) {
   Type result;
 
   auto rootGP = requirements.anchor->getRootGenericParam();
-  if (rootGP->isParameterPack()) {
-    assert(getKind() == Kind::Primary);
-    result = PackArchetypeType::get(ctx, this, requirements.anchor,
-                                    requirements.packShape,
-                                    requirements.protos, superclass,
-                                    requirements.layout);
-  } else {
-    switch (getKind()) {
-    case Kind::Primary:
+  switch (getKind()) {
+  case Kind::Primary:
+    if (rootGP->isParameterPack()) {
+      result = PackArchetypeType::get(ctx, this, requirements.anchor,
+                                      requirements.packShape,
+                                      requirements.protos, superclass,
+                                      requirements.layout);
+    } else {
       result = PrimaryArchetypeType::getNew(ctx, this, requirements.anchor,
                                             requirements.protos, superclass,
                                             requirements.layout);
-      break;
+    }
 
-    case Kind::Opaque: {
-      // If the anchor type isn't rooted in a generic parameter that
-      // represents an opaque declaration, then apply the outer substitutions.
-      // It would be incorrect to build an opaque type archetype here.
-      unsigned opaqueDepth =
-          getOpaqueTypeDecl()->getOpaqueGenericParams().front()->getDepth();
-      if (rootGP->getDepth() < opaqueDepth) {
-        result = maybeApplyOuterContextSubstitutions(requirements.anchor);
-        break;
-      }
+    break;
 
-      result = OpaqueTypeArchetypeType::getNew(this, requirements.anchor,
-                                               requirements.protos, superclass,
-                                               requirements.layout);
+  case Kind::Opaque: {
+    assert(!rootGP->isParameterPack());
+
+    // If the anchor type isn't rooted in a generic parameter that
+    // represents an opaque declaration, then apply the outer substitutions.
+    // It would be incorrect to build an opaque type archetype here.
+    unsigned opaqueDepth =
+        getOpaqueTypeDecl()->getOpaqueGenericParams().front()->getDepth();
+    if (rootGP->getDepth() < opaqueDepth) {
+      result = maybeApplyOuterContextSubstitutions(requirements.anchor);
       break;
     }
 
-    case Kind::OpenedExistential: {
-      // FIXME: The existential layout's protocols might differ from the
-      // canonicalized set of protocols determined by the generic signature.
-      // Before NestedArchetypeType was removed, we used the former when
-      // building a root OpenedArchetypeType, and the latter when building
-      // nested archetypes.
-      // For compatibility, continue using the existential layout's version when
-      // the interface type is a generic parameter. We should align these at
-      // some point.
-      if (depType->is<GenericTypeParamType>()) {
-        auto layout = getOpenedExistentialType()->getExistentialLayout();
-        SmallVector<ProtocolDecl *, 2> protos;
-        for (auto proto : layout.getProtocols())
-          protos.push_back(proto);
-
-        result = OpenedArchetypeType::getNew(this, requirements.anchor, protos,
-                                             superclass, requirements.layout);
-      } else {
-        result = OpenedArchetypeType::getNew(this, requirements.anchor,
+    result = OpaqueTypeArchetypeType::getNew(this, requirements.anchor,
                                              requirements.protos, superclass,
                                              requirements.layout);
-      }
+    break;
+  }
 
+  case Kind::OpenedExistential: {
+    assert(!rootGP->isParameterPack());
+
+    // FIXME: The existential layout's protocols might differ from the
+    // canonicalized set of protocols determined by the generic signature.
+    // Before NestedArchetypeType was removed, we used the former when
+    // building a root OpenedArchetypeType, and the latter when building
+    // nested archetypes.
+    // For compatibility, continue using the existential layout's version when
+    // the interface type is a generic parameter. We should align these at
+    // some point.
+    if (depType->is<GenericTypeParamType>()) {
+      auto layout = getOpenedExistentialType()->getExistentialLayout();
+      SmallVector<ProtocolDecl *, 2> protos;
+      for (auto proto : layout.getProtocols())
+        protos.push_back(proto);
+
+      result = OpenedArchetypeType::getNew(this, requirements.anchor, protos,
+                                           superclass, requirements.layout);
+    } else {
+      result = OpenedArchetypeType::getNew(this, requirements.anchor,
+                                           requirements.protos, superclass,
+                                           requirements.layout);
+    }
+
+    break;
+  }
+
+  case Kind::OpenedElement: {
+    auto packElements = getGenericSignature().getInnermostGenericParams();
+    auto elementDepth = packElements.front()->getDepth();
+
+    if (rootGP->getDepth() < elementDepth) {
+      result = maybeApplyOuterContextSubstitutions(requirements.anchor);
       break;
     }
 
-    case Kind::OpenedElement: {
-      auto packElements = getGenericSignature().getInnermostGenericParams();
-      auto elementDepth = packElements.front()->getDepth();
-
-      if (rootGP->getDepth() < elementDepth) {
-        result = maybeApplyOuterContextSubstitutions(requirements.anchor);
-        break;
-      }
-
-      result = ElementArchetypeType::getNew(this, requirements.anchor,
-                                            requirements.protos, superclass,
-                                            requirements.layout);
-      break;
-    }
-    }
+    result = ElementArchetypeType::getNew(this, requirements.anchor,
+                                          requirements.protos, superclass,
+                                          requirements.layout);
+    break;
+  }
   }
 
   if (genericParam)

--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -67,20 +67,6 @@ bool GenericTypeParamType::isParameterPack() const {
          GenericTypeParamType::TYPE_SEQUENCE_BIT;
 }
 
-GenericTypeParamType *
-GenericTypeParamType::asParameterPack(ASTContext &ctx) const {
-  return GenericTypeParamType::get(/*isParameterPack*/true,
-                                   getDepth(), getIndex(),
-                                   ctx);
-}
-
-GenericTypeParamType *
-GenericTypeParamType::asScalar(ASTContext &ctx) const {
-  return GenericTypeParamType::get(/*isParameterPack*/false,
-                                   getDepth(), getIndex(),
-                                   ctx);
-}
-
 /// G<{X1, ..., Xn}, {Y1, ..., Yn}>... => {G<X1, Y1>, ..., G<Xn, Yn>}...
 PackExpansionType *PackExpansionType::expand() {
   auto countType = getCountType();

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -951,6 +951,13 @@ InferredGenericSignatureRequest::evaluate(
           continue;
 
         if (reduced->isTypeParameter()) {
+          // If one side is a parameter pack and the other is not, this is a
+          // same-element requirement that cannot be expressed with only one
+          // type parameter.
+          if ((genericParam->isParameterPack() && !reduced->isParameterPack()) ||
+              (!genericParam->isParameterPack() && reduced->isParameterPack()))
+            continue;
+
           ctx.Diags.diagnose(loc, diag::requires_generic_params_made_equal,
                              genericParam, result->getSugaredType(reduced))
             .warnUntilSwiftVersion(6);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3627,7 +3627,7 @@ CanType OpaqueTypeArchetypeType::getCanonicalInterfaceType(Type interfaceType) {
   auto sig = Environment->getOpaqueTypeDecl()
       ->getOpaqueInterfaceGenericSignature();
   CanType canonicalType = interfaceType->getReducedType(sig);
-  return Environment->maybeApplyOpaqueTypeSubstitutions(canonicalType)
+  return Environment->maybeApplyOuterContextSubstitutions(canonicalType)
       ->getCanonicalType();
 }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2932,7 +2932,10 @@ namespace {
       auto *shapeTypeVar = CS.createTypeVariable(shapeLoc,
                                                  TVO_CanBindToPack |
                                                  TVO_CanBindToHole);
-      CS.addConstraint(ConstraintKind::ShapeOf, patternTy, shapeTypeVar,
+      auto packReference = expr->getBindings().front();
+      auto packType = CS.simplifyType(CS.getType(packReference))
+          ->castTo<PackExpansionType>()->getPatternType();
+      CS.addConstraint(ConstraintKind::ShapeOf, packType, shapeTypeVar,
                        CS.getConstraintLocator(expr));
 
       return PackExpansionType::get(patternTy, shapeTypeVar);

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -441,7 +441,11 @@ static Expr *getPackExpansion(DeclContext *dc, Expr *expr, SourceLoc opLoc) {
           if (!environment) {
             auto sig = ctx.getOpenedElementSignature(
                 dc->getGenericSignatureOfContext().getCanonicalSignature());
-            environment = GenericEnvironment::forOpenedElement(sig, UUID::fromTime());
+            auto *contextEnv = dc->getGenericEnvironmentOfContext();
+            auto contextSubs = contextEnv->getForwardingSubstitutionMap();
+            environment =
+                GenericEnvironment::forOpenedElement(sig, UUID::fromTime(),
+                                                     contextSubs);
           }
           auto elementType = environment->mapPackTypeIntoElementContext(
               expansionType->getPatternType()->mapTypeOutOfContext());

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 722; // has_symbol SIL serialization
+const uint16_t SWIFTMODULE_VERSION_MINOR = 723; // generic environment substitution
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1729,7 +1729,8 @@ namespace decls_block {
     GENERIC_ENVIRONMENT,
     BCFixed<1>,                  // GenericEnvironmentKind
     TypeIDField,                 // existential type
-    GenericSignatureIDField      // parent signature
+    GenericSignatureIDField,     // parent signature
+    SubstitutionMapIDField       // substitution map
   >;
 
   using SubstitutionMapLayout = BCRecordLayout<

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1504,11 +1504,13 @@ void Serializer::writeASTBlockEntity(const GenericEnvironment *genericEnv) {
     auto existentialTypeID = addTypeRef(genericEnv->getOpenedExistentialType());
     auto parentSig = genericEnv->getOpenedExistentialParentSignature();
     auto parentSigID = addGenericSignatureRef(parentSig);
+    auto emptySubs = SubstitutionMap();
+    auto subsID = addSubstitutionMapRef(emptySubs);
 
     auto genericEnvAbbrCode = DeclTypeAbbrCodes[GenericEnvironmentLayout::Code];
     GenericEnvironmentLayout::emitRecord(Out, ScratchRecord, genericEnvAbbrCode,
                                          unsigned(kind), existentialTypeID,
-                                         parentSigID);
+                                         parentSigID, subsID);
     return;
   }
 
@@ -1516,11 +1518,13 @@ void Serializer::writeASTBlockEntity(const GenericEnvironment *genericEnv) {
     auto kind = GenericEnvironmentKind::OpenedElement;
     auto parentSig = genericEnv->getGenericSignature();
     auto parentSigID = addGenericSignatureRef(parentSig);
+    auto contextSubs = genericEnv->getPackElementContextSubstitutions();
+    auto subsID = addSubstitutionMapRef(contextSubs);
 
     auto genericEnvAbbrCode = DeclTypeAbbrCodes[GenericEnvironmentLayout::Code];
     GenericEnvironmentLayout::emitRecord(Out, ScratchRecord, genericEnvAbbrCode,
                                          unsigned(kind), /*existentialTypeID=*/0,
-                                         parentSigID);
+                                         parentSigID, subsID);
     return;
   }
 

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -58,3 +58,8 @@ func outerArchetype<T..., U>(t: T..., u: U) where T: P {
 func sameElement<T..., U>(t: T..., u: U) where T: P, T == U {
   let _: T... = t.f(u)...
 }
+
+func forEachEach<C..., U>(c: C..., function: (U) -> Void)
+    where C: Collection, C.Element == U {
+  _ = c.forEach(function)...
+}

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -42,3 +42,19 @@ func localValuePack<T...>(_ t: T...) -> (T..., T...) {
 
   return (local..., localAnnotated...)
 }
+
+protocol P {
+  associatedtype A
+
+  var value: A { get }
+
+  func f(_ self: Self) -> Self
+}
+
+func outerArchetype<T..., U>(t: T..., u: U) where T: P {
+  let _: (T.A, U)... = (t.value, u)...
+}
+
+func sameElement<T..., U>(t: T..., u: U) where T: P, T == U {
+  let _: T... = t.f(u)...
+}


### PR DESCRIPTION
Model opened pack element signatures as a complete clone of the outer context signature, with an additional set of element type parameters at depth + 1 and corresponding element requirements. The generic environment stores a substitution map for all generic parameters whose depth is lower than the element depth, using the archetypes from the outer generic context when mapping types into this generic context.

For example, given this generic signature:

```swift
<T..., U> where T: P, T.A == U
```

The opened element generic signature is:

```swift
<T_0_0..., T_0_1, T_1_0> where T_0_0: P, T_1_0: P, T_0_0.[P]A == T_0_1, T_1_0.[P]A == T_0_1
```

where `T_1_0` represents an element in `T_0_0`. The element generic environment also stores substitutions for `T_0_0` and `T_0_1` to the archetypes created in the generic context of the original signature.