### PR TITLE
[5.8][MiscDiagnostics] OpaqueTypes: Handle unrelated #available conditions  gracefully

### DIFF
--- a/test/Serialization/Inputs/opaque_with_limited_availability.swift
+++ b/test/Serialization/Inputs/opaque_with_limited_availability.swift
@@ -67,3 +67,14 @@ public func test_return_from_conditional() -> some P {
 
   return Tuple<(String, Int)>(("", 0))
 }
+
+// This used to crash during serialization because
+// @available negates availability condition.
+@available(macOS, unavailable)
+public func testUnusable() -> some P {
+  if #available(iOS 50, *) {
+    return Named()
+  }
+
+  return Tuple<(String, Int)>(("", 0))
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/62856

--- 

`OpaqueUnderlyingTypeChecker` should skip conditional availability
 blocks if none of the conditions restrict the current target.

Resolves: rdar://103445432
(cherry picked from commit 3c03449797c6a8e4582da17a7b742f3c981f2328)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
