### PR TITLE
[AddressLowering] Rematerialize projections eagerly.

### DIFF
--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -2096,6 +2096,10 @@ exit:
   return %retval : $()
 }
 
+enum PairEnum<T> {
+  case it(T, T)
+}
+
 // CHECK-LABEL: sil [ossa] @test_destructure_tuple_1_guaranteed : {{.*}} {
 // CHECK:         [[INSTANCE:%[^,]+]] = unchecked_take_enum_data_addr
 // CHECK:         [[KLASS_ADDR:%[^,]+]] = tuple_element_addr [[INSTANCE]] {{.*}}, 0
@@ -2125,6 +2129,55 @@ exit:
   return %505 : $()
 }
 
+
+// Verify that the init_enum_data_addr instruction is created before its first
+// use.  Although the opaque values are visited in forward order, their
+// uses are visited at the same time.  At that point, addresses are
+// materialized, and, in this case, an init_enum_data_addr is created.
+//
+// In this test, because %second_in is the first opaque value (i.e. in forward
+// order), its copy_value use is visited before %first_out is defined.  If the
+// init_enum_data_addr were created at that point and reused from then on, it
+// would be reused when rewriting the def of %first_out:
+//
+//     %second_in_addr = alloc_stack $T
+//     %out_addr = alloc_stack $PairEnum<T>
+//     apply undef<T>(%second_in_addr)
+//     %first_out_addr = tuple_element_addr %enum_data_addr, 0
+//                                          ^^^^^^^^^^^^^^^ USE BEFORE DEF
+//     apply undef<T>(%first_out_addr)
+//     %enum_data_addr = init_enum_data_addr %out_addr
+//     %second_out_addr = tuple_element_addr %enum_data_addr, 1
+//     copy_addr %second_in_addr to [init] %second_out_addr
+//
+// We would end up with a use of %enum_data_addr (in the definition of
+// %first_out_addr) that is not dominated by %enum_data_addr's def.
+//
+// CHECK-LABEL: sil [ossa] @test_enum_1_tuple_projection_dominance : {{.*}} {
+// CHECK:         [[SECOND_IN_ADDR:%[^,]+]] = alloc_stack $T
+// CHECK:         [[OUT_ADDR:%[^,]+]] = alloc_stack $PairEnum<T>
+// CHECK:         apply undef<T>([[SECOND_IN_ADDR]])
+// CHECK:         [[ENUM_DATA_ADDR:%[^,]+]] = init_enum_data_addr [[OUT_ADDR]]
+// CHECK:         [[FIRST_OUT_ADDR:%[^,]+]] = tuple_element_addr [[ENUM_DATA_ADDR]]{{.*}}, 0
+// CHECK:         apply undef<T>([[FIRST_OUT_ADDR]])
+// CHECK:         [[SECOND_OUT_ADDR:%[^,]+]] = tuple_element_addr [[ENUM_DATA_ADDR]]{{.*}}, 1
+// CHECK:         copy_addr [[SECOND_IN_ADDR]] to [init] [[SECOND_OUT_ADDR]]
+// CHECK:         inject_enum_addr [[OUT_ADDR]]
+// CHECK:         destroy_addr [[OUT_ADDR]]
+// CHECK:         destroy_addr [[SECOND_IN_ADDR]]
+// CHECK-LABEL: } // end sil function 'test_enum_1_tuple_projection_dominance'
+sil [ossa] @test_enum_1_tuple_projection_dominance : $@convention(thin) <T> () -> () {
+bb0:
+  %second_in = apply undef<T>() : $@convention(thin) <Tee> () -> @out Tee
+  %first_out = apply undef<T>() : $@convention(thin) <Tee> () -> @out Tee
+  %second_out = copy_value %second_in : $T
+  %pair_out = tuple (%first_out : $T, %second_out : $T)
+  %out = enum $PairEnum<T>, #PairEnum.it!enumelt, %pair_out : $(T, T)
+  destroy_value %out : $PairEnum<T>
+  destroy_value %second_in : $T
+  %retval = tuple ()
+  return %retval : $()
+}
 
 // CHECK-LABEL: sil hidden [ossa] @test_store_1 : {{.*}} {
 // CHECK:         [[MAYBE_ADDR:%[^,]+]] = alloc_stack $Optional<Self>


### PR DESCRIPTION
The pass rewrites opaque values in reverse post order of their definitions.  When an opaque value is rewritten, both its definition and its uses are rewritten.  When a def or a use is rewritten, in order to materialize an address with which to rewrite, projection instructions are created.  Some of these projection instructions may be reused when rewriting later opaque values.

As a result, it's possible to have two opaque values `A` and `B` (which are rewritten in that order) such that rewriting a use of `A` which occurs "after" the def (or a use) of `B` creates a projection `P` which is then used by that "earlier" def (or use) of `B`:

    ```
    A =
    B =     // relies on P
    use B
    use A   // creates some projection P
    ```

When rewriting the def (or that use, respectively) of `B`, the projection which was created for the use of `A` will be reused.  But that projection instruction will be "after" the place where it is used when rewriting the def or use of `B`.  That's invalid!

To address this, rather than reusing the old instruction, always create a new instruction for a projection.  If the new instruction occurs "before" (i.e. dominates) the old instruction replace uses of the old with the new and delete the old.  Otherwise, just delete the new instruction.
