### PR TITLE
[cxx-interop] Re-implement template mangling.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1455,6 +1455,8 @@ public:
   /// Finds the address of the given symbol. If `libraryHandleHint` is non-null,
   /// search within the library.
   void *getAddressOfSymbol(const char *name, void *libraryHandleHint = nullptr);
+  
+  Type getNamedSwiftType(ModuleDecl *module, StringRef name);
 
 private:
   friend Decl;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -2001,10 +2001,12 @@ struct ParsedDeclName {
   }
 
   /// Form a declaration name from this parsed declaration name.
-  DeclName formDeclName(ASTContext &ctx, bool isSubscript = false) const;
+  DeclName formDeclName(ASTContext &ctx, bool isSubscript = false,
+                        bool isCxxClassTemplateSpec = false) const;
 
   /// Form a declaration name from this parsed declaration name.
-  DeclNameRef formDeclNameRef(ASTContext &ctx, bool isSubscript = false) const;
+  DeclNameRef formDeclNameRef(ASTContext &ctx, bool isSubscript = false,
+                              bool isCxxClassTemplateSpec = false) const;
 };
 
 /// To assist debugging parser crashes, tell us the location of the
@@ -2026,7 +2028,8 @@ DeclName formDeclName(ASTContext &ctx,
                       ArrayRef<StringRef> argumentLabels,
                       bool isFunctionName,
                       bool isInitializer,
-                      bool isSubscript = false);
+                      bool isSubscript = false,
+                      bool isCxxClassTemplateSpec = false);
 
 /// Form a Swift declaration name reference from its constituent parts.
 DeclNameRef formDeclNameRef(ASTContext &ctx,
@@ -2034,7 +2037,8 @@ DeclNameRef formDeclNameRef(ASTContext &ctx,
                             ArrayRef<StringRef> argumentLabels,
                             bool isFunctionName,
                             bool isInitializer,
-                            bool isSubscript = false);
+                            bool isSubscript = false,
+                            bool isCxxClassTemplateSpec = false);
 
 /// Whether a given token can be the start of a decl.
 bool isKeywordPossibleDeclStart(const Token &Tok);

--- a/lib/AST/ClangTypeConverter.cpp
+++ b/lib/AST/ClangTypeConverter.cpp
@@ -43,22 +43,7 @@ using namespace swift;
 namespace {
 
 static Type getNamedSwiftType(ModuleDecl *stdlib, StringRef name) {
-  auto &ctx = stdlib->getASTContext();
-  SmallVector<ValueDecl*, 1> results;
-  stdlib->lookupValue(ctx.getIdentifier(name), NLKind::QualifiedLookup,
-                      results);
-
-  // If we have one single type decl, and that decl has been
-  // type-checked, return its declared type.
-  //
-  // ...non-type-checked types should only ever show up here because
-  // of test cases using -enable-source-import, but unfortunately
-  // that's a real thing.
-  if (results.size() == 1) {
-    if (auto typeDecl = dyn_cast<TypeDecl>(results[0]))
-      return typeDecl->getDeclaredInterfaceType();
-  }
-  return Type();
+  return stdlib->getASTContext().getNamedSwiftType(stdlib, name);
 }
 
 static clang::QualType

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1658,7 +1658,9 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
 
     if (!skipCustomName) {
       result.info.hasCustomName = true;
-      result.declName = parsedName.formDeclName(swiftCtx);
+      result.declName = parsedName.formDeclName(
+          swiftCtx, /*isSubscript=*/false,
+          isa<clang::ClassTemplateSpecializationDecl>(D));
 
       // Handle globals treated as members.
       if (parsedName.isMember()) {
@@ -1713,7 +1715,8 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
             // Update the name to reflect the new parameter labels.
             result.declName = formDeclName(
                 swiftCtx, parsedName.BaseName, parsedName.ArgumentLabels,
-                /*isFunction=*/true, isInitializer);
+                /*isFunction=*/true, isInitializer, /*isSubscript=*/false,
+                isa<clang::ClassTemplateSpecializationDecl>(D));
           } else if (nameAttr->isAsync) {
             // The custom name was for an async import, but we didn't in fact
             // import as async for some reason. Ignore this import.
@@ -2356,7 +2359,8 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
   baseName = renameUnsafeMethod(swiftCtx, D, baseName);
 
   result.declName = formDeclName(swiftCtx, baseName, argumentNames, isFunction,
-                                 isInitializer);
+                                 isInitializer, /*isSubscript=*/false,
+                                 isa<clang::ClassTemplateSpecializationDecl>(D));
   return result;
 }
 

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -2179,29 +2179,58 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       return importNameImpl(classTemplateSpecDecl->getSpecializedTemplate(),
                             version, givenName);
     if (!isa<clang::ClassTemplatePartialSpecializationDecl>(D)) {
-
-      auto &astContext = classTemplateSpecDecl->getASTContext();
-      // Itanium mangler produces valid Swift identifiers, use it to generate a name for
-      // this instantiation.
-      std::unique_ptr<clang::MangleContext> mangler{
-          clang::ItaniumMangleContext::create(astContext,
-                                              astContext.getDiagnostics())};
+      // When constructing the name of a C++ template, don't expand all the
+      // template, only expand one layer. Here we want to prioritize
+      // readability over total completeness.
       llvm::SmallString<128> storage;
       llvm::raw_svector_ostream buffer(storage);
-      mangler->mangleTypeName(astContext.getRecordType(classTemplateSpecDecl),
-                              buffer);
+      D->printName(buffer);
+      buffer << "<";
+      llvm::interleaveComma(classTemplateSpecDecl->getTemplateArgs().asArray(),
+                            buffer,
+                            [&buffer, this, version](const clang::TemplateArgument& arg) {
+        // Use import name here so builtin types such as "int" map to their
+        // Swift equivalent ("Int32").
+        if (arg.getKind() == clang::TemplateArgument::Type) {
+          auto ty = arg.getAsType().getTypePtr();
+          if (auto builtin = dyn_cast<clang::BuiltinType>(ty)) {
+            auto &ctx = swiftCtx;
+            Type swiftType = nullptr;
+            switch (builtin->getKind()) {
+            case clang::BuiltinType::Void:
+              swiftType = ctx.getNamedSwiftType(ctx.getStdlibModule(), "Void");
+              break;
+      #define MAP_BUILTIN_TYPE(CLANG_BUILTIN_KIND, SWIFT_TYPE_NAME)            \
+            case clang::BuiltinType::CLANG_BUILTIN_KIND:                       \
+              swiftType = ctx.getNamedSwiftType(ctx.getStdlibModule(),         \
+                                                #SWIFT_TYPE_NAME);             \
+              break;
+      #define MAP_BUILTIN_CCHAR_TYPE(CLANG_BUILTIN_KIND, SWIFT_TYPE_NAME)      \
+            case clang::BuiltinType::CLANG_BUILTIN_KIND:                       \
+              swiftType = ctx.getNamedSwiftType(ctx.getStdlibModule(),         \
+                                                #SWIFT_TYPE_NAME);             \
+              break;
+      #include "swift/ClangImporter/BuiltinMappedTypes.def"
+              default:
+                break;
+            }
+            
+            if (swiftType) {
+              if (auto nominal = dyn_cast<NominalType>(swiftType->getCanonicalType())) {
+                buffer << nominal->getDecl()->getNameStr();
+                return;
+              }
+            }
+          } else if (auto namedArg = dyn_cast_or_null<clang::NamedDecl>(ty->getAsTagDecl())) {
+            importNameImpl(namedArg, version, clang::DeclarationName()).getDeclName().print(buffer);
+            return;
+          }
+        }
+        buffer << "_";
+      });
+      buffer << ">";
 
-      // The Itanium mangler does not provide a way to get the mangled
-      // representation of a type. Instead, we call mangleTypeName() that
-      // returns the name of the RTTI typeinfo symbol, and remove the _ZTS
-      // prefix. Then we prepend __CxxTemplateInst to reduce chances of conflict
-      // with regular C and C++ structs.
-      llvm::SmallString<128> mangledNameStorage;
-      llvm::raw_svector_ostream mangledName(mangledNameStorage);
-      assert(buffer.str().take_front(4) == "_ZTS");
-      mangledName << CXX_TEMPLATE_INST_PREFIX << buffer.str().drop_front(4);
-
-      baseName = swiftCtx.getIdentifier(mangledName.str()).get();
+      baseName = swiftCtx.getIdentifier(buffer.str()).get();
     }
   }
 

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -3251,38 +3251,7 @@ bool ClangImporter::Implementation::canImportFoundationModule() {
 
 Type ClangImporter::Implementation::getNamedSwiftType(ModuleDecl *module,
                                                       StringRef name) {
-  if (!module)
-    return Type();
-
-  // Look for the type.
-  Identifier identifier = SwiftContext.getIdentifier(name);
-  SmallVector<ValueDecl *, 2> results;
-
-  // Check if the lookup we're about to perform a lookup within is
-  // a Clang module.
-  for (auto *file : module->getFiles()) {
-    if (auto clangUnit = dyn_cast<ClangModuleUnit>(file)) {
-      // If we have an overlay, look in the overlay. Otherwise, skip
-      // the lookup to avoid infinite recursion.
-      if (auto module = clangUnit->getOverlayModule())
-        module->lookupValue(identifier, NLKind::UnqualifiedLookup, results);
-    } else {
-      file->lookupValue(identifier, NLKind::UnqualifiedLookup, results);
-    }
-  }
-
-  if (results.size() != 1)
-    return Type();
-
-  auto decl = dyn_cast<TypeDecl>(results.front());
-  if (!decl)
-    return Type();
-
-  assert(!decl->hasClangNode() && "picked up the original type?");
-
-  if (auto *nominalDecl = dyn_cast<NominalTypeDecl>(decl))
-    return nominalDecl->getDeclaredType();
-  return decl->getDeclaredInterfaceType();
+  return SwiftContext.getNamedSwiftType(module, name);
 }
 
 Type ClangImporter::Implementation::getNamedSwiftType(StringRef moduleName,

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1360,8 +1360,6 @@ DeclNameRef swift::formDeclNameRef(ASTContext &ctx,
   // We cannot import when the base name is not an identifier.
   if (baseName.empty())
     return DeclNameRef();
-//  if (!Lexer::isIdentifier(baseName) && !Lexer::isOperator(baseName))
-//    return DeclNameRef();
 
   // Get the identifier for the base name. Special-case `init`.
   DeclBaseName baseNameId;

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -1360,8 +1360,8 @@ DeclNameRef swift::formDeclNameRef(ASTContext &ctx,
   // We cannot import when the base name is not an identifier.
   if (baseName.empty())
     return DeclNameRef();
-  if (!Lexer::isIdentifier(baseName) && !Lexer::isOperator(baseName))
-    return DeclNameRef();
+//  if (!Lexer::isIdentifier(baseName) && !Lexer::isOperator(baseName))
+//    return DeclNameRef();
 
   // Get the identifier for the base name. Special-case `init`.
   DeclBaseName baseNameId;

--- a/test/Interop/Cxx/namespace/class-inline-namespace-irgen.swift
+++ b/test/Interop/Cxx/namespace/class-inline-namespace-irgen.swift
@@ -48,7 +48,7 @@ extension Parent.TypedefInInlineChild {
     return ""
   }
 }
-// CHECK: define hidden swiftcc {{.*}} @"$sSo6ParentO11InlineChildO027__CxxTemplateInstN6Parent11b7Child21e2InbC4IcEEV4testE6stringSSvg"()
+// CHECK: define hidden swiftcc {{.*}} @"$sSo6ParentO11InlineChildO0033TemplateInInlineChildInt8_ehGIixbV4testE6stringSSvg"()
 
 extension Parent.InInlineChild {
   func doSomething() {
@@ -70,22 +70,22 @@ extension Parent.InlineChild.InSecondInlineChild {
 }
 // define hidden swiftcc {{.*}} @"$sSo6ParentO11InlineChildO06SecondbC0O02IndbC0V4testE1ySivg"()
 
-// CHECK: define hidden swiftcc {{.*}} @"$s4test3useySSSo6ParentO11InlineChildO027__CxxTemplateInstN6Parent11d7Child21g2IndE4IcEEVF"()
-// CHECK: call swiftcc {{.*}} @"$sSo6ParentO11InlineChildO027__CxxTemplateInstN6Parent11b7Child21e2InbC4IcEEV4testE6stringSSvg"
+// CHECK: define hidden swiftcc {{.*}} @"$s4test3useySSSo6ParentO11InlineChildO0033TemplateInInlineChildInt8_ehGIixbVF"()
+// CHECK: call swiftcc {{.*}} @"$sSo6ParentO11InlineChildO0033TemplateInInlineChildInt8_ehGIixbV4testE6stringSSvg"
 func use(_ x: Parent.TypedefInInlineChild) -> String {
   let s = x.string
   return s
 }
 
-// CHECK: define hidden swiftcc {{.*}} @"$s4test4use2ySSSo6ParentO11InlineChildO027__CxxTemplateInstN6Parent11d7Child21g2IndE4IcEEVF"()
-// CHECK: call swiftcc {{.*}} @"$sSo6ParentO11InlineChildO027__CxxTemplateInstN6Parent11b7Child21e2InbC4IcEEV4testE6stringSSvg"
+// CHECK: define hidden swiftcc {{.*}} @"$s4test4use2ySSSo6ParentO11InlineChildO0033TemplateInInlineChildInt8_ehGIixbVF"()
+// CHECK: call swiftcc {{.*}} @"$sSo6ParentO11InlineChildO0033TemplateInInlineChildInt8_ehGIixbV4testE6stringSSvg"
 func use2(_ x: Parent.InlineChild.TypedefInInlineChild) -> String {
   let s = x.string
   return s
 }
 
 // define swiftcc void @"$s4testAAyySo6ParentO11InlineChildO02IncD0VF"()
-// CHECK: alloca %TSo6ParentO11InlineChildO027__CxxTemplateInstN6Parent11b7Child21e2InbC4IcEEV
+// CHECK: alloca %TSo6ParentO11InlineChildO0033TemplateInInlineChildInt8_ehGIixbV
 // CHECK: call {{.*}} @{{_ZN6Parent11InlineChild21TemplateInInlineChildIcEC|"\?\?0\?\$TemplateInInlineChild@D@InlineChild@Parent@@QEAA@XZ"}}
 // CHECK: call swiftcc void @"$sSo6ParentO11InlineChildO02InbC0V4testE11doSomethingyyF"(
 // CHECK: call swiftcc {{.*}} @"$sSo6ParentO11InlineChildO06SecondbC0O02IndbC0V4testE1xSivg"(

--- a/test/Interop/Cxx/namespace/templates-module-interface.swift
+++ b/test/Interop/Cxx/namespace/templates-module-interface.swift
@@ -3,7 +3,7 @@
 // CHECK:     enum TemplatesNS1 {
 // CHECK-NEXT:   enum TemplatesNS2 {
 // CHECK-NEXT:     static func forwardDeclaredFunctionTemplate<T>(_: T) -> UnsafePointer<CChar>!
-// CHECK-NEXT:     struct __CxxTemplateInstN12TemplatesNS112TemplatesNS228ForwardDeclaredClassTemplateIcEE {
+// CHECK-NEXT:     struct ForwardDeclaredClassTemplate<Int8> {
 // CHECK-NEXT:       init()
 // CHECK-NEXT:       mutating func basicMember() -> UnsafePointer<CChar>!
 // CHECK-NEXT:     }
@@ -11,51 +11,51 @@
 // CHECK-NEXT:     struct ForwardDeclaredClassTemplate<> {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     static func forwardDeclaredFunctionTemplateOutOfLine<T>(_: T) -> UnsafePointer<CChar>!
-// CHECK-NEXT:     struct __CxxTemplateInstN12TemplatesNS112TemplatesNS237ForwardDeclaredClassTemplateOutOfLineIcEE {
+// CHECK-NEXT:     struct ForwardDeclaredClassTemplateOutOfLine<Int8> {
 // CHECK-NEXT:       init()
 // CHECK-NEXT:       mutating func basicMember() -> UnsafePointer<CChar>!
 // CHECK-NEXT:     }
 // CHECK-NEXT:     @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:     struct ForwardDeclaredClassTemplateOutOfLine<> {
 // CHECK-NEXT:     }
-// CHECK-NEXT:     typealias BasicClassTemplateChar = TemplatesNS1.TemplatesNS3.__CxxTemplateInstN12TemplatesNS112TemplatesNS318BasicClassTemplateIcEE
+// CHECK-NEXT:     typealias BasicClassTemplateChar = TemplatesNS1.TemplatesNS3.BasicClassTemplate<Int8>
 // CHECK-NEXT:     static func takesClassTemplateFromSibling(_: TemplatesNS1.TemplatesNS2.BasicClassTemplateChar) -> UnsafePointer<CChar>!
 // CHECK-NEXT:   }
 // CHECK-NEXT:   static func basicFunctionTemplate<T>(_: T) -> UnsafePointer<CChar>!
-// CHECK-NEXT:   struct __CxxTemplateInstN12TemplatesNS118BasicClassTemplateIcEE {
+// CHECK-NEXT:   struct BasicClassTemplate<Int8> {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:     mutating func basicMember() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   }
 // CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:   struct BasicClassTemplate<> {
 // CHECK-NEXT:   }
-// CHECK-NEXT:   typealias BasicClassTemplateChar = TemplatesNS1.__CxxTemplateInstN12TemplatesNS118BasicClassTemplateIcEE
+// CHECK-NEXT:   typealias BasicClassTemplateChar = TemplatesNS1.BasicClassTemplate<Int8>
 // CHECK-NEXT:   static func basicFunctionTemplateDefinedInDefs<T>(_: T) -> UnsafePointer<CChar>!
 // CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:   struct BasicClassTemplateDefinedInDefs<> {
 // CHECK-NEXT:   }
-// CHECK-NEXT:   typealias UseTemplate = TemplatesNS4.__CxxTemplateInstN12TemplatesNS417HasSpecializationIcEE
-// CHECK-NEXT:   typealias UseSpecialized = TemplatesNS4.__CxxTemplateInstN12TemplatesNS417HasSpecializationIiEE
+// CHECK-NEXT:   typealias UseTemplate = TemplatesNS4.HasSpecialization<Int8>
+// CHECK-NEXT:   typealias UseSpecialized = TemplatesNS4.HasSpecialization<Int32>
 // CHECK-NEXT:   enum TemplatesNS3 {
-// CHECK-NEXT:     struct __CxxTemplateInstN12TemplatesNS112TemplatesNS318BasicClassTemplateIcEE {
+// CHECK-NEXT:     struct BasicClassTemplate<Int8> {
 // CHECK-NEXT:       init()
 // CHECK-NEXT:     }
 // CHECK-NEXT:     @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:     struct BasicClassTemplate<> {
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
-// CHECK-NEXT:   struct __CxxTemplateInstN12TemplatesNS112TemplatesNS228ForwardDeclaredClassTemplateIcEE {
+// CHECK-NEXT:   struct ForwardDeclaredClassTemplate<Int8> {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:     mutating func basicMember() -> UnsafePointer<CChar>!
 // CHECK-NEXT:   }
-// CHECK-NEXT:   typealias ForwardDeclaredClassTemplateChar = TemplatesNS1.TemplatesNS2.__CxxTemplateInstN12TemplatesNS112TemplatesNS228ForwardDeclaredClassTemplateIcEE
+// CHECK-NEXT:   typealias ForwardDeclaredClassTemplateChar = TemplatesNS1.TemplatesNS2.ForwardDeclaredClassTemplate<Int8>
 // CHECK-NEXT: }
-// CHECK-NEXT: typealias ForwardDeclaredClassTemplateOutOfLineChar = TemplatesNS1.TemplatesNS2.__CxxTemplateInstN12TemplatesNS112TemplatesNS237ForwardDeclaredClassTemplateOutOfLineIcEE
+// CHECK-NEXT: typealias ForwardDeclaredClassTemplateOutOfLineChar = TemplatesNS1.TemplatesNS2.ForwardDeclaredClassTemplateOutOfLine<Int8>
 // CHECK-NEXT: enum TemplatesNS4 {
-// CHECK-NEXT:   struct __CxxTemplateInstN12TemplatesNS417HasSpecializationIcEE {
+// CHECK-NEXT:   struct HasSpecialization<Int8> {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:   }
-// CHECK-NEXT:   struct __CxxTemplateInstN12TemplatesNS417HasSpecializationIiEE {
+// CHECK-NEXT:   struct HasSpecialization<Int32> {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:   }
 // CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")

--- a/test/Interop/Cxx/namespace/templates-second-header-module-interface.swift
+++ b/test/Interop/Cxx/namespace/templates-second-header-module-interface.swift
@@ -2,10 +2,10 @@
 
 // CHECK: enum TemplatesNS1 {
 // CHECK:   static func basicFunctionTemplateDefinedInDefs<T>(_: T) -> UnsafePointer<CChar>!
-// CHECK:   struct __CxxTemplateInstN12TemplatesNS131BasicClassTemplateDefinedInDefsIcEE {
+// CHECK:   struct BasicClassTemplateDefinedInDefs<Int8> {
 // CHECK:     init()
 // CHECK:     mutating func basicMember() -> UnsafePointer<CChar>!
 // CHECK:   }
 // CHECK: }
 
-// CHECK: typealias BasicClassTemplateDefinedInDefsChar = TemplatesNS1.__CxxTemplateInstN12TemplatesNS131BasicClassTemplateDefinedInDefsIcEE
+// CHECK: typealias BasicClassTemplateDefinedInDefsChar = TemplatesNS1.BasicClassTemplateDefinedInDefs<Int8>

--- a/test/Interop/Cxx/namespace/templates-with-forward-decl-module-interface.swift
+++ b/test/Interop/Cxx/namespace/templates-with-forward-decl-module-interface.swift
@@ -1,21 +1,21 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=TemplatesWithForwardDecl -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK:      enum NS1 {
-// CHECK-NEXT:   struct __CxxTemplateInstN3NS115ForwardDeclaredIiEE {
+// CHECK-NEXT:   struct ForwardDeclared<Int32> {
 // CHECK-NEXT:     init()
 // CHECK-NEXT:   }
 // CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:   struct ForwardDeclared<T> {
 // CHECK-NEXT:   }
-// CHECK-NEXT:   struct __CxxTemplateInstN3NS14DeclIiEE {
+// CHECK-NEXT:   struct Decl<Int32> {
 // CHECK-NEXT:     init()
-// CHECK-NEXT:     init(fwd: NS1.__CxxTemplateInstN3NS115ForwardDeclaredIiEE)
+// CHECK-NEXT:     init(fwd: NS1.ForwardDeclared<Int32>)
 // CHECK-NEXT:     typealias MyInt = Int32
-// CHECK-NEXT:     var fwd: NS1.__CxxTemplateInstN3NS115ForwardDeclaredIiEE
-// CHECK-NEXT:     static let intValue: NS1.__CxxTemplateInstN3NS14DeclIiEE.MyInt
+// CHECK-NEXT:     var fwd: NS1.ForwardDeclared<Int32>
+// CHECK-NEXT:     static let intValue: NS1.Decl<Int32>.MyInt
 // CHECK-NEXT:   }
 // CHECK-NEXT:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK-NEXT:   struct Decl<T> {
 // CHECK-NEXT:   }
-// CHECK-NEXT:   typealias di = NS1.__CxxTemplateInstN3NS14DeclIiEE
+// CHECK-NEXT:   typealias di = NS1.Decl<Int32>
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/operators/member-inline-module-interface.swift
+++ b/test/Interop/Cxx/operators/member-inline-module-interface.swift
@@ -93,7 +93,7 @@
 
 // CHECK: struct TemplatedArray<T> {
 // CHECK: }
-// CHECK: struct __CxxTemplateInst14TemplatedArrayIdE {
+// CHECK: struct TemplatedArray<Double> {
 // CHECK:   subscript(i: Int32) -> Double
 
 // CHECK:   @available(*, unavailable, message: "use subscript")
@@ -102,7 +102,7 @@
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   func __operatorSubscriptConst(_ i: Int32) -> UnsafePointer<Double>
 // CHECK: }
-// CHECK: typealias TemplatedDoubleArray = __CxxTemplateInst14TemplatedArrayIdE
+// CHECK: typealias TemplatedDoubleArray = TemplatedArray<Double>
 
 
 // CHECK: struct TemplatedSubscriptArray {
@@ -139,12 +139,12 @@
 
 // CHECK: struct TemplatedArrayByVal<T> {
 // CHECK: }
-// CHECK: struct __CxxTemplateInst19TemplatedArrayByValIdE {
+// CHECK: struct TemplatedArrayByVal<Double> {
 // CHECK:   subscript(i: Int32) -> Double { mutating get }
 // CHECK:   @available(*, unavailable, message: "use subscript")
 // CHECK:   mutating func __operatorSubscriptConst(_ i: Int32) -> Double
 // CHECK: }
-// CHECK: typealias TemplatedDoubleArrayByVal = __CxxTemplateInst19TemplatedArrayByValIdE
+// CHECK: typealias TemplatedDoubleArrayByVal = TemplatedArrayByVal<Double>
 
 // CHECK: struct TemplatedByVal<T> {
 // CHECK-NEXT: }

--- a/test/Interop/Cxx/stdlib/libcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libcxx-module-interface.swift
@@ -10,14 +10,14 @@
 
 // CHECK-IOSFWD: enum std {
 // CHECK-IOSFWD:   enum __1 {
-// CHECK-IOSFWD:     struct __CxxTemplateInstNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEE : CxxRandomAccessCollection {
+// CHECK-IOSFWD:     struct basic_string<Int8, char_traits<Int8>, allocator<Int8>> : CxxRandomAccessCollection {
 // CHECK-IOSFWD:       typealias value_type = CChar
 // CHECK-IOSFWD:     }
-// CHECK-IOSFWD:     struct __CxxTemplateInstNSt3__112basic_stringIwNS_11char_traitsIwEENS_9allocatorIwEEEE : CxxRandomAccessCollection {
+// CHECK-IOSFWD:     struct basic_string<Scalar, char_traits<Scalar>, allocator<Scalar>> : CxxRandomAccessCollection {
 // CHECK-IOSFWD:       typealias value_type = CWideChar
 // CHECK-IOSFWD:     }
-// CHECK-IOSFWD:     typealias string = std.__1.__CxxTemplateInstNSt3__112basic_stringIcNS_11char_traitsIcEENS_9allocatorIcEEEE
-// CHECK-IOSFWD:     typealias wstring = std.__1.__CxxTemplateInstNSt3__112basic_stringIwNS_11char_traitsIwEENS_9allocatorIwEEEE
+// CHECK-IOSFWD:     typealias string = std.__1.basic_string<Int8, char_traits<Int8>, allocator<Int8>>
+// CHECK-IOSFWD:     typealias wstring = std.__1.basic_string<Scalar, char_traits<Scalar>, allocator<Scalar>>
 // CHECK-IOSFWD:   }
 // CHECK-IOSFWD: }
 

--- a/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libstdcxx-module-interface.swift
@@ -11,11 +11,11 @@
 // REQUIRES: OS=linux-gnu
 
 // CHECK-STD: enum std {
-// CHECK-STRING:   struct {{__CxxTemplateInstNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE|__CxxTemplateInstSs}} : CxxRandomAccessCollection {
-// CHECK-STRING:     typealias value_type = std.__CxxTemplateInstSt11char_traitsIcE.char_type
+// CHECK-STRING:   struct basic_string<Int8, char_traits<Int8>, allocator<Int8>> : CxxRandomAccessCollection {
+// CHECK-STRING:     typealias value_type = std.char_traits<Int8>.char_type
 // CHECK-STRING:   }
-// CHECK-STRING:   struct {{__CxxTemplateInstNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEEE|__CxxTemplateInstSbIwSt11char_traitsIwESaIwEE}} : CxxRandomAccessCollection {
-// CHECK-STRING:     typealias value_type = std.__CxxTemplateInstSt11char_traitsIwE.char_type
+// CHECK-STRING:   struct basic_string<Scalar, char_traits<Scalar>, allocator<Scalar>> : CxxRandomAccessCollection {
+// CHECK-STRING:     typealias value_type = std.char_traits<Scalar>.char_type
 // CHECK-STRING:   }
 
 // CHECK-TO-STRING:   static func to_string(_ __val: Int32) -> std{{(.__cxx11)?}}.string
@@ -23,6 +23,6 @@
 
 // CHECK-SIZE-T:   typealias size_t = Int
 
-// CHECK-STRING:   typealias string = std.{{__cxx11.__CxxTemplateInstNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE|__CxxTemplateInstSs}}
-// CHECK-STRING:   typealias wstring = std.{{__cxx11.__CxxTemplateInstNSt7__cxx1112basic_stringIwSt11char_traitsIwESaIwEEE|__CxxTemplateInstSbIwSt11char_traitsIwESaIwEE}}
+// CHECK-STRING:   typealias string =  std{{(.__cxx11)?}}.basic_string<Int8, char_traits<Int8>, allocator<Int8>>
+// CHECK-STRING:   typealias wstring =  std{{(.__cxx11)?}}.basic_string<Scalar, char_traits<Scalar>, allocator<Scalar>>
 // CHECK-STD: }

--- a/test/Interop/Cxx/stdlib/msvcprt-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/msvcprt-module-interface.swift
@@ -12,13 +12,13 @@
 // CHECK-STRING:   typealias size_t = size_t
 // CHECK-STRING:   static func to_string(_ _Val: Int32) -> std.string
 // CHECK-STRING:   static func to_wstring(_ _Val: Int32) -> std.wstring
-// CHECK-STRING:   struct __CxxTemplateInstSs : CxxRandomAccessCollection {
+// CHECK-STRING:   struct basic_string<Int8, char_traits<Int8>, allocator<Int8>> : CxxRandomAccessCollection {
 // CHECK-STRING:     typealias value_type = CChar
 // CHECK-STRING:   }
-// CHECK-STRING:   struct __CxxTemplateInstSbIwSt11char_traitsIwESaIwEE : CxxRandomAccessCollection {
+// CHECK-STRING:   struct basic_string<Scalar, char_traits<Scalar>, allocator<Scalar>> : CxxRandomAccessCollection {
 // CHECK-STRING:     typealias value_type = CWideChar
 // CHECK-STRING:   }
-// CHECK-STRING:   typealias string = std.__CxxTemplateInstSs
-// CHECK-STRING:   typealias wstring = std.__CxxTemplateInstSbIwSt11char_traitsIwESaIwEE
+// CHECK-STRING:   typealias string = std.basic_string<Int8, char_traits<Int8>, allocator<Int8>>
+// CHECK-STRING:   typealias wstring = std.basic_string<Scalar, char_traits<Scalar>, allocator<Scalar>>
 // CHECK-STRING: }
 

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -86,11 +86,11 @@
 // CHECK-NOT: struct HasNoPreIncrementOperator : UnsafeCxxInputIterator
 // CHECK-NOT: struct HasNoDereferenceOperator : UnsafeCxxInputIterator
 
-// CHECK: struct __CxxTemplateInst17TemplatedIteratorIiE : UnsafeCxxInputIterator {
+// CHECK: struct TemplatedIterator<Int32> : UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
-// CHECK:   func successor() -> __CxxTemplateInst17TemplatedIteratorIiE
+// CHECK:   func successor() -> TemplatedIterator<Int32>
 // CHECK:   typealias Pointee = Int32
-// CHECK:   static func == (lhs: __CxxTemplateInst17TemplatedIteratorIiE, other: __CxxTemplateInst17TemplatedIteratorIiE) -> Bool
+// CHECK:   static func == (lhs: TemplatedIterator<Int32>, other: TemplatedIterator<Int32>) -> Bool
 // CHECK: }
 
 // CHECK: struct __CxxTemplateInst28TemplatedIteratorOutOfLineEqIiE : UnsafeCxxInputIterator {

--- a/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-iterator-module-interface.swift
@@ -93,15 +93,15 @@
 // CHECK:   static func == (lhs: TemplatedIterator<Int32>, other: TemplatedIterator<Int32>) -> Bool
 // CHECK: }
 
-// CHECK: struct __CxxTemplateInst28TemplatedIteratorOutOfLineEqIiE : UnsafeCxxInputIterator {
+// CHECK: struct TemplatedIteratorOutOfLineEq<Int32> : UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
-// CHECK:   func successor() -> __CxxTemplateInst28TemplatedIteratorOutOfLineEqIiE
+// CHECK:   func successor() -> TemplatedIteratorOutOfLineEq<Int32>
 // CHECK:   typealias Pointee = Int32
 // CHECK: }
 
-// CHECK: struct __CxxTemplateInst31TemplatedRACIteratorOutOfLineEqIiE : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
+// CHECK: struct TemplatedRACIteratorOutOfLineEq<Int32> : UnsafeCxxRandomAccessIterator, UnsafeCxxInputIterator {
 // CHECK:   var pointee: Int32 { get }
-// CHECK:   func successor() -> __CxxTemplateInst31TemplatedRACIteratorOutOfLineEqIiE
+// CHECK:   func successor() -> TemplatedRACIteratorOutOfLineEq<Int32>
 // CHECK:   typealias Pointee = Int32
-// CHECK:   typealias Distance = __CxxTemplateInst31TemplatedRACIteratorOutOfLineEqIiE.difference_type
+// CHECK:   typealias Distance = TemplatedRACIteratorOutOfLineEq<Int32>.difference_type
 // CHECK: }

--- a/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
@@ -50,9 +50,9 @@
 // CHECK-NOT:   typealias Iterator
 // CHECK-NOT:   typealias RawIterator
 // CHECK: }
-// CHECK: struct __CxxTemplateInst20HasTemplatedIteratorIi12NoDefinitionIiEE {
+// CHECK: struct HasTemplatedIterator<Int32, NoDefinition<Int32>> {
 // CHECK-NOT:   typealias Element
 // CHECK-NOT:   typealias Iterator
 // CHECK-NOT:   typealias RawIterator
 // CHECK: }
-// CHECK: typealias HasUninstantiatableIterator = __CxxTemplateInst20HasTemplatedIteratorIi12NoDefinitionIiEE
+// CHECK: typealias HasUninstantiatableIterator = HasTemplatedIterator<Int32, NoDefinition<Int32>>

--- a/test/Interop/Cxx/templates/canonical-types-module-interface.swift
+++ b/test/Interop/Cxx/templates/canonical-types-module-interface.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=CanonicalTypes -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
-// CHECK:      struct __CxxTemplateInst12MagicWrapperI10IntWrapperE {
+// CHECK:      struct MagicWrapper<IntWrapper> {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(t: IntWrapper)
 // CHECK-NEXT:   var t: IntWrapper
@@ -12,5 +12,5 @@
 // CHECK-NEXT:   func getValue() -> Int32
 // CHECK-NEXT:   var value: Int32
 // CHECK-NEXT: }
-// CHECK-NEXT: typealias WrappedMagicNumberA = __CxxTemplateInst12MagicWrapperI10IntWrapperE
-// CHECK-NEXT: typealias WrappedMagicNumberB = __CxxTemplateInst12MagicWrapperI10IntWrapperE
+// CHECK-NEXT: typealias WrappedMagicNumberA = MagicWrapper<IntWrapper>
+// CHECK-NEXT: typealias WrappedMagicNumberB = MagicWrapper<IntWrapper>

--- a/test/Interop/Cxx/templates/class-template-in-namespace-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-in-namespace-module-interface.swift
@@ -1,10 +1,11 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateInNamespace -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: enum Space {
-// CHECK:   struct __CxxTemplateInstN5Space4ShipIJFvbEEEE {
+// CHECK:   struct Ship<_> {
 // CHECK:     init()
 // CHECK:   }
+// CHECK:   @available(*, unavailable, message: "Un-specialized class templates are not currently supported. Please use a specialization of this type.")
 // CHECK:   struct Ship<> {
 // CHECK:   }
-// CHECK:   typealias Orbiter = Space.__CxxTemplateInstN5Space4ShipIJFvbEEEE
+// CHECK:   typealias Orbiter = Space.Ship<_>
 // CHECK: }

--- a/test/Interop/Cxx/templates/class-template-instantiation-demangling.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation-demangling.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | grep 'define.*swiftcc.*$' | grep -o '[[:alnum:]]*__CxxTemplateInst[[:alnum:]]*' | xargs %swift-demangle | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | grep 'define.*swiftcc.*$' | xargs %swift-demangle | %FileCheck %s
 
 import Mangling
 
@@ -8,5 +8,5 @@ public func returnInstantiation() -> WrappedMagicInt {
   return WrappedMagicInt()
 }
 
-// CHECK: $s4main20receiveInstantiationyySo34__CxxTemplateInst12MagicWrapperIiEVzF ---> main.receiveInstantiation(inout __C.__CxxTemplateInst12MagicWrapperIiE) -> ()
-// CHECK: $s4main19returnInstantiationSo34__CxxTemplateInst12MagicWrapperIiEVyF ---> main.returnInstantiation() -> __C.__CxxTemplateInst12MagicWrapperIiE
+// CHECK: $s4main20receiveInstantiationyySo0025MagicWrapperInt32_lsFCfibVzF(%TSo0025MagicWrapperInt32_lsFCfibV* ---> @$s4main20receiveInstantiationyySo0025MagicWrapperInt32_lsFCfibVzF(%TSo0025MagicWrapperInt32_lsFCfibV*
+// CHECK: $s4main19returnInstantiationSo0025MagicWrapperInt32_lsFCfibVyF() ---> @$s4main19returnInstantiationSo0025MagicWrapperInt32_lsFCfibVyF()

--- a/test/Interop/Cxx/templates/class-template-with-typedef-module-interface.swift
+++ b/test/Interop/Cxx/templates/class-template-with-typedef-module-interface.swift
@@ -1,8 +1,8 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=ClassTemplateWithTypedef -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
-// CHECK: struct __CxxTemplateInst6LanderIcE {
+// CHECK: struct Lander<Int8> {
 // CHECK:   init()
 // CHECK:   typealias size_type = {{UInt|UInt32}}
 // CHECK:   mutating func test(_: {{UInt|UInt32}})
 // CHECK: }
-// CHECK: typealias Surveyor = __CxxTemplateInst6LanderIcE
+// CHECK: typealias Surveyor = Lander<Int8>

--- a/test/Interop/Cxx/templates/dependent-types-silgen.swift
+++ b/test/Interop/Cxx/templates/dependent-types-silgen.swift
@@ -9,15 +9,15 @@ import DependentTypes
 // CHECK:   [[THUNK_REF:%.*]] = function_ref @$sSC27dependantReturnTypeInferredyyps5Int64VF : $@convention(thin) (Int64) -> @out Any
 // CHECK:   apply [[THUNK_REF]]([[ANY_OUT]], %{{[0-9]+}}) : $@convention(thin) (Int64) -> @out Any
 
-// CHECK:   [[SPEC_OUT:%.*]] = alloc_stack $__CxxTemplateInst1MIxE
-// CHECK:   unconditional_checked_cast_addr Any in [[ANY_OUT]] : $*Any to __CxxTemplateInst1MIxE in [[SPEC_OUT]] : $*__CxxTemplateInst1MIxE
-// CHECK:   [[SPEC_VAL:%.*]] = load [trivial] [[SPEC_OUT]] : $*__CxxTemplateInst1MIxE
+// CHECK:   [[SPEC_OUT:%.*]] = alloc_stack $M<Int64>
+// CHECK:   unconditional_checked_cast_addr Any in [[ANY_OUT]] : $*Any to M<Int64> in [[SPEC_OUT]] : $*M<Int64>
+// CHECK:   [[SPEC_VAL:%.*]] = load [trivial] [[SPEC_OUT]] : $*M<Int64>
 
-// CHECK:   [[SPEC_TEMP:%.*]] = alloc_stack $__CxxTemplateInst1MIxE
-// CHECK:   store [[SPEC_VAL]] to [trivial] [[SPEC_TEMP]] : $*__CxxTemplateInst1MIxE
+// CHECK:   [[SPEC_TEMP:%.*]] = alloc_stack $M<Int64>
+// CHECK:   store [[SPEC_VAL]] to [trivial] [[SPEC_TEMP]] : $*M<Int64>
 
-// CHECK:   [[GET_VAL_FN:%.*]] = function_ref @{{_ZNK1MIxE8getValueEv|\?getValue@\?\$M@_J@@QEBA_JXZ}} : $@convention(cxx_method) (@in_guaranteed __CxxTemplateInst1MIxE) -> Int
-// CHECK:   [[OUT_VAL:%.*]] = apply [[GET_VAL_FN]]([[SPEC_TEMP]]) : $@convention(cxx_method) (@in_guaranteed __CxxTemplateInst1MIxE) -> Int
+// CHECK:   [[GET_VAL_FN:%.*]] = function_ref @{{_ZNK1MIxE8getValueEv|\?getValue@\?\$M@_J@@QEBA_JXZ}} : $@convention(cxx_method) (@in_guaranteed M<Int64>) -> Int
+// CHECK:   [[OUT_VAL:%.*]] = apply [[GET_VAL_FN]]([[SPEC_TEMP]]) : $@convention(cxx_method) (@in_guaranteed M<Int64>) -> Int
 
 // CHECK:   return [[OUT_VAL]] : $Int
 // CHECK-LABEL: end sil function '$s4main4tests5Int64VyF'
@@ -26,13 +26,13 @@ import DependentTypes
 // Check the synthesized thunk:
 // CHECK-LABEL: sil [transparent] [serialized] [ossa] @$sSC27dependantReturnTypeInferredyyps5Int64VF : $@convention(thin) (Int64) -> @out Any
 // CHECK: bb0(%0 : $*Any, %1 : $Int64):
-// CHECK:   [[SPEC_OUT:%.*]] = alloc_stack $__CxxTemplateInst1MIxE
+// CHECK:   [[SPEC_OUT:%.*]] = alloc_stack $M<Int64>
 
-// CHECK:   [[FN:%.*]] = function_ref @{{_Z27dependantReturnTypeInferredIxE1MIT_ES1_|\?\?\$dependantReturnTypeInferred@_J@@YA\?AU\?\$M@_J@@_J@Z}} : $@convention(c) (Int64) -> __CxxTemplateInst1MIxE
-// CHECK:   [[OUT:%.*]] = apply [[FN]](%1) : $@convention(c) (Int64) -> __CxxTemplateInst1MIxE
+// CHECK:   [[FN:%.*]] = function_ref @{{_Z27dependantReturnTypeInferredIxE1MIT_ES1_|\?\?\$dependantReturnTypeInferred@_J@@YA\?AU\?\$M@_J@@_J@Z}} : $@convention(c) (Int64) -> M<Int64>
+// CHECK:   [[OUT:%.*]] = apply [[FN]](%1) : $@convention(c) (Int64) -> M<Int64>
 
-// CHECK:   store [[OUT]] to [trivial] [[SPEC_OUT]] : $*__CxxTemplateInst1MIxE
-// CHECK:   unconditional_checked_cast_addr __CxxTemplateInst1MIxE in [[SPEC_OUT]] : $*__CxxTemplateInst1MIxE to Any in %0 : $*Any
+// CHECK:   store [[OUT]] to [trivial] [[SPEC_OUT]] : $*M<Int64>
+// CHECK:   unconditional_checked_cast_addr M<Int64> in [[SPEC_OUT]] : $*M<Int64> to Any in %0 : $*Any
 // CHECK-LABEL: end sil function '$sSC27dependantReturnTypeInferredyyps5Int64VF'
 
 public func test() -> Int64 {
@@ -40,5 +40,5 @@ public func test() -> Int64 {
   return m.getValue()
 }
 
-// CHECK-LABEL: sil [clang __CxxTemplateInst1MIxE.getValue] @{{_ZNK1MIxE8getValueEv|\?getValue@\?\$M@_J@@QEBA_JXZ}} : $@convention(cxx_method) (@in_guaranteed __CxxTemplateInst1MIxE) -> Int64
-// CHECK-LABEL: sil [serialized] [clang dependantReturnTypeInferred]  @{{_Z27dependantReturnTypeInferredIxE1MIT_ES1_|\?\?\$dependantReturnTypeInferred@_J@@YA\?AU\?\$M@_J@@_J@Z}} : $@convention(c) (Int64) -> __CxxTemplateInst1MIxE
+// CHECK-LABEL: sil [clang M<Int64>.getValue] @{{_ZNK1MIxE8getValueEv|\?getValue@\?\$M@_J@@QEBA_JXZ}} : $@convention(cxx_method) (@in_guaranteed M<Int64>) -> Int64
+// CHECK-LABEL: sil [serialized] [clang dependantReturnTypeInferred]  @{{_Z27dependantReturnTypeInferredIxE1MIT_ES1_|\?\?\$dependantReturnTypeInferred@_J@@YA\?AU\?\$M@_J@@_J@Z}} : $@convention(c) (Int64) -> M<Int64>

--- a/test/Interop/Cxx/templates/explicit-class-specialization-module-interface.swift
+++ b/test/Interop/Cxx/templates/explicit-class-specialization-module-interface.swift
@@ -1,9 +1,9 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=ExplicitClassSpecialization -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
-// CHECK: struct __CxxTemplateInst41HasEmptySpecializationAndStaticDateMemberIiE {
+// CHECK: struct HasEmptySpecializationAndStaticDateMember<Int32> {
 // CHECK:   static let value: Bool
 // CHECK: }
 
-// CHECK: struct __CxxTemplateInst41HasEmptySpecializationAndStaticDateMemberIcE {
+// CHECK: struct HasEmptySpecializationAndStaticDateMember<Int8> {
 // CHECK:   static let value: Bool
 // CHECK: }

--- a/test/Interop/Cxx/templates/large-class-templates-module-interface.swift
+++ b/test/Interop/Cxx/templates/large-class-templates-module-interface.swift
@@ -3,15 +3,13 @@
 // CHECK: struct HasTypeWithSelfAsParam<T> {
 // CHECK: }
 
-// CHECK: struct __CxxTemplateInst22HasTypeWithSelfAsParamIiE {
+// CHECK: struct HasTypeWithSelfAsParam<Int32> {
 // CHECK:   init()
-// CHECK:   typealias TT = __CxxTemplateInst22HasTypeWithSelfAsParamIS_IiEE
+// CHECK:   typealias TT = HasTypeWithSelfAsParam<HasTypeWithSelfAsParam<Int32>>
 // CHECK: }
 
-// CHECK: typealias WillBeInfinite = __CxxTemplateInst22HasTypeWithSelfAsParamIiE
+// CHECK: typealias WillBeInfinite = HasTypeWithSelfAsParam<Int32>
 
-// Make sure we fail to import super slow templates.
-// CHECK-NOT: __CxxTemplateInstN14RegressionTest7ValExprINS_9SliceExprINS_5ArrayIiEELi1EEEEE
 // TODO: we should not be importing functions that use this type in their
 // signature (such as the function below).
-// CHECK: mutating func test1() -> RegressionTest.__CxxTemplateInstN14RegressionTest7ValExprINS_9SliceExprINS_5ArrayIiEELi1EEEEE
+// CHECK: mutating func test1() -> RegressionTest.ValExpr<SliceExpr<SliceExpr<Array<Int32>, _>, _>>

--- a/test/Interop/Cxx/templates/linkage-of-swift-symbols-for-imported-types-irgen.swift
+++ b/test/Interop/Cxx/templates/linkage-of-swift-symbols-for-imported-types-irgen.swift
@@ -16,13 +16,13 @@ public func getMagicNumberForLinkageComparison() -> Any {
 // CHECK: $sSo11MagicNumberVMf" = linkonce_odr hidden constant
 // CHECK: $sSo11MagicNumberVML" = linkonce_odr hidden global
 
-// CHECK: $sSo034__CxxTemplateInst12MagicWrapperI11D7NumberEVWV" = linkonce_odr hidden constant
-// CHECK: $sSo034__CxxTemplateInst12MagicWrapperI11D7NumberEVMn" = linkonce_odr hidden constant
-// CHECK: $sSo034__CxxTemplateInst12MagicWrapperI11D7NumberEVMf" = linkonce_odr hidden constant
-// CHECK: $sSo034__CxxTemplateInst12MagicWrapperI11D7NumberEVML" = linkonce_odr hidden global
+// CHECK: $sSo0031MagicWrapperMagicNumber_IJFJhAbVWV" = linkonce_odr hidden constant
+// CHECK: $sSo0031MagicWrapperMagicNumber_IJFJhAbVMn" = linkonce_odr hidden constant
+// CHECK: $sSo0031MagicWrapperMagicNumber_IJFJhAbVMf" = linkonce_odr hidden constant
+// CHECK: $sSo0031MagicWrapperMagicNumber_IJFJhAbVML" = linkonce_odr hidden global
 
 // CHECK: $sSo11MagicNumberVMB" = linkonce_odr hidden constant
 // CHECK: $sSo11MagicNumberVMF" = linkonce_odr hidden constant
 
-// CHECK: $sSo034__CxxTemplateInst12MagicWrapperI11D7NumberEVMB" = linkonce_odr hidden constant
-// CHECK: $sSo034__CxxTemplateInst12MagicWrapperI11D7NumberEVMF" = linkonce_odr hidden constant
+// CHECK: $sSo0031MagicWrapperMagicNumber_IJFJhAbVMB" = linkonce_odr hidden constant
+// CHECK: $sSo0031MagicWrapperMagicNumber_IJFJhAbVMF" = linkonce_odr hidden constant

--- a/test/Interop/Cxx/templates/mangling-irgen.swift
+++ b/test/Interop/Cxx/templates/mangling-irgen.swift
@@ -5,16 +5,16 @@ import Mangling
 public func receiveInstantiation(_ i: inout WrappedMagicInt) {}
 
 // Don't forget to update manglings.txt when changing s4main20receiveInstantiationyySo34__CxxTemplateInst12MagicWrapperIiEVzF
-// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20receiveInstantiationyySo34__CxxTemplateInst12MagicWrapperIiEVzF"(%TSo34__CxxTemplateInst12MagicWrapperIiEV* nocapture dereferenceable(1) %0)
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20receiveInstantiationyySo0025MagicWrapperInt32_lsFCfibVzF"(%TSo0025MagicWrapperInt32_lsFCfibV* nocapture dereferenceable(1) %0)
 
 public func receiveInstantiation(_ i: inout WrappedMagicBool) {}
 
-// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20receiveInstantiationyySo34__CxxTemplateInst12MagicWrapperIbEVzF"(%TSo34__CxxTemplateInst12MagicWrapperIbEV* nocapture dereferenceable(1) %0)
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main20receiveInstantiationyySo0024MagicWrapperBool_npAIefbVzF"(%TSo0024MagicWrapperBool_npAIefbV* nocapture dereferenceable(1) %0)
 
 public func returnInstantiation() -> WrappedMagicInt {
   return WrappedMagicInt()
 }
 
 // Don't forget to update manglings.txt when changing s4main19returnInstantiationSo34__CxxTemplateInst12MagicWrapperIiEVyF
-// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main19returnInstantiationSo34__CxxTemplateInst12MagicWrapperIiEVyF"()
+// CHECK: define {{(protected |dllexport )?}}swiftcc void @"$s4main19returnInstantiationSo0025MagicWrapperInt32_lsFCfibVyF"()
 

--- a/test/Interop/Cxx/templates/mangling-silgen.swift
+++ b/test/Interop/Cxx/templates/mangling-silgen.swift
@@ -5,16 +5,16 @@ import Mangling
 public func recvInstantiation(_ i: inout WrappedMagicInt) {}
 
 // CHECK: // recvInstantiation(_:)
-// CHECK: sil @$s4main17recvInstantiationyySo34__CxxTemplateInst12MagicWrapperIiEVzF : $@convention(thin) (@inout __CxxTemplateInst12MagicWrapperIiE) -> ()
+// CHECK: sil @$s4main17recvInstantiationyySo0025MagicWrapperInt32_lsFCfibVzF : $@convention(thin) (@inout MagicWrapper<Int32>) -> ()
 
 public func recvInstantiation(_ i: inout WrappedMagicBool) {}
 
 // CHECK: // recvInstantiation(_:)
-// CHECK: sil @$s4main17recvInstantiationyySo34__CxxTemplateInst12MagicWrapperIbEVzF : $@convention(thin) (@inout __CxxTemplateInst12MagicWrapperIbE) -> ()
+// CHECK: sil @$s4main17recvInstantiationyySo0024MagicWrapperBool_npAIefbVzF : $@convention(thin) (@inout MagicWrapper<Bool>) -> ()
 
 public func returnInstantiation() -> WrappedMagicInt {
   return WrappedMagicInt()
 }
 
 // CHECK: // returnInstantiation()
-// CHECK: sil @$s4main19returnInstantiationSo34__CxxTemplateInst12MagicWrapperIiEVyF : $@convention(thin) () -> __CxxTemplateInst12MagicWrapperIiE
+// CHECK: sil @$s4main19returnInstantiationSo0025MagicWrapperInt32_lsFCfibVyF : $@convention(thin) () -> MagicWrapper<Int32>

--- a/test/Interop/Cxx/templates/member-templates-module-interface.swift
+++ b/test/Interop/Cxx/templates/member-templates-module-interface.swift
@@ -12,13 +12,13 @@
 // CHECK:   mutating func make42Ref<T>(_ val: inout T)
 // CHECK: }
 
-// CHECK: struct __CxxTemplateInst32TemplateClassWithMemberTemplatesIiE {
+// CHECK: struct TemplateClassWithMemberTemplates<Int32> {
 // CHECK:   init(_ val: Int32)
 // CHECK:   var value: Int32
 // CHECK:   mutating func setValue<U>(_ val: U)
 // CHECK: }
 
-// CHECK: typealias IntWrapper = __CxxTemplateInst32TemplateClassWithMemberTemplatesIiE
+// CHECK: typealias IntWrapper = TemplateClassWithMemberTemplates<Int32>
 
 // CHECK: struct HasStaticMemberTemplates {
 // CHECK:   init()
@@ -27,21 +27,21 @@
 // CHECK:   static func removeReference<T>(_ a: inout T) -> T
 // CHECK: }
 
-// CHECK: struct __CxxTemplateInst17MyTemplatedStructIiE {
+// CHECK: struct MyTemplatedStruct<Int32> {
 // CHECK:   init()
 // CHECK: }
 
 // CHECK: struct HasTemplatedField {
-// CHECK:   init(x: __CxxTemplateInst17MyTemplatedStructIiE)
-// CHECK:   var x: __CxxTemplateInst17MyTemplatedStructIiE
+// CHECK:   init(x: MyTemplatedStruct<Int32>)
+// CHECK:   var x: MyTemplatedStruct<Int32>
 // CHECK: }
 
-// CHECK: struct __CxxTemplateInst33HasUninstantiatableTemplateMemberIN39HasTemplateInstantiationWithForwardDecl12NoDefinitionE32TemplateClassWithMemberTemplatesIS1_EE {
+// CHECK: struct HasUninstantiatableTemplateMember<NoDefinition, TemplateClassWithMemberTemplates<NoDefinition>> {
 // CHECK:   init(pointer: OpaquePointer!)
 // CHECK:   var pointer: OpaquePointer!
 // CHECK: }
 
 // CHECK: struct HasTemplateInstantiationWithForwardDecl {
-// CHECK:   init(noDefMember: __CxxTemplateInst33HasUninstantiatableTemplateMemberIN39HasTemplateInstantiationWithForwardDecl12NoDefinitionE32TemplateClassWithMemberTemplatesIS1_EE)
-// CHECK:   var noDefMember: __CxxTemplateInst33HasUninstantiatableTemplateMemberIN39HasTemplateInstantiationWithForwardDecl12NoDefinitionE32TemplateClassWithMemberTemplatesIS1_EE
+// CHECK:   init(noDefMember: HasUninstantiatableTemplateMember<NoDefinition, TemplateClassWithMemberTemplates<NoDefinition>>)
+// CHECK:   var noDefMember: HasUninstantiatableTemplateMember<NoDefinition, TemplateClassWithMemberTemplates<NoDefinition>>
 // CHECK: }

--- a/test/Interop/Cxx/templates/member-templates-silgen.swift
+++ b/test/Interop/Cxx/templates/member-templates-silgen.swift
@@ -40,8 +40,8 @@ func basicTest() {
 
 // CHECK-LABEL: sil hidden @$s4main12testSetValueyyF : $@convention(thin) () -> ()
 
-// CHECK: [[SET_VALUE:%.*]] = function_ref @_ZN32TemplateClassWithMemberTemplatesIiE8setValueIlEEvT_ : $@convention(cxx_method) (Int, @inout __CxxTemplateInst32TemplateClassWithMemberTemplatesIiE) -> ()
-// CHECK: apply [[SET_VALUE]]({{.*}}) : $@convention(cxx_method) (Int, @inout __CxxTemplateInst32TemplateClassWithMemberTemplatesIiE) -> ()
+// CHECK: [[SET_VALUE:%.*]] = function_ref @_ZN32TemplateClassWithMemberTemplatesIiE8setValueIlEEvT_ : $@convention(cxx_method) (Int, @inout TemplateClassWithMemberTemplates<Int32>) -> ()
+// CHECK: apply [[SET_VALUE]]({{.*}}) : $@convention(cxx_method) (Int, @inout TemplateClassWithMemberTemplates<Int32>) -> ()
 
 // CHECK-LABEL: end sil function '$s4main12testSetValueyyF'
 func testSetValue() {

--- a/test/Interop/Cxx/templates/not-pre-defined-class-template-module-interface.swift
+++ b/test/Interop/Cxx/templates/not-pre-defined-class-template-module-interface.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=NotPreDefinedClassTemplate -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
-// CHECK:      struct __CxxTemplateInst12MagicWrapperI10IntWrapperE {
+// CHECK:      struct MagicWrapper<IntWrapper> {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(t: IntWrapper)
 // CHECK-NEXT:   var t: IntWrapper
@@ -14,4 +14,4 @@
 // CHECK-NEXT:   var value: Int32
 // CHECK-NEXT: }
 
-// CHECK-NEXT: typealias MagicallyWrappedIntWithoutDefinition = __CxxTemplateInst12MagicWrapperI10IntWrapperE
+// CHECK-NEXT: typealias MagicallyWrappedIntWithoutDefinition = MagicWrapper<IntWrapper>

--- a/test/Interop/Cxx/templates/partially-pre-defined-class-template-silgen.swift
+++ b/test/Interop/Cxx/templates/partially-pre-defined-class-template-silgen.swift
@@ -11,11 +11,11 @@ public func getWrappedMagicInt() -> CInt {
 // CHECK: // getWrappedMagicInt()
 // CHECK: sil @$s4main18getWrappedMagicInts5Int32VyF : $@convention(thin) () -> Int32 {
 // CHECK: [[INT_WRAPPER:%.*]] = struct $IntWrapper ([[_:%.*]] : $Int32)
-// CHECK: [[_:%.*]] = struct $__CxxTemplateInst12MagicWrapperI10IntWrapperE ([[INT_WRAPPER]] : $IntWrapper)
+// CHECK: [[_:%.*]] = struct $MagicWrapper<IntWrapper> ([[INT_WRAPPER]] : $IntWrapper)
 // CHECK: // function_ref {{_ZNK12MagicWrapperI10IntWrapperE15getValuePlusArgEi|\?getValuePlusArg@\?\$MagicWrapper@UIntWrapper@@@@QEBAHH@Z}}
-// CHECK: [[_:%.*]] = function_ref @{{_ZNK12MagicWrapperI10IntWrapperE15getValuePlusArgEi|\?getValuePlusArg@\?\$MagicWrapper@UIntWrapper@@@@QEBAHH@Z}} : $@convention(cxx_method) (Int32, @in_guaranteed __CxxTemplateInst12MagicWrapperI10IntWrapperE) -> Int32
+// CHECK: [[_:%.*]] = function_ref @{{_ZNK12MagicWrapperI10IntWrapperE15getValuePlusArgEi|\?getValuePlusArg@\?\$MagicWrapper@UIntWrapper@@@@QEBAHH@Z}} : $@convention(cxx_method) (Int32, @in_guaranteed MagicWrapper<IntWrapper>) -> Int32
 
 // CHECK: // {{_ZNK12MagicWrapperI10IntWrapperE15getValuePlusArgEi|\?getValuePlusArg@\?\$MagicWrapper@UIntWrapper@@@@QEBAHH@Z}}
 // CHECK: MagicWrapper<IntWrapper>::getValuePlusArg
 
-// CHECK: sil [clang __CxxTemplateInst12MagicWrapperI10IntWrapperE.getValuePlusArg] @{{_ZNK12MagicWrapperI10IntWrapperE15getValuePlusArgEi|\?getValuePlusArg@\?\$MagicWrapper@UIntWrapper@@@@QEBAHH@Z}} : $@convention(cxx_method) (Int32, @in_guaranteed __CxxTemplateInst12MagicWrapperI10IntWrapperE) -> Int32
+// CHECK: sil [clang MagicWrapper<IntWrapper>.getValuePlusArg] @{{_ZNK12MagicWrapperI10IntWrapperE15getValuePlusArgEi|\?getValuePlusArg@\?\$MagicWrapper@UIntWrapper@@@@QEBAHH@Z}} : $@convention(cxx_method) (Int32, @in_guaranteed MagicWrapper<IntWrapper>) -> Int32

--- a/test/Interop/Cxx/templates/swift-class-instantiation-module-interface.swift
+++ b/test/Interop/Cxx/templates/swift-class-instantiation-module-interface.swift
@@ -4,5 +4,5 @@
 
 
 // CHECK: import ClassTemplateForSwiftModule
-// CHECK: func makeWrappedMagicNumber() -> __CxxTemplateInst12MagicWrapperI10IntWrapperE
-// CHECK: func readWrappedMagicNumber(_ i: inout __CxxTemplateInst12MagicWrapperI10IntWrapperE) -> CInt
+// CHECK: func makeWrappedMagicNumber() -> MagicWrapper<IntWrapper>
+// CHECK: func readWrappedMagicNumber(_ i: inout MagicWrapper<IntWrapper>) -> CInt

--- a/test/Interop/Cxx/templates/using-directive-module-interface.swift
+++ b/test/Interop/Cxx/templates/using-directive-module-interface.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=UsingDirective -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
-// CHECK:      struct __CxxTemplateInst12MagicWrapperI10IntWrapperE {
+// CHECK:      struct MagicWrapper<IntWrapper> {
 // CHECK-NEXT:   init()
 // CHECK-NEXT:   init(t: IntWrapper)
 // CHECK-NEXT:   var t: IntWrapper
@@ -12,4 +12,4 @@
 // CHECK-NEXT:   func getValue() -> Int32
 // CHECK-NEXT:   var value: Int32
 // CHECK-NEXT: }
-// CHECK-NEXT: typealias UsingWrappedMagicNumber = __CxxTemplateInst12MagicWrapperI10IntWrapperE
+// CHECK-NEXT: typealias UsingWrappedMagicNumber = MagicWrapper<IntWrapper>

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx-execution.cpp
@@ -150,18 +150,18 @@ int main() {
 // CHECK-NEXT: move NonTrivialTemplate
 // CHECK-NEXT: ~NonTrivialTemplate
 // CHECK-NEXT: copy NonTrivialTemplate
-// CHECK-NEXT: __CxxTemplateInst18NonTrivialTemplateI7TrivialE(x: __C.Trivial(x: 42, y: -942))
+// CHECK-NEXT: NonTrivialTemplate<Trivial>(x: __C.Trivial(x: 42, y: -942))
 // CHECK-NEXT: ~NonTrivialTemplate
 // CHECK-NEXT: ~NonTrivialTemplate
 // CHECK-NEXT: done non trivial
 // CHECK-NEXT: copy NonTrivialTemplate
-// CHECK-NEXT: GENERIC __CxxTemplateInst18NonTrivialTemplateI7TrivialE(x: __C.Trivial(x: 42, y: -1884))
+// CHECK-NEXT: GENERIC NonTrivialTemplate<Trivial>(x: __C.Trivial(x: 42, y: -1884))
 // CHECK-NEXT: ~NonTrivialTemplate
 // CHECK-NEXT: copy NonTrivialTemplate
 // CHECK-NEXT: move NonTrivialTemplate
 // CHECK-NEXT: ~NonTrivialTemplate
 // CHECK-NEXT: copy NonTrivialTemplate
-// CHECK-NEXT: __CxxTemplateInst18NonTrivialTemplateI7TrivialE(x: __C.Trivial(x: 42, y: -1884))
+// CHECK-NEXT: NonTrivialTemplate<Trivial>(x: __C.Trivial(x: 42, y: -1884))
 // CHECK-NEXT: ~NonTrivialTemplate
 // CHECK-NEXT: ~NonTrivialTemplate
 // CHECK-NEXT: secondon non trivial

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -153,7 +153,7 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: #endif
 
 
-// CHECK: SWIFT_EXTERN void $s8UseCxxTy13retNonTrivialSo2nsO02__b18TemplateInstN2ns18efH4IiEEVyF(SWIFT_INDIRECT_RESULT void * _Nonnull) SWIFT_NOEXCEPT SWIFT_CALL; // retNonTrivial()
+// CHECK: SWIFT_EXTERN void $s8UseCxxTy13retNonTrivialSo2nsO0031NonTrivialTemplateInt32_fbGJhubVyF(SWIFT_INDIRECT_RESULT void * _Nonnull) SWIFT_NOEXCEPT SWIFT_CALL; // retNonTrivial()
 // CHECK: SWIFT_EXTERN struct swift_interop_returnStub_UseCxxTy_uint32_t_0_4 $s8UseCxxTy10retTrivialSo0E0VyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // retTrivial()
 
 // CHECK: ns::Immortal *_Nonnull retImmortal() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
@@ -161,7 +161,7 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: }
 
 // CHECK:  ns::ImmortalTemplate<int> *_Nonnull retImmortalTemplate() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
-// CHECK-NEXT: return _impl::$s8UseCxxTy19retImmortalTemplateSo2nsO02__bf10InstN2ns16eF4IiEEVyF();
+// CHECK-NEXT: return _impl::$s8UseCxxTy19retImmortalTemplateSo2nsO0029ImmortalTemplateInt32_hEFAhqbVyF();
 // CHECK-NEXT: }
 
 // CHECK: } // end namespace
@@ -170,7 +170,7 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: namespace _impl {
 // CHECK-EMPTY:
 // CHECK-NEXT: // Type metadata accessor for NonTrivialTemplateInt
-// CHECK-NEXT: SWIFT_EXTERN swift::_impl::MetadataResponseTy $sSo2nsO033__CxxTemplateInstN2ns18NonTrivialC4IiEEVMa(swift::_impl::MetadataRequestTy) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK-NEXT: SWIFT_EXTERN swift::_impl::MetadataResponseTy $sSo2nsO0031NonTrivialTemplateInt32_fbGJhubVMa(swift::_impl::MetadataRequestTy) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-EMPTY:
 // CHECK-EMPTY:
 // CHECK-NEXT: } // namespace _impl
@@ -182,7 +182,7 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<ns::NonTrivialTemplateInt> {
 // CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
-// CHECK-NEXT:     return _impl::$sSo2nsO033__CxxTemplateInstN2ns18NonTrivialC4IiEEVMa(0)._0;
+// CHECK-NEXT:     return _impl::$sSo2nsO0031NonTrivialTemplateInt32_fbGJhubVMa(0)._0;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
 // CHECK-NEXT: namespace _impl{
@@ -197,7 +197,7 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK: inline ns::NonTrivialTemplate<int> retNonTrivial() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: alignas(alignof(ns::NonTrivialTemplate<int>)) char storage[sizeof(ns::NonTrivialTemplate<int>)];
 // CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialTemplate<int> *>(storage);
-// CHECK-NEXT: _impl::$s8UseCxxTy13retNonTrivialSo2nsO02__b18TemplateInstN2ns18efH4IiEEVyF(storage);
+// CHECK-NEXT: _impl::$s8UseCxxTy13retNonTrivialSo2nsO0031NonTrivialTemplateInt32_fbGJhubVyF(storage);
 // CHECK-NEXT: ns::NonTrivialTemplate<int> result(static_cast<ns::NonTrivialTemplate<int> &&>(*storageObjectPtr));
 // CHECK-NEXT: storageObjectPtr->~NonTrivialTemplate();
 // CHECK-NEXT: return result;
@@ -209,7 +209,7 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: namespace _impl {
 // CHECK-EMPTY:
 // CHECK-NEXT: // Type metadata accessor for NonTrivialTemplateTrivial
-// CHECK-NEXT: SWIFT_EXTERN swift::_impl::MetadataResponseTy $sSo2nsO033__CxxTemplateInstN2ns18NonTrivialC20INS_11TrivialinNSEEEVMa(swift::_impl::MetadataRequestTy) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK-NEXT: SWIFT_EXTERN swift::_impl::MetadataResponseTy $sSo2nsO0037NonTrivialTemplateTrivialinNS_CsGGkdcVMa(swift::_impl::MetadataRequestTy) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-EMPTY:
 // CHECK-EMPTY:
 // CHECK-NEXT: } // namespace _impl
@@ -221,7 +221,7 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: template<>
 // CHECK-NEXT: struct TypeMetadataTrait<ns::NonTrivialTemplateTrivial> {
 // CHECK-NEXT:   static inline void * _Nonnull getTypeMetadata() {
-// CHECK-NEXT:     return _impl::$sSo2nsO033__CxxTemplateInstN2ns18NonTrivialC20INS_11TrivialinNSEEEVMa(0)._0;
+// CHECK-NEXT:     return _impl::$sSo2nsO0037NonTrivialTemplateTrivialinNS_CsGGkdcVMa(0)._0;
 // CHECK-NEXT:   }
 // CHECK-NEXT: };
 // CHECK-NEXT: namespace _impl{
@@ -236,7 +236,7 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: inline ns::NonTrivialTemplate<ns::TrivialinNS> retNonTrivial2() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: alignas(alignof(ns::NonTrivialTemplate<ns::TrivialinNS>)) char storage[sizeof(ns::NonTrivialTemplate<ns::TrivialinNS>)];
 // CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialTemplate<ns::TrivialinNS> *>(storage);
-// CHECK-NEXT: _impl::$s8UseCxxTy14retNonTrivial2So2nsO02__b18TemplateInstN2ns18e7TrivialH20INS_11TrivialinNSEEEVyF(storage);
+// CHECK-NEXT: _impl::$s8UseCxxTy14retNonTrivial2So2nsO0037NonTrivialTemplateTrivialinNS_CsGGkdcVyF(storage);
 // CHECK-NEXT: ns::NonTrivialTemplate<ns::TrivialinNS> result(static_cast<ns::NonTrivialTemplate<ns::TrivialinNS> &&>(*storageObjectPtr));
 // CHECK-NEXT: storageObjectPtr->~NonTrivialTemplate();
 // CHECK-NEXT: return result;
@@ -265,11 +265,11 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: }
 
 // CHECK: void takeImmortalTemplate(ns::ImmortalTemplate<int> *_Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) {
-// CHECK-NEXT:   return _impl::$s8UseCxxTy20takeImmortalTemplateyySo2nsO02__bf10InstN2ns16eF4IiEEVF(x);
+// CHECK-NEXT:   return _impl::$s8UseCxxTy20takeImmortalTemplateyySo2nsO0029ImmortalTemplateInt32_hEFAhqbVF(x);
 // CHECK-NEXT: }
 
 // CHECK: inline void takeNonTrivial2(const ns::NonTrivialTemplate<ns::TrivialinNS>& x) noexcept SWIFT_SYMBOL({{.*}}) {
-// CHECK-NEXT:   return _impl::$s8UseCxxTy15takeNonTrivial2yySo2nsO02__b18TemplateInstN2ns18e7TrivialH20INS_11TrivialinNSEEEVF(swift::_impl::getOpaquePointer(x));
+// CHECK-NEXT:   return _impl::$s8UseCxxTy15takeNonTrivial2yySo2nsO0037NonTrivialTemplateTrivialinNS_CsGGkdcVF(swift::_impl::getOpaquePointer(x));
 // CHECK-NEXT: }
 
 // CHECK: inline void takeTrivial(const Trivial& x) noexcept SWIFT_SYMBOL({{.*}}) {


### PR DESCRIPTION
Instead of mangling class template specializations with the prefix "__CxxTemplateInst," simply set the decl name as the class templates plus the types that it is specialized on (so `vector<Int>` rather than `__CxxTemplateInstNSt3__16vectorIi...`).

This is mainly to improve diagnostics. As a side effect of this change, if anyone copies the name of a class template specialization from an error/warning and uses it in source code, the compiler will error (that class templates aren't available in swift) rather than silently passing only to cause serialization failures down the road.