### PR TITLE
Get the compiler building again on 32-bit architectures

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -3308,7 +3308,7 @@ public:
   /// this array will be empty
   ArrayRef<ConversionPair> getArgumentConversions() const {
     return {getTrailingObjects<ConversionPair>(),
-            Bits.ErasureExpr.NumArgumentConversions };
+            static_cast<size_t>(Bits.ErasureExpr.NumArgumentConversions) };
   }
 
   /// Retrieve the conversion expressions mapping requirements from any
@@ -3318,7 +3318,7 @@ public:
   /// this array will be empty
   MutableArrayRef<ConversionPair> getArgumentConversions() {
     return {getTrailingObjects<ConversionPair>(),
-            Bits.ErasureExpr.NumArgumentConversions };
+            static_cast<size_t>(Bits.ErasureExpr.NumArgumentConversions) };
   }
 
   void setArgumentConversion(unsigned i, const ConversionPair &p) {


### PR DESCRIPTION
I've had to use this [since earlier in the year when cross-compiling the toolchain for Android armv7](https://github.com/buttaface/termux-packages/commit/3e036bb06a16a7ec9c0c7018dc9caa0d4ec6a97f#diff-041d6f17b0656a05d2ad4e29d86e9aad4f9f3140e5294501f2529aa28dded147), along with a version of apple/llvm-project#5883.

@CodaFi, since this is a small modification to your #41743, please review whenever you get back from winter break.