### PR TITLE
[OpaqueValues] Build objc thunk args with fn conv.

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1364,6 +1364,7 @@ static SILFunctionType *emitObjCThunkArguments(SILGenFunction &SGF,
   // Emit the other arguments, taking ownership of arguments if necessary.
   auto inputs = objcFnTy->getParameters();
   auto nativeInputs = swiftFnTy->getParameters();
+  auto fnConv = SGF.silConv.getFunctionConventions(swiftFnTy);
   assert(nativeInputs.size() == bridgedFormalTypes.size());
   assert(nativeInputs.size() == nativeFormalTypes.size());
   assert(inputs.size() ==
@@ -1434,7 +1435,7 @@ static SILFunctionType *emitObjCThunkArguments(SILGenFunction &SGF,
 
     // This can happen if the value is resilient in the calling convention
     // but not resilient locally.
-    if (nativeInputs[i].isFormalIndirect() &&
+    if (fnConv.isSILIndirect(nativeInputs[i]) &&
         !native.getType().isAddress()) {
       auto buf = SGF.emitTemporaryAllocation(loc, native.getType());
       native.forwardInto(SGF, loc, buf);

--- a/test/SILGen/opaque_values_objc.swift
+++ b/test/SILGen/opaque_values_objc.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-emit-silgen -enable-sil-opaque-values -Xllvm -sil-full-demangle %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
+
+// REQUIRES: objc_interop
+
+import ObjectiveC
+
+// CHECK-LABEL: sil {{.*}} @$s18opaque_values_objc3fooyyFyypSgcfU_To : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $Optional<Any>
+// CHECK:         [[GUARANTEED:%[^,]+]] = begin_borrow [[INSTANCE]]
+// CHECK:         [[FN:%[^,]+]] = function_ref @$s18opaque_values_objc3fooyyFyypSgcfU_
+// CHECK:         apply [[FN]]([[GUARANTEED]])
+// CHECK:         end_borrow [[GUARANTEED]]
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK-LABEL: } // end sil function '$s18opaque_values_objc3fooyyFyypSgcfU_To'
+func foo() {
+  objc_setUncaughtExceptionHandler { _ in
+  }
+}


### PR DESCRIPTION
Used the function convention to determine whether a `SILParameterInfo` is indirect when emitting objc thunk arguments.
