### PR TITLE
[Runtime] temporary workaround for ptrauth failure in async endpoints…

### DIFF
--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -174,7 +174,7 @@ void swift_task_future_wait_throwing(
   OpaqueValue *,
   SWIFT_ASYNC_CONTEXT AsyncContext *,
   AsyncTask *,
-  ThrowingTaskFutureWaitContinuationFunction *,
+  TaskContinuationFunction *,
   AsyncContext *);
 
 /// Wait for a readyQueue of a Channel to become non empty.
@@ -191,7 +191,7 @@ SWIFT_EXPORT_FROM(swift_Concurrency)
 SWIFT_CC(swiftasync)
 void swift_taskGroup_wait_next_throwing(
     OpaqueValue *resultPointer, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
-    TaskGroup *group, ThrowingTaskFutureWaitContinuationFunction *resumeFn,
+    TaskGroup *group, TaskContinuationFunction *resumeFn,
     AsyncContext *callContext);
 
 /// Initialize a `TaskGroup` in the passed `group` memory location.
@@ -358,7 +358,7 @@ SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
 void swift_asyncLet_wait_throwing(OpaqueValue *,
                                   SWIFT_ASYNC_CONTEXT AsyncContext *,
                                   AsyncLet *,
-                                  ThrowingTaskFutureWaitContinuationFunction *,
+                                  TaskContinuationFunction *,
                                   AsyncContext *);
 
 /// DEPRECATED. swift_asyncLet_finish is used instead.
@@ -415,7 +415,7 @@ SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
 void swift_asyncLet_get_throwing(SWIFT_ASYNC_CONTEXT AsyncContext *,
                                  AsyncLet *,
                                  void *,
-                                 ThrowingTaskFutureWaitContinuationFunction *,
+                                 TaskContinuationFunction *,
                                  AsyncContext *);
 
 /// Exit the scope of an async-let binding. If the task is still running, it
@@ -482,7 +482,7 @@ SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swiftasync)
 void swift_asyncLet_consume_throwing(SWIFT_ASYNC_CONTEXT AsyncContext *,
                                      AsyncLet *,
                                      void *,
-                                     ThrowingTaskFutureWaitContinuationFunction *,
+                                     TaskContinuationFunction *,
                                      AsyncContext *);
 
 /// Returns true if the currently executing AsyncTask has a

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -146,7 +146,7 @@ OVERRIDE_TASK(task_future_wait_throwing, void,
               swift::,
               (OpaqueValue *result,
                SWIFT_ASYNC_CONTEXT AsyncContext *callerContext, AsyncTask *task,
-               ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
+               TaskContinuationFunction *resumeFunction,
                AsyncContext *callContext),
               (result, callerContext, task, resumeFunction, callContext))
 
@@ -218,7 +218,7 @@ OVERRIDE_ASYNC_LET(asyncLet_wait_throwing, void,
                    (OpaqueValue *result,
                        SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
                        AsyncLet *alet,
-                       ThrowingTaskFutureWaitContinuationFunction *resume,
+                       TaskContinuationFunction *resume,
                        AsyncContext *callContext),
                    (result, callerContext, alet, resume, callContext))
 
@@ -240,7 +240,7 @@ OVERRIDE_ASYNC_LET(asyncLet_get_throwing, void,
                    swift::,
                    (SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
                     AsyncLet *alet, void *resultBuffer,
-                    ThrowingTaskFutureWaitContinuationFunction *resumeFn,
+                    TaskContinuationFunction *resumeFn,
                     AsyncContext *callContext),
                    (callerContext, alet, resultBuffer, resumeFn, callContext))
 
@@ -258,7 +258,7 @@ OVERRIDE_ASYNC_LET(asyncLet_consume_throwing, void,
                    swift::,
                    (SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
                     AsyncLet *alet, void *resultBuffer,
-                    ThrowingTaskFutureWaitContinuationFunction *resumeFn,
+                    TaskContinuationFunction *resumeFn,
                     AsyncContext *callContext),
                    (callerContext, alet, resultBuffer, resumeFn, callContext))
 
@@ -290,7 +290,7 @@ OVERRIDE_TASK_GROUP(taskGroup_wait_next_throwing, void,
                     (OpaqueValue *resultPointer,
                      SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
                      TaskGroup *_group,
-                     ThrowingTaskFutureWaitContinuationFunction *resumeFn,
+                     TaskContinuationFunction *resumeFn,
                      AsyncContext *callContext),
                     (resultPointer, callerContext, _group, resumeFn,
                     callContext))

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1183,14 +1183,14 @@ SWIFT_CC(swiftasync)
 void swift_task_future_wait_throwingImpl(
     OpaqueValue *result, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
     AsyncTask *task,
-    ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
+    TaskContinuationFunction *resumeFn,
     AsyncContext *callContext) {
   auto waitingTask = swift_task_getCurrent();
   // Suspend the waiting task.
   waitingTask->ResumeTask = task_wait_throwing_resume_adapter;
   waitingTask->ResumeContext = callContext;
 
-  auto resumeFn = reinterpret_cast<TaskContinuationFunction *>(resumeFunction);
+  auto resumeFunction = reinterpret_cast<ThrowingTaskFutureWaitContinuationFunction *>(resumeFn);
 
   // Wait on the future.
   assert(task->isFuture());

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -756,7 +756,7 @@ __attribute__((noinline))
 SWIFT_CC(swiftasync) static void workaround_function_swift_taskGroup_wait_next_throwingImpl(
     OpaqueValue *result, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
     TaskGroup *_group,
-    ThrowingTaskFutureWaitContinuationFunction resumeFunction,
+    TaskContinuationFunction* resumeFunction,
     AsyncContext *callContext) {
   // Make sure we don't eliminate calls to this function.
   asm volatile("" // Do nothing.
@@ -775,15 +775,14 @@ SWIFT_CC(swiftasync)
 static void swift_taskGroup_wait_next_throwingImpl(
     OpaqueValue *resultPointer, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
     TaskGroup *_group,
-    ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
+    TaskContinuationFunction *resumeFunction,
     AsyncContext *rawContext) {
   auto waitingTask = swift_task_getCurrent();
   waitingTask->ResumeTask = task_group_wait_resume_adapter;
   waitingTask->ResumeContext = rawContext;
 
   auto context = static_cast<TaskFutureWaitAsyncContext *>(rawContext);
-  context->ResumeParent =
-      reinterpret_cast<TaskContinuationFunction *>(resumeFunction);
+  context->ResumeParent = resumeFunction;
   context->Parent = callerContext;
   context->errorResult = nullptr;
   context->successResultPointer = resultPointer;


### PR DESCRIPTION
During codegen, the compiler is signing async continuation functions with hardcoded discriminator for type `TaskContinuationFunction`. This leads to pointer authentication failures. This is a temporary workaround to fix the pointer auth failures until the pointer signing is fixed in the compiler.



Resolves rdar://103425363

