### PR TITLE
[MiscDiagnostics] OpaqueTypes: Handle unrelated #available conditions…

### DIFF
--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3068,13 +3068,22 @@ public:
 
       SmallVector<AvailabilityCondition, 4> conditions;
 
-      llvm::transform(availabilityContext->getCond(),
-                      std::back_inserter(conditions),
-                      [&](const StmtConditionElement &elt) {
-                        auto condition = elt.getAvailability();
-                        return std::make_pair(condition->getAvailableRange(),
-                                              condition->isUnavailability());
-                      });
+      for (const auto &elt : availabilityContext->getCond()) {
+        auto condition = elt.getAvailability();
+
+        auto availabilityRange = condition->getAvailableRange();
+        // If there is no lower endpoint it means that the
+        // current platform is unrelated to this condition
+        // and we can ignore it.
+        if (!availabilityRange.hasLowerEndpoint())
+          continue;
+
+        conditions.push_back(
+            {availabilityRange, condition->isUnavailability()});
+      }
+
+      if (conditions.empty())
+        continue;
 
       conditionalSubstitutions.push_back(
           OpaqueTypeDecl::ConditionallyAvailableSubstitutions::get(

--- a/test/Serialization/Inputs/opaque_with_limited_availability.swift
+++ b/test/Serialization/Inputs/opaque_with_limited_availability.swift
@@ -67,3 +67,14 @@ public func test_return_from_conditional() -> some P {
 
   return Tuple<(String, Int)>(("", 0))
 }
+
+// This used to crash during serialization because
+// @available negates availability condition.
+@available(macOS, unavailable)
+public func testUnusable() -> some P {
+  if #available(iOS 50, *) {
+    return Named()
+  }
+
+  return Tuple<(String, Int)>(("", 0))
+}


### PR DESCRIPTION
… gracefully

`OpaqueUnderlyingTypeChecker` should skip conditional availability blocks
if none of the conditions restrict the current target.

Resolves: rdar://103445432

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
