### PR TITLE
[move-only] Fix a small thinko.

### DIFF
--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -781,7 +781,13 @@ void FieldSensitiveMultiDefPrunedLiveRange::findBoundariesInBlock(
   LLVM_DEBUG(llvm::dbgs() << "Has multiple defs!\n");
 
   // Handle a live-out or live-within block with potentially multiple defs
+#ifndef NDEBUG
+  // We only use prevCount when checking a specific invariant when asserts are
+  // enabled. boundary.getNumLastUsersAndDeadDefs actually asserts if you try to
+  // call it in a non-asserts compiler since it is relatively inefficient and
+  // not needed.
   unsigned prevCount = boundary.getNumLastUsersAndDeadDefs(bitNo);
+#endif
   bool isLive = isLiveOut;
   for (auto &inst : llvm::reverse(*block)) {
     LLVM_DEBUG(llvm::dbgs() << "Visiting: " << inst);

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -1,9 +1,5 @@
 // RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-move-only -enable-sil-verify-all %s | %FileCheck %s
 
-// rdar://104107922
-// REQUIRES: rdar104107922
-
-
 sil_stage raw
 
 import Swift

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1,8 +1,5 @@
 // RUN: %target-swift-emit-sil -verify -enable-experimental-move-only %s
 
-// rdar://104107922
-// REQUIRES: rdar104107922
-
 //////////////////
 // Declarations //
 //////////////////

--- a/test/SILOptimizer/moveonly_deinits.swift
+++ b/test/SILOptimizer/moveonly_deinits.swift
@@ -1,8 +1,5 @@
 // RUN: %target-swift-frontend -enable-experimental-move-only -verify -emit-sil %s
 
-// rdar://104107922
-// REQUIRES: rdar104107922
-
 class Klass {}
 
 var globalMoveOnlyStruct = MoveOnlyStruct()

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1,8 +1,5 @@
 // RUN: %target-swift-emit-sil -verify -enable-experimental-move-only %s
 
-// rdar://104107922
-// REQUIRES: rdar104107922
-
 //////////////////
 // Declarations //
 //////////////////


### PR DESCRIPTION
Specifically, I forgot that when asserts are disabled I made FieldSensitivePrunedLivenessBoundary::getNumLastUsersAndDeadDefs() assert to make sure that callers were sure to place it within a #ifndef block since it is rather expensive and not actual used in the computation. Funnily, I forgot to end.

rdar://104107922
