### PR TITLE
[BuilderTransform] All `if` sequences without `else` should call `bui…

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -1255,26 +1255,9 @@ protected:
         auto *builderCall =
             buildWrappedChainPayload(branchVarRef, i, numPayloads, isOptional);
 
-        auto isTopLevel = [&](Stmt *anchor) {
-          if (ifStmt->getThenStmt() == anchor)
-            return true;
-
-          // The situation is this:
-          //
-          // if <cond> {
-          //   ...
-          // } else if <other-cond> {
-          //   ...
-          // }
-          if (auto *innerIf = getAsStmt<IfStmt>(ifStmt->getElseStmt()))
-            return innerIf->getThenStmt() == anchor;
-
-          return ifStmt->getElseStmt() == anchor;
-        };
-
         // The operand should have optional type if we had optional results,
         // so we just need to call `buildIf` now, since we're at the top level.
-        if (isOptional && isTopLevel(anchor)) {
+        if (isOptional) {
           builderCall = buildCallIfWanted(ifStmt->getThenStmt()->getStartLoc(),
                                           builder.getBuildOptionalId(),
                                           builderCall, /*argLabels=*/{});

--- a/test/Constraints/result_builder.swift
+++ b/test/Constraints/result_builder.swift
@@ -1252,3 +1252,134 @@ do {
   }
   // CHECK: the answer
 }
+
+protocol TestIfSequences {
+}
+
+struct A: TestIfSequences {}
+struct B: TestIfSequences {}
+struct C: TestIfSequences {}
+struct D: TestIfSequences {}
+
+func testOptionalIfElseSequences() {
+  func check<T>(_ v: TestIfSequences,
+                @TupleBuilder body: (TestIfSequences) throws -> T) rethrows {
+    print(try body(v))
+  }
+
+  check(A()) { v in
+    if let a = v as? A {
+      a
+    } else if let b = v as? B {
+      b
+    } else if let c = v as? C {
+      c
+    }
+  }
+
+  check(B()) { v in
+    if let a = v as? A {
+      a
+    } else if let b = v as? B {
+      b
+    } else if let c = v as? C {
+      c
+    }
+  }
+
+  check(C()) { v in
+    if let a = v as? A {
+      a
+    } else if let b = v as? B {
+      b
+    } else if let c = v as? C {
+      c
+    }
+  }
+
+  check(D()) { v in
+    if let a = v as? A {
+      a
+    } else if let b = v as? B {
+      b
+    } else if let c = v as? C {
+      c
+    } else {
+      D()
+    }
+  }
+
+  check(A()) { v in
+    if let a = v as? A {
+      a
+    } else {
+      if let b = v as? B {
+        b
+      }
+
+      if let c = v as? C {
+        c
+      } else if let d = v as? D {
+        d
+      }
+    }
+  }
+
+  check(B()) { v in
+    if let a = v as? A {
+      a
+    } else {
+      if let b = v as? B {
+        b
+      }
+
+      if let c = v as? C {
+        c
+      } else if let d = v as? D {
+        d
+      }
+    }
+  }
+
+  check(C()) { v in
+    if let a = v as? A {
+      a
+    } else {
+      if let b = v as? B {
+        b
+      }
+
+      if let c = v as? C {
+        c
+      } else if let d = v as? D {
+        d
+      }
+    }
+  }
+
+  check(D()) { v in
+    if let a = v as? A {
+      a
+    } else {
+      if let b = v as? B {
+        b
+      }
+
+      if let c = v as? C {
+        c
+      } else if let d = v as? D {
+        d
+      }
+    }
+  }
+}
+
+testOptionalIfElseSequences()
+// CHECK: Optional(main.Either<main.Either<main.A, main.B>, main.C>.first(main.Either<main.A, main.B>.first(main.A())))
+// CHECK-NEXT: Optional(main.Either<main.Either<main.A, main.B>, main.C>.first(main.Either<main.A, main.B>.second(main.B())))
+// CHECK-NEXT: Optional(main.Either<main.Either<main.A, main.B>, main.C>.second(main.C()))
+// CHECK-NEXT: second(main.Either<main.C, main.D>.second(main.D()))
+// CHECK-NEXT: first(main.A())
+// CHECK-NEXT: second(Optional(main.B()), nil)
+// CHECK-NEXT: second(nil, Optional(main.Either<main.C, main.D>.first(main.C())))
+// CHECK-NEXT: second(nil, Optional(main.Either<main.C, main.D>.second(main.D())))


### PR DESCRIPTION
…ldOptional`

In cases like:

```
if (...) {
  <body>
} else if (...) {
  <body>
} else if (...) {
  <body>
}
```

Each branch should end with `buildOptional` wrapping `buildEither`
because there is no covering unconditional `else` in the sequence:

```
var $__builder: <<Type>>

if (...) {
  $__builder = buildOptional(.some(buildEither(...)))
} else {
  if (...) {
    $__builder = buildOptional(.some(buildEither(...)))
  } else {
    if (...) {
      $__builder = buildOptional(.some(buildEither(...)))
    } else {
      $__builder = buildOptional(.none)
    }
  }
}
```

Resolves: rdar://104345754

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
