### PR TITLE
[interop][SwiftToCxx] disable the arm64e testing for swift-expected-execution.cpp

### DIFF
--- a/test/Interop/SwiftToCxx/functions/swift-expected-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-expected-execution.cpp
@@ -10,6 +10,7 @@
 
 // REQUIRES: executable_test
 // UNSUPPORTED: OS=windows-msvc
+// UNSUPPORTED: CPU=arm64e
 
 #include <cassert>
 #include <cstdio>


### PR DESCRIPTION
Cherry pick of #62691

