### PR TITLE
[Macros] Freestanding declaration macros

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8327,17 +8327,6 @@ public:
   }
 };
 
-/// The context in which a macro can be used, which determines the syntax it
-/// uses.
-enum class MacroContext: uint8_t {
-  /// An expression macro, referenced explicitly via "#stringify" or similar
-  /// in the source code.
-  Expression = 0x01,
-};
-
-/// The contexts in which a particular macro declaration can be used.
-using MacroContexts = OptionSet<MacroContext>;
-
 /// Provides a declaration of a macro.
 ///
 /// Macros are declared within the source code with the `macro` introducer.
@@ -8410,7 +8399,10 @@ class MacroExpansionDecl : public Decl {
   SourceLoc LeftAngleLoc, RightAngleLoc;
   ArrayRef<TypeRepr *> GenericArgs;
   ArgumentList *ArgList;
-  Decl *Rewritten;
+  ArrayRef<Decl *> Rewritten;
+
+  /// The referenced macro.
+  ConcreteDeclRef macroRef;
 
 public:
   MacroExpansionDecl(DeclContext *dc, SourceLoc poundLoc, DeclNameRef macro,
@@ -8422,7 +8414,7 @@ public:
       : Decl(DeclKind::MacroExpansion, dc), PoundLoc(poundLoc),
         Macro(macro), MacroLoc(macroLoc),
         LeftAngleLoc(leftAngleLoc), RightAngleLoc(rightAngleLoc),
-        GenericArgs(genericArgs), ArgList(args), Rewritten(nullptr) {}
+        GenericArgs(genericArgs), ArgList(args), Rewritten({}) {}
 
   ArrayRef<TypeRepr *> getGenericArgs() const { return GenericArgs; }
 
@@ -8436,8 +8428,10 @@ public:
   DeclNameLoc getMacroLoc() const { return MacroLoc; }
   DeclNameRef getMacro() const { return Macro; }
   ArgumentList *getArgs() const { return ArgList; }
-  Decl *getRewritten() const { return Rewritten; }
-  void setRewritten(Decl *rewritten) { Rewritten = rewritten; }
+  ArrayRef<Decl *> getRewritten() const { return Rewritten; }
+  void setRewritten(ArrayRef<Decl *> rewritten) { Rewritten = rewritten; }
+  ConcreteDeclRef getMacroRef() const { return macroRef; }
+  void setMacroRef(ConcreteDeclRef ref) { macroRef = ref; }
 
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::MacroExpansion;

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2009,6 +2009,9 @@ ERROR(macro_expansion_expr_expected_macro_identifier,PointsToFirstBadToken,
 ERROR(macro_expansion_decl_expected_macro_identifier,PointsToFirstBadToken,
       "expected a macro identifier for a pound literal declaration", ())
 
+ERROR(declaration_attr_expected_kind,PointsToFirstBadToken,
+      "expected a declaration macro kind ('freestanding' or 'attached')", ())
+
 ERROR(parser_round_trip_error,none,
       "source file did not round-trip through the new Swift parser", ())
 ERROR(parser_new_parser_errors,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6780,6 +6780,8 @@ ERROR(experimental_no_metadata_feature_can_only_be_used_when_enabled,
 
 ERROR(expected_macro_expansion_expr,PointsToFirstBadToken,
       "expected macro expansion to produce an expression", ())
+ERROR(expected_macro_expansion_decls,PointsToFirstBadToken,
+      "expected macro expansion to produce declarations", ())
 ERROR(macro_undefined,PointsToFirstBadToken,
       "no macro named %0", (Identifier))
 ERROR(external_macro_not_found,none,
@@ -6836,6 +6838,8 @@ ERROR(macro_definition_unsupported,none,
 ERROR(external_macro_arg_not_type_name,none,
       "argument to `#externalMacro` must be a string literal naming "
       "the external macro's %select{module|type}", (unsigned))
+ERROR(attached_declaration_macro_not_supported,none,
+      "attached declaration macros are not yet supported", ())
 
 //------------------------------------------------------------------------------
 // MARK: Move Only Errors

--- a/include/swift/AST/MacroDeclaration.h
+++ b/include/swift/AST/MacroDeclaration.h
@@ -1,0 +1,90 @@
+//===--- MacroDeclaration.h - Swift Macro Declaration -----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Data structures that configure the declaration of a macro.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_MACRO_DECLARATION_H
+#define SWIFT_AST_MACRO_DECLARATION_H
+
+#include "swift/AST/Identifier.h"
+
+namespace swift {
+
+/// The context in which a macro can be used, which determines the syntax it
+/// uses.
+enum class MacroContext: uint8_t {
+  /// An expression macro, referenced explicitly via "#stringify" or similar
+  /// in the source code.
+  Expression = 0x01,
+  /// A freestanding declaration macro.
+  FreestandingDeclaration = 0x02,
+  /// An attached declaration macro.
+  AttachedDeclaration = 0x03,
+};
+
+/// The contexts in which a particular macro declaration can be used.
+using MacroContexts = OptionSet<MacroContext>;
+
+enum class MacroIntroducedDeclNameKind {
+  Named,
+  Overloaded,
+  Accessors,
+  Prefixed,
+  Suffixed,
+  Arbitrary,
+};
+
+class MacroIntroducedDeclName {
+public:
+  using Kind = MacroIntroducedDeclNameKind;
+
+private:
+  Kind kind;
+  Identifier identifier;
+
+public:
+  MacroIntroducedDeclName(Kind kind, Identifier identifier = Identifier())
+      : kind(kind), identifier(identifier) {};
+
+  static MacroIntroducedDeclName getNamed(Identifier name) {
+    return MacroIntroducedDeclName(Kind::Named, name);
+  }
+
+  static MacroIntroducedDeclName getOverloaded() {
+    return MacroIntroducedDeclName(Kind::Overloaded);
+  }
+
+  static MacroIntroducedDeclName getAccessors() {
+    return MacroIntroducedDeclName(Kind::Accessors);
+  }
+
+  static MacroIntroducedDeclName getPrefixed(Identifier prefix) {
+    return MacroIntroducedDeclName(Kind::Prefixed, prefix);
+  }
+
+  static MacroIntroducedDeclName getSuffixed(Identifier suffix) {
+    return MacroIntroducedDeclName(Kind::Suffixed, suffix);
+  }
+
+  static MacroIntroducedDeclName getArbitrary() {
+    return MacroIntroducedDeclName(Kind::Arbitrary);
+  }
+
+  Kind getKind() const { return kind; }
+  Identifier getIdentifier() const { return identifier; }
+};
+
+}
+
+#endif // SWIFT_AST_MACRO_DECLARATION_H

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3765,6 +3765,23 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Check whether this is a protocol that has a type wrapper attribute
+/// or one of its dependencies does.
+class UsesTypeWrapperFeature
+    : public SimpleRequest<UsesTypeWrapperFeature, bool(NominalTypeDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  bool evaluate(Evaluator &evaluator, NominalTypeDecl *) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 /// Find the definition of a given macro.
 class MacroDefinitionRequest
     : public SimpleRequest<MacroDefinitionRequest,
@@ -3782,6 +3799,24 @@ public:
   // Source location
   SourceLoc getNearestLoc() const;
 
+  bool isCached() const { return true; }
+};
+
+/// Find the definition of a given macro.
+class ExpandMacroExpansionDeclRequest
+    : public SimpleRequest<ExpandMacroExpansionDeclRequest,
+                           ArrayRef<Decl *>(MacroExpansionDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  ArrayRef<Decl *> evaluate(Evaluator &evaluator,
+                            MacroExpansionDecl *med) const;
+
+public:
   bool isCached() const { return true; }
 };
 

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -449,6 +449,9 @@ SWIFT_REQUEST(TypeChecker, MacroDefinitionRequest,
 SWIFT_REQUEST(TypeChecker, ExternalMacroDefinitionRequest,
               ExternalMacroDefinition(ASTContext *, Identifier, Identifier),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ExpandMacroExpansionDeclRequest,
+              ArrayRef<Decl *>(MacroExpansionDecl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SynthesizeRuntimeMetadataAttrGenerator,
               Expr *(CustomAttr *, ValueDecl *),
               Cached, NoLocationInfo)

--- a/include/swift/AST/TypeMemberVisitor.h
+++ b/include/swift/AST/TypeMemberVisitor.h
@@ -78,6 +78,12 @@ public:
         asImpl().visit(dd);
     }
   }
+
+  /// Visit expanded macros.
+  void visitMacroExpansionDecl(MacroExpansionDecl *D) {
+    for (auto *decl : D->getRewritten())
+      asImpl().visit(decl);
+  }
 };
 
 template<typename ImplClass, typename RetTy = void>

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1090,6 +1090,10 @@ public:
   bool parseDocumentationAttributeArgument(Optional<StringRef> &Metadata,
                                            Optional<AccessLevel> &Visibility);
 
+  /// Parse the @declaration attribute.
+  ParserResult<DeclarationAttr> parseDeclarationAttribute(SourceLoc AtLoc,
+                                                          SourceLoc Loc);
+
   /// Parse a specific attribute.
   ParserStatus parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                                   PatternBindingInitializer *&initContext,

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -428,8 +428,9 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   bool visitMacroExpansionDecl(MacroExpansionDecl *MED) {
     if (MED->getArgs() && doIt(MED->getArgs()))
       return true;
-    if (MED->getRewritten() && doIt(MED->getRewritten()))
-      return true;
+    for (auto *decl : MED->getRewritten())
+      if (doIt(decl))
+        return true;
     return false;
   }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9713,6 +9713,8 @@ MacroContexts MacroDecl::getMacroContexts() const {
   MacroContexts contexts = None;
   if (getAttrs().hasAttribute<ExpressionAttr>())
     contexts |= MacroContext::Expression;
+  for (auto attr : getAttrs().getAttributes<DeclarationAttr>())
+    contexts |= attr->getMacroContext();
   return contexts;
 }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -31,6 +31,7 @@
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/SourceFile.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/Basic/SourceManager.h"

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1773,9 +1773,8 @@ namespace {
     }
 
     void visitMacroExpansionDecl(MacroExpansionDecl *med) {
-      auto *rewritten = med->getRewritten();
-      assert(rewritten && "Macro should have already been expanded by IRGen");
-      visit(rewritten);
+      for (auto *rewritten : med->getRewritten())
+        visit(rewritten);
     }
 
     void addIVarInitializer() {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2132,6 +2132,40 @@ Parser::parseDocumentationAttribute(SourceLoc AtLoc, SourceLoc Loc) {
   return makeParserResult(new (Context) DocumentationAttr(Loc, range, FinalMetadata, Visibility, false));
 }
 
+ParserResult<DeclarationAttr>
+Parser::parseDeclarationAttribute(SourceLoc AtLoc, SourceLoc Loc) {
+  StringRef attrName = "declaration";
+  bool isDeclModifier = DeclAttribute::isDeclModifier(DAK_Declaration);
+  if (!consumeIf(tok::l_paren)) {
+    diagnose(Tok, diag::attr_expected_lparen, attrName, isDeclModifier);
+    return makeParserError();
+  }
+  if (Tok.isNot(tok::identifier)) {
+    diagnose(Tok, diag::declaration_attr_expected_kind);
+    errorAndSkipUntilConsumeRightParen(*this, attrName);
+    return makeParserError();
+  }
+  auto kind = llvm::StringSwitch<Optional<MacroContext>>(Tok.getText())
+      .Case("freestanding", MacroContext::FreestandingDeclaration)
+      .Case("attached", MacroContext::AttachedDeclaration)
+      .Default(None);
+  if (!kind) {
+    diagnose(Tok, diag::declaration_attr_expected_kind);
+    errorAndSkipUntilConsumeRightParen(*this, attrName);
+    return makeParserError();
+  }
+  consumeToken(tok::identifier);
+  // TODO: Parse peer and member names.
+  SourceLoc rParenLoc;
+  if (!consumeIf(tok::r_paren, rParenLoc)) {
+    diagnose(Tok, diag::attr_expected_rparen, attrName, isDeclModifier);
+    return makeParserError();
+  }
+  SourceRange range(Loc, rParenLoc);
+  return makeParserResult(DeclarationAttr::create(
+      Context, AtLoc, range, *kind, {}, {}, /*isImplicit*/ false));
+}
+
 /// Guts of \c parseSingleAttrOption and \c parseSingleAttrOptionIdentifier.
 ///
 /// \param P The parser object.
@@ -3116,6 +3150,14 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
   }
   case DAK_Documentation: {
     auto Attr = parseDocumentationAttribute(AtLoc, Loc);
+    if (Attr.isNonNull())
+      Attributes.add(Attr.get());
+    else
+      return false;
+    break;
+  }
+  case DAK_Declaration: {
+    auto Attr = parseDeclarationAttribute(AtLoc, Loc);
     if (Attr.isNonNull())
       Attributes.add(Attr.get());
     else

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1806,9 +1806,8 @@ void SILGenModule::visitMacroDecl(MacroDecl *d) {
 }
 
 void SILGenModule::visitMacroExpansionDecl(MacroExpansionDecl *d) {
-  auto *rewritten = d->getRewritten();
-  assert(rewritten && "Macro must have been rewritten in SILGen");
-  visit(rewritten);
+  // Expanded declaration macros were already added to the parent decl context
+  // for name lookup to work. Nothing to be done here.
 }
 
 bool

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1235,9 +1235,8 @@ public:
   }
 
   void visitMacroExpansionDecl(MacroExpansionDecl *med) {
-    auto *rewritten = med->getRewritten();
-    assert(rewritten && "Macro must have been rewritten in SILGen");
-    visit(rewritten);
+    for (auto *rewritten : med->getRewritten())
+      visit(rewritten);
   }
 };
 
@@ -1410,9 +1409,8 @@ public:
   }
 
   void visitMacroExpansionDecl(MacroExpansionDecl *med) {
-    auto *rewritten = med->getRewritten();
-    assert(rewritten && "Macro must have been rewritten in SILGen");
-    visit(rewritten);
+    for (auto *rewritten : med->getRewritten())
+      visit(rewritten);
   }
 };
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3757,20 +3757,14 @@ namespace {
 
     /// Lookup all macros with the given macro name.
     SmallVector<OverloadChoice, 1>
-    lookupMacros(
-        Identifier macroName, SourceLoc loc, FunctionRefKind functionRefKind
-    ) {
-      auto result = TypeChecker::lookupUnqualified(
-          CurDC, DeclNameRef(macroName), loc,
-          (defaultUnqualifiedLookupOptions |
-           NameLookupFlags::IncludeOuterResults));
-
+    lookupMacros(Identifier macroName, SourceLoc loc,
+                 FunctionRefKind functionRefKind) {
       SmallVector<OverloadChoice, 1> choices;
-      for (const auto &found : result.allResults()) {
-        if (auto macro = dyn_cast<MacroDecl>(found.getValueDecl())) {
-          OverloadChoice choice = OverloadChoice(Type(), macro, functionRefKind);
-          choices.push_back(choice);
-        }
+      auto results = TypeChecker::lookupMacros(
+          CurDC, DeclNameRef(macroName), loc, MacroContext::Expression);
+      for (const auto &result : results) {
+        OverloadChoice choice = OverloadChoice(Type(), result, functionRefKind);
+        choices.push_back(choice);
       }
 
       // FIXME: At some point, we need to check for function-like macros without

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -160,6 +160,7 @@ public:
   IGNORED_ATTR(BackDeploy)
   IGNORED_ATTR(Documentation)
   IGNORED_ATTR(Expression)
+  IGNORED_ATTR(Declaration)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1597,6 +1597,20 @@ TypeChecker::lookupPrecedenceGroup(DeclContext *dc, Identifier name,
   return PrecedenceGroupLookupResult(dc, name, std::move(groups));
 }
 
+SmallVector<MacroDecl *, 1>
+TypeChecker::lookupMacros(DeclContext *dc, DeclNameRef macroName,
+                          SourceLoc loc, MacroContexts contexts) {
+  auto result = lookupUnqualified(dc, DeclNameRef(macroName), loc,
+                                  (defaultUnqualifiedLookupOptions |
+                                      NameLookupFlags::IncludeOuterResults));
+  SmallVector<MacroDecl *, 1> choices;
+  for (const auto &found : result.allResults())
+    if (auto macro = dyn_cast<MacroDecl>(found.getValueDecl()))
+      if (contexts.contains(macro->getMacroContexts()))
+        choices.push_back(macro);
+  return choices;
+}
+
 /// Validate the given operator declaration.
 ///
 /// This establishes key invariants, such as an InfixOperatorDecl's

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1627,6 +1627,7 @@ namespace  {
     UNINTERESTING_ATTR(RuntimeMetadata)
 
     UNINTERESTING_ATTR(Expression)
+    UNINTERESTING_ATTR(Declaration)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -23,6 +23,7 @@
 #include "TypeCheckAvailability.h"
 #include "TypeCheckConcurrency.h"
 #include "TypeCheckDecl.h"
+#include "TypeCheckMacros.h"
 #include "TypeCheckObjC.h"
 #include "TypeCheckType.h"
 #include "TypeChecker.h"
@@ -2041,7 +2042,8 @@ public:
   }
 
   void visitMacroExpansionDecl(MacroExpansionDecl *MED) {
-    llvm_unreachable("FIXME: macro expansion decl not handled in DeclChecker");
+    (void)evaluateOrDefault(
+        Ctx.evaluator, ExpandMacroExpansionDeclRequest{MED}, {});
   }
 
   void visitBoundVariable(VarDecl *VD) {
@@ -3655,4 +3657,104 @@ void TypeChecker::checkParameterList(ParameterList *params,
     // Check for duplicate parameter names.
     diagnoseDuplicateDecls(*params);
   }
+}
+
+ArrayRef<Decl *>
+ExpandMacroExpansionDeclRequest::evaluate(Evaluator &evaluator,
+                                          MacroExpansionDecl *MED) const {
+  auto &ctx = MED->getASTContext();
+  auto *dc = MED->getDeclContext();
+  auto foundMacros = TypeChecker::lookupMacros(
+      MED->getDeclContext(), MED->getMacro(),
+      MED->getLoc(), MacroContext::FreestandingDeclaration);
+  if (foundMacros.empty()) {
+    MED->diagnose(diag::macro_undefined, MED->getMacro().getBaseIdentifier())
+        .highlight(MED->getMacroLoc().getSourceRange());
+    return {};
+  }
+  // Resolve macro candidates.
+  MacroDecl *macro;
+  // Non-call declaration macros cannot be overloaded.
+  auto *args = MED->getArgs();
+  if (!args) {
+    if (foundMacros.size() > 1) {
+      MED->diagnose(diag::ambiguous_decl_ref, MED->getMacro())
+          .highlight(MED->getMacroLoc().getSourceRange());
+      for (auto *candidate : foundMacros)
+        candidate->diagnose(diag::found_candidate);
+      return {};
+    }
+    macro = foundMacros.front();
+  }
+    // Call-like macros need to be resolved.
+  else {
+    using namespace constraints;
+    ConstraintSystem cs(dc, ConstraintSystemOptions());
+    // Type-check macro arguments.
+    for (auto *arg : args->getArgExprs())
+      cs.setType(arg, TypeChecker::typeCheckExpression(arg, dc));
+    auto choices = map<SmallVector<OverloadChoice, 1>>(
+        foundMacros,
+        [](MacroDecl *md) {
+          return OverloadChoice(Type(), md, FunctionRefKind::SingleApply);
+        });
+    auto locator = cs.getConstraintLocator(MED);
+    auto macroRefType = Type(cs.createTypeVariable(locator, 0));
+    cs.addOverloadSet(macroRefType, choices, dc, locator);
+    if (MED->getGenericArgsRange().isValid()) {
+      // FIXME: Deal with generic args.
+      MED->diagnose(diag::macro_unsupported);
+      return {};
+    }
+    auto getMatchingParams = [&](
+        ArgumentList *argList,
+        SmallVectorImpl<AnyFunctionType::Param> &result) {
+      for (auto arg : *argList) {
+        ParameterTypeFlags flags;
+        auto ty = cs.getType(arg.getExpr()); if (arg.isInOut()) {
+          ty = ty->getInOutObjectType();
+          flags = flags.withInOut(true);
+        }
+        if (arg.isConst()) {
+          flags = flags.withCompileTimeConst(true);
+        }
+        result.emplace_back(ty, arg.getLabel(), flags);
+      }
+    };
+    SmallVector<AnyFunctionType::Param, 8> params;
+    getMatchingParams(args, params);
+    cs.associateArgumentList(locator, args);
+    cs.addConstraint(
+        ConstraintKind::ApplicableFunction,
+        FunctionType::get(params, ctx.getVoidType()),
+        macroRefType,
+        cs.getConstraintLocator(MED, ConstraintLocator::ApplyFunction));
+    // Solve.
+    auto solution = cs.solveSingle();
+    if (!solution) {
+      MED->diagnose(diag::no_overloads_match_exactly_in_call,
+                    /*reference|call*/false, DescriptiveDeclKind::Macro,
+                    false, MED->getMacro().getBaseName())
+          .highlight(MED->getMacroLoc().getSourceRange());
+      for (auto *candidate : foundMacros)
+        candidate->diagnose(diag::found_candidate);
+      return {};
+    }
+    auto choice = solution->getOverloadChoice(locator).choice;
+    macro = cast<MacroDecl>(choice.getDecl());
+  }
+  MED->setMacroRef(macro);
+
+  // Expand the macro.
+  SmallVector<Decl *, 2> expandedTemporary;
+  if (!expandFreestandingDeclarationMacro(MED, expandedTemporary))
+    return {};
+  auto expanded = ctx.AllocateCopy(expandedTemporary);
+  // FIXME: Handle this in name lookup instead of `addMember`.
+  // MED->setRewritten(expanded);
+  if (auto *parentDecl = MED->getDeclContext()->getAsDecl())
+    if (auto *idc = dyn_cast<IterableDeclContext>(parentDecl))
+      for (auto *decl : expanded)
+        idc->addMember(decl);
+  return expanded;
 }

--- a/lib/Sema/TypeCheckMacros.h
+++ b/lib/Sema/TypeCheckMacros.h
@@ -22,6 +22,7 @@
 namespace swift {
 
 class Expr;
+class MacroExpansionDecl;
 class TypeRepr;
 
 /// Expands the given macro expression and type-check the result with
@@ -31,6 +32,13 @@ class TypeRepr;
 // macro could not be expanded.
 Expr *expandMacroExpr(
     DeclContext *dc, Expr *expr, ConcreteDeclRef macroRef, Type expandedType);
+
+/// Expands the given macro expansion declaration, type-checks the replacement
+/// declarations, and adds them to \p results.
+///
+/// \returns true if expansion succeeded, false if failed.
+bool expandFreestandingDeclarationMacro(
+    MacroExpansionDecl *med, SmallVectorImpl<Decl *> &results);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -917,6 +917,10 @@ lookupPrecedenceGroupForInfixOperator(DeclContext *dc, Expr *op, bool diagnose);
 PrecedenceGroupLookupResult
 lookupPrecedenceGroup(DeclContext *dc, Identifier name, SourceLoc nameLoc);
 
+SmallVector<MacroDecl *, 1>
+lookupMacros(DeclContext *dc, DeclNameRef macroName, SourceLoc loc,
+             MacroContexts contexts);
+
 enum class UnsupportedMemberTypeAccessKind : uint8_t {
   None,
   TypeAliasOfUnboundGeneric,

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 732; // deserialization safety
+const uint16_t SWIFTMODULE_VERSION_MINOR = 734; // @declaration
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -604,6 +604,27 @@ enum class GenericEnvironmentKind : uint8_t {
   OpenedExistential,
   OpenedElement
 };
+
+// These IDs must \em not be renumbered or reordered without incrementing
+// the module version.
+enum class MacroContext : uint8_t {
+  Expression,
+  FreestandingDeclaration,
+  AttachedDeclaration,
+};
+using MacroContextField = BCFixed<3>;
+
+// These IDs must \em not be renumbered or reordered without incrementing
+// the module version.
+enum class MacroIntroducedDeclNameKind : uint8_t {
+  Named = 0,
+  Overloaded,
+  Accessors,
+  Prefixed,
+  Suffixed,
+  Arbitrary,
+};
+using MacroIntroducedDeclNameKindField = BCFixed<4>;
 
 // Encodes a VersionTuple:
 //
@@ -2191,6 +2212,15 @@ namespace decls_block {
     IdentifierIDField,  // metadata text
     BCFixed<1>,         // has visibility
     AccessLevelField    // visibility
+  >;
+
+  using DeclarationDeclAttrLayout = BCRecordLayout<
+    Declaration_DECL_ATTR,
+    BCFixed<1>,                // implicit flag
+    MacroContextField,         // macro context
+    BCVBR<5>,                  // number of peer names
+    BCVBR<5>,                  // number of member names
+    BCArray<IdentifierIDField> // introduced decl name kind and identifier pairs
   >;
 
 #undef SYNTAX_SUGAR_TYPE_LAYOUT

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -316,6 +316,7 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       typeWrapperIgnored[#Declaration Attribute#]; name=typeWrapperIgnored
 // ON_MEMBER_LAST-DAG: Keyword/None:                       runtimeMetadata[#Declaration Attribute#]; name=runtimeMetadata
 // ON_MEMBER_LAST-DAG: Keyword/None:                       expression[#Declaration Attribute#]; name=expression
+// ON_MEMBER_LAST-DAG: Keyword/None:                       declaration[#Declaration Attribute#]; name=declaration
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
@@ -389,6 +390,7 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       typeWrapperIgnored[#Declaration Attribute#]; name=typeWrapperIgnored
 // KEYWORD_LAST-DAG: Keyword/None:                       runtimeMetadata[#Declaration Attribute#]; name=runtimeMetadata
 // KEYWORD_LAST-DAG: Keyword/None:                       expression[#Declaration Attribute#]; name=expression
+// KEYWORD_LAST-DAG: Keyword/None:                       declaration[#Declaration Attribute#]; name=declaration
 // KEYWORD_LAST-NOT: Keyword
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -180,3 +180,35 @@ public class NestedDeclInExprMacro: ExpressionMacro {
     """
   }
 }
+
+enum CustomError: Error, CustomStringConvertible {
+  case message(String)
+
+  var description: String {
+    switch self {
+    case .message(let text):
+      return text
+    }
+  }
+}
+
+public struct DefineBitwidthNumberedStructsMacro: FreestandingDeclarationMacro {
+  public static func expansion(
+    of node: MacroExpansionDeclSyntax,
+    in context: inout MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let firstElement = node.argumentList.first,
+          let stringLiteral = firstElement.expression.as(StringLiteralExprSyntax.self),
+          stringLiteral.segments.count == 1,
+          case let .stringSegment(prefix) = stringLiteral.segments.first else {
+      throw CustomError.message("#bitwidthNumberedStructs macro requires a string literal")
+    }
+
+    return [8, 16, 32, 64].map { bitwidth in
+      """
+
+      struct \(raw: prefix)\(raw: String(bitwidth)) { }
+      """
+    }
+  }
+}

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -99,3 +99,48 @@ func testAddBlocker(a: Int, b: Int, c: Int, oa: OnlyAdds) {
 func testNestedDeclInExpr() {
   let _: () -> Void = #nestedDeclInExpr
 }
+
+@declaration(freestanding) macro bitwidthNumberedStructs(_ baseName: String) = #externalMacro(module: "MacroDefinition", type: "DefineBitwidthNumberedStructsMacro")
+// Test overload
+@declaration(freestanding) macro bitwidthNumberedStructs(_ baseName: String, blah: Bool) = #externalMacro(module: "MacroDefinition", type: "DefineBitwidthNumberedStructsMacro")
+
+// FIXME: Declaration macro expansions in BraceStmt don't work yet.
+//#bitwidthNumberedStructs("MyIntGlobal")
+
+func testFreestandingMacroExpansion() {
+  // Explicit structs to force macros to be parsed as decl.
+  struct Foo {
+    #bitwidthNumberedStructs("MyIntOne")
+  }
+  // CHECK: MyIntOne8
+  print(Foo.MyIntOne8.self)
+  // CHECK: MyIntOne16
+  print(Foo.MyIntOne16.self)
+  // CHECK: MyIntOne32
+  print(Foo.MyIntOne32.self)
+  // CHECK: MyIntOne64
+  print(Foo.MyIntOne64.self)
+
+  struct Foo2 {
+    #bitwidthNumberedStructs("MyIntTwo", blah: false)
+  }
+  // CHECK: MyIntTwo8
+  print(Foo2.MyIntTwo8.self)
+  // CHECK: MyIntTwo16
+  print(Foo2.MyIntTwo16.self)
+  // CHECK: MyIntTwo32
+  print(Foo2.MyIntTwo32.self)
+  // CHECK: MyIntTwo64
+  print(Foo2.MyIntTwo64.self)
+
+  // FIXME: Declaration macro expansions in BraceStmt don't work yet.
+//  HECK: MyIntGlobal8
+//  print(MyIntGlobal8.self)
+//  HECK: MyIntGlobal16
+//  print(MyIntGlobal16.self)
+//  HECK: MyIntGlobal32
+//  print(MyIntGlobal32.self)
+//  HECK: MyIntGlobal64
+//  print(MyIntGlobal64.self)
+}
+testFreestandingMacroExpansion()

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -66,6 +66,11 @@ func overloaded1(_ p: Any) { }
 // expected-note@-1{{macro 'intIdentity(value:_:)' declared here}}
 // expected-warning@-2{{external macro implementation type}}
 
+@declaration(freestanding) macro unaryDeclMacro(_ x: String) // expected-note {{found this candidate}}
+// expected-error @-1 {{macro 'unaryDeclMacro' requires a definition}}
+@declaration(freestanding) macro unaryDeclMacro(_ x: String, blah: Bool) // expected-note {{found this candidate}}
+// expected-error @-1 {{macro 'unaryDeclMacro(_:blah:)' requires a definition}}
+
 func testDiags(a: Int, b: Int) {
   // FIXME: Bad diagnostic.
   let s = #stringify<Int, Int>(a + b) // expected-error{{type of expression is ambiguous without more context}}
@@ -89,6 +94,15 @@ func testDiags(a: Int, b: Int) {
 
   overloaded1(a) // okay, calls the function
   #overloaded1(a) // expected-error{{argument type 'Int' does not conform to expected type 'P'}}
+
+//  #unaryDeclMacro("abc") // okay, declaration macro where both exprs and decls are allowed
+//  _ = #unaryDeclMacro("abc") // xpected-error {{no macro named 'unaryDeclMacro'}}
+//  (#unaryDeclMacro("abc"), 3) // xpected-error {{no macro named 'unaryDeclMacro'}}
+
+  struct Foo {
+    #unaryDeclMacro("abc", blah: false) // okay
+    #unaryDeclMacro("abc", blah: false, oh: 2) // expected-error {{no exact matches in reference to macro 'unaryDeclMacro'}}
+  }
 }
 
 func shadow(a: Int, b: Int, stringify: Int) {

--- a/test/Macros/parsing.swift
+++ b/test/Macros/parsing.swift
@@ -15,3 +15,18 @@ protocol Q { associatedtype Assoc }
 
 @expression macro m6 = A // expected-error{{expected '(' for macro parameters or ':' for a value-like macro}}
 // expected-error@-1{{macro must itself be defined by a macro expansion such as '#externalMacro(...)'}}
+
+// expected-error @+2 {{expected '('}}
+// expected-error @+1 {{macro 'm7' must declare its applicable contexts (e.g., '@expression')}}
+@declaration macro m7(_: String) = #externalMacro(module: "A", type: "M4")
+// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm7'; the type must be public and provided via '-load-plugin-library'}}
+// expected-error @+2 {{expected a declaration macro kind ('freestanding' or 'attached')}}
+// expected-error @+1 {{macro 'm8' must declare its applicable contexts (e.g., '@expression')}}
+@declaration(abc) macro m8(_: String) = #externalMacro(module: "A", type: "M4")
+// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm8'; the type must be public and provided via '-load-plugin-library'}}
+@declaration(freestanding) macro m9(_: String) = #externalMacro(module: "A", type: "M4")
+// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm9'; the type must be public and provided via '-load-plugin-library'}}
+
+@expression @declaration(freestanding) @declaration(attached)
+macro m10(_: String) = #externalMacro(module: "A", type: "M4")
+// expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm10'; the type must be public and provided via '-load-plugin-library'}}

--- a/utils/gyb_syntax_support/AttributeKinds.py
+++ b/utils/gyb_syntax_support/AttributeKinds.py
@@ -907,6 +907,11 @@ DECL_MODIFIER_KINDS = [
                         OnMacro,
                         ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIBreakingToRemove,  # noqa: E501
                         code=140),
+
+    DeclAttribute('declaration', 'Declaration',
+                  OnMacro, AllowMultipleAttributes,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIBreakingToRemove,  # noqa: E501
+                  code=141),
 ]
 
 DEPRECATED_MODIFIER_KINDS = [


### PR DESCRIPTION
Add support for freestanding declaration macros.

- Parse `@declaration` attribute.
- Type check and expand `MacroExpansionDecl`.

Known issues:
- Generic macros are not yet handled.
- Expansion does not work when the parent decl context is `BraceStmt`. Need to parse freestanding declaration macro expansions in `BraceStmt` as `MacroExpansionDecl`, and add expanded decls to name lookup.