### PR TITLE
[move-only-object] Teach move only object verifier how to emit proper errors for closure/defer uses

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -731,6 +731,8 @@ ERROR(sil_moveonlychecker_value_used_after_consume, none,
       "'%0' used after consume. Lifetime extension of variable requires a copy", (StringRef))
 ERROR(sil_moveonlychecker_guaranteed_value_consumed, none,
       "'%0' has guaranteed ownership but was consumed", (StringRef))
+ERROR(sil_moveonlychecker_guaranteed_value_captured_by_closure, none,
+      "'%0' has guaranteed ownership but was consumed due to being captured by a closure", (StringRef))
 ERROR(sil_moveonlychecker_inout_not_reinitialized_before_end_of_function, none,
       "'%0' consumed but not reinitialized before end of function", (StringRef))
 ERROR(sil_moveonlychecker_value_consumed_in_a_loop, none,
@@ -740,6 +742,8 @@ ERROR(sil_moveonlychecker_exclusivity_violation, none,
 
 NOTE(sil_moveonlychecker_consuming_use_here, none,
      "consuming use", ())
+NOTE(sil_moveonlychecker_consuming_closure_use_here, none,
+     "closure capture", ())
 NOTE(sil_moveonlychecker_nonconsuming_use_here, none,
      "non-consuming use", ())
 ERROR(sil_moveonlychecker_not_understand_no_implicit_copy, none,

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -954,3 +954,12 @@ SILGenBuilder::createMarkMustCheckInst(SILLocation loc, ManagedValue value,
       loc, value.forward(getSILGenFunction()), kind);
   return cloner.clone(mdi);
 }
+
+ManagedValue SILGenBuilder::emitCopyValueOperation(SILLocation loc,
+                                                   ManagedValue value) {
+  auto cvi = SILBuilder::emitCopyValueOperation(loc, value.getValue());
+  // Trivial type.
+  if (cvi == value.getValue())
+    return value;
+  return SGF.emitManagedRValueWithCleanup(cvi);
+}

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -430,6 +430,9 @@ public:
   using SILBuilder::createMarkMustCheckInst;
   ManagedValue createMarkMustCheckInst(SILLocation loc, ManagedValue value,
                                        MarkMustCheckInst::CheckKind kind);
+
+  using SILBuilder::emitCopyValueOperation;
+  ManagedValue emitCopyValueOperation(SILLocation Loc, ManagedValue v);
 };
 
 } // namespace Lowering

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -845,3 +845,22 @@ func closeOverStructDontCopyTrivial() {
   a = StructWithMutatingMethod()
   takeClosure { a.x }
 }
+
+// Make sure that we handle closure argument initialization when due to forward
+// declaration we represent a let as an lvalue
+func test() {
+    let k: SomeClass
+    let k2: SomeClass
+    var boolean: Bool { true }
+
+    if boolean {
+        k = SomeClass()
+        k2 = SomeClass()
+    } else {
+        k = SomeClass()
+        k2 = SomeClass()
+    }
+
+    assert(k.x == k2.x)
+}
+

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -2046,9 +2046,12 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg(_ x2: __owned EnumTy) {
 // Closure and Defer Tests //
 /////////////////////////////
 
-public func closureClassUseAfterConsume1(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    let f = { // expected-note {{consuming use}}
+public func closureClassUseAfterConsume1(_ x: Klass) {
+    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x' has guaranteed ownership but was consumed due to being captured by a closure}}
+    let f = { // expected-note {{closure capture}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
+        // expected-note @-1 {{consuming use}}
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use}}
         print(x2) // expected-note {{consuming use}}
@@ -2079,50 +2082,58 @@ public func closureClassUseAfterConsumeArg(_ argX: Klass) {
 
 public func closureCaptureClassUseAfterConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
     let f = {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     f()
 }
 
 public func closureCaptureClassUseAfterConsumeError(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use}}
+    let x2 = x
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-note @-3 {{consuming use}}
     let f = { // expected-note {{consuming use}}
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     f()
     let x3 = x2 // expected-note {{consuming use}}
     let _ = x3
 }
 
-public func closureCaptureClassArgUseAfterConsume(_ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    let f = { // expected-note {{consuming use}}
+public func closureCaptureClassArgUseAfterConsume(_ x2: Klass) {
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    let f = { // expected-note {{closure capture}}
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     f()
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
     let f = {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     f()
 }
 
-public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
+public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
     let f = { // expected-note {{consuming use}}
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     f()
     let x3 = x2 // expected-note {{consuming use}}
@@ -2131,63 +2142,68 @@ public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) { /
 
 public func deferCaptureClassUseAfterConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     print(x) // expected-note {{consuming use}}
 }
 
 public func deferCaptureClassUseAfterConsume2(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use}}
-    // TODO: Defer error is b/c we have to lifetime extend x2 for the defer. The
-    // use is a guaranteed use, so we don't emit an error on that use.
+    // expected-note @-1 {{consuming use}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     let x3 = x2 // expected-note {{consuming use}}
     let _ = x3
 }
 
 public func deferCaptureClassArgUseAfterConsume(_ x2: Klass) {
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
     classUseMoveOnlyWithoutEscaping(x2)
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     print("foo")
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     print("foo")
 }
 
-public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
+public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     print(x2) // expected-note {{consuming use}}
 }
 
 public func closureAndDeferCaptureClassUseAfterConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
     let f = {
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         print("foo")
     }
@@ -2196,12 +2212,14 @@ public func closureAndDeferCaptureClassUseAfterConsume(_ x: Klass) { // expected
 
 public func closureAndDeferCaptureClassUseAfterConsume2(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
     let f = {
-        classConsume(x2)
+        classConsume(x2) // expected-note {{consuming use}}
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         print("foo")
     }
@@ -2210,13 +2228,15 @@ public func closureAndDeferCaptureClassUseAfterConsume2(_ x: Klass) { // expecte
 
 public func closureAndDeferCaptureClassUseAfterConsume3(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use}}
+    // expected-note @-1 {{consuming use}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed}}
     let f = { // expected-note {{consuming use}}
-        classConsume(x2)
+        classConsume(x2) // expected-note {{consuming use}}
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         print("foo")
     }
@@ -2224,12 +2244,14 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: Klass) { // expecte
     classConsume(x2) // expected-note {{consuming use}}
 }
 
-public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    let f = { // expected-note {{consuming use}}
+public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: Klass) {
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    let f = { // expected-note {{closure capture}}
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         print("foo")
     }
@@ -2237,23 +2259,26 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: Klass) { // expe
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
     let f = {
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         print("foo")
     }
     f()
 }
 
-public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
+public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
     let f = { // expected-note {{consuming use}}
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         print("foo")
     }
@@ -2263,11 +2288,13 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Kl
 
 public func closureAndClosureCaptureClassUseAfterConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = {
-        let g = {
+        let g = { // expected-note {{closure capture}}
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         g()
     }
@@ -2276,12 +2303,14 @@ public func closureAndClosureCaptureClassUseAfterConsume(_ x: Klass) { // expect
 
 public func closureAndClosureCaptureClassUseAfterConsume2(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use}}
+    // expected-note @-1 {{consuming use}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{consuming use}}
-        let g = {
+        let g = { // expected-note {{closure capture}}
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         g()
     }
@@ -2290,12 +2319,15 @@ public func closureAndClosureCaptureClassUseAfterConsume2(_ x: Klass) { // expec
 }
 
 
-public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    let f = { // expected-note {{consuming use}}
-        let g = {
+public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: Klass) {
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    let f = { // expected-note {{closure capture}}
+        let g = { // expected-note {{closure capture}}
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         g()
     }
@@ -2303,23 +2335,28 @@ public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: Klass) { // ex
 }
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = {
-        let g = {
+        let g = { // expected-note {{closure capture}}
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         g()
     }
     f()
 }
 
-public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
+public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{consuming use}}
-        let g = {
+        let g = { // expected-note {{closure capture}}
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         g()
     }

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -1342,9 +1342,12 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg(_ x2: __owned EnumTy) {
 // Closure and Defer Tests //
 /////////////////////////////
 
-public func closureClassUseAfterConsume1(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    let f = { // expected-note {{consuming use}}
+public func closureClassUseAfterConsume1(_ x: NonTrivialStruct) {
+    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x' has guaranteed ownership but was consumed due to being captured by a closure}}
+    let f = { // expected-note {{closure capture}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
+        // expected-note @-1 {{consuming use}}
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use}}
         print(x2) // expected-note {{consuming use}}
@@ -1375,50 +1378,57 @@ public func closureClassUseAfterConsumeArg(_ argX: NonTrivialStruct) {
 
 public func closureCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
     let f = {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     f()
 }
 
 public func closureCaptureClassUseAfterConsumeError(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use}}
+    // expected-note @-1 {{consuming use}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
     let f = { // expected-note {{consuming use}}
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     f()
     let x3 = x2 // expected-note {{consuming use}}
     let _ = x3
 }
 
-public func closureCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    let f = { // expected-note {{consuming use}}
+public func closureCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) {
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    let f = { // expected-note {{closure capture}}
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     f()
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
     let f = {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     f()
 }
 
-public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialStruct) { // expected-error {{'x2' consumed more than once}}
+public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialStruct) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
     let f = { // expected-note {{consuming use}}
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     f()
     let x3 = x2 // expected-note {{consuming use}}
@@ -1427,63 +1437,71 @@ public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivial
 
 public func deferCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     print(x) // expected-note {{consuming use}}
 }
 
 public func deferCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use}}
+    // expected-note @-1 {{consuming use}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
     // TODO: Defer error is b/c we have to lifetime extend x2 for the defer. The
     // use is a guaranteed use, so we don't emit an error on that use.
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     let x3 = x2 // expected-note {{consuming use}}
     let _ = x3
 }
 
 public func deferCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) {
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
     classUseMoveOnlyWithoutEscaping(x2)
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     print("foo")
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     print("foo")
 }
 
-public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialStruct) { // expected-error {{'x2' consumed more than once}}
+public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialStruct) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
-        print(x2)
+        classConsume(x2) // expected-note {{consuming use}}
+        print(x2) // expected-note {{consuming use}}
     }
     print(x2) // expected-note {{consuming use}}
 }
 
-public func closureAndDeferCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureAndDeferCaptureClassUseAfterConsume(_ x: NonTrivialStruct) {
+    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
     let f = {
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         print("foo")
     }
@@ -1492,12 +1510,14 @@ public func closureAndDeferCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { 
 
 public func closureAndDeferCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
     let f = {
-        classConsume(x2)
+        classConsume(x2) // expected-note {{consuming use}}
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         print("foo")
     }
@@ -1506,13 +1526,15 @@ public func closureAndDeferCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) {
 
 public func closureAndDeferCaptureClassUseAfterConsume3(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use}}
+    // expected-note @-1 {{consuming use}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed}}
     let f = { // expected-note {{consuming use}}
-        classConsume(x2)
+        classConsume(x2) // expected-note {{consuming use}}
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         print("foo")
     }
@@ -1521,11 +1543,12 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: NonTrivialStruct) {
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    let f = { // expected-note {{consuming use}}
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    let f = { // expected-note {{closure capture}}
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         print("foo")
     }
@@ -1533,11 +1556,12 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
     let f = {
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         print("foo")
     }
@@ -1545,11 +1569,12 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Non
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialStruct) { // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
     let f = { // expected-note {{consuming use}}
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) //  expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         print("foo")
     }
@@ -1559,11 +1584,13 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned No
 
 public func closureAndClosureCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = {
-        let g = {
+        let g = { // expected-note {{closure capture}}
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         g()
     }
@@ -1573,11 +1600,13 @@ public func closureAndClosureCaptureClassUseAfterConsume(_ x: NonTrivialStruct) 
 public func closureAndClosureCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use}}
+               // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+               // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{consuming use}}
-        let g = {
+        let g = { // expected-note {{closure capture}}
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         g()
     }
@@ -1586,12 +1615,15 @@ public func closureAndClosureCaptureClassUseAfterConsume2(_ x: NonTrivialStruct)
 }
 
 
-public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    let f = { // expected-note {{consuming use}}
-        let g = {
+public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) {
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    let f = { // expected-note {{closure capture}}
+        let g = { // expected-note {{closure capture}}
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         g()
     }
@@ -1599,23 +1631,28 @@ public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: NonTrivialStru
 }
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
+    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = {
-        let g = {
+        let g = { // expected-note {{closure capture}}
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         g()
     }
     f()
 }
 
-public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialStruct) { // expected-error {{'x2' consumed more than once}}
+public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialStruct) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{consuming use}}
-        let g = {
+        let g = { // expected-note {{closure capture}}
             classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
-            print(x2)
+            classConsume(x2) // expected-note {{consuming use}}
+            print(x2) // expected-note {{consuming use}}
         }
         g()
     }


### PR DESCRIPTION
Specifically, we error if one consumes a value at all in side a closure/defer and do not make a distinction in between no escape, defer, and escaping closures. This is just to make a sane base model that we can then build on top of.

rdar://103313305