### PR TITLE
[Compile Time Constant Extraction] Extract Property Wrapper Locations

### DIFF
--- a/include/swift/AST/ConstTypeInfo.h
+++ b/include/swift/AST/ConstTypeInfo.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_AST_CONST_TYPE_INFO_H
 #define SWIFT_AST_CONST_TYPE_INFO_H
 
+#include "swift/AST/Attr.h"
 #include "swift/AST/Type.h"
 #include <memory>
 #include <string>
@@ -194,7 +195,7 @@ public:
 };
 
 struct CustomAttrValue {
-  swift::Type Type;
+  swift::CustomAttr *Attr;
   std::vector<FunctionParameter> Parameters;
 };
 

--- a/test/ConstExtraction/ExtractLiterals.swift
+++ b/test/ConstExtraction/ExtractLiterals.swift
@@ -352,9 +352,11 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:            }
 // CHECK-NEXT:          ]
 // CHECK-NEXT:        },
-// CHECK-NEXT:        "attributes": [
+// CHECK-NEXT:        "propertyWrappers": [
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "type": "ExtractLiterals.Buffered",
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:            "line": 38,
 // CHECK-NEXT:            "arguments": []
 // CHECK-NEXT:          }
 // CHECK-NEXT:        ]
@@ -399,9 +401,11 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:            }
 // CHECK-NEXT:          ]
 // CHECK-NEXT:        },
-// CHECK-NEXT:        "attributes": [
+// CHECK-NEXT:        "propertyWrappers": [
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "type": "ExtractLiterals.Clamping",
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:            "line": 41,
 // CHECK-NEXT:            "arguments": [
 // CHECK-NEXT:              {
 // CHECK-NEXT:                "label": "min",
@@ -460,13 +464,17 @@ public struct PropertyWrappers : MyProto {
 // CHECK-NEXT:            }
 // CHECK-NEXT:          ]
 // CHECK-NEXT:        },
-// CHECK-NEXT:        "attributes": [
+// CHECK-NEXT:        "propertyWrappers": [
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "type": "ExtractLiterals.Buffered",
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:            "line": 44,
 // CHECK-NEXT:            "arguments": []
 // CHECK-NEXT:          },
 // CHECK-NEXT:          {
 // CHECK-NEXT:            "type": "ExtractLiterals.Clamping",
+// CHECK-NEXT:            "file": "{{.*}}test{{/|\\\\}}ConstExtraction{{/|\\\\}}ExtractLiterals.swift",
+// CHECK-NEXT:            "line": 44,
 // CHECK-NEXT:            "arguments": [
 // CHECK-NEXT:              {
 // CHECK-NEXT:                "label": "min",


### PR DESCRIPTION
- Extract property wrapper line and file locations
- Consolidate file and line functions for `VarDecl`, `NominalTypeDecl`, and `CustomAttr`.