### PR TITLE
stdlib: excise the FP16 support routines on x64

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -780,6 +780,16 @@ importer::addCommonInvocationArguments(
     invocationArgStrs.push_back("-mcx16");
   }
 
+  if (triple.isX86()) {
+    // Enable the FC16/CVT16 extensions which provide half prevision floating
+    // point support on x86_64.  This bumps the minimum requirement of the CPU
+    // to Ivy Bridge, however, Windows 10 (at least as of 1709) requires
+    // ~Broadwell.  At this point, the complexity of supporting an older release
+    // no longer is justified.  For uniformity, bump the minimum x86 CPU on all
+    // the targets.
+    invocationArgStrs.push_back("-mf16c");
+  }
+
   if (!importerOpts.Optimization.empty()) {
     invocationArgStrs.push_back(importerOpts.Optimization);
   }

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -288,6 +288,18 @@ function(_add_target_variant_c_compile_flags)
     endif()
   endif()
 
+  # Avoid the need for the FP16 truncation and extension routines from
+  # compiler-rt by assuming that we have hardware capable of performing
+  # half-precision floating point conversions.  This effectively pins the
+  # minimum CPU requirements to Ivy Bridge (~2013).
+  if(CFLAGS_ARCH STREQUAL x86_64 OR CFLAGS_ARCH STREQUAL i686)
+    if(SWIFT_COMPILER_IS_MSVC_LIKE)
+      list(APPEND result /clang:-mf16c)
+    else()
+      list(APPEND result -mf16c)
+    endif()
+  endif()
+
   if(CFLAGS_ENABLE_ASSERTIONS)
     list(APPEND result "-UNDEBUG")
   else()

--- a/stdlib/public/runtime/Float16Support.cpp
+++ b/stdlib/public/runtime/Float16Support.cpp
@@ -35,6 +35,8 @@
 
 #include "swift/shims/Visibility.h"
 
+#include <stdint.h>
+
 static unsigned toEncoding(float f) {
   unsigned e;
   static_assert(sizeof e == sizeof f, "float and int must have the same size");
@@ -165,7 +167,7 @@ SWIFT_RUNTIME_EXPORT unsigned short __truncdfhf2(double d) {
 #if (defined(__i386__) || defined(__x86_64__)) &&                               \
     !(defined(__ANDROID__) || defined(__APPLE__) || defined(_WIN32))
 
-SWIFT_RUNTIME_EXPORT long double __extendhfxf2(_Float16 h) {
+SWIFT_RUNTIME_EXPORT long double __extendhfxf2(uint16_t h) {
   __uint128_t concat(uint64_t hi, uint64_t lo) {
     return (((__uint128_t)hi) << 64) | lo;
   }
@@ -177,14 +179,14 @@ SWIFT_RUNTIME_EXPORT long double __extendhfxf2(_Float16 h) {
     // with the appropriate sign, then multiply by the appropriate scale
     // factor to produce the f32 result.
     const __uint128_t mask = concat(0x8000, 0xffffffffffffffff);
-    return 0x1.0p16368L * fromEncoding((__int128_t)(short)x << 53 & mask);
+    return 0x1.0p16368L * fromEncoding((__int128_t)h << 53 & mask);
   }
   // We have either a normal number of an infinity or NaN. All of these
   // can be handled by shifting the significand into the correct position,
   // extending the exponent, and then multiplying by the correct scale.
   const __uint128_t value = concat(0x7fe0, 0x8000000000000000);
-  return 0x1.0p-16368L * fromEncoding(((__int128_t)(short)(x & 0xfc00) << 54) |
-                                      ((__int128_t)(x & 0x3ff) << 53) | value);
+  return 0x1.0p-16368L * fromEncoding(((__int128_t)(h & 0xfc00) << 54) |
+                                      ((__int128_t)(h & 0x3ff) << 53) | value);
 }
 
 #endif // (defined(__i386__) || defined(__x86_64__)) &&

--- a/stdlib/public/runtime/Float16Support.cpp
+++ b/stdlib/public/runtime/Float16Support.cpp
@@ -49,6 +49,15 @@ static float fromEncoding(unsigned int e) {
   return f;
 }
 
+#if (defined(__i386__) || defined(__x86_64__)) &&                               \
+    !(defined(__ANDROID__) || defined(__APPLE__) || defined(_WIN32))
+static long double fromEncoding(__uint128 hf) {
+  long double ld;
+  __builtin_memcpy(&ld, &hf, sizeof ld);
+  return ld;
+}
+#endif
+
 #if defined(__x86_64__) && defined(__F16C__)
 
 // If we're compiling the runtime for a target that has the conversion
@@ -157,7 +166,25 @@ SWIFT_RUNTIME_EXPORT unsigned short __truncdfhf2(double d) {
     !(defined(__ANDROID__) || defined(__APPLE__) || defined(_WIN32))
 
 SWIFT_RUNTIME_EXPORT long double __extendhfxf2(_Float16 h) {
-  __builtin_trap();
+  __uint128_t concat(uint64_t hi, uint64_t lo) {
+    return (((__uint128_t)hi) << 64) | lo;
+  }
+
+  // We need to have two cases; subnormals and zeros, and everything else.
+  // We are in the first case if the exponent field (bits 14:10) is zero:
+  if ((h & 0x7c00) == 0) {
+    // Sign-extend and mask so that we get a subnormal or zero in f32
+    // with the appropriate sign, then multiply by the appropriate scale
+    // factor to produce the f32 result.
+    const __uint128_t mask = concat(0x8000, 0xffffffffffffffff);
+    return 0x1.0p16368L * fromEncoding((__int128_t)(short)x << 53 & mask);
+  }
+  // We have either a normal number of an infinity or NaN. All of these
+  // can be handled by shifting the significand into the correct position,
+  // extending the exponent, and then multiplying by the correct scale.
+  const __uint128_t value = concat(0x7fe0, 0x8000000000000000);
+  return 0x1.0p-16368L * fromEncoding(((__int128_t)(short)(x & 0xfc00) << 54) |
+                                      ((__int128_t)(x & 0x3ff) << 53) | value);
 }
 
 #endif // (defined(__i386__) || defined(__x86_64__)) &&

--- a/stdlib/public/runtime/Float16Support.cpp
+++ b/stdlib/public/runtime/Float16Support.cpp
@@ -51,7 +51,7 @@ static float fromEncoding(unsigned int e) {
 
 #if (defined(__i386__) || defined(__x86_64__)) &&                               \
     !(defined(__ANDROID__) || defined(__APPLE__) || defined(_WIN32))
-static long double fromEncoding(__uint128 hf) {
+static long double fromEncoding(__uint128_t hf) {
   long double ld;
   __builtin_memcpy(&ld, &hf, sizeof ld);
   return ld;

--- a/stdlib/public/runtime/Float16Support.cpp
+++ b/stdlib/public/runtime/Float16Support.cpp
@@ -170,7 +170,7 @@ SWIFT_RUNTIME_EXPORT unsigned short __truncdfhf2(double d) {
 SWIFT_RUNTIME_EXPORT long double __extendhfxf2(uint16_t h) {
   auto concat = [](uint64_t hi, uint64_t lo) -> __uint128_t {
     return (((__uint128_t)hi) << 64) | lo;
-  }
+  };
 
   // We need to have two cases; subnormals and zeros, and everything else.
   // We are in the first case if the exponent field (bits 14:10) is zero:

--- a/stdlib/public/runtime/Float16Support.cpp
+++ b/stdlib/public/runtime/Float16Support.cpp
@@ -168,25 +168,7 @@ SWIFT_RUNTIME_EXPORT unsigned short __truncdfhf2(double d) {
     !(defined(__ANDROID__) || defined(__APPLE__) || defined(_WIN32))
 
 SWIFT_RUNTIME_EXPORT long double __extendhfxf2(uint16_t h) {
-  auto concat = [](uint64_t hi, uint64_t lo) -> __uint128_t {
-    return (((__uint128_t)hi) << 64) | lo;
-  };
-
-  // We need to have two cases; subnormals and zeros, and everything else.
-  // We are in the first case if the exponent field (bits 14:10) is zero:
-  if ((h & 0x7c00) == 0) {
-    // Sign-extend and mask so that we get a subnormal or zero in f32
-    // with the appropriate sign, then multiply by the appropriate scale
-    // factor to produce the f32 result.
-    const __uint128_t mask = concat(0x8000, 0xffffffffffffffff);
-    return 0x1.0p16368L * fromEncoding((__int128_t)h << 53 & mask);
-  }
-  // We have either a normal number of an infinity or NaN. All of these
-  // can be handled by shifting the significand into the correct position,
-  // extending the exponent, and then multiplying by the correct scale.
-  const __uint128_t value = concat(0x7fe0, 0x8000000000000000);
-  return 0x1.0p-16368L * fromEncoding(((__int128_t)(h & 0xfc00) << 54) |
-                                      ((__int128_t)(h & 0x3ff) << 53) | value);
+  return (long double)__gnu_h2f_ieee(h);
 }
 
 #endif // (defined(__i386__) || defined(__x86_64__)) &&

--- a/stdlib/public/runtime/Float16Support.cpp
+++ b/stdlib/public/runtime/Float16Support.cpp
@@ -51,15 +51,6 @@ static float fromEncoding(unsigned int e) {
   return f;
 }
 
-#if (defined(__i386__) || defined(__x86_64__)) &&                               \
-    !(defined(__ANDROID__) || defined(__APPLE__) || defined(_WIN32))
-static long double fromEncoding(__uint128_t hf) {
-  long double ld;
-  __builtin_memcpy(&ld, &hf, sizeof ld);
-  return ld;
-}
-#endif
-
 #if defined(__x86_64__) && defined(__F16C__)
 
 // If we're compiling the runtime for a target that has the conversion
@@ -167,7 +158,7 @@ SWIFT_RUNTIME_EXPORT unsigned short __truncdfhf2(double d) {
 #if (defined(__i386__) || defined(__x86_64__)) &&                               \
     !(defined(__ANDROID__) || defined(__APPLE__) || defined(_WIN32))
 
-SWIFT_RUNTIME_EXPORT long double __extendhfxf2(uint16_t h) {
+SWIFT_RUNTIME_EXPORT long double __extendhfxf2(short h) {
   return (long double)__gnu_h2f_ieee(h);
 }
 

--- a/stdlib/public/runtime/Float16Support.cpp
+++ b/stdlib/public/runtime/Float16Support.cpp
@@ -168,7 +168,7 @@ SWIFT_RUNTIME_EXPORT unsigned short __truncdfhf2(double d) {
     !(defined(__ANDROID__) || defined(__APPLE__) || defined(_WIN32))
 
 SWIFT_RUNTIME_EXPORT long double __extendhfxf2(uint16_t h) {
-  __uint128_t concat(uint64_t hi, uint64_t lo) {
+  auto concat = [](uint64_t hi, uint64_t lo) -> __uint128_t {
     return (((__uint128_t)hi) << 64) | lo;
   }
 

--- a/test/IRGen/ordering_x86.sil
+++ b/test/IRGen/ordering_x86.sil
@@ -41,4 +41,4 @@ bb0:
 // the order of features differs.
 
 // X86_64: define{{( protected)?}} swiftcc void @baz{{.*}}#0
-// X86_64: #0 = {{.*}}"target-features"="+cx16,+cx8,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+ssse3,+x87"
+// X86_64: #0 = {{.*}}"target-features"="+avx,+crc32,+cx16,+cx8,+f16c,+fxsr,+mmx,+popcnt,+sahf,+sse,+sse2,+sse3,+sse4.1,+sse4.2,+ssse3,+x87,+xsave"


### PR DESCRIPTION
Bump the minimum supported CPU to ~Nahelem so that we can take advantage of the F16C/CVT16 extensions to support half floating point rounding. This should avoid the need to replicate the compiler-rt functionality in the runtime and the associated problems with linking compiler-rt builtins on non-Windows targets when performing static linking.