### PR TITLE
Print autodiff types in the generated SIL

### DIFF
--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -2406,7 +2406,9 @@ static bool parseSILDifferentiabilityWitnessConfigAndFunction(
   auto origFnType = resultOrigFn->getLoweredFunctionType();
   auto *parameterIndices = IndexSubset::get(
       P.Context, origFnType->getNumParameters(), rawParameterIndices);
-  auto *resultIndices = IndexSubset::get(P.Context, origFnType->getNumResults(),
+  auto *resultIndices = IndexSubset::get(P.Context,
+                                         origFnType->getNumResults() +
+                                         origFnType->getNumIndirectMutatingParameters(),
                                          rawResultIndices);
   resultConfig = AutoDiffConfig(parameterIndices, resultIndices, witnessGenSig);
   return false;

--- a/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
@@ -87,14 +87,9 @@ VarDecl *LinearMapInfo::addVarDecl(NominalTypeDecl *nominal, StringRef name,
 
 void LinearMapInfo::computeAccessLevel(NominalTypeDecl *nominal,
                                        SILLinkage originalLinkage) {
-  auto &astCtx = nominal->getASTContext();
   switch (originalLinkage) {
   case swift::SILLinkage::Public:
   case swift::SILLinkage::PublicNonABI:
-    nominal->setAccess(AccessLevel::Internal);
-    nominal->getAttrs().add(new (astCtx)
-                                UsableFromInlineAttr(/*Implicit*/ true));
-    break;
   case swift::SILLinkage::Hidden:
   case swift::SILLinkage::Shared:
     nominal->setAccess(AccessLevel::Internal);
@@ -139,6 +134,7 @@ LinearMapInfo::createBranchingTraceDecl(SILBasicBlock *originalBB,
   branchingTraceDecl->setImplicit();
   // Branching trace enums shall not be resilient.
   branchingTraceDecl->getAttrs().add(new (astCtx) FrozenAttr(/*implicit*/ true));
+  branchingTraceDecl->getAttrs().add(new (astCtx) UsableFromInlineAttr(/*Implicit*/ true));
   if (genericSig)
     branchingTraceDecl->setGenericSignature(genericSig);
   computeAccessLevel(branchingTraceDecl, original->getEffectiveSymbolLinkage());
@@ -209,6 +205,7 @@ LinearMapInfo::createLinearMapStruct(SILBasicBlock *originalBB,
   linearMapStruct->setImplicit();
   // Linear map structs shall not be resilient.
   linearMapStruct->getAttrs().add(new (astCtx) FrozenAttr(/*implicit*/ true));
+  linearMapStruct->getAttrs().add(new (astCtx) UsableFromInlineAttr(/*Implicit*/ true));
   if (genericSig)
     linearMapStruct->setGenericSignature(genericSig);
   computeAccessLevel(linearMapStruct, original->getEffectiveSymbolLinkage());

--- a/test/AutoDiff/SILOptimizer/derivative_sil.swift
+++ b/test/AutoDiff/SILOptimizer/derivative_sil.swift
@@ -26,6 +26,20 @@ func foo(_ x: Float) -> Float {
   return y
 }
 
+// CHECK-SIL-LABEL: @frozen struct _AD__foo_bb0__PB__src_0_wrt_0 {
+// CHECK-SIL:   @_hasStorage var pullback_0: (Float) -> (Float, Float) { get set }
+// CHECK-SIL: }
+
+// CHECK-SIL-LABEL: @frozen enum _AD__foo_bb0__Pred__src_0_wrt_0 {
+// CHECK-SIL-NEXT: }
+
+// CHECK-SIL-LABEL: @frozen struct _AD__fooMethod_bb0__PB__src_0_wrt_0 {
+// CHECK-SIL:   @_hasStorage var pullback_0: (Float) -> (Float, Float) { get set }
+// CHECK-SIL: }
+
+// CHECK-SIL-LABEL: @frozen enum _AD__fooMethod_bb0__Pred__src_0_wrt_0 {
+// CHECK-SIL-NEXT: }
+
 // CHECK-SIL-LABEL: sil hidden [ossa] @fooTJfSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
 // CHECK-SIL: bb0([[X:%.*]] : $Float):
 // CHECK-SIL:   [[ADD_ORIG_REF:%.*]] = function_ref @add : $@convention(method) (Float, Float, @thin Float.Type) -> Float


### PR DESCRIPTION
The solution is a bit hacky as the types are created in the synthesised module, so we essentially need to pull all top-level decls, get all imported ones and match types by name. The types produced are also not quite correct as they are non-resilient and internal. Make them `@usableFromInline` to allow being `@frozen@.

Also, fixing SIL parsing issue while there.

Fixes #63234