### PR TITLE
[Module Interface Loader] Propagate '-application-extension' by configuring the generic sub-invocation

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1582,6 +1582,7 @@ InterfaceSubContextDelegateImpl::InterfaceSubContextDelegateImpl(
   // If building an application extension, make sure API use
   // is restricted accordingly in downstream dependnecies.
   if (langOpts.EnableAppExtensionRestrictions) {
+    genericSubInvocation.getLangOptions().EnableAppExtensionRestrictions = true;
     GenericArgs.push_back("-application-extension");
   }
   // Save the parent invocation's Target Triple


### PR DESCRIPTION
Simply adding "-application-extension" to the generic arguments, as was done in https://github.com/apple/swift/pull/61545 is sufficient to get it to appear on command-lines as generated by the dependency scanner, but not sufficient to actually propagate the setting to spawned interface building actions. It appears we do not in fact use `GenericArgs` for this. 