### PR TITLE
Add swift:: in a couple of places that don't have using namespace swift (affects sourcekit-lsp)

### DIFF
--- a/stdlib/public/runtime/ImageInspectionCommon.cpp
+++ b/stdlib/public/runtime/ImageInspectionCommon.cpp
@@ -190,7 +190,7 @@ const swift::MetadataSections *swift_getMetadataSection(size_t index) {
 SWIFT_RUNTIME_EXPORT
 const char *
 swift_getMetadataSectionName(const swift::MetadataSections *section) {
-  if (auto info = SymbolInfo::lookup(section)) {
+  if (auto info = swift::SymbolInfo::lookup(section)) {
     if (info->getFilename()) {
       return info->getFilename();
     }
@@ -202,7 +202,7 @@ SWIFT_RUNTIME_EXPORT
 void swift_getMetadataSectionBaseAddress(const swift::MetadataSections *section,
                                          void const **out_actual,
                                          void const **out_expected) {
-  if (auto info = SymbolInfo::lookup(section)) {
+  if (auto info = swift::SymbolInfo::lookup(section)) {
     *out_actual = info->getBaseAddress();
   } else {
     *out_actual = nullptr;


### PR DESCRIPTION
<!-- What's in this pull request? -->
Add `swift::` in a couple of places that don't have `using namespace swift` (affects [sourcekit-lsp](https://github.com/apple/sourcekit-lsp).)

It didn't catch because those functions are only defined under:
```
#ifndef NDEBUG
```

Which the Swift repo doesn't normally build.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
<!--Resolves #NNNNN, fix apple/llvm-project#MMMMM.-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
