### PR TITLE
[CSGen] Closure analyzer shouldn't walk into local some decls/patterns

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2941,6 +2941,14 @@ namespace {
 
           return Action::Continue(expr);
         }
+
+        PreWalkAction walkToDeclPre(Decl *D) override {
+          return Action::VisitChildrenIf(isa<PatternBindingDecl>(D));
+        }
+
+        PreWalkResult<Pattern *> walkToPatternPre(Pattern *P) override {
+          return Action::SkipChildren(P);
+        }
       } collectVarRefs(CS);
 
       closure->walk(collectVarRefs);


### PR DESCRIPTION
While trying to gather all references to external variables, analyzer 
shouldn't walk into patterns and any local declarations except to 
pattern bindings, because decls do not participate in inference and
patterns cannot contain references analyzer is looking for.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
