### PR TITLE
[stdlib] String.UTF8View.index(_:offsetBy:limitedBy:): mark encoding of result

### DIFF
--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -191,7 +191,7 @@ extension String.UTF8View: BidirectionalCollection {
       }
       _precondition(result >= 0 && result <= _guts.count,
         "String index is out of bounds")
-      return Index(_encodedOffset: result)
+      return Index(_encodedOffset: result)._knownUTF8
     }
 
     return _foreignIndex(i, offsetBy: n, limitedBy: limit)


### PR DESCRIPTION
This marks the expected storage encoding of the index returned on the fast path of the UTF-8 view's `index(_:offsetBy:limitedBy:)` method, ensuring index misuse can be detected on subsequent uses, and improving the display of the index during debugging.

This was one path I missed during last year's String fixes.