### PR TITLE
Fix effective context construction for NS_OPTIONS in linkage spec

### DIFF
--- a/test/Interop/Cxx/enum/Inputs/CenumsNSOptions.apinotes
+++ b/test/Interop/Cxx/enum/Inputs/CenumsNSOptions.apinotes
@@ -8,3 +8,11 @@ Enumerators:
   SwiftName: SwiftOptionThreeApiNotes
 - Name: API_NOTES_NAMED_OptionFour
   SwiftName: SwiftOptionFourApiNotes
+Tags:
+- Name: UIPrinterJobTypes
+  SwiftName: UIPrinter.JobTypes
+SwiftVersions:
+- Version: 4
+  Tags:
+  - Name: UIPrinterJobTypes
+    SwiftName: UIPrinterJobTypes

--- a/test/Interop/Cxx/enum/Inputs/CenumsNSOptionsExternC.apinotes
+++ b/test/Interop/Cxx/enum/Inputs/CenumsNSOptionsExternC.apinotes
@@ -1,0 +1,9 @@
+Name: CenumsNSOptionsExternC
+Tags:
+- Name: UIPrinterJobTypes
+  SwiftName: UIPrinter.JobTypes
+SwiftVersions:
+- Version: 4
+  Tags:
+  - Name: UIPrinterJobTypes
+    SwiftName: UIPrinterJobTypes

--- a/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
@@ -18,8 +18,10 @@ extern "C" {
 #define CF_OPTIONS(_type, _name) _type __attribute__((availability(swift, unavailable))) _name; enum __CF_OPTIONS_ATTRIBUTES : _name
 #define NS_OPTIONS(_type, _name) CF_OPTIONS(_type, _name)
 #define NS_REFINED_FOR_SWIFT __attribute__((swift_private))
+#define UIKIT_EXTERN extern "C" __attribute__((visibility("default")))
 
 typedef unsigned long NSUInteger;
+typedef long NSInteger;
 
 typedef NS_OPTIONS(NSUInteger, NSBinarySearchingOptions) {
 	NSBinarySearchingFirstEqual = (1UL << 8),
@@ -38,6 +40,23 @@ typedef NS_OPTIONS(NSUInteger, NSAttributedStringFormattingOptions) {
 @interface NSAttributedString (NSAttributedStringFormatting)
 - (instancetype)initWithOptions:(NSAttributedStringFormattingOptions)options
     NS_REFINED_FOR_SWIFT;
+@end
+
+UIKIT_EXTERN
+@interface UIPrinter
+
+typedef NS_OPTIONS(NSInteger, UIPrinterJobTypes) {
+  UIPrinterJobTypeUnknown = 0,
+  UIPrinterJobTypeDocument = 1 << 0,
+  UIPrinterJobTypeEnvelope = 1 << 1,
+  UIPrinterJobTypeLabel = 1 << 2,
+  UIPrinterJobTypePhoto = 1 << 3,
+  UIPrinterJobTypeReceipt = 1 << 4,
+  UIPrinterJobTypeRoll = 1 << 5,
+  UIPrinterJobTypeLargeFormat = 1 << 6,
+  UIPrinterJobTypePostcard = 1 << 7
+};
+
 @end
 }
 

--- a/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS_without_extern_C.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS_without_extern_C.h
@@ -1,0 +1,32 @@
+#if __has_attribute(enum_extensibility)
+#define __CF_ENUM_ATTRIBUTES __attribute__((enum_extensibility(open)))
+#define __CF_CLOSED_ENUM_ATTRIBUTES __attribute__((enum_extensibility(closed)))
+#define __CF_OPTIONS_ATTRIBUTES __attribute__((flag_enum,enum_extensibility(open)))
+#else
+#define __CF_ENUM_ATTRIBUTES
+#define __CF_CLOSED_ENUM_ATTRIBUTES
+#define __CF_OPTIONS_ATTRIBUTES
+#endif
+
+#define CF_OPTIONS(_type, _name) _type __attribute__((availability(swift, unavailable))) _name; enum __CF_OPTIONS_ATTRIBUTES : _name
+#define NS_OPTIONS(_type, _name) CF_OPTIONS(_type, _name)
+#define UIKIT_EXTERN extern "C" __attribute__((visibility("default")))
+
+typedef long NSInteger;
+
+UIKIT_EXTERN
+@interface UIPrinter
+
+typedef NS_OPTIONS(NSInteger, UIPrinterJobTypes) {
+  UIPrinterJobTypeUnknown = 0,
+  UIPrinterJobTypeDocument = 1 << 0,
+  UIPrinterJobTypeEnvelope = 1 << 1,
+  UIPrinterJobTypeLabel = 1 << 2,
+  UIPrinterJobTypePhoto = 1 << 3,
+  UIPrinterJobTypeReceipt = 1 << 4,
+  UIPrinterJobTypeRoll = 1 << 5,
+  UIPrinterJobTypeLargeFormat = 1 << 6,
+  UIPrinterJobTypePostcard = 1 << 7
+};
+
+@end

--- a/test/Interop/Cxx/enum/Inputs/module.modulemap
+++ b/test/Interop/Cxx/enum/Inputs/module.modulemap
@@ -27,3 +27,8 @@ module TypedUntypedEnums {
   header "typed-untyped-enums.h"
   requires cplusplus
 }
+
+module CenumsNSOptionsExternC [extern_c] {
+  header "c-enums-NS_OPTIONS_without_extern_C.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-transparent-linkage-spec-decl-modulemap-based-extern-c.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-transparent-linkage-spec-decl-modulemap-based-extern-c.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-swift-frontend %s -swift-version 5 -I %S/Inputs -typecheck -module-cache-path %t/cache -enable-experimental-cxx-interop 2>&1 | %FileCheck --allow-empty %s
+
+// REQUIRES: objc_interop
+
+import CenumsNSOptionsExternC
+
+// CHECK-NOT: warning: imported declaration '' could not be mapped to 'UIPrinter.JobTypes'
+// CHECK-NOT: note: please report this issue to the owners of 'CenumsNSOptions'
+

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-transparent-linkage-spec-decl.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-transparent-linkage-spec-decl.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-swift-frontend %s -swift-version 5 -I %S/Inputs -typecheck -module-cache-path %t/cache -enable-experimental-cxx-interop 2>&1 | %FileCheck --allow-empty %s
+
+// REQUIRES: objc_interop
+
+import CenumsNSOptions
+
+// CHECK-NOT: warning: imported declaration '' could not be mapped to 'UIPrinter.JobTypes'
+// CHECK-NOT: note: please report this issue to the owners of 'CenumsNSOptions'
+


### PR DESCRIPTION
This patch is motivated by more errors produced when finalizing the SwiftLookupTable with cxx-interop enabled. In particular, `SwiftLookupTable::translateContextDecl` only knows how to convert a small set of decls into a `StoredContext`. When cxx-interop is turned on, we get more `LinkageSpecDecl` nodes that ordinary. 

If we ever created an `EffectiveClangContext` which holds reference to a `LinkageSpecDecl` we'll get mapping errors such those shown in the added test.

In this patch, we have modified the constructor of `EffectiveClangContext` to skip over any `LinkageSpecDecl`s. We have noticed that `determineEffectiveContext` includes some of the same behavior. In particular, it dispatches to `getRedeclContext` which will skip so called "transparent" contexts, `LinkageSpecDecls` included:

```cpp
DeclContext *DeclContext::getRedeclContext() {
  DeclContext *Ctx = this;

  // In C, a record type is the redeclaration context for its fields only. If
  // we arrive at a record context after skipping anything else, we should skip
  // the record as well. Currently, this means skipping enumerations because
  // they're the only transparent context that can exist within a struct or
  // union.
  bool SkipRecords = getDeclKind() == Decl::Kind::Enum &&
                     !getParentASTContext().getLangOpts().CPlusPlus;

  // Skip through contexts to get to the redeclaration context. Transparent
  // contexts are always skipped.
  while ((SkipRecords && Ctx->isRecord()) || Ctx->isTransparentContext())
    Ctx = Ctx->getParent();
  return Ctx;
}
```

This particular error, can also be fixed by calling `determineEffectiveContext` on produced contexts like so:
```patch
diff --git a/lib/ClangImporter/ImportName.cpp b/lib/ClangImporter/ImportName.cpp
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1773,7 +1773,8 @@
         // It also means they may not have intended this API to be imported like this.
         if (importer::isUnavailableInSwift(typedefType->getDecl(), nullptr, true)) {
           result.setDeclName(swiftCtx.getIdentifier(typedefType->getDecl()->getName()));
-          result.setEffectiveContext(D->getDeclContext());
+          result.setEffectiveContext(
+              determineEffectiveContext(D, D->getDeclContext(), version));
           return result;
         }
       }
```

We could use some input on if this unwrapping should occur at all times, and the best place for it (`determineEffectiveContext` vs `EffectiveClangContext::EffectiveClangContext`) as the logic seems split between the two at the moment.