### PR TITLE
[Reflection] Range-check shapeIndex in createBoundGenericTypeReconstructingParent.

### DIFF
--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -569,6 +569,9 @@ public:
     if (!mangling.isSuccess())
       return nullptr;
 
+    if (shapeIndex >= genericParamsPerLevel.size())
+      return nullptr;
+
     auto numGenericArgs = genericParamsPerLevel[shapeIndex];
 
     auto startOffsetFromEnd = argsIndex + numGenericArgs;


### PR DESCRIPTION
If the parentNode chain ends up being longer than genericParamsPerLevel, we can underflow shapeIndex, resulting in an out-of-bounds read. Range check it against the vector before trying to read it, and return NULL if it's out of bounds.

rdar://103220412