### PR TITLE
Don't rebuild the source location -> source file map every time we lookup

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -598,6 +598,9 @@ void ModuleDecl::updateSourceFileLocationMap() {
   std::sort(sourceFileLocationMap->allSourceFiles.begin(),
             sourceFileLocationMap->allSourceFiles.end(),
             SourceFileRangeComparison{&getASTContext().SourceMgr});
+
+  sourceFileLocationMap->numFiles = files.size();
+  sourceFileLocationMap->numAuxiliaryFiles = AuxiliaryFiles.size();
 }
 
 SourceFile *ModuleDecl::getSourceFileContainingLocation(SourceLoc loc) {


### PR DESCRIPTION
We forgot to update the variables that track when we need a rebuild.

Fixes rdar://105092020.
