### PR TITLE
Add check against NULL before dereferencing pointer

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4270,6 +4270,7 @@ class CaptureListExpr final : public Expr,
                   AbstractClosureExpr *closureBody)
     : Expr(ExprKind::CaptureList, /*Implicit=*/false, Type()),
       closureBody(closureBody) {
+    assert(closureBody);
     Bits.CaptureListExpr.NumCaptures = captureList.size();
     std::uninitialized_copy(captureList.begin(), captureList.end(),
                             getTrailingObjects<CaptureListEntry>());

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3863,9 +3863,6 @@ public:
   /// Only valid when \c hasSingleExpressionBody() is true.
   Expr *getSingleExpressionBody() const;
 
-  /// Whether this closure has a body
-  bool hasBody() const;
-
   /// Returns the body of closures that have a body
   /// returns nullptr if the closure doesn't have a body
   BraceStmt *getBody() const;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1885,19 +1885,7 @@ void AbstractClosureExpr::setParameterList(ParameterList *P) {
     P->setDeclContextOfParamDecls(this);
 }
 
-bool AbstractClosureExpr::hasBody() const {
-  switch (getKind()) {
-    case ExprKind::Closure:
-    case ExprKind::AutoClosure:
-      return true;
-    default:
-      return false;
-  }
-}
-
 BraceStmt * AbstractClosureExpr::getBody() const {
-  if (!hasBody())
-    return nullptr;
   if (const AutoClosureExpr *autocls = dyn_cast<AutoClosureExpr>(this))
     return autocls->getBody();
   if (const ClosureExpr *cls = dyn_cast<ClosureExpr>(this))

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -2485,8 +2485,9 @@ private:
   getIndentContextFrom(CaptureListExpr *CL,
                        SourceLoc ContextLoc = SourceLoc()) {
     AbstractClosureExpr *CE = CL->getClosureBody();
-    BraceStmt *BS = CE ? CE->getBody() : NULL;
-    if (!CE || !BS)
+    assert(CE);
+    BraceStmt *BS = CE->getBody();
+    if (!BS)
       return None;
 
     if (ContextLoc.isValid()) {

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -2485,7 +2485,6 @@ private:
   getIndentContextFrom(CaptureListExpr *CL,
                        SourceLoc ContextLoc = SourceLoc()) {
     AbstractClosureExpr *CE = CL->getClosureBody();
-    assert(CE);
     BraceStmt *BS = CE->getBody();
     if (!BS)
       return None;

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -2485,7 +2485,7 @@ private:
   getIndentContextFrom(CaptureListExpr *CL,
                        SourceLoc ContextLoc = SourceLoc()) {
     AbstractClosureExpr *CE = CL->getClosureBody();
-    BraceStmt *BS = CE->getBody();
+    BraceStmt *BS = CE ? CE->getBody() : NULL;
     if (!CE || !BS)
       return None;
 

--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -213,8 +213,6 @@ shouldWalkIntoExpr(Expr *E, ASTWalker::ParentTy Parent, SILDeclRef Constant) {
     // initializer instead.
     if (!Parent.isNull() || !Constant || !Constant.getAbstractClosureExpr())
       return Action::SkipChildren(E);
-
-    assert(CE->hasBody());
   }
   return Action::Continue(E);
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->

Condition following fix suggests pointer is expected sometimes to be NULL.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
