### PR TITLE
[Compile Time Constant Extraction] Add extraction of initialization calls

### DIFF
--- a/include/swift/AST/ConstTypeInfo.h
+++ b/include/swift/AST/ConstTypeInfo.h
@@ -13,9 +13,10 @@
 #ifndef SWIFT_AST_CONST_TYPE_INFO_H
 #define SWIFT_AST_CONST_TYPE_INFO_H
 
+#include "swift/AST/Type.h"
+#include <memory>
 #include <string>
 #include <vector>
-#include <memory>
 
 namespace swift {
 class NominalTypeDecl;
@@ -55,13 +56,9 @@ private:
 };
 
 struct FunctionParameter {
-public:
-  std::string getLabel() { return Label; }
-  swift::Type *getType() { return Type; }
-
-private:
   std::string Label;
-  swift::Type *Type;
+  swift::Type Type;
+  std::shared_ptr<CompileTimeValue> Value;
 };
 
 /// A representation of a call to a type's initializer
@@ -77,6 +74,7 @@ public:
   }
 
   std::string getName() const { return Name; }
+  std::vector<FunctionParameter> getParameters() const { return Parameters; }
 
 private:
   std::string Name;

--- a/include/swift/ConstExtract/ConstExtract.h
+++ b/include/swift/ConstExtract/ConstExtract.h
@@ -56,7 +56,6 @@ gatherConstValuesForModule(const std::unordered_set<std::string> &Protocols,
 /// provided output stream.
 bool writeAsJSONToFile(const std::vector<ConstValueTypeInfo> &ConstValueInfos,
                        llvm::raw_fd_ostream &OS);
-
 } // namespace swift
 
 #endif

--- a/test/ConstExtraction/fields.swift
+++ b/test/ConstExtraction/fields.swift
@@ -59,6 +59,71 @@
 // CHECK-NEXT:        "value": "[(\"One\", 1), (\"Two\", 2), (\"Three\", 3)]"
 // CHECK-NEXT:      },
 // CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "p10",
+// CHECK-NEXT:        "type": "fields.Bar",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "valueKind": "InitCall",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "type": "fields.Bar",
+// CHECK-NEXT:          "arguments": []
+// CHECK-NEXT:        }
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "p11",
+// CHECK-NEXT:        "type": "fields.Bat",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "valueKind": "InitCall",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "type": "fields.Bat",
+// CHECK-NEXT:          "arguments": [
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "buz",
+// CHECK-NEXT:              "type": "Swift.String",
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "\"\""
+// CHECK-NEXT:            },
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "fuz",
+// CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "0"
+// CHECK-NEXT:            }
+// CHECK-NEXT:          ]
+// CHECK-NEXT:        }
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "p12",
+// CHECK-NEXT:        "type": "fields.Bat",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "valueKind": "InitCall",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "type": "fields.Bat",
+// CHECK-NEXT:          "arguments": [
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "buz",
+// CHECK-NEXT:              "type": "Swift.String",
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "\"hello\""
+// CHECK-NEXT:            },
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "fuz",
+// CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "valueKind": "Runtime"
+// CHECK-NEXT:            }
+// CHECK-NEXT:          ]
+// CHECK-NEXT:        }
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "p13",
+// CHECK-NEXT:        "type": "Swift.Int",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "valueKind": "Runtime"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "p0",
 // CHECK-NEXT:        "type": "Swift.Int",
 // CHECK-NEXT:        "isStatic": "true",
@@ -107,6 +172,25 @@ public struct Foo {
     let p7: Bool? = nil
     let p8: (Int, Float) = (42, 6.6)
     let p9: [String: Int] = ["One": 1, "Two": 2, "Three": 3]
+    let p10 = Bar()
+    let p11: Bat = .init()
+    let p12 = Bat(buz: "hello", fuz: adder(2, 3))
+    let p13: Int = adder(2, 3)
+}
+
+func adder(_ x: Int, _ y: Int) -> Int {
+    x + y
+}
+
+public struct Bar {}
+public struct Bat {
+    let buz: String
+    let fuz: Int
+
+    init(buz: String = "", fuz: Int = 0) {
+        self.buz = buz
+        self.fuz = fuz
+    }
 }
 
 extension Foo : MyProto {}


### PR DESCRIPTION
Statically extract initialization calls and arguments.

Ran clang-format which rearranged some headers.
