### PR TITLE
[CursorInfo] Implement a few expression references as solver-based

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -81,6 +81,11 @@ const std::function<bool(const ExtensionDecl *)>
 void PrintOptions::setBaseType(Type T) {
   if (T->is<ErrorType>())
     return;
+  if (auto DynamicSelf = T->getAs<DynamicSelfType>()) {
+    // TypeTransformContext requires `T` to have members. Look through dynamic
+    // Self.
+    T = DynamicSelf->getSelfType();
+  }
   TransformContext = TypeTransformContext(T);
 }
 

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -16,6 +16,7 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/USRGeneration.h"
+#include "swift/IDE/SelectedOverloadInfo.h"
 #include "swift/IDE/TypeCheckCompletionCallback.h"
 #include "swift/Parse/IDEInspectionCallbacks.h"
 #include "swift/Sema/ConstraintSystem.h"
@@ -51,9 +52,11 @@ void typeCheckDeclAndParentClosures(ValueDecl *VD) {
       TypeCheckASTNodeAtLocContext::declContext(VD->getDeclContext()),
       VD->getLoc());
   if (auto VarD = dyn_cast<VarDecl>(VD)) {
-    // Type check any attached property wrappers so the annotated declaration
-    // can refer to their USRs.
-    (void)VarD->getPropertyWrapperBackingPropertyType();
+    if (VarD->hasAttachedPropertyWrapper()) {
+      // Type check any attached property wrappers so the annotated declaration
+      // can refer to their USRs.
+      (void)VarD->getPropertyWrapperBackingPropertyType();
+    }
     // Visit emitted accessors so we generated accessors from property wrappers.
     VarD->visitEmittedAccessors([&](AccessorDecl *accessor) {});
   }
@@ -61,7 +64,7 @@ void typeCheckDeclAndParentClosures(ValueDecl *VD) {
 
 // MARK: - NodeFinderResults
 
-enum class NodeFinderResultKind { Decl };
+enum class NodeFinderResultKind { Decl, Expr };
 
 class NodeFinderResult {
   NodeFinderResultKind Kind;
@@ -84,6 +87,24 @@ public:
 
   static bool classof(const NodeFinderResult *Res) {
     return Res->getKind() == NodeFinderResultKind::Decl;
+  }
+};
+
+class NodeFinderExprResult : public NodeFinderResult {
+  Expr *E;
+  /// The \c DeclContext in which \c E occurs.
+  DeclContext *DC;
+
+public:
+  NodeFinderExprResult(Expr *E, DeclContext *DC)
+      : NodeFinderResult(NodeFinderResultKind::Expr), E(E), DC(DC) {}
+
+  Expr *getExpr() const { return E; }
+
+  DeclContext *getDeclContext() const { return DC; }
+
+  static bool classof(const NodeFinderResult *Res) {
+    return Res->getKind() == NodeFinderResultKind::Expr;
   }
 };
 
@@ -192,6 +213,23 @@ private:
       }
     }
 
+    if (E->getLoc() != LocToResolve) {
+      return Action::Continue(E);
+    }
+
+    switch (E->getKind()) {
+    case ExprKind::DeclRef:
+    case ExprKind::UnresolvedDot:
+    case ExprKind::UnresolvedDeclRef: {
+      assert(Result == nullptr);
+      Result =
+          std::make_unique<NodeFinderExprResult>(E, getCurrentDeclContext());
+      return Action::Stop();
+    }
+    default:
+      break;
+    }
+
     return Action::Continue(E);
   }
 
@@ -213,6 +251,57 @@ private:
     }
     return Action::Continue(S);
   }
+};
+
+// MARK: - Solver-based expression analysis
+
+class CursorInfoTypeCheckSolutionCallback : public TypeCheckCompletionCallback {
+public:
+  struct CursorInfoDeclReference {
+    /// If the referenced declaration is a member reference, the type of the
+    /// member's base, otherwise \c null.
+    Type BaseType;
+    /// Whether the reference is dynamic (see \c ide::isDynamicRef)
+    bool IsDynamicRef;
+    /// The declaration that is being referenced. Will never be \c nullptr.
+    ValueDecl *ReferencedDecl;
+  };
+
+private:
+  /// The expression for which we want to provide cursor info results.
+  Expr *ResolveExpr;
+
+  SmallVector<CursorInfoDeclReference, 1> Results;
+
+  void sawSolutionImpl(const Solution &S) override {
+    auto &CS = S.getConstraintSystem();
+
+    auto Locator = CS.getConstraintLocator(ResolveExpr);
+    auto CalleeLocator = S.getCalleeLocator(Locator);
+    auto OverloadInfo = getSelectedOverloadInfo(S, CalleeLocator);
+    if (!OverloadInfo.Value) {
+      // We could not resolve the referenced declaration. Skip the solution.
+      return;
+    }
+
+    bool IsDynamicRef = false;
+    auto BaseLocator =
+        CS.getConstraintLocator(Locator, ConstraintLocator::MemberRefBase);
+    if (auto BaseExpr =
+            simplifyLocatorToAnchor(BaseLocator).dyn_cast<Expr *>()) {
+      IsDynamicRef =
+          ide::isDynamicRef(BaseExpr, OverloadInfo.Value,
+                            [&S](Expr *E) { return S.getResolvedType(E); });
+    }
+
+    Results.push_back({OverloadInfo.BaseTy, IsDynamicRef, OverloadInfo.Value});
+  }
+
+public:
+  CursorInfoTypeCheckSolutionCallback(Expr *ResolveExpr)
+      : ResolveExpr(ResolveExpr) {}
+
+  ArrayRef<CursorInfoDeclReference> getResults() const { return Results; }
 };
 
 // MARK: - CursorInfoDoneParsingCallback
@@ -242,6 +331,59 @@ public:
     return CursorInfo;
   }
 
+  std::unique_ptr<ResolvedCursorInfo>
+  getExprResult(NodeFinderExprResult *ExprResult, SourceFile *SrcFile,
+                NodeFinder &Finder) const {
+    Expr *E = ExprResult->getExpr();
+    DeclContext *DC = ExprResult->getDeclContext();
+
+    // Type check the statemnt containing E and listen for solutions.
+    CursorInfoTypeCheckSolutionCallback Callback(E);
+    llvm::SaveAndRestore<TypeCheckCompletionCallback *> CompletionCollector(
+        DC->getASTContext().SolutionCallback, &Callback);
+    typeCheckASTNodeAtLoc(TypeCheckASTNodeAtLocContext::declContext(DC),
+                          E->getLoc());
+
+    if (Callback.getResults().empty()) {
+      // No results.
+      return nullptr;
+    }
+
+    for (auto Info : Callback.getResults()) {
+      // Type check the referenced decls so that all their parent closures are
+      // type-checked (see comment in typeCheckDeclAndParentClosures).
+      typeCheckDeclAndParentClosures(Info.ReferencedDecl);
+    }
+
+    if (Callback.getResults().size() != 1) {
+      // FIXME: We need to be able to report multiple results.
+      return nullptr;
+    }
+
+    // Deliver results
+
+    auto Res = Callback.getResults()[0];
+    auto CursorInfo = std::make_unique<ResolvedValueRefCursorInfo>(
+        ResolvedCursorInfo(SrcFile), Res.ReferencedDecl, /*CtorTyRef=*/nullptr,
+        /*ExtTyRef=*/nullptr, /*IsRef=*/true, /*Ty=*/Type(),
+        /*ContainerType=*/Res.BaseType);
+    CursorInfo->setLoc(RequestedLoc);
+    CursorInfo->setIsDynamic(Res.IsDynamicRef);
+    if (Res.IsDynamicRef && Res.BaseType) {
+      if (auto ReceiverType = Res.BaseType->getAnyNominal()) {
+        CursorInfo->setReceiverTypes({ReceiverType});
+      } else if (auto MT = Res.BaseType->getAs<AnyMetatypeType>()) {
+        // Look through metatypes to get the nominal type decl.
+        if (auto ReceiverType = MT->getInstanceType()->getAnyNominal()) {
+          CursorInfo->setReceiverTypes({ReceiverType});
+        }
+      }
+    }
+    CursorInfo->setShorthandShadowedDecls(
+        Finder.getShorthandShadowedDecls(Res.ReferencedDecl));
+    return CursorInfo;
+  }
+
   void doneParsing(SourceFile *SrcFile) override {
     if (!SrcFile) {
       return;
@@ -256,6 +398,10 @@ public:
     switch (Result->getKind()) {
     case NodeFinderResultKind::Decl:
       CursorInfo = getDeclResult(cast<NodeFinderDeclResult>(Result.get()),
+                                 SrcFile, Finder);
+      break;
+    case NodeFinderResultKind::Expr:
+      CursorInfo = getExprResult(cast<NodeFinderExprResult>(Result.get()),
                                  SrcFile, Finder);
       break;
     }

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -48,9 +48,14 @@ void typeCheckDeclAndParentClosures(ValueDecl *VD) {
     DC = DC->getParent();
   }
 
-  typeCheckASTNodeAtLoc(
-      TypeCheckASTNodeAtLocContext::declContext(VD->getDeclContext()),
-      VD->getLoc());
+  if (!VD->getInterfaceType()) {
+    // The decl has an interface time if it came from another module. In that
+    // case, there's nothing to do. Otherwise, type check the decl to get its
+    // type.
+    typeCheckASTNodeAtLoc(
+        TypeCheckASTNodeAtLocContext::declContext(VD->getDeclContext()),
+        VD->getLoc());
+  }
   if (auto VarD = dyn_cast<VarDecl>(VD)) {
     if (VarD->hasAttachedPropertyWrapper()) {
       // Type check any attached property wrappers so the annotated declaration

--- a/lib/IDE/SelectedOverloadInfo.cpp
+++ b/lib/IDE/SelectedOverloadInfo.cpp
@@ -36,6 +36,9 @@ swift::ide::getSelectedOverloadInfo(const Solution &S,
     if (Result.BaseTy) {
       Result.BaseTy = S.simplifyType(Result.BaseTy)->getRValueType();
     }
+    if (Result.BaseTy && Result.BaseTy->is<ModuleType>()) {
+      Result.BaseTy = nullptr;
+    }
 
     Result.Value = SelectedOverload->choice.getDeclOrNull();
     Result.ValueTy =

--- a/test/SourceKit/CompileNotifications/cursor-info.swift
+++ b/test/SourceKit/CompileNotifications/cursor-info.swift
@@ -1,6 +1,3 @@
-// rdar://103369449
-// REQUIRES: asserts
-
 // RUN: %sourcekitd-test -req=track-compiles == -req=cursor %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1 --enable-yaml-compatibility
 // COMPILE_1: <empty cursor info; internal diagnostic: "Unable to resolve cursor info.">
 // COMPILE_1: {
@@ -12,7 +9,7 @@
 // COMPILE_1:   key.notification: source.notification.compile-did-finish,
 // COMPILE_1:   key.compileid: [[CID1]]
 // COMPILE_1: }
-// FIXME: Once we switch to only run solver-based cursor info, we should only receive a single compile notification
+// FIXME: Once all cursor info kinds are migrated to solver-based and we remove the fallback path to AST-based cursor info, we should only receive a single compile notification
 // COMPILE_1: {
 // COMPILE_1:  key.notification: source.notification.compile-will-start,
 // COMPILE_1:  key.filepath: "SOURCE_DIR{{.*}}cursor-info.swift",

--- a/test/SourceKit/CursorInfo/cursor_in_pound_if.swift
+++ b/test/SourceKit/CursorInfo/cursor_in_pound_if.swift
@@ -8,6 +8,5 @@ func foo() {
   let xxx = "hello"
 #endif
 }
-// TODO: Once we switch to use the solver-based cursor info implementation, we also receive results for the int case
-// CHECK-INT: Unable to resolve cursor info
+// CHECK-INT: <Declaration>let xxx: <Type usr="s:Si">Int</Type></Declaration>
 // CHECK-STR: <Declaration>let xxx: <Type usr="s:SS">String</Type></Declaration>

--- a/test/SourceKit/CursorInfo/cursor_in_stdlib_module.swift
+++ b/test/SourceKit/CursorInfo/cursor_in_stdlib_module.swift
@@ -1,0 +1,12 @@
+func test() {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):9 %s -- %s | %FileCheck %s
+  Swift.min(1, 2)
+}
+
+// CHECK: source.lang.swift.ref.function.free ()
+// CHECK-NEXT: min(_:_:)
+// CHECK-NEXT: s:s3minyxx_xtSLRzlF
+// CHECK-NEXT: source.lang.swift
+// CHECK-NEXT: <T where T : Comparable> (T, T) -> T
+// CHECK-NEXT: $syxx_xtcSLRzluD
+// CHECK-NEXT: Swift

--- a/test/SourceKit/CursorInfo/cursor_simplify_type.swift
+++ b/test/SourceKit/CursorInfo/cursor_simplify_type.swift
@@ -1,0 +1,35 @@
+protocol Publisher<Output> {
+    associatedtype Output
+}
+
+extension Publisher {
+  func stage2() -> MyGenerictype<Self.Output> {
+    fatalError()
+  }
+
+  func stage3() -> Self {
+    fatalError()
+  }
+}
+
+struct MyGenerictype<Output> : Publisher {
+  init() {}
+
+  func stage1(with output: Self.Output) -> HasTypeAccessInTypealias<Self> {
+    fatalError()
+  }
+}
+
+struct HasTypeAccessInTypealias<Upstream> : Publisher where Upstream : Publisher {
+  typealias Output = Upstream.Output
+}
+
+func test() {
+  MyGenerictype()
+    .stage1(with: 0)
+    .stage2()
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):6 %s -- %s
+    .stage3()
+}
+
+// CHECK: <Declaration>func stage3() -&gt; <Type usr="s:4test13MyGenerictypeV">MyGenerictype</Type>&lt;<Type usr="s:4test24HasTypeAccessInTypealiasV">HasTypeAccessInTypealias</Type>&lt;<Type usr="s:4test13MyGenerictypeV">MyGenerictype</Type>&lt;<Type usr="s:Si">Int</Type>&gt;&gt;.<Type usr="s:4test24HasTypeAccessInTypealiasV6Outputa">Output</Type>&gt;</Declaration>

--- a/test/SourceKit/CursorInfo/discriminator.swift
+++ b/test/SourceKit/CursorInfo/discriminator.swift
@@ -35,8 +35,8 @@ func testNestedClosures() {
 }
 
 func testReuseAST(bytes: Int) {
-  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 2):7 -req-opts=verifysolverbasedcursorinfo=1 %s -- %s == \
-  // RUN:   -req=cursor -pos=%(line + 2):7 -req-opts=verifysolverbasedcursorinfo=1 %s -- %s | %FileCheck %s --check-prefix=REUSE_AST
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 2):7 %s -- %s == \
+  // RUN:   -req=cursor -pos=%(line + 2):7 %s -- %s | %FileCheck %s --check-prefix=REUSE_AST
   let size = 3
   var bytes = 6
   // REUSE_AST: source.lang.swift.decl.var.local (40:7-40:11)

--- a/test/SourceKit/CursorInfo/dynamic_self.swift
+++ b/test/SourceKit/CursorInfo/dynamic_self.swift
@@ -1,0 +1,7 @@
+class UserCollection {
+  static let staticMember = "ABC"
+  func test() {
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):10 %s -- %s
+    Self.staticMember
+  }
+}

--- a/test/SourceKit/CursorInfo/look_through_identity_expr_and_types.swift
+++ b/test/SourceKit/CursorInfo/look_through_identity_expr_and_types.swift
@@ -1,0 +1,26 @@
+func lookThroughFunctionConversions() {
+  class DispatchQueue {
+    class var main: DispatchQueue { get }
+    func async(execute work: @escaping @convention(block) () -> Void)
+  }
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):22 %s -- %s | %FileCheck %s --check-prefix=FUNCTION_CONVERSION
+  DispatchQueue.main.async {}
+}
+
+// FUNCTION_CONVERSION: (DispatchQueue) -> (@escaping @convention(block) () -> ()) -> ()
+// FUNCTION_CONVERSION: DYNAMIC
+
+func lookThorughInout() {
+  public struct Villager {}
+  let villager = Villager()
+
+  var villagers: [Villager] = []
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):13 %s -- %s | %FileCheck %s
+  villagers.removeAll(where: { _ in true })
+}
+
+// CHECK: RECEIVERS BEGIN
+// CHECK: s:Sa
+// CHECK: RECEIVERS END
+

--- a/test/SourceKit/CursorInfo/static_vs_class_spelling.swift
+++ b/test/SourceKit/CursorInfo/static_vs_class_spelling.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/Modules)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+
+// BEGIN MyModule.swift
+
+public class UserCollection {
+  public static let sharedStatic = UserCollection()
+  public class var sharedComputedClass: UserCollection { UserCollection() }
+}
+
+// RUN: %target-swift-frontend \
+// RUN:     -emit-module \
+// RUN:     -module-name MyModule \
+// RUN:     -emit-module-path %t/Modules/MyModule.swiftmodule \
+// RUN:     -emit-module-doc-path %t/Modules/MyModule.swiftdoc \
+// RUN:     %t/MyModule.swift
+
+// BEGIN test.swift
+import MyModule
+
+func application() {
+  UserCollection.sharedStatic
+  UserCollection.sharedComputedClass
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=4:18 %t/test.swift -- %t/test.swift -I %t/Modules | %FileCheck %s --check-prefix=SHARED_STATIC
+
+// FIXME: This should be reported as 'static var' rdar://105239467
+// SHARED_STATIC: <Declaration>class let sharedStatic: <Type usr="s:8MyModule14UserCollectionC">UserCollection</Type></Declaration>
+// SHARED_STATIC: <decl.var.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>sharedStatic</decl.name>: <decl.var.type><ref.class usr="s:8MyModule14UserCollectionC">UserCollection</ref.class></decl.var.type></decl.var.class>
+
+// RUN: %sourcekitd-test -req=cursor -pos=5:18 %t/test.swift -- %t/test.swift -I %t/Modules| %FileCheck %s --check-prefix=SHARED_COMPUTED_CLASS
+
+// SHARED_COMPUTED_CLASS: <Declaration>class var sharedComputedClass: <Type usr="s:8MyModule14UserCollectionC">UserCollection</Type> { get }</Declaration>
+// SHARED_COMPUTED_CLASS: <decl.var.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>sharedComputedClass</decl.name>: <decl.var.type><ref.class usr="s:8MyModule14UserCollectionC">UserCollection</ref.class></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.class>

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -519,7 +519,8 @@ struct CursorSymbolInfo {
 
   llvm::Optional<unsigned> ParentNameOffset;
 
-  void print(llvm::raw_ostream &OS, std::string Indentation) const {
+  void print(llvm::raw_ostream &OS, std::string Indentation,
+             bool ForSolverBasedCursorInfoVerification = false) const {
     OS << Indentation << "CursorSymbolInfo" << '\n';
     OS << Indentation << "  Kind: " << Kind.getName() << '\n';
     OS << Indentation << "  DeclarationLang: " << DeclarationLang.getName()
@@ -528,7 +529,14 @@ struct CursorSymbolInfo {
     OS << Indentation << "  USR: " << USR << '\n';
     OS << Indentation << "  TypeName: " << TypeName << '\n';
     OS << Indentation << "  TypeUSR: " << TypeUSR << '\n';
-    OS << Indentation << "  ContainerTypeUSR: " << ContainerTypeUSR << '\n';
+    // The ContainerTypeUSR varies too much between the solver-based and
+    // AST-based implementation. A few manual inspections showed that the
+    // solver-based container is usually more correct than the old. Instead of
+    // fixing the AST-based container type computation, exclude the container
+    // type from the verification.
+    if (!ForSolverBasedCursorInfoVerification) {
+      OS << Indentation << "  ContainerTypeUSR: " << ContainerTypeUSR << '\n';
+    }
     OS << Indentation << "  DocComment: " << DocComment << '\n';
     OS << Indentation << "  GroupName: " << GroupName << '\n';
     OS << Indentation << "  LocalizationKey: " << LocalizationKey << '\n';
@@ -600,7 +608,7 @@ struct CursorInfoData {
     OS << Indentation << "CursorInfoData" << '\n';
     OS << Indentation << "  Symbols:" << '\n';
     for (auto Symbol : Symbols) {
-      Symbol.print(OS, Indentation + "    ");
+      Symbol.print(OS, Indentation + "    ", ForSolverBasedCursorInfoVerification);
     }
     OS << Indentation << "  AvailableActions:" << '\n';
     for (auto AvailableAction : AvailableActions) {

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -519,8 +519,7 @@ struct CursorSymbolInfo {
 
   llvm::Optional<unsigned> ParentNameOffset;
 
-  void print(llvm::raw_ostream &OS, std::string Indentation,
-             bool ForSolverBasedCursorInfoVerification = false) const {
+  void print(llvm::raw_ostream &OS, std::string Indentation) const {
     OS << Indentation << "CursorSymbolInfo" << '\n';
     OS << Indentation << "  Kind: " << Kind.getName() << '\n';
     OS << Indentation << "  DeclarationLang: " << DeclarationLang.getName()
@@ -529,14 +528,7 @@ struct CursorSymbolInfo {
     OS << Indentation << "  USR: " << USR << '\n';
     OS << Indentation << "  TypeName: " << TypeName << '\n';
     OS << Indentation << "  TypeUSR: " << TypeUSR << '\n';
-    // The ContainerTypeUSR varies too much between the solver-based and
-    // AST-based implementation. A few manual inspections showed that the
-    // solver-based container is usually more correct than the old. Instead of
-    // fixing the AST-based container type computation, exclude the container
-    // type from the verification.
-    if (!ForSolverBasedCursorInfoVerification) {
-      OS << Indentation << "  ContainerTypeUSR: " << ContainerTypeUSR << '\n';
-    }
+    OS << Indentation << "  ContainerTypeUSR: " << ContainerTypeUSR << '\n';
     OS << Indentation << "  DocComment: " << DocComment << '\n';
     OS << Indentation << "  GroupName: " << GroupName << '\n';
     OS << Indentation << "  LocalizationKey: " << LocalizationKey << '\n';
@@ -600,23 +592,17 @@ struct CursorInfoData {
   /// Whether the ASTContext was reused for this cursor info.
   bool DidReuseAST = false;
 
-  /// If \p ForSolverBasedCursorInfoVerification is \c true, fields that are
-  /// acceptable to differ between the AST-based and the solver-based result,
-  /// will be excluded.
-  void print(llvm::raw_ostream &OS, std::string Indentation,
-             bool ForSolverBasedCursorInfoVerification = false) const {
+  void print(llvm::raw_ostream &OS, std::string Indentation) const {
     OS << Indentation << "CursorInfoData" << '\n';
     OS << Indentation << "  Symbols:" << '\n';
     for (auto Symbol : Symbols) {
-      Symbol.print(OS, Indentation + "    ", ForSolverBasedCursorInfoVerification);
+      Symbol.print(OS, Indentation + "    ");
     }
     OS << Indentation << "  AvailableActions:" << '\n';
     for (auto AvailableAction : AvailableActions) {
       AvailableAction.print(OS, Indentation + "    ");
     }
-    if (!ForSolverBasedCursorInfoVerification) {
-      OS << Indentation << "DidReuseAST: " << DidReuseAST << '\n';
-    }
+    OS << Indentation << "DidReuseAST: " << DidReuseAST << '\n';
   }
 
   SWIFT_DEBUG_DUMP { print(llvm::errs(), ""); }
@@ -973,7 +959,6 @@ public:
       bool SymbolGraph, bool CancelOnSubsequentRequest,
       ArrayRef<const char *> Args, Optional<VFSOptions> vfsOptions,
       SourceKitCancellationToken CancellationToken,
-      bool VerifySolverBasedCursorInfo,
       std::function<void(const RequestResult<CursorInfoData> &)> Receiver) = 0;
 
   virtual void

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -637,7 +637,6 @@ public:
                      ArrayRef<const char *> Args,
                      Optional<VFSOptions> vfsOptions,
                      SourceKitCancellationToken CancellationToken,
-                     bool VerifySolverBasedCursorInfo,
                      std::function<void(const RequestResult<CursorInfoData> &)>
                          Receiver) override;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1913,7 +1913,6 @@ void SwiftLangSupport::getCursorInfo(
     bool SymbolGraph, bool CancelOnSubsequentRequest,
     ArrayRef<const char *> Args, Optional<VFSOptions> vfsOptions,
     SourceKitCancellationToken CancellationToken,
-    bool VerifySolverBasedCursorInfo,
     std::function<void(const RequestResult<CursorInfoData> &)> Receiver) {
 
   std::string error;
@@ -1963,141 +1962,46 @@ void SwiftLangSupport::getCursorInfo(
     return;
   }
 
-  /// Counts how many symbols \p Res contains.
-  auto ResultCount = [](const RequestResult<CursorInfoData> &Res) -> size_t {
-    if (Res.isValue()) {
-      return Res.value().Symbols.size();
-    } else {
-      return 0;
-    }
-  };
+  bool SolverBasedProducedResult = false;
+  std::string InputFileError;
+  llvm::SmallString<64> RealInputFilePath;
+  fileSystem->getRealPath(InputFile, RealInputFilePath);
+  std::unique_ptr<llvm::MemoryBuffer> UnresolvedInputFile =
+      getASTManager()->getMemoryBuffer(RealInputFilePath, fileSystem,
+                                       InputFileError);
+  if (UnresolvedInputFile) {
+    auto SolverBasedReceiver = [&](const RequestResult<CursorInfoData> &Res) {
+      SolverBasedProducedResult = true;
+      Receiver(Res);
+    };
 
-  /// Serializes \c CursorInfoData into a string.
-  auto ResultDescription =
-      [](const RequestResult<CursorInfoData> &Res) -> std::string {
-    if (Res.isCancelled()) {
-      return "cancelled";
-    } else if (Res.isError()) {
-      return Res.getError().str();
-    } else {
-      std::string Description;
-      llvm::raw_string_ostream OS(Description);
-      Res.value().print(OS, /*Indentation=*/"",
-                        /*ForSolverBasedCursorInfoVerification=*/true);
-      return OS.str();
-    }
-  };
+    CompilerInvocation CompInvok;
+    Invok->applyTo(CompInvok);
 
-  // Currently, we only verify that the solver-based cursor implementation
-  // produces the same results as the AST-based implementation. Only enable it
-  // in assert builds for now.
-
-  // If solver based completion is enabled, a string description of the cursor
-  // info result produced by the solver-based implementation. Once the AST-based
-  // result is produced, we verify that the solver-based result matches the
-  // AST-based result.
-  std::string SolverBasedResultDescription;
-  size_t SolverBasedResultCount = 0;
-  bool SolverBasedReusedAST = false;
-  if (VerifySolverBasedCursorInfo) {
-    std::string InputFileError;
-    llvm::SmallString<64> RealInputFilePath;
-    fileSystem->getRealPath(InputFile, RealInputFilePath);
-    std::unique_ptr<llvm::MemoryBuffer> UnresolvedInputFile =
-        getASTManager()->getMemoryBuffer(RealInputFilePath, fileSystem,
-                                         InputFileError);
-    if (UnresolvedInputFile) {
-      auto SolverBasedReceiver = [&](const RequestResult<CursorInfoData> &Res) {
-        SolverBasedResultCount = ResultCount(Res);
-        SolverBasedResultDescription = ResultDescription(Res);
-        if (Res.isValue()) {
-          SolverBasedReusedAST = Res.value().DidReuseAST;
-        }
-      };
-
-      CompilerInvocation CompInvok;
-      Invok->applyTo(CompInvok);
-
-      performWithParamsToCompletionLikeOperation(
-          UnresolvedInputFile.get(), Offset,
-          /*InsertCodeCompletionToken=*/false, Args, fileSystem,
-          CancellationToken,
-          [&](CancellableResult<CompletionLikeOperationParams> ParmsResult) {
-            ParmsResult.mapAsync<CursorInfoResults>(
-                [&](auto &Params, auto DeliverTransformed) {
-                  getIDEInspectionInstance()->cursorInfo(
-                      Params.Invocation, Args, fileSystem,
-                      Params.completionBuffer, Offset, Params.DiagC,
-                      Params.CancellationFlag, DeliverTransformed);
-                },
-                [&](auto Result) {
-                  deliverCursorInfoResults(SolverBasedReceiver, Result, *this,
-                                           CompInvok, Actionables, SymbolGraph);
-                });
-          });
-    }
+    performWithParamsToCompletionLikeOperation(
+        UnresolvedInputFile.get(), Offset,
+        /*InsertCodeCompletionToken=*/false, Args, fileSystem,
+        CancellationToken,
+        [&](CancellableResult<CompletionLikeOperationParams> ParmsResult) {
+          ParmsResult.mapAsync<CursorInfoResults>(
+              [&](auto &Params, auto DeliverTransformed) {
+                getIDEInspectionInstance()->cursorInfo(
+                    Params.Invocation, Args, fileSystem,
+                    Params.completionBuffer, Offset, Params.DiagC,
+                    Params.CancellationFlag, DeliverTransformed);
+              },
+              [&](auto Result) {
+                deliverCursorInfoResults(SolverBasedReceiver, Result, *this,
+                                         CompInvok, Actionables, SymbolGraph);
+              });
+        });
   }
 
-  /// If the solver-based implementation returned a different result than the
-  /// AST-based implementation, return an error message, describing the
-  /// difference. Otherwise, return an empty string.
-  auto VerifySolverBasedResult =
-      [ResultCount, ResultDescription, SolverBasedResultCount,
-       SolverBasedResultDescription](
-          const RequestResult<CursorInfoData> &ASTBasedResult) -> std::string {
-    if (SolverBasedResultDescription.empty()) {
-      // We did not run the solver-based implementation. Nothing to check.
-      return "";
-    }
-    auto ASTResultDescription = ResultDescription(ASTBasedResult);
-    auto ASTResultCount = ResultCount(ASTBasedResult);
-    if (ASTResultCount == 0 && SolverBasedResultCount > 0) {
-      // The AST-based implementation did not return any results but the
-      // solver-based did. That's an improvement. Success.
-      return "";
-    }
-    if (SolverBasedResultDescription == ASTResultDescription) {
-      // The solver-based and AST-based implementation produced the same
-      // results. Success.
-      return "";
-    }
-    // The solver-based implementation differed from the AST-based
-    // implementation. Report a failure.
-    std::string ErrorMessage;
-    llvm::raw_string_ostream OS(ErrorMessage);
-    OS << "The solver-based implementation returned a different result than "
-          "the AST-based implementation:\n";
-    OS << SolverBasedResultDescription << "\n";
-    OS << "===== (solver-based vs. AST-based) =====\n";
-    OS << ASTResultDescription << "\n";
-    return OS.str();
-  };
-
-  // Thunk around `Receiver` that, if solver-based cursor info is enabled,
-  // verifies that the solver-based cursor info result matches the AST-based
-  // result.
-  auto ReceiverThunk =
-      [Receiver, VerifySolverBasedResult,
-       SolverBasedReusedAST](const RequestResult<CursorInfoData> &Res) {
-        auto VerificationError = VerifySolverBasedResult(Res);
-        if (VerificationError.empty()) {
-          if (Res.isValue()) {
-            // Report whether the solver-based implemenatation reused the AST so
-            // we can check it in test cases.
-            auto Value = Res.value();
-            Value.DidReuseAST = SolverBasedReusedAST;
-            Receiver(RequestResult<CursorInfoData>::fromResult(Value));
-          } else {
-            Receiver(Res);
-          }
-        } else {
-          Receiver(RequestResult<CursorInfoData>::fromError(VerificationError));
-        }
-      };
-
-  resolveCursor(*this, InputFile, Offset, Length, Actionables, SymbolGraph,
-                Invok, /*TryExistingAST=*/true, CancelOnSubsequentRequest,
-                fileSystem, CancellationToken, ReceiverThunk);
+  if (!SolverBasedProducedResult) {
+    resolveCursor(*this, InputFile, Offset, Length, Actionables, SymbolGraph,
+                  Invok, /*TryExistingAST=*/true, CancelOnSubsequentRequest,
+                  fileSystem, CancellationToken, Receiver);
+  }
 }
 
 void SwiftLangSupport::getDiagnostics(

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -772,8 +772,6 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
     } else {
       sourcekitd_request_dictionary_set_int64(Req, KeyOffset, ByteOffset);
     }
-    sourcekitd_request_dictionary_set_int64(Req, KeyVerifySolverBasedCursorInfo,
-                                            true);
     addRequestOptionsDirect(Req, Opts);
     break;
   case SourceKitRequest::RangeInfo: {

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -1393,13 +1393,10 @@ handleRequestCursorInfo(const RequestDict &Req,
       Req.getInt64(KeyRetrieveRefactorActions, Actionables, /*isOptional=*/true);
       int64_t SymbolGraph = false;
       Req.getInt64(KeyRetrieveSymbolGraph, SymbolGraph, /*isOptional=*/true);
-      int64_t VerifySolverBasedCursorInfo = false;
-      Req.getInt64(KeyVerifySolverBasedCursorInfo, VerifySolverBasedCursorInfo,
-                   /*isOptional=*/true);
       return Lang.getCursorInfo(
           *SourceFile, Offset, Length, Actionables, SymbolGraph,
           CancelOnSubsequentRequest, Args, std::move(vfsOptions),
-          CancellationToken, VerifySolverBasedCursorInfo,
+          CancellationToken,
           [Rec](const RequestResult<CursorInfoData> &Result) {
             reportCursorInfo(Result, Rec);
           });

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -166,7 +166,6 @@ public:
         DocName, Offset, /*Length=*/0, /*Actionables=*/false,
         /*SymbolGraph=*/false, CancelOnSubsequentRequest, Args,
         /*vfsOptions=*/None, CancellationToken,
-        /*VerifySolverBasedCursorInfo=*/true,
         [&](const RequestResult<CursorInfoData> &Result) {
           assert(!Result.isCancelled());
           if (Result.isError()) {
@@ -452,7 +451,6 @@ TEST_F(CursorInfoTest, CursorInfoCancelsPreviousRequest) {
       SlowDocName, SlowOffset, /*Length=*/0, /*Actionables=*/false,
       /*SymbolGraph=*/false, /*CancelOnSubsequentRequest=*/true, ArgsForSlow,
       /*vfsOptions=*/None, /*CancellationToken=*/nullptr,
-      /*VerifySolverBasedCursorInfo=*/true,
       [&](const RequestResult<CursorInfoData> &Result) {
         EXPECT_TRUE(Result.isCancelled());
         FirstCursorInfoSema.signal();
@@ -496,7 +494,6 @@ TEST_F(CursorInfoTest, CursorInfoCancellation) {
       SlowDocName, SlowOffset, /*Length=*/0, /*Actionables=*/false,
       /*SymbolGraph=*/false, /*CancelOnSubsequentRequest=*/false, ArgsForSlow,
       /*vfsOptions=*/None, /*CancellationToken=*/CancellationToken,
-      /*VerifySolverBasedCursorInfo=*/true,
       [&](const RequestResult<CursorInfoData> &Result) {
         EXPECT_TRUE(Result.isCancelled());
         CursorInfoSema.signal();

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -189,7 +189,6 @@ UID_KEYS = [
     KEY('OptimizeForIDE', 'key.optimize_for_ide'),
     KEY('RequiredBystanders', 'key.required_bystanders'),
     KEY('ReusingASTContext', 'key.reusingastcontext'),
-    KEY('VerifySolverBasedCursorInfo', 'key.verifysolverbasedcursorinfo'),
     KEY('CompletionMaxASTContextReuseCount',
         'key.completion_max_astcontext_reuse_count'),
     KEY('CompletionCheckDependencyInterval',


### PR DESCRIPTION
This implements cursor info resolving for a few expression types using the constraint system. This allows us to detect ambiguous results – we cannot deliver them yet but that will be done in a follow-up PR.