### PR TITLE
More macro fixes

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -9,6 +9,7 @@ Mangling
 ::
 
   mangled-name ::= '$s' global  // Swift stable mangling
+  mangled-name ::= '@__swiftmacro_' global // Swift mangling for filenames
   mangled-name ::= '_T0' global // Swift 4.0
   mangled-name ::= '$S' global  // Swift 4.2
 

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -232,7 +232,7 @@ class Verifier : public ASTWalker {
       ClosureDiscriminators;
   DeclContext *CanonicalTopLevelSubcontext = nullptr;
 
-  typedef DeclContext * MacroExpansionDiscriminatorKey;
+  typedef std::pair<DeclContext *, Identifier> MacroExpansionDiscriminatorKey;
   llvm::DenseMap<MacroExpansionDiscriminatorKey, SmallBitVector>
       MacroExpansionDiscriminators;
 
@@ -2378,7 +2378,10 @@ public:
 
     void verifyChecked(MacroExpansionExpr *expansion) {
       auto dc = getCanonicalDeclContext(expansion->getDeclContext());
-      MacroExpansionDiscriminatorKey key{dc};
+      MacroExpansionDiscriminatorKey key{
+        dc,
+        expansion->getMacroName().getBaseName().getIdentifier()
+      };
       auto &discriminatorSet = MacroExpansionDiscriminators[key];
       unsigned discriminator = expansion->getDiscriminator();
 
@@ -2398,7 +2401,10 @@ public:
 
     void verifyChecked(MacroExpansionDecl *expansion) {
       auto dc = getCanonicalDeclContext(expansion->getDeclContext());
-      MacroExpansionDiscriminatorKey key{dc};
+      MacroExpansionDiscriminatorKey key{
+        dc,
+        expansion->getMacro().getBaseName().getIdentifier()
+      };
       auto &discriminatorSet = MacroExpansionDiscriminators[key];
       unsigned discriminator = expansion->getDiscriminator();
 

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -199,11 +199,11 @@ func expandFreestandingMacro(
         print("not on a macro expansion node: \(token.recursiveDescription)")
         return -1
       }
+      macroName = parentExpansion.macro.text
       let decls = try declMacro.expansion(
         of: sourceManager.detach(parentExpansion, in: context),
         in: context
       )
-      macroName = parentExpansion.macro.text
       evaluatedSyntax = Syntax(CodeBlockItemListSyntax(
         decls.map { CodeBlockItemSyntax(item: .decl($0)) }))
 
@@ -213,11 +213,12 @@ func expandFreestandingMacro(
     }
   } catch {
     // Record the error
-    context.diagnose(
-      Diagnostic(
+    sourceManager.diagnose(
+      diagnostic: Diagnostic(
         node: parentSyntax,
         message: ThrownErrorDiagnostic(message: String(describing: error))
-      )
+      ),
+      messageSuffix: " (from macro '\(macroName)')"
     )
     return -1
   }
@@ -426,11 +427,12 @@ func expandAttachedMacro(
   } catch {
     // Record the error
     // FIXME: Need to decide where to diagnose the error:
-    context.diagnose(
-      Diagnostic(
+    sourceManager.diagnose(
+      diagnostic: Diagnostic(
         node: Syntax(declarationNode),
         message: ThrownErrorDiagnostic(message: String(describing: error))
-      )
+      ),
+      messageSuffix: " (from macro '\(macroName)')"
     )
 
     return 1

--- a/lib/ASTGen/Sources/ASTGen/SourceManager.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceManager.swift
@@ -76,13 +76,17 @@ extension SourceManager {
       return nil
     }
 
-    // Recursively find the root and its offset. This also must succeed.
+    // Recursively find the root and its offset.
     guard let (rootSF, parentOffset) = rootSourceFile(of: parent) else {
       return nil
     }
 
-    // Add our offset to our parent's offset, and we're done.
-    return (rootSF, parentOffset + SourceLength(utf8Length: offset))
+    // The position of our node is...
+    let finalPosition =
+      node.position                      // Our position relative to its root
+      + SourceLength(utf8Length: offset) // and that root's offset in its parent
+      + SourceLength(utf8Length: parentOffset.utf8Offset)
+    return (rootSF, finalPosition)
   }
 
   /// Produce the C++ source location for a given position based on a
@@ -106,7 +110,7 @@ extension SourceManager {
     // node.
     let position = position ?? node.position
     let offsetWithinSyntaxNode =
-       position.utf8Offset - node.root.position.utf8Offset
+       position.utf8Offset - node.position.utf8Offset
     let offsetFromSourceFile = rootPosition.utf8Offset + offsetWithinSyntaxNode
 
     // Compute the resulting address.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -502,12 +502,6 @@ importer::getNormalInvocationArguments(
       "-fmodules",
       "-Xclang", "-fmodule-feature", "-Xclang", "swift"
   });
-  // Don't enforce strict rules when inside the debugger to work around search
-  // path problems caused by a module existing in both the build/install
-  // directory and the source directory.
-  if (!importerOpts.DebuggerSupport)
-    invocationArgStrs.push_back(
-        "-Werror=non-modular-include-in-framework-module");
 
   bool EnableCXXInterop = LangOpts.EnableCXXInterop;
 

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -177,7 +177,9 @@ int swift::Demangle::getManglingPrefixLength(llvm::StringRef mangledName) {
   llvm::StringRef prefixes[] = {
     /*Swift 4*/   "_T0",
     /*Swift 4.x*/ "$S", "_$S",
-    /*Swift 5+*/  "$s", "_$s"};
+    /*Swift 5+*/  "$s", "_$s",
+    /*Swift 5+ for filenames*/ "@__swiftmacro_",
+  };
 
   // Look for any of the known prefixes
   for (auto prefix : prefixes) {

--- a/test/ClangImporter/non-modular-include.swift
+++ b/test/ClangImporter/non-modular-include.swift
@@ -1,6 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: not %target-swift-frontend -enable-objc-interop -typecheck %/s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --check-prefix=CHECK -check-prefix CHECK-objc %s
-// RUN: not %target-swift-frontend -disable-objc-interop -typecheck %/s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --check-prefix=CHECK -check-prefix CHECK-native %s
+
+// Enable -Werror=non-modular-include-in-framework-module
+// RUN: not %target-swift-frontend -enable-objc-interop -typecheck %/s -I %S/Inputs/non-modular -F %S/Inputs/non-modular -Xcc -Werror=non-modular-include-in-framework-module 2>&1 | %FileCheck --check-prefix=CHECK -check-prefix CHECK-objc %s
+// RUN: not %target-swift-frontend -disable-objc-interop -typecheck -Xcc -Werror=non-modular-include-in-framework-module %/s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --check-prefix=CHECK -check-prefix CHECK-native %s
 
 // CHECK: {{.+}}{{/|\\}}non-modular{{/|\\}}Foo.framework{{/|\\}}Headers{{/|\\}}Foo.h:1:10: error: include of non-modular header inside framework module 'Foo'
 // CHECK-objc: error: could not build Objective-C module 'Foo'
@@ -8,6 +10,7 @@
 // CHECK-NOT: error
 
 // RUN: %target-swift-frontend -debugger-support -typecheck %s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --allow-empty --check-prefix=CHECK-DEBUGGER %s
+// RUN: %target-swift-frontend -typecheck %s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --allow-empty --check-prefix=CHECK-DEBUGGER %s
 
 // CHECK-DEBUGGER-NOT: error:
 

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -452,3 +452,4 @@ $s4main4TestV1xSivpfaAA4Flag ---> runtime attribute generator of main.Test.x : S
 $s4main4TestAaBVmvpfaAA9OtherFlag ---> runtime attribute generator of main.Test : main.Test.Type for attribute = main.OtherFlag
 $s9MacroUser13testStringify1a1bySi_SitF9stringifyfMf1_ ---> freestanding macro expansion #3 of stringify in MacroUser.testStringify(a: Swift.Int, b: Swift.Int) -> ()
 $s9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfMf_6methodfMu0_ ---> unique name #2 of method in freestanding macro expansion #1 of bitwidthNumberedStructs in Foo3 #1 in MacroUser.testFreestandingMacroExpansion() -> ()
+@__swiftmacro_1a13testStringifyAA1bySi_SitF9stringifyfMf_  ---> freestanding macro expansion #1 of stringify in a.testStringify(a: Swift.Int, b: Swift.Int) -> ()

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -11,6 +11,8 @@
 // Debug info SIL testing
 // RUN: %target-swift-frontend -emit-sil -enable-experimental-feature Macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser -o - -g | %FileCheck --check-prefix CHECK-SIL %s
 
+// RUN: %target-swift-frontend -emit-sil -enable-experimental-feature Macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser -o - -g | %FileCheck --check-prefix CHECK-SIL %s
+
 // Execution testing
 // RUN: %target-build-swift -g -enable-experimental-feature Macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser
 // RUN: %target-run %t/main | %FileCheck %s

--- a/test/Macros/macro_expand_throwing.swift
+++ b/test/Macros/macro_expand_throwing.swift
@@ -7,6 +7,9 @@
 // Make sure the diagnostic doesn't crash in SILGen
 // RUN: not %target-swift-frontend -emit-sil -enable-experimental-feature Macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser -o - -g
 
+// FIXME: Swift parser is not enabled on Linux CI yet.
+// REQUIRES: OS=macosx
+
 @freestanding(expression) macro myWarning(_ message: String) = #externalMacro(module: "MacroDefinition", type: "WarningMacro")
 
 func testThrownError() {

--- a/test/Macros/macro_expand_throwing.swift
+++ b/test/Macros/macro_expand_throwing.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath -swift-version 5
+
+// Make sure the diagnostic comes through...
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser
+
+// Make sure the diagnostic doesn't crash in SILGen
+// RUN: not %target-swift-frontend -emit-sil -enable-experimental-feature Macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -module-name MacroUser -o - -g
+
+@freestanding(expression) macro myWarning(_ message: String) = #externalMacro(module: "MacroDefinition", type: "WarningMacro")
+
+func testThrownError() {
+  let name = "hello"
+  #myWarning(name) // expected-error{{#myWarning macro requires a string literal (from macro 'myWarning')}}
+
+  #myWarning("experimental features ahead") // expected-warning{{experimental features ahead}}
+}

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -271,7 +271,7 @@ static bool findMaybeMangled(llvm::StringRef input, llvm::StringRef &match) {
   } state = Start;
   const char *matchStart = nullptr;
 
-  // Find _T, $S, $s, _$S, _$s followed by a valid mangled string
+  // Find _T, $S, $s, _$S, _$s, @__swift_ followed by a valid mangled string
   while (ptr < end) {
     switch (state) {
     case Start:
@@ -285,6 +285,12 @@ static bool findMaybeMangled(llvm::StringRef input, llvm::StringRef &match) {
         } else if (ch == '$') {
           state = SeenDollar;
           matchStart = ptr - 1;
+          break;
+        } else if (ch == '@' &&
+                   llvm::StringRef(ptr, end - ptr).startswith("__swiftmacro_")){
+          matchStart = ptr - 1;
+          ptr = ptr + strlen("__swift_");
+          state = FoundPrefix;
           break;
         }
       }


### PR DESCRIPTION
* Handle demangling prefix `@__swiftmacro_` used for filenames.
* [AST Verifier] Account for names being part of macro discriminators
* [Clang importer] Remove addition of `-Werror=non-modular-include-in-framework-module`
* Fix errors produced by throwing an error out of the macro

Fixes rdar://104064443