### PR TITLE
[Runtime] Add missing bridgeObjectRR_xN entrypoints.

### DIFF
--- a/include/swift/Runtime/CustomRRABI.h
+++ b/include/swift/Runtime/CustomRRABI.h
@@ -62,7 +62,7 @@ Param returnTypeHelper(Ret (*)(Param)) {}
 // Helper macro that defines one entrypoint that takes the parameter in reg and
 // calls through to function.
 #define CUSTOM_RR_ENTRYPOINTS_DEFINE_ONE_ENTRYPOINT(reg, function)             \
-  extern "C" SWIFT_RUNTIME_EXPORT decltype(function(                           \
+  SWIFT_RUNTIME_EXPORT decltype(function(                                      \
       nullptr)) function##_x##reg() {                                          \
     decltype(returnTypeHelper(function)) ptr;                                  \
     asm(".ifnc %0, x" #reg "\n"                                                \

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -26,6 +26,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "swift/Basic/Lazy.h"
 #include "swift/Runtime/Casting.h"
+#include "swift/Runtime/CustomRRABI.h"
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Runtime/Heap.h"
@@ -616,6 +617,8 @@ void *swift::swift_bridgeObjectRetain(void *object) {
 #endif
 }
 
+CUSTOM_RR_ENTRYPOINTS_DEFINE_ENTRYPOINTS(swift_bridgeObjectRetain)
+
 SWIFT_RUNTIME_EXPORT
 void *swift::swift_nonatomic_bridgeObjectRetain(void *object) {
 #if SWIFT_OBJC_INTEROP
@@ -655,6 +658,8 @@ void swift::swift_bridgeObjectRelease(void *object) {
   swift_release(static_cast<HeapObject *>(objectRef));
 #endif
 }
+
+CUSTOM_RR_ENTRYPOINTS_DEFINE_ENTRYPOINTS(swift_bridgeObjectRelease)
 
 void swift::swift_nonatomic_bridgeObjectRelease(void *object) {
 #if SWIFT_OBJC_INTEROP

--- a/test/Runtime/custom_rr_abi.swift
+++ b/test/Runtime/custom_rr_abi.swift
@@ -6,8 +6,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
-// REQUIRES: rdar102783074
-
 import StdlibUnittest
 
 // A class that can provider a retainable pointer and determine whether it's


### PR DESCRIPTION
We're supposed to expose bridgeObjectRetain/Release_xN variants, but they were missing. This fixes the custom_rr_abi.swift test. Also remove the redundant extern "C" on the entrypoint definitions, which fixes some warnings.

rdar://102793667 rdar://102783074