### PR TITLE
Fix possible null dereference

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -84,17 +84,19 @@ Solution ConstraintSystem::finalize() {
     if (getFixedType(tv))
       continue;
 
-    switch (solverState->AllowFreeTypeVariables) {
-    case FreeTypeVariableBinding::Disallow:
-      llvm_unreachable("Solver left free type variables");
+      if (solverState) {
+        switch (solverState->AllowFreeTypeVariables) {
+        case FreeTypeVariableBinding::Disallow:
+          llvm_unreachable("Solver left free type variables");
 
-    case FreeTypeVariableBinding::Allow:
-      break;
+        case FreeTypeVariableBinding::Allow:
+          break;
 
-    case FreeTypeVariableBinding::UnresolvedType:
-      assignFixedType(tv, ctx.TheUnresolvedType);
-      break;
-    }
+        case FreeTypeVariableBinding::UnresolvedType:
+          assignFixedType(tv, ctx.TheUnresolvedType);
+          break;
+        }
+      }
   }
 
   // For each of the type variables, get its fixed type.

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1755,7 +1755,7 @@ ConstraintSystem::filterDisjunction(
         return SolutionKind::Unsolved;
 
       for (auto *currentChoice : disjunction->getNestedConstraints()) {
-        if (currentChoice != choice)
+        if (solverState && currentChoice != choice)
           solverState->disableConstraint(currentChoice);
       }
       return SolutionKind::Solved;


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fix two cases of possible null dereference.
In both cases there's a check against null few lines after dereference which suggests pointer sometimes is expected to be null.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
