### PR TITLE
[cxx-interop] Import non-member operators as global functions

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8241,11 +8241,17 @@ ClangImporter::Implementation::importDeclContextOf(
     if (dc->getDeclKind() == clang::Decl::LinkageSpec)
       dc = dc->getParent();
 
-    // Treat friend decls like top-level decls.
     if (auto functionDecl = dyn_cast<clang::FunctionDecl>(decl)) {
+      // Treat friend decls like top-level decls.
       if (functionDecl->getFriendObjectKind()) {
         // Find the top-level decl context.
         while (isa<clang::NamedDecl>(dc))
+          dc = dc->getParent();
+      }
+
+      // If this is a non-member operator, import it as a top-level function.
+      if (functionDecl->isOverloadedOperator()) {
+        while (dc->isNamespace())
           dc = dc->getParent();
       }
     }

--- a/test/Interop/Cxx/namespace/Inputs/free-functions.h
+++ b/test/Interop/Cxx/namespace/Inputs/free-functions.h
@@ -60,4 +60,13 @@ inline const char *sameNameInSibling() {
 }
 } // namespace FunctionsNS4
 
+namespace FunctionsNS1 {
+namespace FunctionsNS2 {
+namespace FunctionsNS3 {
+struct Y {};
+inline bool operator==(Y, Y) { return true; }
+} // namespace FunctionsNS3
+} // namespace FunctionsNS2
+} // namespace FunctionsNS1
+
 #endif // TEST_INTEROP_CXX_NAMESPACE_INPUTS_FREE_FUNCTION_H

--- a/test/Interop/Cxx/namespace/free-functions-module-interface.swift
+++ b/test/Interop/Cxx/namespace/free-functions-module-interface.swift
@@ -7,21 +7,34 @@
 // CHECK-NEXT:   struct X {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:   }
-// CHECK-NEXT:   static func + (_: FunctionsNS1.X, _: FunctionsNS1.X) -> UnsafePointer<CChar>!
-// CHECK-NEXT:   static func sameNameInChild() -> UnsafePointer<CChar>!
-// CHECK-NEXT:   static func sameNameInSibling() -> UnsafePointer<CChar>!
+
+// FIXME: this seems wrong, the operator shouldn't be printed twice (https://github.com/apple/swift/issues/62727).
+// CHECK-NEXT:   func + (_: FunctionsNS1.X, _: FunctionsNS1.X) -> UnsafePointer<CChar>!
+
 // CHECK-NEXT:   enum FunctionsNS2 {
-// CHECK-NEXT:     static func basicFunctionSecondLevel() -> UnsafePointer<CChar>!
-// CHECK-NEXT:     static func sameNameInChild() -> UnsafePointer<CChar>!
 // CHECK-NEXT:     enum FunctionsNS3 {
+// CHECK-NEXT:       struct Y {
+// CHECK-NEXT:         init()
+// CHECK-NEXT:       }
+
+// FIXME: this seems wrong, the operator shouldn't be printed twice (https://github.com/apple/swift/issues/62727).
+// CHECK-NEXT: func == (_: FunctionsNS1.FunctionsNS2.FunctionsNS3.Y, _: FunctionsNS1.FunctionsNS2.FunctionsNS3.Y) -> Bool
+
 // CHECK-NEXT:       static func basicFunctionLowestLevel() -> UnsafePointer<CChar>!
 // CHECK-NEXT:     }
+// CHECK-NEXT:     static func sameNameInChild() -> UnsafePointer<CChar>!
+// CHECK-NEXT:     static func basicFunctionSecondLevel() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   }
+
+// CHECK-NEXT:   static func sameNameInChild() -> UnsafePointer<CChar>!
+// CHECK-NEXT:   static func sameNameInSibling() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   static func definedInDefs() -> UnsafePointer<CChar>!
 // CHECK-NEXT: }
 
-// CHECK-NEXT: static func + (_: FunctionsNS1.X, _: FunctionsNS1.X) -> UnsafePointer<CChar>!
+// CHECK-NEXT: func + (_: FunctionsNS1.X, _: FunctionsNS1.X) -> UnsafePointer<CChar>!
 
 // CHECK-NEXT: enum FunctionsNS4 {
 // CHECK-NEXT:   static func sameNameInSibling() -> UnsafePointer<CChar>!
 // CHECK-NEXT: }
+
+// CHECK-NEXT: func == (_: FunctionsNS1.FunctionsNS2.FunctionsNS3.Y, _: FunctionsNS1.FunctionsNS2.FunctionsNS3.Y) -> Bool


### PR DESCRIPTION
If a non-member operator is declared in a C++ namespace, we previously imported it as a static member of the enum that represents the C++ namespace.

This is not always correct under Swift rules for operators. In pure Swift, this code is valid:
```
public protocol UnsafeCxxRandomAccessIterator {
  static func +=(lhs: inout Self, rhs: Int)
}

enum std {
  public struct A : UnsafeCxxRandomAccessIterator {
    public static func += (lhs: inout A, rhs: Int) {
    }
  }
}
```
but this is not valid:
```
public protocol UnsafeCxxRandomAccessIterator {
  static func +=(lhs: inout Self, rhs: Int)
}

enum std {
  public struct A : UnsafeCxxRandomAccessIterator {}
  public static func += (lhs: inout A, rhs: Int) {}
}
// error: Member operator '+=' must have at least one argument of type 'std'
```

This caused assertion failures in SILGen when conforming C++ iterator types to `UnsafeCxxRandomAccessIterator`.