### PR TITLE
[SILMem2Reg] For single block allocations don't break after a dealloc_stack

### DIFF
--- a/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
+++ b/lib/SILOptimizer/Transforms/SILMem2Reg.cpp
@@ -1881,8 +1881,9 @@ void MemoryToRegisters::removeSingleBlockAllocation(AllocStackInst *asi) {
       if (dsi->getOperand() == asi) {
         deleter.forceDelete(dsi);
         NumInstRemoved++;
-        // No need to continue scanning after deallocation.
-        break;
+        // Continue even after deallocation, there may be begin_borrows created
+        // for store_borrow whose lifetime needs to be ended.
+        continue;
       }
     }
 

--- a/test/SILOptimizer/mem2reg_borrows.sil
+++ b/test/SILOptimizer/mem2reg_borrows.sil
@@ -207,6 +207,26 @@ bb0(%0 : @guaranteed $Klass):
   return %8 : $()
 }
 
+// CHECK-LABEL: sil [ossa] @test5_lexical :
+// CHECK-NOT: alloc_stack
+// CHECK-LABEL: } // end sil function 'test5_lexical'
+sil [ossa] @test5_lexical : $@convention(thin) (@owned Klass) -> () {
+bb0(%0 : @owned $Klass):
+  %stk = alloc_stack [lexical] $Klass
+  %f = function_ref @use_guaranteed : $@convention(thin) (@guaranteed Klass) -> ()
+  %b1 = begin_borrow %0 : $Klass
+  %sb1 = store_borrow %b1 to %stk : $*Klass
+  %lb1 = load_borrow %sb1 : $*Klass
+  apply %f(%lb1) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %lb1 : $Klass
+  dealloc_stack  %stk : $*Klass
+  end_borrow %sb1 : $*Klass
+  end_borrow %b1 : $Klass
+  destroy_value %0 : $Klass
+  %6 = tuple ()
+  return %6 : $()
+}
+
 // CHECK-LABEL: sil [ossa] @test6 :
 // CHECK-NOT: alloc_stack
 // CHECK-LABEL: } // end sil function 'test6'


### PR DESCRIPTION
We may have a store_borrow for which we created a begin_borrow whose lifetime needs to be ended.
