### PR TITLE
Sema: Improve diagnostics for decls more available than their containers

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1101,17 +1101,21 @@ public:
   /// Retrieve the @available attribute that provides the OS version range that
   /// this declaration is available in.
   ///
-  /// The attribute may come from another declaration, since availability
-  /// could be inherited from a parent declaration.
+  /// This attribute may come from an enclosing decl since availability is
+  /// inherited. The second member of the returned pair is the decl that owns
+  /// the attribute.
   Optional<std::pair<const AvailableAttr *, const Decl *>>
   getSemanticAvailableRangeAttr() const;
 
   /// Retrieve the @available attribute that makes this declaration unavailable,
   /// if any.
   ///
-  /// The attribute may come from another declaration, since unavailability
-  /// could be inherited from a parent declaration. This is a broader notion of
-  /// unavailability than is checked by \c AvailableAttr::isUnavailable.
+  /// This attribute may come from an enclosing decl since availability is
+  /// inherited. The second member of the returned pair is the decl that owns
+  /// the attribute.
+  ///
+  /// Note that this notion of unavailability is broader than that which is
+  /// checked by \c AvailableAttr::isUnavailable.
   Optional<std::pair<const AvailableAttr *, const Decl *>>
   getSemanticUnavailableAttr() const;
 

--- a/test/attr/attr_availability_osx.swift
+++ b/test/attr/attr_availability_osx.swift
@@ -80,8 +80,8 @@ func doSomethingDeprecatedOniOS() { }
 
 doSomethingDeprecatedOniOS() // okay
 
-
-struct TestStruct {}
+@available(macOS 10.10, *)
+struct TestStruct {} // expected-note {{enclosing scope requires availability of macOS 10.10 or newer}}
 
 @available(macOS 10.10, *)
 extension TestStruct { // expected-note {{enclosing scope requires availability of macOS 10.10 or newer}}
@@ -102,6 +102,11 @@ extension TestStruct { // expected-note {{enclosing scope requires availability 
 
   @available(*, deprecated)
   func doDeprecatedThing() {}
+}
+
+extension TestStruct {
+  @available(macOS 10.9, *) // expected-warning {{instance method cannot be more available than enclosing scope}}
+  func doFifthThing() {}
 }
 
 @available(macOS 10.11, *)

--- a/test/attr/attr_inlinable_available.swift
+++ b/test/attr/attr_inlinable_available.swift
@@ -55,7 +55,7 @@ public struct AtInliningTarget {
 }
 
 @available(macOS 10.14.5, *)
-public struct BetweenTargets {
+public struct BetweenTargets { // expected-note {{enclosing scope requires availability of macOS 10.14.5 or newer}}
   @usableFromInline internal init() {}
 }
 
@@ -1102,7 +1102,7 @@ extension BetweenTargets {
 }
 
 extension BetweenTargets {
-  @available(macOS 10.10, *)
+  @available(macOS 10.10, *) // expected-warning {{instance method cannot be more available than enclosing scope}}
   func excessivelyAvailableInternalFuncInExtension() {}
 }
 


### PR DESCRIPTION
Adopt new request-based utilities for looking up the enclosing declaration's availability when type checking an `@available` attribute. This consolidates implementations of the lookup and improves diagnostics by catching more cases where declarations are more available than their containers.

Builds on https://github.com/apple/swift/pull/62876.