### PR TITLE
include/swift/Basic: fix deprecation warnings

### DIFF
--- a/include/swift/Basic/type_traits.h
+++ b/include/swift/Basic/type_traits.h
@@ -45,6 +45,8 @@ struct IsTriviallyConstructible {
 #if defined(_LIBCPP_VERSION) || SWIFT_COMPILER_IS_MSVC
   // libc++ and MSVC implement is_trivially_constructible.
   static const bool value = std::is_trivially_constructible<T>::value;
+#elif __has_feature(is_trivially_constructible)
+  static const bool value = __is_trivially_constructible(T);
 #elif __has_feature(has_trivial_constructor) || __GNUC__ >= 5
   static const bool value = __has_trivial_constructor(T);
 #else
@@ -57,6 +59,8 @@ struct IsTriviallyDestructible {
 #if defined(_LIBCPP_VERSION) || SWIFT_COMPILER_IS_MSVC
   // libc++ and MSVC implement is_trivially_destructible.
   static const bool value = std::is_trivially_destructible<T>::value;
+#elif __has_feature(is_trivially_destructible)
+  static const bool value = __is_trivially_destructible(T);
 #elif __has_feature(has_trivial_destructor) || __GNUC__ >= 5
   static const bool value = __has_trivial_destructor(T);
 #else


### PR DESCRIPTION
These are deprecation warnings
```
include/swift/Basic/type_traits.h:49:29: warning: builtin __has_trivial_constructor is deprecated; use __is_trivially_constructible instead [-Wdeprecated-builtins]
  static const bool value = __has_trivial_constructor(T);
                            ^
include/swift/Basic/type_traits.h:61:29: warning: builtin __has_trivial_destructor is deprecated; use __is_trivially_destructible instead [-Wdeprecated-builtins]
  static const bool value = __has_trivial_destructor(T);
                            ^
2 warnings generated.
```
