### PR TITLE
[Build Script] Remove 'clangd' from list of default-installed LLVM components

### DIFF
--- a/utils/build_swift/build_swift/defaults.py
+++ b/utils/build_swift/build_swift/defaults.py
@@ -119,7 +119,7 @@ def llvm_install_components():
     platforms.
     """
     components = ['llvm-ar', 'llvm-cov', 'llvm-profdata', 'IndexStore', 'clang',
-                  'clang-resource-headers', 'compiler-rt', 'clangd']
+                  'clang-resource-headers', 'compiler-rt']
     if os.sys.platform == 'darwin':
         components.extend(['dsymutil'])
     else:


### PR DESCRIPTION
Otherwise when using `--install-swift` we have been hitting:
```
ninja: error: unknown target 'install-clangd', did you mean 'install-clang'?
ERROR: command terminated with a non-zero exit status 1, aborting
``` 
for a while. 