### PR TITLE
Diagnose differentiable functions returning Void w/o inout arguments.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5334,6 +5334,12 @@ ERROR(differentiable_function_type_invalid_result,none,
       "%select{| and satisfy '%0 == %0.TangentVector'}1, but the enclosing "
       "function type is '@differentiable%select{|(_linear)}1'",
       (StringRef, bool))
+ERROR(differentiable_function_type_void_result,
+      none,
+      "'@differentiable' function returning Void must have at least one "
+      "differentiable inout parameter, i.e. a non-'@noDerivative' parameter "
+      "whose type conforms to 'Differentiable'",
+      ())
 ERROR(differentiable_function_type_no_differentiability_parameters, 
       none,
       "'@differentiable' function type requires at least one differentiability "

--- a/test/AutoDiff/Sema/differentiable_func_type.swift
+++ b/test/AutoDiff/Sema/differentiable_func_type.swift
@@ -41,6 +41,10 @@ let _: @differentiable(_linear) (Float) -> NonDiffType
 
 let _: @differentiable(_linear) (Float) -> Float
 
+// expected-error @+1 {{'@differentiable' function returning Void must have at least one differentiable inout parameter, i.e. a non-'@noDerivative' parameter whose type conforms to 'Differentiable'}}
+let _: @differentiable(reverse) (Float) -> Void
+let _: @differentiable(reverse) (inout Float) -> Void // okay
+
 // expected-error @+1 {{result type '@differentiable(reverse) (U) -> Float' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}
 func test1<T: Differentiable, U: Differentiable>(_: @differentiable(reverse) (T) -> @differentiable(reverse) (U) -> Float) {}
 // expected-error @+1 {{result type '(U) -> Float' does not conform to 'Differentiable', but the enclosing function type is '@differentiable'}}


### PR DESCRIPTION
Such functions are not differentiable and therefore should be rejected. Fixes #62923, fixes #58095