### PR TITLE
Fix two compile-time bugs

### DIFF
--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3047,9 +3047,12 @@ const TypeLowering &TypeConverter::getTypeLoweringForLoweredType(
     AbstractionPattern origType, CanType loweredType,
     TypeExpansionContext forExpansion,
     IsTypeExpansionSensitive_t isTypeExpansionSensitive) {
-  assert(loweredType->isLegalSILType() && "type is not lowered!");
-  (void)loweredType;
-  
+
+  // For very large types (e.g. tuples with many elements), this assertion is
+  // very expensive to execute, because the `isLegalSILType` status is not cached.
+  // Therefore the assert is commented out and only here for documentation purposes.
+  // assert(loweredType->isLegalSILType() && "type is not lowered!");
+
   // Cache the lowered type record for a contextualized type independent of the
   // abstraction pattern. Lowered type parameters can't be cached or looked up
   // without context. (TODO: We could if they match the out-of-context

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -937,14 +937,20 @@ void LoopTreeOptimization::analyzeCurrentLoop(
     }
   }
 
-  for (auto *AI : ReadOnlyApplies) {
-    if (!mayWriteTo(AA, BCA, sideEffects, AI)) {
-      HoistUp.insert(AI);
+  // Avoid quadratic complexity in corner cases. Usually, this limit will not be exceeded.
+  if (ReadOnlyApplies.size() * sideEffects.size() < 8000) {
+    for (auto *AI : ReadOnlyApplies) {
+      if (!mayWriteTo(AA, BCA, sideEffects, AI)) {
+        HoistUp.insert(AI);
+      }
     }
   }
-  for (auto *LI : Loads) {
-    if (!mayWriteTo(AA, sideEffects, LI)) {
-      HoistUp.insert(LI);
+  // Avoid quadratic complexity in corner cases. Usually, this limit will not be exceeded.
+  if (Loads.size() * sideEffects.size() < 8000) {
+    for (auto *LI : Loads) {
+      if (!mayWriteTo(AA, sideEffects, LI)) {
+        HoistUp.insert(LI);
+      }
     }
   }
 


### PR DESCRIPTION
* Comment out an expensive assert in type lowering

For very large types (e.g. tuples with many elements), this assertion is very expensive to execute, because the `isLegalSILType` status is not cached.

* LICM: add limits for the number of alias checks to avoid large compile times in corner cases

Avoids quadratic complexity in corner cases. Usually, these limits will not be exceeded.

Resolves #62837