### PR TITLE
[android][test] Disable new C++ Interop test

### DIFF
--- a/test/Interop/Cxx/class/custom-new-operator-irgen.swift
+++ b/test/Interop/Cxx/class/custom-new-operator-irgen.swift
@@ -1,5 +1,7 @@
 // RUN: %target-swiftxx-frontend -I %S/Inputs %s -emit-ir | %FileCheck %s
 
+// XFAIL: OS=linux-android, OS=linux-androideabi
+
 import CustomNewOperator
 
 var x = callsCustomNew()

--- a/utils/swift_build_support/swift_build_support/products/cmake_product.py
+++ b/utils/swift_build_support/swift_build_support/products/cmake_product.py
@@ -159,10 +159,14 @@ class CMakeProduct(product.Product):
         swift_cmake_options = cmake.CMakeOptions()
 
         if host_target.startswith("android"):
+            # Clang uses a different sysroot natively on Android in the Termux
+            # app, which the Termux build scripts pass in through a $PREFIX
+            # variable.
             prefix = os.environ.get("PREFIX")
             if prefix:
                 llvm_cmake_options.define('DEFAULT_SYSROOT:STRING',
                                           os.path.dirname(prefix))
+                llvm_cmake_options.define('CLANG_DEFAULT_LINKER:STRING', 'lld')
 
             # Android doesn't support building all of compiler-rt yet.
             if not self.is_cross_compile_target(host_target):


### PR DESCRIPTION
Also, add flag and comment from `build-script-util` that was missed in the recent Python translation, #38507.

@egorzhdan, @drodriguez, this new test made the Android CI red a couple weeks ago.