### PR TITLE
[interop] NFC, test, drop libcxx-in-sdk requirement

### DIFF
--- a/test/Interop/Cxx/stdlib/print-libcxx-module-interface.swift
+++ b/test/Interop/Cxx/stdlib/print-libcxx-module-interface.swift
@@ -1,7 +1,6 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=CxxStdlib -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop -module-print-submodules | %FileCheck %s
 
 // REQUIRES: OS=macosx
-// REQUIRES: libcxx-in-sdk
 
 // CHECK: enum std {
 // CHECK-NEXT: enum __1 {

--- a/test/Interop/Cxx/symbolic-imports/print-libcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/print-libcxx-symbolic-module-interface.swift
@@ -2,7 +2,6 @@
 
 // REQUIRES: asserts
 // REQUIRES: OS=macosx
-// REQUIRES: libcxx-in-sdk
 
 // CHECK: enum std {
 // CHECK-NEXT: enum __1 {

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -12,11 +12,6 @@ clang_opt = clang_compile_opt
 is_cf_options_interop_updated = True
 
 if config.variant_sdk and config.variant_sdk != "":
-    # Check if libc++ is present in the SDK or not.
-    if config.target_sdk_libcxx_path and os.path.exists(config.target_sdk_libcxx_path):
-        config.available_features.add('libcxx-in-sdk')
-        config.substitutions.insert(0, ('%libcxx-in-sdk-path', config.target_sdk_libcxx_path))
-
     # Check if CF_OPTIONS macro has been updated to be imported into Swift in C++ mode correctly.
     cf_avail_path = os.path.join(config.variant_sdk, 'System', 'Library', 'Frameworks', 'CoreFoundation.framework', 'Versions', 'A', 'Headers', 'CFAvailability.h')
     cf_avail_path_embedded = os.path.join(config.variant_sdk, 'System', 'Library', 'Frameworks', 'CoreFoundation.framework', 'Headers', 'CFAvailability.h')


### PR DESCRIPTION
CI is running with SDKs that have libc++ already
