### PR TITLE
[SourceKit] Add required rpath back to sourcekitd RPATH_LIST

### DIFF
--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -431,8 +431,9 @@ macro(add_sourcekit_framework name)
     set(RPATH_LIST)
     add_sourcekit_swift_runtime_link_flags(${name} "${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}" ${SOURCEKITFW_HAS_SWIFT_MODULES})
     file(RELATIVE_PATH relative_lib_path
-      "${framework_location}/Versions/A" "${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}/swift/host")
+      "${framework_location}/Versions/A" "${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}")
     list(APPEND RPATH_LIST "@loader_path/${relative_lib_path}")
+    list(APPEND RPATH_LIST "@loader_path/${relative_lib_path}/swift/host")
 
     set_target_properties(${name} PROPERTIES
                           BUILD_WITH_INSTALL_RPATH TRUE
@@ -466,8 +467,9 @@ macro(add_sourcekit_framework name)
     set(RPATH_LIST)
     add_sourcekit_swift_runtime_link_flags(${name} "${framework_location}" SOURCEKITFW_HAS_SWIFT_MODULES RPATH_LIST)
     file(RELATIVE_PATH relative_lib_path
-      "${framework_location}" "${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}/swift/host")
+      "${framework_location}" "${SOURCEKIT_LIBRARY_OUTPUT_INTDIR}")
     list(APPEND RPATH_LIST "@loader_path/${relative_lib_path}")
+    list(APPEND RPATH_LIST "@loader_path/${relative_lib_path}/swift/host")
 
     set_target_properties(${name} PROPERTIES
                           BUILD_WITH_INSTALL_RPATH TRUE
@@ -555,8 +557,9 @@ macro(add_sourcekit_xpc_service name framework_target)
   set(RPATH_LIST)
   add_sourcekit_swift_runtime_link_flags(${name} ${xpc_bin_dir} ${SOURCEKITXPC_HAS_SWIFT_MODULES})
 
-  file(RELATIVE_PATH relative_lib_path "${xpc_bin_dir}" "${lib_dir}/swift/host")
+  file(RELATIVE_PATH relative_lib_path "${xpc_bin_dir}" "${lib_dir}")
   list(APPEND RPATH_LIST "@loader_path/${relative_lib_path}")
+  list(APPEND RPATH_LIST "@loader_path/${relative_lib_path}/swift/host")
 
   # Add rpath for sourcekitdInProc
   # lib/${framework_target}.framework/Versions/A/XPCServices/${name}.xpc/Contents/MacOS/${name}


### PR DESCRIPTION
This was modified to `.../swift/host` in
b338472a2b78d09e3ea9017e20214be1208eea3b, but the SourceKit libraries are not under `swift/host`.

Resolves rdar://103006159.