### PR TITLE
Create begin_borrow in OSSA only

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -745,6 +745,7 @@ public:
 
   BeginBorrowInst *createBeginBorrow(SILLocation Loc, SILValue LV,
                                      bool isLexical = false) {
+    assert(getFunction().hasOwnership());
     assert(!LV->getType().isAddress());
     return insert(new (getModule())
                       BeginBorrowInst(getSILDebugLocation(Loc), LV, isLexical));

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -171,7 +171,8 @@ public:
         // which require an @guaranteed operand into which we'd be attempting to
         // substitute an @owned operand.
         if (calleeYields[i]->getOwnershipKind() == OwnershipKind::Owned &&
-            !yield->getOperandRef(i).isConsuming()) {
+            !yield->getOperandRef(i).isConsuming() &&
+            Builder->getFunction().hasOwnership()) {
           auto *bbi = Builder->createBeginBorrow(Loc, remappedYield);
           guaranteedYields.push_back(bbi);
           remappedYield = bbi;


### PR DESCRIPTION
Fixes rdar://103512260

Creating begin_borrow in non-ossa can raise asserts or reach unreachable in some utils.

