### PR TITLE
[Index] Prevent re-indexing system modules repeatedly

### DIFF
--- a/include/swift/AST/FileUnit.h
+++ b/include/swift/AST/FileUnit.h
@@ -412,6 +412,14 @@ public:
   /// applicable.
   virtual StringRef getLoadedFilename() const { return StringRef(); }
 
+  /// Returns the path of the file for the module represented by this
+  /// \c FileUnit, or an empty string if there is none. For modules either
+  /// built by or adjacent to a module interface, returns the module
+  /// interface instead.
+  virtual StringRef getSourceFilename() const {
+    return getModuleDefiningPath();
+  }
+
   virtual StringRef getFilenameForPrivateDecl(const ValueDecl *decl) const {
     return StringRef();
   }

--- a/include/swift/Frontend/ModuleInterfaceLoader.h
+++ b/include/swift/Frontend/ModuleInterfaceLoader.h
@@ -138,6 +138,7 @@ class ExplicitSwiftModuleLoader: public SerializedModuleLoaderBase {
 
   bool findModule(ImportPath::Element moduleID,
                   SmallVectorImpl<char> *moduleInterfacePath,
+                  SmallVectorImpl<char> *moduleInterfaceSourcePath,
                   std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
                   std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
                   std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,
@@ -145,13 +146,13 @@ class ExplicitSwiftModuleLoader: public SerializedModuleLoaderBase {
                   bool &isSystemModule) override;
 
   std::error_code findModuleFilesInDirectory(
-                  ImportPath::Element ModuleID,
-                  const SerializedModuleBaseName &BaseName,
-                  SmallVectorImpl<char> *ModuleInterfacePath,
-                  std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-                  std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-                  std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-                  bool skipBuildingInterface, bool IsFramework) override;
+      ImportPath::Element ModuleID, const SerializedModuleBaseName &BaseName,
+      SmallVectorImpl<char> *ModuleInterfacePath,
+      SmallVectorImpl<char> *ModuleInterfaceSourcePath,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+      bool skipBuildingInterface, bool IsFramework) override;
 
   bool canImportModule(ImportPath::Module named,
                        ModuleVersionInfo *versionInfo) override;
@@ -418,13 +419,13 @@ class ModuleInterfaceLoader : public SerializedModuleLoaderBase {
   ArrayRef<std::string> PreferInterfaceForModules;
 
   std::error_code findModuleFilesInDirectory(
-     ImportPath::Element ModuleID,
-     const SerializedModuleBaseName &BaseName,
-     SmallVectorImpl<char> *ModuleInterfacePath,
-     std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-     std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-     std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-     bool skipBuildingInterface, bool IsFramework) override;
+      ImportPath::Element ModuleID, const SerializedModuleBaseName &BaseName,
+      SmallVectorImpl<char> *ModuleInterfacePath,
+      SmallVectorImpl<char> *ModuleInterfaceSourcePath,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+      bool skipBuildingInterface, bool IsFramework) override;
 
   bool isCached(StringRef DepPath) override;
 public:

--- a/include/swift/Serialization/ModuleDependencyScanner.h
+++ b/include/swift/Serialization/ModuleDependencyScanner.h
@@ -57,6 +57,7 @@ namespace swift {
           ImportPath::Element ModuleID,
           const SerializedModuleBaseName &BaseName,
           SmallVectorImpl<char> *ModuleInterfacePath,
+          SmallVectorImpl<char> *ModuleInterfaceSourcePath,
           std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
           std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
           std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
@@ -118,6 +119,7 @@ namespace swift {
       virtual bool
       findModule(ImportPath::Element moduleID,
                  SmallVectorImpl<char> *moduleInterfacePath,
+                 SmallVectorImpl<char> *moduleInterfaceSourcePath,
                  std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
                  std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
                  std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2064,11 +2064,9 @@ StringRef ModuleDecl::getModuleFilename() const {
 
 StringRef ModuleDecl::getModuleSourceFilename() const {
   for (auto F : getFiles()) {
-    if (auto *SFU = dyn_cast<SynthesizedFileUnit>(F))
-      continue;
-    return F->getModuleDefiningPath();
+    if (auto LF = dyn_cast<LoadedFile>(F))
+      return LF->getSourceFilename();
   }
-
   return StringRef();
 }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1229,11 +1229,11 @@ bool CompilerInstance::loadPartialModulesAndImplicitImports(
   bool hadLoadError = false;
   for (auto &PM : PartialModules) {
     assert(PM.ModuleBuffer);
-    auto *file =
-      DefaultSerializedLoader->loadAST(*mod, /*diagLoc*/ SourceLoc(), /*moduleInterfacePath*/ "",
-                     std::move(PM.ModuleBuffer), std::move(PM.ModuleDocBuffer),
-                     std::move(PM.ModuleSourceInfoBuffer),
-                     /*isFramework*/ false);
+    auto *file = DefaultSerializedLoader->loadAST(
+        *mod, /*diagLoc=*/SourceLoc(), /*moduleInterfacePath*/ "",
+        /*moduleInterfaceSourcePath=*/"", std::move(PM.ModuleBuffer),
+        std::move(PM.ModuleDocBuffer), std::move(PM.ModuleSourceInfoBuffer),
+        /*isFramework*/ false);
     if (file) {
       partialModules.push_back(file);
     } else {

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -24,6 +24,7 @@
 #include "swift/Frontend/ModuleInterfaceSupport.h"
 #include "swift/Parse/ParseVersion.h"
 #include "swift/Serialization/SerializationOptions.h"
+#include "swift/Serialization/SerializedModuleLoader.h"
 #include "swift/Serialization/Validation.h"
 #include "swift/Strings.h"
 #include "clang/Basic/Module.h"
@@ -1106,39 +1107,35 @@ bool ModuleInterfaceLoader::isCached(StringRef DepPath) {
 /// cache or by converting it in a subordinate \c CompilerInstance, caching
 /// the results.
 std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
-  ImportPath::Element ModuleID,
-  const SerializedModuleBaseName &BaseName,
-  SmallVectorImpl<char> *ModuleInterfacePath,
-  std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-  std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-  std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-  bool skipBuildingInterface, bool IsFramework) {
+    ImportPath::Element ModuleID, const SerializedModuleBaseName &BaseName,
+    SmallVectorImpl<char> *ModuleInterfacePath,
+    SmallVectorImpl<char> *ModuleInterfaceSourcePath,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+    bool skipBuildingInterface, bool IsFramework) {
 
   // If running in OnlySerialized mode, ModuleInterfaceLoader
   // should not have been constructed at all.
   assert(LoadMode != ModuleLoadingMode::OnlySerialized);
 
-  llvm::SmallString<256>
-  ModPath{ BaseName.getName(file_types::TY_SwiftModuleFile) },
-  InPath{  BaseName.getName(file_types::TY_SwiftModuleInterfaceFile) },
-  PrivateInPath{BaseName.getName(file_types::TY_PrivateSwiftModuleInterfaceFile)};
+  std::string ModPath{BaseName.getName(file_types::TY_SwiftModuleFile)};
 
   // First check to see if the .swiftinterface exists at all. Bail if not.
   auto &fs = *Ctx.SourceMgr.getFileSystem();
-  if (!fs.exists(InPath)) {
+  std::string InPath = BaseName.findInterfacePath(fs).getValueOr("");
+  if (InPath.empty()) {
     if (fs.exists(ModPath)) {
       LLVM_DEBUG(llvm::dbgs()
-        << "No .swiftinterface file found adjacent to module file "
-        << ModPath.str() << "\n");
+                 << "No .swiftinterface file found adjacent to module file "
+                 << ModPath << "\n");
       return std::make_error_code(std::errc::not_supported);
     }
     return std::make_error_code(std::errc::no_such_file_or_directory);
   }
 
-  // If present, use the private interface instead of the public one.
-  if (fs.exists(PrivateInPath)) {
-    InPath = PrivateInPath;
-  }
+  if (ModuleInterfaceSourcePath)
+    ModuleInterfaceSourcePath->assign(InPath.begin(), InPath.end());
 
   // If we've been told to skip building interfaces, we are done here and do
   // not need to have the module actually built. For example, if we are
@@ -1146,7 +1143,7 @@ std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
   // the interface.
   if (skipBuildingInterface) {
     if (ModuleInterfacePath)
-      *ModuleInterfacePath = InPath;
+      ModuleInterfacePath->assign(InPath.begin(), InPath.end());
     return std::error_code();
   }
 
@@ -1170,7 +1167,7 @@ std::error_code ModuleInterfaceLoader::findModuleFilesInDirectory(
   if (ModuleBuffer) {
     *ModuleBuffer = std::move(*ModuleBufferOrErr);
     if (ModuleInterfacePath)
-      *ModuleInterfacePath = InPath;
+      ModuleInterfacePath->assign(InPath.begin(), InPath.end());
   }
 
   // Open .swiftsourceinfo file if it's present.
@@ -1920,12 +1917,13 @@ ExplicitSwiftModuleLoader::ExplicitSwiftModuleLoader(
 
 ExplicitSwiftModuleLoader::~ExplicitSwiftModuleLoader() { delete &Impl; }
 
-bool ExplicitSwiftModuleLoader::findModule(ImportPath::Element ModuleID,
-           SmallVectorImpl<char> *ModuleInterfacePath,
-           std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-           std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-           std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-           bool skipBuildingInterface, bool &IsFramework, bool &IsSystemModule) {
+bool ExplicitSwiftModuleLoader::findModule(
+    ImportPath::Element ModuleID, SmallVectorImpl<char> *ModuleInterfacePath,
+    SmallVectorImpl<char> *ModuleInterfaceSourcePath,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+    bool skipBuildingInterface, bool &IsFramework, bool &IsSystemModule) {
   // Find a module with an actual, physical name on disk, in case
   // -module-alias is used (otherwise same).
   //
@@ -2007,13 +2005,13 @@ bool ExplicitSwiftModuleLoader::findModule(ImportPath::Element ModuleID,
 }
 
 std::error_code ExplicitSwiftModuleLoader::findModuleFilesInDirectory(
-  ImportPath::Element ModuleID,
-  const SerializedModuleBaseName &BaseName,
-  SmallVectorImpl<char> *ModuleInterfacePath,
-  std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-  std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-  std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-  bool skipBuildingInterface, bool IsFramework) {
+    ImportPath::Element ModuleID, const SerializedModuleBaseName &BaseName,
+    SmallVectorImpl<char> *ModuleInterfacePath,
+    SmallVectorImpl<char> *ModuleInterfaceSourcePath,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+    bool skipBuildingInterface, bool IsFramework) {
   llvm_unreachable("Not supported in the Explicit Swift Module Loader.");
   return std::make_error_code(std::errc::not_supported);
 }

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -618,74 +618,88 @@ static void addModuleDependencies(ArrayRef<ImportedModule> imports,
       case FileUnitKind::DWARFModule:
       case FileUnitKind::ClangModule: {
         auto *LFU = cast<LoadedFile>(FU);
-        if (auto F = fileMgr.getFile(LFU->getFilename())) {
-          // Use module real name for unit writer in case module aliasing
-          // is used. For example, if a file being indexed has `import Foo`
-          // and `-module-alias Foo=Bar` is passed, treat Foo as an alias
-          // and Bar as the real module name as its dependency.
-          StringRef moduleName = mod->getRealName().str();
-          bool withoutUnitName = true;
-          if (FU->getKind() == FileUnitKind::ClangModule) {
-            auto clangModUnit = cast<ClangModuleUnit>(LFU);
-            bool shouldIndexModule = indexClangModules &&
-                (!clangModUnit->isSystemModule() || indexSystemModules);
-            withoutUnitName = !shouldIndexModule;
-            if (auto clangMod = clangModUnit->getUnderlyingClangModule()) {
-              moduleName = clangMod->getTopLevelModuleName();
-              // FIXME: clang's -Rremarks do not seem to go through Swift's
-              // diagnostic emitter.
-              if (shouldIndexModule)
-                clang::index::emitIndexDataForModuleFile(clangMod,
-                                                         clangCI, unitWriter);
-              // Emit the symbolic interface file in addition to index data.
-              if (indexClangModules)
-                emitSymbolicInterfaceForClangModule(clangModUnit, mod, clangMod,
-                                                    indexStorePath, clangCI,
-                                                    diags);
-            }
-          } else {
-            // Serialized AST file.
-            // Only index distributed system modules, and the stdlib.
-            // We don't officially support binary swift modules, so normally
-            // the index data for user modules would get generated while
-            // building them.
-            bool isDistributedModule = mod->isSDKModule() ||
-                      mod->getASTContext().SearchPathOpts.getSDKPath().empty();
-            if (mod->isSystemModule() && indexSystemModules &&
-                (isDistributedModule || mod->isStdlibModule()) &&
-                (!skipStdlib || !mod->isStdlibModule())) {
-              emitDataForSwiftSerializedModule(mod, indexStorePath,
-                                               indexClangModules,
-                                               indexSystemModules, skipStdlib,
-                                               includeLocals, targetTriple,
-                                               clangCI, diags,
-                                               unitWriter,
-                                               pathRemapper,
-                                               initialFile);
-              withoutUnitName = false;
-            }
 
-            // If this is a cross-import overlay, make sure we use the name of
-            // the underlying module instead.
-            if (auto *declaring = mod->getDeclaringModuleIfCrossImportOverlay())
-              moduleName = declaring->getNameStr();
-
-            // Emit symbolic interface files for any re-exported Clang modules
-            // from this Swift module.
-            if (mod->getASTContext().LangOpts.EnableCXXInterop) {
-              SmallVector<ImportedModule, 4> imports;
-              mod->getImportedModules(imports,
-                                      ModuleDecl::ImportFilterKind::Exported);
-              if (indexClangModules)
-                emitTransitiveClangSymbolicInterfacesForSwiftModuleImports(
-                    imports, indexStorePath, clangCI, diags);
-            }
-          }
-          clang::index::writer::OpaqueModule opaqMod =
-              moduleNameScratch.createString(moduleName);
-          unitWriter.addASTFileDependency(*F, mod->isSystemModule(), opaqMod,
-                                          withoutUnitName);
+        // This should really be returned from emitting index data, rather
+        // than guessing which is used for the output file here.
+        StringRef modulePath;
+        if (FU->getKind() == FileUnitKind::ClangModule) {
+          modulePath = LFU->getFilename();
+        } else {
+          modulePath = LFU->getSourceFilename();
         }
+
+        auto F = fileMgr.getFile(modulePath);
+        if (!F)
+          break;
+
+        // Use module real name for unit writer in case module aliasing
+        // is used. For example, if a file being indexed has `import Foo`
+        // and `-module-alias Foo=Bar` is passed, treat Foo as an alias
+        // and Bar as the real module name as its dependency.
+        StringRef moduleName = mod->getRealName().str();
+        bool withoutUnitName = true;
+        if (FU->getKind() == FileUnitKind::ClangModule) {
+          auto clangModUnit = cast<ClangModuleUnit>(LFU);
+          bool shouldIndexModule = indexClangModules &&
+              (!clangModUnit->isSystemModule() || indexSystemModules);
+          withoutUnitName = !shouldIndexModule;
+          if (auto clangMod = clangModUnit->getUnderlyingClangModule()) {
+            moduleName = clangMod->getTopLevelModuleName();
+            // FIXME: clang's -Rremarks do not seem to go through Swift's
+            // diagnostic emitter.
+            if (shouldIndexModule)
+              clang::index::emitIndexDataForModuleFile(clangMod,
+                                                       clangCI, unitWriter);
+            // Emit the symbolic interface file in addition to index data.
+            if (indexClangModules)
+              emitSymbolicInterfaceForClangModule(clangModUnit, mod, clangMod,
+                                                  indexStorePath, clangCI,
+                                                  diags);
+          }
+        } else {
+          // Serialized AST file.
+          // Only index distributed system modules, and the stdlib.
+          // We don't officially support binary swift modules, so normally
+          // the index data for user modules would get generated while
+          // building them.
+          bool isDistributedModule = mod->isSDKModule() ||
+                    mod->getASTContext().SearchPathOpts.getSDKPath().empty();
+          if (mod->isSystemModule() && indexSystemModules &&
+              (isDistributedModule || mod->isStdlibModule()) &&
+              (!skipStdlib || !mod->isStdlibModule())) {
+            emitDataForSwiftSerializedModule(mod, indexStorePath,
+                                             indexClangModules,
+                                             indexSystemModules, skipStdlib,
+                                             includeLocals, targetTriple,
+                                             clangCI, diags,
+                                             unitWriter,
+                                             pathRemapper,
+                                             initialFile);
+            withoutUnitName = false;
+          }
+
+          // If this is a cross-import overlay, make sure we use the name of
+          // the underlying module instead.
+          if (auto *declaring = mod->getDeclaringModuleIfCrossImportOverlay())
+            moduleName = declaring->getNameStr();
+
+
+          // Emit symbolic interface files for any re-exported Clang modules
+          // from this Swift module.
+          if (mod->getASTContext().LangOpts.EnableCXXInterop) {
+            SmallVector<ImportedModule, 4> imports;
+            mod->getImportedModules(imports,
+                                    ModuleDecl::ImportFilterKind::Exported);
+            if (indexClangModules)
+              emitTransitiveClangSymbolicInterfacesForSwiftModuleImports(
+                  imports, indexStorePath, clangCI, diags);
+          }
+        }
+        clang::index::writer::OpaqueModule opaqMod =
+            moduleNameScratch.createString(moduleName);
+        unitWriter.addASTFileDependency(*F, mod->isSystemModule(), opaqMod,
+                                        withoutUnitName);
+
         break;
       }
       }
@@ -707,7 +721,7 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
                                  IndexUnitWriter &parentUnitWriter,
                                  const PathRemapper &pathRemapper,
                                  SourceFile *initialFile) {
-  StringRef filename = module->getModuleFilename();
+  StringRef filename = module->getModuleSourceFilename();
   std::string moduleName = module->getNameStr().str();
 
   // If this is a cross-import overlay, make sure we use the name of the
@@ -716,8 +730,9 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
     moduleName = declaring->getNameStr().str();
 
   std::string error;
-  auto isUptodateOpt = parentUnitWriter.isUnitUpToDateForOutputFile(/*FilePath=*/filename,
-                                                                /*TimeCompareFilePath=*/filename, error);
+  auto isUptodateOpt = parentUnitWriter.isUnitUpToDateForOutputFile(
+      /*FilePath=*/filename,
+      /*TimeCompareFilePath=*/filename, error);
   if (!isUptodateOpt.has_value()) {
     diags.diagnose(SourceLoc(), diag::error_index_failed_status_check, error);
     return true;
@@ -822,17 +837,15 @@ emitDataForSwiftSerializedModule(ModuleDecl *module,
   // FIXME: Get real values for the following.
   StringRef swiftVersion;
   StringRef sysrootPath = clangCI.getHeaderSearchOpts().Sysroot;
-  std::string indexUnitToken = module->getModuleFilename().str();
   // For indexing serialized modules 'debug compilation' is irrelevant, so
   // set it to true by default.
   bool isDebugCompilation = true;
   auto clangRemapper = pathRemapper.asClangPathRemapper();
 
-  IndexUnitWriter unitWriter(fileMgr, indexStorePath,
-    "swift", swiftVersion, indexUnitToken, moduleName,
-    /*MainFile=*/nullptr, isSystem, /*IsModuleUnit=*/true,
-    isDebugCompilation, targetTriple, sysrootPath,
-    clangRemapper, getModuleInfoFromOpaqueModule);
+  IndexUnitWriter unitWriter(
+      fileMgr, indexStorePath, "swift", swiftVersion, filename, moduleName,
+      /*MainFile=*/nullptr, isSystem, /*IsModuleUnit=*/true, isDebugCompilation,
+      targetTriple, sysrootPath, clangRemapper, getModuleInfoFromOpaqueModule);
 
   auto FE = fileMgr.getFile(filename);
   bool isSystemModule = module->isSystemModule();

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -24,15 +24,14 @@
 using namespace swift;
 using llvm::ErrorOr;
 
-
 std::error_code ModuleDependencyScanner::findModuleFilesInDirectory(
-                                      ImportPath::Element ModuleID,
-                                      const SerializedModuleBaseName &BaseName,
-                                      SmallVectorImpl<char> *ModuleInterfacePath,
-                                      std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
-                                      std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
-                                      std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
-                                      bool skipBuildingInterface, bool IsFramework) {
+    ImportPath::Element ModuleID, const SerializedModuleBaseName &BaseName,
+    SmallVectorImpl<char> *ModuleInterfacePath,
+    SmallVectorImpl<char> *ModuleInterfaceSourcePath,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleDocBuffer,
+    std::unique_ptr<llvm::MemoryBuffer> *ModuleSourceInfoBuffer,
+    bool skipBuildingInterface, bool IsFramework) {
   using namespace llvm::sys;
 
   auto &fs = *Ctx.SourceMgr.getFileSystem();
@@ -72,6 +71,7 @@ std::error_code ModuleDependencyScanner::findModuleFilesInDirectory(
 
 bool PlaceholderSwiftModuleScanner::findModule(
     ImportPath::Element moduleID, SmallVectorImpl<char> *moduleInterfacePath,
+    SmallVectorImpl<char> *moduleInterfaceSourcePath,
     std::unique_ptr<llvm::MemoryBuffer> *moduleBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *moduleDocBuffer,
     std::unique_ptr<llvm::MemoryBuffer> *moduleSourceInfoBuffer,

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -356,9 +356,9 @@ ModuleFile::getModuleName(ASTContext &Ctx, StringRef modulePath,
   std::shared_ptr<const ModuleFileSharedCore> loadedModuleFile;
   bool isFramework = false;
   serialization::ValidationInfo loadInfo = ModuleFileSharedCore::load(
-      modulePath.str(), std::move(newBuf), nullptr, nullptr,
-      /*isFramework*/ isFramework, Ctx.SILOpts.EnableOSSAModules, Ctx.LangOpts.SDKName,
-      Ctx.SearchPathOpts.DeserializedPathRecoverer,
+      "", "", std::move(newBuf), nullptr, nullptr,
+      /*isFramework=*/isFramework, Ctx.SILOpts.EnableOSSAModules,
+      Ctx.LangOpts.SDKName, Ctx.SearchPathOpts.DeserializedPathRecoverer,
       loadedModuleFile);
   Name = loadedModuleFile->Name.str();
   return std::move(moduleBuf.get());

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -781,12 +781,18 @@ public:
   StringRef getModuleFilename() const {
     if (!Core->ModuleInterfacePath.empty())
       return Core->ModuleInterfacePath;
-    // FIXME: This seems fragile, maybe store the filename separately ?
-    return Core->ModuleInputBuffer->getBufferIdentifier();
+    return getModuleLoadedFilename();
   }
 
   StringRef getModuleLoadedFilename() const {
+    // FIXME: This seems fragile, maybe store the filename separately?
     return Core->ModuleInputBuffer->getBufferIdentifier();
+  }
+
+  StringRef getModuleSourceFilename() const {
+    if (!Core->CorrespondingInterfacePath.empty())
+      return Core->CorrespondingInterfacePath;
+    return getModuleFilename();
   }
 
   StringRef getTargetTriple() const {

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -66,6 +66,10 @@ class ModuleFileSharedCore {
   /// Empty if this module didn't come from an interface file.
   StringRef ModuleInterfacePath;
 
+  /// The module interface path if this module is adjacent to such an interface
+  /// or it was itself compiled from an interface. Empty otherwise.
+  StringRef CorrespondingInterfacePath;
+
   /// The Swift compatibility version in use when this module was built.
   version::Version CompatibilityVersion;
 
@@ -516,12 +520,12 @@ public:
   /// \returns Whether the module was successfully loaded, or what went wrong
   ///          if it was not.
   static serialization::ValidationInfo
-  load(StringRef moduleInterfacePath,
+  load(StringRef moduleInterfacePath, StringRef moduleInterfaceSourcePath,
        std::unique_ptr<llvm::MemoryBuffer> moduleInputBuffer,
        std::unique_ptr<llvm::MemoryBuffer> moduleDocInputBuffer,
        std::unique_ptr<llvm::MemoryBuffer> moduleSourceInfoInputBuffer,
-       bool isFramework, bool requiresOSSAModules,
-       StringRef requiredSDK, PathObfuscator &pathRecoverer,
+       bool isFramework, bool requiresOSSAModules, StringRef requiredSDK,
+       PathObfuscator &pathRecoverer,
        std::shared_ptr<const ModuleFileSharedCore> &theModule) {
     serialization::ValidationInfo info;
     auto *core = new ModuleFileSharedCore(
@@ -532,6 +536,11 @@ public:
       ArrayRef<char> path;
       core->allocateBuffer(path, moduleInterfacePath);
       core->ModuleInterfacePath = StringRef(path.data(), path.size());
+    }
+    if (!moduleInterfaceSourcePath.empty()) {
+      ArrayRef<char> path;
+      core->allocateBuffer(path, moduleInterfaceSourcePath);
+      core->CorrespondingInterfacePath = StringRef(path.data(), path.size());
     }
     theModule.reset(core);
     return info;

--- a/test/Index/Store/unit-one-file-multi-file-invocation.swift
+++ b/test/Index/Store/unit-one-file-multi-file-invocation.swift
@@ -1,5 +1,10 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import -index-file -index-file-path %s %s %S/Inputs/SwiftModuleA.swift -module-name unit_one_test -o %t/00-output_for_index -index-store-path %t/idx
+// RUN: %target-build-swift -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import -module-cache-path %t/modulecache -index-file -index-file-path %s %s %S/Inputs/SwiftModuleA.swift -module-name unit_one_test -o %t/00-output_for_index -index-store-path %t/idx
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s -implicit-check-not SwiftShims
+
+// Remove the index and run again to make sure paths don't change from the module cache
+// RUN: %empty-directory(%t/idx)
+// RUN: %target-build-swift -Xfrontend -disable-implicit-concurrency-module-import -Xfrontend -disable-implicit-string-processing-module-import -module-cache-path %t/modulecache -index-file -index-file-path %s %s %S/Inputs/SwiftModuleA.swift -module-name unit_one_test -o %t/00-output_for_index -index-store-path %t/idx
 // RUN: c-index-test core -print-unit %t/idx | %FileCheck %s -implicit-check-not SwiftShims
 
 // The output is sorted by last path component, so make sure the top-level entry
@@ -7,14 +12,14 @@
 
 // CHECK: 00-output_for_index
 // CHECK: DEPEND START
-// CHECK: Unit | system | Swift | [[MODULE:.*[/\\]Swift[.]swiftmodule([/\\].+[.]swiftmodule)?]] | [[SWIFT:.+[.]swiftmodule-[A-Z0-9]*]]
+// CHECK: Unit | system | Swift | [[MODULE:.*[/\\]Swift[.]swiftmodule([/\\].+[.]swiftinterface)?]] | [[SWIFT:.+[.]swiftinterface-[A-Z0-9]*]]
 // CHECK: Record | user | {{.*}}{{/|\\}}unit-one-file-multi-file-invocation.swift |
 // CHECK: DEPEND END (2)
 
 // CHECK: [[SWIFT]]
 // CHECK: DEPEND START
-// CHECK: Record | system | Swift.Math.Floating | [[MODULE]] | {{.+}}.swiftmodule_Math_Floating-{{.*}}
-// CHECK: Record | system | Swift.String | [[MODULE]] | {{.+}}.swiftmodule_String-{{.*}}
+// CHECK: Record | system | Swift.Math.Floating | [[MODULE]] | {{.+}}.swiftinterface_Math_Floating-{{.*}}
+// CHECK: Record | system | Swift.String | [[MODULE]] | {{.+}}.swiftinterface_String-{{.*}}
 // CHECK: DEPEND END
 
 func test1() {

--- a/test/Index/index_system_modules_swiftinterfaces.swift
+++ b/test/Index/index_system_modules_swiftinterfaces.swift
@@ -1,8 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %empty-directory(%t/modulecache)
 // RUN: split-file %s %t
 
-/// Setup the SDK composed of SecretModule and SystemModule
+/// Setup the SDK composed of SecretModule, SystemModule, SystemDepA, SystemDepB, and SystemDepCommon
 // RUN: %empty-directory(%t/SDK)
 // RUN: mkdir -p %t/SDK/Frameworks/SecretModule.framework/Modules/SecretModule.swiftmodule
 // RUN: %target-swift-frontend -emit-module -module-name SecretModule \
@@ -10,6 +9,31 @@
 // RUN:     -o %t/SDK/Frameworks/SecretModule.framework/Modules/SecretModule.swiftmodule/%module-target-triple.swiftmodule \
 // RUN:     -emit-module-interface-path %t/SDK/Frameworks/SecretModule.framework/Modules/SecretModule.swiftmodule/%module-target-triple.swiftinterface \
 // RUN:     %t/SecretModule.swift
+
+// RUN: mkdir -p %t/SDK/Frameworks/SystemDepCommon.framework/Modules/SystemDepCommon.swiftmodule
+// RUN: %target-swift-frontend -emit-module -module-name SystemDepCommon \
+// RUN:     -swift-version 5 -enable-library-evolution -parse-stdlib \
+// RUN:     -o %t/SDK/Frameworks/SystemDepCommon.framework/Modules/SystemDepCommon.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:     -emit-module-interface-path %t/SDK/Frameworks/SystemDepCommon.framework/Modules/SystemDepCommon.swiftmodule/%module-target-triple.swiftinterface \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     %t/SystemDepCommon.swift
+
+// RUN: mkdir -p %t/SDK/Frameworks/SystemDepA.framework/Modules/SystemDepA.swiftmodule
+// RUN: %target-swift-frontend -emit-module -module-name SystemDepA \
+// RUN:     -swift-version 5 -enable-library-evolution -parse-stdlib \
+// RUN:     -o %t/SDK/Frameworks/SystemDepA.framework/Modules/SystemDepA.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:     -emit-module-interface-path %t/SDK/Frameworks/SystemDepA.framework/Modules/SystemDepA.swiftmodule/%module-target-triple.swiftinterface \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     %t/SystemDepA.swift
+
+// RUN: mkdir -p %t/SDK/Frameworks/SystemDepB.framework/Modules/SystemDepB.swiftmodule
+// RUN: %target-swift-frontend -emit-module -module-name SystemDepB \
+// RUN:     -swift-version 5 -enable-library-evolution -parse-stdlib \
+// RUN:     -o %t/SDK/Frameworks/SystemDepB.framework/Modules/SystemDepB.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:     -emit-module-interface-path %t/SDK/Frameworks/SystemDepB.framework/Modules/SystemDepB.swiftmodule/%module-target-triple.swiftinterface \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     %t/SystemDepB.swift
+
 // RUN: mkdir -p %t/SDK/Frameworks/SystemModule.framework/Modules/SystemModule.swiftmodule
 // RUN: %target-swift-frontend -emit-module -module-name SystemModule \
 // RUN:     -swift-version 5 -enable-library-evolution -parse-stdlib \
@@ -21,6 +45,51 @@
 /// Index a client of SystemModule reading from the swiftinterface.
 /// Because of disable-deserialization-recovery and leakyFunc, reading from
 /// the swiftmodule would crash.
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -swift-version 5 \
+// RUN:     -index-system-modules \
+// RUN:     -index-store-path %t/idx \
+// RUN:     -index-ignore-stdlib \
+// RUN:     -sdk %t/SDK \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -module-cache-path %t/modulecache \
+// RUN:     -Rindexing-system-module -Rmodule-loading \
+// RUN:     %t/Client.swift -disable-deserialization-recovery \
+// RUN:     2>&1 | %FileCheck -check-prefix=SYSTEM-INDEX %s
+// SYSTEM-INDEX: loaded module 'SystemDepCommon'; source: '{{.*}}SystemDepCommon.swiftmodule{{.*}}.swiftinterface'
+// SYSTEM-INDEX: loaded module 'SystemDepCommon'; source: '{{.*}}SystemDepCommon.swiftmodule{{.*}}.swiftinterface'
+// SYSTEM-INDEX-NOT: loaded module {{.*}}SystemDepCommon
+// SYSTEM-INDEX: indexing system module {{.*}}SystemDepCommon.swiftmodule{{.*}}.swiftinterface
+// SYSTEM-INDEX-NOT: loaded module {{.*}}SystemDepCommon
+// SYSTEM-INDEX-NOT: indexing system module {{.*}}SystemDepCommon
+
+/// The index should have the public API of SystemModule
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck -check-prefix=UNIT %s
+// UNIT: Unit | system | SystemModule |
+// UNIT: Record | system | SystemModule |
+// RUN: c-index-test core -print-record %t/idx | %FileCheck -check-prefix=RECORD %s
+// RECORD: function/Swift | systemFunc()
+
+/// Now rebuild the same module. We should not reload or re-index any of the
+/// system modules.
+// RUN: %target-swift-frontend -typecheck -parse-stdlib -swift-version 5 \
+// RUN:     -index-system-modules \
+// RUN:     -index-store-path %t/idx \
+// RUN:     -index-ignore-stdlib \
+// RUN:     -sdk %t/SDK \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -module-cache-path %t/modulecache \
+// RUN:     -Rindexing-system-module -Rmodule-loading \
+// RUN:     %t/Client.swift -disable-deserialization-recovery \
+// RUN:     2>&1 | %FileCheck -check-prefix=SECOND-SYSTEM-INDEX %s
+// SECOND-SYSTEM-INDEX: loaded module 'SystemDepCommon'; source: '{{.*}}SystemDepCommon.swiftmodule{{.*}}.swiftinterface'
+// SECOND-SYSTEM-INDEX-NOT: loaded module {{.*}}SystemDepCommon
+// SECOND-SYSTEM-INDEX-NOT: indexing system module {{.*}}SystemDepCommon
+
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck -check-prefix=UNIT %s
+// RUN: c-index-test core -print-record %t/idx | %FileCheck -check-prefix=RECORD %s
+
+/// Rebuild again, but this time remove the index. We should re-index, but not
+/// reload the module as it was already built.
 // RUN: %empty-directory(%t/idx)
 // RUN: %target-swift-frontend -typecheck -parse-stdlib -swift-version 5 \
 // RUN:     -index-system-modules \
@@ -29,14 +98,17 @@
 // RUN:     -sdk %t/SDK \
 // RUN:     -Fsystem %t/SDK/Frameworks \
 // RUN:     -module-cache-path %t/modulecache \
-// RUN:     %t/Client.swift -disable-deserialization-recovery
+// RUN:     -Rindexing-system-module -Rmodule-loading \
+// RUN:     %t/Client.swift -disable-deserialization-recovery \
+// RUN:     2>&1 | %FileCheck -check-prefix=THIRD-SYSTEM-INDEX %s
+// THIRD-SYSTEM-INDEX: loaded module 'SystemDepCommon'; source: '{{.*}}SystemDepCommon.swiftmodule{{.*}}.swiftinterface'
+// THIRD-SYSTEM-INDEX-NOT: loaded module {{.*}}SystemDepCommon
+// THIRD-SYSTEM-INDEX: indexing system module {{.*}}SystemDepCommon.swiftmodule{{.*}}.swiftinterface
+// THIRD-SYSTEM-INDEX-NOT: loaded module {{.*}}SystemDepCommon
+// THIRD-SYSTEM-INDEX-NOT: indexing system module {{.*}}SystemDepCommon
 
-/// The index should have the public API of SystemModule
 // RUN: c-index-test core -print-unit %t/idx | %FileCheck -check-prefix=UNIT %s
-// UNIT: Unit | system | SystemModule |
-// UNIT: Record | system | SystemModule |
 // RUN: c-index-test core -print-record %t/idx | %FileCheck -check-prefix=RECORD %s
-// RECORD: function/Swift | systemFunc()
 
 /// Index a client reading from a broken swiftinterface
 // RUN: %empty-directory(%t/idx)
@@ -54,7 +126,7 @@
 // RUN:     %t/Client.swift \
 // RUN:     2>&1 | %FileCheck -check-prefix=BROKEN-BUILD %s
 
-/// We don't expect so see the swiftinterface error for indexing
+/// We don't expect to see the swiftinterface error for indexing
 // BROKEN-BUILD-NOT: error
 // BROKEN-BUILD-NOT: breaking_the_swifinterface
 // BROKEN-BUILD: indexing system module {{.*}} skipping
@@ -99,9 +171,23 @@ public struct SecretType {}
 //--- SystemModule.swift
 // Use this dependency to hit an easy deserialization failure when recovery is disabled.
 @_implementationOnly import SecretModule
+// Both these import SystemDepCommon - we want to check that it is only indexed
+// once.
+import SystemDepA
+import SystemDepB
+public func systemFunc() {}
+func leakyFunc(_ a: SecretType) {}
 
-public func systemFunc() { }
-func leakyFunc(_ a: SecretType) { }
+//--- SystemDepA.swift
+import SystemDepCommon
+public func systemDepAFunc() {}
+
+//--- SystemDepB.swift
+import SystemDepCommon
+public func systemDepBFunc() {}
+
+//--- SystemDepCommon.swift
+public func systemDepCommonFunc() {}
 
 //--- Client.swift
 import SystemModule
@@ -109,7 +195,6 @@ import SystemModule
 public func clientFunc() {}
 
 //--- ClientWithError.swift
-
 import SystemModule
 public func clientFunc() {}
 

--- a/test/ModuleInterface/loading-remarks.swift
+++ b/test/ModuleInterface/loading-remarks.swift
@@ -50,7 +50,7 @@ import SwiftNonResilientDependency
 import DirectMixedDependency
 
 // CHECK: remark: loaded module 'SwiftShims'; source: '{{.*}}module.modulemap', loaded: '{{.*}}SwiftShims-{{.*}}.pcm'
-// CHECK: remark: loaded module 'Swift'; source: '{{.*}}Swift.swiftmodule', loaded: '{{.*}}Swift.swiftmodule{{.*}}.swiftmodule'
+// CHECK: remark: loaded module 'Swift'; source: '{{.*}}Swift.swiftmodule{{.*}}.swiftinterface', loaded: '{{.*}}Swift.swiftmodule{{.*}}.swiftmodule'
 // CHECK: remark: loaded module 'SwiftDependency'; source: '{{.*}}SwiftDependency.swiftinterface', loaded: '{{.*}}SwiftDependency-{{.*}}.swiftmodule'
 // CHECK: remark: loaded module 'SwiftNonResilientDependency'; source: '{{.*}}SwiftNonResilientDependency.swiftmodule', loaded: '{{.*}}SwiftNonResilientDependency.swiftmodule'
 // CHECK: remark: loaded module 'IndirectMixedDependency' (overlay for a clang dependency); source: '{{.*}}IndirectMixedDependency.swiftinterface', loaded: '{{.*}}IndirectMixedDependency-{{.*}}.swiftmodule'

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -228,9 +228,10 @@ static void indexModule(llvm::MemoryBuffer *Input,
     // documentation file.
     // FIXME: refactor the frontend to provide an easy way to figure out the
     // correct filename here.
-    auto FUnit = Loader->loadAST(*Mod, None, /*moduleInterfacePath*/"",
+    auto FUnit = Loader->loadAST(*Mod, None, /*moduleInterfacePath=*/"",
+                                 /*moduleInterfaceSourcePath=*/"",
                                  std::move(Buf), nullptr, nullptr,
-                                 /*isFramework*/false);
+                                 /*isFramework=*/false);
 
     // FIXME: Not knowing what went wrong is pretty bad. loadModule() should be
     // more modular, rather than emitting diagnostics itself.

--- a/unittests/FrontendTool/ModuleLoadingTests.cpp
+++ b/unittests/FrontendTool/ModuleLoadingTests.cpp
@@ -126,7 +126,7 @@ protected:
     auto error =
       loader->findModuleFilesInDirectory({moduleName, SourceLoc()},
         SerializedModuleBaseName(tempDir, SerializedModuleBaseName("Library")),
-        /*ModuleInterfacePath*/nullptr,
+        /*ModuleInterfacePath=*/nullptr, /*ModuleInterfaceSourcePath=*/nullptr,
         &moduleBuffer, &moduleDocBuffer, &moduleSourceInfoBuffer,
         /*skipBuildingInterface*/ false, /*IsFramework*/false);
     ASSERT_FALSE(error);


### PR DESCRIPTION
If a module was first read using the adjacent swiftmodule and then
reloaded using the swiftinterface, we would do an up to date check on
the adjacent module but write out the unit using the swiftinterface.
This would cause the same modules to be indexed repeatedly for the first
invocation using a new SDK. On the next run we would instead read the
swiftmodule from the cache and thus the out of date check would match
up.

The impact of this varies depending on the size of the module graph in
the initial compilation and the number of jobs started at the same time.
Each SDK dependency is re-indexed *and* reloaded, which is a drain on
both CPU and memory. Thus, if many jobs are initially started and
they're all going down this path, it can cause the system to run out of
memory very quickly.

Resolves rdar://103119964.