### PR TITLE
Add visitInnerAdjacentPhis OSSA helper

### DIFF
--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -114,9 +114,8 @@ InnerBorrowKind PrunedLiveness::updateForBorrowingOperand(Operand *operand) {
   // A nested borrow scope is considered a use-point at each scope ending
   // instruction.
   //
-  // TODO: Handle reborrowed copies by considering the extended borrow
-  // scope. Temporarily bail-out on reborrows because we can't handle uses
-  // that aren't dominated by currentDef.
+  // Note: Ownership liveness should follow reborrows that are dominated by the
+  // ownership definition.
   if (!BorrowingOperand(operand).visitScopeEndingUses([this](Operand *end) {
         if (end->getOperandOwnership() == OperandOwnership::Reborrow) {
           return false;

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -467,15 +467,15 @@ struct ShrinkBorrowScopeTest : UnitTest {
 // Dumps:
 // - function
 // - the adjacent phis
-struct VisitAdjacentReborrowsOfPhiTest : UnitTest {
-  VisitAdjacentReborrowsOfPhiTest(UnitTestRunner *pass) : UnitTest(pass) {}
+struct VisitInnerAdjacentPhisTest : UnitTest {
+  VisitInnerAdjacentPhisTest(UnitTestRunner *pass) : UnitTest(pass) {}
   void invoke(Arguments &arguments) override {
     getFunction()->dump();
-    visitAdjacentReborrowsOfPhi(cast<SILPhiArgument>(arguments.takeValue()),
-                                [](auto *argument) -> bool {
-                                  argument->dump();
-                                  return true;
-                                });
+    visitInnerAdjacentPhis(cast<SILPhiArgument>(arguments.takeValue()),
+                           [](auto *argument) -> bool {
+                             argument->dump();
+                             return true;
+                           });
   }
 };
 
@@ -673,7 +673,8 @@ void UnitTestRunner::withTest(StringRef name, Doit doit) {
 
     ADD_UNIT_TEST_SUBCLASS("ssa-liveness", SSALivenessTest)
     ADD_UNIT_TEST_SUBCLASS("test-specification-parsing", TestSpecificationTest)
-    ADD_UNIT_TEST_SUBCLASS("visit-adjacent-reborrows-of-phi", VisitAdjacentReborrowsOfPhiTest)
+    ADD_UNIT_TEST_SUBCLASS("visit-inner-adjacent-phis",
+                           VisitInnerAdjacentPhisTest)
     /// [new_tests] Add the new mapping from string to subclass above this line.
     ///             Please sort alphabetically by name to help reduce merge
     ///             conflicts.

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -126,7 +126,7 @@ bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {
   // adjacent reborrows and phis are encapsulated within their lifetimes.
   SILPhiArgument *arg;
   if ((arg = dyn_cast<SILPhiArgument>(getCurrentDef())) && arg->isPhi()) {
-    visitAdjacentReborrowsOfPhi(arg, [&](SILPhiArgument *reborrow) {
+    visitInnerAdjacentPhis(arg, [&](SILArgument *reborrow) {
       defUseWorklist.insert(reborrow);
       return true;
     });

--- a/test/SILOptimizer/unit_test.sil
+++ b/test/SILOptimizer/unit_test.sil
@@ -172,40 +172,6 @@ entry:
     return %retval : $()
 }
 
-// CHECK-LABEL: begin running test 1 of 1 on pay_the_phi: visit-adjacent-reborrows-of-phi with: @trace[2]
-// CHECK: sil [ossa] @pay_the_phi : {{.*}} {
-// CHECK:   [[C:%[^,]+]] = apply
-// CHECK:   [[BORROW1:%[^,]+]] = begin_borrow %1
-// CHECK:   [[BORROW2:%[^,]+]] = begin_borrow %1
-// CHECK:   br [[EXIT:bb[0-9]+]]([[C]] : $C, [[BORROW1]] : $C, [[BORROW2]] :
-// CHECK: [[EXIT]]({{%[^,]+}} : @owned $C, [[GUARANTEED1:%[^,]+]] : @guaranteed $C, [[GUARANTEED2:%[^,]+]] :
-// CHECK: } // end sil function 'pay_the_phi'
-
-// CHECK:[[GUARANTEED1]] = argument of [[EXIT]]
-// CHECK:[[GUARANTEED2]] = argument of [[EXIT]]
-// CHECK-LABEL: end running test 1 of 1 on pay_the_phi: visit-adjacent-reborrows-of-phi with: @trace[2]
-sil [ossa] @pay_the_phi : $@convention(thin) () -> () {
-entry:
-  test_specification "visit-adjacent-reborrows-of-phi @trace[2]"
-  %getC = function_ref @getC : $@convention(thin) () -> @owned C
-  %c = apply %getC() : $@convention(thin) () -> @owned C
-  debug_value [trace] %c : $C
-  %borrow1 = begin_borrow %c : $C
-  %borrow2 = begin_borrow %c : $C
-  debug_value [trace] %borrow2 : $C
-  %borrow3 = begin_borrow %borrow2 : $C
-  br exit(%c : $C, %borrow1 : $C, %borrow2 : $C, %borrow3 : $C)
-
-exit(%owned : @owned $C, %guaranteed_1 : @guaranteed $C, %guaranteed_2 : @guaranteed $C, %guaranteed_3 : @guaranteed $C):
-  debug_value [trace] %owned : $C
-  end_borrow %guaranteed_3 : $C
-  end_borrow %guaranteed_2 : $C
-  end_borrow %guaranteed_1 : $C
-  destroy_value %owned : $C
-  %retval = tuple ()
-  return %retval : $()
-}
-
 // CHECK-LABEL: begin running test 1 of {{[^,]+}} on test_arg_parsing_2
 // CHECK:       block:
 // CHECK:       {{bb[0-9]+}}:


### PR DESCRIPTION
This API is the inverse of visitEnclosingDefs when called on a phi.

This replaces the visitAdjacentReborrowsOfPhi algorithm with a small
loop that simply checks all the phis in the current block.

This should all be fairly efficient once SILArgument has a "reborrow"
flag.
