### PR TITLE
Refactor C++ to return Swift::Expected instead of SWIFT_RETURN_THUNK

### DIFF
--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1248,14 +1248,14 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
     os << "    throw (Swift::Error(opaqueError));\n";
     os << "#else\n";
     if (resultTy->isVoid()) {
-      os << "    return SWIFT_RETURN_THUNK(void, Swift::Error(opaqueError));\n";
+      os << "    return Swift::Expected<void>(Swift::Error(opaqueError));\n";
       os << "#endif\n";
     } else {
       auto directResultType = signature.getDirectResultType();
       printDirectReturnOrParamCType(
           *directResultType, resultTy, moduleContext, os, cPrologueOS,
           typeMapping, interopContext, [&]() {
-            os << "    return SWIFT_RETURN_THUNK(";
+            os << "    return Swift::Expected<";
             OptionalTypeKind retKind;
             Type objTy;
             std::tie(objTy, retKind) =
@@ -1263,7 +1263,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
 
             auto s = printClangFunctionReturnType(objTy, retKind, const_cast<ModuleDecl *>(moduleContext),
                                                   OutputLanguageMode::Cxx);
-            os << ", Swift::Error(opaqueError));\n";
+            os << ">(Swift::Error(opaqueError));\n";
             os << "#endif\n";
 
             // Return the function result value if it doesn't throw.

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
@@ -38,7 +38,7 @@ public func emptyThrowFunction() throws { print("passEmptyThrowFunction") }
 // CHECK: #ifdef __cpp_exceptions
 // CHECK: throw (Swift::Error(opaqueError));
 // CHECK: #else
-// CHECK: return SWIFT_RETURN_THUNK(void, Swift::Error(opaqueError));
+// CHECK: return Swift::Expected<void>(Swift::Error(opaqueError));
 // CHECK: #endif
 // CHECK: }
 
@@ -64,7 +64,7 @@ public func testDestroyedError() throws { throw DestroyedError() }
 // CHECK: #ifdef __cpp_exceptions
 // CHECK: throw (Swift::Error(opaqueError));
 // CHECK: #else
-// CHECK: return SWIFT_RETURN_THUNK(void, Swift::Error(opaqueError));
+// CHECK: return Swift::Expected<void>(Swift::Error(opaqueError));
 // CHECK: #endif
 // CHECK: }
 
@@ -82,7 +82,7 @@ public func throwFunction() throws {
 // CHECK: #ifdef __cpp_exceptions
 // CHECK: throw (Swift::Error(opaqueError));
 // CHECK: #else
-// CHECK: return SWIFT_RETURN_THUNK(void, Swift::Error(opaqueError));
+// CHECK: return Swift::Expected<void>(Swift::Error(opaqueError));
 // CHECK: #endif
 // CHECK: }
 
@@ -103,7 +103,7 @@ public func throwFunctionWithPossibleReturn(_ a: Int) throws -> Int {
 // CHECK: #ifdef __cpp_exceptions
 // CHECK: throw (Swift::Error(opaqueError));
 // CHECK: #else
-// CHECK: return SWIFT_RETURN_THUNK(swift::Int, Swift::Error(opaqueError));
+// CHECK: return Swift::Expected<swift::Int>(Swift::Error(opaqueError));
 // CHECK: #endif
 // CHECK: return SWIFT_RETURN_THUNK(swift::Int, returnValue);
 // CHECK: }
@@ -122,7 +122,7 @@ public func throwFunctionWithReturn() throws -> Int {
 // CHECK: #ifdef __cpp_exceptions
 // CHECK: throw (Swift::Error(opaqueError));
 // CHECK: #else
-// CHECK: return SWIFT_RETURN_THUNK(swift::Int, Swift::Error(opaqueError));
+// CHECK: return Swift::Expected<swift::Int>(Swift::Error(opaqueError));
 // CHECK: #endif
 // CHECK: return SWIFT_RETURN_THUNK(swift::Int, returnValue);
 // CHECK: }


### PR DESCRIPTION
This is a simple PR to replace the of `SWIFT_RETURN_THUNK(T, v)` directly by  `Swift::Expected<T>(v)` when it's declared on the `#else` clause of the `#ifdef __cpp_exceptions` on the C++ thunk that represents a Swift function on the bridging header.

Example: 
- Previously: 

``` C++
inline Swift::ThrowingResult<swift::Int> throwFunctionWithReturn() SWIFT_WARN_UNUSED_RESULT {
    void* opaqueError = nullptr;
    void* _ctx = nullptr;
    auto returnValue = _impl::$s9Functions23throwFunctionWithReturnSiyKF(_ctx, &opaqueError);
#ifdef __cpp_exceptions
    throw (Swift::Error(opaqueError));
#else
    return SWIFT_RETURN_THUNK(swift::Int, Swift::Error(opaqueError));
#endif
    return SWIFT_RETURN_THUNK(swift::Int, returnValue);
}
```

- Proposed:
``` C++
inline Swift::ThrowingResult<swift::Int> throwFunctionWithReturn() SWIFT_WARN_UNUSED_RESULT {
    void* opaqueError = nullptr;
    void* _ctx = nullptr;
    auto returnValue = _impl::$s9Functions23throwFunctionWithReturnSiyKF(_ctx, &opaqueError);
#ifdef __cpp_exceptions
    throw (Swift::Error(opaqueError));
#else
    return Swift::Expected<swift::Int>(Swift::Error(opaqueError));
#endif
    return SWIFT_RETURN_THUNK(swift::Int, returnValue);
}
```