### PR TITLE
WalkUtils: fix a crash when visiting mismatching types

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/WalkUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/WalkUtils.swift
@@ -569,6 +569,11 @@ extension ValueUseDefWalker {
     switch def {
     case let str as StructInst:
       if let (index, path) = path.pop(kind: .structField) {
+        if index >= str.operands.count {
+          // This can happen if there is a type mismatch, e.g. two different concrete types of an existential
+          // are visited for the same path.
+          return unmatchedPath(value: str, path: path)
+        }
         return walkUp(value: str.operands[index].value, path: path)
       } else if path.popIfMatches(.anyValueFields, index: nil) != nil {
         return walkUpAllOperands(of: str, path: path)
@@ -577,6 +582,11 @@ extension ValueUseDefWalker {
       }
     case let t as TupleInst:
       if let (index, path) = path.pop(kind: .tupleField) {
+        if index >= t.operands.count {
+          // This can happen if there is a type mismatch, e.g. two different concrete types of an existential
+          // are visited for the same path.
+          return unmatchedPath(value: t, path: path)
+        }
         return walkUp(value: t.operands[index].value, path: path)
       } else if path.popIfMatches(.anyValueFields, index: nil) != nil {
         return walkUpAllOperands(of: t, path: path)

--- a/test/SILOptimizer/escape_info.sil
+++ b/test/SILOptimizer/escape_info.sil
@@ -41,7 +41,14 @@ final class F {
   @_hasStorage var y: Y
 }
 
-struct TwoF {
+protocol P {
+}
+
+struct OneF : P {
+  @_hasStorage var a: F
+}
+
+struct TwoF : P {
   @_hasStorage var a: F
   @_hasStorage var b: F
 }
@@ -1341,5 +1348,32 @@ bb0:
   store %11 to %10 : $*X
   %13 = tuple ()
   return %13 : $()
+}
+
+// CHECK-LABEL: Escape information for test_mismatching_existential_types:
+// CHECK:  -    :   %1 = alloc_ref $Y
+// CHECK: End function test_mismatching_existential_types
+sil @test_mismatching_existential_types : $@convention(thin) (@guaranteed F) -> () {
+bb0(%0 : $F):
+  %1 = alloc_ref $Y
+
+  %2 = alloc_stack $any P
+
+  %3 = init_existential_addr %2 : $*any P, $OneF
+  %4 = struct $OneF (%0 : $F)
+  store %4 to %3 : $*OneF
+
+  // Strictly speaking it's illegal to re-initialize an existential with a different concrete type.
+  // But for this test this doesn't matter.
+  %6 = init_existential_addr %2 : $*any P, $TwoF
+  %7 = struct_element_addr %6 : $*TwoF, #TwoF.b
+  %8 = load %7 : $*F
+
+  %9 = ref_element_addr %8 : $F, #F.y
+  store %1 to %9 : $*Y
+
+  dealloc_stack %2 : $*any P
+  %r = tuple()
+  return %r : $()
 }
 


### PR DESCRIPTION
The path components may not be related to the current value in case mismatching types are visited, e.g. different concrete types of an existential. This can lead to mismatching operand numbers for struct and tuple instructions.

rdar://104435056
