### PR TITLE
[Sema] Don’t fail constraint generation if a closure contains an ErrorExpr

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -4926,7 +4926,9 @@ bool MissingArgumentsFailure::diagnoseClosure(const ClosureExpr *closure) {
 
   auto *locator = getLocator();
   if (locator->isForContextualType()) {
-    funcType = getContextualType(locator->getAnchor())->getAs<FunctionType>();
+    if (auto contextualType = getContextualType(locator->getAnchor())) {
+      funcType = contextualType->getAs<FunctionType>();
+    }
   } else if (auto info = getFunctionArgApplyInfo(locator)) {
     auto paramType = info->getParamType();
     // Drop a single layer of optionality because argument could get injected

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -78,7 +78,7 @@ struct TupleBuilderWithoutIf { // expected-note 3{{struct 'TupleBuilderWithoutIf
   static func buildDo<T>(_ value: T) -> T { return value }
 }
 
-func tuplify<T>(_ cond: Bool, @TupleBuilder body: (Bool) -> T) {
+func tuplify<T>(_ cond: Bool, @TupleBuilder body: (Bool) -> T) { // expected-note 2{{in call to function 'tuplify(_:body:)'}}
   print(body(cond))
 }
 
@@ -88,7 +88,7 @@ func tuplifyWithoutIf<T>(_ cond: Bool, @TupleBuilderWithoutIf body: (Bool) -> T)
 
 func testDiags() {
   // For loop
-  tuplify(true) { _ in
+  tuplify(true) { _ in // expected-error {{generic parameter 'T' could not be inferred}}
     17
     for c in name {
     // expected-error@-1 {{cannot find 'name' in scope}}
@@ -464,7 +464,7 @@ struct TestConstraintGenerationErrors {
   }
 
   func buildTupleClosure() {
-    tuplify(true) { _ in
+    tuplify(true) { _ in // expected-error {{generic parameter 'T' could not be inferred}}
       let a = nothing // expected-error {{cannot find 'nothing' in scope}}
       String(nothing) // expected-error {{cannot find 'nothing' in scope}}
     }

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -775,7 +775,7 @@ class r22240342 {
   lazy var xx: Int = {
     foo {  // expected-error {{cannot find 'foo' in scope}}
       let issueView = 42
-      issueView.delegate = 12
+      issueView.delegate = 12 // expected-error {{value of type 'Int' has no member 'delegate'}}
       
     }
     return 42

--- a/test/StringProcessing/Sema/regex_builder_fix_import_top_level.swift
+++ b/test/StringProcessing/Sema/regex_builder_fix_import_top_level.swift
@@ -19,11 +19,7 @@ Regex { // expected-error {{regex builder requires the 'RegexBuilder' module be 
   /g(h)(i)/
 }
 
-// FIXME: Unfortunately we bail from CSGen if we end up with an ErrorExpr, so
-// don't get a chance to diagnose. We ought to try solving with holes.
-// For now at least, this error should at least hopefully nudge users into
-// realizing they have a missing import.
-Regex {
+Regex { // expected-error {{regex builder requires the 'RegexBuilder' module be imported'}}
   Capture { // expected-error {{cannot find 'Capture' in scope}}
     /abc/
   }

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -409,7 +409,7 @@ func matching_pattern_recursion(zs: [Int]) { // expected-note {{'zs' declared he
   }
 
   switch 42 {
-  case {
+  case { // expected-error {{expression pattern of type '() -> ()' cannot match values of type 'Int'}}
       for i in ws { // expected-error {{cannot find 'ws' in scope; did you mean 'zs'?}}
       }
     }: break


### PR DESCRIPTION
It appears like this was missed in #60062.
