### PR TITLE
[IRGen] Lowered tuple_pack_element_addr.

### DIFF
--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -509,14 +509,12 @@ Address irgen::projectTupleElementAddressByDynamicIndex(IRGenFunction &IGF,
                                                         SILType tupleType,
                                                         llvm::Value *index,
                                                         SILType elementType) {
-  // TODO: retrieve type metadata (ForLayout) for the tuple type
-  // and retrieve the field offset for the given index.  Consider
-  // special-casing constant indices if we can reason statically
-  // about the prior elements.  It's probably not necessary to try
-  // to handle fixed-size tuples specially, because the optimizer
-  // should ideally be lowering this operation to something static
-  // in that case.
-  llvm_unreachable("unimplemented");
+  auto *metadata = IGF.emitTypeMetadataRefForLayout(tupleType);
+
+  llvm::Value *offset = loadTupleOffsetFromMetadata(IGF, metadata, index);
+  auto *gep =
+      IGF.emitByteOffsetGEP(tuple.getAddress(), offset, IGF.IGM.OpaqueTy);
+  return Address(gep, IGF.IGM.OpaqueTy, IGF.IGM.getPointerAlignment());
 }
 
 Optional<Size> irgen::getFixedTupleElementOffset(IRGenModule &IGM,

--- a/test/IRGen/variadic_generics.sil
+++ b/test/IRGen/variadic_generics.sil
@@ -106,3 +106,31 @@ bb0(%pack : $*Pack{Int, repeat each T, Int}, %value : $Int):
   %ret = tuple ()
   return %ret : $()
 }
+
+sil @borrow : $<T> (@in_guaranteed T) -> () {
+entry(%addr : $*T):
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: define {{.*}}@test_tuple_pack_element_addr_1(
+// CHECK-SAME:        {{.*}}* nocapture [[TUPLE_ADDR:%[^,]+]], i{{(64|32)}} [[INDEX:%[^,]+]]
+// CHECK:         [[RESPONSE:%[^,]+]] = call swiftcc %swift.metadata_response @swift_getTupleTypeMetadata
+// CHECK:         [[UNCAST_METADATA:%[^,]+]] = extractvalue %swift.metadata_response [[RESPONSE]], 0
+// CHECK:         [[METADATA:%[^,]+]] = bitcast %swift.type* [[UNCAST_METADATA]] to %swift.tuple_type*
+// CHECK:         [[OFFSET_PTR:%[^,]+]] = getelementptr inbounds %swift.tuple_type, %swift.tuple_type* [[METADATA]], i{{(64|32)}} 0, i32 3, i{{(64|32)}} [[INDEX]]
+// CHECK:         [[OFFSET:%[^,]+]] = load i32, i32* [[OFFSET_PTR]], align 8
+// CHECK:         [[CAST_TUPLE_ADDR:%[^,]+]] = bitcast <{ %TSS }>* [[TUPLE_ADDR]] to i8*
+// CHECK:         [[UNCAST_ELEMENT_ADDR:%[^,]+]] = getelementptr inbounds i8, i8* [[CAST_TUPLE_ADDR]], i32 [[OFFSET]]
+// CHECK:         [[ELEMENT_ADDR:%[^,]+]] = bitcast i8* [[UNCAST_ELEMENT_ADDR]] to %swift.opaque*
+// CHECK:         call swiftcc void @borrow(%swift.opaque* noalias nocapture [[ELEMENT_ADDR]], %swift.type* %"\CF\84_1_0")
+sil @test_tuple_pack_element_addr_1 :  $<T, U> (@inout (String, T, U, Int), Builtin.Word) -> () {
+bb0(%tuple : $*(String, T, U, Int), %i : $Builtin.Word):
+  %index = dynamic_pack_index %i of $Pack{Float, T, U, Float}
+  %0 = open_pack_element %index of <U_1...> at <Pack{String, T, U, Int}>, shape $U_1, uuid "01234567-89AB-CDEF-0123-000000000004"
+  %elt = tuple_pack_element_addr %index of %tuple : $*(String, T, U, Int) as $*@pack_element("01234567-89AB-CDEF-0123-000000000004") U_1
+  %blackhole = function_ref @borrow : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  apply %blackhole<(@pack_element("01234567-89AB-CDEF-0123-000000000004") U_1)>(%elt) : $@convention(thin) <T> (@in_guaranteed T) -> ()
+  %ret = tuple ()
+  return %ret : $()
+}


### PR DESCRIPTION
Generalized preexisting `loadTupleOffsetFromMetadata` function to take an `llvm::Value *` rather than an unsigned and used it to get the offset specified by the dynamic index.
