### PR TITLE
Make std::string conform to CustomDebugStringConvertible

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -25,6 +25,12 @@ extension std.string: ExpressibleByStringLiteral {
   }
 }
 
+extension std.string: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    return "std.string(\(String(cxxString: self)))"
+  }
+}
+
 extension String {
   public init(cxxString: std.string) {
     let buffer = UnsafeBufferPointer<CChar>(

--- a/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
+++ b/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
@@ -37,6 +37,21 @@ StdStringOverlayTestSuite.test("std::string <=> Swift.String") {
   expectEqual(swift6, "xyz\0abc")
 }
 
+StdStringOverlayTestSuite.test("std::string as Swift.CustomDebugStringConvertible") {
+  let cxx1 = std.string()
+  expectEqual(cxx1.debugDescription, "std.string()")
+
+  let cxx2 = std.string("something123")
+  expectEqual(cxx2.debugDescription, "std.string(something123)")
+
+  let bytes: [UInt8] = [0xE1, 0xC1, 0xAC]
+  var cxx3 = std.string()
+  for byte in bytes {
+    cxx3.push_back(CChar(bitPattern: byte))
+  }
+  expectEqual(cxx3.debugDescription, "std.string(���)")
+}
+
 StdStringOverlayTestSuite.test("std::string as Swift.Sequence") {
   let cxx1 = std.string()
   var iterated = false


### PR DESCRIPTION
<!-- What's in this pull request? -->
It'd be useful for `std::string` to conform to `CustomDebugStringConvertible` to see a human readable representation of `std::string` in the debugger.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #62678

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
