### PR TITLE
[Driver] Use llvm-ar by default on Unix and copy it over into the build directory

### DIFF
--- a/lib/Driver/UnixToolChains.cpp
+++ b/lib/Driver/UnixToolChains.cpp
@@ -375,12 +375,8 @@ toolchains::GenericUnix::constructInvocation(const StaticLinkJobAction &job,
 
   ArgStringList Arguments;
 
-  const char *AR;
+  const char *AR = "llvm-ar";
   // Configure the toolchain.
-  if (getTriple().isAndroid())
-    AR = "llvm-ar";
-  else
-    AR = context.OI.LTOVariant != OutputInfo::LTOKind::None ? "llvm-ar" : "ar";
   Arguments.push_back("crs");
 
   Arguments.push_back(

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -15,3 +15,12 @@ file(TO_CMAKE_PATH "${LLVM_BUILD_BINARY_DIR}/bin/FileCheck${CMAKE_EXECUTABLE_SUF
 swift_install_in_component(PROGRAMS "${_SWIFT_UTILS_FILECHECK}"
                            DESTINATION bin
                            COMPONENT llvm-toolchain-dev-tools)
+
+# Copy over llvm-ar to use in building the Swift portions of the corelibs on
+# Unix platforms.
+if(NOT "${SWIFT_HOST_VARIANT_SDK}" MATCHES "OSX|WINDOWS|WASI")
+  file(COPY ${LLVM_RUNTIME_OUTPUT_INTDIR}/bin/llvm-ar
+    DESTINATION "${SWIFT_RUNTIME_OUTPUT_INTDIR}"
+    FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
+    GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+endif()


### PR DESCRIPTION
Now that llvm-ar is installed by default in the toolchain, #62510, and a recent SPM change requires there to be an archiver in the toolchain/PATH, apple/swift-package-manager#5761, use that bundled llvm-ar for all Unix platforms, which requires copying it over into the build directory too before building the corelibs.

I noticed that we now install the LLVM and compiler tools to `toolchain-linux-x86_64/` before the corelibs are built, but [we don't use that yet to build the corelibs in `build-script-impl`](https://github.com/apple/swift/blob/04f4d66b733af905b39f81677901adad96e75413/utils/build-script-impl#L1668), only for SPM and onwards. I considered switching over to using that installed toolchain to build the corelibs, but since that's a larger change that might fail elsewhere and because it would require simple builds to always `--install-swift` too, I chose this simpler route of copying over the freshly-built `llvm-ar`.

Alternately, we could install `llvm-ar` in the linux CI by making sure that Ubuntu package is always installed, but I figured this copying is easier for now.

Note that [the system `ar` is still passed into `CMAKE_AR`](https://github.com/apple/swift/blob/55c0084b9e1ba20e1538d14467c679a58222bb21/utils/swift_build_support/swift_build_support/cmake.py#L163), so the corelibs will keep using that for the non-Swift static libs on the linux CI, but at least this will allow changing the Swift compiler's default archiver name for Unix.