### PR TITLE
[gardening] change an ambiguous variable name

### DIFF
--- a/utils/round-trip-syntax-test
+++ b/utils/round-trip-syntax-test
@@ -74,7 +74,7 @@ class RoundTripTask(object):
                 logging.error(self.stderr.decode('utf-8', errors='replace'))
                 raise RuntimeError()
 
-        contents = ''.join(map(lambda l: l.decode('utf-8', errors='replace'),
+        contents = ''.join(map(lambda _: _.decode('utf-8', errors='replace'),
                                open(self.input_filename, 'rb').readlines()))
         stdout_contents = self.stdout.decode('utf-8', errors='replace')
 


### PR DESCRIPTION
A variable name that consists of the single lowercase letter L trips some python lint configurations. This causes local test runs to fail for an uninteresting reason. This commit changes the offending variable name to a single underscore, which is apparently better.
