### PR TITLE
[AST/Sema] RuntimeMetadata: Align implementation with proposal

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -859,6 +859,10 @@ public:
     return Attrs;
   }
 
+  /// Retrieve runtime discoverable attributes (if any) associated
+  /// with this declaration.
+  ArrayRef<CustomAttr *> getRuntimeDiscoverableAttrs() const;
+
   /// Returns the semantic attributes attached to this declaration,
   /// including attributes that are generated as the result of member
   /// attribute macro expansion.
@@ -2851,9 +2855,6 @@ public:
   GenericParameterReferenceInfo findExistentialSelfReferences(
       Type baseTy, bool treatNonResultCovariantSelfAsInvariant) const;
 
-  /// Retrieve runtime discoverable attributes (if any) associated
-  /// with this declaration.
-  ArrayRef<CustomAttr *> getRuntimeDiscoverableAttrs() const;
   /// Retrieve a nominal type declaration backing given runtime discoverable
   /// attribute.
   ///

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6939,6 +6939,11 @@ ERROR(runtime_attribute_type_requirement_not_accessible,none,
       "(which is %select{private|fileprivate|internal|package|public|open}4)",
       (AccessLevel, DescriptiveDeclKind, DeclName, Type, AccessLevel))
 
+ERROR(cannot_use_attr_with_custom_arguments_on_protocol,none,
+      "reflection metadata attributes applied to protocols cannot have"
+      " additional attribute arguments; attribute arguments must be"
+      " explicitly written on the conforming type",
+      ())
 
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6945,6 +6945,10 @@ ERROR(cannot_use_attr_with_custom_arguments_on_protocol,none,
       " explicitly written on the conforming type",
       ())
 
+NOTE(missing_reflection_metadata_attribute_on_type,none,
+     "protocol %0 requires reflection metadata attribute @%1",
+     (DeclName, StringRef))
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6914,6 +6914,14 @@ ERROR(invalid_decl_for_runtime_discoverable_attr,none,
       "@%0 can only be applied to non-generic types, methods, "
       "instance properties, and global functions", (StringRef))
 
+ERROR(invalid_decl_for_runtime_discoverable_attr_in_extension,none,
+      "@%0 can only be applied to unavailable extensions in the same module"
+      " as %1", (StringRef, DeclName))
+
+ERROR(invalid_attr_redeclaration_in_extension,none,
+      "@%0 is already applied to type %1; did you want to remove it?",
+      (StringRef, DeclName))
+
 ERROR(duplicate_runtime_discoverable_attr,none,
       "duplicate runtime discoverable attribute", ())
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6949,6 +6949,17 @@ NOTE(missing_reflection_metadata_attribute_on_type,none,
      "protocol %0 requires reflection metadata attribute @%1",
      (DeclName, StringRef))
 
+ERROR(missing_reflection_metadata_attribute_on_subclass,none,
+      "superclass %0 requires reflection metadata attribute @%1",
+      (DeclName, StringRef))
+NOTE(add_missing_reflection_metadata_attr,none,
+     "add missing reflection metadata attribute @%0", (StringRef))
+NOTE(opt_out_from_missing_reflection_metadata_attr,none,
+     "opt-out of reflection metadata attribute @%0 using"
+     " unavailable extension",
+     (StringRef))
+
+
 #define UNDEFINE_DIAGNOSTIC_MACROS
 #include "DefineDiagnosticMacros.h"
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3926,7 +3926,7 @@ public:
 
 class GetRuntimeDiscoverableAttributes
     : public SimpleRequest<GetRuntimeDiscoverableAttributes,
-                           ArrayRef<CustomAttr *>(ValueDecl *),
+                           ArrayRef<CustomAttr *>(Decl *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -3934,7 +3934,7 @@ public:
 private:
   friend SimpleRequest;
 
-  ArrayRef<CustomAttr *> evaluate(Evaluator &evaluator, ValueDecl *decl) const;
+  ArrayRef<CustomAttr *> evaluate(Evaluator &evaluator, Decl *decl) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -468,7 +468,7 @@ SWIFT_REQUEST(TypeChecker, SynthesizeRuntimeMetadataAttrGeneratorBody,
               BraceStmt *(CustomAttr *, ValueDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, GetRuntimeDiscoverableAttributes,
-              ArrayRef<CustomAttr *>(ValueDecl *),
+              ArrayRef<CustomAttr *>(Decl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, LocalDiscriminatorsRequest,
               unsigned(DeclContext *),

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2965,12 +2965,6 @@ static bool usesFeatureTypeWrappers(Decl *decl) {
 }
 
 static bool usesFeatureRuntimeDiscoverableAttrs(Decl *decl) {
-  if (decl->getAttrs().hasAttribute<RuntimeMetadataAttr>())
-    return true;
-
-  if (auto *VD = dyn_cast<ValueDecl>(decl))
-    return !VD->getRuntimeDiscoverableAttrs().empty();
-
   return false;
 }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1883,6 +1883,11 @@ bool isNonSendableExtension(const Decl *D) {
 bool ShouldPrintChecker::shouldPrint(const Decl *D,
                                      const PrintOptions &Options) {
   if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
+    // Always print unavilable extensions that carry reflection
+    // metadata attributes.
+    if (!ED->getRuntimeDiscoverableAttrs().empty())
+      return true;
+
     if (Options.printExtensionContentAsMembers(ED))
       return false;
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9888,8 +9888,8 @@ ValueDecl::getRuntimeDiscoverableAttrTypeDecl(CustomAttr *attr) const {
   return nominal;
 }
 
-ArrayRef<CustomAttr *> ValueDecl::getRuntimeDiscoverableAttrs() const {
-  auto *mutableSelf = const_cast<ValueDecl *>(this);
+ArrayRef<CustomAttr *> Decl::getRuntimeDiscoverableAttrs() const {
+  auto *mutableSelf = const_cast<Decl *>(this);
   return evaluateOrDefault(getASTContext().evaluator,
                            GetRuntimeDiscoverableAttributes{mutableSelf},
                            nullptr);

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3689,6 +3689,10 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
     case DeclKind::Protocol: {
       // Allow on protocols because they are sources
       // of inference.
+      if (attr->hasArgs()) {
+        diagnoseAndRemoveAttr(
+            attr, diag::cannot_use_attr_with_custom_arguments_on_protocol);
+      }
       return;
     }
 

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3360,6 +3360,8 @@ public:
       ED->diagnose(diag::moveonly_cannot_conform_to_protocol,
                    nominal->getDescriptiveKind(), nominal->getBaseName());
     }
+
+    TypeChecker::checkReflectionMetadataAttributes(ED);
   }
 
   void visitTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1296,6 +1296,11 @@ bool diagnoseInvalidFunctionType(FunctionType *fnTy, SourceLoc loc,
 /// type repr. \param inferredType The type inferred by the type checker.
 void notePlaceholderReplacementTypes(Type writtenType, Type inferredType);
 
+/// Check whether the given extension introduces a conformance
+/// to a protocol annotated with reflection metadata attribute(s).
+/// If that's the case, conforming type supposed to match attribute
+/// requirements.
+void checkReflectionMetadataAttributes(ExtensionDecl *extension);
 } // namespace TypeChecker
 
 /// Returns the protocol requirement kind of the given declaration.

--- a/test/ModuleInterface/custom_reflection_metadata_attr.swift
+++ b/test/ModuleInterface/custom_reflection_metadata_attr.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/ReflectionMetadata.swiftinterface) %s -module-name CRM -enable-experimental-feature RuntimeDiscoverableAttrs
+// RUN: %target-swift-typecheck-module-from-interface(%t/ReflectionMetadata.swiftinterface) -module-name CRM
+// RUN: %FileCheck %s < %t/ReflectionMetadata.swiftinterface
+
+// REQUIRES: asserts
+
+@runtimeMetadata
+public struct Flag {
+  public init<T>(attachedTo: T) {}
+}
+
+@Flag
+public class BaseClass {}
+
+// CHECK: public class TestClass : CRM.BaseClass
+
+public class TestClass : BaseClass {}
+
+// CHECK: @available(*, unavailable)
+// CHECK-NEXT: @Flag extension CRM.TestClass {
+// CHECK-NEXT: }
+
+@available(*, unavailable)
+@Flag
+public extension TestClass {
+}

--- a/test/ModuleInterface/custom_reflection_metadata_attr.swift
+++ b/test/ModuleInterface/custom_reflection_metadata_attr.swift
@@ -18,7 +18,7 @@ public class BaseClass {}
 public class TestClass : BaseClass {}
 
 // CHECK: @available(*, unavailable)
-// CHECK-NEXT: @Flag extension CRM.TestClass {
+// CHECK-NEXT: @CRM.Flag extension CRM.TestClass {
 // CHECK-NEXT: }
 
 @available(*, unavailable)

--- a/test/SILGen/Inputs/runtime_metadata_defs.swift
+++ b/test/SILGen/Inputs/runtime_metadata_defs.swift
@@ -8,3 +8,14 @@ public struct Ignore {
 
 @Ignore
 public protocol Ignorable {}
+
+public class Base : Ignorable {
+  public init() {}
+}
+
+public class Child : Base {
+}
+
+@available(*, unavailable)
+@Ignore
+extension Child {}

--- a/test/SILGen/runtime_attributes.swift
+++ b/test/SILGen/runtime_attributes.swift
@@ -105,3 +105,6 @@ struct TestSelfUse {
   // CHECK-NEXT: {{.*}} = apply [[FLAG_INIT_REF]]<String, (TestSelfUse) -> ()>({{.*}}, [[PROP_VAL_COPY]], [[FUNC_NAME_STR]], {{.*}})
   @Flag(value: Self.question) func test() {}
 }
+
+// This make sure that Child is valid even though it opted-out of attribute.
+_ = Child()

--- a/test/type/Inputs/RuntimeAttrs.swift
+++ b/test/type/Inputs/RuntimeAttrs.swift
@@ -1,0 +1,1 @@
+public struct CrossModuleTest {}

--- a/test/type/runtime_discoverable_attrs.swift
+++ b/test/type/runtime_discoverable_attrs.swift
@@ -130,8 +130,11 @@ struct TestNoAmbiguity {
   @Flag func testInst(_: Int, _: Int) {} // Ok
 }
 
-@Flag("flag from protocol")
+@Flag
 protocol Flagged {}
+
+@Flag("flag from protocol") // expected-error {{reflection metadata attributes applied to protocols cannot have additional attribute arguments}}
+protocol InvalidFlagged {}
 
 struct Inference1 : Flagged {} // Ok
 class Inference2 : Flagged {}  // Ok
@@ -277,7 +280,7 @@ extension EnumFlag where B == Void {
 }
 
 @available(*, unavailable)
-@EnumFlag extension EnumTypeTest { // expected-error {{@EnumFlag is already applied to type 'EnumTypeTest'; did you want to remove it?}} {{266:1-11=}}
+@EnumFlag extension EnumTypeTest { // expected-error {{@EnumFlag is already applied to type 'EnumTypeTest'; did you want to remove it?}} {{269:1-11=}}
 }
 
 @available(*, unavailable)

--- a/test/type/runtime_discoverable_attrs.swift
+++ b/test/type/runtime_discoverable_attrs.swift
@@ -1,6 +1,10 @@
-// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature RuntimeDiscoverableAttrs
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/RuntimeAttrs.swift -o %t
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature RuntimeDiscoverableAttrs -I %t
 
 // REQUIRES: asserts
+
+import RuntimeAttrs
 
 @runtimeMetadata
 struct Flag<T> {
@@ -263,4 +267,19 @@ extension EnumFlag where B == Void {
   @EnumFlag var x: Int = 42
   @EnumFlag func testInst() {}
   @EnumFlag static func testStatic() -> Int { 42 }
+}
+
+@Flag extension EnumTypeTest { // expected-error {{@Flag can only be applied to unavailable extensions in the same module as 'EnumTypeTest'}}
+}
+
+@available(*, unavailable)
+@Flag extension EnumTypeTest { // Ok
+}
+
+@available(*, unavailable)
+@EnumFlag extension EnumTypeTest { // expected-error {{@EnumFlag is already applied to type 'EnumTypeTest'; did you want to remove it?}} {{266:1-11=}}
+}
+
+@available(*, unavailable)
+@Flag extension CrossModuleTest { // expected-error {{@Flag can only be applied to unavailable extensions in the same module as 'CrossModuleTest'}}
 }

--- a/test/type/runtime_discoverable_attrs.swift
+++ b/test/type/runtime_discoverable_attrs.swift
@@ -318,3 +318,34 @@ class MultiAttrTest {
 }
 
 extension MultiAttrTest : Flagged & EnumFlagged {} // Ok
+
+@Flag
+class BaseClass {}
+
+@Flag
+class ValidChild : BaseClass {} // Ok
+
+class InvalidChild : BaseClass {}
+// expected-error@-1 {{superclass 'BaseClass' requires reflection metadata attribute @Flag}}
+// expected-note@-2 {{add missing reflection metadata attribute @Flag}} {{1-1=@Flag }}
+// expected-note@-3 {{opt-out of reflection metadata attribute @Flag using unavailable extension}} {{34-34=\n\n@available(*, unavailable)\n@Flag extension InvalidChild {\}\n}}
+
+class OptedOutChild : BaseClass {} // Ok (used unavailable extension to opt-out of the attribute)
+
+@available(*, unavailable)
+@Flag
+extension OptedOutChild {}
+
+protocol InvalidProtoWithSuperclass : BaseClass {}
+// expected-error@-1 {{superclass 'BaseClass' requires reflection metadata attribute @Flag}}
+// expected-note@-2 {{add missing reflection metadata attribute @Flag}} {{1-1=@Flag }}
+// expected-note@-3 {{opt-out of reflection metadata attribute @Flag using unavailable extension}} {{51-51=\n\n@available(*, unavailable)\n@Flag extension InvalidProtoWithSuperclass {\}\n}}
+
+@Flag
+protocol ValidProtoWithSuperclass : BaseClass {} // Ok
+
+protocol OptedOutProtoWithSuperclass : BaseClass {} // Ok
+
+@available(*, unavailable)
+@Flag
+extension OptedOutProtoWithSuperclass {}


### PR DESCRIPTION
- @reflectionMetadata attributes declared on a protocol act as requirements. If type doesn't declare attribute, conformance fails unless conformance is stated directly on type declaration, in such cases attribute would be inferred.
- allow using reflection metadata attributes on unavailable extensions declared in the same module as type.
- Reject reflection metadata attributes with custom arguments on protocol declarations. Arguments cannot be used if types declare a conformance to a protocol from a different module.
- Diagnose situations where a sub-class or a protocol are missing reflection metadata attributes required by a superclass.

Resolves: rdar://103990788

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
