### PR TITLE
[SILOptimizer] NFC: Disable moveonly tests failing in CI (rdar://1041…

### DIFF
--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -1,5 +1,9 @@
 // RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-move-only -enable-sil-verify-all %s | %FileCheck %s
 
+// rdar://104107922
+// REQUIRES: rdar104107922
+
+
 sil_stage raw
 
 import Swift

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-emit-sil -verify -enable-experimental-move-only %s
 
+// rdar://104107922
+// REQUIRES: rdar104107922
+
 //////////////////
 // Declarations //
 //////////////////

--- a/test/SILOptimizer/moveonly_deinits.swift
+++ b/test/SILOptimizer/moveonly_deinits.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-frontend -enable-experimental-move-only -verify -emit-sil %s
 
+// rdar://104107922
+// REQUIRES: rdar104107922
+
 class Klass {}
 
 var globalMoveOnlyStruct = MoveOnlyStruct()

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-emit-sil -verify -enable-experimental-move-only %s
 
+// rdar://104107922
+// REQUIRES: rdar104107922
+
 //////////////////
 // Declarations //
 //////////////////


### PR DESCRIPTION
…07922)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
