### PR TITLE
Disable IRGen/temporary_allocation/codegen.swift

### DIFF
--- a/test/IRGen/temporary_allocation/codegen.swift
+++ b/test/IRGen/temporary_allocation/codegen.swift
@@ -2,6 +2,7 @@
 // RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=CHECK-LARGE-STACK-ALLOC -DWORD=i%target-ptrsize
 // RUN: %target-swift-frontend -primary-file %s -O -emit-ir | %FileCheck %s --check-prefix=CHECK-LARGE-HEAP-ALLOC -DWORD=i%target-ptrsize
 // REQUIRES: CPU=x86_64
+// REQUIRES: rdar104435186
 
 @_silgen_name("blackHole")
 func blackHole(_ value: UnsafeMutableRawPointer?) -> Void


### PR DESCRIPTION
rdar://104435186 tracks the test failure. Let's disable it for now to get CI passing.