### PR TITLE
[5.8][Concurrency] Add include of unistd.h to TaskGroup.cpp

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -39,6 +39,10 @@
 #include <mutex>
 #endif
 
+#if defined(__APPLE__)
+#include <unistd.h>
+#endif
+
 #if SWIFT_STDLIB_HAS_ASL
 #include <asl.h>
 #elif defined(__ANDROID__)

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -1083,6 +1083,15 @@ static void _enqueueCompletedTask(NaiveTaskGroupQueue<ReadyQueueItem> *readyQueu
   readyQueue->enqueue(readyItem);
 }
 
+#if SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL
+ static void _enqueueRawError(DiscardingTaskGroup *group,
+                              NaiveTaskGroupQueue<ReadyQueueItem> *readyQueue,
+                              SwiftError *error) {
+   auto readyItem = ReadyQueueItem::getRawError(group, error);
+   readyQueue->enqueue(readyItem);
+ }
+ #endif
+
 // TaskGroup is locked upon entry and exit
 void AccumulatingTaskGroup::enqueueCompletedTask(AsyncTask *completedTask, bool hadErrorResult) {
   // Retain the task while it is in the queue; it must remain alive until

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -40,6 +40,7 @@
 #endif
 
 #if defined(__APPLE__)
+#include <asl.h>
 #include <unistd.h>
 #endif
 

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -39,15 +39,14 @@
 #include <mutex>
 #endif
 
-#if defined(__APPLE__)
-#include <asl.h>
-#include <unistd.h>
-#endif
-
 #if SWIFT_STDLIB_HAS_ASL
 #include <asl.h>
 #elif defined(__ANDROID__)
 #include <android/log.h>
+#endif
+
+#if __has_include(<unistd.h>)
+#include <unistd.h>
 #endif
 
 #if defined(_WIN32)
@@ -573,10 +572,10 @@ struct TaskGroupStatus {
 #if defined(_WIN32)
     #define STDERR_FILENO 2
    _write(STDERR_FILENO, message, strlen(message));
-#else
+#elif defined(STDERR_FILENO)
     write(STDERR_FILENO, message, strlen(message));
 #endif
-#if defined(__APPLE__)
+#if defined(SWIFT_STDLIB_HAS_ASL)
     asl_log(nullptr, nullptr, ASL_LEVEL_ERR, "%s", message);
 #elif defined(__ANDROID__)
     __android_log_print(ANDROID_LOG_FATAL, "SwiftRuntime", "%s", message);


### PR DESCRIPTION
**Description:** This fixes compilation in the SWIFT_CONCURRENCY_TASK_TO_THREAD_MODEL, which was not caught in CI because CI does not verify this configuration. We fixed this on main here: https://github.com/apple/swift/pull/63265/ and should have the same fix on 5.8 to avoid a surprise in case we'd want to use this mode in 5.8.
**Risk:** Low
**Review by:** @DougGregor @drexin 
**Testing:** CI testing
**Original PR:**  https://github.com/apple/swift/pull/63265
**Radar:** rdar://104758975 rdar://104967560