### PR TITLE
[Serialization] Misc prep for the deserialization safety feature

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -356,10 +356,12 @@ namespace swift {
     /// new enough?
     bool EnableTargetOSChecking = true;
 
-    /// Whether to attempt to recover from missing cross-references and other
+    /// Whether to attempt to recover from missing cross-references,
+    /// differences in APIs between language versions, and other
     /// errors when deserializing from a binary swiftmodule file.
     ///
-    /// This flag should only be used in testing.
+    /// This feature should only be disabled for testing as regular builds
+    /// rely heavily on it.
     bool EnableDeserializationRecovery = true;
 
     /// Enable early skipping deserialization of decls that are marked as

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -7088,7 +7088,8 @@ static llvm::Error consumeErrorIfXRefNonLoadedModule(llvm::Error &&error) {
     // Missing module errors are most likely caused by an
     // implementation-only import hiding types and decls.
     // rdar://problem/60291019
-    if (error.isA<XRefNonLoadedModuleError>()) {
+    if (error.isA<XRefNonLoadedModuleError>() ||
+        error.isA<UnsafeDeserializationError>()) {
       consumeError(std::move(error));
       return llvm::Error::success();
     }
@@ -7100,7 +7101,8 @@ static llvm::Error consumeErrorIfXRefNonLoadedModule(llvm::Error &&error) {
       auto errorInfo = takeErrorInfo(std::move(error));
       auto *TE = static_cast<TypeError*>(errorInfo.get());
 
-      if (TE->underlyingReasonIsA<XRefNonLoadedModuleError>()) {
+      if (TE->underlyingReasonIsA<XRefNonLoadedModuleError>() ||
+          TE->underlyingReasonIsA<UnsafeDeserializationError>()) {
         consumeError(std::move(errorInfo));
         return llvm::Error::success();
       }
@@ -7436,6 +7438,7 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
       // errors - we're just doing a best effort to create the
       // module in that case.
       if (witnessSubstitutions.errorIsA<XRefNonLoadedModuleError>() ||
+          witnessSubstitutions.errorIsA<UnsafeDeserializationError>() ||
           allowCompilerErrors()) {
         consumeError(witnessSubstitutions.takeError());
         isOpaque = true;

--- a/test/Generics/validate_stdlib_generic_signatures.swift
+++ b/test/Generics/validate_stdlib_generic_signatures.swift
@@ -1,4 +1,4 @@
 // Verifies that all of the generic signatures in the standard library are
 // minimal and canonical.
 
-// RUN: %target-typecheck-verify-swift -verify-generic-signatures Swift
+// RUN: %target-typecheck-verify-swift -verify-generic-signatures Swift -disable-deserialization-safety

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 //
 // RUN: %target-clang %S/Inputs/Mirror/Mirror.mm -c -o %t/Mirror.mm.o -g
-// RUN: %target-build-swift -parse-stdlib -Xfrontend -disable-access-control -module-name a -I %S/Inputs/Mirror/ -Xlinker %t/Mirror.mm.o %s -o %t.out
+// RUN: %target-build-swift -parse-stdlib -Xfrontend -disable-access-control -module-name a -I %S/Inputs/Mirror/ -Xlinker %t/Mirror.mm.o %s -o %t.out -Xfrontend -disable-deserialization-safety
 // RUN: %target-codesign %t.out
 // RUN: %target-run %t.out
 // REQUIRES: executable_test


### PR DESCRIPTION
Deserialization safety is a WIP feature to prevent reading internal details, it acts earlier than recovery on issues like XRef errors caused by implementation-only imports.

This is a followup to https://github.com/apple/swift/pull/62886 with general fixes to prepare for enabling the feature by default:
- Accept the `UnsafeDeserializationError` error where we already accept `XRefNonLoadedModuleError` as the new error should always hide the previous one when the safety feature is enabled.
- Update tests expecting to see non-public information to disable the safety feature that would otherwise hide non-public decls.
- Update the doc on `EnableDeserializationRecovery`.