### PR TITLE
Fix -conditional-runtime-records crash on @objc protocols

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3811,7 +3811,7 @@ getTypeContextDescriptorEntityReference(IRGenModule &IGM,
 
 static TypeEntityReference
 getProtocolDescriptorEntityReference(IRGenModule &IGM, ProtocolDecl *protocol) {
-  assert(!protocol->isObjC() &&
+  assert(!protocol->hasClangNode() &&
          "objc protocols don't have swift protocol descriptors");
   auto entity = LinkEntity::forProtocolDescriptor(protocol);
   return getContextDescriptorEntityReference(IGM, entity);
@@ -3831,7 +3831,7 @@ getObjCClassByNameReference(IRGenModule &IGM, ClassDecl *cls) {
 TypeEntityReference
 IRGenModule::getTypeEntityReference(GenericTypeDecl *decl) {
   if (auto protocol = dyn_cast<ProtocolDecl>(decl)) {
-    assert(!protocol->isObjC() && "imported protocols not handled here");
+    assert(!protocol->hasClangNode() && "imported protocols not handled here");
     return getProtocolDescriptorEntityReference(*this, protocol);
   }
   

--- a/test/IRGen/conditional-dead-strip-objc-ir.swift
+++ b/test/IRGen/conditional-dead-strip-objc-ir.swift
@@ -6,18 +6,25 @@
 
 // RUN: %target-build-swift -Xfrontend -conditional-runtime-records %s -emit-ir -o - | %FileCheck %s
 
+import Foundation
+
 public class Class {
+}
+
+@objc public protocol ObjCAnnotatedProtocol {
 }
 
 // CHECK:      @llvm.{{(compiler.)?}}used = appending global [
 // CHECK-SAME:   @"$s4main5ClassCHn"
 // CHECK-SAME: ], section "llvm.metadata"
 
-// CHECK:      !llvm.used.conditional = !{[[M1:!.*]], [[M2:!.*]], [[O1:!.*]]}
+// CHECK:      !llvm.used.conditional = !{[[M1:!.*]], [[M2:!.*]], [[M3:!.*]], [[O1:!.*]]}
 
 // CHECK-DAG:      [[M1]]  = !{{{.*}} @"$s4main5ClassCMF", i32 0, [[M1A:!.*]]}
 // CHECK-DAG:      [[M1A]] = !{{{.*}} @"$s4main5ClassCMn"
-// CHECK-DAG:      [[M2]]  = !{{{.*}} @"$s4main5ClassCHn", i32 0, [[M1A:!.*]]}
+// CHECK-DAG:      [[M2]]  = !{{{.*}} @"$s4main21ObjCAnnotatedProtocol_pMF", i32 0, [[M2A:!.*]]}
+// CHECK-DAG:      [[M2A]] = !{{{.*}} @"$s4main21ObjCAnnotatedProtocolMp"
+// CHECK-DAG:      [[M3]]  = !{{{.*}} @"$s4main5ClassCHn", i32 0, [[M1A:!.*]]}
 
 // CHECK-DAG:      [[O1]]  = !{{{.*}} @"objc_classes_$s4main5ClassCN", i32 0, [[O1A:!.*]]}
 // CHECK-DAG:      [[O1A]] = !{{{.*}} @"$s4main5ClassCN"}


### PR DESCRIPTION
The compiler will crash due to assertion failure if run on a file including an `@objc` annotated protocol decl with `-conditional-runtime-records`. The modified test case shows an example.

This patch corrects the asserts and prevents the crash.