### PR TITLE
Colorize swift syntax diagnostics

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Diagnostics.swift
@@ -244,13 +244,17 @@ public func addQueuedDiagnostic(
 @_cdecl("swift_ASTGen_renderQueuedDiagnostics")
 public func renterQueuedDiagnostics(
   queuedDiagnosticsPtr: UnsafeMutablePointer<UInt8>,
+  contextSize: Int,
+  colorize: Int,
   renderedPointer: UnsafeMutablePointer<UnsafePointer<UInt8>?>,
   renderedLength: UnsafeMutablePointer<Int>
 ) {
   queuedDiagnosticsPtr.withMemoryRebound(to: QueuedDiagnostics.self, capacity: 1) { queuedDiagnostics in
     let renderedStr = DiagnosticsFormatter.annotatedSource(
       tree: queuedDiagnostics.pointee.sourceFile,
-      diags: queuedDiagnostics.pointee.diagnostics
+      diags: queuedDiagnostics.pointee.diagnostics,
+      contextSize: contextSize,
+      colorize: colorize != 0
     )
 
     (renderedPointer.pointee, renderedLength.pointee) =

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -42,7 +42,8 @@ extern "C" void swift_ASTGen_addQueuedDiagnostic(
     const void *sourceLoc
 );
 extern "C" void swift_ASTGen_renderQueuedDiagnostics(
-    void *queued, char **outBuffer, ptrdiff_t *outBufferLength);
+    void *queued, ptrdiff_t contextSize, ptrdiff_t colorize,
+    char **outBuffer, ptrdiff_t *outBufferLength);
 
 // FIXME: Hack because we cannot easily get to the already-parsed source
 // file from here. Fix this egregious oversight!
@@ -1106,7 +1107,8 @@ void PrintingDiagnosticConsumer::flush(bool includeTrailingBreak) {
     char *renderedString = nullptr;
     ptrdiff_t renderedStringLen = 0;
     swift_ASTGen_renderQueuedDiagnostics(
-        queuedDiagnostics, &renderedString, &renderedStringLen);
+        queuedDiagnostics, /*contextSize=*/2, ForceColors ? 1 : 0,
+        &renderedString, &renderedStringLen);
     if (renderedString) {
       Stream.write(renderedString, renderedStringLen);
     }


### PR DESCRIPTION
Use the newly-introduced colorizing code in swift-syntax (https://github.com/apple/swift-syntax/pull/1256) to colorize diagnostics that use the swift-syntax rendered.

<img width="572" alt="image" src="https://user-images.githubusercontent.com/989428/214701234-b4af2453-9465-467a-bd84-892aae4d760c.png">
