### PR TITLE
[Macros] Introduce the @attached attribute for declaring attached macros

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2308,17 +2308,17 @@ class DeclarationAttr final
       private llvm::TrailingObjects<DeclarationAttr, MacroIntroducedDeclName> {
   friend TrailingObjects;
 
-  MacroContext macroContext;
+  MacroRole role;
   unsigned numPeerNames, numMemberNames;
 
-  DeclarationAttr(SourceLoc atLoc, SourceRange range, MacroContext macroContext,
+  DeclarationAttr(SourceLoc atLoc, SourceRange range, MacroRole role,
                   ArrayRef<MacroIntroducedDeclName> peerNames,
                   ArrayRef<MacroIntroducedDeclName> memberNames,
                   bool implicit);
 
 public:
   static DeclarationAttr *create(ASTContext &ctx, SourceLoc atLoc,
-                                 SourceRange range, MacroContext macroContext,
+                                 SourceRange range, MacroRole role,
                                  ArrayRef<MacroIntroducedDeclName> peerNames,
                                  ArrayRef<MacroIntroducedDeclName> memberNames,
                                  bool implicit);
@@ -2327,13 +2327,45 @@ public:
     return numPeerNames + numMemberNames;
   }
 
-  MacroContext getMacroContext() const { return macroContext; }
+  MacroRole getMacroRole() const { return role; }
   ArrayRef<MacroIntroducedDeclName> getPeerAndMemberNames() const;
   ArrayRef<MacroIntroducedDeclName> getPeerNames() const;
   ArrayRef<MacroIntroducedDeclName> getMemberNames() const;
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_Declaration;
+  }
+};
+
+/// The @attached attribute, which declares that a given macro can be
+/// "attached" as an attribute to declarations.
+class AttachedAttr final
+    : public DeclAttribute,
+      private llvm::TrailingObjects<AttachedAttr, MacroIntroducedDeclName> {
+  friend TrailingObjects;
+
+  MacroRole role;
+  unsigned numNames;
+
+  AttachedAttr(SourceLoc atLoc, SourceRange range, MacroRole role,
+               ArrayRef<MacroIntroducedDeclName> names,
+               bool implicit);
+
+public:
+  static AttachedAttr *create(ASTContext &ctx, SourceLoc atLoc,
+                              SourceRange range, MacroRole role,
+                              ArrayRef<MacroIntroducedDeclName> names,
+                              bool implicit);
+
+  size_t numTrailingObjects(OverloadToken<MacroIntroducedDeclName>) const {
+    return numNames;
+  }
+
+  MacroRole getMacroRole() const { return role; }
+  ArrayRef<MacroIntroducedDeclName> getNames() const;
+
+  static bool classof(const DeclAttribute *DA) {
+    return DA->getKind() == DAK_Attached;
   }
 };
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8372,7 +8372,7 @@ public:
   Type getResultInterfaceType() const;
 
   /// Determine the contexts in which this macro can be applied.
-  MacroContexts getMacroContexts() const;
+  MacroRoles getMacroRoles() const;
 
   /// Retrieve the definition of this macro.
   MacroDefinition getDefinition() const;

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2020,6 +2020,30 @@ ERROR(macro_expansion_decl_expected_macro_identifier,PointsToFirstBadToken,
 ERROR(declaration_attr_expected_kind,PointsToFirstBadToken,
       "expected a declaration macro kind ('freestanding' or 'attached')", ())
 
+ERROR(macro_role_attr_expected_kind,PointsToFirstBadToken,
+      "expected %select{a freestanding|an attached}0 macro role such as "
+      "%select{'expression'|'accessor'}0", (bool))
+ERROR(macro_role_syntax_mismatch,PointsToFirstBadToken,
+      "expected %select{a freestanding|an attached}0 macro cannot have "
+      "the %1 role", (bool, Identifier))
+ERROR(macro_attribute_unknown_label,PointsToFirstBadToken,
+      "@%select{freestanding|attached}0 has no argument with label %1",
+      (bool, Identifier))
+ERROR(macro_attribute_duplicate_label,PointsToFirstBadToken,
+      "@%select{freestanding|attached}0 already has an argument with "
+      "label %1", (bool, Identifier))
+ERROR(macro_attribute_missing_label,PointsToFirstBadToken,
+      "@%select{freestanding|attached}0 argument is missing label '%1'",
+      (bool, StringRef))
+ERROR(macro_attribute_unknown_name_kind,PointsToFirstBadToken,
+      "unknown introduced name kind %0", (Identifier))
+ERROR(macro_attribute_unknown_argument_form,PointsToFirstBadToken,
+      "introduced name argument should be an identifier", ())
+ERROR(macro_attribute_introduced_name_requires_argument,PointsToFirstBadToken,
+      "introduced name kind %0 requires a single argument '(name)'", (Identifier))
+ERROR(macro_attribute_introduced_name_requires_no_argument,PointsToFirstBadToken,
+      "introduced name kind %0 must not have an argument", (Identifier))
+
 ERROR(parser_round_trip_error,none,
       "source file did not round-trip through the new Swift parser", ())
 ERROR(parser_new_parser_errors,none,

--- a/include/swift/AST/MacroDeclaration.h
+++ b/include/swift/AST/MacroDeclaration.h
@@ -23,23 +23,31 @@ namespace swift {
 
 /// The context in which a macro can be used, which determines the syntax it
 /// uses.
-enum class MacroContext: uint8_t {
+enum class MacroRole: uint32_t {
   /// An expression macro, referenced explicitly via "#stringify" or similar
   /// in the source code.
   Expression = 0x01,
   /// A freestanding declaration macro.
   FreestandingDeclaration = 0x02,
-  /// An attached declaration macro.
-  AttachedDeclaration = 0x04,
+  /// An attached macro that declares accessors for a variable or subscript
+  /// declaration.
+  Accessor = 0x04,
 };
 
 /// The contexts in which a particular macro declaration can be used.
-using MacroContexts = OptionSet<MacroContext>;
+using MacroRoles = OptionSet<MacroRole>;
+
+/// Whether a macro with the given set of macro contexts is freestanding, i.e.,
+/// written in the source code with the `#` syntax.
+bool isFreestandingMacro(MacroRoles contexts);
+
+/// Whether a macro with the given set of macro contexts is attached, i.e.,
+/// written in the source code as an attribute with the `@` syntax.
+bool isAttachedMacro(MacroRoles contexts);
 
 enum class MacroIntroducedDeclNameKind {
   Named,
   Overloaded,
-  Accessors,
   Prefixed,
   Suffixed,
   Arbitrary,
@@ -63,10 +71,6 @@ public:
 
   static MacroIntroducedDeclName getOverloaded() {
     return MacroIntroducedDeclName(Kind::Overloaded);
-  }
-
-  static MacroIntroducedDeclName getAccessors() {
-    return MacroIntroducedDeclName(Kind::Accessors);
   }
 
   static MacroIntroducedDeclName getPrefixed(Identifier prefix) {

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1100,6 +1100,10 @@ public:
   ParserResult<DeclarationAttr> parseDeclarationAttribute(SourceLoc AtLoc,
                                                           SourceLoc Loc);
 
+  /// Parse the @attached attribute.
+  ParserResult<AttachedAttr> parseAttachedAttribute(SourceLoc AtLoc,
+                                                    SourceLoc Loc);
+
   /// Parse a specific attribute.
   ParserStatus parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                                   PatternBindingInitializer *&initContext,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1485,6 +1485,8 @@ StringRef DeclAttribute::getAttrName() const {
     return "_documentation";
   case DAK_Declaration:
     return "declaration";
+  case DAK_Attached:
+    return "attached";
   }
   llvm_unreachable("bad DeclAttrKind");
 }
@@ -2311,12 +2313,12 @@ bool CustomAttr::isArgUnsafe() const {
 }
 
 DeclarationAttr::DeclarationAttr(SourceLoc atLoc, SourceRange range,
-                                 MacroContext macroContext,
+                                 MacroRole role,
                                  ArrayRef<MacroIntroducedDeclName> peerNames,
                                  ArrayRef<MacroIntroducedDeclName> memberNames,
                                  bool implicit)
     : DeclAttribute(DAK_Declaration, atLoc, range, implicit),
-      macroContext(macroContext), numPeerNames(peerNames.size()),
+      role(role), numPeerNames(peerNames.size()),
       numMemberNames(memberNames.size()) {
   auto *trailingNamesBuffer = getTrailingObjects<MacroIntroducedDeclName>();
   std::uninitialized_copy(peerNames.begin(), peerNames.end(),
@@ -2327,14 +2329,14 @@ DeclarationAttr::DeclarationAttr(SourceLoc atLoc, SourceRange range,
 
 DeclarationAttr *
 DeclarationAttr::create(ASTContext &ctx, SourceLoc atLoc, SourceRange range,
-                        MacroContext macroContext,
+                        MacroRole role,
                         ArrayRef<MacroIntroducedDeclName> peerNames,
                         ArrayRef<MacroIntroducedDeclName> memberNames,
                         bool implicit) {
   unsigned size = totalSizeToAlloc<MacroIntroducedDeclName>(
       peerNames.size() + memberNames.size());
   auto *mem = ctx.Allocate(size, alignof(DeclarationAttr));
-  return new (mem) DeclarationAttr(atLoc, range, macroContext, peerNames,
+  return new (mem) DeclarationAttr(atLoc, range, role, peerNames,
                                    memberNames, implicit);
 }
 
@@ -2355,6 +2357,34 @@ ArrayRef<MacroIntroducedDeclName> DeclarationAttr::getMemberNames() const {
     numMemberNames
   };
 }
+
+AttachedAttr::AttachedAttr(SourceLoc atLoc, SourceRange range,
+                           MacroRole role,
+                           ArrayRef<MacroIntroducedDeclName> names,
+                           bool implicit)
+    : DeclAttribute(DAK_Attached, atLoc, range, implicit),
+      role(role), numNames(names.size()) {
+  auto *trailingNamesBuffer = getTrailingObjects<MacroIntroducedDeclName>();
+  std::uninitialized_copy(names.begin(), names.end(), trailingNamesBuffer);
+}
+
+AttachedAttr *
+AttachedAttr::create(ASTContext &ctx, SourceLoc atLoc, SourceRange range,
+                     MacroRole role,
+                     ArrayRef<MacroIntroducedDeclName> names,
+                     bool implicit) {
+  unsigned size = totalSizeToAlloc<MacroIntroducedDeclName>(names.size());
+  auto *mem = ctx.Allocate(size, alignof(AttachedAttr));
+  return new (mem) AttachedAttr(atLoc, range, role, names, implicit);
+}
+
+ArrayRef<MacroIntroducedDeclName> AttachedAttr::getNames() const {
+  return {
+    getTrailingObjects<MacroIntroducedDeclName>(),
+    numNames
+  };
+}
+
 
 const DeclAttribute *
 DeclAttributes::getEffectiveSendableAttr() const {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3061,7 +3061,7 @@ static MacroDecl *findMacroForCustomAttr(CustomAttr *attr, DeclContext *dc) {
   for (const auto &result : lookup.allResults()) {
     // Only keep attached macros, which can be spelled as custom attributes.
     if (auto macro = dyn_cast<MacroDecl>(result.getValueDecl()))
-      if (macro->getMacroContexts().contains(MacroContext::AttachedDeclaration))
+      if (isAttachedMacro(macro->getMacroRoles()))
         macros.push_back(macro);
   }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3761,7 +3761,7 @@ namespace {
                  FunctionRefKind functionRefKind) {
       SmallVector<OverloadChoice, 1> choices;
       auto results = TypeChecker::lookupMacros(
-          CurDC, DeclNameRef(macroName), loc, MacroContext::Expression);
+          CurDC, DeclNameRef(macroName), loc, MacroRole::Expression);
       for (const auto &result : results) {
         OverloadChoice choice = OverloadChoice(Type(), result, functionRefKind);
         choices.push_back(choice);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -161,6 +161,7 @@ public:
   IGNORED_ATTR(Documentation)
   IGNORED_ATTR(Expression)
   IGNORED_ATTR(Declaration)
+  IGNORED_ATTR(Attached)
 #undef IGNORED_ATTR
 
   void visitAlignmentAttr(AlignmentAttr *attr) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1599,14 +1599,14 @@ TypeChecker::lookupPrecedenceGroup(DeclContext *dc, Identifier name,
 
 SmallVector<MacroDecl *, 1>
 TypeChecker::lookupMacros(DeclContext *dc, DeclNameRef macroName,
-                          SourceLoc loc, MacroContexts contexts) {
+                          SourceLoc loc, MacroRoles contexts) {
   auto result = lookupUnqualified(dc, DeclNameRef(macroName), loc,
                                   (defaultUnqualifiedLookupOptions |
                                       NameLookupFlags::IncludeOuterResults));
   SmallVector<MacroDecl *, 1> choices;
   for (const auto &found : result.allResults())
     if (auto macro = dyn_cast<MacroDecl>(found.getValueDecl()))
-      if (contexts.contains(macro->getMacroContexts()))
+      if (contexts.contains(macro->getMacroRoles()))
         choices.push_back(macro);
   return choices;
 }

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -1628,6 +1628,7 @@ namespace  {
 
     UNINTERESTING_ATTR(Expression)
     UNINTERESTING_ATTR(Declaration)
+    UNINTERESTING_ATTR(Attached)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2004,7 +2004,7 @@ public:
       MD->diagnose(diag::macro_experimental);
     if (!MD->getDeclContext()->isModuleScopeContext())
       MD->diagnose(diag::macro_in_nested, MD->getName());
-    if (!MD->getMacroContexts())
+    if (!MD->getMacroRoles())
       MD->diagnose(diag::macro_without_context, MD->getName());
 
     // Check the macro definition.
@@ -3666,7 +3666,7 @@ ExpandMacroExpansionDeclRequest::evaluate(Evaluator &evaluator,
   auto *dc = MED->getDeclContext();
   auto foundMacros = TypeChecker::lookupMacros(
       MED->getDeclContext(), MED->getMacro(),
-      MED->getLoc(), MacroContext::FreestandingDeclaration);
+      MED->getLoc(), MacroRole::FreestandingDeclaration);
   if (foundMacros.empty()) {
     MED->diagnose(diag::macro_undefined, MED->getMacro().getBaseIdentifier())
         .highlight(MED->getMacroLoc().getSourceRange());

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -527,8 +527,8 @@ bool swift::expandFreestandingDeclarationMacro(
   NullTerminatedStringRef evaluatedSource;
 
   MacroDecl *macro = cast<MacroDecl>(med->getMacroRef().getDecl());
-  assert(macro->getMacroContexts()
-             .contains(MacroContext::FreestandingDeclaration));
+  assert(macro->getMacroRoles()
+             .contains(MacroRole::FreestandingDeclaration));
 
   if (isFromExpansionOfMacro(sourceFile, macro)) {
     med->diagnose(diag::macro_recursive, macro->getName());

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -919,7 +919,7 @@ lookupPrecedenceGroup(DeclContext *dc, Identifier name, SourceLoc nameLoc);
 
 SmallVector<MacroDecl *, 1>
 lookupMacros(DeclContext *dc, DeclNameRef macroName, SourceLoc loc,
-             MacroContexts contexts);
+             MacroRoles contexts);
 
 enum class UnsupportedMemberTypeAccessKind : uint8_t {
   None,

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 734; // @declaration
+const uint16_t SWIFTMODULE_VERSION_MINOR = 735; // @attached
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -607,12 +607,12 @@ enum class GenericEnvironmentKind : uint8_t {
 
 // These IDs must \em not be renumbered or reordered without incrementing
 // the module version.
-enum class MacroContext : uint8_t {
+enum class MacroRole : uint8_t {
   Expression,
   FreestandingDeclaration,
-  AttachedDeclaration,
+  Accessor,
 };
-using MacroContextField = BCFixed<3>;
+using MacroRoleField = BCFixed<3>;
 
 // These IDs must \em not be renumbered or reordered without incrementing
 // the module version.
@@ -2217,9 +2217,17 @@ namespace decls_block {
   using DeclarationDeclAttrLayout = BCRecordLayout<
     Declaration_DECL_ATTR,
     BCFixed<1>,                // implicit flag
-    MacroContextField,         // macro context
+    MacroRoleField,         // macro context
     BCVBR<5>,                  // number of peer names
     BCVBR<5>,                  // number of member names
+    BCArray<IdentifierIDField> // introduced decl name kind and identifier pairs
+  >;
+
+  using AttachedDeclAttrLayout = BCRecordLayout<
+    Attached_DECL_ATTR,
+    BCFixed<1>,                // implicit flag
+    MacroRoleField,            // macro roles
+    BCVBR<5>,                  // number of names
     BCArray<IdentifierIDField> // introduced decl name kind and identifier pairs
   >;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2212,14 +2212,14 @@ getStableSelfAccessKind(swift::SelfAccessKind MM) {
   llvm_unreachable("Unhandled StaticSpellingKind in switch.");
 }
 
-static uint8_t getRawStableMacroContext(swift::MacroContext context) {
+static uint8_t getRawStableMacroRole(swift::MacroRole context) {
   switch (context) {
 #define CASE(NAME) \
-  case swift::MacroContext::NAME: \
-    return static_cast<uint8_t>(serialization::MacroContext::NAME);
+  case swift::MacroRole::NAME: \
+    return static_cast<uint8_t>(serialization::MacroRole::NAME);
   CASE(Expression)
   CASE(FreestandingDeclaration)
-  CASE(AttachedDeclaration)
+  CASE(Accessor)
   }
 #undef CASE
   llvm_unreachable("bad result declaration macro kind");
@@ -2233,7 +2233,6 @@ static uint8_t getRawStableMacroIntroducedDeclNameKind(
     return static_cast<uint8_t>(serialization::MacroIntroducedDeclNameKind::NAME);
     CASE(Named)
     CASE(Overloaded)
-    CASE(Accessors)
     CASE(Prefixed)
     CASE(Suffixed)
     CASE(Arbitrary)
@@ -2980,8 +2979,8 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     case DAK_Declaration: {
       auto *theAttr = cast<DeclarationAttr>(DA);
       auto abbrCode = S.DeclTypeAbbrCodes[DeclarationDeclAttrLayout::Code];
-      auto rawMacroContext =
-          getRawStableMacroContext(theAttr->getMacroContext());
+      auto rawMacroRole =
+          getRawStableMacroRole(theAttr->getMacroRole());
       SmallVector<IdentifierID, 4> introducedDeclNames;
       for (auto name : theAttr->getPeerAndMemberNames()) {
         introducedDeclNames.push_back(IdentifierID(
@@ -2992,8 +2991,28 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
 
       DeclarationDeclAttrLayout::emitRecord(
           S.Out, S.ScratchRecord, abbrCode, theAttr->isImplicit(),
-          rawMacroContext, theAttr->getPeerNames().size(),
+          rawMacroRole, theAttr->getPeerNames().size(),
           theAttr->getMemberNames().size(), introducedDeclNames);
+      return;
+    }
+
+    case DAK_Attached: {
+      auto *theAttr = cast<AttachedAttr>(DA);
+      auto abbrCode = S.DeclTypeAbbrCodes[AttachedDeclAttrLayout::Code];
+      auto rawMacroRole =
+          getRawStableMacroRole(theAttr->getMacroRole());
+      SmallVector<IdentifierID, 4> introducedDeclNames;
+      for (auto name : theAttr->getNames()) {
+        introducedDeclNames.push_back(IdentifierID(
+            getRawStableMacroIntroducedDeclNameKind(name.getKind())));
+        introducedDeclNames.push_back(
+            S.addDeclBaseNameRef(name.getIdentifier()));
+      }
+
+      AttachedDeclAttrLayout::emitRecord(
+          S.Out, S.ScratchRecord, abbrCode, theAttr->isImplicit(),
+          rawMacroRole, theAttr->getNames().size(),
+          introducedDeclNames);
       return;
     }
     }

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -317,6 +317,7 @@ struct _S {
 // ON_MEMBER_LAST-DAG: Keyword/None:                       runtimeMetadata[#Declaration Attribute#]; name=runtimeMetadata
 // ON_MEMBER_LAST-DAG: Keyword/None:                       expression[#Declaration Attribute#]; name=expression
 // ON_MEMBER_LAST-DAG: Keyword/None:                       declaration[#Declaration Attribute#]; name=declaration
+// ON_MEMBER_LAST-DAG: Keyword/None:                       attached[#Declaration Attribute#]; name=attached
 // ON_MEMBER_LAST-NOT: Keyword
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // ON_MEMBER_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
@@ -391,6 +392,7 @@ func dummy2() {}
 // KEYWORD_LAST-DAG: Keyword/None:                       runtimeMetadata[#Declaration Attribute#]; name=runtimeMetadata
 // KEYWORD_LAST-DAG: Keyword/None:                       expression[#Declaration Attribute#]; name=expression
 // KEYWORD_LAST-DAG: Keyword/None:                       declaration[#Declaration Attribute#]; name=declaration
+// KEYWORD_LAST-DAG: Keyword/None:                       attached[#Declaration Attribute#]; name=attached
 // KEYWORD_LAST-NOT: Keyword
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule:            MyStruct[#MyStruct#]; name=MyStruct
 // KEYWORD_LAST-DAG: Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper

--- a/test/Macros/accessor_macros.swift
+++ b/test/Macros/accessor_macros.swift
@@ -16,7 +16,7 @@
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx
 
-@declaration(attached)
+@attached(accessor)
 macro myPropertyWrapper: Void =
     #externalMacro(module: "MacroDefinition", type: "PropertyWrapperMacro")
 

--- a/test/Macros/attached_macros_diags.swift
+++ b/test/Macros/attached_macros_diags.swift
@@ -1,14 +1,14 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature Macros -module-name MacrosTest
 
-@declaration(attached) macro m1: Void = #externalMacro(module: "MyMacros", type: "Macro1")
+@attached(accessor) macro m1: Void = #externalMacro(module: "MyMacros", type: "Macro1")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro1' could not be found for macro 'm1'}}
 // expected-note@-2{{'m1' declared here}}
 
-@declaration(attached) macro m2(_: Int) -> Void = #externalMacro(module: "MyMacros", type: "Macro2")
+@attached(accessor) macro m2(_: Int) -> Void = #externalMacro(module: "MyMacros", type: "Macro2")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro2' could not be found for macro 'm2'}}
 // expected-note@-2 2{{macro 'm2' declared here}}
 
-@declaration(attached) macro m2(_: Double) -> Void = #externalMacro(module: "MyMacros", type: "Macro2")
+@attached(accessor) macro m2(_: Double) -> Void = #externalMacro(module: "MyMacros", type: "Macro2")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro2' could not be found for macro 'm2'}}
 // expected-note@-2 2{{macro 'm2' declared here}}
 

--- a/test/Macros/parsing.swift
+++ b/test/Macros/parsing.swift
@@ -27,6 +27,24 @@ protocol Q { associatedtype Assoc }
 @declaration(freestanding) macro m9(_: String) = #externalMacro(module: "A", type: "M4")
 // expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm9'; the type must be public and provided via '-load-plugin-library'}}
 
-@expression @declaration(freestanding) @declaration(attached)
+@expression @declaration(freestanding) @attached(accessor)
 macro m10(_: String) = #externalMacro(module: "A", type: "M4")
 // expected-warning@-1{{external macro implementation type 'A.M4' could not be found for macro 'm10'; the type must be public and provided via '-load-plugin-library'}}
+
+
+@attached(
+  accessor,
+  names: overloaded, arbitrary, named(hello), prefixed(_), suffixed(_favorite)
+)
+macro am1: Void
+// expected-error@-1{{macro 'am1' requires a definition}}
+
+@attached(
+  accessor,
+  overloaded, // expected-error{{@attached argument is missing label 'names'}}
+  unknown, // expected-error{{unknown introduced name kind 'unknown'}}
+  named, // expected-error{{introduced name kind 'named' requires a single argument '(name)'}}
+  arbitrary(a) // expected-error{{introduced name kind 'arbitrary' must not have an argument}}
+)
+macro am2: Void
+// expected-error@-1{{macro 'am2' requires a definition}}

--- a/utils/gyb_syntax_support/AttributeKinds.py
+++ b/utils/gyb_syntax_support/AttributeKinds.py
@@ -912,6 +912,10 @@ DECL_MODIFIER_KINDS = [
                   OnMacro, AllowMultipleAttributes,
                   ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIBreakingToRemove,  # noqa: E501
                   code=141),
+    DeclAttribute('attached', 'Attached',
+                  OnMacro, AllowMultipleAttributes,
+                  ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIBreakingToRemove,  # noqa: E501
+                  code=142),
 ]
 
 DEPRECATED_MODIFIER_KINDS = [


### PR DESCRIPTION
Describe attached macros with the `@attached` attribute, providing the macro role and affected names as arguments to the macro. The form of this macro will remain the same as it gains other kinds of attached macro roles beyond "accessor".

Remove the "accessors" role from `@declaration`, which will be going away.

This is a new design, and works quite a bit better.