### PR TITLE
DiagnosticVerifier: Implement defaulting behavior for lines in expected fix-it replacement range

### DIFF
--- a/include/swift/Frontend/DiagnosticVerifier.h
+++ b/include/swift/Frontend/DiagnosticVerifier.h
@@ -38,14 +38,10 @@ struct ExpectedFixIt;
 
 /// A range expressed in terms of line-and-column pairs.
 struct LineColumnRange {
-  static constexpr unsigned NoValue = ~0u;
-
   unsigned StartLine, StartCol;
   unsigned EndLine, EndCol;
 
-  LineColumnRange()
-      : StartLine(NoValue), StartCol(NoValue), EndLine(NoValue),
-        EndCol(NoValue) {}
+  LineColumnRange() : StartLine(0), StartCol(0), EndLine(0), EndCol(0) {}
 };
 
 class CapturedFixItInfo final {
@@ -63,9 +59,7 @@ public:
   /// Obtain the line-column range corresponding to the fix-it's
   /// replacement range.
   const LineColumnRange &getLineColumnRange(const SourceManager &SM,
-                                            unsigned BufferID,
-                                            bool ComputeStartLocLine,
-                                            bool ComputeEndLocLine) const;
+                                            unsigned BufferID) const;
 };
 
 struct CapturedDiagnosticInfo {

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -461,6 +461,8 @@ static Optional<LineColumnRange> parseExpectedFixItRange(
 
   if (const auto lineAndCol = parseLineAndColumn()) {
     std::tie(Range.EndLine, Range.EndCol) = lineAndCol.value();
+    if (Range.EndLine == LineColumnRange::NoValue)
+      Range.EndLine = Range.StartLine;
   } else {
     return None;
   }

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -447,6 +447,8 @@ static Optional<LineColumnRange> parseExpectedFixItRange(
 
   if (const auto lineAndCol = parseLineAndColumn()) {
     std::tie(Range.StartLine, Range.StartCol) = lineAndCol.value();
+    if (Range.StartLine == LineColumnRange::NoValue)
+      Range.StartLine = DiagnosticLineNo;
   } else {
     return None;
   }

--- a/lib/Frontend/DiagnosticVerifier.cpp
+++ b/lib/Frontend/DiagnosticVerifier.cpp
@@ -35,30 +35,20 @@ struct ExpectedFixIt {
 };
 } // end namespace swift
 
-constexpr unsigned LineColumnRange::NoValue;
-
 const LineColumnRange &
 CapturedFixItInfo::getLineColumnRange(const SourceManager &SM,
-                                      unsigned BufferID,
-                                      bool ComputeStartLocLine,
-                                      bool ComputeEndLocLine) const {
-  if (LineColRange.StartLine == LineColumnRange::NoValue &&
-      ComputeStartLocLine) {
-    std::tie(LineColRange.StartLine, LineColRange.StartCol) =
-        SM.getPresumedLineAndColumnForLoc(getSourceRange().getStart(),
-                                          BufferID);
-  } else if (LineColRange.StartCol == LineColumnRange::NoValue) {
-    LineColRange.StartCol =
-        SM.getColumnInBuffer(getSourceRange().getStart(), BufferID);
+                                      unsigned BufferID) const {
+  if (LineColRange.StartLine != 0) {
+    // Already computed.
+    return LineColRange;
   }
 
-  if (LineColRange.EndLine == LineColumnRange::NoValue && ComputeEndLocLine) {
-    std::tie(LineColRange.EndLine, LineColRange.EndCol) =
-        SM.getPresumedLineAndColumnForLoc(FixIt.getRange().getEnd(), BufferID);
-  } else if (LineColRange.EndCol == LineColumnRange::NoValue) {
-    LineColRange.EndCol =
-        SM.getColumnInBuffer(getSourceRange().getEnd(), BufferID);
-  }
+  auto SrcRange = FixIt.getRange();
+
+  std::tie(LineColRange.StartLine, LineColRange.StartCol) =
+      SM.getPresumedLineAndColumnForLoc(SrcRange.getStart(), BufferID);
+  std::tie(LineColRange.EndLine, LineColRange.EndCol) =
+      SM.getPresumedLineAndColumnForLoc(SrcRange.getEnd(), BufferID);
 
   return LineColRange;
 }
@@ -293,23 +283,11 @@ bool DiagnosticVerifier::checkForFixIt(
       if (ActualFixIt.getText() != Expected.Text)
         continue;
 
-      LineColumnRange ActualRange = ActualFixIt.getLineColumnRange(
-          SM, BufferID,
-          // Don't compute line numbers unless we have to.
-          /*ComputeStartLocLine=*/Expected.Range.StartLine !=
-              LineColumnRange::NoValue,
-          /*ComputeEndLocLine=*/Expected.Range.EndLine !=
-              LineColumnRange::NoValue);
+      auto &ActualRange = ActualFixIt.getLineColumnRange(SM, BufferID);
 
       if (Expected.Range.StartCol != ActualRange.StartCol ||
-          Expected.Range.EndCol != ActualRange.EndCol) {
-        continue;
-      }
-      if (Expected.Range.StartLine != LineColumnRange::NoValue &&
-          Expected.Range.StartLine != ActualRange.StartLine) {
-        continue;
-      }
-      if (Expected.Range.EndLine != LineColumnRange::NoValue &&
+          Expected.Range.EndCol != ActualRange.EndCol ||
+          Expected.Range.StartLine != ActualRange.StartLine ||
           Expected.Range.EndLine != ActualRange.EndLine) {
         continue;
       }
@@ -329,10 +307,7 @@ DiagnosticVerifier::renderFixits(ArrayRef<CapturedFixItInfo> ActualFixIts,
   interleave(
       ActualFixIts,
       [&](const CapturedFixItInfo &ActualFixIt) {
-        LineColumnRange ActualRange =
-            ActualFixIt.getLineColumnRange(SM, BufferID,
-                                           /*ComputeStartLocLine=*/true,
-                                           /*ComputeEndLocLine=*/true);
+        auto &ActualRange = ActualFixIt.getLineColumnRange(SM, BufferID);
         OS << "{{";
 
         if (ActualRange.StartLine != DiagnosticLineNo)
@@ -372,19 +347,23 @@ static Optional<LineColumnRange> parseExpectedFixItRange(
     llvm::function_ref<void(const char *, const Twine &)> diagnoseError) {
   assert(!Str.empty());
 
-  const auto parseLineAndColumn =
-      [&]() -> Optional<std::pair<unsigned, unsigned>> {
-    enum class LineOffsetKind : uint8_t { None, Plus, Minus };
+  struct ParsedLineAndColumn {
+    Optional<unsigned> Line;
+    unsigned Column;
+  };
 
-    LineOffsetKind lineOffsetKind = LineOffsetKind::None;
+  const auto parseLineAndColumn = [&]() -> Optional<ParsedLineAndColumn> {
+    enum class OffsetKind : uint8_t { None, Plus, Minus };
+
+    OffsetKind LineOffsetKind = OffsetKind::None;
     if (!Str.empty()) {
       switch (Str.front()) {
       case '+':
-        lineOffsetKind = LineOffsetKind::Plus;
+        LineOffsetKind = OffsetKind::Plus;
         Str = Str.drop_front();
         break;
       case '-':
-        lineOffsetKind = LineOffsetKind::Minus;
+        LineOffsetKind = OffsetKind::Minus;
         Str = Str.drop_front();
         break;
       default:
@@ -392,63 +371,61 @@ static Optional<LineColumnRange> parseExpectedFixItRange(
       }
     }
 
-    unsigned firstNumber = LineColumnRange::NoValue;
-    if (Str.consumeInteger(10, firstNumber)) {
-      if (lineOffsetKind > LineOffsetKind::None) {
+    unsigned FirstVal = 0;
+    if (Str.consumeInteger(10, FirstVal)) {
+      if (LineOffsetKind == OffsetKind::None) {
+        diagnoseError(Str.data(),
+                      "expected line or column number in fix-it verification");
+      } else {
         diagnoseError(Str.data(),
                       "expected line offset after leading '+' or '-' in fix-it "
                       "verification");
-      } else {
-        diagnoseError(Str.data(),
-                      "expected line or column number in fix-it verification");
       }
       return None;
     }
 
-    unsigned secondNumber = LineColumnRange::NoValue;
-    if (!Str.empty() && Str.front() == ':') {
-      Str = Str.drop_front();
-
-      if (Str.consumeInteger(10, secondNumber)) {
-        diagnoseError(
-            Str.data(),
-            "expected column number after ':' in fix-it verification");
-        return None;
+    // If the first value is not followed by a colon, it is either a column or a
+    // line offset that is missing a column.
+    if (Str.empty() || Str.front() != ':') {
+      if (LineOffsetKind == OffsetKind::None) {
+        return ParsedLineAndColumn{None, FirstVal};
       }
-    } else if (lineOffsetKind > LineOffsetKind::None) {
+
       diagnoseError(Str.data(),
                     "expected colon-separated column number after line offset "
                     "in fix-it verification");
       return None;
     }
 
-    if (secondNumber == LineColumnRange::NoValue) {
-      // If only one value is specified, it's a column number;
-      return std::make_pair(LineColumnRange::NoValue, firstNumber);
+    unsigned Column = 0;
+    Str = Str.drop_front();
+    if (Str.consumeInteger(10, Column)) {
+      diagnoseError(Str.data(),
+                    "expected column number after ':' in fix-it verification");
+      return None;
     }
 
-    unsigned lineNo = DiagnosticLineNo;
-    switch (lineOffsetKind) {
-    case LineOffsetKind::None:
-      lineNo = firstNumber;
+    // Apply the offset relative to the line of the expected diagnostic.
+    switch (LineOffsetKind) {
+    case OffsetKind::None:
       break;
-    case LineOffsetKind::Plus:
-      lineNo += firstNumber;
+    case OffsetKind::Plus:
+      FirstVal += DiagnosticLineNo;
       break;
-    case LineOffsetKind::Minus:
-      lineNo -= firstNumber;
+    case OffsetKind::Minus:
+      FirstVal = DiagnosticLineNo - FirstVal;
       break;
     }
 
-    return std::make_pair(lineNo, secondNumber);
+    return ParsedLineAndColumn{FirstVal, Column};
   };
 
   LineColumnRange Range;
 
-  if (const auto lineAndCol = parseLineAndColumn()) {
-    std::tie(Range.StartLine, Range.StartCol) = lineAndCol.value();
-    if (Range.StartLine == LineColumnRange::NoValue)
-      Range.StartLine = DiagnosticLineNo;
+  if (const auto LineAndCol = parseLineAndColumn()) {
+    // The start line defaults to the line of the expected diagnostic.
+    Range.StartLine = LineAndCol->Line.value_or(DiagnosticLineNo);
+    Range.StartCol = LineAndCol->Column;
   } else {
     return None;
   }
@@ -461,10 +438,10 @@ static Optional<LineColumnRange> parseExpectedFixItRange(
     return None;
   }
 
-  if (const auto lineAndCol = parseLineAndColumn()) {
-    std::tie(Range.EndLine, Range.EndCol) = lineAndCol.value();
-    if (Range.EndLine == LineColumnRange::NoValue)
-      Range.EndLine = Range.StartLine;
+  if (const auto LineAndCol = parseLineAndColumn()) {
+    // The end line defaults to the start line.
+    Range.EndLine = LineAndCol->Line.value_or(Range.StartLine);
+    Range.EndCol = LineAndCol->Column;
   } else {
     return None;
   }

--- a/test/AutoDiff/SILOptimizer/differentiation_control_flow_diagnostics.swift
+++ b/test/AutoDiff/SILOptimizer/differentiation_control_flow_diagnostics.swift
@@ -168,9 +168,9 @@ enum Tree : Differentiable & AdditiveArithmetic {
 // (`Collection.makeIterator` and `IteratorProtocol.next`).
 // expected-error @+1 {{function is not differentiable}}
 @differentiable(reverse)
-// expected-note @+1 {{when differentiating this function definition}}
+// expected-note @+2 {{when differentiating this function definition}}
+// expected-note @+1 {{cannot differentiate through a non-differentiable result; do you want to use 'withoutDerivative(at:)'?}} {{+2:12-12=withoutDerivative(at: }} {{+2:17-17=)}}
 func loop_array(_ array: [Float]) -> Float {
-// expected-note @-1 {{cannot differentiate through a non-differentiable result; do you want to use 'withoutDerivative(at:)'?}} {{12-12=withoutDerivative(at: }} {{17-17=)}}
   var result: Float = 1
   for x in array {
     result = result * x

--- a/test/AutoDiff/Sema/derivative_attr_type_checking.swift
+++ b/test/AutoDiff/Sema/derivative_attr_type_checking.swift
@@ -1105,16 +1105,16 @@ fileprivate func _private_original_fileprivate_derivative(_ x: Float) -> (value:
 public func public_original_private_derivative(_ x: Float) -> Float { x }
 // expected-error @+1 {{derivative function must have same access level as original function; derivative function '_public_original_private_derivative' is fileprivate, but original function 'public_original_private_derivative' is public}}
 @derivative(of: public_original_private_derivative)
-// expected-note @+1 {{mark the derivative function as '@usableFromInline' to match the original function}} {{1-1=@usableFromInline }}
 fileprivate func _public_original_private_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+// expected-note @-1 {{mark the derivative function as '@usableFromInline' to match the original function}} {{-1:1-1=@usableFromInline }}
   fatalError()
 }
 
 public func public_original_internal_derivative(_ x: Float) -> Float { x }
 // expected-error @+1 {{derivative function must have same access level as original function; derivative function '_public_original_internal_derivative' is internal, but original function 'public_original_internal_derivative' is public}}
 @derivative(of: public_original_internal_derivative)
-// expected-note @+1 {{mark the derivative function as '@usableFromInline' to match the original function}} {{1-1=@usableFromInline }}
 func _public_original_internal_derivative(_ x: Float) -> (value: Float, pullback: (Float) -> Float) {
+// expected-note @-1 {{mark the derivative function as '@usableFromInline' to match the original function}} {{-1:1-1=@usableFromInline }}
   fatalError()
 }
 

--- a/test/Concurrency/async_initializer.swift
+++ b/test/Concurrency/async_initializer.swift
@@ -139,10 +139,6 @@ protocol AsyncDefaultConstructable {
   init() async
 }
 
-protocol DefaultConstructable {
-  init() // expected-note {{protocol requires initializer 'init()' with type '()'; do you want to add a stub?}} {{43-43=\n    init() {\n        <#code#>\n    \}\n}}
-}
-
 struct Location {
   var x : Int
   var y : Int
@@ -152,6 +148,9 @@ struct Location {
   }
 }
 
+protocol DefaultConstructable {
+  init() // expected-note {{protocol requires initializer 'init()' with type '()'; do you want to add a stub?}} {{+2:43-43=\n    init() {\n        <#code#>\n    \}\n}}
+}
 extension Location: DefaultConstructable {} // expected-error {{type 'Location' does not conform to protocol 'DefaultConstructable'}}
 
 extension Location: AsyncDefaultConstructable {}

--- a/test/Concurrency/require-explicit-sendable.swift
+++ b/test/Concurrency/require-explicit-sendable.swift
@@ -2,41 +2,41 @@
 
 public protocol P { }
 
+// expected-note@+2{{consider making struct 'S1' conform to the 'Sendable' protocol}}{{18-18=: Sendable}}
+// expected-note@+1{{make struct 'S1' explicitly non-Sendable to suppress this warning}}{{+2:2-2=\n\n@available(*, unavailable)\nextension S1: Sendable { \}\n}}
 public struct S1 { // expected-warning{{public struct 'S1' does not specify whether it is 'Sendable' or not}}
-  // expected-note@-1{{consider making struct 'S1' conform to the 'Sendable' protocol}}{{18-18=: Sendable}}
-  // expected-note@-2{{make struct 'S1' explicitly non-Sendable to suppress this warning}}{{2-2=\n\n@available(*, unavailable)\nextension S1: Sendable { \}\n}}
   var str: String
 }
 
 class C { }
 
+// expected-note@+2{{add '@unchecked Sendable' conformance to struct 'S2' if this type manually implements concurrency safety}}{{18-18=: @unchecked Sendable}}
+// expected-note@+1{{make struct 'S2' explicitly non-Sendable to suppress this warning}}{{+2:2-2=\n\n@available(*, unavailable)\nextension S2: Sendable { \}\n}}
 public struct S2 { // expected-warning{{public struct 'S2' does not specify whether it is 'Sendable' or not}}
-  // expected-note@-1{{add '@unchecked Sendable' conformance to struct 'S2' if this type manually implements concurrency safety}}{{18-18=: @unchecked Sendable}}
-  // expected-note@-2{{make struct 'S2' explicitly non-Sendable to suppress this warning}}{{2-2=\n\n@available(*, unavailable)\nextension S2: Sendable { \}\n}}
   var c: C
 }
 
+// expected-note@+2{{consider making class 'C1' conform to the 'Sendable' protocol}}{{25-25=, Sendable}}
+// expected-note@+1{{make class 'C1' explicitly non-Sendable to suppress this warning}}{{+2:2-2=\n\n@available(*, unavailable)\nextension C1: Sendable { \}\n}}
 final public class C1: P { // expected-warning{{public class 'C1' does not specify whether it is 'Sendable' or not}}
-  // expected-note@-1{{consider making class 'C1' conform to the 'Sendable' protocol}}{{25-25=, Sendable}}
-  // expected-note@-2{{make class 'C1' explicitly non-Sendable to suppress this warning}}{{2-2=\n\n@available(*, unavailable)\nextension C1: Sendable { \}\n}}
   let str: String = ""
 }
 
+// expected-note@+2{{add '@unchecked Sendable' conformance to class 'C2' if this type manually implements concurrency safety}}{{17-17=: @unchecked Sendable}}
+// expected-note@+1{{make class 'C2' explicitly non-Sendable to suppress this warning}}{{+2:2-2=\n\n@available(*, unavailable)\nextension C2: Sendable { \}\n}}
 public class C2 { // expected-warning{{public class 'C2' does not specify whether it is 'Sendable' or not}}
-  // expected-note@-1{{add '@unchecked Sendable' conformance to class 'C2' if this type manually implements concurrency safety}}{{17-17=: @unchecked Sendable}}
-  // expected-note@-2{{make class 'C2' explicitly non-Sendable to suppress this warning}}{{2-2=\n\n@available(*, unavailable)\nextension C2: Sendable { \}\n}}
   var str: String = ""
 }
 
+// expected-note@+2{{consider making generic struct 'S3' conform to the 'Sendable' protocol}}{{+2:2-2=\n\nextension S3: Sendable where T: Sendable { \}\n}}
+// expected-note@+1{{make generic struct 'S3' explicitly non-Sendable to suppress this warning}}{{+2:2-2=\n\n@available(*, unavailable)\nextension S3: Sendable { \}\n}}
 public struct S3<T> { // expected-warning{{public generic struct 'S3' does not specify whether it is 'Sendable' or not}}
-  // expected-note@-1{{consider making generic struct 'S3' conform to the 'Sendable' protocol}}{{2-2=\n\nextension S3: Sendable where T: Sendable { \}\n}}
-  // expected-note@-2{{make generic struct 'S3' explicitly non-Sendable to suppress this warning}}{{2-2=\n\n@available(*, unavailable)\nextension S3: Sendable { \}\n}}
   var t: T
 }
 
+// expected-note@+2{{add '@unchecked Sendable' conformance to generic struct 'S4' if this type manually implements concurrency safety}}{{+3:2-2=\n\nextension S4: @unchecked Sendable where T: Sendable { \}\n}}
+// expected-note@+1{{make generic struct 'S4' explicitly non-Sendable to suppress this warning}}{{+3:2-2=\n\n@available(*, unavailable)\nextension S4: Sendable { \}\n}}
 public struct S4<T> { // expected-warning{{public generic struct 'S4' does not specify whether it is 'Sendable' or not}}
-  // expected-note@-1{{add '@unchecked Sendable' conformance to generic struct 'S4' if this type manually implements concurrency safety}}{{2-2=\n\nextension S4: @unchecked Sendable where T: Sendable { \}\n}}
-  // expected-note@-2{{make generic struct 'S4' explicitly non-Sendable to suppress this warning}}{{2-2=\n\n@available(*, unavailable)\nextension S4: Sendable { \}\n}}
   var t: T
   var c: C
 }
@@ -71,9 +71,9 @@ func testMe(s5: S5, s7: S7) {
   acceptSendable(s7) // expected-warning{{conformance of 'S7' to 'Sendable' is unavailable}}
 }
 
+// expected-note@+2{{consider making generic struct 'S8' conform to the 'Sendable' protocol}}{{+2:2-2=\n\nextension S8: Sendable where T: Sendable, U: Sendable, V: Sendable { \}\n}}
+// expected-note@+1{{make generic struct 'S8' explicitly non-Sendable to suppress this warning}}
 public struct S8<T: Hashable, U, V> { // expected-warning{{public generic struct 'S8' does not specify whether it is 'Sendable' or not}}
-  // expected-note@-1{{consider making generic struct 'S8' conform to the 'Sendable' protocol}}{{2-2=\n\nextension S8: Sendable where T: Sendable, U: Sendable, V: Sendable { \}\n}}
-  // expected-note@-2{{make generic struct 'S8' explicitly non-Sendable to suppress this warning}}
   var member: [T: (U, V?)]
 }
 
@@ -81,10 +81,10 @@ public protocol P2 {
   associatedtype A
 }
 
+// expected-warning@+3{{public generic struct 'S9' does not specify whether it is 'Sendable' or not}}
+// expected-note@+2{{consider making generic struct 'S9' conform to the 'Sendable' protocol}}{{+2:2-2=\n\nextension S9: Sendable where T: Sendable, T.A: Sendable { \}\n}}
+// expected-note@+1{{make generic struct 'S9' explicitly non-Sendable to suppress this warning}}
 public struct S9<T: P2 & Hashable> {
-  // expected-warning@-1{{public generic struct 'S9' does not specify whether it is 'Sendable' or not}}
-  // expected-note@-2{{consider making generic struct 'S9' conform to the 'Sendable' protocol}}{{2-2=\n\nextension S9: Sendable where T: Sendable, T.A: Sendable { \}\n}}
-  // expected-note@-3{{make generic struct 'S9' explicitly non-Sendable to suppress this warning}}
   var dict: [T : T.A] = [:]
 }
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1217,24 +1217,24 @@ takesTuple(true) // expected-error {{cannot convert value of type 'Bool' to expe
 func voidFunc() {
   return 1 
   // expected-error@-1 {{unexpected non-void return value in void function}}
-  // expected-note@-2 {{did you mean to add a return type?}}{{16-16= -> <#Return Type#>}}
+  // expected-note@-2 {{did you mean to add a return type?}}{{-1:16-16= -> <#Return Type#>}}
 }
 
 func voidFuncWithArgs(arg1: Int) {
   return 1 
   // expected-error@-1 {{unexpected non-void return value in void function}}
-  // expected-note@-2 {{did you mean to add a return type?}}{{33-33= -> <#Return Type#>}}
+  // expected-note@-2 {{did you mean to add a return type?}}{{-1:33-33= -> <#Return Type#>}}
 }
 
 func voidFuncWithCondFlow() {
   if Bool.random() {
     return 1
     // expected-error@-1 {{unexpected non-void return value in void function}}
-    // expected-note@-2 {{did you mean to add a return type?}}{{28-28= -> <#Return Type#>}}
+    // expected-note@-2 {{did you mean to add a return type?}}{{-2:28-28= -> <#Return Type#>}}
   } else {
     return 2
     // expected-error@-1 {{unexpected non-void return value in void function}}
-    // expected-note@-2 {{did you mean to add a return type?}}{{28-28= -> <#Return Type#>}}
+    // expected-note@-2 {{did you mean to add a return type?}}{{-6:28-28= -> <#Return Type#>}}
   }
 }
 
@@ -1242,21 +1242,21 @@ func voidFuncWithNestedVoidFunc() {
   func nestedVoidFunc() {
     return 1
     // expected-error@-1 {{unexpected non-void return value in void function}}
-    // expected-note@-2 {{did you mean to add a return type?}}{{24-24= -> <#Return Type#>}}
+    // expected-note@-2 {{did you mean to add a return type?}}{{-1:24-24= -> <#Return Type#>}}
   }
 }
 
 func voidFuncWithEffects1() throws {
   return 1
   // expected-error@-1 {{unexpected non-void return value in void function}}
-  // expected-note@-2 {{did you mean to add a return type?}}{{35-35= -> <#Return Type#>}}
+  // expected-note@-2 {{did you mean to add a return type?}}{{-1:35-35= -> <#Return Type#>}}
 }
 
 @available(SwiftStdlib 5.5, *)
 func voidFuncWithEffects2() async throws {
   return 1
   // expected-error@-1 {{unexpected non-void return value in void function}}
-  // expected-note@-2 {{did you mean to add a return type?}}{{41-41= -> <#Return Type#>}}
+  // expected-note@-2 {{did you mean to add a return type?}}{{-1:41-41= -> <#Return Type#>}}
 }
 
 @available(SwiftStdlib 5.5, *)
@@ -1264,27 +1264,27 @@ func voidFuncWithEffects2() async throws {
 func voidFuncWithEffects3() throws async {
   return 1
   // expected-error@-1 {{unexpected non-void return value in void function}}
-  // expected-note@-2 {{did you mean to add a return type?}}{{41-41= -> <#Return Type#>}}
+  // expected-note@-2 {{did you mean to add a return type?}}{{-1:41-41= -> <#Return Type#>}}
 }
 
 @available(SwiftStdlib 5.5, *)
 func voidFuncWithEffects4() async {
   return 1
   // expected-error@-1 {{unexpected non-void return value in void function}}
-  // expected-note@-2 {{did you mean to add a return type?}}{{34-34= -> <#Return Type#>}}
+  // expected-note@-2 {{did you mean to add a return type?}}{{-1:34-34= -> <#Return Type#>}}
 }
 
 func voidFuncWithEffects5(_ closure: () throws -> Void) rethrows {
   return 1
   // expected-error@-1 {{unexpected non-void return value in void function}}
-  // expected-note@-2 {{did you mean to add a return type?}}{{65-65= -> <#Return Type#>}}
+  // expected-note@-2 {{did you mean to add a return type?}}{{-1:65-65= -> <#Return Type#>}}
 }
 
 @available(SwiftStdlib 5.5, *)
 func voidGenericFuncWithEffects<T>(arg: T) async where T: CustomStringConvertible {
   return 1
   // expected-error@-1 {{unexpected non-void return value in void function}}
-  // expected-note@-2 {{did you mean to add a return type?}}{{49-49= -> <#Return Type#>}}
+  // expected-note@-2 {{did you mean to add a return type?}}{{-1:49-49= -> <#Return Type#>}}
 }
 
 // Special cases: These should not offer a note + fix-it

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -299,8 +299,8 @@ struct MyTuplifiedStruct {
 
   @TupleBuilder var computed: some Any { // expected-note{{remove the attribute to explicitly disable the result builder}}{{3-17=}}
     if condition {
+      // expected-note@+1 {{remove 'return' statements to apply the result builder}}{{7-14=}}{{+2:12-19=}}
       return 17 // expected-warning{{application of result builder 'TupleBuilder' disabled by explicit 'return' statement}}
-      // expected-note@-1{{remove 'return' statements to apply the result builder}}{{7-14=}}{{12-19=}}
     } else {
            return 42
     }

--- a/test/Constraints/result_builder_infer.swift
+++ b/test/Constraints/result_builder_infer.swift
@@ -152,11 +152,11 @@ struct AmbigTupleMe: Tupled, OtherTupled {
   var condition: Bool
 
   // Ambiguous
+  // expected-note@+4{{add an explicit 'return' statement to not use a result builder}}{{+3:3-3=return <#expr#>\n}}
+  // expected-note@+3{{apply result builder 'TupleBuilder' (inferred from protocol 'Tupled')}}{{-1:3-3=@TupleBuilder }}
+  // expected-note@+2{{apply result builder 'OtherTupleBuilder' (inferred from protocol 'OtherTupled')}}{{-1:3-3=@OtherTupleBuilder }}
   internal
   var tuple: Void { // expected-error{{ambiguous result builder inferred for 'tuple': 'TupleBuilder' or 'OtherTupleBuilder'}}
-    // expected-note@-1{{add an explicit 'return' statement to not use a result builder}}{{3-3=return <#expr#>\n}}
-    // expected-note@-2{{apply result builder 'TupleBuilder' (inferred from protocol 'Tupled')}}{{3-3=@TupleBuilder }}
-    // expected-note@-3{{apply result builder 'OtherTupleBuilder' (inferred from protocol 'OtherTupled')}}{{3-3=@OtherTupleBuilder }}
     "hello" // expected-warning{{string literal is unused}}
     "world" // expected-warning{{string literal is unused}}
   }

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1500,9 +1500,9 @@ let r31892961_1 = [1: 1, 2: 2]
 r31892961_1.forEach { (k, v) in print(k + v) }
 
 let r31892961_2 = [1, 2, 3]
+// expected-error@+2 {{closure tuple parameter does not support destructuring}} {{48-60=arg0}} {{+1:3-3=\n  let (index, val) = arg0\n  }}
+// expected-warning@+1 {{unnamed parameters must be written with the empty name '_'}} {{48-48=_: }}
 let _: [Int] = r31892961_2.enumerated().map { ((index, val)) in
-  // expected-error@-1 {{closure tuple parameter does not support destructuring}} {{48-60=arg0}} {{3-3=\n  let (index, val) = arg0\n  }}
-  // expected-warning@-2 {{unnamed parameters must be written with the empty name '_'}} {{48-48=_: }}
   val + 1
   // expected-error@-1 {{cannot find 'val' in scope}}
 }

--- a/test/Distributed/distributed_protocol_isolation.swift
+++ b/test/Distributed/distributed_protocol_isolation.swift
@@ -14,7 +14,7 @@ typealias DefaultDistributedActorSystem = FakeActorSystem
 // MARK: Distributed actor protocols
 
 protocol WrongDistFuncs {
-    distributed func notDistActor() // expected-error{{'distributed' method can only be declared within 'distributed actor'}}{{5-17=}} {{25-25=: DistributedActor}}
+    distributed func notDistActor() // expected-error{{'distributed' method can only be declared within 'distributed actor'}}{{5-17=}} {{-1:25-25=: DistributedActor}}
 }
 
 protocol DistProtocol: DistributedActor {

--- a/test/Frontend/verify-fixits.swift
+++ b/test/Frontend/verify-fixits.swift
@@ -225,6 +225,18 @@ func test1Fixits() {
   labeledFunc(aax: 0, bb: 1) // expected-error {{incorrect argument label in call (have 'aax:bb:', expected 'aa:bb:')}} {{61:15-+1:18=aa}}
 }
 
+func unlabeledFunc(_ aa: Int) {}
+
+func testDefaultedLineNumbers() {
+  // Fix-it end line defaults to first line.
+  // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
+  unlabeledFunc(aa: // expected-error {{extraneous argument label 'aa:' in call}} {{+0:17-+1:5=}}
+    1)
+  // CHECK: [[@LINE+1]]:83: error: expected fix-it not seen; actual fix-it seen: {{{{}}17-[[@LINE+2]]:5=}}
+  unlabeledFunc(aa: // expected-error {{extraneous argument label 'aa:' in call}} {{+0:17-5=}}
+    1)
+}
+
 func test2Fixits() {
   labeledFunc(aax: 0, bbx: 1) // expected-error {{incorrect argument labels in call (have 'aax:bbx:', expected 'aa:bb:')}}
 

--- a/test/Frontend/verify-fixits.swift
+++ b/test/Frontend/verify-fixits.swift
@@ -235,6 +235,14 @@ func testDefaultedLineNumbers() {
   // CHECK: [[@LINE+1]]:83: error: expected fix-it not seen; actual fix-it seen: {{{{}}17-[[@LINE+2]]:5=}}
   unlabeledFunc(aa: // expected-error {{extraneous argument label 'aa:' in call}} {{+0:17-5=}}
     1)
+
+  // Fix-it start line defaults to diagnostic line.
+  // CHECK-NOT: [[@LINE+1]]:{{[0-9]+}}: error:
+  labeledFunc(aa: 0, // expected-error {{incorrect argument label in call (have 'aa:bbx:', expected 'aa:bb:')}} {{+1:15-+1:18=bb}}
+              bbx: 1)
+  // CHECK: [[@LINE+1]]:113: error: expected fix-it not seen; actual fix-it seen: {{{{}}[[@LINE+2]]:15-18=bb}}
+  labeledFunc(aa: 0, // expected-error {{incorrect argument label in call (have 'aa:bbx:', expected 'aa:bb:')}} {{15-+1:18=bb}}
+              bbx: 1)
 }
 
 func test2Fixits() {

--- a/test/Generics/associated_type_where_clause_hints.swift
+++ b/test/Generics/associated_type_where_clause_hints.swift
@@ -16,42 +16,56 @@ protocol P1 {
   associatedtype A5 // expected-note {{'A5' declared here}}
 }
 
-// A typealias in a subprotocol should be written as a same-type
-// requirement.
-protocol P2 : P1 {
-  typealias A = X1 // expected-warning{{typealias overriding associated type 'A' from protocol 'P1' is better expressed as same-type constraint on the protocol}}{{17-17= where A == X1}}{{3-20=}}
+/*
+A typealias or constrained associated type that overrides an associated type
+from an inherited protocol should be written as a same-type requirement...
+*/
+
+protocol P2a : P1 {
+  typealias A = X1 // expected-warning{{typealias overriding associated type 'A' from protocol 'P1' is better expressed as same-type constraint on the protocol}}{{-1:18-18= where A == X1}}{{3-20=}}
 }
 
 // A redeclaration of an associated type that adds type/layout requirements
 // should be written via a where clause.
-protocol P3a : P1 {
-  associatedtype A: P0, P0b // expected-warning{{redeclaration of associated type 'A' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{-1:18--1:18= where A: P0, A: P0b}}{{28:3-28:29=}}
-  associatedtype A2: P0, P0b where A2.A == Never, A2: P1 // expected-warning{{redeclaration of associated type 'A2' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{18-18= where A2: P0, A2: P0b, A2.A == Never, A2 : P1}}{{3-58=}}
-  associatedtype A3 where A3: P0 // expected-warning{{redeclaration of associated type 'A3' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{18-18= where A3 : P0}}{{3-34=}}
+protocol P2b : P1 {
+  associatedtype A: P0, P0b // expected-warning{{redeclaration of associated type 'A' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{-1:18-18= where A: P0, A: P0b}}{{3-29=}}
+}
 
-  // expected-warning@+1 {{redeclaration of associated type 'A4' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{27:18-27:18= where A4: P0, A4 : Collection, A4.Element == A4.Index, A4.SubSequence == A4}}{{33:3-35:51=}}
+protocol P2c : P1 {
+  associatedtype A2: P0, P0b where A2.A == Never, A2: P1 // expected-warning{{redeclaration of associated type 'A2' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{-1:18-18= where A2: P0, A2: P0b, A2.A == Never, A2 : P1}}{{3-58=}}
+}
+
+protocol P2d : P1 {
+  associatedtype A3 where A3: P0 // expected-warning{{redeclaration of associated type 'A3' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{-1:18-18= where A3 : P0}}{{3-34=}}
+}
+
+protocol P2e : P1 {
+  // expected-warning@+1 {{redeclaration of associated type 'A4' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{-2:18-18= where A4: P0, A4 : Collection, A4.Element == A4.Index, A4.SubSequence == A4}}{{3-+2:51=}}
   associatedtype A4: P0 where A4: Collection,
                               A4.Element == A4.Index,
                               A4.SubSequence == A4
+}
 
-  // expected-warning@+1 {{redeclaration of associated type 'A5' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{27:18-27:18= where A5: P0b & Class, A5 : Collection, A5.Element : Collection}}{{+0:3-+1:62=}}
+protocol P2f : P1 {
+  // expected-warning@+1 {{redeclaration of associated type 'A5' from protocol 'P1' is better expressed as a 'where' clause on the protocol}}{{-2:18-18= where A5: P0b & Class, A5 : Collection, A5.Element : Collection}}{{3-+1:62=}}
   associatedtype A5: P0b & Class where A5: Collection,
                                        A5.Element: Collection
 }
 
-// ... unless it has adds a default type witness
-protocol P3b : P1 {
+/*
+ ... unless it's a defaulted associated type.
+*/
+protocol P2g : P1 {
   associatedtype A: P0 = X0   // note: no warning
 }
 
-protocol P4: P1 {
+protocol P3a: P1 {
   associatedtype B // expected-note{{'B' declared here}}
   associatedtype B2 // expected-note{{'B2' declared here}}
 }
-
-protocol P5: P4 where A: P0 {
-  typealias B = X1 // expected-warning{{typealias overriding associated type 'B' from protocol 'P4' is better expressed as same-type constraint on the protocol}}{{28-28=, B == X1}}{{3-20=}}
-  associatedtype B2: P5 // expected-warning{{redeclaration of associated type 'B2' from protocol 'P4' is better expressed as a 'where' clause on the protocol}}{{28-28=, B2: P5}} {{3-25=}}
+protocol P3b: P3a where A: P0 {
+  typealias B = X1 // expected-warning{{typealias overriding associated type 'B' from protocol 'P3a' is better expressed as same-type constraint on the protocol}}{{-1:30-30=, B == X1}}{{3-20=}}
+  associatedtype B2: P3b // expected-warning{{redeclaration of associated type 'B2' from protocol 'P3a' is better expressed as a 'where' clause on the protocol}}{{-2:30-30=, B2: P3b}} {{3-26=}}
 }
 
 

--- a/test/Parse/invalid.swift
+++ b/test/Parse/invalid.swift
@@ -112,12 +112,12 @@ func friend ship<T>(x: T) {} // expected-error {{found an unexpected second iden
 // expected-note@-2 {{join the identifiers together with camel-case}} {{6-17=friendShip}}
 func were
 wolf() {} // expected-error {{found an unexpected second identifier in function declaration; is there an accidental break?}}
-// expected-note@-1 {{join the identifiers together}} {{6-5=werewolf}}
-// expected-note@-2 {{join the identifiers together with camel-case}} {{6-5=wereWolf}}
+// expected-note@-1 {{join the identifiers together}} {{-1:6-+0:5=werewolf}}
+// expected-note@-2 {{join the identifiers together with camel-case}} {{-1:6-+0:5=wereWolf}}
 func hammer
 leavings<T>(x: T) {} // expected-error {{found an unexpected second identifier in function declaration; is there an accidental break?}}
-// expected-note@-1 {{join the identifiers together}} {{6-9=hammerleavings}}
-// expected-note@-2 {{join the identifiers together with camel-case}} {{6-9=hammerLeavings}}
+// expected-note@-1 {{join the identifiers together}} {{-1:6-+0:9=hammerleavings}}
+// expected-note@-2 {{join the identifiers together with camel-case}} {{-1:6-+0:9=hammerLeavings}}
 
 prefix operator %
 prefix func %<T>(x: T) -> T { return x } // No error expected - the < is considered an identifier but is peeled off by the parser.

--- a/test/Parse/try.swift
+++ b/test/Parse/try.swift
@@ -106,7 +106,7 @@ func test() throws -> Int {
     try break // expected-error {{'try' cannot be used with 'break'}}
   }
   
-  try throw // expected-error {{'try' must be placed on the thrown expression}} {{3-7=}} {{3-3=try }} expected-error {{expected expression in 'throw' statement}}
+  try throw // expected-error {{'try' must be placed on the thrown expression}} {{+1:3-3=try }} {{3-7=}} expected-error {{expected expression in 'throw' statement}}
   ; // Reset parser.
   
   try return // expected-error {{'try' cannot be used with 'return'}} expected-error {{non-void function should return a value}}

--- a/test/Parse/try_swift5.swift
+++ b/test/Parse/try_swift5.swift
@@ -106,7 +106,7 @@ func test() throws -> Int {
     try break // expected-error {{'try' cannot be used with 'break'}}
   }
   
-  try throw // expected-error {{'try' must be placed on the thrown expression}} {{3-7=}} {{3-3=try }} expected-error {{expected expression in 'throw' statement}}
+  try throw // expected-error {{'try' must be placed on the thrown expression}} {{+1:3-3=try }} {{3-7=}} expected-error {{expected expression in 'throw' statement}}
   ; // Reset parser.
   
   try return // expected-error {{'try' cannot be used with 'return'}} expected-error {{non-void function should return a value}}

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1426,7 +1426,7 @@ class ClassForFixit {
       let _ = 6
     }
         // expected-error@-4 {{'globalFuncAvailableOn10_51()' is only available in macOS 10.51 or newer}}
-        // expected-note@-5 {{add 'if #available' version check}} {{5-6=if #available(macOS 10.51, *) {\n        if (globalFuncAvailableOn10_51() > 1066) {\n          let _ = 5\n          let _ = 6\n        }\n    } else {\n        // Fallback on earlier versions\n    }}}
+        // expected-note@-5 {{add 'if #available' version check}} {{5-+3:6=if #available(macOS 10.51, *) {\n        if (globalFuncAvailableOn10_51() > 1066) {\n          let _ = 5\n          let _ = 6\n        }\n    } else {\n        // Fallback on earlier versions\n    }}}
   }
 }
 

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -810,7 +810,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   case .a: break
   }
 
-  switch value { // expected-warning {{switch covers known cases, but 'NonExhaustive' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{3-3=@unknown default:\n<#fatalError#>()\n}}
+  switch value { // expected-warning {{switch covers known cases, but 'NonExhaustive' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{+3:3-3=@unknown default:\n<#fatalError#>()\n}}
   case .a: break
   case .b: break
   }
@@ -902,7 +902,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   case .a: break
   }
 
-  switch payload { // expected-warning {{switch covers known cases, but 'NonExhaustivePayload' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{3-3=@unknown default:\n<#fatalError#>()\n}}
+  switch payload { // expected-warning {{switch covers known cases, but 'NonExhaustivePayload' may have additional unknown values}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{+3:3-3=@unknown default:\n<#fatalError#>()\n}}
   case .a: break
   case .b: break
   }

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -168,7 +168,7 @@ struct SomeStruct {
       return 42
     }
     nonmutating
-    set {      // expected-note {{mark accessor 'mutating' to make 'self' mutable}} {{5-16=mutating}}
+    set {      // expected-note {{mark accessor 'mutating' to make 'self' mutable}} {{-1:5-16=mutating}}
       iv = newValue // expected-error {{cannot assign to property: 'self' is immutable}}
     }
   }

--- a/test/attr/attr_availability_narrow.swift
+++ b/test/attr/attr_availability_narrow.swift
@@ -9,13 +9,13 @@ func foo() { }
 
 func useFoo() {
   if #available(macOS 10.50.1, *) {
-    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{23-30=10.50.2}}
+    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{-1:23-30=10.50.2}}
   }
 }
 
 func useFooDifferentSpelling() {
   if #available(OSX 10.50.1, *) {
-    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{21-28=10.50.2}}
+    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{-1:21-28=10.50.2}}
   }
 }
 
@@ -27,7 +27,7 @@ func useFooAlreadyOkRange() {
 
 func useFooUnaffectedSimilarText() {
   if #available(iOS 10.50.10, OSX 10.50.1, *) {
-    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{35-42=10.50.2}}
+    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{-1:35-42=10.50.2}}
   }
 }
 
@@ -42,14 +42,14 @@ func useFooWayOff() {
 @available(OSX 10.50, *)
 class FooUser {
   func useFoo() {
-    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{16-21=10.50.2}}
+    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{-3:16-21=10.50.2}}
   }
 }
 
 @available(OSX, introduced: 10.50, obsoleted: 10.50.4)
 class FooUser2 {
   func useFoo() {
-    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{29-34=10.50.2}}
+    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{-3:29-34=10.50.2}}
   }
 }
 
@@ -57,7 +57,7 @@ class FooUser2 {
 @objc
 class FooUser3 : NSObject {
   func useFoo() {
-    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{29-34=10.50.2}}
+    foo() // expected-error {{'foo()' is only available in macOS 10.50.2 or newer}} {{-4:29-34=10.50.2}}
   }
 }
 

--- a/test/attr/attr_availability_tvos.swift
+++ b/test/attr/attr_availability_tvos.swift
@@ -59,7 +59,7 @@ if #available(iOS 9.3, *) {
 }
 
 if #available(iOS 9.3, tvOS 9.1, *) {
-  functionIntroducedOntvOS9_2() // expected-error {{'functionIntroducedOntvOS9_2()' is only available in tvOS 9.2 or newer}} {{29-32=9.2}}
+  functionIntroducedOntvOS9_2() // expected-error {{'functionIntroducedOntvOS9_2()' is only available in tvOS 9.2 or newer}} {{-1:29-32=9.2}}
 }
 
 if #available(iOS 9.1, tvOS 9.2, *) {

--- a/test/attr/attr_availability_watchos.swift
+++ b/test/attr/attr_availability_watchos.swift
@@ -59,7 +59,7 @@ if #available(iOS 9.3, *) {
 }
 
 if #available(iOS 9.3, watchOS 2.1, *) {
-  functionIntroducedOnwatchOS2_2() // expected-error {{'functionIntroducedOnwatchOS2_2()' is only available in watchOS 2.2 or newer}} {{32-35=2.2}}
+  functionIntroducedOnwatchOS2_2() // expected-error {{'functionIntroducedOnwatchOS2_2()' is only available in watchOS 2.2 or newer}} {{-1:32-35=2.2}}
 }
 
 if #available(iOS 9.1, watchOS 2.2, *) {

--- a/test/attr/attr_ibsegueaction.swift
+++ b/test/attr/attr_ibsegueaction.swift
@@ -103,12 +103,12 @@ protocol CP2 : class { }
   @objc(newProblematicScreen:)
   @IBSegueAction func problematicScreen(_: AnyObject) -> AnyObject {fatalError()}
   // expected-error@-1{{@IBSegueAction method cannot have selector 'newProblematicScreen:' because it has special memory management behavior}}
-  // expected-note@-2{{change Objective-C selector to 'makeProblematicScreen:'}} {{9-30=makeProblematicScreen:}}
+  // expected-note@-2{{change Objective-C selector to 'makeProblematicScreen:'}} {{-1:9-30=makeProblematicScreen:}}
 
   @objc(newProblematicScreen:secondArg:)
   @IBSegueAction func problematicScreen(_: AnyObject, secondArg: AnyObject) -> AnyObject {fatalError()}
   // expected-error@-1{{@IBSegueAction method cannot have selector 'newProblematicScreen:secondArg:' because it has special memory management behavior}}
-  // expected-note@-2{{change Objective-C selector to 'makeProblematicScreen:secondArg:'}} {{9-40=makeProblematicScreen:secondArg:}}
+  // expected-note@-2{{change Objective-C selector to 'makeProblematicScreen:secondArg:'}} {{-1:9-40=makeProblematicScreen:secondArg:}}
 }
 
 // Check which argument types @IBSegueAction can take.

--- a/test/attr/attr_objc_override.swift
+++ b/test/attr/attr_objc_override.swift
@@ -15,11 +15,11 @@ class A {
     get { return ObjCClass() }  // expected-note{{subscript getter declared here}}
   }
 
-  func bar() { } // expected-note{{add '@objc' to make this declaration overridable}}{{3-3=@objc }}
+  func bar() { } // expected-note{{add '@objc' to make this declaration overridable}}{{38:3-3=@objc }}
 }
 
 extension A {
-  func foo() { } // expected-note{{add '@objc' to make this declaration overridable}}{{3-3=@objc }}
+  func foo() { } // expected-note{{add '@objc' to make this declaration overridable}}{{32:3-3=@objc }}
   func wibble(_: SwiftStruct) { } // expected-note{{overridden declaration is here}}
 }
 

--- a/test/attr/open.swift
+++ b/test/attr/open.swift
@@ -137,7 +137,7 @@ open class OpenSubClass : OpenSuperClass {
 
 class InvalidOpenExtensionClass { }
 
-open extension InvalidOpenExtensionClass {  // expected-error {{extensions cannot be declared 'open'; declare individual members as 'open' instead}} {{1-6=}} {{3-3=public }} {{3-3=public }}
+open extension InvalidOpenExtensionClass {  // expected-error {{extensions cannot be declared 'open'; declare individual members as 'open' instead}} {{1-6=}} {{+1:3-3=public }} {{+3:3-3=public }}
   func C() { } // Insert public
   private func A() { } // OK
   var F: Int { 3 } // Insert public

--- a/test/attr/open_objc.swift
+++ b/test/attr/open_objc.swift
@@ -48,7 +48,7 @@ public extension ValidOpenExtension {
 
 class InvalidOpenExtensionClass { }
 
-open extension InvalidOpenExtensionClass {  // expected-error {{extensions cannot be declared 'open'; declare individual members as 'open' instead}} {{1-6=}} {{3-3=public }} {{9-9=open }} {{9-9=open }} {{3-3=public }}
+open extension InvalidOpenExtensionClass {  // expected-error {{extensions cannot be declared 'open'; declare individual members as 'open' instead}} {{1-6=}} {{+2:9-9=open }} {{+3:3-3=public }} {{+5:9-9=open }} {{+6:3-3=public }}
   private func A() { } // OK
   @objc func B() { } // Insert open 
   func C() { } // Insert public
@@ -62,7 +62,7 @@ open extension InvalidOpenExtensionClass {  // expected-error {{extensions canno
 @objcMembers
 class InvalidOpenExtensionObjcClass: NSObject { }
 
-open extension InvalidOpenExtensionObjcClass {  // expected-error {{extensions cannot be declared 'open'; declare individual members as 'open' instead}} {{1-6=}} {{3-3=open }} {{9-9=open }} {{9-9=open }} {{3-3=open }}
+open extension InvalidOpenExtensionObjcClass {  // expected-error {{extensions cannot be declared 'open'; declare individual members as 'open' instead}} {{1-6=}} {{+2:9-9=open }} {{+3:3-3=open }} {{+5:9-9=open }} {{+6:3-3=open }}
   private func A() { } // OK
   @objc func B() { } // Insert open 
   func C() { } // Insert open

--- a/test/attr/require_explicit_availability.swift
+++ b/test/attr/require_explicit_availability.swift
@@ -44,7 +44,7 @@ public struct UnavailableStruct {
 public func foo() { bar() } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
 
 @usableFromInline
-func bar() { } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
+func bar() { } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{-1:1-1=@available(macOS 10.10, *)\n}}
 
 @available(macOS 10.1, *)
 public func ok() { }
@@ -53,10 +53,10 @@ public func ok() { }
 public func unavailableOk() { }
 
 @available(macOS, deprecated: 10.10)
-public func missingIntro() { } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
+public func missingIntro() { } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{-1:1-1=@available(macOS 10.10, *)\n}}
 
 @available(iOS 9.0, *)
-public func missingTargetPlatform() { } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{1-1=@available(macOS 10.10, *)\n}}
+public func missingTargetPlatform() { } // expected-warning {{public declarations should have an availability attribute with an introduction version}} {{-1:1-1=@available(macOS 10.10, *)\n}}
 
 func privateFunc() { }
 

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -122,8 +122,8 @@ class G {
   func f6(_: Int, int: Int) { }
   func f7(_: Int, int: Int) { }
 
-  func g1(_: Int, string: String) { } // expected-note{{potential overridden instance method 'g1(_:string:)' here}} {{28-28=string }}
-  func g1(_: Int, path: String) { } // expected-note{{potential overridden instance method 'g1(_:path:)' here}} {{28-28=path }}
+  func g1(_: Int, string: String) { } // expected-note{{potential overridden instance method 'g1(_:string:)' here}} {{152:28-28=string }}
+  func g1(_: Int, path: String) { } // expected-note{{potential overridden instance method 'g1(_:path:)' here}} {{152:28-28=path }}
 
   func g2(_: Int, string: String) { } // expected-note{{potential overridden instance method 'g2(_:string:)' here}} {{none}}
   func g2(_: Int, path: String) { }
@@ -135,8 +135,8 @@ class G {
   func g4(_: Int, path: String) { }
 
   init(a: Int) {} // expected-note {{potential overridden initializer 'init(a:)' here}} {{none}}
-  init(a: String) {} // expected-note {{potential overridden initializer 'init(a:)' here}} {{17-17=a }} expected-note {{potential overridden initializer 'init(a:)' here}} {{none}}
-  init(b: String) {} // expected-note {{potential overridden initializer 'init(b:)' here}} {{17-17=b }} expected-note {{potential overridden initializer 'init(b:)' here}} {{none}}
+  init(a: String) {} // expected-note {{potential overridden initializer 'init(a:)' here}} {{158:17-17=a }} expected-note {{potential overridden initializer 'init(a:)' here}} {{none}}
+  init(b: String) {} // expected-note {{potential overridden initializer 'init(b:)' here}} {{158:17-17=b }} expected-note {{potential overridden initializer 'init(b:)' here}} {{none}}
 }
 
 class H : G {

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -14,22 +14,22 @@ func +(lhs: X, rhs: X) -> X {} // okay
 func <=>(lhs: X, rhs: X) -> X {} // expected-error {{operator implementation without matching operator declaration}}{{1-1=infix operator <=> : <# Precedence Group #>\n}}
 
 extension X {
-    static func <=>(lhs: X, rhs: X) -> X {} // expected-error {{operator implementation without matching operator declaration}}{{1-1=infix operator <=> : <# Precedence Group #>\n}}
+    static func <=>(lhs: X, rhs: X) -> X {} // expected-error {{operator implementation without matching operator declaration}}{{-1:1-1=infix operator <=> : <# Precedence Group #>\n}}
 }
 
 extension X {
     struct Z {
-        static func <=> (lhs: Z, rhs: Z) -> Z {} // expected-error {{operator implementation without matching operator declaration}}{{1-1=infix operator <=> : <# Precedence Group #>\n}}
+        static func <=> (lhs: Z, rhs: Z) -> Z {} // expected-error {{operator implementation without matching operator declaration}}{{-2:1-1=infix operator <=> : <# Precedence Group #>\n}}
     }
 }
 
 extension X {
-    static prefix func <=>(lhs: X) -> X {} // expected-error {{operator implementation without matching operator declaration}}{{1-1=prefix operator <=> : <# Precedence Group #>\n}}
+    static prefix func <=>(lhs: X) -> X {} // expected-error {{operator implementation without matching operator declaration}}{{-1:1-1=prefix operator <=> : <# Precedence Group #>\n}}
 }
 
 extension X {
     struct ZZ {
-        static prefix func <=>(lhs: ZZ) -> ZZ {} // expected-error {{operator implementation without matching operator declaration}}{{1-1=prefix operator <=> : <# Precedence Group #>\n}}
+        static prefix func <=>(lhs: ZZ) -> ZZ {} // expected-error {{operator implementation without matching operator declaration}}{{-2:1-1=prefix operator <=> : <# Precedence Group #>\n}}
     }
 }
 

--- a/test/decl/protocol/conforms/fixit_stub.swift
+++ b/test/decl/protocol/conforms/fixit_stub.swift
@@ -1,14 +1,14 @@
 // RUN: %target-typecheck-verify-swift
 
 protocol Protocol1 {
-  func foo(arg1: Int, arg2: String) -> String // expected-note{{protocol requires function 'foo(arg1:arg2:)' with type '(Int, String) -> String'; do you want to add a stub?}} {{27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  func bar() throws -> String // expected-note{{protocol requires function 'bar()' with type '() throws -> String'; do you want to add a stub?}} {{27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  func generic<T>(t: T) // expected-note{{protocol requires function 'generic(t:)' with type '<T> (t: T) -> ()'; do you want to add a stub?}} {{27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; do you want to add a stub?}} {{27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  var baz: Int { get } // expected-note{{protocol requires property 'baz' with type 'Int'; do you want to add a stub?}} {{27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  var baz2: Int { get set } // expected-note{{protocol requires property 'baz2' with type 'Int'; do you want to add a stub?}} {{27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  subscript(arg: Int) -> String { get } //expected-note{{rotocol requires subscript with type '(Int) -> String'; do you want to add a stub?}} {{27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  subscript(arg1: Int, arg2: Int) -> String { get set } //expected-note{{protocol requires subscript with type '(Int, Int) -> String'; do you want to add a stub?}} {{27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  func foo(arg1: Int, arg2: String) -> String // expected-note{{protocol requires function 'foo(arg1:arg2:)' with type '(Int, String) -> String'; do you want to add a stub?}} {{14:27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  func bar() throws -> String // expected-note{{protocol requires function 'bar()' with type '() throws -> String'; do you want to add a stub?}} {{14:27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  func generic<T>(t: T) // expected-note{{protocol requires function 'generic(t:)' with type '<T> (t: T) -> ()'; do you want to add a stub?}} {{14:27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; do you want to add a stub?}} {{14:27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  var baz: Int { get } // expected-note{{protocol requires property 'baz' with type 'Int'; do you want to add a stub?}} {{14:27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  var baz2: Int { get set } // expected-note{{protocol requires property 'baz2' with type 'Int'; do you want to add a stub?}} {{14:27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  subscript(arg: Int) -> String { get } //expected-note{{rotocol requires subscript with type '(Int) -> String'; do you want to add a stub?}} {{14:27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  subscript(arg1: Int, arg2: Int) -> String { get set } //expected-note{{protocol requires subscript with type '(Int, Int) -> String'; do you want to add a stub?}} {{14:27-27=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    func generic<T>(t: T) {\n        <#code#>\n    \}\n\n    required init(arg: Int) {\n        <#code#>\n    \}\n\n    var baz: Int\n\n    var baz2: Int\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
 }
 
 class Adopter: Protocol1 { // expected-error{{type 'Adopter' does not conform to protocol 'Protocol1'}}
@@ -17,13 +17,13 @@ class Adopter: Protocol1 { // expected-error{{type 'Adopter' does not conform to
 
 
 protocol Protocol2 {
-  func foo(arg1: Int, arg2: String) -> String // expected-note{{protocol requires function 'foo(arg1:arg2:)' with type '(Int, String) -> String'; do you want to add a stub?}} {{32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  func bar() throws -> String // expected-note{{protocol requires function 'bar()' with type '() throws -> String'; do you want to add a stub?}} {{32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  func foo(arg1: Int, arg2: String) -> String // expected-note{{protocol requires function 'foo(arg1:arg2:)' with type '(Int, String) -> String'; do you want to add a stub?}} {{31:32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  func bar() throws -> String // expected-note{{protocol requires function 'bar()' with type '() throws -> String'; do you want to add a stub?}} {{31:32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
   init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'}} {{none}}
-  var baz: Int { get } // expected-note{{protocol requires property 'baz' with type 'Int'; do you want to add a stub?}} {{32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  var baz2: Int { get set } // expected-note{{protocol requires property 'baz2' with type 'Int'; do you want to add a stub?}} {{32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  subscript(arg: Int) -> String { get } //expected-note{{rotocol requires subscript with type '(Int) -> String'; do you want to add a stub?}} {{32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
-  subscript(arg1: Int, arg2: Int) -> String { get set } //expected-note{{protocol requires subscript with type '(Int, Int) -> String'; do you want to add a stub?}} {{32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  var baz: Int { get } // expected-note{{protocol requires property 'baz' with type 'Int'; do you want to add a stub?}} {{31:32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  var baz2: Int { get set } // expected-note{{protocol requires property 'baz2' with type 'Int'; do you want to add a stub?}} {{31:32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  subscript(arg: Int) -> String { get } //expected-note{{rotocol requires subscript with type '(Int) -> String'; do you want to add a stub?}} {{31:32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
+  subscript(arg1: Int, arg2: Int) -> String { get set } //expected-note{{protocol requires subscript with type '(Int, Int) -> String'; do you want to add a stub?}} {{31:32-32=\n    func foo(arg1: Int, arg2: String) -> String {\n        <#code#>\n    \}\n\n    func bar() throws -> String {\n        <#code#>\n    \}\n\n    var baz: Int {\n        <#code#>\n    \}\n\n    var baz2: Int {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n\n    subscript(arg: Int) -> String {\n        <#code#>\n    \}\n\n    subscript(arg1: Int, arg2: Int) -> String {\n        get {\n            <#code#>\n        \}\n        set {\n            <#code#>\n        \}\n    \}\n}}
 }
 
 class Adopter2 {}
@@ -34,61 +34,54 @@ extension Adopter2: Protocol2 { // expected-error{{ype 'Adopter2' does not confo
 
 
 protocol ProtocolWithAssocType {
-  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}} {{41-41=\n    typealias AssocType = <#type#>\n}}
+  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}} {{+2:41-41=\n    typealias AssocType = <#type#>\n}}
 }
-
 struct Adopter3: ProtocolWithAssocType { //expected-error{{type 'Adopter3' does not conform to protocol 'ProtocolWithAssocType'}}
 }
 
 
 
 protocol ProtocolWithAssocType2 {
-  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'; do you want to add it?}} {{45-45=\n    typealias AssocType = <#type#>\n}}
+  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'; do you want to add it?}} {{+4:45-45=\n    typealias AssocType = <#type#>\n}}
 }
-
 struct Adopter4 {
 }
-
 extension Adopter4: ProtocolWithAssocType2 { //expected-error{{type 'Adopter4' does not conform to protocol 'ProtocolWithAssocType2'}}
 }
 
 
 
 protocol ProtocolWithSelfRequirement {
-  func foo() -> Self // expected-note{{protocol requires function 'foo()' with type '() -> Adopter5'; do you want to add a stub?}} {{47-47=\n    func foo() -> Adopter5 {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter5, rhs: Adopter5) -> Adopter5 {\n        <#code#>\n    \}\n}}
-  func foo(lhs: Self, rhs: Self) -> Self //expected-note{{protocol requires function 'foo(lhs:rhs:)' with type '(Adopter5, Adopter5) -> Adopter5'; do you want to add a stub?}} {{47-47=\n    func foo() -> Adopter5 {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter5, rhs: Adopter5) -> Adopter5 {\n        <#code#>\n    \}\n}}
+  func foo() -> Self // expected-note{{protocol requires function 'foo()' with type '() -> Adopter5'; do you want to add a stub?}} {{+3:47-47=\n    func foo() -> Adopter5 {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter5, rhs: Adopter5) -> Adopter5 {\n        <#code#>\n    \}\n}}
+  func foo(lhs: Self, rhs: Self) -> Self //expected-note{{protocol requires function 'foo(lhs:rhs:)' with type '(Adopter5, Adopter5) -> Adopter5'; do you want to add a stub?}} {{+2:47-47=\n    func foo() -> Adopter5 {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter5, rhs: Adopter5) -> Adopter5 {\n        <#code#>\n    \}\n}}
 }
-
 struct Adopter5: ProtocolWithSelfRequirement { //expected-error{{type 'Adopter5' does not conform to protocol 'ProtocolWithSelfRequirement'}}
 }
 
 
 
 protocol ProtocolWithSelfRequirement2 {
-  func foo() -> Self // expected-note{{protocol requires function 'foo()' with type '() -> Adopter6'; do you want to add a stub?}} {{51-51=\n    func foo() -> Adopter6 {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter6, rhs: Adopter6) -> Adopter6 {\n        <#code#>\n    \}\n}}
-  func foo(lhs: Self, rhs: Self) -> Self //expected-note{{protocol requires function 'foo(lhs:rhs:)' with type '(Adopter6, Adopter6) -> Adopter6'; do you want to add a stub?}} {{51-51=\n    func foo() -> Adopter6 {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter6, rhs: Adopter6) -> Adopter6 {\n        <#code#>\n    \}\n}}
+  func foo() -> Self // expected-note{{protocol requires function 'foo()' with type '() -> Adopter6'; do you want to add a stub?}} {{+4:51-51=\n    func foo() -> Adopter6 {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter6, rhs: Adopter6) -> Adopter6 {\n        <#code#>\n    \}\n}}
+  func foo(lhs: Self, rhs: Self) -> Self //expected-note{{protocol requires function 'foo(lhs:rhs:)' with type '(Adopter6, Adopter6) -> Adopter6'; do you want to add a stub?}} {{+3:51-51=\n    func foo() -> Adopter6 {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter6, rhs: Adopter6) -> Adopter6 {\n        <#code#>\n    \}\n}}
 }
-
 struct Adopter6 {}
-
 extension Adopter6: ProtocolWithSelfRequirement2 { //expected-error{{type 'Adopter6' does not conform to protocol 'ProtocolWithSelfRequirement2'}}
 }
 
 
 protocol ProtocolWithSelfRequirement3 {
-  func foo() -> Self // expected-note{{protocol requires function 'foo()' with type '() -> Self'; do you want to add a stub?}} {{47-47=\n    func foo() -> Self {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter7, rhs: Adopter7) -> Self {\n        <#code#>\n    \}\n}}
-  func foo(lhs: Self, rhs: Self) -> Self //expected-note{{protocol requires function 'foo(lhs:rhs:)' with type '(Adopter7, Adopter7) -> Self'; do you want to add a stub?}} {{47-47=\n    func foo() -> Self {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter7, rhs: Adopter7) -> Self {\n        <#code#>\n    \}\n}}
+  func foo() -> Self // expected-note{{protocol requires function 'foo()' with type '() -> Self'; do you want to add a stub?}} {{+3:47-47=\n    func foo() -> Self {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter7, rhs: Adopter7) -> Self {\n        <#code#>\n    \}\n}}
+  func foo(lhs: Self, rhs: Self) -> Self //expected-note{{protocol requires function 'foo(lhs:rhs:)' with type '(Adopter7, Adopter7) -> Self'; do you want to add a stub?}} {{+2:47-47=\n    func foo() -> Self {\n        <#code#>\n    \}\n\n    func foo(lhs: Adopter7, rhs: Adopter7) -> Self {\n        <#code#>\n    \}\n}}
 }
-
 class Adopter7: ProtocolWithSelfRequirement3 { //expected-error{{type 'Adopter7' does not conform to protocol 'ProtocolWithSelfRequirement3'}}
 }
 
 
 public protocol ProtocolWithPublicAccess1 {
-  func foo() // expected-note{{protocol requires function 'foo()' with type '() -> ()'; do you want to add a stub?}} {{71-71=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
+  func foo() // expected-note{{protocol requires function 'foo()' with type '() -> ()'; do you want to add a stub?}} {{+5:71-71=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
 }
 public protocol ProtocolWithPublicAccess2 {
-  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}} {{71-71=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
+  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}} {{+2:71-71=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
 }
 class Adopter8: ProtocolWithPublicAccess1, ProtocolWithPublicAccess2 {
   // expected-error@-1{{type 'Adopter8' does not conform to protocol 'ProtocolWithPublicAccess1'}}
@@ -96,10 +89,10 @@ class Adopter8: ProtocolWithPublicAccess1, ProtocolWithPublicAccess2 {
 }
 
 public protocol ProtocolWithPublicAccess3 {
-  func foo() // expected-note{{protocol requires function 'foo()' with type '() -> ()'; do you want to add a stub?}} {{78-78=\n    public func foo() {\n        <#code#>\n    \}\n\n    public typealias AssocType = <#type#>\n}}
+  func foo() // expected-note{{protocol requires function 'foo()' with type '() -> ()'; do you want to add a stub?}} {{+5:78-78=\n    public func foo() {\n        <#code#>\n    \}\n\n    public typealias AssocType = <#type#>\n}}
 }
 public protocol ProtocolWithPublicAccess4 {
-  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}} {{78-78=\n    public func foo() {\n        <#code#>\n    \}\n\n    public typealias AssocType = <#type#>\n}}
+  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}} {{+2:78-78=\n    public func foo() {\n        <#code#>\n    \}\n\n    public typealias AssocType = <#type#>\n}}
 }
 public class Adopter9: ProtocolWithPublicAccess3, ProtocolWithPublicAccess4 {
   // expected-error@-1{{type 'Adopter9' does not conform to protocol 'ProtocolWithPublicAccess3'}}
@@ -107,10 +100,10 @@ public class Adopter9: ProtocolWithPublicAccess3, ProtocolWithPublicAccess4 {
 }
 
 private protocol ProtocolWithPrivateAccess1 {
-  func foo() // expected-note{{protocol requires function 'foo()' with type '() -> ()'; do you want to add a stub?}} {{74-74=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
+  func foo() // expected-note{{protocol requires function 'foo()' with type '() -> ()'; do you want to add a stub?}} {{+5:74-74=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
 }
 private protocol ProtocolWithPrivateAccess2 {
-  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}} {{74-74=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
+  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}} {{+2:74-74=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
 }
 class Adopter10: ProtocolWithPrivateAccess1, ProtocolWithPrivateAccess2 {
   // expected-error@-1{{type 'Adopter10' does not conform to protocol 'ProtocolWithPrivateAccess1'}}
@@ -118,10 +111,10 @@ class Adopter10: ProtocolWithPrivateAccess1, ProtocolWithPrivateAccess2 {
 }
 
 private protocol ProtocolWithPrivateAccess3 {
-  func foo() // expected-note{{protocol requires function 'foo()' with type '() -> ()'; do you want to add a stub?}} {{81-81=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
+  func foo() // expected-note{{protocol requires function 'foo()' with type '() -> ()'; do you want to add a stub?}} {{+5:81-81=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
 }
 private protocol ProtocolWithPrivateAccess4 {
-  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}} {{81-81=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
+  associatedtype AssocType //expected-note{{protocol requires nested type 'AssocType'}} {{+2:81-81=\n    func foo() {\n        <#code#>\n    \}\n\n    typealias AssocType = <#type#>\n}}
 }
 public class Adopter11: ProtocolWithPrivateAccess3, ProtocolWithPrivateAccess4 {
   // expected-error@-1{{type 'Adopter11' does not conform to protocol 'ProtocolWithPrivateAccess3'}}
@@ -129,81 +122,77 @@ public class Adopter11: ProtocolWithPrivateAccess3, ProtocolWithPrivateAccess4 {
 }
 
 protocol ProtocolRequiresInit1 {
-  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; do you want to add a stub?}} {{48-48=\n    init(arg: Int) {\n        <#code#>\n    \}\n}}
+  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; do you want to add a stub?}} {{+2:48-48=\n    init(arg: Int) {\n        <#code#>\n    \}\n}}
 }
 final class Adopter12 : ProtocolRequiresInit1 {} //expected-error {{type 'Adopter12' does not conform to protocol 'ProtocolRequiresInit1'}}
 
 protocol ProtocolRequiresInit2 {
-  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; do you want to add a stub?}} {{46-46=\n    convenience init(arg: Int) {\n        <#code#>\n    \}\n}}
+  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; do you want to add a stub?}} {{+3:46-46=\n    convenience init(arg: Int) {\n        <#code#>\n    \}\n}}
 }
 final class Adopter13 {}
 extension Adopter13 : ProtocolRequiresInit2 {} //expected-error {{type 'Adopter13' does not conform to protocol 'ProtocolRequiresInit2'}}
 
 protocol ProtocolRequiresInit3 {
-  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; do you want to add a stub?}} {{46-46=\n    init(arg: Int) {\n        <#code#>\n    \}\n}}
+  init(arg: Int) // expected-note{{protocol requires initializer 'init(arg:)' with type '(arg: Int)'; do you want to add a stub?}} {{+3:46-46=\n    init(arg: Int) {\n        <#code#>\n    \}\n}}
 }
-
 struct Adopter14 {}
 extension Adopter14 : ProtocolRequiresInit3 {} //expected-error {{type 'Adopter14' does not conform to protocol 'ProtocolRequiresInit3'}}
 
 protocol ProtocolChain1 {
-  func foo1() // expected-note {{protocol requires function 'foo1()' with type '() -> ()'; do you want to add a stub?}}{{35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
-  func foo2() // expected-note {{protocol requires function 'foo2()' with type '() -> ()'; do you want to add a stub?}}{{35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
-  func foo3() // expected-note {{protocol requires function 'foo3()' with type '() -> ()'; do you want to add a stub?}}{{35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
-  var foo4 : Int {get set } // expected-note {{protocol requires property 'foo4' with type 'Int'; do you want to add a stub?}}{{35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
+  func foo1() // expected-note {{protocol requires function 'foo1()' with type '() -> ()'; do you want to add a stub?}}{{154:35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
+  func foo2() // expected-note {{protocol requires function 'foo2()' with type '() -> ()'; do you want to add a stub?}}{{154:35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
+  func foo3() // expected-note {{protocol requires function 'foo3()' with type '() -> ()'; do you want to add a stub?}}{{154:35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
+  var foo4 : Int {get set } // expected-note {{protocol requires property 'foo4' with type 'Int'; do you want to add a stub?}}{{154:35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
 }
 protocol ProtocolChain2 : ProtocolChain1 {
-  func bar1() // expected-note {{protocol requires function 'bar1()' with type '() -> ()'; do you want to add a stub?}}{{35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
-  func bar2() // expected-note {{protocol requires function 'bar2()' with type '() -> ()'; do you want to add a stub?}}{{35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
-  func bar3() // expected-note {{protocol requires function 'bar3()' with type '() -> ()'; do you want to add a stub?}}{{35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
-  var bar4 : Int {get set } // expected-note {{protocol requires property 'bar4' with type 'Int'; do you want to add a stub?}}{{35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
+  func bar1() // expected-note {{protocol requires function 'bar1()' with type '() -> ()'; do you want to add a stub?}}{{154:35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
+  func bar2() // expected-note {{protocol requires function 'bar2()' with type '() -> ()'; do you want to add a stub?}}{{154:35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
+  func bar3() // expected-note {{protocol requires function 'bar3()' with type '() -> ()'; do you want to add a stub?}}{{154:35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
+  var bar4 : Int {get set } // expected-note {{protocol requires property 'bar4' with type 'Int'; do you want to add a stub?}}{{154:35-35=\n    func bar1() {\n        <#code#>\n    \}\n\n    func bar2() {\n        <#code#>\n    \}\n\n    func bar3() {\n        <#code#>\n    \}\n\n    var bar4: Int\n\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n\n    func foo3() {\n        <#code#>\n    \}\n\n    var foo4: Int\n}}
 }
 
 class Adopter15 : ProtocolChain2 {} //expected-error {{type 'Adopter15' does not conform to protocol 'ProtocolChain2'}} expected-error {{type 'Adopter15' does not conform to protocol 'ProtocolChain1'}}
 
 protocol ProtocolParallel1 {
-  associatedtype Foo1 // expected-note {{protocol requires nested type 'Foo1'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
-  associatedtype Foo2 // expected-note {{protocol requires nested type 'Foo2'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
-  associatedtype Foo3 // expected-note {{protocol requires nested type 'Foo3'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
+  associatedtype Foo1 // expected-note {{protocol requires nested type 'Foo1'; do you want to add it?}}{{171:57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
+  associatedtype Foo2 // expected-note {{protocol requires nested type 'Foo2'; do you want to add it?}}{{171:57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
+  associatedtype Foo3 // expected-note {{protocol requires nested type 'Foo3'; do you want to add it?}}{{171:57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
   // FIXME: Why do we add stubs for all missing requirements when the note implies a single one?
-  func Foo4() // expected-note {{protocol requires function 'Foo4()' with type '() -> ()'; do you want to add a stub?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
+  func Foo4() // expected-note {{protocol requires function 'Foo4()' with type '() -> ()'; do you want to add a stub?}}{{171:57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
 }
 
 protocol ProtocolParallel2 {
-  associatedtype Bar1 // expected-note {{protocol requires nested type 'Bar1'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
-  associatedtype Bar2 // expected-note {{protocol requires nested type 'Bar2'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
-  associatedtype Bar3 // expected-note {{protocol requires nested type 'Bar3'; do you want to add it?}}{{57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
-  func Bar4() // expected-note {{protocol requires function 'Bar4()' with type '() -> ()'; do you want to add a stub?}}{{57-57=\n    func Bar4() {\n        <#code#>\n    \}\n}}
+  associatedtype Bar1 // expected-note {{protocol requires nested type 'Bar1'; do you want to add it?}}{{171:57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
+  associatedtype Bar2 // expected-note {{protocol requires nested type 'Bar2'; do you want to add it?}}{{171:57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
+  associatedtype Bar3 // expected-note {{protocol requires nested type 'Bar3'; do you want to add it?}}{{171:57-57=\n    typealias Foo1 = <#type#>\n\n    typealias Foo2 = <#type#>\n\n    typealias Foo3 = <#type#>\n\n    func Foo4() {\n        <#code#>\n    \}\n\n    typealias Bar1 = <#type#>\n\n    typealias Bar2 = <#type#>\n\n    typealias Bar3 = <#type#>\n}}
+  func Bar4() // expected-note {{protocol requires function 'Bar4()' with type '() -> ()'; do you want to add a stub?}}{{171:57-57=\n    func Bar4() {\n        <#code#>\n    \}\n}}
 }
 
 class Adopter16 : ProtocolParallel1, ProtocolParallel2 {} // expected-error {{type 'Adopter16' does not conform to protocol 'ProtocolParallel1'}} expected-error {{type 'Adopter16' does not conform to protocol 'ProtocolParallel2'}}
 
 protocol ProtocolParallel3 {
-  func foo1() // expected-note{{protocol requires function 'foo1()' with type '() -> ()'; do you want to add a stub?}}{{56-56=\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n}}
-  func foo2() // expected-note{{protocol requires function 'foo2()' with type '() -> ()'; do you want to add a stub?}}{{56-56=\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n}}
+  func foo1() // expected-note{{protocol requires function 'foo1()' with type '() -> ()'; do you want to add a stub?}}{{+7:56-56=\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n}}
+  func foo2() // expected-note{{protocol requires function 'foo2()' with type '() -> ()'; do you want to add a stub?}}{{+6:56-56=\n    func foo1() {\n        <#code#>\n    \}\n\n    func foo2() {\n        <#code#>\n    \}\n}}
 }
-
 protocol ProtocolParallel4 {
   func bar1()
   func bar2()
 }
-
 class Adopter17: ProtocolParallel3, ProtocolParallel4 { // expected-error {{type 'Adopter17' does not conform to protocol 'ProtocolParallel3'}}
   func bar1() {}
   func bar2() {}
 }
 
 protocol ProtocolHasSubscriptFunction {
-  func `subscript`() // expected-note{{protocol requires function 'subscript()' with type '() -> ()'; do you want to add a stub?}} {{74-74=\n    func `subscript`() {\n        <#code#>\n    \}\n}}
+  func `subscript`() // expected-note{{protocol requires function 'subscript()' with type '() -> ()'; do you want to add a stub?}} {{+2:74-74=\n    func `subscript`() {\n        <#code#>\n    \}\n}}
 }
 class ProtocolHasSubscriptFunctionAdopter: ProtocolHasSubscriptFunction { // expected-error{{type 'ProtocolHasSubscriptFunctionAdopter' does not conform to protocol 'ProtocolHasSubscriptFunction'}}
 
 }
 
 protocol ProtocolHasConsumingRequirement {
-  __consuming func foo() // expected-note {{protocol requires function 'foo()' with type '() -> ()'; do you want to add a stub?}} {{81-81=\n    func foo() {\n        <#code#>\n    \}\n}}
+  __consuming func foo() // expected-note {{protocol requires function 'foo()' with type '() -> ()'; do you want to add a stub?}} {{+2:81-81=\n    func foo() {\n        <#code#>\n    \}\n}}
 }
-
 struct ProtocolHasConsumingRequirementAdopter: ProtocolHasConsumingRequirement { // expected-error {{type 'ProtocolHasConsumingRequirementAdopter' does not conform to protocol 'ProtocolHasConsumingRequirement'}}
 
 }

--- a/test/decl/protocol/fixits_missing_protocols_in_context.swift
+++ b/test/decl/protocol/fixits_missing_protocols_in_context.swift
@@ -13,7 +13,7 @@ class C {
   func assign() {
     p = self
     // expected-error@-1 {{cannot assign value of type 'C' to type '(any P)?'}}
-    // expected-note@-2 {{add missing conformance to 'P' to class 'C'}} {{8-8=: P}} {{10-10=\n    func method() {\n        <#code#>\n    \}\n\n    var property: Int\n}}
+    // expected-note@-2 {{add missing conformance to 'P' to class 'C'}} {{-4:8-8=: P}} {{-4:10-10=\n    func method() {\n        <#code#>\n    \}\n\n    var property: Int\n}}
   }
 }
 
@@ -25,7 +25,7 @@ class C1 {
   func assign() {
     p = self
     // expected-error@-1 {{cannot assign value of type 'C1' to type '(any P)?'}}
-    // expected-note@-2 {{add missing conformance to 'P' to class 'C1'}} {{9-9=: P}} {{11-11=\n    var property: Int\n}}
+    // expected-note@-2 {{add missing conformance to 'P' to class 'C1'}} {{-4:9-9=: P}} {{-4:11-11=\n    var property: Int\n}}
   }
 
   func method() {}
@@ -37,7 +37,7 @@ class C2 {
   func assign() {
     p = self
     // expected-error@-1 {{cannot assign value of type 'C2' to type '(any P)?'}}
-    // expected-note@-2 {{add missing conformance to 'P' to class 'C2'}} {{9-9=: P}}
+    // expected-note@-2 {{add missing conformance to 'P' to class 'C2'}} {{-4:9-9=: P}}
   }
 
   func method() {}

--- a/test/decl/protocol/objc.swift
+++ b/test/decl/protocol/objc.swift
@@ -13,7 +13,7 @@
 
 @objc class C1 : P1 {
   @objc(method1renamed)
-  func method1() { // expected-error{{Objective-C method 'method1renamed' provided by method 'method1()' does not match the requirement's selector ('method1')}}{{9-23=method1}}
+  func method1() { // expected-error{{Objective-C method 'method1renamed' provided by method 'method1()' does not match the requirement's selector ('method1')}}{{-1:9-23=method1}}
   }
 
   var property1: ObjCClass {

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -498,7 +498,7 @@ class C1_53813 {
 
   func conform() {
     c0.foo1 = self // expected-error {{cannot assign value of type 'C1_53813' to type '(any P1_53813)?'}}
-    // expected-note@-1 {{add missing conformance to 'P1_53813' to class 'C1_53813'}}{{15-15=: P1_53813}}
+    // expected-note@-1 {{add missing conformance to 'P1_53813' to class 'C1_53813'}}{{-4:15-15=: P1_53813}}
   }
 }
 
@@ -509,7 +509,7 @@ class C2_53813 {
 
   func conform() {
     c0.foo2 = self // expected-error {{cannot assign value of type 'C2_53813' to type '(any P1_53813 & P2_53813)?'}}
-    // expected-note@-1 {{add missing conformance to 'P1_53813 & P2_53813' to class 'C2_53813'}}{{15-15=: P1_53813 & P2_53813}}
+    // expected-note@-1 {{add missing conformance to 'P1_53813 & P2_53813' to class 'C2_53813'}}{{-4:15-15=: P1_53813 & P2_53813}}
   }
 }
 
@@ -520,7 +520,7 @@ class C3_53813: P3_53813 {
 
   func conform() {
     c0.foo1 = self // expected-error {{cannot assign value of type 'C3_53813' to type '(any P1_53813)?'}}
-    // expected-note@-1 {{add missing conformance to 'P1_53813' to class 'C3_53813'}}{{25-25=, P1_53813}}
+    // expected-note@-1 {{add missing conformance to 'P1_53813' to class 'C3_53813'}}{{-4:25-25=, P1_53813}}
   }
 }
 
@@ -531,7 +531,7 @@ class C4_53813: P1_53813 {
 
   func conform() {
     c0.foo2 = self // expected-error {{cannot assign value of type 'C4_53813' to type '(any P1_53813 & P2_53813)?'}}
-    // expected-note@-1 {{add missing conformance to 'P1_53813 & P2_53813' to class 'C4_53813'}}{{25-25=, P2_53813}}
+    // expected-note@-1 {{add missing conformance to 'P1_53813 & P2_53813' to class 'C4_53813'}}{{-4:25-25=, P2_53813}}
   }
 }
 

--- a/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
@@ -61,8 +61,8 @@ class DecodableSuper : Decodable {
   var value = 5
 }
 
+// expected-note@+1 {{did you mean to override 'init(from:)'?}}{{+1:1-1=\noverride init(from decoder: Decoder) throws {\n    <#code#>\n\}}}
 class DecodableSubWithoutInitialValue : DecodableSuper { // expected-error {{class 'DecodableSubWithoutInitialValue' has no initializers}}
-  // expected-note@-1 {{did you mean to override 'init(from:)'?}}{{1-1=\noverride init(from decoder: Decoder) throws {\n    <#code#>\n\}}}
   var value2: Int // expected-note {{stored property 'value2' without initial value prevents synthesized initializers}}
 }
 
@@ -76,15 +76,16 @@ class CodableSuper : Codable {
   var value = 5
 }
 
+// expected-note@+1 {{did you mean to override 'init(from:)' and 'encode(to:)'?}}{{+1:1-1=\noverride init(from decoder: Decoder) throws {\n    <#code#>\n\}\n\noverride func encode(to encoder: Encoder) throws {\n    <#code#>\n\}}}
 class CodableSubWithoutInitialValue : CodableSuper { // expected-error {{class 'CodableSubWithoutInitialValue' has no initializers}}
-  // expected-note@-1 {{did you mean to override 'init(from:)' and 'encode(to:)'?}}{{1-1=\noverride init(from decoder: Decoder) throws {\n    <#code#>\n\}\n\noverride func encode(to encoder: Encoder) throws {\n    <#code#>\n\}}}
   var value2: Int // expected-note {{stored property 'value2' without initial value prevents synthesized initializers}}
 }
 
 // We should only mention encode(to:) in the diagnostic if the subclass does not
 // override it.
+//
+// expected-note@+1 {{did you mean to override 'init(from:)'?}}{{+1:1-1=\noverride init(from decoder: Decoder) throws {\n    <#code#>\n\}}}
 class EncodableSubWithoutInitialValue : CodableSuper { // expected-error {{class 'EncodableSubWithoutInitialValue' has no initializers}}
-  // expected-note@-1 {{did you mean to override 'init(from:)'?}}{{1-1=\noverride init(from decoder: Decoder) throws {\n    <#code#>\n\}}}
   var value2: Int // expected-note {{stored property 'value2' without initial value prevents synthesized initializers}}
 
   override func encode(to: Encoder) throws {}

--- a/test/expr/closure/trailing.swift
+++ b/test/expr/closure/trailing.swift
@@ -332,7 +332,7 @@ func testOverloadAmbiguity() {
   overloadOnLabelSomeDefaultArgs(1) {} // expected-error {{ambiguous use of 'overloadOnLabelSomeDefaultArgs'}} expected-note {{use an explicit argument label instead of a trailing closure to call 'overloadOnLabelSomeDefaultArgs(_:x:a:)'}} {{35-37=, a: }} {{39-39=)}} expected-note {{use an explicit argument label instead of a trailing closure to call 'overloadOnLabelSomeDefaultArgs(_:x:b:)'}} {{35-37=, b: }} {{39-39=)}}
   overloadOnLabelSomeDefaultArgs(1, x: 2) {} // expected-error {{ambiguous use of 'overloadOnLabelSomeDefaultArgs'}} expected-note {{use an explicit argument label instead of a trailing closure to call 'overloadOnLabelSomeDefaultArgs(_:x:a:)'}} {{41-43=, a: }} {{45-45=)}} expected-note {{use an explicit argument label instead of a trailing closure to call 'overloadOnLabelSomeDefaultArgs(_:x:b:)'}} {{41-43=, b: }} {{45-45=)}}
 
-  overloadOnLabelSomeDefaultArgs( // expected-error {{ambiguous use of 'overloadOnLabelSomeDefaultArgs'}} expected-note {{use an explicit argument label instead of a trailing closure to call 'overloadOnLabelSomeDefaultArgs(_:x:a:)'}} {{12-5=, a: }} {{4-4=)}} expected-note {{use an explicit argument label instead of a trailing closure to call 'overloadOnLabelSomeDefaultArgs(_:x:b:)'}} {{12-5=, b: }} {{4-4=)}}
+  overloadOnLabelSomeDefaultArgs( // expected-error {{ambiguous use of 'overloadOnLabelSomeDefaultArgs'}} expected-note {{use an explicit argument label instead of a trailing closure to call 'overloadOnLabelSomeDefaultArgs(_:x:a:)'}} {{+1:12-+2:5=, a: }} {{+4:4-4=)}} expected-note {{use an explicit argument label instead of a trailing closure to call 'overloadOnLabelSomeDefaultArgs(_:x:b:)'}} {{+1:12-+2:5=, b: }} {{+4:4-4=)}}
     1, x: 2
   ) {
     // some

--- a/test/stmt/nonexhaustive_switch_stmt_editor.swift
+++ b/test/stmt/nonexhaustive_switch_stmt_editor.swift
@@ -13,14 +13,16 @@ public func testNonExhaustive(_ value: NonExhaustive) {
   case .a: break
   }
 
-  switch value { // expected-warning {{switch covers known cases, but 'NonExhaustive' may have additional unknown values}}
-  // expected-note@-1 {{handle unknown values using "@unknown default"}} {{3-3=@unknown default:\n<#fatalError()#>\n}}
+  // expected-warning@+2 {{switch covers known cases, but 'NonExhaustive' may have additional unknown values}}
+  // expected-note@+1 {{handle unknown values using "@unknown default"}} {{+3:3-3=@unknown default:\n<#fatalError()#>\n}}
+  switch value {
   case .a: break
   case .b: break
   }
-  
-  switch value { // expected-error {{switch must be exhaustive}}
-  // expected-note@-1 {{do you want to add missing cases?}} {{3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n@unknown default:\n<#code#>\n}}
+
+  // expected-error@+2 {{switch must be exhaustive}}
+  // expected-note@+1 {{do you want to add missing cases?}} {{+1:3-3=case .a:\n<#code#>\ncase .b:\n<#code#>\n@unknown default:\n<#code#>\n}}
+  switch value {
   }
 
   switch value {

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -185,7 +185,8 @@ func NonVoidReturn1() -> Int {
 }
 
 func NonVoidReturn2() -> Int {
-  return + // expected-error {{unary operator cannot be separated from its operand}} {{11-1=}} expected-error {{expected expression in 'return' statement}}
+  // FIXME: Bad diagnostic
+  return + // expected-error {{unary operator cannot be separated from its operand}} {{11-+1:1=}} expected-error {{expected expression in 'return' statement}}
 }
 
 func VoidReturn1() {
@@ -238,9 +239,9 @@ func DoStmt() {
 
 
 func DoWhileStmt1() {
+  // expected-note@+2 {{did you mean 'repeat-while' statement?}} {{3-5=repeat}}
+  // expected-note@+1 {{did you mean separate 'do' and 'while' statements?}} {{+1:5-5=\n}}
   do { // expected-error {{'do-while' statement is not allowed}}
-  // expected-note@-1 {{did you mean 'repeat-while' statement?}} {{3-5=repeat}}
-  // expected-note@-2 {{did you mean separate 'do' and 'while' statements?}} {{5-5=\n}}
   } while true
 }
 
@@ -274,8 +275,9 @@ func RepeatWhileStmt2() {
 }
 
 func RepeatWhileStmt4() {
+  // FIXME: Bad diagnostic
   repeat {
-  } while + // expected-error {{unary operator cannot be separated from its operand}} {{12-1=}} expected-error {{expected expression in 'repeat-while' condition}}
+  } while + // expected-error {{unary operator cannot be separated from its operand}} {{12-+1:1=}} expected-error {{expected expression in 'repeat-while' condition}}
 }
 
 func brokenSwitch(_ x: Int) -> Int {
@@ -564,33 +566,33 @@ outerLoop: repeat { // expected-note {{'outerLoop' declared here}}
   continue outerloop // expected-error {{cannot find label 'outerloop' in scope; did you mean 'outerLoop'?}} {{12-21=outerLoop}}
 } while true
 
-outerLoop1: for _ in [1] { // expected-note {{did you mean 'outerLoop1'?}} {{11-20=outerLoop1}}
-  outerLoop2: for _ in [1] { // expected-note {{did you mean 'outerLoop2'?}} {{11-20=outerLoop2}}
+outerLoop1: for _ in [1] { // expected-note {{did you mean 'outerLoop1'?}} {{+2:11-20=outerLoop1}}
+  outerLoop2: for _ in [1] { // expected-note {{did you mean 'outerLoop2'?}} {{+1:11-20=outerLoop2}}
     break outerloop // expected-error {{cannot find label 'outerloop' in scope}}
   }
 }
-outerLoop1: for _ in [1] { // expected-note {{did you mean 'outerLoop1'?}} {{14-23=outerLoop1}}
-  outerLoop2: for _ in [1] { // expected-note {{did you mean 'outerLoop2'?}} {{14-23=outerLoop2}}
+outerLoop1: for _ in [1] { // expected-note {{did you mean 'outerLoop1'?}} {{+2:14-23=outerLoop1}}
+  outerLoop2: for _ in [1] { // expected-note {{did you mean 'outerLoop2'?}} {{+1:14-23=outerLoop2}}
     continue outerloop // expected-error {{cannot find label 'outerloop' in scope}}
   }
 }
-outerLoop1: while true { // expected-note {{did you mean 'outerLoop1'?}} {{11-20=outerLoop1}}
-  outerLoop2: while true { // expected-note {{did you mean 'outerLoop2'?}} {{11-20=outerLoop2}}
+outerLoop1: while true { // expected-note {{did you mean 'outerLoop1'?}} {{+2:11-20=outerLoop1}}
+  outerLoop2: while true { // expected-note {{did you mean 'outerLoop2'?}} {{+1:11-20=outerLoop2}}
     break outerloop // expected-error {{cannot find label 'outerloop' in scope}}
   }
 }
-outerLoop1: while true { // expected-note {{did you mean 'outerLoop1'?}} {{14-23=outerLoop1}}
-  outerLoop2: while true { // expected-note {{did you mean 'outerLoop2'?}} {{14-23=outerLoop2}}
+outerLoop1: while true { // expected-note {{did you mean 'outerLoop1'?}} {{+2:14-23=outerLoop1}}
+  outerLoop2: while true { // expected-note {{did you mean 'outerLoop2'?}} {{+1:14-23=outerLoop2}}
     continue outerloop // expected-error {{cannot find label 'outerloop' in scope}}
   }
 }
-outerLoop1: repeat { // expected-note {{did you mean 'outerLoop1'?}} {{11-20=outerLoop1}}
-  outerLoop2: repeat { // expected-note {{did you mean 'outerLoop2'?}} {{11-20=outerLoop2}}
+outerLoop1: repeat { // expected-note {{did you mean 'outerLoop1'?}} {{+2:11-20=outerLoop1}}
+  outerLoop2: repeat { // expected-note {{did you mean 'outerLoop2'?}} {{+1:11-20=outerLoop2}}
     break outerloop // expected-error {{cannot find label 'outerloop' in scope}}
   } while true
 } while true
-outerLoop1: repeat { // expected-note {{did you mean 'outerLoop1'?}} {{14-23=outerLoop1}}
-  outerLoop2: repeat { // expected-note {{did you mean 'outerLoop2'?}} {{14-23=outerLoop2}}
+outerLoop1: repeat { // expected-note {{did you mean 'outerLoop1'?}} {{+2:14-23=outerLoop1}}
+  outerLoop2: repeat { // expected-note {{did you mean 'outerLoop2'?}} {{+1:14-23=outerLoop2}}
     continue outerloop // expected-error {{cannot find label 'outerloop' in scope}}
   } while true
 } while true

--- a/test/stmt/switch_stmt2.swift
+++ b/test/stmt/switch_stmt2.swift
@@ -13,8 +13,8 @@ func foo1(e : E) {
 }
 
 func foo2(i : Int) {
+  // expected-note@+1{{do you want to add a default clause?}}{{+2:3-3=default:\n<#code#>\n}}
   switch i { // expected-error{{switch must be exhaustive}}
-  // expected-note@-1{{do you want to add a default clause?}}{{3-3=default:\n<#code#>\n}}
   case 1: return
   }
 }

--- a/test/stmt/switch_stmt_editor2.swift
+++ b/test/stmt/switch_stmt_editor2.swift
@@ -6,15 +6,15 @@ enum E {
 }
 
 func foo1(e : E) {
+  // expected-note@+1{{do you want to add missing cases?}}{{+2:3-3=case .e2:\n<#code#>\n}}
   switch e { // expected-error{{switch must be exhaustive}}
-  // expected-note@-1{{do you want to add missing cases?}}{{3-3=case .e2:\n<#code#>\n}}
   case .e1: return
   }
 }
 
 func foo2(i : Int) {
+  // expected-note@+1{{do you want to add a default clause?}}{{+2:3-3=default:\n<#code#>\n}}
   switch i { // expected-error{{switch must be exhaustive}}
-  // expected-note@-1{{do you want to add a default clause?}}{{3-3=default:\n<#code#>\n}}
   case 1: return
   }
 }


### PR DESCRIPTION
An audaciously late follow-up to https://github.com/apple/swift/pull/39572#discussion_r795089230.

* Default the start line to the line of the expected diagnostic.
* Default the end line to the start line.

Previously, the start and end lines of a replacement range were verified only when specified in the expected fix-it, e.g. `{{+1:5-10=bla}}`. This patch implements a sensible defaulting behavior for lines in an expected replacement range and thus enables unconditional rigorous full-range verification, which I believe is essential going forward. No noticeable difference is visible or expected performance-wise:
* We have fast paths for the common case of an intra-line source range (when the end location is on the same line).
* The LLVM source manager [exhaustively fills a line offset cache](https://github.com/apple/llvm-project/blob/43904c83c79ccd4eff61215cb5168af12ba46716/llvm/lib/Support/SourceMgr.cpp#L121) the first time a line number is requested in a given buffer. This already happens when the line of the expected diagnostic is computed.

Test changes are mostly cosmetic.