### PR TITLE
Demangling: add a workaround for MSVC ICE

### DIFF
--- a/include/swift/Demangling/TypeLookupError.h
+++ b/include/swift/Demangling/TypeLookupError.h
@@ -177,7 +177,7 @@ public:
       Value = TypeLookupError("unknown error");
   }
 
-  TypeLookupErrorOr(const TypeLookupError &te) : Value(te) {}
+  TypeLookupErrorOr(TypeLookupError &te) : Value(te) {}
 
   T getType() {
     if (auto *ptr = Value.template dyn_cast<T>())

--- a/include/swift/Demangling/TypeLookupError.h
+++ b/include/swift/Demangling/TypeLookupError.h
@@ -177,7 +177,7 @@ public:
       Value = TypeLookupError("unknown error");
   }
 
-  TypeLookupErrorOr(TypeLookupError &te) : Value(te) {}
+  TypeLookupErrorOr(TypeLookupError &&te) : Value(te) {}
 
   T getType() {
     if (auto *ptr = Value.template dyn_cast<T>())


### PR DESCRIPTION
The MSVC 2019 compiler seems to trip over an ICE with the implicit conversion from `const TypeLookupError &` to `TypeLookpError &&`.  This allows us to make further progress.