### PR TITLE
[NFC] TypeLowering: Use lowered type in copy into.

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -1950,7 +1950,7 @@ namespace {
     void emitCopyInto(SILBuilder &B, SILLocation loc,
                       SILValue src, SILValue dest, IsTake_t isTake,
                       IsInitialization_t isInit) const override {
-      if (B.getModule().useLoweredAddresses()) {
+      if (LoweredType.isAddress()) {
         B.createCopyAddr(loc, src, dest, isTake, isInit);
       } else {
         SILValue value = emitLoadOfCopy(B, loc, src, isTake);


### PR DESCRIPTION
Instead of digging the current state of address lowering out of the builder's module, just use the LoweredType whose value category tracks that state.
