### PR TITLE
[CSSyntacticElement] Replace global flag check with info from the solver

### DIFF
--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2111,11 +2111,9 @@ SolutionApplicationToFunctionResult ConstraintSystem::applySolution(
   if (auto transform = solution.getAppliedBuilderTransform(fn)) {
     NullablePtr<BraceStmt> newBody;
 
-    if (Context.LangOpts.hasFeature(Feature::ResultBuilderASTTransform)) {
-      BraceStmt *transformedBody =
-          const_cast<BraceStmt *>(transform->transformedBody.get());
-
-      fn.setParsedBody(transformedBody, /*singleExpression=*/false);
+    if (auto transformedBody = transform->transformedBody) {
+      fn.setParsedBody(const_cast<BraceStmt *>(transformedBody.get()),
+                       /*singleExpression=*/false);
 
       ResultBuilderRewriter rewriter(solution, fn, *transform, rewriteTarget);
 


### PR DESCRIPTION
`transformedBody` is available only if the flag is set, so there is no reason to double-check it before application, the presence of the transformed body is evidence enough.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
