### PR TITLE
Add support for Swift 5.8 branch

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -170,6 +170,48 @@
                 "swift-experimental-string-processing": "swift/main"
             }
         },
+        "release/5.8": {
+            "aliases": ["release/5.8", "swift/release/5.8"],
+            "repos": {
+                "llvm-project": "swift/release/5.8",
+                "swift-llvm-bindings": "swift/release/5.8",
+                "swift": "release/5.8",
+                "cmark": "release/5.8",
+                "llbuild": "release/5.8",
+                "swift-tools-support-core": "release/5.8",
+                "swiftpm": "release/5.8",
+                "swift-argument-parser": "1.0.3",
+                "swift-atomics": "1.0.2",
+                "swift-collections": "1.0.1",
+                "swift-crypto": "1.1.5",
+                "swift-driver": "release/5.8",
+                "swift-numerics": "1.0.1",
+                "swift-syntax": "release/5.8",
+                "swift-system": "1.1.1",
+                "swift-stress-tester": "release/5.8",
+                "swift-corelibs-xctest": "release/5.8",
+                "swift-corelibs-foundation": "release/5.8",
+                "swift-corelibs-libdispatch": "release/5.8",
+                "swift-integration-tests": "release/5.8",
+                "swift-xcode-playground-support": "release/5.8",
+                "ninja": "release",
+                "icu": "release-65-1",
+                "yams": "5.0.1",
+                "cmake": "v3.19.6",
+                "indexstore-db": "release/5.8",
+                "sourcekit-lsp": "release/5.8",
+                "swift-format": "release/5.8",
+                "swift-installer-scripts": "release/5.8",
+                "swift-docc": "release/5.8",
+                "swift-lmdb": "release/5.8",
+                "swift-docc-render-artifact": "main",
+                "swift-docc-symbolkit": "main",
+                "swift-markdown": "main",
+                "swift-nio": "2.31.2",
+                "swift-nio-ssl": "2.15.0",
+                "swift-experimental-string-processing": "swift/release/5.8"
+            }
+        },
         "release/5.7": {
             "aliases": ["release/5.7", "swift/release/5.7"],
             "repos": {

--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -204,9 +204,9 @@
                 "swift-installer-scripts": "release/5.8",
                 "swift-docc": "release/5.8",
                 "swift-lmdb": "release/5.8",
-                "swift-docc-render-artifact": "main",
-                "swift-docc-symbolkit": "main",
-                "swift-markdown": "main",
+                "swift-docc-render-artifact": "release/5.8",
+                "swift-docc-symbolkit": "release/5.8",
+                "swift-markdown": "release/5.8",
                 "swift-nio": "2.31.2",
                 "swift-nio-ssl": "2.15.0",
                 "swift-experimental-string-processing": "swift/release/5.8"


### PR DESCRIPTION
Swift 5.8 branch is now created! 

To support the `release/5.8` scheme update-checkout updating the json file. 