### PR TITLE
[Compile Time Constant Extraction] Fix test failure

### DIFF
--- a/test/ConstExtraction/fields.swift
+++ b/test/ConstExtraction/fields.swift
@@ -160,7 +160,11 @@
 // CHECK-NEXT:        "type": "fields.Foo.Boo",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "true",
-// CHECK-NEXT:        "valueKind": "Runtime"
+// CHECK-NEXT:        "valueKind": "InitCall",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "type": "fields.Foo.Boo",
+// CHECK-NEXT:          "arguments": []
+// CHECK-NEXT:        }
 // CHECK-NEXT:      }
 // CHECK-NEXT:    ]
 // CHECK-NEXT:  }


### PR DESCRIPTION
https://github.com/apple/swift/pull/62465 introduced a change to statically extract variables from extensions.  https://github.com/apple/swift/pull/62461 added more throughout extractions of variable type information. When both changes were merged, it caused the tests from https://github.com/apple/swift/pull/62465 to be invalid. This fixes the test added in https://github.com/apple/swift/pull/62465.

Without this change, `ConstExtraction/fields.swift` will fail as it now expects to properly extract out an `InitCall` instead of `Runtime`.
 