### PR TITLE
[Serialization] Move deserialization safety behind an env var or flag

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -366,7 +366,7 @@ namespace swift {
 
     /// Enable early skipping deserialization of decls that are marked as
     /// unsafe to read.
-    bool EnableDeserializationSafety = true;
+    bool EnableDeserializationSafety = false;
 
     /// Whether to enable the new operator decl and precedencegroup lookup
     /// behavior. This is a staging flag, and will be removed in the future.

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -366,7 +366,8 @@ namespace swift {
 
     /// Enable early skipping deserialization of decls that are marked as
     /// unsafe to read.
-    bool EnableDeserializationSafety = false;
+    bool EnableDeserializationSafety =
+      ::getenv("SWIFT_ENABLE_DESERIALIZATION_SAFETY");
 
     /// Whether to enable the new operator decl and precedencegroup lookup
     /// behavior. This is a staging flag, and will be removed in the future.

--- a/test/Serialization/Safety/override-internal-func.swift
+++ b/test/Serialization/Safety/override-internal-func.swift
@@ -10,11 +10,13 @@
 // RUN:   -emit-module-interface-path %t/Lib.swiftinterface
 
 /// Build against the swiftmodule.
-// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -enable-deserialization-safety
 
 /// Build against the swiftinterface.
 // RUN: rm %t/Lib.swiftmodule
-// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -enable-deserialization-safety
 
 //--- Lib.swift
 

--- a/test/Serialization/Safety/skip-reading-internal-anyobject.swift
+++ b/test/Serialization/Safety/skip-reading-internal-anyobject.swift
@@ -11,7 +11,8 @@
 
 /// Build client.
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -verify -Xllvm -debug-only=Serialization 2>&1 \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -enable-deserialization-safety 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=SAFE %s
 
 /// Decls skips by the deserialization safety logic.

--- a/test/Serialization/Safety/skip-reading-internal-details.swift
+++ b/test/Serialization/Safety/skip-reading-internal-details.swift
@@ -19,7 +19,8 @@
 // RUN:   | %FileCheck --check-prefixes=NEEDED,UNSAFE %s
 
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
-// RUN:   -verify -Xllvm -debug-only=Serialization 2>&1 \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -enable-deserialization-safety 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=NEEDED,CLEAN,SAFE %s
 
 /// Build against the swiftinterface.

--- a/test/Serialization/Safety/skip-reading-internal-details.swift
+++ b/test/Serialization/Safety/skip-reading-internal-details.swift
@@ -23,6 +23,18 @@
 // RUN:   -enable-deserialization-safety 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=NEEDED,CLEAN,SAFE %s
 
+/// Disabled by default.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -verify -Xllvm -debug-only=Serialization \
+// RUN:   -disable-deserialization-safety 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=NEEDED,UNSAFE %s
+
+/// Enable with env var.
+// RUN: env SWIFT_ENABLE_DESERIALIZATION_SAFETY=true \
+// RUN:   %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -verify -Xllvm -debug-only=Serialization 2>&1 \
+// RUN:   | %FileCheck --check-prefixes=NEEDED,CLEAN,SAFE %s
+
 /// Build against the swiftinterface.
 // RUN: rm %t/Lib.swiftmodule
 // RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \

--- a/test/Serialization/Safety/unsafe-decls.swift
+++ b/test/Serialization/Safety/unsafe-decls.swift
@@ -4,11 +4,13 @@
 
 // RUN: %target-swift-frontend -emit-module %s \
 // RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
 // RUN:   -Xllvm -debug-only=Serialization 2>&1 | %swift-demangle --simplified \
 // RUN:   | %FileCheck --check-prefixes=SAFETY-PRIVATE,SAFETY-INTERNAL %s
 
 // RUN: %target-swift-frontend -emit-module %s \
 // RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
 // RUN:   -Xllvm -debug-only=Serialization \
 // RUN:   -enable-testing 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=DISABLED %s
@@ -16,13 +18,14 @@
 /// Don't mark decls as unsafe when private import is enabled.
 // RUN: %target-swift-frontend -emit-module %s \
 // RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
 // RUN:   -Xllvm -debug-only=Serialization \
 // RUN:   -enable-private-imports 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=DISABLED %s
 
 /// Don't mark decls as unsafe without library evolution.
 // RUN: %target-swift-frontend -emit-module %s \
-// RUN:   -swift-version 5 \
+// RUN:   -enable-deserialization-safety -swift-version 5 \
 // RUN:   -Xllvm -debug-only=Serialization 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=DISABLED %s
 

--- a/test/Serialization/Safety/unsafe-extensions.swift
+++ b/test/Serialization/Safety/unsafe-extensions.swift
@@ -4,11 +4,13 @@
 
 // RUN: %target-swift-frontend -emit-module %s \
 // RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
 // RUN:   -Xllvm -debug-only=Serialization 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=SAFETY-PRIVATE,SAFETY-INTERNAL %s
 
 // RUN: %target-swift-frontend -emit-module %s \
 // RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
 // RUN:   -Xllvm -debug-only=Serialization \
 // RUN:   -enable-testing 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=DISABLED %s
@@ -16,13 +18,14 @@
 /// Don't mark decls as unsafe when private import is enabled.
 // RUN: %target-swift-frontend -emit-module %s \
 // RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-deserialization-safety \
 // RUN:   -Xllvm -debug-only=Serialization \
 // RUN:   -enable-private-imports 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=DISABLED %s
 
 /// Don't mark decls as unsafe without library evolution.
 // RUN: %target-swift-frontend -emit-module %s \
-// RUN:   -swift-version 5 \
+// RUN:   -enable-deserialization-safety -swift-version 5 \
 // RUN:   -Xllvm -debug-only=Serialization 2>&1 \
 // RUN:   | %FileCheck --check-prefixes=DISABLED %s
 


### PR DESCRIPTION
Disable deserialization safety by default while we investigate issues with opaque types and indirect conformances via internal types. Also ensure that we can now enable safety with an environment variable for testing.