### PR TITLE
[docs] GettingStarted: Bump required CMake version for `--xcode` once more

### DIFF
--- a/docs/HowToGuides/GettingStarted.md
+++ b/docs/HowToGuides/GettingStarted.md
@@ -187,7 +187,7 @@ toolchain as a one-off, there are a couple of differences:
 
 ### Spot check dependencies
 
-* Run `cmake --version`; this should be at least 3.19.6 (3.22.2 if you want to generate an Xcode project on macOS).
+* Run `cmake --version`; this should be at least 3.19.6 (3.24.2 if you want to use Xcode for editing on macOS).
 * Run `python3 --version`; check that this succeeds.
 * Run `ninja --version`; check that this succeeds.
 * If you installed and want to use Sccache: Run `sccache --version`; check


### PR DESCRIPTION
2.24.2 is the oldest version that didn't reproduce the code signing issue from  https://github.com/apple/swift/issues/62023 with the latest Xcode release (14.2).
