### PR TITLE
[AST] RuntimeMetadata: Generator context should match that of the decl its attached to

### DIFF
--- a/include/swift/AST/Initializer.h
+++ b/include/swift/AST/Initializer.h
@@ -247,7 +247,7 @@ class RuntimeAttributeInitializer : public Initializer {
 public:
   explicit RuntimeAttributeInitializer(CustomAttr *attr, ValueDecl *attachedTo)
       : Initializer(InitializerKind::RuntimeAttribute,
-                    attachedTo->getDeclContext()->getModuleScopeContext()),
+                    attachedTo->getDeclContext()),
         Attr(attr), AttachedTo(attachedTo) {}
 
   CustomAttr *getAttr() const { return Attr; }

--- a/test/type/runtime_discoverable_attrs.swift
+++ b/test/type/runtime_discoverable_attrs.swift
@@ -225,3 +225,10 @@ struct TestStaticFuncs {
   @FlagForStaticFuncs static func test1(_: Int.Type) {}
   @FlagForStaticFuncs static func test2(_: inout [String], x: Int) {}
 }
+
+struct TestSelfUse {
+  static var description: String = "TestSelfUse"
+
+  @Flag(Self.description) var x: Int = 42
+  @Flag(Self.description) func test() {}
+}


### PR DESCRIPTION
This makes it possible to to reference to `Self` if attribute
is attached to a method or a property of a nominal type.

Resolves: rdar://104210108

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
