### PR TITLE
[CSSimplify] Account for tuple splat when resolving closure parameters

### DIFF
--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -386,7 +386,7 @@ func rdar21078316() {
 
 // <rdar://problem/20978044> QoI: Poor diagnostic when using an incorrect tuple element in a closure
 var numbers = [1, 2, 3]
-zip(numbers, numbers).filter { $0.2 > 1 }  // expected-error {{value of tuple type '(Array<Int>.Element, Array<Int>.Element)' has no member '2'}}
+zip(numbers, numbers).filter { $0.2 > 1 }  // expected-error {{value of tuple type '(Int, Int)' has no member '2'}}
 
 
 

--- a/validation-test/Sema/type_checker_perf/fast/issue-62390.swift
+++ b/validation-test/Sema/type_checker_perf/fast/issue-62390.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
+// REQUIRES: tools-release,no_asan
+
+// https://github.com/apple/swift/issues/62390
+// Compiler is extremely slow to compile simple closure
+
+func testFn<U>(_: ((Int, Int)) -> U) {}
+
+testFn { (a, _) in
+  return ((a <= a && a >= a) || (a <= a && a >= a)) // Ok
+}


### PR DESCRIPTION
SE-0110 allows tuple slat between function types. The solver needs to
account for that when trying to infer parameter types from context
while resolving a closure in order to propagate types and speed up
type-checking.

Resolves: https://github.com/apple/swift/issues/62390

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
