### PR TITLE
[SILGen/DI] TypeWrapper: Few improvements to synthesis in user-defined initializers

### DIFF
--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1115,6 +1115,14 @@ public:
       if (auto *normal = dyn_cast<NormalProtocolConformance>(conformance))
         SGM.getWitnessTable(normal);
     }
+
+    // Emit `init(for:storage)` initializer as it would be used
+    // by DI and IRGen later on.
+    if (auto typeWrapperInfo = theType->getTypeWrapper()) {
+      auto *ctor = typeWrapperInfo->Wrapper->getTypeWrapperInitializer();
+      assert(ctor);
+      (void)SGM.getFunction(SILDeclRef(ctor), NotForDefinition);
+    }
   }
 
   //===--------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1315,15 +1315,24 @@ void LifetimeChecker::injectTypeWrapperStorageInitalization() {
         wrapperInitArgs.push_back(storageObj);
         wrapperInitArgs.push_back(typeWrapperType);
 
-        // <wrapper-var> = <TypeWrapper>.init(storage: tmpStorage)
-        auto wrapperInitResult = b.createApply(
-            loc, typeWrapperInitRef,
-            SubstitutionMap::get(typeWrapperInit->getGenericSignature(),
-                                 /*substitutions=*/
-                                 {wrappedType->getMetatypeInstanceType(),
-                                  storageType.getASTType()},
-                                 /*conformances=*/{}),
-            wrapperInitArgs);
+        TypeSubstitutionMap wrapperInitSubs;
+        {
+          auto sig =
+              typeWrapperInit->getGenericSignature().getCanonicalSignature();
+          wrapperInitSubs[sig.getGenericParams()[0]] =
+              wrappedType->getMetatypeInstanceType();
+          wrapperInitSubs[sig.getGenericParams()[1]] = storageType.getASTType();
+        }
+
+        // <wrapper-var> = <TypeWrapper>.init(for: <Type>, storage: tmpStorage)
+        auto wrapperInitResult =
+            b.createApply(loc, typeWrapperInitRef,
+                          SubstitutionMap::get(
+                              typeWrapperInit->getGenericSignature(),
+                              QueryTypeSubstitutionMap{wrapperInitSubs},
+                              LookUpConformanceInModule(
+                                  ctor->getDeclContext()->getParentModule())),
+                          wrapperInitArgs);
 
         // self.$storage is a property access so it has to has to be wrapped
         // in begin/end access instructions.

--- a/test/Interpreter/Inputs/type_wrapper_defs.swift
+++ b/test/Interpreter/Inputs/type_wrapper_defs.swift
@@ -401,3 +401,21 @@ public protocol WrappedProtocol {
 
   var v: T { get set }
 }
+
+@propertyWrapper
+public struct PropWrapperWithDefaultInit<T> {
+  typealias Wrapped = T
+
+  public var wrappedValue: T {
+    get { value! }
+    set { value = newValue }
+  }
+
+  var value: T?
+
+  public init() {}
+
+  public init(wrappedValue: T) {
+    self.value = wrappedValue
+  }
+}

--- a/test/Interpreter/Inputs/type_wrapper_defs.swift
+++ b/test/Interpreter/Inputs/type_wrapper_defs.swift
@@ -419,3 +419,35 @@ public struct PropWrapperWithDefaultInit<T> {
     self.value = wrappedValue
   }
 }
+
+@typeWrapper
+public struct WrapperWithConformance<W : WrappedTypesOnly, S> {
+  var underlying: S
+
+  public init(for wrappedType: W.Type, storage: S) {
+    print("WrapperWithConformance.init(for: \(wrappedType), storage: \(storage))")
+    self.underlying = storage
+  }
+
+  public subscript<V>(propertyKeyPath propertyPath: KeyPath<W, V>,
+    storageKeyPath storagePath: KeyPath<S, V>) -> V {
+    get {
+      print("in read-only getter storage: \(storagePath)")
+      return underlying[keyPath: storagePath]
+    }
+  }
+
+  public subscript<V>(propertyKeyPath propertyPath: KeyPath<W, V>,
+    storageKeyPath storagePath: WritableKeyPath<S, V>) -> V {
+    get {
+      print("in getter storage: \(storagePath)")
+      return underlying[keyPath: storagePath]
+    }
+    set {
+      print("in setter => \(newValue)")
+      underlying[keyPath: storagePath] = newValue
+    }
+  }
+}
+
+public protocol WrappedTypesOnly {}

--- a/test/Interpreter/type_wrappers.swift
+++ b/test/Interpreter/type_wrappers.swift
@@ -710,3 +710,17 @@ do {
   // CHECK-NEXT: in (reference type) getter storage: \$Storage._x
   // CHECK-NEXT: 42
 }
+
+do {
+  @WrapperWithConformance
+  struct Test : WrappedTypesOnly {
+    var a: Int = 42
+    var b: String = ""
+    @PropWrapperWithDefaultInit var c: [Int]
+
+    init() {}
+  }
+
+  let test = Test()
+  // CHECK: WrapperWithConformance.init(for: Test, storage: $Storage(a: 42, b: "", _c: type_wrapper_defs.PropWrapperWithDefaultInit<Swift.Array<Swift.Int>>(value: nil)))
+}

--- a/test/Interpreter/type_wrappers.swift
+++ b/test/Interpreter/type_wrappers.swift
@@ -689,3 +689,24 @@ do {
   // CHECK-NEXT: in getter storage: \$Storage.v
   // CHECK-NEXT: 1
 }
+
+do {
+  @Wrapper
+  class Test {
+    @PropWrapperWithDefaultInit var x: Int
+
+    required init() {}
+
+    required init(x: Int) {
+      self.x = x
+    }
+  }
+
+  var test = Test(x: 42)
+  print(test.x)
+  // CHECK: Wrapper.init(for: Test, storage: $Storage(_x: type_wrapper_defs.PropWrapperWithDefaultInit<Swift.Int>(value: nil)))
+  // CHECK-NEXT: in (reference type) getter storage: \$Storage._x
+  // CHECK-NEXT: in (reference type) setter => PropWrapperWithDefaultInit<Int>(value: Optional(42))
+  // CHECK-NEXT: in (reference type) getter storage: \$Storage._x
+  // CHECK-NEXT: 42
+}


### PR DESCRIPTION
- Make sure that wrapper's initializer is always emitted by SILGen, otherwise it won't be available to DI/IRGen
- Add support to custom conformance requirements on `Wrapped` and `Storage` types.
- Add support for property wrapped fields without initializer expression.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
