### PR TITLE
AST: Correct inferred availability attributes on synthesized declarations

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -398,14 +398,8 @@ void Decl::forEachAttachedMacro(MacroRole role,
 }
 
 const Decl *Decl::getInnermostDeclWithAvailability() const {
-  const Decl *enclosingDecl = this;
-  // Find the innermost enclosing declaration with an @available annotation.
-  while (enclosingDecl != nullptr) {
-    if (enclosingDecl->getAttrs().hasAttribute<AvailableAttr>())
-      return enclosingDecl;
-
-    enclosingDecl = enclosingDecl->getDeclContext()->getAsDecl();
-  }
+  if (auto attrAndDecl = getSemanticAvailableRangeAttr())
+    return attrAndDecl.value().second;
 
   return nullptr;
 }

--- a/test/Concurrency/concurrency_availability.swift
+++ b/test/Concurrency/concurrency_availability.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -parse-stdlib -target x86_64-apple-macosx10.14 -typecheck -verify %s
 // RUN: %target-swift-frontend -parse-stdlib -target x86_64-apple-macosx11 -typecheck %s
+// RUN: %target-swift-frontend -parse-stdlib -target x86_64-apple-macosx12 -typecheck %s -DTARGET_MACOS_12
 // REQUIRES: OS=macosx
 
 func f() async { } // expected-error{{concurrency is only available in}}
@@ -19,3 +20,12 @@ struct S {
   actor A {
   }
 }
+
+// The synthesized unownedExecutor inside this extension on S should inherit
+// availability from S to avoid availability errors.
+#if TARGET_MACOS_12
+extension S {
+  actor A2 {
+  }
+}
+#endif


### PR DESCRIPTION
The `getInnermostDeclWithAvailability()` utility was not looking through extensions to the nominal type declaration when searching for enclosing availability.

Resolves rdar://104931478
