### PR TITLE
Fix a semantic error when the new Swift parser is unavailable

### DIFF
--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -585,7 +585,7 @@ bool swift::expandFreestandingDeclarationMacro(
     break;
 #else
     med->diagnose(diag::macro_unsupported);
-    return nullptr;
+    return false;
 #endif
   }
   }


### PR DESCRIPTION
This broke Windows CI