### PR TITLE
[cxx-interop][docs] Update the C++ stdlib module name

### DIFF
--- a/docs/CppInteroperability/CppInteroperabilityStatus.md
+++ b/docs/CppInteroperability/CppInteroperabilityStatus.md
@@ -22,8 +22,7 @@ using V = std::vector<long>;
 ```Swift
 // main.swift
 import CxxTypes
-import std.vector
-import std.algorithm
+import CxxStdlib
 
 // We can extend C++ types in Swift.
 extension V : RandomAccessCollection {


### PR DESCRIPTION
The C++ standard library module was renamed from `std` to `CxxStdlib` in the context of Swift.