### PR TITLE
Coerce the parameter of the parameter to `withoutActuallyEscaping` to actually be escaping.

### DIFF
--- a/test/SILGen/without_actually_escaping_that_doesnt_actually_escape.swift
+++ b/test/SILGen/without_actually_escaping_that_doesnt_actually_escape.swift
@@ -1,0 +1,5 @@
+// RUN: %target-swift-emit-silgen -verify %s
+
+func foo(_ f: (() -> Void) -> Void, _ b: () -> Void) {
+    return withoutActuallyEscaping(b, do: f)
+}


### PR DESCRIPTION
People can call `withoutActuallyEscaping` and give it a `do:` body function that, well, doesn't actually take an escaping closure argument as in:

```swift
func foo(_ f: (() -> Void) -> Void, _ b: () -> Void) {
    return withoutActuallyEscaping(b, do: f)
}
```

and this wouldn't really work because the did-it-escape checking relies on having a refcounted object to probe, aside from triggering a bunch of assertion failures in SILGen which assumed the parameter would be escaping. Fixes rdar://104477418.