### PR TITLE
[stdlib] String._classify(): Handle shared native case

### DIFF
--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -1276,6 +1276,9 @@ extension _StringObject {
     case ._cocoa(object: let object):
       let address: UnsafeRawPointer = Builtin.reinterpretCast(object)
       print("Cocoa(address: \(address))")
+    case ._shared(object: let object):
+      let address: UnsafeRawPointer = Builtin.reinterpretCast(object)
+      print("Shared(address: \(address))")
     }
 #endif // INTERNAL_CHECKS_ENABLED
   }

--- a/stdlib/public/core/StringTesting.swift
+++ b/stdlib/public/core/StringTesting.swift
@@ -23,7 +23,8 @@ struct _StringRepresentation {
     case _cocoa(object: AnyObject)
     case _native(object: AnyObject)
     case _immortal(address: UInt)
-    // TODO: shared native
+    // Introduced in SwiftStdlib 5.9:
+    case _shared(object: AnyObject)
   }
   public var _form: _Form
 
@@ -31,6 +32,7 @@ struct _StringRepresentation {
     switch _form {
       case ._cocoa(let object): return ObjectIdentifier(object)
       case ._native(let object): return ObjectIdentifier(object)
+      case ._shared(let object): return ObjectIdentifier(object)
       default: return nil
     }
   }
@@ -72,7 +74,6 @@ extension _StringGuts {
       return result
     }
 
-    // TODO: shared native
     _internalInvariant(_object.providesFastUTF8)
     if _object.isImmortal {
       result._form = ._immortal(
@@ -82,6 +83,10 @@ extension _StringGuts {
     if _object.hasNativeStorage {
       _internalInvariant(_object.largeFastIsTailAllocated)
       result._form = ._native(object: _object.nativeStorage)
+      return result
+    }
+    if _object.hasSharedStorage {
+      result._form = ._shared(object: _object.sharedStorage)
       return result
     }
     fatalError()

--- a/test/api-digester/stability-stdlib-abi-without-asserts.test
+++ b/test/api-digester/stability-stdlib-abi-without-asserts.test
@@ -121,4 +121,8 @@ Var _StringGuts._isContiguousUTF16 has been removed
 Var _StringGuts.startUTF16 has been removed
 Func _persistCString(_:) has been removed
 
+// Language inconsistency: enum cases with associated values cannot have availability, but
+// the ABI checker wants to see one anyway.
+EnumElement _StringRepresentation._Form._shared is a new API without @available attribute
+
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)

--- a/test/stdlib/NewString.swift
+++ b/test/stdlib/NewString.swift
@@ -41,6 +41,12 @@ func repr(_ x: _StringRepresentation) -> String {
     return """
       Unmanaged(count: \(x._count))
       """
+  case ._shared(let object):
+    return """
+      Shared(\
+      object: \(hexAddrVal(object)), \
+      count: \(x._count))
+      """
   }
 }
 

--- a/test/stdlib/NewStringAppending.swift
+++ b/test/stdlib/NewStringAppending.swift
@@ -50,6 +50,12 @@ func repr(_ x: _StringRepresentation) -> String {
     return """
       Unmanaged(count: \(x._count))
       """
+  case ._shared(let object):
+    return """
+      Shared(\
+      object: \(hexAddrVal(object)), \
+      count: \(x._count))
+      """
   }
 }
 


### PR DESCRIPTION
Trapping in this case can make debugging string problems extraordinarily frustrating.