### PR TITLE
[Diagnostics][Sema] Improving global actor function mismatch diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -401,6 +401,34 @@ NOTE(generic_parameter_inferred_from_result_context,none,
      "generic parameter %0 inferred as %1 from context",
      (Type, Type))
 
+ERROR(cannot_convert_global_actor,none,
+      "cannot convert function actor-isolated to %0 to function actor-isolated to %1",
+      (Type,Type))
+ERROR(cannot_convert_global_actor_coercion,none,
+      "cannot convert value actor-isolated to %0 to function actor-isolated to %1 in coercion",
+      (Type,Type))
+ERROR(cannot_convert_argument_value_global_actor,none,
+      "cannot convert value actor-isolated to %0 to expected argument type actor-isolated to %1",
+      (Type,Type))
+ERROR(cannot_convert_global_actor_contextual,none,
+      "cannot convert value actor-isolated to %0 to specified type actor-isolated to %1",
+      (Type,Type))
+ERROR(cannot_convert_closure_result_global_actor,none,
+      "cannot convert value actor-isolated to %0 to expected closure result type actor-isolated to %1",
+      (Type,Type))
+ERROR(cannot_convert_global_actor_mismatch_element,none,
+      "cannot convert value actor-isolated to %0 to expected element type actor-isolated to %1",
+      (Type,Type))
+ERROR(cannot_convert_global_actor_mismatch_dict_value,none,
+      "cannot convert value actor-isolated to %0 to expected dictionary value type actor-isolated to %1",
+      (Type,Type))
+ERROR(cannot_convert_global_actor_mismatch_tuple_element,none,
+      "cannot convert type actor-isolated to %0 to type actor-isolated to %1 at tuple element '#%2'",
+      (Type,Type, unsigned))
+ERROR(ternary_expr_cases_global_actor_mismatch,none,
+      "result values in '? :' expression are functions isolated to different actors (%0 vs. %1)",
+      (Type, Type))
+
 // @_nonEphemeral conversion diagnostics
 ERROR(cannot_pass_type_to_non_ephemeral,none,
       "cannot pass %0 to parameter; argument %1 must be a pointer that "

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -421,6 +421,10 @@ enum class FixKind : uint8_t {
 
   /// Macro that has parameters but was not provided with any arguments.
   MacroMissingArguments,
+
+  /// Allow function type actor mismatch e.g. `@MainActor () -> Void`
+  /// vs.`@OtherActor () -> Void`
+  AllowGlobalActorMismatch,
 };
 
 class ConstraintFix {
@@ -3283,6 +3287,30 @@ public:
 
   static bool classof(ConstraintFix *fix) {
     return fix->getKind() == FixKind::MacroMissingArguments;
+  }
+};
+
+/// Allow mismatch between function types global actors.
+/// e.g.  `@MainActor () -> Void` vs.`@OtherActor () -> Void`
+class AllowGlobalActorMismatch final : public ContextualMismatch {
+  AllowGlobalActorMismatch(ConstraintSystem &cs, Type fromType, Type toType,
+                           ConstraintLocator *locator)
+      : ContextualMismatch(cs, FixKind::AllowGlobalActorMismatch, fromType,
+                           toType, locator) {}
+
+public:
+  std::string getName() const override {
+    return "allow function type actor mismatch";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static AllowGlobalActorMismatch *create(ConstraintSystem &cs, Type fromType,
+                                          Type toType,
+                                          ConstraintLocator *locator);
+
+  static bool classof(ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowGlobalActorMismatch;
   }
 };
 

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -255,6 +255,9 @@ ABSTRACT_LOCATOR_PATH_ELT(PatternDecl)
   /// The anonymous variable declared by a `_` pattern.
   CUSTOM_LOCATOR_PATH_ELT(AnyPatternDecl)
 
+/// A function type global actor.
+SIMPLE_LOCATOR_PATH_ELT(GlobalActorType)
+
 #undef LOCATOR_PATH_ELT
 #undef CUSTOM_LOCATOR_PATH_ELT
 #undef SIMPLE_LOCATOR_PATH_ELT

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2900,6 +2900,21 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose function types global actor mismatches
+/// e.g.  `@MainActor () -> Void` vs.`@OtherActor () -> Void`
+class GlobalActorFunctionMismatchFailure final : public ContextualFailure {
+public:
+  GlobalActorFunctionMismatchFailure(const Solution &solution, Type fromType,
+                                     Type toType, ConstraintLocator *locator)
+      : ContextualFailure(solution, fromType, toType, locator) {}
+
+  bool diagnoseAsError() override;
+
+private:
+  Diag<Type, Type> getDiagnosticMessage() const;
+  bool diagnoseTupleElement();
+};
+
 } // end namespace constraints
 } // end namespace swift
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2625,3 +2625,17 @@ MacroMissingArguments::create(ConstraintSystem &cs, MacroDecl *macro,
                               ConstraintLocator *locator) {
   return new (cs.getAllocator()) MacroMissingArguments(cs, macro, locator);
 }
+
+bool AllowGlobalActorMismatch::diagnose(const Solution &solution,
+                                        bool asNote) const {
+  GlobalActorFunctionMismatchFailure failure(solution, getFromType(),
+                                             getToType(), getLocator());
+  return failure.diagnose(asNote);
+}
+
+AllowGlobalActorMismatch *
+AllowGlobalActorMismatch::create(ConstraintSystem &cs, Type fromType,
+                                 Type toType, ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowGlobalActorMismatch(cs, fromType, toType, locator);
+}

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -102,6 +102,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::PatternBindingElement:
   case ConstraintLocator::NamedPatternDecl:
   case ConstraintLocator::AnyPatternDecl:
+  case ConstraintLocator::GlobalActorType:
     return 0;
 
   case ConstraintLocator::FunctionArgument:
@@ -473,6 +474,11 @@ void LocatorPathElt::dump(raw_ostream &out) const {
 
   case ConstraintLocator::AnyPatternDecl: {
     out << "'_' pattern decl";
+    break;
+  }
+
+  case ConstraintLocator::GlobalActorType: {
+    out << "global actor type";
     break;
   }
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5263,10 +5263,12 @@ void constraints::simplifyLocator(ASTNode &anchor,
       }
       break;
 
-    case ConstraintLocator::ContextualType:
+    case ConstraintLocator::GlobalActorType:
+    case ConstraintLocator::ContextualType: {
       // This was just for identifying purposes, strip it off.
       path = path.slice(1);
       continue;
+    }
 
     case ConstraintLocator::KeyPathComponent: {
       auto elt = path[0].castTo<LocatorPathElt::KeyPathComponent>();


### PR DESCRIPTION
<!-- What's in this pull request? -->
Just an improvement on global actor mismatch diagnostics. 
We could later on consider adding a tailored diagnostics(I've experimented with that but felt a bit overkill) for it or an additional note(also experimented with but the note there felt redundant since global actor is printed) mentioning global actor mismatch but that could be a further discussion since mismatch diagnostics already print global actor in function types this already a good improvement.
Also, strengthened a bit the test cases for different kinds of mismatches 
<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves https://github.com/apple/swift/issues/62544

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
