### PR TITLE
[OpaqueValues] Map-into-context back-deploy thunk results.

### DIFF
--- a/lib/SILGen/SILGenBackDeploy.cpp
+++ b/lib/SILGen/SILGenBackDeploy.cpp
@@ -133,14 +133,16 @@ static void emitBackDeployForwardApplyAndReturnOrThrow(
 
     // Emit error block.
     SGF.B.emitBlock(errorBB);
-    SILValue error = errorBB->createPhiArgument(fnConv.getSILErrorType(TEC),
-                                                OwnershipKind::Owned);
+    SILValue error = errorBB->createPhiArgument(
+        SGF.F.mapTypeIntoContext(fnConv.getSILErrorType(TEC)),
+        OwnershipKind::Owned);
     SGF.B.createBranch(loc, SGF.ThrowDest.getBlock(), {error});
 
     // Emit normal block.
     SGF.B.emitBlock(normalBB);
-    SILValue result = normalBB->createPhiArgument(fnConv.getSILResultType(TEC),
-                                                  OwnershipKind::Owned);
+    SILValue result = normalBB->createPhiArgument(
+        SGF.F.mapTypeIntoContext(fnConv.getSILResultType(TEC)),
+        OwnershipKind::Owned);
     SmallVector<SILValue, 4> directResults;
     extractAllElements(result, loc, SGF.B, directResults);
 

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -636,3 +636,12 @@ func takeKeyPathString<T>(_ kp: KeyPath<T, String>) {
 func giveKeyPathString() {
   takeKeyPathString(\StructWithAReadableStringProperty.s)
 }
+
+// CHECK-LABEL: sil {{.*}}@$s20opaque_values_silgen29backDeployingReturningGenericyxxKlFTwb : {{.*}} <T> {{.*}} {
+// Ensure that there aren't any "normal" (in the sense of try_apply) blocks that
+// take unbound generic parameters (τ_0_0).
+// CHECK-NOT: {{bb[0-9]+}}({{%[^,]+}} : @owned $τ_0_0):
+// CHECK-LABEL: } // end sil function '$s20opaque_values_silgen29backDeployingReturningGenericyxxKlFTwb'
+@available(SwiftStdlib 5.1, *)
+@_backDeploy(before: SwiftStdlib 5.8)
+public func backDeployingReturningGeneric<T>(_ t: T) throws -> T { t }


### PR DESCRIPTION
When a throwing function which returns a generic (this is the simplest example) is back deployed, it gets a back deploy thunk.  This back deploy thunk calls one of two variations of the function, depending on availability, both which have the same signature and in particular both return a generic.  The result type of that function signature is an unbound generic.

Previously, that result type was used as is.  Consequently the success blocks for the `try_apply` instructions in these thunks had arguments of unbound generic type.

Here, that type is mapped into the context of the function being emitted.  The thunks now have the appropriate bound generic type.
