### PR TITLE
[Compile Time Constant Extraction] Add extraction of Dictionary values.

### DIFF
--- a/include/swift/AST/ConstTypeInfo.h
+++ b/include/swift/AST/ConstTypeInfo.h
@@ -102,24 +102,6 @@ private:
   std::vector<CompileTimeValue> Members;
 };
 
-/// A dictionary literal value representation
-class DictionaryValue : public CompileTimeValue {
-public:
-  DictionaryValue(std::vector<std::shared_ptr<CompileTimeValue>> elements)
-      : CompileTimeValue(ValueKind::Dictionary), elements(elements) {}
-
-  static bool classof(const CompileTimeValue *T) {
-    return T->getKind() == ValueKind::Dictionary;
-  }
-
-  std::vector<std::shared_ptr<CompileTimeValue>> getElements() const {
-    return elements;
-  }
-
-private:
-  std::vector<std::shared_ptr<CompileTimeValue>> elements;
-};
-
 struct TupleElement {
   Optional<std::string> Label;
   swift::Type Type;
@@ -157,6 +139,24 @@ public:
 
 private:
   std::vector<std::shared_ptr<CompileTimeValue>> Elements;
+};
+
+/// A dictionary literal value representation
+class DictionaryValue : public CompileTimeValue {
+public:
+  DictionaryValue(std::vector<std::shared_ptr<TupleValue>> elements)
+      : CompileTimeValue(ValueKind::Dictionary), Elements(elements) {}
+
+  static bool classof(const CompileTimeValue *T) {
+    return T->getKind() == ValueKind::Dictionary;
+  }
+
+  std::vector<std::shared_ptr<TupleValue>> getElements() const {
+    return Elements;
+  }
+
+private:
+  std::vector<std::shared_ptr<TupleValue>> Elements;
 };
 
 /// A representation of an arbitrary value that does not fall under

--- a/include/swift/AST/ConstTypeInfo.h
+++ b/include/swift/AST/ConstTypeInfo.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -105,11 +105,19 @@ private:
 /// A dictionary literal value representation
 class DictionaryValue : public CompileTimeValue {
 public:
-  DictionaryValue() : CompileTimeValue(ValueKind::Dictionary) {}
+  DictionaryValue(std::vector<std::shared_ptr<CompileTimeValue>> elements)
+      : CompileTimeValue(ValueKind::Dictionary), elements(elements) {}
 
   static bool classof(const CompileTimeValue *T) {
     return T->getKind() == ValueKind::Dictionary;
   }
+
+  std::vector<std::shared_ptr<CompileTimeValue>> getElements() const {
+    return elements;
+  }
+
+private:
+  std::vector<std::shared_ptr<CompileTimeValue>> elements;
 };
 
 struct TupleElement {

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -151,7 +151,9 @@ static std::shared_ptr<CompileTimeValue> extractCompileTimeValue(Expr *expr) {
       std::vector<std::shared_ptr<TupleValue>> tuples;
       for (auto elementExpr : dictionaryExpr->getElements()) {
         auto elementValue = extractCompileTimeValue(elementExpr);
-        tuples.push_back(std::static_pointer_cast<TupleValue>(elementValue));
+        if (isa<TupleValue>(elementValue.get())) {
+          tuples.push_back(std::static_pointer_cast<TupleValue>(elementValue));
+        }
       }
       return std::make_shared<DictionaryValue>(tuples);
     }

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -148,12 +148,12 @@ static std::shared_ptr<CompileTimeValue> extractCompileTimeValue(Expr *expr) {
 
     case ExprKind::Dictionary: {
       auto dictionaryExpr = cast<DictionaryExpr>(expr);
-      std::vector<std::shared_ptr<CompileTimeValue>> elementValues;
-      for (unsigned n = dictionaryExpr->getNumElements(), i = 0; i != n; i++) {
-        auto elementExpr = dictionaryExpr->getElement(i);
-        elementValues.push_back(extractCompileTimeValue(elementExpr));
+      std::vector<std::shared_ptr<TupleValue>> tuples;
+      for (auto elementExpr : dictionaryExpr->getElements()) {
+        auto elementValue = extractCompileTimeValue(elementExpr);
+        tuples.push_back(std::static_pointer_cast<TupleValue>(elementValue));
       }
-      return std::make_shared<DictionaryValue>(elementValues);
+      return std::make_shared<DictionaryValue>(tuples);
     }
 
     case ExprKind::Tuple: {
@@ -392,8 +392,8 @@ void writeValue(llvm::json::OStream &JSON,
   case CompileTimeValue::ValueKind::Dictionary: {
     JSON.attribute("valueKind", "Dictionary");
     JSON.attributeArray("value", [&] {
-      for (auto element : cast<DictionaryValue>(value)->getElements()) {
-        auto tupleElements = cast<TupleValue>(element.get())->getElements();
+      for (auto tupleValue : cast<DictionaryValue>(value)->getElements()) {
+        auto tupleElements = tupleValue.get()->getElements();
         JSON.object([&] {
           JSON.attributeObject(
               "key", [&] { writeValue(JSON, tupleElements[0].Value); });

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -123,8 +123,6 @@ parseProtocolListFromFile(StringRef protocolListFilePath,
 static std::shared_ptr<CompileTimeValue> extractCompileTimeValue(Expr *expr) {
   if (expr) {
     switch (expr->getKind()) {
-    case ExprKind::Dictionary:
-
     case ExprKind::BooleanLiteral:
     case ExprKind::FloatLiteral:
     case ExprKind::IntegerLiteral:
@@ -146,6 +144,16 @@ static std::shared_ptr<CompileTimeValue> extractCompileTimeValue(Expr *expr) {
         elementValues.push_back(extractCompileTimeValue(elementExpr));
       }
       return std::make_shared<ArrayValue>(elementValues);
+    }
+
+    case ExprKind::Dictionary: {
+      auto dictionaryExpr = cast<DictionaryExpr>(expr);
+      std::vector<std::shared_ptr<CompileTimeValue>> elementValues;
+      for (unsigned n = dictionaryExpr->getNumElements(), i = 0; i != n; i++) {
+        auto elementExpr = dictionaryExpr->getElement(i);
+        elementValues.push_back(extractCompileTimeValue(elementExpr));
+      }
+      return std::make_shared<DictionaryValue>(elementValues);
     }
 
     case ExprKind::Tuple: {
@@ -383,6 +391,17 @@ void writeValue(llvm::json::OStream &JSON,
 
   case CompileTimeValue::ValueKind::Dictionary: {
     JSON.attribute("valueKind", "Dictionary");
+    JSON.attributeArray("value", [&] {
+      for (auto element : cast<DictionaryValue>(value)->getElements()) {
+        auto tupleElements = cast<TupleValue>(element.get())->getElements();
+        JSON.object([&] {
+          JSON.attributeObject(
+              "key", [&] { writeValue(JSON, tupleElements[0].Value); });
+          JSON.attributeObject(
+              "value", [&] { writeValue(JSON, tupleElements[1].Value); });
+        });
+      }
+    });
     break;
   }
 

--- a/test/ConstExtraction/ExtractGroups.swift
+++ b/test/ConstExtraction/ExtractGroups.swift
@@ -81,8 +81,118 @@
 // CHECK-NEXT:        "type": "[Swift.String : Swift.Int]",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
-// CHECK-NEXT:        "valueKind": "RawLiteral",
-// CHECK-NEXT:        "value": "[(\"One\", 1), (\"Two\", 2), (\"Three\", 3)]"
+// CHECK-NEXT:        "valueKind": "Dictionary",
+// CHECK-NEXT:        "value": [
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "key": {
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "\"One\""
+// CHECK-NEXT:            },
+// CHECK-NEXT:            "value": {
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "1"
+// CHECK-NEXT:            }
+// CHECK-NEXT:          },
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "key": {
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "\"Two\""
+// CHECK-NEXT:            },
+// CHECK-NEXT:            "value": {
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "2"
+// CHECK-NEXT:            }
+// CHECK-NEXT:          },
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "key": {
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "\"Three\""
+// CHECK-NEXT:            },
+// CHECK-NEXT:            "value": {
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "3"
+// CHECK-NEXT:            }
+// CHECK-NEXT:          }
+// CHECK-NEXT:        ]
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "dict2",
+// CHECK-NEXT:        "type": "[Swift.Int : [Swift.String]]",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "valueKind": "Dictionary",
+// CHECK-NEXT:        "value": [
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "key": {
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "1"
+// CHECK-NEXT:            },
+// CHECK-NEXT:            "value": {
+// CHECK-NEXT:              "valueKind": "Array",
+// CHECK-NEXT:              "value": [
+// CHECK-NEXT:                {
+// CHECK-NEXT:                  "valueKind": "RawLiteral",
+// CHECK-NEXT:                  "value": "\"a\""
+// CHECK-NEXT:                },
+// CHECK-NEXT:                {
+// CHECK-NEXT:                  "valueKind": "RawLiteral",
+// CHECK-NEXT:                  "value": "\"b\""
+// CHECK-NEXT:                },
+// CHECK-NEXT:                {
+// CHECK-NEXT:                  "valueKind": "RawLiteral",
+// CHECK-NEXT:                  "value": "\"c\""
+// CHECK-NEXT:                }
+// CHECK-NEXT:              ]
+// CHECK-NEXT:            }
+// CHECK-NEXT:          },
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "key": {
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "2"
+// CHECK-NEXT:            },
+// CHECK-NEXT:            "value": {
+// CHECK-NEXT:              "valueKind": "Array",
+// CHECK-NEXT:              "value": [
+// CHECK-NEXT:                {
+// CHECK-NEXT:                  "valueKind": "RawLiteral",
+// CHECK-NEXT:                  "value": "\"z\""
+// CHECK-NEXT:                }
+// CHECK-NEXT:              ]
+// CHECK-NEXT:            }
+// CHECK-NEXT:          }
+// CHECK-NEXT:        ]
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "dict3",
+// CHECK-NEXT:        "type": "[Swift.String : ExtractGroups.Foo]",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "valueKind": "Dictionary",
+// CHECK-NEXT:        "value": [
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "key": {
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "\"Bar\""
+// CHECK-NEXT:            },
+// CHECK-NEXT:            "value": {
+// CHECK-NEXT:              "valueKind": "InitCall",
+// CHECK-NEXT:              "value": {
+// CHECK-NEXT:                "type": "ExtractGroups.Bar",
+// CHECK-NEXT:                "arguments": []
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:          },
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "key": {
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "\"Int\""
+// CHECK-NEXT:            },
+// CHECK-NEXT:            "value": {
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "42"
+// CHECK-NEXT:            }
+// CHECK-NEXT:          }
+// CHECK-NEXT:        ]
 // CHECK-NEXT:      }
 // CHECK-NEXT:    ]
 // CHECK-NEXT:  },
@@ -155,6 +265,14 @@ public struct Arrays : MyProto {
 
 public struct Dictionaries : MyProto {
     let dict1: [String: Int] = ["One": 1, "Two": 2, "Three": 3]
+    let dict2: [Int: [String]] = [
+        1: ["a", "b", "c"],
+        2: ["z"]
+    ]
+    let dict3: [String: Foo] = [
+        "Bar": Bar(),
+        "Int": 42
+    ]
 }
 
 public struct Tuples : MyProto {


### PR DESCRIPTION
Handle extraction of `ExprKind::Dictionary` type.
Update `DictionaryValue` to accept `TupleValue` elements for key-value pairs.
Add JSON output as an array of objects with `"key"` and `"value"` attributes.
Update ExtractGroups.swift with expected JSON output and new test cases.