### PR TITLE
SuspendingClock on Windows does not suspend

### DIFF
--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -13,10 +13,7 @@
 #include "swift/Runtime/Concurrency.h"
 #include "swift/Runtime/Once.h"
 
-#if __has_include(<time.h>)
-#define HAS_TIME 1
 #include <time.h>
-#endif
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
@@ -37,11 +34,11 @@ void swift_get_time(
   switch (clock_id) {
     case swift_clock_id_continuous: {
       struct timespec continuous;
-#if defined(__linux__) && HAS_TIME
+#if defined(__linux__)
       clock_gettime(CLOCK_BOOTTIME, &continuous);
-#elif defined(__APPLE__) && HAS_TIME
+#elif defined(__APPLE__)
       clock_gettime(CLOCK_MONOTONIC_RAW, &continuous);
-#elif (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__wasi__)) && HAS_TIME
+#elif (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__wasi__))
       clock_gettime(CLOCK_MONOTONIC, &continuous);
 #elif defined(_WIN32)
       LARGE_INTEGER freq;
@@ -66,13 +63,13 @@ void swift_get_time(
     }
     case swift_clock_id_suspending: {
       struct timespec suspending;
-#if defined(__linux__) && HAS_TIME
+#if defined(__linux__)
       clock_gettime(CLOCK_MONOTONIC, &suspending);
-#elif defined(__APPLE__) && HAS_TIME
+#elif defined(__APPLE__)
       clock_gettime(CLOCK_UPTIME_RAW, &suspending);
-#elif defined(__wasi__) && HAS_TIME
+#elif defined(__wasi__)
       clock_gettime(CLOCK_MONOTONIC, &suspending);
-#elif (defined(__OpenBSD__) || defined(__FreeBSD__)) && HAS_TIME
+#elif (defined(__OpenBSD__) || defined(__FreeBSD__))
       clock_gettime(CLOCK_UPTIME, &suspending);
 #elif defined(_WIN32)
       // QueryUnbiasedInterruptTimePrecise() was added in Windows 10 and is, as
@@ -124,11 +121,11 @@ void swift_get_clock_res(
 switch (clock_id) {
     case swift_clock_id_continuous: {
       struct timespec continuous;
-#if defined(__linux__) && HAS_TIME
+#if defined(__linux__)
       clock_getres(CLOCK_BOOTTIME, &continuous);
-#elif defined(__APPLE__) && HAS_TIME
+#elif defined(__APPLE__)
       clock_getres(CLOCK_MONOTONIC_RAW, &continuous);
-#elif (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__wasi__)) && HAS_TIME
+#elif (defined(__OpenBSD__) || defined(__FreeBSD__) || defined(__wasi__))
       clock_getres(CLOCK_MONOTONIC, &continuous);
 #elif defined(_WIN32)
       LARGE_INTEGER freq;
@@ -144,13 +141,13 @@ switch (clock_id) {
     }
     case swift_clock_id_suspending: {
       struct timespec suspending;
-#if defined(__linux__) && HAS_TIME
+#if defined(__linux__)
       clock_getres(CLOCK_MONOTONIC_RAW, &suspending);
-#elif defined(__APPLE__) && HAS_TIME
+#elif defined(__APPLE__)
       clock_getres(CLOCK_UPTIME_RAW, &suspending);
-#elif defined(__wasi__) && HAS_TIME
+#elif defined(__wasi__)
       clock_getres(CLOCK_MONOTONIC, &suspending);
-#elif (defined(__OpenBSD__) || defined(__FreeBSD__)) && HAS_TIME
+#elif (defined(__OpenBSD__) || defined(__FreeBSD__))
       clock_getres(CLOCK_UPTIME, &suspending);
 #elif defined(_WIN32)
       suspending.tv_sec = 0;

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -21,7 +21,6 @@
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
 #include <Windows.h>
-#include <immintrin.h>
 #include <realtimeapiset.h>
 #endif
 

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Runtime/Concurrency.h"
-#include "swift/Runtime/Debug.h"
 #include "swift/Runtime/Once.h"
 
 #if __has_include(<time.h>)
@@ -25,6 +24,8 @@
 #include <immintrin.h>
 #include <realtimeapiset.h>
 #endif
+
+#include "Error.h"
 
 using namespace swift;
 
@@ -133,7 +134,8 @@ void swift_get_time(
       return;
     }
   }
-  swift::fatalError(0, "Fatal error: invalid clock ID %d\n", clock_id);
+  swift_Concurrency_fatalError(0, "Fatal error: invalid clock ID %d\n",
+                               clock_id);
 }
 
 SWIFT_EXPORT_FROM(swift_Concurrency)
@@ -196,5 +198,6 @@ switch (clock_id) {
       return;
     }
   }
-  swift::fatalError(0, "Fatal error: invalid clock ID %d\n", clock_id);
+  swift_Concurrency_fatalError(0, "Fatal error: invalid clock ID %d\n",
+                               clock_id);
 }

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -124,8 +124,10 @@ switch (clock_id) {
       *seconds = continuous.tv_sec;
       *nanoseconds = continuous.tv_nsec;
 #elif defined(_WIN32)
+      LARGE_INTEGER freq;
+      QueryPerformanceFrequency(&freq);
       *seconds = 0;
-      *nanoseconds = 1000;
+      *nanoseconds = 1000000000 / freq.QuadPart;
 #else
 #error Missing platform continuous time definition
 #endif
@@ -151,7 +153,7 @@ switch (clock_id) {
       *nanoseconds = suspending.tv_nsec;
 #elif defined(_WIN32)
       *seconds = 0;
-      *nanoseconds = 1000;
+      *nanoseconds = 100;
 #else
 #error Missing platform suspending time definition
 #endif

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -62,15 +62,8 @@ void swift_get_time(
       // count by 1,000,000,000 to get nanosecond resolution. By multiplying
       // first, we maintain high precision. The resulting value is the tick
       // count in nanoseconds. Use 128-bit math to avoid overflowing.
-//#if defined(_MSC_VER)
-//      DWORD64 hi = 0;
-//      DWORD64 lo = _umul128(count.QuadPart, 1'000'000'000, &hi);
-//      DWORD64 ns = _udiv128(hi, lo, freq.QuadPart, nullptr);
-//#else
-      auto ns = static_cast<unsigned __int128>(count.QuadPart);
-      ns *= 1'000'000'000;
-      ns /= freq.QuadPart;
-//#endif
+      auto quadPart = static_cast<unsigned __int128>(count.QuadPart);
+      auto ns = (quadPart * 1'000'000'000) / freq.QuadPart;
       *seconds = ns / 1'000'000'000;
       *nanoseconds = ns % 1'000'000'000;
 #else

--- a/stdlib/public/Concurrency/Clock.cpp
+++ b/stdlib/public/Concurrency/Clock.cpp
@@ -87,18 +87,10 @@ void swift_get_time(
       *seconds = suspending.tv_sec;
       *nanoseconds = suspending.tv_nsec;
 #elif defined(_WIN32)
-      LARGE_INTEGER freq;
-      QueryPerformanceFrequency(&freq);
-      LARGE_INTEGER count;
-      QueryPerformanceCounter(&count);
-      *seconds = count.QuadPart / freq.QuadPart;
-      if (freq.QuadPart < 1000000000) {
-        *nanoseconds = 
-            ((count.QuadPart % freq.QuadPart) * 1000000000) / freq.QuadPart;
-      } else {
-        *nanoseconds = 
-            (count.QuadPart % freq.QuadPart) * (1000000000.0 / freq.QuadPart);
-      }
+      ULONGLONG unbiasedTime;
+      QueryUnbiasedInterruptTimePrecise(&unbiasedTime);
+      *seconds = unbiasedTime / 10000000ULL; // unit is 100ns
+      *nanoseconds = unbiasedTime % 10000000ULL;
 #else
 #error Missing platform suspending time definition
 #endif


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR replaces the implementation of `SuspendingClock` on Windows with one that uses `QueryUnbiasedInterruptTimePrecise()`, which _does_ suspend.

I also updated `swift_get_clock_res()` to produce accurate values on Windows instead of a hard-coded 1µs resolution.

Raymond Chen gives a little bit of info about the various timer APIs [here](https://devblogs.microsoft.com/oldnewthing/20170921-00/?p=97057).

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #63224.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
