### PR TITLE
Remove one of two identical sub-expressions 'accessKind == AccessStorage::Class' to the left and to the right of the '||' operator

### DIFF
--- a/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
@@ -746,9 +746,7 @@ void AccessConflictAndMergeAnalysis::visitMayRelease(SILInstruction *instr,
   // This is similar to recordUnknownConflict, but only class and global
   // accesses can be affected by a deinitializer.
   auto isHeapAccess = [](AccessStorage::Kind accessKind) {
-    return accessKind == AccessStorage::Class
-           || accessKind == AccessStorage::Class
-           || accessKind == AccessStorage::Global;
+    return accessKind == AccessStorage::Class || accessKind == AccessStorage::Global;
   };
   // Mark the in-scope accesses as having a nested conflict
   llvm::for_each(state.inScopeConflictFreeAccesses, [&](BeginAccessInst *bai) {


### PR DESCRIPTION
As I get from comment, one of  'accessKind == AccessStorage::Class' should be just removed.

<!-- What's in this pull request? -->

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
