### PR TITLE
[AST] RuntimeMetadata: Allow using enums as custom runtime metadata types

### DIFF
--- a/include/swift/AST/Attr.def.gyb
+++ b/include/swift/AST/Attr.def.gyb
@@ -92,7 +92,7 @@ TYPE_ATTR(thin)
 TYPE_ATTR(thick)
 
 // Declaration Attributes and Modifers
-// To add a new entry here, update https://github.com/apple/swift-syntax
+// To add a new entry here, update `utils/gyb_syntax_support/AttributeKinds.py`
 % for attr in DECL_ATTR_KINDS + DECL_MODIFIER_KINDS + DEPRECATED_MODIFIER_KINDS:
 %   if type(attr) is ContextualDeclAttributeAlias:
 CONTEXTUAL_DECL_ATTR_ALIAS(${attr.name}, ${attr.class_name})

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 736; // add package access modifier
+const uint16_t SWIFTMODULE_VERSION_MINOR = 737; // allow @runtimeMetadata on enums
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -138,8 +138,8 @@ actor MyGlobalActor {
 // KEYWORD4-NEXT:             Keyword/None:                       globalActor[#Enum Attribute#]; name=globalActor
 // KEYWORD4-NEXT:             Keyword/None:                       preconcurrency[#Enum Attribute#]; name=preconcurrency
 // KEYWORD4-NEXT:             Keyword/None:                       typeWrapper[#Enum Attribute#]; name=typeWrapper
+// KEYWORD4-NEXT:             Keyword/None:                       runtimeMetadata[#Enum Attribute#]; name=runtimeMetadata
 // KEYWORD4-NEXT:             End completions
-
 
 @#^KEYWORD5^# struct S{}
 // KEYWORD5:                  Begin completions

--- a/test/IRGen/Inputs/runtime_attrs.swift
+++ b/test/IRGen/Inputs/runtime_attrs.swift
@@ -11,3 +11,24 @@ public struct TestAmbiguity {
 @Ignore
 public protocol Ignored {
 }
+
+@runtimeMetadata
+public enum EnumFlag<B, V> {
+case type(B.Type)
+case method((B) -> V)
+case property(KeyPath<B, V>)
+case function(() -> V)
+}
+
+extension EnumFlag {
+  public init(attachedTo: KeyPath<B, V>) { self = .property(attachedTo) }
+  public init(attachedTo: @escaping (B) -> V) { self = .method(attachedTo) }
+}
+
+extension EnumFlag where V == Void {
+  public init(attachedTo: B.Type) { self = .type(attachedTo) }
+}
+
+extension EnumFlag where B == Void {
+  public init(attachedTo: @escaping () -> V) { self = .function(attachedTo) }
+}

--- a/test/IRGen/runtime_attributes.swift
+++ b/test/IRGen/runtime_attributes.swift
@@ -134,6 +134,17 @@
 // CHECK-SAME: @"$s18runtime_attributes9OuterTypeV15outerMutatingFnSiycvpfaAA19FlagForInnerMethodsHF"
 // CHECK-SAME: section "__TEXT, __swift5_rattrs, regular"
 
+// CHECK: @"$s3RAD8EnumFlagOHa" = internal constant
+// CHECK-SAME: i32 0
+// CHECK-SAME: %swift.type_descriptor** @"got.$s3RAD8EnumFlagOMn"
+// CHECK-SAME: i32 5
+// CHECK-SAME: @"$s18runtime_attributes14globalEnumTestSi_SaySSGtSgycvpfa3RAD0D4FlagHF"
+// CHECK-SAME: @"$s18runtime_attributes12EnumTypeTestV1xSivpfa3RAD0C4FlagHF"
+// CHECK-SAME: @"$s18runtime_attributes12EnumTypeTestV8testInstyycvpfa3RAD0C4FlagHF"
+// CHECK-SAME: @"$s18runtime_attributes12EnumTypeTestV10testStaticSiycvpZfa3RAD0C4FlagHF"
+// CHECK-SAME: @"$s18runtime_attributes12EnumTypeTestAaBVmvpfa3RAD0C4FlagHF"
+// CHECK-SAME: section "__TEXT, __swift5_rattrs, regular"
+
 import RAD
 
 @runtimeMetadata
@@ -315,3 +326,18 @@ extension OuterType {
   // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes9OuterTypeV15outerMutatingFnSiycvpfaAA19FlagForInnerMethods"(%T18runtime_attributes19FlagForInnerMethodsVySiGSg* noalias nocapture sret(%T18runtime_attributes19FlagForInnerMethodsVySiGSg) %0)
   @FlagForInnerMethods mutating func outerMutatingFn() -> Int { 42 }
 }
+
+// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes14globalEnumTestSi_SaySSGtSgycvpfa3RAD0D4Flag"(%T3RAD8EnumFlagOyytSi_SaySSGtSgGSg* noalias nocapture sret(%T3RAD8EnumFlagOyytSi_SaySSGtSgGSg) %0)
+@EnumFlag func globalEnumTest() -> (Int, [String])? {
+  nil
+}
+
+@EnumFlag struct EnumTypeTest {
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes12EnumTypeTestV1xSivpfa3RAD0C4Flag"(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVSiGSg* noalias nocapture sret(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVSiGSg) %0)
+  @EnumFlag var x: Int = 42
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes12EnumTypeTestV8testInstyycvpfa3RAD0C4Flag"(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVytGSg* noalias nocapture sret(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVytGSg) %0)
+  @EnumFlag func testInst() {}
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes12EnumTypeTestV10testStaticSiycvpZfa3RAD0C4Flag"(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVmSiGSg* noalias nocapture sret(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVmSiGSg) %0)
+  @EnumFlag static func testStatic() -> Int { 42 }
+}
+// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes12EnumTypeTestAaBVmvpfa3RAD0C4Flag"(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVytGSg* noalias nocapture sret(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVytGSg) %0)

--- a/test/type/runtime_discoverable_attrs.swift
+++ b/test/type/runtime_discoverable_attrs.swift
@@ -232,3 +232,35 @@ struct TestSelfUse {
   @Flag(Self.description) var x: Int = 42
   @Flag(Self.description) func test() {}
 }
+
+
+@runtimeMetadata
+enum EnumFlag<B, V> {
+  case type(B.Type)
+  case method((B) -> V)
+  case property(KeyPath<B, V>)
+  case function(() -> V)
+}
+
+extension EnumFlag {
+  init(attachedTo: KeyPath<B, V>) { self = .property(attachedTo) }
+  init(attachedTo: @escaping (B) -> V) { self = .method(attachedTo) }
+}
+
+extension EnumFlag where V == Void {
+  init(attachedTo: B.Type) { self = .type(attachedTo) }
+}
+
+extension EnumFlag where B == Void {
+  init(attachedTo: @escaping () -> V) { self = .function(attachedTo) }
+}
+
+@EnumFlag func globalEnumTest() -> (Int, [String])? {
+  nil
+}
+
+@EnumFlag struct EnumTypeTest {
+  @EnumFlag var x: Int = 42
+  @EnumFlag func testInst() {}
+  @EnumFlag static func testStatic() -> Int { 42 }
+}

--- a/utils/gyb_syntax_support/AttributeKinds.py
+++ b/utils/gyb_syntax_support/AttributeKinds.py
@@ -718,7 +718,7 @@ DECL_ATTR_KINDS = [
                         code=138),
 
     SimpleDeclAttribute('runtimeMetadata', 'RuntimeMetadata',
-                        OnStruct, OnClass,
+                        OnStruct, OnClass, OnEnum,
                         ABIBreakingToAdd, ABIBreakingToRemove, APIBreakingToAdd, APIBreakingToRemove,  # noqa: E501
                         code=139)
 ]


### PR DESCRIPTION
`enum` allows declaring initializers which makes it suitable to act as runtime metadata type.
 I have overlooked this while working on the implementation.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
