### PR TITLE
[Dependency Scanning] Do not process transitive `@_implementationOnly` dependencies of binary Swift modules

### DIFF
--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -420,6 +420,12 @@ llvm::ErrorOr<ModuleDependencyInfo> SerializedModuleLoaderBase::scanModuleFile(
     if (dependency.isHeader())
       continue;
 
+    // Transitive @_implementationOnly dependencies of
+    // binary modules are not required to be imported during normal builds
+    // TODO: This is worth revisiting for debugger purposes
+    if (dependency.isImplementationOnly())
+      continue;
+
     // Find the top-level module name.
     auto modulePathStr = dependency.getPrettyPrintedPath();
     StringRef moduleName = modulePathStr;

--- a/test/ScanDependencies/no_trasitive_implementation-only_deps.swift
+++ b/test/ScanDependencies/no_trasitive_implementation-only_deps.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+// RUN: mkdir -p %t/Frameworks
+// RUN: mkdir -p %t/Frameworks/Foo.framework/
+// RUN: mkdir -p %t/Frameworks/Foo.framework/Modules
+// RUN: mkdir -p %t/Frameworks/Foo.framework/Modules/Foo.swiftmodule
+
+// Build a dependency into a binary module with an @_implementationOnly dependency on `E`
+// RUN: echo "@_implementationOnly import E;public func foo() {}" >> %t/foo.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Frameworks/Foo.framework/Modules/Foo.swiftmodule/%target-cpu.swiftmodule -module-cache-path %t.module-cache %t/foo.swift -module-name Foo -I %S/Inputs/Swift
+
+// Run the scan
+// RUN: %target-swift-frontend -scan-dependencies %s -o %t/deps.json -F %t/Frameworks/ -sdk %t
+// RUN: %FileCheck %s < %t/deps.json
+
+import Foo
+
+// CHECK-NOT: "swift": "E"


### PR DESCRIPTION
These modules are not guaranteed to be found, which is okay, as compilation is meant to be possible in their absense since their contents are not used in the public API of the module which imports them as implementation-only.

Resolves rdar://103569312
