### PR TITLE
AddressLowering: speculative tightening of assertion

### DIFF
--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3654,7 +3654,7 @@ static void rewriteFunction(AddressLoweringState &pass) {
       uses.push_back(use);
     }
     for (auto *oper : uses) {
-      assert(isa<DebugValueInst>(oper->getUser()));
+      assert(oper->getUser() && isa<DebugValueInst>(oper->getUser()));
       UseRewriter::rewriteUse(oper, pass);
     }
   }


### PR DESCRIPTION
On Windows CI builds, we have observed a failure to build the Swift Standard Library after 10/27 (first noticed on 11/11 snapshot due to other failures).  The failure is an invalid `isa` cast where the instance is a `nullptr`.  The SILPipeline suggests that the SILOptimizer might be the one triggering the incorrect use of `isa`. The only instance of `isa` introduced in that range in the SILOptimizer/Mandatory region for that duration is this particular instance.  Tighten the assertion to ensure that `oper->getUser()` returns a non-`nullptr` value.

Thanks for @gwynne for helping narrow down the search area.