### PR TITLE
build: tweak flags further

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -11,8 +11,8 @@ project(swift-stdlib LANGUAGES C CXX)
 # being built on Windows.  Since we know that we only support `clang-cl` as the
 # compiler for the runtime due to the use of the Swift calling convention, we
 # simply override the CMake behaviour unconditionally.
-set(CMAKE_INCLUDE_SYSTEM_FLAG_C "-I")
-set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-I")
+set(CMAKE_INCLUDE_SYSTEM_FLAG_C "-Isystem")
+set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-Isystem")
 
 # Add path for custom CMake modules.
 list(APPEND CMAKE_MODULE_PATH


### PR DESCRIPTION
Because we know that we are building the standard library which requires clang (or clang-cl) due to the use of the Swift calling convention, we can use the `-Isystem` flag to indicate that the headers are system headers and should not generate warnings.  This is important as there are uses of anonymous unions and structs in the Windows headers which will trigger warnings which are treated as errors and thus break the build.