### PR TITLE
Revert "[cxx-interop] Workaround interpreter crash"

### DIFF
--- a/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
+++ b/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
@@ -1,8 +1,4 @@
-// FIXME: Cannot use target-run-simple-swift as it causes a runtime crash (https://github.com/apple/swift/issues/52881)
-// RUN: %empty-directory(%t)
-// RUN: %target-build-swift %s -I %S/Inputs -o %t/std-string-overlay -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none
-// RUN: %target-codesign %t/std-string-overlay
-// RUN: %target-run %t/std-string-overlay
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
 //
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx || OS=linux-gnu


### PR DESCRIPTION
This reverts commit 5d86f3e15af44d1cdeb81378133341838273dd23.