### PR TITLE
[cxx-interop] Add `CxxDictionary` protocol for `std::map` ergonomics

### DIFF
--- a/include/swift/AST/KnownProtocols.def
+++ b/include/swift/AST/KnownProtocols.def
@@ -106,6 +106,8 @@ PROTOCOL(DistributedTargetInvocationResultHandler)
 
 // C++ Standard Library Overlay:
 PROTOCOL(CxxConvertibleToCollection)
+PROTOCOL(CxxDictionary)
+PROTOCOL(CxxPair)
 PROTOCOL(CxxSet)
 PROTOCOL(CxxRandomAccessCollection)
 PROTOCOL(CxxSequence)

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1125,6 +1125,8 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
     M = getLoadedModule(Id_Distributed);
     break;
   case KnownProtocolKind::CxxConvertibleToCollection:
+  case KnownProtocolKind::CxxDictionary:
+  case KnownProtocolKind::CxxPair:
   case KnownProtocolKind::CxxRandomAccessCollection:
   case KnownProtocolKind::CxxSet:
   case KnownProtocolKind::CxxSequence:

--- a/lib/ClangImporter/ClangDerivedConformances.cpp
+++ b/lib/ClangImporter/ClangDerivedConformances.cpp
@@ -61,6 +61,15 @@ lookupDirectWithoutExtensions(NominalTypeDecl *decl, Identifier id) {
   return result;
 }
 
+template <typename Decl>
+static Decl *lookupDirectSingleWithoutExtensions(NominalTypeDecl *decl,
+                                                 Identifier id) {
+  auto results = lookupDirectWithoutExtensions(decl, id);
+  if (results.size() != 1)
+    return nullptr;
+  return dyn_cast<Decl>(results.front());
+}
+
 /// Similar to ModuleDecl::conformsToProtocol, but doesn't introduce a
 /// dependency on Sema.
 static bool isConcreteAndValid(ProtocolConformanceRef conformanceRef,
@@ -315,19 +324,14 @@ void swift::conformToCxxIteratorIfNeeded(
 
   // Check if present: `var pointee: Pointee { get }`
   auto pointeeId = ctx.getIdentifier("pointee");
-  auto pointees = lookupDirectWithoutExtensions(decl, pointeeId);
-  if (pointees.size() != 1)
-    return;
-  auto pointee = dyn_cast<VarDecl>(pointees.front());
+  auto pointee = lookupDirectSingleWithoutExtensions<VarDecl>(decl, pointeeId);
   if (!pointee || pointee->isGetterMutating() || pointee->getType()->hasError())
     return;
 
   // Check if present: `func successor() -> Self`
   auto successorId = ctx.getIdentifier("successor");
-  auto successors = lookupDirectWithoutExtensions(decl, successorId);
-  if (successors.size() != 1)
-    return;
-  auto successor = dyn_cast<FuncDecl>(successors.front());
+  auto successor =
+      lookupDirectSingleWithoutExtensions<FuncDecl>(decl, successorId);
   if (!successor || successor->isMutating())
     return;
   auto successorTy = successor->getResultInterfaceType();
@@ -398,20 +402,14 @@ void swift::conformToCxxSequenceIfNeeded(
 
   // Check if present: `func __beginUnsafe() -> RawIterator`
   auto beginId = ctx.getIdentifier("__beginUnsafe");
-  auto begins = lookupDirectWithoutExtensions(decl, beginId);
-  if (begins.size() != 1)
-    return;
-  auto begin = dyn_cast<FuncDecl>(begins.front());
+  auto begin = lookupDirectSingleWithoutExtensions<FuncDecl>(decl, beginId);
   if (!begin)
     return;
   auto rawIteratorTy = begin->getResultInterfaceType();
 
   // Check if present: `func __endUnsafe() -> RawIterator`
   auto endId = ctx.getIdentifier("__endUnsafe");
-  auto ends = lookupDirectWithoutExtensions(decl, endId);
-  if (ends.size() != 1)
-    return;
-  auto end = dyn_cast<FuncDecl>(ends.front());
+  auto end = lookupDirectSingleWithoutExtensions<FuncDecl>(decl, endId);
   if (!end)
     return;
 
@@ -524,6 +522,16 @@ void swift::conformToCxxSequenceIfNeeded(
   }
 }
 
+static bool isStdDecl(const clang::CXXRecordDecl *clangDecl,
+                      llvm::ArrayRef<StringRef> names) {
+  if (!clangDecl->isInStdNamespace())
+    return false;
+  if (!clangDecl->getIdentifier())
+    return false;
+  StringRef name = clangDecl->getName();
+  return llvm::is_contained(names, name);
+}
+
 void swift::conformToCxxSetIfNeeded(ClangImporter::Implementation &impl,
                                     NominalTypeDecl *decl,
                                     const clang::CXXRecordDecl *clangDecl) {
@@ -535,29 +543,88 @@ void swift::conformToCxxSetIfNeeded(ClangImporter::Implementation &impl,
 
   // Only auto-conform types from the C++ standard library. Custom user types
   // might have a similar interface but different semantics.
-  if (!clangDecl->isInStdNamespace())
-    return;
-  if (!clangDecl->getIdentifier())
-    return;
-  StringRef name = clangDecl->getName();
-  if (name != "set" && name != "unordered_set" && name != "multiset")
+  if (!isStdDecl(clangDecl, {"set", "unordered_set", "multiset"}))
     return;
 
-  auto valueTypeId = ctx.getIdentifier("value_type");
-  auto valueTypes = lookupDirectWithoutExtensions(decl, valueTypeId);
-  if (valueTypes.size() != 1)
+  auto valueType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
+      decl, ctx.getIdentifier("value_type"));
+  auto sizeType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
+      decl, ctx.getIdentifier("size_type"));
+  if (!valueType || !sizeType)
     return;
-  auto valueType = dyn_cast<TypeAliasDecl>(valueTypes.front());
-
-  auto sizeTypeId = ctx.getIdentifier("size_type");
-  auto sizeTypes = lookupDirectWithoutExtensions(decl, sizeTypeId);
-  if (sizeTypes.size() != 1)
-    return;
-  auto sizeType = dyn_cast<TypeAliasDecl>(sizeTypes.front());
 
   impl.addSynthesizedTypealias(decl, ctx.Id_Element,
                                valueType->getUnderlyingType());
   impl.addSynthesizedTypealias(decl, ctx.getIdentifier("Size"),
                                sizeType->getUnderlyingType());
   impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::CxxSet});
+}
+
+void swift::conformToCxxPairIfNeeded(ClangImporter::Implementation &impl,
+                                     NominalTypeDecl *decl,
+                                     const clang::CXXRecordDecl *clangDecl) {
+  PrettyStackTraceDecl trace("conforming to CxxPair", decl);
+
+  assert(decl);
+  assert(clangDecl);
+  ASTContext &ctx = decl->getASTContext();
+
+  // Only auto-conform types from the C++ standard library. Custom user types
+  // might have a similar interface but different semantics.
+  if (!isStdDecl(clangDecl, {"pair"}))
+    return;
+
+  auto firstType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
+      decl, ctx.getIdentifier("first_type"));
+  auto secondType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
+      decl, ctx.getIdentifier("second_type"));
+  if (!firstType || !secondType)
+    return;
+
+  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("First"),
+                               firstType->getUnderlyingType());
+  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("Second"),
+                               secondType->getUnderlyingType());
+  impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::CxxPair});
+}
+
+void swift::conformToCxxDictionaryIfNeeded(
+    ClangImporter::Implementation &impl, NominalTypeDecl *decl,
+    const clang::CXXRecordDecl *clangDecl) {
+  PrettyStackTraceDecl trace("conforming to CxxDictionary", decl);
+
+  assert(decl);
+  assert(clangDecl);
+  ASTContext &ctx = decl->getASTContext();
+
+  // Only auto-conform types from the C++ standard library. Custom user types
+  // might have a similar interface but different semantics.
+  if (!isStdDecl(clangDecl, {"map", "unordered_map"}))
+    return;
+
+  auto keyType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
+      decl, ctx.getIdentifier("key_type"));
+  auto valueType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
+      decl, ctx.getIdentifier("mapped_type"));
+  auto iterType = lookupDirectSingleWithoutExtensions<TypeAliasDecl>(
+      decl, ctx.getIdentifier("const_iterator"));
+  if (!keyType || !valueType || !iterType)
+    return;
+
+  // Make the original subscript that returns a non-optional value unavailable.
+  // CxxDictionary adds another subscript that returns an optional value,
+  // similarly to Swift.Dictionary.
+  for (auto member : decl->getCurrentMembersWithoutLoading()) {
+    if (auto subscript = dyn_cast<SubscriptDecl>(member)) {
+      impl.markUnavailable(subscript,
+                           "use subscript with optional return value");
+    }
+  }
+
+  impl.addSynthesizedTypealias(decl, ctx.Id_Key, keyType->getUnderlyingType());
+  impl.addSynthesizedTypealias(decl, ctx.Id_Value,
+                               valueType->getUnderlyingType());
+  impl.addSynthesizedTypealias(decl, ctx.getIdentifier("RawIterator"),
+                               iterType->getUnderlyingType());
+  impl.addSynthesizedProtocolAttrs(decl, {KnownProtocolKind::CxxDictionary});
 }

--- a/lib/ClangImporter/ClangDerivedConformances.h
+++ b/lib/ClangImporter/ClangDerivedConformances.h
@@ -39,6 +39,18 @@ void conformToCxxSetIfNeeded(ClangImporter::Implementation &impl,
                              NominalTypeDecl *decl,
                              const clang::CXXRecordDecl *clangDecl);
 
+/// If the decl is an instantiation of C++ `std::pair`, synthesize a conformance
+/// to CxxPair, which is defined in the Cxx module.
+void conformToCxxPairIfNeeded(ClangImporter::Implementation &impl,
+                              NominalTypeDecl *decl,
+                              const clang::CXXRecordDecl *clangDecl);
+
+/// If the decl is an instantiation of C++ `std::map` or `std::unordered_map`,
+/// synthesize a conformance to CxxDictionary, which is defined in the Cxx module.
+void conformToCxxDictionaryIfNeeded(ClangImporter::Implementation &impl,
+                                    NominalTypeDecl *decl,
+                                    const clang::CXXRecordDecl *clangDecl);
+
 } // namespace swift
 
 #endif // SWIFT_CLANG_DERIVED_CONFORMANCES_H

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2613,6 +2613,8 @@ namespace {
         conformToCxxIteratorIfNeeded(Impl, nominalDecl, decl);
         conformToCxxSequenceIfNeeded(Impl, nominalDecl, decl);
         conformToCxxSetIfNeeded(Impl, nominalDecl, decl);
+        conformToCxxDictionaryIfNeeded(Impl, nominalDecl, decl);
+        conformToCxxPairIfNeeded(Impl, nominalDecl, decl);
       }
 
       if (auto *ntd = dyn_cast<NominalTypeDecl>(result))

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5875,6 +5875,8 @@ SpecialProtocol irgen::getSpecialProtocolID(ProtocolDecl *P) {
   case KnownProtocolKind::DistributedTargetInvocationDecoder:
   case KnownProtocolKind::DistributedTargetInvocationResultHandler:
   case KnownProtocolKind::CxxConvertibleToCollection:
+  case KnownProtocolKind::CxxDictionary:
+  case KnownProtocolKind::CxxPair:
   case KnownProtocolKind::CxxRandomAccessCollection:
   case KnownProtocolKind::CxxSet:
   case KnownProtocolKind::CxxSequence:

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -5,6 +5,8 @@ endif()
 
 add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDLIB
     CxxConvertibleToCollection.swift
+    CxxDictionary.swift
+    CxxPair.swift
     CxxSet.swift
     CxxRandomAccessCollection.swift
     CxxSequence.swift

--- a/stdlib/public/Cxx/CxxDictionary.swift
+++ b/stdlib/public/Cxx/CxxDictionary.swift
@@ -1,0 +1,37 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public protocol CxxDictionary<Key, Value> {
+  associatedtype Key
+  associatedtype Value
+  associatedtype RawIterator: UnsafeCxxInputIterator
+    where RawIterator.Pointee: CxxPair<Key, Value>
+
+  /// Do not implement this function manually in Swift.
+  func __findUnsafe(_ key: Key) -> RawIterator
+
+  /// Do not implement this function manually in Swift.
+  func __endUnsafe() -> RawIterator
+}
+
+extension CxxDictionary {
+  @inlinable
+  public subscript(key: Key) -> Value? {
+    get {
+      let iter = __findUnsafe(key)
+      guard iter != __endUnsafe() else {
+        return nil
+      }
+      return iter.pointee.second
+    }
+  }
+}

--- a/stdlib/public/Cxx/CxxPair.swift
+++ b/stdlib/public/Cxx/CxxPair.swift
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public protocol CxxPair<First, Second> {
+  associatedtype First
+  associatedtype Second
+
+  var first: First { get }
+  var second: Second { get }
+}

--- a/test/Interop/Cxx/stdlib/Inputs/std-map.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-map.h
@@ -2,9 +2,12 @@
 #define TEST_INTEROP_CXX_STDLIB_INPUTS_STD_MAP_H
 
 #include <map>
+#include <unordered_map>
 
 using Map = std::map<int, int>;
+using UnorderedMap = std::unordered_map<int, int>;
 
 inline Map initMap() { return {{1, 3}, {2, 2}, {3, 3}}; }
+inline UnorderedMap initUnorderedMap() { return {{1, 3}, {3, 3}, {2, 2}}; }
 
 #endif // TEST_INTEROP_CXX_STDLIB_INPUTS_STD_MAP_H

--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -2,8 +2,8 @@
 //
 // REQUIRES: executable_test
 //
-// Enable this everywhere once we have a solution for modularizing other C++ stdlibs: rdar://87654514
-// REQUIRES: OS=macosx || OS=linux-gnu
+// REQUIRES: OS=macosx
+// TODO: enable on Linux (rdar://105220600)
 
 import StdlibUnittest
 import StdMap
@@ -20,22 +20,26 @@ StdMapTestSuite.test("init") {
 }
 #endif
 
-StdMapTestSuite.test("subscript") {
+StdMapTestSuite.test("Map.subscript") {
+  // This relies on the `std::map` conformance to `CxxDictionary` protocol.
   var m = initMap()
   let at1 = m[1]
+  expectNotNil(at1)
   expectEqual(at1, 3)
   expectEqual(m[2], 2)
   expectEqual(m[3], 3)
+  expectNil(m[-1])
+  expectNil(m[5])
 }
 
-extension Map : CxxSequence { }
-
-StdMapTestSuite.test("first(where:)") {
-    let m = initMap()
-    let found = m.first(where: { $0.first > 1 })
-
-    expectEqual(found!.first, 2)
-    expectEqual(found!.second, 2)
+StdMapTestSuite.test("UnorderedMap.subscript") {
+  // This relies on the `std::unordered_map` conformance to `CxxDictionary` protocol.
+  var m = initUnorderedMap()
+  expectEqual(m[1], 3)
+  expectEqual(m[2], 2)
+  expectEqual(m[3], 3)
+  expectNil(m[-1])
+  expectNil(m[5])
 }
 
 runAllTests()


### PR DESCRIPTION
This adds a protocol to the C++ standard library overlay which will improve the ergonomics of `std::map` and `std::unordered_map` when used from Swift code.

As of now, `CxxDictionary` adds a subscript with an optional return type that mimics the subscript of `Swift.Dictionary`.

Similar to https://github.com/apple/swift/pull/63244.