### PR TITLE
[Distributed] LocalDAS cannot gain this constraint, even though the DAS protocol has it

### DIFF
--- a/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
+++ b/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
@@ -54,7 +54,7 @@ public final class LocalTestingDistributedActorSystem: DistributedActorSystem, @
   }
 
   public func assignID<Act>(_ actorType: Act.Type) -> ActorID
-    where Act: DistributedActor, Act.ID == ActorID {
+    where Act: DistributedActor {
     let id = self.idProvider.next()
     self.assignedIDsLock.withLock {
       self.assignedIDs.insert(id)


### PR DESCRIPTION
This requirement was added in `LocalTestingDistributedActorSystem` but only on main. Technically this is an ABI break (!), because one could have passed a different type here - if calling internal and not through the witness I AFAICS.

We cannot make this addition and must undo and keep it as it was in Swift 5.7.

The PR introducing the issue was 1675669e4382b86083f0557df84fb824de753f75 which was undoing a bunch of workarounds, but pushed it too far with this one change.

This seems to work @DougGregor, so we got lucky