### PR TITLE
[rebranch][Runtime] Remove attribute ordering hack

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -168,14 +168,6 @@ extern uintptr_t __COMPATIBILITY_LIBRARIES_CANNOT_CHECK_THE_IS_SWIFT_BIT_DIRECTL
 // Bring in visibility attribute macros
 #include "swift/shims/Visibility.h"
 
-// Temporary definitions to allow compilation on clang-15.
-#if defined(__cplusplus)
-#define SWIFT_EXTERN_C extern "C"
-#else
-#define SWIFT_EXTERN_C
-#endif
-#define SWIFT_RUNTIME_EXPORT_ATTRIBUTE SWIFT_EXPORT_FROM_ATTRIBUTE(swiftCore)
-
 // Define mappings for calling conventions.
 
 // Annotation for specifying a calling convention of

--- a/include/swift/Runtime/Heap.h
+++ b/include/swift/Runtime/Heap.h
@@ -29,7 +29,7 @@ namespace swift {
 // Never returns nil. The returned memory is uninitialized. 
 //
 // An "alignment mask" is just the alignment (a power of 2) minus 1.
-SWIFT_EXTERN_C SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT_ATTRIBUTE
+SWIFT_RUNTIME_EXPORT SWIFT_RETURNS_NONNULL SWIFT_NODISCARD
 void *swift_slowAlloc(size_t bytes, size_t alignMask);
 
 // If the caller cannot promise to zero the object during destruction,

--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -61,7 +61,7 @@ struct OpaqueValue;
 ///
 /// POSSIBILITIES: The argument order is fair game.  It may be useful
 /// to have a variant which guarantees zero-initialized memory.
-SWIFT_EXTERN_C SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT_ATTRIBUTE
+SWIFT_RUNTIME_EXPORT SWIFT_RETURNS_NONNULL SWIFT_NODISCARD
 HeapObject *swift_allocObject(HeapMetadata const *metadata,
                               size_t requiredSize,
                               size_t requiredAlignmentMask);
@@ -117,7 +117,7 @@ BoxPair swift_makeBoxUnique(OpaqueValue *buffer, Metadata const *type,
                                     size_t alignMask);
 
 /// Returns the address of a heap object representing all empty box types.
-SWIFT_EXTERN_C SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT_ATTRIBUTE
+SWIFT_RUNTIME_EXPORT SWIFT_RETURNS_NONNULL SWIFT_NODISCARD
 HeapObject* swift_allocEmptyBox();
 
 /// Atomically increments the retain count of an object.

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -313,7 +313,7 @@ swift_getGenericMetadata(MetadataRequest request,
 ///   - installing new v-table entries and overrides; and
 ///   - registering the class with the runtime under ObjC interop.
 /// Most of this work can be achieved by calling swift_initClassMetadata.
-SWIFT_EXTERN_C SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT_ATTRIBUTE
+SWIFT_RUNTIME_EXPORT SWIFT_RETURNS_NONNULL SWIFT_NODISCARD
 ClassMetadata *
 swift_allocateGenericClassMetadata(const ClassDescriptor *description,
                                    const void *arguments,
@@ -322,7 +322,7 @@ swift_allocateGenericClassMetadata(const ClassDescriptor *description,
 /// Allocate a generic value metadata object.  This is intended to be
 /// called by the metadata instantiation function of a generic struct or
 /// enum.
-SWIFT_EXTERN_C SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT_ATTRIBUTE
+SWIFT_RUNTIME_EXPORT SWIFT_RETURNS_NONNULL SWIFT_NODISCARD
 ValueMetadata *
 swift_allocateGenericValueMetadata(const ValueTypeDescriptor *description,
                                    const void *arguments,

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -30,7 +30,6 @@
 #include "swift/ClangImporter/ClangModule.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/IRGen/Linking.h"
-#include "swift/Runtime/HeapObject.h"
 #include "swift/SIL/FormalLinkage.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILModule.h"

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -882,6 +882,10 @@ mixin-preset=
     mixin_lightweight_assertions,no-stdlib-asserts
     buildbot_linux_base
 
+verbose
+extra-cmake-options=
+  --trace-expand
+
 [preset: buildbot_linux,no_assertions]
 mixin-preset=buildbot_linux_base
 


### PR DESCRIPTION
Remove the split macro definitions and move the SWIFT_RUNTIME_EXPORT
macro to the beginning of the attributes list so that `extern "C"`
becomes the first attribute. This is possible since stable/20221013
where mixing GNU and standard attributes was fixed
(https://reviews.llvm.org/D137979).

Also remove an unnecessary include, which would prevent the compiler
itself being built on the released clang-15 (since the GNU/standard
attribute mixing fix isn't in clang-15).