### PR TITLE
[cxx-interop] Remove manual `std::vector` conformance in the benchmark

### DIFF
--- a/benchmark/cxx-source/CxxVectorSum.swift
+++ b/benchmark/cxx-source/CxxVectorSum.swift
@@ -126,8 +126,4 @@ public func run_CxxVectorOfU32_Sum_Swift_Reduce(_ n: Int) {
     }
     blackHole(sum)
 }
-
-extension VectorOfU32.const_iterator : Equatable, UnsafeCxxInputIterator { }
-
-extension VectorOfU32: CxxSequence {}
 #endif

--- a/benchmark/utils/CxxTests/CxxStdlibPerformance.h
+++ b/benchmark/utils/CxxTests/CxxStdlibPerformance.h
@@ -32,6 +32,3 @@ inline uint32_t testVector32Sum(size_t vectorSize, size_t iters) {
     }
     return sum;
 }
-
-// FIXME: remove when the templated operator == is correctly bridged.
-inline bool operator ==(const VectorOfU32::const_iterator &lhs, const VectorOfU32::const_iterator &rhs) { return lhs.base() == rhs.base(); }


### PR DESCRIPTION
`std::vector::const_iterator` is now automatically conformed to `UnsafeCxxRandomAccessIterator`, and `std::vector` is conformed to `CxxRandomAccessCollection`.

The manually added conformances are now redundant.