### PR TITLE
[Test] Print helpful info on malformed unit test.

### DIFF
--- a/lib/SILOptimizer/UtilityPasses/ParseTestSpecification.cpp
+++ b/lib/SILOptimizer/UtilityPasses/ParseTestSpecification.cpp
@@ -584,6 +584,46 @@ SILValue ParseArgumentSpecification::getTraceValue(unsigned index,
 
 } // anonymous namespace
 
+// Member function implementations
+
+void Argument::print(llvm::raw_ostream &os) {
+  switch (kind) {
+  case Kind::Value:
+    llvm::errs() << "value:\n";
+    cast<ValueArgument>(*this).getValue()->print(os);
+    break;
+  case Kind::Operand:
+    os << "operand:\n";
+    cast<OperandArgument>(*this).getValue()->print(os);
+    break;
+  case Kind::Instruction:
+    os << "instruction:\n";
+    cast<InstructionArgument>(*this).getValue()->print(os);
+    break;
+  case Kind::BlockArgument:
+    os << "block argument:\n";
+    cast<BlockArgumentArgument>(*this).getValue()->print(os);
+    break;
+  case Kind::Block:
+    os << "block:\n";
+    cast<BlockArgument>(*this).getValue()->print(os);
+    break;
+  case Kind::Function:
+    os << "function:\n";
+    cast<FunctionArgument>(*this).getValue()->print(os);
+    break;
+  case Kind::Bool:
+    os << "bool: " << cast<BoolArgument>(*this).getValue() << "\n";
+    break;
+  case Kind::UInt:
+    os << "uint: " << cast<UIntArgument>(*this).getValue() << "\n";
+    break;
+  case Kind::String:
+    os << "string: " << cast<StringArgument>(*this).getValue() << "\n";
+    break;
+  }
+}
+
 // API
 
 void swift::test::getTestSpecifications(

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -501,9 +501,11 @@ struct SimplifyCFGSimplifyArgument : UnitTest {
     auto *passToRun = cast<SILFunctionTransform>(createSimplifyCFG());
     passToRun->injectPassManager(getPass()->getPassManager());
     passToRun->injectFunction(getFunction());
+    auto *block = arguments.takeBlock();
+    auto index = arguments.takeUInt();
     SimplifyCFG(*getFunction(), *passToRun, /*VerifyAll=*/false,
                 /*EnableJumpThread=*/false)
-        .simplifyArgument(arguments.takeBlock(), arguments.takeUInt());
+        .simplifyArgument(block, index);
   }
 };
 

--- a/test/SILOptimizer/simplify_cfg_ossa_bbargs.sil
+++ b/test/SILOptimizer/simplify_cfg_ossa_bbargs.sil
@@ -1,8 +1,5 @@
 // RUN: %target-sil-opt -unit-test-runner %s | %FileCheck %s
 
-// Test fails in Windows CI - rdar://104021173
-// UNSUPPORTED: OS=windows-msvc
-
 import Builtin
 
 class Klass {}

--- a/test/SILOptimizer/unit_test.sil
+++ b/test/SILOptimizer/unit_test.sil
@@ -205,3 +205,19 @@ exit(%owned : @owned $C, %guaranteed_1 : @guaranteed $C, %guaranteed_2 : @guaran
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: begin running test 1 of {{[^,]+}} on test_arg_parsing_2
+// CHECK:       block:
+// CHECK:       {{bb[0-9]+}}:
+// CHECK:         {{%[^,]+}} = tuple ()
+// CHECK:         return {{%[^,]+}}
+// CHECK:       uint: 0
+// CHECK-LABEL: end running test 1 of {{[^,]+}} on test_arg_parsing_2
+sil @test_arg_parsing_2 : $() -> () {
+entry:
+  test_specification "test-specification-parsing Bu @block[1] 0"
+  br exit
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
If a unit test is malformed in the sense that the test expects an instance of one type by an instance of some other type is specified, print that out.