### PR TITLE
[ASTScope] Remove a now-incorrect and not-actually-useful assertion.

### DIFF
--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -45,6 +45,13 @@ func testStringify(a: Int, b: Int) {
   _ = (b, b2, s2, s3)
 }
 
+struct Outer {
+  var value: Int = 0
+  func test() {
+    _ = #stringify(1 + value)
+  }
+}
+
 // CHECK: (2, "a + b")
 testStringify(a: 1, b: 1)
 


### PR DESCRIPTION
This assertion is incorrect now that we have macro expansion buffers, which don't meet the narrow definition of "inside" from this check.
