### PR TITLE
[github] Sync feature request issue template with a recent label rename

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Share an idea
 title: ''
-labels: feature request, triage needed
+labels: feature, triage needed
 assignees: ''
 
 ---


### PR DESCRIPTION
I merged the "API request" and "feature request" labels into a single "feature" label the other day and forgot to update the template.