### PR TITLE
Add source buffers pretty-printed for diagnostics to serialized diagnostic files

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -36,6 +36,9 @@ public:
 
     /// A new function body that is replacing an existing function body.
     ReplacedFunctionBody,
+
+    /// Pretty-printed declarations that have no source location.
+    PrettyPrinted,
   } kind;
 
   /// The buffer ID for the enclosing buffer, in which originalSourceRange

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -41,10 +41,6 @@ public:
     PrettyPrinted,
   } kind;
 
-  /// The buffer ID for the enclosing buffer, in which originalSourceRange
-  /// resides.
-  unsigned originalBufferID;
-
   /// The source range in the enclosing buffer where this source was generated.
   ///
   /// This could point at a macro expansion or at the implicit location at

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1241,7 +1241,6 @@ DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic) {
             bufferID,
             GeneratedSourceInfo{
               GeneratedSourceInfo::PrettyPrinted,
-              bufferID,
               SourceRange(),
               SourceRange(
                   memBufferStartLoc,

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -260,6 +260,7 @@ void SourceManager::setGeneratedSourceInfo(
 
   switch (info.kind) {
   case GeneratedSourceInfo::MacroExpansion:
+  case GeneratedSourceInfo::PrettyPrinted:
     break;
 
   case GeneratedSourceInfo::ReplacedFunctionBody:

--- a/lib/IDETool/CompileInstance.cpp
+++ b/lib/IDETool/CompileInstance.cpp
@@ -193,7 +193,6 @@ void retypeCheckFunctionBody(AbstractFunctionDecl *func,
       sliceBufferID,
       GeneratedSourceInfo{
         GeneratedSourceInfo::ReplacedFunctionBody,
-        *func->getParentSourceFile()->getBufferID(),
         func->getOriginalBodySourceRange(),
         newRange,
         func,

--- a/lib/IDETool/IDEInspectionInstance.cpp
+++ b/lib/IDETool/IDEInspectionInstance.cpp
@@ -346,7 +346,6 @@ bool IDEInspectionInstance::performCachedOperationIfPossible(
         newBufferID,
         GeneratedSourceInfo{
           GeneratedSourceInfo::ReplacedFunctionBody,
-          *AFD->getParentSourceFile()->getBufferID(),
           AFD->getOriginalBodySourceRange(),
           newBodyRange,
           AFD,

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -448,7 +448,6 @@ Expr *swift::expandMacroExpr(
   auto macroBufferRange = sourceMgr.getRangeForBuffer(macroBufferID);
   GeneratedSourceInfo sourceInfo{
     GeneratedSourceInfo::MacroExpansion,
-    *sourceFile->getBufferID(),
     expr->getSourceRange(),
     SourceRange(macroBufferRange.getStart(), macroBufferRange.getEnd()),
     ASTNode(expr).getOpaqueValue(),

--- a/test/ImportResolution/import-specific-fixits.swift
+++ b/test/ImportResolution/import-specific-fixits.swift
@@ -55,6 +55,9 @@ import struct ambiguous.funcOrVar // expected-error{{ambiguous name 'funcOrVar' 
 // CHECK-NEXT: Number FIXITs = 0
 // CHECK-NEXT: note: found this candidate
 // CHECK-NEXT: Number FIXITs = 0
+// CHECK-NEXT: CONTENTS OF FILE ambiguous_right.funcOrVar:
+// CHECK: public var funcOrVar: Int
+// CHECK: END CONTENTS OF FILE
 // CHECK-NEXT: note: found this candidate
 
 import func ambiguous.someVar // expected-error{{ambiguous name 'someVar' in module 'ambiguous'}}

--- a/test/Misc/serialized-diagnostics-prettyprint.swift
+++ b/test/Misc/serialized-diagnostics-prettyprint.swift
@@ -1,0 +1,14 @@
+// RUN: rm -f %t.*
+
+// Test swift executable
+// RUN: %target-swift-frontend -typecheck -serialize-diagnostics-path %t.dia %s -verify
+// RUN: c-index-test -read-diagnostics %t.dia > %t.deserialized_diagnostics.txt 2>&1
+// RUN: %FileCheck --input-file=%t.deserialized_diagnostics.txt %s
+
+var x = String.init // expected-error{{ambiguous use of 'init'}}
+// CHECK: {{.*[/\\]}}serialized-diagnostics-prettyprint.swift:[[@LINE-1]]:9: error: ambiguous use of 'init'
+
+// CHECK: Swift.String:2:23: note: found this candidate
+// CHECK: CONTENTS OF FILE Swift.String:
+// CHECK: extension String {
+// CHECK:    public init(_ content: Substring.UnicodeScalarView)


### PR DESCRIPTION
When emitting a diagnostic that references a declaration that does not
itself have a source location (e.g., because it was synthesized or
deserialized), the diagnostics engine pretty-prints the declaration
into a buffer so it can provide caret diagnostics pointing to that
declaration.

Start marking those buffers as "generated source buffers", so that we
emit their contents into serialized diagnostics files. This will allow
tools that make use of serialized diagnostics to also show caret
information.