### PR TITLE
[stdlib] Improve performance of heterogeneous binary integer `==` and `<`

### DIFF
--- a/stdlib/public/core/Integers.swift
+++ b/stdlib/public/core/Integers.swift
@@ -1672,12 +1672,12 @@ extension BinaryInteger {
     if Self.isSigned {    
       return lhs.bitWidth > rhs.bitWidth ? // (1)
         lhs == Self(truncatingIfNeeded: rhs) :
-        lhs < (0 as Self) ? false : Other(truncatingIfNeeded: lhs) == rhs // (2)
+        (lhs >= (0 as Self) && Other(truncatingIfNeeded: lhs) == rhs) // (2)
     }
     // Analogous reasoning applies if `Other` is signed but `Self` is not.
     return lhs.bitWidth < rhs.bitWidth ?
       Other(truncatingIfNeeded: lhs) == rhs :
-      rhs < (0 as Other) ? false : lhs == Self(truncatingIfNeeded: rhs)
+      (rhs >= (0 as Other) && lhs == Self(truncatingIfNeeded: rhs))
   }
 
   /// Returns a Boolean value indicating whether the two given values are not
@@ -1731,12 +1731,12 @@ extension BinaryInteger {
     if Self.isSigned {
       return lhs.bitWidth > rhs.bitWidth ? // (1)
         lhs < Self(truncatingIfNeeded: rhs) :
-        lhs < (0 as Self) ? true : Other(truncatingIfNeeded: lhs) < rhs // (2)
+        (lhs < (0 as Self) || Other(truncatingIfNeeded: lhs) < rhs) // (2)
     }
     // Analogous reasoning applies if `Other` is signed but `Self` is not.
     return lhs.bitWidth < rhs.bitWidth ?
       Other(truncatingIfNeeded: lhs) < rhs :
-      rhs < (0 as Other) ? false : lhs < Self(truncatingIfNeeded: rhs)
+      (rhs > (0 as Other) && lhs < Self(truncatingIfNeeded: rhs))
   }
 
   /// Returns a Boolean value indicating whether the value of the first

--- a/test/IRGen/integer-comparison.swift
+++ b/test/IRGen/integer-comparison.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s
+// REQUIRES: CPU=x86_64 || CPU=arm64
+
+func f(_ x: Int, _ y: UInt32) -> Bool { x < y }
+// CHECK-LABEL: define {{.*}} @"$s4main1fySbSi_s6UInt32VtF"(i64 %0, i32 %1)
+// CHECK: %2 = zext i32 %1 to i64
+// CHECK-NEXT: %3 = icmp sgt i64 %2, %0
+// CHECK-NEXT: ret i1 %3
+
+func g(_ x: UInt32, _ y: Int) -> Bool { x < y }
+// CHECK-LABEL: define {{.*}} @"$s4main1gySbs6UInt32V_SitF"(i32 %0, i64 %1)
+// CHECK: %2 = zext i32 %0 to i64
+// CHECK-NEXT: %3 = icmp slt i64 %2, %1
+// CHECK-NEXT: ret i1 %3

--- a/test/IRGen/temporary_allocation/codegen.swift
+++ b/test/IRGen/temporary_allocation/codegen.swift
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=CHECK-%target-vendor
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-LARGE-ALLOC,CHECK-LARGE-ALLOC-%target-vendor
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=CHECK-LARGE-STACK-ALLOC -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=CHECK-LARGE-HEAP-ALLOC -DWORD=i%target-ptrsize
 
 @_silgen_name("blackHole")
 func blackHole(_ value: UnsafeMutableRawPointer?) -> Void
@@ -74,24 +76,16 @@ withUnsafeTemporaryAllocation(of: Void.self, capacity: 2) { buffer in
 withUnsafeTemporaryAllocation(byteCount: 0x0FFF_FFFF, alignment: 1) { buffer in
   blackHole(buffer.baseAddress)
 }
-// CHECK-apple: [[IS_OS_OK:%[0-9]+]] = call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"
-// CHECK-apple: br i1 [[IS_OS_OK]], label %[[OS_OK_BR:[0-9]+]], label %[[UNSAFE_BR:[0-9]+]]
+// CHECK-LARGE-HEAP-ALLOC: [[HEAP_PTR_RAW:%[0-9]+]] = call noalias i8* @swift_slowAlloc([[WORD]] 268435455, [[WORD]] -1)
+// CHECK-LARGE-HEAP-ALLOC-NEXT: [[HEAP_PTR:%[0-9]+]] = ptrtoint i8* [[HEAP_PTR_RAW]] to [[WORD]]
+// CHECK-LARGE-HEAP-ALLOC-NEXT: call swiftcc void @blackHole([[WORD]] [[HEAP_PTR]])
+// CHECK-LARGE-HEAP-ALLOC-NEXT: call void @swift_slowDealloc(i8* [[HEAP_PTR_RAW]], [[WORD]] -1, [[WORD]] -1)
 
-// CHECK-apple: [[UNSAFE_BR]]:
-// CHECK-unknown: [[UNSAFE_BR:[0-9]+]]:
-// CHECK: [[HEAP_PTR_RAW:%[0-9]+]] = call noalias i8* @swift_slowAlloc([[WORD]] 268435455, [[WORD]] -1)
-// CHECK: [[HEAP_PTR:%[0-9]+]] = ptrtoint i8* [[HEAP_PTR_RAW]] to [[WORD]]
-// CHECK: call swiftcc void @blackHole([[WORD]] [[HEAP_PTR]])
-// CHECK: call void @swift_slowDealloc(i8* [[HEAP_PTR_RAW]], [[WORD]] -1, [[WORD]] -1)
+// CHECK-LARGE-STACK-ALLOC: [[STACK_PTR_RAW:%temp_alloc[0-9]*]] = alloca [268435455 x i8], align 1
+// CHECK-LARGE-STACK-ALLOC-NEXT: [[STACK_PTR:%[0-9]+]] = ptrtoint [268435455 x i8]* [[STACK_PTR_RAW]] to [[WORD]]
+// CHECK-LARGE-STACK-ALLOC-NEXT: call swiftcc void @blackHole([[WORD]] [[STACK_PTR]])
 
-// CHECK-apple: [[OS_OK_BR]]:
-// CHECK: [[IS_SAFE:%[0-9]+]] = call zeroext i1 @swift_stdlib_isStackAllocationSafe([[WORD]] 268435455, [[WORD]] 1)
-// CHECK: br i1 [[IS_SAFE]], label %[[SAFE_BR:[0-9]+]], label %[[UNSAFE_BR]]
-
-// CHECK: [[SAFE_BR]]:
-// CHECK: [[SPSAVE:%spsave[0-9]*]] = call i8* @llvm.stacksave()
-// CHECK: [[STACK_PTR_RAW:%temp_alloc[0-9]*]] = alloca [268435455 x i8], align 1
-// CHECK: [[STACK_PTR:%[0-9]+]] = ptrtoint [268435455 x i8]* [[STACK_PTR_RAW]] to [[WORD]]
-// CHECK: call swiftcc void @blackHole([[WORD]] [[STACK_PTR]])
-// CHECK: call void @llvm.stackrestore(i8* [[SPSAVE]])
-
+// CHECK-LARGE-ALLOC-DAG: [[IS_SAFE:%[0-9]+]] = call zeroext i1 @swift_stdlib_isStackAllocationSafe([[WORD]] 268435455, [[WORD]] 1)
+// CHECK-LARGE-ALLOC-DAG: br i1 [[IS_SAFE]], label %{{[0-9]+}}, label %{{[0-9]+}}
+// CHECK-LARGE-ALLOC-apple-DAG: [[IS_OS_OK:%[0-9]+]] = call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"
+// CHECK-LARGE-ALLOC-apple-DAG: br i1 [[IS_OS_OK]], label %{{[0-9]+}}, label %{{[0-9]+}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
As it turns out, we can simplify this logic quite a bit and get more optimal generated code in the process:

In the first iteration of this PR, we unconditionally apply the "roundtripping" logic used in the existing code to widen a comparand without checking the instance property `bitWidth`:

- If `rhs` can be represented as a value of type `Self`, or if `lhs` can be represented as a value of type `Other`, then the comparison is straightforward.
- If neither is the case, then we can actually know which of `lhs` and `rhs` is smaller just by knowing which of `Self` or `Other` is a signed type (see comments in the code).

This change allows Swift to generate the same, optimal code (at `-O`) for the following input as reported in #62260, which isn't the case today:

```swift
func compare_direct(_ x: Int, _ y: UInt32) -> Bool {
    x < y
}

func compare_widened(_ x: Int, _ y: UInt32) -> Bool {
    x < Int(y)
}
```

However, because the roundtripping logic has to start with either the left-hand side or the right-hand side, the same optimal output can't be obtained when we swap the parameters above—i.e., when `x` is of type `UInt32` and `y` is of type `Int`. The generated code is still _better_ than the status quo, but it's not the _best possible_.

---

To address this issue, in the second iteration of this PR, we compare comparand bit widths explicitly, but only once along each code path in case it's expensive to compute for values of a hypothetical arbitrary-width type. (I'd expect this should be negligible as compared to the widening operation that follows anyway.)

For fixed-width integer types, this approach produces _optimal_ code generation for heterogeneous comparison of any two types. This is because we defer comparison to zero until we reach the only scenario where it's required (when a signed and therefore possibly negative value is being compared to an unsigned value of greater bit width) and otherwise stick to operations that can be optimized away in the concrete case.

This change apparently speeds up generic floating-point conversion severalfold, improves code size for a number of integer and floating-point algorithms, and even shrinks `libswiftCore.dylib` code size by 2%. It also revealed brittleness in an IRGen test which has been modified as a result to improve robustness.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #62260.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
