### PR TITLE
[AST] NFC: Move `VarDecl::getPointerAuthQualifier` implementation to …

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7125,6 +7125,15 @@ void VarDecl::emitLetToVarNoteIfSimple(DeclContext *UseDC) const {
   }
 }
 
+clang::PointerAuthQualifier VarDecl::getPointerAuthQualifier() const {
+  if (auto *clangDecl = getClangDecl()) {
+    if (auto *valueDecl = dyn_cast<clang::ValueDecl>(clangDecl)) {
+      return valueDecl->getType().getPointerAuth();
+    }
+  }
+  return clang::PointerAuthQualifier();
+}
+
 ParamDecl::ParamDecl(SourceLoc specifierLoc,
                      SourceLoc argumentNameLoc, Identifier argumentName,
                      SourceLoc parameterNameLoc, Identifier parameterName,

--- a/lib/AST/TypeWrapper.cpp
+++ b/lib/AST/TypeWrapper.cpp
@@ -44,12 +44,3 @@ bool VarDecl::isTypeWrapperLocalStorageForInitializer() const {
   }
   return false;
 }
-
-clang::PointerAuthQualifier VarDecl::getPointerAuthQualifier() const {
-  if (auto *clangDecl = getClangDecl()) {
-    if (auto *valueDecl = dyn_cast<clang::ValueDecl>(clangDecl)) {
-      return valueDecl->getType().getPointerAuth();
-    }
-  }
-  return clang::PointerAuthQualifier();
-}


### PR DESCRIPTION
…Decl.cpp

I'm not sure what this implementation ended up in `TypeWrapper.cpp` and I'm about
to revert the whole feature so the functionality is moved to `Decl.cpp` instead.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
