### PR TITLE
Sema: Avoid `use @_spi instead` diagnostic on nested decls with `@_spi_available`

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -4509,12 +4509,16 @@ void AttributeChecker::checkOriginalDefinedInAttrs(
 void AttributeChecker::checkAvailableAttrs(ArrayRef<AvailableAttr *> Attrs) {
   if (Attrs.empty())
     return;
-  // If all available are spi available, we should use @_spi instead.
-  if (std::all_of(Attrs.begin(), Attrs.end(), [](AvailableAttr *AV) {
-    return AV->IsSPI;
-  })) {
-    diagnose(D->getLoc(), diag::spi_preferred_over_spi_available);
-  };
+
+  // Only diagnose top level decls since nested ones may have inherited availability.
+  if (!D->getDeclContext()->getInnermostDeclarationDeclContext()) {
+    // If all available are spi available, we should use @_spi instead.
+    if (std::all_of(Attrs.begin(), Attrs.end(), [](AvailableAttr *AV) {
+      return AV->IsSPI;
+    })) {
+      diagnose(D->getLoc(), diag::spi_preferred_over_spi_available);
+    }
+  }
 }
 
 void AttributeChecker::checkBackDeployAttrs(ArrayRef<BackDeployAttr *> Attrs) {

--- a/test/attr/spi_available.swift
+++ b/test/attr/spi_available.swift
@@ -17,3 +17,8 @@ public class SPIClass5 {}
 
 @_spi_available(mscos 10.15, *) // expected-warning {{unrecognized platform name 'mscos'; did you mean 'macOS'?}} {{17-22=macOS}}
 public class SPIClass6 {}
+
+public class ClassWithMembers {
+  @_spi_available(macOS 10.15, *)
+  public func spiFunc() {} // Ok, this declaration is not top level
+}


### PR DESCRIPTION
We should avoid suggesting use of `@_spi` instead of `@_spi_available` on member declarations since we don't check whether there are relevant `@available` attributes on the enclosing decl.

Resolves rdar://102443376