### PR TITLE
[NFC][Dependency Scanner] Rename scanner classes to better represent their meaning

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -87,7 +87,7 @@ namespace swift {
   class LazyContextData;
   class LazyIterableDeclContextData;
   class LazyMemberLoader;
-  class ModuleDependencies;
+  class ModuleDependencyInfo;
   class PatternBindingDecl;
   class PatternBindingInitializer;
   class SourceFile;
@@ -993,16 +993,16 @@ public:
   ///
   /// \param isUnderlyingClangModule When true, only look for a Clang module
   /// with the given name, ignoring any Swift modules.
-  Optional<ModuleDependencies> getModuleDependencies(
+  Optional<ModuleDependencyInfo> getModuleDependencies(
       StringRef moduleName,
       bool isUnderlyingClangModule,
       ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate,
       bool cacheOnly = false,
-      llvm::Optional<std::pair<std::string, swift::ModuleDependenciesKind>> dependencyOf = None);
+      llvm::Optional<std::pair<std::string, swift::ModuleDependencyKind>> dependencyOf = None);
 
   /// Retrieve the module dependencies for the Swift module with the given name.
-  Optional<ModuleDependencies> getSwiftModuleDependencies(
+  Optional<ModuleDependencyInfo> getSwiftModuleDependencies(
       StringRef moduleName,
       ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate);

--- a/include/swift/AST/ModuleDependencies.h
+++ b/include/swift/AST/ModuleDependencies.h
@@ -38,10 +38,16 @@ class Identifier;
 class CompilerInstance;
 
 /// Which kind of module dependencies we are looking for.
-enum class ModuleDependenciesKind : int8_t {
+enum class ModuleDependencyKind : int8_t {
   FirstKind,
+  // Textual Swift dependency
   SwiftInterface = FirstKind,
+  // Binary module Swift dependency
   SwiftBinary,
+  // Clang module dependency
+  Clang,
+  // Used to model the translation unit's source module
+  SwiftSource,
   // Placeholder dependencies are a kind of dependencies used only by the
   // dependency scanner. They are swift modules that the scanner will not be
   // able to locate in its search paths and which are the responsibility of the
@@ -65,31 +71,29 @@ enum class ModuleDependenciesKind : int8_t {
   // with `actual` dependencies in a post-processing step once dependency graphs
   // of all targets, individually, have been computed.
   SwiftPlaceholder,
-  Clang,
-  SwiftSource,
-  LastKind = SwiftSource + 1
+  LastKind = SwiftPlaceholder + 1
 };
 
-struct ModuleDependenciesKindHash {
-  std::size_t operator()(ModuleDependenciesKind k) const {
-    using UnderlyingType = std::underlying_type<ModuleDependenciesKind>::type;
+struct ModuleDependencyKindHash {
+  std::size_t operator()(ModuleDependencyKind k) const {
+    using UnderlyingType = std::underlying_type<ModuleDependencyKind>::type;
     return std::hash<UnderlyingType>{}(static_cast<UnderlyingType>(k));
   }
 };
 
-/// Base class for the variant storage of ModuleDependencies.
+/// Base class for the variant storage of ModuleDependencyInfo.
 ///
-/// This class is mostly an implementation detail for \c ModuleDependencies.
-class ModuleDependenciesStorageBase {
+/// This class is mostly an implementation detail for \c ModuleDependencyInfo.
+class ModuleDependencyInfoStorageBase {
 public:
-  const ModuleDependenciesKind dependencyKind;
+  const ModuleDependencyKind dependencyKind;
 
-  ModuleDependenciesStorageBase(ModuleDependenciesKind dependencyKind)
+  ModuleDependencyInfoStorageBase(ModuleDependencyKind dependencyKind)
       : dependencyKind(dependencyKind) { }
 
-  virtual ModuleDependenciesStorageBase *clone() const = 0;
+  virtual ModuleDependencyInfoStorageBase *clone() const = 0;
 
-  virtual ~ModuleDependenciesStorageBase();
+  virtual ~ModuleDependencyInfoStorageBase();
 
   /// The set of modules on which this module depends.
   std::vector<std::string> moduleDependencies;
@@ -116,9 +120,9 @@ struct CommonSwiftTextualModuleDependencyDetails {
 
 /// Describes the dependencies of a Swift module described by an Swift interface file.
 ///
-/// This class is mostly an implementation detail for \c ModuleDependencies.
+/// This class is mostly an implementation detail for \c ModuleDependencyInfo.
 class SwiftInterfaceModuleDependenciesStorage :
-  public ModuleDependenciesStorageBase {
+  public ModuleDependencyInfoStorageBase {
 public:
   /// Destination output path
   const std::string moduleOutputPath;
@@ -150,7 +154,7 @@ public:
       ArrayRef<StringRef> extraPCMArgs,
       StringRef contextHash,
       bool isFramework
-  ) : ModuleDependenciesStorageBase(ModuleDependenciesKind::SwiftInterface),
+  ) : ModuleDependencyInfoStorageBase(ModuleDependencyKind::SwiftInterface),
       moduleOutputPath(moduleOutputPath),
       swiftInterfaceFile(swiftInterfaceFile),
       compiledModuleCandidates(compiledModuleCandidates.begin(),
@@ -160,20 +164,20 @@ public:
       textualModuleDetails(extraPCMArgs)
       {}
 
-  ModuleDependenciesStorageBase *clone() const override {
+  ModuleDependencyInfoStorageBase *clone() const override {
     return new SwiftInterfaceModuleDependenciesStorage(*this);
   }
 
-  static bool classof(const ModuleDependenciesStorageBase *base) {
-    return base->dependencyKind == ModuleDependenciesKind::SwiftInterface;
+  static bool classof(const ModuleDependencyInfoStorageBase *base) {
+    return base->dependencyKind == ModuleDependencyKind::SwiftInterface;
   }
 };
 
 /// Describes the dependencies of a Swift module
 ///
-/// This class is mostly an implementation detail for \c ModuleDependencies.
+/// This class is mostly an implementation detail for \c ModuleDependencyInfo.
 class SwiftSourceModuleDependenciesStorage :
-  public ModuleDependenciesStorageBase {
+  public ModuleDependencyInfoStorageBase {
 public:
 
   /// Swift source files that are part of the Swift module, when known.
@@ -184,34 +188,34 @@ public:
 
   SwiftSourceModuleDependenciesStorage(
     ArrayRef<StringRef> extraPCMArgs
-  ) : ModuleDependenciesStorageBase(ModuleDependenciesKind::SwiftSource),
+  ) : ModuleDependencyInfoStorageBase(ModuleDependencyKind::SwiftSource),
       textualModuleDetails(extraPCMArgs) {}
 
-  ModuleDependenciesStorageBase *clone() const override {
+  ModuleDependencyInfoStorageBase *clone() const override {
     return new SwiftSourceModuleDependenciesStorage(*this);
   }
 
-  static bool classof(const ModuleDependenciesStorageBase *base) {
-    return base->dependencyKind == ModuleDependenciesKind::SwiftSource;
+  static bool classof(const ModuleDependencyInfoStorageBase *base) {
+    return base->dependencyKind == ModuleDependencyKind::SwiftSource;
   }
 };
 
 /// Describes the dependencies of a pre-built Swift module (with no .swiftinterface).
 ///
-/// This class is mostly an implementation detail for \c ModuleDependencies.
-class SwiftBinaryModuleDependencyStorage : public ModuleDependenciesStorageBase {
+/// This class is mostly an implementation detail for \c ModuleDependencyInfo.
+class SwiftBinaryModuleDependencyStorage : public ModuleDependencyInfoStorageBase {
 public:
   SwiftBinaryModuleDependencyStorage(const std::string &compiledModulePath,
                                      const std::string &moduleDocPath,
                                      const std::string &sourceInfoPath,
                                      const bool isFramework)
-      : ModuleDependenciesStorageBase(ModuleDependenciesKind::SwiftBinary),
+      : ModuleDependencyInfoStorageBase(ModuleDependencyKind::SwiftBinary),
         compiledModulePath(compiledModulePath),
         moduleDocPath(moduleDocPath),
         sourceInfoPath(sourceInfoPath),
         isFramework(isFramework) {}
 
-  ModuleDependenciesStorageBase *clone() const override {
+  ModuleDependencyInfoStorageBase *clone() const override {
     return new SwiftBinaryModuleDependencyStorage(*this);
   }
 
@@ -227,15 +231,15 @@ public:
   /// A flag that indicates this dependency is a framework
   const bool isFramework;
 
-  static bool classof(const ModuleDependenciesStorageBase *base) {
-    return base->dependencyKind == ModuleDependenciesKind::SwiftBinary;
+  static bool classof(const ModuleDependencyInfoStorageBase *base) {
+    return base->dependencyKind == ModuleDependencyKind::SwiftBinary;
   }
 };
 
 /// Describes the dependencies of a Clang module.
 ///
-/// This class is mostly an implementation detail for \c ModuleDependencies.
-class ClangModuleDependenciesStorage : public ModuleDependenciesStorageBase {
+/// This class is mostly an implementation detail for \c ModuleDependencyInfo.
+class ClangModuleDependencyStorage : public ModuleDependencyInfoStorageBase {
 public:
   /// Destination output path
   const std::string pcmOutputPath;
@@ -256,14 +260,14 @@ public:
   /// as found by the scanning action that discovered it
   const std::vector<std::string> capturedPCMArgs;
 
-  ClangModuleDependenciesStorage(
+  ClangModuleDependencyStorage(
       const std::string &pcmOutputPath,
       const std::string &moduleMapFile,
       const std::string &contextHash,
       const std::vector<std::string> &nonPathCommandLine,
       const std::vector<std::string> &fileDependencies,
       const std::vector<std::string> &capturedPCMArgs
-  ) : ModuleDependenciesStorageBase(ModuleDependenciesKind::Clang),
+  ) : ModuleDependencyInfoStorageBase(ModuleDependencyKind::Clang),
       pcmOutputPath(pcmOutputPath),
       moduleMapFile(moduleMapFile),
       contextHash(contextHash),
@@ -271,30 +275,30 @@ public:
       fileDependencies(fileDependencies),
       capturedPCMArgs(capturedPCMArgs) {}
 
-  ModuleDependenciesStorageBase *clone() const override {
-    return new ClangModuleDependenciesStorage(*this);
+  ModuleDependencyInfoStorageBase *clone() const override {
+    return new ClangModuleDependencyStorage(*this);
   }
 
-  static bool classof(const ModuleDependenciesStorageBase *base) {
-    return base->dependencyKind == ModuleDependenciesKind::Clang;
+  static bool classof(const ModuleDependencyInfoStorageBase *base) {
+    return base->dependencyKind == ModuleDependencyKind::Clang;
   }
 };
 
 /// Describes an placeholder Swift module dependency module stub.
 ///
-/// This class is mostly an implementation detail for \c ModuleDependencies.
+/// This class is mostly an implementation detail for \c ModuleDependencyInfo.
 
-class SwiftPlaceholderModuleDependencyStorage : public ModuleDependenciesStorageBase {
+class SwiftPlaceholderModuleDependencyStorage : public ModuleDependencyInfoStorageBase {
 public:
   SwiftPlaceholderModuleDependencyStorage(const std::string &compiledModulePath,
                                           const std::string &moduleDocPath,
                                           const std::string &sourceInfoPath)
-      : ModuleDependenciesStorageBase(ModuleDependenciesKind::SwiftPlaceholder),
+      : ModuleDependencyInfoStorageBase(ModuleDependencyKind::SwiftPlaceholder),
         compiledModulePath(compiledModulePath),
         moduleDocPath(moduleDocPath),
         sourceInfoPath(sourceInfoPath) {}
 
-  ModuleDependenciesStorageBase *clone() const override {
+  ModuleDependencyInfoStorageBase *clone() const override {
     return new SwiftPlaceholderModuleDependencyStorage(*this);
   }
 
@@ -307,40 +311,40 @@ public:
   /// The path to the .swiftSourceInfo file.
   const std::string sourceInfoPath;
 
-  static bool classof(const ModuleDependenciesStorageBase *base) {
-    return base->dependencyKind == ModuleDependenciesKind::SwiftPlaceholder;
+  static bool classof(const ModuleDependencyInfoStorageBase *base) {
+    return base->dependencyKind == ModuleDependencyKind::SwiftPlaceholder;
   }
 };
 
-// MARK: Module Dependencies
+// MARK: Module Dependency Info
 /// Describes the dependencies of a given module.
 ///
 /// The dependencies of a module include all of the source files that go
 /// into that module, as well as any modules that are directly imported
 /// into the module.
-class ModuleDependencies {
+class ModuleDependencyInfo {
 private:
-  std::unique_ptr<ModuleDependenciesStorageBase> storage;
+  std::unique_ptr<ModuleDependencyInfoStorageBase> storage;
 
-  ModuleDependencies(std::unique_ptr<ModuleDependenciesStorageBase> &&storage)
+  ModuleDependencyInfo(std::unique_ptr<ModuleDependencyInfoStorageBase> &&storage)
     : storage(std::move(storage)) { }
 
 public:
-  ModuleDependencies() = default;
-  ModuleDependencies(const ModuleDependencies &other)
+  ModuleDependencyInfo() = default;
+  ModuleDependencyInfo(const ModuleDependencyInfo &other)
     : storage(other.storage->clone()) { }
-  ModuleDependencies(ModuleDependencies &&other) = default;
+  ModuleDependencyInfo(ModuleDependencyInfo &&other) = default;
 
-  ModuleDependencies &operator=(const ModuleDependencies &other) {
+  ModuleDependencyInfo &operator=(const ModuleDependencyInfo &other) {
     storage.reset(other.storage->clone());
     return *this;
   }
 
-  ModuleDependencies &operator=(ModuleDependencies &&other) = default;
+  ModuleDependencyInfo &operator=(ModuleDependencyInfo &&other) = default;
 
   /// Describe the module dependencies for a Swift module that can be
   /// built from a Swift interface file (\c .swiftinterface).
-  static ModuleDependencies forSwiftInterfaceModule(
+  static ModuleDependencyInfo forSwiftInterfaceModule(
       const std::string &moduleOutputPath,
       const std::string &swiftInterfaceFile,
       ArrayRef<std::string> compiledCandidates,
@@ -348,50 +352,50 @@ public:
       ArrayRef<StringRef> extraPCMArgs,
       StringRef contextHash,
       bool isFramework) {
-    return ModuleDependencies(
+    return ModuleDependencyInfo(
         std::make_unique<SwiftInterfaceModuleDependenciesStorage>(
           moduleOutputPath, swiftInterfaceFile, compiledCandidates, buildCommands,
           extraPCMArgs, contextHash, isFramework));
   }
 
   /// Describe the module dependencies for a serialized or parsed Swift module.
-  static ModuleDependencies forSwiftBinaryModule(
+  static ModuleDependencyInfo forSwiftBinaryModule(
       const std::string &compiledModulePath,
       const std::string &moduleDocPath,
       const std::string &sourceInfoPath,
       bool isFramework) {
-    return ModuleDependencies(
+    return ModuleDependencyInfo(
         std::make_unique<SwiftBinaryModuleDependencyStorage>(
           compiledModulePath, moduleDocPath, sourceInfoPath, isFramework));
   }
 
   /// Describe the main Swift module.
-  static ModuleDependencies forSwiftSourceModule(ArrayRef<StringRef> extraPCMArgs) {
-    return ModuleDependencies(
+  static ModuleDependencyInfo forSwiftSourceModule(ArrayRef<StringRef> extraPCMArgs) {
+    return ModuleDependencyInfo(
         std::make_unique<SwiftSourceModuleDependenciesStorage>(extraPCMArgs));
   }
 
   /// Describe the module dependencies for a Clang module that can be
   /// built from a module map and headers.
-  static ModuleDependencies forClangModule(
+  static ModuleDependencyInfo forClangModule(
       const std::string &pcmOutputPath,
       const std::string &moduleMapFile,
       const std::string &contextHash,
       const std::vector<std::string> &nonPathCommandLine,
       const std::vector<std::string> &fileDependencies,
       const std::vector<std::string> &capturedPCMArgs) {
-    return ModuleDependencies(
-        std::make_unique<ClangModuleDependenciesStorage>(
+    return ModuleDependencyInfo(
+        std::make_unique<ClangModuleDependencyStorage>(
           pcmOutputPath, moduleMapFile, contextHash,
           nonPathCommandLine, fileDependencies, capturedPCMArgs));
   }
 
   /// Describe a placeholder dependency swift module.
-  static ModuleDependencies forPlaceholderSwiftModuleStub(
+  static ModuleDependencyInfo forPlaceholderSwiftModuleStub(
       const std::string &compiledModulePath,
       const std::string &moduleDocPath,
       const std::string &sourceInfoPath) {
-    return ModuleDependencies(
+    return ModuleDependencyInfo(
         std::make_unique<SwiftPlaceholderModuleDependencyStorage>(
           compiledModulePath, moduleDocPath, sourceInfoPath));
   }
@@ -419,9 +423,10 @@ public:
   /// Whether the dependencies are for a Clang module.
   bool isClangModule() const;
 
-  ModuleDependenciesKind getKind() const {
+  ModuleDependencyKind getKind() const {
     return storage->dependencyKind;
   }
+
   /// Retrieve the dependencies for a Swift textual-interface module.
   const SwiftInterfaceModuleDependenciesStorage *getAsSwiftInterfaceModule() const;
 
@@ -432,7 +437,7 @@ public:
   const SwiftBinaryModuleDependencyStorage *getAsSwiftBinaryModule() const;
 
   /// Retrieve the dependencies for a Clang module.
-  const ClangModuleDependenciesStorage *getAsClangModule() const;
+  const ClangModuleDependencyStorage *getAsClangModule() const;
 
   /// Retrieve the dependencies for a placeholder dependency module stub.
   const SwiftPlaceholderModuleDependencyStorage *
@@ -475,17 +480,17 @@ public:
   collectCrossImportOverlayNames(ASTContext &ctx, StringRef moduleName);
 };
 
-using ModuleDependencyID = std::pair<std::string, ModuleDependenciesKind>;
-using ModuleDependenciesVector = llvm::SmallVector<ModuleDependencies, 1>;
-using ModuleNameToDependencyMap = llvm::StringMap<ModuleDependencies>;
+using ModuleDependencyID = std::pair<std::string, ModuleDependencyKind>;
+using ModuleDependenciesVector = llvm::SmallVector<ModuleDependencyInfo, 1>;
+using ModuleNameToDependencyMap = llvm::StringMap<ModuleDependencyInfo>;
 using ModuleDependenciesKindMap =
-    std::unordered_map<ModuleDependenciesKind,
+    std::unordered_map<ModuleDependencyKind,
                        ModuleNameToDependencyMap,
-                       ModuleDependenciesKindHash>;
+                       ModuleDependencyKindHash>;
 using ModuleDependenciesKindRefMap =
-    std::unordered_map<ModuleDependenciesKind,
-                       llvm::StringMap<const ModuleDependencies *>,
-                       ModuleDependenciesKindHash>;
+    std::unordered_map<ModuleDependencyKind,
+                       llvm::StringMap<const ModuleDependencyInfo *>,
+                       ModuleDependencyKindHash>;
 
 // MARK: GlobalModuleDependenciesCache
 /// A cache describing the set of module dependencies that has been queried
@@ -535,9 +540,9 @@ class GlobalModuleDependenciesCache {
 
   /// Retrieve the dependencies map that corresponds to the given dependency
   /// kind.
-  ModuleNameToDependencyMap &getDependenciesMap(ModuleDependenciesKind kind);
+  ModuleNameToDependencyMap &getDependenciesMap(ModuleDependencyKind kind);
   const ModuleNameToDependencyMap &
-  getDependenciesMap(ModuleDependenciesKind kind) const;
+  getDependenciesMap(ModuleDependencyKind kind) const;
 
 public:
   GlobalModuleDependenciesCache();
@@ -575,7 +580,7 @@ private:
 
   /// Whether we have cached dependency information for the given module.
   bool hasDependencies(StringRef moduleName,
-                       Optional<ModuleDependenciesKind> kind) const;
+                       Optional<ModuleDependencyKind> kind) const;
 
   /// Return a pointer to the context-specific cache state of the current
   /// scanning action.
@@ -586,23 +591,23 @@ private:
   getCacheForScanningContextHash(StringRef scanningContextHash) const;
 
   /// Look for source-based module dependency details
-  Optional<ModuleDependencies>
+  Optional<ModuleDependencyInfo>
   findSourceModuleDependency(StringRef moduleName) const;
 
   /// Look for module dependencies for a module with the given name
   ///
   /// \returns the cached result, or \c None if there is no cached entry.
-  Optional<ModuleDependencies>
+  Optional<ModuleDependencyInfo>
   findDependencies(StringRef moduleName,
-                   Optional<ModuleDependenciesKind> kind) const;
+                   Optional<ModuleDependencyKind> kind) const;
 
   /// Record dependencies for the given module.
-  const ModuleDependencies *recordDependencies(StringRef moduleName,
-                                               ModuleDependencies dependencies);
+  const ModuleDependencyInfo *recordDependencies(StringRef moduleName,
+                                               ModuleDependencyInfo dependencies);
 
   /// Update stored dependencies for the given module.
-  const ModuleDependencies *updateDependencies(ModuleDependencyID moduleID,
-                                               ModuleDependencies dependencies);
+  const ModuleDependencyInfo *updateDependencies(ModuleDependencyID moduleID,
+                                               ModuleDependencyInfo dependencies);
 
   /// Reference the list of all module dependencies that are not source-based
   /// modules (i.e. interface dependencies, binary dependencies, clang
@@ -649,21 +654,21 @@ private:
 
   /// Retrieve the dependencies map that corresponds to the given dependency
   /// kind.
-  llvm::StringMap<const ModuleDependencies *> &
-  getDependencyReferencesMap(ModuleDependenciesKind kind);
-  const llvm::StringMap<const ModuleDependencies *> &
-  getDependencyReferencesMap(ModuleDependenciesKind kind) const;
+  llvm::StringMap<const ModuleDependencyInfo *> &
+  getDependencyReferencesMap(ModuleDependencyKind kind);
+  const llvm::StringMap<const ModuleDependencyInfo *> &
+  getDependencyReferencesMap(ModuleDependencyKind kind) const;
 
   /// Local cache results lookup, only for modules which were discovered during
   /// the current scanner invocation.
   bool hasDependenciesLocalOnly(StringRef moduleName,
-                                Optional<ModuleDependenciesKind> kind) const;
+                                Optional<ModuleDependencyKind> kind) const;
 
   /// Local cache results lookup, only for modules which were discovered during
   /// the current scanner invocation.
-  Optional<const ModuleDependencies *>
+  Optional<const ModuleDependencyInfo *>
   findDependenciesLocalOnly(StringRef moduleName,
-                            Optional<ModuleDependenciesKind> kind) const;
+                            Optional<ModuleDependencyKind> kind) const;
 
 public:
   ModuleDependenciesCache(GlobalModuleDependenciesCache &globalCache,
@@ -675,7 +680,7 @@ public:
 public:
   /// Whether we have cached dependency information for the given module.
   bool hasDependencies(StringRef moduleName,
-                       Optional<ModuleDependenciesKind> kind) const;
+                       Optional<ModuleDependencyKind> kind) const;
 
   /// Produce a reference to the Clang scanner tool associated with this cache
   clang::tooling::dependencies::DependencyScanningTool& getClangScannerTool() {
@@ -688,17 +693,17 @@ public:
   /// Look for module dependencies for a module with the given name
   ///
   /// \returns the cached result, or \c None if there is no cached entry.
-  Optional<ModuleDependencies>
+  Optional<ModuleDependencyInfo>
   findDependencies(StringRef moduleName,
-                   Optional<ModuleDependenciesKind> kind) const;
+                   Optional<ModuleDependencyKind> kind) const;
 
   /// Record dependencies for the given module.
   void recordDependencies(StringRef moduleName,
-                          ModuleDependencies dependencies);
+                          ModuleDependencyInfo dependencies);
 
   /// Update stored dependencies for the given module.
   void updateDependencies(ModuleDependencyID moduleID,
-                          ModuleDependencies dependencies);
+                          ModuleDependencyInfo dependencies);
 
   const std::vector<ModuleDependencyID> &getAllSourceModules() const {
     return globalCache.getAllSourceModules();

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -46,13 +46,13 @@ class ClangImporterOptions;
 class ClassDecl;
 class FileUnit;
 class ModuleDecl;
-class ModuleDependencies;
+class ModuleDependencyInfo;
 class ModuleDependenciesCache;
 class NominalTypeDecl;
 class SourceFile;
 class TypeDecl;
 class CompilerInstance;
-enum class ModuleDependenciesKind : int8_t;
+enum class ModuleDependencyKind : int8_t;
 
 enum class KnownProtocolKind : uint8_t;
 
@@ -321,7 +321,7 @@ public:
 
   /// Retrieve the dependencies for the given, named module, or \c None
   /// if no such module exists.
-  virtual Optional<ModuleDependencies> getModuleDependencies(
+  virtual Optional<ModuleDependencyInfo> getModuleDependencies(
       StringRef moduleName,
       ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate) = 0;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -423,7 +423,7 @@ public:
       ModuleDependenciesCache &cache,
       const clang::tooling::dependencies::FullDependenciesResult &clangDependencies);
 
-  Optional<ModuleDependencies> getModuleDependencies(
+  Optional<ModuleDependencyInfo> getModuleDependencies(
       StringRef moduleName, ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate) override;
 
@@ -439,7 +439,7 @@ public:
   /// \returns \c true if an error occurred, \c false otherwise
   bool addBridgingHeaderDependencies(
       StringRef moduleName,
-      ModuleDependenciesKind moduleKind,
+      ModuleDependencyKind moduleKind,
       ModuleDependenciesCache &cache);
 
   clang::TargetInfo &getTargetInfo() const override;

--- a/include/swift/DependencyScan/DependencyScanningTool.h
+++ b/include/swift/DependencyScan/DependencyScanningTool.h
@@ -85,7 +85,7 @@ public:
 
   /// Writes the current `SharedCache` instance to a specified FileSystem path.
   void serializeCache(llvm::StringRef path);
-  /// Loads an instance of a `GlobalModuleDependenciesCache` to serve as the `SharedCache`
+  /// Loads an instance of a `SwiftDependencyScanningService` to serve as the `SharedCache`
   /// from a specified FileSystem path.
   bool loadCache(llvm::StringRef path);
   /// Discard the tool's current `SharedCache` and start anew.
@@ -108,7 +108,7 @@ private:
 
   /// Shared cache of module dependencies, re-used by individual full-scan queries
   /// during the lifetime of this Tool.
-  std::unique_ptr<GlobalModuleDependenciesCache> SharedCache;
+  std::unique_ptr<SwiftDependencyScanningService> ScanningService;
 
   /// Shared cache of compiler instances created during batch scanning, corresponding to
   /// command-line options specified in the batch scan input entry.

--- a/include/swift/DependencyScan/ScanDependencies.h
+++ b/include/swift/DependencyScan/ScanDependencies.h
@@ -27,13 +27,13 @@ namespace swift {
 class CompilerInvocation;
 class CompilerInstance;
 class ModuleDependenciesCache;
-class GlobalModuleDependenciesCache;
+class SwiftDependencyScanningService;
 
 namespace dependencies {
 
 using CompilerArgInstanceCacheMap =
     llvm::StringMap<std::tuple<std::unique_ptr<CompilerInstance>,
-                               std::unique_ptr<GlobalModuleDependenciesCache>,
+                               std::unique_ptr<SwiftDependencyScanningService>,
                                std::unique_ptr<ModuleDependenciesCache>>>;
 
 struct BatchScanInput {

--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -23,7 +23,7 @@ class MemoryBuffer;
 namespace swift {
 
 class DiagnosticEngine;
-class GlobalModuleDependenciesCache;
+class SwiftDependencyScanningService;
 
 namespace dependencies {
 namespace module_dependency_cache_serialization {
@@ -174,23 +174,23 @@ using ClangModuleDetailsLayout =
 /// Tries to read the dependency graph from the given buffer.
 /// Returns \c true if there was an error.
 bool readInterModuleDependenciesCache(llvm::MemoryBuffer &buffer,
-                                      GlobalModuleDependenciesCache &cache);
+                                      SwiftDependencyScanningService &cache);
 
 /// Tries to read the dependency graph from the given path name.
 /// Returns true if there was an error.
 bool readInterModuleDependenciesCache(llvm::StringRef path,
-                                      GlobalModuleDependenciesCache &cache);
+                                      SwiftDependencyScanningService &cache);
 
 /// Tries to write the dependency graph to the given path name.
 /// Returns true if there was an error.
 bool writeInterModuleDependenciesCache(DiagnosticEngine &diags,
                                        llvm::StringRef path,
-                                       const GlobalModuleDependenciesCache &cache);
+                                       const SwiftDependencyScanningService &cache);
 
 /// Tries to write out the given dependency cache with the given
 /// bitstream writer.
 void writeInterModuleDependenciesCache(llvm::BitstreamWriter &Out,
-                                       const GlobalModuleDependenciesCache &cache);
+                                       const SwiftDependencyScanningService &cache);
 
 } // end namespace module_dependency_cache_serialization
 } // end namespace dependencies

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -495,6 +495,9 @@ public:
   llvm::vfs::FileSystem &getFileSystem() const {
     return *SourceMgr.getFileSystem();
   }
+  void setFileSystem(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS) {
+    SourceMgr.setFileSystem(FS);
+  }
 
   ASTContext &getASTContext() { return *Context; }
   const ASTContext &getASTContext() const { return *Context; }

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -96,7 +96,7 @@ public:
     // Parsing populates the Objective-C method tables.
   }
 
-  Optional<ModuleDependencies>
+  Optional<ModuleDependencyInfo>
   getModuleDependencies(StringRef moduleName, ModuleDependenciesCache &cache,
                         InterfaceSubContextDelegate &delegate) override;
 };

--- a/include/swift/Serialization/ModuleDependencyScanner.h
+++ b/include/swift/Serialization/ModuleDependencyScanner.h
@@ -33,7 +33,7 @@ namespace swift {
       Identifier moduleName;
 
       /// Scan the given interface file to determine dependencies.
-      llvm::ErrorOr<ModuleDependencies> scanInterfaceFile(
+      llvm::ErrorOr<ModuleDependencyInfo> scanInterfaceFile(
           Twine moduleInterfacePath, bool isFramework);
 
       InterfaceSubContextDelegate &astDelegate;
@@ -41,7 +41,7 @@ namespace swift {
       /// Location where pre-built moduels are to be built into.
       std::string moduleCachePath;
     public:
-      Optional<ModuleDependencies> dependencies;
+      Optional<ModuleDependencyInfo> dependencies;
 
       ModuleDependencyScanner(ASTContext &ctx, ModuleLoadingMode LoadMode,
                               Identifier moduleName,

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -137,7 +137,7 @@ protected:
   }
 
   /// Scan the given serialized module file to determine dependencies.
-  llvm::ErrorOr<ModuleDependencies> scanModuleFile(Twine modulePath, bool isFramework);
+  llvm::ErrorOr<ModuleDependencyInfo> scanModuleFile(Twine modulePath, bool isFramework);
 
   /// Load the module file into a buffer and also collect its module name.
   static std::unique_ptr<llvm::MemoryBuffer>
@@ -205,7 +205,7 @@ public:
 
   virtual void verifyAllModules() override;
 
-  virtual Optional<ModuleDependencies> getModuleDependencies(
+  virtual Optional<ModuleDependencyInfo> getModuleDependencies(
       StringRef moduleName, ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate) override;
 };

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -174,7 +174,7 @@ void ModuleLoader::findOverlayFiles(SourceLoc diagLoc, ModuleDecl *module,
 }
 
 llvm::StringMap<llvm::SmallSetVector<Identifier, 4>>
-ModuleDependencies::collectCrossImportOverlayNames(ASTContext &ctx,
+ModuleDependencyInfo::collectCrossImportOverlayNames(ASTContext &ctx,
                                                    StringRef moduleName) {
   using namespace llvm::sys;
   using namespace file_types;
@@ -183,7 +183,7 @@ ModuleDependencies::collectCrossImportOverlayNames(ASTContext &ctx,
   llvm::StringMap<llvm::SmallSetVector<Identifier, 4>> result;
 
   switch (getKind()) {
-    case swift::ModuleDependenciesKind::SwiftInterface: {
+    case swift::ModuleDependencyKind::SwiftInterface: {
       auto *swiftDep = getAsSwiftInterfaceModule();
       // Prefer interface path to binary module path if we have it.
       modulePath = swiftDep->swiftInterfaceFile;
@@ -194,7 +194,7 @@ ModuleDependencies::collectCrossImportOverlayNames(ASTContext &ctx,
       }
       break;
     }
-    case swift::ModuleDependenciesKind::SwiftBinary: {
+    case swift::ModuleDependencyKind::SwiftBinary: {
       auto *swiftBinaryDep = getAsSwiftBinaryModule();
       modulePath = swiftBinaryDep->compiledModulePath;
       assert(modulePath.has_value());
@@ -204,21 +204,21 @@ ModuleDependencies::collectCrossImportOverlayNames(ASTContext &ctx,
       }
       break;
     }
-    case swift::ModuleDependenciesKind::Clang: {
+    case swift::ModuleDependencyKind::Clang: {
       auto *clangDep = getAsClangModule();
       modulePath = clangDep->moduleMapFile;
       assert(modulePath.has_value());
       break;
     }
-    case swift::ModuleDependenciesKind::SwiftSource: {
+    case swift::ModuleDependencyKind::SwiftSource: {
       auto *swiftSourceDep = getAsSwiftSourceModule();
       assert(!swiftSourceDep->sourceFiles.empty());
       return result;
     }
-    case swift::ModuleDependenciesKind::SwiftPlaceholder: {
+    case swift::ModuleDependencyKind::SwiftPlaceholder: {
       return result;
     }
-    case swift::ModuleDependenciesKind::LastKind:
+    case swift::ModuleDependencyKind::LastKind:
       llvm_unreachable("Unhandled dependency kind.");
   }
   // Mimic getModuleDefiningPath() for Swift and Clang module.

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -132,7 +132,7 @@ void ClangImporter::recordModuleDependencies(
     // If we've already cached this information, we're done.
     if (cache.hasDependencies(
                     clangModuleDep.ID.ModuleName,
-                    ModuleDependenciesKind::Clang))
+                    ModuleDependencyKind::Clang))
       continue;
 
     // File dependencies for this module.
@@ -190,7 +190,7 @@ void ClangImporter::recordModuleDependencies(
 
     // Module-level dependencies.
     llvm::StringSet<> alreadyAddedModules;
-    auto dependencies = ModuleDependencies::forClangModule(
+    auto dependencies = ModuleDependencyInfo::forClangModule(
         pcmPath,
         clangModuleDep.ClangModuleMapFile,
         clangModuleDep.ID.ContextHash,
@@ -206,13 +206,13 @@ void ClangImporter::recordModuleDependencies(
   }
 }
 
-Optional<ModuleDependencies> ClangImporter::getModuleDependencies(
+Optional<ModuleDependencyInfo> ClangImporter::getModuleDependencies(
     StringRef moduleName, ModuleDependenciesCache &cache,
     InterfaceSubContextDelegate &delegate) {
   auto &ctx = Impl.SwiftContext;
   // Check whether there is already a cached result.
   if (auto found = cache.findDependencies(
-          moduleName, ModuleDependenciesKind::Clang))
+          moduleName, ModuleDependencyKind::Clang))
     return found;
 
   // Determine the command-line arguments for dependency scanning.
@@ -262,12 +262,12 @@ Optional<ModuleDependencies> ClangImporter::getModuleDependencies(
   // Record module dependencies for each module we found.
   recordModuleDependencies(cache, *clangDependencies);
             return cache.findDependencies(
-                    moduleName, ModuleDependenciesKind::Clang);
+                    moduleName, ModuleDependencyKind::Clang);
 }
 
 bool ClangImporter::addBridgingHeaderDependencies(
     StringRef moduleName,
-    ModuleDependenciesKind moduleKind,
+    ModuleDependencyKind moduleKind,
     ModuleDependenciesCache &cache) {
   auto &ctx = Impl.SwiftContext;
   auto targetModule = *cache.findDependencies(moduleName, moduleKind);

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -145,7 +145,7 @@ static void findAllImportedClangModules(ASTContext &ctx, StringRef moduleName,
     return;
   allModules.push_back(moduleName.str());
   auto dependencies =
-    cache.findDependencies(moduleName, ModuleDependenciesKind::Clang);
+    cache.findDependencies(moduleName, ModuleDependencyKind::Clang);
   if (!dependencies)
     return;
 
@@ -211,7 +211,7 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
 
     // Find all of the Clang modules this Swift module depends on.
     for (const auto &dep : result) {
-      if (dep.second != ModuleDependenciesKind::Clang)
+      if (dep.second != ModuleDependencyKind::Clang)
         continue;
 
       findAllImportedClangModules(ctx, dep.first, cache, allClangModules,
@@ -227,10 +227,10 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
         // with a given name. This Clang module may have the same name as the
         // Swift module we are resolving, so we need to make sure we don't add a
         // dependency from a Swift module to itself.
-        if ((found->getKind() == ModuleDependenciesKind::SwiftInterface ||
-             found->getKind() == ModuleDependenciesKind::SwiftSource ||
-             found->getKind() == ModuleDependenciesKind::SwiftBinary ||
-             found->getKind() == ModuleDependenciesKind::SwiftPlaceholder) &&
+        if ((found->getKind() == ModuleDependencyKind::SwiftInterface ||
+             found->getKind() == ModuleDependencyKind::SwiftSource ||
+             found->getKind() == ModuleDependencyKind::SwiftBinary ||
+             found->getKind() == ModuleDependencyKind::SwiftPlaceholder) &&
             clangDep != module.first) {
           result.insert({clangDep, found->getKind()});
         }
@@ -277,26 +277,26 @@ static void discoverCrossImportOverlayDependencies(
   // Construct a dummy main to resolve the newly discovered cross import
   // overlays.
   StringRef dummyMainName = "DummyMainModuleForResolvingCrossImportOverlays";
-  auto dummyMainDependencies = ModuleDependencies::forSwiftSourceModule({});
+  auto dummyMainDependencies = ModuleDependencyInfo::forSwiftSourceModule({});
 
   // Update main module's dependencies to include these new overlays.
   auto mainDep = *cache.findDependencies(
-                  mainModuleName, ModuleDependenciesKind::SwiftSource);
+                  mainModuleName, ModuleDependencyKind::SwiftSource);
   std::for_each(newOverlays.begin(), newOverlays.end(),
                 [&](Identifier modName) {
                   dummyMainDependencies.addModuleDependency(modName.str());
                   mainDep.addModuleDependency(modName.str());
                 });
   cache.updateDependencies(
-      {mainModuleName.str(), ModuleDependenciesKind::SwiftSource}, mainDep);
+      {mainModuleName.str(), ModuleDependencyKind::SwiftSource}, mainDep);
 
   // Record the dummy main module's direct dependencies. The dummy main module
   // only directly depend on these newly discovered overlay modules.
   if (cache.findDependencies(
-                 dummyMainName, ModuleDependenciesKind::SwiftSource)) {
+                 dummyMainName, ModuleDependencyKind::SwiftSource)) {
     cache.updateDependencies(
         std::make_pair(dummyMainName.str(),
-                       ModuleDependenciesKind::SwiftSource),
+                       ModuleDependencyKind::SwiftSource),
         dummyMainDependencies);
   } else {
     cache.recordDependencies(dummyMainName, dummyMainDependencies);
@@ -766,14 +766,14 @@ static void writeJSON(llvm::raw_ostream &out,
 
 static std::string createEncodedModuleKindAndName(ModuleDependencyID id) {
   switch (id.second) {
-  case ModuleDependenciesKind::SwiftInterface:
-  case ModuleDependenciesKind::SwiftSource:
+  case ModuleDependencyKind::SwiftInterface:
+  case ModuleDependencyKind::SwiftSource:
     return "swiftTextual:" + id.first;
-  case ModuleDependenciesKind::SwiftBinary:
+  case ModuleDependencyKind::SwiftBinary:
     return "swiftBinary:" + id.first;
-  case ModuleDependenciesKind::SwiftPlaceholder:
+  case ModuleDependencyKind::SwiftPlaceholder:
     return "swiftPlaceholder:" + id.first;
-  case ModuleDependenciesKind::Clang:
+  case ModuleDependencyKind::Clang:
     return "clang:" + id.first;
   default:
     llvm_unreachable("Unhandled dependency kind.");
@@ -924,17 +924,17 @@ generateFullDependencyGraph(CompilerInstance &instance,
     for (const auto &dep : directDependencies) {
       std::string dependencyKindAndName;
       switch (dep.second) {
-      case ModuleDependenciesKind::SwiftInterface:
-      case ModuleDependenciesKind::SwiftSource:
+      case ModuleDependencyKind::SwiftInterface:
+      case ModuleDependencyKind::SwiftSource:
         dependencyKindAndName = "swiftTextual";
         break;
-      case ModuleDependenciesKind::SwiftBinary:
+      case ModuleDependencyKind::SwiftBinary:
         dependencyKindAndName = "swiftBinary";
         break;
-      case ModuleDependenciesKind::SwiftPlaceholder:
+      case ModuleDependencyKind::SwiftPlaceholder:
         dependencyKindAndName = "swiftPlaceholder";
         break;
-      case ModuleDependenciesKind::Clang:
+      case ModuleDependencyKind::Clang:
         dependencyKindAndName = "clang";
         break;
       default:
@@ -983,18 +983,18 @@ static bool diagnoseCycle(CompilerInstance &instance,
         llvm::SmallString<64> buffer;
         for (auto it = startIt; it != openSet.end(); ++it) {
           buffer.append(it->first);
-          buffer.append((it->second == ModuleDependenciesKind::SwiftInterface ||
-                         it->second == ModuleDependenciesKind::SwiftSource ||
-                         it->second == ModuleDependenciesKind::SwiftBinary)
+          buffer.append((it->second == ModuleDependencyKind::SwiftInterface ||
+                         it->second == ModuleDependencyKind::SwiftSource ||
+                         it->second == ModuleDependencyKind::SwiftBinary)
                             ? ".swiftmodule"
                             : ".pcm");
           buffer.append(" -> ");
         }
         buffer.append(startIt->first);
         buffer.append(
-            (startIt->second == ModuleDependenciesKind::SwiftInterface ||
-             startIt->second == ModuleDependenciesKind::SwiftSource ||
-             startIt->second == ModuleDependenciesKind::SwiftBinary)
+            (startIt->second == ModuleDependencyKind::SwiftInterface ||
+             startIt->second == ModuleDependencyKind::SwiftSource ||
+             startIt->second == ModuleDependencyKind::SwiftBinary)
                 ? ".swiftmodule"
                 : ".pcm");
         instance.getASTContext().Diags.diagnose(
@@ -1123,7 +1123,7 @@ forEachBatchEntry(CompilerInstance &invocationInstance,
   return false;
 }
 
-static ModuleDependencies
+static ModuleDependencyInfo
 identifyMainModuleDependencies(CompilerInstance &instance) {
   ModuleDecl *mainModule = instance.getMainModule();
   // Main module file name.
@@ -1145,7 +1145,7 @@ identifyMainModuleDependencies(CompilerInstance &instance) {
     ExtraPCMArgs.insert(ExtraPCMArgs.begin(),
                         {"-Xcc", "-target", "-Xcc",
                          instance.getASTContext().LangOpts.Target.str()});
-  auto mainDependencies = ModuleDependencies::forSwiftSourceModule(ExtraPCMArgs);
+  auto mainDependencies = ModuleDependencyInfo::forSwiftSourceModule(ExtraPCMArgs);
 
   // Compute Implicit dependencies of the main module
   {
@@ -1401,10 +1401,10 @@ swift::dependencies::performModuleScan(CompilerInstance &instance,
   // We may be re-using an instance of the cache which already contains
   // an entry for this module.
   if (cache.findDependencies(
-                mainModuleName, ModuleDependenciesKind::SwiftSource)) {
+                mainModuleName, ModuleDependencyKind::SwiftSource)) {
     cache.updateDependencies(
         std::make_pair(mainModuleName.str(),
-                       ModuleDependenciesKind::SwiftSource),
+                       ModuleDependencyKind::SwiftSource),
         std::move(mainDependencies));
   } else {
     cache.recordDependencies(mainModuleName, std::move(mainDependencies));
@@ -1520,7 +1520,7 @@ swift::dependencies::performBatchModuleScan(
             FEOpts.SerializeModuleInterfaceDependencyHashes,
             FEOpts.shouldTrackSystemDependencies(),
             RequireOSSAModules_t(instance.getSILOptions()));
-        Optional<ModuleDependencies> rootDeps;
+        Optional<ModuleDependencyInfo> rootDeps;
         if (isClang) {
           // Loading the clang module using Clang importer.
           // This action will populate the cache with the main module's
@@ -1540,8 +1540,8 @@ swift::dependencies::performBatchModuleScan(
         }
         // Add the main module.
         allModules.insert(
-            {moduleName.str(), isClang ? ModuleDependenciesKind::Clang
-                                       : ModuleDependenciesKind::SwiftInterface});
+            {moduleName.str(), isClang ? ModuleDependencyKind::Clang
+                                       : ModuleDependencyKind::SwiftInterface});
 
         // Explore the dependencies of every module.
         for (unsigned currentModuleIdx = 0;
@@ -1590,7 +1590,7 @@ swift::dependencies::performBatchModulePrescan(
             FEOpts.SerializeModuleInterfaceDependencyHashes,
             FEOpts.shouldTrackSystemDependencies(),
             RequireOSSAModules_t(instance.getSILOptions()));
-        Optional<ModuleDependencies> rootDeps;
+        Optional<ModuleDependencyInfo> rootDeps;
         if (isClang) {
           // Loading the clang module using Clang importer.
           // This action will populate the cache with the main module's

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -152,7 +152,7 @@ void SourceLoader::loadExtensions(NominalTypeDecl *nominal,
   // nothing to do here.
 }
 
-Optional<ModuleDependencies>
+Optional<ModuleDependencyInfo>
 SourceLoader::getModuleDependencies(StringRef moduleName,
                                     ModuleDependenciesCache &cache,
                                     InterfaceSubContextDelegate &delegate) {

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -82,7 +82,7 @@ bool PlaceholderSwiftModuleScanner::findModule(
     return false;
   }
   auto &moduleInfo = it->getValue();
-  auto dependencies = ModuleDependencies::forPlaceholderSwiftModuleStub(
+  auto dependencies = ModuleDependencyInfo::forPlaceholderSwiftModuleStub(
       moduleInfo.modulePath, moduleInfo.moduleDocPath,
       moduleInfo.moduleSourceInfoPath);
   this->dependencies = std::move(dependencies);
@@ -96,7 +96,7 @@ static std::vector<std::string> getCompiledCandidates(ASTContext &ctx,
       moduleName.str(), interfacePath);
 }
 
-ErrorOr<ModuleDependencies> ModuleDependencyScanner::scanInterfaceFile(
+ErrorOr<ModuleDependencyInfo> ModuleDependencyScanner::scanInterfaceFile(
     Twine moduleInterfacePath, bool isFramework) {
   // Create a module filename.
   // FIXME: Query the module interface loader to determine an appropriate
@@ -105,7 +105,7 @@ ErrorOr<ModuleDependencies> ModuleDependencyScanner::scanInterfaceFile(
   auto realModuleName = Ctx.getRealModuleName(moduleName);
   llvm::SmallString<32> modulePath = realModuleName.str();
   llvm::sys::path::replace_extension(modulePath, newExt);
-  Optional<ModuleDependencies> Result;
+  Optional<ModuleDependencyInfo> Result;
   std::error_code code =
     astDelegate.runInSubContext(realModuleName.str(),
                                               moduleInterfacePath.str(),
@@ -124,7 +124,7 @@ ErrorOr<ModuleDependencies> ModuleDependencyScanner::scanInterfaceFile(
         outputPathBase,
         moduleName.str() + "-" + Hash + "." +
             file_types::getExtension(file_types::TY_SwiftModuleFile));
-    Result = ModuleDependencies::forSwiftInterfaceModule(
+    Result = ModuleDependencyInfo::forSwiftInterfaceModule(
         outputPathBase.str().str(), InPath, compiledCandidates, Args, PCMArgs,
         Hash, isFramework);
     // Open the interface file.
@@ -160,23 +160,23 @@ ErrorOr<ModuleDependencies> ModuleDependencyScanner::scanInterfaceFile(
   return *Result;
 }
 
-Optional<ModuleDependencies> SerializedModuleLoaderBase::getModuleDependencies(
+Optional<ModuleDependencyInfo> SerializedModuleLoaderBase::getModuleDependencies(
     StringRef moduleName, ModuleDependenciesCache &cache,
     InterfaceSubContextDelegate &delegate) {
   auto currentSearchPathSet = Ctx.getAllModuleSearchPathsSet();
 
   // Check whether we've cached this result.
   if (auto found = cache.findDependencies(
-           moduleName, ModuleDependenciesKind::SwiftInterface))
+           moduleName, ModuleDependencyKind::SwiftInterface))
     return found;
   if (auto found = cache.findDependencies(
-           moduleName, ModuleDependenciesKind::SwiftSource))
+           moduleName, ModuleDependencyKind::SwiftSource))
     return found;
   if (auto found = cache.findDependencies(
-            moduleName, ModuleDependenciesKind::SwiftBinary))
+            moduleName, ModuleDependencyKind::SwiftBinary))
     return found;
   if (auto found = cache.findDependencies(
-            moduleName, ModuleDependenciesKind::SwiftPlaceholder))
+            moduleName, ModuleDependencyKind::SwiftPlaceholder))
     return found;
 
   ImportPath::Module::Builder builder(Ctx, moduleName, /*separator=*/'.');

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -391,7 +391,7 @@ std::error_code SerializedModuleLoaderBase::openModuleFile(
   return std::error_code();
 }
 
-llvm::ErrorOr<ModuleDependencies> SerializedModuleLoaderBase::scanModuleFile(
+llvm::ErrorOr<ModuleDependencyInfo> SerializedModuleLoaderBase::scanModuleFile(
     Twine modulePath, bool isFramework) {
   // Open the module file
   auto &fs = *Ctx.SourceMgr.getFileSystem();
@@ -410,7 +410,7 @@ llvm::ErrorOr<ModuleDependencies> SerializedModuleLoaderBase::scanModuleFile(
   const std::string moduleDocPath;
   const std::string sourceInfoPath;
   // Map the set of dependencies over to the "module dependencies".
-  auto dependencies = ModuleDependencies::forSwiftBinaryModule(modulePath.str(),
+  auto dependencies = ModuleDependencyInfo::forSwiftBinaryModule(modulePath.str(),
                                                                moduleDocPath,
                                                                sourceInfoPath,
                                                                isFramework);

--- a/tools/libSwiftScan/libSwiftScan.cpp
+++ b/tools/libSwiftScan/libSwiftScan.cpp
@@ -513,7 +513,7 @@ swiftscan_compiler_target_info_query(swiftscan_scan_invocation_t invocation) {
   for (int i = 0; i < argc; ++i)
     Compilation.push_back(swift::c_string_utils::get_C_string(invocation->argv->strings[i]));
 
-  auto TargetInfo = getTargetInfo(Compilation);
+  auto TargetInfo = swift::dependencies::getTargetInfo(Compilation);
   if (TargetInfo.getError())
     return swift::c_string_utils::create_null();
   return TargetInfo.get();

--- a/unittests/DependencyScan/PrintTarget.cpp
+++ b/unittests/DependencyScan/PrintTarget.cpp
@@ -36,7 +36,7 @@ TEST_F(ScanTest, TestTargetInfoQuery) {
   for (auto &str : CommandStrArr)
     Compilation.push_back(str.c_str());
 
-  auto targetInfo = getTargetInfo(Compilation);
+  auto targetInfo = swift::dependencies::getTargetInfo(Compilation);
   if (targetInfo.getError()) {
     llvm::errs() << "For compilation: ";
     for (auto &str : Compilation)

--- a/unittests/DependencyScan/ScanFixture.h
+++ b/unittests/DependencyScan/ScanFixture.h
@@ -15,8 +15,6 @@
 #include "gtest/gtest.h"
 #include <string>
 
-using namespace swift::dependencies;
-
 namespace swift {
 namespace unittest {
 
@@ -27,7 +25,7 @@ public:
 
 protected:
   // The tool used to execute tests' scanning queries
-  DependencyScanningTool ScannerTool;
+  swift::dependencies::DependencyScanningTool ScannerTool;
 
   // Test workspace directory
   llvm::SmallString<256> TemporaryTestWorkspace;


### PR DESCRIPTION
- `ModuleDependenceis` -> `ModuleDependencyInfo`
These objects represent a singular module dependency.

- `GlobalModuleDependenciesCache` -> `SwiftDependencyScanningService `
This object holds much more than just a cache of discovered module dependencies. It also maintains the scanner's ClangDependencyService, etc.