### PR TITLE
Call out time complexity of `String.count`

### DIFF
--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -34,6 +34,11 @@ extension String: BidirectionalCollection {
   public var endIndex: Index { return _guts.endIndex }
 
   /// The number of characters in a string.
+  ///
+  /// To check whether a string is empty,
+  /// use its `isEmpty` property instead of comparing `count` to zero.
+  ///
+  /// - Complexity: O(n), where n is the length of the string.
   @inline(__always)
   public var count: Int {
     return distance(from: startIndex, to: endIndex)


### PR DESCRIPTION
This discussion borrows wording from the docs for the default implementation of [`Collection.count`](https://developer.apple.com/documentation/swift/collection/count-4l4qk), which are inherited by many other symbols, but with a rewrite here because `String` doesn't guarantee random-access performance (doesn't conform to `RandomAccessCollection`), so accessing the count is never an O(1) operation.

Fixes rdar://91570469