### PR TITLE
Allow the standard library to build with a slightly older compiler

### DIFF
--- a/stdlib/public/core/Macros.swift
+++ b/stdlib/public/core/Macros.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if hasAttribute(expression)
 /// Specifies the module and type name for an externally-defined macro, which
 /// must conform to the appropriate set of `Macro` protocols.
 ///
@@ -23,3 +24,4 @@
 public macro externalMacro<T>(module: String, type: String) -> T =
     Builtin.ExternalMacro
 
+#endif


### PR DESCRIPTION
Check for the `@expression` attribute before using it. Fixes rdar://104036723.
