### PR TITLE
[Dependency Scanning] Refactor the scanner to resolve unqualified module imports

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -991,18 +991,20 @@ public:
 
   /// Retrieve the module dependencies for the module with the given name.
   ///
-  /// \param isUnderlyingClangModule When true, only look for a Clang module
-  /// with the given name, ignoring any Swift modules.
-  Optional<ModuleDependencyInfo> getModuleDependencies(
+  Optional<const ModuleDependencyInfo*> getModuleDependencies(
       StringRef moduleName,
-      bool isUnderlyingClangModule,
       ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate,
-      bool cacheOnly = false,
       llvm::Optional<std::pair<std::string, swift::ModuleDependencyKind>> dependencyOf = None);
 
+  /// Retrieve the module dependencies for the Clang module with the given name.
+  Optional<const ModuleDependencyInfo*> getClangModuleDependencies(
+      StringRef moduleName,
+      ModuleDependenciesCache &cache,
+      InterfaceSubContextDelegate &delegate);
+
   /// Retrieve the module dependencies for the Swift module with the given name.
-  Optional<ModuleDependencyInfo> getSwiftModuleDependencies(
+  Optional<const ModuleDependencyInfo*> getSwiftModuleDependencies(
       StringRef moduleName,
       ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate);

--- a/include/swift/AST/ModuleLoader.h
+++ b/include/swift/AST/ModuleLoader.h
@@ -321,7 +321,7 @@ public:
 
   /// Retrieve the dependencies for the given, named module, or \c None
   /// if no such module exists.
-  virtual Optional<ModuleDependencyInfo> getModuleDependencies(
+  virtual Optional<const ModuleDependencyInfo*> getModuleDependencies(
       StringRef moduleName,
       ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate) = 0;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -423,7 +423,7 @@ public:
       ModuleDependenciesCache &cache,
       const clang::tooling::dependencies::FullDependenciesResult &clangDependencies);
 
-  Optional<ModuleDependencyInfo> getModuleDependencies(
+  Optional<const ModuleDependencyInfo*> getModuleDependencies(
       StringRef moduleName, ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate) override;
 

--- a/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
+++ b/include/swift/DependencyScan/SerializedModuleDependencyCacheFormat.h
@@ -36,7 +36,7 @@ using llvm::BCVBR;
 
 /// Every .moddepcache file begins with these 4 bytes, for easy identification.
 const unsigned char MODULE_DEPENDENCY_CACHE_FORMAT_SIGNATURE[] = {'I', 'M', 'D','C'};
-const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MAJOR = 3;
+const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MAJOR = 4;
 /// Increment this on every change.
 const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MINOR = 0;
 
@@ -45,19 +45,21 @@ const unsigned MODULE_DEPENDENCY_CACHE_FORMAT_VERSION_MINOR = 0;
 using IdentifierIDField = BCVBR<13>;
 using FileIDField = IdentifierIDField;
 using ModuleIDField = IdentifierIDField;
-using ContextHashField = IdentifierIDField;
+using ContextHashIDField = IdentifierIDField;
 
 /// A bit that indicates whether or not a module is a framework
 using IsFrameworkField = BCFixed<1>;
 
 /// Arrays of various identifiers, distinguished for readability
 using IdentifierIDArryField = llvm::BCArray<IdentifierIDField>;
+using ModuleIDArryField = llvm::BCArray<IdentifierIDField>;
 
 /// Identifiers used to refer to the above arrays
 using FileIDArrayIDField = IdentifierIDField;
 using ContextHashIDField = IdentifierIDField;
-using DependencyIDArrayIDField = IdentifierIDField;
+using ImportArrayIDField = IdentifierIDField;
 using FlagIDArrayIDField = IdentifierIDField;
+using DependencyIDArrayIDField = IdentifierIDField;
 
 /// The ID of the top-level block containing the dependency graph
 const unsigned GRAPH_BLOCK_ID = llvm::bitc::FIRST_APPLICATION_BLOCKID;
@@ -115,34 +117,35 @@ using IdentifierArrayLayout =
 // - SwiftPlaceholderModuleDetails
 // - ClangModuleDetails
 using ModuleInfoLayout =
-    BCRecordLayout<MODULE_NODE,             // ID
-                   IdentifierIDField,       // module name
-                   ContextHashIDField,      // 
-                   DependencyIDArrayIDField // directDependencies
+    BCRecordLayout<MODULE_NODE,                  // ID
+                   IdentifierIDField,            // moduleName
+                   ContextHashIDField,           // contextHash
+                   ImportArrayIDField,           // moduleImports
+                   DependencyIDArrayIDField      // resolvedModuleDependencies
                    >;
 
 using SwiftInterfaceModuleDetailsLayout =
     BCRecordLayout<SWIFT_INTERFACE_MODULE_DETAILS_NODE, // ID
-                   FileIDField,        // outputFilePath
-                   FileIDField,        // swiftInterfaceFile
-                   FileIDArrayIDField, // compiledModuleCandidates
-                   FlagIDArrayIDField, // buildCommandLine
-                   FlagIDArrayIDField, // extraPCMArgs
-                   ContextHashField,   // contextHash
-                   IsFrameworkField,   // isFramework
-                   FileIDField,        // bridgingHeaderFile
-                   FileIDArrayIDField, // sourceFiles
-                   FileIDArrayIDField, // bridgingSourceFiles
-                   FileIDArrayIDField   // bridgingModuleDependencies
+                   FileIDField,                         // outputFilePath
+                   FileIDField,                         // swiftInterfaceFile
+                   FileIDArrayIDField,                  // compiledModuleCandidates
+                   FlagIDArrayIDField,                  // buildCommandLine
+                   FlagIDArrayIDField,                  // extraPCMArgs
+                   ContextHashIDField,                  // contextHash
+                   IsFrameworkField,                    // isFramework
+                   FileIDField,                         // bridgingHeaderFile
+                   FileIDArrayIDField,                  // sourceFiles
+                   FileIDArrayIDField,                  // bridgingSourceFiles
+                   FileIDArrayIDField                   // bridgingModuleDependencies
                    >;
 
 using SwiftSourceModuleDetailsLayout =
     BCRecordLayout<SWIFT_SOURCE_MODULE_DETAILS_NODE, // ID
-                   FlagIDArrayIDField, // extraPCMArgs
-                   FileIDField,        // bridgingHeaderFile
-                   FileIDArrayIDField, // sourceFiles
-                   FileIDArrayIDField, // bridgingSourceFiles
-                   FileIDArrayIDField  // bridgingModuleDependencies
+                   FlagIDArrayIDField,               // extraPCMArgs
+                   FileIDField,                      // bridgingHeaderFile
+                   FileIDArrayIDField,               // sourceFiles
+                   FileIDArrayIDField,               // bridgingSourceFiles
+                   FileIDArrayIDField                // bridgingModuleDependencies
                    >;
 
 using SwiftBinaryModuleDetailsLayout =
@@ -157,14 +160,14 @@ using SwiftPlaceholderModuleDetailsLayout =
     BCRecordLayout<SWIFT_PLACEHOLDER_MODULE_DETAILS_NODE, // ID
                    FileIDField,                           // compiledModulePath
                    FileIDField,                           // moduleDocPath
-                   FileIDField // moduleSourceInfoPath
+                   FileIDField                            // moduleSourceInfoPath
                    >;
 
 using ClangModuleDetailsLayout =
     BCRecordLayout<CLANG_MODULE_DETAILS_NODE, // ID
                    FileIDField,               // pcmOutputPath
                    FileIDField,               // moduleMapPath
-                   ContextHashField,          // contextHash
+                   ContextHashIDField,        // contextHash
                    FlagIDArrayIDField,        // commandLine
                    FileIDArrayIDField,        // fileDependencies
                    FlagIDArrayIDField         // capturedPCMArgs

--- a/include/swift/Sema/SourceLoader.h
+++ b/include/swift/Sema/SourceLoader.h
@@ -96,7 +96,7 @@ public:
     // Parsing populates the Objective-C method tables.
   }
 
-  Optional<ModuleDependencyInfo>
+  Optional<const ModuleDependencyInfo*>
   getModuleDependencies(StringRef moduleName, ModuleDependenciesCache &cache,
                         InterfaceSubContextDelegate &delegate) override;
 };

--- a/include/swift/Serialization/SerializedModuleLoader.h
+++ b/include/swift/Serialization/SerializedModuleLoader.h
@@ -205,7 +205,7 @@ public:
 
   virtual void verifyAllModules() override;
 
-  virtual Optional<ModuleDependencyInfo> getModuleDependencies(
+  virtual Optional<const ModuleDependencyInfo*> getModuleDependencies(
       StringRef moduleName, ModuleDependenciesCache &cache,
       InterfaceSubContextDelegate &delegate) override;
 };

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1895,18 +1895,20 @@ static void findPath_dfs(ModuleDependencyID X,
     return;
   }
   visited.insert(X);
-  auto node = cache.findDependencies(X.first, X.second);
-  assert(node.has_value() && "Expected cache value for dependency.");
-  for (const auto &dep : node->getModuleDependencies()) {
+  auto optionalNode = cache.findDependency(X.first, X.second);
+  auto node = optionalNode.getValue();
+  assert(optionalNode.has_value() && "Expected cache value for dependency.");
+  for (const auto &dep : node->getModuleImports()) {
     Optional<ModuleDependencyKind> lookupKind = None;
     // Underlying Clang module needs an explicit lookup to avoid confusing it
     // with the parent Swift module.
     if ((dep == X.first && node->isSwiftModule()) || node->isClangModule())
       lookupKind = ModuleDependencyKind::Clang;
 
-    auto depNode = cache.findDependencies(dep, lookupKind);
-    if (!depNode.has_value())
+    auto optionalDepNode = cache.findDependency(dep, lookupKind);
+    if (!optionalDepNode.has_value())
       continue;
+    auto depNode = optionalDepNode.getValue();
     auto depID = std::make_pair(dep, depNode->getKind());
     if (!visited.count(depID)) {
       findPath_dfs(depID, Y, visited, stack, result, cache);
@@ -1918,7 +1920,7 @@ static void findPath_dfs(ModuleDependencyID X,
 static std::vector<ModuleDependencyID>
 findPathToDependency(ModuleDependencyID dependency,
                      const ModuleDependenciesCache &cache) {
-  auto mainModuleDep = cache.findDependencies(cache.getMainModuleName(),
+  auto mainModuleDep = cache.findDependency(cache.getMainModuleName(),
                                               ModuleDependencyKind::SwiftSource);
   // We may be in a batch scan instance which does not have this dependency
   if (!mainModuleDep.has_value())
@@ -1948,8 +1950,9 @@ static void diagnoseScannerFailure(StringRef moduleName,
     
     for (auto it = path.rbegin(), end = path.rend(); it != end; ++it) {
       const auto &entry = *it;
-      auto entryNode = cache.findDependencies(entry.first, entry.second);
-      assert(entryNode.has_value());
+      auto optionalEntryNode = cache.findDependency(entry.first, entry.second);
+      assert(optionalEntryNode.has_value());
+      auto entryNode = optionalEntryNode.getValue();
       std::string moduleFilePath = "";
       bool isClang = false;
       switch (entryNode->getKind()) {
@@ -1981,57 +1984,79 @@ static void diagnoseScannerFailure(StringRef moduleName,
   }
 }
 
-Optional<ModuleDependencyInfo> ASTContext::getModuleDependencies(
-    StringRef moduleName, bool isUnderlyingClangModule,
-    ModuleDependenciesCache &cache, InterfaceSubContextDelegate &delegate,
-    bool cacheOnly, llvm::Optional<ModuleDependencyID> dependencyOf) {
-  auto searchPathSet = getAllModuleSearchPathsSet();
+Optional<const ModuleDependencyInfo*> ASTContext::getModuleDependencies(
+    StringRef moduleName, ModuleDependenciesCache &cache,
+    InterfaceSubContextDelegate &delegate,
+    llvm::Optional<ModuleDependencyID> dependencyOf) {
   // Retrieve the dependencies for this module.
-  if (cacheOnly) {
-    // Check whether we've cached this result.
-    if (!isUnderlyingClangModule) {
-      if (auto found = cache.findDependencies(
-              moduleName, ModuleDependencyKind::SwiftSource))
-        return found;
-      if (auto found = cache.findDependencies(
-              moduleName, ModuleDependencyKind::SwiftInterface))
-        return found;
-      if (auto found = cache.findDependencies(
-              moduleName, ModuleDependencyKind::SwiftBinary))
-        return found;
-      if (auto found = cache.findDependencies(
-              moduleName, ModuleDependencyKind::SwiftPlaceholder))
-        return found;
-    }
-    if (auto found = cache.findDependencies(
-            moduleName, ModuleDependencyKind::Clang))
-      return found;
-  } else {
-    for (auto &loader : getImpl().ModuleLoaders) {
-      if (isUnderlyingClangModule &&
-          loader.get() != getImpl().TheClangModuleLoader)
-        continue;
+  // Check whether we've cached this result.
+  if (auto found =
+      cache.findDependency(moduleName, ModuleDependencyKind::SwiftSource))
+    return found;
+  if (auto found =
+      cache.findDependency(moduleName, ModuleDependencyKind::SwiftInterface))
+    return found;
+  if (auto found =
+      cache.findDependency(moduleName, ModuleDependencyKind::SwiftBinary))
+    return found;
+  if (auto found =
+      cache.findDependency(moduleName, ModuleDependencyKind::SwiftPlaceholder))
+    return found;
+  if (auto found =
+      cache.findDependency(moduleName, ModuleDependencyKind::Clang))
+    return found;
 
-      if (auto dependencies =
-              loader->getModuleDependencies(moduleName, cache, delegate))
-        return dependencies;
-    }
-    
-    diagnoseScannerFailure(moduleName, Diags, cache,
-                           dependencyOf);
+  for (auto &loader : getImpl().ModuleLoaders) {
+    if (auto dependencies =
+        loader->getModuleDependencies(moduleName, cache, delegate))
+      return dependencies;
   }
 
+  diagnoseScannerFailure(moduleName, Diags, cache,
+                         dependencyOf);
   return None;
 }
 
-Optional<ModuleDependencyInfo>
+Optional<const ModuleDependencyInfo*>
 ASTContext::getSwiftModuleDependencies(StringRef moduleName,
                                        ModuleDependenciesCache &cache,
                                        InterfaceSubContextDelegate &delegate) {
+  // Check whether we've cached this result.
+  if (auto found =
+      cache.findDependency(moduleName, ModuleDependencyKind::SwiftSource))
+    return found;
+  if (auto found =
+      cache.findDependency(moduleName, ModuleDependencyKind::SwiftInterface))
+    return found;
+  if (auto found =
+      cache.findDependency(moduleName, ModuleDependencyKind::SwiftBinary))
+    return found;
+  if (auto found =
+      cache.findDependency(moduleName, ModuleDependencyKind::SwiftPlaceholder))
+    return found;
+
   for (auto &loader : getImpl().ModuleLoaders) {
     if (loader.get() == getImpl().TheClangModuleLoader)
       continue;
+    if (auto dependencies = loader->getModuleDependencies(moduleName, cache,
+                                                          delegate))
+      return dependencies;
+  }
+  return None;
+}
 
+Optional<const ModuleDependencyInfo*>
+ASTContext::getClangModuleDependencies(StringRef moduleName,
+                                       ModuleDependenciesCache &cache,
+                                       InterfaceSubContextDelegate &delegate) {
+  // Check whether we've cached this result.
+  if (auto found =
+      cache.findDependency(moduleName, ModuleDependencyKind::Clang))
+    return found;
+
+  for (auto &loader : getImpl().ModuleLoaders) {
+    if (loader.get() != getImpl().TheClangModuleLoader)
+      continue;
     if (auto dependencies = loader->getModuleDependencies(moduleName, cache,
                                                           delegate))
       return dependencies;

--- a/lib/AST/ModuleLoader.cpp
+++ b/lib/AST/ModuleLoader.cpp
@@ -175,7 +175,7 @@ void ModuleLoader::findOverlayFiles(SourceLoc diagLoc, ModuleDecl *module,
 
 llvm::StringMap<llvm::SmallSetVector<Identifier, 4>>
 ModuleDependencyInfo::collectCrossImportOverlayNames(ASTContext &ctx,
-                                                   StringRef moduleName) {
+                                                     StringRef moduleName) const {
   using namespace llvm::sys;
   using namespace file_types;
   Optional<std::string> modulePath;

--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/Basic/PrettyStackTrace.h"
+
 #include "swift/DependencyScan/ScanDependencies.h"
 #include "swift/DependencyScan/SerializedModuleDependencyCacheFormat.h"
 #include "swift/AST/ASTContext.h"
@@ -144,37 +146,50 @@ static void findAllImportedClangModules(ASTContext &ctx, StringRef moduleName,
   if (!knownModules.insert(moduleName).second)
     return;
   allModules.push_back(moduleName.str());
-  auto dependencies =
-    cache.findDependencies(moduleName, ModuleDependencyKind::Clang);
-  if (!dependencies)
+  auto optionalDependencies =
+    cache.findDependency(moduleName, ModuleDependencyKind::Clang);
+  if (!optionalDependencies.hasValue())
     return;
 
+  auto dependencies = optionalDependencies.getValue();
   for (const auto &dep : dependencies->getModuleDependencies()) {
-    findAllImportedClangModules(ctx, dep, cache, allModules, knownModules);
+    findAllImportedClangModules(ctx, dep.first, cache, allModules, knownModules);
   }
 }
 
 /// Resolve the direct dependencies of the given module.
-static std::vector<ModuleDependencyID>
+static ArrayRef<ModuleDependencyID>
 resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
                           ModuleDependenciesCache &cache,
-                          InterfaceSubContextDelegate &ASTDelegate,
-                          bool cacheOnly = false) {
+                          InterfaceSubContextDelegate &ASTDelegate) {
+  PrettyStackTraceStringAction trace("Resolving direct dependencies of: ", module.first);
   auto &ctx = instance.getASTContext();
-  auto knownDependencies = *cache.findDependencies(module.first, module.second);
-  auto isSwiftInterfaceOrSource = knownDependencies.isSwiftInterfaceModule() ||
-                                  knownDependencies.isSwiftSourceModule();
-  auto isSwift = isSwiftInterfaceOrSource ||
-                 knownDependencies.isSwiftBinaryModule();
+  auto optionalKnownDependencies = cache.findDependency(module.first, module.second);
+  assert(optionalKnownDependencies.hasValue());
+  auto knownDependencies = optionalKnownDependencies.getValue();
+
+  // If this dependency has already been resolved, return the result.
+  if (knownDependencies->isResolved() &&
+      knownDependencies->getKind() != ModuleDependencyKind::SwiftSource)
+    return knownDependencies->getModuleDependencies();
+
+  auto isSwiftInterfaceOrSource = knownDependencies->isSwiftInterfaceModule() ||
+                                  knownDependencies->isSwiftSourceModule();
+  auto isSwift =
+      isSwiftInterfaceOrSource || knownDependencies->isSwiftBinaryModule();
   // Find the dependencies of every module this module directly depends on.
-  std::set<ModuleDependencyID> result;
-  for (auto dependsOn : knownDependencies.getModuleDependencies()) {
+  ModuleDependencyIDSetVector result;
+  for (auto dependsOn : knownDependencies->getModuleImports()) {
     // Figure out what kind of module we need.
     bool onlyClangModule = !isSwift || module.first == dependsOn;
-    if (auto found = ctx.getModuleDependencies(dependsOn, onlyClangModule,
-                                               cache, ASTDelegate, cacheOnly,
-                                               module)) {
-      result.insert({dependsOn, found->getKind()});
+    if (onlyClangModule) {
+      if (auto found =
+              ctx.getClangModuleDependencies(dependsOn, cache, ASTDelegate))
+        result.insert({dependsOn, ModuleDependencyKind::Clang});
+    } else {
+      if (auto found =
+              ctx.getModuleDependencies(dependsOn, cache, ASTDelegate, module))
+        result.insert({dependsOn, found.getValue()->getKind()});
     }
   }
 
@@ -184,22 +199,24 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
     llvm::StringSet<> knownModules;
 
     // If the Swift module has a bridging header, add those dependencies.
-    if (knownDependencies.getBridgingHeader()) {
+    if (knownDependencies->getBridgingHeader()) {
       auto clangImporter =
           static_cast<ClangImporter *>(ctx.getClangModuleLoader());
-      if (!clangImporter->addBridgingHeaderDependencies(module.first, module.second, cache)) {
+      if (!clangImporter->addBridgingHeaderDependencies(module.first,
+                                                        module.second, cache)) {
         // Grab the updated module dependencies.
         // FIXME: This is such a hack.
-        knownDependencies =
-            *cache.findDependencies(module.first, module.second);
+        knownDependencies = *cache.findDependency(module.first, module.second);
 
         // Add the Clang modules referenced from the bridging header to the
         // set of Clang modules we know about.
         const std::vector<std::string> *bridgingModuleDependencies = nullptr;
-        if (auto swiftDeps = knownDependencies.getAsSwiftInterfaceModule())
-          bridgingModuleDependencies = &(swiftDeps->textualModuleDetails.bridgingModuleDependencies);
-        else if (auto sourceDeps = knownDependencies.getAsSwiftSourceModule())
-          bridgingModuleDependencies = &(sourceDeps->textualModuleDetails.bridgingModuleDependencies);
+        if (auto swiftDeps = knownDependencies->getAsSwiftInterfaceModule())
+          bridgingModuleDependencies =
+              &(swiftDeps->textualModuleDetails.bridgingModuleDependencies);
+        else if (auto sourceDeps = knownDependencies->getAsSwiftSourceModule())
+          bridgingModuleDependencies =
+              &(sourceDeps->textualModuleDetails.bridgingModuleDependencies);
 
         assert(bridgingModuleDependencies);
         for (const auto &clangDep : *bridgingModuleDependencies) {
@@ -221,23 +238,17 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
     // Look for overlays for each of the Clang modules. The Swift module
     // directly depends on these.
     for (const auto &clangDep : allClangModules) {
-      if (auto found = ctx.getModuleDependencies(
-              clangDep, /*onlyClangModule=*/false, cache, ASTDelegate, cacheOnly)) {
-        // ASTContext::getModuleDependencies returns dependencies for a module
-        // with a given name. This Clang module may have the same name as the
-        // Swift module we are resolving, so we need to make sure we don't add a
-        // dependency from a Swift module to itself.
-        if ((found->getKind() == ModuleDependencyKind::SwiftInterface ||
-             found->getKind() == ModuleDependencyKind::SwiftSource ||
-             found->getKind() == ModuleDependencyKind::SwiftBinary ||
-             found->getKind() == ModuleDependencyKind::SwiftPlaceholder) &&
-            clangDep != module.first) {
-          result.insert({clangDep, found->getKind()});
-        }
+      if (auto found =
+              ctx.getSwiftModuleDependencies(clangDep, cache, ASTDelegate)) {
+        if (clangDep != module.first)
+          result.insert({clangDep, found.getValue()->getKind()});
       }
     }
   }
-  return std::vector<ModuleDependencyID>(result.begin(), result.end());
+
+  // Resolve the dependnecy info
+  cache.resolveDependencyImports(module, result.takeVector());
+  return cache.findDependency(module.first, module.second).getValue()->getModuleDependencies();
 }
 
 static void discoverCrossImportOverlayDependencies(
@@ -249,9 +260,10 @@ static void discoverCrossImportOverlayDependencies(
   llvm::SetVector<Identifier> newOverlays;
   for (auto dep : allDependencies) {
     auto moduleName = dep.first;
-    auto dependencies = *cache.findDependencies(moduleName,dep.second);
+    auto dependencies = cache.findDependency(moduleName, dep.second).getValue();
+
     // Collect a map from secondary module name to cross-import overlay names.
-    auto overlayMap = dependencies.collectCrossImportOverlayNames(
+    auto overlayMap = dependencies->collectCrossImportOverlayNames(
         instance.getASTContext(), moduleName);
     if (overlayMap.empty())
       continue;
@@ -278,33 +290,24 @@ static void discoverCrossImportOverlayDependencies(
   // overlays.
   StringRef dummyMainName = "DummyMainModuleForResolvingCrossImportOverlays";
   auto dummyMainDependencies = ModuleDependencyInfo::forSwiftSourceModule({});
-
-  // Update main module's dependencies to include these new overlays.
-  auto mainDep = *cache.findDependencies(
-                  mainModuleName, ModuleDependencyKind::SwiftSource);
   std::for_each(newOverlays.begin(), newOverlays.end(),
                 [&](Identifier modName) {
-                  dummyMainDependencies.addModuleDependency(modName.str());
-                  mainDep.addModuleDependency(modName.str());
+                  dummyMainDependencies.addModuleImport(modName.str());
                 });
-  cache.updateDependencies(
-      {mainModuleName.str(), ModuleDependencyKind::SwiftSource}, mainDep);
 
   // Record the dummy main module's direct dependencies. The dummy main module
   // only directly depend on these newly discovered overlay modules.
-  if (cache.findDependencies(
+  if (cache.findDependency(
                  dummyMainName, ModuleDependencyKind::SwiftSource)) {
-    cache.updateDependencies(
+    cache.updateDependency(
         std::make_pair(dummyMainName.str(),
                        ModuleDependencyKind::SwiftSource),
         dummyMainDependencies);
   } else {
-    cache.recordDependencies(dummyMainName, dummyMainDependencies);
+    cache.recordDependency(dummyMainName, dummyMainDependencies);
   }
 
-  llvm::SetVector<ModuleDependencyID, std::vector<ModuleDependencyID>,
-                  std::set<ModuleDependencyID>>
-      allModules;
+  ModuleDependencyIDSetVector allModules;
 
   // Seed the all module list from the dummy main module.
   allModules.insert({dummyMainName.str(), dummyMainDependencies.getKind()});
@@ -313,10 +316,22 @@ static void discoverCrossImportOverlayDependencies(
   for (unsigned currentModuleIdx = 0; currentModuleIdx < allModules.size();
        ++currentModuleIdx) {
     auto module = allModules[currentModuleIdx];
-    auto discoveredModules =
+    auto moduleDependnencyIDs =
         resolveDirectDependencies(instance, module, cache, ASTDelegate);
-    allModules.insert(discoveredModules.begin(), discoveredModules.end());
+    allModules.insert(moduleDependnencyIDs.begin(), moduleDependnencyIDs.end());
   }
+
+  // Update main module's dependencies to include these new overlays.
+  auto mainDep = *(cache.findDependency(
+                   mainModuleName, ModuleDependencyKind::SwiftSource).getValue());
+  std::for_each(/* +1 to exclude dummy main*/ allModules.begin() + 1,
+                allModules.end(),
+                [&](ModuleDependencyID dependencyID) {
+                  mainDep.addModuleDependency(dependencyID);
+                });
+  cache.updateDependency(
+      {mainModuleName.str(), ModuleDependencyKind::SwiftSource}, mainDep);
+
   // Report any discovered modules to the clients, which include all overlays
   // and their dependencies.
   std::for_each(/* +1 to exclude dummy main*/ allModules.begin() + 1,
@@ -764,22 +779,6 @@ static void writeJSON(llvm::raw_ostream &out,
   }
 }
 
-static std::string createEncodedModuleKindAndName(ModuleDependencyID id) {
-  switch (id.second) {
-  case ModuleDependencyKind::SwiftInterface:
-  case ModuleDependencyKind::SwiftSource:
-    return "swiftTextual:" + id.first;
-  case ModuleDependencyKind::SwiftBinary:
-    return "swiftBinary:" + id.first;
-  case ModuleDependencyKind::SwiftPlaceholder:
-    return "swiftPlaceholder:" + id.first;
-  case ModuleDependencyKind::Clang:
-    return "clang:" + id.first;
-  default:
-    llvm_unreachable("Unhandled dependency kind.");
-  }
-}
-
 static swiftscan_dependency_graph_t
 generateFullDependencyGraph(CompilerInstance &instance,
                             ModuleDependenciesCache &cache,
@@ -798,7 +797,7 @@ generateFullDependencyGraph(CompilerInstance &instance,
   for (size_t i = 0; i < allModules.size(); ++i) {
     const auto &module = allModules[i];
     // Grab the completed module dependencies.
-    auto moduleDepsQuery = cache.findDependencies(module.first, module.second);
+    auto moduleDepsQuery = cache.findDependency(module.first, module.second);
     if (!moduleDepsQuery) {
       llvm::report_fatal_error(Twine("Module Dependency Cache missing module") +
                                module.first);
@@ -806,15 +805,15 @@ generateFullDependencyGraph(CompilerInstance &instance,
 
     auto moduleDeps = *moduleDepsQuery;
     // Collect all the required pieces to build a ModuleInfo
-    auto swiftPlaceholderDeps = moduleDeps.getAsPlaceholderDependencyModule();
-    auto swiftTextualDeps = moduleDeps.getAsSwiftInterfaceModule();
-    auto swiftSourceDeps = moduleDeps.getAsSwiftSourceModule();
-    auto swiftBinaryDeps = moduleDeps.getAsSwiftBinaryModule();
-    auto clangDeps = moduleDeps.getAsClangModule();
+    auto swiftPlaceholderDeps = moduleDeps->getAsPlaceholderDependencyModule();
+    auto swiftTextualDeps = moduleDeps->getAsSwiftInterfaceModule();
+    auto swiftSourceDeps = moduleDeps->getAsSwiftSourceModule();
+    auto swiftBinaryDeps = moduleDeps->getAsSwiftBinaryModule();
+    auto clangDeps = moduleDeps->getAsClangModule();
 
     // ModulePath
     const char *modulePathSuffix =
-        moduleDeps.isSwiftModule() ? ".swiftmodule" : ".pcm";
+        moduleDeps->isSwiftModule() ? ".swiftmodule" : ".pcm";
     std::string modulePath;
     if (swiftTextualDeps)
       modulePath = swiftTextualDeps->moduleOutputPath;
@@ -835,10 +834,10 @@ generateFullDependencyGraph(CompilerInstance &instance,
       sourceFiles = clangDeps->fileDependencies;
     }
 
-    // DirectDependencies
-    auto directDependencies = resolveDirectDependencies(
-        instance, ModuleDependencyID(module.first, module.second), cache,
-        ASTDelegate, /*cacheOnly*/ true);
+    auto optionalDepInfo = cache.findDependency(module.first, module.second);
+    assert(optionalDepInfo.hasValue() && "Missing dependency info during graph generation diagnosis.");
+    auto depInfo = optionalDepInfo.getValue();
+    auto directDependencies = depInfo->getModuleDependencies();
 
     // Generate a swiftscan_clang_details_t object based on the dependency kind
     auto getModuleDetails = [&]() -> swiftscan_module_details_t {
@@ -959,19 +958,19 @@ static bool diagnoseCycle(CompilerInstance &instance,
                           ModuleDependenciesCache &cache,
                           ModuleDependencyID mainId,
                           InterfaceSubContextDelegate &astDelegate) {
-  llvm::SetVector<ModuleDependencyID, std::vector<ModuleDependencyID>,
-                  std::set<ModuleDependencyID>>
-      openSet;
-  llvm::SetVector<ModuleDependencyID, std::vector<ModuleDependencyID>,
-                  std::set<ModuleDependencyID>>
-      closeSet;
+  ModuleDependencyIDSetVector openSet;
+  ModuleDependencyIDSetVector closeSet;
   // Start from the main module.
   openSet.insert(mainId);
   while (!openSet.empty()) {
     auto &lastOpen = openSet.back();
     auto beforeSize = openSet.size();
-    for (auto dep :
-         resolveDirectDependencies(instance, lastOpen, cache, astDelegate, /*cacheOnly*/ true)) {
+
+    auto optionalDepInfo = cache.findDependency(lastOpen.first, lastOpen.second);
+    assert(optionalDepInfo.hasValue() && "Missing dependency info during cycle diagnosis.");
+    auto depInfo = optionalDepInfo.getValue();
+
+    for (const auto &dep : depInfo->getModuleDependencies()) {
       if (closeSet.count(dep))
         continue;
       if (openSet.insert(dep)) {
@@ -1155,7 +1154,7 @@ identifyMainModuleDependencies(CompilerInstance &instance) {
       if (!sf)
         continue;
 
-      mainDependencies.addModuleDependencies(*sf, alreadyAddedModules);
+      mainDependencies.addModuleImport(*sf, alreadyAddedModules);
     }
 
     const auto &importInfo = mainModule->getImplicitImportInfo();
@@ -1167,19 +1166,19 @@ identifyMainModuleDependencies(CompilerInstance &instance) {
       break;
 
     case ImplicitStdlibKind::Stdlib:
-      mainDependencies.addModuleDependency("Swift", &alreadyAddedModules);
+      mainDependencies.addModuleImport("Swift", &alreadyAddedModules);
       break;
     }
 
     // Add any implicit module names.
     for (const auto &import : importInfo.AdditionalUnloadedImports) {
-      mainDependencies.addModuleDependency(import.module.getModulePath(),
+      mainDependencies.addModuleImport(import.module.getModulePath(),
                                            &alreadyAddedModules);
     }
 
     // Already-loaded, implicitly imported module names.
     for (const auto &import : importInfo.AdditionalImports) {
-      mainDependencies.addModuleDependency(
+      mainDependencies.addModuleImport(
           import.module.importedModule->getNameStr(), &alreadyAddedModules);
     }
 
@@ -1191,7 +1190,7 @@ identifyMainModuleDependencies(CompilerInstance &instance) {
     // If we are to import the underlying Clang module of the same name,
     // add a dependency with the same name to trigger the search.
     if (importInfo.ShouldImportUnderlyingModule) {
-      mainDependencies.addModuleDependency(mainModule->getName().str(),
+      mainDependencies.addModuleImport(mainModule->getName().str(),
                                            &alreadyAddedModules);
     }
   }
@@ -1382,6 +1381,22 @@ bool swift::dependencies::batchPrescanDependencies(
   return false;
 }
 
+std::string swift::dependencies::createEncodedModuleKindAndName(ModuleDependencyID id) {
+  switch (id.second) {
+  case ModuleDependencyKind::SwiftInterface:
+  case ModuleDependencyKind::SwiftSource:
+    return "swiftTextual:" + id.first;
+  case ModuleDependencyKind::SwiftBinary:
+    return "swiftBinary:" + id.first;
+  case ModuleDependencyKind::SwiftPlaceholder:
+    return "swiftPlaceholder:" + id.first;
+  case ModuleDependencyKind::Clang:
+    return "clang:" + id.first;
+  default:
+    llvm_unreachable("Unhandled dependency kind.");
+  }
+}
+
 llvm::ErrorOr<swiftscan_dependency_graph_t>
 swift::dependencies::performModuleScan(CompilerInstance &instance,
                                        ModuleDependenciesCache &cache) {
@@ -1392,21 +1407,21 @@ swift::dependencies::performModuleScan(CompilerInstance &instance,
 
   // Add the main module.
   StringRef mainModuleName = mainModule->getNameStr();
-  llvm::SetVector<ModuleDependencyID, std::vector<ModuleDependencyID>,
-                  std::set<ModuleDependencyID>> allModules;
+  auto mainModuleID = ModuleDependencyID{mainModuleName.str(), mainDependencies.getKind()};
 
-  allModules.insert({mainModuleName.str(), mainDependencies.getKind()});
+  ModuleDependencyIDSetVector allModules;
+  allModules.insert(mainModuleID);
 
   // We may be re-using an instance of the cache which already contains
   // an entry for this module.
-  if (cache.findDependencies(
+  if (cache.findDependency(
                 mainModuleName, ModuleDependencyKind::SwiftSource)) {
-    cache.updateDependencies(
+    cache.updateDependency(
         std::make_pair(mainModuleName.str(),
                        ModuleDependencyKind::SwiftSource),
         std::move(mainDependencies));
   } else {
-    cache.recordDependencies(mainModuleName, std::move(mainDependencies));
+    cache.recordDependency(mainModuleName, std::move(mainDependencies));
   }
 
   auto ModuleCachePath = getModuleCachePathFromClang(
@@ -1438,29 +1453,40 @@ swift::dependencies::performModuleScan(CompilerInstance &instance,
       /*All transitive dependencies*/ allModules.getArrayRef().slice(1), cache,
       ASTDelegate, [&](ModuleDependencyID id) { allModules.insert(id); });
 
+#ifndef NDEBUG
+  // Verify that all collected dependencies have had their
+  // imports resolved to module IDs
+  for (const auto &moduleID : allModules) {
+    const auto &moduleInfo = cache.findDependency(moduleID.first, moduleID.second).getValue();
+    assert(moduleInfo->isResolved());
+  }
+#endif
+
   // Diagnose cycle in dependency graph.
-  if (diagnoseCycle(instance, cache, /*MainModule*/ allModules.front(),
-                    ASTDelegate))
+  if (diagnoseCycle(instance, cache, mainModuleID, ASTDelegate))
     return std::make_error_code(std::errc::not_supported);
 
   auto dependencyGraph = generateFullDependencyGraph(
-      instance, cache, ASTDelegate,
-      allModules.getArrayRef());
+      instance, cache, ASTDelegate, allModules.getArrayRef());
   // Update the dependency tracker.
   if (auto depTracker = instance.getDependencyTracker()) {
     for (auto module : allModules) {
-      auto deps = cache.findDependencies(module.first, module.second);
-      if (!deps)
+      auto optionalDeps = cache.findDependency(module.first, module.second);
+      if (!optionalDeps.hasValue())
         continue;
+      auto deps = optionalDeps.getValue();
 
       if (auto swiftDeps = deps->getAsSwiftInterfaceModule()) {
-        depTracker->addDependency(swiftDeps->swiftInterfaceFile, /*IsSystem=*/false);
-        for (const auto &bridgingSourceFile : swiftDeps->textualModuleDetails.bridgingSourceFiles)
+        depTracker->addDependency(swiftDeps->swiftInterfaceFile,
+                                  /*IsSystem=*/false);
+        for (const auto &bridgingSourceFile :
+             swiftDeps->textualModuleDetails.bridgingSourceFiles)
           depTracker->addDependency(bridgingSourceFile, /*IsSystem=*/false);
       } else if (auto swiftSourceDeps = deps->getAsSwiftSourceModule()) {
         for (const auto &sourceFile : swiftSourceDeps->sourceFiles)
           depTracker->addDependency(sourceFile, /*IsSystem=*/false);
-        for (const auto &bridgingSourceFile : swiftSourceDeps->textualModuleDetails.bridgingSourceFiles)
+        for (const auto &bridgingSourceFile :
+             swiftSourceDeps->textualModuleDetails.bridgingSourceFiles)
           depTracker->addDependency(bridgingSourceFile, /*IsSystem=*/false);
       } else if (auto clangDeps = deps->getAsClangModule()) {
         if (!clangDeps->moduleMapFile.empty())
@@ -1480,7 +1506,7 @@ swift::dependencies::performModulePrescan(CompilerInstance &instance) {
   // Execute import prescan, and write JSON output to the output stream
   auto mainDependencies = identifyMainModuleDependencies(instance);
   auto *importSet = new swiftscan_import_set_s;
-  importSet->imports = create_set(mainDependencies.getModuleDependencies());
+  importSet->imports = create_set(mainDependencies.getModuleImports());
   return importSet;
 }
 
@@ -1507,9 +1533,7 @@ swift::dependencies::performBatchModuleScan(
         auto ModuleCachePath = getModuleCachePathFromClang(
             ctx.getClangModuleLoader()->getClangInstance());
 
-        llvm::SetVector<ModuleDependencyID, std::vector<ModuleDependencyID>,
-                        std::set<ModuleDependencyID>>
-            allModules;
+        ModuleDependencyIDSetVector allModules;
         InterfaceSubContextDelegateImpl ASTDelegate(
             ctx.SourceMgr, &ctx.Diags, ctx.SearchPathOpts, ctx.LangOpts,
             ctx.ClangImporterOpts, LoaderOpts,
@@ -1519,19 +1543,19 @@ swift::dependencies::performBatchModuleScan(
             FEOpts.SerializeModuleInterfaceDependencyHashes,
             FEOpts.shouldTrackSystemDependencies(),
             RequireOSSAModules_t(instance.getSILOptions()));
-        Optional<ModuleDependencyInfo> rootDeps;
+        Optional<const ModuleDependencyInfo*> rootDeps;
         if (isClang) {
           // Loading the clang module using Clang importer.
           // This action will populate the cache with the main module's
           // dependencies.
-          rootDeps = ctx.getModuleDependencies(moduleName, /*IsClang*/ true,
-                                               cache, ASTDelegate);
+          rootDeps =
+              ctx.getClangModuleDependencies(moduleName, cache, ASTDelegate);
         } else {
           // Loading the swift module's dependencies.
           rootDeps =
               ctx.getSwiftModuleDependencies(moduleName, cache, ASTDelegate);
         }
-        if (!rootDeps.has_value()) {
+        if (!rootDeps.hasValue()) {
           // We cannot find the clang module, abort.
           batchScanResult.push_back(
               std::make_error_code(std::errc::invalid_argument));
@@ -1577,9 +1601,7 @@ swift::dependencies::performBatchModulePrescan(
         ModuleInterfaceLoaderOptions LoaderOpts(FEOpts);
         auto ModuleCachePath = getModuleCachePathFromClang(
             ctx.getClangModuleLoader()->getClangInstance());
-        llvm::SetVector<ModuleDependencyID, std::vector<ModuleDependencyID>,
-                        std::set<ModuleDependencyID>>
-            allModules;
+        ModuleDependencyIDSetVector allModules;
         InterfaceSubContextDelegateImpl ASTDelegate(
             ctx.SourceMgr, &ctx.Diags, ctx.SearchPathOpts, ctx.LangOpts,
             ctx.ClangImporterOpts, LoaderOpts,
@@ -1589,13 +1611,13 @@ swift::dependencies::performBatchModulePrescan(
             FEOpts.SerializeModuleInterfaceDependencyHashes,
             FEOpts.shouldTrackSystemDependencies(),
             RequireOSSAModules_t(instance.getSILOptions()));
-        Optional<ModuleDependencyInfo> rootDeps;
+        Optional<const ModuleDependencyInfo*> rootDeps;
         if (isClang) {
           // Loading the clang module using Clang importer.
           // This action will populate the cache with the main module's
           // dependencies.
-          rootDeps = ctx.getModuleDependencies(moduleName, /*IsClang*/
-                                               true, cache, ASTDelegate);
+          rootDeps =
+              ctx.getClangModuleDependencies(moduleName, cache, ASTDelegate);
         } else {
           // Loading the swift module's dependencies.
           rootDeps =
@@ -1609,7 +1631,7 @@ swift::dependencies::performBatchModulePrescan(
         }
 
         auto *importSet = new swiftscan_import_set_s;
-        importSet->imports = create_set(rootDeps->getModuleDependencies());
+        importSet->imports = create_set(rootDeps.getValue()->getModuleImports());
         batchPrescanResult.push_back(importSet);
       });
 

--- a/lib/Sema/SourceLoader.cpp
+++ b/lib/Sema/SourceLoader.cpp
@@ -152,7 +152,7 @@ void SourceLoader::loadExtensions(NominalTypeDecl *nominal,
   // nothing to do here.
 }
 
-Optional<ModuleDependencyInfo>
+Optional<const ModuleDependencyInfo*>
 SourceLoader::getModuleDependencies(StringRef moduleName,
                                     ModuleDependenciesCache &cache,
                                     InterfaceSubContextDelegate &delegate) {

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -427,7 +427,7 @@ llvm::ErrorOr<ModuleDependencyInfo> SerializedModuleLoaderBase::scanModuleFile(
     if (dotPos != std::string::npos)
       moduleName = moduleName.slice(0, dotPos);
 
-    dependencies.addModuleDependency(moduleName, &addedModuleNames);
+    dependencies.addModuleImport(moduleName, &addedModuleNames);
   }
 
   return std::move(dependencies);

--- a/test/ScanDependencies/can_import_placeholder.swift
+++ b/test/ScanDependencies/can_import_placeholder.swift
@@ -32,21 +32,10 @@ import SomeExternalModule
 
 // CHECK: directDependencies
 // CHECK-NEXT: {
-// CHECK-NEXT: "swift": "F"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swiftPlaceholder": "SomeExternalModule"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "Swift"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "SwiftOnoneSupport"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "_Concurrency"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "_StringProcessing"
-// CHECK-NEXT: }
-// CHECK-NEXT: ],
+// CHECK-DAG: "swift": "F"
+// CHECK-DAG: "swiftPlaceholder": "SomeExternalModule"
+// CHECK-DAG: "swift": "Swift"
+// CHECK-DAG: "swift": "SwiftOnoneSupport"
+// CHECK-DAG: "swift": "_Concurrency"
+// CHECK-DAG: "swift": "_StringProcessing"
+// CHECK: ],

--- a/test/ScanDependencies/module_deps.swift
+++ b/test/ScanDependencies/module_deps.swift
@@ -45,37 +45,17 @@ import SubE
 // CHECK-NEXT: module_deps.swift
 // CHECK-NEXT: ],
 // CHECK-NEXT: "directDependencies": [
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "A"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "clang": "C"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "E"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "F"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "G"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "SubE"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "Swift"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "SwiftOnoneSupport"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "_Concurrency"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "_cross_import_E"
-// CHECK-NEXT:   }
-// CHECK-NEXT: ],
+// CHECK-DAG:     "swift": "A"
+// CHECK-DAG:     "clang": "C"
+// CHECK-DAG:     "swift": "E"
+// CHECK-DAG:     "swift": "F"
+// CHECK-DAG:     "swift": "G"
+// CHECK-DAG:     "swift": "SubE"
+// CHECK-DAG:     "swift": "Swift"
+// CHECK-DAG:     "swift": "SwiftOnoneSupport"
+// CHECK-DAG:     "swift": "_Concurrency"
+// CHECK-DAG:     "swift": "_cross_import_E"
+// CHECK: ],
 
 // CHECK:      "extraPcmArgs": [
 // CHECK-NEXT:    "-Xcc",
@@ -100,10 +80,8 @@ import SubE
 
 // CHECK: directDependencies
 // CHECK-NEXT: {
-// CHECK-NEXT:   "clang": "A"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "Swift"
+// CHECK-DAG:   "clang": "A"
+// CHECK-DAG:   "swift": "Swift"
 // CHECK-NEXT: },
 
 /// --------Clang module C
@@ -159,13 +137,9 @@ import SubE
 // CHECK-NEXT: ],
 // CHECK-NEXT: "directDependencies": [
 // CHECK-NEXT:   {
-// CHECK-NEXT:     "clang": "F"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "Swift"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "SwiftOnoneSupport"
+// CHECK-DAG:     "clang": "F"
+// CHECK-DAG:     "swift": "Swift"
+// CHECK-DAG:     "swift": "SwiftOnoneSupport"
 // CHECK-NEXT:   }
 // CHECK-NEXT: ],
 
@@ -173,15 +147,10 @@ import SubE
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}G-{{.*}}.swiftmodule"
 // CHECK: "directDependencies"
 // CHECK-NEXT: {
-// CHECK-NEXT:   "clang": "G"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "Swift"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "SwiftOnoneSupport"
-// CHECK-NEXT: }
-// CHECK-NEXT: ],
+// CHECK-DAG:   "clang": "G"
+// CHECK-DAG:   "swift": "Swift"
+// CHECK-DAG:   "swift": "SwiftOnoneSupport"
+// CHECK: ],
 // CHECK-NEXT: "details": {
 
 // CHECK: "contextHash": "{{.*}}",

--- a/test/ScanDependencies/module_deps_cache_reuse.swift
+++ b/test/ScanDependencies/module_deps_cache_reuse.swift
@@ -30,39 +30,18 @@ import SubE
 // CHECK-NEXT: ],
 // CHECK-NEXT: "directDependencies": [
 // CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "A"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "clang": "C"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "E"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "F"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "G"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "SubE"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "Swift"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "SwiftOnoneSupport"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "_Concurrency"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "_StringProcessing"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "_cross_import_E"
-// CHECK-NEXT:   }
-// CHECK-NEXT: ],
+// CHECK-DAG:     "swift": "A"
+// CHECK-DAG:     "clang": "C"
+// CHECK-DAG:     "swift": "E"
+// CHECK-DAG:     "swift": "F"
+// CHECK-DAG:     "swift": "G"
+// CHECK-DAG:     "swift": "SubE"
+// CHECK-DAG:     "swift": "Swift"
+// CHECK-DAG:     "swift": "SwiftOnoneSupport"
+// CHECK-DAG:     "swift": "_Concurrency"
+// CHECK-DAG:     "swift": "_StringProcessing"
+// CHECK-DAG:     "swift": "_cross_import_E"
+// CHECK: ],
 
 // CHECK:      "extraPcmArgs": [
 // CHECK-NEXT:    "-Xcc",
@@ -81,17 +60,6 @@ import SubE
 // CHECK: "moduleDependencies": [
 // CHECK-NEXT: "F"
 // CHECK-NEXT: ]
-
-/// --------Swift module A
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
-
-// CHECK: directDependencies
-// CHECK-NEXT: {
-// CHECK-NEXT:   "clang": "A"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "Swift"
-// CHECK-NEXT: },
 
 /// --------Clang module C
 // CHECK-LABEL: "modulePath": "{{.*}}/C-{{.*}}.pcm",
@@ -128,35 +96,14 @@ import SubE
 // CHECK: "moduleInterfacePath"
 // CHECK-SAME: E.swiftinterface
 
-/// --------Swift module F
-// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.swiftmodule",
-// CHECK-NEXT: "sourceFiles": [
-// CHECK-NEXT: ],
-// CHECK-NEXT: "directDependencies": [
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "clang": "F"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "Swift"
-// CHECK-NEXT:   },
-// CHECK-NEXT:   {
-// CHECK-NEXT:     "swift": "SwiftOnoneSupport"
-// CHECK-NEXT:   }
-// CHECK-NEXT: ],
-
 /// --------Swift module G
 // CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}G-{{.*}}.swiftmodule"
 // CHECK: "directDependencies"
 // CHECK-NEXT: {
-// CHECK-NEXT:   "clang": "G"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "Swift"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "SwiftOnoneSupport"
-// CHECK-NEXT: }
-// CHECK-NEXT: ],
+// CHECK-DAG:   "clang": "G"
+// CHECK-DAG:   "swift": "Swift"
+// CHECK-DAG:   "swift": "SwiftOnoneSupport"
+// CHECK: ],
 // CHECK-NEXT: "details": {
 
 // CHECK: "contextHash": "{{.*}}",
@@ -180,6 +127,25 @@ import SubE
 // CHECK-NEXT: {
 // CHECK-NEXT: "clang": "SwiftShims"
 
+/// --------Swift module F
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.swiftmodule",
+// CHECK-NEXT: "sourceFiles": [
+// CHECK-NEXT: ],
+// CHECK-NEXT: "directDependencies": [
+// CHECK-NEXT:   {
+// CHECK-DAG:     "clang": "F"
+// CHECK-DAG:     "swift": "Swift"
+// CHECK-DAG:     "swift": "SwiftOnoneSupport"
+// CHECK: ],
+
+/// --------Swift module A
+// CHECK-LABEL: "modulePath": "{{.*}}{{/|\\}}A-{{.*}}.swiftmodule",
+
+// CHECK: directDependencies
+// CHECK-NEXT: {
+// CHECK-DAG:   "clang": "A"
+// CHECK-DAG:   "swift": "Swift"
+
 /// --------Clang module B
 // CHECK-LABEL: "modulePath": "{{.*}}/B-{{.*}}.pcm",
 
@@ -194,3 +160,4 @@ import SubE
 
 /// --------Clang module SwiftShims
 // CHECK-LABEL: "modulePath": "{{.*}}/SwiftShims-{{.*}}.pcm",
+

--- a/test/ScanDependencies/module_deps_cross_import_overlay.swift
+++ b/test/ScanDependencies/module_deps_cross_import_overlay.swift
@@ -15,28 +15,12 @@ import EWrapper
 import SubEWrapper
 
 // CHECK:  "directDependencies": [
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "EWrapper"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "F"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "SubEWrapper"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "Swift"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "SwiftOnoneSupport"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "_Concurrency"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "_StringProcessing"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT:   "swift": "_cross_import_E"
-// CHECK-NEXT: }
-// CHECK-NEXT: ],
+// CHECK-DAG:   "swift": "EWrapper"
+// CHECK-DAG:   "swift": "F"
+// CHECK-DAG:   "swift": "SubEWrapper"
+// CHECK-DAG:   "swift": "Swift"
+// CHECK-DAG:   "swift": "SwiftOnoneSupport"
+// CHECK-DAG:   "swift": "_Concurrency"
+// CHECK-DAG:   "swift": "_StringProcessing"
+// CHECK-DAG:   "swift": "_cross_import_E"
+// CHECK: ],

--- a/test/ScanDependencies/module_deps_different_paths_no_reuse.swift
+++ b/test/ScanDependencies/module_deps_different_paths_no_reuse.swift
@@ -21,15 +21,10 @@ import A
 // CHECK-INITIAL-SCAN-NEXT:      ],
 // CHECK-INITIAL-SCAN-NEXT:      "directDependencies": [
 // CHECK-INITIAL-SCAN-NEXT:        {
-// CHECK-INITIAL-SCAN-NEXT:          "clang": "A"
-// CHECK-INITIAL-SCAN-NEXT:        },
-// CHECK-INITIAL-SCAN-NEXT:        {
-// CHECK-INITIAL-SCAN-NEXT:          "swift": "Swift"
-// CHECK-INITIAL-SCAN-NEXT:        },
-// CHECK-INITIAL-SCAN-NEXT:        {
-// CHECK-INITIAL-SCAN-NEXT:          "swift": "SwiftOnoneSupport"
-// CHECK-INITIAL-SCAN-NEXT:        }
-// CHECK-INITIAL-SCAN-NEXT:      ],
+// CHECK-INITIAL-SCAN-DAG:          "clang": "A"
+// CHECK-INITIAL-SCAN-DAG:          "swift": "Swift"
+// CHECK-INITIAL-SCAN-DAG:          "swift": "SwiftOnoneSupport"
+// CHECK-INITIAL-SCAN:      ],
 // CHECK-INITIAL-SCAN-NEXT:      "details": {
 // CHECK-INITIAL-SCAN-NEXT:        "swift": {
 // CHECK-INITIAL-SCAN-NEXT:          "moduleInterfacePath": "{{.*}}/Swift/A.swiftinterface",
@@ -39,12 +34,9 @@ import A
 // CHECK-DIFFERENT-NEXT:      ],
 // CHECK-DIFFERENT-NEXT:      "directDependencies": [
 // CHECK-DIFFERENT-NEXT:        {
-// CHECK-DIFFERENT-NEXT:          "swift": "Swift"
-// CHECK-DIFFERENT-NEXT:        },
-// CHECK-DIFFERENT-NEXT:        {
-// CHECK-DIFFERENT-NEXT:          "swift": "SwiftOnoneSupport"
-// CHECK-DIFFERENT-NEXT:        }
-// CHECK-DIFFERENT-NEXT:      ],
+// CHECK-DIFFERENT-DAG:          "swift": "Swift"
+// CHECK-DIFFERENT-DAG:          "swift": "SwiftOnoneSupport"
+// CHECK-DIFFERENT:      ],
 // CHECK-DIFFERENT-NEXT:      "details": {
 // CHECK-DIFFERENT-NEXT:        "swift": {
 // CHECK-DIFFERENT-NEXT:          "moduleInterfacePath": "{{.*}}/SwiftDifferent/A.swiftinterface",

--- a/test/ScanDependencies/module_deps_external.swift
+++ b/test/ScanDependencies/module_deps_external.swift
@@ -44,24 +44,13 @@ import SomeExternalModule
 
 // CHECK: directDependencies
 // CHECK-NEXT: {
-// CHECK-NEXT: "swift": "F"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swiftPlaceholder": "SomeExternalModule"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "Swift"
-// CHECK-NEXT: }
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "SwiftOnoneSupport"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "_Concurrency"
-// CHECK-NEXT: },
-// CHECK-NEXT: {
-// CHECK-NEXT: "swift": "_StringProcessing"
-// CHECK-NEXT: }
-// CHECK-NEXT: ],
+// CHECK-DAG: "swift": "F"
+// CHECK-DAG: "swiftPlaceholder": "SomeExternalModule"
+// CHECK-DAG: "swift": "Swift"
+// CHECK-DAG: "swift": "SwiftOnoneSupport"
+// CHECK-DAG: "swift": "_Concurrency"
+// CHECK-DAG: "swift": "_StringProcessing"
+// CHECK: ],
 
 // CHECK:      "extraPcmArgs": [
 // CHECK-NEXT:    "-Xcc",


### PR DESCRIPTION
Apologies for the size of this PR, the changes here are somewhat-intertwined refactoring of how the scanner works overall.

This patch changes the scanner's behavior to "resolve" a discovered module's dependencies to a set of Module IDs: module name + module kind (swift textual, swift binary, clang, etc.).

The `ModuleDependencyInfo` objects that are stored in the dependency scanner's cache now carry a set of kind-qualified ModuleIDs for their dependencies, in addition to unqualified imported module names of their dependencies.

Previously, the scanner's internal state would cache a module dependnecy as having its own set of dependencies which were stored as names of imported modules. This led to a design where any time we needed to process the dependency downstream from its discovery (e.g. cycle detection, graph construction), we had to query the `ASTContext` to resolve this dependency's imports to what kind of module they are (`Swift`, `Clang`, etc), which shouldn't be necessary. Now, upon discovery, we "resolve" a discovered dependency by executing a lookup for each of its imported module names (this operation happens regardless of this patch) and store a fully-resolved set of dependencies in the dependency module info.

Moreover, looking up a given module dependency by name (via `ASTContext`'s `getModuleDependencies`)(either for the first time, or to qualify its kind later) would result in iterating over the scanner's module "loaders" and querying each for the module name. The corresponding modules would then check the scanner's cache for a respective discovered module, and if no such module is found the "loader" would search the filesystem.

This meant that in practice, we searched the filesystem on many occasions where we actually had cached the required dependency, as follows:
Suppose we had previously discovered a Clang module `foo` and cached its dependency info.
-> `ASTContext.getModuleDependencies("foo")`
---> (1) Swift Module "Loader" checks caches for a Swift module `foo` and doesn't find one, so it searches the filesystem for `foo` and fails to find one there also.
---> (2) Clang Module "Loader" checks caches for a Clang module `foo`, finds one and returns it to the client.

This means that we were always searching the filesystem in (1) even if we knew all the information required to deem that to be futile.
With this change, queries to `ASTContext`'s `getModuleDependencies` will always check all the caches first, and only delegate to the scanner "loaders" if no cached dependency is found. The loaders are then no longer in the business of checking the cached contents.

To handle cases in the scanner where we must only lookup either a Swift-only module or a Clang-only module, this patch splits `getModuleDependencies` into an already-existing `getSwiftModuleDependencies` and a newly-added `getClangModuleDependencies`. 

Note, in expectation this change does not alter the scanner's functionality. The test changes here are mostly to make the tests more resilient to the ordering in which dependency information is emitted. 