### PR TITLE
[Test] Increased timeout.

### DIFF
--- a/test/SILOptimizer/closure_specialize_loop.swift
+++ b/test/SILOptimizer/closure_specialize_loop.swift
@@ -1,4 +1,4 @@
-// RUN: %{python} %S/../Inputs/timeout.py 10 %target-swift-frontend -O -parse-as-library %s -emit-sil | %FileCheck %s
+// RUN: %{python} %S/../Inputs/timeout.py 100 %target-swift-frontend -O -parse-as-library %s -emit-sil | %FileCheck %s
 
 public func callit() {
     testit { false }


### PR DESCRIPTION
On some slower nodes, the timeout is too low.  Since the test just verifies that optimization doesn't run forever, increasing the timeout is consistent with the spirit of the test

rdar://105151757
