### PR TITLE
[cxx-interop] Synthesize conformances to `CxxConvertibleToCollection`

### DIFF
--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -105,6 +105,7 @@ PROTOCOL(DistributedTargetInvocationDecoder)
 PROTOCOL(DistributedTargetInvocationResultHandler)
 
 // C++ Standard Library Overlay:
+PROTOCOL(CxxConvertibleToCollection)
 PROTOCOL(CxxRandomAccessCollection)
 PROTOCOL(CxxSequence)
 PROTOCOL(UnsafeCxxInputIterator)

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1126,6 +1126,7 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
   case KnownProtocolKind::DistributedTargetInvocationResultHandler:
     M = getLoadedModule(Id_Distributed);
     break;
+  case KnownProtocolKind::CxxConvertibleToCollection:
   case KnownProtocolKind::CxxRandomAccessCollection:
   case KnownProtocolKind::CxxSequence:
   case KnownProtocolKind::UnsafeCxxInputIterator:

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5884,6 +5884,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::DistributedTargetInvocationEncoder:
   case KnownProtocolKind::DistributedTargetInvocationDecoder:
   case KnownProtocolKind::DistributedTargetInvocationResultHandler:
+  case KnownProtocolKind::CxxConvertibleToCollection:
   case KnownProtocolKind::CxxRandomAccessCollection:
   case KnownProtocolKind::CxxSequence:
   case KnownProtocolKind::UnsafeCxxInputIterator:

--- a/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
@@ -9,8 +9,6 @@ import Cxx
 
 var CxxSequenceTestSuite = TestSuite("CxxConvertibleToCollection")
 
-extension SimpleSequence: CxxConvertibleToCollection {}
-
 CxxSequenceTestSuite.test("SimpleSequence to Swift.Array") {
   let seq = SimpleSequence()
   let array = Array(seq)
@@ -22,8 +20,6 @@ CxxSequenceTestSuite.test("SimpleSequence to Swift.Set") {
   let set = Set(seq)
   expectEqual(Set([1, 2, 3, 4] as [Int32]), set)
 }
-
-extension SimpleEmptySequence: CxxConvertibleToCollection {}
 
 CxxSequenceTestSuite.test("SimpleEmptySequence to Swift.Array") {
   let seq = SimpleEmptySequence()

--- a/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
@@ -1,30 +1,30 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=CustomSequence -source-filename=x -I %S/Inputs -enable-experimental-cxx-interop -module-cache-path %t | %FileCheck %s
 
-// CHECK: struct SimpleSequence {
+// CHECK: struct SimpleSequence : CxxConvertibleToCollection {
 // CHECK:   typealias Element = ConstIterator.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleSequence>
 // CHECK:   typealias RawIterator = ConstIterator
 // CHECK: }
 
-// CHECK: struct SimpleSequenceWithOutOfLineEqualEqual {
+// CHECK: struct SimpleSequenceWithOutOfLineEqualEqual : CxxConvertibleToCollection {
 // CHECK:   typealias Element = ConstIteratorOutOfLineEq.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleSequenceWithOutOfLineEqualEqual>
 // CHECK:   typealias RawIterator = ConstIteratorOutOfLineEq
 // CHECK: }
 
-// CHECK: struct SimpleArrayWrapperNullableIterators {
+// CHECK: struct SimpleArrayWrapperNullableIterators : CxxConvertibleToCollection {
 // CHECK:   typealias Element = Optional<UnsafePointer<Int32>>.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleArrayWrapperNullableIterators>
 // CHECK:   typealias RawIterator = UnsafePointer<Int32>?
 // CHECK: }
 
-// CHECK: struct SimpleEmptySequence {
+// CHECK: struct SimpleEmptySequence : CxxConvertibleToCollection {
 // CHECK:   typealias Element = Optional<UnsafePointer<Int32>>.Pointee
 // CHECK:   typealias Iterator = CxxIterator<SimpleEmptySequence>
 // CHECK:   typealias RawIterator = UnsafePointer<Int32>?
 // CHECK: }
 
-// CHECK: struct HasMutatingBeginEnd {
+// CHECK: struct HasMutatingBeginEnd : CxxConvertibleToCollection {
 // CHECK:   typealias Element = ConstIterator.Pointee
 // CHECK:   typealias Iterator = CxxIterator<HasMutatingBeginEnd>
 // CHECK:   typealias RawIterator = ConstIterator


### PR DESCRIPTION
This extends the existing auto-conformance mechanism to synthesize the conformances to `CxxConvertibleToCollection` protocol for C++ sequence types.

This means that the developer can now call `Array(myCxxSequence)` or `Set(myCxxSequence)` without adding any extensions manually.