### PR TITLE
[CS] Debug: Print ASTNode for contextual type

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -6854,6 +6854,9 @@ ASTNode findAsyncNode(ClosureExpr *closure);
 /// empty type otherwise.
 Type isPlaceholderVar(PatternBindingDecl *PB);
 
+/// Dump an anchor node for a constraint locator or contextual type.
+void dumpAnchor(ASTNode anchor, SourceManager *SM, raw_ostream &out);
+
 } // end namespace constraints
 
 template<typename ...Args>

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -630,19 +630,7 @@ void ConstraintLocator::dump(SourceManager *sm, raw_ostream &out) const {
   
   out << "locator@" << (void*) this << " [";
 
-  if (auto *expr = anchor.dyn_cast<Expr *>()) {
-    out << Expr::getKindName(expr->getKind());
-    if (sm) {
-      out << '@';
-      expr->getLoc().print(out, *sm);
-    }
-  } else if (auto *pattern = anchor.dyn_cast<Pattern *>()) {
-    out << Pattern::getKindName(pattern->getKind()) << "Pattern";
-    if (sm) {
-      out << '@';
-      pattern->getLoc().print(out, *sm);
-    }
-  }
+  constraints::dumpAnchor(anchor, sm, out);
 
   for (auto elt : getPath()) {
     out << " -> ";

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -7159,3 +7159,21 @@ ASTNode constraints::findAsyncNode(ClosureExpr *closure) {
     return ASTNode();
   return body->findAsyncNode();
 }
+
+void constraints::dumpAnchor(ASTNode anchor, SourceManager *SM,
+                             raw_ostream &out) {
+  if (auto *expr = anchor.dyn_cast<Expr *>()) {
+    out << Expr::getKindName(expr->getKind());
+    if (SM) {
+      out << '@';
+      expr->getLoc().print(out, *SM);
+    }
+  } else if (auto *pattern = anchor.dyn_cast<Pattern *>()) {
+    out << Pattern::getKindName(pattern->getKind()) << "Pattern";
+    if (SM) {
+      out << '@';
+      pattern->getLoc().print(out, *SM);
+    }
+  }
+  // TODO(diagnostics): Implement the rest of the cases.
+}

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1465,9 +1465,13 @@ void ConstraintSystem::print(raw_ostream &out) const {
     if (!info.getType().isNull()) {
       out << "\n";
       out.indent(indent) << "Contextual Type: " << info.getType().getString(PO);
+      out << " at ";
+
+      auto &SM = getASTContext().SourceMgr;
       if (TypeRepr *TR = info.typeLoc.getTypeRepr()) {
-        out << " at ";
-        TR->getSourceRange().print(out, getASTContext().SourceMgr, /*text*/false);
+        TR->getSourceRange().print(out, SM, /*text*/ false);
+      } else {
+        dumpAnchor(contextualTypeEntry.first, &SM, out);
       }
     }
   }


### PR DESCRIPTION
If we don't have an associated TypeRepr for a contextual type in the constraint system, dump the ASTNode that it's for instead.

Before:

```
Contextual Type: $T2
```

After:

```
Contextual Type: $T2 at DeclRef@/Users/hamish/src/swift-test-arena/swift-test-arena/main.swift:1493:21
```
