### PR TITLE
[Dependency Scanning] Simplify the persistent dependency scanning cache

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -550,6 +550,12 @@ public:
     return llvm::hash_value(0);
   }
 
+  /// Return a hash code of any components from these options that should
+  /// contribute to a Swift Dependency Scanning hash.
+  llvm::hash_code getModuleScanningHashComponents() const {
+    return llvm::hash_value(0);
+  }
+
   bool hasMultipleIRGenThreads() const { return !UseSingleModuleLLVMEmission && NumThreads > 1; }
   bool shouldPerformIRGenerationInParallel() const { return !UseSingleModuleLLVMEmission && NumThreads != 0; }
   bool hasMultipleIGMs() const { return hasMultipleIRGenThreads(); }

--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -281,6 +281,12 @@ public:
     return llvm::hash_value(0);
   }
 
+  /// Return a hash code of any components from these options that should
+  /// contribute to a Swift Dependency Scanning hash.
+  llvm::hash_code getModuleScanningHashComponents() const {
+    return llvm::hash_value(0);
+  }
+
   bool shouldOptimize() const {
     return OptMode > OptimizationMode::NoOptimization;
   }

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -421,6 +421,12 @@ public:
                                            RuntimeLibraryImportPaths.end()),
                         DisableModulesValidateSystemDependencies);
   }
+
+  /// Return a hash code of any components from these options that should
+  /// contribute to a Swift Dependency Scanning hash.
+  llvm::hash_code getModuleScanningHashComponents() const {
+    return getPCHHashComponents();
+  }
 };
 }
 

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -86,6 +86,12 @@ public:
     // Nothing here that contributes anything significant when emitting the PCH.
     return llvm::hash_value(0);
   }
+
+  /// Return a hash code of any components from these options that should
+  /// contribute to a Swift Dependency Scanning hash.
+  llvm::hash_code getModuleScanningHashComponents() const {
+    return llvm::hash_value(0);
+  }
 };
 
 } // end namespace swift

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -628,6 +628,12 @@ namespace swift {
       return llvm::hash_combine(Target.str(), OS.str());
     }
 
+    /// Return a hash code of any components from these options that should
+    /// contribute to a Swift Dependency Scanning hash.
+    llvm::hash_code getModuleScanningHashComponents() const {
+      return getPCHHashComponents();
+    }
+
   private:
     llvm::SmallVector<std::pair<PlatformConditionKind, std::string>, 6>
         PlatformConditionValues;
@@ -830,6 +836,12 @@ namespace swift {
                           DisableSwiftBridgeAttr,
                           DisableOverlayModules,
                           EnableClangSPI);
+    }
+
+    /// Return a hash code of any components from these options that should
+    /// contribute to a Swift Dependency Scanning hash.
+    llvm::hash_code getModuleScanningHashComponents() const {
+      return getPCHHashComponents();
     }
 
     std::vector<std::string> getRemappedExtraArgs(

--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -35,9 +35,8 @@ using llvm::BCRecordLayout;
 using llvm::BCVBR;
 
 /// Every .moddepcache file begins with these 4 bytes, for easy identification.
-const unsigned char MODULE_DEPENDENCY_CACHE_FORMAT_SIGNATURE[] = {'I', 'M', 'D',
-                                                                  'C'};
-const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MAJOR = 2;
+const unsigned char MODULE_DEPENDENCY_CACHE_FORMAT_SIGNATURE[] = {'I', 'M', 'D','C'};
+const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MAJOR = 3;
 /// Increment this on every change.
 const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MINOR = 0;
 
@@ -56,7 +55,7 @@ using IdentifierIDArryField = llvm::BCArray<IdentifierIDField>;
 
 /// Identifiers used to refer to the above arrays
 using FileIDArrayIDField = IdentifierIDField;
-using TripleIDField = IdentifierIDField;
+using ContextHashIDField = IdentifierIDField;
 using DependencyIDArrayIDField = IdentifierIDField;
 using FlagIDArrayIDField = IdentifierIDField;
 
@@ -118,7 +117,7 @@ using IdentifierArrayLayout =
 using ModuleInfoLayout =
     BCRecordLayout<MODULE_NODE,             // ID
                    IdentifierIDField,       // module name
-                   TripleIDField,           // target triple
+                   ContextHashIDField,      // 
                    DependencyIDArrayIDField // directDependencies
                    >;
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -345,6 +345,11 @@ public:
   /// in generating a cached PCH file for the bridging header.
   std::string getPCHHash() const;
 
+  /// Retrieve a module hash string that is suitable for uniquely
+  /// identifying the conditions under which the current module is built,
+  /// from the perspective of a dependency scanning action.
+  std::string getModuleScanningHash() const;
+
   /// Retrieve the stdlib kind to implicitly import.
   ImplicitStdlibKind getImplicitStdlibKind() const {
     if (FrontendOpts.InputMode == FrontendOptions::ParseInputMode::SIL) {

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -430,6 +430,12 @@ public:
     return llvm::hash_value(0);
   }
 
+  /// Return a hash code of any components from these options that should
+  /// contribute to a Swift Dependency Scanning hash.
+  llvm::hash_code getModuleScanningHashComponents() const {
+    return llvm::hash_value(0);
+  }
+
   StringRef determineFallbackModuleName() const;
 
   bool isCompilingExactlyOneSwiftFile() const {

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -250,87 +250,24 @@ GlobalModuleDependenciesCache::getCacheForScanningContextHash(StringRef scanning
   return contextSpecificCache->getValue().get();
 }
 
-llvm::StringMap<ModuleDependenciesVector> &
-GlobalModuleDependenciesCache::getDependenciesMap(ModuleDependenciesKind kind) {
-  auto targetSpecificCache = getCurrentCache();
-  auto it = targetSpecificCache->ModuleDependenciesMap.find(kind);
-  assert(it != targetSpecificCache->ModuleDependenciesMap.end() &&
-         "invalid dependency kind");
-  return it->second;
-}
-
-const llvm::StringMap<ModuleDependenciesVector> &
+const ModuleNameToDependencyMap &
 GlobalModuleDependenciesCache::getDependenciesMap(
     ModuleDependenciesKind kind) const {
-  auto targetSpecificCache = getCurrentCache();
-  auto it = targetSpecificCache->ModuleDependenciesMap.find(kind);
-  assert(it != targetSpecificCache->ModuleDependenciesMap.end() &&
+  auto contextSpecificCache = getCurrentCache();
+  auto it = contextSpecificCache->ModuleDependenciesMap.find(kind);
+  assert(it != contextSpecificCache->ModuleDependenciesMap.end() &&
          "invalid dependency kind");
   return it->second;
 }
 
-static std::string moduleBasePath(const StringRef modulePath) {
-  auto parent = llvm::sys::path::parent_path(modulePath);
-  // If the modulePath is that of a .swiftinterface contained in a .swiftmodule,
-  // disambiguate further to parent.
-  if (llvm::sys::path::extension(parent) == ".swiftmodule") {
-    parent = llvm::sys::path::parent_path(parent);
-  }
-
-  // If the module is a part of a framework, disambiguate to the framework's
-  // parent
-  if (llvm::sys::path::filename(parent) == "Modules") {
-    auto grandParent = llvm::sys::path::parent_path(parent);
-    if (llvm::sys::path::extension(grandParent) == ".framework") {
-      parent = llvm::sys::path::parent_path(grandParent);
-    }
-  }
-
-  return parent.str();
-}
-
-static bool
-moduleContainedInImportPathSet(const StringRef modulePath,
-                               const llvm::StringSet<> &importPaths) {
-  return importPaths.contains(moduleBasePath(modulePath));
-}
-
-static bool
-moduleContainedInImportPathSet(const ModuleDependencies &module,
-                               const llvm::StringSet<> &importPaths) {
-  std::string modulePath = "";
-  switch (module.getKind()) {
-  case swift::ModuleDependenciesKind::SwiftInterface: {
-    modulePath = module.getAsSwiftInterfaceModule()->swiftInterfaceFile;
-    break;
-  }
-  case swift::ModuleDependenciesKind::SwiftSource:
-    // We are seeing the main scan module itself. This means that
-    // our search-path disambiguation is not necessary here.
-    return true;
-  case swift::ModuleDependenciesKind::SwiftBinary: {
-    auto *swiftBinaryDep = module.getAsSwiftBinaryModule();
-    modulePath = swiftBinaryDep->compiledModulePath;
-    break;
-  }
-  case swift::ModuleDependenciesKind::Clang: {
-    auto *clangDep = module.getAsClangModule();
-    modulePath = clangDep->moduleMapFile;
-    break;
-  }
-  case swift::ModuleDependenciesKind::SwiftPlaceholder: {
-    // Placeholders are resolved as `true` because they are not associated with
-    // any specific search path.
-    return true;
-  }
-  default:
-    llvm_unreachable("Unhandled dependency kind.");
-  }
-
-  if (moduleContainedInImportPathSet(modulePath, importPaths)) {
-    return true;
-  }
-  return false;
+ModuleNameToDependencyMap &
+GlobalModuleDependenciesCache::getDependenciesMap(
+    ModuleDependenciesKind kind) {
+  auto contextSpecificCache = getCurrentCache();
+  auto it = contextSpecificCache->ModuleDependenciesMap.find(kind);
+  assert(it != contextSpecificCache->ModuleDependenciesMap.end() &&
+         "invalid dependency kind");
+  return it->second;
 }
 
 void GlobalModuleDependenciesCache::configureForContextHash(std::string scanningContextHash) {
@@ -344,8 +281,7 @@ void GlobalModuleDependenciesCache::configureForContextHash(std::string scanning
         std::make_unique<ContextSpecificGlobalCacheState>();
     for (auto kind = ModuleDependenciesKind::FirstKind;
          kind != ModuleDependenciesKind::LastKind; ++kind) {
-      contextSpecificCache->ModuleDependenciesMap.insert(
-          {kind, llvm::StringMap<ModuleDependenciesVector>()});
+      contextSpecificCache->ModuleDependenciesMap.insert({kind, ModuleNameToDependencyMap()});
     }
 
     ContextSpecificCacheMap.insert({scanningContextHash, std::move(contextSpecificCache)});
@@ -355,33 +291,27 @@ void GlobalModuleDependenciesCache::configureForContextHash(std::string scanning
 }
 
 Optional<ModuleDependencies> GlobalModuleDependenciesCache::findDependencies(
-    StringRef moduleName, ModuleLookupSpecifics details) const {
-  if (!details.kind) {
+    StringRef moduleName, Optional<ModuleDependenciesKind> kind) const {
+  if (!kind) {
     for (auto kind = ModuleDependenciesKind::FirstKind;
          kind != ModuleDependenciesKind::LastKind; ++kind) {
-      auto dep =
-          findDependencies(moduleName, {kind, details.currentSearchPaths});
+      auto dep = findDependencies(moduleName, kind);
       if (dep.has_value())
         return dep.value();
     }
     return None;
   }
 
-  assert(details.kind.has_value() && "Expected dependencies kind for lookup.");
-  if (details.kind.value() == swift::ModuleDependenciesKind::SwiftSource) {
+  assert(kind.has_value() && "Expected dependencies kind for lookup.");
+  if (kind.value() == swift::ModuleDependenciesKind::SwiftSource) {
     return findSourceModuleDependency(moduleName);
   }
 
-  const auto &map = getDependenciesMap(*details.kind);
+  const auto &map = getDependenciesMap(kind.value());
   auto known = map.find(moduleName);
-  if (known != map.end()) {
-    assert(!known->second.empty());
-    for (auto &dep : known->second) {
-      if (moduleContainedInImportPathSet(dep, details.currentSearchPaths))
-        return dep;
-    }
-    return None;
-  }
+  if (known != map.end())
+    return known->second;
+
   return None;
 }
 
@@ -396,40 +326,11 @@ GlobalModuleDependenciesCache::findSourceModuleDependency(
 }
 
 bool GlobalModuleDependenciesCache::hasDependencies(
-    StringRef moduleName, ModuleLookupSpecifics details) const {
-  assert(details.kind != ModuleDependenciesKind::Clang &&
+    StringRef moduleName, Optional<ModuleDependenciesKind> kind) const {
+  assert(kind != ModuleDependenciesKind::Clang &&
          "Attempting to query Clang dependency in persistent Dependency "
          "Scanner Cache.");
-  return findDependencies(moduleName, details).has_value();
-}
-
-Optional<ModuleDependenciesVector>
-GlobalModuleDependenciesCache::findAllDependenciesIrrespectiveOfSearchPaths(
-    StringRef moduleName, Optional<ModuleDependenciesKind> kind) const {
-  if (!kind) {
-    for (auto kind = ModuleDependenciesKind::FirstKind;
-         kind != ModuleDependenciesKind::LastKind; ++kind) {
-      if (kind == ModuleDependenciesKind::Clang)
-        continue;
-
-      auto deps =
-          findAllDependenciesIrrespectiveOfSearchPaths(moduleName, kind);
-      if (deps.has_value())
-        return deps.value();
-    }
-    return None;
-  }
-
-  assert(kind.has_value() && "Expected dependencies kind for lookup.");
-  assert(kind.value() != swift::ModuleDependenciesKind::SwiftSource);
-
-  const auto &map = getDependenciesMap(*kind);
-  auto known = map.find(moduleName);
-  if (known != map.end()) {
-    assert(!known->second.empty());
-    return known->second;
-  }
-  return None;
+  return findDependencies(moduleName, kind).has_value();
 }
 
 static std::string modulePathForVerification(const ModuleDependencies &module) {
@@ -479,23 +380,8 @@ const ModuleDependencies *GlobalModuleDependenciesCache::recordDependencies(
   // All other dependencies are recorded according to the target triple of the
   // scanning invocation that discovers them.
   auto &map = getDependenciesMap(kind);
-  // Cache may already have a dependency for this module
-  if (map.count(moduleName) != 0) {
-    // Ensure that the existing dependencies objects are at a different path.
-    // i.e. do not record duplicate dependencies.
-    auto newModulePath = modulePathForVerification(dependencies);
-    for (auto &existingDeps : map[moduleName]) {
-      if (modulePathForVerification(existingDeps) == newModulePath)
-        return &existingDeps;
-    }
-
-    map[moduleName].emplace_back(std::move(dependencies));
-    return map[moduleName].end() - 1;
-  } else {
-    map.insert({moduleName, ModuleDependenciesVector{std::move(dependencies)}});
-    getCurrentCache()->AllModules.push_back({moduleName.str(), kind});
-    return &(map[moduleName].front());
-  }
+  map.insert({moduleName, dependencies});
+  return &(map[moduleName]);
 }
 
 const ModuleDependencies *GlobalModuleDependenciesCache::updateDependencies(
@@ -517,10 +403,8 @@ const ModuleDependencies *GlobalModuleDependenciesCache::updateDependencies(
   auto &map = getDependenciesMap(moduleID.second);
   auto known = map.find(moduleID.first);
   assert(known != map.end() && "Not yet added to map");
-  assert(known->second.size() == 1 &&
-         "Cannot update dependency with multiple candidates.");
-  known->second[0] = std::move(dependencies);
-  return &(known->second[0]);
+  known->second = std::move(dependencies);
+  return &(known->second);
 }
 
 llvm::StringMap<const ModuleDependencies *> &
@@ -541,10 +425,12 @@ ModuleDependenciesCache::getDependencyReferencesMap(
 
 ModuleDependenciesCache::ModuleDependenciesCache(
     GlobalModuleDependenciesCache &globalCache,
-    StringRef mainScanModuleName)
+    std::string mainScanModuleName,
+    std::string scanningContextHash)
     : globalCache(globalCache),
       mainScanModuleName(mainScanModuleName),
       clangScanningTool(globalCache.clangScanningService) {
+  globalCache.configureForContextHash(scannerContextHash);
   for (auto kind = ModuleDependenciesKind::FirstKind;
        kind != ModuleDependenciesKind::LastKind; ++kind) {
     ModuleDependenciesMap.insert(
@@ -552,12 +438,12 @@ ModuleDependenciesCache::ModuleDependenciesCache(
   }
 }
 
-Optional<const ModuleDependencies *> ModuleDependenciesCache::findDependencies(
+Optional<const ModuleDependencies *> ModuleDependenciesCache::findDependenciesLocalOnly(
     StringRef moduleName, Optional<ModuleDependenciesKind> kind) const {
   if (!kind) {
     for (auto kind = ModuleDependenciesKind::FirstKind;
          kind != ModuleDependenciesKind::LastKind; ++kind) {
-      auto dep = findDependencies(moduleName, kind);
+      auto dep = findDependenciesLocalOnly(moduleName, kind);
       if (dep.has_value())
         return dep.value();
     }
@@ -573,21 +459,25 @@ Optional<const ModuleDependencies *> ModuleDependenciesCache::findDependencies(
 }
 
 Optional<ModuleDependencies>
-ModuleDependenciesCache::findDependencies(StringRef moduleName,
-                                          ModuleLookupSpecifics details) const {
+ModuleDependenciesCache::findDependencies(
+    StringRef moduleName, Optional<ModuleDependenciesKind> kind) const {
   // 1. Query the local scan results
-  // 2. If no module found, query the global cache using the module details
-  // lookup
-  auto localResult = findDependencies(moduleName, details.kind);
+  // 2. If no module found, query the global cache
+  auto localResult = findDependenciesLocalOnly(moduleName, kind);
   if (localResult.has_value())
     return *(localResult.value());
   else
-    return globalCache.findDependencies(moduleName, details);
+    return globalCache.findDependencies(moduleName, kind);
+}
+
+bool ModuleDependenciesCache::hasDependenciesLocalOnly(StringRef moduleName,
+                                                       Optional<ModuleDependenciesKind> kind) const {
+  return findDependenciesLocalOnly(moduleName, kind).has_value();
 }
 
 bool ModuleDependenciesCache::hasDependencies(
-    StringRef moduleName, ModuleLookupSpecifics details) const {
-  return findDependencies(moduleName, details).has_value();
+    StringRef moduleName, Optional<ModuleDependenciesKind> kind) const {
+  return findDependencies(moduleName, kind).has_value();
 }
 
 void ModuleDependenciesCache::recordDependencies(

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -120,7 +120,6 @@ void ClangImporter::recordModuleDependencies(
     ModuleDependenciesCache &cache,
     const FullDependenciesResult &clangDependencies) {
   auto &ctx = Impl.SwiftContext;
-  auto currentSwiftSearchPathSet = ctx.getAllModuleSearchPathsSet();
 
   // This scanner invocation's already-captured APINotes version
   std::vector<std::string> capturedPCMArgs = {
@@ -133,7 +132,7 @@ void ClangImporter::recordModuleDependencies(
     // If we've already cached this information, we're done.
     if (cache.hasDependencies(
                     clangModuleDep.ID.ModuleName,
-                    {ModuleDependenciesKind::Clang, currentSwiftSearchPathSet}))
+                    ModuleDependenciesKind::Clang))
       continue;
 
     // File dependencies for this module.
@@ -211,11 +210,9 @@ Optional<ModuleDependencies> ClangImporter::getModuleDependencies(
     StringRef moduleName, ModuleDependenciesCache &cache,
     InterfaceSubContextDelegate &delegate) {
   auto &ctx = Impl.SwiftContext;
-  auto currentSwiftSearchPathSet = ctx.getAllModuleSearchPathsSet();
   // Check whether there is already a cached result.
   if (auto found = cache.findDependencies(
-          moduleName,
-          {ModuleDependenciesKind::Clang, currentSwiftSearchPathSet}))
+          moduleName, ModuleDependenciesKind::Clang))
     return found;
 
   // Determine the command-line arguments for dependency scanning.
@@ -265,8 +262,7 @@ Optional<ModuleDependencies> ClangImporter::getModuleDependencies(
   // Record module dependencies for each module we found.
   recordModuleDependencies(cache, *clangDependencies);
             return cache.findDependencies(
-                    moduleName,
-                    {ModuleDependenciesKind::Clang, currentSwiftSearchPathSet});
+                    moduleName, ModuleDependenciesKind::Clang);
 }
 
 bool ClangImporter::addBridgingHeaderDependencies(
@@ -274,12 +270,7 @@ bool ClangImporter::addBridgingHeaderDependencies(
     ModuleDependenciesKind moduleKind,
     ModuleDependenciesCache &cache) {
   auto &ctx = Impl.SwiftContext;
-  auto currentSwiftSearchPathSet = ctx.getAllModuleSearchPathsSet();
-  
-  auto targetModule = *cache.findDependencies(
-              moduleName,
-              {moduleKind,
-               currentSwiftSearchPathSet});
+  auto targetModule = *cache.findDependencies(moduleName, moduleKind);
 
   // If we've already recorded bridging header dependencies, we're done.
   if (auto swiftInterfaceDeps = targetModule.getAsSwiftInterfaceModule()) {

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -205,8 +205,8 @@ DependencyScanningTool::initScannerForAction(
   auto instanceOrErr = initCompilerInstanceForScan(Command);
   if (instanceOrErr.getError())
     return instanceOrErr;
-  SharedCache->configureForTriple((*instanceOrErr)->getInvocation()
-                                  .getLangOptions().Target.str());
+  SharedCache->configureForContextHash((*instanceOrErr)->getInvocation()
+                                       .getModuleScanningHash());
   return instanceOrErr;
 }
 

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -120,7 +120,8 @@ DependencyScanningTool::getDependencies(
 
   // Local scan cache instance, wrapping the shared global cache.
   ModuleDependenciesCache cache(*SharedCache,
-                                Instance->getMainModule()->getNameStr());
+                                Instance->getMainModule()->getNameStr().str(),
+                                Instance->getInvocation().getModuleScanningHash());
   // Execute the scanning action, retrieving the in-memory result
   auto DependenciesOrErr = performModuleScan(*Instance.get(), cache);
   if (DependenciesOrErr.getError())
@@ -161,7 +162,8 @@ DependencyScanningTool::getDependencies(
 
   // Local scan cache instance, wrapping the shared global cache.
   ModuleDependenciesCache cache(*SharedCache,
-                                Instance->getMainModule()->getNameStr());
+                                Instance->getMainModule()->getNameStr().str(),
+                                Instance->getInvocation().getModuleScanningHash());
   auto BatchScanResults = performBatchModuleScan(
       *Instance.get(), cache, VersionedPCMInstanceCacheCache.get(),
       Saver, BatchInput);
@@ -205,8 +207,6 @@ DependencyScanningTool::initScannerForAction(
   auto instanceOrErr = initCompilerInstanceForScan(Command);
   if (instanceOrErr.getError())
     return instanceOrErr;
-  SharedCache->configureForContextHash((*instanceOrErr)->getInvocation()
-                                       .getModuleScanningHash());
   return instanceOrErr;
 }
 

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -144,11 +144,8 @@ static void findAllImportedClangModules(ASTContext &ctx, StringRef moduleName,
   if (!knownModules.insert(moduleName).second)
     return;
   allModules.push_back(moduleName.str());
-
-  auto currentImportPathSet = ctx.getAllModuleSearchPathsSet();
   auto dependencies =
-    cache.findDependencies(moduleName,
-                           {ModuleDependenciesKind::Clang, currentImportPathSet});
+    cache.findDependencies(moduleName, ModuleDependenciesKind::Clang);
   if (!dependencies)
     return;
 
@@ -164,10 +161,7 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
                           InterfaceSubContextDelegate &ASTDelegate,
                           bool cacheOnly = false) {
   auto &ctx = instance.getASTContext();
-  auto currentImportSet = ctx.getAllModuleSearchPathsSet();
-  auto knownDependencies = *cache.findDependencies(
-                                     module.first,
-                                     {module.second,currentImportSet});
+  auto knownDependencies = *cache.findDependencies(module.first, module.second);
   auto isSwiftInterfaceOrSource = knownDependencies.isSwiftInterfaceModule() ||
                                   knownDependencies.isSwiftSourceModule();
   auto isSwift = isSwiftInterfaceOrSource ||
@@ -197,8 +191,7 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
         // Grab the updated module dependencies.
         // FIXME: This is such a hack.
         knownDependencies =
-            *cache.findDependencies(module.first,
-                                    {module.second, currentImportSet});
+            *cache.findDependencies(module.first, module.second);
 
         // Add the Clang modules referenced from the bridging header to the
         // set of Clang modules we know about.
@@ -251,15 +244,12 @@ static void discoverCrossImportOverlayDependencies(
     CompilerInstance &instance, StringRef mainModuleName,
     ArrayRef<ModuleDependencyID> allDependencies,
     ModuleDependenciesCache &cache, InterfaceSubContextDelegate &ASTDelegate,
-    llvm::function_ref<void(ModuleDependencyID)> action,
-    llvm::StringSet<> &currentImportPathSet) {
+    llvm::function_ref<void(ModuleDependencyID)> action) {
   // Modules explicitly imported. Only these can be secondary module.
   llvm::SetVector<Identifier> newOverlays;
   for (auto dep : allDependencies) {
     auto moduleName = dep.first;
-    auto dependencies = *cache.findDependencies(
-                                            moduleName,
-                                            {dep.second, currentImportPathSet});
+    auto dependencies = *cache.findDependencies(moduleName,dep.second);
     // Collect a map from secondary module name to cross-import overlay names.
     auto overlayMap = dependencies.collectCrossImportOverlayNames(
         instance.getASTContext(), moduleName);
@@ -291,8 +281,7 @@ static void discoverCrossImportOverlayDependencies(
 
   // Update main module's dependencies to include these new overlays.
   auto mainDep = *cache.findDependencies(
-                  mainModuleName,
-                  {ModuleDependenciesKind::SwiftSource, currentImportPathSet});
+                  mainModuleName, ModuleDependenciesKind::SwiftSource);
   std::for_each(newOverlays.begin(), newOverlays.end(),
                 [&](Identifier modName) {
                   dummyMainDependencies.addModuleDependency(modName.str());
@@ -304,8 +293,7 @@ static void discoverCrossImportOverlayDependencies(
   // Record the dummy main module's direct dependencies. The dummy main module
   // only directly depend on these newly discovered overlay modules.
   if (cache.findDependencies(
-                 dummyMainName,
-                 {ModuleDependenciesKind::SwiftSource, currentImportPathSet})) {
+                 dummyMainName, ModuleDependenciesKind::SwiftSource)) {
     cache.updateDependencies(
         std::make_pair(dummyMainName.str(),
                        ModuleDependenciesKind::SwiftSource),
@@ -794,8 +782,7 @@ static swiftscan_dependency_graph_t
 generateFullDependencyGraph(CompilerInstance &instance,
                             ModuleDependenciesCache &cache,
                             InterfaceSubContextDelegate &ASTDelegate,
-                            ArrayRef<ModuleDependencyID> allModules,
-                            llvm::StringSet<> &currentImportPathSet) {
+                            ArrayRef<ModuleDependencyID> allModules) {
   if (allModules.empty()) {
     return nullptr;
   }
@@ -809,9 +796,7 @@ generateFullDependencyGraph(CompilerInstance &instance,
   for (size_t i = 0; i < allModules.size(); ++i) {
     const auto &module = allModules[i];
     // Grab the completed module dependencies.
-    auto moduleDepsQuery = cache.findDependencies(
-                                        module.first,
-                                        {module.second, currentImportPathSet});
+    auto moduleDepsQuery = cache.findDependencies(module.first, module.second);
     if (!moduleDepsQuery) {
       llvm::report_fatal_error(Twine("Module Dependency Cache missing module") +
                                module.first);
@@ -1114,12 +1099,10 @@ forEachBatchEntry(CompilerInstance &invocationInstance,
             SourceLoc(), diag::scanner_arguments_invalid, entry.arguments);
         return true;
       }
-      newGlobalCache->configureForContextHash(newInstance->getInvocation()
-                                              .getModuleScanningHash());
-      
       auto mainModuleName = newInstance->getMainModule()->getNameStr();
+      auto scanContextHash = newInstance->getInvocation().getModuleScanningHash();
       auto newLocalCache = std::make_unique<ModuleDependenciesCache>(
-          *newGlobalCache, mainModuleName);
+          *newGlobalCache, mainModuleName.str(), scanContextHash);
       pInstance = newInstance.get();
       pCache = newLocalCache.get();
       subInstanceMap->insert(
@@ -1257,9 +1240,6 @@ bool swift::dependencies::scanDependencies(CompilerInstance &instance) {
   // `-scan-dependencies` invocations use a single new instance
   // of a module cache
   GlobalModuleDependenciesCache globalCache;
-  globalCache.configureForContextHash(instance.getInvocation()
-                                      .getModuleScanningHash());
-
   if (opts.ReuseDependencyScannerCache)
     deserializeDependencyCache(instance, globalCache);
 
@@ -1267,7 +1247,8 @@ bool swift::dependencies::scanDependencies(CompilerInstance &instance) {
                Context.getClangModuleLoader()->getClangInstance());
 
   ModuleDependenciesCache cache(globalCache,
-                                instance.getMainModule()->getNameStr());
+                                instance.getMainModule()->getNameStr().str(),
+                                instance.getInvocation().getModuleScanningHash());
 
   // Execute scan
   auto dependenciesOrErr = performModuleScan(instance, cache);
@@ -1300,10 +1281,9 @@ bool swift::dependencies::prescanDependencies(CompilerInstance &instance) {
   // `-scan-dependencies` invocations use a single new instance
   // of a module cache
   GlobalModuleDependenciesCache singleUseGlobalCache;
-  singleUseGlobalCache.configureForContextHash(instance.getInvocation()
-                                               .getModuleScanningHash());
   ModuleDependenciesCache cache(singleUseGlobalCache,
-                                instance.getMainModule()->getNameStr());
+                                instance.getMainModule()->getNameStr().str(),
+                                instance.getInvocation().getModuleScanningHash());
   if (out.has_error() || EC) {
     Context.Diags.diagnose(SourceLoc(), diag::error_opening_output, path,
                            EC.message());
@@ -1332,10 +1312,9 @@ bool swift::dependencies::batchScanDependencies(
   // The primary cache used for scans carried out with the compiler instance
   // we have created
   GlobalModuleDependenciesCache singleUseGlobalCache;
-  singleUseGlobalCache.configureForContextHash(instance.getInvocation()
-                                               .getModuleScanningHash());
   ModuleDependenciesCache cache(singleUseGlobalCache,
-                                instance.getMainModule()->getNameStr());
+                                instance.getMainModule()->getNameStr().str(),
+                                instance.getInvocation().getModuleScanningHash());
   (void)instance.getMainModule();
   llvm::BumpPtrAllocator alloc;
   llvm::StringSaver saver(alloc);
@@ -1368,10 +1347,9 @@ bool swift::dependencies::batchPrescanDependencies(
   // The primary cache used for scans carried out with the compiler instance
   // we have created
   GlobalModuleDependenciesCache singleUseGlobalCache;
-  singleUseGlobalCache.configureForContextHash(instance.getInvocation()
-                                               .getModuleScanningHash());
   ModuleDependenciesCache cache(singleUseGlobalCache,
-                                instance.getMainModule()->getNameStr());
+                                instance.getMainModule()->getNameStr().str(),
+                                instance.getInvocation().getModuleScanningHash());
   (void)instance.getMainModule();
   llvm::BumpPtrAllocator alloc;
   llvm::StringSaver saver(alloc);
@@ -1406,7 +1384,6 @@ swift::dependencies::performModuleScan(CompilerInstance &instance,
   // First, identify the dependencies of the main module
   auto mainDependencies = identifyMainModuleDependencies(instance);
   auto &ctx = instance.getASTContext();
-  auto currentImportPathSet = ctx.getAllModuleSearchPathsSet();
 
   // Add the main module.
   StringRef mainModuleName = mainModule->getNameStr();
@@ -1418,8 +1395,7 @@ swift::dependencies::performModuleScan(CompilerInstance &instance,
   // We may be re-using an instance of the cache which already contains
   // an entry for this module.
   if (cache.findDependencies(
-                mainModuleName,
-                {ModuleDependenciesKind::SwiftSource, currentImportPathSet})) {
+                mainModuleName, ModuleDependenciesKind::SwiftSource)) {
     cache.updateDependencies(
         std::make_pair(mainModuleName.str(),
                        ModuleDependenciesKind::SwiftSource),
@@ -1455,8 +1431,7 @@ swift::dependencies::performModuleScan(CompilerInstance &instance,
   discoverCrossImportOverlayDependencies(
       instance, mainModuleName,
       /*All transitive dependencies*/ allModules.getArrayRef().slice(1), cache,
-      ASTDelegate, [&](ModuleDependencyID id) { allModules.insert(id); },
-      currentImportPathSet);
+      ASTDelegate, [&](ModuleDependencyID id) { allModules.insert(id); });
 
   // Diagnose cycle in dependency graph.
   if (diagnoseCycle(instance, cache, /*MainModule*/ allModules.front(),
@@ -1465,12 +1440,11 @@ swift::dependencies::performModuleScan(CompilerInstance &instance,
 
   auto dependencyGraph = generateFullDependencyGraph(
       instance, cache, ASTDelegate,
-      allModules.getArrayRef(), currentImportPathSet);
+      allModules.getArrayRef());
   // Update the dependency tracker.
   if (auto depTracker = instance.getDependencyTracker()) {
     for (auto module : allModules) {
-      auto deps = cache.findDependencies(module.first,
-                                                {module.second, currentImportPathSet});
+      auto deps = cache.findDependencies(module.first, module.second);
       if (!deps)
         continue;
 
@@ -1523,7 +1497,6 @@ swift::dependencies::performBatchModuleScan(
         StringRef moduleName = entry.moduleName;
         bool isClang = !entry.isSwift;
         ASTContext &ctx = instance.getASTContext();
-        auto currentImportPathSet = ctx.getAllModuleSearchPathsSet();
         auto &FEOpts = instance.getInvocation().getFrontendOptions();
         ModuleInterfaceLoaderOptions LoaderOpts(FEOpts);
         auto ModuleCachePath = getModuleCachePathFromClang(
@@ -1575,7 +1548,7 @@ swift::dependencies::performBatchModuleScan(
 
         batchScanResult.push_back(generateFullDependencyGraph(
             instance, cache, ASTDelegate,
-            allModules.getArrayRef(), currentImportPathSet));
+            allModules.getArrayRef()));
       });
 
   return batchScanResult;

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1114,8 +1114,8 @@ forEachBatchEntry(CompilerInstance &invocationInstance,
             SourceLoc(), diag::scanner_arguments_invalid, entry.arguments);
         return true;
       }
-      newGlobalCache->configureForTriple(
-          newInstance->getInvocation().getLangOptions().Target.str());
+      newGlobalCache->configureForContextHash(newInstance->getInvocation()
+                                              .getModuleScanningHash());
       
       auto mainModuleName = newInstance->getMainModule()->getNameStr();
       auto newLocalCache = std::make_unique<ModuleDependenciesCache>(
@@ -1257,8 +1257,8 @@ bool swift::dependencies::scanDependencies(CompilerInstance &instance) {
   // `-scan-dependencies` invocations use a single new instance
   // of a module cache
   GlobalModuleDependenciesCache globalCache;
-  globalCache.configureForTriple(instance.getInvocation()
-                                         .getLangOptions().Target.str());
+  globalCache.configureForContextHash(instance.getInvocation()
+                                      .getModuleScanningHash());
 
   if (opts.ReuseDependencyScannerCache)
     deserializeDependencyCache(instance, globalCache);
@@ -1300,8 +1300,8 @@ bool swift::dependencies::prescanDependencies(CompilerInstance &instance) {
   // `-scan-dependencies` invocations use a single new instance
   // of a module cache
   GlobalModuleDependenciesCache singleUseGlobalCache;
-  singleUseGlobalCache.configureForTriple(instance.getInvocation()
-                                                  .getLangOptions().Target.str());
+  singleUseGlobalCache.configureForContextHash(instance.getInvocation()
+                                               .getModuleScanningHash());
   ModuleDependenciesCache cache(singleUseGlobalCache,
                                 instance.getMainModule()->getNameStr());
   if (out.has_error() || EC) {
@@ -1332,8 +1332,8 @@ bool swift::dependencies::batchScanDependencies(
   // The primary cache used for scans carried out with the compiler instance
   // we have created
   GlobalModuleDependenciesCache singleUseGlobalCache;
-  singleUseGlobalCache.configureForTriple(instance.getInvocation()
-                                                  .getLangOptions().Target.str());
+  singleUseGlobalCache.configureForContextHash(instance.getInvocation()
+                                               .getModuleScanningHash());
   ModuleDependenciesCache cache(singleUseGlobalCache,
                                 instance.getMainModule()->getNameStr());
   (void)instance.getMainModule();
@@ -1368,8 +1368,8 @@ bool swift::dependencies::batchPrescanDependencies(
   // The primary cache used for scans carried out with the compiler instance
   // we have created
   GlobalModuleDependenciesCache singleUseGlobalCache;
-  singleUseGlobalCache.configureForTriple(instance.getInvocation()
-                                                  .getLangOptions().Target.str());
+  singleUseGlobalCache.configureForContextHash(instance.getInvocation()
+                                               .getModuleScanningHash());
   ModuleDependenciesCache cache(singleUseGlobalCache,
                                 instance.getMainModule()->getNameStr());
   (void)instance.getMainModule();

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -66,6 +66,20 @@ std::string CompilerInvocation::getPCHHash() const {
   return llvm::toString(llvm::APInt(64, Code), 36, /*Signed=*/false);
 }
 
+std::string CompilerInvocation::getModuleScanningHash() const {
+  using llvm::hash_combine;
+
+  auto Code = hash_combine(LangOpts.getModuleScanningHashComponents(),
+                           FrontendOpts.getModuleScanningHashComponents(),
+                           ClangImporterOpts.getModuleScanningHashComponents(),
+                           SearchPathOpts.getModuleScanningHashComponents(),
+                           DiagnosticOpts.getModuleScanningHashComponents(),
+                           SILOpts.getModuleScanningHashComponents(),
+                           IRGenOpts.getModuleScanningHashComponents());
+
+  return llvm::toString(llvm::APInt(64, Code), 36, /*Signed=*/false);
+}
+
 const PrimarySpecificPaths &
 CompilerInvocation::getPrimarySpecificPathsForAtMostOnePrimary() const {
   return getFrontendOptions().getPrimarySpecificPathsForAtMostOnePrimary();

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -167,20 +167,16 @@ Optional<ModuleDependencies> SerializedModuleLoaderBase::getModuleDependencies(
 
   // Check whether we've cached this result.
   if (auto found = cache.findDependencies(
-           moduleName,
-           {ModuleDependenciesKind::SwiftInterface, currentSearchPathSet}))
+           moduleName, ModuleDependenciesKind::SwiftInterface))
     return found;
   if (auto found = cache.findDependencies(
-           moduleName,
-           {ModuleDependenciesKind::SwiftSource, currentSearchPathSet}))
+           moduleName, ModuleDependenciesKind::SwiftSource))
     return found;
   if (auto found = cache.findDependencies(
-            moduleName,
-            {ModuleDependenciesKind::SwiftBinary, currentSearchPathSet}))
+            moduleName, ModuleDependenciesKind::SwiftBinary))
     return found;
   if (auto found = cache.findDependencies(
-            moduleName,
-            {ModuleDependenciesKind::SwiftPlaceholder, currentSearchPathSet}))
+            moduleName, ModuleDependenciesKind::SwiftPlaceholder))
     return found;
 
   ImportPath::Module::Builder builder(Ctx, moduleName, /*separator=*/'.');


### PR DESCRIPTION
- Key into a global (shared) dependency scanning cache via context hash.
Introduces a concept of a dependency scanning action context hash, which is used to select an instance of a global dependency scanning cache which gets re-used across multiple dependency scanning actions. In practice, this means that `GlobalModuleDependenciesCache`'s map is keyed with a Context Hash that a given `CompilerInvocation` knows how to produce. 

- Removes disambiguation of 'GlobalModuleDependenciesCache' results by search path set
Previously, `GlobalModuleDependenciesCache ` was keyed by triple and returned a collection of results, one for each potential search path set. This is no longer necessary with the above change since the cache is always configured for the current scanning context hash, which includes the search path set.