### PR TITLE
[IRGen] RuntimeMetadata: Reference type descriptors indirectly when required

### DIFF
--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -4759,7 +4759,10 @@ class RuntimeDiscoverableAttributeRecord
   uint32_t flags;
 
   /// The nominal type that describes the attribute.
-  TargetSignedContextPointer<Runtime, TargetTypeContextDescriptor> Attribute;
+  TargetRelativeIndirectablePointer<Runtime,
+                                    TargetTypeContextDescriptor<Runtime>,
+                                    /*nullable*/ false>
+      Attribute;
 
   /// The number of types this attribute is associated with.
   uint32_t numEntries;

--- a/include/swift/ABI/Metadata.h
+++ b/include/swift/ABI/Metadata.h
@@ -4740,7 +4740,7 @@ using AccessibleFunctionRecord = TargetAccessibleFunctionRecord<InProcess>;
 /// that relates a type attribute is attached to a generator function.
 template <typename Runtime>
 struct TargetRuntimeDiscoverableAttributeEntry {
-  ConstTargetMetadataPointer<Runtime, TargetMetadata> Type;
+  RelativeDirectPointer<const char, /*nullable*/ false> Type;
   RelativeDirectPointer<TargetAccessibleFunctionRecord<Runtime>> Generator;
 };
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -4449,8 +4449,8 @@ void IRGenModule::emitRuntimeDiscoverableAttributes(
     B.addInt32(0);
 
     // Attribute metadata descriptor
-    B.addRelativeAddress(
-        getAddrOfTypeContextDescriptor(attrType, RequireMetadata));
+    B.addRelativeAddress(getAddrOfLLVMVariableOrGOTEquivalent(
+        LinkEntity::forNominalTypeDescriptor(attrType)));
 
     // Number of types it's attached to.
     B.addInt32(attachedTo.size());

--- a/test/IRGen/runtime_attributes.swift
+++ b/test/IRGen/runtime_attributes.swift
@@ -85,7 +85,7 @@
 
 // CHECK: @"$s3RAD6IgnoreVHa" = internal constant
 // CHECK-SAME: i32 0
-// CHECK-SAME: @"$s3RAD6IgnoreVMn"
+// CHECK-SAME: %swift.type_descriptor** @"got.$s3RAD6IgnoreVMn"
 // CHECK-SAME: i32 5
 // CHECK-SAME: @"$s18runtime_attributes1AV5InnerC11extComputedSivpfa3RAD6IgnoreHF"
 // CHECK-SAME: @"$s18runtime_attributes16WithExternalAttrAaBVmvpfa3RAD6IgnoreHF"
@@ -96,7 +96,7 @@
 
 // CHECK: @"$s3RAD13TestAmbiguityVHa" = internal constant
 // CHECK-SAME: i32 0
-// CHECK-SAME: @"$s3RAD13TestAmbiguityVMn"
+// CHECK-SAME: %swift.type_descriptor** @"got.$s3RAD13TestAmbiguityVMn"
 // CHECK-SAME: i32 6
 // CHECK-SAME: @"$s18runtime_attributes4testyySicvpfa3RAD13TestAmbiguityHF"
 // CHECK-SAME: @"$s18runtime_attributes4testyySScvpfa3RAD13TestAmbiguityHF"


### PR DESCRIPTION
Type descriptors cannot always be referenced directly (i.e. when
a type is declared in a different module), so let's use
`getAddrOfLLVMVariableOrGOTEquivalent` facility that knows how
to handle that correctly.

Resolves: rdar://problem/103878515

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
