### PR TITLE
[Concurrency] Add include of unistd.h to TaskGroup.cpp

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -39,6 +39,10 @@
 #include <mutex>
 #endif
 
+#if defined(__APPLE__)
+#include <unistd.h>
+#endif
+
 #if SWIFT_STDLIB_HAS_ASL
 #include <asl.h>
 #elif defined(__ANDROID__)

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -1080,6 +1080,15 @@ static void _enqueueCompletedTask(NaiveTaskGroupQueue<ReadyQueueItem> *readyQueu
   readyQueue->enqueue(readyItem);
 }
 
+#if SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL
+static void _enqueueRawError(DiscardingTaskGroup *group,
+                             NaiveTaskGroupQueue<ReadyQueueItem> *readyQueue,
+                             SwiftError *error) {
+  auto readyItem = ReadyQueueItem::getRawError(group, error);
+  readyQueue->enqueue(readyItem);
+}
+#endif
+
 // TaskGroup is locked upon entry and exit
 void AccumulatingTaskGroup::enqueueCompletedTask(AsyncTask *completedTask, bool hadErrorResult) {
   // Retain the task while it is in the queue; it must remain alive until

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -40,6 +40,7 @@
 #endif
 
 #if defined(__APPLE__)
+#include <asl.h>
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
rdar://104758975

Missing import caused build failures:

```
stdlib/public/Concurrency/TaskGroup.cpp:572:11: error: use of undeclared identifier 'STDERR_FILENO'
    write(STDERR_FILENO, message, strlen(message));
          ^
```
