### PR TITLE
[SourceKit] Make sure we reuse ASTContext in function bodies for solver-based cursor info

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3102,7 +3102,8 @@ public:
 
 class CheckRedeclarationRequest
     : public SimpleRequest<
-          CheckRedeclarationRequest, evaluator::SideEffect(ValueDecl *),
+          CheckRedeclarationRequest,
+          evaluator::SideEffect(ValueDecl *, NominalTypeDecl *),
           RequestFlags::SeparatelyCached | RequestFlags::DependencySource |
               RequestFlags::DependencySink> {
 public:
@@ -3112,10 +3113,13 @@ public:
   friend SimpleRequest;
 
    // Evaluation.
-  evaluator::SideEffect
-  evaluate(Evaluator &evaluator, ValueDecl *VD) const;
+  /// \p SelfNominalType is \c VD->getDeclContext()->getSelfNominalType().
+  /// Passed as a parameter in here so this request doesn't tigger self nominal
+  /// type computation.
+  evaluator::SideEffect evaluate(Evaluator &evaluator, ValueDecl *VD,
+                                 NominalTypeDecl *SelfNominalType) const;
 
- public:
+public:
   // Separate caching.
   bool isCached() const { return true; }
   Optional<evaluator::SideEffect> getCachedResult() const;

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -166,6 +166,17 @@ public:
 
   SourceLoc getIDEInspectionTargetLoc() const;
 
+  /// Returns whether `Range` contains `Loc`. This also respects the
+  /// `ReplacedRanges`, i.e. if `Loc` is in a range that replaces a range which
+  /// overlaps `Range`, this also returns `true`.
+  bool containsRespectingReplacedRanges(SourceRange Range, SourceLoc Loc) const;
+
+  /// Returns whether `Enclosing` contains `Inner`. This also respects the
+  /// `ReplacedRanges`, i.e. if `Inner` is contained in a range that replaces a
+  /// range which overlaps `Range`, this also returns `true`.
+  bool rangeContainsRespectingReplacedRanges(SourceRange Enclosing,
+                                             SourceRange Inner) const;
+
   const llvm::DenseMap<SourceRange, SourceRange> &getReplacedRanges() const {
     return ReplacedRanges;
   }

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1324,7 +1324,7 @@ void CheckRedeclarationRequest::writeDependencySink(
     return;
 
   if (currentDC->isTypeContext()) {
-    if (auto nominal = currentDC->getSelfNominalTypeDecl()) {
+    if (auto nominal = std::get<1>(getStorage())) {
       tracker.addUsedMember(nominal, current->getBaseName());
     }
   } else {

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -45,6 +45,31 @@ SourceLoc SourceManager::getIDEInspectionTargetLoc() const {
       .getAdvancedLoc(IDEInspectionTargetOffset);
 }
 
+bool SourceManager::containsRespectingReplacedRanges(SourceRange Range,
+                                                     SourceLoc Loc) const {
+  if (Loc.isInvalid() || Range.isInvalid()) {
+    return false;
+  }
+
+  if (Range.contains(Loc)) {
+    return true;
+  }
+  for (const auto &pair : getReplacedRanges()) {
+    auto OriginalRange = pair.first;
+    auto NewRange = pair.second;
+    if (NewRange.contains(Loc) && Range.overlaps(OriginalRange)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool SourceManager::rangeContainsRespectingReplacedRanges(
+    SourceRange Enclosing, SourceRange Inner) const {
+  return containsRespectingReplacedRanges(Enclosing, Inner.Start) &&
+         containsRespectingReplacedRanges(Enclosing, Inner.End);
+}
+
 StringRef SourceManager::getDisplayNameForLoc(SourceLoc Loc, bool ForceGeneratedSourceToDisk) const {
   // Respect #line first
   if (auto VFile = getVirtualFile(Loc))

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -50,10 +50,12 @@ void typeCheckDeclAndParentClosures(ValueDecl *VD) {
   typeCheckASTNodeAtLoc(
       TypeCheckASTNodeAtLocContext::declContext(VD->getDeclContext()),
       VD->getLoc());
-  // Type check any attached property wrappers so the annotated declaration can
-  // refer to their USRs
   if (auto VarD = dyn_cast<VarDecl>(VD)) {
+    // Type check any attached property wrappers so the annotated declaration
+    // can refer to their USRs.
     (void)VarD->getPropertyWrapperBackingPropertyType();
+    // Visit emitted accessors so we generated accessors from property wrappers.
+    VarD->visitEmittedAccessors([&](AccessorDecl *accessor) {});
   }
 }
 

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -140,7 +140,7 @@ private:
   DeclContext *getCurrentDeclContext() { return DeclContextStack.back(); }
 
   bool rangeContainsLocToResolve(SourceRange Range) const {
-    return Range.contains(LocToResolve);
+    return getSourceMgr().containsRespectingReplacedRanges(Range, LocToResolve);
   }
 
   PreWalkAction walkToDeclPre(Decl *D) override {

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -50,6 +50,11 @@ void typeCheckDeclAndParentClosures(ValueDecl *VD) {
   typeCheckASTNodeAtLoc(
       TypeCheckASTNodeAtLocContext::declContext(VD->getDeclContext()),
       VD->getLoc());
+  // Type check any attached property wrappers so the annotated declaration can
+  // refer to their USRs
+  if (auto VarD = dyn_cast<VarDecl>(VD)) {
+    (void)VarD->getPropertyWrapperBackingPropertyType();
+  }
 }
 
 // MARK: - NodeFinderResults

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -150,7 +150,10 @@ private:
     }
 
     if (auto VD = dyn_cast<ValueDecl>(D)) {
-      if (VD->hasName()) {
+      // FIXME: ParamDecls might be closure parameters that can have ambiguous
+      // types. The current infrastructure of just asking for the VD's type
+      // doesn't work here. We need to inspect the constraints system solution.
+      if (VD->hasName() && !isa<ParamDecl>(D)) {
         assert(Result == nullptr);
         Result = std::make_unique<NodeFinderDeclResult>(VD);
         return Action::Stop();

--- a/lib/IDETool/IDEInspectionInstance.cpp
+++ b/lib/IDETool/IDEInspectionInstance.cpp
@@ -842,10 +842,9 @@ void swift::ide::IDEInspectionInstance::cursorInfo(
       CancellationFlag,
       [&](CancellableResult<IDEInspectionInstanceResult> CIResult) {
         CIResult.mapAsync<CursorInfoResults>(
-            [&CancellationFlag, Offset](auto &Result, auto DeliverTransformed) {
+            [&CancellationFlag](auto &Result, auto DeliverTransformed) {
               auto &Mgr = Result.CI->getSourceMgr();
-              auto RequestedLoc = Mgr.getLocForOffset(
-                  Mgr.getIDEInspectionTargetBufferID(), Offset);
+              auto RequestedLoc = Mgr.getIDEInspectionTargetLoc();
               ConsumerToCallbackAdapter Consumer(
                   Result.DidReuseAST, CancellationFlag, DeliverTransformed);
               std::unique_ptr<IDEInspectionCallbacksFactory> callbacksFactory(

--- a/lib/Refactoring/Refactoring.cpp
+++ b/lib/Refactoring/Refactoring.cpp
@@ -52,9 +52,11 @@ class ContextFinder : public SourceEntityWalker {
   std::function<bool(ASTNode)> IsContext;
   SmallVector<ASTNode, 4> AllContexts;
   bool contains(ASTNode Enclosing) {
-    auto Result = SM.rangeContains(Enclosing.getSourceRange(), Target);
-    if (Result && IsContext(Enclosing))
+    auto Result = SM.rangeContainsRespectingReplacedRanges(
+        Enclosing.getSourceRange(), Target);
+    if (Result && IsContext(Enclosing)) {
       AllContexts.push_back(Enclosing);
+    }
     return Result;
   }
 public:

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -542,7 +542,8 @@ static void checkRedeclaration(PrecedenceGroupDecl *group) {
 
 /// Check whether \c current is a redeclaration.
 evaluator::SideEffect
-CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current) const {
+CheckRedeclarationRequest::evaluate(Evaluator &eval, ValueDecl *current,
+                                    NominalTypeDecl *SelfNominalType) const {
   // Ignore invalid and anonymous declarations.
   if (current->isInvalid() || !current->hasName())
     return std::make_tuple<>();
@@ -1872,8 +1873,11 @@ public:
       // Force some requests, which can produce diagnostics.
 
       // Check redeclaration.
-      (void) evaluateOrDefault(Context.evaluator,
-                               CheckRedeclarationRequest{VD}, {});
+      (void)evaluateOrDefault(
+          Context.evaluator,
+          CheckRedeclarationRequest{
+              VD, VD->getDeclContext()->getSelfNominalTypeDecl()},
+          {});
 
       // Compute access level.
       (void) VD->getFormalAccess();

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -547,6 +547,21 @@ void SymbolGraph::serialize(llvm::json::OStream &OS) {
       }
     });
 
+#ifndef NDEBUG
+    // FIXME (solver-based-verification-sorting): In assert builds sort the
+    // edges so we get consistent symbol graph output. This allows us to compare
+    // the string representation of the symbolgraph between the solver-based
+    // and AST-based result.
+    // This can be removed once the AST-based cursor info has been removed.
+    SmallVector<Edge> Edges(this->Edges.begin(), this->Edges.end());
+    std::sort(Edges.begin(), Edges.end(), [](const Edge &LHS, const Edge &RHS) {
+      SmallString<256> LHSTargetUSR, RHSTargetUSR;
+      LHS.Target.getUSR(LHSTargetUSR);
+      RHS.Target.getUSR(RHSTargetUSR);
+      return LHSTargetUSR < RHSTargetUSR;
+    });
+#endif
+
     OS.attributeArray("relationships", [&](){
       for (const auto &Relationship : Edges) {
         Relationship.serialize(OS);

--- a/test/SourceKit/CursorInfo/cursor_infer_nonmutating_from_property_wrapper.swift
+++ b/test/SourceKit/CursorInfo/cursor_infer_nonmutating_from_property_wrapper.swift
@@ -1,0 +1,17 @@
+func test() {
+  struct MyStruct {
+// RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):16 %s -- %s | %FileCheck %s
+    @State var myState
+  }
+}
+
+@propertyWrapper struct State {
+    init(initialValue value: Int) {}
+
+    public var wrappedValue: Int {
+        get { return 1 }
+        nonmutating set { }
+    }
+}
+
+// CHECK: <Declaration>@<Type usr="s:46cursor_infer_nonmutating_from_property_wrapper5StateV">State</Type> var myState: &lt;&lt;error type&gt;&gt; { get nonmutating set }</Declaration>

--- a/test/SourceKit/CursorInfo/cursor_local_var_with_property_wrapper.swift
+++ b/test/SourceKit/CursorInfo/cursor_local_var_with_property_wrapper.swift
@@ -1,0 +1,9 @@
+@propertyWrapper struct State {
+    public init(initialValue value: Int)
+    public var wrappedValue: Int { get nonmutating set }
+}
+
+func loadPage() {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):14 %s -- %s
+  @State var pageListener: Int
+}

--- a/test/SourceKit/CursorInfo/cursor_on_closure_parameter.swift
+++ b/test/SourceKit/CursorInfo/cursor_on_closure_parameter.swift
@@ -1,0 +1,8 @@
+func save(_ record: Int, _ x: (String) -> Void) {}
+
+func test() {
+  let record = 2
+// RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):19 %s -- %s
+  save(record) { (record) in
+  }
+}

--- a/test/SourceKit/CursorInfo/cursor_on_var_in_extension_in_func.swift
+++ b/test/SourceKit/CursorInfo/cursor_on_var_in_extension_in_func.swift
@@ -1,0 +1,6 @@
+func foo() {
+  extension XXX {
+// RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):9 %s -- %s
+    var hex 
+  }
+}

--- a/test/SourceKit/CursorInfo/cursor_reuses_astcontext.swift
+++ b/test/SourceKit/CursorInfo/cursor_reuses_astcontext.swift
@@ -1,0 +1,27 @@
+// RUN: %sourcekitd-test -req=cursor -pos=%(line + 2):7 %s -- %s == -req=cursor -pos=%(line + 3):7 %s -- %s | %FileCheck %s --check-prefix IN-FUNCTION
+func foo() {
+  let inFunctionA = 1
+  let inFunctionB = "hi"
+}
+
+// IN-FUNCTION: source.lang.swift.decl.var.local
+// IN-FUNCTION-NEXT: inFunctionA
+// IN-FUNCTION: DID REUSE AST CONTEXT: 0
+// IN-FUNCTION: source.lang.swift.decl.var.local
+// IN-FUNCTION-NEXT: inFunctionB
+// IN-FUNCTION: DID REUSE AST CONTEXT: 1
+
+// RUN: %sourcekitd-test -req=cursor -pos=%(line + 3):9 %s -- %s == -req=cursor -pos=%(line + 4):9 %s -- %s | %FileCheck %s --check-prefix IN-INSTANCE-METHOD
+struct MyStruct {
+  func test() {
+    let inInstanceMethod1 = 2
+    let inInstanceMethod2 = "hello"
+  }
+}
+
+// IN-INSTANCE-METHOD: source.lang.swift.decl.var.local
+// IN-INSTANCE-METHOD-NEXT: inInstanceMethod1
+// IN-INSTANCE-METHOD: DID REUSE AST CONTEXT: 0
+// IN-INSTANCE-METHOD: source.lang.swift.decl.var.local
+// IN-INSTANCE-METHOD-NEXT: inInstanceMethod2
+// IN-INSTANCE-METHOD: DID REUSE AST CONTEXT: 1

--- a/test/SourceKit/CursorInfo/cursor_with_file_replacement.swift
+++ b/test/SourceKit/CursorInfo/cursor_with_file_replacement.swift
@@ -1,0 +1,91 @@
+// BEGIN State1.swift
+
+func foo() {
+  let inFunctionA = 1
+  let inFunctionB = "hi"
+}
+
+// BEGIN State2.swift
+
+func foo() {
+  let newlyAddedMember = 3
+  let inFunctionA = 1
+  let inFunctionB = "hi"
+}
+
+// BEGIN State3.swift
+
+func foo() {
+  let inFunctionB = "hi"
+}
+
+// BEGIN State4.swift
+
+func foo() {
+  let myNewName = "hi"
+}
+
+// BEGIN State5.swift
+
+func foo(param: Int) {
+  let myNewName = "hi"
+}
+
+// BEGIN State6.swift
+
+func foo(param: Int) {
+  let myNewName = 7
+}
+
+
+// BEGIN Dummy.swift
+
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: cp %t/State1.swift %t/file.swift
+
+// RUN: %sourcekitd-test \
+// RUN:   -shell -- echo '## State 1' == \
+// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -shell -- echo '## State 2' == \
+// RUN:   -shell -- cp %t/State2.swift %t/file.swift == \
+// RUN:   -req=cursor -pos=5:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -shell -- echo '## State 3' == \
+// RUN:   -shell -- cp %t/State3.swift %t/file.swift == \
+// RUN:   -req=cursor -pos=3:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -shell -- echo '## State 4' == \
+// RUN:   -shell -- cp %t/State4.swift %t/file.swift == \
+// RUN:   -req=cursor -pos=3:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -shell -- echo '## State 5' == \
+// RUN:   -shell -- cp %t/State5.swift %t/file.swift == \
+// RUN:   -req=cursor -pos=3:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -shell -- echo '## State 6' == \
+// RUN:   -shell -- cp %t/State6.swift %t/file.swift == \
+// RUN:   -req=cursor -pos=3:7 %t/file.swift -- %t/file.swift > %t/response.txt
+// RUN: %FileCheck %s < %t/response.txt
+
+// CHECK-LABEL: ## State 1
+// CHECK: source.lang.swift.decl.var.local (4:7-4:18)
+// CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
+// CHECK: DID REUSE AST CONTEXT: 0
+// CHECK-LABEL: ## State 2
+// CHECK: source.lang.swift.decl.var.local (5:7-5:18)
+// CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
+// CHECK: DID REUSE AST CONTEXT: 1
+// CHECK-LABEL: ## State 3
+// CHECK: source.lang.swift.decl.var.local (3:7-3:18)
+// CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
+// CHECK: DID REUSE AST CONTEXT: 1
+// CHECK-LABEL: ## State 4
+// CHECK: source.lang.swift.decl.var.local (3:7-3:16)
+// CHECK: <Declaration>let myNewName: <Type usr="s:SS">String</Type></Declaration>
+// CHECK: DID REUSE AST CONTEXT: 1
+// CHECK-LABEL: ## State 5
+// CHECK: source.lang.swift.decl.var.local (3:7-3:16)
+// CHECK: <Declaration>let myNewName: <Type usr="s:SS">String</Type></Declaration>
+// CHECK: DID REUSE AST CONTEXT: 0
+// CHECK-LABEL: ## State 6
+// CHECK: source.lang.swift.decl.var.local (3:7-3:16)
+// CHECK: <Declaration>let myNewName: <Type usr="s:Si">Int</Type></Declaration>
+// CHECK: DID REUSE AST CONTEXT: 1

--- a/test/SourceKit/CursorInfo/discriminator.swift
+++ b/test/SourceKit/CursorInfo/discriminator.swift
@@ -1,0 +1,46 @@
+func sink(_ a: (Int) -> Void) {}
+    
+func testSingleStatementClosure() {
+  sink { items in
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):9 %s -- %s | %FileCheck %s --check-prefix=SINGLE-STMT-CLOSURE
+    var items = items
+  }
+  // SINGLE-STMT-CLOSURE: s:13discriminator26testSingleStatementClosureyyFySiXEfU_5itemsL0_Sivp
+}
+
+
+func testMultiStatementClosure() {
+  sink { items in
+    // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):9 %s -- %s | %FileCheck %s --check-prefix=MULTI-STMT-CLOSURE
+    var items = items
+    print("xxx")
+  }
+  // MULTI-STMT-CLOSURE: s:13discriminator25testMultiStatementClosureyyFySiXEfU_5itemsL0_Sivp
+}
+
+func testNestedClosures() {
+  func dataTask(completionHandler: (Int?) -> Void) {}
+  func async2(execute work: () -> Void) {}
+
+  dataTask { (error) in
+    do {
+      // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):17 %s -- %s | %FileCheck %s --check-prefix=NESTED_CLOSURE
+    } catch let error {
+      async2 {
+        print("")
+      }
+    }
+  }
+  // NESTED_CLOSURE: s:13discriminator18testNestedClosuresyyFySiSgXEfU_5errorL1_s5Error_pvp
+}
+
+func testReuseAST(bytes: Int) {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 2):7 -req-opts=verifysolverbasedcursorinfo=1 %s -- %s == \
+  // RUN:   -req=cursor -pos=%(line + 2):7 -req-opts=verifysolverbasedcursorinfo=1 %s -- %s | %FileCheck %s --check-prefix=REUSE_AST
+  let size = 3
+  var bytes = 6
+  // REUSE_AST: source.lang.swift.decl.var.local (40:7-40:11)
+  // REUSE_AST: s:13discriminator12testReuseAST5bytesySi_tF4sizeL_Sivp
+  // REUSE_AST: source.lang.swift.decl.var.local (41:7-41:12)
+  // REUSE_AST: s:13discriminator12testReuseAST5bytesySi_tFACL0_Sivp
+}

--- a/test/SourceKit/CursorInfo/refactoring_actions_with_ast_reuse.swift
+++ b/test/SourceKit/CursorInfo/refactoring_actions_with_ast_reuse.swift
@@ -1,0 +1,20 @@
+func materialize() {
+ let a = 2
+}
+
+func outer() {
+  func inner() {
+  }
+}
+
+// RUN: %sourcekitd-test -req=cursor -pos=2:6 %s -- %s == \
+// RUN: -req=cursor -req-opts=retrieve_refactor_actions=1 -pos=6:8 %s -- %s | %FileCheck %s
+
+// CHECK: source.lang.swift.decl.function.free (6:8-6:15)
+// CHECK: inner()
+// CHECK: ACTIONS BEGIN
+// CHECK-DAG: source.refactoring.kind.rename.local
+// CHECK-DAG: Local Rename
+// CHECK-DAG: source.refactoring.kind.convert.func-to-async
+// CHECK-DAG: Convert Function to Async
+// CHECK: ACTIONS END

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -556,8 +556,15 @@ struct CursorSymbolInfo {
     for (auto ParentContext : ParentContexts) {
       ParentContext.print(OS, Indentation + "    ");
     }
+
+    llvm::SmallVector<ReferencedDeclInfo> SortedReferencedSymbols(
+        ReferencedSymbols.begin(), ReferencedSymbols.end());
+    std::sort(SortedReferencedSymbols.begin(), SortedReferencedSymbols.end(),
+              [](const ReferencedDeclInfo &LHS, const ReferencedDeclInfo &RHS) {
+                return LHS.USR < RHS.USR;
+              });
     OS << Indentation << "ReferencedSymbols:" << '\n';
-    for (auto ReferencedSymbol : ReferencedSymbols) {
+    for (auto ReferencedSymbol : SortedReferencedSymbols) {
       ReferencedSymbol.print(OS, Indentation + "    ");
     }
     OS << Indentation << "ReceiverUSRs:" << '\n';

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -363,6 +363,7 @@ public:
     return RequestResult();
   }
 
+  bool isValue() const { return type == Value; }
   const T &value() const {
     assert(type == Value);
     return *data;
@@ -588,8 +589,14 @@ struct CursorInfoData {
   llvm::ArrayRef<CursorSymbolInfo> Symbols;
   /// All available actions on the code under cursor.
   llvm::ArrayRef<RefactoringInfo> AvailableActions;
+  /// Whether the ASTContext was reused for this cursor info.
+  bool DidReuseAST = false;
 
-  void print(llvm::raw_ostream &OS, std::string Indentation) const {
+  /// If \p ForSolverBasedCursorInfoVerification is \c true, fields that are
+  /// acceptable to differ between the AST-based and the solver-based result,
+  /// will be excluded.
+  void print(llvm::raw_ostream &OS, std::string Indentation,
+             bool ForSolverBasedCursorInfoVerification = false) const {
     OS << Indentation << "CursorInfoData" << '\n';
     OS << Indentation << "  Symbols:" << '\n';
     for (auto Symbol : Symbols) {
@@ -598,6 +605,9 @@ struct CursorInfoData {
     OS << Indentation << "  AvailableActions:" << '\n';
     for (auto AvailableAction : AvailableActions) {
       AvailableAction.print(OS, Indentation + "    ");
+    }
+    if (!ForSolverBasedCursorInfoVerification) {
+      OS << Indentation << "DidReuseAST: " << DidReuseAST << '\n';
     }
   }
 

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -2655,8 +2655,6 @@ static unsigned resolveFromLineCol(unsigned Line, unsigned Col,
   exit(1);
 }
 
-static llvm::StringMap<llvm::MemoryBuffer*> Buffers;
-
 /// Opens \p Filename, first checking \p VFSFiles and then falling back to the
 /// filesystem otherwise. If the file could not be opened and \p ExitOnError is
 /// true, the process exits with an error message. Otherwise a buffer
@@ -2668,10 +2666,6 @@ getBufferForFilename(StringRef Filename,
   auto VFSFileIt = VFSFiles.find(Filename);
   auto MappedFilename =
       VFSFileIt == VFSFiles.end() ? Filename : StringRef(VFSFileIt->second.path);
-
-  auto It = Buffers.find(MappedFilename);
-  if (It != Buffers.end())
-    return It->second;
 
   auto FileBufOrErr = llvm::MemoryBuffer::getFile(MappedFilename);
   std::unique_ptr<llvm::MemoryBuffer> Buffer;
@@ -2687,5 +2681,5 @@ getBufferForFilename(StringRef Filename,
     Buffer = std::move(FileBufOrErr.get());
   }
 
-  return Buffers[MappedFilename] = Buffer.release();
+  return Buffer.release();
 }

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -1995,6 +1995,9 @@ static void printCursorInfo(sourcekitd_variant_t Info, StringRef FilenameIn,
     OS << "-----\n";
   }
   OS << "SECONDARY SYMBOLS END\n";
+  OS << "DID REUSE AST CONTEXT: "
+     << sourcekitd_variant_dictionary_get_bool(Info, KeyReusingASTContext)
+     << '\n';
 }
 
 static void printRangeInfo(sourcekitd_variant_t Info, StringRef FilenameIn,

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -461,6 +461,8 @@ static int handleJsonRequestPath(StringRef QueryPath, const TestOptions &Opts) {
 }
 
 static int performShellExecution(ArrayRef<const char *> Args) {
+  llvm::outs().flush();
+  llvm::errs().flush();
   auto Program = llvm::sys::findProgramByName(Args[0]);
   if (std::error_code ec = Program.getError()) {
     llvm::errs() << "command not found: " << Args[0] << "\n";

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -2409,6 +2409,8 @@ static void reportCursorInfo(const RequestResult<CursorInfoData> &Result,
     }
   }
 
+  Elem.setBool(KeyReusingASTContext, Info.DidReuseAST);
+
   return Rec(RespBuilder.createResponse());
 }
 


### PR DESCRIPTION
The main problem that prevented us from reusing the ASTContext was that we weren’t remapping the `LocToResolve` in the temporary buffer that only contains the re-parsed function back to the original buffer. Thus `NodeFinder` couldn’t find the node that we want to get cursor info for.

Getting AST reuse to work for top-level items is harder because it currently heavily relies on the `HasCodeCompletion` state being set on the parser result. I’ll try that in a follow-up PR.

rdar://103251263