### PR TITLE
[cxx-interop] Do not crash while generating a diagnostic for un-instantiatable template

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -5657,12 +5657,16 @@ clang::FunctionDecl *ClangImporter::instantiateCXXFunctionTemplate(
     std::string failedTypesStr;
     llvm::raw_string_ostream failedTypesStrStream(failedTypesStr);
     llvm::interleaveComma(error->failedTypes, failedTypesStrStream);
+
+    std::string funcName;
+    llvm::raw_string_ostream funcNameStream(funcName);
+    func->printQualifiedName(funcNameStream);
+
     // TODO: Use the location of the apply here.
     // TODO: This error message should not reference implementation details.
     // See: https://github.com/apple/swift/pull/33053#discussion_r477003350
-    ctx.Diags.diagnose(SourceLoc(),
-                       diag::unable_to_convert_generic_swift_types.ID,
-                       {func->getName(), StringRef(failedTypesStr)});
+    ctx.Diags.diagnose(SourceLoc(), diag::unable_to_convert_generic_swift_types,
+                       funcName, failedTypesStr);
     return nullptr;
   }
 

--- a/test/Interop/Cxx/templates/Inputs/class-template-instantiation-errors.h
+++ b/test/Interop/Cxx/templates/Inputs/class-template-instantiation-errors.h
@@ -7,6 +7,12 @@ struct MagicWrapper {
   int getValuePlusArg(int arg) const { return t.getValue() + arg; }
 };
 
+template<class T>
+struct MagicWrapperWithExplicitCtor {
+  T t;
+  MagicWrapperWithExplicitCtor(T t) : t(t) {}
+};
+
 struct IntWrapper {
   int value;
   int getValue() const { return value; }

--- a/test/Interop/Cxx/templates/class-template-instantiation-typechecker.swift
+++ b/test/Interop/Cxx/templates/class-template-instantiation-typechecker.swift
@@ -7,6 +7,11 @@ func swiftTemplateArgNotSupported() {
   var _ = MagicWrapper<Optional>(t: "asdf")
 }
 
+// CHECK: class-template-instantiation-typechecker.swift:12:11: error: could not generate C++ types from the generic Swift types provided. The following Swift type(s) provided to 'MagicWrapperWithExplicitCtor' could not be converted: String.
+func swiftTemplateArgNotSupportedExplicitCtor() {
+  var _ = MagicWrapperWithExplicitCtor<String>("asdf")
+}
+
 // CHECK: error: no member named 'doesNotExist' in 'IntWrapper'
 // CHECK: note: in instantiation of member function 'CannotBeInstantianted<IntWrapper>::CannotBeInstantianted' requested here
 


### PR DESCRIPTION
Swift was previously crashing while emitting an error ("could not generate C++ types from the generic Swift types provided") for C++ decls that do not have a name, such as constructors: `func->getName()` triggered an assertion.

```
Assertion failed: (Name.isIdentifier() && "Name is not a simple identifier"), function getName, file Decl.h, line 275.
...
8  swift-frontend           0x000000010b455b00 swift::DiagnosticEngine::diagnose(swift::SourceLoc, swift::DiagID, llvm::ArrayRef<swift::DiagnosticArgument>) (.cold.1) + 0
9  swift-frontend           0x000000010384c608 swift::ClangImporter::instantiateCXXFunctionTemplate(swift::ASTContext&, clang::FunctionTemplateDecl*, swift::SubstitutionMap) + 636
10 swift-frontend           0x000000010384c99c swift::ClangImporter::getCXXFunctionTemplateSpecialization(swift::SubstitutionMap, swift::ValueDecl*) + 300
11 swift-frontend           0x000000010353ecac swift::constraints::Solution::resolveConcreteDeclRef(swift::ValueDecl*, swift::constraints::ConstraintLocator*) const + 284
12 swift-frontend           0x0000000103554c5c (anonymous namespace)::ExprRewriter::finishApply(swift::ApplyExpr*, swift::Type, swift::constraints::ConstraintLocatorBuilder, swift::constraints::ConstraintLocatorBuilder) + 372
13 swift-frontend           0x000000010355a060 (anonymous namespace)::ExprRewriter::visitApplyExpr(swift::ApplyExpr*) + 212
14 swift-frontend           0x00000001035457e4 (anonymous namespace)::ExprWalker::walkToExprPost(swift::Expr*) + 132
15 swift-frontend           0x0000000103a24d48 (anonymous namespace)::Traversal::doIt(swift::Expr*) + 1012
...
```