### PR TITLE
[test] Disable test/stdlib/StringIndex.swift to unblock CI

### DIFF
--- a/test/stdlib/StringIndex.swift
+++ b/test/stdlib/StringIndex.swift
@@ -9,6 +9,9 @@
 // REQUIRES: executable_test
 // UNSUPPORTED: freestanding
 
+// Temporarily disabled due to extremely slow execution in the "UTF-16 breadcrumbs" test
+// REQUIRES: rdar103934958
+
 import StdlibUnittest
 #if _runtime(_ObjC)
 import Foundation


### PR DESCRIPTION
The new UTF-16 breadcrumbs test is taking >3 hours to complete when the stdlib is built with -Onone.

This is likely only affecting that one test case and only in this configuration, but let'd disable the whole test until I know what's going on.

rdar://103934958

