### PR TITLE
[TypeLowering] Define "copy into" for opaque vals.

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -43,6 +43,15 @@
 using namespace swift;
 using namespace Lowering;
 
+// Necessary to straightforwardly write SIL tests that exercise
+// OpaqueValueTypeLowering (and MoveOnlyOpaqueValueTypeLowering): the tests can
+// be written as though opaque values were enabled to begin but have since been
+// lowered out of.
+llvm::cl::opt<bool> TypeLoweringForceOpaqueValueLowering(
+    "type-lowering-force-opaque-value-lowering", llvm::cl::init(false),
+    llvm::cl::desc("Force TypeLowering to behave as if building with opaque "
+                   "values enabled"));
+
 namespace {
   /// A CRTP type visitor for deciding whether the metatype for a type
   /// is a singleton type, i.e. whether there can only ever be one
@@ -2066,7 +2075,8 @@ namespace {
 
     TypeLowering *handleMoveOnlyAddressOnly(CanType type,
                                             RecursiveProperties properties) {
-      if (!TC.Context.SILOpts.EnableSILOpaqueValues) {
+      if (!TC.Context.SILOpts.EnableSILOpaqueValues &&
+          !TypeLoweringForceOpaqueValueLowering) {
         auto silType = SILType::getPrimitiveAddressType(type);
         return new (TC)
             MoveOnlyAddressOnlyTypeLowering(silType, properties, Expansion);
@@ -2084,7 +2094,8 @@ namespace {
 
     TypeLowering *handleAddressOnly(CanType type,
                                     RecursiveProperties properties) {
-      if (!TC.Context.SILOpts.EnableSILOpaqueValues) {
+      if (!TC.Context.SILOpts.EnableSILOpaqueValues &&
+          !TypeLoweringForceOpaqueValueLowering) {
         auto silType = SILType::getPrimitiveAddressType(type);
         return new (TC) AddressOnlyTypeLowering(silType, properties,
                                                            Expansion);

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -1950,7 +1950,12 @@ namespace {
     void emitCopyInto(SILBuilder &B, SILLocation loc,
                       SILValue src, SILValue dest, IsTake_t isTake,
                       IsInitialization_t isInit) const override {
-      llvm_unreachable("copy into");
+      if (B.getModule().useLoweredAddresses()) {
+        B.createCopyAddr(loc, src, dest, isTake, isInit);
+      } else {
+        SILValue value = emitLoadOfCopy(B, loc, src, isTake);
+        emitStoreOfCopy(B, loc, value, dest, isInit);
+      }
     }
 
     // OpaqueValue store cannot be decoupled from a destroy because it is not

--- a/test/SILOptimizer/constant_propagation_casts_opaque_lowered.sil
+++ b/test/SILOptimizer/constant_propagation_casts_opaque_lowered.sil
@@ -1,0 +1,22 @@
+// RUN: %target-sil-opt -enable-sil-verify-all %s -address-lowering -diagnostic-constant-propagation -type-lowering-force-opaque-value-lowering | %FileCheck %s
+sil_stage canonical
+
+struct G<T> {
+    var t: T
+}
+
+// CHECK-LABEL: sil [ossa] @checked_cast_same_type : {{.*}} {
+// CHECK:         copy_addr [take]
+// CHECK-LABEL: } // end sil function 'checked_cast_same_type'
+sil [ossa] @checked_cast_same_type : $@convention(thin) <T> () -> () {
+  %addr_src = alloc_stack $G<T>
+  %addr_dest = alloc_stack $G<T>
+  apply undef<T>(%addr_src) : $@convention(thin) <U> () -> @out G<U>
+  unconditional_checked_cast_addr G<T> in %addr_src : $*G<T> to G<T> in %addr_dest : $*G<T>
+  apply undef<T>(%addr_dest) : $@convention(thin) <U> (@in_guaranteed G<U>) -> ()
+  destroy_addr %addr_dest : $*G<T>
+  dealloc_stack %addr_dest : $*G<T>
+  dealloc_stack %addr_src : $*G<T>
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
When building with opaque values enable, types which would otherwise get AddressOnlyTypeLowering instead get OpaqueValueTypeLowering.  When such types need to be copied into an address, the emitCopyInto method gets called on the OpaqueValueTypeLowering.  So it must be implemented.

Additionally, vary its implementation based on whether the module is address-lowered.  If it's not address-lowered, emit a copy-into as if the type were loadable.  If it is address-lowered, emit a copy-into as if the type were address-only.
