### PR TITLE
[RequirementMachine] Skip `Sendable` conformance requirements from `@preconcurrency` declarations in requirement inference.

### DIFF
--- a/lib/AST/RequirementMachine/RequirementLowering.h
+++ b/lib/AST/RequirementMachine/RequirementLowering.h
@@ -42,7 +42,8 @@ void desugarRequirement(Requirement req, SourceLoc loc,
                         SmallVectorImpl<Requirement> &result,
                         SmallVectorImpl<RequirementError> &errors);
 
-void inferRequirements(Type type, SourceLoc loc, ModuleDecl *module,
+void inferRequirements(Type type, SourceLoc loc,
+                       ModuleDecl *module, DeclContext *dc,
                        SmallVectorImpl<StructuralRequirement> &result);
 
 void realizeRequirement(DeclContext *dc,

--- a/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
+++ b/lib/AST/RequirementMachine/RequirementMachineRequests.cpp
@@ -829,7 +829,7 @@ InferredGenericSignatureRequest::evaluate(
       loc = typeLoc;
 
     inferRequirements(sourcePair.getType(), typeLoc, moduleForInference,
-                      requirements);
+                      lookupDC, requirements);
   }
 
   // Finish by adding any remaining requirements. This is used to introduce

--- a/test/Generics/requirement_inference_preconcurrency.swift
+++ b/test/Generics/requirement_inference_preconcurrency.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -typecheck %s -debug-generic-signatures 2>&1 | %FileCheck %s
+
+// CHECK-LABEL: ExistingType
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Sendable>
+@preconcurrency
+public struct ExistingType<T: Sendable> : Sendable {}
+
+// CHECK-LABEL: existingClient(arg:)
+// CHECK: Canonical generic signature: <τ_0_0>
+public func existingClient<T>(arg: T.Type) -> ExistingType<T>? { nil }
+
+public typealias Alias = ExistingType
+
+// CHECK-LABEL: existingClient2(arg:)
+// CHECK: Canonical generic signature: <τ_0_0>
+public func existingClient2<T>(arg: T.Type) -> Alias<T>? { nil }

--- a/test/Generics/requirement_inference_preconcurrency.swift
+++ b/test/Generics/requirement_inference_preconcurrency.swift
@@ -14,3 +14,8 @@ public typealias Alias = ExistingType
 // CHECK-LABEL: existingClient2(arg:)
 // CHECK: Canonical generic signature: <τ_0_0>
 public func existingClient2<T>(arg: T.Type) -> Alias<T>? { nil }
+
+// CHECK-LABEL: preconcurrencyClient(arg:)
+// CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : Sendable>
+@preconcurrency
+public func preconcurrencyClient<T>(arg: T.Type) -> ExistingType<T>? { nil }


### PR DESCRIPTION
Otherwise, new `@preconcurrency` annotations can cause breaking changes in existing clients.

Resolves: rdar://104129992