### PR TITLE
[Sema] RuntimeMetadata: Attach source information to synthesized initializers

### DIFF
--- a/lib/Sema/TypeCheckRuntimeMetadataAttr.cpp
+++ b/lib/Sema/TypeCheckRuntimeMetadataAttr.cpp
@@ -97,7 +97,8 @@ static TypeRepr *buildTypeRepr(DeclContext *typeContext,
 /// first parameter is always `self` (with or without `inout`).
 static ClosureExpr *synthesizeMethodThunk(DeclContext *thunkDC,
                                           NominalTypeDecl *nominal,
-                                          FuncDecl *method) {
+                                          FuncDecl *method,
+                                          SourceLoc thunkLoc) {
   auto &ctx = method->getASTContext();
 
   // If this is a method, let's form a thunk so that attribute initializer
@@ -212,17 +213,19 @@ static ClosureExpr *synthesizeMethodThunk(DeclContext *thunkDC,
   }
 
   DeclAttributes attrs;
-  auto *closure = new (ctx) ClosureExpr(
-      attrs, /*bracketRange=*/SourceRange(),
-      /*capturedSelf=*/nullptr, ParameterList::create(ctx, closureParams),
-      /*asyncLoc=*/SourceLoc(),
-      /*throwsLoc=*/SourceLoc(),
-      /*arrowLoc=*/SourceLoc(),
-      /*inLoc=*/SourceLoc(),
-      /*explicitResultType=*/nullptr, thunkDC);
+  auto *closure = new (ctx)
+      ClosureExpr(attrs, /*bracketRange=*/SourceRange(),
+                  /*capturedSelf=*/nullptr,
+                  ParameterList::create(ctx, thunkLoc, closureParams, thunkLoc),
+                  /*asyncLoc=*/SourceLoc(),
+                  /*throwsLoc=*/SourceLoc(),
+                  /*arrowLoc=*/SourceLoc(),
+                  /*inLoc=*/SourceLoc(),
+                  /*explicitResultType=*/nullptr, thunkDC);
 
-  closure->setBody(BraceStmt::createImplicit(ctx, body),
-                   /*isSingleExpr=*/true);
+  closure->setBody(
+      BraceStmt::create(ctx, thunkLoc, body, thunkLoc, /*implicit=*/true),
+      /*isSingleExpr=*/true);
   closure->setImplicit();
 
   return closure;
@@ -246,6 +249,14 @@ Expr *SynthesizeRuntimeMetadataAttrGenerator::evaluate(
 
   auto *initContext = new (ctx) RuntimeAttributeInitializer(attr, attachedTo);
 
+  SourceRange sourceRange;
+  if (auto *repr = attr->getTypeRepr()) {
+    sourceRange = repr->getSourceRange();
+  } else {
+    sourceRange = SourceRange(
+      attachedTo->getAttributeInsertionLoc(/*forModifier=*/false));
+  }
+
   Expr *initArgument = nullptr;
   if (auto *nominal = dyn_cast<NominalTypeDecl>(attachedTo)) {
     // Registry attributes on protocols are only used for
@@ -254,26 +265,28 @@ Expr *SynthesizeRuntimeMetadataAttrGenerator::evaluate(
       return nullptr;
 
     // Form an initializer call passing in the metatype
-    auto *metatype = TypeExpr::createImplicit(nominal->getDeclaredType(), ctx);
+    auto *metatype = TypeExpr::createImplicitHack(
+        sourceRange.Start, nominal->getDeclaredType(), ctx);
     initArgument = new (ctx)
         DotSelfExpr(metatype, /*dot=*/SourceLoc(), /*self=*/SourceLoc());
   } else if (auto *func = dyn_cast<FuncDecl>(attachedTo)) {
     if (auto *nominal = func->getDeclContext()->getSelfNominalTypeDecl()) {
-      initArgument = synthesizeMethodThunk(initContext, nominal, func);
+      initArgument =
+          synthesizeMethodThunk(initContext, nominal, func, sourceRange.Start);
     } else {
-      initArgument = new (ctx)
-          DeclRefExpr({func}, /*Loc=*/DeclNameLoc(), /*implicit=*/true);
+      initArgument = new (ctx) DeclRefExpr(
+          {func}, /*Loc=*/DeclNameLoc(sourceRange.Start), /*implicit=*/true);
     }
   } else {
     auto *var = cast<VarDecl>(attachedTo);
     assert(!var->isStatic());
 
     auto *keyPath =
-        KeyPathExpr::createImplicit(ctx, /*backslashLoc=*/SourceLoc(),
+        KeyPathExpr::createImplicit(ctx, /*backslashLoc=*/sourceRange.Start,
                                     {KeyPathExpr::Component::forProperty(
                                         {var}, var->getValueInterfaceType(),
-                                        /*Loc=*/SourceLoc())},
-                                    /*endLoc=*/SourceLoc());
+                                        /*Loc=*/sourceRange.Start)},
+                                    /*endLoc=*/sourceRange.Start);
 
     // Build a type repr for base of the key path, since attribute
     // could be attached to an inner type, we need to go up decl
@@ -283,20 +296,13 @@ Expr *SynthesizeRuntimeMetadataAttrGenerator::evaluate(
     initArgument = keyPath;
   }
 
-  SourceRange sourceRange;
-  if (auto *repr = attr->getTypeRepr()) {
-    sourceRange = repr->getSourceRange();
-  } else {
-    sourceRange = SourceRange(
-        attachedTo->getAttributeInsertionLoc(/*forModifier=*/false));
-  }
-
   auto typeExpr =
       TypeExpr::createImplicitHack(sourceRange.Start, attrType, ctx);
 
   // Add the initializer argument at the front of the argument list
   SmallVector<Argument, 4> newArgs;
-  newArgs.push_back({/*loc=*/SourceLoc(), ctx.Id_attachedTo, initArgument});
+  newArgs.push_back(
+      {/*loc=*/sourceRange.Start, ctx.Id_attachedTo, initArgument});
   if (auto *attrArgs = attr->getArgs())
     newArgs.append(attrArgs->begin(), attrArgs->end());
 

--- a/test/type/runtime_discoverable_attrs.swift
+++ b/test/type/runtime_discoverable_attrs.swift
@@ -349,3 +349,27 @@ protocol OptedOutProtoWithSuperclass : BaseClass {} // Ok
 @available(*, unavailable)
 @Flag
 extension OptedOutProtoWithSuperclass {}
+
+@runtimeMetadata
+struct FlagForFailures {
+  init(attachedTo: Int.Type) {}
+  init<T>(attachedTo: KeyPath<Int, T>) {}
+  init(attachedTo: (Int) -> Void, _: String) {}
+}
+
+@FlagForFailures // expected-error {{cannot convert value of type 'InvalidMembersTests.Type' to expected argument type 'Int.Type'}}
+struct InvalidMembersTests {
+  @FlagForFailures var x: Int
+  // expected-error@-1 {{cannot convert value of type 'KeyPath<InvalidMembersTests, Int>' to expected argument type 'KeyPath<Int, Int>'}}
+  // expected-note@-2 {{arguments to generic parameter 'Root' ('InvalidMembersTests' and 'Int') are expected to be equal}}
+
+  @FlagForFailures("") static func testStatic() {}
+  // expected-error@-1 {{cannot convert value of type '(InvalidMembersTests.Type) -> ()' to expected argument type '(Int) -> Void'}}
+
+  @FlagForFailures(42) func testInst() {}
+  // expected-error@-1 {{cannot convert value of type '(InvalidMembersTests) -> ()' to expected argument type '(Int) -> Void'}}
+  // expected-error@-2:20 {{cannot convert value of type 'Int' to expected argument type 'String'}}
+}
+
+@FlagForFailures("global") func testGlobalInvalid() {}
+// expected-error@-1 {{cannot convert value of type '() -> ()' to expected argument type '(Int) -> Void'}}


### PR DESCRIPTION
All the locations point to the attribute itself, expect to the custom arguments - they all have real locations.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
