### PR TITLE
Sema: Lift restriction requiring decls with `@_backDeploy` to have explicit availability

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2367,6 +2367,10 @@ public:
   /// otherwise.
   const AvailableAttr *getNoAsync(const ASTContext &ctx) const;
 
+  /// Returns the \c @_backDeploy attribute that is active for the current
+  /// platform.
+  const BackDeployAttr *getBackDeploy(const ASTContext &ctx) const;
+
   SWIFT_DEBUG_DUMPER(dump(const Decl *D = nullptr));
   void print(ASTPrinter &Printer, const PrintOptions &Options,
              const Decl *D = nullptr) const;

--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -24,6 +24,7 @@
 
 namespace swift {
 class ASTContext;
+class AvailableAttr;
 class Decl;
 
 /// A lattice of version ranges of the form [x.y.z, +Inf).
@@ -343,6 +344,11 @@ public:
   /// Returns the context where a declaration is available
   ///  We assume a declaration without an annotation is always available.
   static AvailabilityContext availableRange(const Decl *D, ASTContext &C);
+
+  /// Returns the attribute that should be used to determine the availability
+  /// range of the given declaration, or nullptr if there is none.
+  static const AvailableAttr *attrForAnnotatedAvailableRange(const Decl *D,
+                                                             ASTContext &Ctx);
 
   /// Returns the context for which the declaration
   /// is annotated as available, or None if the declaration

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1098,11 +1098,22 @@ public:
 
   bool isAvailableAsSPI() const;
 
-  /// Whether the declaration is considered unavailable through either being
-  /// explicitly marked as such, or has a parent decl that is semantically
-  /// unavailable. This is a broader notion of unavailability than is checked by
-  /// \c AvailableAttr::isUnavailable.
-  bool isSemanticallyUnavailable() const;
+  /// Retrieve the @available attribute that provides the OS version range that
+  /// this declaration is available in.
+  ///
+  /// The attribute may come from another declaration, since availability
+  /// could be inherited from a parent declaration.
+  Optional<std::pair<const AvailableAttr *, const Decl *>>
+  getSemanticAvailableRangeAttr() const;
+
+  /// Retrieve the @available attribute that makes this declaration unavailable,
+  /// if any.
+  ///
+  /// The attribute may come from another declaration, since unavailability
+  /// could be inherited from a parent declaration. This is a broader notion of
+  /// unavailability than is checked by \c AvailableAttr::isUnavailable.
+  Optional<std::pair<const AvailableAttr *, const Decl *>>
+  getSemanticUnavailableAttr() const;
 
   // List the SPI groups declared with @_spi or inherited by this decl.
   //

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3290,8 +3290,14 @@ ERROR(attr_not_on_decl_with_invalid_access_level,none,
       (DeclAttribute, AccessLevel))
 
 ERROR(attr_has_no_effect_decl_not_available_before,none,
-      "'%0' has no effect because %1 is not available before %2 %3",
-      (DeclAttribute, DeclName, StringRef, llvm::VersionTuple))
+      "'%0' has no effect because %select{getter for |setter for |}1%2 is not "
+      "available before %3 %4",
+      (DeclAttribute, unsigned, DeclName, StringRef, llvm::VersionTuple))
+
+ERROR(attr_has_no_effect_on_unavailable_decl,none,
+      "'%0' has no effect because %select{getter for |setter for |}1%2 is "
+      "unavailable on %3",
+      (DeclAttribute, unsigned, DeclName, StringRef))
 
 ERROR(attr_ambiguous_reference_to_decl,none,
       "ambiguous reference to %0 in '@%1' attribute", (DeclNameRef, StringRef))

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3480,9 +3480,11 @@ public:
   bool isCached() const { return true; }
 };
 
-class IsSemanticallyUnavailableRequest
-    : public SimpleRequest<IsSemanticallyUnavailableRequest,
-                           bool(const Decl *),
+using AvailableAttrDeclPair = std::pair<const AvailableAttr *, const Decl *>;
+
+class SemanticAvailableRangeAttrRequest
+    : public SimpleRequest<SemanticAvailableRangeAttrRequest,
+                           Optional<AvailableAttrDeclPair>(const Decl *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -3490,7 +3492,25 @@ public:
 private:
   friend SimpleRequest;
 
-  bool evaluate(Evaluator &evaluator, const Decl *decl) const;
+  Optional<AvailableAttrDeclPair> evaluate(Evaluator &evaluator,
+                                           const Decl *decl) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
+class SemanticUnavailableAttrRequest
+    : public SimpleRequest<SemanticUnavailableAttrRequest,
+                           Optional<AvailableAttrDeclPair>(const Decl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  Optional<AvailableAttrDeclPair> evaluate(Evaluator &evaluator,
+                                           const Decl *decl) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -392,8 +392,11 @@ SWIFT_REQUEST(TypeChecker, GetImplicitSendableRequest,
 SWIFT_REQUEST(TypeChecker, RenamedDeclRequest,
               ValueDecl *(const ValueDecl *, const AvailableAttr *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, IsSemanticallyUnavailableRequest,
-              bool(const Decl *),
+SWIFT_REQUEST(TypeChecker, SemanticAvailableRangeAttrRequest,
+              Optional<AvailableAttrDeclPair>(const Decl *),
+              Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, SemanticUnavailableAttrRequest,
+              Optional<AvailableAttrDeclPair>(const Decl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ClosureEffectsRequest,
               FunctionType::ExtInfo(ClosureExpr *),

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -398,6 +398,29 @@ const AvailableAttr *DeclAttributes::getNoAsync(const ASTContext &ctx) const {
   return bestAttr;
 }
 
+const BackDeployAttr *
+DeclAttributes::getBackDeploy(const ASTContext &ctx) const {
+  const BackDeployAttr *bestAttr = nullptr;
+
+  for (auto attr : *this) {
+    auto *backDeployAttr = dyn_cast<BackDeployAttr>(attr);
+    if (!backDeployAttr)
+      continue;
+
+    if (backDeployAttr->isInvalid() || !backDeployAttr->isActivePlatform(ctx))
+      continue;
+
+    // We have an attribute that is active for the platform, but
+    // is it more specific than our current best?
+    if (!bestAttr || inheritsAvailabilityFromPlatform(backDeployAttr->Platform,
+                                                      bestAttr->Platform)) {
+      bestAttr = backDeployAttr;
+    }
+  }
+
+  return bestAttr;
+}
+
 void DeclAttributes::dump(const Decl *D) const {
   StreamPrinter P(llvm::errs());
   PrintOptions PO = PrintOptions::printDeclarations();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -390,19 +390,12 @@ Decl::getIntroducedOSVersion(PlatformKind Kind) const {
 
 Optional<llvm::VersionTuple>
 Decl::getBackDeployBeforeOSVersion(ASTContext &Ctx) const {
-  for (auto *attr : getAttrs()) {
-    if (auto *backDeployAttr = dyn_cast<BackDeployAttr>(attr)) {
-      if (backDeployAttr->isActivePlatform(Ctx) && backDeployAttr->Version) {
-        return backDeployAttr->Version;
-      }
-    }
-  }
+  if (auto *attr = getAttrs().getBackDeploy(Ctx))
+    return attr->Version;
 
   // Accessors may inherit `@_backDeploy`.
-  if (getKind() == DeclKind::Accessor) {
-    return cast<AccessorDecl>(this)->getStorage()->getBackDeployBeforeOSVersion(
-        Ctx);
-  }
+  if (auto *AD = dyn_cast<AccessorDecl>(this))
+    return AD->getStorage()->getBackDeployBeforeOSVersion(Ctx);
 
   return None;
 }

--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -99,7 +99,7 @@ static bool shouldProfile(SILDeclRef Constant) {
   // Do not profile AST nodes in unavailable contexts.
   auto *DC = Constant.getInnermostDeclContext();
   if (auto *D = DC->getInnermostDeclarationDeclContext()) {
-    if (D->isSemanticallyUnavailable()) {
+    if (D->getSemanticUnavailableAttr()) {
       LLVM_DEBUG(llvm::dbgs() << "Skipping ASTNode: unavailable context\n");
       return false;
     }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4520,6 +4520,8 @@ void AttributeChecker::checkBackDeployAttrs(ArrayRef<BackDeployAttr *> Attrs) {
   auto *VD = cast<ValueDecl>(D);
   std::map<PlatformKind, SourceLoc> seenPlatforms;
 
+  auto *ActiveAttr = D->getAttrs().getBackDeploy(Ctx);
+
   for (auto *Attr : Attrs) {
     // Back deployment only makes sense for public declarations.
     if (diagnoseAndRemoveAttrIfDeclIsNonPublic(Attr, /*isError=*/true))
@@ -4559,18 +4561,47 @@ void AttributeChecker::checkBackDeployAttrs(ArrayRef<BackDeployAttr *> Attrs) {
       continue;
     }
 
-    // Require explicit availability for back deployed decls.
-    if (diagnoseMissingAvailability(Attr, Platform))
+    if (Ctx.LangOpts.DisableAvailabilityChecking)
       continue;
+
+    // Availability conflicts can only be diagnosed for attributes that apply
+    // to the active platform.
+    if (Attr != ActiveAttr)
+      continue;
+
+    // Unavailable decls cannot be back deployed.
+    if (auto unavailableAttrPair = VD->getSemanticUnavailableAttr()) {
+      auto unavailableAttr = unavailableAttrPair.value().first;
+      DeclName name;
+      unsigned accessorKind;
+      std::tie(accessorKind, name) = getAccessorKindAndNameForDiagnostics(VD);
+      diagnose(AtLoc, diag::attr_has_no_effect_on_unavailable_decl, Attr,
+               accessorKind, name, prettyPlatformString(Platform));
+      diagnose(unavailableAttr->AtLoc, diag::availability_marked_unavailable,
+               accessorKind, name)
+          .highlight(unavailableAttr->getRange());
+      continue;
+    }
 
     // Verify that the decl is available before the back deployment boundary.
     // If it's not, the attribute doesn't make sense since the back deployment
     // fallback could never be executed at runtime.
-    auto IntroVer = D->getIntroducedOSVersion(Platform);
-    if (Attr->Version <= IntroVer.value()) {
-      diagnose(AtLoc, diag::attr_has_no_effect_decl_not_available_before, Attr,
-               VD->getName(), prettyPlatformString(Platform), Attr->Version);
-      continue;
+    if (auto availableRangeAttrPair = VD->getSemanticAvailableRangeAttr()) {
+      auto availableAttr = availableRangeAttrPair.value().first;
+      if (Attr->Version <= availableAttr->Introduced.value()) {
+        DeclName name;
+        unsigned accessorKind;
+        std::tie(accessorKind, name) = getAccessorKindAndNameForDiagnostics(VD);
+        diagnose(AtLoc, diag::attr_has_no_effect_decl_not_available_before,
+                 Attr, accessorKind, name, prettyPlatformString(Platform),
+                 Attr->Version);
+        diagnose(availableAttr->AtLoc, diag::availability_introduced_in_version,
+                 accessorKind, name,
+                 prettyPlatformString(availableAttr->Platform),
+                 *availableAttr->Introduced)
+            .highlight(availableAttr->getRange());
+        continue;
+      }
     }
   }
 }

--- a/test/ModuleInterface/back-deploy-attr.swift
+++ b/test/ModuleInterface/back-deploy-attr.swift
@@ -8,14 +8,12 @@
 public struct TopLevelStruct {
   // CHECK: @_backDeploy(before: macOS 12.0)
   // CHECK: public func backDeployedFunc_SinglePlatform() -> Swift.Int { return 42 }
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public func backDeployedFunc_SinglePlatform() -> Int { return 42 }
   
   // CHECK: @_backDeploy(before: macOS 12.0)
   // CHECK: @_backDeploy(before: iOS 15.0)
   // CHECK: public func backDeployedFunc_MultiPlatform() -> Swift.Int { return 43 }
-  @available(macOS 11.0, iOS 14.0, *)
   @_backDeploy(before: macOS 12.0, iOS 15.0)
   public func backDeployedFunc_MultiPlatform() -> Int { return 43 }
 
@@ -23,7 +21,6 @@ public struct TopLevelStruct {
   // CHECK: public var backDeployedComputedProperty: Swift.Int {
   // CHECK:   get { 44 }
   // CHECK: }
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public var backDeployedComputedProperty: Int { 44 }
 
@@ -31,7 +28,6 @@ public struct TopLevelStruct {
   // CHECK: public var backDeployedPropertyWithAccessors: Swift.Int {
   // CHECK:   get { 45 }
   // CHECK: }
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public var backDeployedPropertyWithAccessors: Int {
     get { 45 }
@@ -41,7 +37,6 @@ public struct TopLevelStruct {
   // CHECK: public subscript(index: Swift.Int) -> Swift.Int {
   // CHECK:   get { 46 }
   // CHECK: }
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public subscript(index: Int) -> Int {
     get { 46 }
@@ -50,7 +45,6 @@ public struct TopLevelStruct {
 
 // CHECK: @_backDeploy(before: macOS 12.0)
 // CHECK: public func backDeployTopLevelFunc1() -> Swift.Int { return 47 }
-@available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0)
 public func backDeployTopLevelFunc1() -> Int { return 47 }
 
@@ -58,13 +52,11 @@ public func backDeployTopLevelFunc1() -> Int { return 47 }
 
 // CHECK: @_backDeploy(before: macOS 12.1)
 // CHECK: public func backDeployTopLevelFunc2() -> Swift.Int { return 48 }
-@available(macOS 11.0, *)
 @_backDeploy(before: _macOS12_1)
 public func backDeployTopLevelFunc2() -> Int { return 48 }
 
 // CHECK: @_backDeploy(before: macOS 12.1)
 // CHECK: @_backDeploy(before: iOS 15.1)
 // CHECK: public func backDeployTopLevelFunc3() -> Swift.Int { return 49 }
-@available(macOS 11.0, iOS 14.0, *)
 @_backDeploy(before: _myProject 1.0)
 public func backDeployTopLevelFunc3() -> Int { return 49 }

--- a/test/SILGen/back_deploy_attribute_accessor.swift
+++ b/test/SILGen/back_deploy_attribute_accessor.swift
@@ -5,7 +5,6 @@
 
 // REQUIRES: OS=macosx
 
-@available(macOS 10.50, *)
 public struct TopLevelStruct {
   // -- Fallback definition for TopLevelStruct.property.getter
   // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvgTwB : $@convention(method) (TopLevelStruct) -> TopLevelStruct
@@ -37,14 +36,12 @@ public struct TopLevelStruct {
 
   // -- Original definition of TopLevelStruct.property.getter
   // CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvg : $@convention(method) (TopLevelStruct) -> TopLevelStruct
-  @available(macOS 10.51, *)
   @_backDeploy(before: macOS 10.52)
   public var property: TopLevelStruct { self }
 }
 
-// CHECK-LABEL: sil hidden [available 10.51] [ossa] @$s11back_deploy6calleryyAA14TopLevelStructVF : $@convention(thin) (TopLevelStruct) -> ()
+// CHECK-LABEL: sil hidden [ossa] @$s11back_deploy6calleryyAA14TopLevelStructVF : $@convention(thin) (TopLevelStruct) -> ()
 // CHECK: bb0([[STRUCT_ARG:%.*]] : $TopLevelStruct):
-@available(macOS 10.51, *)
 func caller(_ s: TopLevelStruct) {
   // -- Verify the thunk is called
   // CHECK: {{%.*}} = function_ref @$s11back_deploy14TopLevelStructV8propertyACvgTwb : $@convention(method) (TopLevelStruct) -> TopLevelStruct

--- a/test/SILGen/back_deploy_attribute_accessor_coroutine.swift
+++ b/test/SILGen/back_deploy_attribute_accessor_coroutine.swift
@@ -5,7 +5,6 @@
 
 // REQUIRES: OS=macosx
 
-@available(macOS 10.50, *)
 public struct TopLevelStruct {
   // -- Fallback definition for TopLevelStruct.property.read
   // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvrTwB : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
@@ -64,16 +63,14 @@ public struct TopLevelStruct {
 
   // -- Original definition of TopLevelStruct.property.read
   // CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy14TopLevelStructV8propertyACvr : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct
-  @available(macOS 10.51, *)
   @_backDeploy(before: macOS 10.52)
   public var property: TopLevelStruct {
     _read { yield self }
   }
 }
 
-// CHECK-LABEL: sil hidden [available 10.51] [ossa] @$s11back_deploy6calleryyAA14TopLevelStructVF : $@convention(thin) (TopLevelStruct) -> ()
+// CHECK-LABEL: sil hidden [ossa] @$s11back_deploy6calleryyAA14TopLevelStructVF : $@convention(thin) (TopLevelStruct) -> ()
 // CHECK: bb0([[STRUCT_ARG:%.*]] : $TopLevelStruct):
-@available(macOS 10.51, *)
 func caller(_ s: TopLevelStruct) {
   // -- Verify the thunk is called
   // CHECK: {{%.*}} = function_ref @$s11back_deploy14TopLevelStructV8propertyACvrTwb : $@yield_once @convention(method) (TopLevelStruct) -> @yields TopLevelStruct

--- a/test/SILGen/back_deploy_attribute_func.swift
+++ b/test/SILGen/back_deploy_attribute_func.swift
@@ -37,7 +37,6 @@
 
 // -- Original definition of trivialFunc()
 // CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy11trivialFuncyyF : $@convention(thin) () -> ()
-@available(macOS 10.51, *)
 @_backDeploy(before: macOS 10.52)
 public func trivialFunc() {}
 
@@ -72,14 +71,12 @@ public func trivialFunc() {}
 
 // -- Original definition of isNumber(_:)
 // CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy8isNumberySbSiF : $@convention(thin) (Int) -> Bool
-@available(macOS 10.51, *)
 @_backDeploy(before: macOS 10.52)
 public func isNumber(_ x: Int) -> Bool {
   return true
 }
 
-// CHECK-LABEL: sil hidden [available 10.51] [ossa] @$s11back_deploy6calleryyF : $@convention(thin) () -> ()
-@available(macOS 10.51, *)
+// CHECK-LABEL: sil hidden [ossa] @$s11back_deploy6calleryyF : $@convention(thin) () -> ()
 func caller() {
   // -- Verify the thunk is called
   // CHECK: {{%.*}} = function_ref @$s11back_deploy11trivialFuncyyFTwb : $@convention(thin) () -> ()

--- a/test/SILGen/back_deploy_attribute_generic_func.swift
+++ b/test/SILGen/back_deploy_attribute_generic_func.swift
@@ -38,14 +38,12 @@
 
 // -- Original definition of genericFunc()
 // CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy11genericFuncyxxlF : $@convention(thin) <T> (@in_guaranteed T) -> @out T
-@available(macOS 10.51, *)
 @_backDeploy(before: macOS 10.52)
 public func genericFunc<T>(_ t: T) -> T {
   return t
 }
 
-// CHECK-LABEL: sil hidden [available 10.51] [ossa] @$s11back_deploy6calleryyF : $@convention(thin) () -> ()
-@available(macOS 10.51, *)
+// CHECK-LABEL: sil hidden [ossa] @$s11back_deploy6calleryyF : $@convention(thin) () -> ()
 func caller() {
   // -- Verify the thunk is called
   // CHECK: {{%.*}} = function_ref @$s11back_deploy11genericFuncyxxlFTwb : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @out τ_0_0

--- a/test/SILGen/back_deploy_attribute_struct_method.swift
+++ b/test/SILGen/back_deploy_attribute_struct_method.swift
@@ -5,7 +5,6 @@
 
 // REQUIRES: OS=macosx
 
-@available(macOS 10.50, *)
 public struct TopLevelStruct {
   // -- Fallback definition for TopLevelStruct.trivialMethod()
   // CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy14TopLevelStructV13trivialMethodyyFTwB : $@convention(method) (TopLevelStruct) -> ()
@@ -39,14 +38,12 @@ public struct TopLevelStruct {
 
   // -- Original definition of TopLevelStruct.trivialMethod()
   // CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy14TopLevelStructV13trivialMethodyyF : $@convention(method) (TopLevelStruct) -> ()
-  @available(macOS 10.51, *)
   @_backDeploy(before: macOS 10.52)
   public func trivialMethod() {}
 }
 
-// CHECK-LABEL: sil hidden [available 10.51] [ossa] @$s11back_deploy6calleryyAA14TopLevelStructVF : $@convention(thin) (TopLevelStruct) -> ()
+// CHECK-LABEL: sil hidden [ossa] @$s11back_deploy6calleryyAA14TopLevelStructVF : $@convention(thin) (TopLevelStruct) -> ()
 // CHECK: bb0([[STRUCT_ARG:%.*]] : $TopLevelStruct):
-@available(macOS 10.51, *)
 func caller(_ s: TopLevelStruct) {
   // -- Verify the thunk is called
   // CHECK: {{%.*}} = function_ref @$s11back_deploy14TopLevelStructV13trivialMethodyyFTwb : $@convention(method) (TopLevelStruct) -> ()

--- a/test/SILGen/back_deploy_attribute_throwing_func.swift
+++ b/test/SILGen/back_deploy_attribute_throwing_func.swift
@@ -50,12 +50,10 @@
 
 // -- Original definition of throwingFunc()
 // CHECK-LABEL: sil [available 10.52] [ossa] @$s11back_deploy12throwingFuncyyKF : $@convention(thin) () -> @error any Error
-@available(macOS 10.51, *)
 @_backDeploy(before: macOS 10.52)
 public func throwingFunc() throws {}
 
-// CHECK-LABEL: sil hidden [available 10.51] [ossa] @$s11back_deploy6calleryyKF : $@convention(thin) () -> @error any Error
-@available(macOS 10.51, *)
+// CHECK-LABEL: sil hidden [ossa] @$s11back_deploy6calleryyKF : $@convention(thin) () -> @error any Error
 func caller() throws {
   // -- Verify the thunk is called
   // CHECK: {{%.*}} = function_ref @$s11back_deploy12throwingFuncyyKFTwb : $@convention(thin) () -> @error any Error

--- a/test/Sema/availability_define.swift
+++ b/test/Sema/availability_define.swift
@@ -96,7 +96,6 @@ public func forbidMacrosInInlinableCode1() {
   }
 }
 
-@available(_iOS8Aligned, *)
 @_backDeploy(before: _iOS9Aligned)
 public func forbidMacrosInInlinableCode2() {
   if #available(_iOS9Aligned, *) { } // expected-error {{availability macro cannot be used in a '@_backDeploy' function}}

--- a/test/Serialization/back-deployed-attr-skip-noninlinable-function-bodies.swift
+++ b/test/Serialization/back-deployed-attr-skip-noninlinable-function-bodies.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-frontend -parse-as-library -enable-library-evolution -emit-module -module-name Test -experimental-skip-non-inlinable-function-bodies %s
 
-@available(SwiftStdlib 5.6, *)
 @_backDeploy(before: SwiftStdlib 5.7)
 public func foo() {}

--- a/test/attr/attr_backDeploy.swift
+++ b/test/attr/attr_backDeploy.swift
@@ -4,38 +4,31 @@
 // MARK: - Valid declarations
 
 // Ok, top level functions
-@available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0)
 public func backDeployedTopLevelFunc() {}
 
 // Ok, internal decls may be back deployed when @usableFromInline
-@available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0)
 @usableFromInline
 internal func backDeployedUsableFromInlineTopLevelFunc() {}
 
 // Ok, function/property/subscript decls in a struct
 public struct TopLevelStruct {
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public func backDeployedMethod() {}
 
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public var backDeployedComputedProperty: Int { 98 }
 
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public subscript(_ index: Int) -> Int { index }
 
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public var readWriteProperty: Int {
     get { 42 }
     set(newValue) {}
   }
 
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public subscript(at index: Int) -> Int {
     get { 42 }
@@ -43,11 +36,9 @@ public struct TopLevelStruct {
   }
 
   public var explicitReadAndModify: Int {
-    @available(macOS 11.0, *)
     @_backDeploy(before: macOS 12.0)
     _read { yield 42 }
 
-    @available(macOS 11.0, *)
     @_backDeploy(before: macOS 12.0)
     _modify {}
   }
@@ -55,62 +46,51 @@ public struct TopLevelStruct {
 
 // Ok, final function decls in a non-final class
 public class TopLevelClass {
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   final public func backDeployedFinalMethod() {}
 
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   final public var backDeployedFinalComputedProperty: Int { 98 }
 
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public static func backDeployedStaticMethod() {}
 
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public final class func backDeployedClassMethod() {}
 }
 
 // Ok, function decls in a final class
 final public class FinalTopLevelClass {
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public func backDeployedMethod() {}
 
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public var backDeployedComputedProperty: Int { 98 }
 }
 
 // Ok, final function decls on an actor
-@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(SwiftStdlib 5.1, *)
 public actor TopLevelActor {
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   final public func finalActorMethod() {}
 
   // Ok, actor methods are effectively final
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public func actorMethod() {}
 }
 
 // Ok, function decls in extension on public types
 extension TopLevelStruct {
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public func backDeployedExtensionMethod() {}
 }
 
 extension TopLevelClass {
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   final public func backDeployedExtensionMethod() {}
 }
 
 extension FinalTopLevelClass {
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public func backDeployedExtensionMethod() {}
 }
@@ -118,7 +98,6 @@ extension FinalTopLevelClass {
 public protocol TopLevelProtocol {}
 
 extension TopLevelProtocol {
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public func backDeployedExtensionMethod() {}
 }
@@ -130,11 +109,9 @@ extension TopLevelProtocol {
 public class CannotBackDeployClass {}
 
 public final class CannotBackDeployClassInitDeinit {
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to initializer declarations}}
   public init() {}
 
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to deinitializer declarations}}
   deinit {}
 }
@@ -163,7 +140,7 @@ extension TopLevelStruct {}
 @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
 protocol CannotBackDeployProtocol {}
 
-@available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
+@available(SwiftStdlib 5.1, *)
 @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
 public actor CannotBackDeployActor {}
 
@@ -177,7 +154,6 @@ public struct FunctionBodyDiagnostics {
   fileprivate func fileprivateFunc() {} // expected-note {{instance method 'fileprivateFunc()' is not '@usableFromInline' or public}}
   private func privateFunc() {} // expected-note {{instance method 'privateFunc()' is not '@usableFromInline' or public}}
 
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public func backDeployedMethod() {
     struct Nested {} // expected-error {{type 'Nested' cannot be nested inside a '@_backDeploy' function}}
@@ -215,26 +191,21 @@ public class TopLevelClass2 {
   public class func nonFinalClassMethod() {}
 }
 
-@available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0, macOS 13.0) // expected-error {{'@_backDeploy' contains multiple versions for macOS}}
 public func duplicatePlatformsFunc1() {}
 
-@available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0)
 @_backDeploy(before: macOS 13.0) // expected-error {{'@_backDeploy' contains multiple versions for macOS}}
 public func duplicatePlatformsFunc2() {}
 
-@available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0)
 @_alwaysEmitIntoClient // expected-error {{'@_alwaysEmitIntoClient' cannot be applied to a back deployed global function}}
 public func alwaysEmitIntoClientFunc() {}
 
-@available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0)
 @inlinable // Ok
 public func inlinableFunc() {}
 
-@available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0)
 @_transparent // expected-error {{'@_transparent' cannot be applied to a back deployed global function}}
 public func transparentFunc() {}
@@ -242,15 +213,12 @@ public func transparentFunc() {}
 
 // MARK: - Attribute parsing
 
-@available(macOS 11.0, iOS 14.0, *)
 @_backDeploy(before: macos 12.0, iOS 15.0) // expected-warning {{unknown platform 'macos' for attribute '@_backDeploy'; did you mean 'macOS'?}} {{22-27=macOS}}
 public func incorrectPlatformCaseFunc() {}
 
-@available(macOS 11.0, iOS 14.0, *)
 @_backDeploy(before: mscos 12.0, iOS 15.0) // expected-warning {{unknown platform 'mscos' for attribute '@_backDeploy'; did you mean 'macOS'?}} {{22-27=macOS}}
 public func incorrectPlatformSimilarFunc() {}
 
-@available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0, unknownOS 1.0) // expected-warning {{unknown platform 'unknownOS' for attribute '@_backDeploy'}}
 public func unknownOSFunc() {}
 
@@ -269,23 +237,18 @@ public func missingVersionFunc2() {}
 @_backDeploy(before: macOS, iOS) // expected-error 2{{expected version number in '@_backDeploy' attribute}}
 public func missingVersionFunc3() {}
 
-@available(macOS 11.0, iOS 14.0, *)
 @_backDeploy(before: macOS 12.0, iOS 15.0,) // expected-error {{unexpected ',' separator}}
 public func unexpectedSeparatorFunc() {}
 
-@available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0.1) // expected-warning {{'@_backDeploy' only uses major and minor version number}}
 public func patchVersionFunc() {}
 
-@available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0, * 9.0) // expected-warning {{* as platform name has no effect in '@_backDeploy' attribute}}
 public func wildcardWithVersionFunc() {}
 
-@available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0, *) // expected-warning {{* as platform name has no effect in '@_backDeploy' attribute}}
 public func trailingWildcardFunc() {}
 
-@available(macOS 11.0, iOS 14.0, *)
 @_backDeploy(before: macOS 12.0, *, iOS 15.0) // expected-warning {{* as platform name has no effect in '@_backDeploy' attribute}}
 public func embeddedWildcardFunc() {}
 
@@ -304,7 +267,6 @@ public func unknownMacroMissingVersion() {}
 // expected-error@-1 {{expected at least one platform version in '@_backDeploy' attribute}}
 public func unknownMacroVersioned() {}
 
-@available(macOS 11.0, *)
 @_backDeploy(before: _unknownMacro 1.0, _myProject 2.0) // expected-warning {{unknown platform '_unknownMacro' for attribute '@_backDeploy'}}
 public func knownAndUnknownMacroVersioned() {}
 
@@ -312,7 +274,6 @@ public func knownAndUnknownMacroVersioned() {}
 // expected-error@-1 {{expected at least one platform version in '@_backDeploy' attribute}}
 public func emptyAttributeFunc() {}
 
-@available(macOS 11.0, *)
 @_backDeploy(macOS 12.0) // expected-error {{expected 'before:' in '@_backDeploy' attribute}} {{14-14=before:}}
 public func missingBeforeFunc() {}
 
@@ -320,15 +281,12 @@ public func missingBeforeFunc() {}
 // expected-error@-1 {{expected at least one platform version in '@_backDeploy' attribute}}
 public func missingColonAfterBeforeFunc() {}
 
-@available(macOS 11.0, *)
 @_backDeploy(before macOS 12.0) // expected-error {{expected ':' after 'before' in '@_backDeploy' attribute}} {{20-20=:}}
 public func missingColonBetweenBeforeAndPlatformFunc() {}
 
-@available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0,) // expected-error {{unexpected ',' separator}} {{32-33=}}
 public func unexpectedTrailingCommaFunc() {}
 
-@available(macOS 11.0, iOS 14.0, *)
 @_backDeploy(before: macOS 12.0,, iOS 15.0) // expected-error {{unexpected ',' separator}} {{33-34=}}
 public func extraCommaFunc() {}
 

--- a/test/attr/attr_backDeploy.swift
+++ b/test/attr/attr_backDeploy.swift
@@ -3,18 +3,18 @@
 
 // MARK: - Valid declarations
 
-// OK: top level functions
+// Ok, top level functions
 @available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0)
 public func backDeployedTopLevelFunc() {}
 
-// OK: internal decls may be back deployed when @usableFromInline
+// Ok, internal decls may be back deployed when @usableFromInline
 @available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0)
 @usableFromInline
 internal func backDeployedUsableFromInlineTopLevelFunc() {}
 
-// OK: function/property/subscript decls in a struct
+// Ok, function/property/subscript decls in a struct
 public struct TopLevelStruct {
   @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
@@ -53,7 +53,7 @@ public struct TopLevelStruct {
   }
 }
 
-// OK: final function decls in a non-final class
+// Ok, final function decls in a non-final class
 public class TopLevelClass {
   @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
@@ -72,7 +72,7 @@ public class TopLevelClass {
   public final class func backDeployedClassMethod() {}
 }
 
-// OK: function decls in a final class
+// Ok, function decls in a final class
 final public class FinalTopLevelClass {
   @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
@@ -83,20 +83,20 @@ final public class FinalTopLevelClass {
   public var backDeployedComputedProperty: Int { 98 }
 }
 
-// OK: final function decls on an actor
+// Ok, final function decls on an actor
 @available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *)
 public actor TopLevelActor {
   @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   final public func finalActorMethod() {}
 
-  // OK: actor methods are effectively final
+  // Ok, actor methods are effectively final
   @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   public func actorMethod() {}
 }
 
-// OK: function decls in extension on public types
+// Ok, function decls in extension on public types
 extension TopLevelStruct {
   @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
@@ -123,7 +123,8 @@ extension TopLevelProtocol {
   public func backDeployedExtensionMethod() {}
 }
 
-// MARK: - Unsupported declaration types
+
+// MARK: - Unsupported declaration kinds
 
 @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
 public class CannotBackDeployClass {}
@@ -166,6 +167,7 @@ protocol CannotBackDeployProtocol {}
 @_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' attribute cannot be applied to this declaration}}
 public actor CannotBackDeployActor {}
 
+
 // MARK: - Function body diagnostics
 
 public struct FunctionBodyDiagnostics {
@@ -187,6 +189,7 @@ public struct FunctionBodyDiagnostics {
     privateFunc() // expected-error {{instance method 'privateFunc()' is private and cannot be referenced from a '@_backDeploy' function}}
   }
 }
+
 
 // MARK: - Incompatible declarations
 
@@ -243,7 +246,7 @@ public func alwaysEmitIntoClientFunc() {}
 
 @available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0)
-@inlinable // OK
+@inlinable // Ok
 public func inlinableFunc() {}
 
 @available(macOS 11.0, *)

--- a/test/attr/attr_backDeploy.swift
+++ b/test/attr/attr_backDeploy.swift
@@ -215,21 +215,6 @@ public class TopLevelClass2 {
   public class func nonFinalClassMethod() {}
 }
 
-@_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' requires that 'missingAllAvailabilityFunc()' have explicit availability for macOS}}
-public func missingAllAvailabilityFunc() {}
-
-@available(macOS 11.0, *)
-@_backDeploy(before: macOS 12.0, iOS 15.0) // expected-error {{'@_backDeploy' requires that 'missingiOSAvailabilityFunc()' have explicit availability for iOS}}
-public func missingiOSAvailabilityFunc() {}
-
-@available(macOS 12.0, *)
-@_backDeploy(before: macOS 12.0) // expected-error {{'@_backDeploy' has no effect because 'availableSameVersionAsBackDeployment()' is not available before macOS 12.0}}
-public func availableSameVersionAsBackDeployment() {}
-
-@available(macOS 12.1, *)
-@_backDeploy(before: macOS 12.0) // expected-error {{'availableAfterBackDeployment()' is not available before macOS 12.0}}
-public func availableAfterBackDeployment() {}
-
 @available(macOS 11.0, *)
 @_backDeploy(before: macOS 12.0, macOS 13.0) // expected-error {{'@_backDeploy' contains multiple versions for macOS}}
 public func duplicatePlatformsFunc1() {}
@@ -253,6 +238,7 @@ public func inlinableFunc() {}
 @_backDeploy(before: macOS 12.0)
 @_transparent // expected-error {{'@_transparent' cannot be applied to a back deployed global function}}
 public func transparentFunc() {}
+
 
 // MARK: - Attribute parsing
 

--- a/test/attr/attr_backDeploy_availability.swift
+++ b/test/attr/attr_backDeploy_availability.swift
@@ -1,0 +1,85 @@
+// RUN: %target-typecheck-verify-swift -parse-as-library
+
+// REQUIRES: OS=macosx
+
+@_backDeploy(before: macOS 12) // Ok, introduced availability is inferred to be macOS 10.9
+public func topLevelFunc() {}
+
+public struct TopLevelStruct {
+  @_backDeploy(before: macOS 12) // Ok, introduced availability is inferred to be macOS 10.9
+  public func methodInStruct() {}
+}
+
+extension TopLevelStruct {
+  @_backDeploy(before: macOS 12) // Ok, introduced availability is inferred to be macOS 10.9
+  public func methodInExtension() {}
+}
+
+@available(macOS 11, *)
+@_backDeploy(before: macOS 12) // Ok, introduced availability is earlier than macOS 12
+public func availableBeforeBackDeployment() {}
+
+@available(macOS 12, *) // expected-note {{'availableSameVersionAsBackDeployment()' was introduced in macOS 12}}
+@_backDeploy(before: macOS 12) // expected-error {{'@_backDeploy' has no effect because 'availableSameVersionAsBackDeployment()' is not available before macOS 12}}
+public func availableSameVersionAsBackDeployment() {}
+
+@available(macOS 12.1, *) // expected-note {{'availableAfterBackDeployment()' was introduced in macOS 12.1}}
+@_backDeploy(before: macOS 12) // expected-error {{'@_backDeploy' has no effect because 'availableAfterBackDeployment()' is not available before macOS 12}}
+public func availableAfterBackDeployment() {}
+
+@available(macOS 12, iOS 13, *)
+@_backDeploy(before: iOS 12) // This is invalid but it can only be diagnosed when building for iOS
+public func availableAfterBackDeploymentForInactiveAttribute() {}
+
+@available(macOS 12, *) // expected-note {{'memberFunc()' was introduced in macOS 12}}
+public struct AvailableMacOS12Struct {
+  @_backDeploy(before: macOS 12) // expected-error {{'@_backDeploy' has no effect because 'memberFunc()' is not available before macOS 12}}
+  public func memberFunc() {}
+}
+
+@available(macOS 12, *) // expected-note {{'methodInExtensionAvailableMacOS12()' was introduced in macOS 12}}
+extension TopLevelStruct {
+  @_backDeploy(before: macOS 12) // expected-error {{'@_backDeploy' has no effect because 'methodInExtensionAvailableMacOS12()' is not available before macOS 12}}
+  public func methodInExtensionAvailableMacOS12() {}
+}
+
+extension TopLevelStruct {
+  @available(macOS 12, *) // expected-note {{getter for 'propertyAvailableMacOS12' was introduced in macOS 12}}
+  public var propertyAvailableMacOS12: Int {
+    @_backDeploy(before: macOS 12) // expected-error {{'@_backDeploy' has no effect because getter for 'propertyAvailableMacOS12' is not available before macOS 12}}
+    get { 0 }
+  }
+}
+
+@available(macOS, unavailable) // expected-note {{'unavailableMacOSFunc()' has been explicitly marked unavailable here}}
+@_backDeploy(before: macOS 12) // expected-error {{'@_backDeploy' has no effect because 'unavailableMacOSFunc()' is unavailable on macOS}}
+public func unavailableMacOSFunc() {}
+
+@available(macOS, unavailable)
+@available(iOS, unavailable)
+@_backDeploy(before: iOS 12) // This is invalid but it can only be diagnosed when building for iOS
+public func unavailableForInactiveAttributeFunc() {}
+
+@available(*, unavailable) // expected-note {{'alwaysUnavailableFunc()' has been explicitly marked unavailable here}}
+@_backDeploy(before: macOS 12) // expected-error {{'@_backDeploy' has no effect because 'alwaysUnavailableFunc()' is unavailable on macOS}}
+public func alwaysUnavailableFunc() {}
+
+@available(macOS, unavailable) // expected-note {{'memberFunc()' has been explicitly marked unavailable here}}
+public struct UnavailableMacOSStruct {
+  @_backDeploy(before: macOS 12) // expected-error {{'@_backDeploy' has no effect because 'memberFunc()' is unavailable on macOS}}
+  public func memberFunc() {}
+}
+
+@available(macOS, unavailable) // expected-note {{'methodInUnavailableExtension()' has been explicitly marked unavailable here}}
+extension TopLevelStruct {
+  @_backDeploy(before: macOS 12) // expected-error {{'@_backDeploy' has no effect because 'methodInUnavailableExtension()' is unavailable on macOS}}
+  public func methodInUnavailableExtension() {}
+}
+
+extension TopLevelStruct {
+  @available(macOS, unavailable) // expected-note {{getter for 'unavailableMacOSProperty' has been explicitly marked unavailable here}}
+  public var unavailableMacOSProperty: Int {
+    @_backDeploy(before: macOS 12) // expected-error {{'@_backDeploy' has no effect because getter for 'unavailableMacOSProperty' is unavailable on macOS}}
+    get { 0 }
+  }
+}

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2671,7 +2671,6 @@ class issue55246 {
 // @_backDeploy
 
 public class BackDeployClass {
-  @available(macOS 11.0, *)
   @_backDeploy(before: macOS 12.0)
   @objc // expected-error {{'@objc' cannot be applied to a back deployed instance method}}
   final public func objcMethod() {}


### PR DESCRIPTION
Swift Evolution has concluded that it is inappropriate to require decls with `@_backDeploy` to also have explicit availability. Lift the restriction and assume declarations with no explicit availability are back deployed as far as possible.

Lifting a simultaneous attribute restriction sounds like it should be an easy task, but that was not the case here. The diagnostics for availability conflicts with the back deployment `before:` version were greatly simplified by the assumption that an explicit `@available` attribute would be present. With the removal of the restriction the implementation of the diagnostics had to be enhanced to look for both inherited availability and unavailability.

Additionally, this PR fixes a bug that would have caused the wrong `@_backDeploy` attribute to be used when attributes for both `iOS` and `macCatalyst` are present.

Resolves rdar://103880356