### PR TITLE
[5.8][BuilderTransform] Make sure that synthesized `if` elements have corr…

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1275,7 +1275,7 @@ protected:
         // The operand should have optional type if we had optional results,
         // so we just need to call `buildIf` now, since we're at the top level.
         if (isOptional && isTopLevel(anchor)) {
-          builderCall = buildCallIfWanted(ifStmt->getEndLoc(),
+          builderCall = buildCallIfWanted(ifStmt->getThenStmt()->getStartLoc(),
                                           builder.getBuildOptionalId(),
                                           builderCall, /*argLabels=*/{});
         }
@@ -1304,7 +1304,7 @@ protected:
             /*argLabels=*/{}));
       }
 
-      auto *ifVarRef = builder.buildVarRef(ifVar.get(), ifStmt->getEndLoc());
+      auto *ifVarRef = builder.buildVarRef(ifVar.get(), ifStmt->getStartLoc());
       doBody.push_back(TypeJoinExpr::create(ctx, ifVarRef, buildEitherCalls));
     }
 

--- a/test/SourceKit/Sema/issue62848.swift
+++ b/test/SourceKit/Sema/issue62848.swift
@@ -1,0 +1,23 @@
+// RUN: %sourcekitd-test -req=collect-type %s -- %s
+
+struct Rectangle {
+  init() {}
+}
+
+@resultBuilder public struct WiewBuilder {
+  public static func buildBlock<Content>(_ content: Content) -> Content {
+    return content
+  }
+  public static func buildIf<Content>(_ content: Content?) -> Content? {
+    return content
+  }
+}
+
+public struct AStack<Content> {
+  init(@WiewBuilder content: () -> Content) {}
+}
+
+func foo() {
+  AStack {
+    if true {
+      Rectangle()


### PR DESCRIPTION
…ect locations

Cherry-pick of https://github.com/apple/swift/pull/62950

---

Placeholder variable that represents result of `if` should
be placed at the beginning of the statement, same goes
for `Optional(.some(...))` that wraps the expression in "then" branch.

Resolves: https://github.com/apple/swift/issues/62848 

(cherry picked from commit 945f35f7cac790f0b377117f01a644c4c1c4cb98)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
