### PR TITLE
[CSGen] Handle recursive use of variable declarations

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1354,6 +1354,13 @@ namespace {
     Type visitDeclRefExpr(DeclRefExpr *E) {
       auto locator = CS.getConstraintLocator(E);
 
+      auto invalidateReference = [&]() -> Type {
+        auto *hole = CS.createTypeVariable(locator, TVO_CanBindToHole);
+        (void)CS.recordFix(AllowRefToInvalidDecl::create(CS, locator));
+        CS.setType(E, hole);
+        return hole;
+      };
+
       Type knownType;
       if (auto *VD = dyn_cast<VarDecl>(E->getDecl())) {
         knownType = CS.getTypeIfAvailable(VD);
@@ -1361,13 +1368,19 @@ namespace {
           knownType = CS.getVarType(VD);
 
         if (knownType) {
+          // An out-of-scope type variable could be a type of a declaration
+          // only in diagnostic mode when invalid variable declaration is
+          // recursively referenced inside of a multi-statement closure
+          // located somewhere within its initializer e.g.:
+          // `let x = [<call>] { ... print(x) }`
+          if (auto *typeVar = knownType->getAs<TypeVariableType>()) {
+            if (!CS.isActiveTypeVariable(typeVar))
+              return invalidateReference();
+          }
+
           // If the known type has an error, bail out.
           if (knownType->hasError()) {
-            auto *hole = CS.createTypeVariable(locator, TVO_CanBindToHole);
-            (void)CS.recordFix(AllowRefToInvalidDecl::create(CS, locator));
-            if (!CS.hasType(E))
-              CS.setType(E, hole);
-            return hole;
+            return invalidateReference();
           }
 
           if (!knownType->hasPlaceholder()) {
@@ -1384,10 +1397,7 @@ namespace {
       // (in getTypeOfReference) so we can match non-error param types.
       if (!knownType && E->getDecl()->isInvalid() &&
           !CS.isForCodeCompletion()) {
-        auto *hole = CS.createTypeVariable(locator, TVO_CanBindToHole);
-        (void)CS.recordFix(AllowRefToInvalidDecl::create(CS, locator));
-        CS.setType(E, hole);
-        return hole;
+        return invalidateReference();
       }
 
       // Create an overload choice referencing this declaration and immediately

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -74,7 +74,7 @@ public:
     if (auto *DRE = dyn_cast<DeclRefExpr>(expr)) {
       auto *decl = DRE->getDecl();
 
-      if (auto type = CS.getTypeIfAvailable(DRE->getDecl())) {
+      if (auto type = CS.getTypeIfAvailable(decl)) {
         auto &ctx = CS.getASTContext();
         // If this is not one of the closure parameters which
         // is inferrable from the body, let's replace type

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -650,3 +650,16 @@ func test_that_closures_are_attempted_in_order() {
     return false
   }
 }
+
+// https://github.com/apple/swift/issues/63455
+func test_recursive_var_reference_in_multistatement_closure() {
+  func takeClosure(_ x: () -> Void) {}
+
+  func test(optionalInt: Int?) {
+    takeClosure {
+      let int = optionalInt { // expected-error {{cannot call value of non-function type 'Int?'}}
+        print(int)
+      }
+    }
+  }
+}

--- a/validation-test/IDE/crashers_2_fixed/issue-63455.swift
+++ b/validation-test/IDE/crashers_2_fixed/issue-63455.swift
@@ -1,0 +1,25 @@
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token COMPLETE
+
+func sheet(onDismiss: () -> Void) -> EmptyView {
+  fatalError()
+}
+
+@resultBuilder struct ViewBuilder2 {
+  static func buildBlock(_ content: EmptyView) -> EmptyView {
+    return content
+  }
+}
+
+struct EmptyView {}
+
+struct SettingsView {
+  var importedFile: Int?
+
+  @ViewBuilder2 var body2: EmptyView {
+    sheet {
+      #^COMPLETE^#if let url = self.importedFile {
+        print(url)
+      }
+    }
+  }
+}


### PR DESCRIPTION
It's possible for out-of-scope type variable to be the type of declaration
if such declaration is recursively referenced in the body of a closure located
in its initializer expression. In such cases type of the variable declaration 
cannot be connected to the closure because its not known in advance 
(determined by the initializer itself).

Resolves: https://github.com/apple/swift/issues/63455

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
