### PR TITLE
ParsePattern: allow identifiers starting with $ in protocol declaration.

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1095,7 +1095,8 @@ ParserResult<Pattern> Parser::parsePattern() {
   }
   case tok::identifier: {
     Identifier name;
-    SourceLoc loc = consumeIdentifier(name, /*diagnoseDollarPrefix=*/true);
+    SourceLoc loc = consumeIdentifier(name,
+        /*diagnoseDollarPrefix=*/!isa<ProtocolDecl>(CurDeclContext));
     if (Tok.isIdentifierOrUnderscore() && !Tok.isContextualDeclKeyword() &&
         !Tok.isAtStartOfLine())
       diagnoseConsecutiveIDs(name.str(), loc,

--- a/test/Parse/dollar_identifier.swift
+++ b/test/Parse/dollar_identifier.swift
@@ -120,6 +120,15 @@ struct S {
 
 let _ = S().$café // Okay
 
+protocol P {
+  var foo: Int { get set }
+  var $foo: String { get }
+}
+
+struct S2: P {
+  @Wrapper var foo = 1337
+}
+
 // https://github.com/apple/swift/issues/55538
 infix operator $ // expected-error{{'$' is considered an identifier and must not appear within an operator name}}
 infix operator `$` // expected-error{{'$' is considered an identifier and must not appear within an operator name}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
This enables protocols to require the existence of certain projected values in conforming types:
```swift
protocol ProtocolWithProjectedValue {
  var foo: Int { get set }
  var $foo: Wrapper<Int> { get }
}

struct StructWithPropertyWrapper: ProtocolWithProjectedValue {
  @Wrapper var foo = 1337
}
```
It is mentioned in the comments here: https://forums.swift.org/t/property-wrapper-requirements-in-protocols/33953 but that proposal seems to be stuck.
As opposed to the full proposal, this PR is a low hanging fruit (one line of code changed) that gives almost the same new capabilities to the developer.
From the desugaring point of view, this PR can also be seen as a prerequisite of the aforementioned proposal.