### PR TITLE
[ModuleInterface] Ignore export_as in private swiftinterface

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -649,6 +649,7 @@ struct PrintOptions {
                                               bool preferTypeRepr,
                                               bool printFullConvention,
                                               bool printSPIs,
+                                              bool useExportedModuleNames,
                                               bool aliasModuleNames,
                                               llvm::SmallSet<StringRef, 4>
                                                 *aliasModuleNamesTargets

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -105,6 +105,7 @@ EXPERIMENTAL_FEATURE(OneWayClosureParameters, false)
 EXPERIMENTAL_FEATURE(TypeWitnessSystemInference, false)
 EXPERIMENTAL_FEATURE(ResultBuilderASTTransform, true)
 EXPERIMENTAL_FEATURE(LayoutPrespecialization, false)
+EXPERIMENTAL_FEATURE(ModuleInterfaceExportAs, true)
 
 /// Whether to enable experimental differentiable programming features:
 /// `@differentiable` declaration attribute, etc.

--- a/include/swift/Frontend/ModuleInterfaceSupport.h
+++ b/include/swift/Frontend/ModuleInterfaceSupport.h
@@ -50,8 +50,8 @@ struct ModuleInterfaceOptions {
   /// ignored by the earlier version of the compiler.
   std::string IgnorableFlags;
 
-  /// Print SPI decls and attributes.
-  bool PrintSPIs = false;
+  /// Print for a private swiftinterface file, SPI decls and attributes.
+  bool PrintPrivateInterfaceContent = false;
 
   /// Print imports with both @_implementationOnly and @_spi, only applies
   /// when PrintSPIs is true.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -132,6 +132,7 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
                                                    bool preferTypeRepr,
                                                    bool printFullConvention,
                                                    bool printSPIs,
+                                                   bool useExportedModuleNames,
                                                    bool aliasModuleNames,
                                                    llvm::SmallSet<StringRef, 4>
                                                      *aliasModuleNamesTargets
@@ -145,7 +146,7 @@ PrintOptions PrintOptions::printSwiftInterfaceFile(ModuleDecl *ModuleToPrint,
   result.FullyQualifiedTypes = true;
   result.FullyQualifiedTypesIfAmbiguous = true;
   result.FullyQualifiedExtendedTypesIfAmbiguous = true;
-  result.UseExportedModuleNames = true;
+  result.UseExportedModuleNames = useExportedModuleNames;
   result.AllowNullTypes = false;
   result.SkipImports = true;
   result.OmitNameOfInaccessibleProperties = true;
@@ -3067,6 +3068,10 @@ static bool usesFeatureVariadicGenerics(Decl *decl) {
 }
 
 static bool usesFeatureLayoutPrespecialization(Decl *decl) {
+  return false;
+}
+
+static bool usesFeatureModuleInterfaceExportAs(Decl *decl) {
   return false;
 }
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -384,7 +384,7 @@ static void ParseModuleInterfaceArgs(ModuleInterfaceOptions &Opts,
   if (const Arg *A = Args.getLastArg(OPT_library_level)) {
     StringRef contents = A->getValue();
     if (contents == "spi") {
-      Opts.PrintSPIs = true;
+      Opts.PrintPrivateInterfaceContent = true;
     }
   }
   for (auto val: Args.getAllArgValues(OPT_skip_import_in_public_interface)) {

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -225,7 +225,7 @@ static void printImports(raw_ostream &out,
   // imports only if they are also SPI. First, list all implementation-only
   // imports and filter them later.
   llvm::SmallSet<ImportedModule, 4, ImportedModule::Order> ioiImportSet;
-  if (Opts.PrintSPIs && Opts.ExperimentalSPIImports) {
+  if (Opts.PrintPrivateInterfaceContent && Opts.ExperimentalSPIImports) {
 
     SmallVector<ImportedModule, 4> ioiImports, allImports;
     M->getImportedModules(ioiImports,
@@ -246,7 +246,7 @@ static void printImports(raw_ostream &out,
 
   /// Collect @_spiOnly imports that are not imported elsewhere publicly.
   llvm::SmallSet<ImportedModule, 4, ImportedModule::Order> spiOnlyImportSet;
-  if (Opts.PrintSPIs) {
+  if (Opts.PrintPrivateInterfaceContent) {
     SmallVector<ImportedModule, 4> spiOnlyImports, otherImports;
     M->getImportedModules(spiOnlyImports,
                           ModuleDecl::ImportFilterKind::SPIOnly);
@@ -305,7 +305,7 @@ static void printImports(raw_ostream &out,
     if (publicImportSet.count(import))
       out << "@_exported ";
 
-    if (Opts.PrintSPIs) {
+    if (Opts.PrintPrivateInterfaceContent) {
       // An import visible in the private swiftinterface only.
       //
       // In the long term, we want to print this attribute for consistency and
@@ -789,7 +789,8 @@ bool swift::emitSwiftInterface(raw_ostream &out,
   printImports(out, Opts, M);
 
   const PrintOptions printOptions = PrintOptions::printSwiftInterfaceFile(
-      M, Opts.PreserveTypesAsWritten, Opts.PrintFullConvention, Opts.PrintSPIs,
+      M, Opts.PreserveTypesAsWritten, Opts.PrintFullConvention,
+      Opts.PrintPrivateInterfaceContent,
       Opts.AliasModuleNames, &aliasModuleNamesTargets);
   InheritedProtocolCollector::PerTypeMap inheritedProtocolMap;
 

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -788,9 +788,18 @@ bool swift::emitSwiftInterface(raw_ostream &out,
 
   printImports(out, Opts, M);
 
+  static bool forceUseExportedModuleNameInPublicOnly =
+    getenv("SWIFT_DEBUG_USE_EXPORTED_MODULE_NAME_IN_PUBLIC_ONLY");
+  bool useExportedModuleNameInPublicOnly =
+    M->getASTContext().LangOpts.hasFeature(Feature::ModuleInterfaceExportAs) ||
+    forceUseExportedModuleNameInPublicOnly;
+  bool useExportedModuleNames = !(useExportedModuleNameInPublicOnly &&
+                                  Opts.PrintPrivateInterfaceContent);
+
   const PrintOptions printOptions = PrintOptions::printSwiftInterfaceFile(
       M, Opts.PreserveTypesAsWritten, Opts.PrintFullConvention,
       Opts.PrintPrivateInterfaceContent,
+      useExportedModuleNames,
       Opts.AliasModuleNames, &aliasModuleNamesTargets);
   InheritedProtocolCollector::PerTypeMap inheritedProtocolMap;
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -949,7 +949,7 @@ static bool emitAnyWholeModulePostTypeCheckSupplementaryOutputs(
   if (opts.InputsAndOutputs.hasPrivateModuleInterfaceOutputPath()) {
     // Copy the settings from the module interface to add SPI printing.
     ModuleInterfaceOptions privOpts = Invocation.getModuleInterfaceOptions();
-    privOpts.PrintSPIs = true;
+    privOpts.PrintPrivateInterfaceContent = true;
     privOpts.ModulesToSkipInPublicInterface.clear();
 
     hadAnyError |= printModuleInterfaceIfNeeded(

--- a/test/ModuleInterface/export-as-in-swiftinterfaces.swift
+++ b/test/ModuleInterface/export-as-in-swiftinterfaces.swift
@@ -1,0 +1,115 @@
+/// Test the logic printing the export_as name in public swiftinterfaces
+/// and the real source module name in the private swiftinterfaces.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Build lib with an export_as.
+// RUN: %target-swift-frontend -emit-module %t/Exported.swift \
+// RUN:   -module-name Exported -swift-version 5 -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-path %t/Exported.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Exported.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Exported.private.swiftinterface \
+// RUN:   -enable-experimental-feature ModuleInterfaceExportAs
+// RUN: %target-swift-typecheck-module-from-interface(%t/Exported.private.swiftinterface) -module-name Exported -I %t
+// RUN: cat %t/Exported.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTER %s
+// RUN: cat %t/Exported.private.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTED %s
+
+/// The public swiftinterface only builds under the name of Exporter.
+// RUN: sed -e "s/module-name Exported/module-name Exporter/" -ibk %t/Exported.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/Exported.swiftinterface) -I %t -module-name Exporter
+
+/// Build lib with an @exported import of the exported one.
+/// Default/old behavior.
+// RUN: %target-swift-frontend -emit-module %t/Exporter.swift \
+// RUN:   -module-name Exporter -swift-version 5 -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-path %t/Exporter.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Exporter.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Exporter.private.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/Exporter.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/Exporter.private.swiftinterface) -module-name Exporter -I %t
+// RUN: cat %t/Exporter.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTER %s
+// RUN: cat %t/Exporter.private.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTER %s
+
+/// Build lib with an @exported import of the exported one.
+/// New behavior via flag.
+// RUN: %target-swift-frontend -emit-module %t/Exporter.swift \
+// RUN:   -module-name Exporter -swift-version 5 -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-path %t/Exporter.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Exporter.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Exporter.private.swiftinterface \
+// RUN:   -enable-experimental-feature ModuleInterfaceExportAs
+// RUN: %target-swift-typecheck-module-from-interface(%t/Exporter.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/Exporter.private.swiftinterface) -module-name Exporter -I %t
+// RUN: cat %t/Exporter.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTER %s
+// RUN: cat %t/Exporter.private.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTED %s
+
+/// Build lib with an @exported import of the exported one.
+/// New behavior via env var.
+// RUN: env SWIFT_DEBUG_USE_EXPORTED_MODULE_NAME_IN_PUBLIC_ONLY=1 \
+// RUN:   %target-swift-frontend -emit-module %t/Exporter.swift \
+// RUN:   -module-name Exporter -swift-version 5 -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-path %t/Exporter.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Exporter.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Exporter.private.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/Exporter.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/Exporter.private.swiftinterface) -module-name Exporter -I %t
+// RUN: cat %t/Exporter.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTER %s
+// RUN: cat %t/Exporter.private.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTED %s
+
+/// Build a client of the exporter lib.
+// RUN: %target-swift-frontend -emit-module %t/Client.swift \
+// RUN:   -module-name Client -swift-version 5 -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-path %t/Client.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Client.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Client.private.swiftinterface \
+// RUN:   -enable-experimental-feature ModuleInterfaceExportAs
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) -module-name Client -I %t
+// RUN: cat %t/Client.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTER %s
+// RUN: cat %t/Client.private.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTED %s
+
+/// Build a client of the exporter lib.
+// RUN: rm %t/Exporter.private.swiftinterface %t/Exporter.swiftmodule
+// RUN: %target-swift-frontend -emit-module %t/Client.swift \
+// RUN:   -module-name Client -swift-version 5 -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-path %t/Client.swiftmodule \
+// RUN:   -emit-module-interface-path %t/Client.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Client.private.swiftinterface \
+// RUN:   -enable-experimental-feature ModuleInterfaceExportAs
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) -module-name Client -I %t
+// RUN: cat %t/Client.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTER %s
+// RUN: cat %t/Client.private.swiftinterface | %FileCheck -check-prefix=CHECK-USE-EXPORTED %s
+
+//--- module.modulemap
+module Exported {
+    export_as Exporter
+    header "Exported.h"
+}
+
+//--- Exported.h
+struct exportedClangType {};
+
+//--- Exported.swift
+@_exported import Exported
+
+public func foo(a: exportedClangType) {}
+// CHECK-USE-EXPORTED: Exported.exportedClangType
+// CHECK-USE-EXPORTER: Exporter.exportedClangType
+
+//--- Exporter.swift
+@_exported import Exported
+
+public func foo(a: exportedClangType) {}
+
+//--- Client.swift
+import Exporter
+
+public func foo(a: exportedClangType) {}


### PR DESCRIPTION
Introduce a new behavior when printing references to modules with an `export_as` definition. Use the `export_as` name in the public swiftinterface and the real module name in the private swiftinterface.

This has some limits but should still be an improvement over the current behavior. First, the we use the `export_as` names only for references to clang decls, not Swift decls with an underlying module defining an `export_as`. Second, we always print the `export_as` name in the public swiftinterface, even in the original swiftinterface file when the `export_as` target is likely not know, so that generated swiftinterface is still broken.

This behavior is enabled by the flags `-enable-experimental-feature ModuleInterfaceExportAs` or the `SWIFT_DEBUG_USE_EXPORTED_MODULE_NAME_IN_PUBLIC_ONLY` env var. We may consider turning it on by default in the future.

rdar://98532918