### PR TITLE
Loop on Win32 to satisfy large random byte requests (as is done on Linux)

### DIFF
--- a/stdlib/public/stubs/Random.cpp
+++ b/stdlib/public/stubs/Random.cpp
@@ -19,6 +19,7 @@
 
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
 #include <Windows.h>
 #include <Bcrypt.h>
 #pragma comment(lib, "bcrypt.lib")

--- a/stdlib/public/stubs/Random.cpp
+++ b/stdlib/public/stubs/Random.cpp
@@ -65,16 +65,18 @@ void swift_stdlib_random(void *buf, __swift_size_t nbytes) {
 
 SWIFT_RUNTIME_STDLIB_API
 void swift_stdlib_random(void *buf, __swift_size_t nbytes) {
-  if (nbytes > ULONG_MAX) {
-    fatalError(0, "Fatal error: %zd exceeds ULONG_MAX\n", nbytes);
-  }
+  while (nbytes > 0) {
+    auto actual_nbytes = std::min(nbytes, (__swift_size_t)ULONG_MAX);
+    NTSTATUS status = BCryptGenRandom(nullptr,
+                                      static_cast<PUCHAR>(buf),
+                                      static_cast<ULONG>(actual_nbytes),
+                                      BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+    if (!BCRYPT_SUCCESS(status)) {
+      fatalError(0, "Fatal error: 0x%lX in '%s'\n", status, __func__);
+    }
 
-  NTSTATUS status = BCryptGenRandom(nullptr,
-                                    static_cast<PUCHAR>(buf),
-                                    static_cast<ULONG>(nbytes),
-                                    BCRYPT_USE_SYSTEM_PREFERRED_RNG);
-  if (!BCRYPT_SUCCESS(status)) {
-    fatalError(0, "Fatal error: 0x%lX in '%s'\n", status, __func__);
+    buf = static_cast<uint8_t *>(buf) + actual_nbytes;
+    nbytes -= actual_nbytes;
   }
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This change resolves a crash on Windows when using `SystemRandomNumberGenerator` and requesting a very large number (> `ULONG_MAX`) of random bytes.

In practice, it's unlikely anyone will be requesting more than 4GB of random bytes, but we don't abort on other platforms and nothing about the API suggests that a large buffer size is unsupported or disallowed.

I have not written a unit test because it would be impractical to request such a large amount of random data during a test run in CI.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #62130.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
