### PR TITLE
Serialization: Update `-experimental-skip-non-inlinable-function-bodies` SIL verification for `@_backDeploy`

### DIFF
--- a/lib/SILOptimizer/UtilityPasses/SILSkippingChecker.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SILSkippingChecker.cpp
@@ -72,6 +72,15 @@ static bool shouldHaveSkippedFunction(const SILFunction &F) {
       return false;
   }
 
+  // Functions with @_backDeploy may be copied into the client, so they
+  // shouldn't be skipped. The SILFunction that may be copied into the client
+  // should be serialized and therefore is already handled above. However, a
+  // second resilient SILFunction is also emitted for back deployed functions.
+  // Since the body of the function as written was not skipped, it's expected
+  // that we see the SILFunction for the resilient copy here.
+  if (func->isBackDeployed())
+    return false;
+
   // If none of those conditions trip, then this is something that _should_
   // be serialized in the module even when we're skipping non-inlinable
   // function bodies.

--- a/test/Serialization/back-deployed-attr-skip-noninlinable-function-bodies.swift
+++ b/test/Serialization/back-deployed-attr-skip-noninlinable-function-bodies.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-frontend -parse-as-library -enable-library-evolution -emit-module -module-name Test -experimental-skip-non-inlinable-function-bodies %s
+
+@available(SwiftStdlib 5.6, *)
+@_backDeploy(before: SwiftStdlib 5.7)
+public func foo() {}


### PR DESCRIPTION
SIL verification was failing for modules built with `-experimental-skip-non-inlinable-function-bodies` and containing functions with `@_backDeploy` because `SILSkippingChecker` expected the `SILFunction` corresponding to the resilient copy of back deployed function to be empty. Since the overall function declaration for a back deployed function is considered inlinable, the body will be typechecked and SIL emitted. However, the checker should expect to see two `SILFunction`s corresponding to each back deployed function: one for the client fallback copy (which passes the existing `F.isSerialized()` check) and a second representing the resilient copy of the function, which is not serialized. A specific exception is needed for that second function.