### PR TITLE
[move-only] Ban move only enums from being indirect or having indirect fields.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6656,6 +6656,8 @@ ERROR(noimplicitcopy_attr_invalid_in_generic_context,
 ERROR(moveonly_generics, none, "move-only type %0 cannot be used with generics yet", (Type))
 ERROR(noimplicitcopy_attr_not_allowed_on_moveonlytype,none,
       "'@_noImplicitCopy' has no effect when applied to a move only type", ())
+ERROR(moveonly_enums_do_not_support_indirect,none,
+      "move-only enum %0 cannot be marked indirect or have indirect cases yet", (Identifier))
 
 //------------------------------------------------------------------------------
 // MARK: Type inference from default expressions

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2586,6 +2586,20 @@ public:
     TypeChecker::checkDeclCircularity(ED);
 
     TypeChecker::checkConformancesInContext(ED);
+
+    // If our enum is marked as move only, it cannot be indirect or have any
+    // indirect cases.
+    if (ED->getAttrs().hasAttribute<MoveOnlyAttr>()) {
+      if (ED->isIndirect())
+        ED->diagnose(diag::moveonly_enums_do_not_support_indirect,
+                     ED->getBaseIdentifier());
+      for (auto *elt : ED->getAllElements()) {
+        if (elt->isIndirect()) {
+          elt->diagnose(diag::moveonly_enums_do_not_support_indirect,
+                        ED->getBaseIdentifier());
+        }
+      }
+    }
   }
 
   void visitStructDecl(StructDecl *SD) {

--- a/test/Sema/moveonly_indirect_enum.swift
+++ b/test/Sema/moveonly_indirect_enum.swift
@@ -1,0 +1,29 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-move-only
+
+// This test validates that move only enums cannot be marked indirect or have
+// indirect cases.
+
+@_moveOnly
+struct S {
+    var i = 5
+}
+
+@_moveOnly enum E { }
+
+@_moveOnly
+enum E1 {
+    case first
+    case second(S)
+}
+
+@_moveOnly
+indirect enum E2 { // expected-error {{move-only enum 'E2' cannot be marked indirect or have indirect cases yet}}
+    case first
+    case second(S)
+}
+
+@_moveOnly
+enum E3 {
+    case first
+    indirect case second(S) // expected-error {{move-only enum 'E3' cannot be marked indirect or have indirect cases yet}}
+}


### PR DESCRIPTION
Banning it for now to close a hole in the model. We just want to implement it at a later point in time.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
