### PR TITLE
test: enable crash-in-user-code on Windows

### DIFF
--- a/test/Frontend/crash-in-user-code.swift
+++ b/test/Frontend/crash-in-user-code.swift
@@ -1,13 +1,13 @@
-
-// RUN: echo %s > %t.filelist.txt
-// RUN: not --crash %target-swift-frontend -interpret -filelist %t.filelist.txt 2>&1 | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: echo %s > %t/filelist.txt
+// RUN: not --crash %target-swift-frontend -interpret -filelist %t/filelist.txt 2>&1 >%t/output.txt
+// %FileCheck %s < %t/output.txt
 
 // REQUIRES: executable_test
 
 // UNSUPPORTED: OS=ios
 // UNSUPPORTED: OS=tvos
 // UNSUPPORTED: OS=watchos
-// UNSUPPORTED: MSVC_VER=15.0
 
 // CHECK: Stack dump:
 // CHECK-NEXT: Program arguments:


### PR DESCRIPTION
This test was disabled on Windows through the `MSC_VER` condition.  The failure was due to the redirection of the output which does not behave entirely the expected way with the lit shell.  Use a temporary file instead and enable the test on Windows.