### PR TITLE
[AddressLowering] Project at storage.

### DIFF
--- a/include/swift/SIL/Dominance.h
+++ b/include/swift/SIL/Dominance.h
@@ -61,6 +61,9 @@ public:
   /// Does value A properly dominate instruction B?
   bool properlyDominates(SILValue a, SILInstruction *b);
 
+  /// The nearest block which dominates all the uses of \p value.
+  SILBasicBlock *getLeastCommonAncestorOfUses(SILValue value);
+
   void verify() const;
 
   /// Return true if the other dominator tree does not match this dominator

--- a/lib/SIL/Utils/Dominance.cpp
+++ b/lib/SIL/Utils/Dominance.cpp
@@ -73,6 +73,15 @@ bool DominanceInfo::properlyDominates(SILValue a, SILInstruction *b) {
   return false;
 }
 
+SILBasicBlock *DominanceInfo::getLeastCommonAncestorOfUses(SILValue value) {
+  SILBasicBlock *lca = nullptr;
+  for (auto *use : value->getUses()) {
+    auto *block = use->getParentBlock();
+    lca = lca ? findNearestCommonDominator(lca, block) : block;
+  }
+  return lca;
+}
+
 void DominanceInfo::verify() const {
   // Recompute.
   auto *F = getRoot()->getParent();

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -1360,8 +1360,8 @@ SILInstruction *AddressLoweringState::getLatestOpeningInst(SILType ty) const {
       auto openingVal =
           getModule()->getRootLocalArchetypeDef(openedTy, function);
 
-      auto *openingInst = openingVal->getDefiningInstruction();
       assert(openingVal && "all opened archetypes should be resolved");
+      auto *openingInst = openingVal->getDefiningInstruction();
       if (latestOpeningInst) {
         if (domInfo->dominates(openingInst, latestOpeningInst))
           return;

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -1342,7 +1342,7 @@ AllocStackInst *OpaqueStorageAllocation::createStackAllocation(SILValue value) {
   // For opened existential types, allocate stack space at the type
   // definition. Allocating as early as possible provides more opportunity for
   // creating use projections into value. But allocation must be no earlier
-  // then the latest type definition.
+  // than the latest type definition.
   SILInstruction *latestOpeningInst = nullptr;
   allocTy.getASTType().visit([&](CanType type) {
     auto archetype = dyn_cast<ArchetypeType>(type);

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -3579,9 +3579,6 @@ void UseRewriter::visitUncheckedEnumDataInst(
 
   assert(enumDataInst->getOwnershipKind() != OwnershipKind::Guaranteed);
 
-  // unchecked_enum_data could be a def-projection. It is handled as a
-  // separate allocation to make it clear that it can't be
-  // rematerialized. This means that
   auto srcAddr = pass.valueStorageMap.getStorage(use->get()).storageAddress;
 
   auto loc = enumDataInst->getLoc();

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -439,7 +439,7 @@ void ValueStorage::dump() const {
   llvm::dbgs() << "isDefProjection: " << isDefProjection << "\n";
   llvm::dbgs() << "isUseProjection: " << isUseProjection << "\n";
   llvm::dbgs() << "isRewritten: " << isRewritten << "\n";
-  llvm::dbgs() << "initializesEnum: " << initializesEnum << "\n";
+  llvm::dbgs() << "initializes: " << initializes << "\n";
 }
 void ValueStorageMap::ValueStoragePair::dump() const {
   llvm::dbgs() << "value: ";
@@ -1071,8 +1071,9 @@ void ValueStorageMap::recordComposingUseProjection(Operand *oper,
 
   storage.isUseProjection = true;
 
-  if (userValue->getType().getEnumOrBoundGenericEnum()) {
-    storage.initializesEnum = true;
+  if (userValue->getType().getEnumOrBoundGenericEnum() ||
+      userValue->getType().isExistentialType()) {
+    storage.initializes = true;
   }
   assert(!storage.isPhiProjection());
 }
@@ -1266,8 +1267,8 @@ bool OpaqueStorageAllocation::findProjectionIntoUseImpl(
     // TODO: fix the memory verifier to consider the actual store instructions
     // to initialize an enum rather than the init_enum_data_addr to reuse enum
     // storage across multiple subobjects within the payload.
-    auto *baseStorage = pass.valueStorageMap.getBaseStorage(
-        userValue, /*allowInitEnum*/ !intoPhi);
+    auto *baseStorage =
+        pass.valueStorageMap.getBaseStorage(userValue, /*allowInit*/ !intoPhi);
     if (!baseStorage)
       continue;
 

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -433,6 +433,29 @@ void ValueStorageMap::replaceValue(SILValue oldValue, SILValue newValue) {
 }
 
 #ifndef NDEBUG
+void ValueStorage::dump() const {
+  llvm::dbgs() << "projectedStorageID: " << projectedStorageID << "\n";
+  llvm::dbgs() << "projectedOperandNum: " << projectedOperandNum << "\n";
+  llvm::dbgs() << "isDefProjection: " << isDefProjection << "\n";
+  llvm::dbgs() << "isUseProjection: " << isUseProjection << "\n";
+  llvm::dbgs() << "isRewritten: " << isRewritten << "\n";
+  llvm::dbgs() << "initializesEnum: " << initializesEnum << "\n";
+}
+void ValueStorageMap::ValueStoragePair::dump() const {
+  llvm::dbgs() << "value: ";
+  value->dump();
+  llvm::dbgs() << "address:  ";
+  if (storage.storageAddress)
+    storage.storageAddress->dump();
+  else
+    llvm::dbgs() << "UNKNOWN!\n";
+  storage.dump();
+}
+void ValueStorageMap::dumpProjections(SILValue value) {
+  for (auto *pair : getProjections(value)) {
+    pair->dump();
+  }
+}
 void ValueStorageMap::dump() {
   llvm::dbgs() << "ValueStorageMap:\n";
   for (unsigned ordinal : indices(valueVector)) {

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -1520,8 +1520,9 @@ void AddressMaterialization::initializeComposingUse(Operand *operand) {
 // storage after materializing the result. In particular, it materializes
 // init_enum_data_addr, but not inject_enum_addr.
 //
-SILValue AddressMaterialization::recursivelyMaterializeStorage(
-    ValueStorage &storage, bool intoPhiOperand = false) {
+SILValue
+AddressMaterialization::recursivelyMaterializeStorage(ValueStorage &storage,
+                                                      bool intoPhiOperand) {
   // If this storage is already materialized, then simply return its
   // address. This not only avoids redundant projections, but is necessary for
   // correctness when emitting init_enum_data_addr.

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -1029,7 +1029,7 @@ void ValueStorageMap::recordDefProjection(Operand *oper,
   storage.isDefProjection = true;
 }
 
-// Mark this operand as coalesced with \p useValue storage.
+// Mark this operand as coalesced with \p userValue storage.
 void ValueStorageMap::recordComposingUseProjection(Operand *oper,
                                                    SILValue userValue) {
   auto &storage = getStorage(oper->get());

--- a/lib/SILOptimizer/Mandatory/AddressLowering.h
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.h
@@ -351,35 +351,6 @@ public:
     return *last;
   }
 
-  /// Return the non-projection storage that this storage refers to.  If this
-  /// storage requires materializing an instruction that performs
-  /// initialization side effects (init_enum_data_addr, init_existential_addr),
-  /// return nullptr.
-  const ValueStorage *getNonInitializingBaseStorage(SILValue value) {
-    for (auto *pair : getProjections(value)) {
-      auto const &storage = pair->storage;
-      if (storage.initializes)
-        return nullptr;
-
-      if (storage.isUseProjection) {
-        continue;
-      }
-      assert(!storage.isDefProjection &&
-             "def projections should not reach here");
-      return &storage;
-    }
-    llvm_unreachable("found no non-projection storage!?");
-  }
-
-  /// Return the non-projection storage that this storage refers to, or nullptr
-  /// if \p allowInit is true and the storage initializes an Enum.
-  const ValueStorage *getBaseStorage(SILValue value, bool allowInit) {
-    if (allowInit)
-      return &getBaseStorage(value);
-
-    return getNonInitializingBaseStorage(value);
-  }
-
   void setStorageAddress(SILValue value, SILValue addr) {
     auto &storage = getStorage(value);
     assert(!storage.storageAddress || storage.storageAddress == addr);

--- a/lib/SILOptimizer/Mandatory/AddressLowering.h
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.h
@@ -265,6 +265,12 @@ public:
   /// Given storage for a projection, return the projected storage by following
   /// single level of projected storage. The returned storage may
   /// recursively be a another projection.
+  const ValueStoragePair &
+  getProjectedStorage(const ValueStorage &storage) const {
+    assert(storage.isProjection());
+    return valueVector[storage.projectedStorageID];
+  }
+
   ValueStoragePair &getProjectedStorage(const ValueStorage &storage) {
     assert(storage.isProjection());
     return valueVector[storage.projectedStorageID];

--- a/lib/SILOptimizer/Mandatory/AddressLowering.h
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.h
@@ -185,6 +185,10 @@ struct ValueStorage {
     assert(isRewritten && "storage has not been materialized");
     return storageAddress;
   }
+
+#ifndef NDEBUG
+  void dump() const;
+#endif
 };
 
 /// Map each opaque/resilient SILValue to its abstract storage.
@@ -197,6 +201,9 @@ class ValueStorageMap {
     SILValue value;
     ValueStorage storage;
     ValueStoragePair(SILValue v, ValueStorage s) : value(v), storage(s) {}
+#ifndef NDEBUG
+    void dump() const;
+#endif
   };
   typedef std::vector<ValueStoragePair> ValueVector;
   // Hash of values to ValueVector indices.
@@ -335,6 +342,7 @@ public:
   bool isComposingUseProjection(Operand *oper) const;
 
 #ifndef NDEBUG
+  void dumpProjections(SILValue value);
   void dump();
 #endif
 };

--- a/lib/SILOptimizer/Mandatory/AddressLowering.h
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.h
@@ -128,6 +128,10 @@ struct ValueStorage {
   /// after materialization (during instruction rewriting).
   SILValue storageAddress;
 
+  /// The latest instruction which opens an archetype involved in the value's
+  /// type.  Just a cache of getLatestOpeningInst(value).
+  mutable llvm::Optional<SILInstruction *> latestOpeningInst = llvm::None;
+
   /// When either isDefProjection or isUseProjection is set, this refers to the
   /// storage whose "def" this value projects out of or whose operand this
   /// storage projects into via its "use.
@@ -205,6 +209,7 @@ struct ValueStorage {
 /// Mapped values are expected to be created in a single RPO pass. "erase" is
 /// unsupported. Values must be replaced using 'replaceValue()'.
 class ValueStorageMap {
+public:
   struct ValueStoragePair {
     SILValue value;
     ValueStorage storage;
@@ -213,6 +218,8 @@ class ValueStorageMap {
     void dump() const;
 #endif
   };
+
+private:
   typedef std::vector<ValueStoragePair> ValueVector;
   // Hash of values to ValueVector indices.
   typedef llvm::DenseMap<SILValue, unsigned> ValueHashMap;

--- a/lib/SILOptimizer/Mandatory/AddressLowering.h
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.h
@@ -317,6 +317,12 @@ public:
     return hashIter->second;
   }
 
+  ValueStoragePair &operator[](uint32_t index) { return valueVector[index]; }
+
+  ValueStoragePair const &operator[](uint32_t index) const {
+    return valueVector[index];
+  }
+
   ValueStorage &getStorage(SILValue value) {
     return valueVector[getOrdinal(value)].storage;
   }

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -1070,6 +1070,26 @@ block(%instance : @owned $any Error):
   return %retval : $()
 }
 
+// CHECK-LABEL: sil [ossa] @f164_testOpenedArchetype2 : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[ERROR_EXI:%[^,]+]] :
+// CHECK:         [[ERROR_CONCR:%[^,]+]] = open_existential_box [[ERROR_EXI]]
+// CHECK:         [[STACK:%[^,]+]] = alloc_stack
+// CHECK:         copy_addr [[ERROR_CONCR]] to [init] [[STACK]]
+// CHECK:         destroy_addr [[STACK]]
+// CHECK:         dealloc_stack [[STACK]]
+// CHECK-LABEL: } // end sil function 'f164_testOpenedArchetype2'
+sil [ossa] @f164_testOpenedArchetype2 : $@convention(thin) (@guaranteed any Error) -> () {
+bb0(%error_exi : @guaranteed $any Error):
+  %error_concr = open_existential_box_value %error_exi : $any Error to $@opened("F616C4D8-268F-11EE-998B-32F16C24A34D", any Error) Self
+  %stack = alloc_stack $@opened("F616C4D8-268F-11EE-998B-32F16C24A34D", any Error) Self
+  %error_copy = copy_value %error_concr : $@opened("F616C4D8-268F-11EE-998B-32F16C24A34D", any Error) Self
+  store %error_copy to [init] %stack : $*@opened("F616C4D8-268F-11EE-998B-32F16C24A34D", any Error) Self
+  destroy_addr %stack : $*@opened("F616C4D8-268F-11EE-998B-32F16C24A34D", any Error) Self
+  dealloc_stack %stack : $*@opened("F616C4D8-268F-11EE-998B-32F16C24A34D", any Error) Self
+  %tuple = tuple ()
+  return %tuple : $()
+}
+
 // CHECK-LABEL: sil [ossa] @f170_compare : $@convention(thin) <T where T : Comparable> (@in_guaranteed T, @in_guaranteed T) -> @out T {
 // CHECK: bb0(%0 : $*T, %1 : $*T, %2 : $*T):
 // CHECK:   [[WT:%.*]] = witness_method $T, #Comparable."<" : <Self where Self : Comparable> (Self.Type) -> (Self, Self) -> Builtin.Int1 : $@convention(witness_method: Comparable) <τ_0_0 where τ_0_0 : Comparable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> Builtin.Int1

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -56,6 +56,11 @@ struct Pair<T> {
   var y : T
 }
 
+struct Box2<T, U> {
+    var v1: T
+    var v2: U
+}
+
 enum Mixed<T> {
   case i(Int)
   case t(T)
@@ -81,9 +86,11 @@ public protocol Comparable {
   static func < (lhs: Self, rhs: Self) -> Bool
 }
 
+
 sil [ossa] @unknown : $@convention(thin) () -> ()
 sil [ossa] @getT : $@convention(thin) <T> () -> @out T
 sil [ossa] @getPair : $@convention(thin) <T> () -> @out Pair<T>
+sil [ossa] @getOwned : $@convention(thin) <T : AnyObject> () -> (@owned T)
 sil [ossa] @takeGuaranteedObject : $@convention(thin) (@guaranteed AnyObject) -> ()
 sil [ossa] @takeIndirectClass : $@convention(thin) (@in_guaranteed C) -> ()
 sil [ossa] @takeTuple : $@convention(thin) <τ_0_0> (@in_guaranteed (τ_0_0, C)) -> ()
@@ -1088,6 +1095,48 @@ bb0(%error_exi : @guaranteed $any Error):
   dealloc_stack %stack : $*@opened("F616C4D8-268F-11EE-998B-32F16C24A34D", any Error) Self
   %tuple = tuple ()
   return %tuple : $()
+}
+
+// Test a chain of projections multiple nodes of which feature an opened
+// archetype AND the archetype-definining instruction for the first projection
+// whose type has an opened archetype dominates all blocks but the
+// archetype-defining instruction for the SECOND projection does not.
+//
+// This test case demonstrates why getDominandsForUseProjection returns
+// multiple values all of which must dominate each incoming value.
+//
+// CHECK-LABEL: sil [ossa] @f165_testOpenedArchetypsDominance : {{.*}} {
+// CHECK:         alloc_stack $(T, T)
+// CHECK-LABEL: } // end sil function 'f165_testOpenedArchetypsDominance'
+sil [ossa] @f165_testOpenedArchetypsDominance : $@convention(thin) <T> () -> () {
+  %borrow = function_ref @takeInGuaranteed : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %take = function_ref @takeIn : $@convention(thin) <T> (@in T) -> ()
+  %get = function_ref @getT : $@convention(thin) <T> () -> (@out T)
+  %getOwned = function_ref @getOwned : $@convention(thin) <T : AnyObject> () -> (@owned T)
+
+
+  %exi = apply %getOwned<any P & C>() : $@convention(thin) <T : AnyObject> () -> (@owned T)
+  %exi2 = apply %getOwned<any P & C>() : $@convention(thin) <T : AnyObject> () -> (@owned T)
+  %O_1 = apply %get<T>() : $@convention(thin) <T> () -> (@out T)
+  %O_2 = apply %get<T>() : $@convention(thin) <T> () -> (@out T)
+  %O = tuple (%O_1 : $T, %O_2 : $T)
+  %ope = open_existential_ref %exi : $P & C to $@opened("00000000-0000-0000-0000-000000000000", P & C) Self
+  cond_br undef, left, right
+
+left:
+  %ope2 = open_existential_ref %exi2 : $P & C to $@opened("00000000-0000-0000-0000-000000000001", P & C) Self
+  %U = struct $Box2<(T, T), @opened("00000000-0000-0000-0000-000000000000", P & C) Self> (%O : $(T, T), %ope : $@opened("00000000-0000-0000-0000-000000000000", P & C) Self)
+  %U2 = struct $Box2<Box2<(T, T), @opened("00000000-0000-0000-0000-000000000000", P & C) Self>, @opened("00000000-0000-0000-0000-000000000001", P & C) Self> (%U : $Box2<(T, T), @opened("00000000-0000-0000-0000-000000000000", P & C) Self> , %ope2 : $@opened("00000000-0000-0000-0000-000000000001", P & C) Self)
+  destroy_value %U2 : $Box2<Box2<(T, T), @opened("00000000-0000-0000-0000-000000000000", P & C) Self>, @opened("00000000-0000-0000-0000-000000000001", P & C) Self>
+  br exit
+right:
+  destroy_value %exi2 : $any P & C
+  destroy_value %ope : $@opened("00000000-0000-0000-0000-000000000000", P & C) Self
+  destroy_value %O : $(T, T)
+  br exit
+exit:
+  %retval = tuple ()
+  return %retval : $()
 }
 
 // CHECK-LABEL: sil [ossa] @f170_compare : $@convention(thin) <T where T : Comparable> (@in_guaranteed T, @in_guaranteed T) -> @out T {

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -123,11 +123,11 @@ bb0(%0 : @owned $(T, T)):
 
 // CHECK-LABEL: sil [ossa] @f012_decompose_tuple_arg : $@convention(thin) <T> (@in (T, T)) -> @out (T, T) {
 // CHECK: bb0(%0 : $*(T, T), %1 : $*(T, T)):
-// CHECK:   [[ARG0:%.*]] = tuple_element_addr %1 : $*(T, T), 0
-// CHECK:   [[ARG1:%.*]] = tuple_element_addr %1 : $*(T, T), 1
-// CHECK:   [[RET0:%.*]] = tuple_element_addr %0 : $*(T, T), 0
-// CHECK:   apply %{{.*}}<T>([[RET0]], [[ARG0]]) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
 // CHECK:   [[RET1:%.*]] = tuple_element_addr %0 : $*(T, T), 1
+// CHECK:   [[RET0:%.*]] = tuple_element_addr %0 : $*(T, T), 0
+// CHECK:   [[ARG1:%.*]] = tuple_element_addr %1 : $*(T, T), 1
+// CHECK:   [[ARG0:%.*]] = tuple_element_addr %1 : $*(T, T), 0
+// CHECK:   apply %{{.*}}<T>([[RET0]], [[ARG0]]) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
 // CHECK:   copy_addr [take] [[ARG1]] to [init] [[RET1]] : $*T
 // CHECK-LABEL: } // end sil function 'f012_decompose_tuple_arg'
 sil [ossa] @f012_decompose_tuple_arg : $@convention(thin) <T> (@in (T, T)) -> @out (T, T) {
@@ -143,13 +143,13 @@ bb0(%0 : @owned $(T, T)):
 // CHECK: bb0(%0 : $*T, %1 : $*T):
 // CHECK:   [[IN:%.*]] = alloc_stack $(T, T)
 // CHECK:   [[OUT:%.*]] = alloc_stack $(T, T)
-// CHECK:   [[IN1:%.*]] = tuple_element_addr [[IN]] : $*(T, T), 1
-// CHECK:   copy_addr %1 to [init] [[IN1]] : $*T
 // CHECK:   [[IN0:%.*]] = tuple_element_addr %2 : $*(T, T), 0
+// CHECK:   [[IN1:%.*]] = tuple_element_addr [[IN]] : $*(T, T), 1
+// CHECK:   [[DEAD:%.*]] = tuple_element_addr [[OUT]] : $*(T, T), 1
+// CHECK:   [[RET:%.*]] = tuple_element_addr [[OUT]] : $*(T, T), 0
+// CHECK:   copy_addr %1 to [init] [[IN1]] : $*T
 // CHECK:   copy_addr [take] %1 to [init] [[IN0]] : $*T
 // CHECK:   apply %{{.*}}<T>([[OUT]], [[IN]]) : $@convention(thin) <τ_0_0> (@in (τ_0_0, τ_0_0)) -> @out (τ_0_0, τ_0_0)
-// CHECK:   [[RET:%.*]] = tuple_element_addr [[OUT]] : $*(T, T), 0
-// CHECK:   [[DEAD:%.*]] = tuple_element_addr [[OUT]] : $*(T, T), 1
 // CHECK:   destroy_addr [[DEAD]] : $*T
 // CHECK:   copy_addr [take] [[RET]] to [init] %0 : $*T
 // CHECK-LABEL: } // end sil function 'f013_pass_tuple_arg'
@@ -522,15 +522,15 @@ bb0:
 // CHECK-LABEL: sil [ossa] @f075_reusedResult : $@convention(thin) <T> (@in T, @owned any C) -> (@out T, @owned any C) {
 // CHECK: bb0(%0 : $*T, %1 : $*T, %2 : @owned $any C):
 // CHECK:   [[TUPLE:%.*]] = alloc_stack $(T, any C)
-// CHECK:   [[E1:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, any C), 0
-// CHECK:   copy_addr [take] %1 to [init] [[E1]] : $*T
+// CHECK:   [[E1_2:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, any C), 0
+// CHECK:   [[E1_1:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, any C), 0
 // CHECK:   [[E2:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, any C), 1
+// CHECK:   copy_addr [take] %1 to [init] [[E1_1]] : $*T
 // CHECK:   store %2 to [init] [[E2]] : $*any C
 // CHECK:   apply %{{.*}}<T>([[TUPLE]]) : $@convention(thin) <τ_0_0> (@in_guaranteed (τ_0_0, any C)) -> ()
-// CHECK:   [[E1:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, any C), 0
 // CHECK:   [[E2:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, any C), 1
 // CHECK:   [[LD:%.*]] = load [take] [[E2]] : $*any C
-// CHECK:   copy_addr [take] [[E1]] to [init] %0 : $*T
+// CHECK:   copy_addr [take] [[E1_2]] to [init] %0 : $*T
 // CHECK:   dealloc_stack [[TUPLE]] : $*(T, any C)
 // CHECK:   return [[LD]] : $any C
 // CHECK-LABEL: } // end sil function 'f075_reusedResult'
@@ -631,8 +631,8 @@ bb0(%0 : @owned $Any):
 // CHECK-LABEL: sil [ossa] @f101_passAny : $@convention(thin) <T> (@in T) -> () {
 // CHECK: bb0(%0 : $*T):
 // CHECK:   %[[A:.*]] = alloc_stack $Any
-// CHECK:   %[[F:.*]] = function_ref @f100_any : $@convention(thin) (@in Any) -> ()
 // CHECK:   %[[T2:.*]] = init_existential_addr %[[A]] : $*Any, $T
+// CHECK:   %[[F:.*]] = function_ref @f100_any : $@convention(thin) (@in Any) -> ()
 // CHECK:   copy_addr %0 to [init] %[[T2]] : $*T
 // CHECK:   %{{.*}} = apply %[[F]](%[[A]]) : $@convention(thin) (@in Any) -> ()
 // CHECK:   destroy_addr %0 : $*T
@@ -655,9 +655,9 @@ bb0(%0 : @owned $T):
 // CHECK-LABEL: sil [ossa] @f102_passAnyObjectAsAny : $@convention(thin) (@in AnyObject) -> () {
 // CHECK: bb0(%0 : $*AnyObject):
 // CHECK:   [[A:%.*]] = alloc_stack $Any
+// CHECK:   [[VAL:%.*]] = init_existential_addr [[A]] : $*Any, $AnyObject
 // CHECK:   [[ARG:%.*]] = load [take] %0 : $*AnyObject
 // CHECK:   [[F:%.*]] = function_ref @f100_any : $@convention(thin) (@in Any) -> ()
-// CHECK:   [[VAL:%.*]] = init_existential_addr [[A]] : $*Any, $AnyObject
 // CHECK:   store [[ARG]] to [init] [[VAL]] : $*AnyObject
 // CHECK:   %{{.*}} = apply [[F]]([[A]]) : $@convention(thin) (@in Any) -> ()
 // CHECK:   [[R:%.*]] = tuple ()
@@ -733,9 +733,9 @@ bb0(%0 : @owned $SI<AnyObject>):
 // CHECK-LABEL: sil [ossa] @f122_testStructExtract : $@convention(method) <T> (@in SRef<T>) -> (@out AnyObject, @out T) {
 // CHECK: bb0(%0 : $*AnyObject, %1 : $*T, %2 : $*SRef<T>):
 // CHECK-NOT: alloc_stack
+// CHECK:   [[E1:%.*]] = struct_element_addr %2 : $*SRef<T>, #SRef.element
 // CHECK:   [[E0:%.*]] = struct_element_addr %2 : $*SRef<T>, #SRef.object
 // CHECK:   [[C:%.*]] = load [copy] [[E0]] : $*AnyObject
-// CHECK:   [[E1:%.*]] = struct_element_addr %2 : $*SRef<T>, #SRef.element
 // CHECK:   copy_addr [[E1]] to [init] %1 : $*T
 // CHECK:   destroy_addr %2 : $*SRef<T>
 // CHECK:   store [[C]] to [init] %0 : $*AnyObject
@@ -757,11 +757,11 @@ bb0(%0 : @owned $SRef<T>):
 // CHECK-LABEL: sil [ossa] @f123_testStructExtract : $@convention(method) <T> (@in SRef<T>) -> (@out AnyObject, @out T) {
 // CHECK: bb0(%0 : $*AnyObject, %1 : $*T, %2 : $*SRef<T>):
 // CHECK-NOT: alloc_stack
+// CHECK:   [[E1:%.*]] = struct_element_addr %2 : $*SRef<T>, #SRef.element
 // CHECK:   [[E0:%.*]] = struct_element_addr %2 : $*SRef<T>, #SRef.object
 // CHECK:   [[L:%.*]] = load_borrow [[E0]] : $*AnyObject
 // CHECK:   apply %{{.*}}([[L]]) : $@convention(thin) (@guaranteed AnyObject) -> ()
 // CHECK:   [[C:%.*]] = copy_value [[L]] : $AnyObject
-// CHECK:   [[E1:%.*]] = struct_element_addr %2 : $*SRef<T>, #SRef.element
 // CHECK:   copy_addr [[E1]] to [init] %1 : $*T
 // CHECK:   end_borrow [[L]] : $AnyObject
 // CHECK:   destroy_addr %2 : $*SRef<T>
@@ -786,9 +786,9 @@ bb0(%0 : @owned $SRef<T>):
 // CHECK-LABEL: sil [ossa] @f124_testTupleExtract : $@convention(method) <T> (@in (AnyObject, T)) -> (@out AnyObject, @out T) {
 // CHECK: bb0(%0 : $*AnyObject, %1 : $*T, %2 : $*(AnyObject, T)):
 // CHECK-NOT: alloc_stack
+// CHECK:   [[E1:%.*]] = tuple_element_addr %2 : $*(AnyObject, T), 1
 // CHECK:   [[E0:%.*]] = tuple_element_addr %2 : $*(AnyObject, T), 0
 // CHECK:   [[C:%.*]] = load [copy] [[E0]] : $*AnyObject
-// CHECK:   [[E1:%.*]] = tuple_element_addr %2 : $*(AnyObject, T), 1
 // CHECK:   copy_addr [[E1]] to [init] %1 : $*T
 // CHECK:   destroy_addr %2 : $*(AnyObject, T)
 // CHECK:   store [[C]] to [init] %0 : $*AnyObject
@@ -809,11 +809,11 @@ bb0(%0 : @owned $(AnyObject, T)):
 // CHECK-LABEL: sil [ossa] @f125_testTupleExtract : $@convention(method) <T> (@in (AnyObject, T)) -> (@out AnyObject, @out T) {
 // CHECK: bb0(%0 : $*AnyObject, %1 : $*T, %2 : $*(AnyObject, T)):
 // CHECK-NOT: alloc_stack
+// CHECK:   [[E1:%.*]] = tuple_element_addr %2 : $*(AnyObject, T), 1
 // CHECK:   [[E0:%.*]] = tuple_element_addr %2 : $*(AnyObject, T), 0
-// CHECK:   [[L:%.*]] = load_borrow %3 : $*AnyObject
+// CHECK:   [[L:%.*]] = load_borrow [[E0]] : $*AnyObject
 // CHECK:   apply %{{.*}}([[L]]) : $@convention(thin) (@guaranteed AnyObject) -> ()
 // CHECK:   [[C:%.*]] = copy_value [[L]] : $AnyObject
-// CHECK:   [[E1:%.*]] = tuple_element_addr %2 : $*(AnyObject, T), 1
 // CHECK:   copy_addr [[E1]] to [init] %1 : $*T
 // CHECK:   end_borrow [[L]] : $AnyObject
 // CHECK:   destroy_addr %2 : $*(AnyObject, T)
@@ -838,9 +838,9 @@ bb0(%0 : @owned $(AnyObject, T)):
 // CHECK-LABEL: sil [ossa] @f126_testDestructureAndBorrow : $@convention(method) <Element> (@in (SI<Element>, I)) -> (@out Element, @out I) {
 // CHECK: bb0(%0 : $*Element, %1 : $*I, %2 : $*(SI<Element>, I)):
 // CHECK:   [[SI:%.*]] = tuple_element_addr %2 : $*(SI<Element>, I), 0
+// CHECK:   [[E:%.*]] = struct_element_addr [[SI]] : $*SI<Element>, #SI.element
 // CHECK:   [[I:%.*]] = tuple_element_addr %2 : $*(SI<Element>, I), 1
 // CHECK:   [[LD:%.*]] = load [trivial] [[I]] : $*I
-// CHECK:   [[E:%.*]] = struct_element_addr [[SI]] : $*SI<Element>, #SI.element
 // CHECK:   copy_addr [[E]] to [init] %0 : $*Element
 // CHECK:   destroy_addr [[SI]] : $*SI<Element>
 // CHECK:   store [[LD]] to [trivial] %1 : $*I
@@ -872,12 +872,12 @@ bb0(%0 : @owned $T):
 // CHECK-LABEL: sil [ossa] @f140_testTupleProject : $@convention(thin) <T> (@in T) -> () {
 // CHECK: bb0(%0 : $*T):
 // CHECK:   [[LOCAL:%.*]] = alloc_stack $((T, T), T)
+// CHECK:   [[ELT1:%.*]] = tuple_element_addr [[LOCAL]] : $*((T, T), T), 1
 // CHECK:   [[ELT0:%.*]] = tuple_element_addr [[LOCAL]] : $*((T, T), T), 0
+// CHECK:   [[ELT0_1:%.*]] = tuple_element_addr [[ELT0]] : $*(T, T), 1
 // CHECK:   [[ELT0_0:%.*]] = tuple_element_addr [[ELT0]] : $*(T, T), 0
 // CHECK:   copy_addr %0 to [init] [[ELT0_0]] : $*T
-// CHECK:   [[ELT1:%.*]] = tuple_element_addr [[LOCAL]] : $*((T, T), T), 1
 // CHECK:   copy_addr %0 to [init] [[ELT1]] : $*T
-// CHECK:   [[ELT0_1:%.*]] = tuple_element_addr [[ELT0]] : $*(T, T), 1
 // CHECK:   copy_addr [take] %0 to [init] [[ELT0_1]] : $*T
 // CHECK:   destroy_addr [[LOCAL]] : $*((T, T), T)
 // CHECK:   dealloc_stack [[LOCAL]] : $*((T, T), T)
@@ -897,12 +897,12 @@ bb0(%0 : @owned $T):
 // CHECK-LABEL: sil [ossa] @f150_testStructProject : $@convention(thin) <T> (@in T) -> () {
 // CHECK: bb0(%0 : $*T):
 // CHECK:   [[ALLOC:%.*]] = alloc_stack $Pair<Pair<T>>
+// CHECK:   [[ELT_Y:%.*]] = struct_element_addr [[ALLOC]] : $*Pair<Pair<T>>, #Pair.y
 // CHECK:   [[ELT_X:%.*]] = struct_element_addr [[ALLOC]] : $*Pair<Pair<T>>, #Pair.x
+// CHECK:   [[ELT_XX:%.*]] = struct_element_addr [[ELT_X]] : $*Pair<T>, #Pair.x
 // CHECK:   [[ELT_XY:%.*]] = struct_element_addr [[ELT_X]] : $*Pair<T>, #Pair.y
 // CHECK:   copy_addr %0 to [init] [[ELT_XY]] : $*T
-// CHECK:   [[ELT_XX:%.*]] = struct_element_addr [[ELT_X]] : $*Pair<T>, #Pair.x
 // CHECK:   copy_addr [take] %0 to [init] [[ELT_XX]] : $*T
-// CHECK:   [[ELT_Y:%.*]] = struct_element_addr [[ALLOC]] : $*Pair<Pair<T>>, #Pair.y
 // CHECK:   copy_addr [[ELT_X]] to [init] [[ELT_Y]] : $*Pair<T>
 // CHECK:   destroy_addr [[ALLOC]] : $*Pair<Pair<T>>
 // CHECK:   dealloc_stack [[ALLOC]] : $*Pair<Pair<T>>
@@ -963,8 +963,8 @@ bb0(%0 : @owned $P):
 // CHECK:   copy_addr %0 to [init] [[ALLOCP]] : $*any P
 // CHECK:   [[OPEN:%.*]] = open_existential_addr immutable_access %0 : $*any P to $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
 // CHECK:   [[OPTIONAL:%.*]] = alloc_stack $Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>
-// CHECK:   witness_method $@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self, #P.foo : <Self where Self : P> (Self) -> () -> (), [[OPEN]] : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
 // CHECK:   [[INIT:%.*]] = init_enum_data_addr [[OPTIONAL]] : $*Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>, #Optional.some!enumelt
+// CHECK:   witness_method $@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self, #P.foo : <Self where Self : P> (Self) -> () -> (), [[OPEN]] : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
 // CHECK:   copy_addr [[OPEN]] to [init] [[INIT]] : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
 // CHECK:   inject_enum_addr [[OPTIONAL]] : $*Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>, #Optional.some!enumelt
 // CHECK:   [[DATA:%.*]] = unchecked_take_enum_data_addr [[OPTIONAL]] : $*Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>, #Optional.some!enumelt
@@ -1912,8 +1912,8 @@ entry:
 // CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] :
 // CHECK:         [[INSTANCE_ADDR:%[^,]+]] = alloc_stack $Pair<T>
 // CHECK:         [[COPY_ADDR:%[^,]+]] = alloc_stack $T
-// CHECK:         apply undef<T>([[INSTANCE_ADDR]])
 // CHECK:         [[X_ADDR:%[^,]+]] = struct_element_addr [[INSTANCE_ADDR]]{{.*}}, #Pair.x
+// CHECK:         apply undef<T>([[INSTANCE_ADDR]])
 // CHECK:         copy_addr [[X_ADDR]] to [init] [[COPY_ADDR]]
 // CHECK:         destroy_addr [[INSTANCE_ADDR]]
 // CHECK:         copy_addr [take] [[COPY_ADDR]] to [[ADDR]]
@@ -1954,9 +1954,9 @@ entry(%addr : $*T):
 // CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] :
 // CHECK:         [[INSTANCE_ADDR:%[^,]+]] = alloc_stack $(T, T)
 // CHECK:         [[COPY_ADDR:%[^,]+]] = alloc_stack $T
-// CHECK:         apply undef<T>([[INSTANCE_ADDR]]) : $@convention(thin) <τ_0_0> () -> @out (τ_0_0, τ_0_0)
-// CHECK:         [[ONE_ADDR:%[^,]+]] = tuple_element_addr [[INSTANCE_ADDR]]{{.*}}, 0
 // CHECK:         [[TWO_ADDR:%[^,]+]] = tuple_element_addr [[INSTANCE_ADDR]]{{.*}}, 1
+// CHECK:         [[ONE_ADDR:%[^,]+]] = tuple_element_addr [[INSTANCE_ADDR]]{{.*}}, 0
+// CHECK:         apply undef<T>([[INSTANCE_ADDR]]) : $@convention(thin) <τ_0_0> () -> @out (τ_0_0, τ_0_0)
 // CHECK:         copy_addr [[ONE_ADDR]] to [init] [[COPY_ADDR]]
 // CHECK:         destroy_addr [[ONE_ADDR]]
 // CHECK:         destroy_addr [[TWO_ADDR]]
@@ -2270,11 +2270,15 @@ exit:
   return %retval : $()
 }
 
+enum PairEnum<T> {
+  case it(T, T)
+}
+
 // CHECK-LABEL: sil [ossa] @test_destructure_tuple_1_guaranteed : {{.*}} {
 // CHECK:         [[INSTANCE:%[^,]+]] = unchecked_take_enum_data_addr
+// CHECK:         [[ANY_ADDR:%[^,]+]] = tuple_element_addr [[INSTANCE]] {{.*}}, 1
 // CHECK:         [[KLASS_ADDR:%[^,]+]] = tuple_element_addr [[INSTANCE]] {{.*}}, 0
 // CHECK:         [[KLASS:%[^,]+]] = load_borrow [[KLASS_ADDR]]
-// CHECK:         [[ANY_ADDR:%[^,]+]] = tuple_element_addr [[INSTANCE]] {{.*}}, 1
 // CHECK:         apply undef<Any>([[ANY_ADDR]])
 // CHECK:         end_borrow [[KLASS]]
 // CHECK:         destroy_addr [[INSTANCE]]
@@ -2297,6 +2301,48 @@ failure:
 exit:
   %505 = tuple ()
   return %505 : $()
+}
+
+// Verify that projections from the unchecked_take_enum_data_addr are dominated
+// by it.
+// CHECK-LABEL: sil [ossa] @test_destructure_tuple_2_from_enum : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INOUT_ADDR:%[^,]+]] :
+// CHECK:         [[ORIGINAL_ADDR:%[^,]+]] = alloc_stack $PairEnum<T>
+// CHECK:         [[NEW_ADDR:%[^,]+]] = alloc_stack $PairEnum<T>
+// CHECK:         [[NEW_PAYLOAD_ADDR:%[^,]+]] = init_enum_data_addr [[NEW_ADDR]]
+// CHECK:         [[NEW_FIRST_ADDR:%[^,]+]] = tuple_element_addr [[NEW_PAYLOAD_ADDR]] {{.*}}, 0
+// CHECK:         [[NEW_SECOND_ADDR:%[^,]+]] = tuple_element_addr [[NEW_PAYLOAD_ADDR]] {{.*}}, 1
+// CHECK:         copy_addr [[INOUT_ADDR]] to [init] [[ORIGINAL_ADDR]] : $*PairEnum<T>
+// CHECK:         switch_enum_addr [[ORIGINAL_ADDR]] : $*PairEnum<T>
+// CHECK:       bb1:
+// CHECK:         [[ORIGINAL_PAYLOAD_ADDR:%[^,]+]] = unchecked_take_enum_data_addr [[ORIGINAL_ADDR]]
+// CHECK:         [[ORIGINAL_SECOND_ADDR:%[^,]+]] = tuple_element_addr [[ORIGINAL_PAYLOAD_ADDR]] {{.*}}, 1
+// CHECK:         [[ORIGINAL_FIRST_ADDR:%[^,]+]] = tuple_element_addr [[ORIGINAL_PAYLOAD_ADDR]] {{.*}}, 0
+// CHECK:         apply undef<T>([[NEW_FIRST_ADDR]], [[ORIGINAL_FIRST_ADDR]])
+// CHECK:         copy_addr [[ORIGINAL_SECOND_ADDR]] to [init] [[NEW_SECOND_ADDR]] : $*T
+// CHECK:         inject_enum_addr [[NEW_ADDR]]
+// CHECK:         destroy_addr [[NEW_ADDR]]
+// CHECK:         destroy_addr [[ORIGINAL_SECOND_ADDR]]
+// CHECK:         destroy_addr [[ORIGINAL_FIRST_ADDR]]
+// CHECK:         dealloc_stack [[NEW_ADDR]]
+// CHECK:         dealloc_stack [[ORIGINAL_ADDR]]
+// CHECK-LABEL: } // end sil function 'test_destructure_tuple_2_from_enum'
+sil [ossa] @test_destructure_tuple_2_from_enum : $@convention(thin) <T> (@inout PairEnum<T>) -> () {
+entry(%inout_addr : $*PairEnum<T>):
+  %original = load [copy] %inout_addr : $*PairEnum<T>
+  switch_enum %original : $PairEnum<T>, case #PairEnum.it!enumelt: it_block
+
+it_block(%original_payload : @owned $(T, T)):
+  (%original_first, %original_second) = destructure_tuple %original_payload : $(T, T)
+  %new_first = apply undef<T>(%original_first) : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> @out τ_0_0
+  %new_second = copy_value %original_second : $T
+  %new_payload = tuple (%new_first : $T, %new_second : $T)
+  %new = enum $PairEnum<T>, #PairEnum.it!enumelt, %new_payload : $(T, T)
+  destroy_value %new : $PairEnum<T>
+  destroy_value %original_second : $T
+  destroy_value %original_first : $T
+  %retval = tuple ()
+  return %retval : $()
 }
 
 // Check that the end_borrows created on behalf of the destructure_tuple end
@@ -2352,6 +2398,55 @@ inner_other(%s_box : @guaranteed $<Tau> { var AnyObject } <T>):
   br exit
 
 exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Verify that the init_enum_data_addr instruction is created before its first
+// use.  Although the opaque values are visited in forward order, their
+// uses are visited at the same time.  At that point, addresses are
+// materialized, and, in this case, an init_enum_data_addr is created.
+//
+// In this test, because %second_in is the first opaque value (i.e. in forward
+// order), its copy_value use is visited before %first_out is defined.  If the
+// init_enum_data_addr were created at that point and reused from then on, it
+// would be reused when rewriting the def of %first_out:
+//
+//     %second_in_addr = alloc_stack $T
+//     %out_addr = alloc_stack $PairEnum<T>
+//     apply undef<T>(%second_in_addr)
+//     %first_out_addr = tuple_element_addr %enum_data_addr, 0
+//                                          ^^^^^^^^^^^^^^^ USE BEFORE DEF
+//     apply undef<T>(%first_out_addr)
+//     %enum_data_addr = init_enum_data_addr %out_addr
+//     %second_out_addr = tuple_element_addr %enum_data_addr, 1
+//     copy_addr %second_in_addr to [init] %second_out_addr
+//
+// We would end up with a use of %enum_data_addr (in the definition of
+// %first_out_addr) that is not dominated by %enum_data_addr's def.
+//
+// CHECK-LABEL: sil [ossa] @test_enum_1_tuple_projection_dominance : {{.*}} {
+// CHECK:         [[SECOND_IN_ADDR:%[^,]+]] = alloc_stack $T
+// CHECK:         [[OUT_ADDR:%[^,]+]] = alloc_stack $PairEnum<T>
+// CHECK:         [[ENUM_DATA_ADDR:%[^,]+]] = init_enum_data_addr [[OUT_ADDR]]
+// CHECK:         [[FIRST_OUT_ADDR:%[^,]+]] = tuple_element_addr [[ENUM_DATA_ADDR]]{{.*}}, 0
+// CHECK:         [[SECOND_OUT_ADDR:%[^,]+]] = tuple_element_addr [[ENUM_DATA_ADDR]]{{.*}}, 1
+// CHECK:         apply undef<T>([[SECOND_IN_ADDR]])
+// CHECK:         apply undef<T>([[FIRST_OUT_ADDR]])
+// CHECK:         copy_addr [[SECOND_IN_ADDR]] to [init] [[SECOND_OUT_ADDR]]
+// CHECK:         inject_enum_addr [[OUT_ADDR]]
+// CHECK:         destroy_addr [[OUT_ADDR]]
+// CHECK:         destroy_addr [[SECOND_IN_ADDR]]
+// CHECK-LABEL: } // end sil function 'test_enum_1_tuple_projection_dominance'
+sil [ossa] @test_enum_1_tuple_projection_dominance : $@convention(thin) <T> () -> () {
+bb0:
+  %second_in = apply undef<T>() : $@convention(thin) <Tee> () -> @out Tee
+  %first_out = apply undef<T>() : $@convention(thin) <Tee> () -> @out Tee
+  %second_out = copy_value %second_in : $T
+  %pair_out = tuple (%first_out : $T, %second_out : $T)
+  %out = enum $PairEnum<T>, #PairEnum.it!enumelt, %pair_out : $(T, T)
+  destroy_value %out : $PairEnum<T>
+  destroy_value %second_in : $T
   %retval = tuple ()
   return %retval : $()
 }
@@ -2577,10 +2672,10 @@ bb0(%instance : @owned $T):
   return %retval : $()
 }
 // CHECK-LABEL: sil [ossa] @test_yield_1_two_values : {{.*}} {
-// CHECK:         tuple_element_addr
-// CHECK:         tuple_element_addr
 // CHECK:         [[KEY:%[^,]+]] = tuple_element_addr {{%[^,]+}} : $*(key: Key, value: Value), 0
 // CHECK:         [[VALUE:%[^,]+]] = tuple_element_addr {{%[^,]+}} : $*(key: Key, value: Value), 1
+// CHECK:         tuple_element_addr
+// CHECK:         tuple_element_addr
 // CHECK:         yield ([[KEY]] : $*Key, [[VALUE]] : $*Value)
 // CHECK-LABEL: } // end sil function 'test_yield_1_two_values'
 sil [ossa] @test_yield_1_two_values : $@yield_once @convention(method) <Key, Value> (@in_guaranteed Key, @in_guaranteed Value) -> (@yields @in_guaranteed Key, @yields @in_guaranteed Value) {

--- a/test/SILOptimizer/address_lowering.sil
+++ b/test/SILOptimizer/address_lowering.sil
@@ -130,11 +130,11 @@ bb0(%0 : @owned $(T, T)):
 
 // CHECK-LABEL: sil [ossa] @f012_decompose_tuple_arg : $@convention(thin) <T> (@in (T, T)) -> @out (T, T) {
 // CHECK: bb0(%0 : $*(T, T), %1 : $*(T, T)):
-// CHECK:   [[RET1:%.*]] = tuple_element_addr %0 : $*(T, T), 1
 // CHECK:   [[RET0:%.*]] = tuple_element_addr %0 : $*(T, T), 0
-// CHECK:   [[ARG1:%.*]] = tuple_element_addr %1 : $*(T, T), 1
 // CHECK:   [[ARG0:%.*]] = tuple_element_addr %1 : $*(T, T), 0
 // CHECK:   apply %{{.*}}<T>([[RET0]], [[ARG0]]) : $@convention(thin) <τ_0_0> (@in τ_0_0) -> @out τ_0_0
+// CHECK:   [[RET1:%.*]] = tuple_element_addr %0 : $*(T, T), 1
+// CHECK:   [[ARG1:%.*]] = tuple_element_addr %1 : $*(T, T), 1
 // CHECK:   copy_addr [take] [[ARG1]] to [init] [[RET1]] : $*T
 // CHECK-LABEL: } // end sil function 'f012_decompose_tuple_arg'
 sil [ossa] @f012_decompose_tuple_arg : $@convention(thin) <T> (@in (T, T)) -> @out (T, T) {
@@ -150,14 +150,14 @@ bb0(%0 : @owned $(T, T)):
 // CHECK: bb0(%0 : $*T, %1 : $*T):
 // CHECK:   [[IN:%.*]] = alloc_stack $(T, T)
 // CHECK:   [[OUT:%.*]] = alloc_stack $(T, T)
-// CHECK:   [[IN0:%.*]] = tuple_element_addr %2 : $*(T, T), 0
 // CHECK:   [[IN1:%.*]] = tuple_element_addr [[IN]] : $*(T, T), 1
-// CHECK:   [[DEAD:%.*]] = tuple_element_addr [[OUT]] : $*(T, T), 1
-// CHECK:   [[RET:%.*]] = tuple_element_addr [[OUT]] : $*(T, T), 0
 // CHECK:   copy_addr %1 to [init] [[IN1]] : $*T
+// CHECK:   [[IN0:%.*]] = tuple_element_addr %2 : $*(T, T), 0
 // CHECK:   copy_addr [take] %1 to [init] [[IN0]] : $*T
 // CHECK:   apply %{{.*}}<T>([[OUT]], [[IN]]) : $@convention(thin) <τ_0_0> (@in (τ_0_0, τ_0_0)) -> @out (τ_0_0, τ_0_0)
+// CHECK:   [[DEAD:%.*]] = tuple_element_addr [[OUT]] : $*(T, T), 1
 // CHECK:   destroy_addr [[DEAD]] : $*T
+// CHECK:   [[RET:%.*]] = tuple_element_addr [[OUT]] : $*(T, T), 0
 // CHECK:   copy_addr [take] [[RET]] to [init] %0 : $*T
 // CHECK-LABEL: } // end sil function 'f013_pass_tuple_arg'
 sil [ossa] @f013_pass_tuple_arg : $@convention(thin) <T> (@in T) -> @out T {
@@ -529,14 +529,14 @@ bb0:
 // CHECK-LABEL: sil [ossa] @f075_reusedResult : $@convention(thin) <T> (@in T, @owned any C) -> (@out T, @owned any C) {
 // CHECK: bb0(%0 : $*T, %1 : $*T, %2 : @owned $any C):
 // CHECK:   [[TUPLE:%.*]] = alloc_stack $(T, any C)
-// CHECK:   [[E1_2:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, any C), 0
 // CHECK:   [[E1_1:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, any C), 0
-// CHECK:   [[E2:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, any C), 1
 // CHECK:   copy_addr [take] %1 to [init] [[E1_1]] : $*T
+// CHECK:   [[E2:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, any C), 1
 // CHECK:   store %2 to [init] [[E2]] : $*any C
 // CHECK:   apply %{{.*}}<T>([[TUPLE]]) : $@convention(thin) <τ_0_0> (@in_guaranteed (τ_0_0, any C)) -> ()
 // CHECK:   [[E2:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, any C), 1
 // CHECK:   [[LD:%.*]] = load [take] [[E2]] : $*any C
+// CHECK:   [[E1_2:%.*]] = tuple_element_addr [[TUPLE]] : $*(T, any C), 0
 // CHECK:   copy_addr [take] [[E1_2]] to [init] %0 : $*T
 // CHECK:   dealloc_stack [[TUPLE]] : $*(T, any C)
 // CHECK:   return [[LD]] : $any C
@@ -638,8 +638,8 @@ bb0(%0 : @owned $Any):
 // CHECK-LABEL: sil [ossa] @f101_passAny : $@convention(thin) <T> (@in T) -> () {
 // CHECK: bb0(%0 : $*T):
 // CHECK:   %[[A:.*]] = alloc_stack $Any
-// CHECK:   %[[T2:.*]] = init_existential_addr %[[A]] : $*Any, $T
 // CHECK:   %[[F:.*]] = function_ref @f100_any : $@convention(thin) (@in Any) -> ()
+// CHECK:   %[[T2:.*]] = init_existential_addr %[[A]] : $*Any, $T
 // CHECK:   copy_addr %0 to [init] %[[T2]] : $*T
 // CHECK:   %{{.*}} = apply %[[F]](%[[A]]) : $@convention(thin) (@in Any) -> ()
 // CHECK:   destroy_addr %0 : $*T
@@ -662,9 +662,9 @@ bb0(%0 : @owned $T):
 // CHECK-LABEL: sil [ossa] @f102_passAnyObjectAsAny : $@convention(thin) (@in AnyObject) -> () {
 // CHECK: bb0(%0 : $*AnyObject):
 // CHECK:   [[A:%.*]] = alloc_stack $Any
-// CHECK:   [[VAL:%.*]] = init_existential_addr [[A]] : $*Any, $AnyObject
 // CHECK:   [[ARG:%.*]] = load [take] %0 : $*AnyObject
 // CHECK:   [[F:%.*]] = function_ref @f100_any : $@convention(thin) (@in Any) -> ()
+// CHECK:   [[VAL:%.*]] = init_existential_addr [[A]] : $*Any, $AnyObject
 // CHECK:   store [[ARG]] to [init] [[VAL]] : $*AnyObject
 // CHECK:   %{{.*}} = apply [[F]]([[A]]) : $@convention(thin) (@in Any) -> ()
 // CHECK:   [[R:%.*]] = tuple ()
@@ -699,9 +699,9 @@ bb0:
 
 // CHECK-LABEL: sil [ossa] @f120_testDestructure : $@convention(method) <Element> (@in SI<Element>) -> (@out Element, @out I) {
 // CHECK: bb0(%0 : $*Element, %1 : $*I, %2 : $*SI<Element>):
-// CHECK:   [[ELT_ADR:%.*]] = struct_element_addr %2 : $*SI<Element>, #SI.element
 // CHECK:   [[IDX_ADR:%.*]] = struct_element_addr %2 : $*SI<Element>, #SI.index
 // CHECK:   [[IDX:%.*]] = load [trivial] [[IDX_ADR]] : $*I
+// CHECK:   [[ELT_ADR:%.*]] = struct_element_addr %2 : $*SI<Element>, #SI.element
 // CHECK:   copy_addr [take] [[ELT_ADR]] to [init] %0 : $*Element // id: %6
 // CHECK:   store [[IDX]] to [trivial] %1 : $*I
 // CHECK:   return %{{.*}} : $()
@@ -740,9 +740,9 @@ bb0(%0 : @owned $SI<AnyObject>):
 // CHECK-LABEL: sil [ossa] @f122_testStructExtract : $@convention(method) <T> (@in SRef<T>) -> (@out AnyObject, @out T) {
 // CHECK: bb0(%0 : $*AnyObject, %1 : $*T, %2 : $*SRef<T>):
 // CHECK-NOT: alloc_stack
-// CHECK:   [[E1:%.*]] = struct_element_addr %2 : $*SRef<T>, #SRef.element
 // CHECK:   [[E0:%.*]] = struct_element_addr %2 : $*SRef<T>, #SRef.object
 // CHECK:   [[C:%.*]] = load [copy] [[E0]] : $*AnyObject
+// CHECK:   [[E1:%.*]] = struct_element_addr %2 : $*SRef<T>, #SRef.element
 // CHECK:   copy_addr [[E1]] to [init] %1 : $*T
 // CHECK:   destroy_addr %2 : $*SRef<T>
 // CHECK:   store [[C]] to [init] %0 : $*AnyObject
@@ -764,11 +764,11 @@ bb0(%0 : @owned $SRef<T>):
 // CHECK-LABEL: sil [ossa] @f123_testStructExtract : $@convention(method) <T> (@in SRef<T>) -> (@out AnyObject, @out T) {
 // CHECK: bb0(%0 : $*AnyObject, %1 : $*T, %2 : $*SRef<T>):
 // CHECK-NOT: alloc_stack
-// CHECK:   [[E1:%.*]] = struct_element_addr %2 : $*SRef<T>, #SRef.element
 // CHECK:   [[E0:%.*]] = struct_element_addr %2 : $*SRef<T>, #SRef.object
 // CHECK:   [[L:%.*]] = load_borrow [[E0]] : $*AnyObject
 // CHECK:   apply %{{.*}}([[L]]) : $@convention(thin) (@guaranteed AnyObject) -> ()
 // CHECK:   [[C:%.*]] = copy_value [[L]] : $AnyObject
+// CHECK:   [[E1:%.*]] = struct_element_addr %2 : $*SRef<T>, #SRef.element
 // CHECK:   copy_addr [[E1]] to [init] %1 : $*T
 // CHECK:   end_borrow [[L]] : $AnyObject
 // CHECK:   destroy_addr %2 : $*SRef<T>
@@ -793,9 +793,9 @@ bb0(%0 : @owned $SRef<T>):
 // CHECK-LABEL: sil [ossa] @f124_testTupleExtract : $@convention(method) <T> (@in (AnyObject, T)) -> (@out AnyObject, @out T) {
 // CHECK: bb0(%0 : $*AnyObject, %1 : $*T, %2 : $*(AnyObject, T)):
 // CHECK-NOT: alloc_stack
-// CHECK:   [[E1:%.*]] = tuple_element_addr %2 : $*(AnyObject, T), 1
 // CHECK:   [[E0:%.*]] = tuple_element_addr %2 : $*(AnyObject, T), 0
 // CHECK:   [[C:%.*]] = load [copy] [[E0]] : $*AnyObject
+// CHECK:   [[E1:%.*]] = tuple_element_addr %2 : $*(AnyObject, T), 1
 // CHECK:   copy_addr [[E1]] to [init] %1 : $*T
 // CHECK:   destroy_addr %2 : $*(AnyObject, T)
 // CHECK:   store [[C]] to [init] %0 : $*AnyObject
@@ -816,11 +816,11 @@ bb0(%0 : @owned $(AnyObject, T)):
 // CHECK-LABEL: sil [ossa] @f125_testTupleExtract : $@convention(method) <T> (@in (AnyObject, T)) -> (@out AnyObject, @out T) {
 // CHECK: bb0(%0 : $*AnyObject, %1 : $*T, %2 : $*(AnyObject, T)):
 // CHECK-NOT: alloc_stack
-// CHECK:   [[E1:%.*]] = tuple_element_addr %2 : $*(AnyObject, T), 1
 // CHECK:   [[E0:%.*]] = tuple_element_addr %2 : $*(AnyObject, T), 0
 // CHECK:   [[L:%.*]] = load_borrow [[E0]] : $*AnyObject
 // CHECK:   apply %{{.*}}([[L]]) : $@convention(thin) (@guaranteed AnyObject) -> ()
 // CHECK:   [[C:%.*]] = copy_value [[L]] : $AnyObject
+// CHECK:   [[E1:%.*]] = tuple_element_addr %2 : $*(AnyObject, T), 1
 // CHECK:   copy_addr [[E1]] to [init] %1 : $*T
 // CHECK:   end_borrow [[L]] : $AnyObject
 // CHECK:   destroy_addr %2 : $*(AnyObject, T)
@@ -844,10 +844,10 @@ bb0(%0 : @owned $(AnyObject, T)):
 
 // CHECK-LABEL: sil [ossa] @f126_testDestructureAndBorrow : $@convention(method) <Element> (@in (SI<Element>, I)) -> (@out Element, @out I) {
 // CHECK: bb0(%0 : $*Element, %1 : $*I, %2 : $*(SI<Element>, I)):
-// CHECK:   [[SI:%.*]] = tuple_element_addr %2 : $*(SI<Element>, I), 0
-// CHECK:   [[E:%.*]] = struct_element_addr [[SI]] : $*SI<Element>, #SI.element
 // CHECK:   [[I:%.*]] = tuple_element_addr %2 : $*(SI<Element>, I), 1
 // CHECK:   [[LD:%.*]] = load [trivial] [[I]] : $*I
+// CHECK:   [[SI:%.*]] = tuple_element_addr %2 : $*(SI<Element>, I), 0
+// CHECK:   [[E:%.*]] = struct_element_addr [[SI]] : $*SI<Element>, #SI.element
 // CHECK:   copy_addr [[E]] to [init] %0 : $*Element
 // CHECK:   destroy_addr [[SI]] : $*SI<Element>
 // CHECK:   store [[LD]] to [trivial] %1 : $*I
@@ -879,12 +879,12 @@ bb0(%0 : @owned $T):
 // CHECK-LABEL: sil [ossa] @f140_testTupleProject : $@convention(thin) <T> (@in T) -> () {
 // CHECK: bb0(%0 : $*T):
 // CHECK:   [[LOCAL:%.*]] = alloc_stack $((T, T), T)
-// CHECK:   [[ELT1:%.*]] = tuple_element_addr [[LOCAL]] : $*((T, T), T), 1
 // CHECK:   [[ELT0:%.*]] = tuple_element_addr [[LOCAL]] : $*((T, T), T), 0
-// CHECK:   [[ELT0_1:%.*]] = tuple_element_addr [[ELT0]] : $*(T, T), 1
 // CHECK:   [[ELT0_0:%.*]] = tuple_element_addr [[ELT0]] : $*(T, T), 0
 // CHECK:   copy_addr %0 to [init] [[ELT0_0]] : $*T
+// CHECK:   [[ELT1:%.*]] = tuple_element_addr [[LOCAL]] : $*((T, T), T), 1
 // CHECK:   copy_addr %0 to [init] [[ELT1]] : $*T
+// CHECK:   [[ELT0_1:%.*]] = tuple_element_addr [[ELT0]] : $*(T, T), 1
 // CHECK:   copy_addr [take] %0 to [init] [[ELT0_1]] : $*T
 // CHECK:   destroy_addr [[LOCAL]] : $*((T, T), T)
 // CHECK:   dealloc_stack [[LOCAL]] : $*((T, T), T)
@@ -904,12 +904,12 @@ bb0(%0 : @owned $T):
 // CHECK-LABEL: sil [ossa] @f150_testStructProject : $@convention(thin) <T> (@in T) -> () {
 // CHECK: bb0(%0 : $*T):
 // CHECK:   [[ALLOC:%.*]] = alloc_stack $Pair<Pair<T>>
-// CHECK:   [[ELT_Y:%.*]] = struct_element_addr [[ALLOC]] : $*Pair<Pair<T>>, #Pair.y
 // CHECK:   [[ELT_X:%.*]] = struct_element_addr [[ALLOC]] : $*Pair<Pair<T>>, #Pair.x
-// CHECK:   [[ELT_XX:%.*]] = struct_element_addr [[ELT_X]] : $*Pair<T>, #Pair.x
 // CHECK:   [[ELT_XY:%.*]] = struct_element_addr [[ELT_X]] : $*Pair<T>, #Pair.y
 // CHECK:   copy_addr %0 to [init] [[ELT_XY]] : $*T
+// CHECK:   [[ELT_XX:%.*]] = struct_element_addr [[ELT_X]] : $*Pair<T>, #Pair.x
 // CHECK:   copy_addr [take] %0 to [init] [[ELT_XX]] : $*T
+// CHECK:   [[ELT_Y:%.*]] = struct_element_addr [[ALLOC]] : $*Pair<Pair<T>>, #Pair.y
 // CHECK:   copy_addr [[ELT_X]] to [init] [[ELT_Y]] : $*Pair<T>
 // CHECK:   destroy_addr [[ALLOC]] : $*Pair<Pair<T>>
 // CHECK:   dealloc_stack [[ALLOC]] : $*Pair<Pair<T>>
@@ -970,8 +970,8 @@ bb0(%0 : @owned $P):
 // CHECK:   copy_addr %0 to [init] [[ALLOCP]] : $*any P
 // CHECK:   [[OPEN:%.*]] = open_existential_addr immutable_access %0 : $*any P to $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
 // CHECK:   [[OPTIONAL:%.*]] = alloc_stack $Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>
-// CHECK:   [[INIT:%.*]] = init_enum_data_addr [[OPTIONAL]] : $*Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>, #Optional.some!enumelt
 // CHECK:   witness_method $@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self, #P.foo : <Self where Self : P> (Self) -> () -> (), [[OPEN]] : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+// CHECK:   [[INIT:%.*]] = init_enum_data_addr [[OPTIONAL]] : $*Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>, #Optional.some!enumelt
 // CHECK:   copy_addr [[OPEN]] to [init] [[INIT]] : $*@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self
 // CHECK:   inject_enum_addr [[OPTIONAL]] : $*Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>, #Optional.some!enumelt
 // CHECK:   [[DATA:%.*]] = unchecked_take_enum_data_addr [[OPTIONAL]] : $*Optional<@opened("EF755EF2-B636-11E7-B7B4-A45E60ECC541", any P) Self>, #Optional.some!enumelt
@@ -1460,7 +1460,7 @@ sil [ossa] @lexical_borrow_struct_extract : $@convention(thin) <T> () -> () {
 }
 
 // CHECK-LABEL: sil [ossa] @lexical_borrow_struct_extract_arg {{.*}} {
-// CHECK:         [[X_ADDR:%[^,]+]] = struct_element_addr [[PAIR_ADDR]]
+// CHECK:         [[X_ADDR:%[^,]+]] = struct_element_addr [[PAIR_ADDR:%[^,]+]]
 // CHECK:         apply {{%[^,]+}}<T>([[X_ADDR]])
 // CHECK:         destroy_addr [[PAIR_ADDR]]
 // CHECK-LABEL: } // end sil function 'lexical_borrow_struct_extract_arg'
@@ -1959,10 +1959,10 @@ entry:
 
 // CHECK-LABEL: sil [ossa] @testCopyValue1StoreExtractAfterDestroyAggregate : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] :
-// CHECK:         [[INSTANCE_ADDR:%[^,]+]] = alloc_stack $Pair<T>
 // CHECK:         [[COPY_ADDR:%[^,]+]] = alloc_stack $T
-// CHECK:         [[X_ADDR:%[^,]+]] = struct_element_addr [[INSTANCE_ADDR]]{{.*}}, #Pair.x
+// CHECK:         [[INSTANCE_ADDR:%[^,]+]] = alloc_stack $Pair<T>
 // CHECK:         apply undef<T>([[INSTANCE_ADDR]])
+// CHECK:         [[X_ADDR:%[^,]+]] = struct_element_addr [[INSTANCE_ADDR]]{{.*}}, #Pair.x
 // CHECK:         copy_addr [[X_ADDR]] to [init] [[COPY_ADDR]]
 // CHECK:         destroy_addr [[INSTANCE_ADDR]]
 // CHECK:         copy_addr [take] [[COPY_ADDR]] to [[ADDR]]
@@ -2003,11 +2003,11 @@ entry(%addr : $*T):
 // CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] :
 // CHECK:         [[INSTANCE_ADDR:%[^,]+]] = alloc_stack $(T, T)
 // CHECK:         [[COPY_ADDR:%[^,]+]] = alloc_stack $T
-// CHECK:         [[TWO_ADDR:%[^,]+]] = tuple_element_addr [[INSTANCE_ADDR]]{{.*}}, 1
-// CHECK:         [[ONE_ADDR:%[^,]+]] = tuple_element_addr [[INSTANCE_ADDR]]{{.*}}, 0
 // CHECK:         apply undef<T>([[INSTANCE_ADDR]]) : $@convention(thin) <τ_0_0> () -> @out (τ_0_0, τ_0_0)
+// CHECK:         [[ONE_ADDR:%[^,]+]] = tuple_element_addr [[INSTANCE_ADDR]]{{.*}}, 0
 // CHECK:         copy_addr [[ONE_ADDR]] to [init] [[COPY_ADDR]]
 // CHECK:         destroy_addr [[ONE_ADDR]]
+// CHECK:         [[TWO_ADDR:%[^,]+]] = tuple_element_addr [[INSTANCE_ADDR]]{{.*}}, 1
 // CHECK:         destroy_addr [[TWO_ADDR]]
 // CHECK:         copy_addr [take] [[COPY_ADDR]] to [[ADDR]]
 // CHECK-LABEL: } // end sil function 'testCopyValue3StoreTupleDestructureFieldAfterDestroy'
@@ -2239,9 +2239,9 @@ bb3:
 // CHECK-LABEL: sil [ossa] @test_checked_cast_br4 : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[OUT_ADDR:%[^,]+]] : $*Optional<T>, [[INSTANCE:%[^,]+]] : @owned $TestGeneric<Element>):
 // CHECK:         [[TEMP:%[^,]+]] = alloc_stack $Optional<T>
-// CHECK:         [[CAST_DEST_ADDR:%[^,]+]] = init_enum_data_addr [[TEMP]] : $*Optional<T>, #Optional.some!enumelt
 // CHECK:         [[CAST_SOURCE_ADDR:%[^,]+]] = alloc_stack $TestGeneric<Element>
 // CHECK:         store [[INSTANCE]] to [init] [[CAST_SOURCE_ADDR]]
+// CHECK:         [[CAST_DEST_ADDR:%[^,]+]] = init_enum_data_addr [[TEMP]] : $*Optional<T>, #Optional.some!enumelt
 // CHECK:         checked_cast_addr_br take_on_success TestGeneric<Element> in [[CAST_SOURCE_ADDR]] : $*TestGeneric<Element> to T in [[CAST_DEST_ADDR]] : $*T, [[SUCCESS:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
 // CHECK:         dealloc_stack [[CAST_SOURCE_ADDR]]
@@ -2325,9 +2325,9 @@ enum PairEnum<T> {
 
 // CHECK-LABEL: sil [ossa] @test_destructure_tuple_1_guaranteed : {{.*}} {
 // CHECK:         [[INSTANCE:%[^,]+]] = unchecked_take_enum_data_addr
-// CHECK:         [[ANY_ADDR:%[^,]+]] = tuple_element_addr [[INSTANCE]] {{.*}}, 1
 // CHECK:         [[KLASS_ADDR:%[^,]+]] = tuple_element_addr [[INSTANCE]] {{.*}}, 0
 // CHECK:         [[KLASS:%[^,]+]] = load_borrow [[KLASS_ADDR]]
+// CHECK:         [[ANY_ADDR:%[^,]+]] = tuple_element_addr [[INSTANCE]] {{.*}}, 1
 // CHECK:         apply undef<Any>([[ANY_ADDR]])
 // CHECK:         end_borrow [[KLASS]]
 // CHECK:         destroy_addr [[INSTANCE]]
@@ -2358,16 +2358,16 @@ exit:
 // CHECK:       {{bb[0-9]+}}([[INOUT_ADDR:%[^,]+]] :
 // CHECK:         [[ORIGINAL_ADDR:%[^,]+]] = alloc_stack $PairEnum<T>
 // CHECK:         [[NEW_ADDR:%[^,]+]] = alloc_stack $PairEnum<T>
-// CHECK:         [[NEW_PAYLOAD_ADDR:%[^,]+]] = init_enum_data_addr [[NEW_ADDR]]
-// CHECK:         [[NEW_FIRST_ADDR:%[^,]+]] = tuple_element_addr [[NEW_PAYLOAD_ADDR]] {{.*}}, 0
-// CHECK:         [[NEW_SECOND_ADDR:%[^,]+]] = tuple_element_addr [[NEW_PAYLOAD_ADDR]] {{.*}}, 1
 // CHECK:         copy_addr [[INOUT_ADDR]] to [init] [[ORIGINAL_ADDR]] : $*PairEnum<T>
 // CHECK:         switch_enum_addr [[ORIGINAL_ADDR]] : $*PairEnum<T>
 // CHECK:       bb1:
 // CHECK:         [[ORIGINAL_PAYLOAD_ADDR:%[^,]+]] = unchecked_take_enum_data_addr [[ORIGINAL_ADDR]]
-// CHECK:         [[ORIGINAL_SECOND_ADDR:%[^,]+]] = tuple_element_addr [[ORIGINAL_PAYLOAD_ADDR]] {{.*}}, 1
+// CHECK:         [[NEW_PAYLOAD_ADDR:%[^,]+]] = init_enum_data_addr [[NEW_ADDR]]
+// CHECK:         [[NEW_FIRST_ADDR:%[^,]+]] = tuple_element_addr [[NEW_PAYLOAD_ADDR]] {{.*}}, 0
 // CHECK:         [[ORIGINAL_FIRST_ADDR:%[^,]+]] = tuple_element_addr [[ORIGINAL_PAYLOAD_ADDR]] {{.*}}, 0
 // CHECK:         apply undef<T>([[NEW_FIRST_ADDR]], [[ORIGINAL_FIRST_ADDR]])
+// CHECK:         [[NEW_SECOND_ADDR:%[^,]+]] = tuple_element_addr [[NEW_PAYLOAD_ADDR]] {{.*}}, 1
+// CHECK:         [[ORIGINAL_SECOND_ADDR:%[^,]+]] = tuple_element_addr [[ORIGINAL_PAYLOAD_ADDR]] {{.*}}, 1
 // CHECK:         copy_addr [[ORIGINAL_SECOND_ADDR]] to [init] [[NEW_SECOND_ADDR]] : $*T
 // CHECK:         inject_enum_addr [[NEW_ADDR]]
 // CHECK:         destroy_addr [[NEW_ADDR]]
@@ -2477,11 +2477,11 @@ exit:
 // CHECK-LABEL: sil [ossa] @test_enum_1_tuple_projection_dominance : {{.*}} {
 // CHECK:         [[SECOND_IN_ADDR:%[^,]+]] = alloc_stack $T
 // CHECK:         [[OUT_ADDR:%[^,]+]] = alloc_stack $PairEnum<T>
+// CHECK:         apply undef<T>([[SECOND_IN_ADDR]])
 // CHECK:         [[ENUM_DATA_ADDR:%[^,]+]] = init_enum_data_addr [[OUT_ADDR]]
 // CHECK:         [[FIRST_OUT_ADDR:%[^,]+]] = tuple_element_addr [[ENUM_DATA_ADDR]]{{.*}}, 0
-// CHECK:         [[SECOND_OUT_ADDR:%[^,]+]] = tuple_element_addr [[ENUM_DATA_ADDR]]{{.*}}, 1
-// CHECK:         apply undef<T>([[SECOND_IN_ADDR]])
 // CHECK:         apply undef<T>([[FIRST_OUT_ADDR]])
+// CHECK:         [[SECOND_OUT_ADDR:%[^,]+]] = tuple_element_addr [[ENUM_DATA_ADDR]]{{.*}}, 1
 // CHECK:         copy_addr [[SECOND_IN_ADDR]] to [init] [[SECOND_OUT_ADDR]]
 // CHECK:         inject_enum_addr [[OUT_ADDR]]
 // CHECK:         destroy_addr [[OUT_ADDR]]
@@ -2652,8 +2652,8 @@ bb0(%0 : @guaranteed $T):
 // CHECK-LABEL: sil hidden [ossa] @test_unconditional_checked_cast3 : $@convention(thin) <T, U> (@in_guaranteed T) -> @out U {
 // CHECK: bb0(%0 : $*U, %1 : $*T):
 // CHECK:   [[TTMP:%.*]] = alloc_stack $T
-// CHECK:   [[UTMP:%.*]] = alloc_stack [lexical] $U
 // CHECK:   copy_addr %1 to [init] [[TTMP]] : $*T
+// CHECK:   [[UTMP:%.*]] = alloc_stack [lexical] $U
 // CHECK:   unconditional_checked_cast_addr T in [[TTMP]] : $*T to U in [[UTMP]] : $*U
 // CHECK:   copy_addr [[UTMP]] to [init] %0 : $*U
 // CHECK:   destroy_addr [[UTMP]] : $*U
@@ -2721,10 +2721,10 @@ bb0(%instance : @owned $T):
   return %retval : $()
 }
 // CHECK-LABEL: sil [ossa] @test_yield_1_two_values : {{.*}} {
-// CHECK:         [[KEY:%[^,]+]] = tuple_element_addr {{%[^,]+}} : $*(key: Key, value: Value), 0
+// CHECK:         tuple_element_addr
+// CHECK:         tuple_element_addr
 // CHECK:         [[VALUE:%[^,]+]] = tuple_element_addr {{%[^,]+}} : $*(key: Key, value: Value), 1
-// CHECK:         tuple_element_addr
-// CHECK:         tuple_element_addr
+// CHECK:         [[KEY:%[^,]+]] = tuple_element_addr {{%[^,]+}} : $*(key: Key, value: Value), 0
 // CHECK:         yield ([[KEY]] : $*Key, [[VALUE]] : $*Value)
 // CHECK-LABEL: } // end sil function 'test_yield_1_two_values'
 sil [ossa] @test_yield_1_two_values : $@yield_once @convention(method) <Key, Value> (@in_guaranteed Key, @in_guaranteed Value) -> (@yields @in_guaranteed Key, @yields @in_guaranteed Value) {

--- a/test/SILOptimizer/address_lowering_phi.sil
+++ b/test/SILOptimizer/address_lowering_phi.sil
@@ -253,42 +253,42 @@ bb3(%phi0 : @owned $T, %phi1 : @owned $T):
 // CHECK:   [[ALLOCB:%.*]] = alloc_stack $SRef<T>
 // CHECK:   [[ALLOCSA:%.*]] = alloc_stack $SRef<T>
 // CHECK:   [[ALLOCSB:%.*]] = alloc_stack $SRef<T>
+// CHECK:   [[A1EADR:%.*]] = struct_element_addr [[ALLOCA]] : $*SRef<T>, #SRef.element
+// CHECK:   [[A2EADR:%.*]] = struct_element_addr [[ALLOCA]] : $*SRef<T>, #SRef.element
+// CHECK:   [[B1EADR:%.*]] = struct_element_addr [[ALLOCB]] : $*SRef<T>, #SRef.element
+// CHECK:   [[B2EADR:%.*]] = struct_element_addr [[ALLOCB]] : $*SRef<T>, #SRef.element
+// CHECK:   [[SA3EADR:%.*]] = struct_element_addr [[ALLOCSA]] : $*SRef<T>, #SRef.object
+// CHECK:   [[SA2EADR:%.*]] = struct_element_addr [[ALLOCSA]] : $*SRef<T>, #SRef.element
+// CHECK:   [[SA1EADR:%.*]] = struct_element_addr [[ALLOCSA]] : $*SRef<T>, #SRef.element
+// CHECK:   [[SB3EADR:%.*]] = struct_element_addr [[ALLOCSB]] : $*SRef<T>, #SRef.object
+// CHECK:   [[SB2EADR:%.*]] = struct_element_addr [[ALLOCSB]] : $*SRef<T>, #SRef.element
+// CHECK:   [[SB1EADR:%.*]] = struct_element_addr [[ALLOCSB]] : $*SRef<T>, #SRef.element
 // CHECK:   copy_addr [take] %0 to [init] [[ALLOCA]] : $*SRef<T>
 // CHECK:   copy_addr [take] %1 to [init] [[ALLOCB]] : $*SRef<T>
 // CHECK:   cond_br undef, bb2, bb1
 // CHECK: bb1:
 // CHECK:   [[A1OADR:%.*]] = struct_element_addr [[ALLOCA]] : $*SRef<T>, #SRef.object
 // CHECK:   [[A1O:%.*]] = load [take] [[A1OADR]] : $*AnyObject
-// CHECK:   [[A1EADR:%.*]] = struct_element_addr [[ALLOCA]] : $*SRef<T>, #SRef.element
 // CHECK:   [[B1OADR:%.*]] = struct_element_addr [[ALLOCB]] : $*SRef<T>, #SRef.object
 // CHECK:   [[B1O:%.*]] = load [take] [[B1OADR]] : $*AnyObject
-// CHECK:   [[B1EADR:%.*]] = struct_element_addr [[ALLOCB]] : $*SRef<T>, #SRef.element
 // CHECK:   destroy_value [[B1O]] : $AnyObject
 // CHECK:   [[CP1:%.*]] = copy_value [[A1O]] : $AnyObject
-// CHECK:   [[SA1EADR:%.*]] = struct_element_addr [[ALLOCSA]] : $*SRef<T>, #SRef.element
 // CHECK:   copy_addr [take] [[A1EADR]] to [init] [[SA1EADR]] : $*T
-// CHECK:   [[SB1EADR:%.*]] = struct_element_addr [[ALLOCSB]] : $*SRef<T>, #SRef.element
 // CHECK:   copy_addr [take] [[B1EADR]] to [init] [[SB1EADR]] : $*T
 // CHECK:   br bb3([[A1O]] : $AnyObject, [[CP1]] : $AnyObject)
 // CHECK: bb2:
 // CHECK:   [[A2OADR:%.*]] = struct_element_addr [[ALLOCA]] : $*SRef<T>, #SRef.object
 // CHECK:   [[A2O:%.*]] = load [take] [[A2OADR]] : $*AnyObject
-// CHECK:   [[A2EADR:%.*]] = struct_element_addr [[ALLOCA]] : $*SRef<T>, #SRef.element
 // CHECK:   [[B2OADR:%.*]] = struct_element_addr [[ALLOCB]] : $*SRef<T>, #SRef.object
 // CHECK:   [[B2O:%.*]] = load [take] [[B2OADR]] : $*AnyObject
-// CHECK:   [[B2EADR:%.*]] = struct_element_addr [[ALLOCB]] : $*SRef<T>, #SRef.element
 // CHECK:   destroy_value [[B2O]] : $AnyObject
 // CHECK:   [[CP2:%.*]] = copy_value [[A2O]] : $AnyObject
-// CHECK:   [[SB2EADR:%.*]] = struct_element_addr [[ALLOCSB]] : $*SRef<T>, #SRef.element
 // CHECK:   copy_addr [take] [[A2EADR]] to [init] [[SB2EADR]] : $*T
-// CHECK:   [[SA2EADR:%.*]] = struct_element_addr [[ALLOCSA]] : $*SRef<T>, #SRef.element
 // CHECK:   copy_addr [take] [[B2EADR]] to [init] [[SA2EADR]] : $*T
 // CHECK:   br bb3([[A2O]] : $AnyObject, [[CP2]] : $AnyObject)
 // CHECK: bb3([[PHI0:%.*]] : @owned $AnyObject, [[PHI1:%.*]] : @owned $AnyObject):
-// CHECK:   [[SA3EADR:%.*]] = struct_element_addr [[ALLOCSA]] : $*SRef<T>, #SRef.object
 // CHECK:   store [[PHI0]] to [init] [[SA3EADR]] : $*AnyObject
-// CHECK:   [[SA3EADR:%.*]] = struct_element_addr [[ALLOCSB]] : $*SRef<T>, #SRef.object
-// CHECK:   store [[PHI1]] to [init] [[SA3EADR]] : $*AnyObject
+// CHECK:   store [[PHI1]] to [init] [[SB3EADR]] : $*AnyObject
 // CHECK:   copy_addr [take] [[ALLOCSA]] to [init] %0 : $*SRef<T>
 // CHECK:   copy_addr [take] [[ALLOCSB]] to [init] %1 : $*SRef<T>
 // CHECK-LABEL: } // end sil function 'f070_testInoutFieldSwap'
@@ -323,13 +323,19 @@ bb3(%phio0 : @owned $AnyObject, %phio1 : @owned $AnyObject, %phie0 : @owned $T, 
 
 // CHECK-LABEL: sil [ossa] @f080_testNestedComposeEnumPhi : $@convention(thin) <T> (@in T, @in T, @owned AnyObject, @owned AnyObject) -> @out OuterEnum<T> {
 // CHECK: bb0(%0 : $*OuterEnum<T>, %1 : $*T, %2 : $*T, %3 : @owned $AnyObject, %4 : @owned $AnyObject):
+// CHECK:   [[TUPLE6:%.*]] = init_enum_data_addr %0 : $*OuterEnum<T>, #OuterEnum.inner!enumelt
+// CHECK:   [[TUPLE6_0:%.*]] = tuple_element_addr [[TUPLE6]] : $*(InnerEnum<T>, AnyObject), 0
+// CHECK:   [[TUPLE6_1:%.*]] = tuple_element_addr [[TUPLE6]] : $*(InnerEnum<T>, AnyObject), 1
+// CHECK:   [[TUPLE1:%.*]] = init_enum_data_addr [[INNER1:%.*]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
+// CHECK:   [[TUPLE1_0:%.*]] = tuple_element_addr [[TUPLE1]] : $*(T, AnyObject), 0
+// CHECK:   [[TUPLE1_1:%.*]] = tuple_element_addr [[TUPLE1]] : $*(T, AnyObject), 1
+// CHECK:   [[TUPLE5:%.*]] = init_enum_data_addr [[INNER5:%.*]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
+// CHECK:   [[TUPLE5_0:%.*]] = tuple_element_addr [[TUPLE5]] : $*(T, AnyObject), 0
+// CHECK:   [[TUPLE5_1:%.*]] = tuple_element_addr [[TUPLE5]] : $*(T, AnyObject), 1
 // CHECK:   cond_br undef, bb2, bb1
 // CHECK: bb1:
 // CHECK:   destroy_addr %2 : $*T
-// CHECK:   [[TUPLE1:%.*]] = init_enum_data_addr [[INNER1:%.*]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
-// CHECK:   [[TUPLE1_0:%.*]] = tuple_element_addr [[TUPLE1]] : $*(T, AnyObject), 0
 // CHECK:   copy_addr [take] %1 to [init] [[TUPLE1_0]] : $*T
-// CHECK:   [[TUPLE1_1:%.*]] = tuple_element_addr [[TUPLE1]] : $*(T, AnyObject), 1
 // CHECK:   store %3 to [init] [[TUPLE1_1]] : $*AnyObject
 // CHECK:   inject_enum_addr [[INNER1]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
 // CHECK:   copy_addr [take] [[INNER1]] to [init] [[PHI6:%.*]] : $*InnerEnum<T>
@@ -345,19 +351,13 @@ bb3(%phio0 : @owned $AnyObject, %phio1 : @owned $AnyObject, %phie0 : @owned $T, 
 // CHECK:   copy_addr [take] %1 to [init] [[PHI5]] : $*T
 // CHECK:   br bb5
 // CHECK: bb5:
-// CHECK:   [[TUPLE5:%.*]] = init_enum_data_addr [[INNER5:%.*]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
-// CHECK:   [[TUPLE5_0:%.*]] = tuple_element_addr [[TUPLE5]] : $*(T, AnyObject), 0
 // CHECK:   copy_addr [take] [[PHI5]] to [init] [[TUPLE5_0]] : $*T
-// CHECK:   [[TUPLE5_1:%.*]] = tuple_element_addr [[TUPLE5]] : $*(T, AnyObject), 1
 // CHECK:   store %3 to [init] [[TUPLE5_1]] : $*AnyObject
 // CHECK:   inject_enum_addr [[INNER5]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
 // CHECK:   copy_addr [take] [[INNER5]] to [init] [[PHI6:%.*]] : $*InnerEnum<T>
 // CHECK:   br bb6
 // CHECK: bb6:
-// CHECK:   [[TUPLE6:%.*]] = init_enum_data_addr %0 : $*OuterEnum<T>, #OuterEnum.inner!enumelt
-// CHECK:   [[TUPLE6_0:%.*]] = tuple_element_addr [[TUPLE6]] : $*(InnerEnum<T>, AnyObject), 0
 // CHECK:   copy_addr [take] [[PHI6]] to [init] [[TUPLE6_0]] : $*InnerEnum<T>
-// CHECK:   [[TUPLE6_1:%.*]] = tuple_element_addr [[TUPLE6]] : $*(InnerEnum<T>, AnyObject), 1
 // CHECK:   store %4 to [init] [[TUPLE6_1]] : $*AnyObject
 // CHECK:   inject_enum_addr %0 : $*OuterEnum<T>, #OuterEnum.inner!enumelt
 // CHECK-LABEL: } // end sil function 'f080_testNestedComposeEnumPhi'
@@ -390,36 +390,36 @@ bb6(%phi6 : @owned $InnerEnum<T>):
 // CHECK-LABEL: sil [ossa] @f080_testNestedComposeStructWithPhi : $@convention(thin) <T> (@in T, @in T, @owned AnyObject, @owned AnyObject) -> @out OuterStruct<T> {
 // CHECK: bb0(%0 : $*OuterStruct<T>, %1 : $*T, %2 : $*T, %3 : @owned $AnyObject, %4 : @owned $AnyObject):
 // CHECK-NOT: alloc
+// CHECK:   [[O6:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.object
+// CHECK:   [[INNER5:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
+// CHECK:   [[O5:%.*]] = struct_element_addr [[INNER5]] : $*InnerStruct<T>, #InnerStruct.object
+// CHECK:   [[INNER1:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
+// CHECK:   [[T2:%.*]] = struct_element_addr [[INNER1]] : $*InnerStruct<T>, #InnerStruct.t
+// CHECK:   [[O2:%.*]] = struct_element_addr [[INNER1]] : $*InnerStruct<T>, #InnerStruct.object
+// CHECK:   [[INNER3:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
+// CHECK:   [[T3:%.*]] = struct_element_addr [[INNER3]] : $*InnerStruct<T>, #InnerStruct.t
+// CHECK:   [[INNER4:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
+// CHECK:   [[T4:%.*]] = struct_element_addr [[INNER4]] : $*InnerStruct<T>, #InnerStruct.t
 // CHECK:   cond_br undef, bb2, bb1
 // CHECK: bb1:
 // CHECK:   destroy_addr %2 : $*T
-// CHECK:   [[INNER1:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
-// CHECK:   [[T2:%.*]] = struct_element_addr [[INNER1]] : $*InnerStruct<T>, #InnerStruct.t
 // CHECK:   copy_addr [take] %1 to [init] [[T2]] : $*T
-// CHECK:   [[O2:%.*]] = struct_element_addr [[INNER1]] : $*InnerStruct<T>, #InnerStruct.object
 // CHECK:   store %3 to [init] [[O2]] : $*AnyObject
 // CHECK:   br bb6
 // CHECK: bb2:
 // CHECK:   cond_br undef, bb4, bb3
 // CHECK: bb3:
 // CHECK:   destroy_addr %1 : $*T
-// CHECK:   [[INNER3:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
-// CHECK:   [[T3:%.*]] = struct_element_addr [[INNER3]] : $*InnerStruct<T>, #InnerStruct.t
 // CHECK:   copy_addr [take] %2 to [init] [[T3]] : $*T
 // CHECK:   br bb5
 // CHECK: bb4:
 // CHECK:   destroy_addr %2 : $*T
-// CHECK:   [[INNER4:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
-// CHECK:   [[T4:%.*]] = struct_element_addr [[INNER4]] : $*InnerStruct<T>, #InnerStruct.t
 // CHECK:   copy_addr [take] %1 to [init] [[T4]] : $*T
 // CHECK:   br bb5
 // CHECK: bb5:
-// CHECK:   [[INNER5:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
-// CHECK:   [[O5:%.*]] = struct_element_addr [[INNER5]] : $*InnerStruct<T>, #InnerStruct.object
 // CHECK:   store %3 to [init] [[O5]] : $*AnyObject
 // CHECK:   br bb6
 // CHECK: bb6:
-// CHECK:   [[O6:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.object
 // CHECK:   store %4 to [init] [[O6]] : $*AnyObject
 // CHECK-NOT: dealloc
 // CHECK-LABEL: } // end sil function 'f080_testNestedComposeStructWithPhi'
@@ -505,7 +505,7 @@ merge(%34 : @owned $Value):
 
 // CHECK-LABEL: sil [ossa] @f105_phi_into_tuple : {{.*}} {
 // CHECK:         [[STORAGE:%[^,]+]] = alloc_stack $(Self, Builtin.Int1)          
-// CHECK:         [[SELF_ADDR:%[^,]+]] = tuple_element_addr [[STORAGE]]
+// CHECK:         [[SELF_ADDR:%[^,]+]] = tuple_element_addr [[STORAGE]] : {{.*}}, 0
 // CHECK:         apply {{%[^,]+}}<Self>([[SELF_ADDR]])
 // CHECK-LABEL: } // end sil function 'f105_phi_into_tuple'
 sil [ossa] @f105_phi_into_tuple : $@convention(thin) <Self> () -> () {

--- a/test/SILOptimizer/address_lowering_phi.sil
+++ b/test/SILOptimizer/address_lowering_phi.sil
@@ -206,9 +206,9 @@ bb3(%arg0 : @owned $T, %arg1 : @owned $T):
 //
 // CHECK-LABEL: sil [ossa] @f060_testInoutSwap : $@convention(thin) <T> (@inout T, @inout T) -> () {
 // CHECK: bb0(%0 : $*T, %1 : $*T):
-// CHECK:   [[ALLOC0:%.*]] = alloc_stack $T
 // CHECK:   [[ALLOC1:%.*]] = alloc_stack $T
 // CHECK:   copy_addr [take] %0 to [init] [[ALLOC1]] : $*T
+// CHECK:   [[ALLOC0:%.*]] = alloc_stack $T
 // CHECK:   copy_addr [take] %1 to [init] [[ALLOC0]] : $*T
 // CHECK:   cond_br undef, bb2, bb1
 // CHECK: bb1:
@@ -223,8 +223,8 @@ bb3(%arg0 : @owned $T, %arg1 : @owned $T):
 // CHECK: bb3:
 // CHECK:   copy_addr [take] [[ALLOC0]] to [init] %0 : $*T
 // CHECK:   copy_addr [take] [[ALLOC1]] to [init] %1 : $*T
-// CHECK:   dealloc_stack [[ALLOC1]] : $*T
 // CHECK:   dealloc_stack [[ALLOC0]] : $*T
+// CHECK:   dealloc_stack [[ALLOC1]] : $*T
 // CHECK-LABEL: } // end sil function 'f060_testInoutSwap'
 sil [ossa] @f060_testInoutSwap : $@convention(thin) <T> (@inout T, @inout T) -> () {
 bb0(%0 : $*T, %1 : $*T):
@@ -253,16 +253,6 @@ bb3(%phi0 : @owned $T, %phi1 : @owned $T):
 // CHECK:   [[ALLOCB:%.*]] = alloc_stack $SRef<T>
 // CHECK:   [[ALLOCSA:%.*]] = alloc_stack $SRef<T>
 // CHECK:   [[ALLOCSB:%.*]] = alloc_stack $SRef<T>
-// CHECK:   [[A1EADR:%.*]] = struct_element_addr [[ALLOCA]] : $*SRef<T>, #SRef.element
-// CHECK:   [[A2EADR:%.*]] = struct_element_addr [[ALLOCA]] : $*SRef<T>, #SRef.element
-// CHECK:   [[B1EADR:%.*]] = struct_element_addr [[ALLOCB]] : $*SRef<T>, #SRef.element
-// CHECK:   [[B2EADR:%.*]] = struct_element_addr [[ALLOCB]] : $*SRef<T>, #SRef.element
-// CHECK:   [[SA3EADR:%.*]] = struct_element_addr [[ALLOCSA]] : $*SRef<T>, #SRef.object
-// CHECK:   [[SA2EADR:%.*]] = struct_element_addr [[ALLOCSA]] : $*SRef<T>, #SRef.element
-// CHECK:   [[SA1EADR:%.*]] = struct_element_addr [[ALLOCSA]] : $*SRef<T>, #SRef.element
-// CHECK:   [[SB3EADR:%.*]] = struct_element_addr [[ALLOCSB]] : $*SRef<T>, #SRef.object
-// CHECK:   [[SB2EADR:%.*]] = struct_element_addr [[ALLOCSB]] : $*SRef<T>, #SRef.element
-// CHECK:   [[SB1EADR:%.*]] = struct_element_addr [[ALLOCSB]] : $*SRef<T>, #SRef.element
 // CHECK:   copy_addr [take] %0 to [init] [[ALLOCA]] : $*SRef<T>
 // CHECK:   copy_addr [take] %1 to [init] [[ALLOCB]] : $*SRef<T>
 // CHECK:   cond_br undef, bb2, bb1
@@ -273,7 +263,11 @@ bb3(%phi0 : @owned $T, %phi1 : @owned $T):
 // CHECK:   [[B1O:%.*]] = load [take] [[B1OADR]] : $*AnyObject
 // CHECK:   destroy_value [[B1O]] : $AnyObject
 // CHECK:   [[CP1:%.*]] = copy_value [[A1O]] : $AnyObject
+// CHECK:   [[SA1EADR:%.*]] = struct_element_addr [[ALLOCSA]] : $*SRef<T>, #SRef.element
+// CHECK:   [[A1EADR:%.*]] = struct_element_addr [[ALLOCA]] : $*SRef<T>, #SRef.element
 // CHECK:   copy_addr [take] [[A1EADR]] to [init] [[SA1EADR]] : $*T
+// CHECK:   [[SB1EADR:%.*]] = struct_element_addr [[ALLOCSB]] : $*SRef<T>, #SRef.element
+// CHECK:   [[B1EADR:%.*]] = struct_element_addr [[ALLOCB]] : $*SRef<T>, #SRef.element
 // CHECK:   copy_addr [take] [[B1EADR]] to [init] [[SB1EADR]] : $*T
 // CHECK:   br bb3([[A1O]] : $AnyObject, [[CP1]] : $AnyObject)
 // CHECK: bb2:
@@ -283,11 +277,17 @@ bb3(%phi0 : @owned $T, %phi1 : @owned $T):
 // CHECK:   [[B2O:%.*]] = load [take] [[B2OADR]] : $*AnyObject
 // CHECK:   destroy_value [[B2O]] : $AnyObject
 // CHECK:   [[CP2:%.*]] = copy_value [[A2O]] : $AnyObject
+// CHECK:   [[SB2EADR:%.*]] = struct_element_addr [[ALLOCSB]] : $*SRef<T>, #SRef.element
+// CHECK:   [[A2EADR:%.*]] = struct_element_addr [[ALLOCA]] : $*SRef<T>, #SRef.element
 // CHECK:   copy_addr [take] [[A2EADR]] to [init] [[SB2EADR]] : $*T
+// CHECK:   [[SA2EADR:%.*]] = struct_element_addr [[ALLOCSA]] : $*SRef<T>, #SRef.element
+// CHECK:   [[B2EADR:%.*]] = struct_element_addr [[ALLOCB]] : $*SRef<T>, #SRef.element
 // CHECK:   copy_addr [take] [[B2EADR]] to [init] [[SA2EADR]] : $*T
 // CHECK:   br bb3([[A2O]] : $AnyObject, [[CP2]] : $AnyObject)
 // CHECK: bb3([[PHI0:%.*]] : @owned $AnyObject, [[PHI1:%.*]] : @owned $AnyObject):
+// CHECK:   [[SA3EADR:%.*]] = struct_element_addr [[ALLOCSA]] : $*SRef<T>, #SRef.object
 // CHECK:   store [[PHI0]] to [init] [[SA3EADR]] : $*AnyObject
+// CHECK:   [[SB3EADR:%.*]] = struct_element_addr [[ALLOCSB]] : $*SRef<T>, #SRef.object
 // CHECK:   store [[PHI1]] to [init] [[SB3EADR]] : $*AnyObject
 // CHECK:   copy_addr [take] [[ALLOCSA]] to [init] %0 : $*SRef<T>
 // CHECK:   copy_addr [take] [[ALLOCSB]] to [init] %1 : $*SRef<T>
@@ -323,19 +323,13 @@ bb3(%phio0 : @owned $AnyObject, %phio1 : @owned $AnyObject, %phie0 : @owned $T, 
 
 // CHECK-LABEL: sil [ossa] @f080_testNestedComposeEnumPhi : $@convention(thin) <T> (@in T, @in T, @owned AnyObject, @owned AnyObject) -> @out OuterEnum<T> {
 // CHECK: bb0(%0 : $*OuterEnum<T>, %1 : $*T, %2 : $*T, %3 : @owned $AnyObject, %4 : @owned $AnyObject):
-// CHECK:   [[TUPLE6:%.*]] = init_enum_data_addr %0 : $*OuterEnum<T>, #OuterEnum.inner!enumelt
-// CHECK:   [[TUPLE6_0:%.*]] = tuple_element_addr [[TUPLE6]] : $*(InnerEnum<T>, AnyObject), 0
-// CHECK:   [[TUPLE6_1:%.*]] = tuple_element_addr [[TUPLE6]] : $*(InnerEnum<T>, AnyObject), 1
-// CHECK:   [[TUPLE1:%.*]] = init_enum_data_addr [[INNER1:%.*]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
-// CHECK:   [[TUPLE1_0:%.*]] = tuple_element_addr [[TUPLE1]] : $*(T, AnyObject), 0
-// CHECK:   [[TUPLE1_1:%.*]] = tuple_element_addr [[TUPLE1]] : $*(T, AnyObject), 1
-// CHECK:   [[TUPLE5:%.*]] = init_enum_data_addr [[INNER5:%.*]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
-// CHECK:   [[TUPLE5_0:%.*]] = tuple_element_addr [[TUPLE5]] : $*(T, AnyObject), 0
-// CHECK:   [[TUPLE5_1:%.*]] = tuple_element_addr [[TUPLE5]] : $*(T, AnyObject), 1
 // CHECK:   cond_br undef, bb2, bb1
 // CHECK: bb1:
 // CHECK:   destroy_addr %2 : $*T
+// CHECK:   [[TUPLE1:%.*]] = init_enum_data_addr [[INNER1:%.*]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
+// CHECK:   [[TUPLE1_0:%.*]] = tuple_element_addr [[TUPLE1]] : $*(T, AnyObject), 0
 // CHECK:   copy_addr [take] %1 to [init] [[TUPLE1_0]] : $*T
+// CHECK:   [[TUPLE1_1:%.*]] = tuple_element_addr [[TUPLE1]] : $*(T, AnyObject), 1
 // CHECK:   store %3 to [init] [[TUPLE1_1]] : $*AnyObject
 // CHECK:   inject_enum_addr [[INNER1]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
 // CHECK:   copy_addr [take] [[INNER1]] to [init] [[PHI6:%.*]] : $*InnerEnum<T>
@@ -351,13 +345,19 @@ bb3(%phio0 : @owned $AnyObject, %phio1 : @owned $AnyObject, %phie0 : @owned $T, 
 // CHECK:   copy_addr [take] %1 to [init] [[PHI5]] : $*T
 // CHECK:   br bb5
 // CHECK: bb5:
+// CHECK:   [[TUPLE5:%.*]] = init_enum_data_addr [[INNER5:%.*]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
+// CHECK:   [[TUPLE5_0:%.*]] = tuple_element_addr [[TUPLE5]] : $*(T, AnyObject), 0
 // CHECK:   copy_addr [take] [[PHI5]] to [init] [[TUPLE5_0]] : $*T
+// CHECK:   [[TUPLE5_1:%.*]] = tuple_element_addr [[TUPLE5]] : $*(T, AnyObject), 1
 // CHECK:   store %3 to [init] [[TUPLE5_1]] : $*AnyObject
 // CHECK:   inject_enum_addr [[INNER5]] : $*InnerEnum<T>, #InnerEnum.payload!enumelt
 // CHECK:   copy_addr [take] [[INNER5]] to [init] [[PHI6:%.*]] : $*InnerEnum<T>
 // CHECK:   br bb6
 // CHECK: bb6:
+// CHECK:   [[TUPLE6:%.*]] = init_enum_data_addr %0 : $*OuterEnum<T>, #OuterEnum.inner!enumelt
+// CHECK:   [[TUPLE6_0:%.*]] = tuple_element_addr [[TUPLE6]] : $*(InnerEnum<T>, AnyObject), 0
 // CHECK:   copy_addr [take] [[PHI6]] to [init] [[TUPLE6_0]] : $*InnerEnum<T>
+// CHECK:   [[TUPLE6_1:%.*]] = tuple_element_addr [[TUPLE6]] : $*(InnerEnum<T>, AnyObject), 1
 // CHECK:   store %4 to [init] [[TUPLE6_1]] : $*AnyObject
 // CHECK:   inject_enum_addr %0 : $*OuterEnum<T>, #OuterEnum.inner!enumelt
 // CHECK-LABEL: } // end sil function 'f080_testNestedComposeEnumPhi'
@@ -390,36 +390,36 @@ bb6(%phi6 : @owned $InnerEnum<T>):
 // CHECK-LABEL: sil [ossa] @f080_testNestedComposeStructWithPhi : $@convention(thin) <T> (@in T, @in T, @owned AnyObject, @owned AnyObject) -> @out OuterStruct<T> {
 // CHECK: bb0(%0 : $*OuterStruct<T>, %1 : $*T, %2 : $*T, %3 : @owned $AnyObject, %4 : @owned $AnyObject):
 // CHECK-NOT: alloc
-// CHECK:   [[O6:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.object
-// CHECK:   [[INNER5:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
-// CHECK:   [[O5:%.*]] = struct_element_addr [[INNER5]] : $*InnerStruct<T>, #InnerStruct.object
-// CHECK:   [[INNER1:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
-// CHECK:   [[T2:%.*]] = struct_element_addr [[INNER1]] : $*InnerStruct<T>, #InnerStruct.t
-// CHECK:   [[O2:%.*]] = struct_element_addr [[INNER1]] : $*InnerStruct<T>, #InnerStruct.object
-// CHECK:   [[INNER3:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
-// CHECK:   [[T3:%.*]] = struct_element_addr [[INNER3]] : $*InnerStruct<T>, #InnerStruct.t
-// CHECK:   [[INNER4:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
-// CHECK:   [[T4:%.*]] = struct_element_addr [[INNER4]] : $*InnerStruct<T>, #InnerStruct.t
 // CHECK:   cond_br undef, bb2, bb1
 // CHECK: bb1:
 // CHECK:   destroy_addr %2 : $*T
+// CHECK:   [[INNER1:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
+// CHECK:   [[T2:%.*]] = struct_element_addr [[INNER1]] : $*InnerStruct<T>, #InnerStruct.t
 // CHECK:   copy_addr [take] %1 to [init] [[T2]] : $*T
+// CHECK:   [[O2:%.*]] = struct_element_addr [[INNER1]] : $*InnerStruct<T>, #InnerStruct.object
 // CHECK:   store %3 to [init] [[O2]] : $*AnyObject
 // CHECK:   br bb6
 // CHECK: bb2:
 // CHECK:   cond_br undef, bb4, bb3
 // CHECK: bb3:
 // CHECK:   destroy_addr %1 : $*T
+// CHECK:   [[INNER3:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
+// CHECK:   [[T3:%.*]] = struct_element_addr [[INNER3]] : $*InnerStruct<T>, #InnerStruct.t
 // CHECK:   copy_addr [take] %2 to [init] [[T3]] : $*T
 // CHECK:   br bb5
 // CHECK: bb4:
 // CHECK:   destroy_addr %2 : $*T
+// CHECK:   [[INNER4:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
+// CHECK:   [[T4:%.*]] = struct_element_addr [[INNER4]] : $*InnerStruct<T>, #InnerStruct.t
 // CHECK:   copy_addr [take] %1 to [init] [[T4]] : $*T
 // CHECK:   br bb5
 // CHECK: bb5:
+// CHECK:   [[INNER5:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.inner
+// CHECK:   [[O5:%.*]] = struct_element_addr [[INNER5]] : $*InnerStruct<T>, #InnerStruct.object
 // CHECK:   store %3 to [init] [[O5]] : $*AnyObject
 // CHECK:   br bb6
 // CHECK: bb6:
+// CHECK:   [[O6:%.*]] = struct_element_addr %0 : $*OuterStruct<T>, #OuterStruct.object
 // CHECK:   store %4 to [init] [[O6]] : $*AnyObject
 // CHECK-NOT: dealloc
 // CHECK-LABEL: } // end sil function 'f080_testNestedComposeStructWithPhi'

--- a/test/SILOptimizer/opaque_values_Onone.swift
+++ b/test/SILOptimizer/opaque_values_Onone.swift
@@ -79,9 +79,9 @@ func doit<T>(_ f: () -> T) -> T {
 // CHECK-LABEL: } // end sil function 'duplicate1'
 // CHECK-LABEL: sil private @$s19opaque_values_Onone10duplicate15valuex_xtx_tlFx_xtyXEfU_ : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[TUPLE_ADDR:%[^,]+]] : $*(Value, Value), [[VALUE_ADDR:%[^,]+]] :
+// CHECK:         [[ELT_2_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]]{{.*}}, 1
 // CHECK:         [[ELT_1_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]]{{.*}}, 0
 // CHECK:         copy_addr [[VALUE_ADDR]] to [init] [[ELT_1_ADDR]]
-// CHECK:         [[ELT_2_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]]{{.*}}, 1
 // CHECK:         copy_addr [[VALUE_ADDR]] to [init] [[ELT_2_ADDR]] : $*Value
 // CHECK-LABEL: } // end sil function '$s19opaque_values_Onone10duplicate15valuex_xtx_tlFx_xtyXEfU_'
 @_silgen_name("duplicate1")
@@ -103,9 +103,9 @@ func duplicate1<Value>(value: Value) -> (Value, Value) {
 // CHECK-LABEL: } // end sil function 'duplicate2'
 // CHECK-LABEL: sil private @$s19opaque_values_Onone10duplicate25valuex3one_x3twotx_tlFxAD_xAEtyXEfU_ : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[TUPLE_ADDR:%[^,]+]] : $*(one: Value, two: Value), [[VALUE_ADDR:%[^,]+]] :
+// CHECK:         [[ELT_2_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]]{{.*}}, 1
 // CHECK:         [[ELT_1_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]]{{.*}}, 0
 // CHECK:         copy_addr [[VALUE_ADDR]] to [init] [[ELT_1_ADDR]]
-// CHECK:         [[ELT_2_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]]{{.*}}, 1
 // CHECK:         copy_addr [[VALUE_ADDR]] to [init] [[ELT_2_ADDR]] : $*Value
 // CHECK-LABEL: } // end sil function '$s19opaque_values_Onone10duplicate25valuex3one_x3twotx_tlFxAD_xAEtyXEfU_'
 @_silgen_name("duplicate2")
@@ -139,22 +139,22 @@ func duplicate_with_int2<Value>(value: Value) -> ((Value, Value), Int) {
 // CHECK-LABEL: } // end sil function 'duplicate_with_int3'
 // CHECK-LABEL: sil private @$s19opaque_values_Onone19duplicate_with_int35valueSi_x_x_x_SitxttSitx_tlFSi_x_x_x_SitxttSityXEfU_ {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[OUT_ADDR:%[^,]+]] : $*(Int, (Value, (Value, (Value, Int), Value)), Int), [[IN_ADDR:%[^,]+]] : $*Value):
+// CHECK:         [[OUT_0_ADDR:%[^,]+]] = tuple_element_addr [[OUT_ADDR]] : $*(Int, (Value, (Value, (Value, Int), Value)), Int), 0
+// CHECK:         [[OUT_2_ADDR:%[^,]+]] = tuple_element_addr [[OUT_ADDR]] : $*(Int, (Value, (Value, (Value, Int), Value)), Int), 2
 // CHECK:         [[OUT_1_ADDR:%[^,]+]] = tuple_element_addr [[OUT_ADDR]] : $*(Int, (Value, (Value, (Value, Int), Value)), Int), 1
+// CHECK:         [[OUT_1_1_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_ADDR]] : $*(Value, (Value, (Value, Int), Value)), 1
+// CHECK:         [[OUT_1_1_2_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_ADDR]] : $*(Value, (Value, Int), Value), 2
+// CHECK:         [[OUT_1_1_1_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_ADDR]] : $*(Value, (Value, Int), Value), 1
+// CHECK:         [[OUT_1_1_1_1_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_1_ADDR]] : $*(Value, Int), 1
+// CHECK:         [[OUT_1_1_1_2_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_1_ADDR]] : $*(Value, Int), 0
+// CHECK:         [[OUT_1_1_0_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_ADDR]] : $*(Value, (Value, Int), Value), 0
 // CHECK:         [[OUT_1_0_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_ADDR]] : $*(Value, (Value, (Value, Int), Value)), 0
 // CHECK:         copy_addr [[IN_ADDR]] to [init] [[OUT_1_0_ADDR]]
-// CHECK:         [[OUT_1_1_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_ADDR]] : $*(Value, (Value, (Value, Int), Value)), 1
-// CHECK:         [[OUT_1_1_0_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_ADDR]] : $*(Value, (Value, Int), Value), 0
 // CHECK:         copy_addr [[IN_ADDR]] to [init] [[OUT_1_1_0_ADDR]]
-// CHECK:         [[OUT_1_1_1_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_ADDR]] : $*(Value, (Value, Int), Value), 1
-// CHECK:         [[OUT_1_1_1_2_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_1_ADDR]] : $*(Value, Int), 0
 // CHECK:         copy_addr [[IN_ADDR]] to [init] [[OUT_1_1_1_2_ADDR]]
-// CHECK:         [[OUT_1_1_2_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_ADDR]] : $*(Value, (Value, Int), Value), 2
 // CHECK:         copy_addr [[IN_ADDR]] to [init] [[OUT_1_1_2_ADDR]]
-// CHECK:         [[OUT_1_1_1_1_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_1_ADDR]] : $*(Value, Int), 1
 // CHECK:         store {{%[^,]+}} to [[OUT_1_1_1_1_ADDR]]
-// CHECK:         [[OUT_2_ADDR:%[^,]+]] = tuple_element_addr [[OUT_ADDR]] : $*(Int, (Value, (Value, (Value, Int), Value)), Int), 0
-// CHECK:         store {{%[^,]+}} to [[OUT_2_ADDR]]
-// CHECK:         [[OUT_2_ADDR:%[^,]+]] = tuple_element_addr [[OUT_ADDR]] : $*(Int, (Value, (Value, (Value, Int), Value)), Int), 2
+// CHECK:         store {{%[^,]+}} to [[OUT_0_ADDR]]
 // CHECK:         store {{%[^,]+}} to [[OUT_2_ADDR]]
 // CHECK-LABEL: } // end sil function '$s19opaque_values_Onone19duplicate_with_int35valueSi_x_x_x_SitxttSitx_tlFSi_x_x_x_SitxttSityXEfU_'
 @_silgen_name("duplicate_with_int3")
@@ -166,9 +166,9 @@ func duplicate_with_int3<Value>(value: Value) -> (Int, (Value, (Value, (Value, I
 
 // CHECK-LABEL: sil hidden @get_a_generic_tuple : {{.*}} {
 // CHECK:         [[TUPLE_ADDR:%[^,]+]] = alloc_stack [lexical] $(This, This)
-// CHECK:         [[GIVE_A_GENERIC_TUPLE:%[^,]+]] = function_ref @give_a_generic_tuple
-// CHECK:         [[TUPLE_0_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]] : $*(This, This), 0
 // CHECK:         [[TUPLE_1_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]] : $*(This, This), 1
+// CHECK:         [[TUPLE_0_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]] : $*(This, This), 0
+// CHECK:         [[GIVE_A_GENERIC_TUPLE:%[^,]+]] = function_ref @give_a_generic_tuple
 // CHECK:         apply [[GIVE_A_GENERIC_TUPLE]]<This>([[TUPLE_0_ADDR]], [[TUPLE_1_ADDR]], {{%[^,]+}})
 // CHECK:         destroy_addr [[TUPLE_ADDR]]
 // CHECK:         dealloc_stack [[TUPLE_ADDR]]

--- a/test/SILOptimizer/opaque_values_Onone.swift
+++ b/test/SILOptimizer/opaque_values_Onone.swift
@@ -79,9 +79,9 @@ func doit<T>(_ f: () -> T) -> T {
 // CHECK-LABEL: } // end sil function 'duplicate1'
 // CHECK-LABEL: sil private @$s19opaque_values_Onone10duplicate15valuex_xtx_tlFx_xtyXEfU_ : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[TUPLE_ADDR:%[^,]+]] : $*(Value, Value), [[VALUE_ADDR:%[^,]+]] :
-// CHECK:         [[ELT_2_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]]{{.*}}, 1
 // CHECK:         [[ELT_1_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]]{{.*}}, 0
 // CHECK:         copy_addr [[VALUE_ADDR]] to [init] [[ELT_1_ADDR]]
+// CHECK:         [[ELT_2_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]]{{.*}}, 1
 // CHECK:         copy_addr [[VALUE_ADDR]] to [init] [[ELT_2_ADDR]] : $*Value
 // CHECK-LABEL: } // end sil function '$s19opaque_values_Onone10duplicate15valuex_xtx_tlFx_xtyXEfU_'
 @_silgen_name("duplicate1")
@@ -103,9 +103,9 @@ func duplicate1<Value>(value: Value) -> (Value, Value) {
 // CHECK-LABEL: } // end sil function 'duplicate2'
 // CHECK-LABEL: sil private @$s19opaque_values_Onone10duplicate25valuex3one_x3twotx_tlFxAD_xAEtyXEfU_ : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[TUPLE_ADDR:%[^,]+]] : $*(one: Value, two: Value), [[VALUE_ADDR:%[^,]+]] :
-// CHECK:         [[ELT_2_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]]{{.*}}, 1
 // CHECK:         [[ELT_1_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]]{{.*}}, 0
 // CHECK:         copy_addr [[VALUE_ADDR]] to [init] [[ELT_1_ADDR]]
+// CHECK:         [[ELT_2_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]]{{.*}}, 1
 // CHECK:         copy_addr [[VALUE_ADDR]] to [init] [[ELT_2_ADDR]] : $*Value
 // CHECK-LABEL: } // end sil function '$s19opaque_values_Onone10duplicate25valuex3one_x3twotx_tlFxAD_xAEtyXEfU_'
 @_silgen_name("duplicate2")
@@ -139,22 +139,22 @@ func duplicate_with_int2<Value>(value: Value) -> ((Value, Value), Int) {
 // CHECK-LABEL: } // end sil function 'duplicate_with_int3'
 // CHECK-LABEL: sil private @$s19opaque_values_Onone19duplicate_with_int35valueSi_x_x_x_SitxttSitx_tlFSi_x_x_x_SitxttSityXEfU_ {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[OUT_ADDR:%[^,]+]] : $*(Int, (Value, (Value, (Value, Int), Value)), Int), [[IN_ADDR:%[^,]+]] : $*Value):
-// CHECK:         [[OUT_0_ADDR:%[^,]+]] = tuple_element_addr [[OUT_ADDR]] : $*(Int, (Value, (Value, (Value, Int), Value)), Int), 0
-// CHECK:         [[OUT_2_ADDR:%[^,]+]] = tuple_element_addr [[OUT_ADDR]] : $*(Int, (Value, (Value, (Value, Int), Value)), Int), 2
 // CHECK:         [[OUT_1_ADDR:%[^,]+]] = tuple_element_addr [[OUT_ADDR]] : $*(Int, (Value, (Value, (Value, Int), Value)), Int), 1
-// CHECK:         [[OUT_1_1_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_ADDR]] : $*(Value, (Value, (Value, Int), Value)), 1
-// CHECK:         [[OUT_1_1_2_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_ADDR]] : $*(Value, (Value, Int), Value), 2
-// CHECK:         [[OUT_1_1_1_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_ADDR]] : $*(Value, (Value, Int), Value), 1
-// CHECK:         [[OUT_1_1_1_1_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_1_ADDR]] : $*(Value, Int), 1
-// CHECK:         [[OUT_1_1_1_2_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_1_ADDR]] : $*(Value, Int), 0
-// CHECK:         [[OUT_1_1_0_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_ADDR]] : $*(Value, (Value, Int), Value), 0
 // CHECK:         [[OUT_1_0_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_ADDR]] : $*(Value, (Value, (Value, Int), Value)), 0
 // CHECK:         copy_addr [[IN_ADDR]] to [init] [[OUT_1_0_ADDR]]
+// CHECK:         [[OUT_1_1_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_ADDR]] : $*(Value, (Value, (Value, Int), Value)), 1
+// CHECK:         [[OUT_1_1_0_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_ADDR]] : $*(Value, (Value, Int), Value), 0
 // CHECK:         copy_addr [[IN_ADDR]] to [init] [[OUT_1_1_0_ADDR]]
+// CHECK:         [[OUT_1_1_1_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_ADDR]] : $*(Value, (Value, Int), Value), 1
+// CHECK:         [[OUT_1_1_1_2_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_1_ADDR]] : $*(Value, Int), 0
 // CHECK:         copy_addr [[IN_ADDR]] to [init] [[OUT_1_1_1_2_ADDR]]
+// CHECK:         [[OUT_1_1_2_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_ADDR]] : $*(Value, (Value, Int), Value), 2
 // CHECK:         copy_addr [[IN_ADDR]] to [init] [[OUT_1_1_2_ADDR]]
+// CHECK:         [[OUT_1_1_1_1_ADDR:%[^,]+]] = tuple_element_addr [[OUT_1_1_1_ADDR]] : $*(Value, Int), 1
 // CHECK:         store {{%[^,]+}} to [[OUT_1_1_1_1_ADDR]]
+// CHECK:         [[OUT_0_ADDR:%[^,]+]] = tuple_element_addr [[OUT_ADDR]] : $*(Int, (Value, (Value, (Value, Int), Value)), Int), 0
 // CHECK:         store {{%[^,]+}} to [[OUT_0_ADDR]]
+// CHECK:         [[OUT_2_ADDR:%[^,]+]] = tuple_element_addr [[OUT_ADDR]] : $*(Int, (Value, (Value, (Value, Int), Value)), Int), 2
 // CHECK:         store {{%[^,]+}} to [[OUT_2_ADDR]]
 // CHECK-LABEL: } // end sil function '$s19opaque_values_Onone19duplicate_with_int35valueSi_x_x_x_SitxttSitx_tlFSi_x_x_x_SitxttSityXEfU_'
 @_silgen_name("duplicate_with_int3")
@@ -165,10 +165,10 @@ func duplicate_with_int3<Value>(value: Value) -> (Int, (Value, (Value, (Value, I
 }
 
 // CHECK-LABEL: sil hidden @get_a_generic_tuple : {{.*}} {
+// CHECK:         [[GIVE_A_GENERIC_TUPLE:%[^,]+]] = function_ref @give_a_generic_tuple
 // CHECK:         [[TUPLE_ADDR:%[^,]+]] = alloc_stack [lexical] $(This, This)
 // CHECK:         [[TUPLE_1_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]] : $*(This, This), 1
 // CHECK:         [[TUPLE_0_ADDR:%[^,]+]] = tuple_element_addr [[TUPLE_ADDR]] : $*(This, This), 0
-// CHECK:         [[GIVE_A_GENERIC_TUPLE:%[^,]+]] = function_ref @give_a_generic_tuple
 // CHECK:         apply [[GIVE_A_GENERIC_TUPLE]]<This>([[TUPLE_0_ADDR]], [[TUPLE_1_ADDR]], {{%[^,]+}})
 // CHECK:         destroy_addr [[TUPLE_ADDR]]
 // CHECK:         dealloc_stack [[TUPLE_ADDR]]


### PR DESCRIPTION
The pass rewrites opaque values in reverse post order of their definitions.  When an opaque value is rewritten, both its definition and its uses are rewritten.  When a def or a use is rewritten, in order to materialize an address with which to rewrite, projection instructions are created.  Previously, these projections were created at the site of the def or use.  Some of these projection instructions may be reused when rewriting later opaque values.

As a result, it's possible to have two opaque values `A` and `B` (which are rewritten in that order) such that rewriting a use of `A` which occurs "after" the def (or a use) of `B` creates a projection `P` which is then used by that "earlier" def (or use) of `B`:

    ```
    A =
    B =     // relies on P
    use B
    use A   // creates some projection P
    ```

When rewriting the def (or that use, respectively) of `B`, the projection which was created for the use of `A` will be reused.  And previously, the projection would be created at the use of A.  But that projection instruction was "after" the place where it is used when rewriting the def or use of `B`.  That's invalid!

To address this, rather than creating projections at the instruction being rewritten, instead create them "as early as possible".  The locations where they will be created are chosen so as to dominate all uses.
