### PR TITLE
Remove lookupSymbol() and have all callers use SymbolInfo::lookup() instead

### DIFF
--- a/stdlib/public/SwiftShims/swift/shims/MetadataSections.h
+++ b/stdlib/public/SwiftShims/swift/shims/MetadataSections.h
@@ -53,8 +53,8 @@ struct MetadataSections {
   /// reported when the section was registered with the Swift runtime.
   ///
   /// The value of this field is equivalent to the value of
-  /// \c SymbolInfo::baseAddress as returned from \c lookupSymbol() for a symbol
-  /// in the image that contains these sections.
+  /// \c SymbolInfo::baseAddress as returned from \c SymbolInfo::lookup() for a
+  /// symbol in the image that contains these sections.
   ///
   /// For Mach-O images, set this field to \c __dso_handle (i.e. the Mach header
   /// for the image.) For ELF images, set it to \c __dso_handle (the runtime

--- a/stdlib/public/runtime/ImageInspectionCommon.cpp
+++ b/stdlib/public/runtime/ImageInspectionCommon.cpp
@@ -65,8 +65,8 @@ static void fixupMetadataSectionBaseAddress(swift::MetadataSections *sections) {
     // We need to fix up the base address. We'll need a known-good address in
     // the same image: `sections` itself will work nicely.
     auto symbolInfo = SymbolInfo::lookup(sections);
-    if (symbolInfo.has_value() && symbolInfo.getBaseAddress()) {
-        sections->baseAddress.store(symbolInfo.getBaseAddress(),
+    if (symbolInfo.has_value() && symbolInfo->getBaseAddress()) {
+        sections->baseAddress.store(symbolInfo->getBaseAddress(),
                                     std::memory_order_relaxed);
     }
   }

--- a/stdlib/public/runtime/ImageInspectionCommon.cpp
+++ b/stdlib/public/runtime/ImageInspectionCommon.cpp
@@ -64,8 +64,8 @@ static void fixupMetadataSectionBaseAddress(swift::MetadataSections *sections) {
   if (fixupNeeded) {
     // We need to fix up the base address. We'll need a known-good address in
     // the same image: `sections` itself will work nicely.
-    swift::SymbolInfo symbolInfo;
-    if (lookupSymbol(sections, &symbolInfo) && symbolInfo.getBaseAddress()) {
+    auto symbolInfo = SymbolInfo::lookup(sections);
+    if (symbolInfo.has_value() && symbolInfo.getBaseAddress()) {
         sections->baseAddress.store(symbolInfo.getBaseAddress(),
                                     std::memory_order_relaxed);
     }
@@ -190,10 +190,9 @@ const swift::MetadataSections *swift_getMetadataSection(size_t index) {
 SWIFT_RUNTIME_EXPORT
 const char *
 swift_getMetadataSectionName(const swift::MetadataSections *section) {
-  swift::SymbolInfo info;
-  if (lookupSymbol(section, &info)) {
-    if (info.getFilename()) {
-      return info.getFilename();
+  if (auto info = SymbolInfo::lookup(section)) {
+    if (info->getFilename()) {
+      return info->getFilename();
     }
   }
   return "";
@@ -203,9 +202,8 @@ SWIFT_RUNTIME_EXPORT
 void swift_getMetadataSectionBaseAddress(const swift::MetadataSections *section,
                                          void const **out_actual,
                                          void const **out_expected) {
-  swift::SymbolInfo info;
-  if (lookupSymbol(section, &info)) {
-    *out_actual = info.getBaseAddress();
+  if (auto info = SymbolInfo::lookup(section)) {
+    *out_actual = info->getBaseAddress();
   } else {
     *out_actual = nullptr;
   }

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1105,9 +1105,8 @@ _gatherGenericParameters(const ContextDescriptor *context,
 
       str += "_gatherGenericParameters: context: ";
 
-      SymbolInfo contextInfo;
-      if (lookupSymbol(context, &contextInfo)) {
-        str += contextInfo.getSymbolName();
+      if (auto contextInfo = SymbolInfo::lookup(context)) {
+        str += contextInfo->getSymbolName();
         str += " ";
       }
 

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -124,12 +124,13 @@ static const char *class_getName(const ClassMetadata* type) {
 }
 
 template<> void ProtocolConformanceDescriptor::dump() const {
-  SymbolInfo info;
+  llvm::Optional<SymbolInfo> info;
   auto symbolName = [&](const void *addr) -> const char * {
-    int ok = lookupSymbol(addr, &info);
-    if (!ok || !info.getSymbolName())
-      return "<unknown addr>";
-    return info.getSymbolName();
+    info = SymbolInfo::lookup(addr);
+    if (info.has_value() && info->getSymbolName()) {
+      return info->getSymbolName();
+    }
+    return "<unknown addr>";
   };
 
   switch (auto kind = getTypeKind()) {

--- a/stdlib/public/runtime/ReflectionMirror.cpp
+++ b/stdlib/public/runtime/ReflectionMirror.cpp
@@ -1116,9 +1116,8 @@ id swift_reflectionMirror_quickLookObject(OpaqueValue *value, const Metadata *T)
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
 const char *swift_keyPath_copySymbolName(void *address) {
-  SymbolInfo info;
-  if (lookupSymbol(address, &info) && info.getSymbolName()) {
-    return strdup(info.getSymbolName());
+  if (auto info = SymbolInfo::lookup(address) && info->getSymbolName()) {
+    return strdup(info->getSymbolName());
   }
   return 0;
 }

--- a/stdlib/public/runtime/ReflectionMirror.cpp
+++ b/stdlib/public/runtime/ReflectionMirror.cpp
@@ -1116,10 +1116,12 @@ id swift_reflectionMirror_quickLookObject(OpaqueValue *value, const Metadata *T)
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
 const char *swift_keyPath_copySymbolName(void *address) {
-  if (auto info = SymbolInfo::lookup(address) && info->getSymbolName()) {
-    return strdup(info->getSymbolName());
+  if (auto info = SymbolInfo::lookup(address)) {
+    if (info->getSymbolName()) {
+      return strdup(info->getSymbolName());
+    }
   }
-  return 0;
+  return nullptr;
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL

--- a/stdlib/public/runtime/SymbolInfo.h
+++ b/stdlib/public/runtime/SymbolInfo.h
@@ -76,27 +76,6 @@ public:
   static llvm::Optional<SymbolInfo> lookup(const void *address);
 };
 
-/// Look up a symbol by address and store the result in a locally-declared
-/// \c SymbolInfo value.
-///
-/// \param address The address where the symbol is located.
-/// \param outInfo On successful return, populated with information about the
-///   symbol at \a address. On failure, unspecified.
-///
-/// \returns On success, a non-zero integer. On failure, zero.
-///
-/// \note This function will be replaced with \c SymbolInfo::lookup() in a
-///   future update.
-static inline int lookupSymbol(const void *address, SymbolInfo *outInfo) {
-  auto info = SymbolInfo::lookup(address);
-  if (info.has_value()) {
-    *outInfo = info.value();
-    return 1;
-  } else {
-    return 0;
-  }
-}
-
 } // end namespace swift
 
 #endif


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR removes the free function `lookupSymbol()` and modifies its callers to use `SymbolInfo::lookup()` instead.

In a previous PR, I refactored `lookupSymbol()` to call through to `SymbolInfo::lookup()` which itself returned an `llvm::Optional<SymbolInfo>`, which `lookupSymbol()` unpacks and copies into an out-param. As discussed in the review for that PR, we might as well remove the stub function and update callers to just use the underlying function.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
<!-- Resolves #NNNNN, fix apple/llvm-project#MMMMM. -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
