### PR TITLE
[Macros] Emit macro expansion buffers for diagnostics.

### DIFF
--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -73,6 +73,9 @@ public:
   /// descriptive style that's specific to Swift (currently experimental).
   FormattingStyle PrintedFormattingStyle = FormattingStyle::LLVM;
 
+  /// Whether to emit macro expansion buffers into separate, temporary files.
+  bool EmitMacroExpansionFiles = false;
+
   std::string DiagnosticDocumentationPath = "";
 
   std::string LocalizationCode = "";

--- a/include/swift/Basic/DiagnosticOptions.h
+++ b/include/swift/Basic/DiagnosticOptions.h
@@ -74,7 +74,7 @@ public:
   FormattingStyle PrintedFormattingStyle = FormattingStyle::LLVM;
 
   /// Whether to emit macro expansion buffers into separate, temporary files.
-  bool EmitMacroExpansionFiles = false;
+  bool EmitMacroExpansionFiles = true;
 
   std::string DiagnosticDocumentationPath = "";
 

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -350,7 +350,8 @@ public:
   llvm::SMDiagnostic GetMessage(SourceLoc Loc, llvm::SourceMgr::DiagKind Kind,
                                 const Twine &Msg,
                                 ArrayRef<llvm::SMRange> Ranges,
-                                ArrayRef<llvm::SMFixIt> FixIts) const;
+                                ArrayRef<llvm::SMFixIt> FixIts,
+                                bool EmitMacroExpansionFiles = false) const;
 
   /// Verifies that all buffers are still valid.
   void verifyAllBuffers() const;

--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -33,6 +33,7 @@ class PrintingDiagnosticConsumer : public DiagnosticConsumer {
   llvm::raw_ostream &Stream;
   bool ForceColors = false;
   bool PrintEducationalNotes = false;
+  bool EmitMacroExpansionFiles = false;
   bool DidErrorOccur = false;
   DiagnosticOptions::FormattingStyle FormattingStyle =
       DiagnosticOptions::FormattingStyle::LLVM;
@@ -75,6 +76,10 @@ public:
 
   void setFormattingStyle(DiagnosticOptions::FormattingStyle style) {
     FormattingStyle = style;
+  }
+
+  void setEmitMacroExpansionFiles(bool ShouldEmit) {
+    EmitMacroExpansionFiles = ShouldEmit;
   }
 
   bool didErrorOccur() {

--- a/include/swift/Frontend/SerializedDiagnosticConsumer.h
+++ b/include/swift/Frontend/SerializedDiagnosticConsumer.h
@@ -36,7 +36,7 @@ namespace swift {
     ///
     /// \returns A new diagnostic consumer that serializes diagnostics.
     std::unique_ptr<DiagnosticConsumer>
-    createConsumer(llvm::StringRef outputPath);
+    createConsumer(llvm::StringRef outputPath, bool emitMacroExpansionFiles);
   }
 }
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -342,6 +342,8 @@ def debug_requirement_machine : Joined<["-"], "debug-requirement-machine=">,
 
 def dump_macro_expansions : Flag<["-"], "dump-macro-expansions">,
   HelpText<"Dumps the results of each macro expansion">;
+def emit_macro_expansion_files : Separate<["-"], "emit-macro-expansion-files">,
+  HelpText<"Specify when to emit macro expansion file: 'none', 'debug', or 'diagnostics'">;
 
 def analyze_requirement_machine : Flag<["-"], "analyze-requirement-machine">,
   Flags<[FrontendOption, HelpHidden, DoesNotAffectIncrementalBuild]>,

--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -1846,7 +1846,7 @@ createDiagConsumer(llvm::raw_ostream &OS, bool &FailOnError, bool DisableFailOnE
   if (!SerializedDiagPath.empty()) {
     FailOnError = !DisableFailOnError;
     results.emplace_back(std::make_unique<PrintingDiagnosticConsumer>());
-    results.emplace_back(serialized_diagnostics::createConsumer(SerializedDiagPath));
+    results.emplace_back(serialized_diagnostics::createConsumer(SerializedDiagPath, false));
   } else if (CompilerStyleDiags) {
     FailOnError = !DisableFailOnError;
     results.emplace_back(std::make_unique<PrintingDiagnosticConsumer>());

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1476,6 +1476,15 @@ static bool ParseDiagnosticArgs(DiagnosticOptions &Opts, ArgList &Args,
     }
   }
 
+  for (const Arg *arg: Args.filtered(OPT_emit_macro_expansion_files)) {
+    StringRef contents = arg->getValue();
+    bool negated = contents.startswith("no-");
+    if (negated)
+      contents = contents.drop_front(3);
+    if (contents == "diagnostics")
+      Opts.EmitMacroExpansionFiles = !negated;
+  }
+
   Opts.FixitCodeForAllDiagnostics |= Args.hasArg(OPT_fixit_all);
   Opts.SuppressWarnings |= Args.hasArg(OPT_suppress_warnings);
   Opts.SuppressRemarks |= Args.hasArg(OPT_suppress_remarks);

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -1182,7 +1182,8 @@ void PrintingDiagnosticConsumer::printDiagnostic(SourceManager &SM,
                                            Info.FormatArgs);
   }
 
-  auto Msg = SM.GetMessage(Info.Loc, SMKind, Text, Ranges, FixIts);
+  auto Msg = SM.GetMessage(Info.Loc, SMKind, Text, Ranges, FixIts,
+                           EmitMacroExpansionFiles);
   rawSM.PrintMessage(out, Msg, ForceColors);
 }
 
@@ -1190,7 +1191,8 @@ llvm::SMDiagnostic
 SourceManager::GetMessage(SourceLoc Loc, llvm::SourceMgr::DiagKind Kind,
                           const Twine &Msg,
                           ArrayRef<llvm::SMRange> Ranges,
-                          ArrayRef<llvm::SMFixIt> FixIts) const {
+                          ArrayRef<llvm::SMFixIt> FixIts,
+                          bool EmitMacroExpansionFiles) const {
 
   // First thing to do: find the current buffer containing the specified
   // location to pull out the source line.
@@ -1200,7 +1202,7 @@ SourceManager::GetMessage(SourceLoc Loc, llvm::SourceMgr::DiagKind Kind,
   std::string LineStr;
 
   if (Loc.isValid()) {
-    BufferID = getDisplayNameForLoc(Loc);
+    BufferID = getDisplayNameForLoc(Loc, EmitMacroExpansionFiles);
     auto CurMB = LLVMSourceMgr.getMemoryBuffer(findBufferContainingLoc(Loc));
 
     // Scan backward to find the start of the line.

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -5,7 +5,7 @@
 // Diagnostics testing
 // RUN: %target-typecheck-verify-swift -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS
 
-// RUN: not %target-swift-frontend -typecheck -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS -serialize-diagnostics-path %t/macro_expand.dia %s
+// RUN: not %target-swift-frontend -typecheck -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS -serialize-diagnostics-path %t/macro_expand.dia %s -emit-macro-expansion-files no-diagnostics
 // RUN: c-index-test -read-diagnostics %t/macro_expand.dia 2>&1 | %FileCheck -check-prefix CHECK-DIAGS %s
 
 // Debug info SIL testing


### PR DESCRIPTION
By default, emit any macro expansion buffers referenced by diagnostics into files in a temporary directory. This makes debugging type-checking failures in macro expansions far easier, because you can see them after the compiler process has exited.

This can be disabled with `-emit-macro-expansion-files no-diagnostics`