### PR TITLE
SILGen: Avoid using back deployment thunks for high enough deployment targets

### DIFF
--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -423,7 +423,8 @@ public:
   /// Is the self method of the given nonmutating method passed indirectly?
   bool isNonMutatingSelfIndirect(SILDeclRef method);
 
-  SILDeclRef getAccessorDeclRef(AccessorDecl *accessor);
+  SILDeclRef getAccessorDeclRef(AccessorDecl *accessor,
+                                ResilienceExpansion expansion);
 
   bool canStorageUseStoredKeyPathComponent(AbstractStorageDecl *decl,
                                            ResilienceExpansion expansion);

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -259,6 +259,31 @@ static void convertOwnershipConventionsGivenParamInfos(
                   });
 }
 
+static bool shouldApplyBackDeploymentThunk(ValueDecl *decl, ASTContext &ctx,
+                                           ResilienceExpansion expansion) {
+  auto backDeployBeforeVersion = decl->getBackDeployBeforeOSVersion(ctx);
+  if (!backDeployBeforeVersion)
+    return false;
+
+  // If the context of the application is inlinable then we must always call the
+  // back deployment thunk since we can't predict the deployment targets of
+  // other modules.
+  if (expansion != ResilienceExpansion::Maximal)
+    return true;
+
+  // In resilient function bodies skip calling the back deployment thunk when
+  // the deployment target is high enough that the ABI implementation of the
+  // back deployed function is guaranteed to be available.
+  auto deploymentAvailability = AvailabilityContext::forDeploymentTarget(ctx);
+  auto declAvailability =
+      AvailabilityContext(VersionRange::allGTE(*backDeployBeforeVersion));
+
+  if (deploymentAvailability.isContainedIn(declAvailability))
+    return false;
+
+  return true;
+}
+
 //===----------------------------------------------------------------------===//
 //                                   Callee
 //===----------------------------------------------------------------------===//
@@ -1104,6 +1129,28 @@ public:
     }
   }
 
+  SILDeclRef getDeclRefForStaticDispatchApply(DeclRefExpr *e) {
+    auto *afd = cast<AbstractFunctionDecl>(e->getDecl());
+    auto &ctx = SGF.getASTContext();
+
+    // A call to a `distributed` function may need to go through a thunk.
+    if (callSite && callSite->shouldApplyDistributedThunk()) {
+      if (auto distributedThunk = afd->getDistributedThunk())
+        return SILDeclRef(distributedThunk).asDistributed();
+    }
+
+    // A call to `@_backDeploy` function may need to go through a thunk.
+    if (shouldApplyBackDeploymentThunk(afd, ctx,
+                                       SGF.F.getResilienceExpansion())) {
+      return SILDeclRef(afd).asBackDeploymentKind(
+          SILDeclRef::BackDeploymentKind::Thunk);
+    }
+
+    return SILDeclRef(afd).asForeign(
+        !isConstructorWithGeneratedAllocatorThunk(afd) &&
+        requiresForeignEntryPoint(afd));
+  }
+
   //
   // Known callees.
   //
@@ -1144,25 +1191,7 @@ public:
     }
 
     // Otherwise, we have a statically-dispatched call.
-    SILDeclRef constant = SILDeclRef(e->getDecl());
-
-    /// Some special handling may be necessary for thunks:
-    if (callSite && callSite->shouldApplyDistributedThunk()) {
-      if (auto distributedThunk = cast<AbstractFunctionDecl>(e->getDecl())->getDistributedThunk()) {
-        constant = SILDeclRef(distributedThunk).asDistributed();
-      }
-    } else if (afd->isBackDeployed()) {
-      // If we're calling a back deployed function then we need to call a
-      // thunk instead that will handle the fallback when the original
-      // function is unavailable at runtime.
-      constant =
-          constant.asBackDeploymentKind(SILDeclRef::BackDeploymentKind::Thunk);
-    } else {
-      constant = constant.asForeign(
-                   !isConstructorWithGeneratedAllocatorThunk(e->getDecl())
-                   && requiresForeignEntryPoint(e->getDecl()));
-    }
-
+    SILDeclRef constant = getDeclRefForStaticDispatchApply(e);
     auto captureInfo = SGF.SGM.Types.getLoweredLocalCaptures(constant);
     SGF.SGM.Types.setCaptureTypeExpansionContext(constant, SGF.SGM.M);
     
@@ -5943,9 +5972,11 @@ SILGenFunction::prepareSubscriptIndices(SubscriptDecl *subscript,
   return result;
 }
 
-SILDeclRef SILGenModule::getAccessorDeclRef(AccessorDecl *accessor) {
+SILDeclRef SILGenModule::getAccessorDeclRef(AccessorDecl *accessor,
+                                            ResilienceExpansion expansion) {
   auto declRef = SILDeclRef(accessor, SILDeclRef::Kind::Func);
-  if (accessor->isBackDeployed())
+
+  if (shouldApplyBackDeploymentThunk(accessor, getASTContext(), expansion))
     return declRef.asBackDeploymentKind(SILDeclRef::BackDeploymentKind::Thunk);
 
   return declRef.asForeign(requiresForeignEntryPoint(accessor));

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2358,6 +2358,11 @@ public:
 
   /// Get the _Pointer protocol used for pointer argument operations.
   ProtocolDecl *getPointerProtocol();
+
+  /// Returns the SILDeclRef to use for references to the given accessor.
+  SILDeclRef getAccessorDeclRef(AccessorDecl *accessor) {
+    return SGM.getAccessorDeclRef(accessor, F.getResilienceExpansion());
+  }
 };
 
 

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2887,7 +2887,7 @@ namespace {
     void emitUsingAccessor(AccessorKind accessorKind,
                            bool isDirect) {
       auto accessor =
-        SGF.SGM.getAccessorDeclRef(Storage->getOpaqueAccessor(accessorKind));
+          SGF.getAccessorDeclRef(Storage->getOpaqueAccessor(accessorKind));
 
       switch (accessorKind) {
       case AccessorKind::Set: {
@@ -3318,16 +3318,18 @@ LValue SILGenLValue::visitDotSyntaxBaseIgnoredExpr(DotSyntaxBaseIgnoredExpr *e,
 static SGFAccessKind getBaseAccessKindForAccessor(SILGenModule &SGM,
                                                   AccessorDecl *accessor,
                                                   CanType baseFormalType) {
-  if (accessor->isMutating()) {
+  if (accessor->isMutating())
     return SGFAccessKind::ReadWrite;
-  } else if (SGM.shouldEmitSelfAsRValue(accessor, baseFormalType)) {
-    return SGM.isNonMutatingSelfIndirect(SGM.getAccessorDeclRef(accessor))
-             ? SGFAccessKind::OwnedAddressRead
-             : SGFAccessKind::OwnedObjectRead;
+
+  auto declRef = SGM.getAccessorDeclRef(accessor, ResilienceExpansion::Minimal);
+  if (SGM.shouldEmitSelfAsRValue(accessor, baseFormalType)) {
+    return SGM.isNonMutatingSelfIndirect(declRef)
+               ? SGFAccessKind::OwnedAddressRead
+               : SGFAccessKind::OwnedObjectRead;
   } else {
-    return SGM.isNonMutatingSelfIndirect(SGM.getAccessorDeclRef(accessor))
-             ? SGFAccessKind::BorrowedAddressRead
-             : SGFAccessKind::BorrowedObjectRead;
+    return SGM.isNonMutatingSelfIndirect(declRef)
+               ? SGFAccessKind::BorrowedAddressRead
+               : SGFAccessKind::BorrowedObjectRead;
   }
 }
 
@@ -3435,7 +3437,7 @@ LValue SILGenLValue::visitMemberRefExpr(MemberRefExpr *e,
       var->getOpaqueAccessor(AccessorKind::Read)) {
     bool isObjC = false;
     auto readAccessor =
-        SGF.SGM.getAccessorDeclRef(var->getOpaqueAccessor(AccessorKind::Read));
+        SGF.getAccessorDeclRef(var->getOpaqueAccessor(AccessorKind::Read));
     if (isCallToReplacedInDynamicReplacement(
             SGF, readAccessor.getAbstractFunctionDecl(), isObjC)) {
       accessSemantics = AccessSemantics::DirectToImplementation;
@@ -3636,7 +3638,7 @@ LValue SILGenLValue::visitSubscriptExpr(SubscriptExpr *e,
       decl->getOpaqueAccessor(AccessorKind::Read)) {
     bool isObjC = false;
     auto readAccessor =
-        SGF.SGM.getAccessorDeclRef(decl->getOpaqueAccessor(AccessorKind::Read));
+        SGF.getAccessorDeclRef(decl->getOpaqueAccessor(AccessorKind::Read));
     if (isCallToReplacedInDynamicReplacement(
             SGF, readAccessor.getAbstractFunctionDecl(), isObjC)) {
       accessSemantics = AccessSemantics::DirectToImplementation;

--- a/test/SILGen/back_deploy_attribute.swift
+++ b/test/SILGen/back_deploy_attribute.swift
@@ -1,0 +1,70 @@
+// RUN: %target-swift-emit-sil -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 -verify
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 | %FileCheck %s --check-prefixes=CHECK,CHECK-BACK-DEPLOY
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.52 | %FileCheck %s --check-prefixes=CHECK,CHECK-NATIVE
+// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.60 | %FileCheck %s --check-prefixes=CHECK,CHECK-NATIVE
+
+// REQUIRES: OS=macosx
+
+@_backDeploy(before: macOS 10.52)
+public func someFunc() {}
+
+public struct S<T> {
+  @usableFromInline var _x: T
+
+  @_backDeploy(before: macOS 10.52)
+  public var x: T {
+    get { _x }
+    set { _x = newValue }
+  }
+}
+
+public struct Z {
+  public init() {}
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s11back_deploy15resilientCalleryyAA1SVyAA1ZVGzF
+func resilientCaller(_ s: inout S<Z>) {
+  // CHECK-BACK-DEPLOY: function_ref @$s11back_deploy8someFuncyyFTwb : $@convention(thin) () -> ()
+  // CHECK-NATIVE: function_ref @$s11back_deploy8someFuncyyF : $@convention(thin) () -> ()
+  someFunc()
+  // CHECK-BACK-DEPLOY: function_ref @$s11back_deploy1SV1xxvgTwb : $@convention(method) <τ_0_0> (@in_guaranteed S<τ_0_0>) -> @out τ_0_0
+  // CHECK-NATIVE: function_ref @$s11back_deploy1SV1xxvg : $@convention(method) <τ_0_0> (@in_guaranteed S<τ_0_0>) -> @out τ_0_0
+  _ = s.x
+  // CHECK-BACK-DEPLOY: function_ref @$s11back_deploy1SV1xxvsTwb : $@convention(method) <τ_0_0> (@in τ_0_0, @inout S<τ_0_0>) -> ()
+  // CHECK-NATIVE: function_ref @$s11back_deploy1SV1xxvs : $@convention(method) <τ_0_0> (@in τ_0_0, @inout S<τ_0_0>) -> ()
+  s.x = Z()
+}
+
+// CHECK-LABEL: sil [serialized] [ossa] @$s11back_deploy15inlinableCalleryyAA1SVyAA1ZVGzF
+@inlinable
+func inlinableCaller(_ s: inout S<Z>) {
+  // CHECK: function_ref @$s11back_deploy8someFuncyyFTwb : $@convention(thin) () -> ()
+  someFunc()
+  // CHECK: function_ref @$s11back_deploy1SV1xxvgTwb : $@convention(method) <τ_0_0> (@in_guaranteed S<τ_0_0>) -> @out τ_0_0
+  _ = s.x
+  // CHECK: function_ref @$s11back_deploy1SV1xxvsTwb : $@convention(method) <τ_0_0> (@in τ_0_0, @inout S<τ_0_0>) -> ()
+  s.x = Z()
+}
+
+// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy10aeicCalleryyAA1SVyAA1ZVGzF
+@_alwaysEmitIntoClient
+func aeicCaller(_ s: inout S<Z>) {
+  // CHECK: function_ref @$s11back_deploy8someFuncyyFTwb : $@convention(thin) () -> ()
+  someFunc()
+  // CHECK: function_ref @$s11back_deploy1SV1xxvgTwb : $@convention(method) <τ_0_0> (@in_guaranteed S<τ_0_0>) -> @out τ_0_0
+  _ = s.x
+  // CHECK: function_ref @$s11back_deploy1SV1xxvsTwb : $@convention(method) <τ_0_0> (@in τ_0_0, @inout S<τ_0_0>) -> ()
+  s.x = Z()
+}
+
+// CHECK-LABEL: sil non_abi [serialized] [ossa] @$s11back_deploy0A14DeployedCalleryyAA1SVyAA1ZVGzFTwB
+@_backDeploy(before: macOS 10.52)
+public func backDeployedCaller(_ s: inout S<Z>) {
+  // CHECK: function_ref @$s11back_deploy8someFuncyyFTwb : $@convention(thin) () -> ()
+  someFunc()
+  // CHECK: function_ref @$s11back_deploy1SV1xxvgTwb : $@convention(method) <τ_0_0> (@in_guaranteed S<τ_0_0>) -> @out τ_0_0
+  _ = s.x
+  // CHECK: function_ref @$s11back_deploy1SV1xxvsTwb : $@convention(method) <τ_0_0> (@in τ_0_0, @inout S<τ_0_0>) -> ()
+  s.x = Z()
+}

--- a/test/SILGen/back_deploy_attribute_accessor.swift
+++ b/test/SILGen/back_deploy_attribute_accessor.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-sil -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 -verify
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s | %FileCheck %s
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 | %FileCheck %s
-// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.60 | %FileCheck %s
 
 // REQUIRES: OS=macosx
 

--- a/test/SILGen/back_deploy_attribute_accessor_coroutine.swift
+++ b/test/SILGen/back_deploy_attribute_accessor_coroutine.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-sil -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 -verify
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s | %FileCheck %s
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 | %FileCheck %s
-// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.60 | %FileCheck %s
 
 // REQUIRES: OS=macosx
 

--- a/test/SILGen/back_deploy_attribute_async_func.swift
+++ b/test/SILGen/back_deploy_attribute_async_func.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-sil -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 -verify
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s | %FileCheck %s
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 | %FileCheck %s
-// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.60 | %FileCheck %s
 
 // REQUIRES: OS=macosx
 // REQUIRES: concurrency

--- a/test/SILGen/back_deploy_attribute_func.swift
+++ b/test/SILGen/back_deploy_attribute_func.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-sil -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 -verify
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s | %FileCheck %s
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 | %FileCheck %s
-// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.60 | %FileCheck %s
 
 // REQUIRES: OS=macosx
 

--- a/test/SILGen/back_deploy_attribute_generic_func.swift
+++ b/test/SILGen/back_deploy_attribute_generic_func.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-sil -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 -verify
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s | %FileCheck %s
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 | %FileCheck %s
-// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.60 | %FileCheck %s
 
 // REQUIRES: OS=macosx
 

--- a/test/SILGen/back_deploy_attribute_struct_init.swift
+++ b/test/SILGen/back_deploy_attribute_struct_init.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-sil -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 -verify
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s | %FileCheck %s
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 | %FileCheck %s
-// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.60 | %FileCheck %s
 
 // REQUIRES: OS=macosx
 

--- a/test/SILGen/back_deploy_attribute_struct_method.swift
+++ b/test/SILGen/back_deploy_attribute_struct_method.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-sil -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 -verify
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s | %FileCheck %s
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 | %FileCheck %s
-// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.60 | %FileCheck %s
 
 // REQUIRES: OS=macosx
 

--- a/test/SILGen/back_deploy_attribute_throwing_func.swift
+++ b/test/SILGen/back_deploy_attribute_throwing_func.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-emit-sil -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 -verify
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s | %FileCheck %s
 // RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.50 | %FileCheck %s
-// RUN: %target-swift-emit-silgen -parse-as-library -module-name back_deploy %s -target %target-cpu-apple-macosx10.60 | %FileCheck %s
 
 // REQUIRES: OS=macosx
 


### PR DESCRIPTION
If a function body references a declaration with the `@_backDeploy(before:)` attribute and that function body will only execute on deployment targets for which the ABI version of the decl is available then it is unnecessary to thunk the reference to the decl. Function bodies that may be emitted into other modules (e.g. `@inlinable`) must always use the thunk.

Resolves rdar://90729799
