### PR TITLE
[benchmark] change a buffer length

### DIFF
--- a/benchmark/single-source/BufferFind.swift
+++ b/benchmark/single-source/BufferFind.swift
@@ -28,19 +28,19 @@ public var benchmarks: [BenchmarkInfo] = [
     setUpFunction: buffer1000Setup,
     tearDownFunction: bufferTeardown
   ),
-  // size 15, alignment 0
+  // size 39, alignment 0
   BenchmarkInfo(
-    name: "RawBuffer.15.findFirst",
+    name: "RawBuffer.39.findFirst",
     runFunction: run_BufferFindFirst,
     tags: [.validation, .api],
-    setUpFunction: buffer15Setup,
+    setUpFunction: buffer39Setup,
     tearDownFunction: bufferTeardown
   ),
   BenchmarkInfo(
-    name: "RawBuffer.15.findLast",
+    name: "RawBuffer.39.findLast",
     runFunction: run_BufferFindLast,
     tags: [.validation, .api],
-    setUpFunction: buffer15Setup,
+    setUpFunction: buffer39Setup,
     tearDownFunction: bufferTeardown
   ),
   // size 7, alignment 0
@@ -66,8 +66,8 @@ func buffer1000Setup() {
   bufferSetup(size: 1000, alignment: 0)
 }
 
-func buffer15Setup() {
-  bufferSetup(size: 15, alignment: 0)
+func buffer39Setup() {
+  bufferSetup(size: 39, alignment: 0)
 }
 
 func buffer7Setup() {


### PR DESCRIPTION
In the `BufferFind.swift` benchmark, the intermediate length (15 bytes) didn’t show results significantly different from those produced by the short length benchmark (7 bytes). Changing to 39 bytes.

In support of issue [63200](https://github.com/apple/swift/issues/63200).
