### PR TITLE
[5.8][AST] Avoid possible segfault in isDirectToStorageAccess

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2108,7 +2108,7 @@ static bool isDirectToStorageAccess(const DeclContext *UseDC,
   if (!var->hasStorage())
     return false;
 
-  auto *AFD = dyn_cast<AbstractFunctionDecl>(UseDC);
+  auto *AFD = dyn_cast_or_null<AbstractFunctionDecl>(UseDC);
   if (AFD == nullptr)
     return false;
 


### PR DESCRIPTION
`isAccessibleFrom` allows a `nullptr` for `useDC`. Thus `UseDC` can be a `nullptr` in the path `checkAccess` -> `getAccessSemanticsFromContext` -> `isDirectToStorageAccess`.

Resolves rdar://104620331.

(cherry picked from commit 526016c5c1e8748e3aca78628c5d1a00b9d83666)