### PR TITLE
The relative_protocol_witness_table.swift test does not work on arm64e

### DIFF
--- a/test/IRGen/relative_protocol_witness_table.swift
+++ b/test/IRGen/relative_protocol_witness_table.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -enable-relative-protocol-witness-tables -module-name A -primary-file %s -emit-ir | %FileCheck %s
 
-// REQUIRES: CPU=x86_64 || CPU=arm64 || CPU=arm64e
+// REQUIRES: CPU=x86_64 || CPU=arm64
 
 protocol FuncOnly {
     func a()


### PR DESCRIPTION
The expected output would be different. The output for arm64e will
change once this work is finished so it makes no sense to adjust the
test for it now.