### PR TITLE
Fix CheckedCastBrJumpThreading when we have dominating checked_cast_br on failure path only

### DIFF
--- a/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
+++ b/lib/SILOptimizer/Utils/CheckedCastBrJumpThreading.cpp
@@ -253,7 +253,7 @@ SILValue CheckedCastBrJumpThreading::isArgValueEquivalentToCondition(
 // Return false if an ownership RAUW is necessary but cannot be performed.
 bool CheckedCastBrJumpThreading::Edit::
 canRAUW(OwnershipFixupContext &rauwContext) {
-  if (InvertSuccess || SuccessPreds.empty())
+  if (InvertSuccess || (SuccessPreds.empty() && !hasUnknownPreds))
     return true;
 
   auto *ccbi = cast<CheckedCastBranchInst>(CCBBlock->getTerminator());
@@ -334,7 +334,7 @@ void CheckedCastBrJumpThreading::Edit::modifyCFGForSuccessPreds(
 
   auto *checkedCastBr = cast<CheckedCastBranchInst>(CCBBlock->getTerminator());
   auto *oldSuccessArg = checkedCastBr->getSuccessBB()->getArgument(0);
-  if (InvertSuccess) {
+  if (InvertSuccess || (SuccessPreds.empty() && !hasUnknownPreds)) {
     assert(!hasUnknownPreds && "is not handled, should have been checked");
     // This success path is unused, so undef its uses and delete the cast.
     oldSuccessArg->replaceAllUsesWithUndef();

--- a/lib/SILOptimizer/Utils/LoopUtils.cpp
+++ b/lib/SILOptimizer/Utils/LoopUtils.cpp
@@ -33,7 +33,7 @@ static SILBasicBlock *createInitialPreheader(SILBasicBlock *Header) {
   llvm::SmallVector<SILValue, 8> Args;
   for (auto *HeaderArg : Header->getArguments()) {
     Args.push_back(Preheader->createPhiArgument(HeaderArg->getType(),
-                                                OwnershipKind::Owned));
+                                                HeaderArg->getOwnershipKind()));
   }
 
   // Create the branch to the header.

--- a/test/SILOptimizer/simplify_cfg_checkcast.sil
+++ b/test/SILOptimizer/simplify_cfg_checkcast.sil
@@ -21,7 +21,6 @@ class Klass {
 protocol OtherKlass : AnyObject {}
 
 sil [ossa] @consume_klass : $@convention(thin) (@owned Klass) -> ()
-sil [ossa] @use_klass : $@convention(thin) (@guaranteed Klass) -> ()
 sil [ossa] @get_klass : $@convention(thin) () -> @owned Klass
 
 sil [ossa] @unknown : $@convention(thin) () -> ()
@@ -675,6 +674,69 @@ bb8:
   destroy_value %0 : $Base
   %25 = tuple ()
   return %25 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @redundant_checked_cast_failure_path :
+// CHECK: checked_cast_br
+// CHECK-NOT: checked_cast_br
+// CHECK-LABEL: } // end sil function 'redundant_checked_cast_failure_path'
+sil [ossa] @redundant_checked_cast_failure_path : $@convention(method) (@owned Base) -> () {
+bb0(%0 : @owned $Base):
+  %borrow = begin_borrow %0 : $Base
+  checked_cast_br %borrow : $Base to Derived, bb1, bb2
+
+bb1(%succ1 : @guaranteed $Derived):
+  br bbexit
+
+bb2(%5 : @guaranteed $Base):
+  checked_cast_br %5 : $Base to Derived, bb3, bb4
+
+bb3(%9 : @guaranteed $Derived):
+  br bbexit
+
+bb4(%10 : @guaranteed $Base):
+  %m = class_method %10 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  apply %m(%10) : $@convention(method) (@guaranteed Base) -> ()
+  br bbexit
+
+bbexit:
+  end_borrow %borrow : $Base
+  destroy_value %0 : $Base
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil [ossa] @redundant_checked_cast_failure_path_not_idom :
+// CHECK: checked_cast_br
+// CHECK-NOT: checked_cast_br
+// CHECK-LABEL: } // end sil function 'redundant_checked_cast_failure_path_not_idom'
+sil [ossa] @redundant_checked_cast_failure_path_not_idom : $@convention(method) (@owned Base) -> () {
+bb0(%0 : @owned $Base):
+  %borrow = begin_borrow %0 : $Base
+  checked_cast_br %borrow : $Base to Derived, bb1, bb2
+
+bb1(%succ1 : @guaranteed $Derived):
+  br bbexit
+
+bb2(%5 : @guaranteed $Base):
+  br bb3(%5 : $Base)
+
+bb3(%6 : @guaranteed $Base):
+  checked_cast_br %6 : $Base to Derived, bb4, bb5
+
+bb4(%9 : @guaranteed $Derived):
+  br bbexit
+
+bb5(%10 : @guaranteed $Base):
+  %m = class_method %10 : $Base, #Base.inner : (Base) -> () -> (), $@convention(method) (@guaranteed Base) -> ()
+  apply %m(%10) : $@convention(method) (@guaranteed Base) -> ()
+  br bbexit
+
+bbexit:
+  end_borrow %borrow : $Base
+  destroy_value %0 : $Base
+  %t = tuple ()
+  return %t : $()
 }
 
 //!!!TODO: test replacing a guaranteed value with an ownedvalue


### PR DESCRIPTION
Also piggyback a small fix for a SILPhiArgument's  OwnershipKind while creating a preheader.