### PR TITLE
SIL: Add parser support for `has_symbol` instructions

### DIFF
--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -4929,7 +4929,6 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       SILDeclRef Member;
       SILType MethodTy;
       SourceLoc TyLoc;
-      SmallVector<ValueDecl *, 4> values;
       if (parseTypedValueRef(Val, B) ||
           P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
         return true;
@@ -6116,7 +6115,12 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       break;
     }
     case SILInstructionKind::HasSymbolInst: {
-      llvm_unreachable("unimplemented"); // FIXME: implement SIL parsing
+      // 'has_symbol' sil-decl-ref
+      SILDeclRef declRef;
+      if (parseSILDeclRef(declRef))
+        return true;
+
+      ResultVal = B.createHasSymbol(InstLoc, declRef.getDecl());
       break;
     }
 

--- a/test/SIL/Parser/has_symbol.sil
+++ b/test/SIL/Parser/has_symbol.sil
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: echo "public func simpleFunc() {}" > %t/has_symbol_helper.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/has_symbol_helper.swiftmodule -parse-as-library -enable-library-evolution %t/has_symbol_helper.swift
+// RUN: %target-swift-frontend -emit-sil -verify %s -I %t/
+
+sil_stage raw
+
+import Builtin
+import Swift
+import SwiftShims
+
+@_weakLinked import has_symbol_helper
+
+sil hidden [ossa] @$s4test0A15GlobalFunctionsyyF : $@convention(thin) () -> () {
+bb0:
+  %0 = has_symbol #simpleFunc
+  cond_br %0, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %1 = tuple ()
+  return %1 : $()
+}


### PR DESCRIPTION
Implements the SIL parsing that was left as a FIXME in #62147.