### PR TITLE
[Debug info] Dump macro expansion buffers to disk for debug info to reference

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -72,6 +72,10 @@ public:
 
   /// The custom attribute for an attached macro.
   CustomAttr *attachedMacroCustomAttr = nullptr;
+
+  /// The name of the source file on disk that was created to hold the
+  /// contents of this file for external clients.
+  StringRef onDiskBufferCopyFileName = StringRef();
 };
 
 /// This class manages and owns source buffers.
@@ -253,11 +257,18 @@ public:
   ///
   /// \p BufferID must be a valid buffer ID.
   ///
+  /// \p ForceGeneratedSourceToDisk can be set to true to create a temporary
+  /// file on-disk for buffers containing generated source code, returning the
+  /// name of that temporary file.
+  ///
   /// This should not be used for displaying information about the \e contents
   /// of a buffer, since lines within the buffer may be marked as coming from
   /// other files using \c #sourceLocation. Use #getDisplayNameForLoc instead
   /// in that case.
-  StringRef getIdentifierForBuffer(unsigned BufferID) const;
+  StringRef getIdentifierForBuffer(
+      unsigned BufferID,
+      bool ForceGeneratedSourceToDisk = false
+  ) const;
 
   /// Returns a SourceRange covering the entire specified buffer.
   ///
@@ -289,10 +300,15 @@ public:
   /// Returns a buffer identifier suitable for display to the user containing
   /// the given source location.
   ///
+  /// \p ForceGeneratedSourceToDisk can be set to true to create a temporary
+  /// file on-disk for buffers containing generated source code, returning the
+  /// name of that temporary file.
+  ///
   /// This respects \c #sourceLocation directives and the 'use-external-names'
   /// directive in VFS overlay files. If you need an on-disk file name, use
   /// #getIdentifierForBuffer instead.
-  StringRef getDisplayNameForLoc(SourceLoc Loc) const;
+  StringRef getDisplayNameForLoc(
+      SourceLoc Loc, bool ForceGeneratedSourceToDisk = false) const;
 
   /// Returns the line and column represented by the given source location.
   ///

--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -410,7 +410,12 @@ public:
   }
 
   /// Extract the line, column, and filename from \p Loc.
-  static FilenameAndLocation decode(SourceLoc Loc, const SourceManager &SM);
+  ///
+  /// \p ForceGeneratedSourceToDisk can be set to true to create a temporary
+  /// file on-disk for buffers containing generated source code, returning the
+  /// name of that temporary file.
+  static FilenameAndLocation decode(SourceLoc Loc, const SourceManager &SM,
+                                    bool ForceGeneratedSourceToDisk = false);
 
   /// Return the decoded FilenameAndLocation.
   /// In case the location has a separate AST node for debugging, this node is

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1309,6 +1309,15 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DAK_Declaration: {
+    Printer.printAttrName("@declaration");
+    Printer << "(";
+    auto Attr = cast<DeclarationAttr>(this);
+    Printer << getMacroRoleString(Attr->getMacroRole());
+    Printer << ")";
+    break;
+  }
+
   case DAK_Attached: {
     Printer.printAttrName("@attached");
     Printer << "(";

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -204,8 +204,11 @@ dumpBufferToFile(const llvm::MemoryBuffer *buffer) {
     return None;
 
   // Dump the contents there.
+  auto contents = buffer->getBuffer();
   llvm::raw_fd_ostream out(tempFD, true);
-  out << buffer->getBuffer();
+  out << contents;
+  if (contents.empty() || contents.back() != '\n')
+    out << "\n";
   out.flush();
 
   llvm::sys::DontRemoveFileOnSignal(tempFileName);

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -861,13 +861,14 @@ public:
 
   void render(raw_ostream &Out) {
     // Print the excerpt for each file.
-    unsigned lineNumberIndent =
-        std::max_element(FileExcerpts.begin(), FileExcerpts.end(),
-                         [](auto &a, auto &b) {
-                           return a.second.getPreferredLineNumberIndent() <
-                                  b.second.getPreferredLineNumberIndent();
-                         })
-            ->second.getPreferredLineNumberIndent();
+    unsigned lineNumberIndent = 0;
+    if (!FileExcerpts.empty()) {
+      lineNumberIndent = std::max_element(FileExcerpts.begin(), FileExcerpts.end(),
+          [](auto &a, auto &b) {
+            return a.second.getPreferredLineNumberIndent() <
+              b.second.getPreferredLineNumberIndent();
+          })->second.getPreferredLineNumberIndent();
+    }
     for (auto excerpt : FileExcerpts)
       excerpt.second.render(lineNumberIndent, Out);
 

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2950,8 +2950,10 @@ void IRGenDebugInfoImpl::emitTypeMetadata(IRGenFunction &IGF,
 SILLocation::FilenameAndLocation
 IRGenDebugInfoImpl::decodeSourceLoc(SourceLoc SL) {
   auto &Cached = FilenameAndLocationCache[SL.getOpaquePointerValue()];
-  if (Cached.filename.empty())
-    Cached = sanitizeCodeViewFilenameAndLocation(SILLocation::decode(SL, SM));
+  if (Cached.filename.empty()) {
+    Cached = sanitizeCodeViewFilenameAndLocation(
+        SILLocation::decode(SL, SM, /*ForceGeneratedSourceToDisk=*/true));
+  }
   return Cached;
 }
 

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -111,7 +111,6 @@ static bool equalWithoutExistentialTypes(Type t1, Type t2) {
 }
 
 class IRGenDebugInfoImpl : public IRGenDebugInfo {
-  friend class IRGenDebugInfoImpl;
   const IRGenOptions &Opts;
   ClangImporter &CI;
   SourceManager &SM;
@@ -395,6 +394,7 @@ private:
     return false;
   }
 
+public:
   llvm::MDNode *createInlinedAt(const SILDebugScope *DS) {
     auto *CS = DS->InlinedCallSite;
     if (!CS)
@@ -414,6 +414,7 @@ private:
     InlinedAtCache.insert({CS, llvm::TrackingMDNodeRef(InlinedAt)});
     return InlinedAt;
   }
+private:
 
 #ifndef NDEBUG
   /// Perform a couple of sanity checks on scopes.
@@ -3104,8 +3105,8 @@ ArtificialLocation::ArtificialLocation(const SILDebugScope *DS,
   if (DI) {
     unsigned Line = 0;
     auto *Scope = DI->getOrCreateScope(DS);
-    if (static_cast<IRGenDebugInfoImpl *>(DI)->getDebugInfoFormat() ==
-        IRGenDebugInfoFormat::CodeView) {
+    auto DII = static_cast<IRGenDebugInfoImpl *>(DI);
+    if (DII->getDebugInfoFormat() == IRGenDebugInfoFormat::CodeView) {
       // In CodeView, line zero is not an artificial line location and so we
       // try to use the location of the scope.
       if (auto *LB = dyn_cast<llvm::DILexicalBlock>(Scope))
@@ -3113,7 +3114,8 @@ ArtificialLocation::ArtificialLocation(const SILDebugScope *DS,
       else if (auto *SP = dyn_cast<llvm::DISubprogram>(Scope))
         Line = SP->getLine();
     }
-    auto DL = llvm::DILocation::get(Scope->getContext(), Line, 0, Scope);
+    auto DL = llvm::DILocation::get(Scope->getContext(), Line, 0, Scope,
+                                    DII->createInlinedAt(DS));
     Builder.SetCurrentDebugLocation(DL);
   }
 }

--- a/lib/SIL/IR/SILLocation.cpp
+++ b/lib/SIL/IR/SILLocation.cpp
@@ -137,10 +137,11 @@ DeclContext *SILLocation::getAsDeclContext() const {
 }
 
 SILLocation::FilenameAndLocation SILLocation::decode(SourceLoc Loc,
-                                              const SourceManager &SM) {
+                                              const SourceManager &SM,
+                                              bool ForceGeneratedSourceToDisk) {
   FilenameAndLocation DL;
   if (Loc.isValid()) {
-    DL.filename = SM.getDisplayNameForLoc(Loc);
+    DL.filename = SM.getDisplayNameForLoc(Loc, ForceGeneratedSourceToDisk);
     std::tie(DL.line, DL.column) = SM.getPresumedLineAndColumnForLoc(Loc);
   }
   return DL;

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5824,6 +5824,11 @@ public:
       // map and go on.
       auto *DS = SI.getDebugScope();
       assert(DS && "Each instruction should have a debug scope");
+
+      // We don't support this verification on inlined call sites yet.
+      if (DS->InlinedCallSite)
+        continue;
+
       if (!AlreadySeenScopes.count(DS)) {
         AlreadySeenScopes.insert(DS);
         LastSeenScope = DS;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5995,6 +5995,8 @@ RValue RValueEmitter::visitMacroExpansionExpr(MacroExpansionExpr *E,
                                               SGFContext C) {
   auto *rewritten = E->getRewritten();
   assert(rewritten && "Macro should have been rewritten by SILGen");
+  MacroScope scope(SGF, CleanupLocation(rewritten), E, E->getMacroName(),
+                   E->getMacroNameLoc());
   return visit(rewritten, C);
 }
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -598,31 +598,13 @@ public:
   /// \param isBindingScope If true, this is a scope for the bindings introduced
   /// by a let expression. This scope ends when the next innermost BraceStmt
   /// ends.
-  void enterDebugScope(SILLocation Loc, bool isBindingScope = false) {
-    auto *Parent = DebugScopeStack.size() ? DebugScopeStack.back().getPointer()
-                                          : F.getDebugScope();
-    auto *DS = Parent;
-    // Don't nest a scope for Loc under Parent unless it's actually different.
-    if (RegularLocation(DS->getLoc()) != RegularLocation(Loc))
-      DS = new (SGM.M) SILDebugScope(RegularLocation(Loc), &getFunction(), DS);
-    DebugScopeStack.emplace_back(DS, isBindingScope);
-    B.setCurrentDebugScope(DS);
-  }
+  void enterDebugScope(SILLocation Loc, bool isBindingScope = false,
+                       Optional<SILLocation> MacroExpansion = {},
+                       DeclNameRef MacroName = {},
+                       DeclNameLoc MacroNameLoc = {});
 
   /// Return to the previous debug scope.
-  void leaveDebugScope() {
-    // Pop any 'guard' scopes first.
-    while (DebugScopeStack.back().getInt())
-      DebugScopeStack.pop_back();
-
-    // Pop the scope we're leaving now.
-    DebugScopeStack.pop_back();
-    if (DebugScopeStack.size())
-      B.setCurrentDebugScope(DebugScopeStack.back().getPointer());
-    // Don't reset the debug scope after leaving the outermost scope,
-    // because the debugger is not expecting the function epilogue to
-    // be in a different scope.
-  }
+  void leaveDebugScope();
 
   std::unique_ptr<Initialization>
   prepareIndirectResultInit(AbstractionPattern origResultType,

--- a/lib/SILGen/Scope.h
+++ b/lib/SILGen/Scope.h
@@ -161,6 +161,22 @@ public:
   ~DebugScope() { SGF.leaveDebugScope(); }
 };
 
+/// A scope that represents a Macro expansion.
+class LLVM_LIBRARY_VISIBILITY MacroScope {
+  SILGenFunction &SGF;
+
+public:
+  explicit MacroScope(SILGenFunction &SGF, CleanupLocation loc,
+                      SILLocation MacroExpansion, DeclNameRef MacroName,
+                      DeclNameLoc MacroNameLoc)
+      : SGF(SGF) {
+    SGF.enterDebugScope(loc, false, MacroExpansion, MacroName, MacroNameLoc);
+  }
+
+  ~MacroScope() { SGF.leaveDebugScope(); }
+};
+
+
 } // end namespace Lowering
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -477,6 +477,7 @@ Expr *swift::expandMacroExpr(
   auto macroSourceFile = new (ctx) SourceFile(
       *dc->getParentModule(), SourceFileKind::MacroExpansion, macroBufferID,
       /*parsingOpts=*/{}, /*isPrimary=*/false);
+  macroSourceFile->setImports(sourceFile->getImports());
 
   // Retrieve the parsed expression from the list of top-level items.
   auto topLevelItems = macroSourceFile->getTopLevelItems();
@@ -655,6 +656,7 @@ bool swift::expandFreestandingDeclarationMacro(
   auto macroSourceFile = new (ctx) SourceFile(
       *dc->getParentModule(), SourceFileKind::MacroExpansion, macroBufferID,
       /*parsingOpts=*/{}, /*isPrimary=*/false);
+  macroSourceFile->setImports(sourceFile->getImports());
 
   PrettyStackTraceDecl debugStack(
       "type checking expanded declaration macro", med);
@@ -832,6 +834,7 @@ void swift::expandAccessors(
   auto macroSourceFile = new (ctx) SourceFile(
       *dc->getParentModule(), SourceFileKind::MacroExpansion, macroBufferID,
       /*parsingOpts=*/{}, /*isPrimary=*/false);
+  macroSourceFile->setImports(declSourceFile->getImports());
 
   PrettyStackTraceDecl debugStack(
       "type checking expanded declaration macro", storage);
@@ -1014,6 +1017,7 @@ void swift::expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member,
   auto macroSourceFile = new (ctx) SourceFile(
       *dc->getParentModule(), SourceFileKind::MacroExpansion, macroBufferID,
       /*parsingOpts=*/{}, /*isPrimary=*/false);
+  macroSourceFile->setImports(declSourceFile->getImports());
 
   PrettyStackTraceDecl debugStack(
       "type checking expanded declaration macro", member);

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -11,9 +11,6 @@
 // Debug info SIL testing
 // RUN: %target-swift-frontend -emit-sil -enable-experimental-feature Macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser -o - -g | %FileCheck --check-prefix CHECK-SIL %s
 
-// Debug info IR testing
-// RUN: %target-swift-frontend -emit-ir -enable-experimental-feature Macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser -o - -g | %FileCheck --check-prefix CHECK-IR %s
-
 // Execution testing
 // RUN: %target-build-swift -g -enable-experimental-feature Macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser
 // RUN: %target-run %t/main | %FileCheck %s
@@ -63,11 +60,6 @@ func testStringify(a: Int, b: Int) {
   _ = (b, b2, s2, s3)
 }
 
-// CHECK-IR-LABEL: define swiftcc void @"$s9MacroUser5OuterV4testyyF"
-// CHECK-IR: call {{.*}}@"$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC"{{.*}}!dbg ![[STRING_LITERAL_DI:[0-9]+]]
-// CHECK-IR: ![[STRING_LITERAL_DI]] = !DILocation(line: 1, column: 13, scope: ![[EXPANSION_FILE_SCOPE_DI:[0-9]+]])
-// CHECK-IR: ![[EXPANSION_FILE_SCOPE_DI]] = !DILexicalBlockFile(scope: ![[EXPANSION_FILE_SCOPE_SCOPE_DI:[0-9]+]], file: ![[EXPANSION_FILE_DI:[0-9]+]], discriminator: 0)
-// CHECK-IR: ![[EXPANSION_FILE_DI]] = !DIFile(filename: "{{.*}}swift-generated-sources{{.*}}.swift", directory: "")
 public struct Outer {
   var value: Int = 0
   public func test() {

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -101,6 +101,16 @@ func testAddBlocker(a: Int, b: Int, c: Int, oa: OnlyAdds) {
   // CHECK-DIAGS-NEXT: Original source range: {{.*}}macro_expand.swift:[[@LINE-6]]:7 - {{.*}}macro_expand.swift:[[@LINE-6]]:27
   // CHECK-DIAGS-NEXT: oa - oa
   // CHECK-DIAGS-NEXT: END CONTENTS OF FILE
+
+  _ = #addBlocker({ // expected-note{{in expansion of macro 'addBlocker' here}}
+
+      print("hello")
+      print(oa + oa) // expected-error{{blocked an add; did you mean to subtract? (from macro 'addBlocker')}}
+      // expected-note@-1{{use '-'}}
+      print(oa + oa) // expected-error{{blocked an add; did you mean to subtract? (from macro 'addBlocker')}}
+      // expected-note@-1{{use '-'}}
+    }())
+
   // Check recursion.
   #recurse(false) // okay
   #recurse(true) // expected-note{{in expansion of macro 'recurse' here}}


### PR DESCRIPTION
When emitting debug info that references into a macro expansion, dump
the macro expansion buffer into a file on disk (in the temporary
directory) so that one can see the macro expansion buffers in the
source files themselves.

And thanks to the @adrian-prantl, emit "inline call" debug scopes for macro expansion expressions. The end result of this is that LLDB can "step into" a macro expansion expression to walk through the expanded code.

Implements a big chunk of rdar://102916513.