### PR TITLE
[5.8] Utils: Decode subprocess output as UTF-8 in `swift-api-dump.py`.

### DIFF
--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -127,6 +127,7 @@ def run_command(args):
     proc = subprocess.Popen(
         args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = proc.communicate()
+    out = out.decode('UTF8')
     exitcode = proc.returncode
     return (exitcode, out, err)
 


### PR DESCRIPTION
Cherry pick of https://github.com/apple/swift/pull/62695 to release/5.8.

The fix prevents errors like this:

```
Collecting frameworks from macOS b'13.0' at b'/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk'
Traceback (most recent call last):
  File "./swift-api-dump.py", line 360, in <module>
    main()
  File "./swift-api-dump.py", line 346, in main
    jobs = jobs + create_dump_module_api_args(
  File "./swift-api-dump.py", line 265, in create_dump_module_api_args
    (frameworks, sdk_root) = collect_frameworks(sdk)
  File "./swift-api-dump.py", line 246, in collect_frameworks
    for entry in os.listdir(frameworks_dir):
FileNotFoundError: [Errno 2] No such file or directory: "b'/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.0.sdk'/System/Library/Frameworks"
```

Resolves rdar://100295474.
