### PR TITLE
[5.8] Adjustments because SwiftSyntax cherry-picks most API changes from main to release/5.8

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/Decls.swift
+++ b/lib/ASTGen/Sources/ASTGen/Decls.swift
@@ -75,7 +75,7 @@ extension ASTGenVisitor {
 
     let loc = self.base.advanced(by: node.position.utf8Offset).raw
     let isStateic = false  // TODO: compute this
-    let isLet = node.letOrVarKeyword.tokenKind == .letKeyword
+    let isLet = node.letOrVarKeyword.tokenKind == .keyword(.let)
 
     // TODO: don't drop "initializer" on the floor.
     return .decl(

--- a/lib/ASTGen/Sources/ASTGen/Exprs.swift
+++ b/lib/ASTGen/Sources/ASTGen/Exprs.swift
@@ -20,7 +20,7 @@ extension ASTGenVisitor {
       let tupleElement = TupleExprElementSyntax(
         label: nil, colon: nil, expression: ExprSyntax(trailingClosure), trailingComma: nil)
 
-      return visit(node.addArgument(tupleElement).withTrailingClosure(nil))
+      return visit(node.addArgument(tupleElement).with(\.trailingClosure, nil))
     }
 
     let args = visit(node.argumentList).rawValue

--- a/lib/ASTGen/Sources/ASTGen/Literals.swift
+++ b/lib/ASTGen/Sources/ASTGen/Literals.swift
@@ -23,7 +23,7 @@ extension ASTGenVisitor {
 
   public func visit(_ node: BooleanLiteralExprSyntax) -> ASTNode {
     let loc = self.base.advanced(by: node.position.utf8Offset).raw
-    let value = node.booleanLiteral == .trueKeyword()
+    let value = node.booleanLiteral == .keyword(.true)
     return .expr(SwiftBooleanLiteralExpr_create(ctx, value, loc))
   }
 

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -176,7 +176,7 @@ func evaluateMacro(
     }
 
     // Emit diagnostics accumulated in the context.
-    let macroName = parentExpansion.macro.withoutTrivia().description
+    let macroName = parentExpansion.macro.trimmedDescription
     for diag in context.diagnostics {
       emitDiagnostic(
         diagEnginePtr: diagEnginePtr,
@@ -186,7 +186,7 @@ func evaluateMacro(
       )
     }
 
-    var evaluatedSyntaxStr = evaluatedSyntax.withoutTrivia().description
+    var evaluatedSyntaxStr = evaluatedSyntax.trimmedDescription
     evaluatedSyntaxStr.withUTF8 { utf8 in
       let evaluatedResultPtr = UnsafeMutablePointer<UInt8>.allocate(capacity: utf8.count + 1)
       if let baseAddress = utf8.baseAddress {

--- a/lib/ASTGen/Sources/ASTGen/Types.swift
+++ b/lib/ASTGen/Sources/ASTGen/Types.swift
@@ -145,12 +145,12 @@ extension ASTGenVisitor {
       let lParenLoc = self.base.advanced(by: node.leftParen.position.utf8Offset).raw
       let rParenLoc = self.base.advanced(by: node.rightParen.position.utf8Offset).raw
       let args = TupleTypeRepr_create(self.ctx, elements, lParenLoc, rParenLoc)
-      let asyncLoc = node.asyncKeyword.map { self.base.advanced(by: $0.position.utf8Offset).raw }
-      let throwsLoc = node.throwsOrRethrowsKeyword.map {
+      let asyncLoc = node.effectSpecifiers?.asyncSpecifier.map { self.base.advanced(by: $0.position.utf8Offset).raw }
+      let throwsLoc = node.effectSpecifiers?.throwsSpecifier.map {
         self.base.advanced(by: $0.position.utf8Offset).raw
       }
-      let arrowLoc = self.base.advanced(by: node.arrow.position.utf8Offset).raw
-      let retTy = visit(node.returnType).rawValue
+      let arrowLoc = self.base.advanced(by: node.output.arrow.position.utf8Offset).raw
+      let retTy = visit(node.output.returnType).rawValue
       return .type(FunctionTypeRepr_create(self.ctx, args, asyncLoc, throwsLoc, arrowLoc, retTy))
     }
   }

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -36,7 +36,7 @@ public struct FileIDMacro: ExpressionMacro {
   public static func expansion(
     of macro: MacroExpansionExprSyntax, in context: inout MacroExpansionContext
   ) -> ExprSyntax {
-    let fileLiteral: ExprSyntax = #""\#(context.moduleName)/\#(context.fileName)""#
+    let fileLiteral: ExprSyntax = #""\#(raw: context.moduleName)/\#(raw: context.fileName)""#
     if let leadingTrivia = macro.leadingTrivia {
       return fileLiteral.with(\.leadingTrivia, leadingTrivia)
     }
@@ -82,9 +82,9 @@ public struct AddBlocker: ExpressionMacro {
     }
 
     // Link the folded argument back into the tree.
-    var node = node.with(\.argumentList, node.argumentList.replacing(childAt: 0, with: node.argumentList.first!.with(\.expression, foldedArgument.as(ExprSyntax.self)!)))
+    let node = node.with(\.argumentList, node.argumentList.replacing(childAt: 0, with: node.argumentList.first!.with(\.expression, foldedArgument.as(ExprSyntax.self)!)))
 
-   class AddVisitor: SyntaxRewriter {
+    class AddVisitor: SyntaxRewriter {
       var diagnostics: [Diagnostic] = []
 
       override func visit(
@@ -117,7 +117,7 @@ public struct AddBlocker: ExpressionMacro {
                         oldNode: Syntax(binOp.operatorToken.with(\.leadingTrivia, []).with(\.trailingTrivia, [])),
                         newNode: Syntax(
                           TokenSyntax(
-                            .spacedBinaryOperator("-"),
+                            .binaryOperator("-"),
                             presence: .present
                           )
                         )
@@ -134,7 +134,7 @@ public struct AddBlocker: ExpressionMacro {
                 ExprSyntax(
                   binOp.with(
                     \.operatorToken,
-                    binOp.operatorToken.withKind(.spacedBinaryOperator("-"))
+                    binOp.operatorToken.withKind(.binaryOperator("-"))
                   )
                 )
               )

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -14,7 +14,7 @@ private func replaceFirstLabel(
   }
 
   return tuple.replacing(
-    childAt: 0, with: firstElement.withLabel(.identifier(newLabel)))
+    childAt: 0, with: firstElement.with(\.label, .identifier(newLabel)))
 }
 
 public struct ColorLiteralMacro: ExpressionMacro {
@@ -26,7 +26,7 @@ public struct ColorLiteralMacro: ExpressionMacro {
     )
     let initSyntax: ExprSyntax = ".init(\(argList))"
     if let leadingTrivia = macro.leadingTrivia {
-      return initSyntax.withLeadingTrivia(leadingTrivia)
+      return initSyntax.with(\.leadingTrivia, leadingTrivia)
     }
     return initSyntax
   }
@@ -38,7 +38,7 @@ public struct FileIDMacro: ExpressionMacro {
   ) -> ExprSyntax {
     let fileLiteral: ExprSyntax = #""\#(context.moduleName)/\#(context.fileName)""#
     if let leadingTrivia = macro.leadingTrivia {
-      return fileLiteral.withLeadingTrivia(leadingTrivia)
+      return fileLiteral.with(\.leadingTrivia, leadingTrivia)
     }
     return fileLiteral
   }
@@ -82,7 +82,7 @@ public struct AddBlocker: ExpressionMacro {
     }
 
     // Link the folded argument back into the tree.
-    var node = node.withArgumentList(node.argumentList.replacing(childAt: 0, with: node.argumentList.first!.withExpression(foldedArgument.as(ExprSyntax.self)!)))
+    var node = node.with(\.argumentList, node.argumentList.replacing(childAt: 0, with: node.argumentList.first!.with(\.expression, foldedArgument.as(ExprSyntax.self)!)))
 
    class AddVisitor: SyntaxRewriter {
       var diagnostics: [Diagnostic] = []
@@ -102,8 +102,8 @@ public struct AddBlocker: ExpressionMacro {
                   severity: .error
                 ),
                 highlights: [
-                  Syntax(node.leftOperand.withoutTrivia()),
-                  Syntax(node.rightOperand.withoutTrivia())
+                  Syntax(node.leftOperand.with(\.leadingTrivia, []).with(\.trailingTrivia, [])),
+                  Syntax(node.rightOperand.with(\.leadingTrivia, []).with(\.trailingTrivia, []))
                 ],
                 fixIts: [
                   FixIt(
@@ -114,7 +114,7 @@ public struct AddBlocker: ExpressionMacro {
                     ),
                     changes: [
                       FixIt.Change.replace(
-                        oldNode: Syntax(binOp.operatorToken.withoutTrivia()),
+                        oldNode: Syntax(binOp.operatorToken.with(\.leadingTrivia, []).with(\.trailingTrivia, [])),
                         newNode: Syntax(
                           TokenSyntax(
                             .spacedBinaryOperator("-"),
@@ -129,9 +129,11 @@ public struct AddBlocker: ExpressionMacro {
             )
 
             return ExprSyntax(
-              node.withOperatorOperand(
+              node.with(
+                \.operatorOperand,
                 ExprSyntax(
-                  binOp.withOperatorToken(
+                  binOp.with(
+                    \.operatorToken,
                     binOp.operatorToken.withKind(.spacedBinaryOperator("-"))
                   )
                 )

--- a/test/Parse/new_parser_diagnostics.swift
+++ b/test/Parse/new_parser_diagnostics.swift
@@ -5,5 +5,5 @@
 // REQUIRES: asserts
 
 _ = [(Int) -> async throws Int]()
-// expected-error@-1{{'async throws' may only occur before '->'}}
+// expected-error@-1{{'async throws' must preceed '->'}}
 // expected-note@-2{{move 'async throws' in front of '->'}}{{15-21=}} {{21-28=}} {{20-21= }} {{12-12=async }} {{12-12=throws }}


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1285.

This cherry-picks the following PRs to `release/5.8` to update this repo for the SwiftSyntax API changes cherry-picked to `release/5.8` by https://github.com/apple/swift-syntax/pull/1285:
- https://github.com/apple/swift/pull/62969
- https://github.com/apple/swift/pull/63160
- https://github.com/apple/swift/pull/63215
- https://github.com/apple/swift/pull/63251