### PR TITLE
Import clang's ptruath qualifier on function pointers

### DIFF
--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -410,7 +410,7 @@ Type ASTBuilder::createFunctionType(
   auto einfo =
       FunctionType::ExtInfoBuilder(representation, noescape, flags.isThrowing(),
                                    resultDiffKind, clangFunctionType,
-                                   globalActor)
+                                   globalActor, clang::PointerAuthQualifier())
           .withAsync(flags.isAsync())
           .withConcurrent(flags.isSendable())
           .build();

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -5923,6 +5923,10 @@ public:
       Printer << " ";
     }
 
+    if (auto ptrAuthQual = info.getPointerAuthQualifier()) {
+      Printer << ptrAuthQual.getAsString() << " ";
+    }
+
     if (!Options.excludeAttrKind(TAK_Sendable) &&
         info.isSendable()) {
       Printer.printSimpleAttr("@Sendable") << " ";

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4273,6 +4273,18 @@ Type AnyFunctionType::getGlobalActor() const {
   }
 }
 
+clang::PointerAuthQualifier AnyFunctionType::getPointerAuthQualifier() const {
+  switch (getKind()) {
+  case TypeKind::Function:
+    return cast<FunctionType>(this)->getPointerAuthQualifier();
+  case TypeKind::GenericFunction:
+    // Generic functions do not have C types.
+    return clang::PointerAuthQualifier();
+  default:
+    llvm_unreachable("Illegal type kind for AnyFunctionType.");
+  }
+}
+
 ClangTypeInfo AnyFunctionType::getCanonicalClangTypeInfo() const {
   return getClangTypeInfo().getCanonical();
 }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1414,12 +1414,12 @@ static Type maybeImportCFOutParameter(ClangImporter::Implementation &impl,
 }
 
 static ImportedType adjustTypeForConcreteImport(
-    ClangImporter::Implementation &impl,
-    ImportResult importResult, ImportTypeKind importKind,
-    bool allowNSUIntegerAsInt, Bridgeability bridging,
+    ClangImporter::Implementation &impl, ImportResult importResult,
+    ImportTypeKind importKind, bool allowNSUIntegerAsInt,
+    Bridgeability bridging,
     llvm::function_ref<void(Diagnostic &&)> addImportDiagnostic,
-    ImportTypeAttrs attrs, OptionalTypeKind optKind,
-    bool resugarNSErrorPointer) {
+    ImportTypeAttrs attrs, OptionalTypeKind optKind, bool resugarNSErrorPointer,
+    clang::PointerAuthQualifier ptrAuth) {
   Type importedType = importResult.AbstractType;
   ImportHint hint = importResult.Hint;
 
@@ -1435,10 +1435,17 @@ static ImportedType adjustTypeForConcreteImport(
   switch (hint) {
   case ImportHint::None:
     break;
-
   case ImportHint::ObjCPointer:
-  case ImportHint::CFunctionPointer:
     break;
+
+  case ImportHint::CFunctionPointer: {
+    if (ptrAuth) {
+      auto fTy = importedType->castTo<FunctionType>();
+      FunctionType::ExtInfo einfo = fTy->getExtInfo();
+      einfo = einfo.intoBuilder().withPointerAuthQualifier(ptrAuth).build();
+      importedType = fTy->withExtInfo(einfo);
+    }
+  } break;
 
   case ImportHint::Void:
     // 'void' can only be imported as a function result type.
@@ -1674,7 +1681,8 @@ ImportedType ClangImporter::Implementation::importType(
   // Now fix up the type based on how we're concretely using it.
   auto adjustedType = adjustTypeForConcreteImport(
       *this, importResult, importKind, allowNSUIntegerAsInt, bridging,
-      addImportDiagnosticFn, attrs, optionality, resugarNSErrorPointer);
+      addImportDiagnosticFn, attrs, optionality, resugarNSErrorPointer,
+      type.getQualifiers().getPointerAuth());
 
   return adjustedType;
 }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3369,7 +3369,7 @@ NeverNullType TypeResolver::resolveASTFunctionType(
 
   FunctionType::ExtInfoBuilder extInfoBuilder(
       FunctionTypeRepresentation::Swift, noescape, repr->isThrowing(), diffKind,
-      /*clangFunctionType*/ nullptr, Type());
+      /*clangFunctionType*/ nullptr, Type(), clang::PointerAuthQualifier());
 
   const clang::Type *clangFnType = parsedClangFunctionType;
   if (shouldStoreClangType(representation) && !clangFnType)

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5874,12 +5874,12 @@ detail::function_deserializer::deserialize(ModuleFile &MF,
     globalActor = globalActorTy.get();
   }
 
-  auto info =
-      FunctionType::ExtInfoBuilder(*representation, noescape, throws, *diffKind,
-                                   clangFunctionType, globalActor)
-          .withConcurrent(concurrent)
-          .withAsync(async)
-          .build();
+  auto info = FunctionType::ExtInfoBuilder(
+                  *representation, noescape, throws, *diffKind,
+                  clangFunctionType, globalActor, clang::PointerAuthQualifier())
+                  .withConcurrent(concurrent)
+                  .withAsync(async)
+                  .build();
 
   auto resultTy = MF.getTypeChecked(resultID);
   if (!resultTy)

--- a/test/ClangImporter/Inputs/custom-modules/import-ptrauth-field-fptr.h
+++ b/test/ClangImporter/Inputs/custom-modules/import-ptrauth-field-fptr.h
@@ -1,0 +1,9 @@
+#ifndef TEST_C_FUNCTION
+#define TEST_C_FUNCTION
+
+struct SecureStruct {
+  int (*__ptrauth(1, 0, 50)(secure_func_ptr))();
+};
+
+extern struct SecureStruct *ptr_to_secure_struct;
+#endif

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -271,3 +271,7 @@ module CommonName {
   header "CommonName.h"
   export *
 }
+
+module PointerAuth {
+  header "import-ptrauth-field-fptr.h"
+}

--- a/test/ClangImporter/import-ptruath-field-fptr.swift
+++ b/test/ClangImporter/import-ptruath-field-fptr.swift
@@ -1,0 +1,12 @@
+// RUN: %swift-frontend %s  -dump-ast -target arm64e-apple-ios13.0 -I %S/Inputs/ 2>&1 | %FileCheck %s
+// REQUIRES: CPU=arm64e
+// REQUIRES: OS=ios
+
+import PointerAuth
+
+// CHECK:(declref_expr type='__ptrauth(1,0,50) @convention(c) () -> Int32' location={{.*}}test/ClangImporter/import-ptruath-field-fptr.swift:9:10{{.*}}
+
+func test_field_fn_ptr() -> Int32 {
+  let fn = ptr_to_secure_struct!.pointee.secure_func_ptr!
+  return fn()
+}


### PR DESCRIPTION
C's function pointers can be qualified with `__ptrauth(value, key, discriminator)`. Such pointers are signed as per the specification of the qualifier and authenticated before use. More details on clang's support for pointer authentication is here - https://llvm.org/docs/PointerAuth.html. This PR is the first step to support Swift's interop with a subset of `__ptrauth` qualified pointers in C.

rdar://96044425

