### PR TITLE
[interop] Emit symbolic interfaces while indexing

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -270,6 +270,10 @@ REMARK(remark_indexing_system_module,none,
        "indexing system module at %0"
        "%select{|; skipping because of a broken swiftinterface}1",
        (StringRef, bool))
+REMARK(remark_emitting_symbolic_interface_module,none,
+       "emitting symbolic interface at %0"
+       "%select{|; skipping because it's up to date}1",
+       (StringRef, bool))
 
 ERROR(error_wrong_number_of_arguments,none,
       "wrong number of '%0' arguments (expected %1, got %2)",

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -270,6 +270,13 @@ REMARK(remark_indexing_system_module,none,
        "indexing system module at %0"
        "%select{|; skipping because of a broken swiftinterface}1",
        (StringRef, bool))
+
+ERROR(error_create_symbolic_interfaces_dir,none,
+      "creating symbolic interfaces directory: %0", (StringRef))
+ERROR(error_symbolic_interfaces_failed_status_check,none,
+      "failed file status check: %0", (StringRef))
+ERROR(error_write_symbolic_interface,none,
+      "writing symbolic interface file: %0", (StringRef))
 REMARK(remark_emitting_symbolic_interface_module,none,
        "emitting symbolic interface at %0"
        "%select{|; skipping because it's up to date}1",

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -562,6 +562,10 @@ struct PrintOptions {
   /// If false, we print them as ordinary associated types.
   bool PrintPrimaryAssociatedTypes = true;
 
+  /// If true, import and print C++ declarations with symbolic import feature
+  /// enabled.
+  bool PrintSymbolicCXXDecls = false;
+
   /// If this is not \c nullptr then function bodies (including accessors
   /// and constructors) will be printed by this function.
   std::function<void(const ValueDecl *, ASTPrinter &)> FunctionBody;

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -562,10 +562,6 @@ struct PrintOptions {
   /// If false, we print them as ordinary associated types.
   bool PrintPrimaryAssociatedTypes = true;
 
-  /// If true, import and print C++ declarations with symbolic import feature
-  /// enabled.
-  bool PrintSymbolicCXXDecls = false;
-
   /// If this is not \c nullptr then function bodies (including accessors
   /// and constructors) will be printed by this function.
   std::function<void(const ValueDecl *, ASTPrinter &)> FunctionBody;

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -167,6 +167,11 @@ EXPERIMENTAL_FEATURE(BuiltinMacros, false)
 /// declare an attribute which is discoverable and constructable at runtime.
 EXPERIMENTAL_FEATURE(RuntimeDiscoverableAttrs, false)
 
+/// Import C++ class templates as semantically-meaningless symbolic
+/// Swift types and C++ methods as symbolic functions with blank
+/// signatures.
+EXPERIMENTAL_FEATURE(ImportSymbolicCXXDecls, false)
+
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE
 #undef SUPPRESSIBLE_LANGUAGE_FEATURE

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -572,6 +572,13 @@ getModuleCachePathFromClang(const clang::CompilerInstance &Instance);
 /// Whether the given parameter name identifies a completion handler.
 bool isCompletionHandlerParamName(StringRef paramName);
 
+namespace importer {
+
+/// Returns true if the given module has a 'cplusplus' requirement.
+bool requiresCPlusPlus(const clang::Module *module);
+
+} // namespace importer
+
 } // end namespace swift
 
 #endif

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -555,6 +555,9 @@ public:
   /// Emit diagnostics for declarations named name that are members
   /// of the provided baseType.
   void diagnoseMemberValue(const DeclName &name, const Type &baseType) override;
+
+  /// Enable/disable the symbolic import experimental feature.
+  void enableSymbolicImportFeature(bool isEnabled = true);
 };
 
 ImportDecl *createImportDecl(ASTContext &Ctx, DeclContext *DC, ClangNode ClangN,

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -556,8 +556,8 @@ public:
   /// of the provided baseType.
   void diagnoseMemberValue(const DeclName &name, const Type &baseType) override;
 
-  /// Enable/disable the symbolic import experimental feature.
-  void enableSymbolicImportFeature(bool isEnabled = true);
+  /// Enable the symbolic import experimental feature for the given callback.
+  void withSymbolicFeatureEnabled(llvm::function_ref<void(void)> callback);
 };
 
 ImportDecl *createImportDecl(ASTContext &Ctx, DeclContext *DC, ClangNode ClangN,

--- a/include/swift/IDE/ModuleInterfacePrinting.h
+++ b/include/swift/IDE/ModuleInterfacePrinting.h
@@ -19,6 +19,10 @@
 #include <string>
 #include <vector>
 
+namespace clang {
+class Module;
+}
+
 namespace swift {
 class ASTContext;
 class ASTPrinter;
@@ -67,6 +71,10 @@ void printHeaderInterface(StringRef Filename, ASTContext &Ctx,
 /// Print the interface for a given swift source file.
 void printSwiftSourceInterface(SourceFile &File, ASTPrinter &Printer,
                                const PrintOptions &Options);
+
+/// Print the symbolic Swift interface for a given imported clang module.
+void printSymbolicSwiftClangModuleInterface(ModuleDecl *M, ASTPrinter &Printer,
+                                            const clang::Module *clangModule);
 
 } // namespace ide
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3170,6 +3170,8 @@ static bool usesFeatureBuiltinMacros(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureImportSymbolicCXXDecls(Decl *decl) { return false; }
+
 static void
 suppressingFeatureNoAsyncAvailability(PrintOptions &options,
                                       llvm::function_ref<void()> action) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6569,3 +6569,19 @@ void ClangImporter::enableSymbolicImportFeature(bool isEnabled) {
   Impl.importSymbolicCXXDecls = isEnabled;
   Impl.nameImporter->enableSymbolicImportFeature(isEnabled);
 }
+
+bool importer::requiresCPlusPlus(const clang::Module *module) {
+  // The libc++ modulemap doesn't currently declare the requirement.
+  if (module->getTopLevelModuleName() == "std")
+    return true;
+
+  // Modulemaps often declare the requirement for the top-level module only.
+  if (auto parent = module->Parent) {
+    if (requiresCPlusPlus(parent))
+      return true;
+  }
+
+  return llvm::any_of(module->Requirements, [](clang::Module::Requirement req) {
+    return req.first == "cplusplus";
+  });
+}

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2269,13 +2269,13 @@ ClangImporter::Implementation::Implementation(
           !ctx.ClangImporterOpts.BridgingHeader.empty()),
       DisableOverlayModules(ctx.ClangImporterOpts.DisableOverlayModules),
       EnableClangSPI(ctx.ClangImporterOpts.EnableClangSPI),
+      importSymbolicCXXDecls(
+          ctx.LangOpts.hasFeature(Feature::ImportSymbolicCXXDecls)),
       IsReadingBridgingPCH(false),
       CurrentVersion(ImportNameVersion::fromOptions(ctx.LangOpts)),
-      Walker(DiagnosticWalker(*this)),
-      BuffersForDiagnostics(ctx.SourceMgr),
+      Walker(DiagnosticWalker(*this)), BuffersForDiagnostics(ctx.SourceMgr),
       BridgingHeaderLookupTable(new SwiftLookupTable(nullptr)),
-      platformAvailability(ctx.LangOpts),
-      nameImporter(),
+      platformAvailability(ctx.LangOpts), nameImporter(),
       DisableSourceImport(ctx.ClangImporterOpts.DisableSourceImport),
       DWARFImporter(dwarfImporterDelegate) {}
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6564,3 +6564,8 @@ CustomRefCountingOperationResult CustomRefCountingOperation::evaluate(
 
   return {CustomRefCountingOperationResult::tooManyFound, nullptr, name};
 }
+
+void ClangImporter::enableSymbolicImportFeature(bool isEnabled) {
+  Impl.importSymbolicCXXDecls = isEnabled;
+  Impl.nameImporter->enableSymbolicImportFeature(isEnabled);
+}

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -2173,6 +2173,11 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
 
   if (auto classTemplateSpecDecl =
           dyn_cast<clang::ClassTemplateSpecializationDecl>(D)) {
+    /// Symbolic specializations get imported as the symbolic class template
+    /// type.
+    if (importSymbolicCXXDecls)
+      return importNameImpl(classTemplateSpecDecl->getSpecializedTemplate(),
+                            version, givenName);
     if (!isa<clang::ClassTemplatePartialSpecializationDecl>(D)) {
 
       auto &astContext = classTemplateSpecDecl->getASTContext();

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -458,6 +458,10 @@ public:
                             clang::ObjCInterfaceDecl *classDecl,
                             bool forInstance);
 
+  inline void enableSymbolicImportFeature(bool isEnabled) {
+    importSymbolicCXXDecls = isEnabled;
+  }
+
 private:
   bool enableObjCInterop() const { return swiftCtx.LangOpts.EnableObjCInterop; }
 

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -387,11 +387,15 @@ class NameImporter {
   llvm::DenseMap<std::pair<const clang::ObjCInterfaceDecl *, char>,
                  std::unique_ptr<InheritedNameSet>> allProperties;
 
+  bool importSymbolicCXXDecls;
+
 public:
   NameImporter(ASTContext &ctx, const PlatformAvailability &avail,
                clang::Sema &cSema)
       : swiftCtx(ctx), availability(avail), clangSema(cSema),
-        enumInfos(clangSema.getPreprocessor()) {}
+        enumInfos(clangSema.getPreprocessor()),
+        importSymbolicCXXDecls(
+            ctx.LangOpts.hasFeature(Feature::ImportSymbolicCXXDecls)) {}
 
   /// Determine the Swift name for a Clang decl
   ImportedName importName(const clang::NamedDecl *decl,

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -66,6 +66,10 @@ bool ClangImporter::Implementation::isOverAligned(const clang::TypeDecl *decl) {
 }
 
 bool ClangImporter::Implementation::isOverAligned(clang::QualType type) {
+  // Do not check type layout for a clang type in symbolic mode as the
+  // type could be a dependent type.
+  if (importSymbolicCXXDecls)
+    return false;
   auto align = getClangASTContext().getTypeAlignInChars(type);
   return align > clang::CharUnits::fromQuantity(MaximumAlignment);
 }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1927,22 +1927,6 @@ inline Optional<const clang::EnumDecl *> findAnonymousEnumForTypedef(
   return None;
 }
 
-inline bool requiresCPlusPlus(const clang::Module *module) {
-  // The libc++ modulemap doesn't currently declare the requirement.
-  if (module->getTopLevelModuleName() == "std")
-    return true;
-
-  // Modulemaps often declare the requirement for the top-level module only.
-  if (auto parent = module->Parent) {
-    if (requiresCPlusPlus(parent))
-      return true;
-  }
-
-  return llvm::any_of(module->Requirements, [](clang::Module::Requirement req) {
-    return req.first == "cplusplus";
-  });
-}
-
 inline std::string getPrivateOperatorName(const std::string &OperatorToken) {
 #define OVERLOADED_OPERATOR(Name, Spelling, Token, Unary, Binary, MemberOnly)  \
   if (OperatorToken == Spelling) {                                             \

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -452,6 +452,7 @@ public:
   const bool BridgingHeaderExplicitlyRequested;
   const bool DisableOverlayModules;
   const bool EnableClangSPI;
+  bool importSymbolicCXXDecls;
 
   bool IsReadingBridgingPCH;
   llvm::SmallVector<clang::serialization::SubmoduleID, 2> PCHImportedSubmodules;

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-libcxx-no-foundation-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-libcxx-no-foundation-symbolic-module-interface.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop
+// RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
+
+// REQUIRES: OS=macosx
+// REQUIRES: cxx-interop-fixed-cf_options
+
+//--- test.swift
+
+import CxxStdlib
+import Foundation
+
+// FILES: std-{{.*}}.pcm.symbolicswiftinterface
+// FILES-NOT: Foundation*

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-libcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-libcxx-symbolic-module-interface.swift
@@ -13,7 +13,6 @@
 // RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
 
 // REQUIRES: OS=macosx
-// REQUIRES: cxx-interop-fixed-cf_options
 
 //--- Inputs/module.modulemap
 module CxxModule {

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-libcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-libcxx-symbolic-module-interface.swift
@@ -28,7 +28,6 @@ int freeFunction(int x, int y);
 
 import CxxStdlib
 import CxxModule
-import Foundation
 
 // REMARK_NEW: remark: emitting symbolic interface at {{.*}}/interfaces/std-{{.*}}.pcm.symbolicswiftinterface{{$}}
 // REMARK_NEW: remark: emitting symbolic interface at {{.*}}/interfaces/CxxModule-{{.*}}.pcm.symbolicswiftinterface{{$}}
@@ -38,6 +37,5 @@ import Foundation
 
 // FILES: CxxModule-{{.*}}.pcm.symbolicswiftinterface
 // FILES: std-{{.*}}.pcm.symbolicswiftinterface
-// FILES-NOT: Foundation*
 
 // CHECK: // Swift interface for system module 'std'

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-libcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-libcxx-symbolic-module-interface.swift
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Verify that symbolic interfaces are emitted.
+//
+// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NEW %s
+// RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
+// RUN: cat %t/store/interfaces/std* | %FileCheck --check-prefix=CHECK %s
+
+// Verify that symbolic interfaces are not emitted when PCM doesn't change.
+//
+// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NO_UPDATE %s
+// RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
+
+// REQUIRES: OS=macosx
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    header "headerA.h"
+    requires cplusplus
+}
+
+//--- Inputs/headerA.h
+
+int freeFunction(int x, int y);
+
+//--- test.swift
+
+import CxxStdlib
+import CxxModule
+import Foundation
+
+// REMARK_NEW: remark: emitting symbolic interface at {{.*}}/interfaces/std-{{.*}}.pcm.symbolicswiftinterface{{$}}
+// REMARK_NEW: remark: emitting symbolic interface at {{.*}}/interfaces/CxxModule-{{.*}}.pcm.symbolicswiftinterface{{$}}
+
+// REMARK_NO_UPDATE: remark: emitting symbolic interface at {{.*}}/interfaces/std-{{.*}}.pcm.symbolicswiftinterface; skipping because it's up to date{{$}}
+// REMARK_NO_UPDATE: remark: emitting symbolic interface at {{.*}}/interfaces/CxxModule-{{.*}}.pcm.symbolicswiftinterface; skipping because it's up to date{{$}}
+
+// FILES: CxxModule-{{.*}}.pcm.symbolicswiftinterface
+// FILES: std-{{.*}}.pcm.symbolicswiftinterface
+// FILES-NOT: Foundation*
+
+// CHECK: // Swift interface for system module 'std'

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-libcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-libcxx-symbolic-module-interface.swift
@@ -13,6 +13,7 @@
 // RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
 
 // REQUIRES: OS=macosx
+// REQUIRES: cxx-interop-fixed-cf_options
 
 //--- Inputs/module.modulemap
 module CxxModule {

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-libcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-libcxx-symbolic-module-interface.swift
@@ -3,7 +3,9 @@
 
 // Verify that symbolic interfaces are emitted.
 //
-// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NEW %s
+// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>%t/remarks
+// RUN: echo "EOF" >> %t/remarks
+// RUN: cat %t/remarks | %FileCheck --check-prefix=REMARK_NEW %s
 // RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
 // RUN: cat %t/store/interfaces/std* | %FileCheck --check-prefix=CHECK %s
 
@@ -30,7 +32,8 @@ import CxxStdlib
 import CxxModule
 
 // REMARK_NEW: remark: emitting symbolic interface at {{.*}}/interfaces/std-{{.*}}.pcm.symbolicswiftinterface{{$}}
-// REMARK_NEW: remark: emitting symbolic interface at {{.*}}/interfaces/CxxModule-{{.*}}.pcm.symbolicswiftinterface{{$}}
+// REMARK_NEW-NEXT: remark: emitting symbolic interface at {{.*}}/interfaces/CxxModule-{{.*}}.pcm.symbolicswiftinterface{{$}}
+// REMARK_NEW-NEXT: EOF
 
 // REMARK_NO_UPDATE: remark: emitting symbolic interface at {{.*}}/interfaces/std-{{.*}}.pcm.symbolicswiftinterface; skipping because it's up to date{{$}}
 // REMARK_NO_UPDATE: remark: emitting symbolic interface at {{.*}}/interfaces/CxxModule-{{.*}}.pcm.symbolicswiftinterface; skipping because it's up to date{{$}}

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-no-symbolic-module-interface-no-clang-module-index.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-no-symbolic-module-interface-no-clang-module-index.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+//
+// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-ignore-clang-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck %s
+// RUN: not ls %t/store/interfaces
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    header "headerA.h"
+    requires cplusplus
+}
+
+//--- Inputs/headerA.h
+
+namespace ns {
+    int freeFunction(int x, int y);
+}
+
+//--- test.swift
+
+import CxxModule
+
+// CHECK-NOT: emitting symbolic interface at

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-objcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-objcxx-symbolic-module-interface.swift
@@ -1,0 +1,59 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NEW %s
+// RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
+// RUN: cat %t/store/interfaces/ObjCxxModule* | %FileCheck --check-prefix=CHECK %s
+
+
+// Verify that symbolic interface is not emitted without interop.
+//
+// RUN: rm -r %t/store/interfaces
+// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NONE %s
+// RUN: not ls %t/store/interfaces
+
+// REQUIRES: objc_interop
+// REQUIRES: cxx-interop-fixed-cf_options
+
+//--- Inputs/module.modulemap
+module ObjCxxModule {
+    header "headerA.h"
+    // NOTE: does not require cplusplus
+}
+
+//--- Inputs/headerA.h
+
+#include <Foundation/Foundation.h>
+
+#ifdef __cplusplus
+namespace ns {
+    int freeCxxFunction(int x, int y);
+}
+#endif
+
+@interface ObjCClass: NSObject
+
+- (void)myTestMethod;
+
+@end
+
+//--- test.swift
+
+import ObjCxxModule
+
+// REMARK_NEW: remark: emitting symbolic interface at {{.*}}/interfaces/ObjCxxModule-{{.*}}.pcm.symbolicswiftinterface{{$}}
+// REMARK_NONE-NOT: emitting symbolic interface at
+
+// FILES: ObjCxxModule-{{.*}}.pcm.symbolicswiftinterface
+
+// CHECK: // Swift interface for module 'ObjCxxModule'
+// CHECK-NEXT: import Foundation
+// CHECK-EMPTY:
+// CHECK-NEXT: public enum ns {
+// CHECK-EMPTY:
+// CHECK-NEXT:     public static func freeCxxFunction(_ x: Int32, _ y: Int32) -> Int32
+// CHECK-NEXT: }
+// CHECK-NEXT: open class ObjCClass : NSObject {
+// CHECK-EMPTY:
+// CHECK-NEXT:     open func myTestMethod()
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface-used-decls.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface-used-decls.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop 2>&1
+// RUN: cat %t/store/interfaces/CxxModule* | %FileCheck --check-prefix=CHECK %s
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    header "header.h"
+    requires cplusplus
+}
+
+//--- Inputs/header.h
+
+namespace ns {
+    template<class T>
+    struct TemplateRecord {
+        void methodFunc(int x) const;
+    };
+}
+
+using TemplateRecordInt = ns::TemplateRecord<int>;
+
+//--- test.swift
+
+import CxxModule
+
+public func useConcreteTemplate() {
+    let x = TemplateRecordInt()
+    x.methodFunc(2)
+}
+
+// CHECK: // Swift interface for module 'CxxModule'
+// CHECK:     public enum ns {
+// CHECK-EMPTY:
+// CHECK-NEXT: public struct TemplateRecord {
+// CHECK-EMPTY:
+// CHECK-NEXT:    public func methodFunc()
+// CHECK-NEXT:}
+// CHECK-NEXT:}
+// CHECK-NEXT: public typealias TemplateRecordInt = ns.TemplateRecord

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface.swift
@@ -88,9 +88,9 @@ using MyType2 = TransitiveStruct<int>;
 
 import CxxModule
 
-// REMARK_NEW: remark: emitting symbolic interface at {{.*}}/interfaces/CxxModule-{{.*}}.pcm.symbolicswiftinterface{{$}}
+// REMARK_NEW: remark: emitting symbolic interface at {{.*}}{{/|\\}}interfaces{{/|\\}}CxxModule-{{.*}}.pcm.symbolicswiftinterface{{$}}
 
-// REMARK_NO_UPDATE: remark: emitting symbolic interface at {{.*}}/interfaces/CxxModule-{{.*}}.pcm.symbolicswiftinterface; skipping because it's up to date{{$}}
+// REMARK_NO_UPDATE: remark: emitting symbolic interface at {{.*}}{{/|\\}}interfaces{{/|\\}}CxxModule-{{.*}}.pcm.symbolicswiftinterface; skipping because it's up to date{{$}}
 
 // FILES: CxxModule-{{.*}}.pcm.symbolicswiftinterface
 // FILES-NOT: TransitiveCppMod

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface.swift
@@ -1,0 +1,131 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// Verify that symbolic interfaces are emitted.
+//
+// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NEW %s
+// RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
+// RUN: cat %t/store/interfaces/CxxModule* | %FileCheck --check-prefix=CHECK %s
+
+// Verify that symbolic interfaces are not emitted when PCM doesn't change.
+//
+// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NO_UPDATE %s
+// RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
+// RUN: cat %t/store/interfaces/CxxModule* | %FileCheck --check-prefix=CHECK %s
+
+// Verify that symbolic interface is re-emitted when the interface is removed.
+//
+// RUN: rm -r %t/store/interfaces
+// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NEW %s
+// RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
+// RUN: cat %t/store/interfaces/CxxModule* | %FileCheck --check-prefixes=CHECK %s
+
+// Verify that symbolic interface is re-emitted when PCM changes.
+//
+// RUN: echo "using AdditionalAlias = int;" >> %t/Inputs/headerA.h
+// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NEW %s
+// RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
+// RUN: cat %t/store/interfaces/CxxModule* | %FileCheck --check-prefixes=CHECK,CHECK-UPDATED %s
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    header "headerA.h"
+    header "headerB.h"
+    requires cplusplus
+}
+
+module TransitiveCppMod {
+    header "transitiveHeader.h"
+    requires cplusplus
+}
+
+//--- Inputs/headerA.h
+
+namespace ns {
+    int freeFunction(int x, int y);
+}
+
+//--- Inputs/transitiveHeader.h
+
+template<class T>
+struct TransitiveStruct {
+    T x;
+
+    void test() {}
+};
+
+//--- Inputs/headerB.h
+
+#include "headerA.h"
+#include "transitiveHeader.h"
+
+namespace ns {
+    struct B {
+        int y;
+    };
+
+    template<class T>
+    struct TemplateRecord {
+        void methodFunc(int x);
+
+        struct InnerRecord {
+            int innerMethod(int y);
+        };
+
+        template<class T2>
+        struct InnerTemplate {
+            void innerTemplateMethod();
+        };
+
+        InnerTemplate<int> returnsTemplateMethod();
+    };
+}
+
+using MyType = ns::TemplateRecord<int>;
+using MyType2 = TransitiveStruct<int>;
+
+//--- test.swift
+
+import CxxModule
+
+// REMARK_NEW: remark: emitting symbolic interface at {{.*}}/interfaces/CxxModule-{{.*}}.pcm.symbolicswiftinterface{{$}}
+
+// REMARK_NO_UPDATE: remark: emitting symbolic interface at {{.*}}/interfaces/CxxModule-{{.*}}.pcm.symbolicswiftinterface; skipping because it's up to date{{$}}
+
+// FILES: CxxModule-{{.*}}.pcm.symbolicswiftinterface
+// FILES-NOT: TransitiveCppMod
+
+// CHECK: // Swift interface for module 'CxxModule'
+// CHECK-UPDATED: typealias AdditionalAlias =
+// CHECK:     enum ns {
+// CHECK-EMPTY:
+// CHECK-NEXT: struct B {
+// CHECK-EMPTY:
+// CHECK-NEXT:    init()
+// CHECK-EMPTY:
+// CHECK-NEXT:    init(y: Int32)
+// CHECK-EMPTY:
+// CHECK-NEXT:    var y: Int32
+// CHECK-NEXT:  }
+// CHECK-EMPTY:
+// CHECK-NEXT:  struct TemplateRecord {
+// CHECK-EMPTY:
+// CHECK-NEXT:    mutating func methodFunc()
+// CHECK-EMPTY:
+// CHECK-NEXT:    struct InnerRecord {
+// CHECK-EMPTY:
+// CHECK-NEXT:      mutating func innerMethod()
+// CHECK-NEXT:    }
+// CHECK-EMPTY:
+// CHECK-NEXT:    struct InnerTemplate {
+// CHECK-EMPTY:
+// CHECK-NEXT:      mutating func innerTemplateMethod()
+// CHECK-NEXT:    }
+// CHECK-EMPTY:
+// CHECK-NEXT:    mutating func returnsTemplateMethod()
+// CHECK-NEXT:  }
+// CHECK-EMPTY:
+// CHECK-NEXT:  static func freeFunction(_ x: Int32, _ y: Int32) -> Int32
+// CHECK-NEXT: }
+// CHECK-NEXT: typealias MyType = ns.TemplateRecord
+// CHECK-NEXT: typealias MyType2 = TransitiveStruct

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-symbolic-module-interface.swift
@@ -3,7 +3,9 @@
 
 // Verify that symbolic interfaces are emitted.
 //
-// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>&1 | %FileCheck --check-prefix=REMARK_NEW %s
+// RUN: %target-swift-frontend %t/test.swift -I %t -c -index-system-modules -index-store-path %t/store -enable-experimental-cxx-interop -Rindexing-system-module 2>%t/remarks
+// RUN: echo "EOF" >> %t/remarks
+// RUN: cat %t/remarks | %FileCheck --check-prefixes=REMARK_NEW,REMARK_INITIAL %s
 // RUN: ls %t/store/interfaces | %FileCheck --check-prefix=FILES %s
 // RUN: cat %t/store/interfaces/CxxModule* | %FileCheck --check-prefix=CHECK %s
 
@@ -88,7 +90,9 @@ using MyType2 = TransitiveStruct<int>;
 
 import CxxModule
 
+// REMARK_INITIAL: remark: emitting symbolic interface at {{.*}}{{/|\\}}interfaces{{/|\\}}CxxShim-{{.*}}.pcm.symbolicswiftinterface{{$}}
 // REMARK_NEW: remark: emitting symbolic interface at {{.*}}{{/|\\}}interfaces{{/|\\}}CxxModule-{{.*}}.pcm.symbolicswiftinterface{{$}}
+// REMARK_INITIAL-NEXT: EOF
 
 // REMARK_NO_UPDATE: remark: emitting symbolic interface at {{.*}}{{/|\\}}interfaces{{/|\\}}CxxModule-{{.*}}.pcm.symbolicswiftinterface; skipping because it's up to date{{$}}
 

--- a/test/Interop/Cxx/symbolic-imports/print-libcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/print-libcxx-symbolic-module-interface.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxStdlib -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop -module-print-submodules -enable-experimental-feature ImportSymbolicCXXDecls | %FileCheck %s
+
+// REQUIRES: asserts
+// REQUIRES: OS=macosx
+// REQUIRES: libcxx-in-sdk
+
+// CHECK: enum std {
+// CHECK-NEXT: enum __1 {
+
+// CHECK: struct basic_string {
+
+// CHECK: typealias string = std.__1.basic_string
+
+// CHECK: struct vector {
+// CHECK: mutating func push_back()
+// CHECK: }
+
+// CHECK: struct map {
+
+// CHECK-NOT: enum std

--- a/test/Interop/Cxx/symbolic-imports/print-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/print-symbolic-module-interface.swift
@@ -1,0 +1,66 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxModule -I %t/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-experimental-feature ImportSymbolicCXXDecls | %FileCheck %s
+
+// REQUIRES: asserts
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    header "headerA.h"
+    header "headerB.h"
+    requires cplusplus
+}
+
+//--- Inputs/headerA.h
+
+namespace ns {
+    int freeFunction(int x, int y);
+}
+
+//--- Inputs/headerB.h
+
+#include "headerA.h"
+
+namespace ns {
+    struct B {
+        int y;
+    };
+
+    template<class T>
+    struct TemplateRecord {
+        void methodFunc(int x);
+
+        struct InnerRecord {
+            int innerMethod(int y);
+        };
+
+        template<class T2>
+        struct InnerTemplate {
+            void innerTemplateMethod();
+        };
+
+        InnerTemplate<int> returnsTemplateMethod();
+    };
+}
+
+using MyType = ns::TemplateRecord<int>;
+
+// CHECK:     enum ns {
+// CHECK-NEXT: struct B {
+// CHECK-NEXT:    init()
+// CHECK-NEXT:    init(y: Int32)
+// CHECK-NEXT:    var y: Int32
+// CHECK-NEXT:  }
+// CHECK-NEXT:  struct TemplateRecord {
+// CHECK-NEXT:    mutating func methodFunc()
+// CHECK-NEXT:    struct InnerRecord {
+// CHECK-NEXT:      mutating func innerMethod()
+// CHECK-NEXT:    }
+// CHECK-NEXT:    struct InnerTemplate {
+// CHECK-NEXT:      mutating func innerTemplateMethod()
+// CHECK-NEXT:    }
+// CHECK-NEXT:    mutating func returnsTemplateMethod()
+// CHECK-NEXT:  }
+// CHECK-NEXT:  static func freeFunction(_ x: Int32, _ y: Int32) -> Int32
+// CHECK-NEXT: }
+// CHECK-NEXT: typealias MyType = ns.TemplateRecord

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -19,8 +19,10 @@ if config.variant_sdk and config.variant_sdk != "":
 
     # Check if CF_OPTIONS macro has been updated to be imported into Swift in C++ mode correctly.
     cf_avail_path = os.path.join(config.variant_sdk, 'System', 'Library', 'Frameworks', 'CoreFoundation.framework', 'Versions', 'A', 'Headers', 'CFAvailability.h')
-    if os.path.exists(cf_avail_path):
-        with open(cf_avail_path, 'r') as file:
+    cf_avail_path_embedded = os.path.join(config.variant_sdk, 'System', 'Library', 'Frameworks', 'CoreFoundation.framework', 'Headers', 'CFAvailability.h')
+    if os.path.exists(cf_avail_path) or os.path.exists(cf_avail_path_embedded):
+        cf_avail_path_use = cf_avail_path if os.path.exists(cf_avail_path) else cf_avail_path_embedded
+        with open(cf_avail_path_use, 'r') as file:
             contents = file.read()
             import re
             regex = r'^#define CF_OPTIONS\(_type, _name\) _type _name; enum __CF_OPTIONS_ATTRIBUTES'


### PR DESCRIPTION
Add 'ImportSymbolicCXXDecls' experimental import mode for importing class templates syntactically but not semantically. This lets us describe C++ class templates and their members as syntactically (but not semantically!) valid Swift types.

This mode is used when index-while-building and C++ interop is enabled, to emit symbolic interfaces for imported Clang modules to disk. This is done for C++ system modules and all user modules. The symbolic interfaces are re-emitted when the clang module's PCM changes. Currently we only emit symbolic interfaces for Clang modules that are directly imported into Swift, but in the future we should also emit symbolic interfaces for transitively imported Clang modules.