### PR TITLE
Add findEnclosingDefs and findBorrowIntroducers utilities

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -206,6 +206,10 @@ SILValue findOwnershipReferenceRoot(SILValue ref);
 
 /// Look through all ownership forwarding instructions to find the values which
 /// were originally borrowed.
+///
+/// Note: This treats guaranteed forwarding phis like roots even though they do
+/// not introduce the borrow scope. This ensures that all roots dominate \p
+/// reference Value. But the client will need to handle forwarding phis.
 void findGuaranteedReferenceRoots(SILValue referenceValue,
                                   bool lookThroughNestedBorrows,
                                   SmallVectorImpl<SILValue> &roots);

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -206,7 +206,8 @@ SILValue findOwnershipReferenceRoot(SILValue ref);
 
 /// Look through all ownership forwarding instructions to find the values which
 /// were originally borrowed.
-void findGuaranteedReferenceRoots(SILValue value, bool lookThroughNestedBorrows,
+void findGuaranteedReferenceRoots(SILValue referenceValue,
+                                  bool lookThroughNestedBorrows,
                                   SmallVectorImpl<SILValue> &roots);
 
 /// Find the aggregate containing the first owned root of the

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -1299,6 +1299,18 @@ void visitExtendedGuaranteedForwardingPhiBaseValuePairs(
     BorrowedValue borrow, function_ref<void(SILPhiArgument *, SILValue)>
                               visitGuaranteedForwardingPhiBaseValuePair);
 
+/// If \p value is a guaranteed non-phi value forwarded from it's instruction's
+/// operands, visit each forwarded operand.
+///
+/// Returns true if \p visitOperand was called (for convenience).
+///
+/// Precondition: \p value is not a phi. The client must handle phis first by
+/// checking if they are reborrows (using BorrowedValue). Reborrows have no
+/// forwarded operands. Guaranteed forwarding need to be handled by recursing
+/// through the phi operands.
+bool visitForwardedGuaranteedOperands(
+  SILValue value, function_ref<void(Operand *)> visitOperand);
+
 /// Visit the phis in the same block as \p phi which are reborrows of a borrow
 /// of one of the values reaching \p phi.
 ///

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -50,6 +50,7 @@
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILValue.h"
+#include "swift/SIL/StackList.h"
 #include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/SmallVector.h"
 
@@ -1318,6 +1319,24 @@ bool visitForwardedGuaranteedOperands(
 /// returns true.
 bool visitAdjacentReborrowsOfPhi(SILPhiArgument *phi,
                                  function_ref<bool(SILPhiArgument *)> visitor);
+
+/// Visit each definition of a scope that immediately encloses a guaranteed
+/// value. The guaranteed value effectively keeps these scopes alive.
+///
+/// This means something different depepending on whether \p value is itself a
+/// borrow introducer vs. a forwarded guaranteed value. If \p value is an
+/// introducer, then this discovers the enclosing borrow scope and visits all
+/// introducers of that scope. If \p value is a forwarded value, then this
+/// visits the introducers of the current borrow scope.
+bool visitEnclosingDefs(SILValue value, function_ref<bool(SILValue)> visitor);
+
+/// Visit the values that introduce the borrow scopes that includes \p
+/// value. If value is owned, or introduces a borrow scope, then this only
+/// visits \p value.
+///
+/// Returns false if the visitor returned false and exited early.
+bool visitBorrowIntroducers(SILValue value,
+                            function_ref<bool(SILValue)> visitor);
 
 /// Given a begin of a borrow scope, visit all end_borrow users of the borrow or
 /// its reborrows.

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -205,7 +205,7 @@ public:
   /// Precondition: this->isTerminatorResult()
   ///
   /// TODO: Move this and other APIs into a TerminatorResult abstraction.
-  const Operand *forwardedTerminatorResultOperand() const;
+  Operand *forwardedTerminatorResultOperand() const;
 
   /// Return the SILArgumentKind of this argument.
   SILArgumentKind getKind() const {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -599,6 +599,10 @@ public:
     return getTypeDependentOperands().size();
   }
 
+  unsigned getNumRealOperands() const {
+    return getAllOperands().size() - getNumTypeDependentOperands();
+  }
+
   bool isTypeDependentOperand(unsigned i) const {
     return i >= getNumOperands() - getNumTypeDependentOperands();
   }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8500,9 +8500,14 @@ public:
   /// example, a switch forwards ownership of the enum type into ownership of
   /// the payload.
   ///
-  /// Postcondition: each successor has zero or one block arguments which
-  /// represents the forwaded result.
+  /// Postcondition: if the result is non-null, then each successor has zero or
+  /// one block arguments which represents the forwaded result.
   const Operand *forwardedOperand() const;
+
+  Operand *forwardedOperand() {
+    return const_cast<Operand *>(
+      static_cast<const TermInst *>(this)->forwardedOperand());
+  }
 };
 
 // Forwards the first operand to a result in each successor block.

--- a/lib/SIL/IR/SILArgument.cpp
+++ b/lib/SIL/IR/SILArgument.cpp
@@ -341,7 +341,7 @@ TermInst *SILPhiArgument::getTerminatorForResult() const {
   return nullptr;
 }
 
-const Operand *SILArgument::forwardedTerminatorResultOperand() const {
+Operand *SILArgument::forwardedTerminatorResultOperand() const {
   assert(isTerminatorResult() && "API is invalid for phis");
   return getSingleTerminator()->forwardedOperand();
 }

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -16,6 +16,8 @@
 #include "swift/Basic/GraphNodeWorklist.h"
 #include "swift/SIL/Consumption.h"
 #include "swift/SIL/DynamicCasts.h"
+#include "swift/SIL/NodeDatastructures.h"
+#include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/SILBridging.h"
 #include "swift/SIL/SILBridgingUtils.h"
 #include "swift/SIL/SILInstruction.h"
@@ -863,75 +865,39 @@ SILValue swift::findOwnershipReferenceRoot(SILValue ref) {
 void swift::findGuaranteedReferenceRoots(SILValue value,
                                          bool lookThroughNestedBorrows,
                                          SmallVectorImpl<SILValue> &roots) {
-  GraphNodeWorklist<SILValue, 4> worklist;
-  auto addAllOperandsToWorklist = [&worklist](SILInstruction *inst) -> bool {
-    if (inst->getNumOperands() > 0) {
-      for (auto operand : inst->getOperandValues()) {
-        worklist.insert(operand);
-      }
-      return true;
-    }
-    return false;
-  };
-  worklist.initialize(value);
+  ValueWorklist worklist(referenceValue->getFunction());
+  worklist.pushIfNotVisited(referenceValue);
   while (auto value = worklist.pop()) {
-    if (auto *result = SILArgument::isTerminatorResult(value)) {
-      if (auto *forwardedOper = result->forwardedTerminatorResultOperand()) {
-        worklist.insert(forwardedOper->get());
-        continue;
-      }
-    } else if (auto *inst = value->getDefiningInstruction()) {
-      if (auto *bbi = dyn_cast<BeginBorrowInst>(inst)) {
-        auto borrowee = bbi->getOperand();
-        if (lookThroughNestedBorrows &&
-            borrowee->getOwnershipKind() == OwnershipKind::Guaranteed) {
-          // A nested borrow, the root guaranteed earlier in the use-def chain.
-          worklist.insert(borrowee);
-        }
-        // The borrowee isn't guaranteed or we aren't looking through nested
-        // borrows.  Fall through to add the begin_borrow to roots.
-      } else if (auto *result =
-              dyn_cast<FirstArgOwnershipForwardingSingleValueInst>(inst)) {
-        if (result->getNumOperands() > 0) {
-          worklist.insert(result->getOperand(0));
-          continue;
-        }
-      } else if (auto *result =
-                     dyn_cast<AllArgOwnershipForwardingSingleValueInst>(inst)) {
-        if (addAllOperandsToWorklist(result)) {
-          continue;
-        }
-      } else if (auto *result = dyn_cast<OwnershipForwardingTermInst>(inst)) {
-        assert(false && "value defined by a terminator?!");
-      } else if (auto *result =
-                     dyn_cast<OwnershipForwardingConversionInst>(inst)) {
-        worklist.insert(result->getConverted());
-        continue;
-      } else if (auto *result =
-                     dyn_cast<OwnershipForwardingSelectEnumInstBase>(inst)) {
-        if (addAllOperandsToWorklist(result)) {
-          continue;
-        }
-      } else if (auto *result =
-                     dyn_cast<OwnershipForwardingMultipleValueInstruction>(
-                         inst)) {
-        if (addAllOperandsToWorklist(result)) {
-          continue;
-        }
-      } else if (auto *mvi =
-                     dyn_cast<MoveOnlyWrapperToCopyableValueInst>(inst)) {
-        if (addAllOperandsToWorklist(mvi)) {
-          continue;
-        }
-      } else if (auto *c = dyn_cast<CopyableToMoveOnlyWrapperValueInst>(inst)) {
-        if (addAllOperandsToWorklist(c)) {
-          continue;
-        }
-      }
+    // Instructions may forwarded None ownership to guaranteed.
+    if (value->getOwnershipKind() != OwnershipKind::Guaranteed)
+      continue;
+
+    if (SILArgument::asPhi(value)) {
+      roots.push_back(value);
+      continue;
     }
 
-    if (value->getOwnershipKind() == OwnershipKind::Guaranteed)
-      roots.push_back(value);
+    if (visitForwardedGuaranteedOperands(value, [&](Operand *operand) {
+        worklist.pushIfNotVisited(operand->get());
+      })) {
+      // This instruction is not a root if any operands were forwarded,
+      // regardless of whether they were already visited.
+      continue;
+    }
+    // Found a potential root.
+    if (lookThroughNestedBorrows) {
+      if (auto *bbi = dyn_cast<BeginBorrowInst>(value)) {
+        auto borrowee = bbi->getOperand();
+        if (borrowee->getOwnershipKind() == OwnershipKind::Guaranteed) {
+          // A nested borrow, the root guaranteed earlier in the use-def chain.
+          worklist.pushIfNotVisited(borrowee);
+          continue;
+        }
+        // The borrowee isn't guaranteed or we aren't looking through nested
+        // borrows. Fall through to add the begin_borrow to roots.
+      }
+    }
+    roots.push_back(value);
   }
 }
 

--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -862,7 +862,7 @@ SILValue swift::findOwnershipReferenceRoot(SILValue ref) {
   return ref;
 }
 
-void swift::findGuaranteedReferenceRoots(SILValue value,
+void swift::findGuaranteedReferenceRoots(SILValue referenceValue,
                                          bool lookThroughNestedBorrows,
                                          SmallVectorImpl<SILValue> &roots) {
   ValueWorklist worklist(referenceValue->getFunction());

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -357,8 +357,12 @@ static bool isStoreCopy(SILValue value) {
     findGuaranteedReferenceRoots(source, /*lookThroughNestedBorrows=*/true,
                                  roots);
     if (llvm::any_of(roots, [](SILValue root) {
-          return isa<BeginApplyInst>(root->getDefiningInstruction());
-        })) {
+      // Handle forwarding phis conservatively rather than recursing.
+      if (SILArgument::asPhi(root) && !BorrowedValue(root))
+        return true;
+
+      return isa<BeginApplyInst>(root->getDefiningInstruction());
+    })) {
       return false;
     }
   }

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -381,6 +381,40 @@ struct VisitAdjacentReborrowsOfPhiTest : UnitTest {
   }
 };
 
+// Arguments:
+// - SILValue: value
+// Dumps:
+// - function
+// - the enclosing defs
+struct FindEnclosingDefsTest : UnitTest {
+  FindEnclosingDefsTest(UnitTestRunner *pass) : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    getFunction()->dump();
+    llvm::dbgs() << "Enclosing Defs:\n";
+    visitEnclosingDefs(arguments.takeValue(), [](SILValue def) {
+      def->dump();
+      return true;
+    });
+  }
+};
+
+// Arguments:
+// - SILValue: value
+// Dumps:
+// - function
+// - the borrow introducers
+struct FindBorrowIntroducers : UnitTest {
+  FindBorrowIntroducers(UnitTestRunner *pass) : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    getFunction()->dump();
+    llvm::dbgs() << "Introducers:\n";
+    visitBorrowIntroducers(arguments.takeValue(), [](SILValue def) {
+      def->dump();
+      return true;
+    });
+  }
+};
+
 /// [new_tests] Add the new UnitTest subclass above this line. 
 ///             Please sort alphabetically by to help reduce merge conflicts.
 
@@ -406,6 +440,8 @@ void UnitTestRunner::withTest(StringRef name, Doit doit) {
     ADD_UNIT_TEST_SUBCLASS("simplify-cfg-canonicalize-switch-enum", SimplifyCFGCanonicalizeSwitchEnum)
     ADD_UNIT_TEST_SUBCLASS("test-specification-parsing", TestSpecificationTest)
     ADD_UNIT_TEST_SUBCLASS("visit-adjacent-reborrows-of-phi", VisitAdjacentReborrowsOfPhiTest)
+    ADD_UNIT_TEST_SUBCLASS("find-enclosing-defs", FindEnclosingDefsTest)
+    ADD_UNIT_TEST_SUBCLASS("find-borrow-introducers", FindBorrowIntroducers)
     /// [new_tests] Add the new mapping from string to subclass above this line.
     ///             Please sort alphabetically by name to help reduce merge
     ///             conflicts.

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -411,6 +411,8 @@ void UnitTestRunner::withTest(StringRef name, Doit doit) {
     ///             conflicts.
 
 #undef ADD_UNIT_TEST_SUBCLASS
+    llvm::errs() << "No test named: " << name << "\n";
+    assert(false && "Invalid test name");
   }
 
 

--- a/test/SILOptimizer/borrow_introducer_unit.sil
+++ b/test/SILOptimizer/borrow_introducer_unit.sil
@@ -1,0 +1,224 @@
+// RUN: %target-sil-opt -unit-test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+
+struct Trivial {
+  var value: Builtin.Int32
+}
+
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
+struct PairC {
+  var first: C
+  var second: C
+}
+
+class C {}
+
+class D : C {}
+
+// The introducer of an introducer is always itself.
+
+// CHECK-LABEL: introducer_identity: find-borrow-introducers with: @trace[0]
+// CHECK: } // end sil function 'introducer_identity'
+// CHECK: Introducers:
+// CHECK-NEXT: %0 = argument of bb0 : $C
+// CHECK-NEXT: introducer_identity: find-borrow-introducers with: @trace[0]
+
+// CHECK-LABEL: introducer_identity: find-borrow-introducers with: @trace[1]
+// CHECK: } // end sil function 'introducer_identity'
+// CHECK: Introducers:
+// CHECK-NEXT: begin_borrow %0 : $C
+// CHECK-NEXT: introducer_identity: find-borrow-introducers with: @trace[1]
+
+// CHECK-LABEL: introducer_identity: find-borrow-introducers with: @trace[2]
+// CHECK: } // end sil function 'introducer_identity'
+// CHECK: Introducers:
+// CHECK-NEXT: load_borrow %1 : $*C
+// CHECK-NEXT: introducer_identity: find-borrow-introducers with: @trace[2]
+
+// CHECK-LABEL: introducer_identity: find-borrow-introducers with: @trace[3]
+// CHECK: } // end sil function 'introducer_identity'
+// CHECK: Introducers:
+// CHECK-NEXT: argument of bb1 : $C
+// CHECK-NEXT: introducer_identity: find-borrow-introducers with: @trace[3]
+
+sil [ossa] @introducer_identity : $@convention(thin) (@guaranteed C, @in C) -> () {
+entry(%0 : @guaranteed $C, %1 : $*C):
+  test_specification "find-borrow-introducers @trace[0]"
+  debug_value [trace] %0 : $C
+  %borrow1 = begin_borrow %0 : $C
+  test_specification "find-borrow-introducers @trace[1]"
+  debug_value [trace] %borrow1 : $C
+
+  %borrow2 = load_borrow %1 : $*C
+  test_specification "find-borrow-introducers @trace[2]"
+  debug_value [trace] %borrow2 : $C
+  end_borrow %borrow2 : $C
+
+  br exit(%borrow1 : $C)
+
+exit(%reborrow : @guaranteed $C):
+  test_specification "find-borrow-introducers @trace[3]"
+  debug_value [trace] %reborrow : $C
+  end_borrow %reborrow : $C
+  destroy_addr %1 : $*C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// There is no introducer if the guaranteed value is produced from a
+// trivial value.
+
+// CHECK-LABEL: introducer_trivial: find-borrow-introducers with: @trace[0]
+// CHECK: } // end sil function 'introducer_trivial'
+// CHECK: Introducers:
+// CHECK-NEXT: introducer_trivial: find-borrow-introducers with: @trace[0]
+
+sil [ossa] @introducer_trivial : $@convention(thin) () -> () {
+entry:
+  %trivial = enum $FakeOptional<C>, #FakeOptional.none!enumelt
+  br none(%trivial : $FakeOptional<C>)
+
+none(%phi : @guaranteed $FakeOptional<C>):
+  test_specification "find-borrow-introducers @trace[0]"
+  debug_value [trace] %phi : $FakeOptional<C>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// An unreachable phi currently looks like a reborrow.
+//
+// TODO: When we have a reborrow flag, an unreachable phi can be
+// either a reborrow or forwarded, as long as it has no end_borrow.
+
+// CHECK-LABEL: introducer_unreachable: find-borrow-introducers with: @trace[0]
+// CHECK: } // end sil function 'introducer_unreachable'
+// CHECK: Introducers:
+// CHECK-NEXT: argument of bb1 : $C
+// CHECK-NEXT: introducer_unreachable: find-borrow-introducers with: @trace[0]
+
+sil [ossa] @introducer_unreachable : $@convention(thin) () -> () {
+entry:
+  br exit
+
+unreachable_loop(%phiCycle : @guaranteed $C):
+  test_specification "find-borrow-introducers @trace[0]"
+  debug_value [trace] %phiCycle : $C
+  br unreachable_loop(%phiCycle : $C)
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// All data flow paths through phis and aggregates originate from the
+// same function argument.
+
+// CHECK-LABEL: introducer_single: find-borrow-introducers with: @trace[0]
+// CHECK: } // end sil function 'introducer_single'
+// CHECK: Introducers:
+// CHECK-NEXT: %0 = argument of bb0 : $C
+// CHECK-NEXT: introducer_single: find-borrow-introducers with: @trace[0]
+
+sil [ossa] @introducer_single : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  %cast = unconditional_checked_cast %0 : $C to D
+  %some = enum $FakeOptional<D>, #FakeOptional.some!enumelt, %cast : $D
+  br switch(%some : $FakeOptional<D>)
+
+switch(%somePhi : @guaranteed $FakeOptional<D>):
+  switch_enum %somePhi : $FakeOptional<D>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
+
+bb1(%payload : @guaranteed $D):
+  %upcast = upcast %payload : $D to $C
+  %aggregate = struct $PairC(%upcast : $C, %0 : $C)
+  %first = struct_extract %aggregate : $PairC, #PairC.first
+  %second = struct_extract %aggregate : $PairC, #PairC.second
+  %aggregate2 = struct $PairC(%first : $C, %second : $C)
+  test_specification "find-borrow-introducers @trace[0]"
+  debug_value [trace] %aggregate2 : $PairC
+  br exit
+
+bb2:
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// %reborrow introduces multiple borrow scopes. But it should only appear
+// in the list once.
+
+// The forwarding %phi originates from %borrow1 and %0. But
+// %borrow1 cannot be an introducer in bb2 because it's scope ends at
+// %reborrow. Therefore, %reborrow is an introducer from separate phi
+// paths, but should only appear in the introducer list once.
+//
+// CHECK-LABEL: introducer_revisit_reborrow: find-borrow-introducers with: @trace[0]
+// CHECK: bb1([[REBORROW:%.*]] : @guaranteed $C
+// CHECK: } // end sil function 'introducer_revisit_reborrow'
+// CHECK: Introducers:
+// CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
+// CHECK-NEXT: %0 = argument of bb0 : $C
+// CHECK-NEXT: introducer_revisit_reborrow: find-borrow-introducers with: @trace[0]
+
+sil [ossa] @introducer_revisit_reborrow : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  %borrow1 = begin_borrow %0 : $C
+  %aggregate = struct $PairC(%0 : $C, %borrow1 : $C)
+  br bb2(%borrow1 : $C, %aggregate : $PairC)
+
+bb2(%reborrow : @guaranteed $C, %phi : @guaranteed $PairC):
+  %first = struct_extract %phi : $PairC, #PairC.first
+  %aggregate2 = struct $PairC(%reborrow : $C, %first : $C)
+  test_specification "find-borrow-introducers @trace[0]"
+  debug_value [trace] %aggregate2 : $PairC
+  br exit
+
+exit:
+  end_borrow %reborrow : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// %phi originates from %0, %borrow1, & %borrow2. %borrow1 is, however,
+// reborrowed in bb2.
+
+// CHECK-LABEL: introducer_multiple_borrow: find-borrow-introducers with: @trace[0]
+// CHECK: begin_borrow %0 : $C  
+// CHECK: [[BORROW2:%.*]] = begin_borrow %0 : $C
+// CHECK: bb1([[REBORROW:%.*]] : @guaranteed $C
+// CHECK: } // end sil function 'introducer_multiple_borrow'
+// CHECK: Introducers:
+// CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
+// CHECK-NEXT: %0 = argument of bb0 : $C
+// CHECK-NEXT: [[BORROW2]] = begin_borrow %0 : $C
+// CHECK-NEXT: introducer_multiple_borrow: find-borrow-introducers with: @trace[0]
+
+sil [ossa] @introducer_multiple_borrow : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  %borrow1 = begin_borrow %0 : $C
+  %borrow2 = begin_borrow %0 : $C
+  %aggregate = struct $PairC(%0 : $C, %borrow2 : $C)
+  br bb2(%borrow1 : $C, %aggregate : $PairC)
+
+bb2(%reborrow : @guaranteed $C, %phi : @guaranteed $PairC):
+  %first = struct_extract %phi : $PairC, #PairC.first
+  %aggregate2 = struct $PairC(%reborrow : $C, %first : $C)
+  test_specification "find-borrow-introducers @trace[0]"
+  debug_value [trace] %aggregate2 : $PairC
+  br exit
+
+exit:
+  end_borrow %reborrow : $C
+  end_borrow %borrow2 : $C
+  %retval = tuple ()
+  return %retval : $()
+}

--- a/test/SILOptimizer/enclosing_def_unit.sil
+++ b/test/SILOptimizer/enclosing_def_unit.sil
@@ -1,0 +1,211 @@
+// RUN: %target-sil-opt -unit-test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+
+struct Trivial {
+  var value: Builtin.Int32
+}
+
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
+struct PairC {
+  var first: C
+  var second: C
+}
+
+class C {}
+
+class D : C {}
+
+// These introducers have no enclosing def.
+
+// CHECK-LABEL: enclosing_def_empty: find-enclosing-defs with: @trace[0]
+// CHECK: } // end sil function 'enclosing_def_empty'
+// CHECK: Enclosing Defs:
+// CHECK-NEXT: enclosing_def_empty: find-enclosing-defs with: @trace[0]
+
+// CHECK-LABEL: enclosing_def_empty: find-enclosing-defs with: @trace[1]
+// CHECK: } // end sil function 'enclosing_def_empty'
+// CHECK: Enclosing Defs:
+// CHECK-NEXT: enclosing_def_empty: find-enclosing-defs with: @trace[1]
+
+sil [ossa] @enclosing_def_empty : $@convention(thin) (@guaranteed C, @in C) -> () {
+entry(%0 : @guaranteed $C, %1 : $*C):
+  test_specification "find-enclosing-defs @trace[0]"
+  debug_value [trace] %0 : $C
+  %borrow1 = load_borrow %1 : $*C
+  test_specification "find-enclosing-defs @trace[1]"
+  debug_value [trace] %borrow1 : $C
+  end_borrow %borrow1 : $C
+  destroy_addr %1 : $*C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// There is no introducer if the guaranteed value is produced from a
+// trivial value.
+
+// CHECK-LABEL: enclosing_def_trivial: find-enclosing-defs with: @trace[0]
+// CHECK: } // end sil function 'enclosing_def_trivial'
+// CHECK: Enclosing Defs:
+// CHECK-NEXT: enclosing_def_trivial: find-enclosing-defs with: @trace[0]
+
+sil [ossa] @enclosing_def_trivial : $@convention(thin) () -> () {
+entry:
+  %trivial = enum $FakeOptional<C>, #FakeOptional.none!enumelt
+  br none(%trivial : $FakeOptional<C>)
+
+none(%phi : @guaranteed $FakeOptional<C>):
+  test_specification "find-enclosing-defs @trace[0]"
+  debug_value [trace] %phi : $FakeOptional<C>
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// There is an introducer but no enclosing def if the guaranteed value
+// is produced from a an unreachable loop.
+
+// CHECK-LABEL: enclosing_def_unreachable: find-enclosing-defs with: @trace[0]
+// CHECK: } // end sil function 'enclosing_def_unreachable'
+// CHECK: Enclosing Defs:
+// CHECK-NEXT: enclosing_def_unreachable: find-enclosing-defs with: @trace[0]
+
+sil [ossa] @enclosing_def_unreachable : $@convention(thin) () -> () {
+entry:
+  br exit
+
+unreachable_loop(%phiCycle : @guaranteed $C):
+  test_specification "find-enclosing-defs @trace[0]"
+  debug_value [trace] %phiCycle : $C
+  br unreachable_loop(%phiCycle : $C)
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// All data flow paths through phis and aggregates originate from the
+// same borrow scope. This is the same as finding the introducer.
+
+// CHECK-LABEL: begin running test 1 of 1 on enclosing_def_single_introducer: find-enclosing-defs with: @trace[0]
+// CHECK: sil [ossa] @enclosing_def_single_introducer
+// CHECK: Enclosing Defs:
+// CHECK:   begin_borrow %0 : $C
+// CHECK-NEXT: end running test 1 of 1 on enclosing_def_single_introducer: find-enclosing-defs with: @trace[0]
+
+sil [ossa] @enclosing_def_single_introducer : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  %borrow = begin_borrow %0 : $C
+  %cast = unconditional_checked_cast %borrow : $C to D
+  %some = enum $FakeOptional<D>, #FakeOptional.some!enumelt, %cast : $D
+  br switch(%some : $FakeOptional<D>)
+
+switch(%somePhi : @guaranteed $FakeOptional<D>):
+  switch_enum %somePhi : $FakeOptional<D>, case #FakeOptional.some!enumelt: bb1, case #FakeOptional.none!enumelt: bb2
+
+bb1(%payload : @guaranteed $D):
+  %upcast = upcast %payload : $D to $C
+  %aggregate = struct $PairC(%upcast : $C, %borrow : $C)
+  %first = struct_extract %aggregate : $PairC, #PairC.first
+  %second = struct_extract %aggregate : $PairC, #PairC.second
+  %aggregate2 = struct $PairC(%first : $C, %second : $C)
+  test_specification "find-enclosing-defs @trace[0]"
+  debug_value [trace] %aggregate2 : $PairC
+  br exit
+
+bb2:
+  br exit
+
+exit:
+  end_borrow %borrow : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// All reborrows original from the same dominating borrow scope.
+
+// CHECK: begin running test 1 of 1 on enclosing_def_single_outer: find-enclosing-defs with: @trace[0]
+// CHECK: } // end sil function 'enclosing_def_single_outer'
+// CHECK: Enclosing Defs:
+// CHECK-NEXT: %0 = argument of bb0 : $C
+// CHECK-NEXT: end running test 1 of 1 on enclosing_def_single_outer: find-enclosing-defs with: @trace[0]
+
+sil [ossa] @enclosing_def_single_outer : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  %borrow = begin_borrow %0 : $C
+  br bb2(%borrow : $C)
+
+bb2(%reborrow2 : @guaranteed $C):
+  br bb3(%reborrow2 : $C)
+
+bb3(%reborrow3 : @guaranteed $C):
+  test_specification "find-enclosing-defs @trace[0]"
+  debug_value [trace] %reborrow3 : $C
+  end_borrow %reborrow3 : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Find the outer enclosingreborrow.
+
+// CHECK-LABEL: begin running test 1 of 1 on enclosing_def_reborrow: find-enclosing-defs with: @trace[0]
+// CHECK: sil [ossa] @enclosing_def_reborrow : $@convention(thin) (@guaranteed C) -> () {
+// CHECK: bb1([[REBORROW:%.*]] : @guaranteed $C, %{{.*}} : @guaranteed $C):
+// CHECK: } // end sil function 'enclosing_def_reborrow'
+// CHECK: Enclosing Defs:
+// CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
+// CHECK-NEXT: end running test 1 of 1 on enclosing_def_reborrow: find-enclosing-defs with: @trace[0]
+
+sil [ossa] @enclosing_def_reborrow : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  %borrow_outer = begin_borrow %0 : $C
+  %borrow_inner = begin_borrow %borrow_outer : $C
+  br bb2(%borrow_outer : $C, %borrow_inner : $C)
+
+bb2(%reborrow_outer : @guaranteed $C, %reborrow_inner : @guaranteed $C):
+  br bb3(%reborrow_inner : $C)
+
+bb3(%reborrow_inner3 : @guaranteed $C):
+  test_specification "find-enclosing-defs @trace[0]"
+  debug_value [trace] %reborrow_inner3 : $C
+
+  end_borrow %reborrow_inner3 : $C
+  end_borrow %reborrow_outer : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// The enclosing def of a forwarding phi cycle is the reborrow phi cycle.
+
+// CHECK-LABEL: begin running test 1 of 1 on enclosing_def_cycle: find-enclosing-defs with: @trace[0]
+// CHECK: sil [ossa] @enclosing_def_cycle : $@convention(thin) (@guaranteed C) -> () {
+// CHECK: bb1([[REBORROW:%.*]] : @guaranteed $C,
+// CHECK: } // end sil function 'enclosing_def_cycle'
+// CHECK: Enclosing Defs:
+// CHECK-NEXT: [[REBORROW]] = argument of bb1 : $C
+// CHECK-NEXT: end running test 1 of 1 on enclosing_def_cycle: find-enclosing-defs with: @trace[0]
+
+sil [ossa] @enclosing_def_cycle : $@convention(thin) (@guaranteed C) -> () {
+entry(%0 : @guaranteed $C):
+  %borrow = begin_borrow %0 : $C
+  %aggregate1 = struct $PairC(%borrow : $C, %borrow : $C)
+  %first1 = struct_extract %aggregate1 : $PairC, #PairC.first
+  br bb2(%borrow : $C, %first1 : $C)
+
+bb2(%reborrow_outer : @guaranteed $C, %forward : @guaranteed $C):
+  test_specification "find-enclosing-defs @trace[0]"
+  debug_value [trace] %forward : $C
+
+  %aggregate2 = struct $PairC(%reborrow_outer : $C, %forward : $C)
+  %first2 = struct_extract %aggregate2 : $PairC, #PairC.first
+  br bb2(%reborrow_outer : $C, %first2 : $C)
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
These APIs are essential for complete OSSA liveness analysis.  The
existing ad-hoc OSSA logic always misses some of the cases handled by
these new utilities. We need to start replacing that ad-hoc logic with
new utilities built on top of these APIs to define away potential
latent bugs.

Add FIXMEs to the inverse API: visitAdjacentBorrowsOfPhi. It should
probably be redesigned in terms of these new APIs.