### PR TITLE
[5.8🍒] Resolve ambiguity error for global-actor function conversions

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3020,6 +3020,13 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
         return getTypeMatchFailure(locator);
     } else if (kind < ConstraintKind::Subtype) {
       return getTypeMatchFailure(locator);
+    } else {
+      // It is possible to convert from a function without a global actor to a
+      // similar function type that does have a global actor. But, since there
+      // is a function conversion going on here, let's increase the score to
+      // avoid ambiguity when solver can also match a global actor matching
+      // function type.
+      increaseScore(SK_FunctionConversion);
     }
   }
 

--- a/test/Concurrency/global_actor_function_types.swift
+++ b/test/Concurrency/global_actor_function_types.swift
@@ -153,3 +153,10 @@ func test() {
     onSomeGlobalActor()
   }
 }
+
+// https://github.com/apple/swift/issues/61436
+let x: @MainActor () -> Void
+
+let y: () -> Void = {}
+
+x = true ? y : y // Ok


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/62514

The basic problem is that ternary expressions like this:

```
let _: @MainActor () -> () = true ? {} : {}
```

could yield an ambiguity error because the constraint solver can discover multiple solutions for adding casts to make this work (i.e., cast each arm of the ternary or cast just the result of the ternary). This wasn't a problem in 5.7 but became an issue as of either 5.7.1. or 5.7.2.