### PR TITLE
[Serialization] Evaluate the safety of opaque types

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3192,7 +3192,6 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     // Note: There's likely room to report some of these as unsafe to prevent
     //       failures.
     if (isa<GenericTypeParamDecl>(decl) ||
-        isa<OpaqueTypeDecl>(decl) ||
         isa<ParamDecl>(decl) ||
         isa<EnumCaseDecl>(decl) ||
         isa<EnumElementDecl>(decl))
@@ -3215,7 +3214,10 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
     // Write a human readable name to an identifier.
     SmallString<64> out;
     llvm::raw_svector_ostream outStream(out);
-    if (auto val = dyn_cast<ValueDecl>(decl)) {
+    if (auto opaque = dyn_cast<OpaqueTypeDecl>(decl)) {
+      outStream << "opaque ";
+      outStream << opaque->getOpaqueReturnTypeIdentifier();
+    } else if (auto val = dyn_cast<ValueDecl>(decl)) {
       outStream << val->getName();
     } else if (auto ext = dyn_cast<ExtensionDecl>(decl)) {
       outStream << "extension ";

--- a/test/Serialization/Safety/unsafe-decls.swift
+++ b/test/Serialization/Safety/unsafe-decls.swift
@@ -4,7 +4,7 @@
 
 // RUN: %target-swift-frontend -emit-module %s \
 // RUN:   -enable-library-evolution -swift-version 5 \
-// RUN:   -Xllvm -debug-only=Serialization 2>&1 \
+// RUN:   -Xllvm -debug-only=Serialization 2>&1 | %swift-demangle --simplified \
 // RUN:   | %FileCheck --check-prefixes=SAFETY-PRIVATE,SAFETY-INTERNAL %s
 
 // RUN: %target-swift-frontend -emit-module %s \
@@ -53,6 +53,9 @@ public struct PublicStruct {
 // NO-SAFETY-INTERNAL: Serialization safety, safe: 'internalTypealias'
 // SAFETY-PRIVATE: Serialization safety, safe: 'localTypealias'
 
+// SAFETY-PRIVATE: Serialization safety, safe: 'opaque PublicStruct.opaqueTypeFunc()'
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'opaque PublicStruct.opaqueFuncInternal()'
+
     public init(publicInit a: Int) {}
 // SAFETY-PRIVATE: Serialization safety, safe: 'init(publicInit:)'
     internal init(internalInit a: Int) {}
@@ -69,11 +72,19 @@ public struct PublicStruct {
 // SAFETY-PRIVATE: Serialization safety, safe: 'inlinableFunc()'
     public func publicFunc() {}
 // SAFETY-PRIVATE: Serialization safety, safe: 'publicFunc()'
-@available(SwiftStdlib 5.1, *) // for the `some` keyword.
+
+    @available(SwiftStdlib 5.1, *) // for the `some` keyword.
     public func opaqueTypeFunc() -> some PublicProto {
+// SAFETY-PRIVATE: Serialization safety, safe: 'opaqueTypeFunc()'
         return InternalStruct()
     }
-// SAFETY-PRIVATE: Serialization safety, safe: 'opaqueTypeFunc()'
+
+    @available(SwiftStdlib 5.1, *) // for the `some` keyword.
+    internal func opaqueFuncInternal() -> some PublicProto {
+// SAFETY-PRIVATE: Serialization safety, unsafe: 'opaqueFuncInternal()'
+        return InternalStruct()
+    }
+
     internal func internalFunc() {}
 // SAFETY-INTERNAL: Serialization safety, unsafe: 'internalFunc()'
 // NO-SAFETY-INTERNAL: Serialization safety, safe: 'internalFunc()'


### PR DESCRIPTION
Some compilation paths access the opaque return type type by itself without going through its function. So access to the type must be protected, otherwise deserialization fails at getting the naming decl when it's unsafe.

rdar://105085860