### PR TITLE
build: Override default build variant for `--xcode`

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -357,7 +357,7 @@ while retaining the option of building with Ninja on the command line.
 
 Assuming that you have already [built the toolchain via Ninja](#the-actual-build),
 several more steps are necessary to set up this environment:
-* Generate Xcode projects with `utils/build-script --release --swift-darwin-supported-archs "$(uname -m)" --xcode --clean`.
+* Generate Xcode projects with `utils/build-script --swift-darwin-supported-archs "$(uname -m)" --xcode --clean`.
   This will first build a few LLVM files that are needed to configure the
   projects.
 * Create a new Xcode workspace.

--- a/utils/build_swift/build_swift/driver_arguments.py
+++ b/utils/build_swift/build_swift/driver_arguments.py
@@ -56,9 +56,20 @@ def _apply_default_arguments(args):
        args.lldb_build_with_xcode is not None:
         args.build_lldb = True
 
+    # Set the default CMake generator.
+    if args.cmake_generator is None:
+        args.cmake_generator = 'Ninja'
+    elif args.cmake_generator == 'Xcode':
+        # Building with Xcode is deprecated.
+        args.skip_build = True
+        args.build_early_swift_driver = False
+        args.build_early_swiftsyntax = False
+
     # Set the default build variant.
     if args.build_variant is None:
-        args.build_variant = 'Debug'
+        args.build_variant = (
+            'MinSizeRel' if args.cmake_generator == 'Xcode' else 'Debug'
+        )
 
     if args.llvm_build_variant is None:
         args.llvm_build_variant = args.build_variant
@@ -118,15 +129,6 @@ def _apply_default_arguments(args):
 
     if args.lldb_assertions is None:
         args.lldb_assertions = args.assertions
-
-    # Set the default CMake generator.
-    if args.cmake_generator is None:
-        args.cmake_generator = 'Ninja'
-    elif args.cmake_generator == 'Xcode':
-        # Building with Xcode is deprecated.
-        args.skip_build = True
-        args.build_early_swift_driver = False
-        args.build_early_swiftsyntax = False
 
     # --ios-all etc are not supported by open-source Swift.
     if args.ios_all:

--- a/utils/build_swift/tests/build_swift/test_driver_arguments.py
+++ b/utils/build_swift/tests/build_swift/test_driver_arguments.py
@@ -644,6 +644,7 @@ class TestDriverArgumentParser(
     def test_implied_defaults_xcode(self):
         namespace = self.parse_default_args(['--xcode'])
         self.assertEqual(namespace.cmake_generator, 'Xcode')
+        self.assertEqual(namespace.build_variant, 'MinSizeRel')
         self.assertTrue(namespace.skip_build)
         self.assertFalse(namespace.build_early_swift_driver)
         self.assertFalse(namespace.build_early_swiftsyntax)


### PR DESCRIPTION
Follow-up to #62156.