### PR TITLE
[stdlib] Speed up short UTF-16 distance calculations

### DIFF
--- a/stdlib/public/core/StringBreadcrumbs.swift
+++ b/stdlib/public/core/StringBreadcrumbs.swift
@@ -13,6 +13,8 @@
 
 // @opaque
 internal final class _StringBreadcrumbs {
+  /// The distance between successive breadcrumbs, measured in UTF-16 code
+  /// units.
   internal static var breadcrumbStride: Int { 64 }
 
   internal var utf16Length: Int

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -795,19 +795,33 @@ extension StringProtocol {
   @_specialize(where Self == Substring)
   public // SPI(Foundation)
   func _toUTF16Offsets(_ indices: Range<Index>) -> Range<Int> {
-    let lowerbound = _toUTF16Offset(indices.lowerBound)
-    let length = self.utf16.distance(
-      from: indices.lowerBound, to: indices.upperBound)
-    return Range(
-      uncheckedBounds: (lower: lowerbound, upper: lowerbound + length))
+    if Self.self == String.self {
+      let s = unsafeBitCast(self, to: String.self)
+      return s.utf16._offsetRange(for: indices, from: s.startIndex)
+    }
+    if Self.self == Substring.self {
+      let s = unsafeBitCast(self, to: Substring.self)
+      return s._slice._base.utf16._offsetRange(for: indices, from: s.startIndex)
+    }
+    let startOffset = _toUTF16Offset(indices.lowerBound)
+    let endOffset = _toUTF16Offset(indices.upperBound)
+    return Range(uncheckedBounds: (lower: startOffset, upper: endOffset))
   }
 
   @_specialize(where Self == String)
   @_specialize(where Self == Substring)
   public // SPI(Foundation)
   func _toUTF16Indices(_ range: Range<Int>) -> Range<Index> {
+    if Self.self == String.self {
+      let s = unsafeBitCast(self, to: String.self)
+      return s.utf16._indexRange(for: range, from: s.startIndex)
+    }
+    if Self.self == Substring.self {
+      let s = unsafeBitCast(self, to: Substring.self)
+      return s._slice._base.utf16._indexRange(for: range, from: s.startIndex)
+    }
     let lowerbound = _toUTF16Index(range.lowerBound)
-    let upperbound = self.utf16.index(lowerbound, offsetBy: range.count)
+    let upperbound = _toUTF16Index(range.upperBound)
     return Range(uncheckedBounds: (lower: lowerbound, upper: upperbound))
   }
 }

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -791,8 +791,6 @@ extension StringProtocol {
     return self.utf16.index(self.utf16.startIndex, offsetBy: offset)
   }
 
-  @_specialize(where Self == String)
-  @_specialize(where Self == Substring)
   public // SPI(Foundation)
   func _toUTF16Offsets(_ indices: Range<Index>) -> Range<Int> {
     if Self.self == String.self {
@@ -808,8 +806,6 @@ extension StringProtocol {
     return Range(uncheckedBounds: (lower: startOffset, upper: endOffset))
   }
 
-  @_specialize(where Self == String)
-  @_specialize(where Self == Substring)
   public // SPI(Foundation)
   func _toUTF16Indices(_ range: Range<Int>) -> Range<Index> {
     if Self.self == String.self {

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -807,7 +807,7 @@ extension StringProtocol {
   public // SPI(Foundation)
   func _toUTF16Indices(_ range: Range<Int>) -> Range<Index> {
     let lowerbound = _toUTF16Index(range.lowerBound)
-    let upperbound = _toUTF16Index(range.lowerBound + range.count)
+    let upperbound = self.utf16.index(lowerbound, offsetBy: range.count)
     return Range(uncheckedBounds: (lower: lowerbound, upper: upperbound))
   }
 }

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -720,7 +720,7 @@ extension String.UTF16View {
   ///
   /// - Complexity: This measures the UTF-16 distance of `idx` from its nearest
   ///    breadcrumb index (rounding down), so on average it needs to look at
-  ///    `breadcrumbStride / 2` UTF-8 code units. (In addition to the O(log(n))
+  ///    `breadcrumbStride / 2` UTF-16 code units. (In addition to the O(log(n))
   ///    cost of looking up the nearest breadcrumb, and the amortizable O(n)
   ///    cost of generating the breadcrumbs in the first place.)
   @usableFromInline
@@ -758,7 +758,7 @@ extension String.UTF16View {
   ///
   /// - Complexity: This iterates UTF-16 code units starting from the
   ///    nearest breadcrumb to `offset` (rounding down), so on
-  ///    average it needs to look at `breadcrumbStride / 2` UTF-8 code
+  ///    average it needs to look at `breadcrumbStride / 2` UTF-16 code
   ///    units. (In addition to the O(1) cost of looking up the nearest
   ///    breadcrumb, and the amortizable O(n) cost of generating the
   ///    breadcrumbs in the first place.)

--- a/stdlib/public/core/StringUTF16View.swift
+++ b/stdlib/public/core/StringUTF16View.swift
@@ -201,14 +201,9 @@ extension String.UTF16View: BidirectionalCollection {
       return _foreignIndex(i, offsetBy: n)
     }
 
-    if n.magnitude <= _StringBreadcrumbs.breadcrumbStride {
+    if n.magnitude <= _StringBreadcrumbs.breadcrumbStride, !_guts.isASCII {
       // Do not use breadcrumbs if directly computing the result is expected to
       // be cheaper.
-      if _guts.isASCII {
-        return Index(
-          _encodedOffset: i._encodedOffset + n
-        )._scalarAligned._encodingIndependent
-      }
       return _index(i, offsetBy: n)._knownUTF8
     }
 
@@ -230,14 +225,9 @@ extension String.UTF16View: BidirectionalCollection {
       return _foreignIndex(i, offsetBy: n, limitedBy: limit)
     }
 
-    if n.magnitude <= _StringBreadcrumbs.breadcrumbStride {
+    if n.magnitude <= _StringBreadcrumbs.breadcrumbStride, !_guts.isASCII {
       // Do not use breadcrumbs if directly computing the result is expected to
       // be cheaper.
-      if _guts.isASCII {
-        return (0 ..< _guts.count).index(
-          i._encodedOffset, offsetBy: n, limitedBy: limit._encodedOffset
-        ).map { Index(_encodedOffset: $0)._scalarAligned._encodingIndependent }
-      }
       return _index(i, offsetBy: n, limitedBy: limit)?._knownUTF8
     }
 
@@ -278,15 +268,15 @@ extension String.UTF16View: BidirectionalCollection {
     }
 
     let utf8Distance = end._encodedOffset - start._encodedOffset
-    if utf8Distance.magnitude <= _StringBreadcrumbs.breadcrumbStride {
+    if
+      utf8Distance.magnitude <= _StringBreadcrumbs.breadcrumbStride,
+      !_guts.isASCII
+    {
       // Do not use breadcrumbs if directly computing the result is expected to
       // be cheaper. The conservative threshold above assumes that each UTF-16
       // code unit will map to a single UTF-8 code unit, i.e., the worst
       // possible (a.k.a. most compact) case with all ASCII scalars.
       // FIXME: Figure out if a more optimistic threshold would work better.
-      if _guts.isASCII {
-        return end._encodedOffset - start._encodedOffset
-      }
       return _utf16Distance(from: start, to: end)
     }
     let lower = _nativeGetOffset(for: start)

--- a/test/stdlib/StringIndex.swift
+++ b/test/stdlib/StringIndex.swift
@@ -995,6 +995,50 @@ suite.test("Index encoding correction/UTF-8→16/conversions/UTF-16") {
 }
 #endif
 
+suite.test("UTF-16 breadcrumbs") {
+
+  let string = #"""
+    The powerful programming language that is also easy to learn.
+    손쉽게 학습할 수 있는 강력한 프로그래밍 언어.
+    🪙 A 🥞 short 🍰 piece 🫘 of 🌰 text 👨‍👨‍👧‍👧 with 👨‍👩‍👦 some 🚶🏽 emoji 🇺🇸🇨🇦 characters 🧈
+    some🔩times 🛺 placed 🎣 in 🥌 the 🆘 mid🔀dle 🇦🇶or🏁 around 🏳️‍🌈 a 🍇 w🍑o🥒r🥨d
+    Unicode is such fun!
+    U̷n̷i̷c̷o̴d̴e̷ ̶i̸s̷ ̸s̵u̵c̸h̷ ̸f̵u̷n̴!̵
+    U̴̡̲͋̾n̵̻̳͌ì̶̠̕c̴̭̈͘ǫ̷̯͋̊d̸͖̩̈̈́ḛ̴́ ̴̟͎͐̈i̴̦̓s̴̜̱͘ ̶̲̮̚s̶̙̞͘u̵͕̯̎̽c̵̛͕̜̓h̶̘̍̽ ̸̜̞̿f̵̤̽ṷ̴͇̎͘ń̷͓̒!̷͍̾̚
+    U̷̢̢̧̨̼̬̰̪͓̞̠͔̗̼̙͕͕̭̻̗̮̮̥̣͉̫͉̬̲̺͍̺͊̂ͅ\#
+    n̶̨̢̨̯͓̹̝̲̣̖̞̼̺̬̤̝̊̌́̑̋̋͜͝ͅ\#
+    ḭ̸̦̺̺͉̳͎́͑\#
+    c̵̛̘̥̮̙̥̟̘̝͙̤̮͉͔̭̺̺̅̀̽̒̽̏̊̆͒͌̂͌̌̓̈́̐̔̿̂͑͠͝͝ͅ\#
+    """#
+
+  print(string.utf16.count)
+  let indices = Array(string.utf16.indices) + [string.utf16.endIndex]
+  for i in 0 ..< indices.count {
+    for j in 0 ..< indices.count {
+      // print(
+      //   """
+      //   i: \(i), indices[i]: \(indices[i]._description); \
+      //   j: \(j), indices[j]: \(indices[j]._description)
+      //   """)
+
+      let distance = string.utf16.distance(from: indices[i], to: indices[j])
+      expectEqual(distance, j - i,
+        """
+        i: \(i), indices[i]: \(indices[i]._description)
+        j: \(j), indices[j]: \(indices[j]._description)
+        """)
+
+      let target = string.utf16.index(indices[i], offsetBy: j - i)
+      expectEqual(target, indices[j],
+        """
+        i: \(i), indices[i]: \(indices[i]._description)
+        j: \(j), indices[j]: \(indices[j]._description)
+        target: \(target._description)
+        """)
+    }
+  }
+}
+
 suite.test("String.replaceSubrange index validation")
 .forEach(in: examples) { string in
   guard #available(SwiftStdlib 5.7, *) else {

--- a/test/stdlib/StringIndex.swift
+++ b/test/stdlib/StringIndex.swift
@@ -1015,12 +1015,6 @@ suite.test("UTF-16 breadcrumbs") {
   let indices = Array(string.utf16.indices) + [string.utf16.endIndex]
   for i in 0 ..< indices.count {
     for j in 0 ..< indices.count {
-      // print(
-      //   """
-      //   i: \(i), indices[i]: \(indices[i]._description); \
-      //   j: \(j), indices[j]: \(indices[j]._description)
-      //   """)
-
       let distance = string.utf16.distance(from: indices[i], to: indices[j])
       expectEqual(distance, j - i,
         """


### PR DESCRIPTION
Previously we insisted on using UTF-16 breadcrumbs even if we only needed to travel a very short way. This could be as much as ~ten~ forty times slower than the naive algorithm of simply visiting all the Unicode scalars in between the start and the end.

(Using breadcrumbs generally means that we need to walk to both endpoints from their nearest breadcrumb, which on average requires walking half the distance between breadcrumbs, twice — and this can mean visiting vastly more Unicode scalars than if we simply walked through the ones that are lying in between the endpoints themselves.)

To put it another way, when we want to measure how long it takes to walk between two trees within a nearby park, it probably isn't a great idea to start by separately measuring each of their distances from the nearest airport. 😛

rdar://103575481