### PR TITLE
build: on FreeBSD, set the rpath of built stdlib dylibs to $ORIGIN

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1115,6 +1115,10 @@ function(add_swift_target_library_single target name)
     set_target_properties("${target}"
       PROPERTIES
       INSTALL_RPATH "$ORIGIN")
+  elseif("${SWIFTLIB_SINGLE_SDK}" STREQUAL "FREEBSD")
+    set_target_properties("${target}"
+      PROPERTIES
+      INSTALL_RPATH "$ORIGIN")
   endif()
 
   set_target_properties("${target}" PROPERTIES BUILD_WITH_INSTALL_RPATH YES)


### PR DESCRIPTION
This matches OpenBSD and Linux, and it allows, for example, libswift_StringProcessing.so to find libswiftGlibc.so at dynamic link time.