### PR TITLE
[5.8][CodeCompletion] Look through optional when determining the function type of a called overload

### DIFF
--- a/lib/IDE/ArgumentCompletion.cpp
+++ b/lib/IDE/ArgumentCompletion.cpp
@@ -37,7 +37,9 @@ bool ArgumentTypeCheckCompletionCallback::addPossibleParams(
   }
 
   ArrayRef<AnyFunctionType::Param> ParamsToPass =
-      Res.FuncTy->getAs<AnyFunctionType>()->getParams();
+      Res.FuncTy->lookThroughAllOptionalTypes()
+          ->getAs<AnyFunctionType>()
+          ->getParams();
 
   ParameterList *PL = nullptr;
   if (Res.FuncD) {

--- a/test/IDE/complete_optional_function.swift
+++ b/test/IDE/complete_optional_function.swift
@@ -1,0 +1,9 @@
+// RUN: %empty-directory(%t) 
+// RUN: %target-swift-ide-test -batch-code-completion -source-filename %s -filecheck %raw-FileCheck -completion-output-dir %t
+
+func foo(_ x: ((_ x: Int, _ y: Int) -> Void)?) {
+  x?(1, #^OPTIONAL_PARAMETER^#)
+  // OPTIONAL_PARAMETER: Begin completions
+  // OPTIONAL_PARAMETER-DAG: Literal[Integer]/None/TypeRelation[Convertible]: 0[#Int#]; name=0
+  // OPTIONAL_PARAMETER: End completions
+}


### PR DESCRIPTION
This is an even more minimal and low-risk version of https://github.com/apple/swift/pull/63515

rdar://97339983
