### PR TITLE
[doc] Fix SIL.rst enum initialization example

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -6022,7 +6022,7 @@ an `inject_enum_addr`_ instruction::
   entry(%0 : $*AddressOnlyEnum, %1 : $*AddressOnlyType):
     // Store the data argument for the case.
     %2 = init_enum_data_addr %0 : $*AddressOnlyEnum, #AddressOnlyEnum.HasData!enumelt
-    copy_addr [take] %2 to [init] %1 : $*AddressOnlyType
+    copy_addr [take] %1 to [init] %2 : $*AddressOnlyType
     // Inject the tag.
     inject_enum_addr %0 : $*AddressOnlyEnum, #AddressOnlyEnum.HasData!enumelt
     return


### PR DESCRIPTION
How has this documentation been backward for 9 years?