### PR TITLE
[NameLookup] Opaque Type Collector should skip existential types

### DIFF
--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -928,7 +928,7 @@ namespace {
       }
     }
 
-    return decl->getGenericParams();
+    return decl->getParsedGenericParams();
   }
 }
 

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2798,7 +2798,6 @@ bool TypeRepr::isProtocol(DeclContext *dc){
   auto &ctx = dc->getASTContext();
   return findIf([&ctx, dc](TypeRepr *ty) {
     return declsAreProtocols(directReferencesForTypeRepr(ctx.evaluator, ctx, ty, dc));
-
   });
 }
 
@@ -2852,6 +2851,8 @@ CollectedOpaqueReprs swift::collectOpaqueReturnTypeReprs(TypeRepr *r, ASTContext
         if (!compositionRepr->isTypeReprAny())
           Reprs.push_back(compositionRepr);
         return Action::SkipChildren();
+      } else if (auto generic = dyn_cast<GenericIdentTypeRepr>(repr)) {
+        return Action::Continue();
       } else if (auto declRefTR = dyn_cast<DeclRefTypeRepr>(repr)) {
         if (declRefTR->isProtocol(dc))
           Reprs.push_back(declRefTR);

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2852,11 +2852,6 @@ CollectedOpaqueReprs swift::collectOpaqueReturnTypeReprs(TypeRepr *r, ASTContext
         if (!compositionRepr->isTypeReprAny())
           Reprs.push_back(compositionRepr);
         return Action::SkipChildren();
-      } else if (auto generic = dyn_cast<GenericIdentTypeRepr>(repr)) {
-        // prevent any P<some P>
-        if (!Reprs.empty() && isa<ExistentialTypeRepr>(Reprs.front())){
-          Reprs.clear();
-        }
       } else if (auto declRefTR = dyn_cast<DeclRefTypeRepr>(repr)) {
         if (declRefTR->isProtocol(dc))
           Reprs.push_back(declRefTR);

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2847,11 +2847,7 @@ CollectedOpaqueReprs swift::collectOpaqueReturnTypeReprs(TypeRepr *r, ASTContext
         return Action::Continue();
       
       if (auto existential = dyn_cast<ExistentialTypeRepr>(repr)) {
-        auto meta = dyn_cast<MetatypeTypeRepr>(existential->getConstraint());
-        auto generic = dyn_cast<GenericIdentTypeRepr>(existential->getConstraint());
-        if(generic)
-          Reprs.push_back(existential);
-        return Action::VisitChildrenIf(meta || generic);
+        return Action::SkipChildren();
       } else if (auto compositionRepr = dyn_cast<CompositionTypeRepr>(repr)) {
         if (!compositionRepr->isTypeReprAny())
           Reprs.push_back(compositionRepr);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2137,11 +2137,8 @@ ResultTypeRequest::evaluate(Evaluator &evaluator, ValueDecl *decl) const {
     return TupleType::getEmpty(ctx);
 
   // Handle opaque types.
-  if (decl->getOpaqueResultTypeRepr()) {
-    auto *opaqueDecl = decl->getOpaqueResultTypeDecl();
-    return (opaqueDecl
-            ? opaqueDecl->getDeclaredInterfaceType()
-            : ErrorType::get(ctx));
+  if (auto *opaqueDecl = decl->getOpaqueResultTypeDecl()) {
+      return opaqueDecl->getDeclaredInterfaceType();
   }
 
   auto options =

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -79,6 +79,7 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
         .diagnose(repr->getLoc(), diag::opaque_type_in_protocol_requirement)
         .fixItInsert(fixitLoc, result)
         .fixItReplace(repr->getSourceRange(), placeholder);
+    repr->setInvalid();
 
     return nullptr;
   }
@@ -162,6 +163,7 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
              .diagnose(currentRepr->getLoc(), diag::opaque_of_optional_rewrite)
              .fixItReplaceChars(currentRepr->getStartLoc(),
                                 currentRepr->getEndLoc(), stream.str());
+          repr->setInvalid();
           return nullptr;
         }
       }
@@ -199,6 +201,7 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
         // Error out if the constraint type isn't a class or existential type.
         ctx.Diags.diagnose(currentRepr->getLoc(),
                            diag::opaque_type_invalid_constraint);
+        currentRepr->setInvalid();
         return nullptr;
       }
 
@@ -246,6 +249,7 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
         ctx.Diags.diagnose(repr->getLoc(),
                            diag::opaque_type_in_parameter,
                            false, interfaceType);
+        repr->setInvalid();
         return true;
       }
     }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -469,8 +469,15 @@ void TypeChecker::checkReferencedGenericParams(GenericContext *dc) {
           continue;
       }
       // Produce an error that this generic parameter cannot be bound.
-      paramDecl->diagnose(diag::unreferenced_generic_parameter,
-                          paramDecl->getNameStr());
+      if (paramDecl->isImplicit()) {
+        paramDecl->getASTContext().Diags
+          .diagnose(paramDecl->getOpaqueTypeRepr()->getLoc(),
+                    diag::unreferenced_generic_parameter,
+                    paramDecl->getNameStr());
+      } else {
+        paramDecl->diagnose(diag::unreferenced_generic_parameter,
+                            paramDecl->getNameStr());
+      }
     }
   }
 }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -136,6 +136,11 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
     }
   } else {
     opaqueReprs = collectOpaqueReturnTypeReprs(repr, ctx, dc);
+    
+    if (opaqueReprs.empty()) {
+      return nullptr;
+    }
+
     SmallVector<GenericTypeParamType *, 2> genericParamTypes;
     SmallVector<Requirement, 2> requirements;
     for (unsigned i = 0; i < opaqueReprs.size(); ++i) {

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -732,7 +732,7 @@ validateTypedPattern(TypedPattern *TP, DeclContext *dc,
   auto *Repr = TP->getTypeRepr();
   if (Repr && (Repr->hasOpaque() ||
                (Context.LangOpts.hasFeature(Feature::ImplicitSome) &&
-                Repr->isProtocol(dc)))) {
+                !collectOpaqueReturnTypeReprs(Repr, Context, dc).empty()))) {
     auto named = dyn_cast<NamedPattern>(
         TP->getSubPattern()->getSemanticsProvidingPattern());
     if (!named) {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2365,8 +2365,10 @@ NeverNullType TypeResolver::resolveType(TypeRepr *repr,
     bool isInExistential = diagnoseDisallowedExistential(opaqueRepr);
     
     if (auto opaqueDecl = dyn_cast<OpaqueTypeDecl>(DC)) {
-      if (auto ordinal = opaqueDecl->getAnonymousOpaqueParamOrdinal(opaqueRepr))
-        return getIdentityOpaqueTypeArchetypeType(opaqueDecl, *ordinal);
+      if (auto ordinal = opaqueDecl->getAnonymousOpaqueParamOrdinal(opaqueRepr)){
+        if(!isInExistential)
+          return getIdentityOpaqueTypeArchetypeType(opaqueDecl, *ordinal);
+      }
     }
 
     // Check whether any of the generic parameters in the context represents
@@ -2382,7 +2384,7 @@ NeverNullType TypeResolver::resolveType(TypeRepr *repr,
       }
     }
     
-    if (!isInExistential){
+    if (!repr->isInvalid()){
       // We are not inside an `OpaqueTypeDecl`, so diagnose an error.
       if (!(options & TypeResolutionFlags::SilenceErrors)) {
         diagnose(opaqueRepr->getOpaqueLoc(),
@@ -4712,6 +4714,7 @@ TypeResolver::resolveExistentialType(ExistentialTypeRepr *repr,
   if (constraintType->hasError())
     return ErrorType::get(getASTContext());
 
+  //TO-DO: generalize this and emit the same erorr for some P?
   if (!constraintType->isConstraintType()) {
     // Emit a tailored diagnostic for the incorrect optional
     // syntax 'any P?' with a fix-it to add parenthesis.

--- a/test/type/implicit_some/explicit_existential.swift
+++ b/test/type/implicit_some/explicit_existential.swift
@@ -1,0 +1,298 @@
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -warn-redundant-requirements  -enable-experimental-feature ImplicitSome
+
+protocol Foo { }
+
+var x: any Foo
+
+protocol SelfAsType {
+  var x: Self { get } // expected-note{{protocol requires property 'x' with type 'U'; do you want to add a stub?}}
+}
+
+struct U : SelfAsType { // expected-error{{type 'U' does not conform to protocol 'SelfAsType'}}
+  var x: any SelfAsType { self } // expected-note {{candidate has non-matching type 'any SelfAsType'}}
+}
+
+protocol HasSelfRequirements {
+  func foo(_ x: Self)
+
+  func returnsOwnProtocol() -> any HasSelfRequirements
+}
+
+protocol Bar {
+  init()
+
+  func bar() -> any Bar
+}
+
+func useBarAsType(_ x: any Bar) {}
+
+protocol Pub : Bar { }
+
+func refinementErasure(_ p: any Pub) {
+  useBarAsType(p)
+}
+
+struct Struct1<T> { }
+
+typealias T1 = Pub & Bar
+typealias T2 = any Pub & Bar
+
+protocol HasAssoc {
+  associatedtype Assoc
+  func foo()
+}
+
+do {
+  enum MyError: Error {
+    case bad(Any)
+  }
+
+  func checkIt(_ js: Any) throws {
+    switch js {
+    case let dbl as any HasAssoc:
+      throw MyError.bad(dbl)
+
+    default:
+      fatalError("wrong")
+    }
+  }
+}
+
+func testHasAssoc(_ x: Any, _: any HasAssoc) {
+  if let p = x as? any HasAssoc {
+    p.foo()
+  }
+
+  struct ConformingType : HasAssoc {
+    typealias Assoc = Int
+    func foo() {}
+
+    func method() -> any HasAssoc {}
+  }
+}
+
+var b: any HasAssoc
+
+protocol P {}
+typealias MoreHasAssoc = HasAssoc & P
+func testHasMoreAssoc(_ x: Any) {
+  if let p = x as? any MoreHasAssoc {
+    p.foo()
+  }
+}
+
+typealias X = Struct1<any Pub & Bar>
+_ = Struct1<any Pub & Bar>.self
+
+typealias AliasWhere<T> = T
+where T: HasAssoc, T.Assoc == any HasAssoc
+
+struct StructWhere<T>
+where T: HasAssoc,
+      T.Assoc == any HasAssoc {}
+
+protocol ProtocolWhere where T == any HasAssoc {
+  associatedtype T
+
+  associatedtype U: HasAssoc
+    where U.Assoc == any HasAssoc
+}
+
+extension HasAssoc where Assoc == any HasAssoc {}
+
+func FunctionWhere<T>(_: T)
+where T : HasAssoc,
+      T.Assoc == any HasAssoc {}
+
+struct SubscriptWhere {
+  subscript<T>(_: T) -> Int
+  where T : HasAssoc,
+        T.Assoc == any HasAssoc {
+    get {}
+    set {}
+  }
+}
+
+struct OuterGeneric<T> {
+  func contextuallyGenericMethod() where T == any HasAssoc {}
+}
+
+func testInvalidAny() {
+  struct S: HasAssoc {
+    typealias Assoc = Int
+    func foo() {}
+  }
+  let _: any S = S() // expected-error{{'any' has no effect on concrete type 'S'}}
+
+  func generic<T: HasAssoc>(t: T) {
+    let _: any T = t // expected-error{{'any' has no effect on type parameter 'T'}}
+    let _: any T.Assoc // expected-error {{'any' has no effect on type parameter 'T.Assoc'}}
+  }
+
+  let _: any ((S) -> Void) = generic // expected-error{{'any' has no effect on concrete type '(S) -> Void'}}
+}
+
+func anyAny() {
+  let _: any Any
+  let _: any AnyObject
+}
+
+protocol P1 {}
+protocol P2 {}
+protocol P3 {}
+do {
+  // Test that we don't accidentally misparse an 'any' type as a 'some' type
+  // and vice versa.
+  let _: P1 & any P2 // expected-error {{'any' should appear at the beginning of a composition}} {{15-19=}} {{10-10=any }}
+  let _: any P1 & any P2 // expected-error {{'any' should appear at the beginning of a composition}} {{19-23=}}
+  let _: any P1 & P2 & any P3 // expected-error {{'any' should appear at the beginning of a composition}} {{24-28=}}
+  let _: any P1 & some P2 // expected-error {{'some' should appear at the beginning of a composition}} {{19-24=}}
+  let _: some P1 & any P2
+  // expected-error@-1 {{'some' type can only be declared on a single property declaration}}
+  // expected-error@-2 {{'any' should appear at the beginning of a composition}} {{20-24=}}
+}
+
+struct ConcreteComposition: P1, P2 {}
+
+func testMetatypes() {
+  let _: any P1.Type = ConcreteComposition.self
+  let _: any (P1 & P2).Type = ConcreteComposition.self
+}
+
+func generic<T: any P1>(_ t: T) {} // expected-error {{type 'T' constrained to non-protocol, non-class type 'any P1'}}
+
+public protocol MyError {}
+
+extension MyError {
+  static func ~=(lhs: any Error, rhs: Self) -> Bool {
+    return true
+  }
+}
+
+struct Wrapper {
+  typealias E = Error
+}
+
+func typealiasMemberReferences(metatype: Wrapper.Type) {
+  let _: any Wrapper.E.Protocol = metatype.E.self // expected-error{{'any' has no effect on concrete type '(any Wrapper.E).Type' (aka '(any Error).Type')}}
+  let _: (any Wrapper.E).Type = metatype.E.self
+}
+
+func testAnyTypeExpr() {
+  let _: (any P).Type = (any P).self
+
+  func test(_: (any P).Type) {}
+  test((any P).self)
+
+  // expected-error@+2 {{expected member name or constructor call after type name}}
+  // expected-note@+1 {{use '.self' to reference the type object}}
+  let invalid = any P
+  test(invalid)
+
+  // Make sure 'any' followed by an identifier
+  // on the next line isn't parsed as a type.
+  func doSomething() {}
+
+  let any = 10
+  let _ = any
+  doSomething()
+}
+
+func hasInvalidExistential(_: any DoesNotExistIHope) {}
+// expected-error@-1 {{cannot find type 'DoesNotExistIHope' in scope}}
+
+protocol Input {
+  associatedtype A
+}
+protocol Output {
+  associatedtype A
+}
+
+
+
+// NOT SURE IF THIS WILL WORK
+
+// ImplicitSome feature always expects explicit 'any' and plain protocols now imply 'some'
+// Verify existential_requires_any error is no longer produced
+typealias OpaqueFunction = (Input) -> Output
+func testOpaqueFunctionAlias(fn: OpaqueFunction) {}
+
+typealias ExistentialFunction = (any Input) -> any Output
+func testFunctionAlias(fn: ExistentialFunction) {}
+
+typealias Constraint = Input
+func testConstraintAlias(x: Constraint) {}
+
+typealias Existential = any Input
+func testExistentialAlias(x: Existential, y: any Constraint) {}
+
+// Reject explicit existential types in inheritance clauses
+protocol Empty {}
+
+struct S : any Empty {} // expected-error {{inheritance from non-protocol type 'any Empty'}}
+class C : any Empty {} // expected-error {{inheritance from non-protocol, non-class type 'any Empty'}}
+
+// FIXME: Diagnostics are not great in the enum case because we confuse this with a raw type
+
+enum E : any Empty { // expected-error {{raw type 'any Empty' is not expressible by a string, integer, or floating-point literal}}
+// expected-error@-1 {{'E' declares raw type 'any Empty', but does not conform to RawRepresentable and conformance could not be synthesized}}
+// expected-error@-2 {{RawRepresentable conformance cannot be synthesized because raw type 'any Empty' is not Equatable}}
+  case hack
+}
+
+enum EE : Equatable, any Empty { // expected-error {{raw type 'any Empty' is not expressible by a string, integer, or floating-point literal}}
+// expected-error@-1 {{'EE' declares raw type 'any Empty', but does not conform to RawRepresentable and conformance could not be synthesized}}
+// expected-error@-2 {{RawRepresentable conformance cannot be synthesized because raw type 'any Empty' is not Equatable}}
+// expected-error@-3 {{raw type 'any Empty' must appear first in the enum inheritance clause}}
+  case hack
+}
+
+func testAnyFixIt() {
+  struct ConformingType : HasAssoc {
+    typealias Assoc = Int
+    func foo() {}
+
+    func method() -> any HasAssoc {}
+  }
+
+  let _: any HasAssoc = ConformingType()
+  let _: Optional<any HasAssoc> = nil
+  let _: any HasAssoc.Type = ConformingType.self
+  let _: (any HasAssoc.Type) = ConformingType.self
+  let _: ((any HasAssoc.Type)) = ConformingType.self
+  let _: (any HasAssoc).Protocol = (any HasAssoc).self
+  let _: (any HasAssoc)? = ConformingType()
+  let _: (any HasAssoc.Type)? = ConformingType.self
+  let _: (any HasAssoc).Protocol? = (any HasAssoc).self
+
+  // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc)?'}}{{10-23=(any HasAssoc)?}}
+  let _: any HasAssoc? = nil
+  // expected-error@+1 {{optional 'any' type must be written '(any HasAssoc.Type)?'}}{{10-28=(any HasAssoc.Type)?}}
+  let _: any HasAssoc.Type? = nil
+}
+
+func testNestedMetatype() {
+  let _: (any P.Type).Type = (any P.Type).self
+  let _: (any (P.Type)).Type = (any P.Type).self
+  let _: ((any (P.Type))).Type = (any P.Type).self
+}
+
+func testEnumAssociatedValue() {
+  enum E {
+    case c1((any HasAssoc) -> Void)
+  }
+}
+
+// https://github.com/apple/swift/issues/58920
+typealias Iterator = any IteratorProtocol
+var example: any Iterator = 5 // expected-error{{redundant 'any' in type 'any Iterator' (aka 'any any IteratorProtocol')}} {{14-18=}}
+// expected-error@-1{{value of type 'Int' does not conform to specified type 'IteratorProtocol'}}
+var example1: any (any IteratorProtocol) = 5 // expected-error{{redundant 'any' in type 'any (any IteratorProtocol)'}} {{15-19=}}
+// expected-error@-1{{value of type 'Int' does not conform to specified type 'IteratorProtocol'}}
+
+protocol PP {}
+struct A : PP {}
+let _: any PP = A() // Ok
+let _: any (any PP) = A() // expected-error{{redundant 'any' in type 'any (any PP)'}} {{8-12=}}
+
+

--- a/test/type/opaque_parameterized_existential.swift
+++ b/test/type/opaque_parameterized_existential.swift
@@ -9,39 +9,24 @@ protocol P<T> {
   associatedtype T
 }
 
-extension Never: P { typealias T = Never }
+struct S: P {
+  typealias T = Self
+}
 
 // I do not like them written clear
-func test() -> any P<some P> { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}}
-// expected-error@-1{{cannot infer underlying type for opaque result 'any P<some P>' from return expression}}
-
-// I do not like them nested here
-func test() -> any P<[some P]> { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}}
-// expected-error@-1{{cannot infer underlying type for opaque result 'any P<[some P]>' from return expression}}
-
+func test() -> any P<some P> { S() } // expected-error {{'some' types cannot be used in constraints on existential types}}
 // I do not like them under questions
-func test() -> any P<(some P)??> { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}}
-// expected-error@-1{{cannot infer underlying type for opaque result 'any P<(some P)??>' from return expression}}
-
+func test() -> any P<(some P)??> { S() } // expected-error {{'some' types cannot be used in constraints on existential types}}
 // I do not like meta-type intentions
-func test() -> (any P<some P>).Type { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}}
-// expected-error@-1{{cannot infer underlying type for opaque result '(any P<some P>).Type' from return expression}}
-
+func test() -> (any P<some P>).Type { S() } // expected-error {{'some' types cannot be used in constraints on existential types}}
 // I do not like them (meta)static-ly
-func test() -> any P<some P>.Type { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}}
-// expected-error@-1{{cannot infer underlying type for opaque result 'any P<some P>.Type' from return expression}}
-
+func test() -> any P<some P>.Type { S() } // expected-error {{'some' types cannot be used in constraints on existential types}}
 // I do not like them tupled-three
-func test() -> (Int, any P<some P>, Int) { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}}
-// expected-error@-1{{cannot infer underlying type for opaque result '(Int, any P<some P>, Int)' from return expression}}
-
+func test() -> (Int, any P<some P>, Int) { S() } // expected-error {{'some' types cannot be used in constraints on existential types}}
 // I do not like them in generics
 struct Wrapper<T> {}
-func test() -> any P<Wrapper<some P>> { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}}
-// expected-error@-1{{cannot infer underlying type for opaque result 'any P<Wrapper<some P>>' from return expression}}
-
+func test() -> any P<Wrapper<some P>> { S() } // expected-error {{'some' types cannot be used in constraints on existential types}}
 // Your attempts to nest them put me in hysterics.
-func test(_ x: any P<some P>) {} // expected-error {{'some' types cannot be used in constraints on existential types}}
-
+func test(_ x: any P<some P>) { } // expected-error {{'some' types cannot be used in constraints on existential types}}
 // No, I do not like nested some type params,
 // I do not like them Σam-i-am

--- a/test/type/parameterized_existential.swift
+++ b/test/type/parameterized_existential.swift
@@ -46,7 +46,6 @@ struct Collapse<T: DoubleWide>: DoubleWide {
 
 func test() -> any DoubleWide<some DoubleWide<Int, Int>, some DoubleWide<Int, Int>> { return Collapse<Int>(x: 42) }
 // expected-error@-1 {{'some' types cannot be used in constraints on existential types}}
-// expected-error@-2 {{'some' types cannot be used in constraints on existential types}}
 
 func diagonalizeAny(_ x: any Sequence<Int>) -> any Sequence<(Int, Int)> {
   return x.map { ($0, $0) }


### PR DESCRIPTION
An error in the opaque type collector is causing basic code using existential 'any' to crash with the 'ImplicitSome' feature.

i.e. 

```
  protocol P { }

  var x: any P
```

Fixes rdar://102698119