### PR TITLE
[WIP] Add the ability to get/set a backtrace value on an error

### DIFF
--- a/docs/Runtime.md
+++ b/docs/Runtime.md
@@ -235,6 +235,8 @@ process start and the function returns.
 
 ```
 0000000000027140 T _swift_willThrow
+                   swift_errorCopyBacktrace
+                   swift_errorSetBacktrace
 ```
 
 ## Objective-C Bridging

--- a/include/swift/Runtime/Error.h
+++ b/include/swift/Runtime/Error.h
@@ -71,6 +71,20 @@ SWIFT_RUNTIME_STDLIB_API void
 swift_willThrow(SWIFT_CONTEXT void *unused,
                 SWIFT_ERROR_RESULT SwiftError **object);
 
+/// For debugger use only -- copies a backtrace previously assigned to an
+/// error by @c swift_errorSetBacktrace(). The caller takes ownership of the
+/// result and must release it with @c swift_unknownObjectRelease() when done.
+SWIFT_CC(swift)
+SWIFT_RUNTIME_STDLIB_API OpaqueValue *
+swift_errorCopyBacktrace(SwiftError *object);
+
+/// For debugger use only -- stores a backtrace in an error. If a backtrace has
+/// already been stored for this error, @a overwrite determines if it is
+/// replaced or not.
+SWIFT_CC(swift)
+SWIFT_RUNTIME_STDLIB_API void
+swift_errorSetBacktrace(SwiftError *object, OpaqueValue *value, bool overwrite);
+
 /// Called when an error is thrown out of the top level of a script.
 SWIFT_CC(swift)
 SWIFT_RUNTIME_STDLIB_API SWIFT_NORETURN void

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -160,6 +160,20 @@ FUNCTION(WillThrow, swift_willThrow, SwiftCC,  AlwaysAvailable,
          ATTRS(NoUnwind),
          EFFECT(NoEffect))
 
+// OpaqueValue *swift_errorCopyBacktrace(SwiftError *object);
+FUNCTION(ErrorCopyBacktrace, swift_errorCopyBacktrace, SwiftCC, AlwaysAvailable,
+         RETURNS(RefCountedPtrTy),
+         ARGS(ErrorPtrTy),
+         ATTRS(NoUnwind),
+         EFFECT(RefCounting))
+
+// void swift_errorSetBacktrace(SwiftError *object, OpaqueValue *value, bool overwrite);
+FUNCTION(ErrorSetBacktrace, swift_errorSetBacktrace, SwiftCC, AlwaysAvailable,
+         RETURNS(VoidTy),
+         ARGS(ErrorPtrTy, RefCountedPtrTy, Int1Ty),
+         ATTRS(NoUnwind),
+         EFFECT(RefCounting, Deallocating))
+
 // void swift_errorInMain(error *ptr);
 FUNCTION(ErrorInMain, swift_errorInMain, SwiftCC, AlwaysAvailable,
          RETURNS(VoidTy),

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -290,13 +290,6 @@ swift::swift_allocError(const Metadata *type,
   return BoxPair{reinterpret_cast<HeapObject*>(instance), valuePtr};
 }
 
-/// Deallocate an error object whose contained object has already been
-/// destroyed.
-void
-swift::swift_deallocError(SwiftError *error, const Metadata *type) {
-  object_dispose((id)error);
-}
-
 static const WitnessTable *getNSErrorConformanceToError() {
   // CFError and NSError are toll-free-bridged, so we can use either type's
   // witness table interchangeably. CFError's is potentially slightly more

--- a/stdlib/public/runtime/ErrorObjectNative.cpp
+++ b/stdlib/public/runtime/ErrorObjectNative.cpp
@@ -92,12 +92,6 @@ swift::swift_allocError(const swift::Metadata *type,
 }
 
 void
-swift::swift_deallocError(SwiftError *error, const Metadata *type) {
-  auto sizeAndAlign = _getErrorAllocatedSizeAndAlignmentMask(type);
-  swift_deallocUninitializedObject(error, sizeAndAlign.first, sizeAndAlign.second);
-}
-
-void
 swift::swift_getErrorValue(const SwiftError *errorObject,
                            void **scratch,
                            ErrorValueResult *out) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
This change adds the ability to get/set a backtrace value on an error so that `swift_willThrow` can be used in a more concurrency-safe manner.

## Problem

In normal execution, errors do not capture backtraces when thrown because the cost of doing so can be prohibitive. However, when an error is thrown from test code, it is extremely useful to know where the error originated.

Today, testing libraries such as XCTest set the runtime hook `_swift_willThrow` which is called whenever an error is thrown in Swift. This function is global, and reconciling the task from which an error was thrown with the current task when the error is finally caught is effectively impossible:

- A task-local value is required to track the error in concurrent code, but task-local values are immutable.
- Using a reference type for the task-local value allows mutation, but a mutable reference type is not `Sendable`, and task-local values must be sendable.
- Using `@unchecked Sendable` is insufficient because multiple subtasks may inherit the same instance and end up modifying the task-local object concurrently.
- Adding a lock to synchronize access prevents data _corruption_ but not data _loss_ as multiple subtasks may end up throwing errors at the same time. (Also, the Swift standard library does not include a cross-platform lock type, so using a lock in cross-platform code requires platform-specific implementations.)

## Solution

The solution I've implemented here is to allow storing the backtrace as a refcounted object _within_ an `Error` and exposing two hidden API functions (_à la_ `_swift_willThrow`) to get and set this field atomically. A testing library that sets `_swift_willThrow` can then use these functions to set the error's backtrace at the moment it's thrown and look it up later when diagnosing the issue.

### Memory requirements

For instances of `NSError`, the object is stored as an associated object for lack of available inline storage. For other kinds of `Error` including all Swift-native error types, it is stored as a `std::atomic` refcounted field in the `SwiftError` structure.

### Runtime costs

In normal execution, these functions are never called, so there is no observable cost to them except:

- **The logical size of `SwiftError` is increased by 4/8 bytes.** On 64-bit Darwin, the current logical size of a `SwiftError` is 72 bytes (`CFRuntimeBase = 16` + `7 * sizeof(void *)`), which is not a multiple of 16 bytes, so the addition of another pointer-width field ends up being free!

- **`swift_deallocError()`must read the field to determine if it needs to be released.** The cost of reading a single field during deallocation—one that's probably already in the CPU cache—should be swamped by the cost of calling `free()`.

During testing, the cost of adopting these functions should be negligible for libraries that already set `_swift_willThrow` and capture backtraces, and the benefit will be to improve test diagnostics and thread safety in said libraries.

## Alternatives Considered

- One alternative would be to add a `_swift_errorWillDeallocate` hook that a testing library could set (as it sets `_swift_willThrow` today.) The testing library could then implement an internal solution with a hashtable and a lock. The non-testing runtime cost of doing so would be the same—an extra read in `swift_deallocError()`.
- If the use of associated objects with `NSError` is unpalatable (understandable!), Foundation could be updated to add a field in `NSError` for the same purpose. That would require changes in Swift to be introduced in tandem since ErrorObject.mm makes strong assumptions about the size of `NSError`.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
<!-- Resolves #NNNNN, fix apple/llvm-project#MMMMM. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
