### PR TITLE
[Index] Use `ide::getReferencedDecl` instead of custom `extractDecl`

### DIFF
--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/IDE/SourceEntityWalker.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Decl.h"
@@ -26,6 +25,8 @@
 #include "swift/Basic/SourceManager.h"
 #include "swift/Parse/Lexer.h"
 #include "clang/Basic/Module.h"
+#include "swift/IDE/SourceEntityWalker.h"
+#include "swift/IDE/Utils.h"
 
 using namespace swift;
 
@@ -93,19 +94,6 @@ private:
   bool passCallArgNames(Expr *Fn, ArgumentList *ArgList);
 
   bool shouldIgnore(Decl *D);
-
-  ValueDecl *extractDecl(Expr *Fn) const {
-    Fn = Fn->getSemanticsProvidingExpr();
-    if (auto *DRE = dyn_cast<DeclRefExpr>(Fn))
-      return DRE->getDecl();
-    if (auto ApplyE = dyn_cast<ApplyExpr>(Fn))
-      return extractDecl(ApplyE->getFn());
-    if (auto *ACE = dyn_cast<AutoClosureExpr>(Fn)) {
-      if (auto *Unwrapped = ACE->getUnwrappedCurryThunkExpr())
-        return extractDecl(Unwrapped);
-    }
-    return nullptr;
-  }
 };
 
 } // end anonymous namespace
@@ -803,7 +791,11 @@ passReference(ValueDecl *D, Type Ty, SourceLoc BaseNameLoc, SourceRange Range,
     if (!CtorRefs.empty() && BaseNameLoc.isValid()) {
       Expr *Fn = CtorRefs.back()->getFn();
       if (Fn->getLoc() == BaseNameLoc) {
-        D = extractDecl(Fn);
+        D = ide::getReferencedDecl(Fn).second.getDecl();
+        if (D == nullptr) {
+          assert(false && "Unhandled constructor reference");
+          return true;
+        }
         CtorTyRef = TD;
       }
     }
@@ -816,12 +808,6 @@ passReference(ValueDecl *D, Type Ty, SourceLoc BaseNameLoc, SourceRange Range,
         ExtDecl = ExtDecls.back();
       }
     }
-  }
-
-  if (D == nullptr) {
-    // FIXME: When does this happen?
-    assert(false && "unhandled reference");
-    return true;
   }
 
   CharSourceRange CharRange =
@@ -842,7 +828,7 @@ bool SemaAnnotator::passReference(ModuleEntity Mod,
 }
 
 bool SemaAnnotator::passCallArgNames(Expr *Fn, ArgumentList *ArgList) {
-  ValueDecl *D = extractDecl(Fn);
+  ValueDecl *D = ide::getReferencedDecl(Fn).second.getDecl();
   if (!D)
     return true; // continue.
 

--- a/test/Index/index_implicit_conversion.swift
+++ b/test/Index/index_implicit_conversion.swift
@@ -1,0 +1,12 @@
+// REQUIRES: objc_interop, concurrency
+
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-indexed-symbols -source-filename %s | %FileCheck %s
+
+import AppKit
+
+@MainActor
+class AppDelegate {
+  let window = NSWindow()
+  // CHECK: [[@LINE-1]]:16 | class/Swift | NSWindow | c:objc(cs)NSWindow | Ref,RelCont
+  // CHECK: [[@LINE-2]]:16 | constructor/Swift | init() | c:objc(cs)NSObject(im)init | Ref,Call,RelCont
+}


### PR DESCRIPTION
`passReference` was failing to find the underlying declaration for a constructor reference. In this case it was for a `FunctionConversionExpr`, but there's likely others. Use `ide::getReferencedDecl` instead.

Resolves rdar://102563191.