### PR TITLE
[cxx-interop][rebranch] Handle clang elaborated types, part 2

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -213,8 +213,8 @@ translateDeclToContext(clang::NamedDecl *decl) {
       return std::make_pair(SwiftLookupTable::ContextKind::Tag,
                             typedefDecl->getName());
     if (auto enumDecl = dyn_cast<clang::EnumDecl>(tag)) {
-      if (auto typedefType = dyn_cast<clang::TypedefType>(
-              enumDecl->getIntegerType().getTypePtr())) {
+      if (auto typedefType =
+              dyn_cast<clang::TypedefType>(getUnderlyingType(enumDecl))) {
         if (importer::isUnavailableInSwift(typedefType->getDecl(), nullptr,
                                            true)) {
           return std::make_pair(SwiftLookupTable::ContextKind::Tag,


### PR DESCRIPTION
This applies the same trick as https://github.com/apple/swift/pull/62190 for newly written code.

Fixes two C++ interop tests in rebranch:
* `Interop/Cxx/enum/c-enums-NS_OPTIONS-api-notes-renamed-options.swift`
* `Interop/Cxx/enum/c-enums-NS_OPTIONS-swift-named-options.swift`

rdar://102858524