### PR TITLE
build: rename `EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR`

### DIFF
--- a/SwiftCompilerSources/Sources/_RegexParser/CMakeLists.txt
+++ b/SwiftCompilerSources/Sources/_RegexParser/CMakeLists.txt
@@ -7,13 +7,13 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 file(GLOB_RECURSE _LIBSWIFT_REGEX_PARSER_SOURCES
-  "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}/Sources/_RegexParser/*.swift")
+  "${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}/Sources/_RegexParser/*.swift")
 set(LIBSWIFT_REGEX_PARSER_SOURCES)
 foreach(source ${_LIBSWIFT_REGEX_PARSER_SOURCES})
   file(TO_CMAKE_PATH "${source}" source)
   list(APPEND LIBSWIFT_REGEX_PARSER_SOURCES ${source})
 endforeach()
-message(STATUS "Using Experimental String Processing library for libswift _RegexParser (${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}).")
+message(STATUS "Using Experimental String Processing library for libswift _RegexParser (${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}).")
 
 add_swift_compiler_module(_CompilerRegexParser
   SOURCES

--- a/stdlib/public/RegexBuilder/CMakeLists.txt
+++ b/stdlib/public/RegexBuilder/CMakeLists.txt
@@ -16,13 +16,13 @@ set(swift_regex_builder_link_libraries
   swift_StringProcessing)
 
 file(GLOB_RECURSE _REGEX_BUILDER_SOURCES
-  "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}/Sources/RegexBuilder/*.swift")
+  "${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}/Sources/RegexBuilder/*.swift")
 set(REGEX_BUILDER_SOURCES)
 foreach(source ${_REGEX_BUILDER_SOURCES})
   file(TO_CMAKE_PATH "${source}" source)
   list(APPEND REGEX_BUILDER_SOURCES ${source})
 endforeach()
-message(STATUS "Using Experimental String Processing library for RegexBuilder (${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}).")
+message(STATUS "Using Experimental String Processing library for RegexBuilder (${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}).")
 
 add_swift_target_library(swiftRegexBuilder ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   "${REGEX_BUILDER_SOURCES}"

--- a/stdlib/public/RegexParser/CMakeLists.txt
+++ b/stdlib/public/RegexParser/CMakeLists.txt
@@ -14,13 +14,13 @@ set(swift_matching_engine_link_libraries
   swiftCore)
 
 file(GLOB_RECURSE _MATCHING_ENGINE_SOURCES
-  "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}/Sources/_RegexParser/*.swift")
+  "${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}/Sources/_RegexParser/*.swift")
 set(MATCHING_ENGINE_SOURCES)
 foreach(source ${_MATCHING_ENGINE_SOURCES})
   file(TO_CMAKE_PATH "${source}" source)
   list(APPEND MATCHING_ENGINE_SOURCES ${source})
 endforeach()
-message(STATUS "Using Experimental String Processing library for _RegexParser (${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}).")
+message(STATUS "Using Experimental String Processing library for _RegexParser (${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}).")
 
 set(SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS_NO_RESILIENCE)
 string(REGEX REPLACE "-enable-library-evolution" ""

--- a/stdlib/public/StringProcessing/CMakeLists.txt
+++ b/stdlib/public/StringProcessing/CMakeLists.txt
@@ -22,15 +22,15 @@ if(SWIFT_BUILD_STATIC_STDLIB)
 endif()
 
 file(GLOB_RECURSE _STRING_PROCESSING_SOURCES
-  "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}/Sources/_StringProcessing/*.swift"
-  "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}/Sources/_CUnicode/*.h"
-  "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}/Sources/_CUnicode/*.c")
+  "${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}/Sources/_StringProcessing/*.swift"
+  "${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}/Sources/_CUnicode/*.h"
+  "${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}/Sources/_CUnicode/*.c")
 set(STRING_PROCESSING_SOURCES)
 foreach(source ${_STRING_PROCESSING_SOURCES})
   file(TO_CMAKE_PATH "${source}" source)
   list(APPEND STRING_PROCESSING_SOURCES ${source})
 endforeach()
-message(STATUS "Using Experimental String Processing library for _StringProcessing (${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}).")
+message(STATUS "Using Experimental String Processing library for _StringProcessing (${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}).")
 
 add_swift_target_library(swift_StringProcessing ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB
   "${STRING_PROCESSING_SOURCES}"

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1224,7 +1224,7 @@ LIBDISPATCH_SOURCE_DIR="${WORKSPACE}/swift-corelibs-libdispatch"
 LIBDISPATCH_STATIC_SOURCE_DIR="${WORKSPACE}/swift-corelibs-libdispatch"
 LIBICU_SOURCE_DIR="${WORKSPACE}/icu"
 LIBCXX_SOURCE_DIR="${WORKSPACE}/llvm-project/runtimes"
-EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR="${WORKSPACE}/swift-experimental-string-processing"
+SWIFT_PATH_TO_STRING_PROCESSING_SOURCE="${WORKSPACE}/swift-experimental-string-processing"
 SWIFTSYNTAX_SOURCE_DIR="${WORKSPACE}/swift-syntax"
 SWIFT_SYNTAX_SOURCE_DIR="${WORKSPACE}/swift-syntax"
 
@@ -2185,11 +2185,11 @@ for host in "${ALL_HOSTS[@]}"; do
                     )
                 fi
 
-                if [[ -d "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}" && \
-                      -n "$(ls -A "${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}")" ]] ; then
+                if [[ -d "${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}" && \
+                      -n "$(ls -A "${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}")" ]] ; then
                     cmake_options=(
                         "${cmake_options[@]}"
-                        -DEXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR="${EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR}"
+                        -DSWIFT_PATH_TO_STRING_PROCESSING_SOURCE="${SWIFT_PATH_TO_STRING_PROCESSING_SOURCE}"
                     )
                     if [[ $(true_false "${SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING}") == "TRUE" ]] ; then
                         cmake_options=(

--- a/utils/build-tooling-libs
+++ b/utils/build-tooling-libs
@@ -253,7 +253,7 @@ class Builder(object):
         ]
         cmake_args += [
             "-DBOOTSTRAPPING_MODE=HOSTTOOLS",
-            "-DEXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR=" +
+            "-DSWIFT_PATH_TO_STRING_PROCESSING_SOURCE=" +
             os.path.join(SWIFT_SOURCE_ROOT,
                          "swift-experimental-string-processing"),
             "-DSWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE=" +

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -220,7 +220,7 @@ cmake ^
   -D PYTHON_EXECUTABLE=%PYTHON_HOME%\python.exe ^
   -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE="%SourceRoot%\swift-corelibs-libdispatch" ^
   -D SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE="%SourceRoot%\swift-syntax" ^
-  -D EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR=%SourceRoot%\swift-experimental-string-processing ^
+  -D SWIFT_PATH_TO_STRING_PROCESSING_SOURCE=%SourceRoot%\swift-experimental-string-processing ^
 
   -G Ninja ^
   -S llvm-project\llvm || (exit /b)
@@ -248,7 +248,7 @@ cmake ^
   -D SWIFT_NATIVE_SWIFT_TOOLS_PATH=%BuildRoot%\1\bin ^
   -D SWIFT_PATH_TO_LIBDISPATCH_SOURCE=%SourceRoot%\swift-corelibs-libdispatch ^
   -D SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE="%SourceRoot%\swift-syntax" ^
-  -D EXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR=%SourceRoot%\swift-experimental-string-processing ^
+  -D SWIFT_PATH_TO_STRING_PROCESSING_SOURCE=%SourceRoot%\swift-experimental-string-processing ^
 
   -D SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY=YES ^
   -D SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED=YES ^

--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -259,6 +259,7 @@ cmake^
     -DSWIFT_PATH_TO_CMARK_BUILD:PATH=%build_root%\cmark^
     -DSWIFT_PATH_TO_CMARK_SOURCE:PATH=%source_root%\cmark^
     -DSWIFT_PATH_TO_LIBDISPATCH_SOURCE:PATH=%source_root%\swift-corelibs-libdispatch^
+    -DSWIFT_PATH_TO_STRING_PROCESSING_SOURCE:PATH=%source_root%\swift-experimental-string-processing^
     -DLLVM_DIR:PATH=%build_root%\llvm\lib\cmake\llvm^
     -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON^
     -DSWIFT_INCLUDE_DOCS:BOOL=NO^
@@ -273,7 +274,6 @@ cmake^
     -DSWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED=YES^
     -DSWIFT_ENABLE_EXPERIMENTAL_DIFFERENTIABLE_PROGRAMMING=YES^
     -DSWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING=YES^
-    -DEXPERIMENTAL_STRING_PROCESSING_SOURCE_DIR=%source_root%\swift-experimental-string-processing^
     -DSWIFT_INSTALL_COMPONENTS="autolink-driver;compiler;clang-resource-dir-symlink;stdlib;sdk-overlay;editor-integration;tools;testsuite-tools;sourcekit-inproc;swift-remote-mirror;swift-remote-mirror-headers"^
     -DSWIFT_PARALLEL_LINK_JOBS=8^
     -DPYTHON_EXECUTABLE:PATH=%PYTHON_HOME%\python.exe^


### PR DESCRIPTION
Rename the variable to `SWIFT_PATH_TO_STRING_PROCESSING_SOURCE` to match the variables used for libdispatch, swift-syntax.