### PR TITLE
[AddressLowering] Handle indirectly yielded values used outside of coroutine range.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -206,7 +206,7 @@ SILValue findOwnershipReferenceRoot(SILValue ref);
 
 /// Look through all ownership forwarding instructions to find the values which
 /// were originally borrowed.
-void findGuaranteedReferenceRoots(SILValue value,
+void findGuaranteedReferenceRoots(SILValue value, bool lookThroughNestedBorrows,
                                   SmallVectorImpl<SILValue> &roots);
 
 /// Find the aggregate containing the first owned root of the

--- a/include/swift/SIL/SILArgumentConvention.h
+++ b/include/swift/SIL/SILArgumentConvention.h
@@ -94,12 +94,12 @@ struct SILArgumentConvention {
   bool isOwnedConvention() const {
     switch (Value) {
     case SILArgumentConvention::Indirect_In:
+    case SILArgumentConvention::Indirect_In_Constant:
     case SILArgumentConvention::Direct_Owned:
       return true;
     case SILArgumentConvention::Indirect_In_Guaranteed:
     case SILArgumentConvention::Direct_Guaranteed:
     case SILArgumentConvention::Indirect_Inout:
-    case SILArgumentConvention::Indirect_In_Constant:
     case SILArgumentConvention::Indirect_Out:
     case SILArgumentConvention::Indirect_InoutAliasable:
     case SILArgumentConvention::Direct_Unowned:

--- a/lib/SIL/Utils/MemoryLocations.cpp
+++ b/lib/SIL/Utils/MemoryLocations.cpp
@@ -173,6 +173,16 @@ void MemoryLocations::analyzeLocations(SILFunction *function) {
           }
         }
       }
+      if (auto *BAI = dyn_cast<BeginApplyInst>(&I)) {
+        auto convention = BAI->getSubstCalleeConv();
+        auto yields = convention.getYields();
+        auto yieldedValues = BAI->getYieldedValues();
+        for (auto index : indices(yields)) {
+          if (convention.isSILIndirect(yields[index])) {
+            analyzeLocation(yieldedValues[index]);
+          }
+        }
+      }
     }
   }
 }

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3306,7 +3306,7 @@ static void emitEndBorrows(SILValue value, AddressLoweringState &pass) {
   SSAPrunedLiveness liveness(&discoveredBlocks);
   liveness.initializeDef(value);
   for (auto *use : usePoints) {
-    assert(!use->isLifetimeEnding());
+    assert(!use->isLifetimeEnding() || isa<EndBorrowInst>(use->getUser()));
     liveness.updateForUse(use->getUser(), /*lifetimeEnding*/ false);
   }
   PrunedLivenessBoundary guaranteedBoundary;

--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -292,7 +292,9 @@ void DCE::markLive() {
           // Visit the end_borrows of all the borrow scopes that this
           // begin_borrow could be borrowing.
           SmallVector<SILValue, 4> roots;
-          findGuaranteedReferenceRoots(borrowInst->getOperand(), roots);
+          findGuaranteedReferenceRoots(borrowInst->getOperand(),
+                                       /*lookThroughNestedBorrows=*/false,
+                                       roots);
           for (auto root : roots) {
             visitTransitiveEndBorrows(root,
                                       [&](EndBorrowInst *endBorrow) {

--- a/test/SIL/memory_lifetime.sil
+++ b/test/SIL/memory_lifetime.sil
@@ -683,3 +683,46 @@ bb3:
   return %14 : $()
 }
 
+sil [ossa] @begin_apply_in_destroy : $@convention(thin) () -> () {
+entry:
+  (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in U
+  destroy_addr %instance : $*Inner
+  end_apply %token
+  %retval = tuple ()
+  return %retval : $()
+}
+
+sil [ossa] @begin_apply_in_constant_destroy : $@convention(thin) () -> () {
+entry:
+  (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in_constant U
+  destroy_addr %instance : $*Inner
+  end_apply %token
+  %retval = tuple ()
+  return %retval : $()
+}
+
+sil [ossa] @begin_apply_in_guaranteed_no_destroy : $@convention(thin) () -> () {
+entry:
+  (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in_guaranteed U
+  end_apply %token
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK: SIL memory lifetime failure in @begin_apply_inout_destroy: memory is not initialized, but should be
+sil [ossa] @begin_apply_inout_no_destroy : $@convention(thin) () -> () {
+entry:
+  (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @inout U
+  end_apply %token
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK: SIL memory lifetime failure in @begin_apply_inout_aliasable_destroy: memory is not initialized, but should be
+sil [ossa] @begin_apply_inout_aliasable_no_destroy : $@convention(thin) () -> () {
+entry:
+  (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @inout_aliasable U
+  end_apply %token
+  %retval = tuple ()
+  return %retval : $()
+}

--- a/test/SIL/memory_lifetime_failures.sil
+++ b/test/SIL/memory_lifetime_failures.sil
@@ -648,3 +648,100 @@ bb0(%0 : $*Optional<String>):
   return %r : $() 
 }
 
+// CHECK: SIL memory lifetime failure in @begin_apply_in_no_destroy: memory is initialized, but shouldn't be
+sil [ossa] @begin_apply_in_no_destroy : $@convention(thin) () -> () {
+entry:
+  (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in U
+  end_apply %token
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK: SIL memory lifetime failure in @begin_apply_in_use_after_end_apply: memory is initialized, but shouldn't be
+sil [ossa] @begin_apply_in_use_after_end_apply : $@convention(thin) () -> () {
+entry:
+  (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in U
+  end_apply %token
+  apply undef<Inner>(%instance) : $@convention(thin) <U> (@in U) -> ()
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK: SIL memory lifetime failure in @begin_apply_in_constant_no_destroy: memory is initialized, but shouldn't be
+sil [ossa] @begin_apply_in_constant_no_destroy : $@convention(thin) () -> () {
+entry:
+  (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in_constant U
+  end_apply %token
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK: SIL memory lifetime failure in @begin_apply_in_constant_use_after_end_apply: memory is initialized, but shouldn't be
+sil [ossa] @begin_apply_in_constant_use_after_end_apply : $@convention(thin) () -> () {
+entry:
+  (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in_constant U
+  end_apply %token
+  apply undef<Inner>(%instance) : $@convention(thin) <U> (@in_constant U) -> ()
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK: SIL memory lifetime failure in @begin_apply_in_guaranteed_destroy: memory is not initialized, but should be
+sil [ossa] @begin_apply_in_guaranteed_destroy : $@convention(thin) () -> () {
+entry:
+  (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in_guaranteed U
+  destroy_addr %instance : $*Inner
+  end_apply %token
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK: SIL memory lifetime failure in @begin_apply_in_guaranteed_use_after_end_apply: memory is not initialized, but should be
+sil [ossa] @begin_apply_in_guaranteed_use_after_end_apply : $@convention(thin) () -> () {
+entry:
+  (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @in_guaranteed U
+  end_apply %token
+  apply undef<Inner>(%instance) : $@convention(thin) <U> (@in_guaranteed U) -> ()
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK: SIL memory lifetime failure in @begin_apply_inout_destroy: memory is not initialized, but should be
+sil [ossa] @begin_apply_inout_destroy : $@convention(thin) () -> () {
+entry:
+  (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @inout U
+  destroy_addr %instance : $*Inner
+  end_apply %token
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK: SIL memory lifetime failure in @begin_apply_inout_use_after_end_apply: memory is not initialized, but should be
+sil [ossa] @begin_apply_inout_use_after_end_apply : $@convention(thin) () -> () {
+entry:
+  (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @inout U
+  end_apply %token
+  apply undef<Inner>(%instance) : $@convention(thin) <U> (@inout U) -> ()
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK: SIL memory lifetime failure in @begin_apply_inout_aliasable_destroy: memory is not initialized, but should be
+sil [ossa] @begin_apply_inout_aliasable_destroy : $@convention(thin) () -> () {
+entry:
+  (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @inout_aliasable U
+  destroy_addr %instance : $*Inner
+  end_apply %token
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK: SIL memory lifetime failure in @begin_apply_inout_aliasable_use_after_end_apply: memory is not initialized, but should be
+sil [ossa] @begin_apply_inout_aliasable_use_after_end_apply : $@convention(thin) () -> () {
+entry:
+  (%instance, %token) = begin_apply undef<Inner>() : $@yield_once @convention(thin) <U> () -> @yields @inout_aliasable U
+  end_apply %token
+  apply undef<Inner>(%instance) : $@convention(thin) <U> (@inout_aliasable U) -> ()
+  %retval = tuple ()
+  return %retval : $()
+}

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1753,6 +1753,33 @@ entry:
   return %retval : $()
 }
 
+// Verify that a copy_value that is a "copy-store" whose source is a borrow of an
+// @in_guaranteed yield generates storage.
+// testBeginApplyH2CopyStoreBorrowedInGuaranteedValue
+// CHECK-LABEL: sil [ossa] @testBeginApplyH2CopyStoreBorrowedInGuaranteedValue : {{.*}} {
+// CHECK:         [[COPY_STORAGE:%[^,]+]] = alloc_stack $T
+// CHECK:         ([[YIELD_STORAGE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply undef
+// CHECK:         copy_addr [[YIELD_STORAGE]] to [init] [[COPY_STORAGE]] : $*T
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         [[PTR:%[^,]+]] = apply undef
+// CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[PTR]]
+// CHECK:         copy_addr [take] [[COPY_STORAGE]] to [[ADDR]]
+// CHECK-LABEL: } // end sil function 'testBeginApplyH2CopyStoreBorrowedInGuaranteedValue'
+sil [ossa] @testBeginApplyH2CopyStoreBorrowedInGuaranteedValue : $@convention(thin) <T> () -> () {
+entry:
+  (%yield, %token) = begin_apply undef<T>() : $@yield_once @convention(thin) <τ_0_0> () -> @yields @in_guaranteed τ_0_0
+  %borrow = begin_borrow %yield : $T
+  apply undef<T>(%borrow) : $@convention(thin) <τ> (@in_guaranteed τ) -> ()
+  %copy = copy_value %borrow : $T
+  end_borrow %borrow : $T
+  end_apply %token
+  %ptr = apply undef<T>() : $@convention(method) <τ_0_0> () -> Builtin.RawPointer
+  %addr = pointer_to_address %ptr : $Builtin.RawPointer to [strict] $*T
+  store %copy to [assign] %addr : $*T
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // sil [ossa] @testBeginApplyIConsumeInValue : {{.*}} {
 // bb0:
 //   [[IN_STORAGE:%[^,]+]] = alloc_stack $T

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1506,8 +1506,8 @@ bb0(%0 : @guaranteed $TestGeneric<T>):
 sil [ossa] @testBeginApply4YieldLoadableTrivial : $@convention(thin) () -> I {
 entry:
   (%instance, %token) = begin_apply undef<LoadableTrivialExtractable>() : $@yield_once @convention(thin) <U> () -> @yields @in_guaranteed U
-  end_apply %token
   %extract = struct_extract %instance : $LoadableTrivialExtractable, #LoadableTrivialExtractable.i
+  end_apply %token
   return %extract : $I
 }
 
@@ -1521,9 +1521,9 @@ entry:
 sil [ossa] @testBeginApply5Yield2LoadableTrivial : $@convention(thin) () -> (I, I) {
 entry:
   (%instance_1, %instance_2, %token) = begin_apply undef<LoadableTrivialExtractable>() : $@yield_once @convention(thin) <U> () -> (@yields @in_guaranteed U, @yields @in_guaranteed U)
-  end_apply %token
   %i_1 = struct_extract %instance_1 : $LoadableTrivialExtractable, #LoadableTrivialExtractable.i
   %i_2 = struct_extract %instance_2 : $LoadableTrivialExtractable, #LoadableTrivialExtractable.i
+  end_apply %token
   %tuple = tuple (%i_1 : $I, %i_2 : $I)
   return %tuple : $(I, I)
 }
@@ -1540,8 +1540,8 @@ sil [ossa] @testBeginApply6Yield1LoadableTrivial1OpaqueGuaranteed : $@convention
 entry:
   (%instance_1, %instance_2, %token) = begin_apply undef<LoadableTrivialExtractable, T>() : $@yield_once @convention(thin) <U, T> () -> (@yields @in_guaranteed U, @yields @in_guaranteed T)
   %copy = copy_value %instance_2 : $T
-  end_apply %token
   %i = struct_extract %instance_1 : $LoadableTrivialExtractable, #LoadableTrivialExtractable.i
+  end_apply %token
   %tuple = tuple (%i : $I, %copy : $T)
   return %tuple : $(I, T)
 }
@@ -1654,12 +1654,12 @@ entry:
 sil [ossa] @testBeginApplyCYield1LoadableNontrivialOwned1OpaqueOwned : $@convention(thin) <T> () -> (@out Klass, @out T) {
 entry:
   (%instance_1, %instance_2, %token) = begin_apply undef<LoadableNontrivial, T>() : $@yield_once @convention(thin) <U, T> () -> (@yields @in U, @yields @in T)
-  end_apply %token
   %borrow_1 = begin_borrow %instance_1 : $LoadableNontrivial
   %extract_1 = struct_extract %borrow_1 : $LoadableNontrivial, #LoadableNontrivial.x
   %copy_1 = copy_value %extract_1 : $Klass
   end_borrow %borrow_1 : $LoadableNontrivial
   destroy_value %instance_1 : $LoadableNontrivial
+  end_apply %token
   %retval = tuple (%copy_1 : $Klass, %instance_2 : $T)
   return %retval : $(Klass, T)
 }

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1648,8 +1648,8 @@ entry:
 // CHECK:       {{bb[0-9]+}}({{%[^,]+}} : $*Klass, [[OPAQUE_OUT:%[^,]+]] : $*T):
 // CHECK:         ([[ADDR_1:%[^,]+]], [[ADDR_2:%[^,]+]], {{%[^,]+}}) = begin_apply
 // CHECK:         [[INSTANCE_1:%[^,]+]] = load [take] [[ADDR_1]]
-// CHECK:         begin_borrow [[INSTANCE_1]]
 // CHECK:         copy_addr [take] [[ADDR_2]] to [init] [[OPAQUE_OUT]]
+// CHECK:         begin_borrow [[INSTANCE_1]]
 // CHECK-LABEL: } // end sil function 'testBeginApplyCYield1LoadableNontrivialOwned1OpaqueOwned'
 sil [ossa] @testBeginApplyCYield1LoadableNontrivialOwned1OpaqueOwned : $@convention(thin) <T> () -> (@out Klass, @out T) {
 entry:
@@ -1708,6 +1708,123 @@ entry:
   %retval = copy_value %instance : $T
   end_apply %token
   return %retval : $T
+}
+
+// Verify that a copy_value of a @in_guaranteed yield generates storage.
+// CHECK-LABEL: sil [ossa] @testBeginApplyGCopyConsumeInGuaranteedValue : {{.*}} {
+// CHECK:       bb0:
+// CHECK:         [[COPY_STORAGE:%[^,]+]] = alloc_stack $T                             
+// CHECK:         ([[YIELD_STORAGE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply
+// CHECK:         copy_addr [[YIELD_STORAGE]] to [init] [[COPY_STORAGE]]
+// CHECK:         end_apply [[TOKEN]]                                    
+// CHECK:         apply undef<T>([[COPY_STORAGE]])
+// CHECK:         dealloc_stack [[COPY_STORAGE]]
+// CHECK-LABEL: } // end sil function 'testBeginApplyGCopyConsumeInGuaranteedValue'
+sil [ossa] @testBeginApplyGCopyConsumeInGuaranteedValue : $@convention(thin) <T> () -> () {
+entry:
+  (%yield, %token) = begin_apply undef<T>() : $@yield_once @convention(thin) <τ_0_0> () -> @yields @in_guaranteed τ_0_0
+  %copy = copy_value %yield : $T
+  end_apply %token
+  apply undef<T>(%copy) : $@convention(thin) <T> (@in T) -> ()
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Verify that a copy_value that is a "copy-store" whose source is an
+// @in_guaranteed storage generates storage.
+// CHECK-LABEL: sil [ossa] @testBeginApplyH1CopyStoreInGuaranteedValue : {{.*}} {
+// CHECK:         [[COPY_STORAGE:%[^,]+]] = alloc_stack $T
+// CHECK:         ([[YIELD_STORAGE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply
+// CHECK:         copy_addr [[YIELD_STORAGE]] to [init] [[COPY_STORAGE]]
+// CHECK:         end_apply [[TOKEN]]
+// CHECK:         [[PTR:%[^,]+]] = apply undef
+// CHECK:         [[ADDR:%[^,]+]] = pointer_to_address [[PTR:%[^,]+]]
+// CHECK:         copy_addr [take] [[COPY_STORAGE]] to [[ADDR]]
+// CHECK-LABEL: } // end sil function 'testBeginApplyH1CopyStoreInGuaranteedValue'
+sil [ossa] @testBeginApplyH1CopyStoreInGuaranteedValue : $@convention(thin) <T> () -> () {
+entry:
+  (%yield, %token) = begin_apply undef<T>() : $@yield_once @convention(thin) <τ_0_0> () -> @yields @in_guaranteed τ_0_0
+  %copy = copy_value %yield : $T
+  end_apply %token
+  %ptr = apply undef<T>() : $@convention(method) <τ_0_0> () -> Builtin.RawPointer
+  %addr = pointer_to_address %ptr : $Builtin.RawPointer to [strict] $*T
+  store %copy to [assign] %addr : $*T
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// sil [ossa] @testBeginApplyIConsumeInValue : {{.*}} {
+// bb0:
+//   [[IN_STORAGE:%[^,]+]] = alloc_stack $T
+//   ([[YIELD_STORAGE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply undef<T>()
+//   copy_addr [take] [[YIELD_STORAGE]] to [init] [[IN_STORAGE]]
+//   end_apply [[TOKEN]]
+//   apply undef<T>([[IN_STORAGE]])
+// } // end sil function 'testBeginApplyIConsumeInValue'
+sil [ossa] @testBeginApplyIConsumeInValue : $@convention(thin) <T> () -> () {
+entry:
+  (%yield, %token) = begin_apply undef<T>() : $@yield_once @convention(thin) <τ_0_0> () -> @yields @in τ_0_0
+  end_apply %token
+  apply undef<T>(%yield) : $@convention(thin) <T> (@in T) -> ()
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// sil [ossa] @testBeginApplyJStoreInValue : {{.*}} {
+//   [[IN_STORAGE:%[^,]+]] = alloc_stack $T
+//   ([[YIELD_STORAGE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply
+//   copy_addr [take] [[YIELD_STORAGE]] to [init] [[IN_STORAGE]]
+//   end_apply [[TOKEN]]
+//   [[PTR:%[^,]+]] = apply
+//   [[ADDR:%[^,]+]] = pointer_to_address [[PTR:%[^,]+]]
+//   copy_addr [take] [[IN_STORAGE]] to [[ADDR]]
+// } // end sil function 'testBeginApplyJStoreInValue'
+sil [ossa] @testBeginApplyJStoreInValue : $@convention(thin) <T> () -> () {
+entry:
+  (%yield, %token) = begin_apply undef<T>() : $@yield_once @convention(thin) <τ_0_0> () -> @yields @in τ_0_0
+  end_apply %token
+  %ptr = apply undef<T>() : $@convention(method) <τ_0_0> () -> Builtin.RawPointer
+  %addr = pointer_to_address %ptr : $Builtin.RawPointer to [strict] $*T
+  store %yield to [assign] %addr : $*T
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// sil [ossa] @testBeginApplyKConsumeInConstantValue : {{.*}} {
+// bb0:
+//   [[IN_CONSTANT_STORAGE:%[^,]+]] = alloc_stack $T
+//   ([[YIELD_STORAGE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply undef<T>()
+//   copy_addr [take] [[YIELD_STORAGE]] to [init] [[IN_CONSTANT_STORAGE]]
+//   end_apply [[TOKEN]]
+//   apply undef<T>([[IN_CONSTANT_STORAGE]])
+// } // end sil function 'testBeginApplyKConsumeInConstantValue'
+sil [ossa] @testBeginApplyKConsumeInConstantValue : $@convention(thin) <T> () -> () {
+entry:
+  (%yield, %token) = begin_apply undef<T>() : $@yield_once @convention(thin) <τ_0_0> () -> @yields @in_constant τ_0_0
+  end_apply %token
+  apply undef<T>(%yield) : $@convention(thin) <T> (@in_constant T) -> ()
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// sil [ossa] @testBeginApplyLStoreInConstantValue : {{.*}} {
+//   [[IN_CONSTANT_STORAGE:%[^,]+]] = alloc_stack $T
+//   ([[YIELD_STORAGE:%[^,]+]], [[TOKEN:%[^,]+]]) = begin_apply
+//   copy_addr [take] [[YIELD_STORAGE]] to [init] [[IN_CONSTANT_STORAGE]]
+//   end_apply [[TOKEN]]
+//   [[PTR:%[^,]+]] = apply
+//   [[ADDR:%[^,]+]] = pointer_to_address [[PTR:%[^,]+]]
+//   copy_addr [take] [[IN_CONSTANT_STORAGE]] to [[ADDR]]
+// } // end sil function 'testBeginApplyLStoreInConstantValue'
+sil [ossa] @testBeginApplyLStoreInConstantValue : $@convention(thin) <T> () -> () {
+entry:
+  (%yield, %token) = begin_apply undef<T>() : $@yield_once @convention(thin) <τ_0_0> () -> @yields @in_constant τ_0_0
+  end_apply %token
+  %ptr = apply undef<T>() : $@convention(method) <τ_0_0> () -> Builtin.RawPointer
+  %addr = pointer_to_address %ptr : $Builtin.RawPointer to [strict] $*T
+  store %yield to [assign] %addr : $*T
+  %retval = tuple ()
+  return %retval : $()
 }
 
 // CHECK-LABEL: sil hidden [ossa] @testOpaqueYield :

--- a/test/SILOptimizer/specialize_ossa.sil
+++ b/test/SILOptimizer/specialize_ossa.sil
@@ -1252,6 +1252,7 @@ bb0(%0 : $Builtin.Int32, %1 : @guaranteed $Builtin.NativeObject):
   %1c = copy_value %1 : $Builtin.NativeObject
   store %1c to [init] %1b : $*Builtin.NativeObject
   (%1result, %1token) = begin_apply %f<Builtin.NativeObject>(%1b) : $@yield_once @convention(thin) <T> (@in_guaranteed T) -> @yields @in T
+  destroy_addr %1result : $*Builtin.NativeObject
 
   end_apply %1token
   destroy_addr %1b : $*Builtin.NativeObject


### PR DESCRIPTION
The `begin_apply` instruction introduces storage which is only valid until the coroutine is ended via `end_apply`/`abort_apply`.  Previously, AddressLowering assumed the memory was valid "as long as it needed to be": either as an argument to the function being lowered (so valid for the whole lifetime) or as a new `alloc_stack` (whose lifetime is determined by AddressLowering itself).  The result was that the storage made available by the `begin_apply` was used after the `end_apply`/`abort_apply` when there were uses of [a copy of] [a projection of] the yield after the `end_apply`/`abort_apply`.

Here, the behavior is fixed.  Now, the storage is used "as soon as possible".  There are two cases:

(1) If an indirect value's ownership is transferred into the caller (i.e. its convention is `@in` or `@in_constant`), the value is `copy_addr [take]`n into caller-local storage when lowering the `begin_apply`.

(2) If an indirect value's ownership is only lent to the caller (i.e. its convention is `@in_guaranteed`), no equivalent operation could be done: there's no `copy_addr [borrow]`; on the other hand, there's no need to do it--uses of the value must have occurred within the coroutine's range.  Instead, it's necessary to disable the store-copy optimization in this case: storage must be allocated for a copy of [a projection of] the yielded value.