### PR TITLE
[Macros] Fix a use-after-free with `getSemanticAttrs()`.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -2613,55 +2613,6 @@ public:
   SourceLoc getStartLoc(bool forModifiers = false) const;
 };
 
-/// Semantic attributes that are applied to a declaration.
-///
-/// This attribute list can include attributes that are not written in
-/// source on a declaration, such as attributes that are applied during
-/// macro expansion or inferred from the declaration context.
-class SemanticDeclAttributes {
-  llvm::SmallVector<DeclAttribute *, 4> attrList;
-
-public:
-  SemanticDeclAttributes() {}
-
-  /// Add a constructed DeclAttribute to this list.
-  void add(DeclAttribute *attr) {
-    attrList.push_back(attr);
-  }
-
-  using SemanticAttrList = llvm::SmallVectorImpl<DeclAttribute *>;
-
-  template <typename AttrType, bool AllowInvalid>
-  using AttributeKindRange =
-      OptionalTransformRange<iterator_range<SemanticAttrList::const_iterator>,
-                             ToAttributeKind<AttrType, AllowInvalid>,
-                             SemanticAttrList::const_iterator>;
-
-  template <typename AttrType, bool AllowInvalid = false>
-  AttributeKindRange<AttrType, AllowInvalid> getAttributes() const {
-    return AttributeKindRange<AttrType, AllowInvalid>(
-        make_range(attrList.begin(), attrList.end()),
-                   ToAttributeKind<AttrType, AllowInvalid>());
-  }
-
-  /// Retrieve the first attribute of the given attribute class.
-  template <typename AttrType>
-  const AttrType *getAttribute(bool allowInvalid = false) const {
-    for (auto attr : attrList)
-      if (auto *specificAttr = dyn_cast<AttrType>(attr))
-        if (specificAttr->isValid() || allowInvalid)
-          return specificAttr;
-
-    return nullptr;
-  }
-
-  /// Determine whether there is an attribute with the given attribute class.
-  template <typename AttrType>
-  bool hasAttribute(bool allowInvalid = false) const {
-    return getAttribute<AttrType>(allowInvalid) != nullptr;
-  }
-};
-
 /// TypeAttributes - These are attributes that may be applied to types.
 class TypeAttributes {
   // Get a SourceLoc for every possible attribute that can be parsed in source.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -850,11 +850,10 @@ public:
     return Attrs;
   }
 
-  /// Returns the semantic attributes attached to this declaration.
-  ///
-  /// \c getSemanticAttrs is intended to be a requestified replacement
-  /// for \c getAttrs
-  SemanticDeclAttributes getSemanticAttrs() const;
+  /// Returns the semantic attributes attached to this declaration,
+  /// including attributes that are generated as the result of member
+  /// attribute macro expansion.
+  DeclAttributes getSemanticAttrs() const;
 
   /// Returns the innermost enclosing decl with an availability annotation.
   const Decl *getInnermostDeclWithAvailability() const;

--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -500,6 +500,17 @@ public:
   /// the \c SourceFileKind is \c MacroExpansion.
   ASTNode getMacroExpansion() const;
 
+  /// For source files created to hold the source code created by expanding
+  /// an attached macro, this is the custom attribute that describes the macro
+  /// expansion.
+  ///
+  /// The source location of this attribute is the place in the source that
+  /// triggered the creation of the macro expansion whose resulting source
+  /// code is in this source file. This will only produce a non-null value when
+  /// the \c SourceFileKind is \c MacroExpansion , and the macro is an attached
+  /// macro.
+  CustomAttr *getAttachedMacroAttribute() const;
+
   /// When this source file is enclosed within another source file, for example
   /// because it describes a macro expansion, return the source file it was
   /// enclosed in.

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -742,26 +742,6 @@ public:
   bool isCached() const { return true; }
 };
 
-/// Request the semantic attributes attached to the given declaration.
-class AttachedSemanticAttrsRequest :
-    public SimpleRequest<AttachedSemanticAttrsRequest,
-                         SemanticDeclAttributes(Decl *),
-                         RequestFlags::Cached> {
-public:
-  using SimpleRequest::SimpleRequest;
-
-private:
-  friend SimpleRequest;
-
-  // Evaluation.
-  SemanticDeclAttributes
-  evaluate(Evaluator &evaluator, Decl *decl) const;
-
-public:
-  // Caching
-  bool isCached() const { return true; }
-};
-
 /// Request the raw (possibly unbound generic) type of the property wrapper
 /// that is attached to the given variable.
 class AttachedPropertyWrapperTypeRequest :
@@ -3835,6 +3815,24 @@ private:
 
   ArrayRef<Decl *> evaluate(Evaluator &evaluator,
                             MacroExpansionDecl *med) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
+/// Expand all member attribute macros attached to the given
+/// declaration.
+class ExpandMemberAttributeMacros
+    : public SimpleRequest<ExpandMemberAttributeMacros,
+                           bool(Decl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  bool evaluate(Evaluator &evaluator, Decl *decl) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -29,9 +29,6 @@ SWIFT_REQUEST(TypeChecker, AttachedPropertyWrapperTypeRequest,
 SWIFT_REQUEST(TypeChecker, AttachedPropertyWrappersRequest,
               llvm::TinyPtrVector<CustomAttr *>(VarDecl *), Cached,
               NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, AttachedSemanticAttrsRequest,
-              SemanticDeclAttributes(Decl *), Cached,
-              NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CallerSideDefaultArgExprRequest,
               Expr *(DefaultArgumentExpr *), SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CheckInconsistentImplementationOnlyImportsRequest,
@@ -454,6 +451,9 @@ SWIFT_REQUEST(TypeChecker, ExternalMacroDefinitionRequest,
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ExpandMacroExpansionDeclRequest,
               ArrayRef<Decl *>(MacroExpansionDecl *),
+              Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ExpandMemberAttributeMacros,
+              bool(Decl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, SynthesizeRuntimeMetadataAttrGenerator,
               Expr *(CustomAttr *, ValueDecl *),

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -365,11 +365,13 @@ StringRef Decl::getDescriptiveKindName(DescriptiveDeclKind K) {
   llvm_unreachable("bad DescriptiveDeclKind");
 }
 
-SemanticDeclAttributes Decl::getSemanticAttrs() const {
+DeclAttributes Decl::getSemanticAttrs() const {
   auto mutableThis = const_cast<Decl *>(this);
-  return evaluateOrDefault(getASTContext().evaluator,
-                           AttachedSemanticAttrsRequest{mutableThis},
-                           SemanticDeclAttributes());
+  evaluateOrDefault(getASTContext().evaluator,
+                    ExpandMemberAttributeMacros{mutableThis},
+                    false);
+
+  return getAttrs();
 }
 
 const Decl *Decl::getInnermostDeclWithAvailability() const {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -887,6 +887,15 @@ ASTNode SourceFile::getMacroExpansion() const {
   return ASTNode::getFromOpaqueValue(genInfo.astNode);
 }
 
+CustomAttr *SourceFile::getAttachedMacroAttribute() const {
+  if (Kind != SourceFileKind::MacroExpansion)
+    return nullptr;
+
+  auto genInfo =
+      *getASTContext().SourceMgr.getGeneratedSourceInfo(*getBufferID());
+  return genInfo.attachedMacroCustomAttr;
+}
+
 SourceFile *SourceFile::getEnclosingSourceFile() const {
   auto macroExpansion = getMacroExpansion();
   if (!macroExpansion)

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -308,6 +308,41 @@ ExternalMacroDefinitionRequest::evaluate(
   return ExternalMacroDefinition{nullptr};
 }
 
+bool ExpandMemberAttributeMacros::evaluate(Evaluator &evaluator,
+                                           Decl *decl) const {
+  auto *parentDecl = decl->getDeclContext()->getAsDecl();
+  if (!parentDecl)
+    return false;
+
+  bool addedAttributes = false;
+  auto parentAttrs = parentDecl->getSemanticAttrs();
+  for (auto customAttrConst: parentAttrs.getAttributes<CustomAttr>()) {
+    auto customAttr = const_cast<CustomAttr *>(customAttrConst);
+    auto customAttrDecl = evaluateOrDefault(
+        evaluator,
+        CustomAttrDeclRequest{
+          customAttr,
+          parentDecl->getInnermostDeclContext()
+        },
+        nullptr);
+
+    if (!customAttrDecl)
+      continue;
+
+    auto macroDecl = customAttrDecl.dyn_cast<MacroDecl *>();
+    if (!macroDecl)
+      continue;
+
+    if (!macroDecl->getMacroRoles().contains(MacroRole::MemberAttribute))
+      continue;
+
+    addedAttributes |= expandAttributes(customAttr, macroDecl, decl);
+  }
+
+  return addedAttributes;
+}
+
+
 /// Determine whether the given source file is from an expansion of the given
 /// macro.
 static bool isFromExpansionOfMacro(SourceFile *sourceFile, MacroDecl *macro) {
@@ -856,8 +891,7 @@ void swift::expandAccessors(
 // FIXME: Almost entirely duplicated code from `expandAccessors`.
 // Factor this out into an `expandAttachedMacro` function, with
 // arguments for the PrettyStackTrace string, 'attachedTo' decl, etc.
-void swift::expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member,
-                             SemanticDeclAttributes &result) {
+bool swift::expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member) {
   auto *dc = member->getInnermostDeclContext();
   ASTContext &ctx = dc->getASTContext();
   SourceManager &sourceMgr = ctx.SourceMgr;
@@ -867,21 +901,21 @@ void swift::expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member,
   auto attrSourceFile =
     moduleDecl->getSourceFileContainingLocation(attr->AtLoc);
   if (!attrSourceFile)
-    return;
+    return false;
 
   auto declSourceFile =
       moduleDecl->getSourceFileContainingLocation(member->getStartLoc());
   if (!declSourceFile)
-    return;
+    return false;
 
   Decl *parentDecl = member->getDeclContext()->getAsDecl();
   if (!parentDecl)
-    return;
+    return false;
 
   auto parentDeclSourceFile =
     moduleDecl->getSourceFileContainingLocation(parentDecl->getLoc());
   if (!parentDeclSourceFile)
-    return;
+    return false;
 
   // Evaluate the macro.
   NullTerminatedStringRef evaluatedSource;
@@ -889,7 +923,7 @@ void swift::expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member,
   if (isFromExpansionOfMacro(attrSourceFile, macro) ||
       isFromExpansionOfMacro(declSourceFile, macro)) {
     member->diagnose(diag::macro_recursive, macro->getName());
-    return;
+    return false;
   }
 
   auto macroDef = macro->getDefinition();
@@ -897,13 +931,13 @@ void swift::expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member,
   case MacroDefinition::Kind::Undefined:
   case MacroDefinition::Kind::Invalid:
     // Already diagnosed as an error elsewhere.
-    return;
+    return false;
 
   case MacroDefinition::Kind::Builtin: {
     switch (macroDef.getBuiltinKind()) {
     case BuiltinMacroKind::ExternalMacro:
       // FIXME: Error here.
-      return;
+      return false;
     }
   }
 
@@ -923,13 +957,13 @@ void swift::expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member,
                         macro->getName()
       );
       macro->diagnose(diag::decl_declared_here, macro->getName());
-      return;
+      return false;
     }
 
     // Make sure macros are enabled before we expand.
     if (!ctx.LangOpts.hasFeature(Feature::Macros)) {
       member->diagnose(diag::macro_experimental);
-      return;
+      return false;
     }
 
 #if SWIFT_SWIFT_PARSER
@@ -937,15 +971,15 @@ void swift::expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member,
 
     auto astGenAttrSourceFile = attrSourceFile->exportedSourceFile;
     if (!astGenAttrSourceFile)
-      return;
+      return false;
 
     auto astGenDeclSourceFile = declSourceFile->exportedSourceFile;
     if (!astGenDeclSourceFile)
-      return;
+      return false;
 
     auto astGenParentDeclSourceFile = parentDeclSourceFile->exportedSourceFile;
     if (!astGenParentDeclSourceFile)
-      return;
+      return false;
 
     Decl *searchDecl = member;
     if (auto *var = dyn_cast<VarDecl>(member))
@@ -961,13 +995,13 @@ void swift::expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member,
         astGenParentDeclSourceFile, parentDecl->getStartLoc().getOpaquePointerValue(),
         &evaluatedSourceAddress, &evaluatedSourceLength);
     if (!evaluatedSourceAddress)
-      return;
+      return false;
     evaluatedSource = NullTerminatedStringRef(evaluatedSourceAddress,
                                               (size_t)evaluatedSourceLength);
     break;
 #else
     member->diagnose(diag::macro_unsupported);
-    return;
+    return false;
 #endif
   }
   }
@@ -1029,6 +1063,7 @@ void swift::expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member,
   PrettyStackTraceDecl debugStack(
       "type checking expanded declaration macro", member);
 
+  bool addedAttributes = false;
   auto topLevelDecls = macroSourceFile->getTopLevelDecls();
   for (auto decl : topLevelDecls) {
     // FIXME: We want to type check decl attributes applied to
@@ -1040,7 +1075,10 @@ void swift::expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member,
 
     // Add the new attributes to the semantic attribute list.
     for (auto *attr : decl->getAttrs()) {
-      result.add(attr);
+      addedAttributes = true;
+      member->getAttrs().add(attr);
     }
   }
+
+  return addedAttributes;
 }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -326,6 +326,17 @@ static bool isFromExpansionOfMacro(SourceFile *sourceFile, MacroDecl *macro) {
       // in it.
       if (expansionDecl->getMacro().getFullName() == macro->getName())
         return true;
+    } else if (auto *macroAttr = sourceFile->getAttachedMacroAttribute()) {
+      auto *decl = expansion.dyn_cast<Decl *>();
+      auto &ctx = decl->getASTContext();
+      auto attrDecl = evaluateOrDefault(ctx.evaluator,
+          CustomAttrDeclRequest{macroAttr, decl->getDeclContext()},
+          nullptr);
+      auto *macroDecl = attrDecl.dyn_cast<MacroDecl *>();
+      if (!macroDecl)
+        return false;
+
+      return macroDecl == macro;
     } else {
       llvm_unreachable("Unknown macro expansion node kind");
     }

--- a/lib/Sema/TypeCheckMacros.h
+++ b/lib/Sema/TypeCheckMacros.h
@@ -51,8 +51,7 @@ void expandAccessors(
 
 /// Expand the attributes for the given member declaration based
 /// on the custom attribute that references the given macro.
-void expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member,
-                      SemanticDeclAttributes &result);
+bool expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3441,7 +3441,7 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
   }
 
   // Check for an accessor macro.
-  for (auto customAttrConst : storage->getAttrs().getAttributes<CustomAttr>()) {
+  for (auto customAttrConst : storage->getSemanticAttrs().getAttributes<CustomAttr>()) {
     auto customAttr = const_cast<CustomAttr *>(customAttrConst);
     auto decl = evaluateOrDefault(
         evaluator,
@@ -3457,8 +3457,8 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
     if (!macro)
       continue;
 
-    // FIXME: Make sure it's an accessors macro. We're not currently parsing
-    // this information in the @declaration attribute.
+    if (!macro->getMacroRoles().contains(MacroRole::Accessor))
+      continue;
 
     // Expand the accessors.
     expandAccessors(storage, customAttr, macro);

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -273,3 +273,57 @@ public struct WrapAllProperties: MemberAttributeMacro {
     return [propertyWrapperAttr]
   }
 }
+
+public struct TypeWrapperMacro: MemberAttributeMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo decl: DeclSyntax,
+    annotating member: DeclSyntax,
+    in context: inout MacroExpansionContext
+  ) throws -> [AttributeSyntax] {
+    guard let varDecl = member.as(VariableDeclSyntax.self),
+      let binding = varDecl.bindings.first,
+      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
+      binding.accessor == nil
+    else {
+      return []
+    }
+
+    if identifier.text == "_storage" {
+      return []
+    }
+
+    let customAttr = AttributeSyntax(
+      attributeName: SimpleTypeIdentifierSyntax(
+        name: .identifier("accessViaStorage")
+      )
+    )
+
+    return [customAttr]
+  }
+}
+
+public struct AccessViaStorageMacro: AccessorDeclarationMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: DeclSyntax,
+    in context: inout MacroExpansionContext
+  ) throws -> [AccessorDeclSyntax] {
+    guard let varDecl = declaration.as(VariableDeclSyntax.self),
+      let binding = varDecl.bindings.first,
+      let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier,
+      binding.accessor == nil
+    else {
+      return []
+    }
+
+    if identifier.text == "_storage" {
+      return []
+    }
+
+    return [
+      "get { _storage.\(identifier) }",
+      "set { _storage.\(identifier) = newValue }",
+    ]
+  }
+}

--- a/test/Macros/composed_macro.swift
+++ b/test/Macros/composed_macro.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+// RUNx: %target-swift-frontend -dump-ast -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser 2>&1 | %FileCheck --check-prefix CHECK-AST %s
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS -swift-version 5
+// RUN: %target-build-swift -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser -swift-version 5
+// RUN: %target-run %t/main | %FileCheck %s
+// REQUIRES: executable_test
+
+// FIXME: Swift parser is not enabled on Linux CI yet.
+// REQUIRES: OS=macosx
+
+@attached(memberAttributes) macro myTypeWrapper() = #externalMacro(module: "MacroDefinition", type: "TypeWrapperMacro")
+@attached(accessor) macro accessViaStorage() = #externalMacro(module: "MacroDefinition", type: "AccessViaStorageMacro")
+
+struct _Storage {
+  var x: Int = 0 {
+    willSet { print("setting \(newValue)") }
+  }
+  var y: Int = 0 {
+    willSet { print("setting \(newValue)") }
+  }
+}
+
+@myTypeWrapper
+struct S {
+  var _storage = _Storage()
+
+  var x: Int
+  var y: Int
+}
+
+var s = S()
+
+// CHECK: setting 10
+s.x = 10
+
+// CHECK: setting 100
+s.y = 100


### PR DESCRIPTION
Having a request for semantic declaration attributes while still allowing the original linked list to be mutated directly can cause use-after-frees on pointers to old decl attributes. For now, introduce a request that expands member attribute macros with a side effect of adding the new attributes to the list. We can revisit this once attribute mutation via `getAttrs()` is audited across the frontend.

This change also re-applies the commit reverted in https://github.com/apple/swift/pull/63062

Resolves: rdar://104297642