### PR TITLE
[Compile Time Constant Extraction] Add extraction of tuples

### DIFF
--- a/include/swift/AST/ConstTypeInfo.h
+++ b/include/swift/AST/ConstTypeInfo.h
@@ -27,7 +27,7 @@ class Type;
 /// in a type property initializer expression
 class CompileTimeValue {
 public:
-  enum ValueKind { RawLiteral, InitCall, Builder, Dictionary, Runtime };
+  enum ValueKind { RawLiteral, InitCall, Builder, Dictionary, Runtime, Tuple };
 
   ValueKind getKind() const { return Kind; }
 
@@ -102,6 +102,28 @@ public:
   static bool classof(const CompileTimeValue *T) {
     return T->getKind() == ValueKind::Dictionary;
   }
+};
+
+struct TupleElement {
+  Optional<std::string> Label;
+  swift::Type Type;
+  std::shared_ptr<CompileTimeValue> Value;
+};
+
+/// A representation of a tuple and each tuple-element
+class TupleValue : public CompileTimeValue {
+public:
+  TupleValue(std::vector<TupleElement> Elements)
+      : CompileTimeValue(ValueKind::Tuple), Elements(Elements) {}
+
+  static bool classof(const CompileTimeValue *T) {
+    return T->getKind() == ValueKind::Tuple;
+  }
+
+  std::vector<TupleElement> getElements() const { return Elements; }
+
+private:
+  std::vector<TupleElement> Elements;
 };
 
 /// A representation of an arbitrary value that does not fall under

--- a/test/ConstExtraction/ExtractGroups.swift
+++ b/test/ConstExtraction/ExtractGroups.swift
@@ -39,11 +39,54 @@
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "tuple1",
-// CHECK-NEXT:        "type": "(Swift.Int, Swift.Float)",
+// CHECK-NEXT:        "type": "(Swift.String, ExtractGroups.Bar)",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
-// CHECK-NEXT:        "valueKind": "RawLiteral",
-// CHECK-NEXT:        "value": "(42, 6.6)"
+// CHECK-NEXT:        "valueKind": "Tuple",
+// CHECK-NEXT:        "value": [
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "type": "Swift.String",
+// CHECK-NEXT:            "valueKind": "RawLiteral",
+// CHECK-NEXT:            "value": "\"foo\""
+// CHECK-NEXT:          },
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "type": "ExtractGroups.Bar",
+// CHECK-NEXT:            "valueKind": "InitCall",
+// CHECK-NEXT:            "value": {
+// CHECK-NEXT:              "type": "ExtractGroups.Bar",
+// CHECK-NEXT:              "arguments": []
+// CHECK-NEXT:            }
+// CHECK-NEXT:          }
+// CHECK-NEXT:        ]
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "tuple2",
+// CHECK-NEXT:        "type": "(lat: Swift.Float, lng: Swift.Float)",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "valueKind": "Tuple",
+// CHECK-NEXT:        "value": [
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "label": "lat",
+// CHECK-NEXT:            "type": "Swift.Float",
+// CHECK-NEXT:            "valueKind": "RawLiteral",
+// CHECK-NEXT:            "value": "42.7"
+// CHECK-NEXT:          },
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "label": "lng",
+// CHECK-NEXT:            "type": "Swift.Float",
+// CHECK-NEXT:            "valueKind": "RawLiteral",
+// CHECK-NEXT:            "value": "-73.9"
+// CHECK-NEXT:          }
+// CHECK-NEXT:        ]
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "tuple3",
+// CHECK-NEXT:        "type": "Swift.Void",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "valueKind": "Tuple",
+// CHECK-NEXT:        "value": []
 // CHECK-NEXT:      }
 // CHECK-NEXT:    ]
 // CHECK-NEXT:  }
@@ -60,5 +103,9 @@ public struct Dictionaries : MyProto {
 }
 
 public struct Tuples : MyProto {
-    let tuple1: (Int, Float) = (42, 6.6)
+    let tuple1: (String, Bar) = ("foo", Bar())
+    let tuple2: (lat: Float, lng: Float) = (lat: 42.7, lng: -73.9)
+    let tuple3: Void = ()
 }
+
+public struct Bar {}


### PR DESCRIPTION
Statically extract tuples with named and unnamed elements.

This change also:

- Refactors `Expr -> CompileTimeValue` into a recursive function to allow proper nesting of extracted values.
- Refactors test extractions into named parameter by type (`t` for tuple, `d` for dictionary, etc.)