### PR TITLE
SILCombine: a better fix for optimizing keypath-offset-of

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -343,14 +343,11 @@ bool SILCombiner::tryOptimizeKeypathOffsetOf(ApplyInst *AI,
 
   KeyPathPattern *pattern = kp->getPattern();
   SubstitutionMap patternSubs = kp->getSubstitutions();
-  CanType rootTy = pattern->getRootType().subst(patternSubs)->getCanonicalType();
+  SILFunction *f = AI->getFunction();
+  SILType rootTy = f->getLoweredType(Lowering::AbstractionPattern::getOpaque(),
+      pattern->getRootType().subst(patternSubs)->getCanonicalType());
 
-  // TODO: support lowering of the rootTy if it's not a legal SIL type in the
-  // first place, e.g. if it contains an AnyFunctionType.
-  if (!rootTy->isLegalSILType())
-    return false;
-
-  CanType parentTy = rootTy;
+  SILType parentTy = rootTy;
   
   // First check if _storedInlineOffset would return an offset or nil. Basically
   // only stored struct and tuple elements produce an offset. Everything else
@@ -387,14 +384,15 @@ bool SILCombiner::tryOptimizeKeypathOffsetOf(ApplyInst *AI,
       hasOffset = false;
       break;
     }
-    parentTy = component.getComponentType();
+    parentTy = f->getLoweredType(Lowering::AbstractionPattern::getOpaque(),
+                                 component.getComponentType());
   }
 
   SILLocation loc = AI->getLoc();
   SILValue result;
 
   if (hasOffset) {
-    SILType rootAddrTy = SILType::getPrimitiveAddressType(rootTy);
+    SILType rootAddrTy = rootTy.getAddressType();
     SILValue rootAddr = Builder.createBaseAddrForOffset(loc, rootAddrTy);
 
     auto projector = KeyPathProjector::create(kp, rootAddr, loc, Builder);

--- a/test/SILOptimizer/keypath_offset.swift
+++ b/test/SILOptimizer/keypath_offset.swift
@@ -159,7 +159,10 @@ func testTupleOffsets() {
   printOffset(TLayout.offset(of: \Tuple<Int, Int>.1))
 }
 
-// Just check that we don't crash.
+// CHECK-LABEL: sil {{.*}} @$s4test0A16TupleOfFunctionsyyF
+// CHECK-NOT:     _storedInlineOffset
+// CHECK-NOT:     class_method
+// CHECK:       } // end sil function '$s4test0A16TupleOfFunctionsyyF'
 @inline(never)
 func testTupleOfFunctions() {
   printOffset(MemoryLayout<TupleOfFunctions>.offset(of: \.b))


### PR DESCRIPTION
Instead of bailing out, use the lowered type.

rdar://103834325

This is a follow-up of https://github.com/apple/swift/pull/62812