### PR TITLE
[OpaqueValues] Fix @in_guaranteed loadable yields.

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -1736,10 +1736,13 @@ static ManagedValue manageYield(SILGenFunction &SGF, SILValue value,
       return ManagedValue::forUnmanaged(value);
     return ManagedValue::forBorrowedObjectRValue(value);
   case ParameterConvention::Indirect_In_Guaranteed: {
-    bool isOpaque = SGF.getTypeLowering(value->getType()).isAddressOnly() &&
-                    !SGF.silConv.useLoweredAddresses();
-    return isOpaque ? ManagedValue::forBorrowedObjectRValue(value)
-                    : ManagedValue::forBorrowedAddressRValue(value);
+    if (SGF.silConv.useLoweredAddresses()) {
+      return ManagedValue::forBorrowedAddressRValue(value);
+    }
+    if (value->getType().isTrivial(SGF.F)) {
+      return ManagedValue::forTrivialObjectRValue(value);
+    }
+    return ManagedValue::forBorrowedObjectRValue(value);
   }
   }
   llvm_unreachable("bad kind");

--- a/test/SILGen/opaque_values_silgen_resilient.swift
+++ b/test/SILGen/opaque_values_silgen_resilient.swift
@@ -28,3 +28,40 @@ public indirect enum OneOfThese : Hashable {
 }
 
 
+public protocol ProtocolWithAYield {
+  associatedtype Assoc
+  @_borrowed
+  subscript() -> Assoc { get }
+}
+
+public struct ResilientTrivialStruct {}
+
+public struct StructYieldingAResilientTrivialValue : ProtocolWithAYield {
+  var i: ResilientTrivialStruct
+  public typealias Assoc = ResilientTrivialStruct
+  // CHECK-LABEL: sil {{.*}}@$s30opaque_values_silgen_resilient36StructYieldingAResilientTrivialValueVAA18ProtocolWithAYieldA2aDP5AssocQzycirTW {{.*}} {
+  // CHECK:         yield {{%[^,]+}} : $ResilientTrivialStruct
+  // CHECK-LABEL: } // end sil function '$s30opaque_values_silgen_resilient36StructYieldingAResilientTrivialValueVAA18ProtocolWithAYieldA2aDP5AssocQzycirTW'
+  public subscript() -> ResilientTrivialStruct {
+    _read {
+      yield i
+    }
+  }
+}
+
+public struct ResilientNontrivialStruct {
+  var s: String
+}
+
+public struct StructYieldingAResilientNonetrivialValue : ProtocolWithAYield {
+  var i: ResilientNontrivialStruct
+  public typealias Assoc = ResilientNontrivialStruct
+  // CHECK-LABEL: sil {{.*}}@$s30opaque_values_silgen_resilient40StructYieldingAResilientNonetrivialValueVAA18ProtocolWithAYieldA2aDP5AssocQzycirTW {{.*}} {
+  // CHECK:         yield {{%[^,]+}} : $ResilientNontrivialStruct
+  // CHECK-LABEL: } // end sil function '$s30opaque_values_silgen_resilient40StructYieldingAResilientNonetrivialValueVAA18ProtocolWithAYieldA2aDP5AssocQzycirTW'
+  public subscript() -> ResilientNontrivialStruct {
+    _read {
+      yield i
+    }
+  }
+}


### PR DESCRIPTION
When opaque values are enabled, when yielding a value with an indirect convention, a value whose type's category is "object" must be yielded. Previously, if a value's type was loadable, an attempt was made to yield a value whose type's category was "address".  Here, that's fixed. Additionally, handling for trivial types yielded via `@in_guaranteed` is added.
