### PR TITLE
Remove `__FILE__` et al as keywords.

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -641,13 +641,6 @@ bool Lexer::isOperator(StringRef string) {
 
 
 tok Lexer::kindOfIdentifier(StringRef Str, bool InSILMode) {
-  // Temporary: treat the deprecated __FILE__, __LINE__, etc. as normal
-  // identifiers. This can go away when we remove them as keywords.
-  if (Str.startswith("__") &&
-      (Str == "__FILE__" || Str == "__LINE__" || Str == "__COLUMN__" ||
-       Str == "__FUNCTION__" || Str == "__DSO_HANDLE__"))
-    return tok::identifier;
-
 #define SIL_KEYWORD(kw)
 #define KEYWORD(kw) if (Str == #kw) return tok::kw_##kw;
 #include "swift/AST/TokenKinds.def"

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1580,13 +1580,6 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
         Kind, Loc, /*implicit=*/false));
   }
 
-  case tok::kw___FILE__:
-  case tok::kw___LINE__:
-  case tok::kw___COLUMN__:
-  case tok::kw___FUNCTION__:
-  case tok::kw___DSO_HANDLE__:
-    llvm_unreachable("Lexer doesn't produce these tokens any more");
-
   case tok::identifier:  // foo
   case tok::kw_self:     // self
 


### PR DESCRIPTION
These were keywords prior to Swift 2, and have only been kept around as keywords to provide a custom error message to rewrite to `#file` et al. It's incorrect to keep them as keywords, and that error should be implemented differently if we care about it.
