### PR TITLE
Basic/type_traits: use `__is_identifier` for some feature checks

### DIFF
--- a/include/swift/Basic/type_traits.h
+++ b/include/swift/Basic/type_traits.h
@@ -49,7 +49,7 @@ struct IsTriviallyConstructible {
 #if defined(_LIBCPP_VERSION) || SWIFT_COMPILER_IS_MSVC
   // libc++ and MSVC implement is_trivially_constructible.
   static const bool value = std::is_trivially_constructible<T>::value;
-#elif __has_keyword(__is_trivially_constructible)
+#elif __has_feature(is_trivially_constructible) || __has_keyword(__is_trivially_constructible)
   static const bool value = __is_trivially_constructible(T);
 #elif __has_feature(has_trivial_constructor) || __GNUC__ >= 5
   static const bool value = __has_trivial_constructor(T);
@@ -63,7 +63,7 @@ struct IsTriviallyDestructible {
 #if defined(_LIBCPP_VERSION) || SWIFT_COMPILER_IS_MSVC
   // libc++ and MSVC implement is_trivially_destructible.
   static const bool value = std::is_trivially_destructible<T>::value;
-#elif __has_keyword(__is_trivially_destructible)
+#elif __has_feature(is_trivially_destructible) || __has_keyword(__is_trivially_destructible)
   static const bool value = __is_trivially_destructible(T);
 #elif __has_feature(has_trivial_destructor) || __GNUC__ >= 5
   static const bool value = __has_trivial_destructor(T);

--- a/include/swift/Basic/type_traits.h
+++ b/include/swift/Basic/type_traits.h
@@ -16,6 +16,10 @@
 #include <type_traits>
 #include "swift/Basic/Compiler.h"
 
+#ifndef __has_keyword
+#define __has_keyword(__x) !(__is_identifier(__x))
+#endif
+
 #ifndef __has_feature
 #define SWIFT_DEFINED_HAS_FEATURE
 #define __has_feature(x) 0
@@ -45,7 +49,7 @@ struct IsTriviallyConstructible {
 #if defined(_LIBCPP_VERSION) || SWIFT_COMPILER_IS_MSVC
   // libc++ and MSVC implement is_trivially_constructible.
   static const bool value = std::is_trivially_constructible<T>::value;
-#elif __has_feature(is_trivially_constructible)
+#elif __has_keyword(__is_trivially_constructible)
   static const bool value = __is_trivially_constructible(T);
 #elif __has_feature(has_trivial_constructor) || __GNUC__ >= 5
   static const bool value = __has_trivial_constructor(T);
@@ -59,7 +63,7 @@ struct IsTriviallyDestructible {
 #if defined(_LIBCPP_VERSION) || SWIFT_COMPILER_IS_MSVC
   // libc++ and MSVC implement is_trivially_destructible.
   static const bool value = std::is_trivially_destructible<T>::value;
-#elif __has_feature(is_trivially_destructible)
+#elif __has_keyword(__is_trivially_destructible)
   static const bool value = __is_trivially_destructible(T);
 #elif __has_feature(has_trivial_destructor) || __GNUC__ >= 5
   static const bool value = __has_trivial_destructor(T);


### PR DESCRIPTION
When building on Alpine with Musl `__has_feature(is_trivially_constructible)` does not work, even though `__is_trivially_constructible` is defined and `__has_trivial_constructor` is deprecated. Same for `__is_trivially_destructible` and `__has_trivial_destructor` respectively.
