### PR TITLE
[DNM] Revert "[Serialization] Enable deserialization safety by default"

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -366,7 +366,7 @@ namespace swift {
 
     /// Enable early skipping deserialization of decls that are marked as
     /// unsafe to read.
-    bool EnableDeserializationSafety = true;
+    bool EnableDeserializationSafety = false;
 
     /// Whether to enable the new operator decl and precedencegroup lookup
     /// behavior. This is a staging flag, and will be removed in the future.

--- a/test/IRGen/type_layout_dumper_all.swift
+++ b/test/IRGen/type_layout_dumper_all.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/type_layout_dumper_other.swiftmodule -module-name=type_layout_dumper_other %S/Inputs/type_layout_dumper_other.swift
 
-// RUN: %target-swift-frontend -dump-type-info -I %t %s -disable-deserialization-safety | %FileCheck %s
+// RUN: %target-swift-frontend -dump-type-info -I %t %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx

--- a/test/IRGen/type_layout_dumper_resilient.swift
+++ b/test/IRGen/type_layout_dumper_resilient.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -enable-library-evolution -emit-module-path=%t/type_layout_dumper_other.swiftmodule -module-name=type_layout_dumper_other %S/Inputs/type_layout_dumper_other.swift
 
-// RUN: %target-swift-frontend -dump-type-info -type-info-dump-filter=resilient -I %t %s -disable-deserialization-safety | %FileCheck %s
+// RUN: %target-swift-frontend -dump-type-info -type-info-dump-filter=resilient -I %t %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: OS=macosx

--- a/test/Serialization/Safety/override-internal-func.swift
+++ b/test/Serialization/Safety/override-internal-func.swift
@@ -10,11 +10,13 @@
 // RUN:   -emit-module-interface-path %t/Lib.swiftinterface
 
 /// Build against the swiftmodule.
-// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -enable-deserialization-safety
 
 /// Build against the swiftinterface.
 // RUN: rm %t/Lib.swiftmodule
-// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -enable-deserialization-safety
 
 //--- Lib.swift
 

--- a/test/Serialization/Safety/skip-reading-internal-anyobject.swift
+++ b/test/Serialization/Safety/skip-reading-internal-anyobject.swift
@@ -11,7 +11,8 @@
 
 /// Build client.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -verify -Xllvm -debug-only=Serialization 2>&1 \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -enable-deserialization-safety 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=SAFE %s
 
 /// Decls skips by the deserialization safety logic.

--- a/test/Serialization/Safety/skip-reading-internal-details.swift
+++ b/test/Serialization/Safety/skip-reading-internal-details.swift
@@ -19,7 +19,8 @@
 // RUN:   | %FileCheck --check-prefixes=NEEDED,UNSAFE %s
 
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -verify -Xllvm -debug-only=Serialization 2>&1 \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -enable-deserialization-safety 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=NEEDED,CLEAN,SAFE %s
 
 /// Build against the swiftinterface.

--- a/test/Serialization/Safety/unsafe-decls.swift
+++ b/test/Serialization/Safety/unsafe-decls.swift
@@ -4,11 +4,13 @@
 
 // RUN: %target-swift-frontend -emit-module %s \
 // RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
 // RUN:   -Xllvm -debug-only=Serialization 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=SAFETY-PRIVATE,SAFETY-INTERNAL %s
 
 // RUN: %target-swift-frontend -emit-module %s \
 // RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
 // RUN:   -Xllvm -debug-only=Serialization \
 // RUN:   -enable-testing 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=SAFETY-PRIVATE,NO-SAFETY-INTERNAL-NOT %s
@@ -16,13 +18,14 @@
 /// Don't mark decls as unsafe when private import is enabled.
 // RUN: %target-swift-frontend -emit-module %s \
 // RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
 // RUN:   -Xllvm -debug-only=Serialization \
 // RUN:   -enable-private-imports 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=DISABLED %s
 
 /// Don't mark decls as unsafe without library evolution.
 // RUN: %target-swift-frontend -emit-module %s \
-// RUN:   -swift-version 5 \
+// RUN:   -enable-deserialization-safety -swift-version 5 \
 // RUN:   -Xllvm -debug-only=Serialization 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=DISABLED %s
 

--- a/test/Serialization/Safety/unsafe-extensions.swift
+++ b/test/Serialization/Safety/unsafe-extensions.swift
@@ -4,11 +4,13 @@
 
 // RUN: %target-swift-frontend -emit-module %s \
 // RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
 // RUN:   -Xllvm -debug-only=Serialization 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=SAFETY-PRIVATE,SAFETY-INTERNAL %s
 
 // RUN: %target-swift-frontend -emit-module %s \
 // RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
 // RUN:   -Xllvm -debug-only=Serialization \
 // RUN:   -enable-testing 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=SAFETY-PRIVATE,NO-SAFETY-INTERNAL %s
@@ -16,13 +18,14 @@
 /// Don't mark decls as unsafe when private import is enabled.
 // RUN: %target-swift-frontend -emit-module %s \
 // RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
 // RUN:   -Xllvm -debug-only=Serialization \
 // RUN:   -enable-private-imports 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=DISABLED %s
 
 /// Don't mark decls as unsafe without library evolution.
 // RUN: %target-swift-frontend -emit-module %s \
-// RUN:   -swift-version 5 \
+// RUN:   -enable-deserialization-safety -swift-version 5 \
 // RUN:   -Xllvm -debug-only=Serialization 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=DISABLED %s
 


### PR DESCRIPTION
Reverts apple/swift#63116

Investigate whether this is a possible cause of RxSwift failures in source compat suite.