### PR TITLE
[Concurrency] Fix too optimistic TaskGroup bail-out-when-empty, 

### DIFF
--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -86,6 +86,7 @@ public func withDiscardingTaskGroup<GroupResult>(
   let result = await body(&group)
 
   try! await group.awaitAllRemainingTasks() // try!-safe, cannot throw since this is a non throwing group
+
   return result
   #else
   fatalError("Swift compiler is incompatible with this SDK version")

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -45,6 +45,10 @@
 #include <android/log.h>
 #endif
 
+#if defined(_WIN32)
+#include <io.h>
+#endif
+
 #include <assert.h>
 #if SWIFT_CONCURRENCY_ENABLE_DISPATCH
 #include <dispatch/dispatch.h>

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -51,15 +51,24 @@
 using namespace swift;
 
 #if 0
-#define SWIFT_TASK_GROUP_DEBUG_LOG(group, fmt, ...) \
+#define SWIFT_TASK_GROUP_DEBUG_LOG(group, fmt, ...)                     \
 fprintf(stderr, "[%#lx] [%s:%d][group(%p%s)] (%s) " fmt "\n",           \
       (unsigned long)Thread::current().platformThreadId(),              \
       __FILE__, __LINE__,                                               \
       group, group->isDiscardingResults() ? ",discardResults" : "",     \
       __FUNCTION__,                                                     \
       __VA_ARGS__)
+
+#define SWIFT_TASK_GROUP_DEBUG_LOG_0(group, fmt, ...)                   \
+fprintf(stderr, "[%#lx] [%s:%d][group(%p)] (%s) " fmt "\n",             \
+      (unsigned long)Thread::current().platformThreadId(),              \
+      __FILE__, __LINE__,                                               \
+      group,                                                            \
+      __FUNCTION__,                                                     \
+      __VA_ARGS__)
 #else
 #define SWIFT_TASK_GROUP_DEBUG_LOG(group, fmt, ...) (void)0
+#define SWIFT_TASK_GROUP_DEBUG_LOG_0(group, fmt, ...) (void)0
 #endif
 
 using FutureFragment = AsyncTask::FutureFragment;
@@ -354,7 +363,11 @@ public:
   /// There can be only at-most-one waiting task on a group at any given time,
   /// and the waiting task is expected to be the parent task in which the group
   /// body is running.
-  PollResult waitAll(AsyncTask *waitingTask);
+  ///
+  /// \param bodyError error thrown by the body of a with...TaskGroup method
+  /// \param waitingTask the task waiting on the group
+  /// \return how the waiting task should be handled, e.g. must wait or can be completed immediately
+  PollResult waitAll(SwiftError* bodyError, AsyncTask *waitingTask);
 
   // Enqueue the completed task onto ready queue if there are no waiting tasks yet
   virtual void enqueueCompletedTask(AsyncTask *completedTask, bool hadErrorResult) = 0;
@@ -410,6 +423,16 @@ public:
 
   virtual TaskGroupStatus statusAddPendingTaskRelaxed(bool unconditionally) = 0;
 };
+
+[[maybe_unused]]
+static std::string to_string(TaskGroupBase::PollStatus status) {
+  switch (status) {
+    case TaskGroupBase::PollStatus::Empty: return "Empty";
+    case TaskGroupBase::PollStatus::MustWait: return "MustWait";
+    case TaskGroupBase::PollStatus::Success: return "Success";
+    case TaskGroupBase::PollStatus::Error: return "Error";
+  }
+}
 
 /// The status of a task group.
 ///
@@ -619,7 +642,7 @@ public:
   /// so unconditionally.
   ///
   /// Returns *assumed* new status, including the just performed +1.
-  TaskGroupStatus statusAddPendingTaskRelaxed(bool unconditionally) {
+  TaskGroupStatus statusAddPendingTaskRelaxed(bool unconditionally) override {
     auto old = status.fetch_add(TaskGroupStatus::onePendingTask,
                                 std::memory_order_relaxed);
     auto s = TaskGroupStatus{old + TaskGroupStatus::onePendingTask};
@@ -713,7 +736,7 @@ public:
   /// so unconditionally.
   ///
   /// Returns *assumed* new status, including the just performed +1.
-  TaskGroupStatus statusAddPendingTaskRelaxed(bool unconditionally) {
+  TaskGroupStatus statusAddPendingTaskRelaxed(bool unconditionally) override {
     auto old = status.fetch_add(TaskGroupStatus::onePendingTask,
                                 std::memory_order_relaxed);
     auto s = TaskGroupStatus{old + TaskGroupStatus::onePendingTask};
@@ -771,8 +794,6 @@ public:
   /// or a `PollStatus::MustWait` result if there are tasks in flight
   /// and the waitingTask eventually be woken up by a completion.
   PollResult poll(AsyncTask *waitingTask);
-
-  bool offerBodyError(SwiftError* _Nonnull bodyError);
 
 private:
   /// Resume waiting task with specified error
@@ -855,8 +876,8 @@ static void swift_taskGroup_initializeWithFlagsImpl(size_t rawGroupFlags,
                                                     TaskGroup *group, const Metadata *T) {
 
   TaskGroupFlags groupFlags(rawGroupFlags);
-  SWIFT_TASK_DEBUG_LOG("group(%p) create; flags: isDiscardingResults=%d",
-                       group, groupFlags.isDiscardResults());
+  SWIFT_TASK_GROUP_DEBUG_LOG_0(group, "create group; flags: isDiscardingResults=%d",
+                               groupFlags.isDiscardResults());
 
   TaskGroupBase *impl;
   if (groupFlags.isDiscardResults()) {
@@ -1151,7 +1172,7 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
   assert(completedTask->hasChildFragment());
   assert(completedTask->hasGroupChildFragment());
   assert(completedTask->groupChildFragment()->getGroup() == asAbstract(this));
-  SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, completedTask:%p , status:%s", completedTask, statusString().c_str());
+  SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, completedTask:%p, status:%s", completedTask, statusString().c_str());
 
   // The current ownership convention is that we are *not* given ownership
   // of a retain on completedTask; we're called from the task completion
@@ -1217,7 +1238,7 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
     }
 
     auto afterComplete = statusCompletePendingAssumeRelease();
-    (void)afterComplete; // silence "not used" warning
+    (void) afterComplete;
     SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, either more pending tasks, or no waiting task, status:%s",
                                afterComplete.to_string(this).c_str());
   }
@@ -1628,7 +1649,7 @@ static void swift_taskGroup_waitAllImpl(
   waitingTask->ResumeContext = rawContext;
 
   auto group = asBaseImpl(_group);
-  PollResult polled = group->waitAll(waitingTask);
+  PollResult polled = group->waitAll(bodyError, waitingTask);
 
   auto context = static_cast<TaskFutureWaitAsyncContext *>(rawContext);
   context->ResumeParent =
@@ -1637,23 +1658,13 @@ static void swift_taskGroup_waitAllImpl(
   context->errorResult = nullptr;
   context->successResultPointer = resultPointer;
 
-  SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAllImpl, waiting task = %p, bodyError = %p, status:%s",
-                       waitingTask, bodyError, group->statusString().c_str());
+  SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAllImpl, waiting task = %p, bodyError = %p, status:%s, polled.status = %s",
+                       waitingTask, bodyError, group->statusString().c_str(), to_string(polled.status).c_str());
 
   switch (polled.status) {
     case PollStatus::MustWait:
-    SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAll MustWait, pending tasks exist, waiting task = %p",
+    SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAllImpl MustWait, pending tasks exist, waiting task = %p",
                                waitingTask);
-      if (bodyError && group->isDiscardingResults()) {
-        auto discardingGroup = asDiscardingImpl(_group);
-        bool storedBodyError = discardingGroup->offerBodyError(bodyError);
-        if (storedBodyError) {
-          SWIFT_TASK_GROUP_DEBUG_LOG(
-              group, "waitAll, stored error thrown by with...Group body, error = %p",
-              bodyError);
-        }
-      }
-
       // The waiting task has been queued on the channel,
       // there were pending tasks so it will be woken up eventually.
 #ifdef __ARM_ARCH_7K__
@@ -1664,7 +1675,7 @@ static void swift_taskGroup_waitAllImpl(
 #endif /* __ARM_ARCH_7K__ */
 
     case PollStatus::Error:
-      SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAll found error, waiting task = %p, body error = %p, status:%s",
+      SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAllImpl Error, waiting task = %p, body error = %p, status:%s",
                                  waitingTask, bodyError, group->statusString().c_str());
 #if SWIFT_TASK_GROUP_BODY_THROWN_ERROR_WINS
       if (bodyError) {
@@ -1686,17 +1697,10 @@ static void swift_taskGroup_waitAllImpl(
       return waitingTask->runInFullyEstablishedContext();
 
     case PollStatus::Empty:
-      /// Anything else than a "MustWait" can be treated as a successful poll.
-      /// Only if there are in flight pending tasks do we need to wait after all.
-      SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAll %s, waiting task = %p, status:%s",
-                                 polled.status == TaskGroupBase::PollStatus::Empty ? "empty" : "success",
-                                 waitingTask, group->statusString().c_str());
-
-
     case PollStatus::Success:
       /// Anything else than a "MustWait" can be treated as a successful poll.
       /// Only if there are in flight pending tasks do we need to wait after all.
-      SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAll %s, waiting task = %p, status:%s",
+      SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAllImpl %s, waiting task = %p, status:%s",
                                  polled.status == TaskGroupBase::PollStatus::Empty ? "empty" : "success",
                                  waitingTask, group->statusString().c_str());
 
@@ -1711,26 +1715,13 @@ static void swift_taskGroup_waitAllImpl(
   }
 }
 
-bool DiscardingTaskGroup::offerBodyError(SwiftError* _Nonnull bodyError) {
+/// Must be called while holding the `taskGroup.lock`!
+/// This is because the discarding task group still has some follow-up operations that must
+/// be performed atomically after this operation sometimes, so we cannot unlock inside `waitAll` itself.
+PollResult TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask) {
   lock(); // TODO: remove group lock, and use status for synchronization
 
-  if (!readyQueue.isEmpty()) {
-    // already other error stored, discard this one
-    unlock();
-    return false;
-  }
-
-  auto readyItem = ReadyQueueItem::getRawError(this, bodyError);
-  readyQueue.enqueue(readyItem);
-  unlock();
-
-  return true;
-}
-
-PollResult TaskGroupBase::waitAll(AsyncTask *waitingTask) {
-  lock(); // TODO: remove group lock, and use status for synchronization
-
-  SWIFT_TASK_GROUP_DEBUG_LOG(this, "waitAll, status = %s", statusString().c_str());
+  SWIFT_TASK_GROUP_DEBUG_LOG(this, "waitAll, bodyError = %p, status = %s", bodyError, statusString().c_str());
   PollResult result = PollResult::getEmpty(this->successType);
   result.status = PollStatus::Empty;
   result.storage = nullptr;
@@ -1774,6 +1765,16 @@ PollResult TaskGroupBase::waitAll(AsyncTask *waitingTask) {
   }
 
   // ==== 2) Add to wait queue -------------------------------------------------
+
+  // ---- 2.1) Discarding task group may need to story the bodyError before we park
+  if (bodyError && isDiscardingResults()) {
+    auto discardingGroup = asDiscardingImpl(this);
+    assert(readyQueue.isEmpty() &&
+           "only a single error may be stored in discarding task group, but something was enqueued already");
+    auto readyItem = ReadyQueueItem::getRawError(discardingGroup, bodyError);
+    readyQueue.enqueue(readyItem);
+  }
+
   auto waitHead = waitQueue.load(std::memory_order_acquire);
   _swift_tsan_release(static_cast<Job *>(waitingTask));
   while (true) {

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -50,7 +50,7 @@
 
 using namespace swift;
 
-#if 0
+#if 1
 #define SWIFT_TASK_GROUP_DEBUG_LOG(group, fmt, ...)                     \
 fprintf(stderr, "[%#lx] [%s:%d][group(%p%s)] (%s) " fmt "\n",           \
       (unsigned long)Thread::current().platformThreadId(),              \

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -1157,55 +1157,85 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
   // Immediately decrement the pending count.
   // We can do this, since in this mode there is no ready count to keep track of,
   // and we immediately discard the result.
-  SWIFT_TASK_GROUP_DEBUG_LOG(this, "discard result, hadError:%d, was pending:%llu, status = %s",
-                             hadErrorResult, assumed.pendingTasks(this), assumed.to_string(this).c_str());
+  auto afterComplete = statusCompletePendingAssumeRelease();
+  (void) afterComplete;
+  const bool alreadyDecrementedStatus = true;
+  SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, complete, status afterComplete:%s", afterComplete.to_string(this).c_str());
 
-    if (hadErrorResult && readyQueue.isEmpty()) {
-      // a discardResults throwing task group must retain the FIRST error it encounters.
-      SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer error, error:%d, completedTask:%p", hadErrorResult, completedTask);
-      enqueueCompletedTask(completedTask, /*hadErrorResult=*/hadErrorResult);
+  // Errors need special treatment
+  if (hadErrorResult) {
+    // Discarding results mode immediately treats a child failure as group cancellation.
+    // "All for one, one for all!" - any task failing must cause the group and all sibling tasks to be cancelled,
+    // such that the discarding group can exit as soon as possible.
+    cancelAll();
+
+    if (afterComplete.hasWaitingTask() && afterComplete.pendingTasks(this) == 0) {
+      // This is the last pending task, and we must resume the waiting task.
+      // - if there already was a previous error stored, we resume using it,
+      // - otherwise, we resume using this current (failed) completedTask
+      ReadyQueueItem readyErrorItem;
+      if (readyQueue.dequeue(readyErrorItem)) {
+        switch (readyErrorItem.getStatus()) {
+          case ReadyStatus::RawError:
+            resumeWaitingTaskWithError(readyErrorItem.getRawError(this), assumed, alreadyDecrementedStatus);
+            break;
+          case ReadyStatus::Error:
+            resumeWaitingTask(readyErrorItem.getTask(), assumed, /*hadErrorResult=*/true, alreadyDecrementedStatus);
+            break;
+          default:
+            swift_Concurrency_fatalError(0,
+                                         "only errors can be stored by a discarding task group, yet it wasn't an error! 1");
+        }
+      } else {
+        // There was no prior failed task stored, so we should resume the waitingTask with this (failed) completedTask
+        resumeWaitingTask(completedTask, assumed, hadErrorResult, alreadyDecrementedStatus);
+      }
+    } else if (readyQueue.isEmpty()) {
+      // There was no waiting task, or other tasks are still pending, so we cannot
+      // it is the first error we encountered, thus we need to store it for future throwing
+      enqueueCompletedTask(completedTask, hadErrorResult);
     } else {
-      // we just are going to discard it.
-      SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer discard the completedTask:%p, status=%s", completedTask, statusString().c_str());
       _swift_taskGroup_detachChild(asAbstract(this), completedTask);
     }
 
-    auto afterComplete = statusCompletePendingAssumeRelease();
-    (void) afterComplete;
-    bool alreadyDecrementedStatus = true;
-    SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, complete, status:%s",
-                               afterComplete.to_string(this).c_str());
-
-  // Discarding results mode, immediately treats a child failure as group cancellation.
-  // "All for one, one for all!" - any task failing must cause the group and all sibling tasks to be cancelled,
-  // such that the discarding group can exit as soon as possible.
-  if (hadErrorResult) {
-    cancelAll();
+    unlock();
+    return;
   }
 
+  assert(!hadErrorResult);
   if (afterComplete.hasWaitingTask() && afterComplete.pendingTasks(this) == 0) {
-    ReadyQueueItem priorErrorItem;
-    if (readyQueue.dequeue(priorErrorItem)) {
-      SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, last pending task, prior error found, fail waitingTask:%p",
-                                 waitQueue.load(std::memory_order_relaxed));
-      switch (priorErrorItem.getStatus()) {
+    SWIFT_TASK_GROUP_DEBUG_LOG(this,
+                               "offer, last pending task completed successfully, resume waitingTask with completedTask:%p",
+                               completedTask);
+
+    /// If there was an error previously stored, we must resume the waitingTask using that error.
+    ReadyQueueItem readyErrorItem;
+    if (readyQueue.dequeue(readyErrorItem)) {
+      _swift_taskGroup_detachChild(asAbstract(this), completedTask);
+      switch (readyErrorItem.getStatus()) {
         case ReadyStatus::RawError:
-          resumeWaitingTaskWithError(priorErrorItem.getRawError(this), assumed, alreadyDecrementedStatus);
+          resumeWaitingTaskWithError(readyErrorItem.getRawError(this), assumed, alreadyDecrementedStatus);
           break;
         case ReadyStatus::Error:
-          resumeWaitingTask(priorErrorItem.getTask(), assumed, /*hadErrorResult=*/true, alreadyDecrementedStatus);
+          resumeWaitingTask(readyErrorItem.getTask(), assumed, /*hadErrorResult=*/true, alreadyDecrementedStatus);
           break;
         default:
-          swift_Concurrency_fatalError(0, "only errors can be stored by a discarding task group, yet it wasn't an error!");
+          swift_Concurrency_fatalError(0,
+                                       "only errors can be stored by a discarding task group, yet it wasn't an error! 2");
       }
     } else {
-      SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, last pending task, completing with completedTask:%p, completedTask.error:%d, waitingTask:%p",
-                                 completedTask, hadErrorResult, waitQueue.load(std::memory_order_relaxed));
-      resumeWaitingTask(completedTask, assumed, /*hadErrorResult=*/hadErrorResult, alreadyDecrementedStatus);
+      // This is the last task, we have a waiting task and there was no error stored previously;
+      // We must resume the waiting task with a success, so let us return here.
+      resumeWaitingTask(completedTask, assumed, hadErrorResult, alreadyDecrementedStatus);
     }
+  } else {
+    // it wasn't the last pending task, and there is no-one to resume;
+    // Since this is a successful result, and we're a discarding task group -- always just ignore this task.
+    _swift_taskGroup_detachChild(asAbstract(this), completedTask);
   }
 
   unlock();
+  return;
 }
 
 /// Must be called while holding the TaskGroup lock.

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -760,7 +760,7 @@ public:
 
 private:
   /// Resume waiting task with specified error
-  void resumeWaitingTaskWithError(SwiftError *error, TaskGroupStatus &assumed);
+  void resumeWaitingTaskWithError(SwiftError *error, TaskGroupStatus &assumed, bool alreadyDecremented);
 };
 
 } // end anonymous namespace
@@ -1172,6 +1172,7 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
 
     auto afterComplete = statusCompletePendingAssumeRelease();
     (void) afterComplete;
+    bool alreadyDecrementedStatus = true;
     SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, complete, status:%s",
                                afterComplete.to_string(this).c_str());
 
@@ -1189,10 +1190,10 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
                                  waitQueue.load(std::memory_order_relaxed));
       switch (priorErrorItem.getStatus()) {
         case ReadyStatus::RawError:
-          resumeWaitingTaskWithError(priorErrorItem.getRawError(this), assumed);
+          resumeWaitingTaskWithError(priorErrorItem.getRawError(this), assumed, alreadyDecrementedStatus);
           break;
         case ReadyStatus::Error:
-          resumeWaitingTask(priorErrorItem.getTask(), assumed, /*hadErrorResult=*/true, /*alreadyDecremented=*/true);
+          resumeWaitingTask(priorErrorItem.getTask(), assumed, /*hadErrorResult=*/true, alreadyDecrementedStatus);
           break;
         default:
           swift_Concurrency_fatalError(0, "only errors can be stored by a discarding task group, yet it wasn't an error!");
@@ -1200,7 +1201,7 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
     } else {
       SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, last pending task, completing with completedTask:%p, completedTask.error:%d, waitingTask:%p",
                                  completedTask, hadErrorResult, waitQueue.load(std::memory_order_relaxed));
-      resumeWaitingTask(completedTask, assumed, /*hadErrorResult=*/hadErrorResult);
+      resumeWaitingTask(completedTask, assumed, /*hadErrorResult=*/hadErrorResult, alreadyDecrementedStatus);
     }
   }
 
@@ -1217,44 +1218,48 @@ void TaskGroupBase::resumeWaitingTask(
   auto waitingTask = waitQueue.load(std::memory_order_acquire);
   assert(waitingTask && "waitingTask must not be null when attempting to resume it");
   assert(assumed.hasWaitingTask());
-  SWIFT_TASK_GROUP_DEBUG_LOG(this, "resume waiting task = %p, error:%d, complete with = %p",
-                       waitingTask, hadErrorResult, completedTask);
+  SWIFT_TASK_GROUP_DEBUG_LOG(this, "resume waiting task = %p, alreadyDecremented:%d, error:%d, complete with = %p",
+                       waitingTask, alreadyDecremented, hadErrorResult, completedTask);
   while (true) {
+    SWIFT_TASK_GROUP_DEBUG_LOG(this, "resumeWaitingTask, attempt CAS, waiting task = %p, waitQueue.head = %p, error:%d, complete with = %p",
+                               waitingTask, waitQueue.load(std::memory_order_relaxed), hadErrorResult, completedTask);
+
     // ==== a) run waiting task directly -------------------------------------
-    // assert(assumed.pendingTasks(this) && "offered to group with no pending tasks!");
-    // We are the "first" completed task to arrive,
-    // and since there is a task waiting we immediately claim and complete it.
-    if (waitQueue.compare_exchange_strong(
-        waitingTask, nullptr,
-        /*success*/ std::memory_order_seq_cst,
-        /*failure*/ std::memory_order_seq_cst)) {
+      // assert(assumed.pendingTasks(this) && "offered to group with no pending tasks!");
+      // We are the "first" completed task to arrive,
+      // and since there is a task waiting we immediately claim and complete it.
+      if (waitQueue.compare_exchange_strong(
+          waitingTask, nullptr,
+          /*success*/ std::memory_order_release,
+          /*failure*/ std::memory_order_acquire)) {
 
 #if SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL
-      // In the task-to-thread model, child tasks are always actually
-      // run synchronously on the parent task's thread.  For task groups
-      // specifically, this means that poll() will pick a child task
-      // that was added to the group and run it to completion as a
-      // subroutine.  Therefore, when we enter offer(), we know that
-      // the parent task is waiting and we can just return to it.
+        // In the task-to-thread model, child tasks are always actually
+        // run synchronously on the parent task's thread.  For task groups
+        // specifically, this means that poll() will pick a child task
+        // that was added to the group and run it to completion as a
+        // subroutine.  Therefore, when we enter offer(), we know that
+        // the parent task is waiting and we can just return to it.
 
-      // The task-to-thread logic in poll() currently expects the child
-      // task to enqueue itself instead of just filling in the result in
-      // the waiting task.  This is a little wasteful; there's no reason
-      // we can't just have the parent task set itself up as a waiter.
-      // But since it's what we're doing, we basically take the same
-      // path as we would if there wasn't a waiter.
-      enqueueCompletedTask(completedTask, hadErrorResult);
-      return;
+        // The task-to-thread logic in poll() currently expects the child
+        // task to enqueue itself instead of just filling in the result in
+        // the waiting task.  This is a little wasteful; there's no reason
+        // we can't just have the parent task set itself up as a waiter.
+        // But since it's what we're doing, we basically take the same
+        // path as we would if there wasn't a waiter.
+        enqueueCompletedTask(completedTask, hadErrorResult);
+        return;
 
 #else /* SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL */
-      fprintf(stderr, "[%s:%d](%s) assumed:%s\n", __FILE_NAME__, __LINE__, __FUNCTION__, assumed.to_string(this).c_str());
-      fprintf(stderr, "[%s:%d](%s)     had:%s\n", __FILE_NAME__, __LINE__, __FUNCTION__, this->statusString().c_str());
+        if (!alreadyDecremented) {
+          (void) statusCompletePendingReadyWaiting(assumed);
+        }
 
-      if (alreadyDecremented || statusCompletePendingReadyWaiting(assumed)) {
         // Run the task.
         auto result = PollResult::get(completedTask, hadErrorResult);
-        SWIFT_TASK_GROUP_DEBUG_LOG(this, "resume waiting DONE, task = %p, complete with = %p, status = %s",
-                                   waitingTask, completedTask, statusString().c_str());
+        SWIFT_TASK_GROUP_DEBUG_LOG(this,
+                                   "resume waiting DONE, task = %p, backup = %p, complete with = %p, status = %s",
+                                   waitingTask, backup, completedTask, statusString().c_str());
 
         // Remove the child from the task group's running tasks list.
         // The parent task isn't currently running (we're about to wake
@@ -1276,8 +1281,10 @@ void TaskGroupBase::resumeWaitingTask(
         // TODO: allow the caller to suggest an executor
         waitingTask->flagAsAndEnqueueOnExecutor(ExecutorRef::generic());
         return;
-      } // else, try again
-#endif
+#endif /* SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL */
+    } else {
+      SWIFT_TASK_GROUP_DEBUG_LOG(this, "CAS failed, task = %p, backup = %p, complete with = %p, status = %s",
+                                 waitingTask, backup, completedTask, statusString().c_str());
     }
   }
   swift_Concurrency_fatalError(0, "should have enqueued and returned.");
@@ -1286,7 +1293,8 @@ void TaskGroupBase::resumeWaitingTask(
 /// Must be called while holding the TaskGroup lock.
 void DiscardingTaskGroup::resumeWaitingTaskWithError(
     SwiftError *error,
-    TaskGroupStatus &assumed) {
+    TaskGroupStatus &assumed,
+    bool alreadyDecremented) {
   auto waitingTask = waitQueue.load(std::memory_order_acquire);
   assert(waitingTask && "cannot resume 'null' waiting task!");
   SWIFT_TASK_GROUP_DEBUG_LOG(this, "resume waiting task = %p, with error = %p",
@@ -1320,7 +1328,7 @@ void DiscardingTaskGroup::resumeWaitingTaskWithError(
       return;
 
 #else /* SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL */
-      if (statusCompletePendingReadyWaiting(assumed)) {
+      if (alreadyDecremented || statusCompletePendingReadyWaiting(assumed)) {
         // Run the task.
         auto result = PollResult::getError(error);
 
@@ -1560,6 +1568,7 @@ reevaluate_if_taskgroup_has_results:;
       waitingTask->flagAsSuspended();
     }
     // Put the waiting task at the beginning of the wait queue.
+    SWIFT_TASK_GROUP_DEBUG_LOG(this, "WATCH OUT, SET WAITER ONTO waitQueue.head = %p", waitQueue.load(std::memory_order_relaxed));
     if (waitQueue.compare_exchange_strong(
         waitHead, waitingTask,
         /*success*/ std::memory_order_release,
@@ -1746,6 +1755,8 @@ PollResult TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask,
       waitingTask->flagAsSuspended();
     }
     // Put the waiting task at the beginning of the wait queue.
+    SWIFT_TASK_GROUP_DEBUG_LOG(this, "WATCH OUT, set waiter onto... waitQueue.head = %p", waitQueue.load(std::memory_order_relaxed));
+
     if (waitQueue.compare_exchange_strong(
         waitHead, waitingTask,
         /*success*/ std::memory_order_release,

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -662,6 +662,8 @@ public:
 
   virtual void destroy() override;
 
+  virtual ~AccumulatingTaskGroup() {}
+
   virtual bool isDiscardingResults() const override {
     return false;
   }
@@ -706,6 +708,8 @@ public:
     : TaskGroupBase(T, TaskGroupStatus::initial().status) {}
 
   virtual void destroy() override;
+
+  virtual ~DiscardingTaskGroup() {}
 
   virtual bool isDiscardingResults() const override {
     return true;

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -52,10 +52,11 @@ using namespace swift;
 
 #if 0
 #define SWIFT_TASK_GROUP_DEBUG_LOG(group, fmt, ...) \
-fprintf(stderr, "[%#lx] [%s:%d](%s) group(%p%s) " fmt "\n",             \
+fprintf(stderr, "[%#lx] [%s:%d][group(%p%s)] (%s) " fmt "\n",           \
       (unsigned long)Thread::current().platformThreadId(),              \
-      __FILE__, __LINE__, __FUNCTION__,                                 \
+      __FILE__, __LINE__,                                               \
       group, group->isDiscardingResults() ? ",discardResults" : "",     \
+      __FUNCTION__,                                                     \
       __VA_ARGS__)
 #else
 #define SWIFT_TASK_GROUP_DEBUG_LOG(group, fmt, ...) (void)0
@@ -70,56 +71,51 @@ struct TaskGroupStatus;
 class AccumulatingTaskGroup;
 class DiscardingTaskGroup;
 
+/*****************************************************************************/
+/************************** QUEUE IMPL ***************************************/
+/*****************************************************************************/
+
+template<typename T>
+class NaiveTaskGroupQueue {
+  std::queue <T> queue;
+
+public:
+  NaiveTaskGroupQueue() = default;
+
+  NaiveTaskGroupQueue(const NaiveTaskGroupQueue<T> &) = delete;
+
+  NaiveTaskGroupQueue &operator=(const NaiveTaskGroupQueue<T> &) = delete;
+
+  NaiveTaskGroupQueue(NaiveTaskGroupQueue<T> &&other) {
+    queue = std::move(other.queue);
+  }
+
+  virtual ~NaiveTaskGroupQueue() {}
+
+  bool dequeue(T &output) {
+    if (queue.empty()) {
+      return false;
+    }
+    output = queue.front();
+    queue.pop();
+    return true;
+  }
+
+  bool isEmpty() const {
+    return queue.empty();
+  }
+
+  void enqueue(const T item) {
+    queue.push(item);
+  }
+};
+
 /******************************************************************************/
 /*************************** TASK GROUP BASE **********************************/
 /******************************************************************************/
 
 class TaskGroupBase : public TaskGroupTaskStatusRecord {
-protected:
-#if SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY || SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL
-  // Synchronization is simple here. In a single threaded mode, all swift tasks
-  // run on a single thread so no coordination is needed. In a task-to-thread
-  // model, only the parent task which created the task group can
-  //
-  //   (a) add child tasks to a group
-  //   (b) run the child tasks
-  //
-  // So we shouldn't need to worry about coordinating between child tasks and
-  // parents in a task group
-  void lock() const {}
-  void unlock() const {}
-#else
-  // TODO: move to lockless via the status atomic (make readyQueue an mpsc_queue_t<ReadyQueueItem>)
-  mutable std::mutex mutex_;
-
-  void lock() const { mutex_.lock(); }
-  void unlock() const { mutex_.unlock(); }
-#endif
-
-  /// Used for queue management, counting number of waiting and ready tasks
-  std::atomic<uint64_t> status;
-
-  /// The task currently waiting on `group.next()`.  Since only the owning
-  /// task can ever be waiting on a group, this is just either a reference
-  /// to that task or null.
-  std::atomic<AsyncTask *> waitQueue;
-
-  const Metadata *successType;
-
-  explicit TaskGroupBase(const Metadata* T, uint64_t initialStatus)
-    : TaskGroupTaskStatusRecord(),
-      status(initialStatus),
-      waitQueue(nullptr),
-      successType(T) {}
-
-  TaskGroupBase(const TaskGroupBase &) = delete;
-
 public:
-  virtual ~TaskGroupBase() {}
-
-  TaskStatusRecordKind getKind() const {
-    return Flags.getKind();
-  }
 
   /// Describes the status of the group.
   enum class ReadyStatus : uintptr_t {
@@ -160,99 +156,155 @@ public:
     Error = 0b11,
   };
 
-    /// The result of waiting on a task group.
-    struct PollResult {
-      PollStatus status; // TODO: pack it into storage pointer or not worth it?
+  /// The result of waiting on a task group.
+  struct PollResult {
+    PollStatus status; // TODO: pack it into storage pointer or not worth it?
 
-      /// Storage for the result of the future.
-      ///
-      /// When the future completed normally, this is a pointer to the storage
-      /// of the result value, which lives inside the future task itself.
-      ///
-      /// When the future completed by throwing an error, this is the error
-      /// object itself.
-      OpaqueValue *storage;
+    /// Storage for the result of the future.
+    ///
+    /// When the future completed normally, this is a pointer to the storage
+    /// of the result value, which lives inside the future task itself.
+    ///
+    /// When the future completed by throwing an error, this is the error
+    /// object itself.
+    OpaqueValue *storage;
 
-      const Metadata *successType;
+    const Metadata *successType;
 
-      /// The completed task, if necessary to keep alive until consumed by next().
-      ///
-      /// # Important: swift_release
-      /// If if a task is returned here, the task MUST be swift_released
-      /// once we are done with it, to balance out the retain made before
-      /// when the task was enqueued into the ready queue to keep it alive
-      /// until a next() call eventually picks it up.
-      AsyncTask *retainedTask;
+    /// The completed task, if necessary to keep alive until consumed by next().
+    ///
+    /// # Important: swift_release
+    /// If if a task is returned here, the task MUST be swift_released
+    /// once we are done with it, to balance out the retain made before
+    /// when the task was enqueued into the ready queue to keep it alive
+    /// until a next() call eventually picks it up.
+    AsyncTask *retainedTask;
 
-      static PollResult get(AsyncTask *asyncTask, bool hadErrorResult) {
-        auto fragment = asyncTask->futureFragment();
-        return PollResult{
-            /*status*/ hadErrorResult ?
-                       PollStatus::Error :
-                       PollStatus::Success,
-            /*storage*/ hadErrorResult ?
-                        reinterpret_cast<OpaqueValue *>(fragment->getError()) :
-                        fragment->getStoragePtr(),
-            /*successType*/fragment->getResultType(),
-            /*task*/ asyncTask
-        };
-      }
+    static PollResult get(AsyncTask *asyncTask, bool hadErrorResult) {
+      auto fragment = asyncTask->futureFragment();
+      return PollResult{
+          /*status=*/hadErrorResult ?
+                     PollStatus::Error :
+                     PollStatus::Success,
+          /*storage=*/hadErrorResult ?
+                      reinterpret_cast<OpaqueValue *>(fragment->getError()) :
+                      fragment->getStoragePtr(),
+          /*successType=*/fragment->getResultType(),
+          /*task=*/asyncTask
+      };
+    }
 
-      static PollResult getEmpty(const Metadata *successType) {
-        return PollResult{
-            /*status*/PollStatus::Empty,
-            /*storage*/nullptr,
-            /*successType*/successType,
-            /*task*/nullptr
-        };
-      }
+    static PollResult getEmpty(const Metadata *successType) {
+      return PollResult{
+          /*status*/PollStatus::Empty,
+          /*storage*/nullptr,
+          /*successType*/successType,
+          /*task*/nullptr
+      };
+    }
 
-      static PollResult getError(SwiftError *error) {
-        assert(error);
-        return PollResult{
-            /*status*/PollStatus::Error,
-            /*storage*/reinterpret_cast<OpaqueValue *>(error),
-            /*successType*/nullptr,
-            /*task*/nullptr
-        };
-      }
-    };
+    static PollResult getError(SwiftError *error) {
+      assert(error);
+      return PollResult{
+          /*status*/PollStatus::Error,
+          /*storage*/reinterpret_cast<OpaqueValue *>(error),
+          /*successType*/nullptr,
+          /*task*/nullptr
+      };
+    }
+  };
 
-    /// An item within the message queue of a group.
-    struct ReadyQueueItem {
-      /// Mask used for the low status bits in a message queue item.
-      static const uintptr_t statusMask = 0x03;
+  /// An item within the message queue of a group.
+  struct ReadyQueueItem {
+    /// Mask used for the low status bits in a message queue item.
+    static const uintptr_t statusMask = 0x03;
 
-      uintptr_t storage;
+    uintptr_t storage;
 
-      ReadyStatus getStatus() const {
-        return static_cast<ReadyStatus>(storage & statusMask);
-      }
+    ReadyStatus getStatus() const {
+      return static_cast<ReadyStatus>(storage & statusMask);
+    }
 
-      AsyncTask *getTask() const {
-        assert(getStatus() != ReadyStatus::RawError && "storage did contain raw error pointer, not task!");
-        return reinterpret_cast<AsyncTask *>(storage & ~statusMask);
-      }
+    AsyncTask *getTask() const {
+      assert(getStatus() != ReadyStatus::RawError && "storage did contain raw error pointer, not task!");
+      return reinterpret_cast<AsyncTask *>(storage & ~statusMask);
+    }
 
-      SwiftError *getRawError(DiscardingTaskGroup *group) const {
-        assert(group && "only a discarding task group uses raw errors in the ready queue");
-        assert(getStatus() == ReadyStatus::RawError && "storage did not contain raw error pointer!");
-        return reinterpret_cast<SwiftError *>(storage & ~statusMask);
-      }
+    SwiftError *getRawError(DiscardingTaskGroup *group) const {
+      assert(group && "only a discarding task group uses raw errors in the ready queue");
+      assert(getStatus() == ReadyStatus::RawError && "storage did not contain raw error pointer!");
+      return reinterpret_cast<SwiftError *>(storage & ~statusMask);
+    }
 
-      static ReadyQueueItem get(ReadyStatus status, AsyncTask *task) {
-        assert(task == nullptr || task->isFuture());
-        return ReadyQueueItem{
-            reinterpret_cast<uintptr_t>(task) | static_cast<uintptr_t>(status)};
-      }
+    static ReadyQueueItem get(ReadyStatus status, AsyncTask *task) {
+      fprintf(stderr, "[%s:%d](%s) store ReadyQueueItem = %s\n", __FILE_NAME__, __LINE__, __FUNCTION__,
+              status == ReadyStatus::Error ? "error" :
+              (status == ReadyStatus::RawError ? "raw-error" :
+              (status == ReadyStatus::Success ? "success" : "other")));
+      assert(task == nullptr || task->isFuture());
+      return ReadyQueueItem{
+          reinterpret_cast<uintptr_t>(task) | static_cast<uintptr_t>(status)};
+    }
 
-      static ReadyQueueItem getRawError(DiscardingTaskGroup *group, SwiftError *error) {
-        assert(group && "only a discarding task group uses raw errors in the ready queue");
-        return ReadyQueueItem{
-            reinterpret_cast<uintptr_t>(error) | static_cast<uintptr_t>(ReadyStatus::RawError)};
-      }
-    };
+    static ReadyQueueItem getRawError(DiscardingTaskGroup *group, SwiftError *error) {
+      assert(group && "only a discarding task group uses raw errors in the ready queue");
+      return ReadyQueueItem{
+          reinterpret_cast<uintptr_t>(error) | static_cast<uintptr_t>(ReadyStatus::RawError)};
+    }
+  };
 
+protected:
+#if SWIFT_STDLIB_SINGLE_THREADED_CONCURRENCY || SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL
+  // Synchronization is simple here. In a single threaded mode, all swift tasks
+  // run on a single thread so no coordination is needed. In a task-to-thread
+  // model, only the parent task which created the task group can
+  //
+  //   (a) add child tasks to a group
+  //   (b) run the child tasks
+  //
+  // So we shouldn't need to worry about coordinating between child tasks and
+  // parents in a task group
+  void lock() const {}
+  void unlock() const {}
+#else
+  // TODO: move to lockless via the status atomic (make readyQueue an mpsc_queue_t<ReadyQueueItem>)
+  mutable std::mutex mutex_;
+
+  void lock() const { mutex_.lock(); }
+  void unlock() const { mutex_.unlock(); }
+#endif
+
+  /// Used for queue management, counting number of waiting and ready tasks
+  std::atomic<uint64_t> status;
+
+  /// The task currently waiting on `group.next()`.  Since only the owning
+  /// task can ever be waiting on a group, this is just either a reference
+  /// to that task or null.
+  std::atomic<AsyncTask *> waitQueue;
+
+  /// Queue containing completed tasks offered into this group.
+  ///
+  /// The low bits contain the status, the rest of the pointer is the
+  /// AsyncTask.
+  NaiveTaskGroupQueue<ReadyQueueItem> readyQueue;
+
+  const Metadata *successType;
+
+  explicit TaskGroupBase(const Metadata* T, uint64_t initialStatus)
+    : TaskGroupTaskStatusRecord(),
+      status(initialStatus),
+      waitQueue(nullptr),
+      readyQueue(),
+      successType(T) {}
+
+  TaskGroupBase(const TaskGroupBase &) = delete;
+
+public:
+  virtual ~TaskGroupBase() {}
+
+  TaskStatusRecordKind getKind() const {
+    return Flags.getKind();
+  }
 
   /// Destroy the storage associated with the group.
   virtual void destroy() = 0;
@@ -291,7 +343,7 @@ public:
   /// There can be only at-most-one waiting task on a group at any given time,
   /// and the waiting task is expected to be the parent task in which the group
   /// body is running.
-  PollResult tryEnqueueWaitingTask(AsyncTask *waitingTask);
+  PollResult waitAll(AsyncTask *waitingTask);
 
   // Enqueue the completed task onto ready queue if there are no waiting tasks yet
   virtual void enqueueCompletedTask(AsyncTask *completedTask, bool hadErrorResult) = 0;
@@ -332,7 +384,6 @@ public:
 
   /// Remove waiting status bit.
   TaskGroupStatus statusRemoveWaitingRelease();
-
 
   /// Cancels the group and returns true if was already cancelled before.
   /// After this function returns, the group is guaranteed to be cancelled.
@@ -510,80 +561,18 @@ bool TaskGroupBase::statusCancel() {
   return old & cancelled;
 }
 
-/*****************************************************************************/
-/************************** QUEUE IMPL ***************************************/
-/*****************************************************************************/
-
-template<typename T>
-class NaiveTaskGroupQueue {
-  std::queue <T> queue;
-
-public:
-  NaiveTaskGroupQueue() = default;
-
-  NaiveTaskGroupQueue(const NaiveTaskGroupQueue<T> &) = delete;
-
-  NaiveTaskGroupQueue &operator=(const NaiveTaskGroupQueue<T> &) = delete;
-
-  NaiveTaskGroupQueue(NaiveTaskGroupQueue<T> &&other) {
-    queue = std::move(other.queue);
-  }
-
-  virtual ~NaiveTaskGroupQueue() {}
-
-  bool dequeue(T &output) {
-    if (queue.empty()) {
-      return false;
-    }
-    output = queue.front();
-    queue.pop();
-    return true;
-  }
-
-  bool isEmpty() const {
-    return queue.empty();
-  }
-
-  void enqueue(const T item) {
-    queue.push(item);
-  }
-};
-
 /******************************************************************************/
 /*************** ACCUMULATING (DEFAULT) TASK GROUP ****************************/
 /******************************************************************************/
 
 /// The default TaskGroup implementation, which accumulates results until they are consumed using `await next()`.
 class AccumulatingTaskGroup: public TaskGroupBase {
-public:
-  /// An item within the pending queue.
-  struct PendingQueueItem {
-    uintptr_t storage;
-
-    AsyncTask *getTask() const {
-      return reinterpret_cast<AsyncTask *>(storage);
-    }
-
-    static ReadyQueueItem get(AsyncTask *task) {
-      assert(task == nullptr || task->isFuture());
-      return ReadyQueueItem{reinterpret_cast<uintptr_t>(task)};
-    }
-  };
-
-private:
-  /// Queue containing completed tasks offered into this group.
-  ///
-  /// The low bits contain the status, the rest of the pointer is the
-  /// AsyncTask.
-  NaiveTaskGroupQueue<ReadyQueueItem> readyQueue;
-
   friend class ::swift::AsyncTask;
 
 public:
 
   explicit AccumulatingTaskGroup(const Metadata *T)
-    : TaskGroupBase(T, TaskGroupStatus::initial().status),
-      readyQueue() {}
+    : TaskGroupBase(T, TaskGroupStatus::initial().status) {}
 
   virtual void destroy() override;
 
@@ -666,45 +655,18 @@ public:
 /******************************************************************************/
 
 class DiscardingTaskGroup: public TaskGroupBase {
-public:
-  /// An item within the pending queue.
-  struct PendingQueueItem {
-    uintptr_t storage;
-
-    AsyncTask *getTask() const {
-      return reinterpret_cast<AsyncTask *>(storage);
-    }
-
-    static ReadyQueueItem get(AsyncTask *task) {
-      assert(task == nullptr || task->isFuture());
-      return ReadyQueueItem{reinterpret_cast<uintptr_t>(task)};
-    }
-  };
-
-private:
-  /// Queue containing completed tasks offered into this group.
-  ///
-  /// The low bits contain the status, the rest of the pointer is the
-  /// AsyncTask.
-  ///
-  /// A discarding task group never actually accumulates tasks here,
-  /// however we use this queue to store errors from child tasks (currently at most one).
-  NaiveTaskGroupQueue<ReadyQueueItem> readyQueue;
-
   friend class ::swift::AsyncTask;
 
 public:
 
   explicit DiscardingTaskGroup(const Metadata *T)
-    : TaskGroupBase(T, TaskGroupStatus::initial().status),
-      readyQueue() {}
+    : TaskGroupBase(T, TaskGroupStatus::initial().status) {}
 
   virtual void destroy() override;
 
   virtual bool isDiscardingResults() const override {
     return true;
   }
-
 
   /// Returns *assumed* new status, including the just performed +1.
   TaskGroupStatus statusMarkWaitingAssumeAcquire() {
@@ -828,13 +790,21 @@ static_assert(sizeof(DiscardingTaskGroup) <= sizeof(TaskGroup) &&
 static TaskGroupBase *asBaseImpl(TaskGroup *group) {
   return reinterpret_cast<TaskGroupBase*>(group);
 }
+static AccumulatingTaskGroup *asAccumulatingImpl(TaskGroupBase *group) {
+  assert(group->isAccumulatingResults());
+  return static_cast<AccumulatingTaskGroup*>(group);
+}
 static AccumulatingTaskGroup *asAccumulatingImpl(TaskGroup *group) {
   assert(group->isAccumulatingResults());
-  return static_cast<AccumulatingTaskGroup*>(reinterpret_cast<TaskGroupBase*>(group));
+  return asAccumulatingImpl(asBaseImpl(group));
+}
+static DiscardingTaskGroup *asDiscardingImpl(TaskGroupBase *group) {
+  assert(group->isDiscardingResults());
+  return static_cast<DiscardingTaskGroup*>(group);
 }
 static DiscardingTaskGroup *asDiscardingImpl(TaskGroup *group) {
   assert(group->isDiscardingResults());
-  return static_cast<DiscardingTaskGroup*>(reinterpret_cast<TaskGroupBase*>(group));
+  return asDiscardingImpl(asBaseImpl(group));
 }
 
 static TaskGroup *asAbstract(TaskGroupBase *group) {
@@ -1256,6 +1226,7 @@ void TaskGroupBase::resumeWaitingTask(
     TaskGroupStatus &assumed,
     bool hadErrorResult) {
   auto waitingTask = waitQueue.load(std::memory_order_acquire);
+  assert(waitingTask && "waitingTask must not be null when attempting to resume it");
   SWIFT_TASK_GROUP_DEBUG_LOG(this, "resume waiting task = %p, complete with = %p",
                        waitingTask, completedTask);
   while (true) {
@@ -1644,6 +1615,9 @@ static void swift_taskGroup_waitAllImpl(
   waitingTask->ResumeTask = task_group_wait_resume_adapter;
   waitingTask->ResumeContext = rawContext;
 
+  auto group = asBaseImpl(_group);
+  PollResult polled = group->waitAll(waitingTask);
+
   auto context = static_cast<TaskFutureWaitAsyncContext *>(rawContext);
   context->ResumeParent =
       reinterpret_cast<TaskContinuationFunction *>(resumeFunction);
@@ -1651,21 +1625,19 @@ static void swift_taskGroup_waitAllImpl(
   context->errorResult = nullptr;
   context->successResultPointer = resultPointer;
 
-  auto group = asBaseImpl(_group);
   SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAllImpl, waiting task = %p, bodyError = %p, status:%s",
                        waitingTask, bodyError, group->statusString().c_str());
 
-  PollResult polled = group->tryEnqueueWaitingTask(waitingTask);
   switch (polled.status) {
     case PollStatus::MustWait:
-    SWIFT_TASK_GROUP_DEBUG_LOG(group, "tryEnqueueWaitingTask MustWait, pending tasks exist, waiting task = %p",
+    SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAll MustWait, pending tasks exist, waiting task = %p",
                                waitingTask);
       if (bodyError && group->isDiscardingResults()) {
         auto discardingGroup = asDiscardingImpl(_group);
         bool storedBodyError = discardingGroup->offerBodyError(bodyError);
         if (storedBodyError) {
           SWIFT_TASK_GROUP_DEBUG_LOG(
-              group, "tryEnqueueWaitingTask, stored error thrown by with...Group body, error = %p",
+              group, "waitAll, stored error thrown by with...Group body, error = %p",
               bodyError);
         }
       }
@@ -1680,7 +1652,7 @@ static void swift_taskGroup_waitAllImpl(
 #endif /* __ARM_ARCH_7K__ */
 
     case PollStatus::Error:
-      SWIFT_TASK_GROUP_DEBUG_LOG(group, "tryEnqueueWaitingTask found error, waiting task = %p, status:%s",
+      SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAll found error, waiting task = %p, status:%s",
                                  waitingTask, group->statusString().c_str());
       fillGroupNextResult(context, polled);
       if (auto completedTask = polled.retainedTask) {
@@ -1694,10 +1666,17 @@ static void swift_taskGroup_waitAllImpl(
       return waitingTask->runInFullyEstablishedContext();
 
     case PollStatus::Empty:
+      /// Anything else than a "MustWait" can be treated as a successful poll.
+      /// Only if there are in flight pending tasks do we need to wait after all.
+      SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAll %s, waiting task = %p, status:%s",
+                                 polled.status == TaskGroupBase::PollStatus::Empty ? "empty" : "success",
+                                 waitingTask, group->statusString().c_str());
+
+
     case PollStatus::Success:
       /// Anything else than a "MustWait" can be treated as a successful poll.
       /// Only if there are in flight pending tasks do we need to wait after all.
-      SWIFT_TASK_GROUP_DEBUG_LOG(group, "tryEnqueueWaitingTask %s, waiting task = %p, status:%s",
+      SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAll %s, waiting task = %p, status:%s",
                                  polled.status == TaskGroupBase::PollStatus::Empty ? "empty" : "success",
                                  waitingTask, group->statusString().c_str());
 
@@ -1728,9 +1707,12 @@ bool DiscardingTaskGroup::offerBodyError(SwiftError* _Nonnull bodyError) {
   return true;
 }
 
-PollResult TaskGroupBase::tryEnqueueWaitingTask(AsyncTask *waitingTask) {
-  SWIFT_TASK_GROUP_DEBUG_LOG(this, "tryEnqueueWaitingTask, status = %s", statusString().c_str());
+PollResult TaskGroupBase::waitAll(AsyncTask *waitingTask) {
+  lock(); // TODO: remove group lock, and use status for synchronization
+
+  SWIFT_TASK_GROUP_DEBUG_LOG(this, "waitAll, status = %s", statusString().c_str());
   PollResult result = PollResult::getEmpty(this->successType);
+  result.status = PollStatus::Empty;
   result.storage = nullptr;
   result.retainedTask = nullptr;
 
@@ -1740,20 +1722,42 @@ PollResult TaskGroupBase::tryEnqueueWaitingTask(AsyncTask *waitingTask) {
 
   reevaluate_if_TaskGroup_has_results:;
   auto assumed = statusMarkWaitingAssumeAcquire();
-  // ==== 1) bail out early if no tasks are pending ----------------------------
+
+  // ==== 1) may be able to bail out early if no tasks are pending -------------
   if (assumed.isEmpty(this)) {
-    SWIFT_TASK_DEBUG_LOG("group(%p) waitAll, is empty, no pending tasks", this);
+    /// A discarding task group may be empty already, but have stored an error that must be thrown
+    /// out of waitAll - providing the "the first error gets thrown" semantics of the group.
+    /// The readyQueue is allowed to have exactly one error element in this case.
+    if (isDiscardingResults()) {
+      auto discardingGroup = asDiscardingImpl(this);
+      ReadyQueueItem firstErrorItem;
+      if (readyQueue.dequeue(firstErrorItem)) {
+        fprintf(stderr, "[%s:%d](%s) waitAll EMPTY AND dequeued from readyQueue: %s\n", __FILE_NAME__, __LINE__, __FUNCTION__,
+                (firstErrorItem.getStatus() == ReadyStatus::Error ? "error" :
+                (firstErrorItem.getStatus() == ReadyStatus::RawError) ? "raw-error" : "wat"));
+        if (firstErrorItem.getStatus() == ReadyStatus::Error) {
+          result = PollResult::get(firstErrorItem.getTask(), /*hadErrorResult=*/true);
+        } else if (firstErrorItem.getStatus() == ReadyStatus::RawError) {
+          result.storage = reinterpret_cast<OpaqueValue*>(firstErrorItem.getRawError(discardingGroup));
+          result.status = PollStatus::Error;
+        }
+      } // else, we're definitely Empty
+
+      unlock();
+      return result;
+    }
+
+    SWIFT_TASK_GROUP_DEBUG_LOG(this, "group is empty, no pending tasks, status = %s", assumed.to_string(this));
     // No tasks in flight, we know no tasks were submitted before this poll
     // was issued, and if we parked here we'd potentially never be woken up.
     // Bail out and return `nil` from `group.next()`.
     statusRemoveWaitingRelease();
+    unlock();
     return result;
   }
 
-  lock(); // TODO: remove pool lock, and use status for synchronization
-  auto waitHead = waitQueue.load(std::memory_order_acquire);
-
   // ==== 2) Add to wait queue -------------------------------------------------
+  auto waitHead = waitQueue.load(std::memory_order_acquire);
   _swift_tsan_release(static_cast<Job *>(waitingTask));
   while (true) {
     if (!hasSuspended) {

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -50,7 +50,7 @@
 
 using namespace swift;
 
-#if 1
+#if 0
 #define SWIFT_TASK_GROUP_DEBUG_LOG(group, fmt, ...)                     \
 fprintf(stderr, "[%#lx] [%s:%d][group(%p%s)] (%s) " fmt "\n",           \
       (unsigned long)Thread::current().platformThreadId(),              \
@@ -114,7 +114,7 @@ public:
     queue = std::move(other.queue);
   }
 
-  virtual ~NaiveTaskGroupQueue() {}
+  ~NaiveTaskGroupQueue() {}
 
   bool dequeue(T &output) {
     if (queue.empty()) {
@@ -367,8 +367,10 @@ public:
   /// \param bodyError error thrown by the body of a with...TaskGroup method
   /// \param waitingTask the task waiting on the group
   /// \param rawContext used to resume the waiting task
-  /// \return how the waiting task should be handled, e.g. must wait or can be completed immediately
-  PollResult waitAll(SwiftError* bodyError, AsyncTask *waitingTask, AsyncContext* rawContext);
+  void waitAll(SwiftError* bodyError, AsyncTask *waitingTask,
+                     OpaqueValue *resultPointer, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+                     ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
+                     AsyncContext *rawContext);
 
   // Enqueue the completed task onto ready queue if there are no waiting tasks yet
   virtual void enqueueCompletedTask(AsyncTask *completedTask, bool hadErrorResult) = 0;
@@ -415,7 +417,7 @@ public:
   /// A waiting task MUST have been already enqueued in the `waitQueue`.
   TaskGroupStatus statusMarkWaitingAssumeRelease();
 
-  TaskGroupStatus statusAddPendingTaskRelaxed(bool unconditionally);
+  TaskGroupStatus statusAddPendingTaskAssumeRelaxed(bool unconditionally);
 
   /// Cancels the group and returns true if was already cancelled before.
   /// After this function returns, the group is guaranteed to be cancelled.
@@ -495,14 +497,13 @@ struct TaskGroupStatus {
 
   /// Status value decrementing the Ready, Pending and Waiting counters by one.
   TaskGroupStatus completingPendingReadyWaiting(const TaskGroupBase* _Nonnull group) {
-//    assert(pendingTasks(group) &&
-//           "can only complete waiting task when pending tasks available");
+    assert(pendingTasks(group) &&
+           "can only complete waiting task when pending tasks available");
     assert(group->isDiscardingResults() || readyTasks(group) &&
                                            "can only complete waiting task when ready tasks available");
     assert(hasWaitingTask() &&
            "can only complete waiting task when waiting task available");
-    uint64_t change = waiting;
-    change += pendingTasks(group) ? onePendingTask : 0;
+    uint64_t change = waiting + onePendingTask;
     // only while accumulating results does the status contain "ready" bits;
     // so if we're in "discard results" mode, we must not decrement the ready count,
     // as there is no ready count in the status.
@@ -511,12 +512,11 @@ struct TaskGroupStatus {
   }
 
   TaskGroupStatus completingPendingReady(const TaskGroupBase* _Nonnull group) {
-//    assert(pendingTasks(group) &&
-//           "can only complete waiting task when pending tasks available");
+    assert(pendingTasks(group) &&
+           "can only complete waiting task when pending tasks available");
     assert(group->isDiscardingResults() || readyTasks(group) &&
                                            "can only complete waiting task when ready tasks available");
-    auto change = 0;
-    change += pendingTasks(group) ? onePendingTask : 0;
+    auto change = onePendingTask;
     change += group->isAccumulatingResults() ? oneReadyTask : 0;
     return TaskGroupStatus{status - change};
   }
@@ -530,7 +530,7 @@ struct TaskGroupStatus {
   ///     TaskGroupStatus{ C:{cancelled} W:{waiting task} R:{ready tasks} P:{pending tasks} {binary repr} }
   /// If discarding results:
   ///     TaskGroupStatus{ C:{cancelled} W:{waiting task} P:{pending tasks} {binary repr} }
-  std::string to_string(const TaskGroupBase* group) {
+  std::string to_string(const TaskGroupBase* _Nullable group) {
     std::string str;
     str.append("TaskGroupStatus{ ");
     str.append("C:"); // cancelled
@@ -557,7 +557,7 @@ struct TaskGroupStatus {
 bool TaskGroupBase::statusCompletePendingReadyWaiting(TaskGroupStatus &old) {
   return status.compare_exchange_strong(
       old.status, old.completingPendingReadyWaiting(this).status,
-      /*success*/ std::memory_order_release,
+      /*success*/ std::memory_order_relaxed,
       /*failure*/ std::memory_order_relaxed);
 }
 
@@ -615,8 +615,7 @@ TaskGroupStatus TaskGroupBase::statusMarkWaitingAssumeRelease() {
 /// so unconditionally.
 ///
 /// Returns *assumed* new status, including the just performed +1.
-TaskGroupStatus TaskGroupBase::statusAddPendingTaskRelaxed(bool unconditionally) {
-
+TaskGroupStatus TaskGroupBase::statusAddPendingTaskAssumeRelaxed(bool unconditionally) {
   auto old = status.fetch_add(TaskGroupStatus::onePendingTask,
                               std::memory_order_relaxed);
   auto s = TaskGroupStatus{old + TaskGroupStatus::onePendingTask};
@@ -628,7 +627,7 @@ TaskGroupStatus TaskGroupBase::statusAddPendingTaskRelaxed(bool unconditionally)
     s = TaskGroupStatus{o - TaskGroupStatus::onePendingTask};
   }
 
-  SWIFT_TASK_GROUP_DEBUG_LOG(this, "addPending, after = %s", s.to_string(this).c_str());
+  SWIFT_TASK_GROUP_DEBUG_LOG(this, "addPending, after: %s", s.to_string(this).c_str());
   return s;
 }
 
@@ -801,6 +800,7 @@ static DiscardingTaskGroup *asDiscardingImpl(TaskGroupBase *group) {
   assert(group->isDiscardingResults());
   return static_cast<DiscardingTaskGroup*>(group);
 }
+[[maybe_unused]]
 static DiscardingTaskGroup *asDiscardingImpl(TaskGroup *group) {
   assert(group->isDiscardingResults());
   return asDiscardingImpl(asBaseImpl(group));
@@ -1002,14 +1002,6 @@ static void fillGroupNextResult(TaskFutureWaitAsyncContext *context,
   }
 }
 
-static void fillGroupNextNilResult(TaskFutureWaitAsyncContext *context,
-                                   PollResult result) {
-  // Initialize the result as a .none Optional<Success>.
-  const Metadata *successType = result.successType;
-  OpaqueValue *destPtr = context->successResultPointer;
-  successType->vw_storeEnumTagSinglePayload(destPtr, 1, 1);
-}
-
 static void _enqueueCompletedTask(NaiveTaskGroupQueue<ReadyQueueItem> *readyQueue,
                                   AsyncTask *completedTask,
                                   bool hadErrorResult) {
@@ -1023,19 +1015,10 @@ static void _enqueueCompletedTask(NaiveTaskGroupQueue<ReadyQueueItem> *readyQueu
   readyQueue->enqueue(readyItem);
 }
 
-/// This can only be used by a discarding task group;
-/// Other groups must enqueue a complete Task to the ready queue.
-static void _enqueueRawError(DiscardingTaskGroup* _Nonnull group,
-                             NaiveTaskGroupQueue<ReadyQueueItem> *readyQueue,
-                             SwiftError *error) {
-  auto readyItem = ReadyQueueItem::getRawError(group, error);
-  readyQueue->enqueue(readyItem);
-}
-
 // TaskGroup is locked upon entry and exit
 void AccumulatingTaskGroup::enqueueCompletedTask(AsyncTask *completedTask, bool hadErrorResult) {
   // Retain the task while it is in the queue; it must remain alive until
-  // it is found by poll.  This retain will balanced by the release in poll.
+  // it is found by poll.  This retain will be balanced by the release in poll.
   swift_retain(completedTask);
 
   _enqueueCompletedTask(&readyQueue, completedTask, hadErrorResult);
@@ -1181,9 +1164,11 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
       if (readyQueue.dequeue(readyErrorItem)) {
         switch (readyErrorItem.getStatus()) {
           case ReadyStatus::RawError:
+            SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, complete, resume with raw error:%p", readyErrorItem.getRawError(this));
             resumeWaitingTaskWithError(readyErrorItem.getRawError(this), assumed, alreadyDecrementedStatus);
             break;
           case ReadyStatus::Error:
+            SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, complete, resume with errorItem.task:%p", readyErrorItem.getTask());
             resumeWaitingTask(readyErrorItem.getTask(), assumed, /*hadErrorResult=*/true, alreadyDecrementedStatus);
             break;
           default:
@@ -1197,8 +1182,10 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
     } else if (readyQueue.isEmpty()) {
       // There was no waiting task, or other tasks are still pending, so we cannot
       // it is the first error we encountered, thus we need to store it for future throwing
+      SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, enqueue child task:%p", completedTask);
       enqueueCompletedTask(completedTask, hadErrorResult);
     } else {
+      SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, complete, discard child task:%p", completedTask);
       _swift_taskGroup_detachChild(asAbstract(this), completedTask);
     }
 
@@ -1206,7 +1193,7 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
     return;
   }
 
-  assert(!hadErrorResult);
+  assert(!hadErrorResult && "only successfully completed tasks can reach here");
   if (afterComplete.hasWaitingTask() && afterComplete.pendingTasks(this) == 0) {
     SWIFT_TASK_GROUP_DEBUG_LOG(this,
                                "offer, last pending task completed successfully, resume waitingTask with completedTask:%p",
@@ -1230,7 +1217,7 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
     } else {
       // This is the last task, we have a waiting task and there was no error stored previously;
       // We must resume the waiting task with a success, so let us return here.
-      resumeWaitingTask(completedTask, assumed, hadErrorResult, alreadyDecrementedStatus);
+      resumeWaitingTask(completedTask, assumed, /*hadErrorResult=*/false, alreadyDecrementedStatus);
     }
   } else {
     // it wasn't the last pending task, and there is no-one to resume;
@@ -1248,7 +1235,6 @@ void TaskGroupBase::resumeWaitingTask(
     TaskGroupStatus &assumed,
     bool hadErrorResult,
     bool alreadyDecremented) {
-  auto backup = waitQueue.load(std::memory_order_acquire);
   auto waitingTask = waitQueue.load(std::memory_order_acquire);
   assert(waitingTask && "waitingTask must not be null when attempting to resume it");
   assert(assumed.hasWaitingTask());
@@ -1292,8 +1278,14 @@ void TaskGroupBase::resumeWaitingTask(
         // Run the task.
         auto result = PollResult::get(completedTask, hadErrorResult);
         SWIFT_TASK_GROUP_DEBUG_LOG(this,
-                                   "resume waiting DONE, task = %p, backup = %p, complete with = %p, status = %s",
-                                   waitingTask, backup, completedTask, statusString().c_str());
+                                   "resume waiting DONE, task = %p, backup = %p, error:%d, complete with = %p, status = %s",
+                                   waitingTask, backup, hadErrorResult, completedTask, statusString().c_str());
+
+        auto waitingContext =
+            static_cast<TaskFutureWaitAsyncContext *>(
+                waitingTask->ResumeContext);
+
+        fillGroupNextResult(waitingContext, result);
 
         // Remove the child from the task group's running tasks list.
         // The parent task isn't currently running (we're about to wake
@@ -1305,12 +1297,6 @@ void TaskGroupBase::resumeWaitingTask(
         // we can't be holding its locks ourselves.
         _swift_taskGroup_detachChild(asAbstract(this), completedTask);
 
-        auto waitingContext =
-            static_cast<TaskFutureWaitAsyncContext *>(
-                waitingTask->ResumeContext);
-
-        fillGroupNextResult(waitingContext, result);
-
         _swift_tsan_acquire(static_cast<Job *>(waitingTask));
         // TODO: allow the caller to suggest an executor
         waitingTask->flagAsAndEnqueueOnExecutor(ExecutorRef::generic());
@@ -1321,7 +1307,6 @@ void TaskGroupBase::resumeWaitingTask(
                                  waitingTask, backup, completedTask, statusString().c_str());
     }
   }
-  swift_Concurrency_fatalError(0, "should have enqueued and returned.");
 }
 
 /// Must be called while holding the TaskGroup lock.
@@ -1380,7 +1365,6 @@ void DiscardingTaskGroup::resumeWaitingTaskWithError(
 #endif
     }
   }
-  swift_Concurrency_fatalError(0, "should have enqueued and returned.");
 }
 
 SWIFT_CC(swiftasync)
@@ -1651,7 +1635,21 @@ static void swift_taskGroup_waitAllImpl(
   auto waitingTask = swift_task_getCurrent();
 
   auto group = asBaseImpl(_group);
-  PollResult polled = group->waitAll(bodyError, waitingTask, rawContext);
+  return group->waitAll(
+      bodyError, waitingTask,
+      resultPointer, callerContext, resumeFunction, rawContext);
+}
+
+void TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask,
+                                  OpaqueValue *resultPointer, SWIFT_ASYNC_CONTEXT AsyncContext *callerContext,
+                                  ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
+                                  AsyncContext *rawContext) {
+  lock();
+
+  // must mutate the waiting task while holding the group lock,
+  // so we don't get an offer concurrently trying to do so
+  waitingTask->ResumeTask = task_group_wait_resume_adapter;
+  waitingTask->ResumeContext = rawContext;
 
   auto context = static_cast<TaskFutureWaitAsyncContext *>(rawContext);
   context->ResumeParent =
@@ -1659,71 +1657,6 @@ static void swift_taskGroup_waitAllImpl(
   context->Parent = callerContext;
   context->errorResult = nullptr;
   context->successResultPointer = resultPointer;
-
-  SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAllImpl, waiting task = %p, bodyError = %p, status:%s, polled.status = %s, status.NOW=%s",
-                       waitingTask, bodyError, group->statusString().c_str(), to_string(polled.status).c_str(), group->statusString().c_str());
-
-  switch (polled.status) {
-    case PollStatus::MustWait: {
-      // The waiting task has been queued on the channel,
-      // there were pending tasks so it will be woken up eventually.
-#ifdef __ARM_ARCH_7K__
-      workaround_function_swift_taskGroup_waitAllImpl(
-         resultPointer, callerContext, _group, bodyError, resumeFunction, rawContext);
-#endif /* __ARM_ARCH_7K__ */
-      return;
-    }
-
-    case PollStatus::Error: {
-      SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAllImpl Error, waiting task = %p, body error = %p, status:%s",
-                                 waitingTask, bodyError, group->statusString().c_str());
-#if SWIFT_TASK_GROUP_BODY_THROWN_ERROR_WINS
-      if (bodyError) {
-        fillGroupNextErrorResult(context, bodyError);
-      } else {
-        fillGroupNextResult(context, polled);
-      }
-#else // so, not SWIFT_TASK_GROUP_BODY_THROWN_ERROR_WINS
-      fillGroupNextResult(context, polled);
-#endif // SWIFT_TASK_GROUP_BODY_THROWN_ERROR_WINS
-      if (auto completedTask = polled.retainedTask) {
-        // Remove the child from the task group's running tasks list.
-        _swift_taskGroup_detachChild(asAbstract(group), completedTask);
-
-        // Balance the retain done by enqueueCompletedTask.
-        swift_release(completedTask);
-      }
-
-      return waitingTask->runInFullyEstablishedContext();
-    }
-
-    case PollStatus::Empty:
-    case PollStatus::Success: {
-      /// Anything else than a "MustWait" can be treated as a successful poll.
-      /// Only if there are in flight pending tasks do we need to wait after all.
-      SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAllImpl %s, waiting task = %p, status:%s",
-                                 polled.status == TaskGroupBase::PollStatus::Empty ? "empty" : "success",
-                                 waitingTask, group->statusString().c_str());
-
-      if (bodyError) {
-        // None of the inner tasks have thrown, so we have to "re throw" the body error:
-        fillGroupNextErrorResult(context, bodyError);
-      } else {
-        fillGroupNextNilResult(context, polled);
-      }
-
-      return waitingTask->runInFullyEstablishedContext();
-    }
-  }
-}
-
-PollResult TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask, AsyncContext *rawContext) {
-  lock();
-
-  // must mutate the waiting task while holding the group lock,
-  // so we don't get an offer concurrently trying to do so
-  waitingTask->ResumeTask = task_group_wait_resume_adapter;
-  waitingTask->ResumeContext = rawContext;
 
   SWIFT_TASK_GROUP_DEBUG_LOG(this, "waitAll, bodyError = %p, status = %s", bodyError, statusString().c_str());
   PollResult result = PollResult::getEmpty(this->successType);
@@ -1733,9 +1666,11 @@ PollResult TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask,
 
   // Have we suspended the task?
   bool hasSuspended = false;
-  bool haveRunOneChildTaskInline = false;
 
+#if SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL
+  bool haveRunOneChildTaskInline = false;
   reevaluate_if_TaskGroup_has_results:;
+#endif
   // Paired with a release when marking Waiting,
   // otherwise we don't modify the status
   auto assumed = statusLoadAcquire();
@@ -1748,6 +1683,7 @@ PollResult TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask,
     /// out of waitAll - providing the "the first error gets thrown" semantics of the group.
     /// The readyQueue is allowed to have exactly one error element in this case.
     if (isDiscardingResults()) {
+      // ---- 1.1) A discarding group needs to check if there is a stored error to throw
       auto discardingGroup = asDiscardingImpl(this);
       ReadyQueueItem firstErrorItem;
       if (readyQueue.dequeue(firstErrorItem)) {
@@ -1758,25 +1694,41 @@ PollResult TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask,
           result.status = PollStatus::Error;
         }
       } // else, we're definitely Empty
-      unlock();
-      return result;
-    }
+    } // else (in an accumulating group), a waitAll can bail out early Empty
 
-    SWIFT_TASK_GROUP_DEBUG_LOG(this, "group is empty, no pending tasks, status = %s", assumed.to_string(this).c_str());
+    SWIFT_TASK_GROUP_DEBUG_LOG(this, "waitAll, early return, no pending tasks, bodyError:%p, status = %s",
+                               bodyError,  assumed.to_string(this).c_str());
     // No tasks in flight, we know no tasks were submitted before this poll
     // was issued, and if we parked here we'd potentially never be woken up.
-    // Bail out and return `nil` from `group.next()`.
+
+#if SWIFT_TASK_GROUP_BODY_THROWN_ERROR_WINS
+    if (bodyError) {
+      fillGroupNextErrorResult(context, bodyError);
+    } else {
+      fillGroupNextResult(context, result);
+    }
+#else // so, not SWIFT_TASK_GROUP_BODY_THROWN_ERROR_WINS
+    fillGroupNextResult(context, polled);
+#endif // SWIFT_TASK_GROUP_BODY_THROWN_ERROR_WINS
+    if (auto completedTask = result.retainedTask) {
+      // Remove the child from the task group's running tasks list.
+      _swift_taskGroup_detachChild(asAbstract(this), completedTask);
+
+      // Balance the retain done by enqueueCompletedTask.
+      swift_release(completedTask);
+    }
+
+    waitingTask->runInFullyEstablishedContext();
+
     unlock();
-    return result;
+    return;
   }
 
   // ==== 2) Add to wait queue -------------------------------------------------
 
   // ---- 2.1) Discarding task group may need to story the bodyError before we park
-  if (bodyError && isDiscardingResults()) {
+  if (bodyError && isDiscardingResults() && readyQueue.isEmpty()) {
     auto discardingGroup = asDiscardingImpl(this);
-    assert(readyQueue.isEmpty() &&
-           "only a single error may be stored in discarding task group, but something was enqueued already");
     auto readyItem = ReadyQueueItem::getRawError(discardingGroup, bodyError);
     readyQueue.enqueue(readyItem);
   }
@@ -1789,16 +1741,13 @@ PollResult TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask,
       waitingTask->flagAsSuspended();
     }
     // Put the waiting task at the beginning of the wait queue.
-    SWIFT_TASK_GROUP_DEBUG_LOG(this, "WATCH OUT, set waiter onto... waitQueue.head = %p", waitQueue.load(std::memory_order_relaxed));
-
     if (waitQueue.compare_exchange_strong(
         waitHead, waitingTask,
         /*success*/ std::memory_order_release,
         /*failure*/ std::memory_order_acquire)) {
       statusMarkWaitingAssumeRelease();
       SWIFT_TASK_GROUP_DEBUG_LOG(this, "waitAll, marked waiting status = %s", statusString().c_str());
-      unlock();
-      
+
 #if SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL
       // The logic here is paired with the logic in TaskGroupBase::offer. Once
       // we run the
@@ -1821,10 +1770,16 @@ PollResult TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask,
       _swift_task_setCurrent(oldTask);
       goto reevaluate_if_TaskGroup_has_results;
 #endif
-      // no ready tasks, so we must wait.
-      result.status = PollStatus::MustWait;
+      // The waiting task has been queued on the channel,
+      // there were pending tasks so it will be woken up eventually.
+#ifdef __ARM_ARCH_7K__
+      workaround_function_swift_taskGroup_waitAllImpl(
+         resultPointer, callerContext, _group, bodyError, resumeFunction, rawContext);
+#endif /* __ARM_ARCH_7K__ */
+
       _swift_task_clearCurrent();
-      return result;
+      unlock();
+      return;
     } // else, try again
   }
 }
@@ -1898,7 +1853,7 @@ void swift::_swift_taskGroup_cancelAllChildren(TaskGroup *group) {
 SWIFT_CC(swift)
 static bool swift_taskGroup_addPendingImpl(TaskGroup *_group, bool unconditionally) {
   auto group = asBaseImpl(_group);
-  auto assumed = group->statusAddPendingTaskRelaxed(unconditionally);
+  auto assumed = group->statusAddPendingTaskAssumeRelaxed(unconditionally);
   SWIFT_TASK_DEBUG_LOG("add pending %s to group(%p), tasks pending = %d",
                        unconditionally ? "unconditionally" : "",
                        group, assumed.pendingTasks(group));

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -1834,7 +1834,7 @@ void TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask,
       // there were pending tasks so it will be woken up eventually.
 #ifdef __ARM_ARCH_7K__
       workaround_function_swift_taskGroup_waitAllImpl(
-         resultPointer, callerContext, _group, bodyError, resumeFunction, rawContext);
+         resultPointer, callerContext, asAbstract(this), bodyError, resumeFunction, rawContext);
 #endif /* __ARM_ARCH_7K__ */
 
       _swift_task_clearCurrent();

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -64,6 +64,21 @@ fprintf(stderr, "[%#lx] [%s:%d][group(%p%s)] (%s) " fmt "\n",           \
 
 using FutureFragment = AsyncTask::FutureFragment;
 
+/// During evolution discussions we opted to implement the following semantic of
+/// a discarding task-group throw:
+/// - the error thrown out of withThrowingDiscardingTaskGroup { ... } always "wins",
+///   even if the group already had an error stored within.
+///
+/// This is harder to implement, since we have to always store the "first error from children",
+/// and keep it around until body completes, and only then are we able to decide which error to
+/// re-throw; If we threw the body task, we must swift_release the stored "first child error" (if it was present).
+///
+/// Implementation of "rethrow the first child error" just works in `waitAll`,
+/// since we poll the error and resume the waiting task with it immediately.
+///
+/// Change this flag, or expose a boolean to offer developers a choice of behavior.
+#define SWIFT_TASK_GROUP_BODY_THROWN_ERROR_WINS 1
+
 namespace {
 class TaskStatusRecord;
 struct TaskGroupStatus;
@@ -237,10 +252,6 @@ public:
     }
 
     static ReadyQueueItem get(ReadyStatus status, AsyncTask *task) {
-      fprintf(stderr, "[%s:%d](%s) store ReadyQueueItem = %s\n", __FILE_NAME__, __LINE__, __FUNCTION__,
-              status == ReadyStatus::Error ? "error" :
-              (status == ReadyStatus::RawError ? "raw-error" :
-              (status == ReadyStatus::Success ? "success" : "other")));
       assert(task == nullptr || task->isFuture());
       return ReadyQueueItem{
           reinterpret_cast<uintptr_t>(task) | static_cast<uintptr_t>(status)};
@@ -976,7 +987,8 @@ static void fillGroupNextResult(TaskFutureWaitAsyncContext *context,
     return;
 
   case PollStatus::Error: {
-    fillGroupNextErrorResult(context, reinterpret_cast<SwiftError *>(result.storage));
+    auto error = reinterpret_cast<SwiftError *>(result.storage);
+    fillGroupNextErrorResult(context, error);
     return;
   }
 
@@ -1652,9 +1664,17 @@ static void swift_taskGroup_waitAllImpl(
 #endif /* __ARM_ARCH_7K__ */
 
     case PollStatus::Error:
-      SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAll found error, waiting task = %p, status:%s",
-                                 waitingTask, group->statusString().c_str());
+      SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAll found error, waiting task = %p, body error = %p, status:%s",
+                                 waitingTask, bodyError, group->statusString().c_str());
+#if SWIFT_TASK_GROUP_BODY_THROWN_ERROR_WINS
+      if (bodyError) {
+        fillGroupNextErrorResult(context, bodyError);
+      } else {
+        fillGroupNextResult(context, polled);
+      }
+#else // so, not SWIFT_TASK_GROUP_BODY_THROWN_ERROR_WINS
       fillGroupNextResult(context, polled);
+#endif // SWIFT_TASK_GROUP_BODY_THROWN_ERROR_WINS
       if (auto completedTask = polled.retainedTask) {
         // Remove the child from the task group's running tasks list.
         _swift_taskGroup_detachChild(asAbstract(group), completedTask);
@@ -1732,9 +1752,6 @@ PollResult TaskGroupBase::waitAll(AsyncTask *waitingTask) {
       auto discardingGroup = asDiscardingImpl(this);
       ReadyQueueItem firstErrorItem;
       if (readyQueue.dequeue(firstErrorItem)) {
-        fprintf(stderr, "[%s:%d](%s) waitAll EMPTY AND dequeued from readyQueue: %s\n", __FILE_NAME__, __LINE__, __FUNCTION__,
-                (firstErrorItem.getStatus() == ReadyStatus::Error ? "error" :
-                (firstErrorItem.getStatus() == ReadyStatus::RawError) ? "raw-error" : "wat"));
         if (firstErrorItem.getStatus() == ReadyStatus::Error) {
           result = PollResult::get(firstErrorItem.getTask(), /*hadErrorResult=*/true);
         } else if (firstErrorItem.getStatus() == ReadyStatus::RawError) {
@@ -1747,7 +1764,7 @@ PollResult TaskGroupBase::waitAll(AsyncTask *waitingTask) {
       return result;
     }
 
-    SWIFT_TASK_GROUP_DEBUG_LOG(this, "group is empty, no pending tasks, status = %s", assumed.to_string(this));
+    SWIFT_TASK_GROUP_DEBUG_LOG(this, "group is empty, no pending tasks, status = %s", assumed.to_string(this).c_str());
     // No tasks in flight, we know no tasks were submitted before this poll
     // was issued, and if we parked here we'd potentially never be woken up.
     // Bail out and return `nil` from `group.next()`.

--- a/test/Concurrency/Runtime/async_taskgroup_discarding.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_discarding.swift
@@ -1,0 +1,62 @@
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library)
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+// REQUIRES: concurrency_runtime
+
+// rdar://78109470
+// UNSUPPORTED: back_deployment_runtime
+
+import _Concurrency
+
+struct Boom: Error {
+  let id: String
+
+  init(file: String = #fileID, line: UInt = #line) {
+    self.id = "\(file):\(line)"
+  }
+
+  init(id: String) {
+    self.id = id
+  }
+}
+
+struct IgnoredBoom: Error {}
+
+@discardableResult
+func echo(_ i: Int) -> Int { i }
+@discardableResult
+func boom(file: String = #fileID, line: UInt = #line) throws -> Int { throw Boom(file: file, line: line) }
+
+func shouldEqual<T: Equatable>(_ lhs: T, _ rhs: T) {
+  precondition(lhs == rhs, "'\(lhs)' did not equal '\(rhs)'")
+}
+func shouldStartWith(_ lhs: Any, _ rhs: Any) {
+  let l = "\(lhs)"
+  let r = "\(rhs)"
+  precondition(l.prefix("\(r)".count) == r, "'\(l)' did not start with '\(r)'")
+}
+
+// NOTE: Not as StdlibUnittest/TestSuite since these types of tests are unreasonably slow to load/debug.
+
+@main struct Main {
+  static func main() async {
+    for i in 0...1_000 {
+      do {
+        let got = try await withThrowingDiscardingTaskGroup() { group in
+          group.addTask {
+            echo(1)
+          }
+          group.addTask {
+            try boom()
+          }
+
+          return 12
+        }
+        fatalError("(iteration:\(i)) expected error to be re-thrown, got: \(got)")
+      } catch {
+        shouldStartWith(error, "Boom(")
+      }
+    }
+  }
+}

--- a/test/Concurrency/Runtime/async_taskgroup_discarding_neverConsumingTasks.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_discarding_neverConsumingTasks.swift
@@ -3,7 +3,6 @@
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
 
-// REQUIRES: rdar104332560
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: OS=linux-gnu
 
@@ -38,7 +37,7 @@ actor Waiter {
   }
 }
 
-func test_taskGroup_void_neverConsume() async {
+func test_discardingTaskGroup_neverConsume() async {
   print(">>> \(#function)")
   let until = 100
   let waiter = Waiter(until: until)
@@ -59,7 +58,7 @@ func test_taskGroup_void_neverConsume() async {
   print("all tasks: \(allTasks)")
 }
 
-func test_taskGroup_void_neverConsume(sleepBeforeGroupWaitAll: Duration) async {
+func test_discardingTaskGroup_neverConsume(sleepBeforeGroupWaitAll: Duration) async {
   print(">>> \(#function)")
   let until = 100
   let waiter = Waiter(until: until)
@@ -85,7 +84,7 @@ func test_taskGroup_void_neverConsume(sleepBeforeGroupWaitAll: Duration) async {
 
 @main struct Main {
   static func main() async {
-    await test_taskGroup_void_neverConsume()
-    await test_taskGroup_void_neverConsume(sleepBeforeGroupWaitAll: .milliseconds(500))
+    await test_discardingTaskGroup_neverConsume()
+    await test_discardingTaskGroup_neverConsume(sleepBeforeGroupWaitAll: .milliseconds(500))
   }
 }

--- a/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
@@ -4,7 +4,6 @@
 // REQUIRES: concurrency
 // REQUIRES: reflection
 
-// REQUIRES: rdar104212282
 // rdar://76038845
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
@@ -173,7 +172,7 @@ func test_discardingTaskGroup_automaticallyRethrows_first_withThrowingBodySecond
     // CHECK: Throwing: Boom(id: "task, first, isCancelled:false
     // CHECK: Throwing: Boom(id: "body, second, isCancelled:true
     // and only then the re-throw happens:
-    // CHECK: rethrown: Boom(id: "task, first, isCancelled:false
+    // CHECK: rethrown: Boom(id: "body, second
     print("rethrown: \(error)")
   }
 }

--- a/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
@@ -73,7 +73,7 @@ func test_discardingTaskGroup_automaticallyRethrows() async {
   print("==== \(#function) ------") // CHECK-LABEL: test_discardingTaskGroup_automaticallyRethrows
   do {
     let got = try await withThrowingDiscardingTaskGroup(returning: Int.self) { group in
-      group.addTask { await echo(1) }
+      group.addTask { _ = await echo(1) }
       group.addTask { throw Boom() }
       // add a throwing task, but don't consume it explicitly
       // since we're in discard results mode, all will be awaited and the first error it thrown
@@ -92,7 +92,7 @@ func test_discardingTaskGroup_automaticallyRethrowsOnlyFirst() async {
   do {
     let got = try await withThrowingDiscardingTaskGroup(returning: Int.self) { group in
       group.addTask {
-        await echo(1)
+        _ = await echo(1)
       }
       group.addTask {
         let error = Boom(id: "first, isCancelled:\(Task.isCancelled)")
@@ -125,9 +125,9 @@ func test_discardingTaskGroup_automaticallyRethrowsOnlyFirst() async {
 func test_discardingTaskGroup_automaticallyRethrows_first_withThrowingBodyFirst() async {
   print("==== \(#function) ------") // CHECK-LABEL: test_discardingTaskGroup_automaticallyRethrows_first_withThrowingBodyFirst
   do {
-    try await withThrowingDiscardingTaskGroup(returning: Int.self) { group in
+    _ = try await withThrowingDiscardingTaskGroup(returning: Int.self) { group in
       group.addTask {
-        await echo(1)
+        _ = await echo(1)
       }
       group.addTask {
         try? await Task.sleep(until: .now + .seconds(10), clock: .continuous)
@@ -154,7 +154,7 @@ func test_discardingTaskGroup_automaticallyRethrows_first_withThrowingBodyFirst(
 func test_discardingTaskGroup_automaticallyRethrows_first_withThrowingBodySecond() async {
   print("==== \(#function) ------") // CHECK-LABEL: test_discardingTaskGroup_automaticallyRethrows_first_withThrowingBodySecond
   do {
-    try await withThrowingDiscardingTaskGroup(returning: Int.self) { group in
+    _ = try await withThrowingDiscardingTaskGroup(returning: Int.self) { group in
       group.addTask {
         let error = Boom(id: "task, first, isCancelled:\(Task.isCancelled)")
         print("Throwing: \(error)")
@@ -173,7 +173,7 @@ func test_discardingTaskGroup_automaticallyRethrows_first_withThrowingBodySecond
     // CHECK: Throwing: Boom(id: "task, first, isCancelled:false
     // CHECK: Throwing: Boom(id: "body, second, isCancelled:true
     // and only then the re-throw happens:
-    // CHECK: rethrown: Boom(id: "body, second
+    // CHECK: rethrown: Boom(id: "task, first, isCancelled:false
     print("rethrown: \(error)")
   }
 }


### PR DESCRIPTION
discarding group may need to emit an error out of such waitAll attempt, if a previous error was already stored.

The exact dance is:
- we store an error from child task
- the pending task count is 0
- the code trying to waitAll would check status ONLY and bail out, noticing that pending count is zero -- returning the actual body value

Instead, it should:
- check again the readyQueue if we're in, if there was a stored value, because if so, it may be an RawError that the DiscardingTaskGroup should emit.

This also is now able to easily handle the "first error always wins" but we choose to implement the "error thrown by body wins" after discussions within the team.

Resolves rdar://104198700
Resolves https://github.com/apple/swift/issues/63147
Resolves rdar://104507347
Resolves rdar://104332560
Resolves rdar://104212282