### PR TITLE
[stdlib] Add String._isIdentical(to:)

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -402,6 +402,26 @@ extension String {
 }
 
 extension String {
+  /// Returns a boolean value indicating whether this string is identical to
+  /// `other`.
+  ///
+  /// Two string values are identical if there is no way to distinguish between
+  /// them.
+  ///
+  /// Comparing strings this way includes comparing (normally) hidden
+  /// implementation details such as the memory location of any underlying
+  /// string storage object. Therefore, identical strings are guaranteed to
+  /// compare equal with `==`, but not all equal strings are considered
+  /// identical.
+  ///
+  /// - Performance: O(1)
+  @_alwaysEmitIntoClient
+  public func _isIdentical(to other: Self) -> Bool {
+    self._guts.rawBits == other._guts.rawBits
+  }
+}
+
+extension String {
   // This force type-casts element to UInt8, since we cannot currently
   // communicate to the type checker that we proved this with our dynamic
   // check in String(decoding:as:).

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -525,7 +525,7 @@ StringTests.test("_isIdentical(to:)") {
   let f = String(repeating: "foo", count: 1000)
   let g = String(repeating: "foo", count: 1000)
   expectEqual(f, g)
-  expectFalse(f._isIdentical(to: g)) // To large, distinct native strings
+  expectFalse(f._isIdentical(to: g)) // Two large, distinct native strings
   expectTrue(f._isIdentical(to: f))
   expectTrue(g._isIdentical(to: g))
 }

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -506,4 +506,28 @@ StringTests.test("Regression/radar-87371813") {
   expectEqual(s2.hashValue, s3.hashValue)
 }
 
+StringTests.test("_isIdentical(to:)") {
+  let a = "Hello"
+  let b = "Hello"
+  expectTrue(a._isIdentical(to: a))
+  expectTrue(b._isIdentical(to: b))
+  expectTrue(a._isIdentical(to: b)) // Both small ASCII strings
+  expectTrue(b._isIdentical(to: a))
+
+  let c = "Cafe\u{301}"
+  let d = "Cafe\u{301}"
+  let e = "Café"
+  expectTrue(c._isIdentical(to: d))
+  expectTrue(d._isIdentical(to: c))
+  expectFalse(c._isIdentical(to: e))
+  expectFalse(d._isIdentical(to: e))
+
+  let f = String(repeating: "foo", count: 1000)
+  let g = String(repeating: "foo", count: 1000)
+  expectEqual(f, g)
+  expectFalse(f._isIdentical(to: g)) // To large, distinct native strings
+  expectTrue(f._isIdentical(to: f))
+  expectTrue(g._isIdentical(to: g))
+}
+
 runAllTests()


### PR DESCRIPTION
This adds a way to quickly decide if two `String` instances are identical, by comparing their underlying bit representations.
This is the same test as done at the beginning of `==`, and it can be used as a quick shortcut in similar situations.

rdar://104828814
