### PR TITLE
[5.8][stdlib] NFC: Restore doc comment for Unsafe[Mutable]BufferPointer

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -29,9 +29,6 @@
 /// instances stored in the underlying memory. However, initializing another
 /// collection with an `${Self}` instance copies the instances out of the
 /// referenced memory and into the new collection.
-// FIXME: rdar://18157434 - until this is fixed, this has to be fixed layout
-// to avoid a hang in Foundation, which has the following setup:
-// struct A { struct B { let x: UnsafeMutableBufferPointer<...> } let b: B }
 @frozen // unsafe-performance
 public struct Unsafe${Mutable}BufferPointer<Element> {
 


### PR DESCRIPTION
**Description**: Cherry picks #63288 onto `release/5.8`. Removes a `//` comment from below a `///` documentation comment, since the latter needs to be attached directly to the declaration or it won't be picked up as documentation.
**Risk**: Low
**Review by**: @stephentyrone @airspeedswift 
**Testing**: CI testing
**Original PR**: #63288 
**Radar**: rdar://104937379
