### PR TITLE
[Runtime] Fatal error when resolving a symbolic reference to NULL.

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -118,6 +118,22 @@ ResolveAsSymbolicReference::operator()(SymbolicReferenceKind kind,
                                        const void *base) {
   // Resolve the absolute pointer to the entity being referenced.
   auto ptr = resolveSymbolicReferenceOffset(kind, isIndirect, offset, base);
+  if (SWIFT_UNLIKELY(!ptr)) {
+    auto symInfo = SymbolInfo::lookup(base);
+    const char *fileName = "<unknown>";
+    const char *symbolName = "<unknown>";
+    if (symInfo) {
+      if (symInfo->getFilename())
+        fileName = symInfo->getFilename();
+      if (symInfo->getSymbolName())
+        symbolName = symInfo->getSymbolName();
+    }
+    swift::fatalError(
+        0,
+        "Failed to look up symbolic reference at %p - offset %" PRId32
+        " - symbol %s in %s\n",
+        base, offset, symbolName, fileName);
+  }
 
   // Figure out this symbolic reference's grammatical role.
   Node::Kind nodeKind;


### PR DESCRIPTION
We crash in ResolveAsSymbolicReference::operator() when a symbolic reference targets a missing symbol. We usually have very little information about what was missing when this happens. Instead of crashing, explicitly check for NULL and fatal error in that case, including information about the location of the symbolic reference that it came from.