### PR TITLE
Fix #61531: swift-symbolgraph-extract crashes when trying to emit the 'Swift' module

### DIFF
--- a/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
+++ b/lib/SymbolGraphGen/SymbolGraphASTWalker.cpp
@@ -214,7 +214,8 @@ bool SymbolGraphASTWalker::walkToDeclPre(Decl *D, CharSourceRange Range) {
           llvm_unreachable("Expected ProtocolDecl or ProtocolCompositionType");
         }
 
-        while (const auto *Comp = UnexpandedCompositions.pop_back_val()) {
+        while (!UnexpandedCompositions.empty()) {
+          const auto *Comp = UnexpandedCompositions.pop_back_val();
           for (const auto &Member : Comp->getMembers()) {
             if (const auto *Proto =
                     dyn_cast_or_null<ProtocolDecl>(Member->getAnyNominal())) {

--- a/test/SymbolGraph/Relationships/ConformsTo/Indirect.swift
+++ b/test/SymbolGraph/Relationships/ConformsTo/Indirect.swift
@@ -35,6 +35,12 @@ extension ES: EQ {
 // EQ : EP
 // EXTERNAL-DAG: "kind": "conformsTo",{{[[:space:]]*}}"source": "s:16ExternalIndirect2EQP",{{[[:space:]]*}}"target": "s:16ExternalIndirect2EPP"
 
+// extension ES : EA (originating from EP : EAB and typealias EAB = EA & EB)
+// EXTENSION-DAG: "kind": "conformsTo",{{[[:space:]]*}}"source": "s:e:s:16ExternalIndirect2ESV0B0E3fooyyF",{{[[:space:]]*}}"target": "s:16ExternalIndirect2EAP"
+
+// extension ES : EB (originating from EP : EAB and typealias EAB = EA & EB)
+// EXTENSION-DAG: "kind": "conformsTo",{{[[:space:]]*}}"source": "s:e:s:16ExternalIndirect2ESV0B0E3fooyyF",{{[[:space:]]*}}"target": "s:16ExternalIndirect2EBP"
+
 // extension ES : EP
 // EXTENSION-DAG: "kind": "conformsTo",{{[[:space:]]*}}"source": "s:e:s:16ExternalIndirect2ESV0B0E3fooyyF",{{[[:space:]]*}}"target": "s:16ExternalIndirect2EPP"
 

--- a/test/SymbolGraph/Relationships/ConformsTo/Inputs/ExternalIndirect.swift
+++ b/test/SymbolGraph/Relationships/ConformsTo/Inputs/ExternalIndirect.swift
@@ -1,4 +1,9 @@
-public protocol EP {
+public protocol EA {}
+public protocol EB {}
+
+public typealias EAB = EA & EB
+
+public protocol EP : EAB {
   func foo()
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR fixes a crash in symbol graph generation caused by an empty SmallVector access while expanding protocol compositions when expanding conformances for a symbol. It also expands the relevant test so that it actually covers the logic causing the crash.

The bug affected all targets that declare a protocol conformance in an extension, where the protocol is or inherits from a protocol composition, for example:

```swift
protocol A {}
protocol B {}

typealias AB = A & B

struct S {}
extension S: AB {}
```

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #61531

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
