### PR TITLE
IRGen: Inhibit `alloc_stack` hoisting in the presence of `has_symbol` instructions

### DIFF
--- a/test/SILOptimizer/allocstack_hoisting.sil
+++ b/test/SILOptimizer/allocstack_hoisting.sil
@@ -257,3 +257,26 @@ bb3:
   return %3 : $()
 }
 
+// CHECK-LABEL: sil @dont_hoist_with_has_symbol_checks
+// CHECK-NOT: alloc_stack
+// CHECK:     cond_br
+// CHECK:   bb1:
+// CHECK:     alloc_stack
+// CHECK: } // end sil function 'dont_hoist_with_has_symbol_checks'
+sil @dont_hoist_with_has_symbol_checks : $@convention(thin) <T> (@in T, Builtin.Int1) -> () {
+bb0(%0 : $*T, %1: $Builtin.Int1):
+  %5 = has_symbol #FixedSize.init
+  cond_br %5, bb1, bb2
+bb1:
+  %2 = alloc_stack $T
+  copy_addr [take] %0 to [init] %2 : $*T
+  destroy_addr %2 : $*T
+  dealloc_stack %2 : $*T
+  br bb3
+bb2:
+  destroy_addr %0 : $*T
+  br bb3
+bb3:
+  %3 = tuple ()
+  return %3 : $()
+}


### PR DESCRIPTION
`if #_hasSymbol(...)` conditionals are used to prevent use of weakly linked symbols when they are not available. Therefore optimization needs to treat these conditionals similarly to `if #available(..)` conditionals and inhibit optimizations like `alloc_stack` hoisting.

Resolves rdar://102837282
