### PR TITLE
[GenericEnvironment] Only include opened pack elements within a given shape class in an opened element generic environment.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1369,7 +1369,8 @@ public:
   ///
   /// This drops the parameter pack bit from each generic parameter,
   /// and converts same-element requirements to same-type requirements.
-  CanGenericSignature getOpenedElementSignature(CanGenericSignature baseGenericSig);
+  CanGenericSignature getOpenedElementSignature(CanGenericSignature baseGenericSig,
+                                                CanType shapeClass);
 
   GenericSignature getOverrideGenericSignature(const ValueDecl *base,
                                                const ValueDecl *derived);

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -67,6 +67,7 @@ struct OpenedExistentialEnvironmentData {
 /// Extra data in a generic environment for an opened pack element.
 struct OpenedElementEnvironmentData {
   UUID uuid;
+  CanType shapeClass;
   SubstitutionMap outerSubstitutions;
 };
 
@@ -140,7 +141,8 @@ private:
       Type existential, GenericSignature parentSig, UUID uuid);
 
   /// Private constructor for opened element environments.
-  explicit GenericEnvironment(GenericSignature signature, UUID uuid,
+  explicit GenericEnvironment(GenericSignature signature,
+                              UUID uuid, CanType shapeClass,
                               SubstitutionMap outerSubs);
 
   friend ArchetypeType;
@@ -187,6 +189,9 @@ public:
   /// opened pack element generic environment.
   SubstitutionMap getPackElementContextSubstitutions() const;
 
+  /// Retrieve the shape equivalence class for an opened element environment.
+  CanType getOpenedElementShapeClass() const;
+
   /// Retrieve the UUID for an opened element environment.
   UUID getOpenedElementUUID() const;
 
@@ -222,10 +227,12 @@ public:
   /// signature of the context whose element type is being opened, but with
   /// the pack parameter bit erased from one or more generic parameters
   /// \param uuid The unique identifier for this opened element
+  /// \param shapeClass The shape equivalence class for the originating packs.
   /// \param outerSubs The substitution map containing archetypes from the
   /// outer generic context.
   static GenericEnvironment *
-  forOpenedElement(GenericSignature signature, UUID uuid,
+  forOpenedElement(GenericSignature signature,
+                   UUID uuid, CanType shapeClass,
                    SubstitutionMap outerSubs);
 
   /// Make vanilla new/delete illegal.

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3987,7 +3987,8 @@ public:
   void addPackElementEnvironment(PackExpansionExpr *expr);
 
   /// Get the opened element generic environment for the given locator.
-  GenericEnvironment *getPackElementEnvironment(ConstraintLocator *locator);
+  GenericEnvironment *getPackElementEnvironment(ConstraintLocator *locator,
+                                                CanType shapeClass);
 
   /// Retrieve the constraint locator for the given anchor and
   /// path, uniqued and automatically infer the summary flags

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -174,7 +174,8 @@ static void emitPackExpansionType(IRGenFunction &IGF,
   auto genericSig = genericEnv->getGenericSignature().getCanonicalSignature();
 
   // Create an opened element signature and environment.
-  auto elementSig = IGF.IGM.Context.getOpenedElementSignature(genericSig);
+  auto elementSig = IGF.IGM.Context.getOpenedElementSignature(
+      genericSig, expansionTy.getCountType());
   auto *elementEnv = GenericEnvironment::forOpenedElement(
       elementSig, UUID::fromTime(), subMap);
 

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -177,7 +177,7 @@ static void emitPackExpansionType(IRGenFunction &IGF,
   auto elementSig = IGF.IGM.Context.getOpenedElementSignature(
       genericSig, expansionTy.getCountType());
   auto *elementEnv = GenericEnvironment::forOpenedElement(
-      elementSig, UUID::fromTime(), subMap);
+      elementSig, UUID::fromTime(), expansionTy.getCountType(), subMap);
 
   // Open each pack archetype.
   for (auto patternPackType : patternPacks) {

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -7124,8 +7124,7 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
     auto *pattern = coerceToType(expansion->getPatternExpr(),
                                  toElementType, locator);
     auto *packEnv = cs.DC->getGenericEnvironmentOfContext();
-    auto patternType = packEnv->mapElementTypeIntoPackContext(
-        toElementType->mapTypeOutOfContext());
+    auto patternType = packEnv->mapElementTypeIntoPackContext(toElementType);
     auto shapeType = toExpansionType->getCountType();
     auto expansionTy = PackExpansionType::get(patternType, shapeType);
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3818,11 +3818,16 @@ namespace {
     }
 
     Expr *visitPackExpansionExpr(PackExpansionExpr *expr) {
+      simplifyExprType(expr);
+
+      // Set the opened pack element environment for this pack expansion.
+      auto expansionTy = cs.getType(expr)->castTo<PackExpansionType>();
       auto *locator = cs.getConstraintLocator(expr);
-      auto *environment = cs.getPackElementEnvironment(locator);
+      auto *environment = cs.getPackElementEnvironment(locator,
+          expansionTy->getCountType()->getCanonicalType());
       expr->setGenericEnvironment(environment);
 
-      return simplifyExprType(expr);
+      return expr;
     }
 
     Expr *visitPackElementExpr(PackElementExpr *expr) {

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1423,9 +1423,10 @@ void PotentialBindings::infer(Constraint *constraint) {
     if (elementVar == TypeVar && !packVar) {
       // Produce a potential binding to the opened element archetype corresponding
       // to the pack type.
+      auto shapeClass = packType->getReducedShape();
       packType = packType->mapTypeOutOfContext();
       auto *elementEnv = CS.getPackElementEnvironment(constraint->getLocator(),
-                                                      packType->getReducedShape());
+                                                      shapeClass);
       auto elementType = elementEnv->mapPackTypeIntoElementContext(packType);
       addPotentialBinding({elementType, AllowedBindingKind::Exact, constraint});
 
@@ -1433,9 +1434,14 @@ void PotentialBindings::infer(Constraint *constraint) {
     } else if (packVar == TypeVar && !elementVar) {
       // Produce a potential binding to the pack archetype corresponding to
       // the opened element type.
+      Type patternType;
       auto *packEnv = CS.DC->getGenericEnvironmentOfContext();
-      elementType = elementType->mapTypeOutOfContext();
-      auto patternType = packEnv->mapElementTypeIntoPackContext(elementType);
+      if (!elementType->hasElementArchetype()) {
+        patternType = elementType;
+      } else {
+        patternType = packEnv->mapElementTypeIntoPackContext(elementType);
+      }
+
       addPotentialBinding({patternType, AllowedBindingKind::Exact, constraint});
 
       break;

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1424,7 +1424,8 @@ void PotentialBindings::infer(Constraint *constraint) {
       // Produce a potential binding to the opened element archetype corresponding
       // to the pack type.
       packType = packType->mapTypeOutOfContext();
-      auto *elementEnv = CS.getPackElementEnvironment(constraint->getLocator());
+      auto *elementEnv = CS.getPackElementEnvironment(constraint->getLocator(),
+                                                      packType->getReducedShape());
       auto elementType = elementEnv->mapPackTypeIntoElementContext(packType);
       addPotentialBinding({elementType, AllowedBindingKind::Exact, constraint});
 

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8704,8 +8704,8 @@ ConstraintSystem::simplifyPackElementOfConstraint(Type first, Type second,
 
   // This constraint only exists to vend bindings.
   auto *packEnv = DC->getGenericEnvironmentOfContext();
-  if (packType->isEqual(packEnv->mapElementTypeIntoPackContext
-                        (elementType->mapTypeOutOfContext()))) {
+  if ((!elementType->hasElementArchetype() && packType->isEqual(elementType)) ||
+      packType->isEqual(packEnv->mapElementTypeIntoPackContext(elementType))) {
     return SolutionKind::Solved;
   } else {
     return SolutionKind::Error;

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -643,7 +643,8 @@ void ConstraintSystem::addPackElementEnvironment(PackExpansionExpr *expr) {
 }
 
 GenericEnvironment *
-ConstraintSystem::getPackElementEnvironment(ConstraintLocator *locator) {
+ConstraintSystem::getPackElementEnvironment(ConstraintLocator *locator,
+                                            CanType shapeClass) {
   auto result = PackExpansionEnvironments.find(locator);
   if (result == PackExpansionEnvironments.end())
     return nullptr;
@@ -651,7 +652,7 @@ ConstraintSystem::getPackElementEnvironment(ConstraintLocator *locator) {
   auto uuid = result->second;
   auto &ctx = getASTContext();
   auto elementSig = ctx.getOpenedElementSignature(
-      DC->getGenericSignatureOfContext().getCanonicalSignature());
+      DC->getGenericSignatureOfContext().getCanonicalSignature(), shapeClass);
   auto *contextEnv = DC->getGenericEnvironmentOfContext();
   auto contextSubs = contextEnv->getForwardingSubstitutionMap();
   return GenericEnvironment::forOpenedElement(elementSig, uuid, contextSubs);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -655,7 +655,8 @@ ConstraintSystem::getPackElementEnvironment(ConstraintLocator *locator,
       DC->getGenericSignatureOfContext().getCanonicalSignature(), shapeClass);
   auto *contextEnv = DC->getGenericEnvironmentOfContext();
   auto contextSubs = contextEnv->getForwardingSubstitutionMap();
-  return GenericEnvironment::forOpenedElement(elementSig, uuid, contextSubs);
+  return GenericEnvironment::forOpenedElement(elementSig, uuid, shapeClass,
+                                              contextSubs);
 }
 
 /// Extend the given depth map by adding depths for all of the subexpressions

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -1759,7 +1759,7 @@ namespace decls_block {
   using GenericEnvironmentLayout = BCRecordLayout<
     GENERIC_ENVIRONMENT,
     BCFixed<1>,                  // GenericEnvironmentKind
-    TypeIDField,                 // existential type
+    TypeIDField,                 // existential type or shape class
     GenericSignatureIDField,     // parent signature
     SubstitutionMapIDField       // substitution map
   >;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1529,6 +1529,7 @@ void Serializer::writeASTBlockEntity(const GenericEnvironment *genericEnv) {
 
   case GenericEnvironment::Kind::OpenedElement: {
     auto kind = GenericEnvironmentKind::OpenedElement;
+    auto shapeClassID = addTypeRef(genericEnv->getOpenedElementShapeClass());
     auto parentSig = genericEnv->getGenericSignature();
     auto parentSigID = addGenericSignatureRef(parentSig);
     auto contextSubs = genericEnv->getPackElementContextSubstitutions();
@@ -1536,7 +1537,7 @@ void Serializer::writeASTBlockEntity(const GenericEnvironment *genericEnv) {
 
     auto genericEnvAbbrCode = DeclTypeAbbrCodes[GenericEnvironmentLayout::Code];
     GenericEnvironmentLayout::emitRecord(Out, ScratchRecord, genericEnvAbbrCode,
-                                         unsigned(kind), /*existentialTypeID=*/0,
+                                         unsigned(kind), shapeClassID,
                                          parentSigID, subsID);
     return;
   }


### PR DESCRIPTION
This changes opened pack element generic environments to store a shape equivalence class, and only include opened element parameters for originating packs in that shape class in the generic signature.