### PR TITLE
watchOS: don't target arm64/arm64e for Compatibility50/51

### DIFF
--- a/stdlib/toolchain/Compatibility50/CMakeLists.txt
+++ b/stdlib/toolchain/Compatibility50/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Don't build the libraries for 64-bit watchOS targets;
+# there is no back-deployment to them.
+list(REMOVE_ITEM SWIFT_SDK_WATCHOS_ARCHITECTURES "arm64" "arm64e")
+
 set(library_name "swiftCompatibility50")
 
 add_swift_target_library("${library_name}" STATIC

--- a/stdlib/toolchain/Compatibility51/CMakeLists.txt
+++ b/stdlib/toolchain/Compatibility51/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Don't build the libraries for 64-bit watchOS targets;
+# there is no back-deployment to them.
+list(REMOVE_ITEM SWIFT_SDK_WATCHOS_ARCHITECTURES "arm64" "arm64e")
 
 set(library_name "swiftCompatibility51")
 


### PR DESCRIPTION
Those architectures were not supported when Swift 5.0/5.1 shipped, so it makes little sense building those.

Addresses rdar://91128579