### PR TITLE
Update guaranteed forwarding phi apis and verification

### DIFF
--- a/include/swift/SIL/SILValue.h
+++ b/include/swift/SIL/SILValue.h
@@ -825,8 +825,6 @@ struct OperandOwnership {
     /// borrow scope.
     /// (tuple_extract, struct_extract, cast, switch)
     GuaranteedForwarding,
-    /// A GuaranteedForwarding value passed as a phi operand.
-    GuaranteedForwardingPhi,
     /// End Borrow. End the borrow scope opened directly by the operand.
     /// The operand must be a begin_borrow, begin_apply, or function argument.
     /// (end_borrow, end_apply)
@@ -919,7 +917,6 @@ inline OwnershipConstraint OperandOwnership::getOwnershipConstraint() {
     return {OwnershipKind::Owned, UseLifetimeConstraint::LifetimeEnding};
   case OperandOwnership::InteriorPointer:
   case OperandOwnership::GuaranteedForwarding:
-  case OperandOwnership::GuaranteedForwardingPhi:
     return {OwnershipKind::Guaranteed,
             UseLifetimeConstraint::NonLifetimeEnding};
   case OperandOwnership::EndBorrow:
@@ -948,7 +945,6 @@ inline bool canAcceptUnownedValue(OperandOwnership operandOwnership) {
   case OperandOwnership::ForwardingConsume:
   case OperandOwnership::InteriorPointer:
   case OperandOwnership::GuaranteedForwarding:
-  case OperandOwnership::GuaranteedForwardingPhi:
   case OperandOwnership::EndBorrow:
   case OperandOwnership::Reborrow:
     return false;

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -428,7 +428,7 @@ OperandOwnership OperandOwnershipClassifier::visitBranchInst(BranchInst *bi) {
 
   if (destBlockArgOwnershipKind == OwnershipKind::Guaranteed) {
     return isGuaranteedForwarding(getValue())
-               ? OperandOwnership::GuaranteedForwardingPhi
+               ? OperandOwnership::GuaranteedForwarding
                : OperandOwnership::Reborrow;
   }
   return destBlockArgOwnershipKind.getForwardingOperandOwnership(

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -27,9 +27,6 @@ bool swift::checkOperandOwnershipInvariants(const Operand *operand,
     // Must be a valid BorrowingOperand.
     return bool(BorrowingOperand(const_cast<Operand *>(operand)));
   }
-  if (opOwnership == OperandOwnership::GuaranteedForwarding) {
-    return canOpcodeForwardGuaranteedValues(const_cast<Operand *>(operand));
-  }
   return true;
 }
 
@@ -430,7 +427,7 @@ OperandOwnership OperandOwnershipClassifier::visitBranchInst(BranchInst *bi) {
       bi->getDestBB()->getArgument(getOperandIndex())->getOwnershipKind();
 
   if (destBlockArgOwnershipKind == OwnershipKind::Guaranteed) {
-    return isGuaranteedForwardingPhi(getValue())
+    return isGuaranteedForwarding(getValue())
                ? OperandOwnership::GuaranteedForwardingPhi
                : OperandOwnership::Reborrow;
   }

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -441,8 +441,6 @@ StringRef OperandOwnership::asString() const {
     return "interior-pointer";
   case OperandOwnership::GuaranteedForwarding:
     return "guaranteed-forwarding";
-  case OperandOwnership::GuaranteedForwardingPhi:
-    return "guaranteed-forwarding-phi";
   case OperandOwnership::EndBorrow:
     return "end-borrow";
   case OperandOwnership::Reborrow:

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -318,10 +318,6 @@ PrunedLiveRange<LivenessWithDefs>::updateForDef(SILValue def) {
       updateForUse(use->getUser(), /*lifetimeEnding*/false);
       break;
     }
-    case OperandOwnership::GuaranteedForwardingPhi: {
-      updateForDef(PhiOperand(use).getValue());
-      break;
-    }
     default:
       updateForUse(use->getUser(), use->isLifetimeEnding());
       break;

--- a/lib/SIL/Verifier/LinearLifetimeChecker.cpp
+++ b/lib/SIL/Verifier/LinearLifetimeChecker.cpp
@@ -317,7 +317,7 @@ void State::checkForSameBlockUseAfterFree(Operand *consumingUse,
     } else if (nonConsumingUse->getOperandOwnership() ==
                    OperandOwnership::Reborrow ||
                nonConsumingUse->getOperandOwnership() ==
-                   OperandOwnership::GuaranteedForwardingPhi) {
+                   OperandOwnership::GuaranteedForwarding) {
       continue;
     }
 

--- a/lib/SIL/Verifier/SILOwnershipVerifier.cpp
+++ b/lib/SIL/Verifier/SILOwnershipVerifier.cpp
@@ -308,8 +308,8 @@ bool SILValueOwnershipChecker::gatherUsers(
       continue;
     }
 
-    if (op->getOperandOwnership() ==
-        OperandOwnership::GuaranteedForwardingPhi) {
+    if (PhiOperand(op) &&
+        op->getOperandOwnership() == OperandOwnership::GuaranteedForwarding) {
       LLVM_DEBUG(llvm::dbgs() << "Regular User: " << *user);
       nonLifetimeEndingUsers.push_back(op);
       continue;

--- a/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
@@ -215,7 +215,6 @@ visitUses(SILValue def, bool updateLivenessAndWeakStores, int callDepth) {
           liveness.updateForUse(user, /*lifetimeEnding*/ false);
         break;
       case OperandOwnership::GuaranteedForwarding:
-      case OperandOwnership::GuaranteedForwardingPhi:
       case OperandOwnership::ForwardingConsume:
         // TermInst includes ReturnInst, which is generally an escape.
         // If this is called as part of getArgumentState, then it is not really

--- a/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnershipLiveRange.cpp
@@ -69,9 +69,12 @@ OwnershipLiveRange::OwnershipLiveRange(SILValue value)
     // DISCUSSION: For now we do not support forwarding instructions with
     // multiple non-trivial arguments since we would need to optimize all of
     // the non-trivial arguments at the same time.
+    //
+    // NOTE: Today we do not support TermInsts for simplicity... we /could/
+    // support it though if we need to.
     auto *ti = dyn_cast<TermInst>(user);
-    if ((ti && !ti->forwardedOperand()) ||
-        !canOpcodeForwardGuaranteedValues(op) ||
+    if ((ti && !ti->mayHaveTerminatorResult()) ||
+        !canOpcodeForwardInnerGuaranteedValues(op) ||
         1 !=
             count_if(user->getNonTypeDependentOperandValues(), [&](SILValue v) {
               return v->getOwnershipKind() == OwnershipKind::Owned;

--- a/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
@@ -275,7 +275,6 @@ bool CanonicalizeBorrowScope::visitBorrowScopeUses(SILValue innerValue,
         break;
 
       case OperandOwnership::GuaranteedForwarding:
-      case OperandOwnership::GuaranteedForwardingPhi:
       case OperandOwnership::ForwardingConsume:
         if (CanonicalizeBorrowScope::isRewritableOSSAForward(user)) {
           if (!visitor.visitForwardingUse(use)) {

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -192,7 +192,6 @@ bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {
         // reborrow of such.
         liveness.updateForUse(user, /*lifetimeEnding*/ false);
         break;
-      case OperandOwnership::GuaranteedForwardingPhi:
       case OperandOwnership::Reborrow:
         BranchInst *branch;
         if (!(branch = dyn_cast<BranchInst>(user))) {

--- a/test/SIL/OwnershipVerifier/arguments.sil
+++ b/test/SIL/OwnershipVerifier/arguments.sil
@@ -54,40 +54,13 @@ bb1(%2 : @guaranteed $Builtin.NativeObject):
 
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'leak_along_path'
 // CHECK: Error! Found a leak due to a consuming post-dominance failure!
-// CHECK: Value: %2 = argument of bb1 : $Builtin.NativeObject
+// CHECK: Value: %3 = argument of bb1 : $Builtin.NativeObject
 // CHECK: Post Dominating Failure Blocks:
 // CHECK: bb3
 // CHECK: Error#: 0. End Error in Function: 'leak_along_path'
 //
 // CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'leak_along_path'
 sil [ossa] @leak_along_path : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
-bb0(%0 : @guaranteed $Builtin.NativeObject):
-  br bb1(%0 : $Builtin.NativeObject)
-
-bb1(%1 : @guaranteed $Builtin.NativeObject):
-  cond_br undef, bb2, bb3
-
-bb2:
-  end_borrow %1 : $Builtin.NativeObject
-  br bb4
-
-bb3:
-  br bb4
-
-bb4:
-  %9999 = tuple()
-  return %9999 : $()
-}
-
-// CHECK-LABEL: Error#: 0. Begin Error in Function: 'leak_along_path_2'
-// CHECK: Error! Found a leak due to a consuming post-dominance failure!
-// CHECK: Value: %3 = argument of bb1 : $Builtin.NativeObject
-// CHECK: Post Dominating Failure Blocks:
-// CHECK: bb3
-// CHECK: Error#: 0. End Error in Function: 'leak_along_path_2'
-//
-// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'leak_along_path_2'
-sil [ossa] @leak_along_path_2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
   br bb1(%1 : $Builtin.NativeObject)
@@ -109,53 +82,16 @@ bb4:
 
 // Make sure that we only flag the subargument leak and not the parent
 // argument. Also check for over consuming due to phi nodes.
-//
+
 // CHECK-LABEL: Error#: 0. Begin Error in Function: 'leak_along_subarg_path'
 // CHECK: Error! Found a leak due to a consuming post-dominance failure!
-// CHECK: Value: %6 = argument of bb4 : $Builtin.NativeObject
+// CHECK: Value: %7 = argument of bb3 : $Builtin.NativeObject
 // CHECK: Post Dominating Failure Blocks:
 // CHECK: bb6
 // CHECK: Error#: 0. End Error in Function: 'leak_along_subarg_path'
 //
 // CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'leak_along_subarg_path'
 sil [ossa] @leak_along_subarg_path : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
-bb0(%0 : @guaranteed $Builtin.NativeObject):
-  br bb1(%0 : $Builtin.NativeObject)
-
-bb1(%1 : @guaranteed $Builtin.NativeObject):
-  cond_br undef, bb2, bb3
-
-bb2:
-  br bb7
-
-bb3:
-  br bb4(%1 : $Builtin.NativeObject)
-
-bb4(%2 : @guaranteed $Builtin.NativeObject):
-  cond_br undef, bb5, bb6
-
-bb5:
-  end_borrow %2 : $Builtin.NativeObject
-  br bb7
-
-bb6:
-  br bb7
-
-bb7:
-  end_borrow %1 : $Builtin.NativeObject
-  %9999 = tuple()
-  return %9999 : $()
-}
-
-// CHECK-LABEL: Error#: 0. Begin Error in Function: 'leak_along_subarg_path_2'
-// CHECK: Error! Found a leak due to a consuming post-dominance failure!
-// CHECK: Value: %7 = argument of bb3 : $Builtin.NativeObject
-// CHECK: Post Dominating Failure Blocks:
-// CHECK: bb6
-// CHECK: Error#: 0. End Error in Function: 'leak_along_subarg_path_2'
-//
-// CHECK-NOT: Error#: {{[0-9][0-9]*}}. End Error in Function: 'leak_along_subarg_path_2'
-sil [ossa] @leak_along_subarg_path_2 : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
 bb0(%0 : @guaranteed $Builtin.NativeObject):
   %1 = begin_borrow %0 : $Builtin.NativeObject
   br bb1(%1 : $Builtin.NativeObject)

--- a/test/SIL/OwnershipVerifier/guaranteed_phis_errors.sil
+++ b/test/SIL/OwnershipVerifier/guaranteed_phis_errors.sil
@@ -180,6 +180,32 @@ bb2(%phi : @guaranteed $SuperKlass):
   return %9999 : $()
 }
 
+// CHECK: Error#: 0. Begin Error in Function: 'test7'
+// CHECK: Malformed @guaranteed phi!
+// CHECK: Phi: %7 = argument of bb3 : $SuperKlass
+// CHECK: Guaranteed forwarding operands not found on all paths!
+// CHECK: Error#: 0. End Error in Function: 'test7'
+sil [ossa] @test7 : $@convention(thin) (@guaranteed Klass, @owned SuperKlass) -> () {
+bb0(%0 : @guaranteed $Klass, %1 : @owned $SuperKlass):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %3 = unchecked_ref_cast %0 : $Klass to $SuperKlass
+  br bb3(%3 : $SuperKlass)
+
+bb2:
+  %5 = begin_borrow %1 : $SuperKlass
+  br bb3(%5 : $SuperKlass)
+
+bb3(%7 : @guaranteed $SuperKlass):
+  %8 = function_ref @use_superklass : $@convention(thin) (@guaranteed SuperKlass) -> ()
+  %9 = apply %8(%7) : $@convention(thin) (@guaranteed SuperKlass) -> ()
+  end_borrow %7 : $SuperKlass
+  destroy_value %1 : $SuperKlass
+  %12 = tuple ()
+  return %12 : $()
+}
+
 enum FakeOptional<T> {
   case none
   case some(T)

--- a/test/SIL/OwnershipVerifier/use_verifier.sil
+++ b/test/SIL/OwnershipVerifier/use_verifier.sil
@@ -1206,7 +1206,8 @@ bb1:
 
 bb2:
   %5 = struct_extract %1 : $NonTrivialStructWithTrivialField, #NonTrivialStructWithTrivialField.owner
-  br bb3(%5 : $Builtin.NativeObject)
+  %6 = begin_borrow %5 : $Builtin.NativeObject
+  br bb3(%6 : $Builtin.NativeObject)
 
 bb3(%7 : @guaranteed $Builtin.NativeObject):
   end_borrow %7 : $Builtin.NativeObject
@@ -1366,7 +1367,6 @@ bb2:
   br bb3(%f2thick : $@callee_owned () -> ())
 
 bb3(%fUnknown : @guaranteed $@callee_owned () -> ()):
-  end_borrow %fUnknown : $@callee_owned () -> ()
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SILOptimizer/copy_propagation_canonicalize_with_reborrows.sil
+++ b/test/SILOptimizer/copy_propagation_canonicalize_with_reborrows.sil
@@ -149,7 +149,8 @@ sil [ossa] @nohoist_destroy_over_reborrow_loop : $@convention(thin) () -> () {
 entry:
   %none1 = enum $FakeOptional<X>, #FakeOptional.none!enumelt
   %none2 = enum $FakeOptional<X>, #FakeOptional.none!enumelt
-  br head(%none2 : $FakeOptional<X>, %none1 : $FakeOptional<X>)
+  %none_borrow_2 = begin_borrow %none2 : $FakeOptional<X>
+  br head(%none_borrow_2 : $FakeOptional<X>, %none1 : $FakeOptional<X>)
 
 head(%reborrow : @guaranteed $FakeOptional<X>, %value : @owned $FakeOptional<X>):
   cond_br undef, body, exit

--- a/test/SILOptimizer/redundant_phi_elimination_ossa.sil
+++ b/test/SILOptimizer/redundant_phi_elimination_ossa.sil
@@ -183,8 +183,6 @@ bb2:
   br bb3(%0 : $FakeOptional<Klass>, %0 : $FakeOptional<Klass>)
 
 bb3(%1 : @guaranteed $FakeOptional<Klass>, %2 : @guaranteed $FakeOptional<Klass>):
-  end_borrow %1 : $FakeOptional<Klass>
-  end_borrow %2 : $FakeOptional<Klass>
   %res = tuple ()
   return %res : $()
 }
@@ -195,17 +193,18 @@ bb3(%1 : @guaranteed $FakeOptional<Klass>, %2 : @guaranteed $FakeOptional<Klass>
 sil [ossa] @test_redundantguaranteedphiarg2 : $@convention(thin) () -> () {
 bb0:
   %0 = enum $FakeOptional<Klass>, #FakeOptional.none!enumelt 
+  %b = begin_borrow %0 : $FakeOptional<Klass>
   cond_br undef, bb1, bb2
 
 bb1:
-  br bb3(%0 : $FakeOptional<Klass>, %0 : $FakeOptional<Klass>)
+  br bb3(%0 : $FakeOptional<Klass>, %b : $FakeOptional<Klass>)
 
 bb2:
-  br bb3(%0 : $FakeOptional<Klass>, %0 : $FakeOptional<Klass>)
+  br bb3(%0 : $FakeOptional<Klass>, %b : $FakeOptional<Klass>)
 
 bb3(%1 : @owned $FakeOptional<Klass>, %2 : @guaranteed $FakeOptional<Klass>):
-  destroy_value %1 : $FakeOptional<Klass>
   end_borrow %2 : $FakeOptional<Klass>
+  destroy_value %1 : $FakeOptional<Klass>
   %res = tuple ()
   return %res : $()
 }
@@ -216,13 +215,15 @@ bb3(%1 : @owned $FakeOptional<Klass>, %2 : @guaranteed $FakeOptional<Klass>):
 sil [ossa] @test_redundantguaranteedphiarg3 : $@convention(thin) () -> () {
 bb0:
   %0 = enum $FakeOptional<Klass>, #FakeOptional.none!enumelt 
+  %b1 = begin_borrow %0 : $FakeOptional<Klass>
+  %b2 = begin_borrow %0 : $FakeOptional<Klass>
   cond_br undef, bb1, bb2
 
 bb1:
-  br bb3(%0 : $FakeOptional<Klass>, %0 : $FakeOptional<Klass>)
+  br bb3(%b1 : $FakeOptional<Klass>, %b2 : $FakeOptional<Klass>)
 
 bb2:
-  br bb3(%0 : $FakeOptional<Klass>, %0 : $FakeOptional<Klass>)
+  br bb3(%b1 : $FakeOptional<Klass>, %b2 : $FakeOptional<Klass>)
 
 bb3(%1 : @guaranteed $FakeOptional<Klass>, %2 : @guaranteed $FakeOptional<Klass>):
   cond_br undef, bb4, bb5

--- a/test/SILOptimizer/semantic-arc-opts-lifetime-joining.sil
+++ b/test/SILOptimizer/semantic-arc-opts-lifetime-joining.sil
@@ -173,10 +173,10 @@ bb2:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @donot_join_liveranges_in_same_block_1 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
-// CHECK: copy_value
-// CHECK: } // end sil function 'donot_join_liveranges_in_same_block_1'
-sil [ossa] @donot_join_liveranges_in_same_block_1 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK-LABEL: sil [ossa] @join_liveranges_in_same_block_5 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK-NOT: copy_value
+// CHECK-LABEL: } // end sil function 'join_liveranges_in_same_block_5'
+sil [ossa] @join_liveranges_in_same_block_5 : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 bb0(%0 : @owned $Builtin.NativeObject):
   %1 = copy_value %0 : $Builtin.NativeObject
   br bb1
@@ -792,10 +792,10 @@ bb3:
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [ossa] @join_live_range_with_borrowscopes_multipledestroys_fail_2 : $@convention(thin) () -> () {
-// CHECK: copy_value
-// CHECK: } // end sil function 'join_live_range_with_borrowscopes_multipledestroys_fail_2'
-sil [ossa] @join_live_range_with_borrowscopes_multipledestroys_fail_2 : $@convention(thin) () -> () {
+// CHECK-LABEL: sil [ossa] @join_live_range_with_borrowscopes_multipledestroys_succeed_8 : $@convention(thin) () -> () {
+// CHECK-NOT: copy_value
+// CHECK: } // end sil function 'join_live_range_with_borrowscopes_multipledestroys_succeed_8'
+sil [ossa] @join_live_range_with_borrowscopes_multipledestroys_succeed_8 : $@convention(thin) () -> () {
 bb0:
   %obj = alloc_ref $Klass
   cond_br undef, bb1, bb2

--- a/test/SILOptimizer/simplify_cfg_checkcast.sil
+++ b/test/SILOptimizer/simplify_cfg_checkcast.sil
@@ -383,7 +383,6 @@ bb10(%failBB7 : @guaranteed $Base):
   br bb11
 
 bb11:
-  end_borrow %joined : $Base
   %20 = tuple ()
   return %20 : $()
 


### PR DESCRIPTION
- Delete `isGuaranteedForwardingPhi` and update `isGuaranteedForwarding`
- Delete `OperandOwnership::GuaranteedForwardingPhi`, and update uses to `OperandOwnership::GuaranteedForwarding`
- Add verification to guaranteed forwarding phis to ensure it has guaranteed forwarding incoming operands on zero or all paths.