### PR TITLE
[Reflection] Bounds-check vector creation in createBoundGenericTypeReconstructingParent.

### DIFF
--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -571,8 +571,13 @@ public:
 
     auto numGenericArgs = genericParamsPerLevel[shapeIndex];
 
+    auto startOffsetFromEnd = argsIndex + numGenericArgs;
+    auto endOffsetFromEnd = argsIndex;
+    if (startOffsetFromEnd > args.size() || endOffsetFromEnd > args.size())
+      return nullptr;
+
     std::vector<const TypeRef *> genericParams(
-        args.end() - argsIndex - numGenericArgs, args.end() - argsIndex);
+        args.end() - startOffsetFromEnd, args.end() - endOffsetFromEnd);
 
     const BoundGenericTypeRef *parent = nullptr;
     if (node->hasChildren()) {


### PR DESCRIPTION
If argsIndex or numGenericsArgs were out of bounds, we'd end up reading off the beginning or end of the args ArrayRef, resulting in memory allocation failures, segfaults, or reading garbage data. Check that we're reading within the bounds of the array, and fail gracefully if not.

rdar://103142856