### PR TITLE
[Autolink Extract] Filter out StringProcessing library from being linked more than once.

### DIFF
--- a/lib/DriverTool/autolink_extract_main.cpp
+++ b/lib/DriverTool/autolink_extract_main.cpp
@@ -249,6 +249,8 @@ int autolink_extract_main(ArrayRef<const char *> Args, const char *Argv0,
       {"-lswiftSwiftOnoneSupport", false},
       {"-lswiftCore", false},
       {"-lswift_Concurrency", false},
+      {"-lswift_StringProcessing", false},
+      {"-lswift_RegexParser", false}
   };
 
   // Extract the linker flags from the objects.

--- a/test/AutolinkExtract/import.swift
+++ b/test/AutolinkExtract/import.swift
@@ -4,11 +4,13 @@
 // RUN: %target-swift-autolink-extract %t/import_experimental.o -o - | %FileCheck --check-prefix CHECK-%target-object-format %s
 // RUN: %target-swiftc_driver -c %s -I %t -o %t/import_experimental_again.o
 // RUN: %target-swift-autolink-extract %t/import_experimental.o %t/import_experimental_again.o -o - | %FileCheck --check-prefix CHECK-%target-object-format %s
-// RUN: %target-swift-autolink-extract %t/import_experimental.o %t/import_experimental_again.o -o - | %FileCheck --check-prefix UNIQUE %s
+// RUN: %target-swift-autolink-extract %t/import_experimental.o %t/import_experimental_again.o -o - | %FileCheck --check-prefix UNIQUECORE %s
+// RUN: %target-swift-autolink-extract %t/import_experimental.o %t/import_experimental_again.o -o - | %FileCheck --check-prefix UNIQUESTRING %s
 
 // REQUIRES: autolink-extract
 
-// UNIQUE-COUNT-1: -lswiftCore
+// UNIQUECORE-COUNT-1: -lswiftCore
+// UNIQUESTRING-COUNT-1: -lswift_StringProcessing
 
 // CHECK-elf-DAG: -lswiftCore
 // CHECK-elf-DAG: -lempty


### PR DESCRIPTION
We cannot filter all libraries because duplicate -l flags have a semantic meaning based on their order, but filtering out just the common Swift libraries should yield a good size improvement already and is safe.
