### PR TITLE
[test] Reenable stdlib/StringIndex, requiring optimized_stdlib

### DIFF
--- a/test/stdlib/StringIndex.swift
+++ b/test/stdlib/StringIndex.swift
@@ -7,10 +7,8 @@
 // 5.7 so that we can test new behavior even if the SDK we're using predates it.
 
 // REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
 // UNSUPPORTED: freestanding
-
-// Temporarily disabled due to extremely slow execution in the "UTF-16 breadcrumbs" test
-// REQUIRES: rdar103934958
 
 import StdlibUnittest
 #if _runtime(_ObjC)


### PR DESCRIPTION
This test was disabled in https://github.com/apple/swift/pull/62875 because the addition of the new UTF-16 breadcrumbs tests seriously regressed DebugAssert runs on CI.

It turns out that even without that test, this test case is simply not appropriate to run with unoptimized stdlib builds -- e.g. the index interchange tests also take an extraordinarily long time to finish.

Let's reenable this test, but only run it with optimized stdlibs.

rdar://103934958
