### PR TITLE
[CSGen]: `getTypeForPattern` should perform member lookup into the external pattern metatype

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2721,6 +2721,18 @@ namespace {
               locator.withPathElement(LocatorPathElt::PatternMatch(pattern)));
 
           baseType = parentType;
+          // Perform member lookup into the external pattern metatype. e.g.
+          // `case let .test(tuple) as Test`.
+        } else if (externalPatternType) {
+          Type externalMetaType = MetatypeType::get(externalPatternType);
+
+          CS.addValueMemberConstraint(
+              externalMetaType, enumPattern->getName(), memberType, CurDC,
+              functionRefKind, {},
+              CS.getConstraintLocator(locator,
+                                      LocatorPathElt::PatternMatch(pattern)));
+
+          baseType = externalPatternType;
         } else {
           // Use the pattern type for member lookup.
           CS.addUnresolvedValueMemberConstraint(

--- a/test/Constraints/issue-60806.swift
+++ b/test/Constraints/issue-60806.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -dump-ast %s | %FileCheck %s
+
+// https://github.com/apple/swift/issues/60806
+
+struct Foo<T> {
+  init(_: (T) -> Void) {}
+}
+
+protocol Bar {}
+
+enum Baz: Bar {
+  case someCase(Int)
+}
+
+enum NonBarBaz {
+  case someCase(Int)
+}
+
+let _: Foo<Bar> = Foo<Bar> { (a: Bar) -> Void in
+  switch a {
+  // CHECK: (pattern_is type='Bar' value_cast Baz
+  // CHECK-NEXT: (pattern_enum_element type='Baz' Baz.someCase
+  case let .someCase(value) as Baz:
+    print(value)
+  // expected-warning@-1 {{cast from 'any Bar' to unrelated type 'NonBarBaz' always fails}}
+  case let .someCase(value) as NonBarBaz:
+    print(value)
+  default:
+      break
+  }
+}


### PR DESCRIPTION
## Summary

This PR fixes: #60806

For example we have `case let .someCase(value) as Baz`.
When resolving the `EnumElementPattern` type in `getTypeForPattern`, 
we should perform member lookup into the external pattern metatype.

## Thanks

Please feel free to critique, and thanks for your code review 😄 .