### PR TITLE
[SwiftSyntax] Adjustments because `VariableDeclSyntax` etc. are no longer expressible by string literals

### DIFF
--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -313,13 +313,13 @@ extension TypeWrapperMacro: MemberDeclarationMacro {
     attachedTo decl: DeclSyntax,
     in context: inout MacroExpansionContext
   ) throws -> [DeclSyntax] {
-    let storageVariable: VariableDeclSyntax =
+    let storageVariable: DeclSyntax =
       """
       private var _storage = _Storage()
       """
 
     return [
-      DeclSyntax(storageVariable),
+      storageVariable,
     ]
   }
 }
@@ -355,17 +355,17 @@ public struct AddMembers: MemberDeclarationMacro {
     attachedTo decl: DeclSyntax,
     in context: inout MacroExpansionContext
   ) throws -> [DeclSyntax] {
-    let storageStruct: StructDeclSyntax =
+    let storageStruct: DeclSyntax =
       """
       struct Storage {}
       """
 
-    let storageVariable: VariableDeclSyntax =
+    let storageVariable: DeclSyntax =
       """
       private var storage = Storage()
       """
 
-    let instanceMethod: FunctionDeclSyntax =
+    let instanceMethod: DeclSyntax =
       """
       func getStorage() -> Storage {
         print("synthesized method")
@@ -374,9 +374,9 @@ public struct AddMembers: MemberDeclarationMacro {
       """
 
     return [
-      DeclSyntax(storageStruct),
-      DeclSyntax(storageVariable),
-      DeclSyntax(instanceMethod),
+      storageStruct,
+      storageVariable,
+      instanceMethod,
     ]
   }
 }


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1269