### PR TITLE
IRGen: Don't treat internal but visible via testable import classes as having fragile layout

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4999,8 +4999,8 @@ bool ClassDecl::hasResilientMetadata() const {
     return false;
 
   // If the class is not public, we can't use it outside the module at all.
-  if (!getFormalAccessScope(/*useDC=*/nullptr,
-                            /*treatUsableFromInlineAsPublic=*/true).isPublic())
+  // Take enable testing into account.
+  if (getEffectiveAccess() < AccessLevel::Public)
     return false;
 
   // Otherwise we access metadata members, such as vtable entries, resiliently.

--- a/lib/IRGen/ClassMetadataVisitor.h
+++ b/lib/IRGen/ClassMetadataVisitor.h
@@ -121,10 +121,6 @@ private:
 
       // Super class metadata is resilient if
       // the superclass is resilient when viewed from the current module.
-      // But not if the current class is defined in an external module and
-      //    not publically accessible (e.g private or internal). This would
-      //    normally not happen except if we compile theClass's module with
-      //    enable-testing.
       } else if (IGM.hasResilientMetadata(superclassDecl,
                                           ResilienceExpansion::Maximal,
                                           rootClass)) {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -5583,17 +5583,6 @@ llvm::Constant *IRGenModule::getAddrOfGlobalUTF16String(StringRef utf8) {
 ///    not publically accessible (e.g private or internal).
 /// This would normally not happen except if we compile theClass's module with
 /// enable-testing.
-static bool shouldTreatClassAsFragileBecauseOfEnableTesting(ClassDecl *D,
-                                                            IRGenModule &IGM) {
-    if (!D)
-      return false;
-
-    return D->getModuleContext() != IGM.getSwiftModule() &&
-           !D->getFormalAccessScope(/*useDC=*/nullptr,
-                                  /*treatUsableFromInlineAsPublic=*/true)
-           .isPublic();
-}
-
 /// Do we have to use resilient access patterns when working with this
 /// declaration?
 ///
@@ -5614,10 +5603,6 @@ bool IRGenModule::isResilient(NominalTypeDecl *D,
     return false;
   }
 
-  if (shouldTreatClassAsFragileBecauseOfEnableTesting(asViewedFromRootClass,
-                                                      *this))
-    return false;
-
   return D->isResilient(getSwiftModule(), expansion);
 }
 
@@ -5633,10 +5618,6 @@ bool IRGenModule::hasResilientMetadata(ClassDecl *D,
       Types.getLoweringMode() == TypeConverter::Mode::CompletelyFragile) {
     return false;
   }
-
-  if (shouldTreatClassAsFragileBecauseOfEnableTesting(asViewedFromRootClass,
-                                                      *this))
-    return false;
 
   return D->hasResilientMetadata(getSwiftModule(), expansion);
 }

--- a/test/IRGen/Inputs/FrameworkA.swift
+++ b/test/IRGen/Inputs/FrameworkA.swift
@@ -1,0 +1,7 @@
+open class BaseThing {
+  private var _x = 1
+
+  public var x : Int { return _x }
+
+  public init() {}
+}

--- a/test/IRGen/Inputs/FrameworkB.swift
+++ b/test/IRGen/Inputs/FrameworkB.swift
@@ -1,0 +1,14 @@
+import FrameworkA
+
+final class SubThing: BaseThing {
+  var y = 2
+  var z = 3
+
+  override init() {}
+
+  func printThis() {
+    print("x \(x)")
+    print("y \(y)")
+    print("z \(z)")
+  }
+}

--- a/test/IRGen/testing-enabled-resilient-super-class-external-module.swift
+++ b/test/IRGen/testing-enabled-resilient-super-class-external-module.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(FrameworkA)) %S/Inputs/FrameworkA.swift -module-name FrameworkA -emit-module -emit-module-path %t/FrameworkA.swiftmodule -enable-library-evolution -emit-module-interface -emit-module-interface-path %t/FrameworkA.swiftinterface
+// RUN: %target-build-swift-dylib(%t/%target-library-name(FrameworkB)) %S/Inputs/FrameworkB.swift -module-name FrameworkB -emit-module -emit-module-path %t/FrameworkB.swiftmodule -enable-library-evolution -enable-testing -I %t -L %t -lFrameworkA
+// Remove the swiftmodule file of FrameworkA such that the test case only has a resilient view of this framework.
+// RUN: rm %t/FrameworkA.swiftmodule
+// RUN: %target-build-swift -I %t -L %t -lFrameworkB %s -o %t/main %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-codesign %t/%target-library-name(FrameworkA) %t/%target-library-name(FrameworkB)
+// RUN: %target-run %t/main %t/%target-library-name(FrameworkA) %t/%target-library-name(FrameworkB) | %FileCheck --check-prefix=EXEC-CHECK %s
+
+// REQUIRES: executable_test
+
+@testable import FrameworkB
+
+func runThis() {
+    var c = SubThing()
+    c.printThis()
+// EXEC-CHECK: x 1
+// EXEC-CHECK: y 2
+// EXEC-CHECK: z 3
+    print("y \(c.y)")
+// EXEC-CHECK: y 2
+}
+
+runThis()

--- a/test/IRGen/testing-enabled-resilient-super-class-external-module.swift
+++ b/test/IRGen/testing-enabled-resilient-super-class-external-module.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift-dylib(%t/%target-library-name(FrameworkA)) %S/Inputs/FrameworkA.swift -module-name FrameworkA -emit-module -emit-module-path %t/FrameworkA.swiftmodule -enable-library-evolution -emit-module-interface -emit-module-interface-path %t/FrameworkA.swiftinterface
-// RUN: %target-build-swift-dylib(%t/%target-library-name(FrameworkB)) %S/Inputs/FrameworkB.swift -module-name FrameworkB -emit-module -emit-module-path %t/FrameworkB.swiftmodule -enable-library-evolution -enable-testing -I %t -L %t -lFrameworkA
+// RUN: %target-build-swift-dylib(%t/%target-library-name(FrameworkB)) %S/Inputs/FrameworkB.swift -module-name FrameworkB -emit-module -emit-module-path %t/FrameworkB.swiftmodule -enable-library-evolution -enable-testing -I %t -L %t -lFrameworkA %target-rpath(%t)
 // Remove the swiftmodule file of FrameworkA such that the test case only has a resilient view of this framework.
 // RUN: rm %t/FrameworkA.swiftmodule
 // RUN: %target-build-swift -I %t -L %t -lFrameworkB %s -o %t/main %target-rpath(%t)

--- a/test/IRGen/testing-enabled-resilient-super-class.swift
+++ b/test/IRGen/testing-enabled-resilient-super-class.swift
@@ -15,9 +15,8 @@
 
 @testable import resilient
 
-// Don't access via the class offset global. Use a fragile access pattern instead.
-
-// CHECK-NOT: s9resilient8SubClassCMo
+// Use a resilient access pattern.
+// CHECK: s9resilient8SubClassC1yAA13TypeContainerV8SomeEnumOvgTj
 
 public func isEqual<T:Equatable>(_ l: T, _ r: T) -> Bool {
     return l == r


### PR DESCRIPTION
That does not work if there is a resilient class in the hiearchy from a different module than the testable imported one.  Rather treat an internal but testable imported class as having resilient metadata.

The scenario that does not work assuming we can build a fragile layout is the following.

FrameworkA is resilient and defines a public class `Base` with a stored field. FrameworkB is resilient and defines an internal class `Sub` that inherits from the class `Base` in FrameworkA and adds some fields. FrameworkB is compiled with enable-testing.
The test case testable imports FrameworkB and accesses a field in the internal class `Base` from FrameworkB. The test case only has access to FrameworkA's public swiftinterface file and therefore does not know `Base`'s layout.  The layout computation for `Sub` cannot take the field from `Base` into account and things fail silently.

rdar://103323275