### PR TITLE
Link imported ObjC forward declarations to their Swift definition

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -353,6 +353,8 @@ public:
       llvm::SmallPtrSet<DerivativeAttr *, 1>>
       DerivativeAttrs;
 
+  ModuleDecl *MainModule = nullptr;
+
 private:
   /// The current generation number, which reflects the number of
   /// times that external modules have been loaded.

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -633,7 +633,7 @@ protected:
     HasAnyUnavailableValues : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1,
     /// If the module is compiled as static library.
     StaticLibrary : 1,
 
@@ -679,7 +679,11 @@ protected:
 
     /// Whether this module has been compiled with comprehensive checking for
     /// concurrency, e.g., Sendable checking.
-    IsConcurrencyChecked : 1
+    IsConcurrencyChecked : 1,
+
+    /// If the map from @objc provided name to top level swift::Decl in this
+    /// module is populated
+    ObjCNameLookupCachePopulated : 1
   );
 
   SWIFT_INLINE_BITFIELD(PrecedenceGroupDecl, Decl, 1+2,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -808,6 +808,10 @@ namespace swift {
     /// instead of dropped altogether when possible.
     bool ImportForwardDeclarations = false;
 
+    /// If true, the compiler will link forward declarations in Objective-C
+    /// that represent an @objc exposed Swift definition to their definition.
+    bool ResolveObjCForwardDeclarationsOfSwiftTypes = false;
+
     /// If true ignore the swift bridged attribute.
     bool DisableSwiftBridgeAttr = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -304,6 +304,10 @@ def enable_experimental_eager_clang_module_diagnostics :
   Flag<["-"], "enable-experimental-eager-clang-module-diagnostics">,
   HelpText<"Enable experimental eager diagnostics reporting on the importability of all referenced C, C++, and Objective-C libraries">;
 
+def enable_resolve_objc_forward_declarations_of_swift_types :
+  Flag<["-"], "enable-resolve-objc-forward-declarations-of-swift-types">,
+  HelpText<"When encountering a forward declaration in imported Objective-C, check if it can be tried to a visible @objc exposed Swift definition">;
+
 def enable_experimental_pairwise_build_block :
   Flag<["-"], "enable-experimental-pairwise-build-block">,
   HelpText<"Enable experimental pairwise 'buildBlock' for result builders">;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -43,6 +43,7 @@
 #include "swift/Basic/Compiler.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
+#include "swift/ClangImporter/ClangModule.h"
 #include "swift/Demangling/ManglingMacros.h"
 #include "swift/Parse/Token.h"
 #include "swift/Strings.h"
@@ -57,8 +58,8 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/SaveAndRestore.h"
-#include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/YAMLTraits.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
 
@@ -491,6 +492,7 @@ ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx,
   Bits.ModuleDecl.HasIncrementalInfo = 0;
   Bits.ModuleDecl.HasHermeticSealAtLink = 0;
   Bits.ModuleDecl.IsConcurrencyChecked = 0;
+  Bits.ModuleDecl.ObjCNameLookupCachePopulated = 0;
 }
 
 ImplicitImportList ModuleDecl::getImplicitImports() const {
@@ -1053,6 +1055,63 @@ void ModuleDecl::getTopLevelDeclsWhereAttributesMatch(
               SmallVectorImpl<Decl*> &Results,
               llvm::function_ref<bool(DeclAttributes)> matchAttributes) const {
   FORWARD(getTopLevelDeclsWhereAttributesMatch, (Results, matchAttributes));
+}
+
+void ModuleDecl::lookupTopLevelDeclsByObjCName(SmallVectorImpl<Decl *> &Results,
+                                               DeclName name) {
+  if (!isObjCNameLookupCachePopulated())
+    populateObjCNameLookupCache();
+
+  // A top level decl can't be special anyways
+  if (name.isSpecial())
+    return;
+
+  auto resultsForFileUnit = ObjCNameLookupCache.find(name.getBaseIdentifier());
+  if (resultsForFileUnit == ObjCNameLookupCache.end())
+    return;
+
+  Results.append(resultsForFileUnit->second.begin(),
+                 resultsForFileUnit->second.end());
+}
+
+void ModuleDecl::populateObjCNameLookupCache() {
+  SmallVector<Decl *> topLevelObjCExposedDeclsInFileUnit;
+  auto hasObjCAttrNamePredicate = [](const DeclAttributes &attrs) -> bool {
+    return attrs.hasAttribute<ObjCAttr>();
+  };
+
+  for (FileUnit *file : getFiles()) {
+    file->getTopLevelDeclsWhereAttributesMatch(
+        topLevelObjCExposedDeclsInFileUnit, hasObjCAttrNamePredicate);
+    if (auto *synth = file->getSynthesizedFile()) {
+      synth->getTopLevelDeclsWhereAttributesMatch(
+          topLevelObjCExposedDeclsInFileUnit, hasObjCAttrNamePredicate);
+    }
+  }
+
+  for (Decl *decl : topLevelObjCExposedDeclsInFileUnit) {
+    if (ValueDecl *VD = dyn_cast<ValueDecl>(decl)) {
+      if (VD->hasName()) {
+        const auto &declObjCAttribute = VD->getAttrs().getAttribute<ObjCAttr>();
+        // No top level decl (class, protocol, extension etc.) is allowed to
+        // have a compound name, @objc provided or otherwise. Global functions
+        // are allowed to have compound names, but not allowed to have @objc
+        // attributes. Thus we are sure to not hit asserts getting the simple
+        // name.
+        //
+        // Similarly, init, dealloc and subscript (the special names) can't be
+        // top level decls, so we won't hit asserts getting the base identifier
+        // out of the value decl.
+        const Identifier &declObjCName =
+            declObjCAttribute->hasName()
+                ? declObjCAttribute->getName()->getSimpleName()
+                : VD->getName().getBaseIdentifier();
+        ObjCNameLookupCache[declObjCName].push_back(decl);
+      }
+    }
+  }
+
+  setIsObjCNameLookupCachePopulated(true);
 }
 
 void SourceFile::getTopLevelDecls(SmallVectorImpl<Decl*> &Results) const {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2258,6 +2258,8 @@ ClangImporter::Implementation::Implementation(
     ASTContext &ctx, DWARFImporterDelegate *dwarfImporterDelegate)
     : SwiftContext(ctx), ImportForwardDeclarations(
                              ctx.ClangImporterOpts.ImportForwardDeclarations),
+      ResolveObjCForwardDeclarationsOfSwiftTypes(
+          ctx.ClangImporterOpts.ResolveObjCForwardDeclarationsOfSwiftTypes),
       DisableSwiftBridgeAttr(ctx.ClangImporterOpts.DisableSwiftBridgeAttr),
       BridgingHeaderExplicitlyRequested(
           !ctx.ClangImporterOpts.BridgingHeader.empty()),
@@ -2265,11 +2267,9 @@ ClangImporter::Implementation::Implementation(
       EnableClangSPI(ctx.ClangImporterOpts.EnableClangSPI),
       IsReadingBridgingPCH(false),
       CurrentVersion(ImportNameVersion::fromOptions(ctx.LangOpts)),
-      Walker(DiagnosticWalker(*this)),
-      BuffersForDiagnostics(ctx.SourceMgr),
+      Walker(DiagnosticWalker(*this)), BuffersForDiagnostics(ctx.SourceMgr),
       BridgingHeaderLookupTable(new SwiftLookupTable(nullptr)),
-      platformAvailability(ctx.LangOpts),
-      nameImporter(),
+      platformAvailability(ctx.LangOpts), nameImporter(),
       DisableSourceImport(ctx.ClangImporterOpts.DisableSourceImport),
       DWARFImporter(dwarfImporterDelegate) {}
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4245,7 +4245,8 @@ namespace {
 
     template <typename T, typename U>
     T *resolveSwiftDeclImpl(const U *decl, Identifier name,
-                            bool hasKnownSwiftName, ModuleDecl *overlay) {
+                            bool hasKnownSwiftName, ModuleDecl *module,
+                            bool allowObjCMismatchFallback) {
       const auto &languageVersion =
           Impl.SwiftContext.LangOpts.EffectiveLanguageVersion;
 
@@ -4277,7 +4278,7 @@ namespace {
 
       // First look at Swift types with the same name.
       SmallVector<ValueDecl *, 4> swiftDeclsByName;
-      overlay->lookupValue(name, NLKind::QualifiedLookup, swiftDeclsByName);
+      module->lookupValue(name, NLKind::QualifiedLookup, swiftDeclsByName);
       T *found = nullptr;
       for (auto result : swiftDeclsByName) {
         if (auto singleResult = dyn_cast<T>(result)) {
@@ -4299,14 +4300,7 @@ namespace {
         SmallVector<Decl *, 4> matchingTopLevelDecls;
 
         // Get decls with a matching @objc attribute
-        overlay->getTopLevelDeclsWhereAttributesMatch(
-          matchingTopLevelDecls,
-          [&name](const DeclAttributes attrs) -> bool {
-            if (auto objcAttr = attrs.getAttribute<ObjCAttr>())
-              if (auto objcName = objcAttr->getName())
-                return objcName->getSimpleName() == name;
-            return false;
-          });
+        module->lookupTopLevelDeclsByObjCName(matchingTopLevelDecls, name);
 
         // Filter by decl kind
         for (auto result : matchingTopLevelDecls) {
@@ -4318,12 +4312,12 @@ namespace {
         }
       }
 
-      if (!found) {
-        // Go back to the first list and find classes with matching Swift names
-        // *even if the ObjC name doesn't match.*
-        // This shouldn't be allowed but we need it for source compatibility;
-        // people used `@class SwiftNameOfClass` as a workaround for not
-        // having the previous loop, and it "worked".
+      if (allowObjCMismatchFallback && !found) {
+        // Go back to the first list and find classes with matching Swift
+        // names *even if the ObjC name doesn't match.* This shouldn't be
+        // allowed but we need it for source compatibility; people used
+        // `@class SwiftNameOfClass` as a workaround for not having the
+        // previous loop, and it "worked".
         for (auto result : swiftDeclsByName) {
           if (auto singleResult = dyn_cast<T>(result)) {
             if (isMatch(singleResult, /*baseNameMatches=*/true,
@@ -4347,15 +4341,36 @@ namespace {
     T *resolveSwiftDecl(const U *decl, Identifier name,
                         bool hasKnownSwiftName, ClangModuleUnit *clangModule) {
       if (auto overlay = clangModule->getOverlayModule())
-        return resolveSwiftDeclImpl<T>(decl, name, hasKnownSwiftName, overlay);
+        return resolveSwiftDeclImpl<T>(decl, name, hasKnownSwiftName, overlay,
+                                       /*allowObjCMismatchFallback*/ true);
       if (clangModule == Impl.ImportedHeaderUnit) {
         // Use an index-based loop because new owners can come in as we're
         // iterating.
         for (size_t i = 0; i < Impl.ImportedHeaderOwners.size(); ++i) {
           ModuleDecl *owner = Impl.ImportedHeaderOwners[i];
-          if (T *result = resolveSwiftDeclImpl<T>(decl, name,
-                                                  hasKnownSwiftName, owner))
+          if (T *result =
+                  resolveSwiftDeclImpl<T>(decl, name, hasKnownSwiftName, owner,
+                                          /*allowObjCMismatchFallback*/ true))
             return result;
+        }
+      }
+      if (Impl.ResolveObjCForwardDeclarationsOfSwiftTypes) {
+        if (auto mainModule = Impl.SwiftContext.MainModule) {
+          llvm::SmallVector<ValueDecl *> results;
+          llvm::SmallVector<ImportedModule> importedModules;
+
+          mainModule->getImportedModules(importedModules,
+                                         ModuleDecl::ImportFilterKind::Default);
+
+          for (auto &import : importedModules) {
+            if (import.importedModule->isNonSwiftModule())
+              continue;
+
+            if (T *result = resolveSwiftDeclImpl<T>(
+                    decl, name, hasKnownSwiftName, import.importedModule,
+                    /*allowObjCMismatchFallback*/ false))
+              return result;
+          }
         }
       }
       return nullptr;
@@ -4400,10 +4415,8 @@ namespace {
       Identifier name = importedName.getDeclName().getBaseIdentifier();
       bool hasKnownSwiftName = importedName.hasCustomName();
 
-      // FIXME: Figure out how to deal with incomplete protocols, since that
-      // notion doesn't exist in Swift.
       if (!decl->hasDefinition()) {
-        // Check if this protocol is implemented in its overlay.
+        // Check if this protocol is implemented in available Swift sources.
         if (auto clangModule = Impl.getClangModuleForDecl(decl, true))
           if (auto native = resolveSwiftDecl<ProtocolDecl>(decl, name,
                                                            hasKnownSwiftName,

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4300,7 +4300,14 @@ namespace {
         SmallVector<Decl *, 4> matchingTopLevelDecls;
 
         // Get decls with a matching @objc attribute
-        module->lookupTopLevelDeclsByObjCName(matchingTopLevelDecls, name);
+        module->getTopLevelDeclsWhereAttributesMatch(
+          matchingTopLevelDecls,
+          [&name](const DeclAttributes attrs) -> bool {
+            if (auto objcAttr = attrs.getAttribute<ObjCAttr>())
+              if (auto objcName = objcAttr->getName())
+                return objcName->getSimpleName() == name;
+            return false;
+          });
 
         // Filter by decl kind
         for (auto result : matchingTopLevelDecls) {

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -448,6 +448,7 @@ public:
       CollectedDiagnostics;
 
   const bool ImportForwardDeclarations;
+  const bool ResolveObjCForwardDeclarationsOfSwiftTypes;
   const bool DisableSwiftBridgeAttr;
   const bool BridgingHeaderExplicitlyRequested;
   const bool DisableOverlayModules;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1218,10 +1218,11 @@ static bool ParseTypeCheckerArgs(TypeCheckerOptions &Opts, ArgList &Args,
   return HadError;
 }
 
-static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
-                                   ArgList &Args,
+static bool ParseClangImporterArgs(ClangImporterOptions &Opts, ArgList &Args,
                                    DiagnosticEngine &Diags,
-                                   StringRef workingDirectory) {
+                                   StringRef workingDirectory,
+                                   const LangOptions &LangOpts,
+                                   const FrontendOptions &FrontendOpts) {
   using namespace options;
 
   if (const Arg *a = Args.getLastArg(OPT_tools_directory)) {
@@ -1288,6 +1289,11 @@ static bool ParseClangImporterArgs(ClangImporterOptions &Opts,
   }
 
   Opts.DumpClangDiagnostics |= Args.hasArg(OPT_dump_clang_diagnostics);
+
+  if (Args.hasArg(
+          OPT_enable_resolve_objc_forward_declarations_of_swift_types)) {
+    Opts.ResolveObjCForwardDeclarationsOfSwiftTypes = true;
+  }
 
   if (Args.hasArg(OPT_embed_bitcode))
     Opts.Mode = ClangImporterOptions::Modes::EmbedBitcode;
@@ -2656,7 +2662,7 @@ bool CompilerInvocation::parseArgs(
   }
 
   if (ParseClangImporterArgs(ClangImporterOpts, ParsedArgs, Diags,
-                             workingDirectory)) {
+                             workingDirectory, LangOpts, FrontendOpts)) {
     return true;
   }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1101,6 +1101,7 @@ ModuleDecl *CompilerInstance::getMainModule() const {
 
     // Register the main module with the AST context.
     Context->addLoadedModule(MainModule);
+    Context->MainModule = MainModule;
 
     // Create and add the module's files.
     SmallVector<FileUnit *, 16> files;
@@ -1123,6 +1124,7 @@ void CompilerInstance::setMainModule(ModuleDecl *newMod) {
   assert(newMod->isMainModule());
   MainModule = newMod;
   Context->addLoadedModule(newMod);
+  Context->MainModule = newMod;
 }
 
 bool CompilerInstance::performParseAndResolveImportsOnly() {

--- a/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/complete-swift-types.swift
+++ b/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/complete-swift-types.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+@objc public class Foo : NSObject {
+    @objc public func sayHello() {
+        print("Hello from Foo.sayHello!")
+    }
+}
+
+@objc(Baz) public class Bar : NSObject {
+    @objc public func sayHello() {
+        print("Hello from Bar.sayHello!")
+    }
+}
+
+class ConflictingTypeName {}
+
+@objc(ConflictingTypeName) public class Qux : NSObject {
+    @objc public func sayHello() {
+        print("Hello from Qux.sayHello!")
+    }
+}
+
+// Created to verify if using a special
+// name as an @objc identifier causes issues
+@objc(subscript) public class Corge : NSObject {
+    @objc public func sayHello() {
+        print("Hello from Corge.sayHello!")
+    }
+}

--- a/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/module.modulemap
+++ b/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/module.modulemap
@@ -1,0 +1,23 @@
+module CompleteTypes {
+    header "complete-types.h"
+}
+
+module IncompleteTypeLibrary1 {
+    header "incomplete-type-library-1.h"
+}
+
+module IncompleteTypeLibrary2 {
+    header "incomplete-type-library-2.h"
+}
+
+module IncompleteNSProxyLibrary {
+    header "incomplete-nsproxy-library.h"
+}
+
+module IncompleteNoRootTypeProtocolLibrary {
+    header "incomplete-noroottype-protocol-library.h"
+}   
+
+module ObjCLibraryForwardDeclaringCompleteSwiftTypes {
+    header "objc-library-forward-declaring-complete-swift-types.h"
+}

--- a/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/objc-library-forward-declaring-complete-swift-types.h
+++ b/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/objc-library-forward-declaring-complete-swift-types.h
@@ -1,0 +1,16 @@
+@class Foo;
+@class Baz;
+@class ConflictingTypeName;
+@class subscript;
+
+void takeAFoo(Foo *foo);
+Foo *returnAFoo();
+
+void takeABaz(Baz *baz);
+Baz *returnABaz();
+
+void takeAConflictingTypeName(ConflictingTypeName *param);
+ConflictingTypeName *returnAConflictingTypeName();
+
+void takeASubscript(subscript *param);
+subscript *returnASubscript();

--- a/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/objc-library-forward-declaring-complete-swift-types.m
+++ b/test/ClangImporter/Inputs/custom-modules/IncompleteTypes/objc-library-forward-declaring-complete-swift-types.m
@@ -1,0 +1,34 @@
+#import "objc-library-forward-declaring-complete-swift-types.h"
+#import "CompleteSwiftTypes-Swift.h"
+
+void takeAFoo(Foo *foo) { [foo sayHello]; }
+
+Foo *returnAFoo() {
+  Foo *result = [[Foo alloc] init];
+  [result sayHello];
+  return result;
+}
+
+void takeABaz(Baz *baz) { [baz sayHello]; }
+
+Baz *returnABaz() {
+  Baz *result = [[Baz alloc] init];
+  [result sayHello];
+  return result;
+}
+
+void takeAConflictingTypeName(ConflictingTypeName *param) { [param sayHello]; }
+
+ConflictingTypeName *returnAConflictingTypeName() {
+  ConflictingTypeName *result = [[ConflictingTypeName alloc] init];
+  [result sayHello];
+  return result;
+}
+
+void takeASubscript(subscript *baz) { [baz sayHello]; }
+
+subscript *returnASubscript() {
+  subscript *result = [[subscript alloc] init];
+  [result sayHello];
+  return result;
+}

--- a/test/ClangImporter/incomplete_objc_types_compatibility_complete_incomplete_inter_file_swift_definition.swift
+++ b/test/ClangImporter/incomplete_objc_types_compatibility_complete_incomplete_inter_file_swift_definition.swift
@@ -1,0 +1,37 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-build-swift -parse-as-library %S/Inputs/custom-modules/IncompleteTypes/complete-swift-types.swift -emit-module -emit-module-path %t/CompleteSwiftTypes.swiftmodule -emit-objc-header -emit-objc-header-path %t/CompleteSwiftTypes-Swift.h -emit-library -o %t/libCompleteSwiftTypes.dylib
+// RUN: %target-clang -framework Foundation -dynamiclib %S/Inputs/custom-modules/IncompleteTypes/objc-library-forward-declaring-complete-swift-types.m -I %t -L %t -lCompleteSwiftTypes -o %t/libObjCLibraryForwardDeclaringCompleteSwiftTypes.dylib
+
+// RUN: %target-build-swift -Xfrontend -enable-resolve-objc-forward-declarations-of-swift-types -Xfrontend -enable-objc-interop %t/full_definition.swift %t/incomplete_definition.swift -I %S/Inputs/custom-modules/IncompleteTypes -I %t -L %t -lCompleteSwiftTypes -lObjCLibraryForwardDeclaringCompleteSwiftTypes -o %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+//--- full_definition.swift
+
+import CompleteSwiftTypes
+
+func getACompleteFoo() -> Foo {
+    return Foo()
+}
+
+func takeACompleteFoo(_ param: Foo) {
+    param.sayHello()
+}
+
+//--- incomplete_definition.swift
+
+import ObjCLibraryForwardDeclaringCompleteSwiftTypes
+
+@main
+class Main {
+    static func main() {
+        let incompleteFoo = returnAFoo()!
+        takeACompleteFoo(incompleteFoo)
+        let completeFoo = getACompleteFoo()
+        assert(type(of: incompleteFoo) == type(of: completeFoo))
+    }
+}

--- a/test/ClangImporter/incomplete_objc_types_swift_definition_imported.swift
+++ b/test/ClangImporter/incomplete_objc_types_swift_definition_imported.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -parse-as-library %S/Inputs/custom-modules/IncompleteTypes/complete-swift-types.swift -emit-module -emit-module-path %t/CompleteSwiftTypes.swiftmodule -emit-objc-header -emit-objc-header-path %t/CompleteSwiftTypes-Swift.h -emit-library -o %t/libCompleteSwiftTypes.dylib
+// RUN: %target-clang -framework Foundation -dynamiclib %S/Inputs/custom-modules/IncompleteTypes/objc-library-forward-declaring-complete-swift-types.m -I %t -L %t -lCompleteSwiftTypes -o %t/libObjCLibraryForwardDeclaringCompleteSwiftTypes.dylib
+// RUN: %target-build-swift -Xfrontend -enable-resolve-objc-forward-declarations-of-swift-types -Xfrontend -enable-objc-interop %s -I %S/Inputs/custom-modules/IncompleteTypes -I %t -L %t -lCompleteSwiftTypes -lObjCLibraryForwardDeclaringCompleteSwiftTypes -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+
+import CompleteSwiftTypes
+import ObjCLibraryForwardDeclaringCompleteSwiftTypes
+
+// Swift initializers
+let foo = Foo()
+let bar = Bar()
+let corge = Corge()
+
+// CHECK: Hello from Foo.sayHello!
+foo.sayHello()
+// CHECK: Hello from Bar.sayHello!
+bar.sayHello()
+// CHECK: Hello from Corge.sayHello!
+corge.sayHello()
+
+// Imported from Objective-C
+// CHECK: Hello from Foo.sayHello!
+takeAFoo(foo)
+// CHECK: Hello from Foo.sayHello!
+let foo2 = returnAFoo()
+// CHECK: Hello from Foo.sayHello!
+foo2!.sayHello()
+
+// CHECK: Hello from Bar.sayHello!
+takeABaz(bar)
+// CHECK: Hello from Bar.sayHello!
+let bar2 = returnABaz()
+// CHECK: Hello from Bar.sayHello!
+bar2!.sayHello()
+
+// CHECK: Hello from Corge.sayHello!
+takeASubscript(corge)
+// CHECK: Hello from Corge.sayHello!
+let corge2 = returnASubscript()
+// CHECK: Hello from Corge.sayHello!
+corge2!.sayHello()

--- a/test/ClangImporter/incomplete_objc_types_swift_definition_imported_name_conflict.swift
+++ b/test/ClangImporter/incomplete_objc_types_swift_definition_imported_name_conflict.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -parse-as-library %S/Inputs/custom-modules/IncompleteTypes/complete-swift-types.swift -emit-module -emit-module-path %t/CompleteSwiftTypes.swiftmodule -emit-objc-header -emit-objc-header-path %t/CompleteSwiftTypes-Swift.h -emit-library -o %t/libCompleteSwiftTypes.dylib
+// RUN: %target-clang -framework Foundation -dynamiclib %S/Inputs/custom-modules/IncompleteTypes/objc-library-forward-declaring-complete-swift-types.m -I %t -L %t -lCompleteSwiftTypes -o %t/libObjCLibraryForwardDeclaringCompleteSwiftTypes.dylib
+// RUN: %target-build-swift -Xfrontend -enable-resolve-objc-forward-declarations-of-swift-types -Xfrontend -enable-objc-interop %s -I %S/Inputs/custom-modules/IncompleteTypes -I %t -L %t -lCompleteSwiftTypes -lObjCLibraryForwardDeclaringCompleteSwiftTypes -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s
+
+// REQUIRES: objc_interop
+// REQUIRES: executable_test
+
+import CompleteSwiftTypes
+import ObjCLibraryForwardDeclaringCompleteSwiftTypes
+
+// Swift initializers
+let qux = Qux()
+
+// CHECK: Hello from Qux.sayHello!
+takeAConflictingTypeName(qux)
+// CHECK: Hello from Qux.sayHello!
+let qux2 = returnAConflictingTypeName()
+// CHECK: Hello from Qux.sayHello!
+qux2!.sayHello()


### PR DESCRIPTION
On occasion, an Objective-C header will forward declare an interface or protocol that is defined elsewhere in Swift. If the definition were in a Clang module instead, the forward declaration would be linked to its definition. Prior to this patch, this was not the case for @objc exposed Swift declarations. This patch fixes that.