### PR TITLE
IRGen: Change to using frame-pointer=non-leaf for functions that request no framepointer

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1310,7 +1310,7 @@ bool swift::irgen::shouldRemoveTargetFeature(StringRef feature) {
 }
 
 void IRGenModule::setHasNoFramePointer(llvm::AttrBuilder &Attrs) {
-  Attrs.addAttribute("frame-pointer", "none");
+  Attrs.addAttribute("frame-pointer", "non-leaf");
 }
 
 void IRGenModule::setHasNoFramePointer(llvm::Function *F) {

--- a/test/IRGen/default_function_ir_attributes.swift
+++ b/test/IRGen/default_function_ir_attributes.swift
@@ -171,6 +171,6 @@ func test_computed_key_path_generic_thunks<T: P0 & Hashable>(value: T) -> KeyPat
 //   unlikely that handrolled code generation would think to add one.
 // CHECK: attributes [[ATTRS_SIMPLE]] = { [[CUSTOM_ATTRS:.*target-cpu.*]] }{{$}}
 // CHECK-DAG: attributes [[ATTRS_NOINLINE_NOUNWIND]] = { noinline nounwind {{.*target-cpu.*}} }
-// CHECK-DAG: attributes [[ATTRS_NOINLINE_READNONE_NOUNWIND_NOFRAME]] = { noinline nounwind readnone {{.*}}"frame-pointer"="none"{{.*target-cpu.*}} }
-// CHECK-DAG: attributes [[ATTRS_NOINLINE_READONLY_NOUNWIND_NOFRAME]] = { noinline nounwind readonly willreturn {{.*}}"frame-pointer"="none"{{.*target-cpu.*}} }
+// CHECK-DAG: attributes [[ATTRS_NOINLINE_READNONE_NOUNWIND_NOFRAME]] = { noinline nounwind readnone {{.*}}"frame-pointer"="non-leaf"{{.*target-cpu.*}} }
+// CHECK-DAG: attributes [[ATTRS_NOINLINE_READONLY_NOUNWIND_NOFRAME]] = { noinline nounwind readonly willreturn {{.*}}"frame-pointer"="non-leaf"{{.*target-cpu.*}} }
 // CHECK-DAG: attributes [[ATTRS_NOUNWIND]] = { nounwind [[CUSTOM_ATTRS]] }{{$}}


### PR DESCRIPTION
Using frame-pointer=none inhibits usage of compact unwind info.

rdar://98857255