### PR TITLE
Disable rdar74087329-debug-scope-trampoline-blocks.swift

### DIFF
--- a/test/AutoDiff/compiler_crashers_fixed/rdar74087329-debug-scope-trampoline-blocks.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/rdar74087329-debug-scope-trampoline-blocks.swift
@@ -1,5 +1,6 @@
 // RUN: %target-build-swift %s
 // RUN: %target-swift-frontend -c -g -Xllvm -verify-di-holes=true %s
+// REQUIRES: issue63107
 
 // rdar://74087329 (DI verification failure with trampoline blocks in VJP)
 


### PR DESCRIPTION
This is failing on the Linux bots. Let’s disable the test for now. rdar://104426107 tracks the actual failure.
___

Cherry pick of #63133.