### PR TITLE
[Serialization] Expect missing custom attributes in deserializeDeclCommon

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5306,7 +5306,7 @@ llvm::Error DeclDeserializer::deserializeDeclCommon() {
 
       // Do a quick check to see if this attribute is a move only attribute. If
       // so, emit a nice error if we don't have experimental move only enabled.
-      if (Attr->getKind() == DeclAttrKind::DAK_MoveOnly &&
+      if (Attr && Attr->getKind() == DeclAttrKind::DAK_MoveOnly &&
           !MF.getContext().LangOpts.Features.contains(Feature::MoveOnly)) {
         MF.getContext().Diags.diagnose(
             SourceLoc(),

--- a/test/Serialization/Recovery/implementation-only-missing.swift
+++ b/test/Serialization/Recovery/implementation-only-missing.swift
@@ -80,6 +80,9 @@ public struct PublicStruct: LibProtocol {
   public init() { }
 
   public var nonWrappedVar: String = "some text"
+
+  @IoiPropertyWrapper("some text")
+  private var wrappedVar: String
 }
 
 struct StructWithOverride: HiddenProtocolWithOverride {


### PR DESCRIPTION
`Attr` can be null here if it was a custom attribute from an implementation-only dependency.

rdar://102525437