### PR TITLE
Revert "[cxx-interop] Fix crash when indexing with C++ interop enabled."

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1130,9 +1130,7 @@ static void performEndOfPipelineActions(CompilerInstance &Instance) {
   // FIXME: This predicate matches the status quo, but there's no reason
   // indexing cannot run for actions that do not require stdlib e.g. to better
   // facilitate tests.
-  if (FrontendOptions::doesActionRequireSwiftStandardLibrary(action) &&
-      // TODO: indexing often crashes when interop is enabled (rdar://87719859).
-      !Invocation.getLangOptions().EnableCXXInterop) {
+  if (FrontendOptions::doesActionRequireSwiftStandardLibrary(action)) {
     emitIndexData(Instance);
   }
 

--- a/test/Interop/Cxx/stdlib/import-foundation-with-indexing.swift
+++ b/test/Interop/Cxx/stdlib/import-foundation-with-indexing.swift
@@ -1,7 +1,11 @@
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %s -c -index-system-modules -index-store-path %t -enable-experimental-cxx-interop
-//
+// RUN: ls %t/v5/units | %FileCheck %s
+
 // REQUIRES: OS=macosx
 
 import Foundation
 
 func test(d: Date) {}
+
+// CHECK: Foundation-{{.*}}.pcm

--- a/test/Interop/Cxx/stdlib/import-foundation-with-indexing.swift
+++ b/test/Interop/Cxx/stdlib/import-foundation-with-indexing.swift
@@ -3,6 +3,7 @@
 // RUN: ls %t/v5/units | %FileCheck %s
 
 // REQUIRES: OS=macosx
+// REQUIRES: cxx-interop-fixed-cf_options
 
 import Foundation
 

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -9,6 +9,22 @@ def get_target_os():
 clang_compile_opt = '-I' + config.swiftlib_dir + ' '
 clang_opt = clang_compile_opt
 
+is_cf_options_interop_updated = True
+
+if config.variant_sdk and config.variant_sdk != "":
+    # Check if CF_OPTIONS macro has been updated to be imported into Swift in C++ mode correctly.
+    cf_avail_path = os.path.join(config.variant_sdk, 'System', 'Library', 'Frameworks', 'CoreFoundation.framework', 'Versions', 'A', 'Headers', 'CFAvailability.h')
+    if os.path.exists(cf_avail_path):
+        with open(cf_avail_path, 'r') as file:
+            contents = file.read()
+            import re
+            regex = r'^#define CF_OPTIONS\(_type, _name\) _type _name; enum __CF_OPTIONS_ATTRIBUTES'
+            if re.search(regex, contents, re.MULTILINE):
+                is_cf_options_interop_updated = False
+
+if is_cf_options_interop_updated:
+    config.available_features.add('cxx-interop-fixed-cf_options')
+
 if get_target_os() in ['windows-msvc']:
     config.substitutions.insert(0, ('%target-abi', 'WIN'))
     # Clang should build object files with link settings equivalent to -libc MD


### PR DESCRIPTION
This reverts commit 883a9abf53799591dbb4c074bc3dd682327f3fcb. Leaves the test.