### PR TITLE
Disable zippered catalyst builds again

### DIFF
--- a/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
+++ b/stdlib/public/SwiftOnoneSupport/CMakeLists.txt
@@ -39,6 +39,7 @@ endif()
 add_swift_target_library(swiftSwiftOnoneSupport
   ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
   ${swiftOnoneSupport_common_options}
+  MACCATALYST_BUILD_FLAVOR "zippered"
   INSTALL_IN_COMPONENT stdlib)
 
 if(WINDOWS IN_LIST SWIFT_SDKS)

--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1234,7 +1234,6 @@ mixin-preset=mixin_buildbot_install_components_with_clang
 ios
 tvos
 watchos
-maccatalyst
 
 lldb
 llbuild


### PR DESCRIPTION
This patch does two things. One, zippers the Onone support library that I missed in the first pass.
Two, disables the catalyst build again. The open-source SwiftC appears to be missing something for catalyst, which would result in a miscompile situration.

The failing test:
    SILGen/availability_query_maccatalyst_zippered_canonical_versions.swift

```swift
if #available(OSX 10.16, iOS 51.1.2, *) {
}
```

The expectation is that we check for both macOS and iOS version numbers in a catalyst build;

```
// CHECK: [[MACOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 10
// CHECK: [[MACOS_MINOR:%.*]] = integer_literal $Builtin.Word, 16
// CHECK: [[MACOS_PATCH:%.*]] = integer_literal $Builtin.Word, 0
// CHECK: [[IOS_MAJOR:%.*]] = integer_literal $Builtin.Word, 51
// CHECK: [[IOS_MINOR:%.*]] = integer_literal $Builtin.Word, 1
// CHECK: [[IOS_PATCH:%.*]] = integer_literal $Builtin.Word, 2
// CHECK: [[FUNC:%.*]] = function_ref @$ss042_stdlib_isOSVersionAtLeastOrVariantVersiondE0yBi1_Bw_BwBwBwBwBwtF : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
// CHECK: [[QUERY_RESULT:%.*]] = apply [[FUNC]]([[MACOS_MAJOR]], [[MACOS_MINOR]], [[MACOS_PATCH]], [[IOS_MAJOR]], [[IOS_MINOR]], [[IOS_PATCH]]) : $@convention(thin) (Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word, Builtin.Word) -> Builtin.Int1
```

Currently, the OSS Swiftc is only emitting checks for macOS. I don't have time at the moment to dig further than that.

The build system should be in a place to handle catalyst builds, but it looks like the compiler is not.

