### PR TITLE
[New parser] Move round-trip checking logic into ASTGen

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2019,5 +2019,8 @@ ERROR(macro_expansion_expr_expected_macro_identifier,none,
 ERROR(macro_expansion_decl_expected_macro_identifier,none,
       "expected a macro identifier for a pound literal declaration", ())
 
+ERROR(parser_round_trip_error,none,
+      "source file did not round-trip through the Swift Swift parser", ())
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -48,3 +48,14 @@ public func destroySourceFile(
     sourceFile.deallocate()
   }
 }
+
+/// Check for whether the given source file round-trips
+@_cdecl("swift_ASTGen_roundTripCheck")
+public func roundTripCheck(
+  sourceFilePtr: UnsafeMutablePointer<UInt8>
+) -> CInt {
+  sourceFilePtr.withMemoryRebound(to: ExportedSourceFile.self, capacity: 1) { sourceFile in
+    let sf = sourceFile.pointee
+    return sf.syntax.syntaxTextBytes.elementsEqual(sf.buffer) ? 0 : 1
+  }
+}

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -176,17 +176,11 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
     tokensRef = ctx.AllocateCopy(*tokens);
 
 #if SWIFT_SWIFT_PARSER
-  if ((ctx.LangOpts.hasFeature(Feature::ParserRoundTrip) ||
-       ctx.LangOpts.hasFeature(Feature::ParserValidation)) &&
+  if (ctx.LangOpts.hasFeature(Feature::ParserValidation) &&
       ctx.SourceMgr.getIDEInspectionTargetBufferID() != bufferID &&
       SF->Kind != SourceFileKind::SIL) {
     auto bufferRange = ctx.SourceMgr.getRangeForBuffer(*bufferID);
     unsigned int flags = 0;
-
-    if (ctx.LangOpts.hasFeature(Feature::ParserRoundTrip) &&
-        !parser.L->lexingCutOffOffset()) {
-      flags |= SCC_RoundTrip;
-    }
 
     if (!ctx.Diags.hadAnyError() &&
         ctx.LangOpts.hasFeature(Feature::ParserValidation))


### PR DESCRIPTION
This removes one bit of code dependency on SwiftCompilerSupport, which we want to eliminate.
