### PR TITLE
[cxx-interop] Add benchmark for std::set conversion to a Swift collection

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -200,6 +200,7 @@ set(SWIFT_BENCH_MODULES
     single-source/WordCount
     single-source/XorLoop
     cxx-source/CreateObjects
+    cxx-source/CxxSetToCollection
     cxx-source/CxxVectorSum
     cxx-source/ReadAccessor
 )

--- a/benchmark/cxx-source/CxxSetToCollection.swift
+++ b/benchmark/cxx-source/CxxSetToCollection.swift
@@ -1,0 +1,61 @@
+//===--- CxxSetToCollection.swift -----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2012 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This is a benchmark that tracks how quickly Swift can convert a C++ set
+// to a Swift collection.
+
+import TestsUtils
+
+#if SWIFT_PACKAGE
+// FIXME: Needs fix for https://github.com/apple/swift/issues/61547.
+
+public let benchmarks = [BenchmarkInfo]()
+
+#else
+
+import CxxStdlibPerformance
+import Cxx
+
+public let benchmarks = [
+  BenchmarkInfo(
+    name: "CxxSetU32.to.Array",
+    runFunction: run_CxxSetOfU32_to_Array,
+    tags: [.validation, .bridging, .cxxInterop],
+    setUpFunction: makeSetOnce),
+  BenchmarkInfo(
+    name: "CxxSetU32.to.Set",
+    runFunction: run_CxxSetOfU32_to_Set,
+    tags: [.validation, .bridging, .cxxInterop],
+    setUpFunction: makeSetOnce),
+]
+
+func makeSetOnce() {
+  initSet(setSize)
+}
+
+let setSize = 1_000
+
+@inline(never)
+public func run_CxxSetOfU32_to_Array(_ n: Int) {
+  for _ in 0..<n {
+    blackHole(Array(set))
+  }
+}
+
+@inline(never)
+public func run_CxxSetOfU32_to_Set(_ n: Int) {
+  for _ in 0..<n {
+    blackHole(Set(set))
+  }
+}
+
+#endif

--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -627,16 +627,26 @@ class BenchmarkDoctor(object):
     @staticmethod
     def _constant_memory_use(measurements):
         select = BenchmarkDoctor._select
+        name = measurements["name"]
+
+        memory_uses = [
+            [r.mem_pages for r in i_series if r.mem_pages is not None]
+            for i_series in [select(measurements, num_iters=i) for i in [1, 2]]
+        ]
+        memory_uses = [m for m in memory_uses if m]
+        if not memory_uses:
+            BenchmarkDoctor.log_memory.info(
+                "unable to compute memory footprint of '%s'",
+                name,
+            )
+            return
+
         (min_i1, max_i1), (min_i2, max_i2) = [
             (min(memory_use), max(memory_use))
-            for memory_use in [
-                [r.mem_pages for r in i_series]
-                for i_series in [select(measurements, num_iters=i) for i in [1, 2]]
-            ]
+            for memory_use in memory_uses
         ]
         range_i1, range_i2 = max_i1 - min_i1, max_i2 - min_i2
         normal_range = 15  # pages
-        name = measurements["name"]
         more_info = False
 
         if abs(min_i1 - min_i2) > max(range_i1, range_i2, normal_range):

--- a/benchmark/utils/CxxTests/CxxStdlibPerformance.h
+++ b/benchmark/utils/CxxTests/CxxStdlibPerformance.h
@@ -2,10 +2,13 @@
 
 #include <cstdint>
 #include <vector>
+#include <set>
 
 using VectorOfU32 = std::vector<uint32_t>;
+using SetOfU32 = std::set<uint32_t>;
 
 static inline VectorOfU32 vec;
+static inline SetOfU32 set;
 
 inline void initVector(size_t size) {
     if (!vec.empty()) {
@@ -17,9 +20,23 @@ inline void initVector(size_t size) {
     }
 }
 
+inline void initSet(size_t size) {
+    if (!set.empty()) {
+        return;
+    }
+    for (size_t i = 0; i < size; ++i) {
+        set.insert(uint32_t(i));
+    }
+}
+
 inline VectorOfU32 makeVector32(size_t size) {
     initVector(size);
     return vec;
+}
+
+inline SetOfU32 makeSet32(size_t size) {
+    initSet(size);
+    return set;
 }
 
 inline uint32_t testVector32Sum(size_t vectorSize, size_t iters) {

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -50,6 +50,7 @@ import ClassArrayGetter
 import CodableTest
 import Combos
 import CreateObjects
+import CxxSetToCollection
 import CxxVectorSum
 import DataBenchmarks
 import DeadArray
@@ -235,6 +236,7 @@ register(CodableTest.benchmarks)
 register(Combos.benchmarks)
 register(ClassArrayGetter.benchmarks)
 register(CreateObjects.benchmarks)
+register(CxxSetToCollection.benchmarks)
 register(CxxVectorSum.benchmarks)
 register(DataBenchmarks.benchmarks)
 register(DeadArray.benchmarks)


### PR DESCRIPTION
This adds a benchmark for the C++ stdlib overlay functionality that converts C++ containers to Swift collections.

This also fixes a Python exception in the benchmarking engine that happened when no memory measurements were taken for a particular benchmark