### PR TITLE
[CSSolver] Solve multi-statement closures in source order

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0186-rdar46497155.swift
+++ b/validation-test/compiler_crashers_2_fixed/0186-rdar46497155.swift
@@ -22,7 +22,7 @@ func foo(arr: [E], other: P) -> Bool {
   return arr.compactMap { i in
     var flag = false
     return try? i.getB(&flag)
-  }.compactMap { u -> P? in // expected-error {{unable to infer type of a closure parameter 'u' in the current context}}
+  }.compactMap { u -> P? in // Ok
     guard let a = try? u.foo() else { return nil }
     return a.value!
   }.contains {


### PR DESCRIPTION
Currently solver picks the first conjunction it can find,
which means - the earliest resolved closure. This is not 
always correct because when calls are chained closures
passed to the lower members could be resolved sooner
than the ones higher up but at the same time they depend 
on types inferred from members higher in the chain.

Let's make sure that multi-statement closures are always 
solved in order they appear in the AST to make sure that
types are available to members lower in the chain.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
