### PR TITLE
test: simplify test and enable more broadly

### DIFF
--- a/test/Index/index_implicit_conversion.swift
+++ b/test/Index/index_implicit_conversion.swift
@@ -1,12 +1,11 @@
-// REQUIRES: objc_interop, concurrency
-
-// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-indexed-symbols -source-filename %s | %FileCheck %s
-
-import AppKit
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s | %FileCheck %s
+// REQUIRES: concurrency
 
 @MainActor
-class AppDelegate {
-  let window = NSWindow()
-  // CHECK: [[@LINE-1]]:16 | class/Swift | NSWindow | c:objc(cs)NSWindow | Ref,RelCont
-  // CHECK: [[@LINE-2]]:16 | constructor/Swift | init() | c:objc(cs)NSObject(im)init | Ref,Call,RelCont
+public struct S {
+  public init(_: @escaping () -> Void) { }
 }
+
+let s = S { }
+// CHECK: [[@LINE-1]]:9 | struct/Swift | S | s:14swift_ide_test1SV | Ref,RelCont
+// CHECK: [[@LINE-2]]:9 | constructor/Swift | init(_:) | s:14swift_ide_test1SVyACyyccfc | Ref,Call,RelCont


### PR DESCRIPTION
Use the implicit conversion of a closure to an actor isolated closure to trigger the assertion failure.  This allows us to test this more broadly on all platforms with concurrency.