### PR TITLE
[ClangImporter] Swift Implemented ObjC Forward Declarations

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -640,6 +640,12 @@ public:
   void lookupValue(DeclName Name, NLKind LookupKind,
                    SmallVectorImpl<ValueDecl*> &Result) const;
 
+  /// Look up a value just as "ModuleDecl::lookupValue` does, but provide the
+  /// Swift context from which the lookup is made.
+  void lookupValueWithContext(DeclName Name, NLKind LookupKind,
+                              SmallVectorImpl<ValueDecl *> &Result,
+                              const DeclContext *Context) const;
+
   /// Look up a local type declaration by its mangled name.
   ///
   /// This does a simple local lookup, not recursively looking through imports.

--- a/include/swift/ClangImporter/ClangModule.h
+++ b/include/swift/ClangImporter/ClangModule.h
@@ -68,6 +68,10 @@ public:
   virtual void lookupValue(DeclName name, NLKind lookupKind,
                            SmallVectorImpl<ValueDecl*> &results) const override;
 
+  void lookupValueWithContext(DeclName name, NLKind lookupKind,
+                              SmallVectorImpl<ValueDecl *> &results,
+                              const DeclContext *context) const;
+
   virtual TypeDecl *
   lookupNestedType(Identifier name,
                    const NominalTypeDecl *baseType) const override;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3286,6 +3286,12 @@ void ClangModuleUnit::getDisplayDecls(SmallVectorImpl<Decl*> &results, bool recu
 
 void ClangModuleUnit::lookupValue(DeclName name, NLKind lookupKind,
                                   SmallVectorImpl<ValueDecl*> &results) const {
+  lookupValueWithContext(name, lookupKind, results, nullptr);
+}
+
+void ClangModuleUnit::lookupValueWithContext(
+    DeclName name, NLKind lookupKind, SmallVectorImpl<ValueDecl *> &results,
+    const DeclContext *context) const {
   // FIXME: Ignore submodules, which are empty for now.
   if (clangModule && clangModule->isSubModule())
     return;
@@ -3305,7 +3311,13 @@ void ClangModuleUnit::lookupValue(DeclName name, NLKind lookupKind,
   // Find the corresponding lookup table.
   if (auto lookupTable = owner.findLookupTable(clangModule)) {
     // Search it.
-    owner.lookupValue(*lookupTable, name, *consumer);
+    if (context) {
+      owner.setImportingContext(*context);
+      owner.lookupValue(*lookupTable, name, *consumer);
+      owner.resetImportingContext();
+    } else {
+      owner.lookupValue(*lookupTable, name, *consumer);
+    }
   }
 }
 

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -528,6 +528,10 @@ private:
   /// used when parsing the attribute text.
   llvm::SmallDenseMap<ModuleDecl *, SourceFile *> ClangSwiftAttrSourceFiles;
 
+  /// If set, the Swift DeclContext from which the current
+  /// import request was triggered.
+  llvm::Optional<const swift::DeclContext *> ImportingContext;
+
 public:
   /// The Swift lookup table for the bridging header.
   std::unique_ptr<SwiftLookupTable> BridgingHeaderLookupTable;
@@ -585,6 +589,16 @@ public:
 
   clang::CompilerInstance *getClangInstance() {
     return Instance.get();
+  }
+
+  void setImportingContext(const DeclContext &importingContext) {
+    ImportingContext = &importingContext;
+  }
+
+  void resetImportingContext() { ImportingContext = None; }
+
+  llvm::Optional<const DeclContext *> getImportingContext() {
+    return ImportingContext;
   }
 
 private:

--- a/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/complete-swift-types.swift
+++ b/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/complete-swift-types.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+@objc public class Foo : NSObject {
+    @objc public func sayHello() {
+        print("Hello from Foo.sayHello!")
+    }
+}
+
+@objc(Baz) public class Bar : NSObject {
+    @objc public func sayHello() {
+        print("Hello from Bar.sayHello!")
+    }
+}

--- a/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/module.modulemap
+++ b/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/module.modulemap
@@ -1,0 +1,3 @@
+module ObjCLibraryForwardDeclaringCompleteSwiftTypes {
+    header "objc-library-forward-declaring-complete-swift-types.h"
+}

--- a/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/objc-library-forward-declaring-complete-swift-types.h
+++ b/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/objc-library-forward-declaring-complete-swift-types.h
@@ -1,0 +1,8 @@
+@class Foo;
+@class Baz;
+
+void takeAFoo(Foo *foo);
+Foo *returnAFoo();
+
+void takeABaz(Baz *baz);
+Baz *returnABaz();

--- a/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/objc-library-forward-declaring-complete-swift-types.m
+++ b/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/objc-library-forward-declaring-complete-swift-types.m
@@ -1,0 +1,18 @@
+#import "objc-library-forward-declaring-complete-swift-types.h"
+#import "CompleteSwiftTypes-Swift.h"
+
+void takeAFoo(Foo *foo) { [foo sayHello]; }
+
+Foo *returnAFoo() {
+  Foo *result = [[Foo alloc] init];
+  [result sayHello];
+  return result;
+}
+
+void takeABaz(Baz *baz) { [baz sayHello]; }
+
+Baz *returnABaz() {
+  Baz *result = [[Baz alloc] init];
+  [result sayHello];
+  return result;
+}

--- a/test/ClangImporter/incomplete_objc_types_swift_definition_imported.swift
+++ b/test/ClangImporter/incomplete_objc_types_swift_definition_imported.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -parse-as-library %S/Inputs/custom-modules/IncompleteTypes/complete-swift-types.swift -emit-module -emit-module-path %t/CompleteSwiftTypes.swiftmodule -emit-objc-header -emit-objc-header-path %t/CompleteSwiftTypes-Swift.h -emit-library -o %t/libCompleteSwiftTypes.dylib
+// RUN: %target-clang -framework Foundation -dynamiclib %S/Inputs/custom-modules/IncompleteTypes/objc-library-forward-declaring-complete-swift-types.m -I %t -L %t -lCompleteSwiftTypes -o %t/libObjCLibraryForwardDeclaringCompleteSwiftTypes.dylib
+// RUN: %target-build-swift -Xfrontend -enable-objc-interop %s -I %S/Inputs/custom-modules/IncompleteTypes -I %t -L %t -lCompleteSwiftTypes -lObjCLibraryForwardDeclaringCompleteSwiftTypes -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import CompleteSwiftTypes
+import ObjCLibraryForwardDeclaringCompleteSwiftTypes
+
+// Swift initializers
+let foo = Foo()
+let bar = Bar()
+
+// Imported from Objective-C
+// CHECK: Hello from Foo.sayHello!
+takeAFoo(foo)
+// CHECK: Hello from Foo.sayHello!
+let foo2 = returnAFoo()
+
+// CHECK: Hello from Bar.sayHello!
+takeABaz(bar)
+// CHECK: Hello from Bar.sayHello!
+let bar2 = returnABaz()
+


### PR DESCRIPTION
Objective-C libraries that wrap Swift types will often forward declare these types in public headers. Prior to this patch, if a Swift client consumed this Obejctive-C header, the forward declarations and dependent declarations will not be imported, despite the client importing the defining Swift module. The same is not true for Clang modules, which was confusing behavior.

This patch allows the ClangImporter to check if a matching @objc Swift declarations is available from the importing Swift context when encountering an incomplete ObjC interface or protocol. If such a Swift declaration is found, it is simply returned.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
