### PR TITLE
[SourceKit] Only verify the solver-based cursor info implementation if requested

### DIFF
--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -948,6 +948,7 @@ public:
       bool SymbolGraph, bool CancelOnSubsequentRequest,
       ArrayRef<const char *> Args, Optional<VFSOptions> vfsOptions,
       SourceKitCancellationToken CancellationToken,
+      bool VerifySolverBasedCursorInfo,
       std::function<void(const RequestResult<CursorInfoData> &)> Receiver) = 0;
 
   virtual void

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -637,6 +637,7 @@ public:
                      ArrayRef<const char *> Args,
                      Optional<VFSOptions> vfsOptions,
                      SourceKitCancellationToken CancellationToken,
+                     bool VerifySolverBasedCursorInfo,
                      std::function<void(const RequestResult<CursorInfoData> &)>
                          Receiver) override;
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1891,6 +1891,7 @@ void SwiftLangSupport::getCursorInfo(
     bool SymbolGraph, bool CancelOnSubsequentRequest,
     ArrayRef<const char *> Args, Optional<VFSOptions> vfsOptions,
     SourceKitCancellationToken CancellationToken,
+    bool VerifySolverBasedCursorInfo,
     std::function<void(const RequestResult<CursorInfoData> &)> Receiver) {
 
   std::string error;
@@ -1967,11 +1968,6 @@ void SwiftLangSupport::getCursorInfo(
   // Currently, we only verify that the solver-based cursor implementation
   // produces the same results as the AST-based implementation. Only enable it
   // in assert builds for now.
-#ifndef NDEBUG
-  bool EnableSolverBasedCursorInfo = true;
-#else
-  bool EnableSolverBasedCursorInfo = false;
-#endif
 
   // If solver based completion is enabled, a string description of the cursor
   // info result produced by the solver-based implementation. Once the AST-based
@@ -1979,7 +1975,7 @@ void SwiftLangSupport::getCursorInfo(
   // AST-based result.
   std::string SolverBasedResultDescription;
   size_t SolverBasedResultCount = 0;
-  if (EnableSolverBasedCursorInfo) {
+  if (VerifySolverBasedCursorInfo) {
     std::string InputFileError;
     llvm::SmallString<64> RealInputFilePath;
     fileSystem->getRealPath(InputFile, RealInputFilePath);

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -770,6 +770,8 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
     } else {
       sourcekitd_request_dictionary_set_int64(Req, KeyOffset, ByteOffset);
     }
+    sourcekitd_request_dictionary_set_int64(Req, KeyVerifySolverBasedCursorInfo,
+                                            true);
     addRequestOptionsDirect(Req, Opts);
     break;
   case SourceKitRequest::RangeInfo: {

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -1393,10 +1393,13 @@ handleRequestCursorInfo(const RequestDict &Req,
       Req.getInt64(KeyRetrieveRefactorActions, Actionables, /*isOptional=*/true);
       int64_t SymbolGraph = false;
       Req.getInt64(KeyRetrieveSymbolGraph, SymbolGraph, /*isOptional=*/true);
+      int64_t VerifySolverBasedCursorInfo = false;
+      Req.getInt64(KeyVerifySolverBasedCursorInfo, VerifySolverBasedCursorInfo,
+                   /*isOptional=*/true);
       return Lang.getCursorInfo(
           *SourceFile, Offset, Length, Actionables, SymbolGraph,
           CancelOnSubsequentRequest, Args, std::move(vfsOptions),
-          CancellationToken,
+          CancellationToken, VerifySolverBasedCursorInfo,
           [Rec](const RequestResult<CursorInfoData> &Result) {
             reportCursorInfo(Result, Rec);
           });

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -166,6 +166,7 @@ public:
         DocName, Offset, /*Length=*/0, /*Actionables=*/false,
         /*SymbolGraph=*/false, CancelOnSubsequentRequest, Args,
         /*vfsOptions=*/None, CancellationToken,
+        /*VerifySolverBasedCursorInfo=*/true,
         [&](const RequestResult<CursorInfoData> &Result) {
           assert(!Result.isCancelled());
           if (Result.isError()) {
@@ -451,6 +452,7 @@ TEST_F(CursorInfoTest, CursorInfoCancelsPreviousRequest) {
       SlowDocName, SlowOffset, /*Length=*/0, /*Actionables=*/false,
       /*SymbolGraph=*/false, /*CancelOnSubsequentRequest=*/true, ArgsForSlow,
       /*vfsOptions=*/None, /*CancellationToken=*/nullptr,
+      /*VerifySolverBasedCursorInfo=*/true,
       [&](const RequestResult<CursorInfoData> &Result) {
         EXPECT_TRUE(Result.isCancelled());
         FirstCursorInfoSema.signal();
@@ -494,6 +496,7 @@ TEST_F(CursorInfoTest, CursorInfoCancellation) {
       SlowDocName, SlowOffset, /*Length=*/0, /*Actionables=*/false,
       /*SymbolGraph=*/false, /*CancelOnSubsequentRequest=*/false, ArgsForSlow,
       /*vfsOptions=*/None, /*CancellationToken=*/CancellationToken,
+      /*VerifySolverBasedCursorInfo=*/true,
       [&](const RequestResult<CursorInfoData> &Result) {
         EXPECT_TRUE(Result.isCancelled());
         CursorInfoSema.signal();

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -189,6 +189,7 @@ UID_KEYS = [
     KEY('OptimizeForIDE', 'key.optimize_for_ide'),
     KEY('RequiredBystanders', 'key.required_bystanders'),
     KEY('ReusingASTContext', 'key.reusingastcontext'),
+    KEY('VerifySolverBasedCursorInfo', 'key.verifysolverbasedcursorinfo'),
     KEY('CompletionMaxASTContextReuseCount',
         'key.completion_max_astcontext_reuse_count'),
     KEY('CompletionCheckDependencyInterval',


### PR DESCRIPTION
This allows us to mark expected deviations between the AST-based and the solver-based implementation in the stress tester as XFails without breaking actual clients

We always verify if a cursor info request is issued through `sourcekitd-test`.

https://github.com/apple/swift-stress-tester/pull/217 makes sure that we always verify the results in the SourceKit stress tester.