### PR TITLE
Make new driver flag '-e' a "Separate" flag instead of "JoinedOrSeparate"

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -252,7 +252,7 @@ def tools_directory : Separate<["-"], "tools-directory">,
 def D : JoinedOrSeparate<["-"], "D">, Flags<[FrontendOption]>,
   HelpText<"Marks a conditional compilation flag as true">;
   
-def e : JoinedOrSeparate<["-"], "e">, Flags<[NewDriverOnlyOption]>,
+def e : Separate<["-"], "e">, Flags<[NewDriverOnlyOption]>,
   HelpText<"Executes a line of code provided on the command line">;
 
 def F : JoinedOrSeparate<["-"], "F">,


### PR DESCRIPTION
Otherwise it causes conflicts with existing '-e' flags.

For example, the innovation: `swift -empty-abi-descriptor ...` resutls in:
```
-e:1:1: error: cannot find 'mpty' in scope
mpty-abi-descriptor
^~~~
-e:1:6: error: cannot find 'abi' in scope
mpty-abi-descriptor
     ^~~
-e:1:10: error: cannot find 'descriptor' in scope
mpty-abi-descriptor
         ^~~~~~~~~~
```
