### PR TITLE
[CSSimplify] Allow conversions between tuple element type and a placeholder

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -6014,6 +6014,12 @@ bool ConstraintSystem::repairFailures(
   }
 
   case ConstraintLocator::TupleElement: {
+    if (lhs->isPlaceholder() || rhs->isPlaceholder()) {
+      recordAnyTypeVarAsPotentialHole(lhs);
+      recordAnyTypeVarAsPotentialHole(rhs);
+      return true;
+    }
+
     if (isExpr<ArrayExpr>(anchor) || isExpr<DictionaryExpr>(anchor)) {
       // If we could record a generic arguments mismatch instead of this fix,
       // don't record a ContextualMismatch here.

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -907,3 +907,34 @@ func test_associated_values_dont_block_solver_when_unresolved() {
     }
   }
 }
+
+func test_dependent_member_with_unresolved_base_type() {
+  struct Wrapper<A, T: P> : P {
+  }
+
+  @resultBuilder
+  struct Builder<A> {
+    static func buildBlock(_ value: some P) -> some P {
+      value
+    }
+  }
+
+  func test<A, U: P>(data: KeyPath<A, [(Int, U.T)]>, // expected-note {{in call to function 'test(data:_:)'}}
+                     @Builder<U.T> _: () -> U) -> Wrapper<A, U> { fatalError() }
+
+  struct Value : P {
+    typealias T = (Int, String)
+  }
+
+  struct Test : P {
+    struct T {
+      var values: [(Int, Value.T)]
+    }
+
+    var v: some P {
+      test(data: \T.values) { // expected-error {{generic parameter 'U' could not be inferred}}
+        Value()
+      }
+    }
+  }
+}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -748,8 +748,9 @@ func invalidDictionaryLiteral() {
 
 
 [4].joined(separator: [1])
-// expected-error@-1 {{cannot convert value of type 'Int' to expected element type 'String'}}
-// expected-error@-2 {{cannot convert value of type '[Int]' to expected argument type 'String'}}
+// expected-error@-1 {{no exact matches in call to instance method 'joined'}}
+// expected-note@-2 {{found candidate with type '(String) -> String'}}
+// There is one more note here - candidate requires that 'Int' conform to 'Sequence' (requirement specified as 'Self.Element' : 'Sequence') pointing to Sequence extension
 
 [4].joined(separator: [[[1]]])
 // expected-error@-1 {{cannot convert value of type 'Int' to expected element type 'String'}}


### PR DESCRIPTION
If a placeholder appears on one of the side of tuple element 
matching conversion, consider that conversion to be solved,
because the actual error is related to the placeholder.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
