### PR TITLE
[Dependency Scanning] Adopt new Clang scan-deps C++ API for querying module deps

### DIFF
--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -50,7 +50,8 @@ namespace clang {
   class CompilerInvocation;
 namespace tooling {
 namespace dependencies {
-  struct FullDependenciesResult;
+  struct ModuleDeps;
+  using ModuleDepsGraph = std::vector<ModuleDeps>;
 }
 }
 }
@@ -421,7 +422,7 @@ public:
 
   void recordModuleDependencies(
       ModuleDependenciesCache &cache,
-      const clang::tooling::dependencies::FullDependenciesResult &clangDependencies);
+      const clang::tooling::dependencies::ModuleDepsGraph &clangDependencies);
 
   Optional<const ModuleDependencyInfo*> getModuleDependencies(
       StringRef moduleName, ModuleDependenciesCache &cache,


### PR DESCRIPTION
As introduced in https://reviews.llvm.org/D140176.
And cherry-picked in https://github.com/apple/llvm-project/pull/6194/files