### PR TITLE
[cxx-interop] Hook libcxxshim modulemap/header to sdk-overlay

### DIFF
--- a/stdlib/public/Cxx/cxxshim/CMakeLists.txt
+++ b/stdlib/public/Cxx/cxxshim/CMakeLists.txt
@@ -38,6 +38,7 @@ foreach(sdk ${SWIFT_SDKS})
     add_custom_target(cxxshim-${sdk}-${arch} ALL
                       DEPENDS ${outputs}
                       COMMENT "Copying cxxshims to ${module_dir}")
+    list(APPEND libcxxshim_modulemap_target_list cxxshim-${sdk}-${arch})
 
 
     swift_install_in_component(FILES libcxxshim.modulemap libcxxshim.h
@@ -50,3 +51,7 @@ foreach(sdk ${SWIFT_SDKS})
     endif()
   endforeach()
 endforeach()
+
+add_custom_target(libcxxshim_modulemap DEPENDS ${libcxxshim_modulemap_target_list})
+set_property(TARGET libcxxshim_modulemap PROPERTY FOLDER "Miscellaneous")
+add_dependencies(sdk-overlay libcxxshim_modulemap)


### PR DESCRIPTION
The modulemap and header files target was added to `ALL`, which works when invoking the build thru the `build-script`, but make some test fail when doing a manual configuration and later doing
`check-swift-validation` or similar, because the modulemap/header were not copied into the build directory.

Follow a pattern similar to the one in GlibC (which this file seemed to be prepared for, since the `libcxxshim_modulemap_target_list` variable was already there), create a global target for all the modulemap/headers of each SDK and add that global target as a dependency of sdk-overlay (which is a dependency of check-swift-validation and others).