### PR TITLE
[DNM][Frontend] Split -working-directory<path>

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1247,6 +1247,16 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
     Opts.IndexStorePath = A->getValue();
 
   for (const Arg *A : Args.filtered(OPT_Xcc)) {
+    StringRef clangArg = A->getValue();
+    if (clangArg.consume_front("-working-directory")) {
+      if (!clangArg.empty() && clangArg.front() != '=') {
+        // Have an old -working-directory<path> argument. Convert it into
+        // two separate arguments as Clang no longer supports that format.
+        Opts.ExtraArgs.push_back("-working-directory");
+        Opts.ExtraArgs.push_back(clangArg.str());
+        continue;
+      }
+    }
     Opts.ExtraArgs.push_back(A->getValue());
   }
 

--- a/test/ClangImporter/working-directory.swift
+++ b/test/ClangImporter/working-directory.swift
@@ -5,6 +5,9 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -Xcc -I -Xcc %S/Inputs/custom-modules -module-cache-path %t/mcp %s
 // RUN: find %t/mcp -name "ObjCParseExtras-*.pcm" | count 1
 
+// Check that the old working directory argument is mapped to the new format
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -Xcc -I -Xcc custom-modules %s -dump-clang-diagnostics -module-cache-path %t/mcp -Xcc -working-directory%S/Inputs 2>&1 | %FileCheck %s
+
 // Check that the working directory is set to the CWD if not explicitly passed
 // RUN: cd %S/Inputs/ && %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -Xcc -I -Xcc custom-modules %s -dump-clang-diagnostics -module-cache-path %t/mcp 2>&1 | %FileCheck %s
 
@@ -15,4 +18,4 @@ import ObjCParseExtras
 print(SomeImageName)
 
 // CHECK: clang
-// CHECK: '-working-directory' '{{[^"]+}}/Inputs'
+// CHECK: '-working-directory' 'SOURCE_DIR/test/ClangImporter/Inputs'


### PR DESCRIPTION
Clang no longer supports `-working-directory<path>`. Split this argument into `-working-directory <path>` so that clients passing the old argument still work.