### PR TITLE
[IDE] Fix crash in common root search in REPL code completion

### DIFF
--- a/lib/IDE/REPLCodeCompletion.cpp
+++ b/lib/IDE/REPLCodeCompletion.cpp
@@ -315,12 +315,17 @@ StringRef REPLCompletions::getRoot() const {
 
   std::string RootStr = CookedResults[0].InsertableString.str();
   for (auto R : CookedResults) {
+    if (RootStr.empty())
+      break;
+
     if (R.NumBytesToErase != 0) {
       RootStr.resize(0);
       break;
     }
-    auto MismatchPlace = std::mismatch(RootStr.begin(), RootStr.end(),
-                                       R.InsertableString.begin());
+
+    auto MismatchPlace =
+        std::mismatch(RootStr.begin(), RootStr.end(),
+                      R.InsertableString.begin(), R.InsertableString.end());
     RootStr.resize(MismatchPlace.first - RootStr.begin());
   }
   Root = RootStr;


### PR DESCRIPTION
Specify end of second range to std::mismatch (since C++14) to avoid accidentally stepping outside that range. In this case fixes a crash when trying to find a common prefix with an empty StringRef.

Also add early return if no common root can be found.

* Fixes #62802
