### PR TITLE
ComputeSideEffects: correct side effects for destroy_addr

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
@@ -442,7 +442,8 @@ private struct ArgumentEscapingWalker : ValueDefUseWalker, AddressDefUseWalker {
       return .continueWalk
 
     // Warning: all instruction listed here, must also be handled in `CollectedEffects.addInstructionEffects`
-    case is StoreInst, is StoreWeakInst, is StoreUnownedInst, is ApplySite, is DestroyAddrInst:
+    case is StoreInst, is StoreWeakInst, is StoreUnownedInst, is ApplySite, is DestroyAddrInst,
+         is DebugValueInst:
       return .continueWalk
 
     default:

--- a/test/SILOptimizer/assemblyvision_remark/chacha.swift
+++ b/test/SILOptimizer/assemblyvision_remark/chacha.swift
@@ -33,7 +33,7 @@ public func run_ChaCha(_ N: Int) {
 
   var checkedtext = Array(repeating: UInt8(0), count: 1024)
   ChaCha20.encrypt(bytes: &checkedtext, key: key, nonce: nonce)
-  checkResult(checkedtext)// expected-note @-2 {{of 'checkedtext}}
+  checkResult(checkedtext)
 
 
   var plaintext = Array(repeating: UInt8(0), count: 30720)
@@ -43,7 +43,7 @@ public func run_ChaCha(_ N: Int) {
                             // expected-remark @-1:27 {{release of type '}}
   }
 } // expected-remark {{release of type '}}
-  // expected-note @-7 {{of 'plaintext}}
+
   // expected-remark @-2 {{release of type '}}
   // expected-note @-16 {{of 'nonce}}
   // expected-remark @-4 {{release of type '}}

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -436,7 +436,7 @@ bb0(%0 : @owned $SP):
 }
 
 // CHECK-LABEL: sil [ossa] @store_destoys
-// CHECK-NEXT:  [%0: write v**, destroy v**]
+// CHECK-NEXT:  [%0: read v**, write v**, destroy v**]
 // CHECK-NEXT:  [%1: write c*.v**, copy c*.v**]
 // CHECK-NEXT:  [global: write,copy]
 // CHECK-NEXT:  {{^[^[]}}
@@ -448,7 +448,7 @@ bb0(%0 : $*X, %1 : @owned $X):
 }
 
 // CHECK-LABEL: sil [ossa] @unknown_destructor_effects
-// CHECK-NEXT:  [%0: write v**, destroy v**]
+// CHECK-NEXT:  [%0: read v**, write v**, destroy v**]
 // CHECK-NEXT:  [%1: read c*.v**, write c*.v**, copy c*.v**, destroy c*.v**]
 // CHECK-NEXT:  [global: read,write,copy,destroy,allocate,deinit_barrier]
 // CHECK-NEXT:  {{^[^[]}}
@@ -471,7 +471,7 @@ bb0(%0 : $*X, %1 : @owned $X):
 }
 
 // CHECK-LABEL: sil [ossa] @copy_destoys
-// CHECK-NEXT:  [%0: write v**, destroy v**]
+// CHECK-NEXT:  [%0: read v**, write v**, destroy v**]
 // CHECK-NEXT:  [%1: read v**, copy v**]
 // CHECK-NEXT:  [global: write,copy]
 // CHECK-NEXT:  {{^[^[]}}
@@ -518,7 +518,7 @@ bb0(%0 : @owned $SP):
 }
 
 // CHECK-LABEL: sil [ossa] @destroy_addr_effects
-// CHECK-NEXT:  [%0: destroy v**]
+// CHECK-NEXT:  [%0: read v**, write v**, destroy v**]
 // CHECK-NEXT:  [global: write,copy]
 // CHECK-NEXT:  {{^[^[]}}
 sil [ossa] @destroy_addr_effects : $@convention(thin) (@in X) -> () {

--- a/test/SILOptimizer/side_effects.sil
+++ b/test/SILOptimizer/side_effects.sil
@@ -1144,3 +1144,15 @@ bb3:
   return %r : $()
 }
 
+// CHECK-LABEL: sil @test_debug_value_address
+// CHECK-NEXT:  [%0: read v**, write v**, destroy v**]
+// CHECK-NEXT:  [global: read,write,copy,destroy,allocate,deinit_barrier]
+// CHECK-NEXT:  {{^[^[]}}
+sil @test_debug_value_address : $@convention(thin) <T> (@in T, @inout T) -> () {
+bb0(%0 : $*T, %1 : $*T):
+  destroy_addr %0 : $*T
+  debug_value %1 : $*T
+  %4 = tuple ()
+  return %4 : $()
+}
+


### PR DESCRIPTION
A destroy_addr also involves a read from the address. It's equivalent to a `%x = load [take]` and `destroy_value %x`.
It's also a write, because the stored value is not available anymore after the destroy.

Fixes a compiler crash in SILMem2Reg.

rdar://103879105

Also, ignore side effects of debug_value with address operands.
