### PR TITLE
Remove StorageType from DebugTypeInfo::getErrorResult().

### DIFF
--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -161,13 +161,9 @@ DebugTypeInfo DebugTypeInfo::getObjCClass(ClassDecl *theClass,
 }
 
 DebugTypeInfo DebugTypeInfo::getErrorResult(swift::Type Ty,
-                                            llvm::Type *StorageType,
                                             IRGenModule &IGM) {
   auto &TI = IGM.getTypeInfoForUnlowered(Ty);
-  // FIXME: Enable this. Currently breaks on i386.
-  // assert(TI.getStorageType() == StorageType);
   DebugTypeInfo DbgTy = getFromTypeInfo(Ty, TI, false);
-  assert(StorageType && "FragmentStorageType is a nullptr");
   return DbgTy;
 }
 

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -87,8 +87,7 @@ public:
                                     llvm::Type *StorageType, Size size,
                                     Alignment align);
   /// Error type.
-  static DebugTypeInfo getErrorResult(swift::Type Ty, llvm::Type *StorageType,
-                                      IRGenModule &IGM);
+  static DebugTypeInfo getErrorResult(swift::Type Ty, IRGenModule &IGM);
 
   TypeBase *getType() const { return Type; }
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -4877,8 +4877,7 @@ void IRGenSILFunction::emitErrorResultVar(CanSILFunctionType FnTy,
     return;
   auto DbgTy = DebugTypeInfo::getErrorResult(
       ErrorInfo.getReturnValueType(IGM.getSILModule(), FnTy,
-                                   IGM.getMaximalTypeExpansionContext()),
-      ErrorResultSlot->getType(), IGM);
+                                   IGM.getMaximalTypeExpansionContext()),IGM);
   IGM.DebugInfo->emitVariableDeclaration(Builder, Storage, DbgTy,
                                          getDebugScope(), {}, *Var,
                                          IndirectValue, ArtificialValue);


### PR DESCRIPTION
Error results are always indirect so passing in the llvm storage type (which is always a pointer) is entirely pointless.

rdar://103416237

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
