### PR TITLE
[5.8] Build-script: ensure we can target armv7k with watchOS 9 SDK

### DIFF
--- a/utils/swift_build_support/swift_build_support/targets.py
+++ b/utils/swift_build_support/swift_build_support/targets.py
@@ -122,6 +122,9 @@ class DarwinPlatform(Platform):
         # The names match up with the xcrun SDK names.
         xcrun_sdk_name = self.name
 
+        if (xcrun_sdk_name == 'watchos' and arch == 'armv7k'):
+            return True
+
         sdk_path = xcrun.sdk_path(sdk=xcrun_sdk_name, toolchain=toolchain)
         if not sdk_path:
             raise RuntimeError('Cannot find SDK path for %s' % xcrun_sdk_name)


### PR DESCRIPTION
Updating to match `SDKSettings.plist`

Addresses rdar://100563701

(cherry picked from commit 82262fc90d547a5b01207034ba213b1fd9ab292d)