### PR TITLE
Add a test to verify that AnyHashable gets eagerly unwrapped

### DIFF
--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -1037,7 +1037,10 @@ CastsTests.test("Do not overuse __SwiftValue (non-ObjC)") {
 }
 
 CastsTests.test("Don't put AnyHashable inside AnyObject") {
-  class C: Hashable {}
+  class C: Hashable {
+    func hash(into hasher: inout Hasher) {}
+    static func ==(lhs: C, rhs: C) -> Bool { true }
+  }
   let a = C()
   let b = AnyHashable(a)
   let c = a as! AnyObject

--- a/test/Casting/Casts.swift
+++ b/test/Casting/Casts.swift
@@ -1036,4 +1036,14 @@ CastsTests.test("Do not overuse __SwiftValue (non-ObjC)") {
   expectTrue(Foo() is AnyObject)
 }
 
+CastsTests.test("Don't put AnyHashable inside AnyObject") {
+  class C: Hashable {}
+  let a = C()
+  let b = AnyHashable(a)
+  let c = a as! AnyObject
+  expectTrue(a === c)
+  let d = c as! C
+  expectTrue(a === d)
+}
+
 runAllTests()


### PR DESCRIPTION
To allow for better compiler optimizations, the
runtime should guarantee that AnyHashable does
not get boxed unnecessarily.

In particular, there was a concern that casting
an `AnyHashable` containing a class reference
to `AnyObject` would box the AnyHashable instead
of unwrapping it.

Further testing shows that the runtime is NOT
doing this unnecessary boxing at current.

Resolves rdar://90269352