### PR TITLE
[cxx-interop] Change the hierarchy of CxxSequence protocols

### DIFF
--- a/stdlib/public/Cxx/CxxRandomAccessCollection.swift
+++ b/stdlib/public/Cxx/CxxRandomAccessCollection.swift
@@ -36,12 +36,6 @@ public protocol CxxRandomAccessCollection<Element>: CxxSequence, RandomAccessCol
   override associatedtype Index = Int
   override associatedtype Indices = Range<Int>
   override associatedtype SubSequence = Slice<Self>
-
-  /// Do not implement this function manually in Swift.
-  func __beginUnsafe() -> RawIterator
-
-  /// Do not implement this function manually in Swift.
-  func __endUnsafe() -> RawIterator
 }
 
 extension CxxRandomAccessCollection {

--- a/stdlib/public/Cxx/CxxSequence.swift
+++ b/stdlib/public/Cxx/CxxSequence.swift
@@ -65,9 +65,9 @@ extension Optional: UnsafeCxxInputIterator where Wrapped: UnsafeCxxInputIterator
 /// This requires the C++ sequence type to define const methods `begin()` and
 /// `end()` which return input iterators into the C++ sequence. The iterator
 /// types must conform to `UnsafeCxxInputIterator`.
-public protocol CxxSequence<Element>: Sequence {
+public protocol CxxSequence<Element>: CxxConvertibleToCollection, Sequence {
   override associatedtype Element
-  associatedtype RawIterator: UnsafeCxxInputIterator
+  override associatedtype RawIterator: UnsafeCxxInputIterator
     where RawIterator.Pointee == Element
   override associatedtype Iterator = CxxIterator<Self>
 


### PR DESCRIPTION
This makes `CxxConvertibleToCollection` the base protocol in the hierarchy. Both `CxxSequence` and `CxxRandomAccessCollection` now inherit from `CxxConvertibleToCollection`.