### PR TITLE
[cxx-interop] Allow instantiated operator methods to serve as protocol conformance witnesses

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -4021,6 +4021,30 @@ SwiftLookupTable *ClangImporter::Implementation::findLookupTable(
   return known->second.get();
 }
 
+SwiftLookupTable *
+ClangImporter::Implementation::findLookupTable(const clang::Decl *decl) {
+  // Contents of a C++ namespace are added to the __ObjC module.
+  bool isWithinNamespace = false;
+  auto declContext = decl->getDeclContext();
+  while (!declContext->isTranslationUnit()) {
+    if (declContext->isNamespace()) {
+      isWithinNamespace = true;
+      break;
+    }
+    declContext = declContext->getParent();
+  }
+
+  clang::Module *owningModule = nullptr;
+  if (!isWithinNamespace) {
+    // Members of class template specializations don't have an owning module.
+    if (auto spec = dyn_cast<clang::ClassTemplateSpecializationDecl>(decl))
+      owningModule = spec->getSpecializedTemplate()->getOwningModule();
+    else
+      owningModule = decl->getOwningModule();
+  }
+  return findLookupTable(owningModule);
+}
+
 bool ClangImporter::Implementation::forEachLookupTable(
        llvm::function_ref<bool(SwiftLookupTable &table)> fn) {
   // Visit the bridging header's lookup table.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2118,15 +2118,7 @@ namespace {
           if (friendDecl->getFriendDecl()) {
             m = friendDecl->getFriendDecl();
 
-            // Find the owning module of the class template. Members of class
-            // template specializations don't have an owning module.
-            clang::Module *owningModule = nullptr;
-            if (auto spec = dyn_cast<clang::ClassTemplateSpecializationDecl>(decl))
-              owningModule = spec->getSpecializedTemplate()->getOwningModule();
-            else
-              owningModule = decl->getOwningModule();
-
-            auto lookupTable = Impl.findLookupTable(owningModule);
+            auto lookupTable = Impl.findLookupTable(decl);
             addEntryToLookupTable(*lookupTable, friendDecl->getFriendDecl(),
                                   Impl.getNameImporter());
           }
@@ -2243,6 +2235,9 @@ namespace {
 
               // Make sure the synthesized decl can be found by lookupDirect.
               result->addMemberToLookupTable(opFuncDecl);
+
+              addEntryToLookupTable(*Impl.findLookupTable(decl), cxxMethod,
+                                    Impl.getNameImporter());
             }
           }
           methods.push_back(MD);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1644,6 +1644,9 @@ public:
   /// about the directly-parsed headers.
   SwiftLookupTable *findLookupTable(const clang::Module *clangModule);
 
+  /// Find the lookup table that should contain the given Clang declaration.
+  SwiftLookupTable *findLookupTable(const clang::Decl *decl);
+
   /// Visit each of the lookup tables in some deterministic order.
   ///
   /// \param fn Invoke the given visitor for each table. If the

--- a/test/Interop/Cxx/class/Inputs/protocol-conformance.h
+++ b/test/Interop/Cxx/class/Inputs/protocol-conformance.h
@@ -55,4 +55,16 @@ struct HasOperatorEqualEqual {
   }
 };
 
+template <typename T>
+struct HasOperatorPlusEqual {
+  T value;
+
+  HasOperatorPlusEqual &operator+=(int x) {
+    value += x;
+    return *this;
+  }
+};
+
+using HasOperatorPlusEqualInt = HasOperatorPlusEqual<int>;
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_PROTOCOL_CONFORMANCE_H

--- a/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-typechecker.swift
@@ -35,3 +35,10 @@ protocol Invertable {
 extension HasOperatorExclaim: Invertable {}
 
 extension HasOperatorEqualEqual: Equatable {}
+
+
+protocol HasOperatorPlusEqualProtocol {
+  static func +=(lhs: inout Self, x: Int32)
+}
+
+extension HasOperatorPlusEqualInt : HasOperatorPlusEqualProtocol {}


### PR DESCRIPTION
If a templated C++ class declares an operator as a member function, and is instantiated using a typedef or a using-decl on the C++ side, it previously could not be conformed to a Swift protocol that requires the operator function despite matching signatures.

This was due to a Swift name lookup issue: operators, unlike regular member functions, are found by doing an unqualified lookup. Since C++ class template specializations and their members are not added to `SwiftLookupTable`, when doing qualified lookup members are searched by looking at all of the members of the specialization and choosing the ones with matching names. With unqualified lookup, we cannot rely on knowing the right specialization and need to search for all the operators in a given module.

This change adds synthesized operator thunks to `SwiftLookupTable` to make them discoverable by unqualified lookup.