### PR TITLE
[Serialization] Don't serialize macro custom attributes.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1702,6 +1702,10 @@ public:
   bool isArgUnsafe() const;
   void setArgIsUnsafe(bool unsafe) { isArgUnsafeBit = unsafe; }
 
+  /// Whether this custom attribute is a macro attached to the given
+  /// declaration.
+  bool isAttachedMacro(const Decl *decl) const;
+
   Expr *getSemanticInit() const { return semanticInit; }
   void setSemanticInit(Expr *expr) { semanticInit = expr; }
 

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -23,6 +23,7 @@
 #include "swift/AST/IndexSubset.h"
 #include "swift/AST/LazyResolver.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/AST/TypeRepr.h"
@@ -2334,6 +2335,21 @@ bool CustomAttr::isArgUnsafe() const {
   }
 
   return isArgUnsafeBit;
+}
+
+bool CustomAttr::isAttachedMacro(const Decl *decl) const {
+  auto &ctx = decl->getASTContext();
+  auto *dc = decl->getInnermostDeclContext();
+
+  auto attrDecl = evaluateOrDefault(
+      ctx.evaluator,
+      CustomAttrDeclRequest{const_cast<CustomAttr *>(this), dc},
+      nullptr);
+
+  if (!attrDecl)
+    return false;
+
+  return attrDecl.dyn_cast<MacroDecl *>();
 }
 
 DeclarationAttr::DeclarationAttr(SourceLoc atLoc, SourceRange range,

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2855,6 +2855,11 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     case DAK_Custom: {
       auto abbrCode = S.DeclTypeAbbrCodes[CustomDeclAttrLayout::Code];
       auto theAttr = cast<CustomAttr>(DA);
+
+      // Macro attributes are not serialized.
+      if (theAttr->isAttachedMacro(D))
+        return;
+
       auto typeID = S.addTypeRef(theAttr->getType());
       if (!typeID && !S.allowCompilerErrors()) {
         llvm::PrettyStackTraceString message("CustomAttr has no type");

--- a/test/Serialization/Inputs/def_macro_plugin.swift
+++ b/test/Serialization/Inputs/def_macro_plugin.swift
@@ -1,0 +1,38 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import _SwiftSyntaxMacros
+
+public struct StringifyMacro: ExpressionMacro {
+  public static func expansion(
+    of macro: MacroExpansionExprSyntax, in context: inout MacroExpansionContext
+  ) -> ExprSyntax {
+    guard let argument = macro.argumentList.first?.expression else {
+      // FIXME: Create a diagnostic for the missing argument?
+      return ExprSyntax(macro)
+    }
+
+    return "(\(argument), \(StringLiteralExprSyntax(content: argument.description)))"
+  }
+}
+
+public struct MyWrapperMacro: AccessorDeclarationMacro {
+    public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: DeclSyntax,
+    in context: inout MacroExpansionContext
+  ) throws -> [AccessorDeclSyntax] {
+    return []
+  }
+}
+
+public struct WrapAllProperties: MemberAttributeMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo parent: DeclSyntax,
+    annotating member: DeclSyntax,
+    in context: inout MacroExpansionContext
+  ) throws -> [AttributeSyntax] {
+    return []
+  }
+}
+

--- a/test/Serialization/Inputs/def_macros.swift
+++ b/test/Serialization/Inputs/def_macros.swift
@@ -1,5 +1,13 @@
-@expression public macro publicStringify<T>(_ value: T) -> (T, String) = SomeModule.StringifyMacro
+@expression public macro publicStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 
-@expression macro internalStringify<T>(_ value: T) -> (T, String) = SomeModule.StringifyMacro
+@expression macro internalStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 
-@attached(accessor) public macro myWrapper: Void = SomeModule.MyWrapperMacro
+@attached(accessor) public macro myWrapper: Void = #externalMacro(module: "MacroDefinition", type: "MyWrapperMacro")
+
+@attached(memberAttributes) public macro wrapAllProperties() = #externalMacro(module: "MacroDefinition", type: "WrapAllProperties")
+
+// Make sure that macro custom attributes are not serialized.
+@wrapAllProperties
+public struct S {
+  public var value: Int
+}

--- a/test/Serialization/macros.swift
+++ b/test/Serialization/macros.swift
@@ -2,15 +2,15 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t-scratch)
-// RUN: %target-swift-frontend -emit-module -o %t/def_macros.swiftmodule %S/Inputs/def_macros.swift -module-name def_macros -enable-experimental-feature Macros
-// RUN: %target-swift-frontend -typecheck -I%t -verify %s -verify-ignore-unknown  -enable-experimental-feature Macros
+// RUN: %target-build-swift -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/def_macro_plugin.swift -g -no-toolchain-stdlib-rpath
+// RUN: %target-swift-frontend -emit-module -o %t/def_macros.swiftmodule %S/Inputs/def_macros.swift -module-name def_macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir
+// RUN: %target-swift-frontend -typecheck -I%t -verify %s -verify-ignore-unknown  -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir
 // REQUIRES: OS=macosx
 
 import def_macros
 
 func test(a: Int, b: Int) {
   _ = #publicStringify(a + b)
-  // expected-error@-1{{external macro implementation type 'SomeModule.StringifyMacro' could not be found for macro 'publicStringify'; the type must be public and provided via '-load-plugin-library'}}
 
   _ = #internalStringify(a + b)
   // expected-error@-1{{no macro named 'internalStringify'}}
@@ -18,5 +18,4 @@ func test(a: Int, b: Int) {
 
 struct TestStruct {
   @myWrapper var x: Int
-  // expected-error@-1{{external macro implementation type 'SomeModule.MyWrapperMacro' could not be found for macro 'myWrapper'}}
 }


### PR DESCRIPTION
Once a macro has expanded, we don't need the custom attribute anymore; don't preserve macro custom during serialization. Previously, attempting to serialize a macro custom attribute would crash, because the custom attribute does not have a type.