### PR TITLE
Revert "Support cross compilation in macOS toolchain builds (#62306)"

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftdocc.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftdocc.py
@@ -64,13 +64,6 @@ class SwiftDocC(product.Product):
             '--build-dir', self.build_dir,
             '--multiroot-data-file', MULTIROOT_DATA_FILE_PATH,
         ]
-
-        # Pass Cross compile host info
-        if self.has_cross_compile_hosts() and self.is_darwin_host(host_target):
-            helper_cmd += ['--cross-compile-hosts']
-            for cross_compile_host in self.args.cross_compile_hosts:
-                helper_cmd += [cross_compile_host]
-
         if action != 'install':
             helper_cmd.extend([
                 # There might have been a Package.resolved created by other builds


### PR DESCRIPTION
This reverts commit a36ab6e287afc6c212ad250bfed440d5baf42b16.

The change to support cross compilation of `docc` in macOS toolchains is breaking nightly toolchain builds – this will unblock them.

> From: https://ci.swift.org/job/oss-swift-package-macos/1265/console
> 
> ```
> ** Building swift-docc **
> + /Users/ec2-user/jenkins/workspace/oss-swift-package-macos/swift-docc/build-script-helper.py test --toolchain /Users/ec2-user/jenkins/workspace/oss-swift-package-macos/build/buildbot_osx/intermediate-install/macosx-x86_64/Applications/Xcode.app/Contents/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-2022-12-02-a.xctoolchain/usr --configuration release --build-dir /Users/ec2-user/jenkins/workspace/oss-swift-package-macos/build/buildbot_osx/unified-swiftpm-build-macosx-x86_64 --multiroot-data-file /Users/ec2-user/jenkins/workspace/oss-swift-package-macos/swift/utils/build_swift/resources/SwiftPM-Unified-Build.xcworkspace --cross-compile-hosts macosx-arm64 --update
> warning: --multiroot-data-file is an *unsupported* option which can be removed at any time; do not rely on it
> warning: 'swiftpm': failed to retrieve search paths with pkg-config; maybe pkg-config is not installed
> warning: 'swiftpm': couldn't find pc file for sqlite3
> warning: 'swiftpm': couldn't find pc file for sqlite3
> error: Could not find target named 'SwiftDocCPackageTests_7C0DE4B8BA63A33A_PackageProduct'
> error: fatalError
> FAIL: Testing swift-docc failed
> ```

It looks like the `--test-product` option Swift-DocC's build script passes to SwiftPM is supported when building for multiple architectures but not when testing. PR toolchain builds don't run tests which is why this wasn't caught before merging.

Resolves rdar://102908495
