### PR TITLE
Clarify the implicit-constructors support in C++ interop status document.

### DIFF
--- a/docs/CppInteroperability/CppInteroperabilityStatus.md
+++ b/docs/CppInteroperability/CppInteroperabilityStatus.md
@@ -83,7 +83,7 @@ This status table describes which of the following C++ language features can be 
 | Virtual Member Functions                    | No |
 | Operators                                   | Yes, with some known issues    |
 | Subscript Operators                         | Yes |
-| Constructors                                | Yes. That includes implicit constructors    |
+| Constructors                                | Yes. Note that implicit constructors are imported into Swift but have to be called explicitly |
 | Destructor                                  | Yes. C++ destructors are invoked automatically when the value is no longer used in Swift |
 | Copy constructor / copy assignment operator | Yes. Swift invokes the underlying copy constructor when copying a C++ value |
 | Move constructor / move assignment operator | No    |


### PR DESCRIPTION
Clarify that the implicit-constructors have to be invoked explicitly when called from Swift in the C++ interop status document.