### PR TITLE
👷🏼‍♂️[stdlib] Experiment with alternative ways to do grapheme breaking 

### DIFF
--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -53,6 +53,7 @@ extension String: BidirectionalCollection {
   /// - Parameter i: A valid index of the collection. `i` must be less than
   ///   `endIndex`.
   /// - Returns: The index value immediately after `i`.
+  @_effects(releasenone)
   public func index(after i: Index) -> Index {
     let i = _guts.validateCharacterIndex(i)
     return _uncheckedIndex(after: i)
@@ -82,6 +83,7 @@ extension String: BidirectionalCollection {
   /// - Parameter i: A valid index of the collection. `i` must be greater than
   ///   `startIndex`.
   /// - Returns: The index value immediately before `i`.
+  @_effects(releasenone)
   public func index(before i: Index) -> Index {
     // FIXME: This method used to not properly validate indices before 5.7;
     // temporarily allow older binaries to keep invoking undefined behavior as
@@ -137,6 +139,7 @@ extension String: BidirectionalCollection {
   ///   is the same value as the result of `abs(distance)` calls to
   ///   `index(before:)`.
   /// - Complexity: O(*n*), where *n* is the absolute value of `distance`.
+  @_effects(releasenone)
   public func index(_ i: Index, offsetBy distance: Int) -> Index {
     // Note: prior to Swift 5.7, this method used to be inlinable, forwarding to
     // `_index(_:offsetBy:)`.
@@ -200,6 +203,7 @@ extension String: BidirectionalCollection {
   ///   case, the method returns `nil`.
   ///
   /// - Complexity: O(*n*), where *n* is the absolute value of `distance`.
+  @_effects(releasenone)
   public func index(
     _ i: Index, offsetBy distance: Int, limitedBy limit: Index
   ) -> Index? {
@@ -254,6 +258,7 @@ extension String: BidirectionalCollection {
   /// - Returns: The distance between `start` and `end`.
   ///
   /// - Complexity: O(*n*), where *n* is the resulting distance.
+  @_effects(releasenone)
   public func distance(from start: Index, to end: Index) -> Int {
     // Note: Prior to Swift 5.7, this function used to be inlinable, forwarding
     // to `BidirectionalCollection._distance(from:to:)`.

--- a/stdlib/public/core/StringGraphemeBreaking.swift
+++ b/stdlib/public/core/StringGraphemeBreaking.swift
@@ -84,6 +84,16 @@ extension _StringGuts {
   ) -> String.Index {
     let offset = i._encodedOffset
 
+    let quickBreak = isFastUTF8 && withFastUTF8 { utf8 in
+      let prev = _decodeScalar(utf8, endingAt: offset).0
+      let next = _decodeScalar(utf8, startingAt: offset).0
+      return _GraphemeBreakingState.hasKnownBreak(
+        between: prev, and: next) == true
+    }
+    if quickBreak {
+      return i
+    }
+
     let offsetBounds = bounds._encodedOffsetRange
     let prior =
       offset - _opaqueCharacterStride(endingAt: offset, in: offsetBounds)

--- a/test/stdlib/CharacterRecognizer.swift
+++ b/test/stdlib/CharacterRecognizer.swift
@@ -138,12 +138,12 @@ if #available(SwiftStdlib 5.8, *) {
 if #available(SwiftStdlib 5.8, *) {
   suite.test("CustomStringConvertible") {
     var r = Unicode._CharacterRecognizer()
-    expectEqual("\(r)", "[]U+0")
+    expectEqual("\(r)", "[U+0:control]")
     expectTrue(r.hasBreak(before: "\u{1F1FA}")) // REGIONAL INDICATOR SYMBOL LETTER U
-    expectEqual("\(r)", "[]U+1F1FA")
+    expectEqual("\(r)", "[U+1F1FA:regionalIndicator]")
     expectFalse(r.hasBreak(before: "\u{1F1F8}")) // REGIONAL INDICATOR SYMBOL LETTER S
-    expectEqual("\(r)", "[R]U+1F1F8")
+    expectEqual("\(r)", "[U+1F1F8:regionalIndicator:R]")
     expectTrue(r.hasBreak(before: "$"))
-    expectEqual("\(r)", "[]U+24")
+    expectEqual("\(r)", "[U+24:any]")
   }
 }


### PR DESCRIPTION
This is a draft attempt at eliminating redundant lookups of Unicode properties during the grapheme breaking process. My hope is that this will (eventually) considerably speed up String's character views, but that will take a bit of work -- String indexing operations currently have no easy way to preserve information about scalars that lie on a Character boundary. (Unfortunately, most scalars tend to lie on a Character boundary...)

When finding grapheme breaks in a string such as `”Cafe\u{301}”`, operations such as `String.count` currently execute the following independent steps:

```swift
var state = _GraphemeBreakingState()
state.shouldBreak(“C”, “a”) // 2 lookups, true
state.shouldBreak(“a”, “f”) // 2 lookups, true
state.shouldBreak(“f”, “e”) // 2 lookups, true
state.shouldBreak(“e”, “\u{301}”) // 2 lookups, false
// Total: 8 property lookups
```

Each `shouldBreak(a, b)` invocation individually looks up grapheme breaking properties for _both_ scalar values, which includes calling nontrivial functions such as `hasBreakWhenPaired` and `Unicode._GraphemeBreakProperty(from:)`.

This means that during the course of the string operation, we’re retrieving this information twice for each scalar, so we are duplicating nontrivial work. We should be able to significantly speed up grapheme breaking by caching this metadata directly in the state, and preserving it across character boundaries.

```swift
var state = _GraphemeBreakingState()
state.hasBreak(before: “C”) // 1 lookup, true
state.hasBreak(before: “a”) // 1 lookup, true
state.hasBreak(before: “f”) // 1 lookup, true
state.hasBreak(before: “e”) // 1 lookup, true
state.hasBreak(before: “\u{301}”) // 1 lookup, false
// Total: 5 property lookups
```

To make this work well, I think we need to change `String.Index` to cache the grapheme breaking property of the addressed scalar, rather than the stride of the addressed Character, as it currently does. This will somewhat slow down code that iterates over strings using indices, but I suspect the improved grapheme breaking throughput will largely make up for this. (If it doesn't, we'll "just" need to also replace the huge switch statements in the current core grapheme breaking algorithms with an artisanal, small batch lookup table.)

Additionally, having indices only store information about their addressed scalar would eliminate a large source of index invalidation surprises: currently range replacements in native Swift strings sometimes invalidate indices way below the slice that they affected, which usually comes as a shock to people.

In case this proves impractical to do in String itself, at minimum we could still use this to speed up `_CharacterRecognizer`.

rdar://103970243