### PR TITLE
Remove special handling of __FILE__, __LINE__, etc.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1034,10 +1034,6 @@ ERROR(invalid_label_on_stmt,none,
 ERROR(labeled_block_needs_do,none,
       "labeled block needs 'do'", ())
 
-ERROR(snake_case_deprecated,none,
-      "%0 has been replaced with %1 in Swift 3",
-      (StringRef, StringRef))
-
 // Assignment statement
 ERROR(expected_expr_assignment,none,
       "expected expression in assignment", ())

--- a/include/swift/AST/MagicIdentifierKinds.def
+++ b/include/swift/AST/MagicIdentifierKinds.def
@@ -40,14 +40,6 @@
 #define MAGIC_IDENTIFIER_TOKEN(NAME, TOKEN)
 #endif
 
-// Used when a given token always maps to a particular magic identifier kind,
-// but that token is deprecated.
-#ifndef MAGIC_IDENTIFIER_DEPRECATED_TOKEN
-#define MAGIC_IDENTIFIER_DEPRECATED_TOKEN(NAME, TOKEN) MAGIC_IDENTIFIER_TOKEN(NAME, TOKEN)
-#endif
-
-
-
 //
 // Magic string literals
 //
@@ -71,12 +63,10 @@ MAGIC_STRING_IDENTIFIER(FilePath, "#filePath", PoundFilePathExpr)
 MAGIC_STRING_IDENTIFIER(FilePathSpelledAsFile, "#file", PoundFileExpr)
   // tok::pound_file is shared with FileIDSpelledAsFile; please write custom
   // code paths for it.
-  MAGIC_IDENTIFIER_DEPRECATED_TOKEN(FilePathSpelledAsFile, kw___FILE__)
 
 /// The \c #function magic identifier literal.
 MAGIC_STRING_IDENTIFIER(Function, "#function", PoundFunctionExpr)
   MAGIC_IDENTIFIER_TOKEN(Function, pound_function)
-  MAGIC_IDENTIFIER_DEPRECATED_TOKEN(Function, kw___FUNCTION__)
 
 
 
@@ -87,12 +77,10 @@ MAGIC_STRING_IDENTIFIER(Function, "#function", PoundFunctionExpr)
 /// The \c #line magic identifier literal.
 MAGIC_INT_IDENTIFIER(Line, "#line", PoundLineExpr)
   MAGIC_IDENTIFIER_TOKEN(Line, pound_line)
-  MAGIC_IDENTIFIER_DEPRECATED_TOKEN(Line, kw___LINE__)
 
 /// The \c #column magic identifier literal.
 MAGIC_INT_IDENTIFIER(Column, "#column", PoundColumnExpr)
   MAGIC_IDENTIFIER_TOKEN(Column, pound_column)
-  MAGIC_IDENTIFIER_DEPRECATED_TOKEN(Column, kw___COLUMN__)
 
 
 
@@ -103,14 +91,9 @@ MAGIC_INT_IDENTIFIER(Column, "#column", PoundColumnExpr)
 /// The \c #dsohandle magic identifier literal.
 MAGIC_POINTER_IDENTIFIER(DSOHandle, "#dsohandle", PoundDsohandleExpr)
   MAGIC_IDENTIFIER_TOKEN(DSOHandle, pound_dsohandle)
-  MAGIC_IDENTIFIER_DEPRECATED_TOKEN(DSOHandle, kw___DSO_HANDLE__)
-
-
-
 
 #undef MAGIC_IDENTIFIER
 #undef MAGIC_STRING_IDENTIFIER
 #undef MAGIC_INT_IDENTIFIER
 #undef MAGIC_POINTER_IDENTIFIER
 #undef MAGIC_IDENTIFIER_TOKEN
-#undef MAGIC_IDENTIFIER_DEPRECATED_TOKEN

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -2590,7 +2590,6 @@ void CompletionLookup::addPoundLiteralCompletions(bool needPound) {
   case MagicIdentifierLiteralExpr::NAME:                                       \
     kwKind = CodeCompletionKeywordKind::TOKEN;                                 \
     break;
-#define MAGIC_IDENTIFIER_DEPRECATED_TOKEN(NAME, TOKEN)
 #include "swift/AST/MagicIdentifierKinds.def"
     }
 

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -641,6 +641,13 @@ bool Lexer::isOperator(StringRef string) {
 
 
 tok Lexer::kindOfIdentifier(StringRef Str, bool InSILMode) {
+  // Temporary: treat the deprecated __FILE__, __LINE__, etc. as normal
+  // identifiers. This can go away when we remove them as keywords.
+  if (Str.startswith("__") &&
+      (Str == "__FILE__" || Str == "__LINE__" || Str == "__COLUMN__" ||
+       Str == "__FUNCTION__" || Str == "__DSO_HANDLE__"))
+    return tok::identifier;
+
 #define SIL_KEYWORD(kw)
 #define KEYWORD(kw) if (Str == #kw) return tok::kw_##kw;
 #include "swift/AST/TokenKinds.def"

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1569,22 +1569,8 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
                                 BooleanLiteralExpr(isTrue, consumeToken()));
   }
 
-  // Cases for deprecated magic identifier tokens
-#define MAGIC_IDENTIFIER_DEPRECATED_TOKEN(NAME, TOKEN) case tok::TOKEN:
-#include "swift/AST/MagicIdentifierKinds.def"
-  {
-    auto Kind = getMagicIdentifierLiteralKind(Tok.getKind(), Context.LangOpts);
-    auto replacement = MagicIdentifierLiteralExpr::getKindString(Kind);
-
-    diagnose(Tok.getLoc(), diag::snake_case_deprecated,
-             Tok.getText(), replacement)
-      .fixItReplace(Tok.getLoc(), replacement);
-    LLVM_FALLTHROUGH;
-  }
-
   // Cases for non-deprecated magic identifier tokens
   case tok::pound_file:
-#define MAGIC_IDENTIFIER_DEPRECATED_TOKEN(NAME, TOKEN)
 #define MAGIC_IDENTIFIER_TOKEN(NAME, TOKEN) case tok::TOKEN:
 #include "swift/AST/MagicIdentifierKinds.def"
   {
@@ -1593,7 +1579,14 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
     return makeParserResult(new (Context) MagicIdentifierLiteralExpr(
         Kind, Loc, /*implicit=*/false));
   }
-      
+
+  case tok::kw___FILE__:
+  case tok::kw___LINE__:
+  case tok::kw___COLUMN__:
+  case tok::kw___FUNCTION__:
+  case tok::kw___DSO_HANDLE__:
+    llvm_unreachable("Lexer doesn't produce these tokens any more");
+
   case tok::identifier:  // foo
   case tok::kw_self:     // self
 

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -93,11 +93,11 @@ do {
   #column // expected-warning {{#column literal is unused}}
   #function // expected-warning {{#function literal is unused}}
   #dsohandle // expected-warning {{#dsohandle literal is unused}}
-  __FILE__ // expected-error {{__FILE__ has been replaced with #file in Swift 3}} expected-warning {{#file literal is unused}}
-  __LINE__ // expected-error {{__LINE__ has been replaced with #line in Swift 3}} expected-warning {{#line literal is unused}}
-  __COLUMN__ // expected-error {{__COLUMN__ has been replaced with #column in Swift 3}} expected-warning {{#column literal is unused}}
-  __FUNCTION__ // expected-error {{__FUNCTION__ has been replaced with #function in Swift 3}} expected-warning {{#function literal is unused}}
-  __DSO_HANDLE__ // expected-error {{__DSO_HANDLE__ has been replaced with #dsohandle in Swift 3}} expected-warning {{#dsohandle literal is unused}}
+  __FILE__ // expected-error {{cannot find '__FILE__' in scope}}
+  __LINE__ // expected-error {{cannot find '__LINE__' in scope}}
+  __COLUMN__ // expected-error {{cannot find '__COLUMN__' in scope}}
+  __FUNCTION__ // expected-error {{cannot find '__FUNCTION__' in scope}}
+  __DSO_HANDLE__ // expected-error {{cannot find '__DSO_HANDLE__' in scope}}
 
   nil // expected-error {{'nil' requires a contextual type}}
   #fileLiteral(resourceName: "what.txt") // expected-error {{could not infer type of file reference literal}} expected-note * {{}}
@@ -172,7 +172,7 @@ var test1b = { 42 }
 var test1c = { { 42 } }
 var test1d = { { { 42 } } }
 
-func test2(_ a: Int, b: Int) -> (c: Int) { // expected-error{{cannot create a single-element tuple with an element label}} {{34-37=}} expected-note {{did you mean 'a'?}} expected-note {{did you mean 'b'?}}
+func test2(_ a: Int, b: Int) -> (c: Int) { // expected-error{{cannot create a single-element tuple with an element label}}
  _ = a+b
  a+b+c // expected-error{{cannot find 'c' in scope}}
  return a+b
@@ -530,7 +530,7 @@ func testSingleQuoteStringLiterals() {
 }
 
 // <rdar://problem/17128913>
-var s = "" // expected-note {{did you mean 's'?}}
+var s = ""
 s.append(contentsOf: ["x"])
 
 //===----------------------------------------------------------------------===//
@@ -611,7 +611,7 @@ var ruleVar: Rule
 ruleVar = Rule("a") // expected-error {{missing argument label 'target:' in call}}
 // expected-error@-1 {{missing argument for parameter 'dependencies' in call}}
 
-class C { // expected-note {{did you mean 'C'?}}
+class C {
   var x: C?
   init(other: C?) { x = other }
 
@@ -659,11 +659,6 @@ func iterators() {
 //===----------------------------------------------------------------------===//
 
 func magic_literals() {
-  _ = __FILE__  // expected-error {{__FILE__ has been replaced with #file in Swift 3}}
-  _ = __LINE__  // expected-error {{__LINE__ has been replaced with #line in Swift 3}}
-  _ = __COLUMN__  // expected-error {{__COLUMN__ has been replaced with #column in Swift 3}}
-  _ = __DSO_HANDLE__  // expected-error {{__DSO_HANDLE__ has been replaced with #dsohandle in Swift 3}}
-
   _ = #file
   _ = #line + #column
   var _: UInt8 = #line + #column


### PR DESCRIPTION
These were replaced by `#file`, `#line`, etc. with SE-0028, prior to Swift 3. We don't need this custom error message any more, and they shouldn't be keywords. Stop treating them as keywords in the lexer.
