### PR TITLE
[Serialization] Disable deserialization safety when testing is enabled

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3136,11 +3136,6 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     if (accessScope.isPublic())
       return true;
 
-    // Testable allows access to internal details.
-    if (value->getDeclContext()->getParentModule()->isTestingEnabled() &&
-        accessScope.isInternal())
-      return true;
-
     if (auto accessor = dyn_cast<AccessorDecl>(value))
       // Accessors are as safe as their storage.
       if (isDeserializationSafe(accessor->getStorage()))
@@ -3189,7 +3184,8 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
 #endif
 
     // Private imports allow safe access to everything.
-    if (DC->getParentModule()->arePrivateImportsEnabled())
+    if (DC->getParentModule()->arePrivateImportsEnabled() ||
+        DC->getParentModule()->isTestingEnabled())
       return;
 
     // Ignore things with no access level.

--- a/test/Serialization/Safety/unsafe-decls.swift
+++ b/test/Serialization/Safety/unsafe-decls.swift
@@ -11,7 +11,7 @@
 // RUN:   -enable-library-evolution -swift-version 5 \
 // RUN:   -Xllvm -debug-only=Serialization \
 // RUN:   -enable-testing 2>&1 \
-// RUN:   | %FileCheck --check-prefixes=SAFETY-PRIVATE,NO-SAFETY-INTERNAL-NOT %s
+// RUN:   | %FileCheck --check-prefixes=DISABLED %s
 
 /// Don't mark decls as unsafe when private import is enabled.
 // RUN: %target-swift-frontend -emit-module %s \

--- a/test/Serialization/Safety/unsafe-extensions.swift
+++ b/test/Serialization/Safety/unsafe-extensions.swift
@@ -11,7 +11,7 @@
 // RUN:   -enable-library-evolution -swift-version 5 \
 // RUN:   -Xllvm -debug-only=Serialization \
 // RUN:   -enable-testing 2>&1 \
-// RUN:   | %FileCheck --check-prefixes=SAFETY-PRIVATE,NO-SAFETY-INTERNAL %s
+// RUN:   | %FileCheck --check-prefixes=DISABLED %s
 
 /// Don't mark decls as unsafe when private import is enabled.
 // RUN: %target-swift-frontend -emit-module %s \


### PR DESCRIPTION
Resilient modules with testing enabled expose internal non-resilient internal types. These types cannot be reliably used by testable clients if they don't have all of their members known. For this reason, this disabled deserialization safety in modules when testing is enabled.

rdar://104923020