### PR TITLE
[Mangling] Fix Runtime Attribute mangling

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -348,7 +348,7 @@ Entities
   entity-spec ::= type 'fU' INDEX            // explicit anonymous closure expression
   entity-spec ::= type 'fu' INDEX            // implicit anonymous closure
   entity-spec ::= 'fA' INDEX                 // default argument N+1 generator
-  entity-spec ::= 'fa'                       // runtime discoverable attribute generator
+  entity-spec ::= entity 'fa'                // runtime discoverable attribute generator
   entity-spec ::= 'fi'                       // non-local variable initializer
   entity-spec ::= 'fP'                       // property wrapper backing initializer
   entity-spec ::= 'fW'                       // property wrapper init from projected value

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3864,8 +3864,13 @@ void ASTMangler::appendRuntimeAttributeGeneratorEntity(const ValueDecl *decl,
                                                        CustomAttr *attr) {
   auto *attrType = decl->getRuntimeDiscoverableAttrTypeDecl(attr);
 
-  appendEntity(decl, "vp", decl->isStatic());
+  appendContext(attrType, attrType->getAlternateModuleName());
+
+  if (auto dc = dyn_cast<DeclContext>(decl)) {
+    appendContext(dc, decl->getAlternateModuleName());
+  } else {
+    appendEntity(decl);
+  }
+
   appendOperator("fa");
-  appendContextOf(attrType);
-  appendDeclName(attrType);
 }

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -3574,7 +3574,7 @@ NodePointer Demangler::demangleFunctionEntity() {
     TypeAndMaybePrivateName,
     TypeAndIndex,
     Index,
-    ContextAndName,
+    ContextArg,
   } Args;
 
   Node::Kind Kind = Node::Kind::EmptyList;
@@ -3592,7 +3592,7 @@ NodePointer Demangler::demangleFunctionEntity() {
     case 'u': Args = TypeAndIndex; Kind = Node::Kind::ImplicitClosure; break;
     case 'A': Args = Index; Kind = Node::Kind::DefaultArgumentInitializer; break;
     case 'a':
-      Args = ContextAndName;
+      Args = ContextArg;
       Kind = Node::Kind::RuntimeAttributeGenerator;
       break;
     case 'm': return demangleEntity(Node::Kind::Macro);
@@ -3610,7 +3610,7 @@ NodePointer Demangler::demangleFunctionEntity() {
   }
 
   NodePointer NameOrIndex = nullptr, ParamType = nullptr, LabelList = nullptr,
-              Context = nullptr, Id = nullptr;
+              Context = nullptr;
   switch (Args) {
     case None:
       break;
@@ -3626,9 +3626,8 @@ NodePointer Demangler::demangleFunctionEntity() {
     case Index:
       NameOrIndex = demangleIndexAsNode();
       break;
-    case ContextAndName:
-      Context = demangleOperator();
-      Id = demangleOperator();
+    case ContextArg:
+      Context = popNode();
       break;
   }
   NodePointer Entity = createWithChild(Kind, popContext());
@@ -3647,9 +3646,8 @@ NodePointer Demangler::demangleFunctionEntity() {
       Entity = addChild(Entity, NameOrIndex);
       Entity = addChild(Entity, ParamType);
       break;
-    case ContextAndName:
+    case ContextArg:
       Entity = addChild(Entity, Context);
-      Entity = addChild(Entity, Id);
       break;
   }
   return Entity;

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -3098,11 +3098,14 @@ NodePointer NodePrinter::print(NodePointer Node, unsigned depth,
     Printer << "#_hasSymbol query for ";
     return nullptr;
   case Node::Kind::RuntimeAttributeGenerator:
-    printEntity(Node, depth, asPrefixContext, TypePrinting::NoType,
-                /*hasName*/ false,
-                "runtime attribute generator");
-    Printer << " for attribute = " << Node->getChild(1)->getText() << "."
-            << Node->getChild(2)->getText();
+    Printer << "runtime attribute generator of ";
+
+    print(Node->getChild(1), depth);
+
+    printEntity(Node, depth, asPrefixContext,
+                TypePrinting::NoType, /*hasName*/ false,
+                " for attribute");
+
     return nullptr;
   case Node::Kind::OpaqueReturnTypeIndex:
   case Node::Kind::OpaqueReturnTypeParent:

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -3616,9 +3616,9 @@ ManglingError
 Remangler::mangleRuntimeAttributeGenerator(Node *node,
                                            unsigned depth) {
   RETURN_IF_ERROR(mangleChildNode(node, 0, depth + 1));
-  Buffer << "fa";
   RETURN_IF_ERROR(mangleChildNode(node, 1, depth + 1));
-  return mangleChildNode(node, 2, depth + 1);
+  Buffer << "fa";
+  return ManglingError::Success;
 }
 
 } // anonymous namespace

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -444,12 +444,13 @@ $s7Library5KlassCTwS ---> #_hasSymbol query for Library.Klass
 $s14swift_ide_test14myColorLiteral3red5green4blue5alphaAA0E0VSf_S3ftcfm ---> swift_ide_test.myColorLiteral(red: Swift.Float, green: Swift.Float, blue: Swift.Float, alpha: Swift.Float) -> swift_ide_test.Color
 $s14swift_ide_test10myFilenamexfm ---> swift_ide_test.myFilename : A
 $s4main4FlagVHa ---> runtime discoverable attribute record for main.Flag
-$s4main4TestV11doSomethingyycvpfaAA4FlagHF ---> accessible function runtime record for runtime attribute generator of main.Test.doSomething : () -> () for attribute = main.Flag
-$s4main10globalTest1a_ySi_SStcvpfaAA4Flag ---> runtime attribute generator of main.globalTest : (a: Swift.Int, _: Swift.String) -> () for attribute = main.Flag
-$s4main4TestV11doSomethingyycvpfaAA4Flag ---> runtime attribute generator of main.Test.doSomething : () -> () for attribute = main.Flag
-$s4main4TestV11doSomethingyycvpZfaAA4Flag ---> runtime attribute generator of static main.Test.doSomething : () -> () for attribute = main.Flag
-$s4main4TestV1xSivpfaAA4Flag ---> runtime attribute generator of main.Test.x : Swift.Int for attribute = main.Flag
-$s4main4TestAaBVmvpfaAA9OtherFlag ---> runtime attribute generator of main.Test : main.Test.Type for attribute = main.OtherFlag
+$s4main4FlagVAA4TestV11doSomethingyycvpfaHF ---> accessible function runtime record for runtime attribute generator of main.Test.doSomething : () -> () for attribute of main.Flag
+$s4main4FlagVAA10globalTest1a_ySi_SStcvpfa ---> runtime attribute generator of main.globalTest : (a: Swift.Int, _: Swift.String) -> () for attribute of main.Flag
+$s4main4FlagVAA4TestV11doSomethingyycvpfa ---> runtime attribute generator of main.Test.doSomething : () -> () for attribute of main.Flag
+$s4main4FlagVAA4TestV11doSomethingyycvpZfa ---> runtime attribute generator of static main.Test.doSomething : () -> () for attribute of main.Flag
+$s4main4FlagVAA4TestV1xSivpfa ---> runtime attribute generator of main.Test.x : Swift.Int for attribute of main.Flag
+$s4main9OtherFlagVAA4TestVfa ---> runtime attribute generator of main.Test for attribute of main.OtherFlag
+$s4main4TestVAA3ABCV4hereyySiFfa ---> runtime attribute generator of main.ABC.here(Swift.Int) -> () for attribute of main.Test
 $s9MacroUser13testStringify1a1bySi_SitF9stringifyfMf1_ ---> freestanding macro expansion #3 of stringify in MacroUser.testStringify(a: Swift.Int, b: Swift.Int) -> ()
 $s9MacroUser016testFreestandingA9ExpansionyyF4Foo3L_V23bitwidthNumberedStructsfMf_6methodfMu0_ ---> unique name #2 of method in freestanding macro expansion #1 of bitwidthNumberedStructs in Foo3 #1 in MacroUser.testFreestandingMacroExpansion() -> ()
 @__swiftmacro_1a13testStringifyAA1bySi_SitF9stringifyfMf_  ---> freestanding macro expansion #1 of stringify in a.testStringify(a: Swift.Int, b: Swift.Int) -> ()

--- a/test/IRGen/runtime_attributes.swift
+++ b/test/IRGen/runtime_attributes.swift
@@ -9,140 +9,145 @@
 // - accessible function records for each generator
 // - runtime attribute records with correct number of trailing objects
 
-// CHECK: @"$s18runtime_attributes8globalFnyycvpfaAA4FlagHF"
-// CHECK: @"$s18runtime_attributes1AV2v1SSvpfaAA4FlagHF"
-// CHECK: @"$s18runtime_attributes1AV4compSivpfaAA4FlagHF"
-// CHECK: @"$s18runtime_attributes1AV5test1SiycvpZfaAA4FlagHF"
-// CHECK: @"$s18runtime_attributes1AV5test2yycvpfaAA4FlagHF"
-// CHECK: @"$s18runtime_attributes1AV1xSaySiGSgvpfaAA4FlagHF"
-// CHECK: @"$s18runtime_attributes1AV1xSaySiGSgvpfaAA13OnlyPropsTestHF"
-// CHECK: @"$s18runtime_attributes1AV5InnerC4testSaySiGSgvpfaAA4FlagHF"
-// CHECK: @"$s18runtime_attributes1AV5InnerC4testSaySiGSgvpfaAA13OnlyPropsTestHF"
-// CHECK: @"$s18runtime_attributes1AV5InnerAcDCmvpfaAA4FlagHF"
-// CHECK: @"$s18runtime_attributes1AAaBVmvpfaAA4FlagHF"
-// CHECK: @"$s18runtime_attributes1AV5InnerC1BV03extC10StaticTestyycvpZfaAA4FlagHF"
-// CHECK: @"$s18runtime_attributes1AV5InnerC1BV03extC4TestyycvpZfaAA4FlagHF"
-// CHECK: @"$s18runtime_attributes1AV5InnerC1BV6storedSivpfaAA13OnlyPropsTestHF"
-// CHECK: @"$s18runtime_attributes1AV5InnerC1BV6storedSivpfaAA4FlagHF"
-// CHECK: @"$s18runtime_attributes1AV5InnerC1BAeFVmvpfaAA4FlagHF"
-// CHECK: @"$s18runtime_attributes1AV5InnerC13extStaticTestyycvpZfaAA4FlagHF"
-// CHECK: @"$s18runtime_attributes1AV5InnerC7extTestyycvpZfaAA4FlagHF"
-// CHECK: @"$s18runtime_attributes1AV5InnerC11extComputedSivpfa3RAD6IgnoreHF"
-// CHECK: @"$s18runtime_attributes1AV5InnerC11extComputedSivpfaAA4FlagHF"
-// CHECK: @"$s18runtime_attributes1AV5InnerC11extComputedSivpfaAA13OnlyPropsTestHF"
-// CHECK: @"$s18runtime_attributes16WithExternalAttrAaBVmvpfa3RAD6IgnoreHF"
-// CHECK: @"$s18runtime_attributes4testyySicvpfa3RAD13TestAmbiguityHF"
-// CHECK: @"$s18runtime_attributes4testyySScvpfa3RAD13TestAmbiguityHF"
-// CHECK: @"$s18runtime_attributes15TestNoAmbiguityV10testStaticSiycvpZfa3RAD0cE0HF"
-// CHECK: @"$s18runtime_attributes15TestNoAmbiguityV10testStaticyycvpZfa3RAD0cE0HF"
-// CHECK: @"$s18runtime_attributes15TestNoAmbiguityV8testInstyySi_SStcvpfa3RAD0cE0HF"
-// CHECK: @"$s18runtime_attributes15TestNoAmbiguityV8testInstyySi_Sitcvpfa3RAD0cE0HF"
-// CHECK: @"$s18runtime_attributes14TestInference1AaBVmvpfa3RAD6IgnoreHF"
-// CHECK: @"$s18runtime_attributes14TestInference2AaBCmvpfa3RAD6IgnoreHF"
-// CHECK: @"$s18runtime_attributes14TestInference3AaBOmvpfa3RAD6IgnoreHF"
-// CHECK: @"$s18runtime_attributes20testWithAvailabilityyySicvpfaAA0E5TestsHF"
-// CHECK: @"$s18runtime_attributes20TypeWithAvailabilityAaBCmvpfaAA0E5TestsHF"
-// CHECK: @"$s18runtime_attributes23MembersWithAvailabilityC8staticFnyycvpZfaAA0E5TestsHF"
-// CHECK: @"$s18runtime_attributes23MembersWithAvailabilityC6instFnyycvpfaAA0E5TestsHF"
-// CHECK: @"$s18runtime_attributes23MembersWithAvailabilityC4propSivpfaAA0E5TestsHF"
-// CHECK: @"$s18runtime_attributes20attrIsHigherThanFuncyycvpfaAA13FlagWithAvailHF"
-// CHECK: @"$s18runtime_attributes9OuterTypeV5InnerV15innerInstFnTestyycvpfaAA07FlagForE7MethodsHF"
-// CHECK: @"$s18runtime_attributes9OuterTypeV5InnerV17innerStaticFnTestyycvpZfaAA07FlagForE7MethodsHF"
-// CHECK: @"$s18runtime_attributes9OuterTypeV5InnerV07mutableE6FnTest1x_ySS_SiztcvpfaAA07FlagForE7MethodsHF"
-// CHECK: @"$s18runtime_attributes9OuterTypeV15outerMutatingFnSiycvpfaAA19FlagForInnerMethodsHF"
+// CHECK: @"$s18runtime_attributes4FlagVAA8globalFnyyFfaHF"
+// CHECK: @"$s18runtime_attributes4FlagVAA1AV2v1SSvpfaHF"
+// CHECK: @"$s18runtime_attributes4FlagVAA1AV4compSivpfaHF"
+// CHECK: @"$s18runtime_attributes4FlagVAA1AV5test1SiyFZfaHF"
+// CHECK: @"$s18runtime_attributes4FlagVAA1AV5test2yyFfaHF"
+// CHECK: @"$s18runtime_attributes4FlagVAA1AV1xSaySiGSgvpfaHF"
+// CHECK: @"$s18runtime_attributes13OnlyPropsTestVAA1AV1xSaySiGSgvpfaHF"
+// CHECK: @"$s18runtime_attributes4FlagVAA1AV5InnerC4testSaySiGSgvpfaHF"
+// CHECK: @"$s18runtime_attributes13OnlyPropsTestVAA1AV5InnerC4testSaySiGSgvpfaHF"
+// CHECK: @"$s18runtime_attributes4FlagVAA1AV5InnerCfaHF"
+// CHECK: @"$s18runtime_attributes4FlagVAA1AVfaHF"
+// CHECK: @"$s18runtime_attributes4FlagVAA1AV5InnerC1BV03extD10StaticTestyyFZfaHF"
+// CHECK: @"$s18runtime_attributes4FlagVAA1AV5InnerC1BV03extD4TestyyFZfaHF"
+// CHECK: @"$s18runtime_attributes13OnlyPropsTestVAA1AV5InnerC1BV6storedSivpfaHF"
+// CHECK: @"$s18runtime_attributes4FlagVAA1AV5InnerC1BV6storedSivpfaHF"
+// CHECK: @"$s18runtime_attributes4FlagVAA1AV5InnerC1BVfaHF"
+// CHECK: @"$s18runtime_attributes4FlagVAA1AV5InnerC13extStaticTestyyFZfaHF"
+// CHECK: @"$s18runtime_attributes4FlagVAA1AV5InnerC7extTestyyFZfaHF"
+// CHECK: @"$s3RAD6IgnoreV18runtime_attributes1AV5InnerC11extComputedSivpfaHF"
+// CHECK: @"$s18runtime_attributes4FlagVAA1AV5InnerC11extComputedSivpfaHF"
+// CHECK: @"$s18runtime_attributes13OnlyPropsTestVAA1AV5InnerC11extComputedSivpfaHF"
+// CHECK: @"$s3RAD6IgnoreV18runtime_attributes16WithExternalAttrVfaHF"
+// CHECK: @"$s3RAD13TestAmbiguityV18runtime_attributes4testyySiFfaHF"
+// CHECK: @"$s3RAD13TestAmbiguityV18runtime_attributes4testyySSFfaHF"
+// CHECK: @"$s3RAD13TestAmbiguityV18runtime_attributes0b2NoC0V10testStaticSiyFZfaHF"
+// CHECK: @"$s3RAD13TestAmbiguityV18runtime_attributes0b2NoC0V10testStaticyyFZfaHF"
+// CHECK: @"$s3RAD13TestAmbiguityV18runtime_attributes0b2NoC0V8testInstyySi_SStFfaHF"
+// CHECK: @"$s3RAD13TestAmbiguityV18runtime_attributes0b2NoC0V8testInstyySi_SitFfaHF"
+// CHECK: @"$s3RAD6IgnoreV18runtime_attributes14TestInference1VfaHF"
+// CHECK: @"$s3RAD6IgnoreV18runtime_attributes14TestInference2CfaHF"
+// CHECK: @"$s3RAD6IgnoreV18runtime_attributes14TestInference3OfaHF"
+// CHECK: @"$s18runtime_attributes17AvailabilityTestsVAA08testWithC0yySiFfaHF"
+// CHECK: @"$s18runtime_attributes17AvailabilityTestsVAA08TypeWithC0CfaHF"
+// CHECK: @"$s18runtime_attributes17AvailabilityTestsVAA011MembersWithC0C8staticFnyyFZfaHF"
+// CHECK: @"$s18runtime_attributes17AvailabilityTestsVAA011MembersWithC0C6instFnyyFfaHF"
+// CHECK: @"$s18runtime_attributes17AvailabilityTestsVAA011MembersWithC0C4propSivpfaHF"
+// CHECK: @"$s18runtime_attributes13FlagWithAvailVAA20attrIsHigherThanFuncyyFfaHF"
+// CHECK: @"$s18runtime_attributes19FlagForInnerMethodsVAA9OuterTypeV0E0V15innerInstFnTestyyFfaHF"
+// CHECK: @"$s18runtime_attributes19FlagForInnerMethodsVAA9OuterTypeV0E0V17innerStaticFnTestyyFZfaHF"
+// CHECK: @"$s18runtime_attributes19FlagForInnerMethodsVAA9OuterTypeV0E0V07mutableE6FnTest1x_ySS_SiztFfaHF"
+// CHECK: @"$s18runtime_attributes19FlagForInnerMethodsVAA9OuterTypeV15outerMutatingFnSiyFfaHF"
+// CHECK: @"$s3RAD8EnumFlagO18runtime_attributes06globalB4TestSi_SaySSGtSgyFfaHF"
+// CHECK: @"$s3RAD8EnumFlagO18runtime_attributes0B8TypeTestV1xSivpfaHF"
+// CHECK: @"$s3RAD8EnumFlagO18runtime_attributes0B8TypeTestV8testInstyyFfaHF"
+// CHECK: @"$s3RAD8EnumFlagO18runtime_attributes0B8TypeTestV10testStaticSiyFZfaHF"
+// CHECK: @"$s3RAD8EnumFlagO18runtime_attributes0B8TypeTestVfaHF"
 
 // CHECK: @"$s18runtime_attributes4FlagVHa" = internal constant
 // CHECK-SAME: i32 0
 // CHECK-SAME: @"$s18runtime_attributes4FlagVMn"
 // CHECK-SAME: i32 16
-// CHECK-SAME: @"$s18runtime_attributes8globalFnyycvpfaAA4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV2v1SSvpfaAA4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV4compSivpfaAA4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV5test1SiycvpZfaAA4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV5test2yycvpfaAA4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV1xSaySiGSgvpfaAA4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV5InnerC4testSaySiGSgvpfaAA4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV5InnerAcDCmvpfaAA4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes1AAaBVmvpfaAA4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV5InnerC1BV03extC10StaticTestyycvpZfaAA4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV5InnerC1BV03extC4TestyycvpZfaAA4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV5InnerC1BV6storedSivpfaAA4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV5InnerC1BAeFVmvpfaAA4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV5InnerC13extStaticTestyycvpZfaAA4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV5InnerC7extTestyycvpZfaAA4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV5InnerC11extComputedSivpfaAA4FlagHF"
+// CHECK-SAME: @"$s18runtime_attributes4FlagVAA8globalFnyyFfaHF"
+// CHECK-SAME: @"$s18runtime_attributes4FlagVAA1AV2v1SSvpfaHF"
+// CHECK-SAME: @"$s18runtime_attributes4FlagVAA1AV4compSivpfaHF"
+// CHECK-SAME: @"$s18runtime_attributes4FlagVAA1AV5test1SiyFZfaHF"
+// CHECK-SAME: @"$s18runtime_attributes4FlagVAA1AV5test2yyFfaHF"
+// CHECK-SAME: @"$s18runtime_attributes4FlagVAA1AV1xSaySiGSgvpfaHF"
+// CHECK-SAME: @"$s18runtime_attributes4FlagVAA1AV5InnerC4testSaySiGSgvpfaHF"
+// CHECK-SAME: @"$s18runtime_attributes4FlagVAA1AV5InnerCfaHF"
+// CHECK-SAME: @"$s18runtime_attributes4FlagVAA1AVfaHF"
+// CHECK-SAME: @"$s18runtime_attributes4FlagVAA1AV5InnerC1BV03extD10StaticTestyyFZfaHF"
+// CHECK-SAME: @"$s18runtime_attributes4FlagVAA1AV5InnerC1BV03extD4TestyyFZfaHF"
+// CHECK-SAME: @"$s18runtime_attributes4FlagVAA1AV5InnerC1BV6storedSivpfaHF"
+// CHECK-SAME: @"$s18runtime_attributes4FlagVAA1AV5InnerC1BVfaHF"
+// CHECK-SAME: @"$s18runtime_attributes4FlagVAA1AV5InnerC13extStaticTestyyFZfaHF"
+// CHECK-SAME: @"$s18runtime_attributes4FlagVAA1AV5InnerC7extTestyyFZfaHF"
+// CHECK-SAME: @"$s18runtime_attributes4FlagVAA1AV5InnerC11extComputedSivpfaHF"
 // CHECK-SAME: section "__TEXT, __swift5_rattrs, regular"
 
 // CHECK: @"$s18runtime_attributes13OnlyPropsTestVHa" = internal constant
 // CHECK-SAME: i32 0
 // CHECK-SAME: @"$s18runtime_attributes13OnlyPropsTestVMn"
 // CHECK-SAME: i32 4
-// CHECK-SAME: @"$s18runtime_attributes1AV1xSaySiGSgvpfaAA13OnlyPropsTestHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV5InnerC4testSaySiGSgvpfaAA13OnlyPropsTestHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV5InnerC1BV6storedSivpfaAA13OnlyPropsTestHF"
-// CHECK-SAME: @"$s18runtime_attributes1AV5InnerC11extComputedSivpfaAA13OnlyPropsTestHF"
+// CHECK-SAME: @"$s18runtime_attributes13OnlyPropsTestVAA1AV1xSaySiGSgvpfaHF"
+// CHECK-SAME: @"$s18runtime_attributes13OnlyPropsTestVAA1AV5InnerC4testSaySiGSgvpfaHF"
+// CHECK-SAME: @"$s18runtime_attributes13OnlyPropsTestVAA1AV5InnerC1BV6storedSivpfaHF"
+// CHECK-SAME: @"$s18runtime_attributes13OnlyPropsTestVAA1AV5InnerC11extComputedSivpfaHF"
 // CHECK-SAME: section "__TEXT, __swift5_rattrs, regular"
 
 // CHECK: @"$s3RAD6IgnoreVHa" = internal constant
 // CHECK-SAME: i32 0
 // CHECK-SAME: %swift.type_descriptor** @"got.$s3RAD6IgnoreVMn"
 // CHECK-SAME: i32 5
-// CHECK-SAME: @"$s18runtime_attributes1AV5InnerC11extComputedSivpfa3RAD6IgnoreHF"
-// CHECK-SAME: @"$s18runtime_attributes16WithExternalAttrAaBVmvpfa3RAD6IgnoreHF"
-// CHECK-SAME: @"$s18runtime_attributes14TestInference1AaBVmvpfa3RAD6IgnoreHF"
-// CHECK-SAME: @"$s18runtime_attributes14TestInference2AaBCmvpfa3RAD6IgnoreHF"
-// CHECK-SAME: @"$s18runtime_attributes14TestInference3AaBOmvpfa3RAD6IgnoreHF"
+// CHECK-SAME: @"$s3RAD6IgnoreV18runtime_attributes1AV5InnerC11extComputedSivpfaHF"
+// CHECK-SAME: @"$s3RAD6IgnoreV18runtime_attributes16WithExternalAttrVfaHF"
+// CHECK-SAME: @"$s3RAD6IgnoreV18runtime_attributes14TestInference1VfaHF"
+// CHECK-SAME: @"$s3RAD6IgnoreV18runtime_attributes14TestInference2CfaHF"
+// CHECK-SAME: @"$s3RAD6IgnoreV18runtime_attributes14TestInference3OfaHF"
 // CHECK-SAME: section "__TEXT, __swift5_rattrs, regular"
 
 // CHECK: @"$s3RAD13TestAmbiguityVHa" = internal constant
 // CHECK-SAME: i32 0
 // CHECK-SAME: %swift.type_descriptor** @"got.$s3RAD13TestAmbiguityVMn"
 // CHECK-SAME: i32 6
-// CHECK-SAME: @"$s18runtime_attributes4testyySicvpfa3RAD13TestAmbiguityHF"
-// CHECK-SAME: @"$s18runtime_attributes4testyySScvpfa3RAD13TestAmbiguityHF"
-// CHECK-SAME: @"$s18runtime_attributes15TestNoAmbiguityV10testStaticSiycvpZfa3RAD0cE0HF"
-// CHECK-SAME: @"$s18runtime_attributes15TestNoAmbiguityV10testStaticyycvpZfa3RAD0cE0HF"
-// CHECK-SAME: @"$s18runtime_attributes15TestNoAmbiguityV8testInstyySi_SStcvpfa3RAD0cE0HF"
-// CHECK-SAME: @"$s18runtime_attributes15TestNoAmbiguityV8testInstyySi_Sitcvpfa3RAD0cE0HF"
+// CHECK-SAME: @"$s3RAD13TestAmbiguityV18runtime_attributes4testyySiFfaHF"
+// CHECK-SAME: @"$s3RAD13TestAmbiguityV18runtime_attributes4testyySSFfaHF"
+// CHECK-SAME: @"$s3RAD13TestAmbiguityV18runtime_attributes0b2NoC0V10testStaticSiyFZfaHF"
+// CHECK-SAME: @"$s3RAD13TestAmbiguityV18runtime_attributes0b2NoC0V10testStaticyyFZfaHF"
+// CHECK-SAME: @"$s3RAD13TestAmbiguityV18runtime_attributes0b2NoC0V8testInstyySi_SStFfaHF"
+// CHECK-SAME: @"$s3RAD13TestAmbiguityV18runtime_attributes0b2NoC0V8testInstyySi_SitFfaHF"
 // CHECK-SAME: section "__TEXT, __swift5_rattrs, regular"
 
 // CHECK: @"$s18runtime_attributes17AvailabilityTestsVHa" = internal constant
 // CHECK-SAME: i32 0
 // CHECK-SAME: @"$s18runtime_attributes17AvailabilityTestsVMn"
 // CHECK-SAME: i32 5
-// CHECK-SAME: @"$s18runtime_attributes20testWithAvailabilityyySicvpfaAA0E5TestsHF
-// CHECK-SAME: @"$s18runtime_attributes20TypeWithAvailabilityAaBCmvpfaAA0E5TestsHF"
-// CHECK-SAME: @"$s18runtime_attributes23MembersWithAvailabilityC8staticFnyycvpZfaAA0E5TestsHF"
-// CHECK-SAME: @"$s18runtime_attributes23MembersWithAvailabilityC6instFnyycvpfaAA0E5TestsHF"
-// CHECK-SAME: @"$s18runtime_attributes23MembersWithAvailabilityC4propSivpfaAA0E5TestsHF"
+// CHECK-SAME: @"$s18runtime_attributes17AvailabilityTestsVAA08testWithC0yySiFfaHF
+// CHECK-SAME: @"$s18runtime_attributes17AvailabilityTestsVAA08TypeWithC0CfaHF"
+// CHECK-SAME: @"$s18runtime_attributes17AvailabilityTestsVAA011MembersWithC0C8staticFnyyFZfaHF"
+// CHECK-SAME: @"$s18runtime_attributes17AvailabilityTestsVAA011MembersWithC0C6instFnyyFfaHF"
+// CHECK-SAME: @"$s18runtime_attributes17AvailabilityTestsVAA011MembersWithC0C4propSivpfaHF"
 // CHECK-SAME: section "__TEXT, __swift5_rattrs, regular"
 
 // CHECK: @"$s18runtime_attributes13FlagWithAvailVHa" = internal constant
 // CHECK-SAME: i32 0
 // CHECK-SAME: @"$s18runtime_attributes13FlagWithAvailVMn"
 // CHECK-SAME: i32 1
-// CHECK-SAME: @"$s18runtime_attributes20attrIsHigherThanFuncyycvpfaAA13FlagWithAvailHF"
+// CHECK-SAME: @"$s18runtime_attributes13FlagWithAvailVAA20attrIsHigherThanFuncyyFfaHF"
 // CHECK-SAME: section "__TEXT, __swift5_rattrs, regular"
 
 // CHECK: @"$s18runtime_attributes19FlagForInnerMethodsVHa" = internal constant
 // CHECK-SAME: i32 0
 // CHECK-SAME: @"$s18runtime_attributes19FlagForInnerMethodsVMn"
 // CHECK-SAME: i32 4
-// CHECK-SAME: @"$s18runtime_attributes9OuterTypeV5InnerV15innerInstFnTestyycvpfaAA07FlagForE7MethodsHF"
-// CHECK-SAME: @"$s18runtime_attributes9OuterTypeV5InnerV17innerStaticFnTestyycvpZfaAA07FlagForE7MethodsHF"
-// CHECK-SAME: @"$s18runtime_attributes9OuterTypeV5InnerV07mutableE6FnTest1x_ySS_SiztcvpfaAA07FlagForE7MethodsHF"
-// CHECK-SAME: @"$s18runtime_attributes9OuterTypeV15outerMutatingFnSiycvpfaAA19FlagForInnerMethodsHF"
+// CHECK-SAME: @"$s18runtime_attributes19FlagForInnerMethodsVAA9OuterTypeV0E0V15innerInstFnTestyyFfaHF"
+// CHECK-SAME: @"$s18runtime_attributes19FlagForInnerMethodsVAA9OuterTypeV0E0V17innerStaticFnTestyyFZfaHF"
+// CHECK-SAME: @"$s18runtime_attributes19FlagForInnerMethodsVAA9OuterTypeV0E0V07mutableE6FnTest1x_ySS_SiztFfaHF"
+// CHECK-SAME: @"$s18runtime_attributes19FlagForInnerMethodsVAA9OuterTypeV15outerMutatingFnSiyFfaHF"
 // CHECK-SAME: section "__TEXT, __swift5_rattrs, regular"
 
 // CHECK: @"$s3RAD8EnumFlagOHa" = internal constant
 // CHECK-SAME: i32 0
 // CHECK-SAME: %swift.type_descriptor** @"got.$s3RAD8EnumFlagOMn"
 // CHECK-SAME: i32 5
-// CHECK-SAME: @"$s18runtime_attributes14globalEnumTestSi_SaySSGtSgycvpfa3RAD0D4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes12EnumTypeTestV1xSivpfa3RAD0C4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes12EnumTypeTestV8testInstyycvpfa3RAD0C4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes12EnumTypeTestV10testStaticSiycvpZfa3RAD0C4FlagHF"
-// CHECK-SAME: @"$s18runtime_attributes12EnumTypeTestAaBVmvpfa3RAD0C4FlagHF"
+// CHECK-SAME: @"$s3RAD8EnumFlagO18runtime_attributes06globalB4TestSi_SaySSGtSgyFfaHF"
+// CHECK-SAME: @"$s3RAD8EnumFlagO18runtime_attributes0B8TypeTestV1xSivpfaHF"
+// CHECK-SAME: @"$s3RAD8EnumFlagO18runtime_attributes0B8TypeTestV8testInstyyFfaHF"
+// CHECK-SAME: @"$s3RAD8EnumFlagO18runtime_attributes0B8TypeTestV10testStaticSiyFZfaHF"
+// CHECK-SAME: @"$s3RAD8EnumFlagO18runtime_attributes0B8TypeTestVfaHF"
 // CHECK-SAME: section "__TEXT, __swift5_rattrs, regular"
 
 import RAD
@@ -161,84 +166,89 @@ struct OnlyPropsTest<B, V> {
 
 // - Check that all of the generator functions have been emitted
 
-// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes8globalFnyycvpfaAA4Flag"(%T18runtime_attributes4FlagVyytGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyytGSg) %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4FlagVAA8globalFnyyFfa"(%T18runtime_attributes4FlagVyytGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyytGSg) %0)
 @Flag("global") func globalFn() {}
 
 @Flag
 struct A {
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes1AV2v1SSvpfaAA4Flag"(%T18runtime_attributes4FlagVySSGSg* noalias nocapture sret(%T18runtime_attributes4FlagVySSGSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4FlagVAA1AV2v1SSvpfa"(%T18runtime_attributes4FlagVySSGSg* noalias nocapture sret(%T18runtime_attributes4FlagVySSGSg) %0)
   @Flag("v1") var v1: String = ""
 
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes1AV4compSivpfaAA4Flag"(%T18runtime_attributes4FlagVySiGSg* noalias nocapture sret(%T18runtime_attributes4FlagVySiGSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4FlagVAA1AV4compSivpfa"(%T18runtime_attributes4FlagVySiGSg* noalias nocapture sret(%T18runtime_attributes4FlagVySiGSg) %0)
   @Flag var comp: Int {
     get { 42 }
   }
 
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes1AV5test1SiycvpZfaAA4Flag"(%T18runtime_attributes4FlagVySiGSg* noalias nocapture sret(%T18runtime_attributes4FlagVySiGSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4FlagVAA1AV5test1SiyFZfa"(%T18runtime_attributes4FlagVySiGSg* noalias nocapture sret(%T18runtime_attributes4FlagVySiGSg) %0)
   @Flag static func test1() -> Int { 42 }
 
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes1AV5test2yycvpfaAA4Flag"(%T18runtime_attributes4FlagVyytGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyytGSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4FlagVAA1AV5test2yyFfa"(%T18runtime_attributes4FlagVyytGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyytGSg) %0)
   @Flag("test2") func test2() {} // Ok
 
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes1AV1xSaySiGSgvpfaAA4Flag"(%T18runtime_attributes4FlagVySaySiGSgGSg* noalias nocapture sret(%T18runtime_attributes4FlagVySaySiGSgGSg) %0)
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes1AV1xSaySiGSgvpfaAA13OnlyPropsTest"(%T18runtime_attributes13OnlyPropsTestVyAA1AVSaySiGSgGSg* noalias nocapture sret(%T18runtime_attributes13OnlyPropsTestVyAA1AVSaySiGSgGSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4FlagVAA1AV1xSaySiGSgvpfa"(%T18runtime_attributes4FlagVySaySiGSgGSg* noalias nocapture sret(%T18runtime_attributes4FlagVySaySiGSgGSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes13OnlyPropsTestVAA1AV1xSaySiGSgvpfa"(%T18runtime_attributes13OnlyPropsTestVyAA1AVSaySiGSgGSg* noalias nocapture sret(%T18runtime_attributes13OnlyPropsTestVyAA1AVSaySiGSgGSg) %0)
   @OnlyPropsTest @Flag("x") var x: [Int]? = [] // Ok
 
   @Flag("Inner type") class Inner {
-    // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes1AV5InnerC4testSaySiGSgvpfaAA4Flag"(%T18runtime_attributes4FlagVySaySiGSgGSg* noalias nocapture sret(%T18runtime_attributes4FlagVySaySiGSgGSg) %0)
-    // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes1AV5InnerC4testSaySiGSgvpfaAA13OnlyPropsTest"(%T18runtime_attributes13OnlyPropsTestVyAA1AV5InnerCSaySiGSgGSg* noalias nocapture sret(%T18runtime_attributes13OnlyPropsTestVyAA1AV5InnerCSaySiGSgGSg) %0)
+    // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4FlagVAA1AV5InnerC4testSaySiGSgvpfa"(%T18runtime_attributes4FlagVySaySiGSgGSg* noalias nocapture sret(%T18runtime_attributes4FlagVySaySiGSgGSg) %0)
+    // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes13OnlyPropsTestVAA1AV5InnerC4testSaySiGSgvpfa"(%T18runtime_attributes13OnlyPropsTestVyAA1AV5InnerCSaySiGSgGSg* noalias nocapture sret(%T18runtime_attributes13OnlyPropsTestVyAA1AV5InnerCSaySiGSgGSg) %0)
     @OnlyPropsTest @Flag("test property") var test: [Int]? = nil // Ok
-  }
+  } // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4FlagVAA1AV5InnerCfa"(%T18runtime_attributes4FlagVyAA1AV5InnerCGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyAA1AV5InnerCGSg) %0)
 }
 
 // The generator for `struct A` is emitted last.
-// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes1AAaBVmvpfaAA4Flag"(%T18runtime_attributes4FlagVyAA1AVGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyAA1AVGSg) %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4FlagVAA1AVfa"(%T18runtime_attributes4FlagVyAA1AVGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyAA1AVGSg) %0)
 
 extension A.Inner {
   @Flag("B type") struct B {
-    // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes1AV5InnerC1BV03extC10StaticTestyycvpZfaAA4Flag"(%T18runtime_attributes4FlagVyytGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyytGSg) %0)
+    // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4FlagVAA1AV5InnerC1BV03extD10StaticTestyyFZfa"(%T18runtime_attributes4FlagVyytGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyytGSg) %0)
     @Flag static func extInnerStaticTest() {}
-    // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes1AV5InnerC1BV03extC4TestyycvpZfaAA4Flag"(%T18runtime_attributes4FlagVyytGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyytGSg) %0)
+    // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4FlagVAA1AV5InnerC1BV03extD4TestyyFZfa"(%T18runtime_attributes4FlagVyytGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyytGSg) %0)
     @Flag static func extInnerTest() {}
 
+    // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes13OnlyPropsTestVAA1AV5InnerC1BV6storedSivpfa"(%T18runtime_attributes13OnlyPropsTestVyAA1AV5InnerC1BVSiGSg* noalias nocapture sret(%T18runtime_attributes13OnlyPropsTestVyAA1AV5InnerC1BVSiGSg) %0)
+    // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4FlagVAA1AV5InnerC1BV6storedSivpfa"(%T18runtime_attributes4FlagVySiGSg* noalias nocapture sret(%T18runtime_attributes4FlagVySiGSg) %0)
     @Flag("stored prop") @OnlyPropsTest let stored: Int = 42
-  } // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes1AV5InnerC1BAeFVmvpfaAA4Flag"(%T18runtime_attributes4FlagVyAA1AV5InnerC1BVGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyAA1AV5InnerC1BVGSg) %0
+  } // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4FlagVAA1AV5InnerC1BVfa"(%T18runtime_attributes4FlagVyAA1AV5InnerC1BVGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyAA1AV5InnerC1BVGSg) %0
 
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes1AV5InnerC13extStaticTestyycvpZfaAA4Flag"(%T18runtime_attributes4FlagVyytGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyytGSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4FlagVAA1AV5InnerC13extStaticTestyyFZfa"(%T18runtime_attributes4FlagVyytGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyytGSg) %0)
   @Flag static func extStaticTest() {}
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes1AV5InnerC7extTestyycvpZfaAA4Flag"(%T18runtime_attributes4FlagVyytGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyytGSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4FlagVAA1AV5InnerC7extTestyyFZfa"(%T18runtime_attributes4FlagVyytGSg* noalias nocapture sret(%T18runtime_attributes4FlagVyytGSg) %0)
   @Flag static func extTest() {}
 
+  // CHECK-LABEL: define hidden swiftcc void @"$s3RAD6IgnoreV18runtime_attributes1AV5InnerC11extComputedSivpfa"(%T3RAD6IgnoreVys7KeyPathCy18runtime_attributes1AV5InnerCSiGGSg* noalias nocapture sret(%T3RAD6IgnoreVys7KeyPathCy18runtime_attributes1AV5InnerCSiGGSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4FlagVAA1AV5InnerC11extComputedSivpfa"(%T18runtime_attributes4FlagVySiGSg* noalias nocapture sret(%T18runtime_attributes4FlagVySiGSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes13OnlyPropsTestVAA1AV5InnerC11extComputedSivpfa"(%T18runtime_attributes13OnlyPropsTestVyAA1AV5InnerCSiGSg* noalias nocapture sret(%T18runtime_attributes13OnlyPropsTestVyAA1AV5InnerCSiGSg) %0)
   @OnlyPropsTest @Flag @Ignore var extComputed: Int {
     get { 42 }
   }
 }
 
-// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes16WithExternalAttrAaBVmvpfa3RAD6Ignore"(%T3RAD6IgnoreVy18runtime_attributes16WithExternalAttrVmGSg* noalias nocapture sret(%T3RAD6IgnoreVy18runtime_attributes16WithExternalAttrVmGSg) %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s3RAD6IgnoreV18runtime_attributes16WithExternalAttrVfa"(%T3RAD6IgnoreVy18runtime_attributes16WithExternalAttrVmGSg* noalias nocapture sret(%T3RAD6IgnoreVy18runtime_attributes16WithExternalAttrVmGSg) %0)
 @Ignore struct WithExternalAttr {}
 
-// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4testyySicvpfa3RAD13TestAmbiguity"(%T3RAD13TestAmbiguityVSg* noalias nocapture sret(%T3RAD13TestAmbiguityVSg) %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s3RAD13TestAmbiguityV18runtime_attributes4testyySiFfa"(%T3RAD13TestAmbiguityVSg* noalias nocapture sret(%T3RAD13TestAmbiguityVSg) %0)
 @TestAmbiguity public func test(_: Int) {}
-// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes4testyySScvpfa3RAD13TestAmbiguity"(%T3RAD13TestAmbiguityVSg* noalias nocapture sret(%T3RAD13TestAmbiguityVSg) %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s3RAD13TestAmbiguityV18runtime_attributes4testyySSFfa"(%T3RAD13TestAmbiguityVSg* noalias nocapture sret(%T3RAD13TestAmbiguityVSg) %0)
 @TestAmbiguity public func test(_: String) {}
 
 public struct TestNoAmbiguity {
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes15TestNoAmbiguityV10testStaticSiycvpZfa3RAD0cE0"(%T3RAD13TestAmbiguityVSg* noalias nocapture sret(%T3RAD13TestAmbiguityVSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s3RAD13TestAmbiguityV18runtime_attributes0b2NoC0V10testStaticSiyFZfa"(%T3RAD13TestAmbiguityVSg* noalias nocapture sret(%T3RAD13TestAmbiguityVSg) %0)
   @TestAmbiguity static func testStatic() -> Int { 42 }
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes15TestNoAmbiguityV10testStaticyycvpZfa3RAD0cE0"(%T3RAD13TestAmbiguityVSg* noalias nocapture sret(%T3RAD13TestAmbiguityVSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s3RAD13TestAmbiguityV18runtime_attributes0b2NoC0V10testStaticyyFZfa"(%T3RAD13TestAmbiguityVSg* noalias nocapture sret(%T3RAD13TestAmbiguityVSg) %0)
   @TestAmbiguity static func testStatic() {}
 
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes15TestNoAmbiguityV8testInstyySi_SStcvpfa3RAD0cE0"(%T3RAD13TestAmbiguityVSg* noalias nocapture sret(%T3RAD13TestAmbiguityVSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s3RAD13TestAmbiguityV18runtime_attributes0b2NoC0V8testInstyySi_SStFfa"(%T3RAD13TestAmbiguityVSg* noalias nocapture sret(%T3RAD13TestAmbiguityVSg) %0)
   @TestAmbiguity func testInst(_: Int, _: String) {}
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes15TestNoAmbiguityV8testInstyySi_Sitcvpfa3RAD0cE0"(%T3RAD13TestAmbiguityVSg* noalias nocapture sret(%T3RAD13TestAmbiguityVSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s3RAD13TestAmbiguityV18runtime_attributes0b2NoC0V8testInstyySi_SitFfa"(%T3RAD13TestAmbiguityVSg* noalias nocapture sret(%T3RAD13TestAmbiguityVSg) %0)
   @TestAmbiguity func testInst(_: Int, _: Int) {}
 }
 
-// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes14TestInference1AaBVmvpfa3RAD6Ignore"(%T3RAD6IgnoreVy18runtime_attributes14TestInference1VmGSg* noalias nocapture sret(%T3RAD6IgnoreVy18runtime_attributes14TestInference1VmGSg) %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s3RAD6IgnoreV18runtime_attributes14TestInference1Vfa"(%T3RAD6IgnoreVy18runtime_attributes14TestInference1VmGSg* noalias nocapture sret(%T3RAD6IgnoreVy18runtime_attributes14TestInference1VmGSg) %0)
 public struct TestInference1 : Ignored {}
-// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes14TestInference2AaBCmvpfa3RAD6Ignore"(%T3RAD6IgnoreVy18runtime_attributes14TestInference2CmGSg* noalias nocapture sret(%T3RAD6IgnoreVy18runtime_attributes14TestInference2CmGSg) %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s3RAD6IgnoreV18runtime_attributes14TestInference2Cfa"(%T3RAD6IgnoreVy18runtime_attributes14TestInference2CmGSg* noalias nocapture sret(%T3RAD6IgnoreVy18runtime_attributes14TestInference2CmGSg) %0)
 public class  TestInference2 : Ignored {}
-// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes14TestInference3AaBOmvpfa3RAD6Ignore"(%T3RAD6IgnoreVy18runtime_attributes14TestInference3OmGSg* noalias nocapture sret(%T3RAD6IgnoreVy18runtime_attributes14TestInference3OmGSg) %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s3RAD6IgnoreV18runtime_attributes14TestInference3Ofa"(%T3RAD6IgnoreVy18runtime_attributes14TestInference3OmGSg* noalias nocapture sret(%T3RAD6IgnoreVy18runtime_attributes14TestInference3OmGSg) %0)
 public enum   TestInference3 : Ignored {}
 
 @runtimeMetadata
@@ -246,14 +256,14 @@ struct AvailabilityTests {
   init(attachedTo: Any) {}
 }
 
-// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes20testWithAvailabilityyySicvpfaAA0E5Tests"(%T18runtime_attributes17AvailabilityTestsVSg* noalias nocapture sret(%T18runtime_attributes17AvailabilityTestsVSg) %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes17AvailabilityTestsVAA08testWithC0yySiFfa"(%T18runtime_attributes17AvailabilityTestsVSg* noalias nocapture sret(%T18runtime_attributes17AvailabilityTestsVSg) %0)
 // CHECK: entry:
 // CHECK: {{.*}} = call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(i64 42, i64 0, i64 0)
 @available(macOS, introduced: 42.0)
 @AvailabilityTests
 func testWithAvailability(_: Int) {}
 
-// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes20TypeWithAvailabilityAaBCmvpfaAA0E5Tests"(%T18runtime_attributes17AvailabilityTestsVSg* noalias nocapture sret(%T18runtime_attributes17AvailabilityTestsVSg) %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes17AvailabilityTestsVAA08TypeWithC0Cfa"(%T18runtime_attributes17AvailabilityTestsVSg* noalias nocapture sret(%T18runtime_attributes17AvailabilityTestsVSg) %0)
 // CHECK: entry:
 // CHECK: {{.*}} = call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(i64 100, i64 0, i64 0)
 @available(macOS, introduced: 100.0)
@@ -261,21 +271,21 @@ func testWithAvailability(_: Int) {}
 class TypeWithAvailability {}
 
 class MembersWithAvailability {
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes23MembersWithAvailabilityC8staticFnyycvpZfaAA0E5Tests"(%T18runtime_attributes17AvailabilityTestsVSg* noalias nocapture sret(%T18runtime_attributes17AvailabilityTestsVSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes17AvailabilityTestsVAA011MembersWithC0C8staticFnyyFZfa"(%T18runtime_attributes17AvailabilityTestsVSg* noalias nocapture sret(%T18runtime_attributes17AvailabilityTestsVSg) %0)
   // CHECK: entry:
   // CHECK: {{.*}} = call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(i64 201, i64 0, i64 0)
   @AvailabilityTests
   @available(macOS, introduced: 201.0)
   static func staticFn() {}
 
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes23MembersWithAvailabilityC6instFnyycvpfaAA0E5Tests"(%T18runtime_attributes17AvailabilityTestsVSg* noalias nocapture sret(%T18runtime_attributes17AvailabilityTestsVSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes17AvailabilityTestsVAA011MembersWithC0C6instFnyyFfa"(%T18runtime_attributes17AvailabilityTestsVSg* noalias nocapture sret(%T18runtime_attributes17AvailabilityTestsVSg) %0)
   // CHECK: entry:
   // CHECK: {{.*}} = call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(i64 202, i64 0, i64 0)
   @AvailabilityTests
   @available(macOS, introduced: 202.0)
   func instFn() {}
 
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes23MembersWithAvailabilityC4propSivpfaAA0E5Tests"(%T18runtime_attributes17AvailabilityTestsVSg* noalias nocapture sret(%T18runtime_attributes17AvailabilityTestsVSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes17AvailabilityTestsVAA011MembersWithC0C4propSivpfa"(%T18runtime_attributes17AvailabilityTestsVSg* noalias nocapture sret(%T18runtime_attributes17AvailabilityTestsVSg) %0)
   // CHECK: entry:
   // CHECK: {{.*}} = call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(i64 203, i64 0, i64 0)
   @AvailabilityTests
@@ -289,7 +299,7 @@ struct FlagWithAvail {
   init(attachedTo: Any) {}
 }
 
-// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes20attrIsHigherThanFuncyycvpfaAA13FlagWithAvail"(%T18runtime_attributes13FlagWithAvailVSg* noalias nocapture sret(%T18runtime_attributes13FlagWithAvailVSg) %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes13FlagWithAvailVAA20attrIsHigherThanFuncyyFfa"(%T18runtime_attributes13FlagWithAvailVSg* noalias nocapture sret(%T18runtime_attributes13FlagWithAvailVSg) %0)
 // CHECK: entry:
 // CHECK: {{.*}} = call swiftcc i1 @"$ss26_stdlib_isOSVersionAtLeastyBi1_Bw_BwBwtF"(i64 110, i64 0, i64 0)
 @FlagWithAvail
@@ -312,32 +322,32 @@ struct FlagForInnerMethods<Result> {
 
 struct OuterType {
   struct Inner {
-    // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes9OuterTypeV5InnerV15innerInstFnTestyycvpfaAA07FlagForE7Methods"(%T18runtime_attributes19FlagForInnerMethodsVyytGSg* noalias nocapture sret(%T18runtime_attributes19FlagForInnerMethodsVyytGSg) %0)
+    // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes19FlagForInnerMethodsVAA9OuterTypeV0E0V15innerInstFnTestyyFfa"(%T18runtime_attributes19FlagForInnerMethodsVyytGSg* noalias nocapture sret(%T18runtime_attributes19FlagForInnerMethodsVyytGSg) %0)
     @FlagForInnerMethods func innerInstFnTest() {}
-    // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes9OuterTypeV5InnerV17innerStaticFnTestyycvpZfaAA07FlagForE7Methods"(%T18runtime_attributes19FlagForInnerMethodsVyytGSg* noalias nocapture sret(%T18runtime_attributes19FlagForInnerMethodsVyytGSg) %0)
+    // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes19FlagForInnerMethodsVAA9OuterTypeV0E0V17innerStaticFnTestyyFZfa"(%T18runtime_attributes19FlagForInnerMethodsVyytGSg* noalias nocapture sret(%T18runtime_attributes19FlagForInnerMethodsVyytGSg) %0)
     @FlagForInnerMethods static func innerStaticFnTest() {}
 
-    // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes9OuterTypeV5InnerV07mutableE6FnTest1x_ySS_SiztcvpfaAA07FlagForE7Methods"(%T18runtime_attributes19FlagForInnerMethodsVyytGSg* noalias nocapture sret(%T18runtime_attributes19FlagForInnerMethodsVyytGSg) %0)
+    // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes19FlagForInnerMethodsVAA9OuterTypeV0E0V07mutableE6FnTest1x_ySS_SiztFfa"(%T18runtime_attributes19FlagForInnerMethodsVyytGSg* noalias nocapture sret(%T18runtime_attributes19FlagForInnerMethodsVyytGSg) %0)
     @FlagForInnerMethods mutating func mutableInnerFnTest(x: String, _ y: inout Int) {}
   }
 }
 
 extension OuterType {
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes9OuterTypeV15outerMutatingFnSiycvpfaAA19FlagForInnerMethods"(%T18runtime_attributes19FlagForInnerMethodsVySiGSg* noalias nocapture sret(%T18runtime_attributes19FlagForInnerMethodsVySiGSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes19FlagForInnerMethodsVAA9OuterTypeV15outerMutatingFnSiyFfa"(%T18runtime_attributes19FlagForInnerMethodsVySiGSg* noalias nocapture sret(%T18runtime_attributes19FlagForInnerMethodsVySiGSg) %0)
   @FlagForInnerMethods mutating func outerMutatingFn() -> Int { 42 }
 }
 
-// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes14globalEnumTestSi_SaySSGtSgycvpfa3RAD0D4Flag"(%T3RAD8EnumFlagOyytSi_SaySSGtSgGSg* noalias nocapture sret(%T3RAD8EnumFlagOyytSi_SaySSGtSgGSg) %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s3RAD8EnumFlagO18runtime_attributes06globalB4TestSi_SaySSGtSgyFfa"(%T3RAD8EnumFlagOyytSi_SaySSGtSgGSg* noalias nocapture sret(%T3RAD8EnumFlagOyytSi_SaySSGtSgGSg) %0)
 @EnumFlag func globalEnumTest() -> (Int, [String])? {
   nil
 }
 
 @EnumFlag struct EnumTypeTest {
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes12EnumTypeTestV1xSivpfa3RAD0C4Flag"(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVSiGSg* noalias nocapture sret(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVSiGSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s3RAD8EnumFlagO18runtime_attributes0B8TypeTestV1xSivpfa"(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVSiGSg* noalias nocapture sret(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVSiGSg) %0)
   @EnumFlag var x: Int = 42
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes12EnumTypeTestV8testInstyycvpfa3RAD0C4Flag"(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVytGSg* noalias nocapture sret(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVytGSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s3RAD8EnumFlagO18runtime_attributes0B8TypeTestV8testInstyyFfa"(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVytGSg* noalias nocapture sret(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVytGSg) %0)
   @EnumFlag func testInst() {}
-  // CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes12EnumTypeTestV10testStaticSiycvpZfa3RAD0C4Flag"(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVmSiGSg* noalias nocapture sret(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVmSiGSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s3RAD8EnumFlagO18runtime_attributes0B8TypeTestV10testStaticSiyFZfa"(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVmSiGSg* noalias nocapture sret(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVmSiGSg) %0)
   @EnumFlag static func testStatic() -> Int { 42 }
 }
-// CHECK-LABEL: define hidden swiftcc void @"$s18runtime_attributes12EnumTypeTestAaBVmvpfa3RAD0C4Flag"(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVytGSg* noalias nocapture sret(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVytGSg) %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s3RAD8EnumFlagO18runtime_attributes0B8TypeTestVfa"(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVytGSg* noalias nocapture sret(%T3RAD8EnumFlagOy18runtime_attributes0B8TypeTestVytGSg) %0)

--- a/test/IRGen/runtime_attributes_on_actors.swift
+++ b/test/IRGen/runtime_attributes_on_actors.swift
@@ -6,19 +6,19 @@
 // REQUIRES: OS=macosx
 // REQUIRES: concurrency
 
-// CHECK: @"$s28runtime_attributes_on_actors9TestActorC15asyncExternallyyyKcvpfaAA17FlagForAsyncFuncsHF"
-// CHECK: @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyyYaKcvpfaAA17FlagForAsyncFuncsHF"
-// CHECK: @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyySiYacvpfaAA17FlagForAsyncFuncsHF"
-// CHECK: @"$s28runtime_attributes_on_actors9TestActorC11doSomething_1xySi_SaySiGztYacvpfaAA17FlagForAsyncFuncsHF"
-// CHECK: @"$s28runtime_attributes_on_actors13globalAsyncFnSaySSGyYacvpfaAA07FlagForF5FuncsHF"
+// CHECK: @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVAA9TestActorC15asyncExternallyyyKFfaHF"
+// CHECK: @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVAA9TestActorC11doSomethingyyYaKFfaHF"
+// CHECK: @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVAA9TestActorC11doSomethingyySiYaFfaHF"
+// CHECK: @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVAA9TestActorC11doSomething_1xySi_SaySiGztYaFfaHF"
+// CHECK: @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVAA06globalG2FnSaySSGyYaFfaHF"
 
 // CHECK: @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVHa" = internal constant
 // CHECK-SAME: i32 5
-// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors9TestActorC15asyncExternallyyyKcvpfaAA17FlagForAsyncFuncsHF"
-// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyyYaKcvpfaAA17FlagForAsyncFuncsHF"
-// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyySiYacvpfaAA17FlagForAsyncFuncsHF"
-// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors9TestActorC11doSomething_1xySi_SaySiGztYacvpfaAA17FlagForAsyncFuncsHF"
-// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors13globalAsyncFnSaySSGyYacvpfaAA07FlagForF5FuncsHF"
+// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVAA9TestActorC15asyncExternallyyyKFfaHF"
+// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVAA9TestActorC11doSomethingyyYaKFfaHF"
+// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVAA9TestActorC11doSomethingyySiYaFfaHF"
+// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVAA9TestActorC11doSomething_1xySi_SaySiGztYaFfaHF"
+// CHECK-SAME: %swift.accessible_function* @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVAA06globalG2FnSaySSGyYaFfaHF"
 
 @runtimeMetadata
 struct FlagForAsyncFuncs {
@@ -29,24 +29,24 @@ struct FlagForAsyncFuncs {
 }
 
 actor TestActor {
-  // CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors9TestActorC15asyncExternallyyyKcvpfaAA17FlagForAsyncFuncs"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVAA9TestActorC15asyncExternallyyyKFfa"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
   @FlagForAsyncFuncs func asyncExternally() throws {
   }
 
-  // CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyyYaKcvpfaAA17FlagForAsyncFuncs"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVAA9TestActorC11doSomethingyyYaKFfa"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
   @FlagForAsyncFuncs func doSomething() async throws {
   }
 
-  // CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors9TestActorC11doSomethingyySiYacvpfaAA17FlagForAsyncFuncs"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVAA9TestActorC11doSomethingyySiYaFfa"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
   @FlagForAsyncFuncs nonisolated func doSomething(_: Int) async {
   }
 
-  // CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors9TestActorC11doSomething_1xySi_SaySiGztYacvpfaAA17FlagForAsyncFuncs"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
+  // CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVAA9TestActorC11doSomething_1xySi_SaySiGztYaFfa"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
   @FlagForAsyncFuncs func doSomething(_: Int, x: inout [Int]) async {
   }
 }
 
-// CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors13globalAsyncFnSaySSGyYacvpfaAA07FlagForF5Funcs"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
+// CHECK-LABEL: define hidden swiftcc void @"$s28runtime_attributes_on_actors17FlagForAsyncFuncsVAA06globalG2FnSaySSGyYaFfa"(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg* noalias nocapture sret(%T28runtime_attributes_on_actors17FlagForAsyncFuncsVSg) %0)
 @FlagForAsyncFuncs
 func globalAsyncFn() async -> [String] {
   return []

--- a/test/SILGen/runtime_attributes.swift
+++ b/test/SILGen/runtime_attributes.swift
@@ -10,7 +10,7 @@ import runtime_metadata_defs
 
 /// Test that generator has source locations for both explicit and inferred attributes.
 
-// CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s18runtime_attributes4TestAaBVmvpfa0A14_metadata_defs6Ignore : $@convention(thin) () -> @out Optional<Ignore>
+// CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s21runtime_metadata_defs6IgnoreV0A11_attributes4TestVfa : $@convention(thin) () -> @out Optional<Ignore>
 // CHECK: [[FILE_ID:%.*]] = string_literal utf8 "runtime_attributes/runtime_attributes.swift"
 // CHECK: [[STRING_INIT:%.*]] = function_ref @$sSS21_builtinStringLiteral17utf8CodeUnitCount7isASCIISSBp_BwBi1_tcfC
 // CHECK-NEXT: [[FILE_STR:%.*]] = apply [[STRING_INIT]]([[FILE_ID]], {{.*}})
@@ -24,7 +24,7 @@ import runtime_metadata_defs
 // CHECK-NEXT: {{.*}} = apply [[IGNORE_INIT]]<Test.Type>({{.*}}, {{.*}}, [[FILE_STR]], [[LINE]], [[COLUMN]], {{.*}})
 struct Test : Ignorable {}
 
-// CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s18runtime_attributes8globalFnyycvpfa0A14_metadata_defs6Ignore : $@convention(thin) () -> @out Optional<Ignore>
+// CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s21runtime_metadata_defs6IgnoreV0A11_attributes8globalFnyyFfa : $@convention(thin) () -> @out Optional<Ignore>
 // CHECK: {{.*}} = string_literal utf8 "runtime_attributes/runtime_attributes.swift"
 // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 33
 // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 2
@@ -33,7 +33,7 @@ struct Test : Ignorable {}
 @Ignore func globalFn() {}
 
 struct MemberTests {
-  // CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s18runtime_attributes11MemberTestsV1xSivpfa0A14_metadata_defs6Ignore : $@convention(thin) () -> @out Optional<Ignore>
+  // CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s21runtime_metadata_defs6IgnoreV0A11_attributes11MemberTestsV1xSivpfa : $@convention(thin) () -> @out Optional<Ignore>
   // CHECK: {{.*}} = string_literal utf8 "runtime_attributes/runtime_attributes.swift"
   // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 42
   // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 4
@@ -41,7 +41,7 @@ struct MemberTests {
   // CHECK-NEXT: {{.*}} = apply [[IGNORE_INIT]]<WritableKeyPath<MemberTests, Int>>({{.*}})
   @Ignore var x: Int = 42
 
-  // CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s18runtime_attributes11MemberTestsV6instFn_1xSSSi_SaySiGtcvpfa0A14_metadata_defs6Ignore : $@convention(thin) () -> @out Optional<Ignore>
+  // CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s21runtime_metadata_defs6IgnoreV0A11_attributes11MemberTestsV6instFn_1xSSSi_SaySiGtFfa : $@convention(thin) () -> @out Optional<Ignore>
   // CHECK: {{.*}} = string_literal utf8 "runtime_attributes/runtime_attributes.swift"
   // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 50
   // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 4
@@ -49,7 +49,7 @@ struct MemberTests {
   // CHECK-NEXT: {{.*}} = apply [[IGNORE_INIT]]<(MemberTests, Int, [Int]) -> String>({{.*}})
   @Ignore func instFn(_: Int, x: [Int]) -> String { "" }
 
-  // CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s18runtime_attributes11MemberTestsV8staticFn_1ySi_SStSS_SiztcvpZfa0A14_metadata_defs6Ignore : $@convention(thin) () -> @out Optional<Ignore>
+  // CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s21runtime_metadata_defs6IgnoreV0A11_attributes11MemberTestsV8staticFn_1ySi_SStSS_SiztFZfa : $@convention(thin) () -> @out Optional<Ignore>
   // CHECK: {{.*}} = string_literal utf8 "runtime_attributes/runtime_attributes.swift"
   // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 58
   // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 4
@@ -57,7 +57,7 @@ struct MemberTests {
   // CHECK-NEXT: {{.*}} = apply [[IGNORE_INIT]]<(MemberTests.Type, String, inout Int) -> (Int, String)>({{.*}})
   @Ignore static func staticFn(_ x: String, y: inout Int) -> (Int, String) { (42, "") }
 
-  // CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s18runtime_attributes11MemberTestsV10mutatingFnSiycvpfa0A14_metadata_defs6Ignore : $@convention(thin) () -> @out Optional<Ignore>
+  // CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s21runtime_metadata_defs6IgnoreV0A11_attributes11MemberTestsV10mutatingFnSiyFfa : $@convention(thin) () -> @out Optional<Ignore>
   // CHECK: {{.*}} = string_literal utf8 "runtime_attributes/runtime_attributes.swift"
   // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 66
   // CHECK: {{.*}} = integer_literal $Builtin.IntLiteral, 4
@@ -75,7 +75,7 @@ struct TestSelfUse {
   static var answer: Int = 42
   static var question: String = ""
 
-  // CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s18runtime_attributes11TestSelfUseV1xSSvpfaAA4Flag : $@convention(thin) () -> @out Optional<Flag<Int>>
+  // CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s18runtime_attributes4FlagVAA11TestSelfUseV1xSSvpfa : $@convention(thin) () -> @out Optional<Flag<Int>>
   // CHECK: [[ADDRESSOR:%.*]] = function_ref @$s18runtime_attributes11TestSelfUseV6answerSivau
   // CHECK-NEXT: [[ADDR_RESULT:%.*]] = apply [[ADDRESSOR]]() : $@convention(thin) () -> Builtin.RawPointer
   // CHECK-NEXT: [[PROP_ADDR:%.*]] = pointer_to_address [[ADDR_RESULT]] : $Builtin.RawPointer to [strict] $*Int
@@ -90,7 +90,7 @@ struct TestSelfUse {
   // CHECK-NEXT: {{.*}} = apply [[FLAG_INIT_REF]]<Int, WritableKeyPath<TestSelfUse, String>>({{.*}}, [[PROP_VAL_COPY]], [[FUNC_NAME_STR]], {{.*}})
   @Flag(value: Self.answer) var x: String = ""
 
-  // CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s18runtime_attributes11TestSelfUseV4testyycvpfaAA4Flag : $@convention(thin) () -> @out Optional<Flag<String>>
+  // CHECK-LABEL: sil hidden [runtime_accessible] [ossa] @$s18runtime_attributes4FlagVAA11TestSelfUseV4testyyFfa : $@convention(thin) () -> @out Optional<Flag<String>>
   // CHECK: [[ADDRESSOR:%.*]] = function_ref @$s18runtime_attributes11TestSelfUseV8questionSSvau
   // CHECK-NEXT: [[ADDR_RESULT:%.*]] = apply [[ADDRESSOR]]() : $@convention(thin) () -> Builtin.RawPointer
   // CHECK-NEXT: [[PROP_ADDR:%.*]] = pointer_to_address [[ADDR_RESULT]] : $Builtin.RawPointer to [strict] $*String


### PR DESCRIPTION
Instead of unconditionally appending `"vp"` (which means a variable), use the correct mangling for all entities that can be represented by this attribute. Also, while we're here let's shift some things around to better match current other manglings.