### PR TITLE
Docs: Update swift manpage to instruct users to run `swift repl` for the REPL

### DIFF
--- a/docs/tools/swift.pod
+++ b/docs/tools/swift.pod
@@ -12,7 +12,7 @@ To invoke the Swift REPL (Read-Eval-Print-Loop):
 
 =over
 
-B<swift>
+B<swift> repl
 
 =back
 


### PR DESCRIPTION
Bare `swift` no longer invokes the REPL.

Resolves rdar://102727000
