### PR TITLE
[stdlib] Define and bump to version 5.9

### DIFF
--- a/stdlib/public/core/Availability.swift
+++ b/stdlib/public/core/Availability.swift
@@ -88,14 +88,17 @@ extension _SwiftStdlibVersion {
   @_alwaysEmitIntoClient
   public static var v5_7_0: Self { Self(_value: 0x050700) }
 
-  // Note: As of now, there is no bincompat level defined for v5.8. If you need
-  // to use this in a call to `_isExecutableLinkedOnOrAfter`, then you'll need
-  // to define this version in the runtime.
+  // Note: As of now, there is no bincompat level defined for the versions
+  // below. If you need to use one of these in a call to
+  // `_isExecutableLinkedOnOrAfter`, then you'll need to define the
+  // corresponding version in the runtime.
   @_alwaysEmitIntoClient
   public static var v5_8_0: Self { Self(_value: 0x050800) }
+  @_alwaysEmitIntoClient
+  public static var v5_9_0: Self { Self(_value: 0x050900) }
 
   @available(SwiftStdlib 5.7, *)
-  public static var current: Self { .v5_8_0 }
+  public static var current: Self { .v5_9_0 }
 }
 
 @available(SwiftStdlib 5.7, *)

--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -33,6 +33,7 @@ SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0
 SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4
 SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0
 SwiftStdlib 5.8:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
+SwiftStdlib 5.9:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
 
 # Local Variables:
 # mode: conf-unix


### PR DESCRIPTION
Following up on #63014, define version 5.9 of the stdlib and bump to it.