### PR TITLE
Adopt malloc_type for allocating Swift objects from runtime

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -129,6 +129,12 @@
 #error Masking ISAs are incompatible with opaque ISAs
 #endif
 
+#if defined(__LP64__) && __has_include(<malloc_type_private.h>) && SWIFT_STDLIB_HAS_DARWIN_LIBMALLOC
+# define SWIFT_STDLIB_HAS_MALLOC_TYPE 1
+#else
+# define SWIFT_STDLIB_HAS_MALLOC_TYPE 0
+#endif
+
 /// Which bits in the class metadata are used to distinguish Swift classes
 /// from ObjC classes?
 #ifndef SWIFT_CLASS_IS_SWIFT_MASK

--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -129,9 +129,13 @@
 #error Masking ISAs are incompatible with opaque ISAs
 #endif
 
-#if defined(__LP64__) && __has_include(<malloc_type_private.h>) && SWIFT_STDLIB_HAS_DARWIN_LIBMALLOC
-# define SWIFT_STDLIB_HAS_MALLOC_TYPE 1
-#else
+#if defined(__APPLE__) && defined(__LP64__) && __has_include(<malloc_type_private.h>) && SWIFT_STDLIB_HAS_DARWIN_LIBMALLOC
+# include <TargetConditionals.h>
+# if TARGET_OS_IOS && !TARGET_OS_SIMULATOR
+#  define SWIFT_STDLIB_HAS_MALLOC_TYPE 1
+# endif
+#endif
+#ifndef SWIFT_STDLIB_HAS_MALLOC_TYPE
 # define SWIFT_STDLIB_HAS_MALLOC_TYPE 0
 #endif
 

--- a/include/swift/Runtime/Heap.h
+++ b/include/swift/Runtime/Heap.h
@@ -32,6 +32,11 @@ namespace swift {
 SWIFT_EXTERN_C SWIFT_RETURNS_NONNULL SWIFT_NODISCARD SWIFT_RUNTIME_EXPORT_ATTRIBUTE
 void *swift_slowAlloc(size_t bytes, size_t alignMask);
 
+using MallocTypeId = unsigned long long;
+
+SWIFT_RETURNS_NONNULL SWIFT_NODISCARD
+void *swift_slowAllocTyped(size_t bytes, size_t alignMask, MallocTypeId typeId);
+
 // If the caller cannot promise to zero the object during destruction,
 // then call these corresponding APIs:
 SWIFT_RUNTIME_EXPORT

--- a/stdlib/public/runtime/Heap.cpp
+++ b/stdlib/public/runtime/Heap.cpp
@@ -73,7 +73,11 @@ static inline malloc_zone_t *DEFAULT_ZONE() {
 // the use of AlignedAlloc. This allows manually allocated to memory to always
 // be deallocated with AlignedFree without knowledge of its original allocation
 // alignment.
-//
+static size_t computeAlignment(size_t alignMask) {
+  return (alignMask == ~(size_t(0))) ? _swift_MinAllocationAlignment
+                                     : alignMask + 1;
+}
+
 // For alignMask > (_minAllocationAlignment-1)
 // i.e. alignment == 0 || alignment > _minAllocationAlignment:
 //   The runtime must use AlignedAlloc, and the standard library must
@@ -93,13 +97,30 @@ void *swift::swift_slowAlloc(size_t size, size_t alignMask) {
     p = malloc(size);
 #endif
   } else {
-    size_t alignment = (alignMask == ~(size_t(0)))
-                           ? _swift_MinAllocationAlignment
-                           : alignMask + 1;
+    size_t alignment = computeAlignment(alignMask);
     p = AlignedAlloc(size, alignment);
   }
   if (!p) swift::crash("Could not allocate memory.");
   return p;
+}
+
+void *swift::swift_slowAllocTyped(size_t size, size_t alignMask,
+                                  MallocTypeId typeId) {
+#if SWIFT_STDLIB_HAS_MALLOC_TYPE
+  if (__builtin_available(macOS 9998, iOS 9998, tvOS 9998, watchOS 9998, *)) {
+    void *p;
+    // This check also forces "default" alignment to use malloc_memalign().
+    if (alignMask <= MALLOC_ALIGN_MASK) {
+      p = malloc_type_zone_malloc(DEFAULT_ZONE(), size, typeId);
+    } else {
+      size_t alignment = computeAlignment(alignMask);
+      p = malloc_type_zone_memalign(DEFAULT_ZONE(), alignment, size, typeId);
+    }
+    if (!p) swift::crash("Could not allocate memory.");
+    return p;
+  }
+#endif
+  return swift_slowAlloc(size, alignMask);
 }
 
 // Unknown alignment is specified by passing alignMask == ~(size_t(0)), forcing


### PR DESCRIPTION
rdar://98998492
