### PR TITLE
Macro expansion diagnostics

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6777,6 +6777,8 @@ ERROR(external_macro_not_found,none,
       "external macro implementation type '%0.%1' could not be found for "
       "macro %2; the type must be public and provided via "
       "'-load-plugin-library'", (StringRef, StringRef, DeclName))
+ERROR(macro_must_be_defined,none,
+      "macro %0 requires a definition", (DeclName))
 NOTE(macro_note, none,
      "%1 (in macro %0)", (DeclName, StringRef))
 WARNING(macro_warning, none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6779,6 +6779,8 @@ ERROR(external_macro_not_found,none,
       "'-load-plugin-library'", (StringRef, StringRef, DeclName))
 ERROR(macro_must_be_defined,none,
       "macro %0 requires a definition", (DeclName))
+ERROR(external_macro_outside_macro_definition,none,
+      "macro 'externalMacro' can only be used to define another macro", ())
 NOTE(macro_note, none,
      "%1 (in macro %0)", (DeclName, StringRef))
 WARNING(macro_warning, none,

--- a/include/swift/AST/MacroDefinition.h
+++ b/include/swift/AST/MacroDefinition.h
@@ -112,7 +112,7 @@ public:
     return data.builtin;
   }
 
-  explicit operator bool() const { return kind != Kind::Invalid; }
+  operator Kind() const { return kind; }
 };
 
 }

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1794,6 +1794,9 @@ enum class ConstraintSystemFlags {
 
   /// When set, ignore async/sync mismatches
   IgnoreAsyncSyncMismatch = 0x80,
+
+  /// Disable macro expansions.
+  DisableMacroExpansions = 0x100,
 };
 
 /// Options that affect the constraint system as a whole.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5397,11 +5397,13 @@ namespace {
       ConcreteDeclRef macroRef = resolveConcreteDeclRef(macro, locator);
       E->setMacroRef(macroRef);
 
-      if (auto newExpr = expandMacroExpr(dc, E, macroRef, expandedType)) {
-        E->setRewritten(newExpr);
-        cs.cacheExprTypes(E);
+      if (!cs.Options.contains(ConstraintSystemFlags::DisableMacroExpansions)) {
+        if (auto newExpr = expandMacroExpr(dc, E, macroRef, expandedType)) {
+          E->setRewritten(newExpr);
+        }
       }
 
+      cs.cacheExprTypes(E);
       return E;
     }
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -422,6 +422,9 @@ TypeChecker::typeCheckTarget(SolutionApplicationTarget &target,
   if (options.contains(TypeCheckExprFlags::LeaveClosureBodyUnchecked))
     csOptions |= ConstraintSystemFlags::LeaveClosureBodyUnchecked;
 
+  if (options.contains(TypeCheckExprFlags::DisableMacroExpansions))
+    csOptions |= ConstraintSystemFlags::DisableMacroExpansions;
+
   ConstraintSystem cs(dc, csOptions);
 
   if (auto *expr = target.getAsExpr()) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -39,6 +39,7 @@
 #include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Initializer.h"
+#include "swift/AST/MacroDefinition.h"
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/PrettyStackTrace.h"
@@ -2004,6 +2005,8 @@ public:
       MD->diagnose(diag::macro_in_nested, MD->getName());
     if (!MD->getMacroContexts())
       MD->diagnose(diag::macro_without_context, MD->getName());
+
+    (void)MD->getDefinition();
   }
 
   void visitMacroExpansionDecl(MacroExpansionDecl *MED) {

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -358,7 +358,7 @@ Expr *swift::expandMacroExpr(
   }
 
   case MacroDefinition::Kind::External: {
-    // Retrieve the extternal definition of the macro.
+    // Retrieve the external definition of the macro.
     auto external = macroDef.getExternalMacro();
     ExternalMacroDefinitionRequest request{
       &ctx, external.moduleName, external.macroTypeName

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -234,7 +234,8 @@ MacroDefinition MacroDefinitionRequest::evaluate(
 
   PrettyStackTraceDecl debugStack("type checking macro definition", macro);
   Type typeCheckedType = TypeChecker::typeCheckExpression(
-      definition, macro, contextualType);
+      definition, macro, contextualType,
+      TypeCheckExprFlags::DisableMacroExpansions);
   if (!typeCheckedType)
     return MacroDefinition::forInvalid();
 
@@ -352,7 +353,8 @@ Expr *swift::expandMacroExpr(
   case MacroDefinition::Kind::Builtin: {
     switch (macroDef.getBuiltinKind()) {
     case BuiltinMacroKind::ExternalMacro:
-      // FIXME: Error here.
+        ctx.Diags.diagnose(
+            expr->getLoc(), diag::external_macro_outside_macro_definition);
       return nullptr;
     }
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -138,6 +138,9 @@ enum class TypeCheckExprFlags {
 
   /// Don't type check expressions for correct availability.
   DisableExprAvailabilityChecking = 0x08,
+
+  /// Don't expansino macros.
+  DisableMacroExpansions = 0x10,
 };
 
 using TypeCheckExprOptions = OptionSet<TypeCheckExprFlags>;

--- a/test/Macros/macro_availability_macosx.swift
+++ b/test/Macros/macro_availability_macosx.swift
@@ -5,6 +5,8 @@
 struct X { }
 
 @expression macro m1: X = #externalMacro(module: "A", type: "B") // expected-error{{'X' is only available in macOS 12.0 or newer}}
+// expected-warning@-1{{external macro implementation type 'A.B' could not be found for macro 'm1'}}
 
 @available(macOS 12.0, *)
 @expression macro m2: X = #externalMacro(module: "A", type: "B")
+// expected-warning@-1{{external macro implementation type 'A.B' could not be found for macro 'm2'}}

--- a/test/Macros/macro_availability_macosx.swift
+++ b/test/Macros/macro_availability_macosx.swift
@@ -4,7 +4,7 @@
 @available(macOS 12.0, *)
 struct X { }
 
-@expression macro m1: X = A.B // expected-error{{'X' is only available in macOS 12.0 or newer}}
+@expression macro m1: X = #externalMacro(module: "A", type: "B") // expected-error{{'X' is only available in macOS 12.0 or newer}}
 
 @available(macOS 12.0, *)
-@expression macro m2: X = A.B
+@expression macro m2: X = #externalMacro(module: "A", type: "B")

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -18,7 +18,7 @@
 
 @expression macro customFileID: String = #externalMacro(module: "MacroDefinition", type: "FileIDMacro")
 @expression macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
-@expression macro fileID<T: _ExpressibleByStringLiteral>: T = #externalMacro(module: "MacroDefinition", type: "FileIDMacro")
+@expression macro fileID<T: ExpressibleByStringLiteral>: T = #externalMacro(module: "MacroDefinition", type: "FileIDMacro")
 @expression macro recurse(_: Bool) = #externalMacro(module: "MacroDefinition", type: "RecursiveMacro")
 
 func testFileID(a: Int, b: Int) {

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -102,3 +102,7 @@ func testMissing() {
 
 @expression macro undefined() // expected-error{{macro 'undefined()' requires a definition}}
 
+func testExternalMacroOutOfPlace() {
+  let _: Int = #externalMacro(module: "A", type: "B")
+  // expected-error@-1{{macro 'externalMacro' can only be used to define another macro}}
+}

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -4,46 +4,47 @@
 // expected-note@-1 2{{'stringify' declared here}}
 @expression macro missingMacro1(_: Any) = MissingModule.MissingType // expected-note{{'missingMacro1' declared here}}
 // expected-warning@-1{{external macro definitions are now written using #externalMacro}}{{43-68=#externalMacro(module: "MissingModule", type: "MissingType")}}
-@expression macro missingMacro2(_: Any) = MissingModule.MissingType
+@expression macro missingMacro2(_: Any) = #externalMacro(module: "MissingModule", type: "MissingType")
 
 protocol P { }
 
-@expression macro tryToHide<T: P>(_: P) -> some P = BuiltinMacros.Blah
+@expression macro tryToHide<T: P>(_: T) -> some P = #externalMacro(module: "BuiltinMacros", type: "Blah")
 // expected-error@-1{{some' types are only permitted in properties, subscripts, and functions}}
+// expected-error@-2{{generic parameter 'T' could not be inferred}}
 
 internal struct X { } // expected-note{{type declared here}}
 
-@expression public macro createAnX: X = BuiltinMacros.Blah
+@expression public macro createAnX: X = #externalMacro(module: "BuiltinMacros", type: "Blah")
 // expected-error@-1{{macro cannot be declared public because its result type uses an internal type}}
 
-@expression macro m1: Int = A.B
-@expression macro m1: Float = A.B
+@expression macro m1: Int = #externalMacro(module: "BuiltinMacros", type: "Blah")
+@expression macro m1: Float = #externalMacro(module: "BuiltinMacros", type: "Blah")
 
-@expression macro m2: Int = A.B // expected-note{{'m2' previously declared here}}
-@expression macro m2: Int = A.B // expected-error{{invalid redeclaration of 'm2'}}
+@expression macro m2: Int = #externalMacro(module: "BuiltinMacros", type: "Blah") // expected-note{{'m2' previously declared here}}
+@expression macro m2: Int = #externalMacro(module: "BuiltinMacros", type: "Blah") // expected-error{{invalid redeclaration of 'm2'}}
 
-@expression macro m3(_: Int) -> Int = A.B
-@expression macro m3(_: Int) -> Float = A.B
+@expression macro m3(_: Int) -> Int = #externalMacro(module: "BuiltinMacros", type: "Blah")
+@expression macro m3(_: Int) -> Float = #externalMacro(module: "BuiltinMacros", type: "Blah")
 
-@expression macro m4(_: Int) -> Int = A.B // expected-note{{'m4' previously declared here}}
-@expression macro m4(_: Int) -> Int = A.B // expected-error{{invalid redeclaration of 'm4'}}
+@expression macro m4(_: Int) -> Int = #externalMacro(module: "BuiltinMacros", type: "Blah") // expected-note{{'m4' previously declared here}}
+@expression macro m4(_: Int) -> Int = #externalMacro(module: "BuiltinMacros", type: "Blah") // expected-error{{invalid redeclaration of 'm4'}}
 
 struct ZZZ {
-  macro m5: Int = A.B
+  macro m5: Int = #externalMacro(module: "BuiltinMacros", type: "Blah")
   // expected-error@-1{{macro 'm5' can only be declared at file scope}}
   // expected-error@-2{{macro 'm5' must declare its applicable contexts (e.g., '@expression')}}
 }
 
-@expression macro multiArgMacro(_: Any, second: Any) = MissingModule.MissingType
+@expression macro multiArgMacro(_: Any, second: Any) = #externalMacro(module: "MissingModule", type: "MissingType")
 // expected-note@-1{{'multiArgMacro(_:second:)' declared here}}
 
-@expression macro overloaded1(_ p: P) = MissingModule.MissingType
+@expression macro overloaded1(_ p: P) = #externalMacro(module: "MissingModule", type: "MissingType")
 func overloaded1(_ p: Any) { }
 
-@expression macro notOverloaded1(_ p: P) = MissingModule.MissingType // expected-note{{'notOverloaded1' previously declared here}}
-@expression macro notOverloaded1(_ p: P) = MissingModule.MissingOtherType // expected-error{{invalid redeclaration of 'notOverloaded1'}}
+@expression macro notOverloaded1(_ p: P) = #externalMacro(module: "MissingModule", type: "MissingType") // expected-note{{'notOverloaded1' previously declared here}}
+@expression macro notOverloaded1(_ p: P) = #externalMacro(module: "MissingModule", type: "MissingOtherType") // expected-error{{invalid redeclaration of 'notOverloaded1'}}
 
-@expression macro intIdentity(value: Int, _: Float) -> Int = MissingModule.MissingType
+@expression macro intIdentity(value: Int, _: Float) -> Int = #externalMacro(module: "MissingModule", type: "MissingType")
 // expected-note@-1{{macro 'intIdentity(value:_:)' declared here}}
 
 func testDiags(a: Int, b: Int) {

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -2,9 +2,12 @@
 
 @expression macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 // expected-note@-1 2{{'stringify' declared here}}
+// expected-warning@-2{{external macro implementation type}}
 @expression macro missingMacro1(_: Any) = MissingModule.MissingType // expected-note{{'missingMacro1' declared here}}
 // expected-warning@-1{{external macro definitions are now written using #externalMacro}}{{43-68=#externalMacro(module: "MissingModule", type: "MissingType")}}
+// expected-warning@-2{{external macro implementation type}}
 @expression macro missingMacro2(_: Any) = #externalMacro(module: "MissingModule", type: "MissingType")
+// expected-warning@-1{{external macro implementation type}}
 
 protocol P { }
 
@@ -16,36 +19,52 @@ internal struct X { } // expected-note{{type declared here}}
 
 @expression public macro createAnX: X = #externalMacro(module: "BuiltinMacros", type: "Blah")
 // expected-error@-1{{macro cannot be declared public because its result type uses an internal type}}
+// expected-warning@-2{{external macro implementation type}}
 
 @expression macro m1: Int = #externalMacro(module: "BuiltinMacros", type: "Blah")
+// expected-warning@-1{{external macro implementation type}}
 @expression macro m1: Float = #externalMacro(module: "BuiltinMacros", type: "Blah")
+// expected-warning@-1{{external macro implementation type}}
 
 @expression macro m2: Int = #externalMacro(module: "BuiltinMacros", type: "Blah") // expected-note{{'m2' previously declared here}}
+// expected-warning@-1{{external macro implementation type}}
 @expression macro m2: Int = #externalMacro(module: "BuiltinMacros", type: "Blah") // expected-error{{invalid redeclaration of 'm2'}}
+// expected-warning@-1{{external macro implementation type}}
 
 @expression macro m3(_: Int) -> Int = #externalMacro(module: "BuiltinMacros", type: "Blah")
+// expected-warning@-1{{external macro implementation type}}
 @expression macro m3(_: Int) -> Float = #externalMacro(module: "BuiltinMacros", type: "Blah")
+// expected-warning@-1{{external macro implementation type}}
 
 @expression macro m4(_: Int) -> Int = #externalMacro(module: "BuiltinMacros", type: "Blah") // expected-note{{'m4' previously declared here}}
+// expected-warning@-1{{external macro implementation type}}
 @expression macro m4(_: Int) -> Int = #externalMacro(module: "BuiltinMacros", type: "Blah") // expected-error{{invalid redeclaration of 'm4'}}
+// expected-warning@-1{{external macro implementation type}}
 
 struct ZZZ {
   macro m5: Int = #externalMacro(module: "BuiltinMacros", type: "Blah")
   // expected-error@-1{{macro 'm5' can only be declared at file scope}}
   // expected-error@-2{{macro 'm5' must declare its applicable contexts (e.g., '@expression')}}
+  // expected-warning@-3{{external macro implementation type}}
 }
 
 @expression macro multiArgMacro(_: Any, second: Any) = #externalMacro(module: "MissingModule", type: "MissingType")
 // expected-note@-1{{'multiArgMacro(_:second:)' declared here}}
+// expected-warning@-2{{external macro implementation type}}
 
 @expression macro overloaded1(_ p: P) = #externalMacro(module: "MissingModule", type: "MissingType")
+// expected-warning@-1{{external macro implementation type}}
+
 func overloaded1(_ p: Any) { }
 
 @expression macro notOverloaded1(_ p: P) = #externalMacro(module: "MissingModule", type: "MissingType") // expected-note{{'notOverloaded1' previously declared here}}
+// expected-warning@-1{{external macro implementation type}}
 @expression macro notOverloaded1(_ p: P) = #externalMacro(module: "MissingModule", type: "MissingOtherType") // expected-error{{invalid redeclaration of 'notOverloaded1'}}
+// expected-warning@-1{{external macro implementation type}}
 
 @expression macro intIdentity(value: Int, _: Float) -> Int = #externalMacro(module: "MissingModule", type: "MissingType")
 // expected-note@-1{{macro 'intIdentity(value:_:)' declared here}}
+// expected-warning@-2{{external macro implementation type}}
 
 func testDiags(a: Int, b: Int) {
   // FIXME: Bad diagnostic.
@@ -80,3 +99,6 @@ func shadow(a: Int, b: Int, stringify: Int) {
 func testMissing() {
   #missingMacro1("hello") // expected-error{{external macro implementation type 'MissingModule.MissingType' could not be found for macro 'missingMacro1'; the type must be public and provided via '-load-plugin-library'}}
 }
+
+@expression macro undefined() // expected-error{{macro 'undefined()' requires a definition}}
+

--- a/test/Macros/parsing.swift
+++ b/test/Macros/parsing.swift
@@ -3,10 +3,15 @@ protocol P { }
 protocol Q { associatedtype Assoc }
 
 @expression macro m1: Int = #externalMacro(module: "A", type: "M1")
+// expected-warning@-1{{external macro implementation type 'A.M1' could not be found for macro 'm1'; the type must be public and provided via '-load-plugin-library'}}
 @expression macro m2(_: Int) = #externalMacro(module: "A", type: "M2")
+// expected-warning@-1{{external macro implementation type 'A.M2' could not be found for macro 'm2'; the type must be public and provided via '-load-plugin-library'}}
 @expression macro m3(a b: Int) -> Int = #externalMacro(module: "A", type: "M3")
+// expected-warning@-1{{external macro implementation type 'A.M3' could not be found for macro 'm3(a:)'; the type must be public and provided via '-load-plugin-library'}}
 @expression macro m4<T: Q>: T = #externalMacro(module: "A", type: "M4") where T.Assoc: P
+// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm4'; the type must be public and provided via '-load-plugin-library'}}
 @expression macro m5<T: P>(_: T) = #externalMacro(module: "A", type: "M4")
+// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm5'; the type must be public and provided via '-load-plugin-library'}}
 
 @expression macro m6 = A // expected-error{{expected '(' for macro parameters or ':' for a value-like macro}}
 // expected-error@-1{{macro must itself be defined by a macro expansion such as '#externalMacro(...)'}}

--- a/test/Macros/parsing.swift
+++ b/test/Macros/parsing.swift
@@ -9,3 +9,4 @@ protocol Q { associatedtype Assoc }
 @expression macro m5<T: P>(_: T) = #externalMacro(module: "A", type: "M4")
 
 @expression macro m6 = A // expected-error{{expected '(' for macro parameters or ':' for a value-like macro}}
+// expected-error@-1{{macro must itself be defined by a macro expansion such as '#externalMacro(...)'}}


### PR DESCRIPTION
Introduce a few more diagnostics related to macros:
* Check the definition of macros at the point of declaration
* Make sure `#externalMacro` cannot be used anywhere except in a macro definition