### PR TITLE
[SourceKit] Retrieve swiftsourcedocinfo for code completion request

### DIFF
--- a/include/swift/IDETool/IDEInspectionInstance.h
+++ b/include/swift/IDETool/IDEInspectionInstance.h
@@ -161,7 +161,7 @@ class IDEInspectionInstance {
       swift::CompilerInvocation &Invocation, llvm::ArrayRef<const char *> Args,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
       llvm::MemoryBuffer *ideInspectionTargetBuffer, unsigned int Offset,
-      DiagnosticConsumer *DiagC, bool IgnoreSwiftSourceInfo,
+      DiagnosticConsumer *DiagC,
       std::shared_ptr<std::atomic<bool>> CancellationFlag,
       llvm::function_ref<void(CancellableResult<IDEInspectionInstanceResult>)>
           Callback);

--- a/lib/IDETool/IDEInspectionInstance.cpp
+++ b/lib/IDETool/IDEInspectionInstance.cpp
@@ -541,7 +541,7 @@ void swift::ide::IDEInspectionInstance::performOperation(
     swift::CompilerInvocation &Invocation, llvm::ArrayRef<const char *> Args,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FileSystem,
     llvm::MemoryBuffer *ideInspectionTargetBuffer, unsigned int Offset,
-    DiagnosticConsumer *DiagC, bool IgnoreSwiftSourceInfo,
+    DiagnosticConsumer *DiagC,
     std::shared_ptr<std::atomic<bool>> CancellationFlag,
     llvm::function_ref<void(CancellableResult<IDEInspectionInstanceResult>)>
         Callback) {
@@ -562,8 +562,6 @@ void swift::ide::IDEInspectionInstance::performOperation(
     // and we don't need to build a new AST. We are done.
     return;
   }
-
-  Invocation.getFrontendOptions().IgnoreSwiftSourceInfo = IgnoreSwiftSourceInfo;
 
   // We don't need token list.
   Invocation.getLangOptions().CollectParsedToken = false;
@@ -620,7 +618,7 @@ void swift::ide::IDEInspectionInstance::codeComplete(
   // they're somewhat heavy operations and aren't needed for completion.
   performOperation(
       Invocation, Args, FileSystem, ideInspectionTargetBuffer, Offset, DiagC,
-      /*IgnoreSwiftSourceInfo=*/true, CancellationFlag,
+      CancellationFlag,
       [&](CancellableResult<IDEInspectionInstanceResult> CIResult) {
         CIResult.mapAsync<CodeCompleteResult>(
             [&CompletionContext, &CancellationFlag](auto &Result,
@@ -697,7 +695,7 @@ void swift::ide::IDEInspectionInstance::typeContextInfo(
 
   performOperation(
       Invocation, Args, FileSystem, ideInspectionTargetBuffer, Offset, DiagC,
-      /*IgnoreSwiftSourceInfo=*/true, CancellationFlag,
+      CancellationFlag,
       [&](CancellableResult<IDEInspectionInstanceResult> CIResult) {
         CIResult.mapAsync<TypeContextInfoResult>(
             [&CancellationFlag](auto &Result, auto DeliverTransformed) {
@@ -765,7 +763,7 @@ void swift::ide::IDEInspectionInstance::conformingMethodList(
 
   performOperation(
       Invocation, Args, FileSystem, ideInspectionTargetBuffer, Offset, DiagC,
-      /*IgnoreSwiftSourceInfo=*/true, CancellationFlag,
+      CancellationFlag,
       [&](CancellableResult<IDEInspectionInstanceResult> CIResult) {
         CIResult.mapAsync<ConformingMethodListResults>(
             [&ExpectedTypeNames, &CancellationFlag](auto &Result,
@@ -831,7 +829,7 @@ void swift::ide::IDEInspectionInstance::cursorInfo(
 
   performOperation(
       Invocation, Args, FileSystem, ideInspectionTargetBuffer, Offset, DiagC,
-      /*IgnoreSwiftSourceInfo=*/false, CancellationFlag,
+      CancellationFlag,
       [&](CancellableResult<IDEInspectionInstanceResult> CIResult) {
         CIResult.mapAsync<CursorInfoResults>(
             [&CancellationFlag, Offset](auto &Result, auto DeliverTransformed) {

--- a/test/SourceKit/CursorInfo/cursor_uses_swiftsourceinfo.swift
+++ b/test/SourceKit/CursorInfo/cursor_uses_swiftsourceinfo.swift
@@ -4,6 +4,11 @@
 // RUN: %target-swift-frontend -emit-module -module-name MyModule -emit-module-path %t/build/MyModule.swiftmodule -emit-module-source-info-path %t/build/MyModule.swiftsourceinfo %t/split/Action.swift
 // RUN: %sourcekitd-test -req=cursor -req-opts=retrieve_symbol_graph=1 -pos=5:14 %t/split/test.swift -- %t/split/test.swift -I %t/build -target %target-triple | %FileCheck %s
 
+// We should also get source doc info if we execute a code completion request (which doesn't need source doc info) first
+// RUN: %sourcekitd-test \
+// RUN: -req=complete %t/split/test.swift -pos=5:14 -- %t/split/test.swift -I %t/build -target %target-triple == \
+// RUN: -req=cursor -req-opts=retrieve_symbol_graph=1 -pos=5:14 %t/split/test.swift -- %t/split/test.swift -I %t/build -target %target-triple
+
 // BEGIN Action.swift
 public protocol Action {}
 


### PR DESCRIPTION
Extracted from https://github.com/apple/swift/pull/62574 to test its performance impact individually.

---

We need swiftsourcedocinfo for cursor info and to be able to reuse the ASTContext from code completion for cursor info, we need to also retrieve the sourcedocinfo for code completion requests.