### PR TITLE
[ModuleInterface] Don't alias the stdlib or builtin modules in alias module names mode

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -69,13 +69,16 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
     out << " -module-alias " << MODULE_DISAMBIGUATING_PREFIX <<
            moduleName << "=" << moduleName;
 
-    SmallVector<ImportedModule> imports;
-    M->getImportedModules(imports,
-                          {ModuleDecl::ImportFilterKind::Default,
+    ModuleDecl::ImportFilter filter = {ModuleDecl::ImportFilterKind::Default,
                            ModuleDecl::ImportFilterKind::Exported,
-                           ModuleDecl::ImportFilterKind::SPIOnly,
-                           ModuleDecl::ImportFilterKind::SPIAccessControl});
+                           ModuleDecl::ImportFilterKind::SPIAccessControl};
+    if (Opts.PrintPrivateInterfaceContent)
+      filter |= ModuleDecl::ImportFilterKind::SPIOnly;
+
+    SmallVector<ImportedModule> imports;
+    M->getImportedModules(imports, filter);
     M->getMissingImportedModules(imports);
+
     for (ImportedModule import: imports) {
       StringRef importedName = import.importedModule->getNameStr();
       if (AliasModuleNamesTargets.insert(importedName).second) {

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -212,7 +212,9 @@ static void diagnoseScopedImports(DiagnosticEngine &diags,
 /// source declarations.
 static void printImports(raw_ostream &out,
                          ModuleInterfaceOptions const &Opts,
-                         ModuleDecl *M) {
+                         ModuleDecl *M,
+                         const llvm::SmallSet<StringRef, 4>
+                           &AliasModuleNamesTargets) {
   // FIXME: This is very similar to what's in Serializer::writeInputBlock, but
   // it's not obvious what higher-level optimization would be factored out here.
   ModuleDecl::ImportFilter allImportFilter = {
@@ -322,7 +324,8 @@ static void printImports(raw_ostream &out,
     }
 
     out << "import ";
-    if (Opts.AliasModuleNames)
+    if (Opts.AliasModuleNames &&
+        AliasModuleNamesTargets.contains(importedModule->getName().str()))
       out << MODULE_DISAMBIGUATING_PREFIX;
     importedModule->getReverseFullModuleName().printForward(out);
 
@@ -786,7 +789,7 @@ bool swift::emitSwiftInterface(raw_ostream &out,
   llvm::SmallSet<StringRef, 4> aliasModuleNamesTargets;
   printToolVersionAndFlagsComment(out, Opts, M, aliasModuleNamesTargets);
 
-  printImports(out, Opts, M);
+  printImports(out, Opts, M, aliasModuleNamesTargets);
 
   static bool forceUseExportedModuleNameInPublicOnly =
     getenv("SWIFT_DEBUG_USE_EXPORTED_MODULE_NAME_IN_PUBLIC_ONLY");

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -81,6 +81,12 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
 
     for (ImportedModule import: imports) {
       StringRef importedName = import.importedModule->getNameStr();
+      // Skip Swift as it's commonly used in inlinable code,
+      // and Builtin as it's imported implicitly by name.
+      if (importedName == STDLIB_NAME ||
+          importedName == BUILTIN_NAME)
+        continue;
+
       if (AliasModuleNamesTargets.insert(importedName).second) {
         out << " -module-alias " << MODULE_DISAMBIGUATING_PREFIX <<
                importedName << "=" << importedName;

--- a/test/ModuleInterface/ambiguous-aliases-workaround-swiftinterface.swift
+++ b/test/ModuleInterface/ambiguous-aliases-workaround-swiftinterface.swift
@@ -1,0 +1,50 @@
+/// Test the generated swiftinterface with -alias-module-names-in-module-interface.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module \
+// RUN:     -swift-version 5 -enable-library-evolution \
+// RUN:     -o %t/PublicLib.swiftmodule %t/EmptyLib.swift
+// RUN: %target-swift-frontend -emit-module \
+// RUN:     -swift-version 5 -enable-library-evolution \
+// RUN:     -o %t/SPILib.swiftmodule %t/EmptyLib.swift
+// RUN: %target-swift-frontend -emit-module \
+// RUN:     -swift-version 5 -enable-library-evolution \
+// RUN:     -o %t/IOILib.swiftmodule %t/EmptyLib.swift
+
+// RUN: %target-swift-frontend -emit-module \
+// RUN:     -swift-version 5 -enable-library-evolution \
+// RUN:     -o %t/Client.swiftmodule \
+// RUN:     -emit-module-interface-path %t/Client.swiftinterface \
+// RUN:     -emit-private-module-interface-path %t/Client.private.swiftinterface \
+// RUN:     %t/Client.swift -I %t -experimental-spi-only-imports \
+// RUN:     -alias-module-names-in-module-interface
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I%t
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) -module-name Client -I%t
+
+// RUN: cat %t/Client.swiftinterface | %FileCheck %s -check-prefix=PUBLIC
+// RUN: cat %t/Client.private.swiftinterface | %FileCheck %s -check-prefix=PRIVATE
+
+//--- EmptyLib.swift
+
+public struct SomeType {}
+
+//--- Client.swift
+
+@_implementationOnly import IOILib
+@_spiOnly import SPILib
+import PublicLib
+
+/// Check alias declarations.
+// PUBLIC-NOT: IOILib
+// PUBLIC-NOT: SPILib
+// PUBLIC: -module-alias Module___PublicLib
+// PRIVATE-NOT: IOILib
+// PRIVATE: -module-alias Module___SPILib
+// PRIVATE: -module-alias Module___PublicLib
+
+/// Check imports.
+// PUBLIC: import Module___PublicLib
+// PRIVATE: import Module___PublicLib
+// PRIVATE: import Module___SPILib

--- a/test/ModuleInterface/ambiguous-aliases-workaround-swiftinterface.swift
+++ b/test/ModuleInterface/ambiguous-aliases-workaround-swiftinterface.swift
@@ -19,7 +19,7 @@
 // RUN:     -emit-module-interface-path %t/Client.swiftinterface \
 // RUN:     -emit-private-module-interface-path %t/Client.private.swiftinterface \
 // RUN:     %t/Client.swift -I %t -experimental-spi-only-imports \
-// RUN:     -alias-module-names-in-module-interface
+// RUN:     -alias-module-names-in-module-interface -parse-stdlib
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I%t
 // RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) -module-name Client -I%t
 
@@ -48,3 +48,10 @@ import PublicLib
 // PUBLIC: import Module___PublicLib
 // PRIVATE: import Module___PublicLib
 // PRIVATE: import Module___SPILib
+
+public func builtinUser(_ a: Builtin.Int32) {}
+
+@inlinable
+public func builtinInlinableUser() {
+    var a: Builtin.Int32
+}

--- a/test/ModuleInterface/ambiguous-aliases-workaround.swift
+++ b/test/ModuleInterface/ambiguous-aliases-workaround.swift
@@ -77,6 +77,7 @@ public struct SomeType {
     @inlinable
     public func inlinableFunc() {
         var x: AmbiguousClientName
+        var y: Swift.Int
     }
 }
 


### PR DESCRIPTION
Skip aliasing references to the stdlib and to the builtin module when enabling the workaround `-alias-module-names-in-module-interface`. Not aliasing the stdlib should allow it to be used in inlinable code, and since `Builtin` isn't usually imported explicitly, references to it shouldn't use the alias.

This PR also cleans up the workaround logic: alias `@_spiOnly` imported modules in the private swiftinterface only, and don't use the alias name in an import if the module was skipped by the newly introduced rules.

rdar://104582241