### PR TITLE
Expose Swift search paths in validateSerializedAST

### DIFF
--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -187,6 +187,12 @@ public:
   }
 };
 
+struct SearchPath {
+  std::string Path;
+  bool IsFramework;
+  bool IsSystem;
+};
+
 /// Returns info about the serialized AST in the given data.
 ///
 /// If the returned status is anything but Status::Valid, the serialized data
@@ -216,7 +222,8 @@ ValidationInfo validateSerializedAST(
     bool requiresRevisionMatch = true,
     ExtendedValidationInfo *extendedInfo = nullptr,
     SmallVectorImpl<SerializationOptions::FileDependency> *dependencies =
-        nullptr);
+        nullptr,
+    SmallVectorImpl<SearchPath> *searchPaths = nullptr);
 
 /// Emit diagnostics explaining a failure to load a serialized AST.
 ///

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -401,7 +401,8 @@ static ValidationInfo validateControlBlock(
 
 static bool validateInputBlock(
     llvm::BitstreamCursor &cursor, SmallVectorImpl<uint64_t> &scratch,
-    SmallVectorImpl<SerializationOptions::FileDependency> &dependencies) {
+    SmallVectorImpl<SerializationOptions::FileDependency> *dependencies,
+    SmallVectorImpl<SearchPath> *searchPaths) {
   SmallVector<StringRef, 4> dependencyDirectories;
   SmallString<256> dependencyFullPathBuffer;
 
@@ -430,33 +431,43 @@ static bool validateInputBlock(
     }
     unsigned kind = maybeKind.get();
     switch (kind) {
-    case input_block::FILE_DEPENDENCY: {
-      bool isHashBased = scratch[2] != 0;
-      bool isSDKRelative = scratch[3] != 0;
+    case input_block::FILE_DEPENDENCY:
+      if (dependencies) {
+        bool isHashBased = scratch[2] != 0;
+        bool isSDKRelative = scratch[3] != 0;
 
-      StringRef path = blobData;
-      size_t directoryIndex = scratch[4];
-      if (directoryIndex != 0) {
-        if (directoryIndex > dependencyDirectories.size())
-          return true;
-        dependencyFullPathBuffer = dependencyDirectories[directoryIndex-1];
-        llvm::sys::path::append(dependencyFullPathBuffer, blobData);
-        path = dependencyFullPathBuffer;
-      }
+        StringRef path = blobData;
+        size_t directoryIndex = scratch[4];
+        if (directoryIndex != 0) {
+          if (directoryIndex > dependencyDirectories.size())
+            return true;
+          dependencyFullPathBuffer = dependencyDirectories[directoryIndex - 1];
+          llvm::sys::path::append(dependencyFullPathBuffer, blobData);
+          path = dependencyFullPathBuffer;
+        }
 
-      if (isHashBased) {
-        dependencies.push_back(
-          SerializationOptions::FileDependency::hashBased(
-            path, isSDKRelative, scratch[0], scratch[1]));
-      } else {
-        dependencies.push_back(
-          SerializationOptions::FileDependency::modTimeBased(
-            path, isSDKRelative, scratch[0], scratch[1]));
+        if (isHashBased)
+          dependencies->push_back(
+              SerializationOptions::FileDependency::hashBased(
+                  path, isSDKRelative, scratch[0], scratch[1]));
+        else
+          dependencies->push_back(
+              SerializationOptions::FileDependency::modTimeBased(
+                  path, isSDKRelative, scratch[0], scratch[1]));
       }
       break;
-    }
     case input_block::DEPENDENCY_DIRECTORY:
-      dependencyDirectories.push_back(blobData);
+      if (dependencies)
+        dependencyDirectories.push_back(blobData);
+      break;
+    case input_block::SEARCH_PATH:
+      if (searchPaths) {
+        bool isFramework;
+        bool isSystem;
+        input_block::SearchPathLayout::readRecord(scratch, isFramework,
+                                                  isSystem);
+        searchPaths->push_back({std::string(blobData), isFramework, isSystem});
+      }
       break;
     default:
       // Unknown metadata record, possibly for use by a future version of the
@@ -467,7 +478,6 @@ static bool validateInputBlock(
   return false;
 }
 
-
 bool serialization::isSerializedAST(StringRef data) {
   StringRef signatureStr(reinterpret_cast<const char *>(SWIFTMODULE_SIGNATURE),
                          llvm::array_lengthof(SWIFTMODULE_SIGNATURE));
@@ -477,7 +487,8 @@ bool serialization::isSerializedAST(StringRef data) {
 ValidationInfo serialization::validateSerializedAST(
     StringRef data, bool requiresOSSAModules, StringRef requiredSDK,
     bool requiresRevisionMatch, ExtendedValidationInfo *extendedInfo,
-    SmallVectorImpl<SerializationOptions::FileDependency> *dependencies) {
+    SmallVectorImpl<SerializationOptions::FileDependency> *dependencies,
+    SmallVectorImpl<SearchPath> *searchPaths) {
   ValidationInfo result;
 
   // Check 32-bit alignment.
@@ -523,7 +534,7 @@ ValidationInfo serialization::validateSerializedAST(
           extendedInfo, localObfuscator);
       if (result.status == Status::Malformed)
         return result;
-    } else if (dependencies &&
+    } else if ((dependencies || searchPaths) &&
                result.status == Status::Valid &&
                topLevelEntry.ID == INPUT_BLOCK_ID) {
       if (llvm::Error Err = cursor.EnterSubBlock(INPUT_BLOCK_ID)) {
@@ -532,7 +543,7 @@ ValidationInfo serialization::validateSerializedAST(
         result.status = Status::Malformed;
         return result;
       }
-      if (validateInputBlock(cursor, scratch, *dependencies)) {
+      if (validateInputBlock(cursor, scratch, dependencies, searchPaths)) {
         result.status = Status::Malformed;
         return result;
       }

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -151,16 +151,11 @@ private:
   /// All modules this module depends on.
   SmallVector<Dependency, 8> Dependencies;
 
-  struct SearchPath {
-    std::string Path;
-    bool IsFramework;
-    bool IsSystem;
-  };
   /// Search paths this module may provide.
   ///
   /// This is not intended for use by frameworks, but may show up in debug
   /// modules.
-  std::vector<SearchPath> SearchPaths;
+  std::vector<serialization::SearchPath> SearchPaths;
 
   /// Info for the (lone) imported header for this module.
   struct {

--- a/test/DebugInfo/ASTSection-single.swift
+++ b/test/DebugInfo/ASTSection-single.swift
@@ -6,9 +6,9 @@
 // RUN: %empty-directory(%t)
 
 // RUN: echo "public let a0 = 0"  >%t/a0.swift
-// RUN: %target-build-swift %t/a0.swift -emit-module -emit-module-path %t/a0.swiftmodule
+// RUN: %target-build-swift %t/a0.swift -emit-module -emit-module-path %t/a0.swiftmodule -I %s/Inputs
 // RUN: %target-swift-modulewrap %t/a0.swiftmodule -o %t/a0-mod.o
 
 // RUN: %lldb-moduleimport-test -verbose %t/a0-mod.o | %FileCheck %s
+// CHECK: Path: {{.*}}/Inputs, framework=false, system=false
 // CHECK: Importing a0... ok!
-

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -44,14 +44,15 @@ void anchorForGetMainExecutable() {}
 
 using namespace llvm::MachO;
 
-static bool
-validateModule(llvm::StringRef data, bool Verbose, bool requiresOSSAModules,
-               swift::serialization::ValidationInfo &info,
-               swift::serialization::ExtendedValidationInfo &extendedInfo) {
+static bool validateModule(
+    llvm::StringRef data, bool Verbose, bool requiresOSSAModules,
+    swift::serialization::ValidationInfo &info,
+    swift::serialization::ExtendedValidationInfo &extendedInfo,
+    llvm::SmallVectorImpl<swift::serialization::SearchPath> &searchPaths) {
   info = swift::serialization::validateSerializedAST(
       data, requiresOSSAModules,
       /*requiredSDK*/ StringRef(), /*requiresRevisionMatch*/ false,
-      &extendedInfo);
+      &extendedInfo, /* dependencies*/ nullptr, &searchPaths);
   if (info.status != swift::serialization::Status::Valid) {
     llvm::outs() << "error: validateSerializedAST() failed\n";
     return false;
@@ -78,6 +79,14 @@ validateModule(llvm::StringRef data, bool Verbose, bool requiresOSSAModules,
       for (llvm::StringRef option : extendedInfo.getExtraClangImporterOptions())
         llvm::outs() << " " << option;
       llvm::outs() << "\n";
+    }
+    llvm::outs() << "- Search Paths:\n";
+    for (auto searchPath : searchPaths) {
+      llvm::outs() << "    Path: " << searchPath.Path;
+      llvm::outs() << ", framework="
+                   << (searchPath.IsFramework ? "true" : "false");
+      llvm::outs() << ", system=" << (searchPath.IsSystem ? "true" : "false")
+                   << "\n";
     }
   }
 
@@ -285,11 +294,12 @@ int main(int argc, char **argv) {
 
   swift::serialization::ValidationInfo info;
   swift::serialization::ExtendedValidationInfo extendedInfo;
+  llvm::SmallVector<swift::serialization::SearchPath> searchPaths;
   for (auto &Module : Modules) {
     info = {};
     extendedInfo = {};
     if (!validateModule(StringRef(Module.first, Module.second), Verbose,
-                        EnableOSSAModules, info, extendedInfo)) {
+                        EnableOSSAModules, info, extendedInfo, searchPaths)) {
       llvm::errs() << "Malformed module!\n";
       return 1;
     }


### PR DESCRIPTION
This is for the benefit of LLDB, which currently does an expensive import of all modules to get to the same information.

rdar://40097459

