### PR TITLE
Update `llvm::Optional` API uses

### DIFF
--- a/include/swift/Basic/BlotMapVector.h
+++ b/include/swift/Basic/BlotMapVector.h
@@ -148,7 +148,7 @@ public:
     if (Iter == Map.end())
       return ValueT();
     auto &P = Vector[Iter->second];
-    if (!P.hasValue())
+    if (!P.has_value())
       return ValueT();
     return P->second;
   }

--- a/include/swift/Basic/SuccessorMap.h
+++ b/include/swift/Basic/SuccessorMap.h
@@ -375,13 +375,13 @@ private:
     assert(Traits::precedes(node->Begin, node->End));
 
     // The first key must be strictly higher than the lower bound.
-    if (lowerBound.hasValue())
-      assert(Traits::precedes(lowerBound.getValue(), node->Begin));
+    if (lowerBound.has_value())
+      assert(Traits::precedes(lowerBound.value(), node->Begin));
 
     // The last key (i.e. End-1) must be strictly lower than
     // upperBound-1, or in other words, End must precede upperBound.
-    if (upperBound.hasValue()) 
-      assert(Traits::precedes(node->End, upperBound.getValue()));
+    if (upperBound.has_value())
+      assert(Traits::precedes(node->End, upperBound.value()));
 
     // The keys in the left sub-tree must all be strictly less than
     // Begin-1, because if any key equals Begin-1, that node should

--- a/lib/Basic/Unix/TaskQueue.inc
+++ b/lib/Basic/Unix/TaskQueue.inc
@@ -59,7 +59,7 @@ TaskProcessInformation::TaskProcessInformation(ProcessId Pid, struct rusage Usag
         Usage.ru_maxrss) {
 #ifndef __APPLE__
             // Apple systems report bytes; everything else appears to report KB.
-            this->ProcessUsage.getValue().Maxrss <<= 10;
+            this->ProcessUsage.value().Maxrss <<= 10;
 #endif // __APPLE__
         }
 #endif // defined(HAVE_GETRUSAGE) && !defined(__HAIKU__)

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
@@ -352,8 +352,8 @@ public:
       return static_cast<ImplClass*>(this)->visitString(CString);
     }
     auto OptInt = Object->getInt64();
-    if (OptInt.hasValue()) {
-      return static_cast<ImplClass*>(this)->visitInt64(OptInt.getValue());
+    if (OptInt.has_value()) {
+      return static_cast<ImplClass*>(this)->visitInt64(OptInt.value());
     }
     llvm_unreachable("unknown sourcekitd_object_t");
   }
@@ -789,7 +789,7 @@ bool RequestDict::getInt64(SourceKit::UIdent Key, int64_t &Val,
   auto Object = static_cast<SKDObject *>(Dict)->get(SKDUIDFromUIdent(Key));
   if (!Object)
     return !isOptional;
-  Val = Object->getInt64().getValueOr(0);
+  Val = Object->getInt64().value_or(0);
   return false;
 }
 
@@ -797,7 +797,7 @@ Optional<int64_t> RequestDict::getOptionalInt64(SourceKit::UIdent Key) const {
   auto Object = static_cast<SKDObject *>(Dict)->get(SKDUIDFromUIdent(Key));
   if (!Object)
     return None;
-  return Object->getInt64().getValueOr(0);
+  return Object->getInt64().value_or(0);
 }
 
 sourcekitd_response_t
@@ -849,7 +849,7 @@ static size_t SKDVar_array_get_count(sourcekitd_variant_t array) {
 }
 
 static int64_t SKDVar_array_get_int64(sourcekitd_variant_t array, size_t index) {
-  return SKD_OBJ(array)->get(index)->getInt64().getValueOr(0);
+  return SKD_OBJ(array)->get(index)->getInt64().value_or(0);
 }
 
 static const char *
@@ -891,7 +891,7 @@ SKDVar_dictionary_get_bool(sourcekitd_variant_t dict, sourcekitd_uid_t key) {
 static int64_t
 SKDVar_dictionary_get_int64(sourcekitd_variant_t dict, sourcekitd_uid_t key) {
   if (auto Object = SKD_OBJ(dict)->get(key)) {
-    return Object->getInt64().getValueOr(0);
+    return Object->getInt64().value_or(0);
   }
   return 0;
 }
@@ -919,7 +919,7 @@ SKDVar_dictionary_get_uid(sourcekitd_variant_t dict, sourcekitd_uid_t key) {
 
 static size_t SKDVar_string_get_length(sourcekitd_variant_t obj) {
   auto String = SKD_OBJ(obj)->getString();
-  return String.hasValue() ? String->size() : 0;
+  return String.has_value() ? String->size() : 0;
 }
 
 static const char *SKDVar_string_get_ptr(sourcekitd_variant_t obj) {
@@ -927,7 +927,7 @@ static const char *SKDVar_string_get_ptr(sourcekitd_variant_t obj) {
 }
 
 static int64_t SKDVar_int64_get_value(sourcekitd_variant_t obj) {
-  return SKD_OBJ(obj)->getInt64().getValueOr(0);
+  return SKD_OBJ(obj)->getInt64().value_or(0);
 }
 
 static sourcekitd_uid_t SKDVar_uid_get_value(sourcekitd_variant_t obj) {

--- a/unittests/Basic/BlotMapVectorTest.cpp
+++ b/unittests/Basic/BlotMapVectorTest.cpp
@@ -632,9 +632,9 @@ TEST(BlotMapVectorCustomTest, FindAsTest) {
 
   // Normal lookup tests
   EXPECT_EQ(1u, map.count(1));
-  EXPECT_EQ(1u, map.find(0)->getValue().second);
-  EXPECT_EQ(2u, map.find(1)->getValue().second);
-  EXPECT_EQ(3u, map.find(2)->getValue().second);
+  EXPECT_EQ(1u, map.find(0)->value().second);
+  EXPECT_EQ(2u, map.find(1)->value().second);
+  EXPECT_EQ(3u, map.find(2)->value().second);
   EXPECT_TRUE(map.find(3) == map.end());
 }
 

--- a/unittests/Basic/EditorPlaceholderTest.cpp
+++ b/unittests/Basic/EditorPlaceholderTest.cpp
@@ -49,17 +49,17 @@ TEST(EditorPlaceholder, EditorPlaceholders) {
 TEST(EditorPlaceholder, InvalidEditorPlaceholders) {
   const char *Text = "<#foo";
   Optional<EditorPlaceholderData> DataOpt = parseEditorPlaceholder(Text);
-  EXPECT_FALSE(DataOpt.hasValue());
+  EXPECT_FALSE(DataOpt.has_value());
 
   Text = "foo#>";
   DataOpt = parseEditorPlaceholder(Text);
-  EXPECT_FALSE(DataOpt.hasValue());
+  EXPECT_FALSE(DataOpt.has_value());
 
   Text = "#foo#>";
   DataOpt = parseEditorPlaceholder(Text);
-  EXPECT_FALSE(DataOpt.hasValue());
+  EXPECT_FALSE(DataOpt.has_value());
 
   Text = " <#foo#>";
   DataOpt = parseEditorPlaceholder(Text);
-  EXPECT_FALSE(DataOpt.hasValue());
+  EXPECT_FALSE(DataOpt.has_value());
 }

--- a/unittests/Basic/FrozenMultiMapTest.cpp
+++ b/unittests/Basic/FrozenMultiMapTest.cpp
@@ -75,7 +75,7 @@ TEST(FrozenMultiMapCustomTest, SimpleFind) {
   EXPECT_EQ(map.size(), 5u);
   {
     auto r = map.find(key1);
-    EXPECT_TRUE(r.hasValue());
+    EXPECT_TRUE(r.has_value());
     EXPECT_EQ(r->size(), 3u);
     EXPECT_EQ((*r)[0].getID(), 2u);
     EXPECT_EQ((*r)[1].getID(), 3u);
@@ -84,7 +84,7 @@ TEST(FrozenMultiMapCustomTest, SimpleFind) {
 
   {
     auto r = map.find(key2);
-    EXPECT_TRUE(r.hasValue());
+    EXPECT_TRUE(r.has_value());
     EXPECT_EQ(r->size(), 2u);
     EXPECT_EQ((*r)[0].getID(), 5u);
     EXPECT_EQ((*r)[1].getID(), 6u);

--- a/unittests/Driver/MockingFineGrainedDependencyGraphs.cpp
+++ b/unittests/Driver/MockingFineGrainedDependencyGraphs.cpp
@@ -43,8 +43,8 @@ mocking_fine_grained_dependency_graphs::getChangesForSimulatedLoad(
   auto swiftDeps =
     cmd->getOutput().getAdditionalOutputForType(file_types::TY_SwiftDeps).str();
   auto swiftDepsFingerprint =
-    swift::mockFingerprintFromString(swiftDeps).getValue();
-  auto interfaceHash = interfaceHashIfNonEmpty.getValueOr(swiftDepsFingerprint);
+    swift::mockFingerprintFromString(swiftDeps).value();
+  auto interfaceHash = interfaceHashIfNonEmpty.value_or(swiftDepsFingerprint);
 
   SourceManager sm;
   DiagnosticEngine diags(sm);
@@ -70,7 +70,7 @@ mocking_fine_grained_dependency_graphs::simulateReload(
       hadCompilationError);
   if (!changedNodes)
     return g.getAllJobs();
-  return g.findJobsToRecompileWhenNodesChange(changedNodes.getValue());
+  return g.findJobsToRecompileWhenNodesChange(changedNodes.value());
 }
 
 LLVM_ATTRIBUTE_UNUSED

--- a/unittests/Driver/UnitTestSourceFileDepGraphFactory.cpp
+++ b/unittests/Driver/UnitTestSourceFileDepGraphFactory.cpp
@@ -58,7 +58,7 @@ void UnitTestSourceFileDepGraphFactory::addADefinedDecl(StringRef s,
   const Optional<Fingerprint> fingerprint =
     swift::mockFingerprintFromString(fingerprintString);
 
-  AbstractSourceFileDepGraphFactory::addADefinedDecl(key.getValue(),
+  AbstractSourceFileDepGraphFactory::addADefinedDecl(key.value(),
                                                      fingerprint);
 }
 
@@ -80,7 +80,7 @@ UnitTestSourceFileDepGraphFactory::computeUseKey(StringRef s,
       isCascadingUse ? DeclAspect::interface : DeclAspect::implementation;
 
   if (!s.empty())
-    return parseADefinedDecl(s, kindOfUse, aspectOfUse).getValue();
+    return parseADefinedDecl(s, kindOfUse, aspectOfUse).value();
   StringRef swiftDepsRef(swiftDeps);
   return DependencyKey::Builder(NodeKind::sourceFileProvide, aspectOfUse)
           .withName(swiftDepsRef)
@@ -155,7 +155,7 @@ UnitTestSourceFileDepGraphFactory::parseContext(const StringRef s,
                                                 const NodeKind kind) {
   return !singleNameIsContext(kind)
              ? s.split(nameContextSeparator).first.str()
-             : singleNameIsContext(kind).getValue() ? s.str() : "";
+             : singleNameIsContext(kind).value() ? s.str() : "";
 }
 
 std::string UnitTestSourceFileDepGraphFactory::parseName(const StringRef s,
@@ -163,7 +163,7 @@ std::string UnitTestSourceFileDepGraphFactory::parseName(const StringRef s,
   const std::string name =
       !singleNameIsContext(kind)
           ? s.split(nameContextSeparator).second.str()
-          : singleNameIsContext(kind).getValue() ? "" : s.str();
+          : singleNameIsContext(kind).value() ? "" : s.str();
   assert(kind != NodeKind::member ||
          !name.empty() && "Should be a potentialMember");
   return name;

--- a/unittests/Parse/BuildConfigTests.cpp
+++ b/unittests/Parse/BuildConfigTests.cpp
@@ -22,25 +22,25 @@ Optional<version::Version> V(const char *VersionString) {
 
 TEST_F(CompilerVersionTest, VersionComparison) {
   auto currentVersion = version::getCurrentCompilerVersion();
-  EXPECT_GE(CV("700").getValue(), CV("602").getValue());
-  EXPECT_GE(CV("700.*").getValue(), CV("700.*").getValue());
-  EXPECT_GE(CV("700.*.1").getValue(), CV("700.*.0").getValue());
-  EXPECT_GE(CV("700.*.23").getValue(), CV("700.*.21").getValue());
-  EXPECT_GE(CV("700.*.1.1.0").getValue(), CV("700.*.1.1").getValue());
+  EXPECT_GE(CV("700").value(), CV("602").value());
+  EXPECT_GE(CV("700.*").value(), CV("700.*").value());
+  EXPECT_GE(CV("700.*.1").value(), CV("700.*.0").value());
+  EXPECT_GE(CV("700.*.23").value(), CV("700.*.21").value());
+  EXPECT_GE(CV("700.*.1.1.0").value(), CV("700.*.1.1").value());
   EXPECT_GE(currentVersion, currentVersion);
-  EXPECT_GE(currentVersion, CV("9223371.*.999.999.999").getValue());
+  EXPECT_GE(currentVersion, CV("9223371.*.999.999.999").value());
 }
 
 TEST_F(VersionTest, VersionComparison) {
   auto currentVersion = version::Version::getCurrentLanguageVersion();
-  EXPECT_GE(V("3").getValue(), V("2").getValue());
-  EXPECT_GE(V("2.0").getValue(), V("2.0").getValue());
-  EXPECT_GE(V("2.1").getValue(), V("2.0").getValue());
-  EXPECT_GE(V("3.1").getValue(), V("3.0.1").getValue());
-  EXPECT_GE(V("2.0").getValue(), V("2").getValue());
+  EXPECT_GE(V("3").value(), V("2").value());
+  EXPECT_GE(V("2.0").value(), V("2.0").value());
+  EXPECT_GE(V("2.1").value(), V("2.0").value());
+  EXPECT_GE(V("3.1").value(), V("3.0.1").value());
+  EXPECT_GE(V("2.0").value(), V("2").value());
   EXPECT_GE(currentVersion, currentVersion);
-  EXPECT_GE(currentVersion, V("1.0").getValue());
-  EXPECT_GE(currentVersion, V("2").getValue());
+  EXPECT_GE(currentVersion, V("1.0").value());
+  EXPECT_GE(currentVersion, V("2").value());
   EXPECT_FALSE(V("2.n").hasValue());
   EXPECT_FALSE(V("").hasValue());
   EXPECT_FALSE(V("\"2.0\"").hasValue());
@@ -53,23 +53,23 @@ TEST_F(VersionTest, VersionComparison) {
 }
 
 TEST_F(CompilerVersionUnpackingTest, VersionComparison) {
-  EXPECT_EQ(CV("700").getValue(), V("0.700").getValue());
-  EXPECT_EQ(CV("700.*").getValue(), V("0.700").getValue());
-  EXPECT_EQ(CV("700.*.1").getValue(), V("0.700.1").getValue());
-  EXPECT_EQ(CV("700.*.23").getValue(), V("0.700.23").getValue());
-  EXPECT_EQ(CV("700.*.1.1").getValue(), V("0.700.1.1").getValue());
+  EXPECT_EQ(CV("700").value(), V("0.700").value());
+  EXPECT_EQ(CV("700.*").value(), V("0.700").value());
+  EXPECT_EQ(CV("700.*.1").value(), V("0.700.1").value());
+  EXPECT_EQ(CV("700.*.23").value(), V("0.700.23").value());
+  EXPECT_EQ(CV("700.*.1.1").value(), V("0.700.1.1").value());
 
-  EXPECT_EQ(CV("1300").getValue(), V("1.300").getValue());
-  EXPECT_EQ(CV("1300.*").getValue(), V("1.300").getValue());
-  EXPECT_EQ(CV("1300.*.1").getValue(), V("1.300.1").getValue());
-  EXPECT_EQ(CV("1300.*.23").getValue(), V("1.300.23").getValue());
-  EXPECT_EQ(CV("1300.*.1.1").getValue(), V("1.300.1.1").getValue());
+  EXPECT_EQ(CV("1300").value(), V("1.300").value());
+  EXPECT_EQ(CV("1300.*").value(), V("1.300").value());
+  EXPECT_EQ(CV("1300.*.1").value(), V("1.300.1").value());
+  EXPECT_EQ(CV("1300.*.23").value(), V("1.300.23").value());
+  EXPECT_EQ(CV("1300.*.1.1").value(), V("1.300.1.1").value());
 
-  EXPECT_EQ(CV("5007").getValue(), V("5.7").getValue());
-  EXPECT_EQ(CV("5007.*").getValue(), V("5.7").getValue());
-  EXPECT_EQ(CV("5007.*.1").getValue(), V("5.7.1").getValue());
-  EXPECT_EQ(CV("5007.*.23").getValue(), V("5.7.23").getValue());
-  EXPECT_EQ(CV("5007.*.1.1").getValue(), V("5.7.1.1").getValue());
+  EXPECT_EQ(CV("5007").value(), V("5.7").value());
+  EXPECT_EQ(CV("5007.*").value(), V("5.7").value());
+  EXPECT_EQ(CV("5007.*.1").value(), V("5.7.1").value());
+  EXPECT_EQ(CV("5007.*.23").value(), V("5.7.23").value());
+  EXPECT_EQ(CV("5007.*.1.1").value(), V("5.7.1.1").value());
 
   // Since this test was added during 5.7, we expect all of these comparisons to
   // be GE, either because we are comparing to the empty version or because we

--- a/unittests/Sema/BindingInferenceTests.cpp
+++ b/unittests/Sema/BindingInferenceTests.cpp
@@ -348,7 +348,7 @@ TEST_F(SemaTest, TestNoDoubleVoidClosureResultInference) {
     llvm::SmallPtrSet<Type, 2> inferredTypes;
 
     while (auto binding = producer()) {
-      ASSERT_TRUE(binding.hasValue());
+      ASSERT_TRUE(binding.has_value());
       ASSERT_EQ(binding->getTypeVariable(), typeVar);
       ASSERT_TRUE(inferredTypes.insert(binding->getType()).second);
     }

--- a/unittests/Sema/PlaceholderTypeInferenceTests.cpp
+++ b/unittests/Sema/PlaceholderTypeInferenceTests.cpp
@@ -48,7 +48,7 @@ TEST_F(SemaTest, TestPlaceholderInferenceForArrayLiteral) {
   auto &solution = solutions[0];
 
   auto eltTy = ConstraintSystem::isArrayType(solution.simplifyType(solution.getType(arrayExpr)));
-  ASSERT_TRUE(eltTy.hasValue());
+  ASSERT_TRUE(eltTy.has_value());
   ASSERT_TRUE((*eltTy)->is<StructType>());
   ASSERT_EQ((*eltTy)->getAs<StructType>()->getDecl(), intTypeDecl);
 }
@@ -89,7 +89,7 @@ TEST_F(SemaTest, TestPlaceholderInferenceForDictionaryLiteral) {
   auto &solution = solutions[0];
 
   auto keyValTys = ConstraintSystem::isDictionaryType(solution.simplifyType(solution.getType(dictExpr)));
-  ASSERT_TRUE(keyValTys.hasValue());
+  ASSERT_TRUE(keyValTys.has_value());
 
   Type keyTy;
   Type valTy;

--- a/unittests/Sema/SolutionFilteringTests.cpp
+++ b/unittests/Sema/SolutionFilteringTests.cpp
@@ -55,7 +55,7 @@ TEST_F(SemaTest, TestFilteringBasedOnSolutionScore) {
 
     auto best = CS.findBestSolution(solutions, /*minimize=*/true);
 
-    ASSERT_FALSE(best.hasValue());
+    ASSERT_FALSE(best.has_value());
     ASSERT_EQ(solutions.size(), 2u);
     ASSERT_EQ(solutions[0].getFixedScore(), bestScore);
     ASSERT_EQ(solutions[1].getFixedScore(), bestScore);
@@ -73,7 +73,7 @@ TEST_F(SemaTest, TestFilteringBasedOnSolutionScore) {
 
     auto best = CS.findBestSolution(solutions, /*minimize=*/true);
 
-    ASSERT_FALSE(best.hasValue());
+    ASSERT_FALSE(best.has_value());
     ASSERT_EQ(solutions.size(), 2u);
     ASSERT_EQ(solutions[0].getFixedScore(), bestScore);
     ASSERT_EQ(solutions[1].getFixedScore(), bestScore);
@@ -92,7 +92,7 @@ TEST_F(SemaTest, TestFilteringBasedOnSolutionScore) {
 
     auto best = CS.findBestSolution(solutions, /*minimize=*/true);
 
-    ASSERT_FALSE(best.hasValue());
+    ASSERT_FALSE(best.has_value());
     ASSERT_EQ(solutions.size(), 2u);
     ASSERT_EQ(solutions[0].getFixedScore(), bestScore);
     ASSERT_EQ(solutions[1].getFixedScore(), bestScore);
@@ -110,7 +110,7 @@ TEST_F(SemaTest, TestFilteringBasedOnSolutionScore) {
 
     auto best = CS.findBestSolution(solutions, /*minimize=*/true);
 
-    ASSERT_FALSE(best.hasValue());
+    ASSERT_FALSE(best.has_value());
     ASSERT_EQ(solutions.size(), 2u);
     ASSERT_EQ(solutions[0].getFixedScore(), bestScore);
     ASSERT_EQ(solutions[1].getFixedScore(), bestScore);
@@ -130,7 +130,7 @@ TEST_F(SemaTest, TestFilteringBasedOnSolutionScore) {
 
     auto best = CS.findBestSolution(solutions, /*minimize=*/true);
 
-    ASSERT_FALSE(best.hasValue());
+    ASSERT_FALSE(best.has_value());
     ASSERT_EQ(solutions.size(), 2u);
     ASSERT_EQ(solutions[0].getFixedScore(), bestScore);
     ASSERT_EQ(solutions[1].getFixedScore(), bestScore);

--- a/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
+++ b/unittests/SourceKit/SwiftLang/CursorInfoTest.cpp
@@ -142,8 +142,8 @@ public:
 
   void open(const char *DocName, StringRef Text,
             Optional<ArrayRef<const char *>> CArgs = llvm::None) {
-    auto Args = CArgs.hasValue() ? makeArgs(DocName, *CArgs)
-                                 : std::vector<const char *>{};
+    auto Args = CArgs.has_value() ? makeArgs(DocName, *CArgs)
+                                  : std::vector<const char *>{};
     auto Buf = MemoryBuffer::getMemBufferCopy(Text, DocName);
     getLang().editorOpen(DocName, Buf.get(), Consumer, Args, None);
   }


### PR DESCRIPTION
Use the std-equivalent names as the LLVM ones are now deprecated (eventually `llvm::Optional` will disappear):
  - `getValue` -> `value`
  - `getValueOr` -> `value_or`
  - `hasValue` -> `has_value`

Follow up from ab1b343dadc8644c8a44def9178948fa0dbe2ade and 7d8bf37e5ec5ec97f35c79dc999eee4d1aaac09c with some missing cases.