### PR TITLE
[ConstraintSystem] Handle ambiguities caused by requirement failures

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -612,6 +612,8 @@ public:
   Type lhsType() const { return LHS; }
   Type rhsType() const { return RHS; }
 
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
+
   bool diagnose(const Solution &solution,
                 bool asNote = false) const override = 0;
 };
@@ -634,8 +636,6 @@ public:
   }
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
-
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 
   static MissingConformance *forRequirement(ConstraintSystem &cs, Type type,
                                             Type protocolType,

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -410,16 +410,16 @@ bool MissingConformance::diagnose(const Solution &solution, bool asNote) const {
   return failure.diagnose(asNote);
 }
 
-bool MissingConformance::diagnoseForAmbiguity(
+bool RequirementFix::diagnoseForAmbiguity(
     CommonFixesArray commonFixes) const {
-  auto *primaryFix = commonFixes.front().second->getAs<MissingConformance>();
+  auto *primaryFix = commonFixes.front().second;
   assert(primaryFix);
 
   if (llvm::all_of(
           commonFixes,
           [&primaryFix](
               const std::pair<const Solution *, const ConstraintFix *> &entry) {
-            return primaryFix->isEqual(entry.second);
+            return primaryFix->getLocator() == entry.second->getLocator();
           }))
     return diagnose(*commonFixes.front().first);
 

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -400,12 +400,13 @@ bool MissingConformance::diagnose(const Solution &solution, bool asNote) const {
     auto &cs = solution.getConstraintSystem();
     auto context = cs.getContextualTypePurpose(locator->getAnchor());
     MissingContextualConformanceFailure failure(
-        solution, context, NonConformingType, ProtocolType, locator);
+        solution, context, getNonConformingType(), getProtocolType(), locator);
     return failure.diagnose(asNote);
   }
 
   MissingConformanceFailure failure(
-      solution, locator, std::make_pair(NonConformingType, ProtocolType));
+      solution, locator,
+      std::make_pair(getNonConformingType(), getProtocolType()));
   return failure.diagnose(asNote);
 }
 
@@ -433,8 +434,9 @@ bool MissingConformance::isEqual(const ConstraintFix *other) const {
     return false;
 
   return IsContextual == conformanceFix->IsContextual &&
-         NonConformingType->isEqual(conformanceFix->NonConformingType) &&
-         ProtocolType->isEqual(conformanceFix->ProtocolType);
+         getNonConformingType()->isEqual(
+             conformanceFix->getNonConformingType()) &&
+         getProtocolType()->isEqual(conformanceFix->getProtocolType());
 }
 
 MissingConformance *

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4914,27 +4914,29 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
   // Aggregate all requirement fixes that belong to the same callee
   // and attempt to diagnose possible ambiguities.
   {
-    auto isResultBuilderRef = [&](ASTNode node) {
+    auto isResultBuilderMethodRef = [&](ASTNode node) {
       auto *UDE = getAsExpr<UnresolvedDotExpr>(node);
-      if (!UDE)
+      if (!(UDE && UDE->isImplicit()))
         return false;
 
       auto &ctx = getASTContext();
-      return UDE->isImplicit() &&
-        UDE->getName().compare(DeclNameRef(ctx.Id_buildBlock)) == 0;
+      SmallVector<Identifier, 4> builderMethods(
+          {ctx.Id_buildBlock, ctx.Id_buildExpression, ctx.Id_buildPartialBlock,
+           ctx.Id_buildFinalResult});
+
+      return llvm::any_of(builderMethods, [&](const Identifier &methodId) {
+        return UDE->getName().compare(DeclNameRef(methodId)) == 0;
+      });
     };
 
-    llvm::MapVector<SourceLoc,
-                    SmallVector<FixInContext, 4>>
-        builderFixes;
+    // Aggregates fixes fixes attached to `buildExpression` and `buildBlock`
+    // methods at the particular source location.
+    llvm::MapVector<SourceLoc, SmallVector<FixInContext, 4>>
+        builderMethodRequirementFixes;
 
     llvm::MapVector<ConstraintLocator *, SmallVector<FixInContext, 4>>
-        requirementFixes;
+        perCalleeRequirementFixes;
 
-    // TODO(diagnostics): This approach doesn't work for synthesized code
-    // because i.e. result builders would inject a new `buildBlock` or
-    // `buildExpression` for every kind of builder. We need to come up
-    // with the strategy to unify locators in such cases.
     for (const auto &entry : fixes) {
       auto *fix = entry.second;
       if (!fix->getLocator()->isLastElement<LocatorPathElt::AnyRequirement>())
@@ -4942,38 +4944,38 @@ bool ConstraintSystem::diagnoseAmbiguityWithFixes(
 
       auto *calleeLoc = entry.first->getCalleeLocator(fix->getLocator());
 
-      if (isResultBuilderRef(calleeLoc->getAnchor())) {
+      if (isResultBuilderMethodRef(calleeLoc->getAnchor())) {
         auto *anchor = castToExpr<Expr>(calleeLoc->getAnchor());
-        builderFixes[anchor->getLoc()].push_back(entry);
+        builderMethodRequirementFixes[anchor->getLoc()].push_back(entry);
       } else {
-        requirementFixes[calleeLoc].push_back(entry);
+        perCalleeRequirementFixes[calleeLoc].push_back(entry);
       }
     }
 
-    SmallVector<FixInContext, 4> diagnosedFixes;
+    SmallVector<SmallVector<FixInContext, 4>, 4> viableGroups;
+    {
+      auto takeAggregateIfViable =
+          [&](SmallVector<FixInContext, 4> &aggregate) {
+            // Ambiguity only if all of the solutions have a requirement
+            // fix at the given location.
+            if (aggregate.size() == solutions.size())
+              viableGroups.push_back(std::move(aggregate));
+          };
 
-    for (auto &entry : builderFixes) {
-      auto &aggregate = entry.second;
+      for (auto &entry : builderMethodRequirementFixes)
+        takeAggregateIfViable(entry.second);
 
-      if (diagnoseAmbiguityWithGenericRequirements(*this, aggregate))
-        diagnosedFixes.append(aggregate.begin(), aggregate.end());
+      for (auto &entry : perCalleeRequirementFixes)
+        takeAggregateIfViable(entry.second);
     }
 
-    for (auto &entry : requirementFixes) {
-      auto &aggregate = entry.second;
-
-      // Ambiguity only if all of the solutions have a requirement
-      // fix at the given location.
-      if (aggregate.size() != solutions.size())
-        continue;
-
-      if (diagnoseAmbiguityWithGenericRequirements(*this, aggregate))
-        diagnosedFixes.append(aggregate.begin(), aggregate.end());
+    for (auto &aggregate : viableGroups) {
+      if (diagnoseAmbiguityWithGenericRequirements(*this, aggregate)) {
+        // Remove diagnosed fixes.
+        fixes.set_subtract(aggregate);
+        diagnosed = true;
+      }
     }
-
-    diagnosed |= !diagnosedFixes.empty();
-    // Remove any diagnosed fixes.
-    fixes.set_subtract(diagnosedFixes);
   }
 
   llvm::MapVector<std::pair<FixKind, ConstraintLocator *>,


### PR DESCRIPTION
Aggregate all requirement failures (regardless of kind) that belong
to the same locator and diagnose them as an ambiguity (if there is
more than one overload) or as the singular failure if all solutions
point to the same overload.

Resolves: https://github.com/apple/swift/issues/56173
Resolves: rdar://79357256
Resolves: rdar://104135510

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
