### PR TITLE
[Parser] Add C++-only `prefix_period`

### DIFF
--- a/include/swift/AST/TokenKinds.def.gyb
+++ b/include/swift/AST/TokenKinds.def.gyb
@@ -172,6 +172,7 @@ SIL_KEYWORD(sil_scope)
 
 PUNCTUATOR(sil_dollar,    "$")    // Only in SIL mode.
 PUNCTUATOR(sil_exclamation, "!")    // Only in SIL mode.
+PUNCTUATOR(period_prefix, ".")
 
 MISC(eof)
 MISC(code_complete)


### PR DESCRIPTION
swift-syntax no longer uses `prefix_period` and has removed it. The C++ lexer still uses it though, so add it back into the C++ side.