### PR TITLE
[cxx-interop] Disallow `import std`, require `import CxxStdlib`

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1908,6 +1908,8 @@ StringRef ModuleDecl::ReverseFullNameIterator::operator*() const {
 
   auto *clangModule =
       static_cast<const clang::Module *>(current.get<const void *>());
+  if (!clangModule->isSubModule() && clangModule->Name == "std")
+    return "CxxStdlib";
   return clangModule->Name;
 }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2028,6 +2028,9 @@ ModuleDecl *ClangImporter::Implementation::loadModule(
   ModuleDecl *MD = nullptr;
   ASTContext &ctx = getNameImporter().getContext();
 
+  // `CxxStdlib` is the only accepted spelling of the C++ stdlib module name.
+  if (path.front().Item.is("std"))
+    return nullptr;
   if (path.front().Item == ctx.Id_CxxStdlib) {
     ImportPath::Builder adjustedPath(ctx.getIdentifier("std"), importLoc);
     adjustedPath.append(path.getSubmodulePath());
@@ -2376,7 +2379,9 @@ ClangModuleUnit *ClangImporter::Implementation::getWrapperForModule(
     return cached;
 
   // FIXME: Handle hierarchical names better.
-  Identifier name = SwiftContext.getIdentifier(underlying->Name);
+  Identifier name = underlying->Name == "std"
+                        ? SwiftContext.Id_CxxStdlib
+                        : SwiftContext.getIdentifier(underlying->Name);
   auto wrapper = ModuleDecl::create(name, SwiftContext);
   wrapper->setIsSystemModule(underlying->IsSystem);
   wrapper->setIsNonSwiftModule();
@@ -3253,7 +3258,13 @@ ImportDecl *swift::createImportDecl(ASTContext &Ctx,
   ImportPath::Builder importPath;
   auto *TmpMod = ImportedMod;
   while (TmpMod) {
-    importPath.push_back(Ctx.getIdentifier(TmpMod->Name));
+    // If this is a C++ stdlib module, print its name as `CxxStdlib` instead of
+    // `std`. `CxxStdlib` is the only accepted spelling of the C++ stdlib module
+    // name in Swift.
+    Identifier moduleName = !TmpMod->isSubModule() && TmpMod->Name == "std"
+                                ? Ctx.Id_CxxStdlib
+                                : Ctx.getIdentifier(TmpMod->Name);
+    importPath.push_back(moduleName);
     TmpMod = TmpMod->Parent;
   }
   std::reverse(importPath.begin(), importPath.end());

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -496,12 +496,9 @@ void IRGenModule::emitSourceFile(SourceFile &SF) {
         !getSwiftModule()->getName().is("Cxx") &&
         !getSwiftModule()->getName().is("CxxStdlib") &&
         !getSwiftModule()->getName().is("std")) {
-      // TODO: link with swiftCxxStdlib unconditionally once the overlay module
-      // is renamed in CMake
+      this->addLinkLibrary(LinkLibrary("swiftCxxStdlib", LibraryKind::Library));
       if (target.isOSDarwin())
-        this->addLinkLibrary(
-            LinkLibrary("swiftCxxStdlib", LibraryKind::Library));
-      this->addLinkLibrary(LinkLibrary("swiftstd", LibraryKind::Library));
+        this->addLinkLibrary(LinkLibrary("swiftstd", LibraryKind::Library));
     }
   }
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 738; // macro role attribute
+const uint16_t SWIFTMODULE_VERSION_MINOR = 739; // CxxStdlib
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -127,7 +127,7 @@ add_dependencies(sdk-overlay libstdcxx-modulemap)
 #
 # C++ Standard Library Overlay.
 #
-add_swift_target_library(swiftstd STATIC NO_LINK_NAME IS_STDLIB
+add_swift_target_library(swiftCxxStdlib STATIC NO_LINK_NAME IS_STDLIB
     std.swift
     String.swift
 

--- a/test/Interop/Cxx/stdlib/libcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/libcxx-module-interface.swift
@@ -5,8 +5,8 @@
 // This test is specific to libc++ and therefore only runs on Darwin platforms.
 // REQUIRES: OS=macosx || OS=ios
 
-// CHECK-STD: import std.iosfwd
-// CHECK-STD: import std.string
+// CHECK-STD: import CxxStdlib.iosfwd
+// CHECK-STD: import CxxStdlib.string
 
 // CHECK-IOSFWD: enum std {
 // CHECK-IOSFWD:   enum __1 {

--- a/test/Interop/Cxx/stdlib/msvcprt-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/msvcprt-module-interface.swift
@@ -5,8 +5,8 @@
 // This test is specific to msvcprt and therefore only runs on Windows.
 // REQUIRES: OS=windows-msvc
 
-// CHECK-STD: import std.iosfwd
-// CHECK-STD: import std.string
+// CHECK-STD: import CxxStdlib.iosfwd
+// CHECK-STD: import CxxStdlib.string
 
 // CHECK-STRING: enum std {
 // CHECK-STRING:   typealias size_t = size_t

--- a/test/Interop/Cxx/stdlib/use-std-string.swift
+++ b/test/Interop/Cxx/stdlib/use-std-string.swift
@@ -1,23 +1,14 @@
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
-// RUN: %target-run-simple-swift(-D USE_CXXSTDLIB_SPELLING -I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
 //
 // REQUIRES: executable_test
 
 import StdlibUnittest
 import StdString
 #if os(Linux)
-#if USE_CXXSTDLIB_SPELLING
 import CxxStdlib
-#else
-import std
-#endif
 // FIXME: import CxxStdlib.string once libstdc++ is split into submodules.
 #else
-#if USE_CXXSTDLIB_SPELLING
 import CxxStdlib.string
-#else
-import std.string
-#endif
 #endif
 
 var StdStringTestSuite = TestSuite("StdString")


### PR DESCRIPTION
`CxxStdlib` will now be the only accepted module name for the C++ standard library module in Swift.