### PR TITLE
[BuilderTransform] Increase impact of unhandled statement fix

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -2480,8 +2480,10 @@ ConstraintSystem::matchResultBuilder(AnyFunctionRef fn, Type builderType,
         }
 
         // Record the first unhandled construct as a fix.
-        if (recordFix(SkipUnhandledConstructInResultBuilder::create(
-                *this, unsupported, builder, getConstraintLocator(locator)))) {
+        if (recordFix(
+                SkipUnhandledConstructInResultBuilder::create(
+                    *this, unsupported, builder, getConstraintLocator(locator)),
+                /*impact=*/100)) {
           return getTypeMatchFailure(locator);
         }
 

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -938,3 +938,32 @@ func test_dependent_member_with_unresolved_base_type() {
     }
   }
 }
+
+// rdar://89880662 - incorrect error about unsupported control flow statement
+func test_impact_of_control_flow_fix() {
+  @resultBuilder
+  struct BuilderA {
+    static func buildOptional<T>(_ value: T?) -> T? { return value }
+    static func buildBlock<T>(_ v1: T) -> T { v1 }
+    static func buildBlock<T, U>(_ v1: T, _ v2: U) -> (T, U) { (v1, v2) }
+  }
+
+  @resultBuilder
+  struct BuilderB {
+    static func buildBlock<T>(_ v1: T) -> T { v1 }
+    static func buildBlock<T, U>(_ v1: T, _ v2: U) -> (T, U) { (v1, v2) }
+  }
+
+  func fn<T>(@BuilderA _: () -> T) {}
+  func fn(@BuilderB _: () -> (Int?, Void)) {}
+
+  func test(_: Int) {}
+
+  fn {
+    if true {
+      0
+    }
+
+    test("") // expected-error {{cannot convert value of type 'String' to expected argument type 'Int'}}
+  }
+}


### PR DESCRIPTION
The impact should be very high because the whole body
is skipped if the builder does not support some of the operations,
otherwise the fix would interfere with result builders that do 
support operations but have syntactic issues in the body.

Resolves: rdar://89880662

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
