### PR TITLE
[Sema] Record specify contextual type for nil in placeholder context

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2147,6 +2147,14 @@ TypeVariableBinding::fixForHole(ConstraintSystem &cs) const {
   }
 
   if (srcLocator->isLastElement<LocatorPathElt::PlaceholderType>()) {
+    // When a 'nil' has a placeholder as contextual type there is not enough
+    // information to resolve it, so let's record a specify contextual type for
+    // nil fix.
+    if (isExpr<NilLiteralExpr>(srcLocator->getAnchor())) {
+      ConstraintFix *fix = SpecifyContextualTypeForNil::create(cs, dstLocator);
+      return std::make_pair(fix, /*impact=*/(unsigned)10);
+    }
+
     ConstraintFix *fix = SpecifyTypeForPlaceholder::create(cs, srcLocator);
     return std::make_pair(fix, defaultImpact);
   }

--- a/test/Sema/placeholder_type.swift
+++ b/test/Sema/placeholder_type.swift
@@ -266,3 +266,7 @@ func deferredInit(_ c: Bool) {
     x = "Goodbye"
   }
 }
+
+// https://github.com/apple/swift/issues/63130
+let _: _  = nil // expected-error{{'nil' requires a contextual type}}
+let _: _? = nil // expected-error{{'nil' requires a contextual type}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Even in placeholder context, if the hole is on a locator that is anchored in a `nil` literal expression, let's record a `specify contextual type for nil` fix. 

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves https://github.com/apple/swift/issues/63130

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
