### PR TITLE
Windows: add conio and corecrt.conio

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -115,6 +115,11 @@ module ucrt [system] {
     }
   }
 
+  module conio {
+    header "conio.h"
+    export *
+  }
+
   module process {
     header "process.h"
     export *
@@ -137,6 +142,11 @@ module corecrt [system] {
   header "corecrt.h"
   header "corecrt_stdio_config.h"
   export *
+
+  module conio {
+    header "corecrt_wconio.h"
+    export *
+  }
 
   module io {
     header "corecrt_io.h"


### PR DESCRIPTION
This adds `conio` and `corecrt.conio` modules to the ucrt modulemap to expose these interfaces to Swift.

Fixes: #63024