### PR TITLE
[cxx-interop] Emit IR for std::get in structured bindings declaration

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -87,6 +87,14 @@ public:
     return true;
   }
 
+  bool VisitBindingDecl(clang::BindingDecl *BD) {
+    if (auto *holdingVar = BD->getHoldingVar()) {
+      if (holdingVar->hasInit())
+        TraverseStmt(holdingVar->getInit());
+    }
+    return true;
+  }
+
   // Do not traverse unevaluated expressions. Doing to might result in compile
   // errors if we try to instantiate an un-instantiatable template.
 

--- a/test/Interop/Cxx/class/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/Inputs/module.modulemap
@@ -78,6 +78,11 @@ module ProtocolConformance {
   requires cplusplus
 }
 
+module StructuredBindingsGetMethod {
+  header "structured-bindings-get-method.h"
+  requires cplusplus
+}
+
 module SynthesizedInitializers {
   header "synthesized-initializers.h"
   requires cplusplus

--- a/test/Interop/Cxx/class/Inputs/structured-bindings-get-method.h
+++ b/test/Interop/Cxx/class/Inputs/structured-bindings-get-method.h
@@ -1,0 +1,54 @@
+#ifndef TEST_INTEROP_CXX_CLASS_STRUCTURED_BINDINGS_H
+#define TEST_INTEROP_CXX_CLASS_STRUCTURED_BINDINGS_H
+
+namespace std {
+
+template<class X, class Y>
+struct pear {
+    pear(X x, Y y) {}
+
+    X getX() const {
+        return 0;
+    }
+    Y getY() const {
+        return 42;
+    }
+};
+
+template<class T>
+struct tuple_size {
+    constexpr static const int value = 2;
+};
+
+template<int n, class T>
+struct tuple_element {
+};
+
+template<class X, class Y>
+struct tuple_element<0, pear<X, Y>> {
+    using type = X;
+};
+
+template<class X, class Y>
+struct tuple_element<1, pear<X, Y>> {
+    using type = Y;
+};
+
+template<int N, class X, class Y>
+inline typename tuple_element<N, pear<X, Y>>::type get(const pear<X, Y> & value) {
+    if constexpr (N == 0) {
+        return value.getX();
+    } else {
+        return value.getY();
+    }
+}
+
+} // namespace std
+
+inline int testDestructure(int x) {
+    auto val = std::pear<int, int>( x, x + 2 );
+    auto [y,z] = val;
+    return z;
+}
+
+#endif // TEST_INTEROP_CXX_CLASS_STRUCTURED_BINDINGS_H

--- a/test/Interop/Cxx/class/structured-bindings-get-method.swift
+++ b/test/Interop/Cxx/class/structured-bindings-get-method.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swiftxx-frontend -I %S/Inputs %s -emit-ir -Xcc -std=c++17 | %FileCheck %s
+
+import StructuredBindingsGetMethod
+
+let x = testDestructure(20)
+
+// Make sure the definition of `std::get` is emitted.
+// CHECK: define {{.*}} @{{_ZSt3getILi0EiiENSt13tuple_elementIXT_ESt4pearIT0_T1_EE4typeERKS4_|"\?\?\$get@\$0A@HH@std@@YAHAEBU\?\$pear@HH@0@@Z"}}


### PR DESCRIPTION
Fixes #62448