### PR TITLE
[Index] Index any system module when no SDK path is defined

### DIFF
--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -451,7 +451,8 @@ static void addModuleDependencies(ArrayRef<ImportedModule> imports,
             // We don't officially support binary swift modules, so normally
             // the index data for user modules would get generated while
             // building them.
-            bool isDistributedModule = mod->isSDKModule();
+            bool isDistributedModule = mod->isSDKModule() ||
+                      mod->getASTContext().SearchPathOpts.getSDKPath().empty();
             if (mod->isSystemModule() && indexSystemModules &&
                 (isDistributedModule || mod->isStdlibModule()) &&
                 (!skipStdlib || !mod->isStdlibModule())) {

--- a/test/Index/index_swift_only_systemmodule.swift
+++ b/test/Index/index_swift_only_systemmodule.swift
@@ -2,6 +2,7 @@ import SomeModule
 print(someFunc())
 
 // UNIT: Record | system | SomeModule |
+// SKIP-NOT: Record | system | SomeModule |
 
 // RUN: %empty-directory(%t)
 //
@@ -37,6 +38,38 @@ print(someFunc())
 // RUN:     -index-ignore-stdlib \
 // RUN:     -index-store-path %t/idx \
 // RUN:     -sdk %t/SDK \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -module-cache-path %t/modulecache \
+// RUN:     %s
+//
+// --- Check the index.
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck -check-prefix=UNIT %s
+//
+// --- Built with indexing, SomeModule is outside of the SDK so it's skipped.
+// RUN: %empty-directory(%t/idx)
+// RUN: %empty-directory(%t/modulecache)
+// RUN: %target-swift-frontend \
+// RUN:     -typecheck \
+// RUN:     -index-system-modules \
+// RUN:     -index-ignore-stdlib \
+// RUN:     -index-store-path %t/idx \
+// RUN:     -sdk %t/NotTheActualSDK \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -module-cache-path %t/modulecache \
+// RUN:     %s
+//
+// --- Check the index.
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck -check-prefix=SKIP %s
+
+// --- Built with indexing, without an SDK path SomeModule is indexed.
+// RUN: %empty-directory(%t/idx)
+// RUN: %empty-directory(%t/modulecache)
+// RUN: %target-swift-frontend \
+// RUN:     -typecheck \
+// RUN:     -index-system-modules \
+// RUN:     -index-ignore-stdlib \
+// RUN:     -index-store-path %t/idx \
+// RUN:     -sdk "" \
 // RUN:     -Fsystem %t/SDK/Frameworks \
 // RUN:     -module-cache-path %t/modulecache \
 // RUN:     %s


### PR DESCRIPTION
Indexing of system modules was restricted to modules under the SDK path in  https://github.com/apple/swift/pull/62353. This PR makes an exception when no SDK is defined, in that case any system module is indexed.