### PR TITLE
[Sema] Teach typeCheckASTNodeAtLoc to check StmtConditionElement

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_on_if_let_binding.swift
+++ b/test/SourceKit/CursorInfo/cursor_on_if_let_binding.swift
@@ -1,0 +1,12 @@
+func foo() {
+  let myVar: Int? = 2
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line + 1):10 %s -- %s | %FileCheck %s
+  if let myVar = myVar {
+  }
+}
+
+// CHECK: source.lang.swift.decl.var.local (4:10-4:15)
+// CHECK-NEXT: myVar
+// CHECK-NEXT: s:24cursor_on_if_let_binding3fooyyF5myVarL0_Sivp
+// CHECK-NEXT: source.lang.swift
+// CHECK-NEXT: Int


### PR DESCRIPTION
Extracted from https://github.com/apple/swift/pull/62574 to test its impact on code completion individually.

---

Type checking a StmtConditionElement is slightly different than type checking the VarDecl declared by it because it doesn’t complain about redeclaration like `if let myVar = myVar`. Thus, we need to handle it in `typeCheckASTNodeAtLoc`
