### PR TITLE
[5.8] Sema: Avoid diagnosing missing imports for desugared typealiases in non-resilient modules

### DIFF
--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -121,10 +121,19 @@ static bool diagnoseTypeAliasDeclRefExportability(SourceLoc loc,
   if (originKind == DisallowedOriginKind::None)
     return false;
 
-  auto definingModule = D->getModuleContext();
-  ASTContext &ctx = definingModule->getASTContext();
-  auto fragileKind = where.getFragileFunctionKind();
+  auto exportingModule = where.getDeclContext()->getParentModule();
+  ASTContext &ctx = exportingModule->getASTContext();
 
+  // As an exception, if the import of the module that defines the desugared
+  // decl is just missing (as opposed to imported explicitly with reduced
+  // visibility) then we should only diagnose if we're building a resilient
+  // module.
+  if (originKind == DisallowedOriginKind::MissingImport &&
+      !exportingModule->isResilient())
+    return false;
+
+  auto definingModule = D->getModuleContext();
+  auto fragileKind = where.getFragileFunctionKind();
   if (fragileKind.kind == FragileFunctionKind::None) {
     auto reason = where.getExportabilityReason();
     ctx.Diags

--- a/test/Sema/missing-import-typealias-swift6.swift
+++ b/test/Sema/missing-import-typealias-swift6.swift
@@ -7,11 +7,11 @@
 // RUN: %target-swift-emit-module-interface(%t/Aliases.swiftinterface) %t/Aliases.swift -I %t
 // RUN: %target-swift-typecheck-module-from-interface(%t/Aliases.swiftinterface) -I %t
 
-// RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesNoImport.swift -I %t -swift-version 6
+// RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesNoImport.swift -enable-library-evolution -I %t -swift-version 6
 
 // REQUIRES: asserts
 
-// This test is a simplified version of implicit-import-typealias.swift that
+// This test is a simplified version of missing-import-typealias.swift that
 // verifies errors are emitted instead of warnings in Swift 6.
 
 //--- Original.swift

--- a/test/Sema/missing-import-typealias.swift
+++ b/test/Sema/missing-import-typealias.swift
@@ -7,10 +7,13 @@
 // RUN: %target-swift-emit-module-interface(%t/Aliases.swiftinterface) %t/Aliases.swift -I %t
 // RUN: %target-swift-typecheck-module-from-interface(%t/Aliases.swiftinterface) -I %t
 
-// RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesNoImport.swift -I %t
-// RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesImplementationOnlyImport.swift -I %t
-// RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesSPIOnlyImport.swift -I %t -experimental-spi-only-imports
-// RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesWithImport.swift  -I %t
+// RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesNoImport.swift -enable-library-evolution -I %t
+// RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesImplementationOnlyImport.swift -enable-library-evolution -I %t
+// RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesSPIOnlyImport.swift -enable-library-evolution -I %t -experimental-spi-only-imports
+// RUN: %target-swift-frontend -typecheck -verify %t/UsesAliasesWithImport.swift -enable-library-evolution -I %t
+
+/// With library evolution disabled UsesAliasesNoImport.swift should compile without diagnostics.
+// RUN: %target-swift-frontend -typecheck %t/UsesAliasesNoImport.swift -I %t | %FileCheck %t/UsesAliasesNoImport.swift --check-prefix=CHECK-NON-RESILIENT --allow-empty
 
 /// The swiftinterface is broken by the missing import without the workaround.
 // RUN: %target-swift-emit-module-interface(%t/UsesAliasesNoImport.swiftinterface) %t/UsesAliasesNoImport.swift -I %t \
@@ -60,6 +63,8 @@ public typealias WrapperAlias = Wrapper
 //--- UsesAliasesNoImport.swift
 
 import Aliases
+
+// CHECK-NON-RESILIENT-NOT: was not imported by this file
 
 // expected-warning@+2 {{'ClazzAlias' aliases 'Original.Clazz' and cannot be used here because 'Original' was not imported by this file; this is an error in Swift 6}}
 // expected-note@+1 {{The missing import of module 'Original' will be added implicitly}}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/63278.

The following diagnostic is meant to prevent broken swiftinterfaces from being emitted:

```
'SomeAlias' aliases 'SomeDesugaredType' and cannot be used here because 'DesugaredTypeModule' was not imported by this file; this is an error in Swift 6
```

If the module exporting the reference to the typealias is non-resilient, though, then the module is not expected to have a buildable `swiftinterface` and therefore the diagnostic is superfluous.

Resolves rdar://104749045
