### PR TITLE
Refactor `_swift_withWin32DbgHelpLibrary()` to avoid using `GetCurrentProcess()` per Microsoft documentation

### DIFF
--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -99,7 +99,7 @@ static bool getSymbolNameAddr(llvm::StringRef libraryName,
 #if defined(_WIN32)
   char szUndName[1024];
   DWORD dwResult;
-  dwResult = _swift_withWin32DbgHelpLibrary([&] (HANDLE hProcess) -> DWORD {
+  dwResult = _swift_win32_withDbgHelpLibrary([&] (HANDLE hProcess) -> DWORD {
     if (!hProcess) {
       return 0;
     }

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -99,8 +99,8 @@ static bool getSymbolNameAddr(llvm::StringRef libraryName,
 #if defined(_WIN32)
   char szUndName[1024];
   DWORD dwResult;
-  dwResult = _swift_withWin32DbgHelpLibrary([&] (bool isInitialized) -> DWORD {
-    if (!isInitialized) {
+  dwResult = _swift_withWin32DbgHelpLibrary([&] (HANDLE hProcess) -> DWORD {
+    if (!hProcess) {
       return 0;
     }
 

--- a/stdlib/public/runtime/ImageInspection.h
+++ b/stdlib/public/runtime/ImageInspection.h
@@ -132,7 +132,7 @@ int lookupSymbol(const void *address, SymbolInfo *info);
 /// their old value before returning. \a body can also call \c SymSetOptions()
 /// if needed.
 SWIFT_RUNTIME_STDLIB_SPI
-void _swift_withWin32DbgHelpLibrary(
+void _swift_win32_withDbgHelpLibrary(
   void (* body)(HANDLE hProcess, void *context), void *context);
 
 /// Configure the environment to allow calling into the Debug Help library.
@@ -150,9 +150,9 @@ void _swift_withWin32DbgHelpLibrary(
 /// \c SymSetOptions() before \a body is invoked, and then resets them back to
 /// their old value before returning. \a body can also call \c SymSetOptions()
 /// if needed.
-static inline void _swift_withWin32DbgHelpLibrary(
+static inline void _swift_win32_withDbgHelpLibrary(
   const std::function<void(HANDLE /*hProcess*/)> &body) {
-  _swift_withWin32DbgHelpLibrary([](HANDLE hProcess, void *context) {
+  _swift_win32_withDbgHelpLibrary([](HANDLE hProcess, void *context) {
     auto bodyp = reinterpret_cast<std::function<void(bool)> *>(context);
     (* bodyp)(hProcess);
   }, const_cast<void *>(reinterpret_cast<const void *>(&body)));
@@ -180,10 +180,10 @@ template <
   typename R = typename std::result_of_t<F&(HANDLE /*hProcess*/)>,
   typename = typename std::enable_if_t<!std::is_same<void, R>::value>
 >
-static inline R _swift_withWin32DbgHelpLibrary(const F& body) {
+static inline R _swift_win32_withDbgHelpLibrary(const F& body) {
   R result;
 
-  _swift_withWin32DbgHelpLibrary([&body, &result] (HANDLE hProcess) {
+  _swift_win32_withDbgHelpLibrary([&body, &result] (HANDLE hProcess) {
     result = body(hProcess);
   });
 

--- a/stdlib/public/runtime/ImageInspection.h
+++ b/stdlib/public/runtime/ImageInspection.h
@@ -153,7 +153,7 @@ void _swift_win32_withDbgHelpLibrary(
 static inline void _swift_win32_withDbgHelpLibrary(
   const std::function<void(HANDLE /*hProcess*/)> &body) {
   _swift_win32_withDbgHelpLibrary([](HANDLE hProcess, void *context) {
-    auto bodyp = reinterpret_cast<std::function<void(bool)> *>(context);
+    auto bodyp = reinterpret_cast<std::function<void(HANDLE)> *>(context);
     (* bodyp)(hProcess);
   }, const_cast<void *>(reinterpret_cast<const void *>(&body)));
 }

--- a/stdlib/public/runtime/ImageInspectionCOFF.cpp
+++ b/stdlib/public/runtime/ImageInspectionCOFF.cpp
@@ -40,7 +40,7 @@ int swift::lookupSymbol(const void *address, SymbolInfo *info) {
   info->symbolAddress = dli_saddr;
   return 1;
 #elif defined(_WIN32)
-  return _swift_withWin32DbgHelpLibrary([&] (HANDLE hProcess) {
+  return _swift_win32_withDbgHelpLibrary([&] (HANDLE hProcess) {
     static const constexpr size_t kSymbolMaxNameLen = 1024;
 
     if (!hProcess) {
@@ -71,7 +71,7 @@ int swift::lookupSymbol(const void *address, SymbolInfo *info) {
 static LazyMutex mutex;
 static HANDLE dbgHelpHandle = nullptr;
 
-void swift::_swift_withWin32DbgHelpLibrary(
+void swift::_swift_win32_withDbgHelpLibrary(
   void (* body)(HANDLE hProcess, void *context), void *context) {
   mutex.withLock([=] () {
     // If we have not previously created a handle to use with the library, do so

--- a/stdlib/public/runtime/ImageInspectionCOFF.cpp
+++ b/stdlib/public/runtime/ImageInspectionCOFF.cpp
@@ -40,30 +40,25 @@ int swift::lookupSymbol(const void *address, SymbolInfo *info) {
   info->symbolAddress = dli_saddr;
   return 1;
 #elif defined(_WIN32)
-  return _swift_withWin32DbgHelpLibrary([&] (bool isInitialized) {
+  return _swift_withWin32DbgHelpLibrary([&] (HANDLE hProcess) {
     static const constexpr size_t kSymbolMaxNameLen = 1024;
 
-    if (!isInitialized) {
+    if (!hProcess) {
       return 0;
     }
 
-    char buffer[sizeof(SYMBOL_INFO) + kSymbolMaxNameLen];
-    PSYMBOL_INFO pSymbol = reinterpret_cast<PSYMBOL_INFO>(buffer);
-    pSymbol->SizeOfStruct = sizeof(SYMBOL_INFO);
-    pSymbol->MaxNameLen = kSymbolMaxNameLen;
-
-    DWORD64 dwDisplacement = 0;
-
-    if (SymFromAddr(GetCurrentProcess(),
-                    reinterpret_cast<const DWORD64>(address),
-                    &dwDisplacement, pSymbol) == FALSE) {
+    SYMBOL_INFO_PACKAGE symbol = {};
+    symbol.si.SizeOfStruct = sizeof(SYMBOL_INFO);
+    symbol.si.MaxNameLen = MAX_SYM_NAME;
+    if (SymFromAddr(hProcess, reinterpret_cast<const DWORD64>(address),
+                    nullptr, &symbol.si) == FALSE) {
       return 0;
     }
 
     info->fileName = NULL;
-    info->baseAddress = reinterpret_cast<void *>(pSymbol->ModBase);
-    info->symbolName.reset(_strdup(pSymbol->Name));
-    info->symbolAddress = reinterpret_cast<void *>(pSymbol->Address);
+    info->baseAddress = reinterpret_cast<void *>(symbol.si.ModBase);
+    info->symbolName.reset(_strdup(symbol.si.Name));
+    info->symbolAddress = reinterpret_cast<void *>(symbol.si.Address);
 
     return 1;
   });
@@ -74,16 +69,58 @@ int swift::lookupSymbol(const void *address, SymbolInfo *info) {
 
 #if defined(_WIN32)
 static LazyMutex mutex;
-static bool isDbgHelpInitialized = false;
+static HANDLE dbgHelpHandle = nullptr;
 
 void swift::_swift_withWin32DbgHelpLibrary(
-  void (* body)(bool isInitialized, void *context), void *context) {
+  void (* body)(HANDLE hProcess, void *context), void *context) {
   mutex.withLock([=] () {
-    if (!isDbgHelpInitialized) {
-      SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS);
-      isDbgHelpInitialized = SymInitialize(GetCurrentProcess(), nullptr, true);
+    // If we have not previously created a handle to use with the library, do so
+    // now. This handle belongs to the Swift runtime and should not be closed by
+    // `body` (or anybody else.)
+    if (!dbgHelpHandle) {
+      // Per the documentation for the Debug Help library, we should not use the
+      // current process handle because other subsystems might also use it and
+      // end up stomping on each other. So we'll try to duplicate that handle to
+      // get a unique one that still fulfills the needs of the library. If that
+      // fails (presumably because the current process doesn't have the
+      // PROCESS_DUP_HANDLE access right) then fall back to using the original
+      // process handle and hope nobody else is using it too.
+      HANDLE currentProcess = GetCurrentProcess();
+      if (!DuplicateHandle(currentProcess, currentProcess, currentProcess,
+                           &dbgHelpHandle, 0, false, DUPLICATE_SAME_ACCESS)) {
+        dbgHelpHandle = currentProcess;
+      }
     }
-    body(isDbgHelpInitialized, context);
+
+    // If we have not previously initialized the Debug Help library, do so now.
+    bool isDbgHelpInitialized = false;
+    if (dbgHelpHandle) {
+      isDbgHelpInitialized = SymInitialize(dbgHelpHandle, nullptr, true);
+    }
+
+    if (isDbgHelpInitialized) {
+      // Set the library's options to what the Swift runtime generally expects.
+      // If the options aren't going to change, we can skip the call and save a
+      // few CPU cycles on the library call.
+      constexpr const DWORD options = SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS;
+      DWORD oldOptions = SymGetOptions();
+      if (oldOptions != options) {
+        SymSetOptions(options);
+      }
+
+      body(dbgHelpHandle, context);
+
+      // Before returning, reset the library's options back to their previous
+      // value. No need to call if the options didn't change because LazyMutex
+      // is not recursive, so there shouldn't be an outer call expecting the
+      // original options, and a subsequent call to this function will set them
+      // to the defaults above.
+      if (oldOptions != options) {
+        SymSetOptions(oldOptions);
+      }
+    } else {
+      body(nullptr, context);
+    }
   });
 }
 #endif


### PR DESCRIPTION
<!-- What's in this pull request? -->

The Microsoft [documentation](https://learn.microsoft.com/en-us/windows/win32/api/dbghelp/nf-dbghelp-syminitialize) for the DbgHelp library warns developers not to pass `GetCurrentProcess()` as the handle to `SymInitialize()` etc.

This change uses a privately-held handle duplicated from `GetCurrentProcess()`. It also takes care to set DbgHelp library options consistently in case something elsewhere calls `SymSetOptions()` and sets them to something incompatible with the runtime's expectations.

We still have no way to thread-safely use the library in coordination with code outside the runtime, but at least the runtime should avoid stomping on shared system resources.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #62290.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
