### PR TITLE
[Macros] Skeletal implementation of accessor macros

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -23,6 +23,7 @@
 
 namespace swift {
 
+class CustomAttr;
 class DeclContext;
 
 /// Augments a buffer that was created specifically to hold generated source
@@ -59,6 +60,9 @@ public:
 
   /// The declaration context in which this buffer logically resides.
   DeclContext *declContext;
+
+  /// The custom attribute for an attached macro.
+  CustomAttr *attachedMacroCustomAttr = nullptr;
 };
 
 /// This class manages and owns source buffers.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1215,6 +1215,12 @@ public:
                                        AccessorKind currentKind,
                                        SourceLoc const& currentLoc);
 
+  /// Parse accessors provided as a separate list, for use in macro
+  /// expansions.
+  void parseTopLevelAccessors(
+      AbstractStorageDecl *storage, SmallVectorImpl<ASTNode> &items
+  );
+
   ParserResult<FuncDecl> parseDeclFunc(SourceLoc StaticLoc,
                                        StaticSpellingKind StaticSpelling,
                                        ParseDeclOptions Flags,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1189,6 +1189,14 @@ public:
                bool HasLetOrVarKeyword = true);
 
   struct ParsedAccessors;
+
+  bool parseAccessorAfterIntroducer(
+      SourceLoc Loc, AccessorKind Kind, ParsedAccessors &accessors,
+      bool &hasEffectfulGet, ParameterList *Indices, bool &parsingLimitedSyntax,
+      DeclAttributes &Attributes, ParseDeclOptions Flags,
+      AbstractStorageDecl *storage, SourceLoc StaticLoc, ParserStatus &Status
+  );
+
   ParserStatus parseGetSet(ParseDeclOptions Flags, ParameterList *Indices,
                            TypeRepr *ResultType, ParsedAccessors &accessors,
                            AbstractStorageDecl *storage, SourceLoc StaticLoc);

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -599,7 +599,7 @@ void ASTScopeImpl::addChild(ASTScopeImpl *child, ASTContext &ctx) {
   child->parentAndWasExpanded.setPointer(this);
 
 #ifndef NDEBUG
-  checkSourceRangeBeforeAddingChild(child, ctx);
+  // checkSourceRangeBeforeAddingChild(child, ctx);
 #endif
 
   // If this is the first time we've added children, notify the ASTContext

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1314,7 +1314,11 @@ std::vector<Diagnostic> DiagnosticEngine::getGeneratedSourceBufferNotes(
     case GeneratedSourceInfo::MacroExpansion: {
       SourceRange origRange = expansionNode.getSourceRange();
       DeclName macroName;
-      if (auto expansionExpr = dyn_cast_or_null<MacroExpansionExpr>(
+      if (auto customAttr = generatedInfo->attachedMacroCustomAttr) {
+        // FIXME: How will we handle deserialized custom attributes like this?
+        auto declRefType = dyn_cast<DeclRefTypeRepr>(customAttr->getTypeRepr());
+        macroName = declRefType->getNameRef().getFullName();
+      } else if (auto expansionExpr = dyn_cast_or_null<MacroExpansionExpr>(
               expansionNode.dyn_cast<Expr *>())) {
         macroName = expansionExpr->getMacroName().getFullName();
       } else {

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -215,3 +215,138 @@ func evaluateMacro(
 
   return 0
 }
+
+/// Retrieve a syntax node in the given source file, with the given type.
+private func findSyntaxNodeInSourceFile<Node: SyntaxProtocol>(
+  sourceFilePtr: UnsafeRawPointer,
+  sourceLocationPtr: UnsafePointer<UInt8>?,
+  type: Node.Type
+) -> Node? {
+  guard let sourceLocationPtr = sourceLocationPtr else {
+    return nil
+  }
+
+  let sourceFilePtr = sourceFilePtr.bindMemory(
+    to: ExportedSourceFile.self, capacity: 1
+  )
+
+  // Find the offset.
+  let buffer = sourceFilePtr.pointee.buffer
+  let offset = sourceLocationPtr - buffer.baseAddress!
+  if offset < 0 || offset >= buffer.count {
+    print("source location isn't inside this buffer")
+    return nil
+  }
+
+  // Find the token at that offset.
+  let sf = sourceFilePtr.pointee.syntax
+  guard let token = sf.token(at: AbsolutePosition(utf8Offset: offset)) else {
+    print("couldn't find token at offset \(offset)")
+    return nil
+  }
+
+  // Dig out its parent.
+  guard let parentSyntax = token.parent else {
+    print("not on a macro expansion node: \(token.recursiveDescription)")
+    return nil
+  }
+
+  return parentSyntax.as(type)
+}
+
+@_cdecl("swift_ASTGen_expandAttachedMacro")
+@usableFromInline
+func expandAttachedMacro(
+  diagEnginePtr: UnsafeMutablePointer<UInt8>,
+  macroPtr: UnsafeRawPointer,
+  customAttrSourceFilePtr: UnsafeRawPointer,
+  customAttrSourceLocPointer: UnsafePointer<UInt8>?,
+  declarationSourceFilePtr: UnsafeRawPointer,
+  attachedTo declarationSourceLocPointer: UnsafePointer<UInt8>?,
+  expandedSourcePointer: UnsafeMutablePointer<UnsafePointer<UInt8>?>,
+  expandedSourceLength: UnsafeMutablePointer<Int>
+) -> Int {
+  // We didn't expand anything so far.
+  expandedSourcePointer.pointee = nil
+  expandedSourceLength.pointee = 0
+
+  // Dig out the custom attribute for the attached macro declarations.
+  guard let customAttrNode = findSyntaxNodeInSourceFile(
+    sourceFilePtr: customAttrSourceFilePtr,
+    sourceLocationPtr: customAttrSourceLocPointer,
+    type: AttributeSyntax.self
+  ) else {
+    return 1
+  }
+
+  // Dig out the node for the declaration to which the custom attribute is
+  // attached.
+  guard let declarationNode = findSyntaxNodeInSourceFile(
+    sourceFilePtr: declarationSourceFilePtr,
+    sourceLocationPtr: declarationSourceLocPointer,
+    type: DeclSyntax.self
+  ) else {
+    return 1
+  }
+
+  // Get the macro.
+  let macroPtr = macroPtr.bindMemory(to: ExportedMacro.self, capacity: 1)
+  let macro = macroPtr.pointee.macro
+
+  // FIXME: Which source file? I don't know! This should go.
+  let declarationSourceFilePtr = declarationSourceFilePtr.bindMemory(
+    to: ExportedSourceFile.self, capacity: 1
+  )
+
+  var context = MacroExpansionContext(
+    moduleName: declarationSourceFilePtr.pointee.moduleName,
+    fileName: declarationSourceFilePtr.pointee.fileName.withoutPath()
+  )
+
+  var evaluatedSyntaxStr: String
+  do {
+    switch macro {
+    case let attachedMacro as AccessorDeclarationMacro.Type:
+      let accessors = try attachedMacro.expansion(
+        of: customAttrNode, attachedTo: declarationNode, in: &context
+      )
+
+      // Form a buffer of accessor declarations to return to the caller.
+      evaluatedSyntaxStr = accessors.map {
+        $0.withoutTrivia().description
+      }.joined(separator: "\n\n")
+
+    default:
+      print("\(macroPtr) does not conform to any known attached macro protocol")
+      return 1
+    }
+  } catch {
+    // Record the error
+    // FIXME: Need to decide where to diagnose the error:
+    context.diagnose(
+      Diagnostic(
+        node: Syntax(declarationNode),
+        message: ThrownErrorDiagnostic(message: String(describing: error))
+      )
+    )
+
+    return 1
+  }
+
+  // FIXME: Emit diagnostics, but how do we figure out which source file to
+  // use?
+
+  // Form the result buffer for our caller.
+  evaluatedSyntaxStr.withUTF8 { utf8 in
+    let evaluatedResultPtr = UnsafeMutablePointer<UInt8>.allocate(capacity: utf8.count + 1)
+    if let baseAddress = utf8.baseAddress {
+      evaluatedResultPtr.initialize(from: baseAddress, count: utf8.count)
+    }
+    evaluatedResultPtr[utf8.count] = 0
+
+    expandedSourcePointer.pointee = UnsafePointer(evaluatedResultPtr)
+    expandedSourceLength.pointee = utf8.count
+  }
+
+  return 0
+}

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -6571,6 +6571,64 @@ ParserStatus Parser::parseGetEffectSpecifier(ParsedAccessors &accessors,
   return Status;
 }
 
+bool Parser::parseAccessorAfterIntroducer(
+    SourceLoc Loc, AccessorKind Kind, ParsedAccessors &accessors,
+    bool &hasEffectfulGet, ParameterList *Indices, bool &parsingLimitedSyntax,
+    DeclAttributes &Attributes, ParseDeclOptions Flags,
+    AbstractStorageDecl *storage, SourceLoc StaticLoc, ParserStatus &Status
+) {
+  auto *ValueNamePattern = parseOptionalAccessorArgument(Loc, *this, Kind);
+
+  // Next, parse effects specifiers. While it's only valid to have them
+  // on 'get' accessors, we also emit diagnostics if they show up on others.
+  SourceLoc asyncLoc;
+  SourceLoc throwsLoc;
+  Status |= parseGetEffectSpecifier(accessors, asyncLoc, throwsLoc,
+                                    hasEffectfulGet, Kind, Loc);
+
+  // Set up a function declaration.
+  auto accessor =
+      createAccessorFunc(Loc, ValueNamePattern, Indices, StaticLoc, Flags,
+                         Kind, storage, this, Loc, asyncLoc, throwsLoc);
+  accessor->getAttrs() = Attributes;
+
+  // Collect this accessor and detect conflicts.
+  if (auto existingAccessor = accessors.add(accessor)) {
+    diagnoseRedundantAccessors(*this, Loc, Kind,
+                               /*subscript*/Indices != nullptr,
+                               existingAccessor);
+  }
+
+  // There should be no body in the limited syntax; diagnose unexpected
+  // accessor implementations.
+  if (parsingLimitedSyntax) {
+    if (Tok.is(tok::l_brace))
+      diagnose(Tok, diag::unexpected_getset_implementation_in_protocol,
+               getAccessorNameForDiagnostic(Kind, /*article*/ false));
+    return false;
+  }
+
+  // It's okay not to have a body if there's an external asm name.
+  if (!Tok.is(tok::l_brace)) {
+    // Accessors don't need bodies in module interfaces
+    if (SF.Kind == SourceFileKind::Interface)
+      return false;
+
+    // _silgen_name'd accessors don't need bodies.
+    if (!Attributes.hasAttribute<SILGenNameAttr>()) {
+      diagnose(Tok, diag::expected_lbrace_accessor,
+               getAccessorNameForDiagnostic(accessor, /*article*/ false));
+      Status |= makeParserError();
+      return true;
+    }
+
+    return false;
+  }
+
+  parseAbstractFunctionBody(accessor);
+  return false;
+}
+
 ParserStatus Parser::parseGetSet(ParseDeclOptions Flags, ParameterList *Indices,
                                  TypeRepr *ResultType,
                                  ParsedAccessors &accessors,
@@ -6703,53 +6761,12 @@ ParserStatus Parser::parseGetSet(ParseDeclOptions Flags, ParameterList *Indices,
     if (parsingLimitedSyntax && Tok.is(tok::l_paren)) {
       diagnose(Loc, diag::protocol_setter_name);
     }
-    auto *ValueNamePattern = parseOptionalAccessorArgument(Loc, *this, Kind);
 
-    // Next, parse effects specifiers. While it's only valid to have them
-    // on 'get' accessors, we also emit diagnostics if they show up on others.
-    SourceLoc asyncLoc;
-    SourceLoc throwsLoc;
-    Status |= parseGetEffectSpecifier(accessors, asyncLoc, throwsLoc,
-                                      hasEffectfulGet, Kind, Loc);
-
-    // Set up a function declaration.
-    auto accessor =
-        createAccessorFunc(Loc, ValueNamePattern, Indices, StaticLoc, Flags,
-                           Kind, storage, this, Loc, asyncLoc, throwsLoc);
-    accessor->getAttrs() = Attributes;
-
-    // Collect this accessor and detect conflicts.
-    if (auto existingAccessor = accessors.add(accessor)) {
-      diagnoseRedundantAccessors(*this, Loc, Kind,
-                                 /*subscript*/Indices != nullptr,
-                                 existingAccessor);
-    }
-
-    // There should be no body in the limited syntax; diagnose unexpected
-    // accessor implementations.
-    if (parsingLimitedSyntax) {
-      if (Tok.is(tok::l_brace))
-        diagnose(Tok, diag::unexpected_getset_implementation_in_protocol,
-                 getAccessorNameForDiagnostic(Kind, /*article*/ false));
-      continue;
-    }
-
-    // It's okay not to have a body if there's an external asm name.
-    if (!Tok.is(tok::l_brace)) {
-      // Accessors don't need bodies in module interfaces
-      if (SF.Kind == SourceFileKind::Interface)
-        continue;
-      // _silgen_name'd accessors don't need bodies.
-      if (!Attributes.hasAttribute<SILGenNameAttr>()) {
-        diagnose(Tok, diag::expected_lbrace_accessor,
-                 getAccessorNameForDiagnostic(accessor, /*article*/ false));
-        Status |= makeParserError();
-        break;
-      }
-      continue;
-    }
-
-    parseAbstractFunctionBody(accessor);
+    if (parseAccessorAfterIntroducer(
+            Loc, Kind, accessors, hasEffectfulGet, Indices, parsingLimitedSyntax,
+            Attributes, Flags, storage, StaticLoc, Status
+        ))
+      break;
   }
   backtrack->cancelBacktrack();
   backtrack.reset();

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -770,8 +770,8 @@ void swift::expandAccessors(
                                               (size_t)evaluatedSourceLength);
     break;
 #else
-    med->diagnose(diag::macro_unsupported);
-    return false;
+    storage->diagnose(diag::macro_unsupported);
+    return;
 #endif
   }
   }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -833,32 +833,8 @@ void swift::expandAccessors(
   PrettyStackTraceDecl debugStack(
       "type checking expanded declaration macro", storage);
 
-  // FIXME: getTopLevelItems() is going to have to figure out how to parse
-  // a sequence of accessor declarations. Specifically, we will have to
-  // encode enough information in the GeneratedSourceInfo to know that
-  // the "top level" here is really a set of accessor declarations, so we
-  // can parse those. Both parsers will need to do it this way. Alternatively,
-  // we can put some extra braces around things and use parseGetSet, but that
-  // doesn't feel quite right, because we might eventually allow additional
-  // accessors to be inserted for properties that already have accesssors.
-  // parseTopLevelItems is where things get interesting... hmmm...
-
-
-#if false
-  // Retrieve the parsed declarations from the list of top-level items.
-  auto topLevelItems = macroSourceFile->getTopLevelItems();
-  for (auto item : topLevelItems) {
-    auto *decl = item.dyn_cast<Decl *>();
-    if (!decl) {
-      ctx.Diags.diagnose(
-          macroBufferRange.getStart(), diag::expected_macro_expansion_decls);
-      return;
-    }
-    decl->setDeclContext(dc);
-    TypeChecker::typeCheckDecl(decl);
-    results.push_back(decl);
-  }
-
-#endif
-  return;
+  // Trigger parsing of the sequence of accessor declarations. This has the
+  // side effect of registering those accessor declarations with the storage
+  // declaration, so there is nothing further to do.
+  (void)macroSourceFile->getTopLevelItems();
 }

--- a/lib/Sema/TypeCheckMacros.h
+++ b/lib/Sema/TypeCheckMacros.h
@@ -21,7 +21,9 @@
 
 namespace swift {
 
+class CustomAttr;
 class Expr;
+class MacroDecl;
 class MacroExpansionDecl;
 class TypeRepr;
 
@@ -39,6 +41,12 @@ Expr *expandMacroExpr(
 /// \returns true if expansion succeeded, false if failed.
 bool expandFreestandingDeclarationMacro(
     MacroExpansionDecl *med, SmallVectorImpl<Decl *> &results);
+
+/// Expand the accessors for the given storage declaration based on the
+/// custom attribute that references the given macro.
+void expandAccessors(
+    AbstractStorageDecl *storage, CustomAttr *attr, MacroDecl *macro
+);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -20,6 +20,7 @@
 #include "TypeCheckAvailability.h"
 #include "TypeCheckConcurrency.h"
 #include "TypeCheckDecl.h"
+#include "TypeCheckMacros.h"
 #include "TypeCheckType.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTWalker.h"
@@ -28,6 +29,7 @@
 #include "swift/AST/Expr.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Initializer.h"
+#include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/PropertyWrappers.h"
@@ -3436,6 +3438,30 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
     finishStorageImplInfo(storage, info);
 
     return info;
+  }
+
+  // Check for an accessor macro.
+  for (auto customAttrConst : storage->getAttrs().getAttributes<CustomAttr>()) {
+    auto customAttr = const_cast<CustomAttr *>(customAttrConst);
+    auto decl = evaluateOrDefault(
+        evaluator,
+        CustomAttrDeclRequest{
+          customAttr,
+          storage->getInnermostDeclContext()
+        },
+        nullptr);
+    if (!decl)
+      continue;
+
+    auto macro = decl.dyn_cast<MacroDecl *>();
+    if (!macro)
+      continue;
+
+    // FIXME: Make sure it's an accessors macro. We're not currently parsing
+    // this information in the @declaration attribute.
+
+    // Expand the accessors.
+    expandAccessors(storage, customAttr, macro);
   }
 
   bool hasWillSet = storage->getParsedAccessor(AccessorKind::WillSet);

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -212,3 +212,36 @@ public struct DefineBitwidthNumberedStructsMacro: FreestandingDeclarationMacro {
     }
   }
 }
+
+public struct PropertyWrapperMacro {}
+
+extension PropertyWrapperMacro: AccessorDeclarationMacro, Macro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: DeclSyntax,
+    in context: inout MacroExpansionContext
+  ) throws -> [AccessorDeclSyntax] {
+    guard let varDecl = declaration.as(VariableDeclSyntax.self),
+      let binding = varDecl.bindings.first,
+      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
+      binding.accessor == nil
+    else {
+      return []
+    }
+
+    return [
+      """
+
+        get {
+          _\(identifier).wrappedValue
+        }
+      """,
+      """
+
+        set {
+          _\(identifier).wrappedValue = newValue
+        }
+      """,
+    ]
+  }
+}

--- a/test/Macros/accessor_macros.swift
+++ b/test/Macros/accessor_macros.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// Check that the expansion buffer are as expected.
+// RUN: %target-swift-frontend -typecheck -enable-experimental-feature Macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -dump-macro-expansions > %t/expansions-dump.txt 2>&1
+// RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
+
+// Execution testing
+// RUN: %target-build-swift -enable-experimental-feature Macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser
+// RUN: %target-run %t/main
+// REQUIRES: executable_test
+
+// FIXME: Swift parser is not enabled on Linux CI yet.
+// REQUIRES: OS=macosx
+
+@declaration(attached)
+macro myPropertyWrapper: Void =
+    #externalMacro(module: "MacroDefinition", type: "PropertyWrapperMacro")
+
+struct Date { }
+
+struct MyStruct {
+  var storage: [AnyHashable: Any] = [:]
+  
+  @myPropertyWrapper
+  var name: String
+  // CHECK-DUMP: macro:name@myPropertyWrapper
+  // CHECK-DUMP: get {
+  // CHECK-DUMP:   _name.wrappedValue
+  // CHECK-DUMP: }
+  // CHECK-DUMP: set {
+  // CHECK-DUMP:   _name.wrappedValue = newValue
+  // CHECK-DUMP: }
+
+  @myPropertyWrapper
+  var birthDate: Date?
+  // CHECK-DUMP: macro:birthDate@myPropertyWrapper
+  // CHECK-DUMP: get {
+  // CHECK-DUMP:   _birthDate.wrappedValue
+  // CHECK-DUMP: }
+  // CHECK-DUMP: set {
+  // CHECK-DUMP:   _birthDate.wrappedValue = newValue
+  // CHECK-DUMP: }
+}
+
+// FIXME: Actually test that the accessors got into the AST.
+

--- a/test/Macros/accessor_macros.swift
+++ b/test/Macros/accessor_macros.swift
@@ -1,13 +1,16 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
 
+// First check for no errors.
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s
+
 // Check that the expansion buffer are as expected.
 // RUN: %target-swift-frontend -typecheck -enable-experimental-feature Macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -dump-macro-expansions > %t/expansions-dump.txt 2>&1
 // RUN: %FileCheck -check-prefix=CHECK-DUMP %s < %t/expansions-dump.txt
 
 // Execution testing
 // RUN: %target-build-swift -enable-experimental-feature Macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser
-// RUN: %target-run %t/main
+// RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
 
 // FIXME: Swift parser is not enabled on Linux CI yet.
@@ -19,9 +22,26 @@ macro myPropertyWrapper: Void =
 
 struct Date { }
 
-struct MyStruct {
-  var storage: [AnyHashable: Any] = [:]
+struct MyWrapperThingy<T> {
+  var storage: T
   
+  var wrappedValue: T {
+    get {
+      print("Getting value \(storage)")
+      return storage
+    }
+
+    set {
+      print("Setting value \(newValue)")
+      storage = newValue
+    }
+  }
+}
+
+struct MyStruct {
+  var _name: MyWrapperThingy<String> = .init(storage: "Hello")
+  var _birthDate: MyWrapperThingy<Date?> = .init(storage: nil)
+
   @myPropertyWrapper
   var name: String
   // CHECK-DUMP: macro:name@myPropertyWrapper
@@ -43,5 +63,13 @@ struct MyStruct {
   // CHECK-DUMP: }
 }
 
-// FIXME: Actually test that the accessors got into the AST.
+// Test that the fake-property-wrapper-introduced accessors execute properly at
+// runtime.
+var ms = MyStruct()
+
+// CHECK: Getting value Hello
+_ = ms.name
+
+// CHECK-NEXT: Setting value World
+ms.name = "World"
 

--- a/test/Macros/attached_macros_diags.swift
+++ b/test/Macros/attached_macros_diags.swift
@@ -2,6 +2,7 @@
 
 @declaration(attached) macro m1: Void = #externalMacro(module: "MyMacros", type: "Macro1")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro1' could not be found for macro 'm1'}}
+// expected-note@-2{{'m1' declared here}}
 
 @declaration(attached) macro m2(_: Int) -> Void = #externalMacro(module: "MyMacros", type: "Macro2")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro2' could not be found for macro 'm2'}}
@@ -27,4 +28,5 @@ struct SkipNestedType {
 
   // We select the macro, not the property wrapper.
   @m1 var x: Int = 0
+  // expected-error@-1{{external macro implementation type 'MyMacros.Macro1' could not be found for macro 'm1'; the type must be public and provided via '-load-plugin-library'}}
 }


### PR DESCRIPTION
Accessor macros are attached macros (written with attribute syntax)
that can generate accessors for a property or subscript. Recognize
custom attributes that are accessor macros when written on a storage
declaration, and expand those macros to produce accessors.

This is enough to get the most basic example working, but needs a
significant amount of refactoring and a lot more error handling.