### PR TITLE
[CodeCompletion] Don't suggest opaque generic parameter types

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3321,8 +3321,13 @@ void FindLocalVal::checkGenericParams(GenericParamList *Params) {
   if (!Params)
     return;
 
-  for (auto P : *Params)
+  for (auto P : *Params) {
+    if (P->isOpaqueType()) {
+      // Generic param for 'some' parameter type is not "visible".
+      continue;
+    }
     checkValueDecl(P, DeclVisibilityKind::GenericParameter);
+  }
 }
 
 void FindLocalVal::checkSourceFile(const SourceFile &SF) {

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -1703,6 +1703,7 @@ void CompletionLookup::addTypeAliasRef(const TypeAliasDecl *TAD,
 void CompletionLookup::addGenericTypeParamRef(
     const GenericTypeParamDecl *GP, DeclVisibilityKind Reason,
     DynamicLookupInfo dynamicLookupInfo) {
+  assert(!GP->getName().empty());
   CodeCompletionResultBuilder Builder(
       Sink, CodeCompletionResultKind::Declaration,
       getSemanticContext(GP, Reason, dynamicLookupInfo));

--- a/validation-test/IDE/crashers_2_fixed/rdar102958462.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar102958462.swift
@@ -1,0 +1,3 @@
+// RUN: %swift-ide-test -code-completion -code-completion-token COMPLETE -code-completion-annotate-results -source-filename %s
+
+func f(_ s: some #^COMPLETE^#

--- a/validation-test/IDE/crashers_2_fixed/rdar103300572.swift
+++ b/validation-test/IDE/crashers_2_fixed/rdar103300572.swift
@@ -1,0 +1,6 @@
+// RUN: %swift-ide-test -code-completion -code-completion-token COMPLETE -code-completion-annotate-results -source-filename %s
+
+protocol P { }
+func f(_ p: some P) {
+  #^COMPLETE^#
+}


### PR DESCRIPTION
'some' parameter types don't have spelling.

rdar://102958462
Resolves #60455

