### PR TITLE
[CSSimplify] Fix sub-pattern matching logic related closure and enum element

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2063,21 +2063,17 @@ static bool isInPatternMatchingContext(ConstraintLocatorBuilder locator) {
     if (path.back().is<LocatorPathElt::PatternMatch>()) {
       return true;
     } else if (path.size() > 1) {
+      auto pathElement = llvm::find_if(path, [](LocatorPathElt &elt) {
+          return elt.is<LocatorPathElt::PatternMatch>();
+      });
+      
+      if (pathElement == path.end())
+          return false;
       // sub-pattern matching as part of the enum element matching
       // where sub-element is a tuple pattern e.g.
       // `case .foo((a: 42, _)) = question`
-      auto lastIdx = path.size() - 1;
-      if (path[lastIdx - 1].is<LocatorPathElt::PatternMatch>() &&
-          path[lastIdx].is<LocatorPathElt::FunctionArgument>())
-        return true;
-      
-      if (path.size() > 5) {
-        // `case .bar(_, (_, (_, (_, (let a, _), _), _))) = question`
-        if (path[3].is<LocatorPathElt::PatternMatch>() &&
-            path[4].is<LocatorPathElt::FunctionArgument>() &&
-            path[lastIdx].is<LocatorPathElt::TupleElement>())
-            return true;
-        }
+      if (pathElement->is<LocatorPathElt::PatternMatch>())
+          return true;
     }
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2055,8 +2055,6 @@ static bool isInPatternMatchingContext(ConstraintLocatorBuilder locator) {
   SmallVector<LocatorPathElt, 4> path;
   (void)locator.getLocatorParts(path);
 
-  // Direct pattern or sub-pattern matching of tuple element.
-  // e.g.`case .foo((a: 42, _)) = question`
   auto pathElement = llvm::find_if(path, [](LocatorPathElt &elt) {
     return elt.is<LocatorPathElt::PatternMatch>();
   });

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2057,7 +2057,6 @@ static bool isInPatternMatchingContext(ConstraintLocatorBuilder locator) {
 
   while (!path.empty() && path.back().is<LocatorPathElt::TupleType>())
     path.pop_back();
-
   if (!path.empty()) {
     // Direct pattern matching between tuple pattern and tuple type.
     // sub-pattern matching as part of the enum element matching

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2063,20 +2063,26 @@ static bool isInPatternMatchingContext(ConstraintLocatorBuilder locator) {
     if (path.back().is<LocatorPathElt::PatternMatch>()) {
       return true;
     } else if (path.size() > 1) {
-      // sub-pattern matching as part of the enum element matching
-      // where sub-element is a tuple pattern e.g.
-      // `case .foo((a: 42, _)) = question`
-      auto lastIdx = path.size() - 1;
-      if (path[lastIdx - 1].is<LocatorPathElt::PatternMatch>() &&
-          path[lastIdx].is<LocatorPathElt::FunctionArgument>())
-        return true;
-      
-      if (path.size() > 5) {
-        // `case .bar(_, (_, (_, (_, (let a, _), _), _))) = question`
-        if (path[3].is<LocatorPathElt::PatternMatch>() &&
-            path[4].is<LocatorPathElt::FunctionArgument>() &&
-            path[lastIdx].is<LocatorPathElt::TupleElement>())
+        int patternMatchIdx = 0;
+        for (int i = 0; i < (int)path.size(); i++) {
+            if (path[i].is<LocatorPathElt::PatternMatch>()) {
+                patternMatchIdx = i;
+            }
+        }
+        
+        // sub-pattern matching as part of the enum element matching
+        // where sub-element is a tuple pattern e.g.
+        // `case .foo((a: 42, _)) = question`
+        if (path[patternMatchIdx].is<LocatorPathElt::PatternMatch>() &&
+            path[patternMatchIdx + 1].is<LocatorPathElt::FunctionArgument>())
             return true;
+        
+        if (path.size() > 2) {
+            // `case .bar(_, (_, (_, (_, (let a, _), _), _))) = question`
+            if (path[patternMatchIdx].is<LocatorPathElt::PatternMatch>() &&
+                path[patternMatchIdx + 1].is<LocatorPathElt::FunctionArgument>() &&
+                path[patternMatchIdx + 2].is<LocatorPathElt::TupleElement>())
+                return true;
         }
     }
   }
@@ -2239,6 +2245,10 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
   case ConstraintKind::Equal: {
     subkind = kind;
 
+      auto &e = llvm::errs();
+      e << "@@ locator dump =>";
+      locator.dump(this);
+      e << "\n";
     if (isInPatternMatchingContext(locator)) {
       if (matcher.matchInPatternMatchingContext())
         return getTypeMatchFailure(locator);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2055,18 +2055,12 @@ static bool isInPatternMatchingContext(ConstraintLocatorBuilder locator) {
   SmallVector<LocatorPathElt, 4> path;
   (void)locator.getLocatorParts(path);
 
-  while (!path.empty() && path.back().is<LocatorPathElt::TupleType>())
-    path.pop_back();
-  if (!path.empty()) {
-    // Direct pattern or sub-pattern matching of tuple element.
-    // e.g.`case .foo((a: 42, _)) = question`
-    auto pathElement = llvm::find_if(path, [](LocatorPathElt &elt) {
-        return elt.is<LocatorPathElt::PatternMatch>();
-    });
-    return pathElement != path.end();
-  }
-
-  return false;
+  // Direct pattern or sub-pattern matching of tuple element.
+  // e.g.`case .foo((a: 42, _)) = question`
+  auto pathElement = llvm::find_if(path, [](LocatorPathElt &elt) {
+    return elt.is<LocatorPathElt::PatternMatch>();
+  });
+  return pathElement != path.end();
 }
 
 namespace {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2060,16 +2060,13 @@ static bool isInPatternMatchingContext(ConstraintLocatorBuilder locator) {
 
   if (!path.empty()) {
     // Direct pattern matching between tuple pattern and tuple type.
-      auto pathElement = llvm::find_if(path, [](LocatorPathElt &elt) {
-          return elt.is<LocatorPathElt::PatternMatch>();
-      });
-      return pathElement != path.end();
-      // sub-pattern matching as part of the enum element matching
-      // where sub-element is a tuple pattern e.g.
-      // `case .foo((a: 42, _)) = question`
-      if (pathElement->is<LocatorPathElt::PatternMatch>())
-          return true;
-    }
+    // sub-pattern matching as part of the enum element matching
+    // where sub-element is a tuple pattern e.g.
+    // `case .foo((a: 42, _)) = question`
+    auto pathElement = llvm::find_if(path, [](LocatorPathElt &elt) {
+        return elt.is<LocatorPathElt::PatternMatch>();
+    });
+    return pathElement != path.end();
   }
 
   return false;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2070,11 +2070,15 @@ static bool isInPatternMatchingContext(ConstraintLocatorBuilder locator) {
       if (path[lastIdx - 1].is<LocatorPathElt::PatternMatch>() &&
           path[lastIdx].is<LocatorPathElt::FunctionArgument>())
         return true;
-      // `case .foo((let a, _), let b) = question`
-      if (path[lastIdx - 2].is<LocatorPathElt::PatternMatch>() &&
-          path[lastIdx - 1].is<LocatorPathElt::FunctionArgument>() &&
-          path[lastIdx].is<LocatorPathElt::TupleElement>())
-        return true;
+      
+        if (path.size() > 5) {
+            // `case .bar(_, (_, (_, (_, (let a, _), _), _))) = question`
+            if (path[3].is<LocatorPathElt::PatternMatch>() &&
+                path[4].is<LocatorPathElt::FunctionArgument>() &&
+                path[lastIdx].is<LocatorPathElt::TupleElement>())
+                return true;
+        }
+      
     }
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2070,6 +2070,11 @@ static bool isInPatternMatchingContext(ConstraintLocatorBuilder locator) {
       if (path[lastIdx - 1].is<LocatorPathElt::PatternMatch>() &&
           path[lastIdx].is<LocatorPathElt::FunctionArgument>())
         return true;
+      // `case .foo((let a, _), let b) = question`
+      if (path[lastIdx - 2].is<LocatorPathElt::PatternMatch>() &&
+          path[lastIdx - 1].is<LocatorPathElt::FunctionArgument>() &&
+          path[lastIdx].is<LocatorPathElt::TupleElement>())
+        return true;
     }
   }
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2060,15 +2060,10 @@ static bool isInPatternMatchingContext(ConstraintLocatorBuilder locator) {
 
   if (!path.empty()) {
     // Direct pattern matching between tuple pattern and tuple type.
-    if (path.back().is<LocatorPathElt::PatternMatch>()) {
-      return true;
-    } else if (path.size() > 1) {
       auto pathElement = llvm::find_if(path, [](LocatorPathElt &elt) {
           return elt.is<LocatorPathElt::PatternMatch>();
       });
-      
-      if (pathElement == path.end())
-          return false;
+      return pathElement != path.end();
       // sub-pattern matching as part of the enum element matching
       // where sub-element is a tuple pattern e.g.
       // `case .foo((a: 42, _)) = question`

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2058,10 +2058,8 @@ static bool isInPatternMatchingContext(ConstraintLocatorBuilder locator) {
   while (!path.empty() && path.back().is<LocatorPathElt::TupleType>())
     path.pop_back();
   if (!path.empty()) {
-    // Direct pattern matching between tuple pattern and tuple type.
-    // sub-pattern matching as part of the enum element matching
-    // where sub-element is a tuple pattern e.g.
-    // `case .foo((a: 42, _)) = question`
+    // Direct pattern or sub-pattern matching of tuple element.
+    // e.g.`case .foo((a: 42, _)) = question`
     auto pathElement = llvm::find_if(path, [](LocatorPathElt &elt) {
         return elt.is<LocatorPathElt::PatternMatch>();
     });

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2071,14 +2071,13 @@ static bool isInPatternMatchingContext(ConstraintLocatorBuilder locator) {
           path[lastIdx].is<LocatorPathElt::FunctionArgument>())
         return true;
       
-        if (path.size() > 5) {
-            // `case .bar(_, (_, (_, (_, (let a, _), _), _))) = question`
-            if (path[3].is<LocatorPathElt::PatternMatch>() &&
-                path[4].is<LocatorPathElt::FunctionArgument>() &&
-                path[lastIdx].is<LocatorPathElt::TupleElement>())
-                return true;
+      if (path.size() > 5) {
+        // `case .bar(_, (_, (_, (_, (let a, _), _), _))) = question`
+        if (path[3].is<LocatorPathElt::PatternMatch>() &&
+            path[4].is<LocatorPathElt::FunctionArgument>() &&
+            path[lastIdx].is<LocatorPathElt::TupleElement>())
+            return true;
         }
-      
     }
   }
 

--- a/test/Constraints/sub-pattern-matching-of-enum-element-for-closure.swift
+++ b/test/Constraints/sub-pattern-matching-of-enum-element-for-closure.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 enum TestType {
     case foo
-    case bar(Bool, (a: String, String))
+    case bar(Bool, (a: String, (b: String, (String, (c: String, Bool), String), String)))
 }
 
 func test(type: TestType) -> String {
@@ -9,8 +9,8 @@ func test(type: TestType) -> String {
         switch type {
         case .foo:
             return ""
-        case .bar(_, (let a, _)):
-            return a
+        case .bar(_, (_, (_, (_, (let c, _), _), _))):
+            return c
         }
     }()
     

--- a/test/Constraints/sub-pattern-matching-of-enum-element-for-closure.swift
+++ b/test/Constraints/sub-pattern-matching-of-enum-element-for-closure.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift
+enum TestType {
+    case foo
+    case bar(Bool, (a: String, String))
+}
+
+func test(type: TestType) -> String {
+    let str: String = {
+        switch type {
+        case .foo:
+            return ""
+        case .bar(_, (let a, _)):
+            return a
+        }
+    }()
+    
+    return str
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->

This PR fix constraint sytem logic around closures where sub-pattern matching as part of the enum element matching. 
When you compile the code below in swift 5.7, error occur, which message is `type of expression is ambiguous without more context`, though error don't occur in swift 5.5 and swift 5.6.1. So this seems degression in swift 5.7.
```
enum TestType {
    case foo
    case bar(Bool, (a: String, String))
}

func test(type: TestType) -> String {
    let str: String = {
        switch type {
        case .foo:
            return ""
        case .bar(_, (let a, _)):
            return a
        }
    }()
    
    return str
}
```

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

I could no find any direct information on this subject. It's a similar issue . https://github.com/apple/swift/issues/60806

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
