### PR TITLE
[SILDebugScope] Only print under !NDEBUG.

### DIFF
--- a/include/swift/SIL/SILDebugScope.h
+++ b/include/swift/SIL/SILDebugScope.h
@@ -88,10 +88,12 @@ public:
     return callSite;
   }
 
+#ifndef NDEBUG
   void print(SourceManager &SM, llvm::raw_ostream &OS = llvm::errs(),
              unsigned Indent = 0) const;
 
   void print(SILModule &Mod) const;
+#endif
 };
 
 /// Determine whether an instruction may not have a SILDebugScope.

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5845,12 +5845,16 @@ public:
       if (DS != LastSeenScope) {
         llvm::errs() << "Broken instruction!\n"; 
         SI.dump();
+#ifndef NDEBUG
         llvm::errs() << "in scope\n";
         DS->print(SI.getFunction()->getModule());
+#endif
         llvm::errs() << "Previous, non-contiguous scope set by";
         LastSeenScopeInst->dump();
+#ifndef NDEBUG
         llvm::errs() << "in scope\n";
         LastSeenScope->print(SI.getFunction()->getModule());
+#endif
         llvm::errs() << "Please report a bug on bugs.swift.org\n";
         llvm::errs() <<
           "Pass -Xllvm -verify-di-holes=false to disable the verification\n";


### PR DESCRIPTION
Guard calls to `SILDebugScope::print` with `#ifndef NDEBUG` and fix the header to only make those methods be available under debug.

