### PR TITLE
[Runtime] Fix debugDescription of .self keypaths.

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -3934,7 +3934,8 @@ extension AnyKeyPath: CustomDebugStringConvertible {
     return withBuffer {
       var buffer = $0
       if buffer.data.isEmpty {
-        _internalInvariantFailure("key path has no components")
+        description.append(".self")
+        return description
       }
       var valueType: Any.Type = Self.rootType
       while true {

--- a/test/Interpreter/keypath.swift
+++ b/test/Interpreter/keypath.swift
@@ -93,3 +93,5 @@ print(\Controller[int: 0, str: "", 0])
 print(\Controller.thirdLabel)
 // CHECK: {{\\Controller\.subscript\(\)|\\Controller\.<computed 0x.* \(Int\)>}}
 print(\Controller.[])
+// CHECK: \Controller.self
+print(\Controller.self)


### PR DESCRIPTION
AnyKeyPath's debugDescription assumes there's always at least one component, but `\Type.self` produces an empty keypath. Special-case the empty case to display a `.self` component.

rdar://103237845