### PR TITLE
[AST/Sema] TypeWrappers: Fix a couple of issues with attribute inference from protocols

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -35,6 +35,7 @@
 #include "swift/AST/StorageImpl.h"
 #include "swift/AST/TypeAlignments.h"
 #include "swift/AST/TypeWalker.h"
+#include "swift/AST/TypeWrappers.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/ArrayRefView.h"
 #include "swift/Basic/Compiler.h"
@@ -3903,7 +3904,7 @@ public:
   bool hasTypeWrapper() const { return bool(getTypeWrapper()); }
 
   /// Return a type wrapper (if any) associated with this type.
-  NominalTypeDecl *getTypeWrapper() const;
+  Optional<TypeWrapperInfo> getTypeWrapper() const;
 
   /// If this declaration has a type wrapper return a property that
   /// is used for all type wrapper related operations (mainly for

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -64,6 +64,7 @@ struct TypeWitnessAndDecl;
 class ValueDecl;
 enum class OpaqueReadOwnership: uint8_t;
 class StorageImplInfo;
+struct TypeWrapperInfo;
 
 /// Display a nominal type or extension thereof.
 void simple_display(
@@ -3522,7 +3523,8 @@ public:
 
 /// Return a type wrapper (if any) associated with the given declaration.
 class GetTypeWrapper
-    : public SimpleRequest<GetTypeWrapper, NominalTypeDecl *(NominalTypeDecl *),
+    : public SimpleRequest<GetTypeWrapper,
+                           Optional<TypeWrapperInfo>(NominalTypeDecl *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -3530,7 +3532,8 @@ public:
 private:
   friend SimpleRequest;
 
-  NominalTypeDecl *evaluate(Evaluator &evaluator, NominalTypeDecl *) const;
+  Optional<TypeWrapperInfo> evaluate(Evaluator &evaluator,
+                                     NominalTypeDecl *) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3752,6 +3752,23 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Check whether this is a protocol that has a type wrapper attribute
+/// or one of its dependencies does.
+class UsesTypeWrapperFeature
+    : public SimpleRequest<UsesTypeWrapperFeature, bool(NominalTypeDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  bool evaluate(Evaluator &evaluator, NominalTypeDecl *) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 /// Find the definition of a given macro.
 class MacroDefinitionRequest
     : public SimpleRequest<MacroDefinitionRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -402,7 +402,7 @@ SWIFT_REQUEST(TypeChecker, GetSourceFileAsyncNode,
               AwaitExpr *(const SourceFile *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetTypeWrapper,
-              NominalTypeDecl *(NominalTypeDecl *),
+              Optional<TypeWrapperInfo>(NominalTypeDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetTypeWrapperType,
               Type(NominalTypeDecl *),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -443,6 +443,9 @@ SWIFT_REQUEST(TypeChecker, ContinueTargetRequest,
 SWIFT_REQUEST(TypeChecker, GetTypeWrapperInitializer,
               ConstructorDecl *(NominalTypeDecl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, UsesTypeWrapperFeature,
+              bool(NominalTypeDecl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, MacroDefinitionRequest,
               MacroDefinition(MacroDecl *),
               Cached, NoLocationInfo)

--- a/include/swift/AST/TypeWrappers.h
+++ b/include/swift/AST/TypeWrappers.h
@@ -1,0 +1,40 @@
+//===--------- TypeWrappers.h - Type Wrapper ASTs ---------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines helper types for type wrappers.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_TYPE_WRAPPERS_H
+#define SWIFT_AST_TYPE_WRAPPERS_H
+
+namespace swift {
+
+struct TypeWrapperInfo {
+  CustomAttr *Attr;
+  NominalTypeDecl *Wrapper;
+  NominalTypeDecl *AttachedTo;
+  bool IsInferred;
+
+  TypeWrapperInfo(CustomAttr *attr, NominalTypeDecl *wrapperDecl,
+                  NominalTypeDecl *attachedTo, bool isInferred)
+      : Attr(attr), Wrapper(wrapperDecl), AttachedTo(attachedTo),
+        IsInferred(isInferred) {}
+
+  TypeWrapperInfo asInferred() const {
+    return {Attr, Wrapper, AttachedTo, true};
+  }
+};
+
+} // end namespace swift
+
+#endif // SWIFT_AST_TYPE_WRAPPERS_H

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1179,6 +1179,16 @@ void PrintAST::printAttributes(const Decl *D) {
 
   D->getAttrs().print(Printer, Options, D);
 
+  // We need to check whether this is a type with an inferred
+  // type wrapper attribute and if so print it explicitly.
+  if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
+    auto typeWrapperInfo = NTD->getTypeWrapper();
+    // The attribute has been inferred and we have to print it.
+    if (typeWrapperInfo && typeWrapperInfo->IsInferred) {
+      typeWrapperInfo->Attr->print(Printer, Options, D);
+    }
+  }
+
   // Print the implicit 'final' attribute.
   if (auto VD = dyn_cast<ValueDecl>(D)) {
     auto VarD = dyn_cast<VarDecl>(D);

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -116,6 +116,7 @@ add_swift_host_library(swiftAST STATIC
   TypeRefinementContext.cpp
   TypeRepr.cpp
   TypeWalker.cpp
+  TypeWrapper.cpp
   UnqualifiedLookup.cpp
   USRGeneration.cpp
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6598,14 +6598,6 @@ bool VarDecl::isMemberwiseInitialized(bool preferDeclaredProperties) const {
   return true;
 }
 
-bool VarDecl::isTypeWrapperLocalStorageForInitializer() const {
-  if (auto *ctor =
-          dyn_cast_or_null<ConstructorDecl>(getDeclContext()->getAsDecl())) {
-    return this == ctor->getLocalTypeWrapperStorageVar();
-  }
-  return false;
-}
-
 bool VarDecl::isLet() const {
   // An awful hack that stabilizes the value of 'isLet' for ParamDecl instances.
   //
@@ -8888,14 +8880,6 @@ bool ConstructorDecl::isObjCZeroParameterWithLongSelector() const {
     return false;
 
   return params->get(0)->getInterfaceType()->isVoid();
-}
-
-VarDecl *ConstructorDecl::getLocalTypeWrapperStorageVar() const {
-  auto &ctx = getASTContext();
-  auto *mutableSelf = const_cast<ConstructorDecl *>(this);
-  return evaluateOrDefault(
-      ctx.evaluator, SynthesizeLocalVariableForTypeWrapperStorage{mutableSelf},
-      nullptr);
 }
 
 DestructorDecl::DestructorDecl(SourceLoc DestructorLoc, DeclContext *Parent)

--- a/lib/AST/TypeWrapper.cpp
+++ b/lib/AST/TypeWrapper.cpp
@@ -1,0 +1,78 @@
+//===--- TypeWrapper.cpp - Type Traversal ---------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements functionality related to type wrapper feature.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/ASTContext.h"
+#include "swift/AST/Decl.h"
+#include "swift/AST/TypeCheckRequests.h"
+#include "swift/AST/TypeResolutionStage.h"
+
+using namespace swift;
+
+NominalTypeDecl *NominalTypeDecl::getTypeWrapper() const {
+  auto *mutableSelf = const_cast<NominalTypeDecl *>(this);
+  return evaluateOrDefault(getASTContext().evaluator,
+                           GetTypeWrapper{mutableSelf}, nullptr);
+}
+
+bool UsesTypeWrapperFeature::evaluate(Evaluator &evaluator,
+                                      NominalTypeDecl *decl) const {
+  // This is a type wrapper type.
+  if (decl->getAttrs().hasAttribute<TypeWrapperAttr>())
+    return true;
+
+  // This is a type wrapped type.
+  if (decl->hasTypeWrapper())
+    return true;
+
+  // This type could be depending on a type wrapper feature
+  // indirectly by conforming to a protocol with a type
+  // wrapper attribute. To determine that we need to walk
+  // protocol dependency chains and check each one.
+
+  auto &ctx = decl->getASTContext();
+
+  auto usesTypeWrapperFeature = [&](ProtocolDecl *protocol) {
+    return evaluateOrDefault(ctx.evaluator, UsesTypeWrapperFeature{protocol},
+                             false);
+  };
+
+  for (unsigned i : indices(decl->getInherited())) {
+    auto inheritedType = evaluateOrDefault(
+        ctx.evaluator,
+        InheritedTypeRequest{decl, i, TypeResolutionStage::Interface}, Type());
+
+    if (!(inheritedType && inheritedType->isConstraintType()))
+      continue;
+
+    if (auto *protocol =
+        dyn_cast_or_null<ProtocolDecl>(inheritedType->getAnyNominal())) {
+      if (usesTypeWrapperFeature(protocol))
+        return true;
+    }
+
+    if (auto composition = inheritedType->getAs<ProtocolCompositionType>()) {
+      for (auto member : composition->getMembers()) {
+        if (auto *protocol =
+                dyn_cast_or_null<ProtocolDecl>(member->getAnyNominal())) {
+          if (usesTypeWrapperFeature(protocol))
+            return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}

--- a/lib/AST/TypeWrapper.cpp
+++ b/lib/AST/TypeWrapper.cpp
@@ -27,6 +27,22 @@ NominalTypeDecl *NominalTypeDecl::getTypeWrapper() const {
                            GetTypeWrapper{mutableSelf}, nullptr);
 }
 
+VarDecl *ConstructorDecl::getLocalTypeWrapperStorageVar() const {
+  auto &ctx = getASTContext();
+  auto *mutableSelf = const_cast<ConstructorDecl *>(this);
+  return evaluateOrDefault(
+      ctx.evaluator, SynthesizeLocalVariableForTypeWrapperStorage{mutableSelf},
+      nullptr);
+}
+
+bool VarDecl::isTypeWrapperLocalStorageForInitializer() const {
+  if (auto *ctor =
+          dyn_cast_or_null<ConstructorDecl>(getDeclContext()->getAsDecl())) {
+    return this == ctor->getLocalTypeWrapperStorageVar();
+  }
+  return false;
+}
+
 bool UsesTypeWrapperFeature::evaluate(Evaluator &evaluator,
                                       NominalTypeDecl *decl) const {
   // This is a type wrapper type.

--- a/lib/AST/TypeWrapper.cpp
+++ b/lib/AST/TypeWrapper.cpp
@@ -18,13 +18,15 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeResolutionStage.h"
+#include "swift/AST/TypeWrappers.h"
 
 using namespace swift;
 
-NominalTypeDecl *NominalTypeDecl::getTypeWrapper() const {
+Optional<TypeWrapperInfo> NominalTypeDecl::getTypeWrapper() const {
   auto *mutableSelf = const_cast<NominalTypeDecl *>(this);
   return evaluateOrDefault(getASTContext().evaluator,
-                           GetTypeWrapper{mutableSelf}, nullptr);
+                           GetTypeWrapper{mutableSelf},
+                           Optional<TypeWrapperInfo>());
 }
 
 VarDecl *ConstructorDecl::getLocalTypeWrapperStorageVar() const {

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1257,8 +1257,9 @@ void LifetimeChecker::injectTypeWrapperStorageInitalization() {
       {
         bool isClass = isa<ClassDecl>(parentType);
 
-        auto typeWrapper = parentType->getTypeWrapper();
-        auto *typeWrapperInit = typeWrapper->getTypeWrapperInitializer();
+        auto typeWrapperInfo = parentType->getTypeWrapper();
+        auto *typeWrapperInit =
+            typeWrapperInfo->Wrapper->getTypeWrapperInitializer();
         SILValue typeWrapperInitRef = createInitRef(typeWrapperInit);
 
         auto *self = TheMemory.findUninitializedSelfValue();

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -364,7 +364,10 @@ static ConstructorDecl *createImplicitConstructor(NominalTypeDecl *decl,
   } else if (ICK == ImplicitConstructorKind::TypeWrapperStorage) {
     accessLevel = AccessLevel::Public;
 
-    auto *typeWrapper = decl->getTypeWrapper();
+    auto typeWrapperInfo = decl->getTypeWrapper();
+    assert(typeWrapperInfo);
+
+    auto *typeWrapper = typeWrapperInfo->Wrapper;
 
     auto *arg = new (ctx) ParamDecl(SourceLoc(), Loc, ctx.Id_storageWrapper,
                                     Loc, ctx.Id_storageWrapper, decl);

--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -77,12 +77,6 @@ VarDecl *VarDecl::getUnderlyingTypeWrapperStorage() const {
                            nullptr);
 }
 
-NominalTypeDecl *NominalTypeDecl::getTypeWrapper() const {
-  auto *mutableSelf = const_cast<NominalTypeDecl *>(this);
-  return evaluateOrDefault(getASTContext().evaluator,
-                           GetTypeWrapper{mutableSelf}, nullptr);
-}
-
 struct TypeWrapperAttrInfo {
   CustomAttr *Attr;
   NominalTypeDecl *Wrapper;

--- a/test/ModuleInterface/type_wrappers.swift
+++ b/test/ModuleInterface/type_wrappers.swift
@@ -46,7 +46,7 @@ public protocol Wrapped {
 
 public protocol OuterWrapped : Wrapped {}
 
-// CHECK: public struct WithProtocol : TypeWrappers.Wrapped {
+// CHECK:  @TypeWrappers.Wrapper public struct WithProtocol : TypeWrappers.Wrapped {
 // CHECK:   public var a: Swift.Int {
 // CHECK:     get
 // CHECK:     set

--- a/test/ModuleInterface/type_wrappers.swift
+++ b/test/ModuleInterface/type_wrappers.swift
@@ -1,0 +1,123 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/TypeWrappers.swiftinterface) %s -module-name TypeWrappers -enable-experimental-feature TypeWrappers
+// RUN: %target-swift-typecheck-module-from-interface(%t/TypeWrappers.swiftinterface) -module-name TypeWrappers
+// RUN: %FileCheck %s < %t/TypeWrappers.swiftinterface
+
+// CHECK: @typeWrapper public struct Wrapper<W, S> {
+// CHECK-NEXT: public init(for: W.Type, storage: S)
+// CHECK-NEXT:   public subscript<V>(propertyKeyPath _: Swift.KeyPath<W, V>, storageKeyPath path: Swift.KeyPath<S, V>) -> V {
+// CHECK-NEXT:     get
+// CHECK-NEXT:   }
+// CHECK-NEXT:   public subscript<V>(propertyKeyPath _: Swift.KeyPath<W, V>, storageKeyPath path: Swift.WritableKeyPath<S, V>) -> V {
+// CHECK-NEXT:     get
+// CHECK-NEXT:     set
+// CHECK-NEXT:   }
+// CHECK-NEXT: }
+
+@typeWrapper
+public struct Wrapper<W, S> {
+  public init(for: W.Type, storage: S) {}
+
+  public subscript<V>(propertyKeyPath _: KeyPath<W, V>, storageKeyPath path: KeyPath<S, V>) -> V {
+    get { fatalError() }
+  }
+
+  public subscript<V>(propertyKeyPath _: KeyPath<W, V>, storageKeyPath path: WritableKeyPath<S, V>) -> V {
+    get { fatalError() }
+    set { }
+  }
+}
+
+// CHECK: @TypeWrappers.Wrapper public class Test<T> where T : Swift.StringProtocol {
+// CHECK:   public init(a: Swift.Int, b: [T])
+// CHECK:   public init(storageWrapper: TypeWrappers.Wrapper<TypeWrappers.Test<T>, TypeWrappers.Test<T>.$Storage>)
+// CHECK: }
+
+@Wrapper
+public class Test<T: StringProtocol> {
+  var a: Int
+  let b: [T]
+}
+
+@Wrapper
+public protocol Wrapped {
+  init()
+}
+
+public protocol OuterWrapped : Wrapped {}
+
+// CHECK: public struct WithProtocol : TypeWrappers.Wrapped {
+// CHECK:   public var a: Swift.Int {
+// CHECK:     get
+// CHECK:     set
+// CHECK:   }
+// CHECK:   public var b: Swift.String {
+// CHECK:     get
+// CHECK:     set
+// CHECK:   }
+// CHECK:   public init()
+// CHECK:   public var $storage: TypeWrappers.Wrapper<TypeWrappers.WithProtocol, TypeWrappers.WithProtocol.$Storage>
+// CHECK:   public struct $Storage {
+// CHECK:   }
+// CHECK:   public init(storageWrapper: TypeWrappers.Wrapper<TypeWrappers.WithProtocol, TypeWrappers.WithProtocol.$Storage>)
+// CHECK: }
+
+public struct WithProtocol : Wrapped {
+  public var a: Int
+  public var b: String
+
+  public init() {
+  }
+}
+
+// CHECK: @TypeWrappers.Wrapper final public class ClassWithProtoocol : TypeWrappers.Wrapped {
+// CHECK:   required public init()
+// CHECK:   final public var $storage: TypeWrappers.Wrapper<TypeWrappers.ClassWithProtoocol, TypeWrappers.ClassWithProtoocol.$Storage>
+// CHECK:   public struct $Storage {
+// CHECK:   }
+// CHECK:   public init(storageWrapper: TypeWrappers.Wrapper<TypeWrappers.ClassWithProtoocol, TypeWrappers.ClassWithProtoocol.$Storage>)
+// CHECK: }
+
+@Wrapper
+public final class ClassWithProtoocol : Wrapped {
+  var test: String = ""
+
+  public required init() {}
+}
+
+// CHECK: @TypeWrappers.Wrapper public struct WithOuterWrapper<T> : TypeWrappers.OuterWrapped {
+// CHECK:   public init()
+// CHECK:   public init(_ v: T)
+// CHECK:   public var $storage: TypeWrappers.Wrapper<TypeWrappers.WithOuterWrapper<T>, TypeWrappers.WithOuterWrapper<T>.$Storage>
+// CHECK:   public struct $Storage {
+// CHECK:   }
+// CHECK:   public init(storageWrapper: TypeWrappers.Wrapper<TypeWrappers.WithOuterWrapper<T>, TypeWrappers.WithOuterWrapper<T>.$Storage>)
+// CHECK: }
+
+@Wrapper
+public struct WithOuterWrapper<T> : OuterWrapped {
+  var test: T? = nil
+
+  public init() {}
+
+  public init(_ v: T) {
+    self.test = v
+  }
+}
+
+protocol UnrelatedProtocol {
+}
+
+// CHECK: @TypeWrappers.Wrapper public struct WithComposition {
+// CHECK:   public init()
+// CHECK:   public var $storage: TypeWrappers.Wrapper<TypeWrappers.WithComposition, TypeWrappers.WithComposition.$Storage>
+// CHECK:   public struct $Storage {
+// CHECK:   }
+// CHECK:   public init(storageWrapper: TypeWrappers.Wrapper<TypeWrappers.WithComposition, TypeWrappers.WithComposition.$Storage>)
+// CHECK: }
+// CHECK: extension TypeWrappers.WithComposition : TypeWrappers.OuterWrapped {}
+
+@Wrapper
+public struct WithComposition : OuterWrapped & UnrelatedProtocol {
+  public init() {}
+}


### PR DESCRIPTION
- ASTPrinter: Feature coverage should include type wrapped types as well (directly and indirectly depending on the feature) otherwise compiler is going to produce a broken swiftinterface file.

- TypeChecker: Synthesis should produce a `public` implementation of `$Storage` and `$storage` if protocol requirements are public.

Resolves: rdar://103270262

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
