### PR TITLE
Mark unsupported-decls-in-cxx  as REQUIRES: distributed

### DIFF
--- a/test/Interop/SwiftToCxx/unsupported/unsupported-decls-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-decls-in-cxx.swift
@@ -5,7 +5,8 @@
 // RUN: %target-swift-frontend %t/clean.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -disable-availability-checking -emit-clang-header-path %t/header.h
 // RUN: %FileCheck %s < %t/header.h
 
-// REQUIRES: concurrency 
+// REQUIRES: concurrency
+// REQUIRES: distributed
 
 // CHECK-NOT: Unsupported
 // CHECK: supported


### PR DESCRIPTION
The test tries to import Distributed, but it will fail to pass if the compiler/stdlib has not been built with experimental distributed support.

