### PR TITLE
[move-only] Refactor CanonicalizeOSSA so we can emit nicer non-consuming use notes and increase quality of errors.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -730,7 +730,7 @@ ERROR(sil_moveonlychecker_owned_value_consumed_more_than_once, none,
 ERROR(sil_moveonlychecker_owned_value_consumed_and_used_at_same_time, none,
       "'%0' consumed and used at the same time", (StringRef))
 ERROR(sil_moveonlychecker_value_used_after_consume, none,
-      "'%0' used after consume. Lifetime extension of variable requires a copy", (StringRef))
+      "'%0' used after consume", (StringRef))
 ERROR(sil_moveonlychecker_guaranteed_value_consumed, none,
       "'%0' has guaranteed ownership but was consumed", (StringRef))
 ERROR(sil_moveonlychecker_guaranteed_value_captured_by_closure, none,
@@ -754,6 +754,8 @@ NOTE(sil_moveonlychecker_boundary_use, none,
      "boundary use here", ())
 NOTE(sil_moveonlychecker_consuming_use_here, none,
      "consuming use here", ())
+NOTE(sil_moveonlychecker_other_consuming_use_here, none,
+     "other consuming use here", ())
 NOTE(sil_moveonlychecker_two_consuming_uses_here, none,
      "two consuming uses here", ())
 NOTE(sil_moveonlychecker_consuming_and_non_consuming_uses_here, none,
@@ -762,6 +764,9 @@ NOTE(sil_moveonlychecker_consuming_closure_use_here, none,
      "closure capture here", ())
 NOTE(sil_moveonlychecker_nonconsuming_use_here, none,
      "non-consuming use here", ())
+NOTE(sil_movekillscopyablevalue_value_cyclic_consumed_in_loop_here, none,
+     "consuming in loop use here", ())
+
 ERROR(sil_moveonlychecker_not_understand_no_implicit_copy, none,
       "Usage of @noImplicitCopy that the move checker does not know how to "
       "check!", ())

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -360,6 +360,11 @@ public:
     return liveness.getLifetimeEndingUsers();
   }
 
+  using NonLifetimeEndingUserRange = PrunedLiveness::NonLifetimeEndingUserRange;
+  NonLifetimeEndingUserRange getNonLifetimeEndingUsers() const {
+    return liveness.getNonLifetimeEndingUsers();
+  }
+
   using UserRange = PrunedLiveness::ConstUserRange;
   UserRange getUsers() const { return liveness.getAllUsers(); }
 

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -213,15 +213,6 @@ private:
   /// copies.
   bool maximizeLifetime;
 
-  /// If true and we are processing a value of move_only type, emit a diagnostic
-  /// when-ever we need to insert a copy_value.
-  std::function<void(Operand *)> moveOnlyCopyValueNotification;
-
-  /// If true and we are processing a value of move_only type, pass back to the
-  /// caller any consuming uses that are going to be used as part of the final
-  /// lifetime boundary in case we need to emit diagnostics.
-  std::function<void(Operand *)> moveOnlyFinalConsumingUse;
-
   // If present, will be used to ensure that the lifetime is not shortened to
   // end inside an access scope which it previously enclosed.  (Note that ending
   // before such an access scope is fine regardless.)
@@ -289,27 +280,10 @@ public:
     }
   }
 
-  void maybeNotifyMoveOnlyCopy(Operand *use) {
-    if (!moveOnlyCopyValueNotification)
-      return;
-    moveOnlyCopyValueNotification(use);
-  }
-
-  void maybeNotifyFinalConsumingUse(Operand *use) {
-    if (!moveOnlyFinalConsumingUse)
-      return;
-    moveOnlyFinalConsumingUse(use);
-  }
-
-  CanonicalizeOSSALifetime(
-      bool pruneDebugMode, bool maximizeLifetime,
-      NonLocalAccessBlockAnalysis *accessBlockAnalysis, DominanceInfo *domTree,
-      InstructionDeleter &deleter,
-      std::function<void(Operand *)> moveOnlyCopyValueNotification = nullptr,
-      std::function<void(Operand *)> moveOnlyFinalConsumingUse = nullptr)
+  CanonicalizeOSSALifetime(bool pruneDebugMode, bool maximizeLifetime,
+                           NonLocalAccessBlockAnalysis *accessBlockAnalysis,
+                           DominanceInfo *domTree, InstructionDeleter &deleter)
       : pruneDebugMode(pruneDebugMode), maximizeLifetime(maximizeLifetime),
-        moveOnlyCopyValueNotification(moveOnlyCopyValueNotification),
-        moveOnlyFinalConsumingUse(moveOnlyFinalConsumingUse),
         accessBlockAnalysis(accessBlockAnalysis), domTree(domTree),
         deleter(deleter),
         liveness(maximizeLifetime ? &discoveredBlocks : nullptr) {}
@@ -348,7 +322,46 @@ public:
   /// operands.
   bool canonicalizeValueLifetime(SILValue def);
 
+  /// Compute the liveness information for \p def. But do not do any rewriting
+  /// or computation of boundaries.
+  ///
+  /// The intention is that this is used if one wants to emit diagnostics using
+  /// the liveness information before doing any rewriting.
+  bool computeLiveness(SILValue def);
+
+  /// Given the already computed liveness boundary for the given def, rewrite
+  /// copies of def as appropriate.
+  ///
+  /// NOTE: It is assumed that one passes the extended boundary from \see
+  /// computeLiveness.
+  ///
+  /// NOTE: It is assumed that one has emitted any diagnostics.
+  void rewriteLifetimes();
+
+  /// Return the pure original boundary just based off of liveness information
+  /// without maximizing or extending liveness.
+  void findOriginalBoundary(PrunedLivenessBoundary &resultingOriginalBoundary);
+
   InstModCallbacks &getCallbacks() { return deleter.getCallbacks(); }
+
+  using IsInterestingUser = PrunedLiveness::IsInterestingUser;
+
+  /// Helper method that returns the isInterestingUser status of \p user in the
+  /// passed in Liveness.
+  ///
+  /// NOTE: Only call this after calling computeLivenessBoundary or the results
+  /// will not be initialized.
+  IsInterestingUser isInterestingUser(SILInstruction *user) const {
+    return liveness.isInterestingUser(user);
+  }
+
+  using LifetimeEndingUserRange = PrunedLiveness::LifetimeEndingUserRange;
+  LifetimeEndingUserRange getLifetimeEndingUsers() const {
+    return liveness.getLifetimeEndingUsers();
+  }
+
+  using UserRange = PrunedLiveness::ConstUserRange;
+  UserRange getUsers() const { return liveness.getAllUsers(); }
 
 private:
   void recordDebugValue(DebugValueInst *dvi) { debugValues.insert(dvi); }
@@ -361,8 +374,6 @@ private:
   bool endsAccessOverlappingPrunedBoundary(SILInstruction *inst);
 
   void extendLivenessThroughOverlappingAccess();
-
-  void findOriginalBoundary(PrunedLivenessBoundary &boundary);
 
   void findExtendedBoundary(PrunedLivenessBoundary const &originalBoundary,
                             PrunedLivenessBoundary &boundary);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
@@ -1012,6 +1012,8 @@ bool GatherUsesVisitor::visitUse(Operand *op, AccessUseType useTy) {
   // For convenience, grab the user of op.
   auto *user = op->getUser();
 
+  LLVM_DEBUG(llvm::dbgs() << "Visiting user: " << *user);
+
   // First check if we have init/reinit. These are quick/simple.
   if (::memInstMustInitialize(op)) {
     LLVM_DEBUG(llvm::dbgs() << "Found init: " << *user);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransform.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransform.cpp
@@ -294,11 +294,11 @@ void BorrowToDestructureTransform::checkForErrorsOnSameInstruction() {
           continue;
 
         if (badOperand->isConsuming())
-          diagnosticEmitter.emitObjectConsumesDestructuredValueTwice(
-              mmci, use, badOperand);
+          diagnosticEmitter.emitObjectInstConsumesValueTwice(mmci, use,
+                                                             badOperand);
         else
-          diagnosticEmitter.emitObjectConsumesAndUsesDestructuredValue(
-              mmci, use, badOperand);
+          diagnosticEmitter.emitObjectInstConsumesAndUsesValue(mmci, use,
+                                                               badOperand);
         emittedError = true;
       }
 
@@ -359,7 +359,9 @@ bool BorrowToDestructureTransform::gatherBorrows(
     return true;
   }
 
-  LLVM_DEBUG(llvm::dbgs() << "Searching for borrows for inst: " << *mmci);
+  LLVM_DEBUG(llvm::dbgs() << "Performing BorrowToDestructureTramsform!\n"
+                             "Searching for borrows for inst: "
+                          << *mmci);
 
   StackList<Operand *> worklist(mmci->getFunction());
   for (auto *op : mmci->getUses())

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -103,7 +103,8 @@ private:
   /// copy. If filter is non-null, allow for the caller to pre-process operands
   /// and emit their own diagnostic. If filter returns true, then we assume that
   /// the caller processed it correctly. false, then we continue to process it.
-  void emitObjectDiagnosticsForFoundUses(bool ignorePartialApply = false) const;
+  void
+  emitObjectDiagnosticsForGuaranteedUses(bool ignorePartialApply = false) const;
   void emitObjectDiagnosticsForPartialApplyUses() const;
 
   void registerDiagnosticEmitted(MarkMustCheckInst *value) {

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -91,13 +91,12 @@ public:
       TypeTreeLeafTypeRange destructureNeededBits,
       FieldSensitivePrunedLivenessBoundary &boundary);
 
-  void emitObjectConsumesDestructuredValueTwice(MarkMustCheckInst *markedValue,
-                                                Operand *firstConsumingUse,
-                                                Operand *secondConsumingUse);
-  void
-  emitObjectConsumesAndUsesDestructuredValue(MarkMustCheckInst *markedValue,
-                                             Operand *consumingUse,
-                                             Operand *nonConsumingUse);
+  void emitObjectInstConsumesValueTwice(MarkMustCheckInst *markedValue,
+                                        Operand *firstConsumingUse,
+                                        Operand *secondConsumingUse);
+  void emitObjectInstConsumesAndUsesValue(MarkMustCheckInst *markedValue,
+                                          Operand *consumingUse,
+                                          Operand *nonConsumingUse);
 
 private:
   /// Emit diagnostics for the final consuming uses and consuming uses needing

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
@@ -13,6 +13,7 @@
 #define DEBUG_TYPE "sil-move-only-checker"
 
 #include "swift/AST/DiagnosticsSIL.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/FrozenMultiMap.h"
 #include "swift/Basic/STLExtras.h"
@@ -21,6 +22,7 @@
 #include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/FieldSensitivePrunedLiveness.h"
 #include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/NodeBits.h"
 #include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/PostOrder.h"
 #include "swift/SIL/PrunedLiveness.h"
@@ -315,6 +317,62 @@ bool swift::siloptimizer::cleanupSILAfterEmittingObjectMoveOnlyDiagnostics(
 }
 
 //===----------------------------------------------------------------------===//
+//                          MARK: OSSACanonicalizer
+//===----------------------------------------------------------------------===//
+
+bool OSSACanonicalizer::canonicalize(SILValue value) {
+  // First compute liveness. If we fail, bail.
+  if (!canonicalizer->computeLiveness(value)) {
+    return false;
+  }
+
+  // Now we have our liveness information. First compute the original boundary
+  // (which ignores destroy_value).
+  PrunedLivenessBoundary originalBoundary;
+  canonicalizer->findOriginalBoundary(originalBoundary);
+
+  // Then use that information to stash for our diagnostics the boundary
+  // consuming/non-consuming users as well as enter the boundary consuming users
+  // into the boundaryConsumignUserSet for quick set testing later.
+  using IsInterestingUser = CanonicalizeOSSALifetime::IsInterestingUser;
+  InstructionSet boundaryConsumingUserSet(value->getFunction());
+  for (auto *lastUser : originalBoundary.lastUsers) {
+    LLVM_DEBUG(llvm::dbgs() << "Looking at boundary use: " << *lastUser);
+    switch (canonicalizer->isInterestingUser(lastUser)) {
+    case IsInterestingUser::NonUser:
+      llvm_unreachable("Last user of original boundary should be a user?!");
+    case IsInterestingUser::NonLifetimeEndingUse:
+      LLVM_DEBUG(llvm::dbgs() << "    NonLifetimeEndingUse!\n");
+      nonConsumingBoundaryUses.push_back(lastUser);
+      continue;
+    case IsInterestingUser::LifetimeEndingUse:
+      LLVM_DEBUG(llvm::dbgs() << "    LifetimeEndingUse!\n");
+      consumingBoundaryUsers.push_back(lastUser);
+      boundaryConsumingUserSet.insert(lastUser);
+      continue;
+    }
+  }
+
+  // Then go through any of the consuming interesting uses found by our liveness
+  // and any that are not on the boundary are ones that we must error for.
+  for (auto *consumingUser : canonicalizer->getLifetimeEndingUsers()) {
+    bool isConsumingUseOnBoundary =
+        boundaryConsumingUserSet.contains(consumingUser);
+    LLVM_DEBUG(llvm::dbgs() << "Is consuming user on boundary "
+                            << (isConsumingUseOnBoundary ? "yes" : "no") << ": "
+                            << *consumingUser);
+    if (!isConsumingUseOnBoundary) {
+      consumingUsesNeedingCopy.push_back(consumingUser);
+    }
+  }
+
+  // Finally, rewrite lifetimes.
+  canonicalizer->rewriteLifetimes();
+
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
 //                         MARK: Forward Declaration
 //===----------------------------------------------------------------------===//
 
@@ -350,6 +408,9 @@ struct MoveOnlyChecker {
     changed |= localChange;
     return localChange;
   }
+
+  bool checkForSameInstMultipleUseErrors(MarkMustCheckInst *base,
+                                         DiagnosticEmitter &emitter);
 };
 
 } // namespace
@@ -366,8 +427,10 @@ bool MoveOnlyChecker::convertBorrowExtractsToOwnedDestructures(
 
   // If we do not have any borrows to process, return true early to show we
   // succeeded in processing.
-  if (borrowWorklist.empty())
+  if (borrowWorklist.empty()) {
+    LLVM_DEBUG(llvm::dbgs() << "    Did not find any borrows to process!\n");
     return true;
+  }
 
   SmallVector<SILBasicBlock *, 8> discoveredBlocks;
 
@@ -414,6 +477,132 @@ bool MoveOnlyChecker::convertBorrowExtractsToOwnedDestructures(
 
   // Now that we have done our rewritting, we need to do a few cleanups.
   transform.cleanup(borrowWorklist);
+
+  return true;
+}
+
+bool MoveOnlyChecker::checkForSameInstMultipleUseErrors(
+    MarkMustCheckInst *mmci, DiagnosticEmitter &diagnosticEmitter) {
+  LLVM_DEBUG(llvm::dbgs() << "Checking for same inst multiple use error!\n");
+
+  SmallFrozenMultiMap<SILInstruction *, Operand *, 8> instToOperandsMap;
+  StackList<Operand *> worklist(mmci->getFunction());
+  for (auto *use : mmci->getUses())
+    worklist.push_back(use);
+
+  while (!worklist.empty()) {
+    auto *nextUse = worklist.pop_back_val();
+
+    switch (nextUse->getOperandOwnership()) {
+    case OperandOwnership::NonUse:
+      continue;
+
+    // Conservatively treat a conversion to an unowned value as a pointer
+    // escape. If we see this in the SIL, fail and return false so we emit a
+    // "compiler doesn't understand error".
+    case OperandOwnership::ForwardingUnowned:
+    case OperandOwnership::PointerEscape:
+    case OperandOwnership::BitwiseEscape:
+      LLVM_DEBUG(llvm::dbgs()
+                 << "        Found forwarding unowned or escape!\n");
+      return false;
+
+    case OperandOwnership::TrivialUse:
+    case OperandOwnership::InstantaneousUse:
+    case OperandOwnership::UnownedInstantaneousUse:
+      // Look through copy_value.
+      if (auto *cvi = dyn_cast<CopyValueInst>(nextUse->getUser())) {
+        for (auto *use : cvi->getUses())
+          worklist.push_back(use);
+        continue;
+      }
+
+      // Treat these as non-consuming uses that could have a consuming use as an
+      // additional operand.
+      LLVM_DEBUG(llvm::dbgs()
+                 << "        Found non consuming use: " << *nextUse->getUser());
+      instToOperandsMap.insert(nextUse->getUser(), nextUse);
+      continue;
+    case OperandOwnership::InteriorPointer:
+      // We do not care about interior pointer uses since there aren't any
+      // interior pointer using instructions that are also consuming uses.
+      continue;
+
+    case OperandOwnership::DestroyingConsume:
+      if (isa<DestroyValueInst>(nextUse->getUser()))
+        continue;
+      [[fallthrough]];
+    case OperandOwnership::ForwardingConsume:
+      LLVM_DEBUG(llvm::dbgs()
+                 << "        Found consuming use: " << *nextUse->getUser());
+
+      instToOperandsMap.insert(nextUse->getUser(), nextUse);
+      continue;
+
+    case OperandOwnership::EndBorrow:
+    case OperandOwnership::Reborrow:
+    case OperandOwnership::GuaranteedForwarding:
+      llvm_unreachable(
+          "We do not process borrows recursively so should never see this.");
+
+    case OperandOwnership::Borrow:
+      // We don't care about borrows so we don't process them recursively
+      continue;
+    }
+  }
+
+  // Ok, we have our list of potential uses. Sort the multi-map and then search
+  // for errors.
+  instToOperandsMap.setFrozen();
+  for (auto pair : instToOperandsMap.getRange()) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Checking inst for multiple uses: " << *pair.first);
+    Operand *foundConsumingUse = nullptr;
+    Operand *foundNonConsumingUse = nullptr;
+    for (auto *use : pair.second) {
+      LLVM_DEBUG(llvm::dbgs()
+                 << "    Visiting use: " << use->getOperandNumber() << '\n');
+      if (use->isConsuming()) {
+        LLVM_DEBUG(llvm::dbgs() << "        Is consuming!\n");
+        if (foundConsumingUse) {
+          // Emit error.
+          LLVM_DEBUG(
+              llvm::dbgs()
+              << "        Had previous consuming use! Emitting error!\n");
+          diagnosticEmitter.emitObjectInstConsumesValueTwice(
+              mmci, foundConsumingUse, use);
+          continue;
+        }
+
+        if (foundNonConsumingUse) {
+          LLVM_DEBUG(
+              llvm::dbgs()
+              << "        Had previous non consuming use! Emitting error!\n");
+          // Emit error.
+          diagnosticEmitter.emitObjectInstConsumesAndUsesValue(
+              mmci, use, foundNonConsumingUse);
+          continue;
+        }
+
+        if (!foundConsumingUse)
+          foundConsumingUse = use;
+        continue;
+      }
+
+      LLVM_DEBUG(llvm::dbgs() << "        Is non consuming!\n");
+      if (foundConsumingUse) {
+        // Emit error.
+        LLVM_DEBUG(llvm::dbgs()
+                   << "        Had previous consuming use! Emitting error!\n");
+        diagnosticEmitter.emitObjectInstConsumesAndUsesValue(
+            mmci, foundConsumingUse, use);
+        continue;
+      }
+
+      if (!foundNonConsumingUse)
+        foundNonConsumingUse = use;
+    }
+  }
 
   return true;
 }
@@ -497,7 +686,25 @@ void MoveOnlyChecker::check(DominanceInfo *domTree, PostOrderAnalysis *poa) {
       continue;
     }
 
-    // First canonicalize ownership.
+    // First search for transitive consuming uses and prove that we do not have
+    // any errors where a single instruction consumes the same value twice or
+    // consumes and uses a value.
+    if (!checkForSameInstMultipleUseErrors(markedValue, diagnosticEmitter)) {
+      LLVM_DEBUG(llvm::dbgs() << "checkForSameInstMultipleUseError didn't "
+                                 "understand part of the SIL\n");
+      diagnosticEmitter.emitCheckerDoesntUnderstandDiagnostic(markedValue);
+      continue;
+    }
+
+    if (diagnosticCount != diagnosticEmitter.getDiagnosticCount()) {
+      LLVM_DEBUG(llvm::dbgs() << "Found single inst multiple user error!\n");
+      continue;
+    }
+
+    // Once that is complete, we then canonicalize ownership, finding our
+    // boundary and any uses that need a copy. We in this section only deal with
+    // instructions due to our first step where we emitted errors for
+    // instructions containing multiple operands.
     if (!canonicalizer.canonicalize(markedValue)) {
       diagnosticEmitter.emitCheckerDoesntUnderstandDiagnostic(markedValue);
       LLVM_DEBUG(

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.h
@@ -22,6 +22,7 @@
 
 #include "swift/Basic/FrozenMultiMap.h"
 #include "swift/SIL/FieldSensitivePrunedLiveness.h"
+#include "swift/SIL/PrunedLiveness.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h"
 #include "llvm/ADT/IntervalMap.h"
@@ -42,7 +43,7 @@ struct OSSACanonicalizer {
   SmallVector<SILInstruction *, 32> consumingBoundaryUsers;
 
   /// A list of non-consuming boundary uses.
-  SmallVector<SILInstruction *, 32> nonConsumingBoundaryUses;
+  SmallVector<SILInstruction *, 32> nonConsumingBoundaryUsers;
 
   /// The actual canonicalizer that we use.
   ///
@@ -71,6 +72,18 @@ struct OSSACanonicalizer {
   }
 
   bool canonicalize(SILValue value);
+
+  bool computeLiveness(SILValue value) {
+    return canonicalizer->computeLiveness(value);
+  }
+
+  void computeBoundaryData(SILValue value);
+
+  void rewriteLifetimes() { canonicalizer->rewriteLifetimes(); }
+
+  void findOriginalBoundary(PrunedLivenessBoundary &resultingFoundBoundary) {
+    canonicalizer->findOriginalBoundary(resultingFoundBoundary);
+  }
 
   bool foundAnyConsumingUses() const {
     return consumingUsesNeedingCopy.size() || consumingBoundaryUsers.size();

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -69,6 +69,7 @@
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/NodeDatastructures.h"
 #include "swift/SIL/OwnershipUtils.h"
+#include "swift/SIL/PrunedLiveness.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
 #include "swift/SILOptimizer/Utils/DebugOptUtils.h"
 #include "swift/SILOptimizer/Utils/InstructionDeleter.h"
@@ -927,16 +928,8 @@ void CanonicalizeOSSALifetime::rewriteCopies() {
     // If this use was not marked as a final destroy *or* this is not the first
     // consumed operand we visited, then it needs a copy.
     if (!consumes.claimConsume(user)) {
-      maybeNotifyMoveOnlyCopy(use);
       return false;
     }
-
-    // Ok, this is a final user that isn't a destroy_value. Notify our caller if
-    // we were asked to.
-    //
-    // If we need this for diagnostics, we will only use it if we found actual
-    // uses that required copies.
-    maybeNotifyFinalConsumingUse(use);
 
     return true;
   };
@@ -997,8 +990,7 @@ void CanonicalizeOSSALifetime::rewriteCopies() {
 //                            MARK: Top-Level API
 //===----------------------------------------------------------------------===//
 
-/// Canonicalize a single extended owned lifetime.
-bool CanonicalizeOSSALifetime::canonicalizeValueLifetime(SILValue def) {
+bool CanonicalizeOSSALifetime::computeLiveness(SILValue def) {
   if (def->getOwnershipKind() != OwnershipKind::Owned)
     return false;
 
@@ -1031,10 +1023,14 @@ bool CanonicalizeOSSALifetime::canonicalizeValueLifetime(SILValue def) {
   if (accessBlockAnalysis) {
     extendLivenessThroughOverlappingAccess();
   }
+  return true;
+}
+
+void CanonicalizeOSSALifetime::rewriteLifetimes() {
   // Step 2: compute original boundary
   PrunedLivenessBoundary originalBoundary;
   findOriginalBoundary(originalBoundary);
-  PrunedLivenessBoundary boundary;
+  PrunedLivenessBoundary extendedBoundary;
   if (maximizeLifetime) {
     // Step 3. (optional) maximize lifetimes
     extendUnconsumedLiveness(originalBoundary);
@@ -1043,19 +1039,33 @@ bool CanonicalizeOSSALifetime::canonicalizeValueLifetime(SILValue def) {
     //         liveness
     findOriginalBoundary(originalBoundary);
     // Step 4: extend boundary to destroys
-    findExtendedBoundary(originalBoundary, boundary);
+    findExtendedBoundary(originalBoundary, extendedBoundary);
   } else {
     // Step 3: (skipped)
     // Step 4: extend boundary to destroys
-    findExtendedBoundary(originalBoundary, boundary);
+    findExtendedBoundary(originalBoundary, extendedBoundary);
   }
+
   // Step 5: insert destroys and record consumes
-  insertDestroysOnBoundary(boundary);
+  insertDestroysOnBoundary(extendedBoundary);
   // Step 6: rewrite copies and delete extra destroys
   rewriteCopies();
 
   clearLiveness();
   consumes.clear();
+}
+
+/// Canonicalize a single extended owned lifetime.
+bool CanonicalizeOSSALifetime::canonicalizeValueLifetime(SILValue def) {
+  // Step 1: Compute liveness.
+  if (!computeLiveness(def)) {
+    LLVM_DEBUG(llvm::dbgs() << "Failed to compute liveness boundary!\n");
+    return false;
+  }
+
+  // Steps 2-6. \see rewriteUses for explanation of steps 2-6.
+  rewriteLifetimes();
+
   return true;
 }
 

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -2380,3 +2380,23 @@ func fieldSensitiveTestReinitEnumMultiBlock2() {
     }
     borrowVal(e)
 }
+
+////////////////////////////////////////////
+// Multiple Use by Same CallSite TestCase //
+////////////////////////////////////////////
+
+func sameCallSiteTestConsumeTwice(_ k: inout Klass) { // expected-error {{'k' consumed more than once}}
+    func consumeKlassTwice(_ k: __owned Klass, _ k2: __owned Klass) {}
+    consumeKlassTwice(k, k)
+    // expected-note @-1 {{consuming use here}}
+    // expected-note @-2 {{consuming use here}}
+    k = Klass()
+}
+
+func sameCallSiteConsumeAndUse(_ k: inout Klass) { // expected-error {{'k' used after consume. Lifetime extension of variable requires a copy}}
+    func consumeKlassAndUseKlass(_ k: __owned Klass, _ k2: Klass) {}
+    consumeKlassAndUseKlass(k, k)
+    // expected-note @-1 {{consuming use here}}
+    // expected-note @-2 {{non-consuming use here}}
+    k = Klass()
+}

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -127,7 +127,7 @@ public func classMultipleNonConsumingUseArgTest(_ x2: inout Klass) { // expected
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func classMultipleNonConsumingUseArgTest2(_ x2: inout Klass) { // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+public func classMultipleNonConsumingUseArgTest2(_ x2: inout Klass) { // expected-error {{'x2' used after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -143,7 +143,7 @@ public func classMultipleNonConsumingUseArgTest3(_ x2: inout Klass) {  // expect
                    // expected-note @-1 {{consuming use here}}
 }
 
-public func classMultipleNonConsumingUseArgTest4(_ x2: inout Klass) { // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+public func classMultipleNonConsumingUseArgTest4(_ x2: inout Klass) { // expected-error {{'x2' used after consume}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -340,7 +340,7 @@ public func classAssignToVar4Arg(_ x2: inout Klass) { // expected-error {{'x2' c
 }
 
 public func classAssignToVar5() {
-    var x2 = Klass() // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    var x2 = Klass() // expected-error {{'x2' used after consume}}
     x2 = Klass()
     var x3 = x2 // expected-note {{consuming use here}}
     // TODO: Need to mark this as the lifetime extending use. We fail
@@ -351,7 +351,7 @@ public func classAssignToVar5() {
 }
 
 public func classAssignToVar5Arg(_ x: Klass, _ x2: inout Klass) {
-    // expected-error @-1 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    // expected-error @-1 {{'x2' used after consume}}
     // expected-error @-2 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
@@ -360,7 +360,7 @@ public func classAssignToVar5Arg(_ x: Klass, _ x2: inout Klass) {
 }
 
 public func classAssignToVar5Arg2(_ x: Klass, _ x2: inout Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-                                                                   // expected-error @-1 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+                                                                   // expected-error @-1 {{'x2' used after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -645,7 +645,7 @@ public func finalClassAssignToVar4Arg(_ x2: inout FinalKlass) {
 }
 
 public func finalClassAssignToVar5() {
-    var x2 = FinalKlass() // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    var x2 = FinalKlass() // expected-error {{'x2' used after consume}}
     x2 = FinalKlass()
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
@@ -654,7 +654,7 @@ public func finalClassAssignToVar5() {
 }
 
 public func finalClassAssignToVar5Arg(_ x2: inout FinalKlass) {
-    // expected-error @-1 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    // expected-error @-1 {{'x2' used after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = FinalKlass()
@@ -1669,7 +1669,7 @@ public func enumAssignToVar4Arg(_ x2: inout EnumTy) {
 }
 
 public func enumAssignToVar5() {
-    var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' used after consume}}
     x2 = EnumTy.klass(Klass())
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
@@ -1678,7 +1678,7 @@ public func enumAssignToVar5() {
 }
 
 public func enumAssignToVar5Arg(_ x2: inout EnumTy) {
-    // expected-error @-1 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    // expected-error @-1 {{'x2' used after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = EnumTy.klass(Klass())
@@ -1736,7 +1736,7 @@ public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{
 
 // This is wrong.
 public func enumPatternMatchSwitch1() {
-    var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' used after consume}}
     x2 = EnumTy.klass(Klass())
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k):
@@ -1783,7 +1783,7 @@ public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {
 
 // QOI: We can do better here. We should also flag x2
 public func enumPatternMatchSwitch2WhereClause() {
-    var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    var x2 = EnumTy.klass(Klass()) // expected-error {{'x2' used after consume}}
     x2 = EnumTy.klass(Klass())
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k)
@@ -1956,7 +1956,7 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
 
 public func deferCaptureClassUseAfterConsume() {
     var x2 = Klass()
-    // expected-error @-1 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    // expected-error @-1 {{'x2' used after consume}}
     // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-3 {{'x2' consumed more than once}}
     x2 = Klass()
@@ -1974,7 +1974,7 @@ public func deferCaptureClassUseAfterConsume2() {
     var x2 = Klass()
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    // expected-error @-3 {{'x2' used after consume}}
     x2 = Klass()
     defer { // expected-note {{non-consuming use here}}
         borrowVal(x2)
@@ -2023,8 +2023,8 @@ public func closureAndDeferCaptureClassUseAfterConsume2() {
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
     // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-error @-4 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
-    // expected-error @-5 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    // expected-error @-4 {{'x2' used after consume}}
+    // expected-error @-5 {{'x2' used after consume}}
     x2 = Klass()
     let f = {
         consumeVal(x2)
@@ -2049,8 +2049,8 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
     // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-error @-4 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
-    // expected-error @-5 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    // expected-error @-4 {{'x2' used after consume}}
+    // expected-error @-5 {{'x2' used after consume}}
     x2 = Klass()
     let f = {
         consumeVal(x2)
@@ -2300,7 +2300,7 @@ func fieldSensitiveTestReinitFieldMultiBlock1() {
 }
 
 func fieldSensitiveTestReinitFieldMultiBlock2() {
-    var a = NonTrivialStruct() // expected-error {{'a' used after consume. Lifetime extension of variable requires a copy}}
+    var a = NonTrivialStruct() // expected-error {{'a' used after consume}}
     a = NonTrivialStruct()
     consumeVal(a.k) // expected-note {{consuming use here}}
 
@@ -2342,7 +2342,7 @@ func fieldSensitiveTestReinitFieldMultiBlock4() {
 }
 
 func fieldSensitiveTestReinitEnumMultiBlock() {
-    var e = NonTrivialEnum.first // expected-error {{'e' used after consume. Lifetime extension of variable requires a copy}}
+    var e = NonTrivialEnum.first // expected-error {{'e' used after consume}}
     e = NonTrivialEnum.second(Klass())
     switch e { // expected-note {{consuming use here}}
     case .second:
@@ -2393,7 +2393,7 @@ func sameCallSiteTestConsumeTwice(_ k: inout Klass) { // expected-error {{'k' co
     k = Klass()
 }
 
-func sameCallSiteConsumeAndUse(_ k: inout Klass) { // expected-error {{'k' used after consume. Lifetime extension of variable requires a copy}}
+func sameCallSiteConsumeAndUse(_ k: inout Klass) { // expected-error {{'k' used after consume}}
     func consumeKlassAndUseKlass(_ k: __owned Klass, _ k2: Klass) {}
     consumeKlassAndUseKlass(k, k)
     // expected-note @-1 {{consuming use here}}

--- a/test/SILOptimizer/moveonly_deinits.swift
+++ b/test/SILOptimizer/moveonly_deinits.swift
@@ -9,11 +9,16 @@ var globalMoveOnlyEnum = MoveOnlyEnum.lhs(Klass())
 struct MoveOnlyStruct {
     var k = Klass()
 
-    deinit { // expected-error {{'self' consumed more than once}}
+    deinit {
+        // expected-error @-1 {{'self' consumed more than once}}
+        // expected-error @-2 {{'self' consumed more than once}}
+        // expected-error @-3 {{'self' consumed more than once}}
         let x = self // expected-note {{consuming use here}}
         _ = x
         var y = MoveOnlyStruct() // expected-error {{'y' consumed more than once}}
-        y = self // expected-note {{consuming use here}}
+        y = self
+        // expected-note @-1 {{consuming use here}}
+        // expected-note @-2 {{consuming use here}}
         // We get an infinite recursion since we are going to call our own
         // deinit here. We are just testing diagnostics here though.
         _ = y // expected-warning {{function call causes an infinite recursion}}
@@ -21,6 +26,7 @@ struct MoveOnlyStruct {
         let z = y // expected-note {{consuming use here}}
         let _ = z
         globalMoveOnlyStruct = self // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     } // expected-note {{consuming use here}}
 }
 
@@ -29,15 +35,20 @@ enum MoveOnlyEnum {
     case lhs(Klass)
     case rhs(Klass)
 
-    deinit { // expected-error {{'self' consumed more than once}}
+    deinit {
+        // expected-error @-1 {{'self' consumed more than once}}
+        // expected-error @-2 {{'self' consumed more than once}}
+        // expected-error @-3 {{'self' consumed more than once}}
         let x = self // expected-note {{consuming use here}}
         _ = x
         var y = MoveOnlyEnum.lhs(Klass())
         y = self // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
         // We get an infinite recursion since we are going to call our own
         // deinit here. We are just testing diagnostics here though.
-        // expected-warning @-3 {{function call causes an infinite recursion}}
+        // expected-warning @-4 {{function call causes an infinite recursion}}
         _ = y 
         globalMoveOnlyEnum = self // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     } // expected-note {{consuming use here}}
 }

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -2417,3 +2417,17 @@ func blackHoleTestCase(_ k: __owned Klass) {
     let _ = k2 // expected-note {{consuming use here}}
     let _ = k2 // expected-note {{consuming use here}}
 }
+
+////////////////////////////////////////////
+// Multiple Use by Same CallSite TestCase //
+////////////////////////////////////////////
+
+func sameCallSiteTestConsumeTwice(_ k: __owned Klass) { // expected-error {{'k' consumed more than once}}
+    func consumeKlassTwice(_ k: __owned Klass, _ k2: __owned Klass) {}
+    consumeKlassTwice(k, k) // expected-note {{two consuming uses here}}
+}
+
+func sameCallSiteConsumeAndUse(_ k: __owned Klass) { // expected-error {{'k' consumed and used at the same time}}
+    func consumeKlassAndUseKlass(_ k: __owned Klass, _ k2: Klass) {}
+    consumeKlassAndUseKlass(k, k) // expected-note {{consuming and non-consuming uses here}}
+}

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1001,7 +1001,7 @@ public func enumAssignToVar4Arg(_ x2: inout EnumTy) {
 }
 
 public func enumAssignToVar5() {
-    var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' used after consume}}
     x2 = EnumTy.klass(NonTrivialStruct())
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
@@ -1009,7 +1009,7 @@ public func enumAssignToVar5() {
     consumeVal(x3)
 }
 
-public func enumAssignToVar5Arg(_ x2: inout EnumTy) { // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+public func enumAssignToVar5Arg(_ x2: inout EnumTy) { // expected-error {{'x2' used after consume}}
                                                             
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
@@ -1060,7 +1060,7 @@ public func enumPatternMatchIfLet2Arg(_ x2: inout EnumTy) { // expected-error {{
 
 // This is wrong.
 public func enumPatternMatchSwitch1() {
-    var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' used after consume}}
     x2 = EnumTy.klass(NonTrivialStruct())
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k):
@@ -1107,7 +1107,7 @@ public func enumPatternMatchSwitch2Arg(_ x2: inout EnumTy) { // expected-error {
 
 // QOI: We can do better here. We should also flag x2
 public func enumPatternMatchSwitch2WhereClause() {
-    var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    var x2 = EnumTy.klass(NonTrivialStruct()) // expected-error {{'x2' used after consume}}
     x2 = EnumTy.klass(NonTrivialStruct())
     switch x2 { // expected-note {{consuming use here}}
     case let EnumTy.klass(k)
@@ -1266,7 +1266,7 @@ public func deferCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
     defer { // expected-note {{non-consuming use here}}
         borrowVal(x2)
@@ -1281,7 +1281,7 @@ public func deferCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    // expected-error @-3 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
     defer { //  expected-note {{non-consuming use here}}
         borrowVal(x2)
@@ -1330,8 +1330,8 @@ public func closureAndDeferCaptureClassUseAfterConsume2() {
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
     // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-error @-4 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
-    // expected-error @-5 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    // expected-error @-4 {{'x2' used after consume}}
+    // expected-error @-5 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
     let f = {
         consumeVal(x2)
@@ -1356,8 +1356,8 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
     // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-error @-4 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
-    // expected-error @-5 {{'x2' used after consume. Lifetime extension of variable requires a copy}}
+    // expected-error @-4 {{'x2' used after consume}}
+    // expected-error @-5 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
     let f = {
         consumeVal(x2)

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -147,10 +147,10 @@ public func aggStructDoubleConsumeOwnedArg(_ x2: __owned AggStruct) { // expecte
 }
 
 public func aggStructLoopConsume(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    let x2 = x // expected-error {{'x2' consumed more than once}}
+    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -160,9 +160,9 @@ public func aggStructLoopConsumeArg(_ x2: AggStruct) { // expected-error {{'x2' 
     }
 }
 
-public func aggStructLoopConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
+public func aggStructLoopConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -193,12 +193,14 @@ public func aggStructDiamondOwnedArg(_ x2: __owned AggStruct) {
 
 public func aggStructDiamondInLoop(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consuming use here}}
+    // expected-error @-2 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -214,11 +216,13 @@ public func aggStructDiamondInLoopArg(_ x2: AggStruct) { // expected-error {{'x2
 }
 
 public func aggStructDiamondInLoopOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -413,10 +417,10 @@ public func aggGenericStructDoubleConsumeOwnedArg(_ x2: __owned AggGenericStruct
 }
 
 public func aggGenericStructLoopConsume(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    let x2 = x // expected-error {{'x2' consumed more than once}}
+    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -426,9 +430,9 @@ public func aggGenericStructLoopConsumeArg(_ x2: AggGenericStruct<CopyableKlass>
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed more than once}}
+public func aggGenericStructLoopConsumeOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -459,12 +463,14 @@ public func aggGenericStructDiamondOwnedArg(_ x2: __owned AggGenericStruct<Copya
 
 public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consuming use here}}
+    // expected-error @-2 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -480,11 +486,13 @@ public func aggGenericStructDiamondInLoopArg(_ x2: AggGenericStruct<CopyableKlas
 }
 
 public func aggGenericStructDiamondInLoopOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          consumeVal(x2) // expected-note {{consuming use here}}
+          consumeVal(x2) // expected-note {{other consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -670,10 +678,10 @@ public func aggGenericStructDoubleConsumeOwnedArg<T>(_ x2: __owned AggGenericStr
 }
 
 public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    let x2 = x // expected-error {{'x2' consumed more than once}}
+    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -683,9 +691,9 @@ public func aggGenericStructLoopConsumeArg<T>(_ x2: AggGenericStruct<T>) { // ex
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
+public func aggGenericStructLoopConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -716,12 +724,14 @@ public func aggGenericStructDiamondOwnedArg<T>(_ x2: __owned AggGenericStruct<T>
 
 public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consuming use here}}
+    // expected-error @-2 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -737,11 +747,13 @@ public func aggGenericStructDiamondInLoopArg<T>(_ x2: AggGenericStruct<T>) { // 
 }
 
 public func aggGenericStructDiamondInLoopOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -935,10 +947,10 @@ public func enumDoubleConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error 
 }
 
 public func enumLoopConsume(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    let x2 = x // expected-error {{'x2' consumed more than once}}
+    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -948,9 +960,9 @@ public func enumLoopConsumeArg(_ x2: EnumTy) { // expected-error {{'x2' has guar
     }
 }
 
-public func enumLoopConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
+public func enumLoopConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming in loop use here}};
     }
 }
 
@@ -981,12 +993,14 @@ public func enumDiamondOwnedArg(_ x2: __owned EnumTy) {
 
 public func enumDiamondInLoop(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
-               // expected-note @-1 {{consuming use here}}
+    // expected-note @-1 {{consuming use here}}
+    // expected-error @-2 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -1002,11 +1016,13 @@ public func enumDiamondInLoopArg(_ x2: EnumTy) { // expected-error {{'x2' has gu
 }
 
 public func enumDiamondInLoopOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -1097,12 +1113,10 @@ public func enumAssignToVar4OwnedArg(_ x2: __owned EnumTy) { // expected-error {
 }
 
 public func enumAssignToVar5(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    let x2 = x // expected-error {{'x2' consumed more than once}}
+    let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
-    // TODO: Need to mark this as the lifetime extending use. We fail
-    // appropriately though.
-    borrowVal(x2)
+    borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
@@ -1117,12 +1131,10 @@ public func enumAssignToVar5Arg(_ x: EnumTy, _ x2: EnumTy) { // expected-error {
     consumeVal(x3)
 }
 
-public func enumAssignToVar5OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
+public func enumAssignToVar5OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
                                                                           // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
-    // TODO: Need to mark this as the lifetime extending use. We fail
-    // appropriately though.
-    borrowVal(x2)
+    borrowVal(x2) // expected-note {{non-consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
@@ -1157,10 +1169,10 @@ public func enumPatternMatchIfLet1OwnedArg(_ x2: __owned EnumTy) { // expected-e
 }
 
 public func enumPatternMatchIfLet2(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    let x2 = x // expected-error {{'x2' consumed more than once}}
+    let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consuming in loop use here}}
             borrowVal(x)
         }
     }
@@ -1174,9 +1186,9 @@ public func enumPatternMatchIfLet2Arg(_ x2: EnumTy) { // expected-error {{'x2' h
     }
 }
 
-public func enumPatternMatchIfLet2OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
+public func enumPatternMatchIfLet2OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consuming in loop use here}}
             borrowVal(x)
         }
     }
@@ -1184,14 +1196,12 @@ public func enumPatternMatchIfLet2OwnedArg(_ x2: __owned EnumTy) { // expected-e
 
 // TODO: This is wrong.
 public func enumPatternMatchSwitch1(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    let x2 = x // expected-error {{'x2' consumed more than once}}
+    let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
         borrowVal(k)
-        // This should be flagged as the use after free use. We are atleast
-        // erroring though.
-        borrowVal(x2)
+        borrowVal(x2) // expected-note {{non-consuming use here}}
     case .int:
         break
     }
@@ -1209,13 +1219,11 @@ public func enumPatternMatchSwitch1Arg(_ x2: EnumTy) { // expected-error {{'x2' 
     }
 }
 
-public func enumPatternMatchSwitch1OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
+public func enumPatternMatchSwitch1OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
         borrowVal(k)
-        // This should be flagged as the use after free use. We are atleast
-        // erroring though.
-        borrowVal(x2)
+        borrowVal(x2) // expected-note {{non-consuming use here}}
     case .int:
         break
     }
@@ -1251,11 +1259,11 @@ public func enumPatternMatchSwitch2OwnedArg(_ x2: __owned EnumTy) {
 
 // TODO: We can do better here. We should also flag x2
 public func enumPatternMatchSwitch2WhereClause(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    let x2 = x // expected-error {{'x2' consumed more than once}}
+    let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
-           where x2.doSomething():
+           where x2.doSomething(): // expected-note {{non-consuming use here}}
         borrowVal(k)
     case .int:
         break
@@ -1276,10 +1284,10 @@ public func enumPatternMatchSwitch2WhereClauseArg(_ x2: EnumTy) { // expected-er
     }
 }
 
-public func enumPatternMatchSwitch2WhereClauseOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
+public func enumPatternMatchSwitch2WhereClauseOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
-           where x2.doSomething():
+           where x2.doSomething(): // expected-note {{non-consuming use here}}
         borrowVal(k)
     case .int:
         break
@@ -1434,12 +1442,10 @@ public func deferCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expecte
 }
 
 public func deferCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    let x2 = x // expected-error {{'x2' consumed more than once}}
+    let x2 = x // expected-error {{'x2' used after consume}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    // TODO: Defer error is b/c we have to lifetime extend x2 for the defer. The
-    // use is a guaranteed use, so we don't emit an error on that use.
-    defer {
+    defer { // expected-note {{non-consuming use here}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1470,9 +1476,9 @@ public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStr
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialStruct) {
-    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' used after consume}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    defer {
+    defer { // expected-note {{non-consuming use here}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
         consumeVal(x2) // expected-note {{consuming use here}}

--- a/test/SILOptimizer/noimplicitcopy.swift
+++ b/test/SILOptimizer/noimplicitcopy.swift
@@ -104,9 +104,9 @@ public func classDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { /
 }
 
 public func classLoopConsume(_ x: Klass) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        classConsume(x2) // expected-note {{consuming use here}}
+        classConsume(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -116,9 +116,9 @@ public func classLoopConsumeArg(@_noImplicitCopy _ x2: Klass) { // expected-erro
     }
 }
 
-public func classLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
+public func classLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        classConsume(x2) // expected-note {{consuming use here}}
+        classConsume(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -149,11 +149,13 @@ public func classDiamondOwnedArg(@_noImplicitCopy _ x2: __owned Klass) {
 
 public func classDiamondInLoop(_ x: Klass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           classConsume(x2) // expected-note {{consuming use here}}
       } else {
           classConsume(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -169,11 +171,13 @@ public func classDiamondInLoopArg(@_noImplicitCopy _ x2: Klass) { // expected-er
 }
 
 public func classDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           classConsume(x2) // expected-note {{consuming use here}}
       } else {
           classConsume(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -258,11 +262,9 @@ public func classAssignToVar4OwnedArg(@_noImplicitCopy _ x2: __owned Klass) { //
 }
 
 public func classAssignToVar5(_ x: Klass) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
-    // TODO: Need to mark this as the lifetime extending use. We fail
-    // appropriately though.
-    classUseMoveOnlyWithoutEscaping(x2)
+    classUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
     x3 = x
     print(x3)
 }
@@ -276,11 +278,9 @@ public func classAssignToVar5Arg(_ x: Klass, @_noImplicitCopy _ x2: Klass) { // 
     print(x3)
 }
 
-public func classAssignToVar5OwnedArg(_ x: Klass, @_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
+public func classAssignToVar5OwnedArg(_ x: Klass, @_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' used after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
-    // TODO: Need to mark this as the lifetime extending use. We fail
-    // appropriately though.
-    classUseMoveOnlyWithoutEscaping(x2)
+    classUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
     x3 = x
     print(x3)
 }
@@ -428,9 +428,9 @@ public func finalClassDoubleConsumeownedArg(@_noImplicitCopy _ x2: __owned Final
 }
 
 public func finalClassLoopConsume(_ x: FinalKlass) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        finalClassConsume(x2) // expected-note {{consuming use here}}
+        finalClassConsume(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -440,9 +440,9 @@ public func finalClassLoopConsumeArg(@_noImplicitCopy _ x2: FinalKlass) { // exp
     }
 }
 
-public func finalClassLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
+public func finalClassLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        finalClassConsume(x2) // expected-note {{consuming use here}}
+        finalClassConsume(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -473,11 +473,13 @@ public func finalClassDiamondOwnedArg(@_noImplicitCopy _ x2: __owned FinalKlass)
 
 public func finalClassDiamondInLoop(_ x: FinalKlass) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           finalClassConsume(x2) // expected-note {{consuming use here}}
       } else {
           finalClassConsume(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -493,11 +495,13 @@ public func finalClassDiamondInLoopArg(@_noImplicitCopy _ x2: FinalKlass) { // e
 }
 
 public func finalClassDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           finalClassConsume(x2) // expected-note {{consuming use here}}
       } else {
           finalClassConsume(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -582,11 +586,9 @@ public func finalClassAssignToVar4OwnedArg(@_noImplicitCopy _ x2: __owned FinalK
 }
 
 public func finalClassAssignToVar5(_ x: FinalKlass) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
-    // TODO: Need to mark this as the lifetime extending use. We fail
-    // appropriately though.
-    finalClassUseMoveOnlyWithoutEscaping(x2)
+    finalClassUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
     x3 = x
     print(x3)
 }
@@ -600,11 +602,9 @@ public func finalClassAssignToVar5Arg(_ x: FinalKlass, @_noImplicitCopy _ x2: Fi
     print(x3)
 }
 
-public func finalClassAssignToVar5OwnedArg(_ x: FinalKlass, @_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
+public func finalClassAssignToVar5OwnedArg(_ x: FinalKlass, @_noImplicitCopy _ x2: __owned FinalKlass) { // expected-error {{'x2' used after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
-    // TODO: Need to mark this as the lifetime extending use. We fail
-    // appropriately though.
-    finalClassUseMoveOnlyWithoutEscaping(x2)
+    finalClassUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
     x3 = x
     print(x3)
 }
@@ -768,9 +768,9 @@ public func aggStructDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStr
 }
 
 public func aggStructLoopConsume(_ x: AggStruct) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        aggStructConsume(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -780,9 +780,9 @@ public func aggStructLoopConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expec
     }
 }
 
-public func aggStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
+public func aggStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        aggStructConsume(x2) // expected-note {{consuming use here}}
+        aggStructConsume(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -813,11 +813,13 @@ public func aggStructDiamondOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) {
 
 public func aggStructDiamondInLoop(_ x: AggStruct) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           aggStructConsume(x2) // expected-note {{consuming use here}}
       } else {
           aggStructConsume(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -833,11 +835,13 @@ public func aggStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggStruct) { // exp
 }
 
 public func aggStructDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           aggStructConsume(x2) // expected-note {{consuming use here}}
       } else {
           aggStructConsume(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -1034,9 +1038,9 @@ public func aggGenericStructDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned
 }
 
 public func aggGenericStructLoopConsume(_ x: AggGenericStruct<Klass>) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        aggGenericStructConsume(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -1046,9 +1050,9 @@ public func aggGenericStructLoopConsumeArg(@_noImplicitCopy _ x2: AggGenericStru
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Klass>) { // expected-error {{'x2' consumed more than once}}
+public func aggGenericStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Klass>) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        aggGenericStructConsume(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -1079,11 +1083,13 @@ public func aggGenericStructDiamondOwnedArg(@_noImplicitCopy _ x2: __owned AggGe
 
 public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<Klass>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           aggGenericStructConsume(x2) // expected-note {{consuming use here}}
       } else {
           aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -1099,11 +1105,13 @@ public func aggGenericStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggGenericSt
 }
 
 public func aggGenericStructDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Klass>) { // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           aggGenericStructConsume(x2) // expected-note {{consuming use here}}
       } else {
           aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -1294,9 +1302,9 @@ public func aggGenericStructDoubleConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __ow
 }
 
 public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        aggGenericStructConsume(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -1306,9 +1314,9 @@ public func aggGenericStructLoopConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericS
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
+public func aggGenericStructLoopConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+        aggGenericStructConsume(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -1339,11 +1347,13 @@ public func aggGenericStructDiamondOwnedArg<T>(@_noImplicitCopy _ x2: __owned Ag
 
 public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           aggGenericStructConsume(x2) // expected-note {{consuming use here}}
       } else {
           aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -1359,11 +1369,13 @@ public func aggGenericStructDiamondInLoopArg<T>(@_noImplicitCopy _ x2: AggGeneri
 }
 
 public func aggGenericStructDiamondInLoopOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           aggGenericStructConsume(x2) // expected-note {{consuming use here}}
       } else {
           aggGenericStructConsume(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -1562,9 +1574,9 @@ public func enumDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { /
 }
 
 public func enumLoopConsume(_ x: EnumTy) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        enumConsume(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -1574,9 +1586,9 @@ public func enumLoopConsumeArg(@_noImplicitCopy _ x2: EnumTy) { // expected-erro
     }
 }
 
-public func enumLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
+public func enumLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        enumConsume(x2) // expected-note {{consuming use here}}
+        enumConsume(x2) // expected-note {{consuming in loop use here}}
     }
 }
 
@@ -1607,11 +1619,13 @@ public func enumDiamondOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) {
 
 public func enumDiamondInLoop(_ x: EnumTy) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           enumConsume(x2) // expected-note {{consuming use here}}
       } else {
           enumConsume(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -1627,11 +1641,13 @@ public func enumDiamondInLoopArg(@_noImplicitCopy _ x2: EnumTy) { // expected-er
 }
 
 public func enumDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           enumConsume(x2) // expected-note {{consuming use here}}
       } else {
           enumConsume(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming in loop use here}}
       }
     }
 }
@@ -1716,11 +1732,9 @@ public func enumAssignToVar4OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { //
 }
 
 public func enumAssignToVar5(_ x: EnumTy) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
-    // TODO: Need to mark this as the lifetime extending use. We fail
-    // appropriately though.
-    enumUseMoveOnlyWithoutEscaping(x2)
+    enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
     x3 = x
     print(x3)
 }
@@ -1734,11 +1748,9 @@ public func enumAssignToVar5Arg(_ x: EnumTy, @_noImplicitCopy _ x2: EnumTy) { //
     print(x3)
 }
 
-public func enumAssignToVar5OwnedArg(_ x: EnumTy, @_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
+public func enumAssignToVar5OwnedArg(_ x: EnumTy, @_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
-    // TODO: Need to mark this as the lifetime extending use. We fail
-    // appropriately though.
-    enumUseMoveOnlyWithoutEscaping(x2)
+    enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
     x3 = x
     print(x3)
 }
@@ -1772,9 +1784,9 @@ public func enumPatternMatchIfLet1OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy
 }
 
 public func enumPatternMatchIfLet2(_ x: EnumTy) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consuming in loop use here}}
             classUseMoveOnlyWithoutEscaping(x)
         }
     }
@@ -1788,9 +1800,9 @@ public func enumPatternMatchIfLet2Arg(@_noImplicitCopy _ x2: EnumTy) { // expect
     }
 }
 
-public func enumPatternMatchIfLet2OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
+public func enumPatternMatchIfLet2OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consuming in loop use here}}
             classUseMoveOnlyWithoutEscaping(x)
         }
     }
@@ -1798,13 +1810,11 @@ public func enumPatternMatchIfLet2OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy
 
 // This is wrong.
 public func enumPatternMatchSwitch1(_ x: EnumTy) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
         classUseMoveOnlyWithoutEscaping(k)
-        // This should be flagged as the use after free use. We are atleast
-        // erroring though.
-        enumUseMoveOnlyWithoutEscaping(x2)
+        enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
     case .int:
         break
     }
@@ -1822,13 +1832,11 @@ public func enumPatternMatchSwitch1Arg(@_noImplicitCopy _ x2: EnumTy) { // expec
     }
 }
 
-public func enumPatternMatchSwitch1OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
+public func enumPatternMatchSwitch1OwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
         classUseMoveOnlyWithoutEscaping(k)
-        // This should be flagged as the use after free use. We are atleast
-        // erroring though.
-        enumUseMoveOnlyWithoutEscaping(x2)
+        enumUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
     case .int:
         break
     }
@@ -1864,10 +1872,10 @@ public func enumPatternMatchSwitch2OwnedArg(@_noImplicitCopy _ x2: __owned EnumT
 
 // QOI: We can do better here. We should also flag x2
 public func enumPatternMatchSwitch2WhereClause(_ x: EnumTy) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
-           where x2.doSomething():
+           where x2.doSomething(): // expected-note {{non-consuming use here}}
         classUseMoveOnlyWithoutEscaping(k)
     case .int:
         break
@@ -1888,10 +1896,10 @@ public func enumPatternMatchSwitch2WhereClauseArg(@_noImplicitCopy _ x2: EnumTy)
     }
 }
 
-public func enumPatternMatchSwitch2WhereClauseOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
+public func enumPatternMatchSwitch2WhereClauseOwnedArg(@_noImplicitCopy _ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
-           where x2.doSomething():
+           where x2.doSomething(): // expected-note {{non-consuming use here}}
         classUseMoveOnlyWithoutEscaping(k)
     case .int:
         break
@@ -2033,11 +2041,8 @@ public func deferCaptureClassUseAfterConsume(_ x: Klass) {
 }
 
 public func deferCaptureClassUseAfterConsume2(_ x: Klass) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
-
-    // TODO: Defer error is b/c we have to lifetime extend x2 for the defer. The
-    // use is a guaranteed use, so we don't emit an error on that use.
-    defer {
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
+    defer { // expected-note {{non-consuming use here}}
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2)
         print(x2)
@@ -2065,8 +2070,8 @@ public func deferCaptureClassOwnedArgUseAfterConsume(@_noImplicitCopy _ x2: __ow
     print("foo")
 }
 
-public func deferCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
-    defer {
+public func deferCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCopy _ x2: __owned Klass) { // expected-error {{'x2' used after consume}}
+    defer { // expected-note {{non-consuming use here}}
         classUseMoveOnlyWithoutEscaping(x2)
         classConsume(x2)
         print(x2)

--- a/test/SILOptimizer/noimplicitcopy_trivial.swift
+++ b/test/SILOptimizer/noimplicitcopy_trivial.swift
@@ -50,12 +50,16 @@ public func trivialMultipleNonConsumingUseTestOwnedArg(@_noImplicitCopy _ x2: __
 }
 
 public func trivialUseAfterConsume(_ x: Trivial) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     let y = x2 // expected-note {{consuming use here}}
     let z = x2 // expected-note {{consuming use here}}
+    // expected-note @-1 {{consuming use here}}
     let _ = y
     let _ = z
-    print(x2) // expected-note {{consuming use here}}
+    print(x2)
+    // expected-note @-1 {{consuming use here}}
 }
 
 public func trivialUseAfterConsumeArg(@_noImplicitCopy _ x2: Trivial) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
@@ -66,12 +70,16 @@ public func trivialUseAfterConsumeArg(@_noImplicitCopy _ x2: Trivial) { // expec
     print(x2) // expected-note {{consuming use here}}
 }
 
-public func trivialUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' consumed more than once}}
+public func trivialUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Trivial) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     let y = x2 // expected-note {{consuming use here}}
     let z = x2 // expected-note {{consuming use here}}
+    // expected-note @-1 {{consuming use here}}
     let _ = y
     let _ = z
-    print(x2) // expected-note {{consuming use here}}
+    print(x2)
+    // expected-note @-1 {{consuming use here}}
 }
 
 public func trivialDoubleConsume(_ x: Trivial) {
@@ -97,9 +105,9 @@ public func trivialDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Trivial)
 }
 
 public func trivialLoopConsume(_ x: Trivial) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        let y = x2 // expected-note {{consuming use here}}
+        let y = x2 // expected-note {{consuming in loop use here}}
         let _ = y
     }
 }
@@ -111,9 +119,9 @@ public func trivialLoopConsumeArg(@_noImplicitCopy _ x2: Trivial) { // expected-
     }
 }
 
-public func trivialLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' consumed more than once}}
+public func trivialLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        let y = x2 // expected-note {{consuming use here}}
+        let y = x2 // expected-note {{consuming in loop use here}}
         let _ = y
     }
 }
@@ -151,12 +159,14 @@ public func trivialDiamondOwnedArg(@_noImplicitCopy _ x2: __owned Trivial) {
 
 public func trivialDiamondInLoop(_ x: Trivial) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           let y = x2 // expected-note {{consuming use here}}
           let _ = y
       } else {
-          let z = x2 // expected-note {{consuming use here}}
+          let z = x2 // expected-note {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
           let _ = z
       }
     }
@@ -174,13 +184,16 @@ public func trivialDiamondInLoopArg(@_noImplicitCopy _ x2: Trivial) { // expecte
     }
 }
 
-public func trivialDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' consumed more than once}}
+public func trivialDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned Trivial) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
       if boolValue {
           let y = x2 // expected-note {{consuming use here}}
           let _ = y
       } else {
-          let z = x2 // expected-note {{consuming use here}}
+          let z = x2 // expected-note {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
           let _ = z
       }
     }
@@ -266,9 +279,9 @@ public func trivialAssignToVar4OwnedArg(@_noImplicitCopy _ x2: __owned Trivial) 
 }
 
 public func trivialAssignToVar5(_ x: Trivial) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
-    trivialUseMoveOnlyWithoutEscaping(x2)
+    trivialUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
     x3 = x
     print(x3)
 }
@@ -280,9 +293,9 @@ public func trivialAssignToVar5Arg(_ x: Trivial, @_noImplicitCopy _ x2: Trivial)
     print(x3)
 }
 
-public func trivialAssignToVar5OwnedArg(_ x: Trivial, @_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' consumed more than once}}
+public func trivialAssignToVar5OwnedArg(_ x: Trivial, @_noImplicitCopy _ x2: __owned Trivial) { // expected-error {{'x2' used after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
-    trivialUseMoveOnlyWithoutEscaping(x2)
+    trivialUseMoveOnlyWithoutEscaping(x2) // expected-note {{non-consuming use here}}
     x3 = x
     print(x3)
 }
@@ -376,10 +389,13 @@ public func aggStructMultipleNonConsumingUseTestOwnedArg(@_noImplicitCopy _ x2: 
 }
 
 public func aggStructUseAfterConsume(_ x: AggStruct) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     let y = x2 // expected-note {{consuming use here}}
     let _ = y
     let z = x2 // expected-note {{consuming use here}}
+    // expected-note @-1 {{consuming use here}}
     let _ = z
     print(x2) // expected-note {{consuming use here}}
 }
@@ -393,10 +409,13 @@ public func aggStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // e
 }
 
 
-public func aggStructUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
+public func aggStructUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     let y = x2 // expected-note {{consuming use here}}
     let _ = y
     let z = x2 // expected-note {{consuming use here}}
+    // expected-note @-1 {{consuming use here}}
     let _ = z
     print(x2) // expected-note {{consuming use here}}
 }
@@ -424,9 +443,9 @@ public func aggStructDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStr
 }
 
 public func aggStructLoopConsume(_ x: AggStruct) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        let y = x2 // expected-note {{consuming use here}}
+        let y = x2 // expected-note {{consuming in loop use here}}
         let _ = y
     }
 }
@@ -438,9 +457,9 @@ public func aggStructLoopConsumeArg(@_noImplicitCopy _ x2: AggStruct) { // expec
     }
 }
 
-public func aggStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
+public func aggStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        let y = x2 // expected-note {{consuming use here}}
+        let y = x2 // expected-note {{consuming in loop use here}}
         let _ = y
     }
 }
@@ -477,17 +496,17 @@ public func aggStructDiamondOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) {
 }
 
 public func aggStructDiamondInLoop(_ x: AggStruct) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
+    // expected-error @-1 {{'x2' used after consume}}
     for _ in 0..<1024 {
         if boolValue {
             let y = x2 // expected-note {{consuming use here}}
             let _ = y
-
-            aggStructConsume(x2)
+            aggStructConsume(x2) // expected-note {{non-consuming use here}}
         } else {
             let y = x2 // expected-note {{consuming use here}}
             let _ = y
-            aggStructConsume(x2)
+            aggStructConsume(x2) // expected-note {{non-consuming use here}}
         }
     }
 }
@@ -507,17 +526,17 @@ public func aggStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggStruct) { // exp
     }
 }
 
-public func aggStructDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' consumed more than once}}
+public func aggStructDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned AggStruct) { // expected-error {{'x2' used after consume}}
+    // expected-error @-1 {{'x2' used after consume}}
     for _ in 0..<1024 {
         if boolValue {
             let y = x2 // expected-note {{consuming use here}}
             let _ = y
-
-            aggStructConsume(x2)
+            aggStructConsume(x2) // expected-note {{non-consuming use here}}
         } else {
             let y = x2 // expected-note {{consuming use here}}
             let _ = y
-            aggStructConsume(x2)
+            aggStructConsume(x2) // expected-note {{non-consuming use here}}
         }
     }
 }
@@ -610,12 +629,12 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg(@_noImplicitCopy
 }
 
 public func aggGenericStructUseAfterConsume(_ x: AggGenericStruct<Trivial>) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     let y = x2  // expected-note {{consuming use here}}
     let _ = y
-    aggGenericStructConsume(x2)
-    print(x2) // expected-note {{consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{non-consuming use here}}
+    print(x2)
 }
 
 public func aggGenericStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggGenericStruct<Trivial>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
@@ -626,12 +645,12 @@ public func aggGenericStructUseAfterConsumeArg(@_noImplicitCopy _ x2: AggGeneric
     print(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) { // expected-error {{'x2' consumed more than once}}
+public func aggGenericStructUseAfterConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) { // expected-error {{'x2' used after consume}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     let y = x2  // expected-note {{consuming use here}}
     let _ = y
-    aggGenericStructConsume(x2)
-    print(x2) // expected-note {{consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{non-consuming use here}}
+    print(x2)
 }
 
 public func aggGenericStructDoubleConsume(_ x: AggGenericStruct<Trivial>) {
@@ -657,9 +676,9 @@ public func aggGenericStructDoubleConsumeOwnedArg(@_noImplicitCopy _ x2: __owned
 }
 
 public func aggGenericStructLoopConsume(_ x: AggGenericStruct<Trivial>) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        let y = x2  // expected-note {{consuming use here}}
+        let y = x2  // expected-note {{consuming in loop use here}}
         let _ = y
     }
 }
@@ -671,22 +690,21 @@ public func aggGenericStructLoopConsumeArg(@_noImplicitCopy _ x2: AggGenericStru
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) { // expected-error {{'x2' consumed more than once}}
+public func aggGenericStructLoopConsumeOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        let y = x2  // expected-note {{consuming use here}}
+        let y = x2  // expected-note {{consuming in loop use here}}
         let _ = y
     }
 }
 
-// This is wrong.
 public func aggGenericStructDiamond(_ x: AggGenericStruct<Trivial>) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
     if boolValue {
         let y = x2 // expected-note {{consuming use here}}
         let _ = y
-        aggGenericStructConsume(x2)
+        aggGenericStructConsume(x2) // expected-note {{non-consuming use here}}
     } else {
-        let z = x2 // expected-note {{consuming use here}}
+        let z = x2
         let _ = z
     }
 }
@@ -702,25 +720,27 @@ public func aggGenericStructDiamondArg(@_noImplicitCopy _ x2: AggGenericStruct<T
     }
 }
 
-public func aggGenericStructDiamondOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) { // expected-error {{'x2' consumed more than once}}
+public func aggGenericStructDiamondOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) { // expected-error {{'x2' used after consume}}
     if boolValue {
         let y = x2 // expected-note {{consuming use here}}
         let _ = y
-        aggGenericStructConsume(x2)
+        aggGenericStructConsume(x2) // expected-note {{non-consuming use here}}
     } else {
-        let z = x2 // expected-note {{consuming use here}}
+        let z = x2
         let _ = z
     }
 }
 
 public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<Trivial>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
         if boolValue {
             let y = x2 // expected-note {{consuming use here}}
             let _ = y
         } else {
             let y = x2 // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming in loop use here}}
             let _ = y
         }
     }
@@ -738,13 +758,16 @@ public func aggGenericStructDiamondInLoopArg(@_noImplicitCopy _ x2: AggGenericSt
     }
 }
 
-public func aggGenericStructDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) { // expected-error {{'x2' consumed more than once}}
+public func aggGenericStructDiamondInLoopOwnedArg(@_noImplicitCopy _ x2: __owned AggGenericStruct<Trivial>) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
         if boolValue {
             let y = x2 // expected-note {{consuming use here}}
             let _ = y
         } else {
             let y = x2 // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming in loop use here}}
             let _ = y
         }
     }
@@ -833,12 +856,12 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg<T>(@_noImplicitC
 }
 
 public func aggGenericStructUseAfterConsume<T>(_ x: AggGenericStruct<T>) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' used after consume}}
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     let y = x2 // expected-note {{consuming use here}}
     let _ = y
-    aggGenericStructConsume(x2)
-    print(x2) // expected-note {{consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{non-consuming use here}}
+    print(x2)
 }
 
 public func aggGenericStructUseAfterConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
@@ -849,12 +872,12 @@ public func aggGenericStructUseAfterConsumeArg<T>(@_noImplicitCopy _ x2: AggGene
     print(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructUseAfterConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
+public func aggGenericStructUseAfterConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' used after consume}} 
     aggGenericStructUseMoveOnlyWithoutEscaping(x2)
     let y = x2 // expected-note {{consuming use here}}
     let _ = y
-    aggGenericStructConsume(x2)
-    print(x2) // expected-note {{consuming use here}}
+    aggGenericStructConsume(x2) // expected-note {{non-consuming use here}}
+    print(x2)
 }
 
 public func aggGenericStructDoubleConsume<T>(_ x: AggGenericStruct<T>) {
@@ -880,9 +903,9 @@ public func aggGenericStructDoubleConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __ow
 }
 
 public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) {
-    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        let z = x2 // expected-note {{consuming use here}}
+        let z = x2 // expected-note {{consuming in loop use here}}
         let _ = z
     }
 }
@@ -894,9 +917,9 @@ public func aggGenericStructLoopConsumeArg<T>(@_noImplicitCopy _ x2: AggGenericS
     }
 }
 
-public func aggGenericStructLoopConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
+public func aggGenericStructLoopConsumeOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        let z = x2 // expected-note {{consuming use here}}
+        let z = x2 // expected-note {{consuming in loop use here}}
         let _ = z
     }
 }
@@ -934,12 +957,14 @@ public func aggGenericStructDiamondOwnedArg<T>(@_noImplicitCopy _ x2: __owned Ag
 
 public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) {
     @_noImplicitCopy let x2 = x // expected-error {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
         if boolValue {
             let z = x2 // expected-note {{consuming use here}}
             let _ = z
         } else {
             let y = x2 // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming in loop use here}}
             let _ = y
         }
     }
@@ -957,13 +982,16 @@ public func aggGenericStructDiamondInLoopArg<T>(@_noImplicitCopy _ x2: AggGeneri
     }
 }
 
-public func aggGenericStructDiamondInLoopOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed more than once}}
+public func aggGenericStructDiamondInLoopOwnedArg<T>(@_noImplicitCopy _ x2: __owned AggGenericStruct<T>) {
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
         if boolValue {
             let z = x2 // expected-note {{consuming use here}}
             let _ = z
         } else {
             let y = x2 // expected-note {{consuming use here}}
+            // expected-note @-1 {{consuming in loop use here}}
             let _ = y
         }
     }


### PR DESCRIPTION
Specifically:

1. I refactored CanonicalizeOSSA so that callers (that is the move object checker) are able to use its internal liveness information before it does any rewriting. This change in design let me eliminate the callbacks from its rewriting implementation and also emit the missing non-consuming use remarks.
2. I changed how we emit the actual diagnostic in the move only object checker so instead of just dumping all of the consuming/non-consuming uses, we actually go search for a reachable use from the non-boundary consuming use that we found. This means that when we emit the error, you will not see consuming boundary uses that are not actually important to the boundary computation.