### PR TITLE
[cxx-interop] Emit IR for templated static members with an out-of-line definition

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -178,17 +178,27 @@ void IRGenModule::emitClangDecl(const clang::Decl *decl) {
 
   ClangDeclFinder refFinder(callback);
 
+  auto &clangSema = Context.getClangModuleLoader()->getClangSema();
+
   while (!stack.empty()) {
     auto *next = const_cast<clang::Decl *>(stack.pop_back_val());
+
+    // If this is a static member of a class, it might be defined out of line.
+    // If the class is templated, the definition of its static member might be
+    // templated as well. If it is, instantiate it here.
+    if (auto var = dyn_cast<clang::VarDecl>(next)) {
+      if (var->isStaticDataMember() &&
+          var->getTemplateSpecializationKind() ==
+              clang::TemplateSpecializationKind::TSK_ImplicitInstantiation)
+        clangSema.InstantiateVariableDefinition(var->getLocation(), var);
+    }
 
     // If a function calls another method in a class template specialization, we
     // need to instantiate that other function. Do that here.
     if (auto *fn = dyn_cast<clang::FunctionDecl>(next)) {
       // Make sure that this method is part of a class template specialization.
       if (fn->getTemplateInstantiationPattern())
-        Context.getClangModuleLoader()
-            ->getClangSema()
-            .InstantiateFunctionDefinition(fn->getLocation(), fn);
+        clangSema.InstantiateFunctionDefinition(fn->getLocation(), fn);
     }
 
     if (clang::Decl *executableDecl = getDeclWithExecutableCode(next)) {

--- a/test/Interop/Cxx/templates/Inputs/class-template-with-static-out-of-line-member.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-with-static-out-of-line-member.h
@@ -1,0 +1,18 @@
+#ifndef TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_WITH_STATIC_OUT_OF_LINE_MEMBER_H
+#define TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_WITH_STATIC_OUT_OF_LINE_MEMBER_H
+
+template <class T>
+struct HasStaticOutOfLineMember {
+  static int values[];
+  
+  static int getFirstValue() {
+    return values[0];
+  }
+};
+
+template <class T>
+int HasStaticOutOfLineMember<T>::values[123];
+
+typedef HasStaticOutOfLineMember<int> HasStaticOutOfLineMemberInt;
+
+#endif // TEST_INTEROP_CXX_TEMPLATES_INPUTS_CLASS_TEMPLATE_WITH_STATIC_OUT_OF_LINE_MEMBER_H

--- a/test/Interop/Cxx/templates/Inputs/module.modulemap
+++ b/test/Interop/Cxx/templates/Inputs/module.modulemap
@@ -8,6 +8,11 @@ module ClassTemplateWithPrimitiveArgument {
   requires cplusplus
 }
 
+module ClassTemplateWithOutOfLineMember {
+  header "class-template-with-static-out-of-line-member.h"
+  requires cplusplus
+}
+
 module NotPreDefinedClassTemplate {
   header "not-pre-defined-class-template.h"
   requires cplusplus

--- a/test/Interop/Cxx/templates/class-template-with-static-out-of-line-member.swift
+++ b/test/Interop/Cxx/templates/class-template-with-static-out-of-line-member.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -disable-availability-checking | %FileCheck %s
+
+import ClassTemplateWithOutOfLineMember
+
+public func usesStaticMember() {
+  HasStaticOutOfLineMemberInt.getFirstValue()
+}
+
+// CHECK: @{{_ZN24HasStaticOutOfLineMemberIiE6valuesE|"\?values@\?\$HasStaticOutOfLineMember@H@@2PAHA"}} = linkonce_odr{{.*}} global {{.*}} zeroinitializer
+
+// CHECK: define {{.*}}i32 @{{_ZN24HasStaticOutOfLineMemberIiE13getFirstValueEv|"\?getFirstValue@\?\$HasStaticOutOfLineMember@H@@SAHXZ"}}()
+// CHECK: %0 = {{.*}} @{{_ZN24HasStaticOutOfLineMemberIiE6valuesE|"\?values@\?\$HasStaticOutOfLineMember@H@@2PAHA"}}


### PR DESCRIPTION
This fixes https://github.com/apple/swift/issues/63055.

rdar://101539308