### PR TITLE
[5.8][Concurrency] Fix too optimistic TaskGroup bail-out-when-empty

### DIFF
--- a/stdlib/public/Concurrency/DiscardingTaskGroup.swift
+++ b/stdlib/public/Concurrency/DiscardingTaskGroup.swift
@@ -86,6 +86,7 @@ public func withDiscardingTaskGroup<GroupResult>(
   let result = await body(&group)
 
   try! await group.awaitAllRemainingTasks() // try!-safe, cannot throw since this is a non throwing group
+
   return result
   #else
   fatalError("Swift compiler is incompatible with this SDK version")

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -45,6 +45,10 @@
 #include <android/log.h>
 #endif
 
+#if defined(_WIN32)
+#include <io.h>
+#endif
+
 #include <assert.h>
 #if SWIFT_CONCURRENCY_ENABLE_DISPATCH
 #include <dispatch/dispatch.h>

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -666,6 +666,8 @@ public:
 
   virtual void destroy() override;
 
+  virtual ~AccumulatingTaskGroup() {}
+
   virtual bool isDiscardingResults() const override {
     return false;
   }
@@ -713,6 +715,8 @@ public:
   virtual ~DiscardingTaskGroup() {}
 
   virtual void destroy() override;
+
+  virtual ~DiscardingTaskGroup() {}
 
   virtual bool isDiscardingResults() const override {
     return true;

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -50,7 +50,7 @@
 
 using namespace swift;
 
-#if 0
+#if 1
 #define SWIFT_TASK_GROUP_DEBUG_LOG(group, fmt, ...)                     \
 fprintf(stderr, "[%#lx] [%s:%d][group(%p%s)] (%s) " fmt "\n",           \
       (unsigned long)Thread::current().platformThreadId(),              \

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -1837,7 +1837,7 @@ void TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask,
       // there were pending tasks so it will be woken up eventually.
 #ifdef __ARM_ARCH_7K__
       workaround_function_swift_taskGroup_waitAllImpl(
-         resultPointer, callerContext, _group, bodyError, resumeFunction, rawContext);
+         resultPointer, callerContext, asAbstract(this), bodyError, resumeFunction, rawContext);
 #endif /* __ARM_ARCH_7K__ */
 
       _swift_task_clearCurrent();

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -721,8 +721,6 @@ public:
 
   virtual void destroy() override;
 
-  virtual ~AccumulatingTaskGroup() {}
-
   virtual bool isDiscardingResults() const override {
     return false;
   }
@@ -770,8 +768,6 @@ public:
   virtual ~DiscardingTaskGroup() {}
 
   virtual void destroy() override;
-
-  virtual ~DiscardingTaskGroup() {}
 
   virtual bool isDiscardingResults() const override {
     return true;

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -374,7 +374,7 @@ public:
   virtual void enqueueCompletedTask(AsyncTask *completedTask, bool hadErrorResult) = 0;
 
   /// Resume waiting task with result from `completedTask`
-  void resumeWaitingTask(AsyncTask *completedTask, TaskGroupStatus &assumed, bool hadErrorResult);
+  void resumeWaitingTask(AsyncTask *completedTask, TaskGroupStatus &assumed, bool hadErrorResult, bool alreadyDecremented = false);
 
   // ==== Status manipulation -------------------------------------------------
 
@@ -415,6 +415,8 @@ public:
   /// A waiting task MUST have been already enqueued in the `waitQueue`.
   TaskGroupStatus statusMarkWaitingAssumeRelease();
 
+  TaskGroupStatus statusAddPendingTaskRelaxed(bool unconditionally);
+
   /// Cancels the group and returns true if was already cancelled before.
   /// After this function returns, the group is guaranteed to be cancelled.
   ///
@@ -427,7 +429,6 @@ public:
   /// This also sets
   bool cancelAll();
 
-  virtual TaskGroupStatus statusAddPendingTaskRelaxed(bool unconditionally) = 0;
 };
 
 [[maybe_unused]]
@@ -494,13 +495,14 @@ struct TaskGroupStatus {
 
   /// Status value decrementing the Ready, Pending and Waiting counters by one.
   TaskGroupStatus completingPendingReadyWaiting(const TaskGroupBase* _Nonnull group) {
-    assert(pendingTasks(group) &&
-           "can only complete waiting task when pending tasks available");
+//    assert(pendingTasks(group) &&
+//           "can only complete waiting task when pending tasks available");
     assert(group->isDiscardingResults() || readyTasks(group) &&
                                            "can only complete waiting task when ready tasks available");
     assert(hasWaitingTask() &&
            "can only complete waiting task when waiting task available");
-    uint64_t change = waiting + onePendingTask;
+    uint64_t change = waiting;
+    change += pendingTasks(group) ? onePendingTask : 0;
     // only while accumulating results does the status contain "ready" bits;
     // so if we're in "discard results" mode, we must not decrement the ready count,
     // as there is no ready count in the status.
@@ -509,11 +511,12 @@ struct TaskGroupStatus {
   }
 
   TaskGroupStatus completingPendingReady(const TaskGroupBase* _Nonnull group) {
-    assert(pendingTasks(group) &&
-           "can only complete waiting task when pending tasks available");
+//    assert(pendingTasks(group) &&
+//           "can only complete waiting task when pending tasks available");
     assert(group->isDiscardingResults() || readyTasks(group) &&
                                            "can only complete waiting task when ready tasks available");
-    auto change = onePendingTask;
+    auto change = 0;
+    change += pendingTasks(group) ? onePendingTask : 0;
     change += group->isAccumulatingResults() ? oneReadyTask : 0;
     return TaskGroupStatus{status - change};
   }
@@ -596,6 +599,39 @@ TaskGroupStatus TaskGroupBase::statusMarkWaitingAssumeRelease() {
   return TaskGroupStatus{old | TaskGroupStatus::waiting};
 }
 
+/// Add a single pending task to the status counter.
+/// This is used to implement next() properly, as we need to know if there
+/// are pending tasks worth suspending/waiting for or not.
+///
+/// Note that the group does *not* store child tasks at all, as they are
+/// stored in the `TaskGroupTaskStatusRecord` inside the current task, that
+/// is currently executing the group. Here we only need the counts of
+/// pending/ready tasks.
+///
+/// If the `unconditionally` parameter is `true` the operation always successfully
+/// adds a pending task, even if the group is cancelled. If the unconditionally
+/// flag is `false`, the added pending count will be *reverted* before returning.
+/// This is because we will NOT add a task to a cancelled group, unless doing
+/// so unconditionally.
+///
+/// Returns *assumed* new status, including the just performed +1.
+TaskGroupStatus TaskGroupBase::statusAddPendingTaskRelaxed(bool unconditionally) {
+
+  auto old = status.fetch_add(TaskGroupStatus::onePendingTask,
+                              std::memory_order_relaxed);
+  auto s = TaskGroupStatus{old + TaskGroupStatus::onePendingTask};
+
+  if (!unconditionally && s.isCancelled()) {
+    // revert that add, it was meaningless
+    auto o = status.fetch_sub(TaskGroupStatus::onePendingTask,
+                              std::memory_order_relaxed);
+    s = TaskGroupStatus{o - TaskGroupStatus::onePendingTask};
+  }
+
+  SWIFT_TASK_GROUP_DEBUG_LOG(this, "addPending, after = %s", s.to_string(this).c_str());
+  return s;
+}
+
 TaskGroupStatus TaskGroupBase::statusRemoveWaitingRelease() {
   auto old = status.fetch_and(~TaskGroupStatus::waiting,
                               std::memory_order_release);
@@ -646,49 +682,6 @@ public:
     return s;
   }
 
-  /// Add a single pending task to the status counter.
-  /// This is used to implement next() properly, as we need to know if there
-  /// are pending tasks worth suspending/waiting for or not.
-  ///
-  /// Note that the group does *not* store child tasks at all, as they are
-  /// stored in the `TaskGroupTaskStatusRecord` inside the current task, that
-  /// is currently executing the group. Here we only need the counts of
-  /// pending/ready tasks.
-  ///
-  /// If the `unconditionally` parameter is `true` the operation always successfully
-  /// adds a pending task, even if the group is cancelled. If the unconditionally
-  /// flag is `false`, the added pending count will be *reverted* before returning.
-  /// This is because we will NOT add a task to a cancelled group, unless doing
-  /// so unconditionally.
-  ///
-  /// Returns *assumed* new status, including the just performed +1.
-  TaskGroupStatus statusAddPendingTaskRelaxed(bool unconditionally) override {
-    auto old = status.fetch_add(TaskGroupStatus::onePendingTask,
-                                std::memory_order_relaxed);
-    auto s = TaskGroupStatus{old + TaskGroupStatus::onePendingTask};
-
-    if (!unconditionally && s.isCancelled()) {
-      // revert that add, it was meaningless
-      auto o = status.fetch_sub(TaskGroupStatus::onePendingTask,
-                                std::memory_order_relaxed);
-      s = TaskGroupStatus{o - TaskGroupStatus::onePendingTask};
-    }
-
-    return s;
-  }
-
-  /// Decrement the pending status count.
-  /// Returns the *assumed* new status, including the just performed -1.
-  TaskGroupStatus statusCompletePendingAssumeRelease() {
-    assert(this->isDiscardingResults()
-           && "only a discardResults TaskGroup may use completePending, "
-              "since it avoids updating the ready count, which other groups need.");
-    auto old = status.fetch_sub(TaskGroupStatus::onePendingTask,
-                                std::memory_order_release);
-    assert(TaskGroupStatus{old}.pendingTasks(this) > 0 && "attempted to decrement pending count when it was 0 already");
-    return TaskGroupStatus{old - TaskGroupStatus::onePendingTask};
-  }
-
   virtual void offer(AsyncTask *completed, AsyncContext *context) override;
 
   virtual void enqueueCompletedTask(AsyncTask *completedTask, bool hadErrorResult) override;
@@ -731,37 +724,6 @@ public:
     return TaskGroupStatus{status.load(std::memory_order_acquire)};
   }
 
-  /// Add a single pending task to the status counter.
-  /// This is used to implement next() properly, as we need to know if there
-  /// are pending tasks worth suspending/waiting for or not.
-  ///
-  /// Note that the group does *not* store child tasks at all, as they are
-  /// stored in the `TaskGroupTaskStatusRecord` inside the current task, that
-  /// is currently executing the group. Here we only need the counts of
-  /// pending/ready tasks.
-  ///
-  /// If the `unconditionally` parameter is `true` the operation always successfully
-  /// adds a pending task, even if the group is cancelled. If the unconditionally
-  /// flag is `false`, the added pending count will be *reverted* before returning.
-  /// This is because we will NOT add a task to a cancelled group, unless doing
-  /// so unconditionally.
-  ///
-  /// Returns *assumed* new status, including the just performed +1.
-  TaskGroupStatus statusAddPendingTaskRelaxed(bool unconditionally) override {
-    auto old = status.fetch_add(TaskGroupStatus::onePendingTask,
-                                std::memory_order_relaxed);
-    auto s = TaskGroupStatus{old + TaskGroupStatus::onePendingTask};
-
-    if (!unconditionally && s.isCancelled()) {
-      // revert that add, it was meaningless
-      auto o = status.fetch_sub(TaskGroupStatus::onePendingTask,
-                                std::memory_order_relaxed);
-      s = TaskGroupStatus{o - TaskGroupStatus::onePendingTask};
-    }
-
-    return s;
-  }
-
   TaskGroupStatus statusLoadRelaxed() {
     return TaskGroupStatus{status.load(std::memory_order_relaxed)};
   }
@@ -784,9 +746,6 @@ public:
   /// Decrement the pending status count.
   /// Returns the *assumed* new status, including the just performed -1.
   TaskGroupStatus statusCompletePendingAssumeRelease() {
-    assert(this->isDiscardingResults()
-           && "only a discardResults TaskGroup may use completePending, "
-              "since it avoids updating the ready count, which other groups need.");
     auto old = status.fetch_sub(TaskGroupStatus::onePendingTask,
                                 std::memory_order_release);
     assert(TaskGroupStatus{old}.pendingTasks(this) > 0 && "attempted to decrement pending count when it was 0 already");
@@ -1123,7 +1082,6 @@ void AccumulatingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *contex
   assert(completedTask->hasChildFragment());
   assert(completedTask->hasGroupChildFragment());
   assert(completedTask->groupChildFragment()->getGroup() == asAbstract(this));
-  SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, completedTask:%p , status:%s", completedTask, statusString().c_str());
 
   // The current ownership convention is that we are *not* given ownership
   // of a retain on completedTask; we're called from the task completion
@@ -1134,6 +1092,8 @@ void AccumulatingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *contex
   // transfer ownership of a retain into this function, in which case we
   // will need to release in the other path.
   lock(); // TODO: remove fragment lock, and use status for synchronization
+
+  SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, completedTask:%p , status:%s", completedTask, statusString().c_str());
 
   // Immediately increment ready count and acquire the status
   //
@@ -1183,16 +1143,7 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
   assert(completedTask->hasChildFragment());
   assert(completedTask->hasGroupChildFragment());
   assert(completedTask->groupChildFragment()->getGroup() == asAbstract(this));
-  SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, completedTask:%p, status:%s", completedTask, statusString().c_str());
 
-  // The current ownership convention is that we are *not* given ownership
-  // of a retain on completedTask; we're called from the task completion
-  // handler, and the task will release itself.  So if we need the task
-  // to survive this call (e.g. because there isn't an immediate waiting
-  // task), we will need to retain it, which we do in enqueueCompletedTask.
-  // This is wasteful, and the task completion function should be fixed to
-  // transfer ownership of a retain into this function, in which case we
-  // will need to release in the other path.
   lock(); // TODO: remove fragment lock, and use status for synchronization
 
   // Since we don't maintain ready counts in a discarding group, only load the status.
@@ -1207,59 +1158,57 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
     hadErrorResult = true;
   }
 
-  /// If we're the last task we've been waiting for, and there is a waiting task on the group
-  bool lastPendingTaskAndWaitingTask =
-      assumed.pendingTasks(this) == 1 &&
-      assumed.hasWaitingTask();
+  SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, completedTask:%p, error:%d, status:%s",
+                             completedTask, hadErrorResult, assumed.to_string(this).c_str());
 
   // Immediately decrement the pending count.
   // We can do this, since in this mode there is no ready count to keep track of,
   // and we immediately discard the result.
   SWIFT_TASK_GROUP_DEBUG_LOG(this, "discard result, hadError:%d, was pending:%llu, status = %s",
                              hadErrorResult, assumed.pendingTasks(this), assumed.to_string(this).c_str());
-  // If this was the last pending task, and there is a waiting task (from waitAll),
-  // we must resume the task; but not otherwise. There cannot be any waiters on next()
-  // while we're discarding results.
-  if (lastPendingTaskAndWaitingTask) {
-    ReadyQueueItem item;
-    SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, offered last pending task, resume waiting task:%p",
-                               waitQueue.load(std::memory_order_relaxed));
-    if (readyQueue.dequeue(item)) {
-      switch (item.getStatus()) {
-        case ReadyStatus::RawError:
-          resumeWaitingTaskWithError(item.getRawError(this), assumed);
-          break;
-        case ReadyStatus::Error:
-          resumeWaitingTask(item.getTask(), assumed, /*hadErrorResult=*/true);
-          break;
-        default:
-          swift_Concurrency_fatalError(0, "only errors can be stored by a discarding task group, yet it wasn't an error!");
-      }
-    } else {
-      resumeWaitingTask(completedTask, assumed, /*hadErrorResult=*/hadErrorResult);
-    }
-  } else {
-    assert(!lastPendingTaskAndWaitingTask);
+
     if (hadErrorResult && readyQueue.isEmpty()) {
       // a discardResults throwing task group must retain the FIRST error it encounters.
-      SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer error, completedTask:%p", completedTask);
+      SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer error, error:%d, completedTask:%p", hadErrorResult, completedTask);
       enqueueCompletedTask(completedTask, /*hadErrorResult=*/hadErrorResult);
     } else {
       // we just are going to discard it.
+      SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer discard the completedTask:%p, status=%s", completedTask, statusString().c_str());
       _swift_taskGroup_detachChild(asAbstract(this), completedTask);
     }
 
     auto afterComplete = statusCompletePendingAssumeRelease();
     (void) afterComplete;
-    SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, either more pending tasks, or no waiting task, status:%s",
+    SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, complete, status:%s",
                                afterComplete.to_string(this).c_str());
-  }
 
   // Discarding results mode, immediately treats a child failure as group cancellation.
   // "All for one, one for all!" - any task failing must cause the group and all sibling tasks to be cancelled,
   // such that the discarding group can exit as soon as possible.
   if (hadErrorResult) {
     cancelAll();
+  }
+
+  if (afterComplete.hasWaitingTask() && afterComplete.pendingTasks(this) == 0) {
+    ReadyQueueItem priorErrorItem;
+    if (readyQueue.dequeue(priorErrorItem)) {
+      SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, last pending task, prior error found, fail waitingTask:%p",
+                                 waitQueue.load(std::memory_order_relaxed));
+      switch (priorErrorItem.getStatus()) {
+        case ReadyStatus::RawError:
+          resumeWaitingTaskWithError(priorErrorItem.getRawError(this), assumed);
+          break;
+        case ReadyStatus::Error:
+          resumeWaitingTask(priorErrorItem.getTask(), assumed, /*hadErrorResult=*/true, /*alreadyDecremented=*/true);
+          break;
+        default:
+          swift_Concurrency_fatalError(0, "only errors can be stored by a discarding task group, yet it wasn't an error!");
+      }
+    } else {
+      SWIFT_TASK_GROUP_DEBUG_LOG(this, "offer, last pending task, completing with completedTask:%p, completedTask.error:%d, waitingTask:%p",
+                                 completedTask, hadErrorResult, waitQueue.load(std::memory_order_relaxed));
+      resumeWaitingTask(completedTask, assumed, /*hadErrorResult=*/hadErrorResult);
+    }
   }
 
   unlock();
@@ -1269,21 +1218,23 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
 void TaskGroupBase::resumeWaitingTask(
     AsyncTask *completedTask,
     TaskGroupStatus &assumed,
-    bool hadErrorResult) {
+    bool hadErrorResult,
+    bool alreadyDecremented) {
+  auto backup = waitQueue.load(std::memory_order_acquire);
   auto waitingTask = waitQueue.load(std::memory_order_acquire);
   assert(waitingTask && "waitingTask must not be null when attempting to resume it");
-  SWIFT_TASK_GROUP_DEBUG_LOG(this, "resume waiting task = %p, complete with = %p",
-                       waitingTask, completedTask);
+  assert(assumed.hasWaitingTask());
+  SWIFT_TASK_GROUP_DEBUG_LOG(this, "resume waiting task = %p, error:%d, complete with = %p",
+                       waitingTask, hadErrorResult, completedTask);
   while (true) {
     // ==== a) run waiting task directly -------------------------------------
-    assert(assumed.hasWaitingTask());
     // assert(assumed.pendingTasks(this) && "offered to group with no pending tasks!");
     // We are the "first" completed task to arrive,
     // and since there is a task waiting we immediately claim and complete it.
     if (waitQueue.compare_exchange_strong(
         waitingTask, nullptr,
-        /*success*/ std::memory_order_release,
-        /*failure*/ std::memory_order_acquire)) {
+        /*success*/ std::memory_order_seq_cst,
+        /*failure*/ std::memory_order_seq_cst)) {
 
 #if SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL
       // In the task-to-thread model, child tasks are always actually
@@ -1303,10 +1254,13 @@ void TaskGroupBase::resumeWaitingTask(
       return;
 
 #else /* SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL */
-      if (statusCompletePendingReadyWaiting(assumed)) {
+      fprintf(stderr, "[%s:%d](%s) assumed:%s\n", __FILE_NAME__, __LINE__, __FUNCTION__, assumed.to_string(this).c_str());
+      fprintf(stderr, "[%s:%d](%s)     had:%s\n", __FILE_NAME__, __LINE__, __FUNCTION__, this->statusString().c_str());
+
+      if (alreadyDecremented || statusCompletePendingReadyWaiting(assumed)) {
         // Run the task.
         auto result = PollResult::get(completedTask, hadErrorResult);
-        SWIFT_TASK_GROUP_DEBUG_LOG(this, "resume waiting DONE, task = %p, complete with = %p, status  = %s",
+        SWIFT_TASK_GROUP_DEBUG_LOG(this, "resume waiting DONE, task = %p, complete with = %p, status = %s",
                                    waitingTask, completedTask, statusString().c_str());
 
         // Remove the child from the task group's running tasks list.
@@ -1670,8 +1624,8 @@ static void swift_taskGroup_waitAllImpl(
   context->errorResult = nullptr;
   context->successResultPointer = resultPointer;
 
-  SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAllImpl, waiting task = %p, bodyError = %p, status:%s, polled.status = %s",
-                       waitingTask, bodyError, group->statusString().c_str(), to_string(polled.status).c_str());
+  SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAllImpl, waiting task = %p, bodyError = %p, status:%s, polled.status = %s, status.NOW=%s",
+                       waitingTask, bodyError, group->statusString().c_str(), to_string(polled.status).c_str(), group->statusString().c_str());
 
   switch (polled.status) {
     case PollStatus::MustWait: {
@@ -1804,6 +1758,7 @@ PollResult TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask,
         /*success*/ std::memory_order_release,
         /*failure*/ std::memory_order_acquire)) {
       statusMarkWaitingAssumeRelease();
+      SWIFT_TASK_GROUP_DEBUG_LOG(this, "waitAll, marked waiting status = %s", statusString().c_str());
       unlock();
       
 #if SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -366,8 +366,9 @@ public:
   ///
   /// \param bodyError error thrown by the body of a with...TaskGroup method
   /// \param waitingTask the task waiting on the group
+  /// \param rawContext used to resume the waiting task
   /// \return how the waiting task should be handled, e.g. must wait or can be completed immediately
-  PollResult waitAll(SwiftError* bodyError, AsyncTask *waitingTask);
+  PollResult waitAll(SwiftError* bodyError, AsyncTask *waitingTask, AsyncContext* rawContext);
 
   // Enqueue the completed task onto ready queue if there are no waiting tasks yet
   virtual void enqueueCompletedTask(AsyncTask *completedTask, bool hadErrorResult) = 0;
@@ -378,6 +379,7 @@ public:
   // ==== Status manipulation -------------------------------------------------
 
   TaskGroupStatus statusLoadRelaxed() const;
+  TaskGroupStatus statusLoadAcquire() const;
 
   std::string statusString() const;
 
@@ -408,6 +410,10 @@ public:
 
   /// Remove waiting status bit.
   TaskGroupStatus statusRemoveWaitingRelease();
+
+  /// Mark the waiting status bit.
+  /// A waiting task MUST have been already enqueued in the `waitQueue`.
+  TaskGroupStatus statusMarkWaitingAssumeRelease();
 
   /// Cancels the group and returns true if was already cancelled before.
   /// After this function returns, the group is guaranteed to be cancelled.
@@ -521,7 +527,7 @@ struct TaskGroupStatus {
   ///     TaskGroupStatus{ C:{cancelled} W:{waiting task} R:{ready tasks} P:{pending tasks} {binary repr} }
   /// If discarding results:
   ///     TaskGroupStatus{ C:{cancelled} W:{waiting task} P:{pending tasks} {binary repr} }
-  std::string to_string(const TaskGroupBase* _Nonnull group) {
+  std::string to_string(const TaskGroupBase* group) {
     std::string str;
     str.append("TaskGroupStatus{ ");
     str.append("C:"); // cancelled
@@ -548,7 +554,7 @@ struct TaskGroupStatus {
 bool TaskGroupBase::statusCompletePendingReadyWaiting(TaskGroupStatus &old) {
   return status.compare_exchange_strong(
       old.status, old.completingPendingReadyWaiting(this).status,
-      /*success*/ std::memory_order_relaxed,
+      /*success*/ std::memory_order_release,
       /*failure*/ std::memory_order_relaxed);
 }
 
@@ -559,6 +565,10 @@ bool TaskGroupBase::isCancelled() const {
 
 TaskGroupStatus TaskGroupBase::statusLoadRelaxed() const {
   return TaskGroupStatus{status.load(std::memory_order_relaxed)};
+}
+
+TaskGroupStatus TaskGroupBase::statusLoadAcquire() const {
+  return TaskGroupStatus{status.load(std::memory_order_acquire)};
 }
 
 std::string TaskGroupBase::statusString() const {
@@ -577,6 +587,12 @@ uint64_t TaskGroupBase::pendingTasks() const {
 
 TaskGroupStatus TaskGroupBase::statusMarkWaitingAssumeAcquire() {
   auto old = status.fetch_or(TaskGroupStatus::waiting, std::memory_order_acquire);
+  return TaskGroupStatus{old | TaskGroupStatus::waiting};
+}
+
+TaskGroupStatus TaskGroupBase::statusMarkWaitingAssumeRelease() {
+  auto old = status.fetch_or(TaskGroupStatus::waiting,
+                             std::memory_order_release);
   return TaskGroupStatus{old | TaskGroupStatus::waiting};
 }
 
@@ -707,18 +723,6 @@ public:
 
   virtual bool isDiscardingResults() const override {
     return true;
-  }
-
-  /// Returns *assumed* new status, including the just performed +1.
-  TaskGroupStatus statusMarkWaitingAssumeAcquire() {
-    auto old = status.fetch_or(TaskGroupStatus::waiting, std::memory_order_acquire);
-    return TaskGroupStatus{old | TaskGroupStatus::waiting};
-  }
-
-  TaskGroupStatus statusRemoveWaitingRelease() {
-    auto old = status.fetch_and(~TaskGroupStatus::waiting,
-                                std::memory_order_release);
-    return TaskGroupStatus{old};
   }
 
   /// Returns *assumed* new status.
@@ -1152,7 +1156,7 @@ void AccumulatingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *contex
     hadErrorResult = true;
   }
 
-  SWIFT_TASK_GROUP_DEBUG_LOG(this, "ready: %d, pending: %u",
+  SWIFT_TASK_GROUP_DEBUG_LOG(this, "ready: %d, pending: %llu",
                        assumed.readyTasks(this), assumed.pendingTasks(this));
 
   // ==== a) has waiting task, so let us complete it right away
@@ -1205,13 +1209,14 @@ void DiscardingTaskGroup::offer(AsyncTask *completedTask, AsyncContext *context)
 
   /// If we're the last task we've been waiting for, and there is a waiting task on the group
   bool lastPendingTaskAndWaitingTask =
-      assumed.pendingTasks(this) == 1 && assumed.hasWaitingTask();
+      assumed.pendingTasks(this) == 1 &&
+      assumed.hasWaitingTask();
 
   // Immediately decrement the pending count.
   // We can do this, since in this mode there is no ready count to keep track of,
   // and we immediately discard the result.
-  SWIFT_TASK_GROUP_DEBUG_LOG(this, "discard result, hadError:%d, was pending:%llu",
-                             hadErrorResult, assumed.pendingTasks(this));
+  SWIFT_TASK_GROUP_DEBUG_LOG(this, "discard result, hadError:%d, was pending:%llu, status = %s",
+                             hadErrorResult, assumed.pendingTasks(this), assumed.to_string(this).c_str());
   // If this was the last pending task, and there is a waiting task (from waitAll),
   // we must resume the task; but not otherwise. There cannot be any waiters on next()
   // while we're discarding results.
@@ -1301,6 +1306,8 @@ void TaskGroupBase::resumeWaitingTask(
       if (statusCompletePendingReadyWaiting(assumed)) {
         // Run the task.
         auto result = PollResult::get(completedTask, hadErrorResult);
+        SWIFT_TASK_GROUP_DEBUG_LOG(this, "resume waiting DONE, task = %p, complete with = %p, status  = %s",
+                                   waitingTask, completedTask, statusString().c_str());
 
         // Remove the child from the task group's running tasks list.
         // The parent task isn't currently running (we're about to wake
@@ -1652,11 +1659,9 @@ static void swift_taskGroup_waitAllImpl(
     ThrowingTaskFutureWaitContinuationFunction *resumeFunction,
     AsyncContext *rawContext) {
   auto waitingTask = swift_task_getCurrent();
-  waitingTask->ResumeTask = task_group_wait_resume_adapter;
-  waitingTask->ResumeContext = rawContext;
 
   auto group = asBaseImpl(_group);
-  PollResult polled = group->waitAll(bodyError, waitingTask);
+  PollResult polled = group->waitAll(bodyError, waitingTask, rawContext);
 
   auto context = static_cast<TaskFutureWaitAsyncContext *>(rawContext);
   context->ResumeParent =
@@ -1669,19 +1674,17 @@ static void swift_taskGroup_waitAllImpl(
                        waitingTask, bodyError, group->statusString().c_str(), to_string(polled.status).c_str());
 
   switch (polled.status) {
-    case PollStatus::MustWait:
-    SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAllImpl MustWait, pending tasks exist, waiting task = %p",
-                               waitingTask);
+    case PollStatus::MustWait: {
       // The waiting task has been queued on the channel,
       // there were pending tasks so it will be woken up eventually.
 #ifdef __ARM_ARCH_7K__
-      return workaround_function_swift_taskGroup_waitAllImpl(
+      workaround_function_swift_taskGroup_waitAllImpl(
          resultPointer, callerContext, _group, bodyError, resumeFunction, rawContext);
-#else /* __ARM_ARCH_7K__ */
-      return;
 #endif /* __ARM_ARCH_7K__ */
+      return;
+    }
 
-    case PollStatus::Error:
+    case PollStatus::Error: {
       SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAllImpl Error, waiting task = %p, body error = %p, status:%s",
                                  waitingTask, bodyError, group->statusString().c_str());
 #if SWIFT_TASK_GROUP_BODY_THROWN_ERROR_WINS
@@ -1702,9 +1705,10 @@ static void swift_taskGroup_waitAllImpl(
       }
 
       return waitingTask->runInFullyEstablishedContext();
+    }
 
     case PollStatus::Empty:
-    case PollStatus::Success:
+    case PollStatus::Success: {
       /// Anything else than a "MustWait" can be treated as a successful poll.
       /// Only if there are in flight pending tasks do we need to wait after all.
       SWIFT_TASK_GROUP_DEBUG_LOG(group, "waitAllImpl %s, waiting task = %p, status:%s",
@@ -1719,14 +1723,17 @@ static void swift_taskGroup_waitAllImpl(
       }
 
       return waitingTask->runInFullyEstablishedContext();
+    }
   }
 }
 
-/// Must be called while holding the `taskGroup.lock`!
-/// This is because the discarding task group still has some follow-up operations that must
-/// be performed atomically after this operation sometimes, so we cannot unlock inside `waitAll` itself.
-PollResult TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask) {
-  lock(); // TODO: remove group lock, and use status for synchronization
+PollResult TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask, AsyncContext *rawContext) {
+  lock();
+
+  // must mutate the waiting task while holding the group lock,
+  // so we don't get an offer concurrently trying to do so
+  waitingTask->ResumeTask = task_group_wait_resume_adapter;
+  waitingTask->ResumeContext = rawContext;
 
   SWIFT_TASK_GROUP_DEBUG_LOG(this, "waitAll, bodyError = %p, status = %s", bodyError, statusString().c_str());
   PollResult result = PollResult::getEmpty(this->successType);
@@ -1739,7 +1746,11 @@ PollResult TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask)
   bool haveRunOneChildTaskInline = false;
 
   reevaluate_if_TaskGroup_has_results:;
-  auto assumed = statusMarkWaitingAssumeAcquire();
+  // Paired with a release when marking Waiting,
+  // otherwise we don't modify the status
+  auto assumed = statusLoadAcquire();
+
+  SWIFT_TASK_GROUP_DEBUG_LOG(this, "waitAll, status = %s", assumed.to_string(this).c_str());
 
   // ==== 1) may be able to bail out early if no tasks are pending -------------
   if (assumed.isEmpty(this)) {
@@ -1757,7 +1768,6 @@ PollResult TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask)
           result.status = PollStatus::Error;
         }
       } // else, we're definitely Empty
-
       unlock();
       return result;
     }
@@ -1766,7 +1776,6 @@ PollResult TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask)
     // No tasks in flight, we know no tasks were submitted before this poll
     // was issued, and if we parked here we'd potentially never be woken up.
     // Bail out and return `nil` from `group.next()`.
-    statusRemoveWaitingRelease();
     unlock();
     return result;
   }
@@ -1794,7 +1803,9 @@ PollResult TaskGroupBase::waitAll(SwiftError* bodyError, AsyncTask *waitingTask)
         waitHead, waitingTask,
         /*success*/ std::memory_order_release,
         /*failure*/ std::memory_order_acquire)) {
-      unlock(); // TODO: remove fragment lock, and use status for synchronization
+      statusMarkWaitingAssumeRelease();
+      unlock();
+      
 #if SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL
       // The logic here is paired with the logic in TaskGroupBase::offer. Once
       // we run the

--- a/test/Concurrency/Runtime/async_taskgroup_discarding.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_discarding.swift
@@ -1,0 +1,62 @@
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library)
+
+// REQUIRES: concurrency
+// REQUIRES: executable_test
+// REQUIRES: concurrency_runtime
+
+// rdar://78109470
+// UNSUPPORTED: back_deployment_runtime
+
+import _Concurrency
+
+struct Boom: Error {
+  let id: String
+
+  init(file: String = #fileID, line: UInt = #line) {
+    self.id = "\(file):\(line)"
+  }
+
+  init(id: String) {
+    self.id = id
+  }
+}
+
+struct IgnoredBoom: Error {}
+
+@discardableResult
+func echo(_ i: Int) -> Int { i }
+@discardableResult
+func boom(file: String = #fileID, line: UInt = #line) throws -> Int { throw Boom(file: file, line: line) }
+
+func shouldEqual<T: Equatable>(_ lhs: T, _ rhs: T) {
+  precondition(lhs == rhs, "'\(lhs)' did not equal '\(rhs)'")
+}
+func shouldStartWith(_ lhs: Any, _ rhs: Any) {
+  let l = "\(lhs)"
+  let r = "\(rhs)"
+  precondition(l.prefix("\(r)".count) == r, "'\(l)' did not start with '\(r)'")
+}
+
+// NOTE: Not as StdlibUnittest/TestSuite since these types of tests are unreasonably slow to load/debug.
+
+@main struct Main {
+  static func main() async {
+    for i in 0...1_000 {
+      do {
+        let got = try await withThrowingDiscardingTaskGroup() { group in
+          group.addTask {
+            echo(1)
+          }
+          group.addTask {
+            try boom()
+          }
+
+          return 12
+        }
+        fatalError("(iteration:\(i)) expected error to be re-thrown, got: \(got)")
+      } catch {
+        shouldStartWith(error, "Boom(")
+      }
+    }
+  }
+}

--- a/test/Concurrency/Runtime/async_taskgroup_discarding_neverConsumingTasks.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_discarding_neverConsumingTasks.swift
@@ -3,8 +3,6 @@
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
 
-// REQUIRES: rdar104332560
-
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: OS=linux-gnu
 
@@ -39,7 +37,7 @@ actor Waiter {
   }
 }
 
-func test_taskGroup_void_neverConsume() async {
+func test_discardingTaskGroup_neverConsume() async {
   print(">>> \(#function)")
   let until = 100
   let waiter = Waiter(until: until)
@@ -60,7 +58,7 @@ func test_taskGroup_void_neverConsume() async {
   print("all tasks: \(allTasks)")
 }
 
-func test_taskGroup_void_neverConsume(sleepBeforeGroupWaitAll: Duration) async {
+func test_discardingTaskGroup_neverConsume(sleepBeforeGroupWaitAll: Duration) async {
   print(">>> \(#function)")
   let until = 100
   let waiter = Waiter(until: until)
@@ -86,7 +84,7 @@ func test_taskGroup_void_neverConsume(sleepBeforeGroupWaitAll: Duration) async {
 
 @main struct Main {
   static func main() async {
-    await test_taskGroup_void_neverConsume()
-    await test_taskGroup_void_neverConsume(sleepBeforeGroupWaitAll: .milliseconds(500))
+    await test_discardingTaskGroup_neverConsume()
+    await test_discardingTaskGroup_neverConsume(sleepBeforeGroupWaitAll: .milliseconds(500))
   }
 }

--- a/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
@@ -4,7 +4,6 @@
 // REQUIRES: concurrency
 // REQUIRES: reflection
 
-// REQUIRES: rdar104212282
 // rdar://76038845
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
@@ -173,7 +172,7 @@ func test_discardingTaskGroup_automaticallyRethrows_first_withThrowingBodySecond
     // CHECK: Throwing: Boom(id: "task, first, isCancelled:false
     // CHECK: Throwing: Boom(id: "body, second, isCancelled:true
     // and only then the re-throw happens:
-    // CHECK: rethrown: Boom(id: "task, first, isCancelled:false
+    // CHECK: rethrown: Boom(id: "body, second
     print("rethrown: \(error)")
   }
 }

--- a/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
@@ -73,7 +73,7 @@ func test_discardingTaskGroup_automaticallyRethrows() async {
   print("==== \(#function) ------") // CHECK-LABEL: test_discardingTaskGroup_automaticallyRethrows
   do {
     let got = try await withThrowingDiscardingTaskGroup(returning: Int.self) { group in
-      group.addTask { await echo(1) }
+      group.addTask { _ = await echo(1) }
       group.addTask { throw Boom() }
       // add a throwing task, but don't consume it explicitly
       // since we're in discard results mode, all will be awaited and the first error it thrown
@@ -92,7 +92,7 @@ func test_discardingTaskGroup_automaticallyRethrowsOnlyFirst() async {
   do {
     let got = try await withThrowingDiscardingTaskGroup(returning: Int.self) { group in
       group.addTask {
-        await echo(1)
+        _ = await echo(1)
       }
       group.addTask {
         let error = Boom(id: "first, isCancelled:\(Task.isCancelled)")
@@ -125,9 +125,9 @@ func test_discardingTaskGroup_automaticallyRethrowsOnlyFirst() async {
 func test_discardingTaskGroup_automaticallyRethrows_first_withThrowingBodyFirst() async {
   print("==== \(#function) ------") // CHECK-LABEL: test_discardingTaskGroup_automaticallyRethrows_first_withThrowingBodyFirst
   do {
-    try await withThrowingDiscardingTaskGroup(returning: Int.self) { group in
+    _ = try await withThrowingDiscardingTaskGroup(returning: Int.self) { group in
       group.addTask {
-        await echo(1)
+        _ = await echo(1)
       }
       group.addTask {
         try? await Task.sleep(until: .now + .seconds(10), clock: .continuous)
@@ -154,7 +154,7 @@ func test_discardingTaskGroup_automaticallyRethrows_first_withThrowingBodyFirst(
 func test_discardingTaskGroup_automaticallyRethrows_first_withThrowingBodySecond() async {
   print("==== \(#function) ------") // CHECK-LABEL: test_discardingTaskGroup_automaticallyRethrows_first_withThrowingBodySecond
   do {
-    try await withThrowingDiscardingTaskGroup(returning: Int.self) { group in
+    _ = try await withThrowingDiscardingTaskGroup(returning: Int.self) { group in
       group.addTask {
         let error = Boom(id: "task, first, isCancelled:\(Task.isCancelled)")
         print("Throwing: \(error)")
@@ -173,7 +173,7 @@ func test_discardingTaskGroup_automaticallyRethrows_first_withThrowingBodySecond
     // CHECK: Throwing: Boom(id: "task, first, isCancelled:false
     // CHECK: Throwing: Boom(id: "body, second, isCancelled:true
     // and only then the re-throw happens:
-    // CHECK: rethrown: Boom(id: "body, second
+    // CHECK: rethrown: Boom(id: "task, first, isCancelled:false
     print("rethrown: \(error)")
   }
 }


### PR DESCRIPTION
**Description:**
discarding group may need to emit an error out of such waitAll attempt, if a previous error was already stored.

The exact dance is:

we store an error from child task
the pending task count is 0
the code trying to waitAll would check status ONLY and bail out, noticing that pending count is zero -- returning the actual body value
Instead, it should:

check again the readyQueue if we're in, if there was a stored value, because if so, it may be an RawError that the DiscardingTaskGroup should emit.
This also is now able to easily handle the "first error always wins" but we choose to implement the "error thrown by body wins" after discussions within the team.


**Risk:** Low, only new task group mode affected. 
**Review by:** @DougGregor @FranzBusch @Lukasa 
**Testing:** CI testing
**Original PR:** https://github.com/apple/swift/pull/63016
**Radar:** rdar://104198700