### PR TITLE
[move-only] Add support for switch_enum in borrow2destructure

### DIFF
--- a/include/swift/SIL/FieldSensitivePrunedLiveness.h
+++ b/include/swift/SIL/FieldSensitivePrunedLiveness.h
@@ -9,6 +9,13 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+///
+/// \file This is a field sensitive implementation of PrunedLiveness. It is a
+/// completely separate implementation for efficiency reasons but in spirit is
+/// implementing the exact same algorithms with changes to account for dealing
+/// with multiple elements.
+///
+//===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_SIL_FIELDSENSITIVEPRUNTEDLIVENESS_H
 #define SWIFT_SIL_FIELDSENSITIVEPRUNTEDLIVENESS_H
@@ -17,7 +24,10 @@
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/FrozenMultiMap.h"
 #include "swift/Basic/STLExtras.h"
-#include "swift/SIL/PrunedLiveness.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILValue.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/Support/raw_ostream.h"
@@ -375,6 +385,252 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
   return os;
 }
 
+/// Discover "pruned" liveness for an arbitrary set of uses. The client builds
+/// liveness by first initializing "def" blocks, then incrementally feeding uses
+/// to updateForUse().
+///
+/// Incrementally building liveness is important for algorithms that create an
+/// initial live region, perform some analysis on that, then expand the live
+/// region by adding new uses before continuing the analysis.
+///
+/// Initializing "def blocks" restricts liveness on any path through those def
+/// blocks to the blocks that occur on or after the def block. If any uses is
+/// not dominated by a def block, then liveness will include the entry block,
+/// as if defined by a function argument
+///
+/// We allow for multiple bits of liveness information to be tracked by
+/// internally using a SmallBitVector. The multiple bit tracking is useful when
+/// tracking state for multiple fields of the same root value. To do this, we
+/// actually track 2 bits per actual needed bit so we can represent 3 Dead,
+/// LiveOut, LiveWithin. This was previously unnecessary since we could just
+/// represent dead by not having liveness state for a block. With multiple bits
+/// possible this is no longer true.
+///
+/// TODO: For efficiency, use BasicBlockBitfield rather than SmallDenseMap.
+class FieldSensitivePrunedLiveBlocks {
+public:
+  /// Per-block liveness state computed during backward dataflow propagation.
+  /// All unvisited blocks are considered Dead. As the are visited, blocks
+  /// transition through these states in one direction:
+  ///
+  /// Dead -> LiveWithin -> LiveOut
+  ///
+  /// Dead blocks are either outside of the def's pruned liveness region, or
+  /// they have not yet been discovered by the liveness computation.
+  ///
+  /// LiveWithin blocks have at least one use and/or def within the block, but
+  /// are not (yet) LiveOut.
+  ///
+  /// LiveOut blocks are live on at least one successor path. LiveOut blocks may
+  /// or may not contain defs or uses.
+  ///
+  /// NOTE: The values below for Dead, LiveWithin, LiveOut were picked to ensure
+  /// that given a 2 bit representation of the value, a value is Dead if the
+  /// first bit is 0 and is LiveOut if the second bit is set.
+  enum IsLive {
+    Dead = 0,
+    LiveWithin = 1,
+    LiveOut = 3,
+  };
+
+  /// A bit vector that stores information about liveness. This is composed
+  /// with SmallBitVector since it contains two bits per liveness so that it
+  /// can represent 3 states, Dead, LiveWithin, LiveOut. We take advantage of
+  /// their numeric values to make testing easier \see documentation on IsLive.
+  class LivenessSmallBitVector {
+    SmallBitVector bits;
+
+  public:
+    LivenessSmallBitVector() : bits() {}
+
+    void init(unsigned numBits) {
+      assert(bits.size() == 0);
+      assert(numBits != 0);
+      bits.resize(numBits * 2);
+    }
+
+    unsigned size() const { return bits.size() / 2; }
+
+    IsLive getLiveness(unsigned bitNo) const {
+      if (!bits[bitNo * 2])
+        return IsLive::Dead;
+      return bits[bitNo * 2 + 1] ? LiveOut : LiveWithin;
+    }
+
+    /// Returns the liveness in \p resultingFoundLiveness. We only return the
+    /// bits for endBitNo - startBitNo.
+    void getLiveness(unsigned startBitNo, unsigned endBitNo,
+                     SmallVectorImpl<IsLive> &resultingFoundLiveness) const {
+      unsigned actualStartBitNo = startBitNo * 2;
+      unsigned actualEndBitNo = endBitNo * 2;
+
+      for (unsigned i = actualStartBitNo, e = actualEndBitNo; i != e; i += 2) {
+        if (!bits[i]) {
+          resultingFoundLiveness.push_back(Dead);
+          continue;
+        }
+
+        resultingFoundLiveness.push_back(bits[i + 1] ? LiveOut : LiveWithin);
+      }
+    }
+
+    void setLiveness(unsigned startBitNo, unsigned endBitNo, IsLive isLive) {
+      for (unsigned i = startBitNo * 2, e = endBitNo * 2; i != e; i += 2) {
+        bits[i] = isLive & 1;
+        bits[i + 1] = isLive & 2;
+      }
+    }
+
+    void setLiveness(unsigned bitNo, IsLive isLive) {
+      setLiveness(bitNo, bitNo + 1, isLive);
+    }
+  };
+
+private:
+  /// Map all blocks in which current def is live to a SmallBitVector indicating
+  /// whether the value represented by said bit is also liveout of the block.
+  llvm::SmallDenseMap<SILBasicBlock *, LivenessSmallBitVector, 4> liveBlocks;
+
+  /// Number of bits of liveness to track. By default 1. Used to track multiple
+  /// liveness bits.
+  unsigned numBitsToTrack;
+
+  /// Optional vector of live blocks for clients that deterministically iterate.
+  SmallVectorImpl<SILBasicBlock *> *discoveredBlocks;
+
+  /// Once the first use has been seen, no definitions can be added.
+  SWIFT_ASSERT_ONLY_DECL(bool seenUse = false);
+
+public:
+  FieldSensitivePrunedLiveBlocks(
+      unsigned numBitsToTrack,
+      SmallVectorImpl<SILBasicBlock *> *discoveredBlocks = nullptr)
+      : numBitsToTrack(numBitsToTrack), discoveredBlocks(discoveredBlocks) {
+    assert(!discoveredBlocks || discoveredBlocks->empty());
+  }
+
+  unsigned getNumBitsToTrack() const { return numBitsToTrack; }
+
+  bool empty() const { return liveBlocks.empty(); }
+
+  void clear() {
+    liveBlocks.clear();
+    SWIFT_ASSERT_ONLY(seenUse = false);
+  }
+
+  unsigned numLiveBlocks() const { return liveBlocks.size(); }
+
+  /// If the constructor was provided with a vector to populate, then this
+  /// returns the list of all live blocks with no duplicates.
+  ArrayRef<SILBasicBlock *> getDiscoveredBlocks() const {
+    return *discoveredBlocks;
+  }
+
+  void initializeDefBlock(SILBasicBlock *defBB, unsigned bitNo) {
+    markBlockLive(defBB, bitNo, LiveWithin);
+  }
+
+  void initializeDefBlock(SILBasicBlock *defBB, unsigned startBitNo,
+                          unsigned endBitNo) {
+    markBlockLive(defBB, startBitNo, endBitNo, LiveWithin);
+  }
+
+  /// Update this liveness result for a single use.
+  IsLive updateForUse(SILInstruction *user, unsigned bitNo) {
+    auto *block = user->getParent();
+    auto liveness = getBlockLiveness(block, bitNo);
+    if (liveness != Dead)
+      return liveness;
+    computeScalarUseBlockLiveness(block, bitNo);
+    return getBlockLiveness(block, bitNo);
+  }
+
+  /// Update this range of liveness results for a single use.
+  void updateForUse(SILInstruction *user, unsigned startBitNo,
+                    unsigned endBitNo,
+                    SmallVectorImpl<IsLive> &resultingLiveness);
+
+  IsLive getBlockLiveness(SILBasicBlock *bb, unsigned bitNo) const {
+    auto liveBlockIter = liveBlocks.find(bb);
+    if (liveBlockIter == liveBlocks.end()) {
+      return Dead;
+    }
+
+    return liveBlockIter->second.getLiveness(bitNo);
+  }
+
+  /// FIXME: This API should directly return the live bitset. The live bitset
+  /// type should have an api for querying and iterating over the live fields.
+  void getBlockLiveness(SILBasicBlock *bb, unsigned startBitNo,
+                        unsigned endBitNo,
+                        SmallVectorImpl<IsLive> &foundLivenessInfo) const {
+    auto liveBlockIter = liveBlocks.find(bb);
+    if (liveBlockIter == liveBlocks.end()) {
+      for (unsigned i : range(endBitNo - startBitNo)) {
+        (void)i;
+        foundLivenessInfo.push_back(Dead);
+      }
+      return;
+    }
+
+    liveBlockIter->second.getLiveness(startBitNo, endBitNo, foundLivenessInfo);
+  }
+
+  llvm::StringRef getStringRef(IsLive isLive) const;
+  void print(llvm::raw_ostream &OS) const;
+  void dump() const;
+
+protected:
+  void markBlockLive(SILBasicBlock *bb, unsigned bitNo, IsLive isLive) {
+    assert(isLive != Dead && "erasing live blocks isn't implemented.");
+    auto iterAndInserted =
+        liveBlocks.insert(std::make_pair(bb, LivenessSmallBitVector()));
+    if (iterAndInserted.second) {
+      // We initialize the size of the small bit vector here rather than in
+      // liveBlocks.insert above to prevent us from allocating upon failure if
+      // we have more than SmallBitVector's small size number of bits.
+      auto &insertedBV = iterAndInserted.first->getSecond();
+      insertedBV.init(numBitsToTrack);
+      insertedBV.setLiveness(bitNo, bitNo + 1, isLive);
+      if (discoveredBlocks)
+        discoveredBlocks->push_back(bb);
+    } else {
+      // If we are dead, always update to the new liveness.
+      switch (iterAndInserted.first->getSecond().getLiveness(bitNo)) {
+      case Dead:
+        iterAndInserted.first->getSecond().setLiveness(bitNo, bitNo + 1,
+                                                       isLive);
+        break;
+      case LiveWithin:
+        if (isLive == LiveOut) {
+          // Update the existing entry to be live-out.
+          iterAndInserted.first->getSecond().setLiveness(bitNo, bitNo + 1,
+                                                         LiveOut);
+        }
+        break;
+      case LiveOut:
+        break;
+      }
+    }
+  }
+
+  void markBlockLive(SILBasicBlock *bb, unsigned startBitNo, unsigned endBitNo,
+                     IsLive isLive) {
+    for (unsigned index : range(startBitNo, endBitNo)) {
+      markBlockLive(bb, index, isLive);
+    }
+  }
+
+private:
+  /// A helper routine that as a fast path handles the scalar case. We do not
+  /// handle the mult-bit case today since the way the code is written today
+  /// assumes we process a bit at a time.
+  ///
+  /// TODO: Make a multi-bit query for efficiency reasons.
+  void computeScalarUseBlockLiveness(SILBasicBlock *userBB,
+                                     unsigned startBitNo);
+};
+
 /// This is exactly like pruned liveness except that instead of tracking a
 /// single bit of liveness, it tracks multiple bits of liveness for leaf type
 /// tree nodes of an allocation one is calculating pruned liveness for.
@@ -383,7 +639,7 @@ inline llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 /// the type T being a child of T in the tree. We say recursively since the tree
 /// unfolds for F and its children as well.
 class FieldSensitivePrunedLiveness {
-  PrunedLiveBlocks liveBlocks;
+  FieldSensitivePrunedLiveBlocks liveBlocks;
 
 public:
   struct InterestingUser {
@@ -517,22 +773,22 @@ public:
   void updateForUse(SILInstruction *user, TypeTreeLeafTypeRange span,
                     bool lifetimeEnding);
 
-  void getBlockLiveness(
-      SILBasicBlock *bb, TypeTreeLeafTypeRange span,
-      SmallVectorImpl<PrunedLiveBlocks::IsLive> &resultingFoundLiveness) const {
+  void getBlockLiveness(SILBasicBlock *bb, TypeTreeLeafTypeRange span,
+                        SmallVectorImpl<FieldSensitivePrunedLiveBlocks::IsLive>
+                            &resultingFoundLiveness) const {
     liveBlocks.getBlockLiveness(bb, span.startEltOffset, span.endEltOffset,
                                 resultingFoundLiveness);
   }
 
   /// Return the liveness for this specific sub-element of our root value.
-  PrunedLiveBlocks::IsLive getBlockLiveness(SILBasicBlock *bb,
-                                            unsigned subElementNumber) const {
+  FieldSensitivePrunedLiveBlocks::IsLive
+  getBlockLiveness(SILBasicBlock *bb, unsigned subElementNumber) const {
     return liveBlocks.getBlockLiveness(bb, subElementNumber);
   }
 
-  void getBlockLiveness(
-      SILBasicBlock *bb,
-      SmallVectorImpl<PrunedLiveBlocks::IsLive> &foundLiveness) const {
+  void getBlockLiveness(SILBasicBlock *bb,
+                        SmallVectorImpl<FieldSensitivePrunedLiveBlocks::IsLive>
+                            &foundLiveness) const {
     liveBlocks.getBlockLiveness(bb, 0, liveBlocks.getNumBitsToTrack(),
                                 foundLiveness);
   }

--- a/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
+++ b/lib/SIL/Utils/FieldSensitivePrunedLiveness.cpp
@@ -485,6 +485,7 @@ void FieldSensitivePrunedLiveBlocks::computeScalarUseBlockLiveness(
 void FieldSensitivePrunedLiveBlocks::updateForUse(
     SILInstruction *user, unsigned startBitNo, unsigned endBitNo,
     SmallVectorImpl<IsLive> &resultingLivenessInfo) {
+  assert(isInitialized());
   resultingLivenessInfo.clear();
 
   SWIFT_ASSERT_ONLY(seenUse = true);

--- a/lib/SIL/Utils/PrunedLiveness.cpp
+++ b/lib/SIL/Utils/PrunedLiveness.cpp
@@ -16,8 +16,9 @@
 #include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/OwnershipUtils.h"
-#include "swift/SIL/ScopedAddressUtils.h"
 #include "swift/SIL/SILInstruction.h"
+#include "swift/SIL/SILValue.h"
+#include "swift/SIL/ScopedAddressUtils.h"
 
 using namespace swift;
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
@@ -1386,7 +1386,7 @@ bool GlobalLivenessChecker::testInstVectorLiveness(
     // If we didn't find a single block error, then we need to go search for our
     // liveness error in successor blocks. We know that this means that our
     // current block must be live out. Do a quick check just to be careful.
-    using IsLive = PrunedLiveBlocks::IsLive;
+    using IsLive = FieldSensitivePrunedLiveBlocks::IsLive;
     SmallVector<IsLive, 8> isLiveArray;
 #ifndef NDEBUG
     liveness.getBlockLiveness(errorUser->getParent(), errorSpan, isLiveArray);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
@@ -156,6 +156,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 
+#include "MoveOnlyBorrowToDestructure.h"
 #include "MoveOnlyDiagnostics.h"
 #include "MoveOnlyObjectChecker.h"
 
@@ -866,9 +867,15 @@ struct MoveOnlyChecker {
   /// Information about destroys that we use when inserting destroys.
   ConsumeInfo consumes;
 
+  /// Allocator used by the BorrowToDestructureTransform.
+  borrowtodestructure::IntervalMapAllocator allocator;
+
+  /// PostOrderAnalysis used by the BorrowToDestructureTransform.
+  PostOrderAnalysis *poa;
+
   MoveOnlyChecker(SILFunction *fn, DeadEndBlocks *deBlocks,
-                  DominanceInfo *domTree)
-      : fn(fn), deleter(), canonicalizer(), diagnosticEmitter() {
+                  DominanceInfo *domTree, PostOrderAnalysis *poa)
+      : fn(fn), deleter(), canonicalizer(), diagnosticEmitter(), poa(poa) {
     deleter.setCallbacks(std::move(
         InstModCallbacks().onDelete([&](SILInstruction *instToDelete) {
           if (auto *mvi = dyn_cast<MarkMustCheckInst>(instToDelete))
@@ -1120,6 +1127,31 @@ bool GatherUsesVisitor::visitUse(Operand *op, AccessUseType useTy) {
     if (li->getOwnershipQualifier() == LoadOwnershipQualifier::Copy ||
         li->getOwnershipQualifier() == LoadOwnershipQualifier::Take) {
       SWIFT_DEFER { moveChecker.canonicalizer.clear(); };
+
+      // Before we do anything, run the borrow to destructure transform in case
+      // we have a switch_enum user.
+      unsigned numDiagnostics =
+          moveChecker.diagnosticEmitter.getDiagnosticCount();
+      BorrowToDestructureTransform borrowToDestructure(
+          moveChecker.allocator, markedValue, li, moveChecker.diagnosticEmitter,
+          moveChecker.poa);
+      if (!borrowToDestructure.transform()) {
+        assert(moveChecker.diagnosticEmitter
+                   .didEmitCheckerDoesntUnderstandDiagnostic());
+        LLVM_DEBUG(llvm::dbgs()
+                   << "Failed to perform borrow to destructure transform!\n");
+        emittedEarlyDiagnostic = true;
+        return false;
+      }
+
+      // If we emitted an error diagnostic, do not transform further and instead
+      // mark that we emitted an early diagnostic and return true.
+      if (numDiagnostics !=
+          moveChecker.diagnosticEmitter.getDiagnosticCount()) {
+        LLVM_DEBUG(llvm::dbgs() << "Emitting borrow to destructure error!\n");
+        emittedEarlyDiagnostic = true;
+        return true;
+      }
 
       // Canonicalize the lifetime of the load [take], load [copy].
       moveChecker.changed |= moveChecker.canonicalizer.canonicalize(li);
@@ -1558,6 +1590,19 @@ void MoveOnlyChecker::cleanupAfterEmittingDiagnostic() {
           changed = true;
         }
       }
+
+      // Convert any copy_value of move_only type to explicit copy value.
+      if (auto *cvi = dyn_cast<CopyValueInst>(inst)) {
+        if (!cvi->getOperand()->getType().isMoveOnly())
+          continue;
+        SILBuilderWithScope b(cvi);
+        auto *expCopy =
+            b.createExplicitCopyValue(cvi->getLoc(), cvi->getOperand());
+        cvi->replaceAllUsesWith(expCopy);
+        cvi->eraseFromParent();
+        changed = true;
+        continue;
+      }
     }
   }
 }
@@ -1982,8 +2027,10 @@ class MoveOnlyCheckerPass : public SILFunctionTransform {
     auto *dominanceAnalysis = getAnalysis<DominanceAnalysis>();
     DominanceInfo *domTree = dominanceAnalysis->get(fn);
     auto *deAnalysis = getAnalysis<DeadEndBlocksAnalysis>()->get(fn);
+    auto *poa = getAnalysis<PostOrderAnalysis>();
 
-    if (MoveOnlyChecker(getFunction(), deAnalysis, domTree).checkFunction()) {
+    if (MoveOnlyChecker(getFunction(), deAnalysis, domTree, poa)
+            .checkFunction()) {
       invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
     }
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
@@ -48,48 +48,6 @@ public:
   }
 };
 
-// We reserve more bits that we need at the beginning so that we can avoid
-// reallocating and potentially breaking our internal mutable array ref
-// points into the data store.
-struct AvailableValues {
-  MutableArrayRef<SILValue> values;
-
-  SILValue operator[](unsigned index) const { return values[index]; }
-  SILValue &operator[](unsigned index) { return values[index]; }
-  unsigned size() const { return values.size(); }
-
-  AvailableValues() : values() {}
-  AvailableValues(MutableArrayRef<SILValue> values) : values(values) {}
-
-  void print(llvm::raw_ostream &os, const char *prefix = nullptr) const;
-  SWIFT_DEBUG_DUMP;
-};
-
-struct AvailableValueStore {
-  std::vector<SILValue> dataStore;
-  llvm::DenseMap<SILBasicBlock *, AvailableValues> blockToValues;
-  unsigned nextOffset = 0;
-  unsigned numBits;
-
-  AvailableValueStore(const FieldSensitivePrunedLiveness &liveness)
-      : dataStore(liveness.getDiscoveredBlocks().size() *
-                  liveness.getNumSubElements()),
-        numBits(liveness.getNumSubElements()) {}
-
-  std::pair<AvailableValues *, bool> get(SILBasicBlock *block) {
-    auto iter = blockToValues.try_emplace(block, AvailableValues());
-
-    if (!iter.second) {
-      return {&iter.first->second, false};
-    }
-
-    iter.first->second.values =
-        MutableArrayRef<SILValue>(&dataStore[nextOffset], numBits);
-    nextOffset += numBits;
-    return {&iter.first->second, true};
-  }
-};
-
 struct Implementation;
 
 } // namespace borrowtodestructure
@@ -98,8 +56,6 @@ class BorrowToDestructureTransform {
   friend borrowtodestructure::Implementation;
 
   using IntervalMapAllocator = borrowtodestructure::IntervalMapAllocator;
-  using AvailableValueStore = borrowtodestructure::AvailableValueStore;
-  using AvailableValues = borrowtodestructure::AvailableValues;
 
   IntervalMapAllocator &allocator;
   MarkMustCheckInst *mmci;
@@ -109,7 +65,6 @@ class BorrowToDestructureTransform {
   SmallVector<Operand *, 8> destructureNeedingUses;
   PostOrderAnalysis *poa;
   PostOrderFunctionInfo *pofi = nullptr;
-  Optional<AvailableValueStore> blockToAvailableValues;
   SILValue initialValue;
   SmallVector<SILInstruction *, 8> createdDestructures;
   SmallVector<SILPhiArgument *, 8> createdPhiArguments;

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
@@ -60,20 +60,10 @@ class BorrowToDestructureTransform {
   IntervalMapAllocator &allocator;
   MarkMustCheckInst *mmci;
   DiagnosticEmitter &diagnosticEmitter;
-  SmallVector<Operand *, 8> destructureNeedingUses;
   PostOrderAnalysis *poa;
   PostOrderFunctionInfo *pofi = nullptr;
   SmallVector<SILInstruction *, 8> createdDestructures;
   SmallVector<SILPhiArgument *, 8> createdPhiArguments;
-
-  using InterestingUser = FieldSensitivePrunedLiveness::InterestingUser;
-  SmallFrozenMultiMap<SILBasicBlock *, std::pair<Operand *, InterestingUser>, 8>
-      blocksToUses;
-
-  /// A frozen multi-map we use to diagnose consuming uses that are used by the
-  /// same instruction as another consuming use or non-consuming use.
-  SmallFrozenMultiMap<SILInstruction *, Operand *, 8>
-      instToInterestingOperandIndexMap;
 
 public:
   BorrowToDestructureTransform(IntervalMapAllocator &allocator,

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
@@ -146,13 +146,6 @@ private:
     return pofi;
   }
 
-  /// Visit all of the uses of \p mmci and find all begin_borrows.
-  ///
-  /// Returns false if we found an escape and thus cannot process. It is assumed
-  /// that the caller will fail in such a case.
-  static bool gatherBorrows(MarkMustCheckInst *mmci,
-                            StackList<BeginBorrowInst *> &borrowWorklist);
-
   /// Once we have gathered up all of our destructure uses and liveness
   /// requiring uses, validate that all of our destructure uses are on our
   /// boundary. Once we have done this, we know that it is safe to perform our

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
@@ -146,25 +146,9 @@ private:
     return pofi;
   }
 
-  /// Once we have gathered up all of our destructure uses and liveness
-  /// requiring uses, validate that all of our destructure uses are on our
-  /// boundary. Once we have done this, we know that it is safe to perform our
-  /// transform.
-  void checkDestructureUsesOnBoundary() const;
-
-  /// Check for cases where we have two consuming uses on the same instruction
-  /// or a consuming/non-consuming use on the same instruction.
-  void checkForErrorsOnSameInstruction();
-
-  /// Rewrite all of the uses of our borrow on our borrow operand, performing
-  /// destructures as appropriate.
-  void rewriteUses();
-
   /// After we have rewritten uses, cleanup the IR by deleting the original
   /// borrow/struct_extract/copies and inserting compensating destroy_values.
   void cleanup(StackList<BeginBorrowInst *> &borrowWorklist);
-
-  AvailableValues &computeAvailableValues(SILBasicBlock *block);
 };
 
 } // namespace siloptimizer

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
@@ -63,7 +63,6 @@ class BorrowToDestructureTransform {
   SmallVector<Operand *, 8> destructureNeedingUses;
   PostOrderAnalysis *poa;
   PostOrderFunctionInfo *pofi = nullptr;
-  SILValue initialValue;
   SmallVector<SILInstruction *, 8> createdDestructures;
   SmallVector<SILPhiArgument *, 8> createdPhiArguments;
 
@@ -92,10 +91,6 @@ private:
       pofi = poa->get(mmci->getFunction());
     return pofi;
   }
-
-  /// After we have rewritten uses, cleanup the IR by deleting the original
-  /// borrow/struct_extract/copies and inserting compensating destroy_values.
-  void cleanup(StackList<BeginBorrowInst *> &borrowWorklist);
 };
 
 } // namespace siloptimizer

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
@@ -90,9 +90,13 @@ struct AvailableValueStore {
   }
 };
 
+struct Implementation;
+
 } // namespace borrowtodestructure
 
 class BorrowToDestructureTransform {
+  friend borrowtodestructure::Implementation;
+
   using IntervalMapAllocator = borrowtodestructure::IntervalMapAllocator;
   using AvailableValueStore = borrowtodestructure::AvailableValueStore;
   using AvailableValues = borrowtodestructure::AvailableValues;
@@ -148,11 +152,6 @@ private:
   /// that the caller will fail in such a case.
   static bool gatherBorrows(MarkMustCheckInst *mmci,
                             StackList<BeginBorrowInst *> &borrowWorklist);
-
-  /// Walk through our borrow's uses recursively and find uses that require only
-  /// a subset of the bits of our type. These are uses that are consuming uses
-  /// that are destructure uses.
-  bool gatherUses(StackList<BeginBorrowInst *> &borrowWorklist);
 
   /// Once we have gathered up all of our destructure uses and liveness
   /// requiring uses, validate that all of our destructure uses are on our

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
@@ -59,6 +59,7 @@ class BorrowToDestructureTransform {
 
   IntervalMapAllocator &allocator;
   MarkMustCheckInst *mmci;
+  SILValue rootValue;
   DiagnosticEmitter &diagnosticEmitter;
   PostOrderAnalysis *poa;
   PostOrderFunctionInfo *pofi = nullptr;
@@ -67,11 +68,11 @@ class BorrowToDestructureTransform {
 
 public:
   BorrowToDestructureTransform(IntervalMapAllocator &allocator,
-                               MarkMustCheckInst *mmci,
+                               MarkMustCheckInst *mmci, SILValue rootValue,
                                DiagnosticEmitter &diagnosticEmitter,
                                PostOrderAnalysis *poa)
-      : allocator(allocator), mmci(mmci), diagnosticEmitter(diagnosticEmitter),
-        poa(poa) {}
+      : allocator(allocator), mmci(mmci), rootValue(rootValue),
+        diagnosticEmitter(diagnosticEmitter), poa(poa) {}
 
   bool transform();
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
@@ -60,8 +60,6 @@ class BorrowToDestructureTransform {
   IntervalMapAllocator &allocator;
   MarkMustCheckInst *mmci;
   DiagnosticEmitter &diagnosticEmitter;
-  // Temporarily optional as this code is refactored.
-  Optional<FieldSensitiveSSAPrunedLiveRange> liveness;
   SmallVector<Operand *, 8> destructureNeedingUses;
   PostOrderAnalysis *poa;
   PostOrderFunctionInfo *pofi = nullptr;
@@ -78,19 +76,13 @@ class BorrowToDestructureTransform {
   SmallFrozenMultiMap<SILInstruction *, Operand *, 8>
       instToInterestingOperandIndexMap;
 
-  SmallVector<SILBasicBlock *, 8> discoveredBlocks;
-
 public:
   BorrowToDestructureTransform(IntervalMapAllocator &allocator,
                                MarkMustCheckInst *mmci,
                                DiagnosticEmitter &diagnosticEmitter,
                                PostOrderAnalysis *poa)
       : allocator(allocator), mmci(mmci), diagnosticEmitter(diagnosticEmitter),
-        liveness(), poa(poa) {
-    liveness.emplace(mmci->getFunction(), &discoveredBlocks);
-    liveness->init(mmci);
-    liveness->initializeDef(mmci, TypeTreeLeafTypeRange(mmci));
-  }
+        poa(poa) {}
 
   bool transform();
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructure.h
@@ -1,0 +1,181 @@
+//===--- MoveOnlyBorrowToDestructure.h ------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SILOPTIMIZER_MANDATORY_MOVEONLYBORROWTODESTRUCTURE_H
+#define SWIFT_SILOPTIMIZER_MANDATORY_MOVEONLYBORROWTODESTRUCTURE_H
+
+#include "swift/Basic/FrozenMultiMap.h"
+#include "swift/SIL/FieldSensitivePrunedLiveness.h"
+#include "swift/SIL/StackList.h"
+#include "swift/SILOptimizer/Analysis/PostOrderAnalysis.h"
+
+#include "llvm/ADT/IntervalMap.h"
+
+namespace swift {
+namespace siloptimizer {
+
+class DiagnosticEmitter;
+
+namespace borrowtodestructure {
+
+class IntervalMapAllocator {
+public:
+  using Map = llvm::IntervalMap<
+      unsigned, SILValue,
+      llvm::IntervalMapImpl::NodeSizer<unsigned, SILValue>::LeafSize,
+      llvm::IntervalMapHalfOpenInfo<unsigned>>;
+
+  using Allocator = Map::Allocator;
+
+private:
+  /// Lazily initialized allocator.
+  Optional<Allocator> allocator;
+
+public:
+  Allocator &get() {
+    if (!allocator)
+      allocator.emplace();
+    return *allocator;
+  }
+};
+
+// We reserve more bits that we need at the beginning so that we can avoid
+// reallocating and potentially breaking our internal mutable array ref
+// points into the data store.
+struct AvailableValues {
+  MutableArrayRef<SILValue> values;
+
+  SILValue operator[](unsigned index) const { return values[index]; }
+  SILValue &operator[](unsigned index) { return values[index]; }
+  unsigned size() const { return values.size(); }
+
+  AvailableValues() : values() {}
+  AvailableValues(MutableArrayRef<SILValue> values) : values(values) {}
+
+  void print(llvm::raw_ostream &os, const char *prefix = nullptr) const;
+  SWIFT_DEBUG_DUMP;
+};
+
+struct AvailableValueStore {
+  std::vector<SILValue> dataStore;
+  llvm::DenseMap<SILBasicBlock *, AvailableValues> blockToValues;
+  unsigned nextOffset = 0;
+  unsigned numBits;
+
+  AvailableValueStore(const FieldSensitivePrunedLiveness &liveness)
+      : dataStore(liveness.getDiscoveredBlocks().size() *
+                  liveness.getNumSubElements()),
+        numBits(liveness.getNumSubElements()) {}
+
+  std::pair<AvailableValues *, bool> get(SILBasicBlock *block) {
+    auto iter = blockToValues.try_emplace(block, AvailableValues());
+
+    if (!iter.second) {
+      return {&iter.first->second, false};
+    }
+
+    iter.first->second.values =
+        MutableArrayRef<SILValue>(&dataStore[nextOffset], numBits);
+    nextOffset += numBits;
+    return {&iter.first->second, true};
+  }
+};
+
+} // namespace borrowtodestructure
+
+class BorrowToDestructureTransform {
+  using IntervalMapAllocator = borrowtodestructure::IntervalMapAllocator;
+  using AvailableValueStore = borrowtodestructure::AvailableValueStore;
+  using AvailableValues = borrowtodestructure::AvailableValues;
+
+  IntervalMapAllocator &allocator;
+  MarkMustCheckInst *mmci;
+  DiagnosticEmitter &diagnosticEmitter;
+  // Temporarily optional as this code is refactored.
+  Optional<FieldSensitiveSSAPrunedLiveRange> liveness;
+  SmallVector<Operand *, 8> destructureNeedingUses;
+  PostOrderAnalysis *poa;
+  PostOrderFunctionInfo *pofi = nullptr;
+  Optional<AvailableValueStore> blockToAvailableValues;
+  SILValue initialValue;
+  SmallVector<SILInstruction *, 8> createdDestructures;
+  SmallVector<SILPhiArgument *, 8> createdPhiArguments;
+
+  using InterestingUser = FieldSensitivePrunedLiveness::InterestingUser;
+  SmallFrozenMultiMap<SILBasicBlock *, std::pair<Operand *, InterestingUser>, 8>
+      blocksToUses;
+
+  /// A frozen multi-map we use to diagnose consuming uses that are used by the
+  /// same instruction as another consuming use or non-consuming use.
+  SmallFrozenMultiMap<SILInstruction *, Operand *, 8>
+      instToInterestingOperandIndexMap;
+
+  SmallVector<SILBasicBlock *, 8> discoveredBlocks;
+
+public:
+  BorrowToDestructureTransform(IntervalMapAllocator &allocator,
+                               MarkMustCheckInst *mmci,
+                               DiagnosticEmitter &diagnosticEmitter,
+                               PostOrderAnalysis *poa)
+      : allocator(allocator), mmci(mmci), diagnosticEmitter(diagnosticEmitter),
+        liveness(), poa(poa) {
+    liveness.emplace(mmci->getFunction(), &discoveredBlocks);
+    liveness->init(mmci);
+    liveness->initializeDef(mmci, TypeTreeLeafTypeRange(mmci));
+  }
+
+  bool transform();
+
+private:
+  PostOrderFunctionInfo *getPostOrderFunctionInfo() {
+    if (!pofi)
+      pofi = poa->get(mmci->getFunction());
+    return pofi;
+  }
+
+  /// Visit all of the uses of \p mmci and find all begin_borrows.
+  ///
+  /// Returns false if we found an escape and thus cannot process. It is assumed
+  /// that the caller will fail in such a case.
+  static bool gatherBorrows(MarkMustCheckInst *mmci,
+                            StackList<BeginBorrowInst *> &borrowWorklist);
+
+  /// Walk through our borrow's uses recursively and find uses that require only
+  /// a subset of the bits of our type. These are uses that are consuming uses
+  /// that are destructure uses.
+  bool gatherUses(StackList<BeginBorrowInst *> &borrowWorklist);
+
+  /// Once we have gathered up all of our destructure uses and liveness
+  /// requiring uses, validate that all of our destructure uses are on our
+  /// boundary. Once we have done this, we know that it is safe to perform our
+  /// transform.
+  void checkDestructureUsesOnBoundary() const;
+
+  /// Check for cases where we have two consuming uses on the same instruction
+  /// or a consuming/non-consuming use on the same instruction.
+  void checkForErrorsOnSameInstruction();
+
+  /// Rewrite all of the uses of our borrow on our borrow operand, performing
+  /// destructures as appropriate.
+  void rewriteUses();
+
+  /// After we have rewritten uses, cleanup the IR by deleting the original
+  /// borrow/struct_extract/copies and inserting compensating destroy_values.
+  void cleanup(StackList<BeginBorrowInst *> &borrowWorklist);
+
+  AvailableValues &computeAvailableValues(SILBasicBlock *block);
+};
+
+} // namespace siloptimizer
+} // namespace swift
+
+#endif

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransform.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransform.cpp
@@ -25,6 +25,7 @@
 
 #define DEBUG_TYPE "sil-move-only-checker"
 
+#include "MoveOnlyBorrowToDestructure.h"
 #include "MoveOnlyDiagnostics.h"
 #include "MoveOnlyObjectChecker.h"
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransform.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransform.cpp
@@ -45,10 +45,7 @@
 
 using namespace swift;
 using namespace swift::siloptimizer;
-
-namespace {
-using AvailableValues = BorrowToDestructureTransform::AvailableValues;
-}
+using namespace swift::siloptimizer::borrowtodestructure;
 
 //===----------------------------------------------------------------------===//
 //                              MARK: Utilities
@@ -1053,7 +1050,7 @@ BorrowToDestructureTransform::computeAvailableValues(SILBasicBlock *block) {
 
 #ifndef NDEBUG
 static LLVM_ATTRIBUTE_USED void
-dumpIntervalMap(BorrowToDestructureTransform::IntervalMapAllocator::Map &map) {
+dumpIntervalMap(IntervalMapAllocator::Map &map) {
   llvm::dbgs() << "Dumping Interval Map!\n";
   for (auto bi = map.begin(), be = map.end(); bi != be; ++bi) {
     llvm::dbgs() << "Entry. Start: " << bi.start() << " End: " << bi.stop()

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransform.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransform.cpp
@@ -213,10 +213,10 @@ struct borrowtodestructure::Implementation {
     initialValue = SILValue();
   }
 
-  void init(SILValue rootAddress) {
+  void init(SILValue rootValue) {
     clear();
-    liveness.init(rootAddress);
-    liveness.initializeDef(rootAddress, TypeTreeLeafTypeRange(rootAddress));
+    liveness.init(rootValue);
+    liveness.initializeDef(rootValue, TypeTreeLeafTypeRange(rootValue));
   }
 
   bool gatherUses(SILValue value);
@@ -233,7 +233,7 @@ struct borrowtodestructure::Implementation {
 
   /// Rewrite all of the uses of our borrow on our borrow operand, performing
   /// destructures as appropriate.
-  void rewriteUses();
+  void rewriteUses(InstructionDeleter *deleter = nullptr);
 
   void cleanup();
 
@@ -241,7 +241,7 @@ struct borrowtodestructure::Implementation {
 
   /// Returns mark_must_check if we are processing borrows or the enum argument
   /// if we are processing switch_enum.
-  SILValue getRootValue() const { return interface.mmci; }
+  SILValue getRootValue() const { return liveness.getRootValue(); }
 
   DiagnosticEmitter &getDiagnostics() const {
     return interface.diagnosticEmitter;
@@ -261,7 +261,7 @@ struct borrowtodestructure::Implementation {
 };
 
 bool Implementation::gatherUses(SILValue value) {
-  LLVM_DEBUG(llvm::dbgs() << "Gathering uses!\n");
+  LLVM_DEBUG(llvm::dbgs() << "Gathering uses for: " << *value);
   StackList<Operand *> useWorklist(value->getFunction());
 
   for (auto *use : value->getUses()) {
@@ -980,15 +980,8 @@ AvailableValues &Implementation::computeAvailableValues(SILBasicBlock *block) {
     // destructure.
     for (unsigned i : range(predAvailableValues.size())) {
       if (auto value = predAvailableValues[i]) {
-#if false
-        auto iterOffsetSize = TypeOffsetSizePair(value, mmci);
-        typeSpanToValue.insert(iterOffsetSize.startOffset,
-                               iterOffsetSize.getEndOffset(),
-                               value);
-#else
         // We check later that we store entire values.
         typeSpanToValue.insert(i, i + 1, value);
-#endif
       }
     }
 
@@ -1168,7 +1161,7 @@ dumpIntervalMap(IntervalMapAllocator::Map &map) {
 }
 #endif
 
-void Implementation::rewriteUses() {
+void Implementation::rewriteUses(InstructionDeleter *deleter) {
   blocksToUses.setFrozen();
 
   LLVM_DEBUG(llvm::dbgs()
@@ -1282,7 +1275,10 @@ void Implementation::rewriteUses() {
               first = builder.createOwnedMoveOnlyWrapperToCopyableValue(
                   getSafeLoc(inst), first);
             }
+            SILInstruction *oldInst = operand.get()->getDefiningInstruction();
             operand.set(first);
+            if (deleter)
+              deleter->forceTrackAsDead(oldInst);
             continue;
           }
 
@@ -1313,7 +1309,10 @@ void Implementation::rewriteUses() {
           // NOTE: This needs to be /after/the interior pointer operand usage
           // above so that we can use the end scope of our interior pointer base
           // value.
+          SILInstruction *oldInst = operand.get()->getDefiningInstruction();
           operand.set(innerValue);
+          if (deleter)
+            deleter->forceTrackAsDead(oldInst);
           continue;
         }
 
@@ -1371,7 +1370,10 @@ void Implementation::rewriteUses() {
                 borrowBuilder.createGuaranteedMoveOnlyWrapperToCopyableValue(
                     loc, value);
           }
+          auto *oldInst = operand.get()->getDefiningInstruction();
           operand.set(value);
+          if (deleter)
+            deleter->forceTrackAsDead(oldInst);
 
           // If we have a terminator that is a trivial use (e.x.: we
           // struct_extract a trivial value). Just put the end_borrow before the
@@ -1441,7 +1443,10 @@ void Implementation::rewriteUses() {
           iterValue = consumeBuilder.createOwnedMoveOnlyWrapperToCopyableValue(
               loc, iterValue);
         }
+        auto *oldInst = operand.get()->getDefiningInstruction();
         operand.set(iterValue);
+        if (deleter)
+          deleter->forceTrackAsDead(oldInst);
 
         // Then go through our available values and use the interval map to
         // update them with the destructured values if we have one for it.
@@ -1594,10 +1599,131 @@ static bool gatherBorrows(MarkMustCheckInst *mmci,
 }
 
 //===----------------------------------------------------------------------===//
+//                          MARK: Switch Enum Search
+//===----------------------------------------------------------------------===//
+
+static bool
+gatherSwitchEnum(SILValue value,
+                 SmallVectorImpl<SwitchEnumInst *> &switchEnumWorklist) {
+  LLVM_DEBUG(llvm::dbgs() << "Gathering switch enums for value: " << *value);
+
+  auto *fn = value->getFunction();
+  StackList<Operand *> useWorklist(fn);
+  for (auto *use : value->getUses()) {
+    useWorklist.push_back(use);
+  }
+
+  // Grab the start of our switch enum worklist, so that after we visit the
+  // switch_enums that are users of this value, we can recursively visit those
+  // values.
+  unsigned start = switchEnumWorklist.size();
+
+  while (!useWorklist.empty()) {
+    auto *nextUse = useWorklist.pop_back_val();
+    LLVM_DEBUG(llvm::dbgs() << "    NextUse: " << *nextUse->getUser());
+    switch (nextUse->getOperandOwnership()) {
+    case OperandOwnership::NonUse:
+      continue;
+
+    // Conservatively treat a conversion to an unowned value as a pointer
+    // escape. If we see this in the SIL, fail and return false so we emit a
+    // "compiler doesn't understand error".
+    case OperandOwnership::ForwardingUnowned:
+    case OperandOwnership::PointerEscape:
+      LLVM_DEBUG(llvm::dbgs()
+                 << "        Found forwarding unowned or pointer escape!\n");
+      return false;
+
+    // These might be uses that we need to perform a destructure or insert
+    // struct_extracts for.
+    case OperandOwnership::TrivialUse:
+    case OperandOwnership::InstantaneousUse:
+    case OperandOwnership::UnownedInstantaneousUse:
+    case OperandOwnership::InteriorPointer:
+    case OperandOwnership::BitwiseEscape: {
+      // Look through copy_value of a move only value. We treat copy_value of
+      // copyable values as normal uses.
+      if (auto *cvi = dyn_cast<CopyValueInst>(nextUse->getUser())) {
+        if (cvi->getOperand()->getType().isMoveOnly()) {
+          LLVM_DEBUG(llvm::dbgs() << "        Found copy value of move only "
+                                     "field... looking through!\n");
+          for (auto *use : cvi->getUses())
+            useWorklist.push_back(use);
+          continue;
+        }
+
+        // If we don't have a copy of a move only type, we just treat this as a
+        // normal use, so we just continue.
+      }
+      continue;
+    }
+
+    case OperandOwnership::ForwardingConsume:
+    case OperandOwnership::DestroyingConsume:
+      // We don't care about forwarding consumes or destroying consumes.
+      continue;
+
+    case OperandOwnership::GuaranteedForwarding:
+      // Look through guaranteed forwarding unless we have a switch enum. If we
+      // have a switch enum, we add it to the list.
+      if (auto *switchEnum = dyn_cast<SwitchEnumInst>(nextUse->getUser())) {
+        LLVM_DEBUG(llvm::dbgs()
+                   << "        Found switch enum: " << *nextUse->getUser());
+        switchEnumWorklist.push_back(switchEnum);
+        continue;
+      }
+
+      ForwardingOperand(nextUse).visitForwardedValues([&](SILValue value) {
+        for (auto *use : value->getUses()) {
+          useWorklist.push_back(use);
+        }
+        return true;
+      });
+      continue;
+
+    case OperandOwnership::Borrow:
+      LLVM_DEBUG(llvm::dbgs() << "        Found recursive borrow!\n");
+      // Look through borrows.
+      for (auto value : nextUse->getUser()->getResults()) {
+        for (auto *use : value->getUses()) {
+          useWorklist.push_back(use);
+        }
+      }
+      continue;
+    case OperandOwnership::EndBorrow:
+      LLVM_DEBUG(llvm::dbgs() << "        Found end borrow!\n");
+      continue;
+    case OperandOwnership::Reborrow:
+      llvm_unreachable("Unsupported for now?!");
+    }
+  }
+
+  unsigned end = switchEnumWorklist.size();
+  if (start == end)
+    return true;
+
+  for (unsigned i : range(start, end)) {
+    auto *s = switchEnumWorklist[i];
+    for (auto argList : s->getSuccessorBlockArgumentLists()) {
+      for (SILValue value : argList) {
+        if (value->getType().isTrivial(*fn))
+          continue;
+
+        if (!gatherSwitchEnum(value, switchEnumWorklist))
+          return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
 //                        MARK: Top Level Entrypoint
 //===----------------------------------------------------------------------===//
 
 bool BorrowToDestructureTransform::transform() {
+  auto *fn = mmci->getFunction();
   StackList<BeginBorrowInst *> borrowWorklist(mmci->getFunction());
 
   // If we failed to gather borrows due to the transform not understanding part
@@ -1610,8 +1736,136 @@ bool BorrowToDestructureTransform::transform() {
   if (borrowWorklist.empty())
     return true;
 
-  // Attempt to gather uses. Return false if we saw something that we did not
-  // understand.
+  // Then go through our borrows and attempt to gather up guaranteed
+  // switch_enums. If we see any of them, we need to transform them into owned
+  // switch_enums.
+  SmallVector<SwitchEnumInst *, 8> switchEnumWorklist;
+  for (auto *borrow : borrowWorklist) {
+    // Attempt to gather the switch enums and if we fail, return false.
+    if (!gatherSwitchEnum(borrow, switchEnumWorklist))
+      return false;
+  }
+
+  // Now perform the checking of our switch_enum, working in stack order.
+  {
+    SmallVector<CopyValueInst *, 8> switchEnumArgCopyValueToDelete;
+    InstructionDeleter deleter;
+    while (!switchEnumWorklist.empty()) {
+      auto *s = switchEnumWorklist.pop_back_val();
+      for (auto argList : s->getSuccessorBlockArgumentLists()) {
+        for (SILValue arg : argList) {
+          // Skip trivial or copyable values. If we have a copyable value, we
+          // will handle it as part of the cleanup phase at the end when we
+          // convert the actual switch_enum to be an owned switch_enum.
+          if (arg->getType().isTrivial(*fn) || !arg->getType().isMoveOnly())
+            continue;
+
+          SmallVector<SILBasicBlock *, 8> discoveredBlocks;
+          Implementation impl(*this, discoveredBlocks);
+          impl.init(arg);
+          if (!impl.gatherUses(arg)) {
+            diagnosticEmitter.emitCheckerDoesntUnderstandDiagnostic(mmci);
+            continue;
+          }
+
+          // Next make sure that any destructure needing instructions are on the
+          // boundary in a per bit field sensitive manner.
+          unsigned diagnosticCount = diagnosticEmitter.getDiagnosticCount();
+          impl.checkDestructureUsesOnBoundary();
+
+          // If we emitted any diagnostic, break out. We return true since we
+          // actually succeeded in our processing by finding the error. We only
+          // return false if we want to tell the rest of the checker that there
+          // was an internal compiler error that we need to emit a "compiler
+          // doesn't understand error".
+          if (diagnosticCount != diagnosticEmitter.getDiagnosticCount())
+            return true;
+
+          // Then check if we had two consuming uses on the same instruction or
+          // a consuming/non-consuming use on the same isntruction.
+          impl.checkForErrorsOnSameInstruction();
+
+          // If we emitted any diagnostic, break out. We return true since we
+          // actually succeeded in our processing by finding the error. We only
+          // return false if we want to tell the rest of the checker that there
+          // was an internal compiler error that we need to emit a "compiler
+          // doesn't understand error".
+          if (diagnosticCount != diagnosticEmitter.getDiagnosticCount())
+            return true;
+
+          // At this point, we know that all of our destructure requiring uses
+          // are on the boundary of our live range. Now we need to do the
+          // rewriting.
+          impl.blockToAvailableValues.emplace(impl.liveness);
+          impl.rewriteUses(&deleter);
+
+          // Now that we have done our rewritting, we need to do a few cleanups
+          // starting by inserting compensating destroys for all of our inserted
+          // phis/destructures/initial value copy.
+          impl.cleanup();
+
+          // Now grab our initialValue which will be a copy_value from our
+          // argument and RAUW it. We are going to convert the argument
+          // later. We left it in to ensure that as we recreated instructions,
+          // OSSA invariants were satisfied locally (albeit the actual IR was
+          // not in a consistent state).
+          auto *cvi = cast<CopyValueInst>(impl.initialValue);
+          switchEnumArgCopyValueToDelete.push_back(cvi);
+        }
+      }
+
+      // Now that we have processed all of the arguments for this switch_enum,
+      // cleanup any dead instructions.
+      deleter.cleanupDeadInstructions();
+
+      // Now that we have processed the switch_enum, we need to convert the
+      // switch_enum to be owned. We do this by introducing a copy on the
+      // switch_enum argument and then insert a destroy_value after the single
+      // copy_value in each destination block that we originally inserted.
+      {
+        SmallVector<SILBasicBlock *, 8> discoveredBlocks;
+        SSAPrunedLiveness liveness(&discoveredBlocks);
+        PrunedLivenessBoundary boundary;
+
+        SILBuilderWithScope builder(s);
+        SILValue newOperand =
+            builder.createCopyValue(getSafeLoc(s), s->getOperand());
+        s->setOperand(0, newOperand);
+        s->setForwardingOwnershipKind(OwnershipKind::Owned);
+        for (auto argList : s->getSuccessorBlockArgumentLists()) {
+          for (SILArgument *arg : argList) {
+            if (arg->getType().isTrivial(*fn))
+              continue;
+            arg->setOwnershipKind(OwnershipKind::Owned);
+
+            if (arg->getType().isMoveOnly())
+              continue;
+
+            // If we have a copyable type, we need to insert compensating
+            // destroys.
+            SWIFT_DEFER {
+              liveness.clear();
+              discoveredBlocks.clear();
+              boundary.clear();
+            };
+            addCompensatingDestroys(liveness, boundary, arg);
+          }
+        }
+      }
+
+      // Now eliminate our unneeded copyvalues from earlier than we inserted to
+      // satisfy OSSA invariants.
+      while (!switchEnumArgCopyValueToDelete.empty()) {
+        auto *cvi = switchEnumArgCopyValueToDelete.pop_back_val();
+        cvi->replaceAllUsesWith(cvi->getOperand());
+        cvi->eraseFromParent();
+      }
+    }
+  }
+
+  // Now that we have handled our switch_enum we need to handle our
+  // borrows... begin by gathering uses. Return false if we saw something that
+  // we did not understand.
   SmallVector<SILBasicBlock *, 8> discoveredBlocks;
   Implementation impl(*this, discoveredBlocks);
   impl.init(mmci);
@@ -1657,10 +1911,12 @@ bool BorrowToDestructureTransform::transform() {
 
   // Then clean up all of our borrows/copies/struct_extracts which no longer
   // have any uses...
-  InstructionDeleter deleter;
-  while (!borrowWorklist.empty()) {
-    deleter.recursivelyForceDeleteUsersAndFixLifetimes(
-        borrowWorklist.pop_back_val());
+  {
+    InstructionDeleter deleter;
+    while (!borrowWorklist.empty()) {
+      deleter.recursivelyForceDeleteUsersAndFixLifetimes(
+          borrowWorklist.pop_back_val());
+    }
   }
 
   return true;

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransformTester.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransformTester.cpp
@@ -38,6 +38,7 @@
 
 using namespace swift;
 using namespace swift::siloptimizer;
+using namespace swift::siloptimizer::borrowtodestructure;
 
 //===----------------------------------------------------------------------===//
 //                            Top Level Entrypoint
@@ -47,7 +48,7 @@ static bool runTransform(SILFunction *fn,
                          ArrayRef<MarkMustCheckInst *> moveIntroducersToProcess,
                          PostOrderAnalysis *poa,
                          DiagnosticEmitter &diagnosticEmitter) {
-  BorrowToDestructureTransform::IntervalMapAllocator allocator;
+  IntervalMapAllocator allocator;
   bool madeChange = false;
   while (!moveIntroducersToProcess.empty()) {
     auto *mmci = moveIntroducersToProcess.back();

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransformTester.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransformTester.cpp
@@ -55,8 +55,8 @@ static bool runTransform(SILFunction *fn,
     auto *mmci = moveIntroducersToProcess.back();
     moveIntroducersToProcess = moveIntroducersToProcess.drop_back();
 
-    BorrowToDestructureTransform transform(allocator, mmci, diagnosticEmitter,
-                                           poa);
+    BorrowToDestructureTransform transform(allocator, mmci, mmci,
+                                           diagnosticEmitter, poa);
     transform.transform();
     madeChange = true;
   }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransformTester.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransformTester.cpp
@@ -20,6 +20,7 @@
 
 #define DEBUG_TYPE "sil-move-only-checker"
 
+#include "MoveOnlyBorrowToDestructure.h"
 #include "MoveOnlyDiagnostics.h"
 #include "MoveOnlyObjectChecker.h"
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -102,6 +102,7 @@ void DiagnosticEmitter::emitCheckerDoesntUnderstandDiagnostic(
              diag::sil_moveonlychecker_not_understand_moveonly);
   }
   registerDiagnosticEmitted(markedValue);
+  emittedCheckerDoesntUnderstandDiagnostic = true;
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -50,6 +50,8 @@ class DiagnosticEmitter {
   /// diagnosics while running a callee.
   unsigned diagnosticCount = 0;
 
+  bool emittedCheckerDoesntUnderstandDiagnostic = false;
+
 public:
   void init(SILFunction *inputFn, OSSACanonicalizer *inputCanonicalizer) {
     fn = inputFn;
@@ -65,6 +67,9 @@ public:
   }
 
   unsigned getDiagnosticCount() const { return diagnosticCount; }
+  bool didEmitCheckerDoesntUnderstandDiagnostic() const {
+    return emittedCheckerDoesntUnderstandDiagnostic;
+  }
 
   void emitCheckerDoesntUnderstandDiagnostic(MarkMustCheckInst *markedValue);
   void emitObjectGuaranteedDiagnostic(MarkMustCheckInst *markedValue);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
@@ -57,6 +57,7 @@
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/RecyclingAllocator.h"
 
+#include "MoveOnlyBorrowToDestructure.h"
 #include "MoveOnlyDiagnostics.h"
 #include "MoveOnlyObjectChecker.h"
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
@@ -390,7 +390,7 @@ struct MoveOnlyChecker {
   /// A set of mark_must_check that we are actually going to process.
   SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
 
-  BorrowToDestructureTransform::IntervalMapAllocator allocator;
+  borrowtodestructure::IntervalMapAllocator allocator;
 
   MoveOnlyChecker(SILFunction *fn, DeadEndBlocks *deBlocks) : fn(fn) {}
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
@@ -423,8 +423,8 @@ struct MoveOnlyChecker {
 bool MoveOnlyChecker::convertBorrowExtractsToOwnedDestructures(
     MarkMustCheckInst *mmci, DiagnosticEmitter &diagnosticEmitter,
     DominanceInfo *domTree, PostOrderAnalysis *poa) {
-  BorrowToDestructureTransform transform(allocator, mmci, diagnosticEmitter,
-                                         poa);
+  BorrowToDestructureTransform transform(allocator, mmci, mmci,
+                                         diagnosticEmitter, poa);
   if (!transform.transform()) {
     LLVM_DEBUG(llvm::dbgs()
                << "Failed to perform borrow to destructure transform!\n");

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
@@ -806,20 +806,6 @@ class MoveOnlyCheckerPass : public SILFunctionTransform {
     if (checker.changed) {
       invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
     }
-
-    if (getOptions().VerifyAll) {
-      for (auto &block : *getFunction()) {
-        for (auto &inst : block) {
-          if (auto *cvi = dyn_cast<CopyValueInst>(&inst)) {
-            if (cvi->getOperand()->getType().isMoveOnly()) {
-              llvm::errs() << "Should have eliminated copy at this point: "
-                           << *cvi;
-              llvm::report_fatal_error("standard compiler error");
-            }
-          }
-        }
-      }
-    }
   }
 };
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
@@ -806,6 +806,9 @@ class MoveOnlyCheckerPass : public SILFunctionTransform {
     if (checker.changed) {
       invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
     }
+
+    // NOTE: We validate in the MoveOnlyAddressChecker (which runs after this)
+    // that we eliminated all copy_value and emit errors otherwise.
   }
 };
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.h
@@ -20,16 +20,13 @@
 #ifndef SWIFT_SILOPTIMIZER_MANDATORY_MOVEONLYOBJECTCHECKER_H
 #define SWIFT_SILOPTIMIZER_MANDATORY_MOVEONLYOBJECTCHECKER_H
 
-#include "swift/Basic/FrozenMultiMap.h"
-#include "swift/SIL/FieldSensitivePrunedLiveness.h"
-#include "swift/SIL/PrunedLiveness.h"
-#include "swift/SIL/SILInstruction.h"
 #include "swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h"
-#include "llvm/ADT/IntervalMap.h"
 #include "llvm/Support/Compiler.h"
 
 namespace swift {
 namespace siloptimizer {
+
+class DiagnosticEmitter;
 
 /// Wrapper around CanonicalizeOSSALifetime that we use to specialize its
 /// interface for our purposes.
@@ -114,158 +111,6 @@ struct OSSACanonicalizer {
              return !isa<PartialApplyInst>(user);
            });
   }
-};
-
-class DiagnosticEmitter;
-
-namespace borrowtodestructure {
-
-class IntervalMapAllocator {
-public:
-  using Map = llvm::IntervalMap<
-      unsigned, SILValue,
-      llvm::IntervalMapImpl::NodeSizer<unsigned, SILValue>::LeafSize,
-      llvm::IntervalMapHalfOpenInfo<unsigned>>;
-
-  using Allocator = Map::Allocator;
-
-private:
-  /// Lazily initialized allocator.
-  Optional<Allocator> allocator;
-
-public:
-  Allocator &get() {
-    if (!allocator)
-      allocator.emplace();
-    return *allocator;
-  }
-};
-
-// We reserve more bits that we need at the beginning so that we can avoid
-// reallocating and potentially breaking our internal mutable array ref
-// points into the data store.
-struct AvailableValues {
-  MutableArrayRef<SILValue> values;
-
-  SILValue operator[](unsigned index) const { return values[index]; }
-  SILValue &operator[](unsigned index) { return values[index]; }
-  unsigned size() const { return values.size(); }
-
-  AvailableValues() : values() {}
-  AvailableValues(MutableArrayRef<SILValue> values) : values(values) {}
-
-  void print(llvm::raw_ostream &os, const char *prefix = nullptr) const;
-  SWIFT_DEBUG_DUMP;
-};
-
-struct AvailableValueStore {
-  std::vector<SILValue> dataStore;
-  llvm::DenseMap<SILBasicBlock *, AvailableValues> blockToValues;
-  unsigned nextOffset = 0;
-  unsigned numBits;
-
-  AvailableValueStore(const FieldSensitivePrunedLiveness &liveness)
-      : dataStore(liveness.getDiscoveredBlocks().size() *
-                  liveness.getNumSubElements()),
-        numBits(liveness.getNumSubElements()) {}
-
-  std::pair<AvailableValues *, bool> get(SILBasicBlock *block) {
-    auto iter = blockToValues.try_emplace(block, AvailableValues());
-
-    if (!iter.second) {
-      return {&iter.first->second, false};
-    }
-
-    iter.first->second.values =
-        MutableArrayRef<SILValue>(&dataStore[nextOffset], numBits);
-    nextOffset += numBits;
-    return {&iter.first->second, true};
-  }
-};
-
-} // namespace borrowtodestructure
-
-class BorrowToDestructureTransform {
-  using IntervalMapAllocator = borrowtodestructure::IntervalMapAllocator;
-  using AvailableValueStore = borrowtodestructure::AvailableValueStore;
-  using AvailableValues = borrowtodestructure::AvailableValues;
-
-  IntervalMapAllocator &allocator;
-  MarkMustCheckInst *mmci;
-  DiagnosticEmitter &diagnosticEmitter;
-  // Temporarily optional as this code is refactored.
-  Optional<FieldSensitiveSSAPrunedLiveRange> liveness;
-  SmallVector<Operand *, 8> destructureNeedingUses;
-  PostOrderAnalysis *poa;
-  PostOrderFunctionInfo *pofi = nullptr;
-  Optional<AvailableValueStore> blockToAvailableValues;
-  SILValue initialValue;
-  SmallVector<SILInstruction *, 8> createdDestructures;
-  SmallVector<SILPhiArgument *, 8> createdPhiArguments;
-
-  using InterestingUser = FieldSensitivePrunedLiveness::InterestingUser;
-  SmallFrozenMultiMap<SILBasicBlock *, std::pair<Operand *, InterestingUser>, 8>
-      blocksToUses;
-
-  /// A frozen multi-map we use to diagnose consuming uses that are used by the
-  /// same instruction as another consuming use or non-consuming use.
-  SmallFrozenMultiMap<SILInstruction *, Operand *, 8>
-      instToInterestingOperandIndexMap;
-
-  SmallVector<SILBasicBlock *, 8> discoveredBlocks;
-
-public:
-  BorrowToDestructureTransform(IntervalMapAllocator &allocator,
-                               MarkMustCheckInst *mmci,
-                               DiagnosticEmitter &diagnosticEmitter,
-                               PostOrderAnalysis *poa)
-      : allocator(allocator), mmci(mmci), diagnosticEmitter(diagnosticEmitter),
-        liveness(), poa(poa) {
-    liveness.emplace(mmci->getFunction(), &discoveredBlocks);
-    liveness->init(mmci);
-    liveness->initializeDef(mmci, TypeTreeLeafTypeRange(mmci));
-  }
-
-  bool transform();
-
-private:
-  PostOrderFunctionInfo *getPostOrderFunctionInfo() {
-    if (!pofi)
-      pofi = poa->get(mmci->getFunction());
-    return pofi;
-  }
-
-  /// Visit all of the uses of \p mmci and find all begin_borrows.
-  ///
-  /// Returns false if we found an escape and thus cannot process. It is assumed
-  /// that the caller will fail in such a case.
-  static bool gatherBorrows(MarkMustCheckInst *mmci,
-                            StackList<BeginBorrowInst *> &borrowWorklist);
-
-  /// Walk through our borrow's uses recursively and find uses that require only
-  /// a subset of the bits of our type. These are uses that are consuming uses
-  /// that are destructure uses.
-  bool gatherUses(StackList<BeginBorrowInst *> &borrowWorklist);
-
-  /// Once we have gathered up all of our destructure uses and liveness
-  /// requiring uses, validate that all of our destructure uses are on our
-  /// boundary. Once we have done this, we know that it is safe to perform our
-  /// transform.
-  void checkDestructureUsesOnBoundary() const;
-
-  /// Check for cases where we have two consuming uses on the same instruction
-  /// or a consuming/non-consuming use on the same instruction.
-  void checkForErrorsOnSameInstruction();
-
-  /// Rewrite all of the uses of our borrow on our borrow operand, performing
-  /// destructures as appropriate.
-  void rewriteUses();
-
-  /// After we have rewritten uses, cleanup the IR by deleting the original
-  /// borrow/struct_extract/copies and inserting compensating destroy_values.
-  void cleanup(StackList<BeginBorrowInst *> &borrowWorklist);
-
-  AvailableValues &computeAvailableValues(SILBasicBlock *block);
 };
 
 /// Search for candidate object mark_must_checks. If we find one that does not

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.h
@@ -208,7 +208,8 @@ struct BorrowToDestructureTransform {
       DiagnosticEmitter &diagnosticEmitter, PostOrderAnalysis *poa,
       SmallVectorImpl<SILBasicBlock *> &discoveredBlocks)
       : allocator(allocator), mmci(mmci), diagnosticEmitter(diagnosticEmitter),
-        liveness(mmci->getFunction(), mmci, &discoveredBlocks), poa(poa) {
+        liveness(mmci->getFunction(), &discoveredBlocks), poa(poa) {
+    liveness.init(mmci);
     liveness.initializeDef(mmci, TypeTreeLeafTypeRange(mmci));
   }
 

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -154,10 +154,14 @@ static void addMandatoryDiagnosticOptPipeline(SILPassPipelinePlan &P) {
   // resolution of nonescaping closure lifetimes to correctly check the use
   // of move-only values as captures in nonescaping closures as borrows.
 
+  // Check noImplicitCopy and move only types for objects
+  //
+  // NOTE: It is important that this is run /before/ move only address checker
+  // since if the address checker emits an error, it will cleanup copy_value of
+  // move only objects meaning that we could lose object level diagnostics.
+  P.addMoveOnlyObjectChecker();
   // Check noImplicitCopy and move only types for addresses.
   P.addMoveOnlyAddressChecker();
-  // Check noImplicitCopy and move only types for objects
-  P.addMoveOnlyObjectChecker();
   // Convert last destroy_value to deinits.
   P.addMoveOnlyDeinitInsertion();
   // Lower move only wrapped trivial types.

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -29,17 +29,11 @@ public final class Klass {
     }
 }
 
-public func nonConsumingUseKlass(_ k: Klass) {}
-public func nonConsumingUseCopyableKlass(_ k: CopyableKlass) {}
-public func nonConsumingUseKlass2(_ k: Klass2) {}
-
 @_moveOnly
 public struct NonTrivialStruct2 {
     var moveOnlyKlass = Klass()
     var copyableKlass = CopyableKlass()
 }
-
-public func nonConsumingUseNonTrivialStruct2(_ s: NonTrivialStruct2) {}
 
 @_moveOnly
 public struct NonTrivialStruct {
@@ -48,8 +42,6 @@ public struct NonTrivialStruct {
     var copyableKlass = CopyableKlass()
     var nonTrivialCopyableStruct = NonTrivialCopyableStruct()
 }
-
-public func nonConsumingUseNonTrivialStruct(_ s: NonTrivialStruct) {}
 
 public struct NonTrivialCopyableStruct2 {
     var copyableKlass = CopyableKlass()
@@ -61,9 +53,6 @@ public struct NonTrivialCopyableStruct {
     var nonTrivialCopyableStruct2 = NonTrivialCopyableStruct2()
 }
 
-public func nonConsumingUseCopyableStruct(_ k: NonTrivialCopyableStruct) {}
-public func nonConsumingUseCopyableStruct2(_ k: NonTrivialCopyableStruct2) {}
-
 @_moveOnly
 public enum NonTrivialEnum {
     case first
@@ -71,7 +60,23 @@ public enum NonTrivialEnum {
     case third(NonTrivialStruct)
 }
 
-public func nonConsumingUseNonTrivialEnum(_ e : NonTrivialEnum) {}
+public func borrowVal(_ e : NonTrivialEnum) {}
+public func borrowVal(_ k: CopyableKlass) {}
+public func borrowVal(_ k: Klass) {}
+public func borrowVal(_ k: Klass2) {}
+public func borrowVal(_ k: NonTrivialCopyableStruct) {}
+public func borrowVal(_ k: NonTrivialCopyableStruct2) {}
+public func borrowVal(_ s: NonTrivialStruct) {}
+public func borrowVal(_ s: NonTrivialStruct2) {}
+
+public func consumeVal(_ e : __owned NonTrivialEnum) {}
+public func consumeVal(_ k: __owned CopyableKlass) {}
+public func consumeVal(_ k: __owned Klass) {}
+public func consumeVal(_ k: __owned Klass2) {}
+public func consumeVal(_ k: __owned NonTrivialCopyableStruct) {}
+public func consumeVal(_ k: __owned NonTrivialCopyableStruct2) {}
+public func consumeVal(_ s: __owned NonTrivialStruct) {}
+public func consumeVal(_ s: __owned NonTrivialStruct2) {}
 
 ///////////
 // Tests //
@@ -87,9 +92,9 @@ public func nonConsumingUseNonTrivialEnum(_ e : NonTrivialEnum) {}
 // CHECK:   [[MARKED_OWNED_ARG:%.*]] = mark_must_check [no_copy] [[OWNED_ARG]]
 // CHECK: } // end sil function '$s8moveonly8useKlassyyAA0C0CF'
 public func useKlass(_ k: Klass) {
-    nonConsumingUseKlass(k)
+    borrowVal(k)
     let k2 = k
-    nonConsumingUseKlass(k)
+    borrowVal(k)
     let _ = k2
 }
 
@@ -100,10 +105,9 @@ public func useKlass(_ k: Klass) {
 // CHECK:   mark_must_check [no_implicit_copy] [[LEXICAL_MOVE]]
 // CHECK: } // end sil function '$s8moveonly15useKlassConsumeyyAA0C0CnF'
 public func useKlassConsume(_ k: __owned Klass) {
-    nonConsumingUseKlass(k)
+    borrowVal(k)
     let k2 = k
-    // NOTE: We should mark the next line as a lifetime extending use.
-    nonConsumingUseKlass(k)
+    borrowVal(k)
     let _ = k2
 }
 
@@ -113,11 +117,11 @@ public func useKlassConsume(_ k: __owned Klass) {
 // CHECK:   mark_must_check [no_copy] [[COPIED_ARG]]
 // CHECK: } // end sil function '$s8moveonly19useNonTrivialStructyyAA0cdE0VF'
 public func useNonTrivialStruct(_ s: NonTrivialStruct) {
-    nonConsumingUseNonTrivialStruct(s)
+    borrowVal(s)
     let s2 = s
     let k = s.moveOnlyKlass
     let _ = k
-    nonConsumingUseNonTrivialStruct(s)
+    borrowVal(s)
     let _ = s2
 }
 
@@ -127,11 +131,11 @@ public func useNonTrivialStruct(_ s: NonTrivialStruct) {
 // CHECK:   mark_must_check [no_implicit_copy] [[MOVED_ARG]]
 // CHECK: } // end sil function '$s8moveonly24useNonTrivialOwnedStructyyAA0cdF0VnF'
 public func useNonTrivialOwnedStruct(_ s: __owned NonTrivialStruct) {
-    nonConsumingUseNonTrivialStruct(s)
+    borrowVal(s)
     let s2 = s
     let k = s.moveOnlyKlass
     let _ = k
-    nonConsumingUseNonTrivialStruct(s)
+    borrowVal(s)
     let _ = s2
 }
 
@@ -141,13 +145,13 @@ public func useNonTrivialOwnedStruct(_ s: __owned NonTrivialStruct) {
 // CHECK:   mark_must_check [no_copy] [[COPIED_ARG]]
 // CHECK: } // end sil function '$s8moveonly17useNonTrivialEnumyyAA0cdE0OF'
 public func useNonTrivialEnum(_ s: NonTrivialEnum) {
-    nonConsumingUseNonTrivialEnum(s)
+    borrowVal(s)
     let s2 = s
     switch s {
     case _:
         break
     }
-    nonConsumingUseNonTrivialEnum(s)
+    borrowVal(s)
     let _ = s2
 }
 
@@ -157,13 +161,13 @@ public func useNonTrivialEnum(_ s: NonTrivialEnum) {
 // CHECK:   mark_must_check [no_implicit_copy] [[MOVED_ARG]]
 // CHECK: } // end sil function '$s8moveonly22useNonTrivialOwnedEnumyyAA0cdF0OnF'
 public func useNonTrivialOwnedEnum(_ s: __owned NonTrivialEnum) {
-    nonConsumingUseNonTrivialEnum(s)
+    borrowVal(s)
     let s2 = s
     switch s {
     case _:
         break
     }
-    nonConsumingUseNonTrivialEnum(s)
+    borrowVal(s)
     let _ = s2
 }
 
@@ -286,20 +290,20 @@ func blackHoleVarInitialization2() {
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly24borrowObjectFunctionCallyyF : $@convention(thin) () -> () {
 // CHECK: [[CLS:%.*]] = mark_must_check [no_implicit_copy]
 // CHECK: [[BORROW:%.*]] = begin_borrow [[CLS]]
-// CHECK: [[FN:%.*]] = function_ref @$s8moveonly20nonConsumingUseKlassyyAA0E0CF
+// CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA5KlassCF
 // CHECK: apply [[FN]]([[BORROW]])
 // CHECK: end_borrow [[BORROW]]
 // CHECK: } // end sil function '$s8moveonly24borrowObjectFunctionCallyyF'
 func borrowObjectFunctionCall() {
     let k = Klass()
-    nonConsumingUseKlass(k)
+    borrowVal(k)
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly25borrowAddressFunctionCallyyF : $@convention(thin) () -> () {
 // CHECK: [[BOX:%.*]] = mark_must_check [no_implicit_copy]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[BOX]]
 // CHECK: [[BORROW:%.*]] = load_borrow [[ACCESS]]
-// CHECK: [[FN:%.*]] = function_ref @$s8moveonly20nonConsumingUseKlassyyAA0E0CF
+// CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA5KlassCF
 // CHECK: apply [[FN]]([[BORROW]])
 // CHECK: end_borrow [[BORROW]]
 // CHECK: end_access [[ACCESS]]
@@ -307,7 +311,7 @@ func borrowObjectFunctionCall() {
 func borrowAddressFunctionCall() {
     var k = Klass()
     k = Klass()
-    nonConsumingUseKlass(k)
+    borrowVal(k)
 }
 
 // We currently have the wrong behavior here since the class is treated by
@@ -321,7 +325,7 @@ func borrowAddressFunctionCall() {
 func klassBorrowAddressFunctionCall2() {
     var k = Klass()
     k = Klass()
-    nonConsumingUseKlass2(k.moveOnlyKlass)
+    borrowVal(k.moveOnlyKlass)
 }
 
 // We copy here since we have a class as our base like the above.
@@ -341,14 +345,14 @@ func klassBorrowAddressFunctionCall2() {
 func klassBorrowCopyableAddressFunctionCall() {
     var k = Klass()
     k = Klass()
-    nonConsumingUseCopyableKlass(k.copyableKlass)
+    borrowVal(k.copyableKlass)
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly29moveOnlyStructNonConsumingUseyyF : $@convention(thin) () -> () {
 // CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK: [[BORROW:%.*]] = load_borrow [[ACCESS]]
-// CHECK: [[FN:%.*]] = function_ref @$s8moveonly31nonConsumingUseNonTrivialStructyyAA0efG0VF :
+// CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA16NonTrivialStructVF :
 // CHECK: apply [[FN]]([[BORROW]])
 // CHECK: end_borrow [[BORROW]]
 // CHECK: end_access [[ACCESS]]
@@ -356,7 +360,7 @@ func klassBorrowCopyableAddressFunctionCall() {
 func moveOnlyStructNonConsumingUse() {
     var k = NonTrivialStruct()
     k = NonTrivialStruct()
-    nonConsumingUseNonTrivialStruct(k)
+    borrowVal(k)
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMoveC20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
@@ -364,7 +368,7 @@ func moveOnlyStructNonConsumingUse() {
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK: [[STRUCT_EXT:%.*]] = struct_element_addr [[ACCESS]]
 // CHECK: [[BORROW:%.*]] = load_borrow [[STRUCT_EXT]]
-// CHECK: [[FN:%.*]] = function_ref @$s8moveonly20nonConsumingUseKlassyyAA0E0CF
+// CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA5KlassCF
 // CHECK: apply [[FN]]([[BORROW]])
 // CHECK: end_borrow [[BORROW]]
 // CHECK: end_access [[ACCESS]]
@@ -372,7 +376,7 @@ func moveOnlyStructNonConsumingUse() {
 func moveOnlyStructMoveOnlyKlassNonConsumingUse() {
     var k = NonTrivialStruct()
     k = NonTrivialStruct()
-    nonConsumingUseKlass(k.moveOnlyKlass)
+    borrowVal(k.moveOnlyKlass)
 }
 
 // We fail here b/c we are accessing through a class.
@@ -387,7 +391,7 @@ func moveOnlyStructMoveOnlyKlassNonConsumingUse() {
 // CHECK:   [[ELT_ADDR:%.*]] = ref_element_addr [[STRUCT_EXT_COPY_BORROW]]
 // CHECK:   [[ACCESS_ELT_ADDR:%.*]] = begin_access [read] [dynamic] [[ELT_ADDR]]
 // CHECK:   [[KLS:%.*]] = load_borrow [[ACCESS_ELT_ADDR]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly21nonConsumingUseKlass2yyAA0E0CF
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA6Klass2CF
 // CHECK:   apply [[FN]]([[KLS]])
 // CHECK:   end_borrow [[KLS]]
 // CHECK:   destroy_value [[STRUCT_EXT_COPY]]
@@ -395,7 +399,7 @@ func moveOnlyStructMoveOnlyKlassNonConsumingUse() {
 func moveOnlyStructMoveOnlyKlassMoveOnlyKlassNonConsumingUse() {
     var k = NonTrivialStruct()
     k = NonTrivialStruct()
-    nonConsumingUseKlass2(k.moveOnlyKlass.moveOnlyKlass)
+    borrowVal(k.moveOnlyKlass.moveOnlyKlass)
 }
 
 // We fail here b/c we are accessing through a class.
@@ -410,7 +414,7 @@ func moveOnlyStructMoveOnlyKlassMoveOnlyKlassNonConsumingUse() {
 // CHECK:   [[FIELD:%.*]] = ref_element_addr [[STRUCT_EXT_COPY_BORROW]]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [dynamic] [[FIELD]]
 // CHECK:   [[BORROWED_KLS:%.*]] = load_borrow [[ACCESS]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly28nonConsumingUseCopyableKlassyyAA0eF0CF
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassCF
 // CHECK:   apply [[FN]]([[BORROWED_KLS]])
 // CHECK:   end_borrow [[BORROWED_KLS]]
 // CHECK:   destroy_value [[STRUCT_EXT_COPY]]
@@ -418,7 +422,7 @@ func moveOnlyStructMoveOnlyKlassMoveOnlyKlassNonConsumingUse() {
 func moveOnlyStructMoveOnlyKlassCopyableKlassNonConsumingUse() {
     var k = NonTrivialStruct()
     k = NonTrivialStruct()
-    nonConsumingUseCopyableKlass(k.moveOnlyKlass.copyableKlass)
+    borrowVal(k.moveOnlyKlass.copyableKlass)
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovecD15NonConsumingUseyyF : $@convention(thin) () -> () {
@@ -426,7 +430,7 @@ func moveOnlyStructMoveOnlyKlassCopyableKlassNonConsumingUse() {
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly32nonConsumingUseNonTrivialStruct2yyAA0efG0VF : $@convention(thin) (@guaranteed NonTrivialStruct2) -> ()
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA17NonTrivialStruct2VF : $@convention(thin) (@guaranteed NonTrivialStruct2) -> ()
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
@@ -434,7 +438,7 @@ func moveOnlyStructMoveOnlyKlassCopyableKlassNonConsumingUse() {
 func moveOnlyStructMoveOnlyStructNonConsumingUse() {
     var k = NonTrivialStruct()
     k = NonTrivialStruct()
-    nonConsumingUseNonTrivialStruct2(k.nonTrivialStruct2)
+    borrowVal(k.nonTrivialStruct2)
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovecdeC20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
@@ -443,7 +447,7 @@ func moveOnlyStructMoveOnlyStructNonConsumingUse() {
 // CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialStruct2, #NonTrivialStruct2.moveOnlyKlass
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP2]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly20nonConsumingUseKlassyyAA0E0CF : $@convention(thin) (@guaranteed Klass) -> ()
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA5KlassCF : $@convention(thin) (@guaranteed Klass) -> ()
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
@@ -451,7 +455,7 @@ func moveOnlyStructMoveOnlyStructNonConsumingUse() {
 func moveOnlyStructMoveOnlyStructMoveOnlyKlassNonConsumingUse() {
     var k = NonTrivialStruct()
     k = NonTrivialStruct()
-    nonConsumingUseKlass(k.nonTrivialStruct2.moveOnlyKlass)
+    borrowVal(k.nonTrivialStruct2.moveOnlyKlass)
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovecD28CopyableKlassNonConsumingUseyyF : $@convention(thin) () -> () {
@@ -460,7 +464,7 @@ func moveOnlyStructMoveOnlyStructMoveOnlyKlassNonConsumingUse() {
 // CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialStruct2, #NonTrivialStruct2.copyableKlass
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP2]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly28nonConsumingUseCopyableKlassyyAA0eF0CF : $@convention(thin) (@guaranteed CopyableKlass) -> ()
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassCF : $@convention(thin) (@guaranteed CopyableKlass) -> ()
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
@@ -468,7 +472,7 @@ func moveOnlyStructMoveOnlyStructMoveOnlyKlassNonConsumingUse() {
 func moveOnlyStructMoveOnlyStructCopyableKlassNonConsumingUse() {
     var k = NonTrivialStruct()
     k = NonTrivialStruct()
-    nonConsumingUseCopyableKlass(k.nonTrivialStruct2.copyableKlass)
+    borrowVal(k.nonTrivialStruct2.copyableKlass)
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly42moveOnlyStructCopyableKlassNonConsumingUseyyF : $@convention(thin) () -> () {
@@ -476,7 +480,7 @@ func moveOnlyStructMoveOnlyStructCopyableKlassNonConsumingUse() {
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.copyableKlass
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly28nonConsumingUseCopyableKlassyyAA0eF0CF : $@convention(thin) (@guaranteed CopyableKlass) -> ()
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassCF : $@convention(thin) (@guaranteed CopyableKlass) -> ()
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
@@ -484,7 +488,7 @@ func moveOnlyStructMoveOnlyStructCopyableKlassNonConsumingUse() {
 func moveOnlyStructCopyableKlassNonConsumingUse() {
     var k = NonTrivialStruct()
     k = NonTrivialStruct()
-    nonConsumingUseCopyableKlass(k.copyableKlass)
+    borrowVal(k.copyableKlass)
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyableD15NonConsumingUseyyF : $@convention(thin) () -> () {
@@ -492,7 +496,7 @@ func moveOnlyStructCopyableKlassNonConsumingUse() {
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly29nonConsumingUseCopyableStructyyAA010NonTrivialeF0VF : 
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA24NonTrivialCopyableStructVF : 
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
@@ -500,7 +504,7 @@ func moveOnlyStructCopyableKlassNonConsumingUse() {
 func moveOnlyStructCopyableStructNonConsumingUse() {
     var k = NonTrivialStruct()
     k = NonTrivialStruct()
-    nonConsumingUseCopyableStruct(k.nonTrivialCopyableStruct)
+    borrowVal(k.nonTrivialCopyableStruct)
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyabledE20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
@@ -509,7 +513,7 @@ func moveOnlyStructCopyableStructNonConsumingUse() {
 // CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.copyableKlass
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP2]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly28nonConsumingUseCopyableKlassyyAA0eF0CF :
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassCF :
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
@@ -517,7 +521,7 @@ func moveOnlyStructCopyableStructNonConsumingUse() {
 func moveOnlyStructCopyableStructCopyableKlassNonConsumingUse() {
     var k = NonTrivialStruct()
     k = NonTrivialStruct()
-    nonConsumingUseCopyableKlass(k.nonTrivialCopyableStruct.copyableKlass)
+    borrowVal(k.nonTrivialCopyableStruct.copyableKlass)
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyabledeD15NonConsumingUseyyF : $@convention(thin) () -> () {
@@ -526,7 +530,7 @@ func moveOnlyStructCopyableStructCopyableKlassNonConsumingUse() {
 // CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.nonTrivialCopyableStruct2
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP2]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly30nonConsumingUseCopyableStruct2yyAA010NonTrivialeF0VF :
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA25NonTrivialCopyableStruct2VF :
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
@@ -534,7 +538,7 @@ func moveOnlyStructCopyableStructCopyableKlassNonConsumingUse() {
 func moveOnlyStructCopyableStructCopyableStructNonConsumingUse() {
     var k = NonTrivialStruct()
     k = NonTrivialStruct()
-    nonConsumingUseCopyableStruct2(k.nonTrivialCopyableStruct.nonTrivialCopyableStruct2)
+    borrowVal(k.nonTrivialCopyableStruct.nonTrivialCopyableStruct2)
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyablededE20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
@@ -544,7 +548,7 @@ func moveOnlyStructCopyableStructCopyableStructNonConsumingUse() {
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.nonTrivialCopyableStruct2
 // CHECK:   [[GEP3:%.*]] = struct_element_addr [[GEP2]] : $*NonTrivialCopyableStruct2, #NonTrivialCopyableStruct2.copyableKlass
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP3]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly28nonConsumingUseCopyableKlassyyAA0eF0CF :
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassCF :
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
@@ -552,7 +556,7 @@ func moveOnlyStructCopyableStructCopyableStructNonConsumingUse() {
 func moveOnlyStructCopyableStructCopyableStructCopyableKlassNonConsumingUse() {
     var k = NonTrivialStruct()
     k = NonTrivialStruct()
-    nonConsumingUseCopyableKlass(k.nonTrivialCopyableStruct.nonTrivialCopyableStruct2.copyableKlass)
+    borrowVal(k.nonTrivialCopyableStruct.nonTrivialCopyableStruct2.copyableKlass)
 }
 
 // We fail here b/c we are accessing through a class.
@@ -569,7 +573,7 @@ func moveOnlyStructCopyableStructCopyableStructCopyableKlassNonConsumingUse() {
 // CHECK:   [[FIELD:%.*]] = ref_element_addr [[BORROWED_COPYABLE_KLASS]]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [dynamic] [[FIELD]]
 // CHECK:   [[BORROWED_MOVEONLY_KLASS:%.*]] = load_borrow [[ACCESS]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly20nonConsumingUseKlassyyAA0E0CF :
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA5KlassCF :
 // CHECK:   apply [[FN]]([[BORROWED_MOVEONLY_KLASS]])
 // CHECK:   end_borrow [[BORROWED_MOVEONLY_KLASS]]
 // CHECK:   destroy_value [[COPYABLE_KLASS]]
@@ -577,5 +581,103 @@ func moveOnlyStructCopyableStructCopyableStructCopyableKlassNonConsumingUse() {
 func moveOnlyStructCopyableStructCopyableStructCopyableKlassMoveOnlyKlassNonConsumingUse() {
     var k = NonTrivialStruct()
     k = NonTrivialStruct()
-    nonConsumingUseKlass(k.nonTrivialCopyableStruct.nonTrivialCopyableStruct2.copyableKlass.k)
+    borrowVal(k.nonTrivialCopyableStruct.nonTrivialCopyableStruct2.copyableKlass.k)
+}
+
+///////////////////////
+// Enum Switch Tests //
+///////////////////////
+
+enum EnumSwitchTests {
+    @_moveOnly
+    enum E2 {
+        case lhs(CopyableKlass)
+        case rhs(Klass)
+    }
+
+    @_moveOnly
+    enum E {
+        case first(NonTrivialStruct2)
+        case second(NonTrivialStruct)
+        case third(CopyableKlass)
+        case fourth(E2)
+    }
+}
+
+func consumeVal(_ e: __owned EnumSwitchTests.E2) {}
+
+var booleanGuard: Bool { false }
+var booleanGuard2: Bool { false }
+
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly15enumSwitchTest1yyAA04EnumC5TestsO1EOF : $@convention(thin) (@guaranteed EnumSwitchTests.E) -> () {
+// CHECK: bb0([[ARG:%.*]] : @guaranteed
+// CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[COPY_ARG]]
+// CHECK:   [[BORROWED_VALUE:%.*]] = begin_borrow [[MARKED_VALUE]]
+// CHECK:   switch_enum [[BORROWED_VALUE]] : $EnumSwitchTests.E, case #EnumSwitchTests.E.first!enumelt: [[BB_E_1:bb[0-9]+]], case #EnumSwitchTests.E.second!enumelt: [[BB_E_2:bb[0-9]+]], case #EnumSwitchTests.E.third!enumelt: [[BB_E_3:bb[0-9]+]], case #EnumSwitchTests.E.fourth!enumelt: [[BB_E_4:bb[0-9]+]]
+//
+// CHECK: [[BB_E_1]]([[BBARG:%.*]] : @guaranteed
+// CHECK:   end_borrow [[BORROWED_VALUE]]
+// CHECK:   br [[BB_CONT:bb[0-9]+]]
+//
+// CHECK: [[BB_E_2]]([[BBARG:%.*]] : @guaranteed
+// CHECK:   [[BBARG_COPY:%.*]] = copy_value [[BBARG]]
+// CHECK:   [[NEW_VAL:%.*]] = move_value [lexical] [[BBARG_COPY]]
+// CHECK:   end_borrow [[BORROWED_VALUE]]
+// CHECK:   br [[BB_CONT]]
+//
+// This case is copyable
+// CHECK: [[BB_E_3]]([[BBARG:%.*]] : @guaranteed
+// CHECK:   [[BBARG_COPY:%.*]] = copy_value [[BBARG]]
+// CHECK:   begin_borrow [lexical] [[BBARG_COPY]]
+// CHECK:   end_borrow [[BORROWED_VALUE]]
+// CHECK:   br [[BB_CONT]]
+//
+// This is a guard case.
+// CHECK: [[BB_E_4]]([[BBARG:%.*]] : @guaranteed
+// CHECK:   cond_br {{%.*}}, [[BB_GUARD_1:bb[0-9]+]], [[BB_GUARD_2:bb[0-9]+]]
+//
+// CHECK: [[BB_GUARD_1]]:
+// CHECK:   end_borrow [[BORROWED_VALUE]]
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_GUARD_2]]:
+// CHECK:   switch_enum [[BBARG]] : $EnumSwitchTests.E2, case #EnumSwitchTests.E2.lhs!enumelt: [[BB_E2_LHS:bb[0-9]+]], case #EnumSwitchTests.E2.rhs!enumelt: [[BB_E2_RHS:bb[0-9]+]]
+//
+// Copyable case
+// CHECK: [[BB_E2_LHS]]([[BBARG:%.*]] : @guaranteed
+// CHECK:   [[BBARG_COPY:%.*]] = copy_value [[BBARG]]
+// CHECK:   begin_borrow [lexical] [[BBARG_COPY]]
+// CHECK:   end_borrow [[BORROWED_VALUE]]
+// CHECK:   br [[BB_CONT]]
+//
+// Move only case.
+// CHECK: [[BB_E2_RHS]]([[BBARG:%.*]] : @guaranteed
+// CHECK:   [[BBARG_COPY:%.*]] = copy_value [[BBARG]]
+// CHECK:   move_value [lexical] [[BBARG_COPY]]
+// CHECK:   end_borrow [[BORROWED_VALUE]]
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_CONT]]:
+// CHECK:   destroy_value [[MARKED_VALUE]]
+// CHECK: } // end sil function '$s8moveonly15enumSwitchTest1yyAA04EnumC5TestsO1EOF'
+func enumSwitchTest1(_ e: EnumSwitchTests.E) {
+    switch e {
+    case .first:
+        break
+    case .second(let x):
+        borrowVal(x)
+        break
+    case .third(let y):
+        borrowVal(y)
+        break
+    case .fourth where booleanGuard:
+        break
+    case .fourth(.lhs(let lhs)):
+        borrowVal(lhs)
+        break
+    case .fourth(.rhs(let rhs)):
+        consumeVal(rhs)
+        break
+    }
 }

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -283,10 +283,8 @@ bb0(%arg : @owned $Klass):
   %21 = move_value [lexical] %19 : $Klass
   %22 = mark_must_check [no_implicit_copy] %21 : $Klass
   debug_value %22 : $Klass, let, name "k2"
-  %24 = copy_value %22 : $Klass
-  %25 = move_value %24 : $Klass
+  %25 = move_value %22 : $Klass
   destroy_value %25 : $Klass
-  destroy_value %22 : $Klass
   destroy_addr %1 : $*Klass
   dealloc_stack %0 : $*Klass
   %30 = tuple ()

--- a/test/SILOptimizer/moveonly_borrow_to_destructure_transform.sil
+++ b/test/SILOptimizer/moveonly_borrow_to_destructure_transform.sil
@@ -43,11 +43,26 @@ struct SingleIntContainingStruct {
     var value: Builtin.Int32
 }
 
+@_moveOnly
+enum E {
+case first(MoveOnlyKlass)
+case second(SingleIntContainingStruct)
+case third(AggStruct2)
+case fourth(Klass)
+}
+
+@_moveOnly
+enum E2 {
+case lhs(AggStruct2)
+case rhs(E)
+}
+
 sil @misc_use : $@convention(thin) () -> ()
 sil @aggstruct_consume : $@convention(thin) (@owned AggStruct) -> ()
 sil @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
 sil @moveonlyklass_use : $@convention(thin) (@guaranteed MoveOnlyKlass) -> ()
 sil @klass_use : $@convention(thin) (@guaranteed Klass) -> ()
+sil @builtin32_use : $@convention(thin) (Builtin.Int32) -> ()
 
 ///////////
 // Tests //
@@ -625,4 +640,390 @@ bb3:
   destroy_value %2 : $GrandParentMultiFieldStruct
   %35 = tuple ()
   return %35 : $()
+}
+
+///////////////////////
+// Switch Enum Tests //
+///////////////////////
+
+// CHECK-LABEL: sil [ossa] @switch_enum_without_destructure : $@convention(thin) (@guaranteed E) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_COPY:%.*]] = copy_value [[MARKED_VALUE]]
+// CHECK:   switch_enum [[MARKED_COPY:%.*]] : $E, case #E.first!enumelt: [[BB_E_FIRST:bb[0-9]+]], case #E.second!enumelt: [[BB_E_SECOND:bb[0-9]+]], case #E.third!enumelt: [[BB_E_THIRD:bb[0-9]+]], case #E.fourth!enumelt: [[BB_E_FOURTH:bb[0-9]+]]
+//
+// CHECK: [[BB_E_FIRST]]([[BBARG:%.*]] : @owned
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT:bb[0-9]+]]
+//
+// CHECK: [[BB_E_SECOND]]([[BBARG:%.*]] : @owned
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_E_THIRD]]([[BBARG:%.*]] : @owned
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_E_FOURTH]]([[BBARG:%.*]] : @owned
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_CONT]]:
+// CHECK:   destroy_value [[MARKED_VALUE]]
+// CHECK: } // end sil function 'switch_enum_without_destructure'
+sil [ossa] @switch_enum_without_destructure : $@convention(thin) (@guaranteed E) -> () {
+bb0(%0 : @guaranteed $E):
+  %1 = copy_value %0 : $E
+  %2 = mark_must_check [no_copy] %1 : $E
+  %3 = begin_borrow %2 : $E
+  switch_enum %3 : $E, case #E.first!enumelt: bb1, case #E.second!enumelt: bb2, case #E.third!enumelt: bb3, case #E.fourth!enumelt: bb4
+
+bb1(%first : @guaranteed $MoveOnlyKlass):
+  br bbCont
+
+bb2(%second : @guaranteed $SingleIntContainingStruct):
+  br bbCont
+
+bb3(%third : @guaranteed $AggStruct2):
+  br bbCont
+
+bb4(%fourth: @guaranteed $Klass):
+  br bbCont
+
+bbCont:
+  end_borrow %3 : $E
+  destroy_value %2 : $E
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @switch_enum_with_destructure : $@convention(thin) (@guaranteed E) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_COPY:%.*]] = copy_value [[MARKED_VALUE]]
+// CHECK:   switch_enum [[MARKED_COPY:%.*]] : $E, case #E.first!enumelt: [[BB_E_FIRST:bb[0-9]+]], case #E.second!enumelt: [[BB_E_SECOND:bb[0-9]+]], case #E.third!enumelt: [[BB_E_THIRD:bb[0-9]+]], case #E.fourth!enumelt: [[BB_E_FOURTH:bb[0-9]+]]
+//
+// CHECK: [[BB_E_FIRST]]([[BBARG:%.*]] : @owned
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT:bb[0-9]+]]
+//
+// CHECK: [[BB_E_SECOND]]([[BBARG:%.*]] : @owned
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_E_THIRD]]([[BBARG:%.*]] : @owned
+// CHECK:   [[FUNC:%.*]] = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
+// CHECK:   ([[FIRST:%.*]], [[SECOND:%.*]], [[THIRD:%.*]]) = destructure_struct [[BBARG]]
+// CHECK:   destroy_value [[THIRD]]
+// CHECK:   destroy_value [[FIRST]]
+// CHECK:   ([[SECOND_FIRST:%.*]], [[SECOND_SECOND:%.*]]) = destructure_struct [[SECOND]]
+// CHECK:   destroy_value [[SECOND_SECOND]]
+// CHECK:   apply [[FUNC]]([[SECOND_FIRST]])
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_E_FOURTH]]([[BBARG:%.*]] : @owned
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_CONT]]:
+// CHECK:   destroy_value [[MARKED_VALUE]]
+// CHECK: } // end sil function 'switch_enum_with_destructure'
+sil [ossa] @switch_enum_with_destructure : $@convention(thin) (@guaranteed E) -> () {
+bb0(%0 : @guaranteed $E):
+  %1 = copy_value %0 : $E
+  %2 = mark_must_check [no_copy] %1 : $E
+  %3 = begin_borrow %2 : $E
+  switch_enum %3 : $E, case #E.first!enumelt: bb1, case #E.second!enumelt: bb2, case #E.third!enumelt: bb3, case #E.fourth!enumelt: bb4
+
+bb1(%first : @guaranteed $MoveOnlyKlass):
+  br bbCont
+
+bb2(%second : @guaranteed $SingleIntContainingStruct):
+  br bbCont
+
+bb3(%third : @guaranteed $AggStruct2):
+  %third1 = begin_borrow %third : $AggStruct2
+  %gep1 = struct_extract %third1 : $AggStruct2, #AggStruct2.pair
+  %gep2 = struct_extract %gep1 : $KlassPair2, #KlassPair2.lhs
+  %copy = copy_value %gep2 : $MoveOnlyKlass
+  %f = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
+  apply %f(%copy) : $@convention(thin) (@owned MoveOnlyKlass) -> ()
+  end_borrow %third1 : $AggStruct2
+  br bbCont
+
+bb4(%fourth: @guaranteed $Klass):
+  br bbCont
+
+bbCont:
+  end_borrow %3 : $E
+  destroy_value %2 : $E
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @switch_enum_with_destructure_recursive : $@convention(thin) (@guaranteed E2) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_COPY:%.*]] = copy_value [[MARKED_VALUE]]
+// CHECK:   switch_enum [[MARKED_COPY:%.*]] : $E2, case #E2.lhs!enumelt: [[BB_E2_LHS:bb[0-9]+]], case #E2.rhs!enumelt: [[BB_E2_RHS:bb[0-9]+]]
+//
+// CHECK: [[BB_E2_LHS]]([[BBARG:%.*]] : @owned
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT:bb[0-9]+]]
+//
+// CHECK: [[BB_E2_RHS]]([[BBARG:%.*]] : @owned
+// CHECK:   switch_enum [[BBARG]] : $E, case #E.first!enumelt: [[BB_E_FIRST:bb[0-9]+]], case #E.second!enumelt: [[BB_E_SECOND:bb[0-9]+]], case #E.third!enumelt: [[BB_E_THIRD:bb[0-9]+]], case #E.fourth!enumelt: [[BB_E_FOURTH:bb[0-9]+]]
+//
+// CHECK: [[BB_E_FIRST]]([[BBARG:%.*]] : @owned
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_E_SECOND]]([[BBARG:%.*]] : @owned
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_E_THIRD]]([[BBARG:%.*]] : @owned
+// CHECK:   [[FUNC:%.*]] = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
+// CHECK:   ([[FIRST:%.*]], [[SECOND:%.*]], [[THIRD:%.*]]) = destructure_struct [[BBARG]]
+// CHECK:   destroy_value [[THIRD]]
+// CHECK:   destroy_value [[FIRST]]
+// CHECK:   ([[SECOND_FIRST:%.*]], [[SECOND_SECOND:%.*]]) = destructure_struct [[SECOND]]
+// CHECK:   destroy_value [[SECOND_SECOND]]
+// CHECK:   apply [[FUNC]]([[SECOND_FIRST]])
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_E_FOURTH]]([[BBARG:%.*]] : @owned
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_CONT]]:
+// CHECK:   destroy_value [[MARKED_VALUE]]
+// CHECK: } // end sil function 'switch_enum_with_destructure_recursive'
+sil [ossa] @switch_enum_with_destructure_recursive : $@convention(thin) (@guaranteed E2) -> () {
+bb0(%0 : @guaranteed $E2):
+  %1 = copy_value %0 : $E2
+  %2 = mark_must_check [no_copy] %1 : $E2
+  %3 = begin_borrow %2 : $E2
+  switch_enum %3 : $E2, case #E2.lhs!enumelt: bbN1, case #E2.rhs!enumelt: bbN2
+
+bbN1(%lhs : @guaranteed $AggStruct2):
+  br bbCont
+
+bbN2(%rhs: @guaranteed $E):
+  switch_enum %rhs : $E, case #E.first!enumelt: bb1, case #E.second!enumelt: bb2, case #E.third!enumelt: bb3, case #E.fourth!enumelt: bb4
+
+bb1(%first : @guaranteed $MoveOnlyKlass):
+  br bbCont
+
+bb2(%second : @guaranteed $SingleIntContainingStruct):
+  br bbCont
+
+bb3(%third : @guaranteed $AggStruct2):
+  %third1 = begin_borrow %third : $AggStruct2
+  %gep1 = struct_extract %third1 : $AggStruct2, #AggStruct2.pair
+  %gep2 = struct_extract %gep1 : $KlassPair2, #KlassPair2.lhs
+  %copy = copy_value %gep2 : $MoveOnlyKlass
+  %f = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
+  apply %f(%copy) : $@convention(thin) (@owned MoveOnlyKlass) -> ()
+  end_borrow %third1 : $AggStruct2
+  br bbCont
+
+bb4(%fourth: @guaranteed $Klass):
+  br bbCont
+
+bbCont:
+  end_borrow %3 : $E2
+  destroy_value %2 : $E2
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @switch_enum_with_destructure_recursive_2 : $@convention(thin) (@guaranteed E2) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_COPY:%.*]] = copy_value [[MARKED_VALUE]]
+// CHECK:   switch_enum [[MARKED_COPY:%.*]] : $E2, case #E2.lhs!enumelt: [[BB_E2_LHS:bb[0-9]+]], case #E2.rhs!enumelt: [[BB_E2_RHS:bb[0-9]+]]
+//
+// CHECK: [[BB_E2_LHS]]([[BBARG:%.*]] : @owned
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT:bb[0-9]+]]
+//
+// CHECK: [[BB_E2_RHS]]([[BBARG:%.*]] : @owned
+// CHECK:   switch_enum [[BBARG]] : $E, case #E.first!enumelt: [[BB_E_FIRST:bb[0-9]+]], case #E.second!enumelt: [[BB_E_SECOND:bb[0-9]+]], case #E.third!enumelt: [[BB_E_THIRD:bb[0-9]+]], case #E.fourth!enumelt: [[BB_E_FOURTH:bb[0-9]+]]
+//
+// CHECK: [[BB_E_FIRST]]([[BBARG:%.*]] : @owned
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_E_SECOND]]([[BBARG:%.*]] : @owned
+// CHECK:   [[BBARG_BORROW:%.*]] = begin_borrow [[BBARG]]
+// CHECK:   [[BBARG_BORROW_EXT:%.*]] = struct_extract [[BBARG_BORROW]]
+// CHECK:   apply {{%.*}}([[BBARG_BORROW_EXT]])
+// CHECK:   end_borrow [[BBARG_BORROW]]
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_E_THIRD]]([[BBARG:%.*]] : @owned
+// CHECK:   [[FUNC:%.*]] = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
+// CHECK:   ([[FIRST:%.*]], [[SECOND:%.*]], [[THIRD:%.*]]) = destructure_struct [[BBARG]]
+// CHECK:   destroy_value [[THIRD]]
+// CHECK:   destroy_value [[FIRST]]
+// CHECK:   ([[SECOND_FIRST:%.*]], [[SECOND_SECOND:%.*]]) = destructure_struct [[SECOND]]
+// CHECK:   destroy_value [[SECOND_SECOND]]
+// CHECK:   apply [[FUNC]]([[SECOND_FIRST]])
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_E_FOURTH]]([[BBARG:%.*]] : @owned
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_CONT]]:
+// CHECK:   destroy_value [[MARKED_VALUE]]
+// CHECK: } // end sil function 'switch_enum_with_destructure_recursive_2'
+sil [ossa] @switch_enum_with_destructure_recursive_2 : $@convention(thin) (@guaranteed E2) -> () {
+bb0(%0 : @guaranteed $E2):
+  %1 = copy_value %0 : $E2
+  %2 = mark_must_check [no_copy] %1 : $E2
+  %3 = begin_borrow %2 : $E2
+  switch_enum %3 : $E2, case #E2.lhs!enumelt: bbN1, case #E2.rhs!enumelt: bbN2
+
+bbN1(%lhs : @guaranteed $AggStruct2):
+  br bbCont
+
+bbN2(%rhs: @guaranteed $E):
+  switch_enum %rhs : $E, case #E.first!enumelt: bb1, case #E.second!enumelt: bb2, case #E.third!enumelt: bb3, case #E.fourth!enumelt: bb4
+
+bb1(%first : @guaranteed $MoveOnlyKlass):
+  br bbCont
+
+bb2(%second : @guaranteed $SingleIntContainingStruct):
+  %second1 = begin_borrow %second : $SingleIntContainingStruct
+  %secondGep1 = struct_extract %second1 : $SingleIntContainingStruct, #SingleIntContainingStruct.value
+  %f2 = function_ref @builtin32_use : $@convention(thin) (Builtin.Int32) -> ()
+  apply %f2(%secondGep1) : $@convention(thin) (Builtin.Int32) -> ()
+  end_borrow %second1 : $SingleIntContainingStruct
+  br bbCont
+
+bb3(%third : @guaranteed $AggStruct2):
+  %third1 = begin_borrow %third : $AggStruct2
+  %gep1 = struct_extract %third1 : $AggStruct2, #AggStruct2.pair
+  %gep2 = struct_extract %gep1 : $KlassPair2, #KlassPair2.lhs
+  %copy = copy_value %gep2 : $MoveOnlyKlass
+  %f = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
+  apply %f(%copy) : $@convention(thin) (@owned MoveOnlyKlass) -> ()
+  end_borrow %third1 : $AggStruct2
+  br bbCont
+
+bb4(%fourth: @guaranteed $Klass):
+  br bbCont
+
+bbCont:
+  end_borrow %3 : $E2
+  destroy_value %2 : $E2
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @switch_enum_with_destructure_recursive_3 : $@convention(thin) (@guaranteed E2) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_COPY:%.*]] = copy_value [[MARKED_VALUE]]
+// CHECK:   switch_enum [[MARKED_COPY:%.*]] : $E2, case #E2.lhs!enumelt: [[BB_E2_LHS:bb[0-9]+]], case #E2.rhs!enumelt: [[BB_E2_RHS:bb[0-9]+]]
+//
+// CHECK: [[BB_E2_LHS]]([[BBARG:%.*]] : @owned
+// CHECK:   [[FUNC:%.*]] = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
+// CHECK:   ([[FIRST:%.*]], [[SECOND:%.*]], [[THIRD:%.*]]) = destructure_struct [[BBARG]]
+// CHECK:   destroy_value [[THIRD]]
+// CHECK:   destroy_value [[FIRST]]
+// CHECK:   ([[SECOND_FIRST:%.*]], [[SECOND_SECOND:%.*]]) = destructure_struct [[SECOND]]
+// CHECK:   destroy_value [[SECOND_SECOND]]
+// CHECK:   apply [[FUNC]]([[SECOND_FIRST]])
+// CHECK:   br [[BB_CONT:bb[0-9]+]]
+//
+// CHECK: [[BB_E2_RHS]]([[BBARG:%.*]] : @owned
+// CHECK:   switch_enum [[BBARG]] : $E, case #E.first!enumelt: [[BB_E_FIRST:bb[0-9]+]], case #E.second!enumelt: [[BB_E_SECOND:bb[0-9]+]], case #E.third!enumelt: [[BB_E_THIRD:bb[0-9]+]], case #E.fourth!enumelt: [[BB_E_FOURTH:bb[0-9]+]]
+//
+// CHECK: [[BB_E_FIRST]]([[BBARG:%.*]] : @owned
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_E_SECOND]]([[BBARG:%.*]] : @owned
+// CHECK:   [[BBARG_BORROW:%.*]] = begin_borrow [[BBARG]]
+// CHECK:   [[BBARG_BORROW_EXT:%.*]] = struct_extract [[BBARG_BORROW]]
+// CHECK:   apply {{%.*}}([[BBARG_BORROW_EXT]])
+// CHECK:   end_borrow [[BBARG_BORROW]]
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_E_THIRD]]([[BBARG:%.*]] : @owned
+// CHECK:   [[FUNC:%.*]] = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
+// CHECK:   ([[FIRST:%.*]], [[SECOND:%.*]], [[THIRD:%.*]]) = destructure_struct [[BBARG]]
+// CHECK:   destroy_value [[THIRD]]
+// CHECK:   destroy_value [[FIRST]]
+// CHECK:   ([[SECOND_FIRST:%.*]], [[SECOND_SECOND:%.*]]) = destructure_struct [[SECOND]]
+// CHECK:   destroy_value [[SECOND_SECOND]]
+// CHECK:   apply [[FUNC]]([[SECOND_FIRST]])
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_E_FOURTH]]([[BBARG:%.*]] : @owned
+// CHECK:   destroy_value [[BBARG]]
+// CHECK:   br [[BB_CONT]]
+//
+// CHECK: [[BB_CONT]]:
+// CHECK:   destroy_value [[MARKED_VALUE]]
+// CHECK: } // end sil function 'switch_enum_with_destructure_recursive_3'
+sil [ossa] @switch_enum_with_destructure_recursive_3 : $@convention(thin) (@guaranteed E2) -> () {
+bb0(%0 : @guaranteed $E2):
+  %1 = copy_value %0 : $E2
+  %2 = mark_must_check [no_copy] %1 : $E2
+  %3 = begin_borrow %2 : $E2
+  switch_enum %3 : $E2, case #E2.lhs!enumelt: bbN1, case #E2.rhs!enumelt: bbN2
+
+bbN1(%lhs : @guaranteed $AggStruct2):
+  %lhs1 = begin_borrow %lhs : $AggStruct2
+  %lhsgep1 = struct_extract %lhs1 : $AggStruct2, #AggStruct2.pair
+  %lhsgep2 = struct_extract %lhsgep1 : $KlassPair2, #KlassPair2.lhs
+  %lhscopy = copy_value %lhsgep2 : $MoveOnlyKlass
+  %f1 = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
+  apply %f1(%lhscopy) : $@convention(thin) (@owned MoveOnlyKlass) -> ()
+  end_borrow %lhs1 : $AggStruct2
+  br bbCont
+
+bbN2(%rhs: @guaranteed $E):
+  switch_enum %rhs : $E, case #E.first!enumelt: bb1, case #E.second!enumelt: bb2, case #E.third!enumelt: bb3, case #E.fourth!enumelt: bb4
+
+bb1(%first : @guaranteed $MoveOnlyKlass):
+  br bbCont
+
+bb2(%second : @guaranteed $SingleIntContainingStruct):
+  %second1 = begin_borrow %second : $SingleIntContainingStruct
+  %secondGep1 = struct_extract %second1 : $SingleIntContainingStruct, #SingleIntContainingStruct.value
+  %f2 = function_ref @builtin32_use : $@convention(thin) (Builtin.Int32) -> ()
+  apply %f2(%secondGep1) : $@convention(thin) (Builtin.Int32) -> ()
+  end_borrow %second1 : $SingleIntContainingStruct
+  br bbCont
+
+bb3(%third : @guaranteed $AggStruct2):
+  %third1 = begin_borrow %third : $AggStruct2
+  %gep1 = struct_extract %third1 : $AggStruct2, #AggStruct2.pair
+  %gep2 = struct_extract %gep1 : $KlassPair2, #KlassPair2.lhs
+  %copy = copy_value %gep2 : $MoveOnlyKlass
+  %f = function_ref @moveonlyklass_consume : $@convention(thin) (@owned MoveOnlyKlass) -> ()
+  apply %f(%copy) : $@convention(thin) (@owned MoveOnlyKlass) -> ()
+  end_borrow %third1 : $AggStruct2
+  br bbCont
+
+bb4(%fourth: @guaranteed $Klass):
+  br bbCont
+
+bbCont:
+  end_borrow %3 : $E2
+  destroy_value %2 : $E2
+  %9999 = tuple()
+  return %9999 : $()
 }


### PR DESCRIPTION
Previously for move only types, SILGen would emit an owned switch_enum. This became an issue since for objects, SILGenPattern always attempts to push it towards borrowing, so eventually we would borrow which could have introduced an inadvertent copy along the decision tree before bindings are assigned.

This patch fixes this issue by doing the following:

1. Refactoring Borrow2Destructure so that it can be used for switch_enum arguments and what it already does.
2. Integrates Borrow2Destructure into the address checker so that when we switch_enum on loaded values, we do not run into this problem.
3. Moves the verification that we haven't introduced unfortunate copies from the object checker into the address checker and then moved the object checker before the address checker in the pipeline.
4. Added to the address checker validation that we never after it runs have load [copy]/copy_addr [!take] on move only types in addition to the copy_value change.
5. It splits out PrunedLiveBlocks and FieldSensitivePrunedLiveBlocks so that they use two different implementations. I tried to split this out of a larger patch in a different PR, but this patch began to rely on it so I moved it into this PR. I am going to close the other one.

