### PR TITLE
[docs] Disable warnings as errors

### DIFF
--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -10,7 +10,6 @@ SET(SWIFT_SPHINX_PAPER_SIZE "letter"
   CACHE STRING "Paper size for generated documentation")
 
 SET(SPHINX_ARGS
-  -W
   -D latex_elements.papersize=${SWIFT_SPHINX_PAPER_SIZE}
   -d ${CMAKE_BINARY_DIR}/doctrees)
 


### PR DESCRIPTION
Currently the rst files have a bunch of warnings that cause build failures if you have sphinx installed. It sounds like these files are all on the path to being converted to markdown, so this loosens that restriction to not block folks from building.