### PR TITLE
[cmake] Propagate `lit_jobs` to `LLVM_LIT_ARGS`

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/cmake_product.py
+++ b/utils/swift_build_support/swift_build_support/products/cmake_product.py
@@ -408,9 +408,9 @@ class CMakeProduct(product.Product):
         swift_cmake_options.define('SWIFT_HOST_VARIANT_ARCH', swift_host_variant_arch)
 
         llvm_cmake_options.define('LLVM_LIT_ARGS', '{} -j {}'.format(
-            self.args.lit_args, self.args.build_jobs))
+            self.args.lit_args, self.args.lit_jobs))
         swift_cmake_options.define('LLVM_LIT_ARGS', '{} -j {}'.format(
-            self.args.lit_args, self.args.build_jobs))
+            self.args.lit_args, self.args.lit_jobs))
 
         if self.args.clang_profile_instr_use:
             llvm_cmake_options.define('LLVM_PROFDATA_FILE',


### PR DESCRIPTION
Missed this when I originally added the `--lit-jobs` build-script option in #61096, propagate the value provided to `LLVM_LIT_ARGS` in addition to `SWIFT_LIT_ARGS`.
