### PR TITLE
Ensure unique names in ParameterList::clone()

### DIFF
--- a/lib/AST/Parameter.cpp
+++ b/lib/AST/Parameter.cpp
@@ -60,6 +60,7 @@ ParameterList *ParameterList::clone(const ASTContext &C,
   SmallVector<ParamDecl*, 8> params(begin(), end());
 
   // Remap the ParamDecls inside of the ParameterList.
+  unsigned i = 0;
   for (auto &decl : params) {
     auto defaultArgKind = decl->getDefaultArgumentKind();
 
@@ -69,8 +70,11 @@ ParameterList *ParameterList::clone(const ASTContext &C,
 
     // If the argument isn't named, give the parameter a name so that
     // silgen will produce a value for it.
-    if (decl->getName().empty() && (options & NamedArguments))
-      decl->setName(C.getIdentifier("argument"));
+    if (decl->getName().empty() && (options & NamedArguments)) {
+      llvm::SmallString<16> s;
+      { llvm::raw_svector_ostream(s) << "__argument" << ++i; }
+      decl->setName(C.getIdentifier(s));
+    }
     
     // If we're inheriting a default argument, mark it as such.
     // FIXME: Figure out how to clone default arguments as well.

--- a/test/ModuleInterface/inherited-generic-parameters.swift
+++ b/test/ModuleInterface/inherited-generic-parameters.swift
@@ -30,7 +30,7 @@ public class Base<In, Out> {
 public class Derived<T> : Base<T, T> {
 // CHECK-NEXT: override public init(x: @escaping (T) -> T)
 // CHECK-NEXT: override public init<A>(_ a1: A, _ a2: A)
-// CHECK-NEXT: override public init<C>(_ argument: C) where C : main.Base<T, T>
+// CHECK-NEXT: override public init<C>(_ __argument1: C) where C : main.Base<T, T>
 // CHECK-NEXT: {{(@objc )?}}deinit
 // CHECK-NEXT: }
 }


### PR DESCRIPTION
IRGenDebugInfo assumes that all argument names within the same scope are unique as it uses them as a key in a hash table.

rdar://102367872
