### PR TITLE
[Parser] Use proper `ParseDeclOptions` when parsing the result of a member macro expansion.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -2049,6 +2049,9 @@ WARNING(macro_expression_attribute_removed,PointsToFirstBadToken,
 ERROR(unexpected_attribute_expansion,PointsToFirstBadToken,
       "unexpected token '%0' in expanded attribute list'",
       (StringRef))
+ERROR(unexpected_member_expansion,PointsToFirstBadToken,
+      "unexpected token '%0' in expanded member list'",
+      (StringRef))
 
 ERROR(parser_round_trip_error,none,
       "source file did not round-trip through the new Swift parser", ())

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1235,6 +1235,10 @@ public:
   /// the attribute list attached.
   void parseExpandedAttributeList(SmallVectorImpl<ASTNode> &items);
 
+  /// Parse the result of member macro expansion, which is a floating
+  /// member list.
+  void parseExpandedMemberList(SmallVectorImpl<ASTNode> &items);
+
   ParserResult<FuncDecl> parseDeclFunc(SourceLoc StaticLoc,
                                        StaticSpellingKind StaticSpelling,
                                        ParseDeclOptions Flags,

--- a/lib/Parse/ParseRequests.cpp
+++ b/lib/Parse/ParseRequests.cpp
@@ -174,10 +174,14 @@ SourceFileParsingResult ParseSourceFileRequest::evaluate(Evaluator &evaluator,
     switch (generatedInfo->kind) {
     case GeneratedSourceInfo::FreestandingDeclMacroExpansion:
     case GeneratedSourceInfo::ExpressionMacroExpansion:
-    case GeneratedSourceInfo::MemberMacroExpansion:
     case GeneratedSourceInfo::ReplacedFunctionBody:
     case GeneratedSourceInfo::PrettyPrinted: {
       parser.parseTopLevelItems(items);
+      break;
+    }
+
+    case GeneratedSourceInfo::MemberMacroExpansion: {
+      parser.parseExpandedMemberList(items);
       break;
     }
 

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -373,10 +373,22 @@ public struct AddMembers: MemberMacro {
       }
       """
 
+    let staticMethod: DeclSyntax =
+      """
+      static func method() {}
+      """
+
+    let initDecl: DeclSyntax =
+      """
+      init() {}
+      """
+
     return [
       storageStruct,
       storageVariable,
       instanceMethod,
+      staticMethod,
+      initDecl,
     ]
   }
 }

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -14,6 +14,7 @@
 @addMembers
 struct S {
   func useSynthesized() {
+    S.method()
     print(type(of: getStorage()))
   }
 }


### PR DESCRIPTION
This prevents bogus parser diagnostics inside member macro expansions for declarations that can only appear inside of types, such as `init`, static methods, subscripts, etc.