### PR TITLE
[CSBindings] Favor conjunctions over last resort existential bindings

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1070,6 +1070,17 @@ bool BindingSet::favoredOverConjunction(Constraint *conjunction) const {
     if (forClosureResult() || forGenericParameter())
       return false;
   }
+
+  // If type variable's binding set is incomplete, let's not
+  // bind it to a type inferred from conformance constraint
+  // (that's the action of last resort because not all
+  // protocols can conform to themselves), instead let's solve
+  // conjunctions first which could end up providing actual
+  // type to convert to a contextual existential.
+  if ((isPotentiallyIncomplete() || isDelayed()) &&
+      isSubtypeOfExistentialType())
+    return false;
+
   return true;
 }
 

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -626,3 +626,26 @@ do {
     }
   }
 }
+
+protocol MyDataProtocol {}
+
+// Make sure that closure is allowed to infer a result type for the body in presence of
+// existential conversion.
+func test_inference_with_existential_result() {
+  struct MyData : MyDataProtocol {}
+
+  func fn<T: MyDataProtocol>(_ fn: () -> T) -> T { fn() }
+
+  func test_single() -> any MyDataProtocol {
+    return fn { // Ok - result is inferred as MyData which is converted to any MyDataProtocol
+      MyData()
+    }
+  }
+
+  func test_multi() -> any MyDataProtocol {
+    return fn { // Ok - result is inferred as MyData which is converted to any MyDataProtocol
+      print("in closure")
+      return MyData()
+    }
+  }
+}


### PR DESCRIPTION
If type variable's binding set is incomplete, let's not
bind it to a type inferred from conformance constraint
(that's the action of last resort because not all
protocols can conform to themselves), instead let's 
solve conjunctions first which could end up providing
 actual type to convert to a contextual existential.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
