### PR TITLE
Record original source range of generated source buffers into dumped files

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -129,6 +129,7 @@ public:
   SourceManager(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS =
                     llvm::vfs::getRealFileSystem())
     : FileSystem(FS) {}
+  ~SourceManager();
 
   llvm::SourceMgr &getLLVMSourceMgr() {
     return LLVMSourceMgr;


### PR DESCRIPTION
This helps us establish where the code from a generated source buffer would go, for external tools that don't understand serialized diagnostics.
