### PR TITLE
[cxx-interop] Require `begin()` and `end()` to be non-mutating for auto-conformed container types

### DIFF
--- a/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/overlay/custom-sequence-module-interface.swift
@@ -24,10 +24,10 @@
 // CHECK:   typealias RawIterator = UnsafePointer<Int32>?
 // CHECK: }
 
-// CHECK: struct HasMutatingBeginEnd : CxxConvertibleToCollection {
-// CHECK:   typealias Element = ConstIterator.Pointee
-// CHECK:   typealias Iterator = CxxIterator<HasMutatingBeginEnd>
-// CHECK:   typealias RawIterator = ConstIterator
+// CHECK: struct HasMutatingBeginEnd {
+// CHECK-NOT:   typealias Element = ConstIterator.Pointee
+// CHECK-NOT:   typealias Iterator = CxxIterator<HasMutatingBeginEnd>
+// CHECK-NOT:   typealias RawIterator = ConstIterator
 // CHECK: }
 
 // CHECK: struct HasNoBeginMethod {


### PR DESCRIPTION
This makes sure that Swift is only auto-conforming C++ container types to `CxxSequence`/`CxxConvertibleToCollection` if they expose non-mutating `begin()` and `end()` methods.

We might want to make `begin()` and `end()` non-mutating in the near future to enable performance optimizations. This change makes sure that client code relying on the automatic conformances doesn't suddenly stop compiling if/when the mutability requirement on the protocol function changes.