### PR TITLE
[IRGen] RuntimeMetadata: Re-enable XFAIL'ed test-case

### DIFF
--- a/test/IRGen/runtime_attributes.swift
+++ b/test/IRGen/runtime_attributes.swift
@@ -5,8 +5,6 @@
 // REQUIRES: asserts
 // REQUIRES: OS=macosx
 
-// REQUIRES: rdar103588798
-
 // First, make sure that we emit:
 // - accessible function records for each generator
 // - runtime attribute records with correct number of trailing objects


### PR DESCRIPTION
Resolves: rdar://103588798

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
