### PR TITLE
[5.8][build][llvm_gtest] add llvm_gtest_main to llvm build_target

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -232,6 +232,8 @@ class LLVM(cmake_product.CMakeProduct):
         if self.args.skip_build or not self.args.build_llvm:
             build_targets = ['llvm-tblgen', 'clang-resource-headers',
                              'intrinsics_gen', 'clang-tablegen-targets']
+            if self.args.cmake_generator == 'Xcode':
+                build_targets += ['llvm_gtest_main']
             if not self.args.build_toolchain_only:
                 build_targets.extend([
                     'FileCheck',


### PR DESCRIPTION
adding llvm_gtest_main target to build_targets in llvm.py when cmake generator is Xcode.

fixing problem of do not building gtest when build option with --xcode.

make issue(#63260) for this.