### PR TITLE
[Macros] Use `@attached(member)` and `@attached(memberAttribute)` in the macro declaration syntax.

### DIFF
--- a/include/swift/AST/MacroDeclaration.h
+++ b/include/swift/AST/MacroDeclaration.h
@@ -48,7 +48,7 @@ enum class MacroRole: uint32_t {
   MemberAttribute = 0x08,
   /// An attached macro that generates synthesized members
   /// inside the declaration.
-  SynthesizedMembers = 0x10,
+  Member = 0x10,
 };
 
 /// The contexts in which a particular macro declaration can be used.

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -44,8 +44,8 @@ public:
     /// The expansion of a member attribute attached macro.
     MemberAttributeMacroExpansion,
 
-    /// The expansion of a synthesized member macro.
-    SynthesizedMemberMacroExpansion,
+    /// The expansion of an attached member macro.
+    MemberMacroExpansion,
 
     /// A new function body that is replacing an existing function body.
     ReplacedFunctionBody,

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3738,7 +3738,7 @@ void ASTMangler::appendMacroExpansionContext(
 
   case GeneratedSourceInfo::AccessorMacroExpansion:
   case GeneratedSourceInfo::MemberAttributeMacroExpansion:
-  case GeneratedSourceInfo::SynthesizedMemberMacroExpansion:
+  case GeneratedSourceInfo::MemberMacroExpansion:
   case GeneratedSourceInfo::PrettyPrinted:
   case GeneratedSourceInfo::ReplacedFunctionBody:
     return appendContext(origDC, StringRef());

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -260,7 +260,7 @@ ASTSourceFileScope::ASTSourceFileScope(SourceFile *SF,
     case MacroRole::MemberAttribute:
       parentLoc = expansion.getStartLoc();
       break;
-    case MacroRole::SynthesizedMembers: {
+    case MacroRole::Member: {
       // For synthesized member macros, take the end loc of the
       // enclosing declaration (before the closing brace), because
       // the macro expansion is inside this scope.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9722,7 +9722,7 @@ StringRef swift::getMacroRoleString(MacroRole role) {
     return "accessor";
 
   case MacroRole::MemberAttribute:
-    return "memberAttributes";
+    return "memberAttribute";
 
   case MacroRole::Member:
     return "member";

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9724,8 +9724,8 @@ StringRef swift::getMacroRoleString(MacroRole role) {
   case MacroRole::MemberAttribute:
     return "memberAttributes";
 
-  case MacroRole::SynthesizedMembers:
-    return "synthesizedMembers";
+  case MacroRole::Member:
+    return "member";
   }
 }
 
@@ -9771,7 +9771,7 @@ static MacroRoles freestandingMacroRoles =
 static MacroRoles attachedMacroRoles = (MacroRoles() |
                                         MacroRole::Accessor |
                                         MacroRole::MemberAttribute |
-                                        MacroRole::SynthesizedMembers);
+                                        MacroRole::Member);
 
 bool swift::isFreestandingMacro(MacroRoles contexts) {
   return bool(contexts & freestandingMacroRoles);
@@ -9924,7 +9924,7 @@ MacroDiscriminatorContext MacroDiscriminatorContext::getParentOf(
 
   case GeneratedSourceInfo::AccessorMacroExpansion:
   case GeneratedSourceInfo::MemberAttributeMacroExpansion:
-  case GeneratedSourceInfo::SynthesizedMemberMacroExpansion:
+  case GeneratedSourceInfo::MemberMacroExpansion:
   case GeneratedSourceInfo::PrettyPrinted:
   case GeneratedSourceInfo::ReplacedFunctionBody:
     return origDC;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -986,7 +986,7 @@ void IterableDeclContext::addMemberSilently(Decl *member, Decl *hint,
 
     // Synthesized member macros can add new members in a macro expansion buffer.
     auto *memberSourceFile = member->getInnermostDeclContext()->getParentSourceFile();
-    if (memberSourceFile->getFulfilledMacroRole() == MacroRole::SynthesizedMembers)
+    if (memberSourceFile->getFulfilledMacroRole() == MacroRole::Member)
       return;
 
     llvm::errs() << "Source ranges out of order in addMember():\n";

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1315,7 +1315,7 @@ std::vector<Diagnostic> DiagnosticEngine::getGeneratedSourceBufferNotes(
     case GeneratedSourceInfo::FreestandingDeclMacroExpansion:
     case GeneratedSourceInfo::AccessorMacroExpansion:
     case GeneratedSourceInfo::MemberAttributeMacroExpansion:
-    case GeneratedSourceInfo::SynthesizedMemberMacroExpansion: {
+    case GeneratedSourceInfo::MemberMacroExpansion: {
       SourceRange origRange = expansionNode.getSourceRange();
       DeclName macroName;
       if (auto customAttr = generatedInfo->attachedMacroCustomAttr) {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -915,8 +915,8 @@ Optional<MacroRole> SourceFile::getFulfilledMacroRole() const {
   case GeneratedSourceInfo::MemberAttributeMacroExpansion:
     return MacroRole::MemberAttribute;
 
-  case GeneratedSourceInfo::SynthesizedMemberMacroExpansion:
-    return MacroRole::SynthesizedMembers;
+  case GeneratedSourceInfo::MemberMacroExpansion:
+    return MacroRole::Member;
 
   case GeneratedSourceInfo::ReplacedFunctionBody:
   case GeneratedSourceInfo::PrettyPrinted:

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -36,7 +36,7 @@ enum MacroRole: UInt8 {
   case FreestandingDeclaration = 0x02
   case Accessor = 0x04
   case MemberAttribute = 0x08
-  case SynthesizedMembers = 0x10
+  case Member = 0x10
 }
 
 /// Resolve a reference to type metadata into a macro, if posible.
@@ -383,7 +383,7 @@ func expandAttachedMacro(
         $0.trimmedDescription
       }.joined(separator: " ")
 
-    case (let attachedMacro as MemberMacro.Type, .SynthesizedMembers):
+    case (let attachedMacro as MemberMacro.Type, .Member):
       let members = try attachedMacro.expansion(
         of: customAttrNode,
         attachedTo: declarationNode,

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -321,7 +321,7 @@ void SourceManager::setGeneratedSourceInfo(
   case GeneratedSourceInfo::FreestandingDeclMacroExpansion:
   case GeneratedSourceInfo::AccessorMacroExpansion:
   case GeneratedSourceInfo::MemberAttributeMacroExpansion:
-  case GeneratedSourceInfo::SynthesizedMemberMacroExpansion:
+  case GeneratedSourceInfo::MemberMacroExpansion:
   case GeneratedSourceInfo::PrettyPrinted:
     break;
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2193,7 +2193,7 @@ static Optional<MacroRole> getMacroRole(
       .Case("expression", MacroRole::Expression)
       .Case("accessor", MacroRole::Accessor)
       .Case("memberAttributes", MacroRole::MemberAttribute)
-      .Case("synthesizedMembers", MacroRole::SynthesizedMembers)
+      .Case("member", MacroRole::Member)
       .Default(None);
 
   if (!role) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2192,7 +2192,7 @@ static Optional<MacroRole> getMacroRole(
       .Case("declaration", MacroRole::Declaration)
       .Case("expression", MacroRole::Expression)
       .Case("accessor", MacroRole::Accessor)
-      .Case("memberAttributes", MacroRole::MemberAttribute)
+      .Case("memberAttribute", MacroRole::MemberAttribute)
       .Case("member", MacroRole::Member)
       .Default(None);
 

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -174,7 +174,7 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
     switch (generatedInfo->kind) {
     case GeneratedSourceInfo::FreestandingDeclMacroExpansion:
     case GeneratedSourceInfo::ExpressionMacroExpansion:
-    case GeneratedSourceInfo::SynthesizedMemberMacroExpansion:
+    case GeneratedSourceInfo::MemberMacroExpansion:
     case GeneratedSourceInfo::ReplacedFunctionBody:
     case GeneratedSourceInfo::PrettyPrinted: {
       parser.parseTopLevelItems(items);

--- a/lib/Sema/TypeCheckMacros.h
+++ b/lib/Sema/TypeCheckMacros.h
@@ -62,7 +62,7 @@ bool expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member);
 ///
 /// Returns \c true if the macro added new synthesized members, \c false
 /// otherwise.
-bool expandSynthesizedMembers(CustomAttr *attr, MacroDecl *macro, Decl *decl);
+bool expandMembers(CustomAttr *attr, MacroDecl *macro, Decl *decl);
 
 } // end namespace swift
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -613,7 +613,7 @@ enum class MacroRole : uint8_t {
   Declaration,
   Accessor,
   MemberAttribute,
-  SynthesizedMembers,
+  Member,
 };
 using MacroRoleField = BCFixed<3>;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2227,7 +2227,7 @@ static uint8_t getRawStableMacroRole(swift::MacroRole context) {
   CASE(Declaration)
   CASE(Accessor)
   CASE(MemberAttribute)
-  CASE(SynthesizedMembers)
+  CASE(Member)
   }
 #undef CASE
   llvm_unreachable("bad result declaration macro kind");

--- a/test/Macros/composed_macro.swift
+++ b/test/Macros/composed_macro.swift
@@ -10,7 +10,7 @@
 // REQUIRES: OS=macosx
 
 @attached(memberAttributes)
-@attached(synthesizedMembers)
+@attached(member)
 macro myTypeWrapper() = #externalMacro(module: "MacroDefinition", type: "TypeWrapperMacro")
 @attached(accessor) macro accessViaStorage() = #externalMacro(module: "MacroDefinition", type: "AccessViaStorageMacro")
 

--- a/test/Macros/composed_macro.swift
+++ b/test/Macros/composed_macro.swift
@@ -9,7 +9,7 @@
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx
 
-@attached(memberAttributes)
+@attached(memberAttribute)
 @attached(member)
 macro myTypeWrapper() = #externalMacro(module: "MacroDefinition", type: "TypeWrapperMacro")
 @attached(accessor) macro accessViaStorage() = #externalMacro(module: "MacroDefinition", type: "AccessViaStorageMacro")

--- a/test/Macros/macro_expand_attributes.swift
+++ b/test/Macros/macro_expand_attributes.swift
@@ -9,7 +9,7 @@
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx
 
-@attached(memberAttributes) macro wrapAllProperties() = #externalMacro(module: "MacroDefinition", type: "WrapAllProperties")
+@attached(memberAttribute) macro wrapAllProperties() = #externalMacro(module: "MacroDefinition", type: "WrapAllProperties")
 
 @propertyWrapper
 struct Wrapper<T> {

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -9,7 +9,7 @@
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx
 
-@attached(synthesizedMembers) macro addMembers() = #externalMacro(module: "MacroDefinition", type: "AddMembers")
+@attached(member) macro addMembers() = #externalMacro(module: "MacroDefinition", type: "AddMembers")
 
 @addMembers
 struct S {

--- a/test/Serialization/Inputs/def_macros.swift
+++ b/test/Serialization/Inputs/def_macros.swift
@@ -4,7 +4,7 @@
 
 @attached(accessor) public macro myWrapper() = #externalMacro(module: "MacroDefinition", type: "MyWrapperMacro")
 
-@attached(memberAttributes) public macro wrapAllProperties() = #externalMacro(module: "MacroDefinition", type: "WrapAllProperties")
+@attached(memberAttribute) public macro wrapAllProperties() = #externalMacro(module: "MacroDefinition", type: "WrapAllProperties")
 
 // Make sure that macro custom attributes are not serialized.
 @wrapAllProperties


### PR DESCRIPTION
* Rename `@attached(synthesizedMembers)` to `@attached(member)`.
* Rename `@attached(memberAttributes)` to `@attached(memberAttribute)`.