### PR TITLE
[tool] Implement initial support for `swift-inspect` under Linux 64-bit

### DIFF
--- a/tools/swift-inspect/README.md
+++ b/tools/swift-inspect/README.md
@@ -1,3 +1,21 @@
+# disclaimer
+This is **work in progress** version of `swift-inpect` which depends on [mikolasstuchlik/memtool](https://github.com/mikolasstuchlik/memtool). I hesistate to (and probably never will) include this package in the SPM manifest of `swift-inspect`.
+Check out this package and build it - then link the products manually via the helper script.
+
+```bash
+# Example
+python3 build_script_helper.py --package-path . \
+                               --build-path .build \
+                               --toolchain /usr/local/bin/swift/ \
+                               --configuration debug \
+                               --memtool-product /home/mikolas/Developer/ptrace/memtool/.build/x86_64-unknown-linux-gnu/debug \
+                               --swift-repo /home/mikolas/Developer/swift5.7/swift
+```
+
+The helper script provided with this WIP version works on linux only and requires `--memtool-product` path to the directory containing `.swiftmodule` and `.so` of `MemtoolCore` and other dependencies. The `--swift-repo` path should lead to a checkout of the `apple/swift` repository.
+
+In the default configuration, log of each method execution is printed on stdout. If you don't wish to see it, remove the `-Xswiftc -DDIAGNOSTIC`.
+
 # swift-inspect
 
 swift-inspect is a debugging tool which allows you to inspect a live Swift process to gain insight into the runtime interactions of the application.

--- a/tools/swift-inspect/README.md
+++ b/tools/swift-inspect/README.md
@@ -24,9 +24,9 @@ swift build -Xcc -I%SDKROOT%\usr\include\swift\SwiftRemoteMirror -Xlinker %SDKRO
 
 The process is a little bit more complicated on Linux. Some features available on macOS and Windows are not present on Linux and additional libraries are needed.
 
-In order to function correctly, `swift-inspect` needs the ability to enumerate memory allocated on the heap. This is not done simply under `Glibc` which is the C library by Swift. The ability to enumerate heap is made available via 3rd party tool called `memtool`. This tool was develop specifically for `swift-inspect`.
+In order to function correctly, `swift-inspect` needs the ability to enumerate memory allocated on the heap. This feature is not natively present in `Glibc` which is the C library used by Swift. The ability to enumerate heap is made available via 3rd party tool called `memtool`. This tool was developed with `swift-inspect` in mind.
 
-**However, `memtool` is not maintained by the Swift maintainers and should be used with caution and at your own risk.**
+**However, `memtool` is not maintained by the Swift maintainers and should be used with caution.**
 
 Before downloading, compiling and executing `memtool`, be sure you are familiar with [important considerations](https://github.com/mikolasstuchlik/memtool/#important-considerations).
 
@@ -55,7 +55,7 @@ swift build --package-path . \
             -Xlinker -rpath -Xlinker $MEMTOOL_REPO_ROOT/.build/x86_64-unknown-linux-gnu/debug
 ```
 
-This build command requires includes (lines with `-I`) from Memtool, but also from the Swift repository, since those includes are not shipped with toolcahin. It also needs to link `libswiftRemoteMirror.so` from the Swift toolchain and `libMemtoolCore.so` from the `memtool` build folder.
+This build command requires includes from Memtool, but also from the Swift repository, since required header files are not shipped with toolcahin. It also needs to link `libswiftRemoteMirror.so` from the Swift toolchain and `libMemtoolCore.so` from the `memtool` build folder.
 
 ### Using
 
@@ -114,7 +114,7 @@ _ = MyClass()
 
 _ = readLine()
 ```
-In order to trace it, we would need to compile it, run it and find the PID:
+In order to trace the program, we need to compile it, run it and find the PID:
 ```bash
 $ swiftc simple.swift
 $ ./simple
@@ -124,7 +124,7 @@ you    37034  0.0  0.0  20264  2360 pts/3    S+   21:17   0:00 grep --color=auto
 ```
 
 The PID is `14808`.
-Now enter the directory containing the `swift-inspect` package and execute (`sudo` may be required)
+Now enter the `swift-inspect` package directory and launch it (`sudo` may be required)
 
 ```
 $ .build/debug/swift-inspect dump-arrays 14808

--- a/tools/swift-inspect/README.md
+++ b/tools/swift-inspect/README.md
@@ -1,21 +1,3 @@
-# disclaimer
-This is **work in progress** version of `swift-inpect` which depends on [mikolasstuchlik/memtool](https://github.com/mikolasstuchlik/memtool). I hesistate to (and probably never will) include this package in the SPM manifest of `swift-inspect`.
-Check out this package and build it - then link the products manually via the helper script.
-
-```bash
-# Example
-python3 build_script_helper.py --package-path . \
-                               --build-path .build \
-                               --toolchain /usr/local/bin/swift/ \
-                               --configuration debug \
-                               --memtool-product /home/mikolas/Developer/ptrace/memtool/.build/x86_64-unknown-linux-gnu/debug \
-                               --swift-repo /home/mikolas/Developer/swift5.7/swift
-```
-
-The helper script provided with this WIP version works on linux only and requires `--memtool-product` path to the directory containing `.swiftmodule` and `.so` of `MemtoolCore` and other dependencies. The `--swift-repo` path should lead to a checkout of the `apple/swift` repository.
-
-In the default configuration, log of each method execution is printed on stdout. If you don't wish to see it, remove the `-Xswiftc -DDIAGNOSTIC`.
-
 # swift-inspect
 
 swift-inspect is a debugging tool which allows you to inspect a live Swift process to gain insight into the runtime interactions of the application.

--- a/tools/swift-inspect/README.md
+++ b/tools/swift-inspect/README.md
@@ -24,7 +24,11 @@ swift-inspect uses the reflection APIs to introspect the live process.  It relie
 
 ### Building
 
-swift-inspect can be built using [swift-package-manager](https://github.com/apple/swift-package-manager).
+All platforms require [swift-package-manager](https://github.com/apple/swift-package-manager).
+
+##### macOS
+
+On macOS, use provided `build_script_helper.py`.
 
 ##### Windows
 
@@ -33,6 +37,43 @@ In order to build on Windows, some additional parameters must be passed to the b
 ~~~
 swift build -Xcc -I%SDKROOT%\usr\include\swift\SwiftRemoteMirror -Xlinker %SDKROOT%\usr\lib\swift\windows\x86_64\swiftRemoteMirror.lib
 ~~~
+
+##### 64bit Linux
+
+The process is a little bit more complicated on Linux. Some features available on macOS and Windows are not present on Linux and additional libraries are needed.
+
+In order to function correctly, `swift-inspect` needs the ability to enumerate memory allocated on the heap. This is not done simply under `Glibc` which is the C library by Swift. The ability to enumerate heap is made available via 3rd party tool called `memtool`. This tool was develop specifically for `swift-inspect`.
+
+**However, `memtool` is not maintained by the Swift maintainers and should be used with caution and at your own risk.**
+
+Before downloading, compiling and executing `memtool`, be sure you are familiar with [important considerations](https://github.com/mikolasstuchlik/memtool/#important-considerations).
+
+**Installation**
+
+1. Check-out and build
+```bash
+git checkout https://github.com/mikolasstuchlik/memtool.git
+cd memtool
+swift build
+```
+
+2. Build `swift-inspect` 
+
+```bash
+swift build --package-path . \
+            --build-path .build \
+            --configuration debug \
+            -Xswiftc -I -Xswiftc $SWIFT_REPO_ROOT/swift/include/swift \
+            -Xswiftc -I -Xswiftc $MEMTOOL_REPO_ROOT/.build/x86_64-unknown-linux-gnu/debug \
+            -Xswiftc -L -Xswiftc $SWIFT_TOOLCHAIN_PATH/usr/lib/swift/linux \
+            -Xswiftc -L -Xswiftc $MEMTOOL_REPO_ROOT/.build/x86_64-unknown-linux-gnu/debug \
+            -Xswiftc -lswiftRemoteMirror \
+            -Xswiftc -lMemtoolCore \
+            -Xlinker -rpath -Xlinker $SWIFT_TOOLCHAIN_PATH/usr/lib/swift/linux \
+            -Xlinker -rpath -Xlinker $MEMTOOL_REPO_ROOT/.build/x86_64-unknown-linux-gnu/debug
+```
+
+This build command requires includes (lines with `-I`) from Memtool, but also from the Swift repository, since those includes are not shipped with toolcahin. It also needs to link `libswiftRemoteMirror.so` from the Swift toolchain and `libMemtoolCore.so` from the `memtool` build folder.
 
 ### Using
 
@@ -59,3 +100,108 @@ dump-raw-metadata &lt;name-or-pid&gt; [--backtrace] [--backtrace-long]
 
 dump-concurrency &lt;name-or-pid&gt;
 : Print information about tasks, actors, and threads under Concurrency.
+
+### Example usage
+
+##### 64bit Linux
+
+Consider this simple demonstration program
+
+```swift
+// simple.swift
+final class MyClass {
+    var aSelf: MyClass?
+
+    var a: UInt = 0xabababababababab
+    var b: UInt = 0xcdcdcdcdcdcdcdcd
+    var c: UInt = 0xefefefefefefefef
+
+    init() {
+        aSelf = self
+    }
+}
+
+var myArray: [UInt] = Array()
+myArray.reserveCapacity(64)
+for _ in 0..<64 {
+    myArray.append(0xabcdabcdabcdabcd)
+}
+
+_ = MyClass()
+_ = MyClass()
+
+_ = readLine()
+```
+In order to trace it, we would need to compile it, run it and find the PID:
+```bash
+$ swiftc simple.swift
+$ ./simple
+$ ps aux | grep simple
+you    14808  0.0  0.0  13572  4040 pts/0    T    17:49   0:00 ./simple
+you    37034  0.0  0.0  20264  2360 pts/3    S+   21:17   0:00 grep --color=auto simple
+```
+
+The PID is `14808`.
+Now enter the directory containing the `swift-inspect` package and execute (`sudo` may be required)
+
+```
+$ .build/debug/swift-inspect dump-arrays 14808
+Address	Size	Count	Is Class
+0x563da5bbb770	552	64	false
+```
+
+In order to run `dump-raw-metadata`, `dump-generic-metadata` and other modes, you will need to set the `SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION` environment variable. Swift Runtime may optionally enable some features based on environment variables, [refer to the compiler source code for more information](https://github.com/apple/swift/blob/main/stdlib/public/runtime/EnvironmentVariables.def).
+
+```bash
+$ export SWIFT_DEBUG_ENABLE_METADATA_ALLOCATION_ITERATION=1 && ./simple
+$ ps aux | grep simple
+you    14809  0.0  0.0  13572  4040 pts/0    T    17:49   0:00 ./simple
+you    37035  0.0  0.0  20264  2360 pts/3    S+   21:17   0:00 grep --color=auto simple
+```
+
+Following execution contains demonstration of the modes mentioned above (`sudo may be required`):
+```bash
+$ .build/debug/swift-inspect dump-raw-metadata 14809
+Metadata allocation at: 0x7f39f704dc88 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704dcb0 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704dcd8 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704dd00 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704dd28 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704dd50 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704dd78 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704dda0 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704ddc8 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704ddf0 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704de18 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704de40 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704de68 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704de90 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704deb8 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704dee0 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704df08 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704df30 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704df58 size: 32 tag: 14 (GenericMetadataCache)
+Metadata allocation at: 0x7f39f704df80 size: 32 tag: 14 (GenericMetadataCache)
+$ .build/debug/swift-inspect dump-generic-metadata 14809
+Address	Allocation	Size	Offset	isArrayOfClass	Name
+0x7f39f6f5a0f0	???	??	???	false	Swift.AnyObject
+0x7f39f6f53960	???	??	???	false	Swift._DictionaryCodingKey
+0x7f39f6f53bd0	???	??	???	false	Swift.Range<Swift.Int>
+0x7f39f6f50be0	???	??	???	false	Swift.Int8
+0x7f39f6f4f168	???	??	???	false	Swift.String.Index
+0x7f39f6f56790	???	??	???	false	Swift.(_V in $7f39f6f7f4e0)
+0x7f39f6f50e60	???	??	???	false	Swift.Int
+0x7f39f6f4db38	???	??	???	false	Swift._HashTable.Bucket
+0x7f39f6f4cb28	???	??	???	false	Swift.Character
+0x7f39f6f50c30	???	??	???	false	Swift.UInt16
+0x7f39f6f50cd0	???	??	???	false	Swift.UInt32
+0x7f39f6f4dee8	???	??	???	false	Swift.Unicode.Scalar
+0x7f39f6f50e10	???	??	???	false	Swift.UInt
+0x7f39f6f4ecf8	???	??	???	false	Swift.StaticString
+0x7f39f6f50b90	???	??	???	false	Swift.UInt8
+0x7f39f6f4eee0	???	??	???	false	Swift.String
+0x7f39f6f50dc0	???	??	???	false	Swift.Int64
+0x7f39f6f552d0	???	??	???	false	Swift.Dictionary<Swift.String, Swift.AnyObject>
+0x7f39f6f4d968	???	??	???	false	Swift.AnyHashable
+0x7f39f6f5a0d8	???	??	???	false	Any
+```

--- a/tools/swift-inspect/Sources/swift-inspect/LinuxRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/LinuxRemoteProcess.swift
@@ -1,0 +1,267 @@
+#if os(Linux) 
+
+import SwiftRemoteMirror
+import MemtoolCore
+import Cutils // Part of Memtool
+
+internal final class Linux64RemoteProcess: RemoteProcess {
+    typealias ProcessIdentifier = Cutils.pid_t
+    typealias ProcessHandle = Cutils.pid_t
+
+    var process: ProcessHandle
+    var context: SwiftReflectionContextRef!
+    let memtoolSession: MemtoolCore.Session
+    let memtoolHeapAnalysis: MemtoolCore.GlibcMallocAnalyzer
+
+    static var QueryDataLayout: QueryDataLayoutFunction {
+        return { (context, type, _, output) in
+            #if DIAGNOSTIC
+            print("Request [Query Layout]: \(type)")
+            #endif
+
+            switch type {
+            case DLQ_GetPointerSize:
+                let size = UInt8(MemoryLayout<UnsafeRawPointer>.stride)
+                output?.storeBytes(of: size, toByteOffset: 0, as: UInt8.self)
+                return 1
+
+            case DLQ_GetSizeSize:
+                // FIXME(compnerd) support 32-bit processes
+                let size = UInt8(MemoryLayout<UInt64>.stride)
+                output?.storeBytes(of: size, toByteOffset: 0, as: UInt8.self)
+                return 1
+
+            case DLQ_GetLeastValidPointerValue:
+                let value: UInt64 = 0x1000
+                output?.storeBytes(of: value, toByteOffset: 0, as: UInt64.self)
+                return 1
+
+            default:
+                return 0
+            }
+        }        
+    }
+
+    static var Free: FreeFunction {
+        return { (_, bytes, _) in
+            #if DIAGNOSTIC
+            print("Request [free]: \(String(describing: bytes))")
+            #endif
+            free(UnsafeMutableRawPointer(mutating: bytes))
+        }
+    }
+
+    static var ReadBytes: ReadBytesFunction {
+        return { (context, baseAddress, size, _) in 
+            let process = Linux64RemoteProcess.fromOpaque(context!)
+            let bytes = UnsafeRawPointer(Cutils.swift_inspect_bridge__ptrace_peekdata(process.process, baseAddress, size))
+            #if DIAGNOSTIC
+            print("Request [Load bytes]: \(baseAddress.hexa) size \(size)")
+            #endif
+            return bytes
+        }
+    }
+
+    static var GetStringLength: GetStringLengthFunction {
+        return { (context, baseAddress) in
+            let process = Linux64RemoteProcess.fromOpaque(context!)
+            let uintBase = UInt(baseAddress)
+            
+            #if DIAGNOSTIC
+            print("Request [Sting length]: \(baseAddress.hexa) ", terminator: "")
+            #endif
+
+            guard let candidateRegion = process.memtoolSession.map?.first(where: { $0.range.contains(uintBase) }) else {
+                #if DIAGNOSTIC
+                print("returned 0; outside any region")
+                #endif
+
+                return 0
+            }
+
+            // Requirement to avoid reading from read-only space was dropped due to frequent attempts to read wq space
+            guard 
+                candidateRegion.properties.flags.contains(.read) 
+            else {
+                #if DIAGNOSTIC
+                print("returned 0; region \(candidateRegion) is not read-only")
+                #endif
+
+                return 0
+
+            }
+
+            var currentAddress = baseAddress
+            var length: UInt64 = 0
+
+            #if DIAGNOSTIC
+            var bytes: [CChar] = []
+            #endif
+
+            while currentAddress < candidateRegion.range.upperBound {
+                let result = Cutils.swift_inspect_bridge__ptrace_peekdata(process.process, currentAddress, 1)
+                guard let char = result?.bindMemory(to: CChar.self, capacity: 1).pointee else {
+                    #if DIAGNOSTIC
+                    print("returned 0; reading failed")
+                    #endif
+                    return 0
+                }
+                result?.deallocate()
+                if char == 0 {
+                    #if DIAGNOSTIC
+                    print("returned \(length); \(bytes)")
+                    #endif
+                    return length
+                }
+                
+                #if DIAGNOSTIC
+                bytes.append(char)
+                #endif
+
+                length += 1
+                currentAddress += 1
+            }
+
+            #if DIAGNOSTIC
+            print("reached end of allowed memory; returned \(length); \(bytes)")
+            #endif
+            
+            return length
+        }
+    }
+
+    static var GetSymbolAddress: GetSymbolAddressFunction { 
+        return { (context, symbol, length) in 
+            let process = Linux64RemoteProcess.fromOpaque(context!)
+
+            #if DIAGNOSTIC
+            print("Request [Get address]: ", terminator: "")
+            #endif
+
+            guard let symbol = symbol else { print("null"); return 0 }
+            let name: String = symbol.withMemoryRebound(to: UInt8.self, capacity: Int(length)) {
+                let buffer = UnsafeBufferPointer(start: $0, count: Int(length))
+                return String(decoding: buffer, as: UTF8.self)
+            }
+            for symbol in process.memtoolSession.symbols ?? [] where symbol.properties.name == name {
+                #if DIAGNOSTIC
+                print("name \(name); symbol {\(symbol.hexa)}")
+                #endif
+                return UInt64(symbol.range.lowerBound)
+            }
+
+            #if DIAGNOSTIC
+            print("name \(name); failed to load")
+            #endif
+
+            return 0
+        }
+    }
+
+    func symbolicate(_ address: swift_addr_t) -> (module: String?, symbol: String?) {
+        for symbol in memtoolSession.symbols ?? [] where symbol.range.contains(0){
+            #if DIAGNOSTIC
+            print("Request [Get symbol]: \(address.hexa) {\(symbol.hexa)}")
+            #endif
+            return (symbol.properties.segment.rawValue, symbol.properties.name)
+        }
+        #if DIAGNOSTIC
+        print("Request [Get symbol]: \(address.hexa) failed")
+        #endif
+        return (nil, nil)
+    }
+
+    func iterateHeap(_ body: (swift_addr_t, UInt64) -> Void) {
+        #if DIAGNOSTIC
+        print("Request [Iterate heap]:")
+        #endif
+        for heapItem in memtoolHeapAnalysis.exploredHeap {
+            guard case let .mallocChunk(state) = heapItem.properties.rebound, state.isActive else {
+                continue
+            }
+            do {
+                let chunk = try memtoolSession.checkedChunk(baseAddress: heapItem.range.lowerBound)
+                #if DIAGNOSTIC
+                print("Will iterate \(chunk.header); \(chunk.chunkAllocatedRange.lowerBound.hexa); buffer: \(chunk.content.asAsciiString)")
+                #endif
+                body(UInt64(chunk.content.segment.lowerBound), UInt64(chunk.content.segment.unsignedCount))
+            } catch {
+                // FIXME(stuchlej) log error
+            }
+        }
+
+    }
+
+    init?(processId: ProcessHandle) {
+        self.process = processId
+        // FIXME(stuchlej) Should I place `wait` here?
+
+        let processSession = MemtoolCore.ProcessSession(pid: processId)
+        self.memtoolSession = processSession
+        processSession.loadMap()
+        processSession.loadSymbols()
+        processSession.loadThreads()
+
+        // Some symbols are prefixed with `.protected ` string, that is not dealt with by memtool
+        for i in 0..<(processSession.symbols?.count ?? 0) {
+            processSession.symbols?[i].properties.name.trimPrefix(".protected ")
+        }
+
+        do {
+            self.memtoolHeapAnalysis = try GlibcMallocAnalyzer(session: processSession)
+            try memtoolHeapAnalysis.analyze()
+        } catch {
+            // FIXME(stuchlej) log error
+            return nil
+        }
+
+        guard 
+            let context = swift_reflection_createReflectionContextWithDataLayout(
+                self.toOpaqueRef(), 
+                Self.QueryDataLayout, 
+                Self.Free, 
+                Self.ReadBytes, 
+                Self.GetStringLength, 
+                Self.GetSymbolAddress
+            )
+        else {
+            // FIXME(stuchlej) log error
+            return nil
+        }
+        self.context = context
+    }
+
+    deinit {
+        swift_reflection_destroyReflectionContext(context)
+    }
+}
+
+
+#if DIAGNOSTIC
+import Foundation
+
+extension UInt {
+    var hexa: String {
+        String(format: "0x%016lx", self)
+    }
+}
+
+extension UInt64 {
+    var hexa: String {
+        String(format: "0x%016lx", self)
+    }
+}
+
+extension MemoryRegion {
+    private struct StringRegion<T> {
+        let range: String
+        let properties: T
+    }
+
+    var hexa: String {
+        "\(StringRegion(range: range.lowerBound.hexa + "..<" + range.upperBound.hexa, properties: properties))"
+    }
+}
+#endif
+
+#endif /* os(Linux) */

--- a/tools/swift-inspect/Sources/swift-inspect/LinuxRemoteProcess.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/LinuxRemoteProcess.swift
@@ -39,7 +39,7 @@ internal final class Linux64RemoteProcess: RemoteProcess {
             default:
                 return 0
             }
-        }        
+        }
     }
 
     static var Free: FreeFunction {

--- a/tools/swift-inspect/Sources/swift-inspect/Process.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/Process.swift
@@ -81,6 +81,12 @@ internal func process(matching: String) -> ProcessIdentifier? {
 
   return matches.first?.0
 }
+#elseif os(Linux)
+internal typealias ProcessIdentifier = Linux64RemoteProcess.ProcessIdentifier
+
+internal func process(matching: String) -> ProcessIdentifier? {
+  Int32(matching, radix: 10)
+}
 #else
 #error("Unsupported platform")
 #endif

--- a/tools/swift-inspect/Sources/swift-inspect/main.swift
+++ b/tools/swift-inspect/Sources/swift-inspect/main.swift
@@ -61,6 +61,11 @@ internal func inspect(options: UniversalOptions,
     print("Failed to create inspector for process id \(processId)")
     return
   }
+#elseif os(Linux)
+  guard let process = Linux64RemoteProcess(processId: processId) else {
+    print("Failed to create inspector for process id \(processId)")
+    return
+  }
 #else
 #error("Unsupported platform")
 #endif


### PR DESCRIPTION
## `swift-inspect`
`swift-inspect` is a tool in `apple/swift` that allows users to debug Swift programs by dumping various information. The `swift-inspect` uses `SwiftRemoteMirror`.  It is available on macOS and Windows.

## This Pull Request
This Pull Request adds an initial support for Linux, specifically for x86-64 architecture. Since the `swift-inspect` requires the ability to enumerate heap and such functionality is not natively available in `Glibc`, this functionality is provided by stand-alone tool called `memtool`.

## `memtool`
The `memtool` is a Swift Package created and maintained by the creator of this Pull Request. It uses `ptrace` and `bash` in order to provide `swift-inspect` with all the information it requires.
Since `memtool` is not maintained by Swift maintainers, I have decided against using it as a Swift Package dependency. Users are expected to read README, where the `memtool` is linked, and advised to review the `memtool` before downloading or executing it.  

---
### Related discussions
https://forums.swift.org/t/building-swift-inspect-on-linux/56858
https://forums.swift.org/t/tool-for-analyzing-heap-of-linux-glibc-swift-process-in-swift/62017
https://forums.swift.org/t/is-there-a-way-to-differentiate-swift-types-and-c-types-at-runtime/61950