### PR TITLE
[Dependency Scanning] Treat '-embed-tbd-for-module' modules as implicit import dependencies.

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -1195,6 +1195,13 @@ identifyMainModuleDependencies(CompilerInstance &instance) {
       mainDependencies.addModuleImport(mainModule->getName().str(),
                                            &alreadyAddedModules);
     }
+
+    // All modules specified with `-embed-tbd-for-module` are treated as implicit
+    // dependnecies for this compilation since they are not guaranteed to be impored
+    // in the source.
+    for (const auto &tbdSymbolModule : instance.getInvocation().getTBDGenOptions().embedSymbolsFromModules) {
+      mainDependencies.addModuleImport(tbdSymbolModule, &alreadyAddedModules);
+    }
   }
 
   return mainDependencies;

--- a/test/ScanDependencies/embed_tbd_module_dependency.swift
+++ b/test/ScanDependencies/embed_tbd_module_dependency.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -swift-version 4 -embed-tbd-for-module E
+// RUN: %FileCheck %s < %t/deps.json
+
+// CHECK: "mainModuleName": "deps"
+// CHECK-NEXT:  "modules": [
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "swift": "deps"
+// CHECK-NEXT:    },
+// CHECK:      "directDependencies": [
+
+// Ensure there is a dependency on 'E' even though it is not explicitly imported
+// CHECK:          "swift": "E"
+


### PR DESCRIPTION
Otherwise the scanning action will not look for them as dependencies, and the compilation it is used to inform will not specify these moduels as explicit inpouts.

Resolves rdar://104761392
