### PR TITLE
[SIL] Removed Indirect_In_Constant convention.

### DIFF
--- a/SwiftCompilerSources/Sources/SIL/Argument.swift
+++ b/SwiftCompilerSources/Sources/SIL/Argument.swift
@@ -87,11 +87,6 @@ public enum ArgumentConvention {
   case indirectIn
 
   /// This argument is passed indirectly, i.e. by directly passing the address
-  /// of an object in memory.  The callee must treat the object as read-only
-  /// The callee may assume that the address does not alias any valid object.
-  case indirectInConstant
-
-  /// This argument is passed indirectly, i.e. by directly passing the address
   /// of an object in memory.  The callee may not modify and does not destroy
   /// the object.
   case indirectInGuaranteed
@@ -130,7 +125,7 @@ public enum ArgumentConvention {
 
   public var isIndirect: Bool {
     switch self {
-    case .indirectIn, .indirectInConstant, .indirectInGuaranteed,
+    case .indirectIn, .indirectInGuaranteed,
          .indirectInout, .indirectInoutAliasable, .indirectOut:
       return true
     case .directOwned, .directUnowned, .directGuaranteed:
@@ -140,7 +135,7 @@ public enum ArgumentConvention {
 
   public var isIndirectIn: Bool {
     switch self {
-    case .indirectIn, .indirectInConstant, .indirectInGuaranteed:
+    case .indirectIn, .indirectInGuaranteed:
       return true
     case .directOwned, .directUnowned, .directGuaranteed,
          .indirectInout, .indirectInoutAliasable, .indirectOut:
@@ -152,7 +147,7 @@ public enum ArgumentConvention {
     switch self {
     case .indirectInGuaranteed, .directGuaranteed:
       return true
-    case .indirectIn, .indirectInConstant, .directOwned, .directUnowned,
+    case .indirectIn, .directOwned, .directUnowned,
          .indirectInout, .indirectInoutAliasable, .indirectOut:
       return false
     }
@@ -161,7 +156,6 @@ public enum ArgumentConvention {
   public var isExclusiveIndirect: Bool {
     switch self {
     case .indirectIn,
-         .indirectInConstant,
          .indirectOut,
          .indirectInGuaranteed,
          .indirectInout:
@@ -182,7 +176,6 @@ public enum ArgumentConvention {
       return true
 
     case .indirectIn,
-         .indirectInConstant,
          .indirectOut,
          .indirectInGuaranteed,
          .directUnowned,
@@ -205,7 +198,6 @@ extension BridgedArgumentConvention {
   var convention: ArgumentConvention {
     switch self {
       case ArgumentConvention_Indirect_In:             return .indirectIn
-      case ArgumentConvention_Indirect_In_Constant:    return .indirectInConstant
       case ArgumentConvention_Indirect_In_Guaranteed:  return .indirectInGuaranteed
       case ArgumentConvention_Indirect_Inout:          return .indirectInout
       case ArgumentConvention_Indirect_InoutAliasable: return .indirectInoutAliasable

--- a/SwiftCompilerSources/Sources/SIL/Effects.swift
+++ b/SwiftCompilerSources/Sources/SIL/Effects.swift
@@ -491,7 +491,7 @@ public struct SideEffects : CustomStringConvertible, NoReflectionChildren {
         result.ownership = SideEffects.Ownership()
       }
       switch convention {
-      case .indirectIn, .indirectInConstant:
+      case .indirectIn:
         result.memory.write = false
       case .indirectInGuaranteed:
         result.memory.write = false

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3708,11 +3708,6 @@ enum class ParameterConvention : uint8_t {
   Indirect_In,
 
   /// This argument is passed indirectly, i.e. by directly passing the address
-  /// of an object in memory.  The callee must treat the object as read-only
-  /// The callee may assume that the address does not alias any valid object.
-  Indirect_In_Constant,
-
-  /// This argument is passed indirectly, i.e. by directly passing the address
   /// of an object in memory.  The callee may not modify and does not destroy
   /// the object.
   Indirect_In_Guaranteed,
@@ -3754,7 +3749,6 @@ static_assert(unsigned(ParameterConvention::Direct_Guaranteed) < (1<<3),
 inline bool isIndirectFormalParameter(ParameterConvention conv) {
   switch (conv) {
   case ParameterConvention::Indirect_In:
-  case ParameterConvention::Indirect_In_Constant:
   case ParameterConvention::Indirect_Inout:
   case ParameterConvention::Indirect_InoutAliasable:
   case ParameterConvention::Indirect_In_Guaranteed:
@@ -3770,7 +3764,6 @@ inline bool isIndirectFormalParameter(ParameterConvention conv) {
 inline bool isConsumedParameter(ParameterConvention conv) {
   switch (conv) {
   case ParameterConvention::Indirect_In:
-  case ParameterConvention::Indirect_In_Constant:
   case ParameterConvention::Direct_Owned:
     return true;
 
@@ -3796,7 +3789,6 @@ inline bool isGuaranteedParameter(ParameterConvention conv) {
   case ParameterConvention::Indirect_Inout:
   case ParameterConvention::Indirect_InoutAliasable:
   case ParameterConvention::Indirect_In:
-  case ParameterConvention::Indirect_In_Constant:
   case ParameterConvention::Direct_Unowned:
   case ParameterConvention::Direct_Owned:
     return false;

--- a/include/swift/SIL/ApplySite.h
+++ b/include/swift/SIL/ApplySite.h
@@ -386,7 +386,6 @@ public:
       return pai->isOnStack() ? SILArgumentConvention::Direct_Guaranteed
                               : SILArgumentConvention::Direct_Owned;
     case SILArgumentConvention::Indirect_In:
-    case SILArgumentConvention::Indirect_In_Constant:
     case SILArgumentConvention::Indirect_In_Guaranteed:
       return pai->isOnStack() ? SILArgumentConvention::Indirect_In_Guaranteed
                               : SILArgumentConvention::Indirect_In;

--- a/include/swift/SIL/SILArgumentConvention.h
+++ b/include/swift/SIL/SILArgumentConvention.h
@@ -25,7 +25,6 @@ namespace swift {
 struct SILArgumentConvention {
   enum ConventionType : uint8_t {
     Indirect_In,
-    Indirect_In_Constant,
     Indirect_In_Guaranteed,
     Indirect_Inout,
     Indirect_InoutAliasable,
@@ -42,9 +41,6 @@ struct SILArgumentConvention {
     switch (Conv) {
     case ParameterConvention::Indirect_In:
       Value = SILArgumentConvention::Indirect_In;
-      return;
-    case ParameterConvention::Indirect_In_Constant:
-      Value = SILArgumentConvention::Indirect_In_Constant;
       return;
     case ParameterConvention::Indirect_Inout:
       Value = SILArgumentConvention::Indirect_Inout;
@@ -81,7 +77,6 @@ struct SILArgumentConvention {
         return true;
       case SILArgumentConvention::Indirect_In_Guaranteed:
       case SILArgumentConvention::Indirect_In:
-      case SILArgumentConvention::Indirect_In_Constant:
       case SILArgumentConvention::Indirect_Out:
       case SILArgumentConvention::Direct_Unowned:
       case SILArgumentConvention::Direct_Owned:
@@ -94,7 +89,6 @@ struct SILArgumentConvention {
   bool isOwnedConvention() const {
     switch (Value) {
     case SILArgumentConvention::Indirect_In:
-    case SILArgumentConvention::Indirect_In_Constant:
     case SILArgumentConvention::Direct_Owned:
       return true;
     case SILArgumentConvention::Indirect_In_Guaranteed:
@@ -115,7 +109,6 @@ struct SILArgumentConvention {
       return true;
     case SILArgumentConvention::Indirect_Inout:
     case SILArgumentConvention::Indirect_In:
-    case SILArgumentConvention::Indirect_In_Constant:
     case SILArgumentConvention::Indirect_Out:
     case SILArgumentConvention::Indirect_InoutAliasable:
     case SILArgumentConvention::Direct_Unowned:
@@ -129,7 +122,6 @@ struct SILArgumentConvention {
   bool isExclusiveIndirectParameter() {
     switch (Value) {
     case SILArgumentConvention::Indirect_In:
-    case SILArgumentConvention::Indirect_In_Constant:
     case SILArgumentConvention::Indirect_Out:
     case SILArgumentConvention::Indirect_In_Guaranteed:
     case SILArgumentConvention::Indirect_Inout:

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -186,7 +186,6 @@ typedef enum {
 
 typedef enum {
   ArgumentConvention_Indirect_In,
-  ArgumentConvention_Indirect_In_Constant,
   ArgumentConvention_Indirect_In_Guaranteed,
   ArgumentConvention_Indirect_Inout,
   ArgumentConvention_Indirect_InoutAliasable,

--- a/include/swift/SIL/SILFunctionConventions.h
+++ b/include/swift/SIL/SILFunctionConventions.h
@@ -519,7 +519,6 @@ inline bool SILModuleConventions::isIndirectSILParam(SILParameterInfo param,
     return false;
 
   case ParameterConvention::Indirect_In:
-  case ParameterConvention::Indirect_In_Constant:
   case ParameterConvention::Indirect_In_Guaranteed:
     return (loweredAddresses ||
             param.getInterfaceType()->isOpenedExistentialWithError());

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -422,9 +422,8 @@ static ParameterConvention
 getParameterConvention(ImplParameterConvention conv) {
   switch (conv) {
   case Demangle::ImplParameterConvention::Indirect_In:
-    return ParameterConvention::Indirect_In;
   case Demangle::ImplParameterConvention::Indirect_In_Constant:
-    return ParameterConvention::Indirect_In_Constant;
+    return ParameterConvention::Indirect_In;
   case Demangle::ImplParameterConvention::Indirect_In_Guaranteed:
     return ParameterConvention::Indirect_In_Guaranteed;
   case Demangle::ImplParameterConvention::Indirect_Inout:

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1861,8 +1861,6 @@ static char getParamConvention(ParameterConvention conv) {
   // different places.
   switch (conv) {
     case ParameterConvention::Indirect_In: return 'i';
-    case ParameterConvention::Indirect_In_Constant:
-      return 'c';
     case ParameterConvention::Indirect_Inout: return 'l';
     case ParameterConvention::Indirect_InoutAliasable: return 'b';
     case ParameterConvention::Indirect_In_Guaranteed: return 'n';

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -6197,7 +6197,6 @@ public:
       Printer << "@callee_guaranteed ";
       return;
     case ParameterConvention::Indirect_In:
-    case ParameterConvention::Indirect_In_Constant:
     case ParameterConvention::Indirect_Inout:
     case ParameterConvention::Indirect_InoutAliasable:
     case ParameterConvention::Indirect_In_Guaranteed:
@@ -6815,8 +6814,6 @@ std::string GenericSignature::getAsString() const {
 static StringRef getStringForParameterConvention(ParameterConvention conv) {
   switch (conv) {
   case ParameterConvention::Indirect_In: return "@in ";
-  case ParameterConvention::Indirect_In_Constant:
-    return "@in_constant ";
   case ParameterConvention::Indirect_In_Guaranteed:  return "@in_guaranteed ";
   case ParameterConvention::Indirect_Inout: return "@inout ";
   case ParameterConvention::Indirect_InoutAliasable: return "@inout_aliasable ";

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1533,7 +1533,6 @@ const TypeInfo &SignatureExpansion::expand(SILParameterInfo param) {
   auto &ti = IGM.getTypeInfo(paramSILType);
   switch (auto conv = param.getConvention()) {
   case ParameterConvention::Indirect_In:
-  case ParameterConvention::Indirect_In_Constant:
   case ParameterConvention::Indirect_In_Guaranteed:
     addIndirectValueParameterAttributes(IGM, Attrs, ti, ParamIRTypes.size());
     addPointerParameter(IGM.getStorageType(getSILFuncConventions().getSILType(

--- a/lib/IRGen/GenDistributed.cpp
+++ b/lib/IRGen/GenDistributed.cpp
@@ -459,8 +459,7 @@ void DistributedAccessor::decodeArgument(unsigned argumentIdx,
   }
 
   switch (param.getConvention()) {
-  case ParameterConvention::Indirect_In:
-  case ParameterConvention::Indirect_In_Constant: {
+  case ParameterConvention::Indirect_In: {
     // The only way to load opaque type is to allocate a temporary
     // variable on the stack for it and initialize from the given address
     // either at +0 or +1 depending on convention.

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -707,7 +707,6 @@ CanType irgen::getArgumentLoweringType(CanType type, SILParameterInfo paramInfo,
   // closures don't take ownership of their arguments so we just capture the
   // address.
   case ParameterConvention::Indirect_In:
-  case ParameterConvention::Indirect_In_Constant:
   case ParameterConvention::Indirect_In_Guaranteed:
     if (isNoEscape)
       return CanInOutType::get(type);
@@ -1341,7 +1340,6 @@ static llvm::Value *emitPartialApplicationForwarder(IRGenModule &IGM,
   case ParameterConvention::Indirect_Inout:
   case ParameterConvention::Indirect_InoutAliasable:
   case ParameterConvention::Indirect_In:
-  case ParameterConvention::Indirect_In_Constant:
   case ParameterConvention::Indirect_In_Guaranteed:
     llvm_unreachable("indirect callables not supported");
   }
@@ -1450,7 +1448,6 @@ static llvm::Value *emitPartialApplicationForwarder(IRGenModule &IGM,
     auto argConvention = conventions[nextCapturedField++];
     switch (argConvention) {
     case ParameterConvention::Indirect_In:
-    case ParameterConvention::Indirect_In_Constant:
     case ParameterConvention::Direct_Owned:
       if (!consumesContext) subIGF.emitNativeStrongRetain(rawData, subIGF.getDefaultAtomicity());
       break;
@@ -1538,8 +1535,7 @@ static llvm::Value *emitPartialApplicationForwarder(IRGenModule &IGM,
       
       Explosion param;
       switch (fieldConvention) {
-      case ParameterConvention::Indirect_In:
-      case ParameterConvention::Indirect_In_Constant: {
+      case ParameterConvention::Indirect_In: {
 
         auto initStackCopy = [&addressesToDeallocate, &needsAllocas, &param,
                               &subIGF](const TypeInfo &fieldTI, SILType fieldTy,
@@ -2095,7 +2091,6 @@ Optional<StackAddress> irgen::emitFunctionPartialApplication(
       switch (argConventions[i]) {
       // Take indirect value arguments out of memory.
       case ParameterConvention::Indirect_In:
-      case ParameterConvention::Indirect_In_Constant:
       case ParameterConvention::Indirect_In_Guaranteed: {
         if (outType->isNoEscape()) {
           cast<LoadableTypeInfo>(fieldLayout.getType())

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -913,7 +913,6 @@ static llvm::Function *emitObjCPartialApplicationForwarder(IRGenModule &IGM,
     break;
   case ParameterConvention::Indirect_In_Guaranteed:
   case ParameterConvention::Indirect_In:
-  case ParameterConvention::Indirect_In_Constant:
   case ParameterConvention::Indirect_Inout:
   case ParameterConvention::Indirect_InoutAliasable:
     llvm_unreachable("self passed indirectly?!");

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -385,7 +385,6 @@ void PolymorphicConvention::considerParameter(SILParameterInfo param,
       // we don't bother, for no good reason. But if this is 'self',
       // consider passing an extra metatype.
     case ParameterConvention::Indirect_In:
-    case ParameterConvention::Indirect_In_Constant:
     case ParameterConvention::Indirect_In_Guaranteed:
     case ParameterConvention::Indirect_Inout:
     case ParameterConvention::Indirect_InoutAliasable:

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3546,7 +3546,6 @@ static bool isSimplePartialApply(IRGenFunction &IGF, PartialApplyInst *i) {
     // direct or indirect.
     switch (appliedParam.getConvention()) {
     case ParameterConvention::Indirect_Inout:
-    case ParameterConvention::Indirect_In_Constant:
     case ParameterConvention::Indirect_In_Guaranteed:
     case ParameterConvention::Indirect_InoutAliasable:
       // Indirect arguments are trivially word sized.

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -407,7 +407,7 @@ SILParameterInfo LargeSILTypeMapper::getNewParameter(GenericEnvironment *env,
                               param.getDifferentiability());
     else
       return SILParameterInfo(storageType.getASTType(),
-                              ParameterConvention::Indirect_In_Constant,
+                              ParameterConvention::Indirect_In,
                               param.getDifferentiability());
   } else {
     auto newType = getNewSILType(env, storageType, IGM);

--- a/lib/SIL/IR/OperandOwnership.cpp
+++ b/lib/SIL/IR/OperandOwnership.cpp
@@ -454,7 +454,6 @@ static OperandOwnership getFunctionArgOwnership(SILArgumentConvention argConv,
 
   switch (argConv) {
   case SILArgumentConvention::Indirect_In:
-  case SILArgumentConvention::Indirect_In_Constant:
   case SILArgumentConvention::Direct_Owned:
     return OperandOwnership::ForwardingConsume;
 

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -711,7 +711,6 @@ static CanSILFunctionType getAutoDiffPullbackType(
       break;
     case ParameterConvention::Indirect_In:
     case ParameterConvention::Indirect_Inout:
-    case ParameterConvention::Indirect_In_Constant:
     case ParameterConvention::Indirect_In_Guaranteed:
     case ParameterConvention::Indirect_InoutAliasable:
       conv = ResultConvention::Indirect;
@@ -1002,7 +1001,6 @@ CanSILFunctionType SILFunctionType::getAutoDiffTransposeFunctionType(
       break;
     case ParameterConvention::Indirect_In:
     case ParameterConvention::Indirect_Inout:
-    case ParameterConvention::Indirect_In_Constant:
     case ParameterConvention::Indirect_In_Guaranteed:
     case ParameterConvention::Indirect_InoutAliasable:
       newConv = ResultConvention::Indirect;

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1487,7 +1487,6 @@ public:
     // Should not apply to callees.
     case ParameterConvention::Direct_Unowned:
     case ParameterConvention::Indirect_In:
-    case ParameterConvention::Indirect_In_Constant:
     case ParameterConvention::Indirect_Inout:
     case ParameterConvention::Indirect_In_Guaranteed:
     case ParameterConvention::Indirect_InoutAliasable:

--- a/lib/SIL/IR/SILValue.cpp
+++ b/lib/SIL/IR/SILValue.cpp
@@ -215,7 +215,6 @@ ValueOwnershipKind::ValueOwnershipKind(const SILFunction &F, SILType Type,
 
   switch (Convention) {
   case SILArgumentConvention::Indirect_In:
-  case SILArgumentConvention::Indirect_In_Constant:
     value = moduleConventions.useLoweredAddresses() ? OwnershipKind::None
                                                     : OwnershipKind::Owned;
     break;

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -2104,7 +2104,6 @@ bool GatherUniqueStorageUses::visitUse(Operand *use, AccessUseType useTy) {
                                &UniqueStorageUseVisitor::visitStore);
     case SILArgumentConvention::Indirect_In_Guaranteed:
     case SILArgumentConvention::Indirect_In:
-    case SILArgumentConvention::Indirect_In_Constant:
       return visitApplyOperand(use, visitor,
                                &UniqueStorageUseVisitor::visitLoad);
     case SILArgumentConvention::Direct_Unowned:

--- a/lib/SIL/Utils/MemoryLocations.cpp
+++ b/lib/SIL/Utils/MemoryLocations.cpp
@@ -147,7 +147,6 @@ void MemoryLocations::analyzeLocations(SILFunction *function) {
     SILFunctionArgument *funcArg = cast<SILFunctionArgument>(arg);
     switch (funcArg->getArgumentConvention()) {
     case SILArgumentConvention::Indirect_In:
-    case SILArgumentConvention::Indirect_In_Constant:
     case SILArgumentConvention::Indirect_In_Guaranteed:
     case SILArgumentConvention::Indirect_Out:
       // These are not SIL addresses under -enable-sil-opaque-values

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -214,8 +214,6 @@ BridgedArgumentConvention SILArgumentConvention_getBridged(SILArgumentConvention
       return ArgumentConvention_Indirect_In_Guaranteed;
     case SILArgumentConvention::Indirect_In:
       return ArgumentConvention_Indirect_In;
-    case SILArgumentConvention::Indirect_In_Constant:
-      return ArgumentConvention_Indirect_In_Constant;
     case SILArgumentConvention::Indirect_Out:
       return ArgumentConvention_Indirect_Out;
     case SILArgumentConvention::Direct_Unowned:
@@ -392,8 +390,6 @@ static BridgedArgumentConvention bridgeArgumentConvention(SILArgumentConvention 
       return ArgumentConvention_Indirect_In_Guaranteed;
     case SILArgumentConvention::Indirect_In:
       return ArgumentConvention_Indirect_In;
-    case SILArgumentConvention::Indirect_In_Constant:
-      return ArgumentConvention_Indirect_In_Constant;
     case SILArgumentConvention::Indirect_Out:
       return ArgumentConvention_Indirect_Out;
     case SILArgumentConvention::Direct_Unowned:

--- a/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
+++ b/lib/SIL/Verifier/MemoryLifetimeVerifier.cpp
@@ -492,7 +492,6 @@ void MemoryLifetimeVerifier::setFuncOperandBits(BlockState &state, Operand &op,
                                         bool isTryApply) {
   switch (convention) {
     case SILArgumentConvention::Indirect_In:
-    case SILArgumentConvention::Indirect_In_Constant:
       killBits(state, op.get());
       break;
     case SILArgumentConvention::Indirect_Out:
@@ -803,7 +802,6 @@ void MemoryLifetimeVerifier::checkFuncArgument(Bits &bits, Operand &argumentOp,
   
   switch (argumentConvention) {
     case SILArgumentConvention::Indirect_In:
-    case SILArgumentConvention::Indirect_In_Constant:
       requireBitsSet(bits, argumentOp.get(), applyInst);
       locations.clearBits(bits, argumentOp.get());
       break;

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -464,7 +464,6 @@ struct ImmutableAddressUseVerifier {
 
     case SILArgumentConvention::Indirect_Out:
     case SILArgumentConvention::Indirect_In:
-    case SILArgumentConvention::Indirect_In_Constant:
     case SILArgumentConvention::Indirect_Inout:
       return true;
 
@@ -5459,7 +5458,6 @@ public:
                          default:
                            return false;
                          case ParameterConvention::Indirect_In:
-                         case ParameterConvention::Indirect_In_Constant:
                          case ParameterConvention::Indirect_Inout:
                          case ParameterConvention::Indirect_InoutAliasable:
                          case ParameterConvention::Indirect_In_Guaranteed:

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4686,7 +4686,6 @@ RValue SILGenFunction::emitApply(
 
     case ParameterConvention::Indirect_In_Guaranteed:
     case ParameterConvention::Indirect_In:
-    case ParameterConvention::Indirect_In_Constant:
     case ParameterConvention::Indirect_Inout:
     case ParameterConvention::Indirect_InoutAliasable:
       // We may need to support this at some point, but currently only imported
@@ -5663,10 +5662,6 @@ bool AccessorBaseArgPreparer::shouldLoadBaseAddress() const {
   case ParameterConvention::Direct_Unowned:
   case ParameterConvention::Direct_Guaranteed:
     return true;
-
-  // Should not show up here.
-  case ParameterConvention::Indirect_In_Constant:
-    break;
   }
   llvm_unreachable("bad convention");
 }

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -331,7 +331,6 @@ static ManagedValue emitManagedParameter(SILGenFunction &SGF, SILLocation loc,
       return SGF.emitManagedRValueWithCleanup(value, valueTL);
     }
 
-  case ParameterConvention::Indirect_In_Constant:
   case ParameterConvention::Indirect_InoutAliasable:
     llvm_unreachable("unexpected convention");
   }
@@ -432,7 +431,6 @@ static void buildFuncToBlockInvokeBody(SILGenFunction &SGF,
         break;
         
       case ParameterConvention::Indirect_In:
-      case ParameterConvention::Indirect_In_Constant:
       case ParameterConvention::Indirect_In_Guaranteed:
       case ParameterConvention::Indirect_Inout:
       case ParameterConvention::Indirect_InoutAliasable:
@@ -2185,8 +2183,6 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
           param = emitManagedRValueWithCleanup(tmp);
           break;
         }
-        case ParameterConvention::Indirect_In_Constant:
-          llvm_unreachable("unsupported convention");
         }
 
         while (maybeAddForeignArg());

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -469,8 +469,6 @@ static ManagedValue createInputFunctionArgument(
   case SILArgumentConvention::Indirect_InoutAliasable:
     // An inout parameter is +0 and guaranteed, but represents an lvalue.
     return ManagedValue::forLValue(arg);
-  case SILArgumentConvention::Indirect_In_Constant:
-    llvm_unreachable("Convention not produced by SILGen");
   case SILArgumentConvention::Indirect_Out:
     llvm_unreachable("unsupported convention for API");
   }

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -1514,8 +1514,6 @@ namespace {
       case ParameterConvention::Indirect_InoutAliasable:
         llvm_unreachable("abstraction difference in aliasable argument not "
                          "allowed");
-      case ParameterConvention::Indirect_In_Constant:
-        llvm_unreachable("in_constant convention not allowed in SILGen");
       }
 
       llvm_unreachable("Covered switch isn't covered?!");
@@ -1731,7 +1729,6 @@ static ManagedValue manageYield(SILGenFunction &SGF, SILValue value,
     return ManagedValue::forLValue(value);
   case ParameterConvention::Direct_Owned:
   case ParameterConvention::Indirect_In:
-  case ParameterConvention::Indirect_In_Constant:
     return SGF.emitManagedRValueWithCleanup(value);
   case ParameterConvention::Direct_Guaranteed:
   case ParameterConvention::Direct_Unowned:

--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -854,7 +854,6 @@ SILFunction *VJPCloner::Implementation::createEmptyPullback() {
       break;
     case ParameterConvention::Indirect_In:
     case ParameterConvention::Indirect_Inout:
-    case ParameterConvention::Indirect_In_Constant:
     case ParameterConvention::Indirect_In_Guaranteed:
     case ParameterConvention::Indirect_InoutAliasable:
       conv = ResultConvention::Indirect;

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -2833,7 +2833,6 @@ void YieldRewriter::rewriteOperand(YieldInst *yieldInst, unsigned index) {
   case ParameterConvention::Indirect_InoutAliasable:
     return;
   case ParameterConvention::Indirect_In:
-  case ParameterConvention::Indirect_In_Constant:
     ownership = OwnershipKind::Owned;
     break;
   case ParameterConvention::Indirect_In_Guaranteed:

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.cpp
@@ -954,7 +954,6 @@ void ElementUseCollector::collectUses(SILValue Pointer, unsigned BaseEltNo) {
 
       // If this is an in-parameter, it is like a load.
       case ParameterConvention::Indirect_In:
-      case ParameterConvention::Indirect_In_Constant:
       case ParameterConvention::Indirect_In_Guaranteed:
         addElementUses(BaseEltNo, PointeeType, User, DIUseKind::IndirectIn);
         continue;

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1175,8 +1175,7 @@ void LifetimeChecker::injectTypeWrapperStorageInitalization() {
               }
 
               switch (convention.getSILArgumentConvention(argIdx)) {
-              case SILArgumentConvention::Indirect_In:
-              case SILArgumentConvention::Indirect_In_Constant: {
+              case SILArgumentConvention::Indirect_In: {
                 // The only way to load opaque type is to allocate a temporary
                 // variable on the stack for it and initialize from the element
                 // address.

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -120,7 +120,6 @@ static  bool fixupReferenceCounts(
     case ParameterConvention::Indirect_In:
       llvm_unreachable("Missing indirect copy");
 
-    case ParameterConvention::Indirect_In_Constant:
     case ParameterConvention::Indirect_Inout:
     case ParameterConvention::Indirect_InoutAliasable:
       break;

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
@@ -898,7 +898,6 @@ bool GatherUsesVisitor::visitUse(Operand *op, AccessUseType useTy) {
     case SILArgumentConvention::Indirect_Inout:
     case SILArgumentConvention::Indirect_InoutAliasable:
     case SILArgumentConvention::Indirect_In:
-    case SILArgumentConvention::Indirect_In_Constant:
     case SILArgumentConvention::Indirect_Out:
     case SILArgumentConvention::Direct_Unowned:
     case SILArgumentConvention::Direct_Owned:

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -1115,7 +1115,6 @@ static bool hasOnlyStoreUses(SingleValueInstruction *addressInst) {
         return false;
       SILArgumentConvention convention = applySite.getArgumentConvention(*use);
       if (convention == SILArgumentConvention::Indirect_In ||
-          convention == SILArgumentConvention::Indirect_In_Constant ||
           convention == SILArgumentConvention::Indirect_In_Guaranteed) {
         if (numWritableArguments > 0)
           return false;

--- a/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
+++ b/lib/SILOptimizer/Mandatory/OSLogOptimization.cpp
@@ -1114,7 +1114,7 @@ static bool hasOnlyStoreUses(SingleValueInstruction *addressInst) {
       if (numWritableArguments > 1)
         return false;
       SILArgumentConvention convention = applySite.getArgumentConvention(*use);
-      if (convention == SILArgumentConvention::Indirect_In_Guaranteed ||
+      if (convention == SILArgumentConvention::Indirect_In ||
           convention == SILArgumentConvention::Indirect_In_Constant ||
           convention == SILArgumentConvention::Indirect_In_Guaranteed) {
         if (numWritableArguments > 0)

--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.cpp
@@ -390,7 +390,6 @@ bool ElementUseCollector::collectUses(SILValue Pointer) {
 
       // If this is an in-parameter, it is like a load.
       case ParameterConvention::Indirect_In:
-      case ParameterConvention::Indirect_In_Constant:
       case ParameterConvention::Indirect_In_Guaranteed:
         Uses.emplace_back(User, PMOUseKind::IndirectIn);
         continue;

--- a/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/RawSILInstLowering.cpp
@@ -143,7 +143,6 @@ static void getAssignByWrapperArgsRecursively(SmallVectorImpl<SILValue> &args,
       break;
     case SILArgumentConvention::Direct_Unowned:
     case SILArgumentConvention::Indirect_In:
-    case SILArgumentConvention::Indirect_In_Constant:
     case SILArgumentConvention::Direct_Owned:
       break;
     case SILArgumentConvention::Indirect_Inout:

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -668,7 +668,6 @@ bool SILCombiner::eraseApply(FullApplySite FAS, const UserListTy &Users) {
       auto Arg = FAS.getArgument(i);
       switch (PI.getConvention()) {
         case ParameterConvention::Indirect_In:
-        case ParameterConvention::Indirect_In_Constant:
         case ParameterConvention::Direct_Owned:
           Builder.emitDestroyOperation(FAS.getLoc(), Arg);
           break;

--- a/lib/SILOptimizer/Transforms/PartialApplySimplification.cpp
+++ b/lib/SILOptimizer/Transforms/PartialApplySimplification.cpp
@@ -162,7 +162,6 @@ static bool isSimplePartialApply(SILModule &M,
   if (isOnStack) {
     switch (contextParam.getConvention()) {
     case ParameterConvention::Indirect_Inout:
-    case ParameterConvention::Indirect_In_Constant:
     case ParameterConvention::Indirect_In_Guaranteed:
     case ParameterConvention::Indirect_InoutAliasable:
       // Indirect arguments are trivially word sized.
@@ -450,7 +449,6 @@ rewriteKnownCalleeWithExplicitContext(SILFunction *callee,
     case ParameterConvention::Direct_Owned:
     case ParameterConvention::Direct_Unowned:
     case ParameterConvention::Indirect_In:
-    case ParameterConvention::Indirect_In_Constant:
     case ParameterConvention::Indirect_In_Guaranteed:
       boxFields.push_back(SILField(param.getInterfaceType(), /*mutable*/false));
       break;
@@ -602,8 +600,7 @@ rewriteKnownCalleeWithExplicitContext(SILFunction *callee,
           // Load a copy of the value from the box.
           projectedArg = B.createLoad(loc, proj, LoadOwnershipQualifier::Copy);
           break;
-        case ParameterConvention::Indirect_In:
-        case ParameterConvention::Indirect_In_Constant: {
+        case ParameterConvention::Indirect_In: {
           // Allocate space for a copy of the value that can be consumed by the
           // function body. We'll need to deallocate the stack slot after the
           // cloned body.
@@ -644,8 +641,7 @@ rewriteKnownCalleeWithExplicitContext(SILFunction *callee,
           projectedArg = B.createLoad(loc, proj, LoadOwnershipQualifier::Unqualified);
           B.createRetainValue(loc, projectedArg, Atomicity::Atomic);
           break;
-        case ParameterConvention::Indirect_In:
-        case ParameterConvention::Indirect_In_Constant: {
+        case ParameterConvention::Indirect_In: {
           // Allocate space for a copy of the value that can be consumed by the
           // function body. We'll need to deallocate the stack slot after the
           // cloned body.
@@ -777,7 +773,6 @@ rewriteKnownCalleeWithExplicitContext(SILFunction *callee,
         break;
           
       case ParameterConvention::Indirect_In_Guaranteed:
-      case ParameterConvention::Indirect_In_Constant:
       case ParameterConvention::Indirect_In:
         // Move the value from its current memory location to the box.
         B.createCopyAddr(loc, arg, proj, IsTake, IsInitialization);

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -679,7 +679,6 @@ CastOptimizer::optimizeBridgedSwiftToObjCCast(SILDynamicCastInst dynamicCast) {
     break;
   case ParameterConvention::Direct_Owned:
   case ParameterConvention::Indirect_In:
-  case ParameterConvention::Indirect_In_Constant:
     // Currently this
     // cannot appear, because the _bridgeToObjectiveC protocol witness method
     // always receives the this pointer (= the source) as guaranteed.

--- a/lib/SILOptimizer/Utils/ConstExpr.cpp
+++ b/lib/SILOptimizer/Utils/ConstExpr.cpp
@@ -2203,8 +2203,7 @@ ConstExprStepEvaluator::skipByMakingEffectsNonConstant(
       ApplySite applySite(applyInst);
       SILArgumentConvention convention =
         applySite.getArgumentConvention(operand);
-      if (convention == SILArgumentConvention::Indirect_In_Guaranteed ||
-          convention == SILArgumentConvention::Indirect_In_Constant) {
+      if (convention == SILArgumentConvention::Indirect_In_Guaranteed) {
         continue;
       }
     }

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -893,7 +893,6 @@ void ReabstractionInfo::createSubstitutedAndSpecializedTypes() {
         hasConvertedResilientParams = true;
       }
       break;
-    case ParameterConvention::Indirect_In_Constant:
     case ParameterConvention::Indirect_Inout:
     case ParameterConvention::Indirect_InoutAliasable:
       break;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3673,7 +3673,7 @@ SILParameterInfo TypeResolver::resolveSILParameter(
              ParameterConvention::Indirect_In_Guaranteed);
     checkFor(TypeAttrKind::TAK_in, ParameterConvention::Indirect_In);
     checkFor(TypeAttrKind::TAK_in_constant,
-             ParameterConvention::Indirect_In_Constant);
+             ParameterConvention::Indirect_In);
     checkFor(TypeAttrKind::TAK_inout, ParameterConvention::Indirect_Inout);
     checkFor(TypeAttrKind::TAK_inout_aliasable,
              ParameterConvention::Indirect_InoutAliasable);

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5553,7 +5553,8 @@ Optional<swift::ParameterConvention> getActualParameterConvention(uint8_t raw) {
   CASE(Indirect_Inout)
   CASE(Indirect_InoutAliasable)
   CASE(Indirect_In_Guaranteed)
-  CASE(Indirect_In_Constant)
+  case serialization::ParameterConvention::Indirect_In_Constant: \
+    return swift::ParameterConvention::Indirect_In;
   CASE(Direct_Owned)
   CASE(Direct_Unowned)
   CASE(Direct_Guaranteed)

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4497,7 +4497,6 @@ static uint8_t getRawStableValueOwnership(swift::ValueOwnership ownership) {
 static uint8_t getRawStableParameterConvention(swift::ParameterConvention pc) {
   switch (pc) {
   SIMPLE_CASE(ParameterConvention, Indirect_In)
-  SIMPLE_CASE(ParameterConvention, Indirect_In_Constant)
   SIMPLE_CASE(ParameterConvention, Indirect_In_Guaranteed)
   SIMPLE_CASE(ParameterConvention, Indirect_Inout)
   SIMPLE_CASE(ParameterConvention, Indirect_InoutAliasable)

--- a/test/AutoDiff/IRGen/loadable_by_address.swift
+++ b/test/AutoDiff/IRGen/loadable_by_address.swift
@@ -39,8 +39,8 @@ func large2large(_ foo: Large) -> Large {
 
 // `large2large` old verification error:
 // SIL verification failed: JVP type does not match expected JVP type
-// $@callee_guaranteed (@in_constant Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector)
-// $@callee_guaranteed (@in_constant Large) -> (@out Large, @owned @callee_guaranteed (@in_constant Large.TangentVector) -> @out Large.TangentVector)
+// $@callee_guaranteed (@in Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector)
+// $@callee_guaranteed (@in Large) -> (@out Large, @owned @callee_guaranteed (@in Large.TangentVector) -> @out Large.TangentVector)
 
 @_silgen_name("large2small")
 @differentiable(reverse)
@@ -50,26 +50,26 @@ func large2small(_ foo: Large) -> Float {
 
 // `large2small` old verification error:
 // SIL verification failed: JVP type does not match expected JVP type
-//   $@callee_guaranteed (@in_constant Large) -> (Float, @owned @callee_guaranteed (Large.TangentVector) -> Float)
-//   $@callee_guaranteed (@in_constant Large) -> (Float, @owned @callee_guaranteed (@in_constant Large.TangentVector) -> Float)
+//   $@callee_guaranteed (@in Large) -> (Float, @owned @callee_guaranteed (Large.TangentVector) -> Float)
+//   $@callee_guaranteed (@in Large) -> (Float, @owned @callee_guaranteed (@in Large.TangentVector) -> Float)
 
 // CHECK-SIL: sil {{.*}}@large2large : $@convention(thin) (Large) -> Large {
-// CHECK-LBA-SIL: sil {{.*}}@large2large : $@convention(thin) (@in_constant Large) -> @out Large {
+// CHECK-LBA-SIL: sil {{.*}}@large2large : $@convention(thin) (@in Large) -> @out Large {
 
 // CHECK-SIL-LABEL: sil {{.*}}@large2small : $@convention(thin) (Large) -> Float {
-// CHECK-LBA-SIL: sil {{.*}}@large2small : $@convention(thin) (@in_constant Large) -> Float {
+// CHECK-LBA-SIL: sil {{.*}}@large2small : $@convention(thin) (@in Large) -> Float {
 
 // CHECK-SIL: sil {{.*}}@large2largeTJfSpSr : $@convention(thin) (Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector) {
-// CHECK-LBA-SIL: sil {{.*}}@large2largeTJfSpSr : $@convention(thin) (@in_constant Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector) {
+// CHECK-LBA-SIL: sil {{.*}}@large2largeTJfSpSr : $@convention(thin) (@in Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector) {
 
 // CHECK-SIL: sil {{.*}}@large2largeTJrSpSr : $@convention(thin) (Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector) {
-// CHECK-LBA-SIL: sil {{.*}}@large2largeTJrSpSr : $@convention(thin) (@in_constant Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector) {
+// CHECK-LBA-SIL: sil {{.*}}@large2largeTJrSpSr : $@convention(thin) (@in Large) -> (Large, @owned @callee_guaranteed (Large.TangentVector) -> Large.TangentVector) {
 
 // CHECK-SIL: sil {{.*}}@large2smallTJfSpSr : $@convention(thin) (Large) -> (Float, @owned @callee_guaranteed (Large.TangentVector) -> Float) {
-// CHECK-LBA-SIL: sil {{.*}}@large2smallTJfSpSr : $@convention(thin) (@in_constant Large) -> (Float, @owned @callee_guaranteed (Large.TangentVector) -> Float) {
+// CHECK-LBA-SIL: sil {{.*}}@large2smallTJfSpSr : $@convention(thin) (@in Large) -> (Float, @owned @callee_guaranteed (Large.TangentVector) -> Float) {
 
 // CHECK-SIL: sil {{.*}}@large2smallTJrSpSr : $@convention(thin) (Large) -> (Float, @owned @callee_guaranteed (Float) -> Large.TangentVector) {
-// CHECK-LBA-SIL: sil {{.*}}@large2smallTJrSpSr : $@convention(thin) (@in_constant Large) -> (Float, @owned @callee_guaranteed (Float) -> Large.TangentVector) {
+// CHECK-LBA-SIL: sil {{.*}}@large2smallTJrSpSr : $@convention(thin) (@in Large) -> (Float, @owned @callee_guaranteed (Float) -> Large.TangentVector) {
 
 LBATests.test("Correctness") {
   let one = Large.TangentVector(a: 1, b: 1, c: 1, d: 1)

--- a/test/AutoDiff/IRGen/loadable_by_address_cross_module.swift
+++ b/test/AutoDiff/IRGen/loadable_by_address_cross_module.swift
@@ -7,7 +7,7 @@
 // RUN: %target-swift-frontend -c -Xllvm -sil-print-after=loadable-address %S/Inputs/loadable_by_address_cross_module.swift 2>&1 | %FileCheck %s -check-prefix=CHECK-MODULE-POST-LBA
 
 // CHECK-MODULE-PRE-LBA: sil {{.*}}LBAModifiedFunction{{.*}} $@convention(method) <T> (Float, LargeLoadableType<T>) -> Float
-// CHECK-MODULE-POST-LBA: sil {{.*}}LBAModifiedFunction{{.*}} $@convention(method) <T> (Float, @in_constant LargeLoadableType<T>) -> Float
+// CHECK-MODULE-POST-LBA: sil {{.*}}LBAModifiedFunction{{.*}} $@convention(method) <T> (Float, @in LargeLoadableType<T>) -> Float
 
 // Compile the module.
 
@@ -24,8 +24,8 @@
 // CHECK-CLIENT-PRE-LBA: differentiability_witness_function [jvp] [reverse] [parameters 0 1] [results 0] <T> @${{.*}}LBAModifiedFunction{{.*}} : $@convention(method) <τ_0_0> (Float, LargeLoadableType<τ_0_0>) -> Float
 // CHECK-CLIENT-PRE-LBA: differentiability_witness_function [vjp] [reverse] [parameters 0 1] [results 0] <T> @${{.*}}LBAModifiedFunction{{.*}} : $@convention(method) <τ_0_0> (Float, LargeLoadableType<τ_0_0>) -> Float
 
-// CHECK-CLIENT-POST-LBA: differentiability_witness_function [jvp] [reverse] [parameters 0 1] [results 0] <T> @$s8external17LargeLoadableTypeV0A19LBAModifiedFunctionyS2fF : $@convention(method) <τ_0_0> (Float, @in_constant LargeLoadableType<τ_0_0>) -> Float as $@convention(method) <τ_0_0> (Float, @in_constant LargeLoadableType<τ_0_0>) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float, τ_0_0) -> Float for <LargeLoadableType<τ_0_0>>)
-// CHECK-CLIENT-POST-LBA: differentiability_witness_function [vjp] [reverse] [parameters 0 1] [results 0] <T> @$s8external17LargeLoadableTypeV0A19LBAModifiedFunctionyS2fF : $@convention(method) <τ_0_0> (Float, @in_constant LargeLoadableType<τ_0_0>) -> Float as $@convention(method) <τ_0_0> (Float, @in_constant LargeLoadableType<τ_0_0>) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float) -> (Float, τ_0_0) for <LargeLoadableType<τ_0_0>>)
+// CHECK-CLIENT-POST-LBA: differentiability_witness_function [jvp] [reverse] [parameters 0 1] [results 0] <T> @$s8external17LargeLoadableTypeV0A19LBAModifiedFunctionyS2fF : $@convention(method) <τ_0_0> (Float, @in LargeLoadableType<τ_0_0>) -> Float as $@convention(method) <τ_0_0> (Float, @in LargeLoadableType<τ_0_0>) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float, τ_0_0) -> Float for <LargeLoadableType<τ_0_0>>)
+// CHECK-CLIENT-POST-LBA: differentiability_witness_function [vjp] [reverse] [parameters 0 1] [results 0] <T> @$s8external17LargeLoadableTypeV0A19LBAModifiedFunctionyS2fF : $@convention(method) <τ_0_0> (Float, @in LargeLoadableType<τ_0_0>) -> Float as $@convention(method) <τ_0_0> (Float, @in LargeLoadableType<τ_0_0>) -> (Float, @owned @callee_guaranteed @substituted <τ_0_0> (Float) -> (Float, τ_0_0) for <LargeLoadableType<τ_0_0>>)
 
 // Finally, execute the test.
 

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -46,9 +46,9 @@ let bigStructGlobalArray : [BigStruct] = [
   BigStruct()
 ]
 
-// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal swiftcc void @"$s22big_types_corner_cases21OptionalInoutFuncTypeC7executeyys5Error_pSgFyyXEfU_"(%T22big_types_corner_cases9BigStructVSg* nocapture dereferenceable({{.*}}) %0, %T22big_types_corner_cases21OptionalInoutFuncTypeC* %1, %T22big_types_corner_cases9BigStructVSgs5Error_pSgIegcg_Sg* nocapture dereferenceable({{.*}})
-// CHECK: call void @"$s22big_types_corner_cases9BigStructVSgs5Error_pSgIegcg_SgWOe
-// CHECK: call void @"$s22big_types_corner_cases9BigStructVSgs5Error_pSgIegcg_SgWOy
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal swiftcc void @"$s22big_types_corner_cases21OptionalInoutFuncTypeC7executeyys5Error_pSgFyyXEfU_"(%T22big_types_corner_cases9BigStructVSg* nocapture dereferenceable({{.*}}) %0, %T22big_types_corner_cases21OptionalInoutFuncTypeC* %1, %T22big_types_corner_cases9BigStructVSgs5Error_pSgIegig_Sg* nocapture dereferenceable({{.*}})
+// CHECK: call void @"$s22big_types_corner_cases9BigStructVSgs5Error_pSgIegig_SgWOe
+// CHECK: call void @"$s22big_types_corner_cases9BigStructVSgs5Error_pSgIegig_SgWOy
 // CHECK: ret void
 
 public func f1_returns_BigType(_ x: BigStruct) -> BigStruct {

--- a/test/IRGen/big_types_coroutine.sil
+++ b/test/IRGen/big_types_coroutine.sil
@@ -22,7 +22,7 @@ public struct BigStruct {
 sil @make_big_struct : $@convention(thin) () -> BigStruct
 sil @use_big_struct : $@convention(thin) (BigStruct) -> ()
 
-// CHECK-LABEL: sil @test_yield_big : $@yield_once @convention(thin) () -> @yields @in_constant BigStruct {
+// CHECK-LABEL: sil @test_yield_big : $@yield_once @convention(thin) () -> @yields @in BigStruct {
 // CHECK:       bb0:
 // CHECK-NEXT:    [[TEMP:%.*]] = alloc_stack $BigStruct
 // CHECK-NEXT:    // function_ref
@@ -54,13 +54,13 @@ unwind:
 // CHECK:       bb0:
 // CHECK-NEXT:    [[TEMP:%.*]] = alloc_stack $BigStruct
 // CHECK-NEXT:    // function_ref
-// CHECK-NEXT:    [[CORO:%.*]] = function_ref @test_yield_big : $@yield_once @convention(thin) () -> @yields @in_constant BigStruct
+// CHECK-NEXT:    [[CORO:%.*]] = function_ref @test_yield_big : $@yield_once @convention(thin) () -> @yields @in BigStruct
 // CHECK-NEXT:    ([[ADDR:%.*]], [[TOKEN:%.*]]) = begin_apply [[CORO]]()
 //   TODO: this isn't very efficient
 // CHECK-NEXT:    [[T0:%.*]] = load [[ADDR]] : $*BigStruct
 // CHECK-NEXT:    store [[T0]] to [[TEMP]] : $*BigStruct
 // CHECK-NEXT:    // function_ref
-// CHECK-NEXT:    [[USE:%.*]] = function_ref @use_big_struct : $@convention(thin) (@in_constant BigStruct) -> ()
+// CHECK-NEXT:    [[USE:%.*]] = function_ref @use_big_struct : $@convention(thin) (@in BigStruct) -> ()
 // CHECK-NEXT:    apply [[USE]]([[TEMP]])
 // CHECK-NEXT:    end_apply [[TOKEN]]
 // CHECK-NEXT:    [[RET:%.*]] = tuple ()

--- a/test/IRGen/yield_once_big.sil
+++ b/test/IRGen/yield_once_big.sil
@@ -44,8 +44,8 @@ entry:
   // CHECK-64-SAME: , align 8
 
   //   Coroutine setup.
-  // CHECK-32-NEXT: [[ID:%.*]] = call token @llvm.coro.id.retcon.once(i32 [[BUFFER_SIZE]], i32 [[BUFFER_ALIGN:4]], i8* %0, i8* bitcast (void (i8*, i1)* @"$s14yield_once_big3BigVyxGAA9SomeClassCRbzlIetAYc_TC" to i8*), i8* bitcast (i8* (i32)* @malloc to i8*), i8* bitcast (void (i8*)* @free to i8*))
-  // CHECK-64-NEXT: [[ID:%.*]] = call token @llvm.coro.id.retcon.once(i32 [[BUFFER_SIZE]], i32 [[BUFFER_ALIGN:8]], i8* %0, i8* bitcast (void (i8*, i1)* @"$s14yield_once_big3BigVyxGAA9SomeClassCRbzlIetAYc_TC" to i8*), i8* bitcast (i8* (i64)* @malloc to i8*), i8* bitcast (void (i8*)* @free to i8*))
+  // CHECK-32-NEXT: [[ID:%.*]] = call token @llvm.coro.id.retcon.once(i32 [[BUFFER_SIZE]], i32 [[BUFFER_ALIGN:4]], i8* %0, i8* bitcast (void (i8*, i1)* @"$s14yield_once_big3BigVyxGAA9SomeClassCRbzlIetAYi_TC" to i8*), i8* bitcast (i8* (i32)* @malloc to i8*), i8* bitcast (void (i8*)* @free to i8*))
+  // CHECK-64-NEXT: [[ID:%.*]] = call token @llvm.coro.id.retcon.once(i32 [[BUFFER_SIZE]], i32 [[BUFFER_ALIGN:8]], i8* %0, i8* bitcast (void (i8*, i1)* @"$s14yield_once_big3BigVyxGAA9SomeClassCRbzlIetAYi_TC" to i8*), i8* bitcast (i8* (i64)* @malloc to i8*), i8* bitcast (void (i8*)* @free to i8*))
   // CHECK-NEXT:    [[BEGIN:%.*]] = call i8* @llvm.coro.begin(token [[ID]], i8* null)
   // CHECK-NEXT:    store %swift.type*
 
@@ -92,7 +92,7 @@ unwind:
   // CHECK-NEXT:    unreachable
 }
 
-// CHECK-LABEL:     declare{{( dllimport)?}}{{( protected)?}} swiftcc void @"$s14yield_once_big3BigVyxGAA9SomeClassCRbzlIetAYc_TC"
+// CHECK-LABEL:     declare{{( dllimport)?}}{{( protected)?}} swiftcc void @"$s14yield_once_big3BigVyxGAA9SomeClassCRbzlIetAYi_TC"
 // CHECK-SAME:      (i8* noalias dereferenceable([[BUFFER_SIZE]]), i1)
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_simple_call(i1 %0)

--- a/test/TypeDecoder/lowered_function_types.swift
+++ b/test/TypeDecoder/lowered_function_types.swift
@@ -26,4 +26,4 @@ do {
 
 // CHECK: @callee_guaranteed (Int, @guaranteed Class, @owned Class, @in_guaranteed Any, @inout Int) -> (Int, @owned Class, @out Any)
 // CHECK: @callee_guaranteed () -> @error Error
-// CHECK: @callee_guaranteed (@in_constant Int) -> @owned Int
+// CHECK: @callee_guaranteed (@in Int) -> @owned Int


### PR DESCRIPTION
It is no different from `@in`.

Continue parse `@in_constant` in textual and serialized SIL, but just as an alias for `@in`.
