### PR TITLE
[runtime] Fix incorrect format specifier in warning message

### DIFF
--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -18,6 +18,7 @@
 #include "swift/Runtime/EnvironmentVariables.h"
 
 #include <string.h>
+#include <inttypes.h>
 
 using namespace swift;
 
@@ -115,7 +116,7 @@ static uint32_t parse_uint32_t(const char *name,
   }
   if (n > UINT32_MAX) {
     swift::warning(RuntimeErrorFlagNone,
-                   "Warning: %s=%s out of bounds, clamping to %d.\n",
+                   "Warning: %s=%s out of bounds, clamping to %" PRIu32 ".\n",
                    name, value, UINT32_MAX);
     return UINT32_MAX;
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
