### PR TITLE
[IRGen] Lowered open_pack_element.

### DIFF
--- a/include/swift/IRGen/GenericRequirement.h
+++ b/include/swift/IRGen/GenericRequirement.h
@@ -17,9 +17,16 @@
 #include "swift/AST/Type.h"
 #include "llvm/Support/raw_ostream.h"
 
+namespace llvm {
+class Type;
+}
+
 namespace swift {
 
 class ProtocolDecl;
+namespace irgen {
+class IRGenModule;
+}
 
 /// The three kinds of entities passed in the runtime calling convention for
 /// generic code: pack shapes, type metadata, and witness tables.
@@ -85,6 +92,13 @@ public:
   static GenericRequirement forWitnessTable(CanType type, ProtocolDecl *proto) {
     assert(proto != nullptr);
     return GenericRequirement(Kind::WitnessTable, type, proto);
+  }
+
+  static llvm::Type *typeForKind(irgen::IRGenModule &IGM,
+                                 GenericRequirement::Kind kind);
+
+  llvm::Type *getType(irgen::IRGenModule &IGM) const {
+    return typeForKind(IGM, getKind());
   }
 
   void dump(llvm::raw_ostream &out) const {

--- a/include/swift/IRGen/GenericRequirement.h
+++ b/include/swift/IRGen/GenericRequirement.h
@@ -15,6 +15,7 @@
 
 #include "swift/AST/Decl.h"
 #include "swift/AST/Type.h"
+#include "swift/AST/Types.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace llvm {
@@ -41,10 +42,12 @@ class IRGenModule;
 /// generic signature.
 class GenericRequirement {
 public:
-  enum class Kind: uint8_t {
+  enum class Kind : uint8_t {
     Shape,
     Metadata,
-    WitnessTable
+    WitnessTable,
+    MetadataPack,
+    WitnessTablePack,
   };
 
 private:
@@ -54,6 +57,16 @@ private:
 
   GenericRequirement(Kind kind, CanType type, ProtocolDecl *proto)
     : kind(kind), type(type), proto(proto) {}
+
+  static bool isPack(CanType ty) {
+    if (auto gp = dyn_cast<GenericTypeParamType>(ty))
+      return gp->isParameterPack();
+    if (auto dm = dyn_cast<DependentMemberType>(ty))
+      if (auto gp =
+              dyn_cast<GenericTypeParamType>(dm->getBase()->getCanonicalType()))
+        return gp->isParameterPack();
+    return false;
+  }
 
 public:
   Kind getKind() const {
@@ -81,17 +94,27 @@ public:
     return kind == Kind::Metadata;
   }
 
+  static GenericRequirement forMetadata(CanType type, bool isPack) {
+    auto kind = isPack ? Kind::MetadataPack : Kind::Metadata;
+    return GenericRequirement(kind, type, nullptr);
+  }
+
   static GenericRequirement forMetadata(CanType type) {
-    return GenericRequirement(Kind::Metadata, type, nullptr);
+    return forMetadata(type, isPack(type));
   }
 
   bool isWitnessTable() const {
     return kind == Kind::WitnessTable;
   }
 
+  static GenericRequirement forWitnessTable(CanType type, ProtocolDecl *proto,
+                                            bool isPack) {
+    auto kind = isPack ? Kind::WitnessTablePack : Kind::WitnessTable;
+    return GenericRequirement(kind, type, proto);
+  }
+
   static GenericRequirement forWitnessTable(CanType type, ProtocolDecl *proto) {
-    assert(proto != nullptr);
-    return GenericRequirement(Kind::WitnessTable, type, proto);
+    return forWitnessTable(type, proto, isPack(type));
   }
 
   static llvm::Type *typeForKind(irgen::IRGenModule &IGM,
@@ -112,6 +135,12 @@ public:
     case Kind::WitnessTable:
       out << "witness_table: " << type << " : " << proto->getName();
       break;
+    case Kind::MetadataPack:
+      out << "metadata_pack: " << type;
+      break;
+    case Kind::WitnessTablePack:
+      out << "witness_table_pack: " << type << " : " << proto->getName();
+      break;
     }
   }
 };
@@ -123,10 +152,12 @@ template <> struct DenseMapInfo<swift::GenericRequirement> {
   using GenericRequirement = swift::GenericRequirement;
   using CanTypeInfo = llvm::DenseMapInfo<swift::CanType>;
   static GenericRequirement getEmptyKey() {
-    return GenericRequirement::forMetadata(CanTypeInfo::getEmptyKey());
+    return GenericRequirement::forMetadata(CanTypeInfo::getEmptyKey(),
+                                           /*isPack=*/false);
   }
   static GenericRequirement getTombstoneKey() {
-    return GenericRequirement::forMetadata(CanTypeInfo::getTombstoneKey());
+    return GenericRequirement::forMetadata(CanTypeInfo::getTombstoneKey(),
+                                           /*isPack=*/false);
   }
   static llvm::hash_code getHashValue(GenericRequirement req) {
     return hash_combine(CanTypeInfo::getHashValue(req.getTypeParameter()),

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3898,13 +3898,11 @@ namespace {
                                ClassDecl *forClass) {
       switch (requirement.getKind()) {
       case GenericRequirement::Kind::Shape:
-        B.addInt(IGM.SizeTy, 0);
+        B.addInt(cast<llvm::IntegerType>(requirement.getType(IGM)), 0);
         break;
       case GenericRequirement::Kind::Metadata:
-        B.addNullPointer(IGM.TypeMetadataPtrTy);
-        break;
       case GenericRequirement::Kind::WitnessTable:
-        B.addNullPointer(IGM.WitnessTablePtrTy);
+        B.addNullPointer(cast<llvm::PointerType>(requirement.getType(IGM)));
         break;
       }
     }

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -3902,6 +3902,8 @@ namespace {
         break;
       case GenericRequirement::Kind::Metadata:
       case GenericRequirement::Kind::WitnessTable:
+      case GenericRequirement::Kind::MetadataPack:
+      case GenericRequirement::Kind::WitnessTablePack:
         B.addNullPointer(cast<llvm::PointerType>(requirement.getType(IGM)));
         break;
       }

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -331,10 +331,9 @@ getForwardedPackArchetypeType(CanPackType packType) {
   return packArchetype;
 }
 
-MetadataResponse
-irgen::emitTypeMetadataPackRef(IRGenFunction &IGF,
-                               CanPackType packType,
-                               DynamicMetadataRequest request) {
+static MetadataResponse
+tryGetLocalPackTypeMetadata(IRGenFunction &IGF, CanPackType packType,
+                            DynamicMetadataRequest request) {
   if (auto result = IGF.tryGetLocalTypeMetadata(packType, request))
     return result;
 
@@ -342,6 +341,15 @@ irgen::emitTypeMetadataPackRef(IRGenFunction &IGF,
     if (auto result = IGF.tryGetLocalTypeMetadata(packArchetypeType, request))
       return result;
   }
+
+  return MetadataResponse();
+}
+
+MetadataResponse
+irgen::emitTypeMetadataPackRef(IRGenFunction &IGF, CanPackType packType,
+                               DynamicMetadataRequest request) {
+  if (auto result = tryGetLocalPackTypeMetadata(IGF, packType, request))
+    return result;
 
   auto pack = emitTypeMetadataPack(IGF, packType, request);
   auto *metadata = IGF.Builder.CreateConstArrayGEP(

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -368,6 +368,214 @@ irgen::emitTypeMetadataPackRef(IRGenFunction &IGF, CanPackType packType,
   return response;
 }
 
+llvm::Value *
+irgen::emitTypeMetadataPackElementRef(IRGenFunction &IGF, CanPackType packType,
+                                      llvm::Value *index,
+                                      DynamicMetadataRequest request) {
+  // If the pack has already been materialized, just gep into it.
+  if (auto pack = tryGetLocalPackTypeMetadata(IGF, packType, request)) {
+    auto *gep = IGF.Builder.CreateInBoundsGEP(IGF.IGM.TypeMetadataPtrTy,
+                                              pack.getMetadata(), index);
+    auto addr =
+        Address(gep, IGF.IGM.TypeMetadataPtrTy, IGF.IGM.getPointerAlignment());
+    auto *metadata = IGF.Builder.CreateLoad(addr);
+    return metadata;
+  }
+
+  // Otherwise, in general, there's no already available array of metadata
+  // which can be indexed into.
+  auto *shape = IGF.emitPackShapeExpression(packType);
+
+  // If the shape and the index are both constant, the type for which metadata
+  // will be emitted is statically available.
+  auto *constantShape = dyn_cast<llvm::ConstantInt>(shape);
+  auto *constantIndex = dyn_cast<llvm::ConstantInt>(index);
+  if (constantShape && constantIndex) {
+    assert(packType->getNumElements() == constantShape->getValue());
+    auto index = constantIndex->getValue().getZExtValue();
+    assert(packType->getNumElements() > index);
+    auto ty = packType.getElementType(index);
+    auto response = IGF.emitTypeMetadataRef(ty, request);
+    auto *metadata = response.getMetadata();
+    return metadata;
+  }
+
+  // A pack consists of types and pack expansion types.  An example:
+  //   {repeat each T, Int, repeat each T, repeat each U, String},
+  // The above type has length 5.  The type "repeat each U" is at index 3.
+  //
+  // A pack _explosion_ is notionally obtained by flat-mapping the pack by the
+  // the operation of "listing elements" in pack expansion types.
+  //
+  // The explosion of the example pack looks like
+  //   {T_0, T_1, ..., Int, T_0, T_1, ..., U_0, U_1, ..., String}
+  //    ^^^^^^^^^^^^^
+  //    the runtime components of "each T"
+  //
+  // We have an index into the explosion,
+  //
+  //  {T_0, T_1, ..., Int, T_0, T_1, ..., U_0, U_1, ... String}
+  //   ------------%index------------>
+  //
+  // and we need to obtain the element in the explosion corresponding to it.
+  //
+  //  {T_0, T_1, ..., Int, T_0, T_1, ..., T_k, ..., U_0, U_1, ... String}
+  //   ------------%index---------------> ^^^
+  //
+  // Unfortunately, the explosion has not (the first check in this function)
+  // been materialized--and doing so is likely wasteful--so we can't simply
+  // index into some array.
+  //
+  // Instead, _notionally_, we will "compute"
+  // (1) the index into the _pack_ and
+  //     {repeat each T, Int, repeat each T, repeat each U, String}
+  //      ------%outer------> ^^^^^^^^^^^^^
+  // (2) the index within the elements of the pack expansion type
+  //     {T_0, T_2, ..., T_k, ...}
+  //      ----%inner---> ^^^
+  //
+  // In fact, we won't ever materialize %outer into any register.  Instead, we
+  // can just brach to materializing the metadata once we've determined which
+  // outer element's range contains %index.
+  //
+  // As for %inner, it will only be materialized in those blocks corresponding
+  // to pack expansions.
+  //
+  // Create the following control flow:
+  //
+  // +-------+      t_0 is not             t_N _is_ an
+  // |entry: |      an expansion           expansion
+  // |...    |      +----------+           +----------+    +----------+
+  // |...    |  --> |check_0:  | -> ... -> |check_N:  | -> |trap:     |
+  // |       |      | %i == %u0|           | %i < %uN |    | llvm.trap|
+  // +-------+      +----------+           +----------+    +----------+
+  //                %outer = 0             %outer = N
+  //                    |                      |
+  //                    V                      V
+  //               +----------+           +-----------------------+
+  //               |emit_1:   |           |emit_N:                |
+  //               | %inner=0 |           | %inner = %index - %lN |
+  //               | %m_1 =   |           | %m_N =                |
+  //               +----------+           +-----------------------+
+  //                    |                      |
+  //                    V                      V
+  //               +-------------------------------------------
+  //               |exit:
+  //               | %m = phi [ %m_1, %emit_1 ],
+  //               |                 ...
+  //               |          [ %m_N, %emit_N ]
+  auto *current = IGF.Builder.GetInsertBlock();
+
+  // Terminate the block that branches to continue checking or metadata emission
+  // depending on whether the index is in the pack expansion's bounds.
+  auto emitCheckBranch = [&IGF](llvm::Value *condition,
+                                llvm::BasicBlock *inBounds,
+                                llvm::BasicBlock *outOfBounds) {
+    if (condition) {
+      IGF.Builder.CreateCondBr(condition, inBounds, outOfBounds);
+    } else {
+      assert(!inBounds &&
+             "no condition to check but a metadata materialization block!?");
+      IGF.Builder.CreateBr(outOfBounds);
+    }
+  };
+
+  // The block which emission will continue in after we finish emitting metadata
+  // for this element.
+  auto *exit = IGF.createBasicBlock("pack-index-element-exit");
+  IGF.Builder.emitBlock(exit);
+  auto *metadataPhi = IGF.Builder.CreatePHI(IGF.IGM.TypeMetadataPtrTy,
+                                            packType.getElementTypes().size());
+
+  IGF.Builder.SetInsertPoint(current);
+  // The previous checkBounds' block's comparision of %index.  Use it to emit a
+  // branch to the current block or the previous block's metadata emission
+  // block.
+  llvm::Value *previousCondition = nullptr;
+  // The previous type's materializeMetadata block.  Use it as the inBounds
+  // target when branching from the previous block.
+  llvm::BasicBlock *previousInBounds = nullptr;
+  // The lower bound of indices for the current pack expansion.  Inclusive.
+  llvm::Value *lowerBound = llvm::ConstantInt::get(IGF.IGM.SizeTy, 0);
+  for (auto elementTy : packType.getElementTypes()) {
+    // The block within which it will be checked whether %index corresponds to
+    // an element of the pack expansion elementTy.
+    auto *checkBounds = IGF.createBasicBlock("pack-index-element-bounds");
+    // Finish emitting the previous block, either entry or check_i-1.
+    //
+    // Branch from the previous bounds-check block either to this bounds-check
+    // block or to the previous metadata-emission block.
+    emitCheckBranch(previousCondition, previousInBounds, checkBounds);
+
+    // (1) Emit check_i {{
+    IGF.Builder.emitBlock(checkBounds);
+
+    // The upper bound for the current pack expansion.  Exclusive.
+    llvm::Value *upperBound = nullptr;
+    llvm::Value *condition = nullptr;
+    if (auto expansionTy = dyn_cast<PackExpansionType>(elementTy)) {
+      auto reducedShape = expansionTy.getCountType();
+      auto *length = IGF.emitPackShapeExpression(reducedShape);
+      upperBound = IGF.Builder.CreateAdd(lowerBound, length);
+      // %index < %upperBound
+      //
+      // It's not necessary to check that %index >= %lowerBound.  Either
+      // elementTy is the first element type in packType or we branched here
+      // from some series of checkBounds blocks in each of which it was
+      // determined that %index is greater than the indices of the
+      // corresponding element type.
+      condition = IGF.Builder.CreateICmpULT(index, upperBound);
+    } else {
+      upperBound = IGF.Builder.CreateAdd(
+          lowerBound, llvm::ConstantInt::get(IGF.IGM.SizeTy, 1));
+      // %index == %lowerBound
+      condition = IGF.Builder.CreateICmpEQ(lowerBound, index);
+    }
+    // }} Finished emitting check_i, except for the terminator which will be
+    //    emitted in the next iteration once the new outOfBounds block is
+    //    available.
+
+    // (2) Emit emit_i {{
+    // The block within which the metadata corresponding to %inner will be
+    // materialized.
+    auto *materializeMetadata =
+        IGF.createBasicBlock("pack-index-element-metadata");
+    IGF.Builder.emitBlock(materializeMetadata);
+
+    llvm::Value *metadata = nullptr;
+    if (auto expansionTy = dyn_cast<PackExpansionType>(elementTy)) {
+      // Actually materialize %inner.  Then use it to get the metadata from the
+      // pack expansion at that index.
+      auto *relativeIndex = IGF.Builder.CreateSub(index, lowerBound);
+      metadata = emitPackExpansionElementMetadata(IGF, expansionTy,
+                                                  relativeIndex, request);
+    } else {
+      metadata = IGF.emitTypeMetadataRef(elementTy, request).getMetadata();
+    }
+    metadataPhi->addIncoming(metadata, materializeMetadata);
+    IGF.Builder.CreateBr(exit);
+    // }} Finished emitting emit_i.
+
+    // Switch back to emitting check_i.  The next iteration will emit its
+    // terminator.
+    IGF.Builder.SetInsertPoint(checkBounds);
+
+    // Set up the values for the next iteration.
+    previousInBounds = materializeMetadata;
+    previousCondition = condition;
+    lowerBound = upperBound;
+  }
+  auto *trap = IGF.createBasicBlock("pack-index-element-trap");
+  emitCheckBranch(previousCondition, previousInBounds, trap);
+
+  IGF.Builder.emitBlock(trap);
+  IGF.emitTrap("Variadic generic index out of bounds",
+               /*EmitUnreachable=*/true);
+
+  IGF.Builder.SetInsertPoint(exit);
+  return metadataPhi;
+}
+
 void irgen::cleanupTypeMetadataPack(IRGenFunction &IGF,
                                     StackAddress pack,
                                     Optional<unsigned> elementCount) {

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -165,7 +165,7 @@ static Address emitFixedSizeMetadataPackRef(IRGenFunction &IGF,
 }
 
 static llvm::Value *emitPackExpansionElementMetadata(
-    IRGenFunction &IGF, CanPackExpansionType expansionTy, llvm::Value *phi,
+    IRGenFunction &IGF, CanPackExpansionType expansionTy, llvm::Value *index,
     DynamicMetadataRequest request) {
   auto patternTy = expansionTy.getPatternType();
 
@@ -204,7 +204,7 @@ static llvm::Value *emitPackExpansionElementMetadata(
     Address fromPtr(
       IGF.Builder.CreateInBoundsGEP(patternPackAddress.getElementType(),
                                     patternPackAddress.getAddress(),
-                                    phi),
+                                    index),
       patternPackAddress.getElementType(),
       patternPackAddress.getAlignment());
     auto metadata = IGF.Builder.CreateLoad(fromPtr);

--- a/lib/IRGen/GenPack.h
+++ b/lib/IRGen/GenPack.h
@@ -50,6 +50,11 @@ emitTypeMetadataPackRef(IRGenFunction &IGF,
                         CanPackType packType,
                         DynamicMetadataRequest request);
 
+llvm::Value *emitTypeMetadataPackElementRef(IRGenFunction &IGF,
+                                            CanPackType packType,
+                                            llvm::Value *index,
+                                            DynamicMetadataRequest request);
+
 void cleanupTypeMetadataPack(IRGenFunction &IGF,
                              StackAddress pack,
                              Optional<unsigned> elementCount);

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -3600,21 +3600,24 @@ void irgen::bindFromGenericRequirementsBuffer(IRGenFunction &IGF,
     }
 
     // Cast if necessary.
-    switch (requirements[index].getKind()) {
-    case GenericRequirement::Kind::Shape:
-      slot = IGF.Builder.CreateElementBitCast(slot, IGF.IGM.SizeTy);
-      break;
-    case GenericRequirement::Kind::Metadata:
-      slot = IGF.Builder.CreateElementBitCast(slot, IGF.IGM.TypeMetadataPtrTy);
-      break;
-    case GenericRequirement::Kind::WitnessTable:
-      slot = IGF.Builder.CreateElementBitCast(slot, IGF.IGM.WitnessTablePtrTy);
-      break;
-    }
+    slot = IGF.Builder.CreateElementBitCast(
+        slot, requirements[index].getType(IGF.IGM));
 
     llvm::Value *value = IGF.Builder.CreateLoad(slot);
     bindGenericRequirement(IGF, requirements[index], value, metadataState,
                            getInContext);
+  }
+}
+
+llvm::Type *GenericRequirement::typeForKind(IRGenModule &IGM,
+                                            GenericRequirement::Kind kind) {
+  switch (kind) {
+  case GenericRequirement::Kind::Shape:
+    return IGM.SizeTy;
+  case GenericRequirement::Kind::Metadata:
+    return IGM.TypeMetadataPtrTy;
+  case GenericRequirement::Kind::WitnessTable:
+    return IGM.WitnessTablePtrTy;
   }
 }
 
@@ -3626,17 +3629,16 @@ void irgen::bindGenericRequirement(IRGenFunction &IGF,
   // Get the corresponding context type.
   auto type = getInContext(requirement.getTypeParameter());
 
+  assert(value->getType() == requirement.getType(IGF.IGM));
   switch (requirement.getKind()) {
   case GenericRequirement::Kind::Shape: {
     assert(isa<ArchetypeType>(type));
-    assert(value->getType() == IGF.IGM.SizeTy);
     auto kind = LocalTypeDataKind::forPackShapeExpression();
     IGF.setUnscopedLocalTypeData(type, kind, value);
     break;
   }
 
   case GenericRequirement::Kind::Metadata: {
-    assert(value->getType() == IGF.IGM.TypeMetadataPtrTy);
     setTypeMetadataName(IGF.IGM, value, type);
     IGF.bindLocalTypeDataFromTypeMetadata(type, IsExact, value, metadataState);
     break;
@@ -3645,7 +3647,6 @@ void irgen::bindGenericRequirement(IRGenFunction &IGF,
   case GenericRequirement::Kind::WitnessTable: {
     auto proto = requirement.getProtocol();
     assert(isa<ArchetypeType>(type));
-    assert(value->getType() == IGF.IGM.WitnessTablePtrTy);
     setProtocolWitnessTableName(IGF.IGM, value, type, proto);
     auto kind = LocalTypeDataKind::forAbstractProtocolWitnessTable(proto);
     IGF.setUnscopedLocalTypeData(type, kind, value);
@@ -3676,17 +3677,15 @@ namespace {
       enumerateUnfulfilledRequirements([&](GenericRequirement reqt) {
         if (reqs)
           reqs->push_back(reqt);
+        out.push_back(reqt.getType(IGM));
         switch (reqt.getKind()) {
         case GenericRequirement::Kind::Shape:
-          out.push_back(IGM.SizeTy);
           ++numShapes;
           break;
         case GenericRequirement::Kind::Metadata:
-          out.push_back(IGM.TypeMetadataPtrTy);
           ++numTypeMetadataPtrs;
           break;
         case GenericRequirement::Kind::WitnessTable:
-          out.push_back(IGM.WitnessTablePtrTy);
           ++numWitnessTablePtrs;
           break;
         }

--- a/lib/IRGen/GenericArguments.h
+++ b/lib/IRGen/GenericArguments.h
@@ -59,17 +59,7 @@ struct GenericArguments {
   void collectTypes(IRGenModule &IGM,
                     const GenericTypeRequirements &requirements) {
     for (auto &requirement : requirements.getRequirements()) {
-      switch (requirement.getKind()) {
-      case GenericRequirement::Kind::Shape:
-        Types.push_back(IGM.SizeTy);
-        break;
-      case GenericRequirement::Kind::Metadata:
-        Types.push_back(IGM.TypeMetadataPtrTy);
-        break;
-      case GenericRequirement::Kind::WitnessTable:
-        Types.push_back(IGM.WitnessTablePtrTy);
-        break;
-      }
+      Types.push_back(requirement.getType(IGM));
     }
   }
 

--- a/test/IRGen/run_variadic_generics.sil
+++ b/test/IRGen/run_variadic_generics.sil
@@ -1,0 +1,137 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift-dylib(%t/%target-library-name(PrintShims)) %S/../Inputs/print-shims.swift -module-name PrintShims -emit-module -emit-module-path %t/PrintShims.swiftmodule
+// RUN: %target-codesign %t/%target-library-name(PrintShims)
+// RUN: %target-build-swift -enable-experimental-feature VariadicGenerics -g -parse-sil %s -emit-ir -I %t -L %t -lPrintShim | %FileCheck %s --check-prefix=CHECK-LL
+// RUN: %target-build-swift -enable-experimental-feature VariadicGenerics -g -parse-sil %s -module-name main -o %t/main -I %t -L %t -lPrintShims %target-rpath(%t)
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main %t/%target-library-name(PrintShims) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// Because of -enable-experimental-feature VariadicGenerics
+// REQUIRES: asserts
+// Because generic specialization does not work yet.
+// REQUIRES: swift_test_mode_optimize_none
+
+import Builtin
+import Swift
+import PrintShims
+
+sil public_external @printGenericType : $@convention(thin) <T> (@thick T.Type) -> ()
+
+struct A {}
+struct B {}
+struct C {}
+struct D {}
+struct E {}
+struct F {}
+struct G {}
+
+sil [ossa] @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %0 = integer_literal $Builtin.Word, 0
+  %1 = integer_literal $Builtin.Word, 1
+  %2 = integer_literal $Builtin.Word, 2
+  %3 = integer_literal $Builtin.Word, 3
+  %4 = integer_literal $Builtin.Word, 4
+  %5 = integer_literal $Builtin.Word, 5
+
+  %two_archetypes_from_two_params_no_singles = function_ref @two_archetypes_from_two_params_no_singles : $@convention(thin) <T_1..., T_2... where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // ---0--> ^
+  // CHECK: A
+  // U_2 -> {D, E, F, A, B, C}
+  // ---0--> ^
+  // CHECK: D
+  apply %two_archetypes_from_two_params_no_singles<Pack{A, B, C}, Pack{D, E, F}>(%0) : $@convention(thin) <T_1..., T_2... where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // ----1----> ^
+  // CHECK: B
+  // U_2 -> {D, E, F, A, B, C}
+  // ----1----> ^
+  // CHECK: E
+  apply %two_archetypes_from_two_params_no_singles<Pack{A, B, C}, Pack{D, E, F}>(%1) : $@convention(thin) <T_1..., T_2... where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // ------2-----> ^
+  // CHECK: C
+  // U_2 -> {D, E, F, A, B, C}
+  // ------2-----> ^
+  // CHECK: F
+  apply %two_archetypes_from_two_params_no_singles<Pack{A, B, C}, Pack{D, E, F}>(%2) : $@convention(thin) <T_1..., T_2... where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // -------3-------> ^
+  // CHECK: D
+  // U_2 -> {D, E, F, A, B, C}
+  // -------3-------> ^
+  // CHECK: A
+  apply %two_archetypes_from_two_params_no_singles<Pack{A, B, C}, Pack{D, E, F}>(%3) : $@convention(thin) <T_1..., T_2... where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // ---------4--------> ^
+  // CHECK: E
+  // U_2 -> {D, E, F, A, B, C}
+  // ---------4--------> ^
+  // CHECK: B
+  apply %two_archetypes_from_two_params_no_singles<Pack{A, B, C}, Pack{D, E, F}>(%4) : $@convention(thin) <T_1..., T_2... where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // -----------5---------> ^
+  // CHECK: F
+  // U_2 -> {D, E, F, A, B, C}
+  // -----------5---------> ^
+  // CHECK: C
+  apply %two_archetypes_from_two_params_no_singles<Pack{A, B, C}, Pack{D, E, F}>(%5) : $@convention(thin) <T_1..., T_2... where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> ()
+
+  %direct_access_from_parameter = function_ref @direct_access_from_parameter : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // --0---> ^
+  apply %direct_access_from_parameter<Pack{A, B, C, E, F, G}>(%0) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // ----1----> ^
+  apply %direct_access_from_parameter<Pack{A, B, C, E, F, G}>(%1) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // -----2------> ^
+  apply %direct_access_from_parameter<Pack{A, B, C, E, F, G}>(%2) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // -------3-------> ^
+  apply %direct_access_from_parameter<Pack{A, B, C, E, F, G}>(%3) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // --------4---------> ^
+  apply %direct_access_from_parameter<Pack{A, B, C, E, F, G}>(%4) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // ----------5----------> ^
+  apply %direct_access_from_parameter<Pack{A, B, C, E, F, G}>(%5) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+
+  %outb = integer_literal $Builtin.Int32, 0
+  %out = struct $Int32 (%outb : $Builtin.Int32)
+  return %out : $Int32
+}
+
+sil @two_archetypes_from_two_params_no_singles : $<T_1..., T_2... where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> () {
+entry(%intIndex : $Builtin.Word):
+  %innerIndex = dynamic_pack_index %intIndex of $Pack{repeat each T_1, repeat each T_2}
+  %token = open_pack_element %innerIndex of <U_1..., U_2... where (repeat (each U_1, each U_2)): Any> at <Pack{repeat each T_1, repeat each T_2}, Pack{repeat each T_2, repeat each T_1}>, shape $U_2, uuid "01234567-89AB-CDEF-0123-000000000000"
+  %metatype_1 = metatype $@thick (@pack_element("01234567-89AB-CDEF-0123-000000000000") U_1).Type
+  %metatype_2 = metatype $@thick (@pack_element("01234567-89AB-CDEF-0123-000000000000") U_2).Type
+  %printGenericType = function_ref @printGenericType : $@convention(thin) <T> (@thick T.Type) -> ()
+  // Print the first archetype that is bound.
+  apply %printGenericType<(@pack_element("01234567-89AB-CDEF-0123-000000000000") U_1)>(%metatype_1) : $@convention(thin) <T> (@thick T.Type) -> ()
+  // Print the second archetype that is bound.
+  apply %printGenericType<(@pack_element("01234567-89AB-CDEF-0123-000000000000") U_2)>(%metatype_2) : $@convention(thin) <T> (@thick T.Type) -> ()
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Verify that we just gep into a parameter pack when that's all that the pack consists of.
+// CHECK-LL: define {{.*}}void @direct_access_from_parameter(i64 [[INDEX:%[^,]+]], i64 {{%[^,]+}}, %swift.type** [[PACK:%[^,]+]])
+// CHECK-LL:   [[ELEMENT_ADDRESS:%[^,]+]] = getelementptr inbounds %swift.type*, %swift.type** [[PACK]], i64 [[INDEX]]
+// CHECK-LL:   [[ELEMENT:%[^,]+]] = load %swift.type*, %swift.type** [[ELEMENT_ADDRESS]]
+// CHECK-LL:   call swiftcc void @printGenericType(%swift.type* [[ELEMENT]], %swift.type* [[ELEMENT]])
+sil @direct_access_from_parameter : $<T_1...> (Builtin.Word) -> () {
+entry(%intIndex : $Builtin.Word):
+  %innerIndex = dynamic_pack_index %intIndex of $Pack{repeat each T_1}
+  %token = open_pack_element %innerIndex of <U_1...> at <Pack{repeat each T_1}>, shape $U_1, uuid "01234567-89AB-CDEF-0123-000000000001"
+  %metatype_1 = metatype $@thick (@pack_element("01234567-89AB-CDEF-0123-000000000001") U_1).Type
+  %printGenericType = function_ref @printGenericType : $@convention(thin) <T> (@thick T.Type) -> ()
+  apply %printGenericType<(@pack_element("01234567-89AB-CDEF-0123-000000000001") U_1)>(%metatype_1) : $@convention(thin) <T> (@thick T.Type) -> ()
+  %t = tuple ()
+  return %t : $()
+}

--- a/test/IRGen/variadic_generic_functions.swift
+++ b/test/IRGen/variadic_generic_functions.swift
@@ -5,11 +5,11 @@
 
 // REQUIRES: PTRSIZE=64
 
-// CHECK-LABEL: define hidden swiftcc void @"$s26variadic_generic_functions2f11tyxxQp_tlF"(%swift.opaque** noalias nocapture %0, i64 %1, %swift.type* %T)
+// CHECK-LABEL: define hidden swiftcc void @"$s26variadic_generic_functions2f11tyxxQp_tlF"(%swift.opaque** noalias nocapture %0, i64 %1, %swift.type** %T)
 func f1<T...>(t: repeat each T) {}
 
-// CHECK-LABEL: define hidden swiftcc void @"$s26variadic_generic_functions2f21t1uyxxQp_q_q_Qptr0_lF"(%swift.opaque** noalias nocapture %0, %swift.opaque** noalias nocapture %1, i64 %2, i64 %3, %swift.type* %T, %swift.type* %U)
+// CHECK-LABEL: define hidden swiftcc void @"$s26variadic_generic_functions2f21t1uyxxQp_q_q_Qptr0_lF"(%swift.opaque** noalias nocapture %0, %swift.opaque** noalias nocapture %1, i64 %2, i64 %3, %swift.type** %T, %swift.type** %U)
 func f2<T..., U...>(t: repeat each T, u: repeat each U) {}
 
-// CHECK-LABEL: define hidden swiftcc void @"$s26variadic_generic_functions2f31t1uyxxQp_q_xQptq_Rhzr0_lF"(%swift.opaque** noalias nocapture %0, %swift.opaque** noalias nocapture %1, i64 %2, %swift.type* %T, %swift.type* %U)
+// CHECK-LABEL: define hidden swiftcc void @"$s26variadic_generic_functions2f31t1uyxxQp_q_xQptq_Rhzr0_lF"(%swift.opaque** noalias nocapture %0, %swift.opaque** noalias nocapture %1, i64 %2, %swift.type** %T, %swift.type** %U)
 func f3<T..., U...>(t: repeat each T, u: repeat each U) where (repeat (each T, each U)): Any {}

--- a/test/Inputs/print-shims.swift
+++ b/test/Inputs/print-shims.swift
@@ -22,3 +22,9 @@ public func printBool(_ bool: Bool) {
 public func printAny(_ any: Any) {
   print(any)
 }
+
+@_silgen_name("printGenericType")
+public func printGenericType<T>(_ t: T.Type) {
+  print(T.self)
+}
+


### PR DESCRIPTION
Initial lowering support for the open_pack_element instruction.  While lowering,

```
open_pack_element 
  %index 
  of <..., U_i..., ...> 
  at <..., Pack_i, ....>, 
  shape $U_k, 
  uuid "01234567-89AB-CDEF-0123-000000000000"
```

binds `(@pack_element(...) U_i)` to the type `T(i, %index)` at `%index` in `Pack_i` for all `i` of the appropriate shape.

Materialize the metadata address for `T(i, %index)` depending on what's already available.  In general, compare the %index to the upper bound of each element's range: if it's in range, emit the metadata at `%innerIndex := %index - %innerLowerBound`; if it's out of range, jump to the next comparison.  From each metadata emission block, jump to a merge point where the result metadata is defined to be the phi of the metadata materialized in each predecessor.

Still to do: handle conformances.
