### PR TITLE
`DispatchQueue.(sync|asyncAndWait)` don't have `@Sendable` parameters

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -427,9 +427,17 @@ AnyFunctionType *adjustFunctionTypeForConcurrency(
     llvm::function_ref<bool(const ClosureExpr *)> isolatedByPreconcurrency,
     llvm::function_ref<Type(Type)> openType);
 
+/// Classifies known dispatch queue operations.
+enum class DispatchQueueOperation {
+  /// This is a dispatch operation we know about.
+  Normal,
+  /// The closure passed to this dispatch queue operation should be Sendable.
+  Sendable,
+};
+
 /// Determine whether the given name is that of a DispatchQueue operation that
 /// takes a closure to be executed on the queue.
-bool isDispatchQueueOperationName(StringRef name);
+Optional<DispatchQueueOperation> isDispatchQueueOperationName(StringRef name);
 
 /// Check the correctness of the given Sendable conformance.
 ///

--- a/test/Concurrency/dispatch_inference.swift
+++ b/test/Concurrency/dispatch_inference.swift
@@ -27,5 +27,10 @@ func testUnsafeSendableInAsync(queue: DispatchQueue) async {
   queue.async {
     x = 17 // expected-error{{mutation of captured var 'x' in concurrently-executing code}}
   }
+
+  queue.sync {
+    x = 17 // okay
+  }
+
   print(x)
 }


### PR DESCRIPTION
The blocking nature of these APIs means that the closures passed to them do not actually escape the concurrency domain of the caller. Remove the implicit `@Sendable`.

Fixes rdar://105106230