### PR TITLE
[5.8][Concurrency] uncomment isCancelled override decl

### DIFF
--- a/stdlib/toolchain/Compatibility56/CompatibilityOverrideConcurrency.def
+++ b/stdlib/toolchain/Compatibility56/CompatibilityOverrideConcurrency.def
@@ -264,9 +264,9 @@ OVERRIDE_TASK_GROUP(taskGroup_isEmpty, bool,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
                     swift::, (TaskGroup *group), (group))
 
-//OVERRIDE_TASK_GROUP(taskGroup_isCancelled, bool,
-//                    SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
-//                    swift::, (TaskGroup *group), (group))
+OVERRIDE_TASK_GROUP(taskGroup_isCancelled, bool,
+                    SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
+                    swift::, (TaskGroup *group), (group))
 
 OVERRIDE_TASK_GROUP(taskGroup_cancelAll, void,
                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),


### PR DESCRIPTION
Description: Wrongly commented override hook.

Original PR: https://github.com/apple/swift/pull/63007