### PR TITLE
Forward SWIFT_COMPILER_VERSION

### DIFF
--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -74,4 +74,9 @@ if (SWIFT_SWIFT_PARSER)
   )
 endif()
 
+if(SWIFT_COMPILER_VERSION)
+  set_property(SOURCE ParseVersion.cpp APPEND_STRING PROPERTY COMPILE_FLAGS
+    " -DSWIFT_COMPILER_VERSION=\"\\\"${SWIFT_COMPILER_VERSION}\\\"\"")
+endif()
+
 set_swift_llvm_is_available(swiftParse)


### PR DESCRIPTION
This is set on a per-file basis and was not forwarded when https://github.com/apple/swift/pull/61014 was integrated.

This is a short-term fix for this issue. I don't see a reason this version number should be applied to individual files instead of being passed as an argument to every translation unit.

rdar://102731783