### PR TITLE
[CSFix] Diagnose use of inaccessible members in ambiguous contexts

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -1847,6 +1847,10 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
   static AllowInaccessibleMember *create(ConstraintSystem &cs, Type baseType,
                                          ValueDecl *member, DeclNameRef name,
                                          ConstraintLocator *locator);

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -783,3 +783,14 @@ func rdar92358570(_ x: RDAR92358570<ClassBoundProtocol>, _ y: RDAR92358570<SomeC
   y.doSomething() // expected-error {{referencing instance method 'doSomething()' on 'RDAR92358570' requires that 'any SomeClassBound & ClassBoundProtocol' inherit from 'AnyObject'}}
   RDAR92358570<SomeClassBound & ClassBoundProtocol>.doSomethingStatically() // expected-error {{referencing static method 'doSomethingStatically()' on 'RDAR92358570' requires that 'any SomeClassBound & ClassBoundProtocol' inherit from 'AnyObject'}}
 }
+
+func test_diagnose_inaccessible_member_in_ambiguous_context() {
+  struct S {
+    private var x: Int // expected-note {{'x' declared here}}
+  }
+
+  func test<T>(_: KeyPath<S, T>, y: Int = 42) {}
+  func test<T>(_: KeyPath<S, T>, x: Int = 42) {}
+
+  test(\.x) // expected-error {{'x' is inaccessible due to 'private' protection level}}
+}


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
