### PR TITLE
[Serialization] Introduce main deserialization safety logic, on the writer side

### DIFF
--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -885,8 +885,13 @@ void ModuleFile::lookupObjCMethods(
   auto found = *known;
   for (const auto &result : found) {
     // Deserialize the method and add it to the list.
-    if (auto func = dyn_cast_or_null<AbstractFunctionDecl>(
-                      getDecl(std::get<2>(result))))
+    auto declOrError = getDeclChecked(std::get<2>(result));
+    if (!declOrError) {
+        consumeError(declOrError.takeError());
+        continue;
+    }
+
+    if (auto func = dyn_cast_or_null<AbstractFunctionDecl>(declOrError.get()))
       results.push_back(func);
   }
 }

--- a/test/Serialization/Safety/lookupObjCMethods.swift
+++ b/test/Serialization/Safety/lookupObjCMethods.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -typecheck -verify %s \
+// RUN:   -enable-deserialization-safety \
+// RUN:   -Xllvm -debug-only=Serialization 2>&1 | %FileCheck %s
+
+// REQUIRES: objc_interop
+// REQUIRES: asserts
+
+import Foundation
+
+// Fails at reading __SwiftNativeNSEnumerator.init() on macOS.
+NSString.instancesRespond(to: "init") // expected-warning {{use of string literal for Objective-C selectors is deprecated; use '#selector' instead}}
+// CHECK: Skipping unsafe deserialization: 'init()'

--- a/test/Serialization/Safety/skip-reading-internal-anyobject.swift
+++ b/test/Serialization/Safety/skip-reading-internal-anyobject.swift
@@ -1,0 +1,49 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// REQUIRES: asserts
+// REQUIRES: VENDOR=apple
+
+/// Build library.
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -emit-module-path %t/Lib.swiftmodule
+
+/// Build client.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -enable-deserialization-safety 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=SAFE %s
+
+/// Decls skips by the deserialization safety logic.
+// SAFE-NOT: InternalClass
+// SAFE: Deserialized: 'PublicClass'
+// SAFE: Deserialized: 'publicFunc()'
+// SAFE: Skipping unsafe deserialization: 'privateFunc()'
+// SAFE: Skipping unsafe deserialization: 'fileprivateFunc()'
+// SAFE: Skipping unsafe deserialization: 'internalFunc()'
+
+//--- Lib.swift
+
+import Foundation
+
+@objc
+public class PublicClass : NSObject {
+    public func publicFunc() {}
+}
+
+@objc
+internal class InternalClass : NSObject {
+    private func privateFunc() {}
+    fileprivate func fileprivateFunc() {}
+    internal func internalFunc() {}
+}
+
+//--- Client.swift
+
+import Lib
+
+var x: AnyObject
+
+// Trigger a typo correction to read all members of all subtypes to NSObject.
+x.notAMember() // expected-error {{value of type 'AnyObject' has no member 'notAMember'}}

--- a/test/Serialization/Safety/unsafe-decls.swift
+++ b/test/Serialization/Safety/unsafe-decls.swift
@@ -72,6 +72,7 @@ public struct PublicStruct {
 // SAFETY-PRIVATE: Serialization safety, safe: 'inlinableFunc()'
     public func publicFunc() {}
 // SAFETY-PRIVATE: Serialization safety, safe: 'publicFunc()'
+@available(SwiftStdlib 5.1, *) // for the `some` keyword.
     public func opaqueTypeFunc() -> some PublicProto {
         return InternalStruct()
     }

--- a/test/Serialization/Safety/unsafe-decls.swift
+++ b/test/Serialization/Safety/unsafe-decls.swift
@@ -1,0 +1,93 @@
+// RUN: %empty-directory(%t)
+
+// REQUIRES: asserts
+
+// RUN: %target-swift-frontend -emit-module %s \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
+// RUN:   -Xllvm -debug-only=Serialization 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=SAFETY-PRIVATE,SAFETY-INTERNAL %s
+
+// RUN: %target-swift-frontend -emit-module %s \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
+// RUN:   -Xllvm -debug-only=Serialization \
+// RUN:   -enable-testing 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=SAFETY-PRIVATE,NO-SAFETY-INTERNAL-NOT %s
+
+/// Don't mark decls as unsafe when private import is enabled.
+// RUN: %target-swift-frontend -emit-module %s \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
+// RUN:   -Xllvm -debug-only=Serialization \
+// RUN:   -enable-private-imports 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=DISABLED %s
+
+/// Don't mark decls as unsafe without library evolution.
+// RUN: %target-swift-frontend -emit-module %s \
+// RUN:   -enable-deserialization-safety -swift-version 5 \
+// RUN:   -Xllvm -debug-only=Serialization 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=DISABLED %s
+
+// DISABLED-NOT: Serialization safety
+
+public protocol PublicProto {}
+// SAFETY-PRIVATE: Serialization safety, safe: 'PublicProto'
+internal protocol InternalProto {}
+// SAFETY-INTERNAL: Serialization safety, unsafe: 'InternalProto'
+// NO-SAFETY-INTERNAL: Serialization safety, safe: 'InternalProto'
+private protocol PrivateProto {}
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'PrivateProto'
+fileprivate protocol FileprivateProto {}
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'FileprivateProto'
+
+internal struct InternalStruct : PublicProto {
+// SAFETY-INTERNAL: Serialization safety, unsafe: 'InternalStruct'
+// NO-SAFETY-INTERNAL: Serialization safety, safe: 'InternalStruct'
+}
+
+public struct PublicStruct {
+// SAFETY-PRIVATE: Serialization safety, safe: 'PublicStruct'
+
+    public typealias publicTypealias = Int
+// SAFETY-PRIVATE: Serialization safety, safe: 'publicTypealias'
+    typealias internalTypealias = Int
+// SAFETY-INTERNAL: Serialization safety, unsafe: 'internalTypealias'
+// NO-SAFETY-INTERNAL: Serialization safety, safe: 'internalTypealias'
+// SAFETY-PRIVATE: Serialization safety, safe: 'localTypealias'
+
+    public init(publicInit a: Int) {}
+// SAFETY-PRIVATE: Serialization safety, safe: 'init(publicInit:)'
+    internal init(internalInit a: Int) {}
+// SAFETY-INTERNAL: Serialization safety, unsafe: 'init(internalInit:)'
+// NO-SAFETY-INTERNAL: Serialization safety, safe: 'init(internalInit:)'
+    private init(privateInit a: Int) {}
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'init(privateInit:)'
+    fileprivate init(fileprivateInit a: Int) {}
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'init(fileprivateInit:)'
+
+    @inlinable public func inlinableFunc() {
+        typealias localTypealias = Int
+    }
+// SAFETY-PRIVATE: Serialization safety, safe: 'inlinableFunc()'
+    public func publicFunc() {}
+// SAFETY-PRIVATE: Serialization safety, safe: 'publicFunc()'
+    public func opaqueTypeFunc() -> some PublicProto {
+        return InternalStruct()
+    }
+// SAFETY-PRIVATE: Serialization safety, safe: 'opaqueTypeFunc()'
+    internal func internalFunc() {}
+// SAFETY-INTERNAL: Serialization safety, unsafe: 'internalFunc()'
+// NO-SAFETY-INTERNAL: Serialization safety, safe: 'internalFunc()'
+    private func privateFunc() {}
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'privateFunc()'
+    fileprivate func fileprivateFunc() {}
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'fileprivateFunc()'
+
+    public var publicProperty = "Some text"
+// SAFETY-PRIVATE: Serialization safety, safe: 'publicProperty'
+    public private(set) var halfPublicProperty = "Some text"
+// SAFETY-PRIVATE: Serialization safety, safe: 'halfPublicProperty'
+    private var privateProperty = "Some text"
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'privateProperty'
+}

--- a/test/Serialization/Safety/unsafe-extensions.swift
+++ b/test/Serialization/Safety/unsafe-extensions.swift
@@ -1,0 +1,137 @@
+// RUN: %empty-directory(%t)
+
+// REQUIRES: asserts
+
+// RUN: %target-swift-frontend -emit-module %s \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
+// RUN:   -Xllvm -debug-only=Serialization 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=SAFETY-PRIVATE,SAFETY-INTERNAL %s
+
+// RUN: %target-swift-frontend -emit-module %s \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
+// RUN:   -Xllvm -debug-only=Serialization \
+// RUN:   -enable-testing 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=SAFETY-PRIVATE,NO-SAFETY-INTERNAL %s
+
+/// Don't mark decls as unsafe when private import is enabled.
+// RUN: %target-swift-frontend -emit-module %s \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
+// RUN:   -Xllvm -debug-only=Serialization \
+// RUN:   -enable-private-imports 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=DISABLED %s
+
+/// Don't mark decls as unsafe without library evolution.
+// RUN: %target-swift-frontend -emit-module %s \
+// RUN:   -enable-deserialization-safety -swift-version 5 \
+// RUN:   -Xllvm -debug-only=Serialization 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=DISABLED %s
+
+// DISABLED-NOT: Serialization safety
+
+/// Public
+// SAFETY-PRIVATE: Serialization safety, safe: 'PublicProto'
+public protocol PublicProto {}
+public struct ExtendedPublic {
+// SAFETY-PRIVATE: Serialization safety, safe: 'ExtendedPublic'
+}
+extension ExtendedPublic {
+// SAFETY-PRIVATE: Serialization safety, safe: 'extension ExtendedPublic'
+    public func publicMember() {}
+}
+extension ExtendedPublic : PublicProto {
+// SAFETY-PRIVATE: Serialization safety, safe: 'extension ExtendedPublic'
+}
+
+/// Internal
+internal protocol InternalProto {}
+// SAFETY-INTERNAL: Serialization safety, unsafe: 'InternalProto'
+// NO-SAFETY-INTERNAL: Serialization safety, safe: 'InternalProto'
+internal struct ExtendedInternal {}
+// SAFETY-INTERNAL: Serialization safety, unsafe: 'ExtendedInternal'
+// NO-SAFETY-INTERNAL: Serialization safety, safe: 'ExtendedInternal'
+extension ExtendedInternal {
+// SAFETY-INTERNAL: Serialization safety, unsafe: 'extension ExtendedInternal'
+// NO-SAFETY-INTERNAL: Serialization safety, safe: 'extension ExtendedInternal'
+    internal func internalMember() {}
+}
+extension ExtendedInternal : InternalProto {}
+// SAFETY-INTERNAL: Serialization safety, unsafe: 'extension ExtendedInternal'
+// NO-SAFETY-INTERNAL: Serialization safety, safe: 'extension ExtendedInternal'
+
+/// Private
+private protocol PrivateProto {}
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'PrivateProto'
+private struct ExtendedPrivate {}
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'ExtendedPrivate'
+extension ExtendedPrivate {
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'extension ExtendedPrivate'
+    private func privateMember() {}
+}
+extension ExtendedPrivate : PrivateProto {}
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'extension ExtendedPrivate'
+
+/// Fileprivate
+private protocol FileprivateProto {}
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'FileprivateProto'
+private struct ExtendedFileprivate {}
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'ExtendedFileprivate'
+extension ExtendedFileprivate {
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'extension ExtendedFileprivate'
+    private func fileprivateMember() {}
+}
+extension ExtendedFileprivate : FileprivateProto {}
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'extension ExtendedFileprivate'
+
+/// Back to public
+extension ExtendedPublic : InternalProto {
+// SAFETY-INTERNAL: Serialization safety, unsafe: 'extension ExtendedPublic'
+// NO-SAFETY-INTERNAL: Serialization safety, safe: 'extension ExtendedPublic'
+}
+extension ExtendedPublic : PrivateProto {
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'extension ExtendedPublic'
+}
+extension ExtendedPublic : FileprivateProto {
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'extension ExtendedPublic'
+}
+
+extension ExtendedPublic {
+// SAFETY-INTERNAL: Serialization safety, unsafe: 'extension ExtendedPublic'
+// NO-SAFETY-INTERNAL: Serialization safety, safe: 'extension ExtendedPublic'
+    internal func internalMemberToPublic() {}
+}
+
+extension ExtendedPublic {
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'extension ExtendedPublic'
+    private func privateMemberToPublic() {}
+}
+
+extension ExtendedPublic {
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'extension ExtendedPublic'
+    fileprivate func fileprivateMemberToPublic() {}
+}
+
+extension ExtendedInternal {
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'extension ExtendedInternal'
+    private func privateMemberToInternal() {}
+}
+
+extension ExtendedInternal {
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'extension ExtendedInternal'
+    fileprivate func fileprivateMemberToInternal() {}
+}
+
+/// Members are serialized last
+// SAFETY-INTERNAL: Serialization safety, unsafe: 'internalMember()'
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'privateMember()'
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'fileprivateMember()'
+
+// SAFETY-INTERNAL: Serialization safety, unsafe: 'internalMemberToPublic()'
+// NO-SAFETY-INTERNAL: Serialization safety, safe: 'internalMemberToPublic()'
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'privateMemberToPublic()'
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'fileprivateMemberToPublic()'
+
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'privateMemberToInternal()'
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'fileprivateMemberToInternal()'


### PR DESCRIPTION
Introduce the serialization-side logic enabling deserialization safety. With deserialization safety, the writer marks decls unsafe to deserialize by writing down a record right before the decl. This safety is determined from the decl's access level, ABI presence, and from the module building mode (enable-testing or enable-private-imports). The general idea is that all decls required by the client must be safe, and as much as possible of internal details should be marked as unsafe to avoid causing deserialization failures.

Note that deserialization safety is still off by default.

Followup to the deserialization safety infrastructure (#62886, #62982), and serialization bug fixes (#62980 and #63068). Next, we need to enable safety by default and maybe fix more serialization bugs.