### PR TITLE
[TaskLocals] Avoid use of `defer` in back deployed functions in the standard library

### DIFF
--- a/stdlib/public/BackDeployConcurrency/TaskCancellation.swift
+++ b/stdlib/public/BackDeployConcurrency/TaskCancellation.swift
@@ -46,9 +46,14 @@ public func withTaskCancellationHandler<T>(
   // unconditionally add the cancellation record to the task.
   // if the task was already cancelled, it will be executed right away.
   let record = _taskAddCancellationHandler(handler: handler)
-  defer { _taskRemoveCancellationHandler(record: record) }
-
-  return try await operation()
+  do {
+    let result = try await operation()
+    _taskRemoveCancellationHandler(record: record)
+    return result
+  } catch {
+    _taskRemoveCancellationHandler(record: record)
+    throw error
+  }
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/stdlib/public/BackDeployConcurrency/TaskLocal.swift
+++ b/stdlib/public/BackDeployConcurrency/TaskLocal.swift
@@ -145,9 +145,14 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)
 
     _taskLocalValuePush(key: key, value: valueDuringOperation)
-    defer { _taskLocalValuePop() }
-
-    return try await operation()
+    do {
+      let result = try await operation()
+      _taskLocalValuePop()
+      return result
+    } catch {
+      _taskLocalValuePop()
+      throw error
+    }
   }
 
   /// Binds the task-local to the specific value for the duration of the

--- a/stdlib/public/Concurrency/TaskCancellation.swift
+++ b/stdlib/public/Concurrency/TaskCancellation.swift
@@ -46,9 +46,14 @@ public func withTaskCancellationHandler<T>(
   // unconditionally add the cancellation record to the task.
   // if the task was already cancelled, it will be executed right away.
   let record = _taskAddCancellationHandler(handler: handler)
-  defer { _taskRemoveCancellationHandler(record: record) }
-
-  return try await operation()
+  do {
+    let result = try await operation()
+    _taskRemoveCancellationHandler(record: record)
+    return result
+  } catch {
+    _taskRemoveCancellationHandler(record: record)
+    throw error
+  }
 }
 
 @available(SwiftStdlib 5.1, *)

--- a/stdlib/public/Concurrency/TaskLocal.swift
+++ b/stdlib/public/Concurrency/TaskLocal.swift
@@ -145,9 +145,14 @@ public final class TaskLocal<Value: Sendable>: Sendable, CustomStringConvertible
     _checkIllegalTaskLocalBindingWithinWithTaskGroup(file: file, line: line)
 
     _taskLocalValuePush(key: key, value: valueDuringOperation)
-    defer { _taskLocalValuePop() }
-
-    return try await operation()
+    do {
+      let result = try await operation()
+      _taskLocalValuePop()
+      return result
+    } catch {
+      _taskLocalValuePop()
+      throw error
+    }
   }
 
   /// Binds the task-local to the specific value for the duration of the


### PR DESCRIPTION
Older versions of the 5.8 compiler have a bug when generating SIL for functions with `@_backDeploy` containing `defer` blocks (https://github.com/apple/swift/pull/62444) and for now we need the standard library interface to be compatible with those older compilers.

Resolves rdar://104045168
