### PR TITLE
Fix objc_direct test that was failing on watchOS

### DIFF
--- a/test/IRGen/objc_direct.swift
+++ b/test/IRGen/objc_direct.swift
@@ -2,9 +2,6 @@
 
 // REQUIRES: objc_interop
 
-// rdar://103369740 #62183
-// UNSUPPORTED: OS=watchos
-
 func markUsed<T>(_ t: T) {}
 
 protocol BarProtocol {
@@ -15,9 +12,9 @@ extension Bar: BarProtocol {}
 
 let bar = Bar()
 markUsed(Bar(value: 0))
-// CHECK: call swiftcc i64 @"$sSo3BarC5valueABSgs5Int32V_tcfC"
+// CHECK: call swiftcc {{i32|i64}} @"$sSo3BarC5valueABSgs5Int32V_tcfC"
 markUsed(Bar.init(value: 0))
-// CHECK: call swiftcc i64 @"$sSo3BarC5valueABSgs5Int32V_tcfC"
+// CHECK: call swiftcc {{i32|i64}} @"$sSo3BarC5valueABSgs5Int32V_tcfC"
 
 bar.directProperty = 123
 // CHECK: call void @"\01-[Bar setDirectProperty:]"({{.*}}, i8* undef, i32 {{.*}})
@@ -60,8 +57,8 @@ markUsed(Bar.directClassMethod2())
 markUsed(bar.directProtocolMethod())
 // CHECK: call {{.*}} @"\01-[Bar directProtocolMethod]"({{.*}}, i8* undef)
 
-// CHECK: define {{.*}} swiftcc i64 @"$sSo3BarC5valueABSgs5Int32V_tcfC"
-// CHECK:   call swiftcc i64 @"$sSo3BarC5valueABSgs5Int32V_tcfcTO"
+// CHECK: define {{.*}} swiftcc {{i32|i64}} @"$sSo3BarC5valueABSgs5Int32V_tcfC"
+// CHECK:   call swiftcc {{i32|i64}} @"$sSo3BarC5valueABSgs5Int32V_tcfcTO"
 // CHECK: }
 
 // CHECK-DAG: declare i32 @"\01-[Bar directProperty]"
@@ -76,6 +73,6 @@ markUsed(bar.directProtocolMethod())
 // CHECK-DAG: declare {{.*}} @"\01+[Bar directClassMethod2]"
 // CHECK-DAG: declare {{.*}} @"\01-[Bar directProtocolMethod]"
 
-// CHECK: define {{.*}} swiftcc i64 @"$sSo3BarC5valueABSgs5Int32V_tcfcTO"
+// CHECK: define {{.*}} swiftcc {{i32|i64}} @"$sSo3BarC5valueABSgs5Int32V_tcfcTO"
 // CHECK:   call {{.*}} @"\01-[Bar initWithValue:]"
 // CHECK: }


### PR DESCRIPTION
https://github.com/apple/swift/pull/62183 extended the `IRGen/objc_direct.swift` test to support calling `objc_direct` constructors. https://github.com/apple/swift/pull/62593 disabled this test for the watchOS target because it was failing.

This fixes the incorrect assumption that some functions return `i64`, which is why the test was failing.
