### PR TITLE
[Diagnostics] Emit generated code buffers into diagnostic files.

### DIFF
--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -404,7 +404,7 @@ static void emitRecordID(unsigned ID, const char *Name,
 static void
 addSourceLocationAbbrev(std::shared_ptr<llvm::BitCodeAbbrev> Abbrev) {
   using namespace llvm;
-  Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 10)); // File ID.
+  Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 5));    // File ID.
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 32)); // Line.
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 32)); // Column.
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 32)); // Offset;
@@ -488,7 +488,7 @@ void SerializedDiagnosticConsumer::emitBlockInfoBlock() {
   // Emit the abbreviation for RECORD_FILENAME.
   Abbrev = std::make_shared<BitCodeAbbrev>();
   Abbrev->Add(BitCodeAbbrevOp(RECORD_FILENAME));
-  Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 10)); // Mapped file ID.
+  Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 5)); // Mapped file ID.
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 32)); // Size.
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 32)); // Modification time.
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 16)); // Text size.
@@ -508,9 +508,9 @@ void SerializedDiagnosticConsumer::emitBlockInfoBlock() {
   // Emit the abbreviation for RECORD_SOURCE_FILE_CONTENTS.
   Abbrev = std::make_shared<BitCodeAbbrev>();
   Abbrev->Add(BitCodeAbbrevOp(RECORD_SOURCE_FILE_CONTENTS));
-  Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 10)); // File ID.
+  Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 5)); // File ID.
   addRangeLocationAbbrev(Abbrev);
-  Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Fixed, 16)); // File size.
+  Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::VBR, 16)); // File size.
   Abbrev->Add(BitCodeAbbrevOp(BitCodeAbbrevOp::Blob)); // File contents.
   Abbrevs.set(RECORD_SOURCE_FILE_CONTENTS,
               Stream.EmitBlockInfoAbbrev(BLOCK_DIAG, Abbrev));

--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -255,16 +255,16 @@ unsigned SerializedDiagnosticConsumer::getEmitFile(
 
   // The source range that this buffer was generated from, expressed as
   // offsets into the original buffer.
-  auto originalFilename = SM.getDisplayNameForLoc(generatedInfo->originalSourceRange.Start);
   if (generatedInfo->originalSourceRange.isValid()) {
+    auto originalFilename = SM.getDisplayNameForLoc(generatedInfo->originalSourceRange.Start);
     addRangeToRecord(
         Lexer::getCharSourceRangeFromSourceRange(
             SM, generatedInfo->originalSourceRange),
         SM, originalFilename, Record
     );
   } else {
-    addLocToRecord(SourceLoc(), SM, originalFilename, Record); // Start
-    addLocToRecord(SourceLoc(), SM, originalFilename, Record); // End
+    addLocToRecord(SourceLoc(), SM, "", Record); // Start
+    addLocToRecord(SourceLoc(), SM, "", Record); // End
   }
 
   // Contents of the buffer.


### PR DESCRIPTION
Extend the serialized diagnostics file format to also support providing the contents of source files, which can include a reference to the "original source range" whose text is conceptually replaced with the contents of the serialized diagnostics file, e.g., due to macro expansion.

Implements the Swift side of rdar://103900370