### PR TITLE
Cope with the various `#` tokens not being tokens in swift-syntax

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1107,8 +1107,9 @@ class ObjectLiteralExpr final : public LiteralExpr {
 public:
   /// The kind of object literal.
   enum LiteralKind : unsigned {
-#define POUND_OBJECT_LITERAL(Name, Desc, Proto) Name,
-#include "swift/AST/TokenKinds.def"
+    colorLiteral,
+    fileLiteral,
+    imageLiteral,
   };
 
 private:

--- a/include/swift/AST/TokenKinds.def.gyb
+++ b/include/swift/AST/TokenKinds.def.gyb
@@ -28,7 +28,7 @@
 ///       PAT_KEYWORD(kw)
 ///     SIL_KEYWORD(kw)
 ///   POUND_KEYWORD(kw)
-///     POUND_OBJECT_LITERAL(kw, desc, proto)
+///     POUND_OBJECT_LITERAL(kw)
 ///     POUND_CONFIG(kw)
 ///     POUND_DIRECTIVE_KEYWORD(kw)
 ///       POUND_COND_DIRECTIVE_KEYWORD(kw)
@@ -96,10 +96,10 @@
 #define POUND_KEYWORD(kw) TOKEN(pound_ ## kw)
 #endif
 
-/// POUND_OBJECT_LITERAL(kw, desc, proto)
+/// POUND_OBJECT_LITERAL(kw)
 ///   Every keyword prefixed with a '#' representing an object literal.
 #ifndef POUND_OBJECT_LITERAL
-#define POUND_OBJECT_LITERAL(kw, desc, proto) POUND_KEYWORD(kw)
+#define POUND_OBJECT_LITERAL(kw) POUND_KEYWORD(kw)
 #endif
 
 /// POUND_CONFIG(kw)
@@ -147,8 +147,6 @@
 % for token in SYNTAX_TOKENS:
 %   if isinstance(token, Token.Punctuator):
 ${token.macro_name()}(${token.unprefixed_kind}, "${token.text}")
-%   elif isinstance(token, Token.PoundObjectLiteral):
-${token.macro_name()}(${token.unprefixed_kind}, "${token.description}", ${token.protocol})
 %   else:
 ${token.macro_name()}(${token.unprefixed_kind})
 %   end
@@ -169,6 +167,28 @@ SIL_KEYWORD(sil_default_witness_table)
 SIL_KEYWORD(sil_differentiability_witness)
 SIL_KEYWORD(sil_coverage_map)
 SIL_KEYWORD(sil_scope)
+
+// These should be treated as normal identifiers, not keywords.
+KEYWORD(__COLUMN__)
+KEYWORD(__DSO_HANDLE__)
+KEYWORD(__FILE__)
+KEYWORD(__FUNCTION__)
+KEYWORD(__LINE__)
+
+// These will eventually be subsumed by macros.
+POUND_KEYWORD(column)
+POUND_KEYWORD(dsohandle)
+POUND_KEYWORD(file)
+POUND_KEYWORD(fileID)
+POUND_KEYWORD(filePath)
+POUND_KEYWORD(function)
+POUND_KEYWORD(keyPath)
+POUND_KEYWORD(line)
+POUND_KEYWORD(selector)
+
+POUND_OBJECT_LITERAL(colorLiteral)
+POUND_OBJECT_LITERAL(fileLiteral)
+POUND_OBJECT_LITERAL(imageLiteral)
 
 PUNCTUATOR(sil_dollar,    "$")    // Only in SIL mode.
 PUNCTUATOR(sil_exclamation, "!")    // Only in SIL mode.

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1186,16 +1186,18 @@ ObjectLiteralExpr::create(ASTContext &ctx, SourceLoc poundLoc, LiteralKind kind,
 
 StringRef ObjectLiteralExpr::getLiteralKindRawName() const {
   switch (getLiteralKind()) {
-#define POUND_OBJECT_LITERAL(Name, Desc, Proto) case Name: return #Name;
-#include "swift/AST/TokenKinds.def"    
+  case colorLiteral: return "colorLiteral";
+  case fileLiteral: return "fileLiteral";
+  case imageLiteral: return "imageLiteral";
   }
   llvm_unreachable("unspecified literal");
 }
 
 StringRef ObjectLiteralExpr::getLiteralKindPlainName() const {
   switch (getLiteralKind()) {
-#define POUND_OBJECT_LITERAL(Name, Desc, Proto) case Name: return Desc;
-#include "swift/AST/TokenKinds.def"    
+    case colorLiteral: return "color";
+    case fileLiteral: return "file reference";
+    case imageLiteral: return "image";
   }
   llvm_unreachable("unspecified literal");
 }

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -200,8 +200,8 @@ SyntaxModelContext::SyntaxModelContext(SourceFile &SrcFile)
         Kind = SyntaxNodeKind::PoundDirectiveKeyword;
         break;
 
-#define POUND_OBJECT_LITERAL(Name, Desc, Proto)
 #define POUND_DIRECTIVE_KEYWORD(Name)
+#define POUND_OBJECT_LITERAL(Name)
 #define POUND_KEYWORD(Name) case tok::pound_##Name:
 #include "swift/AST/TokenKinds.def"
         Kind = SyntaxNodeKind::Keyword;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1743,10 +1743,14 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
                                 ErrorExpr(res.get()->getSourceRange()));
   }
 
-#define POUND_OBJECT_LITERAL(Name, Desc, Proto)                                \
-  case tok::pound_##Name:                                                      \
-    return parseExprObjectLiteral(ObjectLiteralExpr::Name, isExprBasic);
-#include "swift/AST/TokenKinds.def"
+  case tok::pound_colorLiteral:
+    return parseExprObjectLiteral(ObjectLiteralExpr::colorLiteral, isExprBasic);
+
+  case tok::pound_fileLiteral:
+    return parseExprObjectLiteral(ObjectLiteralExpr::fileLiteral, isExprBasic);
+
+  case tok::pound_imageLiteral:
+    return parseExprObjectLiteral(ObjectLiteralExpr::imageLiteral, isExprBasic);
 
   case tok::code_complete: {
     auto Result =

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -142,11 +142,20 @@ ProtocolDecl *TypeChecker::getLiteralProtocol(ASTContext &Context, Expr *expr) {
 
   if (auto E = dyn_cast<ObjectLiteralExpr>(expr)) {
     switch (E->getLiteralKind()) {
-#define POUND_OBJECT_LITERAL(Name, Desc, Protocol)                             \
-  case ObjectLiteralExpr::Name:                                                \
-    return TypeChecker::getProtocol(Context, expr->getLoc(),                   \
-                                    KnownProtocolKind::Protocol);
-#include "swift/AST/TokenKinds.def"
+    case ObjectLiteralExpr::colorLiteral:
+      return TypeChecker::getProtocol(
+          Context, expr->getLoc(),
+          KnownProtocolKind::ExpressibleByColorLiteral);
+
+    case ObjectLiteralExpr::fileLiteral:
+      return TypeChecker::getProtocol(
+          Context, expr->getLoc(),
+          KnownProtocolKind::ExpressibleByFileReferenceLiteral);
+
+    case ObjectLiteralExpr::imageLiteral:
+      return TypeChecker::getProtocol(
+          Context, expr->getLoc(),
+          KnownProtocolKind::ExpressibleByImageLiteral);
     }
   }
 


### PR DESCRIPTION
We're moving away from things like `#line` and `#colorLiteral(red:green:blue:alpha:)` being special grammar terms, and instead looking to make them macro expansion expressions with built-in macros. swift-syntax is making the switch now, so cope with those changes.