### PR TITLE
[DiagnosticsQoI] Sema: Use 'underlying' instead of 'concrete' in opaque result type diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3894,8 +3894,8 @@ ERROR(unresolved_member_no_inference,none,
       (DeclNameRef))
 ERROR(cannot_infer_base_of_unresolved_member,none,
       "cannot infer contextual base in reference to member %0", (DeclNameRef))
-ERROR(cannot_infer_concrete_for_opaque_result,none,
-      "cannot infer concrete type for opaque result %0 from return expression",
+ERROR(cannot_infer_underlying_for_opaque_result,none,
+      "cannot infer underlying type for opaque result %0 from return expression",
       (Type))
 ERROR(unresolved_nil_literal,none,
       "'nil' requires a contextual type", ())

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5968,7 +5968,7 @@ bool MissingGenericArgumentsFailure::diagnoseAsError() {
   if (auto opaqueElt =
           locator->findLast<LocatorPathElt::OpenedOpaqueArchetype>()) {
     auto *opaqueDecl = opaqueElt->getDecl();
-    emitDiagnostic(diag::cannot_infer_concrete_for_opaque_result,
+    emitDiagnostic(diag::cannot_infer_underlying_for_opaque_result,
                    opaqueDecl->getDeclaredInterfaceType());
     return true;
   }

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -581,12 +581,12 @@ do {
 
 // https://github.com/apple/swift/issues/62787
 func f62787() -> Optional<some Collection<Int>> {
-  return nil // expected-error{{cannot infer concrete type for opaque result 'Optional<some Collection<Int>>' from return expression}}
+  return nil // expected-error{{cannot infer underlying type for opaque result 'Optional<some Collection<Int>>' from return expression}}
 }
 
 func f62787_1(x: Bool) -> Optional<some Collection<Int>> {
   if x {
-    return nil // expected-error{{cannot infer concrete type for opaque result 'Optional<some Collection<Int>>' from return expression}}
+    return nil // expected-error{{cannot infer underlying type for opaque result 'Optional<some Collection<Int>>' from return expression}}
   } 
-  return nil // expected-error{{cannot infer concrete type for opaque result 'Optional<some Collection<Int>>' from return expression}}
+  return nil // expected-error{{cannot infer underlying type for opaque result 'Optional<some Collection<Int>>' from return expression}}
 }

--- a/test/type/opaque_parameterized_existential.swift
+++ b/test/type/opaque_parameterized_existential.swift
@@ -13,32 +13,32 @@ extension Never: P { typealias T = Never }
 
 // I do not like them written clear
 func test() -> any P<some P> { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}}
-// expected-error@-1{{cannot infer concrete type for opaque result 'any P<some P>' from return expression}}
+// expected-error@-1{{cannot infer underlying type for opaque result 'any P<some P>' from return expression}}
 
 // I do not like them nested here
 func test() -> any P<[some P]> { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}}
-// expected-error@-1{{cannot infer concrete type for opaque result 'any P<[some P]>' from return expression}}
+// expected-error@-1{{cannot infer underlying type for opaque result 'any P<[some P]>' from return expression}}
 
 // I do not like them under questions
 func test() -> any P<(some P)??> { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}}
-// expected-error@-1{{cannot infer concrete type for opaque result 'any P<(some P)??>' from return expression}}
+// expected-error@-1{{cannot infer underlying type for opaque result 'any P<(some P)??>' from return expression}}
 
 // I do not like meta-type intentions
 func test() -> (any P<some P>).Type { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}}
-// expected-error@-1{{cannot infer concrete type for opaque result '(any P<some P>).Type' from return expression}}
+// expected-error@-1{{cannot infer underlying type for opaque result '(any P<some P>).Type' from return expression}}
 
 // I do not like them (meta)static-ly
 func test() -> any P<some P>.Type { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}}
-// expected-error@-1{{cannot infer concrete type for opaque result 'any P<some P>.Type' from return expression}}
+// expected-error@-1{{cannot infer underlying type for opaque result 'any P<some P>.Type' from return expression}}
 
 // I do not like them tupled-three
 func test() -> (Int, any P<some P>, Int) { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}}
-// expected-error@-1{{cannot infer concrete type for opaque result '(Int, any P<some P>, Int)' from return expression}}
+// expected-error@-1{{cannot infer underlying type for opaque result '(Int, any P<some P>, Int)' from return expression}}
 
 // I do not like them in generics
 struct Wrapper<T> {}
 func test() -> any P<Wrapper<some P>> { fatalError() } // expected-error {{'some' types cannot be used in constraints on existential types}}
-// expected-error@-1{{cannot infer concrete type for opaque result 'any P<Wrapper<some P>>' from return expression}}
+// expected-error@-1{{cannot infer underlying type for opaque result 'any P<Wrapper<some P>>' from return expression}}
 
 // Your attempts to nest them put me in hysterics.
 func test(_ x: any P<some P>) {} // expected-error {{'some' types cannot be used in constraints on existential types}}

--- a/test/type/opaque_return_named.swift
+++ b/test/type/opaque_return_named.swift
@@ -3,11 +3,11 @@
 // Tests for experimental extensions to opaque return type support.
 
 func f0() -> <T> T { return () }
-func f1() -> <T, U, V> T { () } // expected-error{{cannot infer concrete type for opaque result 'T' from return expression}}
+func f1() -> <T, U, V> T { () } // expected-error{{cannot infer underlying type for opaque result 'T' from return expression}}
 func f2() -> <T: Collection, U: SignedInteger> T { // expected-note{{required by opaque return type of global function 'f2()'}}
   () // expected-error{{type '()' cannot conform to 'Collection'}}
   // expected-note@-1{{only concrete types such as structs, enums and classes can conform to protocols}}
-  // expected-error@-2{{cannot infer concrete type for opaque result 'T' from return expression}}
+  // expected-error@-2{{cannot infer underlying type for opaque result 'T' from return expression}}
 }
 
 func f4() async -> <T> T { () }


### PR DESCRIPTION
For the sake of consistency. See [comment](https://github.com/apple/swift/pull/62924#discussion_r1084565046).
