### PR TITLE
Preliminary support for member type representations with non-identifier qualifiers

### DIFF
--- a/docs/Generics/generics.tex
+++ b/docs/Generics/generics.tex
@@ -458,7 +458,7 @@ When emitting code to call to a generic function, the compiler looks at the subs
 \item Conformance lookup: Section~\ref{conformance lookup}
 \end{MoreDetails}
 
-\index{identifier type representation}
+\index{declaration reference type representation}
 \index{associated type}
 \paragraph{Associated types} Perhaps the simplest example of a protocol with an associated type is the \texttt{Iterator} protocol in the standard library. This protocol abstracts over an iterator which produces elements of a type that depends on the conformance:
 \begin{Verbatim}
@@ -473,7 +473,7 @@ func firstElement<I: IteratorProtocol>(_ iter: inout I) -> I.Element {
   return iter.next()!
 }
 \end{Verbatim}
-The return type of our function is the \emph{identifier type representation} \texttt{I.Element} with two components, ``\texttt{I}'' and ``\texttt{Element}''. Type resolution resolves this type representation to a type by performing a qualified lookup of \texttt{Element} on the base type \texttt{I}. The generic parameter type \texttt{I} is subject to a conformance requirement, and qualified lookup finds the associated type declaration \texttt{Element}.
+The return type of our function is the \emph{declaration reference type representation} \texttt{I.Element} with two components, ``\texttt{I}'' and ``\texttt{Element}''. Type resolution resolves this type representation to a type by performing a qualified lookup of \texttt{Element} on the base type \texttt{I}. The generic parameter type \texttt{I} is subject to a conformance requirement, and qualified lookup finds the associated type declaration \texttt{Element}.
 
 \index{dependent member type}
 The resolved type is a \emph{dependent member type} composed from the generic parameter type \texttt{I} and associated type declaration \texttt{Element}. We will denote this dependent member type as \verb|I.[IteratorProtocol]Element| to make explicit the fact that a name lookup has resolved the identifier \texttt{Element} to an associated type.
@@ -487,7 +487,7 @@ The interface type of \verb|firstElement(_:)| is therefore this generic function
 \end{quote}
 
 \begin{MoreDetails}
-\item Identifier type representations: Section \ref{identtyperepr}
+\item Declaration reference type representations: Section \ref{declreftyperepr}
 \end{MoreDetails}
 
 \index{type parameter}
@@ -1393,7 +1393,7 @@ First, we have the string ``\texttt{Array<Int>}'' written somewhere in a source 
 
 A type representation has a tree structure, so when we talk about the type representation \texttt{Array<Int>}, we really mean this:
 \begin{quote}
-``An identifier type representation with a single component, storing the identifier \texttt{Array} together with a single generic argument. The generic argument is another identifier type representation, again with a single component, storing the identifier \texttt{Int}.''
+``A declaration reference type representation with a single component, storing the identifier \texttt{Array} together with a single generic argument. The generic argument is another declaration reference type representation, again with a single component, storing the identifier \texttt{Int}.''
 \end{quote}
 Types also have a tree structure, so when we talk about the type \texttt{Array<Int>}, what we really mean is:
 \begin{quote}
@@ -1671,7 +1671,7 @@ The dynamic Self type appears when a class method declares a return type of \tex
 This concept comes from Objective-C, where it is called \texttt{instancetype}. The dynamic Self type in many ways behaves like a generic parameter, but it is not represented as one; the type checker and SILGen implement support for it directly.
 \begin{example} Listing~\ref{dynamic self example} demonstrates some of the behaviors of the dynamic Self type. Two invalid cases are shown; \texttt{invalid1()} is rejected because the type checker cannot prove that the return type is always an instance of the dynamic type of \texttt{self}, and \texttt{invalid2()} is rejected because \texttt{Self} appears in contravariant position.
 
-Note that \texttt{Self} has a different interpretation inside a non-class type declaration. In a protocol declaration, \texttt{Self} is the implicit generic parameter (Section~\ref{protocols}). In a struct or enum declaration, \texttt{Self} is the declared interface type (Section~\ref{identtyperepr}).
+Note that \texttt{Self} has a different interpretation inside a non-class type declaration. In a protocol declaration, \texttt{Self} is the implicit generic parameter (Section~\ref{protocols}). In a struct or enum declaration, \texttt{Self} is the declared interface type (Section~\ref{declreftyperepr}).
 \end{example}
 
 \section{Sugared Types}\label{sugared types}
@@ -1682,7 +1682,7 @@ Sugared generic parameter types were already described in the previous section. 
 \index{type alias type}
 \paragraph{Type alias types} A type alias type represents a reference to a type alias declaration. It contains an optional parent type, a substitution map, and the substituted underlying type. The canonical type of a type alias type is the substituted underlying type.
 
-The type alias type's substitution map is formed in type resolution, from any generic arguments applied to the type alias type declaration itself, together with the generic arguments of the base type (Section~\ref{identtyperepr}). Type resolution applies this substitution map to the underlying type of the type alias declaration to compute the substituted underlying type. The type alias type also preserves this substitution map for printing, and for requirement inference (Section~\ref{requirementinference}).
+The type alias type's substitution map is formed in type resolution, from any generic arguments applied to the type alias type declaration itself, together with the generic arguments of the base type (Section~\ref{declreftyperepr}). Type resolution applies this substitution map to the underlying type of the type alias declaration to compute the substituted underlying type. The type alias type also preserves this substitution map for printing, and for requirement inference (Section~\ref{requirementinference}).
 
 \index{optional sugared type}
 \paragraph{Optional types} The optional type is written as \texttt{T?} for some object type \texttt{T}; its canonical type is \texttt{Optional<T>}.
@@ -4073,7 +4073,7 @@ Applying the substitution map to the underlying type of each type alias declarat
 \end{quote}
 The first two original types are generic parameters, and substitution directly projects the corresponding replacement type from the substitution map; the second two original types are substituted by recursively replacing generic parameters they contain.
 
-References to generic type alias declarations are more complex because in addition to the generic parameters of the base type, the generic type alias will have generic parameters of its own. Section~\ref{identtyperepr} describes how the substitution map is computed in this case.
+References to generic type alias declarations are more complex because in addition to the generic parameters of the base type, the generic type alias will have generic parameters of its own. Section~\ref{declreftyperepr} describes how the substitution map is computed in this case.
 \end{example}
 
 \index{substitution failure}
@@ -4257,7 +4257,7 @@ Applying this substitution map to the declared interface type of the type alias 
 }
 \]
 \end{example}
-In fact, the type alias \texttt{A} cannot be referenced as a member of this base type at all, because name lookup checks whether the generic requirements of a type declaration are satisfied. Checking generic requirements will be first introduced as part of type resolution (Section~\ref{identtyperepr}), and will come up elsewhere as well.
+In fact, the type alias \texttt{A} cannot be referenced as a member of this base type at all, because name lookup checks whether the generic requirements of a type declaration are satisfied. Checking generic requirements will be first introduced as part of type resolution (Section~\ref{declreftyperepr}), and will come up elsewhere as well.
 \index{protocol substitution map}
 \index{protocol Self type}
 \paragraph{Protocol substitution map}
@@ -5864,20 +5864,20 @@ TODO:
 \end{itemize}
 \fi
 
-\section{Identifier Type Representations}\label{identtyperepr}
+\section{Declaration Reference Type Representations}\label{declreftyperepr}
 
 \ifWIP
 
-\index{identifier type representation}
-Structural types, such as function types and tuples, have their own type representations parsed from special syntax, and type resolution constructs the corresponding semantic types directly. On the other hand, references to type declarations---nominal types, type aliases, generic parameters and associated types---are resolved via name lookup from a very general kind of type representation called an \emph{identifier type representation}.
+\index{declaration reference type representation}
+Structural types, such as function types and tuples, have their own type representations parsed from special syntax, and type resolution constructs the corresponding semantic types directly. On the other hand, references to type declarations---nominal types, type aliases, generic parameters and associated types---are resolved via name lookup from a very general kind of type representation called an \emph{declaration reference type representation}.
 
-This kind of type representation consists of one or more \emph{components}, separated by dot in written syntax. Each component stores an identifier, together with an optional list of one or more generic arguments, where each generic argument is again recursively a type representation. The following identifier type representation has three components, two of which have generic arguments:
+This kind of type representation consists of one or more \emph{components}, separated by dot in written syntax. The first, base component is an arbitrary type representation. Each subsequent component stores an identifier, together with an optional list of one or more generic arguments, where each generic argument is again recursively a type representation. The following declaration reference type representation has three components, two of which have generic arguments:
 \begin{quote}
 \begin{verbatim}
 Foo.Bar<(Int) -> ()>.Baz<Float, String>
 \end{verbatim}
 \end{quote}
-\paragraph{Unqualified lookup} The first component is special. An unqualified name lookup is performed to find a type declaration with the given name, starting from the innermost lexical scope, finally reaching the top level, after which all imported modules are searched.
+\paragraph{Unqualified lookup} The first component is special. If it stores an identifier, an unqualified name lookup is performed to find a type declaration with the given name, starting from the innermost lexical scope, finally reaching the top level, after which all imported modules are searched.
 
 The first component can be a module name, in which case there must be at least two components; modules can only be used as the base of a lookup, and are not first-class values which stand on their own.
 
@@ -5963,7 +5963,7 @@ struct Outer<T> {
 }
 \end{Verbatim}
 \end{listing}
-\begin{example} The return type of \texttt{f1()} in Listing~\ref{applying generic arguments} is an identifier type representation with two components:
+\begin{example} The return type of \texttt{f1()} in Listing~\ref{applying generic arguments} is a declaration reference type representation with two components:
 \begin{enumerate}
 \item The first component is resolved by applying the substitution map $\texttt{T}:=\texttt{Int}$ to the declared interface type of \texttt{Outer}, which outputs \texttt{Outer<Int>}.
 \item The second component is resolved by first building a substitution map for the generic signature of \texttt{Inner}, which is \texttt{<T,~U>}. The base type \texttt{Outer<Int>} provides the replacement $\texttt{T}:=\texttt{Int}$, and the component's single generic argument \texttt{String} provides the replacement $\texttt{U}:=\texttt{String}$. The declared interface type of the named type declaration \texttt{Inner} is \texttt{Outer<T>.Inner<U>}. Applying the combined substitution map to this type gives \texttt{Outer<Int>.Inner<String>}.
@@ -5971,7 +5971,7 @@ struct Outer<T> {
 
 \end{example}
 
-The type resolution process for an identifier type representation might seem unnecessarily convoluted. When resolving a type representation like \texttt{Outer<Int>.Inner<String>}, we build the type of the first component by applying a substitution map to the declared interface type of the type declaration, \texttt{Outer<T>}. In the next step, we turn this type back into a substitution map, extend the substitution map with a replacement type for \texttt{U}, then apply it to the declared interface type of \texttt{Outer<T>.Inner<U>}. It seems like we might be able to get away with performing a chain of name lookups to find the final type declaration, then collect all of the generic arguments and apply them in one shot. Unfortunately, the next example shows why this appealing simplification does not handle the full generality of type resolution.
+The type resolution process for a declaration reference type representation might seem unnecessarily convoluted. When resolving a type representation like \texttt{Outer<Int>.Inner<String>}, we build the type of the first component by applying a substitution map to the declared interface type of the type declaration, \texttt{Outer<T>}. In the next step, we turn this type back into a substitution map, extend the substitution map with a replacement type for \texttt{U}, then apply it to the declared interface type of \texttt{Outer<T>.Inner<U>}. It seems like we might be able to get away with performing a chain of name lookups to find the final type declaration, then collect all of the generic arguments and apply them in one shot. Unfortunately, the next example shows why this appealing simplification does not handle the full generality of type resolution.
 
 \begin{listing}\captionabove{The named type declaration of a component can depend on generic arguments previously applied}\label{type resolution with dependent base}
 \begin{Verbatim}
@@ -6013,7 +6013,7 @@ Clearly, \texttt{Paul.Pony} and \texttt{Maureen.Pony} are two unrelated nominal 
 
 \end{example}
 
-\paragraph{Bound components} A minor optimization worth understanding, because it slightly complicates the implementation. After type resolution of a component succeeds, the bound (or found, perhaps) type declaration is stored inside the component. If the identifier type representation is resolved again, any bound components will skip the name lookup and proceed to compute the final type from the bound declaration. The optimization was more profitable in the past, when type resolution actually had \emph{three} stages, with a third stage resolving interface types to archetypes. The third stage was subsumed by the \texttt{mapTypeIntoContext()} operation on generic environments. Parsing textual SIL also ``manually'' binds components to type declarations which name lookup would otherwise not find, in order to parse some of the more esoteric SIL syntax that we're not going to discuss here.
+\paragraph{Bound components} A minor optimization worth understanding, because it slightly complicates the implementation. After type resolution of a component succeeds, the bound (or found, perhaps) type declaration is stored inside the component. If the declaration reference type representation is resolved again, any bound components will skip the name lookup and proceed to compute the final type from the bound declaration. The optimization was more profitable in the past, when type resolution actually had \emph{three} stages, with a third stage resolving interface types to archetypes. The third stage was subsumed by the \texttt{mapTypeIntoContext()} operation on generic environments. Parsing textual SIL also ``manually'' binds components to type declarations which name lookup would otherwise not find, in order to parse some of the more esoteric SIL syntax that we're not going to discuss here.
 \fi
 
 \section{Checking Generic Arguments}\label{checking generic arguments}

--- a/docs/proposals/DeclarationTypeChecker.rst
+++ b/docs/proposals/DeclarationTypeChecker.rst
@@ -148,7 +148,7 @@ How do we get there?
 
 The proposed architecture is significantly different from the current type checker architecture, so how do we get there from here? There are a few concrete steps we can take:
 
-**Make all AST nodes phase-aware**: Introduce a trait that can ask an arbitrary AST node (``Decl``, ``TypeRepr``, ``Pattern``, etc.) its current phase. AST nodes may compute this information on-the-fly or store it, as appropriate. For example, a ``TypeRepr`` can generally determine its phase based on the existing state of the ``IdentTypeRepr`` nodes it includes.
+**Make all AST nodes phase-aware**: Introduce a trait that can ask an arbitrary AST node (``Decl``, ``TypeRepr``, ``Pattern``, etc.) its current phase. AST nodes may compute this information on-the-fly or store it, as appropriate. For example, a ``TypeRepr`` can generally determine its phase based on the existing state of the ``DeclRefTypeRepr`` nodes it includes.
 
 **Make name lookup phase-aware**: Name lookup is currently one of the worst offenders when violating phase ordering. Parameterize name lookup based on the phase at which it's operating. For example, asking for name lookup at the "extension binding" phase might not resolve type aliases, look into superclasses, or look into protocols.
 

--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -242,7 +242,7 @@ void *ProtocolTypeRepr_create(void *ctx, void *baseType, void *protoLoc);
 void *PackExpansionTypeRepr_create(void *ctx, void *base, void *ellipsisLoc);
 void *TupleTypeRepr_create(void *ctx, BridgedArrayRef elements, void *lParenLoc,
                            void *rParenLoc);
-void *IdentTypeRepr_create(void *ctx, BridgedArrayRef components);
+void *DeclRefTypeRepr_create(void *ctx, BridgedArrayRef bridgedComponents);
 void *GenericIdentTypeRepr_create(void *ctx, BridgedIdentifier name,
                                   void *nameLoc, BridgedArrayRef genericArgs,
                                   void *lAngle, void *rAngle);

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -196,11 +196,12 @@ ERROR(lex_conflict_marker_in_file,none,
 // MARK: Declaration parsing diagnostics
 //------------------------------------------------------------------------------
 
-NOTE(note_in_decl_extension,none,
-     "in %select{declaration|extension}0 of %1", (bool, DeclNameRef))
+NOTE(note_in_decl_of,none,
+     "in declaration of %0", (DeclNameRef))
+NOTE(note_in_extension_of,none,
+     "in extension of %0", (TypeRepr *))
 ERROR(line_directive_style_deprecated,none,
-        "#line directive was renamed to #sourceLocation",
-        ())
+      "#line directive was renamed to #sourceLocation", ())
 
 ERROR(declaration_same_line_without_semi,none,
       "consecutive declarations on a line must be separated by ';'", ())

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -42,7 +42,7 @@ namespace swift {
   class ArchetypeType;
   class ASTContext;
   class AvailabilitySpec;
-  class IdentTypeRepr;
+  class DeclRefTypeRepr;
   class Type;
   class TypeRepr;
   class ValueDecl;
@@ -1338,18 +1338,19 @@ public:
                                        DeclNameLoc NameLoc,
                                        TypeDecl *Decl);
 
-  /// Create a TypeExpr for a member TypeDecl of the given parent IdentTypeRepr.
-  static TypeExpr *createForMemberDecl(IdentTypeRepr *ParentTR,
+  /// Create a \c TypeExpr for a member \c TypeDecl of the given parent
+  /// \c DeclRefTypeRepr.
+  static TypeExpr *createForMemberDecl(DeclRefTypeRepr *ParentTR,
                                        DeclNameLoc NameLoc,
                                        TypeDecl *Decl);
 
-  /// Create a TypeExpr from an IdentTypeRepr with the given arguments applied
-  /// at the specified location.
+  /// Create a \c TypeExpr from an \c DeclRefTypeRepr with the given arguments
+  /// applied at the specified location.
   ///
   /// Returns nullptr if the reference cannot be formed, which is a hack due
   /// to limitations in how we model generic typealiases.
-  static TypeExpr *createForSpecializedDecl(IdentTypeRepr *ParentTR,
-                                            ArrayRef<TypeRepr*> Args,
+  static TypeExpr *createForSpecializedDecl(DeclRefTypeRepr *ParentTR,
+                                            ArrayRef<TypeRepr *> Args,
                                             SourceRange AngleLocs,
                                             ASTContext &C);
 

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1341,8 +1341,7 @@ public:
   /// Create a \c TypeExpr for a member \c TypeDecl of the given parent
   /// \c DeclRefTypeRepr.
   static TypeExpr *createForMemberDecl(DeclRefTypeRepr *ParentTR,
-                                       DeclNameLoc NameLoc,
-                                       TypeDecl *Decl);
+                                       DeclNameLoc NameLoc, TypeDecl *Decl);
 
   /// Create a \c TypeExpr from an \c DeclRefTypeRepr with the given arguments
   /// applied at the specified location.

--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -43,7 +43,8 @@ class ASTScopeImpl;
 } // namespace ast_scope
 
 /// Walk the type representation recursively, collecting any
-/// `OpaqueReturnTypeRepr`s, `CompositionTypeRepr`s  or `IdentTypeRepr`s.
+/// \c OpaqueReturnTypeRepr, \c CompositionTypeRepr  or \c DeclRefTypeRepr
+/// nodes.
 CollectedOpaqueReprs collectOpaqueReturnTypeReprs(TypeRepr *, ASTContext &ctx, DeclContext *dc);
 
 /// LookupResultEntry - One result of unqualified lookup.

--- a/include/swift/AST/TypeDeclFinder.h
+++ b/include/swift/AST/TypeDeclFinder.h
@@ -19,7 +19,7 @@
 namespace swift {
 
 class BoundGenericType;
-class ComponentIdentTypeRepr;
+class IdentTypeRepr;
 class NominalType;
 class TypeAliasType;
 
@@ -44,7 +44,7 @@ public:
 /// equivalently and where generic arguments can be walked to separately from
 /// the generic type.
 class SimpleTypeDeclFinder : public TypeDeclFinder {
-  /// The function to call when a ComponentIdentTypeRepr is seen.
+  /// The function to call when a \c IdentTypeRepr is seen.
   llvm::function_ref<Action(const TypeDecl *)> Callback;
 
   Action visitNominalType(NominalType *ty) override;
@@ -57,20 +57,21 @@ public:
     : Callback(callback) {}
 };
 
-/// Walks a TypeRepr to find all ComponentIdentTypeReprs with bound TypeDecls.
+/// Walks a \c TypeRepr to find all \c IdentTypeRepr nodes with bound
+/// type declarations.
 ///
 /// Subclasses can either override #visitTypeDecl if they only care about
-/// types on their own, or #visitComponentIdentTypeRepr if they want to keep
+/// types on their own, or #visitIdentTypeRepr if they want to keep
 /// the TypeRepr around.
 class TypeReprIdentFinder : public ASTWalker {
-  /// The function to call when a ComponentIdentTypeRepr is seen.
-  llvm::function_ref<bool(const ComponentIdentTypeRepr *)> Callback;
+  /// The function to call when a \c IdentTypeRepr is seen.
+  llvm::function_ref<bool(const IdentTypeRepr *)> Callback;
 
   PostWalkAction walkToTypeReprPost(TypeRepr *TR) override;
 
 public:
   explicit TypeReprIdentFinder(
-      llvm::function_ref<bool(const ComponentIdentTypeRepr *)> callback)
+      llvm::function_ref<bool(const IdentTypeRepr *)> callback)
     : Callback(callback) {}
 };
 

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -256,11 +256,6 @@ protected:
   explicit IdentTypeRepr(TypeReprKind K) : TypeRepr(K) {}
 
 public:
-  /// Copies the provided array and creates a CompoundIdentTypeRepr or just
-  /// returns the single entry in the array if it contains only one.
-  static IdentTypeRepr *create(ASTContext &C,
-                               ArrayRef<ComponentIdentTypeRepr *> Components);
-  
   class ComponentRange;
   inline ComponentRange getComponentRange();
 

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -256,8 +256,14 @@ protected:
   explicit IdentTypeRepr(TypeReprKind K) : TypeRepr(K) {}
 
 public:
-  class ComponentRange;
-  inline ComponentRange getComponentRange();
+  TypeRepr *getBaseComponent();
+  ComponentIdentTypeRepr *getLastComponent();
+
+  /// The type declaration the last component is bound to.
+  TypeDecl *getBoundDecl() const;
+
+  /// The identifier that describes the last component.
+  DeclNameRef getNameRef() const;
 
   static bool classof(const TypeRepr *T) {
     return T->getKind() == TypeReprKind::SimpleIdent  ||
@@ -443,38 +449,6 @@ private:
   void printImpl(ASTPrinter &Printer, const PrintOptions &Opts) const;
   friend class TypeRepr;
 };
-
-/// This wraps an IdentTypeRepr and provides an iterator interface for the
-/// components (or the single component) it represents.
-class IdentTypeRepr::ComponentRange {
-  IdentTypeRepr *IdT;
-
-public:
-  explicit ComponentRange(IdentTypeRepr *T) : IdT(T) {}
-
-  typedef ComponentIdentTypeRepr * const* iterator;
-
-  iterator begin() const {
-    if (isa<ComponentIdentTypeRepr>(IdT))
-      return reinterpret_cast<iterator>(&IdT);
-    return cast<CompoundIdentTypeRepr>(IdT)->getComponents().begin();
-  }
-
-  iterator end() const {
-    if (isa<ComponentIdentTypeRepr>(IdT))
-      return reinterpret_cast<iterator>(&IdT) + 1;
-    return cast<CompoundIdentTypeRepr>(IdT)->getComponents().end();
-  }
-
-  bool empty() const { return begin() == end(); }
-
-  ComponentIdentTypeRepr *front() const { return *begin(); }
-  ComponentIdentTypeRepr *back() const { return *(end()-1); }
-};
-
-inline IdentTypeRepr::ComponentRange IdentTypeRepr::getComponentRange() {
-  return ComponentRange(this);
-}
 
 /// A function type.
 /// \code

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -425,9 +425,19 @@ public:
   static CompoundIdentTypeRepr *create(const ASTContext &Ctx,
                                   ArrayRef<ComponentIdentTypeRepr*> Components);
 
+  TypeRepr *getBaseComponent() const { return getComponents().front(); }
+
   ArrayRef<ComponentIdentTypeRepr*> getComponents() const {
     return {getTrailingObjects<ComponentIdentTypeRepr*>(),
             Bits.CompoundIdentTypeRepr.NumComponents};
+  }
+
+  ArrayRef<ComponentIdentTypeRepr *> getMemberComponents() const {
+    return getComponents().slice(1);
+  }
+
+  ComponentIdentTypeRepr *getLastComponent() const {
+    return getMemberComponents().back();
   }
 
   static bool classof(const TypeRepr *T) {
@@ -437,14 +447,10 @@ public:
 
 private:
   SourceLoc getStartLocImpl() const {
-    return getComponents().front()->getStartLoc();
+    return getBaseComponent()->getStartLoc();
   }
-  SourceLoc getEndLocImpl() const {
-    return getComponents().back()->getEndLoc();
-  }
-  SourceLoc getLocImpl() const {
-    return getComponents().back()->getLoc();
-  }
+  SourceLoc getEndLocImpl() const { return getLastComponent()->getEndLoc(); }
+  SourceLoc getLocImpl() const { return getLastComponent()->getLoc(); }
 
   void printImpl(ASTPrinter &Printer, const PrintOptions &Opts) const;
   friend class TypeRepr;

--- a/include/swift/AST/TypeReprNodes.def
+++ b/include/swift/AST/TypeReprNodes.def
@@ -45,11 +45,11 @@
 TYPEREPR(Error, TypeRepr)
 TYPEREPR(Attributed, TypeRepr)
 
-ABSTRACT_TYPEREPR(Ident, TypeRepr)
-  ABSTRACT_TYPEREPR(ComponentIdent, IdentTypeRepr)
+ABSTRACT_TYPEREPR(DeclRef, TypeRepr)
+  ABSTRACT_TYPEREPR(ComponentIdent, DeclRefTypeRepr)
     TYPEREPR(SimpleIdent, ComponentIdentTypeRepr)
     TYPEREPR(GenericIdent, ComponentIdentTypeRepr)
-  TYPEREPR(Member, IdentTypeRepr)
+  TYPEREPR(Member, DeclRefTypeRepr)
 
 TYPEREPR(Function, TypeRepr)
 TYPEREPR(Array, TypeRepr)

--- a/include/swift/AST/TypeReprNodes.def
+++ b/include/swift/AST/TypeReprNodes.def
@@ -49,7 +49,7 @@ ABSTRACT_TYPEREPR(Ident, TypeRepr)
   ABSTRACT_TYPEREPR(ComponentIdent, IdentTypeRepr)
     TYPEREPR(SimpleIdent, ComponentIdentTypeRepr)
     TYPEREPR(GenericIdent, ComponentIdentTypeRepr)
-  TYPEREPR(CompoundIdent, IdentTypeRepr)
+  TYPEREPR(Member, IdentTypeRepr)
 
 TYPEREPR(Function, TypeRepr)
 TYPEREPR(Array, TypeRepr)

--- a/include/swift/AST/TypeReprNodes.def
+++ b/include/swift/AST/TypeReprNodes.def
@@ -46,9 +46,9 @@ TYPEREPR(Error, TypeRepr)
 TYPEREPR(Attributed, TypeRepr)
 
 ABSTRACT_TYPEREPR(DeclRef, TypeRepr)
-  ABSTRACT_TYPEREPR(ComponentIdent, DeclRefTypeRepr)
-    TYPEREPR(SimpleIdent, ComponentIdentTypeRepr)
-    TYPEREPR(GenericIdent, ComponentIdentTypeRepr)
+  ABSTRACT_TYPEREPR(Ident, DeclRefTypeRepr)
+    TYPEREPR(SimpleIdent, IdentTypeRepr)
+    TYPEREPR(GenericIdent, IdentTypeRepr)
   TYPEREPR(Member, DeclRefTypeRepr)
 
 TYPEREPR(Function, TypeRepr)

--- a/include/swift/Parse/IDEInspectionCallbacks.h
+++ b/include/swift/Parse/IDEInspectionCallbacks.h
@@ -163,10 +163,10 @@ public:
   virtual void completeTypeSimpleBeginning() {};
 
   /// Complete a given type identifier after we have consumed the dot.
-  virtual void completeTypeIdentifierWithDot(DeclRefTypeRepr *TR) {};
+  virtual void completeTypeIdentifierWithDot(DeclRefTypeRepr *TR){};
 
   /// Complete a given type identifier when there is no trailing dot.
-  virtual void completeTypeIdentifierWithoutDot(DeclRefTypeRepr *TR) {};
+  virtual void completeTypeIdentifierWithoutDot(DeclRefTypeRepr *TR){};
 
   /// Complete the beginning of a case statement at the top of switch stmt.
   virtual void completeCaseStmtKeyword() {};

--- a/include/swift/Parse/IDEInspectionCallbacks.h
+++ b/include/swift/Parse/IDEInspectionCallbacks.h
@@ -162,11 +162,11 @@ public:
   /// by user.
   virtual void completeTypeSimpleBeginning() {};
 
-  /// Complete a given type-identifier after we have consumed the dot.
-  virtual void completeTypeIdentifierWithDot(IdentTypeRepr *ITR) {};
+  /// Complete a given type identifier after we have consumed the dot.
+  virtual void completeTypeIdentifierWithDot(DeclRefTypeRepr *TR) {};
 
-  /// Complete a given type-identifier when there is no trailing dot.
-  virtual void completeTypeIdentifierWithoutDot(IdentTypeRepr *ITR) {};
+  /// Complete a given type identifier when there is no trailing dot.
+  virtual void completeTypeIdentifierWithoutDot(DeclRefTypeRepr *TR) {};
 
   /// Complete the beginning of a case statement at the top of switch stmt.
   virtual void completeCaseStmtKeyword() {};

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3112,7 +3112,7 @@ public:
     printRec(T->getTypeRepr());
   }
 
-  void visitComponentIdentTypeRepr(ComponentIdentTypeRepr *T) {
+  void visitIdentTypeRepr(IdentTypeRepr *T) {
     printCommon("type_ident");
 
     PrintWithColorRAII(OS, IdentifierColor)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3112,39 +3112,35 @@ public:
     printRec(T->getTypeRepr());
   }
 
-  void visitIdentTypeRepr(IdentTypeRepr *T) {
+  void visitComponentIdentTypeRepr(ComponentIdentTypeRepr *T) {
     printCommon("type_ident");
-    Indent += 2;
 
-    SmallVector<ComponentIdentTypeRepr *, 2> components;
-    if (auto *comp = dyn_cast<ComponentIdentTypeRepr>(T)) {
-      components.push_back(comp);
-    } else {
-      auto memberComps = cast<CompoundIdentTypeRepr>(T)->getMemberComponents();
-
-      components.push_back(cast<ComponentIdentTypeRepr>(T->getBaseComponent()));
-      components.append(memberComps.begin(), memberComps.end());
-    }
-
-    for (auto comp : components) {
-      OS << '\n';
-      printCommon("component");
-      PrintWithColorRAII(OS, IdentifierColor)
-        << " id='" << comp->getNameRef() << '\'';
-      OS << " bind=";
-      if (comp->isBound())
-        comp->getBoundDecl()->dumpRef(OS);
-      else OS << "none";
-      PrintWithColorRAII(OS, ParenthesisColor) << ')';
-      if (auto GenIdT = dyn_cast<GenericIdentTypeRepr>(comp)) {
-        for (auto genArg : GenIdT->getGenericArgs()) {
-          OS << '\n';
-          printRec(genArg);
-        }
+    PrintWithColorRAII(OS, IdentifierColor)
+        << " id='" << T->getNameRef() << '\'';
+    OS << " bind=";
+    if (T->isBound())
+      T->getBoundDecl()->dumpRef(OS);
+    else
+      OS << "none";
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
+    if (auto *GenIdT = dyn_cast<GenericIdentTypeRepr>(T)) {
+      for (auto genArg : GenIdT->getGenericArgs()) {
+        OS << '\n';
+        printRec(genArg);
       }
     }
+  }
+
+  void visitMemberTypeRepr(MemberTypeRepr *T) {
+    printCommon("type_member");
+
+    OS << '\n';
+    printRec(T->getBaseComponent());
+    for (auto *comp : T->getMemberComponents()) {
+      OS << '\n';
+      printRec(comp);
+    }
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
-    Indent -= 2;
   }
 
   void visitFunctionTypeRepr(FunctionTypeRepr *T) {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3115,7 +3115,15 @@ public:
   void visitIdentTypeRepr(IdentTypeRepr *T) {
     printCommon("type_ident");
     Indent += 2;
-    for (auto comp : T->getComponentRange()) {
+
+    ArrayRef<ComponentIdentTypeRepr *> components;
+    if (auto *comp = dyn_cast<ComponentIdentTypeRepr>(T)) {
+      components = comp;
+    } else {
+      components = cast<CompoundIdentTypeRepr>(T)->getComponents();
+    }
+
+    for (auto comp : components) {
       OS << '\n';
       printCommon("component");
       PrintWithColorRAII(OS, IdentifierColor)

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -3116,11 +3116,14 @@ public:
     printCommon("type_ident");
     Indent += 2;
 
-    ArrayRef<ComponentIdentTypeRepr *> components;
+    SmallVector<ComponentIdentTypeRepr *, 2> components;
     if (auto *comp = dyn_cast<ComponentIdentTypeRepr>(T)) {
-      components = comp;
+      components.push_back(comp);
     } else {
-      components = cast<CompoundIdentTypeRepr>(T)->getComponents();
+      auto memberComps = cast<CompoundIdentTypeRepr>(T)->getMemberComponents();
+
+      components.push_back(cast<ComponentIdentTypeRepr>(T->getBaseComponent()));
+      components.append(memberComps.begin(), memberComps.end());
     }
 
     for (auto comp : components) {

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1972,7 +1972,7 @@ bool Traversal::visitGenericIdentTypeRepr(GenericIdentTypeRepr *T) {
   return false;
 }
 
-bool Traversal::visitCompoundIdentTypeRepr(CompoundIdentTypeRepr *T) {
+bool Traversal::visitMemberTypeRepr(MemberTypeRepr *T) {
   if (doIt(T->getBaseComponent()))
     return true;
 

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1973,7 +1973,10 @@ bool Traversal::visitGenericIdentTypeRepr(GenericIdentTypeRepr *T) {
 }
 
 bool Traversal::visitCompoundIdentTypeRepr(CompoundIdentTypeRepr *T) {
-  for (auto comp : T->getComponents()) {
+  if (doIt(T->getBaseComponent()))
+    return true;
+
+  for (auto comp : T->getMemberComponents()) {
     if (doIt(comp))
       return true;
   }

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -499,7 +499,7 @@ void *TupleTypeRepr_create(void *ctx, BridgedArrayRef elements, void *lParenLoc,
 
 void *DeclRefTypeRepr_create(void *ctx, BridgedArrayRef bridgedComponents) {
   ASTContext &Context = *static_cast<ASTContext *>(ctx);
-  auto components = getArrayRef<ComponentIdentTypeRepr *>(bridgedComponents);
+  auto components = getArrayRef<IdentTypeRepr *>(bridgedComponents);
   if (components.size() == 1) {
     return components.front();
   }

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -497,10 +497,14 @@ void *TupleTypeRepr_create(void *ctx, BridgedArrayRef elements, void *lParenLoc,
                                SourceRange{lParen, rParen});
 }
 
-void *IdentTypeRepr_create(void *ctx, BridgedArrayRef components) {
+void *IdentTypeRepr_create(void *ctx, BridgedArrayRef bridgedComponents) {
   ASTContext &Context = *static_cast<ASTContext *>(ctx);
-  return IdentTypeRepr::create(
-      Context, getArrayRef<ComponentIdentTypeRepr *>(components));
+  auto components = getArrayRef<ComponentIdentTypeRepr *>(bridgedComponents);
+  if (components.size() == 1) {
+    return components.front();
+  }
+
+  return CompoundIdentTypeRepr::create(Context, components);
 }
 
 void *CompositionTypeRepr_create(void *ctx, BridgedArrayRef types,

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -497,7 +497,7 @@ void *TupleTypeRepr_create(void *ctx, BridgedArrayRef elements, void *lParenLoc,
                                SourceRange{lParen, rParen});
 }
 
-void *IdentTypeRepr_create(void *ctx, BridgedArrayRef bridgedComponents) {
+void *DeclRefTypeRepr_create(void *ctx, BridgedArrayRef bridgedComponents) {
   ASTContext &Context = *static_cast<ASTContext *>(ctx);
   auto components = getArrayRef<ComponentIdentTypeRepr *>(bridgedComponents);
   if (components.size() == 1) {

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -504,7 +504,7 @@ void *IdentTypeRepr_create(void *ctx, BridgedArrayRef bridgedComponents) {
     return components.front();
   }
 
-  return CompoundIdentTypeRepr::create(Context, components);
+  return MemberTypeRepr::create(Context, components);
 }
 
 void *CompositionTypeRepr_create(void *ctx, BridgedArrayRef types,

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2224,7 +2224,7 @@ TypeExpr *TypeExpr::createForMemberDecl(DeclNameLoc ParentNameLoc,
   return new (C) TypeExpr(TR);
 }
 
-TypeExpr *TypeExpr::createForMemberDecl(IdentTypeRepr *ParentTR,
+TypeExpr *TypeExpr::createForMemberDecl(DeclRefTypeRepr *ParentTR,
                                         DeclNameLoc NameLoc,
                                         TypeDecl *Decl) {
   ASTContext &C = Decl->getASTContext();
@@ -2246,8 +2246,8 @@ TypeExpr *TypeExpr::createForMemberDecl(IdentTypeRepr *ParentTR,
   return new (C) TypeExpr(TR);
 }
 
-TypeExpr *TypeExpr::createForSpecializedDecl(IdentTypeRepr *ParentTR,
-                                             ArrayRef<TypeRepr*> Args,
+TypeExpr *TypeExpr::createForSpecializedDecl(DeclRefTypeRepr *ParentTR,
+                                             ArrayRef<TypeRepr *> Args,
                                              SourceRange AngleLocs,
                                              ASTContext &C) {
   auto *lastComp = ParentTR->getLastComponent();

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2225,7 +2225,7 @@ TypeExpr *TypeExpr::createForMemberDecl(DeclNameLoc ParentNameLoc,
   NewComp->setValue(Decl, nullptr);
   Components.push_back(NewComp);
 
-  auto *NewTypeRepr = IdentTypeRepr::create(C, Components);
+  auto *NewTypeRepr = CompoundIdentTypeRepr::create(C, Components);
   return new (C) TypeExpr(NewTypeRepr);
 }
 
@@ -2246,7 +2246,7 @@ TypeExpr *TypeExpr::createForMemberDecl(IdentTypeRepr *ParentTR,
   NewComp->setValue(Decl, nullptr);
   Components.push_back(NewComp);
 
-  auto *NewTypeRepr = IdentTypeRepr::create(C, Components);
+  auto *NewTypeRepr = CompoundIdentTypeRepr::create(C, Components);
   return new (C) TypeExpr(NewTypeRepr);
 }
 
@@ -2295,7 +2295,12 @@ TypeExpr *TypeExpr::createForSpecializedDecl(IdentTypeRepr *ParentTR,
     genericComp->setValue(last->getBoundDecl(), last->getDeclContext());
     components.push_back(genericComp);
 
-    auto *genericRepr = IdentTypeRepr::create(C, components);
+    TypeRepr *genericRepr = nullptr;
+    if (components.size() == 1) {
+      genericRepr = components.front();
+    } else {
+      genericRepr = CompoundIdentTypeRepr::create(C, components);
+    }
     return new (C) TypeExpr(genericRepr);
   }
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2225,12 +2225,11 @@ TypeExpr *TypeExpr::createForMemberDecl(DeclNameLoc ParentNameLoc,
 }
 
 TypeExpr *TypeExpr::createForMemberDecl(DeclRefTypeRepr *ParentTR,
-                                        DeclNameLoc NameLoc,
-                                        TypeDecl *Decl) {
+                                        DeclNameLoc NameLoc, TypeDecl *Decl) {
   ASTContext &C = Decl->getASTContext();
 
   // Create a new list of components.
-  SmallVector<ComponentIdentTypeRepr *, 2> Components;
+  SmallVector<IdentTypeRepr *, 2> Components;
   if (auto *MemberTR = dyn_cast<MemberTypeRepr>(ParentTR)) {
     auto MemberComps = MemberTR->getMemberComponents();
     Components.append(MemberComps.begin(), MemberComps.end());
@@ -2269,9 +2268,9 @@ TypeExpr *TypeExpr::createForSpecializedDecl(DeclRefTypeRepr *ParentTR,
       //
       // FIXME: Once we can model generic typealiases properly, rip
       // this out.
-      auto isUnboundGenericComponent = [](ComponentIdentTypeRepr *TR) -> bool {
-        if (isa<SimpleIdentTypeRepr>(TR)) {
-          auto *decl = dyn_cast_or_null<GenericTypeDecl>(TR->getBoundDecl());
+      auto isUnboundGenericComponent = [](IdentTypeRepr *ITR) -> bool {
+        if (isa<SimpleIdentTypeRepr>(ITR)) {
+          auto *decl = dyn_cast_or_null<GenericTypeDecl>(ITR->getBoundDecl());
           if (decl && decl->isGeneric())
             return true;
         }
@@ -2285,7 +2284,7 @@ TypeExpr *TypeExpr::createForSpecializedDecl(DeclRefTypeRepr *ParentTR,
       }
 
       if (auto *identBase =
-              dyn_cast<ComponentIdentTypeRepr>(memberTR->getBaseComponent())) {
+              dyn_cast<IdentTypeRepr>(memberTR->getBaseComponent())) {
         if (isUnboundGenericComponent(identBase))
           return nullptr;
       }
@@ -2302,7 +2301,7 @@ TypeExpr *TypeExpr::createForSpecializedDecl(DeclRefTypeRepr *ParentTR,
 
     // Create a new list of member components, replacing the last one with the
     // new specialized one.
-    SmallVector<ComponentIdentTypeRepr *, 2> newMemberComps;
+    SmallVector<IdentTypeRepr *, 2> newMemberComps;
     newMemberComps.append(oldMemberComps.begin(), oldMemberComps.end());
     newMemberComps.push_back(genericComp);
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2236,8 +2236,12 @@ TypeExpr *TypeExpr::createForMemberDecl(IdentTypeRepr *ParentTR,
 
   // Create a new list of components.
   SmallVector<ComponentIdentTypeRepr *, 2> Components;
-  for (auto *Component : ParentTR->getComponentRange())
-    Components.push_back(Component);
+  if (auto *Comp = dyn_cast<ComponentIdentTypeRepr>(ParentTR)) {
+    Components.push_back(Comp);
+  } else {
+    auto OldComps = cast<CompoundIdentTypeRepr>(ParentTR)->getComponents();
+    Components.append(OldComps.begin(), OldComps.end());
+  }
 
   assert(!Components.empty());
 
@@ -2256,8 +2260,11 @@ TypeExpr *TypeExpr::createForSpecializedDecl(IdentTypeRepr *ParentTR,
                                              ASTContext &C) {
   // Create a new list of components.
   SmallVector<ComponentIdentTypeRepr *, 2> components;
-  for (auto *component : ParentTR->getComponentRange()) {
-    components.push_back(component);
+  if (auto *comp = dyn_cast<ComponentIdentTypeRepr>(ParentTR)) {
+    components.push_back(comp);
+  } else {
+    auto oldComps = cast<CompoundIdentTypeRepr>(ParentTR)->getComponents();
+    components.append(oldComps.begin(), oldComps.end());
   }
 
   auto *last = components.back();

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3081,14 +3081,11 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
                                assocType->getDescriptiveKind(),
                                assocType->getName());
 
-            ComponentIdentTypeRepr *components[2] = {
-              new (ctx) SimpleIdentTypeRepr(identTypeRepr->getNameLoc(),
-                                            DeclNameRef(moduleName)),
-              identTypeRepr
-            };
+            auto *baseComp = new (ctx) SimpleIdentTypeRepr(
+                identTypeRepr->getNameLoc(), DeclNameRef(moduleName));
 
-            auto *newTE = new (ctx)
-                TypeExpr(CompoundIdentTypeRepr::create(ctx, components));
+            auto *newTE = new (ctx) TypeExpr(
+                CompoundIdentTypeRepr::create(ctx, baseComp, {identTypeRepr}));
             attr->resetTypeInformation(newTE);
             return nominal;
           }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2425,7 +2425,14 @@ directReferencesForIdentTypeRepr(Evaluator &evaluator,
                                  DeclContext *dc, bool allowUsableFromInline) {
   DirectlyReferencedTypeDecls current;
 
-  for (const auto &component : ident->getComponentRange()) {
+  ArrayRef<ComponentIdentTypeRepr *> components;
+  if (auto *comp = dyn_cast<ComponentIdentTypeRepr>(ident)) {
+    components = comp;
+  } else {
+    components = cast<CompoundIdentTypeRepr>(ident)->getComponents();
+  }
+
+  for (const auto &component : components) {
     // If we already set a declaration, use it.
     if (auto typeDecl = component->getBoundDecl()) {
       current = {1, typeDecl};

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3076,7 +3076,8 @@ CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
               identTypeRepr
             };
 
-            auto *newTE = new (ctx) TypeExpr(IdentTypeRepr::create(ctx, components));
+            auto *newTE = new (ctx)
+                TypeExpr(CompoundIdentTypeRepr::create(ctx, components));
             attr->resetTypeInformation(newTE);
             return nominal;
           }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2423,12 +2423,12 @@ directReferencesForQualifiedTypeLookup(Evaluator &evaluator,
 
 /// Determine the types directly referenced by the given identifier type.
 static DirectlyReferencedTypeDecls
-directReferencesForIdentTypeRepr(Evaluator &evaluator,
-                                 ASTContext &ctx, IdentTypeRepr *ident,
-                                 DeclContext *dc, bool allowUsableFromInline) {
+directReferencesForDeclRefTypeRepr(Evaluator &evaluator, ASTContext &ctx,
+                                   DeclRefTypeRepr *repr, DeclContext *dc,
+                                   bool allowUsableFromInline) {
   DirectlyReferencedTypeDecls current;
 
-  auto *baseComp = ident->getBaseComponent();
+  auto *baseComp = repr->getBaseComponent();
   if (auto *identBase = dyn_cast<ComponentIdentTypeRepr>(baseComp)) {
     // If we already set a declaration, use it.
     if (auto *typeDecl = identBase->getBoundDecl()) {
@@ -2444,7 +2444,7 @@ directReferencesForIdentTypeRepr(Evaluator &evaluator,
                                           allowUsableFromInline);
   }
 
-  auto *memberTR = dyn_cast<MemberTypeRepr>(ident);
+  auto *memberTR = dyn_cast<MemberTypeRepr>(repr);
   if (!memberTR)
     return current;
 
@@ -2503,9 +2503,9 @@ directReferencesForTypeRepr(Evaluator &evaluator,
   case TypeReprKind::Member:
   case TypeReprKind::GenericIdent:
   case TypeReprKind::SimpleIdent:
-    return directReferencesForIdentTypeRepr(evaluator, ctx,
-                                            cast<IdentTypeRepr>(typeRepr), dc,
-                                            allowUsableFromInline);
+    return directReferencesForDeclRefTypeRepr(evaluator, ctx,
+                                              cast<DeclRefTypeRepr>(typeRepr),
+                                              dc, allowUsableFromInline);
 
   case TypeReprKind::Dictionary:
     return { 1, ctx.getDictionaryDecl()};
@@ -2851,9 +2851,9 @@ CollectedOpaqueReprs swift::collectOpaqueReturnTypeReprs(TypeRepr *r, ASTContext
         if (!Reprs.empty() && isa<ExistentialTypeRepr>(Reprs.front())){
           Reprs.clear();
         }
-      } else if (auto identRepr = dyn_cast<IdentTypeRepr>(repr)) {
-        if (identRepr->isProtocol(dc))
-          Reprs.push_back(identRepr);
+      } else if (auto declRefTR = dyn_cast<DeclRefTypeRepr>(repr)) {
+        if (declRefTR->isProtocol(dc))
+          Reprs.push_back(declRefTR);
       }
       return Action::Continue();
     }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2257,8 +2257,8 @@ resolveTypeDeclsToNominal(Evaluator &evaluator,
         // TypeRepr version: Builtin.AnyObject
         if (auto typeRepr = typealias->getUnderlyingTypeRepr()) {
           if (auto memberTR = dyn_cast<MemberTypeRepr>(typeRepr)) {
-            if (auto identBase = dyn_cast<ComponentIdentTypeRepr>(
-                    memberTR->getBaseComponent())) {
+            if (auto identBase =
+                    dyn_cast<IdentTypeRepr>(memberTR->getBaseComponent())) {
               auto memberComps = memberTR->getMemberComponents();
               if (memberComps.size() == 1 &&
                   identBase->getNameRef().isSimpleName("Builtin") &&
@@ -2429,7 +2429,7 @@ directReferencesForDeclRefTypeRepr(Evaluator &evaluator, ASTContext &ctx,
   DirectlyReferencedTypeDecls current;
 
   auto *baseComp = repr->getBaseComponent();
-  if (auto *identBase = dyn_cast<ComponentIdentTypeRepr>(baseComp)) {
+  if (auto *identBase = dyn_cast<IdentTypeRepr>(baseComp)) {
     // If we already set a declaration, use it.
     if (auto *typeDecl = identBase->getBoundDecl()) {
       current = {1, typeDecl};

--- a/lib/AST/TypeDeclFinder.cpp
+++ b/lib/AST/TypeDeclFinder.cpp
@@ -51,8 +51,8 @@ SimpleTypeDeclFinder::visitTypeAliasType(TypeAliasType *ty) {
 
 ASTWalker::PostWalkAction
 TypeReprIdentFinder::walkToTypeReprPost(TypeRepr *TR) {
-  auto CITR = dyn_cast<ComponentIdentTypeRepr>(TR);
-  if (!CITR || !CITR->getBoundDecl())
+  auto ITR = dyn_cast<IdentTypeRepr>(TR);
+  if (!ITR || !ITR->getBoundDecl())
     return Action::Continue();
-  return Action::StopIf(!Callback(CITR));
+  return Action::StopIf(!Callback(ITR));
 }

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -127,22 +127,24 @@ SourceLoc TypeRepr::findUncheckedAttrLoc() const {
   return SourceLoc();
 }
 
-TypeDecl *IdentTypeRepr::getBoundDecl() const {
-  return const_cast<IdentTypeRepr *>(this)->getLastComponent()->getBoundDecl();
+TypeDecl *DeclRefTypeRepr::getBoundDecl() const {
+  return const_cast<DeclRefTypeRepr *>(this)
+      ->getLastComponent()
+      ->getBoundDecl();
 }
 
-DeclNameRef IdentTypeRepr::getNameRef() const {
-  return const_cast<IdentTypeRepr *>(this)->getLastComponent()->getNameRef();
+DeclNameRef DeclRefTypeRepr::getNameRef() const {
+  return const_cast<DeclRefTypeRepr *>(this)->getLastComponent()->getNameRef();
 }
 
-TypeRepr *IdentTypeRepr::getBaseComponent() {
+TypeRepr *DeclRefTypeRepr::getBaseComponent() {
   if (auto *Comp = dyn_cast<ComponentIdentTypeRepr>(this))
     return Comp;
 
   return cast<MemberTypeRepr>(this)->getBaseComponent();
 }
 
-ComponentIdentTypeRepr *IdentTypeRepr::getLastComponent() {
+ComponentIdentTypeRepr *DeclRefTypeRepr::getLastComponent() {
   if (auto *Comp = dyn_cast<ComponentIdentTypeRepr>(this))
     return Comp;
 

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -127,6 +127,28 @@ SourceLoc TypeRepr::findUncheckedAttrLoc() const {
   return SourceLoc();
 }
 
+TypeDecl *IdentTypeRepr::getBoundDecl() const {
+  return const_cast<IdentTypeRepr *>(this)->getLastComponent()->getBoundDecl();
+}
+
+DeclNameRef IdentTypeRepr::getNameRef() const {
+  return const_cast<IdentTypeRepr *>(this)->getLastComponent()->getNameRef();
+}
+
+TypeRepr *IdentTypeRepr::getBaseComponent() {
+  if (auto *Comp = dyn_cast<ComponentIdentTypeRepr>(this))
+    return Comp;
+
+  return cast<CompoundIdentTypeRepr>(this)->getComponents().front();
+}
+
+ComponentIdentTypeRepr *IdentTypeRepr::getLastComponent() {
+  if (auto *Comp = dyn_cast<ComponentIdentTypeRepr>(this))
+    return Comp;
+
+  return cast<CompoundIdentTypeRepr>(this)->getComponents().back();
+}
+
 DeclNameRef ComponentIdentTypeRepr::getNameRef() const {
   if (IdOrDecl.is<DeclNameRef>())
     return IdOrDecl.get<DeclNameRef>();

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -138,20 +138,20 @@ DeclNameRef DeclRefTypeRepr::getNameRef() const {
 }
 
 TypeRepr *DeclRefTypeRepr::getBaseComponent() {
-  if (auto *Comp = dyn_cast<ComponentIdentTypeRepr>(this))
-    return Comp;
+  if (auto *ITR = dyn_cast<IdentTypeRepr>(this))
+    return ITR;
 
   return cast<MemberTypeRepr>(this)->getBaseComponent();
 }
 
-ComponentIdentTypeRepr *DeclRefTypeRepr::getLastComponent() {
-  if (auto *Comp = dyn_cast<ComponentIdentTypeRepr>(this))
-    return Comp;
+IdentTypeRepr *DeclRefTypeRepr::getLastComponent() {
+  if (auto *ITR = dyn_cast<IdentTypeRepr>(this))
+    return ITR;
 
   return cast<MemberTypeRepr>(this)->getLastComponent();
 }
 
-DeclNameRef ComponentIdentTypeRepr::getNameRef() const {
+DeclNameRef IdentTypeRepr::getNameRef() const {
   if (IdOrDecl.is<DeclNameRef>())
     return IdOrDecl.get<DeclNameRef>();
 
@@ -280,8 +280,8 @@ static void printGenericArgs(ASTPrinter &Printer, const PrintOptions &Opts,
   Printer << ">";
 }
 
-void ComponentIdentTypeRepr::printImpl(ASTPrinter &Printer,
-                                       const PrintOptions &Opts) const {
+void IdentTypeRepr::printImpl(ASTPrinter &Printer,
+                              const PrintOptions &Opts) const {
   if (auto *TD = dyn_cast_or_null<TypeDecl>(getBoundDecl())) {
     if (auto MD = dyn_cast<ModuleDecl>(TD))
       Printer.printModuleRef(MD, getNameRef().getBaseIdentifier());
@@ -386,16 +386,14 @@ GenericIdentTypeRepr *GenericIdentTypeRepr::create(const ASTContext &C,
 
 MemberTypeRepr *
 MemberTypeRepr::create(const ASTContext &C, TypeRepr *Base,
-                       ArrayRef<ComponentIdentTypeRepr *> MemberComponents) {
-  auto size =
-      totalSizeToAlloc<ComponentIdentTypeRepr *>(MemberComponents.size());
+                       ArrayRef<IdentTypeRepr *> MemberComponents) {
+  auto size = totalSizeToAlloc<IdentTypeRepr *>(MemberComponents.size());
   auto mem = C.Allocate(size, alignof(MemberTypeRepr));
   return new (mem) MemberTypeRepr(Base, MemberComponents);
 }
 
-MemberTypeRepr *
-MemberTypeRepr::create(const ASTContext &Ctx,
-                       ArrayRef<ComponentIdentTypeRepr *> Components) {
+MemberTypeRepr *MemberTypeRepr::create(const ASTContext &Ctx,
+                                       ArrayRef<IdentTypeRepr *> Components) {
   return create(Ctx, Components.front(), Components.drop_front());
 }
 

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -382,11 +382,19 @@ GenericIdentTypeRepr *GenericIdentTypeRepr::create(const ASTContext &C,
   return new (mem) GenericIdentTypeRepr(Loc, Id, GenericArgs, AngleBrackets);
 }
 
-CompoundIdentTypeRepr *CompoundIdentTypeRepr::create(const ASTContext &C,
-                                 ArrayRef<ComponentIdentTypeRepr*> Components) {
-  auto size = totalSizeToAlloc<ComponentIdentTypeRepr*>(Components.size());
+CompoundIdentTypeRepr *CompoundIdentTypeRepr::create(
+    const ASTContext &C, TypeRepr *Base,
+    ArrayRef<ComponentIdentTypeRepr *> MemberComponents) {
+  auto size =
+      totalSizeToAlloc<ComponentIdentTypeRepr *>(MemberComponents.size());
   auto mem = C.Allocate(size, alignof(CompoundIdentTypeRepr));
-  return new (mem) CompoundIdentTypeRepr(Components);
+  return new (mem) CompoundIdentTypeRepr(Base, MemberComponents);
+}
+
+CompoundIdentTypeRepr *
+CompoundIdentTypeRepr::create(const ASTContext &Ctx,
+                              ArrayRef<ComponentIdentTypeRepr *> Components) {
+  return create(Ctx, Components.front(), Components.drop_front());
 }
 
 SILBoxTypeRepr *SILBoxTypeRepr::create(ASTContext &C,

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -139,14 +139,14 @@ TypeRepr *IdentTypeRepr::getBaseComponent() {
   if (auto *Comp = dyn_cast<ComponentIdentTypeRepr>(this))
     return Comp;
 
-  return cast<CompoundIdentTypeRepr>(this)->getBaseComponent();
+  return cast<MemberTypeRepr>(this)->getBaseComponent();
 }
 
 ComponentIdentTypeRepr *IdentTypeRepr::getLastComponent() {
   if (auto *Comp = dyn_cast<ComponentIdentTypeRepr>(this))
     return Comp;
 
-  return cast<CompoundIdentTypeRepr>(this)->getLastComponent();
+  return cast<MemberTypeRepr>(this)->getLastComponent();
 }
 
 DeclNameRef ComponentIdentTypeRepr::getNameRef() const {
@@ -293,8 +293,8 @@ void ComponentIdentTypeRepr::printImpl(ASTPrinter &Printer,
     printGenericArgs(Printer, Opts, GenIdT->getGenericArgs());
 }
 
-void CompoundIdentTypeRepr::printImpl(ASTPrinter &Printer,
-                                      const PrintOptions &Opts) const {
+void MemberTypeRepr::printImpl(ASTPrinter &Printer,
+                               const PrintOptions &Opts) const {
   printTypeRepr(getBaseComponent(), Printer, Opts);
   for (auto C : getMemberComponents()) {
     Printer << ".";
@@ -382,18 +382,18 @@ GenericIdentTypeRepr *GenericIdentTypeRepr::create(const ASTContext &C,
   return new (mem) GenericIdentTypeRepr(Loc, Id, GenericArgs, AngleBrackets);
 }
 
-CompoundIdentTypeRepr *CompoundIdentTypeRepr::create(
-    const ASTContext &C, TypeRepr *Base,
-    ArrayRef<ComponentIdentTypeRepr *> MemberComponents) {
+MemberTypeRepr *
+MemberTypeRepr::create(const ASTContext &C, TypeRepr *Base,
+                       ArrayRef<ComponentIdentTypeRepr *> MemberComponents) {
   auto size =
       totalSizeToAlloc<ComponentIdentTypeRepr *>(MemberComponents.size());
-  auto mem = C.Allocate(size, alignof(CompoundIdentTypeRepr));
-  return new (mem) CompoundIdentTypeRepr(Base, MemberComponents);
+  auto mem = C.Allocate(size, alignof(MemberTypeRepr));
+  return new (mem) MemberTypeRepr(Base, MemberComponents);
 }
 
-CompoundIdentTypeRepr *
-CompoundIdentTypeRepr::create(const ASTContext &Ctx,
-                              ArrayRef<ComponentIdentTypeRepr *> Components) {
+MemberTypeRepr *
+MemberTypeRepr::create(const ASTContext &Ctx,
+                       ArrayRef<ComponentIdentTypeRepr *> Components) {
   return create(Ctx, Components.front(), Components.drop_front());
 }
 

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -139,14 +139,14 @@ TypeRepr *IdentTypeRepr::getBaseComponent() {
   if (auto *Comp = dyn_cast<ComponentIdentTypeRepr>(this))
     return Comp;
 
-  return cast<CompoundIdentTypeRepr>(this)->getComponents().front();
+  return cast<CompoundIdentTypeRepr>(this)->getBaseComponent();
 }
 
 ComponentIdentTypeRepr *IdentTypeRepr::getLastComponent() {
   if (auto *Comp = dyn_cast<ComponentIdentTypeRepr>(this))
     return Comp;
 
-  return cast<CompoundIdentTypeRepr>(this)->getComponents().back();
+  return cast<CompoundIdentTypeRepr>(this)->getLastComponent();
 }
 
 DeclNameRef ComponentIdentTypeRepr::getNameRef() const {
@@ -295,8 +295,8 @@ void ComponentIdentTypeRepr::printImpl(ASTPrinter &Printer,
 
 void CompoundIdentTypeRepr::printImpl(ASTPrinter &Printer,
                                       const PrintOptions &Opts) const {
-  printTypeRepr(getComponents().front(), Printer, Opts);
-  for (auto C : getComponents().slice(1)) {
+  printTypeRepr(getBaseComponent(), Printer, Opts);
+  for (auto C : getMemberComponents()) {
     Printer << ".";
     printTypeRepr(C, Printer, Opts);
   }

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -245,15 +245,6 @@ void AttributedTypeRepr::printAttrs(ASTPrinter &Printer,
     Printer.printSimpleAttr("@_noMetadata") << " ";
 }
 
-IdentTypeRepr *IdentTypeRepr::create(ASTContext &C,
-                                ArrayRef<ComponentIdentTypeRepr *> Components) {
-  assert(!Components.empty());
-  if (Components.size() == 1)
-    return Components.front();
-
-  return CompoundIdentTypeRepr::create(C, Components);
-}
-
 static void printGenericArgs(ASTPrinter &Printer, const PrintOptions &Opts,
                              ArrayRef<TypeRepr *> Args) {
   if (Args.empty())

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -72,7 +72,7 @@ extension ASTGenVisitor {
 
     return .type(
       elements.withBridgedArrayRef { elements in
-        return IdentTypeRepr_create(self.ctx, elements)
+        return DeclRefTypeRepr_create(self.ctx, elements)
       })
   }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -220,10 +220,9 @@ class CodeCompletionCallbacksImpl : public IDEInspectionCallbacks {
       if (isa<MemberTypeRepr>(declRefTR))
         return false;
 
-      const auto *component = cast<ComponentIdentTypeRepr>(declRefTR);
+      const auto *identTR = cast<IdentTypeRepr>(declRefTR);
       ImportPath::Module::Builder builder(
-          component->getNameRef().getBaseIdentifier(),
-          component->getLoc());
+          identTR->getNameRef().getBaseIdentifier(), identTR->getLoc());
 
       if (auto Module = Context.getLoadedModule(builder.get()))
         ParsedTypeLoc.setType(ModuleType::get(Module));

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -216,7 +216,7 @@ class CodeCompletionCallbacksImpl : public IDEInspectionCallbacks {
     // It doesn't type check as a type, so see if it's a qualifying module name.
     if (auto *ITR = dyn_cast<IdentTypeRepr>(ParsedTypeLoc.getTypeRepr())) {
       // If it has more than one component, it can't be a module name.
-      if (isa<CompoundIdentTypeRepr>(ITR))
+      if (isa<MemberTypeRepr>(ITR))
         return false;
 
       const auto *component = cast<ComponentIdentTypeRepr>(ITR);

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -214,12 +214,13 @@ class CodeCompletionCallbacksImpl : public IDEInspectionCallbacks {
     ParsedTypeLoc.setType(ty);
 
     // It doesn't type check as a type, so see if it's a qualifying module name.
-    if (auto *ITR = dyn_cast<IdentTypeRepr>(ParsedTypeLoc.getTypeRepr())) {
+    if (auto *declRefTR =
+            dyn_cast<DeclRefTypeRepr>(ParsedTypeLoc.getTypeRepr())) {
       // If it has more than one component, it can't be a module name.
-      if (isa<MemberTypeRepr>(ITR))
+      if (isa<MemberTypeRepr>(declRefTR))
         return false;
 
-      const auto *component = cast<ComponentIdentTypeRepr>(ITR);
+      const auto *component = cast<ComponentIdentTypeRepr>(declRefTR);
       ImportPath::Module::Builder builder(
           component->getNameRef().getBaseIdentifier(),
           component->getLoc());
@@ -266,8 +267,8 @@ public:
 
   void completeTypeDeclResultBeginning() override;
   void completeTypeSimpleBeginning() override;
-  void completeTypeIdentifierWithDot(IdentTypeRepr *ITR) override;
-  void completeTypeIdentifierWithoutDot(IdentTypeRepr *ITR) override;
+  void completeTypeIdentifierWithDot(DeclRefTypeRepr *TR) override;
+  void completeTypeIdentifierWithoutDot(DeclRefTypeRepr *TR) override;
 
   void completeCaseStmtKeyword() override;
   void completeCaseStmtBeginning(CodeCompletionExpr *E) override;
@@ -495,21 +496,21 @@ void CodeCompletionCallbacksImpl::completeInPrecedenceGroup(
 }
 
 void CodeCompletionCallbacksImpl::completeTypeIdentifierWithDot(
-    IdentTypeRepr *ITR) {
-  if (!ITR) {
+    DeclRefTypeRepr *TR) {
+  if (!TR) {
     completeTypeSimpleBeginning();
     return;
   }
   Kind = CompletionKind::TypeIdentifierWithDot;
-  ParsedTypeLoc = TypeLoc(ITR);
+  ParsedTypeLoc = TypeLoc(TR);
   CurDeclContext = P.CurDeclContext;
 }
 
 void CodeCompletionCallbacksImpl::completeTypeIdentifierWithoutDot(
-    IdentTypeRepr *ITR) {
-  assert(ITR);
+    DeclRefTypeRepr *TR) {
+  assert(TR);
   Kind = CompletionKind::TypeIdentifierWithoutDot;
-  ParsedTypeLoc = TypeLoc(ITR);
+  ParsedTypeLoc = TypeLoc(TR);
   CurDeclContext = P.CurDeclContext;
 }
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -215,12 +215,11 @@ class CodeCompletionCallbacksImpl : public IDEInspectionCallbacks {
 
     // It doesn't type check as a type, so see if it's a qualifying module name.
     if (auto *ITR = dyn_cast<IdentTypeRepr>(ParsedTypeLoc.getTypeRepr())) {
-      const auto &componentRange = ITR->getComponentRange();
       // If it has more than one component, it can't be a module name.
-      if (std::distance(componentRange.begin(), componentRange.end()) != 1)
+      if (isa<CompoundIdentTypeRepr>(ITR))
         return false;
 
-      const auto &component = componentRange.front();
+      const auto *component = cast<ComponentIdentTypeRepr>(ITR);
       ImportPath::Module::Builder builder(
           component->getNameRef().getBaseIdentifier(),
           component->getLoc());

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -621,7 +621,7 @@ ASTWalker::PreWalkAction SemaAnnotator::walkToTypeReprPre(TypeRepr *T) {
   if (!Continue)
     return Action::Stop();
 
-  if (auto IdT = dyn_cast<ComponentIdentTypeRepr>(T)) {
+  if (auto IdT = dyn_cast<IdentTypeRepr>(T)) {
     if (ValueDecl *VD = IdT->getBoundDecl()) {
       if (auto *ModD = dyn_cast<ModuleDecl>(VD)) {
         auto ident = IdT->getNameRef().getBaseIdentifier();

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -488,7 +488,7 @@ ASTWalker::PreWalkAction NameMatcher::walkToTypeReprPre(TypeRepr *T) {
   if (shouldSkip(T->getSourceRange()))
     return Action::SkipChildren();
 
-  if (isa<ComponentIdentTypeRepr>(T)) {
+  if (isa<IdentTypeRepr>(T)) {
     // If we're walking a CustomAttr's type we may have an associated call
     // argument to resolve with from its semantic initializer.
     if (CustomAttrArgList.has_value() && CustomAttrArgList->Loc == T->getLoc()) {

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -1178,7 +1178,7 @@ ASTWalker::PreWalkAction ModelASTWalker::walkToTypeReprPre(TypeRepr *T) {
     if (!handleAttrs(AttrT->getAttrs()))
       return Action::SkipChildren();
 
-  } else if (auto IdT = dyn_cast<ComponentIdentTypeRepr>(T)) {
+  } else if (auto IdT = dyn_cast<IdentTypeRepr>(T)) {
     if (!passTokenNodesUntil(IdT->getStartLoc(),
                              ExcludeNodeAtLocation).shouldContinue)
       return Action::SkipChildren();

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1324,12 +1324,11 @@ bool IndexSwiftASTWalker::reportInheritedTypeRefs(ArrayRef<InheritedEntry> Inher
 }
 
 bool IndexSwiftASTWalker::reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet Relations, Decl *Related) {
-
-  if (auto *T = dyn_cast_or_null<IdentTypeRepr>(Ty.getTypeRepr())) {
-    SourceLoc IdLoc = T->getLoc();
+  if (auto *declRefTR = dyn_cast_or_null<DeclRefTypeRepr>(Ty.getTypeRepr())) {
+    SourceLoc IdLoc = declRefTR->getLoc();
     NominalTypeDecl *NTD = nullptr;
     bool isImplicit = false;
-    if (auto *VD = T->getBoundDecl()) {
+    if (auto *VD = declRefTR->getBoundDecl()) {
       if (auto *TAD = dyn_cast<TypeAliasDecl>(VD)) {
         IndexSymbol Info;
         if (!reportRef(TAD, IdLoc, Info, None))
@@ -1424,8 +1423,8 @@ NominalTypeDecl *
 IndexSwiftASTWalker::getTypeLocAsNominalTypeDecl(const TypeLoc &Ty) {
   if (Type T = Ty.getType())
     return T->getAnyNominal();
-  if (auto *T = dyn_cast_or_null<IdentTypeRepr>(Ty.getTypeRepr())) {
-    if (auto NTD = dyn_cast_or_null<NominalTypeDecl>(T->getBoundDecl()))
+  if (auto *declRefTR = dyn_cast_or_null<DeclRefTypeRepr>(Ty.getTypeRepr())) {
+    if (auto NTD = dyn_cast_or_null<NominalTypeDecl>(declRefTR->getBoundDecl()))
       return NTD;
   }
   return nullptr;

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1326,11 +1326,10 @@ bool IndexSwiftASTWalker::reportInheritedTypeRefs(ArrayRef<InheritedEntry> Inher
 bool IndexSwiftASTWalker::reportRelatedTypeRef(const TypeLoc &Ty, SymbolRoleSet Relations, Decl *Related) {
 
   if (auto *T = dyn_cast_or_null<IdentTypeRepr>(Ty.getTypeRepr())) {
-    auto Comps = T->getComponentRange();
-    SourceLoc IdLoc = Comps.back()->getLoc();
+    SourceLoc IdLoc = T->getLoc();
     NominalTypeDecl *NTD = nullptr;
     bool isImplicit = false;
-    if (auto *VD = Comps.back()->getBoundDecl()) {
+    if (auto *VD = T->getBoundDecl()) {
       if (auto *TAD = dyn_cast<TypeAliasDecl>(VD)) {
         IndexSymbol Info;
         if (!reportRef(TAD, IdLoc, Info, None))
@@ -1426,8 +1425,7 @@ IndexSwiftASTWalker::getTypeLocAsNominalTypeDecl(const TypeLoc &Ty) {
   if (Type T = Ty.getType())
     return T->getAnyNominal();
   if (auto *T = dyn_cast_or_null<IdentTypeRepr>(Ty.getTypeRepr())) {
-    auto Comp = T->getComponentRange().back();
-    if (auto NTD = dyn_cast_or_null<NominalTypeDecl>(Comp->getBoundDecl()))
+    if (auto NTD = dyn_cast_or_null<NominalTypeDecl>(T->getBoundDecl()))
       return NTD;
   }
   return nullptr;

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -92,7 +92,7 @@ private:
   }
 
   bool isUserTypeAlias(TypeRepr *T) const {
-    if (auto Ident = dyn_cast<ComponentIdentTypeRepr>(T)) {
+    if (auto Ident = dyn_cast<IdentTypeRepr>(T)) {
       if (auto Bound = Ident->getBoundDecl()) {
         return isa<TypeAliasDecl>(Bound) &&
           !Bound->getModuleContext()->isSystemModule();

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -206,7 +206,7 @@ public:
   }
 
   FoundResult visitCompoundIdentTypeRepr(CompoundIdentTypeRepr *T) {
-    return visit(T->getComponents().back());
+    return visit(T->getLastComponent());
   }
 
   FoundResult visitOptionalTypeRepr(OptionalTypeRepr *T) {

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -205,7 +205,7 @@ public:
     return handleParent(T, T->getGenericArgs());
   }
 
-  FoundResult visitCompoundIdentTypeRepr(CompoundIdentTypeRepr *T) {
+  FoundResult visitMemberTypeRepr(MemberTypeRepr *T) {
     return visit(T->getLastComponent());
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4952,8 +4952,9 @@ Parser::parseDecl(ParseDeclOptions Flags,
                  nominal->createNameRef());
       } else if (auto extension = dyn_cast<ExtensionDecl>(CurDeclContext)) {
         if (auto repr = extension->getExtendedTypeRepr()) {
-          if (auto idRepr = dyn_cast<IdentTypeRepr>(repr)) {
-            diagnose(extension->getLoc(), diag::note_in_extension_of, idRepr);
+          if (auto declRefTR = dyn_cast<DeclRefTypeRepr>(repr)) {
+            diagnose(extension->getLoc(), diag::note_in_extension_of,
+                     declRefTR);
           }
         }
       }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4948,13 +4948,12 @@ Parser::parseDecl(ParseDeclOptions Flags,
 
     if (CurDeclContext) {
       if (auto nominal = dyn_cast<NominalTypeDecl>(CurDeclContext)) {
-        diagnose(nominal->getLoc(), diag::note_in_decl_extension, false,
+        diagnose(nominal->getLoc(), diag::note_in_decl_of,
                  nominal->createNameRef());
       } else if (auto extension = dyn_cast<ExtensionDecl>(CurDeclContext)) {
         if (auto repr = extension->getExtendedTypeRepr()) {
           if (auto idRepr = dyn_cast<IdentTypeRepr>(repr)) {
-            diagnose(extension->getLoc(), diag::note_in_decl_extension, true,
-                     idRepr->getComponentRange().front()->getNameRef());
+            diagnose(extension->getLoc(), diag::note_in_extension_of, idRepr);
           }
         }
       }

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -755,7 +755,7 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType) {
     if (ComponentsR.size() == 1) {
       ITR = ComponentsR.front();
     } else {
-      ITR = CompoundIdentTypeRepr::create(Context, ComponentsR);
+      ITR = MemberTypeRepr::create(Context, ComponentsR);
     }
   }
 

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -504,7 +504,7 @@ ParserResult<TypeRepr> Parser::parseTypeScalar(
     class EraseTypeParamWalker : public ASTWalker {
     public:
       PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-        if (auto ident = dyn_cast<ComponentIdentTypeRepr>(T)) {
+        if (auto ident = dyn_cast<IdentTypeRepr>(T)) {
           if (auto decl = ident->getBoundDecl()) {
             if (auto genericParam = dyn_cast<GenericTypeParamDecl>(decl))
               ident->overwriteNameRef(genericParam->createNameRef());
@@ -689,7 +689,7 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType) {
     return nullptr;
   }
   ParserStatus Status;
-  SmallVector<ComponentIdentTypeRepr *, 4> ComponentsR;
+  SmallVector<IdentTypeRepr *, 4> ComponentsR;
   SourceLoc EndLoc;
   while (true) {
     DeclNameLoc Loc;
@@ -710,7 +710,7 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType) {
       }
       EndLoc = Loc.getEndLoc();
 
-      ComponentIdentTypeRepr *CompT;
+      IdentTypeRepr *CompT;
       if (HasGenericArgs) {
         CompT = GenericIdentTypeRepr::create(Context, Loc, Name, GenericArgs,
                                              SourceRange(LAngle, RAngle));

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -752,7 +752,11 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType) {
 
   IdentTypeRepr *ITR = nullptr;
   if (!ComponentsR.empty()) {
-    ITR = IdentTypeRepr::create(Context, ComponentsR);
+    if (ComponentsR.size() == 1) {
+      ITR = ComponentsR.front();
+    } else {
+      ITR = CompoundIdentTypeRepr::create(Context, ComponentsR);
+    }
   }
 
   if (Status.hasCodeCompletion()) {

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -676,7 +676,7 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType) {
         IDECallbacks->completeTypeSimpleBeginning();
       // Eat the code completion token because we handled it.
       consumeToken(tok::code_complete);
-      return makeParserCodeCompletionResult<IdentTypeRepr>();
+      return makeParserCodeCompletionResult<DeclRefTypeRepr>();
     }
 
     diagnose(Tok, diag::expected_identifier_for_type);
@@ -750,12 +750,12 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType) {
     break;
   }
 
-  IdentTypeRepr *ITR = nullptr;
+  DeclRefTypeRepr *DeclRefTR = nullptr;
   if (!ComponentsR.empty()) {
     if (ComponentsR.size() == 1) {
-      ITR = ComponentsR.front();
+      DeclRefTR = ComponentsR.front();
     } else {
-      ITR = MemberTypeRepr::create(Context, ComponentsR);
+      DeclRefTR = MemberTypeRepr::create(Context, ComponentsR);
     }
   }
 
@@ -764,16 +764,16 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType) {
       // We have a dot.
       consumeToken();
       if (IDECallbacks)
-        IDECallbacks->completeTypeIdentifierWithDot(ITR);
+        IDECallbacks->completeTypeIdentifierWithDot(DeclRefTR);
     } else {
       if (IDECallbacks)
-        IDECallbacks->completeTypeIdentifierWithoutDot(ITR);
+        IDECallbacks->completeTypeIdentifierWithoutDot(DeclRefTR);
     }
     // Eat the code completion token because we handled it.
     consumeToken(tok::code_complete);
   }
 
-  return makeParserResult(Status, ITR);
+  return makeParserResult(Status, DeclRefTR);
 }
 
 /// parseTypeSimpleOrComposition
@@ -920,9 +920,9 @@ ParserResult<TypeRepr> Parser::parseOldStyleProtocolComposition() {
       // Parse the type-identifier.
       ParserResult<TypeRepr> Protocol = parseTypeIdentifier();
       Status |= Protocol;
-      if (auto *ident =
-            dyn_cast_or_null<IdentTypeRepr>(Protocol.getPtrOrNull()))
-        Protocols.push_back(ident);
+      if (auto *DeclRefTR =
+              dyn_cast_or_null<DeclRefTypeRepr>(Protocol.getPtrOrNull()))
+        Protocols.push_back(DeclRefTR);
     } while (consumeIf(tok::comma));
   }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6152,7 +6152,7 @@ bool MissingGenericArgumentsFailure::findArgumentLocations(
       if (Params.empty())
         return Action::SkipChildren();
 
-      auto *ident = dyn_cast<ComponentIdentTypeRepr>(T);
+      auto *ident = dyn_cast<IdentTypeRepr>(T);
       if (!ident)
         return Action::Continue();
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1933,12 +1933,8 @@ static bool isMainDispatchQueueMember(ConstraintLocator *locator) {
   if (!identTypeRepr)
     return false;
 
-  auto components = identTypeRepr->getComponentRange();
-  if (components.empty())
-    return false;
-
-  if (components.back()->getNameRef().getBaseName().userFacingName() !=
-        "DispatchQueue")
+  if (identTypeRepr->getNameRef().getBaseName().userFacingName() !=
+      "DispatchQueue")
     return false;
 
   return true;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1929,12 +1929,11 @@ static bool isMainDispatchQueueMember(ConstraintLocator *locator) {
   if (!typeRepr)
     return false;
 
-  auto identTypeRepr = dyn_cast<IdentTypeRepr>(typeRepr);
-  if (!identTypeRepr)
+  auto declRefTR = dyn_cast<DeclRefTypeRepr>(typeRepr);
+  if (!declRefTR)
     return false;
 
-  if (identTypeRepr->getNameRef().getBaseName().userFacingName() !=
-      "DispatchQueue")
+  if (declRefTR->getNameRef().getBaseName().userFacingName() != "DispatchQueue")
     return false;
 
   return true;

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1454,7 +1454,7 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
   }
 
   // Fold 'T.U' into a nested type.
-  if (auto *ITR = dyn_cast<IdentTypeRepr>(InnerTypeRepr)) {
+  if (auto *DeclRefTR = dyn_cast<DeclRefTypeRepr>(InnerTypeRepr)) {
     // Resolve the TypeRepr to get the base type for the lookup.
     const auto BaseTy = TypeResolution::resolveContextualType(
         InnerTypeRepr, DC, TypeResolverContext::InExpression,
@@ -1478,7 +1478,7 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
       // If there is no nested type with this name, we have a lookup of
       // a non-type member, so leave the expression as-is.
       if (Result.size() == 1) {
-        return TypeExpr::createForMemberDecl(ITR, UDE->getNameLoc(),
+        return TypeExpr::createForMemberDecl(DeclRefTR, UDE->getNameLoc(),
                                              Result.front().Member);
       }
     }
@@ -1492,12 +1492,11 @@ TypeExpr *PreCheckExpression::simplifyUnresolvedSpecializeExpr(
   // If this is a reference type a specialized type, form a TypeExpr.
   // The base should be a TypeExpr that we already resolved.
   if (auto *te = dyn_cast<TypeExpr>(us->getSubExpr())) {
-    if (auto *ITR = dyn_cast_or_null<IdentTypeRepr>(te->getTypeRepr())) {
-      return TypeExpr::createForSpecializedDecl(ITR,
-                                                us->getUnresolvedParams(),
-                                                SourceRange(us->getLAngleLoc(),
-                                                            us->getRAngleLoc()),
-                                                getASTContext());
+    if (auto *declRefTR =
+            dyn_cast_or_null<DeclRefTypeRepr>(te->getTypeRepr())) {
+      return TypeExpr::createForSpecializedDecl(
+          declRefTR, us->getUnresolvedParams(),
+          SourceRange(us->getLAngleLoc(), us->getRAngleLoc()), getASTContext());
     }
   }
 

--- a/lib/Sema/TypeAccessScopeChecker.h
+++ b/lib/Sema/TypeAccessScopeChecker.h
@@ -51,7 +51,7 @@ public:
   getAccessScope(TypeRepr *TR, const DeclContext *useDC,
                  bool treatUsableFromInlineAsPublic = false) {
     TypeAccessScopeChecker checker(useDC, treatUsableFromInlineAsPublic);
-    TR->walk(TypeReprIdentFinder([&](const ComponentIdentTypeRepr *typeRepr) {
+    TR->walk(TypeReprIdentFinder([&](const IdentTypeRepr *typeRepr) {
       return checker.visitDecl(typeRepr->getBoundDecl());
     }));
     return checker.Scope;

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -117,14 +117,14 @@ class TypeAccessScopeDiagnoser : private ASTWalker {
   AccessScope accessScope;
   const DeclContext *useDC;
   bool treatUsableFromInlineAsPublic;
-  const ComponentIdentTypeRepr *offendingType = nullptr;
+  const IdentTypeRepr *offendingType = nullptr;
 
   PreWalkAction walkToTypeReprPre(TypeRepr *TR) override {
-    auto CITR = dyn_cast<ComponentIdentTypeRepr>(TR);
-    if (!CITR)
+    auto ITR = dyn_cast<IdentTypeRepr>(TR);
+    if (!ITR)
       return Action::Continue();
 
-    const ValueDecl *VD = CITR->getBoundDecl();
+    const ValueDecl *VD = ITR->getBoundDecl();
     if (!VD)
       return Action::Continue();
 
@@ -132,7 +132,7 @@ class TypeAccessScopeDiagnoser : private ASTWalker {
         != accessScope)
       return Action::Continue();
 
-    offendingType = CITR;
+    offendingType = ITR;
     return Action::Stop();
   }
 
@@ -295,8 +295,8 @@ static void highlightOffendingType(InFlightDiagnostic &diag,
   diag.highlight(complainRepr->getSourceRange());
   diag.flush();
 
-  if (auto CITR = dyn_cast<ComponentIdentTypeRepr>(complainRepr)) {
-    const ValueDecl *VD = CITR->getBoundDecl();
+  if (auto ITR = dyn_cast<IdentTypeRepr>(complainRepr)) {
+    const ValueDecl *VD = ITR->getBoundDecl();
     VD->diagnose(diag::kind_declared_here, DescriptiveDeclKind::Type);
   }
 }

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -4001,8 +4001,8 @@ public:
       return Action::SkipChildren();
     }
 
-    if (auto *CTR = dyn_cast<CompoundIdentTypeRepr>(T)) {
-      for (auto *comp : CTR->getMemberComponents()) {
+    if (auto *memberTR = dyn_cast<MemberTypeRepr>(T)) {
+      for (auto *comp : memberTR->getMemberComponents()) {
         // If a parent type is unavailable, don't go on to diagnose
         // the member since that will just produce a redundant
         // diagnostic.

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3986,11 +3986,11 @@ public:
       : where(where), flags(flags) {}
 
   PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-    auto *ITR = dyn_cast<IdentTypeRepr>(T);
-    if (!ITR)
+    auto *declRefTR = dyn_cast<DeclRefTypeRepr>(T);
+    if (!declRefTR)
       return Action::Continue();
 
-    auto *baseComp = ITR->getBaseComponent();
+    auto *baseComp = declRefTR->getBaseComponent();
     if (auto *identBase = dyn_cast<ComponentIdentTypeRepr>(baseComp)) {
       if (checkComponentIdentTypeRepr(identBase)) {
         foundAnyIssues = true;

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -3956,7 +3956,7 @@ class TypeReprAvailabilityWalker : public ASTWalker {
   const ExportContext &where;
   DeclAvailabilityFlags flags;
 
-  bool checkComponentIdentTypeRepr(ComponentIdentTypeRepr *ITR) {
+  bool checkIdentTypeRepr(IdentTypeRepr *ITR) {
     if (auto *typeDecl = ITR->getBoundDecl()) {
       auto range = ITR->getNameLoc().getSourceRange();
       if (diagnoseDeclAvailability(typeDecl, range, nullptr, where, flags))
@@ -3991,8 +3991,8 @@ public:
       return Action::Continue();
 
     auto *baseComp = declRefTR->getBaseComponent();
-    if (auto *identBase = dyn_cast<ComponentIdentTypeRepr>(baseComp)) {
-      if (checkComponentIdentTypeRepr(identBase)) {
+    if (auto *identBase = dyn_cast<IdentTypeRepr>(baseComp)) {
+      if (checkIdentTypeRepr(identBase)) {
         foundAnyIssues = true;
         return Action::SkipChildren();
       }
@@ -4006,7 +4006,7 @@ public:
         // If a parent type is unavailable, don't go on to diagnose
         // the member since that will just produce a redundant
         // diagnostic.
-        if (checkComponentIdentTypeRepr(comp)) {
+        if (checkIdentTypeRepr(comp)) {
           foundAnyIssues = true;
           break;
         }

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -486,7 +486,7 @@ public:
     if (components.size() == 1) {
       repr = components.front();
     } else {
-      repr = CompoundIdentTypeRepr::create(Context, components);
+      repr = MemberTypeRepr::create(Context, components);
     }
 
     // See if the repr resolves to a type.
@@ -613,7 +613,7 @@ public:
       if (components.size() == 1) {
         prefixRepr = components.front();
       } else {
-        prefixRepr = CompoundIdentTypeRepr::create(Context, components);
+        prefixRepr = MemberTypeRepr::create(Context, components);
       }
 
       // See first if the entire repr resolves to a type.

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -151,20 +151,20 @@ namespace {
 /// Build up an \c DeclRefTypeRepr and see what it resolves to.
 /// FIXME: Support DeclRefTypeRepr nodes with non-identifier base components.
 struct ExprToDeclRefTypeRepr : public ASTVisitor<ExprToDeclRefTypeRepr, bool> {
-  SmallVectorImpl<ComponentIdentTypeRepr *> &components;
+  SmallVectorImpl<IdentTypeRepr *> &components;
   ASTContext &C;
 
   ExprToDeclRefTypeRepr(decltype(components) &components, ASTContext &C)
-    : components(components), C(C) {}
-  
+      : components(components), C(C) {}
+
   bool visitExpr(Expr *e) {
     return false;
   }
   
   bool visitTypeExpr(TypeExpr *te) {
     if (auto *TR = te->getTypeRepr())
-      if (auto *CITR = dyn_cast<ComponentIdentTypeRepr>(TR)) {
-        components.push_back(CITR);
+      if (auto *ITR = dyn_cast<IdentTypeRepr>(TR)) {
+        components.push_back(ITR);
         return true;
       }
     return false;
@@ -475,7 +475,7 @@ public:
   // Member syntax 'T.Element' forms a pattern if 'T' is an enum and the
   // member name is a member of the enum.
   Pattern *visitUnresolvedDotExpr(UnresolvedDotExpr *ude) {
-    SmallVector<ComponentIdentTypeRepr *, 2> components;
+    SmallVector<IdentTypeRepr *, 2> components;
     if (!ExprToDeclRefTypeRepr(components, Context).visit(ude->getBase()))
       return nullptr;
 
@@ -581,7 +581,7 @@ public:
       return P;
     }
 
-    SmallVector<ComponentIdentTypeRepr *, 2> components;
+    SmallVector<IdentTypeRepr *, 2> components;
     if (!ExprToDeclRefTypeRepr(components, Context).visit(ce->getFn()))
       return nullptr;
     

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -482,7 +482,12 @@ public:
     const auto options =
         TypeResolutionOptions(None) | TypeResolutionFlags::SilenceErrors;
 
-    auto *repr = IdentTypeRepr::create(Context, components);
+    IdentTypeRepr *repr = nullptr;
+    if (components.size() == 1) {
+      repr = components.front();
+    } else {
+      repr = CompoundIdentTypeRepr::create(Context, components);
+    }
 
     // See if the repr resolves to a type.
     const auto ty = TypeResolution::resolveContextualType(
@@ -604,7 +609,12 @@ public:
 
       // Otherwise, see whether we had an enum type as the penultimate
       // component, and look up an element inside it.
-      auto *prefixRepr = IdentTypeRepr::create(Context, components);
+      IdentTypeRepr *prefixRepr = nullptr;
+      if (components.size() == 1) {
+        prefixRepr = components.front();
+      } else {
+        prefixRepr = CompoundIdentTypeRepr::create(Context, components);
+      }
 
       // See first if the entire repr resolves to a type.
       const Type enumTy = TypeResolution::resolveContextualType(

--- a/lib/Sema/TypeCheckRuntimeMetadataAttr.cpp
+++ b/lib/Sema/TypeCheckRuntimeMetadataAttr.cpp
@@ -52,7 +52,7 @@ static TypeRepr *buildTypeRepr(DeclContext *typeContext,
                                bool forMetatype = false) {
   assert(typeContext->isTypeContext());
 
-  SmallVector<ComponentIdentTypeRepr *, 2> components;
+  SmallVector<IdentTypeRepr *, 2> components;
 
   auto &ctx = typeContext->getASTContext();
   DeclContext *DC = typeContext;

--- a/lib/Sema/TypeCheckRuntimeMetadataAttr.cpp
+++ b/lib/Sema/TypeCheckRuntimeMetadataAttr.cpp
@@ -82,7 +82,7 @@ static TypeRepr *buildTypeRepr(DeclContext *typeContext,
   if (components.size() == 1) {
     typeRepr = components.front();
   } else {
-    typeRepr = CompoundIdentTypeRepr::create(ctx, components);
+    typeRepr = MemberTypeRepr::create(ctx, components);
   }
 
   if (forMetatype)

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -172,13 +172,12 @@ static unsigned getGenericRequirementKind(TypeResolutionOptions options) {
   llvm_unreachable("Invalid type resolution context");
 }
 
-Type TypeResolution::resolveDependentMemberType(
-                                          Type baseTy, DeclContext *DC,
-                                          SourceRange baseRange,
-                                          ComponentIdentTypeRepr *ref) const {
+Type TypeResolution::resolveDependentMemberType(Type baseTy, DeclContext *DC,
+                                                SourceRange baseRange,
+                                                IdentTypeRepr *repr) const {
   // FIXME(ModQual): Reject qualified names immediately; they cannot be
   // dependent member types.
-  Identifier refIdentifier = ref->getNameRef().getBaseIdentifier();
+  Identifier refIdentifier = repr->getNameRef().getBaseIdentifier();
   ASTContext &ctx = DC->getASTContext();
 
   switch (stage) {
@@ -201,7 +200,7 @@ Type TypeResolution::resolveDependentMemberType(
       if (auto *protoDecl = nestedType->getDeclContext()->getExtendedProtocolDecl()) {
         if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
           unsigned kind = getGenericRequirementKind(options);
-          ctx.Diags.diagnose(ref->getNameLoc(),
+          ctx.Diags.diagnose(repr->getNameLoc(),
                              diag::protocol_extension_in_where_clause,
                              nestedType->getName(), protoDecl->getName(), kind);
           if (protoDecl->getLoc() && nestedType->getLoc()) {
@@ -216,11 +215,11 @@ Type TypeResolution::resolveDependentMemberType(
     }
 
     // Record the type we found.
-    ref->setValue(nestedType, nullptr);
+    repr->setValue(nestedType, nullptr);
   } else {
     // Resolve the base to a potential archetype.
     // Perform typo correction.
-    TypoCorrectionResults corrections(ref->getNameRef(), ref->getNameLoc());
+    TypoCorrectionResults corrections(repr->getNameRef(), repr->getNameLoc());
     TypeChecker::performTypoCorrection(DC, DeclRefKind::Ordinary,
                                        MetatypeType::get(baseTy),
                                        defaultMemberLookupOptions,
@@ -234,8 +233,8 @@ Type TypeResolution::resolveDependentMemberType(
 
     // If we don't have a single result, complain and fail.
     if (!singleType) {
-      auto name = ref->getNameRef();
-      auto nameLoc = ref->getNameLoc();
+      auto name = repr->getNameRef();
+      auto nameLoc = repr->getNameLoc();
       const auto kind = describeDeclOfType(baseTy);
       ctx.Diags.diagnose(nameLoc, diag::invalid_member_type, name, kind, baseTy)
           .highlight(baseRange);
@@ -245,32 +244,31 @@ Type TypeResolution::resolveDependentMemberType(
     }
 
     // We have a single type result. Suggest it.
-    ctx.Diags.diagnose(ref->getNameLoc(), diag::invalid_member_type_suggest,
-                       baseTy, ref->getNameRef(),
-                       singleType->getBaseName())
-      .fixItReplace(ref->getNameLoc().getSourceRange(),
-                    singleType->getBaseName().userFacingName());
+    ctx.Diags
+        .diagnose(repr->getNameLoc(), diag::invalid_member_type_suggest, baseTy,
+                  repr->getNameRef(), singleType->getBaseName())
+        .fixItReplace(repr->getNameLoc().getSourceRange(),
+                      singleType->getBaseName().userFacingName());
 
     // Correct to the single type result.
-    ref->overwriteNameRef(singleType->createNameRef());
-    ref->setValue(singleType, nullptr);
+    repr->setValue(singleType, nullptr);
   }
 
-  auto *concrete = ref->getBoundDecl();
+  auto *concrete = repr->getBoundDecl();
 
   if (auto concreteBase = genericSig->getConcreteType(baseTy)) {
     bool hasUnboundOpener = !!getUnboundTypeOpener();
     switch (TypeChecker::isUnsupportedMemberTypeAccess(concreteBase, concrete,
                                                        hasUnboundOpener)) {
     case TypeChecker::UnsupportedMemberTypeAccessKind::TypeAliasOfExistential:
-      ctx.Diags.diagnose(ref->getNameLoc(),
+      ctx.Diags.diagnose(repr->getNameLoc(),
                          diag::typealias_outside_of_protocol,
-                         ref->getNameRef(), concreteBase);
+                         repr->getNameRef(), concreteBase);
       break;
     case TypeChecker::UnsupportedMemberTypeAccessKind::AssociatedTypeOfExistential:
-      ctx.Diags.diagnose(ref->getNameLoc(),
+      ctx.Diags.diagnose(repr->getNameLoc(),
                          diag::assoc_type_outside_of_protocol,
-                         ref->getNameRef(), concreteBase);
+                         repr->getNameRef(), concreteBase);
       break;
     default:
       break;
@@ -667,7 +665,7 @@ bool TypeChecker::checkContextualRequirements(GenericTypeDecl *decl,
 /// \param type The generic type to which to apply arguments.
 /// \param resolution The type resolution to perform.
 /// \param silParams Used to look up generic parameters in SIL mode.
-/// \param comp The arguments to apply with the angle bracket range for
+/// \param repr The arguments to apply with the angle bracket range for
 /// diagnostics.
 ///
 /// \returns A BoundGenericType bound to the given arguments, or null on
@@ -676,12 +674,12 @@ bool TypeChecker::checkContextualRequirements(GenericTypeDecl *decl,
 /// \see TypeResolution::applyUnboundGenericArguments
 static Type applyGenericArguments(Type type, TypeResolution resolution,
                                   GenericParamList *silParams,
-                                  ComponentIdentTypeRepr *comp) {
+                                  IdentTypeRepr *repr) {
   auto options = resolution.getOptions();
   auto dc = resolution.getDeclContext();
-  auto loc = comp->getNameLoc().getBaseNameLoc();
+  auto loc = repr->getNameLoc().getBaseNameLoc();
 
-  auto *generic = dyn_cast<GenericIdentTypeRepr>(comp);
+  auto *generic = dyn_cast<GenericIdentTypeRepr>(repr);
   if (!generic) {
     if (auto *const unboundTy = type->getAs<UnboundGenericType>()) {
       if (!options.is(TypeResolverContext::TypeAliasDecl) &&
@@ -1174,23 +1172,22 @@ static void maybeDiagnoseBadConformanceRef(DeclContext *dc,
 /// Returns a valid type or ErrorType in case of an error.
 static Type resolveTypeDecl(TypeDecl *typeDecl, DeclContext *foundDC,
                             TypeResolution resolution,
-                            GenericParamList *silParams,
-                            ComponentIdentTypeRepr *comp) {
+                            GenericParamList *silParams, IdentTypeRepr *repr) {
   // Resolve the type declaration to a specific type. How this occurs
   // depends on the current context and where the type was found.
   Type type = resolution.resolveTypeInContext(typeDecl, foundDC,
-                                              isa<GenericIdentTypeRepr>(comp));
+                                              isa<GenericIdentTypeRepr>(repr));
 
   if (type->hasError() && foundDC &&
       (isa<AssociatedTypeDecl>(typeDecl) || isa<TypeAliasDecl>(typeDecl))) {
     auto fromDC = resolution.getDeclContext();
     assert(fromDC && "No declaration context for type resolution?");
     maybeDiagnoseBadConformanceRef(fromDC, foundDC->getDeclaredInterfaceType(),
-                                   comp->getNameLoc().getBaseNameLoc(),
+                                   repr->getNameLoc().getBaseNameLoc(),
                                    typeDecl);
   }
 
-  return applyGenericArguments(type, resolution, silParams, comp);
+  return applyGenericArguments(type, resolution, silParams, repr);
 }
 
 static std::string getDeclNameFromContext(DeclContext *dc,
@@ -1233,7 +1230,7 @@ static std::string getDeclNameFromContext(DeclContext *dc,
 static Type diagnoseUnknownType(TypeResolution resolution,
                                 Type parentType,
                                 SourceRange parentRange,
-                                ComponentIdentTypeRepr *comp,
+                                IdentTypeRepr *repr,
                                 NameLookupOptions lookupOptions) {
   auto dc = resolution.getDeclContext();
   ASTContext &ctx = dc->getASTContext();
@@ -1243,14 +1240,14 @@ static Type diagnoseUnknownType(TypeResolution resolution,
   if (parentType.isNull()) {
     // Tailored diagnostic for custom attributes.
     if (resolution.getOptions().is(TypeResolverContext::CustomAttr)) {
-      diags.diagnose(comp->getNameLoc(), diag::unknown_attribute,
-                     comp->getNameRef().getBaseIdentifier().str());
+      diags.diagnose(repr->getNameLoc(), diag::unknown_attribute,
+                     repr->getNameRef().getBaseIdentifier().str());
 
       return ErrorType::get(ctx);
     }
 
-    if (comp->getNameRef().isSimpleName(ctx.Id_Self) &&
-        !isa<GenericIdentTypeRepr>(comp)) {
+    if (repr->getNameRef().isSimpleName(ctx.Id_Self) &&
+        !isa<GenericIdentTypeRepr>(repr)) {
       DeclContext *nominalDC = nullptr;
       NominalTypeDecl *nominal = nullptr;
       if ((nominalDC = dc->getInnermostTypeContext()) &&
@@ -1261,21 +1258,20 @@ static Type diagnoseUnknownType(TypeResolution resolution,
 
           // Produce a Fix-It replacing 'Self' with the nominal type name.
           auto name = getDeclNameFromContext(dc, nominal);
-          diags.diagnose(comp->getNameLoc(), diag::dynamic_self_invalid, name)
-            .fixItReplace(comp->getNameLoc().getSourceRange(), name);
+          diags.diagnose(repr->getNameLoc(), diag::dynamic_self_invalid, name)
+              .fixItReplace(repr->getNameLoc().getSourceRange(), name);
 
-          comp->overwriteNameRef(DeclNameRef(nominal->getName()));
-          comp->setValue(nominal, nominalDC->getParent());
+          repr->setValue(nominal, nominalDC->getParent());
 
           return dc->getInnermostTypeContext()->getSelfInterfaceType();
         } else {
-          diags.diagnose(comp->getNameLoc(), diag::cannot_find_type_in_scope,
-                         comp->getNameRef());
+          diags.diagnose(repr->getNameLoc(), diag::cannot_find_type_in_scope,
+                         repr->getNameRef());
           return ErrorType::get(ctx);
         }
       }
       // Attempt to refer to 'Self' from a free function.
-      diags.diagnose(comp->getNameLoc(), diag::dynamic_self_non_method,
+      diags.diagnose(repr->getNameLoc(), diag::dynamic_self_non_method,
                      dc->getParent()->isLocalContext());
 
       return ErrorType::get(ctx);
@@ -1284,13 +1280,12 @@ static Type diagnoseUnknownType(TypeResolution resolution,
     // Try ignoring access control.
     NameLookupOptions relookupOptions = lookupOptions;
     relookupOptions |= NameLookupFlags::IgnoreAccessControl;
-    auto inaccessibleResults =
-    TypeChecker::lookupUnqualifiedType(dc, comp->getNameRef(),
-                                       comp->getLoc(), relookupOptions);
+    auto inaccessibleResults = TypeChecker::lookupUnqualifiedType(
+        dc, repr->getNameRef(), repr->getLoc(), relookupOptions);
     if (!inaccessibleResults.empty()) {
       // FIXME: What if the unviable candidates have different levels of access?
       auto first = cast<TypeDecl>(inaccessibleResults.front().getValueDecl());
-      diags.diagnose(comp->getNameLoc(), diag::candidate_inaccessible,
+      diags.diagnose(repr->getNameLoc(), diag::candidate_inaccessible,
                      first->getBaseName(), first->getFormalAccess());
 
       // FIXME: If any of the candidates (usually just one) are in the same
@@ -1305,22 +1300,23 @@ static Type diagnoseUnknownType(TypeResolution resolution,
     }
 
     // Fallback.
-    auto L = comp->getNameLoc();
-    SourceRange R = comp->getNameLoc().getSourceRange();
+    auto L = repr->getNameLoc();
+    SourceRange R = repr->getNameLoc().getSourceRange();
 
     // Check if the unknown type is in the type remappings.
     auto &Remapped = ctx.RemappedTypes;
-    auto TypeName = comp->getNameRef().getBaseIdentifier().str();
+    auto TypeName = repr->getNameRef().getBaseIdentifier().str();
     auto I = Remapped.find(TypeName);
     if (I != Remapped.end()) {
       auto RemappedTy = I->second->getString();
-      diags.diagnose(L, diag::cannot_find_type_in_scope_did_you_mean,
-                     comp->getNameRef(), RemappedTy)
-        .highlight(R)
-        .fixItReplace(R, RemappedTy);
+      diags
+          .diagnose(L, diag::cannot_find_type_in_scope_did_you_mean,
+                    repr->getNameRef(), RemappedTy)
+          .highlight(R)
+          .fixItReplace(R, RemappedTy);
 
       // Replace the computed type with the suggested type.
-      comp->overwriteNameRef(DeclNameRef(ctx.getIdentifier(RemappedTy)));
+      repr->overwriteNameRef(DeclNameRef(ctx.getIdentifier(RemappedTy)));
 
       // HACK: 'NSUInteger' suggests both 'UInt' and 'Int'.
       if (TypeName == ctx.getSwiftName(KnownFoundationEntity::NSUInteger)) {
@@ -1331,11 +1327,11 @@ static Type diagnoseUnknownType(TypeResolution resolution,
       return I->second;
     }
 
-    diags.diagnose(L, diag::cannot_find_type_in_scope, comp->getNameRef())
+    diags.diagnose(L, diag::cannot_find_type_in_scope, repr->getNameRef())
         .highlight(R);
     if (!ctx.LangOpts.DisableExperimentalClangImporterDiagnostics) {
       ctx.getClangModuleLoader()->diagnoseTopLevelValue(
-          comp->getNameRef().getFullName());
+          repr->getNameRef().getFullName());
     }
 
     return ErrorType::get(ctx);
@@ -1345,13 +1341,13 @@ static Type diagnoseUnknownType(TypeResolution resolution,
   if (!parentType->mayHaveMembers()) {
     const auto kind = describeDeclOfType(parentType);
     diags
-        .diagnose(comp->getNameLoc(), diag::invalid_member_type,
-                  comp->getNameRef(), kind, parentType)
+        .diagnose(repr->getNameLoc(), diag::invalid_member_type,
+                  repr->getNameRef(), kind, parentType)
         .highlight(parentRange);
 
     if (!ctx.LangOpts.DisableExperimentalClangImporterDiagnostics) {
       ctx.getClangModuleLoader()->diagnoseMemberValue(
-          comp->getNameRef().getFullName(), parentType);
+          repr->getNameRef().getFullName(), parentType);
     }
 
     return ErrorType::get(ctx);
@@ -1360,13 +1356,12 @@ static Type diagnoseUnknownType(TypeResolution resolution,
   // Try ignoring access control.
   NameLookupOptions relookupOptions = lookupOptions;
   relookupOptions |= NameLookupFlags::IgnoreAccessControl;
-  auto inaccessibleMembers =
-    TypeChecker::lookupMemberType(dc, parentType, comp->getNameRef(),
-                                  relookupOptions);
+  auto inaccessibleMembers = TypeChecker::lookupMemberType(
+      dc, parentType, repr->getNameRef(), relookupOptions);
   if (inaccessibleMembers) {
     // FIXME: What if the unviable candidates have different levels of access?
     const TypeDecl *first = inaccessibleMembers.front().Member;
-    diags.diagnose(comp->getNameLoc(), diag::candidate_inaccessible,
+    diags.diagnose(repr->getNameLoc(), diag::candidate_inaccessible,
                    first->getBaseName(), first->getFormalAccess());
 
     // FIXME: If any of the candidates (usually just one) are in the same module
@@ -1384,8 +1379,8 @@ static Type diagnoseUnknownType(TypeResolution resolution,
 
   // Lookup into a type.
   if (auto moduleType = parentType->getAs<ModuleType>()) {
-    diags.diagnose(comp->getNameLoc(), diag::no_module_type,
-                   comp->getNameRef(), moduleType->getModule()->getName());
+    diags.diagnose(repr->getNameLoc(), diag::no_module_type, repr->getNameRef(),
+                   moduleType->getModule()->getName());
   } else {
     LookupResult memberLookup;
     // Let's try to look any member of the parent type with the given name,
@@ -1393,26 +1388,26 @@ static Type diagnoseUnknownType(TypeResolution resolution,
     NLOptions memberLookupOptions = (NL_QualifiedDefault |
                                      NL_IgnoreAccessControl);
     SmallVector<ValueDecl *, 2> results;
-    dc->lookupQualified(parentType, comp->getNameRef(), memberLookupOptions,
+    dc->lookupQualified(parentType, repr->getNameRef(), memberLookupOptions,
                         results);
 
     // Looks like this is not a member type, but simply a member of parent type.
     if (!results.empty()) {
       auto member = results[0];
-      diags.diagnose(comp->getNameLoc(), diag::invalid_member_reference,
-                     member->getDescriptiveKind(), member->getName(),
-                     parentType)
+      diags
+          .diagnose(repr->getNameLoc(), diag::invalid_member_reference,
+                    member->getDescriptiveKind(), member->getName(), parentType)
           .highlight(parentRange);
     } else {
       const auto kind = describeDeclOfType(parentType);
       diags
-          .diagnose(comp->getNameLoc(), diag::invalid_member_type,
-                    comp->getNameRef(), kind, parentType)
+          .diagnose(repr->getNameLoc(), diag::invalid_member_type,
+                    repr->getNameRef(), kind, parentType)
           .highlight(parentRange);
 
       if (!ctx.LangOpts.DisableExperimentalClangImporterDiagnostics) {
         ctx.getClangModuleLoader()->diagnoseMemberValue(
-            comp->getNameRef().getFullName(), parentType);
+            repr->getNameRef().getFullName(), parentType);
       }
 
       // Note where the type was defined, this can help diagnose if the user
@@ -1472,7 +1467,7 @@ static SelfTypeKind getSelfTypeKind(DeclContext *dc,
 }
 
 static void diagnoseGenericArgumentsOnSelf(TypeResolution resolution,
-                                           ComponentIdentTypeRepr *comp,
+                                           IdentTypeRepr *repr,
                                            DeclContext *typeDC) {
   ASTContext &ctx = resolution.getASTContext();
   auto &diags = ctx.Diags;
@@ -1480,12 +1475,13 @@ static void diagnoseGenericArgumentsOnSelf(TypeResolution resolution,
   auto *selfNominal = typeDC->getSelfNominalTypeDecl();
   auto declaredType = selfNominal->getDeclaredType();
 
-  diags.diagnose(comp->getNameLoc(), diag::cannot_specialize_self);
+  diags.diagnose(repr->getNameLoc(), diag::cannot_specialize_self);
 
   if (selfNominal->isGeneric() && !isa<ProtocolDecl>(selfNominal)) {
-    diags.diagnose(comp->getNameLoc(), diag::specialize_explicit_type_instead,
-                   declaredType)
-        .fixItReplace(comp->getNameLoc().getSourceRange(),
+    diags
+        .diagnose(repr->getNameLoc(), diag::specialize_explicit_type_instead,
+                  declaredType)
+        .fixItReplace(repr->getNameLoc().getSourceRange(),
                       declaredType.getString());
   }
 }
@@ -1496,46 +1492,44 @@ static void diagnoseGenericArgumentsOnSelf(TypeResolution resolution,
 ///
 /// \returns Either the resolved type or a null type, the latter of
 /// which indicates that some dependencies were unsatisfied.
-static Type resolveTopLevelIdentTypeComponent(TypeResolution resolution,
-                                              GenericParamList *silParams,
-                                              ComponentIdentTypeRepr *comp) {
+static Type resolveUnqualifiedIdentTypeRepr(TypeResolution resolution,
+                                            GenericParamList *silParams,
+                                            IdentTypeRepr *repr) {
   const auto options = resolution.getOptions();
   ASTContext &ctx = resolution.getASTContext();
   auto &diags = ctx.Diags;
 
   // Short-circuiting.
-  if (comp->isInvalid()) return ErrorType::get(ctx);
+  if (repr->isInvalid()) return ErrorType::get(ctx);
 
-  // If the component has already been bound to a declaration, handle
+  // If the representation has already been bound to a declaration, handle
   // that now.
-  if (auto *typeDecl = comp->getBoundDecl()) {
+  if (auto *typeDecl = repr->getBoundDecl()) {
     // Resolve the type declaration within this context.
-    return resolveTypeDecl(typeDecl, comp->getDeclContext(), resolution,
-                           silParams, comp);
+    return resolveTypeDecl(typeDecl, repr->getDeclContext(), resolution,
+                           silParams, repr);
   }
 
-  // Resolve the first component, which is the only one that requires
-  // unqualified name lookup.
+  // Resolve the representation using unqualified name lookup.
   auto DC = resolution.getDeclContext();
-  auto id = comp->getNameRef();
+  auto id = repr->getNameRef();
 
   // In SIL mode, we bind generic parameters here, since name lookup
   // won't find them.
   if (silParams != nullptr) {
     auto name = id.getBaseIdentifier();
     if (auto *paramDecl = silParams->lookUpGenericParam(name)) {
-      comp->setValue(paramDecl, DC);
+      repr->setValue(paramDecl, DC);
 
-      return resolveTypeDecl(paramDecl, DC, resolution,
-                             silParams, comp);
+      return resolveTypeDecl(paramDecl, DC, resolution, silParams, repr);
     }
   }
 
   NameLookupOptions lookupOptions = defaultUnqualifiedLookupOptions;
   if (options.contains(TypeResolutionFlags::AllowUsableFromInline))
     lookupOptions |= NameLookupFlags::IncludeUsableFromInline;
-  auto globals = TypeChecker::lookupUnqualifiedType(DC, id, comp->getLoc(),
-                                                    lookupOptions);
+  auto globals =
+      TypeChecker::lookupUnqualifiedType(DC, id, repr->getLoc(), lookupOptions);
 
   // If we're doing structural resolution and one of the results is an
   // associated type, ignore any other results found from the same
@@ -1570,7 +1564,7 @@ static Type resolveTopLevelIdentTypeComponent(TypeResolution resolution,
 
     // Compute the type of the found declaration when referenced from this
     // location.
-    Type type = resolveTypeDecl(typeDecl, foundDC, resolution, silParams, comp);
+    Type type = resolveTypeDecl(typeDecl, foundDC, resolution, silParams, repr);
     if (type->is<ErrorType>())
       return type;
 
@@ -1596,21 +1590,22 @@ static Type resolveTopLevelIdentTypeComponent(TypeResolution resolution,
   // FIXME: We could recover by looking at later components.
   if (isAmbiguous) {
     if (!options.contains(TypeResolutionFlags::SilenceErrors)) {
-      diags.diagnose(comp->getNameLoc(), diag::ambiguous_type_base,
-                     comp->getNameRef())
-        .highlight(comp->getNameLoc().getSourceRange());
+      diags
+          .diagnose(repr->getNameLoc(), diag::ambiguous_type_base,
+                    repr->getNameRef())
+          .highlight(repr->getNameLoc().getSourceRange());
       for (auto entry : globals) {
         entry.getValueDecl()->diagnose(diag::found_candidate);
       }
     }
 
-    comp->setInvalid();
+    repr->setInvalid();
     return ErrorType::get(ctx);
   }
 
   // If we found a type declaration with the given name, return it now.
   if (current) {
-    comp->setValue(currentDecl, currentDC);
+    repr->setValue(currentDecl, currentDC);
     return current;
   }
 
@@ -1618,7 +1613,7 @@ static Type resolveTopLevelIdentTypeComponent(TypeResolution resolution,
   if (id.isSimpleName(ctx.Id_Self)) {
     if (auto *typeDC = DC->getInnermostTypeContext()) {
       // FIXME: The passed-in TypeRepr should get 'typechecked' as well.
-      // The issue is though that ComponentIdentTypeRepr only accepts a ValueDecl
+      // The issue is though that IdentTypeRepr only accepts a ValueDecl
       // while the 'Self' type is more than just a reference to a TypeDecl.
       auto selfType = typeDC->getSelfInterfaceType();
 
@@ -1627,8 +1622,8 @@ static Type resolveTopLevelIdentTypeComponent(TypeResolution resolution,
 
       // We don't allow generic arguments on 'Self'.
       if (selfTypeKind != SelfTypeKind::InvalidSelf &&
-          isa<GenericIdentTypeRepr>(comp)) {
-        diagnoseGenericArgumentsOnSelf(resolution, comp, typeDC);
+          isa<GenericIdentTypeRepr>(repr)) {
+        diagnoseGenericArgumentsOnSelf(resolution, repr, typeDC);
       }
 
       switch (selfTypeKind) {
@@ -1647,7 +1642,7 @@ static Type resolveTopLevelIdentTypeComponent(TypeResolution resolution,
     return ErrorType::get(ctx);
 
   // Complain and give ourselves a chance to recover.
-  return diagnoseUnknownType(resolution, nullptr, SourceRange(), comp,
+  return diagnoseUnknownType(resolution, nullptr, SourceRange(), repr,
                              lookupOptions);
 }
 
@@ -1673,11 +1668,11 @@ static void diagnoseAmbiguousMemberType(Type baseTy, SourceRange baseRange,
 /// lookup within the given parent type, returning the type it
 /// references.
 /// \param silParams Used to look up generic parameters in SIL mode.
-static Type resolveNestedIdentTypeComponent(TypeResolution resolution,
-                                            GenericParamList *silParams,
-                                            Type parentTy,
-                                            SourceRange parentRange,
-                                            ComponentIdentTypeRepr *comp) {
+static Type resolveQualifiedIdentTypeRepr(TypeResolution resolution,
+                                          GenericParamList *silParams,
+                                          Type parentTy,
+                                          SourceRange parentRange,
+                                          IdentTypeRepr *repr) {
   const auto options = resolution.getOptions();
   auto DC = resolution.getDeclContext();
   auto &ctx = DC->getASTContext();
@@ -1714,13 +1709,13 @@ static Type resolveNestedIdentTypeComponent(TypeResolution resolution,
       return ErrorType::get(ctx);
 
     case TypeChecker::UnsupportedMemberTypeAccessKind::TypeAliasOfExistential:
-      diags.diagnose(comp->getNameLoc(), diag::typealias_outside_of_protocol,
-                     comp->getNameRef(), parentTy);
+      diags.diagnose(repr->getNameLoc(), diag::typealias_outside_of_protocol,
+                     repr->getNameRef(), parentTy);
       return ErrorType::get(ctx);
 
     case TypeChecker::UnsupportedMemberTypeAccessKind::AssociatedTypeOfExistential:
-      diags.diagnose(comp->getNameLoc(), diag::assoc_type_outside_of_protocol,
-                     comp->getNameRef(), parentTy);
+      diags.diagnose(repr->getNameLoc(), diag::assoc_type_outside_of_protocol,
+                     repr->getNameRef(), parentTy);
       return ErrorType::get(ctx);
     }
 
@@ -1738,30 +1733,29 @@ static Type resolveNestedIdentTypeComponent(TypeResolution resolution,
     // Diagnose a bad conformance reference if we need to.
     if (!options.contains(TypeResolutionFlags::SilenceErrors) &&
         inferredAssocType && memberType->hasError()) {
-      maybeDiagnoseBadConformanceRef(DC, parentTy, comp->getLoc(),
+      maybeDiagnoseBadConformanceRef(DC, parentTy, repr->getLoc(),
                                      inferredAssocType);
     }
 
     // If there are generic arguments, apply them now.
-    return applyGenericArguments(memberType, resolution,
-                                 silParams, comp);
+    return applyGenericArguments(memberType, resolution, silParams, repr);
   };
 
   // Short-circuiting.
-  if (comp->isInvalid()) return ErrorType::get(ctx);
+  if (repr->isInvalid()) return ErrorType::get(ctx);
 
   // If the parent is a type parameter, the member is a dependent member,
   // and we skip much of the work below.
   if (parentTy->isTypeParameter()) {
     if (auto memberType = resolution.resolveDependentMemberType(
-            parentTy, DC, parentRange, comp)) {
+            parentTy, DC, parentRange, repr)) {
       // Hack -- if we haven't resolved this to a declaration yet, don't
       // attempt to apply generic arguments, since this will emit a
       // diagnostic, and its possible that this type will become a concrete
       // type later on.
       if (!memberType->is<DependentMemberType>() ||
           memberType->castTo<DependentMemberType>()->getAssocType()) {
-        return applyGenericArguments(memberType, resolution, silParams, comp);
+        return applyGenericArguments(memberType, resolution, silParams, repr);
       }
 
       return memberType;
@@ -1769,14 +1763,14 @@ static Type resolveNestedIdentTypeComponent(TypeResolution resolution,
   }
 
   // Phase 2: If a declaration has already been bound, use it.
-  if (auto *typeDecl = comp->getBoundDecl()) {
+  if (auto *typeDecl = repr->getBoundDecl()) {
     auto memberType =
       TypeChecker::substMemberTypeWithBase(DC->getParentModule(), typeDecl,
                                            parentTy);
     return maybeDiagnoseBadMemberType(typeDecl, memberType, nullptr);
   }
 
-  // Phase 1: Find and bind the component decl.
+  // Phase 1: Find and bind the type declaration.
 
   // Look for member types with the given name.
   NameLookupOptions lookupOptions = defaultMemberLookupOptions;
@@ -1785,15 +1779,15 @@ static Type resolveNestedIdentTypeComponent(TypeResolution resolution,
   LookupTypeResult memberTypes;
   if (parentTy->mayHaveMembers())
     memberTypes = TypeChecker::lookupMemberType(
-        DC, parentTy, comp->getNameRef(), lookupOptions);
+        DC, parentTy, repr->getNameRef(), lookupOptions);
 
   // Name lookup was ambiguous. Complain.
   // FIXME: Could try to apply generic arguments first, and see whether
   // that resolves things. But do we really want that to succeed?
   if (memberTypes.size() > 1) {
     if (!options.contains(TypeResolutionFlags::SilenceErrors))
-      diagnoseAmbiguousMemberType(parentTy, parentRange, comp->getNameRef(),
-                                  comp->getNameLoc(), memberTypes);
+      diagnoseAmbiguousMemberType(parentTy, parentRange, repr->getNameRef(),
+                                  repr->getNameLoc(), memberTypes);
     return ErrorType::get(ctx);
   }
 
@@ -1807,16 +1801,16 @@ static Type resolveNestedIdentTypeComponent(TypeResolution resolution,
     if (options.contains(TypeResolutionFlags::SilenceErrors))
       return ErrorType::get(ctx);
 
-    memberType = diagnoseUnknownType(resolution, parentTy, parentRange, comp,
+    memberType = diagnoseUnknownType(resolution, parentTy, parentRange, repr,
                                      lookupOptions);
-    member = comp->getBoundDecl();
+    member = repr->getBoundDecl();
     if (!member)
       return ErrorType::get(ctx);
   } else {
     memberType = memberTypes.back().MemberType;
     member = memberTypes.back().Member;
     inferredAssocType = memberTypes.back().InferredAssociatedType;
-    comp->setValue(member, nullptr);
+    repr->setValue(member, nullptr);
   }
 
   return maybeDiagnoseBadMemberType(member, memberType, inferredAssocType);
@@ -2198,7 +2192,7 @@ NeverNullType TypeResolver::resolveType(TypeRepr *repr,
   case TypeReprKind::SimpleIdent:
   case TypeReprKind::GenericIdent:
   case TypeReprKind::Member: {
-    return resolveDeclRefTypeRepr(cast<DeclRefTypeRepr>(repr), options);
+      return resolveDeclRefTypeRepr(cast<DeclRefTypeRepr>(repr), options);
   }
 
   case TypeReprKind::Function: {
@@ -3808,10 +3802,10 @@ TypeResolver::resolveDeclRefTypeRepr(DeclRefTypeRepr *repr,
   Type result;
 
   auto *baseComp = repr->getBaseComponent();
-  if (auto *identBase = dyn_cast<ComponentIdentTypeRepr>(baseComp)) {
+  if (auto *identBase = dyn_cast<IdentTypeRepr>(baseComp)) {
     // The base component uses unqualified lookup.
-    result = resolveTopLevelIdentTypeComponent(resolution.withOptions(options),
-                                               genericParams, identBase);
+    result = resolveUnqualifiedIdentTypeRepr(resolution.withOptions(options),
+                                             genericParams, identBase);
   } else {
     result = resolveType(baseComp, options);
   }
@@ -3823,9 +3817,9 @@ TypeResolver::resolveDeclRefTypeRepr(DeclRefTypeRepr *repr,
   if (auto *memberTR = dyn_cast<MemberTypeRepr>(repr)) {
     SourceRange parentRange = baseComp->getSourceRange();
     for (auto *nestedComp : memberTR->getMemberComponents()) {
-      result = resolveNestedIdentTypeComponent(resolution.withOptions(options),
-                                               genericParams, result,
-                                               parentRange, nestedComp);
+      result = resolveQualifiedIdentTypeRepr(resolution.withOptions(options),
+                                             genericParams, result, parentRange,
+                                             nestedComp);
       if (result->hasError())
         return ErrorType::get(result->getASTContext());
 
@@ -4784,7 +4778,7 @@ public:
     }
   }
 
-  void visitComponentIdentTypeRepr(ComponentIdentTypeRepr *T) {
+  void visitIdentTypeRepr(IdentTypeRepr *T) {
     if (T->isInvalid())
       return;
 

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -26,7 +26,7 @@ namespace swift {
 
 class ASTContext;
 class TypeRepr;
-class ComponentIdentTypeRepr;
+class IdentTypeRepr;
 class GenericEnvironment;
 class GenericSignature;
 
@@ -602,7 +602,7 @@ public:
   /// name.
   Type resolveDependentMemberType(Type baseTy, DeclContext *DC,
                                   SourceRange baseRange,
-                                  ComponentIdentTypeRepr *ref) const;
+                                  IdentTypeRepr *repr) const;
 
   /// Determine whether the given two types are equivalent within this
   /// type resolution context.

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -474,14 +474,14 @@ namespace {
         : dc(dc), params(params) {}
 
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-      if (auto *declRefTR = dyn_cast<DeclRefTypeRepr>(T)) {
-      if (auto *base =
-              dyn_cast<ComponentIdentTypeRepr>(declRefTR->getBaseComponent())) {
-        auto name = base->getNameRef().getBaseIdentifier();
+    if (auto *declRefTR = dyn_cast<DeclRefTypeRepr>(T)) {
+      if (auto *identBase =
+              dyn_cast<IdentTypeRepr>(declRefTR->getBaseComponent())) {
+        auto name = identBase->getNameRef().getBaseIdentifier();
         if (auto *paramDecl = params->lookUpGenericParam(name))
-          base->setValue(paramDecl, dc);
+          identBase->setValue(paramDecl, dc);
       }
-      }
+    }
 
       return Action::Continue();
     }

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -475,10 +475,12 @@ namespace {
 
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
       if (auto *ident = dyn_cast<IdentTypeRepr>(T)) {
-        auto firstComponent = ident->getComponentRange().front();
-        auto name = firstComponent->getNameRef().getBaseIdentifier();
+      if (auto *base =
+              dyn_cast<ComponentIdentTypeRepr>(ident->getBaseComponent())) {
+        auto name = base->getNameRef().getBaseIdentifier();
         if (auto *paramDecl = params->lookUpGenericParam(name))
-          firstComponent->setValue(paramDecl, dc);
+          base->setValue(paramDecl, dc);
+      }
       }
 
       return Action::Continue();

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -474,9 +474,9 @@ namespace {
         : dc(dc), params(params) {}
 
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
-      if (auto *ident = dyn_cast<IdentTypeRepr>(T)) {
+      if (auto *declRefTR = dyn_cast<DeclRefTypeRepr>(T)) {
       if (auto *base =
-              dyn_cast<ComponentIdentTypeRepr>(ident->getBaseComponent())) {
+              dyn_cast<ComponentIdentTypeRepr>(declRefTR->getBaseComponent())) {
         auto name = base->getNameRef().getBaseIdentifier();
         if (auto *paramDecl = params->lookUpGenericParam(name))
           base->setValue(paramDecl, dc);

--- a/test/AutoDiff/Parse/differentiable_func_type.swift
+++ b/test/AutoDiff/Parse/differentiable_func_type.swift
@@ -14,13 +14,10 @@ let c: @differentiable(reverse) (Float, @noDerivative Float) -> Float // okay
 // CHECK-NEXT: (type_attributed attrs=@differentiable(reverse)
 // CHECK-NEXT:  (type_function
 // CHECK-NEXT:    (type_tuple
-// CHECK-NEXT:      (type_ident
-// CHECK-NEXT:        (component id='Float' bind=none))
+// CHECK-NEXT:      (type_ident id='Float' bind=none)
 // CHECK-NEXT:      (type_attributed attrs=@noDerivative
-// CHECK-NEXT:        (type_ident
-// CHECK-NEXT:          (component id='Float' bind=none)))
-// CHECK-NEXT:    (type_ident
-// CHECK-NEXT:      (component id='Float' bind=none)))))
+// CHECK-NEXT:        (type_ident id='Float' bind=none))
+// CHECK-NEXT:    (type_ident id='Float' bind=none))))
 
 let d: @differentiable(reverse) (Float) throws -> Float // okay
 // CHECK: (pattern_named 'd'

--- a/test/Frontend/dump-parse.swift
+++ b/test/Frontend/dump-parse.swift
@@ -115,8 +115,7 @@ struct SelfParam {
   // CHECK-NEXT:    (parameter_list range=[{{.+}}])
   // CHECK-NEXT:    (result
   // CHECK-NEXT:      (type_optional
-  // CHECK-NEXT:        (type_ident
-  // CHECK-NEXT:          (component id='SelfParam' bind=none))))
+  // CHECK-NEXT:        (type_ident id='SelfParam' bind=none)))
   static func createOptional() -> SelfParam? {
 
     // CHECK-LABEL: (call_expr type='<null>'
@@ -125,3 +124,12 @@ struct SelfParam {
     SelfParam()
   }
 }
+
+// CHECK-LABEL: (func_decl range=[{{.+}}] "dumpMemberTypeRepr()"
+// CHECK-NEXT:    (parameter_list range=[{{.+}}])
+// CHECK-NEXT:    (result
+// CHECK-NEXT:      (type_member
+// CHECK-NEXT:        (type_ident id='Array' bind=none)
+// CHECK-NEXT:          (type_ident id='Bool' bind=none)
+// CHECK-NEXT:        (type_ident id='Element' bind=none)))
+func dumpMemberTypeRepr() -> Array<Bool>.Element { true }

--- a/test/Frontend/module-alias-dump-ast.swift
+++ b/test/Frontend/module-alias-dump-ast.swift
@@ -16,7 +16,7 @@
 // CHECK-AST-NOT: bind=XLogging
 // CHECK-AST-NOT: module<XLogging>
 // CHECK-AST-NOT: decl=XLogging
-// CHECK-AST: component id='XLogging' bind=AppleLogging
+// CHECK-AST: type_ident id='XLogging' bind=AppleLogging
 // CHECK-AST: module<AppleLogging>
 // CHECK-AST: decl=AppleLogging
 

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -874,3 +874,10 @@ func testSkipToFindOpenBrace1() {
 func testSkipToFindOpenBrace2() {
   do { if true {} else false } // expected-error {{expected '{' or 'if' after 'else'}}
 }
+
+struct Outer {
+  struct Inner<T> {}
+}
+extension Outer.Inner<Never> { // expected-note {{in extension of 'Outer.Inner<Never>'}}
+  @someAttr
+} // expected-error {{expected declaration}}

--- a/test/SourceKit/SyntaxMapData/syntaxmap-edit-del.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-edit-del.swift.response
@@ -83,7 +83,7 @@
           key.column: 8,
           key.filepath: syntaxmap-edit-del.swift,
           key.severity: source.diagnostic.severity.note,
-          key.id: "note_in_decl_extension",
+          key.id: "note_in_decl_of",
           key.description: "in declaration of 'Foo'"
         }
       ]


### PR DESCRIPTION
Silly example: `[Int].Element`. This patch simply paves the way — no functional changes except for that one diagnostic. Beside tackling the edge case of sugared qualifiers, this will later allow us to diagnose illegal type qualification in Sema and lay the foundation for expressing structural qualifiers in the future if the need arises.
 
Partially resolves https://github.com/apple/swift/issues/59923