### PR TITLE
[CSDiagnostics] Add an error message for pack expansion expressions over packs that don't have the same shape.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5164,6 +5164,9 @@ ERROR(multiple_ellipsis_in_tuple,none,
 ERROR(expansion_not_same_shape,none,
       "variadic expansion %0 requires that %1 and %2 have the same shape",
       (Type, Type, Type))
+ERROR(expansion_expr_not_same_shape,none,
+      "pack expansion requires that %0 and %1 have the same shape",
+      (Type, Type))
 
 ERROR(enum_element_ellipsis,none,
       "variadic enum cases are not supported", ())

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -659,8 +659,10 @@ public:
   }
 };
 
-/// Skip same-shape generic requirement constraint,
-/// and assume that types are equal.
+/// Skip a same-shape requirement between two type packs.
+///
+/// A same shape requirement can be inferred from a generic requirement,
+/// or from a pack expansion expression.
 class SkipSameShapeRequirement final : public ConstraintFix {
   Type LHS, RHS;
 
@@ -671,7 +673,7 @@ class SkipSameShapeRequirement final : public ConstraintFix {
 
 public:
   std::string getName() const override {
-    return "skip same-shape generic requirement";
+    return "skip same-shape requirement";
   }
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -681,6 +681,11 @@ bool MissingConformanceFailure::diagnoseAsAmbiguousOperatorRef() {
   return true;
 }
 
+bool SameShapeExpansionFailure::diagnoseAsError() {
+  emitDiagnostic(diag::expansion_expr_not_same_shape, lhs, rhs);
+  return true;
+}
+
 Optional<Diag<Type, Type>> GenericArgumentsMismatchFailure::getDiagnosticFor(
     ContextualTypePurpose context) {
   switch (context) {

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -470,6 +470,17 @@ protected:
   }
 };
 
+class SameShapeExpansionFailure final : public FailureDiagnostic {
+  Type lhs, rhs;
+
+public:
+  SameShapeExpansionFailure(const Solution &solution, Type lhs, Type rhs,
+                            ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator), lhs(lhs), rhs(rhs) {}
+
+  bool diagnoseAsError() override;
+};
+
 /// Diagnose failures related to superclass generic requirements, e.g.
 /// ```swift
 /// class A {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -467,6 +467,11 @@ SkipSameTypeRequirement::create(ConstraintSystem &cs, Type lhs, Type rhs,
 
 bool SkipSameShapeRequirement::diagnose(const Solution &solution,
                                        bool asNote) const {
+  if (getLocator()->isLastElement<LocatorPathElt::PackShape>()) {
+    SameShapeExpansionFailure failure(solution, LHS, RHS, getLocator());
+    return failure.diagnose(asNote);
+  }
+
   SameShapeRequirementFailure failure(solution, LHS, RHS, getLocator());
   return failure.diagnose(asNote);
 }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3025,7 +3025,7 @@ namespace {
         }
 
         CS.addConstraint(ConstraintKind::ShapeOf, packType, shapeTypeVar,
-                         CS.getConstraintLocator(expr));
+            CS.getConstraintLocator(expr, ConstraintLocator::PackShape));
       }
 
       return PackExpansionType::get(patternTy, shapeTypeVar);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6018,6 +6018,13 @@ bool ConstraintSystem::repairFailures(
                           getConstraintLocator(anchor, path));
   }
 
+  case ConstraintLocator::PackShape: {
+    auto *shapeLocator = getConstraintLocator(locator);
+    auto *fix = SkipSameShapeRequirement::create(*this, lhs, rhs, shapeLocator);
+    conversionsOrFixes.push_back(fix);
+    break;
+  }
+
   case ConstraintLocator::SequenceElementType: {
     if (lhs->isPlaceholder() || rhs->isPlaceholder()) {
       recordAnyTypeVarAsPotentialHole(lhs);

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -71,3 +71,9 @@ func typeReprPacks<T...>(_ t: T...) where T: ExpressibleByIntegerLiteral {
   _ = Array<each T>() // expected-error {{pack reference 'T' can only appear in pack expansion or generic requirement}}
   _ = 1 as each T // expected-error {{pack reference 'T' can only appear in pack expansion or generic requirement}}
 }
+
+func sameShapeDiagnostics<T..., U...>(t: T..., u: U...) {
+  _ = (each t, each u)... // expected-error {{pack expansion requires that 'U' and 'T' have the same shape}}
+  _ = Array<(each T, each U)>()... // expected-error {{pack expansion requires that 'U' and 'T' have the same shape}}
+  _ = (Array<each T>(), each u)... // expected-error {{pack expansion requires that 'U' and 'T' have the same shape}}
+}


### PR DESCRIPTION
For example:

```swift
func sameShapeDiagnostics<T..., U...>(t: T..., u: U...) {
  _ = (each t, each u)... // 't' and 'u' do not have the same shape
}
```

A `ShapeOf` constraint breaks down into a `Bind`. Previously if that failed, the constraint system would report `type of expression is ambiguous without more context`. Now, it reports `pack expansion requires that 'U' and 'T' have the same shape`.