### PR TITLE
[move-only] Borrow copyable typed arguments contained within a move only struct/enum.

### DIFF
--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -223,7 +223,7 @@ public:
   }
 
   Expr *findStorageReferenceExprForBorrow() &&;
-  Expr *findStorageReferenceExprForMoveOnlyBorrow() &&;
+  Expr *findStorageReferenceExprForMoveOnlyBorrow(SILGenFunction &SGF) &&;
 
   /// Given that this source is an expression, extract and clear
   /// that expression.

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -4,13 +4,18 @@
 // Declarations //
 //////////////////
 
+public class CopyableKlass {
+    var k = Klass()
+}
+
 @_moveOnly
 public class Klass2 {}
 
 @_moveOnly
 public class Klass {
-    var intField: Int
-    var klsField: Klass2
+    var int: Int
+    var moveOnlyKlass: Klass2
+    var copyableKlass: CopyableKlass
 
     // CHECK-LABEL: sil hidden [ossa] @$s8moveonly5KlassCACycfc : $@convention(method) (@owned Klass) -> @owned Klass {
     // CHECK: bb0([[ARG:%.*]] : @owned $Klass):
@@ -18,28 +23,46 @@ public class Klass {
     // CHECK:   [[MARK_NO_IMP_COPY:%.*]] = mark_must_check [no_implicit_copy] [[MARK_UNINIT]]
     // CHECK: } // end sil function '$s8moveonly5KlassCACycfc'
     init() {
-        klsField = Klass2()
-        intField = 5
+        moveOnlyKlass = Klass2()
+        int = 5
+        copyableKlass = CopyableKlass()
     }
 }
 
 public func nonConsumingUseKlass(_ k: Klass) {}
+public func nonConsumingUseCopyableKlass(_ k: CopyableKlass) {}
 public func nonConsumingUseKlass2(_ k: Klass2) {}
 
 @_moveOnly
 public struct NonTrivialStruct2 {
-    var k = Klass()
+    var moveOnlyKlass = Klass()
+    var copyableKlass = CopyableKlass()
 }
 
 public func nonConsumingUseNonTrivialStruct2(_ s: NonTrivialStruct2) {}
 
 @_moveOnly
 public struct NonTrivialStruct {
-    var k = Klass()
-    var k2 = NonTrivialStruct2()
+    var moveOnlyKlass = Klass()
+    var nonTrivialStruct2 = NonTrivialStruct2()
+    var copyableKlass = CopyableKlass()
+    var nonTrivialCopyableStruct = NonTrivialCopyableStruct()
 }
 
 public func nonConsumingUseNonTrivialStruct(_ s: NonTrivialStruct) {}
+
+public struct NonTrivialCopyableStruct2 {
+    var copyableKlass = CopyableKlass()
+    var copyableKlass2 = CopyableKlass()
+}
+
+public struct NonTrivialCopyableStruct {
+    var copyableKlass = CopyableKlass()
+    var nonTrivialCopyableStruct2 = NonTrivialCopyableStruct2()
+}
+
+public func nonConsumingUseCopyableStruct(_ k: NonTrivialCopyableStruct) {}
+public func nonConsumingUseCopyableStruct2(_ k: NonTrivialCopyableStruct2) {}
 
 @_moveOnly
 public enum NonTrivialEnum {
@@ -92,7 +115,7 @@ public func useKlassConsume(_ k: __owned Klass) {
 public func useNonTrivialStruct(_ s: NonTrivialStruct) {
     nonConsumingUseNonTrivialStruct(s)
     let s2 = s
-    let k = s.k
+    let k = s.moveOnlyKlass
     let _ = k
     nonConsumingUseNonTrivialStruct(s)
     let _ = s2
@@ -106,7 +129,7 @@ public func useNonTrivialStruct(_ s: NonTrivialStruct) {
 public func useNonTrivialOwnedStruct(_ s: __owned NonTrivialStruct) {
     nonConsumingUseNonTrivialStruct(s)
     let s2 = s
-    let k = s.k
+    let k = s.moveOnlyKlass
     let _ = k
     nonConsumingUseNonTrivialStruct(s)
     let _ = s2
@@ -289,7 +312,7 @@ func borrowAddressFunctionCall() {
 
 // We currently have the wrong behavior here since the class is treated by
 // LValue emission as a base. That being said, move only classes are not our
-// high order bit here, so I filed: ...;
+// high order bit here, so I filed a bug. We might be able to do it in the future.
 //
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly31klassBorrowAddressFunctionCall2yyF : $@convention(thin) () -> () {
 // CHECK: [[MARK:%.*]] = mark_must_check [no_implicit_copy]
@@ -298,46 +321,29 @@ func borrowAddressFunctionCall() {
 func klassBorrowAddressFunctionCall2() {
     var k = Klass()
     k = Klass()
-    nonConsumingUseKlass2(k.klsField)
+    nonConsumingUseKlass2(k.moveOnlyKlass)
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s8moveonly31structBorrowObjectFunctionCall1yyF : $@convention(thin) () -> () {
-// CHECK: [[VALUE:%.*]] = mark_must_check [no_implicit_copy]
-// CHECK: [[BORROW:%.*]] = begin_borrow [[VALUE]]
-// CHECK: [[FN:%.*]] = function_ref @$s8moveonly31nonConsumingUseNonTrivialStructyyAA0efG0VF : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
-// CHECK: apply [[FN]]([[BORROW]])
-// CHECK: end_borrow [[BORROW]]
-// CHECK: [[BORROW:%.*]] = begin_borrow [[VALUE]]
-// CHECK: [[STRUCT_EXT:%.*]] = struct_extract [[BORROW]]
-// CHECK: [[STRUCT_EXT_COPY:%.*]] = copy_value [[STRUCT_EXT]]
-// TODO: Should we insert a mark_must_check_here?
-// CHECK: [[FN:%.*]] = function_ref @$s8moveonly20nonConsumingUseKlassyyAA0E0CF
-// CHECK: apply [[FN]]([[STRUCT_EXT_COPY]])
-// CHECK: destroy_value [[STRUCT_EXT_COPY]]
-// CHECK: end_borrow [[BORROW]]
-// CHECK: [[BORROW:%.*]] = begin_borrow [[VALUE]]
-// CHECK: [[STRUCT_EXT:%.*]] = struct_extract [[BORROW]]
-// CHECK: [[STRUCT_EXT_COPY:%.*]] = copy_value [[STRUCT_EXT]]
-// CHECK: [[STRUCT_EXT_COPY_BORROW:%.*]] = begin_borrow [[STRUCT_EXT_COPY]]
-// CHECK: [[METHOD:%.*]] = class_method [[STRUCT_EXT_COPY_BORROW]]
-// CHECK: [[KLS2:%.*]] = apply [[METHOD]]([[STRUCT_EXT_COPY_BORROW]])
-// CHECK: end_borrow [[STRUCT_EXT_COPY_BORROW]]
-// CHECK: [[BORROWED_KLS2:%.*]] = begin_borrow [[KLS2]]
-// CHECK: [[FN:%.*]] = function_ref @$s8moveonly21nonConsumingUseKlass2yyAA0E0CF
-// CHECK: apply [[FN]]([[BORROWED_KLS2]])
-// CHECK: destroy_value [[STRUCT_EXT_COPY]]
-// CHECK: destroy_value [[KLS2]]
-// CHECK: end_borrow [[BORROW]]
-// CHECK: destroy_value [[VALUE]]
-// CHECK: } // end sil function '$s8moveonly31structBorrowObjectFunctionCall1yyF'
-func structBorrowObjectFunctionCall1() {
-    let k = NonTrivialStruct()
-    nonConsumingUseNonTrivialStruct(k)
-    nonConsumingUseKlass(k.k)
-    nonConsumingUseKlass2(k.k.klsField)
+// We copy here since we have a class as our base like the above.
+//
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly38klassBorrowCopyableAddressFunctionCallyyF : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK:  [[CLASS:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:  [[ACCESS:%.*]] = begin_access [read] [unknown] [[CLASS]]
+// CHECK:  [[LOAD:%.*]] = load [copy] [[ACCESS]]
+// CHECK:  end_access [[ACCESS]]
+// CHECK:  [[BORROW_LOAD:%.*]] = begin_borrow [[LOAD]]
+// CHECK:  [[COPY_CLASS:%.*]] = apply {{%.*}}([[BORROW_LOAD]]
+// CHECK:  [[BORROWED_COPY_CLASS:%.*]] = begin_borrow [[COPY_CLASS]]
+// CHECK:  apply {{%.*}}([[BORROWED_COPY_CLASS]])
+// CHECK: } // end sil function '$s8moveonly38klassBorrowCopyableAddressFunctionCallyyF'
+func klassBorrowCopyableAddressFunctionCall() {
+    var k = Klass()
+    k = Klass()
+    nonConsumingUseCopyableKlass(k.copyableKlass)
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s8moveonly31structBorrowObjectFunctionCall2yyF : $@convention(thin) () -> () {
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly29moveOnlyStructNonConsumingUseyyF : $@convention(thin) () -> () {
 // CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK: [[BORROW:%.*]] = load_borrow [[ACCESS]]
@@ -345,6 +351,15 @@ func structBorrowObjectFunctionCall1() {
 // CHECK: apply [[FN]]([[BORROW]])
 // CHECK: end_borrow [[BORROW]]
 // CHECK: end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly29moveOnlyStructNonConsumingUseyyF'
+func moveOnlyStructNonConsumingUse() {
+    var k = NonTrivialStruct()
+    k = NonTrivialStruct()
+    nonConsumingUseNonTrivialStruct(k)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMoveC20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
+// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK: [[STRUCT_EXT:%.*]] = struct_element_addr [[ACCESS]]
 // CHECK: [[BORROW:%.*]] = load_borrow [[STRUCT_EXT]]
@@ -352,10 +367,17 @@ func structBorrowObjectFunctionCall1() {
 // CHECK: apply [[FN]]([[BORROW]])
 // CHECK: end_borrow [[BORROW]]
 // CHECK: end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly018moveOnlyStructMoveC20KlassNonConsumingUseyyF'
+func moveOnlyStructMoveOnlyKlassNonConsumingUse() {
+    var k = NonTrivialStruct()
+    k = NonTrivialStruct()
+    nonConsumingUseKlass(k.moveOnlyKlass)
+}
+
+// We fail here b/c we are accessing through a class.
 //
-// This case we fail due to the class being a base element. We need to use the
-// scope expansion approach to handle this.
-//
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovec5KlassecF15NonConsumingUseyyF : $@convention(thin) () -> () {
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[STRUCT_EXT:%.*]] = struct_element_addr [[ACCESS]]
 // CHECK:   [[STRUCT_EXT_COPY:%.*]] = load [copy] [[STRUCT_EXT]]
@@ -370,28 +392,195 @@ func structBorrowObjectFunctionCall1() {
 // CHECK:   end_borrow [[BORROWED_KLS]]
 // CHECK:   destroy_value [[STRUCT_EXT_COPY]]
 // CHECK:   destroy_value [[KLS]]
+// CHECK: } // end sil function '$s8moveonly018moveOnlyStructMovec5KlassecF15NonConsumingUseyyF'
+func moveOnlyStructMoveOnlyKlassMoveOnlyKlassNonConsumingUse() {
+    var k = NonTrivialStruct()
+    k = NonTrivialStruct()
+    nonConsumingUseKlass2(k.moveOnlyKlass.moveOnlyKlass)
+}
+
+// We fail here b/c we are accessing through a class.
+//
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovec13KlassCopyableF15NonConsumingUseyyF : $@convention(thin) () -> () {
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.k2
+// CHECK:   [[STRUCT_EXT:%.*]] = struct_element_addr [[ACCESS]]
+// CHECK:   [[STRUCT_EXT_COPY:%.*]] = load [copy] [[STRUCT_EXT]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   [[STRUCT_EXT_COPY_BORROW:%.*]] = begin_borrow [[STRUCT_EXT_COPY]]
+// CHECK:   [[METHOD:%.*]] = class_method [[STRUCT_EXT_COPY_BORROW]]
+// CHECK:   [[KLS:%.*]] = apply [[METHOD]]([[STRUCT_EXT_COPY_BORROW]])
+// CHECK:   end_borrow [[STRUCT_EXT_COPY_BORROW]]
+// CHECK:   [[BORROWED_KLS:%.*]] = begin_borrow [[KLS]]
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly28nonConsumingUseCopyableKlassyyAA0eF0CF
+// CHECK:   apply [[FN]]([[BORROWED_KLS]])
+// CHECK:   end_borrow [[BORROWED_KLS]]
+// CHECK:   destroy_value [[STRUCT_EXT_COPY]]
+// CHECK:   destroy_value [[KLS]]
+// CHECK: } // end sil function '$s8moveonly018moveOnlyStructMovec13KlassCopyableF15NonConsumingUseyyF'
+func moveOnlyStructMoveOnlyKlassCopyableKlassNonConsumingUse() {
+    var k = NonTrivialStruct()
+    k = NonTrivialStruct()
+    nonConsumingUseCopyableKlass(k.moveOnlyKlass.copyableKlass)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovecD15NonConsumingUseyyF : $@convention(thin) () -> () {
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP]]
 // CHECK:   [[FN:%.*]] = function_ref @$s8moveonly32nonConsumingUseNonTrivialStruct2yyAA0efG0VF : $@convention(thin) (@guaranteed NonTrivialStruct2) -> ()
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly018moveOnlyStructMovecD15NonConsumingUseyyF'
+func moveOnlyStructMoveOnlyStructNonConsumingUse() {
+    var k = NonTrivialStruct()
+    k = NonTrivialStruct()
+    nonConsumingUseNonTrivialStruct2(k.nonTrivialStruct2)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovecdeC20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.k2
-// CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialStruct2, #NonTrivialStruct2.k
+// CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
+// CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialStruct2, #NonTrivialStruct2.moveOnlyKlass
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP2]]
 // CHECK:   [[FN:%.*]] = function_ref @$s8moveonly20nonConsumingUseKlassyyAA0E0CF : $@convention(thin) (@guaranteed Klass) -> ()
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
-// CHECK: } // end sil function '$s8moveonly31structBorrowObjectFunctionCall2yyF'
-func structBorrowObjectFunctionCall2() {
+// CHECK: } // end sil function '$s8moveonly018moveOnlyStructMovecdeC20KlassNonConsumingUseyyF'
+func moveOnlyStructMoveOnlyStructMoveOnlyKlassNonConsumingUse() {
     var k = NonTrivialStruct()
     k = NonTrivialStruct()
-    nonConsumingUseNonTrivialStruct(k)
-    nonConsumingUseKlass(k.k)
-    nonConsumingUseKlass2(k.k.klsField)
-    nonConsumingUseNonTrivialStruct2(k.k2)
-    nonConsumingUseKlass(k.k2.k)
+    nonConsumingUseKlass(k.nonTrivialStruct2.moveOnlyKlass)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovecD28CopyableKlassNonConsumingUseyyF : $@convention(thin) () -> () {
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
+// CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
+// CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialStruct2, #NonTrivialStruct2.copyableKlass
+// CHECK:   [[BORROW:%.*]] = load_borrow [[GEP2]]
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly28nonConsumingUseCopyableKlassyyAA0eF0CF : $@convention(thin) (@guaranteed CopyableKlass) -> ()
+// CHECK:   apply [[FN]]([[BORROW]])
+// CHECK:   end_borrow [[BORROW]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly018moveOnlyStructMovecD28CopyableKlassNonConsumingUseyyF'
+func moveOnlyStructMoveOnlyStructCopyableKlassNonConsumingUse() {
+    var k = NonTrivialStruct()
+    k = NonTrivialStruct()
+    nonConsumingUseCopyableKlass(k.nonTrivialStruct2.copyableKlass)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly42moveOnlyStructCopyableKlassNonConsumingUseyyF : $@convention(thin) () -> () {
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.copyableKlass
+// CHECK:   [[BORROW:%.*]] = load_borrow [[GEP]]
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly28nonConsumingUseCopyableKlassyyAA0eF0CF : $@convention(thin) (@guaranteed CopyableKlass) -> ()
+// CHECK:   apply [[FN]]([[BORROW]])
+// CHECK:   end_borrow [[BORROW]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly42moveOnlyStructCopyableKlassNonConsumingUseyyF'
+func moveOnlyStructCopyableKlassNonConsumingUse() {
+    var k = NonTrivialStruct()
+    k = NonTrivialStruct()
+    nonConsumingUseCopyableKlass(k.copyableKlass)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyableD15NonConsumingUseyyF : $@convention(thin) () -> () {
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
+// CHECK:   [[BORROW:%.*]] = load_borrow [[GEP]]
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly29nonConsumingUseCopyableStructyyAA010NonTrivialeF0VF : 
+// CHECK:   apply [[FN]]([[BORROW]])
+// CHECK:   end_borrow [[BORROW]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly022moveOnlyStructCopyableD15NonConsumingUseyyF'
+func moveOnlyStructCopyableStructNonConsumingUse() {
+    var k = NonTrivialStruct()
+    k = NonTrivialStruct()
+    nonConsumingUseCopyableStruct(k.nonTrivialCopyableStruct)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyabledE20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
+// CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
+// CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.copyableKlass
+// CHECK:   [[BORROW:%.*]] = load_borrow [[GEP2]]
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly28nonConsumingUseCopyableKlassyyAA0eF0CF :
+// CHECK:   apply [[FN]]([[BORROW]])
+// CHECK:   end_borrow [[BORROW]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly022moveOnlyStructCopyabledE20KlassNonConsumingUseyyF'
+func moveOnlyStructCopyableStructCopyableKlassNonConsumingUse() {
+    var k = NonTrivialStruct()
+    k = NonTrivialStruct()
+    nonConsumingUseCopyableKlass(k.nonTrivialCopyableStruct.copyableKlass)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyabledeD15NonConsumingUseyyF : $@convention(thin) () -> () {
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
+// CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
+// CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.nonTrivialCopyableStruct2
+// CHECK:   [[BORROW:%.*]] = load_borrow [[GEP2]]
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly30nonConsumingUseCopyableStruct2yyAA010NonTrivialeF0VF :
+// CHECK:   apply [[FN]]([[BORROW]])
+// CHECK:   end_borrow [[BORROW]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly022moveOnlyStructCopyabledeD15NonConsumingUseyyF'
+func moveOnlyStructCopyableStructCopyableStructNonConsumingUse() {
+    var k = NonTrivialStruct()
+    k = NonTrivialStruct()
+    nonConsumingUseCopyableStruct2(k.nonTrivialCopyableStruct.nonTrivialCopyableStruct2)
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyablededE20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
+// CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
+// CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.nonTrivialCopyableStruct2
+// CHECK:   [[GEP3:%.*]] = struct_element_addr [[GEP2]] : $*NonTrivialCopyableStruct2, #NonTrivialCopyableStruct2.copyableKlass
+// CHECK:   [[BORROW:%.*]] = load_borrow [[GEP3]]
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly28nonConsumingUseCopyableKlassyyAA0eF0CF :
+// CHECK:   apply [[FN]]([[BORROW]])
+// CHECK:   end_borrow [[BORROW]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s8moveonly022moveOnlyStructCopyablededE20KlassNonConsumingUseyyF'
+func moveOnlyStructCopyableStructCopyableStructCopyableKlassNonConsumingUse() {
+    var k = NonTrivialStruct()
+    k = NonTrivialStruct()
+    nonConsumingUseCopyableKlass(k.nonTrivialCopyableStruct.nonTrivialCopyableStruct2.copyableKlass)
+}
+
+// We fail here b/c we are accessing through a class.
+//
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyabledede9KlassMovecF15NonConsumingUseyyF : $@convention(thin) () -> () {
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
+// CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
+// CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.nonTrivialCopyableStruct2
+// CHECK:   [[GEP3:%.*]] = struct_element_addr [[GEP2]] : $*NonTrivialCopyableStruct2, #NonTrivialCopyableStruct2.copyableKlass
+// CHECK:   [[COPYABLE_KLASS:%.*]] = load [copy] [[GEP3]]
+// CHECK:   end_access [[ACCESS]]
+// CHECK:   [[BORROWED_COPYABLE_KLASS:%.*]] = begin_borrow [[COPYABLE_KLASS]]
+// CHECK:   [[FN:%.*]] = class_method [[BORROWED_COPYABLE_KLASS]] : $CopyableKlass, #CopyableKlass.k!getter :
+// CHECK:   [[MOVEONLY_KLASS:%.*]] = apply [[FN]]([[BORROWED_COPYABLE_KLASS]])
+// CHECK:   end_borrow [[BORROWED_COPYABLE_KLASS]]
+// CHECK:   [[BORROWED_MOVEONLY_KLASS:%.*]] = begin_borrow [[MOVEONLY_KLASS]]
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly20nonConsumingUseKlassyyAA0E0CF :
+// CHECK:   apply [[FN]]([[BORROWED_MOVEONLY_KLASS]])
+// CHECK:   end_borrow [[BORROWED_MOVEONLY_KLASS]]
+// CHECK:   destroy_value [[COPYABLE_KLASS]]
+// CHECK:   destroy_value [[MOVEONLY_KLASS]]
+// CHECK: } // end sil function '$s8moveonly022moveOnlyStructCopyabledede9KlassMovecF15NonConsumingUseyyF'
+func moveOnlyStructCopyableStructCopyableStructCopyableKlassMoveOnlyKlassNonConsumingUse() {
+    var k = NonTrivialStruct()
+    k = NonTrivialStruct()
+    nonConsumingUseKlass(k.nonTrivialCopyableStruct.nonTrivialCopyableStruct2.copyableKlass.k)
 }


### PR DESCRIPTION
Otherwise, we down the normal load [copy] path which will cause us to have a tight exclusivity scope.

One thing to note is that if one accesses a field of a moveonly class one will still get the tight exclusivity scope issue since SILGenLValue will emit the moveonly class as a base of the field causing us to use the non-borrow codegen.

rdar://102746971
