### PR TITLE
[5.8][Index] Resolve any shadowed references to the decl they shadow

### DIFF
--- a/test/Index/index_shadow.swift
+++ b/test/Index/index_shadow.swift
@@ -1,0 +1,60 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-ide-test -print-indexed-symbols -source-filename %s --include-locals | %FileCheck %s
+
+// The index will output references to the shadowed-declaration rather than
+// the one defined by the shorthand if-let or capture. It also skips
+// outputting the shadowing-definiiton since it would then have no references.
+
+struct ShadowedTest {
+  // CHECK: [[@LINE+1]]:7 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Def
+  let shadowedVar: Int?? = 1
+
+  func localShadowTest() {
+    // CHECK: [[@LINE+1]]:9 {{.*}} s:14swift_ide_test12ShadowedTestV011localShadowE0yyF0fD3VarL_SiSgvp {{.*}}Def
+    let localShadowedVar: Int? = 2
+
+    // CHECK-NOT: [[@LINE+2]]:12 {{.*}} localShadowedVar {{.*}}Def
+    // CHECK: [[@LINE+1]]:12 {{.*}} s:14swift_ide_test12ShadowedTestV011localShadowE0yyF0fD3VarL_SiSgvp {{.*}}Ref
+    if let localShadowedVar {
+      // CHECK: [[@LINE+1]]:11 {{.*}} s:14swift_ide_test12ShadowedTestV011localShadowE0yyF0fD3VarL_SiSgvp {{.*}}Ref
+      _ = localShadowedVar
+    }
+
+    // CHECK-NOT: [[@LINE+2]]:12 {{.*}} localShadowedVar {{.*}}Def
+    // CHECK: [[@LINE+1]]:12 {{.*}} s:14swift_ide_test12ShadowedTestV011localShadowE0yyF0fD3VarL_SiSgvp {{.*}}Ref
+    _ = { [localShadowedVar] in
+      // CHECK: [[@LINE+1]]:11 {{.*}} s:14swift_ide_test12ShadowedTestV011localShadowE0yyF0fD3VarL_SiSgvp {{.*}}Ref
+      _ = localShadowedVar
+    }
+  }
+
+  func shadowTest() {
+    // CHECK-NOT: [[@LINE+2]]:12 {{.*}} shadowedVar {{.*}}Def
+    // CHECK: [[@LINE+1]]:12 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
+    if let shadowedVar {
+      // CHECK: [[@LINE+1]]:11 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
+      _ = shadowedVar
+
+      // CHECK-NOT: [[@LINE+2]]:14 {{.*}} shadowedVar {{.*}}Def
+      // CHECK: [[@LINE+1]]:14 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
+      if let shadowedVar {
+        // CHECK: [[@LINE+1]]:13 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
+        _ = shadowedVar
+      }
+    }
+
+    // CHECK-NOT: [[@LINE+2]]:12 {{.*}} shadowedVar {{.*}}Def
+    // CHECK: [[@LINE+1]]:12 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
+    _ = { [shadowedVar] in
+      // CHECK: [[@LINE+1]]:11 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
+      _ = shadowedVar
+
+      // CHECK-NOT: [[@LINE+2]]:14 {{.*}} shadowedVar {{.*}}Def
+      // CHECK: [[@LINE+1]]:14 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
+      _ = { [shadowedVar] in
+        // CHECK: [[@LINE+1]]:13 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
+        _ = shadowedVar
+      }
+    }
+  }
+}


### PR DESCRIPTION
Skip the shadowing decl and instead reference the top-most shadowed decl (ie. follow any shadowed decls up the chain).

Also fix `getShorthandShadows` missing references in `MemberDeclRefExpr` by using `getReferencedDecl` instead of assuming it is a `DeclRefExpr`.

Resolves rdar://99730146, rdar://100006415, and rdar://103449038.

(cherry picked from commit 7b4ab8d0e62966d67fef08c88158cb83fb5b2b12)