### PR TITLE
[Parser] When performing parser validation, suppress warnings from SwiftParser

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/SourceFile.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceFile.swift
@@ -76,7 +76,8 @@ extension Syntax {
 @_cdecl("swift_ASTGen_emitParserDiagnostics")
 public func emitParserDiagnostics(
   diagEnginePtr: UnsafeMutablePointer<UInt8>,
-  sourceFilePtr: UnsafeMutablePointer<UInt8>
+  sourceFilePtr: UnsafeMutablePointer<UInt8>,
+  emitOnlyErrors: CInt
 ) -> CInt {
   return sourceFilePtr.withMemoryRebound(
     to: ExportedSourceFile.self, capacity: 1
@@ -91,6 +92,9 @@ public func emitParserDiagnostics(
       // we are in an active region or not.
       // FIXME: This heuristic could be improved.
       if diag.node.isInIfConfig {
+        continue
+      }
+      if emitOnlyErrors != 0, diag.diagMessage.severity != .error {
         continue
       }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -186,9 +186,9 @@ extern "C" int swift_ASTGen_roundTripCheck(void *sourceFile);
 
 /// Emit parser diagnostics for given source file.. Returns non-zero if any
 /// diagnostics were emitted.
-extern "C" int swift_ASTGen_emitParserDiagnostics(
-    void *diagEngine, void *sourceFile
-);
+extern "C" int swift_ASTGen_emitParserDiagnostics(void *diagEngine,
+                                                  void *sourceFile,
+                                                  int emitOnlyErrors);
 
 // Build AST nodes for the top-level entities in the syntax.
 extern "C" void swift_ASTGen_buildTopLevelASTNodes(void *sourceFile,
@@ -274,8 +274,12 @@ void Parser::parseTopLevelItems(SmallVectorImpl<ASTNode> &items) {
       diagnose(loc, diag::parser_round_trip_error);
     } else if (Context.LangOpts.hasFeature(Feature::ParserValidation) &&
                !Context.Diags.hadAnyError() &&
-               swift_ASTGen_emitParserDiagnostics(
-                   &Context.Diags, SF.exportedSourceFile)) {
+               swift_ASTGen_emitParserDiagnostics(&Context.Diags,
+                                                  SF.exportedSourceFile,
+                                                  /*emitOnlyErrors=*/true)) {
+      // We might have emitted warnings in the C++ parser but no errors, in
+      // which case we still have `hadAnyError() == false`. To avoid emitting
+      // the same warnings from SwiftParser, only emit errors from SwiftParser
       SourceLoc loc;
       if (auto bufferID = SF.getBufferID()) {
         loc = Context.SourceMgr.getLocForBufferStart(*bufferID);
@@ -318,7 +322,7 @@ Parser::parseSourceFileViaASTGen(SmallVectorImpl<ASTNode> &items,
          Context.LangOpts.hasFeature(Feature::ParserASTGen)) &&
         !suppressDiagnostics &&
         swift_ASTGen_emitParserDiagnostics(
-            &Context.Diags, SF.exportedSourceFile) &&
+            &Context.Diags, SF.exportedSourceFile, /*emitOnlyErrors=*/false) &&
         Context.Diags.hadAnyError() &&
         !Context.LangOpts.hasFeature(Feature::ParserASTGen)) {
       // Errors were emitted, and we're still using the C++ parser, so


### PR DESCRIPTION
We can get into a situation where the C++ parser has emitted a warning but no error and thus `hadAnyError()` is still `false`. Suppress warnings from SwiftParser to avoid emitting the same warning that we already emitted from the C++ parser from SwiftParser.