### PR TITLE
build: disable bytecode layout library without stdlib

### DIFF
--- a/stdlib/toolchain/CMakeLists.txt
+++ b/stdlib/toolchain/CMakeLists.txt
@@ -46,7 +46,9 @@ endif()
 # runtime being patched only through public ABI.
 list(APPEND CXX_COMPILE_FLAGS "-DSWIFT_COMPATIBILITY_LIBRARY=1")
 
-add_subdirectory(CompatibilityBytecodeLayouts)
+if(SWIFT_BUILD_STDLIB)
+  add_subdirectory(CompatibilityBytecodeLayouts)
+endif()
 
 if(SWIFT_STDLIB_SUPPORT_BACK_DEPLOYMENT)
   add_subdirectory(legacy_layouts)


### PR DESCRIPTION
This directory is directly added from the top-level CMake which bypasses the compiler swapping dance.  When cross-compiling or building the toolchain with a non-clang compiler, the forced flags for the standard library directory will result in build failures.  Avoid building the library unless the standard library is being built (which will require that the compiler-swap occurs).
