### PR TITLE
Fix async_extended_frame_info_watchos test

### DIFF
--- a/test/IRGen/swift_async_extended_frame_info.swift
+++ b/test/IRGen/swift_async_extended_frame_info.swift
@@ -6,11 +6,17 @@
 // RUN: %target-swift-frontend -disable-availability-checking -swift-async-frame-pointer=never -target x86_64-apple-macosx12 %s -S | %FileCheck  -check-prefix=NEVER %s
 // RUN: %target-swift-frontend -disable-availability-checking -swift-async-frame-pointer=always -target x86_64-apple-macosx11 %s -S | %FileCheck  -check-prefix=ALWAYS %s
 // RUN: %target-swift-frontend -disable-availability-checking -swift-async-frame-pointer=always -target x86_64-apple-macosx12 %s -S | %FileCheck  -check-prefix=ALWAYS %s
+// RUN: %target-swift-frontend -disable-availability-checking -swift-async-frame-pointer=never -target arm64-apple-macos12 %s -S | %FileCheck -check-prefix=NEVER-ARM64 %s
+// RUN: %target-swift-frontend -disable-availability-checking -swift-async-frame-pointer=always -target arm64-apple-macos12 %s -S | %FileCheck -check-prefix=ALWAYS-ARM64 %s
 
 // REQUIRES: OS=macosx
-// REQUIRES: CPU=x86_64
+// REQUIRES: CODEGENERATOR=X86 && CODEGENERATOR=AArch64
+
+@_silgen_name("opaque_function")
+func blarpy()
 
 public func someAsyncFunction() async {
+    blarpy()
 }
 
 // AUTO: s31swift_async_extended_frame_info17someAsyncFunctionyyYaF:
@@ -26,3 +32,11 @@ public func someAsyncFunction() async {
 // AUTO: .weak_reference _swift_async_extendedFramePointerFlags
 // NEVER-NOT: .weak_reference _swift_async_extendedFramePointerFlags
 // ALWAYS-NOT: .weak_reference _swift_async_extendedFramePointerFlags
+
+// NEVER-ARM64: s31swift_async_extended_frame_info17someAsyncFunctionyyYaFTY0
+// NEVER-ARM64-NOT: swift_async_extendedFramePointerFlags
+// NEVER-ARM64-NOT: #0x1000000000000000
+
+// ALWAYS-ARM64: s31swift_async_extended_frame_info17someAsyncFunctionyyYaFTY0
+// ALWAYS-ARM64-NOT: swift_async_extendedFramePointerFlags
+// ALWAYS-ARM64: #0x1000000000000000

--- a/test/IRGen/swift_async_extended_frame_info_watchos.swift
+++ b/test/IRGen/swift_async_extended_frame_info_watchos.swift
@@ -6,10 +6,11 @@
 
 // REQUIRES: OS=watchos
 // REQUIRES: CPU=armv7k || CPU=arm64_32
-// REQUIRES: rdar97790231
 
-public func someAsyncFunction() async {
-}
+@_silgen_name("forward_function")
+func forwardFunction()
+
+public func someAsyncFunction() async { forwardFunction() }
 
 // AUTO: swift_async_extendedFramePointerFlags
 

--- a/test/IRGen/swift_async_extended_frame_info_watchos.swift
+++ b/test/IRGen/swift_async_extended_frame_info_watchos.swift
@@ -4,8 +4,8 @@
 // RUN: %target-swift-frontend -disable-availability-checking -target arm64_32-apple-watchos7  -swift-async-frame-pointer=never %s -S | %FileCheck  -check-prefix=NEVER %s
 // RUN: %target-swift-frontend -disable-availability-checking -target arm64_32-apple-watchos7  -swift-async-frame-pointer=auto %s -S | %FileCheck  -check-prefix=AUTO %s
 
-// REQUIRES: OS=watchos
-// REQUIRES: CPU=armv7k || CPU=arm64_32
+// REQUIRES: OS=watchos || OS=watchossimulator
+// REQUIRES: CODEGENERATOR=AArch64
 
 @_silgen_name("forward_function")
 func forwardFunction()


### PR DESCRIPTION
The optimizer got smarter and stopped emitting a stack frame for the empty `someAsyncFunction`, so the test started failing. Adding an opaque function call to the function body forces the function to get set up properly, so the test starts passing again.

Fixes rdar://97790231