### PR TITLE
build: adopt static linking for Yams on Windows toolchain

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -450,6 +450,7 @@ cmake --build %BuildRoot%\9 --target install || (exit /b)
 cmake ^
   -B %BuildRoot%\10 ^
 
+  -D BUILD_SHARED_LIBS=NO ^
   -D CMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^
   -D CMAKE_C_COMPILER=%BuildRoot%/1/bin/clang-cl.exe ^
   -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy /DYAML_DECLARE_EXPORT /DWIN32" ^


### PR DESCRIPTION
Windows now partially supports static linking of Swift libraries (non-swiftCore targets).  Use this to enable static linking of Yams as there is a single user (swift-driver).  This allows us to save ~256KB due to the internalisation.