### PR TITLE
Add some utility functions for obtaining runtime-relative paths.

### DIFF
--- a/include/swift/Runtime/EnvironmentVariables.h
+++ b/include/swift/Runtime/EnvironmentVariables.h
@@ -24,6 +24,10 @@ void initialize(void *);
 
 extern swift::once_t initializeToken;
 
+// Define a typedef "string" in swift::runtime::environment to make string
+// environment variables work
+using string = const char *;
+
 // Declare backing variables.
 #define VARIABLE(name, type, defaultValue, help) extern type name ## _variable;
 #include "../../../stdlib/public/runtime/EnvironmentVariables.def"

--- a/include/swift/Runtime/Paths.h
+++ b/include/swift/Runtime/Paths.h
@@ -1,0 +1,66 @@
+//===--- Paths.h - Swift Runtime path utility functions ---------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Functions that obtain paths that might be useful within the runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_UTILS_H
+#define SWIFT_RUNTIME_UTILS_H
+
+#include "swift/Runtime/Config.h"
+
+/// Return the path of the libswiftCore library.
+///
+/// This can be used to locate files that are installed alongside the
+/// Swift runtime library.
+///
+/// \return A string containing the full path to libswiftCore.  The string
+///         is owned by the runtime and should not be freed.
+SWIFT_RUNTIME_EXPORT
+const char *
+swift_getRuntimePath();
+
+/// Return the path of the Swift root.
+///
+/// If the path to libswiftCore is `/usr/local/swift/lib/libswiftCore.dylib`,
+/// this function would return `/usr/local/swift`.
+///
+/// The path returned here can be overridden by setting the environment
+/// variable SWIFT_ROOT.
+///
+/// \return A string containing the full path to the Swift root directory,
+///         based either on the location of the Swift runtime, or on the
+///         `SWIFT_ROOT` environment variable if set.
+SWIFT_RUNTIME_EXPORT
+const char *
+swift_getRootPath();
+
+/// Return the path of the specified auxiliary executable.
+///
+/// This function will return `/path/to/swift/root/libexec/<name>`, and on
+/// Windows, it will automatically add `.exe` to the end.  (This means that
+/// you don't need to special case the name for Windows.)
+///
+/// It does not test that the executable exists or that it is indeed
+/// executable by the current user.  If you are using this function to locate
+/// a utility program for use by the runtime, you should provide a way to
+/// override its location using an environment variable.
+///
+/// \param name The name of the executable to locate.
+///
+/// \return A string containing the full path to the executable.
+SWIFT_RUNTIME_EXPORT
+const char *
+swift_getAuxiliaryExecutablePath(const char *name);
+
+#endif // SWIFT_RUNTIME_PATHS_H

--- a/include/swift/Runtime/Paths.h
+++ b/include/swift/Runtime/Paths.h
@@ -21,11 +21,11 @@
 
 /// Return the path of the libswiftCore library.
 ///
-/// This can be used to locate files that are installed alongside the
-/// Swift runtime library.
+/// This can be used to locate files that are installed alongside the Swift
+/// runtime library.
 ///
-/// \return A string containing the full path to libswiftCore.  The string
-///         is owned by the runtime and should not be freed.
+/// \return A string containing the full path to libswiftCore.  The string is
+///         owned by the runtime and should not be freed.
 SWIFT_RUNTIME_EXPORT
 const char *
 swift_getRuntimePath();
@@ -35,28 +35,39 @@ swift_getRuntimePath();
 /// If the path to libswiftCore is `/usr/local/swift/lib/libswiftCore.dylib`,
 /// this function would return `/usr/local/swift`.
 ///
-/// The path returned here can be overridden by setting the environment
-/// variable SWIFT_ROOT.
+/// The path returned here can be overridden by setting the environment variable
+/// SWIFT_ROOT.
 ///
-/// \return A string containing the full path to the Swift root directory,
-///         based either on the location of the Swift runtime, or on the
-///         `SWIFT_ROOT` environment variable if set.
+/// \return A string containing the full path to the Swift root directory, based
+///         either on the location of the Swift runtime, or on the `SWIFT_ROOT`
+///         environment variable if set.
 SWIFT_RUNTIME_EXPORT
 const char *
 swift_getRootPath();
 
 /// Return the path of the specified auxiliary executable.
 ///
-/// This function will return `/path/to/swift/root/libexec/<name>`, and on
-/// Windows, it will automatically add `.exe` to the end.  (This means that
-/// you don't need to special case the name for Windows.)
+/// This function will search for the auxiliary executable in the following
+/// paths:
 ///
-/// It does not test that the executable exists or that it is indeed
-/// executable by the current user.  If you are using this function to locate
-/// a utility program for use by the runtime, you should provide a way to
-/// override its location using an environment variable.
+///   <swift-root>/libexec/swift/<platform>/<name>
+///   <swift-root>/libexec/swift/<name>
+///   <swift-root>/bin/<name>
+///   <swift-root>/<name>
 ///
-/// \param name The name of the executable to locate.
+/// It will return the first of those that exists, but it does not test that
+/// the file is indeed executable.
+///
+/// On Windows, it will automatically add `.exe` to the name, which means you
+/// do not need to special case the name for Windows.
+///
+/// If you are using this function to locate a utility program for use by the
+/// runtime, you should provide a way to override its location using an
+/// environment variable.
+///
+/// If the executable cannot be found, it will return nullptr.
+///
+/// \param name      The name of the executable to locate.
 ///
 /// \return A string containing the full path to the executable.
 SWIFT_RUNTIME_EXPORT

--- a/include/swift/Threading/Impl/Win32/Win32Defs.h
+++ b/include/swift/Threading/Impl/Win32/Win32Defs.h
@@ -47,8 +47,7 @@ typedef struct _RTL_CONDITION_VARIABLE *PRTL_CONDITION_VARIABLE;
 typedef PRTL_CONDITION_VARIABLE PCONDITION_VARIABLE;
 
 // These have to be #defines, to avoid problems with <windows.h>
-#define RTL_SRWLOCK_INIT                                                       \
-  { 0 }
+#define RTL_SRWLOCK_INIT {0}
 #define SRWLOCK_INIT RTL_SRWLOCK_INIT
 #define FLS_OUT_OF_INDEXES ((DWORD)0xFFFFFFFF)
 

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -156,7 +156,10 @@ function(_add_target_variant_c_compile_flags)
 
   set(result ${${CFLAGS_RESULT_VAR_NAME}})
 
-  list(APPEND result "-DSWIFT_RUNTIME")
+  list(APPEND result
+    "-DSWIFT_RUNTIME"
+    "-DSWIFT_LIB_SUBDIR=\"${SWIFT_SDK_${CFLAGS_SDK}_LIB_SUBDIR}\""
+    )
 
   if ("${CFLAGS_ARCH}" STREQUAL "arm64" OR
       "${CFLAGS_ARCH}" STREQUAL "arm64_32")

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -159,6 +159,7 @@ function(_add_target_variant_c_compile_flags)
   list(APPEND result
     "-DSWIFT_RUNTIME"
     "-DSWIFT_LIB_SUBDIR=\"${SWIFT_SDK_${CFLAGS_SDK}_LIB_SUBDIR}\""
+    "-DSWIFT_ARCH=\"${CFLAGS_ARCH}\""
     )
 
   if ("${CFLAGS_ARCH}" STREQUAL "arm64" OR

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -61,6 +61,7 @@ set(swift_runtime_sources
     MetadataLookup.cpp
     Numeric.cpp
     Once.cpp
+    Paths.cpp
     Portability.cpp
     ProtocolConformance.cpp
     RefCount.cpp

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Runtime/Debug.h"
+#include "swift/Runtime/Paths.h"
 #include "swift/Runtime/EnvironmentVariables.h"
 
 #include <string.h>
@@ -22,6 +23,12 @@
 using namespace swift;
 
 namespace {
+
+// This is required to make the macro machinery work correctly; we can't
+// declare a VARIABLE(..., const char *, ...) because then the token-pasted
+// names won't work properly.  It *does* mean that if you want to use std::string
+// somewhere in this file, you'll have to fully qualify the name.
+typedef const char *string;
 
 // Require all environment variable names to start with SWIFT_
 static constexpr bool hasSwiftPrefix(const char *str) {
@@ -121,6 +128,14 @@ static uint32_t parse_uint32_t(const char *name,
   }
 
   return n;
+}
+
+static string parse_string(const char *name,
+                           const char *value,
+                           string defaultValue) {
+  if (!value || value[0] == 0)
+    return strdup(defaultValue);
+  return strdup(value);
 }
 
 // Print a list of all the environment variables. Lazy initialization makes

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -81,4 +81,9 @@ VARIABLE(SWIFT_BINARY_COMPATIBILITY_VERSION, uint32_t, 0,
 VARIABLE(SWIFT_DEBUG_FAILED_TYPE_LOOKUP, bool, false,
          "Enable warnings when we fail to look up a type by name.")
 
+VARIABLE(SWIFT_ROOT, string, "",
+         "Overrides the root directory of the Swift installation. "
+         "This is used to locate auxiliary files relative to the runtime "
+         "itself.")
+
 #undef VARIABLE

--- a/stdlib/public/runtime/Paths.cpp
+++ b/stdlib/public/runtime/Paths.cpp
@@ -99,11 +99,13 @@ _swift_getDefaultRootPath()
   const char *ptr = runtimePath + runtimePathLen;
   while (ptr > runtimePath && !_swift_isPathSep(*--ptr));
 
-  // Remove the "lib" directory if it's present
-  if (ptr - runtimePath >= 4
-      && _swift_isPathSep(ptr[-4])
-      && std::strncmp(ptr - 3, "lib", 3) == 0) {
-    ptr -= 4;
+  // Remove lib/swift/ if present
+  if (ptr - runtimePath >= 10
+      && _swift_isPathSep(ptr[-10])
+      && std::strncmp(ptr - 9, "lib", 3) == 0
+      && _swift_isPathSep(ptr[-6])
+      && std::strncmp(ptr - 5, "swift", 5) == 0) {
+    ptr -= 10;
   }
 
   // If the result is empty, return "./" or ".\\"
@@ -152,9 +154,9 @@ swift_getAuxiliaryExecutablePath(const char *name)
 {
   const char *rootPath = swift_getRootPath();
 
-  // Form <rootPath>/libexec/
+  // Form <rootPath>/libexec/swift/
   size_t rootPathLen = std::strlen(rootPath);
-  const char *libexecStr = PATHSEP_STR "libexec" PATHSEP_STR;
+  const char *libexecStr = PATHSEP_STR "libexec" PATHSEP_STR "swift" PATHSEP_STR;
   size_t libexecLen = std::strlen(libexecStr);
   char *libexecPath = (char *)malloc(rootPathLen + libexecLen + 1);
   std::memcpy(libexecPath, rootPath, rootPathLen);

--- a/stdlib/public/runtime/Paths.cpp
+++ b/stdlib/public/runtime/Paths.cpp
@@ -1,0 +1,282 @@
+//===--- Paths.cpp - Swift Runtime path utility functions -------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Functions that obtain paths that might be useful within the runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Config.h"
+#include "swift/Runtime/EnvironmentVariables.h"
+#include "swift/Runtime/Debug.h"
+#include "swift/Runtime/Paths.h"
+#include "swift/Runtime/Win32.h"
+#include "swift/Threading/Once.h"
+
+#include <filesystem>
+
+#if !defined(_WIN32) || defined(__CYGWIN__)
+#include <sys/stat.h>
+
+#include <dlfcn.h>
+#else
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#include <psapi.h>
+#endif
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+swift::once_t runtimePathToken;
+const char *runtimePath;
+
+swift::once_t rootPathToken;
+const char *rootPath;
+
+void _swift_initRuntimePath(void *);
+void _swift_initRootPath(void *);
+const char *_swift_getDefaultRootPath();
+const char *_swift_getAuxExePathIn(const char *path, const char *name);
+
+bool _swift_isPathSep(char ch) {
+#ifdef _WIN32
+  return ch == '/' || ch == '\\';
+#else
+  return ch == '/';
+#endif
+}
+
+bool _swift_exists(const char *path);
+
+#if !defined(_WIN32) || defined(__CYGWIN__)
+#define PATHSEP_STR "/"
+#define PATHSEP_CHR '/'
+#else
+#define PATHSEP_STR "\\"
+#define PATHSEP_CHR '\\'
+#endif
+
+}
+
+SWIFT_RUNTIME_EXPORT
+const char *
+swift_getRuntimePath()
+{
+  swift::once(runtimePathToken, _swift_initRuntimePath, nullptr);
+  return runtimePath;
+}
+
+SWIFT_RUNTIME_EXPORT
+const char *
+swift_getRootPath()
+{
+  swift::once(rootPathToken, _swift_initRootPath, nullptr);
+  return rootPath;
+}
+
+namespace {
+
+const char *
+_swift_getDefaultRootPath()
+{
+  const char *runtimePath = swift_getRuntimePath();
+  size_t runtimePathLen = std::strlen(runtimePath);
+
+  // Scan backwards until we find a path separator
+  const char *ptr = runtimePath + runtimePathLen;
+  while (ptr > runtimePath && !_swift_isPathSep(*--ptr));
+
+  // Remove the "lib" directory if it's present
+  if (ptr - runtimePath >= 4
+      && _swift_isPathSep(ptr[-4])
+      && std::strncmp(ptr - 3, "lib", 3) == 0) {
+    ptr -= 4;
+  }
+
+  // If the result is empty, return "./" or ".\\"
+  if (ptr == runtimePath) {
+    return "." PATHSEP_STR;
+  }
+
+  // Duplicate the string up to and including ptr
+  size_t len = ptr - runtimePath + 1;
+  char *thePath = (char *)malloc(len + 1);
+  std::memcpy(thePath, runtimePath, len);
+  thePath[len] = 0;
+
+  return thePath;
+}
+
+void
+_swift_initRootPath(void *)
+{
+  // SWIFT_ROOT overrides the path returned by this function
+  const char *swiftRoot = swift::runtime::environment::SWIFT_ROOT();
+  if (swiftRoot && *swiftRoot) {
+    size_t len = std::strlen(swiftRoot);
+
+    // Ensure that there's a trailing slash
+    if (_swift_isPathSep(swiftRoot[len - 1])) {
+      rootPath = swiftRoot;
+    } else {
+      char *thePath = (char *)malloc(len + 2);
+      std::memcpy(thePath, swiftRoot, len);
+      thePath[len] = PATHSEP_CHR;
+      thePath[len + 1] = 0;
+
+      rootPath = thePath;
+    }
+  } else {
+    rootPath = _swift_getDefaultRootPath();
+  }
+}
+
+}
+
+SWIFT_RUNTIME_EXPORT
+const char *
+swift_getAuxiliaryExecutablePath(const char *name)
+{
+  const char *rootPath = swift_getRootPath();
+
+  // Form <rootPath>/libexec/
+  size_t rootPathLen = std::strlen(rootPath);
+  const char *libexecStr = PATHSEP_STR "libexec" PATHSEP_STR;
+  size_t libexecLen = std::strlen(libexecStr);
+  char *libexecPath = (char *)malloc(rootPathLen + libexecLen + 1);
+  std::memcpy(libexecPath, rootPath, rootPathLen);
+  std::memcpy(libexecPath + rootPathLen, libexecStr, libexecLen + 1);
+
+  // If libexec exists, look there
+  if (_swift_exists(libexecPath)) {
+    const char *result = _swift_getAuxExePathIn(libexecPath, name);
+
+    free(libexecPath);
+
+    return result;
+  }
+
+  free(libexecPath);
+
+  // Otherwise, look in the root itself
+  return _swift_getAuxExePathIn(rootPath, name);
+}
+
+namespace {
+
+const char *
+_swift_getAuxExePathIn(const char *path, const char *name)
+{
+  size_t pathLen = std::strlen(path);
+  size_t nameLen = std::strlen(name);
+  size_t extLen = 0;
+
+#ifdef _WIN32
+  if (nameLen > 4 && strcmp(name + nameLen - 4, ".exe") != 0)
+    extLen = 4;
+#endif
+
+  // <path>/<name>[.exe]<NUL>
+  size_t totalLen = pathLen + nameLen + extLen + 1;
+  char *fullPath = (char *)malloc(totalLen);
+  char *ptr = fullPath;
+  std::memcpy(ptr, path, pathLen);
+  ptr += pathLen;
+  std::memcpy(ptr, name, nameLen);
+  ptr += nameLen;
+
+#ifdef _WIN32
+  if (extLen) {
+    std::memcpy(ptr, ".exe", 4);
+    ptr += 4;
+  }
+#endif
+
+  *ptr = 0;
+
+  return fullPath;
+}
+
+#if !defined(_WIN32) || defined(__CYGWIN__)
+void
+_swift_initRuntimePath(void *) {
+  const char *path;
+
+#if APPLE_OS_SYSTEM
+  path = dyld_image_path_containing_address(_swift_initRuntimePath);
+#else
+  Dl_info dli;
+  int ret = ::dladdr((void *)_swift_initRuntimePath, &dli);
+
+  if (!ret) {
+    swift::fatalError(/* flags = */ 0,
+                      "Unable to obtain Swift runtime path\n");
+  }
+
+  path = dli.dli_fname;
+#endif
+
+  runtimePath = ::strdup(path);
+}
+#else
+
+void
+_swift_initRuntimePath(void *) {
+  const DWORD dwBufSize = 4096;
+  LPWSTR lpFilename = (LPWSTR)std::malloc(dwBufSize * sizeof(WCHAR));
+
+  DWORD dwRet = GetMappedFileNameW(GetCurrentProcess(),
+                                   _swift_initRuntimePath,
+                                   lpFilename,
+                                   dwBufSize);
+  if (!dwRet) {
+    swift::fatalError(/* flags = */ 0,
+                      "Unable to obtain Swift runtime path\n");
+  }
+
+  runtimePath = swift::win32::copyUTF8FromWide(lpFilename);
+  if (!runtimePath) {
+    swift::fatalError(/* flags = */ 0,
+                      "Unable to convert Swift runtime path to UTF-8: %lx, %d\n",
+                      ::GetLastError(), errno);
+  }
+
+  free(lpFilename);
+}
+#endif
+
+/// Return true if a file exists at path.
+///
+/// On Windows, path will be in UTF-8 so can't be passed to _stat() or any
+/// of the ANSI functions.
+///
+/// @param path The path to check
+///
+/// @result true iff there is a file at @a path
+bool _swift_exists(const char *path)
+{
+#if !defined(_WIN32)
+  struct stat st;
+  return stat(path, &st) == 0;
+#else
+  wchar_t *wszPath = swift::win32::copyWideFromUTF8(path);
+  bool result = GetFileAttributesW(wszPath) != INVALID_FILE_ATTRIBUTES;
+  free(wszPath);
+  return result;
+#endif // defined(_WIN32)
+}
+
+}

--- a/test/Runtime/Paths.cpp
+++ b/test/Runtime/Paths.cpp
@@ -63,7 +63,7 @@ int main(void) {
 
   // Runtime path must point to libswiftCore and must be a file.
 
-  // CHECK: runtime path: {{.*[\\/]}}libswiftCore.{{so|dylib|dll}}
+  // CHECK: runtime path: {{.*[\\/](lib)?}}swiftCore.{{so|dylib|dll}}
   // CHECK-NEXT: runtime is a file: yes
   printf("runtime path: %s\n", runtimePath ? runtimePath: "<NULL>");
   printf("runtime is a file: %s\n", isfile(runtimePath) ? "yes" : "no");

--- a/test/Runtime/Paths.cpp
+++ b/test/Runtime/Paths.cpp
@@ -1,0 +1,77 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang %s -std=c++11 -I %swift_src_root/include -I %swift_src_root/stdlib/public/SwiftShims -I %clang-include-dir -isysroot %sdk %platform-dylib-dir/%target-library-name(swiftCore) -o %t/paths-test
+// RUN: %target-codesign %t/paths-test
+// RUN: %target-run %t/paths-test | %FileCheck %s
+
+// REQUIRES: executable_test
+// UNSUPPORTED: remote_run
+
+// This can't be done in unittests, because that statically links the runtime
+// so we get the wrong paths.  We explicitly want to test that we get the
+// path we expect (that is, the path to the runtime, and paths relative to
+// that).
+
+#include "swift/Runtime/Paths.h"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#if defined(_WIN32) && !defined(__CYGWIN)
+#define stat _stat
+#define S_IFDIR _S_IFDIR
+#endif
+
+static bool
+exists(const char *path) {
+  struct stat st;
+
+  return stat(path, &st) == 0;
+}
+
+static bool
+isdir(const char *path) {
+  struct stat st;
+
+  return stat(path, &st) == 0 && (st.st_mode & S_IFDIR);
+}
+
+static bool
+isfile(const char *path) {
+  struct stat st;
+
+  return stat(path, &st) == 0 && !(st.st_mode & S_IFDIR);
+}
+
+int main(void) {
+  const char *runtimePath = swift_getRuntimePath();
+
+  // Runtime path must point to libswiftCore and must be a file.
+
+  // CHECK: runtime path: {{.*[\\/]}}libswiftCore.{{so|dylib|dll}}
+  // CHECK-NEXT: runtime is a file: yes
+  printf("runtime path: %s\n", runtimePath ? runtimePath: "<NULL>");
+  printf("runtime is a file: %s\n", isfile(runtimePath) ? "yes" : "no");
+
+  const char *rootPath = swift_getRootPath();
+
+  // Root path must end in a separator and must be a directory
+
+  // CHECK: root path: {{.*[\\/]$}}
+  // CHECK-NEXT: root is a directory: yes
+  printf("root path: %s\n", rootPath ? rootPath : "<NULL>");
+  printf("root is a directory: %s\n", isdir(rootPath) ? "yes" : "no");
+
+  // Auxiliary executable path must be in swift-root/libexec.
+#define UNLIKELY_NAME "anUnlikelyExecutableName"
+
+  const size_t unlikelyLen = strlen(UNLIKELY_NAME);
+  const char *auxPath = swift_getAuxiliaryExecutablePath(UNLIKELY_NAME);
+
+  // CHECK: aux path: {{.*[\\/](libexec[\\/])?}}anUnlikelyExecutableName{{(\.exe)?}}
+  printf("aux path: %s\n", auxPath ? auxPath : "<NULL>");
+
+  return 0;
+}

--- a/test/Runtime/Paths.cpp
+++ b/test/Runtime/Paths.cpp
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-clang %s -std=c++11 -I %swift_src_root/include -I %swift_src_root/stdlib/public/SwiftShims -I %clang-include-dir -isysroot %sdk -L%swift_obj_root/lib/swift/%target-sdk-name -lswiftCore -o %t/paths-test
+// RUN: %target-clang %s -std=c++11 -I %swift_src_root/include -I %swift_src_root/stdlib/public/SwiftShims -I %clang-include-dir -isysroot %sdk -L%swift_obj_root/lib/swift/%target-sdk-name/%target-arch -lswiftCore -o %t/paths-test
 // RUN: %target-codesign %t/paths-test
 // RUN: %target-run %t/paths-test | %FileCheck %s
 

--- a/test/Runtime/environment_variables.swift
+++ b/test/Runtime/environment_variables.swift
@@ -18,6 +18,7 @@
 // CHECK-DAG:    bool SWIFT_DETERMINISTIC_HASHING [default: false] - Disable randomized hash seeding.
 // CHECK-DAG:    bool SWIFT_ENABLE_MANGLED_NAME_VERIFICATION [default: false] - Enable verification that metadata can roundtrip through a mangled name each time metadata is instantiated.
 // CHECK-DAG:    bool SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE [default: false] - Scribble on runtime allocations such as metadata allocations.
+// CHECK-DAG:  string SWIFT_ROOT [default: "{{[^"]*}}"] - Overrides the root directory of the Swift installation. This is used to locate auxiliary files relative to the runtime itself.
 
 // We need to do this because the DAG checks require a non-DAG check as an
 // anchor:

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1756,6 +1756,9 @@ config.substitutions.append(('%module-target-future', target_future))
 # Add 'target-sdk-name' as the name for platform-specific directories
 config.substitutions.append(('%target-sdk-name', config.target_sdk_name))
 
+# Also add 'target-arch' so we can locate some things inside the build tree
+config.substitutions.append(('%target-arch', target_arch))
+
 # Add 'stdlib_dir' as the path to the stdlib resource directory
 stdlib_dir = os.path.join(config.swift_lib_dir, "swift")
 if run_os == 'maccatalyst':


### PR DESCRIPTION
Adds the ability to locate files relative to the path of the Swift runtime library, libswiftCore.

rdar://103071801
