### PR TITLE
Allow Clang modules to be listed in the explicit module map.

### DIFF
--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -173,19 +173,24 @@ public:
   ~ExplicitSwiftModuleLoader();
 };
 
-/// Information about explicitly specified Swift module files.
+/// Information about explicitly specified Swift and Clang module files.
 struct ExplicitModuleInfo {
-  // Path of the .swiftmodule file.
+  // Path of the .swiftmodule file. Empty for pure Clang modules.
   std::string modulePath;
-  // Path of the .swiftmoduledoc file.
+  // Path of the .swiftmoduledoc file. Empty for pure Clang modules.
   std::string moduleDocPath;
-  // Path of the .swiftsourceinfo file.
+  // Path of the .swiftsourceinfo file. Empty for pure Clang modules.
   std::string moduleSourceInfoPath;
   // A flag that indicates whether this module is a framework
   bool isFramework = false;
   // A flag that indicates whether this module is a system module
   // Set the default to be false.
   bool isSystem = false;
+  // Path of the Clang module map file. Empty for pure Swift modules.
+  std::string clangModuleMapPath;
+  // Path of a compiled Clang explicit module file. Empty for pure Swift
+  // modules.
+  std::string clangModulePath;
 };
 
 /// Parser of explicit module maps passed into the compiler.
@@ -194,15 +199,19 @@ struct ExplicitModuleInfo {
 //      "moduleName": "A",
 //      "modulePath": "A.swiftmodule",
 //      "docPath": "A.swiftdoc",
-//      "sourceInfoPath": "A.swiftsourceinfo"
-//      "isFramework": false
+//      "sourceInfoPath": "A.swiftsourceinfo",
+//      "isFramework": false,
+//      "clangModuleMapPath": "A/module.modulemap",
+//      "clangModulePath": "A.pcm",
 //    },
 //    {
 //      "moduleName": "B",
 //      "modulePath": "B.swiftmodule",
 //      "docPath": "B.swiftdoc",
-//      "sourceInfoPath": "B.swiftsourceinfo"
-//      "isFramework": false
+//      "sourceInfoPath": "B.swiftsourceinfo",
+//      "isFramework": false,
+//      "clangModuleMapPath": "B/module.modulemap",
+//      "clangModulePath": "B.pcm",
 //    }
 //  ]
 class ExplicitModuleMapParser {
@@ -279,6 +288,10 @@ private:
         result.isFramework = parseBoolValue(val);
       } else if (key == "isSystem") {
         result.isSystem = parseBoolValue(val);
+      } else if (key == "clangModuleMapPath") {
+        result.clangModuleMapPath = val.str();
+      } else if (key == "clangModulePath") {
+        result.clangModulePath = val.str();
       } else {
         // Being forgiving for future fields.
         continue;

--- a/test/ScanDependencies/explicit-module-map-clang-and-swift.swift
+++ b/test/ScanDependencies/explicit-module-map-clang-and-swift.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/inputs
+// RUN: echo "public func anotherFuncA() {}" > %t/A.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/inputs/A.swiftmodule -emit-module-doc-path %t/inputs/A.swiftdoc -emit-module-source-info -emit-module-source-info-path %t/inputs/A.swiftsourceinfo -import-underlying-module -I%S/Inputs/CHeaders -module-cache-path %t.module-cache %t/A.swift -module-name A
+
+// RUN: echo "[{" > %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"A\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/t/inputs/A.swiftmodule\"," >> %/t/inputs/map.json
+// RUN: echo "\"docPath\": \"%/t/inputs/A.swiftdoc\"," >> %/t/inputs/map.json
+// RUN: echo "\"sourceInfoPath\": \"%/t/inputs/A.swiftsourceinfo\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false," >> %/t/inputs/map.json
+// RUN: echo "\"clangModuleMapPath\": \"%/S/Inputs/CHeaders/module.modulemap\"" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/stdlib_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/ononesupport_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"_Concurrency\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/concurrency_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"_StringProcessing\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/string_processing_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}]" >> %/t/inputs/map.json
+
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Foo.swiftmodule -module-cache-path %t.module-cache -explicit-swift-module-map-file %t/inputs/map.json %s
+
+import A
+
+func callA() {
+  funcA()
+  anotherFuncA()
+}

--- a/test/ScanDependencies/explicit-module-map-clang-explicit.swift
+++ b/test/ScanDependencies/explicit-module-map-clang-explicit.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/inputs
+
+// RUN: echo "[{" > %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"A\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false," >> %/t/inputs/map.json
+// RUN: echo "\"clangModuleMapPath\": \"%/S/Inputs/CHeaders/module.modulemap\"," >> %/t/inputs/map.json
+// RUN: echo "\"clangModulePath\": \"%t/inputs/A.pcm\"" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/stdlib_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/ononesupport_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"_Concurrency\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/concurrency_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"_StringProcessing\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/string_processing_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}]" >> %/t/inputs/map.json
+
+// RUN: %target-swift-emit-pcm -module-name A -o %t/inputs/A.pcm %S/Inputs/CHeaders/module.modulemap
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Foo.swiftmodule -module-cache-path %t.module-cache -explicit-swift-module-map-file %t/inputs/map.json %s
+
+import A
+
+func callA() {
+  funcA()
+}

--- a/test/ScanDependencies/explicit-module-map-clang-implicit.swift
+++ b/test/ScanDependencies/explicit-module-map-clang-implicit.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/inputs
+
+// RUN: echo "[{" > %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"A\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false," >> %/t/inputs/map.json
+// RUN: echo "\"clangModuleMapPath\": \"%/S/Inputs/CHeaders/module.modulemap\"" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"Swift\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/stdlib_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"SwiftOnoneSupport\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/ononesupport_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"_Concurrency\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/concurrency_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"_StringProcessing\"," >> %/t/inputs/map.json
+// RUN: echo "\"modulePath\": \"%/string_processing_module\"," >> %/t/inputs/map.json
+// RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
+// RUN: echo "}]" >> %/t/inputs/map.json
+
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Foo.swiftmodule -module-cache-path %t.module-cache -explicit-swift-module-map-file %t/inputs/map.json %s
+
+import A
+
+func callA() {
+  funcA()
+}


### PR DESCRIPTION
I'm curious what folks think of this. I'd like to unify how dependencies are passed to the compiler when using `-explicit-swift-module-map-file`. Right now, the file is only used for Swift modules, and Clang modules still have to be passed via ClangImporter flags (`-I` or `-fmodule-map-file` or `-fmodule-file`, depending on how explicit you want to be).

Beyond the simplicity of just having a single input file describing all dependency inputs, my longer term goal is that I'd like to implement some other features in terms of this JSON representation, like layering checks for Swift imports. A build system like Bazel or SPM could generate the JSON file and indicate which modules are allowed to be imported directly based on what's listed as explicit dependencies in the BUILD/Package.swift file (vs. which are there only because they're dependencies of other modules), and the compiler can enforce that directly.

The one part of this I'm not crazy about is how the explicit module loader populates the Clang flags as a side effect of loading the file; this creates an order-sensitivity that isn't obvious in the code. I can pull out the JSON parsing out of the creation of the loader but that's a bigger refactoring.