### PR TITLE
Provide support for live priority escalation in the task runtime

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -2343,8 +2343,6 @@ public:
 
 /// Kinds of task status record.
 enum class TaskStatusRecordKind : uint8_t {
-  /// A DeadlineStatusRecord, which represents an active deadline.
-  Deadline = 0,
 
   /// A ChildTaskStatusRecord, which represents the potential for
   /// active child tasks.

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -92,7 +92,7 @@ enum class MetadataKind : uint32_t {
 #define ABSTRACTMETADATAKIND(name, start, end)                                 \
   name##_Start = start, name##_End = end,
 #include "MetadataKind.def"
-  
+
   /// The largest possible non-isa-pointer metadata kind value.
   ///
   /// This is included in the enumeration to prevent against attempts to
@@ -473,7 +473,7 @@ class ProtocolDescriptorFlags {
   };
 
   int_type Data;
-  
+
   constexpr ProtocolDescriptorFlags(int_type Data) : Data(Data) {}
 public:
   constexpr ProtocolDescriptorFlags() : Data(0) {}
@@ -498,7 +498,7 @@ public:
   constexpr ProtocolDescriptorFlags withResilient(bool s) const {
     return ProtocolDescriptorFlags((Data & ~IsResilient) | (s ? IsResilient : 0));
   }
-  
+
   /// Was the protocol defined in Swift 1 or 2?
   bool isSwift() const { return Data & IsSwift; }
 
@@ -506,24 +506,24 @@ public:
   ProtocolClassConstraint getClassConstraint() const {
     return ProtocolClassConstraint(bool(Data & ClassConstraint));
   }
-  
+
   /// What dispatch strategy does this protocol use?
   ProtocolDispatchStrategy getDispatchStrategy() const {
     return ProtocolDispatchStrategy((Data & DispatchStrategyMask)
                                       >> DispatchStrategyShift);
   }
-  
+
   /// Does the protocol require a witness table for method dispatch?
   bool needsWitnessTable() const {
     return swift::protocolRequiresWitnessTable(getDispatchStrategy());
   }
-  
+
   /// Return the identifier if this is a special runtime-known protocol.
   SpecialProtocol getSpecialProtocol() const {
     return SpecialProtocol(uint8_t((Data & SpecialProtocolMask)
                                  >> SpecialProtocolShift));
   }
-  
+
   /// Can new requirements with default witnesses be added resiliently?
   bool isResilient() const { return Data & IsResilient; }
 
@@ -784,11 +784,11 @@ public:
     return ExistentialTypeFlags((Data & ~SpecialProtocolMask)
                                   | (int_type(sp) << SpecialProtocolShift));
   }
-  
+
   unsigned getNumWitnessTables() const {
     return Data & NumWitnessTablesMask;
   }
-  
+
   ProtocolClassConstraint getClassConstraint() const {
     return ProtocolClassConstraint(bool(Data & ClassConstraintMask));
   }
@@ -803,7 +803,7 @@ public:
     return SpecialProtocol(uint8_t((Data & SpecialProtocolMask)
                                      >> SpecialProtocolShift));
   }
-  
+
   int_type getIntValue() const {
     return Data;
   }
@@ -998,7 +998,7 @@ class TargetFunctionTypeFlags {
     // NOTE: The next bit will need to introduce a separate flags word.
   };
   int_type Data;
-  
+
   constexpr TargetFunctionTypeFlags(int_type Data) : Data(Data) {}
 public:
   constexpr TargetFunctionTypeFlags() : Data(0) {}
@@ -1007,7 +1007,7 @@ public:
   withNumParameters(unsigned numParams) const {
     return TargetFunctionTypeFlags((Data & ~NumParametersMask) | numParams);
   }
-  
+
   constexpr TargetFunctionTypeFlags<int_type>
   withConvention(FunctionMetadataConvention c) const {
     return TargetFunctionTypeFlags((Data & ~ConventionMask)
@@ -1088,11 +1088,11 @@ public:
   int_type getIntValue() const {
     return Data;
   }
-  
+
   static TargetFunctionTypeFlags<int_type> fromIntValue(int_type Data) {
     return TargetFunctionTypeFlags(Data);
   }
-  
+
   bool operator==(TargetFunctionTypeFlags<int_type> other) const {
     return Data == other.Data;
   }
@@ -1458,32 +1458,32 @@ constexpr unsigned WitnessTableFirstRequirementOffset = 1;
 enum class ContextDescriptorKind : uint8_t {
   /// This context descriptor represents a module.
   Module = 0,
-  
+
   /// This context descriptor represents an extension.
   Extension = 1,
-  
+
   /// This context descriptor represents an anonymous possibly-generic context
   /// such as a function body.
   Anonymous = 2,
 
   /// This context descriptor represents a protocol context.
   Protocol = 3,
-  
+
   /// This context descriptor represents an opaque type alias.
   OpaqueType = 4,
 
   /// First kind that represents a type of any sort.
   Type_First = 16,
-  
+
   /// This context descriptor represents a class.
   Class = Type_First,
-  
+
   /// This context descriptor represents a struct.
   Struct = Type_First + 1,
-  
+
   /// This context descriptor represents an enum.
   Enum = Type_First + 2,
-  
+
   /// Last kind that represents a type of any sort.
   Type_Last = 31,
 };
@@ -1514,34 +1514,34 @@ public:
   constexpr ContextDescriptorKind getKind() const {
     return ContextDescriptorKind(Value & 0x1Fu);
   }
-  
+
   /// Whether the context being described is generic.
   constexpr bool isGeneric() const {
     return (Value & 0x80u) != 0;
   }
-  
+
   /// Whether this is a unique record describing the referenced context.
   constexpr bool isUnique() const {
     return (Value & 0x40u) != 0;
   }
-  
+
   /// The format version of the descriptor. Higher version numbers may have
   /// additional fields that aren't present in older versions.
   constexpr uint8_t getVersion() const {
     return (Value >> 8u) & 0xFFu;
   }
-  
+
   /// The most significant two bytes of the flags word, which can have
   /// kind-specific meaning.
   constexpr uint16_t getKindSpecificFlags() const {
     return (Value >> 16u) & 0xFFFFu;
   }
-  
+
   constexpr ContextDescriptorFlags withKind(ContextDescriptorKind kind) const {
     return assert((uint8_t(kind) & 0x1F) == uint8_t(kind)),
       ContextDescriptorFlags((Value & 0xFFFFFFE0u) | uint8_t(kind));
   }
-  
+
   constexpr ContextDescriptorFlags withGeneric(bool isGeneric) const {
     return ContextDescriptorFlags((Value & 0xFFFFFF7Fu)
                                   | (isGeneric ? 0x80u : 0));
@@ -1560,7 +1560,7 @@ public:
   withKindSpecificFlags(uint16_t flags) const {
     return ContextDescriptorFlags((Value & 0xFFFFu) | (flags << 16u));
   }
-  
+
   constexpr uint32_t getIntValue() const {
     return Value;
   }
@@ -1591,7 +1591,7 @@ class TypeContextDescriptorFlags : public FlagSet<uint16_t> {
     /// Meaningful for all type-descriptor kinds.
     HasImportInfo = 2,
 
-    /// Set if the type descriptor has a pointer to a list of canonical 
+    /// Set if the type descriptor has a pointer to a list of canonical
     /// prespecializations.
     HasCanonicalMetadataPrespecializations = 3,
 
@@ -1780,13 +1780,13 @@ public:
 enum class GenericParamKind : uint8_t {
   /// A type parameter.
   Type = 0,
-  
+
   Max = 0x3F,
 };
 
 class GenericParamDescriptor {
   uint8_t Value;
-  
+
   explicit constexpr GenericParamDescriptor(uint8_t Value)
     : Value(Value) {}
 public:
@@ -1798,7 +1798,7 @@ public:
                          .withKeyArgument(hasKeyArgument)
                          .withExtraArgument(hasExtraArgument))
   {}
-  
+
   constexpr bool hasKeyArgument() const {
     return (Value & 0x80u) != 0;
   }
@@ -1810,24 +1810,24 @@ public:
   constexpr GenericParamKind getKind() const {
     return GenericParamKind(Value & 0x3Fu);
   }
-  
+
   constexpr GenericParamDescriptor
   withKeyArgument(bool hasKeyArgument) const {
     return GenericParamDescriptor((Value & 0x7Fu)
       | (hasKeyArgument ? 0x80u : 0));
   }
-  
+
   constexpr GenericParamDescriptor
   withExtraArgument(bool hasExtraArgument) const {
     return GenericParamDescriptor((Value & 0xBFu)
       | (hasExtraArgument ? 0x40u : 0));
   }
-  
+
   constexpr GenericParamDescriptor withKind(GenericParamKind kind) const {
     return assert((uint8_t(kind) & 0x3Fu) == uint8_t(kind)),
       GenericParamDescriptor((Value & 0xC0u) | uint8_t(kind));
   }
-  
+
   constexpr uint8_t getIntValue() const {
     return Value;
   }
@@ -1881,7 +1881,7 @@ enum class GenericRequirementKind : uint8_t {
 
 class GenericRequirementFlags {
   uint32_t Value;
-  
+
   explicit constexpr GenericRequirementFlags(uint32_t Value)
     : Value(Value) {}
 public:
@@ -1893,7 +1893,7 @@ public:
                          .withKeyArgument(hasKeyArgument)
                          .withExtraArgument(hasExtraArgument))
   {}
-  
+
   constexpr bool hasKeyArgument() const {
     return (Value & 0x80u) != 0;
   }
@@ -1905,25 +1905,25 @@ public:
   constexpr GenericRequirementKind getKind() const {
     return GenericRequirementKind(Value & 0x1Fu);
   }
-  
+
   constexpr GenericRequirementFlags
   withKeyArgument(bool hasKeyArgument) const {
     return GenericRequirementFlags((Value & 0x7Fu)
       | (hasKeyArgument ? 0x80u : 0));
   }
-  
+
   constexpr GenericRequirementFlags
   withExtraArgument(bool hasExtraArgument) const {
     return GenericRequirementFlags((Value & 0xBFu)
       | (hasExtraArgument ? 0x40u : 0));
   }
-  
+
   constexpr GenericRequirementFlags
   withKind(GenericRequirementKind kind) const {
     return assert((uint8_t(kind) & 0x1Fu) == uint8_t(kind)),
       GenericRequirementFlags((Value & 0xE0u) | uint8_t(kind));
   }
-  
+
   constexpr uint32_t getIntValue() const {
     return Value;
   }
@@ -2343,6 +2343,9 @@ public:
 
 /// Kinds of task status record.
 enum class TaskStatusRecordKind : uint8_t {
+  /// A TaskDependencyStatusRecord which tracks what the current task is
+  /// dependent on.
+  TaskDependency = 0,
 
   /// A ChildTaskStatusRecord, which represents the potential for
   /// active child tasks.

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -325,7 +325,7 @@ public:
 
   /// Flag that this task is now completed. This normally does not do anything
   /// but can be used to locally insert logging.
-  void flagAsCompleted();
+  void flagAsDestroyed();
 
   /// Check whether this task has been cancelled.
   /// Checking this is, of course, inherently race-prone on its own.

--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -37,8 +37,10 @@ class Job;
 struct OpaqueValue;
 struct SwiftError;
 class TaskStatusRecord;
+class TaskDependencyStatusRecord;
 class TaskOptionRecord;
 class TaskGroup;
+class ContinuationAsyncContext;
 
 extern FullMetadata<DispatchClassMetadata> jobHeapMetadata;
 
@@ -316,9 +318,18 @@ public:
   /// ActiveTask.
   void flagAsRunning();
 
-  /// Flag that this task is now suspended.
-  void flagAsSuspended();
+  /// Flag that this task is now suspended with information about what it is
+  /// waiting on.
+  void flagAsSuspendedOnTask(AsyncTask *task);
+  void flagAsSuspendedOnContinuation(ContinuationAsyncContext *context);
+  void flagAsSuspendedOnTaskGroup(TaskGroup *taskGroup);
 
+private:
+  // Helper function
+  void flagAsSuspended(TaskDependencyStatusRecord *dependencyStatusRecord);
+  void destroyTaskDependency(TaskDependencyStatusRecord *dependencyRecord);
+
+public:
   /// Flag that the task is to be enqueued on the provided executor and actually
   /// enqueue it
   void flagAsAndEnqueueOnExecutor(ExecutorRef newExecutor);

--- a/include/swift/ABI/TaskStatus.h
+++ b/include/swift/ABI/TaskStatus.h
@@ -179,7 +179,7 @@ public:
 
     auto oldLastChild = LastChild;
     LastChild = child;
-    
+
     if (!FirstChild) {
       // This is the first child we ever attach, so store it as FirstChild.
       FirstChild = child;
@@ -198,7 +198,7 @@ public:
       }
       return;
     }
-    
+
     AsyncTask *prev = FirstChild;
     // Remove the child from the linked list, i.e.:
     //     prev -> afterPrev -> afterChild
@@ -290,6 +290,78 @@ public:
   static bool classof(const TaskStatusRecord *record) {
     return record->getKind() == TaskStatusRecordKind::EscalationNotification;
   }
+};
+
+// This record is allocated for a task to record what it is dependent on before
+// the task can make progress again.
+class TaskDependencyStatusRecord : public TaskStatusRecord {
+  // A word sized storage which references what this task is suspended waiting
+  // for. Note that this is different from the waitQueue in the future fragment
+  // of a task since that denotes all the tasks which this specific task, will
+  // unblock.
+  //
+  // This field is only really pointing to something valid when the
+  // ActiveTaskStatus specifies that the task is suspended. It can be accessed
+  // asynchronous to the task during escalation which will therefore require the
+  // task status record lock for synchronization.
+  //
+  // When a task has TaskDependencyStatusRecord in the status record list, it
+  // must be the innermost status record, barring the status record lock which
+  // could be taken while this record is present.
+  //
+  // The type of thing we are waiting on, is specified in the enum below
+  union {
+    // This task is suspended waiting on another task. This could be an async
+    // let child task or it could be another unstructured task.
+    AsyncTask *Task;
+
+    // This task is suspended waiting on its continuation to be resumed. The
+    // ContinuationAsyncContext here belongs to this task itself and so we just
+    // stash the pointer here (no +1 or anything taken)
+    ContinuationAsyncContext *Continuation;
+
+    // This task is suspended waiting on the child tasks in the task group to
+    // return with results. Only the task which created the task group can
+    // create this dependency and be suspended waiting for the group - as a
+    // result, it is guaranteed to always have a reference to the task group for
+    // the duration of the wait. We do not need to take an additional +1 on this
+    // task group in this dependency record.
+    TaskGroup *TaskGroup;
+  } WaitingOn;
+
+  // Enum specifying the type of dependency this task has
+  enum DependencyKind {
+    WaitingOnTask = 1,
+    WaitingOnContinuation,
+    WaitingOnTaskGroup,
+  } DependencyKind;
+
+public:
+  TaskDependencyStatusRecord(AsyncTask *task) :
+    TaskStatusRecord(TaskStatusRecordKind::TaskDependency),
+        DependencyKind(WaitingOnTask) {
+      WaitingOn.Task = task;
+  }
+
+  TaskDependencyStatusRecord(ContinuationAsyncContext *context) :
+    TaskStatusRecord(TaskStatusRecordKind::TaskDependency),
+        DependencyKind(WaitingOnContinuation) {
+      WaitingOn.Continuation = context;
+  }
+
+  TaskDependencyStatusRecord(TaskGroup *taskGroup) :
+    TaskStatusRecord(TaskStatusRecordKind::TaskDependency),
+        DependencyKind(WaitingOnTaskGroup) {
+      WaitingOn.TaskGroup = taskGroup;
+  }
+
+  void destroy() { }
+
+  static bool classof(const TaskStatusRecord *record) {
+    return record->getKind() == TaskStatusRecordKind::TaskDependency;
+  }
+
+  void performEscalationAction(JobPriority newPriority);
 };
 
 } // end namespace swift

--- a/include/swift/ABI/TaskStatus.h
+++ b/include/swift/ABI/TaskStatus.h
@@ -79,38 +79,6 @@ public:
   void spliceParent(TaskStatusRecord *newParent) { Parent = newParent; }
 };
 
-/// A deadline for the task.  If this is reached, the task will be
-/// automatically cancelled.  The deadline can also be queried and used
-/// in other ways.
-struct TaskDeadline {
-  // FIXME: I don't really know what this should look like right now.
-  // It's probably target-specific.
-  uint64_t Value;
-
-  bool operator==(const TaskDeadline &other) const {
-    return Value == other.Value;
-  }
-  bool operator<(const TaskDeadline &other) const {
-    return Value < other.Value;
-  }
-};
-
-/// A status record which states that there's an active deadline
-/// within the task.
-class DeadlineStatusRecord : public TaskStatusRecord {
-  TaskDeadline Deadline;
-
-public:
-  DeadlineStatusRecord(TaskDeadline deadline)
-      : TaskStatusRecord(TaskStatusRecordKind::Deadline), Deadline(deadline) {}
-
-  TaskDeadline getDeadline() const { return Deadline; }
-
-  static bool classof(const TaskStatusRecord *record) {
-    return record->getKind() == TaskStatusRecordKind::Deadline;
-  }
-};
-
 /// A status record which states that a task has one or
 /// more active child tasks.
 class ChildTaskStatusRecord : public TaskStatusRecord {

--- a/include/swift/ABI/TaskStatus.h
+++ b/include/swift/ABI/TaskStatus.h
@@ -22,21 +22,26 @@
 
 #include "swift/ABI/MetadataValues.h"
 #include "swift/ABI/Task.h"
+#include "swift/Runtime/HeapObject.h"
 
 namespace swift {
 
 /// The abstract base class for all status records.
 ///
-/// TaskStatusRecords are typically allocated on the stack (possibly
-/// in the task context), partially initialized, and then atomically
-/// added to the task with `swift_task_addTaskStatusRecord`.  While
-/// registered with the task, a status record should only be
-/// modified in ways that respect the possibility of asynchronous
-/// access by a cancelling thread.  In particular, the chain of
-/// status records must not be disturbed.  When the task leaves
-/// the scope that requires the status record, the record can
-/// be unregistered from the task with `removeStatusRecord`,
-/// at which point the memory can be returned to the system.
+/// TaskStatusRecords are typically allocated on the stack (possibly in the task
+/// context), partially initialized, and then atomically added to the task with
+/// `addStatusRecord`.
+///
+/// Status records currently are only added to a task by itself but they may be
+/// removed from the task by other threads, or accessed by other threads
+/// asynchronous to the task for other purposes.
+///
+/// As a result, while registered with the task, a status record should only be
+/// modified in ways that respect the possibility of asynchronous access by a
+/// different thread.  In particular, the chain of status records must not be
+/// disturbed. When the task leaves the scope that requires the status record,
+/// the record can be unregistered from the task with `removeStatusRecord`, at
+/// which point the memory can be returned to the system.
 class TaskStatusRecord {
 public:
   TaskStatusRecordFlags Flags;

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -20,7 +20,6 @@
 #include "swift/ABI/AsyncLet.h"
 #include "swift/ABI/Task.h"
 #include "swift/ABI/TaskGroup.h"
-#include "swift/ABI/TaskStatus.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wreturn-type-c-linkage"

--- a/include/swift/Runtime/Concurrency.h
+++ b/include/swift/Runtime/Concurrency.h
@@ -643,31 +643,6 @@ void swift_task_localValuePop();
 SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
 void swift_task_localsCopyTo(AsyncTask* target);
 
-/// This should have the same representation as an enum like this:
-///    enum NearestTaskDeadline {
-///      case none
-///      case alreadyCancelled
-///      case active(TaskDeadline)
-///    }
-/// TODO: decide what this interface should really be.
-struct NearestTaskDeadline {
-  enum Kind : uint8_t {
-    None,
-    AlreadyCancelled,
-    Active
-  };
-
-  TaskDeadline Value;
-  Kind ValueKind;
-};
-
-/// Returns the nearest deadline that's been registered with this task.
-///
-/// This must be called synchronously with the task.
-SWIFT_EXPORT_FROM(swift_Concurrency) SWIFT_CC(swift)
-NearestTaskDeadline
-swift_task_getNearestDeadline(AsyncTask *task);
-
 /// Switch the current task to a new executor if we aren't already
 /// running on a compatible executor.
 ///

--- a/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverrideConcurrency.def
@@ -373,10 +373,6 @@ OVERRIDE_TASK_STATUS(task_escalate, JobPriority,
                      swift::, (AsyncTask *task, JobPriority newPriority),
                      (task, newPriority))
 
-OVERRIDE_TASK_STATUS(task_getNearestDeadline, NearestTaskDeadline,
-                     SWIFT_EXPORT_FROM(swift_Concurrency), SWIFT_CC(swift),
-                     swift::, (AsyncTask *task), (task))
-
 #undef OVERRIDE
 #undef OVERRIDE_ACTOR
 #undef OVERRIDE_TASK

--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -150,7 +150,7 @@ void swift::asyncLet_addImpl(AsyncTask *task, AsyncLet *asyncLet,
   // ok, now that the async let task actually is initialized: attach it to the
   // current task
   bool addedRecord =
-      addStatusRecord(record, [&](ActiveTaskStatus parentStatus) {
+      addStatusRecord(record, [&](ActiveTaskStatus parentStatus, ActiveTaskStatus& newStatus) {
         updateNewChildWithParentAndGroupState(task, parentStatus, NULL);
         return true;
       });

--- a/stdlib/public/Concurrency/GlobalExecutor.cpp
+++ b/stdlib/public/Concurrency/GlobalExecutor.cpp
@@ -23,7 +23,7 @@
 /// resource or memory.  Concurrent executors are usually used to
 /// manage a pool of threads and prevent the number of allocated
 /// threads from growing without limit.
-/// 
+///
 /// Second, executors may own dedicated threads, or they may schedule
 /// work onto some underlying executor.  Dedicated threads can
 /// improve the responsiveness of a subsystem *locally*, but they impose
@@ -41,7 +41,7 @@
 /// of threads.  Having multiple independent concurrent executors
 /// with their own dedicated threads would undermine that.
 /// Therefore, it is sensible to have a single, global executor
-/// that will ultimately schedule most of the work in the system.  
+/// that will ultimately schedule most of the work in the system.
 /// With that as a baseline, special needs can be recognized and
 /// carved out from the global executor with its cooperation.
 ///

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -330,7 +330,7 @@ static void destroyJob(SWIFT_CONTEXT HeapObject *obj) {
 }
 
 AsyncTask::~AsyncTask() {
-  flagAsCompleted();
+  flagAsDestroyed();
 
   // For a future, destroy the result.
   if (isFuture()) {
@@ -372,7 +372,7 @@ static void destroyTask(SWIFT_CONTEXT HeapObject *obj) {
   // the task-local allocator.  There's actually nothing else to clean up
   // here.
 
-  SWIFT_TASK_DEBUG_LOG("destroy task %p", task);
+  SWIFT_TASK_DEBUG_LOG("Destroyed task %p", task);
   free(task);
 }
 

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1533,8 +1533,8 @@ swift_task_addCancellationHandlerImpl(
 
   bool fireHandlerNow = false;
 
-  addStatusRecord(record, [&](ActiveTaskStatus parentStatus) {
-    if (parentStatus.isCancelled()) {
+  addStatusRecord(record, [&](ActiveTaskStatus oldStatus, ActiveTaskStatus& newStatus) {
+    if (oldStatus.isCancelled()) {
       fireHandlerNow = true;
       // We don't fire the cancellation handler here since this function needs
       // to be idempotent

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -1008,8 +1008,8 @@ extension Task where Failure == Error {
   public static func runInline(_ body: () async throws -> Success) rethrows -> Success {
     return try _runInlineHelper(
       body: {
-        do { 
-          let value = try await body() 
+        do {
+          let value = try await body()
           return Result.success(value)
         }
         catch let error {

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -888,10 +888,10 @@ static void swift_taskGroup_initializeWithFlagsImpl(size_t rawGroupFlags,
   assert(record->getKind() == swift::TaskStatusRecordKind::TaskGroup);
 
   // ok, now that the group actually is initialized: attach it to the task
-  addStatusRecord(record, [&](ActiveTaskStatus parentStatus) {
+  addStatusRecord(record, [&](ActiveTaskStatus oldStatus, ActiveTaskStatus& newStatus) {
     // If the task has already been cancelled, reflect that immediately in
     // the group's status.
-    if (parentStatus.isCancelled()) {
+    if (oldStatus.isCancelled()) {
       impl->statusCancel();
     }
     return true;

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -1592,7 +1592,7 @@ reevaluate_if_taskgroup_has_results:;
   while (true) {
     if (!hasSuspended) {
       hasSuspended = true;
-      waitingTask->flagAsSuspended();
+      waitingTask->flagAsSuspendedOnTaskGroup(asAbstract(this));
     }
     // Put the waiting task at the beginning of the wait queue.
     if (waitQueue.compare_exchange_strong(
@@ -1758,7 +1758,7 @@ PollResult TaskGroupBase::tryEnqueueWaitingTask(AsyncTask *waitingTask) {
   while (true) {
     if (!hasSuspended) {
       hasSuspended = true;
-      waitingTask->flagAsSuspended();
+      waitingTask->flagAsSuspendedOnTaskGroup(asAbstract(this));
     }
     // Put the waiting task at the beginning of the wait queue.
     if (waitQueue.compare_exchange_strong(

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -287,11 +287,9 @@ class alignas(2 * sizeof(void*)) ActiveTaskStatus {
     /// or is completed.
     IsEnqueued = 0x1000,
 
-#ifndef NDEBUG
     /// Task has been completed.  This is purely used to enable an assertion
     /// that the task is completed when we destroy it.
     IsComplete = 0x2000,
-#endif
   };
 
   // Note: this structure is mirrored by ActiveTaskStatusWithEscalation and
@@ -409,7 +407,6 @@ public:
 #endif
   }
 
-#ifndef NDEBUG
   bool isComplete() const {
     return Flags & IsComplete;
   }
@@ -421,7 +418,6 @@ public:
     return ActiveTaskStatus(Record, Flags | IsComplete);
 #endif
   }
-#endif
 
   /// Is there a lock on the linked list of status records?
   bool isStatusRecordLocked() const { return Flags & IsStatusRecordLocked; }
@@ -596,9 +592,7 @@ struct AsyncTask::PrivateStorage {
       auto newStatus = oldStatus.withRunning(false);
       newStatus = newStatus.withoutStoredPriorityEscalation();
       newStatus = newStatus.withoutEnqueued();
-#ifndef NDEBUG
       newStatus = newStatus.withComplete();
-#endif
 
       // This can fail since the task can still get concurrently cancelled or
       // escalated.
@@ -615,10 +609,22 @@ struct AsyncTask::PrivateStorage {
       }
     }
 
-    // Destroy and deallocate any remaining task local items.
-    // We need to do this before we destroy the task local deallocator.
+    // Destroy and deallocate any remaining task local items since the task is
+    // completed. We need to do this before we destroy the task local
+    // deallocator.
     Local.destroy(task);
 
+    // Don't destroy the task private storage as a whole since others which have
+    // a reference to the task might still need to access the ActiveTaskStatus.
+    // It is destroyed when task is destroyed
+  }
+
+  // Destroy the opaque storage of the task
+  void destroy() {
+#if NDEBUG
+    auto oldStatus = task->_private()._status().load(std::memory_order_relaxed);
+    assert(oldStatus.isComplete());
+#endif
     this->~PrivateStorage();
   }
 
@@ -653,11 +659,13 @@ inline void AsyncTask::OpaquePrivateStorage::initializeWithSlab(
     JobPriority basePri, void *slab, size_t slabCapacity) {
   ::new (this) PrivateStorage(basePri, slab, slabCapacity);
 }
+
 inline void AsyncTask::OpaquePrivateStorage::complete(AsyncTask *task) {
   get().complete(task);
 }
+
 inline void AsyncTask::OpaquePrivateStorage::destroy() {
-  // nothing else to do
+  get().destroy();
 }
 
 inline AsyncTask::PrivateStorage &AsyncTask::_private() {
@@ -822,10 +830,10 @@ inline void AsyncTask::flagAsSuspended() {
 }
 
 // READ ME: This is not a dead function! Do not remove it! This is a function
-// that can be used when debugging locally to instrument when a task actually is
-// dealloced.
-inline void AsyncTask::flagAsCompleted() {
-  SWIFT_TASK_DEBUG_LOG("task completed %p", this);
+// that can be used when debugging locally to instrument when a task
+// actually is dealloced.
+inline void AsyncTask::flagAsDestroyed() {
+  SWIFT_TASK_DEBUG_LOG("task destroyed %p", this);
 }
 
 inline void AsyncTask::localValuePush(const HeapObject *key,

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -21,6 +21,7 @@
 #include "swift/Runtime/AtomicWaitQueue.h"
 #include "swift/Runtime/Concurrency.h"
 #include "swift/Threading/Mutex.h"
+#include "swift/Threading/Thread.h"
 #include <atomic>
 
 using namespace swift;
@@ -57,16 +58,29 @@ namespace {
 /// record and clears the lock bit, then notifies the lock record that
 /// the locking operation is complete.
 ///
+/// Note that this status record lock only protects concurrent
+/// modifications/access from *other* threads which may be trying to
+/// inspect/modify a task's status records. A thread which already
+/// owns the StatusRecordLock may recursively take it and modify
+/// the status record list.
+///
 /// When a task wants to iterate task status records, but
 /// it sees that the locked bit is set in the `Status` field, it
 /// must acquire the global status-record lock, find this record
-/// (which should be the innermost record), and wait for an unlock.
+/// (which should be the innermost record), and wait for an unlock if
+/// the the task is not the lock owner. If it already owns the
+/// status record lock, it may proceed.
+///
 class StatusRecordLockRecord
     : public AtomicWaitQueue<StatusRecordLockRecord, LazyMutex>,
       public TaskStatusRecord {
+  Thread Owner;
 public:
+
   StatusRecordLockRecord(TaskStatusRecord *parent)
     : TaskStatusRecord(TaskStatusRecordKind::Private_RecordLock, parent) {
+    // When we create a lock record, we always take it pre-locked
+    Owner = Thread::current();
   }
 
   void updateForNewArguments(TaskStatusRecord *parent) {
@@ -76,10 +90,55 @@ public:
   static bool classof(const TaskStatusRecord *record) {
     return record->getKind() == TaskStatusRecordKind::Private_RecordLock;
   }
+
+  bool isStatusRecordLockedBySelf() {
+    return Owner == Thread::current();
+  }
+
 };
 }
 
-/// Wait for a task's status record lock to be unlocked.
+/// If the status record is already self locked, returns true
+///
+/// If the status record is not self locked, then wait for the owner to unlock
+/// before we return. We still have to retry getting the lock ourselves and may
+/// still run into a race here.
+static bool waitForStatusRecordUnlockIfNotSelfLocked(AsyncTask *task,
+  ActiveTaskStatus &oldStatus) {
+  // Acquire the lock.
+  StatusRecordLockRecord::Waiter waiter(StatusRecordLockLock);
+
+  while (true) {
+    assert(oldStatus.isStatusRecordLocked());
+    bool selfLocked = false;
+
+    bool waited = waiter.tryReloadAndWait([&]() -> StatusRecordLockRecord* {
+      // Check that oldStatus is still correct.
+      oldStatus = task->_private()._status().load(std::memory_order_acquire);
+
+      if (!oldStatus.isStatusRecordLocked())
+        return nullptr;
+
+      auto record = cast<StatusRecordLockRecord>(oldStatus.getInnermostRecord());
+      if (record->isStatusRecordLockedBySelf()) {
+        selfLocked = true;
+        return nullptr;
+      }
+      return record;
+    });
+
+    if (!waited)
+      return selfLocked;
+
+    // Reload the status before trying to relock.
+    oldStatus = task->_private()._status().load(std::memory_order_acquire);
+    if (!oldStatus.isStatusRecordLocked())
+      return false;
+  }
+}
+
+/// Wait for a task's status record lock to be unlocked. This asserts that the
+/// lock is not owned by self as that would result in a deadlock.
 ///
 /// When this function returns, `oldStatus` will have been updated
 /// to the last value read and `isStatusRecordLocked()` will be false.
@@ -99,10 +158,13 @@ static void waitForStatusRecordUnlock(AsyncTask *task,
       if (!oldStatus.isStatusRecordLocked())
         return nullptr;
 
-      // The innermost entry should be a record lock record; wait
-      // for it to be unlocked.
-      auto record = oldStatus.getInnermostRecord();
-      return cast<StatusRecordLockRecord>(record);
+      // The innermost entry should be a record lock record; Verify that we are
+      // not the owner and then wait for it to be unlocked.
+      auto record = cast<StatusRecordLockRecord>(oldStatus.getInnermostRecord());
+      if (record->isStatusRecordLockedBySelf()) {
+        swift_Concurrency_fatalError(0, "Waiting on a status record lock that is owned by self");
+      }
+      return record;
     });
     if (!waited)
       return;
@@ -123,23 +185,33 @@ enum class LockContext {
   OtherAsynchronous
 };
 
+// We can do this because a task can only add status records to itself. If we
+// ever change addStatusRecord to allow it to add status records to a different
+// task, we will need to revisit this.
 static std::memory_order getLoadOrdering(LockContext lockContext) {
   return lockContext != LockContext::OnTask
                           ? std::memory_order_acquire
                           : std::memory_order_relaxed;
 }
 
-/// Call the given function while holding the task status record lock.
+/// Makes sure to call the `fn` while holding the StatusRecordLock of the
+/// input task.
 ///
-/// The value in `status` will be updated with the current status value
-/// (ignoring the `TaskStatusLockRecord`) before calling the function,
-/// and the value there will be written back into the task status after
-/// calling the function.
-template <class Fn>
+/// If the client of withStatusRecordLock has already loaded the status of the
+/// task with the right barriers, they may pass it into this function to avoid a
+/// double-load.
+///
+/// The input `fn` is invoked once while holding the status record lock.
+///
+/// The optional `statusUpdate` is invoked while releasing the StatusRecordLock
+/// from the ActiveTaskStatus so that callers may make additional modifications
+/// to ActiveTaskStatus flags. `statusUpdate` can be called multiple times in a
+/// RMW loop and so much be idempotent.
 static bool withStatusRecordLock(AsyncTask *task,
-                                 LockContext lockContext,
-                                 ActiveTaskStatus &status,
-                                 Fn &&fn) {
+    LockContext lockContext, ActiveTaskStatus status,
+    llvm::function_ref<void(ActiveTaskStatus)>fn,
+    llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus&)> statusUpdate = nullptr) {
+
   StatusRecordLockRecord::Worker worker(StatusRecordLockLock);
 
   auto loadOrdering = getLoadOrdering(lockContext);
@@ -148,18 +220,23 @@ static bool withStatusRecordLock(AsyncTask *task,
   StatusRecordLockRecord *lockingRecord;
 
   // Take the lock record
+  bool installedLockRecord = false;
   while (true) {
-    // If the old info says we're locked, wait for the lock to clear.
-    if (status.isStatusRecordLocked()) {
-      waitForStatusRecordUnlock(task, status); // Will update status
-      continue;
+    if (status.isStatusRecordLocked() &&
+        waitForStatusRecordUnlockIfNotSelfLocked(task, status)) {
+      // Top record is status record lock and we own it.
+      SWIFT_TASK_DEBUG_LOG("[StatusRecordLock] Lock for task %p is already owned by thread", task);
+      break;
     }
 
-    // Make (or reconfigure) a lock record.
+    // Make (or reconfigure) a lock record
     oldRecord = status.getInnermostRecord();
     lockingRecord = worker.createQueue(oldRecord);
 
-    // Install the lock record as the top of the queue.
+    // Install the lock record as the top of the queue with a store release to
+    // publish the contents of the StatusRecordLockRecord. We will read the
+    // status with a load acquire which will pair with any store releases done
+    // by other threads also trying to acquire the lock/add new status records.
     ActiveTaskStatus newStatus = status.withLockingRecord(lockingRecord);
     if (task->_private()._status().compare_exchange_weak(status, newStatus,
             /*success*/ std::memory_order_release,
@@ -168,34 +245,44 @@ static bool withStatusRecordLock(AsyncTask *task,
 
       status.traceStatusChanged(task);
       worker.flagQueueIsPublished(lockingRecord);
+      installedLockRecord = true;
+
+      // We've locked the status
+      assert(worker.isWorkerThread());
       break;
     }
   }
 
-  // We've locked the status
-  assert(worker.isWorkerThread());
-
   // Call the function.
-  std::forward<Fn>(fn)();
+  fn(status);
 
-  // Release lock record, restore the old record at the top
-  //
-  // We may need to reload the status since other flags could have changed on it
-  // while it is locked - namely cancelled bit, max priority, isEscalated.
+  // Release lock record if we installed it earlier and restore the old record
+  // at the top.
   while (true) {
+    auto newStatus = status;
+
     assert(status.isStatusRecordLocked());
-    auto newStatus = status.withoutLockingRecord();
+    if (installedLockRecord) {
+      newStatus = status.withoutLockingRecord();
+    }
+
+    // If the caller of the function wanted to modify something, let them.
+    if (statusUpdate) {
+      statusUpdate(status, newStatus);
+    }
 
     if (task->_private()._status().compare_exchange_weak(status, newStatus,
             /*success*/ std::memory_order_relaxed,
             /*failure*/ std::memory_order_relaxed)) {
-      status.traceStatusChanged(task);
+      newStatus.traceStatusChanged(task);
       break;
     }
   }
 
-  // Unblock any waiters.
-  worker.finishAndUnpublishQueue([]{});
+  if (installedLockRecord) {
+    // Unblock any waiters.
+    worker.finishAndUnpublishQueue([]{});
+  }
 
   return true;
 }
@@ -211,8 +298,8 @@ static bool withStatusRecordLock(AsyncTask *task,
     task->_private()._status().load(loadOrdering);
   if (loadOrdering == std::memory_order_acquire)
     _swift_tsan_acquire(task);
-  return withStatusRecordLock(task, lockContext, status, [&] {
-    fn(status);
+  return withStatusRecordLock(task, lockContext, status, [&](ActiveTaskStatus taskStatus) {
+    fn(taskStatus);
   });
 }
 
@@ -223,7 +310,7 @@ static bool withStatusRecordLock(AsyncTask *task,
 SWIFT_CC(swift)
 bool swift::addStatusRecord(
     TaskStatusRecord *newRecord,
-    llvm::function_ref<bool(ActiveTaskStatus status)> shouldAddRecord) {
+    llvm::function_ref<bool(ActiveTaskStatus, ActiveTaskStatus&)> shouldAddRecord) {
 
   auto task = swift_task_getCurrent();
   // Load the current state. We can use a relaxed load because we're
@@ -232,8 +319,10 @@ bool swift::addStatusRecord(
 
   while (true) {
     // Wait for any active lock to be released.
-    if (oldStatus.isStatusRecordLocked())
-      waitForStatusRecordUnlock(task, oldStatus);
+    if (oldStatus.isStatusRecordLocked()) {
+      bool selfLocked = waitForStatusRecordUnlockIfNotSelfLocked(task, oldStatus);
+      assert(!selfLocked);
+    }
 
     // Reset the parent of the new record.
     newRecord->resetParent(oldStatus.getInnermostRecord());
@@ -241,7 +330,7 @@ bool swift::addStatusRecord(
     // Set the record as the new innermost record.
     ActiveTaskStatus newStatus = oldStatus.withInnermostRecord(newRecord);
 
-    if (shouldAddRecord(newStatus)) {
+    if (shouldAddRecord(oldStatus, newStatus)) {
       // We have to use a release on success to make the initialization of
       // the new record visible to an asynchronous thread trying to modify the
       // status records
@@ -249,6 +338,7 @@ bool swift::addStatusRecord(
       if (task->_private()._status().compare_exchange_weak(oldStatus, newStatus,
               /*success*/ std::memory_order_release,
               /*failure*/ std::memory_order_relaxed)) {
+        newStatus.traceStatusChanged(task);
         return true;
       } else {
         // Retry
@@ -259,61 +349,123 @@ bool swift::addStatusRecord(
   }
 }
 
+static void removeStatusRecordLocked(ActiveTaskStatus status, TaskStatusRecord *record) {
+  bool removedRecord = false;
+  auto cur = status.getInnermostRecord();
+  assert(cur->getKind() == TaskStatusRecordKind::Private_RecordLock);
+
+  // Splice the record out.
+  while (cur != nullptr) {
+    auto next = cur->getParent();
+    if (next == record) {
+      cur->spliceParent(record->getParent());
+      removedRecord = true;
+      break;
+    }
+    cur = next;
+  }
+  assert(removedRecord);
+}
+
+// For when we are trying to remove a record and also optionally trying to
+// modify some flags in the ActiveTaskStatus at the same time.
 SWIFT_CC(swift)
-bool swift::removeStatusRecord(TaskStatusRecord *record) {
-  auto task = swift_task_getCurrent();
-  SWIFT_TASK_DEBUG_LOG("remove status record = %p, from current task = %p",
+void swift::removeStatusRecord(AsyncTask *task, TaskStatusRecord *record,
+     llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus&)>fn = nullptr) {
+
+  SWIFT_TASK_DEBUG_LOG("remove status record = %p, from task = %p",
                        record, task);
 
   // Load the current state.
   auto &status = task->_private()._status();
   auto oldStatus = status.load(std::memory_order_relaxed);
 
-  while (true) {
-    // Wait for any active lock to be released.
-    if (oldStatus.isStatusRecordLocked())
-      waitForStatusRecordUnlock(task, oldStatus);
+  if (oldStatus.isStatusRecordLocked() &&
+        waitForStatusRecordUnlockIfNotSelfLocked(task, oldStatus)) {
+    SWIFT_TASK_DEBUG_LOG("[StatusRecordLock] Lock for task %p is already owned by thread", task);
+    // Case 1: Top record is status record lock and this thread owns it.
+    //
+    // Since we have the lock, we can just remove the record we care about which
+    // should be in the list somewhere and then modify the flags
+    removeStatusRecordLocked(oldStatus, record);
 
-    // If the record is the innermost record, try to just pop it off.
+    if (fn) {
+      // Client wants to modify the flags on the status - do it in a loop to
+      // make sure we handle other concurrent updates.
+      while (true) {
+        auto newStatus = oldStatus;
+        fn(oldStatus, newStatus);
+
+        // We should still remain status record locked no matter what since we
+        // came in with the lock already
+        assert(newStatus.isStatusRecordLocked());
+
+        if (task->_private()._status().compare_exchange_weak(oldStatus, newStatus,
+               /*success*/ std::memory_order_relaxed,
+               /*failure*/ std::memory_order_relaxed)) {
+          newStatus.traceStatusChanged(task);
+          return;
+        }
+      }
+    } else {
+      // Client doesn't have any other flags to change on status, we came in
+      // self-locked and leave with the lock held. No other flags changed.
+      return;
+    }
+  }
+
+  assert(!oldStatus.isStatusRecordLocked());
+
+  while (true) {
+    // We raced with some *other* thread which concurrently locked this task.
+    if (oldStatus.isStatusRecordLocked()) {
+      waitForStatusRecordUnlock(task, oldStatus);
+    }
+
+    // Case 2: No status record lock, see if the record we are trying to pop off
+    // is the topmost record and if so, just get it out and modify the status
+    // flags if needed
     if (oldStatus.getInnermostRecord() == record) {
-      ActiveTaskStatus newStatus =
-        oldStatus.withInnermostRecord(record->getParent());
-      if (status.compare_exchange_weak(oldStatus, newStatus,
-             /*success*/ std::memory_order_relaxed,
-             /*failure*/ std::memory_order_relaxed)) {
-        return !oldStatus.isCancelled();
+      auto newStatus = oldStatus.withInnermostRecord(record->getParent());
+
+      if (fn) {
+        fn(oldStatus, newStatus);
       }
 
-      // Otherwise, restart.
+      if (task->_private()._status().compare_exchange_weak(oldStatus, newStatus,
+             /*success*/ std::memory_order_relaxed,
+             /*failure*/ std::memory_order_relaxed)) {
+        newStatus.traceStatusChanged(task);
+        return;
+      }
+      // Restart the loop again - someone else modified status concurrently
       continue;
     }
 
-    // If the record is not the innermost record, we need to acquire the
-    // record lock; there's no way to splice the record list safely with
-    // a thread that's attempting to acquire the lock.
+    // Case 3: If the record is not the innermost record, we need to acquire the
+    // status record lock; there's no way to splice the record list safely
+    // otherwise
     break;
   }
 
-  // Acquire the status record lock.
-  withStatusRecordLock(task, LockContext::OnTask, oldStatus, [&] {
-    // We can't observe the record to be the innermost record here because
-    // that would require some other thread to be concurrently structurally
-    // changing the set of status records, but we're running
-    // synchronously with the task.
-    auto cur = oldStatus.getInnermostRecord();
-    assert(cur != record);
+  auto lockContext = (swift_task_getCurrent() == task) ? LockContext::OnTask : LockContext::OtherAsynchronous;
 
-    // Splice the record out.
-    while (true) {
-      auto next = cur->getParent();
-      if (next == record) {
-        cur->spliceParent(record->getParent());
-        break;
-      }
-    }
-  });
+  withStatusRecordLock(task, lockContext, oldStatus, [&](ActiveTaskStatus status) {
+    removeStatusRecordLocked(status, record);
+  }, fn);
 
-  return !oldStatus.isCancelled();
+}
+
+// Convenience wrapper for when we don't care to make any modifications to the
+// flags fields of the active task status when we are removing a task status
+// record
+SWIFT_CC(swift)
+void swift::removeStatusRecord(TaskStatusRecord *record) {
+
+  auto task = swift_task_getCurrent();
+  SWIFT_TASK_DEBUG_LOG("remove status record = %p, from current task = %p",
+                       record, task);
+  return removeStatusRecord(task, record);
 }
 
 SWIFT_CC(swift)
@@ -326,8 +478,7 @@ static bool swift_task_hasTaskGroupStatusRecordImpl() {
     return false;
 
   bool foundTaskGroupRecord = false;
-  withStatusRecordLock(task, LockContext::OnTask,
-                       [&](ActiveTaskStatus &status) {
+  withStatusRecordLock(task, LockContext::OnTask, [&](ActiveTaskStatus status) {
     // Scan for the task group record within all the active records.
     for (auto record: status.records()) {
       if (record->getKind() == TaskStatusRecordKind::TaskGroup) {
@@ -390,7 +541,7 @@ static void swift_taskGroup_attachChildImpl(TaskGroup *group,
   auto parent = child->childFragment()->getParent();
   assert(parent == swift_task_getCurrent());
 
-  withStatusRecordLock(parent, LockContext::OnTask, [&](ActiveTaskStatus &parentStatus) {
+  withStatusRecordLock(parent, LockContext::OnTask, [&](ActiveTaskStatus parentStatus) {
     group->addChildTask(child);
 
     // After getting parent's status record lock, do some sanity checks to
@@ -412,7 +563,7 @@ void swift::_swift_taskGroup_detachChild(TaskGroup *group,
   // though, just that it's not concurrently running.
   auto parent = child->childFragment()->getParent();
 
-  withStatusRecordLock(parent, LockContext::OnTask, [&](ActiveTaskStatus &parentStatus) {
+  withStatusRecordLock(parent, LockContext::OnTask, [&](ActiveTaskStatus unused) {
     group->removeChildTask(child);
   });
 }
@@ -499,8 +650,12 @@ static void swift_task_cancelImpl(AsyncTask *task) {
      return;
   }
 
-  withStatusRecordLock(task, LockContext::OtherAsynchronous, newStatus, [&] {
-    for (auto cur : newStatus.records()) {
+  withStatusRecordLock(task, LockContext::OtherAsynchronous, newStatus, [&](ActiveTaskStatus status) {
+    for (auto cur : status.records()) {
+      // Some of the cancellation actions can cause us to recursively
+      // modify this list that is being iterated. However, cancellation is
+      // happening from outside of the task so we know that no new records will
+      // be added since that's only possible while on task.
       performCancellationAction(cur);
     }
   });
@@ -611,9 +766,10 @@ static swift_task_escalateImpl(AsyncTask *task, JobPriority newPriority) {
     return newStatus.getStoredPriority();
   }
 
-  withStatusRecordLock(task, LockContext::OnTask, newStatus, [&] {
-    // Perform escalation operations for all the status records.
-    for (auto cur: newStatus.records()) {
+  withStatusRecordLock(task, LockContext::OtherAsynchronous, newStatus, [&](ActiveTaskStatus status) {
+    // We know that none of the escalation actions will recursively
+    // modify the task status record list by adding or removing task records
+    for (auto cur: status.records()) {
       performEscalationAction(cur, newPriority);
     }
   });

--- a/test/Concurrency/async_task_base_priority.swift
+++ b/test/Concurrency/async_task_base_priority.swift
@@ -8,7 +8,6 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 // UNSUPPORTED: back_deploy_concurrency
-// UNSUPPORTED: threading_none
 
 // rdar://101077408 – Temporarily disable on watchOS simulator
 // UNSUPPORTED: DARWIN_SIMULATOR=watchos

--- a/unittests/runtime/CompatibilityOverrideConcurrency.cpp
+++ b/unittests/runtime/CompatibilityOverrideConcurrency.cpp
@@ -255,8 +255,4 @@ TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_escalate) {
   swift_task_escalate(nullptr, {});
 }
 
-TEST_F(CompatibilityOverrideConcurrencyTest, test_swift_task_getNearestDeadline) {
-  swift_task_getNearestDeadline(nullptr);
-}
-
 #endif


### PR DESCRIPTION
Create the notion of a TaskStatusDependencyRecord which keeps track of
what a task is suspended waiting on.  A task will have this type of
status record in its task status record list for as long as it is
blocked on something else to make progress. This information can then
be used to provide *live* priority escalation if a task is escalated.
    
A task can be blocked on one of the following before it can make
progress:
(a) Another task
(b) A task group
(c) A continuation resumption
(d) A contended actor

If during this time, the task that is blocked is then escalated, we can use the 
TaskStatusDependencyRecord to push the escalation forward onto the 
thing that we are waiting on - ie priority escalation support is live
when a task is blocked on (a), (b) or (c).
    
Radar-Id: rdar://problem/88093007
