### PR TITLE
Allow the "macros" experimental feature to be enabled in production compilers

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -150,7 +150,7 @@ EXPERIMENTAL_FEATURE(ImplicitSome, false)
 EXPERIMENTAL_FEATURE(ParserASTGen, false)
 
 /// Enable the experimental macros feature.
-EXPERIMENTAL_FEATURE(Macros, false)
+EXPERIMENTAL_FEATURE(Macros, true)
 
 /// Parse using the Swift (swift-syntax) parser and use ASTGen to generate the
 /// corresponding syntax tree.


### PR DESCRIPTION
Now that we have a macro in the standard library, we need production compilers to be able to build the standard library.

Fixes rdar://103868067.
