### PR TITLE
[interop][SwiftToCxx] Annotate emitted declarations with Clang's external_source_symbol attribute

### DIFF
--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -12,9 +12,11 @@
 
 #include "ClangSyntaxPrinter.h"
 #include "swift/ABI/MetadataValues.h"
+#include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/SwiftNameTranslation.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/NestedNameSpecifier.h"
@@ -140,6 +142,7 @@ void ClangSyntaxPrinter::printModuleNamespaceStart(
   os << "namespace ";
   printBaseName(&moduleContext);
   os << " __attribute__((swift_private))";
+  printSymbolUSRAttribute(&moduleContext);
   os << " {\n";
 }
 
@@ -147,11 +150,13 @@ void ClangSyntaxPrinter::printModuleNamespaceStart(
 void ClangSyntaxPrinter::printNamespace(
     llvm::function_ref<void(raw_ostream &OS)> namePrinter,
     llvm::function_ref<void(raw_ostream &OS)> bodyPrinter,
-    NamespaceTrivia trivia) const {
+    NamespaceTrivia trivia, const ModuleDecl *moduleContext) const {
   os << "namespace ";
   namePrinter(os);
   if (trivia == NamespaceTrivia::AttributeSwiftPrivate)
     os << " __attribute__((swift_private))";
+  if (moduleContext)
+    printSymbolUSRAttribute(moduleContext);
   os << " {\n\n";
   bodyPrinter(os);
   os << "\n} // namespace ";
@@ -404,4 +409,18 @@ void ClangSyntaxPrinter::printIgnoredDiagnosticBlock(
 void ClangSyntaxPrinter::printIgnoredCxx17ExtensionDiagnosticBlock(
     llvm::function_ref<void()> bodyPrinter) {
   printIgnoredDiagnosticBlock("c++17-extensions", bodyPrinter);
+}
+
+void ClangSyntaxPrinter::printSymbolUSRAttribute(const ValueDecl *D) const {
+  if (isa<ModuleDecl>(D)) {
+    os << " SWIFT_SYMBOL_MODULE(\"";
+    printBaseName(D);
+    os << "\")";
+    return;
+  }
+  auto result = evaluateOrDefault(D->getASTContext().evaluator,
+                                  USRGenerationRequest{D}, std::string());
+  if (result.empty())
+    return;
+  os << " SWIFT_SYMBOL(\"" << result << "\")";
 }

--- a/lib/PrintAsClang/ClangSyntaxPrinter.h
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.h
@@ -125,7 +125,8 @@ public:
   /// Print a C++ namespace declaration with the give name and body.
   void printNamespace(llvm::function_ref<void(raw_ostream &OS)> namePrinter,
                       llvm::function_ref<void(raw_ostream &OS)> bodyPrinter,
-                      NamespaceTrivia trivia = NamespaceTrivia::None) const;
+                      NamespaceTrivia trivia = NamespaceTrivia::None,
+                      const ModuleDecl *moduleContext = nullptr) const;
 
   void printNamespace(StringRef name,
                       llvm::function_ref<void(raw_ostream &OS)> bodyPrinter,
@@ -219,6 +220,10 @@ public:
 
   void printIgnoredCxx17ExtensionDiagnosticBlock(
       llvm::function_ref<void()> bodyPrinter);
+
+  /// Print the macro that applies Clang's `external_source_symbol` attribute
+  /// on the generated declaration.
+  void printSymbolUSRAttribute(const ValueDecl *D) const;
 
 protected:
   raw_ostream &os;

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1413,6 +1413,8 @@ private:
         owningPrinter.interopContext, owningPrinter);
     DeclAndTypeClangFunctionPrinter::FunctionSignatureModifiers modifiers;
     modifiers.isInline = true;
+    // FIXME: Support throwing exceptions for Swift errors.
+    modifiers.isNoexcept = !funcTy->isThrowing();
     auto result = funcPrinter.printFunctionSignature(
         FD, funcABI.getSignature(), cxx_translation::getNameForCxx(FD),
         resultTy,
@@ -1420,9 +1422,6 @@ private:
         modifiers);
     assert(
         !result.isUnsupported()); // The C signature should be unsupported too.
-    // FIXME: Support throwing exceptions for Swift errors.
-    if (!funcTy->isThrowing())
-      os << " noexcept";
     printFunctionClangAttributes(FD, funcTy);
     printAvailability(FD);
     os << " {\n";

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -731,6 +731,8 @@ private:
       }
       os << "  } ";
       syntaxPrinter.printIdentifier(caseName);
+      if (elementDecl)
+        syntaxPrinter.printSymbolUSRAttribute(elementDecl);
       os << ";\n";
     };
 
@@ -742,6 +744,7 @@ private:
           [&](const auto &pair) {
             os << "\n    ";
             syntaxPrinter.printIdentifier(pair.first->getNameStr());
+            syntaxPrinter.printSymbolUSRAttribute(pair.first);
           },
           ",");
       // TODO: allow custom name for this special case

--- a/lib/PrintAsClang/PrintClangClassType.cpp
+++ b/lib/PrintAsClang/PrintClangClassType.cpp
@@ -58,7 +58,9 @@ void ClangClassTypePrinter::printClassTypeDecl(
     baseClassQualifiedName = "swift::_impl::RefCountedClass";
   }
 
-  os << "class ";
+  os << "class";
+  ClangSyntaxPrinter(os).printSymbolUSRAttribute(typeDecl);
+  os << ' ';
   printer.printBaseName(typeDecl);
   if (typeDecl->isFinal())
     os << " final";

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -905,6 +905,9 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
     os << " const";
   if (modifiers.isNoexcept)
     os << " noexcept";
+  if (modifiers.hasSymbolUSR)
+    ClangSyntaxPrinter(os).printSymbolUSRAttribute(
+        modifiers.symbolUSROverride ? modifiers.symbolUSROverride : FD);
   return resultingRepresentation;
 }
 
@@ -1311,6 +1314,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxMethod(
       isa<FuncDecl>(FD) ? cast<FuncDecl>(FD)->isMutating() : false;
   modifiers.isConst =
       !isa<ClassDecl>(typeDeclContext) && !isMutating && !isConstructor;
+  modifiers.hasSymbolUSR = !isDefinition;
   auto result = printFunctionSignature(
       FD, signature,
       isConstructor ? getConstructorName(FD)
@@ -1375,6 +1379,8 @@ void DeclAndTypeClangFunctionPrinter::printCxxPropertyAccessorMethod(
   modifiers.isInline = true;
   modifiers.isConst =
       !isStatic && accessor->isGetter() && !isa<ClassDecl>(typeDeclContext);
+  modifiers.hasSymbolUSR = !isDefinition;
+  modifiers.symbolUSROverride = accessor->getStorage();
   auto result = printFunctionSignature(
       accessor, signature, remapPropertyName(accessor, resultTy), resultTy,
       FunctionSignatureKind::CxxInlineThunk, modifiers);

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -903,6 +903,8 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
   os << ')';
   if (modifiers.isConst)
     os << " const";
+  if (modifiers.isNoexcept)
+    os << " noexcept";
   return resultingRepresentation;
 }
 

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -87,6 +87,10 @@ public:
     bool isInline = false;
     bool isConst = false;
     bool isNoexcept = false;
+    bool hasSymbolUSR = true;
+    /// Specific declaration that should be used to emit the symbol's
+    /// USR instead of the original function declaration.
+    const ValueDecl *symbolUSROverride = nullptr;
 
     FunctionSignatureModifiers() {}
   };

--- a/lib/PrintAsClang/PrintClangFunction.h
+++ b/lib/PrintAsClang/PrintClangFunction.h
@@ -86,6 +86,7 @@ public:
     bool isStatic = false;
     bool isInline = false;
     bool isConst = false;
+    bool isNoexcept = false;
 
     FunctionSignatureModifiers() {}
   };

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -88,7 +88,9 @@ void ClangValueTypePrinter::forwardDeclType(raw_ostream &os,
         typeDecl->getGenericSignature().getCanonicalSignature();
     ClangSyntaxPrinter(os).printGenericSignature(genericSignature);
   }
-  os << "class ";
+  os << "class";
+  ClangSyntaxPrinter(os).printSymbolUSRAttribute(typeDecl);
+  os << ' ';
   ClangSyntaxPrinter(os).printBaseName(typeDecl);
   os << ";\n";
   printTypePrecedingGenericTraits(os, typeDecl, typeDecl->getModuleContext());
@@ -259,7 +261,9 @@ void ClangValueTypePrinter::printValueTypeDecl(
 
   // Print out the C++ class itself.
   printGenericSignature(os);
-  os << "class ";
+  os << "class";
+  ClangSyntaxPrinter(os).printSymbolUSRAttribute(typeDecl);
+  os << ' ';
   ClangSyntaxPrinter(os).printBaseName(typeDecl);
   os << " final {\n";
   os << "public:\n";

--- a/lib/PrintAsClang/_SwiftCxxInteroperability.h
+++ b/lib/PrintAsClang/_SwiftCxxInteroperability.h
@@ -31,6 +31,29 @@
 // FIXME: Use always_inline, artificial.
 #define SWIFT_INLINE_THUNK inline
 
+/// The `SWIFT_SYMBOL_MODULE` and `SWIFT_SYMBOL_MODULE_USR` macros apply
+/// `external_source_symbol` Clang attributes to C++ declarations that represent
+/// Swift declarations. This allows Clang to index them as external
+/// declarations, using the specified Swift USR values.
+#if __has_attribute(external_source_symbol)
+#define SWIFT_SYMBOL_MODULE(moduleValue)                                       \
+  __attribute__((external_source_symbol(                                       \
+      language = "Swift", defined_in = moduleValue, generated_declaration)))
+#if __has_attribute(external_source_symbol_with_usr)
+#define SWIFT_SYMBOL_MODULE_USR(moduleValue, usrValue)                         \
+  __attribute__((                                                              \
+      external_source_symbol(language = "Swift", defined_in = moduleValue,     \
+                             generated_declaration, USR = usrValue)))
+#else
+#define SWIFT_SYMBOL_MODULE_USR(moduleValue, usrValue)                         \
+  __attribute__((external_source_symbol(                                       \
+      language = "Swift", defined_in = moduleValue, generated_declaration)))
+#endif
+#else
+#define SWIFT_SYMBOL_MODULE_USR(moduleValue, usrValue)
+#define SWIFT_SYMBOL_MODULE(moduleValue)
+#endif
+
 namespace swift {
 namespace _impl {
 

--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -156,11 +156,11 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK: SWIFT_EXTERN void $s8UseCxxTy13retNonTrivialSo2nsO02__b18TemplateInstN2ns18efH4IiEEVyF(SWIFT_INDIRECT_RESULT void * _Nonnull) SWIFT_NOEXCEPT SWIFT_CALL; // retNonTrivial()
 // CHECK: SWIFT_EXTERN struct swift_interop_returnStub_UseCxxTy_uint32_t_0_4 $s8UseCxxTy10retTrivialSo0E0VyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // retTrivial()
 
-// CHECK: ns::Immortal *_Nonnull retImmortal() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: ns::Immortal *_Nonnull retImmortal() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: return _impl::$s8UseCxxTy11retImmortalSo2nsO0E0VyF();
 // CHECK-NEXT: }
 
-// CHECK:  ns::ImmortalTemplate<int> *_Nonnull retImmortalTemplate() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:  ns::ImmortalTemplate<int> *_Nonnull retImmortalTemplate() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: return _impl::$s8UseCxxTy19retImmortalTemplateSo2nsO02__bf10InstN2ns16eF4IiEEVyF();
 // CHECK-NEXT: }
 
@@ -192,9 +192,9 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: } // namespace swift
 // CHECK-EMPTY:
-// CHECK-NEXT: namespace UseCxxTy __attribute__((swift_private)) {
+// CHECK-NEXT: namespace UseCxxTy __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("UseCxxTy") {
 
-// CHECK: inline ns::NonTrivialTemplate<int> retNonTrivial() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline ns::NonTrivialTemplate<int> retNonTrivial() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: alignas(alignof(ns::NonTrivialTemplate<int>)) char storage[sizeof(ns::NonTrivialTemplate<int>)];
 // CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialTemplate<int> *>(storage);
 // CHECK-NEXT: _impl::$s8UseCxxTy13retNonTrivialSo2nsO02__b18TemplateInstN2ns18efH4IiEEVyF(storage);
@@ -231,9 +231,9 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: } // namespace swift
 // CHECK-EMPTY:
-// CHECK-NEXT: namespace UseCxxTy __attribute__((swift_private)) {
+// CHECK-NEXT: namespace UseCxxTy __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("UseCxxTy") {
 // CHECK-EMPTY:
-// CHECK-NEXT: inline ns::NonTrivialTemplate<ns::TrivialinNS> retNonTrivial2() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: inline ns::NonTrivialTemplate<ns::TrivialinNS> retNonTrivial2() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: alignas(alignof(ns::NonTrivialTemplate<ns::TrivialinNS>)) char storage[sizeof(ns::NonTrivialTemplate<ns::TrivialinNS>)];
 // CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialTemplate<ns::TrivialinNS> *>(storage);
 // CHECK-NEXT: _impl::$s8UseCxxTy14retNonTrivial2So2nsO02__b18TemplateInstN2ns18e7TrivialH20INS_11TrivialinNSEEEVyF(storage);
@@ -242,7 +242,7 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: return result;
 // CHECK-NEXT: }
 
-// CHECK: inline ns::NonTrivialImplicitMove retNonTrivialImplicitMove() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline ns::NonTrivialImplicitMove retNonTrivialImplicitMove() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: alignas(alignof(ns::NonTrivialImplicitMove)) char storage[sizeof(ns::NonTrivialImplicitMove)];
 // CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<ns::NonTrivialImplicitMove *>(storage);
 // CHECK-NEXT: _impl::$s8UseCxxTy25retNonTrivialImplicitMoveSo2nsO0efgH0VyF(storage);
@@ -251,31 +251,31 @@ public func takeTrivialInout(_ x: inout Trivial) {
 // CHECK-NEXT: return result;
 // CHECK-NEXT: }
 
-// CHECK: ns::NonTrivialTemplate<ns::TrivialinNS> retNonTrivialTypeAlias() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: ns::NonTrivialTemplate<ns::TrivialinNS> retNonTrivialTypeAlias() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 
-// CHECK: inline Trivial retTrivial() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline Trivial retTrivial() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: alignas(alignof(Trivial)) char storage[sizeof(Trivial)];
 // CHECK-NEXT: auto * _Nonnull storageObjectPtr = reinterpret_cast<Trivial *>(storage);
 // CHECK-NEXT: _impl::swift_interop_returnDirect_UseCxxTy_uint32_t_0_4(storage, _impl::$s8UseCxxTy10retTrivialSo0E0VyF());
 // CHECK-NEXT: return *storageObjectPtr;
 // CHECK-NEXT: }
 
-// CHECK: void takeImmortal(ns::Immortal *_Nonnull x) noexcept {
+// CHECK: void takeImmortal(ns::Immortal *_Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT: return _impl::$s8UseCxxTy12takeImmortalyySo2nsO0E0VF(x);
 // CHECK-NEXT: }
 
-// CHECK: void takeImmortalTemplate(ns::ImmortalTemplate<int> *_Nonnull x) noexcept {
+// CHECK: void takeImmortalTemplate(ns::ImmortalTemplate<int> *_Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   return _impl::$s8UseCxxTy20takeImmortalTemplateyySo2nsO02__bf10InstN2ns16eF4IiEEVF(x);
 // CHECK-NEXT: }
 
-// CHECK: inline void takeNonTrivial2(const ns::NonTrivialTemplate<ns::TrivialinNS>& x) noexcept {
+// CHECK: inline void takeNonTrivial2(const ns::NonTrivialTemplate<ns::TrivialinNS>& x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   return _impl::$s8UseCxxTy15takeNonTrivial2yySo2nsO02__b18TemplateInstN2ns18e7TrivialH20INS_11TrivialinNSEEEVF(swift::_impl::getOpaquePointer(x));
 // CHECK-NEXT: }
 
-// CHECK: inline void takeTrivial(const Trivial& x) noexcept {
+// CHECK: inline void takeTrivial(const Trivial& x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   return _impl::$s8UseCxxTy11takeTrivialyySo0E0VF(_impl::swift_interop_passDirect_UseCxxTy_uint32_t_0_4(reinterpret_cast<const char *>(swift::_impl::getOpaquePointer(x))));
 // CHECK-NEXT: }
 
-// CHECK: inline void takeTrivialInout(Trivial& x) noexcept {
+// CHECK: inline void takeTrivialInout(Trivial& x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   return _impl::$s8UseCxxTy16takeTrivialInoutyySo0E0VzF(swift::_impl::getOpaquePointer(x));
 // CHECK-NEXT: }

--- a/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
+++ b/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
@@ -59,17 +59,17 @@ public func retObjClassNullable() -> ObjCKlass? {
 // CHECK-NEXT: void $s9UseObjCTy04takeB11CClassInoutyySo0B6CKlassCzF(ObjCKlass *_Nonnull __strong * _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: void $s9UseObjCTy04takeB14CClassNullableyySo0B6CKlassCSgF(ObjCKlass *_Nullable x) SWIFT_NOEXCEPT SWIFT_CALL;
 
-// CHECK: inline ObjCKlass *_Nonnull retObjClass() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline ObjCKlass *_Nonnull retObjClass() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: return (__bridge_transfer ObjCKlass *)(__bridge void *)_impl::$s9UseObjCTy03retB5ClassSo0B6CKlassCyF();
 
-// CHECK: inline ObjCKlass *_Nullable retObjClassNullable() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline ObjCKlass *_Nullable retObjClassNullable() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: return (__bridge_transfer ObjCKlass *)(__bridge void *)_impl::$s9UseObjCTy03retB13ClassNullableSo0B6CKlassCSgyF();
 
-// CHECK: void takeObjCClass(ObjCKlass *_Nonnull x) noexcept {
+// CHECK: void takeObjCClass(ObjCKlass *_Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT: return _impl::$s9UseObjCTy04takeB6CClassyySo0B6CKlassCF(x);
 
-// CHECK: inline void takeObjCClassInout(ObjCKlass *_Nonnull __strong & x) noexcept {
+// CHECK: inline void takeObjCClassInout(ObjCKlass *_Nonnull __strong & x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT: return _impl::$s9UseObjCTy04takeB11CClassInoutyySo0B6CKlassCzF(&x);
 
-// CHECK: inline void takeObjCClassNullable(ObjCKlass *_Nullable x) noexcept {
+// CHECK: inline void takeObjCClassNullable(ObjCKlass *_Nullable x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT: return _impl::$s9UseObjCTy04takeB14CClassNullableyySo0B6CKlassCSgF(x);

--- a/test/Interop/SwiftToCxx/class/swift-actor-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/swift-actor-in-cxx.swift
@@ -30,13 +30,13 @@ public final actor ActorWithField {
   }
 }
 
-// CHECK: namespace Actor __attribute__((swift_private)) {
+// CHECK: namespace Actor __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Actor") {
 // CHECK: SWIFT_EXTERN void * _Nonnull $s5Actor0A9WithFieldCACycfC(SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // init()
 // CHECK: SWIFT_EXTERN void $s5Actor0A9WithFieldC6methodyyF(SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // method()
 
-// CHECK: class ActorWithField final : public swift::_impl::RefCountedClass {
-// CHECK:   static inline ActorWithField init();
-// CHECK:   inline void method();
+// CHECK: class SWIFT_SYMBOL("s:5Actor0A9WithFieldC") ActorWithField final : public swift::_impl::RefCountedClass {
+// CHECK:   static inline ActorWithField init() SWIFT_SYMBOL("s:5Actor0A9WithFieldCACycfc");
+// CHECK:   inline void method() SWIFT_SYMBOL("s:5Actor0A9WithFieldC6methodyyF");
 
 @_expose(Cxx)
 public func takeActorWithIntField(_ x: ActorWithField) {

--- a/test/Interop/SwiftToCxx/class/swift-class-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-in-cxx.swift
@@ -21,16 +21,16 @@ public final class ClassWithIntField {
   }
 }
 
-// CHECK: namespace Class __attribute__((swift_private)) {
+// CHECK: namespace Class __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Class") {
 
 // CHECK: SWIFT_EXTERN void * _Nonnull $s5Class011passThroughA12WithIntFieldyAA0adeF0CADF(void * _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughClassWithIntField(_:)
 // CHECK-NEXT: SWIFT_EXTERN void * _Nonnull $s5Class06returnA12WithIntFieldAA0acdE0CyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // returnClassWithIntField()
 // CHECK-NEXT: SWIFT_EXTERN void $s5Class04takeA12WithIntFieldyyAA0acdE0CF(void * _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL; // takeClassWithIntField(_:)
 // CHECK-NEXT: SWIFT_EXTERN void $s5Class04takeA17WithIntFieldInoutyyAA0acdE0CzF(void * _Nonnull * _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL; // takeClassWithIntFieldInout(_:)
 
-// CHECK: namespace Class __attribute__((swift_private)) {
+// CHECK: namespace Class __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Class") {
 
-// CHECK: class ClassWithIntField;
+// CHECK: class SWIFT_SYMBOL("s:5Class0A12WithIntFieldC") ClassWithIntField;
 // CHECK-NEXT: } // end namespace
 
 // CHECK: namespace
@@ -43,7 +43,7 @@ public final class ClassWithIntField {
 // CHECK-NEXT: } // namespace swift
 
 // CHECK: namespace
-// CHECK-SAME: Class __attribute__((swift_private)) {
+// CHECK-SAME: Class __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Class") {
 
 // CHECK: namespace
 // CHECK-SAME: _impl {
@@ -55,7 +55,7 @@ public final class ClassWithIntField {
 // CHECK-EMPTY:
 // CHECK-NEXT: } // namespace _impl
 // CHECK-EMPTY:
-// CHECK-NEXT: class ClassWithIntField final : public swift::_impl::RefCountedClass {
+// CHECK-NEXT: class SWIFT_SYMBOL("s:5Class0A12WithIntFieldC") ClassWithIntField final : public swift::_impl::RefCountedClass {
 // CHECK-NEXT: public:
 // CHECK-NEXT:   using RefCountedClass::RefCountedClass;
 // CHECK-NEXT:   using RefCountedClass::operator=;
@@ -92,15 +92,15 @@ public final class ClassWithIntField {
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: } // namespace swift
 // CHECK-EMPTY:
-// CHECK-NEXT: namespace Class __attribute__((swift_private)) {
+// CHECK-NEXT: namespace Class __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Class") {
 
-// CHECK: inline ClassWithIntField passThroughClassWithIntField(const ClassWithIntField& x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline ClassWithIntField passThroughClassWithIntField(const ClassWithIntField& x) noexcept SWIFT_SYMBOL("s:5Class011passThroughA12WithIntFieldyAA0adeF0CADF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_ClassWithIntField::makeRetained(_impl::$s5Class011passThroughA12WithIntFieldyAA0adeF0CADF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 public final class register { }
 
-// CHECK: class register_ final : public swift::_impl::RefCountedClass {
+// CHECK: class SWIFT_SYMBOL("s:5Class8registerC") register_ final : public swift::_impl::RefCountedClass {
 
 public func returnClassWithIntField() -> ClassWithIntField {
   return ClassWithIntField()
@@ -121,14 +121,14 @@ public func takeClassWithIntFieldInout(_ x: inout ClassWithIntField) {
   x.field = -11
 }
 
-// CHECK: inline ClassWithIntField returnClassWithIntField() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline ClassWithIntField returnClassWithIntField() noexcept SWIFT_SYMBOL("s:5Class06returnA12WithIntFieldAA0acdE0CyF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_ClassWithIntField::makeRetained(_impl::$s5Class06returnA12WithIntFieldAA0acdE0CyF());
 // CHECK-NEXT: }
 
-// CHECK: inline void takeClassWithIntField(const ClassWithIntField& x) noexcept {
+// CHECK: inline void takeClassWithIntField(const ClassWithIntField& x) noexcept SWIFT_SYMBOL("s:5Class04takeA12WithIntFieldyyAA0acdE0CF") {
 // CHECK-NEXT:  return _impl::$s5Class04takeA12WithIntFieldyyAA0acdE0CF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x));
 // CHECK-NEXT: }
 
-// CHECK: inline void takeClassWithIntFieldInout(ClassWithIntField& x) noexcept {
+// CHECK: inline void takeClassWithIntFieldInout(ClassWithIntField& x) noexcept SWIFT_SYMBOL("s:5Class04takeA17WithIntFieldInoutyyAA0acdE0CzF") {
 // CHECK-NEXT:    return _impl::$s5Class04takeA17WithIntFieldInoutyyAA0acdE0CzF(&::swift::_impl::_impl_RefCountedClass::getOpaquePointerRef(x));
 // CHECK-NEXT:  }

--- a/test/Interop/SwiftToCxx/class/swift-class-inheritance-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-inheritance-in-cxx.swift
@@ -57,7 +57,7 @@ public func useDerivedClass(_ x: DerivedClass) {
   print("useDerivedClass, type=\(x.self)")
 }
 
-// CHECK:      class DerivedClass : public BaseClass {
+// CHECK:      class SWIFT_SYMBOL("s:5Class07DerivedA0C") DerivedClass : public BaseClass {
 // CHECK-NEXT:  public:
 // CHECK-NEXT:    using BaseClass::BaseClass;
 // CHECK-NEXT:    using BaseClass::operator=;
@@ -67,7 +67,7 @@ public func useDerivedClass(_ x: DerivedClass) {
 // CHECK-NEXT:    friend class _impl::_impl_DerivedClass;
 // CHECK-NEXT:  };
 
-// CHECK:      class DerivedDerivedClass final : public DerivedClass {
+// CHECK:      class SWIFT_SYMBOL("s:5Class07DerivedbA0C") DerivedDerivedClass final : public DerivedClass {
 // CHECK-NEXT: public:
 // CHECK-NEXT:   using DerivedClass::DerivedClass;
 // CHECK-NEXT:   using DerivedClass::operator=;
@@ -81,7 +81,7 @@ public func useDerivedClass(_ x: DerivedClass) {
 public class auto {}
 public class derivedRegister: auto {}
 
-// CHECK:      class derivedRegister : public auto_ {
+// CHECK:      class SWIFT_SYMBOL("s:5Class15derivedRegisterC") derivedRegister : public auto_ {
 // CHECK:        using auto_::auto_;
 // CHECK:        using auto_::operator=;
 // CHECK:        inline derivedRegister(void * _Nonnull ptr) noexcept : auto_(ptr) {}

--- a/test/Interop/SwiftToCxx/core/gen-header-for-module.swift
+++ b/test/Interop/SwiftToCxx/core/gen-header-for-module.swift
@@ -22,5 +22,5 @@ public func reprintedInImportedModule() -> Int {
     return 42
 }
 
-// CHECK: namespace Core __attribute__((swift_private)) {
-// CHECK: swift::Int reprintedInImportedModule() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: namespace Core __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Core") {
+// CHECK: swift::Int reprintedInImportedModule() noexcept SWIFT_SYMBOL("s:4Core25reprintedInImportedModuleSiyF") SWIFT_WARN_UNUSED_RESULT {

--- a/test/Interop/SwiftToCxx/cross-module-refs/imported-enum-refs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/imported-enum-refs-in-cxx.swift
@@ -25,7 +25,7 @@ public func inoutLargeEnum(_ s: inout LargeEnum) {
     return s = LargeEnum.B
 }
 
-// CHECK: inline void inoutLargeEnum(Enums::LargeEnum& s) noexcept {
+// CHECK: inline void inoutLargeEnum(Enums::LargeEnum& s) noexcept SWIFT_SYMBOL("s:9UsesEnums14inoutLargeEnumyy0B00dE0OzF") {
 // CHECK-NEXT: return _impl::$s9UsesEnums14inoutLargeEnumyy0B00dE0OzF(Enums::_impl::_impl_LargeEnum::getOpaquePointer(s));
 // CHECK-NEXT: }
 

--- a/test/Interop/SwiftToCxx/cross-module-refs/imported-struct-refs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/imported-struct-refs-in-cxx.swift
@@ -21,8 +21,8 @@ public struct UsesStructsStruct {
     public let x: StructSeveralI64
 }
 
-// CHECK:      inline Structs::StructSeveralI64 passThroughStructSeveralI64(const Structs::StructSeveralI64& y) const;
-// CHECK-NEXT: inline Structs::StructSeveralI64 getX() const;
+// CHECK:      inline Structs::StructSeveralI64 passThroughStructSeveralI64(const Structs::StructSeveralI64& y) const SWIFT_SYMBOL("s:11UsesStructs0aB6StructV011passThroughC10SeveralI64y0B00cfG0VAGF");
+// CHECK-NEXT: inline Structs::StructSeveralI64 getX() const SWIFT_SYMBOL("s:11UsesStructs0aB6StructV1x0B00C10SeveralI64Vvp");
 
 
 public func passThroughStructSeveralI64(_ x: StructSeveralI64) -> StructSeveralI64 {
@@ -37,18 +37,18 @@ public func passThroughStructSmallDirect(_ x: SmallStructDirectPassing) -> Small
     return x
 }
 
-// CHECK:      inline void inoutStructSeveralI64(Structs::StructSeveralI64& s) noexcept {
+// CHECK:      inline void inoutStructSeveralI64(Structs::StructSeveralI64& s) noexcept SWIFT_SYMBOL("s:11UsesStructs21inoutStructSeveralI64yy0B00deF0VzF") {
 // CHECK-NEXT:   return _impl::$s11UsesStructs21inoutStructSeveralI64yy0B00deF0VzF(Structs::_impl::_impl_StructSeveralI64::getOpaquePointer(s));
 // CHECK-NEXT: }
 
 
-// CHECK:      inline Structs::StructSeveralI64 passThroughStructSeveralI64(const Structs::StructSeveralI64& x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline Structs::StructSeveralI64 passThroughStructSeveralI64(const Structs::StructSeveralI64& x) noexcept SWIFT_SYMBOL("s:11UsesStructs27passThroughStructSeveralI64y0B00efG0VAEF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return Structs::_impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::$s11UsesStructs27passThroughStructSeveralI64y0B00efG0VAEF(result, Structs::_impl::_impl_StructSeveralI64::getOpaquePointer(x));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
-// CHECK:      inline Structs::SmallStructDirectPassing passThroughStructSmallDirect(const Structs::SmallStructDirectPassing& x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline Structs::SmallStructDirectPassing passThroughStructSmallDirect(const Structs::SmallStructDirectPassing& x) noexcept SWIFT_SYMBOL("s:11UsesStructs28passThroughStructSmallDirecty0B00feG7PassingVAEF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return Structs::_impl::_impl_SmallStructDirectPassing::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::swift_interop_returnDirect_UsesStructs_uint32_t_0_4(result, _impl::$s11UsesStructs28passThroughStructSmallDirecty0B00feG7PassingVAEF(_impl::swift_interop_passDirect_UsesStructs_uint32_t_0_4(Structs::_impl::_impl_SmallStructDirectPassing::getOpaquePointer(x))));
 // CHECK-NEXT:  });

--- a/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/large-enums-pass-return-in-cxx.swift
@@ -39,24 +39,24 @@ public func inoutLarge(_ en: inout Large, _ x: Int) {
 // CHECK: SWIFT_EXTERN void $s5Enums9makeLargeyAA0C0OSiF(SWIFT_INDIRECT_RESULT void * _Nonnull, ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // makeLarge(_:)
 // CHECK: SWIFT_EXTERN void $s5Enums16passThroughLargeyAA0D0OADF(SWIFT_INDIRECT_RESULT void * _Nonnull, const void * _Nonnull en) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughLarge(_:)
 // CHECK: SWIFT_EXTERN void $s5Enums10printLargeyyAA0C0OF(const void * _Nonnull en) SWIFT_NOEXCEPT SWIFT_CALL; // printLarge(_:)
-// CHECK: class Large final {
+// CHECK: class SWIFT_SYMBOL("s:5Enums5LargeO") Large final {
 
-// CHECK:      inline void inoutLarge(Large& en, swift::Int x) noexcept {
+// CHECK:      inline void inoutLarge(Large& en, swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums10inoutLargeyyAA0C0Oz_SitF") {
 // CHECK-NEXT:   return _impl::$s5Enums10inoutLargeyyAA0C0Oz_SitF(_impl::_impl_Large::getOpaquePointer(en), x);
 // CHECK-NEXT: }
 
-// CHECK:      inline Large makeLarge(swift::Int x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline Large makeLarge(swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums9makeLargeyAA0C0OSiF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_Large::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::$s5Enums9makeLargeyAA0C0OSiF(result, x);
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK:      inline Large passThroughLarge(const Large& en) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline Large passThroughLarge(const Large& en) noexcept SWIFT_SYMBOL("s:5Enums16passThroughLargeyAA0D0OADF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_Large::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::$s5Enums16passThroughLargeyAA0D0OADF(result, _impl::_impl_Large::getOpaquePointer(en));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK:      inline void printLarge(const Large& en) noexcept {
+// CHECK:      inline void printLarge(const Large& en) noexcept SWIFT_SYMBOL("s:5Enums10printLargeyyAA0C0OF") {
 // CHECK-NEXT:   return _impl::$s5Enums10printLargeyyAA0C0OF(_impl::_impl_Large::getOpaquePointer(en));
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx.swift
@@ -66,8 +66,8 @@ public enum Empty {
 // CHECK-NEXT:    class SWIFT_SYMBOL("s:5Enums3FooO") Foo final {
 // CHECK-NEXT:    public:
 // CHECK:         enum class cases {
-// CHECK-NEXT:      a,
-// NEW_CASE-NEXT:   b,
+// CHECK-NEXT:      a SWIFT_SYMBOL("s:5Enums3FooO1ayACSdcACmF"),
+// NEW_CASE-NEXT:   b SWIFT_SYMBOL("s:5Enums3FooO1byACSicACmF"),
 // CHECK-NEXT:      unknownDefault
 // CHECK-NEXT:    }
 // CHECK:         inline const static struct _impl_unknownDefault {  // impl struct for case unknownDefault

--- a/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx.swift
@@ -42,7 +42,7 @@ public enum Empty {
 // CHECK-EMPTY:
 // CHECK-NEXT:    } // namespace _impl
 // CHECK-EMPTY:
-// CHECK-NEXT:    class Empty final {
+// CHECK-NEXT:    class SWIFT_SYMBOL("s:5Enums5EmptyO") Empty final {
 // CHECK:         enum class cases {
 // CHECK-NEXT:      unknownDefault
 // CHECK-NEXT:    };
@@ -63,7 +63,7 @@ public enum Empty {
 // CHECK-EMPTY:
 // CHECK-NEXT:    } // namespace _impl
 // CHECK-EMPTY:
-// CHECK-NEXT:    class Foo final {
+// CHECK-NEXT:    class SWIFT_SYMBOL("s:5Enums3FooO") Foo final {
 // CHECK-NEXT:    public:
 // CHECK:         enum class cases {
 // CHECK-NEXT:      a,

--- a/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/small-enums-pass-return-in-cxx.swift
@@ -105,45 +105,45 @@ public func inoutSmall(_ en: inout Small, _ x: Int) {
 // CHECK: SWIFT_EXTERN struct swift_interop_returnStub_Enums_uint8_t_0_1 $s5Enums15passThroughTinyyAA0D0OADF(struct swift_interop_passStub_Enums_uint8_t_0_1 en) SWIFT_NOEXCEPT SWIFT_CALL; // passThroughTiny(_:)
 // CHECK: SWIFT_EXTERN void $s5Enums10printSmallyyAA0C0OF(struct swift_interop_passStub_Enums_[[Small]] en) SWIFT_NOEXCEPT SWIFT_CALL; // printSmall(_:)
 // CHECK: SWIFT_EXTERN void $s5Enums9printTinyyyAA0C0OF(struct swift_interop_passStub_Enums_uint8_t_0_1 en) SWIFT_NOEXCEPT SWIFT_CALL; // printTiny(_:)
-// CHECK: class Small final {
-// CHECK: class Tiny final {
+// CHECK: class SWIFT_SYMBOL("s:5Enums5SmallO") Small final {
+// CHECK: class SWIFT_SYMBOL("s:5Enums4TinyO") Tiny final {
 
-// CHECK:      inline void inoutSmall(Small& en, swift::Int x) noexcept {
+// CHECK:      inline void inoutSmall(Small& en, swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums10inoutSmallyyAA0C0Oz_SitF") {
 // CHECK-NEXT:   return _impl::$s5Enums10inoutSmallyyAA0C0Oz_SitF(_impl::_impl_Small::getOpaquePointer(en), x);
 // CHECK-NEXT: }
 
-// CHECK:      inline void inoutTiny(Tiny& en, swift::Int x) noexcept {
+// CHECK:      inline void inoutTiny(Tiny& en, swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums9inoutTinyyyAA0C0Oz_SitF") {
 // CHECK-NEXT:   return _impl::$s5Enums9inoutTinyyyAA0C0Oz_SitF(_impl::_impl_Tiny::getOpaquePointer(en), x);
 // CHECK-NEXT: }
 
-// CHECK:      inline Small makeSmall(swift::Int x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline Small makeSmall(swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums9makeSmallyAA0C0OSiF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_Small::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_[[Small]](result, _impl::$s5Enums9makeSmallyAA0C0OSiF(x));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK:      inline Tiny makeTiny(swift::Int x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline Tiny makeTiny(swift::Int x) noexcept SWIFT_SYMBOL("s:5Enums8makeTinyyAA0C0OSiF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_Tiny::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_uint8_t_0_1(result, _impl::$s5Enums8makeTinyyAA0C0OSiF(x));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK:      inline Small passThroughSmall(const Small& en) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline Small passThroughSmall(const Small& en) noexcept SWIFT_SYMBOL("s:5Enums16passThroughSmallyAA0D0OADF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_Small::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_[[Small]](result, _impl::$s5Enums16passThroughSmallyAA0D0OADF(_impl::swift_interop_passDirect_Enums_[[Small]](_impl::_impl_Small::getOpaquePointer(en))));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK:      inline Tiny passThroughTiny(const Tiny& en) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline Tiny passThroughTiny(const Tiny& en) noexcept SWIFT_SYMBOL("s:5Enums15passThroughTinyyAA0D0OADF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_Tiny::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::swift_interop_returnDirect_Enums_uint8_t_0_1(result, _impl::$s5Enums15passThroughTinyyAA0D0OADF(_impl::swift_interop_passDirect_Enums_uint8_t_0_1(_impl::_impl_Tiny::getOpaquePointer(en))));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK:      inline void printSmall(const Small& en) noexcept {
+// CHECK:      inline void printSmall(const Small& en) noexcept SWIFT_SYMBOL("s:5Enums10printSmallyyAA0C0OF") {
 // CHECK-NEXT:   return _impl::$s5Enums10printSmallyyAA0C0OF(_impl::swift_interop_passDirect_Enums_[[Small]](_impl::_impl_Small::getOpaquePointer(en)));
 // CHECK-NEXT: }
 
-// CHECK:      inline void printTiny(const Tiny& en) noexcept {
+// CHECK:      inline void printTiny(const Tiny& en) noexcept SWIFT_SYMBOL("s:5Enums9printTinyyyAA0C0OF") {
 // CHECK-NEXT:   return _impl::$s5Enums9printTinyyyAA0C0OF(_impl::swift_interop_passDirect_Enums_uint8_t_0_1(_impl::_impl_Tiny::getOpaquePointer(en)));
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
@@ -36,12 +36,12 @@ public struct S {
 
 // CHECK:      class SWIFT_SYMBOL("s:5Enums1EO") E final {
 // CHECK:        enum class cases {
-// CHECK-NEXT:     x,
-// CHECK-NEXT:     y,
-// CHECK-NEXT:     z,
-// CHECK-NEXT:     w,
-// CHECK-NEXT:     auto_,
-// CHECK-NEXT:     foobar
+// CHECK-NEXT:     x SWIFT_SYMBOL("s:5Enums1EO1xyACSdcACmF"),
+// CHECK-NEXT:     y SWIFT_SYMBOL("s:5Enums1EO1yyACSVSgcACmF"),
+// CHECK-NEXT:     z SWIFT_SYMBOL("s:5Enums1EO1zyAcA1SVcACmF"),
+// CHECK-NEXT:     w SWIFT_SYMBOL("s:5Enums1EO1wyACSi_tcACmF"),
+// CHECK-NEXT:     auto_ SWIFT_SYMBOL("s:5Enums1EO4autoyACSvcACmF"),
+// CHECK-NEXT:     foobar SWIFT_SYMBOL("s:5Enums1EO6foobaryA2CmF")
 // CHECK-NEXT:   };
 // CHECK-EMPTY:
 // CHECK-NEXT: #pragma clang diagnostic push
@@ -51,7 +51,7 @@ public struct S {
 // CHECK-NEXT:       return cases::x;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     inline E operator()(double val) const;
-// CHECK-NEXT:   } x;
+// CHECK-NEXT:   } x SWIFT_SYMBOL("s:5Enums1EO1xyACSdcACmF");
 // CHECK-NEXT:   inline bool isX() const;
 // CHECK-NEXT:   inline double getX() const;
 // CHECK-EMPTY:
@@ -60,7 +60,7 @@ public struct S {
 // CHECK-NEXT:       return cases::y;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     inline E operator()(void const * _Nullable val) const;
-// CHECK-NEXT:   } y;
+// CHECK-NEXT:   } y SWIFT_SYMBOL("s:5Enums1EO1yyACSVSgcACmF");
 // CHECK-NEXT:   inline bool isY() const;
 // CHECK-NEXT:   inline void const * _Nullable getY() const;
 // CHECK-EMPTY:
@@ -69,7 +69,7 @@ public struct S {
 // CHECK-NEXT:       return cases::z;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     inline E operator()(const S& val) const;
-// CHECK-NEXT:   } z;
+// CHECK-NEXT:   } z SWIFT_SYMBOL("s:5Enums1EO1zyAcA1SVcACmF");
 // CHECK-NEXT:   inline bool isZ() const;
 // CHECK-NEXT:   inline S getZ() const;
 // CHECK-EMPTY:
@@ -78,7 +78,7 @@ public struct S {
 // CHECK-NEXT:       return cases::w;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     inline E operator()(swift::Int val) const;
-// CHECK-NEXT:   } w;
+// CHECK-NEXT:   } w SWIFT_SYMBOL("s:5Enums1EO1wyACSi_tcACmF");
 // CHECK-NEXT:   inline bool isW() const;
 // CHECK-NEXT:   inline swift::Int getW() const;
 // CHECK-EMPTY:
@@ -87,7 +87,7 @@ public struct S {
 // CHECK-NEXT:       return cases::auto_;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     inline E operator()(void * _Nonnull val) const;
-// CHECK-NEXT:   } auto_;
+// CHECK-NEXT:   } auto_ SWIFT_SYMBOL("s:5Enums1EO4autoyACSvcACmF");
 // CHECK-NEXT:   inline bool isAuto_() const;
 // CHECK-NEXT:   inline void * _Nonnull getAuto_() const;
 // CHECK-EMPTY:
@@ -96,7 +96,7 @@ public struct S {
 // CHECK-NEXT:       return cases::foobar;
 // CHECK-NEXT:     }
 // CHECK-NEXT:     inline E operator()() const;
-// CHECK-NEXT:   } foobar;
+// CHECK-NEXT:   } foobar SWIFT_SYMBOL("s:5Enums1EO6foobaryA2CmF");
 // CHECK-NEXT:   inline bool isFoobar() const;
 // CHECK-EMPTY:
 // CHECK-NEXT: #pragma clang diagnostic pop

--- a/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
@@ -34,7 +34,7 @@ public struct S {
     }
 }
 
-// CHECK:      class E final {
+// CHECK:      class SWIFT_SYMBOL("s:5Enums1EO") E final {
 // CHECK:        enum class cases {
 // CHECK-NEXT:     x,
 // CHECK-NEXT:     y,
@@ -112,9 +112,9 @@ public struct S {
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }
 // CHECK-EMPTY:
-// CHECK-NEXT:   static inline E init();
-// CHECK-NEXT:   inline swift::Int getTen() const;
-// CHECK-NEXT:   inline void printSelf() const;
+// CHECK-NEXT:   static inline E init() SWIFT_SYMBOL("s:5Enums1EOACycfc");
+// CHECK-NEXT:   inline swift::Int getTen() const SWIFT_SYMBOL("s:5Enums1EO3tenSivp");
+// CHECK-NEXT:   inline void printSelf() const SWIFT_SYMBOL("s:5Enums1EO9printSelfyyF");
 // CHECK-NEXT: private:
 // CHECK:        inline char * _Nonnull _destructiveProjectEnumData() {
 // CHECK-NEXT:     auto metadata = _impl::$s5Enums1EOMa(0);
@@ -166,7 +166,7 @@ public struct S {
 // CHECK-NEXT: #endif
 // CHECK-NEXT:     vwTable->initializeWithTake(destStorage, srcStorage, metadata._0);
 // CHECK-NEXT:   }
-// CHECK:      namespace Enums __attribute__((swift_private)) {
+// CHECK:      namespace Enums __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Enums") {
 // CHECK:        inline E E::_impl_x::operator()(double val) const {
 // CHECK-NEXT:     auto result = E::_make();
 // CHECK-NEXT:     memcpy(result._getOpaquePointer(), &val, sizeof(val));

--- a/test/Interop/SwiftToCxx/enums/zero-sized-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/zero-sized-enum-in-cxx.swift
@@ -5,7 +5,7 @@
 public enum EmptyEnum {}
 public enum SingleCaseEnum { case first }
 
-// CHECK: namespace Enums __attribute__((swift_private)) {
-// CHECK-NOT: class EmptyEnum final {
-// CHECK-NOT: class SingleCaseEnum final {
+// CHECK: namespace Enums __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Enums") {
+// CHECK-NOT: EmptyEnum final {
+// CHECK-NOT: SingleCaseEnum final {
 // CHECK: } // namespace Enums

--- a/test/Interop/SwiftToCxx/expose-attr/expose-swift-decls-to-cxx.swift
+++ b/test/Interop/SwiftToCxx/expose-attr/expose-swift-decls-to-cxx.swift
@@ -77,31 +77,31 @@ public final class ExposedClass {
     public func method() {}
 }
 
-// CHECK: class ExposedClass final
-// CHECK: class ExposedStruct final {
-// CHECK: class ExposedStruct2 final {
+// CHECK: class SWIFT_SYMBOL("{{.*}}") ExposedClass final
+// CHECK: class SWIFT_SYMBOL("{{.*}}") ExposedStruct final {
+// CHECK: class SWIFT_SYMBOL("{{.*}}") ExposedStruct2 final {
 // CHECK: ExposedStruct2(ExposedStruct2 &&)
-// CHECK-NEXT: swift::Int getY() const;
-// CHECK-NEXT: void setY(swift::Int value);
-// CHECK-NEXT: static inline ExposedStruct2 init();
-// CHECK-NEXT: static inline ExposedStruct2 initWithValue(swift::Int x);
-// CHECK-NEXT: swift::Int getRenamedProp() const;
-// CHECK-NEXT: void setRenamedProp(swift::Int value);
-// CHECK-NEXT: swift::Int getProp3() const;
-// CHECK-NEXT: void renamedMethod() const;
+// CHECK-NEXT: swift::Int getY() const SWIFT_SYMBOL("{{.*}}");
+// CHECK-NEXT: void setY(swift::Int value) SWIFT_SYMBOL("{{.*}}");
+// CHECK-NEXT: static inline ExposedStruct2 init() SWIFT_SYMBOL("{{.*}}");
+// CHECK-NEXT: static inline ExposedStruct2 initWithValue(swift::Int x) SWIFT_SYMBOL("{{.*}}");
+// CHECK-NEXT: swift::Int getRenamedProp() const SWIFT_SYMBOL("{{.*}}");
+// CHECK-NEXT: void setRenamedProp(swift::Int value) SWIFT_SYMBOL("{{.*}}");
+// CHECK-NEXT: swift::Int getProp3() const SWIFT_SYMBOL("{{.*}}");
+// CHECK-NEXT: void renamedMethod() const SWIFT_SYMBOL("{{.*}}");
 // CHECK-NEXT: private:
 
-// CHECK: inline void exposed1() noexcept {
+// CHECK: inline void exposed1() noexcept SWIFT_SYMBOL("{{.*}}") {
 // CHECK-NEXT:   return _impl::$s6Expose8exposed1yyF();
 // CHECK-NEXT: }
 // CHECK-EMPTY:
 // CHECK-EMPTY:
-// CHECK-NEXT: inline void exposed3() noexcept {
+// CHECK-NEXT: inline void exposed3() noexcept SWIFT_SYMBOL("{{.*}}") {
 // CHECK-NEXT:   return _impl::$s6Expose8exposed3yyF();
 // CHECK-NEXT: }
 // CHECK-EMPTY:
 // CHECK-EMPTY:
-// CHECK-NEXT: inline void exposed4() noexcept {
+// CHECK-NEXT: inline void exposed4() noexcept SWIFT_SYMBOL("{{.*}}") {
 // CHECK-NEXT:   return _impl::$s6Expose15exposed4RenamedyyF();
 // CHECK-NEXT: }
 

--- a/test/Interop/SwiftToCxx/extension/struct-extension-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/extension/struct-extension-in-cxx.swift
@@ -19,8 +19,8 @@ extension Array {
     }
 }
 
-// CHECK class TypeAfterArray;
-// CHECK: class Array final {
-// CHECK:        swift::Int getX() const;
-// CHECK-NEXT:   inline void setX(swift::Int value);
-// CHECK-NEXT:   TypeAfterArray getVal() const;
+// CHECK class SWIFT_SYMBOL("s:7Structs14TypeAfterArrayV") TypeAfterArray;
+// CHECK: class SWIFT_SYMBOL("s:7Structs5ArrayV") Array final {
+// CHECK:        swift::Int getX() const SWIFT_SYMBOL("s:7Structs5ArrayV1xSivp");
+// CHECK-NEXT:   inline void setX(swift::Int value) SWIFT_SYMBOL("s:7Structs5ArrayV1xSivp");
+// CHECK-NEXT:   TypeAfterArray getVal() const SWIFT_SYMBOL("s:7Structs5ArrayV3valAA09TypeAfterB0Vvp");

--- a/test/Interop/SwiftToCxx/functions/cdecl.swift
+++ b/test/Interop/SwiftToCxx/functions/cdecl.swift
@@ -4,7 +4,7 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/cdecl.h)
 
-// CHECK-LABEL: namespace CdeclFunctions __attribute__((swift_private)) {
+// CHECK-LABEL: namespace CdeclFunctions __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("CdeclFunctions") {
 
 // CHECK: namespace _impl {
 // CHECK: SWIFT_EXTERN int cfuncPassTwo(int x, int y) SWIFT_NOEXCEPT;
@@ -13,6 +13,6 @@
 @_cdecl("cfuncPassTwo")
 public func differentCDeclName(x: CInt, y: CInt) -> CInt { return x + y }
 
-// CHECK: inline int differentCDeclName(int x, int y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline int differentCDeclName(int x, int y) noexcept SWIFT_SYMBOL("{{.*}}") SWIFT_WARN_UNUSED_RESULT {
 // CHECK: return _impl::cfuncPassTwo(x, y);
 // CHECK: }

--- a/test/Interop/SwiftToCxx/functions/function-availability.swift
+++ b/test/Interop/SwiftToCxx/functions/function-availability.swift
@@ -4,7 +4,7 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
 
-// CHECK-LABEL: namespace Functions __attribute__((swift_private)) {
+// CHECK-LABEL: namespace Functions __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Functions") {
 
 // CHECK-LABEL: namespace _impl {
 
@@ -16,22 +16,22 @@
 
 // CHECK: }
 
-// CHECK: inline void alwaysDeprecated() noexcept SWIFT_DEPRECATED {
+// CHECK: inline void alwaysDeprecated() noexcept SWIFT_SYMBOL("{{.*}}") SWIFT_DEPRECATED {
 @available(*, deprecated)
 public func alwaysDeprecated() {}
 
-// CHECK: inline void alwaysDeprecatedTwo() noexcept SWIFT_DEPRECATED_MSG("it should not be used")
+// CHECK: inline void alwaysDeprecatedTwo() noexcept SWIFT_SYMBOL("{{.*}}") SWIFT_DEPRECATED_MSG("it should not be used")
 @available(*, deprecated, message: "it should not be used")
 public func alwaysDeprecatedTwo() {}
 
-// CHECK: inline void alwaysUnavailable() noexcept SWIFT_UNAVAILABLE
+// CHECK: inline void alwaysUnavailable() noexcept SWIFT_SYMBOL("{{.*}}") SWIFT_UNAVAILABLE
 @available(*, unavailable)
 public func alwaysUnavailable() {}
 
-// CHECK: inline void alwaysUnavailableMessage() noexcept SWIFT_UNAVAILABLE_MSG("stuff happened")
+// CHECK: inline void alwaysUnavailableMessage() noexcept SWIFT_SYMBOL("{{.*}}") SWIFT_UNAVAILABLE_MSG("stuff happened")
 @available(*, unavailable, message: "stuff happened")
 public func alwaysUnavailableMessage() {}
 
-// CHECK: inline void singlePlatAvailability() noexcept SWIFT_AVAILABILITY(macos,introduced=11)
+// CHECK: inline void singlePlatAvailability() noexcept SWIFT_SYMBOL("{{.*}}") SWIFT_AVAILABILITY(macos,introduced=11)
 @available(macOS 11, *)
 public func singlePlatAvailability() {}

--- a/test/Interop/SwiftToCxx/functions/swift-function-unsupported-cxx-type.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-function-unsupported-cxx-type.swift
@@ -11,6 +11,6 @@ public func c() {}
 // CHECK: SWIFT_EXTERN void $s9Functions1ayyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // a()
 // CHECK: SWIFT_EXTERN void $s9Functions1cyyF(void) SWIFT_NOEXCEPT SWIFT_CALL; // c()
 
-// CHECK: inline void a() noexcept {
-// CHECK: inline void c() noexcept {
+// CHECK: inline void a() noexcept SWIFT_SYMBOL("s:9Functions1ayyF") {
+// CHECK: inline void c() noexcept SWIFT_SYMBOL("s:9Functions1cyyF") {
 // CHECK-NOT: b(

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
@@ -4,7 +4,7 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY  -Wno-shadow -Wno-unused-function)
 
-// CHECK-LABEL: namespace Functions __attribute__((swift_private)) {
+// CHECK-LABEL: namespace Functions __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Functions") {
 
 // CHECK-LABEL: namespace _impl {
 
@@ -30,7 +30,7 @@ public enum NaiveErrors : Error {
 @_expose(Cxx)
 public func emptyThrowFunction() throws { print("passEmptyThrowFunction") }
 
-// CHECK: inline Swift::ThrowingResult<void> emptyThrowFunction() {
+// CHECK: inline Swift::ThrowingResult<void> emptyThrowFunction() SWIFT_SYMBOL("s:9Functions18emptyThrowFunctionyyKF") {
 // CHECK: void* opaqueError = nullptr;
 // CHECK: void* _ctx = nullptr;
 // CHECK: _impl::$s9Functions18emptyThrowFunctionyyKF(_ctx, &opaqueError);
@@ -56,7 +56,7 @@ public struct DestroyedError : Error {
 @_expose(Cxx)
 public func testDestroyedError() throws { throw DestroyedError() }
 
-// CHECK: inline Swift::ThrowingResult<void> testDestroyedError() {
+// CHECK: inline Swift::ThrowingResult<void> testDestroyedError() SWIFT_SYMBOL("s:9Functions18testDestroyedErroryyKF") {
 // CHECK: void* opaqueError = nullptr;
 // CHECK: void* _ctx = nullptr;
 // CHECK: _impl::$s9Functions18testDestroyedErroryyKF(_ctx, &opaqueError);
@@ -74,7 +74,7 @@ public func throwFunction() throws {
     throw NaiveErrors.throwError
 }
 
-// CHECK: inline Swift::ThrowingResult<void> throwFunction() {
+// CHECK: inline Swift::ThrowingResult<void> throwFunction() SWIFT_SYMBOL("s:9Functions13throwFunctionyyKF") {
 // CHECK: void* opaqueError = nullptr;
 // CHECK: void* _ctx = nullptr;
 // CHECK: _impl::$s9Functions13throwFunctionyyKF(_ctx, &opaqueError);
@@ -95,7 +95,7 @@ public func throwFunctionWithPossibleReturn(_ a: Int) throws -> Int {
     return 0
 }
 
-// CHECK: inline Swift::ThrowingResult<swift::Int> throwFunctionWithPossibleReturn(swift::Int a) SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline Swift::ThrowingResult<swift::Int> throwFunctionWithPossibleReturn(swift::Int a) SWIFT_SYMBOL("s:9Functions31throwFunctionWithPossibleReturnyS2iKF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK: void* opaqueError = nullptr;
 // CHECK: void* _ctx = nullptr;
 // CHECK: auto returnValue = _impl::$s9Functions31throwFunctionWithPossibleReturnyS2iKF(a, _ctx, &opaqueError);
@@ -115,7 +115,7 @@ public func throwFunctionWithReturn() throws -> Int {
     return 0
 }
 
-// CHECK: inline Swift::ThrowingResult<swift::Int> throwFunctionWithReturn() SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline Swift::ThrowingResult<swift::Int> throwFunctionWithReturn() SWIFT_SYMBOL("s:9Functions23throwFunctionWithReturnSiyKF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK: void* opaqueError = nullptr;
 // CHECK: void* _ctx = nullptr;
 // CHECK: auto returnValue = _impl::$s9Functions23throwFunctionWithReturnSiyKF(_ctx, &opaqueError);

--- a/test/Interop/SwiftToCxx/functions/swift-functions.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions.swift
@@ -4,7 +4,7 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
 
-// CHECK-LABEL: namespace Functions __attribute__((swift_private)) {
+// CHECK-LABEL: namespace Functions __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Functions") {
 
 // CHECK-LABEL: namespace _impl {
 
@@ -18,13 +18,13 @@
 
 public func passIntReturnVoid(x: CInt) { print("passIntReturnVoid \(x)") }
 
-// CHECK: inline void passIntReturnVoid(int x) noexcept {
+// CHECK: inline void passIntReturnVoid(int x) noexcept SWIFT_SYMBOL("s:9Functions17passIntReturnVoid1xys5Int32V_tF") {
 // CHECK: return _impl::$s9Functions17passIntReturnVoid1xys5Int32V_tF(x);
 // CHECK: }
 
 public func passTwoIntReturnInt(x: CInt, y: CInt) -> CInt { return x + y }
 
-// CHECK: inline int passTwoIntReturnInt(int x, int y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline int passTwoIntReturnInt(int x, int y) noexcept SWIFT_SYMBOL("s:9Functions016passTwoIntReturnD01x1ys5Int32VAF_AFtF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK: return _impl::$s9Functions016passTwoIntReturnD01x1ys5Int32VAF_AFtF(x, y);
 // CHECK: }
 
@@ -33,18 +33,18 @@ public func passTwoIntReturnIntNoArgLabel(_: CInt, _: CInt) -> CInt {
   return 42
 }
 
-// CHECK: inline int passTwoIntReturnIntNoArgLabel(int _1, int _2) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline int passTwoIntReturnIntNoArgLabel(int _1, int _2) noexcept SWIFT_SYMBOL("s:9Functions016passTwoIntReturnD10NoArgLabelys5Int32VAD_ADtF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK: return _impl::$s9Functions016passTwoIntReturnD10NoArgLabelys5Int32VAD_ADtF(_1, _2);
 // CHECK: }
 
 public func passTwoIntReturnIntNoArgLabelParamName(_ x2: CInt, _ y2: CInt) -> CInt { return x2 + y2 }
 
-// CHECK: inline int passTwoIntReturnIntNoArgLabelParamName(int x2, int y2) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline int passTwoIntReturnIntNoArgLabelParamName(int x2, int y2) noexcept SWIFT_SYMBOL("s:9Functions016passTwoIntReturnD19NoArgLabelParamNameys5Int32VAD_ADtF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK:   return _impl::$s9Functions016passTwoIntReturnD19NoArgLabelParamNameys5Int32VAD_ADtF(x2, y2);
 // CHECK: }
 
 public func passVoidReturnVoid() { print("passVoidReturnVoid") }
 
-// CHECK: inline void passVoidReturnVoid() noexcept {
+// CHECK: inline void passVoidReturnVoid() noexcept SWIFT_SYMBOL("s:9Functions014passVoidReturnC0yyF") {
 // CHECK: return _impl::$s9Functions014passVoidReturnC0yyF();
 // CHECK: }

--- a/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-alwaysEmitInClient-func.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-alwaysEmitInClient-func.swift
@@ -6,7 +6,7 @@
 
 // CHECK-NOT: SWIFT_EXTERN bool $s9Functions24alwaysEmitIntoClientFuncyS2bF(bool x) SWIFT_NOEXCEPT SWIFT_CALL; // alwaysEmitIntoClientFunc(_:)
 
-// CHECK:       namespace Functions __attribute__((swift_private)) {
+// CHECK:       namespace Functions __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Functions") {
 // CHECK-EMPTY:
 // CHECK-EMPTY:
 // CHECK-NEXT:  } // namespace Functions

--- a/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-async-func.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-no-expose-unsupported-async-func.swift
@@ -6,12 +6,12 @@
 
 // CHECK-NOT: SWIFT_EXTERN double $s9Functions9asyncFuncyS2dYaF(double x) SWIFT_NOEXCEPT SWIFT_CALL; // asyncFunc(_:)
 
-// CHECK:       namespace Functions __attribute__((swift_private)) {
+// CHECK:       namespace Functions __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Functions") {
 // CHECK-EMPTY:
 // CHECK-EMPTY:
 // CHECK-NEXT:  } // namespace Functions
 
-// CHECK-NOT: inline double asyncFunc(double x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NOT: inline double asyncFunc(double x) noexcept {{.*}}{
 // CHECK-NOT:   return _impl::$s9Functions9asyncFuncyS2dYaF(x);
 // CHECK-NOT: }
 

--- a/test/Interop/SwiftToCxx/functions/swift-primitive-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-primitive-functions-cxx-bridging.swift
@@ -4,158 +4,158 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
 
-// CHECK:      inline float passThrougCFloat(float x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline float passThrougCFloat(float x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: return _impl::$s9Functions16passThrougCFloatyS2fF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline bool passThroughBool(bool x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline bool passThroughBool(bool x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions15passThroughBoolyS2bF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline bool passThroughCBool(bool x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline bool passThroughCBool(bool x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions16passThroughCBoolyS2bF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline char passThroughCChar(char x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline char passThroughCChar(char x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions16passThroughCCharys4Int8VADF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline char16_t passThroughCChar16(char16_t x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline char16_t passThroughCChar16(char16_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions18passThroughCChar16ys6UInt16VADF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline char32_t passThroughCChar32(char32_t x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline char32_t passThroughCChar32(char32_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions18passThroughCChar32ys7UnicodeO6ScalarVAFF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline double passThroughCDouble(double x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline double passThroughCDouble(double x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions18passThroughCDoubleyS2dF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline int passThroughCInt(int x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline int passThroughCInt(int x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions15passThroughCIntys5Int32VADF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline long long passThroughCLongLong(long long x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline long long passThroughCLongLong(long long x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions20passThroughCLongLongys5Int64VADF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline short passThroughCShort(short x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline short passThroughCShort(short x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions17passThroughCShortys5Int16VADF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline signed char passThroughCSignedChar(signed char x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline signed char passThroughCSignedChar(signed char x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions22passThroughCSignedCharys4Int8VADF(x);
 // CHECK-NEXT: }
 
 
-// CHECK:      inline unsigned int passThroughCUnsignedInt(unsigned int x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline unsigned int passThroughCUnsignedInt(unsigned int x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions23passThroughCUnsignedIntys6UInt32VADF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline unsigned long long passThroughCUnsignedLongLong(unsigned long long x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline unsigned long long passThroughCUnsignedLongLong(unsigned long long x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions024passThroughCUnsignedLongE0ys6UInt64VADF(x);
 // CHECK-NEXT: }
 
 
-// CHECK:      inline unsigned short passThroughCUnsignedShort(unsigned short x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline unsigned short passThroughCUnsignedShort(unsigned short x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions25passThroughCUnsignedShortys6UInt16VADF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline unsigned char passThroughCUnsignedSignedChar(unsigned char x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline unsigned char passThroughCUnsignedSignedChar(unsigned char x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions30passThroughCUnsignedSignedCharys5UInt8VADF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline wchar_t passThroughCWideChar(wchar_t x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline wchar_t passThroughCWideChar(wchar_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions20passThroughCWideCharys7UnicodeO6ScalarVAFF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline double passThroughDouble(double x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline double passThroughDouble(double x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions17passThroughDoubleyS2dF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline float passThroughFloat(float x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline float passThroughFloat(float x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions16passThroughFloatyS2fF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline float passThroughFloat32(float x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline float passThroughFloat32(float x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions18passThroughFloat32yS2fF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline double passThroughFloat64(double x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline double passThroughFloat64(double x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions18passThroughFloat64yS2dF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline swift::Int passThroughInt(swift::Int x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline swift::Int passThroughInt(swift::Int x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions14passThroughIntyS2iF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline int16_t passThroughInt16(int16_t x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline int16_t passThroughInt16(int16_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions16passThroughInt16ys0D0VADF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline int32_t passThroughInt32(int32_t x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline int32_t passThroughInt32(int32_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions16passThroughInt32ys0D0VADF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline int64_t passThroughInt64(int64_t x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline int64_t passThroughInt64(int64_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions16passThroughInt64ys0D0VADF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline int8_t passThroughInt8(int8_t x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline int8_t passThroughInt8(int8_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions15passThroughInt8ys0D0VADF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline void * _Nonnull passThroughOpaquePointer(void * _Nonnull x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline void * _Nonnull passThroughOpaquePointer(void * _Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions24passThroughOpaquePointerys0dE0VADF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline swift::UInt passThroughUInt(swift::UInt x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline swift::UInt passThroughUInt(swift::UInt x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions15passThroughUIntyS2uF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline uint16_t passThroughUInt16(uint16_t x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline uint16_t passThroughUInt16(uint16_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions17passThroughUInt16ys0D0VADF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline uint32_t passThroughUInt32(uint32_t x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline uint32_t passThroughUInt32(uint32_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions17passThroughUInt32ys0D0VADF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline uint64_t passThroughUInt64(uint64_t x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline uint64_t passThroughUInt64(uint64_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions17passThroughUInt64ys0D0VADF(x);
 // CHECK-NEXT: }
 
 
-// CHECK:      inline uint8_t passThroughUInt8(uint8_t x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline uint8_t passThroughUInt8(uint8_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions16passThroughUInt8ys0D0VADF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline int32_t * _Nullable passThroughUnsafeGenericMutableOptionalPointer(int32_t * _Nullable x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline int32_t * _Nullable passThroughUnsafeGenericMutableOptionalPointer(int32_t * _Nullable x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions46passThroughUnsafeGenericMutableOptionalPointerySpys5Int32VGSgAFF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline int32_t * _Nonnull passThroughUnsafeGenericMutablePointer(int32_t * _Nonnull x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline int32_t * _Nonnull passThroughUnsafeGenericMutablePointer(int32_t * _Nonnull x) noexcept  SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions38passThroughUnsafeGenericMutablePointerySpys5Int32VGAEF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline int32_t const * _Nullable passThroughUnsafeGenericOptionalPointer(int32_t const * _Nullable x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline int32_t const * _Nullable passThroughUnsafeGenericOptionalPointer(int32_t const * _Nullable x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions39passThroughUnsafeGenericOptionalPointerySPys5Int32VGSgAFF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline int32_t const * _Nonnull passThroughUnsafeGenericPointer(int32_t const * _Nonnull x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline int32_t const * _Nonnull passThroughUnsafeGenericPointer(int32_t const * _Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions31passThroughUnsafeGenericPointerySPys5Int32VGAEF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline void * _Nonnull passThroughUnsafeMutableRawPointer(void * _Nonnull x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline void * _Nonnull passThroughUnsafeMutableRawPointer(void * _Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions34passThroughUnsafeMutableRawPointeryS2vF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline void const * _Nonnull passThroughUnsafeRawPointer(void const * _Nonnull x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline void const * _Nonnull passThroughUnsafeRawPointer(void const * _Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions27passThroughUnsafeRawPointeryS2VF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline void * _Nullable roundTwoPassThroughUnsafeMutableRawPointer(void * _Nullable x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline void * _Nullable roundTwoPassThroughUnsafeMutableRawPointer(void * _Nullable x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions42roundTwoPassThroughUnsafeMutableRawPointerySvSgACF(x);
 // CHECK-NEXT: }
 

--- a/test/Interop/SwiftToCxx/functions/swift-primitive-inout-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-primitive-inout-functions-cxx-bridging.swift
@@ -10,23 +10,23 @@
 // CHECK: SWIFT_EXTERN void $s9Functions24inoutTypeWithNullabilityyySVzF(void const * _Nonnull * _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutTypeWithNullability(_:)
 // CHECK: SWIFT_EXTERN void $s9Functions25inoutUnsafeGenericPointeryySPys5Int32VGzF(int32_t const * _Nonnull * _Nonnull x) SWIFT_NOEXCEPT SWIFT_CALL; // inoutUnsafeGenericPointer(_:)
 
-// CHECK:      inline void inOutInt(swift::Int & x) noexcept {
+// CHECK:      inline void inOutInt(swift::Int & x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   return _impl::$s9Functions8inOutIntyySizF(&x);
 // CHECK-NEXT: }
 
-// CHECK:      inline void inOutTwoInt(swift::Int & x, swift::Int & y) noexcept {
+// CHECK:      inline void inOutTwoInt(swift::Int & x, swift::Int & y) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   return _impl::$s9Functions11inOutTwoIntyySiz_SiztF(&x, &y);
 // CHECK-NEXT: }
 
-// CHECK:      inline void inOutTwoParam(bool & x, double & y) noexcept {
+// CHECK:      inline void inOutTwoParam(bool & x, double & y) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   return _impl::$s9Functions13inOutTwoParamyySbz_SdztF(&x, &y);
 // CHECK-NEXT: }
 
-// CHECK:      inline void inoutTypeWithNullability(void const * _Nonnull & x) noexcept {
+// CHECK:      inline void inoutTypeWithNullability(void const * _Nonnull & x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   return _impl::$s9Functions24inoutTypeWithNullabilityyySVzF(&x);
 // CHECK-NEXT: }
 
-// CHECK:      inline void inoutUnsafeGenericPointer(int32_t const * _Nonnull & x) noexcept {
+// CHECK:      inline void inoutUnsafeGenericPointer(int32_t const * _Nonnull & x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   return _impl::$s9Functions25inoutUnsafeGenericPointeryySPys5Int32VGzF(&x);
 // CHECK-NEXT: }
 

--- a/test/Interop/SwiftToCxx/functions/swift-simd-vector-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-simd-vector-functions-cxx-bridging.swift
@@ -4,23 +4,23 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/functions.h)
 
-// CHECK:      inline swift_double2 passThroughdouble2(swift_double2 x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline swift_double2 passThroughdouble2(swift_double2 x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions18passThroughdouble2y4simd7double2VAEF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline swift_float3 passThroughfloat3(swift_float3 x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline swift_float3 passThroughfloat3(swift_float3 x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions17passThroughfloat3y4simd6float3VAEF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline swift_float4 passThroughfloat4(swift_float4 x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline swift_float4 passThroughfloat4(swift_float4 x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions17passThroughfloat4y4simd6float4VAEF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline swift_int3 passThroughint3(swift_int3 x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline swift_int3 passThroughint3(swift_int3 x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions15passThroughint3y4simd4int3VAEF(x);
 // CHECK-NEXT: }
 
-// CHECK:      inline swift_uint4 passThroughuint4(swift_uint4 x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline swift_uint4 passThroughuint4(swift_uint4 x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions16passThroughuint4y4simd5uint4VAEF(x);
 // CHECK-NEXT: }
 

--- a/test/Interop/SwiftToCxx/functions/swift-transparent-functions-cxx-bridging.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-transparent-functions-cxx-bridging.swift
@@ -6,7 +6,7 @@
 
 // CHECK: SWIFT_EXTERN ptrdiff_t $s9Functions24transparentPrimitiveFuncyS2iF(ptrdiff_t x) SWIFT_NOEXCEPT SWIFT_CALL; // transparentPrimitiveFunc(_:)
 
-// CHECK:      inline swift::Int transparentPrimitiveFunc(swift::Int x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline swift::Int transparentPrimitiveFunc(swift::Int x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::$s9Functions24transparentPrimitiveFuncyS2iF(x);
 // CHECK-NEXT: }
 

--- a/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
@@ -93,7 +93,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: class GenericOpt;
+// CHECK-NEXT: class SWIFT_SYMBOL("s:8Generics10GenericOptO") GenericOpt;
 
 // CHECK: template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts
@@ -107,7 +107,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: class GenericOpt final {
+// CHECK-NEXT: class SWIFT_SYMBOL("s:8Generics10GenericOptO") GenericOpt final {
 // CHECK-NEXT: public:
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
@@ -141,17 +141,17 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT:   }
 // CHECK-NEXT: }
 
-// CHECK: inline void method() const;
-// CHECK-NEXT: inline void reset();
+// CHECK: inline void method() const SWIFT_SYMBOL("s:8Generics10GenericOptO6methodyyF");
+// CHECK-NEXT: inline void reset() SWIFT_SYMBOL("s:8Generics10GenericOptO5resetyyF");
 // CHECK-NEXT: template<class T_1_0>
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_1_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: inline T_1_0 genericMethod(const T_1_0& x) const;
-// CHECK-NEXT: inline swift::Int getComputedProp() const;
+// CHECK-NEXT: inline T_1_0 genericMethod(const T_1_0& x) const SWIFT_SYMBOL("s:8Generics10GenericOptO13genericMethodyqd__qd__lF");
+// CHECK-NEXT: inline swift::Int getComputedProp() const SWIFT_SYMBOL("s:8Generics10GenericOptO12computedPropSivp");
 
 
-// CHECK: inline void inoutConcreteOpt(GenericOpt<uint16_t>& x) noexcept {
+// CHECK: inline void inoutConcreteOpt(GenericOpt<uint16_t>& x) noexcept SWIFT_SYMBOL("s:8Generics16inoutConcreteOptyyAA07GenericD0Oys6UInt16VGzF") {
 // CHECK-NEXT:   return _impl::$s8Generics16inoutConcreteOptyyAA07GenericD0Oys6UInt16VGzF(_impl::_impl_GenericOpt<uint16_t>::getOpaquePointer(x));
 // CHECK-NEXT: }
 
@@ -160,7 +160,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: inline void inoutGenericOpt(GenericOpt<T_0_0>& x, const T_0_0& y) noexcept {
+// CHECK-NEXT: inline void inoutGenericOpt(GenericOpt<T_0_0>& x, const T_0_0& y) noexcept SWIFT_SYMBOL("s:8Generics15inoutGenericOptyyAA0cD0OyxGz_xtlF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
@@ -168,7 +168,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: }
 
 
-// CHECK: inline GenericOpt<uint16_t> makeConcreteOpt(uint16_t x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline GenericOpt<uint16_t> makeConcreteOpt(uint16_t x) noexcept SWIFT_SYMBOL("s:8Generics15makeConcreteOptyAA07GenericD0Oys6UInt16VGAFF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_GenericOpt<uint16_t>::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::swift_interop_returnDirect_Generics_uint32_t_0_4(result, _impl::$s8Generics15makeConcreteOptyAA07GenericD0Oys6UInt16VGAFF(x));
 // CHECK-NEXT:   });
@@ -179,7 +179,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: inline GenericOpt<T_0_0> makeGenericOpt(const T_0_0& x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: inline GenericOpt<T_0_0> makeGenericOpt(const T_0_0& x) noexcept SWIFT_SYMBOL("s:8Generics14makeGenericOptyAA0cD0OyxGxlF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
@@ -189,7 +189,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: }
 
 
-// CHECK: inline void takeConcreteOpt(const GenericOpt<uint16_t>& x) noexcept {
+// CHECK: inline void takeConcreteOpt(const GenericOpt<uint16_t>& x) noexcept SWIFT_SYMBOL("s:8Generics15takeConcreteOptyyAA07GenericD0Oys6UInt16VGF") {
 // CHECK-NEXT:   return _impl::$s8Generics15takeConcreteOptyyAA07GenericD0Oys6UInt16VGF(_impl::swift_interop_passDirect_Generics_uint32_t_0_4(_impl::_impl_GenericOpt<uint16_t>::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
@@ -198,7 +198,7 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: inline void takeGenericOpt(const GenericOpt<T_0_0>& x) noexcept {
+// CHECK-NEXT: inline void takeGenericOpt(const GenericOpt<T_0_0>& x) noexcept SWIFT_SYMBOL("s:8Generics14takeGenericOptyyAA0cD0OyxGlF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif

--- a/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-enum-in-cxx.swift
@@ -124,14 +124,14 @@ public func inoutConcreteOpt(_ x: inout GenericOpt<UInt16>) {
 // CHECK-NEXT: }
 
 // CHECK: enum class cases {
-// CHECK-NEXT:  some,
-// CHECK-NEXT:  none
+// CHECK-NEXT:  some SWIFT_SYMBOL("s:8Generics10GenericOptO4someyACyxGxcAEmlF"),
+// CHECK-NEXT:  none SWIFT_SYMBOL("s:8Generics10GenericOptO4noneyACyxGAEmlF")
 // CHECK-NEXT: };
 
 // CHECK: inline GenericOpt<T_0_0> operator()(const T_0_0& val) const;
-// CHECK-NEXT: } some;
+// CHECK-NEXT: } some SWIFT_SYMBOL("s:8Generics10GenericOptO4someyACyxGxcAEmlF");
 // CHECK: inline GenericOpt<T_0_0> operator()() const;
-// CHECK-NEXT: } none;
+// CHECK-NEXT: } none SWIFT_SYMBOL("s:8Generics10GenericOptO4noneyACyxGAEmlF");
 
 // CHECK: inline operator cases() const {
 // CHECK-NEXT:   switch (_getEnumTag()) {

--- a/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-function-in-cxx.swift
@@ -114,12 +114,12 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: inline T_0_0 genericMethodPassThrough(const T_0_0& x) const;
+// CHECK-NEXT: inline T_0_0 genericMethodPassThrough(const T_0_0& x) const SWIFT_SYMBOL("s:9Functions15TestSmallStructV24genericMethodPassThroughyxxlF");
 // CHECK-NEXT: template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: inline void genericMethodMutTake(const T_0_0& x);
+// CHECK-NEXT: inline void genericMethodMutTake(const T_0_0& x) SWIFT_SYMBOL("s:9Functions15TestSmallStructV20genericMethodMutTakeyyxlF");
 // CHECK:      template<class T>
 // CHECK-NEXT: returnNewValue
 
@@ -127,7 +127,7 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: inline void genericPrintFunction(const T_0_0& x) noexcept {
+// CHECK-NEXT: inline void genericPrintFunction(const T_0_0& x) noexcept SWIFT_SYMBOL("s:9Functions20genericPrintFunctionyyxlF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
@@ -139,7 +139,7 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: inline void genericPrintFunctionMultiGeneric(swift::Int x, const T_0_0& t1, const T_0_0& t1p, swift::Int y, const T_0_1& t2) noexcept {
+// CHECK-NEXT: inline void genericPrintFunctionMultiGeneric(swift::Int x, const T_0_0& t1, const T_0_0& t1p, swift::Int y, const T_0_1& t2) noexcept SWIFT_SYMBOL("s:9Functions32genericPrintFunctionMultiGenericyySi_xxSiq_tr0_lF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -152,7 +152,7 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: inline void genericPrintFunctionTwoArg(const T_0_0& x, swift::Int y) noexcept {
+// CHECK-NEXT: inline void genericPrintFunctionTwoArg(const T_0_0& x, swift::Int y) noexcept SWIFT_SYMBOL("s:9Functions26genericPrintFunctionTwoArgyyx_SitlF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
@@ -163,7 +163,7 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: inline T_0_0 genericRet(const T_0_0& x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: inline T_0_0 genericRet(const T_0_0& x) noexcept SWIFT_SYMBOL("s:9Functions10genericRetyxxlF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
@@ -196,7 +196,7 @@ public func createTestSmallStruct(_ x: UInt32) -> TestSmallStruct {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: inline void genericSwap(T_0_0& x, T_0_0& y) noexcept {
+// CHECK-NEXT: inline void genericSwap(T_0_0& x, T_0_0& y) noexcept SWIFT_SYMBOL("s:9Functions11genericSwapyyxz_xztlF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif

--- a/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-in-cxx.swift
@@ -204,7 +204,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: class GenericPair;
+// CHECK-NEXT: class SWIFT_SYMBOL("s:8Generics11GenericPairV") GenericPair;
 
 // CHECK: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: #ifdef __cpp_concepts
@@ -220,7 +220,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: class GenericPair final {
+// CHECK-NEXT: class SWIFT_SYMBOL("s:8Generics11GenericPairV") GenericPair final {
 // CHECK-NEXT: public:
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
@@ -269,7 +269,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: } // namespace swift
 
-// CHECK: inline void inoutConcretePair(uint16_t x, GenericPair<uint16_t, uint16_t>& y) noexcept {
+// CHECK: inline void inoutConcretePair(uint16_t x, GenericPair<uint16_t, uint16_t>& y) noexcept SWIFT_SYMBOL("s:8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF") {
 // CHECK-NEXT:   return _impl::$s8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF(x, _impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(y));
 // CHECK-NEXT: }
 
@@ -277,7 +277,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: inline void inoutGenericPair(GenericPair<T_0_0, T_0_1>& x, const T_0_0& y) noexcept {
+// CHECK-NEXT: inline void inoutGenericPair(GenericPair<T_0_0, T_0_1>& x, const T_0_0& y) noexcept SWIFT_SYMBOL("s:8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -289,7 +289,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: inline GenericPair<T_0_0, T_0_1> makeGenericPair(const T_0_0& x, const T_0_1& y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: inline GenericPair<T_0_0, T_0_1> makeGenericPair(const T_0_0& x, const T_0_1& y) noexcept SWIFT_SYMBOL("s:8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -299,7 +299,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK: inline GenericPair<uint16_t, uint16_t> passThroughConcretePair(const GenericPair<uint16_t, uint16_t>& x, uint16_t y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline GenericPair<uint16_t, uint16_t> passThroughConcretePair(const GenericPair<uint16_t, uint16_t>& x, uint16_t y) noexcept SWIFT_SYMBOL("s:8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_GenericPair<uint16_t, uint16_t>::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::swift_interop_returnDirect_Generics_uint32_t_0_4(result, _impl::$s8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF(_impl::swift_interop_passDirect_Generics_uint32_t_0_4(_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)), y));
 // CHECK-NEXT:   });
@@ -309,7 +309,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: inline GenericPair<T_0_0, T_0_1> passThroughGenericPair(const GenericPair<T_0_0, T_0_1>& x, const T_0_1& y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK-NEXT: inline GenericPair<T_0_0, T_0_1> passThroughGenericPair(const GenericPair<T_0_0, T_0_1>& x, const T_0_1& y) noexcept SWIFT_SYMBOL("s:8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -319,7 +319,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK: inline void takeConcretePair(const GenericPair<uint16_t, uint16_t>& x) noexcept {
+// CHECK: inline void takeConcretePair(const GenericPair<uint16_t, uint16_t>& x) noexcept SWIFT_SYMBOL("s:8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF") {
 // CHECK-NEXT:  return _impl::$s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF(_impl::swift_interop_passDirect_Generics_uint32_t_0_4(_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
@@ -327,7 +327,7 @@ public func inoutConcretePair(_ x: UInt16, _ y: inout GenericPair<UInt16, UInt16
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: inline void takeGenericPair(const GenericPair<T_0_0, T_0_1>& x) noexcept {
+// CHECK-NEXT: inline void takeGenericPair(const GenericPair<T_0_0, T_0_1>& x) noexcept SWIFT_SYMBOL("s:8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");

--- a/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-direct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-struct-known-layout-direct-in-cxx.swift
@@ -74,24 +74,24 @@
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: class GenericPair;
+// CHECK-NEXT: class SWIFT_SYMBOL("s:8Generics11GenericPairV") GenericPair;
 
 // CHECK: template<class T_0_0, class T_0_1>
 // CHECK: template<class T_0_0, class T_0_1>
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0> && swift::isUsableInGenericContext<T_0_1>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: class GenericPair final {
+// CHECK-NEXT: class SWIFT_SYMBOL("s:8Generics11GenericPairV") GenericPair final {
 
 // CHECK: swift::_impl::OpaqueStorage _storage;
 // CHECK-NEXT: friend class _impl::_impl_GenericPair<T_0_0, T_0_1>;
 // CHECK-NEXT: }
 
-// CHECK: inline void inoutConcretePair(uint16_t x, GenericPair<uint16_t, uint16_t>& y) noexcept {
+// CHECK: inline void inoutConcretePair(uint16_t x, GenericPair<uint16_t, uint16_t>& y) noexcept SWIFT_SYMBOL("s:8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF") {
 // CHECK-NEXT: return _impl::$s8Generics17inoutConcretePairyys6UInt16V_AA07GenericD0VyA2DGztF(x, _impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(y));
 
 
-// CHECK: inline void inoutGenericPair(GenericPair<T_0_0, T_0_1>& x, const T_0_0& y) noexcept {
+// CHECK: inline void inoutGenericPair(GenericPair<T_0_0, T_0_1>& x, const T_0_0& y) noexcept SWIFT_SYMBOL("s:8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -99,11 +99,11 @@
 // CHECK-NEXT:   return _impl::$s8Generics16inoutGenericPairyyAA0cD0Vyxq_Gz_xtr0_lF(_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata());
 
 
-// CHECK: inline GenericPair<uint16_t, uint16_t> makeConcretePair(uint16_t x, uint16_t y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline GenericPair<uint16_t, uint16_t> makeConcretePair(uint16_t x, uint16_t y) noexcept SWIFT_SYMBOL("s:8Generics16makeConcretePairyAA07GenericD0Vys6UInt16VAFGAF_AFtF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_GenericPair<uint16_t, uint16_t>::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, _impl::$s8Generics16makeConcretePairyAA07GenericD0Vys6UInt16VAFGAF_AFtF(x, y));
 
-// CHECK: inline GenericPair<T_0_0, T_0_1> makeGenericPair(const T_0_0& x, const T_0_1& y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline GenericPair<T_0_0, T_0_1> makeGenericPair(const T_0_0& x, const T_0_1& y) noexcept SWIFT_SYMBOL("s:8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -111,11 +111,11 @@
 // CHECK-NEXT:  return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, _impl::$s8Generics15makeGenericPairyAA0cD0Vyxq_Gx_q_tr0_lF(swift::_impl::getOpaquePointer(x), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata()));
 
-// CHECK: inline GenericPair<uint16_t, uint16_t> passThroughConcretePair(const GenericPair<uint16_t, uint16_t>& x, uint16_t y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline GenericPair<uint16_t, uint16_t> passThroughConcretePair(const GenericPair<uint16_t, uint16_t>& x, uint16_t y) noexcept SWIFT_SYMBOL("s:8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_GenericPair<uint16_t, uint16_t>::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, _impl::$s8Generics23passThroughConcretePair_1yAA07GenericE0Vys6UInt16VAGGAH_AGtF(_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)), y));
 
-// CHECK: inline GenericPair<T_0_0, T_0_1> passThroughGenericPair(const GenericPair<T_0_0, T_0_1>& x, const T_0_1& y) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline GenericPair<T_0_0, T_0_1> passThroughGenericPair(const GenericPair<T_0_0, T_0_1>& x, const T_0_1& y) noexcept SWIFT_SYMBOL("s:8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");
@@ -123,11 +123,11 @@
 // CHECK-NEXT:  return _impl::_impl_GenericPair<T_0_0, T_0_1>::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::swift_interop_returnDirect_Generics_[[PTRPTRENC]](result, _impl::$s8Generics22passThroughGenericPairyAA0dE0Vyxq_GAE_q_tr0_lF(_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_impl::_impl_GenericPair<T_0_0, T_0_1>::getOpaquePointer(x)), swift::_impl::getOpaquePointer(y), swift::TypeMetadataTrait<T_0_0>::getTypeMetadata(), swift::TypeMetadataTrait<T_0_1>::getTypeMetadata()));
 
-// CHECK: inline void takeConcretePair(const GenericPair<uint16_t, uint16_t>& x) noexcept {
+// CHECK: inline void takeConcretePair(const GenericPair<uint16_t, uint16_t>& x) noexcept SWIFT_SYMBOL("s:8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF") {
 // CHECK-NEXT:  return _impl::$s8Generics16takeConcretePairyyAA07GenericD0Vys6UInt16VAFGF(_impl::swift_interop_passDirect_Generics_[[PTRPTRENC]](_impl::_impl_GenericPair<uint16_t, uint16_t>::getOpaquePointer(x)));
 
 
-// CHECK:  inline void takeGenericPair(const GenericPair<T_0_0, T_0_1>& x) noexcept {
+// CHECK:  inline void takeGenericPair(const GenericPair<T_0_0, T_0_1>& x) noexcept SWIFT_SYMBOL("s:8Generics15takeGenericPairyyAA0cD0Vyxq_Gr0_lF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_1>, "type cannot be used in a Swift generic context");

--- a/test/Interop/SwiftToCxx/generics/generic-type-traits-fwd.swift
+++ b/test/Interop/SwiftToCxx/generics/generic-type-traits-fwd.swift
@@ -28,23 +28,23 @@ public struct LaterGeneric<T> {
 }
 
 
-// CHECK: class LaterGeneric;
+// CHECK: class SWIFT_SYMBOL("s:8Generics12LaterGenericV") LaterGeneric;
 
-// CHECK: class ComesFirstStruct;
+// CHECK: class SWIFT_SYMBOL("s:8Generics16ComesFirstStructV") ComesFirstStruct;
 // CHECK: static inline const constexpr bool isUsableInGenericContext<Generics::ComesFirstStruct> = true;
 
-// CHECK: class ComesFirstEnum;
+// CHECK: class SWIFT_SYMBOL("s:8Generics14ComesFirstEnumO") ComesFirstEnum;
 // CHECK: static inline const constexpr bool isUsableInGenericContext<Generics::ComesFirstEnum> = true;
 
-// CHECK: class ComesFirstEnum final {
-// CHECK: LaterGeneric<ComesFirstEnum> returnsLaterOpt() const;
+// CHECK: class SWIFT_SYMBOL("s:8Generics14ComesFirstEnumO") ComesFirstEnum final {
+// CHECK: LaterGeneric<ComesFirstEnum> returnsLaterOpt() const SWIFT_SYMBOL("s:8Generics14ComesFirstEnumO15returnsLaterOptAA0F7GenericVyACGyF");
 
-// CHECK: namespace Generics __attribute__((swift_private)) {
+// CHECK: namespace Generics __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Generics") {
 // CHECK-EMPTY:
 // CHECK-NEXT:  namespace _impl {
 // CHECK-EMPTY:
 // CHECK-NEXT:  class _impl_ComesFirstStruct;
 
-// CHECK: class ComesFirstStruct final {
-// CHECK: LaterGeneric<ComesFirstStruct> returnsLaterOpt() const;
-// CHECK: class LaterGeneric final {
+// CHECK: class SWIFT_SYMBOL("s:8Generics16ComesFirstStructV") ComesFirstStruct final {
+// CHECK: LaterGeneric<ComesFirstStruct> returnsLaterOpt() const SWIFT_SYMBOL("s:8Generics16ComesFirstStructV15returnsLaterOptAA0F7GenericVyACGyF");
+// CHECK: class SWIFT_SYMBOL("s:8Generics12LaterGenericV") LaterGeneric final {

--- a/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/initializers/init-in-cxx.swift
@@ -37,12 +37,12 @@ public struct FirstSmallStruct {
     }
 }
 
-// CHECK: class FirstSmallStruct final {
+// CHECK: class SWIFT_SYMBOL("s:4Init16FirstSmallStructV") FirstSmallStruct final {
 // CHECK-NEXT: public:
 // CHECK:   inline FirstSmallStruct(FirstSmallStruct &&)
-// CHECK-NEXT:   inline uint32_t getX() const;
-// CHECK-NEXT:   static inline FirstSmallStruct init();
-// CHECK-NEXT:   static inline FirstSmallStruct init(swift::Int x);
+// CHECK-NEXT:   inline uint32_t getX() const SWIFT_SYMBOL("s:4Init16FirstSmallStructV1xs6UInt32Vvp");
+// CHECK-NEXT:   static inline FirstSmallStruct init() SWIFT_SYMBOL("s:4Init16FirstSmallStructVACycfc");
+// CHECK-NEXT:   static inline FirstSmallStruct init(swift::Int x) SWIFT_SYMBOL("s:4Init16FirstSmallStructVyACSicfc");
 // CHECK-NEXT: private:
 
 public struct LargeStruct {
@@ -67,10 +67,10 @@ public struct LargeStruct {
     }
 }
 
-// CHECK: class LargeStruct final {
-// CHECK:       inline swift::Int getX6() const;
-// CHECK-NEXT:  static inline LargeStruct init();
-// CHECK-NEXT:  static inline LargeStruct init(swift::Int x, const FirstSmallStruct& y);
+// CHECK: class SWIFT_SYMBOL("s:4Init11LargeStructV") LargeStruct final {
+// CHECK:       inline swift::Int getX6() const SWIFT_SYMBOL("s:4Init11LargeStructV2x6Sivp");
+// CHECK-NEXT:  static inline LargeStruct init() SWIFT_SYMBOL("s:4Init11LargeStructVACycfc");
+// CHECK-NEXT:  static inline LargeStruct init(swift::Int x, const FirstSmallStruct& y) SWIFT_SYMBOL("s:4Init11LargeStructV1x1yACSi_AA010FirstSmallC0Vtcfc");
 // CHECK-NEXT: private:
 
 private class RefCountedClass {
@@ -97,8 +97,8 @@ public struct StructWithRefCountStoredProp {
     }
 }
 
-// CHECK:      static inline StructWithRefCountStoredProp init();
-// CHECK-NEXT: static inline StructWithRefCountStoredProp init(swift::Int x);
+// CHECK:      static inline StructWithRefCountStoredProp init() SWIFT_SYMBOL("s:4Init28StructWithRefCountStoredPropVACycfc");
+// CHECK-NEXT: static inline StructWithRefCountStoredProp init(swift::Int x) SWIFT_SYMBOL("s:4Init28StructWithRefCountStoredPropV1xACSi_tcfc");
 
 
 public final class FinalClass {

--- a/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/method-in-cxx.swift
@@ -76,20 +76,20 @@ public final class PassStructInClassMethod {
 // CHECK: SWIFT_EXTERN void $s7Methods23PassStructInClassMethodC03retC0yAA05LargeC0VSiF(SWIFT_INDIRECT_RESULT void * _Nonnull, ptrdiff_t x, SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // retStruct(_:)
 // CHECK: SWIFT_EXTERN void $s7Methods23PassStructInClassMethodC06updateC0yySi_AA05LargeC0VtF(ptrdiff_t x, const void * _Nonnull y, SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // updateStruct(_:_:)
 
-// CHECK: class ClassWithMethods final : public swift::_impl::RefCountedClass {
+// CHECK: class SWIFT_SYMBOL("s:7Methods09ClassWithA0C") ClassWithMethods final : public swift::_impl::RefCountedClass {
 // CHECK:   using RefCountedClass::RefCountedClass;
 // CHECK-NEXT:   using RefCountedClass::operator=;
-// CHECK-NEXT:   inline void dump();
-// CHECK-NEXT:   inline ClassWithMethods sameRet();
-// CHECK-NEXT:   inline void mutate();
-// CHECK-NEXT:   inline ClassWithMethods deepCopy(swift::Int x);
+// CHECK-NEXT:   inline void dump() SWIFT_SYMBOL("s:7Methods09ClassWithA0C4dumpyyF");
+// CHECK-NEXT:   inline ClassWithMethods sameRet() SWIFT_SYMBOL("s:7Methods09ClassWithA0C7sameRetACyF");
+// CHECK-NEXT:   inline void mutate() SWIFT_SYMBOL("s:7Methods09ClassWithA0C6mutateyyF");
+// CHECK-NEXT:   inline ClassWithMethods deepCopy(swift::Int x) SWIFT_SYMBOL("s:7Methods09ClassWithA0C8deepCopyyACSiF");
 
-// CHECK: class LargeStruct final {
+// CHECK: class SWIFT_SYMBOL("s:7Methods11LargeStructV") LargeStruct final {
 // CHECK: inline LargeStruct(LargeStruct &&)
-// CHECK-NEXT: inline LargeStruct doubled() const;
-// CHECK-NEXT: inline void dump() const;
-// CHECK-NEXT: inline LargeStruct scaled(swift::Int x, swift::Int y) const;
-// CHECK-NEXT: inline LargeStruct added(const LargeStruct& x) const;
+// CHECK-NEXT: inline LargeStruct doubled() const SWIFT_SYMBOL("s:7Methods11LargeStructV7doubledACyF");
+// CHECK-NEXT: inline void dump() const SWIFT_SYMBOL("s:7Methods11LargeStructV4dumpyyF");
+// CHECK-NEXT: inline LargeStruct scaled(swift::Int x, swift::Int y) const SWIFT_SYMBOL("s:7Methods11LargeStructV6scaledyACSi_SitF");
+// CHECK-NEXT: inline LargeStruct added(const LargeStruct& x) const SWIFT_SYMBOL("s:7Methods11LargeStructV5addedyA2CF");
 // CHECK-NEXT: private
 
 public func createClassWithMethods(_ x: Int) -> ClassWithMethods {

--- a/test/Interop/SwiftToCxx/methods/mutating-method-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/methods/mutating-method-in-cxx.swift
@@ -56,18 +56,18 @@ public struct SmallStruct {
 // CHECK: SWIFT_EXTERN struct swift_interop_returnStub_Methods_float_0_4 $s7Methods11SmallStructV5scaleyACSfF(float y, SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // scale(_:)
 // CHECK: SWIFT_EXTERN void $s7Methods11SmallStructV6invertyyF(SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // invert()
 
-// CHECK: class LargeStruct final {
+// CHECK: class SWIFT_SYMBOL("s:7Methods11LargeStructV") LargeStruct final {
 // CHECK: inline LargeStruct(LargeStruct &&)
-// CHECK-NEXT:   inline void dump() const;
-// CHECK-NEXT:   inline void double_();
-// CHECK-NEXT:   inline LargeStruct scale(swift::Int x, swift::Int y);
+// CHECK-NEXT:   inline void dump() const SWIFT_SYMBOL("s:7Methods11LargeStructV4dumpyyF");
+// CHECK-NEXT:   inline void double_() SWIFT_SYMBOL("s:7Methods11LargeStructV6doubleyyF");
+// CHECK-NEXT:   inline LargeStruct scale(swift::Int x, swift::Int y) SWIFT_SYMBOL("s:7Methods11LargeStructV5scaleyACSi_SitF");
 // CHECK-NEXT: private
 
-// CHECK: class SmallStruct final {
+// CHECK: class SWIFT_SYMBOL("s:7Methods11SmallStructV") SmallStruct final {
 // CHECK:   inline SmallStruct(SmallStruct &&)
-// CHECK-NEXT:   inline void dump() const;
-// CHECK-NEXT:   inline SmallStruct scale(float y);
-// CHECK-NEXT:   inline void invert();
+// CHECK-NEXT:   inline void dump() const SWIFT_SYMBOL("s:7Methods11SmallStructV4dumpyyF");
+// CHECK-NEXT:   inline SmallStruct scale(float y) SWIFT_SYMBOL("s:7Methods11SmallStructV5scaleyACSfF");
+// CHECK-NEXT:   inline void invert() SWIFT_SYMBOL("s:7Methods11SmallStructV6invertyyF");
 // CHECK-NEXT: private:
 
 

--- a/test/Interop/SwiftToCxx/module/module-to-namespace.swift
+++ b/test/Interop/SwiftToCxx/module/module-to-namespace.swift
@@ -4,5 +4,12 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/empty.h)
 
-// CHECK-LABEL: namespace Test __attribute__((swift_private)) {
+// CHECK: #ifdef SWIFT_SYMBOL
+// CHECK-NEXT: #undef SWIFT_SYMBOL
+// CHECK-NEXT: #endif
+// CHECK-NEXT: #define SWIFT_SYMBOL(usrValue) SWIFT_SYMBOL_MODULE_USR("Test", usrValue)
+
+// CHECK-LABEL: namespace Test __attribute__((swift_private)) SWIFT_SYMBOL_MODULE({{.*}}) {
 // CHECK:       } // namespace Test
+// CHECK-EMPTY:
+// CHECK-NEXT: #undef SWIFT_SYMBOL

--- a/test/Interop/SwiftToCxx/properties/bool-is-has-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/bool-is-has-in-cxx.swift
@@ -21,16 +21,16 @@ public struct IsHasProperties {
     let x1, x2, x3, x4, x5, x6: Int
 }
 
-// CHECK: class IsHasProperties
+// CHECK: class SWIFT_SYMBOL({{.*}}) IsHasProperties
 
-// CHECK: inline bool isEmpty() const;
-// CHECK-NEXT: inline bool hasFlavor() const;
-// CHECK-NEXT: inline bool isSolid() const;
-// CHECK-NEXT: inline void setIsSolid(bool value);
-// CHECK-NEXT: inline bool getFlag() const;
-// CHECK-NEXT: inline void setFlag(bool value);
-// CHECK-NEXT: inline bool getHas() const;
-// CHECK-NEXT: inline swift::Int getIsOption() const;
+// CHECK: inline bool isEmpty() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline bool hasFlavor() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline bool isSolid() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline void setIsSolid(bool value) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline bool getFlag() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline void setFlag(bool value) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline bool getHas() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline swift::Int getIsOption() const SWIFT_SYMBOL({{.*}});
 
 // CHECK: inline bool IsHasProperties::isEmpty() const {
 // CHECK-NEXT: return _impl::$s10Properties05IsHasA0V7isEmptySbvg(_getOpaquePointer());

--- a/test/Interop/SwiftToCxx/properties/getter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/getter-in-cxx.swift
@@ -8,10 +8,10 @@ public struct FirstSmallStruct {
     public let x: UInt32
 }
 
-// CHECK: class FirstSmallStruct final {
+// CHECK: class SWIFT_SYMBOL({{.*}}) FirstSmallStruct final {
 // CHECK: public:
 // CHECK:   inline FirstSmallStruct(FirstSmallStruct &&)
-// CHECK-NEXT:   inline uint32_t getX() const;
+// CHECK-NEXT:   inline uint32_t getX() const SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT:   private:
 
 public struct LargeStruct {
@@ -34,19 +34,19 @@ public struct LargeStruct {
     }
 }
 
-// CHECK: class LargeStruct final {
+// CHECK: class SWIFT_SYMBOL({{.*}}) LargeStruct final {
 // CHECK: public:
 // CHECK: inline LargeStruct(LargeStruct &&)
-// CHECK-NEXT: inline swift::Int getX1() const;
-// CHECK-NEXT: inline swift::Int getX2() const;
-// CHECK-NEXT: inline swift::Int getX3() const;
-// CHECK-NEXT: inline swift::Int getX4() const;
-// CHECK-NEXT: inline swift::Int getX5() const;
-// CHECK-NEXT: inline swift::Int getX6() const;
-// CHECK-NEXT: inline LargeStruct getAnotherLargeStruct() const;
-// CHECK-NEXT: inline FirstSmallStruct getFirstSmallStruct() const;
-// CHECK-NEXT: static inline swift::Int getStaticX();
-// CHECK-NEXT: static inline FirstSmallStruct getStaticSmallStruct();
+// CHECK-NEXT: inline swift::Int getX1() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline swift::Int getX2() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline swift::Int getX3() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline swift::Int getX4() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline swift::Int getX5() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline swift::Int getX6() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline LargeStruct getAnotherLargeStruct() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline FirstSmallStruct getFirstSmallStruct() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: static inline swift::Int getStaticX() SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: static inline FirstSmallStruct getStaticSmallStruct() SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT: private:
 
 public final class PropertiesInClass {
@@ -65,11 +65,11 @@ public final class PropertiesInClass {
     }
 }
 
-// CHECK: class PropertiesInClass final : public swift::_impl::RefCountedClass {
+// CHECK: class SWIFT_SYMBOL({{.*}}) PropertiesInClass final : public swift::_impl::RefCountedClass {
 // CHECK: using RefCountedClass::operator=;
-// CHECK-NEXT: inline int32_t getStoredInt();
-// CHECK-NEXT: inline swift::Int getComputedInt();
-// CHECK-NEXT: inline FirstSmallStruct getSmallStruct();
+// CHECK-NEXT: inline int32_t getStoredInt() SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline swift::Int getComputedInt() SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline FirstSmallStruct getSmallStruct() SWIFT_SYMBOL({{.*}});
 
 public func createPropsInClass(_ x: Int32) -> PropertiesInClass {
     return PropertiesInClass(x)
@@ -90,13 +90,13 @@ public struct SmallStructWithGetters {
     }
 }
 
-// CHECK: class SmallStructWithGetters final {
+// CHECK: class SWIFT_SYMBOL({{.*}}) SmallStructWithGetters final {
 // CHECK: public:
 // CHECK:   inline SmallStructWithGetters(SmallStructWithGetters &&)
-// CHECK-NEXT:  inline uint32_t getStoredInt() const;
-// CHECK-NEXT:  inline swift::Int getComputedInt() const;
-// CHECK-NEXT:  inline LargeStruct getLargeStruct() const;
-// CHECK-NEXT:  inline SmallStructWithGetters getSmallStruct() const;
+// CHECK-NEXT:  inline uint32_t getStoredInt() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:  inline swift::Int getComputedInt() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:  inline LargeStruct getLargeStruct() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:  inline SmallStructWithGetters getSmallStruct() const SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT: private:
 
 public func createSmallStructWithGetter() -> SmallStructWithGetters {

--- a/test/Interop/SwiftToCxx/properties/setter-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/properties/setter-in-cxx.swift
@@ -8,11 +8,11 @@ public struct FirstSmallStruct {
     public var x: UInt32
 }
 
-// CHECK: class FirstSmallStruct final {
+// CHECK: class SWIFT_SYMBOL({{.*}}) FirstSmallStruct final {
 // CHECK: public:
 // CHECK:   inline FirstSmallStruct(FirstSmallStruct &&)
-// CHECK-NEXT:   inline uint32_t getX() const;
-// CHECK-NEXT:   inline void setX(uint32_t value);
+// CHECK-NEXT:   inline uint32_t getX() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:   inline void setX(uint32_t value) SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT:   private:
 
 public struct LargeStruct {
@@ -29,23 +29,23 @@ public struct LargeStruct {
     }
 }
 
-// CHECK: class LargeStruct final {
+// CHECK: class SWIFT_SYMBOL({{.*}}) LargeStruct final {
 // CHECK: public:
 // CHECK: inline LargeStruct(LargeStruct &&)
-// CHECK-NEXT: inline swift::Int getX1() const;
-// CHECK-NEXT: inline void setX1(swift::Int value);
-// CHECK-NEXT: inline swift::Int getX2() const;
-// CHECK-NEXT: inline void setX2(swift::Int value);
-// CHECK-NEXT: inline swift::Int getX3() const;
-// CHECK-NEXT: inline void setX3(swift::Int value);
-// CHECK-NEXT: inline swift::Int getX4() const;
-// CHECK-NEXT: inline void setX4(swift::Int value);
-// CHECK-NEXT: inline swift::Int getX5() const;
-// CHECK-NEXT: inline void setX5(swift::Int value);
-// CHECK-NEXT: inline swift::Int getX6() const;
-// CHECK-NEXT: inline void setX6(swift::Int value);
-// CHECK-NEXT: static inline swift::Int getStaticX();
-// CHECK-NEXT: static inline void setStaticX(swift::Int newValue);
+// CHECK-NEXT: inline swift::Int getX1() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline void setX1(swift::Int value) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline swift::Int getX2() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline void setX2(swift::Int value) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline swift::Int getX3() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline void setX3(swift::Int value) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline swift::Int getX4() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline void setX4(swift::Int value) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline swift::Int getX5() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline void setX5(swift::Int value) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline swift::Int getX6() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline void setX6(swift::Int value) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: static inline swift::Int getStaticX() SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: static inline void setStaticX(swift::Int newValue) SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT: private:
 
 public struct LargeStructWithProps {
@@ -53,12 +53,12 @@ public struct LargeStructWithProps {
     public var storedSmallStruct: FirstSmallStruct
 }
 
-// CHECK:      class LargeStructWithProps final {
+// CHECK:      class SWIFT_SYMBOL({{.*}}) LargeStructWithProps final {
 // CHECK-NEXT: public:
-// CHECK:      inline LargeStruct getStoredLargeStruct() const;
-// CHECK-NEXT: inline void setStoredLargeStruct(const LargeStruct& value);
-// CHECK-NEXT: inline FirstSmallStruct getStoredSmallStruct() const;
-// CHECK-NEXT: inline void setStoredSmallStruct(const FirstSmallStruct& value);
+// CHECK:      inline LargeStruct getStoredLargeStruct() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline void setStoredLargeStruct(const LargeStruct& value) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline FirstSmallStruct getStoredSmallStruct() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline void setStoredSmallStruct(const FirstSmallStruct& value) SWIFT_SYMBOL({{.*}});
 
 public final class PropertiesInClass {
     public var storedInt: Int32
@@ -76,12 +76,12 @@ public final class PropertiesInClass {
     }
 }
 
-// CHECK: class PropertiesInClass final : public swift::_impl::RefCountedClass {
+// CHECK: class SWIFT_SYMBOL({{.*}}) PropertiesInClass final : public swift::_impl::RefCountedClass {
 // CHECK: using RefCountedClass::operator=;
-// CHECK-NEXT: inline int32_t getStoredInt();
-// CHECK-NEXT: inline void setStoredInt(int32_t value);
-// CHECK-NEXT: inline swift::Int getComputedInt();
-// CHECK-NEXT: inline void setComputedInt(swift::Int newValue);
+// CHECK-NEXT: inline int32_t getStoredInt() SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline void setStoredInt(int32_t value) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline swift::Int getComputedInt() SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline void setComputedInt(swift::Int newValue) SWIFT_SYMBOL({{.*}});
 
 public func createPropsInClass(_ x: Int32) -> PropertiesInClass {
     return PropertiesInClass(x)
@@ -107,15 +107,15 @@ public struct SmallStructWithProps {
     }
 }
 
-// CHECK: class SmallStructWithProps final {
+// CHECK: class SWIFT_SYMBOL({{.*}}) SmallStructWithProps final {
 // CHECK: public:
 // CHECK:   inline SmallStructWithProps(SmallStructWithProps &&)
-// CHECK-NEXT:    inline uint32_t getStoredInt() const;
-// CHECK-NEXT:    inline void setStoredInt(uint32_t value);
-// CHECK-NEXT:    inline swift::Int getComputedInt() const;
-// CHECK-NEXT:    inline void setComputedInt(swift::Int newValue);
-// CHECK-NEXT:    inline LargeStructWithProps getLargeStructWithProps() const;
-// CHECK-NEXT:    inline void setLargeStructWithProps(const LargeStructWithProps& newValue);
+// CHECK-NEXT:    inline uint32_t getStoredInt() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:    inline void setStoredInt(uint32_t value) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:    inline swift::Int getComputedInt() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:    inline void setComputedInt(swift::Int newValue) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:    inline LargeStructWithProps getLargeStructWithProps() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:    inline void setLargeStructWithProps(const LargeStructWithProps& newValue) SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT: private:
 
 public func createSmallStructWithProps() -> SmallStructWithProps {

--- a/test/Interop/SwiftToCxx/stdlib/optional/optional-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/optional/optional-in-cxx.swift
@@ -54,20 +54,20 @@ public func resetOpt<T>(_ val: inout Optional<T>) {
 }
 
 
-// CHECK: inline Swift::Optional<int> createCIntOpt(int val) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline Swift::Optional<int> createCIntOpt(int val) noexcept SWIFT_SYMBOL("s:11UseOptional13createCIntOptys5Int32VSgADF") SWIFT_WARN_UNUSED_RESULT {
  // CHECK-NEXT: return Swift::_impl::_impl_Optional<int>::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:   _impl::swift_interop_returnDirect_UseOptional_[[CINTENC:[a-z0-9_]+]](result, _impl::$s11UseOptional13createCIntOptys5Int32VSgADF(val));
 // CHECK-NEXT: });
 // CHECK-NEXT: }
 
 
-// CHECK: inline Swift::Optional<Klass> createKlassOpt(int16_t val) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline Swift::Optional<Klass> createKlassOpt(int16_t val) noexcept SWIFT_SYMBOL("s:11UseOptional14createKlassOptyAA0D0CSgs5Int16VF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return Swift::_impl::_impl_Optional<Klass>::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT: _impl::swift_interop_returnDirect_UseOptional_[[CLASSENC:[a-z0-9_]+]](result, _impl::$s11UseOptional14createKlassOptyAA0D0CSgs5Int16VF(val));
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK: inline Swift::Optional<SmallStruct> createSmallStructOpt(int16_t val) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline Swift::Optional<SmallStruct> createSmallStructOpt(int16_t val) noexcept SWIFT_SYMBOL("s:11UseOptional20createSmallStructOptyAA0dE0VSgs5Int16VF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return Swift::_impl::_impl_Optional<SmallStruct>::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::swift_interop_returnDirect_UseOptional_uint32_t_0_4(result, _impl::$s11UseOptional20createSmallStructOptyAA0dE0VSgs5Int16VF(val));
 // CHECK-NEXT:   });
@@ -78,7 +78,7 @@ public func resetOpt<T>(_ val: inout Optional<T>) {
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: inline void resetOpt(Swift::Optional<T_0_0>& val) noexcept {
+// CHECK-NEXT: inline void resetOpt(Swift::Optional<T_0_0>& val) noexcept SWIFT_SYMBOL("s:11UseOptional8resetOptyyxSgzlF") {
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
 // CHECK-NEXT: #endif
@@ -86,16 +86,16 @@ public func resetOpt<T>(_ val: inout Optional<T>) {
 // CHECK-NEXT: }
 
 
-// CHECK: inline void takeCIntOpt(const Swift::Optional<int>& val) noexcept {
+// CHECK: inline void takeCIntOpt(const Swift::Optional<int>& val) noexcept SWIFT_SYMBOL("s:11UseOptional11takeCIntOptyys5Int32VSgF") {
 // CHECK-NEXT:  return _impl::$s11UseOptional11takeCIntOptyys5Int32VSgF(_impl::swift_interop_passDirect_UseOptional_[[CINTENC]](Swift::_impl::_impl_Optional<int>::getOpaquePointer(val)));
 // CHECK-NEXT: }
 
 
-// CHECK: inline void takeKlassOpt(const Swift::Optional<Klass>& val) noexcept {
+// CHECK: inline void takeKlassOpt(const Swift::Optional<Klass>& val) noexcept SWIFT_SYMBOL("s:11UseOptional12takeKlassOptyyAA0D0CSgF") {
 // CHECK-NEXT:   return _impl::$s11UseOptional12takeKlassOptyyAA0D0CSgF(_impl::swift_interop_passDirect_UseOptional_[[CLASSENC]](Swift::_impl::_impl_Optional<Klass>::getOpaquePointer(val)));
 // CHECK-NEXT: }
 
 
-// CHECK: inline void takeSmallStructOpt(const Swift::Optional<SmallStruct>& val) noexcept {
+// CHECK: inline void takeSmallStructOpt(const Swift::Optional<SmallStruct>& val) noexcept SWIFT_SYMBOL("s:11UseOptional18takeSmallStructOptyyAA0dE0VSgF") {
 // CHECK-NEXT:  return _impl::$s11UseOptional18takeSmallStructOptyyAA0dE0VSgF(_impl::swift_interop_passDirect_UseOptional_uint32_t_0_4(Swift::_impl::_impl_Optional<SmallStruct>::getOpaquePointer(val)));
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/stdlib/stdlib-dep-inline-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/stdlib-dep-inline-in-cxx.swift
@@ -14,5 +14,5 @@ public func test() -> String {
     return ""
 }
 
-// CHECK: namespace Swift __attribute__((swift_private)) {
-// CHECK: class String final {
+// CHECK: namespace Swift __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Swift") {
+// CHECK: class SWIFT_SYMBOL("{{.*}}") String final {

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -60,7 +60,7 @@
 // CHECK-NEXT: inline Optional(const Optional &other) {
 // CHECK: }
 // CHECK:   enum class cases {
-// CHECK-NEXT: some,
+// CHECK-NEXT: some SWIFT_SYMBOL({{.*}}),
 // CHECK-NEXT: none
 // CHECK-NEXT: };
 // CHECK: inline bool isSome() const;

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -6,27 +6,27 @@
 
 // FIXME: remove need for -Wno-shadow
 
-// CHECK: namespace Swift __attribute__((swift_private)) {
+// CHECK: namespace Swift __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Swift") {
 
 // CHECK: template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: class Optional;
+// CHECK-NEXT: class SWIFT_SYMBOL("s:Sq") Optional;
 
-// CHECK: class String;
+// CHECK: class SWIFT_SYMBOL("s:SS") String;
 
 // CHECK: template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: class Array;
+// CHECK-NEXT: class SWIFT_SYMBOL("s:Sa") Array;
 // CHECK: template<class T_0_0>
 // CHECK: template<class T_0_0>
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: class Array final {
+// CHECK-NEXT: class SWIFT_SYMBOL("s:Sa") Array final {
 // CHECK-NEXT: public:
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
@@ -35,12 +35,12 @@
 // CHECK: }
 // CHECK-NEXT: inline Array(const Array &other) {
 // CHECK: }
-// CHECK: static inline Array<T_0_0> init();
-// CHECK: inline void append(const T_0_0& newElement);
-// CHECK: inline T_0_0 remove(swift::Int index);
-// CHECK: inline T_0_0 operator [](swift::Int index) const;
-// CHECK: inline swift::Int getCount() const;
-// CHECK: inline swift::Int getCapacity() const;
+// CHECK: static inline Array<T_0_0> init() SWIFT_SYMBOL({{.*}});
+// CHECK: inline void append(const T_0_0& newElement) SWIFT_SYMBOL({{.*}});
+// CHECK: inline T_0_0 remove(swift::Int index) SWIFT_SYMBOL({{.*}});
+// CHECK: inline T_0_0 operator [](swift::Int index) const SWIFT_SYMBOL({{.*}});
+// CHECK: inline swift::Int getCount() const SWIFT_SYMBOL({{.*}});
+// CHECK: inline swift::Int getCapacity() const SWIFT_SYMBOL({{.*}});
 
 // CHECK: template<class T_0_0>
 // CHECK: template<class T_0_0>
@@ -50,7 +50,7 @@
 // CHECK-NEXT: #ifdef __cpp_concepts
 // CHECK-NEXT: requires swift::isUsableInGenericContext<T_0_0>
 // CHECK-NEXT: #endif
-// CHECK-NEXT: class Optional final {
+// CHECK-NEXT: class SWIFT_SYMBOL({{.*}}) Optional final {
 // CHECK-NEXT: public:
 // CHECK-NEXT: #ifndef __cpp_concepts
 // CHECK-NEXT: static_assert(swift::isUsableInGenericContext<T_0_0>, "type cannot be used in a Swift generic context");
@@ -65,19 +65,19 @@
 // CHECK-NEXT: };
 // CHECK: inline bool isSome() const;
 // CHECK: inline bool isNone() const;
-// CHECK: inline T_0_0 getUnsafelyUnwrapped() const;
+// CHECK: inline T_0_0 getUnsafelyUnwrapped() const SWIFT_SYMBOL({{.*}});
 
-// CHECK: class String final {
+// CHECK: class SWIFT_SYMBOL({{.*}}) String final {
 // CHECK-NEXT: public:
 // CHECK-NEXT: inline ~String() {
 // CHECK:  }
 // CHECK-NEXT:  inline String(const String &other) {
 // CHECK:  }
 // CHECK-NEXT:  inline String(String &&) { abort(); }
-// CHECK-NEXT:  static inline String init();
-// CHECK-NEXT:  inline UTF8View getUtf8() const;
-// CHECK-NEXT:  inline void setUtf8(const UTF8View& newValue);
-// CHECK-NEXT:  inline bool isContiguousUTF8() const;
+// CHECK-NEXT:  static inline String init() SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:  inline UTF8View getUtf8() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:  inline void setUtf8(const UTF8View& newValue) SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:  inline bool isContiguousUTF8() const SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT:  #if defined(__OBJC__)
 // CHECK-NEXT:  inline __attribute__((always_inline)) operator NSString * _Nonnull () const noexcept {
 // CHECK-NEXT:    return (__bridge_transfer NSString *)(_impl::$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF(_impl::swift_interop_passDirect_Swift_String(_getOpaquePointer())));
@@ -104,16 +104,16 @@
 // CHECK-NEXT: #endif
 // CHECK-NEXT: private:
 
-// CHECK: class UTF8View final {
+// CHECK: class SWIFT_SYMBOL({{.*}}) UTF8View final {
 // CHECK:  inline UTF8View(UTF8View &&) { abort(); }
-// CHECK-NEXT: inline String_Index getStartIndex() const;
-// CHECK-NEXT:   inline String_Index getEndIndex() const;
-// CHECK-NEXT:   inline String_Index index(const String_Index& i, swift::Int n) const;
-// CHECK-NEXT:   inline Swift::Optional<String_Index> index(const String_Index& i, swift::Int n, const String_Index& limit) const;
-// CHECK-NEXT:   inline swift::Int distance(const String_Index& i, const String_Index& j) const;
-// CHECK-NEXT: inline uint8_t operator [](const String_Index& i) const;
-// CHECK:   inline String getDescription() const;
-// CHECK:   inline swift::Int getCount() const;
+// CHECK-NEXT: inline String_Index getStartIndex() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:   inline String_Index getEndIndex() const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:   inline String_Index index(const String_Index& i, swift::Int n) const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:   inline Swift::Optional<String_Index> index(const String_Index& i, swift::Int n, const String_Index& limit) const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT:   inline swift::Int distance(const String_Index& i, const String_Index& j) const SWIFT_SYMBOL({{.*}});
+// CHECK-NEXT: inline uint8_t operator [](const String_Index& i) const SWIFT_SYMBOL({{.*}});
+// CHECK:   inline String getDescription() const SWIFT_SYMBOL({{.*}});
+// CHECK:   inline swift::Int getCount() const SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT: private:
 
 // CHECK: #if __has_include(<../../../swift/swiftToCxx/_SwiftStdlibCxxOverlay.h>)

--- a/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/large-structs-pass-return-indirect-in-cxx.swift
@@ -9,7 +9,7 @@ public struct StructSeveralI64 {
 }
 
 // CHECK: SWIFT_EXTERN void $s7Structs21inoutStructSeveralI64yyAA0cdE0VzF(void * _Nonnull s) SWIFT_NOEXCEPT SWIFT_CALL; // inoutStructSeveralI64(_:)
-// CHECK: class StructSeveralI64 final {
+// CHECK: class SWIFT_SYMBOL("s:7Structs16StructSeveralI64V") StructSeveralI64 final {
 
 public func returnNewStructSeveralI64(i: Int64) -> StructSeveralI64 {
     return StructSeveralI64(x1: i, x2: 0, x3: -17, x4: 12345612, x5: -0xFFFF)
@@ -31,24 +31,24 @@ public func inoutStructSeveralI64(_ s: inout StructSeveralI64) {
     s.x5 = -5
 }
 
-// CHECK:      inline void inoutStructSeveralI64(StructSeveralI64& s) noexcept {
+// CHECK:      inline void inoutStructSeveralI64(StructSeveralI64& s) noexcept SWIFT_SYMBOL("s:7Structs21inoutStructSeveralI64yyAA0cdE0VzF") {
 // CHECK-NEXT:   return _impl::$s7Structs21inoutStructSeveralI64yyAA0cdE0VzF(_impl::_impl_StructSeveralI64::getOpaquePointer(s));
 // CHECK-NEXT: }
 
 
-// CHECK: inline StructSeveralI64 passThroughStructSeveralI64(int64_t i, const StructSeveralI64& x, float j) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline StructSeveralI64 passThroughStructSeveralI64(int64_t i, const StructSeveralI64& x, float j) noexcept SWIFT_SYMBOL("s:7Structs27passThroughStructSeveralI641i_1jAA0deF0Vs5Int64V_AFSftF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::$s7Structs27passThroughStructSeveralI641i_1jAA0deF0Vs5Int64V_AFSftF(result, i, _impl::_impl_StructSeveralI64::getOpaquePointer(x), j);
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
-// CHECK: inline void printStructSeveralI64(const StructSeveralI64& x) noexcept {
+// CHECK: inline void printStructSeveralI64(const StructSeveralI64& x) noexcept SWIFT_SYMBOL("s:7Structs21printStructSeveralI64yyAA0cdE0VF") {
 // CHECK-NEXT:  return _impl::$s7Structs21printStructSeveralI64yyAA0cdE0VF(_impl::_impl_StructSeveralI64::getOpaquePointer(x));
 // CHECK-NEXT: }
 
 
-// CHECK: inline StructSeveralI64 returnNewStructSeveralI64(int64_t i) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline StructSeveralI64 returnNewStructSeveralI64(int64_t i) noexcept SWIFT_SYMBOL("s:7Structs25returnNewStructSeveralI641iAA0deF0Vs5Int64V_tF") SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructSeveralI64::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::$s7Structs25returnNewStructSeveralI641iAA0deF0Vs5Int64V_tF(result, i);
 // CHECK-NEXT:  });

--- a/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/resilient-struct-in-cxx.swift
@@ -27,12 +27,12 @@ public struct FirstSmallStruct {
     }
 }
 
-// CHECK: class FirstSmallStruct;
+// CHECK: class SWIFT_SYMBOL("s:7Structs16FirstSmallStructV") FirstSmallStruct;
 
 // CHECK: template<>
 // CHECK-NEXT: static inline const constexpr bool isUsableInGenericContext<Structs::FirstSmallStruct> = true;
 
-// CHECK: class FirstSmallStruct final {
+// CHECK: class SWIFT_SYMBOL("s:7Structs16FirstSmallStructV") FirstSmallStruct final {
 // CHECK-NEXT: public:
 // CHECK: inline FirstSmallStruct(const FirstSmallStruct &other) {
 // CHECK-NEXT:   auto metadata = _impl::$s7Structs16FirstSmallStructVMa(0);
@@ -92,12 +92,12 @@ public struct FirstSmallStruct {
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: } // namespace swift
 // CHECK-EMPTY:
-// CHECK-NEXT: namespace Structs __attribute__((swift_private)) {
+// CHECK-NEXT: namespace Structs __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Structs") {
 
 @frozen public struct FrozenStruct {
     private let storedInt: Int32
 }
-// CHECK: class FrozenStruct final {
+// CHECK: class SWIFT_SYMBOL("s:7Structs12FrozenStructV") FrozenStruct final {
 // CHECK:        alignas(4) char _storage[4];
 // CHECK-NEXT:   friend class _impl::_impl_FrozenStruct;
 // CHECK-NEXT: };
@@ -115,7 +115,7 @@ public struct LargeStruct {
     }
 }
 
-// CHECK: class LargeStruct final {
+// CHECK: class SWIFT_SYMBOL("s:7Structs11LargeStructV") LargeStruct final {
 // CHECK-NEXT: public:
 // CHECK: inline LargeStruct(const LargeStruct &other) {
 // CHECK-NEXT:   auto metadata = _impl::$s7Structs11LargeStructVMa(0);
@@ -196,23 +196,23 @@ public func mutateSmall(_ x: inout FirstSmallStruct) {
 #endif
 }
 
-// CHECK:      inline LargeStruct createLargeStruct(swift::Int x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline LargeStruct createLargeStruct(swift::Int x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_LargeStruct::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::$s7Structs17createLargeStructyAA0cD0VSiF(result, x);
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK:      inline StructWithRefCountStoredProp createStructWithRefCountStoredProp() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK:      inline StructWithRefCountStoredProp createStructWithRefCountStoredProp() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:   return _impl::_impl_StructWithRefCountStoredProp::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:     _impl::$s7Structs34createStructWithRefCountStoredPropAA0cdefgH0VyF(result);
 // CHECK-NEXT:   });
 // CHECK-NEXT: }
 
-// CHECK:      inline void mutateSmall(FirstSmallStruct& x) noexcept {
+// CHECK:      inline void mutateSmall(FirstSmallStruct& x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   return _impl::$s7Structs11mutateSmallyyAA05FirstC6StructVzF(_impl::_impl_FirstSmallStruct::getOpaquePointer(x));
 // CHECK-NEXT: }
 
-// CHECK:      inline void printSmallAndLarge(const FirstSmallStruct& x, const LargeStruct& y) noexcept {
+// CHECK:      inline void printSmallAndLarge(const FirstSmallStruct& x, const LargeStruct& y) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   return _impl::$s7Structs18printSmallAndLargeyyAA05FirstC6StructV_AA0eG0VtF(_impl::_impl_FirstSmallStruct::getOpaquePointer(x), _impl::_impl_LargeStruct::getOpaquePointer(y));
 // CHECK-NEXT: }
 

--- a/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/small-structs-pass-return-direct-in-cxx.swift
@@ -34,11 +34,11 @@ public struct StructDoubleAndFloat {
 // CHECK: SWIFT_EXTERN void $s7Structs25inoutStructDoubleAndFloatyyAA0cdeF0VzF(void * _Nonnull s) SWIFT_NOEXCEPT SWIFT_CALL; // inoutStructDoubleAndFloat(_:)
 // CHECK: SWIFT_EXTERN void $s7Structs020inoutStructOneI16AnddC0yyAA0cdefdC0Vz_AA0C6TwoI32VtF(void * _Nonnull s, struct swift_interop_passStub_Structs_[[StructTwoI32:[0-9a-z_]+]] s2) SWIFT_NOEXCEPT SWIFT_CALL; // inoutStructOneI16AndOneStruct(_:_:)
 
-// CHECK: class StructDoubleAndFloat final {
+// CHECK: class SWIFT_SYMBOL("s:7Structs20StructDoubleAndFloatV") StructDoubleAndFloat final {
 
-// CHECK: class StructOneI16AndOneStruct final {
+// CHECK: class SWIFT_SYMBOL("s:7Structs015StructOneI16AndcB0V") StructOneI16AndOneStruct final {
 
-// CHECK: class StructOneI64 final {
+// CHECK: class SWIFT_SYMBOL("s:7Structs12StructOneI64V") StructOneI64 final {
 
 #if RESILIENT
 /*not frozen*/ public struct StructOneI64_resilient {
@@ -49,15 +49,15 @@ public func printStructOneI64_resilient(_ x : StructOneI64_resilient) {
     print(x)
 }
 
-// RESILIENT:       class StructOneI64_resilient final {
+// RESILIENT:       class SWIFT_SYMBOL({{.*}}) StructOneI64_resilient final {
 // RESILIENT:         swift::_impl::OpaqueStorage _storage;
 // RESILIENT-NEXT:    friend class _impl::_impl_StructOneI64_resilient;
 // RESILIENT-NEXT:  };
 #endif
 
-// CHECK: class StructTwoI32 final {
+// CHECK: class SWIFT_SYMBOL("s:7Structs12StructTwoI32V") StructTwoI32 final {
 
-// CHECK: class StructU16AndPointer final {
+// CHECK: class SWIFT_SYMBOL("s:7Structs19StructU16AndPointerV") StructU16AndPointer final {
 
 public func returnNewStructOneI64() -> StructOneI64 { return StructOneI64(x: 42 ) }
 
@@ -112,94 +112,94 @@ public func inoutStructDoubleAndFloat(_ s: inout StructDoubleAndFloat) {
     s.y /= 10
 }
 
-// CHECK: inline double getStructDoubleAndFloat_x(const StructDoubleAndFloat& x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline double getStructDoubleAndFloat_x(const StructDoubleAndFloat& x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::$s7Structs25getStructDoubleAndFloat_xySdAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_double_0_8_float_8_12(_impl::_impl_StructDoubleAndFloat::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
-// CHECK: inline float getStructDoubleAndFloat_y(const StructDoubleAndFloat& x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline float getStructDoubleAndFloat_y(const StructDoubleAndFloat& x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::$s7Structs25getStructDoubleAndFloat_yySfAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_double_0_8_float_8_12(_impl::_impl_StructDoubleAndFloat::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
-// CHECK: inline uint8_t getStructU16AndPointer_x(const StructU16AndPointer& x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline uint8_t getStructU16AndPointer_x(const StructU16AndPointer& x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::$s7Structs24getStructU16AndPointer_xys5UInt8VAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_[[StructU16AndPointer:[0-9a-z_]+]](_impl::_impl_StructU16AndPointer::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
-// CHECK: inline void * _Nonnull getStructU16AndPointer_y(const StructU16AndPointer& x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline void * _Nonnull getStructU16AndPointer_y(const StructU16AndPointer& x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::$s7Structs24getStructU16AndPointer_yySvAA0cdeF0VF(_impl::swift_interop_passDirect_Structs_[[StructU16AndPointer]](_impl::_impl_StructU16AndPointer::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
-// CHECK:      inline void inoutStructDoubleAndFloat(StructDoubleAndFloat& s) noexcept {
+// CHECK:      inline void inoutStructDoubleAndFloat(StructDoubleAndFloat& s) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   return _impl::$s7Structs25inoutStructDoubleAndFloatyyAA0cdeF0VzF(_impl::_impl_StructDoubleAndFloat::getOpaquePointer(s));
 // CHECK-NEXT: }
 
 
-// CHECK:      inline void inoutStructOneI16AndOneStruct(StructOneI16AndOneStruct& s, const StructTwoI32& s2) noexcept {
+// CHECK:      inline void inoutStructOneI16AndOneStruct(StructOneI16AndOneStruct& s, const StructTwoI32& s2) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:   return _impl::$s7Structs020inoutStructOneI16AnddC0yyAA0cdefdC0Vz_AA0C6TwoI32VtF(_impl::_impl_StructOneI16AndOneStruct::getOpaquePointer(s), _impl::swift_interop_passDirect_Structs_[[StructTwoI32]](_impl::_impl_StructTwoI32::getOpaquePointer(s2)));
 // CHECK-NEXT: }
 
 
-// CHECK: inline StructOneI64 passThroughStructOneI64(const StructOneI64& x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline StructOneI64 passThroughStructOneI64(const StructOneI64& x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructOneI64::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_uint64_t_0_8(result, _impl::$s7Structs23passThroughStructOneI64yAA0deF0VADF(_impl::swift_interop_passDirect_Structs_uint64_t_0_8(_impl::_impl_StructOneI64::getOpaquePointer(x))));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
-// CHECK: inline StructTwoI32 passThroughStructTwoI32(int32_t i, const StructTwoI32& x, int32_t j) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline StructTwoI32 passThroughStructTwoI32(int32_t i, const StructTwoI32& x, int32_t j) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructTwoI32::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_[[StructTwoI32]](result, _impl::$s7Structs23passThroughStructTwoI32yAA0deF0Vs5Int32V_AdFtF(i, _impl::swift_interop_passDirect_Structs_[[StructTwoI32]](_impl::_impl_StructTwoI32::getOpaquePointer(x)), j));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
-// CHECK: inline void printStructOneI64(const StructOneI64& x) noexcept {
+// CHECK: inline void printStructOneI64(const StructOneI64& x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:  return _impl::$s7Structs17printStructOneI64yyAA0cdE0VF(_impl::swift_interop_passDirect_Structs_uint64_t_0_8(_impl::_impl_StructOneI64::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
-// CHECK: inline void printStructStructTwoI32_and_OneI16AndOneStruct(const StructTwoI32& y, const StructOneI16AndOneStruct& x) noexcept {
+// CHECK: inline void printStructStructTwoI32_and_OneI16AndOneStruct(const StructTwoI32& y, const StructOneI16AndOneStruct& x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:  return _impl::$s7Structs011printStructc20TwoI32_and_OneI16AndgC0yyAA0cdE0V_AA0cghigC0VtF(_impl::swift_interop_passDirect_Structs_[[StructTwoI32]](_impl::_impl_StructTwoI32::getOpaquePointer(y)), _impl::swift_interop_passDirect_Structs_[[StructOneI16AndOneStruct:[0-9a-z_]+]](_impl::_impl_StructOneI16AndOneStruct::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
-// CHECK: inline void printStructTwoI32(const StructTwoI32& x) noexcept {
+// CHECK: inline void printStructTwoI32(const StructTwoI32& x) noexcept SWIFT_SYMBOL({{.*}}) {
 // CHECK-NEXT:  return _impl::$s7Structs17printStructTwoI32yyAA0cdE0VF(_impl::swift_interop_passDirect_Structs_[[StructTwoI32]](_impl::_impl_StructTwoI32::getOpaquePointer(x)));
 // CHECK-NEXT: }
 
 
-// CHECK: inline StructDoubleAndFloat returnNewStructDoubleAndFloat(float y, double x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline StructDoubleAndFloat returnNewStructDoubleAndFloat(float y, double x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructDoubleAndFloat::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_double_0_8_float_8_12(result, _impl::$s7Structs29returnNewStructDoubleAndFloatyAA0defG0VSf_SdtF(y, x));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
-// CHECK: inline StructOneI16AndOneStruct returnNewStructOneI16AndOneStruct() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline StructOneI16AndOneStruct returnNewStructOneI16AndOneStruct() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructOneI16AndOneStruct::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_[[StructOneI16AndOneStruct]](result, _impl::$s7Structs024returnNewStructOneI16AndeD0AA0defgeD0VyF());
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
-// CHECK: inline StructOneI64 returnNewStructOneI64() noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline StructOneI64 returnNewStructOneI64() noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructOneI64::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_uint64_t_0_8(result, _impl::$s7Structs21returnNewStructOneI64AA0deF0VyF());
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
-// CHECK: inline StructTwoI32 returnNewStructTwoI32(int32_t x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline StructTwoI32 returnNewStructTwoI32(int32_t x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructTwoI32::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_[[StructTwoI32]](result, _impl::$s7Structs21returnNewStructTwoI32yAA0deF0Vs5Int32VF(x));
 // CHECK-NEXT:  });
 // CHECK-NEXT: }
 
 
-// CHECK: inline StructU16AndPointer returnNewStructU16AndPointer(void * _Nonnull x) noexcept SWIFT_WARN_UNUSED_RESULT {
+// CHECK: inline StructU16AndPointer returnNewStructU16AndPointer(void * _Nonnull x) noexcept SWIFT_SYMBOL({{.*}}) SWIFT_WARN_UNUSED_RESULT {
 // CHECK-NEXT:  return _impl::_impl_StructU16AndPointer::returnNewValue([&](char * _Nonnull result) {
 // CHECK-NEXT:    _impl::swift_interop_returnDirect_Structs_[[StructU16AndPointer]](result, _impl::$s7Structs28returnNewStructU16AndPointeryAA0defG0VSvF(x));
 // CHECK-NEXT:  });

--- a/test/Interop/SwiftToCxx/structs/struct-with-refcounted-member.swift
+++ b/test/Interop/SwiftToCxx/structs/struct-with-refcounted-member.swift
@@ -25,7 +25,7 @@ public func printBreak(_ x: Int) {
     print("breakpoint \(x)")
 }
 
-// CHECK:      class StructWithRefcountedMember final {
+// CHECK:      class SWIFT_SYMBOL({{.*}}) StructWithRefcountedMember final {
 // CHECK-NEXT: public:
 // CHECK-NEXT:   inline ~StructWithRefcountedMember() {
 // CHECK-NEXT:     auto metadata = _impl::$s7Structs26StructWithRefcountedMemberVMa(0);

--- a/test/Interop/SwiftToCxx/structs/swift-struct-circular-dependent-defs.swift
+++ b/test/Interop/SwiftToCxx/structs/swift-struct-circular-dependent-defs.swift
@@ -24,15 +24,15 @@ public struct B {
     let v: Large = Large()
 }
 
-// CHECK: class B;
-// CHECK: class A;
+// CHECK: class SWIFT_SYMBOL({{.*}}) B;
+// CHECK: class SWIFT_SYMBOL({{.*}}) A;
 // CHECK: namespace _impl {
 // CHECK-EMPTY:
 // CHECK-NEXT: class _impl_A;
 
-// CHECK: class A final {
+// CHECK: class SWIFT_SYMBOL({{.*}}) A final {
 
-// CHECK: B returnsB() const;
+// CHECK: B returnsB() const SWIFT_SYMBOL({{.*}});
 
 // CHECK: namespace _impl {
 // CHECK-EMPTY:
@@ -42,7 +42,7 @@ public struct B {
 // CHECK-EMPTY:
 // CHECK-NEXT: class _impl_B;
 
-// CHECK: class B final {
+// CHECK: class SWIFT_SYMBOL({{.*}}) B final {
 
 // CHECK: inline B A::returnsB() const {
 // CHECK: inline A B::returnsA() const {

--- a/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
@@ -4,12 +4,12 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/structs.h -Wno-unused-private-field -Wno-unused-function)
 
-// CHECK: namespace Structs __attribute__((swift_private)) {
+// CHECK: namespace Structs __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Structs") {
 // CHECK: namespace _impl {
 
-// CHECK: namespace Structs __attribute__((swift_private)) {
+// CHECK: namespace Structs __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Structs") {
 
-// CHECK: class StructWithIntField;
+// CHECK: class SWIFT_SYMBOL("s:7Structs18StructWithIntFieldV") StructWithIntField;
 // CHECK-NEXT: } // end namespace
 
 // CHECK: namespace swift {
@@ -20,7 +20,7 @@
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: } // namespace swift
 
-// CHECK: namespace Structs __attribute__((swift_private)) {
+// CHECK: namespace Structs __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Structs") {
 
 // CHECK:      namespace _impl {
 // CHECK-EMPTY:
@@ -32,7 +32,7 @@
 // CHECK-EMPTY:
 // CHECK-NEXT: }
 
-// CHECK:      class StructWithIntField final {
+// CHECK:      class SWIFT_SYMBOL("s:7Structs18StructWithIntFieldV") StructWithIntField final {
 // CHECK-NEXT: public:
 // CHECK-NEXT:   inline ~StructWithIntField() {
 // CHECK:        }
@@ -95,14 +95,14 @@
 // CHECK-NEXT: #pragma clang diagnostic pop
 // CHECK-NEXT: } // namespace swift
 // CHECK-EMPTY:
-// CHECK-NEXT: namespace Structs __attribute__((swift_private)) {
+// CHECK-NEXT: namespace Structs __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Structs") {
 
 public struct StructWithIntField {
   let field: Int64
 }
 
 // Special name gets renamed in C++.
-// CHECK: class register_ final {
+// CHECK: class SWIFT_SYMBOL({{.*}}) register_ final {
 // CHECK: alignas(8) char _storage[16];
 // CHECK-NEXT:   friend class
 // CHECK-NEXT: };

--- a/test/Interop/SwiftToCxx/structs/zero-sized-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/zero-sized-struct-in-cxx.swift
@@ -2,9 +2,9 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Structs -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
 // RUN: %FileCheck %s < %t/structs.h
 
-// CHECK: namespace Structs __attribute__((swift_private)) {
+// CHECK: namespace Structs __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Structs") {
 
-// CHECK-NOT: class ZeroSizedStruct final {
+// CHECK-NOT: class SWIFT_SYMBOL({{.*}}) ZeroSizedStruct final {
 
 public struct ZeroSizedStruct {}
 

--- a/test/Interop/SwiftToCxxToSwift/hide-swift-module-namespace-in-swift.swift
+++ b/test/Interop/SwiftToCxxToSwift/hide-swift-module-namespace-in-swift.swift
@@ -32,6 +32,6 @@ public func testFunction() -> String {
     return ""
 }
 
-// CHECK: namespace Swift __attribute__((swift_private)) {
-// CHECK: namespace SwiftMod __attribute__((swift_private)) {
+// CHECK: namespace Swift __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Swift") {
+// CHECK: namespace SwiftMod __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("SwiftMod") {
 // CHECK-NOT: namespace Swift {

--- a/test/PrintAsCxx/empty.swift
+++ b/test/PrintAsCxx/empty.swift
@@ -103,7 +103,7 @@
 // CHECK:       } // namespace swift
 // CHECK-EMPTY:
 // CHECK-NEXT:  #endif
-// CHECK:       namespace empty __attribute__((swift_private)) {
+// CHECK:       namespace empty __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("empty") {
 // CHECK:       } // namespace empty
 // CHECK:       #endif
 


### PR DESCRIPTION
Each emitted declaration is annotated with the external_source_symbol with its own USR, to allow Clang's indexer to recognize this declaration as a Swift declaration with a specific USR
