### PR TITLE
[Runtime] Make the swift_getTypeByMangled... functions emit error messages.

### DIFF
--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -78,4 +78,7 @@ VARIABLE(SWIFT_DEBUG_RUNTIME_EXCLUSIVITY_LOGGING, bool, false,
 VARIABLE(SWIFT_BINARY_COMPATIBILITY_VERSION, uint32_t, 0,
         "Set the binary compatibility level of the Swift Standard Library")
 
+VARIABLE(SWIFT_DEBUG_FAILED_TYPE_LOOKUP, bool, false,
+         "Enable warnings when we fail to look up a type by name.")
+
 #undef VARIABLE

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -25,6 +25,7 @@
 #include "swift/Runtime/Casting.h"
 #include "swift/Runtime/Concurrent.h"
 #include "swift/Runtime/Debug.h"
+#include "swift/Runtime/EnvironmentVariables.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Strings.h"
@@ -1951,7 +1952,8 @@ swift_getTypeByMangledNameInEnvironment(
     [&substitutions](const Metadata *type, unsigned index) {
       return substitutions.getWitnessTable(type, index);
     });
-  if (result.isError()) {
+  if (result.isError()
+      && runtime::environment::SWIFT_DEBUG_FAILED_TYPE_LOOKUP()) {
     TypeLookupError *error = result.getError();
     char *errorString = error->copyErrorString();
     swift::warning(0, "failed type lookup for %.*s: %s\n",
@@ -1982,7 +1984,8 @@ swift_getTypeByMangledNameInEnvironmentInMetadataState(
     [&substitutions](const Metadata *type, unsigned index) {
       return substitutions.getWitnessTable(type, index);
     });
-  if (result.isError()) {
+  if (result.isError()
+      && runtime::environment::SWIFT_DEBUG_FAILED_TYPE_LOOKUP()) {
     TypeLookupError *error = result.getError();
     char *errorString = error->copyErrorString();
     swift::warning(0, "failed type lookup for %.*s: %s\n",
@@ -2012,7 +2015,8 @@ swift_getTypeByMangledNameInContext(
     [&substitutions](const Metadata *type, unsigned index) {
       return substitutions.getWitnessTable(type, index);
     });
-  if (result.isError()) {
+  if (result.isError()
+      && runtime::environment::SWIFT_DEBUG_FAILED_TYPE_LOOKUP()) {
     TypeLookupError *error = result.getError();
     char *errorString = error->copyErrorString();
     swift::warning(0, "failed type lookup for %.*s: %s\n",
@@ -2043,7 +2047,8 @@ swift_getTypeByMangledNameInContextInMetadataState(
     [&substitutions](const Metadata *type, unsigned index) {
       return substitutions.getWitnessTable(type, index);
     });
-  if (result.isError()) {
+  if (result.isError()
+      && runtime::environment::SWIFT_DEBUG_FAILED_TYPE_LOOKUP()) {
     TypeLookupError *error = result.getError();
     char *errorString = error->copyErrorString();
     swift::warning(0, "failed type lookup for %.*s: %s\n",

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1942,14 +1942,25 @@ swift_getTypeByMangledNameInEnvironment(
                         const void * const *genericArgs) {
   llvm::StringRef typeName(typeNameStart, typeNameLength);
   SubstGenericParametersFromMetadata substitutions(environment, genericArgs);
-  return swift_getTypeByMangledName(MetadataState::Complete, typeName,
+  TypeLookupErrorOr<TypeInfo> result = swift_getTypeByMangledName(
+    MetadataState::Complete, typeName,
     genericArgs,
     [&substitutions](unsigned depth, unsigned index) {
       return substitutions.getMetadata(depth, index);
     },
     [&substitutions](const Metadata *type, unsigned index) {
       return substitutions.getWitnessTable(type, index);
-    }).getType().getMetadata();
+    });
+  if (result.isError()) {
+    TypeLookupError *error = result.getError();
+    char *errorString = error->copyErrorString();
+    swift::warning(0, "failed type lookup for %.*s: %s\n",
+                   (int)typeNameLength, typeNameStart,
+                   errorString);
+    error->freeErrorString(errorString);
+    return nullptr;
+  }
+  return result.getType().getMetadata();
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
@@ -1962,14 +1973,25 @@ swift_getTypeByMangledNameInEnvironmentInMetadataState(
                         const void * const *genericArgs) {
   llvm::StringRef typeName(typeNameStart, typeNameLength);
   SubstGenericParametersFromMetadata substitutions(environment, genericArgs);
-  return swift_getTypeByMangledName((MetadataState)metadataState, typeName,
+  TypeLookupErrorOr<TypeInfo> result = swift_getTypeByMangledName(
+    (MetadataState)metadataState, typeName,
     genericArgs,
     [&substitutions](unsigned depth, unsigned index) {
       return substitutions.getMetadata(depth, index);
     },
     [&substitutions](const Metadata *type, unsigned index) {
       return substitutions.getWitnessTable(type, index);
-    }).getType().getMetadata();
+    });
+  if (result.isError()) {
+    TypeLookupError *error = result.getError();
+    char *errorString = error->copyErrorString();
+    swift::warning(0, "failed type lookup for %.*s: %s\n",
+                   (int)typeNameLength, typeNameStart,
+                   errorString);
+    error->freeErrorString(errorString);
+    return nullptr;
+  }
+  return result.getType().getMetadata();
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
@@ -1981,14 +2003,25 @@ swift_getTypeByMangledNameInContext(
                         const void * const *genericArgs) {
   llvm::StringRef typeName(typeNameStart, typeNameLength);
   SubstGenericParametersFromMetadata substitutions(context, genericArgs);
-  return swift_getTypeByMangledName(MetadataState::Complete, typeName,
+  TypeLookupErrorOr<TypeInfo> result = swift_getTypeByMangledName(
+    MetadataState::Complete, typeName,
     genericArgs,
     [&substitutions](unsigned depth, unsigned index) {
       return substitutions.getMetadata(depth, index);
     },
     [&substitutions](const Metadata *type, unsigned index) {
       return substitutions.getWitnessTable(type, index);
-    }).getType().getMetadata();
+    });
+  if (result.isError()) {
+    TypeLookupError *error = result.getError();
+    char *errorString = error->copyErrorString();
+    swift::warning(0, "failed type lookup for %.*s: %s\n",
+                   (int)typeNameLength, typeNameStart,
+                   errorString);
+    error->freeErrorString(errorString);
+    return nullptr;
+  }
+  return result.getType().getMetadata();
 }
 
 SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
@@ -2001,14 +2034,26 @@ swift_getTypeByMangledNameInContextInMetadataState(
                         const void * const *genericArgs) {
   llvm::StringRef typeName(typeNameStart, typeNameLength);
   SubstGenericParametersFromMetadata substitutions(context, genericArgs);
-  return swift_getTypeByMangledName((MetadataState)metadataState, typeName,
+  TypeLookupErrorOr<TypeInfo> result = swift_getTypeByMangledName(
+    (MetadataState)metadataState, typeName,
     genericArgs,
     [&substitutions](unsigned depth, unsigned index) {
       return substitutions.getMetadata(depth, index);
     },
     [&substitutions](const Metadata *type, unsigned index) {
       return substitutions.getWitnessTable(type, index);
-    }).getType().getMetadata();
+    });
+  if (result.isError()) {
+    TypeLookupError *error = result.getError();
+    char *errorString = error->copyErrorString();
+    swift::warning(0, "failed type lookup for %.*s: %s\n",
+                   (int)typeNameLength, typeNameStart,
+                   errorString);
+    error->freeErrorString(errorString);
+    return nullptr;
+  }
+  return result.getType().getMetadata();
+
 }
 
 /// Demangle a mangled name, but don't allow symbolic references.


### PR DESCRIPTION
When type lookups fail, these functions should at least generate a warning.

rdar://103950409
