### PR TITLE
Fix Representation of Extensions Across Exported Imports in the Extension Block Symbol Format

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -370,5 +370,8 @@ bool SymbolGraphASTWalker::isOurModule(const ModuleDecl *M) const {
 bool SymbolGraphASTWalker::shouldBeRecordedAsExtension(
     const ExtensionDecl *ED) const {
   return Options.EmitExtensionBlockSymbols &&
-      !areModulesEqual(ED->getModuleContext(), ED->getExtendedNominal()->getModuleContext());
+         !areModulesEqual(ED->getModuleContext(),
+                          ED->getExtendedNominal()->getModuleContext()) &&
+         !isExportedImportedModule(
+             ED->getExtendedNominal()->getModuleContext());
 }

--- a/test/SymbolGraph/Module/ExportedImportExtensions.swift
+++ b/test/SymbolGraph/Module/ExportedImportExtensions.swift
@@ -1,0 +1,56 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/Inputs/ExportedImportExtensions/A.swift -module-name A -emit-module -emit-module-path %t/A.swiftmodule
+// RUN: %target-swift-frontend %S/Inputs/ExportedImportExtensions/B.swift -module-name B -emit-module -emit-module-path %t/B.swiftmodule -I %t
+// RUN: %target-swift-frontend %s -module-name ExportedImportExtensions -emit-module -emit-module-path /dev/null -I %t -emit-symbol-graph -emit-symbol-graph-dir %t/ -emit-extension-block-symbols
+// RUN: %FileCheck %s --input-file %t/ExportedImportExtensions.symbols.json
+// RUN: ls %t | %FileCheck %s --check-prefix FILES
+
+@_exported import A
+@_exported import B
+
+public protocol P {
+    func pRequirement()
+}
+
+public extension SymbolFromA {
+    func extensionFromMain() { }
+}
+
+public extension SymbolFromB {
+    func extensionFromMain() { }
+}
+
+extension SymbolFromB: P {
+    public func pRequirement() { }
+}
+
+// CHECK-NOT: "swift.extension"
+
+// the extensions on SymbolFromA ...
+// CHECK-DAG: "precise":"s:1A11SymbolFromAV"
+// ... made by B
+// CHECK-DAG: "precise":"s:1A11SymbolFromAV1BE09extensionB1ByyF"
+// CHECK-DAG: {"kind":"memberOf","source":"s:1A11SymbolFromAV1BE09extensionB1ByyF","target":"s:1A11SymbolFromAV","targetFallback":"A.SymbolFromA"}
+// ... and by this file
+// CHECK-DAG: "precise":"s:1A11SymbolFromAV24ExportedImportExtensionsE09extensionB4MainyyF"
+// CHECK-DAG: {"kind":"memberOf","source":"s:1A11SymbolFromAV24ExportedImportExtensionsE09extensionB4MainyyF","target":"s:1A11SymbolFromAV","targetFallback":"A.SymbolFromA"}
+
+// the simple member extension on SymbolFromB (made by this file)
+// CHECK-DAG: "precise":"s:1B11SymbolFromBV"
+// CHECK-DAG: "precise":"s:1B11SymbolFromBV24ExportedImportExtensionsE09extensionB4MainyyF"
+// CHECK-DAG: {"kind":"memberOf","source":"s:1B11SymbolFromBV24ExportedImportExtensionsE09extensionB4MainyyF","target":"s:1B11SymbolFromBV","targetFallback":"B.SymbolFromB"}
+
+// the conformance extension on SymbolFromB (made by this file)
+// CHECK-DAG: "precise":"s:1B11SymbolFromBV24ExportedImportExtensionsE12pRequirementyyF"
+// CHECK-DAG: {"kind":"memberOf","source":"s:1B11SymbolFromBV24ExportedImportExtensionsE12pRequirementyyF","target":"s:1B11SymbolFromBV","targetFallback":"B.SymbolFromB","sourceOrigin":{"identifier":"s:24ExportedImportExtensions1PP12pRequirementyyF","displayName":"P.pRequirement()"}}
+// CHECK-DAG: {"kind":"conformsTo","source":"s:1B11SymbolFromBV","target":"s:24ExportedImportExtensions1PP"}
+
+// FIXME: Symbols from `@_exported import` do not get emitted when using swift-symbolgraph-extract
+// This is tracked by https://github.com/apple/swift-docc/issues/179.
+
+// FILES-NOT: ExportedImportExtensions@A.symbols.json
+// FILES-NOT: ExportedImportExtensions@B.symbols.json
+// FILES-NOT: A@B.symbols.json
+// FILES-NOT: B@A.symbols.json
+// FILES-NOT: A.symbols.json
+// FILES-NOT: B.symbols.json

--- a/test/SymbolGraph/Module/Inputs/ExportedImportExtensions/A.swift
+++ b/test/SymbolGraph/Module/Inputs/ExportedImportExtensions/A.swift
@@ -1,0 +1,1 @@
+public struct SymbolFromA {}

--- a/test/SymbolGraph/Module/Inputs/ExportedImportExtensions/B.swift
+++ b/test/SymbolGraph/Module/Inputs/ExportedImportExtensions/B.swift
@@ -1,0 +1,7 @@
+import A
+
+public struct SymbolFromB {}
+
+public extension  SymbolFromA {
+    func extensionFromB() {}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR  makes sure extension block symbols for extensions to external types are no longer emitted when the extended type is re-exported by the extending module. See the issue for more details.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves apple/swift-docc#422

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
