### PR TITLE
[cxx-interop] Rename `swiftstd` to `swiftCxxStdlib` in CMake

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -496,12 +496,9 @@ void IRGenModule::emitSourceFile(SourceFile &SF) {
         !getSwiftModule()->getName().is("Cxx") &&
         !getSwiftModule()->getName().is("CxxStdlib") &&
         !getSwiftModule()->getName().is("std")) {
-      // TODO: link with swiftCxxStdlib unconditionally once the overlay module
-      // is renamed in CMake
+      this->addLinkLibrary(LinkLibrary("swiftCxxStdlib", LibraryKind::Library));
       if (target.isOSDarwin())
-        this->addLinkLibrary(
-            LinkLibrary("swiftCxxStdlib", LibraryKind::Library));
-      this->addLinkLibrary(LinkLibrary("swiftstd", LibraryKind::Library));
+        this->addLinkLibrary(LinkLibrary("swiftstd", LibraryKind::Library));
     }
   }
 

--- a/stdlib/public/Cxx/std/CMakeLists.txt
+++ b/stdlib/public/Cxx/std/CMakeLists.txt
@@ -127,7 +127,7 @@ add_dependencies(sdk-overlay libstdcxx-modulemap)
 #
 # C++ Standard Library Overlay.
 #
-add_swift_target_library(swiftstd STATIC NO_LINK_NAME IS_STDLIB
+add_swift_target_library(swiftCxxStdlib STATIC NO_LINK_NAME IS_STDLIB
     std.swift
     String.swift
 


### PR DESCRIPTION
This is the next step in the renaming process after https://github.com/apple/swift/pull/63193.

This change is being done in multiple steps due to the necessity to adjust both the compiler and the stdlib, while also keeping the CI green.