### PR TITLE
Emit error when move-only type is used as a generic type

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6653,6 +6653,7 @@ ERROR(noimplicitcopy_attr_valid_only_on_local_let_params,
       none, "'@_noImplicitCopy' attribute can only be applied to local lets and params", ())
 ERROR(noimplicitcopy_attr_invalid_in_generic_context,
       none, "'@_noImplicitCopy' attribute cannot be applied to entities in generic contexts", ())
+ERROR(moveonly_generics, none, "move-only type %0 cannot be used with generics yet", (Type))
 ERROR(noimplicitcopy_attr_not_allowed_on_moveonlytype,none,
       "'@_noImplicitCopy' has no effect when applied to a move only type", ())
 
@@ -6972,4 +6973,3 @@ NOTE(opt_out_from_missing_reflection_metadata_attr,none,
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"
-

--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -117,6 +117,8 @@ PROTOCOL(AsyncIteratorProtocol)
 
 PROTOCOL(FloatingPoint)
 
+PROTOCOL_(Copyable)
+
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByArrayLiteral, "Array", false)
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByBooleanLiteral, "BooleanLiteralType", true)
 EXPRESSIBLE_BY_LITERAL_PROTOCOL(ExpressibleByDictionaryLiteral, "Dictionary", false)

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -602,9 +602,8 @@ public:
 
   bool isPlaceholder();
 
-  /// Returns true if this is a move only type. Returns false if this is a
-  /// non-move only type or a move only wrapped type.
-  bool isPureMoveOnly() const;
+  /// Returns true if this is a move-only type.
+  bool isPureMoveOnly();
 
   /// Does the type have outer parenthesis?
   bool hasParenSugar() const { return getKind() == TypeKind::Paren; }

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -2040,15 +2040,13 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static MustBeCopyable *create(ConstraintSystem &cs,
                              Type noncopyableTy,
                              ConstraintLocator *locator);
 
-  static bool classof(ConstraintFix *fix) {
+  static bool classof(ConstraintFix const* fix) {
     return fix->getKind() == FixKind::MustBeCopyable;
   }
 };

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1527,6 +1527,11 @@ LookupConformanceInModuleRequest::evaluate(
   // constraint and the superclass conforms to the protocol.
   if (auto archetype = type->getAs<ArchetypeType>()) {
 
+    // All archetypes conform to Copyable since they represent a generic.
+    // FIXME: can't tell whether this is a hack.
+    if (protocol->isSpecificProtocol(KnownProtocolKind::Copyable))
+      return ProtocolConformanceRef(protocol);
+
     // The generic signature builder drops conformance requirements that are made
     // redundant by a superclass requirement, so check for a concrete
     // conformance first, since an abstract conformance might not be

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1659,6 +1659,15 @@ LookupConformanceInModuleRequest::evaluate(
       } else {
         return ProtocolConformanceRef::forMissingOrInvalid(type, protocol);
       }
+    } else if (protocol->isSpecificProtocol(KnownProtocolKind::Copyable)) {
+      // Only move-only nominals are not Copyable
+      if (nominal->isMoveOnly()) {
+        return ProtocolConformanceRef::forInvalid();
+      } else {
+        // FIXME: this should probably follow the Sendable case in that
+        // we should synthesize and append a ProtocolConformance to the `conformances` list.
+       return ProtocolConformanceRef(protocol);
+      }
     } else {
       // Was unable to infer the missing conformance.
       return ProtocolConformanceRef::forMissingOrInvalid(type, protocol);

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1369,7 +1369,7 @@ static ProtocolConformanceRef getBuiltinTupleTypeConformance(
     return ProtocolConformanceRef(specialized);
   }
 
-  /// For some known protocols like Sendable and Copyable, a tuple type
+  /// For some known protocols (KPs) like Sendable and Copyable, a tuple type
   /// conforms to the protocol KP when all of their element types conform to KP.
   if (protocol->isSpecificProtocol(KnownProtocolKind::Sendable) ||
       protocol->isSpecificProtocol(KnownProtocolKind::Copyable)) {
@@ -1458,8 +1458,8 @@ static ProtocolConformanceRef getBuiltinFunctionTypeConformance(
                                   BuiltinConformanceKind::Synthesized));
   }
 
-  // Functions cannot destroy move-only vars/lets that they capture, so it's
-  // safe to copy functions, as if they're classes.
+  // Functions cannot permanently destroy a move-only var/let
+  // that they capture, so it's safe to copy functions, like classes.
   if (protocol->isSpecificProtocol(KnownProtocolKind::Copyable)) {
     return ProtocolConformanceRef(
         ctx.getBuiltinConformance(type, protocol, GenericSignature(), {},
@@ -1547,7 +1547,6 @@ LookupConformanceInModuleRequest::evaluate(
   if (auto archetype = type->getAs<ArchetypeType>()) {
 
     // All archetypes conform to Copyable since they represent a generic.
-    // FIXME: can't tell whether this is a hack.
     if (protocol->isSpecificProtocol(KnownProtocolKind::Copyable))
       return ProtocolConformanceRef(protocol);
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1206,6 +1206,13 @@ ModuleDecl::lookupExistentialConformance(Type type, ProtocolDecl *protocol) {
   if (!protocol->existentialConformsToSelf())
     return ProtocolConformanceRef::forInvalid();
 
+  // All existentials are Copyable.
+  if (protocol->isSpecificProtocol(KnownProtocolKind::Copyable)) {
+    return ProtocolConformanceRef(
+        ctx.getBuiltinConformance(type, protocol, GenericSignature(), {},
+                                  BuiltinConformanceKind::Synthesized));
+  }
+
   auto layout = type->getExistentialLayout();
 
   // Due to an IRGen limitation, witness tables cannot be passed from an

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1239,8 +1239,7 @@ static SmallVector<ProtocolConformance *, 2> findSynthesizedConformances(
   // Concrete types may synthesize some conformances
   if (!isa<ProtocolDecl>(nominal)) {
     trySynthesize(KnownProtocolKind::Sendable);
-    trySynthesize(KnownProtocolKind::Copyable); // FIXME: we do it when the conformance table is generaetd
-                                                // so this is actually useless now.
+    trySynthesize(KnownProtocolKind::Copyable);
   }
 
   /// Distributed actors can synthesize Encodable/Decodable, so look for those

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1097,6 +1097,11 @@ void NominalTypeDecl::prepareConformanceTable() const {
   if (mutableThis->getAttrs().hasAttribute<GlobalActorAttr>()) {
     addSynthesized(ctx.getProtocol(KnownProtocolKind::GlobalActor));
   }
+
+  // All nominal types that are not move-only conform to Copyable.
+  if (!mutableThis->isMoveOnly()) {
+    addSynthesized(ctx.getProtocol(KnownProtocolKind::Copyable));
+  }
 }
 
 bool NominalTypeDecl::lookupConformance(
@@ -1224,24 +1229,24 @@ static SmallVector<ProtocolConformance *, 2> findSynthesizedConformances(
   // Try to find specific conformances
   SmallVector<ProtocolConformance *, 2> result;
 
-  // Sendable may be synthesized for concrete types
-  if (!isa<ProtocolDecl>(nominal)) {
-    if (auto sendable =
-            findSynthesizedConformance(dc, KnownProtocolKind::Sendable)) {
-      result.push_back(sendable);
+  auto trySynthesize = [&](KnownProtocolKind knownProto) {
+    if (auto conformance =
+            findSynthesizedConformance(dc, knownProto)) {
+      result.push_back(conformance);
     }
+  };
+
+  // Concrete types may synthesize some conformances
+  if (!isa<ProtocolDecl>(nominal)) {
+    trySynthesize(KnownProtocolKind::Sendable);
+    trySynthesize(KnownProtocolKind::Copyable); // FIXME: we do it when the conformance table is generaetd
+                                                // so this is actually useless now.
   }
 
   /// Distributed actors can synthesize Encodable/Decodable, so look for those
   if (nominal->isDistributedActor()) {
-    if (auto conformance =
-            findSynthesizedConformance(dc, KnownProtocolKind::Encodable)) {
-      result.push_back(conformance);
-    }
-    if (auto conformance =
-            findSynthesizedConformance(dc, KnownProtocolKind::Decodable)) {
-      result.push_back(conformance);
-    }
+    trySynthesize(KnownProtocolKind::Encodable);
+    trySynthesize(KnownProtocolKind::Decodable);
   }
 
   return result;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -165,9 +165,17 @@ bool TypeBase::isAny() {
   return constraint->isEqual(getASTContext().TheAnyType);
 }
 
-bool TypeBase::isPureMoveOnly() const {
-  if (auto *nom = getCanonicalType()->getNominalOrBoundGenericNominal())
+bool TypeBase::isPureMoveOnly() {
+  if (auto *nom = getNominalOrBoundGenericNominal())
     return nom->isMoveOnly();
+
+  // if any components of the tuple are move-only, then the tuple is move-only.
+  if (auto *tupl = getCanonicalType()->getAs<TupleType>()) {
+    for (auto eltTy : tupl->getElementTypes())
+      if (eltTy->isPureMoveOnly())
+        return true;
+  }
+
   return false;
 }
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5885,6 +5885,7 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::UnsafeSendable:
   case KnownProtocolKind::RangeReplaceableCollection:
   case KnownProtocolKind::GlobalActor:
+  case KnownProtocolKind::Copyable:
     return SpecialProtocol::None;
   }
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5822,6 +5822,11 @@ bool NotCompileTimeConstFailure::diagnoseAsError() {
   return true;
 }
 
+bool NotCopyableFailure::diagnoseAsError() {
+  emitDiagnostic(diag::moveonly_generics, noncopyableTy);
+  return true;
+}
+
 bool CollectionElementContextualFailure::diagnoseAsError() {
   auto anchor = getRawAnchor();
   auto *locator = getLocator();

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1823,6 +1823,15 @@ public:
   bool diagnoseAsError() override;
 };
 
+class NotCopyableFailure final : public FailureDiagnostic {
+  Type noncopyableTy;
+public:
+  NotCopyableFailure(const Solution &solution, Type noncopyableTy, ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), noncopyableTy(noncopyableTy) {}
+
+  bool diagnoseAsError() override;
+};
+
 /// Diagnose a contextual mismatch between expected collection element type
 /// and the one provided (e.g. source of the assignment or argument to a call)
 /// e.g.:

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1328,6 +1328,21 @@ bool NotCompileTimeConst::diagnose(const Solution &solution, bool asNote) const 
   return failure.diagnose(asNote);
 }
 
+MustBeCopyable::MustBeCopyable(ConstraintSystem &cs, Type noncopyableTy, ConstraintLocator *locator)
+    : ConstraintFix(cs, FixKind::MustBeCopyable, locator, FixBehavior::Error),
+      noncopyableTy(noncopyableTy) {}
+
+bool MustBeCopyable::diagnose(const Solution &solution, bool asNote) const {
+  NotCopyableFailure failure(solution, noncopyableTy, getLocator());
+  return failure.diagnose(asNote);
+}
+
+MustBeCopyable* MustBeCopyable::create(ConstraintSystem &cs,
+                                              Type noncopyableTy,
+                                              ConstraintLocator *locator) {
+  return new (cs.getAllocator()) MustBeCopyable(cs, noncopyableTy, locator);
+}
+
 bool CollectionElementContextualMismatch::diagnose(const Solution &solution,
                                                    bool asNote) const {
   CollectionElementContextualFailure failure(

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8129,6 +8129,14 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
           return SolutionKind::Solved;
       }
     }
+
+    // If this is a failure to conform to Copyable, tailor the error message.
+    if (protocol->isSpecificProtocol(KnownProtocolKind::Copyable)) {
+      auto *fix =
+          MustBeCopyable::create(*this, type, getConstraintLocator(locator));
+      if (!recordFix(fix))
+        return SolutionKind::Solved;
+    }
   }
 
   // There's nothing more we can do; fail.
@@ -13943,6 +13951,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::IgnoreKeyPathContextualMismatch:
   case FixKind::NotCompileTimeConst:
   case FixKind::RenameConflictingPatternVariables:
+  case FixKind::MustBeCopyable:
   case FixKind::MacroMissingPound:
   case FixKind::AllowGlobalActorMismatch: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3823,6 +3823,18 @@ ConstraintSystem::matchExistentialTypes(Type type1, Type type2,
     return getTypeMatchAmbiguous();
   }
 
+  // move-only types cannot match with any existential types.
+  if (type1->isPureMoveOnly()) {
+    // tailor error message
+    if (shouldAttemptFixes()) {
+      auto *fix = MustBeCopyable::create(*this, type1,
+                                        getConstraintLocator(locator));
+      if (!recordFix(fix))
+        return getTypeMatchSuccess();
+    }
+    return getTypeMatchFailure(locator);
+  }
+
   // FIXME: Feels like a hack.
   if (type1->is<InOutType>())
     return getTypeMatchFailure(locator);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11124,6 +11124,12 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
   if (type1->isTypeVariableOrMember() || type2->isTypeVariableOrMember())
     return formUnsolved();
 
+  // Move-only types can't be involved in a bridging conversion since a bridged
+  // type assumes the ability to copy.
+  if (type1->isPureMoveOnly()) {
+    return SolutionKind::Error;
+  }
+
   Type unwrappedFromType;
   unsigned numFromOptionals;
   std::tie(unwrappedFromType, numFromOptionals) = unwrapType(type1);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1810,6 +1810,10 @@ TypeVariableType *ConstraintSystem::openGenericParameter(
     ProtocolDecl *copyable = TypeChecker::getProtocol(
         getASTContext(), SourceLoc(), KnownProtocolKind::Copyable);
 
+    // FIXME(kavon): there's a dependency ordering issues here with the
+    // protocol being defined in the stdlib, because when trying to build
+    // the stdlib itself, or a Swift program with -parse-stdlib, we can't
+    // load the protocol to add this constraint. (rdar://104898230)
     assert(copyable && "stdlib is missing _Copyable protocol!");
     addConstraint(
         ConstraintKind::ConformsTo, typeVar,

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1804,6 +1804,19 @@ TypeVariableType *ConstraintSystem::openGenericParameter(
   assert(result.second);
   (void)result;
 
+  // When move-only types are available, add a constraint to force generic
+  // parameters to conform to a "Copyable" protocol.
+  if (getASTContext().LangOpts.hasFeature(Feature::MoveOnly)) {
+    ProtocolDecl *copyable = TypeChecker::getProtocol(
+        getASTContext(), SourceLoc(), KnownProtocolKind::Copyable);
+
+    assert(copyable && "stdlib is missing _Copyable protocol!");
+    addConstraint(
+        ConstraintKind::ConformsTo, typeVar,
+        copyable->getDeclaredInterfaceType(),
+        locator.withPathElement(LocatorPathElt::GenericParameter(parameter)));
+  }
+
   return typeVar;
 }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1659,6 +1659,27 @@ TypeChecker::typeCheckCheckedCast(Type fromType, Type toType,
        !unwrappedIUO)) {
     return CheckedCastKind::Coercion;
   }
+
+  // Since move-only types currently cannot conform to protocols, nor be a class
+  // type, the subtyping hierarchy is a bit bizarre as of now:
+  //
+  //              noncopyable
+  //           structs and enums
+  //                   |
+  //       +--------- Any
+  //       |           |
+  //   AnyObject    protocol
+  //       |       existentials
+  //       |            |   \
+  //       +---------+  |    +-- structs/enums
+  //                 |  |
+  //                classes
+  //           (and their subtyping)
+  //
+  //
+  // Thus, right now, a move-only type is only a subtype of itself.
+  if (fromType->isPureMoveOnly())
+    return CheckedCastKind::Unresolved;
   
   // Check for a bridging conversion.
   // Anything bridges to AnyObject.

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2582,6 +2582,7 @@ public:
       }
     }
 
+    // FIXME(kavon): see if these can be integrated into other parts of Sema
     diagnoseCopyableTypeContainingMoveOnlyType(ED);
     diagnoseMoveOnlyNominalDeclDoesntConformToProtocols(ED);
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4596,6 +4596,14 @@ swift::checkTypeWitness(Type type, AssociatedTypeDecl *assocType,
       proto->isComputingRequirementSignature())
     return ErrorType::get(ctx);
 
+  // No move-only type can witness an associatedtype requirement.
+  if (type->isPureMoveOnly()) {
+    // describe the failure reason as it not conforming to Copyable
+    auto *copyable = ctx.getProtocol(KnownProtocolKind::Copyable);
+    assert(copyable && "missing _Copyable from stdlib!");
+    return CheckTypeWitnessResult(copyable->getDeclaredInterfaceType());
+  }
+
   const auto depTy = DependentMemberType::get(proto->getSelfInterfaceType(),
                                               assocType);
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -964,6 +964,23 @@ static Type applyGenericArguments(Type type, TypeResolution resolution,
   return result;
 }
 
+/// if any of the generic args are a concrete move-only type, emit an error.
+/// returns true iff an error diagnostic was emitted
+static bool didDiagnoseMoveOnlyGenericArgs(ASTContext &ctx,
+                                         SourceLoc loc,
+                                         ArrayRef<Type> genericArgs) {
+  bool didEmitDiag = false;
+  for (auto t: genericArgs) {
+    if (!t->isPureMoveOnly())
+      continue;
+
+    ctx.Diags.diagnose(loc, diag::moveonly_generics, t);
+    didEmitDiag = true;
+  }
+
+  return didEmitDiag;
+}
+
 /// Apply generic arguments to the given type.
 Type TypeResolution::applyUnboundGenericArguments(
     GenericTypeDecl *decl, Type parentTy, SourceLoc loc,
@@ -983,6 +1000,10 @@ Type TypeResolution::applyUnboundGenericArguments(
   // or unbound generics, let's skip the check here, and let the solver
   // do it when missing types are deduced.
   bool skipRequirementsCheck = false;
+
+  // check for generic args that are move-only
+  if (didDiagnoseMoveOnlyGenericArgs(getASTContext(), loc, genericArgs))
+    return ErrorType::get(getASTContext());
 
   // Get the substitutions for outer generic parameters from the parent
   // type.
@@ -1970,6 +1991,7 @@ namespace {
     }
 
     Type diagnoseDisallowedExistential(TypeRepr *repr, Type type);
+    bool diagnoseMoveOnly(TypeRepr *repr, Type genericArgTy);
 
     NeverNullType resolveOpenedExistentialArchetype(
         TypeAttributes &attrs, TypeRepr *repr,
@@ -2198,6 +2220,23 @@ Type TypeResolver::diagnoseDisallowedExistential(TypeRepr *repr, Type type) {
   }
 
   return type;
+}
+
+/// Checks the given type, assuming that it appears as an argument for a
+/// generic parameter in the \c repr, to see if it is move-only.
+///
+/// Because generic type parameters currently all assume copyability of
+/// the substituted type, it's an error for a move-only type to appear
+/// as an argument for type parameters.
+///
+/// returns true if an error diagnostic was emitted
+bool TypeResolver::diagnoseMoveOnly(TypeRepr *repr, Type genericArgTy) {
+  if (genericArgTy->isPureMoveOnly()) {
+    diagnoseInvalid(repr, repr->getLoc(), diag::moveonly_generics,
+                    genericArgTy);
+    return true;
+  }
+  return false;
 }
 
 NeverNullType TypeResolver::resolveType(TypeRepr *repr,
@@ -4190,6 +4229,10 @@ NeverNullType TypeResolver::resolveArrayType(ArrayTypeRepr *repr,
     return ErrorType::get(ctx);
   }
 
+  // do not allow move-only types in an array
+  if (diagnoseMoveOnly(repr, baseTy))
+    return ErrorType::get(ctx);
+
   return ArraySliceType::get(baseTy);
 }
 
@@ -4239,6 +4282,10 @@ NeverNullType TypeResolver::resolveOptionalType(OptionalTypeRepr *repr,
   if (optionalTy->hasError()) {
     return ErrorType::get(getASTContext());
   }
+
+  // do not allow move-only types in an optional
+  if (diagnoseMoveOnly(repr, baseTy))
+    return ErrorType::get(getASTContext());
 
   return optionalTy;
 }
@@ -4337,6 +4384,10 @@ NeverNullType TypeResolver::resolveImplicitlyUnwrappedOptionalType(
     return ErrorType::get(getASTContext());
   }
 
+  // do not allow move-only types in an implicitly-unwrapped optional
+  if (diagnoseMoveOnly(repr, baseTy))
+    return ErrorType::get(getASTContext());
+
   return uncheckedOptionalTy;
 }
 
@@ -4350,6 +4401,10 @@ NeverNullType TypeResolver::resolveVarargType(VarargTypeRepr *repr,
     diagnose(repr->getLoc(), diag::vararg_not_allowed)
       .highlight(repr->getSourceRange());
   }
+
+  // do not allow move-only types as the element of a vararg
+  if (diagnoseMoveOnly(repr, element))
+    return ErrorType::get(getASTContext());
 
   return element;
 }

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -154,3 +154,8 @@ public func _getTypeByMangledNameInContext(
 public func _unsafePerformance<T>(_ c: () -> T) -> T {
   return c()
 }
+
+
+/// This is not a protocol you can explicitly use in your programs.
+/// It exists for the compiler and type checker for diagnostic purposes.
+@_marker public protocol _Copyable { }

--- a/test/Constraints/moveonly_constraints.swift
+++ b/test/Constraints/moveonly_constraints.swift
@@ -1,0 +1,143 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-move-only
+
+// a concrete move-only type
+@_moveOnly struct MO {
+  var x: Int?
+}
+
+@_moveOnly struct Container {
+  var mo: MO = MO()
+}
+
+// utilities
+
+struct LocalArray<Element> {}
+
+protocol Box<T> {
+  associatedtype T
+  func get() -> T
+}
+
+class RefBox<T>: Box {
+  var val: T
+  init(_ t: T) { val = t }
+  func get() -> T { return val }
+}
+
+struct ValBox<T>: Box {
+  var val: T
+  init(_ t: T) { val = t }
+  func get() -> T { return val }
+}
+
+class NotStoredGenerically<T> {
+  func take(_ t: T) {}
+  func give() -> T { fatalError("todo") }
+}
+
+enum Maybe<T> {
+  case none
+  case just(T)
+}
+
+func takeConcrete(_ m: MO) {}
+func takeGeneric<T>(_ t: T) {}
+func takeMaybe<T>(_ m: Maybe<T>) {}
+func takeAnyBoxErased(_ b: any Box) {}
+func takeAnyBox<T>(_ b: any Box<T>) {}
+func takeAny(_ a: Any) {}
+
+var globalMO: MO = MO()
+
+
+// ----------------------
+// --- now some tests ---
+// ----------------------
+
+// some top-level tests
+let _: MO = globalMO
+takeGeneric(globalMO) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+
+
+
+
+func testAny() {
+  let _: Any = MO() // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  takeAny(MO()) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+}
+
+func testFunctionCalls() {
+  takeConcrete(globalMO)
+  takeConcrete(MO())
+
+  takeGeneric(globalMO) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  takeGeneric(MO()) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+}
+
+func checkBasicBoxes() {
+  let mo = MO()
+
+  let vb = ValBox(_move mo) // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
+  _ = vb.get()
+  _ = vb.val
+
+  let rb = RefBox(MO())  // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
+  _ = rb.get()
+  _ = rb.val
+
+  let vb2: ValBox<MO> = .init(MO())  // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+}
+
+func checkExistential() {
+  takeAnyBox( // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+      RefBox(MO())) // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
+
+  takeAnyBox( // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+      ValBox(globalMO)) // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
+
+  takeAnyBoxErased(
+      RefBox(MO())) // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
+
+  takeAnyBoxErased(
+      ValBox(globalMO)) // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
+}
+
+func checkMethodCalls() {
+  let tg: NotStoredGenerically<MO> = NotStoredGenerically() // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  tg.take(MO())
+  tg.give()
+
+  let _: Maybe<MO> = .none // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _ = Maybe<MO>.just(MO()) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: Maybe<MO> = .just(MO()) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  takeMaybe(.just(MO())) // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
+
+  takeMaybe(true ? .none : .just(MO())) // expected-error 3{{move-only type 'MO' cannot be used with generics yet}}
+}
+
+func checkCasting(_ b: any Box) {
+  // casting dynamically is allowed, but should always fail since you can't
+  // construct such a type.
+  let box = b as! ValBox<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let dup = box
+
+  let _: MO = dup.get()
+  let _: MO = dup.val
+}
+
+func checkStdlibTypes(_ mo: MO) {
+  let _: [MO] = // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+      [MO(), MO()]
+  let _: [MO] = // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+      []
+  let _: [String: MO] = // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+      ["hello" : MO()]
+
+  // i think this one's only caught b/c of the 'Any' change
+  _ = [MO()] // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+
+  let _: Array<MO> = .init() // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  _ = [MO]() // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+
+  let s: String = "hello \(mo)" // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+}

--- a/test/Constraints/moveonly_constraints.swift
+++ b/test/Constraints/moveonly_constraints.swift
@@ -91,6 +91,9 @@ func testBasic(_ mo: MO) {
 
   let singleton : (MO) = (mo)
   takeGeneric(singleton) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+
+  takeAny((mo)) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  takeAny((mo, mo)) // expected-error {{move-only type '(MO, MO)' cannot be used with generics yet}}
 }
 
 func checkBasicBoxes() {

--- a/test/Constraints/moveonly_constraints.swift
+++ b/test/Constraints/moveonly_constraints.swift
@@ -137,7 +137,7 @@ func checkMethodCalls() {
   takeMaybe(true ? .none : .just(MO())) // expected-error 3{{move-only type 'MO' cannot be used with generics yet}}
 }
 
-func checkCasting(_ b: any Box) {
+func checkCasting(_ b: any Box, _ mo: MO) {
   // casting dynamically is allowed, but should always fail since you can't
   // construct such a type.
   let box = b as! ValBox<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
@@ -145,6 +145,16 @@ func checkCasting(_ b: any Box) {
 
   let _: MO = dup.get()
   let _: MO = dup.val
+
+  let _: Sendable = (MO(), MO()) // expected-error {{move-only type '(MO, MO)' cannot be used with generics yet}}
+  let _: Sendable = MO() // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: _Copyable = mo // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: AnyObject = MO() // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: Any = mo // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+
+  // FIXME: this shouldn't be allowed
+  let _: AnyHashable = MO() as! AnyHashable
+
 }
 
 func checkStdlibTypes(_ mo: MO) {

--- a/test/Constraints/moveonly_constraints.swift
+++ b/test/Constraints/moveonly_constraints.swift
@@ -158,12 +158,28 @@ func checkCasting(_ b: any Box, _ mo: MO) {
   _ = MO() as any P // expected-error {{move-only type 'MO' cannot be used with generics yet}}
   _ = MO() as Any // expected-error {{move-only type 'MO' cannot be used with generics yet}}
   _ = MO() as MO
-
-  // TODO: make sure at runtime these casts actually fail, or just make them errors?
-  let _: AnyHashable = MO() as! AnyHashable // expected-warning {{cast from 'MO' to unrelated type 'AnyHashable' always fails}}
-
-  // TODO: figure out how this is getting past us! Doesn't seem to hit `typeCheckCheckedCast` at all!
   _ = MO() as AnyObject // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+
+  // FIXME(kavon): make sure at runtime these casts actually fail, or just make them errors? (rdar://104900293)
+
+  _ = MO() is AnyHashable // expected-warning {{cast from 'MO' to unrelated type 'AnyHashable' always fails}}
+  _ = MO() is AnyObject // expected-warning {{cast from 'MO' to unrelated type 'AnyObject' always fails}}
+  _ = MO() is Any // expected-warning {{cast from 'MO' to unrelated type 'Any' always fails}}
+  _ = MO() is P // expected-warning {{cast from 'MO' to unrelated type 'any P' always fails}}
+  _ = MO() is MO // expected-warning {{'is' test is always true}}
+
+  _ = MO() as! AnyHashable // expected-warning {{cast from 'MO' to unrelated type 'AnyHashable' always fails}}
+  _ = MO() as! AnyObject // expected-warning {{cast from 'MO' to unrelated type 'AnyObject' always fails}}
+  _ = MO() as! Any // expected-warning {{cast from 'MO' to unrelated type 'Any' always fails}}
+  _ = MO() as! P // expected-warning {{cast from 'MO' to unrelated type 'any P' always fails}}
+  _ = MO() as! MO // expected-warning {{forced cast of 'MO' to same type has no effect}}
+
+  _ = MO() as? AnyHashable // expected-warning {{cast from 'MO' to unrelated type 'AnyHashable' always fails}}
+  _ = MO() as? AnyObject // expected-warning {{cast from 'MO' to unrelated type 'AnyObject' always fails}}
+  _ = MO() as? Any // expected-warning {{cast from 'MO' to unrelated type 'Any' always fails}}
+  _ = MO() as? P // expected-warning {{cast from 'MO' to unrelated type 'any P' always fails}}
+  _ = MO() as? MO // expected-warning {{conditional cast from 'MO' to 'MO' always succeeds}}
+
 }
 
 func checkStdlibTypes(_ mo: MO) {

--- a/test/Constraints/moveonly_constraints.swift
+++ b/test/Constraints/moveonly_constraints.swift
@@ -164,6 +164,13 @@ func checkStdlibTypes(_ mo: MO) {
   let s: String = "hello \(mo)" // expected-error {{move-only type 'MO' cannot be used with generics yet}}
 }
 
+func copyableExistentials(_ a: Any, _ e1: Error, _ e2: any Error, _ ah: AnyHashable) {
+  takeGeneric(a)
+  takeGeneric(e1)
+  takeGeneric(e2)
+  takeGeneric(ah)
+}
+
 // ensure that associated types can't be witnessed by move-only types
 
 protocol HasType<Ty> {

--- a/test/Constraints/moveonly_constraints.swift
+++ b/test/Constraints/moveonly_constraints.swift
@@ -13,6 +13,8 @@
 
 struct LocalArray<Element> {}
 
+protocol P {}
+
 protocol Box<T> {
   associatedtype T
   func get() -> T
@@ -152,9 +154,16 @@ func checkCasting(_ b: any Box, _ mo: MO) {
   let _: AnyObject = MO() // expected-error {{move-only type 'MO' cannot be used with generics yet}}
   let _: Any = mo // expected-error {{move-only type 'MO' cannot be used with generics yet}}
 
-  // FIXME: this shouldn't be allowed
-  let _: AnyHashable = MO() as! AnyHashable
+  _ = MO() as P // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  _ = MO() as any P // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  _ = MO() as Any // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  _ = MO() as MO
 
+  // TODO: make sure at runtime these casts actually fail, or just make them errors?
+  let _: AnyHashable = MO() as! AnyHashable // expected-warning {{cast from 'MO' to unrelated type 'AnyHashable' always fails}}
+
+  // TODO: figure out how this is getting past us! Doesn't seem to hit `typeCheckCheckedCast` at all!
+  _ = MO() as AnyObject // expected-error {{move-only type 'MO' cannot be used with generics yet}}
 }
 
 func checkStdlibTypes(_ mo: MO) {

--- a/test/SILGen/moveonly_var.swift
+++ b/test/SILGen/moveonly_var.swift
@@ -5,13 +5,21 @@
 // Declarations //
 //////////////////
 
+class OrdinaryClass {}
+
+@_moveOnly
+public enum MaybeKlass {
+    case just(Klass)
+    case none
+}
+
 @_moveOnly
 public class Klass {
     var intField: Int
-    var klsField: Klass?
+    var klsField: OrdinaryClass // FIXME(104504239): this is suppose to be MaybeKlass, or better yet, Optional<Klass>
 
     init() {
-        klsField = Klass()
+        klsField = OrdinaryClass()
         intField = 5
     }
 }

--- a/test/SILOptimizer/move_only_checker_addressonly_fail.swift
+++ b/test/SILOptimizer/move_only_checker_addressonly_fail.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-move-only -verify %s -parse-stdlib -emit-sil
+// RUN: %target-swift-frontend -enable-experimental-move-only -verify %s -emit-sil
 
 func useValue<T>(_ x: T) {}
 func consumeValue<T>(_ x: __owned T) {}

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -9,7 +9,7 @@ public class CopyableKlass {}
 @_moveOnly
 public class Klass {
     var intField: Int
-    var k: Klass?
+    var k: Klass
     init()
 }
 

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -20,7 +20,7 @@ public class CopyableKlass {}
 @_moveOnly
 public class Klass {
     var intField: Int
-    var k: Klass?
+    var k: Klass
     init()
 }
 

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -6,15 +6,31 @@
 
 public class CopyableKlass {}
 
-public func copyableClassUseMoveOnlyWithoutEscaping(_ x: CopyableKlass) {
-}
-public func copyableClassConsume(_ x: __owned CopyableKlass) {
-}
+public func borrowVal(_ x: __shared CopyableKlass) {}
+public func borrowVal(_ x: __shared Klass) {}
+public func borrowVal(_ s: __shared NonTrivialStruct) {}
+public func borrowVal(_ s: __shared NonTrivialStruct2) {}
+public func borrowVal(_ s: __shared NonTrivialCopyableStruct) {}
+public func borrowVal(_ s: __shared NonTrivialCopyableStruct2) {}
+public func borrowVal(_ e : __shared NonTrivialEnum) {}
+public func borrowVal(_ x: __shared FinalKlass) {}
+public func borrowVal(_ x: __shared AggStruct) {}
+public func borrowVal(_ x: __shared AggGenericStruct<CopyableKlass>) {}
+public func borrowVal<T>(_ x: __shared AggGenericStruct<T>) {}
+public func borrowVal(_ x: __shared EnumTy) {}
+
+public func consumeVal(_ x: __owned CopyableKlass) {}
+public func consumeVal(_ x: __owned Klass) {}
+public func consumeVal(_ x: __owned FinalKlass) {}
+public func consumeVal(_ x: __owned AggStruct) {}
+public func consumeVal(_ x: __owned AggGenericStruct<CopyableKlass>) {}
+public func consumeVal<T>(_ x: __owned AggGenericStruct<T>) {}
+public func consumeVal(_ x: __owned EnumTy) {}
 
 @_moveOnly
 public class Klass {
     var intField: Int
-    var k: Klass?
+    var k: Klass
     init() {
         k = Klass()
         intField = 5
@@ -22,11 +38,6 @@ public class Klass {
 }
 
 var boolValue: Bool { return true }
-
-public func classUseMoveOnlyWithoutEscaping(_ x: Klass) {
-}
-public func classConsume(_ x: __owned Klass) {
-}
 
 @_moveOnly
 public struct NonTrivialStruct {
@@ -36,27 +47,19 @@ public struct NonTrivialStruct {
     var nonTrivialCopyableStruct = NonTrivialCopyableStruct()
 }
 
-public func nonConsumingUseNonTrivialStruct(_ s: NonTrivialStruct) {}
-
 @_moveOnly
 public struct NonTrivialStruct2 {
     var copyableKlass = CopyableKlass()
 }
-
-public func nonConsumingUseNonTrivialStruct2(_ s: NonTrivialStruct2) {}
 
 public struct NonTrivialCopyableStruct {
     var copyableKlass = CopyableKlass()
     var nonTrivialCopyableStruct2 = NonTrivialCopyableStruct2()
 }
 
-public func nonConsumingUseNonTrivialCopyableStruct(_ s: NonTrivialCopyableStruct) {}
-
 public struct NonTrivialCopyableStruct2 {
     var copyableKlass = CopyableKlass()
 }
-
-public func nonConsumingUseNonTrivialCopyableStruct2(_ s: NonTrivialCopyableStruct2) {}
 
 @_moveOnly
 public enum NonTrivialEnum {
@@ -66,11 +69,9 @@ public enum NonTrivialEnum {
     case fourth(CopyableKlass)
 }
 
-public func nonConsumingUseNonTrivialEnum(_ e : NonTrivialEnum) {}
-
 @_moveOnly
 public final class FinalKlass {
-    var k: Klass? = nil
+    var k: Klass = Klass()
 }
 
 ///////////
@@ -89,7 +90,7 @@ public func classSimpleChainTest(_ x: Klass) { // expected-error {{'x' has guara
     let k2 = y2
     let k3 = x2 // expected-note {{consuming use here}}
     let _ = k3
-    classUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func classSimpleChainArgTest(_ x2: inout Klass) {
@@ -99,54 +100,54 @@ public func classSimpleChainArgTest(_ x2: inout Klass) {
     y2 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
     let k2 = y2
-    classUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func classSimpleNonConsumingUseTest(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = x // expected-note {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func classSimpleNonConsumingUseArgTest(_ x2: inout Klass) {
-    classUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func classMultipleNonConsumingUseTest(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = x // expected-note {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x2)
-    classUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
 public func classMultipleNonConsumingUseArgTest(_ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-    classUseMoveOnlyWithoutEscaping(x2)
-    classUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func classMultipleNonConsumingUseArgTest2(_ x2: inout Klass) { // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
-    classUseMoveOnlyWithoutEscaping(x2)
-    classUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    borrowVal(x2) // expected-note {{non-consuming use here}}
 }
 
 public func classMultipleNonConsumingUseArgTest3(_ x2: inout Klass) {  // expected-error {{'x2' consumed but not reinitialized before end of function}}
                                                                        // expected-error @-1 {{'x2' consumed more than once}}
-    classUseMoveOnlyWithoutEscaping(x2)
-    classUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
-              // expected-note @-1 {{consuming use here}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+                   // expected-note @-1 {{consuming use here}}
 }
 
 public func classMultipleNonConsumingUseArgTest4(_ x2: inout Klass) { // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
-    classUseMoveOnlyWithoutEscaping(x2)
-    classUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    borrowVal(x2) // expected-note {{non-consuming use here}}
     x2 = Klass()
 }
 
@@ -155,31 +156,31 @@ public func classUseAfterConsume(_ x: Klass) { // expected-error {{'x' has guara
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = x // expected-note {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x2)
-    classConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func classUseAfterConsumeArg(_ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
                                                          // expected-error @-1 {{'x2' consumed more than once}}
-    classUseMoveOnlyWithoutEscaping(x2)
-    classConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
-              // expected-note @-1 {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+                   // expected-note @-1 {{consuming use here}}
 }
 
 public func classDoubleConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     x2 = Klass()
-    classConsume(x2) // expected-note {{consuming use here}}
-    classConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func classDoubleConsumeArg(_ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
                                                        // expected-error @-1 {{'x2' consumed more than once}}
-    classConsume(x2) // expected-note {{consuming use here}}
-    classConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
                      // expected-note @-1 {{consuming use here}}
 }
 
@@ -188,19 +189,19 @@ public func classLoopConsume(_ x: Klass) { // expected-error {{'x' has guarantee
                // expected-note @-1 {{consuming use here}}
     x2 = Klass()
     for _ in 0..<1024 {
-        classConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func classLoopConsumeArg(_ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
-        classConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func classLoopConsumeArg2(_ x2: inout Klass) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        classConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     x2 = Klass()
 }
@@ -209,18 +210,18 @@ public func classDiamond(_ x: Klass) { // expected-error {{'x' has guaranteed ow
     var x2 = x // expected-note {{consuming use here}}
     x2 = Klass()
     if boolValue {
-        classConsume(x2)
+        consumeVal(x2)
     } else {
-        classConsume(x2)
+        consumeVal(x2)
     }
 }
 
 public func classDiamondArg(_ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
                                                  // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     if boolValue {
-        classConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     } else {
-        classConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -231,9 +232,9 @@ public func classDiamondInLoop(_ x: Klass) { // expected-error {{'x' has guarant
     x2 = Klass()
     for _ in 0..<1024 {
       if boolValue {
-          classConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          classConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
                            // expected-note @-1 {{consuming use here}}
       }
     }
@@ -243,9 +244,9 @@ public func classDiamondInLoopArg(_ x2: inout Klass) { // expected-error {{'x2' 
                                                        // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
       if boolValue {
-          classConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          classConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
@@ -254,9 +255,9 @@ public func classDiamondInLoopArg2(_ x2: inout Klass) { // expected-error {{'x2'
                                                        // expected-error @-1 {{'x2' consumed more than once}}
     for _ in 0..<1024 {
       if boolValue {
-          classConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          classConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
                            // expected-note @-1 {{consuming use here}}
       }
     }
@@ -270,7 +271,7 @@ public func classAssignToVar1(_ x: Klass) { // expected-error {{'x' has guarante
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func classAssignToVar1Arg(_ x2: inout Klass) { // expected-error {{'x2' consumed more than once}}
@@ -279,7 +280,7 @@ public func classAssignToVar1Arg(_ x2: inout Klass) { // expected-error {{'x2' c
     x3 = x2 // expected-note {{consuming use here}}
             // expected-note @-1 {{consuming use here}}
     x3 = Klass()
-    print(x3)
+    consumeVal(x3)
 }
 
 public func classAssignToVar2(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
@@ -288,7 +289,7 @@ public func classAssignToVar2(_ x: Klass) { // expected-error {{'x' has guarante
     x2 = Klass()
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x3)
+    borrowVal(x3)
 }
 
 public func classAssignToVar2Arg(_ x2: inout Klass) { // expected-error {{'x2' consumed more than once}}
@@ -296,7 +297,7 @@ public func classAssignToVar2Arg(_ x2: inout Klass) { // expected-error {{'x2' c
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
             // expected-note @-1 {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x3)
+    borrowVal(x3)
 }
 
 public func classAssignToVar3(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
@@ -304,21 +305,21 @@ public func classAssignToVar3(_ x: Klass) { // expected-error {{'x' has guarante
     x2 = Klass()
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func classAssignToVar3Arg(_ x: Klass, _ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
                                                             // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func classAssignToVar3Arg2(_ x: Klass, _ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
                                                                    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func classAssignToVar4(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
@@ -326,16 +327,16 @@ public func classAssignToVar4(_ x: Klass) { // expected-error {{'x' has guarante
                // expected-note @-1 {{consuming use here}}
     x2 = Klass()
     let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x3)
 }
 
 public func classAssignToVar4Arg(_ x2: inout Klass) { // expected-error {{'x2' consumed more than once}}
                                                       // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     let x3 = x2 // expected-note {{consuming use here}}
-    print(x2)   // expected-note {{consuming use here}}
+    consumeVal(x2)   // expected-note {{consuming use here}}
                 // expected-note @-1 {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func classAssignToVar5() {
@@ -344,26 +345,26 @@ public func classAssignToVar5() {
     var x3 = x2 // expected-note {{consuming use here}}
     // TODO: Need to mark this as the lifetime extending use. We fail
     // appropriately though.
-    classUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = Klass()
-    print(x3)
+    consumeVal(x3)
 }
 
 public func classAssignToVar5Arg(_ x: Klass, _ x2: inout Klass) {
     // expected-error @-1 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
     // expected-error @-2 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = x // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func classAssignToVar5Arg2(_ x: Klass, _ x2: inout Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
                                                                    // expected-error @-1 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
     var x3 = x2 // expected-note {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = x // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
     x2 = Klass()
 }
 
@@ -372,18 +373,18 @@ public func classAccessAccessField(_ x: Klass) { // expected-error {{'x' has gua
     // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     x2 = Klass()
-    classUseMoveOnlyWithoutEscaping(x2.k!) // expected-note {{consuming use here}}
+    borrowVal(x2.k) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.k!) // expected-note {{consuming use here}}
+        borrowVal(x2.k) // expected-note {{consuming use here}}
     }
 }
 
 public func classAccessAccessFieldArg(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
-    classUseMoveOnlyWithoutEscaping(x2.k!) // expected-note {{consuming use here}}
+    borrowVal(x2.k) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.k!) // expected-note {{consuming use here}}
+        borrowVal(x2.k) // expected-note {{consuming use here}}
     }
 }
 
@@ -393,9 +394,9 @@ public func classAccessConsumeField(_ x: Klass) { // expected-error {{'x' has gu
     // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     x2 = Klass()
     // Since a class is a reference type, we do not emit an error here.
-    classConsume(x2.k!) // expected-note {{consuming use here}}
+    consumeVal(x2.k) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.k!) // expected-note {{consuming use here}}
+        consumeVal(x2.k) // expected-note {{consuming use here}}
     }
 }
 
@@ -403,9 +404,9 @@ public func classAccessConsumeFieldArg(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     // Since a class is a reference type, we do not emit an error here.
-    classConsume(x2.k!) // expected-note {{consuming use here}}
+    consumeVal(x2.k) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.k!) // expected-note {{consuming use here}}
+        consumeVal(x2.k) // expected-note {{consuming use here}}
     }
 }
 
@@ -420,29 +421,24 @@ extension Klass {
 // Final Class //
 /////////////////
 
-public func finalClassUseMoveOnlyWithoutEscaping(_ x: FinalKlass) {
-}
-public func finalClassConsume(_ x: __owned FinalKlass) {
-}
-
 public func finalClassSimpleChainTest() {
     var x2 = FinalKlass()
     x2 = FinalKlass()
     let y2 = x2
     let k2 = y2
-    finalClassUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func finalClassSimpleChainTestArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
-    finalClassUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func finalClassSimpleChainTestArg2(_ x2: inout FinalKlass) {
     let y2 = x2
     let k2 = y2
-    finalClassUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
     x2 = FinalKlass()
 }
 
@@ -450,61 +446,61 @@ public func finalClassSimpleChainTestArg3(_ x2: inout FinalKlass) {
     for _ in 0..<1024 {}
     let y2 = x2
     let k2 = y2
-    finalClassUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
     x2 = FinalKlass()
 }
 
 public func finalClassSimpleNonConsumingUseTest(_ x: __owned FinalKlass) {
     var x2 = x
     x2 = FinalKlass()
-    finalClassUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func finalClassSimpleNonConsumingUseTestArg(_ x2: inout FinalKlass) {
-    finalClassUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func finalClassMultipleNonConsumingUseTest() {
     var x2 = FinalKlass()
     x2 = FinalKlass()
-    finalClassUseMoveOnlyWithoutEscaping(x2)
-    finalClassUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
 public func finalClassMultipleNonConsumingUseTestArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-    finalClassUseMoveOnlyWithoutEscaping(x2)
-    finalClassUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func finalClassUseAfterConsume() {
     var x2 = FinalKlass() // expected-error {{'x2' consumed more than once}}
     x2 = FinalKlass()
-    finalClassUseMoveOnlyWithoutEscaping(x2)
-    finalClassConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func finalClassUseAfterConsumeArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed more than once}}
                                                                    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    finalClassUseMoveOnlyWithoutEscaping(x2)
-    finalClassConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
               // expected-note @-1 {{consuming use here}}
 }
 
 public func finalClassDoubleConsume() {
     var x2 = FinalKlass()  // expected-error {{'x2' consumed more than once}}
     x2 = FinalKlass()
-    finalClassConsume(x2) // expected-note {{consuming use here}}
-    finalClassConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func finalClassDoubleConsumeArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed more than once}}
                                                                  // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}    
-    finalClassConsume(x2) // expected-note {{consuming use here}}
-    finalClassConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
                           // expected-note @-1 {{consuming use here}}
 }
 
@@ -512,13 +508,13 @@ public func finalClassLoopConsume() {
     var x2 = FinalKlass() // expected-error {{'x2' consumed by a use in a loop}}
     x2 = FinalKlass()
     for _ in 0..<1024 {
-        finalClassConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func finalClassLoopConsumeArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
-        finalClassConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -526,18 +522,18 @@ public func finalClassDiamond() {
     var x2 = FinalKlass()
     x2 = FinalKlass()
     if boolValue {
-        finalClassConsume(x2)
+        consumeVal(x2)
     } else {
-        finalClassConsume(x2)
+        consumeVal(x2)
     }
 }
 
 public func finalClassDiamondArg(_ x2: inout FinalKlass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
                                                            // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     if boolValue {
-        finalClassConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     } else {
-        finalClassConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -547,9 +543,9 @@ public func finalClassDiamondInLoop() {
     x2 = FinalKlass()
     for _ in 0..<1024 {
       if boolValue {
-          finalClassConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          finalClassConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
                                 // expected-note @-1 {{consuming use here}}
       }
     }
@@ -559,9 +555,9 @@ public func finalClassDiamondInLoopArg(_ x2: inout FinalKlass) { // expected-err
                                                                  // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
       if boolValue {
-          finalClassConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          finalClassConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
@@ -570,9 +566,9 @@ public func finalClassDiamondInLoopArg2(_ x2: inout FinalKlass) { // expected-er
                                                                   // expected-error @-1 {{'x2' consumed more than once}}
     for _ in 0..<1024 {
       if boolValue {
-          finalClassConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          finalClassConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
                                 // expected-note @-1 {{consuming use here}}
       }
     }
@@ -586,7 +582,7 @@ public func finalClassAssignToVar1() {
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = FinalKlass()
-    print(x3)
+    consumeVal(x3)
 }
 
 public func finalClassAssignToVar1Arg(_ x2: inout FinalKlass) {
@@ -596,7 +592,7 @@ public func finalClassAssignToVar1Arg(_ x2: inout FinalKlass) {
     x3 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
     x3 = FinalKlass()
-    print(x3)
+    consumeVal(x3)
 }
 
 public func finalClassAssignToVar2() {
@@ -604,7 +600,7 @@ public func finalClassAssignToVar2() {
     x2 = FinalKlass()
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
-    finalClassUseMoveOnlyWithoutEscaping(x3)
+    borrowVal(x3)
 }
 
 public func finalClassAssignToVar2Arg(_ x2: inout FinalKlass) {
@@ -613,7 +609,7 @@ public func finalClassAssignToVar2Arg(_ x2: inout FinalKlass) {
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
             // expected-note @-1 {{consuming use here}}
-    finalClassUseMoveOnlyWithoutEscaping(x3)
+    borrowVal(x3)
 }
 
 public func finalClassAssignToVar3() {
@@ -621,55 +617,55 @@ public func finalClassAssignToVar3() {
     x2 = Klass()
     var x3 = x2
     x3 = Klass()
-    print(x3)
+    consumeVal(x3)
 }
 
 public func finalClassAssignToVar3Arg(_ x2: inout FinalKlass) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = FinalKlass()
-    print(x3)
+    consumeVal(x3)
 }
 
 public func finalClassAssignToVar4() {
     var x2 = FinalKlass() // expected-error {{'x2' consumed more than once}}
     x2 = FinalKlass()
     let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x3)
 }
 
 public func finalClassAssignToVar4Arg(_ x2: inout FinalKlass) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
               // expected-note @-1 {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func finalClassAssignToVar5() {
     var x2 = FinalKlass() // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
     x2 = FinalKlass()
     var x3 = x2 // expected-note {{consuming use here}}
-    finalClassUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = FinalKlass()
-    print(x3)
+    consumeVal(x3)
 }
 
 public func finalClassAssignToVar5Arg(_ x2: inout FinalKlass) {
     // expected-error @-1 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
     var x3 = x2 // expected-note {{consuming use here}}
-    finalClassUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = FinalKlass()
-    print(x3)
+    consumeVal(x3)
 }
 
 public func finalClassAssignToVar5Arg2(_ x2: inout FinalKlass) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = FinalKlass()
-    print(x3)
+    consumeVal(x3)
 }
 
 public func finalClassAccessField() {
@@ -677,18 +673,18 @@ public func finalClassAccessField() {
     // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     x2 = FinalKlass()
-    classUseMoveOnlyWithoutEscaping(x2.k!) // expected-note {{consuming use here}}
+    borrowVal(x2.k) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.k!) // expected-note {{consuming use here}}
+        borrowVal(x2.k) // expected-note {{consuming use here}}
     }
 }
 
 public func finalClassAccessFieldArg(_ x2: inout FinalKlass) {
     // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
-    classUseMoveOnlyWithoutEscaping(x2.k!) // expected-note {{consuming use here}}
+    borrowVal(x2.k) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.k!) // expected-note {{consuming use here}}
+        borrowVal(x2.k) // expected-note {{consuming use here}}
     }
 }
 
@@ -698,18 +694,18 @@ public func finalClassConsumeField() {
     // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     x2 = FinalKlass()
 
-    classConsume(x2.k!) // expected-note {{consuming use here}}
+    consumeVal(x2.k) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.k!) // expected-note {{consuming use here}}
+        consumeVal(x2.k) // expected-note {{consuming use here}}
     }
 }
 
 public func finalClassConsumeFieldArg(_ x2: inout FinalKlass) {
     // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
-    classConsume(x2.k!) // expected-note {{consuming use here}}
+    consumeVal(x2.k) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.k!) // expected-note {{consuming use here}}
+        consumeVal(x2.k) // expected-note {{consuming use here}}
     }
 }
 
@@ -776,17 +772,12 @@ public struct AggStruct {
     }
 }
 
-public func aggStructUseMoveOnlyWithoutEscaping(_ x: AggStruct) {
-}
-public func aggStructConsume(_ x: __owned AggStruct) {
-}
-
 public func aggStructSimpleChainTest() {
     var x2 = AggStruct()
     x2 = AggStruct()
     let y2 = x2
     let k2 = y2
-    aggStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func aggStructSimpleChainTestArg(_ x2: inout AggStruct) {
@@ -796,62 +787,62 @@ public func aggStructSimpleChainTestArg(_ x2: inout AggStruct) {
     y2 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
     let k2 = y2
-    aggStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func aggStructSimpleNonConsumingUseTest() {
     var x2 = AggStruct()
     x2 = AggStruct()
-    aggStructUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func aggStructSimpleNonConsumingUseTestArg(_ x2: inout AggStruct) {
-    aggStructUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func aggStructMultipleNonConsumingUseTest() {
     var x2 = AggStruct()
     x2 = AggStruct()
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
 public func aggStructMultipleNonConsumingUseTestArg(_ x2: inout AggStruct) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggStructUseAfterConsume() {
     var x2 = AggStruct() // expected-error {{'x2' consumed more than once}}
     x2 = AggStruct()
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggStructUseAfterConsumeArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
               // expected-note @-1 {{consuming use here}}
 }
 
 public func aggStructDoubleConsume() {
     var x2 = AggStruct()  // expected-error {{'x2' consumed more than once}}
     x2 = AggStruct()
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggStructDoubleConsumeArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
 }
 
@@ -859,13 +850,13 @@ public func aggStructLoopConsume() {
     var x2 = AggStruct() // expected-error {{'x2' consumed by a use in a loop}}
     x2 = AggStruct()
     for _ in 0..<1024 {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func aggStructLoopConsumeArg(_ x2: inout AggStruct) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -873,9 +864,9 @@ public func aggStructDiamond() {
     var x2 = AggStruct()
     x2 = AggStruct()
     if boolValue {
-        aggStructConsume(x2)
+        consumeVal(x2)
     } else {
-        aggStructConsume(x2)
+        consumeVal(x2)
     }
 }
 
@@ -883,9 +874,9 @@ public func aggStructDiamondArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     if boolValue {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     } else {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -896,9 +887,9 @@ public func aggStructDiamondInLoop() {
     x2 = AggStruct()
     for _ in 0..<1024 {
       if boolValue {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
           // expected-note @-1 {{consuming use here}}
       }
     }
@@ -909,9 +900,9 @@ public func aggStructDiamondInLoopArg(_ x2: inout AggStruct) {
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
       if boolValue {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
@@ -919,16 +910,16 @@ public func aggStructDiamondInLoopArg(_ x2: inout AggStruct) {
 public func aggStructAccessField() {
     var x2 = AggStruct()
     x2 = AggStruct()
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
 public func aggStructAccessFieldArg(_ x2: inout AggStruct) {
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
@@ -936,9 +927,9 @@ public func aggStructConsumeField() {
     var x2 = AggStruct() // expected-error {{'x2' consumed by a use in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggStruct()
-    classConsume(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
 }
@@ -946,25 +937,25 @@ public func aggStructConsumeField() {
 public func aggStructConsumeFieldArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    classConsume(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consuming use here}}
     }
 }
 
 public func aggStructAccessGrandField() {
     var x2 = AggStruct()
     x2 = AggStruct()
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
 public func aggStructAccessGrandFieldArg(_ x2: inout AggStruct) {
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
@@ -972,9 +963,9 @@ public func aggStructConsumeGrandField() {
     var x2 = AggStruct() // expected-error {{'x2' consumed by a use in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggStruct()
-    classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
 }
@@ -982,9 +973,9 @@ public func aggStructConsumeGrandField() {
 public func aggStructConsumeGrandFieldArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     }
 }
 
@@ -997,6 +988,9 @@ public struct AggGenericStruct<T> {
     var lhs: Klass = Klass()
     var rhs: UnsafeRawPointer? = nil
     var pair: KlassPair = KlassPair()
+
+    // FIXME: this is the only use of the generic parameter and it's totally unused!
+    // What are we testing here that's not covered by the non-generic one?
     var ptr2: UnsafePointer<T>? = nil
 
     init() {}
@@ -1045,219 +1039,214 @@ public struct AggGenericStruct<T> {
     }
 }
 
-public func aggGenericStructUseMoveOnlyWithoutEscaping(_ x: AggGenericStruct<Klass>) {
-}
-public func aggGenericStructConsume(_ x: __owned AggGenericStruct<Klass>) {
-}
-
 public func aggGenericStructSimpleChainTest() {
-    var x2 = AggGenericStruct<Klass>()
-    x2 = AggGenericStruct<Klass>()
+    var x2 = AggGenericStruct<CopyableKlass>()
+    x2 = AggGenericStruct<CopyableKlass>()
     let y2 = x2
     let k2 = y2
-    aggGenericStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg(_ x2: inout AggGenericStruct<Klass>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggGenericStructSimpleChainTestArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
-    aggGenericStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func aggGenericStructSimpleNonConsumingUseTest() {
-    var x2 = AggGenericStruct<Klass>()
-    x2 = AggGenericStruct<Klass>()
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+    var x2 = AggGenericStruct<CopyableKlass>()
+    x2 = AggGenericStruct<CopyableKlass>()
+    borrowVal(x2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<Klass>) {
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+public func aggGenericStructSimpleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
+    borrowVal(x2)
 }
 
 public func aggGenericStructMultipleNonConsumingUseTest() {
-    var x2 = AggGenericStruct<Klass>()
-    x2 = AggGenericStruct<Klass>()
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    var x2 = AggGenericStruct<CopyableKlass>()
+    x2 = AggGenericStruct<CopyableKlass>()
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<Klass>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggGenericStructUseAfterConsume() {
-    var x2 = AggGenericStruct<Klass>() // expected-error {{'x2' consumed more than once}}
-    x2 = AggGenericStruct<Klass>()
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    var x2 = AggGenericStruct<CopyableKlass>() // expected-error {{'x2' consumed more than once}}
+    x2 = AggGenericStruct<CopyableKlass>()
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructUseAfterConsumeArg(_ x2: inout AggGenericStruct<Klass>) {
+public func aggGenericStructUseAfterConsumeArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}x
 }
 
 public func aggGenericStructDoubleConsume() {
-    var x2 = AggGenericStruct<Klass>()  // expected-error {{'x2' consumed more than once}}
-    x2 = AggGenericStruct<Klass>()
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    var x2 = AggGenericStruct<CopyableKlass>()  // expected-error {{'x2' consumed more than once}}
+    x2 = AggGenericStruct<CopyableKlass>()
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsumeArg(_ x2: inout AggGenericStruct<Klass>) {
+public func aggGenericStructDoubleConsumeArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
 }
 
 public func aggGenericStructLoopConsume() {
-    var x2 = AggGenericStruct<Klass>() // expected-error {{'x2' consumed by a use in a loop}}
-    x2 = AggGenericStruct<Klass>()
+    var x2 = AggGenericStruct<CopyableKlass>() // expected-error {{'x2' consumed by a use in a loop}}
+    x2 = AggGenericStruct<CopyableKlass>()
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
-public func aggGenericStructLoopConsumeArg(_ x2: inout AggGenericStruct<Klass>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggGenericStructLoopConsumeArg(_ x2: inout AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func aggGenericStructDiamond() {
-    var x2 = AggGenericStruct<Klass>()
-    x2 = AggGenericStruct<Klass>()
+    var x2 = AggGenericStruct<CopyableKlass>()
+    x2 = AggGenericStruct<CopyableKlass>()
     if boolValue {
-        aggGenericStructConsume(x2)
+        consumeVal(x2)
     } else {
-        aggGenericStructConsume(x2)
+        consumeVal(x2)
     }
 }
 
-public func aggGenericStructDiamondArg(_ x2: inout AggGenericStruct<Klass>) {
+public func aggGenericStructDiamondArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     if boolValue {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     } else {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func aggGenericStructDiamondInLoop() {
-    var x2 = AggGenericStruct<Klass>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<CopyableKlass>() // expected-error {{'x2' consumed by a use in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
-    x2 = AggGenericStruct<Klass>()
+    x2 = AggGenericStruct<CopyableKlass>()
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
           // expected-note @-1 {{consuming use here}}
       }
     }
 }
 
-public func aggGenericStructDiamondInLoopArg(_ x2: inout AggGenericStruct<Klass>) {
+public func aggGenericStructDiamondInLoopArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
 
 public func aggGenericStructAccessField() {
-    var x2 = AggGenericStruct<Klass>()
-    x2 = AggGenericStruct<Klass>()
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    var x2 = AggGenericStruct<CopyableKlass>()
+    x2 = AggGenericStruct<CopyableKlass>()
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
-public func aggGenericStructAccessFieldArg(_ x2: inout AggGenericStruct<Klass>) {
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+public func aggGenericStructAccessFieldArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
 public func aggGenericStructConsumeField() {
-    var x2 = AggGenericStruct<Klass>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<CopyableKlass>() // expected-error {{'x2' consumed by a use in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
-    x2 = AggGenericStruct<Klass>()
-    classConsume(x2.lhs) // expected-note {{consuming use here}}
+    x2 = AggGenericStruct<CopyableKlass>()
+    consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
 }
 
-public func aggGenericStructConsumeFieldArg(_ x2: inout AggGenericStruct<Klass>) {
+public func aggGenericStructConsumeFieldArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    classConsume(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consuming use here}}
     }
 }
 
 public func aggGenericStructAccessGrandField() {
-    var x2 = AggGenericStruct<Klass>()
-    x2 = AggGenericStruct<Klass>()
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    var x2 = AggGenericStruct<CopyableKlass>()
+    x2 = AggGenericStruct<CopyableKlass>()
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
-public func aggGenericStructAccessGrandFieldArg(_ x2: inout AggGenericStruct<Klass>) {
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+public func aggGenericStructAccessGrandFieldArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
 public func aggGenericStructConsumeGrandField() {
-    var x2 = AggGenericStruct<Klass>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<CopyableKlass>() // expected-error {{'x2' consumed by a use in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
-    x2 = AggGenericStruct<Klass>()
-    classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+    x2 = AggGenericStruct<CopyableKlass>()
+    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
 }
 
 public func aggGenericStructConsumeGrandField2() {
-    var x2 = AggGenericStruct<Klass>() // expected-error {{'x2' consumed more than once}}
-    x2 = AggGenericStruct<Klass>()
-    classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+    var x2 = AggGenericStruct<CopyableKlass>() // expected-error {{'x2' consumed more than once}}
+    x2 = AggGenericStruct<CopyableKlass>()
+    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
     }
-    classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructConsumeGrandFieldArg(_ x2: inout AggGenericStruct<Klass>) {
+public func aggGenericStructConsumeGrandFieldArg(_ x2: inout AggGenericStruct<CopyableKlass>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     }
 }
 
@@ -1265,78 +1254,73 @@ public func aggGenericStructConsumeGrandFieldArg(_ x2: inout AggGenericStruct<Kl
 // Aggregate Generic Struct + Generic But Body is Trivial //
 ////////////////////////////////////////////////////////////
 
-public func aggGenericStructUseMoveOnlyWithoutEscaping<T>(_ x: AggGenericStruct<T>) {
-}
-public func aggGenericStructConsume<T>(_ x: __owned AggGenericStruct<T>) {
-}
-
 public func aggGenericStructSimpleChainTest<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>()
     x2 = AggGenericStruct<T>()
     let y2 = x2
     let k2 = y2
-    aggGenericStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func aggGenericStructSimpleChainTestArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
-    aggGenericStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func aggGenericStructSimpleNonConsumingUseTest<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>()
     x2 = AggGenericStruct<T>()
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func aggGenericStructSimpleNonConsumingUseTestArg<T>(_ x2: inout AggGenericStruct<T>) {
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>()
     x2 = AggGenericStruct<T>()
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
 public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: inout AggGenericStruct<T>) { //expected-error {{'x2' consumed but not reinitialized before end of function}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggGenericStructUseAfterConsume<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
 }
 
 public func aggGenericStructDoubleConsume<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
 }
 
@@ -1344,13 +1328,13 @@ public func aggGenericStructLoopConsume<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed by a use in a loop}}
     x2 = AggGenericStruct<T>()
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func aggGenericStructLoopConsumeArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -1358,9 +1342,9 @@ public func aggGenericStructDiamond<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>()
     x2 = AggGenericStruct<T>()
     if boolValue {
-        aggGenericStructConsume(x2)
+        consumeVal(x2)
     } else {
-        aggGenericStructConsume(x2)
+        consumeVal(x2)
     }
 }
 
@@ -1368,9 +1352,9 @@ public func aggGenericStructDiamondArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     if boolValue {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     } else {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -1380,9 +1364,9 @@ public func aggGenericStructDiamondInLoop<T>(_ x: T.Type) {
     x2 = AggGenericStruct<T>()
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
           // expected-note @-1 {{consuming use here}}
       }
     }
@@ -1393,9 +1377,9 @@ public func aggGenericStructDiamondInLoopArg<T>(_ x2: inout AggGenericStruct<T>)
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
@@ -1403,16 +1387,16 @@ public func aggGenericStructDiamondInLoopArg<T>(_ x2: inout AggGenericStruct<T>)
 public func aggGenericStructAccessField<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>()
     x2 = AggGenericStruct<T>()
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
 public func aggGenericStructAccessFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
@@ -1420,9 +1404,9 @@ public func aggGenericStructConsumeField<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed by a use in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
-    classConsume(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
 }
@@ -1430,25 +1414,25 @@ public func aggGenericStructConsumeField<T>(_ x: T.Type) {
 public func aggGenericStructConsumeFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    classConsume(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consuming use here}}
     }
 }
 
 public func aggGenericStructAccessGrandField<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>()
     x2 = AggGenericStruct<T>()
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
 public func aggGenericStructAccessGrandFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
@@ -1456,9 +1440,9 @@ public func aggGenericStructConsumeGrandField<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed by a use in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
-    classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
 }
@@ -1466,9 +1450,9 @@ public func aggGenericStructConsumeGrandField<T>(_ x: T.Type) {
 public func aggGenericStructConsumeGrandFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     }
 }
 
@@ -1484,78 +1468,73 @@ public enum EnumTy {
     func doSomething() -> Bool { true }
 }
 
-public func enumUseMoveOnlyWithoutEscaping(_ x: EnumTy) {
-}
-public func enumConsume(_ x: __owned EnumTy) {
-}
-
 public func enumSimpleChainTest() {
     var x2 = EnumTy.klass(Klass())
     x2 = EnumTy.klass(Klass())
     let y2 = x2
     let k2 = y2
-    enumUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func enumSimpleChainTestArg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
-    enumUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func enumSimpleNonConsumingUseTest() {
     var x2 = EnumTy.klass(Klass())
     x2 = EnumTy.klass(Klass())
-    enumUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func enumSimpleNonConsumingUseTestArg(_ x2: inout EnumTy) {
-    enumUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func enumMultipleNonConsumingUseTest() {
     var x2 = EnumTy.klass(Klass())
     x2 = EnumTy.klass(Klass())
-    enumUseMoveOnlyWithoutEscaping(x2)
-    enumUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
 public func enumMultipleNonConsumingUseTestArg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-    enumUseMoveOnlyWithoutEscaping(x2)
-    enumUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func enumUseAfterConsume() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(Klass())
-    enumUseMoveOnlyWithoutEscaping(x2)
-    enumConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func enumUseAfterConsumeArg(_ x2: inout EnumTy) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    enumUseMoveOnlyWithoutEscaping(x2)
-    enumConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
 }
 
 public func enumDoubleConsume() {
     var x2 = EnumTy.klass(Klass())  // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(Klass())
-    enumConsume(x2) // expected-note {{consuming use here}}
-    enumConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func enumDoubleConsumeArg(_ x2: inout EnumTy) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}} 
-    enumConsume(x2) // expected-note {{consuming use here}}
-    enumConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
 }
 
@@ -1563,13 +1542,13 @@ public func enumLoopConsume() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed by a use in a loop}}
     x2 = EnumTy.klass(Klass())
     for _ in 0..<1024 {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func enumLoopConsumeArg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -1577,9 +1556,9 @@ public func enumDiamond() {
     var x2 = EnumTy.klass(Klass())
     x2 = EnumTy.klass(Klass())
     if boolValue {
-        enumConsume(x2)
+        consumeVal(x2)
     } else {
-        enumConsume(x2)
+        consumeVal(x2)
     }
 }
 
@@ -1587,9 +1566,9 @@ public func enumDiamondArg(_ x2: inout EnumTy) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     if boolValue {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     } else {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -1600,9 +1579,9 @@ public func enumDiamondInLoop() {
     x2 = EnumTy.klass(Klass())
     for _ in 0..<1024 {
       if boolValue {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
           // expected-note @-1 {{consuming use here}}
       }
     }
@@ -1613,9 +1592,9 @@ public func enumDiamondInLoopArg(_ x2: inout EnumTy) {
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
       if boolValue {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
@@ -1626,7 +1605,7 @@ public func enumAssignToVar1() {
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = EnumTy.klass(Klass())
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar1Arg(_ x2: inout EnumTy) {
@@ -1637,7 +1616,7 @@ public func enumAssignToVar1Arg(_ x2: inout EnumTy) {
     x3 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
     x3 = EnumTy.klass(Klass())
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar2() {
@@ -1645,7 +1624,7 @@ public func enumAssignToVar2() {
     x2 = EnumTy.klass(Klass())
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
-    enumUseMoveOnlyWithoutEscaping(x3)
+    borrowVal(x3)
 }
 
 public func enumAssignToVar2Arg(_ x2: inout EnumTy) {
@@ -1654,7 +1633,7 @@ public func enumAssignToVar2Arg(_ x2: inout EnumTy) {
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
      // expected-note @-1 {{consuming use here}}
-    enumUseMoveOnlyWithoutEscaping(x3)
+    borrowVal(x3)
 }
 
 public func enumAssignToVar3() {
@@ -1662,55 +1641,55 @@ public func enumAssignToVar3() {
     x2 = EnumTy.klass(Klass())
     var x3 = x2
     x3 = EnumTy.klass(Klass())
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar3Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
                                                             
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = EnumTy.klass(Klass())
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar4() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(Klass())
     let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x3)
 }
 
 public func enumAssignToVar4Arg(_ x2: inout EnumTy) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}} 
     let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar5() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
     x2 = EnumTy.klass(Klass())
     var x3 = x2 // expected-note {{consuming use here}}
-    enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = EnumTy.klass(Klass())
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar5Arg(_ x2: inout EnumTy) {
     // expected-error @-1 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
     var x3 = x2 // expected-note {{consuming use here}}
-    enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+    borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = EnumTy.klass(Klass())
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar5Arg2(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
                                                             
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = EnumTy.klass(Klass())
-    print(x3)
+    consumeVal(x3)
 }
 
 
@@ -1718,10 +1697,10 @@ public func enumPatternMatchIfLet1() {
     var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(Klass())
     if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x)
+        borrowVal(x)
     }
     if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x)
+        borrowVal(x)
     }
 }
 
@@ -1729,11 +1708,11 @@ public func enumPatternMatchIfLet1Arg(_ x2: inout EnumTy) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}}
     if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x)
+        borrowVal(x)
     }
     if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x)
+        borrowVal(x)
     }
 }
 
@@ -1742,7 +1721,7 @@ public func enumPatternMatchIfLet2() {
     x2 = EnumTy.klass(Klass())
     for _ in 0..<1024 {
         if case let EnumTy.klass(x) = x2 {  // expected-note {{consuming use here}}
-            classUseMoveOnlyWithoutEscaping(x)
+            borrowVal(x)
         }
     }
 }
@@ -1750,7 +1729,7 @@ public func enumPatternMatchIfLet2() {
 public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
         if case let EnumTy.klass(x) = x2 {  // expected-note {{consuming use here}}
-            classUseMoveOnlyWithoutEscaping(x)
+            borrowVal(x)
         }
     }
 }
@@ -1761,10 +1740,10 @@ public func enumPatternMatchSwitch1() {
     x2 = EnumTy.klass(Klass())
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k):
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
         // This should be flagged as the use after free use. We are atleast
         // erroring though.
-        enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
+        borrowVal(x2) // expected-note {{non-consuming use here}}
     case .int:
         break
     }
@@ -1773,10 +1752,10 @@ public func enumPatternMatchSwitch1() {
 public func enumPatternMatchSwitch1Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k):
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
         // This should be flagged as the use after free use. We are atleast
         // erroring though.
-        enumUseMoveOnlyWithoutEscaping(x2)
+        borrowVal(x2)
     case .int:
         break
     }
@@ -1787,7 +1766,7 @@ public func enumPatternMatchSwitch2() {
     x2 = EnumTy.klass(Klass())
     switch x2 {
     case let EnumTy.klass(k):
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     }
@@ -1796,7 +1775,7 @@ public func enumPatternMatchSwitch2() {
 public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k):
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     }
@@ -1809,7 +1788,7 @@ public func enumPatternMatchSwitch2WhereClause() {
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k)
            where x2.doSomething(): // expected-note {{non-consuming use here}}
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     case EnumTy.klass:
@@ -1821,7 +1800,7 @@ public func enumPatternMatchSwitch2WhereClauseArg(_ x2: inout EnumTy) { // expec
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k)
            where x2.doSomething():
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     case EnumTy.klass:
@@ -1835,7 +1814,7 @@ public func enumPatternMatchSwitch2WhereClause2() {
     switch x2 {
     case let EnumTy.klass(k)
            where boolValue:
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     case EnumTy.klass:
@@ -1847,7 +1826,7 @@ public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: inout EnumTy) { // expe
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k)
            where boolValue:
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     case EnumTy.klass:
@@ -1863,9 +1842,9 @@ public func closureClassUseAfterConsume1() {
     let f = {
         var x2 = Klass() // expected-error {{'x2' consumed more than once}}
         x2 = Klass()
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f()
 }
@@ -1874,9 +1853,9 @@ public func closureClassUseAfterConsume2() {
     let f = { () in
         var x2 = Klass() // expected-error {{'x2' consumed more than once}}
         x2 = Klass()
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f()
 }
@@ -1886,9 +1865,9 @@ public func closureClassUseAfterConsumeArg(_ argX: inout Klass) {
     let f = { (_ x2: inout Klass) in
         // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
         // expected-error @-2 {{'x2' consumed more than once}}
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
     f(&argX)
@@ -1906,11 +1885,11 @@ public func closureCaptureClassUseAfterConsume() {
     // expected-error @-5 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = Klass()
     let f = {
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
+        borrowVal(x2)
+        consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
-        print(x2)
+        consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
         // expected-note @-3 {{consuming use here}}
@@ -1926,8 +1905,8 @@ public func closureCaptureClassUseAfterConsume2() {
     // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = Klass()
     let f = {
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
+        borrowVal(x2)
+        consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
     }
@@ -1943,11 +1922,11 @@ public func closureCaptureClassUseAfterConsumeError() {
     // expected-error @-5 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = Klass()
     let f = {
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
+        borrowVal(x2)
+        consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
-        print(x2)
+        consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
         // expected-note @-3 {{consuming use here}}
@@ -1965,10 +1944,10 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
     // expected-note @-4 {{'x2' is declared 'inout'}}
     let f = { // expected-note {{consuming use here}}
         // expected-error @-1 {{escaping closure captures 'inout' parameter 'x2'}}
-        classUseMoveOnlyWithoutEscaping(x2) // expected-note {{captured here}}
-        classConsume(x2) // expected-note {{captured here}}
+        borrowVal(x2) // expected-note {{captured here}}
+        consumeVal(x2) // expected-note {{captured here}}
         // expected-note @-1 {{consuming use here}}
-        print(x2) // expected-note {{captured here}}
+        consumeVal(x2) // expected-note {{captured here}}
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
     }
@@ -1982,13 +1961,13 @@ public func deferCaptureClassUseAfterConsume() {
     // expected-error @-3 {{'x2' consumed more than once}}
     x2 = Klass()
     defer { // expected-note {{non-consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2)
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
     }
-    print(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func deferCaptureClassUseAfterConsume2() {
@@ -1998,9 +1977,9 @@ public func deferCaptureClassUseAfterConsume2() {
     // expected-error @-3 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
     x2 = Klass()
     defer { // expected-note {{non-consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
     let x3 = x2 // expected-note {{consuming use here}}
@@ -2010,11 +1989,11 @@ public func deferCaptureClassUseAfterConsume2() {
 public func deferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    classUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
     defer {
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
     print("foo")
@@ -2028,9 +2007,9 @@ public func closureAndDeferCaptureClassUseAfterConsume() {
     x2 = Klass()
     let f = {
         defer {
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) // expected-note {{consuming use here}}
-            print(x2)
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{consuming use here}}
         }
@@ -2048,15 +2027,15 @@ public func closureAndDeferCaptureClassUseAfterConsume2() {
     // expected-error @-5 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
     x2 = Klass()
     let f = {
-        classConsume(x2)
+        consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
         defer {
             // expected-note @-1 {{non-consuming use here}}
             // expected-note @-2 {{non-consuming use here}}
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) // expected-note {{consuming use here}}
-            print(x2)
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{consuming use here}}
         }
@@ -2074,22 +2053,22 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
     // expected-error @-5 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
     x2 = Klass()
     let f = {
-        classConsume(x2)
+        consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
         defer {
             // expected-note @-1 {{non-consuming use here}}
             // expected-note @-2 {{non-consuming use here}}
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) // expected-note {{consuming use here}}
-            print(x2)
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{consuming use here}}
         }
         print("foo")
     }
     f()
-    classConsume(x2)
+    consumeVal(x2)
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
@@ -2100,10 +2079,10 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
               // expected-note @-1 {{consuming use here}}
         defer { // expected-note {{captured indirectly by this call}}
-            classUseMoveOnlyWithoutEscaping(x2) // expected-note {{captured here}}
-            classConsume(x2) // expected-note {{captured here}}
+            borrowVal(x2) // expected-note {{captured here}}
+            consumeVal(x2) // expected-note {{captured here}}
             // expected-note @-1 {{consuming use here}}
-            print(x2) // expected-note {{captured here}}
+            consumeVal(x2) // expected-note {{captured here}}
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{consuming use here}}
         }
@@ -2124,11 +2103,11 @@ public func closureAndClosureCaptureClassUseAfterConsume() {
     x2 = Klass()
     let f = {
         let g = {
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
+            borrowVal(x2)
+            consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{consuming use here}}
-            print(x2)
+            consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{consuming use here}}
             // expected-note @-3 {{consuming use here}}
@@ -2151,11 +2130,11 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
     x2 = Klass()
     let f = {
         let g = {
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
+            borrowVal(x2)
+            consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{consuming use here}}
-            print(x2)
+            consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{consuming use here}}
             // expected-note @-3 {{consuming use here}}
@@ -2164,7 +2143,7 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
         g()
     }
     f()
-    print(x2)
+    consumeVal(x2)
 }
 
 
@@ -2180,14 +2159,14 @@ public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
         let g = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{captured indirectly by this call}}
-            classUseMoveOnlyWithoutEscaping(x2)
+            borrowVal(x2)
             // expected-note @-1 {{captured here}}
             // expected-note @-2 {{captured here}}
-            classConsume(x2)
+            consumeVal(x2)
             // expected-note @-1 {{captured here}}
             // expected-note @-2 {{captured here}}
             // expected-note @-3 {{consuming use here}}
-            print(x2)
+            consumeVal(x2)
             // expected-note @-1 {{captured here}}
             // expected-note @-2 {{captured here}}
             // expected-note @-3 {{consuming use here}}
@@ -2255,26 +2234,26 @@ func blackHoleKlassTestCase(_ k: __owned Klass) {
 func copyableKlassInAMoveOnlyStruct() {
     var a = NonTrivialStruct()
     a = NonTrivialStruct()
-    copyableClassUseMoveOnlyWithoutEscaping(a.copyableK)
-    copyableClassConsume(a.copyableK)
+    borrowVal(a.copyableK)
+    consumeVal(a.copyableK)
 }
 
 // This shouldn't error since we are consuming a copyable type.
 func copyableKlassInAMoveOnlyStruct2() {
     var a = NonTrivialStruct()
     a = NonTrivialStruct()
-    copyableClassUseMoveOnlyWithoutEscaping(a.copyableK)
-    copyableClassConsume(a.copyableK)
-    copyableClassConsume(a.copyableK)
+    borrowVal(a.copyableK)
+    consumeVal(a.copyableK)
+    consumeVal(a.copyableK)
 }
 
 // This shouldn't error since we are working with a copyable type.
 func copyableKlassInAMoveOnlyStruct3() {
     var a = NonTrivialStruct()
     a = NonTrivialStruct()
-    copyableClassUseMoveOnlyWithoutEscaping(a.copyableK)
-    copyableClassConsume(a.copyableK)
-    copyableClassUseMoveOnlyWithoutEscaping(a.copyableK)
+    borrowVal(a.copyableK)
+    consumeVal(a.copyableK)
+    borrowVal(a.copyableK)
 }
 
 // This used to error, but no longer errors since we are using a true field
@@ -2282,19 +2261,19 @@ func copyableKlassInAMoveOnlyStruct3() {
 func copyableKlassInAMoveOnlyStruct4() {
     var a = NonTrivialStruct()
     a = NonTrivialStruct()
-    copyableClassUseMoveOnlyWithoutEscaping(a.copyableK)
-    copyableClassConsume(a.copyableK)
-    nonConsumingUseNonTrivialStruct2(a.nonTrivialStruct2)
+    borrowVal(a.copyableK)
+    consumeVal(a.copyableK)
+    borrowVal(a.nonTrivialStruct2)
 }
 
 func copyableStructsInMoveOnlyStructNonConsuming() {
     var a = NonTrivialStruct()
     a = NonTrivialStruct()
-    nonConsumingUseNonTrivialStruct(a)
-    nonConsumingUseNonTrivialStruct2(a.nonTrivialStruct2)
-    nonConsumingUseNonTrivialCopyableStruct(a.nonTrivialCopyableStruct)
-    nonConsumingUseNonTrivialCopyableStruct2(a.nonTrivialCopyableStruct.nonTrivialCopyableStruct2)
-    copyableClassUseMoveOnlyWithoutEscaping(a.nonTrivialCopyableStruct.nonTrivialCopyableStruct2.copyableKlass)
+    borrowVal(a)
+    borrowVal(a.nonTrivialStruct2)
+    borrowVal(a.nonTrivialCopyableStruct)
+    borrowVal(a.nonTrivialCopyableStruct.nonTrivialCopyableStruct2)
+    borrowVal(a.nonTrivialCopyableStruct.nonTrivialCopyableStruct2.copyableKlass)
 }
 
 ///////////////////////////
@@ -2304,38 +2283,38 @@ func copyableStructsInMoveOnlyStructNonConsuming() {
 func fieldSensitiveTestReinitField() {
     var a = NonTrivialStruct()
     a = NonTrivialStruct()
-    classConsume(a.k)
+    consumeVal(a.k)
     a.k = Klass()
-    classUseMoveOnlyWithoutEscaping(a.k)
+    borrowVal(a.k)
 }
 
 func fieldSensitiveTestReinitFieldMultiBlock1() {
     var a = NonTrivialStruct()
     a = NonTrivialStruct()
-    classConsume(a.k)
+    consumeVal(a.k)
 
     if boolValue {
         a.k = Klass()
-        classUseMoveOnlyWithoutEscaping(a.k)
+        borrowVal(a.k)
     }
 }
 
 func fieldSensitiveTestReinitFieldMultiBlock2() {
     var a = NonTrivialStruct() // expected-error {{'a' used after consume. Lifetime extension of variable requires a copy}}
     a = NonTrivialStruct()
-    classConsume(a.k) // expected-note {{consuming use here}}
+    consumeVal(a.k) // expected-note {{consuming use here}}
 
     if boolValue {
         a.k = Klass()
     }
 
-    classUseMoveOnlyWithoutEscaping(a.k) // expected-note {{non-consuming use here}}
+    borrowVal(a.k) // expected-note {{non-consuming use here}}
 }
 
 func fieldSensitiveTestReinitFieldMultiBlock3() {
     var a = NonTrivialStruct()
     a = NonTrivialStruct()
-    classConsume(a.k)
+    consumeVal(a.k)
 
     if boolValue {
         a.k = Klass()
@@ -2343,7 +2322,7 @@ func fieldSensitiveTestReinitFieldMultiBlock3() {
         a.k = Klass()
     }
 
-    classUseMoveOnlyWithoutEscaping(a.k)
+    borrowVal(a.k)
 }
 
 // This test sees what happens if we partially reinit along one path and do a
@@ -2351,7 +2330,7 @@ func fieldSensitiveTestReinitFieldMultiBlock3() {
 func fieldSensitiveTestReinitFieldMultiBlock4() {
     var a = NonTrivialStruct()
     a = NonTrivialStruct()
-    classConsume(a.k)
+    consumeVal(a.k)
 
     if boolValue {
         a.k = Klass()
@@ -2359,7 +2338,7 @@ func fieldSensitiveTestReinitFieldMultiBlock4() {
         a = NonTrivialStruct()
     }
 
-    classUseMoveOnlyWithoutEscaping(a.k)
+    borrowVal(a.k)
 }
 
 func fieldSensitiveTestReinitEnumMultiBlock() {
@@ -2371,7 +2350,7 @@ func fieldSensitiveTestReinitEnumMultiBlock() {
     default:
         break
     }
-    nonConsumingUseNonTrivialEnum(e) // expected-note {{non-consuming use here}}
+    borrowVal(e) // expected-note {{non-consuming use here}}
 }
 
 func fieldSensitiveTestReinitEnumMultiBlock1() {
@@ -2383,7 +2362,7 @@ func fieldSensitiveTestReinitEnumMultiBlock1() {
     default:
         e = NonTrivialEnum.fourth(CopyableKlass())
     }
-    nonConsumingUseNonTrivialEnum(e)
+    borrowVal(e)
 }
 
 func fieldSensitiveTestReinitEnumMultiBlock2() {
@@ -2399,5 +2378,5 @@ func fieldSensitiveTestReinitEnumMultiBlock2() {
     } else {
         e = NonTrivialEnum.third(NonTrivialStruct())
     }
-    nonConsumingUseNonTrivialEnum(e)
+    borrowVal(e)
 }

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-sil -verify -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s
+// RUN: %target-swift-emit-sil -verify -enable-experimental-move-only %s
 
 //////////////////
 // Declarations //
@@ -11,17 +11,21 @@ public struct NonTrivialStruct {
     var i: Int = 0
 }
 
-public func nonConsumingUseNonTrivialStruct(_ s: NonTrivialStruct) {}
-public func classUseMoveOnlyWithoutEscaping(_ x: Int) {
-}
-public func classUseMoveOnlyWithoutEscaping(_ x: MoveOnlyInt) {
-}
-public func classUseMoveOnlyWithoutEscaping(_ x: NonTrivialStruct) {
-}
-public func classConsume(_ x: Int) {}
-public func classConsume(_ x: __owned MoveOnlyInt) {}
-public func classConsume(_ x: __owned NonTrivialStruct) {
-}
+public func borrowVal(_ x: __shared Int) {}
+public func borrowVal(_ x: __shared MoveOnlyInt) {}
+public func borrowVal(_ x: __shared NonTrivialStruct) {}
+public func borrowVal(_ x: __shared AggStruct) {}
+public func borrowVal(_ x: __shared AggGenericStruct<String>) {}
+public func borrowVal<T>(_ x: __shared AggGenericStruct<T>) {}
+public func borrowVal(_ x: __shared EnumTy) {}
+
+public func consumeVal(_ x: __owned Int) {}
+public func consumeVal(_ x: __owned MoveOnlyInt) {}
+public func consumeVal(_ x: __owned NonTrivialStruct) {}
+public func consumeVal(_ x: __owned EnumTy) {}
+public func consumeVal(_ x: __owned AggStruct) {}
+public func consumeVal(_ x: __owned AggGenericStruct<String>) {}
+public func consumeVal<T>(_ x: __owned AggGenericStruct<T>) {}
 
 @_moveOnly
 public enum NonTrivialEnum {
@@ -29,8 +33,6 @@ public enum NonTrivialEnum {
     case second(Int)
     case third(NonTrivialStruct)
 }
-
-public func nonConsumingUseNonTrivialEnum(_ e : NonTrivialEnum) {}
 
 ///////////
 // Tests //
@@ -104,17 +106,12 @@ public struct AggStruct {
     }
 }
 
-public func aggStructUseMoveOnlyWithoutEscaping(_ x: AggStruct) {
-}
-public func aggStructConsume(_ x: __owned AggStruct) {
-}
-
 public func aggStructSimpleChainTest() {
     var x2 = AggStruct()
     x2 = AggStruct()
     let y2 = x2
     let k2 = y2
-    aggStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func aggStructSimpleChainTestArg(_ x2: inout AggStruct) {
@@ -124,62 +121,62 @@ public func aggStructSimpleChainTestArg(_ x2: inout AggStruct) {
     y2 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
     let k2 = y2
-    aggStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func aggStructSimpleNonConsumingUseTest() {
     var x2 = AggStruct()
     x2 = AggStruct()
-    aggStructUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func aggStructSimpleNonConsumingUseTestArg(_ x2: inout AggStruct) {
-    aggStructUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func aggStructMultipleNonConsumingUseTest() {
     var x2 = AggStruct()
     x2 = AggStruct()
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
 public func aggStructMultipleNonConsumingUseTestArg(_ x2: inout AggStruct) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggStructUseAfterConsume() {
     var x2 = AggStruct() // expected-error {{'x2' consumed more than once}}
     x2 = AggStruct()
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggStructUseAfterConsumeArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
               // expected-note @-1 {{consuming use here}}
 }
 
 public func aggStructDoubleConsume() {
     var x2 = AggStruct()  // expected-error {{'x2' consumed more than once}}
     x2 = AggStruct()
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggStructDoubleConsumeArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
 }
 
@@ -187,13 +184,13 @@ public func aggStructLoopConsume() {
     var x2 = AggStruct() // expected-error {{'x2' consumed by a use in a loop}}
     x2 = AggStruct()
     for _ in 0..<1024 {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func aggStructLoopConsumeArg(_ x2: inout AggStruct) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -201,9 +198,9 @@ public func aggStructDiamond() {
     var x2 = AggStruct()
     x2 = AggStruct()
     if boolValue {
-        aggStructConsume(x2)
+        consumeVal(x2)
     } else {
-        aggStructConsume(x2)
+        consumeVal(x2)
     }
 }
 
@@ -211,9 +208,9 @@ public func aggStructDiamondArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     if boolValue {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     } else {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -224,9 +221,9 @@ public func aggStructDiamondInLoop() {
     x2 = AggStruct()
     for _ in 0..<1024 {
       if boolValue {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
           // expected-note @-1 {{consuming use here}}
       }
     }
@@ -237,9 +234,9 @@ public func aggStructDiamondInLoopArg(_ x2: inout AggStruct) {
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
       if boolValue {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
@@ -247,16 +244,16 @@ public func aggStructDiamondInLoopArg(_ x2: inout AggStruct) {
 public func aggStructAccessField() {
     var x2 = AggStruct()
     x2 = AggStruct()
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
 public func aggStructAccessFieldArg(_ x2: inout AggStruct) {
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
@@ -264,9 +261,9 @@ public func aggStructConsumeField() {
     var x2 = AggStruct() // expected-error {{'x2' consumed by a use in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggStruct()
-    classConsume(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
 }
@@ -274,25 +271,25 @@ public func aggStructConsumeField() {
 public func aggStructConsumeFieldArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    classConsume(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consuming use here}}
     }
 }
 
 public func aggStructAccessGrandField() {
     var x2 = AggStruct()
     x2 = AggStruct()
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
 public func aggStructAccessGrandFieldArg(_ x2: inout AggStruct) {
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
@@ -300,9 +297,9 @@ public func aggStructConsumeGrandField() {
     var x2 = AggStruct() // expected-error {{'x2' consumed by a use in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggStruct()
-    classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
 }
@@ -310,9 +307,9 @@ public func aggStructConsumeGrandField() {
 public func aggStructConsumeGrandFieldArg(_ x2: inout AggStruct) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     }
 }
 
@@ -321,7 +318,7 @@ public func aggStructConsumeGrandFieldArg(_ x2: inout AggStruct) {
 //////////////////////////////
 
 @_moveOnly
-public struct AggGenericStruct<T> {
+public struct AggGenericStruct<T> { // FIXME: this generic parameter should probably be used for better coverage.
     var lhs = MoveOnlyInt(value: 5)
     var rhs: UnsafeRawPointer? = nil
     var pair = KlassPair(lhs: MoveOnlyInt(value: 5), rhs: 6)
@@ -374,219 +371,214 @@ public struct AggGenericStruct<T> {
     }
 }
 
-public func aggGenericStructUseMoveOnlyWithoutEscaping(_ x: AggGenericStruct<NonTrivialStruct>) {
-}
-public func aggGenericStructConsume(_ x: __owned AggGenericStruct<NonTrivialStruct>) {
-}
-
 public func aggGenericStructSimpleChainTest() {
-    var x2 = AggGenericStruct<NonTrivialStruct>()
-    x2 = AggGenericStruct<NonTrivialStruct>()
+    var x2 = AggGenericStruct<String>()
+    x2 = AggGenericStruct<String>()
     let y2 = x2
     let k2 = y2
-    aggGenericStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg(_ x2: inout AggGenericStruct<NonTrivialStruct>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggGenericStructSimpleChainTestArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
-    aggGenericStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func aggGenericStructSimpleNonConsumingUseTest() {
-    var x2 = AggGenericStruct<NonTrivialStruct>()
-    x2 = AggGenericStruct<NonTrivialStruct>()
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+    var x2 = AggGenericStruct<String>()
+    x2 = AggGenericStruct<String>()
+    borrowVal(x2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<NonTrivialStruct>) {
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+public func aggGenericStructSimpleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<String>) {
+    borrowVal(x2)
 }
 
 public func aggGenericStructMultipleNonConsumingUseTest() {
-    var x2 = AggGenericStruct<NonTrivialStruct>()
-    x2 = AggGenericStruct<NonTrivialStruct>()
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    var x2 = AggGenericStruct<String>()
+    x2 = AggGenericStruct<String>()
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<NonTrivialStruct>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggGenericStructUseAfterConsume() {
-    var x2 = AggGenericStruct<NonTrivialStruct>() // expected-error {{'x2' consumed more than once}}
-    x2 = AggGenericStruct<NonTrivialStruct>()
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    var x2 = AggGenericStruct<String>() // expected-error {{'x2' consumed more than once}}
+    x2 = AggGenericStruct<String>()
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructUseAfterConsumeArg(_ x2: inout AggGenericStruct<NonTrivialStruct>) {
+public func aggGenericStructUseAfterConsumeArg(_ x2: inout AggGenericStruct<String>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}x
 }
 
 public func aggGenericStructDoubleConsume() {
-    var x2 = AggGenericStruct<NonTrivialStruct>()  // expected-error {{'x2' consumed more than once}}
-    x2 = AggGenericStruct<NonTrivialStruct>()
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    var x2 = AggGenericStruct<String>()  // expected-error {{'x2' consumed more than once}}
+    x2 = AggGenericStruct<String>()
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsumeArg(_ x2: inout AggGenericStruct<NonTrivialStruct>) {
+public func aggGenericStructDoubleConsumeArg(_ x2: inout AggGenericStruct<String>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
 }
 
 public func aggGenericStructLoopConsume() {
-    var x2 = AggGenericStruct<NonTrivialStruct>() // expected-error {{'x2' consumed by a use in a loop}}
-    x2 = AggGenericStruct<NonTrivialStruct>()
+    var x2 = AggGenericStruct<String>() // expected-error {{'x2' consumed by a use in a loop}}
+    x2 = AggGenericStruct<String>()
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
-public func aggGenericStructLoopConsumeArg(_ x2: inout AggGenericStruct<NonTrivialStruct>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func aggGenericStructLoopConsumeArg(_ x2: inout AggGenericStruct<String>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func aggGenericStructDiamond() {
-    var x2 = AggGenericStruct<NonTrivialStruct>()
-    x2 = AggGenericStruct<NonTrivialStruct>()
+    var x2 = AggGenericStruct<String>()
+    x2 = AggGenericStruct<String>()
     if boolValue {
-        aggGenericStructConsume(x2)
+        consumeVal(x2)
     } else {
-        aggGenericStructConsume(x2)
+        consumeVal(x2)
     }
 }
 
-public func aggGenericStructDiamondArg(_ x2: inout AggGenericStruct<NonTrivialStruct>) {
+public func aggGenericStructDiamondArg(_ x2: inout AggGenericStruct<String>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     if boolValue {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     } else {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func aggGenericStructDiamondInLoop() {
-    var x2 = AggGenericStruct<NonTrivialStruct>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<String>() // expected-error {{'x2' consumed by a use in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
-    x2 = AggGenericStruct<NonTrivialStruct>()
+    x2 = AggGenericStruct<String>()
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
           // expected-note @-1 {{consuming use here}}
       }
     }
 }
 
-public func aggGenericStructDiamondInLoopArg(_ x2: inout AggGenericStruct<NonTrivialStruct>) {
+public func aggGenericStructDiamondInLoopArg(_ x2: inout AggGenericStruct<String>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
 
 public func aggGenericStructAccessField() {
-    var x2 = AggGenericStruct<NonTrivialStruct>()
-    x2 = AggGenericStruct<NonTrivialStruct>()
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    var x2 = AggGenericStruct<String>()
+    x2 = AggGenericStruct<String>()
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
-public func aggGenericStructAccessFieldArg(_ x2: inout AggGenericStruct<NonTrivialStruct>) {
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+public func aggGenericStructAccessFieldArg(_ x2: inout AggGenericStruct<String>) {
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
 public func aggGenericStructConsumeField() {
-    var x2 = AggGenericStruct<NonTrivialStruct>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<String>() // expected-error {{'x2' consumed by a use in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
-    x2 = AggGenericStruct<NonTrivialStruct>()
-    classConsume(x2.lhs) // expected-note {{consuming use here}}
+    x2 = AggGenericStruct<String>()
+    consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
 }
 
-public func aggGenericStructConsumeFieldArg(_ x2: inout AggGenericStruct<NonTrivialStruct>) {
+public func aggGenericStructConsumeFieldArg(_ x2: inout AggGenericStruct<String>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    classConsume(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consuming use here}}
     }
 }
 
 public func aggGenericStructAccessGrandField() {
-    var x2 = AggGenericStruct<NonTrivialStruct>()
-    x2 = AggGenericStruct<NonTrivialStruct>()
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    var x2 = AggGenericStruct<String>()
+    x2 = AggGenericStruct<String>()
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
-public func aggGenericStructAccessGrandFieldArg(_ x2: inout AggGenericStruct<NonTrivialStruct>) {
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+public func aggGenericStructAccessGrandFieldArg(_ x2: inout AggGenericStruct<String>) {
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
 public func aggGenericStructConsumeGrandField() {
-    var x2 = AggGenericStruct<NonTrivialStruct>() // expected-error {{'x2' consumed by a use in a loop}}
+    var x2 = AggGenericStruct<String>() // expected-error {{'x2' consumed by a use in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
-    x2 = AggGenericStruct<NonTrivialStruct>()
-    classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+    x2 = AggGenericStruct<String>()
+    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
 }
 
 public func aggGenericStructConsumeGrandField2() {
-    var x2 = AggGenericStruct<NonTrivialStruct>() // expected-error {{'x2' consumed more than once}}
-    x2 = AggGenericStruct<NonTrivialStruct>()
-    classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+    var x2 = AggGenericStruct<String>() // expected-error {{'x2' consumed more than once}}
+    x2 = AggGenericStruct<String>()
+    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
     }
-    classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructConsumeGrandFieldArg(_ x2: inout AggGenericStruct<NonTrivialStruct>) {
+public func aggGenericStructConsumeGrandFieldArg(_ x2: inout AggGenericStruct<String>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     }
 }
 
@@ -594,78 +586,73 @@ public func aggGenericStructConsumeGrandFieldArg(_ x2: inout AggGenericStruct<No
 // Aggregate Generic Struct + Generic But Body is Trivial //
 ////////////////////////////////////////////////////////////
 
-public func aggGenericStructUseMoveOnlyWithoutEscaping<T>(_ x: AggGenericStruct<T>) {
-}
-public func aggGenericStructConsume<T>(_ x: __owned AggGenericStruct<T>) {
-}
-
 public func aggGenericStructSimpleChainTest<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>()
     x2 = AggGenericStruct<T>()
     let y2 = x2
     let k2 = y2
-    aggGenericStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func aggGenericStructSimpleChainTestArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
-    aggGenericStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func aggGenericStructSimpleNonConsumingUseTest<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>()
     x2 = AggGenericStruct<T>()
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func aggGenericStructSimpleNonConsumingUseTestArg<T>(_ x2: inout AggGenericStruct<T>) {
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>()
     x2 = AggGenericStruct<T>()
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
 public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: inout AggGenericStruct<T>) { //expected-error {{'x2' consumed but not reinitialized before end of function}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggGenericStructUseAfterConsume<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
 }
 
 public func aggGenericStructDoubleConsume<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
 }
 
@@ -673,13 +660,13 @@ public func aggGenericStructLoopConsume<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed by a use in a loop}}
     x2 = AggGenericStruct<T>()
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func aggGenericStructLoopConsumeArg<T>(_ x2: inout AggGenericStruct<T>) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -687,9 +674,9 @@ public func aggGenericStructDiamond<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>()
     x2 = AggGenericStruct<T>()
     if boolValue {
-        aggGenericStructConsume(x2)
+        consumeVal(x2)
     } else {
-        aggGenericStructConsume(x2)
+        consumeVal(x2)
     }
 }
 
@@ -697,9 +684,9 @@ public func aggGenericStructDiamondArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     if boolValue {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     } else {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -709,9 +696,9 @@ public func aggGenericStructDiamondInLoop<T>(_ x: T.Type) {
     x2 = AggGenericStruct<T>()
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
           // expected-note @-1 {{consuming use here}}
       }
     }
@@ -722,9 +709,9 @@ public func aggGenericStructDiamondInLoopArg<T>(_ x2: inout AggGenericStruct<T>)
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
@@ -732,16 +719,16 @@ public func aggGenericStructDiamondInLoopArg<T>(_ x2: inout AggGenericStruct<T>)
 public func aggGenericStructAccessField<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>()
     x2 = AggGenericStruct<T>()
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
 public func aggGenericStructAccessFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
@@ -749,9 +736,9 @@ public func aggGenericStructConsumeField<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed by a use in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
-    classConsume(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
 }
@@ -759,25 +746,25 @@ public func aggGenericStructConsumeField<T>(_ x: T.Type) {
 public func aggGenericStructConsumeFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    classConsume(x2.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.lhs) // expected-note {{consuming use here}}
     }
 }
 
 public func aggGenericStructAccessGrandField<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>()
     x2 = AggGenericStruct<T>()
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
 public func aggGenericStructAccessGrandFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
@@ -785,9 +772,9 @@ public func aggGenericStructConsumeGrandField<T>(_ x: T.Type) {
     var x2 = AggGenericStruct<T>() // expected-error {{'x2' consumed by a use in a loop}}
     // expected-error @-1 {{'x2' consumed more than once}}
     x2 = AggGenericStruct<T>()
-    classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
 }
@@ -795,9 +782,9 @@ public func aggGenericStructConsumeGrandField<T>(_ x: T.Type) {
 public func aggGenericStructConsumeGrandFieldArg<T>(_ x2: inout AggGenericStruct<T>) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+    consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs) // expected-note {{consuming use here}}
+        consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     }
 }
 
@@ -813,78 +800,73 @@ public enum EnumTy {
     func doSomething() -> Bool { true }
 }
 
-public func enumUseMoveOnlyWithoutEscaping(_ x: EnumTy) {
-}
-public func enumConsume(_ x: __owned EnumTy) {
-}
-
 public func enumSimpleChainTest() {
     var x2 = EnumTy.klass(NonTrivialStruct())
     x2 = EnumTy.klass(NonTrivialStruct())
     let y2 = x2
     let k2 = y2
-    enumUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func enumSimpleChainTestArg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
-    enumUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func enumSimpleNonConsumingUseTest() {
     var x2 = EnumTy.klass(NonTrivialStruct())
     x2 = EnumTy.klass(NonTrivialStruct())
-    enumUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func enumSimpleNonConsumingUseTestArg(_ x2: inout EnumTy) {
-    enumUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func enumMultipleNonConsumingUseTest() {
     var x2 = EnumTy.klass(NonTrivialStruct())
     x2 = EnumTy.klass(NonTrivialStruct())
-    enumUseMoveOnlyWithoutEscaping(x2)
-    enumUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
 public func enumMultipleNonConsumingUseTestArg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
-    enumUseMoveOnlyWithoutEscaping(x2)
-    enumUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func enumUseAfterConsume() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(NonTrivialStruct())
-    enumUseMoveOnlyWithoutEscaping(x2)
-    enumConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func enumUseAfterConsumeArg(_ x2: inout EnumTy) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    enumUseMoveOnlyWithoutEscaping(x2)
-    enumConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
 }
 
 public func enumDoubleConsume() {
     var x2 = EnumTy.klass(NonTrivialStruct())  // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(NonTrivialStruct())
-    enumConsume(x2) // expected-note {{consuming use here}}
-    enumConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func enumDoubleConsumeArg(_ x2: inout EnumTy) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}} 
-    enumConsume(x2) // expected-note {{consuming use here}}
-    enumConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
 }
 
@@ -892,13 +874,13 @@ public func enumLoopConsume() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed by a use in a loop}}
     x2 = EnumTy.klass(NonTrivialStruct())
     for _ in 0..<1024 {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func enumLoopConsumeArg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -906,9 +888,9 @@ public func enumDiamond() {
     var x2 = EnumTy.klass(NonTrivialStruct())
     x2 = EnumTy.klass(NonTrivialStruct())
     if boolValue {
-        enumConsume(x2)
+        consumeVal(x2)
     } else {
-        enumConsume(x2)
+        consumeVal(x2)
     }
 }
 
@@ -916,9 +898,9 @@ public func enumDiamondArg(_ x2: inout EnumTy) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     if boolValue {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     } else {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -929,9 +911,9 @@ public func enumDiamondInLoop() {
     x2 = EnumTy.klass(NonTrivialStruct())
     for _ in 0..<1024 {
       if boolValue {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
           // expected-note @-1 {{consuming use here}}
       }
     }
@@ -942,9 +924,9 @@ public func enumDiamondInLoopArg(_ x2: inout EnumTy) {
     // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
       if boolValue {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
@@ -955,7 +937,7 @@ public func enumAssignToVar1() {
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = EnumTy.klass(NonTrivialStruct())
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar1Arg(_ x2: inout EnumTy) {
@@ -966,7 +948,7 @@ public func enumAssignToVar1Arg(_ x2: inout EnumTy) {
     x3 = x2 // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
     x3 = EnumTy.klass(NonTrivialStruct())
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar2() {
@@ -974,7 +956,7 @@ public func enumAssignToVar2() {
     x2 = EnumTy.klass(NonTrivialStruct())
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
-    enumUseMoveOnlyWithoutEscaping(x3)
+    borrowVal(x3)
 }
 
 public func enumAssignToVar2Arg(_ x2: inout EnumTy) {
@@ -983,7 +965,7 @@ public func enumAssignToVar2Arg(_ x2: inout EnumTy) {
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
      // expected-note @-1 {{consuming use here}}
-    enumUseMoveOnlyWithoutEscaping(x3)
+    borrowVal(x3)
 }
 
 public func enumAssignToVar3() {
@@ -991,58 +973,58 @@ public func enumAssignToVar3() {
     x2 = EnumTy.klass(NonTrivialStruct())
     var x3 = x2
     x3 = EnumTy.klass(NonTrivialStruct())
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar3Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
                                                             
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = EnumTy.klass(NonTrivialStruct())
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar4() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(NonTrivialStruct())
     let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x3)
 }
 
 public func enumAssignToVar4Arg(_ x2: inout EnumTy) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}} 
     let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
     // expected-note @-1 {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar5() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
     x2 = EnumTy.klass(NonTrivialStruct())
     var x3 = x2 // expected-note {{consuming use here}}
-    enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use}}
+    borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = EnumTy.klass(NonTrivialStruct())
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar5Arg(_ x2: inout EnumTy) { // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
                                                             
     var x3 = x2 // expected-note {{consuming use here}}
-    enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use}}
+    borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = EnumTy.klass(NonTrivialStruct())
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumPatternMatchIfLet1() {
     var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' consumed more than once}}
     x2 = EnumTy.klass(NonTrivialStruct())
     if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x)
+        borrowVal(x)
     }
     if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x)
+        borrowVal(x)
     }
 }
 
@@ -1050,11 +1032,11 @@ public func enumPatternMatchIfLet1Arg(_ x2: inout EnumTy) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
     // expected-error @-2 {{'x2' consumed more than once}}
     if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x)
+        borrowVal(x)
     }
     if case let EnumTy.klass(x) = x2 { // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x)
+        borrowVal(x)
     }
 }
 
@@ -1063,7 +1045,7 @@ public func enumPatternMatchIfLet2() {
     x2 = EnumTy.klass(NonTrivialStruct())
     for _ in 0..<1024 {
         if case let EnumTy.klass(x) = x2 {  // expected-note {{consuming use here}}
-            classUseMoveOnlyWithoutEscaping(x)
+            borrowVal(x)
         }
     }
 }
@@ -1071,7 +1053,7 @@ public func enumPatternMatchIfLet2() {
 public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     for _ in 0..<1024 {
         if case let EnumTy.klass(x) = x2 {  // expected-note {{consuming use here}}
-            classUseMoveOnlyWithoutEscaping(x)
+            borrowVal(x)
         }
     }
 }
@@ -1082,10 +1064,10 @@ public func enumPatternMatchSwitch1() {
     x2 = EnumTy.klass(NonTrivialStruct())
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k):
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
         // This should be flagged as the use after free use. We are atleast
         // erroring though.
-        enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use}}
+        borrowVal(x2) // expected-note {{non-consuming use here}}
     case .int:
         break
     }
@@ -1094,10 +1076,10 @@ public func enumPatternMatchSwitch1() {
 public func enumPatternMatchSwitch1Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k):
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
         // This should be flagged as the use after free use. We are atleast
         // erroring though.
-        enumUseMoveOnlyWithoutEscaping(x2)
+        borrowVal(x2)
     case .int:
         break
     }
@@ -1108,7 +1090,7 @@ public func enumPatternMatchSwitch2() {
     x2 = EnumTy.klass(NonTrivialStruct())
     switch x2 {
     case let EnumTy.klass(k):
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     }
@@ -1117,7 +1099,7 @@ public func enumPatternMatchSwitch2() {
 public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k):
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     }
@@ -1129,8 +1111,8 @@ public func enumPatternMatchSwitch2WhereClause() {
     x2 = EnumTy.klass(NonTrivialStruct())
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k)
-           where x2.doSomething(): // expected-note {{non-consuming use}}
-        classUseMoveOnlyWithoutEscaping(k)
+           where x2.doSomething(): // expected-note {{non-consuming use here}}
+        borrowVal(k)
     case .int:
         break
     case EnumTy.klass:
@@ -1142,7 +1124,7 @@ public func enumPatternMatchSwitch2WhereClauseArg(_ x2: inout EnumTy) { // expec
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k)
            where x2.doSomething():
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     case EnumTy.klass:
@@ -1156,7 +1138,7 @@ public func enumPatternMatchSwitch2WhereClause2() {
     switch x2 {
     case let EnumTy.klass(k)
            where boolValue:
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     case EnumTy.klass:
@@ -1168,7 +1150,7 @@ public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: inout EnumTy) { // expe
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k)
            where boolValue:
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     case EnumTy.klass:
@@ -1184,9 +1166,9 @@ public func closureClassUseAfterConsume1() {
     let f = {
         var x2 = NonTrivialStruct() // expected-error {{'x2' consumed more than once}}
         x2 = NonTrivialStruct()
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f()
 }
@@ -1195,9 +1177,9 @@ public func closureClassUseAfterConsume2() {
     let f = { () in
         var x2 = NonTrivialStruct() // expected-error {{'x2' consumed more than once}}
         x2 = NonTrivialStruct()
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f()
 }
@@ -1207,9 +1189,9 @@ public func closureClassUseAfterConsumeArg(_ argX: inout NonTrivialStruct) {
     let f = { (_ x2: inout NonTrivialStruct) in
         // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
         // expected-error @-2 {{'x2' consumed more than once}}
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
     f(&argX)
@@ -1225,11 +1207,11 @@ public func closureCaptureClassUseAfterConsume() {
     // expected-error @-5 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = NonTrivialStruct()
     let f = {
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
+        borrowVal(x2)
+        consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
-        print(x2)
+        consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
         // expected-note @-3 {{consuming use here}}
@@ -1247,11 +1229,11 @@ public func closureCaptureClassUseAfterConsumeError() {
     // expected-error @-5 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = NonTrivialStruct()
     let f = {
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2)
+        borrowVal(x2)
+        consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
-        print(x2)
+        consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
         // expected-note @-3 {{consuming use here}}
@@ -1269,10 +1251,10 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) 
     // expected-note @-4 {{'x2' is declared 'inout'}}
     let f = { // expected-note {{consuming use here}}
         // expected-error @-1 {{escaping closure captures 'inout' parameter 'x2'}}
-        classUseMoveOnlyWithoutEscaping(x2) // expected-note {{captured here}}
-        classConsume(x2) // expected-note {{captured here}}
+        borrowVal(x2) // expected-note {{captured here}}
+        consumeVal(x2) // expected-note {{captured here}}
         // expected-note @-1 {{consuming use here}}
-        print(x2) // expected-note {{captured here}}
+        consumeVal(x2) // expected-note {{captured here}}
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
     }
@@ -1286,13 +1268,13 @@ public func deferCaptureClassUseAfterConsume() {
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
     x2 = NonTrivialStruct()
-    defer { // expected-note {{non-consuming use}}
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+    defer { // expected-note {{non-consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
-    print(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func deferCaptureClassUseAfterConsume2() {
@@ -1301,10 +1283,10 @@ public func deferCaptureClassUseAfterConsume2() {
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
     x2 = NonTrivialStruct()
-    defer { //  expected-note {{non-consuming use}}
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+    defer { //  expected-note {{non-consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
     let x3 = x2 // expected-note {{consuming use here}}
@@ -1314,11 +1296,11 @@ public func deferCaptureClassUseAfterConsume2() {
 public func deferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    classUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
     defer {
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}
     }
     print("foo")
@@ -1332,9 +1314,9 @@ public func closureAndDeferCaptureClassUseAfterConsume() {
     x2 = NonTrivialStruct()
     let f = {
         defer {
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) // expected-note {{consuming use here}}
-            print(x2)
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{consuming use here}}
         }
@@ -1352,15 +1334,15 @@ public func closureAndDeferCaptureClassUseAfterConsume2() {
     // expected-error @-5 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
     x2 = NonTrivialStruct()
     let f = {
-        classConsume(x2)
+        consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
         defer {
-            // expected-note @-1 {{non-consuming use}}
-            // expected-note @-2 {{non-consuming use}}
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) // expected-note {{consuming use here}}
-            print(x2)
+            // expected-note @-1 {{non-consuming use here}}
+            // expected-note @-2 {{non-consuming use here}}
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{consuming use here}}
         }
@@ -1378,22 +1360,22 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
     // expected-error @-5 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
     x2 = NonTrivialStruct()
     let f = {
-        classConsume(x2)
+        consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
         defer {
-            // expected-note @-1 {{non-consuming use}}
-            // expected-note @-2 {{non-consuming use}}
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) // expected-note {{consuming use here}}
-            print(x2)
+            // expected-note @-1 {{non-consuming use here}}
+            // expected-note @-2 {{non-consuming use here}}
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{consuming use here}}
         }
         print("foo")
     }
     f()
-    classConsume(x2)
+    consumeVal(x2)
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
@@ -1404,10 +1386,10 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivial
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
               // expected-note @-1 {{consuming use here}}
         defer { // expected-note {{captured indirectly by this call}}
-            classUseMoveOnlyWithoutEscaping(x2) // expected-note {{captured here}}
-            classConsume(x2) // expected-note {{captured here}}
+            borrowVal(x2) // expected-note {{captured here}}
+            consumeVal(x2) // expected-note {{captured here}}
             // expected-note @-1 {{consuming use here}}
-            print(x2) // expected-note {{captured here}}
+            consumeVal(x2) // expected-note {{captured here}}
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{consuming use here}}
         }
@@ -1428,11 +1410,11 @@ public func closureAndClosureCaptureClassUseAfterConsume() {
     x2 = NonTrivialStruct()
     let f = {
         let g = {
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
+            borrowVal(x2)
+            consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{consuming use here}}
-            print(x2)
+            consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{consuming use here}}
             // expected-note @-3 {{consuming use here}}
@@ -1455,11 +1437,11 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
     x2 = NonTrivialStruct()
     let f = {
         let g = {
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2)
+            borrowVal(x2)
+            consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{consuming use here}}
-            print(x2)
+            consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{consuming use here}}
             // expected-note @-3 {{consuming use here}}
@@ -1468,7 +1450,7 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
         g()
     }
     f()
-    print(x2)
+    consumeVal(x2)
 }
 
 
@@ -1484,14 +1466,14 @@ public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: inout NonTrivi
         let g = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
             // expected-note @-1 {{consuming use here}}
             // expected-note @-2 {{captured indirectly by this call}}
-            classUseMoveOnlyWithoutEscaping(x2)
+            borrowVal(x2)
             // expected-note @-1 {{captured here}}
             // expected-note @-2 {{captured here}}
-            classConsume(x2)
+            consumeVal(x2)
             // expected-note @-1 {{captured here}}
             // expected-note @-2 {{captured here}}
             // expected-note @-3 {{consuming use here}}
-            print(x2)
+            consumeVal(x2)
             // expected-note @-1 {{captured here}}
             // expected-note @-2 {{captured here}}
             // expected-note @-3 {{consuming use here}}

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -4,7 +4,7 @@
 // Declarations //
 //////////////////
 
-public class Klass {}
+public class CopyableKlass {}
 
 var boolValue: Bool { return true }
 
@@ -13,12 +13,21 @@ public struct NonTrivialStruct {
     var i: Int = 0
 }
 
-public func nonConsumingUseNonTrivialStruct(_ s: NonTrivialStruct) {}
+public func borrowVal(_ x: __shared Int) {}
+public func borrowVal(_ x: __shared AggStruct) {}
+public func borrowVal(_ x: __shared NonTrivialStruct) {}
+public func borrowVal(_ x: __shared AggGenericStruct<CopyableKlass>) {}
+public func borrowVal<T>(_ x: __shared AggGenericStruct<T>) {}
+public func borrowVal(_ x: __shared EnumTy) {}
 
-public func classUseMoveOnlyWithoutEscaping(_ x: Int) {}
-public func classUseMoveOnlyWithoutEscaping(_ x: NonTrivialStruct) {}
-public func classConsume(_ x: Int) {}
-public func classConsume(_ x: __owned NonTrivialStruct) {}
+public func consumeVal(_ x: __owned Int) {}
+public func consumeVal(_ x: __owned NonTrivialStruct) {}
+public func consumeVal(_ x: __owned String) {}
+public func consumeVal(_ x: __owned EnumTy) {}
+public func consumeVal<T>(_ x: __owned AggGenericStruct<T>) {}
+public func consumeVal(_ x: __owned AggStruct) {}
+public func consumeVal(_ x: __owned AggGenericStruct<CopyableKlass>) {}
+
 
 @_moveOnly
 public enum NonTrivialEnum {
@@ -26,8 +35,6 @@ public enum NonTrivialEnum {
     case second((Int, Int))
     case third(NonTrivialStruct)
 }
-
-public func nonConsumingUseNonTrivialEnum(_ e : NonTrivialEnum) {}
 
 ///////////
 // Tests //
@@ -38,7 +45,7 @@ public func nonConsumingUseNonTrivialEnum(_ e : NonTrivialEnum) {}
 //////////////////////
 
 @_moveOnly
-public struct KlassPair {
+public struct MOIntPair {
     var lhs: Int
     var rhs: Int
 }
@@ -48,144 +55,139 @@ public struct AggStruct {
     var lhs: Int
     var center: Int
     var rhs: Int
-    var pair: KlassPair
-}
-
-public func aggStructUseMoveOnlyWithoutEscaping(_ x: AggStruct) {
-}
-public func aggStructConsume(_ x: __owned AggStruct) {
+    var pair: MOIntPair
 }
 
 public func aggStructSimpleChainTest(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
-    aggStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func aggStructSimpleChainTestArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
-    aggStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func aggStructSimpleChainTestOwnedArg(_ x2: __owned AggStruct) {
     let y2 = x2
     let k2 = y2
-    aggStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func aggStructSimpleNonConsumingUseTest(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    aggStructUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func aggStructSimpleNonConsumingUseTestArg(_ x2: AggStruct) {
-    aggStructUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func aggStructSimpleNonConsumingUseTestOwnedArg(_ x2: __owned AggStruct) {
-    aggStructUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func aggStructMultipleNonConsumingUseTest(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
 public func aggStructMultipleNonConsumingUseTestArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggStructMultipleNonConsumingUseTestOwnedArg(_ x2: __owned AggStruct) {
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
 public func aggStructUseAfterConsume(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggStructUseAfterConsumeArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggStructUseAfterConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
-    aggStructUseMoveOnlyWithoutEscaping(x2)
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggStructDoubleConsume(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggStructDoubleConsumeArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggStructDoubleConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
-    aggStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggStructLoopConsume(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func aggStructLoopConsumeArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func aggStructLoopConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
     for _ in 0..<1024 {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func aggStructDiamond(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
-        aggStructConsume(x2)
+        consumeVal(x2)
     } else {
-        aggStructConsume(x2)
+        consumeVal(x2)
     }
 }
 
 public func aggStructDiamondArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if boolValue {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     } else {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func aggStructDiamondOwnedArg(_ x2: __owned AggStruct) {
     if boolValue {
-        aggStructConsume(x2)
+        consumeVal(x2)
     } else {
-        aggStructConsume(x2)
+        consumeVal(x2)
     }
 }
 
@@ -194,9 +196,9 @@ public func aggStructDiamondInLoop(_ x: AggStruct) { // expected-error {{'x' has
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
       if boolValue {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
@@ -204,9 +206,9 @@ public func aggStructDiamondInLoop(_ x: AggStruct) { // expected-error {{'x' has
 public func aggStructDiamondInLoopArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
@@ -214,100 +216,100 @@ public func aggStructDiamondInLoopArg(_ x2: AggStruct) { // expected-error {{'x2
 public func aggStructDiamondInLoopOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
     for _ in 0..<1024 {
       if boolValue {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
 
 public func aggStructAccessField(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
 public func aggStructAccessFieldArg(_ x2: AggStruct) {
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
 public func aggStructAccessFieldOwnedArg(_ x2: __owned AggStruct) {
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
 public func aggStructConsumeField(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    classConsume(x2.lhs)
+    consumeVal(x2.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.lhs)
+        consumeVal(x2.lhs)
     }
 }
 
 // TODO: We should error here!
 public func aggStructConsumeFieldArg(_ x2: AggStruct) {
-    classConsume(x2.lhs)
+    consumeVal(x2.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.lhs)
+        consumeVal(x2.lhs)
     }
 }
 
 public func aggStructConsumeFieldOwnedArg(_ x2: __owned AggStruct) {
-    classConsume(x2.lhs)
+    consumeVal(x2.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.lhs)
+        consumeVal(x2.lhs)
     }
 }
 
 public func aggStructAccessGrandField(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
 public func aggStructAccessGrandFieldArg(_ x2: AggStruct) {
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
 public func aggStructAccessGrandFieldOwnedArg(_ x2: __owned AggStruct) {
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
 public func aggStructConsumeGrandField(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    classConsume(x2.pair.lhs)
+    consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs)
+        consumeVal(x2.pair.lhs)
     }
 }
 
 // TODO: This needs to error.
 public func aggStructConsumeGrandFieldArg(_ x2: AggStruct) {
-    classConsume(x2.pair.lhs)
+    consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs)
+        consumeVal(x2.pair.lhs)
     }
 }
 
 public func aggStructConsumeGrandFieldOwnedArg(_ x2: __owned AggStruct) {
-    classConsume(x2.pair.lhs)
+    consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs)
+        consumeVal(x2.pair.lhs)
     }
 }
 
@@ -319,264 +321,259 @@ public func aggStructConsumeGrandFieldOwnedArg(_ x2: __owned AggStruct) {
 public struct AggGenericStruct<T> {
     var lhs: Int
     var rhs: UnsafeRawPointer
-    var pair: KlassPair
+    var pair: MOIntPair
 }
 
-public func aggGenericStructUseMoveOnlyWithoutEscaping(_ x: AggGenericStruct<Klass>) {
-}
-public func aggGenericStructConsume(_ x: __owned AggGenericStruct<Klass>) {
-}
-
-public func aggGenericStructSimpleChainTest(_ x: AggGenericStruct<Klass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTest(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
-    aggGenericStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg(_ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTestArg(_ x2: AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
-    aggGenericStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestOwnedArg(_ x2: __owned AggGenericStruct<Klass>) {
+public func aggGenericStructSimpleChainTestOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) {
     let y2 = x2
     let k2 = y2
-    aggGenericStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTest(_ x: AggGenericStruct<Klass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleNonConsumingUseTest(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTestArg(_ x2: AggGenericStruct<Klass>) {
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+public func aggGenericStructSimpleNonConsumingUseTestArg(_ x2: AggGenericStruct<CopyableKlass>) {
+    borrowVal(x2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTestOwnedArg(_ x2: __owned AggGenericStruct<Klass>) {
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+public func aggGenericStructSimpleNonConsumingUseTestOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) {
+    borrowVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTest(_ x: AggGenericStruct<Klass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTest(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestOwnedArg(_ x2: __owned AggGenericStruct<Klass>) {
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+public func aggGenericStructMultipleNonConsumingUseTestOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) {
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
-public func aggGenericStructUseAfterConsume(_ x: AggGenericStruct<Klass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsume(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructUseAfterConsumeArg(_ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+public func aggGenericStructUseAfterConsumeArg(_ x2: AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructUseAfterConsumeOwnedArg(_ x2: __owned AggGenericStruct<Klass>) { // expected-error {{'x2' consumed more than once}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+public func aggGenericStructUseAfterConsumeOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed more than once}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsume(_ x: AggGenericStruct<Klass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsume(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsumeArg(_ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+public func aggGenericStructDoubleConsumeArg(_ x2: AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsumeOwnedArg(_ x2: __owned AggGenericStruct<Klass>) { // expected-error {{'x2' consumed more than once}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+public func aggGenericStructDoubleConsumeOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed more than once}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructLoopConsume(_ x: AggGenericStruct<Klass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsume(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
-public func aggGenericStructLoopConsumeArg(_ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsumeArg(_ x2: AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg(_ x2: __owned AggGenericStruct<Klass>) { // expected-error {{'x2' consumed more than once}}
+public func aggGenericStructLoopConsumeOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed more than once}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
-public func aggGenericStructDiamond(_ x: AggGenericStruct<Klass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamond(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
-        aggGenericStructConsume(x2)
+        consumeVal(x2)
     } else {
-        aggGenericStructConsume(x2)
+        consumeVal(x2)
     }
 }
 
-public func aggGenericStructDiamondArg(_ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondArg(_ x2: AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if boolValue {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     } else {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
-public func aggGenericStructDiamondOwnedArg(_ x2: __owned AggGenericStruct<Klass>) {
+public func aggGenericStructDiamondOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) {
     if boolValue {
-        aggGenericStructConsume(x2)
+        consumeVal(x2)
     } else {
-        aggGenericStructConsume(x2)
+        consumeVal(x2)
     }
 }
 
-public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<Klass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
 
-public func aggGenericStructDiamondInLoopArg(_ x2: AggGenericStruct<Klass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoopArg(_ x2: AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
 
-public func aggGenericStructDiamondInLoopOwnedArg(_ x2: __owned AggGenericStruct<Klass>) { // expected-error {{'x2' consumed more than once}}
+public func aggGenericStructDiamondInLoopOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed more than once}}
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
 
-public func aggGenericStructAccessField(_ x: AggGenericStruct<Klass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessField(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
-public func aggGenericStructAccessFieldArg(_ x2: AggGenericStruct<Klass>) {
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+public func aggGenericStructAccessFieldArg(_ x2: AggGenericStruct<CopyableKlass>) {
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
-public func aggGenericStructAccessFieldOwnedArg(_ x2: __owned AggGenericStruct<Klass>) {
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+public func aggGenericStructAccessFieldOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) {
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
-public func aggGenericStructConsumeField(_ x: AggGenericStruct<Klass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeField(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    classConsume(x2.lhs)
+    consumeVal(x2.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.lhs)
+        consumeVal(x2.lhs)
     }
 }
 
-public func aggGenericStructConsumeFieldArg(_ x2: AggGenericStruct<Klass>) {
-    classConsume(x2.lhs)
+public func aggGenericStructConsumeFieldArg(_ x2: AggGenericStruct<CopyableKlass>) {
+    consumeVal(x2.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.lhs)
+        consumeVal(x2.lhs)
     }
 }
 
-public func aggGenericStructConsumeFieldOwnedArg(_ x2: __owned AggGenericStruct<Klass>) {
-    classConsume(x2.lhs)
+public func aggGenericStructConsumeFieldOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) {
+    consumeVal(x2.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.lhs)
+        consumeVal(x2.lhs)
     }
 }
 
-public func aggGenericStructAccessGrandField(_ x: AggGenericStruct<Klass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessGrandField(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
-public func aggGenericStructAccessGrandFieldArg(_ x2: AggGenericStruct<Klass>) {
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+public func aggGenericStructAccessGrandFieldArg(_ x2: AggGenericStruct<CopyableKlass>) {
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
-public func aggGenericStructAccessGrandFieldOwnedArg(_ x2: __owned AggGenericStruct<Klass>) {
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+public func aggGenericStructAccessGrandFieldOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) {
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
-public func aggGenericStructConsumeGrandField(_ x: AggGenericStruct<Klass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeGrandField(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    classConsume(x2.pair.lhs)
+    consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs)
+        consumeVal(x2.pair.lhs)
     }
 }
 
-public func aggGenericStructConsumeGrandFieldArg(_ x2: AggGenericStruct<Klass>) {
-    classConsume(x2.pair.lhs)
+public func aggGenericStructConsumeGrandFieldArg(_ x2: AggGenericStruct<CopyableKlass>) {
+    consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs)
+        consumeVal(x2.pair.lhs)
     }
 }
 
-public func aggGenericStructConsumeGrandFieldOwnedArg(_ x2: __owned AggGenericStruct<Klass>) {
-    classConsume(x2.pair.lhs)
+public func aggGenericStructConsumeGrandFieldOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) {
+    consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs)
+        consumeVal(x2.pair.lhs)
     }
 }
 
@@ -584,141 +581,136 @@ public func aggGenericStructConsumeGrandFieldOwnedArg(_ x2: __owned AggGenericSt
 // Aggregate Generic Struct + Generic But Body is Trivial //
 ////////////////////////////////////////////////////////////
 
-public func aggGenericStructUseMoveOnlyWithoutEscaping<T>(_ x: AggGenericStruct<T>) {
-}
-public func aggGenericStructConsume<T>(_ x: __owned AggGenericStruct<T>) {
-}
-
 public func aggGenericStructSimpleChainTest<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
-    aggGenericStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func aggGenericStructSimpleChainTestArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
-    aggGenericStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func aggGenericStructSimpleChainTestOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) {
     let y2 = x2
     let k2 = y2
-    aggGenericStructUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func aggGenericStructSimpleNonConsumingUseTest<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func aggGenericStructSimpleNonConsumingUseTestArg<T>(_ x2: AggGenericStruct<T>) {
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func aggGenericStructSimpleNonConsumingUseTestOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) {
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
 public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: AggGenericStruct<T>) { //expected-error {{'x2' has guaranteed ownership but was consumed}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggGenericStructMultipleNonConsumingUseTestOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) {
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
 public func aggGenericStructUseAfterConsume<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggGenericStructUseAfterConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
-    aggGenericStructUseMoveOnlyWithoutEscaping(x2)
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggGenericStructDoubleConsume<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggGenericStructDoubleConsumeArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggGenericStructDoubleConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
-    aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func aggGenericStructLoopConsumeArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func aggGenericStructLoopConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func aggGenericStructDiamond<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
-        aggGenericStructConsume(x2)
+        consumeVal(x2)
     } else {
-        aggGenericStructConsume(x2)
+        consumeVal(x2)
     }
 }
 
 public func aggGenericStructDiamondArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if boolValue {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     } else {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func aggGenericStructDiamondOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) {
     if boolValue {
-        aggGenericStructConsume(x2)
+        consumeVal(x2)
     } else {
-        aggGenericStructConsume(x2)
+        consumeVal(x2)
     }
 }
 
@@ -727,9 +719,9 @@ public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) { // expe
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
@@ -737,9 +729,9 @@ public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) { // expe
 public func aggGenericStructDiamondInLoopArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
@@ -747,98 +739,98 @@ public func aggGenericStructDiamondInLoopArg<T>(_ x2: AggGenericStruct<T>) { // 
 public func aggGenericStructDiamondInLoopOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
     for _ in 0..<1024 {
       if boolValue {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
 
 public func aggGenericStructAccessField<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
 public func aggGenericStructAccessFieldArg<T>(_ x2: AggGenericStruct<T>) {
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
 public func aggGenericStructAccessFieldOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) {
-    classUseMoveOnlyWithoutEscaping(x2.lhs)
+    borrowVal(x2.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.lhs)
+        borrowVal(x2.lhs)
     }
 }
 
 public func aggGenericStructConsumeField<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    classConsume(x2.lhs)
+    consumeVal(x2.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.lhs)
+        consumeVal(x2.lhs)
     }
 }
 
 public func aggGenericStructConsumeFieldArg<T>(_ x2: AggGenericStruct<T>) {
-    classConsume(x2.lhs)
+    consumeVal(x2.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.lhs)
+        consumeVal(x2.lhs)
     }
 }
 
 public func aggGenericStructConsumeFieldOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) {
-    classConsume(x2.lhs)
+    consumeVal(x2.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.lhs)
+        consumeVal(x2.lhs)
     }
 }
 
 public func aggGenericStructAccessGrandField<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
 public func aggGenericStructAccessGrandFieldArg<T>(_ x2: AggGenericStruct<T>) {
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
 public func aggGenericStructAccessGrandFieldOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) {
-    classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+    borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classUseMoveOnlyWithoutEscaping(x2.pair.lhs)
+        borrowVal(x2.pair.lhs)
     }
 }
 
 public func aggGenericStructConsumeGrandField<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    classConsume(x2.pair.lhs)
+    consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs)
+        consumeVal(x2.pair.lhs)
     }
 }
 
 public func aggGenericStructConsumeGrandFieldArg<T>(_ x2: AggGenericStruct<T>) {
-    classConsume(x2.pair.lhs)
+    consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs)
+        consumeVal(x2.pair.lhs)
     }
 }
 
 public func aggGenericStructConsumeGrandFieldOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) {
-    classConsume(x2.pair.lhs)
+    consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
-        classConsume(x2.pair.lhs)
+        consumeVal(x2.pair.lhs)
     }
 }
 
@@ -854,141 +846,136 @@ public enum EnumTy {
     func doSomething() -> Bool { true }
 }
 
-public func enumUseMoveOnlyWithoutEscaping(_ x: EnumTy) {
-}
-public func enumConsume(_ x: __owned EnumTy) {
-}
-
 public func enumSimpleChainTest(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
-    enumUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func enumSimpleChainTestArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
-    enumUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func enumSimpleChainTestOwnedArg(_ x2: __owned EnumTy) {
     let y2 = x2
     let k2 = y2
-    enumUseMoveOnlyWithoutEscaping(k2)
+    borrowVal(k2)
 }
 
 public func enumSimpleNonConsumingUseTest(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    enumUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func enumSimpleNonConsumingUseTestArg(_ x2: EnumTy) {
-    enumUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func enumSimpleNonConsumingUseTestOwnedArg(_ x2: __owned EnumTy) {
-    enumUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
 }
 
 public func enumMultipleNonConsumingUseTest(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    enumUseMoveOnlyWithoutEscaping(x2)
-    enumUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
 public func enumMultipleNonConsumingUseTestArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    enumUseMoveOnlyWithoutEscaping(x2)
-    enumUseMoveOnlyWithoutEscaping(x2)
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func enumMultipleNonConsumingUseTestOwnedArg(_ x2: __owned EnumTy) {
-    enumUseMoveOnlyWithoutEscaping(x2)
-    enumUseMoveOnlyWithoutEscaping(x2)
-    print(x2)
+    borrowVal(x2)
+    borrowVal(x2)
+    consumeVal(x2)
 }
 
 public func enumUseAfterConsume(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
-    enumUseMoveOnlyWithoutEscaping(x2)
-    enumConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func enumUseAfterConsumeArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    enumUseMoveOnlyWithoutEscaping(x2)
-    enumConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func enumUseAfterConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    enumUseMoveOnlyWithoutEscaping(x2)
-    enumConsume(x2) // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
+    borrowVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func enumDoubleConsume(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
-    enumConsume(x2) // expected-note {{consuming use here}}
-    enumConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func enumDoubleConsumeArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    enumConsume(x2) // expected-note {{consuming use here}}
-    enumConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func enumDoubleConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
-    enumConsume(x2) // expected-note {{consuming use here}}
-    enumConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func enumLoopConsume(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func enumLoopConsumeArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func enumLoopConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     for _ in 0..<1024 {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func enumDiamond(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
-        enumConsume(x2)
+        consumeVal(x2)
     } else {
-        enumConsume(x2)
+        consumeVal(x2)
     }
 }
 
 public func enumDiamondArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if boolValue {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     } else {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
 public func enumDiamondOwnedArg(_ x2: __owned EnumTy) {
     if boolValue {
-        enumConsume(x2)
+        consumeVal(x2)
     } else {
-        enumConsume(x2)
+        consumeVal(x2)
     }
 }
 
@@ -997,9 +984,9 @@ public func enumDiamondInLoop(_ x: EnumTy) { // expected-error {{'x' has guarant
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
       if boolValue {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
@@ -1007,9 +994,9 @@ public func enumDiamondInLoop(_ x: EnumTy) { // expected-error {{'x' has guarant
 public func enumDiamondInLoopArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
       if boolValue {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
@@ -1017,9 +1004,9 @@ public func enumDiamondInLoopArg(_ x2: EnumTy) { // expected-error {{'x2' has gu
 public func enumDiamondInLoopOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     for _ in 0..<1024 {
       if boolValue {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          enumConsume(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
       }
     }
 }
@@ -1030,7 +1017,7 @@ public func enumAssignToVar1(_ x: EnumTy) { // expected-error {{'x' has guarante
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar1Arg(_ x: EnumTy, _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
@@ -1038,7 +1025,7 @@ public func enumAssignToVar1Arg(_ x: EnumTy, _ x2: EnumTy) { // expected-error {
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar1OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
@@ -1046,7 +1033,7 @@ public func enumAssignToVar1OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // exp
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar2(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
@@ -1054,59 +1041,59 @@ public func enumAssignToVar2(_ x: EnumTy) { // expected-error {{'x' has guarante
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
-    enumUseMoveOnlyWithoutEscaping(x3)
+    borrowVal(x3)
 }
 
 public func enumAssignToVar2Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
-    enumUseMoveOnlyWithoutEscaping(x3)
+    borrowVal(x3)
 }
 
 public func enumAssignToVar2OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
-    enumUseMoveOnlyWithoutEscaping(x3)
+    borrowVal(x3)
 }
 
 public func enumAssignToVar3(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar3Arg(_ x: EnumTy, _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
                                                              // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar3OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar4(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x3)
 }
 
 public func enumAssignToVar4Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x3)
 }
 
 public func enumAssignToVar4OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     let x3 = x2 // expected-note {{consuming use here}}
-    print(x2) // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x2) // expected-note {{consuming use here}}
+    consumeVal(x3)
 }
 
 public func enumAssignToVar5(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
@@ -1115,9 +1102,9 @@ public func enumAssignToVar5(_ x: EnumTy) { // expected-error {{'x' has guarante
     var x3 = x2 // expected-note {{consuming use here}}
     // TODO: Need to mark this as the lifetime extending use. We fail
     // appropriately though.
-    enumUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
     x3 = x // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar5Arg(_ x: EnumTy, _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
@@ -1125,9 +1112,9 @@ public func enumAssignToVar5Arg(_ x: EnumTy, _ x2: EnumTy) { // expected-error {
     var x3 = x2 // expected-note {{consuming use here}}
     // TODO: Need to mark this as the lifetime extending use. We fail
     // appropriately though.
-    enumUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
     x3 = x // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumAssignToVar5OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
@@ -1135,37 +1122,37 @@ public func enumAssignToVar5OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // exp
     var x3 = x2 // expected-note {{consuming use here}}
     // TODO: Need to mark this as the lifetime extending use. We fail
     // appropriately though.
-    enumUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
     x3 = x // expected-note {{consuming use here}}
-    print(x3)
+    consumeVal(x3)
 }
 
 public func enumPatternMatchIfLet1(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     if case let .klass(x) = x2 { // expected-note {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x.i)
+        borrowVal(x.i)
     }
     if case let .klass(x) = x2 { // expected-note {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x.i)
+        borrowVal(x.i)
     }
 }
 
 public func enumPatternMatchIfLet1Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if case let .klass(x) = x2 { // expected-note {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x.i)
+        borrowVal(x.i)
     }
     if case let .klass(x) = x2 { // expected-note {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x.i)
+        borrowVal(x.i)
     }
 }
 
 public func enumPatternMatchIfLet1OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     if case let .klass(x) = x2 { // expected-note {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x)
+        borrowVal(x)
     }
     if case let .klass(x) = x2 { // expected-note {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x)
+        borrowVal(x)
     }
 }
 
@@ -1174,7 +1161,7 @@ public func enumPatternMatchIfLet2(_ x: EnumTy) { // expected-error {{'x' has gu
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
         if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
-            classUseMoveOnlyWithoutEscaping(x)
+            borrowVal(x)
         }
     }
 }
@@ -1182,7 +1169,7 @@ public func enumPatternMatchIfLet2(_ x: EnumTy) { // expected-error {{'x' has gu
 public func enumPatternMatchIfLet2Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
         if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
-            classUseMoveOnlyWithoutEscaping(x)
+            borrowVal(x)
         }
     }
 }
@@ -1190,21 +1177,21 @@ public func enumPatternMatchIfLet2Arg(_ x2: EnumTy) { // expected-error {{'x2' h
 public func enumPatternMatchIfLet2OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     for _ in 0..<1024 {
         if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
-            classUseMoveOnlyWithoutEscaping(x)
+            borrowVal(x)
         }
     }
 }
 
-// This is wrong.
+// TODO: This is wrong.
 public func enumPatternMatchSwitch1(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
         // This should be flagged as the use after free use. We are atleast
         // erroring though.
-        enumUseMoveOnlyWithoutEscaping(x2)
+        borrowVal(x2)
     case .int:
         break
     }
@@ -1213,10 +1200,10 @@ public func enumPatternMatchSwitch1(_ x: EnumTy) { // expected-error {{'x' has g
 public func enumPatternMatchSwitch1Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
         // This should be flagged as the use after free use. We are atleast
         // erroring though.
-        enumUseMoveOnlyWithoutEscaping(x2)
+        borrowVal(x2)
     case .int:
         break
     }
@@ -1225,10 +1212,10 @@ public func enumPatternMatchSwitch1Arg(_ x2: EnumTy) { // expected-error {{'x2' 
 public func enumPatternMatchSwitch1OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
         // This should be flagged as the use after free use. We are atleast
         // erroring though.
-        enumUseMoveOnlyWithoutEscaping(x2)
+        borrowVal(x2)
     case .int:
         break
     }
@@ -1238,7 +1225,7 @@ public func enumPatternMatchSwitch2(_ x: EnumTy) { // expected-error {{'x' has g
     let x2 = x // expected-note {{consuming use here}}
     switch x2 {
     case let .klass(k):
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     }
@@ -1247,7 +1234,7 @@ public func enumPatternMatchSwitch2(_ x: EnumTy) { // expected-error {{'x' has g
 public func enumPatternMatchSwitch2Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     }
@@ -1256,20 +1243,20 @@ public func enumPatternMatchSwitch2Arg(_ x2: EnumTy) { // expected-error {{'x2' 
 public func enumPatternMatchSwitch2OwnedArg(_ x2: __owned EnumTy) {
     switch x2 {
     case let .klass(k):
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     }
 }
 
-// QOI: We can do better here. We should also flag x2
+// TODO: We can do better here. We should also flag x2
 public func enumPatternMatchSwitch2WhereClause(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
            where x2.doSomething():
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     case .klass:
@@ -1281,7 +1268,7 @@ public func enumPatternMatchSwitch2WhereClauseArg(_ x2: EnumTy) { // expected-er
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
            where x2.doSomething():
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     case .klass:
@@ -1293,7 +1280,7 @@ public func enumPatternMatchSwitch2WhereClauseOwnedArg(_ x2: __owned EnumTy) { /
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
            where x2.doSomething():
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     case .klass:
@@ -1306,7 +1293,7 @@ public func enumPatternMatchSwitch2WhereClause2(_ x: EnumTy) { // expected-error
     switch x2 {
     case let .klass(k)
            where boolValue:
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     case .klass:
@@ -1318,7 +1305,7 @@ public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: EnumTy) { // expected-e
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
            where boolValue:
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     case .klass:
@@ -1330,7 +1317,7 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg(_ x2: __owned EnumTy) {
     switch x2 {
     case let .klass(k)
            where boolValue:
-        classUseMoveOnlyWithoutEscaping(k)
+        borrowVal(k)
     case .int:
         break
     case .klass:
@@ -1345,12 +1332,12 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg(_ x2: __owned EnumTy) {
 public func closureClassUseAfterConsume1(_ x: NonTrivialStruct) {
     // expected-error @-1 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x' has guaranteed ownership but was consumed due to being captured by a closure}}
-    let f = { // expected-note {{closure capture}}
+    let f = { // expected-note {{closure capture here}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
         // expected-note @-1 {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f()
 }
@@ -1359,9 +1346,9 @@ public func closureClassUseAfterConsume2(_ argX: NonTrivialStruct) {
     let f = { (_ x: NonTrivialStruct) in // expected-error {{'x' has guaranteed ownership but was consumed}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
                    // expected-note @-1 {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f(argX)
 }
@@ -1369,9 +1356,9 @@ public func closureClassUseAfterConsume2(_ argX: NonTrivialStruct) {
 public func closureClassUseAfterConsumeArg(_ argX: NonTrivialStruct) {
     // TODO: Fix this
     let f = { (_ x2: NonTrivialStruct) in // expected-error {{'x2' has guaranteed ownership but was consumed}}
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f(argX)
 }
@@ -1380,9 +1367,9 @@ public func closureCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expec
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f()
 }
@@ -1392,9 +1379,9 @@ public func closureCaptureClassUseAfterConsumeError(_ x: NonTrivialStruct) { // 
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = { // expected-note {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f()
     let x3 = x2 // expected-note {{consuming use here}}
@@ -1404,10 +1391,10 @@ public func closureCaptureClassUseAfterConsumeError(_ x: NonTrivialStruct) { // 
 public func closureCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
-    let f = { // expected-note {{closure capture}}
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+    let f = { // expected-note {{closure capture here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f()
 }
@@ -1415,9 +1402,9 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) {
 public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f()
 }
@@ -1426,9 +1413,9 @@ public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivial
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = { // expected-note {{consuming use here}}
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     f()
     let x3 = x2 // expected-note {{consuming use here}}
@@ -1439,11 +1426,11 @@ public func deferCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expecte
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     defer {
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
-    print(x) // expected-note {{consuming use here}}
+    consumeVal(x) // expected-note {{consuming use here}}
 }
 
 public func deferCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
@@ -1453,9 +1440,9 @@ public func deferCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) { // expect
     // TODO: Defer error is b/c we have to lifetime extend x2 for the defer. The
     // use is a guaranteed use, so we don't emit an error on that use.
     defer {
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     let x3 = x2 // expected-note {{consuming use here}}
     let _ = x3
@@ -1463,34 +1450,34 @@ public func deferCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) { // expect
 
 public func deferCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    classUseMoveOnlyWithoutEscaping(x2)
+    borrowVal(x2)
     defer {
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
-    print("foo")
+    consumeVal("foo")
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     defer {
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
-    print("foo")
+    consumeVal("foo")
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     defer {
-        classUseMoveOnlyWithoutEscaping(x2)
-        classConsume(x2) // expected-note {{consuming use here}}
-        print(x2) // expected-note {{consuming use here}}
+        borrowVal(x2)
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
-    print(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func closureAndDeferCaptureClassUseAfterConsume(_ x: NonTrivialStruct) {
@@ -1499,11 +1486,11 @@ public func closureAndDeferCaptureClassUseAfterConsume(_ x: NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         defer {
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) // expected-note {{consuming use here}}
-            print(x2) // expected-note {{consuming use here}}
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
-        print("foo")
+        consumeVal("foo")
     }
     f()
 }
@@ -1513,13 +1500,13 @@ public func closureAndDeferCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
-        classConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
         defer {
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) // expected-note {{consuming use here}}
-            print(x2) // expected-note {{consuming use here}}
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
-        print("foo")
+        consumeVal("foo")
     }
     f()
 }
@@ -1530,27 +1517,27 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: NonTrivialStruct) {
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-3 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = { // expected-note {{consuming use here}}
-        classConsume(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
         defer {
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) // expected-note {{consuming use here}}
-            print(x2) // expected-note {{consuming use here}}
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
-        print("foo")
+        consumeVal("foo")
     }
     f()
-    classConsume(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    let f = { // expected-note {{closure capture}}
+    let f = { // expected-note {{closure capture here}}
         defer {
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) // expected-note {{consuming use here}}
-            print(x2) // expected-note {{consuming use here}}
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
-        print("foo")
+        consumeVal("foo")
     }
     f()
 }
@@ -1559,11 +1546,11 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Non
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         defer {
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) // expected-note {{consuming use here}}
-            print(x2) // expected-note {{consuming use here}}
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
-        print("foo")
+        consumeVal("foo")
     }
     f()
 }
@@ -1572,14 +1559,14 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned No
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = { // expected-note {{consuming use here}}
         defer {
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) //  expected-note {{consuming use here}}
-            print(x2) // expected-note {{consuming use here}}
+            borrowVal(x2)
+            consumeVal(x2) //  expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
-        print("foo")
+        consumeVal("foo")
     }
     f()
-    print(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func closureAndClosureCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
@@ -1587,10 +1574,10 @@ public func closureAndClosureCaptureClassUseAfterConsume(_ x: NonTrivialStruct) 
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = {
-        let g = { // expected-note {{closure capture}}
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) // expected-note {{consuming use here}}
-            print(x2) // expected-note {{consuming use here}}
+        let g = { // expected-note {{closure capture here}}
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         g()
     }
@@ -1603,15 +1590,15 @@ public func closureAndClosureCaptureClassUseAfterConsume2(_ x: NonTrivialStruct)
                // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
                // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{consuming use here}}
-        let g = { // expected-note {{closure capture}}
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) // expected-note {{consuming use here}}
-            print(x2) // expected-note {{consuming use here}}
+        let g = { // expected-note {{closure capture here}}
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         g()
     }
     f()
-    print(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 
@@ -1619,11 +1606,11 @@ public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: NonTrivialStru
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
-    let f = { // expected-note {{closure capture}}
-        let g = { // expected-note {{closure capture}}
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) // expected-note {{consuming use here}}
-            print(x2) // expected-note {{consuming use here}}
+    let f = { // expected-note {{closure capture here}}
+        let g = { // expected-note {{closure capture here}}
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         g()
     }
@@ -1634,10 +1621,10 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned N
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = {
-        let g = { // expected-note {{closure capture}}
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) // expected-note {{consuming use here}}
-            print(x2) // expected-note {{consuming use here}}
+        let g = { // expected-note {{closure capture here}}
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         g()
     }
@@ -1649,13 +1636,13 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned 
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{consuming use here}}
-        let g = { // expected-note {{closure capture}}
-            classUseMoveOnlyWithoutEscaping(x2)
-            classConsume(x2) // expected-note {{consuming use here}}
-            print(x2) // expected-note {{consuming use here}}
+        let g = { // expected-note {{closure capture here}}
+            borrowVal(x2)
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         g()
     }
     f()
-    print(x2) // expected-note {{consuming use here}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }

--- a/test/SILOptimizer/opaque_values_Onone_stdlib.swift
+++ b/test/SILOptimizer/opaque_values_Onone_stdlib.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -parse-stdlib -enable-experimental-move-only -module-name Swift -enable-sil-opaque-values -parse-as-library -emit-sil -Onone %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-stdlib -module-name Swift -enable-sil-opaque-values -parse-as-library -emit-sil -Onone %s | %FileCheck %s
 
 // Like opaque_values_Onone.swift but for code that needs to be compiled with 
 // -parse-stdlib.
@@ -32,10 +32,11 @@ public func type<T, Metatype>(of value: T) -> Metatype
 class X {}
 func consume(_ x : __owned X) {}
 
-func foo(@_noImplicitCopy _ x: __owned X) {
-  consume(_copy(x))
-  consume(x)
-}
+// FIXME: disabled temporarily until rdar://104898230 is resolved
+//func foo(@_noImplicitCopy _ x: __owned X) {
+//  consume(_copy(x))
+//  consume(x)
+//}
 
 // CHECK-LABEL: sil [transparent] [_semantics "lifetimemanagement.copy"] @_copy : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[OUT_ADDR:%[^,]+]] : $*T, [[IN_ADDR:%[^,]+]] : $*T):

--- a/test/Sema/copyable.swift
+++ b/test/Sema/copyable.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-move-only
+
+protocol P: _Copyable {}
+struct S: P {}
+
+class C: _Copyable {}
+
+@_moveOnly struct MOStruct: _Copyable {} // expected-error {{move-only struct 'MOStruct' cannot conform to protocol '_Copyable'}}

--- a/test/Sema/moveonly_illegal_types.swift
+++ b/test/Sema/moveonly_illegal_types.swift
@@ -1,0 +1,81 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-move-only
+
+// This test focuses on the prevention of users from _writing_ types where
+// a move-only type is substituted for a generic parameter.
+//
+// This means this is hitting on the TypeRepr -> Type phase in TypeCheckType.
+
+// ----------------------
+// ---   utilities    ---
+// ----------------------
+
+class Klass {}
+
+let asdf: any Hashable & Klass
+
+// a concrete move-only type
+@_moveOnly struct MO {
+  var x: Int?
+}
+
+@_moveOnly struct GenericMO<T> {
+  var t: T
+}
+
+protocol Box<T> {
+  associatedtype T
+  func get() -> T
+}
+
+struct ValBox<T>: Box {
+  var val: T
+  init(_ t: T) { val = t }
+  func get() -> T { return val }
+}
+
+enum Maybe<T> {
+  case none
+  case just(T)
+}
+
+struct CerebralValley<T> {
+  struct GenericBro<T> {}
+  struct TechBro {}
+}
+
+// ----------------------
+// --- now some tests ---
+// ----------------------
+
+func basic_vararg(_ va: MO...) {} // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+
+func illegalTypes<T>(_ t: T) {
+  let _: Array<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: Maybe<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: Dictionary<MO, String> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: [MO] // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: [String : MO] // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: [MO : MO] // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
+  let _: [MO : T] // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+
+  _ = t as! ValBox<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+
+  let _: Optional<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: MO? // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: MO?? // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: MO! // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: MO?! // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+
+  let _: Klass & MO // expected-error {{non-protocol, non-class type 'MO' cannot be used within a protocol-constrained type}}
+  let _: any MO // expected-error {{'any' has no effect on concrete type 'MO'}}
+  let _: any GenericMO<T> // expected-error {{'any' has no effect on concrete type 'GenericMO<T>'}}
+
+  let _: CerebralValley<MO>.TechBro // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  let _: CerebralValley<Int>.GenericBro<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+
+  let _: GenericMO<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+}
+
+func illegalInExpr() {
+
+}

--- a/test/Sema/moveonly_restrictions.swift
+++ b/test/Sema/moveonly_restrictions.swift
@@ -3,16 +3,20 @@
 class CopyableKlass {}
 @_moveOnly
 class MoveOnlyKlass {}
+@_moveOnly
+class MoveOnlyStruct {}
 
 class C {
     var copyable: CopyableKlass? = nil
-    var moveOnly: MoveOnlyKlass? = nil
+    var moveOnlyC: MoveOnlyKlass? = nil // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
+    var moveOnlyS: MoveOnlyStruct? = nil // expected-error {{move-only type 'MoveOnlyStruct' cannot be used with generics yet}}
 }
 
 @_moveOnly
 class CMoveOnly {
     var copyable: CopyableKlass? = nil
-    var moveOnly: MoveOnlyKlass? = nil
+    var moveOnlyC: MoveOnlyKlass? = nil // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
+    var moveOnlyS: MoveOnlyStruct? = nil // expected-error {{move-only type 'MoveOnlyStruct' cannot be used with generics yet}}
 }
 
 struct OptionalGrandField<T> { // expected-error {{generic struct 'OptionalGrandField' cannot contain a move-only type without also being move-only}}
@@ -21,7 +25,8 @@ struct OptionalGrandField<T> { // expected-error {{generic struct 'OptionalGrand
 }
 
 struct S0 {
-    var moveOnly3: OptionalGrandField<MoveOnlyKlass>
+    var moveOnly3: OptionalGrandField<MoveOnlyKlass> // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
+    var moveOnly4: OptionalGrandField<MoveOnlyStruct> // expected-error {{move-only type 'MoveOnlyStruct' cannot be used with generics yet}}
 }
 
 struct SCopyable {
@@ -30,9 +35,10 @@ struct SCopyable {
 
 struct S { // expected-error {{struct 'S' cannot contain a move-only type without also being move-only}}
     var copyable: CopyableKlass
-    var moveOnly2: MoveOnlyKlass?
-    var moveOnly: MoveOnlyKlass // expected-note {{contained move-only property 'S.moveOnly'}}
-    var moveOnly3: OptionalGrandField<MoveOnlyKlass>
+    var moveOnly2: MoveOnlyStruct? // expected-error {{move-only type 'MoveOnlyStruct' cannot be used with generics yet}}
+    var moveOnly: MoveOnlyStruct // expected-note {{contained move-only property 'S.moveOnly'}}
+    var moveOnly3: OptionalGrandField<MoveOnlyKlass> // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
+    var moveOnly3: OptionalGrandField<MoveOnlyStruct> // expected-error {{move-only type 'MoveOnlyStruct' cannot be used with generics yet}}
 }
 
 @_moveOnly
@@ -44,7 +50,7 @@ struct SMoveOnly {
 enum E { // expected-error {{enum 'E' cannot contain a move-only type without also being move-only}}
     case lhs(CopyableKlass)
     case rhs(MoveOnlyKlass) // expected-note {{contained move-only enum case 'E.rhs'}}
-    case rhs2(OptionalGrandField<MoveOnlyKlass>)
+    case rhs2(OptionalGrandField<MoveOnlyKlass>) // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
 }
 
 @_moveOnly
@@ -56,13 +62,13 @@ enum EMoveOnly {
 func foo() {
     class C2 {
         var copyable: CopyableKlass? = nil
-        var moveOnly: MoveOnlyKlass? = nil
+        var moveOnly: MoveOnlyKlass? = nil // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
     }
 
     @_moveOnly
     class C2MoveOnly {
         var copyable: CopyableKlass? = nil
-        var moveOnly: MoveOnlyKlass? = nil
+        var moveOnly: MoveOnlyKlass? = nil // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
     }
 
     struct S2 { // expected-error {{struct 'S2' cannot contain a move-only type without also being move-only}}
@@ -89,13 +95,13 @@ func foo() {
     {
         class C3 {
             var copyable: CopyableKlass? = nil
-            var moveOnly: MoveOnlyKlass? = nil
+            var moveOnly: MoveOnlyKlass? = nil // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
         }
 
         @_moveOnly
         class C3MoveOnly {
             var copyable: CopyableKlass? = nil
-            var moveOnly: MoveOnlyKlass? = nil
+            var moveOnly: MoveOnlyKlass? = nil // expected-error {{move-only type 'MoveOnlyKlass' cannot be used with generics yet}}
         }
 
         struct S3 { // expected-error {{struct 'S3' cannot contain a move-only type without also being move-only}}


### PR DESCRIPTION
resolves rdar://101651405

Needed-before-merge TODOs:
- [x] Prevent conformances to `Copyable` from appearing in swiftinterface files (see `Sema/missing-import-typealias.swift`)
- [x] Fix any other issues with other tests.

Deferrable TODOs:
- [x] Diagnose expressions that explicitly cast a move-only value to some existential as an error, not warning. i.e., `mo as! AnyHashable`. Alternatively, make sure they truly do fail at runtime.
- [ ] Improve diagnostics (specify the 2nd type it failed to match with in the message!)
- [ ] Prevent move-only types from appearing in tuples.
- [x] Make pack types (`repeat each T`) conform to `_Copyable` (see `Generics/tuple-conformances.swift`)
- [x] Get `_Copyable` out of the stdlib and make it some sort of builtin that's pre-populated in the ASTContext, like `Any`. We can't bootstrap the stdlib if that protocol is defined in some part of the stdlib, because every generic parameter is implicitly constrained to it and we have to be able to typecheck with `-parse-stdlib`. (see `Sema/stdlib_sugar_types.swift`)
- [ ] Determine whether changes to the diagnostics for unqualified member lookups are a significant concern and whether we can mitigate them. Example:
```
protocol MungedString {}

func format<T: MungedString>(_ t: T) {}
func takeGeneric<T>(_ t: T) {}

func caller() {
  // PREVIOUSLY error: type 'MungedString' has no member 'emptyString'
  // NOW error: reference to member 'emptyString' cannot be resolved without a contextual type
  format(.emptyString)

  // PREVIOUSLY error: cannot infer contextual base in reference to member 'somebody'
  // NOW error: type '_Copyable' has no member 'somebody'
  takeGeneric(.somebody)
}
```
