### PR TITLE
[5.8] [SE-0368] StaticBigInt: Fix test failures

### DIFF
--- a/test/stdlib/StaticBigInt.swift
+++ b/test/stdlib/StaticBigInt.swift
@@ -13,12 +13,10 @@
 // RUN: %target-run-simple-swift(-parse-as-library)
 // REQUIRES: executable_test
 // REQUIRES: reflection
+// UNSUPPORTED: use_os_stdlib
 // END.
 //
 //===----------------------------------------------------------------------===//
-
-// rdar://103369837
-// UNSUPPORTED: OS=watchos || OS=macos
 
 import StdlibUnittest
 
@@ -69,17 +67,19 @@ extension StaticBigIntTests {
     for (actual, expected) in keyValuePairs {
       expectEqual(expected.signum,   actual.signum())
       expectEqual(expected.bitWidth, actual.bitWidth)
-      if getInt(UInt.bitWidth) == 32 {
-        expectEqual(expected._32bit[0], actual[0])
-        expectEqual(expected._32bit[1], actual[1])
-        expectEqual(expected._32bit[2], actual[2])
-        expectEqual(expected._32bit[3], actual[3])
-        expectEqual(expected._32bit[4], actual[4])
-      } else if getInt(UInt.bitWidth) == 64 {
-        expectEqual(expected._64bit[0], actual[0])
-        expectEqual(expected._64bit[1], actual[1])
-        expectEqual(expected._64bit[2], actual[2])
-      }
+#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32) || arch(powerpc)
+      expectEqual(expected._32bit[0], actual[0])
+      expectEqual(expected._32bit[1], actual[1])
+      expectEqual(expected._32bit[2], actual[2])
+      expectEqual(expected._32bit[3], actual[3])
+      expectEqual(expected._32bit[4], actual[4])
+#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+      expectEqual(expected._64bit[0], actual[0])
+      expectEqual(expected._64bit[1], actual[1])
+      expectEqual(expected._64bit[2], actual[2])
+#else
+#error("Unimplemented")
+#endif
     }
   }
 }
@@ -154,39 +154,46 @@ extension StaticBigIntTests {
       let negative = Wrapper(-0x00112233_44556677_8899AABB_CCDDEEFF)
       expectEqual( -1, negative.actual.signum())
       expectEqual(118, negative.actual.bitWidth)
-      if getInt(UInt.bitWidth) == 32 {
-        expectEqual(0x33221101, negative.actual[0])
-        expectEqual(0x77665544, negative.actual[1])
-        expectEqual(0xBBAA9988, negative.actual[2])
-        expectEqual(0xFFEEDDCC, negative.actual[3])
-        expectEqual(0xFFFFFFFF, negative.actual[4])
-        expectEqual(0xFFFFFFFF, negative.actual[.max])
-      } else if getInt(UInt.bitWidth) == 64 {
-        expectEqual(0x77665544_33221101, negative.actual[0])
-        expectEqual(0xFFEEDDCC_BBAA9988, negative.actual[1])
-        expectEqual(0xFFFFFFFF_FFFFFFFF, negative.actual[2])
-        expectEqual(0xFFFFFFFF_FFFFFFFF, negative.actual[.max])
-      }
+#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32) || arch(powerpc)
+      expectEqual(0x33221101, negative.actual[0])
+      expectEqual(0x77665544, negative.actual[1])
+      expectEqual(0xBBAA9988, negative.actual[2])
+      expectEqual(0xFFEEDDCC, negative.actual[3])
+      expectEqual(0xFFFFFFFF, negative.actual[4])
+      expectEqual(0xFFFFFFFF, negative.actual[.max])
+#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+      expectEqual(0x77665544_33221101, negative.actual[0])
+      expectEqual(0xFFEEDDCC_BBAA9988, negative.actual[1])
+      expectEqual(0xFFFFFFFF_FFFFFFFF, negative.actual[2])
+      expectEqual(0xFFFFFFFF_FFFFFFFF, negative.actual[.max])
+#else
+#error("Unimplemented")
+#endif
     }
     do {
       let positive = Wrapper(0x00112233_44556677_8899AABB_CCDDEEFF)
       expectEqual( +1, positive.actual.signum())
       expectEqual(118, positive.actual.bitWidth)
-      if getInt(UInt.bitWidth) == 32 {
-        expectEqual(0xCCDDEEFF, positive.actual[0])
-        expectEqual(0x8899AABB, positive.actual[1])
-        expectEqual(0x44556677, positive.actual[2])
-        expectEqual(0x00112233, positive.actual[3])
-        expectEqual(0x00000000, positive.actual[4])
-        expectEqual(0x00000000, positive.actual[.max])
-      } else if getInt(UInt.bitWidth) == 64 {
-        expectEqual(0x8899AABB_CCDDEEFF, positive.actual[0])
-        expectEqual(0x00112233_44556677, positive.actual[1])
-        expectEqual(0x00000000_00000000, positive.actual[2])
-        expectEqual(0x00000000_00000000, positive.actual[.max])
-      }
+#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32) || arch(powerpc)
+      expectEqual(0xCCDDEEFF, positive.actual[0])
+      expectEqual(0x8899AABB, positive.actual[1])
+      expectEqual(0x44556677, positive.actual[2])
+      expectEqual(0x00112233, positive.actual[3])
+      expectEqual(0x00000000, positive.actual[4])
+      expectEqual(0x00000000, positive.actual[.max])
+#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
+      expectEqual(0x8899AABB_CCDDEEFF, positive.actual[0])
+      expectEqual(0x00112233_44556677, positive.actual[1])
+      expectEqual(0x00000000_00000000, positive.actual[2])
+      expectEqual(0x00000000_00000000, positive.actual[.max])
+#else
+#error("Unimplemented")
+#endif
     }
-    if getInt(UInt.bitWidth) == 64 {
+    do {
+#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32) || arch(powerpc)
+      // Unimplemented.
+#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x) || arch(riscv64)
       let fibonacciSequence = Wrapper(
         0xA94FAD42221F2702_68A3DD8E61ECCFBD_40ABCFB3C0325745_27F80DDAA1BA7878_18B3C1D91E77DECD_0F444C01834299AB_096F75D79B354522_05D4D629E80D5489_039A9FADB327F099_023A367C34E563F0_016069317E428CA9_00D9CD4AB6A2D747_00869BE6C79FB562_00533163EF0321E5_00336A82D89C937D_001FC6E116668E68_0013A3A1C2360515_000C233F54308953_000780626E057BC2_0004A2DCE62B0D91_0002DD8587DA6E31_0001C5575E509F60_0001182E2989CED1_0000AD2934C6D08F_00006B04F4C2FE42_000042244003D24D_000028E0B4BF2BF5_000019438B44A658_00000F9D297A859D_000009A661CA20BB_000005F6C7B064E2_000003AF9A19BBD9_000002472D96A909_000001686C8312D0_000000DEC1139639_00000089AB6F7C97_0000005515A419A2_0000003495CB62F5_000000207FD8B6AD_0000001415F2AC48_0000000C69E60A65_00000007AC0CA1E3_00000004BDD96882_00000002EE333961_00000001CFA62F21_000000011E8D0A40_00000000B11924E1_000000006D73E55F_0000000043A53F82_0000000029CEA5DD_0000000019D699A5_000000000FF80C38_0000000009DE8D6D_0000000006197ECB_0000000003C50EA2_0000000002547029_0000000001709E79_0000000000E3D1B0_00000000008CCCC9_00000000005704E7_000000000035C7E2_0000000000213D05_0000000000148ADD_00000000000CB228_000000000007D8B5_000000000004D973_000000000002FF42_000000000001DA31_0000000000012511_000000000000B520_0000000000006FF1_000000000000452F_0000000000002AC2_0000000000001A6D_0000000000001055_0000000000000A18_000000000000063D_00000000000003DB_0000000000000262_0000000000000179_00000000000000E9_0000000000000090_0000000000000059_0000000000000037_0000000000000022_0000000000000015_000000000000000D_0000000000000008_0000000000000005_0000000000000003_0000000000000002_0000000000000001_0000000000000001_0000000000000000
       )
@@ -201,6 +208,9 @@ extension StaticBigIntTests {
           fibonacciSequence.actual[wordIndex - 2]
         )
       }
+#else
+#error("Unimplemented")
+#endif
     }
   }
 }


### PR DESCRIPTION
Cherry-pick of apple/swift#62746.

**Explanation**: Prevents `use_os_stdlib` testing. Fixes watchOS device testing.

**Scope**: One stdlib test file.

**Issue**: <rdar://103369837>

**Risk**: None.

**Testing**: Unable to pre-test on a watchOS device (or 32-bit simulator).

**Reviewer**: @stephentyrone is the release manager for the Swift Standard Library.