### PR TITLE
Disable this test on watchOS

### DIFF
--- a/validation-test/Reflection/reflect_Enum_MultiPayload_degenerate.swift
+++ b/validation-test/Reflection/reflect_Enum_MultiPayload_degenerate.swift
@@ -8,6 +8,9 @@
 // REQUIRES: executable_test
 // UNSUPPORTED: use_os_stdlib
 
+// Currently broken rdar://104199930
+// UNSUPPORTED: OS=watchos
+
 import SwiftReflectionTest
 
 // Only one case has a non-zero-sized payload, so this gets


### PR DESCRIPTION
I've not been able to fill in the 32-bit expectations here yet. Until I can do that, this won't work on any 32-bit platforms.