### PR TITLE
Adjustment ASTGen for removed `with<childName>` functions

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -20,7 +20,7 @@ extension ASTGenVisitor {
       let tupleElement = TupleExprElementSyntax(
         label: nil, colon: nil, expression: ExprSyntax(trailingClosure), trailingComma: nil)
 
-      return visit(node.addArgument(tupleElement).withTrailingClosure(nil))
+      return visit(node.addArgument(tupleElement).with(\.trailingClosure, nil))
     }
 
     let args = visit(node.argumentList).rawValue

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -202,7 +202,7 @@ func evaluateMacro(
         return -1
       }
 
-      macroName = parentExpansion.macro.withoutTrivia().description
+      macroName = parentExpansion.macro.text
       evaluatedSyntax = Syntax(try exprMacro.expansion(of: parentExpansion, in: &context))
 
     // Handle expression macro. The resulting decls are wrapped in a `CodeBlockItemListSyntax`.
@@ -212,7 +212,7 @@ func evaluateMacro(
         return -1
       }
       let decls = try declMacro.expansion(of: parentExpansion, in: &context)
-      macroName = parentExpansion.macro.withoutTrivia().description
+      macroName = parentExpansion.macro.text
       evaluatedSyntax = Syntax(CodeBlockItemListSyntax(
         decls.map { CodeBlockItemSyntax(item: .decl($0)) }))
 
@@ -241,7 +241,7 @@ func evaluateMacro(
     )
   }
 
-  var evaluatedSyntaxStr = evaluatedSyntax.withoutTrivia().description
+  var evaluatedSyntaxStr = evaluatedSyntax.trimmedDescription
   evaluatedSyntaxStr.withUTF8 { utf8 in
     let evaluatedResultPtr = UnsafeMutablePointer<UInt8>.allocate(capacity: utf8.count + 1)
     if let baseAddress = utf8.baseAddress {
@@ -357,7 +357,7 @@ func expandAttachedMacro(
 
       // Form a buffer of accessor declarations to return to the caller.
       evaluatedSyntaxStr = accessors.map {
-        $0.withoutTrivia().description
+        $0.trimmedDescription
       }.joined(separator: "\n\n")
 
     case (let attachedMacro as MemberAttributeMacro.Type, .MemberAttribute):
@@ -380,7 +380,7 @@ func expandAttachedMacro(
 
       // Form a buffer containing an attribute list to return to the caller.
       evaluatedSyntaxStr = attributes.map {
-        $0.withoutTrivia().description
+        $0.trimmedDescription
       }.joined(separator: " ")
 
     case (let attachedMacro as MemberDeclarationMacro.Type, .SynthesizedMembers):
@@ -392,7 +392,7 @@ func expandAttachedMacro(
 
       // Form a buffer of member declarations to return to the caller.
       evaluatedSyntaxStr = members.map {
-        $0.withoutTrivia().description
+        $0.trimmedDescription
       }.joined(separator: "\n\n")
 
     default:

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -14,7 +14,7 @@ private func replaceFirstLabel(
   }
 
   return tuple.replacing(
-    childAt: 0, with: firstElement.withLabel(.identifier(newLabel)))
+    childAt: 0, with: firstElement.with(\.label, .identifier(newLabel)))
 }
 
 public struct ColorLiteralMacro: ExpressionMacro {
@@ -26,7 +26,7 @@ public struct ColorLiteralMacro: ExpressionMacro {
     )
     let initSyntax: ExprSyntax = ".init(\(argList))"
     if let leadingTrivia = macro.leadingTrivia {
-      return initSyntax.withLeadingTrivia(leadingTrivia)
+      return initSyntax.with(\.leadingTrivia, leadingTrivia)
     }
     return initSyntax
   }
@@ -38,7 +38,7 @@ public struct FileIDMacro: ExpressionMacro {
   ) -> ExprSyntax {
     let fileLiteral: ExprSyntax = #""\#(raw: context.moduleName)/\#(raw: context.fileName)""#
     if let leadingTrivia = macro.leadingTrivia {
-      return fileLiteral.withLeadingTrivia(leadingTrivia)
+      return fileLiteral.with(\.leadingTrivia, leadingTrivia)
     }
     return fileLiteral
   }
@@ -82,7 +82,7 @@ public enum AddBlocker: ExpressionMacro {
     }
 
     // Link the folded argument back into the tree.
-    let node = node.withArgumentList(node.argumentList.replacing(childAt: 0, with: node.argumentList.first!.withExpression(foldedArgument.as(ExprSyntax.self)!)))
+    let node = node.with(\.argumentList, node.argumentList.replacing(childAt: 0, with: node.argumentList.first!.with(\.expression, foldedArgument.as(ExprSyntax.self)!)))
 
     class AddVisitor: SyntaxRewriter {
       var diagnostics: [Diagnostic] = []
@@ -102,8 +102,8 @@ public enum AddBlocker: ExpressionMacro {
                   severity: .error
                 ),
                 highlights: [
-                  Syntax(node.leftOperand.withoutTrivia()),
-                  Syntax(node.rightOperand.withoutTrivia())
+                  Syntax(node.leftOperand.with(\.leadingTrivia, []).with(\.trailingTrivia, [])),
+                  Syntax(node.rightOperand.with(\.leadingTrivia, []).with(\.trailingTrivia, []))
                 ],
                 fixIts: [
                   FixIt(
@@ -114,7 +114,7 @@ public enum AddBlocker: ExpressionMacro {
                     ),
                     changes: [
                       FixIt.Change.replace(
-                        oldNode: Syntax(binOp.operatorToken.withoutTrivia()),
+                        oldNode: Syntax(binOp.operatorToken.with(\.leadingTrivia, []).with(\.trailingTrivia, [])),
                         newNode: Syntax(
                           TokenSyntax(
                             .binaryOperator("-"),
@@ -129,9 +129,11 @@ public enum AddBlocker: ExpressionMacro {
             )
 
             return ExprSyntax(
-              node.withOperatorOperand(
+              node.with(
+                \.operatorOperand,
                 ExprSyntax(
-                  binOp.withOperatorToken(
+                  binOp.with(
+                    \.operatorToken,
                     binOp.operatorToken.withKind(.binaryOperator("-"))
                   )
                 )


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1253