### PR TITLE
[CS] Increase the score for implicit global actor function conversion

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3020,6 +3020,13 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
         return getTypeMatchFailure(locator);
     } else if (kind < ConstraintKind::Subtype) {
       return getTypeMatchFailure(locator);
+    } else {
+      // It is possible to convert from a function without a global actor to a
+      // similar function type that does have a global actor. But, since there
+      // is a function conversion going on here, let's increase the score to
+      // avoid ambiguity when solver can also match a global actor matching
+      // function type.
+      increaseScore(SK_FunctionConversion);
     }
   }
 

--- a/test/Concurrency/global_actor_function_types.swift
+++ b/test/Concurrency/global_actor_function_types.swift
@@ -153,3 +153,10 @@ func test() {
     onSomeGlobalActor()
   }
 }
+
+// https://github.com/apple/swift/issues/61436
+let x: @MainActor () -> Void
+
+let y: () -> Void = {}
+
+x = true ? y : y // Ok


### PR DESCRIPTION
<!-- What's in this pull request? -->
From https://github.com/apple/swift/pull/36466 a conversion between a normal function `() -> Void` to a global actor function `@MainActor () -> Void` (which generates an implicit conversion). As we also can see in the proposal [examples](https://github.com/apple/swift-evolution/blob/main/proposals/0316-global-actors.md#global-actor-function-types).

In this case solver is finding both `@MainActor () -> Void` and `() -> Void` as possible type for result of ternary operator which is now leading to [ambiguity](https://godbolt.org/z/1zsrc7xs7). So this adjust this case to whenever matching a function without a global actor to a function type that does have a global actor, increase the function conversion score to account for that implicit conversion and avoid ambiguity in those cases.

That sounds reasonable to me, but let me know if I'm missing something important.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves https://github.com/apple/swift/issues/61436

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
