### PR TITLE
Revert "At -Onone preserve debug info after splitting loads"

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1914,8 +1914,6 @@ public:
 /// Clone all projections and casts on the access use-def chain until the
 /// checkBase predicate returns a valid base.
 ///
-/// Returns the cloned value equivalent to \p addr.
-///
 /// This will not clone ref_element_addr or ref_tail_addr because those aren't
 /// part of the access chain.
 ///
@@ -1923,7 +1921,7 @@ public:
 /// returns a valid SILValue to use as the base of the cloned access path, or an
 /// invalid SILValue to continue cloning.
 ///
-/// CheckBase must return a valid SILValue before attempting to clone the
+/// CheckBase must return a valid SILValue either before attempting to clone the
 /// access base. The most basic valid predicate is:
 ///
 ///    auto checkBase = [&](SILValue srcAddr) {
@@ -1938,8 +1936,6 @@ SILValue cloneUseDefChain(SILValue addr, SILInstruction *insertionPoint,
 
 /// Analog to cloneUseDefChain to check validity. begin_borrow and
 /// mark_dependence currently cannot be cloned.
-///
-/// Returns the cloned value equivalent to \p addr.
 template <typename CheckBase>
 bool canCloneUseDefChain(SILValue addr, CheckBase checkBase) {
   return AccessUseDefChainCloner<CheckBase>(checkBase, nullptr)

--- a/test/SILOptimizer/silgen_cleanup.sil
+++ b/test/SILOptimizer/silgen_cleanup.sil
@@ -362,33 +362,3 @@ bb9(%0 : @owned $Klass):
   destroy_value %0 : $Klass
   return %v : $Builtin.Int64
 }
-
-// debug_value must be preserved after splitting loads
-
-struct IntWrapper {
-  var _value : Int
-}
-
-sil_scope 5 { loc "./test.swift":3:6 parent @testSplitLoadDebug : $@convention(thin) (@in_guaranteed IntWrapper) -> Builtin.Int32 }
-sil_scope 6 { loc "./test.swift":3:10 parent 5 }
-
-// CHECK-LABEL: sil hidden [ossa] @testSplitLoadDebug : $@convention(thin) (@in_guaranteed IntWrapper) -> Builtin.Int32 {
-// CHECK: bb0(%0 : $*IntWrapper):
-// CHECKDEB:   [[A1:%.*]] = struct_element_addr %0 : $*IntWrapper, #IntWrapper._value
-// CHECKDEB:   [[A2:%.*]] = struct_element_addr [[A1]] : $*Int, #Int._value
-// CHECKDEB:   [[SPLIT:%.*]] = load [trivial] %2 : $*Builtin.Int32
-// CHECKDEB:   [[A3:%.*]] = struct_element_addr %0 : $*IntWrapper, #IntWrapper._value
-// CHECKDEB:   [[A4:%.*]] = begin_access [read] [unsafe] [no_nested_conflict] [[A3]] : $*Int
-// CHECKDEB:   [[OLD:%.*]] = load [trivial] [[A4]] : $*Int
-// CHECKDEB:   end_access [[A4]] : $*Int
-// CHECKDEB:   debug_value [[OLD]] : $Int, let, name "flag"
-// CHECKDEB:   return [[SPLIT]] : $Builtin.Int32
-// CHECK-LABEL: } // end sil function 'testSplitLoadDebug'
-sil hidden [ossa] @testSplitLoadDebug : $@convention(thin) (@in_guaranteed IntWrapper) -> Builtin.Int32 {
-bb0(%0: $*IntWrapper):
-  %1 = struct_element_addr %0 : $*IntWrapper, #IntWrapper._value
-  %2 = load [trivial] %1 : $*Int
-  debug_value %2 : $Int, let, name "flag", loc "./test.swift":4:7, scope 6
-  %4 = struct_extract %2 : $Int, #Int._value
-  return %4 : $Builtin.Int32
-}


### PR DESCRIPTION
This reverts commit 02f7450759c992682ed3f149914bd2ecf4dec071.

Fixes rdar://104667596 (incorrectly reports an error when resolving initialization out of a switch)
