### PR TITLE
Copy files from SwiftSyntax’s gyb_syntax_support that are relevant to the compiler to this repo

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -8,7 +8,7 @@ include(SwiftCXXUtils)
 function(_swift_gyb_target_sources target scope)
   file(GLOB GYB_UNICODE_DATA ${SWIFT_SOURCE_DIR}/utils/UnicodeData/*)
   file(GLOB GYB_STDLIB_SUPPORT ${SWIFT_SOURCE_DIR}/utils/gyb_stdlib_support.py)
-  file(GLOB GYB_SYNTAX_SUPPORT ${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/*.py)
+  file(GLOB GYB_SYNTAX_SUPPORT ${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/*.py)
   file(GLOB GYB_SOURCEKIT_SUPPORT ${SWIFT_SOURCE_DIR}/utils/gyb_sourcekit_support/*.py)
   set(GYB_SOURCES
     ${SWIFT_SOURCE_DIR}/utils/gyb
@@ -26,7 +26,7 @@ function(_swift_gyb_target_sources target scope)
 
     add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${generated}
       COMMAND
-        ${CMAKE_COMMAND} -E env PYTHONPATH=${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE} $<TARGET_FILE:Python3::Interpreter> ${SWIFT_SOURCE_DIR}/utils/gyb -D CMAKE_SIZEOF_VOID_P=${CMAKE_SIZEOF_VOID_P} ${SWIFT_GYB_FLAGS} -o ${CMAKE_CURRENT_BINARY_DIR}/${generated}.tmp ${absolute}
+        ${CMAKE_COMMAND} -E env $<TARGET_FILE:Python3::Interpreter> ${SWIFT_SOURCE_DIR}/utils/gyb -D CMAKE_SIZEOF_VOID_P=${CMAKE_SIZEOF_VOID_P} ${SWIFT_GYB_FLAGS} -o ${CMAKE_CURRENT_BINARY_DIR}/${generated}.tmp ${absolute}
       COMMAND
         ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/${generated}.tmp ${CMAKE_CURRENT_BINARY_DIR}/${generated}
       COMMAND

--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -58,7 +58,7 @@ function(handle_gyb_source_single dependency_out_var_name)
       COMMAND
           "${CMAKE_COMMAND}" -E make_directory "${dir}"
       COMMAND
-          "${CMAKE_COMMAND}" -E env PYTHONPATH=${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE} "$<TARGET_FILE:Python3::Interpreter>" "${gyb_tool}" ${SWIFT_GYB_FLAGS} ${GYB_SINGLE_FLAGS} -o "${GYB_SINGLE_OUTPUT}.tmp" "${GYB_SINGLE_SOURCE}"
+          "${CMAKE_COMMAND}" -E env "$<TARGET_FILE:Python3::Interpreter>" "${gyb_tool}" ${SWIFT_GYB_FLAGS} ${GYB_SINGLE_FLAGS} -o "${GYB_SINGLE_OUTPUT}.tmp" "${GYB_SINGLE_SOURCE}"
       COMMAND
           "${CMAKE_COMMAND}" -E copy_if_different "${GYB_SINGLE_OUTPUT}.tmp" "${GYB_SINGLE_OUTPUT}"
       COMMAND

--- a/include/swift/AST/CMakeLists.txt
+++ b/include/swift/AST/CMakeLists.txt
@@ -11,10 +11,7 @@ set(generated_include_sources
 add_gyb_target(swift-ast-generated-headers
     "${generated_include_sources}"
     DEPENDS
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/kinds.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/AttributeKinds.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/Classification.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/Token.py"
-      "${SWIFT_PATH_TO_SWIFT_SYNTAX_SOURCE}/gyb_syntax_support/Utils.py")
+      "${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/AttributeKinds.py"
+      "${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/Token.py")
 set_property(TARGET swift-ast-generated-headers
     PROPERTY FOLDER "Miscellaneous")

--- a/utils/gyb_syntax_support/AttributeKinds.py
+++ b/utils/gyb_syntax_support/AttributeKinds.py
@@ -1,0 +1,912 @@
+import sys
+
+def error(msg):
+    print('error: ' + msg, file=sys.stderr)
+    sys.exit(-1)
+
+class Attribute(object):
+    def __init__(self, name, swift_name=None):
+        self.name = name
+        self.swift_name = swift_name or name
+
+class TypeAttribute(Attribute):
+    def __init__(self, name):
+        super().__init__(name, name)
+
+class DeclAttribute(Attribute):
+    def __init__(self, name, class_name, *options, code, swift_name=None):
+        super().__init__(name, swift_name)
+        self.class_name = class_name
+        self.options = options
+        self.code = code
+
+class SimpleDeclAttribute(DeclAttribute):
+    def __init__(self, name, class_name, *options, code, swift_name=None):
+        super().__init__(name, class_name, *options, code=code, swift_name=swift_name)
+
+class ContextualDeclAttribute(DeclAttribute):
+    def __init__(self, name, class_name, *options, code):
+        super().__init__(name, class_name, *options, code=code)
+
+class ContextualSimpleDeclAttribute(SimpleDeclAttribute):
+    def __init__(self, name, class_name, *options, code):
+        super().__init__(name, class_name, *options, code=code)
+
+class DeclAttributeAlias(Attribute):
+    def __init__(self, name, class_name, swift_name=None):
+        super().__init__(name, swift_name)
+        self.class_name = class_name
+
+class ContextualDeclAttributeAlias(DeclAttributeAlias):
+    def __init__(self, name, class_name, swift_name=None):
+        super().__init__(name, class_name, swift_name)
+
+class BuiltinDeclModifier(Attribute):
+    def __init__(self, name, swift_name=None):
+        super().__init__(name, swift_name)
+
+# Abstract class aggregations for use in Attr.def.
+OnValue = 'OnValue'
+OnTypeAlias = 'OnTypeAlias'
+OnEnumElement = 'OnEnumElement'
+OnMacro = 'OnMacro'
+OnSubscript = 'OnSubscript'
+OnVar = 'OnVar'
+OnExtension = 'OnExtension'
+OnClass = 'OnClass'
+OnFunc = 'OnFunc'
+OnAccessor = 'OnAccessor'
+OnEnum = 'OnEnum'
+OnConstructor = 'OnConstructor'
+OnStruct = 'OnStruct'
+OnImport = 'OnImport'
+OnAssociatedType = 'OnAssociatedType'
+OnGenericTypeParam = 'OnGenericTypeParam'
+OnParam = 'OnParam'
+OnNominalType = 'OnNominalType'
+OnProtocol = 'OnProtocol'
+OnConcreteNominalType = 'OnConcreteNominalType'
+OnGenericType = 'OnGenericType'
+OnAbstractFunction = 'OnAbstractFunction'
+OnOperator = 'OnOperator'
+OnAnyDecl = 'OnAnyDecl'
+
+# True if multiple instances of this attribute are allowed on a single
+# declaration.
+AllowMultipleAttributes = 'AllowMultipleAttributes'
+
+# True if this is a decl modifier - i.e., that it should not be spelled
+# with an @.
+DeclModifier = 'DeclModifier'
+
+# True if this is a long attribute that should be printed on its own line.
+#
+# Currently has no effect on DeclModifier attributes.
+LongAttribute = 'LongAttribute'
+
+# True if this shouldn't be serialized.
+NotSerialized = 'NotSerialized'
+
+# True if this attribute is only valid when parsing a .sil file.
+SILOnly = 'SILOnly'
+
+# The attribute should be reported by parser as unknown.
+RejectByParser = 'RejectByParser'
+
+# Whether client code cannot use the attribute.
+UserInaccessible = 'UserInaccessible'
+
+# Whether adding this attribute can break API
+APIBreakingToAdd = 'APIBreakingToAdd'
+
+# Whether removing this attribute can break API
+APIBreakingToRemove = 'APIBreakingToRemove'
+
+# Whether adding this attribute can break ABI
+ABIBreakingToAdd = 'ABIBreakingToAdd'
+
+# Whether removing this attribute can break ABI
+ABIBreakingToRemove = 'ABIBreakingToRemove'
+
+# The opposite of APIBreakingToAdd
+APIStableToAdd = 'APIStableToAdd'
+
+# The opposite of APIBreakingToRemove
+APIStableToRemove = 'APIStableToRemove'
+
+# The opposite of ABIBreakingToAdd
+ABIStableToAdd = 'ABIStableToAdd'
+
+# The opposite of ABIBreakingToRemove
+ABIStableToRemove = 'ABIStableToRemove'
+
+# Whether this attribute is only valid when concurrency is enabled.
+ConcurrencyOnly = 'ConcurrencyOnly'
+
+# Whether this attribute is valid on additional decls in ClangImporter.
+OnAnyClangDecl = 'OnAnyClangDecl'
+
+# Type attributes
+TYPE_ATTR_KINDS = [
+    TypeAttribute('autoclosure'),
+    TypeAttribute('convention'),
+    TypeAttribute('noescape'),
+    TypeAttribute('escaping'),
+    TypeAttribute('differentiable'),
+    TypeAttribute('noDerivative'),
+    TypeAttribute('async'),
+    TypeAttribute('Sendable'),
+    TypeAttribute('unchecked'),
+    TypeAttribute('_local'),
+    TypeAttribute('_noMetadata'),
+
+    # Generated interface attributes
+    TypeAttribute('_opaqueReturnTypeOf'),
+]
+
+# Schema for `DeclAttribute`s:
+#
+# - Attribute name.
+# - C++ class name without the 'Attr' suffix
+# - Options for the attribute, including:
+#    * the declarations the attribute can appear on
+#    * whether duplicates are allowed
+# - Unique attribute identifier used for serialization. This
+#   can never be changed.
+#
+# SimpleDeclAttribute is the same, but the class becomes
+# SimpleDeclAttr<DAK_##NAME> on the C++ side.
+#
+# Please help ease code review/audits:
+# - Please place the "OnXYZ" flags together on the next line.
+# - Please place the non-OnXYZ flags together on the next to last line.
+# - Please place the unique code number on the last line.
+# - Please sort attributes by serialization number.
+# - Please create a "NOTE" comment if a unique number is skipped.
+#
+# If you're adding a new kind of "attribute" that is spelled without a leading
+# '@' symbol, add an entry to the `DECL_MODIFIER_KINDS` array instead.
+#
+# If you're adding a new underscored attribute here, please document it in
+# docs/ReferenceGuides/UnderscoredAttributes.md.
+DECL_ATTR_KINDS = [
+    DeclAttribute('_silgen_name', 'SILGenName',
+                  OnAbstractFunction,
+                  LongAttribute,  UserInaccessible,  ABIStableToAdd,  ABIStableToRemove,
+                  APIStableToAdd,  APIStableToRemove,
+                  code=0),
+    DeclAttribute('available', 'Available',
+                  OnAbstractFunction,  OnGenericType,  OnVar,  OnSubscript,  OnEnumElement, OnMacro,
+                  OnExtension,  AllowMultipleAttributes,  LongAttribute,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=1),
+    DeclAttribute('objc', 'ObjC',
+                  OnAbstractFunction,  OnClass,  OnProtocol,  OnExtension,  OnVar,
+                  OnSubscript,  OnEnum,  OnEnumElement,
+                  ABIBreakingToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=3),
+    SimpleDeclAttribute('dynamicCallable', 'DynamicCallable',
+                        OnNominalType,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=6),
+    DeclAttribute('main', 'MainType',
+                  OnClass,  OnStruct,  OnEnum,  OnExtension,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=7),
+    SimpleDeclAttribute('_exported', 'Exported',
+                        OnImport,
+                        UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=8),
+    SimpleDeclAttribute('dynamicMemberLookup', 'DynamicMemberLookup',
+                        OnNominalType,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=9),
+    SimpleDeclAttribute('NSCopying', 'NSCopying',
+                        OnVar,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=10),
+    SimpleDeclAttribute('IBAction', 'IBAction',
+                        OnFunc,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=11),
+    SimpleDeclAttribute('IBDesignable', 'IBDesignable',
+                        OnClass,  OnExtension,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=12),
+    SimpleDeclAttribute('IBInspectable', 'IBInspectable',
+                        OnVar,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=13),
+    SimpleDeclAttribute('IBOutlet', 'IBOutlet',
+                        OnVar,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=14),
+    SimpleDeclAttribute('NSManaged', 'NSManaged',
+                        OnVar,  OnFunc,  OnAccessor,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=15),
+    SimpleDeclAttribute('LLDBDebuggerFunction', 'LLDBDebuggerFunction',
+                        OnFunc,
+                        UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=17),
+    SimpleDeclAttribute('UIApplicationMain', 'UIApplicationMain',
+                        OnClass,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=18),
+    SimpleDeclAttribute('unsafe_no_objc_tagged_pointer', 'UnsafeNoObjCTaggedPointer',
+                        OnProtocol,
+                        UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=19),
+    DeclAttribute('inline', 'Inline',
+                  OnVar,  OnSubscript,  OnAbstractFunction,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=20),
+    DeclAttribute('_semantics', 'Semantics',
+                  OnAbstractFunction,  OnSubscript,  OnNominalType,  OnVar,
+                  AllowMultipleAttributes,  UserInaccessible,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=21),
+    SimpleDeclAttribute('_transparent', 'Transparent',
+                        OnFunc,  OnAccessor,  OnConstructor,  OnVar,  UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=26),
+    SimpleDeclAttribute('requires_stored_property_inits', 'RequiresStoredPropertyInits',
+                        OnClass,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=27),
+    SimpleDeclAttribute('nonobjc', 'NonObjC',
+                        OnExtension,  OnFunc,  OnAccessor,  OnVar,  OnSubscript,  OnConstructor,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=30),
+    SimpleDeclAttribute('_fixed_layout', 'FixedLayout',
+                        OnVar,  OnClass,  OnStruct,  OnProtocol,
+                        UserInaccessible,  ABIBreakingToAdd,  ABIBreakingToRemove,
+                        APIStableToAdd,  APIStableToRemove,
+                        code=31),
+    SimpleDeclAttribute('inlinable', 'Inlinable',
+                        OnVar,  OnSubscript,  OnAbstractFunction,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=32),
+    DeclAttribute('_specialize', 'Specialize',
+                  OnConstructor,  OnFunc,  OnAccessor,
+                  AllowMultipleAttributes,  LongAttribute,  UserInaccessible,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=33),
+    SimpleDeclAttribute('objcMembers', 'ObjCMembers',
+                        OnClass,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=34),
+    ContextualSimpleDeclAttribute('_compilerInitialized', 'CompilerInitialized',
+                                  OnVar,
+                                  UserInaccessible,
+                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  code=35),
+    SimpleDeclAttribute('_hasStorage', 'HasStorage',
+                        OnVar,
+                        UserInaccessible,
+                        NotSerialized,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=45),
+    DeclAttribute('__raw_doc_comment', 'RawDocComment',
+                  OnAnyDecl,
+                  UserInaccessible,
+                  RejectByParser,
+                  NotSerialized,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=48),
+    DeclAttribute('_effects', 'Effects',
+                  OnAbstractFunction,
+                  AllowMultipleAttributes,  UserInaccessible,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=50),
+    DeclAttribute('__objc_bridged', 'ObjCBridged',
+                  OnClass,
+                  UserInaccessible,
+                  RejectByParser,
+                  NotSerialized,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=51),
+    SimpleDeclAttribute('NSApplicationMain', 'NSApplicationMain',
+                        OnClass,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=52),
+    SimpleDeclAttribute('_objc_non_lazy_realization', 'ObjCNonLazyRealization',
+                        OnClass,
+                        UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=53),
+    DeclAttribute('__synthesized_protocol', 'SynthesizedProtocol',
+                  OnConcreteNominalType,
+                  UserInaccessible,
+                  RejectByParser,
+                  NotSerialized,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=54),
+    SimpleDeclAttribute('testable', 'Testable',
+                        OnImport,
+                        UserInaccessible,
+                        NotSerialized,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=55),
+    DeclAttribute('_alignment', 'Alignment',
+                  OnStruct,  OnEnum,
+                  UserInaccessible,
+                  ABIBreakingToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=56),
+    SimpleDeclAttribute('rethrows', 'AtRethrows',
+                        OnProtocol,
+                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        swift_name='atRethrows',
+                        code=58),
+    DeclAttribute('_swift_native_objc_runtime_base', 'SwiftNativeObjCRuntimeBase',
+                  OnClass,
+                  UserInaccessible,
+                  ABIBreakingToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=59),
+    SimpleDeclAttribute('warn_unqualified_access', 'WarnUnqualifiedAccess',
+                        OnFunc,  OnAccessor,  #| OnVar
+                        LongAttribute,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=61),
+    SimpleDeclAttribute('_show_in_interface', 'ShowInInterface',
+                        OnProtocol,
+                        UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=62),
+    DeclAttribute('_cdecl', 'CDecl',
+                  OnFunc,  OnAccessor,
+                  LongAttribute,  UserInaccessible,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=63),
+    SimpleDeclAttribute('usableFromInline', 'UsableFromInline',
+                        OnAbstractFunction,  OnVar,  OnSubscript,  OnNominalType,  OnTypeAlias,
+                        LongAttribute,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=64),
+    SimpleDeclAttribute('discardableResult', 'DiscardableResult',
+                        OnFunc,  OnAccessor,  OnConstructor,
+                        LongAttribute,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=65),
+    SimpleDeclAttribute('GKInspectable', 'GKInspectable',
+                        OnVar,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=66),
+    DeclAttribute('_implements', 'Implements',
+                  OnFunc,  OnAccessor,  OnVar,  OnSubscript,  OnTypeAlias,
+                  UserInaccessible,
+                  NotSerialized,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=67),
+    DeclAttribute('_objcRuntimeName', 'ObjCRuntimeName',
+                  OnClass,
+                  UserInaccessible,
+                  NotSerialized,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=68),
+    SimpleDeclAttribute('_staticInitializeObjCMetadata', 'StaticInitializeObjCMetadata',
+                        OnClass,
+                        UserInaccessible,
+                        LongAttribute,  RejectByParser,
+                        NotSerialized,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=69),
+    DeclAttribute('_restatedObjCConformance', 'RestatedObjCConformance',
+                  OnProtocol,
+                  UserInaccessible,
+                  LongAttribute,  RejectByParser,
+                  NotSerialized,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=70),
+  # NOTE: 71 is unused
+    DeclAttribute('_objcImplementation', 'ObjCImplementation',
+                  OnExtension,
+                  UserInaccessible,
+                  ABIBreakingToAdd, ABIBreakingToRemove, APIBreakingToAdd, APIBreakingToRemove,
+                  code=72),
+    DeclAttribute('_optimize', 'Optimize',
+                  OnAbstractFunction,  OnSubscript,  OnVar,
+                  UserInaccessible,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=73),
+    DeclAttribute('_clangImporterSynthesizedType', 'ClangImporterSynthesizedType',
+                  OnGenericType,
+                  LongAttribute,  RejectByParser,  UserInaccessible,
+                  NotSerialized,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=74),
+    SimpleDeclAttribute('_weakLinked', 'WeakLinked',
+                        OnNominalType,  OnAssociatedType,  OnFunc,  OnAccessor,  OnVar,
+                        OnSubscript,  OnConstructor,  OnEnumElement,  OnExtension,  OnImport,
+                        UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=75),
+    SimpleDeclAttribute('frozen', 'Frozen',
+                        OnEnum,  OnStruct,  ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToRemove,  APIStableToAdd,
+                        code=76),
+    DeclAttributeAlias('_frozen', 'Frozen'),
+    SimpleDeclAttribute('_forbidSerializingReference', 'ForbidSerializingReference',
+                        OnAnyDecl,
+                        LongAttribute,  RejectByParser,  UserInaccessible,  NotSerialized,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=77),
+    SimpleDeclAttribute('_hasInitialValue', 'HasInitialValue',
+                        OnVar,
+                        UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=78),
+    SimpleDeclAttribute('_nonoverride', 'NonOverride',
+                        OnFunc,  OnAccessor,  OnVar,  OnSubscript,  OnConstructor,  OnAssociatedType,
+                        UserInaccessible,  NotSerialized,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=79),
+    DeclAttribute('_dynamicReplacement', 'DynamicReplacement',
+                  OnAbstractFunction,  OnVar,  OnSubscript,  UserInaccessible,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=80),
+    SimpleDeclAttribute('_borrowed', 'Borrowed',
+                        OnVar,  OnSubscript,  UserInaccessible,
+                        NotSerialized,
+                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=81),
+    DeclAttribute('_private', 'PrivateImport',
+                  OnImport,
+                  UserInaccessible,
+                  NotSerialized,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=82),
+    SimpleDeclAttribute('_alwaysEmitIntoClient', 'AlwaysEmitIntoClient',
+                        OnVar,  OnSubscript,  OnAbstractFunction,  UserInaccessible,
+                        ABIBreakingToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=83),
+
+    SimpleDeclAttribute('_implementationOnly', 'ImplementationOnly',
+                        OnImport,  OnFunc,  OnConstructor,  OnVar,  OnSubscript,  UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=84),
+    DeclAttribute('_custom', 'Custom',
+                  OnAnyDecl,  RejectByParser,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=85),
+    SimpleDeclAttribute('propertyWrapper', 'PropertyWrapper',
+                        OnStruct,  OnClass,  OnEnum,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=86),
+    SimpleDeclAttribute('_disfavoredOverload', 'DisfavoredOverload',
+                        OnAbstractFunction,  OnVar,  OnSubscript,  UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=87),
+    SimpleDeclAttribute('resultBuilder', 'ResultBuilder',
+                        OnNominalType,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=88),
+    DeclAttribute('_projectedValueProperty', 'ProjectedValueProperty',
+                  OnVar,  UserInaccessible,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=89),
+    SimpleDeclAttribute('_nonEphemeral', 'NonEphemeral',
+                        OnParam,  UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIBreakingToAdd,  APIStableToRemove,
+                        code=90),
+
+    DeclAttribute('differentiable', 'Differentiable',
+                  OnAccessor,  OnConstructor,  OnFunc,  OnVar,  OnSubscript,  LongAttribute,
+                  AllowMultipleAttributes,
+                  ABIStableToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIBreakingToRemove,
+                  code=91),
+
+    SimpleDeclAttribute('_hasMissingDesignatedInitializers',
+                        'HasMissingDesignatedInitializers',
+                        OnClass,  UserInaccessible,  NotSerialized,
+                        APIBreakingToAdd,  ABIBreakingToAdd,  APIStableToRemove,  ABIStableToRemove,
+                        code=92),
+
+    SimpleDeclAttribute('_inheritsConvenienceInitializers',
+                        'InheritsConvenienceInitializers',
+                        OnClass,  UserInaccessible,  NotSerialized,
+                        APIStableToAdd,  ABIStableToAdd,  APIBreakingToRemove,  ABIBreakingToRemove,
+                        code=93),
+
+    DeclAttribute('_typeEraser', 'TypeEraser',
+                  OnProtocol,  UserInaccessible,
+                  ABIStableToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIBreakingToRemove,
+                  code=94),
+
+    SimpleDeclAttribute('IBSegueAction', 'IBSegueAction',
+                        OnFunc,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=95),
+
+    DeclAttribute('_originallyDefinedIn', 'OriginallyDefinedIn',
+                  OnNominalType,  OnFunc,  OnVar,  OnExtension,  UserInaccessible,
+                  AllowMultipleAttributes,  LongAttribute,
+                  ABIBreakingToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=96),
+
+    DeclAttribute('derivative', 'Derivative',
+                  OnFunc,  LongAttribute,  AllowMultipleAttributes,
+                  ABIStableToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIBreakingToRemove,
+                  code=97),
+
+    DeclAttribute('_spi', 'SPIAccessControl',
+                  OnAbstractFunction,  OnExtension,  OnGenericType,  OnVar,  OnSubscript,
+                  OnImport,  OnAccessor,  OnEnumElement, OnMacro,
+                  AllowMultipleAttributes,  UserInaccessible,
+                  ABIStableToAdd,  ABIStableToRemove,  APIBreakingToAdd,  APIStableToRemove,
+                  code=98),
+
+    DeclAttribute('transpose', 'Transpose',
+                  OnFunc,  LongAttribute,  AllowMultipleAttributes,
+                  ABIStableToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIBreakingToRemove,
+                  code=99),
+
+    SimpleDeclAttribute('noDerivative', 'NoDerivative',
+                        OnAbstractFunction,  OnVar,  OnSubscript,
+                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        code=100),
+
+    # 101 was @asyncHandler and is now unused
+
+    SimpleDeclAttribute('globalActor', 'GlobalActor',
+                        OnClass,  OnStruct,  OnEnum,
+                        ABIStableToAdd,  ABIBreakingToRemove,
+                        APIStableToAdd,  APIBreakingToRemove,
+                        code=104),
+
+    SimpleDeclAttribute('_specializeExtension', 'SpecializeExtension',
+                        OnExtension,  UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=105),
+
+    SimpleDeclAttribute('Sendable', 'Sendable',
+                        OnFunc,  OnConstructor,  OnAccessor,  OnAnyClangDecl,
+                        ABIBreakingToAdd,  ABIBreakingToRemove,
+                        APIBreakingToAdd,  APIBreakingToRemove,
+                        code=107),
+
+    SimpleDeclAttribute('_marker', 'Marker',
+                        OnProtocol,  UserInaccessible,
+                        ABIBreakingToAdd,  ABIBreakingToRemove,
+                        APIBreakingToAdd,  APIBreakingToRemove,
+                        code=108),
+
+    SimpleDeclAttribute('reasync', 'AtReasync',
+                        OnProtocol,  ConcurrencyOnly,
+                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        swift_name='atReasync',
+                        code=110),
+
+    # 111 was an experimental @completionHandlerAsync and is now unused
+
+    # 113 was experimental _unsafeSendable and is now unused
+
+    SimpleDeclAttribute('_unsafeInheritExecutor', 'UnsafeInheritExecutor',
+                        OnFunc,  UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIBreakingToRemove,
+                        code=114), # previously experimental _unsafeMainActor
+
+    SimpleDeclAttribute('_implicitSelfCapture', 'ImplicitSelfCapture',
+                        OnParam,  UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIBreakingToRemove,
+                        code=115),
+
+    SimpleDeclAttribute('_inheritActorContext', 'InheritActorContext',
+                        OnParam,  UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        code=116),
+
+    SimpleDeclAttribute('_eagerMove', 'EagerMove',
+                        UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,
+                        APIStableToAdd,  APIStableToRemove,
+                        OnFunc,  OnParam,  OnVar,  OnNominalType,
+                        code=117),
+
+    SimpleDeclAttribute('_noEagerMove', 'NoEagerMove',
+                        UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,
+                        APIStableToAdd,  APIStableToRemove,
+                        OnFunc,  OnParam,  OnVar,  OnNominalType,
+                        code=119),
+
+    SimpleDeclAttribute('_assemblyVision', 'EmitAssemblyVisionRemarks',
+                        OnFunc,  UserInaccessible,  NotSerialized,  OnNominalType,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=120),
+
+    DeclAttribute('_nonSendable', 'NonSendable',
+                  OnNominalType,
+                  UserInaccessible,  AllowMultipleAttributes,
+                  ABIStableToAdd,  ABIBreakingToRemove,
+                  APIStableToAdd,  APIBreakingToRemove,
+                  code=121),
+
+    SimpleDeclAttribute('_noImplicitCopy', 'NoImplicitCopy',
+                        UserInaccessible,
+                        ABIStableToAdd,  ABIBreakingToRemove,
+                        APIStableToAdd,  APIBreakingToRemove,
+                        OnFunc,  OnParam,  OnVar,
+                        code=122),
+
+    SimpleDeclAttribute('_noLocks', 'NoLocks',
+                        OnAbstractFunction,  OnSubscript,  UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=123),
+
+    SimpleDeclAttribute('_noAllocation', 'NoAllocation',
+                        OnAbstractFunction,  OnSubscript,  UserInaccessible,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=124),
+
+    SimpleDeclAttribute('preconcurrency', 'Preconcurrency',
+                        OnFunc,  OnConstructor,  OnProtocol,  OnGenericType,  OnVar,  OnSubscript,
+                        OnEnumElement,  OnImport,
+                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        code=125),
+
+    DeclAttribute('_unavailableFromAsync', 'UnavailableFromAsync',
+                  OnFunc,  OnConstructor,  OnMacro, UserInaccessible,
+                  ABIStableToAdd,  ABIStableToRemove,
+                  APIBreakingToAdd,  APIStableToRemove,
+                  code=127),
+
+    DeclAttribute('exclusivity', 'Exclusivity',
+                  OnVar,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=128),
+
+    DeclAttribute('_backDeploy', 'BackDeploy',
+                  OnAbstractFunction,  OnAccessor,  OnSubscript,  OnVar,
+                    AllowMultipleAttributes,  LongAttribute,  UserInaccessible,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIBreakingToRemove,
+                  code=129),
+
+    SimpleDeclAttribute('_moveOnly', 'MoveOnly',
+                        OnNominalType,
+                        UserInaccessible,
+                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        code=131),
+
+    SimpleDeclAttribute('_alwaysEmitConformanceMetadata', 'AlwaysEmitConformanceMetadata',
+                        OnProtocol,  UserInaccessible,  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=132),
+
+    DeclAttribute('_expose', 'Expose',
+                  OnFunc,  OnNominalType,  OnVar,  OnConstructor,
+                  LongAttribute,  UserInaccessible,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=133),
+
+    SimpleDeclAttribute('typeWrapper', 'TypeWrapper',
+                        OnStruct,  OnClass,  OnEnum,
+                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        code=134),
+
+    SimpleDeclAttribute('_spiOnly', 'SPIOnly',
+                        OnImport, UserInaccessible,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
+                        code=135),
+    DeclAttribute('_documentation', 'Documentation',
+                  OnAnyDecl, UserInaccessible,
+                  APIBreakingToAdd, APIStableToRemove, ABIStableToAdd, ABIStableToRemove,
+                  code=136),
+
+    SimpleDeclAttribute('typeWrapperIgnored', 'TypeWrapperIgnored',
+                        OnVar,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
+                        code=137),
+
+    SimpleDeclAttribute('_noMetadata', 'NoMetadata',
+                        OnGenericTypeParam,
+                        UserInaccessible,
+                        NotSerialized,
+                        ABIStableToAdd, ABIBreakingToRemove, APIStableToAdd, APIStableToRemove,
+                        code=138),
+
+    SimpleDeclAttribute('runtimeMetadata', 'RuntimeMetadata',
+                        OnStruct,  OnClass,
+                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        code=139)
+]
+
+# Schema for declaration modifiers:
+#
+# - Modifier name.
+# - C++ class name without the 'Attr' suffix
+# - Options for the attribute, including:
+#    * the declarations the attribute can appear on
+#    * whether duplicates are allowed
+# - Unique attribute identifier used for serialization. This
+#   can never be changed.
+#
+# SimpleDeclAttribute is the same, but the class becomes
+# SimpleDeclAttr<DAK_##NAME> on the C++ side.
+#
+# Please help ease code review/audits:
+# - Please place the "OnXYZ" flags together on the next line.
+# - Please place the non-OnXYZ flags together on the next to last line.
+# - Please place the unique code number on the last line.
+# - Please sort attributes by serialization number.
+# - Please create a "NOTE" comment if a unique number is skipped.
+#
+# If you're adding a new kind of attribute that is spelled with a leading
+# '@' symbol, add an entry to the `DECL_ATTR_KINDS` array instead.
+DECL_MODIFIER_KINDS = [
+    # These are not really attributes or modifiers in the C++ AST and they are
+    # serialized directly into the ASTs they are attached to rather than using
+    # the generic attribute serialization infrastructure.
+    BuiltinDeclModifier('static', swift_name='staticKeyword'),
+    BuiltinDeclModifier('class', swift_name='classKeyword'),
+
+    ContextualSimpleDeclAttribute('final', 'Final',
+                                  OnClass,  OnFunc,  OnAccessor,  OnVar,  OnSubscript,
+                                  DeclModifier,
+                                  ABIBreakingToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  code=2),
+    ContextualSimpleDeclAttribute('required', 'Required',
+                                  OnConstructor,
+                                  DeclModifier,
+                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  code=4),
+    ContextualSimpleDeclAttribute('optional', 'Optional',
+                                  OnConstructor,  OnFunc,  OnAccessor,  OnVar,  OnSubscript,
+                                  DeclModifier,
+                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  code=5),
+    ContextualSimpleDeclAttribute('lazy', 'Lazy',  DeclModifier,
+                                  OnVar,
+                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  code=16),
+    ContextualSimpleDeclAttribute('dynamic', 'Dynamic',
+                                  OnFunc,  OnAccessor,  OnVar,  OnSubscript,  OnConstructor,
+                                  DeclModifier,  ABIBreakingToAdd,  ABIBreakingToRemove,
+                                  APIStableToAdd,  APIStableToRemove,
+                                  code=22),
+    ContextualSimpleDeclAttribute('infix', 'Infix',
+                                  OnFunc,  OnOperator,
+                                  DeclModifier,
+                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  code=23),
+    ContextualSimpleDeclAttribute('prefix', 'Prefix',
+                                  OnFunc,  OnOperator,
+                                  DeclModifier,
+                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  code=24),
+    ContextualSimpleDeclAttribute('postfix', 'Postfix',
+                                  OnFunc,  OnOperator,
+                                  DeclModifier,
+                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  code=25),
+    ContextualSimpleDeclAttribute('__consuming', 'Consuming',
+                                  OnFunc,  OnAccessor,
+                                  DeclModifier,
+                                  UserInaccessible,
+                                  NotSerialized,
+                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  code=40),
+    ContextualSimpleDeclAttribute('mutating', 'Mutating',
+                                  OnFunc,  OnAccessor,
+                                  DeclModifier,
+                                  NotSerialized,
+                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  code=41),
+    ContextualSimpleDeclAttribute('nonmutating', 'NonMutating',
+                                  OnFunc,  OnAccessor,
+                                  DeclModifier,
+                                  NotSerialized,
+                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  code=42),
+    ContextualSimpleDeclAttribute('convenience', 'Convenience',
+                                  OnConstructor,
+                                  DeclModifier,
+                                  NotSerialized,
+                                  ABIBreakingToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  code=43),
+    ContextualSimpleDeclAttribute('override', 'Override',
+                                  OnFunc,  OnAccessor,  OnVar,  OnSubscript,  OnConstructor,  OnAssociatedType,
+                                  DeclModifier,
+                                  NotSerialized,
+                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  code=44),
+    DeclAttribute('private', 'AccessControl',
+                  OnFunc,  OnAccessor,  OnExtension,  OnGenericType,  OnVar,  OnSubscript,
+                  OnConstructor, OnMacro,
+                  DeclModifier,
+                  NotSerialized,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  swift_name='privateKeyword',
+                  code=46),
+    DeclAttributeAlias('fileprivate', 'AccessControl', swift_name='fileprivateKeyword'),
+    DeclAttributeAlias('internal', 'AccessControl', swift_name='internalKeyword'),
+    DeclAttributeAlias('public', 'AccessControl', swift_name='publicKeyword'),
+    ContextualDeclAttributeAlias('open', 'AccessControl'),
+    DeclAttribute('__setter_access', 'SetterAccess',
+                  OnVar,  OnSubscript,
+                  DeclModifier,  RejectByParser,
+                  NotSerialized,
+                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  code=47),
+    ContextualDeclAttribute('weak', 'ReferenceOwnership',
+                            OnVar,
+                            DeclModifier,
+                            NotSerialized,
+                            ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                            code=49),
+    ContextualDeclAttributeAlias('unowned', 'ReferenceOwnership', swift_name='unowned'),
+
+    SimpleDeclAttribute('rethrows', 'Rethrows',
+                        OnFunc,  OnConstructor,
+                        RejectByParser,
+                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        code=57,
+                        swift_name='`rethrows`'),
+                        
+    ContextualSimpleDeclAttribute('indirect', 'Indirect',  DeclModifier,
+                                  OnEnum,  OnEnumElement,
+                                  ABIBreakingToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  code=60),
+
+    ContextualSimpleDeclAttribute('isolated', 'Isolated',
+                                  DeclModifier,  OnParam,
+                                  ABIBreakingToAdd,  ABIBreakingToRemove,
+                                  APIBreakingToAdd,  APIBreakingToRemove,
+                                  code=103),
+
+    ContextualSimpleDeclAttribute('async', 'Async',
+                                  DeclModifier,  OnVar,  OnFunc,
+                                  ABIBreakingToAdd,  ABIBreakingToRemove,
+                                  APIBreakingToAdd,  APIBreakingToRemove,
+                                  code=106),
+
+    SimpleDeclAttribute('reasync', 'Reasync',
+                        OnFunc,  OnConstructor,
+                        RejectByParser,
+                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        code=109),
+
+    ContextualSimpleDeclAttribute('nonisolated', 'Nonisolated',
+                                  DeclModifier,  OnFunc,  OnConstructor,  OnVar,  OnSubscript,
+                                  ABIStableToAdd,  ABIStableToRemove,
+                                  APIBreakingToAdd,  APIStableToRemove,
+                                  code=112),
+
+    ContextualSimpleDeclAttribute('distributed', 'DistributedActor',
+                                  DeclModifier,  OnClass,  OnFunc,  OnAccessor,  OnVar,
+                                  ABIBreakingToAdd,  ABIBreakingToRemove,
+                                  APIBreakingToAdd,  APIBreakingToRemove,
+                                  code=118),
+
+    ContextualSimpleDeclAttribute('_const', 'CompileTimeConst',
+                                  DeclModifier,  OnParam,  OnVar,
+                                  UserInaccessible,
+                                  ABIStableToAdd,  ABIStableToRemove,  APIBreakingToAdd,  APIStableToRemove,
+                                  code=126),
+
+    ContextualSimpleDeclAttribute('_local', 'KnownToBeLocal',
+                                  DeclModifier,  OnFunc,  OnParam,  OnVar,
+                                  UserInaccessible,
+                                  ABIBreakingToAdd,  ABIBreakingToRemove,
+                                  APIBreakingToAdd,  APIBreakingToRemove,
+                                  code=130),
+]
+
+DEPRECATED_MODIFIER_KINDS = [
+    # TODO: Remove this once we don't need to support 'actor' as a modifier
+    ContextualSimpleDeclAttribute('actor', 'Actor',
+                                  DeclModifier,  OnClass,  ConcurrencyOnly,
+                                  ABIBreakingToAdd,  ABIBreakingToRemove,
+                                  APIBreakingToAdd,  APIBreakingToRemove,
+                                  code=102),
+]
+
+def verify_attribute_serialization_codes(nodes):
+    # Verify that no serialization code is used twice
+    used_codes = set()
+    for node in nodes:
+        if isinstance(node, DeclAttribute):
+            if node.code in used_codes:
+                error("Serialization code %d used twice" % node.code)
+            used_codes.add(node.code)

--- a/utils/gyb_syntax_support/AttributeKinds.py
+++ b/utils/gyb_syntax_support/AttributeKinds.py
@@ -1,17 +1,21 @@
 import sys
 
+
 def error(msg):
     print('error: ' + msg, file=sys.stderr)
     sys.exit(-1)
+
 
 class Attribute(object):
     def __init__(self, name, swift_name=None):
         self.name = name
         self.swift_name = swift_name or name
 
+
 class TypeAttribute(Attribute):
     def __init__(self, name):
         super().__init__(name, name)
+
 
 class DeclAttribute(Attribute):
     def __init__(self, name, class_name, *options, code, swift_name=None):
@@ -20,30 +24,37 @@ class DeclAttribute(Attribute):
         self.options = options
         self.code = code
 
+
 class SimpleDeclAttribute(DeclAttribute):
     def __init__(self, name, class_name, *options, code, swift_name=None):
         super().__init__(name, class_name, *options, code=code, swift_name=swift_name)
+
 
 class ContextualDeclAttribute(DeclAttribute):
     def __init__(self, name, class_name, *options, code):
         super().__init__(name, class_name, *options, code=code)
 
+
 class ContextualSimpleDeclAttribute(SimpleDeclAttribute):
     def __init__(self, name, class_name, *options, code):
         super().__init__(name, class_name, *options, code=code)
+
 
 class DeclAttributeAlias(Attribute):
     def __init__(self, name, class_name, swift_name=None):
         super().__init__(name, swift_name)
         self.class_name = class_name
 
+
 class ContextualDeclAttributeAlias(DeclAttributeAlias):
     def __init__(self, name, class_name, swift_name=None):
         super().__init__(name, class_name, swift_name)
 
+
 class BuiltinDeclModifier(Attribute):
     def __init__(self, name, swift_name=None):
         super().__init__(name, swift_name)
+
 
 # Abstract class aggregations for use in Attr.def.
 OnValue = 'OnValue'
@@ -172,410 +183,410 @@ TYPE_ATTR_KINDS = [
 DECL_ATTR_KINDS = [
     DeclAttribute('_silgen_name', 'SILGenName',
                   OnAbstractFunction,
-                  LongAttribute,  UserInaccessible,  ABIStableToAdd,  ABIStableToRemove,
-                  APIStableToAdd,  APIStableToRemove,
+                  LongAttribute, UserInaccessible, ABIStableToAdd, ABIStableToRemove,
+                  APIStableToAdd, APIStableToRemove,
                   code=0),
     DeclAttribute('available', 'Available',
-                  OnAbstractFunction,  OnGenericType,  OnVar,  OnSubscript,  OnEnumElement, OnMacro,
-                  OnExtension,  AllowMultipleAttributes,  LongAttribute,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  OnAbstractFunction, OnGenericType, OnVar, OnSubscript, OnEnumElement, OnMacro,  # noqa: E501
+                  OnExtension, AllowMultipleAttributes, LongAttribute,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=1),
     DeclAttribute('objc', 'ObjC',
-                  OnAbstractFunction,  OnClass,  OnProtocol,  OnExtension,  OnVar,
-                  OnSubscript,  OnEnum,  OnEnumElement,
-                  ABIBreakingToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIStableToRemove,
+                  OnAbstractFunction, OnClass, OnProtocol, OnExtension, OnVar,
+                  OnSubscript, OnEnum, OnEnumElement,
+                  ABIBreakingToAdd, ABIBreakingToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                   code=3),
     SimpleDeclAttribute('dynamicCallable', 'DynamicCallable',
                         OnNominalType,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=6),
     DeclAttribute('main', 'MainType',
-                  OnClass,  OnStruct,  OnEnum,  OnExtension,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  OnClass, OnStruct, OnEnum, OnExtension,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=7),
     SimpleDeclAttribute('_exported', 'Exported',
                         OnImport,
                         UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=8),
     SimpleDeclAttribute('dynamicMemberLookup', 'DynamicMemberLookup',
                         OnNominalType,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=9),
     SimpleDeclAttribute('NSCopying', 'NSCopying',
                         OnVar,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=10),
     SimpleDeclAttribute('IBAction', 'IBAction',
                         OnFunc,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=11),
     SimpleDeclAttribute('IBDesignable', 'IBDesignable',
-                        OnClass,  OnExtension,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        OnClass, OnExtension,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=12),
     SimpleDeclAttribute('IBInspectable', 'IBInspectable',
                         OnVar,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=13),
     SimpleDeclAttribute('IBOutlet', 'IBOutlet',
                         OnVar,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=14),
     SimpleDeclAttribute('NSManaged', 'NSManaged',
-                        OnVar,  OnFunc,  OnAccessor,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        OnVar, OnFunc, OnAccessor,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=15),
     SimpleDeclAttribute('LLDBDebuggerFunction', 'LLDBDebuggerFunction',
                         OnFunc,
                         UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=17),
     SimpleDeclAttribute('UIApplicationMain', 'UIApplicationMain',
                         OnClass,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=18),
     SimpleDeclAttribute('unsafe_no_objc_tagged_pointer', 'UnsafeNoObjCTaggedPointer',
                         OnProtocol,
                         UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=19),
     DeclAttribute('inline', 'Inline',
-                  OnVar,  OnSubscript,  OnAbstractFunction,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  OnVar, OnSubscript, OnAbstractFunction,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=20),
     DeclAttribute('_semantics', 'Semantics',
-                  OnAbstractFunction,  OnSubscript,  OnNominalType,  OnVar,
-                  AllowMultipleAttributes,  UserInaccessible,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  OnAbstractFunction, OnSubscript, OnNominalType, OnVar,
+                  AllowMultipleAttributes, UserInaccessible,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=21),
     SimpleDeclAttribute('_transparent', 'Transparent',
-                        OnFunc,  OnAccessor,  OnConstructor,  OnVar,  UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        OnFunc, OnAccessor, OnConstructor, OnVar, UserInaccessible,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=26),
     SimpleDeclAttribute('requires_stored_property_inits', 'RequiresStoredPropertyInits',
                         OnClass,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=27),
     SimpleDeclAttribute('nonobjc', 'NonObjC',
-                        OnExtension,  OnFunc,  OnAccessor,  OnVar,  OnSubscript,  OnConstructor,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        OnExtension, OnFunc, OnAccessor, OnVar, OnSubscript, OnConstructor,  # noqa: E501
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=30),
     SimpleDeclAttribute('_fixed_layout', 'FixedLayout',
-                        OnVar,  OnClass,  OnStruct,  OnProtocol,
-                        UserInaccessible,  ABIBreakingToAdd,  ABIBreakingToRemove,
-                        APIStableToAdd,  APIStableToRemove,
+                        OnVar, OnClass, OnStruct, OnProtocol,
+                        UserInaccessible, ABIBreakingToAdd, ABIBreakingToRemove,
+                        APIStableToAdd, APIStableToRemove,
                         code=31),
     SimpleDeclAttribute('inlinable', 'Inlinable',
-                        OnVar,  OnSubscript,  OnAbstractFunction,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        OnVar, OnSubscript, OnAbstractFunction,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=32),
     DeclAttribute('_specialize', 'Specialize',
-                  OnConstructor,  OnFunc,  OnAccessor,
-                  AllowMultipleAttributes,  LongAttribute,  UserInaccessible,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  OnConstructor, OnFunc, OnAccessor,
+                  AllowMultipleAttributes, LongAttribute, UserInaccessible,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=33),
     SimpleDeclAttribute('objcMembers', 'ObjCMembers',
                         OnClass,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=34),
     ContextualSimpleDeclAttribute('_compilerInitialized', 'CompilerInitialized',
                                   OnVar,
                                   UserInaccessible,
-                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                                   code=35),
     SimpleDeclAttribute('_hasStorage', 'HasStorage',
                         OnVar,
                         UserInaccessible,
                         NotSerialized,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=45),
     DeclAttribute('__raw_doc_comment', 'RawDocComment',
                   OnAnyDecl,
                   UserInaccessible,
                   RejectByParser,
                   NotSerialized,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=48),
     DeclAttribute('_effects', 'Effects',
                   OnAbstractFunction,
-                  AllowMultipleAttributes,  UserInaccessible,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  AllowMultipleAttributes, UserInaccessible,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=50),
     DeclAttribute('__objc_bridged', 'ObjCBridged',
                   OnClass,
                   UserInaccessible,
                   RejectByParser,
                   NotSerialized,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=51),
     SimpleDeclAttribute('NSApplicationMain', 'NSApplicationMain',
                         OnClass,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=52),
     SimpleDeclAttribute('_objc_non_lazy_realization', 'ObjCNonLazyRealization',
                         OnClass,
                         UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=53),
     DeclAttribute('__synthesized_protocol', 'SynthesizedProtocol',
                   OnConcreteNominalType,
                   UserInaccessible,
                   RejectByParser,
                   NotSerialized,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=54),
     SimpleDeclAttribute('testable', 'Testable',
                         OnImport,
                         UserInaccessible,
                         NotSerialized,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=55),
     DeclAttribute('_alignment', 'Alignment',
-                  OnStruct,  OnEnum,
+                  OnStruct, OnEnum,
                   UserInaccessible,
-                  ABIBreakingToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIStableToRemove,
+                  ABIBreakingToAdd, ABIBreakingToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                   code=56),
     SimpleDeclAttribute('rethrows', 'AtRethrows',
                         OnProtocol,
-                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        ABIBreakingToAdd, ABIBreakingToRemove, APIBreakingToAdd, APIBreakingToRemove,  # noqa: E501
                         swift_name='atRethrows',
                         code=58),
     DeclAttribute('_swift_native_objc_runtime_base', 'SwiftNativeObjCRuntimeBase',
                   OnClass,
                   UserInaccessible,
-                  ABIBreakingToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIStableToRemove,
+                  ABIBreakingToAdd, ABIBreakingToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                   code=59),
     SimpleDeclAttribute('warn_unqualified_access', 'WarnUnqualifiedAccess',
-                        OnFunc,  OnAccessor,  #| OnVar
+                        OnFunc, OnAccessor,  # | OnVar
                         LongAttribute,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=61),
     SimpleDeclAttribute('_show_in_interface', 'ShowInInterface',
                         OnProtocol,
                         UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=62),
     DeclAttribute('_cdecl', 'CDecl',
-                  OnFunc,  OnAccessor,
-                  LongAttribute,  UserInaccessible,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  OnFunc, OnAccessor,
+                  LongAttribute, UserInaccessible,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=63),
     SimpleDeclAttribute('usableFromInline', 'UsableFromInline',
-                        OnAbstractFunction,  OnVar,  OnSubscript,  OnNominalType,  OnTypeAlias,
+                        OnAbstractFunction, OnVar, OnSubscript, OnNominalType, OnTypeAlias,  # noqa: E501
                         LongAttribute,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=64),
     SimpleDeclAttribute('discardableResult', 'DiscardableResult',
-                        OnFunc,  OnAccessor,  OnConstructor,
+                        OnFunc, OnAccessor, OnConstructor,
                         LongAttribute,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=65),
     SimpleDeclAttribute('GKInspectable', 'GKInspectable',
                         OnVar,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=66),
     DeclAttribute('_implements', 'Implements',
-                  OnFunc,  OnAccessor,  OnVar,  OnSubscript,  OnTypeAlias,
+                  OnFunc, OnAccessor, OnVar, OnSubscript, OnTypeAlias,
                   UserInaccessible,
                   NotSerialized,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=67),
     DeclAttribute('_objcRuntimeName', 'ObjCRuntimeName',
                   OnClass,
                   UserInaccessible,
                   NotSerialized,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=68),
     SimpleDeclAttribute('_staticInitializeObjCMetadata', 'StaticInitializeObjCMetadata',
                         OnClass,
                         UserInaccessible,
-                        LongAttribute,  RejectByParser,
+                        LongAttribute, RejectByParser,
                         NotSerialized,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=69),
     DeclAttribute('_restatedObjCConformance', 'RestatedObjCConformance',
                   OnProtocol,
                   UserInaccessible,
-                  LongAttribute,  RejectByParser,
+                  LongAttribute, RejectByParser,
                   NotSerialized,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=70),
-  # NOTE: 71 is unused
+    # NOTE: 71 is unused
     DeclAttribute('_objcImplementation', 'ObjCImplementation',
                   OnExtension,
                   UserInaccessible,
-                  ABIBreakingToAdd, ABIBreakingToRemove, APIBreakingToAdd, APIBreakingToRemove,
+                  ABIBreakingToAdd, ABIBreakingToRemove, APIBreakingToAdd, APIBreakingToRemove,  # noqa: E501
                   code=72),
     DeclAttribute('_optimize', 'Optimize',
-                  OnAbstractFunction,  OnSubscript,  OnVar,
+                  OnAbstractFunction, OnSubscript, OnVar,
                   UserInaccessible,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=73),
     DeclAttribute('_clangImporterSynthesizedType', 'ClangImporterSynthesizedType',
                   OnGenericType,
-                  LongAttribute,  RejectByParser,  UserInaccessible,
+                  LongAttribute, RejectByParser, UserInaccessible,
                   NotSerialized,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=74),
     SimpleDeclAttribute('_weakLinked', 'WeakLinked',
-                        OnNominalType,  OnAssociatedType,  OnFunc,  OnAccessor,  OnVar,
-                        OnSubscript,  OnConstructor,  OnEnumElement,  OnExtension,  OnImport,
+                        OnNominalType, OnAssociatedType, OnFunc, OnAccessor, OnVar,
+                        OnSubscript, OnConstructor, OnEnumElement, OnExtension, OnImport,  # noqa: E501
                         UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=75),
     SimpleDeclAttribute('frozen', 'Frozen',
-                        OnEnum,  OnStruct,  ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToRemove,  APIStableToAdd,
+                        OnEnum, OnStruct, ABIBreakingToAdd, ABIBreakingToRemove, APIBreakingToRemove, APIStableToAdd,  # noqa: E501
                         code=76),
     DeclAttributeAlias('_frozen', 'Frozen'),
     SimpleDeclAttribute('_forbidSerializingReference', 'ForbidSerializingReference',
                         OnAnyDecl,
-                        LongAttribute,  RejectByParser,  UserInaccessible,  NotSerialized,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        LongAttribute, RejectByParser, UserInaccessible, NotSerialized,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=77),
     SimpleDeclAttribute('_hasInitialValue', 'HasInitialValue',
                         OnVar,
                         UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=78),
     SimpleDeclAttribute('_nonoverride', 'NonOverride',
-                        OnFunc,  OnAccessor,  OnVar,  OnSubscript,  OnConstructor,  OnAssociatedType,
-                        UserInaccessible,  NotSerialized,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        OnFunc, OnAccessor, OnVar, OnSubscript, OnConstructor, OnAssociatedType,  # noqa: E501
+                        UserInaccessible, NotSerialized,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=79),
     DeclAttribute('_dynamicReplacement', 'DynamicReplacement',
-                  OnAbstractFunction,  OnVar,  OnSubscript,  UserInaccessible,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  OnAbstractFunction, OnVar, OnSubscript, UserInaccessible,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=80),
     SimpleDeclAttribute('_borrowed', 'Borrowed',
-                        OnVar,  OnSubscript,  UserInaccessible,
+                        OnVar, OnSubscript, UserInaccessible,
                         NotSerialized,
-                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIBreakingToAdd, ABIBreakingToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=81),
     DeclAttribute('_private', 'PrivateImport',
                   OnImport,
                   UserInaccessible,
                   NotSerialized,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=82),
     SimpleDeclAttribute('_alwaysEmitIntoClient', 'AlwaysEmitIntoClient',
-                        OnVar,  OnSubscript,  OnAbstractFunction,  UserInaccessible,
-                        ABIBreakingToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        OnVar, OnSubscript, OnAbstractFunction, UserInaccessible,
+                        ABIBreakingToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=83),
 
     SimpleDeclAttribute('_implementationOnly', 'ImplementationOnly',
-                        OnImport,  OnFunc,  OnConstructor,  OnVar,  OnSubscript,  UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        OnImport, OnFunc, OnConstructor, OnVar, OnSubscript, UserInaccessible,  # noqa: E501
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=84),
     DeclAttribute('_custom', 'Custom',
-                  OnAnyDecl,  RejectByParser,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  OnAnyDecl, RejectByParser,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=85),
     SimpleDeclAttribute('propertyWrapper', 'PropertyWrapper',
-                        OnStruct,  OnClass,  OnEnum,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        OnStruct, OnClass, OnEnum,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=86),
     SimpleDeclAttribute('_disfavoredOverload', 'DisfavoredOverload',
-                        OnAbstractFunction,  OnVar,  OnSubscript,  UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        OnAbstractFunction, OnVar, OnSubscript, UserInaccessible,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=87),
     SimpleDeclAttribute('resultBuilder', 'ResultBuilder',
                         OnNominalType,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=88),
     DeclAttribute('_projectedValueProperty', 'ProjectedValueProperty',
-                  OnVar,  UserInaccessible,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  OnVar, UserInaccessible,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=89),
     SimpleDeclAttribute('_nonEphemeral', 'NonEphemeral',
-                        OnParam,  UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIBreakingToAdd,  APIStableToRemove,
+                        OnParam, UserInaccessible,
+                        ABIStableToAdd, ABIStableToRemove, APIBreakingToAdd, APIStableToRemove,  # noqa: E501
                         code=90),
 
     DeclAttribute('differentiable', 'Differentiable',
-                  OnAccessor,  OnConstructor,  OnFunc,  OnVar,  OnSubscript,  LongAttribute,
+                  OnAccessor, OnConstructor, OnFunc, OnVar, OnSubscript, LongAttribute,
                   AllowMultipleAttributes,
-                  ABIStableToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIBreakingToRemove,
+                  ABIStableToAdd, ABIBreakingToRemove, APIStableToAdd, APIBreakingToRemove,  # noqa: E501
                   code=91),
 
     SimpleDeclAttribute('_hasMissingDesignatedInitializers',
                         'HasMissingDesignatedInitializers',
-                        OnClass,  UserInaccessible,  NotSerialized,
-                        APIBreakingToAdd,  ABIBreakingToAdd,  APIStableToRemove,  ABIStableToRemove,
+                        OnClass, UserInaccessible, NotSerialized,
+                        APIBreakingToAdd, ABIBreakingToAdd, APIStableToRemove, ABIStableToRemove,  # noqa: E501
                         code=92),
 
     SimpleDeclAttribute('_inheritsConvenienceInitializers',
                         'InheritsConvenienceInitializers',
-                        OnClass,  UserInaccessible,  NotSerialized,
-                        APIStableToAdd,  ABIStableToAdd,  APIBreakingToRemove,  ABIBreakingToRemove,
+                        OnClass, UserInaccessible, NotSerialized,
+                        APIStableToAdd, ABIStableToAdd, APIBreakingToRemove, ABIBreakingToRemove,  # noqa: E501
                         code=93),
 
     DeclAttribute('_typeEraser', 'TypeEraser',
-                  OnProtocol,  UserInaccessible,
-                  ABIStableToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIBreakingToRemove,
+                  OnProtocol, UserInaccessible,
+                  ABIStableToAdd, ABIBreakingToRemove, APIStableToAdd, APIBreakingToRemove,  # noqa: E501
                   code=94),
 
     SimpleDeclAttribute('IBSegueAction', 'IBSegueAction',
                         OnFunc,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=95),
 
     DeclAttribute('_originallyDefinedIn', 'OriginallyDefinedIn',
-                  OnNominalType,  OnFunc,  OnVar,  OnExtension,  UserInaccessible,
-                  AllowMultipleAttributes,  LongAttribute,
-                  ABIBreakingToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIStableToRemove,
+                  OnNominalType, OnFunc, OnVar, OnExtension, UserInaccessible,
+                  AllowMultipleAttributes, LongAttribute,
+                  ABIBreakingToAdd, ABIBreakingToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                   code=96),
 
     DeclAttribute('derivative', 'Derivative',
-                  OnFunc,  LongAttribute,  AllowMultipleAttributes,
-                  ABIStableToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIBreakingToRemove,
+                  OnFunc, LongAttribute, AllowMultipleAttributes,
+                  ABIStableToAdd, ABIBreakingToRemove, APIStableToAdd, APIBreakingToRemove,  # noqa: E501
                   code=97),
 
     DeclAttribute('_spi', 'SPIAccessControl',
-                  OnAbstractFunction,  OnExtension,  OnGenericType,  OnVar,  OnSubscript,
-                  OnImport,  OnAccessor,  OnEnumElement, OnMacro,
-                  AllowMultipleAttributes,  UserInaccessible,
-                  ABIStableToAdd,  ABIStableToRemove,  APIBreakingToAdd,  APIStableToRemove,
+                  OnAbstractFunction, OnExtension, OnGenericType, OnVar, OnSubscript,
+                  OnImport, OnAccessor, OnEnumElement, OnMacro,
+                  AllowMultipleAttributes, UserInaccessible,
+                  ABIStableToAdd, ABIStableToRemove, APIBreakingToAdd, APIStableToRemove,  # noqa: E501
                   code=98),
 
     DeclAttribute('transpose', 'Transpose',
-                  OnFunc,  LongAttribute,  AllowMultipleAttributes,
-                  ABIStableToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIBreakingToRemove,
+                  OnFunc, LongAttribute, AllowMultipleAttributes,
+                  ABIStableToAdd, ABIBreakingToRemove, APIStableToAdd, APIBreakingToRemove,  # noqa: E501
                   code=99),
 
     SimpleDeclAttribute('noDerivative', 'NoDerivative',
-                        OnAbstractFunction,  OnVar,  OnSubscript,
-                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        OnAbstractFunction, OnVar, OnSubscript,
+                        ABIBreakingToAdd, ABIBreakingToRemove, APIBreakingToAdd, APIBreakingToRemove,  # noqa: E501
                         code=100),
 
     # 101 was @asyncHandler and is now unused
 
     SimpleDeclAttribute('globalActor', 'GlobalActor',
-                        OnClass,  OnStruct,  OnEnum,
-                        ABIStableToAdd,  ABIBreakingToRemove,
-                        APIStableToAdd,  APIBreakingToRemove,
+                        OnClass, OnStruct, OnEnum,
+                        ABIStableToAdd, ABIBreakingToRemove,
+                        APIStableToAdd, APIBreakingToRemove,
                         code=104),
 
     SimpleDeclAttribute('_specializeExtension', 'SpecializeExtension',
-                        OnExtension,  UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        OnExtension, UserInaccessible,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=105),
 
     SimpleDeclAttribute('Sendable', 'Sendable',
-                        OnFunc,  OnConstructor,  OnAccessor,  OnAnyClangDecl,
-                        ABIBreakingToAdd,  ABIBreakingToRemove,
-                        APIBreakingToAdd,  APIBreakingToRemove,
+                        OnFunc, OnConstructor, OnAccessor, OnAnyClangDecl,
+                        ABIBreakingToAdd, ABIBreakingToRemove,
+                        APIBreakingToAdd, APIBreakingToRemove,
                         code=107),
 
     SimpleDeclAttribute('_marker', 'Marker',
-                        OnProtocol,  UserInaccessible,
-                        ABIBreakingToAdd,  ABIBreakingToRemove,
-                        APIBreakingToAdd,  APIBreakingToRemove,
+                        OnProtocol, UserInaccessible,
+                        ABIBreakingToAdd, ABIBreakingToRemove,
+                        APIBreakingToAdd, APIBreakingToRemove,
                         code=108),
 
     SimpleDeclAttribute('reasync', 'AtReasync',
-                        OnProtocol,  ConcurrencyOnly,
-                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        OnProtocol, ConcurrencyOnly,
+                        ABIBreakingToAdd, ABIBreakingToRemove, APIBreakingToAdd, APIBreakingToRemove,  # noqa: E501
                         swift_name='atReasync',
                         code=110),
 
@@ -584,131 +595,131 @@ DECL_ATTR_KINDS = [
     # 113 was experimental _unsafeSendable and is now unused
 
     SimpleDeclAttribute('_unsafeInheritExecutor', 'UnsafeInheritExecutor',
-                        OnFunc,  UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIBreakingToRemove,
-                        code=114), # previously experimental _unsafeMainActor
+                        OnFunc, UserInaccessible,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIBreakingToRemove,  # noqa: E501
+                        code=114),  # previously experimental _unsafeMainActor
 
     SimpleDeclAttribute('_implicitSelfCapture', 'ImplicitSelfCapture',
-                        OnParam,  UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIBreakingToRemove,
+                        OnParam, UserInaccessible,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIBreakingToRemove,  # noqa: E501
                         code=115),
 
     SimpleDeclAttribute('_inheritActorContext', 'InheritActorContext',
-                        OnParam,  UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        OnParam, UserInaccessible,
+                        ABIStableToAdd, ABIStableToRemove, APIBreakingToAdd, APIBreakingToRemove,  # noqa: E501
                         code=116),
 
     SimpleDeclAttribute('_eagerMove', 'EagerMove',
                         UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,
-                        APIStableToAdd,  APIStableToRemove,
-                        OnFunc,  OnParam,  OnVar,  OnNominalType,
+                        ABIStableToAdd, ABIStableToRemove,
+                        APIStableToAdd, APIStableToRemove,
+                        OnFunc, OnParam, OnVar, OnNominalType,
                         code=117),
 
     SimpleDeclAttribute('_noEagerMove', 'NoEagerMove',
                         UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,
-                        APIStableToAdd,  APIStableToRemove,
-                        OnFunc,  OnParam,  OnVar,  OnNominalType,
+                        ABIStableToAdd, ABIStableToRemove,
+                        APIStableToAdd, APIStableToRemove,
+                        OnFunc, OnParam, OnVar, OnNominalType,
                         code=119),
 
     SimpleDeclAttribute('_assemblyVision', 'EmitAssemblyVisionRemarks',
-                        OnFunc,  UserInaccessible,  NotSerialized,  OnNominalType,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        OnFunc, UserInaccessible, NotSerialized, OnNominalType,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=120),
 
     DeclAttribute('_nonSendable', 'NonSendable',
                   OnNominalType,
-                  UserInaccessible,  AllowMultipleAttributes,
-                  ABIStableToAdd,  ABIBreakingToRemove,
-                  APIStableToAdd,  APIBreakingToRemove,
+                  UserInaccessible, AllowMultipleAttributes,
+                  ABIStableToAdd, ABIBreakingToRemove,
+                  APIStableToAdd, APIBreakingToRemove,
                   code=121),
 
     SimpleDeclAttribute('_noImplicitCopy', 'NoImplicitCopy',
                         UserInaccessible,
-                        ABIStableToAdd,  ABIBreakingToRemove,
-                        APIStableToAdd,  APIBreakingToRemove,
-                        OnFunc,  OnParam,  OnVar,
+                        ABIStableToAdd, ABIBreakingToRemove,
+                        APIStableToAdd, APIBreakingToRemove,
+                        OnFunc, OnParam, OnVar,
                         code=122),
 
     SimpleDeclAttribute('_noLocks', 'NoLocks',
-                        OnAbstractFunction,  OnSubscript,  UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        OnAbstractFunction, OnSubscript, UserInaccessible,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=123),
 
     SimpleDeclAttribute('_noAllocation', 'NoAllocation',
-                        OnAbstractFunction,  OnSubscript,  UserInaccessible,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        OnAbstractFunction, OnSubscript, UserInaccessible,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=124),
 
     SimpleDeclAttribute('preconcurrency', 'Preconcurrency',
-                        OnFunc,  OnConstructor,  OnProtocol,  OnGenericType,  OnVar,  OnSubscript,
-                        OnEnumElement,  OnImport,
-                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        OnFunc, OnConstructor, OnProtocol, OnGenericType, OnVar, OnSubscript,  # noqa: E501
+                        OnEnumElement, OnImport,
+                        ABIBreakingToAdd, ABIBreakingToRemove, APIBreakingToAdd, APIBreakingToRemove,  # noqa: E501
                         code=125),
 
     DeclAttribute('_unavailableFromAsync', 'UnavailableFromAsync',
-                  OnFunc,  OnConstructor,  OnMacro, UserInaccessible,
-                  ABIStableToAdd,  ABIStableToRemove,
-                  APIBreakingToAdd,  APIStableToRemove,
+                  OnFunc, OnConstructor, OnMacro, UserInaccessible,
+                  ABIStableToAdd, ABIStableToRemove,
+                  APIBreakingToAdd, APIStableToRemove,
                   code=127),
 
     DeclAttribute('exclusivity', 'Exclusivity',
                   OnVar,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=128),
 
     DeclAttribute('_backDeploy', 'BackDeploy',
-                  OnAbstractFunction,  OnAccessor,  OnSubscript,  OnVar,
-                    AllowMultipleAttributes,  LongAttribute,  UserInaccessible,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIBreakingToRemove,
+                  OnAbstractFunction, OnAccessor, OnSubscript, OnVar,
+                  AllowMultipleAttributes, LongAttribute, UserInaccessible,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIBreakingToRemove,  # noqa: E501
                   code=129),
 
     SimpleDeclAttribute('_moveOnly', 'MoveOnly',
                         OnNominalType,
                         UserInaccessible,
-                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        ABIBreakingToAdd, ABIBreakingToRemove, APIBreakingToAdd, APIBreakingToRemove,  # noqa: E501
                         code=131),
 
-    SimpleDeclAttribute('_alwaysEmitConformanceMetadata', 'AlwaysEmitConformanceMetadata',
-                        OnProtocol,  UserInaccessible,  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+    SimpleDeclAttribute('_alwaysEmitConformanceMetadata', 'AlwaysEmitConformanceMetadata',  # noqa: E501
+                        OnProtocol, UserInaccessible, ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=132),
 
     DeclAttribute('_expose', 'Expose',
-                  OnFunc,  OnNominalType,  OnVar,  OnConstructor,
-                  LongAttribute,  UserInaccessible,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  OnFunc, OnNominalType, OnVar, OnConstructor,
+                  LongAttribute, UserInaccessible,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=133),
 
     SimpleDeclAttribute('typeWrapper', 'TypeWrapper',
-                        OnStruct,  OnClass,  OnEnum,
-                        ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                        OnStruct, OnClass, OnEnum,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=134),
 
     SimpleDeclAttribute('_spiOnly', 'SPIOnly',
                         OnImport, UserInaccessible,
-                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=135),
     DeclAttribute('_documentation', 'Documentation',
                   OnAnyDecl, UserInaccessible,
-                  APIBreakingToAdd, APIStableToRemove, ABIStableToAdd, ABIStableToRemove,
+                  APIBreakingToAdd, APIStableToRemove, ABIStableToAdd, ABIStableToRemove,  # noqa: E501
                   code=136),
 
     SimpleDeclAttribute('typeWrapperIgnored', 'TypeWrapperIgnored',
                         OnVar,
-                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
+                        ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=137),
 
     SimpleDeclAttribute('_noMetadata', 'NoMetadata',
                         OnGenericTypeParam,
                         UserInaccessible,
                         NotSerialized,
-                        ABIStableToAdd, ABIBreakingToRemove, APIStableToAdd, APIStableToRemove,
+                        ABIStableToAdd, ABIBreakingToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=138),
 
     SimpleDeclAttribute('runtimeMetadata', 'RuntimeMetadata',
-                        OnStruct,  OnClass,
-                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        OnStruct, OnClass,
+                        ABIBreakingToAdd, ABIBreakingToRemove, APIBreakingToAdd, APIBreakingToRemove,  # noqa: E501
                         code=139)
 ]
 
@@ -742,81 +753,81 @@ DECL_MODIFIER_KINDS = [
     BuiltinDeclModifier('class', swift_name='classKeyword'),
 
     ContextualSimpleDeclAttribute('final', 'Final',
-                                  OnClass,  OnFunc,  OnAccessor,  OnVar,  OnSubscript,
+                                  OnClass, OnFunc, OnAccessor, OnVar, OnSubscript,
                                   DeclModifier,
-                                  ABIBreakingToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  ABIBreakingToAdd, ABIBreakingToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                                   code=2),
     ContextualSimpleDeclAttribute('required', 'Required',
                                   OnConstructor,
                                   DeclModifier,
-                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                                   code=4),
     ContextualSimpleDeclAttribute('optional', 'Optional',
-                                  OnConstructor,  OnFunc,  OnAccessor,  OnVar,  OnSubscript,
+                                  OnConstructor, OnFunc, OnAccessor, OnVar, OnSubscript,
                                   DeclModifier,
-                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                                   code=5),
-    ContextualSimpleDeclAttribute('lazy', 'Lazy',  DeclModifier,
+    ContextualSimpleDeclAttribute('lazy', 'Lazy', DeclModifier,
                                   OnVar,
-                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                                   code=16),
     ContextualSimpleDeclAttribute('dynamic', 'Dynamic',
-                                  OnFunc,  OnAccessor,  OnVar,  OnSubscript,  OnConstructor,
-                                  DeclModifier,  ABIBreakingToAdd,  ABIBreakingToRemove,
-                                  APIStableToAdd,  APIStableToRemove,
+                                  OnFunc, OnAccessor, OnVar, OnSubscript, OnConstructor,
+                                  DeclModifier, ABIBreakingToAdd, ABIBreakingToRemove,
+                                  APIStableToAdd, APIStableToRemove,
                                   code=22),
     ContextualSimpleDeclAttribute('infix', 'Infix',
-                                  OnFunc,  OnOperator,
+                                  OnFunc, OnOperator,
                                   DeclModifier,
-                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                                   code=23),
     ContextualSimpleDeclAttribute('prefix', 'Prefix',
-                                  OnFunc,  OnOperator,
+                                  OnFunc, OnOperator,
                                   DeclModifier,
-                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                                   code=24),
     ContextualSimpleDeclAttribute('postfix', 'Postfix',
-                                  OnFunc,  OnOperator,
+                                  OnFunc, OnOperator,
                                   DeclModifier,
-                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                                   code=25),
     ContextualSimpleDeclAttribute('__consuming', 'Consuming',
-                                  OnFunc,  OnAccessor,
+                                  OnFunc, OnAccessor,
                                   DeclModifier,
                                   UserInaccessible,
                                   NotSerialized,
-                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                                   code=40),
     ContextualSimpleDeclAttribute('mutating', 'Mutating',
-                                  OnFunc,  OnAccessor,
+                                  OnFunc, OnAccessor,
                                   DeclModifier,
                                   NotSerialized,
-                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                                   code=41),
     ContextualSimpleDeclAttribute('nonmutating', 'NonMutating',
-                                  OnFunc,  OnAccessor,
+                                  OnFunc, OnAccessor,
                                   DeclModifier,
                                   NotSerialized,
-                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                                   code=42),
     ContextualSimpleDeclAttribute('convenience', 'Convenience',
                                   OnConstructor,
                                   DeclModifier,
                                   NotSerialized,
-                                  ABIBreakingToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  ABIBreakingToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                                   code=43),
     ContextualSimpleDeclAttribute('override', 'Override',
-                                  OnFunc,  OnAccessor,  OnVar,  OnSubscript,  OnConstructor,  OnAssociatedType,
+                                  OnFunc, OnAccessor, OnVar, OnSubscript, OnConstructor, OnAssociatedType,  # noqa: E501
                                   DeclModifier,
                                   NotSerialized,
-                                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                                   code=44),
     DeclAttribute('private', 'AccessControl',
-                  OnFunc,  OnAccessor,  OnExtension,  OnGenericType,  OnVar,  OnSubscript,
+                  OnFunc, OnAccessor, OnExtension, OnGenericType, OnVar, OnSubscript,
                   OnConstructor, OnMacro,
                   DeclModifier,
                   NotSerialized,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   swift_name='privateKeyword',
                   code=46),
     DeclAttributeAlias('fileprivate', 'AccessControl', swift_name='fileprivateKeyword'),
@@ -824,83 +835,84 @@ DECL_MODIFIER_KINDS = [
     DeclAttributeAlias('public', 'AccessControl', swift_name='publicKeyword'),
     ContextualDeclAttributeAlias('open', 'AccessControl'),
     DeclAttribute('__setter_access', 'SetterAccess',
-                  OnVar,  OnSubscript,
-                  DeclModifier,  RejectByParser,
+                  OnVar, OnSubscript,
+                  DeclModifier, RejectByParser,
                   NotSerialized,
-                  ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                   code=47),
     ContextualDeclAttribute('weak', 'ReferenceOwnership',
                             OnVar,
                             DeclModifier,
                             NotSerialized,
-                            ABIStableToAdd,  ABIStableToRemove,  APIStableToAdd,  APIStableToRemove,
+                            ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                             code=49),
     ContextualDeclAttributeAlias('unowned', 'ReferenceOwnership', swift_name='unowned'),
 
     SimpleDeclAttribute('rethrows', 'Rethrows',
-                        OnFunc,  OnConstructor,
+                        OnFunc, OnConstructor,
                         RejectByParser,
-                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        ABIBreakingToAdd, ABIBreakingToRemove, APIBreakingToAdd, APIBreakingToRemove,  # noqa: E501
                         code=57,
                         swift_name='`rethrows`'),
-                        
-    ContextualSimpleDeclAttribute('indirect', 'Indirect',  DeclModifier,
-                                  OnEnum,  OnEnumElement,
-                                  ABIBreakingToAdd,  ABIBreakingToRemove,  APIStableToAdd,  APIStableToRemove,
+
+    ContextualSimpleDeclAttribute('indirect', 'Indirect', DeclModifier,
+                                  OnEnum, OnEnumElement,
+                                  ABIBreakingToAdd, ABIBreakingToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                                   code=60),
 
     ContextualSimpleDeclAttribute('isolated', 'Isolated',
-                                  DeclModifier,  OnParam,
-                                  ABIBreakingToAdd,  ABIBreakingToRemove,
-                                  APIBreakingToAdd,  APIBreakingToRemove,
+                                  DeclModifier, OnParam,
+                                  ABIBreakingToAdd, ABIBreakingToRemove,
+                                  APIBreakingToAdd, APIBreakingToRemove,
                                   code=103),
 
     ContextualSimpleDeclAttribute('async', 'Async',
-                                  DeclModifier,  OnVar,  OnFunc,
-                                  ABIBreakingToAdd,  ABIBreakingToRemove,
-                                  APIBreakingToAdd,  APIBreakingToRemove,
+                                  DeclModifier, OnVar, OnFunc,
+                                  ABIBreakingToAdd, ABIBreakingToRemove,
+                                  APIBreakingToAdd, APIBreakingToRemove,
                                   code=106),
 
     SimpleDeclAttribute('reasync', 'Reasync',
-                        OnFunc,  OnConstructor,
+                        OnFunc, OnConstructor,
                         RejectByParser,
-                        ABIBreakingToAdd,  ABIBreakingToRemove,  APIBreakingToAdd,  APIBreakingToRemove,
+                        ABIBreakingToAdd, ABIBreakingToRemove, APIBreakingToAdd, APIBreakingToRemove,  # noqa: E501
                         code=109),
 
     ContextualSimpleDeclAttribute('nonisolated', 'Nonisolated',
-                                  DeclModifier,  OnFunc,  OnConstructor,  OnVar,  OnSubscript,
-                                  ABIStableToAdd,  ABIStableToRemove,
-                                  APIBreakingToAdd,  APIStableToRemove,
+                                  DeclModifier, OnFunc, OnConstructor, OnVar, OnSubscript,  # noqa: E501
+                                  ABIStableToAdd, ABIStableToRemove,
+                                  APIBreakingToAdd, APIStableToRemove,
                                   code=112),
 
     ContextualSimpleDeclAttribute('distributed', 'DistributedActor',
-                                  DeclModifier,  OnClass,  OnFunc,  OnAccessor,  OnVar,
-                                  ABIBreakingToAdd,  ABIBreakingToRemove,
-                                  APIBreakingToAdd,  APIBreakingToRemove,
+                                  DeclModifier, OnClass, OnFunc, OnAccessor, OnVar,
+                                  ABIBreakingToAdd, ABIBreakingToRemove,
+                                  APIBreakingToAdd, APIBreakingToRemove,
                                   code=118),
 
     ContextualSimpleDeclAttribute('_const', 'CompileTimeConst',
-                                  DeclModifier,  OnParam,  OnVar,
+                                  DeclModifier, OnParam, OnVar,
                                   UserInaccessible,
-                                  ABIStableToAdd,  ABIStableToRemove,  APIBreakingToAdd,  APIStableToRemove,
+                                  ABIStableToAdd, ABIStableToRemove, APIBreakingToAdd, APIStableToRemove,  # noqa: E501
                                   code=126),
 
     ContextualSimpleDeclAttribute('_local', 'KnownToBeLocal',
-                                  DeclModifier,  OnFunc,  OnParam,  OnVar,
+                                  DeclModifier, OnFunc, OnParam, OnVar,
                                   UserInaccessible,
-                                  ABIBreakingToAdd,  ABIBreakingToRemove,
-                                  APIBreakingToAdd,  APIBreakingToRemove,
+                                  ABIBreakingToAdd, ABIBreakingToRemove,
+                                  APIBreakingToAdd, APIBreakingToRemove,
                                   code=130),
 ]
 
 DEPRECATED_MODIFIER_KINDS = [
     # TODO: Remove this once we don't need to support 'actor' as a modifier
     ContextualSimpleDeclAttribute('actor', 'Actor',
-                                  DeclModifier,  OnClass,  ConcurrencyOnly,
-                                  ABIBreakingToAdd,  ABIBreakingToRemove,
-                                  APIBreakingToAdd,  APIBreakingToRemove,
+                                  DeclModifier, OnClass, ConcurrencyOnly,
+                                  ABIBreakingToAdd, ABIBreakingToRemove,
+                                  APIBreakingToAdd, APIBreakingToRemove,
                                   code=102),
 ]
+
 
 def verify_attribute_serialization_codes(nodes):
     # Verify that no serialization code is used twice

--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -1,0 +1,390 @@
+def lowercase_first_word(name):
+    """
+    Lowercases the first word in the provided camelCase or PascalCase string.
+    EOF -> eof
+    IfKeyword -> ifKeyword
+    EOFToken -> eofToken
+    """
+    word_index = 0
+    threshold_index = 1
+    for c in name:
+        if c.islower():
+            if word_index > threshold_index:
+                word_index -= 1
+            break
+        word_index += 1
+    if word_index == 0:
+        return name
+    return name[:word_index].lower() + name[word_index:]
+
+
+class Token(object):
+    """
+    Represents the specification for a Token in the TokenSyntax file.
+    """
+
+    def __init__(self, name, kind, name_for_diagnostics,
+                 unprefixed_kind=None, text=None, classification='None',
+                 is_keyword=False, requires_leading_space=False,
+                 requires_trailing_space=False):
+        self.name = name
+        self.kind = kind
+        if unprefixed_kind is None:
+            self.unprefixed_kind = kind
+        else:
+            self.unprefixed_kind = unprefixed_kind
+        self.name_for_diagnostics = name_for_diagnostics
+        self.text = text
+        self.is_keyword = is_keyword
+        self.requires_leading_space = requires_leading_space
+        self.requires_trailing_space = requires_trailing_space
+
+    def swift_kind(self):
+        name = lowercase_first_word(self.name)
+        if self.is_keyword:
+            return name + 'Keyword'
+        return name
+
+
+class Keyword(Token):
+    """
+    Represents a keyword token.
+    """
+
+    def __init__(self, name, text, classification='Keyword',
+                 requires_leading_space=False, requires_trailing_space=True):
+        Token.__init__(self,
+                       name=name,
+                       kind='kw_' + text,
+                       name_for_diagnostics=text,
+                       unprefixed_kind=text, text=text,
+                       classification=classification, is_keyword=True,
+                       requires_leading_space=requires_leading_space,
+                       requires_trailing_space=requires_trailing_space)
+
+    def macro_name(self):
+        return "KEYWORD"
+
+
+class SwiftKeyword(Keyword):
+    def macro_name(self):
+        return "SWIFT_KEYWORD"
+
+
+class DeclKeyword(SwiftKeyword):
+    def macro_name(self):
+        return "DECL_KEYWORD"
+
+
+class StmtKeyword(SwiftKeyword):
+    def macro_name(self):
+        return "STMT_KEYWORD"
+
+
+class ExprKeyword(SwiftKeyword):
+    def macro_name(self):
+        return "EXPR_KEYWORD"
+
+
+class PatternKeyword(SwiftKeyword):
+    def macro_name(self):
+        return "PAT_KEYWORD"
+
+
+class SilKeyword(Keyword):
+    def macro_name(self):
+        return "SIL_KEYWORD"
+
+
+class PoundKeyword(Token):
+    def __init__(self, name, kind, text, name_for_diagnostics=None,
+                 classification='Keyword'):
+        if name_for_diagnostics is None:
+            name_for_diagnostics = text
+        Token.__init__(self,
+                       name=name,
+                       kind='pound_' + kind,
+                       name_for_diagnostics=name_for_diagnostics,
+                       unprefixed_kind=kind, text=text,
+                       classification=classification, is_keyword=True,
+                       requires_trailing_space=True)
+
+    def macro_name(self):
+        return "POUND_KEYWORD"
+
+
+class PoundObjectLiteral(PoundKeyword):
+    def __init__(self, name, kind, text, name_for_diagnostics,
+                 protocol, classification='ObjectLiteral'):
+        PoundKeyword.__init__(
+            self,
+            name=name,
+            kind=kind,
+            text=text,
+            name_for_diagnostics=name_for_diagnostics,
+            classification=classification
+        )
+        self.description = name_for_diagnostics
+        self.protocol = protocol
+
+    def macro_name(self):
+        return "POUND_OBJECT_LITERAL"
+
+
+class PoundConfig(PoundKeyword):
+    def macro_name(self):
+        return "POUND_CONFIG"
+
+
+class PoundDirectiveKeyword(PoundKeyword):
+    def __init__(self, name, kind, text,
+                 classification='PoundDirectiveKeyword'):
+        PoundKeyword.__init__(
+            self,
+            name=name,
+            kind=kind,
+            text=text,
+            classification=classification
+        )
+
+    def macro_name(self):
+        return "POUND_DIRECTIVE_KEYWORD"
+
+
+class PoundConditionalDirectiveKeyword(PoundDirectiveKeyword):
+    def __init__(self, name, kind, text,
+                 classification='PoundDirectiveKeyword'):
+        PoundKeyword.__init__(
+            self,
+            name=name,
+            kind=kind,
+            text=text,
+            classification=classification
+        )
+
+    def macro_name(self):
+        return "POUND_COND_DIRECTIVE_KEYWORD"
+
+
+class Punctuator(Token):
+    def __init__(self, name, kind, text, classification='None',
+                 requires_leading_space=False, requires_trailing_space=False):
+        Token.__init__(
+            self,
+            name=name,
+            kind=kind,
+            name_for_diagnostics=text,
+            unprefixed_kind=None,
+            text=text,
+            classification=classification,
+            is_keyword=False,
+            requires_leading_space=requires_leading_space,
+            requires_trailing_space=requires_trailing_space
+        )
+
+    def macro_name(self):
+        return "PUNCTUATOR"
+
+
+class Literal(Token):
+    def macro_name(self):
+        return "LITERAL"
+
+
+class Misc(Token):
+    def macro_name(self):
+        return "MISC"
+
+
+SYNTAX_TOKENS = [
+    # Keywords that start decls
+    DeclKeyword('Associatedtype', 'associatedtype'),
+    DeclKeyword('Class', 'class'),
+    DeclKeyword('Deinit', 'deinit'),
+    DeclKeyword('Enum', 'enum'),
+    DeclKeyword('Extension', 'extension'),
+    DeclKeyword('Func', 'func'),
+    DeclKeyword('Import', 'import'),
+    DeclKeyword('Init', 'init'),
+    DeclKeyword('Inout', 'inout'),
+    DeclKeyword('Let', 'let'),
+    DeclKeyword('Operator', 'operator'),
+    DeclKeyword('Precedencegroup', 'precedencegroup'),
+    DeclKeyword('Protocol', 'protocol'),
+    DeclKeyword('Struct', 'struct'),
+    DeclKeyword('Subscript', 'subscript'),
+    DeclKeyword('Typealias', 'typealias'),
+    DeclKeyword('Var', 'var'),
+
+    DeclKeyword('Fileprivate', 'fileprivate'),
+    DeclKeyword('Internal', 'internal'),
+    DeclKeyword('Private', 'private'),
+    DeclKeyword('Public', 'public'),
+    DeclKeyword('Static', 'static'),
+
+    # Statement keywords
+    StmtKeyword('Defer', 'defer'),
+    StmtKeyword('If', 'if'),
+    StmtKeyword('Guard', 'guard'),
+    StmtKeyword('Do', 'do', requires_trailing_space=False),
+    StmtKeyword('Repeat', 'repeat'),
+    StmtKeyword('Else', 'else'),
+    StmtKeyword('For', 'for'),
+    StmtKeyword('In', 'in'),
+    StmtKeyword('While', 'while'),
+    StmtKeyword('Return', 'return'),
+    StmtKeyword('Break', 'break'),
+    StmtKeyword('Continue', 'continue'),
+    StmtKeyword('Fallthrough', 'fallthrough'),
+    StmtKeyword('Switch', 'switch'),
+    StmtKeyword('Case', 'case'),
+    StmtKeyword('Default', 'default', requires_trailing_space=False),
+    StmtKeyword('Where', 'where', requires_leading_space=True),
+    StmtKeyword('Catch', 'catch', requires_leading_space=True,
+                requires_trailing_space=False),
+    StmtKeyword('Throw', 'throw'),
+
+    # Expression keywords
+    ExprKeyword('As', 'as'),
+    ExprKeyword('Any', 'Any'),
+    ExprKeyword('False', 'false', requires_trailing_space=False),
+    ExprKeyword('Is', 'is'),
+    ExprKeyword('Nil', 'nil', requires_trailing_space=False),
+    ExprKeyword('Rethrows', 'rethrows'),
+    ExprKeyword('Super', 'super', requires_trailing_space=False),
+    ExprKeyword('Self', 'self', requires_trailing_space=False),
+    ExprKeyword('CapitalSelf', 'Self', requires_trailing_space=False),
+    ExprKeyword('True', 'true', requires_trailing_space=False),
+    ExprKeyword('Try', 'try'),
+    ExprKeyword('Throws', 'throws'),
+
+    # Pattern keywords
+    PatternKeyword('Wildcard', '_'),
+
+    # Punctuators
+    Punctuator('LeftParen', 'l_paren', text='('),
+    Punctuator('RightParen', 'r_paren', text=')'),
+    Punctuator('LeftBrace', 'l_brace', text='{', requires_leading_space=True),
+    Punctuator('RightBrace', 'r_brace', text='}'),
+    Punctuator('LeftSquareBracket', 'l_square', text='['),
+    Punctuator('RightSquareBracket', 'r_square', text=']'),
+    Punctuator('LeftAngle', 'l_angle', text='<', requires_leading_space=True,
+               requires_trailing_space=True),
+    Punctuator('RightAngle', 'r_angle', text='>', requires_leading_space=True,
+               requires_trailing_space=True),
+
+    Punctuator('Period', 'period', text='.'),
+    Punctuator('PrefixPeriod', 'period_prefix', text='.'),
+    Punctuator('Comma', 'comma', text=',', requires_trailing_space=True),
+    Punctuator('Ellipsis', 'ellipsis', text='...'),
+    Punctuator('Colon', 'colon', text=':', requires_trailing_space=True),
+    Punctuator('Semicolon', 'semi', text=';'),
+    Punctuator('Equal', 'equal', text='=', requires_leading_space=True,
+               requires_trailing_space=True),
+    Punctuator('AtSign', 'at_sign', text='@', classification='Attribute'),
+    Punctuator('Pound', 'pound', text='#'),
+
+    Punctuator('PrefixAmpersand', 'amp_prefix', text='&'),
+    Punctuator('Arrow', 'arrow', text='->', requires_leading_space=True,
+               requires_trailing_space=True),
+
+    Punctuator('Backtick', 'backtick', text='`'),
+
+    Punctuator('Backslash', 'backslash', text='\\\\'),
+
+    Punctuator('ExclamationMark', 'exclaim_postfix', text='!'),
+
+    Punctuator('PostfixQuestionMark', 'question_postfix', text='?'),
+    Punctuator('InfixQuestionMark', 'question_infix', text='?'),
+
+    Punctuator('StringQuote', 'string_quote', text='\\\"',
+               classification='StringLiteral'),
+    Punctuator('SingleQuote', 'single_quote', text='\\\'',
+               classification='StringLiteral'),
+    Punctuator('MultilineStringQuote', 'multiline_string_quote',
+               text='\\\"\\\"\\\"', classification='StringLiteral'),
+
+    # Keywords prefixed with a '#'.
+
+    PoundKeyword('PoundKeyPath', 'keyPath', text='#keyPath'),
+    PoundKeyword('PoundLine', 'line', text='#line'),
+    PoundKeyword('PoundSelector', 'selector', text='#selector'),
+    PoundKeyword('PoundFile', 'file', text='#file'),
+    PoundKeyword('PoundFileID', 'fileID', text='#fileID'),
+    PoundKeyword('PoundFilePath', 'filePath', text='#filePath'),
+    PoundKeyword('PoundColumn', 'column', text='#column'),
+    PoundKeyword('PoundFunction', 'function', text='#function'),
+    PoundKeyword('PoundDsohandle', 'dsohandle', text='#dsohandle'),
+    PoundKeyword('PoundAssert', 'assert', text='#assert'),
+
+    PoundDirectiveKeyword('PoundSourceLocation', 'sourceLocation',
+                          text='#sourceLocation'),
+    PoundDirectiveKeyword('PoundWarning', 'warning', text='#warning'),
+    PoundDirectiveKeyword('PoundError', 'error', text='#error'),
+
+    PoundConditionalDirectiveKeyword('PoundIf', 'if', text='#if'),
+    PoundConditionalDirectiveKeyword('PoundElse', 'else', text='#else'),
+    PoundConditionalDirectiveKeyword('PoundElseif', 'elseif',
+                                     text='#elseif'),
+    PoundConditionalDirectiveKeyword('PoundEndif', 'endif',
+                                     text='#endif'),
+
+    PoundConfig('PoundAvailable', 'available', text='#available'),
+    PoundConfig('PoundUnavailable', 'unavailable', text='#unavailable'),
+
+    PoundObjectLiteral('PoundFileLiteral', 'fileLiteral',
+                       text='#fileLiteral',
+                       name_for_diagnostics='file reference',
+                       protocol='ExpressibleByFileReferenceLiteral'),
+    PoundObjectLiteral('PoundImageLiteral', 'imageLiteral',
+                       text='#imageLiteral',
+                       name_for_diagnostics='image',
+                       protocol='ExpressibleByImageLiteral'),
+    PoundObjectLiteral('PoundColorLiteral', 'colorLiteral',
+                       text='#colorLiteral',
+                       name_for_diagnostics='color',
+                       protocol='ExpressibleByColorLiteral'),
+
+    PoundConfig('PoundHasSymbol', '_hasSymbol', text='#_hasSymbol'),
+
+    Literal('IntegerLiteral', 'integer_literal', name_for_diagnostics='integer literal',
+            classification='IntegerLiteral'),
+    Literal('FloatingLiteral', 'floating_literal',
+            name_for_diagnostics='floating literal', classification='FloatingLiteral'),
+    Literal('StringLiteral', 'string_literal', name_for_diagnostics='string literal',
+            classification='StringLiteral'),
+    Literal('RegexLiteral', 'regex_literal', name_for_diagnostics='regex literal'),
+
+    Misc('Unknown', 'unknown', name_for_diagnostics='token'),
+    Misc('Identifier', 'identifier', name_for_diagnostics='identifier',
+         classification='Identifier'),
+    Misc('UnspacedBinaryOperator', 'oper_binary_unspaced',
+         name_for_diagnostics='binary operator',
+         classification='OperatorIdentifier'),
+    Misc('SpacedBinaryOperator', 'oper_binary_spaced',
+         name_for_diagnostics='binary operator',
+         classification='OperatorIdentifier',
+         requires_leading_space=True, requires_trailing_space=True),
+    Misc('PostfixOperator', 'oper_postfix', name_for_diagnostics='postfix operator',
+         classification='OperatorIdentifier'),
+    Misc('PrefixOperator', 'oper_prefix', name_for_diagnostics='prefix operator',
+         classification='OperatorIdentifier'),
+    Misc('DollarIdentifier', 'dollarident', name_for_diagnostics='dollar identifier',
+         classification='DollarIdentifier'),
+
+    Misc('ContextualKeyword', 'contextual_keyword', name_for_diagnostics='keyword',
+         classification='Keyword'),
+    Misc('RawStringDelimiter', 'raw_string_delimiter',
+         name_for_diagnostics='raw string delimiter'),
+    Misc('StringSegment', 'string_segment', name_for_diagnostics='string segment',
+         classification='StringLiteral'),
+    Misc('StringInterpolationAnchor', 'string_interpolation_anchor',
+         name_for_diagnostics='string interpolation anchor',
+         text=')', classification='StringInterpolationAnchor'),
+    Misc('Yield', 'kw_yield', name_for_diagnostics='yield',
+         text='yield'),
+
+]
+
+SYNTAX_TOKEN_MAP = {token.name + 'Token': token for token in SYNTAX_TOKENS}
+


### PR DESCRIPTION
This allows us to evolve e.g. token kinds and how attributes are modeled independently between SwiftSyntax and the compiler. It also makes it easier to e.g. add an attribute because you don’t need to create PRs for two repositories.