### PR TITLE
Fix compiler warnings.

### DIFF
--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -32,6 +32,7 @@ void SourceManager::verifyAllBuffers() const {
     arbitraryTotal += buffer->getBufferStart()[0];
     arbitraryTotal += buffer->getBufferEnd()[-1];
   }
+  (void)arbitraryTotal;
 }
 
 SourceLoc SourceManager::getIDEInspectionTargetLoc() const {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -162,12 +162,14 @@ extern "C" void parseTopLevelSwift(const char *buffer,
                                    void *outputContext,
                                    void (*)(void *, void *));
 
+#if SWIFT_SWIFT_PARSER
 static void appendToVector(void *declPtr, void *vecPtr) {
   auto vec = static_cast<SmallVectorImpl<ASTNode> *>(vecPtr);
   auto decl = static_cast<Decl *>(declPtr);
 
   vec->push_back(decl);
 }
+#endif
 
 /// Parse a source file.
 extern "C" void *swift_ASTGen_parseSourceFile(const char *buffer,

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -79,6 +79,7 @@ static std::string mangledNameForTypeMetadataAccessor(
   return mangleResult.result();
 }
 
+#if SWIFT_SWIFT_PARSER
 /// Look for macro's type metadata given its external module and type name.
 static void const *lookupMacroTypeMetadataByExternalName(
     ASTContext &ctx, StringRef moduleName, StringRef typeName) {
@@ -106,6 +107,7 @@ static void const *lookupMacroTypeMetadataByExternalName(
   auto accessor = reinterpret_cast<MetadataAccessFunc*>(accessorAddr);
   return accessor(MetadataRequest(MetadataState::Complete));
 }
+#endif
 
 /// Handle the "A.B" spelling of an external macro definition, from early
 /// pitches of the expression-macros proposal, which is also used as the syntax


### PR DESCRIPTION
main branch shouldn't have any warnings. It messes up my workflow.

Two static symbol declarations are only used under SWIFT_SWIFT_PARSER.