### PR TITLE
Sema: Don't diagnose explicitly unavailable decls as "more available than unavailable scope"

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1903,11 +1903,14 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
 
   if (EnclosingDecl) {
     if (EnclosingDeclIsUnavailable) {
-      diagnose(D->isImplicit() ? EnclosingDecl->getLoc() : attr->getLocation(),
-               diag::availability_decl_more_than_unavailable_enclosing,
-               D->getDescriptiveKind());
-      diagnose(EnclosingDecl->getLoc(),
-               diag::availability_decl_more_than_unavailable_enclosing_here);
+      if (!AttrRange.isKnownUnreachable()) {
+        diagnose(D->isImplicit() ? EnclosingDecl->getLoc()
+                                 : attr->getLocation(),
+                 diag::availability_decl_more_than_unavailable_enclosing,
+                 D->getDescriptiveKind());
+        diagnose(EnclosingDecl->getLoc(),
+                 diag::availability_decl_more_than_unavailable_enclosing_here);
+      }
     } else if (!AttrRange.isContainedIn(EnclosingAnnotatedRange.value())) {
       diagnose(D->isImplicit() ? EnclosingDecl->getLoc() : attr->getLocation(),
                diag::availability_decl_more_than_enclosing,

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -625,6 +625,12 @@ class ClassAvailableOn10_51 { // expected-note {{enclosing scope requires availa
   @available(OSX, introduced: 10.9) // expected-error {{instance method cannot be more available than enclosing scope}}
   func someMethodAvailableOn10_9() { }
 
+  @available(OSX, unavailable)
+  func someMethodUnavailable() { }
+
+  @available(*, unavailable)
+  func someMethodUniversallyUnavailable() { }
+
   @available(OSX, introduced: 10.52)
   var propWithGetter: Int { // expected-note{{enclosing scope requires availability of macOS 10.52 or newer}}
     @available(OSX, introduced: 10.51) // expected-error {{getter cannot be more available than enclosing scope}}

--- a/test/attr/attr_availability_transitive_osx.swift
+++ b/test/attr/attr_availability_transitive_osx.swift
@@ -129,6 +129,16 @@ extension Outer {
   func osx_more_available_but_still_unavailable_call_osx() {
     osx() // OK
   }
+
+  @available(OSX, unavailable)
+  func osx_double_unavailable_call_osx() {
+    osx() // OK
+  }
+
+  @available(*, unavailable)
+  func osx_universally_unavailable_call_osx() {
+    osx() // OK
+  }
   
   // rdar://92551870
   func osx_call_osx_more_available_but_still_unavailable() {


### PR DESCRIPTION
Fixes a logic error introduced in https://github.com/apple/swift/pull/61242.

Resolves rdar://102877953
