### PR TITLE
Fix IRGen debug info for swift_task_alloc'ed variables.

### DIFF
--- a/test/DebugInfo/async-lifetime-extension.swift
+++ b/test/DebugInfo/async-lifetime-extension.swift
@@ -8,8 +8,8 @@
 
 // CHECK-LABEL: define {{.*}} void @"$s1a4fiboyS2iYaFTY0_"
 // CHECK-NEXT: entryresume.0:
-// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[R:[0-9]+]], {{.*}}!DIExpression(DW_OP
 // CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[N:[0-9]+]], {{.*}}!DIExpression(DW_OP
+// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[R:[0-9]+]], {{.*}}!DIExpression(DW_OP
 // CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[LHS:[0-9]+]], {{.*}}!DIExpression(DW_OP
 // CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[RHS:[0-9]+]], {{.*}}!DIExpression(DW_OP
 // CHECK-NOT: {{ ret }}

--- a/test/DebugInfo/async-task-alloc.swift
+++ b/test/DebugInfo/async-task-alloc.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - \
+// RUN:    -module-name a  -disable-availability-checking \
+// RUN:    | %FileCheck %s --check-prefix=CHECK
+// REQUIRES: concurrency
+
+// Test dynamically allocated local variables in async functions.
+
+// CHECK-LABEL: define {{.*}} void @"$s1a1fyxxYalF"
+// CHECK: swift_task_alloc
+// CHECK-LABEL: define {{.*}} void @"$s1a1fyxxYalFTY0_"
+// CHECK-NEXT: entryresume.0:
+// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[T:[0-9]+]], {{.*}}!DIExpression({{.*}}DW_OP_deref
+// CHECK-NEXT: call void @llvm.dbg.declare(metadata {{.*}}%0, metadata ![[DYNA:[0-9]+]], {{.*}}!DIExpression({{.*}}DW_OP_deref
+
+// CHECK: ![[DYNA]] = !DILocalVariable(name: "dyna"
+// CHECK: ![[T]] = !DILocalVariable(name: "t"
+public func f<T>(_ t: T) async -> T {
+  let dyna = t
+  return dyna
+}


### PR DESCRIPTION
The old code attempted to load the variable despite not knowing its size. Fixed by describing the variable's address on the task heap.
