### PR TITLE
[Test] Fix deinit_escape test.

### DIFF
--- a/test/Runtime/deinit_escape.swift
+++ b/test/Runtime/deinit_escape.swift
@@ -8,17 +8,19 @@ import StdlibUnittest
 
 var DeinitEscapeTestSuite = TestSuite("DeinitEscape")
 
-var globalObjects: [AnyObject] = []
+var globalObjects1: [AnyObject] = []
+var globalObjects2: [AnyObject] = []
 
 DeinitEscapeTestSuite.test("deinit escapes self") {
   expectCrashLater()
 
   class C {
     deinit {
-      globalObjects.append(self)
+      globalObjects2.append(self)
     }
   }
-  _ = C()
+  globalObjects1.append(C())
+  globalObjects1 = []
 
   expectUnreachable()
 }


### PR DESCRIPTION
When compiled with optimizations, the compiler saw that C() doesn't escape and stack promoted it, which breaks the check. Deliberately escape the object into a global array beforehand to ensure it has to be on the heap.

rdar://103369708