### PR TITLE
[Dependency Scanning] Use persistent dependency scanning filesystem in the Swift dependency scanner

### DIFF
--- a/include/swift/DependencyScan/ScanDependencies.h
+++ b/include/swift/DependencyScan/ScanDependencies.h
@@ -31,10 +31,6 @@ class GlobalModuleDependenciesCache;
 
 namespace dependencies {
 
-//using CompilerArgInstanceCacheMap =
-//    llvm::StringMap<std::pair<std::unique_ptr<CompilerInstance>,
-//                              std::unique_ptr<ModuleDependenciesCache>>>;
-
 using CompilerArgInstanceCacheMap =
     llvm::StringMap<std::tuple<std::unique_ptr<CompilerInstance>,
                                std::unique_ptr<GlobalModuleDependenciesCache>,

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -217,6 +217,9 @@ DependencyScanningTool::initCompilerInstanceForScan(
   auto Instance = std::make_unique<CompilerInstance>();
   Instance->addDiagnosticConsumer(&CDC);
 
+  // Wrap the filesystem with a caching `DependencyScanningWorkerFilesystem`
+  SharedCache->overlaySharedFilesystemCacheForCompilation(*Instance);
+
   // Basic error checking on the arguments
   if (CommandArgs.empty()) {
     Instance->getDiags().diagnose(SourceLoc(), diag::error_no_frontend_args);

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1242,13 +1242,13 @@ bool swift::dependencies::scanDependencies(CompilerInstance &instance) {
   GlobalModuleDependenciesCache globalCache;
   if (opts.ReuseDependencyScannerCache)
     deserializeDependencyCache(instance, globalCache);
-
-  auto ModuleCachePath = getModuleCachePathFromClang(
-               Context.getClangModuleLoader()->getClangInstance());
-
+  // Wrap the filesystem with a caching `DependencyScanningWorkerFilesystem`
+  globalCache.overlaySharedFilesystemCacheForCompilation(instance);
   ModuleDependenciesCache cache(globalCache,
                                 instance.getMainModule()->getNameStr().str(),
                                 instance.getInvocation().getModuleScanningHash());
+  auto ModuleCachePath = getModuleCachePathFromClang(
+               Context.getClangModuleLoader()->getClangInstance());
 
   // Execute scan
   auto dependenciesOrErr = performModuleScan(instance, cache);
@@ -1312,6 +1312,9 @@ bool swift::dependencies::batchScanDependencies(
   // The primary cache used for scans carried out with the compiler instance
   // we have created
   GlobalModuleDependenciesCache singleUseGlobalCache;
+  // Wrap the filesystem with a caching `DependencyScanningWorkerFilesystem`
+  // Wrap the filesystem with a caching `DependencyScanningWorkerFilesystem`
+  singleUseGlobalCache.overlaySharedFilesystemCacheForCompilation(instance);
   ModuleDependenciesCache cache(singleUseGlobalCache,
                                 instance.getMainModule()->getNameStr().str(),
                                 instance.getInvocation().getModuleScanningHash());


### PR DESCRIPTION
Adopts Clang's 'DependencyScanningWorkerFilesystem' for use by the scanner, with the persistent scanner instance keeping a 'DependencyScanningFilesystemSharedCache'.