### PR TITLE
tests: disable floating point conversion tests for the x86_64 simulator

### DIFF
--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -1,6 +1,9 @@
 // RUN: %target-run-simple-swiftgyb(-parse-stdlib)
 // REQUIRES: executable_test
 
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+
 import Swift
 import StdlibUnittest
 

--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -8,6 +8,9 @@
 // rdar://77087867
 // UNSUPPORTED: CPU=arm64_32 && OS=watchos
 
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+
 import StdlibUnittest
 import SwiftPrivateLibcExtras
 #if canImport(Darwin)

--- a/test/stdlib/PrintFloatLocale.swift.gyb
+++ b/test/stdlib/PrintFloatLocale.swift.gyb
@@ -8,4 +8,7 @@
 // rdar://77087867
 // UNSUPPORTED: CPU=arm64_32 && OS=watchos
 
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+
 // UNSUPPORTED: freestanding

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-Onone)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt16.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-Onone)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt32.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-Onone)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt64.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-Onone)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToInt8.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-Onone)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-Onone)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt16.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-Onone)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt32.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-Onone)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt64.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-Onone)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Debug64_ToUInt8.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-Onone)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-O)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt16.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-O)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt32.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-O)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt64.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-O)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToInt8.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-O)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-O)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt16.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt16.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-O)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt32.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt32.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-O)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt64.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt64.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-O)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt8.swift
+++ b/validation-test/stdlib/FixedPointConversion/FixedPointConversion_Release64_ToUInt8.swift
@@ -8,6 +8,10 @@
 // REQUIRES: executable_test
 // REQUIRES: PTRSIZE=64
 // RUN: %target-run-simple-swift(-O)
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//
 // END.
 //
 //===----------------------------------------------------------------------===//

--- a/validation-test/stdlib/FloatingPointConversion_Debug.test-sh
+++ b/validation-test/stdlib/FloatingPointConversion_Debug.test-sh
@@ -5,3 +5,7 @@
 //
 // RUN: %line-directive %t/FloatingPointConversion.swift -- %target-run %t/a.out_Debug
 // REQUIRES: executable_test
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//

--- a/validation-test/stdlib/FloatingPointConversion_Release.test-sh
+++ b/validation-test/stdlib/FloatingPointConversion_Release.test-sh
@@ -5,3 +5,7 @@
 //
 // RUN: %line-directive %t/FloatingPointConversion.swift -- %target-run %t/a.out_Release
 // REQUIRES: executable_test
+//
+// rdar://104232602
+// UNSUPPORTED: CPU=x86_64 && (DARWIN_SIMULATOR=ios || DARWIN_SIMULATOR=watchos || DARWIN_SIMULATOR=tvos)
+//


### PR DESCRIPTION
There is a problem with 16-bit floating point conversions.

rdar://104232602
