### PR TITLE
[NameLookup] Allow qualified type lookup to find types in protocols

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2391,7 +2391,7 @@ directReferencesForQualifiedTypeLookup(Evaluator &evaluator,
   {
     // Look into the base types.
     SmallVector<ValueDecl *, 4> members;
-    auto options = NL_RemoveNonVisible | NL_OnlyTypes;
+    auto options = NL_RemoveNonVisible | NL_OnlyTypes | NL_ProtocolMembers;
 
     if (allowUsableFromInline)
       options |= NL_IncludeUsableFromInline;

--- a/test/decl/var/property_wrapper_protocol_typealias.swift
+++ b/test/decl/var/property_wrapper_protocol_typealias.swift
@@ -1,0 +1,35 @@
+// RUN: %target-typecheck-verify-swift
+
+@propertyWrapper public struct Wrapper<ValueType> {
+  public var wrappedValue: ValueType
+  public init(wrappedValue: ValueType) {}
+}
+
+public protocol Proto {
+  typealias TA = Wrapper
+}
+
+public class SubToProto : Proto {
+  @TA // Ok
+  var a = 12
+
+  @SubToProto.TA // Ok - typealias is declared in the protocol `Proto`
+  var b = 12
+
+  @Proto.TA // Ok
+  var c = 12
+
+  func foo(a: SubToProto.TA<Int>, b: Proto.TA<Int>) {} // Ok
+}
+
+public class BaseClass {
+  typealias TA = Wrapper
+}
+
+public class SubClass : BaseClass {
+  @SubClass.TA // Ok
+  var b = 12
+
+  @BaseClass.TA // Ok
+  var c = 12
+}


### PR DESCRIPTION
Doing so allows lookup to find typealiases declared in protocols that type conforms to.

Resolves: rdar://102107225

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
