### PR TITLE
Support cross compilation of `docc` in macOS toolchain builds

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftdocc.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftdocc.py
@@ -64,6 +64,13 @@ class SwiftDocC(product.Product):
             '--build-dir', self.build_dir,
             '--multiroot-data-file', MULTIROOT_DATA_FILE_PATH,
         ]
+
+        # Pass Cross compile host info
+        if self.has_cross_compile_hosts() and self.is_darwin_host(host_target):
+            helper_cmd += ['--cross-compile-hosts']
+            for cross_compile_host in self.args.cross_compile_hosts:
+                helper_cmd += [cross_compile_host]
+
         if action != 'install':
             helper_cmd.extend([
                 # There might have been a Package.resolved created by other builds


### PR DESCRIPTION
Resolves https://github.com/apple/swift-docc/issues/433.

Updates the build script used in SwiftCI for building the `docc` executable as part of Swift.org toolchains to support cross compilation.

Currently the `docc` executable included in the otherwise universal macOS toolchain only supports x86_64. This resolves the issue.
