### PR TITLE
[Diagnostics] Relax contextual type presence from assertion to a check

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1676,7 +1676,11 @@ public:
   Type getContextualType(ASTNode anchor) const {
     for (const auto &entry : contextualTypes) {
       if (entry.first == anchor) {
-        return simplifyType(entry.second.getType());
+        // The contextual information record could contain the purpose
+        // without a type i.e. when the context is an optional-some or
+        // an invalid pattern binding.
+        if (auto contextualTy = entry.second.getType())
+          return simplifyType(contextualTy);
       }
     }
     return Type();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4342,7 +4342,15 @@ static bool diagnoseAmbiguityWithContextualType(
   auto name = result->choices.front().getName();
   auto contextualTy = solution.getContextualType(anchor);
 
-  assert(contextualTy);
+  // In some situations `getContextualType` for a contextual type
+  // locator is going to return then empty type. This happens because
+  // e.g. optional-some patterns and patterns with incorrect type don't
+  // have a contextual type for initialization expression but use
+  // a conversion with contextual locator nevertheless to indicate
+  // the purpose. This doesn't affect non-ambiguity diagnostics
+  // because mismatches carry both `from` and `to` types.
+  if (!contextualTy)
+    return false;
 
   DE.diagnose(getLoc(anchor),
               contextualTy->is<ProtocolType>()

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar103739206.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar103739206.swift
@@ -1,0 +1,20 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+protocol RawTokenKindSubset {}
+
+struct Parser {
+  func canRecoverTo<Subset: RawTokenKindSubset>(anyIn subset: Subset.Type) {
+    if let (kind, handle) = self.at(anyIn: subset) {
+    }
+  }
+
+  func at(_ keyword: Int) -> Bool {}
+
+  func at(
+<<<<<<< HEAD (Note: diff markers are required for reproduction of the crash)
+  ) -> Bool {
+=======
+  ) -> Bool {
+>>>>>>> My commit message (don't remove)
+  }
+}


### PR DESCRIPTION
In some situations `getContextualType` for a contextual type locator
is going to return then empty type. This happens because e.g. 
optional-some patterns and patterns with incorrect type don't
have a contextual type for initialization expression but use a 
conversion with contextual locator nevertheless to indicate the 
purpose. This doesn't affect non-ambiguity diagnostics because
mismatches carry both `from` and `to` types.

Resolves: rdar://problem/103739206

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
