### PR TITLE
[stdlib] Gardening BackDeployConcurrency files

### DIFF
--- a/stdlib/public/BackDeployConcurrency/AsyncCompactMapSequence.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncCompactMapSequence.swift
@@ -30,15 +30,15 @@ extension AsyncSequence {
   /// returns `nil` in this case, which `compactMap(_:)` omits from the
   /// transformed asynchronous sequence.
   ///
-  ///     let romanNumeralDict: [Int : String] =
+  ///     let romanNumeralDict: [Int: String] =
   ///         [1: "I", 2: "II", 3: "III", 5: "V"]
   ///         
   ///     let stream = Counter(howHigh: 5)
   ///         .compactMap { romanNumeralDict[$0] }
   ///     for await numeral in stream {
-  ///         print("\(numeral) ", terminator: " ")
+  ///         print(numeral, terminator: " ")
   ///     }
-  ///     // Prints: I  II  III  V
+  ///     // Prints "I II III V "
   ///
   /// - Parameter transform: A mapping closure. `transform` accepts an element
   ///   of this sequence as its parameter and returns a transformed value of the

--- a/stdlib/public/BackDeployConcurrency/AsyncDropFirstSequence.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncDropFirstSequence.swift
@@ -22,12 +22,12 @@ extension AsyncSequence {
   ///
   /// In this example, an asynchronous sequence called `Counter` produces `Int`
   /// values from `1` to `10`. The `dropFirst(_:)` method causes the modified
-  /// sequence to ignore the values `0` through `4`, and instead emit `5` through `10`:
+  /// sequence to ignore the values `1` through `3`, and instead emit `4` through `10`:
   ///
   ///     for await number in Counter(howHigh: 10).dropFirst(3) {
-  ///         print("\(number) ", terminator: " ")
+  ///         print(number, terminator: " ")
   ///     }
-  ///     // prints "4 5 6 7 8 9 10"
+  ///     // Prints "4 5 6 7 8 9 10 "
   ///
   /// If the number of elements to drop exceeds the number of elements in the
   /// sequence, the result is an empty sequence.

--- a/stdlib/public/BackDeployConcurrency/AsyncDropWhileSequence.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncDropWhileSequence.swift
@@ -28,9 +28,9 @@ extension AsyncSequence {
   ///     let stream = Counter(howHigh: 10)
   ///         .drop { $0 % 3 != 0 }
   ///     for await number in stream {
-  ///         print("\(number) ", terminator: " ")
+  ///         print(number, terminator: " ")
   ///     }
-  ///     // prints "3 4 5 6 7 8 9 10"
+  ///     // Prints "3 4 5 6 7 8 9 10 "
   ///
   /// After the predicate returns `false`, the sequence never executes it again,
   /// and from then on the sequence passes through elements from its underlying

--- a/stdlib/public/BackDeployConcurrency/AsyncFilterSequence.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncFilterSequence.swift
@@ -24,9 +24,9 @@ extension AsyncSequence {
   ///     let stream = Counter(howHigh: 10)
   ///         .filter { $0 % 2 == 0 }
   ///     for await number in stream {
-  ///         print("\(number) ", terminator: " ")
+  ///         print(number, terminator: " ")
   ///     }
-  ///     // Prints: 2  4  6  8  10
+  ///     // Prints "2 4 6 8 10 "
   ///
   /// - Parameter isIncluded: A closure that takes an element of the
   ///   asynchronous sequence as its argument and returns a Boolean value

--- a/stdlib/public/BackDeployConcurrency/AsyncFlatMapSequence.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncFlatMapSequence.swift
@@ -31,14 +31,14 @@ extension AsyncSequence {
   ///     let stream = Counter(howHigh: 5)
   ///         .flatMap { Counter(howHigh: $0) }
   ///     for await number in stream {
-  ///         print("\(number)", terminator: " ")
+  ///         print(number, terminator: " ")
   ///     }
-  ///     // Prints: 1 1 2 1 2 3 1 2 3 4 1 2 3 4 5
+  ///     // Prints "1 1 2 1 2 3 1 2 3 4 1 2 3 4 5 "
   ///
   /// - Parameter transform: A mapping closure. `transform` accepts an element
   ///   of this sequence as its parameter and returns an `AsyncSequence`.
   /// - Returns: A single, flattened asynchronous sequence that contains all
-  ///   elements in all the asychronous sequences produced by `transform`.
+  ///   elements in all the asynchronous sequences produced by `transform`.
  @inlinable
   public __consuming func flatMap<SegmentOfResult: AsyncSequence>(
     _ transform: @escaping (Element) async -> SegmentOfResult

--- a/stdlib/public/BackDeployConcurrency/AsyncIteratorProtocol.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncIteratorProtocol.swift
@@ -26,18 +26,19 @@ import Swift
 /// conforms to `AsyncIteratorProtocol`. The following example shows a `Counter`
 /// type that uses an inner iterator to monotonically generate `Int` values
 /// until reaching a `howHigh` value. While this example isn't itself
-/// asychronous, it shows the shape of a custom sequence and iterator, and how
+/// asynchronous, it shows the shape of a custom sequence and iterator, and how
 /// to use it as if it were asynchronous:
 ///
-///     struct Counter : AsyncSequence {
+///     struct Counter: AsyncSequence {
 ///         typealias Element = Int
 ///         let howHigh: Int
 ///
-///         struct AsyncIterator : AsyncIteratorProtocol {
+///         struct AsyncIterator: AsyncIteratorProtocol {
 ///             let howHigh: Int
 ///             var current = 1
+///
 ///             mutating func next() async -> Int? {
-///                 // A genuinely asychronous implementation uses the `Task`
+///                 // A genuinely asynchronous implementation uses the `Task`
 ///                 // API to check for cancellation here and return early.
 ///                 guard current <= howHigh else {
 ///                     return nil
@@ -56,10 +57,10 @@ import Swift
 ///
 /// At the call site, this looks like:
 ///
-///     for await i in Counter(howHigh: 10) {
-///       print(i, terminator: " ")
+///     for await number in Counter(howHigh: 10) {
+///       print(number, terminator: " ")
 ///     }
-///     // Prints: 1 2 3 4 5 6 7 8 9 10
+///     // Prints "1 2 3 4 5 6 7 8 9 10 "
 ///
 /// ### End of Iteration
 ///

--- a/stdlib/public/BackDeployConcurrency/AsyncMapSequence.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncMapSequence.swift
@@ -34,9 +34,9 @@ extension AsyncSequence {
   ///     let stream = Counter(howHigh: 5)
   ///         .map { romanNumeralDict[$0] ?? "(unknown)" }
   ///     for await numeral in stream {
-  ///         print("\(numeral) ", terminator: " ")
+  ///         print(numeral, terminator: " ")
   ///     }
-  ///     // Prints: I  II  III  (unknown)  V
+  ///     // Prints "I II III (unknown) V "
   ///
   /// - Parameter transform: A mapping closure. `transform` accepts an element
   ///   of this sequence as its parameter and returns a transformed value of the

--- a/stdlib/public/BackDeployConcurrency/AsyncPrefixSequence.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncPrefixSequence.swift
@@ -25,9 +25,9 @@ extension AsyncSequence {
   /// sequence to pass through the first six values, then end.
   ///
   ///     for await number in Counter(howHigh: 10).prefix(6) {
-  ///         print("\(number) ")
+  ///         print(number, terminator: " ")
   ///     }
-  ///     // prints "1 2 3 4 5 6"
+  ///     // Prints "1 2 3 4 5 6 "
   ///
   /// If the count passed to `prefix(_:)` exceeds the number of elements in the
   /// base sequence, the result contains all of the elements in the sequence.

--- a/stdlib/public/BackDeployConcurrency/AsyncPrefixWhileSequence.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncPrefixWhileSequence.swift
@@ -29,9 +29,9 @@ extension AsyncSequence {
   ///     let stream = Counter(howHigh: 10)
   ///         .prefix { $0 % 2 != 0 || $0 % 3 != 0 }
   ///     for try await number in stream {
-  ///         print("\(number) ", terminator: " ")
+  ///         print(number, terminator: " ")
   ///     }
-  ///     // prints "1  2  3  4  5"
+  ///     // Prints "1 2 3 4 5 "
   ///     
   /// - Parameter predicate: A closure that takes an element as a parameter and
   ///   returns a Boolean value indicating whether the element should be

--- a/stdlib/public/BackDeployConcurrency/AsyncSequence.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncSequence.swift
@@ -27,10 +27,10 @@ import Swift
 /// over `Counter`, a custom `AsyncSequence` that produces `Int` values from
 /// `1` up to a `howHigh` value:
 ///
-///     for await i in Counter(howHigh: 10) {
-///         print(i, terminator: " ")
+///     for await number in Counter(howHigh: 10) {
+///         print(number, terminator: " ")
 ///     }
-///     // Prints: 1 2 3 4 5 6 7 8 9 10
+///     // Prints "1 2 3 4 5 6 7 8 9 10 "
 ///
 /// An `AsyncSequence` doesn't generate or contain the values; it just defines
 /// how you access them. Along with defining the type of values as an associated
@@ -69,7 +69,7 @@ import Swift
 ///     for await s in stream {
 ///         print(s, terminator: " ")
 ///     }
-///     // Prints: Odd Even Odd Even Odd Even Odd Even Odd Even
+///     // Prints "Odd Even Odd Even Odd Even Odd Even Odd Even "
 ///
 @available(SwiftStdlib 5.1, *)
 @rethrows
@@ -108,7 +108,7 @@ extension AsyncSequence {
   ///             $0 + $1
   ///         }
   ///     print(sum)
-  ///     // Prints: 10
+  ///     // Prints "10"
   ///
   ///
   /// - Parameters:
@@ -204,7 +204,7 @@ extension AsyncSequence {
   ///     let containsDivisibleByThree = await Counter(howHigh: 10)
   ///         .contains { $0 % 3 == 0 }
   ///     print(containsDivisibleByThree)
-  ///     // Prints: true
+  ///     // Prints "true"
   ///
   /// The predicate executes each time the asynchronous sequence produces an
   /// element, until either the predicate finds a match or the sequence ends.
@@ -231,7 +231,7 @@ extension AsyncSequence {
   ///     let allLessThanTen = await Counter(howHigh: 10)
   ///         .allSatisfy { $0 < 10 }
   ///     print(allLessThanTen)
-  ///     // Prints: false
+  ///     // Prints "false"
   ///
   /// The predicate executes each time the asynchronous sequence produces an
   /// element, until either the predicate returns `false` or the sequence ends.
@@ -263,7 +263,7 @@ extension AsyncSequence where Element: Equatable {
   ///     let containsFive = await Counter(howHigh: 10)
   ///         .contains(5)
   ///     print(containsFive)
-  ///     // Prints: true
+  ///     // Prints "true"
   ///
   /// - Parameter search: The element to find in the asynchronous sequence.
   /// - Returns: `true` if the method found the element in the asynchronous
@@ -306,7 +306,7 @@ extension AsyncSequence {
   ///     let divisibleBy2And3 = await Counter(howHigh: 10)
   ///         .first { $0 % 2 == 0 && $0 % 3 == 0 }
   ///     print(divisibleBy2And3 ?? "none")
-  ///     // Prints: 6
+  ///     // Prints "6"
   ///
   /// The predicate executes each time the asynchronous sequence produces an
   /// element, until either the predicate finds a match or the sequence ends.
@@ -357,7 +357,7 @@ extension AsyncSequence {
   ///     let min = await RankCounter()
   ///         .min { $0.rawValue < $1.rawValue }
   ///     print(min ?? "none")
-  ///     // Prints: ace
+  ///     // Prints "ace"
   ///
   /// - Parameter areInIncreasingOrder: A predicate that returns `true` if its
   ///   first argument should be ordered before its second argument; otherwise,
@@ -412,7 +412,7 @@ extension AsyncSequence {
   ///     let max = await RankCounter()
   ///         .max { $0.rawValue < $1.rawValue }
   ///     print(max ?? "none")
-  ///     // Prints: king
+  ///     // Prints "king"
   ///
   /// - Parameter areInIncreasingOrder: A predicate that returns `true` if its
   ///   first argument should be ordered before its second argument; otherwise,
@@ -449,7 +449,7 @@ extension AsyncSequence where Element: Comparable {
   ///     let min = await Counter(howHigh: 10)
   ///         .min()
   ///     print(min ?? "none")
-  ///     // Prints: 1
+  ///     // Prints "1"
   ///
   /// - Returns: The sequence’s minimum element. If the sequence has no
   ///   elements, returns `nil`.
@@ -469,7 +469,7 @@ extension AsyncSequence where Element: Comparable {
   ///     let max = await Counter(howHigh: 10)
   ///         .max()
   ///     print(max ?? "none")
-  ///     // Prints: 10
+  ///     // Prints "10"
   ///
   /// - Returns: The sequence’s maximum element. If the sequence has no
   ///   elements, returns `nil`.

--- a/stdlib/public/BackDeployConcurrency/AsyncStream.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncStream.swift
@@ -89,9 +89,9 @@ import Swift
 /// produces it:
 ///
 ///     for await quake in QuakeMonitor.quakes {
-///         print ("Quake: \(quake.date)")
+///         print("Quake: \(quake.date)")
 ///     }
-///     print ("Stream finished.")
+///     print("Stream finished.")
 ///
 @available(SwiftStdlib 5.1, *)
 public struct AsyncStream<Element> {
@@ -177,7 +177,7 @@ public struct AsyncStream<Element> {
     let storage: _Storage
 
     /// Resume the task awaiting the next iteration point by having it return
-    /// nomally from its suspension point with a given element.
+    /// normally from its suspension point with a given element.
     ///
     /// - Parameter value: The value to yield from the continuation.
     /// - Returns: A `YieldResult` that indicates the success or failure of the
@@ -270,18 +270,18 @@ public struct AsyncStream<Element> {
   ///
   ///     let stream = AsyncStream<Int>(Int.self,
   ///                                   bufferingPolicy: .bufferingNewest(5)) { continuation in
-  ///             Task.detached {
-  ///                 for _ in 0..<100 {
-  ///                     await Task.sleep(1 * 1_000_000_000)
-  ///                     continuation.yield(Int.random(in: 1...10))
-  ///                 }
-  ///                 continuation.finish()
+  ///         Task.detached {
+  ///             for _ in 0..<100 {
+  ///                 await Task.sleep(1 * 1_000_000_000)
+  ///                 continuation.yield(Int.random(in: 1...10))
   ///             }
+  ///             continuation.finish()
   ///         }
+  ///     }
   ///
   ///     // Call point:
   ///     for await random in stream {
-  ///         print ("\(random)")
+  ///         print(random)
   ///     }
   ///
   public init(
@@ -303,7 +303,7 @@ public struct AsyncStream<Element> {
   ///     stream.
   ///   - onCancel: A closure to execute when canceling the stream's task.
   ///
-  /// Use this convenience initializer when you have an asychronous function
+  /// Use this convenience initializer when you have an asynchronous function
   /// that can produce elements for the stream, and don't want to invoke
   /// a continuation manually. This initializer "unfolds" your closure into
   /// an asynchronous stream. The created stream handles conformance
@@ -317,15 +317,13 @@ public struct AsyncStream<Element> {
   /// the `unfolding` parameter label.
   ///
   ///     let stream = AsyncStream<Int> {
-  ///             await Task.sleep(1 * 1_000_000_000)
-  ///             return Int.random(in: 1...10)
-  ///         }
-  ///         onCancel: { @Sendable () in print ("Canceled.") }
-  ///     )
+  ///         await Task.sleep(1 * 1_000_000_000)
+  ///         return Int.random(in: 1...10)
+  ///     } onCancel: { @Sendable () in print("Canceled.") }
   ///
   ///     // Call point:
   ///     for await random in stream {
-  ///         print ("\(random)")
+  ///         print(random)
   ///     }
   ///
   ///

--- a/stdlib/public/BackDeployConcurrency/AsyncThrowingCompactMapSequence.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncThrowingCompactMapSequence.swift
@@ -30,7 +30,7 @@ extension AsyncSequence {
   /// transformed asynchronous sequence. When the value is `5`, the closure
   /// throws `MyError`, terminating the sequence.
   ///
-  ///     let romanNumeralDict: [Int : String] =
+  ///     let romanNumeralDict: [Int: String] =
   ///         [1: "I", 2: "II", 3: "III", 5: "V"]
   ///
   ///     do {
@@ -42,12 +42,12 @@ extension AsyncSequence {
   ///                 return romanNumeralDict[value]
   ///             }
   ///         for try await numeral in stream {
-  ///             print("\(numeral) ", terminator: " ")
+  ///             print(numeral, terminator: " ")
   ///         }
   ///     } catch {
   ///         print("Error: \(error)")
   ///     }
-  ///     // Prints: I  II  III  Error: MyError()
+  ///     // Prints "I II III Error: MyError() "
   ///
   /// - Parameter transform: An error-throwing mapping closure. `transform`
   ///   accepts an element of this sequence as its parameter and returns a

--- a/stdlib/public/BackDeployConcurrency/AsyncThrowingDropWhileSequence.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncThrowingDropWhileSequence.swift
@@ -30,7 +30,7 @@ extension AsyncSequence {
   /// throws without ever printing anything.
   ///
   ///     do {
-  ///         let stream =  Counter(howHigh: 10)
+  ///         let stream = Counter(howHigh: 10)
   ///             .drop {
   ///                 if $0 % 2 == 0 {
   ///                     throw EvenError()
@@ -38,12 +38,12 @@ extension AsyncSequence {
   ///                 return $0 < 5
   ///             }
   ///         for try await number in stream {
-  ///             print("\(number) ")
+  ///             print(number)
   ///         }
   ///     } catch {
-  ///         print ("\(error)")
+  ///         print(error)
   ///     }
-  ///     // Prints: EvenError()
+  ///     // Prints "EvenError()"
   ///
   /// After the predicate returns `false`, the sequence never executes it again,
   /// and from then on the sequence passes through elements from its underlying

--- a/stdlib/public/BackDeployConcurrency/AsyncThrowingFilterSequence.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncThrowingFilterSequence.swift
@@ -23,7 +23,7 @@ extension AsyncSequence {
   /// but also throws an error for values divisible by 5:
   ///
   ///     do {
-  ///         let stream =  Counter(howHigh: 10)
+  ///         let stream = Counter(howHigh: 10)
   ///             .filter {
   ///                 if $0 % 5 == 0 {
   ///                     throw MyError()
@@ -31,12 +31,12 @@ extension AsyncSequence {
   ///                 return $0 % 2 == 0
   ///             }
   ///         for try await number in stream {
-  ///             print("\(number) ", terminator: " ")
+  ///             print(number, terminator: " ")
   ///         }
   ///     } catch {
   ///         print("Error: \(error)")
   ///     }
-  ///     // Prints: 2  4  Error: MyError()
+  ///     // Prints "2 4 Error: MyError() "
   ///
   /// - Parameter isIncluded: An error-throwing closure that takes an element
   ///   of the asynchronous sequence as its argument and returns a Boolean value

--- a/stdlib/public/BackDeployConcurrency/AsyncThrowingFlatMapSequence.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncThrowingFlatMapSequence.swift
@@ -39,18 +39,18 @@ extension AsyncSequence {
   ///                 return Counter(howHigh: value)
   ///             }
   ///         for try await number in stream {
-  ///             print ("\(number)", terminator: " ")
+  ///             print(number, terminator: " ")
   ///         }
   ///     } catch {
   ///         print(error)
   ///     }
-  ///     // Prints: 1 1 2 1 2 3 MyError()
+  ///     // Prints "1 1 2 1 2 3 MyError() "
   ///
   /// - Parameter transform: An error-throwing mapping closure. `transform`
   ///   accepts an element of this sequence as its parameter and returns an
   ///   `AsyncSequence`. If `transform` throws an error, the sequence ends.
   /// - Returns: A single, flattened asynchronous sequence that contains all
-  ///   elements in all the asychronous sequences produced by `transform`. The
+  ///   elements in all the asynchronous sequences produced by `transform`. The
   ///   sequence ends either when the the last sequence created from the last
   ///   element from base sequence ends, or when `transform` throws an error.
   @inlinable

--- a/stdlib/public/BackDeployConcurrency/AsyncThrowingMapSequence.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncThrowingMapSequence.swift
@@ -31,7 +31,7 @@ extension AsyncSequence {
   /// receiving this value from `Counter` ends the modified sequence with an
   /// error.
   ///
-  ///     let romanNumeralDict: [Int : String] =
+  ///     let romanNumeralDict: [Int: String] =
   ///         [1: "I", 2: "II", 3: "III", 5: "V"]
   ///
   ///     do {
@@ -43,12 +43,12 @@ extension AsyncSequence {
   ///                 return roman
   ///             }
   ///         for try await numeral in stream {
-  ///             print("\(numeral) ", terminator: " ")
+  ///             print(numeral, terminator: " ")
   ///         }
   ///     } catch {
-  ///         print ("Error: \(error)")
+  ///         print("Error: \(error)")
   ///     }
-  ///     // Prints: I  II  III  Error: MyError()
+  ///     // Prints "I II III Error: MyError() "
   ///
   /// - Parameter transform: A mapping closure. `transform` accepts an element
   ///   of this sequence as its parameter and returns a transformed value of the

--- a/stdlib/public/BackDeployConcurrency/AsyncThrowingPrefixWhileSequence.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncThrowingPrefixWhileSequence.swift
@@ -36,12 +36,12 @@ extension AsyncSequence {
   ///                 return $0 < 8
   ///             }
   ///         for try await number in stream {
-  ///             print("\(number) ", terminator: " ")
+  ///             print(number, terminator: " ")
   ///         }
   ///     } catch {
   ///         print("Error: \(error)")
   ///     }
-  ///     // Prints: 1  2  3  4  Error: MyError()
+  ///     // Prints "1 2 3 4 Error: MyError() "
   ///
   /// - Parameter predicate: A error-throwing closure that takes an element of
   ///   the asynchronous sequence as its argument and returns a Boolean value

--- a/stdlib/public/BackDeployConcurrency/AsyncThrowingStream.swift
+++ b/stdlib/public/BackDeployConcurrency/AsyncThrowingStream.swift
@@ -51,7 +51,7 @@ import Swift
 /// `Quake` instances every time it detects an earthquake. To receive callbacks,
 /// callers set a custom closure as the value of the monitor's
 /// `quakeHandler` property, which the monitor calls back as necessary. Callers
-/// can also set an `errorHandler` to receive asychronous error notifications,
+/// can also set an `errorHandler` to receive asynchronous error notifications,
 /// such as the monitor service suddenly becoming unavailable.
 ///
 ///     class QuakeMonitor {
@@ -105,11 +105,11 @@ import Swift
 ///
 ///     do {
 ///         for try await quake in quakeStream {
-///             print ("Quake: \(quake.date)")
+///             print("Quake: \(quake.date)")
 ///         }
-///         print ("Stream done.")
+///         print("Stream done.")
 ///     } catch {
-///         print ("Error: \(error)")
+///         print("Error: \(error)")
 ///     }
 ///
 @available(SwiftStdlib 5.1, *)
@@ -281,7 +281,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
   ///   elements to the stream and terminate the stream when finished.
   ///
   /// The `AsyncStream.Continuation` received by the `build` closure is
-  /// appopriate for use in concurrent contexts. It is thread safe to send and
+  /// appropriate for use in concurrent contexts. It is thread safe to send and
   /// finish; all calls are to the continuation are serialized. However, calling
   /// this from multiple concurrent contexts could result in out-of-order
   /// delivery.
@@ -290,33 +290,33 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
   /// initializer that produces 100 random numbers on a one-second interval,
   /// calling `yield(_:)` to deliver each element to the awaiting call point.
   /// When the `for` loop exits and the stream finishes by calling the
-  /// continuation's `finish()` method. If the random number is divisble by 5
+  /// continuation's `finish()` method. If the random number is divisible by 5
   /// with no remainder, the stream throws a `MyRandomNumberError`.
   ///
   ///     let stream = AsyncThrowingStream<Int, Error>(Int.self,
   ///                                                  bufferingPolicy: .bufferingNewest(5)) { continuation in
-  ///             Task.detached {
-  ///                 for _ in 0..<100 {
-  ///                     await Task.sleep(1 * 1_000_000_000)
-  ///                     let random = Int.random(in: 1...10)
-  ///                     if (random % 5 == 0) {
-  ///                         continuation.finish(throwing: MyRandomNumberError())
-  ///                         return
-  ///                     } else {
-  ///                         continuation.yield(random)
-  ///                     }
+  ///         Task.detached {
+  ///             for _ in 0..<100 {
+  ///                 await Task.sleep(1 * 1_000_000_000)
+  ///                 let random = Int.random(in: 1...10)
+  ///                 if random % 5 == 0 {
+  ///                     continuation.finish(throwing: MyRandomNumberError())
+  ///                     return
+  ///                 } else {
+  ///                     continuation.yield(random)
   ///                 }
-  ///                 continuation.finish()
   ///             }
+  ///             continuation.finish()
   ///         }
+  ///     }
   ///
   ///     // Call point:
   ///     do {
   ///         for try await random in stream {
-  ///             print ("\(random)")
+  ///             print(random)
   ///         }
   ///     } catch {
-  ///         print ("\(error)")
+  ///         print(error)
   ///     }
   ///
   public init(
@@ -336,7 +336,7 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
   ///   - produce: A closure that asynchronously produces elements for the
   ///    stream.
   ///
-  /// Use this convenience initializer when you have an asychronous function
+  /// Use this convenience initializer when you have an asynchronous function
   /// that can produce elements for the stream, and don't want to invoke
   /// a continuation manually. This initializer "unfolds" your closure into
   /// a full-blown asynchronous stream. The created stream handles adherence to
@@ -345,25 +345,25 @@ public struct AsyncThrowingStream<Element, Failure: Error> {
   ///
   /// The following example shows an `AsyncThrowingStream` created with this
   /// initializer that produces random numbers on a one-second interval. If the
-  /// random number is divisble by 5 with no remainder, the stream throws a
+  /// random number is divisible by 5 with no remainder, the stream throws a
   /// `MyRandomNumberError`.
   ///
   ///     let stream = AsyncThrowingStream<Int, Error> {
-  ///             await Task.sleep(1 * 1_000_000_000)
-  ///             let random = Int.random(in: 1...10)
-  ///             if (random % 5 == 0) {
-  ///                 throw MyRandomNumberError()
-  ///             }
-  ///             return random
+  ///         await Task.sleep(1 * 1_000_000_000)
+  ///         let random = Int.random(in: 1...10)
+  ///         if random % 5 == 0 {
+  ///           throw MyRandomNumberError()
   ///         }
+  ///         return random
+  ///     }
   ///
   ///     // Call point:
   ///     do {
   ///         for try await random in stream {
-  ///             print ("\(random)")
+  ///             print(random)
   ///         }
   ///     } catch {
-  ///         print ("\(error)")
+  ///         print(error)
   ///     }
   ///
   public init(

--- a/stdlib/public/BackDeployConcurrency/MainActor.swift
+++ b/stdlib/public/BackDeployConcurrency/MainActor.swift
@@ -46,7 +46,7 @@ import Swift
 extension MainActor {
   /// Execute the given body closure on the main actor.
   ///
-  /// Historical ABI entry point, superceded by the Sendable version that is
+  /// Historical ABI entry point, superseded by the Sendable version that is
   /// also inlined to back-deploy a semantic fix where this operation would
   /// not hop back at the end.
   @usableFromInline


### PR DESCRIPTION
Before `Swift 5.6 concurrency library` was separated in #59282, I revised some Concurrency files in #58930.
This PR applies the revised content to the back-deployed concurrency library.
Please review! 😄