### PR TITLE
IRGen: Thin function values may carry a precise pointer to function type rather than i8*

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -153,6 +153,21 @@ namespace {
       return new ThinFuncTypeInfo(formalType, storageType, size, align,
                                   spareBits);
     }
+    void initialize(IRGenFunction &IGF, Explosion &src, Address addr,
+                    bool isOutlined) const override {
+      auto *fn = src.claimNext();
+
+      // We might be presented with a value of the more precise pointer to
+      // function type "void(*)*" rather than the generic "i8*". Downcast to the
+      // more general expected type.
+      if (fn->getContext().supportsTypedPointers() &&
+          fn->getType()->getNonOpaquePointerElementType()->isFunctionTy())
+        fn = IGF.Builder.CreateBitCast(fn, getStorageType());
+
+      Explosion tmp;
+      tmp.add(fn);
+      PODSingleScalarTypeInfo<ThinFuncTypeInfo,LoadableTypeInfo>::initialize(IGF, tmp, addr, isOutlined);
+    }
 
     TypeLayoutEntry *buildTypeLayoutEntry(IRGenModule &IGM,
                                           SILType T) const override {

--- a/test/IRGen/Inputs/fnptr.h
+++ b/test/IRGen/Inputs/fnptr.h
@@ -1,0 +1,10 @@
+#ifndef fnptr_h
+#define fnptr_h
+
+#include <stddef.h>
+
+typedef struct {
+    void (* _Nonnull fnptr)(size_t *);
+} Container;
+
+#endif

--- a/test/IRGen/fnptr.swift
+++ b/test/IRGen/fnptr.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -import-objc-header %S/Inputs/fnptr.h -swift-version 5 -target arm64e-apple-ios13.0 %s -emit-ir -module-name test -use-clang-function-types -Xcc -Xclang -Xcc -fptrauth-function-pointer-type-discrimination | %FileCheck %s
+
+// REQUIRES: CPU=arm64e
+// REQUIRES: OS=ios
+
+// This test used to crash in IRGen because of mismatching pointer types.
+
+// CHECK: define{{.*}} swiftcc void @"$s4testAAyyF"()
+// CHECK:   store i8* bitcast {{.*}} @"$s4testAAyyFySpySiGSgcfU_To.ptrauth" to i8*), i8**
+
+public func test() {
+  var tmp = Container(
+    fnptr: { (x) in return }
+  )
+}


### PR DESCRIPTION
Tolerate the more precise pointer value when storing

rdar://103964986