### PR TITLE
runtime: export `_swift_willThrow`

### DIFF
--- a/stdlib/public/runtime/ErrorObjectCommon.cpp
+++ b/stdlib/public/runtime/ErrorObjectCommon.cpp
@@ -24,8 +24,9 @@
 
 using namespace swift;
 
-SWIFT_RUNTIME_EXPORT
-std::atomic<void (*)(SwiftError *error)> swift::_swift_willThrow;
+namespace swift {
+extern "C" std::atomic<void (*)(SwiftError *error)> _swift_willThrow;
+}
 
 void swift::_swift_setWillThrowHandler(void (* handler)(SwiftError *error)) {
   _swift_willThrow.store(handler, std::memory_order_release);

--- a/stdlib/public/runtime/ErrorObjectCommon.cpp
+++ b/stdlib/public/runtime/ErrorObjectCommon.cpp
@@ -24,6 +24,7 @@
 
 using namespace swift;
 
+SWIFT_RUNTIME_EXPORT
 std::atomic<void (*)(SwiftError *error)> swift::_swift_willThrow;
 
 void swift::_swift_setWillThrowHandler(void (* handler)(SwiftError *error)) {


### PR DESCRIPTION
`_swift_willThrow` is meant as a debugging hook and is a symbol that is meant to be exported.  This will not be exported currently on Windows as it is not attributed, and the default visibility is hidden.  Adjust this to make it available on Windows.

Thanks to @grynspan for identifying this issue!