### PR TITLE
[IRGen] Don't fetch dynamic self metadata for ObjC types

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2236,9 +2236,12 @@ static void emitDynamicSelfMetadata(IRGenSILFunction &IGF) {
 
   // Specify the exact Self type if we know it, either because the class
   // is final, or because the function we're emitting is a method with the
-  // [exact_self_class] attribute set on it during the SIL pipeline.
-  bool isExact = selfTy->getClassOrBoundGenericClass()->isFinal()
-    || IGF.CurSILFn->isExactSelfClass();
+  // [exact_self_class] attribute set on it during the SIL pipeline. Dynamic
+  // self metadata of a type exposed to ObjC might be changed through
+  // runtime; therefore, it can't be exact.
+  bool isExact = (selfTy->getClassOrBoundGenericClass()->isFinal() &&
+                  !selfTy->getClassOrBoundGenericClass()->isObjC()) ||
+                 IGF.CurSILFn->isExactSelfClass();
 
   IGF.setDynamicSelfMetadata(selfTy, isExact, value, selfKind);
 }

--- a/test/IRGen/objc_metadata.swift
+++ b/test/IRGen/objc_metadata.swift
@@ -1,0 +1,24 @@
+// RUN: %target-swift-frontend -module-name main -emit-ir %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+@_silgen_name("useMetadata")
+func useMetadata<T>(_: T.Type)
+
+private final class Final: NSObject {
+    @objc dynamic func foo() {
+        // CHECK: call swiftcc %swift.metadata_response @"$s4main5Final
+        useMetadata(Final.self)
+    }
+}
+
+private class NotFinal: NSObject {
+    @objc dynamic func foo() {
+        // CHECK: call swiftcc %swift.metadata_response @"$s4main8NotFinal
+        useMetadata(NotFinal.self)
+    }
+}
+
+// CHECK-NOT: %.Type = call %swift.type* @swift_getObjectType


### PR DESCRIPTION
Adding a `final` modifier to an `NSObject` subclass causes references to the self type to be fetched through `getObjectType`. The result is weirdness in the following example:

```swift
import Foundation

class A: NSObject {
    @objc dynamic func foo() {
    }
}

// Uncomment to get "Called in A" instead of "Called in B"
// final
class B: NSObject {
    @objc dynamic func swizzled_foo() {
        print("Called in \(B.self)")
    }
}

method_exchangeImplementations(
    class_getInstanceMethod(A.self, #selector(A.foo))!,
    class_getInstanceMethod(B.self, #selector(B.swizzled_foo))!
)

A().foo()
```

In Swift 5.1.3, whether `B` was final or not, the output was `Called in B`, but since then, it has been `Called in B` and `Called in A` dependent on whether `B` is final.

I believe the behaviour was changed by #26571.

This PR causes the output to be `Called in B` regardless of the final modifier. Fixes #55178.
