### PR TITLE
Remove linear map structs and use plain tuples instead.

### DIFF
--- a/include/swift/SILOptimizer/Differentiation/LinearMapInfo.h
+++ b/include/swift/SILOptimizer/Differentiation/LinearMapInfo.h
@@ -69,8 +69,8 @@ private:
   /// Differentiation indices of the function.
   const AutoDiffConfig config;
 
-  /// Mapping from original basic blocks to linear map structs.
-  llvm::DenseMap<SILBasicBlock *, StructDecl *> linearMapStructs;
+  /// Mapping from original basic blocks to linear map tuple types.
+  llvm::DenseMap<SILBasicBlock *, TupleType *> linearMapTuples;
 
   /// Mapping from original basic blocks to branching trace enums.
   /// For pullbacks: these are predecessor enums.
@@ -78,16 +78,13 @@ private:
   llvm::DenseMap<SILBasicBlock *, EnumDecl *> branchingTraceDecls;
 
   /// Mapping from `apply` instructions in the original function to the
-  /// corresponding linear map field declaration in the linear map struct.
-  llvm::DenseMap<ApplyInst *, VarDecl *> linearMapFieldMap;
+  /// corresponding linear map tuple type index.
+  llvm::DenseMap<ApplyInst *, unsigned> linearMapIndexMap;
 
   /// Mapping from predecessor-successor basic block pairs in the original
   /// function to the corresponding branching trace enum case.
   llvm::DenseMap<std::pair<SILBasicBlock *, SILBasicBlock *>, EnumElementDecl *>
       branchingTraceEnumCases;
-
-  /// Mapping from linear map structs to their branching trace enum fields.
-  llvm::DenseMap<StructDecl *, VarDecl *> linearMapStructEnumFields;
 
   /// Blocks in a loop.
   llvm::SmallSetVector<SILBasicBlock *, 4> blocksInLoop;
@@ -102,37 +99,21 @@ private:
   /// Remaps the given type into the derivative function's context.
   SILType remapTypeInDerivative(SILType ty);
 
-  /// Adds a `VarDecl` member with the given name and type to the given nominal
-  /// declaration.
-  VarDecl *addVarDecl(NominalTypeDecl *nominal, StringRef name, Type type);
-
   /// Retrieves the file unit that contains implicit declarations in the
   /// current Swift module.
   SynthesizedFileUnit &getSynthesizedFile() { return synthesizedFile; }
-
-  /// Computes and sets the access level for the given nominal type, given the
-  /// original function linkage.
-  void computeAccessLevel(NominalTypeDecl *nominal, SILLinkage originalLinkage);
 
   /// Creates an enum declaration with the given JVP/VJP generic signature,
   /// whose cases represent the predecessors/successors of the given original
   /// block.
   EnumDecl *createBranchingTraceDecl(SILBasicBlock *originalBB,
-                                     CanGenericSignature genericSig,
-                                     SILLoopInfo *loopInfo);
+                                     CanGenericSignature genericSig);
+  void populateBranchingTraceDecl(SILBasicBlock *originalBB,
+                                  SILLoopInfo *loopInfo);
 
-  /// Creates a struct declaration with the given JVP/VJP generic signature, for
-  /// storing the linear map values and predecessor/successor basic block of the
-  /// given original block.
-  StructDecl *createLinearMapStruct(SILBasicBlock *originalBB,
-                                    CanGenericSignature genericSig);
-
-  /// Adds a linear map field to the linear map struct.
-  VarDecl *addLinearMapDecl(ApplyInst *ai, SILType linearMapType);
-
-  /// Given an `apply` instruction, conditionally adds a linear map struct field
-  /// for its linear map function if it is active.
-  void addLinearMapToStruct(ADContext &context, ApplyInst *ai);
+  /// Given an `apply` instruction, conditionally gets a linear map tuple field
+  /// AST type for its linear map function if it is active.
+  Type getLinearMapType(ADContext &context, ApplyInst *ai);
 
   /// Generates linear map struct and branching enum declarations for the given
   /// function. Linear map structs are populated with linear map fields and a
@@ -153,22 +134,20 @@ public:
                          const DifferentiableActivityInfo &activityInfo,
                          SILLoopInfo *loopInfo);
 
-  /// Returns the linear map struct associated with the given original block.
-  StructDecl *getLinearMapStruct(SILBasicBlock *origBB) const {
-    return linearMapStructs.lookup(origBB);
+  /// Returns the linear map tuple associated with the given original block.
+  TupleType *getLinearMapTupleType(SILBasicBlock *origBB) const {
+    return linearMapTuples.lookup(origBB);
   }
 
-  /// Returns the lowered SIL type of the linear map struct associated with the
+  /// Returns the lowered SIL type of the linear map tuple associated with the
   /// given original block.
-  SILType getLinearMapStructLoweredType(SILBasicBlock *origBB) const {
+  SILType getLinearMapTupleLoweredType(SILBasicBlock *origBB) const {
     auto derivativeGenSig =
         derivative->getLoweredFunctionType()->getSubstGenericSignature();
-    auto *linMapStruct = getLinearMapStruct(origBB);
-    auto linMapStructType =
-        linMapStruct->getDeclaredInterfaceType()->getReducedType(
-            derivativeGenSig);
-    Lowering::AbstractionPattern pattern(derivativeGenSig, linMapStructType);
-    return typeConverter.getLoweredType(pattern, linMapStructType,
+    auto linMapTupleType =
+      getLinearMapTupleType(origBB)->getReducedType(derivativeGenSig);
+    Lowering::AbstractionPattern pattern(derivativeGenSig, linMapTupleType);
+    return typeConverter.getLoweredType(pattern, linMapTupleType,
                                         TypeExpansionContext::minimal());
   }
 
@@ -199,27 +178,19 @@ public:
     return branchingTraceEnumCases.lookup({origPredBB, origSuccBB});
   }
 
-  /// Returns the mapping from linear map structs to their branching trace enum
-  /// fields.
-  llvm::DenseMap<StructDecl *, VarDecl *> &getLinearMapStructEnumFields() {
-    return linearMapStructEnumFields;
-  }
-
-  /// Returns the branching trace enum field for the linear map struct of the
-  /// given original block.
-  VarDecl *lookUpLinearMapStructEnumField(SILBasicBlock *origBB) const {
-    auto *linearMapStruct = getLinearMapStruct(origBB);
-    return linearMapStructEnumFields.lookup(linearMapStruct);
-  }
-
-  /// Finds the linear map declaration in the pullback struct for the given
+  /// Finds the linear map index in the pullback tuple for the given
   /// `apply` instruction in the original function.
-  VarDecl *lookUpLinearMapDecl(ApplyInst *ai) const {
+  unsigned lookUpLinearMapIndex(ApplyInst *ai) const {
     assert(ai->getFunction() == original);
-    auto lookup = linearMapFieldMap.find(ai);
-    assert(lookup != linearMapFieldMap.end() &&
+    auto lookup = linearMapIndexMap.find(ai);
+    assert(lookup != linearMapIndexMap.end() &&
            "No linear map field corresponding to the given `apply`");
     return lookup->getSecond();
+  }
+
+  Type lookUpLinearMapType(ApplyInst *ai) const {
+    unsigned idx = lookUpLinearMapIndex(ai);
+    return getLinearMapTupleType(ai->getParentBlock())->getElement(idx).getType();
   }
 
   bool hasLoops() const {

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -3449,6 +3449,36 @@ static void printSILDifferentiabilityWitnesses(
     dw->print(Ctx.OS(), Ctx.printVerbose());
 }
 
+static void printSILLinearMapTypes(SILPrintContext &Ctx,
+                                   const ModuleDecl *M) {
+  auto &OS = Ctx.OS();
+
+  PrintOptions Options = PrintOptions::printSIL();
+  Options.TypeDefinitions = true;
+  Options.VarInitializers = true;
+  Options.ExplodePatternBindingDecls = true;
+  Options.SkipImplicit = false;
+  Options.PrintGetSetOnRWProperties = true;
+  Options.PrintInSILBody = false;
+
+  SmallVector<Decl *, 32> topLevelDecls;
+  M->getTopLevelDecls(topLevelDecls);
+  for (const Decl *D : topLevelDecls) {
+    if (D->getDeclContext() == M)
+      continue;
+
+    if (!isa<StructDecl>(D) && !isa<EnumDecl>(D))
+      continue;
+
+    StringRef Name = cast<TypeDecl>(D)->getNameStr();
+    if (!Name.startswith("_AD__"))
+      continue;
+
+    D->print(OS, Options);
+    OS << "\n\n";
+  }
+}
+
 static void
 printSILCoverageMaps(SILPrintContext &Ctx,
                      const SILModule::CoverageMapCollectionType &CoverageMaps) {
@@ -3624,6 +3654,7 @@ void SILModule::print(SILPrintContext &PrintCtx, ModuleDecl *M,
   printSILGlobals(PrintCtx, getSILGlobalList());
   printSILDifferentiabilityWitnesses(PrintCtx,
                                      getDifferentiabilityWitnessList());
+  printSILLinearMapTypes(PrintCtx, getSwiftModule());
   printSILFunctions(PrintCtx, getFunctionList());
   printSILVTables(PrintCtx, getVTables());
   printSILWitnessTables(PrintCtx, getWitnessTableList());

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -2416,7 +2416,9 @@ static bool parseSILDifferentiabilityWitnessConfigAndFunction(
   auto origFnType = resultOrigFn->getLoweredFunctionType();
   auto *parameterIndices = IndexSubset::get(
       P.Context, origFnType->getNumParameters(), rawParameterIndices);
-  auto *resultIndices = IndexSubset::get(P.Context, origFnType->getNumResults(),
+  auto *resultIndices = IndexSubset::get(P.Context,
+                                         origFnType->getNumResults() +
+                                         origFnType->getNumIndirectMutatingParameters(),
                                          rawResultIndices);
   resultConfig = AutoDiffConfig(parameterIndices, resultIndices, witnessGenSig);
   return false;

--- a/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Linear map struct and branching trace enum information for differentiation.
+// Linear map tuple and branching trace enum information for differentiation.
 //
 //===----------------------------------------------------------------------===//
 
@@ -69,51 +69,11 @@ SILType LinearMapInfo::remapTypeInDerivative(SILType ty) {
   return derivative->mapTypeIntoContext(ty);
 }
 
-VarDecl *LinearMapInfo::addVarDecl(NominalTypeDecl *nominal, StringRef name,
-                                   Type type) {
-  auto &astCtx = nominal->getASTContext();
-  auto id = astCtx.getIdentifier(name);
-  auto *varDecl = new (astCtx) VarDecl(
-      /*IsStatic*/ false, VarDecl::Introducer::Var,
-      SourceLoc(), id, nominal);
-  varDecl->setAccess(AccessLevel::Private);
-  if (type->hasArchetype())
-    varDecl->setInterfaceType(type->mapTypeOutOfContext());
-  else
-    varDecl->setInterfaceType(type);
-  nominal->addMember(varDecl);
-  return varDecl;
-}
-
-void LinearMapInfo::computeAccessLevel(NominalTypeDecl *nominal,
-                                       SILLinkage originalLinkage) {
-  switch (originalLinkage) {
-  case swift::SILLinkage::Public:
-  case swift::SILLinkage::PublicNonABI:
-  case swift::SILLinkage::Hidden:
-  case swift::SILLinkage::Shared:
-    nominal->setAccess(AccessLevel::Internal);
-    break;
-  case swift::SILLinkage::Private:
-    nominal->setAccess(AccessLevel::FilePrivate);
-    break;
-  default:
-    // When the original function has external linkage, we create an internal
-    // struct for use by our own module. This is necessary for cross-cell
-    // differentiation in Jupyter.
-    // TODO: Add a test in the compiler that exercises a similar situation as
-    // cross-cell differentiation in Jupyter.
-    nominal->setAccess(AccessLevel::Internal);
-  }
-}
-
 EnumDecl *
 LinearMapInfo::createBranchingTraceDecl(SILBasicBlock *originalBB,
-                                        CanGenericSignature genericSig,
-                                        SILLoopInfo *loopInfo) {
+                                        CanGenericSignature genericSig) {
   assert(originalBB->getParent() == original);
   auto &astCtx = original->getASTContext();
-  auto *moduleDecl = original->getModule().getSwiftModule();
   auto &file = getSynthesizedFile();
   // Create a branching trace enum.
   Mangle::ASTMangler mangler;
@@ -132,32 +92,58 @@ LinearMapInfo::createBranchingTraceDecl(SILBasicBlock *originalBB,
   // Note: must mark enum as implicit to satisfy assertion in
   // `Parser::parseDeclListDelayed`.
   branchingTraceDecl->setImplicit();
-  // Branching trace enums shall not be resilient.
-  branchingTraceDecl->getAttrs().add(new (astCtx) FrozenAttr(/*implicit*/ true));
-  branchingTraceDecl->getAttrs().add(new (astCtx) UsableFromInlineAttr(/*Implicit*/ true));
   if (genericSig)
     branchingTraceDecl->setGenericSignature(genericSig);
-  computeAccessLevel(branchingTraceDecl, original->getEffectiveSymbolLinkage());
+  switch (original->getEffectiveSymbolLinkage()) {
+  case swift::SILLinkage::Public:
+  case swift::SILLinkage::PublicNonABI:
+    // Branching trace enums shall not be resilient.
+    branchingTraceDecl->getAttrs().add(new (astCtx) FrozenAttr(/*implicit*/ true));
+    branchingTraceDecl->getAttrs().add(new (astCtx) UsableFromInlineAttr(/*Implicit*/ true));
+    LLVM_FALLTHROUGH;
+  case swift::SILLinkage::Hidden:
+  case swift::SILLinkage::Shared:
+    branchingTraceDecl->setAccess(AccessLevel::Internal);
+    break;
+  case swift::SILLinkage::Private:
+    branchingTraceDecl->setAccess(AccessLevel::FilePrivate);
+    break;
+  default:
+    // When the original function has external linkage, we create an internal
+    // struct for use by our own module. This is necessary for cross-cell
+    // differentiation in Jupyter.
+    // TODO: Add a test in the compiler that exercises a similar situation as
+    // cross-cell differentiation in Jupyter.
+    branchingTraceDecl->setAccess(AccessLevel::Internal);
+  }
   file.addTopLevelDecl(branchingTraceDecl);
+
+  return branchingTraceDecl;
+}
+
+void LinearMapInfo::populateBranchingTraceDecl(SILBasicBlock *originalBB,
+                                               SILLoopInfo *loopInfo) {
+  auto &astCtx = original->getASTContext();
+  auto *moduleDecl = original->getModule().getSwiftModule();
+  auto loc = original->getLocation().getSourceLoc();
+  auto *branchingTraceDecl = getBranchingTraceDecl(originalBB);
+
   // Add basic block enum cases.
   for (auto *predBB : originalBB->getPredecessorBlocks()) {
     // Create dummy declaration representing enum case parameter.
     auto *decl = new (astCtx)
         ParamDecl(loc, loc, Identifier(), loc, Identifier(), moduleDecl);
     decl->setSpecifier(ParamDecl::Specifier::Default);
-    // If predecessor block is in a loop, its linear map struct will be
+    // If predecessor block is in a loop, its linear map tuple will be
     // indirectly referenced in memory owned by the context object. The payload
     // is just a raw pointer.
     if (loopInfo->getLoopFor(predBB)) {
       blocksInLoop.insert(predBB);
       decl->setInterfaceType(astCtx.TheRawPointerType);
     }
-    // Otherwise the payload is the linear map struct.
+    // Otherwise the payload is the linear map tuple.
     else {
-      auto *linearMapStruct = getLinearMapStruct(predBB);
-      assert(linearMapStruct);
-      auto linearMapStructTy =
-          linearMapStruct->getDeclaredInterfaceType()->getCanonicalType();
+      auto linearMapStructTy = getLinearMapTupleType(predBB)->getCanonicalType();
       decl->setInterfaceType(
           linearMapStructTy->hasArchetype()
               ? linearMapStructTy->mapTypeOutOfContext() : linearMapStructTy);
@@ -177,86 +163,10 @@ LinearMapInfo::createBranchingTraceDecl(SILBasicBlock *originalBB,
     // Record enum element declaration.
     branchingTraceEnumCases.insert({{predBB, originalBB}, enumEltDecl});
   }
-  return branchingTraceDecl;
 }
 
-StructDecl *
-LinearMapInfo::createLinearMapStruct(SILBasicBlock *originalBB,
-                                     CanGenericSignature genericSig) {
-  assert(originalBB->getParent() == original);
-  auto *original = originalBB->getParent();
-  auto &astCtx = original->getASTContext();
-  auto &file = getSynthesizedFile();
-  // Create a linear map struct.
-  Mangle::ASTMangler mangler;
-  auto config = this->config.withGenericSignature(genericSig);
-  auto structName = mangler.mangleAutoDiffGeneratedDeclaration(
-      AutoDiffGeneratedDeclarationKind::LinearMapStruct,
-      original->getName().str(), originalBB->getDebugID(), kind, config);
-  auto structId = astCtx.getIdentifier(structName);
-  GenericParamList *genericParams = nullptr;
-  if (genericSig)
-    genericParams = cloneGenericParameters(astCtx, &file, genericSig);
-  auto *linearMapStruct = new (astCtx) StructDecl(
-      /*StructLoc*/ SourceLoc(), /*Name*/ structId, /*NameLoc*/ SourceLoc(),
-      /*Inherited*/ {}, /*GenericParams*/ genericParams, /*DC*/ &file);
-  // Note: must mark struct as implicit to satisfy assertion in
-  // `Parser::parseDeclListDelayed`.
-  linearMapStruct->setImplicit();
-  // Linear map structs shall not be resilient.
-  linearMapStruct->getAttrs().add(new (astCtx) FrozenAttr(/*implicit*/ true));
-  linearMapStruct->getAttrs().add(new (astCtx) UsableFromInlineAttr(/*Implicit*/ true));
-  if (genericSig)
-    linearMapStruct->setGenericSignature(genericSig);
-  computeAccessLevel(linearMapStruct, original->getEffectiveSymbolLinkage());
-  file.addTopLevelDecl(linearMapStruct);
-  return linearMapStruct;
-}
 
-VarDecl *LinearMapInfo::addLinearMapDecl(ApplyInst *ai, SILType linearMapType) {
-  // IRGen requires decls to have AST types (not `SILFunctionType`), so we
-  // convert the `SILFunctionType` of the linear map to a `FunctionType` with
-  // the same parameters and results.
-  auto silFnTy = linearMapType.castTo<SILFunctionType>();
-  SmallVector<AnyFunctionType::Param, 8> params;
-  for (auto &param : silFnTy->getParameters()) {
-    ParameterTypeFlags flags;
-    if (param.isIndirectMutating())
-      flags = flags.withInOut(true);
-    params.push_back(
-        AnyFunctionType::Param(param.getInterfaceType(), Identifier(), flags));
-  }
-
-  AnyFunctionType *astFnTy;
-  if (auto genSig = silFnTy->getSubstGenericSignature()) {
-    // FIXME: Verify ExtInfo state is correct, not working by accident.
-    GenericFunctionType::ExtInfo info;
-    astFnTy = GenericFunctionType::get(
-        genSig, params, silFnTy->getAllResultsInterfaceType().getASTType(),
-        info);
-  } else {
-    FunctionType::ExtInfo info;
-    astFnTy = FunctionType::get(
-        params, silFnTy->getAllResultsInterfaceType().getASTType(), info);
-  }
-
-  auto *origBB = ai->getParent();
-  auto *linMapStruct = getLinearMapStruct(origBB);
-  std::string linearMapName;
-  switch (kind) {
-  case AutoDiffLinearMapKind::Differential:
-    linearMapName = "differential_" + llvm::itostr(linearMapFieldMap.size());
-    break;
-  case AutoDiffLinearMapKind::Pullback:
-    linearMapName = "pullback_" + llvm::itostr(linearMapFieldMap.size());
-    break;
-  }
-  auto *linearMapDecl = addVarDecl(linMapStruct, linearMapName, astFnTy);
-  linearMapFieldMap.insert({ai, linearMapDecl});
-  return linearMapDecl;
-}
-
-void LinearMapInfo::addLinearMapToStruct(ADContext &context, ApplyInst *ai) {
+Type LinearMapInfo::getLinearMapType(ADContext &context, ApplyInst *ai) {
   SmallVector<SILValue, 4> allResults;
   SmallVector<unsigned, 8> activeParamIndices;
   SmallVector<unsigned, 8> activeResultIndices;
@@ -282,9 +192,9 @@ void LinearMapInfo::addLinearMapToStruct(ADContext &context, ApplyInst *ai) {
     }
   }
   if (!hasActiveArguments)
-    return;
+    return {};
   if (!hasActiveResults && !hasActiveInoutArgument)
-    return;
+    return {};
 
   // Compute differentiability parameters.
   // - If the callee has `@differentiable` function type, use differentiation
@@ -339,7 +249,7 @@ void LinearMapInfo::addLinearMapToStruct(ADContext &context, ApplyInst *ai) {
     return false;
   };
   if (checkNondifferentiableOriginalFunctionType(remappedOrigFnSubstTy))
-    return;
+    return nullptr;
 
   AutoDiffDerivativeFunctionKind derivativeFnKind(kind);
   auto derivativeFnType =
@@ -360,7 +270,37 @@ void LinearMapInfo::addLinearMapToStruct(ADContext &context, ApplyInst *ai) {
     linearMapSILType = SILType::getPrimitiveObjectType(
         fnTy->getUnsubstitutedType(original->getModule()));
   }
-  addLinearMapDecl(ai, linearMapSILType);
+
+  // IRGen requires decls to have AST types (not `SILFunctionType`), so we
+  // convert the `SILFunctionType` of the linear map to a `FunctionType` with
+  // the same parameters and results.
+  auto silFnTy = linearMapSILType.castTo<SILFunctionType>();
+  SmallVector<AnyFunctionType::Param, 8> params;
+  for (auto &param : silFnTy->getParameters()) {
+    ParameterTypeFlags flags;
+    if (param.isIndirectMutating())
+      flags = flags.withInOut(true);
+    params.push_back(
+        AnyFunctionType::Param(param.getInterfaceType(), Identifier(), flags));
+  }
+
+  AnyFunctionType *astFnTy;
+  if (auto genSig = silFnTy->getSubstGenericSignature()) {
+    // FIXME: Verify ExtInfo state is correct, not working by accident.
+    GenericFunctionType::ExtInfo info;
+    astFnTy = GenericFunctionType::get(
+        genSig, params, silFnTy->getAllResultsInterfaceType().getASTType(),
+        info);
+  } else {
+    FunctionType::ExtInfo info;
+    astFnTy = FunctionType::get(
+        params, silFnTy->getAllResultsInterfaceType().getASTType(), info);
+  }
+
+  if (astFnTy->hasArchetype())
+    return astFnTy->mapTypeOutOfContext();
+
+  return astFnTy;
 }
 
 void LinearMapInfo::generateDifferentiationDataStructures(
@@ -371,12 +311,6 @@ void LinearMapInfo::generateDifferentiationDataStructures(
   if (auto *derivativeFnGenEnv = derivativeFn->getGenericEnvironment())
     derivativeFnGenSig =
         derivativeFnGenEnv->getGenericSignature().getCanonicalSignature();
-
-  // Create linear map struct for each original block.
-  for (auto &origBB : *original) {
-    auto *linearMapStruct = createLinearMapStruct(&origBB, derivativeFnGenSig);
-    linearMapStructs.insert({&origBB, linearMapStruct});
-  }
 
   // Create branching trace enum for each original block and add it as a field
   // in the corresponding struct.
@@ -389,43 +323,51 @@ void LinearMapInfo::generateDifferentiationDataStructures(
     traceEnumFieldName = "predecessor";
     break;
   }
+
   for (auto &origBB : *original) {
     auto *traceEnum =
-        createBranchingTraceDecl(&origBB, derivativeFnGenSig, loopInfo);
+        createBranchingTraceDecl(&origBB, derivativeFnGenSig);
     branchingTraceDecls.insert({&origBB, traceEnum});
-    if (origBB.isEntry())
-      continue;
-    // Add branching trace enum field to corresponding linear map struct.
-    auto *linearMapStruct = getLinearMapStruct(&origBB);
-    auto *traceEnumField = addVarDecl(
-        linearMapStruct, astCtx.getIdentifier(traceEnumFieldName).str(),
-        traceEnum->getDeclaredInterfaceType());
-    linearMapStructEnumFields.insert({linearMapStruct, traceEnumField});
   }
 
-  // Do not add linear map fields for semantic member accessors, which have
-  // special-case pullback generation. Linear map structs should be empty.
-  if (isSemanticMemberAccessor(original))
-    return;
-
-  // Add linear map fields to the linear map structs.
+  // Add linear map fields to the linear map tuples.
   for (auto &origBB : *original) {
-    for (auto &inst : origBB) {
-      if (auto *ai = dyn_cast<ApplyInst>(&inst)) {
-        // Add linear map field to struct for active `apply` instructions.
-        // Skip array literal intrinsic applications since array literal
-        // initialization is linear and handled separately.
-        if (!shouldDifferentiateApplySite(ai) ||
-            ArraySemanticsCall(ai, semantics::ARRAY_UNINITIALIZED_INTRINSIC))
-          continue;
-        if (ArraySemanticsCall(ai, semantics::ARRAY_FINALIZE_INTRINSIC))
-          continue;
-        LLVM_DEBUG(getADDebugStream()
-                   << "Adding linear map struct field for " << *ai);
-        addLinearMapToStruct(context, ai);
+    SmallVector<TupleTypeElt, 4> linearTupleTypes;
+    if (!origBB.isEntry()) {
+      CanType traceEnumType = getBranchingTraceEnumLoweredType(&origBB).getASTType();
+      linearTupleTypes.emplace_back(traceEnumType,
+                                    astCtx.getIdentifier(traceEnumFieldName));
+    }
+
+    if (isSemanticMemberAccessor(original)) {
+      // Do not add linear map fields for semantic member accessors, which have
+      // special-case pullback generation. Linear map tuples should be empty.
+    } else {
+      for (auto &inst : origBB) {
+        if (auto *ai = dyn_cast<ApplyInst>(&inst)) {
+          // Add linear map field to struct for active `apply` instructions.
+          // Skip array literal intrinsic applications since array literal
+          // initialization is linear and handled separately.
+          if (!shouldDifferentiateApplySite(ai) ||
+              ArraySemanticsCall(ai, semantics::ARRAY_UNINITIALIZED_INTRINSIC))
+            continue;
+          if (ArraySemanticsCall(ai, semantics::ARRAY_FINALIZE_INTRINSIC))
+            continue;
+          LLVM_DEBUG(getADDebugStream()
+                     << "Adding linear map tuple field for " << *ai);
+          if (Type linearMapType = getLinearMapType(context, ai)) {
+            linearMapIndexMap.insert({ai, linearTupleTypes.size()});
+            linearTupleTypes.emplace_back(linearMapType);
+          }
+        }
       }
     }
+
+    linearMapTuples.insert({&origBB, TupleType::get(linearTupleTypes, astCtx)});
   }
+
+  for (auto &origBB : *original)
+    populateBranchingTraceDecl(&origBB, loopInfo);
 
   // Print generated linear map structs and branching trace enums.
   // These declarations do not show up with `-emit-sil` because they are
@@ -437,13 +379,14 @@ void LinearMapInfo::generateDifferentiationDataStructures(
     printOptions.TypeDefinitions = true;
     printOptions.ExplodePatternBindingDecls = true;
     printOptions.SkipImplicit = false;
-    s << "Generated linear map structs and branching trace enums for @"
+    s << "Generated linear map tuples and branching trace enums for @"
       << original->getName() << ":\n";
     for (auto &origBB : *original) {
-      auto *linearMapStruct = getLinearMapStruct(&origBB);
-      linearMapStruct->print(s, printOptions);
+      auto *linearMapTuple = getLinearMapTupleType(&origBB);
+      linearMapTuple->print(s, printOptions);
       s << '\n';
     }
+
     for (auto &origBB : *original) {
       auto *traceEnum = getBranchingTraceDecl(&origBB);
       traceEnum->print(s, printOptions);

--- a/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
@@ -87,14 +87,9 @@ VarDecl *LinearMapInfo::addVarDecl(NominalTypeDecl *nominal, StringRef name,
 
 void LinearMapInfo::computeAccessLevel(NominalTypeDecl *nominal,
                                        SILLinkage originalLinkage) {
-  auto &astCtx = nominal->getASTContext();
   switch (originalLinkage) {
   case swift::SILLinkage::Public:
   case swift::SILLinkage::PublicNonABI:
-    nominal->setAccess(AccessLevel::Internal);
-    nominal->getAttrs().add(new (astCtx)
-                                UsableFromInlineAttr(/*Implicit*/ true));
-    break;
   case swift::SILLinkage::Hidden:
   case swift::SILLinkage::Shared:
     nominal->setAccess(AccessLevel::Internal);
@@ -139,6 +134,7 @@ LinearMapInfo::createBranchingTraceDecl(SILBasicBlock *originalBB,
   branchingTraceDecl->setImplicit();
   // Branching trace enums shall not be resilient.
   branchingTraceDecl->getAttrs().add(new (astCtx) FrozenAttr(/*implicit*/ true));
+  branchingTraceDecl->getAttrs().add(new (astCtx) UsableFromInlineAttr(/*Implicit*/ true));
   if (genericSig)
     branchingTraceDecl->setGenericSignature(genericSig);
   computeAccessLevel(branchingTraceDecl, original->getEffectiveSymbolLinkage());
@@ -209,6 +205,7 @@ LinearMapInfo::createLinearMapStruct(SILBasicBlock *originalBB,
   linearMapStruct->setImplicit();
   // Linear map structs shall not be resilient.
   linearMapStruct->getAttrs().add(new (astCtx) FrozenAttr(/*implicit*/ true));
+  linearMapStruct->getAttrs().add(new (astCtx) UsableFromInlineAttr(/*Implicit*/ true));
   if (genericSig)
     linearMapStruct->setGenericSignature(genericSig);
   computeAccessLevel(linearMapStruct, original->getEffectiveSymbolLinkage());

--- a/test/AutoDiff/SILOptimizer/derivative_sil.swift
+++ b/test/AutoDiff/SILOptimizer/derivative_sil.swift
@@ -26,19 +26,11 @@ func foo(_ x: Float) -> Float {
   return y
 }
 
-// CHECK-SIL-LABEL: @frozen struct _AD__foo_bb0__PB__src_0_wrt_0 {
-// CHECK-SIL:   @_hasStorage var pullback_0: (Float) -> (Float, Float) { get set }
-// CHECK-SIL: }
+// CHECK-SIL-LABEL: enum _AD__foo_bb0__Pred__src_0_wrt_0 {
+// CHECK-SIL-NEXT:  }
 
-// CHECK-SIL-LABEL: @frozen enum _AD__foo_bb0__Pred__src_0_wrt_0 {
-// CHECK-SIL-NEXT: }
-
-// CHECK-SIL-LABEL: @frozen struct _AD__fooMethod_bb0__PB__src_0_wrt_0 {
-// CHECK-SIL:   @_hasStorage var pullback_0: (Float) -> (Float, Float) { get set }
-// CHECK-SIL: }
-
-// CHECK-SIL-LABEL: @frozen enum _AD__fooMethod_bb0__Pred__src_0_wrt_0 {
-// CHECK-SIL-NEXT: }
+// CHECK-SIL-LABEL: enum _AD__fooMethod_bb0__Pred__src_0_wrt_0 {
+// CHECK-SIL-NEXT:  }
 
 // CHECK-SIL-LABEL: sil hidden [ossa] @fooTJfSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
 // CHECK-SIL: bb0([[X:%.*]] : $Float):
@@ -49,16 +41,16 @@ func foo(_ x: Float) -> Float {
 // CHECK-SIL:   [[ADD_JVP_FN:%.*]] = differentiable_function_extract [jvp] [[ADD_DIFF_FN]]
 // CHECK-SIL:   [[ADD_RESULT:%.*]] = apply [[ADD_JVP_FN]]([[X]], [[X]], {{.*}})
 // CHECK-SIL:   ([[ORIG_RES:%.*]], [[ADD_DF:%.*]]) = destructure_tuple [[ADD_RESULT]]
-// CHECK-SIL:   [[DF_STRUCT:%.*]] = struct $_AD__foo_bb0__DF__src_0_wrt_0 ([[ADD_DF]] : $@callee_guaranteed (Float, Float) -> Float)
-// CHECK-SIL:   [[DF_REF:%.*]] = function_ref @fooTJdSpSr : $@convention(thin) (Float, @owned _AD__foo_bb0__DF__src_0_wrt_0) -> Float
+// CHECK-SIL:   [[DF_STRUCT:%.*]] = tuple ([[ADD_DF]] : $@callee_guaranteed (Float, Float) -> Float)
+// CHECK-SIL:   [[DF_REF:%.*]] = function_ref @fooTJdSpSr : $@convention(thin) (Float, @owned (_: @callee_guaranteed (Float, Float) -> Float)) -> Float
 // CHECK-SIL:   [[DF_FN:%.*]] = partial_apply [callee_guaranteed] [[DF_REF]]([[DF_STRUCT]])
 // CHECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[ORIG_RES]] : $Float, [[DF_FN]] : $@callee_guaranteed (Float) -> Float)
 // CHECK-SIL:   return [[VJP_RESULT]] : $(Float, @callee_guaranteed (Float) -> Float)
 // CHECK-SIL: }
 
-// CHECK-SIL-LABEL: sil private [ossa] @fooTJdSpSr : $@convention(thin) (Float, @owned _AD__foo_bb0__DF__src_0_wrt_0) -> Float {
-// CHECK-SIL: bb0([[DX:%.*]] : $Float, [[DF_STRUCT:%.*]] : @owned $_AD__foo_bb0__DF__src_0_wrt_0):
-// CHECK-SIL:   [[ADD_DF:%.*]] = destructure_struct [[DF_STRUCT]] : $_AD__foo_bb0__DF__src_0_wrt_0
+// CHECK-SIL-LABEL: sil private [ossa] @fooTJdSpSr : $@convention(thin) (Float, @owned (_: @callee_guaranteed (Float, Float) -> Float)) -> Float {
+// CHECK-SIL: bb0([[DX:%.*]] : $Float, [[DF_STRUCT:%.*]] : @owned $(_: @callee_guaranteed (Float, Float) -> Float)):
+// CHECK-SIL:   [[ADD_DF:%.*]] = destructure_tuple [[DF_STRUCT]] : $(_: @callee_guaranteed (Float, Float) -> Float)
 // CHECK-SIL:   [[DY:%.*]] = apply [[ADD_DF]]([[DX]], [[DX]]) : $@callee_guaranteed (Float, Float) -> Float
 // CHECK-SIL:   destroy_value [[ADD_DF]] : $@callee_guaranteed (Float, Float) -> Float
 // CHECK-SIL:   return [[DY]] : $Float
@@ -73,16 +65,16 @@ func foo(_ x: Float) -> Float {
 // CHECK-SIL:   [[ADD_VJP_FN:%.*]] = differentiable_function_extract [vjp] [[ADD_DIFF_FN]]
 // CHECK-SIL:   [[ADD_RESULT:%.*]] = apply [[ADD_VJP_FN]]([[X]], [[X]], {{.*}})
 // CHECK-SIL:   ([[ORIG_RES:%.*]], [[ADD_PB:%.*]]) = destructure_tuple [[ADD_RESULT]]
-// CHECK-SIL:   [[PB_STRUCT:%.*]] = struct $_AD__foo_bb0__PB__src_0_wrt_0 ([[ADD_PB]] : $@callee_guaranteed (Float) -> (Float, Float))
-// CHECK-SIL:   [[PB_REF:%.*]] = function_ref @fooTJpSpSr : $@convention(thin) (Float, @owned _AD__foo_bb0__PB__src_0_wrt_0) -> Float
+// CHECK-SIL:   [[PB_STRUCT:%.*]] = tuple ([[ADD_PB]] : $@callee_guaranteed (Float) -> (Float, Float))
+// CHECK-SIL:   [[PB_REF:%.*]] = function_ref @fooTJpSpSr : $@convention(thin) (Float, @owned (_: @callee_guaranteed (Float) -> (Float, Float))) -> Float
 // CHECK-SIL:   [[PB_FN:%.*]] = partial_apply [callee_guaranteed] [[PB_REF]]([[PB_STRUCT]])
 // CHECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[ORIG_RES]] : $Float, [[PB_FN]] : $@callee_guaranteed (Float) -> Float)
 // CHECK-SIL:   return [[VJP_RESULT]] : $(Float, @callee_guaranteed (Float) -> Float)
 // CHECK-SIL: }
 
-// CHECK-SIL-LABEL: sil private [ossa] @fooTJpSpSr : $@convention(thin) (Float, @owned _AD__foo_bb0__PB__src_0_wrt_0) -> Float {
-// CHECK-SIL: bb0([[DY:%.*]] : $Float, [[PB_STRUCT:%.*]] : @owned $_AD__foo_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   [[ADD_PB:%.*]] = destructure_struct [[PB_STRUCT]] : $_AD__foo_bb0__PB__src_0_wrt_0
+// CHECK-SIL-LABEL: sil private [ossa] @fooTJpSpSr : $@convention(thin) (Float, @owned (_: @callee_guaranteed (Float) -> (Float, Float))) -> Float {
+// CHECK-SIL: bb0([[DY:%.*]] : $Float, [[PB_STRUCT:%.*]] : @owned $(_: @callee_guaranteed (Float) -> (Float, Float))):
+// CHECK-SIL:   [[ADD_PB:%.*]] = destructure_tuple [[PB_STRUCT]] : $(_: @callee_guaranteed (Float) -> (Float, Float))
 // CHECK-SIL:   debug_value [[DY]] : $Float, let, name "y"
 // CHECK-SIL:   [[ADD_PB_RES:%.*]] = apply [[ADD_PB]]([[DY]]) : $@callee_guaranteed (Float) -> (Float, Float)
 // CHECK-SIL:   ([[DX_1:%.*]], [[DX_2:%.*]]) = destructure_tuple [[ADD_PB_RES]] : $(Float, Float)
@@ -116,8 +108,8 @@ struct ExampleStruct {
 
 // CHECK-SIL-LABEL: sil hidden [ossa] @fooMethodTJfSUpSr  : $@convention(method) (Float, ExampleStruct) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
 
-// CHECK-SIL-LABEL: sil private [ossa] @fooMethodTJdSUpSr : $@convention(thin) (Float, @owned _AD__fooMethod_bb0__DF__src_0_wrt_0) -> Float {
+// CHECK-SIL-LABEL: sil private [ossa] @fooMethodTJdSUpSr : $@convention(thin) (Float, @owned (_: @callee_guaranteed (Float, Float) -> Float)) -> Float {
 
 // CHECK-SIL-LABEL: sil hidden [ossa] @fooMethodTJrSUpSr : $@convention(method) (Float, ExampleStruct) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
 
-// CHECK-SIL-LABEL: sil private [ossa] @fooMethodTJpSUpSr : $@convention(thin) (Float, @owned _AD__fooMethod_bb0__PB__src_0_wrt_0) -> Float {
+// CHECK-SIL-LABEL: sil private [ossa] @fooMethodTJpSUpSr : $@convention(thin) (Float, @owned (_: @callee_guaranteed (Float) -> (Float, Float))) -> Float {

--- a/test/AutoDiff/SILOptimizer/derivative_sil.swift
+++ b/test/AutoDiff/SILOptimizer/derivative_sil.swift
@@ -26,6 +26,20 @@ func foo(_ x: Float) -> Float {
   return y
 }
 
+// CHECK-SIL-LABEL: @frozen struct _AD__foo_bb0__PB__src_0_wrt_0 {
+// CHECK-SIL:   @_hasStorage var pullback_0: (Float) -> (Float, Float) { get set }
+// CHECK-SIL: }
+
+// CHECK-SIL-LABEL: @frozen enum _AD__foo_bb0__Pred__src_0_wrt_0 {
+// CHECK-SIL-NEXT: }
+
+// CHECK-SIL-LABEL: @frozen struct _AD__fooMethod_bb0__PB__src_0_wrt_0 {
+// CHECK-SIL:   @_hasStorage var pullback_0: (Float) -> (Float, Float) { get set }
+// CHECK-SIL: }
+
+// CHECK-SIL-LABEL: @frozen enum _AD__fooMethod_bb0__Pred__src_0_wrt_0 {
+// CHECK-SIL-NEXT: }
+
 // CHECK-SIL-LABEL: sil hidden [ossa] @fooTJfSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
 // CHECK-SIL: bb0([[X:%.*]] : $Float):
 // CHECK-SIL:   [[ADD_ORIG_REF:%.*]] = function_ref @add : $@convention(method) (Float, Float, @thin Float.Type) -> Float

--- a/test/AutoDiff/SILOptimizer/differentiation_control_flow_sil.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_control_flow_sil.swift
@@ -19,85 +19,79 @@ func cond(_ x: Float) -> Float {
   return x - x
 }
 
-// CHECK-DATA-STRUCTURES: struct _AD__cond_bb0__PB__src_0_wrt_0 {
-// CHECK-DATA-STRUCTURES: }
-// CHECK-DATA-STRUCTURES: struct _AD__cond_bb1__PB__src_0_wrt_0 {
-// CHECK-DATA-STRUCTURES:   var predecessor: _AD__cond_bb1__Pred__src_0_wrt_0
-// CHECK-DATA-STRUCTURES:   var pullback_0: (Float) -> (Float, Float)
-// CHECK-DATA-STRUCTURES: }
-// CHECK-DATA-STRUCTURES: struct _AD__cond_bb2__PB__src_0_wrt_0 {
-// CHECK-DATA-STRUCTURES:   var predecessor: _AD__cond_bb2__Pred__src_0_wrt_0
-// CHECK-DATA-STRUCTURES:   var pullback_1: (Float) -> (Float, Float)
-// CHECK-DATA-STRUCTURES: }
-// CHECK-DATA-STRUCTURES: struct _AD__cond_bb3__PB__src_0_wrt_0 {
-// CHECK-DATA-STRUCTURES:   var predecessor: _AD__cond_bb3__Pred__src_0_wrt_0
-// CHECK-DATA-STRUCTURES: }
+()
+
+// CHECK-DATA-STRUCTURES-LABEL: Generated linear map tuples and branching trace enums for @cond
+// CHECK-DATA-STRUCTURES: ()
+// CHECK-DATA-STRUCTURES: (predecessor: _AD__cond_bb1__Pred__src_0_wrt_0, (Float) -> (Float, Float))
+// CHECK-DATA-STRUCTURES: (predecessor: _AD__cond_bb2__Pred__src_0_wrt_0, (Float) -> (Float, Float))
+// CHECK-DATA-STRUCTURES: (predecessor: _AD__cond_bb3__Pred__src_0_wrt_0)
 // CHECK-DATA-STRUCTURES: enum _AD__cond_bb0__Pred__src_0_wrt_0 {
 // CHECK-DATA-STRUCTURES: }
 // CHECK-DATA-STRUCTURES: enum _AD__cond_bb1__Pred__src_0_wrt_0 {
-// CHECK-DATA-STRUCTURES:   case bb0(_AD__cond_bb0__PB__src_0_wrt_0)
+// CHECK-DATA-STRUCTURES:   case bb0(())
 // CHECK-DATA-STRUCTURES: }
 // CHECK-DATA-STRUCTURES: enum _AD__cond_bb2__Pred__src_0_wrt_0 {
-// CHECK-DATA-STRUCTURES:   case bb0(_AD__cond_bb0__PB__src_0_wrt_0)
+// CHECK-DATA-STRUCTURES:   case bb0(())
 // CHECK-DATA-STRUCTURES: }
 // CHECK-DATA-STRUCTURES: enum _AD__cond_bb3__Pred__src_0_wrt_0 {
-// CHECK-DATA-STRUCTURES:   case bb2(_AD__cond_bb2__PB__src_0_wrt_0)
-// CHECK-DATA-STRUCTURES:   case bb1(_AD__cond_bb1__PB__src_0_wrt_0)
+// CHECK-DATA-STRUCTURES:   case bb2((predecessor: _AD__cond_bb2__Pred__src_0_wrt_0, (Float) -> (Float, Float)))
+// CHECK-DATA-STRUCTURES:   case bb1((predecessor: _AD__cond_bb1__Pred__src_0_wrt_0, (Float) -> (Float, Float)))
 // CHECK-DATA-STRUCTURES: }
 
 // CHECK-SIL-LABEL: sil hidden [ossa] @condTJrSpSr : $@convention(thin) (Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
 // CHECK-SIL: bb0([[INPUT_ARG:%.*]] : $Float):
-// CHECK-SIL:   [[BB0_PB_STRUCT:%.*]] = struct $_AD__cond_bb0__PB__src_0_wrt_0 ()
+// CHECK-SIL:   [[BB0_PB_STRUCT:%.*]] = tuple ()
 // CHECK-SIL:   cond_br {{%.*}}, bb1, bb2
 
 // CHECK-SIL: bb1:
 // CHECK-SIL:   [[BB1_PRED:%.*]] = enum $_AD__cond_bb1__Pred__src_0_wrt_0, #_AD__cond_bb1__Pred__src_0_wrt_0.bb0!enumelt, [[BB0_PB_STRUCT]]
-// CHECK-SIL:   [[BB1_PB_STRUCT:%.*]] = struct $_AD__cond_bb1__PB__src_0_wrt_0
+// CHECK-SIL:   [[BB1_PB_STRUCT:%.*]] = tuple $(predecessor: _AD__cond_bb1__Pred__src_0_wrt_0, @callee_guaranteed (Float) -> (Float, Float)) ([[BB1_PRED]]
 // CHECK-SIL:   [[BB3_PRED_PRED1:%.*]] = enum $_AD__cond_bb3__Pred__src_0_wrt_0, #_AD__cond_bb3__Pred__src_0_wrt_0.bb1!enumelt, [[BB1_PB_STRUCT]]
 // CHECK-SIL:   br bb3({{.*}} : $Float, [[BB3_PRED_PRED1]] : $_AD__cond_bb3__Pred__src_0_wrt_0)
 
 // CHECK-SIL: bb2:
 // CHECK-SIL:   [[BB2_PRED:%.*]] = enum $_AD__cond_bb2__Pred__src_0_wrt_0, #_AD__cond_bb2__Pred__src_0_wrt_0.bb0!enumelt, [[BB0_PB_STRUCT]]
-// CHECK-SIL:   [[BB2_PB_STRUCT:%.*]] = struct $_AD__cond_bb2__PB__src_0_wrt_0
+// CHECK-SIL:   [[BB2_PB_STRUCT:%.*]] = tuple $(predecessor: _AD__cond_bb2__Pred__src_0_wrt_0, @callee_guaranteed (Float) -> (Float, Float)) ([[BB2_PRED]]
 // CHECK-SIL:   [[BB3_PRED_PRED2:%.*]] = enum $_AD__cond_bb3__Pred__src_0_wrt_0, #_AD__cond_bb3__Pred__src_0_wrt_0.bb2!enumelt, [[BB2_PB_STRUCT]]
 // CHECK-SIL:   br bb3({{.*}} : $Float, [[BB3_PRED_PRED2]] : $_AD__cond_bb3__Pred__src_0_wrt_0)
 
-// CHECK-SIL: bb3([[ORIG_RES:%.*]] : $Float, [[BB3_PRED_ARG:%.*]] : @owned $_AD__cond_bb3__Pred__src_0_wrt_0)
-// CHECK-SIL:   [[BB3_PB_STRUCT:%.*]] = struct $_AD__cond_bb3__PB__src_0_wrt_0
+// CHECK-SIL: bb3([[ORIG_RES:%.*]] : $Float, [[BB3_PRED_ARG:%.*]] : $_AD__cond_bb3__Pred__src_0_wrt_0)
+// CHECK-SIL:   [[BB3_PB_STRUCT:%.*]] = tuple $(predecessor: _AD__cond_bb3__Pred__src_0_wrt_0) ([[BB3_PRED_ARG]])
 // CHECK-SIL:   [[PULLBACK_REF:%.*]] = function_ref @condTJpSpSr
 // CHECK-SIL:   [[PB:%.*]] = partial_apply [callee_guaranteed] [[PULLBACK_REF]]([[BB3_PB_STRUCT]])
 // CHECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[ORIG_RES]] : $Float, [[PB]] : $@callee_guaranteed (Float) -> Float)
 // CHECK-SIL:   return [[VJP_RESULT]]
 
 
-// CHECK-SIL-LABEL: sil private [ossa] @condTJpSpSr : $@convention(thin) (Float, @owned _AD__cond_bb3__PB__src_0_wrt_0) -> Float {
-// CHECK-SIL: bb0([[SEED:%.*]] : $Float, [[BB3_PB_STRUCT:%.*]] : @owned $_AD__cond_bb3__PB__src_0_wrt_0):
-// CHECK-SIL:   [[BB3_PRED:%.*]] = destructure_struct [[BB3_PB_STRUCT]] : $_AD__cond_bb3__PB__src_0_wrt_0
+// CHECK-SIL-LABEL: sil private [ossa] @condTJpSpSr : $@convention(thin) (Float, @owned (predecessor: _AD__cond_bb3__Pred__src_0_wrt_0)) -> Float {
+// CHECK-SIL: bb0([[SEED:%.*]] : $Float, [[BB3_PB_STRUCT:%.*]] : $(predecessor: _AD__cond_bb3__Pred__src_0_wrt_0)):
+// CHECK-SIL:   [[BB3_PRED:%.*]] = destructure_tuple [[BB3_PB_STRUCT]] : $(predecessor: _AD__cond_bb3__Pred__src_0_wrt_0)
 // CHECK-SIL:   switch_enum [[BB3_PRED]] : $_AD__cond_bb3__Pred__src_0_wrt_0, case #_AD__cond_bb3__Pred__src_0_wrt_0.bb2!enumelt: bb1, case #_AD__cond_bb3__Pred__src_0_wrt_0.bb1!enumelt: bb3
 
-// CHECK-SIL: bb1([[BB3_PRED2_TRAMP_PB_STRUCT:%.*]] : @owned $_AD__cond_bb2__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb2({{%.*}} : $Float, {{%.*}}: $Float, [[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_bb2__PB__src_0_wrt_0)
+// CHECK-SIL: bb1([[BB3_PRED2_TRAMP_PB_STRUCT:%.*]] : @owned $(predecessor: _AD__cond_bb2__Pred__src_0_wrt_0, @callee_guaranteed (Float) -> (Float, Float))):
+// CHECK-SIL:   br bb2({{%.*}} : $Float, {{%.*}}: $Float, [[BB3_PRED2_TRAMP_PB_STRUCT]] : $(predecessor: _AD__cond_bb2__Pred__src_0_wrt_0, @callee_guaranteed (Float) -> (Float, Float)))
 
-// CHECK-SIL: bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB2_PB_STRUCT:%.*]] : @owned $_AD__cond_bb2__PB__src_0_wrt_0):
-// CHECK-SIL:   ([[BB2_PRED:%.*]], [[BB2_PB:%.*]]) = destructure_struct [[BB2_PB_STRUCT]]
+// CHECK-SIL: bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB2_PB_STRUCT:%.*]] : @owned $(predecessor: _AD__cond_bb2__Pred__src_0_wrt_0, @callee_guaranteed (Float) -> (Float, Float))):
+// CHECK-SIL:   ([[BB2_PRED:%.*]], [[BB2_PB:%.*]]) = destructure_tuple [[BB2_PB_STRUCT]]
 // CHECK-SIL:   [[BB2_ADJVALS:%.*]] = apply [[BB2_PB]]([[SEED]]) : $@callee_guaranteed (Float) -> (Float, Float)
 // CHECK-SIL:   switch_enum [[BB2_PRED]] : $_AD__cond_bb2__Pred__src_0_wrt_0, case #_AD__cond_bb2__Pred__src_0_wrt_0.bb0!enumelt: bb6
 
-// CHECK-SIL: bb3([[BB3_PRED1_TRAMP_PB_STRUCT:%.*]] : @owned $_AD__cond_bb1__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb4({{%.*}} : $Float, {{%.*}}: $Float, [[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_bb1__PB__src_0_wrt_0)
+// CHECK-SIL: bb3([[BB3_PRED1_TRAMP_PB_STRUCT:%.*]] : @owned $(predecessor: _AD__cond_bb1__Pred__src_0_wrt_0, @callee_guaranteed (Float) -> (Float, Float))):
+// CHECK-SIL:   br bb4({{%.*}} : $Float, {{%.*}}: $Float, [[BB3_PRED1_TRAMP_PB_STRUCT]] : $(predecessor: _AD__cond_bb1__Pred__src_0_wrt_0, @callee_guaranteed (Float) -> (Float, Float)))
 
-// CHECK-SIL: bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB1_PB_STRUCT:%.*]] : @owned $_AD__cond_bb1__PB__src_0_wrt_0):
-// CHECK-SIL:   ([[BB1_PRED:%.*]], [[BB1_PB:%.*]]) = destructure_struct [[BB1_PB_STRUCT]]
+// CHECK-SIL: bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB1_PB_STRUCT:%.*]] : @owned $(predecessor: _AD__cond_bb1__Pred__src_0_wrt_0, @callee_guaranteed (Float) -> (Float, Float))):
+// CHECK-SIL:   ([[BB1_PRED:%.*]], [[BB1_PB:%.*]]) = destructure_tuple [[BB1_PB_STRUCT]]
 // CHECK-SIL:   [[BB1_ADJVALS:%.*]] = apply [[BB1_PB]]([[SEED]]) : $@callee_guaranteed (Float) -> (Float, Float)
 // CHECK-SIL:   switch_enum [[BB1_PRED]] : $_AD__cond_bb1__Pred__src_0_wrt_0, case #_AD__cond_bb1__Pred__src_0_wrt_0.bb0!enumelt: bb5
 
-// CHECK-SIL: bb5([[BB1_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0)
+// CHECK-SIL: bb5([[BB1_PRED0_TRAMP_PB_STRUCT:%.*]] : $()):
+// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB1_PRED0_TRAMP_PB_STRUCT]] : $())
 
-// CHECK-SIL: bb6([[BB2_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_bb0__PB__src_0_wrt_0)
+// CHECK-SIL: bb6([[BB2_PRED0_TRAMP_PB_STRUCT:%.*]] : $()):
+// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB2_PRED0_TRAMP_PB_STRUCT]] : $())
 
-// CHECK-SIL: bb7({{%.*}} : $Float, [[BB0_PB_STRUCT:%.*]] : $_AD__cond_bb0__PB__src_0_wrt_0):
+// CHECK-SIL: bb7({{%.*}} : $Float, [[BB0_PB_STRUCT:%.*]] : $()):
 // CHECK-SIL:   return {{%.*}} : $Float
 
 @differentiable(reverse)
@@ -157,23 +151,23 @@ func enum_notactive(_ e: Enum, _ x: Float) -> Float {
 
 // CHECK-SIL-LABEL: sil hidden [ossa] @enum_notactiveTJrUSpSr : $@convention(thin) (Enum, Float) -> (Float, @owned @callee_guaranteed (Float) -> Float) {
 // CHECK-SIL: bb0([[ENUM_ARG:%.*]] : $Enum, [[X_ARG:%.*]] : $Float):
-// CHECK-SIL:   [[BB0_PB_STRUCT:%.*]] = struct $_AD__enum_notactive_bb0__PB__src_0_wrt_1 ()
+// CHECK-SIL:   [[BB0_PB_STRUCT:%.*]] = tuple ()
 // CHECK-SIL:   switch_enum [[ENUM_ARG]] : $Enum, case #Enum.a!enumelt: bb1, case #Enum.b!enumelt: bb2
 
 // CHECK-SIL: bb1([[ENUM_A:%.*]] : $Float):
-// CHECK-SIL:   [[BB1_PRED_PRED0:%.*]] = enum $_AD__enum_notactive_bb1__Pred__src_0_wrt_1, #_AD__enum_notactive_bb1__Pred__src_0_wrt_1.bb0!enumelt, [[BB0_PB_STRUCT]] : $_AD__enum_notactive_bb0__PB__src_0_wrt_1
-// CHECK-SIL:   [[BB1_PB_STRUCT:%.*]] = struct $_AD__enum_notactive_bb1__PB__src_0_wrt_1 ({{.*}})
-// CHECK-SIL:   [[BB3_PRED_PRED1:%.*]] = enum $_AD__enum_notactive_bb3__Pred__src_0_wrt_1, #_AD__enum_notactive_bb3__Pred__src_0_wrt_1.bb1!enumelt, [[BB1_PB_STRUCT]] : $_AD__enum_notactive_bb1__PB__src_0_wrt_1
+// CHECK-SIL:   [[BB1_PRED_PRED0:%.*]] = enum $_AD__enum_notactive_bb1__Pred__src_0_wrt_1, #_AD__enum_notactive_bb1__Pred__src_0_wrt_1.bb0!enumelt, [[BB0_PB_STRUCT]] : $()
+// CHECK-SIL:   [[BB1_PB_STRUCT:%.*]] = tuple $(predecessor: _AD__enum_notactive_bb1__Pred__src_0_wrt_1, @callee_guaranteed (Float) -> Float) ([[BB1_PRED_PRED0]]
+// CHECK-SIL:   [[BB3_PRED_PRED1:%.*]] = enum $_AD__enum_notactive_bb3__Pred__src_0_wrt_1, #_AD__enum_notactive_bb3__Pred__src_0_wrt_1.bb1!enumelt, [[BB1_PB_STRUCT]] : $(predecessor: _AD__enum_notactive_bb1__Pred__src_0_wrt_1, @callee_guaranteed (Float) -> Float)
 // CHECK-SIL:   br bb3({{.*}} : $Float, [[BB3_PRED_PRED1]] : $_AD__enum_notactive_bb3__Pred__src_0_wrt_1)
 
 // CHECK-SIL: bb2([[ENUM_B:%.*]] : $(Float, Float)):
-// CHECK-SIL:   [[BB2_PRED_PRED0:%.*]] = enum $_AD__enum_notactive_bb2__Pred__src_0_wrt_1, #_AD__enum_notactive_bb2__Pred__src_0_wrt_1.bb0!enumelt, [[BB0_PB_STRUCT]] : $_AD__enum_notactive_bb0__PB__src_0_wrt_1
-// CHECK-SIL:   [[BB2_PB_STRUCT:%.*]] = struct $_AD__enum_notactive_bb2__PB__src_0_wrt_1 ({{.*}})
-// CHECK-SIL:   [[BB3_PRED_PRED2:%.*]] = enum $_AD__enum_notactive_bb3__Pred__src_0_wrt_1, #_AD__enum_notactive_bb3__Pred__src_0_wrt_1.bb2!enumelt, [[BB2_PB_STRUCT]] : $_AD__enum_notactive_bb2__PB__src_0_wrt_1
+// CHECK-SIL:   [[BB2_PRED_PRED0:%.*]] = enum $_AD__enum_notactive_bb2__Pred__src_0_wrt_1, #_AD__enum_notactive_bb2__Pred__src_0_wrt_1.bb0!enumelt, [[BB0_PB_STRUCT]] : $()
+// CHECK-SIL:   [[BB2_PB_STRUCT:%.*]] = tuple $(predecessor: _AD__enum_notactive_bb2__Pred__src_0_wrt_1, @callee_guaranteed (Float) -> Float, @callee_guaranteed (Float) -> Float) ([[BB2_PRED_PRED0]]
+// CHECK-SIL:   [[BB3_PRED_PRED2:%.*]] = enum $_AD__enum_notactive_bb3__Pred__src_0_wrt_1, #_AD__enum_notactive_bb3__Pred__src_0_wrt_1.bb2!enumelt, [[BB2_PB_STRUCT]] : $(predecessor: _AD__enum_notactive_bb2__Pred__src_0_wrt_1, @callee_guaranteed (Float) -> Float, @callee_guaranteed (Float) -> Float)
 // CHECK-SIL:   br bb3({{.*}} : $Float, [[BB3_PRED_PRED2]] : $_AD__enum_notactive_bb3__Pred__src_0_wrt_1)
 
-// CHECK-SIL: bb3([[ORIG_RES:%.*]] : $Float, [[BB3_PRED_ARG:%.*]] : @owned $_AD__enum_notactive_bb3__Pred__src_0_wrt_1)
-// CHECK-SIL:   [[BB3_PB_STRUCT:%.*]] = struct $_AD__enum_notactive_bb3__PB__src_0_wrt_1
+// CHECK-SIL: bb3([[ORIG_RES:%.*]] : $Float, [[BB3_PRED_ARG:%.*]] : $_AD__enum_notactive_bb3__Pred__src_0_wrt_1)
+// CHECK-SIL:   [[BB3_PB_STRUCT:%.*]] = tuple $(predecessor: _AD__enum_notactive_bb3__Pred__src_0_wrt_1) ([[BB3_PRED_ARG]])
 // CHECK-SIL:   [[PULLBACK_REF:%.*]] = function_ref @enum_notactiveTJpUSpSr
 // CHECK-SIL:   [[PB:%.*]] = partial_apply [callee_guaranteed] [[PULLBACK_REF]]([[BB3_PB_STRUCT]])
 // CHECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[ORIG_RES]] : $Float, [[PB]] : $@callee_guaranteed (Float) -> Float)
@@ -200,30 +194,30 @@ func enum_addr_notactive<T>(_ e: AddressOnlyEnum<T>, _ x: Float) -> Float {
 // CHECK-SIL: bb0([[ENUM_ARG:%.*]] : $*AddressOnlyEnum<τ_0_0>, [[X_ARG:%.*]] : $Float):
 // CHECK-SIL:   [[ENUM_ADDR:%.*]] = alloc_stack $AddressOnlyEnum<τ_0_0>
 // CHECK-SIL:   copy_addr [[ENUM_ARG]] to [init] [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>
-// CHECK-SIL:   [[BB0_PB_STRUCT:%.*]] = struct $_AD__enum_addr_notactive_bb0__PB__src_0_wrt_1_l<τ_0_0> ()
+// CHECK-SIL:   [[BB0_PB_STRUCT:%.*]] = tuple ()
 // CHECK-SIL:   switch_enum_addr [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>, case #AddressOnlyEnum.none!enumelt: bb1, case #AddressOnlyEnum.some!enumelt: bb2
 
-// CHECK-SIL: bb1:
-// CHECK-SIL:   [[BB1_PRED_PRED0:%.*]] = enum $_AD__enum_addr_notactive_bb1__Pred__src_0_wrt_1_l<τ_0_0>, #_AD__enum_addr_notactive_bb1__Pred__src_0_wrt_1_l.bb0!enumelt, [[BB0_PB_STRUCT]] : $_AD__enum_addr_notactive_bb0__PB__src_0_wrt_1_l<τ_0_0>
+// CHECK-SIL-LABEL: bb1:
+// CHECK-SIL:   [[BB1_PRED_PRED0:%.*]] = enum $_AD__enum_addr_notactive_bb1__Pred__src_0_wrt_1_l<τ_0_0>, #_AD__enum_addr_notactive_bb1__Pred__src_0_wrt_1_l.bb0!enumelt, [[BB0_PB_STRUCT]] : $()
 // CHECK-SIL:   dealloc_stack [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>
-// CHECK-SIL:   [[BB1_PB_STRUCT:%.*]] = struct $_AD__enum_addr_notactive_bb1__PB__src_0_wrt_1_l<τ_0_0> ([[BB1_PRED_PRED0]] : $_AD__enum_addr_notactive_bb1__Pred__src_0_wrt_1_l<τ_0_0>)
-// CHECK-SIL:   [[BB3_PRED_PRED1:%.*]] = enum $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>, #_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l.bb1!enumelt, [[BB1_PB_STRUCT]] : $_AD__enum_addr_notactive_bb1__PB__src_0_wrt_1_l<τ_0_0>
+// CHECK-SIL:   [[BB1_PB_STRUCT:%.*]] = tuple $(predecessor: _AD__enum_addr_notactive_bb1__Pred__src_0_wrt_1_l<τ_0_0>) ([[BB1_PRED_PRED0]])
+// CHECK-SIL:   [[BB3_PRED_PRED1:%.*]] = enum $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>, #_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l.bb1!enumelt, [[BB1_PB_STRUCT]] : $(predecessor: _AD__enum_addr_notactive_bb1__Pred__src_0_wrt_1_l<τ_0_0>)
 // CHECK-SIL:   br bb3([[BB3_PRED_PRED1]] : $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>)
 
-// CHECK-SIL: bb2:
-// CHECK-SIL:   [[BB2_PRED_PRED0:%.*]] = enum $_AD__enum_addr_notactive_bb2__Pred__src_0_wrt_1_l<τ_0_0>, #_AD__enum_addr_notactive_bb2__Pred__src_0_wrt_1_l.bb0!enumelt, [[BB0_PB_STRUCT]] : $_AD__enum_addr_notactive_bb0__PB__src_0_wrt_1_l<τ_0_0>
+// CHECK-SIL-LABEL: bb2:
+// CHECK-SIL:   [[BB2_PRED_PRED0:%.*]] = enum $_AD__enum_addr_notactive_bb2__Pred__src_0_wrt_1_l<τ_0_0>, #_AD__enum_addr_notactive_bb2__Pred__src_0_wrt_1_l.bb0!enumelt, [[BB0_PB_STRUCT]] : $()
 // CHECK-SIL:   [[ENUM_DATA:%.*]] = unchecked_take_enum_data_addr [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>, #AddressOnlyEnum.some!enumelt
 // CHECK-SIL:   destroy_addr [[ENUM_DATA]] : $*τ_0_0
 // CHECK-SIL:   dealloc_stack [[ENUM_ADDR]] : $*AddressOnlyEnum<τ_0_0>
-// CHECK-SIL:   [[BB2_PB_STRUCT:%.*]] = struct $_AD__enum_addr_notactive_bb2__PB__src_0_wrt_1_l<τ_0_0> ([[BB2_PRED_PRED0]] : $_AD__enum_addr_notactive_bb2__Pred__src_0_wrt_1_l<τ_0_0>)
-// CHECK-SIL:   [[BB3_PRED_PRED2:%.*]] = enum $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>, #_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l.bb2!enumelt, [[BB2_PB_STRUCT]] : $_AD__enum_addr_notactive_bb2__PB__src_0_wrt_1_l<τ_0_0>
+// CHECK-SIL:   [[BB2_PB_STRUCT:%.*]] = tuple $(predecessor: _AD__enum_addr_notactive_bb2__Pred__src_0_wrt_1_l<τ_0_0>) ([[BB2_PRED_PRED0]])
+// CHECK-SIL:   [[BB3_PRED_PRED2:%.*]] = enum $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>, #_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l.bb2!enumelt, [[BB2_PB_STRUCT]] : $(predecessor: _AD__enum_addr_notactive_bb2__Pred__src_0_wrt_1_l<τ_0_0>)
 // CHECK-SIL:   br bb3([[BB3_PRED_PRED2]] : $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>)
 
 // CHECK-SIL: bb3([[BB3_PRED_ARG:%.*]] : $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>):
-// CHECK-SIL:   [[BB3_PB_STRUCT:%.*]] = struct $_AD__enum_addr_notactive_bb3__PB__src_0_wrt_1_l<τ_0_0> ([[BB3_PRED_ARG]] : $_AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>)
+// CHECK-SIL:   [[BB3_PB_STRUCT:%.*]] = tuple $(predecessor: _AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>) ([[BB3_PRED_ARG]])
 
-// CHECK-SIL:   [[PB_FNREF:%.*]] = function_ref @enum_addr_notactivelTJpUSpSr : $@convention(thin) <τ_0_0> (Float, @owned _AD__enum_addr_notactive_bb3__PB__src_0_wrt_1_l<τ_0_0>) -> Float
-// CHECK-SIL:   [[PB:%.*]] = partial_apply [callee_guaranteed] [[PB_FNREF]]<τ_0_0>([[BB3_PB_STRUCT]]) : $@convention(thin) <τ_0_0> (Float, @owned _AD__enum_addr_notactive_bb3__PB__src_0_wrt_1_l<τ_0_0>) -> Float
+// CHECK-SIL:   [[PB_FNREF:%.*]] = function_ref @enum_addr_notactivelTJpUSpSr : $@convention(thin) <τ_0_0> (Float, @owned (predecessor: _AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>)) -> Float
+// CHECK-SIL:   [[PB:%.*]] = partial_apply [callee_guaranteed] [[PB_FNREF]]<τ_0_0>([[BB3_PB_STRUCT]]) : $@convention(thin) <τ_0_0> (Float, @owned (predecessor: _AD__enum_addr_notactive_bb3__Pred__src_0_wrt_1_l<τ_0_0>)) -> Float
 // CHECK-SIL:   [[VJP_RESULT:%.*]] = tuple ([[X_ARG]] : $Float, [[PB]] : $@callee_guaranteed (Float) -> Float)
 // CHECK-SIL:   return [[VJP_RESULT]] : $(Float, @callee_guaranteed (Float) -> Float)
 
@@ -241,36 +235,36 @@ func cond_tuple_var(_ x: Float) -> Float {
   return y.1
 }
 
-// CHECK-SIL-LABEL: sil private [ossa] @cond_tuple_varTJpSpSr : $@convention(thin) (Float, @owned _AD__cond_tuple_var_bb3__PB__src_0_wrt_0) -> Float {
-// CHECK-SIL: bb0([[SEED:%.*]] : $Float, [[BB3_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb3__PB__src_0_wrt_0):
-// CHECK-SIL:   [[BB3_PRED:%.*]] = destructure_struct [[BB3_PB_STRUCT]] : $_AD__cond_tuple_var_bb3__PB__src_0_wrt_0
+// CHECK-SIL-LABEL: sil private [ossa] @cond_tuple_varTJpSpSr : $@convention(thin) (Float, @owned (predecessor: _AD__cond_tuple_var_bb3__Pred__src_0_wrt_0)) -> Float {
+// CHECK-SIL: bb0([[SEED:%.*]] : $Float, [[BB3_PB_STRUCT:%.*]] : $(predecessor: _AD__cond_tuple_var_bb3__Pred__src_0_wrt_0)):
+// CHECK-SIL:   [[BB3_PRED:%.*]] = destructure_tuple [[BB3_PB_STRUCT]] : $(predecessor: _AD__cond_tuple_var_bb3__Pred__src_0_wrt_0)
 // CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)
 // CHECK-SIL-NOT:   copy_addr {{%.*}} to {{%.*}} : $*Float
 // CHECK-SIL:   switch_enum [[BB3_PRED]] : $_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0, case #_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0.bb2!enumelt: bb1, case #_AD__cond_tuple_var_bb3__Pred__src_0_wrt_0.bb1!enumelt: bb3
 
-// CHECK-SIL: bb1([[BB3_PRED2_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB3_PRED2_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0)
+// CHECK-SIL: bb1([[BB3_PRED2_TRAMP_PB_STRUCT:%.*]] : $(predecessor: _AD__cond_tuple_var_bb2__Pred__src_0_wrt_0)):
+// CHECK-SIL:   br bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB3_PRED2_TRAMP_PB_STRUCT]] : $(predecessor: _AD__cond_tuple_var_bb2__Pred__src_0_wrt_0))
 
-// CHECK-SIL: bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB2_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb2__PB__src_0_wrt_0):
-// CHECK-SIL:   [[BB2_PRED:%.*]] = destructure_struct [[BB2_PB_STRUCT]]
+// CHECK-SIL: bb2({{%.*}} : $Float, {{%.*}} : $Float, [[BB2_PB_STRUCT:%.*]] : $(predecessor: _AD__cond_tuple_var_bb2__Pred__src_0_wrt_0)):
+// CHECK-SIL:   [[BB2_PRED:%.*]] = destructure_tuple [[BB2_PB_STRUCT]]
 // CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)
 // CHECK-SIL-NOT:   copy_addr {{%.*}} to {{%.*}} : $*Float
 // CHECK-SIL:   switch_enum [[BB2_PRED]] : $_AD__cond_tuple_var_bb2__Pred__src_0_wrt_0, case #_AD__cond_tuple_var_bb2__Pred__src_0_wrt_0.bb0!enumelt: bb6
 
-// CHECK-SIL: bb3([[BB3_PRED1_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB3_PRED1_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0)
+// CHECK-SIL: bb3([[BB3_PRED1_TRAMP_PB_STRUCT:%.*]] : $(predecessor: _AD__cond_tuple_var_bb1__Pred__src_0_wrt_0)):
+// CHECK-SIL:   br bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB3_PRED1_TRAMP_PB_STRUCT]] : $(predecessor: _AD__cond_tuple_var_bb1__Pred__src_0_wrt_0))
 
-// CHECK-SIL: bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB1_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb1__PB__src_0_wrt_0):
-// CHECK-SIL:   [[BB1_PRED:%.*]] = destructure_struct [[BB1_PB_STRUCT]]
+// CHECK-SIL: bb4({{%.*}} : $Float, {{%.*}} : $Float, [[BB1_PB_STRUCT:%.*]] : $(predecessor: _AD__cond_tuple_var_bb1__Pred__src_0_wrt_0)):
+// CHECK-SIL:   [[BB1_PRED:%.*]] = destructure_tuple [[BB1_PB_STRUCT]]
 // CHECK-SIL:   copy_addr {{%.*}} to {{%.*}} : $*(Float, Float)
 // CHECK-SIL-NOT:   copy_addr {{%.*}} to {{%.*}} : $*Float
 // CHECK-SIL:   switch_enum [[BB1_PRED]] : $_AD__cond_tuple_var_bb1__Pred__src_0_wrt_0, case #_AD__cond_tuple_var_bb1__Pred__src_0_wrt_0.bb0!enumelt: bb5
 
-// CHECK-SIL: bb5([[BB1_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB1_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
+// CHECK-SIL: bb5([[BB1_PRED0_TRAMP_PB_STRUCT:%.*]] : $()):
+// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB1_PRED0_TRAMP_PB_STRUCT]] : $())
 
-// CHECK-SIL: bb6([[BB2_PRED0_TRAMP_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
-// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB2_PRED0_TRAMP_PB_STRUCT]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0)
+// CHECK-SIL: bb6([[BB2_PRED0_TRAMP_PB_STRUCT:%.*]] : $()):
+// CHECK-SIL:   br bb7({{%.*}} : $Float, [[BB2_PRED0_TRAMP_PB_STRUCT]] : $())
 
-// CHECK-SIL: bb7({{%.*}} : $Float, [[BB0_PB_STRUCT:%.*]] : $_AD__cond_tuple_var_bb0__PB__src_0_wrt_0):
+// CHECK-SIL: bb7({{%.*}} : $Float, [[BB0_PB_STRUCT:%.*]] : $()):
 // CHECK-SIL:   return {{%.*}} : $Float

--- a/test/AutoDiff/SILOptimizer/semantic_member_accessors_sil.swift
+++ b/test/AutoDiff/SILOptimizer/semantic_member_accessors_sil.swift
@@ -77,7 +77,7 @@ func trigger<T: Differentiable>(_ x: T.Type) {
 // CHECK: }
 
 // CHECK-LABEL: sil private [ossa] @$s4null6StructV1xSfvsTJpSSpSr
-// CHECK: bb0([[ADJ_SELF:%.*]] : $*Struct.TangentVector, {{.*}} : $_AD__$s4null6StructV1xSfvs_bb0__PB__src_0_wrt_0_1):
+// CHECK: bb0([[ADJ_SELF:%.*]] : $*Struct.TangentVector, {{.*}} : $()):
 // CHECK:   [[ADJ_X_ADDR:%.*]] = struct_element_addr [[ADJ_SELF]] : $*Struct.TangentVector, #Struct.TangentVector.x
 // CHECK:   [[ADJ_X:%.*]] = load [trivial] [[ADJ_X_ADDR]] : $*Float
 // CHECK:   [[ZERO_FN:%.*]] = witness_method $Float, #AdditiveArithmetic.zero!getter
@@ -86,7 +86,7 @@ func trigger<T: Differentiable>(_ x: T.Type) {
 // CHECK: }
 
 // CHECK-LABEL: sil private [ossa] @$s4null6StructV1xSfvgTJpSpSr
-// CHECK: bb0([[ADJ_X:%.*]] : $Float, {{.*}} : $_AD__$s4null6StructV1xSfvg_bb0__PB__src_0_wrt_0):
+// CHECK: bb0([[ADJ_X:%.*]] : $Float, {{.*}} : $()):
 // CHECK:   [[ADJ_Y_ADDR:%.*]] = alloc_stack $Float
 // CHECK:   [[ZERO_FN:%.*]] = witness_method $Float, #AdditiveArithmetic.zero!getter
 // CHECK:   apply [[ZERO_FN]]<Float>([[ADJ_Y_ADDR]], {{.*}})

--- a/test/AutoDiff/compiler_crashers_fixed/58660-conflicting-debug-info-inlining.swift
+++ b/test/AutoDiff/compiler_crashers_fixed/58660-conflicting-debug-info-inlining.swift
@@ -45,7 +45,7 @@ struct MyModel: Differentiable {
   mutating func member4() {
 // CHECK-LABEL: // pullback of MyModel.member4()
 // CHECK-NOT: debug_value %{{.*}} : $MyModel.TangentVector, var, name %{{.*}}, argno 1, implicit, scope
-// CHECK: bb1(%{{.*}} : $_AD__$s4main7MyModelV7member4yyF_bb1__PB__src_0_wrt_0):
+// CHECK: bb0(%{{.*}} : $(predecessor: _AD__$s4main7MyModelV7member4yyF_bb3__Pred__src_0_wrt_0)):
 // CHECK: debug_value %{{.*}} : $MyModel.TangentVector, var, name "derivative of 'self' in scope at {{.*}} (scope #1)", implicit, scope
     // Must be a differentiable type.
     var localVar: Float = 0

--- a/test/AutoDiff/validation-test/simple_math.swift
+++ b/test/AutoDiff/validation-test/simple_math.swift
@@ -438,7 +438,7 @@ SimpleMathTests.test("Adjoint value accumulation for aggregate lhs and concrete 
 
 // CHECK-LABEL: sil private [ossa] @${{.*}}doubled{{.*}}TJp{{.*}} : $@convention(thin) (Float, @owned {{.*}}) -> SmallTestModel.TangentVector {
 // CHECK: bb0([[DX:%.*]] : $Float, [[PB_STRUCT:%.*]] : {{.*}}):
-// CHECK:   ([[PB0:%.*]], [[PB1:%.*]]) = destructure_struct [[PB_STRUCT]]
+// CHECK:   ([[PB0:%.*]], [[PB1:%.*]]) = destructure_tuple [[PB_STRUCT]]
 // CHECK:   [[ADJ_TUPLE:%.*]] = apply [[PB1]]([[DX]]) : $@callee_guaranteed (Float) -> (Float, Float)
 // CHECK:   ([[TMP0:%.*]], [[ADJ_CONCRETE:%.*]]) = destructure_tuple [[ADJ_TUPLE]] : $(Float, Float)
 // CHECK:   [[TMP1:%.*]] = apply [[PB0]]([[TMP0]]) : $@callee_guaranteed (Float) -> SmallTestModel.TangentVector


### PR DESCRIPTION
The changes are intentionally were made close to the original implementation w/o possible simplifications to ease the review

Fixes #63207, supersedes #63379 (and fixes #63234)