### PR TITLE
Changed 'protocols' to 'type constraints' for obsoleted protocol composition syntax error

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -889,7 +889,7 @@ ERROR(expected_rangle_protocol,PointsToFirstBadToken,
       "expected '>' to complete protocol-constrained type", ())
 
 ERROR(deprecated_protocol_composition,none,
-      "'protocol<...>' composition syntax has been removed; join the protocols using '&'", ())
+      "'protocol<...>' composition syntax has been removed; join the type constraints using '&'", ())
 ERROR(deprecated_protocol_composition_single,none,
       "'protocol<...>' composition syntax has been removed and is not needed here", ())
 ERROR(deprecated_any_composition,none,

--- a/test/Parse/swift3_warnings_swift4_errors_version_4.swift
+++ b/test/Parse/swift3_warnings_swift4_errors_version_4.swift
@@ -11,7 +11,7 @@ protocol P2 {}
 
 let x: protocol<> // expected-error {{'protocol<>' syntax has been removed; use 'Any' instead}}
 let y: protocol<P1> // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}}}
-let z: protocol<P1, P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}}
+let z: protocol<P1, P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}}
 
 func bar(f: @noescape () -> ()) {} // expected-error {{unknown attribute 'noescape'}}
 

--- a/test/decl/inherit/inherit.swift
+++ b/test/decl/inherit/inherit.swift
@@ -49,7 +49,7 @@ struct S4 : P, P { }
 // expected-error@-1{{redundant conformance of 'S4' to protocol 'P'}}
 // expected-note@-2{{'S4' declares conformance to protocol 'P' here}}
 struct S6 : P & { }      // expected-error {{expected identifier for type name}}
-struct S7 : protocol<P, Q> { }  // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}}
+struct S7 : protocol<P, Q> { }  // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}}
                                 // expected-error @-1 {{non-class type 'S7' cannot conform to class protocol 'Q'}}
 
 class GenericBase<T> {}

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -110,7 +110,7 @@ func testConversion() {
   accept_manyPrintable(sp)
 
   // Conversions among existential types.
-  var x2 : protocol<SuperREPLPrintable, FooProtocol> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{12-53=SuperREPLPrintable & FooProtocol}}
+  var x2 : protocol<SuperREPLPrintable, FooProtocol> // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{12-53=SuperREPLPrintable & FooProtocol}}
   x2 = x // expected-error{{value of type 'any FooProtocol & REPLPrintable' does not conform to 'SuperREPLPrintable' in assignment}}
   x = x2
 
@@ -118,31 +118,31 @@ func testConversion() {
   var _ : () -> FooProtocol & SuperREPLPrintable = return_superPrintable
 
   // FIXME: closures make ABI conversions explicit. rdar://problem/19517003
-  var _ : () -> protocol<FooProtocol, REPLPrintable> = { return_superPrintable() } // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{17-53=FooProtocol & REPLPrintable}}
+  var _ : () -> protocol<FooProtocol, REPLPrintable> = { return_superPrintable() } // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{17-53=FooProtocol & REPLPrintable}}
 }
 
 // Test the parser's splitting of >= into > and =.
 var x : protocol<P5>= 17 // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{9-22=P5=}} expected-error {{'=' must have consistent whitespace on both sides}}
-var y : protocol<P5, P7>= 17 // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{9-26=P5 & P7=}} expected-error {{'=' must have consistent whitespace on both sides}}
-var z : protocol<P5, P7>?=17 // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{9-27=(P5 & P7)?=}}
+var y : protocol<P5, P7>= 17 // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{9-26=P5 & P7=}} expected-error {{'=' must have consistent whitespace on both sides}}
+var z : protocol<P5, P7>?=17 // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{9-27=(P5 & P7)?=}}
 
 typealias A1 = protocol<> // expected-error {{'protocol<>' syntax has been removed; use 'Any' instead}} {{16-26=Any}}
 typealias A2 = protocol<>? // expected-error {{'protocol<>' syntax has been removed; use 'Any' instead}} {{16-27=Any?}}
-typealias B1 = protocol<P1,P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{16-31=P1 & P2}}
-typealias B2 = protocol<P1, P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{16-32=P1 & P2}}
-typealias B3 = protocol<P1 ,P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{16-32=P1 & P2}}
-typealias B4 = protocol<P1 , P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{16-33=P1 & P2}}
-typealias C1 = protocol<Any, P1> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{16-33=Any & P1}}
-typealias C2 = protocol<P1, Any> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{16-33=P1 & Any}}
+typealias B1 = protocol<P1,P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{16-31=P1 & P2}}
+typealias B2 = protocol<P1, P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{16-32=P1 & P2}}
+typealias B3 = protocol<P1 ,P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{16-32=P1 & P2}}
+typealias B4 = protocol<P1 , P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{16-33=P1 & P2}}
+typealias C1 = protocol<Any, P1> // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{16-33=Any & P1}}
+typealias C2 = protocol<P1, Any> // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{16-33=P1 & Any}}
 typealias D = protocol<P1> // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{15-27=P1}}
 typealias E = protocol<Any> // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{15-28=Any}}
-typealias F = protocol<Any, Any> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{15-33=Any & Any}}
+typealias F = protocol<Any, Any> // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{15-33=Any & Any}}
 typealias G = protocol<P1>.Type // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{15-27=P1}}
 typealias H = protocol<P1>! // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{15-28=P1!}}
 // expected-warning@-1 {{using '!' is not allowed here; treating this as '?' instead}}
-typealias J = protocol<P1, P2>.Protocol // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{15-31=(P1 & P2)}}
-typealias K = protocol<P1, P2>? // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{15-32=(P1 & P2)?}}
-typealias L = protocol<(P1), P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{15-33=(P1) & P2}}
+typealias J = protocol<P1, P2>.Protocol // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{15-31=(P1 & P2)}}
+typealias K = protocol<P1, P2>? // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{15-32=(P1 & P2)?}}
+typealias L = protocol<(P1), P2> // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{15-33=(P1) & P2}}
 
 // Deprecated protocol composition syntax in expression context.
 do {
@@ -150,12 +150,12 @@ do {
 
   typesAreEqual(Optional<P1 & P2>.self,
                 Optional<protocol<P1, P2>>.self)
-  // expected-error@-1 {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{26-43=P1 & P2>}}
+  // expected-error@-1 {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{26-43=P1 & P2>}}
 
   // Test that we parse non-identifier components.
   typesAreEqual(Optional<P1 & P2>.self,
                 Optional<protocol<P1, (P2)>>.self)
-  // expected-error@-1 {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{26-45=P1 & (P2)>}}
+  // expected-error@-1 {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{26-45=P1 & (P2)>}}
 }
 
 typealias T01 = P1.Protocol & P2 // expected-error {{non-protocol, non-class type '(any P1).Type' cannot be used within a protocol-constrained type}}
@@ -165,7 +165,7 @@ typealias T04 = P1 & P2! // expected-error {{non-protocol, non-class type '(any 
 // expected-warning@-1 {{using '!' is not allowed here; treating this as '?' instead}}
 typealias T05 = P1 & P2 -> P3 // expected-error {{single argument function types require parentheses}} {{17-17=(}} {{24-24=)}}
 typealias T06 = P1 -> P2 & P3 // expected-error {{single argument function types require parentheses}} {{17-17=(}} {{19-19=)}}
-typealias T07 = P1 & protocol<P2, P3> // expected-error {{protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{22-38=P2 & P3}}
+typealias T07 = P1 & protocol<P2, P3> // expected-error {{protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{22-38=P2 & P3}}
 func fT07(x: T07) -> P1 & P2 & P3 { return x } // OK, 'P1 & protocol<P2, P3>' is parsed as 'P1 & P2 & P3'.
 let _: P1 & P2 & P3 -> P1 & P2 & P3 = fT07 // expected-error {{single argument function types require parentheses}} {{8-8=(}} {{20-20=)}}
 
@@ -177,8 +177,8 @@ struct S05<T> where T : P5? & P6 {} // expected-error {{non-protocol, non-class 
 
 // https://github.com/apple/swift/issues/45712
 // Protocol Composition Often Migrated Incorrectly
-struct S_45712<T: protocol<P1, P3>> {} // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{19-36=P1 & P3>}}
-func f1_45712<U where U: protocol<P1, P3>>(_: U)  {} // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}} {{26-43=P1 & P3>}} // expected-error {{'where' clause}}
+struct S_45712<T: protocol<P1, P3>> {} // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{19-36=P1 & P3>}}
+func f1_45712<U where U: protocol<P1, P3>>(_: U)  {} // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}} {{26-43=P1 & P3>}} // expected-error {{'where' clause}}
 func f2_45712<U : protocol<P1>>(_: U)  {} // expected-error {{'protocol<...>' composition syntax has been removed and is not needed here}} {{19-32=P1>}}
 
 // Make sure we correctly form compositions in expression context

--- a/test/type/protocol_types.swift
+++ b/test/type/protocol_types.swift
@@ -55,11 +55,11 @@ struct Struct2<T : Pub & Bar> { }
 struct Struct3<T : Pub & Bar & P3> { } // expected-error {{cannot find type 'P3' in scope}}
 struct Struct4<T> where T : Pub & Bar {}
 
-struct Struct5<T : protocol<Pub, Bar>> { } // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}}
-struct Struct6<T> where T : protocol<Pub, Bar> {} // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}}
+struct Struct5<T : protocol<Pub, Bar>> { } // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}}
+struct Struct6<T> where T : protocol<Pub, Bar> {} // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}}
 
 typealias T1 = Pub & Bar
-typealias T2 = protocol<Pub , Bar> // expected-error {{'protocol<...>' composition syntax has been removed; join the protocols using '&'}}
+typealias T2 = protocol<Pub , Bar> // expected-error {{'protocol<...>' composition syntax has been removed; join the type constraints using '&'}}
 
 // rdar://problem/20593294
 protocol HasAssoc {


### PR DESCRIPTION
Fixes #62518

Improves the error message caused due to obsoleted protocol composition syntax as discussed in the issue thread, `'type constraints'` would be more accurate as it isn't just limited to `'protocols'`. Changes were done in the `include/swift/AST/DiagnosticsParse.def` file and the responsible test files in the `/test` directory.