### PR TITLE
Tests: `#_hasSymbol` support for members of opaque/existential types

### DIFF
--- a/test/IRGen/Inputs/has_symbol_helper.swift
+++ b/test/IRGen/Inputs/has_symbol_helper.swift
@@ -21,6 +21,11 @@ public func asyncFunc() async {}
 
 public protocol P {
   func requirement()
+  func requirementWithDefaultImpl()
+}
+
+extension P {
+  public func requirementWithDefaultImpl() {}
 }
 
 public struct S {

--- a/test/IRGen/has_symbol.swift
+++ b/test/IRGen/has_symbol.swift
@@ -113,6 +113,30 @@ public func testEnum(_ e: E) {
 // CHECK: define linkonce_odr hidden i1 @"$s17has_symbol_helper1EO11payloadCaseyAcA1SVcACmFTwS"()
 // CHECK:   ret i1 icmp ne (i32* @"$s17has_symbol_helper1EO11payloadCaseyAcA1SVcACmFWC", i32* null)
 
+public func testOpaqueParameter<T: P>(_ p: T) {
+  // CHECK: %{{[0-9]+}} = call i1 @"$s17has_symbol_helper1PP11requirementyyFTwS"()
+  if #_hasSymbol(p.requirement) {}
+
+  // CHECK: %{{[0-9]+}} = call i1 @"$s17has_symbol_helper1PP26requirementWithDefaultImplyyFTwS"()
+  if #_hasSymbol(p.requirementWithDefaultImpl) {}
+}
+
+// --- P.requirement() ---
+// CHECK: define linkonce_odr hidden i1 @"$s17has_symbol_helper1PP11requirementyyFTwS"()
+// CHECK:   ret i1 icmp ne (void (%swift.opaque*, %swift.type*, i8**)* @"$s17has_symbol_helper1PP11requirementyyF", void (%swift.opaque*, %swift.type*, i8**)* null)
+
+// --- P.requirementWithDefaultImpl() ---
+// CHECK: define linkonce_odr hidden i1 @"$s17has_symbol_helper1PP26requirementWithDefaultImplyyFTwS"()
+// CHECK:   ret i1 icmp ne (void (%swift.opaque*, %swift.type*, i8**)* @"$s17has_symbol_helper1PP26requirementWithDefaultImplyyF", void (%swift.opaque*, %swift.type*, i8**)* null)
+
+public func testExistentialParameter(_ p: any P) {
+  // CHECK: %{{[0-9]+}} = call i1 @"$s17has_symbol_helper1PP11requirementyyFTwS"()
+  if #_hasSymbol(p.requirement) {}
+
+  // CHECK: %{{[0-9]+}} = call i1 @"$s17has_symbol_helper1PP26requirementWithDefaultImplyyFTwS"()
+  if #_hasSymbol(p.requirementWithDefaultImpl) {}
+}
+
 public func testMetatypes() {
   // CHECK: %{{[0-9]+}} = call i1 @"$s17has_symbol_helper1SVTwS"()
   if #_hasSymbol(S.self) {}

--- a/test/SILGen/Inputs/has_symbol_helper.swift
+++ b/test/SILGen/Inputs/has_symbol_helper.swift
@@ -8,6 +8,11 @@ public func genericFunc<T: P>(_ t: T) {}
 
 public protocol P {
   func requirement()
+  func requirementWithDefaultImpl()
+}
+
+extension P {
+  public func requirementWithDefaultImpl() {}
 }
 
 public struct S {

--- a/test/SILGen/has_symbol.swift
+++ b/test/SILGen/has_symbol.swift
@@ -170,16 +170,31 @@ func testEnum(_ e: E) {
 // CHECK: sil @$s17has_symbol_helper1EO6methodyyF : $@convention(method) (@in_guaranteed E) -> ()
 
 
-// CHECK: sil hidden [ossa] @$s4test0A8Protocolyyx17has_symbol_helper1PRzlF : $@convention(thin) <T where T : P> (@in_guaranteed T) -> ()
-func testProtocol<T: P>(_ p: T) {
+// CHECK: sil hidden [ossa] @$s4test0A15OpaqueParameteryyx17has_symbol_helper1PRzlF : $@convention(thin) <T where T : P> (@in_guaranteed T) -> ()
+func testOpaqueParameter<T: P>(_ p: T) {
   // CHECK: [[RES:%[0-9]+]] = has_symbol #P.requirement
   // CHECK: cond_br [[RES]], bb{{[0-9]+}}, bb{{[0-9]+}}
   if #_hasSymbol(p.requirement) {}
+  // CHECK: [[RES:%[0-9]+]] = has_symbol #P.requirementWithDefaultImpl
+  // CHECK: cond_br [[RES]], bb{{[0-9]+}}, bb{{[0-9]+}}
+  if #_hasSymbol(p.requirementWithDefaultImpl) {}
 }
 
 // --- P.requirement() ---
 // CHECK: sil @$s17has_symbol_helper1PP11requirementyyF : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
 
+// --- P.requirementWithDefaultImpl() ---
+// CHECK: sil @$s17has_symbol_helper1PP26requirementWithDefaultImplyyF : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+
+// CHECK: sil hidden [ossa] @$s4test0A20ExistentialParameteryy17has_symbol_helper1P_pF : $@convention(thin) (@in_guaranteed any P) -> ()
+func testExistentialParameter(_ p: any P) {
+  // CHECK: [[RES:%[0-9]+]] = has_symbol #P.requirement
+  // CHECK: cond_br [[RES]], bb{{[0-9]+}}, bb{{[0-9]+}}
+  if #_hasSymbol(p.requirement) {}
+  // CHECK: [[RES:%[0-9]+]] = has_symbol #P.requirementWithDefaultImpl
+  // CHECK: cond_br [[RES]], bb{{[0-9]+}}, bb{{[0-9]+}}
+  if #_hasSymbol(p.requirementWithDefaultImpl) {}
+}
 
 // CHECK: sil hidden [ossa] @$s4test0A9MetatypesyyF : $@convention(thin) () -> ()
 func testMetatypes() {

--- a/test/Sema/Inputs/has_symbol_helper.swift
+++ b/test/Sema/Inputs/has_symbol_helper.swift
@@ -16,6 +16,16 @@ extension P {
   public func requirementWithDefaultImpl() {}
 }
 
+public protocol PAT {
+  associatedtype A
+  func requirement() -> A
+  func requirementWithDefaultImpl()
+}
+
+extension PAT {
+  public func requirementWithDefaultImpl() {}
+}
+
 public struct S {
   public static var staticMember: Int = 0
   public static func staticFunc() {}

--- a/test/Sema/has_symbol.swift
+++ b/test/Sema/has_symbol.swift
@@ -60,6 +60,18 @@ func testEnum(_ e: E) {
   if #_hasSymbol(e.method) {}
 }
 
+func testOpaqueParameter<T: PAT>(_ p: T) {
+  // FIXME: Improve this diagnostic
+  if #_hasSymbol(T.A.self) {} // expected-error {{'#_hasSymbol' condition must refer to a declaration}}
+  if #_hasSymbol(p.requirement) {}
+  if #_hasSymbol(p.requirementWithDefaultImpl) {}
+}
+
+func testExistentialParameter(_ p: any P) {
+  if #_hasSymbol(p.requirement) {}
+  if #_hasSymbol(p.requirementWithDefaultImpl) {}
+}
+
 func testMetatypes() {
   if #_hasSymbol(P.self) {}
   if #_hasSymbol(S.self) {}


### PR DESCRIPTION
Resolves rdar://101063734
