### PR TITLE
[Sema] RuntimeMetadata: Require "self" for both static and instance methods

### DIFF
--- a/test/IRGen/runtime_attributes.swift
+++ b/test/IRGen/runtime_attributes.swift
@@ -294,6 +294,7 @@ func test_local_type_with_protocol_conformance() {
 struct FlagForInnerMethods<Result> {
   init(attachedTo: () -> Result) {}
   init<T>(attachedTo: (T) -> Result) {}
+  init<T>(attachedTo: (T.Type) -> Result) {}
   init<T>(attachedTo: (inout T) -> Result) {}
   init<T>(attachedTo: (inout T, String, inout Int) -> Result) {}
 }

--- a/test/type/runtime_discoverable_attrs.swift
+++ b/test/type/runtime_discoverable_attrs.swift
@@ -212,3 +212,16 @@ actor TestActor {
 func globalAsyncFn() async -> [String] {
   return []
 }
+
+@runtimeMetadata
+struct FlagForStaticFuncs {
+  init<T>(attachedTo: (T.Type) -> Void) {}
+  init<T>(attachedTo: (T.Type, Int.Type) -> Void) {}
+  init<T>(attachedTo: (T.Type, inout [String], Int) -> Void) {}
+}
+
+struct TestStaticFuncs {
+  @FlagForStaticFuncs static func test0() {}
+  @FlagForStaticFuncs static func test1(_: Int.Type) {}
+  @FlagForStaticFuncs static func test2(_: inout [String], x: Int) {}
+}


### PR DESCRIPTION
For instance methods type is going to require a value of type, 
for static methods its metatype, which means it possible to 
distinguish between instance and static methods and global functions.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
