### PR TITLE
Implement @globalConstructor attribute

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -520,6 +520,27 @@ public:
   }
 };
 
+/// Defines the @globalConstructor attribute.
+class GlobalConstructorAttr : public DeclAttribute {
+public:
+  GlobalConstructorAttr(int Priority, SourceLoc AtLoc, SourceRange Range)
+    : DeclAttribute(DAK_GlobalConstructor, AtLoc, Range, false),
+      Priority(Priority) {}
+
+  GlobalConstructorAttr(SourceLoc AtLoc, SourceRange Range)
+    : GlobalConstructorAttr(DefaultPriority, AtLoc, Range) {}
+
+  GlobalConstructorAttr(int Priority)
+    : GlobalConstructorAttr(Priority, SourceLoc(), SourceRange()) {}
+
+  const int Priority;
+  static const int DefaultPriority = 65535;
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_GlobalConstructor;
+  }
+};
+
 /// Defines the @_semantics attribute.
 class SemanticsAttr : public DeclAttribute {
 public:

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -700,6 +700,8 @@ ERROR(sil_specialize_target_func_not_found,none,
       "_specialize target function not found %0", (Identifier))
 ERROR(sil_availability_expected_version,none,
       "expected version number in 'available' attribute", ())
+ERROR(sil_global_constructor_expected_version,none,
+      "expected version number in 'global_constructor' attribute", ())
 
 // SIL Stage
 ERROR(expected_sil_stage_name, none,
@@ -1591,6 +1593,16 @@ ERROR(attr_back_deploy_expected_colon_after_before,none,
       "expected ':' after 'before' in '@_backDeploy' attribute", ())
 ERROR(attr_back_deploy_missing_rparen,none,
       "expected ')' in '@_backDeploy' argument list", ())
+
+// globalConstructor
+ERROR(attr_global_constructor_expected_priority_label,none,
+      "expected 'priority:' in '@globalConstructor' attribute", ())
+ERROR(attr_global_constructor_expected_colon_after_priority,none,
+      "expected ':' after 'priority' in '@globalConstructor' attribute", ())
+ERROR(attr_global_constructor_expected_int,none,
+      "expected 'priority' in '@globalConstructor' to be an integer value between 0 and 65535", ())
+ERROR(attr_global_constructor_missing_rparen,none,
+      "expected ')' after '@globalConstructor' priority", ())
 
 // convention
 ERROR(convention_attribute_expected_lparen,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1537,6 +1537,19 @@ ERROR(cdecl_empty_name,none,
 ERROR(cdecl_throws,none,
       "raising errors from @_cdecl functions is not supported", ())
 
+ERROR(global_constructor_not_at_top_level,none,
+      "@globalConstructor can only be applied to global functions", ())
+ERROR(global_constructor_no_async,none,
+      "@globalConstructor cannot be applied to async functions", ())
+ERROR(global_constructor_no_throws,none,
+      "@globalConstructor cannot be applied to throwing functions", ())
+ERROR(global_constructor_required_type,none,
+      "'@globalConstructor' can only be applied to functions of type '() -> Void'", ())
+ERROR(global_constructor_actor,none,
+      "'@MainActor' cannot be used on functions with '@globalConstructor'", ())
+ERROR(global_constructor_cdecl,none,
+      "'@_cdecl' cannot be used on functions with '@globalConstructor'", ())
+
 ERROR(expose_only_non_other_attr,none,
       "@_expose attribute cannot be applied to an '%0' declaration", (StringRef))
 ERROR(expose_inside_unexposed_decl,none,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1098,6 +1098,11 @@ public:
   bool parseDocumentationAttributeArgument(Optional<StringRef> &Metadata,
                                            Optional<AccessLevel> &Visibility);
 
+  /// Parse the @globalConstructor attribute.
+  bool parseGlobalConstructorAttribute(DeclAttributes &Attributes,
+                                       SourceLoc AtLoc,
+                                       SourceLoc Loc);
+
   /// Parse a specific attribute.
   ParserStatus parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                                   PatternBindingInitializer *&initContext,

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -293,6 +293,11 @@ private:
 
   PerformanceConstraints perfConstraints = PerformanceConstraints::None;
 
+  /// If the function is a global ctor
+  bool IsGlobalConstructor = false;
+  /// The priority of the global ctor, called in ascending order
+  int GlobalConstructorPriority = 0;
+
   /// This is the number of uses of this SILFunction inside the SIL.
   /// It does not include references from debug scopes.
   unsigned RefCount = 0;
@@ -1080,6 +1085,14 @@ public:
   }
 
   void setSpecialPurpose(Purpose purpose) { specialPurpose = purpose; }
+
+  void setGlobalConstructorPriority(int priority) {
+    IsGlobalConstructor = true;
+    GlobalConstructorPriority = priority;
+  }
+
+  bool getIsGlobalConstructor() const { return IsGlobalConstructor; }
+  int getGlobalConstructorPriority() const { return GlobalConstructorPriority; }
 
   /// Return whether this function has a foreign implementation which can
   /// be emitted on demand.

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1285,6 +1285,15 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DAK_GlobalConstructor: {
+    Printer.printAttrName("@globalConstructor");
+    Printer << "(priority: ";
+    auto Attr = cast<GlobalConstructorAttr>(this);
+    Printer << Attr->Priority;
+    Printer << ")";
+    break;
+  }
+
   case DAK_Count:
     llvm_unreachable("exceed declaration attribute kinds");
 
@@ -1459,6 +1468,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "_expose";
   case DAK_Documentation:
     return "_documentation";
+  case DAK_GlobalConstructor:
+    return "globalConstructor";
   }
   llvm_unreachable("bad DeclAttrKind");
 }

--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -178,6 +178,7 @@ swift::getIRTargetOptions(const IRGenOptions &Opts, ASTContext &Ctx) {
   // on Darwin platforms but not on others.
   TargetOpts.DebuggerTuning = llvm::DebuggerKind::LLDB;
   TargetOpts.FunctionSections = Opts.FunctionSections;
+  TargetOpts.UseInitArray = true;
 
   auto *Clang = static_cast<ClangImporter *>(Ctx.getClangModuleLoader());
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -60,6 +60,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/MathExtras.h"
 #include "llvm/Support/SaveAndRestore.h"
+#include "llvm/Transforms/Utils/ModuleUtils.h"
 
 #include "CallEmission.h"
 #include "EntryPointArgumentEmission.h"
@@ -2277,6 +2278,9 @@ void IRGenSILFunction::emitSILFunction() {
     IGM.emitDistributedTargetAccessor(CurSILFn);
     IGM.addAccessibleFunction(CurSILFn);
   }
+
+  if (CurSILFn->getIsGlobalConstructor())
+    llvm::appendToGlobalCtors(IGM.Module, CurFn, CurSILFn->getGlobalConstructorPriority(), nullptr);
 
   // Configure the dominance resolver.
   // TODO: consider re-using a dom analysis from the PassManager

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -196,6 +196,8 @@ void SILFunction::init(
   this->Linkage = unsigned(Linkage);
   this->HasCReferences = false;
   this->IsAlwaysWeakImported = false;
+  this->IsGlobalConstructor = false;
+  this->GlobalConstructorPriority = 0;
   this->IsDynamicReplaceable = isDynamic;
   this->ExactSelfClass = isExactSelfClass;
   this->IsDistributed = isDistributed;
@@ -275,6 +277,8 @@ void SILFunction::createSnapshot(int id) {
   newSnapshot->GlobalInitFlag = GlobalInitFlag;
   newSnapshot->HasCReferences = HasCReferences;
   newSnapshot->IsAlwaysWeakImported = IsAlwaysWeakImported;
+  newSnapshot->IsGlobalConstructor = IsGlobalConstructor;
+  newSnapshot->GlobalConstructorPriority = GlobalConstructorPriority;
   newSnapshot->HasOwnership = HasOwnership;
   newSnapshot->IsWithoutActuallyEscapingThunk = IsWithoutActuallyEscapingThunk;
   newSnapshot->OptMode = OptMode;
@@ -825,6 +829,9 @@ SILFunction::isPossiblyUsedExternally() const {
     return true;
 
   if (isDistributed() && isThunk())
+    return true;
+
+  if (getIsGlobalConstructor())
     return true;
 
   // Declaration marked as `@_alwaysEmitIntoClient` that

--- a/lib/SIL/IR/SILFunctionBuilder.cpp
+++ b/lib/SIL/IR/SILFunctionBuilder.cpp
@@ -318,6 +318,9 @@ SILFunction *SILFunctionBuilder::getOrCreateFunction(
 
     F->setIsAlwaysWeakImported(decl->isAlwaysWeakImported());
 
+    if (auto *A = decl->getAttrs().getAttribute<GlobalConstructorAttr>())
+      F->setGlobalConstructorPriority(A->Priority);
+
     if (auto *accessor = dyn_cast<AccessorDecl>(decl)) {
       auto *storage = accessor->getStorage();
       // Add attributes for e.g. computed properties.

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3056,6 +3056,9 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
     OS << "[available " << version.getAsString() << "] ";
   }
 
+  if (getIsGlobalConstructor())
+    OS << "[global_constructor " << getGlobalConstructorPriority() << "] ";
+
   switch (getInlineStrategy()) {
     case NoInline: OS << "[noinline] "; break;
     case AlwaysInline: OS << "[always_inline] "; break;

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1499,6 +1499,7 @@ namespace  {
     UNINTERESTING_ATTR(Exported)
     UNINTERESTING_ATTR(ForbidSerializingReference)
     UNINTERESTING_ATTR(GKInspectable)
+    UNINTERESTING_ATTR(GlobalConstructor)
     UNINTERESTING_ATTR(HasMissingDesignatedInitializers)
     UNINTERESTING_ATTR(IBAction)
     UNINTERESTING_ATTR(IBDesignable)

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -1923,6 +1923,11 @@ namespace decls_block {
     BCBlob      // _silgen_name
   >;
 
+  using GlobalConstructorDeclAttrLayout = BCRecordLayout<
+    GlobalConstructor_DECL_ATTR,
+    BCVBR<8> // priority
+  >;
+
   using SPIAccessControlDeclAttrLayout = BCRecordLayout<
     SPIAccessControl_DECL_ATTR,
     BCArray<IdentifierIDField>  // SPI names

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2551,6 +2551,14 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return;
     }
 
+    case DAK_GlobalConstructor: {
+      auto *theAttr = cast<GlobalConstructorAttr>(DA);
+      auto abbrCode = S.DeclTypeAbbrCodes[GlobalConstructorDeclAttrLayout::Code];
+      GlobalConstructorDeclAttrLayout::emitRecord(S.Out, S.ScratchRecord,
+                                                  abbrCode, theAttr->Priority);
+      return;
+    }
+
     case DAK_SPIAccessControl: {
       auto theAttr = cast<SPIAccessControlAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[SPIAccessControlDeclAttrLayout::Code];

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -92,6 +92,7 @@ actor MyGlobalActor {
 // KEYWORD2-NEXT:             Keyword/None:                       noDerivative[#Func Attribute#]; name=noDerivative
 // KEYWORD2-NEXT:             Keyword/None:                       Sendable[#Func Attribute#]; name=Sendable
 // KEYWORD2-NEXT:             Keyword/None:                       preconcurrency[#Func Attribute#]; name=preconcurrency
+// KEYWORD2-NEXT:             Keyword/None:                       globalConstructor[#Func Attribute#]; name=globalConstructor
 // KEYWORD2-NOT:              Keyword
 // KEYWORD2-DAG:              Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD2-DAG:              Decl[Struct]/CurrModule:            MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
@@ -241,6 +242,7 @@ struct _S {
 // ON_METHOD-DAG: Keyword/None:                       Sendable[#Func Attribute#]; name=Sendable
 // ON_METHOD-DAG: Keyword/None:                       noDerivative[#Func Attribute#]; name=noDerivative
 // ON_METHOD-DAG: Keyword/None:                       preconcurrency[#Func Attribute#]; name=preconcurrency
+// ON_METHOD-DAG: Keyword/None:                       globalConstructor[#Func Attribute#]; name=globalConstructor
 // ON_METHOD-NOT: Keyword
 // ON_METHOD-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_METHOD-DAG: Decl[Struct]/CurrModule:            MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
@@ -315,6 +317,7 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       typeWrapper[#Declaration Attribute#]; name=typeWrapper
 // ON_MEMBER_LAST-DAG: Keyword/None:                       typeWrapperIgnored[#Declaration Attribute#]; name=typeWrapperIgnored
 // ON_MEMBER_LAST-DAG: Keyword/None:                       runtimeMetadata[#Declaration Attribute#]; name=runtimeMetadata
+// ON_MEMBER_LAST-DAG: Keyword/None:                       globalConstructor[#Declaration Attribute#]; name=globalConstructor
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
@@ -387,6 +390,7 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       typeWrapper[#Declaration Attribute#]; name=typeWrapper
 // KEYWORD_LAST-DAG: Keyword/None:                       typeWrapperIgnored[#Declaration Attribute#]; name=typeWrapperIgnored
 // KEYWORD_LAST-DAG: Keyword/None:                       runtimeMetadata[#Declaration Attribute#]; name=runtimeMetadata
+// KEYWORD_LAST-DAG: Keyword/None:                       globalConstructor[#Declaration Attribute#]; name=globalConstructor
 // KEYWORD_LAST-NOT: Keyword
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper

--- a/test/IRGen/global_constructor.swift
+++ b/test/IRGen/global_constructor.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -parse-stdlib -emit-ir -module-name foo %s | %IRGenFileCheck %s
+
+// RUN: %target-swift-frontend -target x86_64-apple-macosx11.0 -S -parse-stdlib -primary-file %s -module-name foo -o - | %FileCheck %s --check-prefix=CHECK-MACHO
+// RUN: %target-swift-frontend -target x86_64-unknown-linux-gnu -S -parse-stdlib -primary-file %s -module-name foo -o - | %FileCheck %s --check-prefix=CHECK-ELF
+// RUN: %target-swift-frontend -target x86_64-unknown-windows-itanium -S -parse-stdlib -primary-file %s -module-name foo -o - | %FileCheck %s --check-prefix=CHECK-COFF
+
+@globalConstructor(priority: 0) func first() {}
+
+@globalConstructor(priority: 100) private func third() {}
+
+@globalConstructor(priority: 10) public func second() {}
+
+// CHECK: @llvm.global_ctors = appending global
+// CHECK-SAME: { i32 0, void ()* @"$s3foo5firstyyF"
+// CHECK-SAME: { i32 100, void ()* @"$s3foo5third
+// CHECK-SAME: { i32 10, void ()* @"$s3foo6secondyyF"
+
+// CHECK-MACHO: __mod_init_func
+// CHECK-MACHO-NEXT: .p2align
+// CHECK-MACHO-NEXT: .quad	_$s3foo5firstyyF
+// CHECK-MACHO-NEXT: .quad	_$s3foo6secondyyF
+// CHECK-MACHO-NEXT: .quad	_$s3foo5third
+
+// CHECK-ELF: .init_array.0
+// CHECK-ELF: .quad	($s3foo5firstyyF)
+// CHECK-ELF: .init_array.10
+// CHECK-ELF: .quad	($s3foo6secondyyF)
+// CHECK-ELF: .init_array.100
+// CHECK-ELF: .quad	($s3foo5third
+
+// CHECK-COFF: .CRT$XCA00000
+// CHECK-COFF: .p2align
+// CHECK-COFF: .quad	($s3foo5firstyyF)
+// CHECK-COFF: .CRT$XCA00010
+// CHECK-COFF: .quad	($s3foo6secondyyF)
+// CHECK-COFF: .CRT$XCA00100
+// CHECK-COFF: .quad	($s3foo5third

--- a/test/attr/globalConstructor.swift
+++ b/test/attr/globalConstructor.swift
@@ -1,0 +1,100 @@
+// RUN: %target-typecheck-verify-swift -parse-as-library \
+// RUN:   -define-availability "_myProject 2.0:macOS 12.0"
+
+// MARK: - Valid declarations
+
+@globalConstructor func normalFunc() {}
+
+@globalConstructor(priority: 0) func explicitVoidFunc() -> Void {}
+
+@globalConstructor func explicitEmptyTupleFunc() -> () {}
+
+@globalConstructor(priority: 50) private func privateFunc() {}
+
+// MARK: - Unsupported declaration types
+
+@globalConstructor // expected-error {{@globalConstructor cannot be applied to throwing functions}}
+func throwingFunc() throws {}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 9, *)
+@globalConstructor // expected-error {{@globalConstructor cannot be applied to async functions}}
+func asyncFunc() async {}
+
+@globalConstructor(priority: 0) // expected-error {{@globalConstructor may only be used on 'func' declarations}}
+let closure: () -> Void = {}
+
+@globalConstructor // expected-error {{@globalConstructor may only be used on 'func' declarations}}
+class SomeClass {
+  @globalConstructor // expected-error {{@globalConstructor can only be applied to global functions}}
+  class func staticFunc() {}
+
+  @globalConstructor // expected-error {{@globalConstructor can only be applied to global functions}}
+  func memberFunc() {}
+
+  @globalConstructor // expected-error {{@globalConstructor may only be used on 'func' declarations}}
+  init() {}
+
+  @globalConstructor // expected-error {{@globalConstructor may only be used on 'func' declarations}}
+  deinit {}
+
+  @globalConstructor // expected-error {{@globalConstructor may only be used on 'func' declarations}}
+  subscript() -> Int {
+    return 0
+  }
+}
+
+@globalConstructor // expected-error {{@globalConstructor may only be used on 'func' declarations}}
+class Subclass: SomeClass {
+  @globalConstructor // expected-error {{@globalConstructor can only be applied to global functions}}
+  override class func staticFunc() {}
+
+  @globalConstructor // expected-error {{@globalConstructor can only be applied to global functions}}
+  override func memberFunc() {}
+}
+
+@globalConstructor(priority 5) // expected-error {{expected ':' after 'priority' in '@globalConstructor' attribute}} {{28-28=: }}
+func missingColon() {}
+
+@globalConstructor(5) // expected-error {{expected 'priority:' in '@globalConstructor' attribute}} {{20-20=priority: }}
+func missingPriorityLabel() {}
+
+@globalConstructor(priority: -5) // expected-error {{expected 'priority' in '@globalConstructor' to be an integer value between 0 and 65535}} expected-error {{expected declaration}}
+func negativeNumber() {}
+
+@globalConstructor(priority: 1000000) // expected-error {{expected 'priority' in '@globalConstructor' to be an integer value between 0 and 65535}}
+func largeNumber() {}
+
+@globalConstructor(priority: 0x1) // expected-error {{expected 'priority' in '@globalConstructor' to be an integer value between 0 and 65535}} expected-error {{expected declaration}}
+func hexNumber() {}
+
+@globalConstructor(priority: "something") // expected-error {{expected 'priority' in '@globalConstructor' to be an integer value between 0 and 65535}} expected-error {{expected declaration}}
+func stringInsteadOfNumber() {}
+
+@globalConstructor(priority: 5.5) // expected-error {{expected 'priority' in '@globalConstructor' to be an integer value between 0 and 65535}} expected-error {{expected declaration}}
+func floatInsteadOfInt() {}
+
+@globalConstructor(priority: 4000) // expected-error {{'@globalConstructor' can only be applied to functions of type '() -> Void'}}
+func returnsSomething() -> Int { 1 }
+
+@globalConstructor(priority: 5000) // expected-error {{'@globalConstructor' can only be applied to functions of type '() -> Void'}}
+func returnsNever() -> Never {}
+
+@globalConstructor(priority: 6000) // expected-error {{'@globalConstructor' can only be applied to functions of type '() -> Void'}}
+func takesAnArgument(_ a: Int) {}
+
+@globalConstructor(priority: 7777) // expected-error {{'@globalConstructor' can only be applied to functions of type '() -> Void'}}
+func takesAnArgumentWithDefaultValue(_ a: Int = 5) {}
+
+@globalConstructor(priority: 50) // expected-error {{'@globalConstructor' can only be applied to functions of type '() -> Void'}}
+func hasGenerics<T>(_ a: T) {}
+
+@globalConstructor(priority: 0) // expected-error {{'@MainActor' cannot be used on functions with '@globalConstructor'}}
+@MainActor
+func isMainActor() {}
+
+@globalConstructor(priority: 0) // expected-error {{'@_cdecl' cannot be used on functions with '@globalConstructor'}}
+@_cdecl("some_decl")
+func hasCdecl() {}
+
+@globalConstructor(priority: 100 // expected-note {{to match this opening '('}}
+func missingRightParen() {} // expected-error {{expected ')' after '@globalConstructor' priority}}


### PR DESCRIPTION
This attribute mirrors the behavior of `__attribute__((constructor))` in C based languages to allow functions to run on the load of a binary / library. This is implemented with a new attribute that feeds the function into the global `@llvm.global_ctors` variable, which does the appropriate things per-platform.

https://github.com/apple/swift-syntax/pull/1120
https://forums.swift.org/t/pitch-globalconstructor/61901/3