### PR TITLE
[IDE] Rename CodeCompletion to IDEInspection in cases where the code path no longer exclusively applies to code completion

### DIFF
--- a/include/swift/AST/ASTTypeIDZone.def
+++ b/include/swift/AST/ASTTypeIDZone.def
@@ -44,8 +44,8 @@ SWIFT_TYPEID(Witness)
 SWIFT_TYPEID_NAMED(AbstractFunctionDecl *, AbstractFunctionDecl)
 SWIFT_TYPEID_NAMED(ApplyExpr *, ApplyExpr)
 SWIFT_TYPEID_NAMED(ClosureExpr *, ClosureExpr)
-SWIFT_TYPEID_NAMED(CodeCompletionCallbacksFactory *,
-                   CodeCompletionCallbacksFactory)
+SWIFT_TYPEID_NAMED(IDEInspectionCallbacksFactory *,
+                                 IDEInspectionCallbacksFactory)
 SWIFT_TYPEID_NAMED(ConstructorDecl *, ConstructorDecl)
 SWIFT_TYPEID_NAMED(CustomAttr *, CustomAttr)
 SWIFT_TYPEID_NAMED(ConstValueTypeInfo *, ConstValueTypeInfo)

--- a/include/swift/AST/ASTTypeIDs.h
+++ b/include/swift/AST/ASTTypeIDs.h
@@ -29,7 +29,7 @@ enum class BodyInitKind;
 struct BodyInitKindAndExpr;
 class BraceStmt;
 class ClosureExpr;
-class CodeCompletionCallbacksFactory;
+class IDEInspectionCallbacksFactory;
 class ConstructorDecl;
 class CustomAttr;
 class Decl;

--- a/include/swift/AST/ParseRequests.h
+++ b/include/swift/AST/ParseRequests.h
@@ -136,11 +136,11 @@ public:
 };
 
 void simple_display(llvm::raw_ostream &out,
-                    const CodeCompletionCallbacksFactory *factory);
+                    const IDEInspectionCallbacksFactory *factory);
 
-class CodeCompletionSecondPassRequest
-    : public SimpleRequest<CodeCompletionSecondPassRequest,
-                           bool(SourceFile *, CodeCompletionCallbacksFactory *),
+class IDEInspectionSecondPassRequest
+    : public SimpleRequest<IDEInspectionSecondPassRequest,
+                           bool(SourceFile *, IDEInspectionCallbacksFactory *),
                            RequestFlags::Uncached|RequestFlags::DependencySource> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -150,7 +150,7 @@ private:
 
   // Evaluation.
   bool evaluate(Evaluator &evaluator, SourceFile *SF,
-                CodeCompletionCallbacksFactory *Factory) const;
+                IDEInspectionCallbacksFactory *Factory) const;
 
 public:
   evaluator::DependencySource

--- a/include/swift/AST/ParseTypeIDZone.def
+++ b/include/swift/AST/ParseTypeIDZone.def
@@ -14,8 +14,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-SWIFT_REQUEST(Parse, CodeCompletionSecondPassRequest,
-              bool (SourceFile *, CodeCompletionCallbacksFactory *),
+SWIFT_REQUEST(Parse, IDEInspectionSecondPassRequest,
+              bool (SourceFile *, IDEInspectionCallbacksFactory *),
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(Parse, ParseMembersRequest,
               FingerprintAndMembers(IterableDeclContext *), Cached, NoLocationInfo)

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3340,8 +3340,8 @@ public:
 /// Retrieve the file being used for code completion in the main module.
 // FIXME: This isn't really a type-checking request, if we ever split off a
 // zone for more basic AST requests, this should be moved there.
-class CodeCompletionFileRequest
-    : public SimpleRequest<CodeCompletionFileRequest,
+class IDEInspectionFileRequest
+    : public SimpleRequest<IDEInspectionFileRequest,
                            SourceFile *(ModuleDecl *), RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -42,7 +42,7 @@ SWIFT_REQUEST(TypeChecker, CheckRedeclarationRequest,
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ClassAncestryFlagsRequest,
               AncestryFlags(ClassDecl *), Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, CodeCompletionFileRequest,
+SWIFT_REQUEST(TypeChecker, IDEInspectionFileRequest,
               SourceFile *(ModuleDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CompareDeclSpecializationRequest,
               bool (DeclContext *, ValueDecl *, ValueDecl *, bool), Cached,

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -39,8 +39,8 @@ public:
 private:
   llvm::SourceMgr LLVMSourceMgr;
   llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem;
-  unsigned CodeCompletionBufferID = 0U;
-  unsigned CodeCompletionOffset;
+  unsigned IDEInspectionTargetBufferID = 0U;
+  unsigned IDEInspectionTargetOffset;
 
   /// Associates buffer identifiers to buffer IDs.
   llvm::DenseMap<StringRef, unsigned> BufIdentIDMap;
@@ -84,26 +84,26 @@ public:
     return FileSystem;
   }
 
-  void setCodeCompletionPoint(unsigned BufferID, unsigned Offset) {
+  void setIDEInspectionTarget(unsigned BufferID, unsigned Offset) {
     assert(BufferID != 0U && "Buffer should be valid");
 
-    CodeCompletionBufferID = BufferID;
-    CodeCompletionOffset = Offset;
+    IDEInspectionTargetBufferID = BufferID;
+    IDEInspectionTargetOffset = Offset;
   }
 
-  bool hasCodeCompletionBuffer() const {
-    return CodeCompletionBufferID != 0U;
+  bool hasIDEInspectionTargetBuffer() const {
+    return IDEInspectionTargetBufferID != 0U;
   }
 
-  unsigned getCodeCompletionBufferID() const {
-    return CodeCompletionBufferID;
+  unsigned getIDEInspectionTargetBufferID() const {
+    return IDEInspectionTargetBufferID;
   }
 
-  unsigned getCodeCompletionOffset() const {
-    return CodeCompletionOffset;
+  unsigned getIDEInspectionTargetOffset() const {
+    return IDEInspectionTargetOffset;
   }
 
-  SourceLoc getCodeCompletionLoc() const;
+  SourceLoc getIDEInspectionTargetLoc() const;
 
   const llvm::DenseMap<SourceRange, SourceRange> &getReplacedRanges() const {
     return ReplacedRanges;
@@ -142,9 +142,9 @@ public:
   }
 
   /// Returns true if range \p R contains the code-completion location, if any.
-  bool rangeContainsCodeCompletionLoc(SourceRange R) const {
-    return CodeCompletionBufferID
-               ? rangeContainsTokenLoc(R, getCodeCompletionLoc())
+  bool rangeContainsIDEInspectionTarget(SourceRange R) const {
+    return IDEInspectionTargetBufferID
+               ? rangeContainsTokenLoc(R, getIDEInspectionTargetLoc())
                : false;
   }
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -35,7 +35,7 @@
 #include "swift/Frontend/ModuleInterfaceSupport.h"
 #include "swift/IRGen/TBDGen.h"
 #include "swift/Migrator/MigratorOptions.h"
-#include "swift/Parse/CodeCompletionCallbacks.h"
+#include "swift/Parse/IDEInspectionCallbacks.h"
 #include "swift/Parse/Parser.h"
 #include "swift/Sema/SourceLoader.h"
 #include "swift/Serialization/Validation.h"
@@ -95,13 +95,14 @@ class CompilerInvocation {
   IRGenOptions IRGenOpts;
   TBDGenOptions TBDGenOpts;
   ModuleInterfaceOptions ModuleInterfaceOpts;
-  llvm::MemoryBuffer *CodeCompletionBuffer = nullptr;
+  llvm::MemoryBuffer *IDEInspectionTargetBuffer = nullptr;
 
-  /// Code completion offset in bytes from the beginning of the main
-  /// source file.  Valid only if \c isCodeCompletion() == true.
-  unsigned CodeCompletionOffset = ~0U;
+  /// The offset that IDEInspection wants to further examine in offset of bytes
+  /// from the beginning of the main source file.  Valid only if
+  /// \c isIDEInspection() == true.
+  unsigned IDEInspectionOffset = ~0U;
 
-  CodeCompletionCallbacksFactory *CodeCompletionFactory = nullptr;
+  IDEInspectionCallbacksFactory *IDEInspectionFactory = nullptr;
 
 public:
   CompilerInvocation();
@@ -322,22 +323,22 @@ public:
     return FrontendOpts.InputsAndOutputs.getSingleOutputFilename();
   }
 
-  void setCodeCompletionPoint(llvm::MemoryBuffer *Buf, unsigned Offset) {
+  void setIDEInspectionTarget(llvm::MemoryBuffer *Buf, unsigned Offset) {
     assert(Buf);
-    CodeCompletionBuffer = Buf;
-    CodeCompletionOffset = Offset;
+    IDEInspectionTargetBuffer = Buf;
+    IDEInspectionOffset = Offset;
     // We don't need typo-correction for code-completion.
     // FIXME: This isn't really true, but is a performance issue.
     LangOpts.TypoCorrectionLimit = 0;
   }
 
-  std::pair<llvm::MemoryBuffer *, unsigned> getCodeCompletionPoint() const {
-    return std::make_pair(CodeCompletionBuffer, CodeCompletionOffset);
+  std::pair<llvm::MemoryBuffer *, unsigned> getIDEInspectionTarget() const {
+    return std::make_pair(IDEInspectionTargetBuffer, IDEInspectionOffset);
   }
 
   /// \returns true if we are doing code completion.
-  bool isCodeCompletion() const {
-    return CodeCompletionOffset != ~0U;
+  bool isIDEInspection() const {
+    return IDEInspectionOffset != ~0U;
   }
 
   /// Retrieve a module hash string that is suitable for uniquely
@@ -588,9 +589,9 @@ public:
 
   const CompilerInvocation &getInvocation() const { return Invocation; }
 
-  /// If a code completion buffer has been set, returns the corresponding source
+  /// If a IDE inspection buffer has been set, returns the corresponding source
   /// file.
-  SourceFile *getCodeCompletionFile() const;
+  SourceFile *getIDEInspectionFile() const;
 
 private:
   /// Set up the file system by loading and validating all VFS overlay YAML
@@ -609,7 +610,7 @@ private:
   /// \return false if successful, true on error.
   bool setupDiagnosticVerifierIfNeeded();
 
-  Optional<unsigned> setUpCodeCompletionBuffer();
+  Optional<unsigned> setUpIDEInspectionTargetBuffer();
 
   /// Find a buffer for a given input file and ensure it is recorded in
   /// SourceMgr, PartialModules, or InputSourceCodeBufferIDs as appropriate.

--- a/include/swift/IDE/CodeCompletion.h
+++ b/include/swift/IDE/CodeCompletion.h
@@ -20,7 +20,7 @@
 #include "swift/IDE/CompletionLookup.h"
 
 namespace swift {
-class CodeCompletionCallbacksFactory;
+class IDEInspectionCallbacksFactory;
 class Decl;
 class DeclContext;
 class FrontendOptions;
@@ -70,7 +70,7 @@ void deliverCompletionResults(CodeCompletionContext &CompletionContext,
                               CodeCompletionConsumer &Consumer);
 
 /// Create a factory for code completion callbacks.
-CodeCompletionCallbacksFactory *
+IDEInspectionCallbacksFactory *
 makeCodeCompletionCallbacksFactory(CodeCompletionContext &CompletionContext,
                                    CodeCompletionConsumer &Consumer);
 

--- a/include/swift/IDE/CodeCompletionConsumer.h
+++ b/include/swift/IDE/CodeCompletionConsumer.h
@@ -14,7 +14,7 @@
 #define SWIFT_IDE_CODECOMPLETIONCONSUMER
 
 #include "swift/IDE/CodeCompletionContext.h"
-#include "swift/Parse/CodeCompletionCallbacks.h"
+#include "swift/Parse/IDEInspectionCallbacks.h"
 
 namespace swift {
 namespace ide {

--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -26,7 +26,7 @@
 #include "swift/IDE/CodeCompletionResult.h"
 #include "swift/IDE/CodeCompletionStringPrinter.h"
 #include "swift/IDE/PossibleParamInfo.h"
-#include "swift/Parse/CodeCompletionCallbacks.h"
+#include "swift/Parse/IDEInspectionCallbacks.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "swift/Strings.h"
 
@@ -616,7 +616,8 @@ public:
 
   void collectPrecedenceGroups();
 
-  void getPrecedenceGroupCompletions(CodeCompletionCallbacks::PrecedenceGroupCompletionKind SK);
+  void getPrecedenceGroupCompletions(
+      IDEInspectionCallbacks::PrecedenceGroupCompletionKind SK);
 
   void getPoundAvailablePlatformCompletions();
 

--- a/include/swift/IDE/ConformingMethodList.h
+++ b/include/swift/IDE/ConformingMethodList.h
@@ -17,7 +17,7 @@
 #include "swift/Basic/LLVM.h"
 
 namespace swift {
-class CodeCompletionCallbacksFactory;
+class IDEInspectionCallbacksFactory;
 
 namespace ide {
 
@@ -45,7 +45,7 @@ public:
 };
 
 /// Create a factory for code completion callbacks.
-CodeCompletionCallbacksFactory *makeConformingMethodListCallbacksFactory(
+IDEInspectionCallbacksFactory *makeConformingMethodListCallbacksFactory(
     ArrayRef<const char *> expectedTypeNames,
     ConformingMethodListConsumer &Consumer);
 

--- a/include/swift/IDE/CursorInfo.h
+++ b/include/swift/IDE/CursorInfo.h
@@ -18,7 +18,7 @@
 #include "swift/IDE/Utils.h"
 
 namespace swift {
-class CodeCompletionCallbacksFactory;
+class IDEInspectionCallbacksFactory;
 
 namespace ide {
 
@@ -30,7 +30,7 @@ public:
 };
 
 /// Create a factory for code completion callbacks.
-CodeCompletionCallbacksFactory *
+IDEInspectionCallbacksFactory *
 makeCursorInfoCallbacksFactory(CursorInfoConsumer &Consumer,
                                SourceLoc RequestedLoc);
 

--- a/include/swift/IDE/REPLCodeCompletion.h
+++ b/include/swift/IDE/REPLCodeCompletion.h
@@ -20,7 +20,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/IDE/CodeCompletionCache.h"
 #include "swift/IDE/CodeCompletionConsumer.h"
-#include "swift/Parse/CodeCompletionCallbacks.h"
+#include "swift/Parse/IDEInspectionCallbacks.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include <memory>
@@ -63,7 +63,7 @@ private:
   ide::CodeCompletionCache CompletionCache;
   ide::CodeCompletionContext CompletionContext;
   std::unique_ptr<ide::CodeCompletionConsumer> Consumer;
-  std::unique_ptr<CodeCompletionCallbacksFactory> CompletionCallbacksFactory;
+  std::unique_ptr<IDEInspectionCallbacksFactory> IDEInspectionCallbacksFactory;
 
   std::vector<StringRef> CompletionStrings;
   std::vector<CookedResult> CookedResults;

--- a/include/swift/IDE/TypeContextInfo.h
+++ b/include/swift/IDE/TypeContextInfo.h
@@ -17,7 +17,7 @@
 #include "swift/Basic/LLVM.h"
 
 namespace swift {
-class CodeCompletionCallbacksFactory;
+class IDEInspectionCallbacksFactory;
 
 namespace ide {
 
@@ -41,7 +41,7 @@ public:
 };
 
 /// Create a factory for code completion callbacks.
-CodeCompletionCallbacksFactory *
+IDEInspectionCallbacksFactory *
 makeTypeContextInfoCallbacksFactory(TypeContextInfoConsumer &Consumer);
 
 } // namespace ide

--- a/include/swift/Parse/IDEInspectionCallbacks.h
+++ b/include/swift/Parse/IDEInspectionCallbacks.h
@@ -1,4 +1,4 @@
-//===--- CodeCompletionCallbacks.h - Parser's interface to code completion ===//
+//===--- IDEInspectionCallbacks.h - Parser's interface to IDE inspection --===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -30,7 +30,7 @@ enum class ObjCSelectorContext {
 };
 
 /// Parser's interface to code completion.
-class CodeCompletionCallbacks {
+class IDEInspectionCallbacks {
 protected:
   Parser &P;
   ASTContext &Context;
@@ -55,11 +55,11 @@ protected:
   std::vector<Expr *> leadingSequenceExprs;
 
 public:
-  CodeCompletionCallbacks(Parser &P)
+  IDEInspectionCallbacks(Parser &P)
       : P(P), Context(P.Context) {
   }
 
-  virtual ~CodeCompletionCallbacks() {}
+  virtual ~IDEInspectionCallbacks() {}
 
   bool isInsideObjCSelector() const {
     return CompleteExprSelectorContext != ObjCSelectorContext::None;
@@ -81,10 +81,10 @@ public:
   }
 
   class InEnumElementRawValueRAII {
-    CodeCompletionCallbacks *Callbacks;
+    IDEInspectionCallbacks *Callbacks;
 
   public:
-    InEnumElementRawValueRAII(CodeCompletionCallbacks *Callbacks)
+    InEnumElementRawValueRAII(IDEInspectionCallbacks *Callbacks)
         : Callbacks(Callbacks) {
       if (Callbacks)
         Callbacks->InEnumElementRawValue = true;
@@ -99,10 +99,10 @@ public:
   /// RAII type that temporarily sets the "in Objective-C #selector expression"
   /// flag on the code completion callbacks object.
   class InObjCSelectorExprRAII {
-    CodeCompletionCallbacks *Callbacks;
+    IDEInspectionCallbacks *Callbacks;
 
   public:
-    InObjCSelectorExprRAII(CodeCompletionCallbacks *Callbacks,
+    InObjCSelectorExprRAII(IDEInspectionCallbacks *Callbacks,
                            ObjCSelectorContext SelectorContext)
         : Callbacks(Callbacks) {
       if (Callbacks)
@@ -257,14 +257,14 @@ public:
   virtual void doneParsing(SourceFile *SrcFile) = 0;
 };
 
-/// A factory to create instances of \c CodeCompletionCallbacks.
-class CodeCompletionCallbacksFactory {
+/// A factory to create instances of \c IDEInspectionCallbacks.
+class IDEInspectionCallbacksFactory {
 public:
-  virtual ~CodeCompletionCallbacksFactory() {}
+  virtual ~IDEInspectionCallbacksFactory() {}
 
-  /// Create an instance of \c CodeCompletionCallbacks.  The result
+  /// Create an instance of \c IDEInspectionCallbacks.  The result
   /// should be deallocated with 'delete'.
-  virtual CodeCompletionCallbacks *createCodeCompletionCallbacks(Parser &P) = 0;
+  virtual IDEInspectionCallbacks *createIDEInspectionCallbacks(Parser &P) = 0;
 };
 
 } // namespace swift

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -40,8 +40,8 @@ namespace llvm {
 }
 
 namespace swift {
-  class CodeCompletionCallbacks;
-  class CodeCompletionCallbacksFactory;
+  class IDEInspectionCallbacks;
+  class IDEInspectionCallbacksFactory;
   class DefaultArgumentInitializer;
   class DiagnosticEngine;
   class Expr;
@@ -126,7 +126,7 @@ public:
   std::unique_ptr<PersistentParserState> OwnedState;
   DeclContext *CurDeclContext;
   ASTContext &Context;
-  CodeCompletionCallbacks *CodeCompletion = nullptr;
+  IDEInspectionCallbacks *IDECallbacks = nullptr;
   std::vector<Located<std::vector<ParamDecl*>>> AnonClosureVars;
 
   /// The current token hash, or \c None if the parser isn't computing a hash
@@ -187,12 +187,12 @@ public:
   /// the #if decl.
   bool shouldEvaluatePoundIfDecls() const;
 
-  void setCodeCompletionCallbacks(CodeCompletionCallbacks *Callbacks) {
-    CodeCompletion = Callbacks;
+  void setIDECallbacks(IDEInspectionCallbacks *Callbacks) {
+    IDECallbacks = Callbacks;
   }
 
-  bool isCodeCompletionFirstPass() const {
-    return SourceMgr.hasCodeCompletionBuffer() && !CodeCompletion;
+  bool isIDEInspectionFirstPass() const {
+    return SourceMgr.hasIDEInspectionTargetBuffer() && !IDECallbacks;
   }
 
   bool allowTopLevelCode() const;
@@ -1897,8 +1897,8 @@ public:
   //===--------------------------------------------------------------------===//
   // Code completion second pass.
 
-  void performCodeCompletionSecondPassImpl(
-      CodeCompletionDelayedDeclState &info);
+  void performIDEInspectionSecondPassImpl(
+      IDEInspectionDelayedDeclState &info);
 };
 
 /// Describes a parsed declaration name.

--- a/include/swift/Parse/PersistentParserState.h
+++ b/include/swift/Parse/PersistentParserState.h
@@ -26,33 +26,33 @@ class SourceFile;
 class DeclContext;
 class IterableDeclContext;
 
-enum class CodeCompletionDelayedDeclKind {
+enum class IDEInspectionDelayedDeclKind {
   TopLevelCodeDecl,
   Decl,
   FunctionBody,
 };
 
-class CodeCompletionDelayedDeclState {
+class IDEInspectionDelayedDeclState {
 public:
-  CodeCompletionDelayedDeclKind Kind;
+  IDEInspectionDelayedDeclKind Kind;
   unsigned Flags;
   DeclContext *ParentContext;
   unsigned StartOffset;
   unsigned EndOffset;
   unsigned PrevOffset;
 
-  CodeCompletionDelayedDeclState(CodeCompletionDelayedDeclKind Kind,
-                                 unsigned Flags, DeclContext *ParentContext,
-                                 unsigned StartOffset, unsigned EndOffset,
-                                 unsigned PrevOffset)
+  IDEInspectionDelayedDeclState(IDEInspectionDelayedDeclKind Kind,
+                                unsigned Flags, DeclContext *ParentContext,
+                                unsigned StartOffset, unsigned EndOffset,
+                                unsigned PrevOffset)
       : Kind(Kind), Flags(Flags), ParentContext(ParentContext),
-        StartOffset(StartOffset), EndOffset(EndOffset),
-        PrevOffset(PrevOffset) {}
+        StartOffset(StartOffset), EndOffset(EndOffset), PrevOffset(PrevOffset) {
+  }
 };
 
 /// Parser state persistent across multiple parses.
 class PersistentParserState {
-  std::unique_ptr<CodeCompletionDelayedDeclState> CodeCompletionDelayedDeclStat;
+  std::unique_ptr<IDEInspectionDelayedDeclState> IDEInspectionDelayedDeclStat;
 
   /// The local context for all top-level code.
   TopLevelContext TopLevelCode;
@@ -62,31 +62,31 @@ public:
   PersistentParserState(ASTContext &ctx) : PersistentParserState() { }
   ~PersistentParserState();
 
-  void setCodeCompletionDelayedDeclState(SourceManager &SM, unsigned BufferID,
-                                         CodeCompletionDelayedDeclKind Kind,
-                                         unsigned Flags,
-                                         DeclContext *ParentContext,
-                                         SourceRange BodyRange,
-                                         SourceLoc PreviousLoc);
-  void restoreCodeCompletionDelayedDeclState(
-      const CodeCompletionDelayedDeclState &other);
+  void setIDEInspectionDelayedDeclState(SourceManager &SM, unsigned BufferID,
+                                        IDEInspectionDelayedDeclKind Kind,
+                                        unsigned Flags,
+                                        DeclContext *ParentContext,
+                                        SourceRange BodyRange,
+                                        SourceLoc PreviousLoc);
+  void restoreIDEInspectionDelayedDeclState(
+      const IDEInspectionDelayedDeclState &other);
 
-  bool hasCodeCompletionDelayedDeclState() const {
-    return CodeCompletionDelayedDeclStat.get() != nullptr;
+  bool hasIDEInspectionDelayedDeclState() const {
+    return IDEInspectionDelayedDeclStat.get() != nullptr;
   }
 
-  CodeCompletionDelayedDeclState &getCodeCompletionDelayedDeclState() {
-    return *CodeCompletionDelayedDeclStat.get();
+  IDEInspectionDelayedDeclState &getIDEInspectionDelayedDeclState() {
+    return *IDEInspectionDelayedDeclStat.get();
   }
-  const CodeCompletionDelayedDeclState &
-  getCodeCompletionDelayedDeclState() const {
-    return *CodeCompletionDelayedDeclStat.get();
+  const IDEInspectionDelayedDeclState &
+  getIDEInspectionDelayedDeclState() const {
+    return *IDEInspectionDelayedDeclStat.get();
   }
 
-  std::unique_ptr<CodeCompletionDelayedDeclState>
-  takeCodeCompletionDelayedDeclState() {
-    assert(hasCodeCompletionDelayedDeclState());
-    return std::move(CodeCompletionDelayedDeclStat);
+  std::unique_ptr<IDEInspectionDelayedDeclState>
+  takeIDEInspectionDelayedDeclState() {
+    assert(hasIDEInspectionDelayedDeclState());
+    return std::move(IDEInspectionDelayedDeclStat);
   }
 
   TopLevelContext &getTopLevelContext() {

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3681,10 +3681,8 @@ public:
     return TypeVariables.count(typeVar) > 0;
   }
 
-  /// Whether the given ASTNode's source range contains the code
-  /// completion location.
-  bool containsCodeCompletionLoc(ASTNode node) const;
-  bool containsCodeCompletionLoc(const ArgumentList *args) const;
+  bool containsIDEInspectionTarget(ASTNode node) const;
+  bool containsIDEInspectionTarget(const ArgumentList *args) const;
 
   /// Marks the argument \p Arg as being ignored because it occurs after the
   /// code completion token. This assumes that the argument is not type checked

--- a/include/swift/Subsystems.h
+++ b/include/swift/Subsystems.h
@@ -40,7 +40,7 @@ namespace llvm {
 namespace swift {
   class GenericSignatureBuilder;
   class ASTContext;
-  class CodeCompletionCallbacksFactory;
+  class IDEInspectionCallbacksFactory;
   class Decl;
   class DeclContext;
   class DiagnosticConsumer;
@@ -104,9 +104,8 @@ namespace swift {
 
   /// @}
 
-  /// Finish the code completion.
-  void performCodeCompletionSecondPass(SourceFile &SF,
-                                       CodeCompletionCallbacksFactory &Factory);
+  void performIDEInspectionSecondPass(SourceFile &SF,
+                                      IDEInspectionCallbacksFactory &Factory);
 
   /// Lex and return a vector of tokens for the given buffer.
   std::vector<Token> tokenize(const LangOptions &LangOpts,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8017,9 +8017,9 @@ BraceStmt *AbstractFunctionDecl::getBody(bool canSynthesize) const {
   ASTContext &ctx = getASTContext();
 
   // Don't allow getBody() to trigger parsing of an unparsed body containing the
-  // code completion location.
+  // IDE inspection location.
   if (getBodyKind() == BodyKind::Unparsed &&
-      ctx.SourceMgr.rangeContainsCodeCompletionLoc(getBodySourceRange())) {
+      ctx.SourceMgr.rangeContainsIDEInspectionTarget(getBodySourceRange())) {
     return nullptr;
   }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -665,15 +665,15 @@ ArrayRef<SourceFile *> ModuleDecl::getPrimarySourceFiles() const {
   return evaluateOrDefault(eval, PrimarySourceFilesRequest{mutableThis}, {});
 }
 
-SourceFile *CodeCompletionFileRequest::evaluate(Evaluator &evaluator,
-                                                ModuleDecl *mod) const {
+SourceFile *IDEInspectionFileRequest::evaluate(Evaluator &evaluator,
+                                               ModuleDecl *mod) const {
   const auto &SM = mod->getASTContext().SourceMgr;
   assert(mod->isMainModule() && "Can only do completion in the main module");
-  assert(SM.hasCodeCompletionBuffer() && "Not performing code completion?");
+  assert(SM.hasIDEInspectionTargetBuffer() && "Not in IDE inspection mode?");
 
   for (auto *file : mod->getFiles()) {
     auto *SF = dyn_cast<SourceFile>(file);
-    if (SF && SF->getBufferID() == SM.getCodeCompletionBufferID())
+    if (SF && SF->getBufferID() == SM.getIDEInspectionTargetBufferID())
       return SF;
   }
   llvm_unreachable("Couldn't find the completion file?");

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -34,12 +34,12 @@ void SourceManager::verifyAllBuffers() const {
   }
 }
 
-SourceLoc SourceManager::getCodeCompletionLoc() const {
-  if (CodeCompletionBufferID == 0U)
+SourceLoc SourceManager::getIDEInspectionTargetLoc() const {
+  if (IDEInspectionTargetBufferID == 0U)
     return SourceLoc();
 
-  return getLocForBufferStart(CodeCompletionBufferID)
-      .getAdvancedLoc(CodeCompletionOffset);
+  return getLocForBufferStart(IDEInspectionTargetBufferID)
+      .getAdvancedLoc(IDEInspectionTargetOffset);
 }
 
 StringRef SourceManager::getDisplayNameForLoc(SourceLoc Loc) const {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -631,30 +631,31 @@ bool CompilerInstance::setUpModuleLoaders() {
   return false;
 }
 
-Optional<unsigned> CompilerInstance::setUpCodeCompletionBuffer() {
-  Optional<unsigned> codeCompletionBufferID;
-  auto codeCompletePoint = Invocation.getCodeCompletionPoint();
-  if (codeCompletePoint.first) {
-    auto memBuf = codeCompletePoint.first;
+Optional<unsigned> CompilerInstance::setUpIDEInspectionTargetBuffer() {
+  Optional<unsigned> ideInspectionTargetBufferID;
+  auto ideInspectionTarget = Invocation.getIDEInspectionTarget();
+  if (ideInspectionTarget.first) {
+    auto memBuf = ideInspectionTarget.first;
     // CompilerInvocation doesn't own the buffers, copy to a new buffer.
-    codeCompletionBufferID = SourceMgr.addMemBufferCopy(memBuf);
-    InputSourceCodeBufferIDs.push_back(*codeCompletionBufferID);
-    SourceMgr.setCodeCompletionPoint(*codeCompletionBufferID,
-                                     codeCompletePoint.second);
+    ideInspectionTargetBufferID = SourceMgr.addMemBufferCopy(memBuf);
+    InputSourceCodeBufferIDs.push_back(*ideInspectionTargetBufferID);
+    SourceMgr.setIDEInspectionTarget(*ideInspectionTargetBufferID,
+                                    ideInspectionTarget.second);
   }
-  return codeCompletionBufferID;
+  return ideInspectionTargetBufferID;
 }
 
-SourceFile *CompilerInstance::getCodeCompletionFile() const {
+SourceFile *CompilerInstance::getIDEInspectionFile() const {
   auto *mod = getMainModule();
   auto &eval = mod->getASTContext().evaluator;
-  return evaluateOrDefault(eval, CodeCompletionFileRequest{mod}, nullptr);
+  return evaluateOrDefault(eval, IDEInspectionFileRequest{mod}, nullptr);
 }
 
 bool CompilerInstance::setUpInputs() {
   // Adds to InputSourceCodeBufferIDs, so may need to happen before the
   // per-input setup.
-  const Optional<unsigned> codeCompletionBufferID = setUpCodeCompletionBuffer();
+  const Optional<unsigned> ideInspectionTargetBufferID =
+      setUpIDEInspectionTargetBuffer();
 
   const auto &Inputs =
       Invocation.getFrontendOptions().InputsAndOutputs.getAllInputs();
@@ -676,11 +677,11 @@ bool CompilerInstance::setUpInputs() {
   if (hasFailed)
     return true;
 
-  // Set the primary file to the code-completion point if one exists.
-  if (codeCompletionBufferID.has_value() &&
-      !isPrimaryInput(*codeCompletionBufferID)) {
+  // Set the primary file to the IDE inspection point if one exists.
+  if (ideInspectionTargetBufferID.has_value() &&
+      !isPrimaryInput(*ideInspectionTargetBufferID)) {
     assert(PrimaryBufferIDs.empty() && "re-setting PrimaryBufferID");
-    recordPrimaryInputBuffer(*codeCompletionBufferID);
+    recordPrimaryInputBuffer(*ideInspectionTargetBufferID);
   }
 
   return false;

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -2246,7 +2246,7 @@ bool CompletionLookup::tryUnwrappedCompletions(Type ExprType, bool isIUO) {
       // member from an optional key path root.
       auto loc = IsAfterSwiftKeyPathRoot ? DotLoc.getAdvancedLoc(1) : DotLoc;
       NumBytesToEraseForOptionalUnwrap = Ctx.SourceMgr.getByteDistance(
-          loc, Ctx.SourceMgr.getCodeCompletionLoc());
+          loc, Ctx.SourceMgr.getIDEInspectionTargetLoc());
     } else {
       NumBytesToEraseForOptionalUnwrap = 0;
     }
@@ -2828,7 +2828,7 @@ void CompletionLookup::getUnresolvedMemberCompletions(Type T) {
     unsigned bytesToErase = 0;
     auto &SM = CurrDeclContext->getASTContext().SourceMgr;
     if (DotLoc.isValid())
-      bytesToErase = SM.getByteDistance(DotLoc, SM.getCodeCompletionLoc());
+      bytesToErase = SM.getByteDistance(DotLoc, SM.getIDEInspectionTargetLoc());
     addKeyword("nil", T, SemanticContextKind::None,
                CodeCompletionKeywordKind::kw_nil, bytesToErase);
   }
@@ -3087,26 +3087,27 @@ void CompletionLookup::collectPrecedenceGroups() {
   }
 }
 
-void CompletionLookup::getPrecedenceGroupCompletions(CodeCompletionCallbacks::PrecedenceGroupCompletionKind SK) {
+void CompletionLookup::getPrecedenceGroupCompletions(
+    IDEInspectionCallbacks::PrecedenceGroupCompletionKind SK) {
   switch (SK) {
-  case CodeCompletionCallbacks::PrecedenceGroupCompletionKind::Associativity:
+  case IDEInspectionCallbacks::PrecedenceGroupCompletionKind::Associativity:
     addKeyword(getAssociativitySpelling(Associativity::None));
     addKeyword(getAssociativitySpelling(Associativity::Left));
     addKeyword(getAssociativitySpelling(Associativity::Right));
     return;
-  case CodeCompletionCallbacks::PrecedenceGroupCompletionKind::Assignment:
+  case IDEInspectionCallbacks::PrecedenceGroupCompletionKind::Assignment:
     addKeyword(getTokenText(tok::kw_false), Type(), SemanticContextKind::None,
                CodeCompletionKeywordKind::kw_false);
     addKeyword(getTokenText(tok::kw_true), Type(), SemanticContextKind::None,
                CodeCompletionKeywordKind::kw_true);
     return;
-  case CodeCompletionCallbacks::PrecedenceGroupCompletionKind::AttributeList:
+  case IDEInspectionCallbacks::PrecedenceGroupCompletionKind::AttributeList:
     addKeyword("associativity");
     addKeyword("higherThan");
     addKeyword("lowerThan");
     addKeyword("assignment");
     return;
-  case CodeCompletionCallbacks::PrecedenceGroupCompletionKind::Relation:
+  case IDEInspectionCallbacks::PrecedenceGroupCompletionKind::Relation:
     collectPrecedenceGroups();
     return;
   }
@@ -3184,7 +3185,7 @@ void CompletionLookup::getToplevelCompletions(bool OnlyTypes, bool OnlyMacros) {
   NeedLeadingMacroPound = !OnlyMacros;
 
   UsableFilteringDeclConsumer UsableFilteringConsumer(
-      Ctx.SourceMgr, CurrDeclContext, Ctx.SourceMgr.getCodeCompletionLoc(),
+      Ctx.SourceMgr, CurrDeclContext, Ctx.SourceMgr.getIDEInspectionTargetLoc(),
       *this);
   AccessFilteringDeclConsumer AccessFilteringConsumer(CurrDeclContext,
                                                       UsableFilteringConsumer);

--- a/lib/IDE/CompletionOverrideLookup.cpp
+++ b/lib/IDE/CompletionOverrideLookup.cpp
@@ -178,7 +178,7 @@ void CompletionOverrideLookup::addValueOverride(
   // Erase existing introducer (e.g. 'func') if any modifiers are added.
   if (hasDeclIntroducer && modifierAdded) {
     auto dist = Ctx.SourceMgr.getByteDistance(
-        introducerLoc, Ctx.SourceMgr.getCodeCompletionLoc());
+        introducerLoc, Ctx.SourceMgr.getIDEInspectionTargetLoc());
     if (dist <= CodeCompletionResult::MaxNumBytesToErase) {
       Builder.setNumBytesToErase(dist);
       hasDeclIntroducer = false;

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -16,7 +16,7 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/USRGeneration.h"
-#include "swift/Parse/CodeCompletionCallbacks.h"
+#include "swift/Parse/IDEInspectionCallbacks.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
@@ -25,7 +25,7 @@ using namespace swift;
 using namespace ide;
 
 namespace {
-class ConformingMethodListCallbacks : public CodeCompletionCallbacks {
+class ConformingMethodListCallbacks : public IDEInspectionCallbacks {
   ArrayRef<const char *> ExpectedTypeNames;
   ConformingMethodListConsumer &Consumer;
   SourceLoc Loc;
@@ -40,7 +40,7 @@ public:
   ConformingMethodListCallbacks(Parser &P,
                                 ArrayRef<const char *> ExpectedTypeNames,
                                 ConformingMethodListConsumer &Consumer)
-      : CodeCompletionCallbacks(P), ExpectedTypeNames(ExpectedTypeNames),
+      : IDEInspectionCallbacks(P), ExpectedTypeNames(ExpectedTypeNames),
         Consumer(Consumer) {}
 
   // Only handle callbacks for suffix completions.
@@ -173,14 +173,14 @@ void ConformingMethodListCallbacks::getMatchingMethods(
 
 } // anonymous namespace.
 
-CodeCompletionCallbacksFactory *
+IDEInspectionCallbacksFactory *
 swift::ide::makeConformingMethodListCallbacksFactory(
     ArrayRef<const char *> expectedTypeNames,
     ConformingMethodListConsumer &Consumer) {
 
   // CC callback factory which produces 'ContextInfoCallbacks'.
   class ConformingMethodListCallbacksFactoryImpl
-      : public CodeCompletionCallbacksFactory {
+      : public IDEInspectionCallbacksFactory {
     ArrayRef<const char *> ExpectedTypeNames;
     ConformingMethodListConsumer &Consumer;
 
@@ -190,7 +190,7 @@ swift::ide::makeConformingMethodListCallbacksFactory(
         ConformingMethodListConsumer &Consumer)
         : ExpectedTypeNames(ExpectedTypeNames), Consumer(Consumer) {}
 
-    CodeCompletionCallbacks *createCodeCompletionCallbacks(Parser &P) override {
+    IDEInspectionCallbacks *createIDEInspectionCallbacks(Parser &P) override {
       return new ConformingMethodListCallbacks(P, ExpectedTypeNames, Consumer);
     }
   };

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -17,7 +17,7 @@
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/USRGeneration.h"
 #include "swift/IDE/TypeCheckCompletionCallback.h"
-#include "swift/Parse/CodeCompletionCallbacks.h"
+#include "swift/Parse/IDEInspectionCallbacks.h"
 #include "swift/Sema/ConstraintSystem.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "clang/AST/Attr.h"
@@ -207,14 +207,14 @@ private:
 
 // MARK: - CursorInfoDoneParsingCallback
 
-class CursorInfoDoneParsingCallback : public CodeCompletionCallbacks {
+class CursorInfoDoneParsingCallback : public IDEInspectionCallbacks {
   CursorInfoConsumer &Consumer;
   SourceLoc RequestedLoc;
 
 public:
   CursorInfoDoneParsingCallback(Parser &P, CursorInfoConsumer &Consumer,
                                 SourceLoc RequestedLoc)
-      : CodeCompletionCallbacks(P), Consumer(Consumer),
+      : IDEInspectionCallbacks(P), Consumer(Consumer),
         RequestedLoc(RequestedLoc) {}
 
   std::unique_ptr<ResolvedCursorInfo>
@@ -257,10 +257,10 @@ public:
 
 } // anonymous namespace.
 
-CodeCompletionCallbacksFactory *
+IDEInspectionCallbacksFactory *
 swift::ide::makeCursorInfoCallbacksFactory(CursorInfoConsumer &Consumer,
                                            SourceLoc RequestedLoc) {
-  class CursorInfoCallbacksFactoryImpl : public CodeCompletionCallbacksFactory {
+  class CursorInfoCallbacksFactoryImpl : public IDEInspectionCallbacksFactory {
     CursorInfoConsumer &Consumer;
     SourceLoc RequestedLoc;
 
@@ -269,7 +269,7 @@ swift::ide::makeCursorInfoCallbacksFactory(CursorInfoConsumer &Consumer,
                                    SourceLoc RequestedLoc)
         : Consumer(Consumer), RequestedLoc(RequestedLoc) {}
 
-    CodeCompletionCallbacks *createCodeCompletionCallbacks(Parser &P) override {
+    IDEInspectionCallbacks *createIDEInspectionCallbacks(Parser &P) override {
       return new CursorInfoDoneParsingCallback(P, Consumer, RequestedLoc);
     }
   };

--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -213,14 +213,14 @@ REPLCompletions::REPLCompletions()
 
   // Create a factory for code completion callbacks that will feed the
   // Consumer.
-  CompletionCallbacksFactory.reset(
+  IDEInspectionCallbacksFactory.reset(
       ide::makeCodeCompletionCallbacksFactory(CompletionContext,
                                               *Consumer));
 }
 
 static void
 doCodeCompletion(SourceFile &SF, StringRef EnteredCode, unsigned *BufferID,
-                 CodeCompletionCallbacksFactory *CompletionCallbacksFactory) {
+                 IDEInspectionCallbacksFactory *CompletionCallbacksFactory) {
   // Temporarily disable printing the diagnostics.
   ASTContext &Ctx = SF.getASTContext();
   DiagnosticSuppression SuppressedDiags(Ctx.Diags);
@@ -231,7 +231,7 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode, unsigned *BufferID,
 
   const unsigned CodeCompletionOffset = AugmentedCode.size() - 1;
 
-  Ctx.SourceMgr.setCodeCompletionPoint(*BufferID, CodeCompletionOffset);
+  Ctx.SourceMgr.setIDEInspectionTarget(*BufferID, CodeCompletionOffset);
 
   // Import the last module.
   auto *lastModule = SF.getParentModule();
@@ -258,7 +258,7 @@ doCodeCompletion(SourceFile &SF, StringRef EnteredCode, unsigned *BufferID,
   performImportResolution(newSF);
   bindExtensions(*newModule);
 
-  performCodeCompletionSecondPass(newSF, *CompletionCallbacksFactory);
+  performIDEInspectionSecondPass(newSF, *CompletionCallbacksFactory);
 
   // Reset the error state because it's only relevant to the code that we just
   // processed, which now gets thrown away.
@@ -275,7 +275,7 @@ void REPLCompletions::populate(SourceFile &SF, StringRef EnteredCode) {
 
   unsigned BufferID;
   doCodeCompletion(SF, EnteredCode, &BufferID,
-                   CompletionCallbacksFactory.get());
+                   IDEInspectionCallbacksFactory.get());
 
   ASTContext &Ctx = SF.getASTContext();
   std::vector<Token> Tokens = tokenize(Ctx.LangOpts, Ctx.SourceMgr, BufferID);
@@ -292,7 +292,7 @@ void REPLCompletions::populate(SourceFile &SF, StringRef EnteredCode) {
                                                            BufferID);
 
       doCodeCompletion(SF, EnteredCode.substr(0, Offset),
-                       &BufferID, CompletionCallbacksFactory.get());
+                       &BufferID, IDEInspectionCallbacksFactory.get());
     }
   }
 

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -15,7 +15,7 @@
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/USRGeneration.h"
-#include "swift/Parse/CodeCompletionCallbacks.h"
+#include "swift/Parse/IDEInspectionCallbacks.h"
 #include "swift/Sema/IDETypeChecking.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/Decl.h"
@@ -24,7 +24,7 @@
 using namespace swift;
 using namespace ide;
 
-class ContextInfoCallbacks : public CodeCompletionCallbacks {
+class ContextInfoCallbacks : public IDEInspectionCallbacks {
   TypeContextInfoConsumer &Consumer;
   SourceLoc Loc;
   Expr *ParsedExpr = nullptr;
@@ -34,7 +34,7 @@ class ContextInfoCallbacks : public CodeCompletionCallbacks {
 
 public:
   ContextInfoCallbacks(Parser &P, TypeContextInfoConsumer &Consumer)
-      : CodeCompletionCallbacks(P), Consumer(Consumer) {}
+      : IDEInspectionCallbacks(P), Consumer(Consumer) {}
 
   void completePostfixExprBeginning(CodeCompletionExpr *E) override;
   void completeForEachSequenceBeginning(CodeCompletionExpr *E) override;
@@ -174,19 +174,19 @@ void ContextInfoCallbacks::getImplicitMembers(
                            /*includeProtocolExtensionMembers*/true);
 }
 
-CodeCompletionCallbacksFactory *swift::ide::makeTypeContextInfoCallbacksFactory(
+IDEInspectionCallbacksFactory *swift::ide::makeTypeContextInfoCallbacksFactory(
     TypeContextInfoConsumer &Consumer) {
 
   // CC callback factory which produces 'ContextInfoCallbacks'.
   class ContextInfoCallbacksFactoryImpl
-      : public CodeCompletionCallbacksFactory {
+      : public IDEInspectionCallbacksFactory {
     TypeContextInfoConsumer &Consumer;
 
   public:
     ContextInfoCallbacksFactoryImpl(TypeContextInfoConsumer &Consumer)
         : Consumer(Consumer) {}
 
-    CodeCompletionCallbacks *createCodeCompletionCallbacks(Parser &P) override {
+    IDEInspectionCallbacks *createIDEInspectionCallbacks(Parser &P) override {
       return new ContextInfoCallbacks(P, Consumer);
     }
   };

--- a/lib/IDETool/CMakeLists.txt
+++ b/lib/IDETool/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_swift_host_library(swiftIDETool STATIC
   CompileInstance.cpp
   CompilerInvocation.cpp
-  CompletionInstance.cpp
+  IDEInspectionInstance.cpp
   DependencyChecking.cpp
   )
 

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -207,8 +207,8 @@ void Lexer::initialize(unsigned Offset, unsigned EndOffset) {
   ContentStart = BufferStart + BOMLength;
 
   // Initialize code completion.
-  if (BufferID == SourceMgr.getCodeCompletionBufferID()) {
-    const char *Ptr = BufferStart + SourceMgr.getCodeCompletionOffset();
+  if (BufferID == SourceMgr.getIDEInspectionTargetBufferID()) {
+    const char *Ptr = BufferStart + SourceMgr.getIDEInspectionTargetOffset();
     // If the pointer points to a null byte, it's the null byte that was
     // inserted to mark the code completion token. If the IDE inspection offset
     // points to a normal character, no code completion token should be

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -29,7 +29,7 @@
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Basic/StringExtras.h"
-#include "swift/Parse/CodeCompletionCallbacks.h"
+#include "swift/Parse/IDEInspectionCallbacks.h"
 #include "swift/Parse/ParseSILSupport.h"
 #include "swift/Parse/Parser.h"
 #include "swift/Strings.h"
@@ -198,7 +198,7 @@ void Parser::parseTopLevelItems(SmallVectorImpl<ASTNode> &items) {
   if ((Context.LangOpts.hasFeature(Feature::Macros) ||
        Context.LangOpts.hasFeature(Feature::BuiltinMacros) ||
        Context.LangOpts.hasFeature(Feature::ParserASTGen)) &&
-      !SourceMgr.hasCodeCompletionBuffer() &&
+      !SourceMgr.hasIDEInspectionTargetBuffer() &&
       SF.Kind != SourceFileKind::SIL) {
     StringRef contents =
         SourceMgr.extractText(SourceMgr.getRangeForBuffer(L->getBufferID()));
@@ -429,8 +429,8 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
     if (ArgumentKind == IsInvalid) {
       diagnose(ArgumentLoc, diag::attr_availability_expected_option, AttrName)
           .highlight(SourceRange(ArgumentLoc));
-      if (Tok.is(tok::code_complete) && CodeCompletion) {
-        CodeCompletion->completeDeclAttrParam(DAK_Available, ParamIndex);
+      if (Tok.is(tok::code_complete) && IDECallbacks) {
+        IDECallbacks->completeDeclAttrParam(DAK_Available, ParamIndex);
         consumeToken(tok::code_complete);
       } else {
         consumeIf(tok::identifier);
@@ -860,8 +860,8 @@ bool Parser::parseAvailability(
   //   identifier
   if (!Tok.is(tok::identifier) &&
       !(Tok.isAnyOperator() && Tok.getText() == "*")) {
-    if (Tok.is(tok::code_complete) && CodeCompletion) {
-      CodeCompletion->completeDeclAttrParam(DAK_Available, 0);
+    if (Tok.is(tok::code_complete) && IDECallbacks) {
+      IDECallbacks->completeDeclAttrParam(DAK_Available, 0);
       consumeToken(tok::code_complete);
     }
     diagnose(Tok.getLoc(), diag::attr_availability_platform, AttrName)
@@ -3208,10 +3208,10 @@ ParserResult<CustomAttr> Parser::parseCustomAttribute(
   if (Tok.isFollowingLParen() && isCustomAttributeArgument()) {
     if (peekToken().is(tok::code_complete)) {
       consumeToken(tok::l_paren);
-      if (CodeCompletion) {
+      if (IDECallbacks) {
         auto typeE = new (Context) TypeExpr(type.get());
         auto CCE = new (Context) CodeCompletionExpr(Tok.getLoc());
-        CodeCompletion->completePostfixExprParen(typeE, CCE);
+        IDECallbacks->completePostfixExprParen(typeE, CCE);
       }
       consumeToken(tok::code_complete);
       skipUntil(tok::r_paren);
@@ -3245,8 +3245,8 @@ ParserResult<CustomAttr> Parser::parseCustomAttribute(
   auto *TE = new (Context) TypeExpr(type.get());
   auto *customAttr = CustomAttr::create(Context, atLoc, TE, initContext,
                                         argList);
-  if (status.hasCodeCompletion() && CodeCompletion) {
-    CodeCompletion->setCompletingInAttribute(customAttr);
+  if (status.hasCodeCompletion() && IDECallbacks) {
+    IDECallbacks->setCompletingInAttribute(customAttr);
   }
   return makeParserResult(status, customAttr);
 }
@@ -3285,12 +3285,12 @@ ParserStatus Parser::parseDeclAttribute(
       Tok.isNot(tok::kw_rethrows)) {
 
     if (Tok.is(tok::code_complete)) {
-      if (CodeCompletion) {
+      if (IDECallbacks) {
         // If the next token is not on the same line, this attribute might be
         // starting new declaration instead of adding attribute to existing
         // decl.
         auto isIndependent = peekToken().isAtStartOfLine();
-        CodeCompletion->completeDeclAttrBeginning(isInSILMode(), isIndependent);
+        IDECallbacks->completeDeclAttrBeginning(isInSILMode(), isIndependent);
       }
       consumeToken(tok::code_complete);
       return makeParserCodeCompletionStatus();
@@ -3616,8 +3616,8 @@ ParserStatus Parser::parseTypeAttribute(TypeAttributes &Attributes,
 
     if (Tok.is(tok::code_complete)) {
       if (!justChecking) {
-        if (CodeCompletion) {
-          CodeCompletion->completeTypeAttrBeginning();
+        if (IDECallbacks) {
+          IDECallbacks->completeTypeAttrBeginning();
         }
       }
       consumeToken(tok::code_complete);
@@ -4542,9 +4542,8 @@ void Parser::consumeDecl(ParserPosition BeginParserPosition,
   backtrackToPosition(BeginParserPosition);
   SourceLoc BeginLoc = Tok.getLoc();
 
-  State->setCodeCompletionDelayedDeclState(
-      SourceMgr, L->getBufferID(),
-      CodeCompletionDelayedDeclKind::Decl,
+  State->setIDEInspectionDelayedDeclState(
+      SourceMgr, L->getBufferID(), IDEInspectionDelayedDeclKind::Decl,
       Flags.toRaw(), CurDeclContext, {BeginLoc, EndLoc},
       BeginParserPosition.PreviousLoc);
 
@@ -4618,7 +4617,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
                   bool IfConfigsAreDeclAttrs,
                   llvm::function_ref<void(Decl*)> Handler) {
   ParserPosition BeginParserPosition;
-  if (isCodeCompletionFirstPass())
+  if (isIDEInspectionFirstPass())
     BeginParserPosition = getParserPosition();
 
   if (Tok.is(tok::pound_if) && !ifConfigContainsOnlyAttributes()) {
@@ -4640,7 +4639,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
                                   [&](Decl *D) {Decls.emplace_back(D);});
         }
       });
-    if (IfConfigResult.hasCodeCompletion() && isCodeCompletionFirstPass()) {
+    if (IfConfigResult.hasCodeCompletion() && isIDEInspectionFirstPass()) {
       consumeDecl(BeginParserPosition, Flags,
                   CurDeclContext->isModuleScopeContext());
       return makeParserError();
@@ -4705,7 +4704,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
     StaticLoc = SourceLoc(); // we handled static if present.
     MayNeedOverrideCompletion = true;
     if ((AttrStatus.hasCodeCompletion() || DeclResult.hasCodeCompletion())
-        && isCodeCompletionFirstPass())
+        && isIDEInspectionFirstPass())
       return;
     std::for_each(Entries.begin(), Entries.end(), Handler);
     HandlerAlreadyCalled = true;
@@ -4745,7 +4744,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
     llvm::SmallVector<Decl *, 4> Entries;
     DeclResult = parseDeclEnumCase(Flags, Attributes, Entries);
     if ((AttrStatus.hasCodeCompletion() || DeclResult.hasCodeCompletion()) &&
-        isCodeCompletionFirstPass())
+        isIDEInspectionFirstPass())
       break;
     std::for_each(Entries.begin(), Entries.end(), Handler);
     HandlerAlreadyCalled = true;
@@ -4781,7 +4780,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
                                     Attributes, Entries);
     StaticLoc = SourceLoc(); // we handled static if present.
     if ((AttrStatus.hasCodeCompletion() || DeclResult.hasCodeCompletion()) &&
-        isCodeCompletionFirstPass())
+        isIDEInspectionFirstPass())
       break;
     std::for_each(Entries.begin(), Entries.end(), Handler);
     MayNeedOverrideCompletion = true;
@@ -4799,8 +4798,8 @@ Parser::parseDecl(ParseDeclOptions Flags,
         peekToken().is(tok::code_complete) &&
         Tok.getLoc().getAdvancedLoc(1) == peekToken().getLoc()) {
       consumeToken();
-      if (CodeCompletion)
-        CodeCompletion->completeAfterPoundDirective();
+      if (IDECallbacks)
+        IDECallbacks->completeAfterPoundDirective();
       consumeToken(tok::code_complete);
       DeclResult = makeParserCodeCompletionResult<Decl>();
       break;
@@ -4922,7 +4921,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
   }
 
   if (DeclResult.isParseErrorOrHasCompletion() && Tok.is(tok::code_complete)) {
-    if (MayNeedOverrideCompletion && CodeCompletion) {
+    if (MayNeedOverrideCompletion && IDECallbacks) {
       // If we need to complete an override, collect the keywords already
       // specified so that we do not duplicate them in code completion
       // strings.
@@ -4949,8 +4948,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
       for (auto attr : Attributes) {
         Keywords.push_back(attr->getAttrName());
       }
-      CodeCompletion->completeNominalMemberBeginning(Keywords,
-                                                     introducerLoc);
+      IDECallbacks->completeNominalMemberBeginning(Keywords, introducerLoc);
     }
 
     DeclResult = makeParserCodeCompletionStatus();
@@ -4958,7 +4956,7 @@ Parser::parseDecl(ParseDeclOptions Flags,
   }
 
   if (AttrStatus.hasCodeCompletion() || DeclResult.hasCodeCompletion()) {
-    if (isCodeCompletionFirstPass() &&
+    if (isIDEInspectionFirstPass() &&
         !CurDeclContext->isModuleScopeContext() &&
         !isa<TopLevelCodeDecl>(CurDeclContext) &&
         !isa<AbstractClosureExpr>(CurDeclContext)) {
@@ -4967,14 +4965,14 @@ Parser::parseDecl(ParseDeclOptions Flags,
 
       return makeParserError();
     }
-    if (AttrStatus.hasCodeCompletion() && CodeCompletion) {
+    if (AttrStatus.hasCodeCompletion() && IDECallbacks) {
       Optional<DeclKind> DK;
       if (DeclResult.isNonNull())
         DK = DeclResult.get()->getKind();
-      CodeCompletion->setAttrTargetDeclKind(DK);
+      IDECallbacks->setAttrTargetDeclKind(DK);
     }
     DeclResult.setHasCodeCompletionAndIsError();
-    if (isCodeCompletionFirstPass())
+    if (isIDEInspectionFirstPass())
       return DeclResult;
   }
 
@@ -5113,7 +5111,7 @@ ParserResult<ImportDecl> Parser::parseDeclImport(ParseDeclOptions Flags,
   SourceLoc ImportLoc = consumeToken(tok::kw_import);
   DebuggerContextChange DCC (*this);
 
-  if (!CodeCompletion && !DCC.movedToTopLevel() && !(Flags & PD_AllowTopLevel)) {
+  if (!IDECallbacks && !DCC.movedToTopLevel() && !(Flags & PD_AllowTopLevel)) {
     diagnose(ImportLoc, diag::decl_inner_scope);
     return nullptr;
   }
@@ -5158,8 +5156,8 @@ ParserResult<ImportDecl> Parser::parseDeclImport(ParseDeclOptions Flags,
   do {
     if (Tok.is(tok::code_complete)) {
       consumeToken();
-      if (CodeCompletion) {
-        CodeCompletion->completeImportDecl(importPath);
+      if (IDECallbacks) {
+        IDECallbacks->completeImportDecl(importPath);
       }
       return makeParserCodeCompletionStatus();
     }
@@ -5179,11 +5177,11 @@ ParserResult<ImportDecl> Parser::parseDeclImport(ParseDeclOptions Flags,
   if (Tok.is(tok::code_complete)) {
     // We omit the code completion token if it immediately follows the module
     // identifiers.
-    auto BufferId = SourceMgr.getCodeCompletionBufferID();
+    auto BufferId = SourceMgr.getIDEInspectionTargetBufferID();
     auto IdEndOffset = SourceMgr.getLocOffsetInBuffer(importPath.back().Loc,
       BufferId) + importPath.back().Item.str().size();
     auto CCTokenOffset = SourceMgr.getLocOffsetInBuffer(SourceMgr.
-      getCodeCompletionLoc(), BufferId);
+      getIDEInspectionTargetLoc(), BufferId);
     if (IdEndOffset == CCTokenOffset) {
       consumeToken();
     }
@@ -5612,7 +5610,7 @@ Parser::parseDeclExtension(ParseDeclOptions Flags, DeclAttributes &Attributes) {
     SmallVector<RequirementRepr, 4> requirements;
     auto whereStatus = parseGenericWhereClause(whereLoc, endLoc, requirements);
     if (whereStatus.hasCodeCompletion()) {
-      if (isCodeCompletionFirstPass())
+      if (isIDEInspectionFirstPass())
         return whereStatus;
       trailingWhereHadCodeCompletion = true;
     }
@@ -5629,8 +5627,8 @@ Parser::parseDeclExtension(ParseDeclOptions Flags, DeclAttributes &Attributes) {
                                              CurDeclContext,
                                              trailingWhereClause);
   ext->getAttrs() = Attributes;
-  if (trailingWhereHadCodeCompletion && CodeCompletion)
-    CodeCompletion->setParsedDecl(ext);
+  if (trailingWhereHadCodeCompletion && IDECallbacks)
+    IDECallbacks->setParsedDecl(ext);
 
   SourceLoc LBLoc, RBLoc;
 
@@ -5913,7 +5911,7 @@ parseDeclTypeAlias(Parser::ParseDeclOptions Flags, DeclAttributes &Attributes) {
   GenericParamList *genericParams = nullptr;
   if (startsWithLess(Tok)) {
     auto Result = parseGenericParameters();
-    if (Result.hasCodeCompletion() && !CodeCompletion)
+    if (Result.hasCodeCompletion() && !IDECallbacks)
       return makeParserCodeCompletionStatus();
     genericParams = Result.getPtrOrNull();
 
@@ -6052,7 +6050,7 @@ ParserResult<TypeDecl> Parser::parseDeclAssociatedType(Parser::ParseDeclOptions 
     auto whereStatus = parseProtocolOrAssociatedTypeWhereClause(
         TrailingWhere, /*isProtocol=*/false);
     Status |= whereStatus;
-    if (whereStatus.hasCodeCompletion() && !CodeCompletion) {
+    if (whereStatus.hasCodeCompletion() && !IDECallbacks) {
       // Trigger delayed parsing, no need to continue.
       return whereStatus;
     }
@@ -6216,7 +6214,7 @@ static ParameterList *parseOptionalAccessorArgument(SourceLoc SpecifierLoc,
 
 bool Parser::canDelayFunctionBodyParsing(bool &HasNestedTypeDeclarations) {
   // If explicitly disabled, respect the flag.
-  if (!isDelayedParsingEnabled() && !isCodeCompletionFirstPass())
+  if (!isDelayedParsingEnabled() && !isIDEInspectionFirstPass())
     return false;
 
   // Skip until the matching right curly bracket; If it has a potential regex
@@ -6559,9 +6557,9 @@ ParserStatus Parser::parseGetSet(ParseDeclOptions Flags, ParameterList *Indices,
         // If it's the first accessor, it's handled in function body parsing
         // because it might be an implicit getter.
         if (!IsFirstAccessor || parsingLimitedSyntax) {
-          if (CodeCompletion) {
-            CodeCompletion->setParsedDecl(storage);
-            CodeCompletion->completeAccessorBeginning(nullptr);
+          if (IDECallbacks) {
+            IDECallbacks->setParsedDecl(storage);
+            IDECallbacks->completeAccessorBeginning(nullptr);
           }
           consumeToken(tok::code_complete);
           accessorHasCodeCompletion = true;
@@ -7119,7 +7117,7 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
         Status |= init;
         // If we are doing second pass of code completion, we don't want to
         // suddenly cut off parsing and throw away the declaration.
-        if (isCodeCompletionFirstPass())
+        if (isIDEInspectionFirstPass())
           return makeResult(makeParserCodeCompletionStatus());
       }
 
@@ -7288,7 +7286,7 @@ ParserResult<FuncDecl> Parser::parseDeclFunc(SourceLoc StaticLoc,
   GenericParams = GenericParamResult.getPtrOrNull();
   if (GenericParamResult.hasCodeCompletion()) {
     Status.setHasCodeCompletionAndIsError();
-    if (!CodeCompletion)
+    if (!IDECallbacks)
       return Status;
   }
 
@@ -7305,7 +7303,7 @@ ParserResult<FuncDecl> Parser::parseDeclFunc(SourceLoc StaticLoc,
                                    asyncLoc, reasync,
                                    throwsLoc, rethrows,
                                    FuncRetTy);
-  if (Status.hasCodeCompletion() && !CodeCompletion) {
+  if (Status.hasCodeCompletion() && !IDECallbacks) {
     // Trigger delayed parsing, no need to continue.
     return Status;
   }
@@ -7347,7 +7345,7 @@ ParserResult<FuncDecl> Parser::parseDeclFunc(SourceLoc StaticLoc,
     ContextChange CC(*this, FD);
 
     Status |= parseFreestandingGenericWhereClause(FD);
-    if (Status.hasCodeCompletion() && !CodeCompletion) {
+    if (Status.hasCodeCompletion() && !IDECallbacks) {
       // Trigger delayed parsing, no need to continue.
       return Status;
     }
@@ -7373,8 +7371,8 @@ ParserResult<FuncDecl> Parser::parseDeclFunc(SourceLoc StaticLoc,
 
   // Pass the function signature to code completion.
   if (Status.hasCodeCompletion()) {
-    assert(CodeCompletion && "must be code completion second pass");
-    CodeCompletion->setParsedDecl(FD);
+    assert(IDECallbacks && "must be code completion second pass");
+    IDECallbacks->setParsedDecl(FD);
   }
 
   DefaultArgs.setFunctionContext(FD, FD->getParameters());
@@ -7408,15 +7406,15 @@ Parser::parseAbstractFunctionBodyImpl(AbstractFunctionDecl *AFD) {
   // In implicit getter, if a CC token is the first token after '{', it might
   // be a start of an accessor block. Perform special completion for that.
   if (auto accessor = dyn_cast<AccessorDecl>(AFD)) {
-    if (CodeCompletion && peekToken().is(tok::code_complete) &&
+    if (IDECallbacks && peekToken().is(tok::code_complete) &&
         accessor->isImplicitGetter()) {
       SourceLoc LBraceLoc, RBraceLoc;
       LBraceLoc = consumeToken(tok::l_brace);
       auto *CCE = new (Context) CodeCompletionExpr(Tok.getLoc());
       auto *Return =
           new (Context) ReturnStmt(SourceLoc(), CCE, /*implicit=*/true);
-      CodeCompletion->setParsedDecl(accessor);
-      CodeCompletion->completeAccessorBeginning(CCE);
+      IDECallbacks->setParsedDecl(accessor);
+      IDECallbacks->completeAccessorBeginning(CCE);
       RBraceLoc = Tok.getLoc();
       consumeToken(tok::code_complete);
       auto *BS =
@@ -7507,16 +7505,15 @@ void Parser::parseAbstractFunctionBody(AbstractFunctionDecl *AFD) {
   // while skipping, we'll make a note of it.
   auto BodyPreviousLoc = PreviousLoc;
   SourceRange BodyRange(Tok.getLoc());
-  auto setCodeCompletionDelayedDeclStateIfNeeded = [&] {
-    if (!isCodeCompletionFirstPass() ||
-        !SourceMgr.rangeContainsCodeCompletionLoc(BodyRange)) {
+  auto setIDEInspectionDelayedDeclStateIfNeeded = [&] {
+    if (!isIDEInspectionFirstPass() ||
+        !SourceMgr.rangeContainsIDEInspectionTarget(BodyRange)) {
       return;
     }
-    if (State->hasCodeCompletionDelayedDeclState())
-      State->takeCodeCompletionDelayedDeclState();
-    State->setCodeCompletionDelayedDeclState(
-        SourceMgr, L->getBufferID(),
-        CodeCompletionDelayedDeclKind::FunctionBody,
+    if (State->hasIDEInspectionDelayedDeclState())
+      State->takeIDEInspectionDelayedDeclState();
+    State->setIDEInspectionDelayedDeclState(
+        SourceMgr, L->getBufferID(), IDEInspectionDelayedDeclKind::FunctionBody,
         PD_Default, AFD, BodyRange, BodyPreviousLoc);
   };
 
@@ -7531,7 +7528,7 @@ void Parser::parseAbstractFunctionBody(AbstractFunctionDecl *AFD) {
     AFD->setBodyDelayed(BodyRange);
     AFD->setHasNestedTypeDeclarations(HasNestedTypeDeclarations);
 
-    setCodeCompletionDelayedDeclStateIfNeeded();
+    setIDEInspectionDelayedDeclStateIfNeeded();
     return;
   }
 
@@ -7539,7 +7536,7 @@ void Parser::parseAbstractFunctionBody(AbstractFunctionDecl *AFD) {
   assert(BodyRange.Start == AFD->getBodySourceRange().Start &&
          "The start of the body should be the 'l_brace' token above");
   BodyRange = AFD->getBodySourceRange();
-  setCodeCompletionDelayedDeclStateIfNeeded();
+  setIDEInspectionDelayedDeclStateIfNeeded();
 }
 
 BodyAndFingerprint
@@ -7628,7 +7625,7 @@ ParserResult<EnumDecl> Parser::parseDeclEnum(ParseDeclOptions Flags,
   // Parse a 'where' clause if present.
   if (Tok.is(tok::kw_where)) {
     auto whereStatus = parseFreestandingGenericWhereClause(ED);
-    if (whereStatus.hasCodeCompletion() && !CodeCompletion) {
+    if (whereStatus.hasCodeCompletion() && !IDECallbacks) {
       // Trigger delayed parsing, no need to continue.
       return whereStatus;
     }
@@ -7752,8 +7749,8 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
     if (Tok.is(tok::equal)) {
       EqualsLoc = consumeToken();
       {
-        CodeCompletionCallbacks::InEnumElementRawValueRAII
-            InEnumElementRawValue(CodeCompletion);
+        IDEInspectionCallbacks::InEnumElementRawValueRAII
+            InEnumElementRawValue(IDECallbacks);
         if (!CurLocalContext) {
           // A local context is needed for parsing closures. We want to parse
           // them anyways for proper diagnosis.
@@ -7900,7 +7897,7 @@ ParserResult<StructDecl> Parser::parseDeclStruct(ParseDeclOptions Flags,
   // Parse a 'where' clause if present.
   if (Tok.is(tok::kw_where)) {
     auto whereStatus = parseFreestandingGenericWhereClause(SD);
-    if (whereStatus.hasCodeCompletion() && !CodeCompletion) {
+    if (whereStatus.hasCodeCompletion() && !IDECallbacks) {
       // Trigger delayed parsing, no need to continue.
       return whereStatus;
     }
@@ -8016,7 +8013,7 @@ ParserResult<ClassDecl> Parser::parseDeclClass(ParseDeclOptions Flags,
   // Parse a 'where' clause if present.
   if (Tok.is(tok::kw_where)) {
     auto whereStatus = parseFreestandingGenericWhereClause(CD);
-    if (whereStatus.hasCodeCompletion() && !CodeCompletion) {
+    if (whereStatus.hasCodeCompletion() && !IDECallbacks) {
       // Trigger delayed parsing, no need to continue.
       return whereStatus;
     }
@@ -8140,7 +8137,7 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
     auto whereStatus = parseProtocolOrAssociatedTypeWhereClause(
         TrailingWhere, /*isProtocol=*/true);
     if (whereStatus.hasCodeCompletion()) {
-      if (isCodeCompletionFirstPass())
+      if (isIDEInspectionFirstPass())
         return whereStatus;
       whereClauseHadCodeCompletion = true;
     }
@@ -8153,8 +8150,8 @@ parseDeclProtocol(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   // No need to setLocalDiscriminator: protocols can't appear in local contexts.
 
   Proto->getAttrs() = Attributes;
-  if (whereClauseHadCodeCompletion && CodeCompletion)
-    CodeCompletion->setParsedDecl(Proto);
+  if (whereClauseHadCodeCompletion && IDECallbacks)
+    IDECallbacks->setParsedDecl(Proto);
 
   ContextChange CC(*this, Proto);
 
@@ -8225,7 +8222,7 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
   GenericParams = Result.getPtrOrNull();
   if (Result.hasCodeCompletion()) {
     Status.setHasCodeCompletionAndIsError();
-    if (!CodeCompletion)
+    if (!IDECallbacks)
       return Status;
   }
 
@@ -8236,7 +8233,7 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
     = parseSingleParameterClause(ParameterContextKind::Subscript,
                                  &argumentNames, &DefaultArgs);
   Status |= Indices;
-  if (Status.hasCodeCompletion() && !CodeCompletion)
+  if (Status.hasCodeCompletion() && !IDECallbacks)
     return Status;
   
   SourceLoc ArrowLoc;
@@ -8259,7 +8256,7 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
     // type
     ElementTy = parseDeclResultType(diag::expected_type_subscript);
     Status |= ElementTy;
-    if (Status.hasCodeCompletion() && !CodeCompletion)
+    if (Status.hasCodeCompletion() && !IDECallbacks)
       return Status;
 
     if (ElementTy.isNull()) {
@@ -8299,7 +8296,7 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
     ContextChange CC(*this, Subscript);
 
     Status |= parseFreestandingGenericWhereClause(Subscript);
-    if (Status.hasCodeCompletion() && !CodeCompletion) {
+    if (Status.hasCodeCompletion() && !IDECallbacks) {
       // Trigger delayed parsing, no need to continue.
       return Status;
     }
@@ -8307,8 +8304,8 @@ Parser::parseDeclSubscript(SourceLoc StaticLoc,
 
   // Pass the function signature to code completion.
   if (Status.hasCodeCompletion()) {
-    assert(CodeCompletion && "must be code completion second pass");
-    CodeCompletion->setParsedDecl(Subscript);
+    assert(IDECallbacks && "must be code completion second pass");
+    IDECallbacks->setParsedDecl(Subscript);
   }
 
   Decls.push_back(Subscript);
@@ -8395,7 +8392,7 @@ Parser::parseDeclInit(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   GenericParamList *GenericParams = GPResult.getPtrOrNull();
   if (GPResult.hasCodeCompletion()) {
     Status.setHasCodeCompletionAndIsError();
-    if (!CodeCompletion)
+    if (!IDECallbacks)
       return Status;
   }
 
@@ -8413,7 +8410,7 @@ Parser::parseDeclInit(ParseDeclOptions Flags, DeclAttributes &Attributes) {
                                    asyncLoc, reasync,
                                    throwsLoc, rethrows,
                                    FuncRetTy);
-  if (Status.hasCodeCompletion() && !CodeCompletion) {
+  if (Status.hasCodeCompletion() && !IDECallbacks) {
     // Trigger delayed parsing, no need to continue.
     return Status;
   }
@@ -8466,7 +8463,7 @@ Parser::parseDeclInit(ParseDeclOptions Flags, DeclAttributes &Attributes) {
     ContextChange(*this, CD);
 
     Status |= parseFreestandingGenericWhereClause(CD);
-    if (Status.hasCodeCompletion() && !CodeCompletion) {
+    if (Status.hasCodeCompletion() && !IDECallbacks) {
       // Trigger delayed parsing, no need to continue.
       return Status;
     }
@@ -8478,8 +8475,8 @@ Parser::parseDeclInit(ParseDeclOptions Flags, DeclAttributes &Attributes) {
 
   // Pass the function signature to code completion.
   if (Status.hasCodeCompletion()) {
-    assert(CodeCompletion && "must be code completion second pass");
-    CodeCompletion->setParsedDecl(CD);
+    assert(IDECallbacks && "must be code completion second pass");
+    IDECallbacks->setParsedDecl(CD);
   }
 
   if (ConstructorsNotAllowed) {
@@ -8657,9 +8654,9 @@ Parser::parseDeclOperatorImpl(SourceLoc OperatorLoc, Identifier Name,
   if (Tok.is(tok::colon)) {
     colonLoc = consumeToken();
     if (Tok.is(tok::code_complete)) {
-      if (CodeCompletion && !isPrefix && !isPostfix) {
-        CodeCompletion->completeInPrecedenceGroup(
-           CodeCompletionCallbacks::PrecedenceGroupCompletionKind::Relation);
+      if (IDECallbacks && !isPrefix && !isPostfix) {
+        IDECallbacks->completeInPrecedenceGroup(
+            IDEInspectionCallbacks::PrecedenceGroupCompletionKind::Relation);
       }
       consumeToken();
 
@@ -8756,7 +8753,7 @@ Parser::parseDeclPrecedenceGroup(ParseDeclOptions flags,
   SourceLoc precedenceGroupLoc = consumeToken(tok::kw_precedencegroup);
   DebuggerContextChange DCC (*this);
 
-  if (!CodeCompletion &&
+  if (!IDECallbacks &&
       !DCC.movedToTopLevel() &&
       !(flags & PD_AllowTopLevel)) {
     diagnose(precedenceGroupLoc, diag::decl_inner_scope);
@@ -8852,10 +8849,11 @@ Parser::parseDeclPrecedenceGroup(ParseDeclOptions flags,
     }
   };
 
-  auto checkCodeCompletion = [&](CodeCompletionCallbacks::PrecedenceGroupCompletionKind SK) -> bool {
+  auto checkCodeCompletion =
+      [&](IDEInspectionCallbacks::PrecedenceGroupCompletionKind SK) -> bool {
     if (Tok.is(tok::code_complete)) {
-      if (CodeCompletion)
-        CodeCompletion->completeInPrecedenceGroup(SK);
+      if (IDECallbacks)
+        IDECallbacks->completeInPrecedenceGroup(SK);
       consumeToken();
       return true;
     }
@@ -8873,7 +8871,8 @@ Parser::parseDeclPrecedenceGroup(ParseDeclOptions flags,
 
   // Parse the attributes in the body.
   while (Tok.isNot(tok::r_brace)) {
-    if (checkCodeCompletion(CodeCompletionCallbacks::PrecedenceGroupCompletionKind::AttributeList)) {
+    if (checkCodeCompletion(IDEInspectionCallbacks::
+                                PrecedenceGroupCompletionKind::AttributeList)) {
       hasCodeCompletion = true;
       continue;
     } else if (Tok.isNot(tok::identifier)) {
@@ -8888,7 +8887,8 @@ Parser::parseDeclPrecedenceGroup(ParseDeclOptions flags,
                                            tok::contextual_keyword);
       parseAttributePrefix(associativityKeywordLoc);
 
-      if (checkCodeCompletion(CodeCompletionCallbacks::PrecedenceGroupCompletionKind::Associativity))
+      if (checkCodeCompletion(IDEInspectionCallbacks::
+                                  PrecedenceGroupCompletionKind::Associativity))
         return abortBody(/*hasCodeCompletion*/true);
 
       if (Tok.isNot(tok::identifier)) {
@@ -8926,7 +8926,8 @@ Parser::parseDeclPrecedenceGroup(ParseDeclOptions flags,
       // "assignment" is considered as a contextual keyword.
       TokReceiver->registerTokenKindChange(assignmentKeywordLoc,
                                            tok::contextual_keyword);
-      if (checkCodeCompletion(CodeCompletionCallbacks::PrecedenceGroupCompletionKind::Assignment))
+      if (checkCodeCompletion(IDEInspectionCallbacks::
+                                  PrecedenceGroupCompletionKind::Assignment))
         return abortBody(/*hasCodeCompletion*/true);
 
       if (consumeIf(tok::kw_true, assignmentValueLoc)) {
@@ -8953,7 +8954,8 @@ Parser::parseDeclPrecedenceGroup(ParseDeclOptions flags,
       auto &relations = (isLowerThan ? lowerThan : higherThan);
 
       do {
-        if (checkCodeCompletion(CodeCompletionCallbacks::PrecedenceGroupCompletionKind::Relation)) {
+        if (checkCodeCompletion(IDEInspectionCallbacks::
+                                    PrecedenceGroupCompletionKind::Relation)) {
           return abortBody(/*hasCodeCompletion*/true);
         }
 
@@ -9093,7 +9095,7 @@ ParserResult<MacroDecl> Parser::parseDeclMacro(DeclAttributes &attributes) {
   // Parse a 'where' clause if present.
   if (Tok.is(tok::kw_where)) {
     auto whereStatus = parseFreestandingGenericWhereClause(macro);
-    if (whereStatus.hasCodeCompletion() && !CodeCompletion) {
+    if (whereStatus.hasCodeCompletion() && !IDECallbacks) {
       // Trigger delayed parsing, no need to continue.
       return whereStatus;
     }

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -18,7 +18,7 @@
 #include "swift/AST/DiagnosticsParse.h"
 #include "swift/AST/GenericParamList.h"
 #include "swift/AST/TypeRepr.h"
-#include "swift/Parse/CodeCompletionCallbacks.h"
+#include "swift/Parse/IDEInspectionCallbacks.h"
 #include "swift/Parse/Lexer.h"
 
 using namespace swift;
@@ -260,8 +260,8 @@ ParserStatus Parser::parseGenericWhereClause(
   bool HasNextReq;
   do {
     if (Tok.is(tok::code_complete)) {
-      if (CodeCompletion)
-        CodeCompletion->completeGenericRequirement();
+      if (IDECallbacks)
+        IDECallbacks->completeGenericRequirement();
       EndLoc = consumeToken(tok::code_complete);
       Status.setHasCodeCompletionAndIsError();
       break;

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -23,7 +23,7 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/TypeRepr.h"
 #include "swift/Basic/StringExtras.h"
-#include "swift/Parse/CodeCompletionCallbacks.h"
+#include "swift/Parse/IDEInspectionCallbacks.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/Support/SaveAndRestore.h"
@@ -239,8 +239,8 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
     if (paramContext != ParameterContextKind::EnumElement) {
       auto AttrStatus = parseDeclAttributeList(param.Attrs);
       if (AttrStatus.hasCodeCompletion()) {
-        if (CodeCompletion)
-          CodeCompletion->setAttrTargetDeclKind(DeclKind::Param);
+        if (IDECallbacks)
+          IDECallbacks->setAttrTargetDeclKind(DeclKind::Param);
         status.setHasCodeCompletionAndIsError();
       }
     }
@@ -989,8 +989,8 @@ ParserStatus Parser::parseEffectsSpecifiers(SourceLoc existingArrowLoc,
     // Code completion.
     if (Tok.is(tok::code_complete) && !Tok.isAtStartOfLine() &&
         !existingArrowLoc.isValid()) {
-      if (CodeCompletion)
-        CodeCompletion->completeEffectsSpecifier(asyncLoc.isValid(),
+      if (IDECallbacks)
+        IDECallbacks->completeEffectsSpecifier(asyncLoc.isValid(),
                                                  throwsLoc.isValid());
       consumeToken(tok::code_complete);
       status.setHasCodeCompletionAndIsError();
@@ -1027,9 +1027,10 @@ ParserResult<Pattern> Parser::parseTypedPattern() {
     if (!Ty.isNull()) {
       // Attempt to diagnose initializer calls incorrectly written
       // as typed patterns, such as "var x: [Int]()".
-      // Disable this tentative parse when in code-completion mode, otherwise
+      // Disable this tentative parse when in IDE inspection mode, otherwise
       // code-completion may enter the delayed-decl state twice.
-      if (Tok.isFollowingLParen() && !SourceMgr.hasCodeCompletionBuffer()) {
+      if (Tok.isFollowingLParen() &&
+          !SourceMgr.hasIDEInspectionTargetBuffer()) {
         CancellableBacktrackingScope backtrack(*this);
 
         // Create a local context if needed so we can parse trailing closures.

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -157,10 +157,10 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
   diags.setSuppressWarnings(didSuppressWarnings || shouldSuppress);
   SWIFT_DEFER { diags.setSuppressWarnings(didSuppressWarnings); };
 
-  // If this buffer is for code completion, hook up the state needed by its
+  // If this buffer is for IDE functionality, hook up the state needed by its
   // second pass.
   PersistentParserState *state = nullptr;
-  if (ctx.SourceMgr.getCodeCompletionBufferID() == bufferID) {
+  if (ctx.SourceMgr.getIDEInspectionTargetBufferID() == bufferID) {
     state = new PersistentParserState();
     SF->setDelayedParserState({state, &deletePersistentParserState});
   }
@@ -178,7 +178,7 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
 #if SWIFT_SWIFT_PARSER
   if ((ctx.LangOpts.hasFeature(Feature::ParserRoundTrip) ||
        ctx.LangOpts.hasFeature(Feature::ParserValidation)) &&
-      ctx.SourceMgr.getCodeCompletionBufferID() != bufferID &&
+      ctx.SourceMgr.getIDEInspectionTargetBufferID() != bufferID &&
       SF->Kind != SourceFileKind::SIL) {
     auto bufferRange = ctx.SourceMgr.getRangeForBuffer(*bufferID);
     unsigned int flags = 0;
@@ -265,15 +265,15 @@ ArrayRef<Decl *> ParseTopLevelDeclsRequest::evaluate(
 }
 
 //----------------------------------------------------------------------------//
-// CodeCompletionSecondPassRequest computation.
+// IDEInspectionSecondPassRequest computation.
 //----------------------------------------------------------------------------//
 
 
 void swift::simple_display(llvm::raw_ostream &out,
-                           const CodeCompletionCallbacksFactory *factory) { }
+                           const IDEInspectionCallbacksFactory *factory) { }
 
 evaluator::DependencySource
-CodeCompletionSecondPassRequest::readDependencySource(
+IDEInspectionSecondPassRequest::readDependencySource(
     const evaluator::DependencyRecorder &e) const {
   return std::get<0>(getStorage());
 }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -19,7 +19,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Version.h"
-#include "swift/Parse/CodeCompletionCallbacks.h"
+#include "swift/Parse/IDEInspectionCallbacks.h"
 #include "swift/Parse/Lexer.h"
 #include "swift/Parse/Parser.h"
 #include "swift/Subsystems.h"
@@ -126,8 +126,8 @@ ParserStatus Parser::parseExprOrStmt(ASTNode &Result) {
   if (Tok.is(tok::pound) && Tok.isAtStartOfLine() &&
       peekToken().is(tok::code_complete)) {
     consumeToken();
-    if (CodeCompletion)
-      CodeCompletion->completeAfterPoundDirective();
+    if (IDECallbacks)
+      IDECallbacks->completeAfterPoundDirective();
     consumeToken(tok::code_complete);
     return makeParserCodeCompletionStatus();
   }
@@ -143,14 +143,14 @@ ParserStatus Parser::parseExprOrStmt(ASTNode &Result) {
   StructureMarkerRAII ParsingStmt(*this, Tok.getLoc(),
                                   StructureMarkerKind::Statement);
 
-  if (CodeCompletion)
-    CodeCompletion->setExprBeginning(getParserPosition());
+  if (IDECallbacks)
+    IDECallbacks->setExprBeginning(getParserPosition());
 
   if (Tok.is(tok::code_complete)) {
     auto *CCE = new (Context) CodeCompletionExpr(Tok.getLoc());
     Result = CCE;
-    if (CodeCompletion)
-      CodeCompletion->completeStmtOrExpr(CCE);
+    if (IDECallbacks)
+      IDECallbacks->completeStmtOrExpr(CCE);
     consumeToken(tok::code_complete);
     return makeParserCodeCompletionStatus();
   }
@@ -233,9 +233,9 @@ void Parser::consumeTopLevelDecl(ParserPosition BeginParserPosition,
   SourceLoc EndLoc = PreviousLoc;
   backtrackToPosition(BeginParserPosition);
   SourceLoc BeginLoc = Tok.getLoc();
-  State->setCodeCompletionDelayedDeclState(
+  State->setIDEInspectionDelayedDeclState(
       SourceMgr, L->getBufferID(),
-      CodeCompletionDelayedDeclKind::TopLevelCodeDecl,
+      IDEInspectionDelayedDeclKind::TopLevelCodeDecl,
       PD_Default, TLCD, {BeginLoc, EndLoc}, BeginParserPosition.PreviousLoc);
 
   // Skip the rest of the file to prevent the parser from constructing the AST
@@ -320,7 +320,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
     }
 
     ParserPosition BeginParserPosition;
-    if (isCodeCompletionFirstPass())
+    if (isIDEInspectionFirstPass())
       BeginParserPosition = getParserPosition();
 
     // Parse the decl, stmt, or expression.
@@ -333,7 +333,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
                             : BraceItemListKind::InactiveConditionalBlock,
                           IsFollowingGuard);
         });
-      if (IfConfigResult.hasCodeCompletion() && isCodeCompletionFirstPass()) {
+      if (IfConfigResult.hasCodeCompletion() && isIDEInspectionFirstPass()) {
         consumeDecl(BeginParserPosition, None, IsTopLevel);
         return IfConfigResult;
       }
@@ -385,7 +385,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
       if (DeclResult.isParseErrorOrHasCompletion()) {
         NeedParseErrorRecovery = true;
         if (DeclResult.hasCodeCompletion() && IsTopLevel &&
-            isCodeCompletionFirstPass()) {
+            isIDEInspectionFirstPass()) {
           consumeDecl(BeginParserPosition, None, IsTopLevel);
           return DeclResult;
         }
@@ -407,7 +407,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
 
       ParserStatus Status = parseExprOrStmt(Result);
       BraceItemsStatus |= Status;
-      if (Status.hasCodeCompletion() && isCodeCompletionFirstPass()) {
+      if (Status.hasCodeCompletion() && isIDEInspectionFirstPass()) {
         consumeTopLevelDecl(BeginParserPosition, TLCD);
         auto Brace = BraceStmt::create(Context, StartLoc, {}, PreviousLoc);
         TLCD->setBody(Brace);
@@ -660,8 +660,8 @@ static ParserStatus parseOptionalControlTransferTarget(Parser &P,
       TargetLoc = P.consumeIdentifier(Target, /*diagnoseDollarPrefix=*/false);
       return makeParserSuccess();
     } else if (P.Tok.is(tok::code_complete)) {
-      if (P.CodeCompletion)
-        P.CodeCompletion->completeStmtLabel(Kind);
+      if (P.IDECallbacks)
+        P.IDECallbacks->completeStmtLabel(Kind);
       TargetLoc = P.consumeToken(tok::code_complete);
       return makeParserCodeCompletionStatus();
     }
@@ -715,8 +715,8 @@ ParserResult<Stmt> Parser::parseStmtReturn(SourceLoc tryLoc) {
   if (Tok.is(tok::code_complete)) {
     auto CCE = new (Context) CodeCompletionExpr(Tok.getLoc());
     auto Result = makeParserResult(new (Context) ReturnStmt(ReturnLoc, CCE));
-    if (CodeCompletion) {
-      CodeCompletion->completeReturnStmt(CCE);
+    if (IDECallbacks) {
+      IDECallbacks->completeReturnStmt(CCE);
     }
     Result.setHasCodeCompletionAndIsError();
     consumeToken();
@@ -783,8 +783,8 @@ ParserResult<Stmt> Parser::parseStmtYield(SourceLoc tryLoc) {
     auto cce = new (Context) CodeCompletionExpr(Tok.getLoc());
     auto result = makeParserResult(
       YieldStmt::create(Context, yieldLoc, SourceLoc(), cce, SourceLoc()));
-    if (CodeCompletion) {
-      CodeCompletion->completeYieldStmt(cce, /*index=*/ None);
+    if (IDECallbacks) {
+      IDECallbacks->completeYieldStmt(cce, /*index=*/ None);
     }
     result.setHasCodeCompletionAndIsError();
     consumeToken();
@@ -1017,13 +1017,13 @@ static void parseGuardedPattern(Parser &P, GuardedPattern &result,
   if (P.Tok.is(tok::code_complete)) {
     auto CCE = new (P.Context) CodeCompletionExpr(P.Tok.getLoc());
     result.ThePattern = new (P.Context) ExprPattern(CCE);
-    if (P.CodeCompletion) {
+    if (P.IDECallbacks) {
       switch (parsingContext) {
       case GuardedPatternContext::Case:
-        P.CodeCompletion->completeCaseStmtBeginning(CCE);
+        P.IDECallbacks->completeCaseStmtBeginning(CCE);
         break;
       case GuardedPatternContext::Catch:
-        P.CodeCompletion->completePostfixExprBeginning(CCE);
+        P.IDECallbacks->completePostfixExprBeginning(CCE);
         break;
       }
     }
@@ -1581,8 +1581,8 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
     }
 
   } else if (Tok.is(tok::code_complete)) {
-    if (CodeCompletion) {
-      CodeCompletion->completeOptionalBinding();
+    if (IDECallbacks) {
+      IDECallbacks->completeOptionalBinding();
     }
     ThePattern = makeParserResult(new (Context) AnyPattern(Tok.getLoc()));
     ThePattern.setHasCodeCompletionAndIsError();
@@ -1816,8 +1816,8 @@ ParserResult<Stmt> Parser::parseStmtIf(LabeledStmtInfo LabelInfo,
       }
       ElseBody = parseStmtIf(LabeledStmtInfo(), implicitlyInsertIf);
     } else if (Tok.is(tok::code_complete)) {
-      if (CodeCompletion)
-        CodeCompletion->completeAfterIfStmtElse();
+      if (IDECallbacks)
+        IDECallbacks->completeAfterIfStmtElse();
       Status.setHasCodeCompletionAndIsError();
       consumeToken(tok::code_complete);
     } else {
@@ -2193,9 +2193,9 @@ ParserResult<Stmt> Parser::parseStmtForEach(LabeledStmtInfo LabelInfo) {
   }
 
   if (Tok.is(tok::code_complete)) {
-    if (CodeCompletion) {
-      CodeCompletion->completeForEachPatternBeginning(TryLoc.isValid(),
-                                                      AwaitLoc.isValid());
+    if (IDECallbacks) {
+      IDECallbacks->completeForEachPatternBeginning(TryLoc.isValid(),
+                                                    AwaitLoc.isValid());
     }
     consumeToken(tok::code_complete);
     // Since 'completeForeachPatternBeginning' is a keyword only completion,
@@ -2262,8 +2262,8 @@ ParserResult<Stmt> Parser::parseStmtForEach(LabeledStmtInfo LabelInfo) {
     // If there is no "in" keyword, suggest it. Otherwise, complete the
     // sequence.
     if (InLoc.isInvalid()) {
-      if (CodeCompletion)
-        CodeCompletion->completeForEachInKeyword();
+      if (IDECallbacks)
+        IDECallbacks->completeForEachInKeyword();
       consumeToken(tok::code_complete);
       return makeParserCodeCompletionStatus();
     } else {
@@ -2271,8 +2271,8 @@ ParserResult<Stmt> Parser::parseStmtForEach(LabeledStmtInfo LabelInfo) {
           makeParserResult(new (Context) CodeCompletionExpr(Tok.getLoc()));
       Container.setHasCodeCompletionAndIsError();
       Status |= Container;
-      if (CodeCompletion)
-        CodeCompletion->completeForEachSequenceBeginning(
+      if (IDECallbacks)
+        IDECallbacks->completeForEachSequenceBeginning(
             cast<CodeCompletionExpr>(Container.get()));
       consumeToken(tok::code_complete);
     }
@@ -2417,8 +2417,8 @@ Parser::parseStmtCases(SmallVectorImpl<ASTNode> &cases, bool IsActive) {
         cases.emplace_back(PDD);
       }
     } else if (Tok.is(tok::code_complete)) {
-      if (CodeCompletion)
-        CodeCompletion->completeCaseStmtKeyword();
+      if (IDECallbacks)
+        IDECallbacks->completeCaseStmtKeyword();
       consumeToken(tok::code_complete);
       return makeParserCodeCompletionStatus();
     } else {

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -21,7 +21,7 @@
 #include "swift/AST/SourceFile.h" // only for isMacroSignatureFile
 #include "swift/AST/TypeRepr.h"
 #include "swift/Parse/Lexer.h"
-#include "swift/Parse/CodeCompletionCallbacks.h"
+#include "swift/Parse/IDEInspectionCallbacks.h"
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/Twine.h"
@@ -184,8 +184,8 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
     ty = parseTypeTupleBody();
     break;
   case tok::code_complete:
-    if (CodeCompletion)
-      CodeCompletion->completeTypeSimpleBeginning();
+    if (IDECallbacks)
+      IDECallbacks->completeTypeSimpleBeginning();
     return makeParserCodeCompletionResult<TypeRepr>(
         new (Context) ErrorTypeRepr(consumeToken(tok::code_complete)));
   case tok::l_square: {
@@ -573,8 +573,8 @@ ParserResult<TypeRepr> Parser::parseTypeWithOpaqueParams(Diag<> MessageID) {
 
 ParserResult<TypeRepr> Parser::parseDeclResultType(Diag<> MessageID) {
   if (Tok.is(tok::code_complete)) {
-    if (CodeCompletion)
-      CodeCompletion->completeTypeDeclResultBeginning();
+    if (IDECallbacks)
+      IDECallbacks->completeTypeDeclResultBeginning();
     consumeToken(tok::code_complete);
     return makeParserCodeCompletionStatus();
   }
@@ -672,8 +672,8 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType) {
     if (Tok.is(tok::kw_Any)) {
       return parseAnyType();
     } else if (Tok.is(tok::code_complete)) {
-      if (CodeCompletion)
-        CodeCompletion->completeTypeSimpleBeginning();
+      if (IDECallbacks)
+        IDECallbacks->completeTypeSimpleBeginning();
       // Eat the code completion token because we handled it.
       consumeToken(tok::code_complete);
       return makeParserCodeCompletionResult<IdentTypeRepr>();
@@ -759,11 +759,11 @@ Parser::parseTypeIdentifier(bool isParsingQualifiedDeclBaseType) {
     if (Tok.isNot(tok::code_complete)) {
       // We have a dot.
       consumeToken();
-      if (CodeCompletion)
-        CodeCompletion->completeTypeIdentifierWithDot(ITR);
+      if (IDECallbacks)
+        IDECallbacks->completeTypeIdentifierWithDot(ITR);
     } else {
-      if (CodeCompletion)
-        CodeCompletion->completeTypeIdentifierWithoutDot(ITR);
+      if (IDECallbacks)
+        IDECallbacks->completeTypeIdentifierWithoutDot(ITR);
     }
     // Eat the code completion token because we handled it.
     consumeToken(tok::code_complete);

--- a/lib/Parse/PersistentParserState.cpp
+++ b/lib/Parse/PersistentParserState.cpp
@@ -26,11 +26,11 @@ PersistentParserState::PersistentParserState() { }
 
 PersistentParserState::~PersistentParserState() { }
 
-void PersistentParserState::setCodeCompletionDelayedDeclState(
-    SourceManager &SM, unsigned BufferID, CodeCompletionDelayedDeclKind Kind,
+void PersistentParserState::setIDEInspectionDelayedDeclState(
+    SourceManager &SM, unsigned BufferID, IDEInspectionDelayedDeclKind Kind,
     unsigned Flags, DeclContext *ParentContext, SourceRange BodyRange,
     SourceLoc PreviousLoc) {
-  assert(!CodeCompletionDelayedDeclStat.get() &&
+  assert(!IDEInspectionDelayedDeclStat.get() &&
          "only one decl can be delayed for code completion");
   unsigned startOffset = SM.getLocOffsetInBuffer(BodyRange.Start, BufferID);
   unsigned endOffset = SM.getLocOffsetInBuffer(BodyRange.End, BufferID);
@@ -38,13 +38,13 @@ void PersistentParserState::setCodeCompletionDelayedDeclState(
   if (PreviousLoc.isValid())
     prevOffset = SM.getLocOffsetInBuffer(PreviousLoc, BufferID);
 
-  CodeCompletionDelayedDeclStat.reset(new CodeCompletionDelayedDeclState(
+  IDEInspectionDelayedDeclStat.reset(new IDEInspectionDelayedDeclState(
       Kind, Flags, ParentContext, startOffset, endOffset, prevOffset));
 }
 
-void PersistentParserState::restoreCodeCompletionDelayedDeclState(
-    const CodeCompletionDelayedDeclState &other) {
-  CodeCompletionDelayedDeclStat.reset(new CodeCompletionDelayedDeclState(
+void PersistentParserState::restoreIDEInspectionDelayedDeclState(
+    const IDEInspectionDelayedDeclState &other) {
+  IDEInspectionDelayedDeclStat.reset(new IDEInspectionDelayedDeclState(
       other.Kind, other.Flags, other.ParentContext,
       other.StartOffset, other.EndOffset, other.PrevOffset));
 }

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -744,7 +744,7 @@ protected:
         // HACK: still allow empty bodies if typechecking for code
         // completion. Code completion ignores diagnostics
         // and won't get any types if we fail.
-        if (!ctx.SourceMgr.hasCodeCompletionBuffer()) {
+        if (!ctx.SourceMgr.hasIDEInspectionTargetBuffer()) {
           hadError = true;
           return nullptr;
         }
@@ -1454,7 +1454,7 @@ protected:
         // HACK: still allow empty bodies if typechecking for code
         // completion. Code completion ignores diagnostics
         // and won't get any types if we fail.
-        if (!ctx.SourceMgr.hasCodeCompletionBuffer())
+        if (!ctx.SourceMgr.hasIDEInspectionTargetBuffer())
           return None;
       }
     }
@@ -2479,7 +2479,8 @@ ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
         // If we're solving for code completion and the body contains the code
         // completion location, skipping it won't get us to a useful solution so
         // just bail.
-        if (isForCodeCompletion() && containsCodeCompletionLoc(fn.getBody())) {
+        if (isForCodeCompletion() &&
+            containsIDEInspectionTarget(fn.getBody())) {
           return getTypeMatchFailure(locator);
         }
 
@@ -2562,7 +2563,7 @@ ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
       // If we're solving for code completion and the body contains the code
       // completion location, skipping it won't get us to a useful solution so
       // just bail.
-      if (isForCodeCompletion() && containsCodeCompletionLoc(fn.getBody())) {
+      if (isForCodeCompletion() && containsIDEInspectionTarget(fn.getBody())) {
         return getTypeMatchFailure(locator);
       }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1116,7 +1116,7 @@ constraints::getCompletionArgInfo(ASTNode anchor, ConstraintSystem &CS) {
     return None;
 
   for (unsigned i : indices(*args)) {
-    if (CS.containsCodeCompletionLoc(args->getExpr(i)))
+    if (CS.containsIDEInspectionTarget(args->getExpr(i)))
       return CompletionArgInfo{i, args->getFirstTrailingClosureIndex(),
                                args->size()};
   }
@@ -2878,7 +2878,7 @@ static bool fixMissingArguments(ConstraintSystem &cs, ASTNode anchor,
   // code completion location, since they may have just not been written yet.
   if (cs.isForCodeCompletion()) {
     if (auto *closure = getAsExpr<ClosureExpr>(anchor)) {
-      if (cs.containsCodeCompletionLoc(closure) &&
+      if (cs.containsIDEInspectionTarget(closure) &&
           (closure->hasAnonymousClosureVars() ||
            (args.empty() && closure->getInLoc().isInvalid())))
           return false;
@@ -5297,8 +5297,9 @@ bool ConstraintSystem::repairFailures(
         // other (explicit) argument's so source range containment alone isn't
         // sufficient.
         bool isSynthesizedArg = arg->isImplicit() && isa<DeclRefExpr>(arg);
-        if (!isSynthesizedArg && isForCodeCompletion() && containsCodeCompletionLoc(arg) &&
-            !lhs->isVoid() && !lhs->isUninhabited())
+        if (!isSynthesizedArg && isForCodeCompletion() &&
+            containsIDEInspectionTarget(arg) && !lhs->isVoid() &&
+            !lhs->isUninhabited())
           return true;
       }
     }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -352,19 +352,19 @@ ConstraintSystem::getAlternativeLiteralTypes(KnownProtocolKind kind,
   return scratch;
 }
 
-bool ConstraintSystem::containsCodeCompletionLoc(ASTNode node) const {
+bool ConstraintSystem::containsIDEInspectionTarget(ASTNode node) const {
   SourceRange range = node.getSourceRange();
   if (range.isInvalid())
     return false;
-  return Context.SourceMgr.rangeContainsCodeCompletionLoc(range);
+  return Context.SourceMgr.rangeContainsIDEInspectionTarget(range);
 }
 
-bool ConstraintSystem::containsCodeCompletionLoc(
+bool ConstraintSystem::containsIDEInspectionTarget(
     const ArgumentList *args) const {
   SourceRange range = args->getSourceRange();
   if (range.isInvalid())
     return false;
-  return Context.SourceMgr.rangeContainsCodeCompletionLoc(range);
+  return Context.SourceMgr.rangeContainsIDEInspectionTarget(range);
 }
 
 ConstraintLocator *ConstraintSystem::getConstraintLocator(
@@ -3467,7 +3467,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     // contains the completion location
     auto SE = getAsExpr<SubscriptExpr>(locator->getAnchor());
     if (!isForCodeCompletion() ||
-        (SE && !containsCodeCompletionLoc(SE->getArgs()))) {
+        (SE && !containsIDEInspectionTarget(SE->getArgs()))) {
       increaseScore(SK_KeyPathSubscript);
     }
     break;

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -564,7 +564,7 @@ bool TypeChecker::typeCheckForCodeCompletion(
   {
     auto range = target.getSourceRange();
     if (range.isInvalid() ||
-        !Context.SourceMgr.rangeContainsCodeCompletionLoc(range))
+        !Context.SourceMgr.rangeContainsIDEInspectionTarget(range))
       return false;
   }
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3572,7 +3572,7 @@ bool SimpleDidSetRequest::evaluate(Evaluator &evaluator,
   }
 
   // Always assume non-simple 'didSet' in code completion mode.
-  if (decl->getASTContext().SourceMgr.hasCodeCompletionBuffer())
+  if (decl->getASTContext().SourceMgr.hasIDEInspectionTargetBuffer())
     return false;
 
   // didSet must have a single parameter.

--- a/tools/SourceKit/include/SourceKit/Core/Context.h
+++ b/tools/SourceKit/include/SourceKit/Core/Context.h
@@ -34,14 +34,14 @@ namespace SourceKit {
 class GlobalConfig {
 public:
   struct Settings {
-    struct CompletionOptions {
+    struct IDEInspectionOptions {
 
-      /// Max count of reusing ASTContext for cached code completion.
+      /// Max count of reusing ASTContext for cached IDE inspection.
       unsigned MaxASTContextReuseCount = 100;
 
-      /// Interval second for checking dependencies in cached code completion.
+      /// Interval second for checking dependencies in cached IDE inspection.
       unsigned CheckDependencyInterval = 5;
-    } CompletionOpts;
+    } IDEInspectionOpts;
   };
 
 private:
@@ -49,9 +49,9 @@ private:
   mutable llvm::sys::Mutex Mtx;
 
 public:
-  Settings update(Optional<unsigned> CompletionMaxASTContextReuseCount,
-                  Optional<unsigned> CompletionCheckDependencyInterval);
-  Settings::CompletionOptions getCompletionOpts() const;
+  Settings update(Optional<unsigned> IDEInspectionMaxASTContextReuseCount,
+                  Optional<unsigned> IDEInspectionCheckDependencyInterval);
+  Settings::IDEInspectionOptions getIDEInspectionOpts() const;
 };
 
 /// Keeps track of all requests that are currently in progress and coordinates

--- a/tools/SourceKit/lib/Core/Context.cpp
+++ b/tools/SourceKit/lib/Core/Context.cpp
@@ -21,18 +21,18 @@ GlobalConfig::update(Optional<unsigned> CompletionMaxASTContextReuseCount,
                      Optional<unsigned> CompletionCheckDependencyInterval) {
   llvm::sys::ScopedLock L(Mtx);
   if (CompletionMaxASTContextReuseCount.has_value())
-    State.CompletionOpts.MaxASTContextReuseCount =
+    State.IDEInspectionOpts.MaxASTContextReuseCount =
         *CompletionMaxASTContextReuseCount;
   if (CompletionCheckDependencyInterval.has_value())
-    State.CompletionOpts.CheckDependencyInterval =
+    State.IDEInspectionOpts.CheckDependencyInterval =
         *CompletionCheckDependencyInterval;
   return State;
 }
 
-GlobalConfig::Settings::CompletionOptions
-GlobalConfig::getCompletionOpts() const {
+GlobalConfig::Settings::IDEInspectionOptions
+GlobalConfig::getIDEInspectionOpts() const {
   llvm::sys::ScopedLock L(Mtx);
-  return State.CompletionOpts;
+  return State.IDEInspectionOpts;
 }
 
 SourceKit::Context::Context(

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -23,7 +23,7 @@
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/IDE/CodeCompletionCache.h"
 #include "swift/IDE/CodeCompletionResultPrinter.h"
-#include "swift/IDETool/CompletionInstance.h"
+#include "swift/IDETool/IDEInspectionInstance.h"
 
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/MemoryBuffer.h"
@@ -111,7 +111,7 @@ static void swiftCodeCompleteImpl(
               ParamsResult) {
         ParamsResult.mapAsync<CodeCompleteResult>(
             [&](auto &CIParams, auto DeliverTransformed) {
-              Lang.getCompletionInstance()->codeComplete(
+              Lang.getIDEInspectionInstance()->codeComplete(
                   CIParams.Invocation, Args, FileSystem,
                   CIParams.completionBuffer, Offset, CIParams.DiagC,
                   CompletionContext, CIParams.CancellationFlag,

--- a/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftConformingMethodList.cpp
@@ -16,7 +16,7 @@
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/IDE/ConformingMethodList.h"
-#include "swift/IDETool/CompletionInstance.h"
+#include "swift/IDETool/IDEInspectionInstance.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Comment.h"
 #include "clang/AST/Decl.h"
@@ -181,7 +181,7 @@ void SwiftLangSupport::getConformingMethodList(
       [&](CancellableResult<CompletionLikeOperationParams> ParmsResult) {
         ParmsResult.mapAsync<ConformingMethodListResults>(
             [&](auto &Params, auto DeliverTransformed) {
-              getCompletionInstance()->conformingMethodList(
+              getIDEInspectionInstance()->conformingMethodList(
                   Params.Invocation, Args, fileSystem, Params.completionBuffer,
                   Offset, Params.DiagC, ExpectedTypeNames,
                   Params.CancellationFlag, DeliverTransformed);

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -27,7 +27,7 @@
 #include "swift/IDE/Indenting.h"
 #include "swift/Refactoring/Refactoring.h"
 #include "swift/IDETool/CompileInstance.h"
-#include "swift/IDETool/CompletionInstance.h"
+#include "swift/IDETool/IDEInspectionInstance.h"
 #include "swift/Index/IndexSymbol.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
 #include "llvm/ADT/StringMap.h"
@@ -51,7 +51,7 @@ namespace swift {
 
 namespace ide {
   class CodeCompletionCache;
-  class CompletionInstance;
+  class IDEInspectionInstance;
   class OnDiskCodeCompletionCache;
   class SourceEditConsumer;
   enum class CodeCompletionDeclKind : uint8_t;
@@ -354,7 +354,7 @@ class SwiftLangSupport : public LangSupport {
   ThreadSafeRefCntPtr<SwiftCustomCompletions> CustomCompletions;
   std::shared_ptr<SwiftStatistics> Stats;
   llvm::StringMap<std::unique_ptr<FileSystemProvider>> FileSystemProviders;
-  std::shared_ptr<swift::ide::CompletionInstance> CompletionInst;
+  std::shared_ptr<swift::ide::IDEInspectionInstance> IDEInspectionInst;
   compile::SessionManager CompileManager;
 
 public:
@@ -378,8 +378,9 @@ public:
     return CCCache;
   }
 
-  std::shared_ptr<swift::ide::CompletionInstance> getCompletionInstance() {
-    return CompletionInst;
+  std::shared_ptr<swift::ide::IDEInspectionInstance>
+  getIDEInspectionInstance() {
+    return IDEInspectionInst;
   }
 
   /// Returns the FileSystemProvider registered under Name, or nullptr if not
@@ -515,7 +516,7 @@ public:
   };
 
   /// Execute \p PerformOperation synchronously with the parameters necessary to
-  /// invoke a completion-like operation on \c CompletionInstance.
+  /// invoke a completion-like operation on \c IDEInspectionInstance.
   /// If \p InsertCodeCompletionToken is \c true, a code completion token will
   /// be inserted into the source buffer, if \p InsertCodeCompletionToken is \c
   /// false, the buffer is left as-is.

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1996,7 +1996,7 @@ void SwiftLangSupport::getCursorInfo(
           [&](CancellableResult<CompletionLikeOperationParams> ParmsResult) {
             ParmsResult.mapAsync<CursorInfoResults>(
                 [&](auto &Params, auto DeliverTransformed) {
-                  getCompletionInstance()->cursorInfo(
+                  getIDEInspectionInstance()->cursorInfo(
                       Params.Invocation, Args, fileSystem,
                       Params.completionBuffer, Offset, Params.DiagC,
                       Params.CancellationFlag, DeliverTransformed);

--- a/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftTypeContextInfo.cpp
@@ -16,7 +16,7 @@
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/IDE/TypeContextInfo.h"
-#include "swift/IDETool/CompletionInstance.h"
+#include "swift/IDETool/IDEInspectionInstance.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Comment.h"
 #include "clang/AST/Decl.h"
@@ -151,7 +151,7 @@ void SwiftLangSupport::getExpressionContextInfo(
       [&](CancellableResult<CompletionLikeOperationParams> ParamsResult) {
         ParamsResult.mapAsync<TypeContextInfoResult>(
             [&](auto &CIParams, auto DeliverTransformed) {
-              getCompletionInstance()->typeContextInfo(
+              getIDEInspectionInstance()->typeContextInfo(
                   CIParams.Invocation, Args, fileSystem,
                   CIParams.completionBuffer, Offset, CIParams.DiagC,
                   CIParams.CancellationFlag, DeliverTransformed);

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -505,9 +505,9 @@ void handleRequestImpl(sourcekitd_object_t ReqObj,
     getGlobalContext().getSwiftLangSupport().globalConfigurationUpdated(Config);
 
     dict.set(KeyCompletionMaxASTContextReuseCount,
-             UpdatedConfig.CompletionOpts.MaxASTContextReuseCount);
+             UpdatedConfig.IDEInspectionOpts.MaxASTContextReuseCount);
     dict.set(KeyCompletionCheckDependencyInterval,
-             UpdatedConfig.CompletionOpts.CheckDependencyInterval);
+             UpdatedConfig.IDEInspectionOpts.CheckDependencyInterval);
 
     return Rec(RB.createResponse());
   }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -47,7 +47,7 @@
 #include "swift/IDE/TypeContextInfo.h"
 #include "swift/IDE/Utils.h"
 #include "swift/IDETool/CompilerInvocation.h"
-#include "swift/IDETool/CompletionInstance.h"
+#include "swift/IDETool/IDEInspectionInstance.h"
 #include "swift/Index/Index.h"
 #include "swift/Markup/Markup.h"
 #include "swift/Parse/ParseVersion.h"
@@ -890,7 +890,7 @@ struct CompletionLikeOperationParams {
 };
 
 /// Run \p PerformOperation with the parameters that are needed to perform a
-/// completion like operation on a \c CompletionInstance. This function will
+/// completion like operation on a \c IDEInspectionInstance. This function will
 /// return the same value as \p PerformOperation.
 /// In case there was an error setting up the parameters for the operation,
 /// this method returns \c true and does not call \p PerformOperation.
@@ -1003,9 +1003,9 @@ static int doTypeContextInfo(const CompilerInvocation &InitInvok,
       InitInvok, SourceFilename, SecondSourceFileName, CodeCompletionToken,
       CodeCompletionDiagnostics,
       [&](CompletionLikeOperationParams Params) -> bool {
-        CompletionInstance CompletionInst;
+        IDEInspectionInstance IDEInspectionInst;
         int ExitCode = 2;
-        CompletionInst.typeContextInfo(
+        IDEInspectionInst.typeContextInfo(
             Params.Invocation, Params.Args, Params.FileSystem,
             Params.CompletionBuffer, Params.Offset, Params.DiagC,
             /*CancellationFlag=*/nullptr,
@@ -1075,9 +1075,9 @@ doConformingMethodList(const CompilerInvocation &InitInvok,
       InitInvok, SourceFilename, SecondSourceFileName, CodeCompletionToken,
       CodeCompletionDiagnostics,
       [&](CompletionLikeOperationParams Params) -> bool {
-        CompletionInstance CompletionInst;
+        IDEInspectionInstance IDEInspectionInst;
         int ExitCode = 2;
-        CompletionInst.conformingMethodList(
+        IDEInspectionInst.conformingMethodList(
             Params.Invocation, Params.Args, Params.FileSystem,
             Params.CompletionBuffer, Params.Offset, Params.DiagC, typeNames,
             /*CancellationFlag=*/nullptr,
@@ -1222,7 +1222,7 @@ doCodeCompletion(const CompilerInvocation &InitInvok, StringRef SourceFilename,
       InitInvok, SourceFilename, SecondSourceFileName, CodeCompletionToken,
       CodeCompletionDiagnostics,
       [&](CompletionLikeOperationParams Params) -> bool {
-        CompletionInstance Inst;
+        IDEInspectionInstance Inst;
         int ExitCode = 2;
         Inst.codeComplete(
             Params.Invocation, Params.Args, Params.FileSystem,
@@ -1488,7 +1488,7 @@ static int doBatchCodeCompletion(const CompilerInvocation &InitInvok,
   CompilerInvocation Invocation(InitInvok);
   auto FileSystem = llvm::vfs::getRealFileSystem();
 
-  CompletionInstance CompletionInst;
+  IDEInspectionInstance IDEInspectionInst;
 
   std::unique_ptr<ide::OnDiskCodeCompletionCache> OnDiskCache;
   if (!options::CompletionCachePath.empty())
@@ -1556,7 +1556,7 @@ static int doBatchCodeCompletion(const CompilerInvocation &InitInvok,
     bool wasASTContextReused = false;
     std::string completionError = "";
     bool CallbackCalled = false;
-    CompletionInst.codeComplete(
+    IDEInspectionInst.codeComplete(
         Invocation, /*Args=*/{}, FileSystem, completionBuffer.get(), Offset,
         CodeCompletionDiagnostics ? &PrintDiags : nullptr, CompletionContext,
         /*CancellationFlag=*/nullptr,

--- a/unittests/Parse/LexerTests.cpp
+++ b/unittests/Parse/LexerTests.cpp
@@ -470,7 +470,7 @@ TEST_F(LexerTest, RestoreStopAtCodeCompletion) {
   LangOptions LangOpts;
   SourceManager SourceMgr;
   unsigned BufferID = SourceMgr.addMemBufferCopy(StringRef(Source, 16));
-  SourceMgr.setCodeCompletionPoint(BufferID, 6);
+  SourceMgr.setIDEInspectionTarget(BufferID, 6);
 
   Lexer L(LangOpts, SourceMgr, BufferID, /*Diags=*/nullptr, LexerMode::Swift);
 


### PR DESCRIPTION
The code completion infrastructure is also being used for cursor info now, so it should no longer be called code completion.

rdar://103251187