### PR TITLE
[interop] verify that a C++ record is a Swift nominal type before try…

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2588,7 +2588,8 @@ namespace {
         conformToCxxSequenceIfNeeded(Impl, nominalDecl, decl);
       }
 
-      addExplicitProtocolConformances(cast<NominalTypeDecl>(result));
+      if (auto *ntd = dyn_cast<NominalTypeDecl>(result))
+        addExplicitProtocolConformances(ntd);
 
       return result;
     }

--- a/test/Interop/Cxx/stdlib/print-foundation-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/print-foundation-module-interface.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=Foundation -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop
+
+// REQUIRES: OS=macosx


### PR DESCRIPTION
…ing to add explicit protocol conformances

This fixes the issue where we crashed printing foundation
