### PR TITLE
Sema: Lift restriction preventing use of `#_hasSymbol` on non-Darwin-platforms

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6716,8 +6716,6 @@ WARNING(has_symbol_decl_must_be_weak,none,
         (DescriptiveDeclKind, DeclName))
 ERROR(has_symbol_invalid_expr,none,
       "'#_hasSymbol' condition must refer to a declaration", ())
-ERROR(has_symbol_unsupported_on_target,none,
-      "'#_hasSymbol' is unsupported on target '%0'", (StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: Type erasure

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -4506,15 +4506,6 @@ static bool diagnoseHasSymbolCondition(PoundHasSymbolInfo *info,
     return false;
 
   auto &ctx = DC->getASTContext();
-  if (!ctx.LangOpts.Target.isOSDarwin()) {
-    // SILGen for #_hasSymbol is currently implemented assuming the target OS
-    // is a Darwin platform.
-    ctx.Diags.diagnose(info->getStartLoc(),
-                       diag::has_symbol_unsupported_on_target,
-                       ctx.LangOpts.Target.str());
-    return true;
-  }
-
   auto decl = info->getReferencedDecl().getDecl();
   if (!decl) {
     // Diagnose because we weren't able to interpret the expression as one

--- a/test/AutoDiff/SILGen/has_symbol.swift
+++ b/test/AutoDiff/SILGen/has_symbol.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/Library.swiftmodule -parse-as-library %t/Library.swift -enable-library-evolution
 // RUN: %target-swift-frontend -emit-silgen %t/Client.swift -I %t -module-name test | %FileCheck %t/Client.swift
 
-// REQUIRES: VENDOR=apple
+// UNSUPPORTED: OS=windows-msvc
 
 //--- Library.swift
 

--- a/test/IRGen/has_symbol.swift
+++ b/test/IRGen/has_symbol.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/has_symbol_helper.swiftmodule -parse-as-library %S/Inputs/has_symbol_helper.swift -enable-library-evolution -disable-availability-checking
 // RUN: %target-swift-frontend -emit-irgen %s -I %t -module-name test | %FileCheck %s
 
-// REQUIRES: VENDOR=apple
+// UNSUPPORTED: OS=windows-msvc
 
 // rdar://102246128
 // REQUIRES: PTRSIZE=64

--- a/test/IRGen/has_symbol_async.swift
+++ b/test/IRGen/has_symbol_async.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-irgen %s -I %t -module-name test | %FileCheck %s
 
 // REQUIRES: concurrency
-// REQUIRES: VENDOR=apple
+// UNSUPPORTED: OS=windows-msvc
 
 @_weakLinked import has_symbol_helper
 

--- a/test/Interpreter/has_symbol.swift
+++ b/test/Interpreter/has_symbol.swift
@@ -26,7 +26,7 @@
 // RUN: %target-run %t/test %t/%target-library-name(helper) | %FileCheck %s --check-prefix=NO-ANSWER
 
 // REQUIRES: executable_test
-// REQUIRES: VENDOR=apple
+// UNSUPPORTED: OS=windows-msvc
 
 // This test requires executable tests to be run on the same machine as the
 // compiler, as it links with a dylib that it doesn't arrange to get uploaded

--- a/test/Parse/has_symbol.swift
+++ b/test/Parse/has_symbol.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/Library.swiftmodule -parse-as-library %t/Library.swift -enable-library-evolution
 // RUN: %target-swift-frontend -typecheck -verify %t/Client.swift -I %t
 
-// REQUIRES: VENDOR=apple
+// UNSUPPORTED: OS=windows-msvc
 
 //--- Library.swift
 

--- a/test/SIL/Parser/has_symbol.sil
+++ b/test/SIL/Parser/has_symbol.sil
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/has_symbol_helper.swiftmodule -parse-as-library -enable-library-evolution %t/has_symbol_helper.swift
 // RUN: %target-swift-frontend -emit-sil -verify %s -I %t/
 
-// REQUIRES: vendor=apple
+// UNSUPPORTED: OS=windows-msvc
 
 sil_stage raw
 

--- a/test/SILGen/has_symbol.swift
+++ b/test/SILGen/has_symbol.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/has_symbol_helper.swiftmodule -parse-as-library %S/Inputs/has_symbol_helper.swift -enable-library-evolution
 // RUN: %target-swift-frontend -emit-silgen %s -I %t -module-name test | %FileCheck %s
 
-// REQUIRES: VENDOR=apple
+// UNSUPPORTED: OS=windows-msvc
 
 @_weakLinked import has_symbol_helper
 

--- a/test/SILOptimizer/has_symbol.swift
+++ b/test/SILOptimizer/has_symbol.swift
@@ -3,7 +3,7 @@
 // RUN: %target-swift-frontend -O -emit-module -emit-module-path %t/Library.swiftmodule -parse-as-library %t/Library.swift -enable-library-evolution
 // RUN: %target-swift-frontend -O -emit-sil %t/Client.swift -I %t -module-name test | %FileCheck %s
 
-// REQUIRES: VENDOR=apple
+// UNSUPPORTED: OS=windows-msvc
 
 //--- Library.swift
 

--- a/test/Sema/has_symbol.swift
+++ b/test/Sema/has_symbol.swift
@@ -3,7 +3,7 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -I %t -enable-experimental-feature ResultBuilderASTTransform
 
-// REQUIRES: VENDOR=apple
+// UNSUPPORTED: OS=windows-msvc
 
 @_weakLinked import has_symbol_helper
 

--- a/test/Sema/has_symbol_unsupported.swift
+++ b/test/Sema/has_symbol_unsupported.swift
@@ -1,8 +1,0 @@
-// RUN: %target-typecheck-verify-swift
-// UNSUPPORTED: VENDOR=apple
-
-// Verify that #_hasSymbol is rejected on non-Darwin platforms
-
-func foo() {}
-
-if #_hasSymbol(foo) { } // expected-error {{'#_hasSymbol' is unsupported on target}}


### PR DESCRIPTION
An early approach to codegen for `#_hasSymbol` relied on the Darwin platfom SDK, but now that the feature lowers directly to NULL checks in LLVM IR a platform restriction is no longer needed.

However, the tests for `#_hasSymbol` remain unsupported on Windows since that OS does not support weak linking.
