### PR TITLE
[Sema] Fix for non-API level property wrappers with closure.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1087,7 +1087,7 @@ namespace {
                                 locator);
 
         auto *const calleeParamDecl = calleeParamList->get(idx);
-        if (calleeParamDecl->hasAttachedPropertyWrapper() && calleeParamDecl->hasExternalPropertyWrapper()) {
+        if (calleeParamDecl->hasExternalPropertyWrapper()) {
           // Rewrite the parameter ref to the backing wrapper initialization
           // expression.
           auto &appliedWrapper = appliedPropertyWrappers[appliedWrapperIndex++];

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1087,7 +1087,7 @@ namespace {
                                 locator);
 
         auto *const calleeParamDecl = calleeParamList->get(idx);
-        if (calleeParamDecl->hasAttachedPropertyWrapper()) {
+        if (calleeParamDecl->hasAttachedPropertyWrapper() && calleeParamDecl->hasExternalPropertyWrapper()) {
           // Rewrite the parameter ref to the backing wrapper initialization
           // expression.
           auto &appliedWrapper = appliedPropertyWrappers[appliedWrapperIndex++];

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4768,7 +4768,6 @@ ConstraintSystem::applyPropertyWrapperToParameter(
     return getTypeMatchSuccess();
   }
 
-  PropertyWrapperInitKind initKind;
   if (argLabel.hasDollarPrefix()) {
     Type projectionType = computeProjectedValueType(param, wrapperType);
     addConstraint(matchKind, paramType, projectionType, locator);
@@ -4779,15 +4778,15 @@ ConstraintSystem::applyPropertyWrapperToParameter(
       setType(param->getPropertyWrapperProjectionVar(), projectionType);
     }
 
-    initKind = PropertyWrapperInitKind::ProjectedValue;
-  } else {
+    appliedPropertyWrappers[anchor].push_back({ wrapperType, PropertyWrapperInitKind::ProjectedValue });
+  } else if (param->hasExternalPropertyWrapper()) {
     Type wrappedValueType = computeWrappedValueType(param, wrapperType);
     addConstraint(matchKind, paramType, wrappedValueType, locator);
-    initKind = PropertyWrapperInitKind::WrappedValue;
     setType(param->getPropertyWrapperWrappedValueVar(), wrappedValueType);
+
+    appliedPropertyWrappers[anchor].push_back({ wrapperType, PropertyWrapperInitKind::WrappedValue });
   }
 
-  appliedPropertyWrappers[anchor].push_back({ wrapperType, initKind });
   return getTypeMatchSuccess();
 }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4785,6 +4785,8 @@ ConstraintSystem::applyPropertyWrapperToParameter(
     setType(param->getPropertyWrapperWrappedValueVar(), wrappedValueType);
 
     appliedPropertyWrappers[anchor].push_back({ wrapperType, PropertyWrapperInitKind::WrappedValue });
+  } else {
+    return getTypeMatchFailure(locator);
   }
 
   return getTypeMatchSuccess();

--- a/test/Sema/property_wrapper_parameter.swift
+++ b/test/Sema/property_wrapper_parameter.swift
@@ -21,6 +21,15 @@ struct Wrapper<T> {
   }
 }
 
+@propertyWrapper
+struct ImplementationDetailWrapper<T> {
+  var wrappedValue: T
+
+  init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+}
+
 func globalFunc(@Wrapper arg: Int) {
   let _: Int = arg
   let _: Projection<Int> = $arg
@@ -36,6 +45,17 @@ func testGlobalFunc(value: Int, projection: Projection<Int>) {
   let _: (Projection<Int>) -> Void = globalFunc($arg:)
 }
 
+func globalFuncWithImplementationDetailWrapper(@ImplementationDetailWrapper arg: Int) {
+  let _: Int = arg
+  let _: ImplementationDetailWrapper<Int> = _arg
+}
+
+func testGlobalFuncWithImplementationDetailWrapper(value: Int) {
+  globalFuncWithImplementationDetailWrapper(arg: value)
+
+  let _: (Int) -> Void = globalFuncWithImplementationDetailWrapper
+  let _: (Int) -> Void = globalFuncWithImplementationDetailWrapper(arg:)
+}
 
 struct S<Value> {
   func method(@Wrapper arg: Value) {
@@ -44,10 +64,20 @@ struct S<Value> {
     let _: Wrapper<Value> = _arg
   }
 
+  func methodWithImplementationDetailWrapper(@ImplementationDetailWrapper arg: Value) {
+    let _: Value = arg
+    let _: ImplementationDetailWrapper<Value> = _arg
+  }
+
   static func staticMethod(@Wrapper arg: Value) {
     let _: Value = arg
     let _: Projection<Value> = $arg
     let _: Wrapper<Value> = _arg
+  }
+
+  static func staticMethodWithImplementationDetailWrapper(@ImplementationDetailWrapper arg: Value) {
+    let _: Value = arg
+    let _: ImplementationDetailWrapper<Value> = _arg
   }
 }
 
@@ -76,6 +106,22 @@ func testMethods(instance: S<String>, Metatype: S<String>.Type,
   let _: (S) -> (Projection<String>) -> Void = Metatype.method($arg:)
 }
 
+func testMethodsWithImplementationDetailWrapper(instance: S<String>, Metatype: S<String>.Type,
+                                                @ImplementationDetailWrapper value: String) {
+  Metatype.staticMethodWithImplementationDetailWrapper(arg: value)
+
+  instance.methodWithImplementationDetailWrapper(arg: value)
+
+  let _: (String) -> Void = Metatype.staticMethodWithImplementationDetailWrapper
+  let _: (String) -> Void = Metatype.staticMethodWithImplementationDetailWrapper(arg:)
+
+  let _: (String) -> Void = instance.methodWithImplementationDetailWrapper
+  let _: (String) -> Void = instance.methodWithImplementationDetailWrapper(arg:)
+
+  let _: (S) -> (String) -> Void = Metatype.methodWithImplementationDetailWrapper
+  let _: (S) -> (String) -> Void = Metatype.methodWithImplementationDetailWrapper(arg:)
+}
+
 func testClosures() {
   typealias PropertyWrapperTuple = (Wrapper<Int>, Int, Projection<Int>)
 
@@ -85,6 +131,12 @@ func testClosures() {
 
   let _: (Projection<Int>) -> PropertyWrapperTuple = { (@Wrapper $value) in
     (_value, value, $value)
+  }
+}
+
+func testClosuresWithImplementationDetailWrapper() {
+  let _: (Int) -> (ImplementationDetailWrapper<Int>, Int) = { (@ImplementationDetailWrapper value) in
+    (_value, value)
   }
 }
 


### PR DESCRIPTION
Hi,

I was using property wrappers in my code and encountered a compiler crash. Here is a code to reproduce it:

```swift
@propertyWrapper
struct Wrapper {
  let wrappedValue: Int
}

class Class {
  static func staticMethod(@Wrapper value: Int) {
  }
}

func foo() {
  let _: (Int) -> Void = Class.staticMethod
}

```

I have dumped an AST for this code and noticed that it tries to apply a property wrapper of the wrong type to an argument,
i.e. it tries to apply `Int` wrapper to an `Int` argument:

```
(argument_list implicit
  (argument
    (applied_property_wrapper_expr implicit type='Int'
      (declref_expr implicit type='Int' decl=main.(file).foo().autoclosure discriminator=0.autoclosure discriminator=1.value function_ref=unapplied))))
```

Such output produced only for non API-level property wrappers. It makes no sense for me, so I have considered it as a bug.


I have checked test files and noticed that they does not contain tests for non API-level property wrappers as parameters. 
I have added more tests to cover such wrappers and encountered few other crashes.

I have changed few conditions that affect property wrapper application. Now argument declaration seems to be in order:

```
(argument_list implicit
  (argument
    (declref_expr implicit type='Int' decl=main.(file).foo().autoclosure discriminator=0.value function_ref=unapplied)))
```

Here are my changes to fix this crash.