### PR TITLE
[SourceKit] Resolve info request

### DIFF
--- a/test/SourceKit/ResolveInfo/Inputs/other.swift
+++ b/test/SourceKit/ResolveInfo/Inputs/other.swift
@@ -1,0 +1,6 @@
+extension C {
+	convenience init(msg: String) {
+		self.init()
+		print(msg)
+	}
+}

--- a/test/SourceKit/ResolveInfo/basic.swift
+++ b/test/SourceKit/ResolveInfo/basic.swift
@@ -1,0 +1,53 @@
+let x: Int = 3
+let y = "abc"
+
+let z = x
+
+struct A {}
+
+func bar() {
+    let x = 4.0
+    let y = A()
+    print(x)
+}
+
+
+// RUN: %sourcekitd-test -req=collect-resolve-info %s -- %s | %FileCheck %s
+// CHECK: <Declarations>
+// CHECK-NEXT: Reference (7, 10):
+// CHECK-NEXT: 	Kind: Struct
+// CHECK-NEXT: 	USR: s:Si
+// CHECK-NEXT: 	Module: Swift
+// CHECK-NEXT: 	Module group: Math/Integers
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (38, 39):
+// CHECK-NEXT: 	Kind: Var
+// CHECK-NEXT: 	USR: s:5basic1xSivp
+// CHECK-NEXT: 	Source: SOURCE_DIR/test/SourceKit/ResolveInfo/basic.swift
+// CHECK-NEXT: 	Range: (4, 5)
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (95, 96):
+// CHECK-NEXT: 	Kind: Constructor
+// CHECK-NEXT: 	USR: s:5basic1AVACycfc
+// CHECK-NEXT: 	Source: SOURCE_DIR/test/SourceKit/ResolveInfo/basic.swift
+// CHECK-NEXT: 	Range: (48, 52)
+// CHECK-NEXT: 	Synthesized: 1
+// CHECK-NEXT: 	Secondary declaration:
+// CHECK-NEXT: 		Kind: Struct
+// CHECK-NEXT: 		USR: s:5basic1AV
+// CHECK-NEXT: 		Source: SOURCE_DIR/test/SourceKit/ResolveInfo/basic.swift
+// CHECK-NEXT: 		Range: (48, 49)
+// CHECK-NEXT: 		Synthesized: 0
+// CHECK-NEXT: Reference (103, 108):
+// CHECK-NEXT: 	Kind: Func
+// CHECK-NEXT: 	USR: s:s5print_9separator10terminatoryypd_S2StF
+// CHECK-NEXT: 	Module: Swift
+// CHECK-NEXT: 	Module group: Misc
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (109, 110):
+// CHECK-NEXT: 	Kind: Var
+// CHECK-NEXT: 	s:5basic3baryyF1xL_Sdvp
+// CHECK-NEXT: 	Source: SOURCE_DIR/test/SourceKit/ResolveInfo/basic.swift
+// CHECK-NEXT: 	Range: (75, 76)
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: </Declarations>

--- a/test/SourceKit/ResolveInfo/disabled.swift
+++ b/test/SourceKit/ResolveInfo/disabled.swift
@@ -1,0 +1,23 @@
+let a = 1
+#if false
+print(a)
+#endif
+print(a)
+
+
+
+// RUN: %sourcekitd-test -req=collect-resolve-info %s -- %s | %FileCheck %s
+// CHECK: <Declarations>
+// CHECK-NEXT: Reference (36, 41):
+// CHECK-NEXT: 	Kind: Func
+// CHECK-NEXT: 	USR: s:s5print_9separator10terminatoryypd_S2StF
+// CHECK-NEXT: 	Module: Swift
+// CHECK-NEXT: 	Module group: Misc
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (42, 43):
+// CHECK-NEXT: 	Kind: Var
+// CHECK-NEXT: 	USR: s:8disabled1aSivp
+// CHECK-NEXT: 	Source: SOURCE_DIR/test/SourceKit/ResolveInfo/disabled.swift
+// CHECK-NEXT: 	Range: (4, 5)
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: </Declarations>

--- a/test/SourceKit/ResolveInfo/if_let_shorthand.swift
+++ b/test/SourceKit/ResolveInfo/if_let_shorthand.swift
@@ -1,0 +1,27 @@
+var a: Int? = 1
+
+if let a {
+    print(a)
+}
+
+// RUN: %sourcekitd-test -req=collect-resolve-info %s -- %s | %FileCheck %s
+// CHECK: <Declarations>
+// CHECK-NEXT: Reference (7, 10):
+// CHECK-NEXT: 	Kind: Struct
+// CHECK-NEXT: 	USR: s:Si
+// CHECK-NEXT: 	Module: Swift
+// CHECK-NEXT: 	Module group: Math/Integers
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (32, 37):
+// CHECK-NEXT: 	Kind: Func
+// CHECK-NEXT: 	USR: s:s5print_9separator10terminatoryypd_S2StF
+// CHECK-NEXT: 	Module: Swift
+// CHECK-NEXT: 	Module group: Misc
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (38, 39):
+// CHECK-NEXT: 	Kind: Var
+// CHECK-NEXT: 	USR: s:16if_let_shorthand1aL_Sivp
+// CHECK-NEXT: 	Source: SOURCE_DIR/test/SourceKit/ResolveInfo/if_let_shorthand.swift
+// CHECK-NEXT: 	Range: (24, 25)
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: </Declarations>

--- a/test/SourceKit/ResolveInfo/multiple_sources.swift
+++ b/test/SourceKit/ResolveInfo/multiple_sources.swift
@@ -1,0 +1,19 @@
+class C {}
+
+let c = C(msg: "Hello")
+
+// RUN: %sourcekitd-test -req=collect-resolve-info %s -- %s %S/Inputs/other.swift | %FileCheck %s
+// CHECK: <Declarations>
+// CHECK-NEXT: Reference (20, 21):
+// CHECK-NEXT:	Kind: Constructor
+// CHECK-NEXT:	USR: s:4main1CC3msgACSS_tcfc
+// CHECK-NEXT:	Source: SOURCE_DIR/test/SourceKit/ResolveInfo/Inputs/other.swift
+// CHECK-NEXT:	Range: (27, 44)
+// CHECK-NEXT:	Synthesized: 0
+// CHECK-NEXT:	Secondary declaration:
+// CHECK-NEXT:		Kind: Class
+// CHECK-NEXT:		USR: s:4main1CC
+// CHECK-NEXT:		Source: SOURCE_DIR/test/SourceKit/ResolveInfo/multiple_sources.swift
+// CHECK-NEXT:		Range: (6, 7)
+// CHECK-NEXT:		Synthesized: 0
+// CHECK-NEXT: </Declarations>

--- a/test/SourceKit/ResolveInfo/secondary_decl.swift
+++ b/test/SourceKit/ResolveInfo/secondary_decl.swift
@@ -1,0 +1,65 @@
+class C {
+    init() {}
+}
+
+let c = C()
+
+extension Int {
+    init(str: String) {
+     self.init(0.0)
+    }
+}
+
+let num = Int(str: "Hello")
+
+// RUN: %sourcekitd-test -req=collect-resolve-info %s -- %s | %FileCheck %s
+// CHECK: <Declarations>
+// CHECK-NEXT: Reference (35, 36):
+// CHECK-NEXT: 	Kind: Constructor
+// CHECK-NEXT: 	USR: s:14secondary_decl1CCACycfc
+// CHECK-NEXT: 	Source: SOURCE_DIR/test/SourceKit/ResolveInfo/secondary_decl.swift
+// CHECK-NEXT: 	Range: (14, 20)
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: 	Secondary declaration:
+// CHECK-NEXT: 		Kind: Class
+// CHECK-NEXT: 		USR: s:14secondary_decl1CC
+// CHECK-NEXT: 		Source: SOURCE_DIR/test/SourceKit/ResolveInfo/secondary_decl.swift
+// CHECK-NEXT: 		Range: (6, 7)
+// CHECK-NEXT: 		Synthesized: 0
+// CHECK-NEXT: Reference (50, 53):
+// CHECK-NEXT: 	Kind: Struct
+// CHECK-NEXT: 	USR: s:Si
+// CHECK-NEXT: 	Module: Swift
+// CHECK-NEXT: 	Module group: Math/Integers
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (70, 76):
+// CHECK-NEXT: 	Kind: Struct
+// CHECK-NEXT: 	USR: s:SS
+// CHECK-NEXT: 	Module: Swift
+// CHECK-NEXT: 	Module group: String
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (85, 89):
+// CHECK-NEXT: 	Kind: Param
+// CHECK-NEXT: 	USR: s:Si14secondary_declE3strSiSS_tcfc4selfL_Sivp
+// CHECK-NEXT: 	Source: SOURCE_DIR/test/SourceKit/ResolveInfo/secondary_decl.swift
+// CHECK-NEXT: 	Range: (60, 64)
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (90, 94):
+// CHECK-NEXT: 	Kind: Constructor
+// CHECK-NEXT: 	USR: s:SiySiSdcfc
+// CHECK-NEXT: 	Module: Swift
+// CHECK-NEXT: 	Module group: Math/Integers
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (119, 122):
+// CHECK-NEXT: 	Kind: Constructor
+// CHECK-NEXT: 	USR: s:Si14secondary_declE3strSiSS_tcfc
+// CHECK-NEXT: 	Source: SOURCE_DIR/test/SourceKit/ResolveInfo/secondary_decl.swift
+// CHECK-NEXT: 	Range: (60, 77)
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: 	Secondary declaration:
+// CHECK-NEXT: 		Kind: Struct
+// CHECK-NEXT: 		USR: s:Si
+// CHECK-NEXT: 		Module: Swift
+// CHECK-NEXT: 		Module group: Math/Integers
+// CHECK-NEXT: 		Synthesized: 0
+// CHECK-NEXT: </Declarations>

--- a/test/SourceKit/ResolveInfo/synthesized.swift
+++ b/test/SourceKit/ResolveInfo/synthesized.swift
@@ -1,0 +1,84 @@
+class H: Hashable {
+    static func == (lhs: H, rhs: H) -> Bool {
+        true
+    }
+
+    func hash(into hasher: inout Hasher) {}
+
+    func _rawHashValue(seed: Int) -> Int {
+        21
+    }
+}
+
+let h = H()
+
+let _ = h.hashValue
+
+// RUN: %sourcekitd-test -req=collect-resolve-info %s -- %s | %FileCheck %s
+// CHECK: <Declarations>
+// CHECK-NEXT: Reference (9, 17):
+// CHECK-NEXT: 	Kind: Protocol
+// CHECK-NEXT: 	USR: s:SH
+// CHECK-NEXT: 	Module: Swift
+// CHECK-NEXT: 	Module group: Hashing
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (45, 46):
+// CHECK-NEXT: 	Kind: Class
+// CHECK-NEXT: 	USR: s:11synthesized1HC
+// CHECK-NEXT: 	Source: SOURCE_DIR/test/SourceKit/ResolveInfo/synthesized.swift
+// CHECK-NEXT: 	Range: (6, 7)
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (53, 54):
+// CHECK-NEXT: 	Kind: Class
+// CHECK-NEXT: 	USR: s:11synthesized1HC
+// CHECK-NEXT: 	Source: SOURCE_DIR/test/SourceKit/ResolveInfo/synthesized.swift
+// CHECK-NEXT: 	Range: (6, 7)
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (59, 63):
+// CHECK-NEXT: 	Kind: Struct
+// CHECK-NEXT: 	USR: s:Sb
+// CHECK-NEXT: 	Module: Swift
+// CHECK-NEXT: 	Module group: Bool
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (119, 125):
+// CHECK-NEXT: 	Kind: Struct
+// CHECK-NEXT: 	USR: s:s6HasherV
+// CHECK-NEXT: 	Module: Swift
+// CHECK-NEXT: 	Module group: Hashing
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (160, 163):
+// CHECK-NEXT: 	Kind: Struct
+// CHECK-NEXT: 	USR: s:Si
+// CHECK-NEXT: 	Module: Swift
+// CHECK-NEXT: 	Module group: Math/Integers
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (168, 171):
+// CHECK-NEXT: 	Kind: Struct
+// CHECK-NEXT: 	USR: s:Si
+// CHECK-NEXT: 	Module: Swift
+// CHECK-NEXT: 	Module group: Math/Integers
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (202, 203):
+// CHECK-NEXT: 	Kind: Constructor
+// CHECK-NEXT: 	USR: s:11synthesized1HCACycfc
+// CHECK-NEXT: 	Source: SOURCE_DIR/test/SourceKit/ResolveInfo/synthesized.swift
+// CHECK-NEXT: 	Range: (6, 10)
+// CHECK-NEXT: 	Synthesized: 1
+// CHECK-NEXT: 	Secondary declaration:
+// CHECK-NEXT: 		Kind: Class
+// CHECK-NEXT: 		USR: s:11synthesized1HC
+// CHECK-NEXT: 		Source: SOURCE_DIR/test/SourceKit/ResolveInfo/synthesized.swift
+// CHECK-NEXT: 		Range: (6, 7)
+// CHECK-NEXT: 		Synthesized: 0
+// CHECK-NEXT: Reference (215, 216):
+// CHECK-NEXT: 	Kind: Var
+// CHECK-NEXT: 	USR: s:11synthesized1hAA1HCvp
+// CHECK-NEXT: 	Source: SOURCE_DIR/test/SourceKit/ResolveInfo/synthesized.swift
+// CHECK-NEXT: 	Range: (198, 199)
+// CHECK-NEXT: 	Synthesized: 0
+// CHECK-NEXT: Reference (217, 226):
+// CHECK-NEXT: 	Kind: Var
+// CHECK-NEXT: 	USR: s:11synthesized1HC9hashValueSivp
+// CHECK-NEXT: 	Module: synthesized
+// CHECK-NEXT: 	Synthesized: 1
+// CHECK-NEXT: </Declarations>

--- a/tools/SourceKit/docs/Protocol.md
+++ b/tools/SourceKit/docs/Protocol.md
@@ -830,6 +830,58 @@ var-type-info ::=
 $ sourcekitd-test -req=collect-var-type /path/to/file.swift -- /path/to/file.swift
 ```
 
+## Resolve Info
+Collects all references in a document and returns their declarations. It returns the path to the document, the 
+offset, and the length of the declaration if this information is available. For the declarations that are not in the 
+project sources, it returns the USR and the module name. These can be used to find the offset in a generated interface 
+document (see `Module interface generation`). If a matching document is already open, its id is added to the response 
+as `module-interface-name`.
+
+### Request
+
+```
+{
+    <key.request>:                  (UID)     <source.request.resolve.info>,
+    <key.sourcefile>:               (string)  // Absolute path to the file.
+    <key.compilerargs>:             [string*] // Array of zero or more strings for the compiler arguments,
+                                              // e.g., ["-sdk", "/path/to/sdk"]. These must include the path to the 
+                                              // provided source file.
+}
+```
+
+### Response
+```
+{
+    <key.results>:       (array) [resolve-info*]   // A list containing the references in the source file and
+                                                   // information about the corresponding declaration for each reference.
+}
+```
+
+```
+resolve-info ::=
+{ 
+    <key.reference_offset>:             (int64)  // Byte offset of the reference in the provided source file.
+    <key.reference_length>:             (int64)  // Length of the reference in the provided source file.
+    <key.kind>:                         (string) // The declaration kind (Struct, Protocol, etc.).
+    <key.usr>:                          (string) // USR for the declaration.
+    <key.is_synthesized>:               (bool)   // True if the declaration is synthesized.
+    [opt] <key.offset>:                 (int64)  // Byte offset of the declaration.
+    [opt] <key.length>:                 (int64)  // Length of the declaration.
+    [opt] <key.modulename>:             (string) // Module that contains the declaration.
+    [opt] <key.groupname>:              (string) // Module group name.
+    [opt] <key.module_interface_name>:  (string) // If the declaration is in a generated interface document that is already
+                                                 // open, the unique id of the document is provided.
+    [opt] <key.secondary_declaration>:  (dict)   // If the reference points to a synthesized constructor, the secondary 
+                                                 // declaration contains the type declaration.
+}
+```
+
+### Testing
+
+```
+$ sourcekitd-test -req=collect-resolve-info /path/to/file.swift -- /path/to/file.swift
+```
+
 # UIDs
 
 ## Keys

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -17,6 +17,7 @@
 #include "SourceKit/Support/CancellationToken.h"
 #include "SourceKit/Support/UIdent.h"
 #include "swift/AST/Type.h"
+#include "swift/IDE/Utils.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/Optional.h"
@@ -472,6 +473,23 @@ struct CursorSymbolInfo {
   llvm::Optional<unsigned> ParentNameOffset;
 };
 
+struct DeclarationInfo {
+  StringRef Kind = "";
+  StringRef USR = "";
+  StringRef ModuleName = "";
+  StringRef GroupName = "";
+  StringRef ModuleInterfaceName = "";
+  LocationInfo Location = LocationInfo();
+  bool IsSynthesized = false;
+};
+
+struct ResolveInfo {
+  unsigned RefOffset = 0;
+  unsigned RefLength = 0;
+  DeclarationInfo Decl;
+  DeclarationInfo SecondaryDecl;
+};
+
 struct CursorInfoData {
   // If nonempty, a proper Info could not be resolved (and the rest of the Info
   // will be empty). Clients can potentially use this to show a diagnostic
@@ -894,6 +912,13 @@ public:
       ArrayRef<const char *> ExpectedProtocols, bool FullyQualified,
       bool CanonicalType, SourceKitCancellationToken CancellationToken,
       std::function<void(const RequestResult<ExpressionTypesInFile> &)>
+          Receiver) = 0;
+
+  virtual void collectResolvedReferences(
+      StringRef FileName, ArrayRef<const char *> Args,
+      Optional<VFSOptions> vfsOptions,
+      SourceKitCancellationToken CancellationToken,
+      std::function<void(const RequestResult<std::vector<ResolveInfo>> &)>
           Receiver) = 0;
 
   /// Collects variable types for a range defined by `Offset` and `Length` in

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -680,6 +680,13 @@ public:
       std::function<void(const RequestResult<ExpressionTypesInFile> &)>
           Receiver) override;
 
+  void collectResolvedReferences(
+      StringRef Filename, ArrayRef<const char *> Args,
+      Optional<VFSOptions> vfsOptions,
+      SourceKitCancellationToken CancellationToken,
+      std::function<void(const RequestResult<std::vector<ResolveInfo>> &)>
+          Receiver) override;
+
   void collectVariableTypes(
       StringRef FileName, ArrayRef<const char *> Args,
       Optional<unsigned> Offset, Optional<unsigned> Length, bool FullyQualified,

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -152,6 +152,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
         .Case("diags", SourceKitRequest::Diagnostics)
         .Case("compile", SourceKitRequest::Compile)
         .Case("compile.close", SourceKitRequest::CompileClose)
+        .Case("collect-resolve-info", SourceKitRequest::CollectResolveInfo)
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) .Case("refactoring." #ID, SourceKitRequest::KIND)
 #include "swift/Refactoring/RefactoringKinds.def"
         .Default(SourceKitRequest::None);
@@ -202,6 +203,7 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
                      << "- collect-type\n"
                      << "- global-config\n"
                      << "- dependency-updated\n"
+                     << "- collect-resolve-info\n"
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) << "- refactoring." #ID "\n"
 #include "swift/Refactoring/RefactoringKinds.def"
                         "\n";

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -65,6 +65,7 @@ enum class SourceKitRequest {
   CollectExpressionType,
   CollectVariableType,
   GlobalConfiguration,
+  CollectResolveInfo,
   DependencyUpdated,
   Diagnostics,
   Compile,

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -124,7 +124,6 @@ UID_KEYS = [
     KEY('SwiftVersion', 'key.swift_version'),
     KEY('Value', 'key.value'),
     KEY('EnableDiagnostics', 'key.enablediagnostics'),
-    KEY('GroupName', 'key.groupname'),
     KEY('ActionName', 'key.actionname'),
     KEY('SynthesizedExtension', 'key.synthesizedextensions'),
     KEY('UsingSwiftArgs', 'key.usingswiftargs'),
@@ -136,6 +135,7 @@ UID_KEYS = [
     KEY('Overrides', 'key.overrides'),
     KEY('AssociatedUSRs', 'key.associated_usrs'),
     KEY('ModuleName', 'key.modulename'),
+    KEY('GroupName', 'key.groupname'),
     KEY('RelatedDecls', 'key.related_decls'),
     KEY('Simplified', 'key.simplified'),
     KEY('RangeContent', 'key.rangecontent'),
@@ -201,7 +201,11 @@ UID_KEYS = [
     # Before executing the actual request wait x ms. The request can be canceled
     # in this time. For cancellation testing purposes.
     KEY('SimulateLongRequest', 'key.simulate_long_request'),
+    KEY('RefOffset', 'key.reference_offset'),
+    KEY('RefLength', 'key.reference_length'),
+    KEY('DeclSource', 'key.declaration_source_file'),
     KEY('IsSynthesized', 'key.is_synthesized'),
+    KEY('SecondaryDecl', 'key.secondary_declaration')
 ]
 
 
@@ -260,6 +264,7 @@ UID_REQUESTS = [
     REQUEST('TestNotification', 'source.request.test_notification'),
     REQUEST('CollectExpressionType', 'source.request.expression.type'),
     REQUEST('CollectVariableType', 'source.request.variable.type'),
+    REQUEST('CollectResolveInfo', 'source.request.resolve.info'),
     REQUEST('GlobalConfiguration', 'source.request.configuration.global'),
     REQUEST('DependencyUpdated', 'source.request.dependency_updated'),
     REQUEST('Diagnostics', 'source.request.diagnostics'),


### PR DESCRIPTION
This adds a new request to SourceKit that provides resolve information for the references in a file. It returns the path to the document, the offset, and the length of the declaration if this information is available. For the declarations that are not in the 
project sources, it returns the USR and the module name. `tools/SourceKit/docs/Protocol.md` contains a detailed description of the request.

@rintaro do you mind taking a look at this?