### PR TITLE
[Macros] Clean up `MacroExpansionDecl`

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8467,12 +8467,11 @@ public:
 
 class MacroExpansionDecl : public Decl {
   SourceLoc PoundLoc;
-  DeclNameRef Macro;
-  DeclNameLoc MacroLoc;
+  DeclNameRef MacroName;
+  DeclNameLoc MacroNameLoc;
   SourceLoc LeftAngleLoc, RightAngleLoc;
   ArrayRef<TypeRepr *> GenericArgs;
   ArgumentList *ArgList;
-  ArrayRef<Decl *> Rewritten;
 
   /// The referenced macro.
   ConcreteDeclRef macroRef;
@@ -8487,9 +8486,9 @@ public:
                      SourceLoc rightAngleLoc,
                      ArgumentList *args)
       : Decl(DeclKind::MacroExpansion, dc), PoundLoc(poundLoc),
-        Macro(macro), MacroLoc(macroLoc),
+        MacroName(macro), MacroNameLoc(macroLoc),
         LeftAngleLoc(leftAngleLoc), RightAngleLoc(rightAngleLoc),
-        GenericArgs(genericArgs), ArgList(args), Rewritten({}) {
+        GenericArgs(genericArgs), ArgList(args) {
     Bits.MacroExpansionDecl.Discriminator = InvalidDiscriminator;
   }
 
@@ -8502,11 +8501,10 @@ public:
   SourceRange getSourceRange() const;
   SourceLoc getLocFromSource() const { return PoundLoc; }
   SourceLoc getPoundLoc() const { return PoundLoc; }
-  DeclNameLoc getMacroLoc() const { return MacroLoc; }
-  DeclNameRef getMacro() const { return Macro; }
+  DeclNameLoc getMacroNameLoc() const { return MacroNameLoc; }
+  DeclNameRef getMacroName() const { return MacroName; }
   ArgumentList *getArgs() const { return ArgList; }
-  ArrayRef<Decl *> getRewritten() const { return Rewritten; }
-  void setRewritten(ArrayRef<Decl *> rewritten) { Rewritten = rewritten; }
+  ArrayRef<Decl *> getRewritten() const;
   ConcreteDeclRef getMacroRef() const { return macroRef; }
   void setMacroRef(ConcreteDeclRef ref) { macroRef = ref; }
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1321,7 +1321,7 @@ namespace {
 
     void visitMacroExpansionDecl(MacroExpansionDecl *MED) {
       printCommon(MED, "macro_expansion_decl ");
-      OS << MED->getMacro();
+      OS << MED->getMacroName();
       if (MED->getArgs()) {
         OS << '\n';
         OS.indent(Indent + 2);

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3386,7 +3386,7 @@ void ASTMangler::appendEntity(const ValueDecl *decl) {
     appendMacroExpansionContext(
         expansion->getLoc(), expansion->getDeclContext());
     appendMacroExpansionOperator(
-        expansion->getMacro().getBaseName().userFacingName(),
+        expansion->getMacroName().getBaseName().userFacingName(),
         MacroRole::Declaration,
         expansion->getDiscriminator());
     return;
@@ -3748,7 +3748,7 @@ void ASTMangler::appendMacroExpansionContext(
     } else {
       auto decl = cast<MacroExpansionDecl>(parent.get<Decl *>());
       outerExpansionLoc = decl->getLoc();
-      baseName = decl->getMacro().getBaseName();
+      baseName = decl->getMacroName().getBaseName();
       discriminator = decl->getDiscriminator();
       role = MacroRole::Declaration;
     }
@@ -3854,7 +3854,7 @@ std::string ASTMangler::mangleMacroExpansion(
   beginMangling();
   appendMacroExpansionContext(expansion->getLoc(), expansion->getDeclContext());
   appendMacroExpansionOperator(
-      expansion->getMacro().getBaseName().userFacingName(),
+      expansion->getMacroName().getBaseName().userFacingName(),
       MacroRole::Declaration,
       expansion->getDiscriminator());
   return finalize();

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4600,7 +4600,7 @@ void PrintAST::visitMacroDecl(MacroDecl *decl) {
 }
 
 void PrintAST::visitMacroExpansionDecl(MacroExpansionDecl *decl) {
-  Printer << '#' << decl->getMacro();
+  Printer << '#' << decl->getMacroName();
   if (decl->getArgs()) {
     Printer << '(';
     auto args = decl->getArgs()->getOriginalArgs();

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2436,7 +2436,7 @@ public:
       auto dc = getCanonicalDeclContext(expansion->getDeclContext());
       MacroExpansionDiscriminatorKey key{
         dc,
-        expansion->getMacro().getBaseName().getIdentifier()
+        expansion->getMacroName().getBaseName().getIdentifier()
       };
       auto &discriminatorSet = MacroExpansionDiscriminators[key];
       unsigned discriminator = expansion->getDiscriminator();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9894,7 +9894,7 @@ SourceRange MacroExpansionDecl::getSourceRange() const {
   else if (RightAngleLoc.isValid())
     endLoc = RightAngleLoc;
   else
-    endLoc = MacroLoc.getEndLoc();
+    endLoc = MacroNameLoc.getEndLoc();
 
   return SourceRange(PoundLoc, endLoc);
 }
@@ -9910,10 +9910,17 @@ unsigned MacroExpansionDecl::getDiscriminator() const {
       MacroDiscriminatorContext::getParentOf(mutableThis);
   mutableThis->setDiscriminator(
       ctx.getNextMacroDiscriminator(
-          discriminatorContext, getMacro().getBaseName()));
+          discriminatorContext, getMacroName().getBaseName()));
 
   assert(getRawDiscriminator() != InvalidDiscriminator);
   return getRawDiscriminator();
+}
+
+ArrayRef<Decl *> MacroExpansionDecl::getRewritten() const {
+  auto mutableThis = const_cast<MacroExpansionDecl *>(this);
+  return evaluateOrDefault(
+      getASTContext().evaluator,
+      ExpandMacroExpansionDeclRequest{mutableThis}, {});
 }
 
 NominalTypeDecl *

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1328,7 +1328,7 @@ std::vector<Diagnostic> DiagnosticEngine::getGeneratedSourceBufferNotes(
       } else {
         auto expansionDecl =
             cast<MacroExpansionDecl>(expansionNode.get<Decl *>());
-        macroName = expansionDecl->getMacro().getFullName();
+        macroName = expansionDecl->getMacroName().getFullName();
       }
 
       Diagnostic expansionNote(diag::in_macro_expansion, macroName);

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1664,7 +1664,7 @@ void swift::simple_display(
 
 DeclNameRef UnresolvedMacroReference::getMacroName() const {
   if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
-    return med->getMacro();
+    return med->getMacroName();
   if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
     return mee->getMacroName();
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {
@@ -1688,7 +1688,7 @@ SourceLoc UnresolvedMacroReference::getSigilLoc() const {
 
 DeclNameLoc UnresolvedMacroReference::getMacroNameLoc() const {
   if (auto *med = pointer.dyn_cast<MacroExpansionDecl *>())
-    return med->getMacroLoc();
+    return med->getMacroNameLoc();
   if (auto *mee = pointer.dyn_cast<MacroExpansionExpr *>())
     return mee->getMacroNameLoc();
   if (auto *attr = pointer.dyn_cast<CustomAttr *>()) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3738,11 +3738,11 @@ ExpandMacroExpansionDeclRequest::evaluate(Evaluator &evaluator,
   auto &ctx = MED->getASTContext();
   auto *dc = MED->getDeclContext();
   auto foundMacros = TypeChecker::lookupMacros(
-      MED->getDeclContext(), MED->getMacro(),
+      MED->getDeclContext(), MED->getMacroName(),
       MED->getLoc(), MacroRole::Declaration);
   if (foundMacros.empty()) {
-    MED->diagnose(diag::macro_undefined, MED->getMacro().getBaseIdentifier())
-        .highlight(MED->getMacroLoc().getSourceRange());
+    MED->diagnose(diag::macro_undefined, MED->getMacroName().getBaseIdentifier())
+        .highlight(MED->getMacroNameLoc().getSourceRange());
     return {};
   }
   // Resolve macro candidates.
@@ -3754,8 +3754,8 @@ ExpandMacroExpansionDeclRequest::evaluate(Evaluator &evaluator,
   }
   else {
     if (foundMacros.size() > 1) {
-      MED->diagnose(diag::ambiguous_decl_ref, MED->getMacro())
-          .highlight(MED->getMacroLoc().getSourceRange());
+      MED->diagnose(diag::ambiguous_decl_ref, MED->getMacroName())
+          .highlight(MED->getMacroNameLoc().getSourceRange());
       for (auto *candidate : foundMacros)
         candidate->diagnose(diag::found_candidate);
       return {};
@@ -3770,7 +3770,5 @@ ExpandMacroExpansionDeclRequest::evaluate(Evaluator &evaluator,
   SmallVector<Decl *, 2> expandedTemporary;
   if (!expandFreestandingDeclarationMacro(MED, expandedTemporary))
     return {};
-  auto expanded = ctx.AllocateCopy(expandedTemporary);
-  MED->setRewritten(expanded);
-  return expanded;
+  return ctx.AllocateCopy(expandedTemporary);
 }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -374,7 +374,7 @@ static bool isFromExpansionOfMacro(SourceFile *sourceFile, MacroDecl *macro,
             expansion.dyn_cast<Decl *>())) {
       // FIXME: Update once MacroExpansionDecl has a proper macro reference
       // in it.
-      if (expansionDecl->getMacro().getFullName() == macro->getName())
+      if (expansionDecl->getMacroName().getFullName() == macro->getName())
         return true;
     } else if (auto *macroAttr = sourceFile->getAttachedMacroAttribute()) {
       auto *decl = expansion.dyn_cast<Decl *>();


### PR DESCRIPTION
- Remove the `Rewritten` field and `setRewritten()`. Make `getRewritten()` invoke the request.
- Rename fields `Macro` and `MacroLoc` to `MacroName` and `MacroNameLoc` respectively as well as their getters to match those in `MacroExpansionExpr`.