### PR TITLE
[Index] Only index system modules in the SDK, not local ones

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -859,6 +859,10 @@ public:
   /// applicable.
   StringRef getModuleLoadedFilename() const;
 
+  /// \returns true if this module is defined under the SDK path.
+  /// If no SDK path is defined, this always returns false.
+  bool isSDKModule() const;
+
   /// \returns true if this module is the "swift" standard library module.
   bool isStdlibModule() const;
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1996,6 +1996,18 @@ StringRef ModuleDecl::getModuleLoadedFilename() const {
   return StringRef();
 }
 
+bool ModuleDecl::isSDKModule() const {
+  if (getASTContext().SearchPathOpts.getSDKPath().empty())
+    return false;
+
+  auto sdkPath = SmallString<8>(),
+       modulePath = SmallString<8>();
+  llvm::sys::path::native(getASTContext().SearchPathOpts.getSDKPath(), sdkPath);
+  llvm::sys::path::native(getModuleSourceFilename(), modulePath);
+
+  return modulePath.startswith(sdkPath);
+}
+
 bool ModuleDecl::isStdlibModule() const {
   return !getParent() && getName() == getASTContext().StdlibModuleName;
 }

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -447,11 +447,12 @@ static void addModuleDependencies(ArrayRef<ImportedModule> imports,
             }
           } else {
             // Serialized AST file.
-            // Only index system modules (essentially stdlib and overlays).
+            // Only index system modules from the SDK, and the stdlib.
             // We don't officially support binary swift modules, so normally
             // the index data for user modules would get generated while
             // building them.
             if (mod->isSystemModule() && indexSystemModules &&
+                (mod->isSDKModule() || mod->isStdlibModule()) &&
                 (!skipStdlib || !mod->isStdlibModule())) {
               emitDataForSwiftSerializedModule(mod, indexStorePath,
                                                indexClangModules,

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -447,12 +447,13 @@ static void addModuleDependencies(ArrayRef<ImportedModule> imports,
             }
           } else {
             // Serialized AST file.
-            // Only index system modules from the SDK, and the stdlib.
+            // Only index distributed system modules, and the stdlib.
             // We don't officially support binary swift modules, so normally
             // the index data for user modules would get generated while
             // building them.
+            bool isDistributedModule = mod->isSDKModule();
             if (mod->isSystemModule() && indexSystemModules &&
-                (mod->isSDKModule() || mod->isStdlibModule()) &&
+                (isDistributedModule || mod->isStdlibModule()) &&
                 (!skipStdlib || !mod->isStdlibModule())) {
               emitDataForSwiftSerializedModule(mod, indexStorePath,
                                                indexClangModules,

--- a/test/Index/Store/cross-import-overlay.swift
+++ b/test/Index/Store/cross-import-overlay.swift
@@ -3,7 +3,7 @@
 // RUN: cp -r %S/../Inputs/CrossImport %t/CrossImport
 // RUN: %{python} %S/../../CrossImport/Inputs/rewrite-module-triples.py %t/CrossImport %module-target-triple
 
-// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -c -index-store-path %t/idx -module-cache-path %t/mcp -index-system-modules -index-ignore-stdlib -enable-cross-import-overlays %s -Fsystem %t/CrossImport -o %t/file1.o -module-name cross_import_overlay
+// RUN: %target-swift-frontend -disable-implicit-concurrency-module-import -disable-implicit-string-processing-module-import -c -index-store-path %t/idx -module-cache-path %t/mcp -index-system-modules -index-ignore-stdlib -enable-cross-import-overlays %s -Fsystem %t/CrossImport -o %t/file1.o -module-name cross_import_overlay -sdk %t
 // RUN: c-index-test core -print-unit %t/idx > %t/units
 
 import A

--- a/test/Index/index_only_sdk_system_modules.swift
+++ b/test/Index/index_only_sdk_system_modules.swift
@@ -1,0 +1,60 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/cache)
+// RUN: %empty-directory(%t/idx)
+// RUN: %empty-directory(%t/sdk)
+// RUN: split-file %s %t
+
+/// Create a Swift module to import.
+// RUN: cp %t/module.modulemap %t/sdk/
+// RUN: %target-swift-frontend -emit-module \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -emit-module-path %t/sdk/LocalSystemModule.swiftmodule \
+// RUN:   -emit-module-interface-path %t/sdk/LocalSystemModule.swiftinterface \
+// RUN:   %t/LocalSystemModule.swift -I %t/sdk \
+// RUN:   -enable-testing
+
+/// Build a test client once with indexing, not setting an SDK.
+// RUN: %target-swift-frontend -typecheck %t/TestClient.swift \
+// RUN:   -I %t/sdk -module-cache-path %t/cache \
+// RUN:   -index-system-modules \
+// RUN:   -index-store-path %t/idx \
+// RUN:   -index-ignore-stdlib \
+// RUN:   -sdk %t/someothersdk -Rmodule-loading 2>&1 \
+// RUN:   | %FileCheck -check-prefix=CHECK-SWIFTMODULE %s
+// CHECK-SWIFTMODULE: source: '{{.*}}LocalSystemModule.swiftmodule'
+
+/// Build the test client again not setting an SDK, this one should still use
+/// the adjacent module that is built for testing.
+// RUN: %target-swift-frontend -typecheck %t/TestClient.swift \
+// RUN:   -I %t/sdk -module-cache-path %t/cache \
+// RUN:   -sdk %t/someothersdk -Rmodule-loading 2>&1 \
+// RUN:   | %FileCheck -check-prefix=CHECK-SWIFTMODULE %s
+
+/// @testable import of a module in the SDK works once but not after it's cached.
+// RUN: %empty-directory(%t/idx)
+// RUN: %target-swift-frontend -typecheck %t/TestClient.swift \
+// RUN:   -I %t/sdk -module-cache-path %t/cache \
+// RUN:   -index-system-modules \
+// RUN:   -index-store-path %t/idx \
+// RUN:   -index-ignore-stdlib \
+// RUN:   -sdk %t/sdk -Rmodule-loading 2>&1 \
+// RUN:   | %FileCheck -check-prefix=CHECK-SWIFTMODULE %s
+
+/// Failing case when building against the cached swiftmodule.
+// RUN: %target-swift-frontend -typecheck %t/TestClient.swift \
+// RUN:   -I %t/sdk -module-cache-path %t/cache \
+// RUN:   -sdk %t/sdk -Rmodule-loading \
+// RUN:   -verify -verify-ignore-unknown -show-diagnostics-after-fatal 2>&1
+
+//--- module.modulemap
+
+module LocalSystemModule [system] { }
+
+//--- LocalSystemModule.swift
+
+@_exported import LocalSystemModule
+
+//--- TestClient.swift
+
+@testable import LocalSystemModule // expected-error {{module 'LocalSystemModule' was not compiled for testing}}
+// expected-remark @-1 {{LocalSystemModule.swiftinterface}}


### PR DESCRIPTION
Indexing a module from the swiftinterface puts the swiftinterface-sourced swiftmodule in the cache. Subsequent builds don't see the adjacent swiftmodule file and use the cached one. This can break test clients that need the adjacent swiftmodule information. To avoid this scenario and get a more sound behavior, ensure that we only index system modules in the SDK, not local versions.

rdar://102207620