### PR TITLE
test: adjust for untyped pointers in LLVM

### DIFF
--- a/test/Interop/SwiftToCxx/core/unsigned-return-type-no-zext-msvc.cpp
+++ b/test/Interop/SwiftToCxx/core/unsigned-return-type-no-zext-msvc.cpp
@@ -13,5 +13,5 @@ void test(void *p) {
   getEnumTagi32(p);
 }
 
-// CHECK: declare dso_local noundef i8 @"?getEnumTagi8@@YAEPEAX@Z"(i8* noundef) #1
-// CHECK: declare dso_local noundef i32 @"?getEnumTagi32@@YAIPEAX@Z"(i8* noundef) #1
+// CHECK: declare dso_local noundef i8 @"?getEnumTagi8@@YAEPEAX@Z"(ptr noundef) #1
+// CHECK: declare dso_local noundef i32 @"?getEnumTagi32@@YAIPEAX@Z"(ptr noundef) #1


### PR DESCRIPTION
The LLVM IR has begun migration towards untyped pointers.  Adjust the test to follow suit.  This was identified when working towards Windows support for the rebranch.
