### PR TITLE
[ConstraintSystem] Teach `getCalleeLocator` about pattern matching

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -496,6 +496,15 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
     }
   }
 
+  {
+    // Pattern match is always a callee regardless of what comes after it.
+    auto iter = path.rbegin();
+    if (locator->findLast<LocatorPathElt::PatternMatch>(iter)) {
+      auto newPath = path.drop_back(iter - path.rbegin());
+      return getConstraintLocator(anchor, newPath);
+    }
+  }
+
   if (locator->findLast<LocatorPathElt::DynamicCallable>()) {
     return getConstraintLocator(anchor, LocatorPathElt::ApplyFunction());
   }

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -540,3 +540,20 @@ func f60503() {
   let (key, _) = settings.enumerate() // expected-error{{cannot find 'settings' in scope}}
   let (_, _) = settings.enumerate() // expected-error{{cannot find 'settings' in scope}}
 }
+
+// rdar://105089074
+enum EWithIdent<Id> where Id: P { // expected-note 2 {{where 'Id' = 'Int'}}
+case test(Id)
+}
+
+extension [EWithIdent<Int>] {
+  func test() {
+    sorted { lhs, rhs in
+      switch (rhs, rhs) {
+      case let (.test(x), .test(y)): break
+        // expected-error@-1 2 {{generic enum 'EWithIdent' requires that 'Int' conform to 'P'}}
+      case (_, _): break
+      }
+    }
+  }
+}


### PR DESCRIPTION
Requesting a callee locator from locator in pattern matching context should always yield pattern match.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
