### PR TITLE
SwiftConfigureSDK.cmake: convert tabs to spaces

### DIFF
--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -392,9 +392,9 @@ macro(configure_sdk_unix name architectures)
 
         set(SWIFT_SDK_OPENBSD_ARCH_amd64_TRIPLE "amd64-unknown-openbsd${openbsd_system_version}")
 
-	if(CMAKE_SYSROOT)
-	  set(SWIFT_SDK_OPENBSD_ARCH_${arch}_PATH "${CMAKE_SYSROOT}${SWIFT_SDK_OPENBSD_ARCH_${arch}_PATH}" CACHE INTERNAL "sysroot path" FORCE)
-	endif()
+        if(CMAKE_SYSROOT)
+          set(SWIFT_SDK_OPENBSD_ARCH_${arch}_PATH "${CMAKE_SYSROOT}${SWIFT_SDK_OPENBSD_ARCH_${arch}_PATH}" CACHE INTERNAL "sysroot path" FORCE)
+        endif()
       elseif("${prefix}" STREQUAL "CYGWIN")
         if(NOT arch STREQUAL x86_64)
           message(FATAL_ERROR "unsupported arch for cygwin: ${arch}")


### PR DESCRIPTION
Using tabs instead of spaces in this file led to inconsistency and broken formatting.
