### PR TITLE
[Serialization] Drop overriding relationship in constructors when safe

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3138,6 +3138,10 @@ public:
     } else if (overriddenOrError.errorIsA<FatalDeserializationError>()) {
       // Pass through fatal deserialization errors.
       return overriddenOrError.takeError();
+    } else if (MF.allowCompilerErrors()) {
+      // Drop overriding relationship when allowing errors.
+      llvm::consumeError(overriddenOrError.takeError());
+      overridden = nullptr;
     } else {
       llvm::consumeError(overriddenOrError.takeError());
       if (overriddenAffectsABI || !ctx.LangOpts.EnableDeserializationRecovery) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3094,7 +3094,7 @@ public:
     GenericSignatureID genericSigID;
     uint8_t storedInitKind, rawAccessLevel;
     DeclID overriddenID;
-    bool needsNewVTableEntry, firstTimeRequired;
+    bool overriddenAffectsABI, needsNewVTableEntry, firstTimeRequired;
     unsigned numArgNames;
     ArrayRef<uint64_t> argNameAndDependencyIDs;
 
@@ -3104,6 +3104,7 @@ public:
                                                async, throws, storedInitKind,
                                                genericSigID,
                                                overriddenID,
+                                               overriddenAffectsABI,
                                                rawAccessLevel,
                                                needsNewVTableEntry,
                                                firstTimeRequired,
@@ -3130,15 +3131,21 @@ public:
       attrs.setRawAttributeChain(DAttrs);
     }
 
-    auto overridden = MF.getDeclChecked(overriddenID);
-    if (!overridden) {
-      // Pass through deserialization errors.
-      if (overridden.errorIsA<FatalDeserializationError>())
-        return overridden.takeError();
+    Expected<Decl *> overriddenOrError = MF.getDeclChecked(overriddenID);
+    Decl *overridden;
+    if (overriddenOrError) {
+      overridden = overriddenOrError.get();
+    } else if (overriddenOrError.errorIsA<FatalDeserializationError>()) {
+      // Pass through fatal deserialization errors.
+      return overriddenOrError.takeError();
+    } else {
+      llvm::consumeError(overriddenOrError.takeError());
+      if (overriddenAffectsABI || !ctx.LangOpts.EnableDeserializationRecovery) {
+        return llvm::make_error<OverrideError>(name, errorFlags,
+                                               numVTableEntries);
+      }
 
-      llvm::consumeError(overridden.takeError());
-      return llvm::make_error<OverrideError>(
-          name, errorFlags, numVTableEntries);
+      overridden = nullptr;
     }
 
     for (auto dependencyID : argNameAndDependencyIDs.slice(numArgNames)) {
@@ -3198,7 +3205,7 @@ public:
     ctx.evaluator.cacheOutput(NeedsNewVTableEntryRequest{ctor},
                               std::move(needsNewVTableEntry));
 
-    ctor->setOverriddenDecl(cast_or_null<ConstructorDecl>(overridden.get()));
+    ctor->setOverriddenDecl(cast_or_null<ConstructorDecl>(overridden));
     if (auto *overridden = ctor->getOverriddenDecl()) {
       if (!attributeChainContains<RequiredAttr>(DAttrs) ||
           !overridden->isRequired()) {

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 741; // SIL pack types
+const uint16_t SWIFTMODULE_VERSION_MINOR = 742; // Constructor affects ABI
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -1455,6 +1455,7 @@ namespace decls_block {
     CtorInitializerKindField,  // initializer kind
     GenericSignatureIDField, // generic environment
     DeclIDField, // overridden decl
+    BCFixed<1>,   // whether the overridden decl affects ABI
     AccessLevelField, // access level
     BCFixed<1>,   // requires a new vtable slot
     BCFixed<1>,   // 'required' but overridden is not (used for recovery)

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3540,13 +3540,15 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       return false;
 
     // In a public-override-internal case, the override doesn't have ABI
-    // implications.
+    // implications. This corresponds to hiding the override keyword from the
+    // module interface.
     auto isPublic = [](const ValueDecl *VD) {
       return VD->getFormalAccessScope(VD->getDeclContext(),
                                       /*treatUsableFromInlineAsPublic*/true)
                .isPublic();
     };
-    if (isPublic(override) && !isPublic(overridden))
+    if (override->getDeclContext()->getParentModule()->isResilient() &&
+        isPublic(override) && !isPublic(overridden))
       return false;
 
     return true;

--- a/test/Serialization/Safety/override-internal-func.swift
+++ b/test/Serialization/Safety/override-internal-func.swift
@@ -19,6 +19,8 @@
 //--- Lib.swift
 
 open class Base {
+  internal init() {}
+
   public func publicMethod() -> Int {
     return 1
   }
@@ -33,6 +35,10 @@ open class Base {
 }
 
 open class Derived : Base {
+  public override init() {
+      super.init()
+  }
+
   open override func publicMethod() -> Int {
     return super.publicMethod() + 1
   }
@@ -62,4 +68,8 @@ public class OtherFinalDerived : Derived {
   public override func internalMethod() -> Int {
     return super.internalMethod() + 1
   }
+}
+
+func foo() {
+    let a = Derived()
 }


### PR DESCRIPTION
Deserialization recovery lead the compiler to drop public constructors overriding internal constructors. This PR limits the logic to dropping only the overriding relationship instead of the whole constructor. This applies when the overriden constructor fails to deserialize and only when the overriding relationship was marked as not affecting ABI. This should realign the behavior between swiftmodules and swiftinterfaces.

rdar://104704832

Fixes: https://github.com/apple/swift/issues/63242

This is the equivalent of https://github.com/apple/swift/pull/63068 for constructors.