### PR TITLE
[Macros] Miscellaneous fixes for accessor and member macros

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2657,10 +2657,10 @@ getActualMacroRole(uint8_t context) {
   CASE(Declaration)
   CASE(Accessor)
   CASE(MemberAttribute)
+  CASE(Member)
 #undef CASE
-  default:
-    return None;
   }
+  return None;
 }
 
 static Optional<swift::MacroIntroducedDeclNameKind>

--- a/test/Macros/accessor_macros.swift
+++ b/test/Macros/accessor_macros.swift
@@ -2,7 +2,7 @@
 // RUN: %target-build-swift -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
 
 // First check for no errors.
-// RUN: %target-typecheck-verify-swift -enable-experimental-feature Macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature Macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir
 
 // Check that the expansion buffer are as expected.
 // RUN: %target-swift-frontend -typecheck -enable-experimental-feature Macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir %s -dump-macro-expansions > %t/expansions-dump.txt 2>&1
@@ -53,7 +53,7 @@ struct MyStruct {
   // CHECK-DUMP: }
 
   @myPropertyWrapper
-  var birthDate: Date?
+  var birthDate: Date? = nil
   // CHECK-DUMP: macro:birthDate@myPropertyWrapper
   // CHECK-DUMP: get {
   // CHECK-DUMP:   _birthDate.wrappedValue


### PR DESCRIPTION
* When an accessor macro produces a non-observing accessor, remove the initializer
* Make sure we don't forget to serialize macro roles