### PR TITLE
Split IDEInspectionCallbacks into CodeCompletionCallbacks and DoneParsingCallback

### DIFF
--- a/include/swift/IDE/CompletionLookup.h
+++ b/include/swift/IDE/CompletionLookup.h
@@ -614,7 +614,7 @@ public:
   void collectPrecedenceGroups();
 
   void getPrecedenceGroupCompletions(
-      IDEInspectionCallbacks::PrecedenceGroupCompletionKind SK);
+      CodeCompletionCallbacks::PrecedenceGroupCompletionKind SK);
 
   void getPoundAvailablePlatformCompletions();
 

--- a/include/swift/Parse/IDEInspectionCallbacks.h
+++ b/include/swift/Parse/IDEInspectionCallbacks.h
@@ -30,7 +30,7 @@ enum class ObjCSelectorContext {
 };
 
 /// Parser's interface to code completion.
-class IDEInspectionCallbacks {
+class CodeCompletionCallbacks {
 protected:
   Parser &P;
   ASTContext &Context;
@@ -55,11 +55,9 @@ protected:
   std::vector<Expr *> leadingSequenceExprs;
 
 public:
-  IDEInspectionCallbacks(Parser &P)
-      : P(P), Context(P.Context) {
-  }
+  CodeCompletionCallbacks(Parser &P) : P(P), Context(P.Context) {}
 
-  virtual ~IDEInspectionCallbacks() {}
+  virtual ~CodeCompletionCallbacks() {}
 
   bool isInsideObjCSelector() const {
     return CompleteExprSelectorContext != ObjCSelectorContext::None;
@@ -81,10 +79,10 @@ public:
   }
 
   class InEnumElementRawValueRAII {
-    IDEInspectionCallbacks *Callbacks;
+    CodeCompletionCallbacks *Callbacks;
 
   public:
-    InEnumElementRawValueRAII(IDEInspectionCallbacks *Callbacks)
+    InEnumElementRawValueRAII(CodeCompletionCallbacks *Callbacks)
         : Callbacks(Callbacks) {
       if (Callbacks)
         Callbacks->InEnumElementRawValue = true;
@@ -99,10 +97,10 @@ public:
   /// RAII type that temporarily sets the "in Objective-C #selector expression"
   /// flag on the code completion callbacks object.
   class InObjCSelectorExprRAII {
-    IDEInspectionCallbacks *Callbacks;
+    CodeCompletionCallbacks *Callbacks;
 
   public:
-    InObjCSelectorExprRAII(IDEInspectionCallbacks *Callbacks,
+    InObjCSelectorExprRAII(CodeCompletionCallbacks *Callbacks,
                            ObjCSelectorContext SelectorContext)
         : Callbacks(Callbacks) {
       if (Callbacks)
@@ -251,20 +249,31 @@ public:
   virtual void completeTypeAttrBeginning() {};
 
   virtual void completeOptionalBinding(){};
+};
+
+class DoneParsingCallback {
+public:
+  virtual ~DoneParsingCallback() {}
 
   /// Signals that the AST for the all the delayed-parsed code was
   /// constructed.  No \c complete*() callbacks will be done after this.
   virtual void doneParsing(SourceFile *SrcFile) = 0;
 };
 
-/// A factory to create instances of \c IDEInspectionCallbacks.
+/// A factory to create instances of \c CodeCompletionCallbacks and
+/// \c DoneParsingCallback.
 class IDEInspectionCallbacksFactory {
 public:
   virtual ~IDEInspectionCallbacksFactory() {}
 
+  struct Callbacks {
+    std::shared_ptr<CodeCompletionCallbacks> CompletionCallbacks;
+    std::shared_ptr<DoneParsingCallback> DoneParsingCallback;
+  };
+
   /// Create an instance of \c IDEInspectionCallbacks.  The result
   /// should be deallocated with 'delete'.
-  virtual IDEInspectionCallbacks *createIDEInspectionCallbacks(Parser &P) = 0;
+  virtual Callbacks createCallbacks(Parser &P) = 0;
 };
 
 } // namespace swift

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -41,7 +41,8 @@ namespace llvm {
 
 namespace swift {
   class IdentTypeRepr;
-  class IDEInspectionCallbacks;
+  class CodeCompletionCallbacks;
+  class DoneParsingCallback;
   class IDEInspectionCallbacksFactory;
   class DefaultArgumentInitializer;
   class DiagnosticEngine;
@@ -129,7 +130,8 @@ public:
   std::unique_ptr<PersistentParserState> OwnedState;
   DeclContext *CurDeclContext;
   ASTContext &Context;
-  IDEInspectionCallbacks *IDECallbacks = nullptr;
+  CodeCompletionCallbacks *CodeCompletionCallbacks = nullptr;
+  DoneParsingCallback *DoneParsingCallback = nullptr;
   std::vector<Located<std::vector<ParamDecl*>>> AnonClosureVars;
 
   /// The current token hash, or \c None if the parser isn't computing a hash
@@ -163,12 +165,16 @@ public:
   /// the #if decl.
   bool shouldEvaluatePoundIfDecls() const;
 
-  void setIDECallbacks(IDEInspectionCallbacks *Callbacks) {
-    IDECallbacks = Callbacks;
+  void setCodeCompletionCallbacks(class CodeCompletionCallbacks *Callbacks) {
+    CodeCompletionCallbacks = Callbacks;
+  }
+
+  void setDoneParsingCallback(class DoneParsingCallback *Callback) {
+    this->DoneParsingCallback = Callback;
   }
 
   bool isIDEInspectionFirstPass() const {
-    return SourceMgr.hasIDEInspectionTargetBuffer() && !IDECallbacks;
+    return SourceMgr.hasIDEInspectionTargetBuffer() && !DoneParsingCallback;
   }
 
   bool allowTopLevelCode() const;

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -3049,26 +3049,26 @@ void CompletionLookup::collectPrecedenceGroups() {
 }
 
 void CompletionLookup::getPrecedenceGroupCompletions(
-    IDEInspectionCallbacks::PrecedenceGroupCompletionKind SK) {
+    CodeCompletionCallbacks::PrecedenceGroupCompletionKind SK) {
   switch (SK) {
-  case IDEInspectionCallbacks::PrecedenceGroupCompletionKind::Associativity:
+  case CodeCompletionCallbacks::PrecedenceGroupCompletionKind::Associativity:
     addKeyword(getAssociativitySpelling(Associativity::None));
     addKeyword(getAssociativitySpelling(Associativity::Left));
     addKeyword(getAssociativitySpelling(Associativity::Right));
     return;
-  case IDEInspectionCallbacks::PrecedenceGroupCompletionKind::Assignment:
+  case CodeCompletionCallbacks::PrecedenceGroupCompletionKind::Assignment:
     addKeyword(getTokenText(tok::kw_false), Type(), SemanticContextKind::None,
                CodeCompletionKeywordKind::kw_false);
     addKeyword(getTokenText(tok::kw_true), Type(), SemanticContextKind::None,
                CodeCompletionKeywordKind::kw_true);
     return;
-  case IDEInspectionCallbacks::PrecedenceGroupCompletionKind::AttributeList:
+  case CodeCompletionCallbacks::PrecedenceGroupCompletionKind::AttributeList:
     addKeyword("associativity");
     addKeyword("higherThan");
     addKeyword("lowerThan");
     addKeyword("assignment");
     return;
-  case IDEInspectionCallbacks::PrecedenceGroupCompletionKind::Relation:
+  case CodeCompletionCallbacks::PrecedenceGroupCompletionKind::Relation:
     collectPrecedenceGroups();
     return;
   }

--- a/lib/IDE/ConformingMethodList.cpp
+++ b/lib/IDE/ConformingMethodList.cpp
@@ -25,7 +25,8 @@ using namespace swift;
 using namespace ide;
 
 namespace {
-class ConformingMethodListCallbacks : public IDEInspectionCallbacks {
+class ConformingMethodListCallbacks : public CodeCompletionCallbacks,
+                                      public DoneParsingCallback {
   ArrayRef<const char *> ExpectedTypeNames;
   ConformingMethodListConsumer &Consumer;
   SourceLoc Loc;
@@ -40,8 +41,8 @@ public:
   ConformingMethodListCallbacks(Parser &P,
                                 ArrayRef<const char *> ExpectedTypeNames,
                                 ConformingMethodListConsumer &Consumer)
-      : IDEInspectionCallbacks(P), ExpectedTypeNames(ExpectedTypeNames),
-        Consumer(Consumer) {}
+      : CodeCompletionCallbacks(P), DoneParsingCallback(),
+        ExpectedTypeNames(ExpectedTypeNames), Consumer(Consumer) {}
 
   // Only handle callbacks for suffix completions.
   // {
@@ -190,8 +191,10 @@ swift::ide::makeConformingMethodListCallbacksFactory(
         ConformingMethodListConsumer &Consumer)
         : ExpectedTypeNames(ExpectedTypeNames), Consumer(Consumer) {}
 
-    IDEInspectionCallbacks *createIDEInspectionCallbacks(Parser &P) override {
-      return new ConformingMethodListCallbacks(P, ExpectedTypeNames, Consumer);
+    Callbacks createCallbacks(Parser &P) override {
+      auto Callback = std::make_shared<ConformingMethodListCallbacks>(
+          P, ExpectedTypeNames, Consumer);
+      return {Callback, Callback};
     }
   };
 

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -318,15 +318,14 @@ public:
 
 // MARK: - CursorInfoDoneParsingCallback
 
-class CursorInfoDoneParsingCallback : public IDEInspectionCallbacks {
+class CursorInfoDoneParsingCallback : public DoneParsingCallback {
   CursorInfoConsumer &Consumer;
   SourceLoc RequestedLoc;
 
 public:
   CursorInfoDoneParsingCallback(Parser &P, CursorInfoConsumer &Consumer,
                                 SourceLoc RequestedLoc)
-      : IDEInspectionCallbacks(P), Consumer(Consumer),
-        RequestedLoc(RequestedLoc) {}
+      : DoneParsingCallback(), Consumer(Consumer), RequestedLoc(RequestedLoc) {}
 
   ResolvedCursorInfoPtr getDeclResult(NodeFinderDeclResult *DeclResult,
                                       SourceFile *SrcFile,
@@ -439,8 +438,10 @@ swift::ide::makeCursorInfoCallbacksFactory(CursorInfoConsumer &Consumer,
                                    SourceLoc RequestedLoc)
         : Consumer(Consumer), RequestedLoc(RequestedLoc) {}
 
-    IDEInspectionCallbacks *createIDEInspectionCallbacks(Parser &P) override {
-      return new CursorInfoDoneParsingCallback(P, Consumer, RequestedLoc);
+    Callbacks createCallbacks(Parser &P) override {
+      auto Callback = std::make_shared<CursorInfoDoneParsingCallback>(
+          P, Consumer, RequestedLoc);
+      return {nullptr, Callback};
     }
   };
 

--- a/lib/IDE/TypeContextInfo.cpp
+++ b/lib/IDE/TypeContextInfo.cpp
@@ -26,7 +26,8 @@
 using namespace swift;
 using namespace ide;
 
-class ContextInfoCallbacks : public IDEInspectionCallbacks {
+class ContextInfoCallbacks : public CodeCompletionCallbacks,
+                             public DoneParsingCallback {
   TypeContextInfoConsumer &Consumer;
   SourceLoc Loc;
   Expr *ParsedExpr = nullptr;
@@ -36,7 +37,7 @@ class ContextInfoCallbacks : public IDEInspectionCallbacks {
 
 public:
   ContextInfoCallbacks(Parser &P, TypeContextInfoConsumer &Consumer)
-      : IDEInspectionCallbacks(P), Consumer(Consumer) {}
+      : CodeCompletionCallbacks(P), DoneParsingCallback(), Consumer(Consumer) {}
 
   void completePostfixExprBeginning(CodeCompletionExpr *E) override;
   void completeForEachSequenceBeginning(CodeCompletionExpr *E) override;
@@ -211,8 +212,9 @@ IDEInspectionCallbacksFactory *swift::ide::makeTypeContextInfoCallbacksFactory(
     ContextInfoCallbacksFactoryImpl(TypeContextInfoConsumer &Consumer)
         : Consumer(Consumer) {}
 
-    IDEInspectionCallbacks *createIDEInspectionCallbacks(Parser &P) override {
-      return new ContextInfoCallbacks(P, Consumer);
+    Callbacks createCallbacks(Parser &P) override {
+      auto Callbacks = std::make_shared<ContextInfoCallbacks>(P, Consumer);
+      return {Callbacks, Callbacks};
     }
   };
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5175,8 +5175,9 @@ Parser::parseDecl(ParseDeclOptions Flags,
         peekToken().is(tok::code_complete) &&
         Tok.getLoc().getAdvancedLoc(1) == peekToken().getLoc()) {
       consumeToken();
-      if (CodeCompletionCallbacks)
+      if (CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeAfterPoundDirective();
+      }
       consumeToken(tok::code_complete);
       DeclResult = makeParserCodeCompletionResult<Decl>();
       break;
@@ -9380,8 +9381,9 @@ Parser::parseDeclPrecedenceGroup(ParseDeclOptions flags,
   auto checkCodeCompletion =
       [&](CodeCompletionCallbacks::PrecedenceGroupCompletionKind SK) -> bool {
     if (Tok.is(tok::code_complete)) {
-      if (CodeCompletionCallbacks)
+      if (CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeInPrecedenceGroup(SK);
+      }
       consumeToken();
       return true;
     }

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -9381,9 +9381,8 @@ Parser::parseDeclPrecedenceGroup(ParseDeclOptions flags,
   auto checkCodeCompletion =
       [&](CodeCompletionCallbacks::PrecedenceGroupCompletionKind SK) -> bool {
     if (Tok.is(tok::code_complete)) {
-      if (CodeCompletionCallbacks) {
-        CodeCompletionCallbacks->completeInPrecedenceGroup(SK);
-      }
+      if (this->CodeCompletionCallbacks)
+        this->CodeCompletionCallbacks->completeInPrecedenceGroup(SK);
       consumeToken();
       return true;
     }

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -734,9 +734,8 @@ ParserResult<Expr> Parser::parseExprKeyPathObjC() {
           Context, keywordLoc, lParenLoc, components, Tok.getLoc());
     }
 
-    if (CodeCompletionCallbacks) {
-      CodeCompletionCallbacks->completeExprKeyPath(expr, DotLoc);
-    }
+    if (this->CodeCompletionCallbacks)
+      this->CodeCompletionCallbacks->completeExprKeyPath(expr, DotLoc);
 
     // Eat the code completion token because we handled it.
     consumeToken(tok::code_complete);

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -699,8 +699,9 @@ ParserResult<Expr> Parser::parseExprKeyPath() {
         CodeCompletionExpr(pathResult.getPtrOrNull(), Tok.getLoc());
     auto *keypath = KeyPathExpr::createParsed(
         Context, backslashLoc, rootResult.getPtrOrNull(), CC, hasLeadingDot);
-    if (CodeCompletionCallbacks)
+    if (CodeCompletionCallbacks) {
       CodeCompletionCallbacks->completeExprKeyPath(keypath, DotLoc);
+    }
     consumeToken(tok::code_complete);
     return makeParserCodeCompletionResult(keypath);
   }
@@ -734,8 +735,9 @@ ParserResult<Expr> Parser::parseExprKeyPathObjC() {
           Context, keywordLoc, lParenLoc, components, Tok.getLoc());
     }
 
-    if (CodeCompletionCallbacks)
+    if (CodeCompletionCallbacks) {
       CodeCompletionCallbacks->completeExprKeyPath(expr, DotLoc);
+    }
 
     // Eat the code completion token because we handled it.
     consumeToken(tok::code_complete);
@@ -2565,8 +2567,9 @@ ParserStatus Parser::parseClosureSignatureIfPresent(
           initializer = initializerResult.get();
         } else {
           auto CCE = new (Context) CodeCompletionExpr(Tok.getLoc());
-          if (CodeCompletionCallbacks)
+          if (CodeCompletionCallbacks) {
             CodeCompletionCallbacks->completePostfixExprBeginning(CCE);
+          }
           name = Identifier();
           initializer = CCE;
           consumeToken();
@@ -3135,9 +3138,10 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
     } else if (isArgumentList && Tok.is(tok::code_complete)) {
       // Handle call arguments specially because it may need argument labels.
       auto CCExpr = new (Context) CodeCompletionExpr(Tok.getLoc());
-      if (CodeCompletionCallbacks)
+      if (CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeCallArg(CCExpr,
                                                  PreviousLoc == leftLoc);
+      }
       consumeIf(tok::code_complete);
       SubExpr = CCExpr;
       Status.setHasCodeCompletionAndIsError();
@@ -3243,9 +3247,10 @@ Parser::parseTrailingClosures(bool isExprBasic, SourceRange calleeRange,
 
       // foo() {} <token>
       auto CCExpr = new (Context) CodeCompletionExpr(Tok.getLoc());
-      if (CodeCompletionCallbacks)
+      if (CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeLabeledTrailingClosure(
             CCExpr, Tok.isAtStartOfLine());
+      }
       consumeToken(tok::code_complete);
       result.setHasCodeCompletionAndIsError();
       closures.emplace_back(SourceLoc(), Identifier(), CCExpr);
@@ -3323,8 +3328,9 @@ Parser::parseExprPoundCodeCompletion(Optional<StmtKind> ParentKind) {
   consumeToken(); // '#' token.
   auto CodeCompletionPos = consumeToken();
   auto Expr = new (Context) CodeCompletionExpr(CodeCompletionPos);
-  if (CodeCompletionCallbacks)
+  if (CodeCompletionCallbacks) {
     CodeCompletionCallbacks->completeAfterPoundExpr(Expr, ParentKind);
+  }
   return makeParserCodeCompletionResult(Expr);
 }
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -699,9 +699,8 @@ ParserResult<Expr> Parser::parseExprKeyPath() {
         CodeCompletionExpr(pathResult.getPtrOrNull(), Tok.getLoc());
     auto *keypath = KeyPathExpr::createParsed(
         Context, backslashLoc, rootResult.getPtrOrNull(), CC, hasLeadingDot);
-    if (CodeCompletionCallbacks) {
-      CodeCompletionCallbacks->completeExprKeyPath(keypath, DotLoc);
-    }
+    if (this->CodeCompletionCallbacks)
+      this->CodeCompletionCallbacks->completeExprKeyPath(keypath, DotLoc);
     consumeToken(tok::code_complete);
     return makeParserCodeCompletionResult(keypath);
   }
@@ -3138,10 +3137,9 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
     } else if (isArgumentList && Tok.is(tok::code_complete)) {
       // Handle call arguments specially because it may need argument labels.
       auto CCExpr = new (Context) CodeCompletionExpr(Tok.getLoc());
-      if (CodeCompletionCallbacks) {
-        CodeCompletionCallbacks->completeCallArg(CCExpr,
-                                                 PreviousLoc == leftLoc);
-      }
+      if (this->CodeCompletionCallbacks)
+        this->CodeCompletionCallbacks->completeCallArg(CCExpr,
+                                                       PreviousLoc == leftLoc);
       consumeIf(tok::code_complete);
       SubExpr = CCExpr;
       Status.setHasCodeCompletionAndIsError();

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -132,7 +132,7 @@ ParserResult<Expr> Parser::parseExprArrow() {
   status |= parseEffectsSpecifiers(SourceLoc(),
                                    asyncLoc, /*reasync=*/nullptr,
                                    throwsLoc, /*rethrows=*/nullptr);
-  if (status.hasCodeCompletion() && !IDECallbacks) {
+  if (status.hasCodeCompletion() && !CodeCompletionCallbacks) {
     // Trigger delayed parsing, no need to continue.
     return status;
   }
@@ -190,8 +190,8 @@ ParserResult<Expr> Parser::parseExprSequence(Diag<> Message,
       parseExprSequenceElement(Message, isExprBasic);
     SequenceStatus |= Primary;
 
-    if (SequenceStatus.hasCodeCompletion() && IDECallbacks)
-      IDECallbacks->setLeadingSequenceExprs(SequencedExprs);
+    if (SequenceStatus.hasCodeCompletion() && CodeCompletionCallbacks)
+      CodeCompletionCallbacks->setLeadingSequenceExprs(SequencedExprs);
 
     if (Primary.isNull()) {
       if (SequenceStatus.hasCodeCompletion()) {
@@ -699,8 +699,8 @@ ParserResult<Expr> Parser::parseExprKeyPath() {
         CodeCompletionExpr(pathResult.getPtrOrNull(), Tok.getLoc());
     auto *keypath = KeyPathExpr::createParsed(
         Context, backslashLoc, rootResult.getPtrOrNull(), CC, hasLeadingDot);
-    if (IDECallbacks)
-      IDECallbacks->completeExprKeyPath(keypath, DotLoc);
+    if (CodeCompletionCallbacks)
+      CodeCompletionCallbacks->completeExprKeyPath(keypath, DotLoc);
     consumeToken(tok::code_complete);
     return makeParserCodeCompletionResult(keypath);
   }
@@ -734,8 +734,8 @@ ParserResult<Expr> Parser::parseExprKeyPathObjC() {
           Context, keywordLoc, lParenLoc, components, Tok.getLoc());
     }
 
-    if (IDECallbacks)
-      IDECallbacks->completeExprKeyPath(expr, DotLoc);
+    if (CodeCompletionCallbacks)
+      CodeCompletionCallbacks->completeExprKeyPath(expr, DotLoc);
 
     // Eat the code completion token because we handled it.
     consumeToken(tok::code_complete);
@@ -855,8 +855,8 @@ ParserResult<Expr> Parser::parseExprSelector() {
   }
 
   // Parse the subexpression.
-  IDEInspectionCallbacks::InObjCSelectorExprRAII
-    InObjCSelectorExpr(IDECallbacks, selectorContext);
+  CodeCompletionCallbacks::InObjCSelectorExprRAII InObjCSelectorExpr(
+      CodeCompletionCallbacks, selectorContext);
   ParserResult<Expr> subExpr =
     parseExpr(selectorKind == ObjCSelectorExpr::Method
                 ? diag::expr_selector_expected_method_expr
@@ -1248,8 +1248,8 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
         assert(!InSwiftKeyPath);
         auto CCExpr = new (Context) CodeCompletionExpr(Result.get(),
                                                        Tok.getLoc());
-        if (IDECallbacks) {
-          IDECallbacks->completeDotExpr(CCExpr, /*DotLoc=*/TokLoc);
+        if (CodeCompletionCallbacks) {
+          CodeCompletionCallbacks->completeDotExpr(CCExpr, /*DotLoc=*/TokLoc);
         }
         consumeToken(tok::code_complete);
 
@@ -1472,9 +1472,9 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
         return Result;
       }
 
-      if (IDECallbacks && Result.isNonNull()) {
+      if (CodeCompletionCallbacks && Result.isNonNull()) {
         bool hasSpace = Tok.getLoc() != getEndOfPreviousLoc();
-        IDECallbacks->completePostfixExpr(Result.get(), hasSpace);
+        CodeCompletionCallbacks->completePostfixExpr(Result.get(), hasSpace);
       }
       // Eat the code completion token because we handled it.
       consumeToken(tok::code_complete);
@@ -1748,8 +1748,8 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
       auto CCE = new (Context) CodeCompletionExpr(Tok.getLoc());
       auto Result = makeParserResult(CCE);
       Result.setHasCodeCompletionAndIsError();
-      if (IDECallbacks) {
-        IDECallbacks->completeUnresolvedMember(CCE, DotLoc);
+      if (CodeCompletionCallbacks) {
+        CodeCompletionCallbacks->completeUnresolvedMember(CCE, DotLoc);
       }
       consumeToken();
       return Result;
@@ -1816,14 +1816,14 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
     auto Result =
         makeParserResult(new (Context) CodeCompletionExpr(Tok.getLoc()));
     Result.setHasCodeCompletionAndIsError();
-    if (IDECallbacks &&
+    if (CodeCompletionCallbacks &&
         // We cannot code complete anything after var/let.
         (!InBindingPattern ||
          InBindingPattern == PatternBindingState::InMatchingPattern)) {
       if (InPoundIfEnvironment) {
-        IDECallbacks->completePlatformCondition();
+        CodeCompletionCallbacks->completePlatformCondition();
       } else {
-        IDECallbacks->completePostfixExprBeginning(
+        CodeCompletionCallbacks->completePostfixExprBeginning(
             cast<CodeCompletionExpr>(Result.get()));
       }
     }
@@ -2565,8 +2565,8 @@ ParserStatus Parser::parseClosureSignatureIfPresent(
           initializer = initializerResult.get();
         } else {
           auto CCE = new (Context) CodeCompletionExpr(Tok.getLoc());
-          if (IDECallbacks)
-            IDECallbacks->completePostfixExprBeginning(CCE);
+          if (CodeCompletionCallbacks)
+            CodeCompletionCallbacks->completePostfixExprBeginning(CCE);
           name = Identifier();
           initializer = CCE;
           consumeToken();
@@ -3135,8 +3135,9 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
     } else if (isArgumentList && Tok.is(tok::code_complete)) {
       // Handle call arguments specially because it may need argument labels.
       auto CCExpr = new (Context) CodeCompletionExpr(Tok.getLoc());
-      if (IDECallbacks)
-        IDECallbacks->completeCallArg(CCExpr, PreviousLoc == leftLoc);
+      if (CodeCompletionCallbacks)
+        CodeCompletionCallbacks->completeCallArg(CCExpr,
+                                                 PreviousLoc == leftLoc);
       consumeIf(tok::code_complete);
       SubExpr = CCExpr;
       Status.setHasCodeCompletionAndIsError();
@@ -3236,15 +3237,15 @@ Parser::parseTrailingClosures(bool isExprBasic, SourceRange calleeRange,
       // If the current completion mode doesn't support trailing closure
       // completion, leave the token here and let "postfix completion" to
       // handle it.
-      if (IDECallbacks &&
-          !IDECallbacks->canPerformCompleteLabeledTrailingClosure())
+      if (CodeCompletionCallbacks &&
+          !CodeCompletionCallbacks->canPerformCompleteLabeledTrailingClosure())
         break;
 
       // foo() {} <token>
       auto CCExpr = new (Context) CodeCompletionExpr(Tok.getLoc());
-      if (IDECallbacks)
-        IDECallbacks->completeLabeledTrailingClosure(CCExpr,
-                                                     Tok.isAtStartOfLine());
+      if (CodeCompletionCallbacks)
+        CodeCompletionCallbacks->completeLabeledTrailingClosure(
+            CCExpr, Tok.isAtStartOfLine());
       consumeToken(tok::code_complete);
       result.setHasCodeCompletionAndIsError();
       closures.emplace_back(SourceLoc(), Identifier(), CCExpr);
@@ -3322,8 +3323,8 @@ Parser::parseExprPoundCodeCompletion(Optional<StmtKind> ParentKind) {
   consumeToken(); // '#' token.
   auto CodeCompletionPos = consumeToken();
   auto Expr = new (Context) CodeCompletionExpr(CodeCompletionPos);
-  if (IDECallbacks)
-    IDECallbacks->completeAfterPoundExpr(Expr, ParentKind);
+  if (CodeCompletionCallbacks)
+    CodeCompletionCallbacks->completeAfterPoundExpr(Expr, ParentKind);
   return makeParserCodeCompletionResult(Expr);
 }
 
@@ -3338,7 +3339,7 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn, bool isExprBasic) {
 
   // If there is a code completion token right after the '(', do a special case
   // callback.
-  if (peekToken().is(tok::code_complete) && IDECallbacks) {
+  if (peekToken().is(tok::code_complete) && CodeCompletionCallbacks) {
     auto lParenLoc = consumeToken(tok::l_paren);
     auto CCE = new (Context) CodeCompletionExpr(Tok.getLoc());
     auto rParenLoc = Tok.getLoc();
@@ -3347,7 +3348,7 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn, bool isExprBasic) {
         /*trailingClosureIdx*/ None);
     auto Result = makeParserResult(
         fn, CallExpr::create(Context, fn.get(), argList, /*implicit*/ false));
-    IDECallbacks->completePostfixExprParen(fn.get(), CCE);
+    CodeCompletionCallbacks->completePostfixExprParen(fn.get(), CCE);
     // Eat the code completion token because we handled it.
     consumeToken(tok::code_complete);
     Result.setHasCodeCompletionAndIsError();
@@ -3675,8 +3676,8 @@ Parser::parsePlatformVersionConstraintSpec() {
   SourceLoc PlatformLoc;
   if (Tok.is(tok::code_complete)) {
     consumeToken();
-    if (IDECallbacks) {
-      IDECallbacks->completePoundAvailablePlatform();
+    if (CodeCompletionCallbacks) {
+      CodeCompletionCallbacks->completePoundAvailablePlatform();
     }
     return makeParserCodeCompletionStatus();
   }

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -280,8 +280,8 @@ ParserStatus Parser::parseGenericWhereClause(
   bool HasNextReq;
   do {
     if (Tok.is(tok::code_complete)) {
-      if (IDECallbacks)
-        IDECallbacks->completeGenericRequirement();
+      if (CodeCompletionCallbacks)
+        CodeCompletionCallbacks->completeGenericRequirement();
       EndLoc = consumeToken(tok::code_complete);
       Status.setHasCodeCompletionAndIsError();
       break;

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -280,8 +280,9 @@ ParserStatus Parser::parseGenericWhereClause(
   bool HasNextReq;
   do {
     if (Tok.is(tok::code_complete)) {
-      if (CodeCompletionCallbacks)
+      if (CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeGenericRequirement();
+      }
       EndLoc = consumeToken(tok::code_complete);
       Status.setHasCodeCompletionAndIsError();
       break;

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -245,9 +245,8 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
     if (paramContext != ParameterContextKind::EnumElement) {
       auto AttrStatus = parseDeclAttributeList(param.Attrs);
       if (AttrStatus.hasCodeCompletion()) {
-        if (CodeCompletionCallbacks) {
-          CodeCompletionCallbacks->setAttrTargetDeclKind(DeclKind::Param);
-        }
+        if (this->CodeCompletionCallbacks)
+          this->CodeCompletionCallbacks->setAttrTargetDeclKind(DeclKind::Param);
         status.setHasCodeCompletionAndIsError();
       }
     }

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -245,8 +245,9 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
     if (paramContext != ParameterContextKind::EnumElement) {
       auto AttrStatus = parseDeclAttributeList(param.Attrs);
       if (AttrStatus.hasCodeCompletion()) {
-        if (CodeCompletionCallbacks)
+        if (CodeCompletionCallbacks) {
           CodeCompletionCallbacks->setAttrTargetDeclKind(DeclKind::Param);
+        }
         status.setHasCodeCompletionAndIsError();
       }
     }
@@ -987,9 +988,10 @@ ParserStatus Parser::parseEffectsSpecifiers(SourceLoc existingArrowLoc,
     // Code completion.
     if (Tok.is(tok::code_complete) && !Tok.isAtStartOfLine() &&
         !existingArrowLoc.isValid()) {
-      if (CodeCompletionCallbacks)
+      if (CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeEffectsSpecifier(asyncLoc.isValid(),
                                                           throwsLoc.isValid());
+      }
       consumeToken(tok::code_complete);
       status.setHasCodeCompletionAndIsError();
       continue;

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -245,8 +245,8 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
     if (paramContext != ParameterContextKind::EnumElement) {
       auto AttrStatus = parseDeclAttributeList(param.Attrs);
       if (AttrStatus.hasCodeCompletion()) {
-        if (IDECallbacks)
-          IDECallbacks->setAttrTargetDeclKind(DeclKind::Param);
+        if (CodeCompletionCallbacks)
+          CodeCompletionCallbacks->setAttrTargetDeclKind(DeclKind::Param);
         status.setHasCodeCompletionAndIsError();
       }
     }
@@ -987,9 +987,9 @@ ParserStatus Parser::parseEffectsSpecifiers(SourceLoc existingArrowLoc,
     // Code completion.
     if (Tok.is(tok::code_complete) && !Tok.isAtStartOfLine() &&
         !existingArrowLoc.isValid()) {
-      if (IDECallbacks)
-        IDECallbacks->completeEffectsSpecifier(asyncLoc.isValid(),
-                                                 throwsLoc.isValid());
+      if (CodeCompletionCallbacks)
+        CodeCompletionCallbacks->completeEffectsSpecifier(asyncLoc.isValid(),
+                                                          throwsLoc.isValid());
       consumeToken(tok::code_complete);
       status.setHasCodeCompletionAndIsError();
       continue;

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -140,8 +140,8 @@ ParserStatus Parser::parseExprOrStmt(ASTNode &Result) {
   if (Tok.is(tok::pound) && Tok.isAtStartOfLine() &&
       peekToken().is(tok::code_complete)) {
     consumeToken();
-    if (IDECallbacks)
-      IDECallbacks->completeAfterPoundDirective();
+    if (CodeCompletionCallbacks)
+      CodeCompletionCallbacks->completeAfterPoundDirective();
     consumeToken(tok::code_complete);
     return makeParserCodeCompletionStatus();
   }
@@ -175,14 +175,14 @@ ParserStatus Parser::parseExprOrStmt(ASTNode &Result) {
   StructureMarkerRAII ParsingStmt(*this, Tok.getLoc(),
                                   StructureMarkerKind::Statement);
 
-  if (IDECallbacks)
-    IDECallbacks->setExprBeginning(getParserPosition());
+  if (CodeCompletionCallbacks)
+    CodeCompletionCallbacks->setExprBeginning(getParserPosition());
 
   if (Tok.is(tok::code_complete)) {
     auto *CCE = new (Context) CodeCompletionExpr(Tok.getLoc());
     Result = CCE;
-    if (IDECallbacks)
-      IDECallbacks->completeStmtOrExpr(CCE);
+    if (CodeCompletionCallbacks)
+      CodeCompletionCallbacks->completeStmtOrExpr(CCE);
     consumeToken(tok::code_complete);
     return makeParserCodeCompletionStatus();
   }
@@ -700,8 +700,8 @@ static ParserStatus parseOptionalControlTransferTarget(Parser &P,
       TargetLoc = P.consumeIdentifier(Target, /*diagnoseDollarPrefix=*/false);
       return makeParserSuccess();
     } else if (P.Tok.is(tok::code_complete)) {
-      if (P.IDECallbacks)
-        P.IDECallbacks->completeStmtLabel(Kind);
+      if (P.CodeCompletionCallbacks)
+        P.CodeCompletionCallbacks->completeStmtLabel(Kind);
       TargetLoc = P.consumeToken(tok::code_complete);
       return makeParserCodeCompletionStatus();
     }
@@ -755,8 +755,8 @@ ParserResult<Stmt> Parser::parseStmtReturn(SourceLoc tryLoc) {
   if (Tok.is(tok::code_complete)) {
     auto CCE = new (Context) CodeCompletionExpr(Tok.getLoc());
     auto Result = makeParserResult(new (Context) ReturnStmt(ReturnLoc, CCE));
-    if (IDECallbacks) {
-      IDECallbacks->completeReturnStmt(CCE);
+    if (CodeCompletionCallbacks) {
+      CodeCompletionCallbacks->completeReturnStmt(CCE);
     }
     Result.setHasCodeCompletionAndIsError();
     consumeToken();
@@ -836,8 +836,8 @@ ParserResult<Stmt> Parser::parseStmtYield(SourceLoc tryLoc) {
     auto cce = new (Context) CodeCompletionExpr(Tok.getLoc());
     auto result = makeParserResult(
       YieldStmt::create(Context, yieldLoc, SourceLoc(), cce, SourceLoc()));
-    if (IDECallbacks) {
-      IDECallbacks->completeYieldStmt(cce, /*index=*/ None);
+    if (CodeCompletionCallbacks) {
+      CodeCompletionCallbacks->completeYieldStmt(cce, /*index=*/None);
     }
     result.setHasCodeCompletionAndIsError();
     consumeToken();
@@ -1097,13 +1097,13 @@ static void parseGuardedPattern(Parser &P, GuardedPattern &result,
     auto CCE = new (P.Context) CodeCompletionExpr(P.Tok.getLoc());
     result.ThePattern =
         ExprPattern::createParsed(P.Context, CCE, P.CurDeclContext);
-    if (P.IDECallbacks) {
+    if (P.CodeCompletionCallbacks) {
       switch (parsingContext) {
       case GuardedPatternContext::Case:
-        P.IDECallbacks->completeCaseStmtBeginning(CCE);
+        P.CodeCompletionCallbacks->completeCaseStmtBeginning(CCE);
         break;
       case GuardedPatternContext::Catch:
-        P.IDECallbacks->completePostfixExprBeginning(CCE);
+        P.CodeCompletionCallbacks->completePostfixExprBeginning(CCE);
         break;
       }
     }
@@ -1665,8 +1665,8 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
     }
 
   } else if (Tok.is(tok::code_complete)) {
-    if (IDECallbacks) {
-      IDECallbacks->completeOptionalBinding();
+    if (CodeCompletionCallbacks) {
+      CodeCompletionCallbacks->completeOptionalBinding();
     }
     ThePattern = makeParserResult(new (Context) AnyPattern(Tok.getLoc()));
     ThePattern.setHasCodeCompletionAndIsError();
@@ -1896,8 +1896,8 @@ ParserResult<Stmt> Parser::parseStmtIf(LabeledStmtInfo LabelInfo,
       }
       ElseBody = parseStmtIf(LabeledStmtInfo(), implicitlyInsertIf);
     } else if (Tok.is(tok::code_complete)) {
-      if (IDECallbacks)
-        IDECallbacks->completeAfterIfStmtElse();
+      if (CodeCompletionCallbacks)
+        CodeCompletionCallbacks->completeAfterIfStmtElse();
       Status.setHasCodeCompletionAndIsError();
       consumeToken(tok::code_complete);
     } else {
@@ -2267,9 +2267,9 @@ ParserResult<Stmt> Parser::parseStmtForEach(LabeledStmtInfo LabelInfo) {
   }
 
   if (Tok.is(tok::code_complete)) {
-    if (IDECallbacks) {
-      IDECallbacks->completeForEachPatternBeginning(TryLoc.isValid(),
-                                                    AwaitLoc.isValid());
+    if (CodeCompletionCallbacks) {
+      CodeCompletionCallbacks->completeForEachPatternBeginning(
+          TryLoc.isValid(), AwaitLoc.isValid());
     }
     consumeToken(tok::code_complete);
     // Since 'completeForeachPatternBeginning' is a keyword only completion,
@@ -2336,8 +2336,8 @@ ParserResult<Stmt> Parser::parseStmtForEach(LabeledStmtInfo LabelInfo) {
     // If there is no "in" keyword, suggest it. Otherwise, complete the
     // sequence.
     if (InLoc.isInvalid()) {
-      if (IDECallbacks)
-        IDECallbacks->completeForEachInKeyword();
+      if (CodeCompletionCallbacks)
+        CodeCompletionCallbacks->completeForEachInKeyword();
       consumeToken(tok::code_complete);
       return makeParserCodeCompletionStatus();
     } else {
@@ -2345,8 +2345,8 @@ ParserResult<Stmt> Parser::parseStmtForEach(LabeledStmtInfo LabelInfo) {
           makeParserResult(new (Context) CodeCompletionExpr(Tok.getLoc()));
       Container.setHasCodeCompletionAndIsError();
       Status |= Container;
-      if (IDECallbacks)
-        IDECallbacks->completeForEachSequenceBeginning(
+      if (CodeCompletionCallbacks)
+        CodeCompletionCallbacks->completeForEachSequenceBeginning(
             cast<CodeCompletionExpr>(Container.get()));
       consumeToken(tok::code_complete);
     }
@@ -2491,8 +2491,8 @@ Parser::parseStmtCases(SmallVectorImpl<ASTNode> &cases, bool IsActive) {
         cases.emplace_back(PDD);
       }
     } else if (Tok.is(tok::code_complete)) {
-      if (IDECallbacks)
-        IDECallbacks->completeCaseStmtKeyword();
+      if (CodeCompletionCallbacks)
+        CodeCompletionCallbacks->completeCaseStmtKeyword();
       consumeToken(tok::code_complete);
       return makeParserCodeCompletionStatus();
     } else {

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -140,8 +140,9 @@ ParserStatus Parser::parseExprOrStmt(ASTNode &Result) {
   if (Tok.is(tok::pound) && Tok.isAtStartOfLine() &&
       peekToken().is(tok::code_complete)) {
     consumeToken();
-    if (CodeCompletionCallbacks)
+    if (CodeCompletionCallbacks) {
       CodeCompletionCallbacks->completeAfterPoundDirective();
+    }
     consumeToken(tok::code_complete);
     return makeParserCodeCompletionStatus();
   }
@@ -175,14 +176,16 @@ ParserStatus Parser::parseExprOrStmt(ASTNode &Result) {
   StructureMarkerRAII ParsingStmt(*this, Tok.getLoc(),
                                   StructureMarkerKind::Statement);
 
-  if (CodeCompletionCallbacks)
+  if (CodeCompletionCallbacks) {
     CodeCompletionCallbacks->setExprBeginning(getParserPosition());
+  }
 
   if (Tok.is(tok::code_complete)) {
     auto *CCE = new (Context) CodeCompletionExpr(Tok.getLoc());
     Result = CCE;
-    if (CodeCompletionCallbacks)
+    if (CodeCompletionCallbacks) {
       CodeCompletionCallbacks->completeStmtOrExpr(CCE);
+    }
     consumeToken(tok::code_complete);
     return makeParserCodeCompletionStatus();
   }
@@ -1896,8 +1899,9 @@ ParserResult<Stmt> Parser::parseStmtIf(LabeledStmtInfo LabelInfo,
       }
       ElseBody = parseStmtIf(LabeledStmtInfo(), implicitlyInsertIf);
     } else if (Tok.is(tok::code_complete)) {
-      if (CodeCompletionCallbacks)
+      if (CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeAfterIfStmtElse();
+      }
       Status.setHasCodeCompletionAndIsError();
       consumeToken(tok::code_complete);
     } else {
@@ -2336,8 +2340,9 @@ ParserResult<Stmt> Parser::parseStmtForEach(LabeledStmtInfo LabelInfo) {
     // If there is no "in" keyword, suggest it. Otherwise, complete the
     // sequence.
     if (InLoc.isInvalid()) {
-      if (CodeCompletionCallbacks)
+      if (CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeForEachInKeyword();
+      }
       consumeToken(tok::code_complete);
       return makeParserCodeCompletionStatus();
     } else {
@@ -2345,9 +2350,10 @@ ParserResult<Stmt> Parser::parseStmtForEach(LabeledStmtInfo LabelInfo) {
           makeParserResult(new (Context) CodeCompletionExpr(Tok.getLoc()));
       Container.setHasCodeCompletionAndIsError();
       Status |= Container;
-      if (CodeCompletionCallbacks)
+      if (CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeForEachSequenceBeginning(
             cast<CodeCompletionExpr>(Container.get()));
+      }
       consumeToken(tok::code_complete);
     }
   } else {
@@ -2491,8 +2497,9 @@ Parser::parseStmtCases(SmallVectorImpl<ASTNode> &cases, bool IsActive) {
         cases.emplace_back(PDD);
       }
     } else if (Tok.is(tok::code_complete)) {
-      if (CodeCompletionCallbacks)
+      if (CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeCaseStmtKeyword();
+      }
       consumeToken(tok::code_complete);
       return makeParserCodeCompletionStatus();
     } else {

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -199,8 +199,9 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
       ty = parseTypeIdentifier();
       if (auto *ITR = cast_or_null<IdentTypeRepr>(ty.getPtrOrNull())) {
         if (Tok.is(tok::code_complete) && !Tok.isAtStartOfLine()) {
-          if (CodeCompletionCallbacks)
+          if (CodeCompletionCallbacks) {
             CodeCompletionCallbacks->completeTypeSimpleWithoutDot(ITR);
+          }
 
           ty.setHasCodeCompletionAndIsError();
           consumeToken(tok::code_complete);
@@ -216,8 +217,9 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
     ty = parseTypeTupleBody();
     break;
   case tok::code_complete:
-    if (CodeCompletionCallbacks)
+    if (CodeCompletionCallbacks) {
       CodeCompletionCallbacks->completeTypeSimpleBeginning();
+    }
     return makeParserCodeCompletionResult<TypeRepr>(
         new (Context) ErrorTypeRepr(consumeToken(tok::code_complete)));
   case tok::l_square: {
@@ -630,8 +632,9 @@ ParserResult<TypeRepr> Parser::parseTypeWithOpaqueParams(Diag<> MessageID) {
 
 ParserResult<TypeRepr> Parser::parseDeclResultType(Diag<> MessageID) {
   if (Tok.is(tok::code_complete)) {
-    if (CodeCompletionCallbacks)
+    if (CodeCompletionCallbacks) {
       CodeCompletionCallbacks->completeTypeDeclResultBeginning();
+    }
     consumeToken(tok::code_complete);
     return makeParserCodeCompletionStatus();
   }
@@ -721,8 +724,9 @@ ParserResult<TypeRepr> Parser::parseQualifiedDeclNameBaseType() {
     if (Tok.is(tok::kw_Any)) {
       return parseAnyType();
     } else if (Tok.is(tok::code_complete)) {
-      if (CodeCompletionCallbacks)
+      if (CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeTypeSimpleBeginning();
+      }
       // Eat the code completion token because we handled it.
       consumeToken(tok::code_complete);
       return makeParserCodeCompletionResult<DeclRefTypeRepr>();
@@ -788,11 +792,13 @@ ParserResult<TypeRepr> Parser::parseQualifiedDeclNameBaseType() {
     if (Tok.isNot(tok::code_complete)) {
       // We have a dot.
       consumeToken();
-      if (CodeCompletionCallbacks)
+      if (CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeTypeSimpleWithDot(DeclRefTR);
+      }
     } else {
-      if (CodeCompletionCallbacks)
+      if (CodeCompletionCallbacks) {
         CodeCompletionCallbacks->completeTypeSimpleWithoutDot(DeclRefTR);
+      }
     }
     // Eat the code completion token because we handled it.
     consumeToken(tok::code_complete);

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -199,8 +199,8 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
       ty = parseTypeIdentifier();
       if (auto *ITR = cast_or_null<IdentTypeRepr>(ty.getPtrOrNull())) {
         if (Tok.is(tok::code_complete) && !Tok.isAtStartOfLine()) {
-          if (IDECallbacks)
-            IDECallbacks->completeTypeSimpleWithoutDot(ITR);
+          if (CodeCompletionCallbacks)
+            CodeCompletionCallbacks->completeTypeSimpleWithoutDot(ITR);
 
           ty.setHasCodeCompletionAndIsError();
           consumeToken(tok::code_complete);
@@ -216,8 +216,8 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
     ty = parseTypeTupleBody();
     break;
   case tok::code_complete:
-    if (IDECallbacks)
-      IDECallbacks->completeTypeSimpleBeginning();
+    if (CodeCompletionCallbacks)
+      CodeCompletionCallbacks->completeTypeSimpleBeginning();
     return makeParserCodeCompletionResult<TypeRepr>(
         new (Context) ErrorTypeRepr(consumeToken(tok::code_complete)));
   case tok::l_square: {
@@ -256,8 +256,8 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
       if (peekToken().is(tok::code_complete)) {
         consumeToken();
 
-        if (IDECallbacks) {
-          IDECallbacks->completeTypeSimpleWithDot(ty.get());
+        if (CodeCompletionCallbacks) {
+          CodeCompletionCallbacks->completeTypeSimpleWithDot(ty.get());
         }
 
         ty.setHasCodeCompletionAndIsError();
@@ -286,8 +286,8 @@ ParserResult<TypeRepr> Parser::parseTypeSimple(
     }
 
     if (Tok.is(tok::code_complete) && !Tok.isAtStartOfLine()) {
-      if (IDECallbacks) {
-        IDECallbacks->completeTypeSimpleWithoutDot(ty.get());
+      if (CodeCompletionCallbacks) {
+        CodeCompletionCallbacks->completeTypeSimpleWithoutDot(ty.get());
       }
 
       ty.setHasCodeCompletionAndIsError();
@@ -630,8 +630,8 @@ ParserResult<TypeRepr> Parser::parseTypeWithOpaqueParams(Diag<> MessageID) {
 
 ParserResult<TypeRepr> Parser::parseDeclResultType(Diag<> MessageID) {
   if (Tok.is(tok::code_complete)) {
-    if (IDECallbacks)
-      IDECallbacks->completeTypeDeclResultBeginning();
+    if (CodeCompletionCallbacks)
+      CodeCompletionCallbacks->completeTypeDeclResultBeginning();
     consumeToken(tok::code_complete);
     return makeParserCodeCompletionStatus();
   }
@@ -721,8 +721,8 @@ ParserResult<TypeRepr> Parser::parseQualifiedDeclNameBaseType() {
     if (Tok.is(tok::kw_Any)) {
       return parseAnyType();
     } else if (Tok.is(tok::code_complete)) {
-      if (IDECallbacks)
-        IDECallbacks->completeTypeSimpleBeginning();
+      if (CodeCompletionCallbacks)
+        CodeCompletionCallbacks->completeTypeSimpleBeginning();
       // Eat the code completion token because we handled it.
       consumeToken(tok::code_complete);
       return makeParserCodeCompletionResult<DeclRefTypeRepr>();
@@ -788,11 +788,11 @@ ParserResult<TypeRepr> Parser::parseQualifiedDeclNameBaseType() {
     if (Tok.isNot(tok::code_complete)) {
       // We have a dot.
       consumeToken();
-      if (IDECallbacks)
-        IDECallbacks->completeTypeSimpleWithDot(DeclRefTR);
+      if (CodeCompletionCallbacks)
+        CodeCompletionCallbacks->completeTypeSimpleWithDot(DeclRefTR);
     } else {
-      if (IDECallbacks)
-        IDECallbacks->completeTypeSimpleWithoutDot(DeclRefTR);
+      if (CodeCompletionCallbacks)
+        CodeCompletionCallbacks->completeTypeSimpleWithoutDot(DeclRefTR);
     }
     // Eat the code completion token because we handled it.
     consumeToken(tok::code_complete);


### PR DESCRIPTION
Cursor info only cares about the `doneParsing` callback and not about all the `complete` functions that are now defined in `CodeCompletionCallbacks`. To make the design clearer, split `IDEInspectionCallbacks`.

rdar://105120332