### PR TITLE
WIP: Compute type relations for variables in result builders with buildBlock

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -74,7 +74,8 @@ class SolutionApplicationTarget;
 namespace TypeChecker {
 
 Optional<BraceStmt *> applyResultBuilderBodyTransform(FuncDecl *func,
-                                                        Type builderType);
+                                                      Type builderType,
+                                                      bool AllowHoles);
 
 Optional<constraints::SolutionApplicationTarget>
 typeCheckExpression(constraints::SolutionApplicationTarget &target,
@@ -1783,6 +1784,8 @@ enum class ConstraintSystemFlags {
 
   /// When set, ignore async/sync mismatches
   IgnoreAsyncSyncMismatch = 0x80,
+
+  AllowResultBuilderTransformWithHoles = 0x100,
 };
 
 /// Options that affect the constraint system as a whole.
@@ -3587,7 +3590,8 @@ private:
   // FIXME: Perhaps these belong on ConstraintSystem itself.
   friend Optional<BraceStmt *>
   swift::TypeChecker::applyResultBuilderBodyTransform(FuncDecl *func,
-                                                        Type builderType);
+                                                      Type builderType,
+                                                      bool AllowHoles);
 
   friend Optional<SolutionApplicationTarget>
   swift::TypeChecker::typeCheckExpression(

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -290,6 +290,7 @@ namespace {
 class ExprParentFinder : public ASTWalker {
   friend class ExprContextAnalyzer;
   Expr *ChildExpr;
+  bool AcceptRangeMatch;
   std::function<bool(ParentTy, ParentTy)> Predicate;
 
   bool arePositionsSame(Expr *E1, Expr *E2) {
@@ -299,14 +300,20 @@ class ExprParentFinder : public ASTWalker {
 
 public:
   llvm::SmallVector<ParentTy, 5> Ancestors;
-  ExprParentFinder(Expr *ChildExpr,
+
+  /// Search for the \p ChildExpr in the decl context that is walked by this
+  /// \c ExprParentFinder. Add every parent node that matches \p Predicate to
+  /// \c Ancestors. If \p AcceptRangeMatch is \c true, consider an expression
+  /// with the same source range as \p ChildExpr equivalent to \p ChildExpr.
+  ExprParentFinder(Expr *ChildExpr, bool AcceptRangeMatch,
                    std::function<bool(ParentTy, ParentTy)> Predicate)
-      : ChildExpr(ChildExpr), Predicate(Predicate) {}
+      : ChildExpr(ChildExpr), AcceptRangeMatch(AcceptRangeMatch),
+        Predicate(Predicate) {}
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     // Finish if we found the target. 'ChildExpr' might have been replaced
     // with typechecked expression. In that case, match the position.
-    if (E == ChildExpr || arePositionsSame(E, ChildExpr))
+    if (E == ChildExpr || (AcceptRangeMatch && arePositionsSame(E, ChildExpr)))
       return Action::Stop();
 
     if (E != ChildExpr && Predicate(E, Parent)) {
@@ -356,6 +363,28 @@ public:
     if (Predicate(P, Parent))
       Ancestors.pop_back();
     return Action::Continue(P);
+  }
+};
+
+/// Finds all the \c DeclRefExprs that reference a given \c ValueExpr.
+class DeclRefFinder : public ASTWalker {
+  /// Search for \c DeclRefExprs that reference this value.
+  ValueDecl *SearchValue;
+
+public:
+  /// After the \c DeclRefFinder walked a \c DeclContext, the \c DeclRefExprs
+  /// that reference \c SearchValue.
+  std::vector<DeclRefExpr *> Refs;
+
+  DeclRefFinder(ValueDecl *SearchValue) : SearchValue(SearchValue) {}
+
+  PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
+    if (auto *DR = dyn_cast<DeclRefExpr>(E)) {
+      if (DR->getDecl() == SearchValue) {
+        Refs.push_back(DR);
+      }
+    }
+    return Action::Continue(E);
   }
 };
 
@@ -791,6 +820,10 @@ getPositionInParams(DeclContext &DC, const ArgumentList *Args, Expr *CCExpr,
 class ExprContextAnalyzer {
   DeclContext *DC;
   Expr *ParsedExpr;
+  /// If \p AcceptRangeMatch is \c true, analyze consider expressions with the
+  /// same source range as \p ParsedExpr equivalent to \p ParsedExpr and analyze
+  /// those instead.
+  bool AcceptRangeMatch;
   SourceManager &SM;
   ASTContext &Context;
 
@@ -1140,6 +1173,71 @@ class ExprContextAnalyzer {
     return SM.rangeContains(E->getSourceRange(), ParsedExpr->getSourceRange());
   }
 
+  void recordPossibleTypeForPattern(Pattern *InitPattern, Expr *InitExpr) {
+    if (!InitPattern->hasType()) {
+      return;
+    }
+    Type InitType = InitPattern->getType();
+
+    // Consider completion in the following code fragement
+    //   let x = #^COMPLETE^#
+    //   foo(x) // with func foo(_ x: Int) {}
+    // x has unresolved type so by default we can't show any type relations
+    // for the global completions resulting from #^COMPLETE^#. But we know that
+    // x is later used in a situation that requires an Int, so we can prioritize
+    // code completion results that return an Int.
+    //
+    // This is particularly useful for result builders. Here, a result builder
+    //   @ViewBuilder var body: some View {
+    //     Text("Foo")
+    //     #^COMPLETE^#
+    //   }
+    // gets rewritten to
+    //   @ViewBuilder var body: some View {
+    //     let $__builder2: Text
+    //     let $__builder0 = Text("Foo")
+    //     let $__builder1 = #^COMPLETE^#
+    //     $__builder2 = ViewBuilder.buildBlock($__builder0, $__builder1)
+    //     return $__builder2
+    //   }
+    // which puts us in exactly the situation described above.
+    if (InitType->is<UnresolvedType>() && InitExpr == ParsedExpr) {
+      if (auto *Var = InitPattern->getSingleVar()) {
+        // We are in the let x = #^COMPLETE^# situation described above.
+        // Find any references to the newly defined variable with unresolved
+        // type, compute the contextual type where they are being used and
+        // report those contextual types for the newly defined variable.
+        // Note: We currently form the union of the contextual types of all var
+        // usages. Technically the intersection would be more correct, but
+        // that's non-trivial to compute.
+        DeclRefFinder DeclRefs(Var);
+        DC->walkContext(DeclRefs);
+        for (auto *DR : DeclRefs.Refs) {
+          // We only care about the contextual types of the variable usage.
+          // Discard everything else computed by the SubAnalyzer.
+          Expr *DiscardAnalyzedExpr = nullptr;
+          SmallVector<PossibleParamInfo, 0> DiscardPossibleParams;
+          SmallVector<FunctionTypeAndDecl, 0> DiscardPossibleCallees;
+          bool DiscardImplictSingleExpressionReturn;
+          // In result builders references to the implicitly declared variable
+          // have the same source range as its initializing expression, so we
+          // can't consider expressions with the same range as the variable
+          // reference equivalent or we'd end up in an infinite loop because we
+          // keep finding the initializing expression.
+          ExprContextAnalyzer SubAnalyzer(
+              DC, DR, /*AcceptRangeMatch=*/false, PossibleTypes,
+              DiscardPossibleParams, DiscardPossibleCallees,
+              DiscardAnalyzedExpr, DiscardImplictSingleExpressionReturn);
+          SubAnalyzer.Analyze();
+        }
+        return;
+      }
+    }
+
+    // We're not in the situation described above. Just record the type.
+    recordPossibleType(InitType);
+  }
+
   void analyzeDecl(Decl *D) {
     switch (D->getKind()) {
     case DeclKind::PatternBinding: {
@@ -1147,10 +1245,8 @@ class ExprContextAnalyzer {
       for (unsigned I : range(PBD->getNumPatternEntries())) {
         if (auto Init = PBD->getInit(I)) {
           if (containsTarget(Init)) {
-            if (PBD->getPattern(I)->hasType()) {
-              recordPossibleType(PBD->getPattern(I)->getType());
-              break;
-            }
+            recordPossibleTypeForPattern(PBD->getPattern(I), Init);
+            break;
           }
         }
       }
@@ -1253,15 +1349,15 @@ class ExprContextAnalyzer {
   }
 
 public:
-  ExprContextAnalyzer(
-      DeclContext *DC, Expr *ParsedExpr, SmallVectorImpl<Type> &PossibleTypes,
-      SmallVectorImpl<PossibleParamInfo> &PossibleArgs,
-      SmallVectorImpl<FunctionTypeAndDecl> &PossibleCallees,
-      Expr *&AnalyzedExpr, bool &implicitSingleExpressionReturn)
-      : DC(DC), ParsedExpr(ParsedExpr), SM(DC->getASTContext().SourceMgr),
-        Context(DC->getASTContext()), PossibleTypes(PossibleTypes),
-        PossibleParams(PossibleArgs), PossibleCallees(PossibleCallees),
-        AnalyzedExpr(AnalyzedExpr),
+  ExprContextAnalyzer(DeclContext *DC, Expr *ParsedExpr, bool AcceptRangeMatch,
+                      SmallVectorImpl<Type> &PossibleTypes,
+                      SmallVectorImpl<PossibleParamInfo> &PossibleArgs,
+                      SmallVectorImpl<FunctionTypeAndDecl> &PossibleCallees,
+                      Expr *&AnalyzedExpr, bool &implicitSingleExpressionReturn)
+      : DC(DC), ParsedExpr(ParsedExpr), AcceptRangeMatch(AcceptRangeMatch),
+        SM(DC->getASTContext().SourceMgr), Context(DC->getASTContext()),
+        PossibleTypes(PossibleTypes), PossibleParams(PossibleArgs),
+        PossibleCallees(PossibleCallees), AnalyzedExpr(AnalyzedExpr),
         implicitSingleExpressionReturn(implicitSingleExpressionReturn) {}
 
   void Analyze() {
@@ -1269,7 +1365,7 @@ public:
     if (!ParsedExpr)
       return;
 
-    ExprParentFinder Finder(ParsedExpr, [&](ASTWalker::ParentTy Node,
+    ExprParentFinder Finder(ParsedExpr, AcceptRangeMatch, [&](ASTWalker::ParentTy Node,
                                             ASTWalker::ParentTy Parent) {
       if (auto E = Node.getAsExpr()) {
         switch (E->getKind()) {
@@ -1369,8 +1465,8 @@ public:
 } // end anonymous namespace
 
 ExprContextInfo::ExprContextInfo(DeclContext *DC, Expr *TargetExpr) {
-  ExprContextAnalyzer Analyzer(DC, TargetExpr, PossibleTypes, PossibleParams,
-                               PossibleCallees, AnalyzedExpr,
-                               implicitSingleExpressionReturn);
+  ExprContextAnalyzer Analyzer(DC, TargetExpr, /*AcceptRangeMatch=*/true,
+                               PossibleTypes, PossibleParams, PossibleCallees,
+                               AnalyzedExpr, implicitSingleExpressionReturn);
   Analyzer.Analyze();
 }

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -2230,8 +2230,9 @@ BraceStmt *swift::applyResultBuilderTransform(
   return cast<BraceStmt>(result.get());
 }
 
-Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
-    FuncDecl *func, Type builderType) {
+Optional<BraceStmt *>
+TypeChecker::applyResultBuilderBodyTransform(FuncDecl *func, Type builderType,
+                                             bool AllowHoles) {
   // Pre-check the body: pre-check any expressions in it and look
   // for return statements.
   //
@@ -2287,6 +2288,9 @@ Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
   }
 
   ConstraintSystemOptions options = ConstraintSystemFlags::AllowFixes;
+  if (AllowHoles) {
+    options |= ConstraintSystemFlags::AllowResultBuilderTransformWithHoles;
+  }
   auto resultInterfaceTy = func->getResultInterfaceType();
   auto resultContextType = func->mapTypeIntoContext(resultInterfaceTy);
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9464,7 +9464,10 @@ Optional<SolutionApplicationTarget> ConstraintSystem::applySolution(
   // produce a fallback diagnostic to highlight the problem.
   {
     const auto &score = solution.getFixedScore();
-    if (score.Data[SK_Fix] > numResolvableFixes || score.Data[SK_Hole] > 0) {
+    if (score.Data[SK_Fix] > numResolvableFixes ||
+        (score.Data[SK_Hole] > 0 &&
+         !this->Options.contains(
+             ConstraintSystemFlags::AllowResultBuilderTransformWithHoles))) {
       maybeProduceFallbackDiagnostic(target);
       return None;
     }

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2049,8 +2049,8 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
   // Function builder function doesn't support partial type checking.
   if (auto *func = dyn_cast<FuncDecl>(DC)) {
     if (Type builderType = getResultBuilderType(func)) {
-      auto optBody =
-          TypeChecker::applyResultBuilderBodyTransform(func, builderType);
+      auto optBody = TypeChecker::applyResultBuilderBodyTransform(
+          func, builderType, /*AllowHoles=*/true);
       if (optBody && *optBody) {
         // Wire up the function body now.
         func->setBody(*optBody, AbstractFunctionDecl::BodyKind::TypeChecked);
@@ -2139,9 +2139,8 @@ TypeCheckFunctionBodyRequest::evaluate(Evaluator &evaluator,
   bool alreadyTypeChecked = false;
   if (auto *func = dyn_cast<FuncDecl>(AFD)) {
     if (Type builderType = getResultBuilderType(func)) {
-      if (auto optBody =
-              TypeChecker::applyResultBuilderBodyTransform(
-                func, builderType)) {
+      if (auto optBody = TypeChecker::applyResultBuilderBodyTransform(
+              func, builderType, /*AllowHoles=*/false)) {
         if (!*optBody)
           return errorBody();
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -455,7 +455,8 @@ void typeCheckASTNode(ASTNode &node, DeclContext *DC,
 /// fully type-checked body of the function (on success) or a \c nullptr
 /// value if an error occurred while type checking the transformed body.
 Optional<BraceStmt *> applyResultBuilderBodyTransform(FuncDecl *func,
-                                                        Type builderType);
+                                                      Type builderType,
+                                                      bool AllowHoles);
 
 /// Find the return statements within the body of the given function.
 std::vector<ReturnStmt *> findReturnStatements(AnyFunctionRef fn);

--- a/test/IDE/complete_contextual_type_in_result_builder.swift
+++ b/test/IDE/complete_contextual_type_in_result_builder.swift
@@ -1,0 +1,30 @@
+
+protocol View2 {}
+
+@resultBuilder public struct ViewBuilder2 {
+  static func buildBlock<Content>(_ content: Content) -> Content where Content : View2 { fatalError() }
+  static func buildBlock<C0, C1>(_ c0: C0, _ c1: C1) -> C0 where C0 : View2, C1: View2 { fatalError() }
+}
+
+struct MyText: View2 {}
+
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token SINGLE_ELEMENT | %FileCheck %s --check-prefix=SINGLE_ELEMENT
+struct MyView {
+	@ViewBuilder2 var body2: some View2 {
+		#^SINGLE_ELEMENT^#
+	}
+}
+// SINGLE_ELEMENT: Begin completions
+// SINGLE_ELEMENT-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyText[#MyText#];
+// SINGLE_ELEMENT: End completions
+
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token SECOND_ELEMENT | %FileCheck %s --check-prefix=SECOND_ELEMENT
+struct MyView {
+	@ViewBuilder2 var body2: some View2 {
+		MyText()
+		#^SECOND_ELEMENT^#
+	}
+}
+// SECOND_ELEMENT: Begin completions
+// SECOND_ELEMENT-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyText[#MyText#];
+// SECOND_ELEMENT: End completions


### PR DESCRIPTION
This re-opens https://github.com/apple/swift/pull/41028 because the result builder AST transform that a constraint system-based solution would require has not been merged yet.