### PR TITLE
SILGen: Match up abstraction level when materializing mixed set and read/unsafeAddress properties.

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3198,7 +3198,7 @@ private:
         return SGF.emitLValue(e->getSubExpr(), SGFAccessKind::ReadWrite);
       }
     }();
-
+    
     if (loweredSubstParamType.hasAbstractionDifference(Rep,
                                                        loweredSubstArgType)) {
       lv.addSubstToOrigComponent(origType, loweredSubstParamType);

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1861,7 +1861,7 @@ namespace {
     }
 
     void dump(raw_ostream &OS, unsigned indent) const override {
-      OS.indent(indent) << "MaterializeToTemporaryComponent";
+      OS.indent(indent) << "MaterializeToTemporaryComponent\n";
     }
 
   private:
@@ -1894,6 +1894,10 @@ namespace {
                                       getSubstFormalType(),
                                       /*actorIsolation=*/None);
         }
+      }
+      
+      if (lv.getTypeOfRValue() != getTypeOfRValue()) {
+        lv.addOrigToSubstComponent(getTypeOfRValue());
       }
 
       return lv;
@@ -3490,6 +3494,7 @@ struct MemberStorageAccessEmitter : AccessEmitter<Impl, StorageType> {
                                BaseFormalType, typeData, varStorageType,
                                ArgListForDiagnostics, std::move(Indices),
                                IsOnSelfParameter);
+    
   }
 
   void emitUsingCoroutineAccessor(SILDeclRef accessor, bool isDirect,

--- a/test/SILGen/mix-setter-and-read.swift
+++ b/test/SILGen/mix-setter-and-read.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-emit-silgen -verify %s
+
+struct Attributt<T> {
+    public var read_and_set: T {
+        _read {
+            yield UnsafePointer<T>(bitPattern: 17)!.pointee
+        }
+        nonmutating set {
+        }
+    }
+    public var address_and_set: T {
+        unsafeAddress {
+            return UnsafePointer<T>(bitPattern: 38)!
+        }
+        nonmutating set {
+        }
+    }
+}
+
+func foo(x: inout (Int) -> Int) { }
+
+func bar(x: Attributt<(Int) -> Int>) {
+    foo(x: &x.read_and_set)
+    foo(x: &x.address_and_set)
+}
+


### PR DESCRIPTION
Addresses part of rdar://102525437.