### PR TITLE
[Macros] Type-check attached macro arguments.

### DIFF
--- a/include/swift/AST/MacroDeclaration.h
+++ b/include/swift/AST/MacroDeclaration.h
@@ -66,17 +66,13 @@ bool macroIntroducedNameRequiresArgument(MacroIntroducedDeclNameKind kind);
 StringRef getMacroIntroducedDeclNameString(
     MacroIntroducedDeclNameKind kind);
 
-class MacroDecl;
 class CustomAttr;
 
 /// Perform lookup to determine whether the given custom attribute refers to
-/// a macro declaration, and return that macro declaration.
-///
-/// \Returns \c None if the custom attribute name does not match any macro
-/// declarations, \c nullptr if the macro reference has errors in the argument
-/// list, or a resolved macro declaration for a valid macro attribute.
-Optional<MacroDecl *>
-findMacroForCustomAttr(CustomAttr *attr, DeclContext *dc);
+/// a macro declaration, and populate the \c macros vector with the lookup
+/// results that are attached macros.
+void findMacroForCustomAttr(CustomAttr *attr, DeclContext *dc,
+                            llvm::TinyPtrVector<ValueDecl *> &macros);
 
 class MacroIntroducedDeclName {
 public:

--- a/include/swift/AST/MacroDeclaration.h
+++ b/include/swift/AST/MacroDeclaration.h
@@ -66,6 +66,13 @@ bool macroIntroducedNameRequiresArgument(MacroIntroducedDeclNameKind kind);
 StringRef getMacroIntroducedDeclNameString(
     MacroIntroducedDeclNameKind kind);
 
+class MacroDecl;
+class CustomAttr;
+
+/// Perform lookup to determine whether the given custom attribute refers to
+/// a macro declaration, and return that macro declaration.
+MacroDecl *findMacroForCustomAttr(CustomAttr *attr, DeclContext *dc);
+
 class MacroIntroducedDeclName {
 public:
   using Kind = MacroIntroducedDeclNameKind;

--- a/include/swift/AST/MacroDeclaration.h
+++ b/include/swift/AST/MacroDeclaration.h
@@ -71,7 +71,12 @@ class CustomAttr;
 
 /// Perform lookup to determine whether the given custom attribute refers to
 /// a macro declaration, and return that macro declaration.
-MacroDecl *findMacroForCustomAttr(CustomAttr *attr, DeclContext *dc);
+///
+/// \Returns \c None if the custom attribute name does not match any macro
+/// declarations, \c nullptr if the macro reference has errors in the argument
+/// list, or a resolved macro declaration for a valid macro attribute.
+Optional<MacroDecl *>
+findMacroForCustomAttr(CustomAttr *attr, DeclContext *dc);
 
 class MacroIntroducedDeclName {
 public:

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3128,6 +3128,24 @@ public:
                            evaluator::SideEffect) const;
 };
 
+/// Resolve a given custom attribute to an attached macro declaration.
+class ResolveAttachedMacroRequest
+    : public SimpleRequest<ResolveAttachedMacroRequest,
+                           MacroDecl *(CustomAttr *, DeclContext *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  MacroDecl *
+  evaluate(Evaluator &evaluator, CustomAttr *attr, DeclContext *dc) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 class ResolveTypeEraserTypeRequest
     : public SimpleRequest<ResolveTypeEraserTypeRequest,
                            Type (ProtocolDecl *, TypeEraserAttr *),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -340,6 +340,9 @@ SWIFT_REQUEST(TypeChecker, PreCheckResultBuilderRequest,
 SWIFT_REQUEST(TypeChecker, ResolveImplicitMemberRequest,
               evaluator::SideEffect(NominalTypeDecl *, ImplicitMemberAction),
               Uncached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ResolveAttachedMacroRequest,
+              MacroDecl *(CustomAttr *, DeclContext *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveTypeEraserTypeRequest,
               Type(ProtocolDecl *, TypeEraserAttr *),
               SeparatelyCached, NoLocationInfo)

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2342,15 +2342,12 @@ bool CustomAttr::isAttachedMacro(const Decl *decl) const {
   auto &ctx = decl->getASTContext();
   auto *dc = decl->getInnermostDeclContext();
 
-  auto attrDecl = evaluateOrDefault(
+  auto *macroDecl = evaluateOrDefault(
       ctx.evaluator,
-      CustomAttrDeclRequest{const_cast<CustomAttr *>(this), dc},
+      ResolveAttachedMacroRequest{const_cast<CustomAttr *>(this), dc},
       nullptr);
 
-  if (!attrDecl)
-    return false;
-
-  return attrDecl.dyn_cast<MacroDecl *>();
+  return macroDecl != nullptr;
 }
 
 DeclarationAttr::DeclarationAttr(SourceLoc atLoc, SourceRange range,

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -26,6 +26,7 @@
 #include "swift/AST/ImportCache.h"
 #include "swift/AST/Initializer.h"
 #include "swift/AST/LazyResolver.h"
+#include "swift/AST/MacroDeclaration.h"
 #include "swift/AST/ModuleNameLookup.h"
 #include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/ParameterList.h"
@@ -3038,48 +3039,6 @@ GenericParamListRequest::evaluate(Evaluator &evaluator, GenericContext *value) c
       parsedGenericParams->getWhereLoc(),
       parsedGenericParams->getRequirements(),
       parsedGenericParams->getRAngleLoc());
-}
-
-/// Perform lookup to determine whether the given custom attribute refers to
-/// a macro declaration, and return that macro declaration.
-static MacroDecl *findMacroForCustomAttr(CustomAttr *attr, DeclContext *dc) {
-  auto *identTypeRepr = dyn_cast_or_null<IdentTypeRepr>(attr->getTypeRepr());
-  if (!identTypeRepr)
-    return nullptr;
-
-  // Look for macros at module scope. They can only occur at module scope, and
-  // we need to be sure not to trigger name lookup into type contexts along
-  // the way.
-  llvm::TinyPtrVector<MacroDecl *> macros;
-  auto moduleScopeDC = dc->getModuleScopeContext();
-  ASTContext &ctx = moduleScopeDC->getASTContext();
-  UnqualifiedLookupDescriptor descriptor(
-      identTypeRepr->getNameRef(), moduleScopeDC
-  );
-  auto lookup = evaluateOrDefault(
-      ctx.evaluator, UnqualifiedLookupRequest{descriptor}, {});
-  for (const auto &result : lookup.allResults()) {
-    // Only keep attached macros, which can be spelled as custom attributes.
-    if (auto macro = dyn_cast<MacroDecl>(result.getValueDecl()))
-      if (isAttachedMacro(macro->getMacroRoles()))
-        macros.push_back(macro);
-  }
-
-  if (macros.empty())
-    return nullptr;
-
-  if (macros.size() > 1) {
-    ctx.Diags.diagnose(attr->getLocation(), diag::ambiguous_macro_reference,
-                       identTypeRepr->getNameRef().getFullName());
-
-    for (auto macro : macros) {
-      macro->diagnose(
-          diag::kind_declname_declared_here, macro->getDescriptiveKind(),
-          macro->getName());
-    }
-  }
-
-  return macros.front();
 }
 
 MacroOrNominalTypeDecl

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3048,7 +3048,7 @@ CustomAttrDeclRequest::evaluate(Evaluator &evaluator,
   // nested scopes. At this point, we're looking to see whether there are
   // any suitable macros.
   if (auto macro = findMacroForCustomAttr(attr, dc))
-    return macro;
+    return macro.getValue();
 
   // Find the types referenced by the custom attribute.
   auto &ctx = dc->getASTContext();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3590,7 +3590,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     if (auto macro = dyn_cast<MacroDecl>(decl)) {
       // Macro can only be used in an expansion. If we end up here, it's
       // because we found a macro but are missing the leading '#'.
-      if (!locator->isForMacroExpansion()) {
+      if (!(locator->isForMacroExpansion() || locator->getAnchor().isImplicit())) {
         // Record a fix here
         (void)recordFix(MacroMissingPound::create(*this, macro, locator));
       }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3558,19 +3558,20 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
   auto found = evaluateOrDefault(
     Ctx.evaluator, CustomAttrDeclRequest{attr, dc}, nullptr);
 
-  // FIXME: deal with macros.
   NominalTypeDecl *nominal = nullptr;
   if (found) {
-    // FIXME: Do full checking of the macro arguments here by turning it into
-    // a macro expansion expression (?).
-    if (found.is<MacroDecl *>())
-      return;
-
     nominal = found.dyn_cast<NominalTypeDecl *>();
   }
 
-  // Diagnose errors.
   if (!found) {
+    // Try resolving an attached macro attribute.
+    auto *macro = evaluateOrDefault(
+        Ctx.evaluator, ResolveAttachedMacroRequest{attr, dc}, nullptr);
+    if (macro || !attr->isValid())
+      return;
+
+    // Diagnose errors.
+
     auto typeRepr = attr->getTypeRepr();
 
     auto type = TypeResolution::forInterface(dc, TypeResolverContext::CustomAttr,

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1083,11 +1083,11 @@ bool swift::expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member) {
   return addedAttributes;
 }
 
-MacroDecl *
+Optional<MacroDecl *>
 swift::findMacroForCustomAttr(CustomAttr *attr, DeclContext *dc) {
   auto *identTypeRepr = dyn_cast_or_null<IdentTypeRepr>(attr->getTypeRepr());
   if (!identTypeRepr)
-    return nullptr;
+    return None;
 
   // Look for macros at module scope. They can only occur at module scope, and
   // we need to be sure not to trigger name lookup into type contexts along
@@ -1108,7 +1108,7 @@ swift::findMacroForCustomAttr(CustomAttr *attr, DeclContext *dc) {
   }
 
   if (macros.empty())
-    return nullptr;
+    return None;
 
   // Extract macro arguments from the attribute, or create an empty list.
   ArgumentList *attrArgs;
@@ -1133,5 +1133,7 @@ swift::findMacroForCustomAttr(CustomAttr *attr, DeclContext *dc) {
     if (auto *macro = dyn_cast<MacroDecl>(fn->getDecl()))
       return macro;
 
-  return dyn_cast<MacroDecl>(macros.front());
+  // If we couldn't resolve a macro decl, the attribute is invalid.
+  attr->setInvalid();
+  return nullptr;
 }

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3443,17 +3443,14 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
   // Check for an accessor macro.
   for (auto customAttrConst : storage->getSemanticAttrs().getAttributes<CustomAttr>()) {
     auto customAttr = const_cast<CustomAttr *>(customAttrConst);
-    auto decl = evaluateOrDefault(
+    auto *macro = evaluateOrDefault(
         evaluator,
-        CustomAttrDeclRequest{
+        ResolveAttachedMacroRequest{
           customAttr,
           storage->getInnermostDeclContext()
         },
         nullptr);
-    if (!decl)
-      continue;
 
-    auto macro = decl.dyn_cast<MacroDecl *>();
     if (!macro)
       continue;
 

--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -124,7 +124,9 @@ static void getTypeWrappers(NominalTypeDecl *decl,
   for (auto *attr : decl->getAttrs().getAttributes<CustomAttr>()) {
     auto *mutableAttr = const_cast<CustomAttr *>(attr);
     auto found = evaluateOrDefault(
-        ctx.evaluator, CustomAttrDeclRequest{mutableAttr, decl}, nullptr);
+        ctx.evaluator,
+        CustomAttrDeclRequest{mutableAttr, decl->getDeclContext()},
+        nullptr);
 
     if (!found)
       continue;

--- a/test/Macros/accessor_macros.swift
+++ b/test/Macros/accessor_macros.swift
@@ -17,7 +17,7 @@
 // REQUIRES: OS=macosx
 
 @attached(accessor)
-macro myPropertyWrapper: Void =
+macro myPropertyWrapper() =
     #externalMacro(module: "MacroDefinition", type: "PropertyWrapperMacro")
 
 struct Date { }

--- a/test/Macros/attached_macros_diags.swift
+++ b/test/Macros/attached_macros_diags.swift
@@ -1,21 +1,21 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature Macros -module-name MacrosTest
 
-@attached(accessor) macro m1: Void = #externalMacro(module: "MyMacros", type: "Macro1")
-// expected-warning@-1{{external macro implementation type 'MyMacros.Macro1' could not be found for macro 'm1'}}
-// expected-note@-2{{'m1' declared here}}
+@attached(accessor) macro m1() = #externalMacro(module: "MyMacros", type: "Macro1")
+// expected-warning@-1{{external macro implementation type 'MyMacros.Macro1' could not be found for macro 'm1()'}}
+// expected-note@-2{{'m1()' declared here}}
 
 @attached(accessor) macro m2(_: Int) -> Void = #externalMacro(module: "MyMacros", type: "Macro2")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro2' could not be found for macro 'm2'}}
-// expected-note@-2 2{{macro 'm2' declared here}}
+// expected-note@-2 2{{candidate has partially matching parameter list (Int)}}
 
 @attached(accessor) macro m2(_: Double) -> Void = #externalMacro(module: "MyMacros", type: "Macro2")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro2' could not be found for macro 'm2'}}
-// expected-note@-2 2{{macro 'm2' declared here}}
+// expected-note@-2 2{{candidate has partially matching parameter list (Double)}}
 
 @m1 struct X1 { }
 
 // FIXME: Redundant diagnostic
-@m2 struct X2 { } // expected-error 2{{ambiguous reference to macro 'm2'}}
+@m2 struct X2 { } // expected-error 2{{no exact matches in call to macro 'm2'}}
 
 // Check for nesting rules.
 struct SkipNestedType {
@@ -28,5 +28,5 @@ struct SkipNestedType {
 
   // We select the macro, not the property wrapper.
   @m1 var x: Int = 0
-  // expected-error@-1{{external macro implementation type 'MyMacros.Macro1' could not be found for macro 'm1'; the type must be public and provided via '-load-plugin-library'}}
+  // expected-error@-1{{external macro implementation type 'MyMacros.Macro1' could not be found for macro 'm1()'; the type must be public and provided via '-load-plugin-library'}}
 }

--- a/test/Macros/attached_macros_diags.swift
+++ b/test/Macros/attached_macros_diags.swift
@@ -7,10 +7,19 @@
 @attached(accessor) macro m2(_: Int) -> Void = #externalMacro(module: "MyMacros", type: "Macro2")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro2' could not be found for macro 'm2'}}
 // expected-note@-2{{candidate has partially matching parameter list (Int)}}
+// expected-note@-3{{candidate expects value of type 'Int' for parameter #1 (got 'String')}}
 
 @attached(accessor) macro m2(_: Double) -> Void = #externalMacro(module: "MyMacros", type: "Macro2")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro2' could not be found for macro 'm2'}}
 // expected-note@-2{{candidate has partially matching parameter list (Double)}}
+// expected-note@-3{{candidate expects value of type 'Double' for parameter #1 (got 'String')}}
+
+@attached(accessor) macro m3(message: String) -> Void = #externalMacro(module: "MyMacros", type: "Macro3")
+// expected-warning@-1{{external macro implementation type 'MyMacros.Macro3' could not be found for macro 'm3(message:)'}}
+
+@expression macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MyMacros", type: "StringifyMacro")
+// expected-warning@-1{{external macro implementation type 'MyMacros.StringifyMacro' could not be found for macro 'stringify'}}
+// expected-note@-2{{'stringify' declared here}}
 
 @m1 struct X1 { }
 
@@ -28,4 +37,30 @@ struct SkipNestedType {
   // We select the macro, not the property wrapper.
   @m1 var x: Int = 0
   // expected-error@-1{{external macro implementation type 'MyMacros.Macro1' could not be found for macro 'm1()'; the type must be public and provided via '-load-plugin-library'}}
+}
+
+struct TestMacroArgs {
+  @m1("extra arg") struct Args1 {} // expected-error{{argument passed to call that takes no arguments}}
+
+  @m2(10) struct Args2 {}
+
+  @m2(10.0) struct Args3 {}
+
+  @m2("") struct Args4 {} // expected-error{{no exact matches in call to macro 'm2'}}
+
+  @m2(Nested.x) struct Args5 {}
+
+  struct Nested {
+    static let x = 10
+
+    @m2(x) struct Args1 {}
+
+    @m2(Nested.x) struct Args2 {}
+  }
+
+  @m3(message: stringify(Nested.x).1) struct Args6 {}
+  // expected-error@-1{{expansion of macro 'stringify' requires leading '#'}}
+
+  @m3(message: #stringify(Nested.x).1) struct Args7 {}
+  // expected-error@-1{{external macro implementation type 'MyMacros.StringifyMacro' could not be found for macro 'stringify'}}
 }

--- a/test/Macros/attached_macros_diags.swift
+++ b/test/Macros/attached_macros_diags.swift
@@ -6,16 +6,15 @@
 
 @attached(accessor) macro m2(_: Int) -> Void = #externalMacro(module: "MyMacros", type: "Macro2")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro2' could not be found for macro 'm2'}}
-// expected-note@-2 2{{candidate has partially matching parameter list (Int)}}
+// expected-note@-2{{candidate has partially matching parameter list (Int)}}
 
 @attached(accessor) macro m2(_: Double) -> Void = #externalMacro(module: "MyMacros", type: "Macro2")
 // expected-warning@-1{{external macro implementation type 'MyMacros.Macro2' could not be found for macro 'm2'}}
-// expected-note@-2 2{{candidate has partially matching parameter list (Double)}}
+// expected-note@-2{{candidate has partially matching parameter list (Double)}}
 
 @m1 struct X1 { }
 
-// FIXME: Redundant diagnostic
-@m2 struct X2 { } // expected-error 2{{no exact matches in call to macro 'm2'}}
+@m2 struct X2 { } // expected-error{{no exact matches in call to macro 'm2'}}
 
 // Check for nesting rules.
 struct SkipNestedType {

--- a/test/Serialization/Inputs/def_macros.swift
+++ b/test/Serialization/Inputs/def_macros.swift
@@ -2,7 +2,7 @@
 
 @expression macro internalStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 
-@attached(accessor) public macro myWrapper: Void = #externalMacro(module: "MacroDefinition", type: "MyWrapperMacro")
+@attached(accessor) public macro myWrapper() = #externalMacro(module: "MacroDefinition", type: "MyWrapperMacro")
 
 @attached(memberAttributes) public macro wrapAllProperties() = #externalMacro(module: "MacroDefinition", type: "WrapAllProperties")
 


### PR DESCRIPTION
To type-check macro arguments, we build an overload set from all of the attached macro declarations found in `findMacroForCustomAttr`, and then form a `CallExpr` with the overload set as the callee with the custom attribute arguments (or an implicit empty argument list). The concrete `DeclRefExpr` written back to the type-checked AST is the resolved macro decl for the given arguments.

Note that this change prevents macros from being declared using a `: Void` type annotation, because we always build a `CallExpr` to resolve the macro reference; a call to a macro declaration with type `Void` would result in the error `cannot call value of non-function type 'Void'`.