### PR TITLE
[Concurrency] TaskLocal.withValue closure should produce no warnings inside Actor

### DIFF
--- a/stdlib/public/BackDeployConcurrency/TaskLocal.swift
+++ b/stdlib/public/BackDeployConcurrency/TaskLocal.swift
@@ -102,6 +102,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     self.defaultValue = defaultValue
   }
 
+  @usableFromInline
   var key: Builtin.RawPointer {
     unsafeBitCast(self, to: Builtin.RawPointer.self)
   }
@@ -135,7 +136,10 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// If the value is a reference type, it will be retained for the duration of
   /// the operation closure.
   @discardableResult
+  @inline(__always)
   @_unsafeInheritExecutor
+  @available(SwiftStdlib 5.1, *) // back deploy requires we declare the availability explicitly on this method
+  @_backDeploy(before: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999) // SwiftStdlib 5.8 but it doesn't work with _backDeploy
   public func withValue<R>(_ valueDuringOperation: Value, operation: () async throws -> R,
                            file: String = #file, line: UInt = #line) async rethrows -> R {
     // check if we're not trying to bind a value from an illegal context; this may crash
@@ -161,6 +165,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// If the value is a reference type, it will be retained for the duration of
   /// the operation closure.
   @discardableResult
+  @inline(__always)
   public func withValue<R>(_ valueDuringOperation: Value, operation: () throws -> R,
                            file: String = #file, line: UInt = #line) rethrows -> R {
     // check if we're not trying to bind a value from an illegal context; this may crash
@@ -172,6 +177,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     return try operation()
   }
 
+  @inline(__always)
   public var projectedValue: TaskLocal<Value> {
     get {
       self
@@ -213,6 +219,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
 // ==== ------------------------------------------------------------------------
 
 @available(SwiftStdlib 5.1, *)
+@usableFromInline
 @_silgen_name("swift_task_localValuePush")
 func _taskLocalValuePush<Value>(
   key: Builtin.RawPointer/*: Key*/,
@@ -220,16 +227,19 @@ func _taskLocalValuePush<Value>(
 ) // where Key: TaskLocal
 
 @available(SwiftStdlib 5.1, *)
+@usableFromInline
 @_silgen_name("swift_task_localValuePop")
 func _taskLocalValuePop()
 
 @available(SwiftStdlib 5.1, *)
+@usableFromInline
 @_silgen_name("swift_task_localValueGet")
 func _taskLocalValueGet(
   key: Builtin.RawPointer/*Key*/
 ) -> UnsafeMutableRawPointer? // where Key: TaskLocal
 
 @available(SwiftStdlib 5.1, *)
+@usableFromInline
 @_silgen_name("swift_task_localsCopyTo")
 func _taskLocalsCopy(
   to target: Builtin.NativeObject

--- a/stdlib/public/BackDeployConcurrency/TaskLocal.swift
+++ b/stdlib/public/BackDeployConcurrency/TaskLocal.swift
@@ -134,8 +134,9 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   ///
   /// If the value is a reference type, it will be retained for the duration of
   /// the operation closure.
+  @Sendable
   @discardableResult
-  public func withValue<R>(_ valueDuringOperation: Value, operation: () async throws -> R,
+  public func withValue<R>(_ valueDuringOperation: Value, operation: @Sendable () async throws -> R,
                            file: String = #file, line: UInt = #line) async rethrows -> R {
     // check if we're not trying to bind a value from an illegal context; this may crash
     _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)

--- a/stdlib/public/BackDeployConcurrency/TaskLocal.swift
+++ b/stdlib/public/BackDeployConcurrency/TaskLocal.swift
@@ -134,9 +134,9 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   ///
   /// If the value is a reference type, it will be retained for the duration of
   /// the operation closure.
-  @Sendable
   @discardableResult
-  public func withValue<R>(_ valueDuringOperation: Value, operation: @Sendable () async throws -> R,
+  @_unsafeInheritExecutor
+  public func withValue<R>(_ valueDuringOperation: Value, operation: () async throws -> R,
                            file: String = #file, line: UInt = #line) async rethrows -> R {
     // check if we're not trying to bind a value from an illegal context; this may crash
     _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)

--- a/stdlib/public/BackDeployConcurrency/TaskLocal.swift
+++ b/stdlib/public/BackDeployConcurrency/TaskLocal.swift
@@ -102,7 +102,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     self.defaultValue = defaultValue
   }
 
-  @usableFromInline
+  @_alwaysEmitIntoClient
   var key: Builtin.RawPointer {
     unsafeBitCast(self, to: Builtin.RawPointer.self)
   }
@@ -136,10 +136,10 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// If the value is a reference type, it will be retained for the duration of
   /// the operation closure.
   @discardableResult
-  @inline(__always)
+  @inlinable
   @_unsafeInheritExecutor
   @available(SwiftStdlib 5.1, *) // back deploy requires we declare the availability explicitly on this method
-  @_backDeploy(before: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999) // SwiftStdlib 5.8 but it doesn't work with _backDeploy
+  @_backDeploy(before: SwiftStdlib 5.8)
   public func withValue<R>(_ valueDuringOperation: Value, operation: () async throws -> R,
                            file: String = #file, line: UInt = #line) async rethrows -> R {
     // check if we're not trying to bind a value from an illegal context; this may crash
@@ -164,8 +164,8 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   ///
   /// If the value is a reference type, it will be retained for the duration of
   /// the operation closure.
+  @inlinable
   @discardableResult
-  @inline(__always)
   public func withValue<R>(_ valueDuringOperation: Value, operation: () throws -> R,
                            file: String = #file, line: UInt = #line) rethrows -> R {
     // check if we're not trying to bind a value from an illegal context; this may crash
@@ -177,7 +177,6 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     return try operation()
   }
 
-  @inline(__always)
   public var projectedValue: TaskLocal<Value> {
     get {
       self
@@ -219,7 +218,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
 // ==== ------------------------------------------------------------------------
 
 @available(SwiftStdlib 5.1, *)
-@usableFromInline
+@_alwaysEmitIntoClient
 @_silgen_name("swift_task_localValuePush")
 func _taskLocalValuePush<Value>(
   key: Builtin.RawPointer/*: Key*/,
@@ -227,19 +226,17 @@ func _taskLocalValuePush<Value>(
 ) // where Key: TaskLocal
 
 @available(SwiftStdlib 5.1, *)
-@usableFromInline
+@_alwaysEmitIntoClient
 @_silgen_name("swift_task_localValuePop")
 func _taskLocalValuePop()
 
 @available(SwiftStdlib 5.1, *)
-@usableFromInline
 @_silgen_name("swift_task_localValueGet")
 func _taskLocalValueGet(
   key: Builtin.RawPointer/*Key*/
 ) -> UnsafeMutableRawPointer? // where Key: TaskLocal
 
 @available(SwiftStdlib 5.1, *)
-@usableFromInline
 @_silgen_name("swift_task_localsCopyTo")
 func _taskLocalsCopy(
   to target: Builtin.NativeObject

--- a/stdlib/public/BackDeployConcurrency/TaskLocal.swift
+++ b/stdlib/public/BackDeployConcurrency/TaskLocal.swift
@@ -218,7 +218,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
 // ==== ------------------------------------------------------------------------
 
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@usableFromInline
 @_silgen_name("swift_task_localValuePush")
 func _taskLocalValuePush<Value>(
   key: Builtin.RawPointer/*: Key*/,
@@ -226,7 +226,7 @@ func _taskLocalValuePush<Value>(
 ) // where Key: TaskLocal
 
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@usableFromInline
 @_silgen_name("swift_task_localValuePop")
 func _taskLocalValuePop()
 

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -135,7 +135,8 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// If the value is a reference type, it will be retained for the duration of
   /// the operation closure.
   @discardableResult
-  public func withValue<R>(_ valueDuringOperation: Value, operation: @Sendable () async throws -> R,
+  @_unsafeInheritExecutor
+  public func withValue<R>(_ valueDuringOperation: Value, operation: () async throws -> R,
                            file: String = #fileID, line: UInt = #line) async rethrows -> R {
     // check if we're not trying to bind a value from an illegal context; this may crash
     _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -102,6 +102,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     self.defaultValue = defaultValue
   }
 
+  @usableFromInline
   var key: Builtin.RawPointer {
     unsafeBitCast(self, to: Builtin.RawPointer.self)
   }
@@ -136,6 +137,8 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// the operation closure.
   @discardableResult
   @_unsafeInheritExecutor
+  @available(SwiftStdlib 5.1, *) // back deploy requires we declare the availability explicitly on this method
+  @_backDeploy(before: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999) // SwiftStdlib 5.8 but it doesn't work with _backDeploy
   public func withValue<R>(_ valueDuringOperation: Value, operation: () async throws -> R,
                            file: String = #fileID, line: UInt = #line) async rethrows -> R {
     // check if we're not trying to bind a value from an illegal context; this may crash
@@ -161,6 +164,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// If the value is a reference type, it will be retained for the duration of
   /// the operation closure.
   @discardableResult
+  @inline(__always)
   public func withValue<R>(_ valueDuringOperation: Value, operation: () throws -> R,
                            file: String = #fileID, line: UInt = #line) rethrows -> R {
     // check if we're not trying to bind a value from an illegal context; this may crash
@@ -172,6 +176,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     return try operation()
   }
 
+  @inline(__always)
   public var projectedValue: TaskLocal<Value> {
     get {
       self
@@ -213,6 +218,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
 // ==== ------------------------------------------------------------------------
 
 @available(SwiftStdlib 5.1, *)
+@usableFromInline
 @_silgen_name("swift_task_localValuePush")
 func _taskLocalValuePush<Value>(
   key: Builtin.RawPointer/*: Key*/,
@@ -220,16 +226,19 @@ func _taskLocalValuePush<Value>(
 ) // where Key: TaskLocal
 
 @available(SwiftStdlib 5.1, *)
+@usableFromInline
 @_silgen_name("swift_task_localValuePop")
 func _taskLocalValuePop()
 
 @available(SwiftStdlib 5.1, *)
+@usableFromInline
 @_silgen_name("swift_task_localValueGet")
 func _taskLocalValueGet(
   key: Builtin.RawPointer/*Key*/
 ) -> UnsafeMutableRawPointer? // where Key: TaskLocal
 
 @available(SwiftStdlib 5.1, *)
+@usableFromInline
 @_silgen_name("swift_task_localsCopyTo")
 func _taskLocalsCopy(
   to target: Builtin.NativeObject

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -135,7 +135,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   /// If the value is a reference type, it will be retained for the duration of
   /// the operation closure.
   @discardableResult
-  public func withValue<R>(_ valueDuringOperation: Value, operation: () async throws -> R,
+  public func withValue<R>(_ valueDuringOperation: Value, operation: @Sendable () async throws -> R,
                            file: String = #fileID, line: UInt = #line) async rethrows -> R {
     // check if we're not trying to bind a value from an illegal context; this may crash
     _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -102,7 +102,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     self.defaultValue = defaultValue
   }
 
-  @usableFromInline
+  @_alwaysEmitIntoClient
   var key: Builtin.RawPointer {
     unsafeBitCast(self, to: Builtin.RawPointer.self)
   }
@@ -135,10 +135,11 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   ///
   /// If the value is a reference type, it will be retained for the duration of
   /// the operation closure.
+  @inlinable
   @discardableResult
   @_unsafeInheritExecutor
   @available(SwiftStdlib 5.1, *) // back deploy requires we declare the availability explicitly on this method
-  @_backDeploy(before: macOS 9999, iOS 9999, watchOS 9999, tvOS 9999) // SwiftStdlib 5.8 but it doesn't work with _backDeploy
+  @_backDeploy(before: SwiftStdlib 5.8)
   public func withValue<R>(_ valueDuringOperation: Value, operation: () async throws -> R,
                            file: String = #fileID, line: UInt = #line) async rethrows -> R {
     // check if we're not trying to bind a value from an illegal context; this may crash
@@ -163,8 +164,8 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
   ///
   /// If the value is a reference type, it will be retained for the duration of
   /// the operation closure.
+  @inlinable
   @discardableResult
-  @inline(__always)
   public func withValue<R>(_ valueDuringOperation: Value, operation: () throws -> R,
                            file: String = #fileID, line: UInt = #line) rethrows -> R {
     // check if we're not trying to bind a value from an illegal context; this may crash
@@ -176,7 +177,6 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     return try operation()
   }
 
-  @inline(__always)
   public var projectedValue: TaskLocal<Value> {
     get {
       self
@@ -218,7 +218,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
 // ==== ------------------------------------------------------------------------
 
 @available(SwiftStdlib 5.1, *)
-@usableFromInline
+@_alwaysEmitIntoClient
 @_silgen_name("swift_task_localValuePush")
 func _taskLocalValuePush<Value>(
   key: Builtin.RawPointer/*: Key*/,
@@ -226,19 +226,17 @@ func _taskLocalValuePush<Value>(
 ) // where Key: TaskLocal
 
 @available(SwiftStdlib 5.1, *)
-@usableFromInline
+@_alwaysEmitIntoClient
 @_silgen_name("swift_task_localValuePop")
 func _taskLocalValuePop()
 
 @available(SwiftStdlib 5.1, *)
-@usableFromInline
 @_silgen_name("swift_task_localValueGet")
 func _taskLocalValueGet(
   key: Builtin.RawPointer/*Key*/
 ) -> UnsafeMutableRawPointer? // where Key: TaskLocal
 
 @available(SwiftStdlib 5.1, *)
-@usableFromInline
 @_silgen_name("swift_task_localsCopyTo")
 func _taskLocalsCopy(
   to target: Builtin.NativeObject

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -218,7 +218,7 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
 // ==== ------------------------------------------------------------------------
 
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@usableFromInline
 @_silgen_name("swift_task_localValuePush")
 func _taskLocalValuePush<Value>(
   key: Builtin.RawPointer/*: Key*/,
@@ -226,7 +226,7 @@ func _taskLocalValuePush<Value>(
 ) // where Key: TaskLocal
 
 @available(SwiftStdlib 5.1, *)
-@_alwaysEmitIntoClient
+@usableFromInline
 @_silgen_name("swift_task_localValuePop")
 func _taskLocalValuePop()
 

--- a/test/Concurrency/Runtime/async_task_locals_basic.swift
+++ b/test/Concurrency/Runtime/async_task_locals_basic.swift
@@ -200,6 +200,24 @@ func withLocal_body_mustNotEscape() async {
 }
 
 @available(SwiftStdlib 5.1, *)
+actor Worker {
+  @TaskLocal
+  static var declaredInActor: String = "<default-value>"
+
+  func setAndRead() async {
+    print("setAndRead") // CHECK: setAndRead
+    await Worker.$declaredInActor.withValue("value-1") {
+      await printTaskLocalAsync(Worker.$declaredInActor) // CHECK-NEXT: TaskLocal<String>(defaultValue: <default-value>) (value-1)
+    }
+  }
+}
+
+@available(SwiftStdlib 5.1, *)
+func inside_actor() async {
+  await Worker().setAndRead()
+}
+
+@available(SwiftStdlib 5.1, *)
 @main struct Main {
   static func main() async {
     await simple()
@@ -210,5 +228,6 @@ func withLocal_body_mustNotEscape() async {
     await nested_3_onlyTopContributes()
     await nested_3_onlyTopContributesAsync()
     await nested_3_onlyTopContributesMixed()
+    await inside_actor()
   }
 }

--- a/test/Concurrency/async_task_locals_basic_warnings.swift
+++ b/test/Concurrency/async_task_locals_basic_warnings.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/OtherActors.swiftmodule -module-name OtherActors %S/Inputs/OtherActors.swift -disable-availability-checking
+// RUN: %target-typecheck-verify-swift -I %t  -disable-availability-checking -warn-concurrency -parse-as-library
+// REQUIRES: concurrency
+
+// REQUIRES: concurrency
+
+@available(SwiftStdlib 5.1, *)
+actor Test {
+
+  @TaskLocal static var local: Int?
+
+  func run() async {
+    // This should NOT produce any warnings, the closure withValue uses is @Sendable:
+    await Test.$local.withValue(42) {
+      await work()
+    }
+  }
+
+  func work() async {
+    print("Hello \(Test.local ?? 0)")
+  }
+}


### PR DESCRIPTION
Without the @Sendable, using a task-local's `withValue` results with unexpected warnings which scared developers into thinking they might be misusing the API.

This PR adds the missing annotation; I believe this is ABI compatible, but would like to make sure.

Resolves https://github.com/apple/swift/issues/62220
rdar://102638772