### PR TITLE
Demangle an OpaqueArchetypeTypeRef's ID as a type not as a symbol

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -653,6 +653,7 @@ Types
   type ::= assoc-type-name 'Qz'                      // shortcut for 'Qyz'
   type ::= assoc-type-list 'QY' GENERIC-PARAM-INDEX  // associated type at depth
   type ::= assoc-type-list 'QZ'                      // shortcut for 'QYz'
+  type ::= opaque-type-decl-name bound-generic-args 'Qo' INDEX // opaque type
   
   type ::= pattern-type count-type 'Qp'      // pack expansion type
   type ::= pack-element-list 'QP'            // pack type

--- a/stdlib/public/RemoteInspection/TypeRef.cpp
+++ b/stdlib/public/RemoteInspection/TypeRef.cpp
@@ -974,7 +974,7 @@ public:
   }
       
   Demangle::NodePointer visitOpaqueArchetypeTypeRef(const OpaqueArchetypeTypeRef *O) {
-    auto decl = Dem.demangleSymbol(O->getID());
+    auto decl = Dem.demangleType(O->getID());
     if (!decl)
       return nullptr;
     


### PR DESCRIPTION
(cherry picked from commit e2febeadaf48aedaa1f92e23308d399ab060c9f5)

rdar://104982758

[Cherry-pick of https://github.com/apple/swift/pull/61091
](https://github.com/apple/swift/pull/62043)

---

- Explanation:

Fix a bug which would crash the demangler when trying to process opaque types when used from remote mirrors.

For example, when debugging the following code in LLDB:

```swift
protocol P {}

struct S: P {}

struct A<T> {
  let t: T
}
let p: some P = S()
let a = A(t: p)
print(1) // Stop here, run "v a"
}
```
The demangler will crash when trying to demangle the type of `t` without this change

- Main Branch PR: https://github.com/apple/swift/pull/62043

- Resolves: rdar://104982758

- Risk: Low. This has been merged in the main branch since December 21st with no problems. Also, only LLDB or other remote mirrors users should exercise this code path. 

- Testing:  LLDB test case added in https://github.com/apple/llvm-project/pull/5848.