### PR TITLE
[NameLookup] The custom attribute lookup request only returns nominal types.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1716,7 +1716,7 @@ public:
   }
 
 private:
-  friend class CustomAttrDeclRequest;
+  friend class CustomAttrNominalRequest;
   void resetTypeInformation(TypeExpr *repr);
 
 private:

--- a/include/swift/AST/NameLookupRequests.h
+++ b/include/swift/AST/NameLookupRequests.h
@@ -323,14 +323,11 @@ private:
                                        ExtensionDecl *ext) const;
 };
 
-using MacroOrNominalTypeDecl =
-    llvm::PointerUnion<MacroDecl *, NominalTypeDecl *>;
-
-/// Request the macro or nominal type declaration to which the given custom
+/// Request the nominal type declaration to which the given custom
 /// attribute refers.
-class CustomAttrDeclRequest :
-    public SimpleRequest<CustomAttrDeclRequest,
-                         MacroOrNominalTypeDecl(CustomAttr *, DeclContext *),
+class CustomAttrNominalRequest :
+    public SimpleRequest<CustomAttrNominalRequest,
+                         NominalTypeDecl *(CustomAttr *, DeclContext *),
                          RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -339,7 +336,7 @@ private:
   friend SimpleRequest;
 
   // Evaluation.
-  MacroOrNominalTypeDecl
+  NominalTypeDecl *
   evaluate(Evaluator &evaluator, CustomAttr *attr, DeclContext *dc) const;
 
 public:

--- a/include/swift/AST/NameLookupTypeIDZone.def
+++ b/include/swift/AST/NameLookupTypeIDZone.def
@@ -18,8 +18,8 @@
 SWIFT_REQUEST(NameLookup, AnyObjectLookupRequest,
               QualifiedLookupResult(const DeclContext *, DeclName, NLOptions),
               Uncached, NoLocationInfo)
-SWIFT_REQUEST(NameLookup, CustomAttrDeclRequest,
-              MacroOrNominalTypeDecl(CustomAttr *, DeclContext *), Cached,
+SWIFT_REQUEST(NameLookup, CustomAttrNominalRequest,
+              NominalTypeDecl *(CustomAttr *, DeclContext *), Cached,
               NoLocationInfo)
 SWIFT_REQUEST(NameLookup, DirectLookupRequest,
               TinyPtrVector<ValueDecl *>(DirectLookupDescriptor), Uncached,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -6848,11 +6848,8 @@ VarDecl::getAttachedPropertyWrapperTypeInfo(unsigned i) const {
     auto attr = attrs[i];
     auto dc = getDeclContext();
     ASTContext &ctx = getASTContext();
-    if (auto found = evaluateOrDefault(
-           ctx.evaluator, CustomAttrDeclRequest{attr, dc}, nullptr))
-      nominal = found.dyn_cast<NominalTypeDecl *>();
-    else
-      nominal = nullptr;
+    nominal = evaluateOrDefault(
+        ctx.evaluator, CustomAttrNominalRequest{attr, dc}, nullptr);
   }
 
   if (!nominal)
@@ -9878,8 +9875,7 @@ NominalTypeDecl *
 ValueDecl::getRuntimeDiscoverableAttrTypeDecl(CustomAttr *attr) const {
   auto &ctx = getASTContext();
   auto *nominal = evaluateOrDefault(
-      ctx.evaluator, CustomAttrDeclRequest{attr, getDeclContext()}, nullptr)
-    .get<NominalTypeDecl *>();
+      ctx.evaluator, CustomAttrNominalRequest{attr, getDeclContext()}, nullptr);
   assert(nominal->getAttrs().hasAttribute<RuntimeMetadataAttr>());
   return nominal;
 }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -3065,9 +3065,9 @@ void swift::findMacroForCustomAttr(CustomAttr *attr, DeclContext *dc,
   }
 }
 
-MacroOrNominalTypeDecl
-CustomAttrDeclRequest::evaluate(Evaluator &evaluator,
-                                CustomAttr *attr, DeclContext *dc) const {
+NominalTypeDecl *
+CustomAttrNominalRequest::evaluate(Evaluator &evaluator,
+                                   CustomAttr *attr, DeclContext *dc) const {
   // Look for names at module scope, so we don't trigger name lookup for
   // nested scopes. At this point, we're looking to see whether there are
   // any suitable macros.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3564,15 +3564,10 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
   auto dc = D->getDeclContext();
 
   // Figure out which nominal declaration this custom attribute refers to.
-  auto found = evaluateOrDefault(
-    Ctx.evaluator, CustomAttrDeclRequest{attr, dc}, nullptr);
+  auto *nominal = evaluateOrDefault(
+    Ctx.evaluator, CustomAttrNominalRequest{attr, dc}, nullptr);
 
-  NominalTypeDecl *nominal = nullptr;
-  if (found) {
-    nominal = found.dyn_cast<NominalTypeDecl *>();
-  }
-
-  if (!found) {
+  if (!nominal) {
     // Try resolving an attached macro attribute.
     auto *macro = evaluateOrDefault(
         Ctx.evaluator, ResolveAttachedMacroRequest{attr, dc}, nullptr);
@@ -7426,15 +7421,12 @@ static void forEachCustomAttribute(
   for (auto *attr : decl->getAttrs().getAttributes<CustomAttr>()) {
     auto *mutableAttr = const_cast<CustomAttr *>(attr);
 
-    auto found = evaluateOrDefault(
+    auto *nominal = evaluateOrDefault(
         ctx.evaluator,
-        CustomAttrDeclRequest{mutableAttr, decl->getDeclContext()}, nullptr);
-    if (!found)
-      continue;
+        CustomAttrNominalRequest{mutableAttr, decl->getDeclContext()}, nullptr);
 
-    auto nominal = found.dyn_cast<NominalTypeDecl *>();
     if (!nominal)
-      continue; // FIXME: add another entry point for macros we've found
+      continue;
 
     if (nominal->getAttrs().hasAttribute<ATTR>())
       fn(mutableAttr, nominal);

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -257,15 +257,10 @@ swift::checkGlobalActorAttributes(
   NominalTypeDecl *globalActorNominal = nullptr;
   for (auto attr : attrs) {
     // Figure out which nominal declaration this custom attribute refers to.
-    auto found = evaluateOrDefault(ctx.evaluator,
-                                   CustomAttrDeclRequest{attr, dc},
-                                    nullptr);
+    auto *nominal = evaluateOrDefault(ctx.evaluator,
+                                      CustomAttrNominalRequest{attr, dc},
+                                      nullptr);
 
-    // Ignore unresolvable custom attributes.
-    if (!found)
-      continue;
-
-    auto nominal = found.dyn_cast<NominalTypeDecl *>();
     if (!nominal)
       continue;
 

--- a/lib/Sema/TypeCheckPropertyWrapper.cpp
+++ b/lib/Sema/TypeCheckPropertyWrapper.cpp
@@ -441,12 +441,8 @@ AttachedPropertyWrappersRequest::evaluate(Evaluator &evaluator,
   for (auto attr : attachedAttrs.getAttributes<CustomAttr>()) {
     auto mutableAttr = const_cast<CustomAttr *>(attr);
     // Figure out which nominal declaration this custom attribute refers to.
-    auto found = evaluateOrDefault(
-      ctx.evaluator, CustomAttrDeclRequest{mutableAttr, dc}, nullptr);
-
-    NominalTypeDecl *nominal = nullptr;
-    if (found)
-      nominal = found.dyn_cast<NominalTypeDecl *>();
+    auto *nominal = evaluateOrDefault(
+      ctx.evaluator, CustomAttrNominalRequest{mutableAttr, dc}, nullptr);
 
     // If we didn't find a nominal type with a @propertyWrapper attribute,
     // skip this custom attribute.

--- a/lib/Sema/TypeCheckRequestFunctions.cpp
+++ b/lib/Sema/TypeCheckRequestFunctions.cpp
@@ -174,15 +174,10 @@ AttachedResultBuilderRequest::evaluate(Evaluator &evaluator,
   for (auto attr : decl->getAttrs().getAttributes<CustomAttr>()) {
     auto mutableAttr = const_cast<CustomAttr *>(attr);
     // Figure out which nominal declaration this custom attribute refers to.
-    auto found = evaluateOrDefault(ctx.evaluator,
-                                   CustomAttrDeclRequest{mutableAttr, dc},
-                                  nullptr);
+    auto *nominal = evaluateOrDefault(ctx.evaluator,
+                                      CustomAttrNominalRequest{mutableAttr, dc},
+                                      nullptr);
 
-    // Ignore unresolvable custom attributes.
-    if (!found)
-      continue;
-
-    auto nominal = found.dyn_cast<NominalTypeDecl *>();
     if (!nominal)
       continue;
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5022,7 +5022,7 @@ Type CustomAttrTypeRequest::evaluate(Evaluator &eval, CustomAttr *attr,
 
   // We always require the type to resolve to a nominal type. If the type was
   // not a nominal type, we should have already diagnosed an error via
-  // CustomAttrDeclRequest.
+  // CustomAttrNominalRequest.
   auto checkType = [](Type type) -> bool {
     while (auto *genericDecl = type->getAnyGeneric()) {
       if (isa<NominalTypeDecl>(genericDecl))

--- a/lib/Sema/TypeCheckTypeWrapper.cpp
+++ b/lib/Sema/TypeCheckTypeWrapper.cpp
@@ -123,15 +123,11 @@ static void getTypeWrappers(NominalTypeDecl *decl,
   // Attributes applied directly to the type.
   for (auto *attr : decl->getAttrs().getAttributes<CustomAttr>()) {
     auto *mutableAttr = const_cast<CustomAttr *>(attr);
-    auto found = evaluateOrDefault(
+    auto *nominal = evaluateOrDefault(
         ctx.evaluator,
-        CustomAttrDeclRequest{mutableAttr, decl->getDeclContext()},
+        CustomAttrNominalRequest{mutableAttr, decl->getDeclContext()},
         nullptr);
 
-    if (!found)
-      continue;
-
-    auto nominal = found.dyn_cast<NominalTypeDecl *>();
     if (!nominal)
       continue;
 


### PR DESCRIPTION
Macro attribute lookup is now implemented in `ResolveMacroRequest`, which happens later because it needs overload resolution to resolve a custom attribute to a macro decl.