### PR TITLE
[Macros] Initial support for synthesized member macros.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -80,6 +80,7 @@ namespace swift {
   class GenericSignature;
   class GenericTypeParamDecl;
   class GenericTypeParamType;
+  class MacroDecl;
   class MacroDefinition;
   class ModuleDecl;
   class NamedPattern;
@@ -855,6 +856,13 @@ public:
   /// including attributes that are generated as the result of member
   /// attribute macro expansion.
   DeclAttributes getSemanticAttrs() const;
+
+  using MacroCallback = llvm::function_ref<void(CustomAttr *, MacroDecl *)>;
+
+  /// Iterate over each attached macro with the given role, invoking the
+  /// given callback with each macro custom attribute and corresponding macro
+  /// declaration.
+  void forEachAttachedMacro(MacroRole role, MacroCallback) const;
 
   /// Returns the innermost enclosing decl with an availability annotation.
   const Decl *getInnermostDeclWithAvailability() const;

--- a/include/swift/AST/MacroDeclaration.h
+++ b/include/swift/AST/MacroDeclaration.h
@@ -35,6 +35,9 @@ enum class MacroRole: uint32_t {
   /// An attached macro that generates attributes for the
   /// members inside the declaration.
   MemberAttribute = 0x08,
+  /// An attached macro that generates synthesized members
+  /// inside the declaration.
+  SynthesizedMembers = 0x10,
 };
 
 /// The contexts in which a particular macro declaration can be used.

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -511,6 +511,13 @@ public:
   /// macro.
   CustomAttr *getAttachedMacroAttribute() const;
 
+  /// For source files created to hold the source code created by expanding
+  /// an attached macro, this is the macro role that the expansion fulfills.
+  ///
+  /// \Returns the fulfilled macro role, or \c None if this source file is not
+  /// for a macro expansion.
+  Optional<MacroRole> getFulfilledMacroRole() const;
+
   /// When this source file is enclosed within another source file, for example
   /// because it describes a macro expansion, return the source file it was
   /// enclosed in.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3856,6 +3856,23 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Expand synthesized member macros attached to the given declaration.
+class ExpandSynthesizedMemberMacroRequest
+    : public SimpleRequest<ExpandSynthesizedMemberMacroRequest,
+                           bool(Decl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  bool evaluate(Evaluator &evaluator, Decl *decl) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 /// Resolve an external macro given its module and type name.
 class ExternalMacroDefinitionRequest
     : public SimpleRequest<ExternalMacroDefinitionRequest,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -458,6 +458,9 @@ SWIFT_REQUEST(TypeChecker, ExpandMacroExpansionDeclRequest,
 SWIFT_REQUEST(TypeChecker, ExpandMemberAttributeMacros,
               bool(Decl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeCHecker, ExpandSynthesizedMemberMacroRequest,
+              bool(Decl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SynthesizeRuntimeMetadataAttrGenerator,
               Expr *(CustomAttr *, ValueDecl *),
               Cached, NoLocationInfo)

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -44,6 +44,9 @@ public:
     /// The expansion of a member attribute attached macro.
     MemberAttributeMacroExpansion,
 
+    /// The expansion of a synthesized member macro.
+    SynthesizedMemberMacroExpansion,
+
     /// A new function body that is replacing an existing function body.
     ReplacedFunctionBody,
 

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -248,7 +248,28 @@ ASTSourceFileScope::ASTSourceFileScope(SourceFile *SF,
                                        ScopeCreator *scopeCreator)
     : SF(SF), scopeCreator(scopeCreator) {
   if (auto enclosingSF = SF->getEnclosingSourceFile()) {
-    SourceLoc parentLoc = SF->getMacroExpansion().getStartLoc();
+    SourceLoc parentLoc;
+    auto macroRole = SF->getFulfilledMacroRole();
+    auto expansion = SF->getMacroExpansion();
+
+    // Determine the parent source location based on the macro role.
+    switch (*macroRole) {
+    case MacroRole::Expression:
+    case MacroRole::FreestandingDeclaration:
+    case MacroRole::Accessor:
+    case MacroRole::MemberAttribute:
+      parentLoc = expansion.getStartLoc();
+      break;
+    case MacroRole::SynthesizedMembers: {
+      // For synthesized member macros, take the end loc of the
+      // enclosing declaration (before the closing brace), because
+      // the macro expansion is inside this scope.
+      auto *decl = expansion.getAsDeclContext()->getAsDecl();
+      parentLoc = decl->getEndLoc();
+      break;
+    }
+    }
+
     if (auto parentScope = findStartingScopeForLookup(enclosingSF, parentLoc)) {
       parentAndWasExpanded.setPointer(const_cast<ASTScopeImpl *>(parentScope));
     }

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3654,12 +3654,13 @@ public:
     void checkSourceRanges(Decl *D) {
       PrettyStackTraceDecl debugStack("verifying ranges", D);
       const auto SR = D->getSourceRange();
+
+      // We don't care about source ranges on implicitly-generated
+      // decls.
+      if (D->isImplicit())
+        return;
+
       if (!SR.isValid()) {
-        // We don't care about source ranges on implicitly-generated
-        // decls.
-        if (D->isImplicit())
-          return;
-        
         Out << "invalid source range for decl: ";
         D->print(Out);
         Out << "\n";

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9703,6 +9703,9 @@ StringRef swift::getMacroRoleString(MacroRole role) {
 
   case MacroRole::MemberAttribute:
     return "memberAttributes";
+
+  case MacroRole::SynthesizedMembers:
+    return "synthesizedMembers";
   }
 }
 
@@ -9745,8 +9748,10 @@ static MacroRoles freestandingMacroRoles =
   (MacroRoles() |
    MacroRole::Expression |
    MacroRole::FreestandingDeclaration);
-static MacroRoles attachedMacroRoles = (MacroRoles() | MacroRole::Accessor |
-                                        MacroRole::MemberAttribute);
+static MacroRoles attachedMacroRoles = (MacroRoles() |
+                                        MacroRole::Accessor |
+                                        MacroRole::MemberAttribute |
+                                        MacroRole::SynthesizedMembers);
 
 bool swift::isFreestandingMacro(MacroRoles contexts) {
   return bool(contexts & freestandingMacroRoles);

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1314,7 +1314,8 @@ std::vector<Diagnostic> DiagnosticEngine::getGeneratedSourceBufferNotes(
     case GeneratedSourceInfo::ExpressionMacroExpansion:
     case GeneratedSourceInfo::FreestandingDeclMacroExpansion:
     case GeneratedSourceInfo::AccessorMacroExpansion:
-    case GeneratedSourceInfo::MemberAttributeMacroExpansion: {
+    case GeneratedSourceInfo::MemberAttributeMacroExpansion:
+    case GeneratedSourceInfo::SynthesizedMemberMacroExpansion: {
       SourceRange origRange = expansionNode.getSourceRange();
       DeclName macroName;
       if (auto customAttr = generatedInfo->attachedMacroCustomAttr) {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -896,6 +896,34 @@ CustomAttr *SourceFile::getAttachedMacroAttribute() const {
   return genInfo.attachedMacroCustomAttr;
 }
 
+Optional<MacroRole> SourceFile::getFulfilledMacroRole() const {
+  if (Kind != SourceFileKind::MacroExpansion)
+    return None;
+
+  auto genInfo =
+      *getASTContext().SourceMgr.getGeneratedSourceInfo(*getBufferID());
+  switch (genInfo.kind) {
+  case GeneratedSourceInfo::ExpressionMacroExpansion:
+    return MacroRole::Expression;
+
+  case GeneratedSourceInfo::FreestandingDeclMacroExpansion:
+    return MacroRole::FreestandingDeclaration;
+
+  case GeneratedSourceInfo::AccessorMacroExpansion:
+    return MacroRole::Accessor;
+
+  case GeneratedSourceInfo::MemberAttributeMacroExpansion:
+    return MacroRole::MemberAttribute;
+
+  case GeneratedSourceInfo::SynthesizedMemberMacroExpansion:
+    return MacroRole::SynthesizedMembers;
+
+  case GeneratedSourceInfo::ReplacedFunctionBody:
+  case GeneratedSourceInfo::PrettyPrinted:
+    return None;
+  }
+}
+
 SourceFile *SourceFile::getEnclosingSourceFile() const {
   auto macroExpansion = getMacroExpansion();
   if (!macroExpansion)

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -344,6 +344,18 @@ func expandAttachedMacro(
         $0.withoutTrivia().description
       }.joined(separator: " ")
 
+    case let attachedMacro as MemberDeclarationMacro.Type:
+      let members = try attachedMacro.expansion(
+        of: customAttrNode,
+        attachedTo: declarationNode,
+        in: &context
+      )
+
+      // Form a buffer of member declarations to return to the caller.
+      evaluatedSyntaxStr = members.map {
+        $0.withoutTrivia().description
+      }.joined(separator: "\n\n")
+
     default:
       print("\(macroPtr) does not conform to any known attached macro protocol")
       return 1

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -314,6 +314,7 @@ void SourceManager::setGeneratedSourceInfo(
   case GeneratedSourceInfo::FreestandingDeclMacroExpansion:
   case GeneratedSourceInfo::AccessorMacroExpansion:
   case GeneratedSourceInfo::MemberAttributeMacroExpansion:
+  case GeneratedSourceInfo::SynthesizedMemberMacroExpansion:
   case GeneratedSourceInfo::PrettyPrinted:
     break;
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2225,6 +2225,7 @@ static Optional<MacroRole> getMacroRole(
       .Case("expression", MacroRole::Expression)
       .Case("accessor", MacroRole::Accessor)
       .Case("memberAttributes", MacroRole::MemberAttribute)
+      .Case("synthesizedMembers", MacroRole::SynthesizedMembers)
       .Default(None);
 
   if (!role) {

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -174,6 +174,7 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
     switch (generatedInfo->kind) {
     case GeneratedSourceInfo::FreestandingDeclMacroExpansion:
     case GeneratedSourceInfo::ExpressionMacroExpansion:
+    case GeneratedSourceInfo::SynthesizedMemberMacroExpansion:
     case GeneratedSourceInfo::ReplacedFunctionBody:
     case GeneratedSourceInfo::PrettyPrinted: {
       parser.parseTopLevelItems(items);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2789,6 +2789,13 @@ static ArrayRef<Decl *> evaluateMembersRequest(
     }
   }
 
+  // Expand synthesized member macros.
+  auto *mutableDecl = const_cast<Decl *>(idc->getDecl());
+  (void)evaluateOrDefault(
+      ctx.evaluator,
+      ExpandSynthesizedMemberMacroRequest{mutableDecl},
+      false);
+
   // If the decl has a @main attribute, we need to force synthesis of the
   // $main function.
   (void) evaluateOrDefault(

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -338,6 +338,31 @@ bool ExpandMemberAttributeMacros::evaluate(Evaluator &evaluator,
   return addedAttributes;
 }
 
+bool ExpandSynthesizedMemberMacroRequest::evaluate(Evaluator &evaluator,
+                                                   Decl *decl) const {
+  auto &ctx = decl->getASTContext();
+  auto *dc = decl->getInnermostDeclContext();
+  bool synthesizedMembers = false;
+
+  for (auto customAttrConst : decl->getSemanticAttrs().getAttributes<CustomAttr>()) {
+    auto customAttr = const_cast<CustomAttr *>(customAttrConst);
+    auto *macroDecl = evaluateOrDefault(
+        ctx.evaluator,
+        ResolveAttachedMacroRequest{customAttr, dc},
+        nullptr);
+
+    if (!macroDecl)
+      continue;
+
+    if (!macroDecl->getMacroRoles().contains(MacroRole::SynthesizedMembers))
+      continue;
+
+    // Expand the synthesized members.
+    synthesizedMembers |= expandSynthesizedMembers(customAttr, macroDecl, decl);
+  }
+
+  return synthesizedMembers;
+}
 
 /// Determine whether the given source file is from an expansion of the given
 /// macro.
@@ -1080,6 +1105,181 @@ bool swift::expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member) {
   }
 
   return addedAttributes;
+}
+
+bool swift::expandSynthesizedMembers(CustomAttr *attr, MacroDecl *macro,
+                                     Decl *decl) {
+  auto *dc = decl->getInnermostDeclContext();
+  ASTContext &ctx = dc->getASTContext();
+  SourceManager &sourceMgr = ctx.SourceMgr;
+  auto moduleDecl = dc->getParentModule();
+
+  auto attrSourceFile =
+    moduleDecl->getSourceFileContainingLocation(attr->AtLoc);
+  if (!attrSourceFile)
+    return false;
+
+  auto declSourceFile =
+      moduleDecl->getSourceFileContainingLocation(decl->getStartLoc());
+  if (!declSourceFile)
+    return false;
+
+  // Evaluate the macro.
+  NullTerminatedStringRef evaluatedSource;
+
+  if (isFromExpansionOfMacro(attrSourceFile, macro) ||
+      isFromExpansionOfMacro(declSourceFile, macro)) {
+    decl->diagnose(diag::macro_recursive, macro->getName());
+    return false;
+  }
+
+  auto macroDef = macro->getDefinition();
+  switch (macroDef.kind) {
+  case MacroDefinition::Kind::Undefined:
+  case MacroDefinition::Kind::Invalid:
+    // Already diagnosed as an error elsewhere.
+    return false;
+
+  case MacroDefinition::Kind::Builtin: {
+    switch (macroDef.getBuiltinKind()) {
+    case BuiltinMacroKind::ExternalMacro:
+      // FIXME: Error here.
+      return false;
+    }
+  }
+
+  case MacroDefinition::Kind::External: {
+    // Retrieve the external definition of the macro.
+    auto external = macroDef.getExternalMacro();
+    ExternalMacroDefinitionRequest request{
+        &ctx, external.moduleName, external.macroTypeName
+    };
+    auto externalDef = evaluateOrDefault(
+        ctx.evaluator, request, ExternalMacroDefinition()
+    );
+    if (!externalDef.opaqueHandle) {
+      decl->diagnose(diag::external_macro_not_found,
+                     external.moduleName.str(),
+                     external.macroTypeName.str(),
+                     macro->getName()
+      );
+      macro->diagnose(diag::decl_declared_here, macro->getName());
+      return false;
+    }
+
+    // Make sure macros are enabled before we expand.
+    if (!ctx.LangOpts.hasFeature(Feature::Macros)) {
+      decl->diagnose(diag::macro_experimental);
+      return false;
+    }
+
+#if SWIFT_SWIFT_PARSER
+    PrettyStackTraceDecl debugStack("expanding attribute macro", decl);
+
+    auto astGenAttrSourceFile = attrSourceFile->exportedSourceFile;
+    if (!astGenAttrSourceFile)
+      return false;
+
+    auto astGenDeclSourceFile = declSourceFile->exportedSourceFile;
+    if (!astGenDeclSourceFile)
+      return false;
+
+    const char *evaluatedSourceAddress;
+    ptrdiff_t evaluatedSourceLength;
+    swift_ASTGen_expandAttachedMacro(
+        &ctx.Diags,
+        externalDef.opaqueHandle,
+        astGenAttrSourceFile, attr->AtLoc.getOpaquePointerValue(),
+        astGenDeclSourceFile, decl->getStartLoc().getOpaquePointerValue(),
+        /*parentDeclSourceFile*/nullptr, /*parentDeclLoc*/nullptr,
+        &evaluatedSourceAddress, &evaluatedSourceLength);
+    if (!evaluatedSourceAddress)
+      return false;
+    evaluatedSource = NullTerminatedStringRef(evaluatedSourceAddress,
+                                              (size_t)evaluatedSourceLength);
+    break;
+#else
+    decl->diagnose(diag::macro_unsupported);
+    return false;
+#endif
+  }
+  }
+
+  // Figure out a reasonable name for the macro expansion buffer.
+  std::string bufferName;
+  {
+    llvm::raw_string_ostream out(bufferName);
+
+    out << "macro:"
+        << "@" << macro->getName().getBaseName();
+    if (auto bufferID = declSourceFile->getBufferID()) {
+      unsigned startLine, startColumn;
+      std::tie(startLine, startColumn) =
+          sourceMgr.getLineAndColumnInBuffer(decl->getStartLoc(), *bufferID);
+
+      SourceLoc endLoc =
+          Lexer::getLocForEndOfToken(sourceMgr, decl->getEndLoc());
+      unsigned endLine, endColumn;
+      std::tie(endLine, endColumn) =
+          sourceMgr.getLineAndColumnInBuffer(endLoc, *bufferID);
+
+      out << ":" << sourceMgr.getIdentifierForBuffer(*bufferID) << ":"
+          << startLine << ":" << startColumn
+          << "-" << endLine << ":" << endColumn;
+    }
+  }
+
+  // Dump macro expansions to standard output, if requested.
+  if (ctx.LangOpts.DumpMacroExpansions) {
+    llvm::errs() << bufferName
+                 << "\n------------------------------\n"
+                 << evaluatedSource
+                 << "\n------------------------------\n";
+  }
+
+  // Create a new source buffer with the contents of the expanded macro.
+  auto macroBuffer =
+      llvm::MemoryBuffer::getMemBufferCopy(evaluatedSource, bufferName);
+  unsigned macroBufferID = sourceMgr.addNewSourceBuffer(std::move(macroBuffer));
+  auto macroBufferRange = sourceMgr.getRangeForBuffer(macroBufferID);
+  GeneratedSourceInfo sourceInfo{
+      GeneratedSourceInfo::SynthesizedMemberMacroExpansion,
+      decl->getEndLoc(),
+      SourceRange(macroBufferRange.getStart(), macroBufferRange.getEnd()),
+      ASTNode(decl).getOpaqueValue(),
+      dc,
+      attr
+  };
+  sourceMgr.setGeneratedSourceInfo(macroBufferID, sourceInfo);
+  free((void*)evaluatedSource.data());
+
+  // Create a source file to hold the macro buffer. This is automatically
+  // registered with the enclosing module.
+  auto macroSourceFile = new (ctx) SourceFile(
+      *dc->getParentModule(), SourceFileKind::MacroExpansion, macroBufferID,
+      /*parsingOpts=*/{}, /*isPrimary=*/false);
+  macroSourceFile->setImports(declSourceFile->getImports());
+
+  PrettyStackTraceDecl debugStack(
+      "type checking expanded declaration macro", decl);
+
+  bool synthesizedMembers = false;
+  auto topLevelDecls = macroSourceFile->getTopLevelDecls();
+  for (auto member : topLevelDecls) {
+    member->setDeclContext(decl->getInnermostDeclContext());
+    member->setImplicit();
+
+    if (auto *nominal = dyn_cast<NominalTypeDecl>(decl)) {
+      nominal->addMember(member);
+    } else if (auto *extension = dyn_cast<ExtensionDecl>(decl)) {
+      extension->addMember(member);
+    }
+
+    TypeChecker::typeCheckDecl(member);
+    synthesizedMembers = true;
+  }
+
+  return synthesizedMembers;
 }
 
 MacroDecl *

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1251,7 +1251,6 @@ bool swift::expandSynthesizedMembers(CustomAttr *attr, MacroDecl *macro,
       extension->addMember(member);
     }
 
-    TypeChecker::typeCheckDecl(member);
     synthesizedMembers = true;
   }
 

--- a/lib/Sema/TypeCheckMacros.h
+++ b/lib/Sema/TypeCheckMacros.h
@@ -53,6 +53,13 @@ void expandAccessors(
 /// on the custom attribute that references the given macro.
 bool expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member);
 
+/// Expand the synthesized members for the given declaration based on
+/// the custom attribute that references the given macro.
+///
+/// Returns \c true if the macro added new synthesized members, \c false
+/// otherwise.
+bool expandSynthesizedMembers(CustomAttr *attr, MacroDecl *macro, Decl *decl);
+
 } // end namespace swift
 
 #endif /* SWIFT_SEMA_TYPECHECKMACROS_H */

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -114,7 +114,6 @@ static void computeLoweredStoredProperties(NominalTypeDecl *decl,
     (void)decl->getTypeWrapperProperty();
 
   // Expand synthesized member macros.
-  // FIXME: Member macros can add members other than stored properties.
   auto &ctx = decl->getASTContext();
   evaluateOrDefault(ctx.evaluator,
                     ExpandSynthesizedMemberMacroRequest{decl},

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -113,6 +113,13 @@ static void computeLoweredStoredProperties(NominalTypeDecl *decl,
   if (decl->hasTypeWrapper())
     (void)decl->getTypeWrapperProperty();
 
+  // Expand synthesized member macros.
+  // FIXME: Member macros can add members other than stored properties.
+  auto &ctx = decl->getASTContext();
+  evaluateOrDefault(ctx.evaluator,
+                    ExpandSynthesizedMemberMacroRequest{decl},
+                    false);
+
   // Just walk over the members of the type, forcing backing storage
   // for lazy properties and property wrappers to be synthesized.
   for (auto *member : implDecl->getMembers()) {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -613,6 +613,7 @@ enum class MacroRole : uint8_t {
   FreestandingDeclaration,
   Accessor,
   MemberAttribute,
+  SynthesizedMembers,
 };
 using MacroRoleField = BCFixed<3>;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2227,6 +2227,7 @@ static uint8_t getRawStableMacroRole(swift::MacroRole context) {
   CASE(FreestandingDeclaration)
   CASE(Accessor)
   CASE(MemberAttribute)
+  CASE(SynthesizedMembers)
   }
 #undef CASE
   llvm_unreachable("bad result declaration macro kind");

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -346,3 +346,32 @@ public struct AccessViaStorageMacro: AccessorDeclarationMacro {
     ]
   }
 }
+
+public struct AddMembers: MemberDeclarationMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: DeclSyntax,
+    in context: inout MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let storageStruct: StructDeclSyntax =
+      """
+      struct Nested {}
+      """
+
+    let storageVariable: VariableDeclSyntax =
+      """
+      var value: Int = 0
+      """
+
+    let instanceMethod: FunctionDeclSyntax =
+      """
+      func method() { print("synthesized method") }
+      """
+
+    return [
+      DeclSyntax(storageStruct),
+      DeclSyntax(storageVariable),
+      DeclSyntax(instanceMethod),
+    ]
+  }
+}

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -327,3 +327,20 @@ public struct AccessViaStorageMacro: AccessorDeclarationMacro {
     ]
   }
 }
+
+public struct TypeWrapperStorageMacro: MemberDeclarationMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: DeclSyntax,
+    in context: inout MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let storageVariable: VariableDeclSyntax =
+      """
+      private var _storage = _Storage()
+      """
+
+    return [
+      DeclSyntax(storageVariable),
+    ]
+  }
+}

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -274,7 +274,9 @@ public struct WrapAllProperties: MemberAttributeMacro {
   }
 }
 
-public struct TypeWrapperMacro: MemberAttributeMacro {
+public struct TypeWrapperMacro {}
+
+extension TypeWrapperMacro: MemberAttributeMacro {
   public static func expansion(
     of node: AttributeSyntax,
     attachedTo decl: DeclSyntax,
@@ -303,6 +305,23 @@ public struct TypeWrapperMacro: MemberAttributeMacro {
   }
 }
 
+extension TypeWrapperMacro: MemberDeclarationMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: DeclSyntax,
+    in context: inout MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let storageVariable: VariableDeclSyntax =
+      """
+      private var _storage = _Storage()
+      """
+
+    return [
+      DeclSyntax(storageVariable),
+    ]
+  }
+}
+
 public struct AccessViaStorageMacro: AccessorDeclarationMacro {
   public static func expansion(
     of node: AttributeSyntax,
@@ -324,23 +343,6 @@ public struct AccessViaStorageMacro: AccessorDeclarationMacro {
     return [
       "get { _storage.\(identifier) }",
       "set { _storage.\(identifier) = newValue }",
-    ]
-  }
-}
-
-public struct TypeWrapperStorageMacro: MemberDeclarationMacro {
-  public static func expansion(
-    of node: AttributeSyntax,
-    attachedTo decl: DeclSyntax,
-    in context: inout MacroExpansionContext
-  ) throws -> [DeclSyntax] {
-    let storageVariable: VariableDeclSyntax =
-      """
-      private var _storage = _Storage()
-      """
-
-    return [
-      DeclSyntax(storageVariable),
     ]
   }
 }

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -355,12 +355,12 @@ public struct AddMembers: MemberDeclarationMacro {
   ) throws -> [DeclSyntax] {
     let storageStruct: StructDeclSyntax =
       """
-      struct Nested {}
+      struct Storage {}
       """
 
     let storageVariable: VariableDeclSyntax =
       """
-      var value: Int = 0
+      var storage = Storage()
       """
 
     let instanceMethod: FunctionDeclSyntax =

--- a/test/Macros/composed_macro.swift
+++ b/test/Macros/composed_macro.swift
@@ -10,6 +10,7 @@
 // REQUIRES: OS=macosx
 
 @attached(memberAttributes) macro myTypeWrapper() = #externalMacro(module: "MacroDefinition", type: "TypeWrapperMacro")
+@attached(synthesizedMembers) macro typeWrapperStorage() = #externalMacro(module: "MacroDefinition", type: "TypeWrapperStorageMacro")
 @attached(accessor) macro accessViaStorage() = #externalMacro(module: "MacroDefinition", type: "AccessViaStorageMacro")
 
 struct _Storage {
@@ -21,10 +22,9 @@ struct _Storage {
   }
 }
 
+@typeWrapperStorage
 @myTypeWrapper
 struct S {
-  var _storage = _Storage()
-
   var x: Int
   var y: Int
 }

--- a/test/Macros/composed_macro.swift
+++ b/test/Macros/composed_macro.swift
@@ -9,8 +9,9 @@
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx
 
-@attached(memberAttributes) macro myTypeWrapper() = #externalMacro(module: "MacroDefinition", type: "TypeWrapperMacro")
-@attached(synthesizedMembers) macro typeWrapperStorage() = #externalMacro(module: "MacroDefinition", type: "TypeWrapperStorageMacro")
+@attached(memberAttributes)
+@attached(synthesizedMembers)
+macro myTypeWrapper() = #externalMacro(module: "MacroDefinition", type: "TypeWrapperMacro")
 @attached(accessor) macro accessViaStorage() = #externalMacro(module: "MacroDefinition", type: "AccessViaStorageMacro")
 
 struct _Storage {
@@ -22,7 +23,6 @@ struct _Storage {
   }
 }
 
-@typeWrapperStorage
 @myTypeWrapper
 struct S {
   var x: Int

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -14,15 +14,13 @@
 @addMembers
 struct S {
   func useSynthesized() {
-    print(s.value)
-    print(S.Nested())
-    s.method()
+    print(type(of: storage))
+    method()
   }
 }
 
 let s = S()
 
-// CHECK: 0
-// CHECK: Nested
+// CHECK: Storage
 // CHECK: synthesized method
 s.useSynthesized()

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -1,0 +1,28 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUNx: %target-swift-frontend -dump-ast -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser 2>&1 | %FileCheck --check-prefix CHECK-AST %s
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
+// RUN: %target-build-swift -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+
+// FIXME: Swift parser is not enabled on Linux CI yet.
+// REQUIRES: OS=macosx
+
+@attached(synthesizedMembers) macro addMembers() = #externalMacro(module: "MacroDefinition", type: "AddMembers")
+
+@addMembers
+struct S {
+  func useSynthesized() {
+    print(s.value)
+    print(S.Nested())
+    s.method()
+  }
+}
+
+let s = S()
+
+// CHECK: 0
+// CHECK: Nested
+// CHECK: synthesized method
+s.useSynthesized()


### PR DESCRIPTION
Implement initial support for attached macros that can add members inside the declaration they are attached to. For example:

```swift
@attached(synthesizedMembers) macro addMembers() = #externalMacro(...)

@addMembers
struct S {}
```

can expand to

```swift
struct S {
  struct Storage { ... }

  var storage = Storage()
}
```