### PR TITLE
Only enable Macros when asserts are enabled

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -289,7 +289,9 @@ endif()
 # STAGING: Temporarily avoids having to write #fileID in Swift.swiftinterface.
 list(APPEND swift_stdlib_compile_flags "-Xfrontend" "-enable-experimental-concise-pound-file")
 
-list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Macros")
+if(LLVM_ENABLE_ASSERTIONS)
+  list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Macros")
+endif()
 
 if(SWIFT_CHECK_ESSENTIAL_STDLIB)
   add_swift_target_library(swift_stdlib_essential ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_STDLIB_CORE


### PR DESCRIPTION
Enabling the experimental Macros feature will fail builds of the Swift stdlib when building without assertions: 

https://github.com/apple/swift/blob/main/lib/Frontend/CompilerInvocation.cpp#L657-L663

Modify the CMake config to only enable Macros when we have asserts enabled. 