### PR TITLE
[Build] Build host libraries into toolchain's lib/swift/host as shared libraries

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -569,7 +569,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
 
   if(SWIFT_SWIFT_PARSER)
     # Make sure we can find the early SwiftSyntax libraries.
-    target_link_directories(${target} PRIVATE "${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/lib")
+    target_link_directories(${target} PRIVATE "${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/lib/swift/host")
 
     # For the "end step" of bootstrapping configurations on Darwin, need to be
     # able to fall back to the SDK directory for libswiftCore et al.

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -914,7 +914,7 @@ function(add_swift_host_tool executable)
   if(SWIFT_SWIFT_PARSER)
     set_property(
       TARGET ${executable}
-      APPEND PROPERTY INSTALL_RPATH "@executable_path/../lib")
+      APPEND PROPERTY INSTALL_RPATH "@executable_path/../lib/swift/host")
   endif()
 
   if(ASHT_THINLTO_LD64_ADD_FLTO_CODEGEN_ONLY)

--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -912,9 +912,17 @@ function(add_swift_host_tool executable)
   endif()
 
   if(SWIFT_SWIFT_PARSER)
+    set(extra_relative_rpath "")
+    if(NOT ${ASHT_BOOTSTRAPPING} STREQUAL "")
+      if (${executable} MATCHES "-bootstrapping")
+        set(extra_relative_rpath "../")
+      endif()
+    endif()
+
     set_property(
       TARGET ${executable}
-      APPEND PROPERTY INSTALL_RPATH "@executable_path/../lib/swift/host")
+      APPEND PROPERTY INSTALL_RPATH
+        "@executable_path/../${extra_relative_rpath}lib/swift/host")
   endif()
 
   if(ASHT_THINLTO_LD64_ADD_FLTO_CODEGEN_ONLY)

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -87,7 +87,7 @@ if (SWIFT_SWIFT_PARSER)
   )
 
   target_include_directories(swiftASTGen PUBLIC
-    "${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/swift")
+    "${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/lib/swift/host")
 
   set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS swiftASTGen)
 endif()

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -114,8 +114,24 @@ if (SWIFT_SWIFT_PARSER)
     )
   endforeach()
 
+  # Copy all of the Swift modules from earlyswiftsyntax so they can be found
+  # in the same relative place within the build directory as in the final
+  # toolchain.
+  list(TRANSFORM SWIFT_SYNTAX_MODULES APPEND ".swiftmodule"
+       OUTPUT_VARIABLE SWIFT_SYNTAX_MODULE_DIRS)
+  foreach(module_dir ${SWIFT_SYNTAX_MODULE_DIRS})
+    file(GLOB module_files
+         "${SWIFT_SYNTAX_LIBRARIES_SOURCE_DIR}/${module_dir}/*.swift*")
+    add_custom_command(
+      TARGET swiftASTGen PRE_BUILD
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${SWIFT_SYNTAX_LIBRARIES_DEST_DIR}/${module_dir}
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${module_files} ${SWIFT_SYNTAX_LIBRARIES_DEST_DIR}/${module_dir}/
+      COMMENT "Copying ${module_dir}"
+    )
+  endforeach()
+
   target_include_directories(swiftASTGen PUBLIC
-    "${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/lib/swift/host")
+    ${SWIFT_SYNTAX_LIBRARIES_DEST_DIR})
 
   set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS swiftASTGen)
 endif()

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -51,11 +51,8 @@ if (SWIFT_SWIFT_PARSER)
     cmake_parse_arguments(ARGS "" "" "PUBLIC" ${ARGN})
 
     foreach(DEPENDENCY ${ARGS_PUBLIC})
-      # This is a hack to workaround a cmake bug that results in multiple ninja targets producing
-      # the same file in a downstream SourceKit target. This should use `PUBLIC`, the dependency
-      # directly (rather than `TARGET_OBJECTS`), and no `add_dependencies`.
       target_link_libraries(${TARGET} PRIVATE
-       $<TARGET_OBJECTS:${DEPENDENCY}>
+        ${DEPENDENCY}
       )
       add_dependencies(${TARGET} ${DEPENDENCY})
 
@@ -69,22 +66,53 @@ if (SWIFT_SWIFT_PARSER)
     endforeach()
   endfunction()
 
+  set(SWIFT_SYNTAX_MODULES
+    SwiftBasicFormat
+    SwiftParser
+    SwiftParserDiagnostics
+    SwiftDiagnostics
+    SwiftSyntax
+    SwiftOperators
+    SwiftSyntaxBuilder
+    _SwiftSyntaxMacros
+    SwiftCompilerSupport
+  )
+
+  # Compute the list of SwiftSyntax targets
+  list(TRANSFORM SWIFT_SYNTAX_MODULES PREPEND "SwiftSyntax::"
+       OUTPUT_VARIABLE SWIFT_SYNTAX_TARGETS)
+
   # TODO: Change to target_link_libraries when cmake is fixed
   force_target_link_libraries(swiftASTGen PUBLIC
-    SwiftSyntax::SwiftBasicFormat
-    SwiftSyntax::SwiftParser
-    SwiftSyntax::SwiftParserDiagnostics
-    SwiftSyntax::SwiftDiagnostics
-    SwiftSyntax::SwiftSyntax
-    SwiftSyntax::SwiftOperators
-    SwiftSyntax::SwiftSyntaxBuilder
-    SwiftSyntax::_SwiftSyntaxMacros
-    SwiftSyntax::SwiftCompilerSupport
+    ${SWIFT_SYNTAX_TARGETS}
   )
   target_link_libraries(swiftASTGen PUBLIC
     swiftAST
     swift_CompilerPluginSupport
   )
+
+  set(SWIFT_SYNTAX_LIBRARIES_SOURCE_DIR
+      "${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/lib/swift/host")
+  set(SWIFT_SYNTAX_LIBRARIES_DEST_DIR
+      "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/swift/host")
+
+  # Determine the SwiftSyntax shared library files that were built as
+  # part of earlyswiftsyntax.
+  list(TRANSFORM SWIFT_SYNTAX_MODULES PREPEND ${CMAKE_SHARED_LIBRARY_PREFIX}
+       OUTPUT_VARIABLE SWIFT_SYNTAX_SHARED_LIBRARIES)
+  list(TRANSFORM SWIFT_SYNTAX_SHARED_LIBRARIES APPEND
+       ${CMAKE_SHARED_LIBRARY_SUFFIX}
+       OUTPUT_VARIABLE SWIFT_SYNTAX_SHARED_LIBRARIES)
+
+  # Copy over all of the shared libraries from earlyswiftsyntax so they can
+  # be found via RPATH.
+  foreach (sharedlib ${SWIFT_SYNTAX_SHARED_LIBRARIES})
+    add_custom_command(
+      TARGET swiftASTGen PRE_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SWIFT_SYNTAX_LIBRARIES_SOURCE_DIR}/${sharedlib} ${SWIFT_SYNTAX_LIBRARIES_DEST_DIR}/${sharedlib}
+      COMMENT "Copying ${sharedlib}"
+    )
+  endforeach()
 
   target_include_directories(swiftASTGen PUBLIC
     "${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/lib/swift/host")

--- a/lib/CompilerPluginSupport/CMakeLists.txt
+++ b/lib/CompilerPluginSupport/CMakeLists.txt
@@ -18,6 +18,12 @@ if(SWIFT_SWIFT_PARSER)
   add_library("${library_name}" SHARED
     CompilerPluginSupport.swift)
 
+  set_target_properties(${library_name}
+    PROPERTIES
+      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/swift/host"
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib/swift/host"
+  )
+
   if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
     set(DEPLOYMENT_VERSION "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_DEPLOYMENT_VERSION}")
   endif()
@@ -28,7 +34,7 @@ if(SWIFT_SWIFT_PARSER)
 
   # Determine the Swift module path
   set(module_triple ${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_MODULE})
-  set(module_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+  set(module_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/swift/host")
   set(module_base "${module_dir}/${module_name}.swiftmodule")
   set(module_file "${module_base}/${module_triple}.swiftmodule")
   set(module_interface_file "${module_base}/${module_triple}.swiftinterface")
@@ -82,17 +88,17 @@ if(SWIFT_SWIFT_PARSER)
       DESTINATION "bin"
       COMPONENT compiler
     FRAMEWORK
-      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
+      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host"
       COMPONENT compiler
     LIBRARY
-      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
+      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host"
       COMPONENT compiler
     ARCHIVE
-      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}"
+      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host"
       COMPONENT compiler)
 
     swift_install_in_component(DIRECTORY "${module_base}"
-                               DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift"
+                               DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host"
                                COMPONENT compiler)
 
     set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${library_name})

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -38,15 +38,15 @@ if (SWIFT_SWIFT_PARSER)
   #   )
   target_link_libraries(swiftParse
     PRIVATE
-    $<TARGET_OBJECTS:SwiftSyntax::SwiftBasicFormat>
-    $<TARGET_OBJECTS:SwiftSyntax::SwiftParser>
-    $<TARGET_OBJECTS:SwiftSyntax::SwiftParserDiagnostics>
-    $<TARGET_OBJECTS:SwiftSyntax::SwiftDiagnostics>
-    $<TARGET_OBJECTS:SwiftSyntax::SwiftSyntax>
-    $<TARGET_OBJECTS:SwiftSyntax::SwiftOperators>
-    $<TARGET_OBJECTS:SwiftSyntax::SwiftSyntaxBuilder>
-    $<TARGET_OBJECTS:SwiftSyntax::_SwiftSyntaxMacros>
-    $<TARGET_OBJECTS:SwiftSyntax::SwiftCompilerSupport>
+    SwiftSyntax::SwiftBasicFormat
+    SwiftSyntax::SwiftParser
+    SwiftSyntax::SwiftParserDiagnostics
+    SwiftSyntax::SwiftDiagnostics
+    SwiftSyntax::SwiftSyntax
+    SwiftSyntax::SwiftOperators
+    SwiftSyntax::SwiftSyntaxBuilder
+    SwiftSyntax::_SwiftSyntaxMacros
+    SwiftSyntax::SwiftCompilerSupport
     $<TARGET_OBJECTS:swiftASTGen>
   )
 

--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -48,9 +48,8 @@
 // RUN: %empty-directory(%t/DISTINCTIVE-PATH/usr/bin/)
 // RUN: %empty-directory(%t/DISTINCTIVE-PATH/usr/lib/)
 // RUN: %hardlink-or-copy(from: %swift_frontend_plain, to: %t/DISTINCTIVE-PATH/usr/bin/swiftc)
-// RUN: %copy-plugin-support-library(%t/DISTINCTIVE-PATH/usr/lib/)
 // RUN: ln -s "swiftc" %t/DISTINCTIVE-PATH/usr/bin/swift-update
-// RUN: %t/DISTINCTIVE-PATH/usr/bin/swiftc -driver-print-jobs -c -update-code -target x86_64-apple-macosx10.9 %s 2>&1 > %t.upd.txt
+// RUN: %host-library-env %t/DISTINCTIVE-PATH/usr/bin/swiftc -driver-print-jobs -c -update-code -target x86_64-apple-macosx10.9 %s 2>&1 > %t.upd.txt
 // RUN: %FileCheck -check-prefix UPDATE-CODE %s < %t.upd.txt
 // Clean up the test executable because hard links are expensive.
 // RUN: rm -rf %t/DISTINCTIVE-PATH/usr/bin/swiftc

--- a/test/Driver/linker-clang_rt.swift
+++ b/test/Driver/linker-clang_rt.swift
@@ -8,33 +8,32 @@
 // RUN: %empty-directory(%t/bin)
 // RUN: %empty-directory(%t/lib)
 // RUN: %hardlink-or-copy(from: %swift_frontend_plain, to: %t/bin/swiftc)
-// RUN: %copy-plugin-support-library(%t/lib/)
 // RUN: %empty-directory(%t/lib/swift/clang/lib/darwin/)
 
 // RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-NO-RUNTIME %s
 
 // RUN: touch %t/lib/swift/clang/lib/darwin/libclang_rt.osx.a %t/lib/swift/clang/lib/darwin/libclang_rt.ios.a %t/lib/swift/clang/lib/darwin/libclang_rt.iossim.a %t/lib/swift/clang/lib/darwin/libclang_rt.tvos.a %t/lib/swift/clang/lib/darwin/libclang_rt.tvossim.a %t/lib/swift/clang/lib/darwin/libclang_rt.watchos.a %t/lib/swift/clang/lib/darwin/libclang_rt.watchossim.a
 
-// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-MACOS %s
-// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-ios13.1-macabi %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-MACCATALYST %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-MACOS %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target x86_64-apple-ios13.1-macabi %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-MACCATALYST %s
 
-// RUN: %t/bin/swiftc -driver-print-jobs -target i386-apple-ios7-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-IOSSIM %s
-// RUN: %t/bin/swiftc -driver-print-jobs -target i386-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-IOSSIM %s
-// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-ios7-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-IOSSIM %s
-// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-IOSSIM %s
-// RUN: %t/bin/swiftc -driver-print-jobs -target armv7s-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-IOS %s
-// RUN: %t/bin/swiftc -driver-print-jobs -target arm64-apple-ios7-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-IOSSIM %s
-// RUN: %t/bin/swiftc -driver-print-jobs -target arm64-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-IOS %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target i386-apple-ios7-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-IOSSIM %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target i386-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-IOSSIM %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target x86_64-apple-ios7-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-IOSSIM %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target x86_64-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-IOSSIM %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target armv7s-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-IOS %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target arm64-apple-ios7-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-IOSSIM %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target arm64-apple-ios7 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-IOS %s
 
-// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-tvos9-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-TVOSSIM %s
-// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-tvos9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-TVOSSIM %s
-// RUN: %t/bin/swiftc -driver-print-jobs -target arm64-apple-tvos9-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-TVOSSIM %s
-// RUN: %t/bin/swiftc -driver-print-jobs -target arm64-apple-tvos9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-TVOS %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target x86_64-apple-tvos9-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-TVOSSIM %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target x86_64-apple-tvos9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-TVOSSIM %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target arm64-apple-tvos9-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-TVOSSIM %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target arm64-apple-tvos9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-TVOS %s
 
-// RUN: %t/bin/swiftc -driver-print-jobs -target i386-apple-watchos2-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-WATCHOSSIM %s
-// RUN: %t/bin/swiftc -driver-print-jobs -target i386-apple-watchos2 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-WATCHOSSIM %s
-// RUN: %t/bin/swiftc -driver-print-jobs -target armv7k-apple-watchos2 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-WATCHOS %s
-// RUN: %t/bin/swiftc -driver-print-jobs -target arm64-apple-watchos2-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-WATCHOSSIM %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target i386-apple-watchos2-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-WATCHOSSIM %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target i386-apple-watchos2 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-WATCHOSSIM %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target armv7k-apple-watchos2 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-WATCHOS %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target arm64-apple-watchos2-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-WATCHOSSIM %s
 
 // Clean up the test executable because hard links are expensive.
 // RUN: rm -f %t/bin/swiftc

--- a/test/Driver/linker-clang_rt.swift
+++ b/test/Driver/linker-clang_rt.swift
@@ -10,7 +10,7 @@
 // RUN: %hardlink-or-copy(from: %swift_frontend_plain, to: %t/bin/swiftc)
 // RUN: %empty-directory(%t/lib/swift/clang/lib/darwin/)
 
-// RUN: %t/bin/swiftc -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-NO-RUNTIME %s
+// RUN: %host-library-env %t/bin/swiftc -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck -check-prefix CHECK -check-prefix CHECK-NO-RUNTIME %s
 
 // RUN: touch %t/lib/swift/clang/lib/darwin/libclang_rt.osx.a %t/lib/swift/clang/lib/darwin/libclang_rt.ios.a %t/lib/swift/clang/lib/darwin/libclang_rt.iossim.a %t/lib/swift/clang/lib/darwin/libclang_rt.tvos.a %t/lib/swift/clang/lib/darwin/libclang_rt.tvossim.a %t/lib/swift/clang/lib/darwin/libclang_rt.watchos.a %t/lib/swift/clang/lib/darwin/libclang_rt.watchossim.a
 

--- a/test/Driver/options-repl-darwin.swift
+++ b/test/Driver/options-repl-darwin.swift
@@ -19,7 +19,7 @@
 // RUN: %empty-directory(%t/Toolchains/Test.xctoolchain/usr/bin)
 // RUN: %empty-directory(%t/Toolchains/Test.xctoolchain/usr/lib)
 // RUN: mv %t/usr/bin/swift %t/Toolchains/Test.xctoolchain/usr/bin/swift
-// RUN: %t/Toolchains/Test.xctoolchain/usr/bin/swift -repl -### | %FileCheck -check-prefix=LLDB %s
+// RUN: %host-library-env %t/Toolchains/Test.xctoolchain/usr/bin/swift -repl -### | %FileCheck -check-prefix=LLDB %s
 
 // Clean up the test executable because hard links are expensive.
 // RUN: rm -rf %t/Toolchains/Test.xctoolchain/usr/bin/swift

--- a/test/Driver/options-repl-darwin.swift
+++ b/test/Driver/options-repl-darwin.swift
@@ -7,20 +7,18 @@
 // RUN: %empty-directory(%t/usr/bin/)
 // RUN: %empty-directory(%t/usr/lib/)
 // RUN: %hardlink-or-copy(from: %swift_driver_plain, to: %t/usr/bin/swift)
-// RUN: %copy-plugin-support-library(%t/usr/lib/)
 
-// RUN: %t/usr/bin/swift -repl -### | %FileCheck -check-prefix=INTEGRATED %s
-// RUN: %t/usr/bin/swift -### | %FileCheck -check-prefix=INTEGRATED %s
+// RUN: %host-library-env %t/usr/bin/swift -repl -### | %FileCheck -check-prefix=INTEGRATED %s
+// RUN: %host-library-env %t/usr/bin/swift -### | %FileCheck -check-prefix=INTEGRATED %s
 
 // RUN: touch %t/usr/bin/lldb
 // RUN: chmod +x %t/usr/bin/lldb
-// RUN: %t/usr/bin/swift -repl -### | %FileCheck -check-prefix=LLDB %s
-// RUN: %t/usr/bin/swift -### | %FileCheck -check-prefix=LLDB %s
+// RUN: %host-library-env %t/usr/bin/swift -repl -### | %FileCheck -check-prefix=LLDB %s
+// RUN: %host-library-env %t/usr/bin/swift -### | %FileCheck -check-prefix=LLDB %s
 
 // RUN: %empty-directory(%t/Toolchains/Test.xctoolchain/usr/bin)
 // RUN: %empty-directory(%t/Toolchains/Test.xctoolchain/usr/lib)
 // RUN: mv %t/usr/bin/swift %t/Toolchains/Test.xctoolchain/usr/bin/swift
-// RUN: %copy-plugin-support-library(%t/Toolchains/Test.xctoolchain/usr/lib/)
 // RUN: %t/Toolchains/Test.xctoolchain/usr/bin/swift -repl -### | %FileCheck -check-prefix=LLDB %s
 
 // Clean up the test executable because hard links are expensive.

--- a/test/Driver/options-repl.swift
+++ b/test/Driver/options-repl.swift
@@ -8,10 +8,9 @@
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/usr/bin
 // RUN: mkdir -p %t/usr/lib
-// RUN: %copy-plugin-support-library(%t/usr/lib/)
 // RUN: %hardlink-or-copy(from: %swift_frontend_plain, to: %t/usr/bin/swift)
 
-// RUN: %t/usr/bin/swift -sdk "" -deprecated-integrated-repl -### | %FileCheck -check-prefix=INTEGRATED %s
+// RUN: %host-library-env %t/usr/bin/swift -sdk "" -deprecated-integrated-repl -### | %FileCheck -check-prefix=INTEGRATED %s
 
 // INTEGRATED: swift{{c?(\.exe)?"?}} -frontend -repl
 // INTEGRATED: -module-name REPL
@@ -46,10 +45,10 @@
 // like the Xcode installation environment. We use hard links to make sure
 // the Swift driver really thinks it's been moved.
 
-// RUN: %t/usr/bin/swift -sdk "" -repl -### | %FileCheck -check-prefix=INTEGRATED %s
-// RUN: %t/usr/bin/swift -sdk "" -### | %FileCheck -check-prefix=INTEGRATED %s
+// RUN: %host-library-env %t/usr/bin/swift -sdk "" -repl -### | %FileCheck -check-prefix=INTEGRATED %s
+// RUN: %host-library-env %t/usr/bin/swift -sdk "" -### | %FileCheck -check-prefix=INTEGRATED %s
 
 // RUN: touch %t/usr/bin/lldb
 // RUN: chmod +x %t/usr/bin/lldb
-// RUN: %t/usr/bin/swift -sdk "" -repl -### | %FileCheck -check-prefix=LLDB %s
-// RUN: %t/usr/bin/swift -sdk "" -### | %FileCheck -check-prefix=LLDB %s
+// RUN: %host-library-env %t/usr/bin/swift -sdk "" -repl -### | %FileCheck -check-prefix=LLDB %s
+// RUN: %host-library-env %t/usr/bin/swift -sdk "" -### | %FileCheck -check-prefix=LLDB %s

--- a/test/Driver/subcommands.swift
+++ b/test/Driver/subcommands.swift
@@ -5,10 +5,9 @@
 // RUN: mkdir -p %t.dir/usr/bin
 // RUN: mkdir -p %t.dir/usr/lib
 // RUN: %hardlink-or-copy(from: %swift_frontend_plain, to: %t.dir/usr/bin/swift)
-// RUN: %copy-plugin-support-library(%t.dir/usr/lib/)
 
-// RUN: %t.dir/usr/bin/swift -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-REPL %s
-// RUN: %t.dir/usr/bin/swift repl -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-REPL %s
+// RUN: %host-library-env %t.dir/usr/bin/swift -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-REPL %s
+// RUN: %host-library-env %t.dir/usr/bin/swift repl -### 2>&1 | %FileCheck -check-prefix=CHECK-SWIFT-INVOKES-REPL %s
 
 // CHECK-SWIFT-INVOKES-REPL: {{.*}}/swift{{.*}} -repl
 

--- a/test/Driver/windows-link-job.swift
+++ b/test/Driver/windows-link-job.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t/DISTINCTIVE-WINDOWS-PATH/usr/bin)
 // RUN: %empty-directory(%t/DISTINCTIVE-WINDOWS-PATH/usr/lib)
 // RUN: %hardlink-or-copy(from: %swift_frontend_plain, to: %t/DISTINCTIVE-WINDOWS-PATH/usr/bin/swiftc)
-// RUN: %copy-plugin-support-library(%t/DISTINCTIVE-WINDOWS-PATH/usr/lib/)
-// RUN: env PATH= %t/DISTINCTIVE-WINDOWS-PATH/usr/bin/swiftc -target x86_64-unknown-windows-msvc -### -module-name link -emit-library %s 2>&1 | %FileCheck %s
+// RUN: %host-library-env PATH= %t/DISTINCTIVE-WINDOWS-PATH/usr/bin/swiftc -target x86_64-unknown-windows-msvc -### -module-name link -emit-library %s 2>&1 | %FileCheck %s
 
 // swift-frontend cannot be copied to another location with bootstrapping because
 // it will not find the libswiftCore library with its relative RPATH.

--- a/test/Macros/macro_plugin.swift
+++ b/test/Macros/macro_plugin.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking -I %swift-lib-dir -L %swift-lib-dir -emit-library -emit-library-path=%t/%target-library-name(MacroDefinition) -working-directory=%t -module-name=MacroDefinition %S/Inputs/macro_definition.swift
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -emit-library-path=%t/%target-library-name(MacroDefinition) -working-directory=%t -module-name=MacroDefinition %S/Inputs/macro_definition.swift
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/ColorLib.swift
-// RUN: %target-swift-frontend -I %swift-lib-dir -L %swift-lib-dir -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %t -disable-availability-checking -dump-ast -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend -I %swift-host-lib-dir -L %swift-host-lib-dir -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %t -disable-availability-checking -dump-ast -primary-file %s | %FileCheck %s
 
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx

--- a/test/Macros/macro_plugin_diagnostics.swift
+++ b/test/Macros/macro_plugin_diagnostics.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking -I %swift-lib-dir -L %swift-lib-dir -emit-library -emit-library-path=%t/%target-library-name(MacroDefinitionMissingAllMacros) -working-directory=%t -module-name=MacroDefinitionMissingAllMacros %S/Inputs/macro_definition_missing_allmacros.swift
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking -I %swift-lib-dir -L %swift-lib-dir -emit-library -emit-library-path=%t/%target-library-name(MacroDefinition) -working-directory=%t -module-name=MacroDefinition %S/Inputs/macro_definition.swift
-// RUN: %target-swift-frontend -I %swift-lib-dir -L %swift-lib-dir -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -load-plugin-library %t/%target-library-name(MacroDefinitionMissingAllMacros) -disable-availability-checking -typecheck -verify -primary-file %s
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -emit-library-path=%t/%target-library-name(MacroDefinitionMissingAllMacros) -working-directory=%t -module-name=MacroDefinitionMissingAllMacros %S/Inputs/macro_definition_missing_allmacros.swift
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -emit-library-path=%t/%target-library-name(MacroDefinition) -working-directory=%t -module-name=MacroDefinition %S/Inputs/macro_definition.swift
+// RUN: %target-swift-frontend -I %swift-host-lib-dir -L %swift-host-lib-dir -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -load-plugin-library %t/%target-library-name(MacroDefinitionMissingAllMacros) -disable-availability-checking -typecheck -verify -primary-file %s
 
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx

--- a/test/Macros/macro_plugin_exec.swift
+++ b/test/Macros/macro_plugin_exec.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking -I %swift-lib-dir -L %swift-lib-dir -emit-library -emit-library-path=%t/%target-library-name(MacroDefinition) -working-directory=%t -module-name=MacroDefinition %S/Inputs/macro_definition.swift
-// RUN: %target-build-swift -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-lib-dir -L %swift-lib-dir %s -o %t/main
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -emit-library-path=%t/%target-library-name(MacroDefinition) -working-directory=%t -module-name=MacroDefinition %S/Inputs/macro_definition.swift
+// RUN: %target-build-swift -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2485,7 +2485,7 @@ if hasattr(config, 'target_library_path_var'):
           "/usr/bin/env " +
           construct_library_path_env([config.swift_host_lib_dir]))
 else:
-  host_library_env = ""
+  host_library_env = "env"
 
 config.substitutions.append(('%host-library-env', host_library_env))
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -466,8 +466,10 @@ shutil.rmtree(completion_cache_path, ignore_errors=True)
 ccp_opt = "-completion-cache-path %r" % completion_cache_path
 lit_config.note("Using code completion cache: " + completion_cache_path)
 
+config.swift_host_lib_dir = make_path(config.swift_lib_dir, 'swift', 'host')
 config.substitutions.append( ('%llvm_obj_root', config.llvm_obj_root) )
 config.substitutions.append( ('%swift-lib-dir', config.swift_lib_dir) )
+config.substitutions.append( ('%swift-host-lib-dir', config.swift_host_lib_dir))
 config.substitutions.append( ('%llvm_src_root', config.llvm_src_root) )
 config.substitutions.append( ('%swift_obj_root', config.swift_obj_root) )
 config.substitutions.append( ('%swift_src_root', config.swift_src_root) )
@@ -2480,7 +2482,7 @@ config.substitutions.append(('%llvm-cov', config.llvm_cov))
 # Name of the compiler plugin support library.
 plugin_support_shared_lib_name = ("%sswift_CompilerPluginSupport%s" %
     (config.target_shared_library_prefix, config.target_shared_library_suffix))
-plugin_support_shared_lib = make_path(config.swift_lib_dir, plugin_support_shared_lib_name)
+plugin_support_shared_lib = make_path(config.swift_host_lib_dir, plugin_support_shared_lib_name)
 config.substitutions.append(('%compiler_plugin_library',
                              plugin_support_shared_lib))
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2479,24 +2479,11 @@ config.substitutions.append(('%target-resilience-test', config.target_resilience
 config.substitutions.append(('%llvm-profdata', config.llvm_profdata))
 config.substitutions.append(('%llvm-cov', config.llvm_cov))
 
-# Name of the compiler plugin support library.
-plugin_support_shared_lib_name = ("%sswift_CompilerPluginSupport%s" %
-    (config.target_shared_library_prefix, config.target_shared_library_suffix))
-plugin_support_shared_lib = make_path(config.swift_host_lib_dir, plugin_support_shared_lib_name)
-config.substitutions.append(('%compiler_plugin_library',
-                             plugin_support_shared_lib))
-
-if "swift_swift_parser" in config.available_features:
-  config.substitutions.append(
-      (r'%copy-plugin-support-library\(*(.*)\)',
-       SubstituteCaptures(
-           r'cp %s \1' %
-           (escape_for_substitute_captures(plugin_support_shared_lib)))))
-else:
-  config.substitutions.append(
-      (r'%copy-plugin-support-library\(*(.*)\)',
-       r'echo "No plugin support library to copy"'))
-
+# Set up the host library environment.
+host_library_env = (
+        "/usr/bin/env " +
+        construct_library_path_env(config.swift_host_lib_dir))
+config.substitutions.append(('%host-library-env', host_library_env))
 
 if hasattr(config, 'otool_classic'):
     config.substitutions.append(('%otool-classic', config.otool_classic))

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2483,7 +2483,7 @@ config.substitutions.append(('%llvm-cov', config.llvm_cov))
 if hasattr(config, 'target_library_path_var'):
   host_library_env = (
           "/usr/bin/env " +
-          construct_library_path_env(config.swift_host_lib_dir))
+          construct_library_path_env([config.swift_host_lib_dir]))
 else:
   host_library_env = ""
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2480,9 +2480,13 @@ config.substitutions.append(('%llvm-profdata', config.llvm_profdata))
 config.substitutions.append(('%llvm-cov', config.llvm_cov))
 
 # Set up the host library environment.
-host_library_env = (
-        "/usr/bin/env " +
-        construct_library_path_env(config.swift_host_lib_dir))
+if hasattr(config, 'target_library_path_var'):
+  host_library_env = (
+          "/usr/bin/env " +
+          construct_library_path_env(config.swift_host_lib_dir))
+else:
+  host_library_env = ""
+
 config.substitutions.append(('%host-library-env', host_library_env))
 
 if hasattr(config, 'otool_classic'):

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -431,7 +431,7 @@ macro(add_sourcekit_framework name)
     set(RPATH_LIST)
     add_sourcekit_swift_runtime_link_flags(${name} "${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}" ${SOURCEKITFW_HAS_SWIFT_MODULES})
     file(RELATIVE_PATH relative_lib_path
-      "${framework_location}/Versions/A" "${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}")
+      "${framework_location}/Versions/A" "${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}/swift/host")
     list(APPEND RPATH_LIST "@loader_path/${relative_lib_path}")
 
     set_target_properties(${name} PROPERTIES
@@ -466,7 +466,7 @@ macro(add_sourcekit_framework name)
     set(RPATH_LIST)
     add_sourcekit_swift_runtime_link_flags(${name} "${framework_location}" SOURCEKITFW_HAS_SWIFT_MODULES RPATH_LIST)
     file(RELATIVE_PATH relative_lib_path
-      "${framework_location}" "${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}")
+      "${framework_location}" "${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}/swift/host")
     list(APPEND RPATH_LIST "@loader_path/${relative_lib_path}")
 
     set_target_properties(${name} PROPERTIES
@@ -555,7 +555,7 @@ macro(add_sourcekit_xpc_service name framework_target)
   set(RPATH_LIST)
   add_sourcekit_swift_runtime_link_flags(${name} ${xpc_bin_dir} ${SOURCEKITXPC_HAS_SWIFT_MODULES})
 
-  file(RELATIVE_PATH relative_lib_path "${xpc_bin_dir}" "${lib_dir}")
+  file(RELATIVE_PATH relative_lib_path "${xpc_bin_dir}" "${lib_dir}/swift/host")
   list(APPEND RPATH_LIST "@loader_path/${relative_lib_path}")
 
   # Add rpath for sourcekitdInProc

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -157,7 +157,7 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
 
   if(SWIFT_SWIFT_PARSER)
     # Make sure we can find the early SwiftSyntax libraries.
-    target_link_directories(${target} PRIVATE "${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/lib")
+    target_link_directories(${target} PRIVATE "${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/lib/swift/host")
 
     # For the "end step" of bootstrapping configurations on Darwin, need to be
     # able to fall back to the SDK directory for libswiftCore et al.

--- a/tools/libSwiftScan/CMakeLists.txt
+++ b/tools/libSwiftScan/CMakeLists.txt
@@ -29,6 +29,13 @@ set_target_properties(libSwiftScan
     PROPERTIES
     OUTPUT_NAME ${SWIFT_SCAN_LIB_NAME})
 
+if(SWIFT_SWIFT_PARSER)
+  # Ensure that we can find the host shared libraries.
+  set_property(
+    TARGET libSwiftScan
+    APPEND PROPERTY INSTALL_RPATH "@loader_path/swift/host")
+endif()
+
 add_llvm_symbol_exports(libSwiftScan ${LLVM_EXPORTED_SYMBOL_FILE})
 
 # Adds -dead_strip option

--- a/tools/libSwiftScan/CMakeLists.txt
+++ b/tools/libSwiftScan/CMakeLists.txt
@@ -34,6 +34,9 @@ if(SWIFT_SWIFT_PARSER)
   set_property(
     TARGET libSwiftScan
     APPEND PROPERTY INSTALL_RPATH "@loader_path/swift/host")
+  set_property(
+    TARGET libSwiftScan
+    APPEND PROPERTY INSTALL_RPATH "@loader_path/../host")
 endif()
 
 add_llvm_symbol_exports(libSwiftScan ${LLVM_EXPORTED_SYMBOL_FILE})

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -38,6 +38,7 @@ build-swift-stdlib-unittest-extra
 
 install-llvm
 install-swift
+install-swiftsyntax
 
 skip-test-cmark
 
@@ -384,6 +385,7 @@ install-swift
 install-llbuild
 install-swiftpm
 install-swift-driver
+install-swiftsyntax
 install-libcxx
 
 [preset: buildbot_incremental,tools=RA,stdlib=RA,apple_silicon]
@@ -818,6 +820,7 @@ install-lldb
 install-llbuild
 install-swiftpm
 install-swift-driver
+install-swiftsyntax
 install-xctest
 install-libicu
 install-prefix=/usr
@@ -948,6 +951,7 @@ host-test
 install-prefix=/usr
 install-llvm
 install-swift
+install-swiftsyntax
 
 skip-test-linux
 skip-build-benchmarks
@@ -1058,6 +1062,7 @@ install-llbuild
 install-foundation
 install-swiftpm
 install-swift-driver
+install-swiftsyntax
 install-xctest
 install-prefix=/usr
 swift-install-components=autolink-driver;compiler;clang-builtin-headers;stdlib;swift-remote-mirror;sdk-overlay;dev
@@ -1126,6 +1131,7 @@ install-llbuild
 install-libicu
 install-swiftpm
 install-swift-driver
+install-swiftsyntax
 install-foundation
 install-libdispatch
 install-xctest
@@ -1536,6 +1542,7 @@ libcxx
 # Install swift and libcxx
 install-llvm
 install-swift
+install-swiftsyntax
 install-libcxx
 
 # Build Playground support
@@ -1591,6 +1598,7 @@ install-swift
 install-llbuild
 install-swiftpm
 install-swift-driver
+install-swiftsyntax
 install-libcxx
 install-swiftdocc
 
@@ -1658,6 +1666,7 @@ install-llvm
 install-swift
 install-llbuild
 install-swiftpm
+install-swiftsyntax
 install-libcxx
 
 skip-test-swift
@@ -1945,6 +1954,7 @@ install-llvm
 install-swift
 install-llbuild
 install-swiftpm
+install-swiftsyntax
 install-xctest
 install-sourcekit-lsp
 
@@ -1977,6 +1987,7 @@ skip-build-llbuild
 skip-build-benchmarks
 install-llvm
 install-swift
+install-swiftsyntax
 install-prefix=%(install_toolchain_dir)s/usr
 build-swift-examples=0
 build-swift-tools=0
@@ -2621,6 +2632,7 @@ install-llvm
 install-swift
 install-swiftpm
 install-swift-driver
+install-swiftsyntax
 reconfigure
 verbose-build
 skip-build-benchmarks

--- a/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
@@ -49,7 +49,7 @@ class EarlySwiftSyntax(cmake_product.CMakeProduct):
     def build(self, host_target):
         self.cmake_options.define('CMAKE_BUILD_TYPE:STRING',
                                   self.args.swift_build_variant)
-        self.cmake_options.define('BUILD_SHARED_LIBS:STRING', 'NO')
+        self.cmake_options.define('BUILD_SHARED_LIBS:STRING', 'YES')
 
         (platform, arch) = host_target.split('-')
 

--- a/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
@@ -83,7 +83,7 @@ class EarlySwiftSyntax(cmake_product.CMakeProduct):
         Whether or not this product should be installed with the given
         arguments.
         """
-        return self.args.install_swiftsyntax
+        return self.should_build(host_target) and self.args.install_swiftsyntax
 
     def install(self, host_target):
         """

--- a/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
@@ -67,6 +67,7 @@ class EarlySwiftSyntax(cmake_product.CMakeProduct):
             toolchain_file = self.generate_linux_toolchain_file(platform, arch)
             self.cmake_options.define('CMAKE_TOOLCHAIN_FILE:PATH', toolchain_file)
 
+        self.cmake_options.define('CMAKE_INSTALL_PREFIX:PATH', self.args.install_prefix)
         self.build_with_cmake(["all"], self.args.swift_build_variant, [])
 
     def should_test(self, host_target):
@@ -77,17 +78,18 @@ class EarlySwiftSyntax(cmake_product.CMakeProduct):
         pass
 
     def should_install(self, host_target):
-        # This product is for the swift-syntax used with the build-directory compiler.
-        # If a toolchain install is required, please use the SwiftSyntax (no 'Early')
-        # product with `--swift-syntax --install-swift-syntax`.
-        return False
+        """should_install() -> Bool
 
-    @classmethod
-    def is_ignore_install_all_product(cls):
-        # Ensures that `install_all` setting triggered by `--infer` does not
-        # affect products which specify `is_ignore_install_all_product` as
-        # True. This is useful for products which should not be installed into the
-        # toolchain (corresponding build products that use the just-built
-        # toolchain are the products that get installed, e.g. `swiftsyntax` to
-        # `earlyswiftsyntax`).
-        return True
+        Whether or not this product should be installed with the given
+        arguments.
+        """
+        return self.args.install_all
+
+    def install(self, host_target):
+        """
+        Perform the install phase for the product.
+
+        This phase might copy the artifacts from the previous phases into a
+        destination directory.
+        """
+        self.install_with_cmake(["install"], self.host_install_destdir(host_target))

--- a/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/earlyswiftsyntax.py
@@ -83,7 +83,7 @@ class EarlySwiftSyntax(cmake_product.CMakeProduct):
         Whether or not this product should be installed with the given
         arguments.
         """
-        return self.args.install_all
+        return self.args.install_swiftsyntax
 
     def install(self, host_target):
         """


### PR DESCRIPTION
Start building shared libraries into the toolchain within `lib/swift/host`:
* Move `swift_CompilerPluginSupport` into `lib/swift/host`
* Start building swift-syntax as resilient shared libraries into `lib/swift/host`
* Have the compiler, SourceKit, and other tools link against these shared libraries

This means we won't get redundant copies of the swift-syntax libraries across the compiler and SourceKit (and other executables), and that compiler plugins can build against these shared versions safely.