### PR TITLE
Sema/TypeCheckMacros: fix ` cannot convert from 'nullptr' to 'bool'`

### DIFF
--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -585,7 +585,7 @@ bool swift::expandFreestandingDeclarationMacro(
     break;
 #else
     med->diagnose(diag::macro_unsupported);
-    return nullptr;
+    return false;
 #endif
   }
   }


### PR DESCRIPTION
This causes a regression in the Windows build, which doesn't have `SWIFT_SWIFT_PARSER` enabled.
