### PR TITLE
Fixes for the compat56 library

### DIFF
--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -32,6 +32,19 @@ if (SWIFT_SWIFT_PARSER)
     Sources/ASTGen/Types.swift
   )
 
+  # The compat56 library is not available in current toolchains. The stage-0
+  # compiler will build fine since the builder compiler is not aware of the 56
+  # compat library, but the stage-1 and subsequent stage compilers will fail as
+  # the stage-0 compiler is aware and will attempt to include the appropriate
+  # compatibility library. We should turn this back on once we are building the
+  # compiler correctly.
+  # Note: This is safe at the moment because the 5.6 compat library only
+  #       contains concurrency runtime fixes, and the compiler frontend does not
+  #       use concurrency at the moment.
+  target_compile_options(swiftASTGen PRIVATE
+    $<$<COMPILE_LANGUAGE:Swift>:-runtime-compatibility-version>
+    $<$<COMPILE_LANGUAGE:Swift>:none>)
+
   # Set the appropriate target triple.
   if(SWIFT_HOST_VARIANT_SDK IN_LIST SWIFT_DARWIN_PLATFORMS)
     set(DEPLOYMENT_VERSION "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_DEPLOYMENT_VERSION}")

--- a/stdlib/public/BackDeployConcurrency/Actor.cpp
+++ b/stdlib/public/BackDeployConcurrency/Actor.cpp
@@ -1228,7 +1228,7 @@ void DefaultActorImpl::giveUpThread(RunningJobInfo runner) {
     }
 
 #define LOG_STATE_TRANSITION                                                   \
-  SWIFT_TASK_DEBUG_LOG("actor %p transitioned from %zx to %zx (%s)\n", this,   \
+  SWIFT_TASK_DEBUG_LOG("actor %p transitioned from %zx to %zx (%s)", this,     \
                        oldState.Flags.getOpaqueValue(),                        \
                        newState.Flags.getOpaqueValue(), __FUNCTION__)
     LOG_STATE_TRANSITION;

--- a/stdlib/public/BackDeployConcurrency/TaskGroup.cpp
+++ b/stdlib/public/BackDeployConcurrency/TaskGroup.cpp
@@ -479,7 +479,7 @@ static void swift_taskGroup_initializeImpl(TaskGroup *group, const Metadata *T) 
 // ==== add / attachChild ------------------------------------------------------
 
 void TaskGroup::addChildTask(AsyncTask *child) {
-  SWIFT_TASK_DEBUG_LOG("attach child task = %p to group = %p", child, group);
+  SWIFT_TASK_DEBUG_LOG("attach child task = %p to group = %p", child, this);
 
   // The counterpart of this (detachChild) is performed by the group itself,
   // when it offers the completed (child) task's value to a waiting task -

--- a/stdlib/public/BackDeployConcurrency/TaskPrivate.h
+++ b/stdlib/public/BackDeployConcurrency/TaskPrivate.h
@@ -47,7 +47,7 @@ namespace swift {
 #if 0
 #define SWIFT_TASK_DEBUG_LOG(fmt, ...)                                         \
   fprintf(stderr, "[%lu] [%s:%d](%s) " fmt "\n",                               \
-          (unsigned long)Thread::current()::platformThreadId(),                \
+          (unsigned long)Thread::current().platformThreadId(),                 \
           __FILE__, __LINE__, __FUNCTION__,                                    \
           __VA_ARGS__)
 #else

--- a/stdlib/toolchain/Compatibility56/CMakeLists.txt
+++ b/stdlib/toolchain/Compatibility56/CMakeLists.txt
@@ -2,6 +2,10 @@ set(library_name "swiftCompatibility56")
 
 include_directories("include/" "${SWIFT_STDLIB_SOURCE_DIR}")
 
+set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN YES)
+
 add_compile_definitions(SWIFT_COMPATIBILITY56)
 add_swift_target_library("${library_name}" STATIC
   Overrides.cpp

--- a/stdlib/toolchain/Compatibility56/Concurrency/Task.cpp
+++ b/stdlib/toolchain/Compatibility56/Concurrency/Task.cpp
@@ -15,6 +15,7 @@ FutureFragment::Status AsyncTask::waitFuture(AsyncTask *waitingTask,
                                              TaskContinuationFunction *resumeFn,
                                              AsyncContext *callerContext,
                                              OpaqueValue *result) {
+  SWIFT_TASK_DEBUG_LOG("compat 56 task task %p", this);
   using Status = FutureFragment::Status;
   using WaitQueueItem = FutureFragment::WaitQueueItem;
 

--- a/stdlib/toolchain/Compatibility56/Overrides.cpp
+++ b/stdlib/toolchain/Compatibility56/Overrides.cpp
@@ -39,6 +39,7 @@ struct ConcurrencyOverrideSection {
 
 #undef OVERRIDE
 
+__attribute__((visibility("hidden")))
 ConcurrencyOverrideSection Swift56ConcurrencyOverrides
 __attribute__((used, section("__DATA,__s_async_hook"))) = {
   .version = 0,
@@ -46,6 +47,7 @@ __attribute__((used, section("__DATA,__s_async_hook"))) = {
   .task_future_wait_throwing = swift56override_swift_task_future_wait_throwing,
 };
 
+__attribute__((visibility("hidden")))
 RuntimeOverrideSection Swift56RuntimeOverrides
 __attribute__((used, section("__DATA,__swift56_hooks"))) = {
   .version = 0,

--- a/stdlib/toolchain/Compatibility56/include/Concurrency/Error.h
+++ b/stdlib/toolchain/Compatibility56/include/Concurrency/Error.h
@@ -23,6 +23,7 @@
 
 namespace swift {
 
+__attribute__((visibility("hidden")))
 SWIFT_NORETURN void swift_Concurrency_fatalError(uint32_t flags, const char *format, ...);
 
 } // namespace swift

--- a/stdlib/toolchain/Compatibility56/include/Concurrency/Task.h
+++ b/stdlib/toolchain/Compatibility56/include/Concurrency/Task.h
@@ -307,7 +307,9 @@ public:
   ///
   /// Generally this should be done immediately after updating
   /// ActiveTask.
+  __attribute__((visibility("hidden")))
   void flagAsRunning();
+  __attribute__((visibility("hidden")))
   void flagAsRunning_slow();
 
   /// Flag that this task is now suspended.  This can update the
@@ -316,26 +318,33 @@ public:
   /// clearing ActiveTask and immediately before enqueuing the task
   /// somewhere.  TODO: record where the task is enqueued if
   /// possible.
+  __attribute__((visibility("hidden")))
   void flagAsSuspended();
+  __attribute__((visibility("hidden")))
   void flagAsSuspended_slow();
 
   /// Flag that this task is now completed. This normally does not do anything
   /// but can be used to locally insert logging.
+  __attribute__((visibility("hidden")))
   void flagAsCompleted();
 
   /// Check whether this task has been cancelled.
   /// Checking this is, of course, inherently race-prone on its own.
+  __attribute__((visibility("hidden")))
   bool isCancelled() const;
 
   // ==== Task Local Values ----------------------------------------------------
 
+  __attribute__((visibility("hidden")))
   void localValuePush(const HeapObject *key,
                       /* +1 */ OpaqueValue *value,
                       const Metadata *valueType);
 
+  __attribute__((visibility("hidden")))
   OpaqueValue *localValueGet(const HeapObject *key);
 
   /// Returns true if storage has still more bindings.
+  __attribute__((visibility("hidden")))
   bool localValuePop();
 
   // ==== Child Fragment -------------------------------------------------------
@@ -563,6 +572,7 @@ public:
   /// the future has completed and can be queried.
   /// The waiting task's async context will be intialized with the parameters if
   /// the current's task state is executing.
+  __attribute__((visibility("hidden")))
   FutureFragment::Status waitFuture(AsyncTask *waitingTask,
                                     AsyncContext *waitingTaskContext,
                                     TaskContinuationFunction *resumeFn,

--- a/stdlib/toolchain/Compatibility56/include/Concurrency/Task.h
+++ b/stdlib/toolchain/Compatibility56/include/Concurrency/Task.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_ABI_TASK_BACKDEPLOY56_H
 #define SWIFT_ABI_TASK_BACKDEPLOY56_H
 
+#include "Concurrency/TaskLocal.h"
 #include "Executor.h"
 #include "swift/ABI/HeapObject.h"
 #include "swift/ABI/Metadata.h"
@@ -26,7 +27,7 @@
 #include "VoucherShims.h"
 #include "swift/Basic/STLExtras.h"
 #include <bitset>
-#include <queue>
+#include <queue> // TODO: remove and replace with our own mpsc
 
 namespace swift {
 class AsyncTask;
@@ -275,13 +276,6 @@ public:
   void setTaskId();
   uint64_t getTaskId();
 
-  /// Get the task's resume function, for logging purposes only. This will
-  /// attempt to see through the various adapters that are sometimes used, and
-  /// failing that will return ResumeTask. The returned function pointer may
-  /// have a different signature than ResumeTask, and it's only for identifying
-  /// code associated with the task.
-  const void *getResumeFunctionForLogging();
-
   /// Given that we've already fully established the job context
   /// in the current thread, start running this task.  To establish
   /// the job context correctly, call swift_job_run or
@@ -316,13 +310,14 @@ public:
   void flagAsRunning();
   void flagAsRunning_slow();
 
-  /// Flag that this task is now suspended.
+  /// Flag that this task is now suspended.  This can update the
+  /// priority stored in the job flags if the priority hsa been
+  /// escalated.  Generally this should be done immediately after
+  /// clearing ActiveTask and immediately before enqueuing the task
+  /// somewhere.  TODO: record where the task is enqueued if
+  /// possible.
   void flagAsSuspended();
   void flagAsSuspended_slow();
-
-  /// Flag that the task is to be enqueued on the provided executor and actually
-  /// enqueue it
-  void flagAsAndEnqueueOnExecutor(ExecutorRef newExecutor);
 
   /// Flag that this task is now completed. This normally does not do anything
   /// but can be used to locally insert logging.
@@ -566,7 +561,7 @@ public:
   /// \c Executing, then \c waitingTask has been added to the
   /// wait queue and will be scheduled when the future completes. Otherwise,
   /// the future has completed and can be queried.
-  /// The waiting task's async context will be initialized with the parameters if
+  /// The waiting task's async context will be intialized with the parameters if
   /// the current's task state is executing.
   FutureFragment::Status waitFuture(AsyncTask *waitingTask,
                                     AsyncContext *waitingTaskContext,
@@ -614,6 +609,65 @@ inline void Job::runInFullyEstablishedContext() {
 
 // ==== ------------------------------------------------------------------------
 
+/// The Swift5.6 AsyncContextKind for the AsyncContext.
+/// Note that these were removed in Swift5.7
+/// (aca744b21165a20655502b563a6fa54c2c83efdf).
+/// Kinds of async context.
+enum class AsyncContextKind {
+  /// An ordinary asynchronous function.
+  Ordinary         = 0,
+
+  /// A context which can yield to its caller.
+  Yielding         = 1,
+
+  /// A continuation context.
+  Continuation     = 2,
+
+  // Other kinds are reserved for interesting special
+  // intermediate contexts.
+
+  // Kinds >= 192 are private to the implementation.
+  First_Reserved = 192
+};
+
+
+/// The Swift5.6 AsyncContextFlags for the AsyncContext.
+/// Note that these were removed in Swift5.7
+/// (aca744b21165a20655502b563a6fa54c2c83efdf).
+/// Flags for async contexts.
+class AsyncContextFlags : public FlagSet<uint32_t> {
+public:
+  enum {
+    Kind                = 0,
+    Kind_width          = 8,
+
+    CanThrow            = 8,
+
+    // Kind-specific flags should grow down from 31.
+
+    Continuation_IsExecutorSwitchForced = 31,
+  };
+
+  explicit AsyncContextFlags(uint32_t bits) : FlagSet(bits) {}
+  constexpr AsyncContextFlags() {}
+  AsyncContextFlags(AsyncContextKind kind) {
+    setKind(kind);
+  }
+
+  /// The kind of context this represents.
+  FLAGSET_DEFINE_FIELD_ACCESSORS(Kind, Kind_width, AsyncContextKind,
+                                 getKind, setKind)
+
+  /// Whether this context is permitted to throw.
+  FLAGSET_DEFINE_FLAG_ACCESSORS(CanThrow, canThrow, setCanThrow)
+
+  /// See AsyncContinuationFlags::isExecutorSwitchForced.
+  FLAGSET_DEFINE_FLAG_ACCESSORS(Continuation_IsExecutorSwitchForced,
+                                continuation_isExecutorSwitchForced,
+                                continuation_setIsExecutorSwitchForced)
+};
+
+
 /// An asynchronous context within a task.  Generally contexts are
 /// allocated using the task-local stack alloc/dealloc operations, but
 /// there's no guarantee of that, and the ABI is designed to permit
@@ -634,9 +688,19 @@ public:
   TaskContinuationFunction * __ptrauth_swift_async_context_resume
     ResumeParent;
 
-  AsyncContext(TaskContinuationFunction *resumeParent,
+  /// Flags describing this context.
+  ///
+  /// Note that this field is only 32 bits; any alignment padding
+  /// following this on 64-bit platforms can be freely used by the
+  /// function.  If the function is a yielding function, that padding
+  /// is of course interrupted by the YieldToParent field.
+  AsyncContextFlags Flags;
+
+  AsyncContext(AsyncContextFlags flags,
+               TaskContinuationFunction *resumeParent,
                AsyncContext *parent)
-    : Parent(parent), ResumeParent(resumeParent) {}
+    : Parent(parent), ResumeParent(resumeParent),
+      Flags(flags) {}
 
   AsyncContext(const AsyncContext &) = delete;
   AsyncContext &operator=(const AsyncContext &) = delete;
@@ -660,58 +724,36 @@ public:
   TaskContinuationFunction * __ptrauth_swift_async_context_yield
     YieldToParent;
 
-  YieldingAsyncContext(TaskContinuationFunction *resumeParent,
+  YieldingAsyncContext(AsyncContextFlags flags,
+                       TaskContinuationFunction *resumeParent,
                        TaskContinuationFunction *yieldToParent,
                        AsyncContext *parent)
-    : AsyncContext(resumeParent, parent),
+    : AsyncContext(flags, resumeParent, parent),
       YieldToParent(yieldToParent) {}
+
+  static bool classof(const AsyncContext *context) {
+    return context->Flags.getKind() == AsyncContextKind::Yielding;
+  }
 };
 
 /// An async context that can be resumed as a continuation.
 class ContinuationAsyncContext : public AsyncContext {
 public:
-  class FlagsType : public FlagSet<size_t> {
-  public:
-    enum {
-      CanThrow = 0,
-      IsExecutorSwitchForced = 1,
-    };
-
-    explicit FlagsType(size_t bits) : FlagSet(bits) {}
-    constexpr FlagsType() {}
-
-    /// Whether this is a throwing continuation.
-    FLAGSET_DEFINE_FLAG_ACCESSORS(CanThrow,
-                                  canThrow,
-                                  setCanThrow)
-
-    /// See AsyncContinuationFlags::isExecutorSwitchForced().
-    FLAGSET_DEFINE_FLAG_ACCESSORS(IsExecutorSwitchForced,
-                                  isExecutorSwitchForced,
-                                  setIsExecutorSwitchForced)
-  };
-
-  /// Flags for the continuation.  Not public ABI.
-  FlagsType Flags;
-
   /// An atomic object used to ensure that a continuation is not
   /// scheduled immediately during a resume if it hasn't yet been
-  /// awaited by the function which set it up.  Not public ABI.
+  /// awaited by the function which set it up.
   std::atomic<ContinuationStatus> AwaitSynchronization;
 
   /// The error result value of the continuation.
   /// This should be null-initialized when setting up the continuation.
   /// Throwing resumers must overwrite this with a non-null value.
-  /// Public ABI.
   SwiftError *ErrorResult;
 
   /// A pointer to the normal result value of the continuation.
   /// Normal resumers must initialize this before resuming.
-  /// Public ABI.
   OpaqueValue *NormalResult;
 
   /// The executor that should be resumed to.
-  /// Public ABI.
   ExecutorRef ResumeToExecutor;
 
   void setErrorResult(SwiftError *error) {
@@ -719,7 +761,11 @@ public:
   }
 
   bool isExecutorSwitchForced() const {
-    return Flags.isExecutorSwitchForced();
+    return Flags.continuation_isExecutorSwitchForced();
+  }
+
+  static bool classof(const AsyncContext *context) {
+    return context->Flags.getKind() == AsyncContextKind::Continuation;
   }
 };
 

--- a/stdlib/toolchain/Compatibility56/include/Concurrency/TaskPrivate.h
+++ b/stdlib/toolchain/Compatibility56/include/Concurrency/TaskPrivate.h
@@ -106,18 +106,23 @@ public:
 
 /// Adopt the voucher stored in `task`. This removes the voucher from the task
 /// and adopts it on the current thread.
+__attribute__((visibility("hidden")))
 void adoptTaskVoucher(AsyncTask *task);
 
 /// Restore the voucher for `task`. This un-adopts the current thread's voucher
 /// and stores it back into the task again.
+__attribute__((visibility("hidden")))
 void restoreTaskVoucher(AsyncTask *task);
 
 /// release() establishes a happens-before relation with a preceding acquire()
 /// on the same address.
+__attribute__((visibility("hidden")))
 void _swift_tsan_acquire(void *addr);
+__attribute__((visibility("hidden")))
 void _swift_tsan_release(void *addr);
 
 /// Clear the active task reference for the current thread.
+__attribute__((visibility("hidden")))
 AsyncTask *_swift_task_clearCurrent();
 
 /// The current state of a task's status records.

--- a/stdlib/toolchain/Compatibility56/include/Concurrency/TaskPrivate.h
+++ b/stdlib/toolchain/Compatibility56/include/Concurrency/TaskPrivate.h
@@ -29,7 +29,25 @@
 
 namespace swift {
 
+#if 0
+using ThreadID = decltype(pthread_self());
+
+inline ThreadID _swift_get_thread_id() {
+#if defined(_WIN32)
+  return GetCurrentThreadId();
+#else
+  return pthread_self();
+#endif
+}
+
+#define SWIFT_TASK_DEBUG_LOG(fmt, ...)                                         \
+  fprintf(stderr, "[%lu] [%s:%d](%s) " fmt "\n",                               \
+          (unsigned long)_swift_get_thread_id(),                               \
+          __FILE__, __LINE__, __FUNCTION__,                                    \
+          __VA_ARGS__)
+#else
 #define SWIFT_TASK_DEBUG_LOG(fmt ...) (void)0
+#endif
 
 /// Allocate task-local memory on behalf of a specific task,
 /// not necessarily the current one.  Generally this should only be

--- a/stdlib/toolchain/Compatibility56/include/Concurrency/TaskStatus.h
+++ b/stdlib/toolchain/Compatibility56/include/Concurrency/TaskStatus.h
@@ -159,6 +159,7 @@ public:
 };
 
 /// Return the current thread's active task reference.
+__attribute__((visibility("hidden")))
 SWIFT_CC(swift)
 AsyncTask *swift_task_getCurrent(void);
 } // namespace swift

--- a/stdlib/toolchain/Compatibility56/include/Concurrency/Threading/MutexPThread.h
+++ b/stdlib/toolchain/Compatibility56/include/Concurrency/Threading/MutexPThread.h
@@ -56,6 +56,7 @@ typedef pthread_mutex_t MutexHandle;
 ///
 /// See ConditionVariable
 struct ConditionPlatformHelper {
+  __attribute__((visibility("hidden")))
 #if SWIFT_CONDITION_SUPPORTS_CONSTEXPR
   static constexpr
 #else
@@ -65,10 +66,15 @@ struct ConditionPlatformHelper {
       staticInit() {
     return PTHREAD_COND_INITIALIZER;
   };
+  __attribute__((visibility("hidden")))
   static void init(ConditionHandle &condition);
+  __attribute__((visibility("hidden")))
   static void destroy(ConditionHandle &condition);
+  __attribute__((visibility("hidden")))
   static void notifyOne(ConditionHandle &condition);
+  __attribute__((visibility("hidden")))
   static void notifyAll(ConditionHandle &condition);
+  __attribute__((visibility("hidden")))
   static void wait(ConditionHandle &condition, ConditionMutexHandle &mutex);
 };
 
@@ -77,6 +83,7 @@ struct ConditionPlatformHelper {
 ///
 /// See Mutex
 struct MutexPlatformHelper {
+  __attribute__((visibility("hidden")))
 #if SWIFT_MUTEX_SUPPORTS_CONSTEXPR
   static constexpr
 #else
@@ -86,6 +93,7 @@ struct MutexPlatformHelper {
       conditionStaticInit() {
     return PTHREAD_MUTEX_INITIALIZER;
   };
+  __attribute__((visibility("hidden")))
 #if SWIFT_MUTEX_SUPPORTS_CONSTEXPR
   static constexpr
 #else
@@ -99,30 +107,46 @@ struct MutexPlatformHelper {
     return PTHREAD_MUTEX_INITIALIZER;
 #endif  
   }
+
+  __attribute__((visibility("hidden")))
   static void init(ConditionMutexHandle &mutex, bool checked = false);
+
+  __attribute__((visibility("hidden")))
   static void destroy(ConditionMutexHandle &mutex);
+  __attribute__((visibility("hidden")))
   static void lock(ConditionMutexHandle &mutex);
+  __attribute__((visibility("hidden")))
   static void unlock(ConditionMutexHandle &mutex);
+  __attribute__((visibility("hidden")))
   static bool try_lock(ConditionMutexHandle &mutex);
 
   // The ConditionMutexHandle versions handle everything on-Apple platforms.
 #if HAS_OS_UNFAIR_LOCK
 
+  __attribute__((visibility("hidden")))
   static void init(MutexHandle &mutex, bool checked = false);
+  __attribute__((visibility("hidden")))
   static void destroy(MutexHandle &mutex);
+  __attribute__((visibility("hidden")))
   static void lock(MutexHandle &mutex);
+  __attribute__((visibility("hidden")))
   static void unlock(MutexHandle &mutex);
+  __attribute__((visibility("hidden")))
   static bool try_lock(MutexHandle &mutex);
 
   // os_unfair_lock always checks for errors, so just call through.
+  __attribute__((visibility("hidden")))
   static void unsafeLock(MutexHandle &mutex) { lock(mutex); }
+  __attribute__((visibility("hidden")))
   static void unsafeUnlock(MutexHandle &mutex) { unlock(mutex); }
 #endif
 
   // The unsafe versions don't do error checking.
+  __attribute__((visibility("hidden")))
   static void unsafeLock(ConditionMutexHandle &mutex) {
     (void)pthread_mutex_lock(&mutex);
   }
+  __attribute__((visibility("hidden")))
   static void unsafeUnlock(ConditionMutexHandle &mutex) {
     (void)pthread_mutex_unlock(&mutex);
   }
@@ -133,6 +157,8 @@ struct MutexPlatformHelper {
 ///
 /// See ReadWriteLock
 struct ReadWriteLockPlatformHelper {
+
+  __attribute__((visibility("hidden")))
 #if SWIFT_READWRITELOCK_SUPPORTS_CONSTEXPR
   static constexpr
 #else
@@ -143,13 +169,21 @@ struct ReadWriteLockPlatformHelper {
     return PTHREAD_RWLOCK_INITIALIZER;
   };
 
+  __attribute__((visibility("hidden")))
   static void init(ReadWriteLockHandle &rwlock);
+  __attribute__((visibility("hidden")))
   static void destroy(ReadWriteLockHandle &rwlock);
+  __attribute__((visibility("hidden")))
   static void readLock(ReadWriteLockHandle &rwlock);
+  __attribute__((visibility("hidden")))
   static bool try_readLock(ReadWriteLockHandle &rwlock);
+  __attribute__((visibility("hidden")))
   static void readUnlock(ReadWriteLockHandle &rwlock);
+  __attribute__((visibility("hidden")))
   static void writeLock(ReadWriteLockHandle &rwlock);
+  __attribute__((visibility("hidden")))
   static bool try_writeLock(ReadWriteLockHandle &rwlock);
+  __attribute__((visibility("hidden")))
   static void writeUnlock(ReadWriteLockHandle &rwlock);
 };
 }

--- a/stdlib/toolchain/Compatibility56/include/Runtime/Concurrency.h
+++ b/stdlib/toolchain/Compatibility56/include/Runtime/Concurrency.h
@@ -82,6 +82,7 @@ using FutureAsyncSignature =
 /// This has no effect if the task already has at least the given priority.
 /// Returns the priority of the task.
 SWIFT_CC(swift)
+__attribute__((visibility("hidden")))
 JobPriority swift_task_escalateBackdeploy56(AsyncTask *task,
                                             JobPriority newPriority);
 } // namespace swift

--- a/test/Concurrency/Runtime/continuation_validation.swift
+++ b/test/Concurrency/Runtime/continuation_validation.swift
@@ -7,6 +7,9 @@
 // REQUIRES: concurrency
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
+
+// Commit afc5116ef0de added support for the error check
+// UNSUPPORTED: back_deploy_concurrency
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: freestanding
 


### PR DESCRIPTION
This patch contains a myriad of small but important fixes for the compat56 library.

- Break link requirement on compiler-rt:

This is a static library, and therefore was not triggering linking against compiler-rt. This resulted in a failure for binaries to launch since they were missing the `_platformIsAtLeast` symbol required for the availability check in `swift_voucher_needs_adopt`. To avoid the availability check for the underlying `voucher_needs_adopt` function, I just use `dlsym` to see if we have the symbol available. Since this library has to run on systems that both do and don't have it, this check must be done dynamically, so this seemed like the most reasonable way to detect whether we have it or not without needing the platform version check.

This way builds do not need to be changed to run with the compat library.

- `AsyncContext` layout change:

I apparently copied the Task.h from the wrong place, and we had a small ABI change in `AsyncContext` between 5.6/5.5/backdeploy and the 5.7 runtime that I copied the header from. `AsyncContext` lost the `AsyncContextFlags` field in 5.7, resulting in lots of carnage. I feel sorry for the person who has to do the next compat library, but for now, this should work. In debugging this, I found that the `SWIFT_TASK_DEBUG_LOG` was not working, so I fixed that up.

Additionally, I found that the `continuation_validation` test was breaking. Note that I think the only reason it was running was because I was running a very cursed system. It looks like it doesn't run on a reasonable 10.15/11.0 system, but it does when you shove the runtimes from 10.15 into macOS 13.1. The test crashes, as we expect, but doesn't have the error message because the backdeploy-concurrency runtime simply does not have the pieces. I added an `UNSUPPORTED` line for that.

rdar://104084276
rdar://104241404

- Symbol visibility:

Apparently the `-fvisibility=hidden` being passed to the compiler is not sufficient to hide all the symbols. I had some complaints about this library exposing symbols. I've gone through and labelled all of the API's that tooling was reporting was being exported that shouldn't have been. Here's to hoping that works. I'd like to avoid having to annotate every function with the hidden visibility attribute.

rdar://104237736
rdar://104237749

- Stage-0 ASTGen:

The stage-0 ASTGen build doesn't have a compatibility library to link against. I've disabled the runtime compatibility mode on the library until we have better stage tracking for the compiler as a whole. This is safe enough since ASTGen doesn't use concurrency and that's the only part with fixes being back deploy in the compat56 library.

rdar://104576917