### PR TITLE
[move-only][no-implicit-copy] Some small fixes

### DIFF
--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
@@ -554,7 +554,14 @@ void MoveOnlyChecker::check(DominanceInfo *domTree, PostOrderAnalysis *poa) {
     if (!diagnosticEmitter.emittedDiagnosticForValue(markedInst)) {
       if (markedInst->getCheckKind() == MarkMustCheckInst::CheckKind::NoCopy) {
         if (auto *cvi = dyn_cast<CopyValueInst>(markedInst->getOperand())) {
-          if (auto *arg = dyn_cast<SILFunctionArgument>(cvi->getOperand())) {
+          SingleValueInstruction *i = cvi;
+          if (auto *copyToMoveOnly =
+                  dyn_cast<CopyableToMoveOnlyWrapperValueInst>(
+                      cvi->getOperand())) {
+            i = copyToMoveOnly;
+          }
+
+          if (auto *arg = dyn_cast<SILFunctionArgument>(i->getOperand(0))) {
             if (arg->getOwnershipKind() == OwnershipKind::Guaranteed) {
               for (auto *use : markedInst->getConsumingUses()) {
                 destroys.push_back(cast<DestroyValueInst>(use->getUser()));

--- a/test/SILOptimizer/noimplicitcopy.sil
+++ b/test/SILOptimizer/noimplicitcopy.sil
@@ -1,0 +1,31 @@
+// RUN: %target-sil-opt -enable-experimental-move-only -enable-sil-verify-all -sil-move-only-object-checker %s
+
+//////////////////
+// Declarations //
+//////////////////
+
+class Klass {}
+
+sil @classUseMoveOnlyWithoutEscaping : $@convention(thin) (@guaranteed Klass) -> ()
+
+///////////
+// Tests //
+///////////
+
+// This test makes sure that we eliminate %2 after checking and that
+// sil-verify-all does not trigger.
+sil [ossa] @test_remove_early_copyvalue : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @noImplicitCopy @guaranteed $Klass):
+  %1 = copyable_to_moveonlywrapper [guaranteed] %0 : $Klass
+  %2 = copy_value %1 : $@moveOnly Klass
+  %3 = mark_must_check [no_copy] %2 : $@moveOnly Klass
+  debug_value %3 : $@moveOnly Klass, let, name "x2", argno 1
+  %5 = begin_borrow %3 : $@moveOnly Klass
+  %6 = function_ref @classUseMoveOnlyWithoutEscaping : $@convention(thin) (@guaranteed Klass) -> ()
+  %7 = moveonlywrapper_to_copyable [guaranteed] %5 : $@moveOnly Klass
+  %8 = apply %6(%7) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %5 : $@moveOnly Klass
+  destroy_value %3 : $@moveOnly Klass
+  %11 = tuple ()
+  return %11 : $()
+}

--- a/test/SILOptimizer/noimplicitcopy.swift
+++ b/test/SILOptimizer/noimplicitcopy.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-move-only -verify %s -parse-stdlib -emit-sil
+// RUN: %target-swift-frontend -sil-verify-all -enable-experimental-move-only -verify %s -parse-stdlib -emit-sil
 
 import Swift
 

--- a/test/SILOptimizer/noimplicitcopy_borrow_to_destructure_transform_diagnostics.sil
+++ b/test/SILOptimizer/noimplicitcopy_borrow_to_destructure_transform_diagnostics.sil
@@ -1,0 +1,59 @@
+// RUN: %target-sil-opt -verify -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all -sil-move-only-borrow-to-destructure %s
+
+sil_stage raw
+
+import Builtin
+
+//////////////////
+// Declarations //
+//////////////////
+
+class Klass {}
+
+struct AggStruct {
+   var lhs: Klass
+   var rhs: Klass
+}
+
+sil @classConsume : $@convention(thin) (@owned Klass) -> ()
+
+// We shouldn't emit any errors here since while AggStruct is no implicit copy,
+// its fields are not, so we can copy them.
+sil [ossa] @aggStructConsumeField : $@convention(thin) (@guaranteed AggStruct) -> () {
+bb0(%0 : @guaranteed $AggStruct):
+  debug_value %0 : $AggStruct, let, name "x", argno 1
+  %2 = copy_value %0 : $AggStruct
+  %3 = begin_borrow [lexical] %2 : $AggStruct
+  %4 = copy_value %3 : $AggStruct
+  %5 = copyable_to_moveonlywrapper [owned] %4 : $AggStruct
+  %6 = mark_must_check [no_implicit_copy] %5 : $@moveOnly AggStruct
+  debug_value %6 : $@moveOnly AggStruct, let, name "x2"
+  %8 = begin_borrow %6 : $@moveOnly AggStruct
+  %9 = struct_extract %8 : $@moveOnly AggStruct, #AggStruct.lhs
+  %10 = copy_value %9 : $@moveOnly Klass
+  %11 = function_ref @classConsume : $@convention(thin) (@owned Klass) -> ()
+  %12 = moveonlywrapper_to_copyable [owned] %10 : $@moveOnly Klass
+  %13 = apply %11(%12) : $@convention(thin) (@owned Klass) -> ()
+  end_borrow %8 : $@moveOnly AggStruct
+  br bb1
+
+bb1:
+  cond_br undef, bb2, bb3
+
+bb2:
+  %52 = begin_borrow %6 : $@moveOnly AggStruct
+  %53 = struct_extract %52 : $@moveOnly AggStruct, #AggStruct.lhs
+  %54 = copy_value %53 : $@moveOnly Klass
+  %55 = function_ref @classConsume : $@convention(thin) (@owned Klass) -> ()
+  %56 = moveonlywrapper_to_copyable [owned] %54 : $@moveOnly Klass
+  %57 = apply %55(%56) : $@convention(thin) (@owned Klass) -> ()
+  end_borrow %52 : $@moveOnly AggStruct
+  br bb1
+
+bb3:
+  destroy_value %6 : $@moveOnly AggStruct
+  end_borrow %3 : $AggStruct
+  destroy_value %2 : $AggStruct
+  %64 = tuple ()
+  return %64 : $()
+}

--- a/test/SILOptimizer/noimplicitcopy_trivial.swift
+++ b/test/SILOptimizer/noimplicitcopy_trivial.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-move-only -verify %s -parse-stdlib -emit-sil
+// RUN: %target-swift-frontend -sil-verify-all -enable-experimental-move-only -verify %s -parse-stdlib -emit-sil
 
 import Swift
 


### PR DESCRIPTION
Specifically:

1. Adding a test that I forgot to upstream.
2. Fixing a small issue where when given a no-copy noimplicitcopy, we were not eliminating the early copy_value due to pattern matching expecting a normal move-only type.
3. I enabled sił-verify-all on the no implicit copy tests since they are clean.