### PR TITLE
Fix leak of argv when realloc fails grow original buffer but succeeds allocate grown one

### DIFF
--- a/stdlib/public/CommandLineSupport/CommandLine.cpp
+++ b/stdlib/public/CommandLineSupport/CommandLine.cpp
@@ -123,12 +123,18 @@ char **_swift_stdlib_getUnsafeArgvArgc(int *outArgLen) {
       // STL collections may call operator new() which can be overridden by 
       // client code and that client code could call back into Swift.
       size_t argvSize = sizeof(char *) * (maxArgc + 1);
-      argv = reinterpret_cast<char **>(realloc(argv, argvSize));
-      if (!argv) {
+      char **argvReallocated = reinterpret_cast<char **>(realloc(argv, argvSize));
+      if (!argvReallocated) {
         swift::fatalError(0,
           "Fatal error: Could not allocate space for %d commandline "
           " arguments: %d\n",
           argc, errno);
+      }
+      if (!argv) { // initial allocation
+        argv = argvReallocated;
+      } else if (argvReallocated != argv) { // argv didn't grow in original location, but was reallocated
+        free(argv);
+        argv = argvReallocated;
       }
     }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
