### PR TITLE
Fix a crash in the mandatory inliner related to optimization remarks

### DIFF
--- a/lib/SIL/Utils/OptimizationRemark.cpp
+++ b/lib/SIL/Utils/OptimizationRemark.cpp
@@ -136,7 +136,7 @@ static bool hasForceEmitSemanticAttr(SILFunction &fn, StringRef passName) {
 }
 
 static bool isMethodWithForceEmitSemanticAttrNominalType(SILFunction &fn) {
-  if (!fn.hasSelfParam())
+  if (!fn.hasSelfParam() || fn.getArguments().empty())
     return false;
 
   auto selfType = fn.getSelfArgument()->getType();

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -223,3 +223,8 @@ func closueWhichModifiesLocalVar() -> Int {
   return x
 }
 
+@_noAllocation
+func createEmptyArray() {
+  _ = [Int]() // expected-error {{ending the lifetime of a value of type}}
+}
+


### PR DESCRIPTION
Even if a function's type has a self parameter, it may be specialized and the function argument is actually not there anymore.

rdar://103065348
