### PR TITLE
Sink isFixedBuffer into DebugTypeInfo and ensure the enclosed types

### DIFF
--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -17,6 +17,7 @@
 
 #include "DebugTypeInfo.h"
 #include "FixedTypeInfo.h"
+#include "IRGenModule.h"
 #include "swift/SIL/SILGlobalVariable.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
@@ -27,23 +28,12 @@ using namespace irgen;
 DebugTypeInfo::DebugTypeInfo(swift::Type Ty, llvm::Type *FragmentStorageTy,
                              Optional<Size::int_type> SizeInBits,
                              Alignment Align, bool HasDefaultAlignment,
-                             bool IsMetadata, bool SizeIsFragmentSize)
+                             bool IsMetadata, bool SizeIsFragmentSize,
+                             bool IsFixedBuffer)
     : Type(Ty.getPointer()), FragmentStorageType(FragmentStorageTy),
       SizeInBits(SizeInBits), Align(Align),
       DefaultAlignment(HasDefaultAlignment), IsMetadataType(IsMetadata),
-      SizeIsFragmentSize(SizeIsFragmentSize) {
-  assert(Align.getValue() != 0);
-}
-
-DebugTypeInfo::DebugTypeInfo(swift::Type Ty, llvm::Type *FragmentStorageTy,
-                             Optional<Size> SizeInBytes, Alignment Align,
-                             bool HasDefaultAlignment, bool IsMetadata,
-                             bool SizeIsFragmentSize)
-    : Type(Ty.getPointer()), FragmentStorageType(FragmentStorageTy),
-      Align(Align), DefaultAlignment(HasDefaultAlignment),
-      IsMetadataType(IsMetadata), SizeIsFragmentSize(SizeIsFragmentSize) {
-  if (SizeInBytes)
-    SizeInBits = SizeInBytes->getValue() * 8;
+      SizeIsFragmentSize(SizeIsFragmentSize), IsFixedBuffer(IsFixedBuffer) {
   assert(Align.getValue() != 0);
 }
 
@@ -56,17 +46,20 @@ static bool hasDefaultAlignment(swift::Type Ty) {
   return true;
 }
 
-DebugTypeInfo DebugTypeInfo::getFromTypeInfo(swift::Type Ty,
-                                             const TypeInfo &Info,
+DebugTypeInfo DebugTypeInfo::getFromTypeInfo(swift::Type Ty, const TypeInfo &TI,
                                              bool IsFragmentTypeInfo) {
-  Optional<Size> size;
-  if (Info.isFixedSize()) {
-    const FixedTypeInfo &FixTy = *cast<const FixedTypeInfo>(&Info);
-    size = FixTy.getFixedSize();
+  Optional<Size::int_type> SizeInBits;
+  llvm::Type *StorageType = TI.getStorageType();
+  if (TI.isFixedSize()) {
+    const FixedTypeInfo &FixTy = *cast<const FixedTypeInfo>(&TI);
+    Size::int_type Size = FixTy.getFixedSize().getValue() * 8;
+    //if (!StorageType->isPointerTy())
+    //  Size -= FixTy.getSpareBits().asAPInt().countTrailingOnes();
+    SizeInBits = Size;
   }
-  assert(Info.getStorageType() && "StorageType is a nullptr");
-  return DebugTypeInfo(Ty.getPointer(), Info.getStorageType(), size,
-                       Info.getBestKnownAlignment(), ::hasDefaultAlignment(Ty),
+  assert(TI.getStorageType() && "StorageType is a nullptr");
+  return DebugTypeInfo(Ty.getPointer(), StorageType, SizeInBits,
+                       TI.getBestKnownAlignment(), ::hasDefaultAlignment(Ty),
                        false, IsFragmentTypeInfo);
 }
 
@@ -92,8 +85,8 @@ DebugTypeInfo DebugTypeInfo::getLocalVariable(VarDecl *Decl, swift::Type Ty,
 DebugTypeInfo DebugTypeInfo::getGlobalMetadata(swift::Type Ty,
                                                llvm::Type *StorageTy, Size size,
                                                Alignment align) {
-  DebugTypeInfo DbgTy(Ty.getPointer(), StorageTy, size,
-                      align, true, false, false);
+  DebugTypeInfo DbgTy(Ty.getPointer(), StorageTy, size.getValue() * 8, align,
+                      true, false, false);
   assert(StorageTy && "StorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() &&
          "type metadata cannot contain an archetype");
@@ -103,8 +96,8 @@ DebugTypeInfo DebugTypeInfo::getGlobalMetadata(swift::Type Ty,
 DebugTypeInfo DebugTypeInfo::getTypeMetadata(swift::Type Ty,
                                              llvm::Type *StorageTy, Size size,
                                              Alignment align) {
-  DebugTypeInfo DbgTy(Ty.getPointer(), StorageTy, size,
-                      align, true, true, false);
+  DebugTypeInfo DbgTy(Ty.getPointer(), StorageTy, size.getValue() * 8, align,
+                      true, true, false);
   assert(StorageTy && "StorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() &&
          "type metadata cannot contain an archetype");
@@ -117,8 +110,8 @@ DebugTypeInfo DebugTypeInfo::getForwardDecl(swift::Type Ty) {
 }
 
 DebugTypeInfo DebugTypeInfo::getGlobal(SILGlobalVariable *GV,
-                                       llvm::Type *StorageTy, Size size,
-                                       Alignment align) {
+                                       llvm::Type *FragmentStorageType,
+                                       IRGenModule &IGM) {
   // Prefer the original, potentially sugared version of the type if
   // the type hasn't been mucked with by an optimization pass.
   auto LowTy = GV->getLoweredType().getASTType();
@@ -128,20 +121,41 @@ DebugTypeInfo DebugTypeInfo::getGlobal(SILGlobalVariable *GV,
     if (DeclType->isEqual(LowTy))
       Type = DeclType.getPointer();
   }
-  DebugTypeInfo DbgTy(Type, StorageTy, size, align, ::hasDefaultAlignment(Type),
-                      false, false);
-  assert(StorageTy && "FragmentStorageType is a nullptr");
+  auto &TI = IGM.getTypeInfoForUnlowered(Type);
+  DebugTypeInfo DbgTy = getFromTypeInfo(Type, TI, false);
+  assert(FragmentStorageType && "FragmentStorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() &&
          "type of global variable cannot be an archetype");
-  assert(align.getValue() != 0);
+  return DbgTy;
+}
+
+DebugTypeInfo
+DebugTypeInfo::getGlobalFixedBuffer(SILGlobalVariable *GV,
+                                    llvm::Type *FragmentStorageType,
+                                    Size SizeInBytes, Alignment Align) {
+  // Prefer the original, potentially sugared version of the type if
+  // the type hasn't been mucked with by an optimization pass.
+  auto LowTy = GV->getLoweredType().getASTType();
+  auto *Type = LowTy.getPointer();
+  if (auto *Decl = GV->getDecl()) {
+    auto DeclType = Decl->getType();
+    if (DeclType->isEqual(LowTy))
+      Type = DeclType.getPointer();
+  }
+  DebugTypeInfo DbgTy(Type, FragmentStorageType, SizeInBytes.getValue() * 8,
+                      Align, ::hasDefaultAlignment(Type), false, false, true);
+  assert(FragmentStorageType && "FragmentStorageType is a nullptr");
+  assert(!DbgTy.isContextArchetype() &&
+         "type of global variable cannot be an archetype");
   return DbgTy;
 }
 
 DebugTypeInfo DebugTypeInfo::getObjCClass(ClassDecl *theClass,
                                           llvm::Type *FragmentStorageType,
-                                          Size size, Alignment align) {
+                                          Size SizeInBytes, Alignment align) {
   DebugTypeInfo DbgTy(theClass->getInterfaceType().getPointer(),
-                      FragmentStorageType, size, align, true, false, false);
+                      FragmentStorageType, SizeInBytes.getValue() * 8, align,
+                      true, false, false);
   assert(FragmentStorageType && "FragmentStorageType is a nullptr");
   assert(!DbgTy.isContextArchetype() &&
          "type of objc class cannot be an archetype");
@@ -149,10 +163,13 @@ DebugTypeInfo DebugTypeInfo::getObjCClass(ClassDecl *theClass,
 }
 
 DebugTypeInfo DebugTypeInfo::getErrorResult(swift::Type Ty,
-                                            llvm::Type *StorageType, Size size,
-                                            Alignment align) {
+                                            llvm::Type *StorageType,
+                                            IRGenModule &IGM) {
+  auto &TI = IGM.getTypeInfoForUnlowered(Ty);
+  assert(TI.getStorageType() == StorageType);
+  DebugTypeInfo DbgTy = getFromTypeInfo(Ty, TI, false);
   assert(StorageType && "FragmentStorageType is a nullptr");
-  return {Ty, StorageType, size, align, true, false, false};
+  return DbgTy;
 }
 
 bool DebugTypeInfo::operator==(DebugTypeInfo T) const {

--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -76,8 +76,9 @@ DebugTypeInfo DebugTypeInfo::getLocalVariable(VarDecl *Decl, swift::Type Ty,
   return getFromTypeInfo(Type, Info, IsFragmentTypeInfo);
 }
 
-DebugTypeInfo DebugTypeInfo::getMetadata(swift::Type Ty, llvm::Type *StorageTy,
-                                         Size size, Alignment align) {
+DebugTypeInfo DebugTypeInfo::getGlobalMetadata(swift::Type Ty,
+                                               llvm::Type *StorageTy, Size size,
+                                               Alignment align) {
   DebugTypeInfo DbgTy(Ty.getPointer(), StorageTy, size,
                       align, true, false, false);
   assert(StorageTy && "StorageType is a nullptr");
@@ -86,8 +87,9 @@ DebugTypeInfo DebugTypeInfo::getMetadata(swift::Type Ty, llvm::Type *StorageTy,
   return DbgTy;
 }
 
-DebugTypeInfo DebugTypeInfo::getArchetype(swift::Type Ty, llvm::Type *StorageTy,
-                                          Size size, Alignment align) {
+DebugTypeInfo DebugTypeInfo::getTypeMetadata(swift::Type Ty,
+                                             llvm::Type *StorageTy, Size size,
+                                             Alignment align) {
   DebugTypeInfo DbgTy(Ty.getPointer(), StorageTy, size,
                       align, true, true, false);
   assert(StorageTy && "StorageType is a nullptr");

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -61,11 +61,11 @@ public:
                                         const TypeInfo &Info,
                                         bool IsFragmentTypeInfo);
   /// Create type for global type metadata.
-  static DebugTypeInfo getMetadata(swift::Type Ty, llvm::Type *StorageTy,
-                                   Size size, Alignment align);
+  static DebugTypeInfo getGlobalMetadata(swift::Type Ty, llvm::Type *StorageTy,
+                                         Size size, Alignment align);
   /// Create type for an artificial metadata variable.
-  static DebugTypeInfo getArchetype(swift::Type Ty, llvm::Type *StorageTy,
-                                    Size size, Alignment align);
+  static DebugTypeInfo getTypeMetadata(swift::Type Ty, llvm::Type *StorageTy,
+                                       Size size, Alignment align);
 
   /// Create a forward declaration for a type whose size is unknown.
   static DebugTypeInfo getForwardDecl(swift::Type Ty);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -4798,9 +4798,10 @@ llvm::GlobalValue *IRGenModule::defineTypeMetadata(
                 : LinkEntity::forTypeMetadata(
                       concreteType, TypeMetadataAddress::FullMetadata));
 
-  auto DbgTy = DebugTypeInfo::getMetadata(MetatypeType::get(concreteType),
-    entity.getDefaultDeclarationType(*this)->getPointerTo(),
-    Size(0), Alignment(1));
+  auto DbgTy = DebugTypeInfo::getGlobalMetadata(
+      MetatypeType::get(concreteType),
+      entity.getDefaultDeclarationType(*this)->getPointerTo(), Size(0),
+      Alignment(1));
 
   // Define the variable.
   llvm::GlobalVariable *var = cast<llvm::GlobalVariable>(
@@ -4942,9 +4943,9 @@ IRGenModule::getAddrOfTypeMetadata(CanType concreteType,
         LinkEntity::forNoncanonicalSpecializedGenericTypeMetadata(concreteType);
     break;
   }
-  DbgTy = DebugTypeInfo::getMetadata(MetatypeType::get(concreteType),
-                                     defaultVarTy->getPointerTo(), Size(0),
-                                     Alignment(1));
+  DbgTy = DebugTypeInfo::getGlobalMetadata(MetatypeType::get(concreteType),
+                                           defaultVarTy->getPointerTo(),
+                                           Size(0), Alignment(1));
 
   ConstantReference addr;
   llvm::Type *typeOfValue = nullptr;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2354,7 +2354,7 @@ llvm::Function *irgen::createFunction(IRGenModule &IGM, LinkInfo &linkInfo,
 llvm::GlobalVariable *swift::irgen::createVariable(
     IRGenModule &IGM, LinkInfo &linkInfo, llvm::Type *storageType,
     Alignment alignment, DebugTypeInfo DbgTy, Optional<SILLocation> DebugLoc,
-    StringRef DebugName, bool inFixedBuffer) {
+    StringRef DebugName) {
   auto name = linkInfo.getName();
   llvm::GlobalValue *existingValue = IGM.Module.getNamedGlobal(name);
   if (existingValue) {
@@ -2384,7 +2384,7 @@ llvm::GlobalVariable *swift::irgen::createVariable(
   if (IGM.DebugInfo && !DbgTy.isNull() && linkInfo.isForDefinition())
     IGM.DebugInfo->emitGlobalVariableDeclaration(
         var, DebugName.empty() ? name : DebugName, name, DbgTy,
-        var->hasInternalLinkage(), inFixedBuffer, DebugLoc);
+        var->hasInternalLinkage(), DebugLoc);
 
   return var;
 }
@@ -2666,10 +2666,13 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
           loc = var->getLocation();
         name = var->getName();
       }
-      auto DbgTy = DebugTypeInfo::getGlobal(var, storageTypeWithContainer,
-                                            fixedSize, fixedAlignment);
+      DebugTypeInfo DbgTy =
+          inFixedBuffer
+              ? DebugTypeInfo::getGlobalFixedBuffer(
+                    var, storageTypeWithContainer, fixedSize, fixedAlignment)
+              : DebugTypeInfo::getGlobal(var, storageTypeWithContainer, *this);
       gvar = createVariable(*this, link, storageTypeWithContainer,
-                            fixedAlignment, DbgTy, loc, name, inFixedBuffer);
+                            fixedAlignment, DbgTy, loc, name);
     }
     /// Add a zero initializer.
     if (forDefinition)

--- a/lib/IRGen/GenDecl.h
+++ b/lib/IRGen/GenDecl.h
@@ -51,7 +51,7 @@ namespace irgen {
   createVariable(IRGenModule &IGM, LinkInfo &linkInfo, llvm::Type *objectType,
                  Alignment alignment, DebugTypeInfo DebugType = DebugTypeInfo(),
                  Optional<SILLocation> DebugLoc = None,
-                 StringRef DebugName = StringRef(), bool heapAllocated = false);
+                 StringRef DebugName = StringRef());
 
   llvm::GlobalVariable *
   createLinkerDirectiveVariable(IRGenModule &IGM, StringRef Name);

--- a/lib/IRGen/GenInit.cpp
+++ b/lib/IRGen/GenInit.cpp
@@ -43,11 +43,10 @@ void IRGenModule::emitSILGlobalVariable(SILGlobalVariable *var) {
   // variable directly, don't actually emit it; just return undef.
   if (ti.isKnownEmpty(expansion)) {
     if (DebugInfo && var->getDecl()) {
-      auto DbgTy = DebugTypeInfo::getGlobal(var, Int8Ty, Size(0), Alignment(1));
+      auto DbgTy = DebugTypeInfo::getGlobal(var, Int8Ty, *this);
       DebugInfo->emitGlobalVariableDeclaration(
           nullptr, var->getDecl()->getName().str(), "", DbgTy,
-          var->getLinkage() != SILLinkage::Public,
-          IRGenDebugInfo::NotHeapAllocated, SILLocation(var->getDecl()));
+          var->getLinkage() != SILLinkage::Public, SILLocation(var->getDecl()));
     }
     return;
   }

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2918,7 +2918,7 @@ void IRGenDebugInfoImpl::emitTypeMetadata(IRGenFunction &IGF,
   static const char *Tau = u8"\u03C4";
   llvm::raw_svector_ostream OS(Buf);
   OS << '$' << Tau << '_' << Depth << '_' << Index;
-  auto DbgTy = DebugTypeInfo::getArchetype(
+  auto DbgTy = DebugTypeInfo::getTypeMetadata(
       getMetadataType(Name)->getDeclaredInterfaceType().getPointer(),
       Metadata->getType(), Size(CI.getTargetInfo().getPointerWidth(0)),
       Alignment(CI.getTargetInfo().getPointerAlign(0)));

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1780,15 +1780,15 @@ private:
     if (auto *DITy = getTypeOrNull(DbgTy.getType())) {
       // FIXME: Enable this assertion.
 #if SWIFT_DEBUGINFO_CACHE_VERIFICATION
-      if (auto CachedSizeInBits = DbgTy.getTypeSizeInBits()) {
-        if (unsigned SizeInBits = getSizeInBits(DITy)) {
-          if (SizeInBits != *CachedSizeInBits) {
+      if (auto SizeInBits = DbgTy.getTypeSizeInBits()) {
+        if (unsigned CachedSizeInBits = getSizeInBits(DITy)) {
+          if (llvm::alignTo(CachedSizeInBits, 8) != *SizeInBits) {
             DITy->dump();
             DbgTy.dump();
-            llvm::errs() << "SizeInBits = " << SizeInBits << "\n";
-            llvm::errs() << "CachedSizeInBits = " << *CachedSizeInBits << "\n";
+            llvm::errs() << "SizeInBits = " << *SizeInBits << "\n";
+            llvm::errs() << "CachedSizeInBits = " << CachedSizeInBits << "\n";
           }
-          assert(SizeInBits == *CachedSizeInBits);
+          assert(llvm::alignTo(CachedSizeInBits, 8) == *SizeInBits);
         }
       }
 #endif

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -177,13 +177,11 @@ public:
                         const SILDebugScope *DS, bool InCoroContext = false,
                         AddrDbgInstrKind = AddrDbgInstrKind::DbgDeclare);
 
-  enum { NotHeapAllocated = false };
-  
   /// Create debug metadata for a global variable.
   void emitGlobalVariableDeclaration(llvm::GlobalVariable *Storage,
                                      StringRef Name, StringRef LinkageName,
                                      DebugTypeInfo DebugType,
-                                     bool IsLocalToUnit, bool InFixedBuffer,
+                                     bool IsLocalToUnit,
                                      Optional<SILLocation> Loc);
 
   /// Emit debug metadata for type metadata (for generic types). So meta.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -4878,8 +4878,7 @@ void IRGenSILFunction::emitErrorResultVar(CanSILFunctionType FnTy,
   auto DbgTy = DebugTypeInfo::getErrorResult(
       ErrorInfo.getReturnValueType(IGM.getSILModule(), FnTy,
                                    IGM.getMaximalTypeExpansionContext()),
-      ErrorResultSlot->getType(), IGM.getPointerSize(),
-      IGM.getPointerAlignment());
+      ErrorResultSlot->getType(), IGM);
   IGM.DebugInfo->emitVariableDeclaration(Builder, Storage, DbgTy,
                                          getDebugScope(), {}, *Var,
                                          IndirectValue, ArtificialValue);

--- a/test/DebugInfo/EagerTypeMetadata.swift
+++ b/test/DebugInfo/EagerTypeMetadata.swift
@@ -8,8 +8,11 @@ public class C<T>
     // CHECK: define {{.*}} @"$s17EagerTypeMetadata1CC1cyyxF"
     // CHECK: %T = load %swift.type*, %swift.type**
     // CHECK-SAME: !dbg ![[LOC:[0-9]+]], !invariant.load
-    // CHECK: ![[LOC]] = !DILocation(line: 0,
     var x = [i]
   }
 }
+// CHECK: !DIDerivedType(tag: DW_TAG_typedef, name: "T",
+// CHECK-SAME:           baseType: ![[PTRTY:[0-9]+]]
+// CHECK: ![[PTRTY]] = !DIDerivedType(tag: DW_TAG_pointer_type, name: "$sBpD", baseType: null, size: {{64|32}})
+// CHECK: ![[LOC]] = !DILocation(line: 0,
 

--- a/test/DebugInfo/global_resilience.swift
+++ b/test/DebugInfo/global_resilience.swift
@@ -6,8 +6,8 @@
 // RUN:   -emit-module-path=%t/resilient_struct.swiftmodule \
 // RUN:   -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
 //
-// RUN: %target-swift-frontend -g -I %t -emit-ir -enable-library-evolution %s  -o - \
-// RUN:  | %FileCheck %s
+// RUN: %target-swift-frontend -g -I %t -emit-ir -enable-library-evolution \
+// RUN:   %s -o - | %FileCheck %s
 import resilient_struct
 
 // Fits in buffer
@@ -16,10 +16,15 @@ let small = Size(w: 1, h: 2)
 // Needs out-of-line allocation
 let large = Rectangle(p: Point(x: 1, y: 2), s: Size(w: 3, h: 4), color: 5)
 
+let tuple = (Size(w: 1, h: 2), Size(w: 3, h: 4))
+
 // CHECK: @"$s17global_resilience5small16resilient_struct4SizeVvp" =
 // CHECK-SAME: !dbg ![[SMALL:[0-9]+]]
 // CHECK: @"$s17global_resilience5large16resilient_struct9RectangleVvp" =
 // CHECK-SAME: !dbg ![[LARGE:[0-9]+]]
+
+// CHECK: @"$s17global_resilience5tuple
+// CHECK-SAME: !dbg ![[TUPLE:[0-9]+]]
 
 // CHECK: ![[SMALL]] = !DIGlobalVariableExpression(
 // CHECK-SAME:            var: ![[VAR_SMALL:[0-9]+]]
@@ -27,11 +32,29 @@ let large = Rectangle(p: Point(x: 1, y: 2), s: Size(w: 3, h: 4), color: 5)
 // CHECK: ![[VAR_SMALL]] = distinct !DIGlobalVariable(
 // CHECK-SAME:            type: ![[SMALL_TY:[0-9]+]]
 // CHECK: ![[SMALL_TY]] = !DICompositeType(tag: DW_TAG_structure_type,
-// CHECK-SAME:            name: "$swift.fixedbuffer", 
+// CHECK-SAME:            name: "$swift.fixedbuffer",
+// CHECK-SAME:            elements: ![[SMALL_TY_EL:[0-9]+]]
+// CHECK: ![[SMALL_TY_EL]] = !{![[SMALL_TY_M:[0-9]+]]}
+// CHECK: ![[SMALL_TY_M]] = !DIDerivedType(tag: DW_TAG_member,
+// CHECK-SAME:            baseType: ![[SMALL_TY_CT:[0-9]+]]
+// CHECK: ![[SMALL_TY_CT]] = !DIDerivedType(tag: DW_TAG_const_type,
+// CHECK-SAME:            baseType: ![[SMALL_TY_TY:[0-9]+]]
+// CHECK: ![[SMALL_TY_TY]] = !DICompositeType(
+// CHECK-NOT:             size:
+// CHECK-SAME:            DIFlagFwdDecl
+
 // CHECK: ![[LARGE]] = !DIGlobalVariableExpression(
 // CHECK-SAME:            var: ![[VAR_LARGE:[0-9]+]]
 // CHECK-SAME:            expr: !DIExpression())
 // CHECK: ![[VAR_LARGE]] = distinct !DIGlobalVariable(
 // CHECK-SAME:            type: ![[LARGE_TY:[0-9]+]]
 // CHECK: ![[LARGE_TY]] = !DICompositeType(tag: DW_TAG_structure_type,
+// CHECK-SAME:            name: "$swift.fixedbuffer", 
+
+// CHECK: ![[TUPLE]] = !DIGlobalVariableExpression(
+// CHECK-SAME:            var: ![[VAR_TUPLE:[0-9]+]]
+// CHECK-SAME:            expr: !DIExpression())
+// CHECK: ![[VAR_TUPLE]] = distinct !DIGlobalVariable(
+// CHECK-SAME:            type: ![[TUPLE_TY:[0-9]+]]
+// CHECK: ![[TUPLE_TY]] = !DICompositeType(tag: DW_TAG_structure_type,
 // CHECK-SAME:            name: "$swift.fixedbuffer", 


### PR DESCRIPTION
Sink isFixedBuffer into DebugTypeInfo and ensure the enclosed types aren't emitted with the size of the fixed buffer.