### PR TITLE
[cxx-interop] NFC: move unsafe iterator types to a separate file

### DIFF
--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -10,6 +10,7 @@ add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDL
     CxxSet.swift
     CxxRandomAccessCollection.swift
     CxxSequence.swift
+    UnsafeCxxIterators.swift
 
     SWIFT_COMPILE_FLAGS ${SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS} ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -Xfrontend -enable-experimental-cxx-interop

--- a/stdlib/public/Cxx/CxxRandomAccessCollection.swift
+++ b/stdlib/public/Cxx/CxxRandomAccessCollection.swift
@@ -10,24 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Bridged C++ iterator that allows computing the distance between two of its
-/// instances, and advancing an instance by a given number of elements.
-///
-/// Mostly useful for conforming a type to the `CxxRandomAccessCollection`
-/// protocol and should not generally be used directly.
-///
-/// - SeeAlso: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator
-public protocol UnsafeCxxRandomAccessIterator: UnsafeCxxInputIterator {
-  associatedtype Distance: BinaryInteger
-
-  static func -(lhs: Self, rhs: Self) -> Distance
-  static func +=(lhs: inout Self, rhs: Distance)
-}
-
-extension UnsafePointer: UnsafeCxxRandomAccessIterator {}
-
-extension UnsafeMutablePointer: UnsafeCxxRandomAccessIterator {}
-
 public protocol CxxRandomAccessCollection<Element>: CxxSequence, RandomAccessCollection {
   override associatedtype Element
   override associatedtype RawIterator: UnsafeCxxRandomAccessIterator

--- a/stdlib/public/Cxx/CxxSequence.swift
+++ b/stdlib/public/Cxx/CxxSequence.swift
@@ -10,53 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-/// Bridged C++ iterator that allows to traverse the elements of a sequence 
-/// using a for-in loop.
-///
-/// Mostly useful for conforming a type to the `CxxSequence` protocol and should
-/// not generally be used directly.
-///
-/// - SeeAlso: https://en.cppreference.com/w/cpp/named_req/InputIterator
-public protocol UnsafeCxxInputIterator: Equatable {
-  associatedtype Pointee
-
-  /// Returns the unwrapped result of C++ `operator*()`.
-  ///
-  /// Generally, Swift creates this property automatically for C++ types that
-  /// define `operator*()`.
-  var pointee: Pointee { get }
-
-  /// Returns an iterator pointing to the next item in the sequence.
-  ///
-  /// Generally, Swift creates this property automatically for C++ types that
-  /// define pre-increment `operator++()`.
-  func successor() -> Self
-}
-
-extension UnsafePointer: UnsafeCxxInputIterator {}
-
-extension UnsafeMutablePointer: UnsafeCxxInputIterator {}
-
-extension Optional: UnsafeCxxInputIterator where Wrapped: UnsafeCxxInputIterator {
-  public typealias Pointee = Wrapped.Pointee
-
-  @inlinable
-  public var pointee: Pointee {
-    if let value = self {
-      return value.pointee
-    }
-    fatalError("Could not dereference nullptr")
-  }
-
-  @inlinable
-  public func successor() -> Self {
-    if let value = self {
-      return value.successor()
-    }
-    fatalError("Could not increment nullptr")
-  }
-}
-
 /// Use this protocol to conform custom C++ sequence types to Swift's `Sequence`
 /// protocol like this:
 ///

--- a/stdlib/public/Cxx/UnsafeCxxIterators.swift
+++ b/stdlib/public/Cxx/UnsafeCxxIterators.swift
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Bridged C++ iterator that allows to traverse the elements of a sequence 
+/// using a for-in loop.
+///
+/// Mostly useful for conforming a type to the `CxxSequence` protocol and should
+/// not generally be used directly.
+///
+/// - SeeAlso: https://en.cppreference.com/w/cpp/named_req/InputIterator
+public protocol UnsafeCxxInputIterator: Equatable {
+  associatedtype Pointee
+
+  /// Returns the unwrapped result of C++ `operator*()`.
+  ///
+  /// Generally, Swift creates this property automatically for C++ types that
+  /// define `operator*()`.
+  var pointee: Pointee { get }
+
+  /// Returns an iterator pointing to the next item in the sequence.
+  ///
+  /// Generally, Swift creates this property automatically for C++ types that
+  /// define pre-increment `operator++()`.
+  func successor() -> Self
+}
+
+extension UnsafePointer: UnsafeCxxInputIterator {}
+
+extension UnsafeMutablePointer: UnsafeCxxInputIterator {}
+
+extension Optional: UnsafeCxxInputIterator where Wrapped: UnsafeCxxInputIterator {
+  public typealias Pointee = Wrapped.Pointee
+
+  @inlinable
+  public var pointee: Pointee {
+    if let value = self {
+      return value.pointee
+    }
+    fatalError("Could not dereference nullptr")
+  }
+
+  @inlinable
+  public func successor() -> Self {
+    if let value = self {
+      return value.successor()
+    }
+    fatalError("Could not increment nullptr")
+  }
+}
+
+/// Bridged C++ iterator that allows computing the distance between two of its
+/// instances, and advancing an instance by a given number of elements.
+///
+/// Mostly useful for conforming a type to the `CxxRandomAccessCollection`
+/// protocol and should not generally be used directly.
+///
+/// - SeeAlso: https://en.cppreference.com/w/cpp/named_req/RandomAccessIterator
+public protocol UnsafeCxxRandomAccessIterator: UnsafeCxxInputIterator {
+  associatedtype Distance: BinaryInteger
+
+  static func -(lhs: Self, rhs: Self) -> Distance
+  static func +=(lhs: inout Self, rhs: Distance)
+}
+
+extension UnsafePointer: UnsafeCxxRandomAccessIterator {}
+
+extension UnsafeMutablePointer: UnsafeCxxRandomAccessIterator {}


### PR DESCRIPTION
Since the unsafe iterator types are now used throughout the overlay, not just by `CxxSequence` and `CxxRandomAccessCollection`, let's move them to a separate file.