### PR TITLE
Disable SILOptimizer/set.swift

### DIFF
--- a/test/SILOptimizer/set.swift
+++ b/test/SILOptimizer/set.swift
@@ -1,3 +1,5 @@
+// REQUIRES: rdar102865253
+
 // RUN: %target-swift-frontend  -parse-as-library -primary-file %s -O -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
 // RUN: %target-swift-frontend  -parse-as-library -primary-file %s -Osize -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib


### PR DESCRIPTION
This test is failing on the macOS package bot. Disabling for now.

https://ci.swift.org/job/oss-swift-package-macos//1258/console