### PR TITLE
[5.7] Disable NSSlowTaggedLocalizedString.swift

### DIFF
--- a/test/stdlib/NSSlowTaggedLocalizedString.swift
+++ b/test/stdlib/NSSlowTaggedLocalizedString.swift
@@ -4,6 +4,8 @@
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out
 
+// REQUIRES: rdar100559801
+
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
This test started failing in Xcode 14.1 with macOS 12.6
https://github.com/apple/swift/issues/62579

(cherry picked from commit 45d6cb04ac0dc3e5997515426c54cde183608172)
