### PR TITLE
Fix dynamic replacement of weakly linked symbols

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -2732,6 +2732,10 @@ static InitializeDynamicReplacementLookup initDynamicReplacements;
 SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END
 
 void DynamicReplacementDescriptor::enableReplacement() const {
+  // Weakly linked symbols can be zero.
+  if (replacedFunctionKey.get() == nullptr)
+    return;
+
   auto *chainRoot = const_cast<DynamicReplacementChainEntry *>(
       replacedFunctionKey->root.get());
 

--- a/test/Interpreter/Inputs/dynamic_replacement_ReplacementA.swift
+++ b/test/Interpreter/Inputs/dynamic_replacement_ReplacementA.swift
@@ -1,0 +1,8 @@
+@_weakLinked import LibA
+
+extension A {
+  @_dynamicReplacement(for: printThis())
+  func _replacementForPrintThis() {
+    Swift.print("replacement")
+  }
+}

--- a/test/Interpreter/Inputs/dynamic_replacement_libA.swift
+++ b/test/Interpreter/Inputs/dynamic_replacement_libA.swift
@@ -1,0 +1,25 @@
+public struct A {
+    public var x : Int = 0
+    public var y : Int = 1
+    public init() {}
+#if BEFORE
+    public func print() {
+        printThis()
+    }
+
+    public dynamic func printThis() {
+        Swift.print(x)
+        Swift.print(y)
+    }
+#else
+    public func print() {
+        printThis2()
+    }
+
+    public dynamic func printThis2() {
+        Swift.print(x)
+        Swift.print(y)
+    }
+
+#endif
+}

--- a/test/Interpreter/dynamic_replacement_weak_linked.swift
+++ b/test/Interpreter/dynamic_replacement_weak_linked.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(LibA)) -DBEFORE -module-name LibA -emit-module -emit-module-path %t/LibA.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_libA.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(ReplacementA)) -I%t -L%t -lLibA -module-name ReplacementA -swift-version 5 %S/Inputs/dynamic_replacement_ReplacementA.swift
+// RUN: %target-build-swift-dylib(%t/%target-library-name(LibA)) -module-name LibA -emit-module -emit-module-path %t/LibA.swiftmodule -swift-version 5 %S/Inputs/dynamic_replacement_libA.swift
+// RUN: %target-build-swift -I%t -L%t -lLibA -o %t/main %target-rpath(%t) %s -swift-version 5
+// RUN: %target-codesign %t/main %t/%target-library-name(LibA) %t/%target-library-name(ReplacementA)
+// RUN: %target-run %t/main %t/%target-library-name(LibA) %t/%target-library-name(ReplacementA)
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+// REQUIRES: swift_test_mode_optimize_none
+
+import Darwin
+
+import LibA
+
+private func target_library_name(_ name: String) -> String {
+  return "lib\(name).dylib"
+}
+
+var executablePath = CommandLine.arguments[0]
+executablePath.removeLast(4)
+_ = dlopen(executablePath + target_library_name("ReplacementA"), RTLD_NOW)
+
+A().print()


### PR DESCRIPTION
If the replaced symbol goes away in the original library, the replacement key in the replacement descriptor will be null. Handle this by ignoring the replacement entry rather than crashing.

rdar://103307821