### PR TITLE
[NameLookup] Type Aliases should resolve as opaque

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2791,7 +2791,15 @@ static bool declsAreAssociatedTypes(ArrayRef<TypeDecl *> decls) {
 static bool declsAreProtocols(ArrayRef<TypeDecl *> decls) {
   if (decls.empty())
     return false;
-  return llvm::any_of(decls, [&](const TypeDecl *decl) { return isa<ProtocolDecl>(decl); });;;
+  return llvm::any_of(decls, [&](const TypeDecl *decl) {
+    if (auto *alias = dyn_cast<TypeAliasDecl>(decl)) {
+      auto ty = alias->getUnderlyingType();
+      decl = ty->getNominalOrBoundGenericNominal();
+      if (decl == nullptr || ty->is<ExistentialType>())
+        return false;
+    }
+    return isa<ProtocolDecl>(decl);
+  });;;
 }
 
 bool TypeRepr::isProtocol(DeclContext *dc){
@@ -2800,7 +2808,6 @@ bool TypeRepr::isProtocol(DeclContext *dc){
     return declsAreProtocols(directReferencesForTypeRepr(ctx.evaluator, ctx, ty, dc));
   });
 }
-
 
 static GenericParamList *
 createExtensionGenericParams(ASTContext &ctx,

--- a/test/type/implicit_some/explicit_existential.swift
+++ b/test/type/implicit_some/explicit_existential.swift
@@ -208,10 +208,6 @@ protocol Output {
   associatedtype A
 }
 
-
-
-// NOT SURE IF THIS WILL WORK
-
 // ImplicitSome feature always expects explicit 'any' and plain protocols now imply 'some'
 // Verify existential_requires_any error is no longer produced
 typealias OpaqueFunction = (Input) -> Output

--- a/test/type/implicit_some/opaque_return.swift
+++ b/test/type/implicit_some/opaque_return.swift
@@ -73,8 +73,8 @@ func inspect( _ snack: some Snack) -> some Snack {
 // tuple type alias
 func highestRated() -> (some Snack, some Snack) { } // expected-error {{function declares an opaque return type, but has no return statements in its body from which to infer an underlying type}}
 
-// TO-DO: Fix type alias for plain protocols; resolves as an existential type
-func list(_: (Meal, Meal)) -> (Meal, Meal){ }
+func list(_: (Meal, Meal)) -> (Meal, Meal){ } // expected-error {{function declares an opaque return type, but has no return statements in its body from which to infer an underlying type}}
+
 func find() -> Snack { }
 
 // opaque compostion types


### PR DESCRIPTION
Type aliases for plain protocols should resolve as opaque types with implicit some feature flag

Fixes rdar://101403690

