### PR TITLE
Disable test only on windows, rather than everywhere

### DIFF
--- a/test/Concurrency/Runtime/async_taskgroup_discarding.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_discarding.swift
@@ -4,10 +4,11 @@
 // REQUIRES: executable_test
 // REQUIRES: concurrency_runtime
 
-// REQUIRES: rdar104982289
-
 // rdar://78109470
 // UNSUPPORTED: back_deployment_runtime
+
+// rdar://104982289
+// UNSUPPORTED: OS=windows-msvc 
 
 import _Concurrency
 


### PR DESCRIPTION
I was hoping this to be stable on other platforms by now, so let's please not disable everywhere so it gets more runs there.

Disabling only on windows for now then

rdar://104982289