### PR TITLE
[pruned-liveness] Make some small fixes that only are exposed when working with multi-bit code

### DIFF
--- a/include/swift/Basic/FrozenMultiMap.h
+++ b/include/swift/Basic/FrozenMultiMap.h
@@ -246,6 +246,19 @@ public:
     auto optRange = makeOptionalTransformRange(baseRange, ToNonErasedValues());
     return makeTransformRange(optRange, PairWithTypeErasedOptionalSecondElt());
   }
+
+  /// Returns true if all values for all keys have been deleted.
+  ///
+  /// This is intended to be used in use cases where a frozen multi map is
+  /// filled up with a multi-map and then as we process keys, we delete values
+  /// we have handled. In certain cases, one wishes to validate after processing
+  /// that all values for all keys were properly handled. One cannot perform
+  /// this operation with getRange() in a nice way.
+  bool allValuesHaveBeenDeleted() const {
+    return llvm::all_of(storage, [](const std::pair<Key, Optional<Value>> &pair) {
+      return !pair.second.hasValue();
+    });
+  }
 };
 
 template <typename Key, typename Value, typename Storage>

--- a/include/swift/Basic/SmallBitVector.h
+++ b/include/swift/Basic/SmallBitVector.h
@@ -1,0 +1,30 @@
+//===--- SmallBitVector.h -------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_SMALLBITVECTOR_H
+#define SWIFT_BASIC_SMALLBITVECTOR_H
+
+#include "llvm/ADT/SmallBitVector.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace llvm {
+
+inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                                     const SmallBitVector &bv) {
+  for (unsigned i = 0, e = bv.size(); i != e; ++i)
+    os << (bv[i] ? '1' : '0');
+  return os;
+}
+
+} // namespace llvm
+
+#endif

--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -283,7 +283,7 @@ public:
     auto liveness = getBlockLiveness(block, bitNo);
     if (liveness != Dead)
       return liveness;
-    computeUseBlockLiveness(block, bitNo, bitNo + 1);
+    computeScalarUseBlockLiveness(block, bitNo);
     return getBlockLiveness(block, bitNo);
   }
 
@@ -348,8 +348,14 @@ protected:
     }
   }
 
-  void computeUseBlockLiveness(SILBasicBlock *userBB, unsigned startBitNo,
-                               unsigned endBitNo);
+private:
+  /// A helper routine that as a fast path handles the scalar case. We do not
+  /// handle the mult-bit case today since the way the code is written today
+  /// assumes we process a bit at a time.
+  ///
+  /// TODO: Make a multi-bit query for efficiency reasons.
+  void computeScalarUseBlockLiveness(SILBasicBlock *userBB,
+                                     unsigned startBitNo);
 };
 
 /// If inner borrows are 'Contained', then liveness is fully described by the

--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -209,13 +209,6 @@ public:
       unsigned actualStartBitNo = startBitNo * 2;
       unsigned actualEndBitNo = endBitNo * 2;
 
-      // NOTE: We pad both before/after with Dead to ensure that we are
-      // returning an array that acts as a bit mask and thus can be directly
-      // compared against other such bitmasks. This invariant is used when
-      // computing boundaries.
-      for (unsigned i = 0; i != startBitNo; ++i) {
-        resultingFoundLiveness.push_back(Dead);
-      }
       for (unsigned i = actualStartBitNo, e = actualEndBitNo; i != e; i += 2) {
         if (!bits[i]) {
           resultingFoundLiveness.push_back(Dead);
@@ -223,9 +216,6 @@ public:
         }
 
         resultingFoundLiveness.push_back(bits[i + 1] ? LiveOut : LiveWithin);
-      }
-      for (unsigned i = endBitNo, e = size(); i != e; ++i) {
-        resultingFoundLiveness.push_back(Dead);
       }
     }
 
@@ -314,7 +304,7 @@ public:
                         SmallVectorImpl<IsLive> &foundLivenessInfo) const {
     auto liveBlockIter = liveBlocks.find(bb);
     if (liveBlockIter == liveBlocks.end()) {
-      for (unsigned i : range(numBitsToTrack)) {
+      for (unsigned i : range(endBitNo - startBitNo)) {
         (void)i;
         foundLivenessInfo.push_back(Dead);
       }

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -22,14 +22,11 @@
 using namespace swift;
 
 void PrunedLiveBlocks::computeScalarUseBlockLiveness(SILBasicBlock *userBB,
-                                                     unsigned startBitNo) {
-  unsigned endBitNo = startBitNo + 1;
-
+                                                     unsigned bitNo) {
   // If, we are visiting this block, then it is not already LiveOut. Mark it
   // LiveWithin to indicate a liveness boundary within the block.
-  markBlockLive(userBB, startBitNo, endBitNo, LiveWithin);
+  markBlockLive(userBB, bitNo, LiveWithin);
 
-  // Specialize the given code for scalar code.
   BasicBlockWorklist worklist(userBB->getFunction());
   worklist.push(userBB);
 
@@ -39,12 +36,12 @@ void PrunedLiveBlocks::computeScalarUseBlockLiveness(SILBasicBlock *userBB,
     // Traversal terminates at any previously visited block, including the
     // blocks initialized as definition blocks.
     for (auto *predBlock : block->getPredecessorBlocks()) {
-      switch (getBlockLiveness(predBlock, startBitNo)) {
+      switch (getBlockLiveness(predBlock, bitNo)) {
       case Dead:
         worklist.pushIfNotVisited(predBlock);
         LLVM_FALLTHROUGH;
       case LiveWithin:
-        markBlockLive(predBlock, startBitNo, endBitNo, LiveOut);
+        markBlockLive(predBlock, bitNo, LiveOut);
         break;
       case LiveOut:
         break;

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -21,16 +21,15 @@
 
 using namespace swift;
 
-/// Mark blocks live during a reverse CFG traversal from one specific block
-/// containing a user.
-void PrunedLiveBlocks::computeUseBlockLiveness(SILBasicBlock *userBB,
-                                               unsigned startBitNo,
-                                               unsigned endBitNo) {
+void PrunedLiveBlocks::computeScalarUseBlockLiveness(SILBasicBlock *userBB,
+                                                     unsigned startBitNo) {
+  unsigned endBitNo = startBitNo + 1;
+
   // If, we are visiting this block, then it is not already LiveOut. Mark it
   // LiveWithin to indicate a liveness boundary within the block.
   markBlockLive(userBB, startBitNo, endBitNo, LiveWithin);
 
-  SmallVector<IsLive, 8> predLivenessInfo;
+  // Specialize the given code for scalar code.
   BasicBlockWorklist worklist(userBB->getFunction());
   worklist.push(userBB);
 
@@ -40,19 +39,15 @@ void PrunedLiveBlocks::computeUseBlockLiveness(SILBasicBlock *userBB,
     // Traversal terminates at any previously visited block, including the
     // blocks initialized as definition blocks.
     for (auto *predBlock : block->getPredecessorBlocks()) {
-      SWIFT_DEFER { predLivenessInfo.clear(); };
-      getBlockLiveness(predBlock, startBitNo, endBitNo, predLivenessInfo);
-      for (unsigned i : indices(predLivenessInfo)) {
-        switch (predLivenessInfo[i]) {
-        case Dead:
-          worklist.pushIfNotVisited(predBlock);
-          LLVM_FALLTHROUGH;
-        case LiveWithin:
-          markBlockLive(predBlock, startBitNo, endBitNo, LiveOut);
-          break;
-        case LiveOut:
-          break;
-        }
+      switch (getBlockLiveness(predBlock, startBitNo)) {
+      case Dead:
+        worklist.pushIfNotVisited(predBlock);
+        LLVM_FALLTHROUGH;
+      case LiveWithin:
+        markBlockLive(predBlock, startBitNo, endBitNo, LiveOut);
+        break;
+      case LiveOut:
+        break;
       }
     }
   }
@@ -66,22 +61,26 @@ void PrunedLiveBlocks::computeUseBlockLiveness(SILBasicBlock *userBB,
 void PrunedLiveBlocks::updateForUse(
     SILInstruction *user, unsigned startBitNo, unsigned endBitNo,
     SmallVectorImpl<IsLive> &resultingLivenessInfo) {
+  resultingLivenessInfo.clear();
+
   SWIFT_ASSERT_ONLY(seenUse = true);
 
   auto *bb = user->getParent();
   getBlockLiveness(bb, startBitNo, endBitNo, resultingLivenessInfo);
 
-  for (auto isLive : resultingLivenessInfo) {
-    switch (isLive) {
+  for (auto pair : llvm::enumerate(resultingLivenessInfo)) {
+    unsigned index = pair.index();
+    unsigned specificBitNo = startBitNo + index;
+    switch (pair.value()) {
     case LiveOut:
     case LiveWithin:
       continue;
     case Dead: {
       // This use block has not yet been marked live. Mark it and its
       // predecessor blocks live.
-      computeUseBlockLiveness(bb, startBitNo, endBitNo);
-      resultingLivenessInfo.clear();
-      return getBlockLiveness(bb, startBitNo, endBitNo, resultingLivenessInfo);
+      computeScalarUseBlockLiveness(bb, specificBitNo);
+      resultingLivenessInfo.push_back(getBlockLiveness(bb, specificBitNo));
+      continue;
     }
     }
     llvm_unreachable("covered switch");

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -179,10 +179,13 @@ void PrunedLiveBlocks::print(llvm::raw_ostream &OS) const {
   if (!discoveredBlocks) {
     OS << "No deterministic live block list\n";
   }
+  SmallVector<IsLive, 8> isLive;
   for (auto *block : *discoveredBlocks) {
     block->printAsOperand(OS);
-    OS
-      << ": " << getStringRef(this->getBlockLiveness(block, 0)) << "\n";
+    OS << ": ";
+    for (unsigned i : range(getNumBitsToTrack()))
+      OS << getStringRef(this->getBlockLiveness(block, i)) << ", ";
+    OS << "\n";
   }
 }
 

--- a/lib/SILOptimizer/Mandatory/MoveKillsCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveKillsCopyableAddressesChecker.cpp
@@ -141,6 +141,7 @@
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/FrozenMultiMap.h"
 #include "swift/Basic/GraphNodeWorklist.h"
+#include "swift/Basic/SmallBitVector.h"
 #include "swift/SIL/BasicBlockBits.h"
 #include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SIL/Consumption.h"
@@ -182,15 +183,6 @@ static void diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag,
                      U &&...args) {
   Context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
 }
-
-namespace llvm {
-llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const SmallBitVector &bv) {
-  for (unsigned index : range(bv.size())) {
-    os << (bv[index] ? 1 : 0);
-  }
-  return os;
-}
-} // namespace llvm
 
 static SourceLoc getSourceLocFromValue(SILValue value) {
   if (auto *defInst = value->getDefiningInstruction())


### PR DESCRIPTION
I am fixing some issues that I discovered in FieldSensitive liveness which internally uses pruned live blocks. There are a few things that I did here that fix some architectural issues:

1. Rather than attempting to perform operations all at once for multiple bits, we instead now just work one bit at a time. This simplifies the internal implementation and also more importantly allows me to specialize the internal implementation for single bit usage.
2. I changed getBlockLiveness to only return enough block liveness for the requested bits. If we returned extra dead bits we perform computeUseBlockLiveness additional times for bits where we do not want to do so. This can cause weird propagation issues.

NOTE: This is an interim change. I plan on splitting PrunedLiveBlocks into two separate implementations in a subsequent commit. The first will take advantage of SILNodeBits and only handle single bits and we will have a separate FieldSensitive one that handles multiple bits.