### PR TITLE
Sema: Allow `@inlinable` on back deployed functions

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4391,19 +4391,14 @@ void AttributeChecker::checkBackDeployAttrs(ArrayRef<BackDeployAttr *> Attrs) {
   if (Attrs.empty())
     return;
 
-  // Diagnose conflicting attributes. @_alwaysEmitIntoClient, @inlinable, and
-  // @_transparent all conflict with back deployment because they each cause the
-  // body of a function to be copied into the client under certain conditions
-  // and would defeat the goal of back deployment, which is to always use the
-  // ABI version of the declaration when it is available.
+  // Diagnose conflicting attributes. @_alwaysEmitIntoClient and @_transparent
+  // conflict with back deployment because they each cause the body of a
+  // function to always be copied into the client and would defeat the goal of
+  // back deployment, which is to use the ABI version of the declaration when it
+  // is available.
   if (auto *AEICA = D->getAttrs().getAttribute<AlwaysEmitIntoClientAttr>()) {
     diagnoseAndRemoveAttr(AEICA, diag::attr_incompatible_with_back_deploy,
                           AEICA, D->getDescriptiveKind());
-  }
-
-  if (auto *IA = D->getAttrs().getAttribute<InlinableAttr>()) {
-    diagnoseAndRemoveAttr(IA, diag::attr_incompatible_with_back_deploy, IA,
-                          D->getDescriptiveKind());
   }
 
   if (auto *TA = D->getAttrs().getAttribute<TransparentAttr>()) {

--- a/test/attr/Inputs/BackDeployHelper.swift
+++ b/test/attr/Inputs/BackDeployHelper.swift
@@ -140,6 +140,7 @@ extension IntArray {
 
   @available(BackDeploy 1.0, *)
   @_backDeploy(before: BackDeploy 2.0)
+  @inlinable
   public subscript(_ i: Int) -> Int {
     get { _values[i] }
     _modify { yield &_values[i] }
@@ -180,6 +181,7 @@ extension ReferenceIntArray {
 
   @available(BackDeploy 1.0, *)
   @_backDeploy(before: BackDeploy 2.0)
+  @inlinable
   public final subscript(_ i: Int) -> Int {
     get { _values[i] }
     _modify { yield &_values[i] }

--- a/test/attr/attr_backDeploy.swift
+++ b/test/attr/attr_backDeploy.swift
@@ -243,7 +243,7 @@ public func alwaysEmitIntoClientFunc() {}
 
 @available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0)
-@inlinable // expected-error {{'@inlinable' cannot be applied to a back deployed global function}}
+@inlinable // OK
 public func inlinableFunc() {}
 
 @available(macOS 11.0, *)


### PR DESCRIPTION
Per Swift Evolution feedback, back deployed functions should be allowed to be inlinable, even though this means that the version of the function in the library may not always be exectued when it is otherwise available.

Resolves rdar://102792806
