### PR TITLE
[Distributed][CustomRuntimeAttrs] Support custom runtime attributes on distributed actors

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -1268,8 +1268,7 @@ public:
 
     case LinkEntity::Kind::DistributedAccessor: {
       entity.Data = LINKENTITY_SET_FIELD(
-          Kind,
-          unsigned(LinkEntity::Kind::DistributedAccessorAsyncPointer));
+          Kind, unsigned(LinkEntity::Kind::DistributedAccessorAsyncPointer));
       break;
     }
 

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -880,11 +880,10 @@ SILLinkage LinkEntity::getLinkage(ForDefinition_t forDefinition) const {
   case Kind::KnownAsyncFunctionPointer:
     return SILLinkage::PublicExternal;
   case Kind::PartialApplyForwarder:
-  case Kind::DistributedAccessor:
     return SILLinkage::Private;
+  case Kind::DistributedAccessor:
   case Kind::AccessibleFunctionRecord:
-    return getSILFunction()->isDistributed() ? SILLinkage::Private
-                                             : SILLinkage::Shared;
+    return SILLinkage::Shared;
   case Kind::ExtendedExistentialTypeShape:
     return (isExtendedExistentialTypeShapeShared()
               ? SILLinkage::Shared : SILLinkage::Private);

--- a/test/Distributed/distributed_actor_accessor_thunks_32bit.swift
+++ b/test/Distributed/distributed_actor_accessor_thunks_32bit.swift
@@ -94,7 +94,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTE"
 
-// CHECK: define internal swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* nocapture %1, i8* %2, i8* %3, {{.*}}, %T27distributed_actor_accessors7MyActorC* [[ACTOR:%.*]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* nocapture %1, i8* %2, i8* %3, {{.*}}, %T27distributed_actor_accessors7MyActorC* [[ACTOR:%.*]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// Read the current offset and cast an element to `Int`
 
@@ -152,7 +152,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple2ySSSiYaKFTE"
 
-// CHECK: define internal swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple2ySSSiYaKFTETF"
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple2ySSSiYaKFTETF"
 
 // CHECK: [[COERCED_RESULT_SLOT:%.*]] = bitcast i8* {{.*}} to %TSS*
 
@@ -194,7 +194,7 @@ public distributed actor MyOtherActor {
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTE"
 
 /// !!! in `simple3` interesting bits are: argument value extraction (because string is exploded into N arguments) and call to distributed thunk
-// CHECK: define internal swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 
 // CHECK: [[TYPED_RESULT_BUFF:%.*]] = bitcast i8* [[RESULT_BUFF]] to %TSi*
@@ -257,7 +257,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTE"
 
-// CHECK: define internal swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// Let's check that the call doesn't have any arguments and returns nothing.
 
@@ -268,7 +268,7 @@ public distributed actor MyOtherActor {
 /// --> Thunk and distributed method accessor for `with_indirect_enums`
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC19with_indirect_enumsyAA9IndirectEOAF_SitYaKFTE"
-// CHECK: define internal swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC19with_indirect_enumsyAA9IndirectEOAF_SitYaKFTETF"
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC19with_indirect_enumsyAA9IndirectEOAF_SitYaKFTETF"
 
 /// First, Load both arguments from the buffer.
 
@@ -303,7 +303,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTE"
 
-// CHECK: define internal swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTETF"(%swift.context* swiftasync {{.*}}, %swift.opaque* nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTETF"(%swift.context* swiftasync {{.*}}, %swift.opaque* nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// First, let's check that all of the different argument types here are loaded correctly.
 
@@ -362,7 +362,7 @@ public distributed actor MyOtherActor {
 
 /// ---> Accessor for `genericArgs`
 
-// CHECK: define internal swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC11genericArgsyyx_Sayq_GtYaKSeRzSERzSeR_SER_r0_lFTETF"(%swift.context* swiftasync %0, %swift.opaque*  nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUF:%.*]], i8* [[GENERIC_SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR:%.*]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC11genericArgsyyx_Sayq_GtYaKSeRzSERzSeR_SER_r0_lFTETF"(%swift.context* swiftasync %0, %swift.opaque*  nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUF:%.*]], i8* [[GENERIC_SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR:%.*]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// ---> Load `T`
 
@@ -418,7 +418,7 @@ public distributed actor MyOtherActor {
 
 /// Let's check that there is argument decoding since parameter list is empty
 
-// CHECK: define internal swift{{(tail)?}}cc void @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTETF"(%swift.context* swiftasync {{.*}}, %swift.opaque* nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors12MyOtherActorC* {{.*}}, %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTETF"(%swift.context* swiftasync {{.*}}, %swift.opaque* nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i32 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors12MyOtherActorC* {{.*}}, %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 // CHECK-NEXT: entry:
 // CHECK-NEXT: {{.*}} = alloca %swift.context*
 // CHECK-NEXT: %swifterror = alloca %swift.error*

--- a/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
+++ b/test/Distributed/distributed_actor_accessor_thunks_64bit.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-swift-frontend -module-name distributed_actor_accessors -emit-irgen -disable-availability-checking -I %t 2>&1 %s | %IRGenFileCheck %s -check-prefix CHECK-%target-import-type
+// RUN: %target-swift-frontend -module-name distributed_actor_accessors -emit-irgen -disable-availability-checking -I %t 2>&1 %s | %IRGenFileCheck %s -check-prefix CHECK-%target-import-type --dump-input=always
 
 // UNSUPPORTED: back_deploy_concurrency
 // REQUIRES: concurrency
@@ -94,7 +94,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTE"
 
-// CHECK: define internal swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* nocapture %1, i8* %2, i8* %3, {{.*}}, %T27distributed_actor_accessors7MyActorC* [[ACTOR:%.*]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple1yySiYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* nocapture %1, i8* %2, i8* %3, {{.*}}, %T27distributed_actor_accessors7MyActorC* [[ACTOR:%.*]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// Read the current offset and cast an element to `Int`
 
@@ -153,7 +153,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple2ySSSiYaKFTE"
 
-// CHECK: define internal swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple2ySSSiYaKFTETF"
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple2ySSSiYaKFTETF"
 
 /// !!! - We are not going to double-check argument extraction here since it's the same as `simple1`.
 // CHECK: [[NATIVE_ARG_VAL:%.*]] = load i64, i64* %._value
@@ -198,7 +198,7 @@ public distributed actor MyOtherActor {
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTE"
 
 /// !!! in `simple3` interesting bits are: argument value extraction (because string is exploded into N arguments) and call to distributed thunk
-// CHECK: define internal swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7simple3ySiSSYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 // CHECK: [[TYPED_RESULT_BUFF:%.*]] = bitcast i8* [[RESULT_BUFF]] to %TSi*
 
@@ -241,7 +241,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTE"
 
-// CHECK: define internal swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC16single_case_enumyAA7SimpleEOAFYaKFTETF"(%swift.context* swiftasync %0, %swift.opaque* nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// Let's check that the call doesn't have any arguments and returns nothing.
 
@@ -252,7 +252,7 @@ public distributed actor MyOtherActor {
 /// --> Thunk and distributed method accessor for `with_indirect_enums`
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC19with_indirect_enumsyAA9IndirectEOAF_SitYaKFTE"
-// CHECK: define internal swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC19with_indirect_enumsyAA9IndirectEOAF_SitYaKFTETF"
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC19with_indirect_enumsyAA9IndirectEOAF_SitYaKFTETF"
 
 /// First, Load both arguments from the buffer.
 
@@ -287,7 +287,7 @@ public distributed actor MyOtherActor {
 
 // CHECK: define hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTE"
 
-// CHECK: define internal swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTETF"(%swift.context* swiftasync {{.*}}, %swift.opaque* nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC7complexyAA11LargeStructVSaySiG_AA3ObjCSSSgAFtYaKFTETF"(%swift.context* swiftasync {{.*}}, %swift.opaque* nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// First, let's check that all of the different argument types here are loaded correctly.
 
@@ -342,7 +342,7 @@ public distributed actor MyOtherActor {
 
 /// ---> Accessor for `genericArgs`
 
-// CHECK: define internal swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC11genericArgsyyx_Sayq_GtYaKSeRzSERzSeR_SER_r0_lFTETF"(%swift.context* swiftasync %0, %swift.opaque*  nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUF:%.*]], i8* [[GENERIC_SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR:%.*]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors7MyActorC11genericArgsyyx_Sayq_GtYaKSeRzSERzSeR_SER_r0_lFTETF"(%swift.context* swiftasync %0, %swift.opaque*  nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUF:%.*]], i8* [[GENERIC_SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors7MyActorC* [[ACTOR:%.*]], %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 
 /// ---> Load `T`
 
@@ -395,7 +395,7 @@ public distributed actor MyOtherActor {
 
 /// Let's check that there is argument decoding since parameter list is empty
 
-// CHECK: define internal swift{{(tail)?}}cc void @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTETF"(%swift.context* swiftasync {{.*}}, %swift.opaque* nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors12MyOtherActorC* {{.*}}, %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
+// CHECK: define linkonce_odr hidden swift{{(tail)?}}cc void @"$s27distributed_actor_accessors12MyOtherActorC5emptyyyYaKFTETF"(%swift.context* swiftasync {{.*}}, %swift.opaque* nocapture [[ARG_DECODER:%.*]], i8* [[ARG_TYPES:%.*]], i8* [[RESULT_BUFF:%.*]], i8* [[SUBS:%.*]], i8* [[WITNESS_TABLES:%.*]], i64 [[NUM_WITNESS_TABLES:%.*]], %T27distributed_actor_accessors12MyOtherActorC* {{.*}}, %swift.type* [[DECODER_TYPE:%.*]], i8** [[DECODER_PROTOCOL_WITNESS:%.*]])
 // CHECK-NEXT: entry:
 // CHECK-NEXT: {{.*}} = alloca %swift.context*
 // CHECK-NEXT: %swifterror = alloca swifterror %swift.error*

--- a/test/IRGen/runtime_attributes_on_distributed_actors.swift
+++ b/test/IRGen/runtime_attributes_on_distributed_actors.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path=%t/RAD.swiftmodule -module-name=RAD -enable-experimental-feature RuntimeDiscoverableAttrs -disable-availability-checking %S/Inputs/runtime_attrs.swift
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -I %t -swift-version 5 -enable-experimental-feature RuntimeDiscoverableAttrs -disable-availability-checking | %IRGenFileCheck %s
+
+// REQUIRES: asserts
+// REQUIRES: OS=macosx
+// REQUIRES: concurrency
+
+// CHECK: @"$s28runtime_attributes_on_actors9TestActorC15asyncExternallyyyKcvpfaAA17FlagForAsyncFuncsHF"
+// CHECK: @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyyYaKcvpfaAA17FlagForAsyncFuncsHF"
+// CHECK: @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyySiYacvpfaAA17FlagForAsyncFuncsHF"
+// CHECK: @"$s28runtime_attributes_on_actors9TestActorC11doSomething_1xySi_SaySiGztYacvpfaAA17FlagForAsyncFuncsHF"
+// CHECK: @"$s28runtime_attributes_on_actors13globalAsyncFnSaySSGyYacvpfaAA07FlagForF5FuncsHF"
+
+// CHECK: @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVHa" = internal constant
+// CHECK-SAME: i32 5
+// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors9TestActorC15asyncExternallyyyKcvpfaAA17FlagForAsyncFuncsHF"
+// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyyYaKcvpfaAA17FlagForAsyncFuncsHF"
+// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyySiYacvpfaAA17FlagForAsyncFuncsHF"
+// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors9TestActorC11doSomething_1xySi_SaySiGztYacvpfaAA17FlagForAsyncFuncsHF"
+// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors13globalAsyncFnSaySSGyYacvpfaAA07FlagForF5FuncsHF"
+
+import Distributed
+
+@runtimeMetadata
+struct FlagForAsyncFuncs {
+  init<Act>(attachedTo: (Act) async throws -> Void) {}
+  init<Act>(attachedTo: (Act, Int, [Int]) async throws -> Void) {}
+  init<Act>(attachedTo: (Act, Int) async -> Void) {}
+  init(attachedTo: () async -> [String]) {}
+}
+
+distributed actor TestActor {
+  typealias ActorSystem = LocalTestingDistributedActorSystem
+
+  // CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors9TestActorC15asyncExternallyyyKcvpfaAA17FlagForAsyncFuncs"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
+  @FlagForAsyncFuncs distributed func asyncExternally() throws {}
+
+  // CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyyYaKcvpfaAA17FlagForAsyncFuncs"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
+  @FlagForAsyncFuncs distributed func doSomething() async throws {}
+
+  // CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyySiYacvpfaAA17FlagForAsyncFuncs"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
+  @FlagForAsyncFuncs nonisolated func doSomething(_: Int) async {}
+
+  // CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors9TestActorC11doSomething_1xySi_SaySiGztYacvpfaAA17FlagForAsyncFuncs"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
+  @FlagForAsyncFuncs distributed func doSomething(_: Int, x: [Int]) async {}
+}

--- a/test/IRGen/runtime_attributes_on_distributed_actors.swift
+++ b/test/IRGen/runtime_attributes_on_distributed_actors.swift
@@ -6,19 +6,17 @@
 // REQUIRES: OS=macosx
 // REQUIRES: concurrency
 
-// CHECK: @"$s28runtime_attributes_on_actors9TestActorC15asyncExternallyyyKcvpfaAA17FlagForAsyncFuncsHF"
-// CHECK: @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyyYaKcvpfaAA17FlagForAsyncFuncsHF"
-// CHECK: @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyySiYacvpfaAA17FlagForAsyncFuncsHF"
-// CHECK: @"$s28runtime_attributes_on_actors9TestActorC11doSomething_1xySi_SaySiGztYacvpfaAA17FlagForAsyncFuncsHF"
-// CHECK: @"$s28runtime_attributes_on_actors13globalAsyncFnSaySSGyYacvpfaAA07FlagForF5FuncsHF"
+// : @"$s28runtime_attributes_on_distributed_actors9TestActorC15asyncExternallyyyKcvpfaAA17FlagForAsyncFuncsHF"
+// : @"$s28runtime_attributes_on_distributed_actors9TestActorC11doSomethingyyYaKcvpfaAA17FlagForAsyncFuncsHF"
+// : @"$s28runtime_attributes_on_distributed_actors9TestActorC11doSomethingyySiYacvpfaAA17FlagForAsyncFuncsHF"
+// : @"$s28runtime_attributes_on_distributed_actors9TestActorC11doSomething_1xySi_SaySiGztYacvpfaAA17FlagForAsyncFuncsHF"
 
-// CHECK: @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVHa" = internal constant
-// CHECK-SAME: i32 5
-// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors9TestActorC15asyncExternallyyyKcvpfaAA17FlagForAsyncFuncsHF"
-// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyyYaKcvpfaAA17FlagForAsyncFuncsHF"
-// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyySiYacvpfaAA17FlagForAsyncFuncsHF"
-// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors9TestActorC11doSomething_1xySi_SaySiGztYacvpfaAA17FlagForAsyncFuncsHF"
-// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors13globalAsyncFnSaySSGyYacvpfaAA07FlagForF5FuncsHF"
+// : @"$s40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVHa" = internal constant
+// SAME: i32 5   4
+// SAME: %swift.accessible_function* @"s40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVAA9TestActorC15asyncExternallyyyKFfaHF"
+// SAME: %swift.accessible_function* @"$s40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVAA9TestActorC11doSomethingyyYaKFfaHF"
+// SAME: %swift.accessible_function* @"$s40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVAA9TestActorC11doSomethingyySiYaFfaHF"
+// SAME: %swift.accessible_function* @"$s40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVAA9TestActorC11doSomething_1xySi_SaySiGtYaFfaHF"
 
 import Distributed
 
@@ -33,15 +31,15 @@ struct FlagForAsyncFuncs {
 distributed actor TestActor {
   typealias ActorSystem = LocalTestingDistributedActorSystem
 
-  // CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors9TestActorC15asyncExternallyyyKcvpfaAA17FlagForAsyncFuncs"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVAA9TestActorC15asyncExternallyyyKFfa"(%T40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVSg) %0)
   @FlagForAsyncFuncs distributed func asyncExternally() throws {}
 
-  // CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyyYaKcvpfaAA17FlagForAsyncFuncs"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVAA9TestActorC11doSomethingyyYaKFfa"(%T40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVSg) %0)
   @FlagForAsyncFuncs distributed func doSomething() async throws {}
 
-  // CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyySiYacvpfaAA17FlagForAsyncFuncs"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVAA9TestActorC11doSomethingyySiYaFfa"(%T40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVSg) %0)
   @FlagForAsyncFuncs nonisolated func doSomething(_: Int) async {}
 
-  // CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors9TestActorC11doSomething_1xySi_SaySiGztYacvpfaAA17FlagForAsyncFuncs"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVAA9TestActorC11doSomething_1xySi_SaySiGtYaFfa"(%T40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T40runtime_attributes_on_distributed_actors17FlagForAsyncFuncsVSg) %0)
   @FlagForAsyncFuncs distributed func doSomething(_: Int, x: [Int]) async {}
 }

--- a/test/type/runtime_discoverable_attrs.swift
+++ b/test/type/runtime_discoverable_attrs.swift
@@ -5,7 +5,6 @@
 // REQUIRES: asserts
 
 import RuntimeAttrs
-import Distributed
 
 @runtimeMetadata
 struct Flag<T> {
@@ -305,35 +304,6 @@ extension InvalidConformanceTest2 : Flagged & EnumFlagged {}
 // expected-error@-2 {{type 'InvalidConformanceTest2' does not conform to protocol 'EnumFlagged'}}
 // expected-note@-3 {{protocol 'Flagged' requires reflection metadata attribute @Flag}}
 // expected-note@-4 {{protocol 'EnumFlagged' requires reflection metadata attribute @EnumFlag}}
-
-typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
-
-distributed actor TestDistributedActor {
-  @FlagForAsyncFuncs distributed func asyncExternallyDist() throws {}
-
-  @FlagForAsyncFuncs distributed func doSomethingDist() async throws {}
-
-  @FlagForAsyncFuncs nonisolated func doSomethingNonisolated(_: Int) async {}
-
-  @FlagForAsyncFuncs distributed func doSomethingDist(_: Int, x: [Int]) async {}
-}
-
-@ActorFlag
-distributed actor TestDistributedActor2 {}
-
-@runtimeMetadata
-enum ActorFlag<A> {
-  case actor(A.Type)
-  case distributedActor(A.Type)
-}
-
-extension ActorFlag where A: Actor {
-  init(attachedTo: A.Type) { self = .actor(attachedTo) }
-}
-extension ActorFlag where A: DistributedActor {
-  init(attachedTo: A.Type) { self = .distributedActor(attachedTo) }
-}
-
 
 @Flag
 struct ValidConformance1 {}

--- a/test/type/runtime_discoverable_attrs.swift
+++ b/test/type/runtime_discoverable_attrs.swift
@@ -5,6 +5,7 @@
 // REQUIRES: asserts
 
 import RuntimeAttrs
+import Distributed
 
 @runtimeMetadata
 struct Flag<T> {
@@ -304,6 +305,35 @@ extension InvalidConformanceTest2 : Flagged & EnumFlagged {}
 // expected-error@-2 {{type 'InvalidConformanceTest2' does not conform to protocol 'EnumFlagged'}}
 // expected-note@-3 {{protocol 'Flagged' requires reflection metadata attribute @Flag}}
 // expected-note@-4 {{protocol 'EnumFlagged' requires reflection metadata attribute @EnumFlag}}
+
+typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
+
+distributed actor TestDistributedActor {
+  @FlagForAsyncFuncs distributed func asyncExternallyDist() throws {}
+
+  @FlagForAsyncFuncs distributed func doSomethingDist() async throws {}
+
+  @FlagForAsyncFuncs nonisolated func doSomethingNonisolated(_: Int) async {}
+
+  @FlagForAsyncFuncs distributed func doSomethingDist(_: Int, x: [Int]) async {}
+}
+
+@ActorFlag
+distributed actor TestDistributedActor2 {}
+
+@runtimeMetadata
+enum ActorFlag<A> {
+  case actor(A.Type)
+  case distributedActor(A.Type)
+}
+
+extension ActorFlag where A: Actor {
+  init(attachedTo: A.Type) { self = .actor(attachedTo) }
+}
+extension ActorFlag where A: DistributedActor {
+  init(attachedTo: A.Type) { self = .distributedActor(attachedTo) }
+}
+
 
 @Flag
 struct ValidConformance1 {}

--- a/test/type/runtime_discoverable_attrs_distributed.swift
+++ b/test/type/runtime_discoverable_attrs_distributed.swift
@@ -11,20 +11,18 @@ typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
 
 @runtimeMetadata
 struct FlagForAsyncFuncs {
-  init<Act>(attachedTo: (Act) async throws -> Void) {}
-  init<Act>(attachedTo: (Act, Int, inout [Int]) async throws -> Void) {}
-  init<Act>(attachedTo: (Act, Int) async -> Void) {}
+  init<Act: DistributedActor>(attachedTo: (Act) async throws -> Void) {}
+  init<Act: DistributedActor>(attachedTo: (Act, Int, [Int]) async throws -> Void) {}
+  init<Act: DistributedActor>(attachedTo: (Act, Int) async -> Void) {}
   init(attachedTo: () async -> [String]) {}
 }
 
 @ActorFlag
 distributed actor TestDistributedActor {
+  @FlagForAsyncFuncs distributed func asyncExternallyAsyncDist() {} // ok
   @FlagForAsyncFuncs distributed func asyncExternallyDist() throws {} // ok
-
   @FlagForAsyncFuncs distributed func doSomethingDist() async throws {} // ok
-
   @FlagForAsyncFuncs nonisolated func doSomethingNonisolated(_: Int) async {} // ok
-
   @FlagForAsyncFuncs distributed func doSomethingDist(_: Int, x: [Int]) async {} // ok
 }
 

--- a/test/type/runtime_discoverable_attrs_distributed.swift
+++ b/test/type/runtime_discoverable_attrs_distributed.swift
@@ -1,0 +1,39 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %S/Inputs/RuntimeAttrs.swift -o %t
+// RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature RuntimeDiscoverableAttrs -I %t
+
+// REQUIRES: asserts
+
+import RuntimeAttrs
+import Distributed
+
+typealias DefaultDistributedActorSystem = LocalTestingDistributedActorSystem
+
+@runtimeMetadata
+struct FlagForAsyncFuncs {
+  init<Act>(attachedTo: (Act) async throws -> Void) {}
+  init<Act>(attachedTo: (Act, Int, inout [Int]) async throws -> Void) {}
+  init<Act>(attachedTo: (Act, Int) async -> Void) {}
+  init(attachedTo: () async -> [String]) {}
+}
+
+@ActorFlag
+distributed actor TestDistributedActor {
+  @FlagForAsyncFuncs distributed func asyncExternallyDist() throws {} // ok
+
+  @FlagForAsyncFuncs distributed func doSomethingDist() async throws {} // ok
+
+  @FlagForAsyncFuncs nonisolated func doSomethingNonisolated(_: Int) async {} // ok
+
+  @FlagForAsyncFuncs distributed func doSomethingDist(_: Int, x: [Int]) async {} // ok
+}
+
+@runtimeMetadata
+enum ActorFlag<A> {
+  case actor(A.Type)
+  case distributedActor(A.Type)
+}
+
+extension ActorFlag where A: DistributedActor {
+  init(attachedTo: A.Type) { self = .distributedActor(attachedTo) }
+}


### PR DESCRIPTION
Making sure we can use custom runtime attributes on a `distributed actor` even if only on distributed methods.

It seems we can't do this on non distributed methods at least typecheck wise, but it fails in SIL -- would you be able to have a look @xedin? We should make sure we're able to annotate `distributed func`s using attributes, this would be tremendously useful in the near term for distributed.