### PR TITLE
[Sema/SILGen] Allow property wrappers on `let` declarations

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5320,7 +5320,7 @@ ERROR(nonisolated_actor_sync_init,none,
       "'nonisolated' on an actor's synchronous initializer is invalid",
       ())
 ERROR(nonisolated_wrapped_property,none,
-      "'nonisolated' is not supported on properties with property wrappers",
+      "'nonisolated' is not supported on `var` declared property wrappers",
       ())
 
 ERROR(actor_instance_property_wrapper,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6734,9 +6734,6 @@ ERROR(property_wrapper_mutating_get_composed_to_get_only,none,
 
 ERROR(property_wrapper_top_level,none,
       "property wrappers are not yet supported in top-level code", ())
-ERROR(property_wrapper_let, none,
-      "property wrapper can only be applied to a 'var'",
-      ())
 ERROR(property_wrapper_computed, none,
       "property wrapper cannot be applied to a computed property",
       ())

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4091,7 +4091,7 @@ void PrintAST::visitVarDecl(VarDecl *decl) {
   if (decl->getKind() == DeclKind::Var || Options.PrintParameterSpecifiers) {
     // Map all non-let specifiers to 'var'.  This is not correct, but
     // SourceKit relies on this for info about parameter decls.
-    Printer.printIntroducerKeyword(decl->isLet() ? "let" : "var", Options, " ");
+    Printer.printIntroducerKeyword(decl->isLet() && !decl->hasAttachedPropertyWrapper() ? "let" : "var", Options, " ");
   }
   printContextIfNeeded(decl);
   recordDeclLoc(decl,

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -228,8 +228,8 @@ public:
     return current;
   }
 
-  void set(SILGenFunction &SGF, SILLocation loc,
-           ArgumentSource &&value, ManagedValue base) &&;
+  virtual void set(SILGenFunction &SGF, SILLocation loc, ArgumentSource &&value,
+                   ManagedValue base) &&;
 
   /// Determines whether this component has any actor-isolation.
   bool hasActorIsolation() const { return ActorIso.has_value(); }

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -807,7 +807,7 @@ public:
   void set(SILGenFunction &SGF, SILLocation loc, ArgumentSource &&value,
            ManagedValue base) &&
       override {
-    if (isa<ConstructorDecl>(SGF.FunctionDC->getAsDecl()) &&
+    if (isa_and_nonnull<ConstructorDecl>(SGF.FunctionDC->getAsDecl()) &&
         Field->hasAttachedPropertyWrapper() && Field->isLet()) {
       auto backingVar = Field->getPropertyWrapperBackingProperty();
       auto ValType = backingVar->getValueInterfaceType();
@@ -928,7 +928,7 @@ public:
     void set(SILGenFunction &SGF, SILLocation loc, ArgumentSource &&value,
              ManagedValue base) &&
         override {
-      if (isa<ConstructorDecl>(SGF.FunctionDC->getAsDecl()) &&
+      if (isa_and_nonnull<ConstructorDecl>(SGF.FunctionDC->getAsDecl()) &&
           Field->hasAttachedPropertyWrapper() && Field->isLet()) {
         auto backingVar = Field->getPropertyWrapperBackingProperty();
         auto ValType = backingVar->getValueInterfaceType();

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -29,6 +29,7 @@
 #include "swift/AST/DiagnosticsCommon.h"
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/SIL/Consumption.h"
@@ -767,69 +768,87 @@ static void copyBorrowedYieldsIntoTemporary(SILGenFunction &SGF,
 }
 
 namespace {
-  class RefElementComponent : public PhysicalPathComponent {
-    VarDecl *Field;
-    SILType SubstFieldType;
-    bool IsNonAccessing;
-  public:
-    RefElementComponent(VarDecl *field, LValueOptions options,
-                        SILType substFieldType, LValueTypeData typeData,
-                        Optional<ActorIsolation> actorIso)
-      : PhysicalPathComponent(typeData, RefElementKind, actorIso),
-        Field(field), SubstFieldType(substFieldType),
+class NominalTypeElementComponent : public PhysicalPathComponent {
+protected:
+  VarDecl *Field;
+  SILType SubstFieldType;
+  SubstitutionMap Subs;
+
+public:
+  NominalTypeElementComponent(KindTy kind, VarDecl *field,
+                              LValueOptions options, SILType substFieldType,
+                              LValueTypeData typeData, SubstitutionMap subs,
+                              Optional<ActorIsolation> actorIso)
+      : PhysicalPathComponent(typeData, kind, actorIso), Field(field),
+        SubstFieldType(substFieldType), Subs(subs) {}
+
+  virtual bool isLoadingPure() const override = 0;
+
+  VarDecl *getField() const { return Field; }
+
+  virtual ManagedValue project(SILGenFunction &SGF, SILLocation loc,
+                               ManagedValue base) && override = 0;
+};
+
+class RefElementComponent : public NominalTypeElementComponent {
+  bool IsNonAccessing;
+
+public:
+  RefElementComponent(VarDecl *field, LValueOptions options,
+                      SILType substFieldType, LValueTypeData typeData,
+                      SubstitutionMap subs, Optional<ActorIsolation> actorIso)
+      : NominalTypeElementComponent(RefElementKind, field, options,
+                                    substFieldType, typeData, subs, actorIso),
         IsNonAccessing(options.IsNonAccessing) {}
 
-    virtual bool isLoadingPure() const override { return true; }
+  bool isLoadingPure() const override { return true; }
 
-    VarDecl *getField() const { return Field; }
+  ManagedValue project(SILGenFunction &SGF, SILLocation loc,
+                       ManagedValue base) &&
+      override {
+    assert(base.getType().hasReferenceSemantics() &&
+           "base for ref element component must be a reference type");
 
-    ManagedValue project(SILGenFunction &SGF, SILLocation loc,
-                         ManagedValue base) && override {
-      assert(base.getType().hasReferenceSemantics() &&
-             "base for ref element component must be a reference type");
+    // Borrow the ref element addr using formal access. If we need the ref
+    // element addr, we will load it in this expression.
+    if (base.getType().isAddress()) {
+      base = SGF.B.createFormalAccessLoadBorrow(loc, base);
+    } else {
+      base = base.formalAccessBorrow(SGF, loc);
+    }
+    SILValue result = SGF.B.createRefElementAddr(loc, base.getUnmanagedValue(),
+                                                 Field, SubstFieldType);
 
-      // Borrow the ref element addr using formal access. If we need the ref
-      // element addr, we will load it in this expression.
-      if (base.getType().isAddress()) {
-        base = SGF.B.createFormalAccessLoadBorrow(loc, base);
-      } else {
-        base = base.formalAccessBorrow(SGF, loc);
+    // Avoid emitting access markers completely for non-accesses or immutable
+    // declarations. Access marker verification is aware of these cases.
+    if (!IsNonAccessing && !Field->isLet()) {
+      if (auto enforcement = SGF.getDynamicEnforcement(Field)) {
+        result = enterAccessScope(SGF, loc, base, result, getTypeData(),
+                                  getAccessKind(), *enforcement,
+                                  takeActorIsolation());
       }
-      SILValue result =
-        SGF.B.createRefElementAddr(loc, base.getUnmanagedValue(),
-                                   Field, SubstFieldType);
-
-      // Avoid emitting access markers completely for non-accesses or immutable
-      // declarations. Access marker verification is aware of these cases.
-      if (!IsNonAccessing && !Field->isLet()) {
-        if (auto enforcement = SGF.getDynamicEnforcement(Field)) {
-          result = enterAccessScope(SGF, loc, base, result, getTypeData(),
-                                    getAccessKind(), *enforcement,
-                                    takeActorIsolation());
-        }
-      }
-
-      // If we have a move only type, add a marker.
-      //
-      // NOTE: We purposely do this on the access itself to ensure that when we
-      // hoist destroy_addr, they stay within the access scope.
-      if (result->getType().isMoveOnly()) {
-        auto checkKind =
-            MarkMustCheckInst::CheckKind::AssignableButNotConsumable;
-        if (isReadAccess(getAccessKind())) {
-          // Add a mark_must_check [no_consume_or_assign].
-          checkKind = MarkMustCheckInst::CheckKind::NoConsumeOrAssign;
-        }
-        result = SGF.B.createMarkMustCheckInst(loc, result, checkKind);
-      }
-
-      return ManagedValue::forLValue(result);
     }
 
-    void dump(raw_ostream &OS, unsigned indent) const override {
-      OS.indent(indent) << "RefElementComponent(" << Field->getName() << ")\n";
+    // If we have a move only type, add a marker.
+    //
+    // NOTE: We purposely do this on the access itself to ensure that when we
+    // hoist destroy_addr, they stay within the access scope.
+    if (result->getType().isMoveOnly()) {
+      auto checkKind = MarkMustCheckInst::CheckKind::AssignableButNotConsumable;
+      if (isReadAccess(getAccessKind())) {
+        // Add a mark_must_check [no_consume_or_assign].
+        checkKind = MarkMustCheckInst::CheckKind::NoConsumeOrAssign;
+      }
+      result = SGF.B.createMarkMustCheckInst(loc, result, checkKind);
     }
-  };
+
+    return ManagedValue::forLValue(result);
+  }
+
+  void dump(raw_ostream &OS, unsigned indent) const override {
+    OS.indent(indent) << "RefElementComponent(" << Field->getName() << ")\n";
+  }
+};
 
   class TupleElementComponent : public PhysicalPathComponent {
     unsigned ElementIndex;
@@ -860,17 +879,51 @@ namespace {
     }
   };
 
-  class StructElementComponent : public PhysicalPathComponent {
-    VarDecl *Field;
-    SILType SubstFieldType;
+  class StructElementComponent : public NominalTypeElementComponent {
   public:
     StructElementComponent(VarDecl *field, SILType substFieldType,
-                           LValueTypeData typeData,
+                           LValueTypeData typeData, SubstitutionMap subs,
                            Optional<ActorIsolation> actorIso)
-      : PhysicalPathComponent(typeData, StructElementKind, actorIso),
-        Field(field), SubstFieldType(substFieldType) {}
+        : NominalTypeElementComponent(StructElementKind, field, LValueOptions(),
+                                      substFieldType, typeData, subs,
+                                      actorIso) {}
 
-    virtual bool isLoadingPure() const override { return true; }
+    bool isLoadingPure() const override { return true; }
+
+    void set(SILGenFunction &SGF, SILLocation loc, ArgumentSource &&value,
+             ManagedValue base) &&
+        override {
+      if (isa<ConstructorDecl>(SGF.FunctionDC->getAsDecl()) &&
+          Field->hasAttachedPropertyWrapper() && Field->isLet()) {
+        auto backingVar = Field->getPropertyWrapperBackingProperty();
+        auto ValType = backingVar->getValueInterfaceType();
+        if (!Subs.empty()) {
+          ValType = ValType.subst(Subs);
+        }
+        auto wrapperValue = SGF.emitApplyOfPropertyWrapperBackingInitializer(
+            loc, Field, Subs, std::move(value).getAsRValue(SGF));
+
+        auto typeData = getLogicalStorageTypeData(
+            SGF.getTypeExpansionContext(), SGF.SGM, getTypeData().AccessKind,
+            ValType->getCanonicalType());
+        SILType varStorageType = SGF.SGM.Types.getSubstitutedStorageType(
+            TypeExpansionContext::minimal(), backingVar,
+            ValType->getCanonicalType());
+        StructElementComponent SEC(backingVar, varStorageType, typeData, Subs,
+                                   /*actorIsolation=*/None);
+        auto proj = std::move(SEC).project(SGF, loc, base);
+
+        auto srcRValue = std::move(wrapperValue).ensurePlusOne(SGF, loc);
+        std::move(srcRValue).assignInto(SGF, loc, proj.getValue());
+        return;
+      }
+      auto finalDestAddr = std::move(*this).project(SGF, loc, base);
+      assert(finalDestAddr.getType().isAddress());
+
+      auto srcRValue =
+          std::move(value).getAsRValue(SGF).ensurePlusOne(SGF, loc);
+      std::move(srcRValue).assignInto(SGF, loc, finalDestAddr.getValue());
+    }
 
     ManagedValue project(SILGenFunction &SGF, SILLocation loc,
                          ManagedValue base) && override {
@@ -1774,11 +1827,13 @@ namespace {
               SGF.maybeEmitValueOfLocalVarDecl(backingVar, AccessKind::Write);
         } else if (BaseFormalType->mayHaveSuperclass()) {
           RefElementComponent REC(backingVar, LValueOptions(), varStorageType,
-                                  typeData, /*actorIsolation=*/None);
+                                  typeData, Substitutions,
+                                  /*actorIsolation=*/None);
           proj = std::move(REC).project(SGF, loc, base);
         } else {
           assert(BaseFormalType->getStructOrBoundGenericStruct());
           StructElementComponent SEC(backingVar, varStorageType, typeData,
+                                     Substitutions,
                                      /*actorIsolation=*/None);
           proj = std::move(SEC).project(SGF, loc, base);
         }
@@ -3753,11 +3808,11 @@ void LValue::addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
           SGF.getTypeExpansionContext(), Storage, FormalRValueType);
 
       if (BaseFormalType->mayHaveSuperclass()) {
-        LV.add<RefElementComponent>(Storage, Options, varStorageType,
-                                    typeData, ActorIso);
+        LV.add<RefElementComponent>(Storage, Options, varStorageType, typeData,
+                                    Subs, ActorIso);
       } else {
         assert(BaseFormalType->getStructOrBoundGenericStruct());
-        LV.add<StructElementComponent>(Storage, varStorageType, typeData,
+        LV.add<StructElementComponent>(Storage, varStorageType, typeData, Subs,
                                        ActorIso);
       }
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -6723,10 +6723,11 @@ void AttributeChecker::visitNonisolatedAttr(NonisolatedAttr *attr) {
       }
     }
 
-    // Using 'nonisolated' with wrapped properties is unsupported, because
-    // backing storage is a stored 'var' that is part of the internal state
-    // of the actor which could only be accessed in actor's isolation context.
-    if (var->hasAttachedPropertyWrapper()) {
+    // Using 'nonisolated' with `var` declared wrapped properties is
+    // unsupported, because backing storage is a stored 'var' that is part of
+    // the internal state of the actor which could only be accessed in actor's
+    // isolation context.
+    if (var->hasAttachedPropertyWrapper() && !var->isLet()) {
       diagnoseAndRemoveAttr(attr, diag::nonisolated_wrapped_property);
       return;
     }

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -477,12 +477,6 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
       continue;
     }
 
-    // A property wrapper cannot be attached to a 'let'.
-    if (!isa<ParamDecl>(var) && var->isLet()) {
-      ctx.Diags.diagnose(attr->getLocation(), diag::property_wrapper_let);
-      continue;
-    }
-
     // Check for conflicting attributes.
     if (attachedAttrs.hasAttribute<LazyAttr>() ||
         attachedAttrs.hasAttribute<NSCopyingAttr>() ||

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2797,7 +2797,7 @@ static VarDecl *synthesizePropertyWrapperProjectionVar(
   } else {
     bool hasSetter = wrapperVar->isSettable(nullptr) &&
     wrapperVar->isSetterAccessibleFrom(var->getInnermostDeclContext());
-    if (hasSetter)
+    if (hasSetter && !var->isLet())
       property->setImplInfo(StorageImplInfo::getMutableComputed());
     else
       property->setImplInfo(StorageImplInfo::getImmutableComputed());

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -2777,6 +2777,8 @@ static VarDecl *synthesizePropertyWrapperProjectionVar(
                                         VarDecl::Introducer::Var,
                                         var->getLoc(),
                                         name, dc);
+  if (var->isLet() && var->getAttrs().hasAttribute<NonisolatedAttr>())
+    property->getAttrs().add(new (ctx) NonisolatedAttr(/*isImplicit=*/true));
   property->setImplicit();
   property->setOriginalWrappedProperty(var);
   addMemberToContextIfNeeded(property, dc, var);
@@ -3035,6 +3037,9 @@ PropertyWrapperAuxiliaryVariablesRequest::evaluate(Evaluator &evaluator,
                                    introducer,
                                    var->getLoc(),
                                    name, dc);
+    if (var->isLet() && var->getAttrs().hasAttribute<NonisolatedAttr>())
+      backingVar->getAttrs().add(new (ctx)
+                                     NonisolatedAttr(/*isImplicit=*/true));
     backingVar->setImplicit();
     backingVar->setOriginalWrappedProperty(var);
 
@@ -3046,6 +3051,7 @@ PropertyWrapperAuxiliaryVariablesRequest::evaluate(Evaluator &evaluator,
   }
 
   if (wrapperInfo.projectedValueVar || var->getName().hasDollarPrefix()) {
+
     projectionVar = synthesizePropertyWrapperProjectionVar(
         ctx, var, wrapperInfo.projectedValueVar);
   }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3027,7 +3027,10 @@ PropertyWrapperAuxiliaryVariablesRequest::evaluate(Evaluator &evaluator,
     backingVar = ParamDecl::cloneWithoutType(ctx, param);
     backingVar->setName(name);
   } else {
-    auto introducer = isa<ParamDecl>(var) ? VarDecl::Introducer::Let : VarDecl::Introducer::Var;
+
+    auto introducer = (isa<ParamDecl>(var) || var->isLet())
+                          ? VarDecl::Introducer::Let
+                          : VarDecl::Introducer::Var;
     backingVar = new (ctx) VarDecl(/*IsStatic=*/var->isStatic(),
                                    introducer,
                                    var->getLoc(),

--- a/test/Concurrency/global_actor_inference.swift
+++ b/test/Concurrency/global_actor_inference.swift
@@ -466,7 +466,7 @@ struct SimplePropertyWrapper {
 @MainActor
 class WrappedContainsNonisolatedAttr {
   @SimplePropertyWrapper nonisolated var value 
-  // expected-error@-1 {{'nonisolated' is not supported on properties with property wrappers}}
+  // expected-error@-1 {{'nonisolated' is not supported on `var` declared property wrappers}}
   // expected-note@-2 2{{property declared here}}
 
   nonisolated func test() {

--- a/test/Concurrency/task_local.swift
+++ b/test/Concurrency/task_local.swift
@@ -15,6 +15,9 @@ struct TL {
 
   @TaskLocal
   var notStatic: String? // expected-error{{property 'notStatic', must be static because property wrapper 'TaskLocal<String?>' can only be applied to static properties}}
+  
+  @TaskLocal
+  static let meltingPoint: Double = 273.1 // expected-note {{change 'let' to 'var' to make it mutable}}
 }
 
 @TaskLocal // expected-error{{property wrappers are not yet supported in top-level code}}
@@ -26,6 +29,7 @@ class NotSendable {}
 func test () async {
   TL.number = 10 // expected-error{{cannot assign to property: 'number' is a get-only property}}
   TL.$number = 10 // expected-error{{cannot assign value of type 'Int' to type 'TaskLocal<Int>'}}
+  TL.meltingPoint = 100.0 // expected-error {{cannot assign to property: 'meltingPoint' is a 'let' constant}}
   let _: Int = TL.number
   let _: Int = TL.$number.get()
 }

--- a/test/Interpreter/property_wrappers.swift
+++ b/test/Interpreter/property_wrappers.swift
@@ -87,3 +87,32 @@ func testMyType(_ myType: MyType<Int>) {
 }
 
 testMyType(MyType(x: 17))
+
+do {
+  @propertyWrapper
+  struct Wrapper {
+    var wrappedValue: Int
+    init(wrappedValue: Int) {
+      self.wrappedValue = wrappedValue
+    }
+  }
+  
+  @Wrapper let value = 20
+  print(value)
+  //CHECK-NEXT: 20
+  
+  struct S {
+    @Wrapper let defaulted = 42
+    @Wrapper let initValue: Int
+    
+    init(v: Int) {
+      initValue = v
+    }
+  }
+  
+  let s = S(v: 50)
+  print(s.defaulted)
+  print(s.initValue)
+  //CHECK-NEXT: 42
+  //CHECK-NEXT: 50
+}

--- a/test/ModuleInterface/property_wrappers.swift
+++ b/test/ModuleInterface/property_wrappers.swift
@@ -18,6 +18,15 @@ public struct Wrapper<T> {
 }
 
 @propertyWrapper
+public struct WrapperWithWrappedValueInit<T> {
+  public var wrappedValue: T
+
+  public init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+@propertyWrapper
 public struct WrapperWithInitialValue<T> {
   private var value: T
   
@@ -26,8 +35,8 @@ public struct WrapperWithInitialValue<T> {
     set { value = newValue }
   }
 
-  public init(initialValue: T) {
-    self.value = initialValue
+  public init(wrappedValue: T) {
+    self.value = wrappedValue
   }
 
   public init(alternate value: T) {
@@ -42,6 +51,11 @@ public struct WrapperWithInitialValue<T> {
 
 // CHECK: public struct HasWrappers {
 public struct HasWrappers {
+  // CHECK: @TestResilient.WrapperWithInitialValue @_projectedValueProperty($v) public var v: Swift.String {
+  // CHECK-NEXT: get
+  // CHECK-NEXT: }
+  @WrapperWithInitialValue public let v: String = "Hello"
+  
   // CHECK: @TestResilient.Wrapper public var x: {{(Swift.)?}}Int {
   // CHECK-NEXT: get
   // CHECK-NEXT: set

--- a/test/SILOptimizer/property_wrapper_init_transform.swift
+++ b/test/SILOptimizer/property_wrapper_init_transform.swift
@@ -1,0 +1,68 @@
+// RUN: %target-swift-frontend -module-name test -disable-availability-checking -emit-sil %s 2>&1 | %FileCheck %s
+
+// REQUIRES: asserts
+
+@propertyWrapper
+public struct Wrapper {
+  public var wrappedValue: Int { 0 }
+  public init(wrappedValue: Int) {}
+}
+
+struct S {
+  // CHECK-LABEL: sil hidden @$s4test1SVACycfC : $@convention(method) (@thin S.Type) -> S
+  // CHECK: [[BACKING_INIT:%.*]] = function_ref @$s4test1SV5valueSivpfP : $@convention(thin) (Int) -> Wrapper
+  // CHECK-NEXT: [[WRAPPER_VALUE:%.*]] = apply [[BACKING_INIT]]({{.*}}) : $@convention(thin) (Int) -> Wrapper
+  // CHECK-NEXT: [[BACKING_VAR:%.*]] = struct_element_addr {{.*}} : $*S, #S._value
+  // CHECK-NEXT: store [[WRAPPER_VALUE]] to [[BACKING_VAR]] : $*Wrapper
+  @Wrapper let value: Int
+  
+  init() {
+    value = 10
+  }
+}
+
+@propertyWrapper
+public struct WrapperStructWithGenericType<T> {
+  public var wrappedValue: T
+  public init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+struct R {
+  // CHECK-LABEL: sil hidden @$s4test1RV1vACSi_tcfC : $@convention(method) (Int, @thin R.Type) -> R {
+  // CHECK: [[BACKING_INIT:%.*]] = function_ref @$s4test1RV5valueSivpfP : $@convention(thin) (Int) -> WrapperStructWithGenericType<Int>
+  // CHECK: [[WRAPPER_VALUE:%.*]] = apply [[BACKING_INIT]]({{.*}}) : $@convention(thin) (Int) -> WrapperStructWithGenericType<Int>
+  // CHECK: [[BACKING_VAR:%.*]] = struct_element_addr {{.*}} : $*R, #R._value
+  // CHECK: store [[WRAPPER_VALUE]] to [[BACKING_VAR]] : $*WrapperStructWithGenericType<Int>
+  @WrapperStructWithGenericType let value: Int
+  
+  init(v: Int) {
+    value = v
+  }
+}
+
+let r = R(v: 10)
+
+@propertyWrapper
+public class WrapperClassWithGenericType<T> {
+  public var wrappedValue: T
+  public init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
+class C {
+  // CHECK-LABEL: sil hidden @$s4test1CC1vACSi_tcfc : $@convention(method) (Int, @owned C) -> @owned C {
+  // CHECK:     [[BACKING_INIT:%.*]] = function_ref @$s4test1CC5valueSivpfP : $@convention(thin) (Int) -> @owned WrapperClassWithGenericType<Int>
+  // CHECK:     [[WRAPPER_VALUE:%.*]] = apply [[BACKING_INIT]]({{.*}}) : $@convention(thin) (Int) -> @owned WrapperClassWithGenericType<Int>
+  // CHECK:     [[BACKING_VAR:%.*]] = ref_element_addr {{.*}} : $C, #C._value
+  // CHECK:     store [[WRAPPER_VALUE]] to [[BACKING_VAR]] : $*WrapperClassWithGenericType<Int>
+  @WrapperClassWithGenericType let value: Int
+  
+  init(v: Int) {
+    value = v
+  }
+}
+
+let c = C(v: 10)

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -546,16 +546,17 @@ struct UseMutatingnessWrappers {
   var y = 17
 
   @WrapperWithNonMutatingSetter
-  let z = 3.14159
+  let z = 3.14159 // expected-note 2{{change 'let' to 'var' to make it mutable}}
 
   @ClassWrapper
   var w = "Hello"
   
   @ClassWrapper
-  let v = "Good morning"
+  let v = "Good morning" // expected-note 2{{change 'let' to 'var' to make it mutable}}
 }
 
 func testMutatingness() {
+  
   var mutable = UseMutatingnessWrappers()
 
   _ = mutable.x
@@ -591,6 +592,20 @@ func testMutatingness() {
   
   _ = nonmutable.v
   nonmutable.v = "Good afternoon" // expected-error{{cannot assign to property: 'v' is a 'let' constant}}
+}
+
+struct LetWrappedPropertyReassignment {
+  @ClassWrapper
+  let u: String // expected-note{{change 'let' to 'var' to make it mutable}}
+  
+  init() {
+    self.u = "Red"
+  }
+}
+
+func testLetReassignment() {
+  var m = LetWrappedPropertyReassignment()
+  m.u = "Yellow" // expected-error{{cannot assign to property: 'u' is a 'let' constant}}
 }
 
 // ---------------------------------------------------------------------------

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -545,11 +545,14 @@ struct UseMutatingnessWrappers {
   @WrapperWithMutatingGetter
   var y = 17
 
-  @WrapperWithNonMutatingSetter // expected-error{{property wrapper can only be applied to a 'var'}}
-  let z = 3.14159 // expected-note 2{{change 'let' to 'var' to make it mutable}}
+  @WrapperWithNonMutatingSetter
+  let z = 3.14159
 
   @ClassWrapper
   var w = "Hello"
+  
+  @ClassWrapper
+  let v = "Good morning"
 }
 
 func testMutatingness() {
@@ -566,6 +569,9 @@ func testMutatingness() {
 
   _ = mutable.w
   mutable.w = "Goodbye"
+  
+  _ = mutable.v
+  mutable.v = "Good night" // expected-error{{cannot assign to property: 'v' is a 'let' constant}}
 
   let nonmutable = UseMutatingnessWrappers() // expected-note 2{{change 'let' to 'var' to make it mutable}}
 
@@ -582,6 +588,9 @@ func testMutatingness() {
   // Okay due to implicitly nonmutating setter
   _ = nonmutable.w
   nonmutable.w = "World"
+  
+  _ = nonmutable.v
+  nonmutable.v = "Good afternoon" // expected-error{{cannot assign to property: 'v' is a 'let' constant}}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
This adds support for `let` declared property wrappers to the Swift language and is the implementation [for SE-NNNN Allow Property Wrappers on Let Declarations](https://github.com/apple/swift-evolution/pull/1910). 

At the time of this proposal, let declared property wrappers are not allowed:

```
@propertyWrapper
struct Wrapper {
  init(wrappedValue: Int) {}
  var wrappedValue: Int { 0 }
}

struct S {
  @Wrapper let value: Int  // error: property wrapper can only be applied to a ‘var’
}
```

This PR implements changes so that the above is legal in Swift and `let` wrapped properties are allowed as local and instance variables. 