### PR TITLE
[Compile Time Constant Extraction] Extract line and file information

### DIFF
--- a/test/ConstExtraction/ExtractCalls.swift
+++ b/test/ConstExtraction/ExtractCalls.swift
@@ -4,91 +4,6 @@
 // RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractCalls.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
 // RUN: cat %t/ExtractCalls.swiftconstvalues 2>&1 | %FileCheck %s
 
-// CHECK: [
-// CHECK-NEXT:  {
-// CHECK-NEXT:    "typeName": "ExtractCalls.Foo",
-// CHECK-NEXT:    "kind": "struct",
-// CHECK-NEXT:    "properties": [
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "init1",
-// CHECK-NEXT:        "type": "ExtractCalls.Bar",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "false",
-// CHECK-NEXT:        "valueKind": "InitCall",
-// CHECK-NEXT:        "value": {
-// CHECK-NEXT:          "type": "ExtractCalls.Bar",
-// CHECK-NEXT:          "arguments": []
-// CHECK-NEXT:        }
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "init2",
-// CHECK-NEXT:        "type": "ExtractCalls.Bat",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "false",
-// CHECK-NEXT:        "valueKind": "InitCall",
-// CHECK-NEXT:        "value": {
-// CHECK-NEXT:          "type": "ExtractCalls.Bat",
-// CHECK-NEXT:          "arguments": [
-// CHECK-NEXT:            {
-// CHECK-NEXT:              "label": "buz",
-// CHECK-NEXT:              "type": "Swift.String",
-// CHECK-NEXT:              "valueKind": "RawLiteral",
-// CHECK-NEXT:              "value": ""
-// CHECK-NEXT:            },
-// CHECK-NEXT:            {
-// CHECK-NEXT:              "label": "fuz",
-// CHECK-NEXT:              "type": "Swift.Int",
-// CHECK-NEXT:              "valueKind": "RawLiteral",
-// CHECK-NEXT:              "value": "0"
-// CHECK-NEXT:            }
-// CHECK-NEXT:          ]
-// CHECK-NEXT:        }
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "init3",
-// CHECK-NEXT:        "type": "ExtractCalls.Bat",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "false",
-// CHECK-NEXT:        "valueKind": "InitCall",
-// CHECK-NEXT:        "value": {
-// CHECK-NEXT:          "type": "ExtractCalls.Bat",
-// CHECK-NEXT:          "arguments": [
-// CHECK-NEXT:            {
-// CHECK-NEXT:              "label": "buz",
-// CHECK-NEXT:              "type": "Swift.String",
-// CHECK-NEXT:              "valueKind": "RawLiteral",
-// CHECK-NEXT:              "value": "hello"
-// CHECK-NEXT:            },
-// CHECK-NEXT:            {
-// CHECK-NEXT:              "label": "fuz",
-// CHECK-NEXT:              "type": "Swift.Int",
-// CHECK-NEXT:              "valueKind": "Runtime"
-// CHECK-NEXT:            }
-// CHECK-NEXT:          ]
-// CHECK-NEXT:        }
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "func1",
-// CHECK-NEXT:        "type": "Swift.Int",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "false",
-// CHECK-NEXT:        "valueKind": "Runtime"
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "ext1",
-// CHECK-NEXT:        "type": "ExtractCalls.Foo.Boo",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "true",
-// CHECK-NEXT:        "valueKind": "InitCall",
-// CHECK-NEXT:        "value": {
-// CHECK-NEXT:          "type": "ExtractCalls.Foo.Boo",
-// CHECK-NEXT:          "arguments": []
-// CHECK-NEXT:        }
-// CHECK-NEXT:      }
-// CHECK-NEXT:    ]
-// CHECK-NEXT:  }
-// CHECK-NEXT:]
-
 protocol MyProto {}
 
 public struct Foo : MyProto {
@@ -118,3 +33,100 @@ public struct Bat {
         self.fuz = fuz
     }
 }
+
+// CHECK: [
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "typeName": "ExtractCalls.Foo",
+// CHECK-NEXT:    "kind": "struct",
+// CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:    "line": 9,
+// CHECK-NEXT:    "properties": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "init1",
+// CHECK-NEXT:        "type": "ExtractCalls.Bar",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:        "line": 10,
+// CHECK-NEXT:        "valueKind": "InitCall",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "type": "ExtractCalls.Bar",
+// CHECK-NEXT:          "arguments": []
+// CHECK-NEXT:        }
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "init2",
+// CHECK-NEXT:        "type": "ExtractCalls.Bat",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:        "line": 11,
+// CHECK-NEXT:        "valueKind": "InitCall",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "type": "ExtractCalls.Bat",
+// CHECK-NEXT:          "arguments": [
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "buz",
+// CHECK-NEXT:              "type": "Swift.String",
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": ""
+// CHECK-NEXT:            },
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "fuz",
+// CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "0"
+// CHECK-NEXT:            }
+// CHECK-NEXT:          ]
+// CHECK-NEXT:        }
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "init3",
+// CHECK-NEXT:        "type": "ExtractCalls.Bat",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:        "line": 12,
+// CHECK-NEXT:        "valueKind": "InitCall",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "type": "ExtractCalls.Bat",
+// CHECK-NEXT:          "arguments": [
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "buz",
+// CHECK-NEXT:              "type": "Swift.String",
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "hello"
+// CHECK-NEXT:            },
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "fuz",
+// CHECK-NEXT:              "type": "Swift.Int",
+// CHECK-NEXT:              "valueKind": "Runtime"
+// CHECK-NEXT:            }
+// CHECK-NEXT:          ]
+// CHECK-NEXT:        }
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "func1",
+// CHECK-NEXT:        "type": "Swift.Int",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:        "line": 13,
+// CHECK-NEXT:        "valueKind": "Runtime"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "ext1",
+// CHECK-NEXT:        "type": "ExtractCalls.Foo.Boo",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "true",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractCalls.swift",
+// CHECK-NEXT:        "line": 19,
+// CHECK-NEXT:        "valueKind": "InitCall",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "type": "ExtractCalls.Foo.Boo",
+// CHECK-NEXT:          "arguments": []
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ]
+// CHECK-NEXT:  }
+// CHECK-NEXT:]

--- a/test/ConstExtraction/ExtractGroups.swift
+++ b/test/ConstExtraction/ExtractGroups.swift
@@ -4,16 +4,51 @@
 // RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractGroups.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
 // RUN: cat %t/ExtractGroups.swiftconstvalues 2>&1 | %FileCheck %s
 
+protocol MyProto {}
+
+public struct Arrays : MyProto {
+    let array1: [Int] = [1, 2, 3]
+    let array2: [Foo] = [Bar(), 1, "hi"]
+    let array3: [Bar] = [Bar()]
+}
+
+public struct Dictionaries : MyProto {
+    let dict1: [String: Int] = ["One": 1, "Two": 2, "Three": 3]
+    let dict2: [Int: [String]] = [
+        1: ["a", "b", "c"],
+        2: ["z"]
+    ]
+    let dict3: [String: Foo] = [
+        "Bar": Bar(),
+        "Int": 42
+    ]
+}
+
+public struct Tuples : MyProto {
+    let tuple1: (String, Bar) = ("foo", Bar())
+    let tuple2: (lat: Float, lng: Float) = (lat: 42.7, lng: -73.9)
+    let tuple3: Void = ()
+}
+
+public protocol Foo {}
+public struct Bar: Foo {}
+extension Int: Foo {}
+extension String: Foo {}
+
 // CHECK: [
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractGroups.Arrays",
 // CHECK-NEXT:    "kind": "struct",
+// CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:    "line": 9,
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "array1",
 // CHECK-NEXT:        "type": "[Swift.Int]",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:        "line": 10,
 // CHECK-NEXT:        "valueKind": "Array",
 // CHECK-NEXT:        "value": [
 // CHECK-NEXT:          {
@@ -35,6 +70,8 @@
 // CHECK-NEXT:        "type": "[ExtractGroups.Foo]",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:        "line": 11,
 // CHECK-NEXT:        "valueKind": "Array",
 // CHECK-NEXT:        "value": [
 // CHECK-NEXT:          {
@@ -59,6 +96,8 @@
 // CHECK-NEXT:        "type": "[ExtractGroups.Bar]",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:        "line": 12,
 // CHECK-NEXT:        "valueKind": "Array",
 // CHECK-NEXT:        "value": [
 // CHECK-NEXT:          {
@@ -75,12 +114,16 @@
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractGroups.Dictionaries",
 // CHECK-NEXT:    "kind": "struct",
+// CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:    "line": 15,
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "dict1",
 // CHECK-NEXT:        "type": "[Swift.String : Swift.Int]",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:        "line": 16,
 // CHECK-NEXT:        "valueKind": "Dictionary",
 // CHECK-NEXT:        "value": [
 // CHECK-NEXT:          {
@@ -120,6 +163,8 @@
 // CHECK-NEXT:        "type": "[Swift.Int : [Swift.String]]",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:        "line": 17,
 // CHECK-NEXT:        "valueKind": "Dictionary",
 // CHECK-NEXT:        "value": [
 // CHECK-NEXT:          {
@@ -167,6 +212,8 @@
 // CHECK-NEXT:        "type": "[Swift.String : ExtractGroups.Foo]",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:        "line": 21,
 // CHECK-NEXT:        "valueKind": "Dictionary",
 // CHECK-NEXT:        "value": [
 // CHECK-NEXT:          {
@@ -199,12 +246,16 @@
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "typeName": "ExtractGroups.Tuples",
 // CHECK-NEXT:    "kind": "struct",
+// CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:    "line": 27,
 // CHECK-NEXT:    "properties": [
 // CHECK-NEXT:      {
 // CHECK-NEXT:        "label": "tuple1",
 // CHECK-NEXT:        "type": "(Swift.String, ExtractGroups.Bar)",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:        "line": 28,
 // CHECK-NEXT:        "valueKind": "Tuple",
 // CHECK-NEXT:        "value": [
 // CHECK-NEXT:          {
@@ -227,6 +278,8 @@
 // CHECK-NEXT:        "type": "(lat: Swift.Float, lng: Swift.Float)",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:        "line": 29,
 // CHECK-NEXT:        "valueKind": "Tuple",
 // CHECK-NEXT:        "value": [
 // CHECK-NEXT:          {
@@ -248,40 +301,11 @@
 // CHECK-NEXT:        "type": "Swift.Void",
 // CHECK-NEXT:        "isStatic": "false",
 // CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractGroups.swift",
+// CHECK-NEXT:        "line": 30,
 // CHECK-NEXT:        "valueKind": "Tuple",
 // CHECK-NEXT:        "value": []
 // CHECK-NEXT:      }
 // CHECK-NEXT:    ]
 // CHECK-NEXT:  }
 // CHECK-NEXT:]
-
-protocol MyProto {}
-
-public struct Arrays : MyProto {
-    let array1: [Int] = [1, 2, 3]
-    let array2: [Foo] = [Bar(), 1, "hi"]
-    let array3: [Bar] = [Bar()]
-}
-
-public struct Dictionaries : MyProto {
-    let dict1: [String: Int] = ["One": 1, "Two": 2, "Three": 3]
-    let dict2: [Int: [String]] = [
-        1: ["a", "b", "c"],
-        2: ["z"]
-    ]
-    let dict3: [String: Foo] = [
-        "Bar": Bar(),
-        "Int": 42
-    ]
-}
-
-public struct Tuples : MyProto {
-    let tuple1: (String, Bar) = ("foo", Bar())
-    let tuple2: (lat: Float, lng: Float) = (lat: 42.7, lng: -73.9)
-    let tuple3: Void = ()
-}
-
-public protocol Foo {}
-public struct Bar: Foo {}
-extension Int: Foo {}
-extension String: Foo {}

--- a/test/ConstExtraction/ExtractLiterals.swift
+++ b/test/ConstExtraction/ExtractLiterals.swift
@@ -4,233 +4,6 @@
 // RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractLiterals.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
 // RUN: cat %t/ExtractLiterals.swiftconstvalues 2>&1 | %FileCheck %s
 
-// CHECK: [
-// CHECK-NEXT:  {
-// CHECK-NEXT:    "typeName": "ExtractLiterals.Bools",
-// CHECK-NEXT:    "kind": "struct",
-// CHECK-NEXT:    "properties": [
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "bool1",
-// CHECK-NEXT:        "type": "Swift.Bool",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "false",
-// CHECK-NEXT:        "valueKind": "RawLiteral",
-// CHECK-NEXT:        "value": "false"
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "bool2",
-// CHECK-NEXT:        "type": "Swift.Bool?",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "false",
-// CHECK-NEXT:        "valueKind": "RawLiteral",
-// CHECK-NEXT:        "value": "nil"
-// CHECK-NEXT:      }
-// CHECK-NEXT:    ]
-// CHECK-NEXT:  },
-// CHECK-NEXT:  {
-// CHECK-NEXT:    "typeName": "ExtractLiterals.Ints",
-// CHECK-NEXT:    "kind": "struct",
-// CHECK-NEXT:    "properties": [
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "int1",
-// CHECK-NEXT:        "type": "Swift.Int",
-// CHECK-NEXT:        "isStatic": "true",
-// CHECK-NEXT:        "isComputed": "false",
-// CHECK-NEXT:        "valueKind": "RawLiteral",
-// CHECK-NEXT:        "value": "1"
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "int2",
-// CHECK-NEXT:        "type": "Swift.Int",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "true",
-// CHECK-NEXT:        "valueKind": "RawLiteral",
-// CHECK-NEXT:        "value": "2"
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "int3",
-// CHECK-NEXT:        "type": "Swift.Int",
-// CHECK-NEXT:        "isStatic": "true",
-// CHECK-NEXT:        "isComputed": "true",
-// CHECK-NEXT:        "valueKind": "RawLiteral",
-// CHECK-NEXT:        "value": "3"
-// CHECK-NEXT:      }
-// CHECK-NEXT:    ]
-// CHECK-NEXT:  },
-// CHECK-NEXT:  {
-// CHECK-NEXT:    "typeName": "ExtractLiterals.Floats",
-// CHECK-NEXT:    "kind": "struct",
-// CHECK-NEXT:    "properties": [
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "float1",
-// CHECK-NEXT:        "type": "Swift.Float",
-// CHECK-NEXT:        "isStatic": "true",
-// CHECK-NEXT:        "isComputed": "false",
-// CHECK-NEXT:        "valueKind": "RawLiteral",
-// CHECK-NEXT:        "value": "42.2"
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "float2",
-// CHECK-NEXT:        "type": "Swift.Float",
-// CHECK-NEXT:        "isStatic": "true",
-// CHECK-NEXT:        "isComputed": "true",
-// CHECK-NEXT:        "valueKind": "RawLiteral",
-// CHECK-NEXT:        "value": "6"
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "float3",
-// CHECK-NEXT:        "type": "Swift.Float",
-// CHECK-NEXT:        "isStatic": "true",
-// CHECK-NEXT:        "isComputed": "true",
-// CHECK-NEXT:        "valueKind": "Runtime"
-// CHECK-NEXT:      }
-// CHECK-NEXT:    ]
-// CHECK-NEXT:  },
-// CHECK-NEXT:  {
-// CHECK-NEXT:    "typeName": "ExtractLiterals.Strings",
-// CHECK-NEXT:    "kind": "struct",
-// CHECK-NEXT:    "properties": [
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "string1",
-// CHECK-NEXT:        "type": "Swift.String",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "false",
-// CHECK-NEXT:        "valueKind": "RawLiteral",
-// CHECK-NEXT:        "value": "First \"string\"\nSecond \\ string"
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "string2",
-// CHECK-NEXT:        "type": "Swift.String",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "false",
-// CHECK-NEXT:        "valueKind": "RawLiteral",
-// CHECK-NEXT:        "value": "Hi"
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "string3",
-// CHECK-NEXT:        "type": "Swift.String",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "true",
-// CHECK-NEXT:        "valueKind": "RawLiteral",
-// CHECK-NEXT:        "value": "Hey"
-// CHECK-NEXT:      }
-// CHECK-NEXT:    ]
-// CHECK-NEXT:  },
-// CHECK-NEXT:  {
-// CHECK-NEXT:    "typeName": "ExtractLiterals.PropertyWrappers",
-// CHECK-NEXT:    "kind": "struct",
-// CHECK-NEXT:    "properties": [
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "_propertyWrapper1",
-// CHECK-NEXT:        "type": "ExtractLiterals.Buffered<Swift.String>",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "false",
-// CHECK-NEXT:        "valueKind": "Runtime"
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "_propertyWrapper2",
-// CHECK-NEXT:        "type": "ExtractLiterals.Clamping<Swift.Int>",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "false",
-// CHECK-NEXT:        "valueKind": "Runtime"
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "_propertyWrapper3",
-// CHECK-NEXT:        "type": "ExtractLiterals.Buffered<ExtractLiterals.Clamping<Swift.Int>>",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "false",
-// CHECK-NEXT:        "valueKind": "Runtime"
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "propertyWrapper1",
-// CHECK-NEXT:        "type": "Swift.String",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "true",
-// CHECK-NEXT:        "valueKind": "RawLiteral",
-// CHECK-NEXT:        "value": "Hello",
-// CHECK-NEXT:        "attributes": [
-// CHECK-NEXT:          {
-// CHECK-NEXT:            "type": "ExtractLiterals.Buffered",
-// CHECK-NEXT:            "arguments": []
-// CHECK-NEXT:          }
-// CHECK-NEXT:        ]
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "$propertyWrapper1",
-// CHECK-NEXT:        "type": "(Swift.String, Swift.String?)",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "true",
-// CHECK-NEXT:        "valueKind": "Runtime"
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "propertyWrapper2",
-// CHECK-NEXT:        "type": "Swift.Int",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "true",
-// CHECK-NEXT:        "valueKind": "RawLiteral",
-// CHECK-NEXT:        "value": "128",
-// CHECK-NEXT:        "attributes": [
-// CHECK-NEXT:          {
-// CHECK-NEXT:            "type": "ExtractLiterals.Clamping",
-// CHECK-NEXT:            "arguments": [
-// CHECK-NEXT:              {
-// CHECK-NEXT:                "label": "min",
-// CHECK-NEXT:                "type": "Swift.Int",
-// CHECK-NEXT:                "valueKind": "RawLiteral",
-// CHECK-NEXT:                "value": "0"
-// CHECK-NEXT:              },
-// CHECK-NEXT:              {
-// CHECK-NEXT:                "label": "max",
-// CHECK-NEXT:                "type": "Swift.Int",
-// CHECK-NEXT:                "valueKind": "RawLiteral",
-// CHECK-NEXT:                "value": "255"
-// CHECK-NEXT:              }
-// CHECK-NEXT:            ]
-// CHECK-NEXT:          }
-// CHECK-NEXT:        ]
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "propertyWrapper3",
-// CHECK-NEXT:        "type": "Swift.Int",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "true",
-// CHECK-NEXT:        "valueKind": "RawLiteral",
-// CHECK-NEXT:        "value": "128",
-// CHECK-NEXT:        "attributes": [
-// CHECK-NEXT:          {
-// CHECK-NEXT:            "type": "ExtractLiterals.Buffered",
-// CHECK-NEXT:            "arguments": []
-// CHECK-NEXT:          },
-// CHECK-NEXT:          {
-// CHECK-NEXT:            "type": "ExtractLiterals.Clamping",
-// CHECK-NEXT:            "arguments": [
-// CHECK-NEXT:              {
-// CHECK-NEXT:                "label": "min",
-// CHECK-NEXT:                "type": "Swift.Int",
-// CHECK-NEXT:                "valueKind": "RawLiteral",
-// CHECK-NEXT:                "value": "0"
-// CHECK-NEXT:              },
-// CHECK-NEXT:              {
-// CHECK-NEXT:                "label": "max",
-// CHECK-NEXT:                "type": "Swift.Int",
-// CHECK-NEXT:                "valueKind": "RawLiteral",
-// CHECK-NEXT:                "value": "255"
-// CHECK-NEXT:              }
-// CHECK-NEXT:            ]
-// CHECK-NEXT:          }
-// CHECK-NEXT:        ]
-// CHECK-NEXT:      },
-// CHECK-NEXT:      {
-// CHECK-NEXT:        "label": "$propertyWrapper3",
-// CHECK-NEXT:        "type": "(ExtractLiterals.Clamping<Swift.Int>, ExtractLiterals.Clamping<Swift.Int>?)",
-// CHECK-NEXT:        "isStatic": "false",
-// CHECK-NEXT:        "isComputed": "true",
-// CHECK-NEXT:        "valueKind": "Runtime"
-// CHECK-NEXT:      }
-// CHECK-NEXT:    ]
-// CHECK-NEXT:  }
-// CHECK-NEXT:]
-
 protocol MyProto {}
 
 public struct Bools : MyProto {
@@ -316,4 +89,279 @@ public struct PropertyWrappers : MyProto {
      }
 
      var projectedValue: (V, V?) { (self.value, self.lastValue) }
- }
+}
+
+// CHECK: [
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "typeName": "ExtractLiterals.Bools",
+// CHECK-NEXT:    "kind": "struct",
+// CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:    "line": 9,
+// CHECK-NEXT:    "properties": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "bool1",
+// CHECK-NEXT:        "type": "Swift.Bool",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 10,
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "false"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "bool2",
+// CHECK-NEXT:        "type": "Swift.Bool?",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 11,
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "nil"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ]
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "typeName": "ExtractLiterals.Ints",
+// CHECK-NEXT:    "kind": "struct",
+// CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:    "line": 14,
+// CHECK-NEXT:    "properties": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "int1",
+// CHECK-NEXT:        "type": "Swift.Int",
+// CHECK-NEXT:        "isStatic": "true",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 15,
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "1"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "int2",
+// CHECK-NEXT:        "type": "Swift.Int",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "true",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 16,
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "2"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "int3",
+// CHECK-NEXT:        "type": "Swift.Int",
+// CHECK-NEXT:        "isStatic": "true",
+// CHECK-NEXT:        "isComputed": "true",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 17,
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "3"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ]
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "typeName": "ExtractLiterals.Floats",
+// CHECK-NEXT:    "kind": "struct",
+// CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:    "line": 20,
+// CHECK-NEXT:    "properties": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "float1",
+// CHECK-NEXT:        "type": "Swift.Float",
+// CHECK-NEXT:        "isStatic": "true",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 21,
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "42.2"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "float2",
+// CHECK-NEXT:        "type": "Swift.Float",
+// CHECK-NEXT:        "isStatic": "true",
+// CHECK-NEXT:        "isComputed": "true",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 22,
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "6"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "float3",
+// CHECK-NEXT:        "type": "Swift.Float",
+// CHECK-NEXT:        "isStatic": "true",
+// CHECK-NEXT:        "isComputed": "true",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 23,
+// CHECK-NEXT:        "valueKind": "Runtime"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ]
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "typeName": "ExtractLiterals.Strings",
+// CHECK-NEXT:    "kind": "struct",
+// CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:    "line": 26,
+// CHECK-NEXT:    "properties": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "string1",
+// CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 27,
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "First \"string\"\nSecond \\ string"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "string2",
+// CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 33,
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "Hi"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "string3",
+// CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "true",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 34,
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "Hey"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ]
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "typeName": "ExtractLiterals.PropertyWrappers",
+// CHECK-NEXT:    "kind": "struct",
+// CHECK-NEXT:    "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:    "line": 37,
+// CHECK-NEXT:    "properties": [
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "_propertyWrapper1",
+// CHECK-NEXT:        "type": "ExtractLiterals.Buffered<Swift.String>",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 39,
+// CHECK-NEXT:        "valueKind": "Runtime"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "_propertyWrapper2",
+// CHECK-NEXT:        "type": "ExtractLiterals.Clamping<Swift.Int>",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 42,
+// CHECK-NEXT:        "valueKind": "Runtime"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "_propertyWrapper3",
+// CHECK-NEXT:        "type": "ExtractLiterals.Buffered<ExtractLiterals.Clamping<Swift.Int>>",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "false",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 45,
+// CHECK-NEXT:        "valueKind": "Runtime"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "propertyWrapper1",
+// CHECK-NEXT:        "type": "Swift.String",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "true",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 39,
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "Hello",
+// CHECK-NEXT:        "attributes": [
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "type": "ExtractLiterals.Buffered",
+// CHECK-NEXT:            "arguments": []
+// CHECK-NEXT:          }
+// CHECK-NEXT:        ]
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "$propertyWrapper1",
+// CHECK-NEXT:        "type": "(Swift.String, Swift.String?)",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "true",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 39,
+// CHECK-NEXT:        "valueKind": "Runtime"
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "propertyWrapper2",
+// CHECK-NEXT:        "type": "Swift.Int",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "true",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 42,
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "128",
+// CHECK-NEXT:        "attributes": [
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "type": "ExtractLiterals.Clamping",
+// CHECK-NEXT:            "arguments": [
+// CHECK-NEXT:              {
+// CHECK-NEXT:                "label": "min",
+// CHECK-NEXT:                "type": "Swift.Int",
+// CHECK-NEXT:                "valueKind": "RawLiteral",
+// CHECK-NEXT:                "value": "0"
+// CHECK-NEXT:              },
+// CHECK-NEXT:              {
+// CHECK-NEXT:                "label": "max",
+// CHECK-NEXT:                "type": "Swift.Int",
+// CHECK-NEXT:                "valueKind": "RawLiteral",
+// CHECK-NEXT:                "value": "255"
+// CHECK-NEXT:              }
+// CHECK-NEXT:            ]
+// CHECK-NEXT:          }
+// CHECK-NEXT:        ]
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "propertyWrapper3",
+// CHECK-NEXT:        "type": "Swift.Int",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "true",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 45,
+// CHECK-NEXT:        "valueKind": "RawLiteral",
+// CHECK-NEXT:        "value": "128",
+// CHECK-NEXT:        "attributes": [
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "type": "ExtractLiterals.Buffered",
+// CHECK-NEXT:            "arguments": []
+// CHECK-NEXT:          },
+// CHECK-NEXT:          {
+// CHECK-NEXT:            "type": "ExtractLiterals.Clamping",
+// CHECK-NEXT:            "arguments": [
+// CHECK-NEXT:              {
+// CHECK-NEXT:                "label": "min",
+// CHECK-NEXT:                "type": "Swift.Int",
+// CHECK-NEXT:                "valueKind": "RawLiteral",
+// CHECK-NEXT:                "value": "0"
+// CHECK-NEXT:              },
+// CHECK-NEXT:              {
+// CHECK-NEXT:                "label": "max",
+// CHECK-NEXT:                "type": "Swift.Int",
+// CHECK-NEXT:                "valueKind": "RawLiteral",
+// CHECK-NEXT:                "value": "255"
+// CHECK-NEXT:              }
+// CHECK-NEXT:            ]
+// CHECK-NEXT:          }
+// CHECK-NEXT:        ]
+// CHECK-NEXT:      },
+// CHECK-NEXT:      {
+// CHECK-NEXT:        "label": "$propertyWrapper3",
+// CHECK-NEXT:        "type": "(ExtractLiterals.Clamping<Swift.Int>, ExtractLiterals.Clamping<Swift.Int>?)",
+// CHECK-NEXT:        "isStatic": "false",
+// CHECK-NEXT:        "isComputed": "true",
+// CHECK-NEXT:        "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:        "line": 45,
+// CHECK-NEXT:        "valueKind": "Runtime"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    ]
+// CHECK-NEXT:  }
+// CHECK-NEXT:]


### PR DESCRIPTION
This PR adds line number and filename extraction for types and properties.

It also restructures tests to have `CHECK` after the declared code to help limit future line number changes.