### PR TITLE
docs: remove files converted to Markdown from `contents.rst`

### DIFF
--- a/docs/contents.rst
+++ b/docs/contents.rst
@@ -6,8 +6,6 @@ Contents
 .. toctree::
    :maxdepth: 1
 
-   ErrorHandling
-   ErrorHandlingRationale
    Generics
    StoredAndComputedVariables
    SIL


### PR DESCRIPTION
This fixes

```
Warning, treated as error:
swift/docs/contents.rst:6:toctree contains reference to nonexisting document 'ErrorHandlingRationale'
```
