### PR TITLE
[Distributed] LocalDAS cannot gain constraint on resolve method

### DIFF
--- a/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
+++ b/stdlib/public/Distributed/LocalTestingDistributedActorSystem.swift
@@ -43,7 +43,7 @@ public final class LocalTestingDistributedActorSystem: DistributedActorSystem, @
   public init() {}
 
   public func resolve<Act>(id: ActorID, as actorType: Act.Type)
-    throws -> Act? where Act: DistributedActor, Act.ID == ActorID {
+    throws -> Act? where Act: DistributedActor {
     guard let anyActor = self.activeActorsLock.withLock({ self.activeActors[id] }) else {
       throw LocalTestingDistributedActorSystemError(message: "Unable to locate id '\(id)' locally")
     }


### PR DESCRIPTION
We fixed this issue for `assignID` in https://github.com/apple/swift/pull/62572 however, the same issue exists on `resolve` of the `LocalDAS` so we need to fix it over there as well.

Resolves rdar://101858553