### PR TITLE
Add ownership liveness utilities

### DIFF
--- a/include/swift/SIL/OwnershipLiveness.h
+++ b/include/swift/SIL/OwnershipLiveness.h
@@ -1,0 +1,299 @@
+//===--- OwnershipLiveness.h ---------------------------------*- C++ -*----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// Terminology:
+///
+/// Linear lifetime: All paths through the value's definition to the
+/// function exit pass through exactly one lifetime-ending operation.
+///
+/// Complete OSSA: All owned values and borrow introducers have linear lifetime.
+///
+/// Borrow introducer: defines a guaranteed SILValue and an associated explicit
+/// borrow scope: begin_borrow, load_borrow, store_borrow, and reborrow.  A
+/// "reborrow" is a guaranteed phi for which `isGuaranteedForwarding` returns
+/// false. (Eventually, the phi will know whether it is a reborrow based on a
+/// flag or subclass). Guaranteed function arguments do conceptually introduce
+/// borrow scopes, but their scopes are implied by the function entry and
+/// return points.
+///
+/// Completing an OSSA lifetime is the process of giving an owned value or a
+/// borrow introducer a linear lifetime. This process may require phi creation
+/// whenever a nested scope involves a guaranteed phi that is not dominated by
+/// the outer scope's definition. A new phi will be created that ends the outer
+/// lifetime and begins a new lifetime in the successor block. This new phi will
+/// either forward an owned value or reborrow the outer borrow scope. The new
+/// phi's lifetime will then be recursively extended over the lifetime of the
+/// original guaranteed phi, which we refer to as its inner adjacent phi.
+///
+//===----------------------------------------------------------------------===//
+///
+/// Linear SSA liveness:
+///
+/// - Liveness for a single "defining" owned value or borrow introducing value
+///   assuming the value's lifetime is already linear.
+///
+/// - The definition dominates all use points (phis do not extend the lifetime)
+///
+/// - Only lifetime-ending operations generate liveness
+///
+/// - Oblivious to pointer escapes within the lifetime
+///
+///
+/// Interior SSA liveness:
+///
+/// - Liveness for a single "defining" value with any ownership.
+///
+/// - The definition dominates all use points (phis do not extend the lifetime)
+///
+/// - Does not assume the current lifetime is linear. Transitively follows
+///   guaranteed forwarding and address uses within the current scope.
+///
+/// - Liveness cannot extend beyond lifetime-ending operations
+///   (a.k.a. affine lifetimes).
+///
+/// - Assumes inner scopes *are* linear, including borrow and address scopes
+///   (e.g. begin_borrow, load_borrow, begin_apply, store_borrow, begin_access)
+///   A callback may be used to complete inner scopes before updating liveness.
+///
+/// - Only returns AddressUseKind::PointerEscape if one of the uses of the
+///   outer value has OperandOwnership::PointerEscape or
+///   OperandOwnership::BitwiseEscape. An inner scope's guaranteed value may
+///   escape without causing the outer scope's value to escape.
+///
+/// - Insulates outer scopes from inner scope details. Maintains the
+///   invariant that inlining cannot pessimize optimization.
+///
+/// - Interior SSA liveness is used to complete (linearize) an OSSA lifetime
+///
+/// Interior liveness example:
+///
+///     %struct = struct ...
+///     %f = struct_extract %s     // defines a guaranteed value (%f)
+///     %b = begin_borrow %field
+///     %a = ref_element_addr %b
+///     _  = address_to_pointer %a
+///     end_borrow %b              // the only interior use of %f
+///
+/// When computing interior liveness for %f, %b is an inner scope. Because inner
+/// scopes are complete, the only relevant use is end_borrow %b. Despite the
+/// address_to_pointer instruction, %f does not escape any dependent address.
+///
+/// Transitive SSA liveness
+///
+/// - Similar to Interior SSA liveness, but does not assume that any lifetimes
+///   are linear. Transitively follows uses within inner scopes, recursively
+///   through nested scopes, including forwarding operations and address uses.
+///
+/// - Much more likely to return AddressUseKind::PointerEscape
+///
+/// Transitive liveness example:
+///
+///     %struct = struct ...
+///     %f = struct_extract %s     // defines a guaranteed value (%f)
+///     %b = begin_borrow %field
+///     %a = ref_element_addr %b
+///     _  = address_to_pointer %a // a transitive use of %f escapes
+///
+/// When computing transitive liveness for %f, %b is an inner scope. Liveness
+/// does not assume that an end_borrow exists. Instead it transitively considers
+/// all uses of %b. As a result, %f escapes.
+///
+/// - This header provides no interface for transitive liveness because it is no
+///   longer needed with complete OSSA lifetimes
+///
+/// Extended liveness
+///
+/// - Liveness of a single "defining" value extended beyond its lifetime-ending
+///   operations.
+///
+/// - May refer to copy-extension, phi-extension, or extension over barriers
+///   such as access markers.
+///
+/// - For phi-extension, the definition no longer dominates the use
+///   points. MultiDefPrunedLiveness must be used. Each phi is added as a new
+///   definition.
+///
+/// Extended linear liveness
+///
+/// - Extended liveness that only considers lifetime-ending operations. Assumes
+///   the definition already has a linear lifetime and that any phis that end
+///   the current lifetime also have linear lifetimes.
+///
+/// Extended interior liveness
+///
+/// - Like interior SSA liveness, does not assume the current lifetime is
+///   linear. Transitively follows guaranteed forwarding and address uses within
+///   the current scope. Assumes inner scopes *are* linear.
+///
+/// - Interior copy-extension is used to canonicalize an OSSA lifetime
+///
+/// - This header provides no interface for extended interior liveness because
+///   it is highly specific to a particular task.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_OWNERSHIPLIVENESS_H
+#define SWIFT_SIL_OWNERSHIPLIVENESS_H
+
+#include "swift/Basic/Debug.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/SIL/PrunedLiveness.h"
+#include "swift/SIL/OwnershipUseVisitor.h"
+#include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILValue.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace swift {
+
+/// Analyze SSA liveness of values that introduce an OSSA live range:
+///
+/// 1. Owned non-phi values
+/// 2. Owned phi values
+/// 3. Borrow scope introducers: begin_borrow/load_borrow
+/// 4. Reborrows: guaranteed phis that end their operands' borrow scopes and
+///    require their own post-dominating end_borrows.
+///
+/// Used for OSSA lifetime completion.
+class OSSALiveness {
+protected:
+  SILValue ownershipDef;
+
+  // MARK: Results.
+
+  SmallVector<SILBasicBlock *, 8> discoveredBlocks;
+  SSAPrunedLiveness liveness;
+
+  OSSALiveness(const OSSALiveness &) = delete;
+  OSSALiveness &operator=(const OSSALiveness &) = delete;
+
+public:
+  OSSALiveness(SILValue def): ownershipDef(def), liveness(&discoveredBlocks) {}
+
+  const SSAPrunedLiveness &getLiveness() const { return liveness; }
+
+  ArrayRef<SILBasicBlock *> getDiscoveredBlocks() const {
+    return discoveredBlocks;
+  }
+
+  void print(llvm::raw_ostream &OS) const;
+  void dump() const;
+};
+
+// Internal implementation
+struct LinearLivenessVisitor;
+
+/// Compute ownershipDef's lifetime based on it's lifetime-ending uses, assuming
+/// it is already complete/linear. ownershipDef must be either an owned value or
+/// a local borrow scope introduced (begin_borrow, load_borrow, or
+/// store_borrow).
+///
+/// This is the simplest OSSA liveness analysis, but is not appropriate for
+/// fixing OSSA lifetimes after a transformation and cannot tell you whether
+/// pointer escapes occur.
+class LinearLiveness : public OSSALiveness {
+  friend LinearLivenessVisitor;
+
+public:
+  LinearLiveness(SILValue def);
+
+  void compute();
+};
+
+// Internal implementation
+struct InteriorLivenessVisitor;
+
+/// Compute ownershipDef's lifetime based on all its uses (except those
+/// already enclosed by inner scopes). Returns AddressUseKind::PointerEscape
+/// if a pointer to ownershipDef escapes (and is not already enclosed by an
+/// inner scope).
+class InteriorLiveness : public OSSALiveness {
+  friend InteriorLivenessVisitor;
+
+  // Handle inner scopes. Called for inner reborrows, inner adjacent reborrows,
+  // and address scopes.
+  //
+  // This may add uses to the inner scope, but it may not modify a use-list
+  // in any outer scopes.
+  using InnerScopeHandlerRef = llvm::function_ref<void(SILValue)>;
+
+public:
+  // Summarize address uses
+  AddressUseKind addressUseKind = AddressUseKind::Unknown;
+
+  // Record any guaranteed phi uses that are not already enclosed by an outer
+  // adjacent phi.
+  SmallVector<SILValue, 8> unenclosedPhis;
+
+public:
+  InteriorLiveness(SILValue def): OSSALiveness(def) {}
+
+  void compute(const DominanceInfo *domInfo,
+               InnerScopeHandlerRef handleInnerScope = InnerScopeHandlerRef());
+
+  AddressUseKind getAddressUseKind() const { return addressUseKind; }
+
+  ArrayRef<SILValue> getUnenclosedPhis() const { return unenclosedPhis; }
+
+  void print(llvm::raw_ostream &OS) const;
+  void dump() const;
+};
+
+// Internal implementation
+struct ExtendedLinearLivenessVisitor;
+
+/// Analyze liveness of values that introduce an OSSA live range. This computes
+/// the phi-extended live range for these four categories of live range
+/// introducing values:
+///
+/// 1. Owned non-phi values
+/// 2. Owned phi values
+/// 3. Borrow scope introducers: begin_borrow/load_borrow
+/// 4. Reborrows: guaranteed phis that end their incoming borrow scopes and
+///    begin a new borrow scope
+class ExtendedLinearLiveness {
+  friend ExtendedLinearLivenessVisitor;
+
+  SILValue ownershipDef;
+
+  // MARK: Results.
+
+  // Because of reborrows, the ssa def may not dominate all
+  // uses. Consider the reborrows to be separate defs.
+  SmallVector<SILBasicBlock *, 8> discoveredBlocks;
+  MultiDefPrunedLiveness liveness;
+
+  ExtendedLinearLiveness(const ExtendedLinearLiveness &) = delete;
+  ExtendedLinearLiveness &operator=(const ExtendedLinearLiveness &) = delete;
+
+public:
+  ExtendedLinearLiveness(SILValue def);
+
+  void compute();
+
+  /// The array of defs. The first element is ownershipDef. The remaining
+  /// elements are outer reborrows discovered during computation.
+  ///
+  /// TODO: These are always SILValues. Convert the iterator.
+  NodeSetVector::iterator defBegin() const { return liveness.defBegin(); }
+  NodeSetVector::iterator defEnd() const { return liveness.defBegin(); }
+
+  const MultiDefPrunedLiveness &getLiveness() const { return liveness; }
+
+  void print(llvm::raw_ostream &OS) const;
+  void dump() const;
+};
+
+} // namespace swift
+
+#endif

--- a/include/swift/SIL/OwnershipUseVisitor.h
+++ b/include/swift/SIL/OwnershipUseVisitor.h
@@ -1,0 +1,475 @@
+//===--- OwnershipUseVisitor.h -------------------------------*- C++ -*----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// A visitor that classifies the uses of an OSSA value. The main entry points
+/// are:
+///
+///     bool OwnershipUseVisitor::visitLifetimeEndingUses(SILValue ssaDef)
+///
+///     bool OwnershipUseVisitor::visitInteriorUses(SILValue ssaDef)
+///
+/// Extensions of the visitor determine how to handle pointer escapes,
+/// reborrows, inner borrows, and scoped addresses.
+
+#ifndef SWIFT_SIL_OWNERSHIPUSEVISITOR_H
+#define SWIFT_SIL_OWNERSHIPUSEVISITOR_H
+
+#include "swift/SIL/NodeBits.h"
+#include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/ScopedAddressUtils.h"
+#include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILValue.h"
+
+namespace swift {
+
+enum class OwnershipUseKind { LifetimeEnding, NonLifetimeEnding };
+
+/// Impl provides:
+///
+/// - NodeSet visited (if interior uses are visited)
+///
+/// - 'bool handleUsePoint(Operand *use, UseLifetimeConstraint)'
+///
+///   Where 'use->get()' is either the original SSA def, or the SILValue that
+///   introduces an inner scope for which 'use' ends the scope.
+///
+/// Impl overrides:
+///
+/// - 'bool handlePointerEscape(Operand *use)' (default false)
+///
+/// -  bool handleOwnedPhi(Operand *phiOper) { return true; }
+///
+/// - 'bool handleOuterReborrow(Operand *phiOper)' (default true)
+///
+/// - 'bool handleGuaranteedForward(Operand *use)' (default true)
+///
+/// - 'bool handleInnerBorrow(BorrowingOperand)' (default true)
+///
+/// - 'bool handleInnerAdjacentReborrow(SILArgument *reborrow)' (default true)
+///
+/// - 'bool handleInnerReborrow(Operand *use)' (default true)
+///
+/// - 'bool handleScopedAddress(ScopedAddressValue)' (default true)
+///
+/// These may be overridden with a transformation that adds uses to the use's
+/// instruction or phi, but it may not modify the use-list containing \p
+/// use or \p phiOper or in any outer scopes.
+template <typename Impl>
+class OwnershipUseVisitorBase {
+protected:
+  /// If this returns true, then handleUsePoint will be called as if the pointer
+  /// escape is an instantaneous use. The implementation may decide to track
+  /// AddressUseKind::PointerEscaping. Bail-out by default for safety.
+  bool handlePointerEscape(Operand *use) {
+    return false;
+  }
+
+  /// Handle a owned forwarding phi of the original SSA def. Later, the phi
+  /// will itself be visited as a use but its scope's uses will not be
+  /// transitively visited. The implementation may track owned phis to
+  /// continue processing extended liveness.
+  ///
+  /// Return true to continue visiting other uses.
+  bool handleOwnedPhi(Operand *phiOper) { return true; }
+
+  /// Handle a transitive reborrow of the original SSA def. Later, the reborrow
+  /// will itself be visited as a use but its scope's uses will not be
+  /// transitively visited. The implementation may track outer reborrows to
+  /// continue processing extended liveness.
+  ///
+  /// Return true to continue visiting other uses.
+  bool handleOuterReborrow(Operand *phiOper) { return true; }
+
+  /// Handle a guaranteed forwarding instruction. After the returns, this will
+  /// itself be visited as a use, but its uses will not be transitively
+  /// visited. The implementation may transtitively follow uses or track
+  /// unenclosed guaranteed phis to insert missing reborrows.
+  ///
+  /// Return true to continue visiting other uses.
+  bool handleGuaranteedForwardingPhi(Operand *phiOper) { return true; }
+
+  /// If this returns true, then handleUsePoint will be called on the scope
+  /// ending operands.
+  ///
+  /// Handles begin_borrow, load_borrow, store_borrow, begin_apply
+  ///
+  /// Allows the implementation to complete inner scopes before considering
+  /// their scope ending operations as uses of the outer scope.
+  bool handleInnerBorrow(BorrowingOperand borrowingOperand) {
+    return true;
+  }
+
+  /// Handles an inner adjacent phi where ownershipDef is a phi in the same
+  /// block.
+  ///
+  /// If this returns true, then handleUsePoint will be called on the
+  /// reborrow's immediate scope ending uses are visited, along with
+  /// handleInnerBorrow for any uses that are also reborrows.
+  bool handleInnerAdjacentReborrow(SILArgument *reborrow) {
+    return true;
+  }
+
+  /// Handle an inner reborrow. Later, the reborrow will itself be visited as a
+  /// use, but its scope's uses will not be transitively visited. The
+  /// implementation may track the reborrow to insert missing reborrows or to
+  /// continue processing extended liveness.
+  ///
+  /// Return true to continue visiting other uses.
+  bool handleInnerReborrow(Operand *phiOper) { return true; }
+
+  /// If this returns true, then handleUsePoint will be called on the scope
+  /// ending operands.
+  ///
+  /// Allows the implementation to complete inner scopes before considering
+  /// their scope ending operations as uses of the outer scope.
+  ///
+  /// This may add uses to the inner scope, but it may not modify the use-list
+  /// containing \p scopedAddress or in any outer scopes.
+  bool handleScopedAddress(ScopedAddressValue scopedAddress) {
+    return true;
+  }
+};
+
+/// Visit uses relevant to liveness of a single OSSA value.
+template <typename Impl>
+class OwnershipUseVisitor : OwnershipUseVisitorBase<Impl> {
+protected:
+  Impl &asImpl() { return static_cast<Impl &>(*this); }
+
+  bool handleUsePoint(Operand *use, UseLifetimeConstraint useConstraint) {
+    asImpl().handleUsePoint(use, useConstraint);
+    return true;
+  }
+
+public:
+  /// Assumes that ssaDef's lifetime is complete (linear).
+  bool visitLifetimeEndingUses(SILValue ssaDef);
+
+  /// Does not assume that ssaDef's lifetime is complete.
+  ///
+  /// If ssaDef is either an owned phi or reborrow, then find inner adjacent
+  /// phis and treat them just like inner borrow scopes.
+  bool visitInteriorUses(SILValue ssaDef);
+
+protected:
+  bool visitConsumes(SILValue ssaDef);
+
+  bool visitOuterBorrow(SILValue borrowBegin);
+
+  bool visitOuterBorrowScopeEnd(Operand *borrowEnd);
+
+  bool visitInnerBorrow(Operand *borrowingOperand);
+
+  bool visitInnerAdjacentReborrow(SILArgument *reborrow);
+  
+  bool visitInnerBorrowScopeEnd(Operand *borrowEnd);
+
+  bool visitOwnedUse(Operand *use);
+
+  bool visitGuaranteedUses(SILValue guaranteedValue) {
+    for (Operand *use : guaranteedValue->getUses()) {
+      if (!visitGuaranteedUse(use))
+        return false;
+    }
+    return true;
+  }
+
+  bool visitGuaranteedUse(Operand *use);
+
+  bool visitInteriorPointerUses(Operand *use);
+};
+
+/// Recursively visit all lifetime-ending uses that contribute to the ownership
+/// live range of \p ssaDef. This assumes that ssaDef has a complete
+/// lifetime and ignores non-lifetime-ending uses.
+template <typename Impl>
+bool OwnershipUseVisitor<Impl>::visitLifetimeEndingUses(SILValue ssaDef) {
+  switch (ssaDef->getOwnershipKind()) {
+  case OwnershipKind::Owned:
+    return visitConsumes(ssaDef);
+
+  case OwnershipKind::Guaranteed:
+    return visitOuterBorrow(ssaDef);
+
+  case OwnershipKind::Any:
+  case OwnershipKind::None:
+  case OwnershipKind::Unowned:
+    llvm_unreachable("requires an owned or guaranteed orignalDef");
+  }
+  return true;
+}
+
+template <typename Impl>
+bool OwnershipUseVisitor<Impl>::visitConsumes(SILValue ssaDef) {
+  for (Operand *use : ssaDef->getUses()) {
+    if (use->isConsuming()) {
+      if (PhiOperand(use) && !asImpl().handleOwnedPhi(use))
+        return false;
+        
+      if (!handleUsePoint(use, UseLifetimeConstraint::LifetimeEnding))
+        return false;
+    }
+  }
+  return true;
+}
+
+template <typename Impl>
+bool OwnershipUseVisitor<Impl>::visitOuterBorrow(SILValue borrowBegin) {
+  BorrowedValue borrow(borrowBegin);
+  assert(borrow && "guaranteed values have no lifetime ending uses");
+  return borrow.visitLocalScopeEndingUses([this](Operand *borrowEnd) {
+    return visitOuterBorrowScopeEnd(borrowEnd);
+  });
+}
+
+template <typename Impl>
+bool OwnershipUseVisitor<Impl>::visitOuterBorrowScopeEnd(Operand *borrowEnd) {
+  switch (borrowEnd->getOperandOwnership()) {
+  case OperandOwnership::EndBorrow:
+    return handleUsePoint(borrowEnd, UseLifetimeConstraint::LifetimeEnding);
+
+  case OperandOwnership::Reborrow:
+    if (!asImpl().handleOuterReborrow(borrowEnd))
+      return false;
+
+    return handleUsePoint(borrowEnd, UseLifetimeConstraint::LifetimeEnding);
+
+  default:
+    llvm_unreachable("expected borrow scope end");
+  }
+}
+
+/// Visit the lifetime-ending uses of borrow scope
+/// (begin_borrow, load_borrow, or begin_apply).
+template <typename Impl>
+bool OwnershipUseVisitor<Impl>::visitInnerBorrow(Operand *borrowingOperand) {
+  if (!asImpl().handleInnerBorrow(borrowingOperand))
+    return false;
+
+  return BorrowingOperand(borrowingOperand)
+    .visitScopeEndingUses([&](Operand *borrowEnd) {
+      return visitInnerBorrowScopeEnd(borrowEnd);
+    });
+}
+
+template <typename Impl>
+bool OwnershipUseVisitor<Impl>::
+visitInnerAdjacentReborrow(SILArgument *reborrow) {
+  if (!asImpl().handleInnerAdjacentReborrow(reborrow))
+    return false;
+
+  return
+    BorrowedValue(reborrow).visitLocalScopeEndingUses([&](Operand *borrowEnd) {
+      return visitInnerBorrowScopeEnd(borrowEnd);
+    });
+}
+
+/// Note: borrowEnd->get() may be a borrow introducer for an inner scope, or a
+/// borrow scopes that does not introduce a borrowed value (begin_apply).
+template <typename Impl>
+bool OwnershipUseVisitor<Impl>::visitInnerBorrowScopeEnd(Operand *borrowEnd) {
+  switch (borrowEnd->getOperandOwnership()) {
+  case OperandOwnership::EndBorrow:
+    return handleUsePoint(borrowEnd, UseLifetimeConstraint::NonLifetimeEnding);
+
+  case OperandOwnership::Reborrow:
+    if (!asImpl().handleInnerReborrow(borrowEnd))
+      return false;
+
+    return handleUsePoint(borrowEnd, UseLifetimeConstraint::NonLifetimeEnding);
+
+  default:
+    llvm_unreachable("expected borrow scope end");
+  }
+}
+
+/// Recursively visit all uses that contribute to the ownership live range of \p
+/// ssaDef. This does not assume that ssaDef has a complete lifetime
+/// and visits non-lifetime-ending uses.
+///
+/// If ssaDef is a phi (owned or reborrowed), then find its inner adjacent phis
+/// and treat them like inner borrows.
+template <typename Impl>
+bool OwnershipUseVisitor<Impl>::visitInteriorUses(SILValue ssaDef) {
+  // Inner adjacent reborrows are considered inner borrow scopes.
+  if (auto phi = SILArgument::asPhi(ssaDef)) {
+    if (!visitInnerAdjacentPhis(phi, [&](SILArgument *innerPhi) {
+      // TODO: Remove this call to isGuaranteedForwarding.
+      // The phi itself should know if it is a reborrow.
+      if (isGuaranteedForwarding(innerPhi)) {
+        return visitGuaranteedUses(innerPhi);
+      } else {
+        return visitInnerAdjacentReborrow(innerPhi);
+      }
+    })) {
+      return false;
+    }
+  }
+  switch (ssaDef->getOwnershipKind()) {
+  case OwnershipKind::Owned: {
+    for (Operand *use : ssaDef->getUses()) {
+      if (!visitOwnedUse(use))
+        return false;
+    }
+    return true;
+  }
+  case OwnershipKind::Guaranteed: {
+    return visitGuaranteedUses(ssaDef);
+  }
+
+  case OwnershipKind::Any:
+  case OwnershipKind::None:
+  case OwnershipKind::Unowned:
+    llvm_unreachable("requires an owned or guaranteed orignalDef");
+  }
+}
+
+template <typename Impl>
+bool OwnershipUseVisitor<Impl>::visitOwnedUse(Operand *use) {
+  switch (use->getOperandOwnership()) {
+  case OperandOwnership::NonUse:
+    return true;
+
+  case OperandOwnership::ForwardingConsume:
+  case OperandOwnership::DestroyingConsume:
+    if (auto phiOper = PhiOperand(use)) {
+      if (!asImpl().handleOwnedPhi(use))
+        return false;
+    }
+    return handleUsePoint(use, UseLifetimeConstraint::LifetimeEnding);
+
+  case OperandOwnership::PointerEscape:
+    if (!asImpl().handlePointerEscape(use))
+      return false;
+
+    LLVM_FALLTHROUGH;
+  case OperandOwnership::InstantaneousUse:
+  case OperandOwnership::ForwardingUnowned:
+  case OperandOwnership::UnownedInstantaneousUse:
+  case OperandOwnership::BitwiseEscape:
+    return handleUsePoint(use, UseLifetimeConstraint::NonLifetimeEnding);
+
+  case OperandOwnership::Borrow:
+    return visitInnerBorrow(use);
+
+  // TODO: Eventually, handle owned InteriorPointers as implicit borrows.
+  case OperandOwnership::InteriorPointer:
+  case OperandOwnership::TrivialUse:
+  case OperandOwnership::EndBorrow:
+  case OperandOwnership::Reborrow:
+  case OperandOwnership::GuaranteedForwarding:
+    llvm_unreachable("ownership incompatible with an owned value");
+  }
+}
+
+template <typename Impl>
+bool OwnershipUseVisitor<Impl>::visitGuaranteedUse(Operand *use) {
+  switch (use->getOperandOwnership()) {
+  case OperandOwnership::NonUse:
+    return true;
+
+  case OperandOwnership::PointerEscape:
+    if (!asImpl().handlePointerEscape(use))
+      return false;
+
+    LLVM_FALLTHROUGH;
+  case OperandOwnership::InstantaneousUse:
+  case OperandOwnership::ForwardingUnowned:
+  case OperandOwnership::UnownedInstantaneousUse:
+  case OperandOwnership::BitwiseEscape:
+  case OperandOwnership::EndBorrow:
+    return handleUsePoint(use, UseLifetimeConstraint::NonLifetimeEnding);
+
+  case OperandOwnership::Reborrow:
+    if (!asImpl().handleOuterReborrow(use))
+      return false;
+
+    return handleUsePoint(use, UseLifetimeConstraint::LifetimeEnding);
+
+  case OperandOwnership::GuaranteedForwarding:
+    if (!handleUsePoint(use, UseLifetimeConstraint::NonLifetimeEnding))
+      return false;
+
+    if (PhiOperand(use)) {
+      return asImpl().handleGuaranteedForwardingPhi(use);
+    }
+
+    if (!asImpl().visited.insert(use->getUser()->asSILNode()))
+      return true;
+
+    return ForwardingOperand(use).visitForwardedValues([&](SILValue result) {
+      // Do not include transitive uses with 'none' ownership
+      if (result->getOwnershipKind() != OwnershipKind::None) {
+        return visitGuaranteedUses(result);
+      }
+      return true;
+    });
+
+  case OperandOwnership::Borrow:
+    return visitInnerBorrow(use);
+
+  case OperandOwnership::InteriorPointer:
+    return visitInteriorPointerUses(use);
+
+  case OperandOwnership::TrivialUse:
+  case OperandOwnership::ForwardingConsume:
+  case OperandOwnership::DestroyingConsume:
+    llvm_unreachable("ownership incompatible with a guaranteed value");
+  }
+}
+
+template <typename Impl>
+bool OwnershipUseVisitor<Impl>::visitInteriorPointerUses(Operand *use) {
+  assert(use->getOperandOwnership() == OperandOwnership::InteriorPointer);
+
+  if (auto scopedAddress = ScopedAddressValue::forUse(use)) {
+    // e.g. client may need to insert end_borrow if scopedAddress is a store_borrow.
+    if (!asImpl().handleScopedAddress(scopedAddress))
+      return false;
+
+    return scopedAddress.visitScopeEndingUses([this](Operand *end) {
+        return handleUsePoint(end, UseLifetimeConstraint::NonLifetimeEnding);
+      });
+  }
+  handleUsePoint(use, UseLifetimeConstraint::NonLifetimeEnding);
+
+  auto interiorPtrOp = InteriorPointerOperand(use);
+  if (interiorPtrOp.getProjectedAddress()->use_empty()) {
+    // findTransitiveUses reports PointerEscape for a dead interior address. But
+    // the use-point was already recorded above. So it's safe to simply return.
+    return true;
+  }
+
+  // TODO: findTransitiveUses should be a visitor so we're not recursively
+  // allocating use vectors and potentially merging the use points.
+  //
+  // TODO: handleInnerBorrow needs to be called for any transitive load_borrow
+  // uses to ensure their lifetimes are complete. For now, findTransitiveUses
+  // just assumes that all scopes are incomplete.
+  SmallVector<Operand *, 8> interiorUses;
+  auto useKind = InteriorPointerOperand(use).findTransitiveUses(&interiorUses);
+  if (useKind == AddressUseKind::PointerEscape) {
+    if (!asImpl().handlePointerEscape(use))
+      return false;
+  }
+  for (auto *interiorUse : interiorUses) {
+    if (!handleUsePoint(interiorUse, UseLifetimeConstraint::NonLifetimeEnding))
+      return false;
+  }
+  return true;
+}
+
+} // namespace swift
+
+#endif

--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -275,9 +275,6 @@ public:
   SILValue getSingleForwardedValue() const;
 };
 
-/// Returns true if the instruction is a 'reborrow'.
-bool isReborrowInstruction(const SILInstruction *inst);
-
 class BorrowingOperandKind {
 public:
   enum Kind : uint8_t {

--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -35,6 +35,10 @@ inline bool requiresOSSACleanup(SILValue v) {
          v->getOwnershipKind() != OwnershipKind::Unowned;
 }
 
+//===----------------------------------------------------------------------===//
+//                   Basic scope and lifetime extension API
+//===----------------------------------------------------------------------===//
+
 /// Rewrite the lifetime of \p ownedValue to match \p lifetimeBoundary. This may
 /// insert copies at forwarding consumes, including phis.
 ///

--- a/lib/SIL/Utils/CMakeLists.txt
+++ b/lib/SIL/Utils/CMakeLists.txt
@@ -11,6 +11,7 @@ target_sources(swiftSIL PRIVATE
   MemAccessUtils.cpp
   MemoryLocations.cpp
   OptimizationRemark.cpp
+  OwnershipLiveness.cpp
   OwnershipUtils.cpp
   PrettyStackTrace.cpp
   Projection.cpp

--- a/lib/SIL/Utils/OwnershipLiveness.cpp
+++ b/lib/SIL/Utils/OwnershipLiveness.cpp
@@ -1,0 +1,357 @@
+//===--- OwnershipLiveness.cpp --------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/Debug.h"
+#include "swift/Basic/Defer.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/SIL/Dominance.h"
+#include "swift/SIL/OwnershipLiveness.h"
+#include "swift/SIL/PrunedLiveness.h"
+#include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILValue.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace swift {
+
+void OSSALiveness::print(llvm::raw_ostream &OS) const { liveness.print(OS); }
+
+void OSSALiveness::dump() const { print(llvm::dbgs()); }
+
+struct LinearLivenessVisitor :
+  public OwnershipUseVisitor<LinearLivenessVisitor> {
+
+  LinearLiveness &linearLiveness;
+
+  LinearLivenessVisitor(LinearLiveness &linearLiveness):
+    linearLiveness(linearLiveness){}
+
+  bool handleUsePoint(Operand *use, UseLifetimeConstraint useConstraint) {
+    linearLiveness.liveness.updateForUse(
+      use->getUser(), useConstraint == UseLifetimeConstraint::LifetimeEnding);
+    return true;
+  }
+
+  bool handlePointerEscape(Operand *use) {
+    llvm_unreachable("a pointer escape cannot end a linear lifetime");
+  }
+
+  // handleOwnedPhi and handleOuterReborrow ends the linear lifetime.
+  // By default, they are treated like a normal lifetime-ending use.
+
+  bool handleGuaranteedForwardingPhi(Operand *use) {
+    llvm_unreachable("guaranteed forwarding phi cannot end a linear lifetime");
+  }
+
+  bool handleInnerBorrow(BorrowingOperand borrowingOperand) {
+    llvm_unreachable("an inner borrow cannot end a linear lifetime");
+  }
+
+  bool handleInnerAdjacentReborrow(SILArgument *reborrow) {
+    llvm_unreachable("inner adjacent reborrows are not visited");
+  }
+
+  bool handleInnerReborrow(BorrowingOperand borrowingOperand) {
+    llvm_unreachable("an inner borrow cannot end a linear lifetime");
+  }
+
+  bool handleScopedAddress(ScopedAddressValue scopedAddress) {
+    llvm_unreachable("an scoped address cannot end a linear lifetime");
+  }
+};
+
+LinearLiveness::LinearLiveness(SILValue def): OSSALiveness(def) {
+  if (def->getOwnershipKind() != OwnershipKind::Owned) {
+    BorrowedValue borrowedValue(def);
+    assert(borrowedValue && borrowedValue.isLocalScope());
+    (void)borrowedValue;
+  }
+}
+
+void LinearLiveness::compute() {
+  liveness.initializeDef(ownershipDef);
+  LinearLivenessVisitor(*this).visitLifetimeEndingUses(ownershipDef);
+}
+
+struct InteriorLivenessVisitor :
+  public OwnershipUseVisitor<InteriorLivenessVisitor> {
+
+  InteriorLiveness &interiorLiveness;
+  const DominanceInfo *domInfo = nullptr;
+
+  /// handleInnerScopeCallback may add uses to the inner scope, but it may not
+  /// modify the use-list containing \p borrowingOperand. This callback can be
+  /// used to ensure that the inner scope is complete before visiting its scope
+  /// ending operands.
+  ///
+  /// An inner scope encapsulates any pointer escapes so visiting its interior
+  /// uses is not necessary when visiting the outer scope's interior uses.
+  InteriorLiveness::InnerScopeHandlerRef handleInnerScopeCallback;
+
+  // State local to an invocation of
+  // OwnershipUseVisitor::visitOwnershipUses().
+  NodeSet visited;
+
+  InteriorLivenessVisitor(
+    InteriorLiveness &interiorLiveness,
+    const DominanceInfo *domInfo,
+    InteriorLiveness::InnerScopeHandlerRef handleInnerScope)
+    : interiorLiveness(interiorLiveness),
+      domInfo(domInfo),
+      handleInnerScopeCallback(handleInnerScope),
+      visited(interiorLiveness.ownershipDef->getFunction()) {}
+
+  bool handleUsePoint(Operand *use, UseLifetimeConstraint useConstraint) {
+    interiorLiveness.liveness.updateForUse(
+      use->getUser(), useConstraint == UseLifetimeConstraint::LifetimeEnding);
+    return true;
+  }
+
+  bool handlePointerEscape(Operand *use) {
+    interiorLiveness.addressUseKind = AddressUseKind::PointerEscape;
+    return true;
+  }
+
+  // handleOwnedPhi and handleOuterReborrow ends the linear lifetime.
+  // By default, they are treated like a normal lifetime-ending use.
+
+  bool handleGuaranteedForwardingPhi(Operand *use) {
+    recursivelyVisitInnerGuaranteedPhi(PhiOperand(use), /*reborrow*/false);
+    return true;
+  }
+
+  /// After this returns true, handleUsePoint will be called on the scope
+  /// ending operands.
+  ///
+  /// Handles begin_borrow, load_borrow, store_borrow, begin_apply.
+  bool handleInnerBorrow(BorrowingOperand borrowingOperand) {
+    if (handleInnerScopeCallback) {
+      handleInnerScopeCallback(
+        borrowingOperand.getBorrowIntroducingUserResult().value);
+    }
+    return true;
+  }
+
+  bool handleInnerAdjacentReborrow(SILArgument *reborrow) {
+    if (handleInnerScopeCallback) {
+      handleInnerScopeCallback(reborrow);
+    }
+    return true;
+  }
+
+  bool handleInnerReborrow(Operand *phiOper) {
+    recursivelyVisitInnerGuaranteedPhi(PhiOperand(phiOper), /*reborrow*/true);
+    return true;
+  }
+
+  /// After this returns true, handleUsePoint will be called on the scope
+  /// ending operands.
+  ///
+  /// Handles store_borrow, begin_access.
+  bool handleScopedAddress(ScopedAddressValue scopedAddress) {
+    if (handleInnerScopeCallback) {
+      handleInnerScopeCallback(scopedAddress.value);
+    }
+    return true;
+  }
+
+  void recursivelyVisitInnerGuaranteedPhi(PhiOperand phiOper, bool isReborrow);
+};
+
+// Dominating ownershipDef example: handleReborrow must continue visiting phi
+// uses:
+//
+// bb0:
+//  d1 = ...
+//  cond_br bb1, bb2
+// bb1:
+//   b1 = borrow d1
+//   br bb3(b1)
+// bb2:
+//   b2 = borrow d1
+//   br bb3(b2)
+// bb3(reborrow):
+//   u1 = d1
+//   u2 = reborrow
+//   // can't move destroy above u2
+//   destroy_value d1
+//
+// Dominating ownershipDef example: handleGuaranteedForwardingPhi must continue
+// visiting phi uses:
+//
+// bb0:
+//  b1 = borrow d1
+//  cond_br bb1, bb2
+// bb1:
+//   p1 = projection b1
+//   br bb3(p1)
+// bb2:
+//   p1 = projection b1
+//   br bb3(p2)
+// bb3(forwardingPhi):
+//   u1 = b1
+//   u2 = forwardingPhi
+//   // can't move end_borrow above u2
+//   end_borrow b1
+//
+// TODO: when phi's have a reborrow flag, remove \p isReborrow.
+void InteriorLivenessVisitor::
+recursivelyVisitInnerGuaranteedPhi(PhiOperand phiOper, bool isReborrow) {
+  SILValue phiValue = phiOper.getValue();
+  if (!visited.insert(phiValue))
+    return;
+
+  if (!visitEnclosingDefs(phiValue, [this](SILValue enclosingDef){
+    // If the enclosing def is \p ownershipDef, return false to check
+    // dominance.
+    if (enclosingDef == interiorLiveness.ownershipDef)
+      return false;
+
+    // Otherwise, phiValue is enclosed by an outer adjacent phi, so its scope
+    // does not contribute to the outer liveness. This phi will be recorded as a
+    // regular use by the visitor, and this enclosing def will be visited as
+    // separate lifetime-ending-use use. Return true to continue checking if any
+    // other enclosing defs do not have an outer adjacent reborrow.
+    return true;
+  })) {
+    // At least one enclosing def is ownershipDef. If ownershipDef dominates
+    // phiValue, then this is consistent with a well-formed linear lifetime, and
+    // the phi's uses directly contribute to ownershipDef's liveness.
+    if (domInfo->dominates(interiorLiveness.ownershipDef->getParentBlock(),
+                           phiValue->getParentBlock())) {
+      if (isReborrow) {
+        visitInnerBorrow(phiOper.getOperand());
+      } else {
+        visitInteriorUses(phiValue);
+      }
+      return;
+    }
+    // ownershipDef does not dominate this phi. Record it so the liveness
+    // client can use this information to insert the missing outer adjacent phi.
+    interiorLiveness.unenclosedPhis.push_back(phiValue);
+  }
+}
+
+void InteriorLiveness::compute(const DominanceInfo *domInfo, InnerScopeHandlerRef handleInnerScope) {
+  liveness.initializeDef(ownershipDef);
+  addressUseKind = AddressUseKind::NonEscaping;
+  InteriorLivenessVisitor(*this, domInfo, handleInnerScope)
+    .visitInteriorUses(ownershipDef);
+}
+
+void InteriorLiveness::print(llvm::raw_ostream &OS) const {
+  OSSALiveness::print(OS);
+
+  switch (getAddressUseKind()) {
+  case AddressUseKind::NonEscaping:
+    OS << "Complete liveness\n";
+    break;
+  case AddressUseKind::PointerEscape:
+    OS << "Incomplete liveness: Escaping address\n";
+    break;
+  case AddressUseKind::Unknown:
+    OS << "Incomplete liveness: Unknown address use\n";
+    break;
+  }
+  OS << "Unenclosed phis {\n";
+  for (SILValue phi : getUnenclosedPhis()) {
+    OS << "  " << phi;
+  }
+  OS << "}\n";
+}
+
+void InteriorLiveness::dump() const { print(llvm::dbgs()); }
+
+// =============================================================================
+// ExtendedLinearLiveness
+// =============================================================================
+  
+struct ExtendedLinearLivenessVisitor
+    : public OwnershipUseVisitor<ExtendedLinearLivenessVisitor> {
+
+  ExtendedLinearLiveness &extendedLiveness;
+
+  // State local to an invocation of
+  // OwnershipUseVisitor::visitOwnershipUses().
+  InstructionSet visited;
+
+  ExtendedLinearLivenessVisitor(ExtendedLinearLiveness &extendedLiveness)
+    : extendedLiveness(extendedLiveness),
+      visited(extendedLiveness.ownershipDef->getFunction()) {}
+
+  bool handleUsePoint(Operand *use, UseLifetimeConstraint useConstraint) {
+    extendedLiveness.liveness.updateForUse(
+      use->getUser(), useConstraint == UseLifetimeConstraint::LifetimeEnding);
+    return true;
+  }
+
+  bool handlePointerEscape(Operand *use) {
+    llvm_unreachable("a pointer escape cannot end a linear lifetime");
+  }
+
+  bool handleOwnedPhi(Operand *phiOper) {
+    extendedLiveness.liveness.initializeDef(PhiOperand(phiOper).getValue());
+    return true;
+  }
+
+  bool handleOuterReborrow(Operand *phiOper) {
+    extendedLiveness.liveness.initializeDef(PhiOperand(phiOper).getValue());
+    return true;
+  }
+
+  bool handleGuaranteedForwardingPhi(Operand *use) {
+    llvm_unreachable("guaranteed forwarding phi cannot end a linear lifetime");
+  }
+
+  bool handleInnerBorrow(BorrowingOperand borrowingOperand) {
+    llvm_unreachable("an inner borrow cannot end a linear lifetime");
+  }
+
+  bool handleInnerAdjacentReborrow(SILArgument *reborrow) {
+    llvm_unreachable("inner adjacent reborrows are not visited");
+  }
+
+  bool handleInnerReborrow(BorrowingOperand borrowingOperand) {
+    llvm_unreachable("an inner borrow cannot end a linear lifetime");
+  }
+
+  bool handleScopedAddress(ScopedAddressValue scopedAddress) {
+    llvm_unreachable("an scoped address cannot end a linear lifetime");
+  }
+};
+
+ExtendedLinearLiveness::ExtendedLinearLiveness(SILValue def)
+  : ownershipDef(def), liveness(def->getFunction(), &discoveredBlocks) {
+  if (def->getOwnershipKind() != OwnershipKind::Owned) {
+    BorrowedValue borrowedValue(def);
+    assert(borrowedValue && borrowedValue.isLocalScope());
+    (void)borrowedValue;
+  }
+}
+
+void ExtendedLinearLiveness::compute() {
+  liveness.initializeDef(ownershipDef);
+  for (auto defIter = liveness.defBegin(); defIter != liveness.defEnd();
+       ++defIter) {
+    auto *def = cast<ValueBase>(*defIter);
+    ExtendedLinearLivenessVisitor(*this).visitLifetimeEndingUses(def);
+  }
+}
+
+void ExtendedLinearLiveness::print(llvm::raw_ostream &OS) const {
+  liveness.print(OS);
+}
+
+void ExtendedLinearLiveness::dump() const { print(llvm::dbgs()); }
+
+} // namespace swift

--- a/test/SILOptimizer/ownership_liveness_unit.sil
+++ b/test/SILOptimizer/ownership_liveness_unit.sil
@@ -1,0 +1,737 @@
+// RUN: %target-sil-opt -unit-test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+//
+// TODO: when complete lifetime verification become the default for SIL verification,
+// then consider moving all tests with 'unreachable' into a separate file with the flag
+// -disable-ownership-verification
+
+sil_stage canonical
+
+import Builtin
+
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
+class C {}
+class D {
+  var object: C
+  @_borrowed @_hasStorage var borrowed: C { get set }
+}
+
+struct PairC {
+  var first: C
+  var second: C
+}
+
+sil @getC : $@convention(thin) () -> @owned C
+
+// =============================================================================
+// LinearLiveness
+// =============================================================================
+
+// CHECK-LABEL: begin running test 1 of 1 on testLinearRefElementEscape: linear-liveness with: @trace[0]
+// CHECK-LABEL: Linear liveness:
+// CHECK: lifetime-ending user:
+// CHECK-SAME: end_borrow
+// CHECK-NEXT: last user:   end_borrow
+// CHECK-NEXT: end running test 1 of 1 on testLinearRefElementEscape
+sil [ossa] @testLinearRefElementEscape : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  test_specification "linear-liveness @trace[0]"
+  %borrow = begin_borrow %0 : $C
+  debug_value [trace] %borrow : $C
+  cond_br undef, bb1, bb2
+
+bb1:
+  %d1 = unchecked_ref_cast %0 : $C to $D
+  %f1 = ref_element_addr %d1 : $D, #D.object
+  %p1 = address_to_pointer %f1 : $*C to $Builtin.RawPointer
+  br bb3(%d1 : $D)
+  
+bb2:
+  %d2 = unchecked_ref_cast %0 : $C to $D
+  %f2 = ref_element_addr %d2 : $D, #D.object  
+  %p2 = address_to_pointer %f2 : $*C to $Builtin.RawPointer
+  br bb3(%d2 : $D)
+
+bb3(%phi : @guaranteed $D):
+  end_borrow %borrow : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testLinearBitwiseEscape: linear-liveness with: @trace[0]
+// CHECK: Linear liveness:
+// CHECK: lifetime-ending user:
+// CHECK-SAME: end_borrow
+// CHECK-NEXT: last user:   end_borrow
+// CHECK-NEXT: end running test 1 of 1 on testLinearBitwiseEscape
+sil [ossa] @testLinearBitwiseEscape : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  test_specification "linear-liveness @trace[0]"
+  %borrow = begin_borrow %0 : $C
+  debug_value [trace] %borrow : $C
+  cond_br undef, bb1, bb2
+
+bb1:
+  %d1 = unchecked_bitwise_cast %0 : $C to $D
+  br bb3(%d1 : $D)
+  
+bb2:
+  %d2 = unchecked_bitwise_cast %0 : $C to $D
+  br bb3(%d2 : $D)
+
+bb3(%phi : @unowned $D):
+  end_borrow %borrow : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testLinearInnerReborrow: linear-liveness with: @argument[0]
+// CHECK: Linear liveness:
+// CHECK: lifetime-ending user:
+// CHECK-SAME: destroy_value %0
+// CHECK-NEXT: last user:   destroy_value %0
+// CHECK-NEXT: end running test 1 of 1 on testLinearInnerReborrow
+sil [ossa] @testLinearInnerReborrow : $@convention(thin) (@owned C) -> () {
+bb0(%0 : @owned $C):
+  test_specification "linear-liveness @argument[0]"
+  cond_br undef, bb1, bb2
+
+bb1:
+  %borrow1 = begin_borrow %0 : $C
+  br bb3(%borrow1 : $C)
+  
+bb2:
+  %borrow2 = begin_borrow %0 : $C
+  br bb3(%borrow2 : $C)
+
+bb3(%phi : @guaranteed $C):
+  end_borrow %phi : $C
+  destroy_value %0 : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testLinearAdjacentReborrow: linear-liveness with: @trace[0]
+// CHECK: lifetime-ending user:
+// CHECK-SAME: br bb3
+// CHECK-NEXT: lifetime-ending user: br bb3
+// CHECK-NEXT: last user: br bb3
+// CHECK-NEXT: last user: br bb3
+// CHECK-NEXT: end running test 1 of 1 on testLinearAdjacentReborrow
+sil [ossa] @testLinearAdjacentReborrow : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  test_specification "linear-liveness @trace[0]"
+  %borrow = begin_borrow %0 : $C
+  debug_value [trace] %borrow : $C
+  cond_br undef, bb1, bb2
+
+bb1:
+  %borrow1 = begin_borrow %borrow : $C
+  br bb3(%borrow : $C, %borrow1 : $C)
+  
+bb2:
+  %borrow2 = begin_borrow %borrow : $C
+  br bb3(%borrow : $C, %borrow2 : $C)
+
+bb3(%outer : @guaranteed $C, %inner : @guaranteed $C):
+  end_borrow %inner : $C
+  end_borrow %outer : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// =============================================================================
+// visitInnerAdjacentPhis
+// =============================================================================
+
+// CHECK-LABEL: begin running test 1 of 1 on pay_the_phi: visit-inner-adjacent-phis with: @trace[0]
+// CHECK: sil [ossa] @pay_the_phi : {{.*}} {
+// CHECK:   [[C:%[^,]+]] = apply
+// CHECK:   [[BORROW1:%[^,]+]] = begin_borrow %1
+// CHECK:   [[BORROW2:%[^,]+]] = begin_borrow %1
+// CHECK:   br [[EXIT:bb[0-9]+]]([[C]] : $C, [[BORROW1]] : $C, [[BORROW2]] :
+// CHECK: [[EXIT]]({{%[^,]+}} : @owned $C, [[GUARANTEED1:%[^,]+]] : @guaranteed $C, [[GUARANTEED2:%[^,]+]] :
+// CHECK: } // end sil function 'pay_the_phi'
+//
+// CHECK:[[GUARANTEED1]] = argument of [[EXIT]]
+// CHECK:[[GUARANTEED2]] = argument of [[EXIT]]
+// CHECK-LABEL: end running test 1 of 1 on pay_the_phi: visit-inner-adjacent-phis with: @trace[0]
+sil [ossa] @pay_the_phi : $@convention(thin) () -> () {
+entry:
+  %getC = function_ref @getC : $@convention(thin) () -> @owned C
+  %c = apply %getC() : $@convention(thin) () -> @owned C
+  %borrow1 = begin_borrow %c : $C
+  %borrow2 = begin_borrow %c : $C
+  %borrow3 = begin_borrow %borrow2 : $C
+  br exit(%c : $C, %borrow1 : $C, %borrow2 : $C, %borrow3 : $C)
+
+exit(%owned : @owned $C, %guaranteed_1 : @guaranteed $C, %guaranteed_2 : @guaranteed $C, %guaranteed_3 : @guaranteed $C):
+  test_specification "visit-inner-adjacent-phis @trace[0]"
+  debug_value [trace] %owned : $C
+  end_borrow %guaranteed_3 : $C
+  end_borrow %guaranteed_2 : $C
+  end_borrow %guaranteed_1 : $C
+  destroy_value %owned : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on pay_the_phi_forward: visit-inner-adjacent-phis with: @trace[0]
+// CHECK: bb1(%{{.*}} : @guaranteed $C, [[INNER:%.*]] : @guaranteed $D):    // Preds: bb0
+// CHECK: } // end sil function 'pay_the_phi_forward'
+// CHECK: [[INNER]] = argument of bb1 : $D
+// CHECK: end running test 1 of 1 on pay_the_phi_forward: visit-inner-adjacent-phis with: @trace[0]
+sil [ossa] @pay_the_phi_forward : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  %borrow0 = begin_borrow %0 : $C
+  %d0 = unchecked_ref_cast %borrow0 : $C to $D
+  br exit(%borrow0 : $C, %d0 : $D)
+
+exit(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
+  test_specification "visit-inner-adjacent-phis @trace[0]"
+  debug_value [trace] %reborrow : $C
+  %f = ref_element_addr %phi : $D, #D.object
+  %o = load [copy] %f : $*C
+  destroy_value %o : $C
+  end_borrow %reborrow : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// =============================================================================
+// InteriorLiveness and visitAdjacentPhis
+// =============================================================================
+
+// CHECK-LABEL: begin running test 1 of 1 on testInteriorRefElementEscape: interior-liveness with: @trace[0]
+// CHECK: Incomplete liveness: Escaping address
+// CHECK: last user:   %{{.*}} = address_to_pointer
+// CHECK-NEXT: end running test 1 of 1 on testInteriorRefElementEscape:
+sil [ossa] @testInteriorRefElementEscape : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  test_specification "interior-liveness @trace[0]"
+  %d = unchecked_ref_cast %0 : $C to $D
+  debug_value [trace] %d : $D
+  %f1 = ref_element_addr %d : $D, #D.object  
+  %p1 = address_to_pointer %f1 : $*C to $Builtin.RawPointer
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testInteriorReborrow: interior-liveness with: @trace[0]
+// CHECK: Complete liveness
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb1
+// CHECK-NEXT: end running test 1 of 1 on testInteriorReborrow: interior-liveness with: @trace[0]
+sil [ossa] @testInteriorReborrow : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  test_specification "interior-liveness @trace[0]"
+  %borrow = begin_borrow %0 : $C
+  debug_value [trace] %borrow : $C
+  br bb1(%borrow : $C)
+
+bb1(%reborrow : @guaranteed $C):
+  end_borrow %reborrow : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testInteriorDominatedGuaranteedForwardingPhi: interior-liveness with: @argument[0]
+// CHECK: Complete liveness
+// CHECK: last user: %{{.*}} load [copy]
+// CHECK-NEXT: end running test 1 of 1 on testInteriorDominatedGuaranteedForwardingPhi:
+sil [ossa] @testInteriorDominatedGuaranteedForwardingPhi : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  test_specification "interior-liveness @argument[0]"
+  cond_br undef, bb1, bb2
+
+bb1:
+  %d1 = unchecked_ref_cast %0 : $C to $D
+  br bb3(%d1 : $D)
+
+bb2:
+  %d2 = unchecked_ref_cast %0 : $C to $D
+  br bb3(%d2 : $D)
+
+bb3(%phi : @guaranteed $D):
+  %f = ref_element_addr %phi : $D, #D.object  
+  %o = load [copy] %f : $*C
+  destroy_value %o : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testInteriorNondominatedGuaranteedForwardingPhi: interior-liveness with: @trace[0]
+// CHECK: Complete liveness
+// CHECK: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb3(
+// CHECK-NEXT: end running test 1 of 1 on testInteriorNondominatedGuaranteedForwardingPhi: interior-liveness with: @trace[0]
+sil [ossa] @testInteriorNondominatedGuaranteedForwardingPhi : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %borrow1 = begin_borrow %0 : $C
+  debug_value [trace] %borrow1 : $C
+  test_specification "interior-liveness @trace[0]"
+  %d1 = unchecked_ref_cast %borrow1 : $C to $D
+  br bb3(%borrow1 : $C, %d1 : $D)
+
+bb2:
+  %borrow2 = begin_borrow %0 : $C
+  %d2 = unchecked_ref_cast %borrow2 : $C to $D
+  br bb3(%borrow2 : $C, %d2 : $D)
+
+bb3(%reborrow : @guaranteed $C, %phi : @guaranteed $D):
+  %f = ref_element_addr %phi : $D, #D.object  
+  %o = load [copy] %f : $*C
+  destroy_value %o : $C
+  end_borrow %reborrow : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testInnerDominatedReborrow: interior-liveness with: @argument[0]
+// CHECK: Interior liveness:
+// CHECK: Inner scope:   %{{.*}} = begin_borrow %0 : $C
+// CHECK: Complete liveness
+// CHECK: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_borrow
+// CHECK-NEXT: end running test 1 of 1 on testInnerDominatedReborrow: interior-liveness with: @argument[0]
+sil [ossa] @testInnerDominatedReborrow : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  test_specification "interior-liveness @argument[0]"
+  %borrow = begin_borrow %0 : $C
+  br bb1(%borrow : $C)
+
+bb1(%reborrow : @guaranteed $C):
+  end_borrow %reborrow : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testInnerDominatedReborrow2: interior-liveness with: @trace[0]
+// CHECK: Inner scope:   %{{.*}} = begin_borrow %1 : $C
+// CHECK-NEXT: Inner scope: %{{.*}} = argument of bb3 : $C
+// CHECK: Complete liveness
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   destroy_value
+// CHECK-NEXT: end running test 1 of 1 on testInnerDominatedReborrow2: interior-liveness with: @trace[0]
+sil [ossa] @testInnerDominatedReborrow2 : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  %copy0a = copy_value %0 : $C
+  %copy0b = copy_value %0 : $C
+  test_specification "interior-liveness @trace[0]"
+  debug_value [trace] %copy0a : $C
+  cond_br undef, bb1, bb2
+
+bb1:
+  %borrow1 = begin_borrow %copy0a : $C
+  br bb3(%borrow1 : $C)
+
+bb2:
+  %borrow2 = begin_borrow %copy0b : $C
+  br bb3(%borrow2 : $C)
+
+bb3(%reborrow : @guaranteed $C):
+  end_borrow %reborrow : $C
+  destroy_value %copy0a : $C
+  destroy_value %copy0b : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testInnerNonDominatedReborrow: interior-liveness with: @trace[0]
+// CHECK: Inner scope:   [[BORROW:%.*]] = begin_borrow [[DEF:%.*]] : $D
+// CHECK: Complete liveness
+// CHECK: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb3([[DEF]] : $D, [[BORROW]] : $D)
+// CHECK-NEXT: end running test 1 of 1 on testInnerNonDominatedReborrow: interior-liveness with: @trace[0]
+sil [ossa] @testInnerNonDominatedReborrow : $@convention(thin) (@guaranteed D) -> () {
+bb0(%0 : @guaranteed $D):
+  cond_br undef, bb1, bb2
+
+bb1:
+  test_specification "interior-liveness @trace[0]"
+  %borrow1 = begin_borrow %0 : $D
+  debug_value [trace] %borrow1 : $D
+  %inner1 = begin_borrow %borrow1 : $D
+  br bb3(%borrow1 : $D, %inner1 : $D)
+
+bb2:
+  %borrow2 = begin_borrow %0 : $D
+  %inner2 = begin_borrow %borrow2 : $D
+  br bb3(%borrow2 : $D, %inner2 : $D)
+
+bb3(%outer : @guaranteed $D, %inner : @guaranteed $D):
+  %f = ref_element_addr %inner : $D, #D.object  
+  %o = load [copy] %f : $*C
+  destroy_value %o : $C
+  end_borrow %inner : $D
+  end_borrow %outer : $D
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testInnerAdjacentReborrow1: interior-liveness with: @trace[0]
+// CHECK: Interior liveness: [[DEF:%.*]] = argument of bb3 : $D
+// CHECK:      Inner scope: %{{.*}} = argument of bb3 : $D
+// CHECK:      Inner scope: %{{.*}} = argument of bb4 : $D
+// CHECK:      regular user:   end_borrow
+// CHECK-NEXT: regular user:   br bb4(
+// CHECK-NEXT: Complete liveness
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user: end_borrow
+// CHECK-NEXT: end running test 1 of 1 on testInnerAdjacentReborrow1: interior-liveness with: @trace[0]
+sil [ossa] @testInnerAdjacentReborrow1 : $@convention(thin) (@guaranteed D) -> () {
+bb0(%0 : @guaranteed $D):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy1 = copy_value %0 : $D
+  %borrow1 = begin_borrow %copy1 : $D
+  br bb3(%copy1 : $D, %borrow1 : $D)
+
+bb2:
+  %copy2 = copy_value %0 : $D
+  %borrow2 = begin_borrow %0 : $D
+  br bb3(%copy2 : $D, %borrow2 : $D)
+
+bb3(%outer3 : @owned $D, %inner3 : @guaranteed $D):
+  test_specification "interior-liveness @trace[0]"
+  debug_value [trace] %outer3 : $D
+  br bb4(%inner3 : $D)
+
+bb4(%inner4 : @guaranteed $D):
+  %f = ref_element_addr %inner4 : $D, #D.object  
+  %o = load [copy] %f : $*C
+  destroy_value %o : $C
+  end_borrow %inner4 : $D
+  unreachable
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testInnerAdjacentReborrow2: interior-liveness with: @trace[0]
+// CHECK: Interior liveness: [[DEF:%.*]] = argument of bb3 : $D
+// CHECK:      Inner scope: %{{.*}} = argument of bb3 : $D
+// CHECK:      Inner scope: %{{.*}} = argument of bb4 : $D
+// CHECK:      regular user:   end_borrow
+// CHECK-NEXT: regular user:   br bb4(
+// CHECK-NEXT: Complete liveness
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user: end_borrow
+// CHECK-NEXT: end running test 1 of 1 on testInnerAdjacentReborrow2: interior-liveness with: @trace[0]
+sil [ossa] @testInnerAdjacentReborrow2 : $@convention(thin) (@guaranteed D) -> () {
+bb0(%0 : @guaranteed $D):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy1 = copy_value %0 : $D
+  %borrow1 = begin_borrow %copy1 : $D
+  br bb3(%copy1 : $D, %borrow1 : $D)
+
+bb2:
+  %copy2 = copy_value %0 : $D
+  %borrow2 = begin_borrow %0 : $D
+  br bb3(%copy2 : $D, %borrow2 : $D)
+
+bb3(%outer3 : @owned $D, %inner3 : @guaranteed $D):
+  test_specification "interior-liveness @trace[0]"
+  debug_value [trace] %outer3 : $D
+  br bb4(%inner3 : $D)
+
+bb4(%inner4 : @guaranteed $D):
+  %f = ref_element_addr %inner4 : $D, #D.object
+  %o = load [copy] %f : $*C
+  destroy_value %o : $C
+  end_borrow %inner4 : $D
+  unreachable
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testInnerNonAdjacentReborrow: interior-liveness with: @trace[0]
+// CHECK: Interior liveness: [[DEF:%.*]] = argument of bb3 : $D
+// CHECK-NOT:  Inner scope
+// CHECK-NOT:  lifetime-ending user
+// CHECK:      Complete liveness
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: dead def: [[DEF]] = argument of bb3 : $D
+// CHECK-NEXT: end running test 1 of 1 on testInnerNonAdjacentReborrow: interior-liveness with: @trace[0]
+sil [ossa] @testInnerNonAdjacentReborrow : $@convention(thin) (@guaranteed D) -> () {
+bb0(%0 : @guaranteed $D):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy1 = copy_value %0 : $D
+  %borrow1 = begin_borrow %0 : $D
+  br bb3(%copy1 : $D, %borrow1 : $D)
+
+bb2:
+  %copy2 = copy_value %0 : $D
+  %borrow2 = begin_borrow %0 : $D
+  br bb3(%copy2 : $D, %borrow2 : $D)
+
+bb3(%outer3 : @owned $D, %inner3 : @guaranteed $D):
+  test_specification "interior-liveness @trace[0]"
+  debug_value [trace] %outer3 : $D
+  br bb4(%inner3 : $D)
+
+bb4(%inner4 : @guaranteed $D):
+  %f = ref_element_addr %inner4 : $D, #D.object  
+  %o = load [copy] %f : $*C
+  destroy_value %o : $C
+  end_borrow %inner4 : $D
+  unreachable
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testInnerAdjacentPhi1: interior-liveness with: @trace[0]
+// CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
+// CHECK: Complete liveness
+// CHECK: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = load [copy]
+// CHECK-NEXT: end running test 1 of 1 on testInnerAdjacentPhi1: interior-liveness with: @trace[0]
+sil [ossa] @testInnerAdjacentPhi1 : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy1 = copy_value %0 : $C
+  %borrow1 = begin_borrow %copy1 : $C
+  %d1 = unchecked_ref_cast %borrow1 : $C to $D
+  br bb3(%copy1 : $C, %borrow1 : $C, %d1 :$D)
+
+bb2:
+  %copy2 = copy_value %0 : $C
+  %borrow2 = begin_borrow %copy2 : $C
+  %d2 = unchecked_ref_cast %0 : $C to $D
+  br bb3(%copy2 : $C, %borrow2 : $C, %d2 :$D)
+
+bb3(%outer3 : @owned $C, %inner3 : @guaranteed $C, %phi3 : @guaranteed $D):
+  test_specification "interior-liveness @trace[0]"
+  debug_value [trace] %inner3 : $C
+  br bb4(%phi3 : $D)
+
+bb4(%phi4 : @guaranteed $D):
+  %f = ref_element_addr %phi4 : $D, #D.object
+  %o = load [copy] %f : $*C
+  destroy_value %o : $C
+  unreachable
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testInnerAdjacentPhi2: interior-liveness with: @trace[0]
+// CHECK: Interior liveness: %{{.*}} = argument of bb3 : $C
+// CHECK: Complete liveness
+// CHECK: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   %{{.*}} = load [copy]
+// CHECK-NEXT: end running test 1 of 1 on testInnerAdjacentPhi2: interior-liveness with: @trace[0]
+sil [ossa] @testInnerAdjacentPhi2 : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy1 = copy_value %0 : $C
+  %borrow1 = begin_borrow %copy1 : $C
+  %d1 = unchecked_ref_cast %0 : $C to $D
+  br bb3(%copy1 : $C, %borrow1 : $C, %d1 :$D)
+
+bb2:
+  %copy2 = copy_value %0 : $C
+  %borrow2 = begin_borrow %copy2 : $C
+  %d2 = unchecked_ref_cast %borrow2 : $C to $D
+  br bb3(%copy2 : $C, %borrow2 : $C, %d2 :$D)
+
+bb3(%outer3 : @owned $C, %inner3 : @guaranteed $C, %phi3 : @guaranteed $D):
+  test_specification "interior-liveness @trace[0]"
+  debug_value [trace] %inner3 : $C
+  br bb4(%phi3 : $D)
+
+bb4(%phi4 : @guaranteed $D):
+  %f = ref_element_addr %phi4 : $D, #D.object
+  %o = load [copy] %f : $*C
+  destroy_value %o : $C
+  unreachable
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testInnerNonAdjacentPhi: interior-liveness with: @trace[0]
+// CHECK: Interior liveness: [[DEF:%.*]] = argument of bb3 : $C
+// CHECK: Complete liveness
+// CHECK: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: dead def: [[DEF]] = argument of bb3 : $C
+// CHECK-NEXT: end running test 1 of 1 on testInnerNonAdjacentPhi: interior-liveness with: @trace[0]
+sil [ossa] @testInnerNonAdjacentPhi : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy1 = copy_value %0 : $C
+  %borrow1 = begin_borrow %copy1 : $C
+  %d1 = unchecked_ref_cast %0 : $C to $D
+  br bb3(%copy1 : $C, %borrow1 : $C, %d1 :$D)
+
+bb2:
+  %copy2 = copy_value %0 : $C
+  %borrow2 = begin_borrow %copy2 : $C
+  %d2 = unchecked_ref_cast %0 : $C to $D
+  br bb3(%copy2 : $C, %borrow2 : $C, %d2 :$D)
+
+bb3(%outer3 : @owned $C, %inner3 : @guaranteed $C, %phi3 : @guaranteed $D):
+  test_specification "interior-liveness @trace[0]"
+  debug_value [trace] %inner3 : $C
+  br bb4(%phi3 : $D)
+
+bb4(%phi4 : @guaranteed $D):
+  %f = ref_element_addr %phi4 : $D, #D.object
+  %o = load [copy] %f : $*C
+  destroy_value %o : $C
+  unreachable
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testScopedAddress: interior-liveness with: @argument[0]
+// CHECK: Complete liveness
+// CHECK-NEXT: Unenclosed phis {
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   end_access
+// CHECK-NEXT: end running test 1 of 1 on testScopedAddress: interior-liveness with: @argument[0]
+sil [ossa] @testScopedAddress : $@convention(thin) (@guaranteed D) -> () {
+bb0(%0 : @guaranteed $D):
+  test_specification "interior-liveness @argument[0]"
+  %f = ref_element_addr %0 : $D, #D.object
+  %access = begin_access [read] [static] %f : $*C
+  %o = load [copy] %access : $*C
+  end_access %access : $*C
+  destroy_value %o : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testUnenclosedReborrow: interior-liveness with: @trace[0]
+// CHECK: Interior liveness:   [[DEF:%.*]] = copy_value %0 : $C
+// CHECK-NEXT: Inner scope:   [[BORROW:%.*]] = begin_borrow [[DEF]] : $C
+// CHECK: Complete liveness
+// CHECK: Unenclosed phis {
+// CHECK-NEXT:   %{{.*}} = argument of bb3 : $C
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb3([[BORROW]] : $C)
+// CHECK-NEXT: end running test 1 of 1 on testUnenclosedReborrow: interior-liveness with: @trace[0]
+sil [ossa] @testUnenclosedReborrow : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  test_specification "interior-liveness @trace[0]"
+  %copy0a = copy_value %0 : $C
+  debug_value [trace] %copy0a : $C
+  %borrow1 = begin_borrow %copy0a : $C
+  br bb3(%borrow1 : $C)
+
+bb2:
+  %copy0b = copy_value %0 : $C
+  %borrow2 = begin_borrow %copy0b : $C
+  br bb3(%borrow2 : $C)
+
+bb3(%reborrow : @guaranteed $C):
+  end_borrow %reborrow : $C
+  unreachable
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testUnenclosedGuaranteedPhi: interior-liveness with: @trace[0]
+// CHECK: Interior liveness:   %{{.*}} = begin_borrow
+// CHECK: Complete liveness
+// CHECK: Unenclosed phis {
+// CHECK-NEXT:   %{{.*}} = argument of bb3 : $D
+// CHECK-NEXT: }
+// CHECK-NEXT: last user:   br bb3(
+// CHECK-NEXT: end running test 1 of 1 on testUnenclosedGuaranteedPhi: interior-liveness with: @trace[0]
+sil [ossa] @testUnenclosedGuaranteedPhi : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  test_specification "interior-liveness @trace[0]"
+  %copy0a = copy_value %0 : $C
+  %borrow1 = begin_borrow %copy0a : $C
+  debug_value [trace] %borrow1 : $C
+  %d1 = unchecked_ref_cast %borrow1 : $C to $D
+  br bb3(%d1 : $D)
+
+bb2:
+  %copy0b = copy_value %0 : $C
+  %borrow2 = begin_borrow %copy0b : $C
+  %d2 = unchecked_ref_cast %borrow2 : $C to $D
+  br bb3(%d2 : $D)
+
+bb3(%phi : @guaranteed $D):
+  unreachable
+}
+
+// =============================================================================
+// ExtendedLiveness
+// =============================================================================
+
+// CHECK-LABEL: begin running test 1 of 1 on testExtendedPhi: extended-liveness with: @trace[0]
+// CHECK: Extended liveness:   %{{.*}} = copy_value %0 : $C
+// CHECK: lifetime-ending user:   br bb3(
+// CHECK: lifetime-ending user:   destroy_value
+// CHECK: last user:   br bb3(
+// CHECK: last user:   destroy_value
+// CHECK: end running test 1 of 1 on testExtendedPhi: extended-liveness with: @trace[0]
+sil [ossa] @testExtendedPhi : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  test_specification "extended-liveness @trace[0]"
+  %copy1 = copy_value %0 : $C
+  debug_value [trace] %copy1 : $C
+  br bb3(%copy1 : $C)
+
+bb2:
+  %copy2 = copy_value %0 : $C
+  br bb3(%copy2 : $C)
+
+bb3(%phi : @owned $C):
+  destroy_value %phi : $C
+  %99 = tuple()
+  return %99 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testExtendedReborrow: extended-liveness with: @trace[0]
+// CHECK: Extended liveness:   %{{.*}} = begin_borrow
+// CHECK: lifetime-ending user:   br bb3(
+// CHECK: lifetime-ending user:   end_borrow
+// CHECK: last user:   br bb3(
+// CHECK: last user:   end_borrow
+// CHECK: end running test 1 of 1 on testExtendedReborrow: extended-liveness with: @trace[0]
+sil [ossa] @testExtendedReborrow : $@convention(thin) (@guaranteed C) -> () {
+bb0(%0 : @guaranteed $C):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy1 = copy_value %0 : $C
+  test_specification "extended-liveness @trace[0]"
+  %borrow1 = begin_borrow %copy1 : $C
+  debug_value [trace] %borrow1 : $C
+  br bb3(%copy1 : $C, %borrow1 : $C)
+
+bb2:
+  %copy2 = copy_value %0 : $C
+  %borrow2 = begin_borrow %copy2 : $C
+  br bb3(%copy2 : $C, %borrow2 : $C)
+
+bb3(%phi : @owned $C, %reborrow : @guaranteed $C):
+  end_borrow %reborrow : $C
+  destroy_value %phi : $C
+  %99 = tuple()
+  return %99 : $()
+}


### PR DESCRIPTION
Encapsulate all the complexity of reborrows and guaranteed phi in 3
ownership liveness interfaces:

LinerLiveness, InteriorLiveness, and ExtendedLiveness

Required for the "complete OSSA lifetimes" utility.