### PR TITLE
[Reflection] Update availability

### DIFF
--- a/stdlib/public/Reflection/Sources/Reflection/Case.swift
+++ b/stdlib/public/Reflection/Sources/Reflection/Case.swift
@@ -12,7 +12,7 @@
 import Swift
 import _Runtime
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct Case {
   @usableFromInline
@@ -44,7 +44,7 @@ public struct Case {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Case {
   @inlinable
   public var hasPayload: Bool {
@@ -77,7 +77,7 @@ extension Case {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Case: CustomStringConvertible {
   @inlinable
   public var description: String {
@@ -97,7 +97,7 @@ extension Case: CustomStringConvertible {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct Cases {
   @usableFromInline
@@ -109,7 +109,7 @@ public struct Cases {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Cases: RandomAccessCollection {
   @inlinable
   public var startIndex: Int {
@@ -143,7 +143,7 @@ extension Cases: RandomAccessCollection {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Type {
   @inlinable
   public var cases: Cases {

--- a/stdlib/public/Reflection/Sources/Reflection/Field.swift
+++ b/stdlib/public/Reflection/Sources/Reflection/Field.swift
@@ -12,7 +12,7 @@
 import Swift
 import _Runtime
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct Field {
   @usableFromInline
@@ -28,7 +28,7 @@ public struct Field {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Field {
   @inlinable
   public var isVar: Bool {
@@ -94,7 +94,7 @@ extension Field {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Field: CustomStringConvertible {
   @inlinable
   public var description: String {
@@ -112,7 +112,7 @@ extension Field: CustomStringConvertible {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct Fields {
   @usableFromInline
@@ -124,7 +124,7 @@ public struct Fields {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Fields: RandomAccessCollection {
   @inlinable
   public var startIndex: Int {
@@ -164,7 +164,7 @@ extension Fields: RandomAccessCollection {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Type {
   @inlinable
   public var fields: Fields {

--- a/stdlib/public/Reflection/Sources/Reflection/GenericArguments.swift
+++ b/stdlib/public/Reflection/Sources/Reflection/GenericArguments.swift
@@ -12,7 +12,7 @@
 import Swift
 import _Runtime
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct GenericArguments {
   @usableFromInline
@@ -28,7 +28,7 @@ public struct GenericArguments {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension GenericArguments: RandomAccessCollection {
   @inlinable
   public var startIndex: Int {
@@ -55,7 +55,7 @@ extension GenericArguments: RandomAccessCollection {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension GenericArguments: BidirectionalCollection {
   @inlinable
   public func index(before i: Int) -> Int {

--- a/stdlib/public/Reflection/Sources/Reflection/KeyPath.swift
+++ b/stdlib/public/Reflection/Sources/Reflection/KeyPath.swift
@@ -13,7 +13,7 @@ import Swift
 import _Runtime
 
 extension KeyPath {
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @usableFromInline
   static func create(for field: Field) -> KeyPath {
     let result = Builtin.allocWithTailElems_1(
@@ -50,7 +50,7 @@ extension KeyPath {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Case {
   @inlinable
   public func get(from instance: Any) -> Any? {

--- a/stdlib/public/Reflection/Sources/Reflection/PartialType.swift
+++ b/stdlib/public/Reflection/Sources/Reflection/PartialType.swift
@@ -12,7 +12,7 @@
 import Swift
 import _Runtime
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct PartialType {
   @usableFromInline
@@ -24,7 +24,7 @@ public struct PartialType {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension PartialType {
   @inlinable
   public var isGeneric: Bool {
@@ -37,7 +37,7 @@ extension PartialType {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension PartialType {
   @inlinable
   public func create() -> Type? {
@@ -98,7 +98,7 @@ extension PartialType {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension PartialType {
   @inlinable
   public func create(with arg: Any.Type) -> Type? {
@@ -158,7 +158,7 @@ extension PartialType {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension PartialType: Equatable {
   @inlinable
   public static func ==(_ lhs: PartialType, _ rhs: PartialType) -> Bool {
@@ -166,7 +166,7 @@ extension PartialType: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension PartialType: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/Reflection/Type.swift
+++ b/stdlib/public/Reflection/Sources/Reflection/Type.swift
@@ -12,7 +12,7 @@
 import Swift
 import _Runtime
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct Type {
   @usableFromInline
@@ -34,7 +34,7 @@ public struct Type {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Type {
   @inlinable
   public var isClass: Bool {
@@ -62,7 +62,7 @@ extension Type {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Type {
   @inlinable
   public var swiftType: Any.Type {
@@ -70,7 +70,7 @@ extension Type {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Type {
   @inlinable
   public var genericArguments: GenericArguments {
@@ -113,7 +113,7 @@ extension Type {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Type: CustomStringConvertible {
   @inlinable
   public var description: String {
@@ -121,7 +121,7 @@ extension Type: CustomStringConvertible {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Type: Equatable {
   @inlinable
   public static func ==(_ lhs: Type, _ rhs: Type) -> Bool {
@@ -129,7 +129,7 @@ extension Type: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Type: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/AnonymousDescriptor.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/AnonymousDescriptor.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct AnonymousDescriptor: PublicLayout {
   public typealias Layout = ContextDescriptor.Layout
@@ -24,7 +24,7 @@ public struct AnonymousDescriptor: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension AnonymousDescriptor {
   @inlinable
   public var base: ContextDescriptor {
@@ -37,7 +37,7 @@ extension AnonymousDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension AnonymousDescriptor {
   @inlinable
   public var genericSignature: GenericSignature? {
@@ -53,7 +53,7 @@ extension AnonymousDescriptor {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension AnonymousDescriptor: Equatable {
   @inlinable
   public static func ==(
@@ -64,7 +64,7 @@ extension AnonymousDescriptor: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension AnonymousDescriptor: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/ClassDescriptor.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/ClassDescriptor.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct ClassDescriptor: PublicLayout {
   public typealias Layout = (
@@ -32,7 +32,7 @@ public struct ClassDescriptor: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ClassDescriptor {
   @inlinable
   public var base: TypeDescriptor {
@@ -45,7 +45,7 @@ extension ClassDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ClassDescriptor {
   @inlinable
   public var genericSignature: GenericSignature? {
@@ -57,7 +57,7 @@ extension ClassDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ClassDescriptor {
   @inlinable
   var genericArgumentOffset: Int {
@@ -100,7 +100,7 @@ extension ClassDescriptor {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ClassDescriptor: Equatable {
   @inlinable
   public static func ==(lhs: ClassDescriptor, rhs: ClassDescriptor) -> Bool {
@@ -108,7 +108,7 @@ extension ClassDescriptor: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ClassDescriptor: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/ContextDescriptor.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/ContextDescriptor.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct ContextDescriptor: PublicLayout {
   public typealias Layout = (
@@ -29,7 +29,7 @@ public struct ContextDescriptor: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ContextDescriptor {
   @inlinable
   public var flags: Flags {
@@ -94,7 +94,7 @@ extension ContextDescriptor {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ContextDescriptor: Equatable {
   @inlinable
   public static func ==(
@@ -105,7 +105,7 @@ extension ContextDescriptor: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ContextDescriptor: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/ContextDescriptorValues.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/ContextDescriptorValues.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension AnonymousDescriptor {
   @frozen
   public struct Flags {
@@ -36,7 +36,7 @@ extension AnonymousDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ConformanceDescriptor {
   @frozen
   public struct Flags {
@@ -129,7 +129,7 @@ extension ConformanceDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ContextDescriptor {
   @frozen
   public struct Kind {
@@ -191,7 +191,7 @@ extension ContextDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ContextDescriptor.Kind: Equatable {
   @inlinable
   public static func ==(
@@ -202,7 +202,7 @@ extension ContextDescriptor.Kind: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ContextDescriptor {
   @frozen
   public struct Flags {
@@ -284,7 +284,7 @@ extension ContextDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExtendedExistentialShape {
   @frozen
   public struct SpecialKind {
@@ -322,7 +322,7 @@ extension ExtendedExistentialShape {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExtendedExistentialShape.SpecialKind: Equatable {
   @inlinable
   public static func ==(
@@ -333,7 +333,7 @@ extension ExtendedExistentialShape.SpecialKind: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExtendedExistentialShape {
   @frozen
   public struct Flags {
@@ -410,7 +410,7 @@ extension ExtendedExistentialShape {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension FieldDescriptor.Element {
   @frozen
   public struct Flags {
@@ -441,7 +441,7 @@ extension FieldDescriptor.Element {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension GenericSignature {
   @frozen
   public struct ParameterDescriptor {
@@ -500,7 +500,7 @@ extension GenericSignature {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension GenericSignature.RequirementDescriptor {
   @frozen
   public struct Kind {
@@ -583,7 +583,7 @@ extension GenericSignature.RequirementDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ProtocolDescriptor {
   @frozen
   public struct DispatchStrategy {
@@ -609,7 +609,7 @@ extension ProtocolDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ProtocolDescriptor.DispatchStrategy: Equatable {
   @inlinable
   public static func ==(
@@ -620,7 +620,7 @@ extension ProtocolDescriptor.DispatchStrategy: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ProtocolDescriptor {
   @frozen
   public struct Flags {
@@ -695,7 +695,7 @@ extension ProtocolDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ProtocolRequirement {
   @frozen
   public struct Kind {
@@ -763,7 +763,7 @@ extension ProtocolRequirement {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ProtocolRequirement.Kind: Equatable {
   @inlinable
   public static func ==(
@@ -774,7 +774,7 @@ extension ProtocolRequirement.Kind: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ProtocolRequirement {
   @frozen
   public struct Flags {
@@ -856,7 +856,7 @@ public struct MetadataInitializationKind {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeDescriptor {
   @frozen
   public struct Flags {
@@ -990,7 +990,7 @@ extension TypeDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeReference {
   @frozen
   public struct Kind {
@@ -1028,7 +1028,7 @@ extension TypeReference {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeReference.Kind: Equatable {
   @inlinable
   public static func ==(

--- a/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/EnumDescriptor.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/EnumDescriptor.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct EnumDescriptor: PublicLayout {
   public typealias Layout = (
@@ -28,7 +28,7 @@ public struct EnumDescriptor: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension EnumDescriptor {
   @inlinable
   public var numberOfPayloadCases: Int {
@@ -47,7 +47,7 @@ extension EnumDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension EnumDescriptor {
   @inlinable
   public var type: TypeDescriptor {
@@ -68,7 +68,7 @@ extension EnumDescriptor {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension EnumDescriptor: Equatable {
   @inlinable
   public static func ==(lhs: EnumDescriptor, rhs: EnumDescriptor) -> Bool {
@@ -76,7 +76,7 @@ extension EnumDescriptor: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension EnumDescriptor: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/ExtendedExistentialShape.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/ExtendedExistentialShape.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct ExtendedExistentialShape: PublicLayout {
   public typealias Layout = (
@@ -28,7 +28,7 @@ public struct ExtendedExistentialShape: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExtendedExistentialShape {
   @inlinable
   public var flags: Flags {
@@ -40,7 +40,7 @@ extension ExtendedExistentialShape {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExtendedExistentialShape: Equatable {
   @inlinable
   public static func ==(
@@ -51,7 +51,7 @@ extension ExtendedExistentialShape: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExtendedExistentialShape: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/ExtensionDescriptor.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/ExtensionDescriptor.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct ExtensionDescriptor: PublicLayout {
   public typealias Layout = (
@@ -27,7 +27,7 @@ public struct ExtensionDescriptor: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExtensionDescriptor {
   @inlinable
   public var extendedContext: MangledTypeReference {
@@ -35,7 +35,7 @@ extension ExtensionDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExtensionDescriptor {
   @inlinable
   public var genericSignature: GenericSignature? {
@@ -47,7 +47,7 @@ extension ExtensionDescriptor {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExtensionDescriptor: Equatable {
   public static func ==(
     lhs: ExtensionDescriptor,
@@ -57,7 +57,7 @@ extension ExtensionDescriptor: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExtensionDescriptor: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/FieldDescriptor.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/FieldDescriptor.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct FieldDescriptor: PublicLayout {
   public typealias Layout = (
@@ -30,7 +30,7 @@ public struct FieldDescriptor: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension FieldDescriptor {
   @frozen
   public struct Element: PublicLayout {
@@ -65,7 +65,7 @@ extension FieldDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension FieldDescriptor {
   @inlinable
   @inline(__always)
@@ -87,7 +87,7 @@ extension FieldDescriptor {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension FieldDescriptor: Equatable {
   @inlinable
   public static func ==(lhs: FieldDescriptor, rhs: FieldDescriptor) -> Bool {
@@ -95,7 +95,7 @@ extension FieldDescriptor: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension FieldDescriptor: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/GenericSignature.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/GenericSignature.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct GenericSignature {
   public let header: Header
@@ -30,7 +30,7 @@ public struct GenericSignature {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension GenericSignature {
   @frozen
   public struct Header {
@@ -56,7 +56,7 @@ extension GenericSignature {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension GenericSignature {
   @frozen
   public struct RequirementDescriptor: PublicLayout {
@@ -81,7 +81,7 @@ extension GenericSignature {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @inlinable
 func getGenericSignature(at address: UnsafeRawPointer) -> GenericSignature {
   var address = address

--- a/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/ModuleDescriptor.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/ModuleDescriptor.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct ModuleDescriptor: PublicLayout {
   public typealias Layout = (
@@ -27,7 +27,7 @@ public struct ModuleDescriptor: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ModuleDescriptor {
   @inlinable
   public var name: String {
@@ -39,7 +39,7 @@ extension ModuleDescriptor {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ModuleDescriptor: Equatable {
   @inlinable
   public static func ==(lhs: ModuleDescriptor, rhs: ModuleDescriptor) -> Bool {
@@ -47,7 +47,7 @@ extension ModuleDescriptor: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ModuleDescriptor: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/OpaqueDescriptor.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/OpaqueDescriptor.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct OpaqueDescriptor: PublicLayout {
   public typealias Layout = ContextDescriptor.Layout
@@ -24,7 +24,7 @@ public struct OpaqueDescriptor: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension OpaqueDescriptor {
   @inlinable
   public var numberOfUnderlyingTypes: Int {
@@ -36,7 +36,7 @@ extension OpaqueDescriptor {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension OpaqueDescriptor: Equatable {
   @inlinable
   public static func ==(lhs: OpaqueDescriptor, rhs: OpaqueDescriptor) -> Bool {
@@ -44,7 +44,7 @@ extension OpaqueDescriptor: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension OpaqueDescriptor: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/ProtocolDescriptor.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/ProtocolDescriptor.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct ProtocolDescriptor: PublicLayout {
   public typealias Layout = (
@@ -30,7 +30,7 @@ public struct ProtocolDescriptor: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ProtocolDescriptor {
   @inlinable
   public var name: String {
@@ -63,7 +63,7 @@ extension ProtocolDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct ProtocolRequirement: PublicLayout {
   public typealias Layout = (
@@ -83,7 +83,7 @@ public struct ProtocolRequirement: PublicLayout {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ProtocolDescriptor: Equatable {
   @inlinable
   public static func ==(
@@ -94,7 +94,7 @@ extension ProtocolDescriptor: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ProtocolDescriptor: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {
@@ -102,7 +102,7 @@ extension ProtocolDescriptor: Hashable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ProtocolRequirement: Equatable {
   @inlinable
   public static func ==(
@@ -113,7 +113,7 @@ extension ProtocolRequirement: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ProtocolRequirement: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/StructDescriptor.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/StructDescriptor.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct StructDescriptor: PublicLayout {
   public typealias Layout = (
@@ -28,7 +28,7 @@ public struct StructDescriptor: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension StructDescriptor {
   @inlinable
   public var base: TypeDescriptor {
@@ -46,7 +46,7 @@ extension StructDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension StructDescriptor {
   @inlinable
   public var genericSignature: GenericSignature? {
@@ -62,7 +62,7 @@ extension StructDescriptor {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension StructDescriptor: Equatable {
   @inlinable
   public static func ==(lhs: StructDescriptor, rhs: StructDescriptor) -> Bool {
@@ -70,7 +70,7 @@ extension StructDescriptor: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension StructDescriptor: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/TypeDescriptor.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/TypeDescriptor.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct TypeDescriptor: PublicLayout {
   public typealias Layout = (
@@ -29,7 +29,7 @@ public struct TypeDescriptor: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeDescriptor {
   @inlinable
   public var base: ContextDescriptor {
@@ -57,7 +57,7 @@ extension TypeDescriptor {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeDescriptor {
   @inlinable
   var sizeOfSelf: Int {
@@ -88,7 +88,7 @@ extension TypeDescriptor {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeDescriptor: Equatable {
   @inlinable
   public static func ==(_ lhs: TypeDescriptor, _ rhs: TypeDescriptor) -> Bool {
@@ -96,7 +96,7 @@ extension TypeDescriptor: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeDescriptor: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/TypeReference.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/ContextDescriptor/TypeReference.swift
@@ -9,7 +9,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct TypeReference: PublicLayout {
   public typealias Layout = Int32
@@ -22,7 +22,7 @@ public struct TypeReference: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeReference {
   @inlinable
   public func descriptor(_ kind: Kind) -> ContextDescriptor {

--- a/stdlib/public/Reflection/Sources/_Runtime/Metadata/ClassMetadata.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Metadata/ClassMetadata.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct ClassMetadata: PublicLayout {
 #if canImport(ObjectiveC)
@@ -54,7 +54,7 @@ public struct ClassMetadata: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ClassMetadata {
   @inlinable
   public var superclass: Metadata? {
@@ -75,7 +75,7 @@ extension ClassMetadata {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ClassMetadata: Equatable {
   @inlinable
   public static func ==(lhs: ClassMetadata, rhs: ClassMetadata) -> Bool {
@@ -83,7 +83,7 @@ extension ClassMetadata: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ClassMetadata: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/Metadata/EnumMetadata.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Metadata/EnumMetadata.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct EnumMetadata: PublicLayout {
   public typealias Layout = (
@@ -27,7 +27,7 @@ public struct EnumMetadata: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension EnumMetadata {
   @inlinable
   public var vwt: ValueWitnessTable {
@@ -45,7 +45,7 @@ extension EnumMetadata {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension EnumMetadata {
   @inlinable
   public var type: TypeMetadata {
@@ -57,7 +57,7 @@ extension EnumMetadata {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension EnumMetadata: Equatable {
   @inlinable
   public static func ==(_ lhs: EnumMetadata, _ rhs: EnumMetadata) -> Bool {
@@ -65,7 +65,7 @@ extension EnumMetadata: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension EnumMetadata: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/Metadata/EnumValueWitnessTable.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Metadata/EnumValueWitnessTable.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct EnumValueWitnessTable: PublicLayout {
   public typealias Layout = UnsafePointer<(
@@ -39,7 +39,7 @@ public struct EnumValueWitnessTable: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension EnumValueWitnessTable {
   @inlinable
   public func getEnumTag(_ value: UnsafeRawPointer) -> UInt32 {
@@ -64,7 +64,7 @@ extension EnumValueWitnessTable {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension EnumValueWitnessTable: Equatable {
   @inlinable
   public static func ==(
@@ -75,7 +75,7 @@ extension EnumValueWitnessTable: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension EnumValueWitnessTable: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/Metadata/ExistentialMetadata.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Metadata/ExistentialMetadata.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct ExistentialMetadata: PrivateLayout {
   typealias Layout = (
@@ -28,7 +28,7 @@ public struct ExistentialMetadata: PrivateLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExistentialMetadata {
   public var protocols: BufferView<ProtocolDescriptor> {
     var start = trailing
@@ -48,7 +48,7 @@ extension ExistentialMetadata {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExistentialMetadata: Equatable {
   public static func ==(
     lhs: ExistentialMetadata,
@@ -58,7 +58,7 @@ extension ExistentialMetadata: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExistentialMetadata: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(ptr)

--- a/stdlib/public/Reflection/Sources/_Runtime/Metadata/ExtendedExistentialMetadata.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Metadata/ExtendedExistentialMetadata.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct ExtendedExistentialMetadata: PrivateLayout {
   typealias Layout = (
@@ -27,7 +27,7 @@ public struct ExtendedExistentialMetadata: PrivateLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExtendedExistentialMetadata {
   public var shape: ExtendedExistentialShape {
     PtrAuth.signNonUniqueExtendedExistentialShape(layout.shape)
@@ -38,7 +38,7 @@ extension ExtendedExistentialMetadata {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExtendedExistentialMetadata: Equatable {
   public static func ==(
     lhs: ExtendedExistentialMetadata,
@@ -48,7 +48,7 @@ extension ExtendedExistentialMetadata: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExtendedExistentialMetadata: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(ptr)

--- a/stdlib/public/Reflection/Sources/_Runtime/Metadata/ForeignClassMetadata.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Metadata/ForeignClassMetadata.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct ForeignClassMetadata: PublicLayout {
   public typealias Layout = (
@@ -28,7 +28,7 @@ public struct ForeignClassMetadata: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ForeignClassMetadata {
   @inlinable
   public var descriptor: ClassDescriptor {
@@ -45,7 +45,7 @@ extension ForeignClassMetadata {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ForeignClassMetadata: Equatable {
   @inlinable
   public static func ==(
@@ -56,7 +56,7 @@ extension ForeignClassMetadata: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ForeignClassMetadata: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/Metadata/ForeignReferenceTypeMetadata.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Metadata/ForeignReferenceTypeMetadata.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct ForeignReferenceTypeMetadata: PublicLayout {
   public typealias Layout = (
@@ -27,7 +27,7 @@ public struct ForeignReferenceTypeMetadata: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ForeignReferenceTypeMetadata {
   @inlinable
   public var descriptor: ClassDescriptor {
@@ -39,7 +39,7 @@ extension ForeignReferenceTypeMetadata {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ForeignReferenceTypeMetadata: Equatable {
   @inlinable
   public static func ==(
@@ -50,7 +50,7 @@ extension ForeignReferenceTypeMetadata: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ForeignReferenceTypeMetadata: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/Metadata/FunctionMetadata.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Metadata/FunctionMetadata.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct FunctionMetadata: PrivateLayout {
   typealias Layout = (
@@ -28,7 +28,7 @@ public struct FunctionMetadata: PrivateLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension FunctionMetadata {
   public var convention: Convention {
     layout.flags.convention
@@ -63,7 +63,7 @@ extension FunctionMetadata {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension FunctionMetadata {
   public var differentiableKind: DifferentiableKind {
     guard isDifferential else {
@@ -102,14 +102,14 @@ extension FunctionMetadata {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension FunctionMetadata: Equatable {
   public static func ==(lhs: FunctionMetadata, rhs: FunctionMetadata) -> Bool {
     lhs.ptr == rhs.ptr
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension FunctionMetadata: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(ptr)

--- a/stdlib/public/Reflection/Sources/_Runtime/Metadata/Metadata.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Metadata/Metadata.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct Metadata: PublicLayout {
   public typealias Layout = Int
@@ -29,7 +29,7 @@ public struct Metadata: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Metadata {
   @inlinable
   public var vwt: ValueWitnessTable {
@@ -42,7 +42,7 @@ extension Metadata {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Metadata {
   @inlinable
   public var `class`: ClassMetadata {
@@ -89,7 +89,7 @@ extension Metadata {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Metadata: Equatable {
   @inlinable
   public static func ==(_ lhs: Metadata, _ rhs: Metadata) -> Bool {
@@ -97,7 +97,7 @@ extension Metadata: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Metadata: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {
@@ -105,7 +105,7 @@ extension Metadata: Hashable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Metadata: CustomStringConvertible {
   @inlinable
   public var description: String {

--- a/stdlib/public/Reflection/Sources/_Runtime/Metadata/MetadataAccessFunction.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Metadata/MetadataAccessFunction.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Metadata {
   @frozen
   public struct AccessFunction {

--- a/stdlib/public/Reflection/Sources/_Runtime/Metadata/MetadataValues.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Metadata/MetadataValues.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Metadata {
   @frozen
   public struct Kind {
@@ -131,7 +131,7 @@ extension Metadata {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Metadata.Kind: Equatable {
   @inlinable
   public static func ==(_ lhs: Metadata.Kind, _ rhs: Metadata.Kind) -> Bool {
@@ -150,7 +150,7 @@ extension Metadata.Kind: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension Metadata {
   @frozen
   public struct Request {
@@ -225,7 +225,7 @@ extension Metadata {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ExistentialMetadata {
   internal struct Flags {
     let value: UInt32
@@ -281,7 +281,7 @@ extension ExistentialMetadata {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension FunctionMetadata {
   @frozen
   public struct Convention {
@@ -309,7 +309,7 @@ extension FunctionMetadata {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension FunctionMetadata.Convention: Equatable {
   public static func ==(
     lhs: FunctionMetadata.Convention,
@@ -319,7 +319,7 @@ extension FunctionMetadata.Convention: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension FunctionMetadata {
   @frozen
   public struct DifferentiableKind {
@@ -351,7 +351,7 @@ extension FunctionMetadata {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension FunctionMetadata.DifferentiableKind: Equatable {
   public static func ==(
     lhs: FunctionMetadata.DifferentiableKind,
@@ -361,7 +361,7 @@ extension FunctionMetadata.DifferentiableKind: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension FunctionMetadata {
   struct Flags {
     let value: Int
@@ -456,7 +456,7 @@ extension FunctionMetadata {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension FunctionMetadata {
   struct ParameterFlags {
     let value: UInt32
@@ -501,7 +501,7 @@ enum ValueOwnership: UInt8 {
   case owned = 3
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ValueWitnessTable {
   @frozen
   public struct Flags {

--- a/stdlib/public/Reflection/Sources/_Runtime/Metadata/MetatypeMetadata.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Metadata/MetatypeMetadata.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct MetatypeMetadata: PrivateLayout {
   typealias Layout = (
@@ -27,7 +27,7 @@ public struct MetatypeMetadata: PrivateLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension MetatypeMetadata {
   public var instanceMetadata: Metadata {
     layout.instanceMetadata
@@ -38,14 +38,14 @@ extension MetatypeMetadata {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension MetatypeMetadata: Equatable {
   public static func ==(lhs: MetatypeMetadata, rhs: MetatypeMetadata) -> Bool {
     lhs.ptr == rhs.ptr
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension MetatypeMetadata: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(ptr)

--- a/stdlib/public/Reflection/Sources/_Runtime/Metadata/StructMetadata.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Metadata/StructMetadata.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct StructMetadata: PublicLayout {
   public typealias Layout = (
@@ -27,7 +27,7 @@ public struct StructMetadata: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension StructMetadata {
   @inlinable
   public var descriptor: StructDescriptor {
@@ -43,7 +43,7 @@ extension StructMetadata {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension StructMetadata {
   @inlinable
   public var vwt: ValueWitnessTable {
@@ -51,7 +51,7 @@ extension StructMetadata {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension StructMetadata {
   @inlinable
   public var type: TypeMetadata {
@@ -63,7 +63,7 @@ extension StructMetadata {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension StructMetadata: Equatable {
   @inlinable
   public static func ==(_ lhs: StructMetadata, _ rhs: StructMetadata) -> Bool {
@@ -71,7 +71,7 @@ extension StructMetadata: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension StructMetadata: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/Metadata/TupleMetadata.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Metadata/TupleMetadata.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct TupleMetadata: PrivateLayout {
   typealias Layout = (
@@ -28,7 +28,7 @@ public struct TupleMetadata: PrivateLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TupleMetadata {
   @frozen
   public struct Elements {
@@ -42,7 +42,7 @@ extension TupleMetadata {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TupleMetadata.Elements {
   @frozen
   public struct Element: PrivateLayout {
@@ -75,7 +75,7 @@ extension TupleMetadata.Elements {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TupleMetadata.Elements.Element {
   public var label: String {
     // Go back up n times the size of our layout to get the beginning element
@@ -118,7 +118,7 @@ extension TupleMetadata.Elements.Element {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TupleMetadata.Elements: RandomAccessCollection {
   @inlinable
   public var startIndex: Int {
@@ -145,7 +145,7 @@ extension TupleMetadata.Elements: RandomAccessCollection {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TupleMetadata {
   @inlinable
   public var elements: Elements {
@@ -157,14 +157,14 @@ extension TupleMetadata {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TupleMetadata: Equatable {
   public static func ==(lhs: TupleMetadata, rhs: TupleMetadata) -> Bool {
     lhs.ptr == rhs.ptr
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TupleMetadata: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(ptr)

--- a/stdlib/public/Reflection/Sources/_Runtime/Metadata/TypeMetadata.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Metadata/TypeMetadata.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct TypeMetadata: PublicLayout {
   public typealias Layout = Int
@@ -24,7 +24,7 @@ public struct TypeMetadata: PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeMetadata {
   @inlinable
   public var descriptor: TypeDescriptor {
@@ -62,7 +62,7 @@ extension TypeMetadata {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeMetadata {
   @inlinable
   public var metadata: Metadata {
@@ -85,7 +85,7 @@ extension TypeMetadata {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeMetadata {
   @inlinable
   public func resolve(_ typeRef: MangledTypeReference) -> Any.Type? {
@@ -107,7 +107,7 @@ extension TypeMetadata {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeMetadata: Equatable {
   @inlinable
   public static func ==(lhs: TypeMetadata, rhs: TypeMetadata) -> Bool {
@@ -115,7 +115,7 @@ extension TypeMetadata: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeMetadata: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/Metadata/ValueWitnessTable.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Metadata/ValueWitnessTable.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct ValueWitnessTable: PublicLayout {
   public typealias Layout = UnsafePointer<(
@@ -41,7 +41,7 @@ public struct ValueWitnessTable: PublicLayout {
 // Function Typealiases
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ValueWitnessTable {
   public typealias InitializeBufferWithCopyOfBuffer = @convention(c) (
     // Destination
@@ -120,7 +120,7 @@ extension ValueWitnessTable {
 // Function API
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ValueWitnessTable {
   @inlinable
   @discardableResult
@@ -259,7 +259,7 @@ extension ValueWitnessTable {
 // Property API
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ValueWitnessTable {
   @inlinable
   public var size: Int {
@@ -286,7 +286,7 @@ extension ValueWitnessTable {
 // Stdlib conformances
 //===----------------------------------------------------------------------===//
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ValueWitnessTable: Equatable {
   @inlinable
   public static func ==(
@@ -297,7 +297,7 @@ extension ValueWitnessTable: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension ValueWitnessTable: Hashable {
   @inlinable
   public func hash(into hasher: inout Hasher) {

--- a/stdlib/public/Reflection/Sources/_Runtime/Utils/BufferView.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Utils/BufferView.swift
@@ -12,7 +12,7 @@
 import Swift
 
 // TODO: Replace this with Guillaume's actual BufferView
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct BufferView<Element/* : BitwiseCopyable */> {
   public let start: UnsafeRawPointer
@@ -30,7 +30,7 @@ public struct BufferView<Element/* : BitwiseCopyable */> {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension BufferView: RandomAccessCollection {
   @inlinable
   public var startIndex: Int {
@@ -61,7 +61,7 @@ extension BufferView: RandomAccessCollection {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct IndirectBufferView<Element: PublicLayout> {
   public let start: UnsafeRawPointer
@@ -74,7 +74,7 @@ public struct IndirectBufferView<Element: PublicLayout> {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension IndirectBufferView: RandomAccessCollection {
   @inlinable
   public var startIndex: Int {

--- a/stdlib/public/Reflection/Sources/_Runtime/Utils/Layouts.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Utils/Layouts.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 public protocol PublicLayout {
   associatedtype Layout
   
@@ -20,7 +20,7 @@ public protocol PublicLayout {
   init(_ ptr: UnsafeRawPointer)
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension PublicLayout {
   @inline(__always)
   @inlinable
@@ -62,7 +62,7 @@ extension PublicLayout {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 protocol PrivateLayout {
   associatedtype Layout
   
@@ -71,7 +71,7 @@ protocol PrivateLayout {
   init(_ ptr: UnsafeRawPointer)
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension PrivateLayout {
   var layout: Layout {
     ptr.loadUnaligned(as: Layout.self)

--- a/stdlib/public/Reflection/Sources/_Runtime/Utils/MangledTypeReference.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Utils/MangledTypeReference.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct MangledTypeReference {
   @usableFromInline
@@ -23,7 +23,7 @@ public struct MangledTypeReference {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension MangledTypeReference {
   @inlinable
   var standardSubstitution: Any.Type? {

--- a/stdlib/public/Reflection/Sources/_Runtime/Utils/PointerStuff.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Utils/PointerStuff.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @inlinable
 public func unsafeBitCast<T, U>(_ x: T, to type: U.Type = U.self) -> U {
   Swift.unsafeBitCast(x, to: type)

--- a/stdlib/public/Reflection/Sources/_Runtime/Utils/PtrAuth.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Utils/PtrAuth.swift
@@ -142,7 +142,7 @@ extension PtrAuth {
 
 extension PtrAuth {
 #if _ptrauth(_arm64e)
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   static func signDescriptor<T: PublicLayout>(_ descriptor: T) -> T {
     let signedBitPattern = UInt64(Builtin.int_ptrauth_sign(
@@ -154,7 +154,7 @@ extension PtrAuth {
     return T(signedBitPattern.rawPointer)
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   static func signNonUniqueExtendedExistentialShape(
     _ shape: ExtendedExistentialShape
@@ -168,7 +168,7 @@ extension PtrAuth {
     return ExtendedExistentialShape(signedBitPattern.rawPointer)
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   static func signObjcISA(_ isa: Metadata) -> Metadata {
     let signedBitPattern = UInt64(Builtin.int_ptrauth_sign(
@@ -180,7 +180,7 @@ extension PtrAuth {
     return Metadata(signedBitPattern.rawPointer)
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   static func signSuperclass(_ superclass: Metadata) -> Metadata {
     let signedBitPattern = UInt64(Builtin.int_ptrauth_sign(
@@ -192,13 +192,13 @@ extension PtrAuth {
     return Metadata(signedBitPattern.rawPointer)
   }
 #else
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   static func signDescriptor<T: PublicLayout>(_ descriptor: T) -> T {
     descriptor
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   static func signNonUniqueExtendedExistentialShape(
     _ shape: ExtendedExistentialShape
@@ -206,13 +206,13 @@ extension PtrAuth {
     shape
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   static func signObjcISA(_ isa: Metadata) -> Metadata {
     isa
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   static func signSuperclass(_ superclass: Metadata) -> Metadata {
     superclass
@@ -245,7 +245,7 @@ extension UnsafeRawPointer {
     return resigned.rawPointer
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   var signedVWTInitializeBufferWithCopyOfBuffer: ValueWitnessTable.InitializeBufferWithCopyOfBuffer {
     unsafeBitCast(signedVWTFunc(
@@ -256,7 +256,7 @@ extension UnsafeRawPointer {
     ))
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   var signedVWTDestroy: ValueWitnessTable.Destroy {
     unsafeBitCast(signedVWTFunc(
@@ -267,7 +267,7 @@ extension UnsafeRawPointer {
     ))
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   var signedVWTInitializeWithCopy: ValueWitnessTable.InitializeWithCopy {
     unsafeBitCast(signedVWTFunc(
@@ -278,7 +278,7 @@ extension UnsafeRawPointer {
     ))
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   var signedVWTAssignWithCopy: ValueWitnessTable.AssignWithCopy {
     unsafeBitCast(signedVWTFunc(
@@ -289,7 +289,7 @@ extension UnsafeRawPointer {
     ))
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   var signedVWTInitializeWithTake: ValueWitnessTable.InitializeWithTake {
     unsafeBitCast(signedVWTFunc(
@@ -300,7 +300,7 @@ extension UnsafeRawPointer {
     ))
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   var signedVWTAssignWithTake: ValueWitnessTable.AssignWithTake {
     unsafeBitCast(signedVWTFunc(
@@ -311,7 +311,7 @@ extension UnsafeRawPointer {
     ))
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   var signedVWTGetEnumTagSinglePayload: ValueWitnessTable.GetEnumTagSinglePayload {
     unsafeBitCast(signedVWTFunc(
@@ -322,7 +322,7 @@ extension UnsafeRawPointer {
     ))
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   var signedVWTStoreEnumTagSinglePayload: ValueWitnessTable.StoreEnumTagSinglePayload {
     unsafeBitCast(signedVWTFunc(
@@ -333,49 +333,49 @@ extension UnsafeRawPointer {
     ))
   }
 #else
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   var signedVWTInitializeBufferWithCopyOfBuffer: ValueWitnessTable.InitializeBufferWithCopyOfBuffer {
     unsafeBitCast(loadUnaligned(as: UnsafeRawPointer.self))
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   var signedVWTDestroy: ValueWitnessTable.Destroy {
     unsafeBitCast(loadUnaligned(as: UnsafeRawPointer.self))
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   var signedVWTInitializeWithCopy: ValueWitnessTable.InitializeWithCopy {
     unsafeBitCast(loadUnaligned(as: UnsafeRawPointer.self))
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   var signedVWTAssignWithCopy: ValueWitnessTable.AssignWithCopy {
     unsafeBitCast(loadUnaligned(as: UnsafeRawPointer.self))
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   var signedVWTInitializeWithTake: ValueWitnessTable.InitializeWithTake {
     unsafeBitCast(loadUnaligned(as: UnsafeRawPointer.self))
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   var signedVWTAssignWithTake: ValueWitnessTable.AssignWithTake {
     unsafeBitCast(loadUnaligned(as: UnsafeRawPointer.self))
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   var signedVWTGetEnumTagSinglePayload: ValueWitnessTable.GetEnumTagSinglePayload {
     unsafeBitCast(loadUnaligned(as: UnsafeRawPointer.self))
   }
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   var signedVWTStoreEnumTagSinglePayload: ValueWitnessTable.StoreEnumTagSinglePayload {
     unsafeBitCast(loadUnaligned(as: UnsafeRawPointer.self))

--- a/stdlib/public/Reflection/Sources/_Runtime/Utils/RelativeDirectPointer.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Utils/RelativeDirectPointer.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct RelativeDirectPointer<Pointee>: RelativePointer {
   public let offset: Int32
@@ -28,7 +28,7 @@ public struct RelativeDirectPointer<Pointee>: RelativePointer {
 }
 
 extension UnsafeRawPointer {
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   public func relativeDirectAddress<T>(as type: T.Type) -> UnsafeRawPointer {
     let relativePointer = RelativeDirectPointer<T>(

--- a/stdlib/public/Reflection/Sources/_Runtime/Utils/RelativeDirectPointerIntPair.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Utils/RelativeDirectPointerIntPair.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct RelativeDirectPointerIntPair<
   Pointee,

--- a/stdlib/public/Reflection/Sources/_Runtime/Utils/RelativeIndirectPointer.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Utils/RelativeIndirectPointer.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct RelativeIndirectPointer<Pointee>: RelativePointer {
   public let offset: Int32
@@ -28,7 +28,7 @@ public struct RelativeIndirectPointer<Pointee>: RelativePointer {
 }
 
 extension UnsafeRawPointer {
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   @inlinable
   public func relativeIndirectAddress<T>(as type: T.Type) -> UnsafeRawPointer {
     let relativePointer = RelativeIndirectPointer<T>(

--- a/stdlib/public/Reflection/Sources/_Runtime/Utils/RelativeIndirectablePointer.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Utils/RelativeIndirectablePointer.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct RelativeIndirectablePointer<Pointee>: RelativePointer {
   public let offset: Int32

--- a/stdlib/public/Reflection/Sources/_Runtime/Utils/RelativeIndirectablePointerIntPair.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Utils/RelativeIndirectablePointerIntPair.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 @frozen
 public struct RelativeIndirectablePointerIntPair<
   Pointee,

--- a/stdlib/public/Reflection/Sources/_Runtime/Utils/RelativePointer.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Utils/RelativePointer.swift
@@ -11,7 +11,7 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 public protocol RelativePointer {
   associatedtype Pointee
   
@@ -21,7 +21,7 @@ public protocol RelativePointer {
   func pointee(from ptr: UnsafeRawPointer) -> Pointee?
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension RelativePointer {
   @inlinable
   public var isNull: Bool {

--- a/stdlib/public/Reflection/Sources/_Runtime/Utils/TypeCache.swift
+++ b/stdlib/public/Reflection/Sources/_Runtime/Utils/TypeCache.swift
@@ -11,17 +11,17 @@
 
 import Swift
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 struct TypeCache {
   var cache: Lock<[Key: Any.Type?]>
   
-  @available(SwiftStdlib 9999, *)
+  @available(SwiftStdlib 5.9, *)
   init() {
     cache = Lock.create(with: [:])
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeCache {
   struct Key {
     let typeRef: MangledTypeReference
@@ -34,7 +34,7 @@ extension TypeCache {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeCache.Key: Equatable {
   static func ==(_ lhs: TypeCache.Key, _ rhs: TypeCache.Key) -> Bool {
     var lhsEnd = lhs.typeRef.ptr
@@ -106,7 +106,7 @@ extension TypeCache.Key: Equatable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeCache.Key: Hashable {
   func hash(into hasher: inout Hasher) {
     var isGeneric = false
@@ -160,7 +160,7 @@ extension TypeCache.Key: Hashable {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 extension TypeCache {
   func getOrInsert(
     _ typeRef: MangledTypeReference,
@@ -187,7 +187,7 @@ extension TypeCache {
   }
 }
 
-@available(SwiftStdlib 9999, *)
+@available(SwiftStdlib 5.9, *)
 var typeCache: TypeCache = {
   var result = TypeCache()
   


### PR DESCRIPTION
Now that `SwiftStdlib 5.9` is an availability macro, use that for these reflection APIs.