### PR TITLE
Do not insert dynamic exclusivity checks in closure cycles

### DIFF
--- a/test/Interpreter/enforce_exclusive_access.swift
+++ b/test/Interpreter/enforce_exclusive_access.swift
@@ -383,4 +383,56 @@ ExclusiveAccessTestSuite.test("directlyAppliedEscapingConflict") {
   }()
 }
 
+// rdar://102056143 - recursive locals inside a mutating method
+// effectively capture self as inout even if they don't modify
+// self. This should not trigger a runtime trap.
+struct RecursiveLocalDuringMutation {
+  var flag: Bool = false
+
+  mutating func update() {
+    func local1(_ done: Bool) -> Bool {
+      if !done {
+        return local2()
+      }
+      return flag
+    }
+    func local2() -> Bool {
+      return local1(true)
+    }
+    flag = !local1(false)
+  }
+}
+
+ExclusiveAccessTestSuite.test("recursiveLocalDuringMutation") {
+  var v = RecursiveLocalDuringMutation()
+  v.update()
+  _blackHole(v.flag)
+}
+
+// rdar://102056143 - negative test. Make sure we still catch true
+// violations on recursive captures.
+struct RecursiveCaptureViolation {
+  func testBadness() -> Bool {
+    var flag = false
+    func local1(_ x: inout Bool) {
+      if !flag {
+        x = true
+        local2()
+      }
+    }
+    func local2() {
+      local1(&flag)
+    }
+    local2()
+    return flag
+  }
+}
+
+ExclusiveAccessTestSuite.test("recursiveCaptureViolation") {
+  var s = RecursiveCaptureViolation()
+  expectCrashLater()
+  s.testBadness()
+  _blackHole(s)
+}
+
 runAllTests()

--- a/test/SILOptimizer/access_enforcement_selection.swift
+++ b/test/SILOptimizer/access_enforcement_selection.swift
@@ -101,9 +101,8 @@ public func recaptureStack() -> Int {
 
 
 // -----------------------------------------------------------------------------
-// Inout access in a recursive closure currently has dynamic enforcement
-// because enforcement selection cannot visit all closure scopes before
-// selecting enforcement within the closure.
+// Inout access in a recursive non-escaping closure currently has
+// static enforcement.
 
 public protocol Apply {
     func apply(_ body: (Apply) -> ())
@@ -111,7 +110,7 @@ public protocol Apply {
 
 // CHECK-LABEL: sil private @$s28access_enforcement_selection20testRecursiveClosure1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tF : $@convention(thin) (@in_guaranteed any Apply, @inout_aliasable Int) -> () {
 // CHECK: bb0(%0 : $*any Apply, %1 : @closureCapture $*Int):
-// CHECK:   begin_access [modify] [dynamic] %1 : $*Int
+// CHECK:   begin_access [modify] [static] %1 : $*Int
 // CHECK-LABEL: } // end sil function '$s28access_enforcement_selection20testRecursiveClosure1a1xyAA5Apply_p_SiztF9localFuncL_1byAaE_p_tF'
 public func testRecursiveClosure(a: Apply, x: inout Int) {
     func localFunc(b: Apply) {
@@ -122,4 +121,20 @@ public func testRecursiveClosure(a: Apply, x: inout Int) {
         b.apply(closure)
     }
     a.apply(localFunc)
+}
+
+// CHECK-LABEL: sil private @$s28access_enforcement_selection25testRecursiveLocalCapture1iys5Int64Vz_tF6local2L_yyF : $@convention(thin) (@inout_aliasable Int64) -> () {
+// CHECK: begin_access [modify] [static] %0 : $*Int64
+// CHECK-LABEL: } // end sil function '$s28access_enforcement_selection25testRecursiveLocalCapture1iys5Int64Vz_tF6local2L_yyF'
+func testRecursiveLocalCapture(i: inout Int64) {
+  func local1() {
+    if i < 1 {
+      local2()
+    }
+  }
+  func local2() {
+    i = i + 1
+    local1()
+  }
+  local1()
 }


### PR DESCRIPTION
Closure cycles were originally enforced "conservatively". Real code does, however, use recursive local functions. And it's surprisingly easy to create false exclusivity violations in those cases.

This is safe as long as we can rely on SILGen to keep captured variables in boxes if the capture escapes in any closure that may call other closures that capture the same variable.

Fixes https://github.com/apple/swift/issues/61404
Dynamic exclusivity checking bug with nested functions. #61404

Fixes rdar://102056143 (assertion failure due to exclusivity checker - AccessEnforcementSelection should handle recursive local captures)
