### PR TITLE
[CMake] Don't add unnecessary gyb support .py files

### DIFF
--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -122,27 +122,7 @@ function(handle_gyb_sources dependency_out_var_name sources_var_name)
       "${SWIFT_SOURCE_DIR}/utils/SwiftFloatingPointTypes.py"
       "${SWIFT_SOURCE_DIR}/utils/UnicodeData/GraphemeBreakProperty.txt"
       "${SWIFT_SOURCE_DIR}/utils/UnicodeData/GraphemeBreakTest.txt"
-      "${SWIFT_SOURCE_DIR}/utils/gyb_stdlib_support.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/__init__.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/Child.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/Classification.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/kinds.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/Node.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/AttributeKinds.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/AttributeNodes.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/AvailabilityNodes.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/CommonNodes.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/DeclNodes.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/ExprNodes.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/GenericNodes.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/PatternNodes.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/StmtNodes.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/TypeNodes.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/Token.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/Trivia.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/Traits.py"
-      "${SWIFT_SOURCE_DIR}/utils/gyb_sourcekit_support/__init__.py"
-      "${SWIFT_SOURCE_DIR}/utils/gyb_sourcekit_support/UIDs.py")
+      "${SWIFT_SOURCE_DIR}/utils/gyb_stdlib_support.py")
 
   foreach (src ${${sources_var_name}})
     # On Windows (using Visual Studio), the generated project files assume that the

--- a/include/swift/AST/Attr.def.gyb
+++ b/include/swift/AST/Attr.def.gyb
@@ -1,6 +1,5 @@
 %{
   # -*- mode: C++ -*-
-  from gyb_syntax_support import *
   from gyb_syntax_support.AttributeKinds import *
   # Ignore the following admonition; it applies to the resulting .def file only
 }%

--- a/include/swift/AST/CMakeLists.txt
+++ b/include/swift/AST/CMakeLists.txt
@@ -9,6 +9,12 @@ set(generated_include_sources
     TokenKinds.def.gyb)
 
 add_gyb_target(swift-ast-generated-headers
-    "${generated_include_sources}")
+    "${generated_include_sources}"
+    DEPENDS
+      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/kinds.py"
+      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/AttributeKinds.py"
+      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/Classification.py"
+      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/Token.py"
+      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/Utils.py")
 set_property(TARGET swift-ast-generated-headers
     PROPERTY FOLDER "Miscellaneous")

--- a/include/swift/AST/TokenKinds.def.gyb
+++ b/include/swift/AST/TokenKinds.def.gyb
@@ -1,6 +1,6 @@
 %{
   # -*- mode: Swift -*-
-  from gyb_syntax_support import *
+  from gyb_syntax_support.Token import *
   # Ignore the following admonition it applies to the resulting .def file only
 }%
 //// Automatically Generated From TokenKinds.def.gyb.
@@ -145,9 +145,9 @@
 
 // Keywords that start decls.
 % for token in SYNTAX_TOKENS:
-%   if isinstance(token, Token.Punctuator):
+%   if isinstance(token, Punctuator):
 ${token.macro_name()}(${token.unprefixed_kind}, "${token.text}")
-%   elif isinstance(token, Token.PoundObjectLiteral):
+%   elif isinstance(token, PoundObjectLiteral):
 ${token.macro_name()}(${token.unprefixed_kind}, "${token.description}", ${token.protocol})
 %   else:
 ${token.macro_name()}(${token.unprefixed_kind})

--- a/tools/SourceKit/include/SourceKit/Core/CMakeLists.txt
+++ b/tools/SourceKit/include/SourceKit/Core/CMakeLists.txt
@@ -1,1 +1,5 @@
-add_gyb_target(generated_sourcekit_uids ProtocolUIDs.def.gyb)
+add_gyb_target(generated_sourcekit_uids
+  ProtocolUIDs.def.gyb
+  DEPENDS
+    "${SWIFT_SOURCE_DIR}/utils/gyb_sourcekit_support/__init__.py"
+    "${SWIFT_SOURCE_DIR}/utils/gyb_sourcekit_support/UIDs.py")


### PR DESCRIPTION
'add_gyb_target' can accept 'DEPENDS'. Utilize it.
