### PR TITLE
Fix bug of using GenericParamList after it's std::move'd

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4504,6 +4504,17 @@ public:
 
       outerParams = genericParams;
     }
+#ifndef NDEBUG
+    // Use outerParams before it will be moved with std::move(outerParams)
+    unsigned paramCount = 0;
+    if (outerParams) {
+      for (auto *paramList = outerParams;
+           paramList != nullptr;
+           paramList = paramList->getOuterParameters()) {
+        paramCount += paramList->size();
+      }
+    }
+#endif
     ctx.evaluator.cacheOutput(GenericParamListRequest{extension},
                               std::move(outerParams));
 
@@ -4532,12 +4543,6 @@ public:
 
 #ifndef NDEBUG
     if (outerParams) {
-      unsigned paramCount = 0;
-      for (auto *paramList = outerParams;
-           paramList != nullptr;
-           paramList = paramList->getOuterParameters()) {
-        paramCount += paramList->size();
-      }
       assert(paramCount ==
              extension->getGenericSignature().getGenericParams().size());
     }


### PR DESCRIPTION
<!-- What's in this pull request? -->

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
