### PR TITLE
[docs] Suggest `ninja bin/swift-frontend` instead of `ninja swift-frontend`

### DIFF
--- a/SwiftCompilerSources/README.md
+++ b/SwiftCompilerSources/README.md
@@ -24,7 +24,7 @@ The bootstrapping mode is cached in the `CMakeCache.txt` file in the Swift build
 
 ### Bootstrapping
 
-The bootstrapping process is completely implemented with CMake dependencies. The build-script is not required to build the whole bootstrapping chain. For example, a `ninja swift-frontend` invocation builds all the required bootstrapping steps required for the final `swift-frontend`.
+The bootstrapping process is completely implemented with CMake dependencies. The build-script is not required to build the whole bootstrapping chain. For example, a `ninja bin/swift-frontend` invocation builds all the required bootstrapping steps required for the final `swift-frontend`.
 
 Bootstrapping involves the following steps:
 

--- a/docs/DevelopmentTips.md
+++ b/docs/DevelopmentTips.md
@@ -45,7 +45,7 @@ DYLD_LIBRARY_PATH=/Library/Developer/Toolchains/swift-LOCAL-YYYY-MM-DD.xctoolcha
 ### Working with two build directories
 For developing and debugging you are probably building a debug configuration of swift. But it's often beneficial to also build a release-assert configuration in parallel (`utils/build-script -R`).
 
-The standard library takes very long to build with a debug compiler. It's much faster to build everything (including the standard library) with a release compiler and only the swift-frontend (with `ninja swift-frontend`) in debug. Then copy the release-built standard library to the debug build:
+The standard library takes very long to build with a debug compiler. It's much faster to build everything (including the standard library) with a release compiler and only the swift-frontend (with `ninja bin/swift-frontend`) in debug. Then copy the release-built standard library to the debug build:
 ```
 src=/path/to/build/Ninja-ReleaseAssert/swift-macosx-x86_64
 dst=/path/to/build/Ninja-DebugAssert/swift-macosx-x86_64

--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -250,11 +250,16 @@ Phew, that's a lot to digest! Now let's proceed to the actual build itself!
      ```
      If you installed and want to use Sccache, include the `--sccache` option in
      the invocation as well.
+   <!-- FIXME: Without this "hard" line break, the note doesn’t get properly spaced from the bullet -->
+   <br />
 
    > **Note**  
-   > If you aren't planning to edit the parts of the compiler that are written
-   > in Swift, pass `--bootstrapping=hosttools` to speed up local development.
-   > This requires a recent Xcode and/or swift toolchain to be installed.
+   > If you are planning to work on the compiler, but not the parts that are
+   > written in Swift, pass `--bootstrapping=hosttools` to speed up local
+   > development. Note that on Linux — unlike macOS, where the toolchain already
+   > comes with Xcode — this option additionally requires
+   > [a recent Swift toolchain](https://www.swift.org/download/) to be
+   > installed.
 
    This will create a directory `swift-project/build/Ninja-RelWithDebInfoAssert`
    containing the Swift compiler and standard library and clang/LLVM build artifacts.


### PR DESCRIPTION
...to cope with a bootstrapping quirk on arm64 Macs. 

An iteration on #63381.
