### PR TITLE
Sema: Allow `AnyColorBox` in SwiftUI to derive from a less available base class

### DIFF
--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -208,6 +208,10 @@ public:
   const VersionRange &getRequiredOSVersionRange() const {
     return RequiredDeploymentRange;
   }
+
+  /// Returns true if the required OS version range's lower endpoint is at or
+  /// below the deployment target of the given ASTContext.
+  bool requiresDeploymentTargetOrEarlier(ASTContext &Ctx) const;
 };
 
 /// Represents everything that a particular chunk of code may assume about its

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -230,6 +230,14 @@ bool Decl::isSemanticallyUnavailable() const {
   return evaluateOrDefault(eval, IsSemanticallyUnavailableRequest{this}, false);
 }
 
+bool UnavailabilityReason::requiresDeploymentTargetOrEarlier(
+    ASTContext &Ctx) const {
+  return RequiredDeploymentRange.getLowerEndpoint() <=
+         AvailabilityContext::forDeploymentTarget(Ctx)
+             .getOSVersion()
+             .getLowerEndpoint();
+}
+
 AvailabilityContext
 AvailabilityInference::annotatedAvailableRangeForAttr(const SpecializeAttr* attr,
                                                       ASTContext &ctx) {

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2067,9 +2067,7 @@ static Diagnostic getPotentialUnavailabilityDiagnostic(
   auto Platform = prettyPlatformString(targetPlatform(Context.LangOpts));
   auto Version = Reason.getRequiredOSVersionRange().getLowerEndpoint();
 
-  if (Version <= AvailabilityContext::forDeploymentTarget(Context)
-                     .getOSVersion()
-                     .getLowerEndpoint()) {
+  if (Reason.requiresDeploymentTargetOrEarlier(Context)) {
     // The required OS version is at or before the deployment target so this
     // diagnostic should indicate that the decl could be unavailable to clients
     // of the module containing the reference.
@@ -2090,7 +2088,7 @@ bool TypeChecker::diagnosePotentialUnavailability(
     const ValueDecl *D, SourceRange ReferenceRange,
     const DeclContext *ReferenceDC,
     const UnavailabilityReason &Reason,
-    bool WarnBeforeDeploymentTarget) {
+    bool WarnBeforeDeploymentTarget = false) {
   ASTContext &Context = ReferenceDC->getASTContext();
 
   auto RequiredRange = Reason.getRequiredOSVersionRange();
@@ -3724,18 +3722,20 @@ bool swift::diagnoseDeclAvailability(const ValueDecl *D, SourceRange R,
   if (!maybeUnavail.has_value())
     return false;
 
+  auto unavailReason = maybeUnavail.value();
   auto *DC = Where.getDeclContext();
+  if (Flags.contains(
+          DeclAvailabilityFlag::
+              AllowPotentiallyUnavailableAtOrBelowDeploymentTarget) &&
+      unavailReason.requiresDeploymentTargetOrEarlier(DC->getASTContext()))
+    return false;
 
   if (accessor) {
     bool forInout = Flags.contains(DeclAvailabilityFlag::ForInout);
     TypeChecker::diagnosePotentialAccessorUnavailability(
-        accessor, R, DC, maybeUnavail.value(), forInout);
+        accessor, R, DC, unavailReason, forInout);
   } else {
-    bool downgradeBeforeDeploymentTarget = Flags.contains(
-        DeclAvailabilityFlag::
-            WarnForPotentialUnavailabilityBeforeDeploymentTarget);
-    if (!TypeChecker::diagnosePotentialUnavailability(
-            D, R, DC, maybeUnavail.value(), downgradeBeforeDeploymentTarget))
+    if (!TypeChecker::diagnosePotentialUnavailability(D, R, DC, unavailReason))
       return false;
   }
 

--- a/lib/Sema/TypeCheckAvailability.h
+++ b/lib/Sema/TypeCheckAvailability.h
@@ -58,11 +58,9 @@ enum class DeclAvailabilityFlag : uint8_t {
   /// warning. Used for ObjC key path components.
   ForObjCKeyPath = 1 << 3,
   
-  /// Downgrade errors about decl availability to warnings when the fix would be
-  /// to constrain availability to a version that is more available than the
-  /// current deployment target. This is needed for source compatibility in when
-  /// checking public extensions in library modules.
-  WarnForPotentialUnavailabilityBeforeDeploymentTarget = 1 << 4,
+  /// Do not diagnose potential decl unavailability if that unavailability
+  /// would only occur at or below the deployment target.
+  AllowPotentiallyUnavailableAtOrBelowDeploymentTarget = 1 << 4,
 };
 using DeclAvailabilityFlags = OptionSet<DeclAvailabilityFlag>;
 

--- a/test/Sema/availability_swiftui.swift
+++ b/test/Sema/availability_swiftui.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift -verify -target %target-cpu-apple-macosx12.0 -module-name SwiftUI -library-level api
+// RUN: not %target-typecheck-verify-swift -verify -target %target-cpu-apple-macosx12.0 -module-name Other -library-level api
+
+// REQUIRES: OS=macosx
+
+@available(macOS 11, *)
+public class LessAvailable {}
+
+@available(macOS 10.15, *)
+@usableFromInline
+class AnyColorBox: LessAvailable {} // Ok, exception specifically for AnyColorBox
+
+@available(macOS 10.15, *)
+@usableFromInline
+class OtherClass: LessAvailable {} // expected-error {{'LessAvailable' is only available in macOS 11 or newer; clients of 'SwiftUI' may have a lower deployment target}}

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -1369,10 +1369,8 @@ public enum NoAvailableEnumWithClasses {
   public class InheritsAtDeploymentTarget: AtDeploymentTargetClass {} // expected-error {{'AtDeploymentTargetClass' is only available in macOS 10.15 or newer; clients of 'Test' may have a lower deployment target}} expected-note 2 {{add @available attribute to enclosing class}}
   public class InheritsAfterDeploymentTarget: AfterDeploymentTargetClass {} // expected-error {{'AfterDeploymentTargetClass' is only available in macOS 11 or newer}} expected-note 2 {{add @available attribute to enclosing class}}
   
-  // As a special case, downgrade the less available superclasses diagnostic for
-  // `@usableFromInline` classes.
   @usableFromInline
-  class UFIInheritsBetweenTargets: BetweenTargetsClass {} // expected-warning {{'BetweenTargetsClass' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note 2 {{add @available attribute to enclosing class}}
+  class UFIInheritsBetweenTargets: BetweenTargetsClass {} // expected-error {{'BetweenTargetsClass' is only available in macOS 10.14.5 or newer; clients of 'Test' may have a lower deployment target}} expected-note 2 {{add @available attribute to enclosing class}}
 }
 
 @_spi(Private)


### PR DESCRIPTION
The potential unavailability diagnostic for `AnyColorBox` in SwiftUI was demoted from an error to a warning for source compatibility. However, since this diagnostic cannot be addressed it is better to make a more specific exception that suppresses the diagnostic entirely.

Resolves rdar://101915368
