### PR TITLE
[AddressLowering] Handle builtins for resumes.

### DIFF
--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -2930,6 +2930,16 @@ protected:
 
   void visitBuiltinInst(BuiltinInst *bi) {
     switch (bi->getBuiltinKind().value_or(BuiltinValueKind::None)) {
+    case BuiltinValueKind::ResumeNonThrowingContinuationReturning: {
+      SILValue opAddr = addrMat.materializeAddress(use->get());
+      bi->setOperand(1, opAddr);
+      break;
+    }
+    case BuiltinValueKind::ResumeThrowingContinuationReturning: {
+      SILValue opAddr = addrMat.materializeAddress(use->get());
+      bi->setOperand(1, opAddr);
+      break;
+    }
     case BuiltinValueKind::Copy: {
       SILValue opAddr = addrMat.materializeAddress(use->get());
       bi->setOperand(0, opAddr);


### PR DESCRIPTION
The builtins for resuming UnsafeContinuations traffic in generic values and must be rewritten to use addresses instead of values.
