### PR TITLE
Add Sendable conformance to EnumeratedSequence when possible

### DIFF
--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -164,5 +164,4 @@ extension EnumeratedSequence: Sequence {
   }
 }
 
-@available(SwiftStdlib 5.8, *)
 extension EnumeratedSequence: Sendable where Base: Sendable {}

--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -157,4 +157,12 @@ extension EnumeratedSequence: Sequence {
   public __consuming func makeIterator() -> Iterator {
     return Iterator(_base: _base.makeIterator())
   }
+  
+  @_alwaysEmitIntoClient
+  public var underestimatedCount: Int {
+    _base.underestimatedCount
+  }
 }
+
+@available(SwiftStdlib 5.8, *)
+extension EnumeratedSequence: Sendable where Base: Sendable {}


### PR DESCRIPTION
This change adds `Sendable` conformance to `EnumeratedSequence` when the base sequence itself is `Sendable`. It also includes a customization of `Sequence.underestimatedCount` that passes through the base sequence's value.

rdar://103954542