### PR TITLE
StandardLibraryProgrammersManual.md Typo "Dominated" -> "Denominated"

### DIFF
--- a/docs/StandardLibraryProgrammersManual.md
+++ b/docs/StandardLibraryProgrammersManual.md
@@ -380,7 +380,7 @@ The regular `as` operator should be able to convert between reference types with
 
 #### `_fastPath` and `_slowPath`
 
-`_fastPath` returns its argument, wrapped in a Builtin.expect. This informs the optimizer that the vast majority of the time, the branch will be taken (i.e. the then branch is “hot”). The SIL optimizer may alter heuristics for anything dominated by the then branch. But the real performance impact comes from the fact that the SIL optimizer will consider anything dominated by the else branch to be infrequently executed (i.e. “cold”). This means that transformations that may increase code size have very conservative heuristics to keep the rarely executed code small.
+`_fastPath` returns its argument, wrapped in a Builtin.expect. This informs the optimizer that the vast majority of the time, the branch will be taken (i.e. the then branch is “hot”). The SIL optimizer may alter heuristics for anything denominated by the then branch. But the real performance impact comes from the fact that the SIL optimizer will consider anything denominated by the else branch to be infrequently executed (i.e. “cold”). This means that transformations that may increase code size have very conservative heuristics to keep the rarely executed code small.
 
 The probabilities are passed through to LLVM as branch weight metadata, to leverage LLVM’s use of GCC style builtin_expect knowledge (e.g. for code layout and low-level inlining).
 
@@ -412,7 +412,7 @@ return
 
 #### `_onFastPath`
 
-This should be rarely used. It informs the SIL optimizer that any code dominated by it should be treated as the innermost loop of a performance critical section of code. It cranks optimizer heuristics to 11. Injudicious use of this will degrade performance and bloat binary size.
+This should be rarely used. It informs the SIL optimizer that any code denominated by it should be treated as the innermost loop of a performance critical section of code. It cranks optimizer heuristics to 11. Injudicious use of this will degrade performance and bloat binary size.
 
 
 #### <a name="precondition"></a>`_precondition`, `_debugPrecondition`, and `_internalInvariant`


### PR DESCRIPTION
Opening a new PR for #62663 because I don't see that I can re-open the issue...I don't think this is _actually the right usage of the word "dominated" here.