### PR TITLE
Update build-windows-toolchain.bat

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -588,7 +588,7 @@ cmake --build %BuildRoot%\14 --target install || (exit /b)
 cmake ^
   -B %BuildRoot%\15 ^
 
-  -D BUILD_SHARED_LIBS=YES ^
+  -D BUILD_SHARED_LIBS=NO ^
   -D CMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^
   -D CMAKE_C_COMPILER=%BuildRoot%/1/bin/clang-cl.exe ^
   -D CMAKE_C_FLAGS="/GS- /Oy /Gw /Gy" ^


### PR DESCRIPTION
Update `build-windows-toolchain.bat` to build IndexStoreDB statically. This is used in exactly one location: SourceKit-LSP.  By statically linking the product we reduce the distribution set and reduce the disk size by ~50K.

```
Dynamic:
    629,248 IndexStoreDB.dll
  8,943,616 sourcekit-lsp.exe
Static:
  9,523,200 sourcekit-lsp.exe
```