### PR TITLE
[rebranch] Handle out-of-date identifiers in macros

### DIFF
--- a/lib/ClangImporter/ImportMacro.cpp
+++ b/lib/ClangImporter/ImportMacro.cpp
@@ -472,6 +472,15 @@ static ValueDecl *importMacro(ClangImporter::Implementation &impl,
     if (tok.is(clang::tok::identifier)) {
       auto clangID = tok.getIdentifierInfo();
 
+      if (clangID->isOutOfDate())
+        // Update the identifier with macro definitions subsequently loaded from
+        // a module/AST file. We're supposed to use
+        // Preprocessor::HandleIdentifier() to do that, but that method does too
+        // much to call it here. Instead, we call getLeafModuleMacros() for its
+        // side effect of calling updateOutOfDateIdentifier().
+        // FIXME: clang should give us a better way to do this.
+        (void)impl.getClangPreprocessor().getLeafModuleMacros(clangID);
+
       // If it's an identifier that is itself a macro, look into that macro.
       if (clangID->hasMacroDefinition()) {
         auto isNilMacro =

--- a/test/ClangImporter/Inputs/sdk-bridging-header.h
+++ b/test/ClangImporter/Inputs/sdk-bridging-header.h
@@ -1,4 +1,5 @@
 @import ObjectiveC;
+#import <stdbool.h>
 
 @class NSArray;
 
@@ -11,3 +12,5 @@
 + (nonnull MyPredicate *)and:(nonnull NSArray *)subpredicates;
 + (nonnull MyPredicate *)or:(nonnull NSArray *)subpredicates;
 @end
+
+#define MY_TRUE true

--- a/test/ClangImporter/pch-bridging-header.swift
+++ b/test/ClangImporter/pch-bridging-header.swift
@@ -58,3 +58,7 @@ let not = MyPredicate.not()
 let and = MyPredicate.and([])
 let or = MyPredicate.or([not, and])
 
+// When a bridging header macro refers to a macro imported from another module,
+// do we actually find the other module's macro definition, or do we just fail
+// to import it?
+if MY_TRUE == 1 {}


### PR DESCRIPTION
After adopting the stable/20221013 clang branch, ClangImporter started seeing out-of-date identifiers in macros where it previously never had. Force these identifiers to update themselves before we read the macro definition out of them.

Fixes rdar://104456939.

~~WIP: Needs a test.~~