### PR TITLE
[Parser] Handle REPL raw multi-line string literal input

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -745,6 +745,11 @@ public:
   /// Check whether the current token starts with '...'.
   bool startsWithEllipsis(Token Tok);
 
+  /// Check whether the current token starts with a multi-line string delimiter.
+  bool startsWithMultilineStringDelimiter(Token Tok) {
+    return Tok.getText().ltrim('#').startswith("\"\"\"");
+  }
+
   /// Returns true if token is an identifier with the given value.
   bool isIdentifier(Token Tok, StringRef value) {
     return Tok.is(tok::identifier) && Tok.getText() == value;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1806,7 +1806,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
   // Eat an invalid token in an expression context.  Error tokens are diagnosed
   // by the lexer, so there is no reason to emit another diagnostic.
   case tok::unknown:
-    if (Tok.getText().startswith("\"\"\"")) {
+    if (startsWithMultilineStringDelimiter(Tok)) {
       // This was due to unterminated multi-line string.
       IsInputIncomplete = true;
     }

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -304,7 +304,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
 
     // Eat invalid tokens instead of allowing them to produce downstream errors.
     if (Tok.is(tok::unknown)) {
-      if (Tok.getText().startswith("\"\"\"")) {
+      if (startsWithMultilineStringDelimiter(Tok)) {
         // This was due to unterminated multi-line string.
         IsInputIncomplete = true;
       }

--- a/test/IDE/test-input-complete/Inputs/multi_line_string4.swift
+++ b/test/IDE/test-input-complete/Inputs/multi_line_string4.swift
@@ -1,0 +1,4 @@
+#"""
+raw
+multiline
+string

--- a/test/IDE/test-input-complete/Inputs/multi_line_string5.swift
+++ b/test/IDE/test-input-complete/Inputs/multi_line_string5.swift
@@ -1,0 +1,5 @@
+let s = ##"""
+"raw"
+multiline
+string
+##\(

--- a/test/IDE/test-input-complete/test_input.swift
+++ b/test/IDE/test-input-complete/test_input.swift
@@ -34,6 +34,8 @@
 // RUN: %swift-ide-test -test-input-complete -source-filename %S/Inputs/multi_line_string1.swift | %FileCheck %s -check-prefix=INCOMPLETE
 // RUN: %swift-ide-test -test-input-complete -source-filename %S/Inputs/multi_line_string2.swift | %FileCheck %s -check-prefix=INCOMPLETE
 // RUN: %swift-ide-test -test-input-complete -source-filename %S/Inputs/multi_line_string3.swift | %FileCheck %s -check-prefix=INCOMPLETE
+// RUN: %swift-ide-test -test-input-complete -source-filename %S/Inputs/multi_line_string4.swift | %FileCheck %s -check-prefix=INCOMPLETE
+// RUN: %swift-ide-test -test-input-complete -source-filename %S/Inputs/multi_line_string5.swift | %FileCheck %s -check-prefix=INCOMPLETE
 
 // INCOMPLETE: IS_INCOMPLETE
 // COMPLETE: IS_COMPLETE


### PR DESCRIPTION
Extend handling of incomplete multi-line string literals during input in REPL to also cover raw multi-line strings.

Fixes #52840 and apple/llvm-project#4628