### PR TITLE
[TypeConverter] Track address lowering.

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -874,7 +874,12 @@ public:
   /// True if SIL conventions force address-only to be passed by address.
   bool useLoweredAddresses() const { return loweredAddresses; }
 
-  void setLoweredAddresses(bool val) { loweredAddresses = val; }
+  void setLoweredAddresses(bool val) {
+    loweredAddresses = val;
+    if (val) {
+      Types.setLoweredAddresses();
+    }
+  }
 
   llvm::IndexedInstrProfReader *getPGOReader() const { return PGOReader.get(); }
 

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -289,9 +289,13 @@ public:
 private:
   friend class TypeConverter;
 
-  /// The SIL type of values with this Swift type.
-  SILType LoweredType;
+  virtual void setLoweredAddresses() const {}
 
+protected:
+  /// The SIL type of values with this Swift type.
+  mutable SILType LoweredType;
+
+private:
   RecursiveProperties Properties;
 
   /// The resilience expansion for this type lowering.
@@ -778,6 +782,9 @@ class TypeConverter {
   void removeNullEntry(const TypeKey &k);
 #endif
 
+  /// True if SIL conventions force address-only to be passed by address.
+  bool LoweredAddresses;
+
   CanGenericSignature CurGenericSignature;
 
   /// Stack of types currently being lowered as part of an aggregate.
@@ -824,7 +831,7 @@ public:
   ModuleDecl &M;
   ASTContext &Context;
 
-  TypeConverter(ModuleDecl &m);
+  TypeConverter(ModuleDecl &m, bool loweredAddresses = true);
   ~TypeConverter();
   TypeConverter(TypeConverter const &) = delete;
   TypeConverter &operator=(TypeConverter const &) = delete;
@@ -1218,6 +1225,9 @@ public:
   
   void setCaptureTypeExpansionContext(SILDeclRef constant,
                                       SILModule &M);
+
+  void setLoweredAddresses();
+
 private:
   CanType computeLoweredRValueType(TypeExpansionContext context,
                                    AbstractionPattern origType,

--- a/lib/DriverTool/modulewrap_main.cpp
+++ b/lib/DriverTool/modulewrap_main.cpp
@@ -189,7 +189,8 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   
   ASTCtx.addModuleLoader(ClangImporter::create(ASTCtx, ""), true);
   ModuleDecl *M = ModuleDecl::create(ASTCtx.getIdentifier("swiftmodule"), ASTCtx);
-  std::unique_ptr<Lowering::TypeConverter> TC(new Lowering::TypeConverter(*M));
+  std::unique_ptr<Lowering::TypeConverter> TC(
+      new Lowering::TypeConverter(*M, ASTCtx.SILOpts.EnableSILOpaqueValues));
   std::unique_ptr<SILModule> SM = SILModule::createEmptyModule(M, *TC, SILOpts);
   createSwiftModuleObjectFile(*SM, (*ErrOrBuf)->getBuffer(),
                               Invocation.getOutputFilename());

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -202,8 +202,10 @@ SerializationOptions CompilerInvocation::computeSerializationOptions(
 Lowering::TypeConverter &CompilerInstance::getSILTypes() {
   if (auto *tc = TheSILTypes.get())
     return *tc;
-  
-  auto *tc = new Lowering::TypeConverter(*getMainModule());
+
+  auto *tc = new Lowering::TypeConverter(
+      *getMainModule(),
+      /*loweredAddresses=*/!Context->SILOpts.EnableSILOpaqueValues);
   TheSILTypes.reset(tc);
   return *tc;
 }

--- a/lib/IRGen/IRABIDetailsProvider.cpp
+++ b/lib/IRGen/IRABIDetailsProvider.cpp
@@ -71,7 +71,7 @@ namespace swift {
 class IRABIDetailsProviderImpl {
 public:
   IRABIDetailsProviderImpl(ModuleDecl &mod, const IRGenOptions &opts)
-      : typeConverter(mod),
+      : typeConverter(mod, /*addressLowered=*/true),
         silMod(SILModule::createEmptyModule(&mod, typeConverter, silOpts)),
         IRGen(opts, *silMod), IGM(IRGen, IRGen.createTargetMachine()) {}
 

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -43,6 +43,15 @@
 using namespace swift;
 using namespace Lowering;
 
+// Necessary to straightforwardly write SIL tests that exercise
+// OpaqueValueTypeLowering (and MoveOnlyOpaqueValueTypeLowering): the tests can
+// be written as though opaque values were enabled to begin but have since been
+// lowered out of.
+llvm::cl::opt<bool> TypeLoweringForceOpaqueValueLowering(
+    "type-lowering-force-opaque-value-lowering", llvm::cl::init(false),
+    llvm::cl::desc("Force TypeLowering to behave as if building with opaque "
+                   "values enabled"));
+
 namespace {
   /// A CRTP type visitor for deciding whether the metatype for a type
   /// is a singleton type, i.e. whether there can only ever be one
@@ -2066,7 +2075,8 @@ namespace {
 
     TypeLowering *handleMoveOnlyAddressOnly(CanType type,
                                             RecursiveProperties properties) {
-      if (!TC.Context.SILOpts.EnableSILOpaqueValues) {
+      if (!TC.Context.SILOpts.EnableSILOpaqueValues &&
+          !TypeLoweringForceOpaqueValueLowering) {
         auto silType = SILType::getPrimitiveAddressType(type);
         return new (TC)
             MoveOnlyAddressOnlyTypeLowering(silType, properties, Expansion);
@@ -2084,7 +2094,8 @@ namespace {
 
     TypeLowering *handleAddressOnly(CanType type,
                                     RecursiveProperties properties) {
-      if (!TC.Context.SILOpts.EnableSILOpaqueValues) {
+      if (!TC.Context.SILOpts.EnableSILOpaqueValues &&
+          !TypeLoweringForceOpaqueValueLowering) {
         auto silType = SILType::getPrimitiveAddressType(type);
         return new (TC) AddressOnlyTypeLowering(silType, properties,
                                                            Expansion);

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -1942,6 +1942,10 @@ namespace {
   /// Lower address only types as opaque values.
   class OpaqueValueTypeLowering : public LeafLoadableTypeLowering {
   public:
+    void setLoweredAddresses() const override {
+      LoweredType = LoweredType.getAddressType();
+    }
+
     OpaqueValueTypeLowering(SILType type, RecursiveProperties properties,
                             TypeExpansionContext forExpansion)
       : LeafLoadableTypeLowering(type, properties, IsNotReferenceCounted,
@@ -2004,6 +2008,10 @@ namespace {
         : LeafLoadableTypeLowering(type, properties, IsNotReferenceCounted,
                                    forExpansion) {}
 
+    void setLoweredAddresses() const override {
+      LoweredType = LoweredType.getAddressType();
+    }
+
     void emitCopyInto(SILBuilder &B, SILLocation loc, SILValue src,
                       SILValue dest, IsTake_t isTake,
                       IsInitialization_t isInit) const override {
@@ -2041,9 +2049,13 @@ namespace {
   class LowerType
     : public TypeClassifierBase<LowerType, TypeLowering *>
   {
+    bool loweredAddresses;
+
   public:
-    LowerType(TypeConverter &TC, TypeExpansionContext Expansion)
-      : TypeClassifierBase(TC, Expansion) {}
+    LowerType(TypeConverter &TC, TypeExpansionContext Expansion,
+              bool loweredAddresses)
+        : TypeClassifierBase(TC, Expansion),
+          loweredAddresses(loweredAddresses) {}
 
     TypeLowering *handleTrivial(CanType type) {
       return handleTrivial(type, RecursiveProperties::forTrivial());
@@ -2100,7 +2112,9 @@ namespace {
         return new (TC) AddressOnlyTypeLowering(silType, properties,
                                                            Expansion);
       }
-      auto silType = SILType::getPrimitiveObjectType(type);
+      auto silType = SILType::getPrimitiveType(
+          type, loweredAddresses ? SILValueCategory::Address
+                                 : SILValueCategory::Object);
       return new (TC) OpaqueValueTypeLowering(silType, properties, Expansion);
     }
     
@@ -2394,9 +2408,8 @@ namespace {
   };
 } // end anonymous namespace
 
-TypeConverter::TypeConverter(ModuleDecl &m)
-  : M(m), Context(m.getASTContext()) {
-}
+TypeConverter::TypeConverter(ModuleDecl &m, bool loweredAddresses)
+    : LoweredAddresses(loweredAddresses), M(m), Context(m.getASTContext()) {}
 
 TypeConverter::~TypeConverter() {
   // The bump pointer allocator destructor will deallocate but not destroy all
@@ -2597,7 +2610,7 @@ TypeConverter::getTypeLowering(AbstractionPattern origType,
   // and cache it.
   if (loweredSubstType == substType && key.isCacheable()) {
     lowering =
-        LowerType(*this, forExpansion)
+        LowerType(*this, forExpansion, LoweredAddresses)
             .visit(key.SubstType, key.OrigType, isTypeExpansionSensitive);
 
     // Otherwise, check the table at a key that would be used by the
@@ -3059,9 +3072,8 @@ const TypeLowering &TypeConverter::getTypeLoweringForLoweredType(
         forExpansion, origType, loweredType);
   }
 
-  lowering =
-      LowerType(*this, forExpansion)
-        .visit(loweredType, origType, isTypeExpansionSensitive);
+  lowering = LowerType(*this, forExpansion, LoweredAddresses)
+                 .visit(loweredType, origType, isTypeExpansionSensitive);
 
   if (!lowering->isResilient() && !lowering->isTypeExpansionSensitive())
     insert(key.getKeyForMinimalExpansion(), lowering);
@@ -4356,6 +4368,14 @@ void TypeConverter::setCaptureTypeExpansionContext(SILDeclRef constant,
     // some place we need to keep opaque types opaque.
     CaptureTypeExpansionContexts.insert({constant, context});
   }
+}
+
+void TypeConverter::setLoweredAddresses() {
+  assert(!LoweredAddresses);
+  for (auto &pair : this->LoweredTypes) {
+    pair.getSecond()->setLoweredAddresses();
+  }
+  LoweredAddresses = true;
 }
 
 static void countNumberOfInnerFields(unsigned &fieldsCount, TypeConverter &TC,

--- a/test/SILOptimizer/existential_specializer_soletype_opaque_addrlowered.sil
+++ b/test/SILOptimizer/existential_specializer_soletype_opaque_addrlowered.sil
@@ -1,0 +1,48 @@
+// RUN: %target-sil-opt  -wmo -enable-sil-verify-all -emit-sorted-sil %s -enable-existential-specializer -existential-specializer  -type-lowering-force-opaque-value-lowering 2>&1 | %FileCheck %s
+
+// Test ExistentialSpecializer with OpaqueValueTypeLowerings.
+
+import Builtin
+import Swift
+import SwiftShims
+
+public protocol P {}
+
+public struct S : P {
+  init()
+
+  var o: AnyObject // nontrivial to check ownership conventions
+}
+
+// Verify that the opened existential type used in thunk building is properly
+// address lowered even though it has an OpaqueValueTypeLowering.
+// CHECK-LABEL: sil hidden [signature_optimized_thunk] [always_inline] @$s6test2_6storePyyAA1P_p_AaC_pztF : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[IN_ADDR:%[^,]+]] : $*any P, [[OUT_ADDR:%[^,]+]] : $*any P):
+// CHECK:         [[OPENED_IN_ADDR:%[^,]+]] = open_existential_addr mutable_access [[IN_ADDR]] : $*any P to $*@opened([[UUID:".*"]], any P) Self 
+// CHECK:         [[OPENED_OUT_ADDR:%[^,]+]] = alloc_stack $@opened([[UUID]], any P) Self 
+// CHECK:         copy_addr [[OPENED_IN_ADDR]] to [init] [[OPENED_OUT_ADDR]] : $*@opened([[UUID]], any P) Self 
+// CHECK:         apply {{%[^,]+}}<@opened([[UUID]], any P) Self>([[OPENED_OUT_ADDR]], [[OUT_ADDR]])
+// CHECK:         destroy_addr [[IN_ADDR]]
+// CHECK:         dealloc_stack [[OPENED_OUT_ADDR]]
+// CHECK-LABEL: } // end sil function '$s6test2_6storePyyAA1P_p_AaC_pztF'
+sil hidden [noinline] @$s6test2_6storePyyAA1P_p_AaC_pztF : $@convention(thin) (@in P, @inout P) -> () {
+bb0(%0 : $*P, %1 : $*P):
+  copy_addr %0 to [init] %1 : $*P
+  destroy_addr %0 : $*P
+  %5 = tuple ()
+  return %5 : $()
+}
+
+sil @$s6test2_6storeS1s1qyAA1SV_AA1P_pztF : $@convention(thin) (S, @inout P) -> () {
+bb0(%0 : $S, %1 : $*P):
+  %4 = alloc_stack $P
+  %5 = init_existential_addr %4 : $*P, $S
+  store %0 to %5 : $*S
+  %7 = function_ref @$s6test2_6storePyyAA1P_p_AaC_pztF : $@convention(thin) (@in P, @inout P) -> ()
+  %8 = apply %7(%4, %1) : $@convention(thin) (@in P, @inout P) -> ()
+  dealloc_stack %4 : $*P
+  %10 = tuple ()
+  return %10 : $()
+}
+
+sil_witness_table S: P module test {}


### PR DESCRIPTION
When opaque values are enabled, `TypeConverter` associates to an address-only type an `OpaqueValueTypeLowering`.  That lowering stores a single lowered SIL type, and its value category is "object".  So long as the module has not yet been address-lowered, that type has the appropriate value category.  After the module has been address-lowered, however, that type has the wrong value category: the type is address-only, and in an address-lowered module, its lowered type's value category must be "address".

Code that obtains a lowered type expects the value category to reflect the state of the module.  So somewhere, it's necessary to fixup that single lowered type's value category.

One option would be to update all code that uses lowered types.  That would require many changes across the codebase and all new code that used lowered types would need to account for this.

Another option would be to update some popular conveniences that call through to `TypeConverter`, for example those on SILFunction, and ensure that all code used those conveniences.  Even if this were done completely, it would be easy enough for new code to be added which didn't use the conveniences.

A third option would be to update `TypeLowering::getLoweredType` to take in the context necessary to determine whether the stored SILType should be fixed up.  That would require each callsite to be changed and potentially to carry around more context than it already had in order to be able to pass it along.

A fourth option would be to make `TypeConverter` aware of the address-loweredness, and to update its state at the end of AddressLowering.

Updating `TypeConverter`'s state would entail updating all cached `OpaqueValueTypeLowering` instances.  Additionally, when `TypeConverter` produces new `OpaqueValueTypeLowerings`, they would need to have the "address" value category from creation.

Of all the options, the last is least invasive and least error-prone, so it is taken here.
