### PR TITLE
LetPropertiesOpts: don't crash for properties in ObjC extensions

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -941,6 +941,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
   case DAK_Optimize:
   case DAK_Exclusivity:
   case DAK_NonSendable:
+  case DAK_ObjCImplementation:
     if (getKind() == DAK_Effects &&
         cast<EffectsAttr>(this)->getKind() == EffectsKind::Custom) {
       Printer.printAttrName("@_effects");

--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -361,6 +361,10 @@ static bool isAssignableExternally(VarDecl *Property, SILModule *Module) {
 
     auto *Ty = dyn_cast<NominalTypeDecl>(Property->getDeclContext());
 
+    // Check for "unusual" decl contexts, e.g. ObjC extensions.
+    if (!Ty)
+      return true;
+
     // Initializer for a let property of a class cannot exist externally.
     // It cannot be defined by an extension or a derived class.
     if (isa<ClassDecl>(Ty))

--- a/test/SILOptimizer/Inputs/let_properties_opts.h
+++ b/test/SILOptimizer/Inputs/let_properties_opts.h
@@ -1,0 +1,5 @@
+#import <Foundation/NSObject.h>
+
+@interface ObjcInterface: NSObject
+@end
+

--- a/test/SILOptimizer/let_properties_opts_objc.swift
+++ b/test/SILOptimizer/let_properties_opts_objc.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -module-name test -primary-file %s -import-objc-header %S/Inputs/let_properties_opts.h -O -wmo -emit-sil | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+// CHECK-LABEL: @_objcImplementation extension ObjcInterface
+@_objcImplementation extension ObjcInterface {
+    final public let i: Int
+}
+
+// Check that it doesn't crash with properties in ObjC extensions
+
+// CHECK-LABEL: sil @$s4test0A13ObjcInterfaceySiSo0bC0CF
+// CHECK:         ref_element_addr %0 : $ObjcInterface, #ObjcInterface.i
+// CHECK:       } // end sil function '$s4test0A13ObjcInterfaceySiSo0bC0CF'
+public func testObjcInterface(_ x: ObjcInterface) -> Int {
+  return x.i
+}
+


### PR DESCRIPTION
also: fix printing of the `@_objcImplementation` attribute

rdar://103381746