### PR TITLE
[5.8][stdlib] String: Fix forward implementation of grapheme breaking rule 11

### DIFF
--- a/stdlib/public/core/StringGraphemeBreaking.swift
+++ b/stdlib/public/core/StringGraphemeBreaking.swift
@@ -723,11 +723,17 @@ extension _GraphemeBreakingState {
     case (_, .extend),
          (_, .zwj):
 
-      // If we're currently in an emoji sequence, then extends and ZWJ help
-      // continue the grapheme cluster by combining more scalars later. If we're
-      // not currently in an emoji sequence, but our lhs scalar is a pictograph,
-      // then that's a signal that it's the start of an emoji sequence.
-      if self.isInEmojiSequence || x == .extendedPictographic {
+      // Prepare for recognizing GB11, by remembering if we're in an emoji
+      // sequence.
+      //
+      //   GB11: Extended_Pictographic Extend* ZWJ × Extended_Pictographic
+      //
+      // If our left-side scalar is a pictograph, then it starts a new emoji
+      // sequence; the sequence continues through subsequent extend/extend and
+      // extend/zwj pairs.
+      if (
+        x == .extendedPictographic || (self.isInEmojiSequence && x == .extend)
+      ) {
         enterEmojiSequence = true
       }
 


### PR DESCRIPTION
(Cherry picked from #63043.)

Rule GB11 in Unicode Annex 29 is:

    GB11: Extended_Pictographic Extend* ZWJ × Extended_Pictographic

However, our forward grapheme breaking state machine implements it as:

    GB11: Extended_Pictographic (Extend | ZWJ)* ZWJ × Extended_Pictographic

We implement the correct rules when going backward, which can cause String values to have different counts whether we’re going forward or back.

The rule as implemented would be fine (Unicode doesn’t care much about the placement of grapheme breaks in invalid sequences), but the directional inconsistency messes with String’s Collection conformance.

rdar://104279671
