### PR TITLE
[IRGen] Bind wtables at open_pack_element.

### DIFF
--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -260,6 +260,7 @@ llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
                                        /*request*/ MetadataState::Complete,
                                        nullptr).getMetadata();
 
+  IGF.setScopedLocalTypeData(archetype, localDataKind, wtable);
   return wtable;
 }
 

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -158,9 +158,6 @@ static Address emitFixedSizeMetadataPackRef(IRGenFunction &IGF,
     IGF.Builder.CreateStore(metadata, slot);
   }
 
-  pack = IGF.Builder.CreateConstArrayGEP(
-      pack, 0, IGF.IGM.getPointerSize());
-
   return pack;
 }
 
@@ -359,8 +356,7 @@ irgen::emitTypeMetadataPackRef(IRGenFunction &IGF, CanPackType packType,
     return result;
 
   auto pack = emitTypeMetadataPack(IGF, packType, request);
-  auto *metadata = IGF.Builder.CreateConstArrayGEP(
-      pack.getAddress(), 0, IGF.IGM.getPointerSize()).getAddress();
+  auto *metadata = pack.getAddress().getAddress();
 
   auto response = MetadataResponse::forComplete(metadata);
   IGF.setScopedLocalTypeMetadata(packType, response);

--- a/lib/IRGen/GenPack.h
+++ b/lib/IRGen/GenPack.h
@@ -19,6 +19,7 @@
 
 #include "swift/AST/Types.h"
 #include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace llvm {
 
@@ -50,10 +51,12 @@ emitTypeMetadataPackRef(IRGenFunction &IGF,
                         CanPackType packType,
                         DynamicMetadataRequest request);
 
-llvm::Value *emitTypeMetadataPackElementRef(IRGenFunction &IGF,
-                                            CanPackType packType,
-                                            llvm::Value *index,
-                                            DynamicMetadataRequest request);
+llvm::Value *
+emitTypeMetadataPackElementRef(IRGenFunction &IGF, CanPackType packType,
+                               ArrayRef<ProtocolDecl *> protocols,
+                               llvm::Value *index,
+                               DynamicMetadataRequest request,
+                               llvm::SmallVectorImpl<llvm::Value *> &wtables);
 
 void cleanupTypeMetadataPack(IRGenFunction &IGF,
                              StackAddress pack,

--- a/lib/IRGen/GenPack.h
+++ b/lib/IRGen/GenPack.h
@@ -59,6 +59,15 @@ void cleanupTypeMetadataPack(IRGenFunction &IGF,
                              StackAddress pack,
                              Optional<unsigned> elementCount);
 
+StackAddress emitWitnessTablePack(IRGenFunction &IGF, CanPackType packType,
+                                  PackConformance *conformance);
+
+llvm::Value *emitWitnessTablePackRef(IRGenFunction &IGF, CanPackType packType,
+                                     PackConformance *conformance);
+
+void cleanupWitnessTablePack(IRGenFunction &IGF, StackAddress pack,
+                             Optional<unsigned> elementCount);
+
 /// Emit the dynamic index of a particular structural component
 /// of the given pack type.  If the component is a pack expansion, this
 /// is the index of the first element of the pack (or where it would be

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -68,6 +68,7 @@
 #include "GenHeap.h"
 #include "GenMeta.h"
 #include "GenOpaque.h"
+#include "GenPack.h"
 #include "GenPointerAuth.h"
 #include "GenPoly.h"
 #include "GenType.h"
@@ -3250,6 +3251,9 @@ llvm::Value *irgen::emitWitnessTableRef(IRGenFunction &IGF,
   // conformance info for them.  However, that conformance info might be
   // more concrete than we're expecting.
   // TODO: make a best effort to devirtualize, maybe?
+  } else if (conformance.isPack()) {
+    auto pack = cast<PackType>(srcType);
+    return emitWitnessTablePackRef(IGF, pack, conformance.getPack());
   } else {
     concreteConformance = conformance.getConcrete();
   }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -6876,10 +6876,13 @@ void IRGenSILFunction::visitOpenPackElementInst(swift::OpenPackElementInst *i) {
 
   i->getOpenedGenericEnvironment()->forEachPackElementBinding(
       [&](auto *archetype, auto *pack) {
+        auto protocols = archetype->getConformsTo();
+        llvm::SmallVector<llvm::Value *, 2> wtables;
         auto *metadata = emitTypeMetadataPackElementRef(
-            *this, CanPackType(pack), index, MetadataState::Complete);
-        this->bindArchetype(CanElementArchetypeType(archetype), metadata,
-                            MetadataState::Complete, {});
+            *this, CanPackType(pack), protocols, index, MetadataState::Complete,
+            wtables);
+        bindArchetype(CanElementArchetypeType(archetype), metadata,
+                      MetadataState::Complete, wtables);
       });
 
   // The result is just used for type dependencies.

--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -711,6 +711,8 @@ void LocalTypeDataKind::print(llvm::raw_ostream &out) const {
     out << "RepresentationTypeMetadata";
   } else if (Value == ValueWitnessTable) {
     out << "ValueWitnessTable";
+  } else if (Value == Shape) {
+    out << "Shape";
   } else {
     assert(isSingletonKind());
     if (Value >= ValueWitnessDiscriminatorBase) {

--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -25,6 +25,7 @@
 #include "IRGenModule.h"
 #include "MetadataRequest.h"
 #include "swift/AST/IRGenOptions.h"
+#include "swift/AST/PackConformance.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/SIL/SILModule.h"
 
@@ -704,6 +705,12 @@ void LocalTypeDataKind::print(llvm::raw_ostream &out) const {
   } else if (isAbstractProtocolConformance()) {
     out << "AbstractConformance("
         << getAbstractProtocolConformance()->getName()
+        << ")";
+  } else if (isPackProtocolConformance()) {
+    out << "PackConformance("
+        << getPackProtocolConformance()->getType()
+        << ":"
+        << getPackProtocolConformance()->getProtocol()->getName()
         << ")";
   } else if (Value == FormalTypeMetadata) {
     out << "FormalTypeMetadata";

--- a/test/IRGen/run_variadic_generics.sil
+++ b/test/IRGen/run_variadic_generics.sil
@@ -83,22 +83,28 @@ bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<
   %direct_access_from_parameter = function_ref @direct_access_from_parameter : $@convention(thin) <T_1...> (Builtin.Word) -> ()
   // U_1 -> {A, B, C, D, E, F}
   // --0---> ^
-  apply %direct_access_from_parameter<Pack{A, B, C, E, F, G}>(%0) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // CHECK: A
+  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%0) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
   // U_1 -> {A, B, C, D, E, F}
   // ----1----> ^
-  apply %direct_access_from_parameter<Pack{A, B, C, E, F, G}>(%1) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // CHECK: B
+  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%1) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
   // U_1 -> {A, B, C, D, E, F}
   // -----2------> ^
-  apply %direct_access_from_parameter<Pack{A, B, C, E, F, G}>(%2) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // CHECK: C
+  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%2) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
   // U_1 -> {A, B, C, D, E, F}
   // -------3-------> ^
-  apply %direct_access_from_parameter<Pack{A, B, C, E, F, G}>(%3) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // CHECK: D
+  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%3) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
   // U_1 -> {A, B, C, D, E, F}
   // --------4---------> ^
-  apply %direct_access_from_parameter<Pack{A, B, C, E, F, G}>(%4) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // CHECK: E
+  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%4) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
   // U_1 -> {A, B, C, D, E, F}
   // ----------5----------> ^
-  apply %direct_access_from_parameter<Pack{A, B, C, E, F, G}>(%5) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // CHECK: F
+  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%5) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
 
   %outb = integer_literal $Builtin.Int32, 0
   %out = struct $Int32 (%outb : $Builtin.Int32)

--- a/test/IRGen/run_variadic_generics.sil
+++ b/test/IRGen/run_variadic_generics.sil
@@ -19,13 +19,102 @@ import PrintShims
 
 sil public_external @printGenericType : $@convention(thin) <T> (@thick T.Type) -> ()
 
-struct A {}
-struct B {}
-struct C {}
-struct D {}
-struct E {}
-struct F {}
-struct G {}
+protocol P {
+  static func static_member_fn()
+}
+
+struct A : P {
+  static func static_member_fn()
+}
+struct B : P {
+  static func static_member_fn()
+}
+struct C : P {
+  static func static_member_fn()
+}
+struct D : P {
+  static func static_member_fn()
+}
+struct E : P {
+  static func static_member_fn()
+}
+struct F : P {
+  static func static_member_fn()
+}
+struct G : P {
+  static func static_member_fn()
+}
+
+sil private @A_static_member_fn : $@convention(witness_method: P) (@thick A.Type) -> () {
+bb0(%0 : $@thick A.Type):
+  %printGenericType = function_ref @printGenericType : $@convention(thin) <T> (@thick T.Type) -> ()
+  apply %printGenericType<A>(%0) : $@convention(thin) <T> (@thick T.Type) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+sil_witness_table A : P module main {
+  method #P.static_member_fn: <Self where Self : P> (Self.Type) -> () -> () : @A_static_member_fn
+}
+sil private @B_static_member_fn : $@convention(witness_method: P) (@thick B.Type) -> () {
+bb0(%0 : $@thick B.Type):
+  %printGenericType = function_ref @printGenericType : $@convention(thin) <T> (@thick T.Type) -> ()
+  apply %printGenericType<B>(%0) : $@convention(thin) <T> (@thick T.Type) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+sil_witness_table B : P module main {
+  method #P.static_member_fn: <Self where Self : P> (Self.Type) -> () -> () : @B_static_member_fn
+}
+sil private @C_static_member_fn : $@convention(witness_method: P) (@thick C.Type) -> () {
+bb0(%0 : $@thick C.Type):
+  %printGenericType = function_ref @printGenericType : $@convention(thin) <T> (@thick T.Type) -> ()
+  apply %printGenericType<C>(%0) : $@convention(thin) <T> (@thick T.Type) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+sil_witness_table C : P module main {
+  method #P.static_member_fn: <Self where Self : P> (Self.Type) -> () -> () : @C_static_member_fn
+}
+sil private @D_static_member_fn : $@convention(witness_method: P) (@thick D.Type) -> () {
+bb0(%0 : $@thick D.Type):
+  %printGenericType = function_ref @printGenericType : $@convention(thin) <T> (@thick T.Type) -> ()
+  apply %printGenericType<D>(%0) : $@convention(thin) <T> (@thick T.Type) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+sil_witness_table D : P module main {
+  method #P.static_member_fn: <Self where Self : P> (Self.Type) -> () -> () : @D_static_member_fn
+}
+sil private @E_static_member_fn : $@convention(witness_method: P) (@thick E.Type) -> () {
+bb0(%0 : $@thick E.Type):
+  %printGenericType = function_ref @printGenericType : $@convention(thin) <T> (@thick T.Type) -> ()
+  apply %printGenericType<E>(%0) : $@convention(thin) <T> (@thick T.Type) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+sil_witness_table E : P module main {
+  method #P.static_member_fn: <Self where Self : P> (Self.Type) -> () -> () : @E_static_member_fn
+}
+sil private @F_static_member_fn : $@convention(witness_method: P) (@thick F.Type) -> () {
+bb0(%0 : $@thick F.Type):
+  %printGenericType = function_ref @printGenericType : $@convention(thin) <T> (@thick T.Type) -> ()
+  apply %printGenericType<F>(%0) : $@convention(thin) <T> (@thick T.Type) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+sil_witness_table F : P module main {
+  method #P.static_member_fn: <Self where Self : P> (Self.Type) -> () -> () : @F_static_member_fn
+}
+sil private @G_static_member_fn : $@convention(witness_method: P) (@thick G.Type) -> () {
+bb0(%0 : $@thick G.Type):
+  %printGenericType = function_ref @printGenericType : $@convention(thin) <T> (@thick T.Type) -> ()
+  apply %printGenericType<G>(%0) : $@convention(thin) <T> (@thick T.Type) -> ()
+  %4 = tuple ()
+  return %4 : $()
+}
+sil_witness_table G : P module main {
+  method #P.static_member_fn: <Self where Self : P> (Self.Type) -> () -> () : @G_static_member_fn
+}
 
 sil [ossa] @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
 bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
@@ -36,6 +125,87 @@ bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<
   %4 = integer_literal $Builtin.Word, 4
   %5 = integer_literal $Builtin.Word, 5
 
+  %two_archetypes_from_two_params_no_singles_with_conformance = function_ref @two_archetypes_from_two_params_no_singles_with_conformance : $@convention(thin) <T_1... : P, T_2... : P where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // ---0--> ^
+  // CHECK: A
+  // CHECK: A
+  // U_2 -> {D, E, F, A, B, C}
+  // ---0--> ^
+  // CHECK: D
+  // CHECK: D
+  apply %two_archetypes_from_two_params_no_singles_with_conformance<Pack{A, B, C}, Pack{D, E, F}>(%0) : $@convention(thin) <T_1... : P, T_2... : P where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // ----1----> ^
+  // CHECK: B
+  // CHECK: B
+  // U_2 -> {D, E, F, A, B, C}
+  // ----1----> ^
+  // CHECK: E
+  // CHECK: E
+  apply %two_archetypes_from_two_params_no_singles_with_conformance<Pack{A, B, C}, Pack{D, E, F}>(%1) : $@convention(thin) <T_1... : P, T_2... : P where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // ------2-----> ^
+  // CHECK: C
+  // CHECK: C
+  // U_2 -> {D, E, F, A, B, C}
+  // ------2-----> ^
+  // CHECK: F
+  // CHECK: F
+  apply %two_archetypes_from_two_params_no_singles_with_conformance<Pack{A, B, C}, Pack{D, E, F}>(%2) : $@convention(thin) <T_1... : P, T_2... : P where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // -------3-------> ^
+  // CHECK: D
+  // CHECK: D
+  // U_2 -> {D, E, F, A, B, C}
+  // -------3-------> ^
+  // CHECK: A
+  // CHECK: A
+  apply %two_archetypes_from_two_params_no_singles_with_conformance<Pack{A, B, C}, Pack{D, E, F}>(%3) : $@convention(thin) <T_1... : P, T_2... : P where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // ---------4--------> ^
+  // CHECK: E
+  // CHECK: E
+  // U_2 -> {D, E, F, A, B, C}
+  // ---------4--------> ^
+  // CHECK: B
+  // CHECK: B
+  apply %two_archetypes_from_two_params_no_singles_with_conformance<Pack{A, B, C}, Pack{D, E, F}>(%4) : $@convention(thin) <T_1... : P, T_2... : P where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // -----------5---------> ^
+  // CHECK: F
+  // CHECK: F
+  // U_2 -> {D, E, F, A, B, C}
+  // -----------5---------> ^
+  // CHECK: C
+  // CHECK: C
+  apply %two_archetypes_from_two_params_no_singles_with_conformance<Pack{A, B, C}, Pack{D, E, F}>(%5) : $@convention(thin) <T_1... : P, T_2... : P where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> ()
+
+  %direct_access_from_parameter = function_ref @direct_access_from_parameter : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // --0---> ^
+  // CHECK: A
+  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%0) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // ----1----> ^
+  // CHECK: B
+  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%1) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // -----2------> ^
+  // CHECK: C
+  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%2) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // -------3-------> ^
+  // CHECK: D
+  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%3) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // --------4---------> ^
+  // CHECK: E
+  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%4) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // U_1 -> {A, B, C, D, E, F}
+  // ----------5----------> ^
+  // CHECK: F
+  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%5) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
   %two_archetypes_from_two_params_no_singles = function_ref @two_archetypes_from_two_params_no_singles : $@convention(thin) <T_1..., T_2... where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> ()
   // U_1 -> {A, B, C, D, E, F}
   // ---0--> ^
@@ -80,31 +250,37 @@ bb0(%argc : $Int32, %argv : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<
   // CHECK: C
   apply %two_archetypes_from_two_params_no_singles<Pack{A, B, C}, Pack{D, E, F}>(%5) : $@convention(thin) <T_1..., T_2... where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> ()
 
-  %direct_access_from_parameter = function_ref @direct_access_from_parameter : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  %direct_access_from_parameter_with_conformance = function_ref @direct_access_from_parameter_with_conformance : $@convention(thin) <T_1...: P> (Builtin.Word) -> ()
   // U_1 -> {A, B, C, D, E, F}
   // --0---> ^
   // CHECK: A
-  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%0) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // CHECK: A
+  apply %direct_access_from_parameter_with_conformance<Pack{A, B, C, D, E, F}>(%0) : $@convention(thin) <T_1... : P> (Builtin.Word) -> ()
   // U_1 -> {A, B, C, D, E, F}
   // ----1----> ^
   // CHECK: B
-  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%1) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // CHECK: B
+  apply %direct_access_from_parameter_with_conformance<Pack{A, B, C, D, E, F}>(%1) : $@convention(thin) <T_1... : P> (Builtin.Word) -> ()
   // U_1 -> {A, B, C, D, E, F}
   // -----2------> ^
   // CHECK: C
-  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%2) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // CHECK: C
+  apply %direct_access_from_parameter_with_conformance<Pack{A, B, C, D, E, F}>(%2) : $@convention(thin) <T_1... : P> (Builtin.Word) -> ()
   // U_1 -> {A, B, C, D, E, F}
   // -------3-------> ^
   // CHECK: D
-  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%3) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // CHECK: D
+  apply %direct_access_from_parameter_with_conformance<Pack{A, B, C, D, E, F}>(%3) : $@convention(thin) <T_1... : P> (Builtin.Word) -> ()
   // U_1 -> {A, B, C, D, E, F}
   // --------4---------> ^
   // CHECK: E
-  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%4) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // CHECK: E
+  apply %direct_access_from_parameter_with_conformance<Pack{A, B, C, D, E, F}>(%4) : $@convention(thin) <T_1... : P> (Builtin.Word) -> ()
   // U_1 -> {A, B, C, D, E, F}
   // ----------5----------> ^
   // CHECK: F
-  apply %direct_access_from_parameter<Pack{A, B, C, D, E, F}>(%5) : $@convention(thin) <T_1...> (Builtin.Word) -> ()
+  // CHECK: F
+  apply %direct_access_from_parameter_with_conformance<Pack{A, B, C, D, E, F}>(%5) : $@convention(thin) <T_1... : P> (Builtin.Word) -> ()
 
   %outb = integer_literal $Builtin.Int32, 0
   %out = struct $Int32 (%outb : $Builtin.Int32)
@@ -126,6 +302,25 @@ entry(%intIndex : $Builtin.Word):
   return %retval : $()
 }
 
+sil @two_archetypes_from_two_params_no_singles_with_conformance : $<T_1... : P, T_2... : P where (repeat (each T_1, each T_2)): Any> (Builtin.Word) -> () {
+entry(%intIndex : $Builtin.Word):
+  %innerIndex = dynamic_pack_index %intIndex of $Pack{repeat each T_1, repeat each T_2}
+  %token = open_pack_element %innerIndex of <U_1... : P, U_2... : P where (repeat (each U_1, each U_2)): Any> at <Pack{repeat each T_1, repeat each T_2}, Pack{repeat each T_2, repeat each T_1}>, shape $U_2, uuid "01234567-89AB-CDEF-0123-000000000003"
+  %metatype_1 = metatype $@thick (@pack_element("01234567-89AB-CDEF-0123-000000000003") U_1).Type
+  %metatype_2 = metatype $@thick (@pack_element("01234567-89AB-CDEF-0123-000000000003") U_2).Type
+  %printGenericType = function_ref @printGenericType : $@convention(thin) <T> (@thick T.Type) -> ()
+  %static_member_fn_1 = witness_method $(@pack_element("01234567-89AB-CDEF-0123-000000000003") U_1), #P.static_member_fn : <Self where Self : P> (Self.Type) -> () -> () : $@convention(witness_method: P) <T where T : P> (@thick T.Type) -> ()
+  %static_member_fn_2 = witness_method $(@pack_element("01234567-89AB-CDEF-0123-000000000003") U_2), #P.static_member_fn : <Self where Self : P> (Self.Type) -> () -> () : $@convention(witness_method: P) <T where T : P> (@thick T.Type) -> ()
+  // Print the first archetype that is bound.
+  apply %printGenericType<(@pack_element("01234567-89AB-CDEF-0123-000000000003") U_1)>(%metatype_1) : $@convention(thin) <T> (@thick T.Type) -> ()
+  apply %static_member_fn_1<(@pack_element("01234567-89AB-CDEF-0123-000000000003") U_1)>(%metatype_1) : $@convention(witness_method: P) <T where T : P> (@thick T.Type) -> ()
+  // Print the second archetype that is bound.
+  apply %printGenericType<(@pack_element("01234567-89AB-CDEF-0123-000000000003") U_2)>(%metatype_2) : $@convention(thin) <T> (@thick T.Type) -> ()
+  apply %static_member_fn_2<(@pack_element("01234567-89AB-CDEF-0123-000000000003") U_2)>(%metatype_2) : $@convention(witness_method: P) <T where T : P> (@thick T.Type) -> ()
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // Verify that we just gep into a parameter pack when that's all that the pack consists of.
 // CHECK-LL: define {{.*}}void @direct_access_from_parameter(i{{(32|64)}} [[INDEX:%[^,]+]], i{{(32|64)}} {{%[^,]+}}, %swift.type** [[PACK:%[^,]+]])
 // CHECK-LL:   [[ELEMENT_ADDRESS:%[^,]+]] = getelementptr inbounds %swift.type*, %swift.type** [[PACK]], i{{(32|64)}} [[INDEX]]
@@ -138,6 +333,19 @@ entry(%intIndex : $Builtin.Word):
   %metatype_1 = metatype $@thick (@pack_element("01234567-89AB-CDEF-0123-000000000001") U_1).Type
   %printGenericType = function_ref @printGenericType : $@convention(thin) <T> (@thick T.Type) -> ()
   apply %printGenericType<(@pack_element("01234567-89AB-CDEF-0123-000000000001") U_1)>(%metatype_1) : $@convention(thin) <T> (@thick T.Type) -> ()
+  %t = tuple ()
+  return %t : $()
+}
+
+sil @direct_access_from_parameter_with_conformance : $<T_1... : P> (Builtin.Word) -> () {
+entry(%intIndex : $Builtin.Word):
+  %innerIndex = dynamic_pack_index %intIndex of $Pack{repeat each T_1}
+  %token = open_pack_element %innerIndex of <U_1... : P> at <Pack{repeat each T_1}>, shape $U_1, uuid "01234567-89AB-CDEF-0123-000000000002"
+  %metatype_1 = metatype $@thick (@pack_element("01234567-89AB-CDEF-0123-000000000002") U_1).Type
+  %printGenericType = function_ref @printGenericType : $@convention(thin) <T> (@thick T.Type) -> ()
+  apply %printGenericType<(@pack_element("01234567-89AB-CDEF-0123-000000000002") U_1)>(%metatype_1) : $@convention(thin) <T> (@thick T.Type) -> ()
+  %static_member_fn = witness_method $(@pack_element("01234567-89AB-CDEF-0123-000000000002") U_1), #P.static_member_fn : <Self where Self : P> (Self.Type) -> () -> () : $@convention(witness_method: P) <T where T : P> (@thick T.Type) -> ()
+  apply %static_member_fn<(@pack_element("01234567-89AB-CDEF-0123-000000000002") U_1)>(%metatype_1) : $@convention(witness_method: P) <T where T : P> (@thick T.Type) -> ()
   %t = tuple ()
   return %t : $()
 }

--- a/test/IRGen/variadic_generic_functions.sil
+++ b/test/IRGen/variadic_generic_functions.sil
@@ -1,0 +1,47 @@
+// RUN: %target-swift-frontend -parse-sil -emit-ir -primary-file %s -enable-experimental-feature VariadicGenerics | %FileCheck %s
+
+// Because of -enable-experimental-feature VariadicGenerics
+// REQUIRES: asserts
+
+import Builtin
+import Swift
+
+protocol P {}
+struct S : P {}
+sil_witness_table S : P module main {}
+struct S_2 : P {}
+sil_witness_table S_2 : P module main {}
+struct S_3 : P {}
+sil_witness_table S_3 : P module main {}
+
+// CHECK-LABEL: define {{.*}}void @c()
+// CHECK:       entry:
+// CHECK:         [[METADATA_PACK:%[^,]+]] = alloca [1 x %swift.type*]
+// CHECK:         [[WTABLE_PACK:%[^,]+]] = alloca [1 x i8**]
+// CHECK:         [[METADATA_ELEMENT_0:%[^,]+]] = getelementptr inbounds [1 x %swift.type*], [1 x %swift.type*]* [[METADATA_PACK]]
+// CHECK:         store %swift.type* bitcast {{.*}}$s26variadic_generic_functions3S_2VMf{{.*}}, %swift.type** [[METADATA_ELEMENT_0]]
+// CHECK:         [[WTABLE_ELEMENT_0:%[^,]+]] = getelementptr inbounds [1 x i8**], [1 x i8**]* [[WTABLE_PACK]]
+// CHECK:         store i8** getelementptr inbounds {{.*}}$s26variadic_generic_functions3S_2VAA1PAAWP{{.*}}, i8*** [[WTABLE_ELEMENT_0]]
+// CHECK:         [[METADATA_PACK_PTR:%[^,]+]] = bitcast [1 x %swift.type*]* [[METADATA_PACK]] to %swift.type**
+// CHECK:         [[WTABLE_PACK_ADDR:%[^,]+]] = bitcast [1 x i8**]* [[WTABLE_PACK]] to i8***
+// CHECK:         call swiftcc void @g(i64 1, %swift.type** [[METADATA_PACK_PTR]], i8*** [[WTABLE_PACK_ADDR]])
+sil @c : $() -> () {
+  %g = function_ref @g : $@convention(thin) <T... : P> () -> ()
+  apply %g<Pack{S_2}>() : $@convention(thin) <T... : P> () -> ()
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK: define {{.*}}void @f(i64 %0, %swift.type** %T, i8*** %T.P)
+sil @f : $<T... : P> () -> () {
+    %ret = tuple ()
+    return %ret : $()
+}
+
+// CHECK: define {{.*}}void @g(i64 %0, %swift.type** %T, i8*** %T.P)
+sil @g : $<T... : P> () -> () {
+    %f = function_ref @f : $@convention(thin) <T... : P> () -> ()
+    apply %f<Pack{repeat each T, S, repeat each T, repeat each T}>() : $@convention(thin) <T... : P> () -> ()
+    %ret = tuple ()
+    return %ret : $()
+}

--- a/test/IRGen/variadic_generic_functions.swift
+++ b/test/IRGen/variadic_generic_functions.swift
@@ -13,3 +13,9 @@ func f2<T..., U...>(t: repeat each T, u: repeat each U) {}
 
 // CHECK-LABEL: define hidden swiftcc void @"$s26variadic_generic_functions2f31t1uyxxQp_q_xQptq_Rhzr0_lF"(%swift.opaque** noalias nocapture %0, %swift.opaque** noalias nocapture %1, i64 %2, %swift.type** %T, %swift.type** %U)
 func f3<T..., U...>(t: repeat each T, u: repeat each U) where (repeat (each T, each U)): Any {}
+
+protocol P {}
+
+// CHECK-LABEL: define {{.*}}void @f4(%swift.opaque** noalias nocapture %0, i64 %1, %swift.type** %T, i8*** %T.P)
+@_silgen_name("f4")
+func f4<T... : P>(t: repeat each T) {}


### PR DESCRIPTION
Based on https://github.com/apple/swift/pull/63424 .

Call out to the infrastructure for emitting witness table packs to emit references to individual witness tables when binding opened archetypes during `open_pack_element`.

