### PR TITLE
Experimentally emit diagnostics from the new Swift parser 

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1965,12 +1965,6 @@ ERROR(associatedtype_cannot_be_variadic,none,
       "associated types cannot be variadic", ())
 
 //------------------------------------------------------------------------------
-// MARK: Consistency diagnostics
-//------------------------------------------------------------------------------
-ERROR(new_parser_failure, none,
-      "new parser has failed consistency checking; please see errors above", ())
-
-//------------------------------------------------------------------------------
 // MARK: syntax parsing diagnostics
 //------------------------------------------------------------------------------
 ERROR(unknown_syntax_entity, PointsToFirstBadToken,
@@ -2021,6 +2015,9 @@ ERROR(macro_expansion_decl_expected_macro_identifier,none,
 
 ERROR(parser_round_trip_error,none,
       "source file did not round-trip through the Swift Swift parser", ())
+ERROR(parser_new_parser_errors,none,
+      "Swift Swift parser generated errors for code that C++ parser accepted",
+       ())
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -138,9 +138,10 @@ EXPERIMENTAL_FEATURE(ParserRoundTrip, false)
 /// Swift parser.
 EXPERIMENTAL_FEATURE(ParserValidation, false)
 
-/// Whether to fold sequence expressions in the syntax tree produced by the
-/// Swift Swift parser.
-EXPERIMENTAL_FEATURE(ParserSequenceFolding, false)
+/// Whether to emit diagnostics from the new parser first, and only emit
+/// diagnostics from the existing parser when there are none from the new
+/// parser.
+EXPERIMENTAL_FEATURE(ParserDiagnostics, false)
 
 /// Enables implicit some while also enabling existential `any`
 EXPERIMENTAL_FEATURE(ImplicitSome, false)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2974,7 +2974,7 @@ static bool usesFeatureParserValidation(Decl *decl) {
   return false;
 }
 
-static bool usesFeatureParserSequenceFolding(Decl *decl) {
+static bool usesFeatureParserDiagnostics(Decl *decl) {
   return false;
 }
 

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -76,7 +76,6 @@ if (SWIFT_SWIFT_PARSER)
     SwiftOperators
     SwiftSyntaxBuilder
     _SwiftSyntaxMacros
-    SwiftCompilerSupport
   )
 
   # Compute the list of SwiftSyntax targets

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -33,7 +33,7 @@ if (SWIFT_SWIFT_PARSER)
   #
   #   target_link_libraries(swiftParse
   #     PRIVATE
-  #     SwiftSyntax::SwiftCompilerSupport
+  #     SwiftSyntax::SwiftParser
   #     ...
   #   )
   target_link_libraries(swiftParse
@@ -46,7 +46,6 @@ if (SWIFT_SWIFT_PARSER)
     SwiftSyntax::SwiftOperators
     SwiftSyntax::SwiftSyntaxBuilder
     SwiftSyntax::_SwiftSyntaxMacros
-    SwiftSyntax::SwiftCompilerSupport
     $<TARGET_OBJECTS:swiftASTGen>
   )
 
@@ -59,13 +58,7 @@ if (SWIFT_SWIFT_PARSER)
     SwiftSyntax::SwiftOperators
     SwiftSyntax::SwiftSyntaxBuilder
     SwiftSyntax::_SwiftSyntaxMacros
-    SwiftSyntax::SwiftCompilerSupport
     swiftASTGen
-  )
-
-  target_include_directories(swiftParse
-    PRIVATE
-    ${CMAKE_CURRENT_SOURCE_DIR}/../../../swift-syntax/Sources/SwiftCompilerSupport
   )
 
   target_compile_definitions(swiftParse

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -23,10 +23,6 @@
 #include "swift/Parse/Parser.h"
 #include "swift/Subsystems.h"
 
-#if SWIFT_SWIFT_PARSER
-#include "SwiftCompilerSupport.h"
-#endif
-
 using namespace swift;
 
 namespace swift {
@@ -174,44 +170,6 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
   Optional<ArrayRef<Token>> tokensRef;
   if (auto tokens = parser.takeTokenReceiver()->finalize())
     tokensRef = ctx.AllocateCopy(*tokens);
-
-#if SWIFT_SWIFT_PARSER
-  if (ctx.LangOpts.hasFeature(Feature::ParserValidation) &&
-      ctx.SourceMgr.getIDEInspectionTargetBufferID() != bufferID &&
-      SF->Kind != SourceFileKind::SIL) {
-    auto bufferRange = ctx.SourceMgr.getRangeForBuffer(*bufferID);
-    unsigned int flags = 0;
-
-    if (!ctx.Diags.hadAnyError() &&
-        ctx.LangOpts.hasFeature(Feature::ParserValidation))
-      flags |= SCC_ParseDiagnostics;
-
-    if (ctx.LangOpts.hasFeature(Feature::ParserSequenceFolding) &&
-        !parser.L->lexingCutOffOffset())
-      flags |= SCC_FoldSequences;
-
-    if (flags) {
-      SourceLoc startLoc =
-          parser.SourceMgr.getLocForBufferStart(parser.L->getBufferID());
-      struct ParserContext {
-        SourceLoc startLoc;
-        DiagnosticEngine *engine;
-      } context{startLoc, &parser.Diags};
-      int roundTripResult = swift_parser_consistencyCheck(
-          bufferRange.str().data(), bufferRange.getByteLength(),
-          SF->getFilename().str().c_str(), flags, static_cast<void *>(&context),
-          [](ptrdiff_t off, const char *text, void *ctx) {
-            auto *context = static_cast<ParserContext *>(ctx);
-            SourceLoc loc = context->startLoc.getAdvancedLoc(off);
-            context->engine->diagnose(loc, diag::foreign_diagnostic,
-                                      StringRef(text));
-          });
-
-      if (roundTripResult)
-        ctx.Diags.diagnose(SourceLoc(), diag::new_parser_failure);
-    }
-  }
-#endif
 
   return SourceFileParsingResult{ctx.AllocateCopy(items), tokensRef,
                                  parser.CurrentTokenHash};

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -57,8 +57,10 @@ struct OnlyAdds {
 func testAddBlocker(a: Int, b: Int, c: Int, oa: OnlyAdds) {
   _ = #addBlocker(a * b * c)
 #if TEST_DIAGNOSTICS
-  _ = #addBlocker(a + b * c) // expected-error{{blocked an add; did you mean to subtract? (from macro 'addBlocker')}}{{21-22=-}}
-  _ = #addBlocker(oa + oa) // expected-error{{blocked an add; did you mean to subtract? (from macro 'addBlocker')}}{{22-23=-}}
-      // expected-note@-1{{in expansion of macro 'addBlocker' here}}
+  _ = #addBlocker(a + b * c) // expected-error{{blocked an add; did you mean to subtract? (from macro 'addBlocker')}}
+  // expected-note@-1{{use '-'}}{{21-22=-}}
+  _ = #addBlocker(oa + oa) // expected-error{{blocked an add; did you mean to subtract? (from macro 'addBlocker')}}
+  // expected-note@-1{{in expansion of macro 'addBlocker' here}}
+  // expected-note@-2{{use '-'}}{{22-23=-}}
 #endif
 }

--- a/test/Parse/new_parser_diagnostics.swift
+++ b/test/Parse/new_parser_diagnostics.swift
@@ -5,4 +5,4 @@
 // REQUIRES: asserts
 
 _ = [(Int) -> async throws Int]()
-// expected-error@-1{{'async throws' may only occur before '->'}}
+// expected-error@-1{{'async throws' may only occur before '->'}}{{15-21=}} {{21-28=}} {{20-21= }} {{12-12=async }} {{12-12=throws }}

--- a/test/Parse/new_parser_diagnostics.swift
+++ b/test/Parse/new_parser_diagnostics.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature ParserDiagnostics
+
+// FIXME: Swift parser is not enabled on Linux CI yet.
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+_ = [(Int) -> async throws Int]()
+// expected-error@-1{{'async throws' may only occur before '->'}}

--- a/test/Parse/new_parser_diagnostics.swift
+++ b/test/Parse/new_parser_diagnostics.swift
@@ -5,4 +5,5 @@
 // REQUIRES: asserts
 
 _ = [(Int) -> async throws Int]()
-// expected-error@-1{{'async throws' may only occur before '->'}}{{15-21=}} {{21-28=}} {{20-21= }} {{12-12=async }} {{12-12=throws }}
+// expected-error@-1{{'async throws' may only occur before '->'}}
+// expected-note@-2{{move 'async throws' in front of '->'}}{{15-21=}} {{21-28=}} {{20-21= }} {{12-12=async }} {{12-12=throws }}


### PR DESCRIPTION
Introduce the experimental feature `ParserDiagnostics`, which emits
diagnostics from the new Swift parser *first* for a source file. If
that produces any errors, we suppress any diagnostics emitted from the
C++ parser.

While here, move diagnostic validation checking into ASTGen, so we
can drop our dependency on SwiftCompilerSupport... which will go away.