### PR TITLE
Failing test for runtime polymorphism.

### DIFF
--- a/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
+++ b/test/Interop/Cxx/class/inheritance/Inputs/module.modulemap
@@ -6,6 +6,11 @@ module Fields {
   header "fields.h"
 }
 
+module Polymorphism {
+  header "polymorphism.h"
+  requires cplusplus
+}
+
 module SubTypes {
   header "sub-types.h"
 }

--- a/test/Interop/Cxx/class/inheritance/Inputs/polymorphism.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/polymorphism.h
@@ -1,0 +1,20 @@
+#ifndef TEST_INTEROP_CXX_CLASS_INHERITANCE_POLYMORPHISM_H_
+#define TEST_INTEROP_CXX_CLASS_INHERITANCE_POLYMORPHISM_H_
+
+class Shape {
+ public:
+  virtual int NumberOfSides() { return 0; }
+};
+
+class Rectangle : public Shape {
+ public:
+  virtual int NumberOfSides() { return 4; }
+};
+
+// For testing runtime polymorphism.
+Shape* MakeShape() {
+  return new Rectangle();
+}
+
+#endif  // TEST_INTEROP_CXX_CLASS_INHERITANCE_POLYMORPHISM_H_
+

--- a/test/Interop/Cxx/class/inheritance/runtime-polymorphism.swift
+++ b/test/Interop/Cxx/class/inheritance/runtime-polymorphism.swift
@@ -1,0 +1,24 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs/ -Xfrontend -enable-experimental-cxx-interop)
+//
+// REQUIRES: executable_test
+//
+// XFAIL: *
+
+import Polymorphism
+import StdlibUnittest
+
+
+var PolymorphismTestSuite = TestSuite("Determining if runtime polymorphism works")
+
+
+PolymorphismTestSuite.test("Call overridden methods with pointer to base type") {
+  // MakeShape() creates a Rectangle and returns the object as a Shape*.
+  let shape = MakeShape()
+
+  // DOES NOT WORK: executes the Shape implementation, not the Rectangle
+  // version, and thus fails the comparision (0 != 4)
+  // Filed as https://github.com/apple/swift/issues/62354.
+  expectEqual(shape!.pointee.NumberOfSides(), 4)
+}
+
+runAllTests()


### PR DESCRIPTION
Add a (failing) test for runtime polymorphism. 

This covers https://github.com/apple/swift/issues/62354 and will need to be fixed when that bug is fixed. Currently the vtable is not used for dispatching, so it ends up calling the statically-typed method. 