### PR TITLE
[cxx-interop] Treat name lookup as successful if we found a C++ member operator

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4074,9 +4074,11 @@ bool ClangImporter::Implementation::lookupValue(SwiftLookupTable &table,
           if (auto func = dyn_cast_or_null<FuncDecl>(
                   importDeclReal(entry->getMostRecentDecl(), CurrentVersion))) {
             if (auto synthesizedOperator =
-                    importer->getCXXSynthesizedOperatorFunc(func))
+                    importer->getCXXSynthesizedOperatorFunc(func)) {
               consumer.foundDecl(synthesizedOperator,
                                  DeclVisibilityKind::VisibleAtTopLevel);
+              declFound = true;
+            }
           }
         }
       }


### PR DESCRIPTION
`ClangImporter::Implementation::lookupValue` used to return `false` if it found an overloaded C++ operator that is declared as a member function of a C++ type.

This doesn't have any effect now since the return value isn't used under normal conditions, but it might bite us later.