### PR TITLE
Revert "[Profile] Update swift after LLVM API update"

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -55,11 +55,7 @@ SILGenModule::SILGenModule(SILModule &M, ModuleDecl *SM)
       FileIDsByFilePath(SM->computeFileIDMap(/*shouldDiagnose=*/true)) {
   const SILOptions &Opts = M.getOptions();
   if (!Opts.UseProfile.empty()) {
-    // FIXME: Create file system to read the profile. In the future, the vfs
-    // needs to come from CompilerInstance.
-    auto FS = llvm::vfs::getRealFileSystem();
-    auto ReaderOrErr =
-        llvm::IndexedInstrProfReader::create(Opts.UseProfile, *FS);
+    auto ReaderOrErr = llvm::IndexedInstrProfReader::create(Opts.UseProfile);
     if (auto E = ReaderOrErr.takeError()) {
       diagnose(SourceLoc(), diag::profile_read_error, Opts.UseProfile,
                llvm::toString(std::move(E)));


### PR DESCRIPTION
Reverts apple/swift#62376

Disregard https://github.com/apple/swift/pull/62401. That is merging into the next branch.

See rdar://102938752 for details.