### PR TITLE
[IDE] Implement completion-like cursor info for ValueDecls

### DIFF
--- a/include/swift/IDE/CursorInfo.h
+++ b/include/swift/IDE/CursorInfo.h
@@ -1,0 +1,40 @@
+//===--- CursorInfo.h --- ---------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_IDE_CURSORINFO_H
+#define SWIFT_IDE_CURSORINFO_H
+
+#include "swift/AST/Type.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/IDE/Utils.h"
+
+namespace swift {
+class CodeCompletionCallbacksFactory;
+
+namespace ide {
+
+/// An abstract base class for consumers of context info results.
+class CursorInfoConsumer {
+public:
+  virtual ~CursorInfoConsumer() {}
+  virtual void handleResults(const ResolvedCursorInfo &) = 0;
+};
+
+/// Create a factory for code completion callbacks.
+CodeCompletionCallbacksFactory *
+makeCursorInfoCallbacksFactory(CursorInfoConsumer &Consumer,
+                               SourceLoc RequestedLoc);
+
+} // namespace ide
+} // namespace swift
+
+#endif // SWIFT_IDE_CURSORINFO_H

--- a/include/swift/IDETool/CompletionInstance.h
+++ b/include/swift/IDETool/CompletionInstance.h
@@ -161,7 +161,7 @@ class CompletionInstance {
       swift::CompilerInvocation &Invocation, llvm::ArrayRef<const char *> Args,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
       llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
-      DiagnosticConsumer *DiagC,
+      DiagnosticConsumer *DiagC, bool IgnoreSwiftSourceInfo,
       std::shared_ptr<std::atomic<bool>> CancellationFlag,
       llvm::function_ref<void(CancellableResult<CompletionInstanceResult>)>
           Callback);

--- a/include/swift/IDETool/CompletionInstance.h
+++ b/include/swift/IDETool/CompletionInstance.h
@@ -19,6 +19,7 @@
 #include "swift/IDE/CodeCompletionResult.h"
 #include "swift/IDE/CodeCompletionResultSink.h"
 #include "swift/IDE/ConformingMethodList.h"
+#include "swift/IDE/CursorInfo.h"
 #include "swift/IDE/ImportDepth.h"
 #include "swift/IDE/SwiftCompletionInfo.h"
 #include "swift/IDE/TypeContextInfo.h"
@@ -74,6 +75,14 @@ struct TypeContextInfoResult {
 struct ConformingMethodListResults {
   /// The actual results. If \c nullptr, no results were found.
   const ConformingMethodListResult *Result;
+  /// Whether an AST was reused for the completion.
+  bool DidReuseAST;
+};
+
+/// The results returned from \c CompletionInstance::conformingMethodList.
+struct CursorInfoResults {
+  /// The actual results. If \c nullptr, no results were found.
+  const ResolvedCursorInfo *Result;
   /// Whether an AST was reused for the completion.
   bool DidReuseAST;
 };
@@ -192,6 +201,14 @@ public:
       std::shared_ptr<std::atomic<bool>> CancellationFlag,
       llvm::function_ref<void(CancellableResult<ConformingMethodListResults>)>
           Callback);
+
+  void cursorInfo(
+      swift::CompilerInvocation &Invocation, llvm::ArrayRef<const char *> Args,
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
+      llvm::MemoryBuffer *completionBuffer, unsigned int Offset,
+      DiagnosticConsumer *DiagC,
+      std::shared_ptr<std::atomic<bool>> CancellationFlag,
+      llvm::function_ref<void(CancellableResult<CursorInfoResults>)> Callback);
 };
 
 } // namespace ide

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -192,7 +192,7 @@ public:
   }
 
   bool isCodeCompletionFirstPass() const {
-    return L->isCodeCompletion() && !CodeCompletion;
+    return SourceMgr.hasCodeCompletionBuffer() && !CodeCompletion;
   }
 
   bool allowTopLevelCode() const;

--- a/lib/IDE/CMakeLists.txt
+++ b/lib/IDE/CMakeLists.txt
@@ -18,6 +18,7 @@ add_swift_host_library(swiftIDE STATIC
   CompletionLookup.cpp
   CompletionOverrideLookup.cpp
   ConformingMethodList.cpp
+  CursorInfo.cpp
   ExprCompletion.cpp
   ExprContextAnalysis.cpp
   Formatting.cpp

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -1,0 +1,278 @@
+//===--- CursorInfo.cpp ---------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/IDE/CursorInfo.h"
+#include "ExprContextAnalysis.h"
+#include "swift/AST/ASTDemangler.h"
+#include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/NameLookup.h"
+#include "swift/AST/USRGeneration.h"
+#include "swift/IDE/TypeCheckCompletionCallback.h"
+#include "swift/Parse/CodeCompletionCallbacks.h"
+#include "swift/Sema/ConstraintSystem.h"
+#include "swift/Sema/IDETypeChecking.h"
+#include "clang/AST/Attr.h"
+#include "clang/AST/Decl.h"
+#include "clang/Basic/Module.h"
+
+using namespace swift;
+using namespace swift::constraints;
+using namespace ide;
+
+namespace {
+
+// MARK: - Utilities
+
+void typeCheckDeclAndParentClosures(ValueDecl *VD) {
+  // We need to type check any parent closures because their types are
+  // encoded in the USR of ParentContexts in the cursor info response.
+  auto DC = VD->getDeclContext();
+  while (DC->getParent()) {
+    if (auto Closure = dyn_cast<AbstractClosureExpr>(DC)) {
+      if (Closure->getType().isNull()) {
+        typeCheckASTNodeAtLoc(
+            TypeCheckASTNodeAtLocContext::declContext(DC->getParent()),
+            Closure->getLoc());
+      }
+    }
+    DC = DC->getParent();
+  }
+
+  typeCheckASTNodeAtLoc(
+      TypeCheckASTNodeAtLocContext::declContext(VD->getDeclContext()),
+      VD->getLoc());
+}
+
+// MARK: - NodeFinderResults
+
+enum class NodeFinderResultKind { Decl };
+
+class NodeFinderResult {
+  NodeFinderResultKind Kind;
+
+protected:
+  NodeFinderResult(NodeFinderResultKind Kind) : Kind(Kind) {}
+
+public:
+  NodeFinderResultKind getKind() const { return Kind; }
+};
+
+class NodeFinderDeclResult : public NodeFinderResult {
+  ValueDecl *ValueD;
+
+public:
+  NodeFinderDeclResult(ValueDecl *ValueD)
+      : NodeFinderResult(NodeFinderResultKind::Decl), ValueD(ValueD) {}
+
+  ValueDecl *getDecl() const { return ValueD; }
+
+  static bool classof(const NodeFinderResult *Res) {
+    return Res->getKind() == NodeFinderResultKind::Decl;
+  }
+};
+
+// MARK: - NodeFinder
+
+/// Walks the AST, looking for a node at \c LocToResolve. While walking the
+/// AST, also gathers information about shorthand shadows.
+class NodeFinder : ASTWalker {
+  SourceFile &SrcFile;
+  SourceLoc LocToResolve;
+
+  /// As we are walking the tree, this variable is updated to the last seen
+  /// DeclContext.
+  SmallVector<DeclContext *> DeclContextStack;
+
+  /// The found node.
+  std::unique_ptr<NodeFinderResult> Result;
+
+  /// If a decl shadows another decl using shorthand syntax (`[foo]` or
+  /// `if let foo {`), this maps the re-declared variable to the one that is
+  /// being shadowed.
+  /// The transitive closure of shorthand shadowed decls should be reported as
+  /// additional results in cursor info.
+  llvm::DenseMap<ValueDecl *, ValueDecl *> ShorthandShadowedDecls;
+
+public:
+  NodeFinder(SourceFile &SrcFile, SourceLoc LocToResolve)
+      : SrcFile(SrcFile), LocToResolve(LocToResolve),
+        DeclContextStack({&SrcFile}) {}
+
+  void resolve() { SrcFile.walk(*this); }
+
+  std::unique_ptr<NodeFinderResult> takeResult() { return std::move(Result); }
+
+  /// Get the declarations that \p ShadowingDecl shadows using shorthand shadow
+  /// syntax.
+  SmallVector<ValueDecl *, 2>
+  getShorthandShadowedDecls(ValueDecl *ShadowingDecl) {
+    SmallVector<ValueDecl *, 2> Result;
+    auto ShorthandShadowedDecl = ShorthandShadowedDecls[ShadowingDecl];
+    while (ShorthandShadowedDecl) {
+      Result.push_back(ShorthandShadowedDecl);
+      ShorthandShadowedDecl = ShorthandShadowedDecls[ShorthandShadowedDecl];
+    }
+    return Result;
+  }
+
+private:
+  SourceManager &getSourceMgr() const {
+    return SrcFile.getASTContext().SourceMgr;
+  }
+
+  /// The decl context that is currently being walked.
+  DeclContext *getCurrentDeclContext() { return DeclContextStack.back(); }
+
+  bool rangeContainsLocToResolve(SourceRange Range) const {
+    return Range.contains(LocToResolve);
+  }
+
+  PreWalkAction walkToDeclPre(Decl *D) override {
+    if (!rangeContainsLocToResolve(D->getSourceRangeIncludingAttrs())) {
+      return PreWalkAction::SkipChildren;
+    }
+
+    if (auto *newDC = dyn_cast<DeclContext>(D)) {
+      DeclContextStack.push_back(newDC);
+    }
+
+    if (D->getLoc() != LocToResolve) {
+      return Action::Continue();
+    }
+
+    if (auto VD = dyn_cast<ValueDecl>(D)) {
+      if (VD->hasName()) {
+        assert(Result == nullptr);
+        Result = std::make_unique<NodeFinderDeclResult>(VD);
+        return Action::Stop();
+      }
+    }
+
+    return Action::Continue();
+  }
+
+  PostWalkAction walkToDeclPost(Decl *D) override {
+    if (auto *newDC = dyn_cast<DeclContext>(D)) {
+      assert(DeclContextStack.back() == newDC);
+      DeclContextStack.pop_back();
+    }
+    return Action::Continue();
+  }
+
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
+    if (auto closure = dyn_cast<ClosureExpr>(E)) {
+      DeclContextStack.push_back(closure);
+    }
+
+    if (auto CaptureList = dyn_cast<CaptureListExpr>(E)) {
+      for (auto ShorthandShadows :
+           getShorthandShadows(CaptureList, getCurrentDeclContext())) {
+        assert(ShorthandShadowedDecls.count(ShorthandShadows.first) == 0);
+        ShorthandShadowedDecls[ShorthandShadows.first] =
+            ShorthandShadows.second;
+      }
+    }
+
+    return Action::Continue(E);
+  }
+
+  PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
+    if (auto *closure = dyn_cast<ClosureExpr>(E)) {
+      assert(DeclContextStack.back() == closure);
+      DeclContextStack.pop_back();
+    }
+    return Action::Continue(E);
+  }
+
+  PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
+    if (auto CondStmt = dyn_cast<LabeledConditionalStmt>(S)) {
+      for (auto ShorthandShadow :
+           getShorthandShadows(CondStmt, getCurrentDeclContext())) {
+        assert(ShorthandShadowedDecls.count(ShorthandShadow.first) == 0);
+        ShorthandShadowedDecls[ShorthandShadow.first] = ShorthandShadow.second;
+      }
+    }
+    return Action::Continue(S);
+  }
+};
+
+// MARK: - CursorInfoDoneParsingCallback
+
+class CursorInfoDoneParsingCallback : public CodeCompletionCallbacks {
+  CursorInfoConsumer &Consumer;
+  SourceLoc RequestedLoc;
+
+public:
+  CursorInfoDoneParsingCallback(Parser &P, CursorInfoConsumer &Consumer,
+                                SourceLoc RequestedLoc)
+      : CodeCompletionCallbacks(P), Consumer(Consumer),
+        RequestedLoc(RequestedLoc) {}
+
+  std::unique_ptr<ResolvedCursorInfo>
+  getDeclResult(NodeFinderDeclResult *DeclResult, SourceFile *SrcFile,
+                NodeFinder &Finder) const {
+    typeCheckDeclAndParentClosures(DeclResult->getDecl());
+    auto CursorInfo = std::make_unique<ResolvedValueRefCursorInfo>(
+        ResolvedCursorInfo(SrcFile), DeclResult->getDecl(),
+        /*CtorTyRef=*/nullptr,
+        /*ExtTyRef=*/nullptr, /*IsRef=*/false, /*Ty=*/Type(),
+        /*ContainerType=*/Type());
+    CursorInfo->setLoc(RequestedLoc);
+    CursorInfo->setShorthandShadowedDecls(
+        Finder.getShorthandShadowedDecls(DeclResult->getDecl()));
+    return CursorInfo;
+  }
+
+  void doneParsing(SourceFile *SrcFile) override {
+    if (!SrcFile) {
+      return;
+    }
+    NodeFinder Finder(*SrcFile, RequestedLoc);
+    Finder.resolve();
+    auto Result = Finder.takeResult();
+    if (!Result) {
+      return;
+    }
+    std::unique_ptr<ResolvedCursorInfo> CursorInfo;
+    switch (Result->getKind()) {
+    case NodeFinderResultKind::Decl:
+      CursorInfo = getDeclResult(cast<NodeFinderDeclResult>(Result.get()),
+                                 SrcFile, Finder);
+      break;
+    }
+    if (Result) {
+      Consumer.handleResults(*CursorInfo);
+    }
+  }
+};
+
+} // anonymous namespace.
+
+CodeCompletionCallbacksFactory *
+swift::ide::makeCursorInfoCallbacksFactory(CursorInfoConsumer &Consumer,
+                                           SourceLoc RequestedLoc) {
+  class CursorInfoCallbacksFactoryImpl : public CodeCompletionCallbacksFactory {
+    CursorInfoConsumer &Consumer;
+    SourceLoc RequestedLoc;
+
+  public:
+    CursorInfoCallbacksFactoryImpl(CursorInfoConsumer &Consumer,
+                                   SourceLoc RequestedLoc)
+        : Consumer(Consumer), RequestedLoc(RequestedLoc) {}
+
+    CodeCompletionCallbacks *createCodeCompletionCallbacks(Parser &P) override {
+      return new CursorInfoDoneParsingCallback(P, Consumer, RequestedLoc);
+    }
+  };
+
+  return new CursorInfoCallbacksFactoryImpl(Consumer, RequestedLoc);
+}

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -209,8 +209,13 @@ void Lexer::initialize(unsigned Offset, unsigned EndOffset) {
   // Initialize code completion.
   if (BufferID == SourceMgr.getCodeCompletionBufferID()) {
     const char *Ptr = BufferStart + SourceMgr.getCodeCompletionOffset();
-    if (Ptr >= BufferStart && Ptr <= BufferEnd)
+    // If the pointer points to a null byte, it's the null byte that was
+    // inserted to mark the code completion token. If the IDE inspection offset
+    // points to a normal character, no code completion token should be
+    // inserted.
+    if (Ptr >= BufferStart && Ptr <= BufferEnd && *Ptr == '\0') {
       CodeCompletionPtr = Ptr;
+    }
   }
 
   ArtificialEOF = BufferStart + EndOffset;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1388,9 +1388,7 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
       assert(activeElements.size() == 1 && activeElements[0].is<Expr *>());
       auto expr = activeElements[0].get<Expr *>();
       ParserStatus status(ICD);
-      if (SourceMgr.getCodeCompletionLoc().isValid() &&
-          SourceMgr.rangeContainsTokenLoc(expr->getSourceRange(),
-                                          SourceMgr.getCodeCompletionLoc()))
+      if (SourceMgr.rangeContainsCodeCompletionLoc(expr->getSourceRange()) && L->isCodeCompletion())
         status.setHasCodeCompletion();
       hasBindOptional |= exprsWithBindOptional.contains(expr);
       Result = makeParserResult(status, expr);
@@ -2818,9 +2816,12 @@ ParserResult<Expr> Parser::parseExprClosure() {
     // Ignore 'CodeCompletionDelayedDeclState' inside closures.
     // Completions inside functions body inside closures at top level should
     // be considered top-level completions.
-    if (State->hasCodeCompletionDelayedDeclState())
+    if (State->hasCodeCompletionDelayedDeclState()) {
       (void)State->takeCodeCompletionDelayedDeclState();
-    Status.setHasCodeCompletionAndIsError();
+    }
+    if (L->isCodeCompletion()) {
+      Status.setHasCodeCompletionAndIsError();
+    }
   }
 
   // Parse the closing '}'.

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1029,7 +1029,7 @@ ParserResult<Pattern> Parser::parseTypedPattern() {
       // as typed patterns, such as "var x: [Int]()".
       // Disable this tentative parse when in code-completion mode, otherwise
       // code-completion may enter the delayed-decl state twice.
-      if (Tok.isFollowingLParen() && !L->isCodeCompletion()) {
+      if (Tok.isFollowingLParen() && !SourceMgr.hasCodeCompletionBuffer()) {
         CancellableBacktrackingScope backtrack(*this);
 
         // Create a local context if needed so we can parse trailing closures.

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -116,6 +116,11 @@ bool CodeCompletionSecondPassRequest::evaluate(
   if (!parserState->hasCodeCompletionDelayedDeclState())
     return true;
 
+  // Decrement the closure discriminator index by one so a top-level closure
+  // gets the same discriminator as before when being re-parsed in the second
+  // pass.
+  parserState->getTopLevelContext().overrideNextClosureDiscriminator(
+      parserState->getTopLevelContext().claimNextClosureDiscriminator() - 1);
   auto state = parserState->takeCodeCompletionDelayedDeclState();
   auto &Ctx = SF->getASTContext();
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5297,7 +5297,7 @@ bool ConstraintSystem::repairFailures(
         // other (explicit) argument's so source range containment alone isn't
         // sufficient.
         bool isSynthesizedArg = arg->isImplicit() && isa<DeclRefExpr>(arg);
-        if (!isSynthesizedArg && containsCodeCompletionLoc(arg) &&
+        if (!isSynthesizedArg && isForCodeCompletion() && containsCodeCompletionLoc(arg) &&
             !lhs->isVoid() && !lhs->isUninhabited())
           return true;
       }

--- a/test/SourceKit/CompileNotifications/cursor-info.swift
+++ b/test/SourceKit/CompileNotifications/cursor-info.swift
@@ -9,5 +9,15 @@
 // COMPILE_1:   key.notification: source.notification.compile-did-finish,
 // COMPILE_1:   key.compileid: [[CID1]]
 // COMPILE_1: }
+// FIXME: Once we switch to only run solver-based cursor info, we should only receive a single compile notification
+// COMPILE_1: {
+// COMPILE_1:  key.notification: source.notification.compile-will-start,
+// COMPILE_1:  key.filepath: "SOURCE_DIR{{.*}}cursor-info.swift",
+// COMPILE_1:  key.compileid: [[CID2:".*"]]
+// COMPILE_1: }
+// COMPILE_1: {
+// COMPILE_1:   key.notification: source.notification.compile-did-finish,
+// COMPILE_1:   key.compileid: [[CID2]]
+// COMPILE_1: }
 // COMPILE_1-NOT: compile-will-start
 // COMPILE_1-NOT: compile-did-finish

--- a/test/SourceKit/CursorInfo/completion_like_cursor_with_edit.swift
+++ b/test/SourceKit/CursorInfo/completion_like_cursor_with_edit.swift
@@ -1,0 +1,13 @@
+// RUN: %sourcekitd-test -req=open %s -- %s == \
+// RUN: -req=edit -pos=7:16 -length=0 -replace=yyy %s == \
+// RUN: -req=cursor -pos=7:16 %s -- %s | %FileCheck %s
+
+class SceneDelegate {
+    func scene(_ scene: String?) {
+        if let xxx = scene {
+        }
+    }
+}
+
+// CHECK: source.lang.swift.decl.var.local (7:16-7:22)
+// CHECK-NEXT: yyyxxx

--- a/test/SourceKit/CursorInfo/cursor_in_closure_initializing_var.swift
+++ b/test/SourceKit/CursorInfo/cursor_in_closure_initializing_var.swift
@@ -1,0 +1,10 @@
+// RUN: %sourcekitd-test -req=cursor -pos=5:13 %s -- %s | %FileCheck %s
+
+class MyClass {
+    lazy var calculatorContext: Int = {
+        let context = 1
+        return context
+    }()
+}
+
+// CHECK: s:34cursor_in_closure_initializing_var7MyClassC17calculatorContextSivgSiyXEfU_7contextL_Sivp

--- a/test/SourceKit/CursorInfo/cursor_in_global_closure.swift
+++ b/test/SourceKit/CursorInfo/cursor_in_global_closure.swift
@@ -1,0 +1,6 @@
+// RUN: %sourcekitd-test -req=cursor -pos=4:9 %s -- %s | %FileCheck %s
+
+fileprivate let formatter: DateFormatter = {
+    let formatter
+
+// CHECK: s:24cursor_in_global_closureXefU_9formatterL_Xevp

--- a/test/SourceKit/CursorInfo/cursor_in_pound_if.swift
+++ b/test/SourceKit/CursorInfo/cursor_in_pound_if.swift
@@ -1,0 +1,13 @@
+// RUN: %sourcekitd-test -req=cursor -pos=6:7 %s -- %s | %FileCheck %s --check-prefix=CHECK-INT
+// RUN: %sourcekitd-test -req=cursor -pos=8:7 %s -- %s | %FileCheck %s --check-prefix=CHECK-STR
+
+func foo() {
+#if USE_INT
+  let xxx = 1
+#else
+  let xxx = "hello"
+#endif
+}
+// TODO: Once we switch to use the solver-based cursor info implementation, we also receive results for the int case
+// CHECK-INT: Unable to resolve cursor info
+// CHECK-STR: <Declaration>let xxx: <Type usr="s:SS">String</Type></Declaration>

--- a/test/SourceKit/CursorInfo/cursor_in_top_level_closure.swift
+++ b/test/SourceKit/CursorInfo/cursor_in_top_level_closure.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t/split)
+// RUN: %{python} %utils/split_file.py -o %t/split %s
+// RUN: %empty-directory(%t/build)
+// RUN: %sourcekitd-test -req=cursor -pos=5:9 %t/split/MovieRow.swift -- %t/split/MovieRow.swift %t/split/Color.swift | %FileCheck %s
+
+// BEGIN Color.swift
+
+extension Invalid {}
+
+// BEGIN MovieRow.swift
+
+struct Bar {}
+
+fileprivate let bar: Bar = {
+    let bar = Bar()
+    return bar
+}()
+
+
+// CHECK: source.lang.swift.decl.var.local (5:9-5:12)
+// CHECK-NEXT: bar
+// CHECK: RELATED BEGIN
+// CHECK-NEXT: <RelatedName usr="s:4main3bar33_F48676AE0C86F007C79C860E40EDA2D3LLAA3BarVvp">bar</RelatedName>
+// CHECK-NEXT: RELATED END

--- a/test/SourceKit/CursorInfo/cursor_uses_swiftsourceinfo.swift
+++ b/test/SourceKit/CursorInfo/cursor_uses_swiftsourceinfo.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t/split)
+// RUN: %{python} %utils/split_file.py -o %t/split %s
+// RUN: %empty-directory(%t/build)
+// RUN: %target-swift-frontend -emit-module -module-name MyModule -emit-module-path %t/build/MyModule.swiftmodule -emit-module-source-info-path %t/build/MyModule.swiftsourceinfo %t/split/Action.swift
+// RUN: %sourcekitd-test -req=cursor -req-opts=retrieve_symbol_graph=1 -pos=5:14 %t/split/test.swift -- %t/split/test.swift -I %t/build | %FileCheck %s
+
+// BEGIN Action.swift
+public protocol Action {}
+
+// BEGIN test.swift
+import MyModule
+
+func test(action: Action) {
+    switch action {
+    case let action
+
+// CHECK: REFERENCED DECLS BEGIN
+// CHECK-NEXT: s:8MyModule6ActionP | public | {{.*}}/split/Action.swift | MyModule | User | NonSPI | source.lang.swift
+// CHECK-NEXT: Action swift.protocol s:8MyModule6ActionP
+// CHECK-NEXT: REFERENCED DECLS END

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -652,7 +652,8 @@ std::unique_ptr<llvm::MemoryBuffer> SwiftASTManager::getMemoryBuffer(
     StringRef Filename,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
     std::string &Error) {
-  return Impl.getMemoryBuffer(Filename, FileSystem, Error);
+  return Impl.getFileContent(Filename, /*IsPrimary=*/false, FileSystem, Error)
+      .Buffer;
 }
 
 static FrontendInputsAndOutputs


### PR DESCRIPTION
This brings up the ability to compute cursor info results using the completion-like type checking paradigm, which an reuse ASTContexts and doesn’t need to type check the entire file.

For now, the new implementation only supports cursor info on `ValueDecl`s (not on references) because they were easiest to implement. More cursor info kinds are coming soon.

At the moment, we only run the new implementation in a verification mode: It is only invoked in assert toolchains and when run, we check that the results are equivalent to the old implementation. Once more cursor info kinds are implemented and if the SourceKit stress tester doesn’t find any verification issues, we can enable the new implementation, falling back to the old implementation if the new one didn’t produce any results.