### PR TITLE
[CSSyntacticElement] Correctly determine whether body is a "single ex…

### DIFF
--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -2396,7 +2396,10 @@ bool ConstraintSystem::applySolutionToBody(Solution &solution,
   if (!body || application.hadError)
     return true;
 
-  fn.setTypecheckedBody(cast<BraceStmt>(body), fn.hasSingleExpressionBody());
+  fn.setTypecheckedBody(cast<BraceStmt>(body),
+                        solution.getAppliedBuilderTransform(fn)
+                            ? false
+                            : fn.hasSingleExpressionBody());
   return false;
 }
 


### PR DESCRIPTION
…pression"

Result builder transformed bodies are always multi-statement.

Resolves: https://github.com/apple/swift/issues/63264

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
