### PR TITLE
replace `llvm::NoneType::None` -> `None`

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -632,14 +632,14 @@ namespace swift {
     /// contribute to a Swift Dependency Scanning hash.
     llvm::hash_code getModuleScanningHashComponents() const {
       auto hashValue = getPCHHashComponents();
-      if (TargetVariant.hasValue())
-        hashValue = llvm::hash_combine(hashValue, TargetVariant.getValue().str());
-      if (ClangTarget.hasValue())
-        hashValue = llvm::hash_combine(hashValue, ClangTarget.getValue().str());
-      if (SDKVersion.hasValue())
-        hashValue = llvm::hash_combine(hashValue, SDKVersion.getValue().getAsString());
-      if (VariantSDKVersion.hasValue())
-        hashValue = llvm::hash_combine(hashValue, VariantSDKVersion.getValue().getAsString());
+      if (TargetVariant.has_value())
+        hashValue = llvm::hash_combine(hashValue, TargetVariant.value().str());
+      if (ClangTarget.has_value())
+        hashValue = llvm::hash_combine(hashValue, ClangTarget.value().str());
+      if (SDKVersion.has_value())
+        hashValue = llvm::hash_combine(hashValue, SDKVersion.value().getAsString());
+      if (VariantSDKVersion.has_value())
+        hashValue = llvm::hash_combine(hashValue, VariantSDKVersion.value().getAsString());
       return hashValue;
     }
 

--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -838,7 +838,7 @@ ScalarTypeLayoutEntry::layoutString(IRGenModule &IGM) const {
              0x0, 0x0, 0x0, 0x1, 'N'}};
   }
   default:
-    return llvm::NoneType::None;
+    return None;
   }
 }
 
@@ -1156,7 +1156,7 @@ llvm::Optional<Size> AlignedGroupEntry::fixedSize(IRGenModule &IGM) const {
   Size currentSize(0);
   for (auto *entry : entries) {
     if (!entry->fixedSize(IGM) || !entry->fixedAlignment(IGM)) {
-      return *(_fixedSize = llvm::Optional<Size>(llvm::NoneType::None));
+      return *(_fixedSize = llvm::Optional<Size>(None));
     }
     Size entrySize = *entry->fixedSize(IGM);
     currentSize =
@@ -1174,7 +1174,7 @@ AlignedGroupEntry::fixedAlignment(IRGenModule &IGM) const {
   for (auto *entry : entries) {
     if (!entry->fixedAlignment(IGM)) {
       return *(_fixedAlignment =
-                   llvm::Optional<Alignment>(llvm::NoneType::None));
+                   llvm::Optional<Alignment>(None));
     }
     currentAlignment = std::max(currentAlignment, *entry->fixedAlignment(IGM));
   }
@@ -1190,7 +1190,7 @@ AlignedGroupEntry::fixedXICount(IRGenModule &IGM) const {
   for (auto *entry : entries) {
     auto entryXICount = entry->fixedXICount(IGM);
     if (!entryXICount) {
-      return *(_fixedXICount = llvm::Optional<uint32_t>(llvm::NoneType::None));
+      return *(_fixedXICount = llvm::Optional<uint32_t>(None));
     }
     currentMaxXICount = std::max(*entryXICount, currentMaxXICount);
   }
@@ -1269,7 +1269,7 @@ AlignedGroupEntry::layoutString(IRGenModule &IGM) const {
     }
     auto entryStr = entry->layoutString(IGM);
     if (!entryStr) {
-      return llvm::NoneType::None;
+      return None;
     }
     uint32_t entryStrSize;
     llvm::support::endian::write32be(&entryStrSize, entryStr->size());
@@ -1597,17 +1597,17 @@ bool ArchetypeLayoutEntry::canValueWitnessExtraInhabitantsUpTo(
 bool ArchetypeLayoutEntry::isSingleRetainablePointer() const { return false; }
 
 llvm::Optional<Size> ArchetypeLayoutEntry::fixedSize(IRGenModule &IGM) const {
-  return llvm::NoneType::None;
+  return None;
 }
 
 llvm::Optional<Alignment>
 ArchetypeLayoutEntry::fixedAlignment(IRGenModule &IGM) const {
-  return llvm::NoneType::None;
+  return None;
 }
 
 llvm::Optional<uint32_t>
 ArchetypeLayoutEntry::fixedXICount(IRGenModule &IGM) const {
-  return llvm::NoneType::None;
+  return None;
 }
 
 llvm::Value *
@@ -1638,7 +1638,7 @@ ArchetypeLayoutEntry::layoutString(IRGenModule &IGM) const {
       return layoutStr;
     }
   }
-  return llvm::NoneType::None;
+  return None;
 }
 
 void ArchetypeLayoutEntry::destroy(IRGenFunction &IGF, Address addr) const {
@@ -1770,7 +1770,7 @@ EnumTypeLayoutEntry::layoutString(IRGenModule &IGM) const {
     // E numEmptyPayloads numPayloads legnthOfEachPayload payloads
     //
     // Not yet supported/implemented
-    return llvm::NoneType::None;
+    return None;
   } else {
     // SINGLEENUM := 'e' SIZE SIZE VALUE
     // e NumEmptyPayloads LengthOfPayload Payload
@@ -1783,7 +1783,7 @@ EnumTypeLayoutEntry::layoutString(IRGenModule &IGM) const {
     llvm::Optional<std::vector<uint8_t>> payloadLayout =
         cases[0]->layoutString(IGM);
     if (!payloadLayout) {
-      return llvm::NoneType::None;
+      return None;
     }
     assert(payloadLayout->size() <= UINT32_MAX &&
            "Enum layout exceeds length limit");
@@ -1938,7 +1938,7 @@ llvm::Optional<Size> EnumTypeLayoutEntry::fixedSize(IRGenModule &IGM) const {
     auto payloadNumExtraInhabitants = cases[0]->fixedXICount(IGM);
     auto payloadSize = cases[0]->fixedSize(IGM);
     if (!payloadNumExtraInhabitants || !payloadSize) {
-      return *(_fixedSize = llvm::Optional<Size>(llvm::NoneType::None));
+      return *(_fixedSize = llvm::Optional<Size>(None));
     }
     if (*payloadNumExtraInhabitants >= numEmptyCases) {
       size = *payloadSize;
@@ -1957,7 +1957,7 @@ llvm::Optional<Size> EnumTypeLayoutEntry::fixedSize(IRGenModule &IGM) const {
   for (auto enum_case : cases) {
     auto caseSize = enum_case->fixedSize(IGM);
     if (!caseSize) {
-      return *(_fixedSize = llvm::Optional<Size>(llvm::NoneType::None));
+      return *(_fixedSize = llvm::Optional<Size>(None));
     }
     maxPayloadSize = std::max(*caseSize, maxPayloadSize);
   }
@@ -1977,7 +1977,7 @@ EnumTypeLayoutEntry::fixedAlignment(IRGenModule &IGM) const {
     auto caseAlign = payload->fixedAlignment(IGM);
     if (!caseAlign) {
       return *(_fixedAlignment =
-                   llvm::Optional<Alignment>(llvm::NoneType::None));
+                   llvm::Optional<Alignment>(None));
     }
     maxAlign = std::max(*caseAlign, maxAlign);
   }
@@ -1999,7 +1999,7 @@ EnumTypeLayoutEntry::fixedXICount(IRGenModule &IGM) const {
     //     payloadNumExtraInhabitants - emptyCases : 0;
     auto payloadXIs = cases[0]->fixedXICount(IGM);
     if (!payloadXIs) {
-      return *(_fixedXICount = llvm::Optional<uint32_t>(llvm::NoneType::None));
+      return *(_fixedXICount = llvm::Optional<uint32_t>(None));
     }
     return *(_fixedXICount =
                  payloadXIs >= numEmptyCases ? *payloadXIs - numEmptyCases : 0);
@@ -2015,7 +2015,7 @@ EnumTypeLayoutEntry::fixedXICount(IRGenModule &IGM) const {
   for (auto enum_case : cases) {
     auto caseSize = enum_case->fixedSize(IGM);
     if (!caseSize) {
-      return *(_fixedXICount = llvm::Optional<uint32_t>(llvm::NoneType::None));
+      return *(_fixedXICount = llvm::Optional<uint32_t>(None));
     }
     maxPayloadSize = std::max(*caseSize, maxPayloadSize);
   }
@@ -2900,7 +2900,7 @@ llvm::Value *ResilientTypeLayoutEntry::size(IRGenFunction &IGF) const {
 
 llvm::Optional<Size>
 ResilientTypeLayoutEntry::fixedSize(IRGenModule &IGM) const {
-  return llvm::NoneType::None;
+  return None;
 }
 
 bool ResilientTypeLayoutEntry::isFixedSize(IRGenModule &IGM) const {
@@ -2920,12 +2920,12 @@ bool ResilientTypeLayoutEntry::canValueWitnessExtraInhabitantsUpTo(
 
 llvm::Optional<Alignment>
 ResilientTypeLayoutEntry::fixedAlignment(IRGenModule &IGM) const {
-  return llvm::NoneType::None;
+  return None;
 }
 
 llvm::Optional<uint32_t>
 ResilientTypeLayoutEntry::fixedXICount(IRGenModule &IGM) const {
-  return llvm::NoneType::None;
+  return None;
 }
 
 llvm::Value *
@@ -3190,7 +3190,7 @@ void TypeInfoBasedTypeLayoutEntry::storeEnumTagSinglePayload(
 
 llvm::Optional<std::vector<uint8_t>>
 TypeInfoBasedTypeLayoutEntry::layoutString(IRGenModule &IGM) const {
-  return llvm::NoneType::None;
+  return None;
 }
 
 #if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)

--- a/lib/IRGen/TypeLayout.h
+++ b/lib/IRGen/TypeLayout.h
@@ -411,20 +411,20 @@ private:
   /// Optional(None) -> Not fixed size
   /// Optional(Size) -> Fixed Size
   mutable llvm::Optional<llvm::Optional<Size>> _fixedSize =
-      llvm::NoneType::None;
+      None;
   /// Memoize the value of fixedAlignment()
   /// None -> Not yet computed
   /// Optional(None) -> Not fixed Alignment
   /// Optional(Alignment) -> Fixed Alignment
   mutable llvm::Optional<llvm::Optional<Alignment>> _fixedAlignment =
-      llvm::NoneType::None;
+      None;
 
   /// Memoize the value of fixedXICount()
   /// None -> Not yet computed
   /// Optional(None) -> Not fixed xi count
   /// Optional(Count) -> Fixed XICount
   mutable llvm::Optional<llvm::Optional<uint32_t>> _fixedXICount =
-      llvm::NoneType::None;
+      None;
 
   llvm::Value *withExtraInhabitantProvidingEntry(
       IRGenFunction &IGF, Address addr, llvm::Type *returnType,
@@ -532,20 +532,20 @@ private:
   /// Optional(None) -> Not fixed size
   /// Optional(Size) -> Fixed Size
   mutable llvm::Optional<llvm::Optional<Size>> _fixedSize =
-      llvm::NoneType::None;
+      None;
   /// Memoize the value of fixedAlignment()
   /// None -> Not yet computed
   /// Optional(None) -> Not fixed Alignment
   /// Optional(Alignment) -> Fixed Alignment
   mutable llvm::Optional<llvm::Optional<Alignment>> _fixedAlignment =
-      llvm::NoneType::None;
+      None;
 
   /// Memoize the value of fixedXICount()
   /// None -> Not yet computed
   /// Optional(None) -> Not fixed xi count
   /// Optional(Count) -> Fixed XICount
   mutable llvm::Optional<llvm::Optional<uint32_t>> _fixedXICount =
-      llvm::NoneType::None;
+      None;
 
   llvm::Value *maxPayloadSize(IRGenFunction &IGF) const;
   llvm::BasicBlock *testSinglePayloadEnumContainsPayload(IRGenFunction &IGF,

--- a/lib/SIL/Utils/Projection.cpp
+++ b/lib/SIL/Utils/Projection.cpp
@@ -376,7 +376,7 @@ Optional<ProjectionPath> ProjectionPath::getProjectionPath(SILValue Start,
   // and unions. This is currently only associated with structs.
   if (Start->getType().aggregateHasUnreferenceableStorage() ||
       End->getType().aggregateHasUnreferenceableStorage())
-    return llvm::NoneType::None;
+    return None;
 
   auto Iter = End;
   while (Start != Iter) {
@@ -405,7 +405,7 @@ Optional<ProjectionPath> ProjectionPath::getProjectionPath(SILValue Start,
   // ProjectionPath never allow paths to be compared as a list of indices.
   // Only the encoded type+index pair will be compared.
   if (P.empty() || Start != Iter)
-    return llvm::NoneType::None;
+    return None;
 
   // Reverse to get a path from base to most-derived.
   std::reverse(P.Path.begin(), P.Path.end());
@@ -540,7 +540,7 @@ ProjectionPath::removePrefix(const ProjectionPath &Path,
                              const ProjectionPath &Prefix) {
   // We can only subtract paths that have the same base.
   if (Path.BaseType != Prefix.BaseType)
-    return llvm::NoneType::None;
+    return None;
 
   // If Prefix is greater than or equal to Path in size, Prefix can not be a
   // prefix of Path. Return None.
@@ -548,7 +548,7 @@ ProjectionPath::removePrefix(const ProjectionPath &Path,
   unsigned PathSize = Path.size();
 
   if (PrefixSize >= PathSize)
-    return llvm::NoneType::None;
+    return None;
 
   // First make sure that the prefix matches.
   Optional<ProjectionPath> P = ProjectionPath(Path.BaseType);


### PR DESCRIPTION
This is needed for the rebranch.

Also, use new `llvm::Optional` APIs to fix warnings in rebranch