### PR TITLE
[Tests] TypeWrappers: Require asserts for type wrapper roundtrip tests

### DIFF
--- a/test/Serialization/type_wrapper_in_swiftinterface.swift
+++ b/test/Serialization/type_wrapper_in_swiftinterface.swift
@@ -31,6 +31,8 @@
 // RUN:   -module-name Client -I %t \
 // RUN:   -enable-experimental-feature TypeWrappers
 
+// REQUIRES: asserts
+
 //--- PublicModule.swift
 @typeWrapper
 public struct Wrapper<W : Wrapped, S> {


### PR DESCRIPTION

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
