### PR TITLE
[SourceKit] Refactor main 'handleRequestImpl' function

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
@@ -128,11 +128,17 @@ class RequestDict {
   sourcekitd_object_t Dict;
 
 public:
-  explicit RequestDict(sourcekitd_object_t Dict) : Dict(Dict) {}
+  explicit RequestDict(sourcekitd_object_t Dict) : Dict(Dict) {
+    sourcekitd_request_retain(Dict);
+  }
+  RequestDict(const RequestDict &other) : RequestDict(other.Dict) {}
+  ~RequestDict() {
+    sourcekitd_request_release(Dict);
+  }
 
-  sourcekitd_uid_t getUID(SourceKit::UIdent Key);
-  Optional<llvm::StringRef> getString(SourceKit::UIdent Key);
-  Optional<RequestDict> getDictionary(SourceKit::UIdent Key);
+  sourcekitd_uid_t getUID(SourceKit::UIdent Key) const;
+  Optional<llvm::StringRef> getString(SourceKit::UIdent Key) const;
+  Optional<RequestDict> getDictionary(SourceKit::UIdent Key) const;
 
   /// Populate the vector with an array of C strings.
   /// \param isOptional true if the key is optional. If false and the key is
@@ -141,16 +147,17 @@ public:
   /// the array does not contain strings.
   bool getStringArray(SourceKit::UIdent Key,
                       llvm::SmallVectorImpl<const char *> &Arr,
-                      bool isOptional);
+                      bool isOptional) const;
   bool getUIDArray(SourceKit::UIdent Key,
                    llvm::SmallVectorImpl<sourcekitd_uid_t> &Arr,
-                   bool isOptional);
+                   bool isOptional) const;
 
-  bool dictionaryArrayApply(SourceKit::UIdent key,
-                            llvm::function_ref<bool(RequestDict)> applier);
+  bool
+  dictionaryArrayApply(SourceKit::UIdent key,
+                       llvm::function_ref<bool(RequestDict)> applier) const;
 
-  bool getInt64(SourceKit::UIdent Key, int64_t &Val, bool isOptional);
-  Optional<int64_t> getOptionalInt64(SourceKit::UIdent Key);
+  bool getInt64(SourceKit::UIdent Key, int64_t &Val, bool isOptional) const;
+  Optional<int64_t> getOptionalInt64(SourceKit::UIdent Key) const;
 };
 
 /// Initialize the sourcekitd client library. Returns true if this is the first

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
@@ -706,19 +706,19 @@ ResponseBuilder::Dictionary ResponseBuilder::Array::appendDictionary() {
 // Internal RequestDict Implementation
 //===----------------------------------------------------------------------===//
 
-sourcekitd_uid_t RequestDict::getUID(UIdent Key) {
+sourcekitd_uid_t RequestDict::getUID(UIdent Key) const {
   auto Object = static_cast<SKDObject *>(Dict)->get(SKDUIDFromUIdent(Key));
   return Object ? Object->getUID() : nullptr;
 }
 
-Optional<StringRef> RequestDict::getString(UIdent Key) {
+Optional<StringRef> RequestDict::getString(UIdent Key) const {
   if (auto Object = static_cast<SKDObject *>(Dict)->get(SKDUIDFromUIdent(Key))) {
     return Object->getString();
   }
   return None;
 }
 
-Optional<RequestDict> RequestDict::getDictionary(SourceKit::UIdent Key) {
+Optional<RequestDict> RequestDict::getDictionary(SourceKit::UIdent Key) const {
   SKDDictionary *DictObject = nullptr;
   if (auto Object = static_cast<SKDObject *>(Dict)->get(SKDUIDFromUIdent(Key))) {
     DictObject = dyn_cast<SKDDictionary>(Object);
@@ -728,7 +728,7 @@ Optional<RequestDict> RequestDict::getDictionary(SourceKit::UIdent Key) {
 
 bool RequestDict::getStringArray(SourceKit::UIdent Key,
                                  llvm::SmallVectorImpl<const char *> &Arr,
-                                 bool isOptional) {
+                                 bool isOptional) const {
   auto Object = static_cast<SKDObject *>(Dict)->get(SKDUIDFromUIdent(Key));
   if (!Object)
     return !isOptional;
@@ -748,7 +748,7 @@ bool RequestDict::getStringArray(SourceKit::UIdent Key,
 
 bool RequestDict::getUIDArray(SourceKit::UIdent Key,
                               llvm::SmallVectorImpl<sourcekitd_uid_t> &Arr,
-                              bool isOptional) {
+                              bool isOptional) const {
   auto Object = static_cast<SKDObject *>(Dict)->get(SKDUIDFromUIdent(Key));
   if (!Object)
     return !isOptional;
@@ -767,7 +767,8 @@ bool RequestDict::getUIDArray(SourceKit::UIdent Key,
 }
 
 bool RequestDict::dictionaryArrayApply(
-    SourceKit::UIdent Key, llvm::function_ref<bool(RequestDict)> Applier) {
+    SourceKit::UIdent Key,
+    llvm::function_ref<bool(RequestDict)> Applier) const {
   auto Object = static_cast<SKDObject *>(Dict)->get(SKDUIDFromUIdent(Key));
   if (!Object)
     return true;
@@ -784,7 +785,7 @@ bool RequestDict::dictionaryArrayApply(
 }
 
 bool RequestDict::getInt64(SourceKit::UIdent Key, int64_t &Val,
-                           bool isOptional) {
+                           bool isOptional) const {
   auto Object = static_cast<SKDObject *>(Dict)->get(SKDUIDFromUIdent(Key));
   if (!Object)
     return !isOptional;
@@ -792,7 +793,7 @@ bool RequestDict::getInt64(SourceKit::UIdent Key, int64_t &Val,
   return false;
 }
 
-Optional<int64_t> RequestDict::getOptionalInt64(SourceKit::UIdent Key) {
+Optional<int64_t> RequestDict::getOptionalInt64(SourceKit::UIdent Key) const {
   auto Object = static_cast<SKDObject *>(Dict)->get(SKDUIDFromUIdent(Key));
   if (!Object)
     return None;

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -283,11 +283,11 @@ ResponseBuilder::Dictionary ResponseBuilder::Array::appendDictionary() {
   return Dictionary(dict);
 }
 
-sourcekitd_uid_t RequestDict::getUID(UIdent Key) {
+sourcekitd_uid_t RequestDict::getUID(UIdent Key) const {
   return sourcekitd_uid_t(xpc_dictionary_get_uint64(Dict, Key.c_str()));
 }
 
-Optional<StringRef> RequestDict::getString(UIdent Key) {
+Optional<StringRef> RequestDict::getString(UIdent Key) const {
   xpc_object_t xobj = xpc_dictionary_get_value(Dict, Key.c_str());
   if (!xobj)
     return None;
@@ -297,7 +297,7 @@ Optional<StringRef> RequestDict::getString(UIdent Key) {
                    xpc_string_get_length(xobj));
 }
 
-Optional<RequestDict> RequestDict::getDictionary(SourceKit::UIdent Key) {
+Optional<RequestDict> RequestDict::getDictionary(SourceKit::UIdent Key) const {
   xpc_object_t xobj = xpc_dictionary_get_value(Dict, Key.c_str());
   if (!xobj)
     return None;
@@ -308,7 +308,7 @@ Optional<RequestDict> RequestDict::getDictionary(SourceKit::UIdent Key) {
 
 bool RequestDict::getStringArray(SourceKit::UIdent Key,
                                  llvm::SmallVectorImpl<const char *> &Arr,
-                                 bool isOptional) {
+                                 bool isOptional) const {
   xpc_object_t xarr = xpc_dictionary_get_value(Dict, Key.c_str());
   if (!xarr)
     return !isOptional;
@@ -327,7 +327,7 @@ bool RequestDict::getStringArray(SourceKit::UIdent Key,
 
 bool RequestDict::getUIDArray(SourceKit::UIdent Key,
                               llvm::SmallVectorImpl<sourcekitd_uid_t> &Arr,
-                              bool isOptional) {
+                              bool isOptional) const {
   xpc_object_t xarr = xpc_dictionary_get_value(Dict, Key.c_str());
   if (!xarr)
     return !isOptional;
@@ -345,7 +345,8 @@ bool RequestDict::getUIDArray(SourceKit::UIdent Key,
 }
 
 bool RequestDict::dictionaryArrayApply(
-    SourceKit::UIdent key, llvm::function_ref<bool(RequestDict)> applier) {
+    SourceKit::UIdent key,
+    llvm::function_ref<bool(RequestDict)> applier) const {
   xpc_object_t xarr = xpc_dictionary_get_value(Dict, key.c_str());
   if (!xarr || xpc_get_type(xarr) != XPC_TYPE_ARRAY)
     return true;
@@ -361,7 +362,7 @@ bool RequestDict::dictionaryArrayApply(
 }
 
 bool RequestDict::getInt64(SourceKit::UIdent Key, int64_t &Val,
-                           bool isOptional) {
+                           bool isOptional) const {
   xpc_object_t xobj = xpc_dictionary_get_value(Dict, Key.c_str());
   if (!xobj)
     return !isOptional;
@@ -369,7 +370,7 @@ bool RequestDict::getInt64(SourceKit::UIdent Key, int64_t &Val,
   return false;
 }
 
-Optional<int64_t> RequestDict::getOptionalInt64(SourceKit::UIdent Key) {
+Optional<int64_t> RequestDict::getOptionalInt64(SourceKit::UIdent Key) const {
   xpc_object_t xobj = xpc_dictionary_get_value(Dict, Key.c_str());
   if (!xobj)
     return None;


### PR DESCRIPTION
Previously, SourceKit requests are handled in a single `handleRequestImpl`/`handleSemanticRequest` with, basically, a giant `if (ReqUID == RequstXXX)` branches. Some request parameters are extracted at the top of the function, but not all request kind used all of them.

Factor out each handling logic to its own function, and check/extract request parameters in it. This makes it clear that which request uses what parameters, and how they are handled.

This is mostly a mechanical change, and mostly NFC.