### PR TITLE
[Gardening] Simplify excessive conditional expression: (A && !B) || (!A && B) is equivalent to bool(A) != bool(B)

### DIFF
--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -954,8 +954,7 @@ InferredGenericSignatureRequest::evaluate(
           // If one side is a parameter pack and the other is not, this is a
           // same-element requirement that cannot be expressed with only one
           // type parameter.
-          if ((genericParam->isParameterPack() && !reduced->isParameterPack()) ||
-              (!genericParam->isParameterPack() && reduced->isParameterPack()))
+          if (genericParam->isParameterPack() != reduced->isParameterPack())
             continue;
 
           ctx.Diags.diagnose(loc, diag::requires_generic_params_made_equal,


### PR DESCRIPTION
<!-- What's in this pull request? -->

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
