### PR TITLE
[interop] AST printer should only visit one original namespace decl t…

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -28,6 +28,10 @@
 // ambiguities with type names, in AliasModuleNames mode.
 #define MODULE_DISAMBIGUATING_PREFIX "Module___"
 
+namespace clang {
+class Decl;
+}
+
 namespace swift {
   class Decl;
   class DeclContext;
@@ -111,6 +115,7 @@ class ASTPrinter {
   unsigned CurrentIndentation = 0;
   unsigned PendingNewlines = 0;
   TypeOrExtensionDecl SynthesizeTarget;
+  llvm::SmallPtrSet<const clang::Decl *, 8> printedClangDecl;
 
   void printTextImpl(StringRef Text);
 
@@ -329,6 +334,12 @@ public:
   void callPrintStructurePre(PrintStructureKind Kind, const Decl *D = nullptr) {
     forceNewlines();
     printStructurePre(Kind, D);
+  }
+
+  /// Return true when the given redeclared clang decl is being printed for the
+  /// first time.
+  bool shouldPrintRedeclaredClangDecl(const clang::Decl *d) {
+    return printedClangDecl.insert(d).second;
   }
 
 private:

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -2300,7 +2300,15 @@ static void addNamespaceMembers(Decl *decl,
 
   // This is only to keep track of the members we've already seen.
   llvm::SmallPtrSet<Decl *, 16> addedMembers;
+  const auto *declOwner = namespaceDecl->getOwningModule();
+  if (declOwner)
+    declOwner = declOwner->getTopLevelModule();
   for (auto redecl : namespaceDecl->redecls()) {
+    // Skip namespace declarations that come from other top-level modules.
+    if (const auto *redeclOwner = redecl->getOwningModule()) {
+      if (declOwner && declOwner != redeclOwner->getTopLevelModule())
+        continue;
+    }
     for (auto member : redecl->decls()) {
       if (auto classTemplate = dyn_cast<clang::ClassTemplateDecl>(member)) {
         // Add all specializations to a worklist so we don't accidently mutate

--- a/test/Interop/Cxx/namespace/cross-module-redecls-module-interface.swift
+++ b/test/Interop/Cxx/namespace/cross-module-redecls-module-interface.swift
@@ -1,0 +1,49 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-ide-test -print-module -module-to-print=ModuleB -I %t/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck --check-prefix=CHECKB %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=ModuleA -I %t/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck --check-prefix=CHECKA %s
+
+//--- Inputs/module.modulemap
+module ModuleA {
+    header "headerA.h"
+    requires cplusplus
+}
+
+module ModuleB {
+    header "headerB.h"
+    requires cplusplus
+}
+
+//--- Inputs/headerA.h
+
+namespace ns {
+    struct A {
+        int x;
+    };
+}
+
+//--- Inputs/headerB.h
+
+#include "headerA.h"
+
+namespace ns {
+    struct B {
+        int y;
+    };
+}
+
+// CHECKB:     enum ns {
+// CHECKB-NEXT: struct B {
+// CHECKB-NEXT:    init()
+// CHECKB-NEXT:    init(y: Int32)
+// CHECKB-NEXT:    var y: Int32
+// CHECKB-NEXT:  }
+// CHECKB-NEXT: }
+
+// CHECKA:     enum ns {
+// CHECKA-NEXT: struct A {
+// CHECKA-NEXT:    init()
+// CHECKA-NEXT:    init(x: Int32)
+// CHECKA-NEXT:    var x: Int32
+// CHECKA-NEXT:  }
+// CHECKA-NEXT: }

--- a/test/Interop/Cxx/stdlib/print-libcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/print-libcxx-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=std -I %libcxx-in-sdk-path -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop -module-print-submodules | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxStdlib -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop -module-print-submodules | %FileCheck %s
 
 // REQUIRES: OS=macosx
 // REQUIRES: libcxx-in-sdk

--- a/test/Interop/Cxx/stdlib/print-libcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/print-libcxx-module-interface.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print=std -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop -module-print-submodules | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -module-to-print=std -I %libcxx-in-sdk-path -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop -module-print-submodules | %FileCheck %s
 
 // REQUIRES: OS=macosx
 // REQUIRES: libcxx-in-sdk

--- a/test/Interop/Cxx/stdlib/print-libcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/print-libcxx-module-interface.swift
@@ -1,6 +1,7 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=std -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop -module-print-submodules | %FileCheck %s
 
 // REQUIRES: OS=macosx
+// REQUIRES: libcxx-in-sdk
 
 // CHECK: enum std {
 // CHECK-NEXT: enum __1 {

--- a/test/Interop/Cxx/stdlib/print-libcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/print-libcxx-module-interface.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=std -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop -module-print-submodules | %FileCheck %s
+
+// REQUIRES: OS=macosx
+
+// CHECK: enum std {
+// CHECK-NEXT: enum __1 {
+
+// CHECK: typealias string =
+
+// CHECK-NOT: enum std

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -15,6 +15,7 @@ if config.variant_sdk and config.variant_sdk != "":
     # Check if libc++ is present in the SDK or not.
     if config.target_sdk_libcxx_path and os.path.exists(config.target_sdk_libcxx_path):
         config.available_features.add('libcxx-in-sdk')
+        config.substitutions.insert(0, ('%libcxx-in-sdk-path', config.target_sdk_libcxx_path))
 
     # Check if CF_OPTIONS macro has been updated to be imported into Swift in C++ mode correctly.
     cf_avail_path = os.path.join(config.variant_sdk, 'System', 'Library', 'Frameworks', 'CoreFoundation.framework', 'Versions', 'A', 'Headers', 'CFAvailability.h')

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -12,6 +12,10 @@ clang_opt = clang_compile_opt
 is_cf_options_interop_updated = True
 
 if config.variant_sdk and config.variant_sdk != "":
+    # Check if libc++ is present in the SDK or not.
+    if config.target_sdk_libcxx_path and os.path.exists(config.target_sdk_libcxx_path):
+        config.available_features.add('libcxx-in-sdk')
+
     # Check if CF_OPTIONS macro has been updated to be imported into Swift in C++ mode correctly.
     cf_avail_path = os.path.join(config.variant_sdk, 'System', 'Library', 'Frameworks', 'CoreFoundation.framework', 'Versions', 'A', 'Headers', 'CFAvailability.h')
     if os.path.exists(cf_avail_path):


### PR DESCRIPTION
…o avoid printing redecls over and over again

Also, lookup namespace members directly without doing a lookup. This helps us print the libc++ module interface in < 1s on M1.

Also, print namespace redecls that are specific to the module being printed. This ensures that when we're printing multiple module interfaces, we separate out the namespaces and their members correctly between the produced module interfaces.
