### PR TITLE
Fix DeclarationMacro deprecations

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -177,7 +177,7 @@ func evaluateMacro(
       evaluatedSyntax = Syntax(try exprMacro.expansion(of: parentExpansion, in: &context))
 
     // Handle expression macro. The resulting decls are wrapped in a `CodeBlockItemListSyntax`.
-    case let declMacro as FreestandingDeclarationMacro.Type:
+    case let declMacro as DeclarationMacro.Type:
       guard let parentExpansion = parentSyntax.as(MacroExpansionDeclSyntax.self) else {
         print("not on a macro expansion node: \(token.recursiveDescription)")
         return -1
@@ -321,7 +321,7 @@ func expandAttachedMacro(
   var evaluatedSyntaxStr: String
   do {
     switch (macro, macroRole) {
-    case (let attachedMacro as AccessorDeclarationMacro.Type, .Accessor):
+    case (let attachedMacro as AccessorMacro.Type, .Accessor):
       let accessors = try attachedMacro.expansion(
         of: customAttrNode, attachedTo: declarationNode, in: &context
       )
@@ -354,7 +354,7 @@ func expandAttachedMacro(
         $0.withoutTrivia().description
       }.joined(separator: " ")
 
-    case (let attachedMacro as MemberDeclarationMacro.Type, .SynthesizedMembers):
+    case (let attachedMacro as MemberMacro.Type, .SynthesizedMembers):
       let members = try attachedMacro.expansion(
         of: customAttrNode,
         attachedTo: declarationNode,

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -192,7 +192,7 @@ enum CustomError: Error, CustomStringConvertible {
   }
 }
 
-public struct DefineBitwidthNumberedStructsMacro: FreestandingDeclarationMacro {
+public struct DefineBitwidthNumberedStructsMacro: DeclarationMacro {
   public static func expansion(
     of node: MacroExpansionDeclSyntax,
     in context: inout MacroExpansionContext
@@ -215,7 +215,7 @@ public struct DefineBitwidthNumberedStructsMacro: FreestandingDeclarationMacro {
 
 public struct PropertyWrapperMacro {}
 
-extension PropertyWrapperMacro: AccessorDeclarationMacro, Macro {
+extension PropertyWrapperMacro: AccessorMacro, Macro {
   public static func expansion(
     of node: AttributeSyntax,
     attachedTo declaration: DeclSyntax,
@@ -305,7 +305,7 @@ extension TypeWrapperMacro: MemberAttributeMacro {
   }
 }
 
-extension TypeWrapperMacro: MemberDeclarationMacro {
+extension TypeWrapperMacro: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
     attachedTo decl: DeclSyntax,
@@ -322,7 +322,7 @@ extension TypeWrapperMacro: MemberDeclarationMacro {
   }
 }
 
-public struct AccessViaStorageMacro: AccessorDeclarationMacro {
+public struct AccessViaStorageMacro: AccessorMacro {
   public static func expansion(
     of node: AttributeSyntax,
     attachedTo declaration: DeclSyntax,
@@ -347,7 +347,7 @@ public struct AccessViaStorageMacro: AccessorDeclarationMacro {
   }
 }
 
-public struct AddMembers: MemberDeclarationMacro {
+public struct AddMembers: MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,
     attachedTo decl: DeclSyntax,

--- a/test/Serialization/Inputs/def_macro_plugin.swift
+++ b/test/Serialization/Inputs/def_macro_plugin.swift
@@ -15,7 +15,7 @@ public struct StringifyMacro: ExpressionMacro {
   }
 }
 
-public struct MyWrapperMacro: AccessorDeclarationMacro {
+public struct MyWrapperMacro: AccessorMacro {
     public static func expansion(
     of node: AttributeSyntax,
     attachedTo declaration: DeclSyntax,


### PR DESCRIPTION
These deprecations are simple renames, but this PR should get rid of the warnings.