### PR TITLE
[Index] Handle shorthand if let/closure captures in local rename

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -161,7 +161,8 @@ protected:
     /// that names both the newly declared variable and the referenced variable
     /// by the same identifier in the source text. This includes shorthand
     /// closure captures (`[foo]`) and shorthand if captures
-    /// (`if let foo {`).
+    /// (`if let foo {`). Ordered from innermost to outermost shadows.
+    ///
     /// Decls that are shadowed using shorthand syntax should be reported as
     /// additional cursor info results.
     SmallVector<ValueDecl *> ShorthandShadowedDecls;

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -112,7 +112,7 @@ public:
   std::unique_ptr<NodeFinderResult> takeResult() { return std::move(Result); }
 
   /// Get the declarations that \p ShadowingDecl shadows using shorthand shadow
-  /// syntax.
+  /// syntax. Ordered from innermost to outermost shadows.
   SmallVector<ValueDecl *, 2>
   getShorthandShadowedDecls(ValueDecl *ShadowingDecl) {
     SmallVector<ValueDecl *, 2> Result;

--- a/lib/Refactoring/Refactoring.cpp
+++ b/lib/Refactoring/Refactoring.cpp
@@ -912,6 +912,11 @@ bool RefactoringActionLocalRename::performChange() {
   auto ValueRefCursorInfo = dyn_cast<ResolvedValueRefCursorInfo>(&CursorInfo);
   if (ValueRefCursorInfo && ValueRefCursorInfo->getValueD()) {
     ValueDecl *VD = ValueRefCursorInfo->typeOrValue();
+    // The index always uses the outermost shadow for references
+    if (!ValueRefCursorInfo->getShorthandShadowedDecls().empty()) {
+      VD = ValueRefCursorInfo->getShorthandShadowedDecls().back();
+    }
+
     SmallVector<DeclContext *, 8> Scopes;
 
     Optional<RenameRefInfo> RefInfo;

--- a/test/refactoring/rename/shorthand_shadow.swift
+++ b/test/refactoring/rename/shorthand_shadow.swift
@@ -1,0 +1,16 @@
+// Local rename starts from the `DeclContext` of the renamed `Decl`. For
+// closures that means we have no parents, so check that case specifically.
+
+func renameInClosure() {
+  // RUN: %refactor -rename -dump-text -source-filename %s -pos=%(line+2):10 -new-name=renamed | %FileCheck %s
+  // CHECK: shorthand_shadow.swift [[# @LINE+1]]:10 -> [[# @LINE+1]]:18
+  _ = { (toRename: Int?) in
+    // RUN: %refactor -rename -dump-text -source-filename %s -pos=%(line+2):12 -new-name=renamed | %FileCheck %s
+    // CHECK: shorthand_shadow.swift [[# @LINE+1]]:12 -> [[# @LINE+1]]:20
+    if let toRename {
+      // RUN: %refactor -rename -dump-text -source-filename %s -pos=%(line+2):11 -new-name=renamed | %FileCheck %s
+      // CHECK: shorthand_shadow.swift [[# @LINE+1]]:11 -> [[# @LINE+1]]:19
+      _ = toRename
+    }
+  }
+}

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1172,6 +1172,7 @@ static bool passCursorInfoForDecl(
     });
     return false;
   }
+
   if (MainInfo.VD != OrigInfo.VD && !OrigInfo.Unavailable) {
     CursorSymbolInfo &CtorSymbol = Symbols.emplace_back();
     if (auto Err =
@@ -1182,16 +1183,21 @@ static bool passCursorInfoForDecl(
       Symbols.pop_back();
     }
   }
-  for (auto D : Info.getShorthandShadowedDecls()) {
-    CursorSymbolInfo &SymbolInfo = Symbols.emplace_back();
-    DeclInfo DInfo(D, Type(), /*IsRef=*/true, /*IsDynamic=*/false,
-                   ArrayRef<NominalTypeDecl *>(), Invoc);
-    if (auto Err =
-            fillSymbolInfo(SymbolInfo, DInfo, Info.getLoc(), AddSymbolGraph,
-                           Lang, Invoc, PreviousSnaps, Allocator)) {
-      // Ignore but make sure to remove the partially-filled symbol
-      llvm::handleAllErrors(std::move(Err), [](const llvm::StringError &E) {});
-      Symbols.pop_back();
+
+  // Add in shadowed declarations if on a decl. For references just go to the
+  // actual declaration.
+  if (!Info.isRef()) {
+    for (auto D : Info.getShorthandShadowedDecls()) {
+      CursorSymbolInfo &SymbolInfo = Symbols.emplace_back();
+      DeclInfo DInfo(D, Type(), /*IsRef=*/true, /*IsDynamic=*/false,
+                     ArrayRef<NominalTypeDecl *>(), Invoc);
+      if (auto Err =
+          fillSymbolInfo(SymbolInfo, DInfo, Info.getLoc(), AddSymbolGraph,
+                         Lang, Invoc, PreviousSnaps, Allocator)) {
+        // Ignore but make sure to remove the partially-filled symbol
+        llvm::handleAllErrors(std::move(Err), [](const llvm::StringError &E) {});
+        Symbols.pop_back();
+      }
     }
   }
 


### PR DESCRIPTION
Update rename to pull the outermost-declaration so that references are correctly found.

Rather than keeping suppressed locations in the current parent, keep them for the whole index. Local rename starts the lookup from the innermost context it can, which could be a closure. In that case there is no parent decl on the stack and thus no where to store the locations to suppress. We could have a specific store for this case, but there shouldn't be that many of these and they're relatively cheap to store anyway.

Resolves rdar://104568539.