### PR TITLE
[stdlib] NFC: Restore doc comment for Unsafe[Mutable]BufferPointer

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -14,6 +14,9 @@
 % for mutable in (True, False):
 %  Self = 'UnsafeMutableBufferPointer' if mutable else 'UnsafeBufferPointer'
 %  Mutable = 'Mutable' if mutable else ''
+// FIXME: rdar://18157434 - until this is fixed, this has to be fixed layout
+// to avoid a hang in Foundation, which has the following setup:
+// struct A { struct B { let x: UnsafeMutableBufferPointer<...> } let b: B }
 /// A nonowning collection interface to a buffer of ${Mutable.lower()}
 /// elements stored contiguously in memory.
 ///
@@ -29,9 +32,6 @@
 /// instances stored in the underlying memory. However, initializing another
 /// collection with an `${Self}` instance copies the instances out of the
 /// referenced memory and into the new collection.
-// FIXME: rdar://18157434 - until this is fixed, this has to be fixed layout
-// to avoid a hang in Foundation, which has the following setup:
-// struct A { struct B { let x: UnsafeMutableBufferPointer<...> } let b: B }
 @frozen // unsafe-performance
 public struct Unsafe${Mutable}BufferPointer<Element> {
 

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -14,9 +14,6 @@
 % for mutable in (True, False):
 %  Self = 'UnsafeMutableBufferPointer' if mutable else 'UnsafeBufferPointer'
 %  Mutable = 'Mutable' if mutable else ''
-// FIXME: rdar://18157434 - until this is fixed, this has to be fixed layout
-// to avoid a hang in Foundation, which has the following setup:
-// struct A { struct B { let x: UnsafeMutableBufferPointer<...> } let b: B }
 /// A nonowning collection interface to a buffer of ${Mutable.lower()}
 /// elements stored contiguously in memory.
 ///


### PR DESCRIPTION
Moves a `//` comment up above a `///` documentation comment, since the latter needs to be attached directly to the declaration or it won't be picked up as documentation.
