### PR TITLE
[SourceKit] Preparation for solver-based cursor info

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -171,6 +171,13 @@ public:
   SourceLoc getStartLoc() const;
   SourceLoc getEndLoc() const;
 
+  SourceLoc getContentStartLoc() const;
+  SourceLoc getContentEndLoc() const;
+  /// The range of the brace statement without the braces.
+  SourceRange getContentRange() const {
+    return {getContentStartLoc(), getContentEndLoc()};
+  }
+
   bool empty() const { return getNumElements() == 0; }
   unsigned getNumElements() const { return Bits.BraceStmt.NumElements; }
 

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -128,38 +128,63 @@ enum class CursorInfoKind {
   StmtStart,
 };
 
+/// Base class of more specialized \c ResolvedCursorInfos that also represents
+/// and \c Invalid cursor info.
+/// Subclasses of \c ResolvedCursorInfo cannot add new stored properies because
+/// \c ResolvedCursorInfo is being passed around as its base class and thus any
+/// properties in subclasses would get lost.
 struct ResolvedCursorInfo {
+protected:
   CursorInfoKind Kind = CursorInfoKind::Invalid;
   SourceFile *SF = nullptr;
   SourceLoc Loc;
-  ValueDecl *ValueD = nullptr;
-  TypeDecl *CtorTyRef = nullptr;
-  ExtensionDecl *ExtTyRef = nullptr;
-  /// Declarations that were shadowed by \c ValueD using a shorthand syntax that
-  /// names both the newly declared variable and the referenced variable by the
-  /// same identifier in the source text. This includes shorthand closure
-  /// captures (`[foo]`) and shorthand if captures
-  /// (`if let foo {`).
-  /// Decls that are shadowed using shorthand syntax should be reported as
-  /// additional cursor info results.
-  SmallVector<ValueDecl *, 2> ShorthandShadowedDecls;
-  ModuleEntity Mod;
-  bool IsRef = true;
-  bool IsKeywordArgument = false;
-  Type Ty;
-  Type ContainerType;
-  Stmt *TrailingStmt = nullptr;
-  Expr *TrailingExpr = nullptr;
-  /// It this is a ref, whether it is "dynamic". See \c ide::isDynamicRef.
-  bool IsDynamic = false;
-  /// If this is a dynamic ref, the types of the base (multiple in the case of
-  /// protocol composition).
-  SmallVector<NominalTypeDecl *, 1> ReceiverTypes;
 
+  // Technically, these structs could form a union (because only one of them is
+  // active at a time). But I had issues with C++ complaining about copy
+  // constructors and gave up. At the moment it's only wasting 3 words for non
+  // ValueRef data.
+  struct {
+    ValueDecl *ValueD = nullptr;
+    TypeDecl *CtorTyRef = nullptr;
+    ExtensionDecl *ExtTyRef = nullptr;
+    bool IsRef = true;
+    Type Ty;
+    Type ContainerType;
+    bool IsKeywordArgument = false;
+    /// It this is a ref, whether it is "dynamic". See \c ide::isDynamicRef.
+    bool IsDynamic = false;
+    /// If this is a dynamic ref, the types of the base (multiple in the case of
+    /// protocol composition).
+    SmallVector<NominalTypeDecl *> ReceiverTypes;
+    /// Declarations that were shadowed by \c ValueD using a shorthand syntax
+    /// that names both the newly declared variable and the referenced variable
+    /// by the same identifier in the source text. This includes shorthand
+    /// closure captures (`[foo]`) and shorthand if captures
+    /// (`if let foo {`).
+    /// Decls that are shadowed using shorthand syntax should be reported as
+    /// additional cursor info results.
+    SmallVector<ValueDecl *> ShorthandShadowedDecls;
+  } ValueRefInfo;
+  struct {
+    ModuleEntity Mod;
+  } ModuleRefInfo;
+  struct {
+    Expr *TrailingExpr = nullptr;
+  } ExprStartInfo;
+  struct {
+    Stmt *TrailingStmt = nullptr;
+  } StmtStartInfo;
+
+public:
   ResolvedCursorInfo() = default;
   ResolvedCursorInfo(SourceFile *SF) : SF(SF) {}
 
-  ValueDecl *typeOrValue() { return CtorTyRef ? CtorTyRef : ValueD; }
+  CursorInfoKind getKind() const { return Kind; }
+
+  SourceFile *getSourceFile() const { return SF; }
+
+  SourceLoc getLoc() const { return Loc; }
+  void setLoc(SourceLoc Loc) { this->Loc = Loc; }
 
   friend bool operator==(const ResolvedCursorInfo &lhs,
                          const ResolvedCursorInfo &rhs) {
@@ -167,32 +192,136 @@ struct ResolvedCursorInfo {
       lhs.Loc.getOpaquePointerValue() == rhs.Loc.getOpaquePointerValue();
   }
 
-  void setValueRef(ValueDecl *ValueD, TypeDecl *CtorTyRef,
-                   ExtensionDecl *ExtTyRef, bool IsRef,
-                   Type Ty, Type ContainerType) {
-    Kind = CursorInfoKind::ValueRef;
-    this->ValueD = ValueD;
-    this->CtorTyRef = CtorTyRef;
-    this->ExtTyRef = ExtTyRef;
-    this->IsRef = IsRef;
-    this->Ty = Ty;
-    this->ContainerType = ContainerType;
-  }
-  void setModuleRef(ModuleEntity Mod) {
-    Kind = CursorInfoKind::ModuleRef;
-    this->Mod = Mod;
-  }
-  void setTrailingStmt(Stmt *TrailingStmt) {
-    Kind = CursorInfoKind::StmtStart;
-    this->TrailingStmt = TrailingStmt;
-  }
-  void setTrailingExpr(Expr* TrailingExpr) {
-    Kind = CursorInfoKind::ExprStart;
-    this->TrailingExpr = TrailingExpr;
-  }
-
   bool isValid() const { return !isInvalid(); }
   bool isInvalid() const { return Kind == CursorInfoKind::Invalid; }
+};
+
+struct ResolvedValueRefCursorInfo : public ResolvedCursorInfo {
+  // IMPORTANT: Don't add stored properties here. See comment on
+  // ResolvedCursorInfo.
+
+  ResolvedValueRefCursorInfo() = default;
+  explicit ResolvedValueRefCursorInfo(const ResolvedCursorInfo &Base,
+                                      ValueDecl *ValueD, TypeDecl *CtorTyRef,
+                                      ExtensionDecl *ExtTyRef, bool IsRef,
+                                      Type Ty, Type ContainerType)
+      : ResolvedCursorInfo(Base) {
+    assert(Base.getKind() == CursorInfoKind::Invalid &&
+           "Can only specialize from invalid");
+    Kind = CursorInfoKind::ValueRef;
+    ValueRefInfo.ValueD = ValueD;
+    ValueRefInfo.CtorTyRef = CtorTyRef;
+    ValueRefInfo.ExtTyRef = ExtTyRef;
+    ValueRefInfo.IsRef = IsRef;
+    ValueRefInfo.Ty = Ty;
+    ValueRefInfo.ContainerType = ContainerType;
+  }
+
+  ValueDecl *getValueD() const { return ValueRefInfo.ValueD; }
+  void setValueD(ValueDecl *ValueD) { ValueRefInfo.ValueD = ValueD; }
+
+  ExtensionDecl *getExtTyRef() const { return ValueRefInfo.ExtTyRef; }
+
+  TypeDecl *getCtorTyRef() const { return ValueRefInfo.CtorTyRef; }
+
+  bool isRef() const { return ValueRefInfo.IsRef; }
+  void setIsRef(bool IsRef) { ValueRefInfo.IsRef = IsRef; }
+
+  Type getType() const { return ValueRefInfo.Ty; }
+
+  Type getContainerType() const { return ValueRefInfo.ContainerType; }
+  void setContainerType(Type Ty) { ValueRefInfo.ContainerType = Ty; }
+
+  bool isKeywordArgument() const { return ValueRefInfo.IsKeywordArgument; }
+  void setIsKeywordArgument(bool IsKeywordArgument) {
+    ValueRefInfo.IsKeywordArgument = IsKeywordArgument;
+  }
+
+  bool isDynamic() const { return ValueRefInfo.IsDynamic; }
+  void setIsDynamic(bool IsDynamic) { ValueRefInfo.IsDynamic = IsDynamic; }
+
+  ArrayRef<NominalTypeDecl *> getReceiverTypes() const {
+    return ValueRefInfo.ReceiverTypes;
+  }
+  void setReceiverTypes(const SmallVector<NominalTypeDecl *> &ReceiverTypes) {
+    ValueRefInfo.ReceiverTypes = ReceiverTypes;
+  }
+
+  ArrayRef<ValueDecl *> getShorthandShadowedDecls() const {
+    return ValueRefInfo.ShorthandShadowedDecls;
+  };
+  void setShorthandShadowedDecls(
+      const SmallVector<ValueDecl *> &ShorthandShadowedDecls) {
+    ValueRefInfo.ShorthandShadowedDecls = ShorthandShadowedDecls;
+  };
+
+  ValueDecl *typeOrValue() {
+    return ValueRefInfo.CtorTyRef ? ValueRefInfo.CtorTyRef
+                                  : ValueRefInfo.ValueD;
+  }
+
+  static bool classof(const ResolvedCursorInfo *Info) {
+    return Info->getKind() == CursorInfoKind::ValueRef;
+  }
+};
+
+struct ResolvedModuleRefCursorInfo : public ResolvedCursorInfo {
+  // IMPORTANT: Don't add stored properties here. See comment on
+  // ResolvedCursorInfo.
+
+  ResolvedModuleRefCursorInfo(const ResolvedCursorInfo &Base, ModuleEntity Mod)
+      : ResolvedCursorInfo(Base) {
+    assert(Base.getKind() == CursorInfoKind::Invalid &&
+           "Can only specialize from invalid");
+    Kind = CursorInfoKind::ModuleRef;
+    ModuleRefInfo.Mod = Mod;
+  }
+
+  ModuleEntity getMod() const { return ModuleRefInfo.Mod; }
+
+  static bool classof(const ResolvedCursorInfo *Info) {
+    return Info->getKind() == CursorInfoKind::ModuleRef;
+  }
+};
+
+struct ResolvedExprStartCursorInfo : public ResolvedCursorInfo {
+  // IMPORTANT: Don't add stored properties here. See comment on
+  // ResolvedCursorInfo.
+
+  ResolvedExprStartCursorInfo(const ResolvedCursorInfo &Base,
+                              Expr *TrailingExpr)
+      : ResolvedCursorInfo(Base) {
+    assert(Base.getKind() == CursorInfoKind::Invalid &&
+           "Can only specialize from invalid");
+    Kind = CursorInfoKind::ExprStart;
+    ExprStartInfo.TrailingExpr = TrailingExpr;
+  }
+
+  Expr *getTrailingExpr() const { return ExprStartInfo.TrailingExpr; }
+
+  static bool classof(const ResolvedCursorInfo *Info) {
+    return Info->getKind() == CursorInfoKind::ExprStart;
+  }
+};
+
+struct ResolvedStmtStartCursorInfo : public ResolvedCursorInfo {
+  // IMPORTANT: Don't add stored properties here. See comment on
+  // ResolvedCursorInfo.
+
+  ResolvedStmtStartCursorInfo(const ResolvedCursorInfo &Base,
+                              Stmt *TrailingStmt)
+      : ResolvedCursorInfo(Base) {
+    assert(Base.getKind() == CursorInfoKind::Invalid &&
+           "Can only specialize from invalid");
+    Kind = CursorInfoKind::StmtStart;
+    StmtStartInfo.TrailingStmt = TrailingStmt;
+  }
+
+  Stmt *getTrailingStmt() const { return StmtStartInfo.TrailingStmt; }
+
+  static bool classof(const ResolvedCursorInfo *Info) {
+    return Info->getKind() == CursorInfoKind::StmtStart;
+  }
 };
 
 void simple_display(llvm::raw_ostream &out, const ResolvedCursorInfo &info);

--- a/include/swift/Parse/CodeCompletionCallbacks.h
+++ b/include/swift/Parse/CodeCompletionCallbacks.h
@@ -254,7 +254,7 @@ public:
 
   /// Signals that the AST for the all the delayed-parsed code was
   /// constructed.  No \c complete*() callbacks will be done after this.
-  virtual void doneParsing() = 0;
+  virtual void doneParsing(SourceFile *SrcFile) = 0;
 };
 
 /// A factory to create instances of \c CodeCompletionCallbacks.

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -164,6 +164,11 @@ namespace swift {
       constraints::SolutionApplicationTarget &target, bool needsPrecheck,
       llvm::function_ref<void(const constraints::Solution &)> callback);
 
+  /// Thunk around \c TypeChecker::resolveDeclRefExpr to make it available to
+  /// \c swift::ide
+  Expr *resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *Context,
+                         bool replaceInvalidRefsWithErrors);
+
   LookupResult
   lookupSemanticMember(DeclContext *DC, Type ty, DeclName name);
 
@@ -339,12 +344,17 @@ namespace swift {
   /// these shorthand shadows.
   /// The first element in the pair is the implicitly declared variable and the
   /// second variable is the shadowed one.
+  /// If a \c DeclContext is passed, it is used to resolve any
+  /// \c UnresolvedDeclRef that a shorthand shadow may refer to.
   SmallVector<std::pair<ValueDecl *, ValueDecl *>, 1>
-  getShorthandShadows(CaptureListExpr *CaptureList);
+  getShorthandShadows(CaptureListExpr *CaptureList, DeclContext *DC = nullptr);
 
   /// Same as above but for shorthand `if let foo {` syntax.
+  /// If a \c DeclContext is passed, it is used to resolve any
+  /// \c UnresolvedDeclRef that a shorthand shadow may refer to.
   SmallVector<std::pair<ValueDecl *, ValueDecl *>, 1>
-  getShorthandShadows(LabeledConditionalStmt *CondStmt);
+  getShorthandShadows(LabeledConditionalStmt *CondStmt,
+                      DeclContext *DC = nullptr);
 }
 
 #endif

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -160,6 +160,17 @@ SourceLoc BraceStmt::getStartLoc() const {
   if (LBLoc) {
     return LBLoc;
   }
+  return getContentStartLoc();
+}
+
+SourceLoc BraceStmt::getEndLoc() const {
+  if (RBLoc) {
+    return RBLoc;
+  }
+  return getContentEndLoc();
+}
+
+SourceLoc BraceStmt::getContentStartLoc() const {
   for (auto elt : getElements()) {
     if (auto loc = elt.getStartLoc()) {
       return loc;
@@ -168,10 +179,7 @@ SourceLoc BraceStmt::getStartLoc() const {
   return SourceLoc();
 }
 
-SourceLoc BraceStmt::getEndLoc() const {
-  if (RBLoc) {
-    return RBLoc;
-  }
+SourceLoc BraceStmt::getContentEndLoc() const {
   for (auto elt : llvm::reverse(getElements())) {
     if (auto loc = elt.getEndLoc()) {
       return loc;

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -287,7 +287,7 @@ public:
   void completeTypeAttrBeginning() override;
   void completeOptionalBinding() override;
 
-  void doneParsing() override;
+  void doneParsing(SourceFile *SrcFile) override;
 
 private:
   void addKeywords(CodeCompletionResultSink &Sink, bool MaybeFuncBody);
@@ -1552,7 +1552,7 @@ static void undoSingleExpressionReturn(DeclContext *DC) {
   }
 }
 
-void CodeCompletionCallbacksImpl::doneParsing() {
+void CodeCompletionCallbacksImpl::doneParsing(SourceFile *SrcFile) {
   CompletionContext.CodeCompletionKind = Kind;
 
   if (Kind == CompletionKind::None) {

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -49,7 +49,7 @@ public:
   void completePostfixExpr(Expr *E, bool hasSpace) override;
   // }
 
-  void doneParsing() override;
+  void doneParsing(SourceFile *SrcFile) override;
 };
 
 void ConformingMethodListCallbacks::completeDotExpr(CodeCompletionExpr *E,
@@ -64,7 +64,7 @@ void ConformingMethodListCallbacks::completePostfixExpr(Expr *E,
   ParsedExpr = E;
 }
 
-void ConformingMethodListCallbacks::doneParsing() {
+void ConformingMethodListCallbacks::doneParsing(SourceFile *SrcFile) {
   if (!ParsedExpr)
     return;
 

--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -125,20 +125,24 @@ bool CursorInfoResolver::tryResolve(ValueDecl *D, TypeDecl *CtorTyRef,
     }
   }
 
+  ResolvedValueRefCursorInfo ValueRefInfo(CursorInfo, D, CtorTyRef, ExtTyRef,
+                                          IsRef, Ty, ContainerType);
   if (Expr *BaseE = getBase(ExprStack)) {
     if (isDynamicRef(BaseE, D)) {
-      CursorInfo.IsDynamic = true;
-      ide::getReceiverType(BaseE, CursorInfo.ReceiverTypes);
+      ValueRefInfo.setIsDynamic(true);
+      SmallVector<NominalTypeDecl *> ReceiverTypes;
+      ide::getReceiverType(BaseE, ReceiverTypes);
+      ValueRefInfo.setReceiverTypes(ReceiverTypes);
     }
   }
 
-  CursorInfo.setValueRef(D, CtorTyRef, ExtTyRef, IsRef, Ty, ContainerType);
+  CursorInfo = ValueRefInfo;
   return true;
 }
 
 bool CursorInfoResolver::tryResolve(ModuleEntity Mod, SourceLoc Loc) {
   if (Loc == LocToResolve) {
-    CursorInfo.setModuleRef(Mod);
+    CursorInfo = ResolvedModuleRefCursorInfo(CursorInfo, Mod);
     return true;
   }
   return false;
@@ -147,13 +151,13 @@ bool CursorInfoResolver::tryResolve(ModuleEntity Mod, SourceLoc Loc) {
 bool CursorInfoResolver::tryResolve(Stmt *St) {
   if (auto *LST = dyn_cast<LabeledStmt>(St)) {
     if (LST->getStartLoc() == LocToResolve) {
-      CursorInfo.setTrailingStmt(St);
+      CursorInfo = ResolvedStmtStartCursorInfo(CursorInfo, St);
       return true;
     }
   }
   if (auto *CS = dyn_cast<CaseStmt>(St)) {
     if (CS->getStartLoc() == LocToResolve) {
-      CursorInfo.setTrailingStmt(St);
+      CursorInfo = ResolvedStmtStartCursorInfo(CursorInfo, St);
       return true;
     }
   }
@@ -171,16 +175,21 @@ bool CursorInfoResolver::visitSubscriptReference(ValueDecl *D,
 ResolvedCursorInfo CursorInfoResolver::resolve(SourceLoc Loc) {
   assert(Loc.isValid());
   LocToResolve = Loc;
-  CursorInfo.Loc = Loc;
+  CursorInfo.setLoc(Loc);
 
   walk(SrcFile);
 
-  if (!CursorInfo.IsRef) {
-    // If we have a definition, add any decls that it potentially shadows
-    auto ShorthandShadowedDecl = ShorthandShadowedDecls[CursorInfo.ValueD];
-    while (ShorthandShadowedDecl) {
-      CursorInfo.ShorthandShadowedDecls.push_back(ShorthandShadowedDecl);
-      ShorthandShadowedDecl = ShorthandShadowedDecls[ShorthandShadowedDecl];
+  if (auto ValueRefInfo = dyn_cast<ResolvedValueRefCursorInfo>(&CursorInfo)) {
+    if (!ValueRefInfo->isRef()) {
+      SmallVector<ValueDecl *> ShadowedDecls;
+      // If we have a definition, add any decls that it potentially shadows
+      auto ShorthandShadowedDecl =
+          ShorthandShadowedDecls[ValueRefInfo->getValueD()];
+      while (ShorthandShadowedDecl) {
+        ShadowedDecls.push_back(ShorthandShadowedDecl);
+        ShorthandShadowedDecl = ShorthandShadowedDecls[ShorthandShadowedDecl];
+      }
+      ValueRefInfo->setShorthandShadowedDecls(ShadowedDecls);
     }
   }
 
@@ -307,7 +316,7 @@ bool CursorInfoResolver::walkToExprPost(Expr *E) {
     return false;
 
   if (OutermostCursorExpr && isCursorOn(E, LocToResolve)) {
-    CursorInfo.setTrailingExpr(OutermostCursorExpr);
+    CursorInfo = ResolvedExprStartCursorInfo(CursorInfo, OutermostCursorExpr);
     return false;
   }
 
@@ -328,8 +337,9 @@ bool CursorInfoResolver::visitCallArgName(Identifier Name,
     return true;
 
   bool Found = tryResolve(D, nullptr, nullptr, Range.getStart(), /*IsRef=*/true);
-  if (Found)
-    CursorInfo.IsKeywordArgument = true;
+  if (Found) {
+    cast<ResolvedValueRefCursorInfo>(CursorInfo).setIsKeywordArgument(true);
+  }
   return !Found;
 }
 
@@ -383,9 +393,9 @@ void swift::ide::simple_display(llvm::raw_ostream &out,
   if (info.isInvalid())
     return;
   out << "Resolved cursor info at ";
-  auto &SM = info.SF->getASTContext().SourceMgr;
-  out << SM.getIdentifierForBuffer(*info.SF->getBufferID());
-  auto LC = SM.getLineAndColumnInBuffer(info.Loc);
+  auto &SM = info.getSourceFile()->getASTContext().SourceMgr;
+  out << SM.getIdentifierForBuffer(*info.getSourceFile()->getBufferID());
+  auto LC = SM.getLineAndColumnInBuffer(info.getLoc());
   out << ":" << LC.first << ":" << LC.second;
 }
 

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -48,7 +48,7 @@ public:
   void completeUnresolvedMember(CodeCompletionExpr *E,
                                 SourceLoc DotLoc) override;
 
-  void doneParsing() override;
+  void doneParsing(SourceFile *SrcFile) override;
 };
 
 void ContextInfoCallbacks::completePostfixExprBeginning(CodeCompletionExpr *E) {
@@ -85,7 +85,7 @@ void ContextInfoCallbacks::completeCaseStmtBeginning(CodeCompletionExpr *E) {
   // TODO: Implement?
 }
 
-void ContextInfoCallbacks::doneParsing() {
+void ContextInfoCallbacks::doneParsing(SourceFile *SrcFile) {
   if (!ParsedExpr)
     return;
 

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -195,7 +195,7 @@ void Parser::performCodeCompletionSecondPassImpl(
   assert(!State->hasCodeCompletionDelayedDeclState() &&
          "Second pass should not set any code completion info");
 
-  CodeCompletion->doneParsing();
+  CodeCompletion->doneParsing(DC->getParentSourceFile());
 
   State->restoreCodeCompletionDelayedDeclState(info);
 }

--- a/lib/Refactoring/Refactoring.cpp
+++ b/lib/Refactoring/Refactoring.cpp
@@ -847,14 +847,16 @@ class RefactoringAction##KIND: public RangeBasedRefactoringAction {           \
 
 bool RefactoringActionLocalRename::
 isApplicable(const ResolvedCursorInfo &CursorInfo, DiagnosticEngine &Diag) {
-  if (CursorInfo.Kind != CursorInfoKind::ValueRef)
+  auto ValueRefInfo = dyn_cast<ResolvedValueRefCursorInfo>(&CursorInfo);
+  if (!ValueRefInfo)
     return false;
 
   Optional<RenameRefInfo> RefInfo;
-  if (CursorInfo.IsRef)
-    RefInfo = {CursorInfo.SF, CursorInfo.Loc, CursorInfo.IsKeywordArgument};
+  if (ValueRefInfo->isRef())
+    RefInfo = {CursorInfo.getSourceFile(), CursorInfo.getLoc(),
+               ValueRefInfo->isKeywordArgument()};
 
-  auto RenameOp = getAvailableRenameForDecl(CursorInfo.ValueD, RefInfo);
+  auto RenameOp = getAvailableRenameForDecl(ValueRefInfo->getValueD(), RefInfo);
   return RenameOp.hasValue() &&
     RenameOp.getValue() == RefactoringKind::LocalRename;
 }
@@ -908,13 +910,15 @@ bool RefactoringActionLocalRename::performChange() {
   CursorInfo = evaluateOrDefault(TheFile->getASTContext().evaluator,
                           CursorInfoRequest{CursorInfoOwner(TheFile, StartLoc)},
                                  ResolvedCursorInfo());
-  if (CursorInfo.isValid() && CursorInfo.ValueD) {
-    ValueDecl *VD = CursorInfo.typeOrValue();
+  auto ValueRefCursorInfo = dyn_cast<ResolvedValueRefCursorInfo>(&CursorInfo);
+  if (ValueRefCursorInfo && ValueRefCursorInfo->getValueD()) {
+    ValueDecl *VD = ValueRefCursorInfo->typeOrValue();
     SmallVector<DeclContext *, 8> Scopes;
 
     Optional<RenameRefInfo> RefInfo;
-    if (CursorInfo.IsRef)
-      RefInfo = {CursorInfo.SF, CursorInfo.Loc, CursorInfo.IsKeywordArgument};
+    if (ValueRefCursorInfo->isRef())
+      RefInfo = {CursorInfo.getSourceFile(), CursorInfo.getLoc(),
+                 ValueRefCursorInfo->isKeywordArgument()};
 
     analyzeRenameScope(VD, RefInfo, DiagEngine, Scopes);
     if (Scopes.empty())
@@ -1817,11 +1821,12 @@ bool RefactoringActionReplaceBodiesWithFatalError::performChange() {
 
 static std::pair<IfStmt *, IfStmt *>
 findCollapseNestedIfTarget(const ResolvedCursorInfo &CursorInfo) {
-  if (CursorInfo.Kind != CursorInfoKind::StmtStart)
+  auto StmtStartInfo = dyn_cast<ResolvedStmtStartCursorInfo>(&CursorInfo);
+  if (!StmtStartInfo)
     return {};
 
   // Ensure the statement is 'if' statement. It must not have 'else' clause.
-  IfStmt *OuterIf = dyn_cast<IfStmt>(CursorInfo.TrailingStmt);
+  IfStmt *OuterIf = dyn_cast<IfStmt>(StmtStartInfo->getTrailingStmt());
   if (!OuterIf)
     return {};
   if (OuterIf->getElseStmt())
@@ -2909,12 +2914,16 @@ FillProtocolStubContext FillProtocolStubContext::
 getContextFromCursorInfo(const ResolvedCursorInfo &CursorInfo) {
   if(!CursorInfo.isValid())
     return FillProtocolStubContext();
-  if (!CursorInfo.IsRef) {
+  auto ValueRefInfo = dyn_cast<ResolvedValueRefCursorInfo>(&CursorInfo);
+  if (!ValueRefInfo) {
+    return FillProtocolStubContext();
+  }
+  if (!ValueRefInfo->isRef()) {
     // If the type name is on the declared nominal, e.g. "class A {}"
-    if (auto ND = dyn_cast<NominalTypeDecl>(CursorInfo.ValueD)) {
+    if (auto ND = dyn_cast<NominalTypeDecl>(ValueRefInfo->getValueD())) {
       return FillProtocolStubContext(ND);
     }
-  } else if (auto *ED = CursorInfo.ExtTyRef) {
+  } else if (auto *ED = ValueRefInfo->getExtTyRef()) {
     // If the type ref is on a declared extension, e.g. "extension A {}"
     return FillProtocolStubContext(ED);
   }
@@ -3063,12 +3072,12 @@ isApplicable(const ResolvedCursorInfo &CursorInfo, DiagnosticEngine &Diag) {
       Diag.diagnose(SourceLoc(), diag::invalid_default_location);
     return Applicable;
   };
-  if (CursorInfo.Kind != CursorInfoKind::StmtStart)
+  auto StmtStartInfo = dyn_cast<ResolvedStmtStartCursorInfo>(&CursorInfo);
+  if (!StmtStartInfo)
     return Exit(false);
-  if (auto *CS = dyn_cast<CaseStmt>(CursorInfo.TrailingStmt)) {
-    auto EnclosingSwitchStmt = findEnclosingSwitchStmt(CS,
-                                                       CursorInfo.SF,
-                                                       Diag);
+  if (auto *CS = dyn_cast<CaseStmt>(StmtStartInfo->getTrailingStmt())) {
+    auto EnclosingSwitchStmt =
+        findEnclosingSwitchStmt(CS, CursorInfo.getSourceFile(), Diag);
     if (!EnclosingSwitchStmt)
       return false;
     auto EnumD = getEnumDeclFromSwitchStmt(EnclosingSwitchStmt);
@@ -3081,7 +3090,8 @@ isApplicable(const ResolvedCursorInfo &CursorInfo, DiagnosticEngine &Diag) {
 bool RefactoringActionExpandDefault::performChange() {
   // If we've not seen the default statement inside the switch statement, issue
   // error.
-  auto *CS = static_cast<CaseStmt*>(CursorInfo.TrailingStmt);
+  auto StmtStartInfo = cast<ResolvedStmtStartCursorInfo>(CursorInfo);
+  auto *CS = static_cast<CaseStmt *>(StmtStartInfo.getTrailingStmt());
   auto *SwitchS = findEnclosingSwitchStmt(CS, TheFile, DiagEngine);
   assert(SwitchS);
   EditorConsumerInsertStream OS(EditConsumer, SM,
@@ -3095,16 +3105,18 @@ bool RefactoringActionExpandDefault::performChange() {
 
 bool RefactoringActionExpandSwitchCases::
 isApplicable(const ResolvedCursorInfo &CursorInfo, DiagnosticEngine &DiagEngine) {
-  if (!CursorInfo.TrailingStmt)
+  auto StmtStartInfo = dyn_cast<ResolvedStmtStartCursorInfo>(&CursorInfo);
+  if (!StmtStartInfo || !StmtStartInfo->getTrailingStmt())
     return false;
-  if (auto *Switch = dyn_cast<SwitchStmt>(CursorInfo.TrailingStmt)) {
+  if (auto *Switch = dyn_cast<SwitchStmt>(StmtStartInfo->getTrailingStmt())) {
     return getEnumDeclFromSwitchStmt(Switch);
   }
   return false;
 }
 
 bool RefactoringActionExpandSwitchCases::performChange() {
-  auto *SwitchS = dyn_cast<SwitchStmt>(CursorInfo.TrailingStmt);
+  auto StmtStartInfo = cast<ResolvedStmtStartCursorInfo>(CursorInfo);
+  auto *SwitchS = dyn_cast<SwitchStmt>(StmtStartInfo.getTrailingStmt());
   assert(SwitchS);
 
   auto InsertRange = CharSourceRange();
@@ -3132,7 +3144,8 @@ bool RefactoringActionExpandSwitchCases::performChange() {
 }
 
 static Expr *findLocalizeTarget(const ResolvedCursorInfo &CursorInfo) {
-  if (CursorInfo.Kind != CursorInfoKind::ExprStart)
+  auto ExprStartInfo = dyn_cast<ResolvedExprStartCursorInfo>(&CursorInfo);
+  if (!ExprStartInfo)
     return nullptr;
   struct StringLiteralFinder: public SourceEntityWalker {
     SourceLoc StartLoc;
@@ -3149,8 +3162,8 @@ static Expr *findLocalizeTarget(const ResolvedCursorInfo &CursorInfo) {
       }
       return true;
     }
-  } Walker(CursorInfo.TrailingExpr->getStartLoc());
-  Walker.walk(CursorInfo.TrailingExpr);
+  } Walker(ExprStartInfo->getTrailingExpr()->getStartLoc());
+  Walker.walk(ExprStartInfo->getTrailingExpr());
   return Walker.Target;
 }
 
@@ -3238,13 +3251,14 @@ static void generateMemberwiseInit(SourceEditConsumer &EditConsumer,
 static SourceLoc
 collectMembersForInit(const ResolvedCursorInfo &CursorInfo,
                       SmallVectorImpl<MemberwiseParameter> &memberVector) {
-
-  if (!CursorInfo.ValueD)
+  auto ValueRefInfo = dyn_cast<ResolvedValueRefCursorInfo>(&CursorInfo);
+  if (!ValueRefInfo || !ValueRefInfo->getValueD())
     return SourceLoc();
-  
-  NominalTypeDecl *nominalDecl = dyn_cast<NominalTypeDecl>(CursorInfo.ValueD);
+
+  NominalTypeDecl *nominalDecl =
+      dyn_cast<NominalTypeDecl>(ValueRefInfo->getValueD());
   if (!nominalDecl || nominalDecl->getStoredProperties().empty() ||
-      CursorInfo.IsRef) {
+      ValueRefInfo->isRef()) {
     return SourceLoc();
   }
 
@@ -3519,14 +3533,15 @@ getProtocolRequirements() {
 
 AddEquatableContext AddEquatableContext::
 getDeclarationContextFromInfo(const ResolvedCursorInfo &Info) {
-  if (Info.isInvalid()) {
+  auto ValueRefInfo = dyn_cast<ResolvedValueRefCursorInfo>(&Info);
+  if (!ValueRefInfo) {
     return AddEquatableContext();
   }
-  if (!Info.IsRef) {
-    if (auto *NomDecl = dyn_cast<NominalTypeDecl>(Info.ValueD)) {
+  if (!ValueRefInfo->isRef()) {
+    if (auto *NomDecl = dyn_cast<NominalTypeDecl>(ValueRefInfo->getValueD())) {
       return AddEquatableContext(NomDecl);
     }
-  } else if (auto *ExtDecl = Info.ExtTyRef) {
+  } else if (auto *ExtDecl = ValueRefInfo->getExtTyRef()) {
     if (ExtDecl->getExtendedNominal()) {
       return AddEquatableContext(ExtDecl);
     }
@@ -3717,11 +3732,12 @@ void AddCodableContext::printInsertionText(const ResolvedCursorInfo &CursorInfo,
 
 AddCodableContext AddCodableContext::getDeclarationContextFromInfo(
     const ResolvedCursorInfo &Info) {
-  if (Info.isInvalid()) {
+  auto ValueRefInfo = dyn_cast<ResolvedValueRefCursorInfo>(&Info);
+  if (!ValueRefInfo) {
     return AddCodableContext();
   }
-  if (!Info.IsRef) {
-    if (auto *NomDecl = dyn_cast<NominalTypeDecl>(Info.ValueD)) {
+  if (!ValueRefInfo->isRef()) {
+    if (auto *NomDecl = dyn_cast<NominalTypeDecl>(ValueRefInfo->getValueD())) {
       return AddCodableContext(NomDecl);
     }
   }
@@ -3748,10 +3764,9 @@ bool RefactoringActionAddExplicitCodableImplementation::performChange() {
 }
 
 static CharSourceRange
-findSourceRangeToWrapInCatch(const ResolvedCursorInfo &CursorInfo,
-                             SourceFile *TheFile,
-                             SourceManager &SM) {
-  Expr *E = CursorInfo.TrailingExpr;
+findSourceRangeToWrapInCatch(const ResolvedExprStartCursorInfo &CursorInfo,
+                             SourceFile *TheFile, SourceManager &SM) {
+  Expr *E = CursorInfo.getTrailingExpr();
   if (!E)
     return CharSourceRange();
   auto Node = ASTNode(E);
@@ -3779,15 +3794,17 @@ findSourceRangeToWrapInCatch(const ResolvedCursorInfo &CursorInfo,
 
 bool RefactoringActionConvertToDoCatch::
 isApplicable(const ResolvedCursorInfo &Tok, DiagnosticEngine &Diag) {
-  if (!Tok.TrailingExpr)
+  auto ExprStartInfo = dyn_cast<ResolvedExprStartCursorInfo>(&Tok);
+  if (!ExprStartInfo || !ExprStartInfo->getTrailingExpr())
     return false;
-  return isa<ForceTryExpr>(Tok.TrailingExpr);
+  return isa<ForceTryExpr>(ExprStartInfo->getTrailingExpr());
 }
 
 bool RefactoringActionConvertToDoCatch::performChange() {
-  auto *TryExpr = dyn_cast<ForceTryExpr>(CursorInfo.TrailingExpr);
+  auto ExprStartInfo = cast<ResolvedExprStartCursorInfo>(CursorInfo);
+  auto *TryExpr = dyn_cast<ForceTryExpr>(ExprStartInfo.getTrailingExpr());
   assert(TryExpr);
-  auto Range = findSourceRangeToWrapInCatch(CursorInfo, TheFile, SM);
+  auto Range = findSourceRangeToWrapInCatch(ExprStartInfo, TheFile, SM);
   if (!Range.isValid())
     return true;
   // Wrap given range in do catch block.
@@ -3807,7 +3824,8 @@ bool RefactoringActionConvertToDoCatch::performChange() {
 static NumberLiteralExpr *getTrailingNumberLiteral(
     const ResolvedCursorInfo &Tok) {
   // This cursor must point to the start of an expression.
-  if (Tok.Kind != CursorInfoKind::ExprStart)
+  auto ExprStartInfo = dyn_cast<ResolvedExprStartCursorInfo>(&Tok);
+  if (!ExprStartInfo)
     return nullptr;
 
   // For every sub-expression, try to find the literal expression that matches
@@ -3834,7 +3852,7 @@ static NumberLiteralExpr *getTrailingNumberLiteral(
     }
   };
 
-  auto parent = Tok.TrailingExpr;
+  auto parent = ExprStartInfo->getTrailingExpr();
   FindLiteralNumber finder(parent);
   parent->walk(finder);
   return finder.found;
@@ -3905,16 +3923,15 @@ bool RefactoringActionSimplifyNumberLiteral::performChange() {
 
 static CallExpr *findTrailingClosureTarget(
     SourceManager &SM, const ResolvedCursorInfo &CursorInfo) {
-  if (CursorInfo.Kind == CursorInfoKind::StmtStart)
+  if (CursorInfo.getKind() == CursorInfoKind::StmtStart)
     // StmtStart postion can't be a part of CallExpr.
     return nullptr;
 
   // Find inner most CallExpr
-  ContextFinder
-  Finder(*CursorInfo.SF, CursorInfo.Loc,
-         [](ASTNode N) {
-           return N.isStmt(StmtKind::Brace) || N.isExpr(ExprKind::Call);
-         });
+  ContextFinder Finder(
+      *CursorInfo.getSourceFile(), CursorInfo.getLoc(), [](ASTNode N) {
+        return N.isStmt(StmtKind::Brace) || N.isExpr(ExprKind::Call);
+      });
   Finder.resolve();
   auto contexts = Finder.getContexts();
   if (contexts.empty())
@@ -3946,7 +3963,7 @@ static CallExpr *findTrailingClosureTarget(
 
 bool RefactoringActionTrailingClosure::
 isApplicable(const ResolvedCursorInfo &CursorInfo, DiagnosticEngine &Diag) {
-  SourceManager &SM = CursorInfo.SF->getASTContext().SourceMgr;
+  SourceManager &SM = CursorInfo.getSourceFile()->getASTContext().SourceMgr;
   return findTrailingClosureTarget(SM, CursorInfo);
 }
 
@@ -4147,7 +4164,8 @@ CallExpr *findOuterCall(const ResolvedCursorInfo &CursorInfo) {
   // TODO: Bit pointless using the "ContextFinder" here. Ideally we would have
   //       already generated a slice of the AST for anything that contains
   //       the cursor location
-  ContextFinder Finder(*CursorInfo.SF, CursorInfo.Loc, IncludeInContext);
+  ContextFinder Finder(*CursorInfo.getSourceFile(), CursorInfo.getLoc(),
+                       IncludeInContext);
   Finder.resolve();
   auto Contexts = Finder.getContexts();
   if (Contexts.empty())
@@ -4157,8 +4175,8 @@ CallExpr *findOuterCall(const ResolvedCursorInfo &CursorInfo) {
   if (!CE)
     return nullptr;
 
-  SourceManager &SM = CursorInfo.SF->getASTContext().SourceMgr;
-  if (!SM.rangeContains(CE->getFn()->getSourceRange(), CursorInfo.Loc))
+  SourceManager &SM = CursorInfo.getSourceFile()->getASTContext().SourceMgr;
+  if (!SM.rangeContains(CE->getFn()->getSourceRange(), CursorInfo.getLoc()))
     return nullptr;
   return CE;
 }
@@ -4172,7 +4190,8 @@ FuncDecl *findFunction(const ResolvedCursorInfo &CursorInfo) {
     return false;
   };
 
-  ContextFinder Finder(*CursorInfo.SF, CursorInfo.Loc, IncludeInContext);
+  ContextFinder Finder(*CursorInfo.getSourceFile(), CursorInfo.getLoc(),
+                       IncludeInContext);
   Finder.resolve();
 
   auto Contexts = Finder.getContexts();
@@ -4190,10 +4209,10 @@ FuncDecl *findFunction(const ResolvedCursorInfo &CursorInfo) {
   if (!Body && !isa<ProtocolDecl>(FD->getDeclContext()))
     return nullptr;
 
-  SourceManager &SM = CursorInfo.SF->getASTContext().SourceMgr;
+  SourceManager &SM = CursorInfo.getSourceFile()->getASTContext().SourceMgr;
   SourceLoc DeclEnd = Body ? Body->getLBraceLoc() : FD->getEndLoc();
   if (!SM.rangeContains(SourceRange(FD->getStartLoc(), DeclEnd),
-                        CursorInfo.Loc))
+                        CursorInfo.getLoc()))
     return nullptr;
 
   return FD;
@@ -8263,10 +8282,9 @@ bool RefactoringActionConvertCallToAsyncAlternative::performChange() {
          "Should not run performChange when refactoring is not applicable");
 
   // Find the scope this call is in
-  ContextFinder Finder(*CursorInfo.SF, CursorInfo.Loc,
-                      [](ASTNode N) {
-    return N.isStmt(StmtKind::Brace) && !N.isImplicit();
-  });
+  ContextFinder Finder(
+      *CursorInfo.getSourceFile(), CursorInfo.getLoc(),
+      [](ASTNode N) { return N.isStmt(StmtKind::Brace) && !N.isImplicit(); });
   Finder.resolve();
   auto Scopes = Finder.getContexts();
   BraceStmt *Scope = nullptr;
@@ -8572,23 +8590,27 @@ void swift::ide::collectRenameAvailabilityInfo(
 void swift::ide::collectAvailableRefactorings(
     const ResolvedCursorInfo &CursorInfo,
     SmallVectorImpl<RefactoringKind> &Kinds, bool ExcludeRename) {
-  DiagnosticEngine DiagEngine(CursorInfo.SF->getASTContext().SourceMgr);
+  DiagnosticEngine DiagEngine(
+      CursorInfo.getSourceFile()->getASTContext().SourceMgr);
 
   if (!ExcludeRename) {
     if (RefactoringActionLocalRename::isApplicable(CursorInfo, DiagEngine))
       Kinds.push_back(RefactoringKind::LocalRename);
 
-    switch (CursorInfo.Kind) {
+    switch (CursorInfo.getKind()) {
     case CursorInfoKind::ModuleRef:
     case CursorInfoKind::Invalid:
     case CursorInfoKind::StmtStart:
     case CursorInfoKind::ExprStart:
       break;
     case CursorInfoKind::ValueRef: {
+      auto ValueRefInfo = cast<ResolvedValueRefCursorInfo>(CursorInfo);
       Optional<RenameRefInfo> RefInfo;
-      if (CursorInfo.IsRef)
-        RefInfo = {CursorInfo.SF, CursorInfo.Loc, CursorInfo.IsKeywordArgument};
-      auto RenameOp = getAvailableRenameForDecl(CursorInfo.ValueD, RefInfo);
+      if (ValueRefInfo.isRef())
+        RefInfo = {CursorInfo.getSourceFile(), CursorInfo.getLoc(),
+                   ValueRefInfo.isKeywordArgument()};
+      auto RenameOp =
+          getAvailableRenameForDecl(ValueRefInfo.getValueD(), RefInfo);
       if (RenameOp.hasValue() &&
           RenameOp.getValue() == RefactoringKind::GlobalRename)
         Kinds.push_back(RenameOp.getValue());
@@ -8802,14 +8824,16 @@ int swift::ide::findLocalRenameRanges(
     evaluateOrDefault(SF->getASTContext().evaluator,
                       CursorInfoRequest{CursorInfoOwner(SF, StartLoc)},
                       ResolvedCursorInfo());
-  if (!CursorInfo.isValid() || !CursorInfo.ValueD) {
+  auto ValueRefCursorInfo = dyn_cast<ResolvedValueRefCursorInfo>(&CursorInfo);
+  if (!ValueRefCursorInfo || !ValueRefCursorInfo->getValueD()) {
     Diags.diagnose(StartLoc, diag::unresolved_location);
     return true;
   }
-  ValueDecl *VD = CursorInfo.typeOrValue();
+  ValueDecl *VD = ValueRefCursorInfo->typeOrValue();
   Optional<RenameRefInfo> RefInfo;
-  if (CursorInfo.IsRef)
-    RefInfo = {CursorInfo.SF, CursorInfo.Loc, CursorInfo.IsKeywordArgument};
+  if (ValueRefCursorInfo->isRef())
+    RefInfo = {CursorInfo.getSourceFile(), CursorInfo.getLoc(),
+               ValueRefCursorInfo->isKeywordArgument()};
 
   llvm::SmallVector<DeclContext *, 8> Scopes;
   analyzeRenameScope(VD, RefInfo, Diags, Scopes);

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -551,6 +551,11 @@ bool swift::typeCheckForCodeCompletion(
                                                  callback);
 }
 
+Expr *swift::resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *Context,
+                                bool replaceInvalidRefsWithErrors) {
+  return TypeChecker::resolveDeclRefExpr(UDRE, Context, replaceInvalidRefsWithErrors);
+}
+
 void TypeChecker::checkForForbiddenPrefix(ASTContext &C, DeclBaseName Name) {
   if (C.TypeCheckerOpts.DebugForbidTypecheckPrefix.empty())
     return;

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -386,6 +386,15 @@ struct RefactoringInfo {
 
   RefactoringInfo(UIdent Kind, StringRef KindName, StringRef UnavailableReason)
       : Kind(Kind), KindName(KindName), UnavailableReason(UnavailableReason) {}
+
+  void print(llvm::raw_ostream &OS, std::string Indentation) const {
+    OS << Indentation << "RefactoringInfo" << '\n';
+    OS << Indentation << "  Kind: " << Kind.getName() << '\n';
+    OS << Indentation << "  KindName: " << KindName << '\n';
+    OS << Indentation << "  UnavailableReason: " << UnavailableReason << '\n';
+  }
+
+  SWIFT_DEBUG_DUMP { print(llvm::errs(), ""); }
 };
 
 struct ParentInfo {
@@ -395,6 +404,15 @@ struct ParentInfo {
 
   ParentInfo(StringRef Title, StringRef KindName, StringRef USR)
       : Title(Title), KindName(KindName), USR(USR) {}
+
+  void print(llvm::raw_ostream &OS, std::string Indentation) const {
+    OS << Indentation << "ParentInfo" << '\n';
+    OS << Indentation << "  Title: " << Title << '\n';
+    OS << Indentation << "  KindName: " << KindName << '\n';
+    OS << Indentation << "  USR: " << USR << '\n';
+  }
+
+  SWIFT_DEBUG_DUMP { print(llvm::errs(), ""); }
 };
 
 struct ReferencedDeclInfo {
@@ -413,6 +431,24 @@ struct ReferencedDeclInfo {
       : USR(USR), DeclarationLang(DeclLang), AccessLevel(AccessLevel),
         FilePath(FilePath), ModuleName(ModuleName), IsSystem(System),
         IsSPI(SPI), ParentContexts(Parents) {}
+
+  void print(llvm::raw_ostream &OS, std::string Indentation) const {
+    OS << Indentation << "ReferencedDeclInfo" << '\n';
+    OS << Indentation << "  USR: " << USR << '\n';
+    OS << Indentation << "  DeclarationLang: " << DeclarationLang.getName()
+       << '\n';
+    OS << Indentation << "  AccessLevel: " << AccessLevel << '\n';
+    OS << Indentation << "  FilePath: " << FilePath << '\n';
+    OS << Indentation << "  ModuleName: " << ModuleName << '\n';
+    OS << Indentation << "  IsSystem: " << IsSystem << '\n';
+    OS << Indentation << "  IsSPI: " << IsSPI << '\n';
+    OS << Indentation << "  ParentContexts:" << '\n';
+    for (auto ParentCtx : ParentContexts) {
+      ParentCtx.print(OS, Indentation + "   ");
+    }
+  }
+
+  SWIFT_DEBUG_DUMP { print(llvm::errs(), ""); }
 };
 
 struct LocationInfo {
@@ -421,6 +457,17 @@ struct LocationInfo {
   unsigned Length = 0;
   unsigned Line = 0;
   unsigned Column = 0;
+
+  void print(llvm::raw_ostream &OS, std::string Indentation) const {
+    OS << Indentation << "LocationInfo" << '\n';
+    OS << Indentation << "  Filename: " << Filename << '\n';
+    OS << Indentation << "  Offset: " << Offset << '\n';
+    OS << Indentation << "  Length: " << Length << '\n';
+    OS << Indentation << "  Line: " << Line << '\n';
+    OS << Indentation << "  Column: " << Column << '\n';
+  }
+
+  SWIFT_DEBUG_DUMP { print(llvm::errs(), ""); }
 };
 
 struct CursorSymbolInfo {
@@ -470,6 +517,60 @@ struct CursorSymbolInfo {
   bool IsSynthesized = false;
 
   llvm::Optional<unsigned> ParentNameOffset;
+
+  void print(llvm::raw_ostream &OS, std::string Indentation) const {
+    OS << Indentation << "CursorSymbolInfo" << '\n';
+    OS << Indentation << "  Kind: " << Kind.getName() << '\n';
+    OS << Indentation << "  DeclarationLang: " << DeclarationLang.getName()
+       << '\n';
+    OS << Indentation << "  Name: " << Name << '\n';
+    OS << Indentation << "  USR: " << USR << '\n';
+    OS << Indentation << "  TypeName: " << TypeName << '\n';
+    OS << Indentation << "  TypeUSR: " << TypeUSR << '\n';
+    OS << Indentation << "  ContainerTypeUSR: " << ContainerTypeUSR << '\n';
+    OS << Indentation << "  DocComment: " << DocComment << '\n';
+    OS << Indentation << "  GroupName: " << GroupName << '\n';
+    OS << Indentation << "  LocalizationKey: " << LocalizationKey << '\n';
+    OS << Indentation << "  AnnotatedDeclaration: " << AnnotatedDeclaration
+       << '\n';
+    OS << Indentation
+       << "  FullyAnnotatedDeclaration: " << FullyAnnotatedDeclaration << '\n';
+    OS << Indentation << "  SymbolGraph: " << SymbolGraph << '\n';
+    OS << Indentation << "  ModuleName: " << ModuleName << '\n';
+    OS << Indentation << "  ModuleInterfaceName: " << ModuleInterfaceName
+       << '\n';
+    Location.print(OS, Indentation + "  ");
+    OS << Indentation << "  OverrideUSRs:" << '\n';
+    for (auto OverrideUSR : OverrideUSRs) {
+      OS << Indentation << "    " << OverrideUSR << '\n';
+    }
+    OS << Indentation << "  AnnotatedRelatedDeclarations:" << '\n';
+    for (auto AnnotatedRelatedDeclaration : AnnotatedRelatedDeclarations) {
+      OS << Indentation << "    " << AnnotatedRelatedDeclaration << '\n';
+    }
+    OS << Indentation << "  ModuleGroupArray:" << '\n';
+    for (auto ModuleGroup : ModuleGroupArray) {
+      OS << Indentation << "    " << ModuleGroup << '\n';
+    }
+    OS << Indentation << "  ParentContexts:" << '\n';
+    for (auto ParentContext : ParentContexts) {
+      ParentContext.print(OS, Indentation + "    ");
+    }
+    OS << Indentation << "ReferencedSymbols:" << '\n';
+    for (auto ReferencedSymbol : ReferencedSymbols) {
+      ReferencedSymbol.print(OS, Indentation + "    ");
+    }
+    OS << Indentation << "ReceiverUSRs:" << '\n';
+    for (auto ReceiverUSR : ReceiverUSRs) {
+      OS << Indentation << "    " << ReceiverUSR << '\n';
+    }
+    OS << Indentation << "IsSystem: " << IsSystem << '\n';
+    OS << Indentation << "IsDynamic: " << IsDynamic << '\n';
+    OS << Indentation << "IsSynthesized: " << IsSynthesized << '\n';
+    OS << Indentation << "ParentNameOffset: " << ParentNameOffset << '\n';
+  }
+
+  SWIFT_DEBUG_DUMP { print(llvm::errs(), ""); }
 };
 
 struct CursorInfoData {
@@ -480,6 +581,20 @@ struct CursorInfoData {
   llvm::ArrayRef<CursorSymbolInfo> Symbols;
   /// All available actions on the code under cursor.
   llvm::ArrayRef<RefactoringInfo> AvailableActions;
+
+  void print(llvm::raw_ostream &OS, std::string Indentation) const {
+    OS << Indentation << "CursorInfoData" << '\n';
+    OS << Indentation << "  Symbols:" << '\n';
+    for (auto Symbol : Symbols) {
+      Symbol.print(OS, Indentation + "    ");
+    }
+    OS << Indentation << "  AvailableActions:" << '\n';
+    for (auto AvailableAction : AvailableActions) {
+      AvailableAction.print(OS, Indentation + "    ");
+    }
+  }
+
+  SWIFT_DEBUG_DUMP { print(llvm::errs(), ""); }
 };
 
 /// The result type of `LangSupport::getDiagnostics`

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -648,9 +648,11 @@ SwiftASTManager::~SwiftASTManager() {
   delete &Impl;
 }
 
-std::unique_ptr<llvm::MemoryBuffer>
-SwiftASTManager::getMemoryBuffer(StringRef Filename, std::string &Error) {
-  return Impl.getMemoryBuffer(Filename, llvm::vfs::getRealFileSystem(), Error);
+std::unique_ptr<llvm::MemoryBuffer> SwiftASTManager::getMemoryBuffer(
+    StringRef Filename,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
+    std::string &Error) {
+  return Impl.getMemoryBuffer(Filename, FileSystem, Error);
 }
 
 static FrontendInputsAndOutputs

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
@@ -262,8 +262,10 @@ public:
                   SourceKitCancellationToken CancellationToken,
                   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> fileSystem);
 
-  std::unique_ptr<llvm::MemoryBuffer> getMemoryBuffer(StringRef Filename,
-                                                      std::string &Error);
+  std::unique_ptr<llvm::MemoryBuffer>
+  getMemoryBuffer(StringRef Filename,
+                  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
+                  std::string &Error);
 
   bool initCompilerInvocation(swift::CompilerInvocation &Invocation,
                               ArrayRef<const char *> Args,

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -105,7 +105,8 @@ static void swiftCodeCompleteImpl(
   CompletionContext.setAddCallWithNoDefaultArgs(opts.addCallWithNoDefaultArgs);
 
   Lang.performWithParamsToCompletionLikeOperation(
-      UnresolvedInputFile, Offset, Args, FileSystem, CancellationToken,
+      UnresolvedInputFile, Offset, /*InsertCodeCompletionToken=*/true, Args,
+      FileSystem, CancellationToken,
       [&](CancellableResult<SwiftLangSupport::CompletionLikeOperationParams>
               ParamsResult) {
         ParamsResult.mapAsync<CodeCompleteResult>(

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -176,7 +176,8 @@ void SwiftLangSupport::getConformingMethodList(
   }
 
   performWithParamsToCompletionLikeOperation(
-      UnresolvedInputFile, Offset, Args, fileSystem, CancellationToken,
+      UnresolvedInputFile, Offset, /*InsertCodeCompletionToken=*/true, Args,
+      fileSystem, CancellationToken,
       [&](CancellableResult<CompletionLikeOperationParams> ParmsResult) {
         ParmsResult.mapAsync<ConformingMethodListResults>(
             [&](auto &Params, auto DeliverTransformed) {

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -277,7 +277,8 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
                                    IndexingConsumer &IdxConsumer,
                                    ArrayRef<const char *> OrigArgs) {
   std::string Error;
-  auto InputBuf = ASTMgr->getMemoryBuffer(InputFile, Error);
+  auto InputBuf =
+      ASTMgr->getMemoryBuffer(InputFile, llvm::vfs::getRealFileSystem(), Error);
   if (!InputBuf) {
     IdxConsumer.failed(Error);
     return;

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -1008,7 +1008,7 @@ SwiftLangSupport::getFileSystem(const Optional<VFSOptions> &vfsOptions,
 
 void SwiftLangSupport::performWithParamsToCompletionLikeOperation(
     llvm::MemoryBuffer *UnresolvedInputFile, unsigned Offset,
-    ArrayRef<const char *> Args,
+    bool InsertCodeCompletionToken, ArrayRef<const char *> Args,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
     SourceKitCancellationToken CancellationToken,
     llvm::function_ref<void(CancellableResult<CompletionLikeOperationParams>)>
@@ -1026,8 +1026,18 @@ void SwiftLangSupport::performWithParamsToCompletionLikeOperation(
   // Create a buffer for code completion. This contains '\0' at 'Offset'
   // position of 'UnresolvedInputFile' buffer.
   auto origOffset = Offset;
-  auto newBuffer = ide::makeCodeCompletionMemoryBuffer(
-      UnresolvedInputFile, Offset, bufferIdentifier);
+
+  // If we inserted a code completion token into the buffer, this keeps the
+  // buffer alive. Should never be accessed, `buffer` should be used instead.
+  std::unique_ptr<llvm::MemoryBuffer> codeCompletionBuffer;
+  llvm::MemoryBuffer *buffer;
+  if (InsertCodeCompletionToken) {
+    codeCompletionBuffer = ide::makeCodeCompletionMemoryBuffer(
+        UnresolvedInputFile, Offset, bufferIdentifier);
+    buffer = codeCompletionBuffer.get();
+  } else {
+    buffer = UnresolvedInputFile;
+  }
 
   SourceManager SM;
   DiagnosticEngine Diags(SM);
@@ -1055,7 +1065,7 @@ void SwiftLangSupport::performWithParamsToCompletionLikeOperation(
   std::string CompilerInvocationError;
   bool CreatingInvocationFailed = getASTManager()->initCompilerInvocation(
       Invocation, Args, FrontendOptions::ActionType::Typecheck, Diags,
-      newBuffer->getBufferIdentifier(), FileSystem, CompilerInvocationError);
+      buffer->getBufferIdentifier(), FileSystem, CompilerInvocationError);
   if (CreatingInvocationFailed) {
     PerformOperation(CancellableResult<CompletionLikeOperationParams>::failure(
         CompilerInvocationError));
@@ -1075,7 +1085,7 @@ void SwiftLangSupport::performWithParamsToCompletionLikeOperation(
     CancellationFlag->store(true, std::memory_order_relaxed);
   });
 
-  CompletionLikeOperationParams Params = {Invocation, newBuffer.get(), &CIDiags,
+  CompletionLikeOperationParams Params = {Invocation, buffer, &CIDiags,
                                           CancellationFlag};
   PerformOperation(
       CancellableResult<CompletionLikeOperationParams>::success(Params));

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -516,9 +516,12 @@ public:
 
   /// Execute \p PerformOperation synchronously with the parameters necessary to
   /// invoke a completion-like operation on \c CompletionInstance.
+  /// If \p InsertCodeCompletionToken is \c true, a code completion token will
+  /// be inserted into the source buffer, if \p InsertCodeCompletionToken is \c
+  /// false, the buffer is left as-is.
   void performWithParamsToCompletionLikeOperation(
       llvm::MemoryBuffer *UnresolvedInputFile, unsigned Offset,
-      ArrayRef<const char *> Args,
+      bool InsertCodeCompletionToken, ArrayRef<const char *> Args,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
       SourceKitCancellationToken CancellationToken,
       llvm::function_ref<

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -146,7 +146,8 @@ void SwiftLangSupport::getExpressionContextInfo(
   }
 
   performWithParamsToCompletionLikeOperation(
-      UnresolvedInputFile, Offset, Args, fileSystem, CancellationToken,
+      UnresolvedInputFile, Offset, /*InsertCodeCompletionToken=*/true, Args,
+      fileSystem, CancellationToken,
       [&](CancellableResult<CompletionLikeOperationParams> ParamsResult) {
         ParamsResult.mapAsync<TypeContextInfoResult>(
             [&](auto &CIParams, auto DeliverTransformed) {


### PR DESCRIPTION
This PR contains multiple, more or less independent commits that are required to implement cursor info using the solver-based / completion-like design that doesn’t type check the entire file but only those parts that are necessary to server the request and which will allow cursor info to return ambiguous results.

If any of these changes is controversial, I can split it into a separate PR.