### PR TITLE
[Build] Skip early swift driver/syntax

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -877,6 +877,12 @@ install-foundation
 install-libdispatch
 reconfigure
 
+# Temporarily skip so we can use release images to build Swift. This will need
+# to be removed and the bootstrap fixed in order to support macros
+# (rdar://104346187).
+skip-early-swift-driver
+skip-early-swiftsyntax
+
 [preset: buildbot_linux]
 mixin-preset=
     mixin_lightweight_assertions,no-stdlib-asserts


### PR DESCRIPTION
CI currently skips these because there is no host Swift anyway. Forcefully skip them to allow using the release docker images as the base image (with Clang and Swift pre-installed). CentOS 7 needs this as the packaged Clang (in software collections) is only Clang 5. It does technically support C++17 but has a bug causing a compiler error for most uses of `variant` (now used all throughout LLVM) - https://github.com/llvm/llvm-project/issues/32569.

This is temporary as the bootstrap should work. It currently fails when linking `libswiftDemangle.so`, which tries to link with `swiftCore`, but fails to find it. Need to look into that, but this is an easy fix that doesn't regress anything for now.