### PR TITLE
build: Make `--xcode` imply `--skip-early-swiftsyntax`

### DIFF
--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -126,6 +126,7 @@ def _apply_default_arguments(args):
         # Building with Xcode is deprecated.
         args.skip_build = True
         args.build_early_swift_driver = False
+        args.build_early_swiftsyntax = False
 
     # --ios-all etc are not supported by open-source Swift.
     if args.ios_all:

--- a/utils/build_swift/tests/build_swift/test_driver_arguments.py
+++ b/utils/build_swift/tests/build_swift/test_driver_arguments.py
@@ -646,3 +646,4 @@ class TestDriverArgumentParser(
         self.assertEqual(namespace.cmake_generator, 'Xcode')
         self.assertTrue(namespace.skip_build)
         self.assertFalse(namespace.build_early_swift_driver)
+        self.assertFalse(namespace.build_early_swiftsyntax)


### PR DESCRIPTION
One can use the package file in the swift-syntax repo to open the project in Xcode.

Resolves #62645
