### PR TITLE
[CSClosure] Implement type-join across `return` statements

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -6006,11 +6006,24 @@ class TypeJoinExpr final : public Expr,
     return { getTrailingObjects<Expr *>(), getNumElements() };
   }
 
-  TypeJoinExpr(DeclRefExpr *var, ArrayRef<Expr *> elements);
+  TypeJoinExpr(llvm::PointerUnion<DeclRefExpr *, TypeBase *> result,
+               ArrayRef<Expr *> elements);
+
+  static TypeJoinExpr *
+  createImpl(ASTContext &ctx,
+             llvm::PointerUnion<DeclRefExpr *, TypeBase *> varOrType,
+             ArrayRef<Expr *> elements);
 
 public:
   static TypeJoinExpr *create(ASTContext &ctx, DeclRefExpr *var,
-                              ArrayRef<Expr *> exprs);
+                              ArrayRef<Expr *> exprs) {
+    return createImpl(ctx, var, exprs);
+  }
+
+  static TypeJoinExpr *create(ASTContext &ctx, Type joinType,
+                              ArrayRef<Expr *> exprs) {
+    return createImpl(ctx, joinType.getPointer(), exprs);
+  }
 
   SourceLoc getLoc() const { return SourceLoc(); }
   SourceRange getSourceRange() const { return SourceRange(); }

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -4350,6 +4350,10 @@ public:
     Bits.OpaqueValueExpr.IsPlaceholder = isPlaceholder;
   }
 
+  static OpaqueValueExpr *
+  createImplicit(ASTContext &ctx, Type Ty, bool isPlaceholder = false,
+                 AllocationArena arena = AllocationArena::Permanent);
+
   /// Whether this opaque value expression represents a placeholder that
   /// is injected before type checking to act as a placeholder for some
   /// value to be specified later.
@@ -6012,17 +6016,20 @@ class TypeJoinExpr final : public Expr,
   static TypeJoinExpr *
   createImpl(ASTContext &ctx,
              llvm::PointerUnion<DeclRefExpr *, TypeBase *> varOrType,
-             ArrayRef<Expr *> elements);
+             ArrayRef<Expr *> elements,
+             AllocationArena arena = AllocationArena::Permanent);
 
 public:
-  static TypeJoinExpr *create(ASTContext &ctx, DeclRefExpr *var,
-                              ArrayRef<Expr *> exprs) {
-    return createImpl(ctx, var, exprs);
+  static TypeJoinExpr *
+  create(ASTContext &ctx, DeclRefExpr *var, ArrayRef<Expr *> exprs,
+         AllocationArena arena = AllocationArena::Permanent) {
+    return createImpl(ctx, var, exprs, arena);
   }
 
-  static TypeJoinExpr *create(ASTContext &ctx, Type joinType,
-                              ArrayRef<Expr *> exprs) {
-    return createImpl(ctx, joinType.getPointer(), exprs);
+  static TypeJoinExpr *
+  create(ASTContext &ctx, Type joinType, ArrayRef<Expr *> exprs,
+         AllocationArena arena = AllocationArena::Permanent) {
+    return createImpl(ctx, joinType.getPointer(), exprs, arena);
   }
 
   SourceLoc getLoc() const { return SourceLoc(); }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2995,8 +2995,12 @@ public:
   void visitTypeJoinExpr(TypeJoinExpr *E) {
     printCommon(E, "type_join_expr");
 
-    PrintWithColorRAII(OS, DeclColor) << " var=";
-    printRec(E->getVar());
+    if (auto *var = E->getVar()) {
+      PrintWithColorRAII(OS, DeclColor) << " var=";
+      printRec(var);
+      OS << '\n';
+    }
+
     OS << '\n';
 
     for (auto *member : E->getElements()) {

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1260,10 +1260,12 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   Expr *visitTypeJoinExpr(TypeJoinExpr *E) {
-    if (auto *newVar = dyn_cast<DeclRefExpr>(doIt(E->getVar()))) {
-      E->setVar(newVar);
-    } else {
-      return nullptr;
+    if (auto *var = E->getVar()) {
+      if (auto *newVar = dyn_cast<DeclRefExpr>(doIt(var))) {
+        E->setVar(newVar);
+      } else {
+        return nullptr;
+      }
     }
 
     for (unsigned i = 0, e = E->getNumElements(); i != e; ++i) {

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2516,9 +2516,18 @@ RegexLiteralExpr::createParsed(ASTContext &ctx, SourceLoc loc,
                                     /*implicit*/ false);
 }
 
-TypeJoinExpr::TypeJoinExpr(DeclRefExpr *varRef, ArrayRef<Expr *> elements)
-  : Expr(ExprKind::TypeJoin, /*implicit=*/true, Type()), Var(varRef) {
-  assert(Var);
+TypeJoinExpr::TypeJoinExpr(llvm::PointerUnion<DeclRefExpr *, TypeBase *> result,
+                           ArrayRef<Expr *> elements)
+    : Expr(ExprKind::TypeJoin, /*implicit=*/true, Type()), Var(nullptr) {
+
+  if (auto *varRef = result.dyn_cast<DeclRefExpr *>()) {
+    assert(varRef);
+    Var = varRef;
+  } else {
+    auto joinType = Type(result.get<TypeBase *>());
+    assert(joinType && "expected non-null type");
+    setType(joinType);
+  }
 
   Bits.TypeJoinExpr.NumElements = elements.size();
   // Copy elements.
@@ -2526,11 +2535,12 @@ TypeJoinExpr::TypeJoinExpr(DeclRefExpr *varRef, ArrayRef<Expr *> elements)
                           getTrailingObjects<Expr *>());
 }
 
-TypeJoinExpr *TypeJoinExpr::create(ASTContext &ctx, DeclRefExpr *var,
-                                   ArrayRef<Expr *> elements) {
+TypeJoinExpr *TypeJoinExpr::createImpl(
+    ASTContext &ctx, llvm::PointerUnion<DeclRefExpr *, TypeBase *> varOrType,
+    ArrayRef<Expr *> elements) {
   size_t size = totalSizeToAlloc<Expr *>(elements.size());
   void *mem = ctx.Allocate(size, alignof(TypeJoinExpr));
-  return new (mem) TypeJoinExpr(var, elements);
+  return new (mem) TypeJoinExpr(varOrType, elements);
 }
 
 SourceRange MacroExpansionExpr::getSourceRange() const {

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1560,6 +1560,15 @@ static ValueDecl *getCalledValue(Expr *E, bool skipFunctionConversions) {
   return nullptr;
 }
 
+OpaqueValueExpr *OpaqueValueExpr::createImplicit(ASTContext &ctx, Type Ty,
+                                                 bool isPlaceholder,
+                                                 AllocationArena arena) {
+  auto *mem =
+      ctx.Allocate(sizeof(OpaqueValueExpr), alignof(OpaqueValueExpr), arena);
+  return new (mem) OpaqueValueExpr(
+      /*Range=*/SourceRange(), Ty, isPlaceholder);
+}
+
 PropertyWrapperValuePlaceholderExpr *
 PropertyWrapperValuePlaceholderExpr::create(ASTContext &ctx, SourceRange range,
                                             Type ty, Expr *wrappedValue,
@@ -2537,9 +2546,9 @@ TypeJoinExpr::TypeJoinExpr(llvm::PointerUnion<DeclRefExpr *, TypeBase *> result,
 
 TypeJoinExpr *TypeJoinExpr::createImpl(
     ASTContext &ctx, llvm::PointerUnion<DeclRefExpr *, TypeBase *> varOrType,
-    ArrayRef<Expr *> elements) {
+    ArrayRef<Expr *> elements, AllocationArena arena) {
   size_t size = totalSizeToAlloc<Expr *>(elements.size());
-  void *mem = ctx.Allocate(size, alignof(TypeJoinExpr));
+  void *mem = ctx.Allocate(size, alignof(TypeJoinExpr), arena);
   return new (mem) TypeJoinExpr(varOrType, elements);
 }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3760,8 +3760,14 @@ namespace {
 
 
       for (auto *element : expr->getElements()) {
+        auto contextualTypePurpose = CS.getContextualTypePurpose(element);
+
         elements.emplace_back(CS.getType(element),
-                              CS.getConstraintLocator(element));
+                              contextualTypePurpose == CTP_Unused
+                                  ? CS.getConstraintLocator(element)
+                                  : CS.getConstraintLocator(
+                                        element, LocatorPathElt::ContextualType(
+                                                     contextualTypePurpose)));
       }
 
       Type resultTy;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3725,7 +3725,16 @@ namespace {
                               CS.getConstraintLocator(element));
       }
 
-      auto resultTy = CS.getType(expr->getVar());
+      Type resultTy;
+
+      if (auto *var = expr->getVar()) {
+        resultTy = CS.getType(var);
+      } else {
+        resultTy = expr->getType();
+      }
+
+      assert(resultTy);
+
       // The type of a join expression is obtained by performing
       // a "join-meet" operation on deduced types of its elements
       // and the underlying variable.

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2946,7 +2946,7 @@ namespace {
           CS, ConstraintKind::DefaultClosureType, closureType, inferredType,
           locator, referencedVars));
 
-      CS.setClosureType(closure, inferredType);
+      CS.setClosure(closure, {inferredType});
       return closureType;
     }
 
@@ -3950,7 +3950,7 @@ namespace {
       if (auto closure = dyn_cast<ClosureExpr>(expr)) {
         FunctionType *closureTy =
             inferClosureType(closure, /*allowResultBindToHole=*/true);
-        CS.setClosureType(closure, closureTy);
+        CS.setClosure(closure, {closureTy});
         CS.setType(closure, closureTy);
       } else {
         TypeVariableType *exprType = CS.createTypeVariable(

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -593,7 +593,7 @@ ConstraintSystem::SolverScope::SolverScope(ConstraintSystem &cs)
   numResultBuilderTransformed = cs.resultBuilderTransformed.size();
   numAppliedPropertyWrappers = cs.appliedPropertyWrappers.size();
   numResolvedOverloads = cs.ResolvedOverloads.size();
-  numInferredClosureTypes = cs.ClosureTypes.size();
+  numInferredClosures = cs.Closures.size();
   numContextualTypes = cs.contextualTypes.size();
   numSolutionApplicationTargets = cs.solutionApplicationTargets.size();
   numCaseLabelItems = cs.caseLabelItems.size();
@@ -696,7 +696,7 @@ ConstraintSystem::SolverScope::~SolverScope() {
   truncate(cs.appliedPropertyWrappers, numAppliedPropertyWrappers);
 
   // Remove any inferred closure types (e.g. used in result builder body).
-  truncate(cs.ClosureTypes, numInferredClosureTypes);
+  truncate(cs.Closures, numInferredClosures);
 
   // Remove any contextual types.
   truncate(cs.contextualTypes, numContextualTypes);

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -61,6 +61,14 @@ public:
       ClosureDCs.push_back(closure);
     }
 
+    if (auto *joinExpr = dyn_cast<TypeJoinExpr>(expr)) {
+      // If this join is over a known type, let's
+      // analyze it too because it can contain type
+      // variables.
+      if (!joinExpr->getVar())
+        inferVariables(joinExpr->getType());
+    }
+
     if (auto *DRE = dyn_cast<DeclRefExpr>(expr)) {
       auto *decl = DRE->getDecl();
 

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -205,10 +205,22 @@ private:
         return;
     }
 
+    // Don't walk into the opaque archetypes because they are not
+    // transparent in this context - `some P` could reference a
+    // type variables as substitutions which are visible only to
+    // the outer context.
+    if (type->is<OpaqueTypeArchetypeType>())
+      return;
+
     if (type->hasTypeVariable()) {
       SmallPtrSet<TypeVariableType *, 4> typeVars;
       type->getTypeVariables(typeVars);
-      ReferencedVars.insert(typeVars.begin(), typeVars.end());
+
+      // Some of the type variables could be non-representative, so
+      // we need to recurse into `inferTypeVariables` to property
+      // handle them.
+      for (auto *typeVar : typeVars)
+        inferVariables(typeVar);
     }
   }
 };

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1339,7 +1339,7 @@ ConstraintGraph::computeConnectedComponents(
 bool ConstraintGraph::contractEdges() {
   // Current constraint system doesn't have any closure expressions
   // associated with it so there is nothing to here.
-  if (CS.ClosureTypes.empty())
+  if (CS.Closures.empty())
     return false;
 
   // For a given constraint kind, decide if we should attempt to eliminate its
@@ -1355,8 +1355,9 @@ bool ConstraintGraph::contractEdges() {
   };
 
   SmallVector<Constraint *, 16> constraints;
-  for (const auto &closure : CS.ClosureTypes) {
-    for (const auto &param : closure.second->getParams()) {
+  for (const auto &closure : CS.Closures) {
+    const auto &info = closure.second;
+    for (const auto &param : info.Type->getParams()) {
       auto paramTy = param.getPlainType()->getAs<TypeVariableType>();
       if (!paramTy)
         continue;

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -1357,7 +1357,7 @@ bool ConstraintGraph::contractEdges() {
   SmallVector<Constraint *, 16> constraints;
   for (const auto &closure : CS.Closures) {
     const auto &info = closure.second;
-    for (const auto &param : info.Type->getParams()) {
+    for (const auto &param : info.getType()->getParams()) {
       auto paramTy = param.getPlainType()->getAs<TypeVariableType>();
       if (!paramTy)
         continue;

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -650,3 +650,42 @@ func test_that_closures_are_attempted_in_order() {
     return false
   }
 }
+
+func coule_of_result_join_tests() {
+  func fn<T>(_ f: () -> T) -> T { f() }
+  func genericRes<T>() -> T { fatalError() }
+
+  let resDouble = fn { // Joins to Double
+    if true {
+      return 42
+    }
+
+    return 0.0
+  }
+
+  let _: Double = resDouble // Ok
+
+  let resOptDouble = fn { // Joins to Double?
+    if true {
+      return 42
+    }
+
+    if false {
+      for x in 0..<2 {
+        if x == 0 {
+          return nil
+        } else if x == 1 {
+          return genericRes()
+        }
+        // Unfortunately this doesn't work because ExpressibleByNilLiteral doesn't get propagated out from the closure
+        // else {
+        //  return fn { nil }
+        // }
+      }
+    }
+
+    return 0.0
+  }
+
+  let _: Double = resOptDouble! // Ok
+}

--- a/unittests/Sema/ConstraintSimplificationTests.cpp
+++ b/unittests/Sema/ConstraintSimplificationTests.cpp
@@ -106,7 +106,7 @@ TEST_F(SemaTest, TestClosureInferenceFromOptionalContext) {
   auto defaultTy = FunctionType::get({FunctionType::Param(paramTy, paramName)},
                                      resultTy, extInfo);
 
-  cs.setClosureType(closure, defaultTy);
+  cs.setClosure(closure, {defaultTy, /*returns=*/{}});
 
   auto *closureTy = cs.createTypeVariable(closureLoc, /*options=*/0);
 

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar83418797.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar83418797.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Description: Hashable {
+  let name: String
+  let id: Int
+}
+
+struct Value {
+  let ID: Int?
+}
+
+func test(allValues: [Value]) {
+  // Type for `return nil` cannot be inferred at the moment because there is no join for result expressions.
+  let owners = Set(allValues.compactMap { // expected-error {{generic parameter 'Element' could not be inferred}}
+      // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}}
+      guard let id = $0.ID else { return nil }
+      return Description(name: "", id: id)
+    })
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar83418797.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar83418797.swift
@@ -10,9 +10,7 @@ struct Value {
 }
 
 func test(allValues: [Value]) {
-  // Type for `return nil` cannot be inferred at the moment because there is no join for result expressions.
-  let owners = Set(allValues.compactMap { // expected-error {{generic parameter 'Element' could not be inferred}}
-      // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}}
+  let _ = Set(allValues.compactMap {
       guard let id = $0.ID else { return nil }
       return Description(name: "", id: id)
     })


### PR DESCRIPTION
If a closure has multiple explicit return statements, solve them
as a unit via `TypeJoinExpr` after all other body elements have
been successfully solved. This strategy helps to solve situations
 like `return nil` appear before result type could be determined 
from other `return` statements.

The method allows to solve some of the returns individually
before joining everything together (i.e. when result expression
doesn't have any literal expressions), in such cases pre-solved
`return` appear an "opaque value" in the final type-join operation.

Resolves: rdar://problem/104381868
Resolves: rdar://problem/61795422

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
