### PR TITLE
[Concurrency] Base priority should be present on UnsafeTask too

### DIFF
--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -824,7 +824,7 @@ public struct UnsafeCurrentTask {
   /// The current task's base priority.
   ///
   /// - SeeAlso: `TaskPriority`
-  /// - SeeAlso: `Task.currentBasePriority`
+  /// - SeeAlso: `Task.basePriority`
   @available(SwiftStdlib 5.9, *)
   public var basePriority: TaskPriority {
     TaskPriority(rawValue: _taskBasePriority(_task))

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -287,10 +287,10 @@ extension Task where Success == Never, Failure == Never {
   /// If the system can't provide a priority,
   /// this property's value is `Priority.default`.
   public static var currentPriority: TaskPriority {
-    withUnsafeCurrentTask { task in
+    withUnsafeCurrentTask { unsafeTask in
       // If we are running on behalf of a task, use that task's priority.
-      if let unsafeTask = task {
-         return TaskPriority(rawValue: _taskCurrentPriority(unsafeTask._task))
+      if let unsafeTask {
+         return unsafeTask.priority
       }
 
       // Otherwise, query the system.
@@ -311,6 +311,7 @@ extension Task where Success == Never, Failure == Never {
       return nil
     }
   }
+
 }
 
 @available(SwiftStdlib 5.1, *)
@@ -818,6 +819,15 @@ public struct UnsafeCurrentTask {
   /// - SeeAlso: `Task.currentPriority`
   public var priority: TaskPriority {
     TaskPriority(rawValue: _taskCurrentPriority(_task))
+  }
+
+  /// The current task's base priority.
+  ///
+  /// - SeeAlso: `TaskPriority`
+  /// - SeeAlso: `Task.currentBasePriority`
+  @available(SwiftStdlib 5.9, *)
+  public var basePriority: TaskPriority {
+    TaskPriority(rawValue: _taskBasePriority(_task))
   }
 
   /// Cancel the current task.

--- a/test/Concurrency/async_task_priority.swift
+++ b/test/Concurrency/async_task_priority.swift
@@ -39,6 +39,13 @@ func expectedBasePri(priority: TaskPriority) -> TaskPriority {
   let basePri = Task.basePriority!
   print("Testing basePri matching expected pri - \(basePri) == \(priority)")
   expectEqual(basePri, priority)
+  Task.withUnsafeCurrentTask { unsafeTask in
+    guard let unsafeTask else {
+      fatalError("Expected to be able to get current task, but could not!")
+    }
+    // The UnsafeCurrentTask must return the same value
+    expectEqual(basePri, unsafeTask.basePriority)
+  }
 
   return basePri
 }


### PR DESCRIPTION
In 5.7 `Task.basePriority` was added though we missed adding it to `UnsafeTask` which should reflect all API available on the "current task" using static functions.

The naming of the "inspect the current task" methods used to be prefixed with current in early SE reviews, but since now it only is the `Task.currentPriority` I guess that convention doesn't really hold water, so keeping the name as-is as "`basePriority`" is likely okey -- so this PR only adds the one missing API so UnsafeTask and Task have feature parity.