### PR TITLE
prevent move-only types from being cast incorrectly

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6681,6 +6681,8 @@ ERROR(noimplicitcopy_attr_not_allowed_on_moveonlytype,none,
       "'@_noImplicitCopy' has no effect when applied to a move only type", ())
 ERROR(moveonly_enums_do_not_support_indirect,none,
       "move-only enum %0 cannot be marked indirect or have indirect cases yet", (Identifier))
+ERROR(moveonly_cast,none,
+      "move-only types cannot be conditionally cast", ())
 
 //------------------------------------------------------------------------------
 // MARK: Type inference from default expressions

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1678,7 +1678,7 @@ TypeChecker::typeCheckCheckedCast(Type fromType, Type toType,
   //
   //
   // Thus, right now, a move-only type is only a subtype of itself.
-  if (fromType->isPureMoveOnly())
+  if (fromType->isPureMoveOnly() || toType->isPureMoveOnly())
     return CheckedCastKind::Unresolved;
   
   // Check for a bridging conversion.

--- a/test/Constraints/moveonly_constraints.swift
+++ b/test/Constraints/moveonly_constraints.swift
@@ -139,7 +139,7 @@ func checkMethodCalls() {
   takeMaybe(true ? .none : .just(MO())) // expected-error 3{{move-only type 'MO' cannot be used with generics yet}}
 }
 
-func checkCasting(_ b: any Box, _ mo: MO) {
+func checkCasting(_ b: any Box, _ mo: MO, _ a: Any) {
   // casting dynamically is allowed, but should always fail since you can't
   // construct such a type.
   let box = b as! ValBox<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
@@ -159,26 +159,65 @@ func checkCasting(_ b: any Box, _ mo: MO) {
   _ = MO() as Any // expected-error {{move-only type 'MO' cannot be used with generics yet}}
   _ = MO() as MO
   _ = MO() as AnyObject // expected-error {{move-only type 'MO' cannot be used with generics yet}}
+  _ = 5 as MO // expected-error {{cannot convert value of type 'Int' to type 'MO' in coercion}}
+  _ = a as MO // expected-error {{cannot convert value of type 'Any' to type 'MO' in coercion}}
+  _ = b as MO // expected-error {{cannot convert value of type 'any Box' to type 'MO' in coercion}}
 
   // FIXME(kavon): make sure at runtime these casts actually fail, or just make them errors? (rdar://104900293)
 
   _ = MO() is AnyHashable // expected-warning {{cast from 'MO' to unrelated type 'AnyHashable' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
   _ = MO() is AnyObject // expected-warning {{cast from 'MO' to unrelated type 'AnyObject' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
   _ = MO() is Any // expected-warning {{cast from 'MO' to unrelated type 'Any' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
   _ = MO() is P // expected-warning {{cast from 'MO' to unrelated type 'any P' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
   _ = MO() is MO // expected-warning {{'is' test is always true}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+
+  _ = 5 is MO // expected-warning {{cast from 'Int' to unrelated type 'MO' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  _ = a is MO // expected-warning {{cast from 'Any' to unrelated type 'MO' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  _ = b is MO // expected-warning {{cast from 'any Box' to unrelated type 'MO' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
 
   _ = MO() as! AnyHashable // expected-warning {{cast from 'MO' to unrelated type 'AnyHashable' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
   _ = MO() as! AnyObject // expected-warning {{cast from 'MO' to unrelated type 'AnyObject' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
   _ = MO() as! Any // expected-warning {{cast from 'MO' to unrelated type 'Any' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
   _ = MO() as! P // expected-warning {{cast from 'MO' to unrelated type 'any P' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
   _ = MO() as! MO // expected-warning {{forced cast of 'MO' to same type has no effect}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+
+  _ = 5 as! MO // expected-warning {{cast from 'Int' to unrelated type 'MO' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  _ = a as! MO // expected-warning {{cast from 'Any' to unrelated type 'MO' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  _ = b as! MO // expected-warning {{cast from 'any Box' to unrelated type 'MO' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
 
   _ = MO() as? AnyHashable // expected-warning {{cast from 'MO' to unrelated type 'AnyHashable' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
   _ = MO() as? AnyObject // expected-warning {{cast from 'MO' to unrelated type 'AnyObject' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
   _ = MO() as? Any // expected-warning {{cast from 'MO' to unrelated type 'Any' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
   _ = MO() as? P // expected-warning {{cast from 'MO' to unrelated type 'any P' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
   _ = MO() as? MO // expected-warning {{conditional cast from 'MO' to 'MO' always succeeds}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+
+  _ = 5 as? MO // expected-warning {{cast from 'Int' to unrelated type 'MO' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  _ = a as? MO // expected-warning {{cast from 'Any' to unrelated type 'MO' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  _ = b as? MO // expected-warning {{cast from 'any Box' to unrelated type 'MO' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
 
 }
 

--- a/test/Sema/moveonly_sendable.swift
+++ b/test/Sema/moveonly_sendable.swift
@@ -106,12 +106,22 @@ func tryToCastIt(_ fd: FileDescriptor) {
   let _ = fd as Sendable // expected-error {{move-only type 'FileDescriptor' cannot be used with generics yet}}
 
   let _ = fd as? Sendable // expected-warning {{cast from 'FileDescriptor' to unrelated type 'any Sendable' always fails}}
-                          // expected-error@-1 {{marker protocol 'Sendable' cannot be used in a conditional cast}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
 
   let _ = fd as! Sendable // expected-warning {{cast from 'FileDescriptor' to unrelated type 'any Sendable' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
 
   let _ = fd is Sendable // expected-warning {{cast from 'FileDescriptor' to unrelated type 'any Sendable' always fails}}
-                         // expected-error@-1 {{marker protocol 'Sendable' cannot be used in a conditional cast}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+
+  let sendy = mkSendable()
+  let _ = sendy as FileDescriptor // expected-error {{cannot convert value of type 'any Sendable' to type 'FileDescriptor' in coercion}}
+  let _ = sendy is FileDescriptor // expected-warning {{cast from 'any Sendable' to unrelated type 'FileDescriptor' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  let _ = sendy as! FileDescriptor // expected-warning {{cast from 'any Sendable' to unrelated type 'FileDescriptor' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
+  let _ = sendy as? FileDescriptor// expected-warning {{cast from 'any Sendable' to unrelated type 'FileDescriptor' always fails}}
+  // expected-error@-1 {{move-only types cannot be conditionally cast}}
 }
 
 protocol GiveSendable<T> {


### PR DESCRIPTION
It appears that conditional casts require a check of the type's metadata at runtime. There's no reason for us to permit that at this time, since all such conditional casts are going to fail, unless its the identity cast. That is, a move-only type is currently only a subtype of itself.

- [x] ban `as?` and `is` casts of move-only values
- [x] ensure `as!` of move-only values are statically an error too.
- [x] get a warning emitted explaining the impossibility of a cast like `anyValue as! MO` when emitting said error.

resolves rdar://105313385