### PR TITLE
[Macros] Create macro expansion contexts based on the SourceManager

### DIFF
--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -29,6 +29,7 @@ if (SWIFT_SWIFT_PARSER)
     Sources/ASTGen/Misc.swift
     Sources/ASTGen/SourceFile.swift
     Sources/ASTGen/SourceManager.swift
+    Sources/ASTGen/SourceManager+MacroExpansionContext.swift
     Sources/ASTGen/Stmts.swift
     Sources/ASTGen/Types.swift
   )

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -181,7 +181,7 @@ func expandFreestandingMacro(
       ) throws -> ExprSyntax {
         return try exprMacro.expansion(
           of: sourceManager.detach(
-            node, in: context,
+            node,
             foldingWith: OperatorTable.standardOperators
           ),
           in: context
@@ -201,7 +201,10 @@ func expandFreestandingMacro(
       }
       macroName = parentExpansion.macro.text
       let decls = try declMacro.expansion(
-        of: sourceManager.detach(parentExpansion, in: context),
+        of: sourceManager.detach(
+          parentExpansion,
+          foldingWith: OperatorTable.standardOperators
+        ),
         in: context
       )
       evaluatedSyntax = Syntax(CodeBlockItemListSyntax(
@@ -348,8 +351,11 @@ func expandAttachedMacro(
     switch (macro, macroRole) {
     case (let attachedMacro as AccessorMacro.Type, .Accessor):
       let accessors = try attachedMacro.expansion(
-        of: context.detach(customAttrNode),
-        providingAccessorsOf: context.detach(declarationNode),
+        of: sourceManager.detach(
+          customAttrNode,
+          foldingWith: OperatorTable.standardOperators
+        ),
+        providingAccessorsOf: sourceManager.detach(declarationNode),
         in: context
       )
 
@@ -377,11 +383,12 @@ func expandAttachedMacro(
         _ node: Node
       ) throws -> [AttributeSyntax] {
         return try attachedMacro.expansion(
-          of: context.detach(customAttrNode),
-          attachedTo: sourceManager.detach(node, in: context),
-          providingAttributesFor: sourceManager.detach(
-            declarationNode, in: context
+          of: sourceManager.detach(
+            customAttrNode,
+            foldingWith: OperatorTable.standardOperators
           ),
+          attachedTo: sourceManager.detach(node),
+          providingAttributesFor: sourceManager.detach(declarationNode),
           in: context
         )
       }
@@ -407,8 +414,11 @@ func expandAttachedMacro(
         _ node: Node
       ) throws -> [DeclSyntax] {
         return try attachedMacro.expansion(
-          of: sourceManager.detach(customAttrNode, in: context),
-          providingMembersOf: sourceManager.detach(node, in: context),
+          of: sourceManager.detach(
+            customAttrNode,
+            foldingWith: OperatorTable.standardOperators
+          ),
+          providingMembersOf: sourceManager.detach(node),
           in: context
         )
       }

--- a/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
@@ -1,0 +1,132 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+extension SourceManager {
+  class MacroExpansionContext {
+    /// The source manager.
+    private let sourceManager: SourceManager
+
+    /// The set of diagnostics that were emitted as part of expanding the
+    /// macro.
+    var diagnostics: [Diagnostic] = []
+
+    /// The macro expansion discriminator, which is used to form unique names
+    /// when requested.
+    ///
+    /// The expansion discriminator is combined with the `uniqueNames` counters
+    /// to produce unique names.
+    private var discriminator: String
+
+    /// Counter for each of the uniqued names.
+    ///
+    /// Used in conjunction with `expansionDiscriminator`.
+    private var uniqueNames: [String: Int] = [:]
+
+    init(sourceManager: SourceManager, discriminator: String) {
+      self.sourceManager = sourceManager
+      self.discriminator = discriminator
+    }
+  }
+
+  /// Create a new macro expansion context
+  func createMacroExpansionContext(
+    discriminator: String = ""
+  ) -> MacroExpansionContext {
+    return MacroExpansionContext(
+      sourceManager: self, discriminator: discriminator
+    )
+  }
+}
+
+extension String {
+  /// Retrieve the base name of a string that represents a path, removing the
+  /// directory.
+  fileprivate var basename: String {
+    guard let lastSlash = lastIndex(of: "/") else {
+      return self
+    }
+
+    return String(self[index(after: lastSlash)...])
+  }
+}
+
+extension SourceManager.MacroExpansionContext: MacroExpansionContext {
+  /// Generate a unique name for use in the macro.
+  public func createUniqueName(_ providedName: String) -> TokenSyntax {
+    // If provided with an empty name, substitute in something.
+    let name = providedName.isEmpty ? "__local" : providedName
+
+    // Grab a unique index value for this name.
+    let uniqueIndex = uniqueNames[name, default: 0]
+    uniqueNames[name] = uniqueIndex + 1
+
+    // Start with the discriminator.
+    var resultString = discriminator
+
+    // Mangle the name
+    resultString += "\(name.count)\(name)"
+
+    // Mangle the operator for unique macro names.
+    resultString += "fMu"
+
+    // Mangle the index.
+    if uniqueIndex > 0 {
+      resultString += "\(uniqueIndex - 1)"
+    }
+    resultString += "_"
+
+    return TokenSyntax(.identifier(resultString), presence: .present)
+  }
+
+  /// Produce a diagnostic while expanding the macro.
+  public func diagnose(_ diagnostic: Diagnostic) {
+    diagnostics.append(diagnostic)
+  }
+
+  public func location<Node: SyntaxProtocol>(
+    of node: Node,
+    at position: PositionInSyntaxNode,
+    filePathMode: SourceLocationFilePathMode
+  ) -> SourceLocation? {
+    guard let (sourceFile, rootPosition) = sourceManager.rootSourceFile(of: node),
+        let exportedSourceFile =
+            sourceManager.exportedSourceFilesBySyntax[sourceFile]?.pointee
+    else {
+      return nil
+    }
+
+    // Determine the filename to use in the resulting location.
+    let fileName: String
+    switch filePathMode {
+    case .fileID:
+      fileName = "\(exportedSourceFile.moduleName)/\(exportedSourceFile.fileName.basename)"
+
+    case .filePath:
+      fileName = exportedSourceFile.fileName
+    }
+
+    // Find the node's offset relative to its root.
+    let rawPosition: AbsolutePosition
+    switch position {
+    case .beforeLeadingTrivia:
+      rawPosition = node.position
+
+    case .afterLeadingTrivia:
+      rawPosition = node.positionAfterSkippingLeadingTrivia
+
+    case .beforeTrailingTrivia:
+      rawPosition = node.endPositionBeforeTrailingTrivia
+
+    case .afterTrailingTrivia:
+      rawPosition = node.endPosition
+    }
+
+    let offsetWithinSyntaxNode =
+      rawPosition.utf8Offset - node.position.utf8Offset
+
+    // Do the location lookup.
+    let converter = SourceLocationConverter(file: fileName, tree: sourceFile)
+    return converter.location(for: rootPosition.advanced(by: offsetWithinSyntaxNode))
+  }
+}


### PR DESCRIPTION
Rather than trying to patch up the "basic" macro expansion context that comes from the swift-syntax package, implement our own based on the new SourceManager. Fixes the `location(of:)` operation.
