### PR TITLE
Fix Issue #63291 by aligning error messages for failure to infer generic parameter and opaque result type.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3918,7 +3918,7 @@ ERROR(unresolved_member_no_inference,none,
 ERROR(cannot_infer_base_of_unresolved_member,none,
       "cannot infer contextual base in reference to member %0", (DeclNameRef))
 ERROR(cannot_infer_underlying_for_opaque_result,none,
-      "cannot infer underlying type for opaque result %0 from return expression",
+      "underlying type for opaque result type %0 could not be inferred from return expression",
       (Type))
 ERROR(unresolved_nil_literal,none,
       "'nil' requires a contextual type", ())

--- a/test/type/opaque.swift
+++ b/test/type/opaque.swift
@@ -581,12 +581,12 @@ do {
 
 // https://github.com/apple/swift/issues/62787
 func f62787() -> Optional<some Collection<Int>> {
-  return nil // expected-error{{cannot infer underlying type for opaque result 'Optional<some Collection<Int>>' from return expression}}
+  return nil // expected-error{{underlying type for opaque result type 'Optional<some Collection<Int>>' could not be inferred from return expression}}
 }
 
 func f62787_1(x: Bool) -> Optional<some Collection<Int>> {
   if x {
-    return nil // expected-error{{cannot infer underlying type for opaque result 'Optional<some Collection<Int>>' from return expression}}
+    return nil // expected-error{{underlying type for opaque result type 'Optional<some Collection<Int>>' could not be inferred from return expression}}
   } 
-  return nil // expected-error{{cannot infer underlying type for opaque result 'Optional<some Collection<Int>>' from return expression}}
+  return nil // expected-error{{underlying type for opaque result type 'Optional<some Collection<Int>>' could not be inferred from return expression}}
 }

--- a/test/type/opaque_return_named.swift
+++ b/test/type/opaque_return_named.swift
@@ -3,11 +3,11 @@
 // Tests for experimental extensions to opaque return type support.
 
 func f0() -> <T> T { return () }
-func f1() -> <T, U, V> T { () } // expected-error{{cannot infer underlying type for opaque result 'T' from return expression}}
+func f1() -> <T, U, V> T { () } // expected-error{{underlying type for opaque result type 'T' could not be inferred from return expression}}
 func f2() -> <T: Collection, U: SignedInteger> T { // expected-note{{required by opaque return type of global function 'f2()'}}
   () // expected-error{{type '()' cannot conform to 'Collection'}}
   // expected-note@-1{{only concrete types such as structs, enums and classes can conform to protocols}}
-  // expected-error@-2{{cannot infer underlying type for opaque result 'T' from return expression}}
+  // expected-error@-2{{underlying type for opaque result type 'T' could not be inferred from return expression}}
 }
 
 func f4() async -> <T> T { () }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Aligned the errors messages caused by failure to inferring generic parameter and opaque result type, by changing the messages appropriately in the `include/swift/AST/DiagnosticsSema.def` file, as well as the tests file `test/type/opaque.swift` and `test/type/opaque_return_named.swift`.

Resolves #63291.