### PR TITLE
[move-only] Teach move checker that captured vars are treated like inout in the relevant closures

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -733,6 +733,8 @@ ERROR(sil_moveonlychecker_guaranteed_value_consumed, none,
       "'%0' has guaranteed ownership but was consumed", (StringRef))
 ERROR(sil_moveonlychecker_guaranteed_value_captured_by_closure, none,
       "'%0' has guaranteed ownership but was consumed due to being captured by a closure", (StringRef))
+ERROR(sil_moveonlychecker_let_value_consumed_in_closure, none,
+      "'%0' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations", (StringRef))
 ERROR(sil_moveonlychecker_inout_not_reinitialized_before_end_of_function, none,
       "'%0' consumed but not reinitialized before end of function", (StringRef))
 ERROR(sil_moveonlychecker_value_consumed_in_a_loop, none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -737,6 +737,8 @@ ERROR(sil_moveonlychecker_let_value_consumed_in_closure, none,
       "'%0' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations", (StringRef))
 ERROR(sil_moveonlychecker_inout_not_reinitialized_before_end_of_function, none,
       "'%0' consumed but not reinitialized before end of function", (StringRef))
+ERROR(sil_moveonlychecker_inout_not_reinitialized_before_end_of_closure, none,
+      "'%0' consumed in closure but not reinitialized before end of closure", (StringRef))
 ERROR(sil_moveonlychecker_value_consumed_in_a_loop, none,
       "'%0' consumed by a use in a loop", (StringRef))
 ERROR(sil_moveonlychecker_exclusivity_violation, none,

--- a/include/swift/SILOptimizer/Utils/InstructionDeleter.h
+++ b/include/swift/SILOptimizer/Utils/InstructionDeleter.h
@@ -126,6 +126,10 @@ public:
 
   InstModCallbacks &getCallbacks() { return callbacks; }
 
+  void setCallbacks(const InstModCallbacks &newCallbacks) {
+    callbacks = newCallbacks;
+  }
+
   bool hadCallbackInvocation() const {
     return const_cast<InstructionDeleter *>(this)
         ->getCallbacks()

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -581,6 +581,9 @@ static void emitCaptureArguments(SILGenFunction &SGF,
         SILType::getPrimitiveObjectType(boxTy), VD);
     box->setClosureCapture(true);
     SILValue addr = SGF.B.createProjectBox(VD, box, 0);
+    if (addr->getType().isMoveOnly())
+      addr = SGF.B.createMarkMustCheckInst(
+          VD, addr, MarkMustCheckInst::CheckKind::NoImplicitCopy);
     SGF.VarLocs[VD] = SILGenFunction::VarLoc::get(addr, box);
     SILDebugVariable DbgVar(VD->isLet(), ArgNo);
     SGF.B.createDebugValueAddr(Loc, addr, DbgVar);

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(swiftSILOptimizer PRIVATE
   MovedAsyncVarDebugInfoPropagator.cpp
   MoveKillsCopyableAddressesChecker.cpp
   MoveKillsCopyableValuesChecker.cpp
+  MoveOnlyDiagnostics.cpp
   MoveOnlyObjectChecker.cpp
   MoveOnlyAddressChecker.cpp
   MoveOnlyDeinitInsertion.cpp

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -1,0 +1,368 @@
+//===--- MoveOnlyDiagnostics.cpp ------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "sil-move-only-checker"
+
+#include "MoveOnlyDiagnostics.h"
+
+#include "swift/AST/DiagnosticsSIL.h"
+#include "swift/SIL/DebugUtils.h"
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+using namespace swift::siloptimizer;
+
+//===----------------------------------------------------------------------===//
+//                              MARK: Utilities
+//===----------------------------------------------------------------------===//
+
+template <typename... T, typename... U>
+static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
+                     U &&...args) {
+  Context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
+}
+
+static StringRef getVariableNameForValue(MarkMustCheckInst *mmci) {
+  if (auto *allocInst = dyn_cast<AllocationInst>(mmci->getOperand())) {
+    DebugVarCarryingInst debugVar(allocInst);
+    if (auto varInfo = debugVar.getVarInfo()) {
+      return varInfo->Name;
+    } else {
+      if (auto *decl = debugVar.getDecl()) {
+        return decl->getBaseName().userFacingName();
+      }
+    }
+  }
+
+  if (auto *use = getSingleDebugUse(mmci)) {
+    DebugVarCarryingInst debugVar(use->getUser());
+    if (auto varInfo = debugVar.getVarInfo()) {
+      return varInfo->Name;
+    } else {
+      if (auto *decl = debugVar.getDecl()) {
+        return decl->getBaseName().userFacingName();
+      }
+    }
+  }
+
+  return "unknown";
+}
+
+//===----------------------------------------------------------------------===//
+//                           MARK: Misc Diagnostics
+//===----------------------------------------------------------------------===//
+
+void DiagnosticEmitter::emitCheckerDoesntUnderstandDiagnostic(
+    MarkMustCheckInst *markedValue) {
+  // If we failed to canonicalize ownership, there was something in the SIL
+  // that copy propagation did not understand. Emit a we did not understand
+  // error.
+  if (markedValue->getType().isMoveOnlyWrapped()) {
+    diagnose(fn->getASTContext(), markedValue->getLoc().getSourceLoc(),
+             diag::sil_moveonlychecker_not_understand_no_implicit_copy);
+  } else {
+    diagnose(fn->getASTContext(), markedValue->getLoc().getSourceLoc(),
+             diag::sil_moveonlychecker_not_understand_moveonly);
+  }
+  valuesWithDiagnostics.insert(markedValue);
+}
+
+//===----------------------------------------------------------------------===//
+//                          MARK: Object Diagnostics
+//===----------------------------------------------------------------------===//
+
+void DiagnosticEmitter::emitObjectGuaranteedDiagnostic(
+    MarkMustCheckInst *markedValue) {
+  auto &astContext = fn->getASTContext();
+  StringRef varName = getVariableNameForValue(markedValue);
+
+  // See if we have any closure capture uses and emit a better diagnostic.
+  if (getCanonicalizer().hasPartialApplyConsumingUse()) {
+    diagnose(astContext,
+             markedValue->getDefiningInstruction()->getLoc().getSourceLoc(),
+             diag::sil_moveonlychecker_guaranteed_value_captured_by_closure,
+             varName);
+    emitObjectDiagnosticsForPartialApplyUses();
+    valuesWithDiagnostics.insert(markedValue);
+  }
+
+  // If we do not have any non-partial apply consuming uses... just exit early.
+  if (!getCanonicalizer().hasNonPartialApplyConsumingUse())
+    return;
+
+  // Check if this value is closure captured. In such a case, emit a special
+  // error.
+  if (auto *fArg = dyn_cast<SILFunctionArgument>(
+          lookThroughCopyValueInsts(markedValue->getOperand()))) {
+    if (fArg->isClosureCapture()) {
+      diagnose(astContext,
+               markedValue->getDefiningInstruction()->getLoc().getSourceLoc(),
+               diag::sil_moveonlychecker_let_value_consumed_in_closure,
+               varName);
+      emitObjectDiagnosticsForFoundUses(true /*ignore partial apply uses*/);
+      valuesWithDiagnostics.insert(markedValue);
+      return;
+    }
+  }
+
+  diagnose(astContext,
+           markedValue->getDefiningInstruction()->getLoc().getSourceLoc(),
+           diag::sil_moveonlychecker_guaranteed_value_consumed, varName);
+
+  emitObjectDiagnosticsForFoundUses(true /*ignore partial apply uses*/);
+  valuesWithDiagnostics.insert(markedValue);
+}
+
+void DiagnosticEmitter::emitObjectOwnedDiagnostic(
+    MarkMustCheckInst *markedValue) {
+  auto &astContext = fn->getASTContext();
+  StringRef varName = getVariableNameForValue(markedValue);
+
+  diagnose(astContext,
+           markedValue->getDefiningInstruction()->getLoc().getSourceLoc(),
+           diag::sil_moveonlychecker_owned_value_consumed_more_than_once,
+           varName);
+
+  emitObjectDiagnosticsForFoundUses();
+  valuesWithDiagnostics.insert(markedValue);
+}
+
+void DiagnosticEmitter::emitObjectDiagnosticsForFoundUses(
+    bool ignorePartialApplyUses) const {
+  auto &astContext = fn->getASTContext();
+
+  for (auto *consumingUse : getCanonicalizer().consumingUsesNeedingCopy) {
+    // See if the consuming use is an owned moveonly_to_copyable whose only
+    // user is a return. In that case, use the return loc instead. We do this
+    // b/c it is illegal to put a return value location on a non-return value
+    // instruction... so we have to hack around this slightly.
+    auto *user = consumingUse->getUser();
+    auto loc = user->getLoc();
+    if (auto *mtc = dyn_cast<MoveOnlyWrapperToCopyableValueInst>(user)) {
+      if (auto *ri = mtc->getSingleUserOfType<ReturnInst>()) {
+        loc = ri->getLoc();
+      }
+    }
+
+    if (ignorePartialApplyUses &&
+        isa<PartialApplyInst>(consumingUse->getUser()))
+      continue;
+    diagnose(astContext, loc.getSourceLoc(),
+             diag::sil_moveonlychecker_consuming_use_here);
+  }
+
+  for (auto *consumingUse : getCanonicalizer().finalConsumingUses) {
+    // See if the consuming use is an owned moveonly_to_copyable whose only
+    // user is a return. In that case, use the return loc instead. We do this
+    // b/c it is illegal to put a return value location on a non-return value
+    // instruction... so we have to hack around this slightly.
+    auto *user = consumingUse->getUser();
+    auto loc = user->getLoc();
+    if (auto *mtc = dyn_cast<MoveOnlyWrapperToCopyableValueInst>(user)) {
+      if (auto *ri = mtc->getSingleUserOfType<ReturnInst>()) {
+        loc = ri->getLoc();
+      }
+    }
+
+    if (ignorePartialApplyUses &&
+        isa<PartialApplyInst>(consumingUse->getUser()))
+      continue;
+
+    diagnose(astContext, loc.getSourceLoc(),
+             diag::sil_moveonlychecker_consuming_use_here);
+  }
+}
+
+void DiagnosticEmitter::emitObjectDiagnosticsForPartialApplyUses() const {
+  auto &astContext = fn->getASTContext();
+
+  for (auto *consumingUse : getCanonicalizer().consumingUsesNeedingCopy) {
+    // See if the consuming use is an owned moveonly_to_copyable whose only
+    // user is a return. In that case, use the return loc instead. We do this
+    // b/c it is illegal to put a return value location on a non-return value
+    // instruction... so we have to hack around this slightly.
+    auto *user = consumingUse->getUser();
+    auto loc = user->getLoc();
+    if (auto *mtc = dyn_cast<MoveOnlyWrapperToCopyableValueInst>(user)) {
+      if (auto *ri = mtc->getSingleUserOfType<ReturnInst>()) {
+        loc = ri->getLoc();
+      }
+    }
+
+    if (!isa<PartialApplyInst>(consumingUse->getUser()))
+      continue;
+    diagnose(astContext, loc.getSourceLoc(),
+             diag::sil_moveonlychecker_consuming_closure_use_here);
+  }
+
+  for (auto *consumingUse : getCanonicalizer().finalConsumingUses) {
+    // See if the consuming use is an owned moveonly_to_copyable whose only
+    // user is a return. In that case, use the return loc instead. We do this
+    // b/c it is illegal to put a return value location on a non-return value
+    // instruction... so we have to hack around this slightly.
+    auto *user = consumingUse->getUser();
+    auto loc = user->getLoc();
+    if (auto *mtc = dyn_cast<MoveOnlyWrapperToCopyableValueInst>(user)) {
+      if (auto *ri = mtc->getSingleUserOfType<ReturnInst>()) {
+        loc = ri->getLoc();
+      }
+    }
+
+    if (!isa<PartialApplyInst>(consumingUse->getUser()))
+      continue;
+
+    diagnose(astContext, loc.getSourceLoc(),
+             diag::sil_moveonlychecker_consuming_closure_use_here);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+//                         MARK: Address Diagnostics
+//===----------------------------------------------------------------------===//
+
+void DiagnosticEmitter::emitAddressExclusivityHazardDiagnostic(
+    MarkMustCheckInst *markedValue, SILInstruction *consumingUse) {
+  if (!useWithDiagnostic.insert(consumingUse).second)
+    return;
+
+  valuesWithDiagnostics.insert(markedValue);
+
+  auto &astContext = markedValue->getFunction()->getASTContext();
+  StringRef varName = getVariableNameForValue(markedValue);
+
+  LLVM_DEBUG(llvm::dbgs() << "Emitting error for exclusivity!\n");
+  LLVM_DEBUG(llvm::dbgs() << "    Mark: " << *markedValue);
+  LLVM_DEBUG(llvm::dbgs() << "    Consuming use: " << *consumingUse);
+
+  diagnose(astContext,
+           markedValue->getDefiningInstruction()->getLoc().getSourceLoc(),
+           diag::sil_moveonlychecker_exclusivity_violation, varName);
+  diagnose(astContext, consumingUse->getLoc().getSourceLoc(),
+           diag::sil_moveonlychecker_consuming_use_here);
+}
+
+void DiagnosticEmitter::emitAddressDiagnostic(MarkMustCheckInst *markedValue,
+                                              SILInstruction *lastLiveUse,
+                                              SILInstruction *violatingUse,
+                                              bool isUseConsuming,
+                                              bool isInOutEndOfFunction) {
+  if (!useWithDiagnostic.insert(violatingUse).second)
+    return;
+
+  valuesWithDiagnostics.insert(markedValue);
+
+  auto &astContext = markedValue->getFunction()->getASTContext();
+  StringRef varName = getVariableNameForValue(markedValue);
+
+  LLVM_DEBUG(llvm::dbgs() << "Emitting error!\n");
+  LLVM_DEBUG(llvm::dbgs() << "    Mark: " << *markedValue);
+  LLVM_DEBUG(llvm::dbgs() << "    Last Live Use: " << *lastLiveUse);
+  LLVM_DEBUG(llvm::dbgs() << "    Last Live Use Is Consuming? "
+                          << (isUseConsuming ? "yes" : "no") << '\n');
+  LLVM_DEBUG(llvm::dbgs() << "    Violating Use: " << *violatingUse);
+
+  // If our liveness use is the same as our violating use, then we know that we
+  // had a loop. Give a better diagnostic.
+  if (lastLiveUse == violatingUse) {
+    diagnose(astContext,
+             markedValue->getDefiningInstruction()->getLoc().getSourceLoc(),
+             diag::sil_moveonlychecker_value_consumed_in_a_loop, varName);
+    diagnose(astContext, violatingUse->getLoc().getSourceLoc(),
+             diag::sil_moveonlychecker_consuming_use_here);
+    return;
+  }
+
+  if (isInOutEndOfFunction) {
+    diagnose(
+        astContext,
+        markedValue->getDefiningInstruction()->getLoc().getSourceLoc(),
+        diag::
+            sil_moveonlychecker_inout_not_reinitialized_before_end_of_function,
+        varName);
+    diagnose(astContext, violatingUse->getLoc().getSourceLoc(),
+             diag::sil_moveonlychecker_consuming_use_here);
+    return;
+  }
+
+  // First if we are consuming emit an error for no implicit copy semantics.
+  if (isUseConsuming) {
+    diagnose(astContext,
+             markedValue->getDefiningInstruction()->getLoc().getSourceLoc(),
+             diag::sil_moveonlychecker_owned_value_consumed_more_than_once,
+             varName);
+    diagnose(astContext, violatingUse->getLoc().getSourceLoc(),
+             diag::sil_moveonlychecker_consuming_use_here);
+    diagnose(astContext, lastLiveUse->getLoc().getSourceLoc(),
+             diag::sil_moveonlychecker_consuming_use_here);
+    return;
+  }
+
+  // Otherwise, use the "used after consuming use" error.
+  diagnose(astContext,
+           markedValue->getDefiningInstruction()->getLoc().getSourceLoc(),
+           diag::sil_moveonlychecker_value_used_after_consume, varName);
+  diagnose(astContext, violatingUse->getLoc().getSourceLoc(),
+           diag::sil_moveonlychecker_consuming_use_here);
+  diagnose(astContext, lastLiveUse->getLoc().getSourceLoc(),
+           diag::sil_moveonlychecker_nonconsuming_use_here);
+}
+
+void DiagnosticEmitter::emitInOutEndOfFunctionDiagnostic(
+    MarkMustCheckInst *markedValue, SILInstruction *violatingUse) {
+  if (!useWithDiagnostic.insert(violatingUse).second)
+    return;
+
+  assert(cast<SILFunctionArgument>(markedValue->getOperand())
+             ->getArgumentConvention()
+             .isInoutConvention() &&
+         "Expected markedValue to be on an inout");
+
+  auto &astContext = markedValue->getFunction()->getASTContext();
+  StringRef varName = getVariableNameForValue(markedValue);
+
+  LLVM_DEBUG(llvm::dbgs() << "Emitting inout error error!\n");
+  LLVM_DEBUG(llvm::dbgs() << "    Mark: " << *markedValue);
+  LLVM_DEBUG(llvm::dbgs() << "    Violating Use: " << *violatingUse);
+
+  // Otherwise, we need to do no implicit copy semantics. If our last use was
+  // consuming message:
+  diagnose(
+      astContext,
+      markedValue->getDefiningInstruction()->getLoc().getSourceLoc(),
+      diag::sil_moveonlychecker_inout_not_reinitialized_before_end_of_function,
+      varName);
+  diagnose(astContext, violatingUse->getLoc().getSourceLoc(),
+           diag::sil_moveonlychecker_consuming_use_here);
+  valuesWithDiagnostics.insert(markedValue);
+}
+
+void DiagnosticEmitter::emitAddressDiagnosticNoCopy(
+    MarkMustCheckInst *markedValue, SILInstruction *consumingUse) {
+  if (!useWithDiagnostic.insert(consumingUse).second)
+    return;
+
+  auto &astContext = markedValue->getFunction()->getASTContext();
+  StringRef varName = getVariableNameForValue(markedValue);
+
+  LLVM_DEBUG(llvm::dbgs() << "Emitting no copy error!\n");
+  LLVM_DEBUG(llvm::dbgs() << "    Mark: " << *markedValue);
+  LLVM_DEBUG(llvm::dbgs() << "    Consuming Use: " << *consumingUse);
+
+  // Otherwise, we need to do no implicit copy semantics. If our last use was
+  // consuming message:
+  diagnose(astContext,
+           markedValue->getDefiningInstruction()->getLoc().getSourceLoc(),
+           diag::sil_moveonlychecker_guaranteed_value_consumed, varName);
+  diagnose(astContext, consumingUse->getLoc().getSourceLoc(),
+           diag::sil_moveonlychecker_consuming_use_here);
+  valuesWithDiagnostics.insert(markedValue);
+}

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -1,0 +1,84 @@
+//===--- MoveOnlyDiagnostics.h --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// Shared diagnostic code used by both the move only address checker and move
+/// only object checker.
+///
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_MANDATORY_MOVEONLYDIAGNOSTICS_H
+#define SWIFT_SILOPTIMIZER_MANDATORY_MOVEONLYDIAGNOSTICS_H
+
+#include "MoveOnlyObjectChecker.h"
+#include "swift/Basic/NullablePtr.h"
+
+namespace swift {
+namespace siloptimizer {
+
+struct DiagnosticEmitter {
+  SILFunction *fn;
+
+  /// The canonicalizer that contains the final consuming uses and consuming
+  /// uses needing copy for object level diagnostics.
+  NullablePtr<OSSACanonicalizer> canonicalizer = nullptr;
+
+  /// Any mark must check inst that we have emitted diagnostics for are placed
+  /// here.
+  SmallPtrSet<MarkMustCheckInst *, 4> valuesWithDiagnostics;
+
+  // Track any violating uses we have emitted a diagnostic for so we don't emit
+  // multiple diagnostics for the same use.
+  SmallPtrSet<SILInstruction *, 8> useWithDiagnostic;
+
+  /// Clear our cache of uses that we have diagnosed for a specific
+  /// mark_must_check.
+  void clearUsesWithDiagnostic() { useWithDiagnostic.clear(); }
+
+  const OSSACanonicalizer &getCanonicalizer() const {
+    return *canonicalizer.get();
+  }
+
+  void emitCheckerDoesntUnderstandDiagnostic(MarkMustCheckInst *markedValue);
+  void emitObjectGuaranteedDiagnostic(MarkMustCheckInst *markedValue);
+  void emitObjectOwnedDiagnostic(MarkMustCheckInst *markedValue);
+
+  bool emittedAnyDiagnostics() const { return valuesWithDiagnostics.size(); }
+
+  bool emittedDiagnosticForValue(MarkMustCheckInst *markedValue) const {
+    return valuesWithDiagnostics.count(markedValue);
+  }
+
+  void emitAddressDiagnostic(MarkMustCheckInst *markedValue,
+                             SILInstruction *lastLiveUse,
+                             SILInstruction *violatingUse, bool isUseConsuming,
+                             bool isInOutEndOfFunction = false);
+  void emitInOutEndOfFunctionDiagnostic(MarkMustCheckInst *markedValue,
+                                        SILInstruction *violatingUse);
+  void emitAddressDiagnosticNoCopy(MarkMustCheckInst *markedValue,
+                                   SILInstruction *consumingUse);
+  void emitAddressExclusivityHazardDiagnostic(MarkMustCheckInst *markedValue,
+                                              SILInstruction *consumingUse);
+
+private:
+  /// Emit diagnostics for the final consuming uses and consuming uses needing
+  /// copy. If filter is non-null, allow for the caller to pre-process operands
+  /// and emit their own diagnostic. If filter returns true, then we assume that
+  /// the caller processed it correctly. false, then we continue to process it.
+  void emitObjectDiagnosticsForFoundUses(bool ignorePartialApply = false) const;
+  void emitObjectDiagnosticsForPartialApplyUses() const;
+};
+
+} // namespace siloptimizer
+} // namespace swift
+
+#endif

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
@@ -38,303 +38,15 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 
+#include "MoveOnlyDiagnostics.h"
+#include "MoveOnlyObjectChecker.h"
+
 using namespace swift;
-
-//===----------------------------------------------------------------------===//
-//                            MARK: Checker State
-//===----------------------------------------------------------------------===//
-
-namespace {
-
-/// Wrapper around CanonicalizeOSSALifetime that we use to specialize its
-/// interface for our purposes.
-struct OSSACanonicalizer {
-  /// A per mark must check, vector of uses that copy propagation says need a
-  /// copy and thus are not final consuming uses.
-  SmallVector<Operand *, 32> consumingUsesNeedingCopy;
-
-  /// A per mark must check, vector of consuming uses that copy propagation says
-  /// are actual last uses.
-  SmallVector<Operand *, 32> finalConsumingUses;
-
-  /// The actual canonicalizer that we use.
-  ///
-  /// We mark this Optional to avoid UB behavior caused by us needing to
-  /// initialize CanonicalizeOSSALifetime with parts of OSSACanoncializer
-  /// (specifically with state in our arrays) before the actual constructor has
-  /// run. Specifically this avoids:
-  ///
-  /// 11.9.5p1 class.cdtor: For an object with a non-trivial constructor,
-  /// referring to any non-static member or base class of the object before the
-  /// constructor begins execution results in undefined behavior.
-  Optional<CanonicalizeOSSALifetime> canonicalizer;
-
-  OSSACanonicalizer(SILFunction *fn,
-                    NonLocalAccessBlockAnalysis *accessBlockAnalysis,
-                    DominanceInfo *domTree, InstructionDeleter &deleter) {
-    auto foundConsumingUseNeedingCopy = std::function<void(Operand *)>(
-        [&](Operand *use) { consumingUsesNeedingCopy.push_back(use); });
-    auto foundConsumingUseNotNeedingCopy = std::function<void(Operand *)>(
-        [&](Operand *use) { finalConsumingUses.push_back(use); });
-
-    canonicalizer.emplace(
-        false /*pruneDebugMode*/, !fn->shouldOptimize() /*maximizeLifetime*/,
-        accessBlockAnalysis, domTree, deleter, foundConsumingUseNeedingCopy,
-        foundConsumingUseNotNeedingCopy);
-  }
-
-  void clear() {
-    consumingUsesNeedingCopy.clear();
-    finalConsumingUses.clear();
-  }
-
-  bool canonicalize(MarkMustCheckInst *markedValue) {
-    return canonicalizer->canonicalizeValueLifetime(markedValue);
-  }
-
-  bool foundAnyConsumingUses() const {
-    return consumingUsesNeedingCopy.size() || finalConsumingUses.size();
-  }
-
-  bool foundConsumingUseRequiringCopy() const {
-    return consumingUsesNeedingCopy.size();
-  }
-
-  bool hasPartialApplyConsumingUse() const {
-    return llvm::any_of(consumingUsesNeedingCopy,
-                        [](Operand *use) {
-                          return isa<PartialApplyInst>(use->getUser());
-                        }) ||
-           llvm::any_of(finalConsumingUses, [](Operand *use) {
-             return isa<PartialApplyInst>(use->getUser());
-           });
-  }
-
-  bool hasNonPartialApplyConsumingUse() const {
-    return llvm::any_of(consumingUsesNeedingCopy,
-                        [](Operand *use) {
-                          return !isa<PartialApplyInst>(use->getUser());
-                        }) ||
-           llvm::any_of(finalConsumingUses, [](Operand *use) {
-             return !isa<PartialApplyInst>(use->getUser());
-           });
-  }
-};
-
-} // anonymous namespace
+using namespace swift::siloptimizer;
 
 //===----------------------------------------------------------------------===//
 //                         MARK: Diagnostic Utilities
 //===----------------------------------------------------------------------===//
-
-template <typename... T, typename... U>
-static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
-                     U &&...args) {
-  Context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
-}
-
-static StringRef getVariableNameForValue(MarkMustCheckInst *mmci) {
-  StringRef varName = "unknown";
-  if (auto *use = getSingleDebugUse(mmci)) {
-    DebugVarCarryingInst debugVar(use->getUser());
-    if (auto varInfo = debugVar.getVarInfo()) {
-      varName = varInfo->Name;
-    } else {
-      if (auto *decl = debugVar.getDecl()) {
-        varName = decl->getBaseName().userFacingName();
-      }
-    }
-  }
-
-  return varName;
-}
-
-namespace {
-
-struct DiagnosticEmitter {
-  SILFunction *fn;
-  const OSSACanonicalizer &canonicalizer;
-  SmallPtrSet<MarkMustCheckInst *, 4> valuesWithDiagnostics;
-
-  void emitCheckerDoesntUnderstandDiagnostic(MarkMustCheckInst *markedValue);
-  void emitGuaranteedDiagnostic(MarkMustCheckInst *markedValue);
-  void emitOwnedDiagnostic(MarkMustCheckInst *markedValue);
-
-  bool emittedAnyDiagnostics() const { return valuesWithDiagnostics.size(); }
-
-  bool emittedDiagnosticForValue(MarkMustCheckInst *markedValue) const {
-    return valuesWithDiagnostics.count(markedValue);
-  }
-
-private:
-  /// Emit diagnostics for the final consuming uses and consuming uses needing
-  /// copy. If filter is non-null, allow for the caller to pre-process operands
-  /// and emit their own diagnostic. If filter returns true, then we assume that
-  /// the caller processed it correctly. false, then we continue to process it.
-  void emitDiagnosticsForFoundUses(bool ignorePartialApply = false) const;
-  void emitDiagnosticsForPartialApplyUses() const;
-};
-
-} // anonymous namespace
-
-void DiagnosticEmitter::emitCheckerDoesntUnderstandDiagnostic(
-    MarkMustCheckInst *markedValue) {
-  // If we failed to canonicalize ownership, there was something in the SIL
-  // that copy propagation did not understand. Emit a we did not understand
-  // error.
-  if (markedValue->getType().isMoveOnlyWrapped()) {
-    diagnose(fn->getASTContext(), markedValue->getLoc().getSourceLoc(),
-             diag::sil_moveonlychecker_not_understand_no_implicit_copy);
-  } else {
-    diagnose(fn->getASTContext(), markedValue->getLoc().getSourceLoc(),
-             diag::sil_moveonlychecker_not_understand_moveonly);
-  }
-  valuesWithDiagnostics.insert(markedValue);
-}
-
-void DiagnosticEmitter::emitGuaranteedDiagnostic(
-    MarkMustCheckInst *markedValue) {
-  auto &astContext = fn->getASTContext();
-  StringRef varName = getVariableNameForValue(markedValue);
-
-  // See if we have any closure capture uses and emit a better diagnostic.
-  if (canonicalizer.hasPartialApplyConsumingUse()) {
-    diagnose(astContext,
-             markedValue->getDefiningInstruction()->getLoc().getSourceLoc(),
-             diag::sil_moveonlychecker_guaranteed_value_captured_by_closure,
-             varName);
-    emitDiagnosticsForPartialApplyUses();
-    valuesWithDiagnostics.insert(markedValue);
-  }
-
-  // If we do not have any non-partial apply consuming uses... just exit early.
-  if (!canonicalizer.hasNonPartialApplyConsumingUse())
-    return;
-
-  // Check if this value is closure captured. In such a case, emit a special
-  // error.
-  if (auto *fArg = dyn_cast<SILFunctionArgument>(
-          lookThroughCopyValueInsts(markedValue->getOperand()))) {
-    if (fArg->isClosureCapture()) {
-      diagnose(astContext,
-               markedValue->getDefiningInstruction()->getLoc().getSourceLoc(),
-               diag::sil_moveonlychecker_let_value_consumed_in_closure,
-               varName);
-      emitDiagnosticsForFoundUses(true /*ignore partial apply uses*/);
-      valuesWithDiagnostics.insert(markedValue);
-      return;
-    }
-  }
-
-  diagnose(astContext,
-           markedValue->getDefiningInstruction()->getLoc().getSourceLoc(),
-           diag::sil_moveonlychecker_guaranteed_value_consumed, varName);
-
-  emitDiagnosticsForFoundUses(true /*ignore partial apply uses*/);
-  valuesWithDiagnostics.insert(markedValue);
-}
-
-void DiagnosticEmitter::emitOwnedDiagnostic(MarkMustCheckInst *markedValue) {
-  auto &astContext = fn->getASTContext();
-  StringRef varName = getVariableNameForValue(markedValue);
-
-  diagnose(astContext,
-           markedValue->getDefiningInstruction()->getLoc().getSourceLoc(),
-           diag::sil_moveonlychecker_owned_value_consumed_more_than_once,
-           varName);
-
-  emitDiagnosticsForFoundUses();
-  valuesWithDiagnostics.insert(markedValue);
-}
-
-void DiagnosticEmitter::emitDiagnosticsForFoundUses(
-    bool ignorePartialApplyUses) const {
-  auto &astContext = fn->getASTContext();
-
-  for (auto *consumingUse : canonicalizer.consumingUsesNeedingCopy) {
-    // See if the consuming use is an owned moveonly_to_copyable whose only
-    // user is a return. In that case, use the return loc instead. We do this
-    // b/c it is illegal to put a return value location on a non-return value
-    // instruction... so we have to hack around this slightly.
-    auto *user = consumingUse->getUser();
-    auto loc = user->getLoc();
-    if (auto *mtc = dyn_cast<MoveOnlyWrapperToCopyableValueInst>(user)) {
-      if (auto *ri = mtc->getSingleUserOfType<ReturnInst>()) {
-        loc = ri->getLoc();
-      }
-    }
-
-    if (ignorePartialApplyUses &&
-        isa<PartialApplyInst>(consumingUse->getUser()))
-      continue;
-    diagnose(astContext, loc.getSourceLoc(),
-             diag::sil_moveonlychecker_consuming_use_here);
-  }
-
-  for (auto *consumingUse : canonicalizer.finalConsumingUses) {
-    // See if the consuming use is an owned moveonly_to_copyable whose only
-    // user is a return. In that case, use the return loc instead. We do this
-    // b/c it is illegal to put a return value location on a non-return value
-    // instruction... so we have to hack around this slightly.
-    auto *user = consumingUse->getUser();
-    auto loc = user->getLoc();
-    if (auto *mtc = dyn_cast<MoveOnlyWrapperToCopyableValueInst>(user)) {
-      if (auto *ri = mtc->getSingleUserOfType<ReturnInst>()) {
-        loc = ri->getLoc();
-      }
-    }
-
-    if (ignorePartialApplyUses &&
-        isa<PartialApplyInst>(consumingUse->getUser()))
-      continue;
-
-    diagnose(astContext, loc.getSourceLoc(),
-             diag::sil_moveonlychecker_consuming_use_here);
-  }
-}
-
-void DiagnosticEmitter::emitDiagnosticsForPartialApplyUses() const {
-  auto &astContext = fn->getASTContext();
-
-  for (auto *consumingUse : canonicalizer.consumingUsesNeedingCopy) {
-    // See if the consuming use is an owned moveonly_to_copyable whose only
-    // user is a return. In that case, use the return loc instead. We do this
-    // b/c it is illegal to put a return value location on a non-return value
-    // instruction... so we have to hack around this slightly.
-    auto *user = consumingUse->getUser();
-    auto loc = user->getLoc();
-    if (auto *mtc = dyn_cast<MoveOnlyWrapperToCopyableValueInst>(user)) {
-      if (auto *ri = mtc->getSingleUserOfType<ReturnInst>()) {
-        loc = ri->getLoc();
-      }
-    }
-
-    if (!isa<PartialApplyInst>(consumingUse->getUser()))
-      continue;
-    diagnose(astContext, loc.getSourceLoc(),
-             diag::sil_moveonlychecker_consuming_closure_use_here);
-  }
-
-  for (auto *consumingUse : canonicalizer.finalConsumingUses) {
-    // See if the consuming use is an owned moveonly_to_copyable whose only
-    // user is a return. In that case, use the return loc instead. We do this
-    // b/c it is illegal to put a return value location on a non-return value
-    // instruction... so we have to hack around this slightly.
-    auto *user = consumingUse->getUser();
-    auto loc = user->getLoc();
-    if (auto *mtc = dyn_cast<MoveOnlyWrapperToCopyableValueInst>(user)) {
-      if (auto *ri = mtc->getSingleUserOfType<ReturnInst>()) {
-        loc = ri->getLoc();
-      }
-    }
-
-    if (!isa<PartialApplyInst>(consumingUse->getUser()))
-      continue;
-
-    diagnose(astContext, loc.getSourceLoc(),
-             diag::sil_moveonlychecker_consuming_closure_use_here);
-  }
-}
 
 //===----------------------------------------------------------------------===//
 //                              MARK: Main Pass
@@ -357,7 +69,7 @@ struct MoveOnlyChecker {
   ///
   /// \returns true if we deleted a mark_must_check inst that we didn't
   /// recognize after emitting the diagnostic.
-  bool searchForCandidateMarkMustChecks();
+  bool searchForCandidateMarkMustChecks(DiagnosticEmitter &emitter);
 
   bool check(NonLocalAccessBlockAnalysis *accessBlockAnalysis,
              DominanceInfo *domTree);
@@ -365,7 +77,8 @@ struct MoveOnlyChecker {
 
 } // namespace
 
-bool MoveOnlyChecker::searchForCandidateMarkMustChecks() {
+bool MoveOnlyChecker::searchForCandidateMarkMustChecks(
+    DiagnosticEmitter &emitter) {
   bool changed = false;
   for (auto &block : *fn) {
     for (auto ii = block.begin(), ie = block.end(); ii != ie;) {
@@ -557,13 +270,7 @@ bool MoveOnlyChecker::searchForCandidateMarkMustChecks() {
       // We then RAUW the mark_must_check once we have emitted the error since
       // later passes expect that mark_must_check has been eliminated by
       // us. Since we are failing already, this is ok to do.
-      if (mmci->getType().isMoveOnlyWrapped()) {
-        diagnose(fn->getASTContext(), mmci->getLoc().getSourceLoc(),
-                 diag::sil_moveonlychecker_not_understand_no_implicit_copy);
-      } else {
-        diagnose(fn->getASTContext(), mmci->getLoc().getSourceLoc(),
-                 diag::sil_moveonlychecker_not_understand_moveonly);
-      }
+      emitter.emitCheckerDoesntUnderstandDiagnostic(mmci);
       mmci->replaceAllUsesWith(mmci->getOperand());
       mmci->eraseFromParent();
       changed = true;
@@ -576,9 +283,20 @@ bool MoveOnlyChecker::check(NonLocalAccessBlockAnalysis *accessBlockAnalysis,
                             DominanceInfo *domTree) {
   bool changed = false;
 
+  auto callbacks =
+      InstModCallbacks().onDelete([&](SILInstruction *instToDelete) {
+        if (auto *mvi = dyn_cast<MarkMustCheckInst>(instToDelete))
+          moveIntroducersToProcess.remove(mvi);
+        instToDelete->eraseFromParent();
+      });
+  InstructionDeleter deleter(std::move(callbacks));
+  OSSACanonicalizer canonicalizer;
+  canonicalizer.init(fn, accessBlockAnalysis, domTree, deleter);
+  DiagnosticEmitter diagnosticEmitter{fn, &canonicalizer, {}, {}};
+
   // First search for candidates to process and emit diagnostics on any
   // mark_must_check [noimplicitcopy] we didn't recognize.
-  changed |= searchForCandidateMarkMustChecks();
+  changed |= searchForCandidateMarkMustChecks(diagnosticEmitter);
 
   // If we didn't find any introducers to check, just return changed.
   //
@@ -587,16 +305,6 @@ bool MoveOnlyChecker::check(NonLocalAccessBlockAnalysis *accessBlockAnalysis,
   // and then deleting.
   if (moveIntroducersToProcess.empty())
     return changed;
-
-  auto callbacks =
-      InstModCallbacks().onDelete([&](SILInstruction *instToDelete) {
-        if (auto *mvi = dyn_cast<MarkMustCheckInst>(instToDelete))
-          moveIntroducersToProcess.remove(mvi);
-        instToDelete->eraseFromParent();
-      });
-  InstructionDeleter deleter(std::move(callbacks));
-  OSSACanonicalizer canonicalizer(fn, accessBlockAnalysis, domTree, deleter);
-  DiagnosticEmitter diagnosticEmitter{fn, canonicalizer, {}};
 
   auto moveIntroducers = llvm::makeArrayRef(moveIntroducersToProcess.begin(),
                                             moveIntroducersToProcess.end());
@@ -621,7 +329,7 @@ bool MoveOnlyChecker::check(NonLocalAccessBlockAnalysis *accessBlockAnalysis,
     // /any/ consuming uses.
     if (markedValue->getCheckKind() == MarkMustCheckInst::CheckKind::NoCopy) {
       if (canonicalizer.foundAnyConsumingUses()) {
-        diagnosticEmitter.emitGuaranteedDiagnostic(markedValue);
+        diagnosticEmitter.emitObjectGuaranteedDiagnostic(markedValue);
       }
       continue;
     }
@@ -634,7 +342,7 @@ bool MoveOnlyChecker::check(NonLocalAccessBlockAnalysis *accessBlockAnalysis,
       continue;
     }
 
-    diagnosticEmitter.emitOwnedDiagnostic(markedValue);
+    diagnosticEmitter.emitObjectOwnedDiagnostic(markedValue);
   }
 
   bool emittedDiagnostic = diagnosticEmitter.emittedAnyDiagnostics();

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.h
@@ -1,0 +1,109 @@
+//===--- MoveOnlyObjectChecker.h ------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This is for shared code in between the move only object checker and the move
+/// only address checker. This is needed since the move only address checker
+/// uses the move only object checker to check values loaded from allocations
+/// that it is analyzing.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_MANDATORY_MOVEONLYOBJECTCHECKER_H
+#define SWIFT_SILOPTIMIZER_MANDATORY_MOVEONLYOBJECTCHECKER_H
+
+#include "swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h"
+
+namespace swift {
+namespace siloptimizer {
+
+/// Wrapper around CanonicalizeOSSALifetime that we use to specialize its
+/// interface for our purposes.
+struct OSSACanonicalizer {
+  /// A per mark must check, vector of uses that copy propagation says need a
+  /// copy and thus are not final consuming uses.
+  SmallVector<Operand *, 32> consumingUsesNeedingCopy;
+
+  /// A per mark must check, vector of consuming uses that copy propagation says
+  /// are actual last uses.
+  SmallVector<Operand *, 32> finalConsumingUses;
+
+  /// The actual canonicalizer that we use.
+  ///
+  /// We mark this Optional to avoid UB behavior caused by us needing to
+  /// initialize CanonicalizeOSSALifetime with parts of OSSACanoncializer
+  /// (specifically with state in our arrays) before the actual constructor has
+  /// run. Specifically this avoids:
+  ///
+  /// 11.9.5p1 class.cdtor: For an object with a non-trivial constructor,
+  /// referring to any non-static member or base class of the object before the
+  /// constructor begins execution results in undefined behavior.
+  Optional<CanonicalizeOSSALifetime> canonicalizer;
+
+  OSSACanonicalizer() {}
+
+  void init(SILFunction *fn, NonLocalAccessBlockAnalysis *accessBlockAnalysis,
+            DominanceInfo *domTree, InstructionDeleter &deleter) {
+    auto foundConsumingUseNeedingCopy = std::function<void(Operand *)>(
+        [&](Operand *use) { consumingUsesNeedingCopy.push_back(use); });
+    auto foundConsumingUseNotNeedingCopy = std::function<void(Operand *)>(
+        [&](Operand *use) { finalConsumingUses.push_back(use); });
+
+    canonicalizer.emplace(
+        false /*pruneDebugMode*/, !fn->shouldOptimize() /*maximizeLifetime*/,
+        accessBlockAnalysis, domTree, deleter, foundConsumingUseNeedingCopy,
+        foundConsumingUseNotNeedingCopy);
+  }
+
+  void clear() {
+    consumingUsesNeedingCopy.clear();
+    finalConsumingUses.clear();
+  }
+
+  bool canonicalize(SILValue value) {
+    return canonicalizer->canonicalizeValueLifetime(value);
+  }
+
+  bool foundAnyConsumingUses() const {
+    return consumingUsesNeedingCopy.size() || finalConsumingUses.size();
+  }
+
+  bool foundConsumingUseRequiringCopy() const {
+    return consumingUsesNeedingCopy.size();
+  }
+
+  bool foundFinalConsumingUses() const { return finalConsumingUses.size(); }
+
+  bool hasPartialApplyConsumingUse() const {
+    return llvm::any_of(consumingUsesNeedingCopy,
+                        [](Operand *use) {
+                          return isa<PartialApplyInst>(use->getUser());
+                        }) ||
+           llvm::any_of(finalConsumingUses, [](Operand *use) {
+             return isa<PartialApplyInst>(use->getUser());
+           });
+  }
+
+  bool hasNonPartialApplyConsumingUse() const {
+    return llvm::any_of(consumingUsesNeedingCopy,
+                        [](Operand *use) {
+                          return !isa<PartialApplyInst>(use->getUser());
+                        }) ||
+           llvm::any_of(finalConsumingUses, [](Operand *use) {
+             return !isa<PartialApplyInst>(use->getUser());
+           });
+  }
+};
+
+} // namespace siloptimizer
+} // namespace swift
+
+#endif

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1883,11 +1883,19 @@ public func closureClassUseAfterConsumeArg(_ argX: inout Klass) {
 public func closureCaptureClassUseAfterConsume() {
     var x2 = Klass()
     // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-3 {{'x2' consumed more than once}}
+    // expected-error @-4 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = {
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2)
+        // expected-note @-1 {{consuming use}}
+        // expected-note @-2 {{consuming use}}
         print(x2)
+        // expected-note @-1 {{consuming use}}
+        // expected-note @-2 {{consuming use}}
+        // expected-note @-3 {{consuming use}}
     }
     f()
 }
@@ -1895,11 +1903,19 @@ public func closureCaptureClassUseAfterConsume() {
 public func closureCaptureClassUseAfterConsumeError() {
     var x2 = Klass()
     // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    // expected-error @-3 {{'x2' consumed more than once}}
+    // expected-error @-4 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = Klass()
     let f = {
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2)
+        // expected-note @-1 {{consuming use}}
+        // expected-note @-2 {{consuming use}}
         print(x2)
+        // expected-note @-1 {{consuming use}}
+        // expected-note @-2 {{consuming use}}
+        // expected-note @-3 {{consuming use}}
     }
     f()
     let x3 = x2
@@ -1908,7 +1924,7 @@ public func closureCaptureClassUseAfterConsumeError() {
 
 public func closureCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-3 {{'x2' consumed more than once}}
     // expected-note @-4 {{'x2' is declared 'inout'}}
     let f = { // expected-note {{consuming use}}
@@ -1926,7 +1942,7 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
 // TODO: Improve error msg here to make it clear the use is due to the defer.
 public func deferCaptureClassUseAfterConsume() {
     var x2 = Klass()
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = Klass()
     defer {
@@ -1940,7 +1956,7 @@ public func deferCaptureClassUseAfterConsume() {
 
 public func deferCaptureClassUseAfterConsume2() {
     var x2 = Klass()
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = Klass()
     defer {
@@ -1955,7 +1971,7 @@ public func deferCaptureClassUseAfterConsume2() {
 }
 
 public func deferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
     classUseMoveOnlyWithoutEscaping(x2)
     defer {
@@ -1970,7 +1986,7 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
 public func closureAndDeferCaptureClassUseAfterConsume() {
     var x2 = Klass()
     // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-3 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = {
@@ -1988,7 +2004,7 @@ public func closureAndDeferCaptureClassUseAfterConsume() {
 
 public func closureAndDeferCaptureClassUseAfterConsume2() {
     var x2 = Klass()
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
     // expected-error @-3 {{'x2' consumed more than once}}
     x2 = Klass()
@@ -2008,7 +2024,7 @@ public func closureAndDeferCaptureClassUseAfterConsume2() {
 
 public func closureAndDeferCaptureClassUseAfterConsume3() {
     var x2 = Klass()
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
     // expected-error @-3 {{'x2' consumed more than once}}
     x2 = Klass()
@@ -2029,7 +2045,7 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-3 {{'x2' consumed more than once}}
     // expected-note @-4 {{'x2' is declared 'inout'}}
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
@@ -2050,12 +2066,22 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
 public func closureAndClosureCaptureClassUseAfterConsume() {
     var x2 = Klass()
     // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-3 {{'x2' consumed more than once}}
+    // expected-error @-4 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-5 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-6 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = {
         let g = {
             classUseMoveOnlyWithoutEscaping(x2)
             classConsume(x2)
+            // expected-note @-1 {{consuming use}}
+            // expected-note @-2 {{consuming use}}
             print(x2)
+            // expected-note @-1 {{consuming use}}
+            // expected-note @-2 {{consuming use}}
+            // expected-note @-3 {{consuming use}}
         }
         g()
     }
@@ -2065,12 +2091,22 @@ public func closureAndClosureCaptureClassUseAfterConsume() {
 public func closureAndClosureCaptureClassUseAfterConsume2() {
     var x2 = Klass()
     // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-4 {{'x2' consumed more than once}}
+    // expected-error @-5 {{'x2' consumed more than once}}
+    // expected-error @-6 {{Usage of a move only type that the move checker does not know how to check!}}
     x2 = Klass()
     let f = {
         let g = {
             classUseMoveOnlyWithoutEscaping(x2)
             classConsume(x2)
+            // expected-note @-1 {{consuming use}}
+            // expected-note @-2 {{consuming use}}
             print(x2)
+            // expected-note @-1 {{consuming use}}
+            // expected-note @-2 {{consuming use}}
+            // expected-note @-3 {{consuming use}}
         }
         g()
     }
@@ -2081,8 +2117,8 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
 
 public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-3 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-4 {{'x2' consumed more than once}}
     // expected-note @-5 {{'x2' is declared 'inout'}}
     // expected-note @-6 {{'x2' is declared 'inout'}}

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -2048,7 +2048,7 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg(_ x2: __owned EnumTy) {
 
 public func closureClassUseAfterConsume1(_ x: Klass) {
     // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
-    // expected-error @-2 {{'x' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-2 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = { // expected-note {{closure capture}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
         // expected-note @-1 {{consuming use}}
@@ -2082,7 +2082,7 @@ public func closureClassUseAfterConsumeArg(_ argX: Klass) {
 
 public func closureCaptureClassUseAfterConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use}}
@@ -2094,7 +2094,7 @@ public func closureCaptureClassUseAfterConsume(_ x: Klass) { // expected-error {
 public func closureCaptureClassUseAfterConsumeError(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-note @-3 {{consuming use}}
     let f = { // expected-note {{consuming use}}
         classUseMoveOnlyWithoutEscaping(x2)
@@ -2107,7 +2107,7 @@ public func closureCaptureClassUseAfterConsumeError(_ x: Klass) { // expected-er
 }
 
 public func closureCaptureClassArgUseAfterConsume(_ x2: Klass) {
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{closure capture}}
         classUseMoveOnlyWithoutEscaping(x2)
@@ -2118,7 +2118,7 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: Klass) {
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use}}
@@ -2129,7 +2129,7 @@ public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
 
 public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = { // expected-note {{consuming use}}
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use}}
@@ -2142,7 +2142,7 @@ public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) {
 
 public func deferCaptureClassUseAfterConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use}}
@@ -2154,7 +2154,7 @@ public func deferCaptureClassUseAfterConsume(_ x: Klass) { // expected-error {{'
 public func deferCaptureClassUseAfterConsume2(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use}}
@@ -2165,7 +2165,7 @@ public func deferCaptureClassUseAfterConsume2(_ x: Klass) { // expected-error {{
 }
 
 public func deferCaptureClassArgUseAfterConsume(_ x2: Klass) {
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     classUseMoveOnlyWithoutEscaping(x2)
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
@@ -2176,7 +2176,7 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: Klass) {
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use}}
@@ -2187,7 +2187,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
 
 public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use}}
@@ -2198,7 +2198,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) {
 
 public func closureAndDeferCaptureClassUseAfterConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
@@ -2212,8 +2212,8 @@ public func closureAndDeferCaptureClassUseAfterConsume(_ x: Klass) { // expected
 
 public func closureAndDeferCaptureClassUseAfterConsume2(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         classConsume(x2) // expected-note {{consuming use}}
         defer {
@@ -2229,8 +2229,8 @@ public func closureAndDeferCaptureClassUseAfterConsume2(_ x: Klass) { // expecte
 public func closureAndDeferCaptureClassUseAfterConsume3(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
-    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-3 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = { // expected-note {{consuming use}}
         classConsume(x2) // expected-note {{consuming use}}
         defer {
@@ -2245,7 +2245,7 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: Klass) { // expecte
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: Klass) {
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{closure capture}}
         defer {
@@ -2259,7 +2259,7 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: Klass) {
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
@@ -2273,7 +2273,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Kla
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = { // expected-note {{consuming use}}
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
@@ -2288,7 +2288,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Kl
 
 public func closureAndClosureCaptureClassUseAfterConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = {
         let g = { // expected-note {{closure capture}}
@@ -2304,7 +2304,7 @@ public func closureAndClosureCaptureClassUseAfterConsume(_ x: Klass) { // expect
 public func closureAndClosureCaptureClassUseAfterConsume2(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{consuming use}}
         let g = { // expected-note {{closure capture}}
@@ -2320,7 +2320,7 @@ public func closureAndClosureCaptureClassUseAfterConsume2(_ x: Klass) { // expec
 
 
 public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: Klass) {
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{closure capture}}
@@ -2335,7 +2335,7 @@ public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: Klass) {
 }
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = {
         let g = { // expected-note {{closure capture}}
@@ -2350,7 +2350,7 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned K
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{consuming use}}
         let g = { // expected-note {{closure capture}}

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1219,11 +1219,19 @@ public func closureClassUseAfterConsumeArg(_ argX: inout NonTrivialStruct) {
 public func closureCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-3 {{'x2' consumed more than once}}
+    // expected-error @-4 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
     let f = {
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2)
+        // expected-note @-1 {{consuming use}}
+        // expected-note @-2 {{consuming use}}
         print(x2)
+        // expected-note @-1 {{consuming use}}
+        // expected-note @-2 {{consuming use}}
+        // expected-note @-3 {{consuming use}}
     }
     f()
 }
@@ -1231,11 +1239,19 @@ public func closureCaptureClassUseAfterConsume() {
 public func closureCaptureClassUseAfterConsumeError() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-3 {{'x2' consumed more than once}}
+    // expected-error @-4 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
     let f = {
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2)
+        // expected-note @-1 {{consuming use}}
+        // expected-note @-2 {{consuming use}}
         print(x2)
+        // expected-note @-1 {{consuming use}}
+        // expected-note @-2 {{consuming use}}
+        // expected-note @-3 {{consuming use}}
     }
     f()
     let x3 = x2
@@ -1244,7 +1260,7 @@ public func closureCaptureClassUseAfterConsumeError() {
 
 public func closureCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-3 {{'x2' consumed more than once}}
     // expected-note @-4 {{'x2' is declared 'inout'}}
     let f = { // expected-note {{consuming use}}
@@ -1262,7 +1278,7 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) 
 // TODO: Improve error msg here to make it clear the use is due to the defer.
 public func deferCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
     defer {
@@ -1276,7 +1292,7 @@ public func deferCaptureClassUseAfterConsume() {
 
 public func deferCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
     defer {
@@ -1291,7 +1307,7 @@ public func deferCaptureClassUseAfterConsume2() {
 }
 
 public func deferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
     classUseMoveOnlyWithoutEscaping(x2)
     defer {
@@ -1306,7 +1322,7 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
 public func closureAndDeferCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-3 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
     let f = {
@@ -1324,7 +1340,7 @@ public func closureAndDeferCaptureClassUseAfterConsume() {
 
 public func closureAndDeferCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
     // expected-error @-3 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
@@ -1344,7 +1360,7 @@ public func closureAndDeferCaptureClassUseAfterConsume2() {
 
 public func closureAndDeferCaptureClassUseAfterConsume3() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
     // expected-error @-3 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
@@ -1365,7 +1381,7 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-3 {{'x2' consumed more than once}}
     // expected-note @-4 {{'x2' is declared 'inout'}}
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
@@ -1386,12 +1402,22 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivial
 public func closureAndClosureCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-3 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-4 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-5 {{'x2' consumed more than once}}
+    // expected-error @-6 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
     let f = {
         let g = {
             classUseMoveOnlyWithoutEscaping(x2)
             classConsume(x2)
+            // expected-note @-1 {{consuming use}}
+            // expected-note @-2 {{consuming use}}
             print(x2)
+            // expected-note @-1 {{consuming use}}
+            // expected-note @-2 {{consuming use}}
+            // expected-note @-3 {{consuming use}}
         }
         g()
     }
@@ -1401,12 +1427,22 @@ public func closureAndClosureCaptureClassUseAfterConsume() {
 public func closureAndClosureCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-3 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-4 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-5 {{'x2' consumed more than once}}
+    // expected-error @-6 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
     let f = {
         let g = {
             classUseMoveOnlyWithoutEscaping(x2)
             classConsume(x2)
+            // expected-note @-1 {{consuming use}}
+            // expected-note @-2 {{consuming use}}
             print(x2)
+            // expected-note @-1 {{consuming use}}
+            // expected-note @-2 {{consuming use}}
+            // expected-note @-3 {{consuming use}}
         }
         g()
     }
@@ -1417,8 +1453,8 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
 
 public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-3 {{'x2' consumed but not reinitialized before end of function}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-4 {{'x2' consumed more than once}}
     // expected-note @-5 {{'x2' is declared 'inout'}}
     // expected-note @-6 {{'x2' is declared 'inout'}}

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -1343,7 +1343,7 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg(_ x2: __owned EnumTy) {
 /////////////////////////////
 
 public func closureClassUseAfterConsume1(_ x: NonTrivialStruct) {
-    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{closure capture}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
@@ -1378,7 +1378,7 @@ public func closureClassUseAfterConsumeArg(_ argX: NonTrivialStruct) {
 
 public func closureCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use}}
@@ -1390,7 +1390,7 @@ public func closureCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expec
 public func closureCaptureClassUseAfterConsumeError(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = { // expected-note {{consuming use}}
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use}}
@@ -1402,7 +1402,7 @@ public func closureCaptureClassUseAfterConsumeError(_ x: NonTrivialStruct) { // 
 }
 
 public func closureCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) {
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{closure capture}}
         classUseMoveOnlyWithoutEscaping(x2)
@@ -1413,7 +1413,7 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) {
 }
 
 public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use}}
@@ -1424,7 +1424,7 @@ public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialS
 
 public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = { // expected-note {{consuming use}}
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use}}
@@ -1437,7 +1437,7 @@ public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivial
 
 public func deferCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use}}
@@ -1449,7 +1449,7 @@ public func deferCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expecte
 public func deferCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // TODO: Defer error is b/c we have to lifetime extend x2 for the defer. The
     // use is a guaranteed use, so we don't emit an error on that use.
     defer {
@@ -1462,7 +1462,7 @@ public func deferCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) { // expect
 }
 
 public func deferCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) {
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     classUseMoveOnlyWithoutEscaping(x2)
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
@@ -1473,7 +1473,7 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) {
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use}}
@@ -1484,7 +1484,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStr
 
 public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     defer {
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2) // expected-note {{consuming use}}
@@ -1496,7 +1496,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialSt
 public func closureAndDeferCaptureClassUseAfterConsume(_ x: NonTrivialStruct) {
     // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
@@ -1510,8 +1510,8 @@ public func closureAndDeferCaptureClassUseAfterConsume(_ x: NonTrivialStruct) {
 
 public func closureAndDeferCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         classConsume(x2) // expected-note {{consuming use}}
         defer {
@@ -1527,8 +1527,8 @@ public func closureAndDeferCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) {
 public func closureAndDeferCaptureClassUseAfterConsume3(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
-    // expected-error @-3 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-3 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = { // expected-note {{consuming use}}
         classConsume(x2) // expected-note {{consuming use}}
         defer {
@@ -1543,7 +1543,7 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: NonTrivialStruct) {
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = { // expected-note {{closure capture}}
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
@@ -1556,7 +1556,7 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
@@ -1569,7 +1569,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Non
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialStruct) { // expected-error {{'x2' consumed more than once}}
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = { // expected-note {{consuming use}}
         defer {
             classUseMoveOnlyWithoutEscaping(x2)
@@ -1584,7 +1584,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned No
 
 public func closureAndClosureCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use}}
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = {
         let g = { // expected-note {{closure capture}}
@@ -1600,7 +1600,7 @@ public func closureAndClosureCaptureClassUseAfterConsume(_ x: NonTrivialStruct) 
 public func closureAndClosureCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use}}
-               // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+               // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
                // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{consuming use}}
         let g = { // expected-note {{closure capture}}
@@ -1616,7 +1616,7 @@ public func closureAndClosureCaptureClassUseAfterConsume2(_ x: NonTrivialStruct)
 
 
 public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) {
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{closure capture}}
@@ -1631,7 +1631,7 @@ public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: NonTrivialStru
 }
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = {
         let g = { // expected-note {{closure capture}}
@@ -1646,7 +1646,7 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned N
 
 public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' has guaranteed ownership but was consumed}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{consuming use}}
         let g = { // expected-note {{closure capture}}


### PR DESCRIPTION
I also cleaned up some of the messages from the previous let patch and refactored the diagnostic infrastructure so that the move only address/object can share parts of it.