### PR TITLE
[5.8][IDE] Remove invalid assertions

### DIFF
--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -942,8 +942,6 @@ swift::getShorthandShadows(CaptureListExpr *CaptureList, DeclContext *DC) {
     if (!ReferencedVar)
       continue;
 
-    assert(DeclaredVar->getName() == ReferencedVar->getName());
-
     Result.emplace_back(std::make_pair(DeclaredVar, ReferencedVar));
   }
   return Result;
@@ -970,7 +968,6 @@ swift::getShorthandShadows(LabeledConditionalStmt *CondStmt, DeclContext *DC) {
     Cond.getPattern()->forEachVariable([&](VarDecl *DeclaredVar) {
       if (DeclaredVar->getLoc() != Init->getLoc())
         return;
-      assert(DeclaredVar->getName() == ReferencedVar->getName());
       Result.emplace_back(std::make_pair(DeclaredVar, ReferencedVar));
     });
   }

--- a/test/Index/index_shadow.swift
+++ b/test/Index/index_shadow.swift
@@ -4,7 +4,6 @@
 // The index will output references to the shadowed-declaration rather than
 // the one defined by the shorthand if-let or capture. It also skips
 // outputting the shadowing-definiiton since it would then have no references.
-
 struct ShadowedTest {
   // CHECK: [[@LINE+1]]:7 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Def
   let shadowedVar: Int?? = 1
@@ -54,6 +53,18 @@ struct ShadowedTest {
       _ = { [shadowedVar] in
         // CHECK: [[@LINE+1]]:13 {{.*}} s:14swift_ide_test12ShadowedTestV11shadowedVarSiSgSgvp {{.*}}Ref
         _ = shadowedVar
+      }
+    }
+  }
+
+  func nestedFuncTest() {
+    // CHECK: [[@LINE+1]]:10 {{.*}} s:14swift_ide_test12ShadowedTestV010nestedFuncE0yyF08shadowedG0L_yyF {{.*}}Def
+    func shadowedFunc() {
+      // CHECK-NOT: [[@LINE+2]]:14 {{.*}} shadowedFunc {{.*}}Def
+      // CHECK: [[@LINE+1]]:14 {{.*}} s:14swift_ide_test12ShadowedTestV010nestedFuncE0yyF08shadowedG0L_yyF {{.*}}Ref
+      _ = { [shadowedFunc] in
+        // CHECK: [[@LINE+1]]:13 {{.*}} s:14swift_ide_test12ShadowedTestV010nestedFuncE0yyF08shadowedG0L_yyF {{.*}}Ref
+        _ = shadowedFunc
       }
     }
   }


### PR DESCRIPTION
The declaration and reference aren't necessarily the same type (eg. they could be a function and a local). Thus they don't have to have the same names, making the assertion invalid.

Resolves #63262.

(cherry picked from commit 21f997c01a25d7d8a80148902fcd8ab98d284ef9)