### PR TITLE
Test that SIL inlining works for the new variadic generics instructions

### DIFF
--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -169,7 +169,7 @@ public:
   bool isCanonical() const;
 
   /// Return the canonical form of this substitution map.
-  SubstitutionMap getCanonical() const;
+  SubstitutionMap getCanonical(bool canonicalizeSignature = true) const;
 
   /// Apply a substitution to all replacement types in the map. Does not
   /// change keys.

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -164,10 +164,12 @@ bool SubstitutionMap::isCanonical() const {
   return true;
 }
 
-SubstitutionMap SubstitutionMap::getCanonical() const {
+SubstitutionMap SubstitutionMap::getCanonical(bool canonicalizeSignature) const {
   if (empty()) return *this;
 
-  auto canonicalSig = getGenericSignature().getCanonicalSignature();
+  auto sig = getGenericSignature();
+  if (canonicalizeSignature) sig = sig.getCanonicalSignature();
+
   SmallVector<Type, 4> replacementTypes;
   for (Type replacementType : getReplacementTypesBuffer()) {
     if (replacementType)
@@ -181,11 +183,10 @@ SubstitutionMap SubstitutionMap::getCanonical() const {
     conformances.push_back(conf.getCanonicalConformanceRef());
   }
 
-  return SubstitutionMap::get(canonicalSig,
+  return SubstitutionMap::get(sig,
                               ArrayRef<Type>(replacementTypes),
                               ArrayRef<ProtocolConformanceRef>(conformances));
 }
-
 
 SubstitutionMap SubstitutionMap::get(GenericSignature genericSig,
                                      SubstitutionMap substitutions) {

--- a/test/SILOptimizer/variadic_generics.sil
+++ b/test/SILOptimizer/variadic_generics.sil
@@ -1,0 +1,109 @@
+// RUN: %target-sil-opt -enable-experimental-feature VariadicGenerics -enable-sil-verify-all %s -inline | %FileCheck %s
+
+import Swift
+import Builtin
+
+sil [ossa] [always_inline] @scalar_pack_index : $<T...> () -> () {
+bb0:
+  %0 = scalar_pack_index 0 of $Pack{Int, repeat each T}
+  %1 = scalar_pack_index 1 of $Pack{repeat each T, Int}
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @test_scalar_pack_index_1
+// CHECK:         scalar_pack_index 0 of $Pack{Int, repeat each U}
+// CHECK:         scalar_pack_index 1 of $Pack{repeat each U, Int}
+sil @test_scalar_pack_index_1 : $<U...> () -> () {
+bb0:
+  %fn = function_ref @scalar_pack_index : $@convention(thin) <T...> () -> ()
+  apply %fn<Pack{repeat each U}>() : $@convention(thin) <T...> () -> ()
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @test_scalar_pack_index_2
+// CHECK:         scalar_pack_index 0 of $Pack{Int, Float, repeat each U}
+// CHECK:         scalar_pack_index 2 of $Pack{Float, repeat each U, Int}
+sil @test_scalar_pack_index_2 : $<U...> () -> () {
+bb0:
+  %fn = function_ref @scalar_pack_index : $@convention(thin) <T...> () -> ()
+  apply %fn<Pack{Float, repeat each U}>() : $@convention(thin) <T...> () -> ()
+  %ret = tuple ()
+  return %ret : $()
+}
+
+sil [ossa] [always_inline] @pack_pack_index : $<T...> (Builtin.Word) -> () {
+bb0(%i: $Builtin.Word):
+  %index = dynamic_pack_index %i of $Pack{repeat each T}
+  %0 = pack_pack_index 1, %index of $Pack{Int, repeat each T}
+  %1 = pack_pack_index 0, %index of $Pack{repeat each T, Int}
+  %2 = pack_pack_index 1, %index of $Pack{repeat each T, repeat each T}
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @test_pack_pack_index_1
+// CHECK:         [[INNER:%.*]] = dynamic_pack_index %0 of $Pack{repeat each U}
+// CHECK:         pack_pack_index 1, [[INNER]] of $Pack{Int, repeat each U}
+// CHECK:         pack_pack_index 0, [[INNER]] of $Pack{repeat each U, Int}
+// CHECK:         pack_pack_index 1, [[INNER]] of $Pack{repeat each U, repeat each U}
+sil @test_pack_pack_index_1 : $<U...> (Builtin.Word) -> () {
+bb0(%i: $Builtin.Word):
+  %fn = function_ref @pack_pack_index : $@convention(thin) <T...> (Builtin.Word) -> ()
+  apply %fn<Pack{repeat each U}>(%i) : $@convention(thin) <T...> (Builtin.Word) -> ()
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @test_pack_pack_index_2
+// CHECK:         [[INNER:%.*]] = dynamic_pack_index %0 of $Pack{Float, repeat each U}
+// CHECK:         pack_pack_index 1, [[INNER]] of $Pack{Int, Float, repeat each U}
+// CHECK:         pack_pack_index 0, [[INNER]] of $Pack{Float, repeat each U, Int}
+// CHECK:         pack_pack_index 2, [[INNER]] of $Pack{Float, repeat each U, Float, repeat each U}
+sil @test_pack_pack_index_2 : $<U...> (Builtin.Word) -> () {
+bb0(%i: $Builtin.Word):
+  %fn = function_ref @pack_pack_index : $@convention(thin) <T...> (Builtin.Word) -> ()
+  apply %fn<Pack{Float, repeat each U}>(%i) : $@convention(thin) <T...> (Builtin.Word) -> ()
+  %ret = tuple ()
+  return %ret : $()
+}
+
+sil [ossa] [always_inline] @tuple_pack_element : $<T...> (Builtin.Word, @inout (repeat each T)) -> () {
+bb0(%i: $Builtin.Word, %tuple : $*(repeat each T)):
+  %index = dynamic_pack_index %i of $Pack{repeat each T}
+  %tok = open_pack_element %index of <Z...> at <Pack{repeat each T}>, shape $Z, uuid "01234567-89AB-CDEF-0123-000000000000"
+  %0 = tuple_pack_element_addr %index of %tuple : $*(repeat each T) as $*@pack_element("01234567-89AB-CDEF-0123-000000000000") Z
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @test_tuple_pack_element_1
+// CHECK:         [[INDEX:%.*]] = dynamic_pack_index %0 of $Pack{repeat each U}
+// CHECK:         open_pack_element [[INDEX]] of <Z...> at <Pack{repeat each U}>, shape $Z, uuid [[UUID:".*"]]
+// CHECK:         tuple_pack_element_addr [[INDEX]] of %1 : $*(repeat each U) as $*@pack_element([[UUID]]) Z
+sil @test_tuple_pack_element_1 : $<U...> (Builtin.Word, @inout (repeat each U)) -> () {
+bb0(%i: $Builtin.Word, %tuple : $*(repeat each U)):
+  %fn = function_ref @tuple_pack_element : $@convention(thin) <T...> (Builtin.Word, @inout (repeat each T)) -> ()
+  apply %fn<Pack{repeat each U}>(%i, %tuple) : $@convention(thin) <T...> (Builtin.Word, @inout (repeat each T)) -> ()
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: sil @test_tuple_pack_element_2
+// CHECK:         [[TEMP:%.*]] = alloc_stack $Float
+// CHECK-NEXT:    [[I:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK-NEXT:    [[INDEX:%.*]] = dynamic_pack_index [[I]] of $Pack{Float}
+// CHECK-NEXT:    open_pack_element [[INDEX]] of <Z...> at <Pack{Float}>, shape $Z, uuid [[UUID:".*"]]
+// CHECK-NEXT:    unchecked_addr_cast [[TEMP]] : $*Float to $*@pack_element([[UUID]]) Z
+sil @test_tuple_pack_element_2 : $() -> () {
+bb0:
+  %tuple = alloc_stack $Float
+  %i = integer_literal $Builtin.Word, 0
+  %fn = function_ref @tuple_pack_element : $@convention(thin) <T...> (Builtin.Word, @inout (repeat each T)) -> ()
+  apply %fn<Pack{Float}>(%i, %tuple) : $@convention(thin) <T...> (Builtin.Word, @inout (repeat each T)) -> ()
+  dealloc_stack %tuple : $*Float
+  %ret = tuple ()
+  return %ret : $()
+}
+


### PR DESCRIPTION
I had a fix a bunch of bugs in this, which isn't very surprising.

I removed the getCanonical() call in remapSubstitutionMap because it messes up printing open_pack_element pretty badly --- we end up printing a sugared shape class but a desugared generic signature.  This is the second time I've found myself doing something a little gross in order to preserve sugar for printing this instruction.  On the other hand, there's no good reason to canonicalize this here anyway.  If we want canonical types in the substitutions, we should probably just do that and leave the signature alone.

The most interesting part of this is that I implemented a rule which handles tuple types becoming scalar as part of the substitution of tuple_pack_element_addr.  We talked about having this rule in the formal type system, and I thought we were going to do it, but it looks like we haven't actually implemented that yet.  I added it to SIL substitution because (1) I anticipate we'll be doing this eventually in the formal type system, and that will have consequences for SIL, and (2) we don't actually have a way to parse these singleton tuple types, and I didn't want expanding singleton packs into tuples to become this weird untestable corner case.

I think adding a type_refine_addr that statically asserts a type match is the right way to go in the long term for rewriting singleton tuple_pack_element_addr, but I'm a little sick of adding SIL instructions, so we just rewrite to unchecked_addr_cast for now.