### PR TITLE
[TBDGen] Ensure classes that emit ObjC MetaClass also emit matching ObjC Class symbols

### DIFF
--- a/include/swift/SIL/SILSymbolVisitor.h
+++ b/include/swift/SIL/SILSymbolVisitor.h
@@ -109,7 +109,6 @@ public:
   virtual void addMethodLookupFunction(ClassDecl *CD) {}
   virtual void addNominalTypeDescriptor(NominalTypeDecl *NTD) {}
   virtual void addObjCInterface(ClassDecl *CD) {}
-  virtual void addObjCMetaclass(ClassDecl *CD) {}
   virtual void addObjCMethod(AbstractFunctionDecl *AFD) {}
   virtual void addObjCResilientClassStub(ClassDecl *CD) {}
   virtual void addOpaqueTypeDescriptor(OpaqueTypeDecl *OTD) {}

--- a/lib/IRGen/IRSymbolVisitor.cpp
+++ b/lib/IRGen/IRSymbolVisitor.cpp
@@ -162,10 +162,6 @@ public:
     Visitor.addObjCInterface(CD);
   }
 
-  void addObjCMetaclass(ClassDecl *CD) override {
-    addLinkEntity(LinkEntity::forObjCMetaclass(CD));
-  }
-
   void addObjCMethod(AbstractFunctionDecl *AFD) override {
     // Pass through; Obj-C methods don't have linkable symbols.
     Visitor.addObjCMethod(AFD);

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -320,15 +320,9 @@ class SILSymbolVisitorImpl : public ASTVisitor<SILSymbolVisitorImpl> {
     // Metaclasses and ObjC classes (duh) are an ObjC thing, and so are not
     // needed in build artifacts/for classes which can't touch ObjC.
     if (objCCompatible) {
-      if (isObjC)
+      if (isObjC || CD->getMetaclassKind() == ClassDecl::MetaclassKind::ObjC)
         Visitor.addObjCInterface(CD);
-
-      if (CD->getMetaclassKind() == ClassDecl::MetaclassKind::ObjC) {
-        // If an ObjCInterface was not added, ObjC Metaclass may still need to
-        // be included.
-        if (!isObjC)
-          Visitor.addObjCMetaclass(CD);
-      } else
+      else
         Visitor.addSwiftMetaclassStub(CD);
     }
 

--- a/test/TBD/multimodule-implied-objc.swift
+++ b/test/TBD/multimodule-implied-objc.swift
@@ -1,0 +1,53 @@
+// REQUIRES: VENDOR=apple
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/cache)
+// RUN: split-file %s %t
+
+/// Create Swift modules to import.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   -module-name IndirectMixedDependency -I %t \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -emit-module %t/IndirectMixedDependency.swift \
+// RUN:   -emit-module-path %t/IndirectMixedDependency.swiftmodule
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -emit-module %t/SwiftDependency.swift \
+// RUN:   -module-name SwiftDependency -I %t\
+// RUN:   -emit-module-path %t/SwiftDependency.swiftmodule
+
+// Generate TBD file.
+// RUN: %target-swift-frontend -I %t -module-cache-path %t/cache \
+// RUN:   %t/Client.swift -emit-ir -o/dev/null -parse-as-library \
+// RUN:   -module-name client -validate-tbd-against-ir=missing \
+// RUN:   -emit-tbd -emit-tbd-path %t/client.tbd 
+
+// RUN: %FileCheck %s < %t/client.tbd
+// CHECK: objc-classes: [ _TtCO6client11extendedAPI6Square ]
+// CHECK-NOT: _OBJC_CLASS_$
+// CHECK-NOT: _OBJC_METACLASS_$
+
+//--- module.modulemap
+module IndirectMixedDependency {
+  header "IndirectMixedDependency.h"
+}
+
+//--- IndirectMixedDependency.h
+@import Foundation;
+@interface Shape : NSObject
+@end
+
+//--- IndirectMixedDependency.swift
+@_exported import IndirectMixedDependency
+
+//--- SwiftDependency.swift
+import IndirectMixedDependency 
+open class Rectangle : IndirectMixedDependency.Shape {}
+
+
+//--- Client.swift
+import SwiftDependency
+
+public enum extendedAPI {}
+extension extendedAPI {
+    public class Square : SwiftDependency.Rectangle {}
+}


### PR DESCRIPTION
This is to account for swift classes that have objc class ancestry. 

resolves: rdar://102525824