### PR TITLE
[NFC] SILOptimizer: remove unused `NumMemoryElements` variable

### DIFF
--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -3236,14 +3236,8 @@ handleConditionalDestroys(SILValue ControlVariableAddr) {
   SILBuilderWithScope B(TheMemory.getUninitializedValue());
   Identifier ShiftRightFn, TruncateFn, CmpEqFn;
 
-  unsigned NumMemoryElements = TheMemory.getNumElements();
-
   unsigned SelfInitializedElt = TheMemory.getNumElements();
   unsigned SuperInitElt = TheMemory.getNumElements() - 1;
-
-  // We might need an extra bit to check if self was consumed.
-  if (HasConditionalSelfInitialized)
-    ++NumMemoryElements;
 
   // Utilities.
 


### PR DESCRIPTION
Exact warning text:
```
swift/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp:3239:12: warning: variable 'NumMemoryElements' set but not used [-Wunused-but-set-variable]
  unsigned NumMemoryElements = TheMemory.getNumElements();
           ^
1 warning generated.
```
