### PR TITLE
[5.8] LLVM product: amend installation path of compiler-rt libraries...

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -459,6 +459,6 @@ class LLVM(cmake_product.CMakeProduct):
 
         if self.args.llvm_install_components and system() == 'Darwin':
             clang_dest_dir = '{}{}'.format(host_install_destdir,
-                                           targets.install_prefix())
+                                           self.args.install_prefix)
             self.copy_embedded_compiler_rt_builtins_from_darwin_host_toolchain(
                 clang_dest_dir)


### PR DESCRIPTION
...copied from the host toolchain

Addresses #62626, rdar://104724130

(cherry picked from commit a2aed1f1736d9050b767c2971d1f6aa9ffac5f59, #63311 )
