### PR TITLE
Cleanup PrunedLiveness interface.

### DIFF
--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1131,7 +1131,7 @@ bool AddressOwnership::areUsesWithinLifetime(
   // Compute the reference value's liveness.
   SSAPrunedLiveness liveness;
   liveness.initializeDef(root);
-  SimpleLiveRangeSummary summary = liveness.computeSimple();
+  LiveRangeSummary summary = liveness.computeSimple();
   // Conservatively ignore InnerBorrowKind::Reborrowed and
   // AddressUseKind::PointerEscape and Reborrowed. The resulting liveness at
   // least covers the known uses.

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -275,18 +275,15 @@ void PrunedLivenessBoundary::visitInsertionPoints(
 //===----------------------------------------------------------------------===//
 
 template <typename LivenessWithDefs>
-SimpleLiveRangeSummary
-PrunedLiveRange<LivenessWithDefs>::updateForDef(SILValue def) {
+LiveRangeSummary PrunedLiveRange<LivenessWithDefs>::updateForDef(SILValue def) {
   ValueSet visited(def->getFunction());
   return recursivelyUpdateForDef(def, visited, def);
 }
 
 template <typename LivenessWithDefs>
-SimpleLiveRangeSummary
-PrunedLiveRange<LivenessWithDefs>::recursivelyUpdateForDef(SILValue initialDef,
-                                                           ValueSet &visited,
-                                                           SILValue value) {
-  SimpleLiveRangeSummary summary;
+LiveRangeSummary PrunedLiveRange<LivenessWithDefs>::recursivelyUpdateForDef(
+    SILValue initialDef, ValueSet &visited, SILValue value) {
+  LiveRangeSummary summary;
 
   if (!visited.insert(value))
     return summary;
@@ -620,10 +617,10 @@ void MultiDefPrunedLiveness::findBoundariesInBlock(
          && "findBoundariesInBlock must be called on a live block");
 }
 
-SimpleLiveRangeSummary MultiDefPrunedLiveness::computeSimple() {
+LiveRangeSummary MultiDefPrunedLiveness::computeSimple() {
   assert(isInitialized() && "defs uninitialized");
 
-  SimpleLiveRangeSummary summary;
+  LiveRangeSummary summary;
   for (SILNode *defNode : defs) {
     if (auto *arg = dyn_cast<SILArgument>(defNode))
       summary.meet(updateForDef(arg));

--- a/lib/SILOptimizer/Mandatory/MoveKillsCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveKillsCopyableAddressesChecker.cpp
@@ -722,7 +722,7 @@ void ClosureArgDataflowState::classifyUses(BasicBlockSet &initBlocks,
   for (auto *user : useState.inits) {
     if (upwardScanForInit(user, useState)) {
       LLVM_DEBUG(llvm::dbgs() << "    Found init block at: " << *user);
-      livenessForConsumes.initializeDef(cast<SILNode>(user));
+      livenessForConsumes.initializeDef(user);
       initBlocks.insert(user->getParent());
     }
   }

--- a/lib/SILOptimizer/Mandatory/MoveKillsCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveKillsCopyableValuesChecker.cpp
@@ -165,10 +165,8 @@ bool CheckerLivenessInfo::compute() {
         // just mark it as extending liveness and look through it.
         liveness.updateForUse(user, /*lifetimeEnding*/ false);
         ForwardingOperand(use).visitForwardedValues([&](SILValue result) {
-          if (auto *arg = dyn_cast<SILPhiArgument>(result)) {
-            if (arg->isTerminatorResult()) {
-              return true;
-            }
+          if (SILArgument::isTerminatorResult(result)) {
+            return true;
           }
           if (result->getOwnershipKind() == OwnershipKind::Guaranteed)
             defUseWorklist.insert(result);

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -301,7 +301,7 @@ struct SSALivenessTest : UnitTest {
     SmallVector<SILBasicBlock *, 8> discoveredBlocks;
     SSAPrunedLiveness liveness(&discoveredBlocks);
     liveness.initializeDef(value);
-    SimpleLiveRangeSummary summary = liveness.computeSimple();
+    LiveRangeSummary summary = liveness.computeSimple();
     if (summary.innerBorrowKind == InnerBorrowKind::Reborrowed)
       llvm::outs() << "Incomplete liveness: Reborrowed inner scope\n";
 


### PR DESCRIPTION
In preparation for adding OwnershipLiveness.

Rename Simple LiveRangeSummary to LiveRangeSummary.

Add initializeDefNode helpers to avoid confusion about the argument type.

Add defBegin/defEnd iterators in MultiDefPrunedLiveness.
