### PR TITLE
[5.8][Runtime] Fix key paths on 32-bit with KVC string pointers in the top half of memory.

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -177,7 +177,9 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
     }
     else {
       let offset = Int(bitPattern: _kvcKeyPathStringPtr) - 1
-      if (offset <= maximumOffsetOn32BitArchitecture) {
+      // Pointers above 0x7fffffff will come in as negative numbers which are
+      // less than maximumOffsetOn32BitArchitecture, be sure to reject them.
+      if (offset >= 0 && offset <= maximumOffsetOn32BitArchitecture) {
         return offset
       }
       return nil


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/63302 to `release/5.8`.

Key paths can store an offset or a pointer in the same field. On 32-bit, the field is considered to be an offset when it's less than the 4kB zero page, and a pointer otherwise.

The check uses a signed comparison, so pointers in the top half of memory would look like negative offsets. Add a check that the offset is zero or positive to avoid this.

rdar://103886537