### PR TITLE
[Task-to-Thread] Make sure to explicitly initialize the drainLock in DefaultActorImpl::initialize 

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -853,7 +853,9 @@ public:
   /// Properly construct an actor, except for the heap header.
   void initialize(bool isDistributedRemote = false) {
     this->isDistributedRemoteActor = isDistributedRemote;
-#if !SWIFT_CONCURRENCY_ACTORS_AS_LOCKS
+#if SWIFT_CONCURRENCY_ACTORS_AS_LOCKS
+    new (&this->drainLock) Mutex();
+#else
    _status().store(ActiveActorStatus(), std::memory_order_relaxed);
 #endif
     SWIFT_TASK_DEBUG_LOG("Creating default actor %p", this);


### PR DESCRIPTION
[Task-to-Thread] Make sure to explicitly initialize the drainLock in DefaultActorImpl::initialize 

Radar-Id: rdar://problem/103426321
