### PR TITLE
[cxx-interop] Members of private base classes should not be exposed

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5007,6 +5007,9 @@ TinyPtrVector<ValueDecl *> ClangRecordMemberLookup::evaluate(
   if (auto cxxRecord =
           dyn_cast<clang::CXXRecordDecl>(recordDecl->getClangDecl())) {
     for (auto base : cxxRecord->bases()) {
+      if (base.getAccessSpecifier() != clang::AccessSpecifier::AS_public)
+        continue;
+
       clang::QualType baseType = base.getType();
       if (auto spectType = dyn_cast<clang::TemplateSpecializationType>(baseType))
         baseType = spectType->desugar();

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8442,6 +8442,9 @@ void ClangImporter::Implementation::loadAllMembersOfRecordDecl(
   // If this is a C++ record, look through the base classes too.
   if (auto cxxRecord = dyn_cast<clang::CXXRecordDecl>(clangRecord)) {
     for (auto base : cxxRecord->bases()) {
+      if (base.getAccessSpecifier() != clang::AccessSpecifier::AS_public)
+        continue;
+
       clang::QualType baseType = base.getType();
       if (auto spectType = dyn_cast<clang::TemplateSpecializationType>(baseType))
         baseType = spectType->desugar();

--- a/test/Interop/Cxx/class/inheritance/Inputs/functions.h
+++ b/test/Interop/Cxx/class/inheritance/Inputs/functions.h
@@ -77,6 +77,12 @@ struct DerivedFromDerived : Derived {
 struct __attribute__((swift_attr("import_unsafe"))) DerivedFromNonTrivial
     : NonTrivial {};
 
+struct PrivatelyInherited : private Base {
+};
+
+struct ProtectedInherited : protected Base {
+};
+
 struct EmptyBaseClass {
   const char *inBase() const __attribute__((swift_attr("import_unsafe"))) {
     return "EmptyBaseClass::inBase";

--- a/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-module-interface.swift
@@ -92,3 +92,11 @@
 // CHECK-NEXT:   @discardableResult
 // CHECK-NEXT:   func inNonTrivialWithArgs(_ a: Int32, _ b: Int32) -> UnsafePointer<CChar>?
 // CHECK-NEXT: }
+
+// CHECK-NEXT: struct PrivatelyInherited {
+// CHECK-NEXT:   init()
+// CHECK-NEXT: }
+
+// CHECK-NEXT: struct ProtectedInherited {
+// CHECK-NEXT:   init()
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/class/inheritance/functions-typechecker.swift
+++ b/test/Interop/Cxx/class/inheritance/functions-typechecker.swift
@@ -2,6 +2,10 @@
 
 import Functions
 
+PrivatelyInherited().constInBase() // expected-error {{value of type 'PrivatelyInherited' has no member 'constInBase'}}
+ProtectedInherited().constInBase() // expected-error {{value of type 'ProtectedInherited' has no member 'constInBase'}}
+
+
 extension Base {
   public func swiftFunc() {}
 }


### PR DESCRIPTION
Trying to use members of C++ private base classes from Swift causes an assertion failure in ClangImporter:

```
<build dir>/swift/lib/swift/macosx/arm64/libcxxshim.h:2:66: error: cannot cast 'A' to its private base class 'B'
To __swift_interopStaticCast(From from) { return static_cast<To>(from); }
                                                                 ^

Assertion failed: (Val && "isa<> used on a null pointer"), function doit, file Casting.h, line 104.
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
...
8  swift-frontend           llvm::isa_impl_cl<swift::FuncDecl, swift::Decl const*>::doit(swift::Decl const*) + 100
9  swift-frontend           llvm::isa_impl_wrap<swift::FuncDecl, swift::Decl const*, swift::Decl const*>::doit(swift::Decl const* const&) + 28
10 swift-frontend           llvm::isa_impl_wrap<swift::FuncDecl, swift::Decl* const, swift::Decl const*>::doit(swift::Decl* const&) + 40
11 swift-frontend           bool llvm::isa<swift::FuncDecl, swift::Decl*>(swift::Decl* const&) + 24
12 swift-frontend           llvm::cast_retty<swift::FuncDecl, swift::Decl*>::ret_type llvm::cast<swift::FuncDecl, swift::Decl>(swift::Decl*) + 28
13 swift-frontend           getInteropStaticCastDeclRefExpr(swift::ASTContext&, clang::Module const*, swift::Type, swift::Type) + 768
14 swift-frontend           synthesizeBaseClassMethodBody(swift::AbstractFunctionDecl*, void*)::$_30::operator()() const + 396
...
```

Such members should not be exposed.

rdar://103871000