### PR TITLE
DependencyScan: change commandline processing style

### DIFF
--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -42,7 +42,12 @@ llvm::ErrorOr<swiftscan_string_ref_t> getTargetInfo(ArrayRef<const char *> Comma
   SmallVector<const char *, 4> Args;
   llvm::BumpPtrAllocator Alloc;
   llvm::StringSaver Saver(Alloc);
-  llvm::cl::TokenizeGNUCommandLine(CommandString, Saver, Args);
+  // Ensure that we use the Windows command line parsing on Windows as we need
+  // to ensure that we properly handle paths.
+  if (llvm::Triple(llvm::sys::getProcessTriple()).isOSwindows()) 
+    llvm::cl::TokenizeWindowsCommandLine(CommandString, Saver, Args);
+  else
+    llvm::cl::TokenizeGNUCommandLine(CommandString, Saver, Args);
   SourceManager dummySM;
   DiagnosticEngine DE(dummySM);
   CompilerInvocation Invocation;

--- a/lib/DependencyScan/DependencyScanningTool.cpp
+++ b/lib/DependencyScan/DependencyScanningTool.cpp
@@ -44,7 +44,7 @@ llvm::ErrorOr<swiftscan_string_ref_t> getTargetInfo(ArrayRef<const char *> Comma
   llvm::StringSaver Saver(Alloc);
   // Ensure that we use the Windows command line parsing on Windows as we need
   // to ensure that we properly handle paths.
-  if (llvm::Triple(llvm::sys::getProcessTriple()).isOSwindows()) 
+  if (llvm::Triple(llvm::sys::getProcessTriple()).isOSWindows()) 
     llvm::cl::TokenizeWindowsCommandLine(CommandString, Saver, Args);
   else
     llvm::cl::TokenizeGNUCommandLine(CommandString, Saver, Args);


### PR DESCRIPTION
We would previously unconditionally treat the command line as GNU style arguments.  However, Windows uses a different command-line style, and this would incorrectly process the arguments, potentially corrupting paths which do not quote the path separator.  Ideally, we would introduce a new api (`swiftscan_compiler_target_info_query_v3`?) that takes a quoting style (matching `--rsp-quoting`) which would allow us to support both quoting styles properly.