### PR TITLE
[DependencyScanning] Count target variant, clang target, and sdk versions as components of scanning context hash

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -631,7 +631,16 @@ namespace swift {
     /// Return a hash code of any components from these options that should
     /// contribute to a Swift Dependency Scanning hash.
     llvm::hash_code getModuleScanningHashComponents() const {
-      return getPCHHashComponents();
+      auto hashValue = getPCHHashComponents();
+      if (TargetVariant.hasValue())
+        hashValue = llvm::hash_combine(hashValue, TargetVariant.getValue().str());
+      if (ClangTarget.hasValue())
+        hashValue = llvm::hash_combine(hashValue, ClangTarget.getValue().str());
+      if (SDKVersion.hasValue())
+        hashValue = llvm::hash_combine(hashValue, SDKVersion.getValue().getAsString());
+      if (VariantSDKVersion.hasValue())
+        hashValue = llvm::hash_combine(hashValue, VariantSDKVersion.getValue().getAsString());
+      return hashValue;
     }
 
   private:

--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -439,9 +439,10 @@ ModuleDependenciesCache::getDependencyReferencesMap(
 ModuleDependenciesCache::ModuleDependenciesCache(
     GlobalModuleDependenciesCache &globalCache,
     std::string mainScanModuleName,
-    std::string scanningContextHash)
+    std::string scannerContextHash)
     : globalCache(globalCache),
       mainScanModuleName(mainScanModuleName),
+      scannerContextHash(scannerContextHash),
       clangScanningTool(globalCache.ClangScanningService) {
   globalCache.configureForContextHash(scannerContextHash);
   for (auto kind = ModuleDependenciesKind::FirstKind;


### PR DESCRIPTION
Otherwise we get unintended collisions in cases like: scanning for the same target but a different target variant, e.g. Catalyst. 