### PR TITLE
[Gardening] Simplify excessive conditional expression: (A && !B) || (!A && B) is equivalent to bool(A) != bool(B)

### DIFF
--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -488,24 +488,24 @@ static bool typedAccessTBAAMayAlias(SILType LTy, SILType RTy,
   // Tuples do not alias non-tuples.
   bool LTyTT = LTy.is<TupleType>();
   bool RTyTT = RTy.is<TupleType>();
-  if ((LTyTT && !RTyTT) || (!LTyTT && RTyTT))
+  if (LTyTT != RTyTT)
     return false;
 
   // Structs do not alias non-structs.
   StructDecl *LTyStruct = LTy.getStructOrBoundGenericStruct();
   StructDecl *RTyStruct = RTy.getStructOrBoundGenericStruct();
-  if ((LTyStruct && !RTyStruct) || (!LTyStruct && RTyStruct))
+  if ((LTyStruct != nullptr) != (RTyStruct != nullptr))
     return false;
 
   // Enums do not alias non-enums.
   EnumDecl *LTyEnum = LTy.getEnumOrBoundGenericEnum();
   EnumDecl *RTyEnum = RTy.getEnumOrBoundGenericEnum();
-  if ((LTyEnum && !RTyEnum) || (!LTyEnum && RTyEnum))
+  if ((LTyEnum != nullptr) != (RTyEnum != nullptr))
     return false;
 
   // Classes do not alias non-classes.
   ClassDecl *RTyClass = RTy.getClassOrBoundGenericClass();
-  if ((LTyClass && !RTyClass) || (!LTyClass && RTyClass))
+  if ((LTyClass != nullptr) != (RTyClass != nullptr))
     return false;
 
   // Classes with separate class hierarchies do not alias.


### PR DESCRIPTION
<!-- What's in this pull request? -->

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
