### PR TITLE
[CMake] Make sure sourcekitd-test and other SourceKit tools can find libswift_CompilerPluginSupport

### DIFF
--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -158,6 +158,8 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
   if(SWIFT_SWIFT_PARSER)
     # Make sure we can find the early SwiftSyntax libraries.
     target_link_directories(${target} PRIVATE "${SWIFT_PATH_TO_EARLYSWIFTSYNTAX_BUILD_DIR}/lib/swift/host")
+    # ... and libswift_SwiftCompilerSupport
+    target_link_directories(${target} PRIVATE "${SWIFTLIB_DIR}/host")
 
     # For the "end step" of bootstrapping configurations on Darwin, need to be
     # able to fall back to the SDK directory for libswiftCore et al.


### PR DESCRIPTION
sourcekitd-test were only searching the earlyswiftsyntax build directory for dylibs to link. But `libswift_CompilerPluginSupport` lives in the main Swift build directory so we need to search that one as well.

@DougGregor I’m not entirely sure if this is the correct fix but it fixes the issue locally for me.