### PR TITLE
Macro diagnostics fixes

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
@@ -88,7 +88,8 @@ fileprivate func emitDiagnosticParts(
 func emitDiagnostic(
   diagEnginePtr: UnsafeMutablePointer<UInt8>,
   sourceFileBuffer: UnsafeMutableBufferPointer<UInt8>,
-  diagnostic: Diagnostic
+  diagnostic: Diagnostic,
+  messageSuffix: String? = nil
 ) {
   // Collect all of the Fix-It changes based on their Fix-It ID.
   var fixItChangesByID: [MessageID : [FixIt.Change]] = [:]
@@ -101,7 +102,7 @@ func emitDiagnostic(
   emitDiagnosticParts(
     diagEnginePtr: diagEnginePtr,
     sourceFileBuffer: sourceFileBuffer,
-    message: diagnostic.diagMessage.message,
+    message: diagnostic.diagMessage.message + (messageSuffix ?? ""),
     severity: diagnostic.diagMessage.severity,
     position: diagnostic.position,
     highlights: diagnostic.highlights,

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -176,13 +176,13 @@ func evaluateMacro(
     }
 
     // Emit diagnostics accumulated in the context.
+    let macroName = parentExpansion.macro.withoutTrivia().description
     for diag in context.diagnostics {
-      // FIXME: Consider tacking on a note that says that this diagnostic
-      // came from a macro expansion.
       emitDiagnostic(
         diagEnginePtr: diagEnginePtr,
         sourceFileBuffer: .init(mutating: sourceFile.pointee.buffer),
-        diagnostic: diag
+        diagnostic: diag,
+        messageSuffix: " (from macro '\(macroName)')"
       )
     }
 

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -182,7 +182,6 @@ func evaluateMacro(
       emitDiagnostic(
         diagEnginePtr: diagEnginePtr,
         sourceFileBuffer: .init(mutating: sourceFile.pointee.buffer),
-        nodeStartOffset: parentSyntax.position.utf8Offset,
         diagnostic: diag
       )
     }

--- a/test/Index/index_macros.swift
+++ b/test/Index/index_macros.swift
@@ -3,9 +3,9 @@
 // REQUIRES: OS=macosx
 
 
-macro myLine: Int = _SwiftSyntaxMacros.LineMacro
-macro myFilename<T: ExpressibleByStringLiteral>: T = _SwiftSyntaxMacros.FilePathMacro
-macro myStringify<T>(_: T) -> (T, String) = _SwiftSyntaxMacros.StringifyMacro
+macro myLine: Int = MacroDefinition.LineMacro
+macro myFilename<T: ExpressibleByStringLiteral>: T = MacroDefinition.FileMacro
+macro myStringify<T>(_: T) -> (T, String) = MacroDefinition.StringifyMacro
 
 func test(x: Int) {
   _ = #myLine

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -53,6 +53,6 @@ macro addBlocker<T>(_ value: T) -> T = MacroDefinition.AddBlocker
 func testAddBlocker(a: Int, b: Int, c: Int) {
   _ = #addBlocker(a * b * c)
 #if TEST_DIAGNOSTICS
-  _ = #addBlocker(a + b * c) // expected-error{{blocked an add; did you mean to subtract?}}{{21-22=-}}
+  _ = #addBlocker(a + b * c) // expected-error{{blocked an add; did you mean to subtract? (from macro 'addBlocker')}}{{21-22=-}}
 #endif
 }

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -53,7 +53,6 @@ macro addBlocker<T>(_ value: T) -> T = MacroDefinition.AddBlocker
 func testAddBlocker(a: Int, b: Int, c: Int) {
   _ = #addBlocker(a * b * c)
 #if TEST_DIAGNOSTICS
-  // FIXME: Highlight locations are wrong.
-  _ = #addBlocker(a + b * c) // expected-error{{blocked an add}}
+  _ = #addBlocker(a + b * c) // expected-error{{blocked an add; did you mean to subtract?}}{{21-22=-}}
 #endif
 }

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -1,7 +1,9 @@
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature Macros -module-name MacrosTest
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Macros -module-name MacrosTest -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir
 // REQUIRES: OS=macosx
 
-macro stringify<T>(_ value: T) -> (T, String) = _SwiftSyntaxMacros.StringifyMacro
+macro stringify<T>(_ value: T) -> (T, String) = MacroDefinition.StringifyMacro
 macro missingMacro1(_: Any) = MissingModule.MissingType // expected-note{{'missingMacro1' declared here}}
 macro missingMacro2(_: Any) = MissingModule.MissingType
 

--- a/test/ModuleInterface/macros.swift
+++ b/test/ModuleInterface/macros.swift
@@ -7,14 +7,14 @@
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Macros.swiftinterface -o %t/Macros.swiftmodule
 
 // CHECK: #if compiler(>=5.3) && $Macros
-// CHECK-NEXT: public macro publicStringify<T>(_ value: T) -> (T, Swift.String) = _SwiftSyntaxMacros.StringifyMacro
+// CHECK-NEXT: public macro publicStringify<T>(_ value: T) -> (T, Swift.String) = SomeModule.StringifyMacro
 // CHECK-NEXT: #endif
-public macro publicStringify<T>(_ value: T) -> (T, String) = _SwiftSyntaxMacros.StringifyMacro
+public macro publicStringify<T>(_ value: T) -> (T, String) = SomeModule.StringifyMacro
 
 // CHECK: #if compiler(>=5.3) && $Macros
-// CHECK: public macro publicLine<T>: T = _SwiftSyntaxMacros.Line where T : Swift.ExpressibleByIntegerLiteral
+// CHECK: public macro publicLine<T>: T = SomeModule.Line where T : Swift.ExpressibleByIntegerLiteral
 // CHECK-NEXT: #endif
-public macro publicLine<T: ExpressibleByIntegerLiteral>: T = _SwiftSyntaxMacros.Line
+public macro publicLine<T: ExpressibleByIntegerLiteral>: T = SomeModule.Line
 
 // CHECK-NOT: internalStringify
-macro internalStringify<T>(_ value: T) -> (T, String) = _SwiftSyntaxMacros.StringifyMacro
+macro internalStringify<T>(_ value: T) -> (T, String) = SomeModule.StringifyMacro

--- a/test/Serialization/Inputs/def_macros.swift
+++ b/test/Serialization/Inputs/def_macros.swift
@@ -1,3 +1,3 @@
-public macro publicStringify<T>(_ value: T) -> (T, String) = _SwiftSyntaxMacros.StringifyMacro
+public macro publicStringify<T>(_ value: T) -> (T, String) = SomeModule.StringifyMacro
 
-macro internalStringify<T>(_ value: T) -> (T, String) = _SwiftSyntaxMacros.StringifyMacro
+macro internalStringify<T>(_ value: T) -> (T, String) = SomeModule.StringifyMacro

--- a/test/Serialization/macros.swift
+++ b/test/Serialization/macros.swift
@@ -10,6 +10,7 @@ import def_macros
 
 func test(a: Int, b: Int) {
   _ = #publicStringify(a + b)
+  // expected-error@-1{{external macro implementation type 'SomeModule.StringifyMacro' could not be found for macro 'publicStringify'; the type must be public and provided via '-load-plugin-library'}}
 
   _ = #internalStringify(a + b)
   // expected-error@-1{{macro 'internalStringify' is undefined}}


### PR DESCRIPTION
Clean up and fix the handling of source locations in diagnostics produced from macros, and test by adding a Fix-It to the AddBlocker macro that replaces the `+` with a `-`. For diagnostics that come from a macro, append message text saying which macro it came from.
