### PR TITLE
[CS] Connect isolated conjunctions to referenced VarDecls

### DIFF
--- a/test/Constraints/rdar105080067.swift
+++ b/test/Constraints/rdar105080067.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift
+
+// rdar://105080067 - This isn't currently allowed but make sure we don't
+// emit a spurious "cannot reference invalid declaration" error.
+for b in [true] where if b { true } else { false } {}
+// expected-error@-1 {{'if' may only be used as expression in return, throw, or as the source of an assignment}}


### PR DESCRIPTION
Currently we only consider ParamDecls, but isolated conjunctions can reference external VarDecls too.

This fixes a spurious "cannot reference invalid declaration" error when the result builder transform is disabled in the test case `rdar104687668.swift`. It also fixes the attached test case, where an if expression references a pattern var in a for loop.

rdar://105080067