### PR TITLE
[5.8][CSClosure] A couple of closure related fixes

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2055,25 +2055,10 @@ static bool isInPatternMatchingContext(ConstraintLocatorBuilder locator) {
   SmallVector<LocatorPathElt, 4> path;
   (void)locator.getLocatorParts(path);
 
-  while (!path.empty() && path.back().is<LocatorPathElt::TupleType>())
-    path.pop_back();
-
-  if (!path.empty()) {
-    // Direct pattern matching between tuple pattern and tuple type.
-    if (path.back().is<LocatorPathElt::PatternMatch>()) {
-      return true;
-    } else if (path.size() > 1) {
-      // sub-pattern matching as part of the enum element matching
-      // where sub-element is a tuple pattern e.g.
-      // `case .foo((a: 42, _)) = question`
-      auto lastIdx = path.size() - 1;
-      if (path[lastIdx - 1].is<LocatorPathElt::PatternMatch>() &&
-          path[lastIdx].is<LocatorPathElt::FunctionArgument>())
-        return true;
-    }
-  }
-
-  return false;
+  auto pathElement = llvm::find_if(path, [](LocatorPathElt &elt) {
+    return elt.is<LocatorPathElt::PatternMatch>();
+  });
+  return pathElement != path.end();
 }
 
 namespace {

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -197,10 +197,22 @@ private:
         return;
     }
 
+    // Don't walk into the opaque archetypes because they are not
+    // transparent in this context - `some P` could reference a
+    // type variables as substitutions which are visible only to
+    // the outer context.
+    if (type->is<OpaqueTypeArchetypeType>())
+      return;
+
     if (type->hasTypeVariable()) {
       SmallPtrSet<TypeVariableType *, 4> typeVars;
       type->getTypeVariables(typeVars);
-      ReferencedVars.insert(typeVars.begin(), typeVars.end());
+
+      // Some of the type variables could be non-representative, so
+      // we need to recurse into `inferTypeVariables` to property
+      // handle them.
+      for (auto *typeVar : typeVars)
+        inferVariables(typeVar);
     }
   }
 };

--- a/test/Constraints/sub-pattern-matching-of-enum-element-for-closure.swift
+++ b/test/Constraints/sub-pattern-matching-of-enum-element-for-closure.swift
@@ -1,0 +1,18 @@
+// RUN: %target-typecheck-verify-swift
+enum TestType {
+    case foo
+    case bar(Bool, (a: String, (b: String, (String, (c: String, Bool), String), String)))
+}
+
+func test(type: TestType) -> String {
+    let str: String = {
+        switch type {
+        case .foo:
+            return ""
+        case .bar(_, (_, (_, (_, (let c, _), _), _))):
+            return c
+        }
+    }()
+    
+    return str
+}

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar83418797.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar83418797.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Description: Hashable {
+  let name: String
+  let id: Int
+}
+
+struct Value {
+  let ID: Int?
+}
+
+func test(allValues: [Value]) {
+  // Type for `return nil` cannot be inferred at the moment because there is no join for result expressions.
+  let owners = Set(allValues.compactMap { // expected-error {{generic parameter 'Element' could not be inferred}}
+      // expected-note@-1 {{explicitly specify the generic arguments to fix this issue}}
+      guard let id = $0.ID else { return nil }
+      return Description(name: "", id: id)
+    })
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/issues/60806
Cherry-pick of https://github.com/apple/swift/pull/62773

---

- Fix handling of non-representativate variables
- Fix sub-pattern matching logic related closure and enum element

Resolves: rdar://83418797
Resolves: #62777 

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
