### PR TITLE
Performance annotations: make `UnsafeMutableRawBufferPointer.bindMemory` allocation/lock free

### DIFF
--- a/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
+++ b/lib/SILOptimizer/Transforms/GenericSpecializer.cpp
@@ -373,6 +373,14 @@ optimizeInst(SILInstruction *inst, SILOptFunctionBuilder &funcBuilder,
     deleter.forceDelete(bi);
     return true;
   }
+  if (auto *mti = dyn_cast<MetatypeInst>(inst)) {
+    // Remove dead `metatype` instructions which only have `debug_value` uses.
+    // We lose debug info for such type variables, but this is a compromise we
+    // need to accept to get allocation/lock free code.
+    if (onlyHaveDebugUses(mti)) {
+      deleter.forceDeleteWithUsers(mti);
+    }
+  }
   return false;
 }
 

--- a/test/SILOptimizer/performance-annotations.swift
+++ b/test/SILOptimizer/performance-annotations.swift
@@ -131,12 +131,12 @@ func testGlobalWithComplexInit() -> Int {
   return Str.s3 // expected-note {{called from here}}
 }
 
-func metatypeArg<T>(_ t: T.Type, _ b: Bool) { // expected-error {{Using type 'Int' can cause metadata allocation or locks}}
+func metatypeArg<T>(_ t: T.Type, _ b: Bool) {
 }
 
 @_noAllocation
 func callFuncWithMetatypeArg() {
-  metatypeArg(Int.self, false)                // expected-note {{called from here}}
+  metatypeArg(Int.self, false)
 }
 
 @_noAllocation
@@ -226,5 +226,18 @@ func closueWhichModifiesLocalVar() -> Int {
 @_noAllocation
 func createEmptyArray() {
   _ = [Int]() // expected-error {{ending the lifetime of a value of type}}
+}
+
+struct Buffer {
+  var p: UnsafeMutableRawBufferPointer
+
+  func bind<T>(of type: T.Type) -> UnsafeMutableBufferPointer<T> {
+    self.p.bindMemory(to: T.self)
+  }
+
+  @_noAllocation
+  func callBind() -> UnsafeMutableBufferPointer<Int> {
+    return bind(of: Int.self)
+  }
 }
 


### PR DESCRIPTION
Remove dead `metatype` instructions which only have `debug_value` uses. We lose debug info for such type variables, but this is a compromise we need to accept to get allocation/lock free code.

rdar://103270882
