### PR TITLE
Disable the test IRGen/fnptr.swift

### DIFF
--- a/test/IRGen/fnptr.swift
+++ b/test/IRGen/fnptr.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: CPU=arm64e
 // REQUIRES: OS=ios
+// XFAIL: *
 
 // This test used to crash in IRGen because of mismatching pointer types.
 


### PR DESCRIPTION
The flag is not supported by current clang.
