### PR TITLE
[5.8][test] Disable test/stdlib/StringIndex.swift to unblock CI

### DIFF
--- a/test/stdlib/StringIndex.swift
+++ b/test/stdlib/StringIndex.swift
@@ -9,6 +9,9 @@
 // REQUIRES: executable_test
 // UNSUPPORTED: freestanding
 
+// Temporarily disabled due to extremely slow execution in the "UTF-16 breadcrumbs" test
+// REQUIRES: rdar103934958
+
 import StdlibUnittest
 #if _runtime(_ObjC)
 import Foundation


### PR DESCRIPTION
The test is now taking multiple hours to complete on some configurations. Let's disable this while I'm investigating offline.

rdar://103934958
