### PR TITLE
[cxx-interop] More test coverage for Collection conformances

### DIFF
--- a/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-collection.swift
@@ -13,18 +13,34 @@ CxxCollectionTestSuite.test("SimpleCollectionNoSubscript as Swift.Collection") {
   let c = SimpleCollectionNoSubscript()
   expectEqual(c.first, 1)
   expectEqual(c.last, 5)
+
+  // This subscript is a default implementation added in CxxRandomAccessCollection.
+  expectEqual(c[0], 1)
+  expectEqual(c[1], 2)
+  expectEqual(c[4], 5)
 }
 
 CxxCollectionTestSuite.test("SimpleCollectionReadOnly as Swift.Collection") {
   let c = SimpleCollectionReadOnly()
   expectEqual(c.first, 1)
   expectEqual(c.last, 5)
+
+  let slice = c[1..<3]
+  expectEqual(slice.first, 2)
+  expectEqual(slice.last, 3)
 }
 
 CxxCollectionTestSuite.test("SimpleArrayWrapper as Swift.Collection") {
   let c = SimpleArrayWrapper()
   expectEqual(c.first, 10)
   expectEqual(c.last, 50)
+
+  let reduced = c.reduce(0, +)
+  expectEqual(reduced, 150)
+
+  let mapped = c.map { $0 + 1 }
+  expectEqual(mapped.first, 11)
+  expectEqual(mapped.last, 51)
 }
 
 runAllTests()

--- a/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-convertible-to-collection.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop)
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
 //
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx || OS=linux-gnu
@@ -11,6 +11,12 @@ var CxxSequenceTestSuite = TestSuite("CxxConvertibleToCollection")
 
 CxxSequenceTestSuite.test("SimpleSequence to Swift.Array") {
   let seq = SimpleSequence()
+  let array = Array(seq)
+  expectEqual([1, 2, 3, 4] as [Int32], array)
+}
+
+CxxSequenceTestSuite.test("SimpleSequenceWithOutOfLineEqualEqual to Swift.Array") {
+  let seq = SimpleSequenceWithOutOfLineEqualEqual()
   let array = Array(seq)
   expectEqual([1, 2, 3, 4] as [Int32], array)
 }


### PR DESCRIPTION
This adds a few tests for the default implementation of subscript, slicing, map/reduce.