### PR TITLE
Add a new flag to import objc forward declarations

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -825,7 +825,7 @@ namespace swift {
 
     /// If true, forward declarations will be imported using unavailable types
     /// instead of dropped altogether when possible.
-    bool ImportForwardDeclarations = false;
+    bool ImportForwardDeclarations = true;
 
     /// If true ignore the swift bridged attribute.
     bool DisableSwiftBridgeAttr = false;


### PR DESCRIPTION
This was create for the purpose of testing against the source compatibility suite and source kit stress test only.

Real PR is here: https://github.com/apple/swift/pull/61606