### PR TITLE
.github: add `Threading` implementation code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,10 @@ lib/PrintAsClang            @zoecarver @hyp @egorzhdan
 stdlib/public/Cxx           @zoecarver @hyp @egorzhdan
 test/Interop                @zoecarver @hyp @egorzhdan
 
+# Threading implementation
+include/swift/Threading @al45tair
+lib/Threading           @al45tair
+
 # Windows support
 cmake/**/*Windows*    @compnerd
 lib/Basic/Windows     @compnerd


### PR DESCRIPTION
Per a discussion offline, Alastair Houghton is a code owner of `lib/Threading` and `include/swift/Threading`.  