### PR TITLE
[ConstraintSystem] Reject property wrapper transform on func paramete…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1403,6 +1403,15 @@ unwrapPropertyWrapperParameterTypes(ConstraintSystem &cs, AbstractFunctionDecl *
     return functionType;
   }
 
+  // This transform is not applicable to pattern matching context.
+  //
+  // Note: If the transform is ever enabled for patterns - new branch
+  // would have to be added to `nameLoc` selection.
+  if (auto last = locator.last()) {
+    if (last->is<LocatorPathElt::PatternMatch>())
+      return functionType;
+  }
+
   auto *paramList = funcDecl->getParameters();
   auto paramTypes = functionType->getParams();
   SmallVector<AnyFunctionType::Param, 4> adjustedParamTypes;

--- a/validation-test/Sema/SwiftUI/case_with_overloaded_elements_in_optional_context.swift
+++ b/validation-test/Sema/SwiftUI/case_with_overloaded_elements_in_optional_context.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx10.15 -swift-version 5 -enable-experimental-feature ResultBuilderASTTransform -
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+struct Person {
+  var fullName: String
+}
+
+enum State<Input, Output, Failure: Error> {
+  case success(Input, Output)
+  case failure(Input, Failure)
+}
+
+// Type-checker finds this overload based on
+// `extension Optional : View where Wrapped : View { ... }`
+extension View {
+  func failure(_: String) -> some View { EmptyView() }
+}
+
+struct MyTest : View {
+  var state: State<Person, UUID, Error>?
+
+  // `switch` has to be anchored on `AccessorDecl` to reproduce
+  // a crash.
+  var body: some View {
+    switch state {
+    case nil:
+      Text("nil")
+    case .success(let person, _), .failure(let person, _):
+      Text(person.fullName)
+    }
+  }
+}


### PR DESCRIPTION
…rs in pattern context

The transform is not currently supported on anything but regular calls.

There is no crash without `ResultBuilderASTTransform` enabled because pattern ends
up anchored on synthesized `OneWayExpr`.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
