### PR TITLE
[Macros] Generalize `MacroExpansionExpr` and use it for both freestanding and attached macros.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -6051,16 +6051,19 @@ public:
   }
 };
 
+/// An invocation of a macro expansion, spelled with `#` for freestanding
+/// macros or `@` for attached macros.
 class MacroExpansionExpr final : public Expr {
 private:
   DeclContext *DC;
-  SourceLoc PoundLoc;
+  SourceLoc SigilLoc;
   DeclNameRef MacroName;
   DeclNameLoc MacroNameLoc;
   SourceLoc LeftAngleLoc, RightAngleLoc;
   ArrayRef<TypeRepr *> GenericArgs;
   ArgumentList *ArgList;
   Expr *Rewritten;
+  MacroRoles Roles;
 
   /// The referenced macro.
   ConcreteDeclRef macroRef;
@@ -6069,21 +6072,22 @@ public:
   enum : unsigned { InvalidDiscriminator = 0xFFFF };
 
   explicit MacroExpansionExpr(DeclContext *dc,
-                              SourceLoc poundLoc, DeclNameRef macroName,
+                              SourceLoc sigilLoc, DeclNameRef macroName,
                               DeclNameLoc macroNameLoc,
                               SourceLoc leftAngleLoc,
                               ArrayRef<TypeRepr *> genericArgs,
                               SourceLoc rightAngleLoc,
                               ArgumentList *argList,
+                              MacroRoles roles,
                               bool isImplicit = false,
                               Type ty = Type())
       : Expr(ExprKind::MacroExpansion, isImplicit, ty),
-        DC(dc), PoundLoc(poundLoc),
+        DC(dc), SigilLoc(sigilLoc),
         MacroName(macroName), MacroNameLoc(macroNameLoc),
         LeftAngleLoc(leftAngleLoc), RightAngleLoc(rightAngleLoc),
         GenericArgs(genericArgs),
         ArgList(argList),
-        Rewritten(nullptr) {
+        Rewritten(nullptr), Roles(roles) {
     Bits.MacroExpansionExpr.Discriminator = InvalidDiscriminator;
   }
 
@@ -6102,7 +6106,9 @@ public:
   ArgumentList *getArgs() const { return ArgList; }
   void setArgs(ArgumentList *newArgs) { ArgList = newArgs; }
 
-  SourceLoc getLoc() const { return PoundLoc; }
+  MacroRoles getMacroRoles() const { return Roles; }
+
+  SourceLoc getLoc() const { return SigilLoc; }
 
   ConcreteDeclRef getMacroRef() const { return macroRef; }
   void setMacroRef(ConcreteDeclRef ref) { macroRef = ref; }

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -6086,9 +6086,16 @@ public:
         MacroName(macroName), MacroNameLoc(macroNameLoc),
         LeftAngleLoc(leftAngleLoc), RightAngleLoc(rightAngleLoc),
         GenericArgs(genericArgs),
-        ArgList(argList),
         Rewritten(nullptr), Roles(roles) {
     Bits.MacroExpansionExpr.Discriminator = InvalidDiscriminator;
+
+    // Macro expansions always have an argument list. If one is not provided, create
+    // an implicit one.
+    if (argList) {
+      ArgList = argList;
+    } else {
+      ArgList = ArgumentList::createImplicit(dc->getASTContext(), {});
+    }
   }
 
   DeclNameRef getMacroName() const { return MacroName; }

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3151,6 +3151,7 @@ public:
     return pointer.getOpaqueValue();
   }
 
+  SourceLoc getSigilLoc() const;
   DeclNameRef getMacroName() const;
   DeclNameLoc getMacroNameLoc() const;
   SourceRange getGenericArgsRange() const;

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -419,9 +419,6 @@ enum class FixKind : uint8_t {
   /// Macro without leading #.
   MacroMissingPound,
 
-  /// Macro that has parameters but was not provided with any arguments.
-  MacroMissingArguments,
-
   /// Allow function type actor mismatch e.g. `@MainActor () -> Void`
   /// vs.`@OtherActor () -> Void`
   AllowGlobalActorMismatch,
@@ -3265,32 +3262,6 @@ public:
 
   static bool classof(ConstraintFix *fix) {
     return fix->getKind() == FixKind::MacroMissingPound;
-  }
-};
-
-class MacroMissingArguments final : public ConstraintFix {
-  MacroDecl *macro;
-
-  MacroMissingArguments(ConstraintSystem &cs, MacroDecl *macro,
-                        ConstraintLocator *locator)
-      : ConstraintFix(cs, FixKind::MacroMissingArguments, locator),
-        macro(macro) { }
-
-public:
-  std::string getName() const override { return "macro missing arguments"; }
-
-  bool diagnose(const Solution &solution, bool asNote = false) const override;
-
-  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
-    return diagnose(*commonFixes.front().first);
-  }
-
-  static MacroMissingArguments *
-  create(ConstraintSystem &cs, MacroDecl *macro,
-         ConstraintLocator *locator);
-
-  static bool classof(ConstraintFix *fix) {
-    return fix->getKind() == FixKind::MacroMissingArguments;
   }
 };
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2538,14 +2538,14 @@ TypeJoinExpr *TypeJoinExpr::create(ASTContext &ctx, DeclRefExpr *var,
 
 SourceRange MacroExpansionExpr::getSourceRange() const {
   SourceLoc endLoc;
-  if (ArgList)
+  if (ArgList && !ArgList->isImplicit())
     endLoc = ArgList->getEndLoc();
   else if (RightAngleLoc.isValid())
     endLoc = RightAngleLoc;
   else
     endLoc = MacroNameLoc.getEndLoc();
 
-  return SourceRange(PoundLoc, endLoc);
+  return SourceRange(SigilLoc, endLoc);
 }
 
 unsigned MacroExpansionExpr::getDiscriminator() const {

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1676,6 +1676,16 @@ DeclNameRef UnresolvedMacroReference::getMacroName() const {
   llvm_unreachable("Unhandled case");
 }
 
+SourceLoc UnresolvedMacroReference::getSigilLoc() const {
+  if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
+    return med->getPoundLoc();
+  if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
+    return mee->getLoc();
+  if (auto *attr = pointer.dyn_cast<CustomAttr *>())
+    return attr->getRangeWithAt().Start;
+  llvm_unreachable("Unhandled case");
+}
+
 DeclNameLoc UnresolvedMacroReference::getMacroNameLoc() const {
   if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
     return med->getMacroLoc();

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3368,7 +3368,8 @@ ParserResult<Expr> Parser::parseExprMacroExpansion(bool isExprBasic) {
       status,
       new (Context) MacroExpansionExpr(
           CurDeclContext, poundLoc, macroNameRef, macroNameLoc, leftAngleLoc,
-          Context.AllocateCopy(genericArgs), rightAngleLoc, argList));
+          Context.AllocateCopy(genericArgs), rightAngleLoc, argList,
+          MacroRole::Expression));
 }
 
 /// parseExprCollection - Parse a collection literal expression.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2985,7 +2985,7 @@ namespace {
           auto expansion = new (ctx) MacroExpansionExpr(
               dc, expr->getStartLoc(), DeclNameRef(macro->getName()),
               DeclNameLoc(expr->getLoc()), SourceLoc(), { }, SourceLoc(),
-              nullptr, /*isImplicit=*/true, expandedType);
+              nullptr, MacroRole::Expression, /*isImplicit=*/true, expandedType);
           expansion->setMacroRef(macroRef);
           expansion->setRewritten(newExpr);
           cs.cacheExprTypes(expansion);
@@ -5406,7 +5406,8 @@ namespace {
       ConcreteDeclRef macroRef = resolveConcreteDeclRef(macro, locator);
       E->setMacroRef(macroRef);
 
-      if (!cs.Options.contains(ConstraintSystemFlags::DisableMacroExpansions)) {
+      if (E->getMacroRoles().contains(MacroRole::Expression) &&
+          !cs.Options.contains(ConstraintSystemFlags::DisableMacroExpansions)) {
         if (auto newExpr = expandMacroExpr(dc, E, macroRef, expandedType)) {
           E->setRewritten(newExpr);
         }

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8530,35 +8530,6 @@ bool AddMissingMacroPound::diagnoseAsError() {
   return true;
 }
 
-bool AddMissingMacroArguments::diagnoseAsError() {
-  std::string argumentString;
-  {
-    llvm::raw_string_ostream out(argumentString);
-    out << "(";
-    llvm::interleave(
-        macro->parameterList->begin(), macro->parameterList->end(),
-        [&](ParamDecl *param) {
-          if (!param->getArgumentName().empty()) {
-            out << param->getArgumentName() << ": ";
-          }
-
-          out << "<#" << param->getInterfaceType().getString() << "#" << ">";
-        },
-        [&] {
-          out << ", ";
-        });
-    out << ")";
-  }
-
-  auto insertLoc = getRawAnchor().getEndLoc();
-  emitDiagnostic(diag::macro_expansion_missing_arguments, macro->getName())
-    .fixItInsertAfter(insertLoc, argumentString);
-  macro->diagnose(
-      diag::kind_declname_declared_here, macro->getDescriptiveKind(),
-      macro->getName());
-  return true;
-}
-
 bool GlobalActorFunctionMismatchFailure::diagnoseTupleElement() {
   auto *locator = getLocator();
   auto path = locator->getPath();

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -2877,29 +2877,6 @@ public:
   bool diagnoseAsError() override;
 };
 
-/// Diagnose situations where we end up type checking a reference to a macro
-/// that has parameters, but was not provided any arguments.
-///
-/// \code
-/// func print(_ value: Any)
-/// @expression macro print<Value...>(_ value: Value...)
-///
-/// func test(e: E) {
-///   #print
-/// }
-/// \endcode
-class AddMissingMacroArguments final : public FailureDiagnostic {
-  MacroDecl *macro;
-
-public:
-  AddMissingMacroArguments(const Solution &solution, MacroDecl *macro,
-                       ConstraintLocator *locator)
-    : FailureDiagnostic(solution, locator),
-      macro(macro) { }
-
-  bool diagnoseAsError() override;
-};
-
 /// Diagnose function types global actor mismatches
 /// e.g.  `@MainActor () -> Void` vs.`@OtherActor () -> Void`
 class GlobalActorFunctionMismatchFailure final : public ContextualFailure {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -2614,18 +2614,6 @@ MacroMissingPound::create(ConstraintSystem &cs, MacroDecl *macro,
   return new (cs.getAllocator()) MacroMissingPound(cs, macro, locator);
 }
 
-bool MacroMissingArguments::diagnose(const Solution &solution,
-                                     bool asNote) const {
-  AddMissingMacroArguments failure(solution, macro, getLocator());
-  return failure.diagnose(asNote);
-}
-
-MacroMissingArguments *
-MacroMissingArguments::create(ConstraintSystem &cs, MacroDecl *macro,
-                              ConstraintLocator *locator) {
-  return new (cs.getAllocator()) MacroMissingArguments(cs, macro, locator);
-}
-
 bool AllowGlobalActorMismatch::diagnose(const Solution &solution,
                                         bool asNote) const {
   GlobalActorFunctionMismatchFailure failure(solution, getFromType(),

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1211,7 +1211,8 @@ namespace {
 
         auto macroIdent = ctx.getIdentifier(kind);
         auto macros = lookupMacros(
-            macroIdent, expr->getLoc(), FunctionRefKind::Unapplied);
+            macroIdent, expr->getLoc(), FunctionRefKind::Unapplied,
+            MacroRole::Expression);
         if (!macros.empty()) {
           // Introduce an overload set for the macro reference.
           auto locator = CS.getConstraintLocator(expr);
@@ -3775,10 +3776,11 @@ namespace {
     /// Lookup all macros with the given macro name.
     SmallVector<OverloadChoice, 1>
     lookupMacros(Identifier macroName, SourceLoc loc,
-                 FunctionRefKind functionRefKind) {
+                 FunctionRefKind functionRefKind,
+                 MacroRoles roles) {
       SmallVector<OverloadChoice, 1> choices;
       auto results = TypeChecker::lookupMacros(
-          CurDC, DeclNameRef(macroName), loc, MacroRole::Expression);
+          CurDC, DeclNameRef(macroName), loc, roles);
       for (const auto &result : results) {
         OverloadChoice choice = OverloadChoice(Type(), result, functionRefKind);
         choices.push_back(choice);
@@ -3809,7 +3811,7 @@ namespace {
                                                : FunctionRefKind::Unapplied;
       auto macros = lookupMacros(
           macroIdent, expr->getMacroNameLoc().getBaseNameLoc(),
-          functionRefKind);
+          functionRefKind, expr->getMacroRoles());
       if (macros.empty()) {
         ctx.Diags.diagnose(expr->getMacroNameLoc(), diag::macro_undefined,
                            macroIdent)

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3799,16 +3799,11 @@ namespace {
       auto &ctx = CS.getASTContext();
       auto locator = CS.getConstraintLocator(expr);
 
-      // For calls, set up the argument list.
-      bool isCall = expr->getArgs() != nullptr;
-      if (isCall) {
-        CS.associateArgumentList(locator, expr->getArgs());
-      }
+      CS.associateArgumentList(locator, expr->getArgs());
 
       // Look up the macros with this name.
       auto macroIdent = expr->getMacroName().getBaseIdentifier();
-      FunctionRefKind functionRefKind = isCall ? FunctionRefKind::SingleApply
-                                               : FunctionRefKind::Unapplied;
+      FunctionRefKind functionRefKind = FunctionRefKind::SingleApply;
       auto macros = lookupMacros(
           macroIdent, expr->getMacroNameLoc().getBaseNameLoc(),
           functionRefKind, expr->getMacroRoles());
@@ -3831,11 +3826,7 @@ namespace {
           return Type();
       }
 
-      // For non-calls, the type variable is the result.
-      if (!isCall)
-        return macroRefType;
-
-      // For calls, form the applicable-function constraint. The result type
+      // Form the applicable-function constraint. The result type
       // is the result of that call.
       SmallVector<AnyFunctionType::Param, 8> params;
       getMatchingParams(expr->getArgs(), params);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13944,7 +13944,6 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyFixConstraint(
   case FixKind::NotCompileTimeConst:
   case FixKind::RenameConflictingPatternVariables:
   case FixKind::MacroMissingPound:
-  case FixKind::MacroMissingArguments:
   case FixKind::AllowGlobalActorMismatch: {
     return recordFix(fix) ? SolutionKind::Error : SolutionKind::Solved;
   }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3590,7 +3590,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     if (auto macro = dyn_cast<MacroDecl>(decl)) {
       // Macro can only be used in an expansion. If we end up here, it's
       // because we found a macro but are missing the leading '#'.
-      if (!(locator->isForMacroExpansion() || locator->getAnchor().isImplicit())) {
+      if (!locator->isForMacroExpansion()) {
         // Record a fix here
         (void)recordFix(MacroMissingPound::create(*this, macro, locator));
       }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3594,26 +3594,6 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
         // Record a fix here
         (void)recordFix(MacroMissingPound::create(*this, macro, locator));
       }
-
-      // If the macro has parameters but wasn't provided with any arguments,
-      // introduce a fix to add the arguments.
-      bool isCall;
-      switch (choice.getFunctionRefKind()) {
-      case FunctionRefKind::SingleApply:
-      case FunctionRefKind::DoubleApply:
-        isCall = true;
-        break;
-
-      case FunctionRefKind::Unapplied:
-      case FunctionRefKind::Compound:
-        // Note: macros don't have compound name references.
-        isCall = false;
-        break;
-      }
-      if (macro->parameterList && !isCall) {
-        // Record a fix here
-        (void)recordFix(MacroMissingArguments::create(*this, macro, locator));
-      }
     }
   }
 

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1258,36 +1258,34 @@ ResolveMacroRequest::evaluate(Evaluator &evaluator,
     return nullptr;
 
   // Extract macro arguments, or create an empty list.
-  auto *args = macroRef.getArgs();
-  if (!args)
-    args = ArgumentList::createImplicit(ctx, {});
+  auto *argList = macroRef.getArgs();
+  if (!argList)
+    argList = ArgumentList::createImplicit(ctx, {});
 
-  // Form an `OverloadedDeclRefExpr` with the filtered lookup result above
-  // to ensure @freestanding macros are not considered in overload resolution.
-  FunctionRefKind functionRefKind = FunctionRefKind::SingleApply;
-  SmallVector<ValueDecl *> valueDecls;
-  for (auto *macro : foundMacros)
-    valueDecls.push_back(macro);
-  Expr *callee = new (ctx) OverloadedDeclRefExpr(
-      valueDecls, macroRef.getMacroNameLoc(), functionRefKind,
-      /*implicit*/true);
-  auto genArgs = macroRef.getGenericArgs();
-  if (!genArgs.empty()) {
-    auto genArgsRange = macroRef.getGenericArgsRange();
-    callee = UnresolvedSpecializeExpr::create(
-        ctx, callee, genArgsRange.Start, genArgs, genArgsRange.End);
+  // If we already have a MacroExpansionExpr, use that. Otherwise,
+  // create one.
+  MacroExpansionExpr *macroExpansion;
+  if (auto *expr = macroRef.getExpr()) {
+    macroExpansion = expr;
+  } else {
+    SourceRange genericArgsRange = macroRef.getGenericArgsRange();
+    macroExpansion = new (ctx) MacroExpansionExpr(
+      dc, macroRef.getSigilLoc(), macroRef.getMacroName(),
+      macroRef.getMacroNameLoc(), genericArgsRange.Start,
+      macroRef.getGenericArgs(), genericArgsRange.End,
+      argList, roles);
   }
-  auto *call = CallExpr::createImplicit(ctx, callee, args);
 
-  Expr *result = call;
+  Expr *result = macroExpansion;
   TypeChecker::typeCheckExpression(result, dc);
 
-  if (auto *fn = dyn_cast<DeclRefExpr>(call->getFn()))
-    if (auto *macro = dyn_cast<MacroDecl>(fn->getDecl()))
-      return macro;
+  auto macroDeclRef = macroExpansion->getMacroRef();
+  if (auto *macroDecl = dyn_cast_or_null<MacroDecl>(macroDeclRef.getDecl()))
+    return macroDecl;
 
   // If we couldn't resolve a macro decl, the attribute is invalid.
   if (auto *attr = macroRef.getAttr())
     attr->setInvalid();
+
   return nullptr;
 }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -1257,11 +1257,6 @@ ResolveMacroRequest::evaluate(Evaluator &evaluator,
   if (foundMacros.empty())
     return nullptr;
 
-  // Extract macro arguments, or create an empty list.
-  auto *argList = macroRef.getArgs();
-  if (!argList)
-    argList = ArgumentList::createImplicit(ctx, {});
-
   // If we already have a MacroExpansionExpr, use that. Otherwise,
   // create one.
   MacroExpansionExpr *macroExpansion;
@@ -1273,7 +1268,7 @@ ResolveMacroRequest::evaluate(Evaluator &evaluator,
       dc, macroRef.getSigilLoc(), macroRef.getMacroName(),
       macroRef.getMacroNameLoc(), genericArgsRange.Start,
       macroRef.getGenericArgs(), genericArgsRange.End,
-      argList, roles);
+      macroRef.getArgs(), roles);
   }
 
   Expr *result = macroExpansion;

--- a/test/Index/index_macros.swift
+++ b/test/Index/index_macros.swift
@@ -3,8 +3,8 @@
 // REQUIRES: OS=macosx
 
 
-macro myLine: Int = MacroDefinition.LineMacro
-macro myFilename<T: ExpressibleByStringLiteral>: T = MacroDefinition.FileMacro
+macro myLine() -> Int = MacroDefinition.LineMacro
+macro myFilename<T: ExpressibleByStringLiteral>() -> T = MacroDefinition.FileMacro
 macro myStringify<T>(_: T) -> (T, String) = MacroDefinition.StringifyMacro
 
 func test(x: Int) {
@@ -13,14 +13,14 @@ func test(x: Int) {
   _ = #myStringify(x + x)
 }
 
-// CHECK: 6:7 | macro/Swift | myLine | s:14swift_ide_test6myLineSifm | Def | rel: 0
-// CHECK: 6:15 | struct/Swift | Int | s:Si | Ref | rel: 0
-// CHECK: 7:7 | macro/Swift | myFilename | s:14swift_ide_test10myFilenamexfm | Def | rel: 0
+// CHECK: 6:7 | macro/Swift | myLine() | s:14swift_ide_test6myLineSiycfm | Def | rel: 0
+// CHECK: 6:19 | struct/Swift | Int | s:Si | Ref | rel: 0
+// CHECK: 7:7 | macro/Swift | myFilename() | s:14swift_ide_test10myFilenamexycfm | Def | rel: 0
 // CHECK: 7:21 | protocol/Swift | ExpressibleByStringLiteral | s:s26ExpressibleByStringLiteralP | Ref | rel: 0
 // CHECK: 8:7 | macro/Swift | myStringify(_:) | s:14swift_ide_test11myStringifyyx_SStxcfm | Def | rel: 0
 
-// CHECK: 11:8 | macro/Swift | myLine | s:14swift_ide_test6myLineSifm | Ref,RelCont | rel: 1
-// CHECK: 12:20 | macro/Swift | myFilename | s:14swift_ide_test10myFilenamexfm | Ref,RelCont | rel: 1
+// CHECK: 11:8 | macro/Swift | myLine() | s:14swift_ide_test6myLineSiycfm | Ref,RelCont | rel: 1
+// CHECK: 12:20 | macro/Swift | myFilename() | s:14swift_ide_test10myFilenamexycfm | Ref,RelCont | rel: 1
 // CHECK: 13:8 | macro/Swift | myStringify(_:) | s:14swift_ide_test11myStringifyyx_SStxcfm | Ref,RelCont | rel: 1
 // CHECK: 13:20 | param/Swift | x | s:14swift_ide_test0C01xySi_tFACL_Sivp | Ref,Read,RelCont | rel: 1
 // CHECK: 13:22 | static-method/infix-operator/Swift | +(_:_:) | s:Si1poiyS2i_SitFZ | Ref,Call,RelCall,RelCont | rel: 1

--- a/test/Macros/attached_macros_diags.swift
+++ b/test/Macros/attached_macros_diags.swift
@@ -40,7 +40,7 @@ struct SkipNestedType {
 }
 
 struct TestMacroArgs {
-  @m1("extra arg") struct Args1 {} // expected-error{{argument passed to call that takes no arguments}}
+  @m1("extra arg") struct Args1 {} // expected-error{{argument passed to macro expansion that takes no arguments}}
 
   @m2(10) struct Args2 {}
 

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -19,9 +19,9 @@
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx
 
-@freestanding(expression) macro customFileID: String = #externalMacro(module: "MacroDefinition", type: "FileIDMacro")
+@freestanding(expression) macro customFileID() -> String = #externalMacro(module: "MacroDefinition", type: "FileIDMacro")
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
-@freestanding(expression) macro fileID<T: ExpressibleByStringLiteral>: T = #externalMacro(module: "MacroDefinition", type: "FileIDMacro")
+@freestanding(expression) macro fileID<T: ExpressibleByStringLiteral>() -> T = #externalMacro(module: "MacroDefinition", type: "FileIDMacro")
 @freestanding(expression) macro recurse(_: Bool) = #externalMacro(module: "MacroDefinition", type: "RecursiveMacro")
 
 func testFileID(a: Int, b: Int) {
@@ -116,7 +116,7 @@ func testAddBlocker(a: Int, b: Int, c: Int, oa: OnlyAdds) {
 }
 
 // Make sure we don't crash with declarations produced by expansions.
-@freestanding(expression) macro nestedDeclInExpr: () -> Void = #externalMacro(module: "MacroDefinition", type: "NestedDeclInExprMacro")
+@freestanding(expression) macro nestedDeclInExpr() -> () -> Void = #externalMacro(module: "MacroDefinition", type: "NestedDeclInExprMacro")
 
 func testNestedDeclInExpr() {
   let _: () -> Void = #nestedDeclInExpr

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -105,7 +105,7 @@ func testDiags(a: Int, b: Int) {
 
   struct Foo {
     #unaryDeclMacro("abc", blah: false) // okay
-    #unaryDeclMacro("abc", blah: false, oh: 2) // expected-error {{extra argument 'oh' in call}}
+    #unaryDeclMacro("abc", blah: false, oh: 2) // expected-error {{extra argument 'oh' in macro expansion}}
     #genericDeclMacro(2, 4.0) // okay
     #genericDeclMacro(2, "not a number") // expected-error {{macro 'genericDeclMacro' requires that 'String' conform to 'Numeric'}}
   }

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -64,7 +64,7 @@ func overloaded1(_ p: Any) { }
 // expected-warning@-1{{external macro implementation type}}
 
 @freestanding(expression) macro intIdentity(value: Int, _: Float) -> Int = #externalMacro(module: "MissingModule", type: "MissingType")
-// expected-note@-1{{macro 'intIdentity(value:_:)' declared here}}
+// expected-note@-1{{'intIdentity(value:_:)' declared here}}
 // expected-warning@-2{{external macro implementation type}}
 
 @freestanding(declaration) macro unaryDeclMacro(_ x: String)
@@ -94,7 +94,7 @@ func testDiags(a: Int, b: Int) {
   _ = stringify(a + b)
   // expected-error@-1{{expansion of macro 'stringify' requires leading '#'}}{{7-7=#}}
 
-  _ = #intIdentity // expected-error{{expansion of macro 'intIdentity(value:_:)' requires arguments}}{{19-19=(value: <#Int#>, <#Float#>)}}
+  _ = #intIdentity // expected-error{{missing arguments for parameters 'value', #2 in macro expansion}}{{19-19=(value: <#Int#>, <#Float#>)}}
 
   overloaded1(a) // okay, calls the function
   #overloaded1(a) // expected-error{{argument type 'Int' does not conform to expected type 'P'}}


### PR DESCRIPTION
* `MacroExpansionExpr` now carries a `MacroRole` that is used to filter out macro declarations during lookup.
* `MacroExpansionExpr` now always has an argument list. If an explicit argument list is not written, an implicit, empty argument list is created.

This change enforces a consistent invocation model between freestanding and attached macros, which also allows the implementation to share more type checking code.