### PR TITLE
Organize UnitTestRunner.cpp before making it bigger.

### DIFF
--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -160,8 +160,130 @@ class UnitTestRunner : public SILFunctionTransform {
 };
 
 //===----------------------------------------------------------------------===//
-// MARK: Unit Test Subclasses                                                 {{
+// MARK: General Unit Tests
 //===----------------------------------------------------------------------===//
+
+// Arguments: NONE
+// Dumps:
+// - the function
+struct DumpFunction : UnitTest {
+  DumpFunction(UnitTestRunner *pass) : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override { getFunction()->dump(); }
+};
+
+// Arguments: NONE
+// Dumps: the index of the self argument of the current function
+struct FunctionGetSelfArgumentIndex : UnitTest {
+  FunctionGetSelfArgumentIndex(UnitTestRunner *pass) : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    auto index =
+        SILFunction_getSelfArgumentIndex(BridgedFunction{getFunction()});
+    llvm::errs() << "self argument index = " << index << "\n";
+  }
+};
+
+// Arguments:
+// - string: list of characters, each of which specifies subsequent arguments
+//           - A: (block) argument
+//           - F: function
+//           - B: block
+//           - I: instruction
+//           - V: value
+//           - O: operand
+//           - b: boolean
+//           - u: unsigned
+//           - s: string
+// - ...
+// - an argument of the type specified in the initial string
+// - ...
+// Dumps:
+// - for each argument (after the initial string)
+//   - its type
+//   - something to identify the instance (mostly this means calling dump)
+struct TestSpecificationTest : UnitTest {
+  TestSpecificationTest(UnitTestRunner *pass) : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    auto expectedFields = arguments.takeString();
+    for (auto expectedField : expectedFields) {
+      switch (expectedField) {
+      case 'A': {
+        auto *argument = arguments.takeBlockArgument();
+        llvm::errs() << "argument:\n";
+        argument->dump();
+        break;
+      }
+      case 'F': {
+        auto *function = arguments.takeFunction();
+        llvm::errs() << "function: " << function->getName() << "\n";
+        break;
+      }
+      case 'B': {
+        auto *block = arguments.takeBlock();
+        llvm::errs() << "block:\n";
+        block->dump();
+        break;
+      }
+      case 'I': {
+        auto *instruction = arguments.takeInstruction();
+        llvm::errs() << "instruction: ";
+        instruction->dump();
+        break;
+      }
+      case 'V': {
+        auto value = arguments.takeValue();
+        llvm::errs() << "value: ";
+        value->dump();
+        break;
+      }
+      case 'O': {
+        auto *operand = arguments.takeOperand();
+        llvm::errs() << "operand: ";
+        operand->print(llvm::errs());
+        break;
+      }
+      case 'u': {
+        auto u = arguments.takeUInt();
+        llvm::errs() << "uint: " << u << "\n";
+        break;
+      }
+      case 'b': {
+        auto b = arguments.takeBool();
+        llvm::errs() << "bool: " << b << "\n";
+        break;
+      }
+      case 's': {
+        auto s = arguments.takeString();
+        llvm::errs() << "string: " << s << "\n";
+        break;
+      }
+      default:
+        llvm_unreachable("unknown field type was expected?!");
+      }
+    }
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// MARK: OSSA Lifetime Unit Tests
+//===----------------------------------------------------------------------===//
+
+// Arguments:
+// - variadic list of - instruction: a last user
+// Dumps:
+// - the insertion points
+struct PrunedLivenessBoundaryWithListOfLastUsersInsertionPointsTest : UnitTest {
+  PrunedLivenessBoundaryWithListOfLastUsersInsertionPointsTest(
+      UnitTestRunner *pass)
+      : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    PrunedLivenessBoundary boundary;
+    while (arguments.hasUntaken()) {
+      boundary.lastUsers.push_back(arguments.takeInstruction());
+    }
+    boundary.visitInsertionPoints(
+        [](SILBasicBlock::iterator point) { point->dump(); });
+  }
+};
 
 // Arguments:
 // - bool: pruneDebug
@@ -186,25 +308,6 @@ struct CanonicalizeOSSALifetimeTest : UnitTest {
   }
 };
 
-// Arguments: NONE
-// Dumps:
-// - the function
-struct DumpFunction : UnitTest {
-  DumpFunction(UnitTestRunner *pass) : UnitTest(pass) {}
-  void invoke(Arguments &arguments) override { getFunction()->dump(); }
-};
-
-// Arguments: NONE
-// Dumps: the index of the self argument of the current function
-struct FunctionGetSelfArgumentIndex : UnitTest {
-  FunctionGetSelfArgumentIndex(UnitTestRunner *pass) : UnitTest(pass) {}
-  void invoke(Arguments &arguments) override {
-    auto index =
-        SILFunction_getSelfArgumentIndex(BridgedFunction{getFunction()});
-    llvm::errs() << "self argument index = " << index << "\n";
-  }
-};
-
 // Arguments:
 // - instruction
 // Dumps:
@@ -219,24 +322,6 @@ struct IsDeinitBarrierTest : UnitTest {
     instruction->dump();
     auto *boolString = isBarrier ? "true" : "false";
     llvm::errs() << boolString << "\n";
-  }
-};
-
-// Arguments:
-// - variadic list of - instruction: a last user
-// Dumps:
-// - the insertion points
-struct PrunedLivenessBoundaryWithListOfLastUsersInsertionPointsTest : UnitTest {
-  PrunedLivenessBoundaryWithListOfLastUsersInsertionPointsTest(
-      UnitTestRunner *pass)
-      : UnitTest(pass) {}
-  void invoke(Arguments &arguments) override {
-    PrunedLivenessBoundary boundary;
-    while (arguments.hasUntaken()) {
-      boundary.lastUsers.push_back(arguments.takeInstruction());
-    }
-    boundary.visitInsertionPoints(
-        [](SILBasicBlock::iterator point) { point->dump(); });
   }
 };
 
@@ -269,6 +354,61 @@ struct ShrinkBorrowScopeTest : UnitTest {
     assert(expected == shrunk && "didn't shrink expectedly!?");
   }
 };
+
+// Arguments:
+// - SILValue: phi
+// Dumps:
+// - function
+// - the adjacent phis
+struct VisitAdjacentReborrowsOfPhiTest : UnitTest {
+  VisitAdjacentReborrowsOfPhiTest(UnitTestRunner *pass) : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    getFunction()->dump();
+    visitAdjacentReborrowsOfPhi(cast<SILPhiArgument>(arguments.takeValue()),
+                                [](auto *argument) -> bool {
+                                  argument->dump();
+                                  return true;
+                                });
+  }
+};
+
+// Arguments:
+// - SILValue: value
+// Dumps:
+// - function
+// - the enclosing defs
+struct FindEnclosingDefsTest : UnitTest {
+  FindEnclosingDefsTest(UnitTestRunner *pass) : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    getFunction()->dump();
+    llvm::dbgs() << "Enclosing Defs:\n";
+    visitEnclosingDefs(arguments.takeValue(), [](SILValue def) {
+      def->dump();
+      return true;
+    });
+  }
+};
+
+// Arguments:
+// - SILValue: value
+// Dumps:
+// - function
+// - the borrow introducers
+struct FindBorrowIntroducers : UnitTest {
+  FindBorrowIntroducers(UnitTestRunner *pass) : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    getFunction()->dump();
+    llvm::dbgs() << "Introducers:\n";
+    visitBorrowIntroducers(arguments.takeValue(), [](SILValue def) {
+      def->dump();
+      return true;
+    });
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// MARK: SimplifyCFG Unit Tests
+//===----------------------------------------------------------------------===//
 
 struct SimplifyCFGSimplifyArgument : UnitTest {
   SimplifyCFGSimplifyArgument(UnitTestRunner *pass) : UnitTest(pass) {}
@@ -372,143 +512,10 @@ struct SimplifyCFGTryJumpThreading : UnitTest {
   }
 };
 
-// Arguments:
-// - string: list of characters, each of which specifies subsequent arguments
-//           - A: (block) argument
-//           - F: function
-//           - B: block
-//           - I: instruction
-//           - V: value
-//           - O: operand
-//           - b: boolean
-//           - u: unsigned
-//           - s: string
-// - ...
-// - an argument of the type specified in the initial string
-// - ...
-// Dumps:
-// - for each argument (after the initial string)
-//   - its type
-//   - something to identify the instance (mostly this means calling dump)
-struct TestSpecificationTest : UnitTest {
-  TestSpecificationTest(UnitTestRunner *pass) : UnitTest(pass) {}
-  void invoke(Arguments &arguments) override {
-    auto expectedFields = arguments.takeString();
-    for (auto expectedField : expectedFields) {
-      switch (expectedField) {
-      case 'A': {
-        auto *argument = arguments.takeBlockArgument();
-        llvm::errs() << "argument:\n";
-        argument->dump();
-        break;
-      }
-      case 'F': {
-        auto *function = arguments.takeFunction();
-        llvm::errs() << "function: " << function->getName() << "\n";
-        break;
-      }
-      case 'B': {
-        auto *block = arguments.takeBlock();
-        llvm::errs() << "block:\n";
-        block->dump();
-        break;
-      }
-      case 'I': {
-        auto *instruction = arguments.takeInstruction();
-        llvm::errs() << "instruction: ";
-        instruction->dump();
-        break;
-      }
-      case 'V': {
-        auto value = arguments.takeValue();
-        llvm::errs() << "value: ";
-        value->dump();
-        break;
-      }
-      case 'O': {
-        auto *operand = arguments.takeOperand();
-        llvm::errs() << "operand: ";
-        operand->print(llvm::errs());
-        break;
-      }
-      case 'u': {
-        auto u = arguments.takeUInt();
-        llvm::errs() << "uint: " << u << "\n";
-        break;
-      }
-      case 'b': {
-        auto b = arguments.takeBool();
-        llvm::errs() << "bool: " << b << "\n";
-        break;
-      }
-      case 's': {
-        auto s = arguments.takeString();
-        llvm::errs() << "string: " << s << "\n";
-        break;
-      }
-      default:
-        llvm_unreachable("unknown field type was expected?!");
-      }
-    }
-  }
-};
-
-// Arguments:
-// - SILValue: phi
-// Dumps:
-// - function
-// - the adjacent phis
-struct VisitAdjacentReborrowsOfPhiTest : UnitTest {
-  VisitAdjacentReborrowsOfPhiTest(UnitTestRunner *pass) : UnitTest(pass) {}
-  void invoke(Arguments &arguments) override {
-    getFunction()->dump();
-    visitAdjacentReborrowsOfPhi(cast<SILPhiArgument>(arguments.takeValue()),
-                                [](auto *argument) -> bool {
-                                  argument->dump();
-                                  return true;
-                                });
-  }
-};
-
-// Arguments:
-// - SILValue: value
-// Dumps:
-// - function
-// - the enclosing defs
-struct FindEnclosingDefsTest : UnitTest {
-  FindEnclosingDefsTest(UnitTestRunner *pass) : UnitTest(pass) {}
-  void invoke(Arguments &arguments) override {
-    getFunction()->dump();
-    llvm::dbgs() << "Enclosing Defs:\n";
-    visitEnclosingDefs(arguments.takeValue(), [](SILValue def) {
-      def->dump();
-      return true;
-    });
-  }
-};
-
-// Arguments:
-// - SILValue: value
-// Dumps:
-// - function
-// - the borrow introducers
-struct FindBorrowIntroducers : UnitTest {
-  FindBorrowIntroducers(UnitTestRunner *pass) : UnitTest(pass) {}
-  void invoke(Arguments &arguments) override {
-    getFunction()->dump();
-    llvm::dbgs() << "Introducers:\n";
-    visitBorrowIntroducers(arguments.takeValue(), [](SILValue def) {
-      def->dump();
-      return true;
-    });
-  }
-};
-
 /// [new_tests] Add the new UnitTest subclass above this line. 
-///             Please sort alphabetically by to help reduce merge conflicts.
 
 //===----------------------------------------------------------------------===//
-// MARK: Unit Test Subclasses                                                 }}
+// MARK: Unit Test Registration
 //===----------------------------------------------------------------------===//
 
 template <typename Doit>
@@ -520,8 +527,11 @@ void UnitTestRunner::withTest(StringRef name, Doit doit) {
     return;                                                                    \
   }
 
+    // Alphabetical mapping from string to unit test subclass.
     ADD_UNIT_TEST_SUBCLASS("canonicalize-ossa-lifetime", CanonicalizeOSSALifetimeTest)
     ADD_UNIT_TEST_SUBCLASS("dump-function", DumpFunction)
+    ADD_UNIT_TEST_SUBCLASS("find-borrow-introducers", FindBorrowIntroducers)
+    ADD_UNIT_TEST_SUBCLASS("find-enclosing-defs", FindEnclosingDefsTest)
     ADD_UNIT_TEST_SUBCLASS("function-get-self-argument-index", FunctionGetSelfArgumentIndex)
     ADD_UNIT_TEST_SUBCLASS("is-deinit-barrier", IsDeinitBarrierTest)
     ADD_UNIT_TEST_SUBCLASS("pruned-liveness-boundary-with-list-of-last-users-insertion-points", PrunedLivenessBoundaryWithListOfLastUsersInsertionPointsTest)
@@ -550,8 +560,6 @@ void UnitTestRunner::withTest(StringRef name, Doit doit) {
 
     ADD_UNIT_TEST_SUBCLASS("test-specification-parsing", TestSpecificationTest)
     ADD_UNIT_TEST_SUBCLASS("visit-adjacent-reborrows-of-phi", VisitAdjacentReborrowsOfPhiTest)
-    ADD_UNIT_TEST_SUBCLASS("find-enclosing-defs", FindEnclosingDefsTest)
-    ADD_UNIT_TEST_SUBCLASS("find-borrow-introducers", FindBorrowIntroducers)
     /// [new_tests] Add the new mapping from string to subclass above this line.
     ///             Please sort alphabetically by name to help reduce merge
     ///             conflicts.


### PR DESCRIPTION
Create a few sections for unit test. Ideally these would be in separate files using a static global registry. For now, at least make it possible to survey the available tests without reading them all every time.

I'm preparing to replace utility passes with more unit tests, but it's too hard to see what unit tests are related.