### PR TITLE
SILCombine: fix a crash when optimizing keypath-offset-of

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -344,6 +344,12 @@ bool SILCombiner::tryOptimizeKeypathOffsetOf(ApplyInst *AI,
   KeyPathPattern *pattern = kp->getPattern();
   SubstitutionMap patternSubs = kp->getSubstitutions();
   CanType rootTy = pattern->getRootType().subst(patternSubs)->getCanonicalType();
+
+  // TODO: support lowering of the rootTy if it's not a legal SIL type in the
+  // first place, e.g. if it contains an AnyFunctionType.
+  if (!rootTy->isLegalSILType())
+    return false;
+
   CanType parentTy = rootTy;
   
   // First check if _storedInlineOffset would return an offset or nil. Basically

--- a/test/SILOptimizer/keypath_offset.swift
+++ b/test/SILOptimizer/keypath_offset.swift
@@ -61,6 +61,8 @@ struct TupleProperties {
 
 typealias Tuple<T, U> = (S<T>, C<U>)
 
+typealias TupleOfFunctions = (a: @convention(c) () -> (), b: @convention(c) () -> ())
+
 func getIdentityKeyPathOfType<T>(_: T.Type) -> KeyPath<T, T> {
   return \.self
 }
@@ -157,6 +159,12 @@ func testTupleOffsets() {
   printOffset(TLayout.offset(of: \Tuple<Int, Int>.1))
 }
 
+// Just check that we don't crash.
+@inline(never)
+func testTupleOfFunctions() {
+  printOffset(MemoryLayout<TupleOfFunctions>.offset(of: \.b))
+}
+
 // CHECK-LABEL: sil {{.*}} @$s4test0A19GenericTupleOffsetsyyxmlF
 // CHECK-NOT:     _storedInlineOffset
 // CHECK-NOT:     class_method
@@ -194,4 +202,6 @@ print("### testGenericTupleOffsets")
 testGenericTupleOffsets(Int.self)
 print("### testResilientOffsets")
 testResilientOffsets()
+print("### testTupleOfFunctions")
+testTupleOfFunctions()
 


### PR DESCRIPTION
Need to check if the keypath's root type is a legal SIL type.

rdar://103834325
