### PR TITLE
SILGen: Fix 'multiple definitions of symbol' error for functions with `@_backDeploy` containing defer blocks

### DIFF
--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -66,7 +66,10 @@ public:
   llvm::DenseMap<SILDeclRef, SILDeclRef> delayedFunctions;
 
   /// Queue of delayed SILFunctions that need to be forced.
-  std::deque<SILDeclRef> forcedFunctions;
+  std::deque<SILDeclRef> pendingForcedFunctions;
+
+  /// Delayed SILFunctions that need to be forced.
+  llvm::DenseSet<SILDeclRef> forcedFunctions;
 
   /// Mapping global VarDecls to their onceToken and onceFunc, respectively.
   llvm::DenseMap<VarDecl *, std::pair<SILGlobalVariable *,

--- a/test/SILGen/back_deploy_attribute_async_func.swift
+++ b/test/SILGen/back_deploy_attribute_async_func.swift
@@ -1,0 +1,59 @@
+// RUN: %target-swift-emit-sil -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 -verify
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.60 | %FileCheck %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: concurrency
+
+@available(macOS 10.51, *)
+@usableFromInline func otherFunc() async {}
+
+// -- Fallback definition of asyncFunc()
+// CHECK: sil non_abi [serialized] [ossa] @$s11back_deploy9asyncFuncyyYaFTwB : $@convention(thin) @async () -> ()
+// CHECK: bb0:
+// CHECK:   [[FNREF:%.*]] = function_ref @$s11back_deploy9otherFuncyyYaF : $@convention(thin) @async () -> ()
+// CHECK:   [[APPLY:%.*]] = apply [[FNREF]]() : $@convention(thin) @async () -> ()
+// CHECK:   [[RESULT:%.*]] = tuple ()
+// CHECK:   return [[RESULT]] : $()
+
+// -- Back deployment thunk for trivialFunc()
+// CHECK-LABEL: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy9asyncFuncyyYaFTwb : $@convention(thin) @async () -> ()
+// CHECK: bb0:
+// CHECK:   [[MAJOR:%.*]] = integer_literal $Builtin.Word, 10
+// CHECK:   [[MINOR:%.*]] = integer_literal $Builtin.Word, 52
+// CHECK:   [[PATCH:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK:   [[OSVFN:%.*]] = function_ref @$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK:   [[AVAIL:%.*]] = apply [[OSVFN]]([[MAJOR]], [[MINOR]], [[PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
+// CHECK:   cond_br [[AVAIL]], [[AVAIL_BB:bb[0-9]+]], [[UNAVAIL_BB:bb[0-9]+]]
+//
+// CHECK: [[UNAVAIL_BB]]:
+// CHECK:   [[FALLBACKFN:%.*]] = function_ref @$s11back_deploy9asyncFuncyyYaFTwB : $@convention(thin) @async () -> ()
+// CHECK:   {{%.*}} = apply [[FALLBACKFN]]() : $@convention(thin) @async () -> ()
+// CHECK:   br [[RETURN_BB:bb[0-9]+]]
+//
+// CHECK: [[AVAIL_BB]]:
+// CHECK:   [[ORIGFN:%.*]] = function_ref @$s11back_deploy9asyncFuncyyYaF : $@convention(thin) @async () -> ()
+// CHECK:   {{%.*}} = apply [[ORIGFN]]() : $@convention(thin) @async () -> ()
+// CHECK:   br [[RETURN_BB]]
+//
+// CHECK: [[RETURN_BB]]
+// CHECK:   [[RESULT:%.*]] = tuple ()
+// CHECK:   return [[RESULT]] : $()
+
+// -- Original definition of trivialFunc()
+// CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy9asyncFuncyyYaF : $@convention(thin) @async () -> ()
+@available(macOS 10.51, *)
+@_backDeploy(before: macOS 10.52)
+public func asyncFunc() async {
+  await otherFunc()
+}
+
+// CHECK-LABEL: sil hidden [available 10.51] [ossa] @$s11back_deploy6calleryyYaF : $@convention(thin) @async () -> ()
+@available(macOS 10.51, *)
+func caller() async {
+  // -- Verify the thunk is called
+  // CHECK: {{%.*}} = function_ref @$s11back_deploy9asyncFuncyyYaFTwb : $@convention(thin) @async () -> ()
+  await asyncFunc()
+}
+

--- a/test/attr/Inputs/BackDeployHelper.swift
+++ b/test/attr/Inputs/BackDeployHelper.swift
@@ -151,6 +151,13 @@ extension IntArray {
   public var rawValues: [Int] {
     _read { yield _values }
   }
+
+  @available(BackDeploy 1.0, *)
+  @_backDeploy(before: BackDeploy 2.0)
+  public mutating func removeLast() -> Int? {
+    defer { _values.removeLast() }
+    return _values.last
+  }
 }
 
 extension ReferenceIntArray {
@@ -191,6 +198,13 @@ extension ReferenceIntArray {
   @_backDeploy(before: BackDeploy 2.0)
   public final var rawValues: [Int] {
     _read { yield _values }
+  }
+
+  @available(BackDeploy 1.0, *)
+  @_backDeploy(before: BackDeploy 2.0)
+  public final func removeLast() -> Int? {
+    defer { _values.removeLast() }
+    return _values.last
   }
 }
 

--- a/test/attr/attr_backDeploy_evolution.swift
+++ b/test/attr/attr_backDeploy_evolution.swift
@@ -162,7 +162,9 @@ do {
   
   // CHECK-ABI: library: [5, 43, 3]
   // CHECK-BD: client: [5, 43, 3]
-  print(array.rawValues.print())
+  array.rawValues.print()
+
+  precondition(array.removeLast() == 3)
 }
 
 do {
@@ -194,5 +196,7 @@ do {
   
   // CHECK-ABI: library: [7, 40, 1]
   // CHECK-BD: client: [7, 40, 1]
-  print(array.rawValues.print())
+  array.rawValues.print()
+
+  precondition(array.removeLast() == 1)
 }


### PR DESCRIPTION
If the emission of a function is delayed via `emitOrDelayFunction()`, then the function is recorded on a list of delayed functions. If the delayed function is later referenced, then the function moves from the delayed list to the "forced" list which will cause it to actually be emitted later. The implementation of `emitOrDelayFunction()` had a bug when called twice for the same delayable function - it would emit that function prematurely if the function moved to the forced list between the two invocations. Later, during forced function emission a multiple definitions of symbol diagnostic would be emitted since the function was not empty.
    
This issue could be triggered by `@_backDeploy` functions that have auxilary delayable helper functions (e.g. defer blocks). SILGen visits `@_backDeploy` functions twice (once for the copy of the function emitted into the client and once for the resilient copy of the function) so `emitOrDelayFunction()` is called twice for each of the helper functions and the helper functions could become referenced between the two calls.
    
The fix is to check for an existing entry in the forced functions list before delaying or emitting a delayable function.
    
Resolves rdar://102909684
