### PR TITLE
[cxx-interop] Link with `CxxStdlib` binary if it is available

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -494,8 +494,15 @@ void IRGenModule::emitSourceFile(SourceFile &SF) {
     // Do not try to link std with itself.
     if ((target.isOSDarwin() || target.isOSLinux()) &&
         !getSwiftModule()->getName().is("Cxx") &&
-        !getSwiftModule()->getName().is("std"))
+        !getSwiftModule()->getName().is("CxxStdlib") &&
+        !getSwiftModule()->getName().is("std")) {
+      // TODO: link with swiftCxxStdlib unconditionally once the overlay module
+      // is renamed in CMake
+      if (target.isOSDarwin())
+        this->addLinkLibrary(
+            LinkLibrary("swiftCxxStdlib", LibraryKind::Library));
       this->addLinkLibrary(LinkLibrary("swiftstd", LibraryKind::Library));
+    }
   }
 
   // FIXME: It'd be better to have the driver invocation or build system that


### PR DESCRIPTION
The C++ standard library module `std` is being renamed to `CxxStdlib`, and `swiftstd` binary is being renamed to `swiftCxxStdlib`. This change teaches IRGen to link with the newly renamed binary.