### PR TITLE
[NFC] Fix change in SWIFT_CLASS_NAMED macro

### DIFF
--- a/include/swift/PrintAsClang/ClangMacros.def
+++ b/include/swift/PrintAsClang/ClangMacros.def
@@ -133,7 +133,7 @@ CLANG_MACRO_BODY("SWIFT_CLASS", \
         "SWIFT_RUNTIME_NAME(SWIFT_NAME) __attribute__((objc_subclassing_restricted)) " \
         "SWIFT_CLASS_EXTRA\n" \
     "#  define SWIFT_CLASS_NAMED(SWIFT_NAME) " \
-        "__attribute((objc_subclassing_restricted)) SWIFT_COMPILE_NAME(SWIFT_NAME) " \
+        "__attribute__((objc_subclassing_restricted)) SWIFT_COMPILE_NAME(SWIFT_NAME) " \
         "SWIFT_CLASS_EXTRA\n" \
     "# else\n" \
     "#  define SWIFT_CLASS(SWIFT_NAME) " \


### PR DESCRIPTION
apple/swift#59072 accidentally changed the SWIFT_CLASS_NAMED macro to use `__attribute` when it previously used `__attribute__` (note the trailing underscores). While both keywords have the same semantics in clang, they are technically different tokens, so clang refuses to merge macro definitions that use one instead of the other; instead it would diagnose an ambiguity when a generated header from a new compiler imported a generated header from an old compiler. Change back to the old token to avoid this problem.

Fixes rdar://104252758.