### PR TITLE
[cxx-interop][android] Exclude Android from the list of platforms to link against the swiftstd library

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -496,7 +496,7 @@ void IRGenModule::emitSourceFile(SourceFile &SF) {
 
     // Only link with std on platforms where the overlay is available.
     // Do not try to link std with itself.
-    if ((target.isOSDarwin() || target.isOSLinux()) &&
+    if ((target.isOSDarwin() || (target.isOSLinux() && !target.isAndroid())) &&
         !getSwiftModule()->getName().is("Cxx") &&
         !getSwiftModule()->getName().is("std"))
       this->addLinkLibrary(LinkLibrary("swiftstd", LibraryKind::Library));


### PR DESCRIPTION
I just built the toolchain natively on Android from the last Dec. 21 source snapshot and most of the C++ Interop tests in the validation suite fail because of this recent change. I'm unsure why this didn't break anything on the community Android CI that cross-compiles the stdlib and tests, maybe it's picking up the linux overlay somehow?

@egorzhdan, please review whenever you get back from your winter break, no hurry. @3405691582, let me know if I should exclude OpenBSD here too, and @mhjacobson, I can add FreeBSD if you need it.