### PR TITLE
Clarify documentation for `CommandLine.unsafeArgv` re: the trailing `nil`. (#58484)

### DIFF
--- a/stdlib/public/core/CommandLine.swift
+++ b/stdlib/public/core/CommandLine.swift
@@ -42,8 +42,13 @@ public enum CommandLine {
     return _argc
   }
 
-  /// Access to the raw argv value from C. Accessing the argument vector
-  /// through this pointer is unsafe.
+  /// Access to the raw argv value from C.
+  ///
+  /// The value of this property is a `nil`-terminated C array. Including the
+  /// trailing `nil`, there are ``argc`` `+ 1` elements in the array.
+  ///
+  /// - Note: Accessing the argument vector through this pointer is unsafe.
+  ///   Where possible, use ``arguments`` instead.
   public static var unsafeArgv:
     UnsafeMutablePointer<UnsafeMutablePointer<Int8>?> {
     return _unsafeArgv


### PR DESCRIPTION
<!-- What's in this pull request? -->
The documentation for `CommandLine.unsafeArgv` is ambiguous about a trailing `nil` value. There is one, as is expected by C. We should say so.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #58484.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
