### PR TITLE
[Build] Limit Ubuntu 18.04 LSAN CI to 12 link jobs

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1215,6 +1215,9 @@ reconfigure
 [preset: buildbot_incremental_linux,lsan,tools=RDA,stdlib=DA,test=no]
 build-subdir=buildbot_incremental_lsan
 
+llvm-cmake-options=-DLLVM_PARALLEL_LINK_JOBS=12
+swift-cmake-options=-DSWIFT_PARALLEL_LINK_JOBS=12
+
 release-debuginfo
 assertions
 enable-lsan


### PR DESCRIPTION
It's currently running out of memory, likely due to the machine's high core count and linking many jobs at once. Limit to 12 only.