### PR TITLE
[AST] Add descriptions for statement kinds

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -51,6 +51,7 @@ namespace swift {
   enum class StaticSpellingKind : uint8_t;
   enum class DescriptiveDeclKind : uint8_t;
   enum DeclAttrKind : unsigned;
+  enum class StmtKind;
 
   /// Enumeration describing all of possible diagnostics.
   ///
@@ -116,6 +117,7 @@ namespace swift {
     ReferenceOwnership,
     StaticSpellingKind,
     DescriptiveDeclKind,
+    DescriptiveStmtKind,
     DeclAttribute,
     VersionTuple,
     LayoutConstraint,
@@ -149,6 +151,7 @@ namespace swift {
       ReferenceOwnership ReferenceOwnershipVal;
       StaticSpellingKind StaticSpellingKindVal;
       DescriptiveDeclKind DescriptiveDeclKindVal;
+      StmtKind DescriptiveStmtKindVal;
       const DeclAttribute *DeclAttributeVal;
       llvm::VersionTuple VersionVal;
       LayoutConstraint LayoutConstraintVal;
@@ -234,6 +237,10 @@ namespace swift {
     DiagnosticArgument(DescriptiveDeclKind DDK)
         : Kind(DiagnosticArgumentKind::DescriptiveDeclKind),
           DescriptiveDeclKindVal(DDK) {}
+
+    DiagnosticArgument(StmtKind SK)
+        : Kind(DiagnosticArgumentKind::DescriptiveStmtKind),
+          DescriptiveStmtKindVal(SK) {}
 
     DiagnosticArgument(const DeclAttribute *attr)
         : Kind(DiagnosticArgumentKind::DeclAttribute),
@@ -339,6 +346,11 @@ namespace swift {
     DescriptiveDeclKind getAsDescriptiveDeclKind() const {
       assert(Kind == DiagnosticArgumentKind::DescriptiveDeclKind);
       return DescriptiveDeclKindVal;
+    }
+
+    StmtKind getAsDescriptiveStmtKind() const {
+      assert(Kind == DiagnosticArgumentKind::DescriptiveStmtKind);
+      return DescriptiveStmtKindVal;
     }
 
     const DeclAttribute *getAsDeclAttribute() const {

--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -120,6 +120,10 @@ public:
   /// to the user of the compiler in any way.
   static StringRef getKindName(StmtKind kind);
 
+  /// Retrieve the descriptive kind name for a given statement. This is suitable
+  /// for use in diagnostics.
+  static StringRef getDescriptiveKindName(StmtKind K);
+
   /// Return the location of the start of the statement.
   SourceLoc getStartLoc() const;
   

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/Pattern.h"
 #include "swift/AST/PrintOptions.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/AST/Stmt.h"
 #include "swift/AST/TypeRepr.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Config.h"
@@ -802,6 +803,11 @@ static void formatDiagnosticArgument(StringRef Modifier,
     assert(Modifier.empty() &&
            "Improper modifier for DescriptiveDeclKind argument");
     Out << Decl::getDescriptiveKindName(Arg.getAsDescriptiveDeclKind());
+    break;
+
+  case DiagnosticArgumentKind::DescriptiveStmtKind:
+    assert(Modifier.empty() && "Improper modifier for StmtKind argument");
+    Out << Stmt::getDescriptiveKindName(Arg.getAsDescriptiveStmtKind());
     break;
 
   case DiagnosticArgumentKind::DeclAttribute:

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -42,6 +42,50 @@ StringRef Stmt::getKindName(StmtKind K) {
   llvm_unreachable("bad StmtKind");
 }
 
+StringRef Stmt::getDescriptiveKindName(StmtKind K) {
+  switch (K) {
+  case StmtKind::Brace:
+    return "brace";
+  case StmtKind::Return:
+    return "return";
+  case StmtKind::Yield:
+    return "yield";
+  case StmtKind::Defer:
+    return "defer";
+  case StmtKind::If:
+    return "if";
+  case StmtKind::Guard:
+    return "guard";
+  case StmtKind::While:
+    return "while";
+  case StmtKind::Do:
+    return "do";
+  case StmtKind::DoCatch:
+    return "do-catch";
+  case StmtKind::RepeatWhile:
+    return "repeat-while";
+  case StmtKind::ForEach:
+    return "for-in";
+  case StmtKind::Switch:
+    return "switch";
+  case StmtKind::Case:
+    return "case";
+  case StmtKind::Break:
+    return "break";
+  case StmtKind::Continue:
+    return "continue";
+  case StmtKind::Fallthrough:
+    return "fallthrough";
+  case StmtKind::Fail:
+    return "return";
+  case StmtKind::Throw:
+    return "throw";
+  case StmtKind::PoundAssert:
+    return "#assert";
+  }
+  llvm_unreachable("Unhandled case in switch!");
+}
+
 // Helper functions to check statically whether a method has been
 // overridden from its implementation in Stmt.  The sort of thing you
 // need when you're avoiding v-tables.


### PR DESCRIPTION
And plumb through the logic such that the DiagnosticEngine can handle StmtKind args. We could introduce a separate DescriptiveStmtKind a la DescriptiveDeclKind, but it would be a 1:1 map, so I'm not convinced it's currently worth doing.