### PR TITLE
ModuleInterface: Coallesce `@_backDeploy` attributes when printed

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -543,6 +543,25 @@ static void printShortFormAvailable(ArrayRef<const DeclAttribute *> Attrs,
     Printer.printNewline();
 }
 
+static void printShortFormBackDeployed(ArrayRef<const DeclAttribute *> Attrs,
+                                       ASTPrinter &Printer,
+                                       const PrintOptions &Options) {
+  assert(!Attrs.empty());
+  Printer << "@_backDeploy(before: ";
+  bool isFirst = true;
+
+  for (auto *DA : Attrs) {
+    if (!isFirst)
+      Printer << ", ";
+    auto *attr = cast<BackDeployAttr>(DA);
+    Printer << platformString(attr->Platform) << " "
+            << attr->Version.getAsString();
+    isFirst = false;
+  }
+  Printer << ")";
+  Printer.printNewline();
+}
+
 /// The kind of a parameter in a `wrt:` differentiation parameters clause:
 /// either a differentiability parameter or a linearity parameter. Used for
 /// printing `@differentiable`, `@derivative`, and `@transpose` attributes.
@@ -754,6 +773,7 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
   AttributeVector shortAvailableAttributes;
   const DeclAttribute *swiftVersionAvailableAttribute = nullptr;
   const DeclAttribute *packageDescriptionVersionAvailableAttribute = nullptr;
+  AttributeVector backDeployAttributes;
   AttributeVector longAttributes;
   AttributeVector attributes;
   AttributeVector modifiers;
@@ -791,6 +811,7 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
     }
 
     AttributeVector &which = DA->isDeclModifier() ? modifiers :
+                             isa<BackDeployAttr>(DA) ? backDeployAttributes :
                              isShortAvailable(DA) ? shortAvailableAttributes :
                              DA->isLongAttribute() ? longAttributes :
                              attributes;
@@ -803,6 +824,8 @@ void DeclAttributes::print(ASTPrinter &Printer, const PrintOptions &Options,
     printShortFormAvailable(packageDescriptionVersionAvailableAttribute, Printer, Options);
   if (!shortAvailableAttributes.empty())
     printShortFormAvailable(shortAvailableAttributes, Printer, Options);
+  if (!backDeployAttributes.empty())
+    printShortFormBackDeployed(backDeployAttributes, Printer, Options);
 
   for (auto DA : longAttributes)
     DA->print(Printer, Options, D);

--- a/test/ModuleInterface/back-deploy-attr.swift
+++ b/test/ModuleInterface/back-deploy-attr.swift
@@ -11,11 +11,18 @@ public struct TopLevelStruct {
   @_backDeploy(before: macOS 12.0)
   public func backDeployedFunc_SinglePlatform() -> Int { return 42 }
   
-  // CHECK: @_backDeploy(before: macOS 12.0)
-  // CHECK: @_backDeploy(before: iOS 15.0)
+  // CHECK: @_backDeploy(before: macOS 12.0, iOS 15.0)
   // CHECK: public func backDeployedFunc_MultiPlatform() -> Swift.Int { return 43 }
   @_backDeploy(before: macOS 12.0, iOS 15.0)
   public func backDeployedFunc_MultiPlatform() -> Int { return 43 }
+
+  // CHECK: @_backDeploy(before: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0)
+  // CHECK: public func backDeployedFunc_MultiPlatformSeparate() -> Swift.Int { return 43 }
+  @_backDeploy(before: macOS 12.0)
+  @_backDeploy(before: iOS 15.0)
+  @_backDeploy(before: watchOS 8.0)
+  @_backDeploy(before: tvOS 15.0)
+  public func backDeployedFunc_MultiPlatformSeparate() -> Int { return 43 }
 
   // CHECK: @_backDeploy(before: macOS 12.0)
   // CHECK: public var backDeployedComputedProperty: Swift.Int {
@@ -55,8 +62,7 @@ public func backDeployTopLevelFunc1() -> Int { return 47 }
 @_backDeploy(before: _macOS12_1)
 public func backDeployTopLevelFunc2() -> Int { return 48 }
 
-// CHECK: @_backDeploy(before: macOS 12.1)
-// CHECK: @_backDeploy(before: iOS 15.1)
+// CHECK: @_backDeploy(before: macOS 12.1, iOS 15.1)
 // CHECK: public func backDeployTopLevelFunc3() -> Swift.Int { return 49 }
 @_backDeploy(before: _myProject 1.0)
 public func backDeployTopLevelFunc3() -> Int { return 49 }


### PR DESCRIPTION
This should improve the readability of declarations with `@_backDeploy` attributes for multiple platforms.

Resolves rdar://104712811
