### PR TITLE
[test] Mark moveonly tests that use the `MoveOnlyClasses` experimental feature as requiring assertions

### DIFF
--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s | %FileCheck %s
+// REQUIRES: asserts
 
 //////////////////
 // Declarations //

--- a/test/SILGen/moveonly_var.swift
+++ b/test/SILGen/moveonly_var.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s | %FileCheck %s
 // RUN: %target-swift-emit-sil -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s | %FileCheck %s
+// REQUIRES: asserts
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-sil -verify -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s
+// REQUIRES: asserts
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_lifetime.swift
+++ b/test/SILOptimizer/moveonly_lifetime.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-sil -Onone -verify -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s | %FileCheck %s
+// REQUIRES: asserts
 
 @_moveOnly
 class C {}

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-sil -verify -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s
+// REQUIRES: asserts
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-emit-sil -verify -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s
+// REQUIRES: asserts
 
 //////////////////
 // Declarations //


### PR DESCRIPTION
Experimental features are not available in non-assert compilers, so these tests fail for release compilers.

This fixes the CI failure in https://ci.swift.org/job/oss-swift_tools-R_stdlib-RD_test-simulator/2279/, caused by https://github.com/apple/swift/pull/63179.