### PR TITLE
[test] Re-enable temporary allocation IRGen testing, separating large allocation testing and making it less brittle

### DIFF
--- a/test/IRGen/temporary_allocation/codegen.swift
+++ b/test/IRGen/temporary_allocation/codegen.swift
@@ -1,8 +1,4 @@
-// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-LARGE-ALLOC,CHECK-LARGE-ALLOC-%target-vendor
-// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=CHECK-LARGE-STACK-ALLOC -DWORD=i%target-ptrsize
-// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=CHECK-LARGE-HEAP-ALLOC -DWORD=i%target-ptrsize
-// REQUIRES: CPU=x86_64
-// REQUIRES: rdar104435186
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s
 
 @_silgen_name("blackHole")
 func blackHole(_ value: UnsafeMutableRawPointer?) -> Void
@@ -70,24 +66,3 @@ withUnsafeTemporaryAllocation(of: Void.self, capacity: 2) { buffer in
 // CHECK: [[VOID_PTR:%[0-9]+]] = ptrtoint [2 x i8]* [[VOID_PTR_RAW]] to [[WORD]]
 // CHECK: call swiftcc void @blackHole([[WORD]] [[VOID_PTR]])
 
-// MARK: Very large allocation
-
-// A large allocation size should produce an OS version check, call to
-// swift_stdlib_isStackAllocationSafe(), and then a branch based on the result
-// to either stack-allocate or heap-allocate.
-withUnsafeTemporaryAllocation(byteCount: 0x0FFF_FFFF, alignment: 1) { buffer in
-  blackHole(buffer.baseAddress)
-}
-// CHECK-LARGE-HEAP-ALLOC: [[HEAP_PTR_RAW:%[0-9]+]] = call noalias i8* @swift_slowAlloc([[WORD]] 268435455, [[WORD]] -1)
-// CHECK-LARGE-HEAP-ALLOC-NEXT: [[HEAP_PTR:%[0-9]+]] = ptrtoint i8* [[HEAP_PTR_RAW]] to [[WORD]]
-// CHECK-LARGE-HEAP-ALLOC-NEXT: call swiftcc void @blackHole([[WORD]] [[HEAP_PTR]])
-// CHECK-LARGE-HEAP-ALLOC-NEXT: call void @swift_slowDealloc(i8* [[HEAP_PTR_RAW]], [[WORD]] -1, [[WORD]] -1)
-
-// CHECK-LARGE-STACK-ALLOC: [[STACK_PTR_RAW:%temp_alloc[0-9]*]] = alloca [268435455 x i8], align 1
-// CHECK-LARGE-STACK-ALLOC-NEXT: [[STACK_PTR:%[0-9]+]] = ptrtoint [268435455 x i8]* [[STACK_PTR_RAW]] to [[WORD]]
-// CHECK-LARGE-STACK-ALLOC-NEXT: call swiftcc void @blackHole([[WORD]] [[STACK_PTR]])
-
-// CHECK-LARGE-ALLOC-DAG: [[IS_SAFE:%[0-9]+]] = call zeroext i1 @swift_stdlib_isStackAllocationSafe([[WORD]] 268435455, [[WORD]] 1)
-// CHECK-LARGE-ALLOC-DAG: br i1 [[IS_SAFE]], label %{{[0-9]+}}, label %{{[0-9]+}}
-// CHECK-LARGE-ALLOC-apple-DAG: [[IS_OS_OK:%[0-9]+]] = call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"
-// CHECK-LARGE-ALLOC-apple-DAG: br i1 [[IS_OS_OK]], label %{{[0-9]+}}, label %{{[0-9]+}}

--- a/test/IRGen/temporary_allocation/codegen_very_large_allocation.swift
+++ b/test/IRGen/temporary_allocation/codegen_very_large_allocation.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s --check-prefixes=CHECK-LARGE-ALLOC,CHECK-LARGE-ALLOC-%target-vendor -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=CHECK-LARGE-STACK-ALLOC -DWORD=i%target-ptrsize
+// RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=CHECK-LARGE-HEAP-ALLOC -DWORD=i%target-ptrsize
+// REQUIRES: rdar104435186
+
+@_silgen_name("blackHole")
+func blackHole(_ value: UnsafeMutableRawPointer?) -> Void
+
+// MARK: Very large allocation
+
+// A large allocation size should produce an OS version check, call to
+// swift_stdlib_isStackAllocationSafe(), and then a branch based on the result
+// to either stack-allocate or heap-allocate.
+withUnsafeTemporaryAllocation(byteCount: 0x0FFF_FFFF, alignment: 1) { buffer in
+  blackHole(buffer.baseAddress)
+}
+// CHECK-LARGE-HEAP-ALLOC: [[HEAP_PTR_RAW:%[0-9]+]] = {{(tail )?}}call noalias i8* @swift_slowAlloc([[WORD]] 268435455, [[WORD]] -1)
+// CHECK-LARGE-HEAP-ALLOC-NEXT: [[HEAP_PTR:%[0-9]+]] = ptrtoint i8* [[HEAP_PTR_RAW]] to [[WORD]]
+// CHECK-LARGE-HEAP-ALLOC-NEXT: {{(tail )?}}call swiftcc void @blackHole([[WORD]] [[HEAP_PTR]])
+// CHECK-LARGE-HEAP-ALLOC-NEXT: {{(tail )?}}call void @swift_slowDealloc(i8* [[HEAP_PTR_RAW]], [[WORD]] -1, [[WORD]] -1)
+
+// CHECK-LARGE-STACK-ALLOC: [[STACK_PTR_RAW:%temp_alloc[0-9]*]] = alloca [268435455 x i8], align 1
+// CHECK-LARGE-STACK-ALLOC-NEXT: [[STACK_PTR:%[0-9]+]] = ptrtoint [268435455 x i8]* [[STACK_PTR_RAW]] to [[WORD]]
+// CHECK-LARGE-STACK-ALLOC-NEXT: call swiftcc void @blackHole([[WORD]] [[STACK_PTR]])
+
+// CHECK-LARGE-ALLOC-DAG: [[IS_SAFE:%[0-9]+]] = {{(tail )?}}call {{(zeroext )?}}i1 @swift_stdlib_isStackAllocationSafe([[WORD]] 268435455, [[WORD]] 1)
+// CHECK-LARGE-ALLOC-DAG: br i1 [[IS_SAFE]], label %{{[0-9]+}}, label %{{[0-9]+}}
+// CHECK-LARGE-ALLOC-apple-DAG: [[IS_OS_OK:%[0-9]+]] = {{(tail )?}}call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"
+// CHECK-LARGE-ALLOC-apple-DAG: br i1 [[IS_OS_OK]], label %{{[0-9]+}}, label %{{[0-9]+}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
As per the bots, `zeroext` isn't emitted for all architectures when calling `swift_stdlib_isStackAllocationSafe`.

Since this very large temporary allocation test is a brittle one, we'll relocate it into a separate file and noodle on it there, and we'll keep this test disabled for now with the tracking rdar. This should allow us to re-enable the remaining temporary allocation tests

Once moved to its own file, turns out that a bunch of calls in the very large temporary allocation test are also emitted as tail calls, so we'll also accommodate that change.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Partially resolves rdar104435186.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
