### PR TITLE
[AddressLowering] Omit dealloc_stack in dead ends.

### DIFF
--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1740,6 +1740,19 @@ bb2:
   unwind
 }
 
+// CHECK-LABEL: sil [ossa] @testUnreachable1NoDestroy : {{.*}} {
+// CHECK:         [[STORAGE:%[^,]+]] = alloc_stack $T                             
+// CHECK:         apply undef<T>([[STORAGE]])
+// CHECK:         apply undef<T>([[STORAGE]])
+// CHECK:         unreachable                                     
+// CHECK-LABEL: } // end sil function 'testUnreachable1NoDestroy'
+sil [ossa] @testUnreachable1NoDestroy : $@convention(thin) <T> () -> () {
+bb0:
+    %instance = apply undef<T>() : $@convention(thin) <τ> () -> @out τ
+    apply undef<T>(%instance) : $@convention(thin) <τ> (@in_guaranteed τ) -> ()
+    unreachable
+}
+
 sil [ossa] @use_T : $@convention(thin) <T> (@in T) -> ()
 
 // CHECK-LABEL: sil [ossa] @test_checked_cast_br1 : $@convention(method) <T> (@in Any) -> () {


### PR DESCRIPTION
It is valid for owned values not to be destroyed on paths terminating in `unreachable`.  Similarly, it is valid for storage not to be deallocated on paths terminating in `unreachable`.  However, it is _not_ valid for storage to be deallocated before being deinitialized, even in paths terminating in `unreachable`.  Consequently, when AddressLowering, `dealloc_stack`s must not be created in dead-end blocks: because the input OSSA may not destroy an owned value, the output may not deinitialize owned storage; so a `dealloc_stack` in an `unreachable` block could dealloc storage which was not deinitialized.