### PR TITLE
build-script: Check the existence of Clang+Swift compilers when using a custom toolchain

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1658,12 +1658,20 @@ for host in "${ALL_HOSTS[@]}"; do
 
     if [[ "${NATIVE_CLANG_TOOLS_PATH}" ]] ; then
         CLANG_BIN="${NATIVE_CLANG_TOOLS_PATH}"
+        if [[ ! -f "${CLANG_BIN}/clang" ]] ; then
+            echo "error: clang does not exist at the specified native tools path: ${CLANG_BIN}/clang"
+            exit 1
+        fi
     else
         CLANG_BIN="$(build_directory_bin ${LOCAL_HOST} llvm)"
     fi
 
     if [[ "${NATIVE_SWIFT_TOOLS_PATH}" ]] ; then
         SWIFTC_BIN="${NATIVE_SWIFT_TOOLS_PATH}/swiftc"
+        if [[ ! -f "${SWIFTC_BIN}" ]] ; then
+            echo "error: swiftc does not exist at the specified native tools path: ${SWIFTC_BIN}"
+            exit 1
+        fi
     else
         SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
     fi


### PR DESCRIPTION
When building a preset using build-script that uses a custom toolchain path (e.g. the "freestanding" presets), and the toolchain path is wrong, you currently get a late mysterious CMake configuration error. Let's fix that and instead error out early with a clear message.

rdar://104132083