### PR TITLE
Add default value for ExplicitModuleInfo isFramework

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -182,7 +182,7 @@ struct ExplicitModuleInfo {
   // Path of the .swiftsourceinfo file.
   std::string moduleSourceInfoPath;
   // A flag that indicates whether this module is a framework
-  bool isFramework;
+  bool isFramework = false;
   // A flag that indicates whether this module is a system module
   // Set the default to be false.
   bool isSystem = false;


### PR DESCRIPTION
If the json file doesn't contain a value for this, this was never set, which results in UB.

Unfortunately clang doesn't warn about this but gcc does https://godbolt.org/z/M3sdE73zs