### PR TITLE
[Macros] Unify macro resolution under `ResolveMacroRequest`

### DIFF
--- a/include/swift/AST/MacroDeclaration.h
+++ b/include/swift/AST/MacroDeclaration.h
@@ -54,6 +54,10 @@ enum class MacroRole: uint32_t {
 /// The contexts in which a particular macro declaration can be used.
 using MacroRoles = OptionSet<MacroRole>;
 
+void simple_display(llvm::raw_ostream &out, MacroRoles roles);
+bool operator==(MacroRoles lhs, MacroRoles rhs);
+llvm::hash_code hash_value(MacroRoles roles);
+
 /// Retrieve the string form of the given macro role, as written on the
 /// corresponding attribute.
 StringRef getMacroRoleString(MacroRole role);
@@ -62,9 +66,13 @@ StringRef getMacroRoleString(MacroRole role);
 /// written in the source code with the `#` syntax.
 bool isFreestandingMacro(MacroRoles contexts);
 
+MacroRoles getFreestandingMacroRoles();
+
 /// Whether a macro with the given set of macro contexts is attached, i.e.,
 /// written in the source code as an attribute with the `@` syntax.
 bool isAttachedMacro(MacroRoles contexts);
+
+MacroRoles getAttachedMacroRoles();
 
 enum class MacroIntroducedDeclNameKind {
   Named,

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -340,7 +340,7 @@ SWIFT_REQUEST(TypeChecker, PreCheckResultBuilderRequest,
 SWIFT_REQUEST(TypeChecker, ResolveImplicitMemberRequest,
               evaluator::SideEffect(NominalTypeDecl *, ImplicitMemberAction),
               Uncached, NoLocationInfo)
-SWIFT_REQUEST(TypeChecker, ResolveAttachedMacroRequest,
+SWIFT_REQUEST(TypeChecker, ResolveMacroRequest,
               MacroDecl *(CustomAttr *, DeclContext *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveTypeEraserTypeRequest,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2356,7 +2356,8 @@ bool CustomAttr::isAttachedMacro(const Decl *decl) const {
 
   auto *macroDecl = evaluateOrDefault(
       ctx.evaluator,
-      ResolveAttachedMacroRequest{const_cast<CustomAttr *>(this), dc},
+      ResolveMacroRequest{const_cast<CustomAttr *>(this),
+                          getAttachedMacroRoles(), dc},
       nullptr);
 
   return macroDecl != nullptr;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -384,7 +384,7 @@ void Decl::forEachAttachedMacro(MacroRole role,
     auto customAttr = const_cast<CustomAttr *>(customAttrConst);
     auto *macroDecl = evaluateOrDefault(
         ctx.evaluator,
-        ResolveAttachedMacroRequest{customAttr, dc},
+        ResolveMacroRequest{customAttr, getAttachedMacroRoles(), dc},
         nullptr);
 
     if (!macroDecl)
@@ -9780,8 +9780,16 @@ bool swift::isFreestandingMacro(MacroRoles contexts) {
   return bool(contexts & freestandingMacroRoles);
 }
 
+MacroRoles swift::getFreestandingMacroRoles() {
+  return freestandingMacroRoles;
+}
+
 bool swift::isAttachedMacro(MacroRoles contexts) {
   return bool(contexts & attachedMacroRoles);
+}
+
+MacroRoles swift::getAttachedMacroRoles() {
+  return attachedMacroRoles;
 }
 
 MacroDecl::MacroDecl(

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3575,7 +3575,8 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
   if (!found) {
     // Try resolving an attached macro attribute.
     auto *macro = evaluateOrDefault(
-        Ctx.evaluator, ResolveAttachedMacroRequest{attr, dc}, nullptr);
+        Ctx.evaluator, ResolveMacroRequest{attr, getAttachedMacroRoles(), dc},
+        nullptr);
     if (macro || !attr->isValid())
       return;
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1602,14 +1602,16 @@ TypeChecker::lookupPrecedenceGroup(DeclContext *dc, Identifier name,
 
 SmallVector<MacroDecl *, 1>
 TypeChecker::lookupMacros(DeclContext *dc, DeclNameRef macroName,
-                          SourceLoc loc, MacroRoles contexts) {
-  auto result = lookupUnqualified(dc, DeclNameRef(macroName), loc,
-                                  (defaultUnqualifiedLookupOptions |
-                                      NameLookupFlags::IncludeOuterResults));
+                          SourceLoc loc, MacroRoles roles) {
   SmallVector<MacroDecl *, 1> choices;
-  for (const auto &found : result.allResults())
+  auto moduleScopeDC = dc->getModuleScopeContext();
+  ASTContext &ctx = moduleScopeDC->getASTContext();
+  UnqualifiedLookupDescriptor descriptor(macroName, moduleScopeDC);
+  auto lookup = evaluateOrDefault(
+      ctx.evaluator, UnqualifiedLookupRequest{descriptor}, {});
+  for (const auto &found : lookup.allResults())
     if (auto macro = dyn_cast<MacroDecl>(found.getValueDecl()))
-      if (contexts.contains(macro->getMacroRoles()))
+      if (roles.contains(macro->getMacroRoles()))
         choices.push_back(macro);
   return choices;
 }

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3685,9 +3685,12 @@ ExpandMacroExpansionDeclRequest::evaluate(Evaluator &evaluator,
   }
   // Resolve macro candidates.
   MacroDecl *macro;
-  // Non-call declaration macros cannot be overloaded.
-  auto *args = MED->getArgs();
-  if (!args) {
+  if (auto *args = MED->getArgs()) {
+    macro = evaluateOrDefault(
+        ctx.evaluator, ResolveMacroRequest{MED, MacroRole::Declaration, dc},
+        nullptr);
+  }
+  else {
     if (foundMacros.size() > 1) {
       MED->diagnose(diag::ambiguous_decl_ref, MED->getMacro())
           .highlight(MED->getMacroLoc().getSourceRange());
@@ -3697,63 +3700,8 @@ ExpandMacroExpansionDeclRequest::evaluate(Evaluator &evaluator,
     }
     macro = foundMacros.front();
   }
-    // Call-like macros need to be resolved.
-  else {
-    using namespace constraints;
-    ConstraintSystem cs(dc, ConstraintSystemOptions());
-    // Type-check macro arguments.
-    for (auto *arg : args->getArgExprs())
-      cs.setType(arg, TypeChecker::typeCheckExpression(arg, dc));
-    auto choices = map<SmallVector<OverloadChoice, 1>>(
-        foundMacros,
-        [](MacroDecl *md) {
-          return OverloadChoice(Type(), md, FunctionRefKind::SingleApply);
-        });
-    auto locator = cs.getConstraintLocator(MED);
-    auto macroRefType = Type(cs.createTypeVariable(locator, 0));
-    cs.addOverloadSet(macroRefType, choices, dc, locator);
-    if (MED->getGenericArgsRange().isValid()) {
-      // FIXME: Deal with generic args.
-      MED->diagnose(diag::macro_unsupported);
-      return {};
-    }
-    auto getMatchingParams = [&](
-        ArgumentList *argList,
-        SmallVectorImpl<AnyFunctionType::Param> &result) {
-      for (auto arg : *argList) {
-        ParameterTypeFlags flags;
-        auto ty = cs.getType(arg.getExpr()); if (arg.isInOut()) {
-          ty = ty->getInOutObjectType();
-          flags = flags.withInOut(true);
-        }
-        if (arg.isConst()) {
-          flags = flags.withCompileTimeConst(true);
-        }
-        result.emplace_back(ty, arg.getLabel(), flags);
-      }
-    };
-    SmallVector<AnyFunctionType::Param, 8> params;
-    getMatchingParams(args, params);
-    cs.associateArgumentList(locator, args);
-    cs.addConstraint(
-        ConstraintKind::ApplicableFunction,
-        FunctionType::get(params, ctx.getVoidType()),
-        macroRefType,
-        cs.getConstraintLocator(MED, ConstraintLocator::ApplyFunction));
-    // Solve.
-    auto solution = cs.solveSingle();
-    if (!solution) {
-      MED->diagnose(diag::no_overloads_match_exactly_in_call,
-                    /*reference|call*/false, DescriptiveDeclKind::Macro,
-                    false, MED->getMacro().getBaseName())
-          .highlight(MED->getMacroLoc().getSourceRange());
-      for (auto *candidate : foundMacros)
-        candidate->diagnose(diag::found_candidate);
-      return {};
-    }
-    auto choice = solution->getOverloadChoice(locator).choice;
-    macro = cast<MacroDecl>(choice.getDecl());
-  }
+  if (!macro)
+    return {};
   MED->setMacroRef(macro);
 
   // Expand the macro.

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -374,7 +374,7 @@ static bool isFromExpansionOfMacro(SourceFile *sourceFile, MacroDecl *macro,
       auto *decl = expansion.dyn_cast<Decl *>();
       auto &ctx = decl->getASTContext();
       auto *macroDecl = evaluateOrDefault(ctx.evaluator,
-          ResolveAttachedMacroRequest{macroAttr, decl->getDeclContext()},
+          ResolveMacroRequest{macroAttr, role, decl->getDeclContext()},
           nullptr);
       if (!macroDecl)
         return false;
@@ -1247,33 +1247,118 @@ bool swift::expandSynthesizedMembers(CustomAttr *attr, MacroDecl *macro,
   return synthesizedMembers;
 }
 
-MacroDecl *
-ResolveAttachedMacroRequest::evaluate(Evaluator &evaluator,
-                                      CustomAttr *attr,
-                                      DeclContext *dc) const {
-  auto &ctx = dc->getASTContext();
-  llvm::TinyPtrVector<ValueDecl *> macros;
-  findMacroForCustomAttr(attr, dc, macros);
+DeclNameRef UnresolvedMacroReference::getMacroName() const {
+  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
+    return med->getMacro();
+  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
+    return mee->getMacroName();
+  if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
+    auto *identTypeRepr = dyn_cast_or_null<IdentTypeRepr>(attr->getTypeRepr());
+    if (!identTypeRepr)
+      return DeclNameRef();
+    return identTypeRepr->getNameRef();
+  }
+  llvm_unreachable("Unhandled case");
+}
 
-  if (macros.empty())
+DeclNameLoc UnresolvedMacroReference::getMacroNameLoc() const {
+  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
+    return med->getMacroLoc();
+  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
+    return mee->getMacroNameLoc();
+  if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
+    auto *identTypeRepr = dyn_cast_or_null<IdentTypeRepr>(attr->getTypeRepr());
+    if (!identTypeRepr)
+      return DeclNameLoc();
+    return identTypeRepr->getNameLoc();
+  }
+  llvm_unreachable("Unhandled case");
+}
+
+SourceRange UnresolvedMacroReference::getGenericArgsRange() const {
+  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
+    return med->getGenericArgsRange();
+  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
+    return mee->getGenericArgsRange();
+  if (auto *attr = pointer.dyn_cast<CustomAttr *>())
+    return SourceRange();
+  llvm_unreachable("Unhandled case");
+}
+
+ArrayRef<TypeRepr *> UnresolvedMacroReference::getGenericArgs() const {
+  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
+    return med->getGenericArgs();
+  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
+    return mee->getGenericArgs();
+  if (auto *attr = pointer.dyn_cast<CustomAttr *>())
+    return {};
+  llvm_unreachable("Unhandled case");
+}
+
+ArgumentList *UnresolvedMacroReference::getArgs() const {
+  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
+    return med->getArgs();
+  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
+    return mee->getArgs();
+  if (auto *attr = pointer.dyn_cast<CustomAttr *>())
+    return attr->getArgs();
+  llvm_unreachable("Unhandled case");
+}
+
+void swift::simple_display(llvm::raw_ostream &out,
+                    const UnresolvedMacroReference &ref) {
+  if (ref.getDecl())
+    out << "macro-expansion-decl";
+  else if (ref.getExpr())
+    out << "macro-expansion-expr";
+  else if (ref.getAttr())
+    out << "custom-attr";
+}
+
+void swift::simple_display(llvm::raw_ostream &out, MacroRoles roles) {
+  out << "macro-roles";
+}
+
+bool swift::operator==(MacroRoles lhs, MacroRoles rhs) {
+  return lhs.containsOnly(rhs);
+}
+
+llvm::hash_code swift::hash_value(MacroRoles roles) {
+  return roles.toRaw();
+}
+
+MacroDecl *
+ResolveMacroRequest::evaluate(Evaluator &evaluator,
+                              UnresolvedMacroReference macroRef,
+                              MacroRoles roles,
+                              DeclContext *dc) const {
+  auto &ctx = dc->getASTContext();
+  auto foundMacros = TypeChecker::lookupMacros(
+      dc, macroRef.getMacroName(), SourceLoc(), roles);
+  if (foundMacros.empty())
     return nullptr;
 
-  // Extract macro arguments from the attribute, or create an empty list.
-  ArgumentList *attrArgs;
-  if (attr->hasArgs()) {
-    attrArgs = attr->getArgs();
-  } else {
-    attrArgs = ArgumentList::createImplicit(ctx, {});
-  }
+  // Extract macro arguments, or create an empty list.
+  auto *args = macroRef.getArgs();
+  if (!args)
+    args = ArgumentList::createImplicit(ctx, {});
 
   // Form an `OverloadedDeclRefExpr` with the filtered lookup result above
   // to ensure @freestanding macros are not considered in overload resolution.
   FunctionRefKind functionRefKind = FunctionRefKind::SingleApply;
-  auto *identTypeRepr = dyn_cast<IdentTypeRepr>(attr->getTypeRepr());
-  auto macroRefExpr = new (ctx) OverloadedDeclRefExpr(
-      macros, identTypeRepr->getNameLoc(), functionRefKind,
+  SmallVector<ValueDecl *> valueDecls;
+  for (auto *macro : foundMacros)
+    valueDecls.push_back(macro);
+  Expr *callee = new (ctx) OverloadedDeclRefExpr(
+      valueDecls, macroRef.getMacroNameLoc(), functionRefKind,
       /*implicit*/true);
-  auto *call = CallExpr::createImplicit(ctx, macroRefExpr, attrArgs);
+  auto genArgs = macroRef.getGenericArgs();
+  if (!genArgs.empty()) {
+    auto genArgsRange = macroRef.getGenericArgsRange();
+    callee = UnresolvedSpecializeExpr::create(
+        ctx, callee, genArgsRange.Start, genArgs, genArgsRange.End);
+  }
+  auto *call = CallExpr::createImplicit(ctx, callee, args);
 
   Expr *result = call;
   TypeChecker::typeCheckExpression(result, dc);
@@ -1283,6 +1368,7 @@ ResolveAttachedMacroRequest::evaluate(Evaluator &evaluator,
       return macro;
 
   // If we couldn't resolve a macro decl, the attribute is invalid.
-  attr->setInvalid();
+  if (auto *attr = macroRef.getAttr())
+    attr->setInvalid();
   return nullptr;
 }

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -67,10 +67,13 @@ func overloaded1(_ p: Any) { }
 // expected-note@-1{{macro 'intIdentity(value:_:)' declared here}}
 // expected-warning@-2{{external macro implementation type}}
 
-@freestanding(declaration) macro unaryDeclMacro(_ x: String) // expected-note {{found this candidate}}
+@freestanding(declaration) macro unaryDeclMacro(_ x: String)
 // expected-error @-1 {{macro 'unaryDeclMacro' requires a definition}}
-@freestanding(declaration) macro unaryDeclMacro(_ x: String, blah: Bool) // expected-note {{found this candidate}}
+@freestanding(declaration) macro unaryDeclMacro(_ x: String, blah: Bool)
 // expected-error @-1 {{macro 'unaryDeclMacro(_:blah:)' requires a definition}}
+@freestanding(declaration) macro genericDeclMacro<T: Numeric, U: Numeric>(_ x: T, _ y: U)
+// expected-error @-1 {{macro 'genericDeclMacro' requires a definition}}
+// expected-note @-2 {{where 'U' = 'String'}}
 
 func testDiags(a: Int, b: Int) {
   // FIXME: Bad diagnostic.
@@ -102,7 +105,9 @@ func testDiags(a: Int, b: Int) {
 
   struct Foo {
     #unaryDeclMacro("abc", blah: false) // okay
-    #unaryDeclMacro("abc", blah: false, oh: 2) // expected-error {{no exact matches in reference to macro 'unaryDeclMacro'}}
+    #unaryDeclMacro("abc", blah: false, oh: 2) // expected-error {{extra argument 'oh' in call}}
+    #genericDeclMacro(2, 4.0) // okay
+    #genericDeclMacro(2, "not a number") // expected-error {{macro 'genericDeclMacro' requires that 'String' conform to 'Numeric'}}
   }
 }
 


### PR DESCRIPTION
Rename `ResolveAttachedMacroRequest` to `ResolveMacroRequest` and make use of the request in freestanding declaration macro type checking. Add support for type-checking generic arguments on `MacroExpansionDecl`.