### PR TITLE
Requires-asserts macro tests

### DIFF
--- a/test/ModuleInterface/macros.swift
+++ b/test/ModuleInterface/macros.swift
@@ -1,3 +1,5 @@
+// REQUIRES: asserts
+
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -typecheck -module-name Macros -emit-module-interface-path %t/Macros.swiftinterface -enable-experimental-feature Macros %s

--- a/test/Serialization/macros.swift
+++ b/test/Serialization/macros.swift
@@ -1,3 +1,5 @@
+// REQUIRES: asserts
+
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t-scratch)
 // RUN: %target-swift-frontend -emit-module -o %t/def_macros.swiftmodule %S/Inputs/def_macros.swift -module-name def_macros -enable-experimental-feature Macros


### PR DESCRIPTION
Macros are an experimental feature, as such are not available on non-asserts compilers.

Adding requires asserts to remaining experimental macro tests.
 - ModuleInterface/macros.swift
 - Serialization/macros.swift

rdar://102869470