### PR TITLE
Fix documentation links in CppInteroperabilityManifesto

### DIFF
--- a/docs/CppInteroperability/CppInteroperabilityManifesto.md
+++ b/docs/CppInteroperability/CppInteroperabilityManifesto.md
@@ -67,7 +67,7 @@ Assumptions:
     + [Function templates: calls with generic type parameters](#function-templates-calls-with-generic-type-parameters)
     + [Function templates: importing as real generic functions](#function-templates-importing-as-real-generic-functions)
     + [Class templates](#class-templates)
-    + [Class templates: importing instantiation behind typedef](#class-templates-importing-instantiation-behind-typedef)
+    + [Class templates: importing full class template instantiations](#class-templates-importing-full-class-template-instantiations)
     + [Class templates: importing specific specializations](#class-templates-importing-specific-specializations)
     + [Class templates: using with generic type parameters](#class-templates-using-with-generic-type-parameters)
     + [Class templates: using in generic code through a synthesized protocol](#class-templates-using-in-generic-code-through-a-synthesized-protocol)
@@ -184,7 +184,7 @@ that pick different sides, forcing the user to choose.
 
 Swift/C++ interoperability builds on top of the Swift/C interoperability, so it
 helps to be familiar with [Swift's strategy for importing C
-modules](HowSwiftImportsCAPIs.md).
+modules](../HowSwiftImportsCAPIs.md).
 
 # Importing C++ APIs into Swift
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

In `CppInteroperabilityManifesto.md` The anchor `#class-templates-importing-instantiation-behind-typedef` no longer exists and the link doesn't work. Also, the link to `HowSwiftImportsCAPIs.md` wasn't working.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
