### PR TITLE
Two of the macros tests are failing to import SwiftDiagnostics.

### DIFF
--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -3,6 +3,8 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature Macros -module-name MacrosTest -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir
 // REQUIRES: OS=macosx
 
+// REQUIRES: rdar103606300
+
 macro stringify<T>(_ value: T) -> (T, String) = MacroDefinition.StringifyMacro
 macro missingMacro1(_: Any) = MissingModule.MissingType // expected-note{{'missingMacro1' declared here}}
 macro missingMacro2(_: Any) = MissingModule.MissingType

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -7,6 +7,8 @@ func testStringify(a: Int, b: Int) {
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx
 
+// REQUIRES: rdar103606300
+
 // REQUIRES=shell
 
 // RUN: %empty-directory(%t)


### PR DESCRIPTION
Marking these as UNSUPPORTED for now, pending a fix.
