### PR TITLE
[stdlib] Export grapheme breaking facility

### DIFF
--- a/test/stdlib/CharacterRecognizer.swift
+++ b/test/stdlib/CharacterRecognizer.swift
@@ -1,0 +1,76 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-run-stdlib-swift %S/Inputs/
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: optimized_stdlib
+
+import Swift
+import StdlibUnittest
+import StdlibUnicodeUnittest
+
+var suite = TestSuite("CharacterRecognizer")
+defer { runAllTests() }
+
+if #available(SwiftStdlib 5.8, *) {
+  suite.test("Unicode test data") {
+    for test in graphemeBreakTests {
+      var it = test.string.unicodeScalars.makeIterator()
+      guard let first = it.next() else { continue }
+      var recognizer = Unicode._CharacterRecognizer(first: first)
+      var pieces: [[Unicode.Scalar]] = []
+      var piece: [Unicode.Scalar] = [first]
+      while let next = it.next() {
+        if recognizer.hasCharacterBoundary(before: next) {
+          pieces.append(piece)
+          piece = [next]
+        } else {
+          piece.append(next)
+        }
+      }
+      if !piece.isEmpty { pieces.append(piece) }
+      expectEqual(pieces, test.pieces,
+        "string: \(String(reflecting: test.string))")
+    }
+  }
+}
+
+if #available(SwiftStdlib 5.8, *) {
+  suite.test("Consistency with Swift String's behavior") {
+    let sampleString = #"""
+    The powerful programming language that is also easy to learn.
+    손쉽게 학습할 수 있는 강력한 프로그래밍 언어.
+    🪙 A 🥞 short 🍰 piece 🫘 of 🌰 text 👨‍👨‍👧‍👧 with 👨‍👩‍👦 some 🚶🏽 emoji 🇺🇸🇨🇦 characters 🧈
+    some🔩times 🛺 placed 🎣 in 🥌 the 🆘 mid🔀dle 🇦🇶or🏁 around 🏳️‍🌈 a 🍇 w🍑o🥒r🥨d
+    Unicode is such fun!
+    U̷n̷i̷c̷o̴d̴e̷ ̶i̸s̷ ̸s̵u̵c̸h̷ ̸f̵u̷n̴!̵
+    U̴̡̲͋̾n̵̻̳͌ì̶̠̕c̴̭̈͘ǫ̷̯͋̊d̸͖̩̈̈́ḛ̴́ ̴̟͎͐̈i̴̦̓s̴̜̱͘ ̶̲̮̚s̶̙̞͘u̵͕̯̎̽c̵̛͕̜̓h̶̘̍̽ ̸̜̞̿f̵̤̽ṷ̴͇̎͘ń̷͓̒!̷͍̾̚
+    U̷̢̢̧̨̼̬̰̪͓̞̠͔̗̼̙͕͕̭̻̗̮̮̥̣͉̫͉̬̲̺͍̺͊̂ͅ\#
+    n̶̨̢̨̯͓̹̝̲̣̖̞̼̺̬̤̝̊̌́̑̋̋͜͝ͅ\#
+    ḭ̸̦̺̺͉̳͎́͑\#
+    c̵̛̘̥̮̙̥̟̘̝͙̤̮͉͔̭̺̺̅̀̽̒̽̏̊̆͒͌̂͌̌̓̈́̐̔̿̂͑͠͝͝ͅ\#
+    ö̶̱̠̱̤̙͚͖̳̜̰̹̖̣̻͎͉̞̫̬̯͕̝͔̝̟̘͔̙̪̭̲́̆̂͑̌͂̉̀̓́̏̎̋͗͛͆̌̽͌̄̎̚͝͝͝͝ͅ\#
+    d̶̨̨̡̡͙̟͉̱̗̝͙͍̮͍̘̮͔͑\#
+    e̶̢͕̦̜͔̘̘̝͈̪̖̺̥̺̹͉͎͈̫̯̯̻͑͑̿̽͂̀̽͋́̎̈́̈̿͆̿̒̈́̽̔̇͐͛̀̓͆̏̾̀̌̈́̆̽̕ͅ
+    """#
+
+    let expectedBreaks = Array(sampleString.indices)
+
+    let u = sampleString.unicodeScalars
+    var i = u.startIndex
+    var actualBreaks = [i]
+    var recognizer = Unicode._CharacterRecognizer(first: u[i])
+    u.formIndex(after: &i)
+    while i < u.endIndex {
+      if recognizer.hasCharacterBoundary(before: u[i]) {
+        actualBreaks.append(i)
+      }
+      u.formIndex(after: &i)
+    }
+    expectEqual(actualBreaks, expectedBreaks,
+      """
+      actualBreaks: \(actualBreaks.map { $0._description })
+      expectedBreaks: \(expectedBreaks.map { $0._description })
+      """)
+  }
+}

--- a/test/stdlib/CharacterRecognizer.swift
+++ b/test/stdlib/CharacterRecognizer.swift
@@ -13,19 +13,17 @@ var suite = TestSuite("CharacterRecognizer")
 defer { runAllTests() }
 
 if #available(SwiftStdlib 5.8, *) {
-  suite.test("Unicode test data") {
+  suite.test("Unicode test data/hasBreak") {
     for test in graphemeBreakTests {
-      var it = test.string.unicodeScalars.makeIterator()
-      guard let first = it.next() else { continue }
-      var recognizer = Unicode._CharacterRecognizer(first: first)
+      var recognizer = Unicode._CharacterRecognizer()
       var pieces: [[Unicode.Scalar]] = []
-      var piece: [Unicode.Scalar] = [first]
-      while let next = it.next() {
-        if recognizer.hasCharacterBoundary(before: next) {
-          pieces.append(piece)
-          piece = [next]
+      var piece: [Unicode.Scalar] = []
+      for scalar in test.string.unicodeScalars {
+        if recognizer.hasBreak(before: scalar) {
+          if !piece.isEmpty { pieces.append(piece) }
+          piece = [scalar]
         } else {
-          piece.append(next)
+          piece.append(scalar)
         }
       }
       if !piece.isEmpty { pieces.append(piece) }
@@ -57,15 +55,13 @@ if #available(SwiftStdlib 5.8, *) {
     let expectedBreaks = Array(sampleString.indices)
 
     let u = sampleString.unicodeScalars
-    var i = u.startIndex
-    var actualBreaks = [i]
-    var recognizer = Unicode._CharacterRecognizer(first: u[i])
-    u.formIndex(after: &i)
-    while i < u.endIndex {
-      if recognizer.hasCharacterBoundary(before: u[i]) {
+
+    var recognizer = Unicode._CharacterRecognizer()
+    var actualBreaks: [String.Index] = []
+    for i in u.indices {
+      if recognizer.hasBreak(before: u[i]) {
         actualBreaks.append(i)
       }
-      u.formIndex(after: &i)
     }
     expectEqual(actualBreaks, expectedBreaks,
       """

--- a/test/stdlib/StringIndex.swift
+++ b/test/stdlib/StringIndex.swift
@@ -656,8 +656,8 @@ suite.test("Fully exhaustive index interchange")
 
 #if _runtime(_ObjC)
 suite.test("Fully exhaustive index interchange/GraphemeBreakTests") {
-  for string in graphemeBreakTests.map { $0.0 } {
-    fullyExhaustiveIndexInterchange(string)
+  for test in graphemeBreakTests {
+    fullyExhaustiveIndexInterchange(test.string)
   }
 }
 #endif


### PR DESCRIPTION
`Unicode._CharacterRecognizer` is a newly exported opaque type that exposes the stdlib’s extended grapheme cluster breaking facility, independent of `String`.

This essentially makes the underlying simple state machine public, without exposing any of the (unstable) Unicode details.

The ability to perform grapheme breaking over, say, the scalars stored in multiple `String` values can be extremely useful while building custom text processing algorithms and data structures.

Ideally this would eventually become API, but before proposing this to Swift Evolution, I’d like to prove the shape of the type in actual use (and we’ll also need to find better names for its operations).

rdar://103903565