### PR TITLE
[Index] Use access level to check decls to include

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -3467,14 +3467,14 @@ bool FileUnit::walk(ASTWalker &walker) {
     if (SkipInternal) {
       // Ignore if the decl isn't visible
       if (auto *VD = dyn_cast<ValueDecl>(D)) {
-        if (!VD->isAccessibleFrom(nullptr))
+        if (VD->getFormalAccess() < AccessLevel::Public)
           continue;
       }
 
       // Also ignore if the extended nominal isn't visible
       if (auto *ED = dyn_cast<ExtensionDecl>(D)) {
         auto *ND = ED->getExtendedNominal();
-        if (ND && !ND->isAccessibleFrom(nullptr))
+        if (ND && ND->getFormalAccess() < AccessLevel::Public)
           continue;
       }
     }

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1008,7 +1008,7 @@ private:
       return false;
 
     // Do not handle non-public imported decls.
-    if (IsModuleFile && !D->isAccessibleFrom(nullptr))
+    if (IsModuleFile && D->getFormalAccess() < AccessLevel::Public)
       return false;
 
     if (!IdxConsumer.indexLocals() && isLocalSymbol(D))

--- a/test/Index/index_objc_impl.swift
+++ b/test/Index/index_objc_impl.swift
@@ -1,0 +1,24 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/mods)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -o %t/mods %t/ObjcImpl.swift -import-objc-header %t/objc_impl.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-ide-test -print-indexed-symbols -module-to-print ObjcImpl -source-filename none -I %t/mods | %FileCheck %s
+
+//--- objc_impl.h
+@interface NSObject
+@end
+
+@interface ObjCClass : NSObject
+@property int someObjCDeclaredVar;
+@end
+
+//--- ObjcImpl.swift
+// CHECK: extension/ext-class/Swift | ObjCClass | s:e:c:@CM@ObjcImpl@@objc(cs)ObjCClass(py)someObjCDeclaredVar | Def
+// CHECK: class/Swift | ObjCClass | c:objc(cs)ObjCClass | Ref
+@_objcImplementation public extension ObjCClass {
+  // CHECK: instance-property/Swift | someObjCDeclaredVar | c:@CM@ObjcImpl@@objc(cs)ObjCClass(py)someObjCDeclaredVar | Def
+  @objc var someObjCDeclaredVar: CInt
+}


### PR DESCRIPTION
`isAccessibleFrom` has special handling for `@_objcImplementation` members, which causes the definition in Swift to be missed. Use access level directly rather than passing `nullptr` into `isAccessibleFrom`.