### PR TITLE
[5.8][CSGen] Handle recursive use of variable declarations

### DIFF
--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -74,7 +74,7 @@ public:
     if (auto *DRE = dyn_cast<DeclRefExpr>(expr)) {
       auto *decl = DRE->getDecl();
 
-      if (auto type = CS.getTypeIfAvailable(DRE->getDecl())) {
+      if (auto type = CS.getTypeIfAvailable(decl)) {
         auto &ctx = CS.getASTContext();
         // If this is not one of the closure parameters which
         // is inferrable from the body, let's replace type

--- a/test/expr/closure/multi_statement.swift
+++ b/test/expr/closure/multi_statement.swift
@@ -650,3 +650,16 @@ func test_that_closures_are_attempted_in_order() {
     return false
   }
 }
+
+// https://github.com/apple/swift/issues/63455
+func test_recursive_var_reference_in_multistatement_closure() {
+  func takeClosure(_ x: () -> Void) {}
+
+  func test(optionalInt: Int?) {
+    takeClosure {
+      let int = optionalInt { // expected-error {{cannot call value of non-function type 'Int?'}}
+        print(int)
+      }
+    }
+  }
+}

--- a/validation-test/IDE/crashers_2_fixed/issue-63455.swift
+++ b/validation-test/IDE/crashers_2_fixed/issue-63455.swift
@@ -1,0 +1,25 @@
+// RUN: %swift-ide-test -code-completion -source-filename %s -code-completion-token COMPLETE
+
+func sheet(onDismiss: () -> Void) -> EmptyView {
+  fatalError()
+}
+
+@resultBuilder struct ViewBuilder2 {
+  static func buildBlock(_ content: EmptyView) -> EmptyView {
+    return content
+  }
+}
+
+struct EmptyView {}
+
+struct SettingsView {
+  var importedFile: Int?
+
+  @ViewBuilder2 var body2: EmptyView {
+    sheet {
+      #^COMPLETE^#if let url = self.importedFile {
+        print(url)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/63505

---

It's possible for out-of-scope type variable to be the type 
of declaration if such declaration is recursively referenced 
in the body of a closure located in its initializer expression. 
In such cases type of the variable declaration cannot be 
connected to the closure because its not known in advance 
(determined by the initializer itself).

Resolves: https://github.com/apple/swift/issues/63455 (cherry picked from commit 83dd93ad2e902972eee58a3344f69a554e98e661)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
