### PR TITLE
stdlib: repair 32bit non-Darwin build for TypeLayout

### DIFF
--- a/stdlib/toolchain/CompatibilityBytecodeLayouts/BytecodeLayouts.cpp
+++ b/stdlib/toolchain/CompatibilityBytecodeLayouts/BytecodeLayouts.cpp
@@ -75,6 +75,14 @@ size_t BitVector::count() const {
   return total;
 }
 
+void BitVector::addPointer(uintptr_t byte) {
+#if __POINTER_WIDTH__ == 64
+  add((uint64_t)byte);
+#else
+  add((uint32_t)byte);
+#endif
+}
+
 void BitVector::add(uint64_t byte) {
   for (size_t i = 0; i < 64; i++)
     data.push_back(byte >> (63 - i) & 0x1);
@@ -391,7 +399,7 @@ BitVector MultiPayloadEnum::spareBits() const {
 
 static BitVector pointerSpareBitMask() {
   BitVector bv;
-  bv.add(heap_object_abi::SwiftSpareBitsMask);
+  bv.addPointer(heap_object_abi::SwiftSpareBitsMask);
   return bv;
 }
 

--- a/stdlib/toolchain/CompatibilityBytecodeLayouts/BytecodeLayouts.h
+++ b/stdlib/toolchain/CompatibilityBytecodeLayouts/BytecodeLayouts.h
@@ -159,6 +159,9 @@ struct BitVector {
   /// Append on a 64bit value
   void add(uint64_t values);
 
+  /// Append on a pointer-size value
+  void addPointer(uintptr_t values);
+
   /// Append on a vector of bytes
   void add(std::vector<uint8_t> values);
 


### PR DESCRIPTION
glibc's `uintptr_t` and `uint64_t` are both `unsigned long int`, but `uint32_t` is `unsigned int`, so BitVector overloads cannot be resoled on 32-bit platforms by following compilation error:

error: call to member function 'add' is ambiguous
  bv.add(heap_object_abi::SwiftSpareBitsMask);

darwin 32-bit platforms use stdint types defined in SwiftStdint.h, so they are identical

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
