### PR TITLE
Allow `MoveOnlyClasses` in non-assert builds

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -102,8 +102,13 @@ EXPERIMENTAL_FEATURE(StaticAssert, false)
 EXPERIMENTAL_FEATURE(VariadicGenerics, false)
 EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)
 EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures, false)
-EXPERIMENTAL_FEATURE(MoveOnly, false)
-EXPERIMENTAL_FEATURE(MoveOnlyClasses, false)
+EXPERIMENTAL_FEATURE(MoveOnly, true)
+
+// FIXME: MoveOnlyClasses is not intended to be in production,
+// but our tests currently rely on it, and we want to run those
+// tests in non-asserts builds too.
+EXPERIMENTAL_FEATURE(MoveOnlyClasses, true)
+
 EXPERIMENTAL_FEATURE(OneWayClosureParameters, false)
 EXPERIMENTAL_FEATURE(TypeWitnessSystemInference, false)
 EXPERIMENTAL_FEATURE(LayoutPrespecialization, false)

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s | %FileCheck %s
-// REQUIRES: asserts
 
 //////////////////
 // Declarations //

--- a/test/SILGen/moveonly_var.swift
+++ b/test/SILGen/moveonly_var.swift
@@ -1,6 +1,5 @@
 // RUN: %target-swift-emit-silgen -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s | %FileCheck %s
 // RUN: %target-swift-emit-sil -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s | %FileCheck %s
-// REQUIRES: asserts
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-sil -verify -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s
-// REQUIRES: asserts
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_lifetime.swift
+++ b/test/SILOptimizer/moveonly_lifetime.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-sil -Onone -verify -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s | %FileCheck %s
-// REQUIRES: asserts
 
 @_moveOnly
 class C {}

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-sil -verify -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s
-// REQUIRES: asserts
 
 //////////////////
 // Declarations //

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1,5 +1,4 @@
 // RUN: %target-swift-emit-sil -verify -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s
-// REQUIRES: asserts
 
 //////////////////
 // Declarations //


### PR DESCRIPTION
This reverts https://github.com/apple/swift/pull/63199 in favor of a solution that just makes it work in non-assert builds. It's not intended to be used by users, just so that our tests aren't disabled in such CI builds.