### PR TITLE
Break cyclic dependency due to implicit initialization of optional properties

### DIFF
--- a/test/Macros/accessor_macros.swift
+++ b/test/Macros/accessor_macros.swift
@@ -53,7 +53,7 @@ struct MyStruct {
   // CHECK-DUMP: }
 
   @myPropertyWrapper
-  var birthDate: Date? = nil
+  var birthDate: Date?
   // CHECK-DUMP: @__swiftmacro_15accessor_macros8MyStructV9birthDateAA0F0VSgvp17myPropertyWrapperfMa_.swift 
   // CHECK-DUMP: get {
   // CHECK-DUMP:   _birthDate.wrappedValue


### PR DESCRIPTION
The fundamental problem here is that we don't know a priori whether an accessor macro will convert a stored property into a computed one. That can only be determined after macro expansion, which depends on having a determined type for the property.

Implicit initialization of optional-typed values (e.g., "var birthDate: Date?") adds the initializer when there is storage, triggering the cycle. Introduce a very narrow fix that assumes that properties that have an accessor macro on them do not have storage. We probably want to enforce this, so that the "does this variable have storage?" query can be made cheaper.
