### PR TITLE
Don't require a strict revision match in LLDB for tagged compilers.

### DIFF
--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -360,11 +360,9 @@ static ValidationInfo validateControlBlock(
       static const char* forcedDebugRevision =
         ::getenv("SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION");
 
-      bool isCompilerTagged = forcedDebugRevision ||
-        version::isCurrentCompilerTagged();
-
       StringRef moduleRevision = blobData;
-      if (isCompilerTagged) {
+      if (forcedDebugRevision ||
+          (requiresRevisionMatch && version::isCurrentCompilerTagged())) {
         StringRef compilerRevision = forcedDebugRevision ?
           forcedDebugRevision : version::getCurrentCompilerTag();
         if (moduleRevision != compilerRevision) {


### PR DESCRIPTION
This is a follow-up to 3cc2831608a22c87df24220348ac1695aa476276 because the relaxed checking introduced was being bypassed by the code block that checks for a tagged compiler.
