### PR TITLE
[Refactoring] Fix stack-use-after-scope in ContextFinder

### DIFF
--- a/lib/Refactoring/Refactoring.cpp
+++ b/lib/Refactoring/Refactoring.cpp
@@ -49,7 +49,7 @@ class ContextFinder : public SourceEntityWalker {
   ASTContext &Ctx;
   SourceManager &SM;
   SourceRange Target;
-  function_ref<bool(ASTNode)> IsContext;
+  std::function<bool(ASTNode)> IsContext;
   SmallVector<ASTNode, 4> AllContexts;
   bool contains(ASTNode Enclosing) {
     auto Result = SM.rangeContains(Enclosing.getSourceRange(), Target);
@@ -59,12 +59,12 @@ class ContextFinder : public SourceEntityWalker {
   }
 public:
   ContextFinder(SourceFile &SF, ASTNode TargetNode,
-                function_ref<bool(ASTNode)> IsContext =
+                std::function<bool(ASTNode)> IsContext =
                   [](ASTNode N) { return true; }) :
                   SF(SF), Ctx(SF.getASTContext()), SM(Ctx.SourceMgr),
                   Target(TargetNode.getSourceRange()), IsContext(IsContext) {}
   ContextFinder(SourceFile &SF, SourceLoc TargetLoc,
-                function_ref<bool(ASTNode)> IsContext =
+                std::function<bool(ASTNode)> IsContext =
                   [](ASTNode N) { return true; }) :
                   SF(SF), Ctx(SF.getASTContext()), SM(Ctx.SourceMgr),
                   Target(TargetLoc), IsContext(IsContext) {


### PR DESCRIPTION
Storing `llvm::function_ref` as a member field is not safe. Just use std::function instead.

rdar://103369305
