### PR TITLE
Fix wrong calculation of generic params per level when building decl

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -2953,13 +2953,19 @@ private:
           // Only consider generic contexts of type class, enum or struct.
           // There are other context types that can be generic, but they should
           // not affect the generic shape.
-          if (genericContext &&
-              (current->getKind() == ContextDescriptorKind::Class ||
-               current->getKind() == ContextDescriptorKind::Enum ||
-               current->getKind() == ContextDescriptorKind::Struct)) {
-            auto contextHeader = genericContext->getGenericContextHeader();
-            paramsPerLevel.emplace_back(contextHeader.NumParams - runningCount);
-            runningCount += paramsPerLevel.back();
+          if (current->getKind() == ContextDescriptorKind::Class ||
+              current->getKind() == ContextDescriptorKind::Enum ||
+              current->getKind() == ContextDescriptorKind::Struct) {
+            if (genericContext) {
+              auto contextHeader = genericContext->getGenericContextHeader();
+              paramsPerLevel.emplace_back(contextHeader.NumParams -
+                                          runningCount);
+              runningCount += paramsPerLevel.back();
+            } else {
+              // If there is no generic context, this is a non-generic type
+              // which has 0 generic parameters.
+              paramsPerLevel.emplace_back(0);
+            }
           }
         };
     countLevels(descriptor, runningCount);

--- a/include/swift/RemoteInspection/TypeRefBuilder.h
+++ b/include/swift/RemoteInspection/TypeRefBuilder.h
@@ -596,9 +596,13 @@ public:
           break;
         }
       }
-      if (parentNode)
-        parent = createBoundGenericTypeReconstructingParent(
-            parentNode, decl, --shapeIndex, args, argsIndex + numGenericArgs);
+      if (parentNode) {
+        if (shapeIndex > 0)
+          parent = createBoundGenericTypeReconstructingParent(
+              parentNode, decl, --shapeIndex, args, argsIndex + numGenericArgs);
+        else
+          return nullptr;
+      }
     }
 
     return BoundGenericTypeRef::create(*this, mangling.result(), genericParams,

--- a/validation-test/Reflection/reflect_nested.swift
+++ b/validation-test/Reflection/reflect_nested.swift
@@ -43,6 +43,37 @@ reflect(object: obj)
 // CHECK-32-NEXT:   (bound_generic_class reflect_nested.OuterGeneric.Inner
 // CHECK-32-NEXT:     (bound_generic_class reflect_nested.OuterGeneric
 // CHECK-32-NEXT:       (struct Swift.Int))))
+  
+class OuterNonGeneric {
+  class InnerGeneric<T, U> {
+    var x: T
+    var y: U
+
+    init(x: T, y: U) {
+      self.x = x
+      self.y = y
+    }
+  }
+}
+
+var obj2 = OuterNonGeneric.InnerGeneric(x: 17, y: "hello")
+reflect(object: obj2)
+
+// CHECK-64: Reflecting an object.
+// CHECK-64: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-64: Type reference:
+// CHECK-64: (bound_generic_class reflect_nested.OuterNonGeneric.InnerGeneric
+// CHECK-64-NEXT:   (struct Swift.Int)
+// CHECK-64-NEXT:   (struct Swift.String)
+// CHECK-64-NEXT:     (bound_generic_class reflect_nested.OuterNonGeneric))
+
+// CHECK-32: Reflecting an object.
+// CHECK-32: Instance pointer in child address space: 0x{{[0-9a-fA-F]+}}
+// CHECK-32: Type reference:
+// CHECK-32: (bound_generic_class reflect_nested.OuterNonGeneric.InnerGeneric
+// CHECK-32-NEXT:   (struct Swift.Int)
+// CHECK-32-NEXT:   (struct Swift.String)
+// CHECK-32-NEXT:     (bound_generic_class reflect_nested.OuterNonGeneric))
 
 doneReflecting()
 


### PR DESCRIPTION
Fix computation of generic params per level when a generic type is nested in  a non-generic one. For example, for the following code:

```
class A {
  class B<T, U> {
  }
}
```
Fix the array of generic params per level from [2] to [0, 2].

rdar://103457629
