### PR TITLE
[Sema] RuntimeMetadata: Make sure that inferred attributes have sourc…

### DIFF
--- a/test/SILGen/Inputs/runtime_metadata_defs.swift
+++ b/test/SILGen/Inputs/runtime_metadata_defs.swift
@@ -1,0 +1,10 @@
+@runtimeMetadata
+public struct Ignore {
+  public init<T>(attachedTo: T,
+                 fileID: String = #fileID,
+                 line: Int = #line,
+                 column: Int = #column) {}
+}
+
+@Ignore
+public protocol Ignorable {}

--- a/test/SILGen/runtime_attributes.swift
+++ b/test/SILGen/runtime_attributes.swift
@@ -1,0 +1,67 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -enable-experimental-feature RuntimeDiscoverableAttrs -emit-module -o %t -enable-library-evolution %S/Inputs/runtime_metadata_defs.swift
+
+// This uses '-primary-file' to ensure we're conservative with lazy SIL emission.
+// RUN: %target-swift-emit-silgen -enable-experimental-feature RuntimeDiscoverableAttrs -primary-file %s -I %t | %FileCheck %s
+
+// REQUIRES: asserts
+
+import runtime_metadata_defs
+
+/// Test that generator has source locations for both explicit and inferred attributes.
+
+// CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s18runtime_attributes4TestAaBVmvpfa0A14_metadata_defs6Ignore : $@convention(thin) () -> @out Optional<Ignore>
+// CHECK: [[FILE_ID:%.*]] = string_literal utf8 "runtime_attributes/runtime_attributes.swift"
+// CHECK: [[STRING_INIT:%.*]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
+// CHECK-NEXT: [[FILE_STR:%.*]] = apply [[STRING_INIT]]([[FILE_ID]], {{.*}})
+// CHECK: [[LINE_RAW:%.*]] = integer_literal $Builtin.IntLiteral, 25
+// CHECK: [[INT_INIT:%.*]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC
+// CHECK-NEXT: [[LINE:%.*]] = apply [[INT_INIT]]([[LINE_RAW]], {{.*}})
+// CHECK: [[COLUMN_RAW:%.*]] = integer_literal $Builtin.IntLiteral, 1
+// CHECK: [[INT_INIT:%.*]] = function_ref @$sSi22_builtinIntegerLiteralSiBI_tcfC
+// CHECK-NEXT: [[COLUMN:%.*]] = apply [[INT_INIT]]([[COLUMN_RAW]], {{.*}})
+// CHECK: [[IGNORE_INIT:%.*]] = function_ref @$s21runtime_metadata_defs6IgnoreV10attachedTo6fileID4line6columnACx_SSS2itclufC
+// CHECK-NEXT: {{.*}} = apply [[IGNORE_INIT]]<Test.Type>({{.*}}, {{.*}}, [[FILE_STR]], [[LINE]], [[COLUMN]], {{.*}})
+struct Test : Ignorable {}
+
+// CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s18runtime_attributes8globalFnyycvpfa0A14_metadata_defs6Ignore : $@convention(thin) () -> @out Optional<Ignore>
+// CHECK: {{.*}} = string_literal utf8 "runtime_attributes/runtime_attributes.swift"
+// CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 33
+// CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 2
+// CHECK: [[IGNORE_INIT:%.*]] = function_ref @$s21runtime_metadata_defs6IgnoreV10attachedTo6fileID4line6columnACx_SSS2itclufC
+// CHECK-NEXT: {{.*}} = apply [[IGNORE_INIT]]<() -> ()>({{.*}})
+@Ignore func globalFn() {}
+
+struct MemberTests {
+  // CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s18runtime_attributes11MemberTestsV1xSivpfa0A14_metadata_defs6Ignore : $@convention(thin) () -> @out Optional<Ignore>
+  // CHECK: {{.*}} = string_literal utf8 "runtime_attributes/runtime_attributes.swift"
+  // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 42
+  // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 4
+  // CHECK: [[IGNORE_INIT:%.*]] = function_ref @$s21runtime_metadata_defs6IgnoreV10attachedTo6fileID4line6columnACx_SSS2itclufC
+  // CHECK-NEXT: {{.*}} = apply [[IGNORE_INIT]]<WritableKeyPath<MemberTests, Int>>({{.*}})
+  @Ignore var x: Int = 42
+
+  // CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s18runtime_attributes11MemberTestsV6instFn_1xSSSi_SaySiGtcvpfa0A14_metadata_defs6Ignore : $@convention(thin) () -> @out Optional<Ignore>
+  // CHECK: {{.*}} = string_literal utf8 "runtime_attributes/runtime_attributes.swift"
+  // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 50
+  // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 4
+  // CHECK: [[IGNORE_INIT:%.*]] = function_ref @$s21runtime_metadata_defs6IgnoreV10attachedTo6fileID4line6columnACx_SSS2itclufC
+  // CHECK-NEXT: {{.*}} = apply [[IGNORE_INIT]]<(MemberTests, Int, [Int]) -> String>({{.*}})
+  @Ignore func instFn(_: Int, x: [Int]) -> String { "" }
+
+  // CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s18runtime_attributes11MemberTestsV8staticFn_1ySi_SStSS_SiztcvpZfa0A14_metadata_defs6Ignore : $@convention(thin) () -> @out Optional<Ignore>
+  // CHECK: {{.*}} = string_literal utf8 "runtime_attributes/runtime_attributes.swift"
+  // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 58
+  // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 4
+  // CHECK: [[IGNORE_INIT:%.*]] = function_ref @$s21runtime_metadata_defs6IgnoreV10attachedTo6fileID4line6columnACx_SSS2itclufC
+  // CHECK-NEXT: {{.*}} = apply [[IGNORE_INIT]]<(MemberTests.Type, String, inout Int) -> (Int, String)>({{.*}})
+  @Ignore static func staticFn(_ x: String, y: inout Int) -> (Int, String) { (42, "") }
+
+  // CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s18runtime_attributes11MemberTestsV10mutatingFnSiycvpfa0A14_metadata_defs6Ignore : $@convention(thin) () -> @out Optional<Ignore>
+  // CHECK: {{.*}} = string_literal utf8 "runtime_attributes/runtime_attributes.swift"
+  // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 66
+  // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 4
+  // CHECK: [[IGNORE_INIT:%.*]] = function_ref @$s21runtime_metadata_defs6IgnoreV10attachedTo6fileID4line6columnACx_SSS2itclufC
+  // CHECK-NEXT: {{.*}} = apply [[IGNORE_INIT]]<(inout MemberTests) -> Int>({{.*}})
+  @Ignore mutating func mutatingFn() -> Int { 42 }
+}


### PR DESCRIPTION
…e information

If an attribute is inferred from a protocol conformance it won't have
any source information, in such cases let's determine where an attribute
could have been inserted if it was spelled explicitly and use that location
in a synthesized initializer call.

Resolves: rdar://103938899

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
