### PR TITLE
Disable test/SILGen/pack_expansion_type.swift on Windows temporarily

### DIFF
--- a/test/SILGen/pack_expansion_type.swift
+++ b/test/SILGen/pack_expansion_type.swift
@@ -3,6 +3,8 @@
 // Experimental features require an asserts compiler
 // REQUIRES: asserts
 
+// XFAIL: OS=windows-msvc
+
 // CHECK-LABEL: sil [ossa] @$s19pack_expansion_type16variadicFunction1t1ux_q_txQp_txxQp_q_q_Qptq_Rhzr0_lF : $@convention(thin) <T..., U... where ((T, U)...) : Any> (@in_guaranteed T..., @in_guaranteed U...) -> @out (T, U)... {
 // CHECK: bb0(%0 : $*(T, U)..., %1 : $*T..., %2 : $*U...):
 public func variadicFunction<T..., U...>(t: T..., u: U...) -> ((T, U)...) {}


### PR DESCRIPTION
Until rdar://103123122 is resolved