### PR TITLE
#62310: "unable to type-check in reasonable time" error should suggest reporting a bug

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -177,7 +177,7 @@ ERROR(cannot_pass_rvalue_mutating_getter,none,
       (Type))
 
 ERROR(expression_too_complex,none,
-      "the compiler is unable to type-check this expression in reasonable time; "
+      "the compiler is unable to type-check this expression in reasonable time; please file a bug report "
       "try breaking up the expression into distinct sub-expressions", ())
 
 ERROR(value_type_comparison_with_nil_illegal_did_you_mean,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -177,8 +177,9 @@ ERROR(cannot_pass_rvalue_mutating_getter,none,
       (Type))
 
 ERROR(expression_too_complex,none,
-      "the compiler is unable to type-check this expression in reasonable time; please file a bug report "
-      "try breaking up the expression into distinct sub-expressions", ())
+      "the compiler is unable to type-check this expression in reasonable time ",
+      SWIFT_BUG_REPORT_MESSAGE,
+      " try breaking up the expression into distinct sub-expressions ", ())
 
 ERROR(value_type_comparison_with_nil_illegal_did_you_mean,none,
       "value of type %0 cannot be compared by reference; "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -177,9 +177,9 @@ ERROR(cannot_pass_rvalue_mutating_getter,none,
       (Type))
 
 ERROR(expression_too_complex,none,
-      "the compiler is unable to type-check this expression in reasonable time ",
-      SWIFT_BUG_REPORT_MESSAGE,
-      " try breaking up the expression into distinct sub-expressions ", ())
+      "the compiler is unable to type-check this expression in reasonable time "
+      " try breaking up the expression into distinct sub-expressions "
+      SWIFT_BUG_REPORT_MESSAGE, ())
 
 ERROR(value_type_comparison_with_nil_illegal_did_you_mean,none,
       "value of type %0 cannot be compared by reference; "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -178,7 +178,7 @@ ERROR(cannot_pass_rvalue_mutating_getter,none,
 
 ERROR(expression_too_complex,none,
       "the compiler is unable to type-check this expression in reasonable time "
-      " try breaking up the expression into distinct sub-expressions "
+      " try breaking up the expression into distinct sub-expressions; "
       SWIFT_BUG_REPORT_MESSAGE, ())
 
 ERROR(value_type_comparison_with_nil_illegal_did_you_mean,none,


### PR DESCRIPTION
<!-- What's in this pull request? -->
It adds the `SWIFT_BUG_REPORT_MESSAGE` to "unable to type-check in reasonable time". This change might be controversial given the utility of bug reports being filed for an issue that is actively being developed, however, i'm adding this change in case it is useful/the issue is eventually accepted as valid. 

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #62310, "unable to type-check in reasonable time" error should suggest reporting a bug
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
