### PR TITLE
ABI Checker: avoid reporting module importation changes

### DIFF
--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -549,8 +549,7 @@ namespace {
 
 static bool isMissingDeclAcceptable(const SDKNodeDecl *D) {
   // Don't complain about removing importation of SwiftOnoneSupport.
-  if (D->getKind() == SDKNodeKind::DeclImport &&
-      D->getName() == "SwiftOnoneSupport") {
+  if (D->getKind() == SDKNodeKind::DeclImport) {
     return true;
   }
   return false;

--- a/test/api-digester/Outputs/apinotes-diags.txt
+++ b/test/api-digester/Outputs/apinotes-diags.txt
@@ -15,7 +15,6 @@ APINotesTest(APINotesTest.h): TypeAlias CatAttributeName has been removed
 APINotesTest(APINotesTest.h): Protocol SwiftTypeWithMethodLeft has been renamed to Protocol SwiftTypeWithMethodRight
 APINotesTest(APINotesTest.h): Var OldType.oldMember has been renamed to Var NewType.newMember
 APINotesTest(APINotesTest.h): Var globalAttributeName has been renamed to Var AnimalAttributeName.globalAttributeName
-APINotesTest: Import Foundation has been renamed to Import objc_generics
 
 /* Type Changes */
 APINotesTest(APINotesTest.h): Constructor Cat.init(name:) has return type change from APINotesTest.Cat to APINotesTest.Cat?


### PR DESCRIPTION
ABI changes due to imported module changes should be reflected by other symbol changes. Reporting module import changes seems to be redundant.
