### PR TITLE
[AST] Avoid possible segfault in isDirectToStorageAccess

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2143,7 +2143,7 @@ static bool isDirectToStorageAccess(const DeclContext *UseDC,
   if (!var->hasStorage())
     return false;
 
-  auto *AFD = dyn_cast<AbstractFunctionDecl>(UseDC);
+  auto *AFD = dyn_cast_or_null<AbstractFunctionDecl>(UseDC);
   if (AFD == nullptr)
     return false;
 


### PR DESCRIPTION
`isAccessibleFrom` allows a `nullptr` for `useDC`. Thus `UseDC` can be a `nullptr` in the path `checkAccess` -> `getAccessSemanticsFromContext` -> `isDirectToStorageAccess`.

Resolves rdar://104620331.