### PR TITLE
[CSClosure] Fix handling of non-representivate variables

### DIFF
--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -197,10 +197,22 @@ private:
         return;
     }
 
+    // Don't walk into the opaque archetypes because they are not
+    // transparent in this context - `some P` could reference a
+    // type variables as substitutions which are visible only to
+    // the outer context.
+    if (type->is<OpaqueTypeArchetypeType>())
+      return;
+
     if (type->hasTypeVariable()) {
       SmallPtrSet<TypeVariableType *, 4> typeVars;
       type->getTypeVariables(typeVars);
-      ReferencedVars.insert(typeVars.begin(), typeVars.end());
+
+      // Some of the type variables could be non-representative, so
+      // we need to recurse into `inferTypeVariables` to property
+      // handle them.
+      for (auto *typeVar : typeVars)
+        inferVariables(typeVar);
     }
   }
 };

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar83418797.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar83418797.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Description: Hashable {
+  let name: String
+  let id: Int
+}
+
+struct Value {
+  let ID: Int?
+}
+
+func test(allValues: [Value]) {
+  // Type for `return nil` cannot be inferred at the moment because there is no join for result expressions.
+  let owners = Set(allValues.compactMap { // expected-error {{generic parameter 'Element' could not be inferred}}
+      // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}}
+      guard let id = $0.ID else { return nil }
+      return Description(name: "", id: id)
+    })
+}


### PR DESCRIPTION
All of the type variables referenced by a type had to be handled by `inferVariables` 
otherwise it would to possible to bring non-representative variable into scope which 
in turn later would get simplied into a variable that doesn't exist in the active scope 
and solver would crash.

Resolves: rdar://83418797


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
