### PR TITLE
[debug-info] Add a new super class of DebugVarCarryingInst called VarDeclCarryingInst

### DIFF
--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -37,6 +37,7 @@
 #define SWIFT_SIL_DEBUGUTILS_H
 
 #include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILGlobalVariable.h"
 #include "swift/SIL/SILInstruction.h"
 
 namespace swift {
@@ -237,31 +238,39 @@ bool hasNonTrivialNonDebugTransitiveUsers(
     PointerUnion<SILInstruction *, SILArgument *> V);
 
 /// A light weight abstraction on top of an instruction that carries within it
-/// information about a debug variable. This allows one to write high level code
-/// over the set of such instructions with greater correctness by using
-/// exhaustive switches, methods, and keeping it light weight by using *, ->
-/// operators to access functionality from the underlying instruction when
-/// needed.
-struct DebugVarCarryingInst {
+/// information about a VarDecl. This allows one to write high level code over
+/// the set of such instructions with greater correctness by using exhaustive
+/// switches, methods, and keeping it light weight by using *, -> operators to
+/// access functionality from the underlying instruction when eneded.
+class VarDeclCarryingInst {
+public:
   enum class Kind : uint8_t {
     Invalid = 0,
     DebugValue,
     AllocStack,
     AllocBox,
+    GlobalAddr,
+    RefElementAddr,
   };
 
+protected:
   SILInstruction *inst;
   Kind kind;
   uintptr_t spareBits : (sizeof(uintptr_t) - sizeof(Kind)) * 8;
 
-  DebugVarCarryingInst() : inst(nullptr), kind(Kind::Invalid), spareBits(0) {}
-  DebugVarCarryingInst(DebugValueInst *dvi)
+public:
+  VarDeclCarryingInst() : inst(nullptr), kind(Kind::Invalid), spareBits(0) {}
+  VarDeclCarryingInst(DebugValueInst *dvi)
       : inst(dvi), kind(Kind::DebugValue), spareBits(0) {}
-  DebugVarCarryingInst(AllocStackInst *asi)
+  VarDeclCarryingInst(AllocStackInst *asi)
       : inst(asi), kind(Kind::AllocStack), spareBits(0) {}
-  DebugVarCarryingInst(AllocBoxInst *abi)
+  VarDeclCarryingInst(AllocBoxInst *abi)
       : inst(abi), kind(Kind::AllocBox), spareBits(0) {}
-  DebugVarCarryingInst(SILInstruction *newInst)
+  VarDeclCarryingInst(GlobalAddrInst *gai)
+      : inst(gai), kind(Kind::GlobalAddr), spareBits(0) {}
+  VarDeclCarryingInst(RefElementAddrInst *reai)
+      : inst(reai), kind(Kind::RefElementAddr), spareBits(0) {}
+  VarDeclCarryingInst(SILInstruction *newInst)
       : inst(nullptr), kind(Kind::Invalid), spareBits(0) {
     switch (newInst->getKind()) {
     default:
@@ -274,6 +283,12 @@ struct DebugVarCarryingInst {
       break;
     case SILInstructionKind::AllocBoxInst:
       kind = Kind::AllocBox;
+      break;
+    case SILInstructionKind::GlobalAddrInst:
+      kind = Kind::GlobalAddr;
+      break;
+    case SILInstructionKind::RefElementAddrInst:
+      kind = Kind::RefElementAddr;
       break;
     }
     inst = newInst;
@@ -288,17 +303,22 @@ struct DebugVarCarryingInst {
   /// '->'. This keeps the wrapper light weight.
   SILInstruction *operator->() const { return inst; }
 
-  bool operator==(const DebugVarCarryingInst &other) const {
+  unsigned getSpareBits() const { return spareBits; }
+  void setSpareBits(unsigned newSpareBits) { spareBits = newSpareBits; }
+
+  bool operator==(const VarDeclCarryingInst &other) const {
     return kind == other.kind && inst == other.inst &&
            spareBits == other.spareBits;
   }
 
-  bool operator!=(const DebugVarCarryingInst &other) const {
+  bool operator!=(const VarDeclCarryingInst &other) const {
     return !(*this == other);
   }
 
   /// Add support for this struct in `if` statement.
   explicit operator bool() const { return bool(kind); }
+
+  Kind getKind() const { return kind; }
 
   VarDecl *getDecl() const {
     switch (kind) {
@@ -310,33 +330,125 @@ struct DebugVarCarryingInst {
       return cast<AllocStackInst>(inst)->getDecl();
     case Kind::AllocBox:
       return cast<AllocBoxInst>(inst)->getDecl();
+    case Kind::GlobalAddr:
+      return cast<GlobalAddrInst>(inst)->getReferencedGlobal()->getDecl();
+    case Kind::RefElementAddr:
+      return cast<RefElementAddrInst>(inst)->getField();
     }
     llvm_unreachable("covered switch");
   }
 
+  /// If \p value is an alloc_stack, alloc_box use that. Otherwise, see if \p
+  /// value has a single debug user, return that. Otherwise return the invalid
+  /// VarDeclCarryingInst.
+  static VarDeclCarryingInst getFromValue(SILValue value);
+
+  StringRef getName() const {
+    assert(kind != Kind::Invalid);
+    StringRef varName = "unknown";
+    if (auto *decl = getDecl()) {
+      varName = decl->getBaseName().userFacingName();
+    }
+    return varName;
+  }
+
+  /// Take in \p inst, a potentially invalid VarDeclCarryingInst, and returns a
+  /// name for it. If we have an invalid value or don't find var info or a decl,
+  /// return "unknown".
+  ///
+  /// The reason this isn't a method is that in all the other parts of
+  /// VarDeclCarryingInst, we use Invalid to signal early error.
+  static StringRef getName(VarDeclCarryingInst inst) {
+    if (!inst)
+      return "unknown";
+    return inst.getName();
+  }
+};
+
+inline VarDeclCarryingInst VarDeclCarryingInst::getFromValue(SILValue value) {
+  if (auto *svi = dyn_cast<SingleValueInstruction>(value)) {
+    if (auto result = VarDeclCarryingInst(svi)) {
+      return result;
+    }
+  }
+
+  return VarDeclCarryingInst();
+}
+
+/// A light weight abstraction on top of an instruction that carries within it
+/// information about a debug variable. This allows one to write high level code
+/// over the set of such instructions with greater correctness by using
+/// exhaustive switches, methods, and keeping it light weight by using *, ->
+/// operators to access functionality from the underlying instruction when
+/// needed.
+struct DebugVarCarryingInst : VarDeclCarryingInst {
+#ifdef SET_TO_SUPER_ENUM_KIND
+#error "Cannot reuse this macro"
+#endif
+#define SET_TO_SUPER_ENUM_KIND(X)                                              \
+  X = std::underlying_type<VarDeclCarryingInst::Kind>::type(                   \
+      VarDeclCarryingInst::Kind::X)
+  enum class Kind : uint8_t {
+    SET_TO_SUPER_ENUM_KIND(Invalid),
+    SET_TO_SUPER_ENUM_KIND(DebugValue),
+    SET_TO_SUPER_ENUM_KIND(AllocStack),
+    SET_TO_SUPER_ENUM_KIND(AllocBox),
+  };
+#undef SET_TO_SUPER_ENUM_KIND
+  static_assert(
+      std::is_same<
+          std::underlying_type<VarDeclCarryingInst::Kind>::type,
+          std::underlying_type<DebugVarCarryingInst::Kind>::type>::value,
+      "DebugVarCarryingInst and VarDeclCarryingInst must have the "
+      "same underlying type");
+
+  DebugVarCarryingInst() : VarDeclCarryingInst() {}
+  DebugVarCarryingInst(DebugValueInst *dvi) : VarDeclCarryingInst(dvi) {}
+  DebugVarCarryingInst(AllocStackInst *asi) : VarDeclCarryingInst(asi) {}
+  DebugVarCarryingInst(AllocBoxInst *abi) : VarDeclCarryingInst(abi) {}
+  DebugVarCarryingInst(SILInstruction *newInst)
+      : VarDeclCarryingInst() {
+    switch (newInst->getKind()) {
+    default:
+      return;
+    case SILInstructionKind::DebugValueInst:
+      kind = VarDeclCarryingInst::Kind::DebugValue;
+      break;
+    case SILInstructionKind::AllocStackInst:
+      kind = VarDeclCarryingInst::Kind::AllocStack;
+      break;
+    case SILInstructionKind::AllocBoxInst:
+      kind = VarDeclCarryingInst::Kind::AllocBox;
+      break;
+    }
+    inst = newInst;
+  }
+
+  Kind getKind() const { return Kind(VarDeclCarryingInst::getKind()); }
+
   Optional<SILDebugVariable> getVarInfo() const {
-    switch (kind) {
+    switch (getKind()) {
     case Kind::Invalid:
       llvm_unreachable("Invalid?!");
     case Kind::DebugValue:
-      return cast<DebugValueInst>(inst)->getVarInfo();
+      return cast<DebugValueInst>(**this)->getVarInfo();
     case Kind::AllocStack:
-      return cast<AllocStackInst>(inst)->getVarInfo();
+      return cast<AllocStackInst>(**this)->getVarInfo();
     case Kind::AllocBox:
-      return cast<AllocBoxInst>(inst)->getVarInfo();
+      return cast<AllocBoxInst>(**this)->getVarInfo();
     }
     llvm_unreachable("covered switch");
   }
 
   void setDebugVarScope(const SILDebugScope *NewDS) {
-    switch (kind) {
+    switch (getKind()) {
     case Kind::Invalid:
       llvm_unreachable("Invalid?!");
     case Kind::DebugValue:
-      cast<DebugValueInst>(inst)->setDebugVarScope(NewDS);
+      cast<DebugValueInst>(**this)->setDebugVarScope(NewDS);
       break;
     case Kind::AllocStack:
-      cast<AllocStackInst>(inst)->setDebugVarScope(NewDS);
+      cast<AllocStackInst>(**this)->setDebugVarScope(NewDS);
       break;
     case Kind::AllocBox:
       llvm_unreachable("Not implemented");
@@ -344,14 +456,14 @@ struct DebugVarCarryingInst {
   }
 
   void markAsMoved() {
-    switch (kind) {
+    switch (getKind()) {
     case Kind::Invalid:
       llvm_unreachable("Invalid?!");
     case Kind::DebugValue:
-      cast<DebugValueInst>(inst)->markAsMoved();
+      cast<DebugValueInst>(**this)->markAsMoved();
       break;
     case Kind::AllocStack:
-      cast<AllocStackInst>(inst)->markAsMoved();
+      cast<AllocStackInst>(**this)->markAsMoved();
       break;
     case Kind::AllocBox:
       llvm_unreachable("Not implemented");
@@ -360,13 +472,13 @@ struct DebugVarCarryingInst {
 
   /// Returns true if this DebugVarCarryingInst was moved.
   bool getWasMoved() const {
-    switch (kind) {
+    switch (getKind()) {
     case Kind::Invalid:
       llvm_unreachable("Invalid?!");
     case Kind::DebugValue:
-      return cast<DebugValueInst>(inst)->getWasMoved();
+      return cast<DebugValueInst>(**this)->getWasMoved();
     case Kind::AllocStack:
-      return cast<AllocStackInst>(inst)->getWasMoved();
+      return cast<AllocStackInst>(**this)->getWasMoved();
     case Kind::AllocBox:
       // We do not support moving alloc box today, so we always return false.
       return false;
@@ -380,13 +492,13 @@ struct DebugVarCarryingInst {
   /// For a debug_value, we just return the actual operand, otherwise we return
   /// the pointer address.
   SILValue getOperandForDebugValueClone() const {
-    switch (kind) {
+    switch (getKind()) {
     case Kind::Invalid:
       llvm_unreachable("Invalid?!");
     case Kind::DebugValue:
-      return cast<DebugValueInst>(inst)->getOperand();
+      return cast<DebugValueInst>(**this)->getOperand();
     case Kind::AllocStack:
-      return cast<AllocStackInst>(inst);
+      return cast<AllocStackInst>(**this);
     case Kind::AllocBox:
       llvm_unreachable("Not implemented");
     }
@@ -397,6 +509,17 @@ struct DebugVarCarryingInst {
   /// DebugVarCarryingInst.
   static DebugVarCarryingInst getFromValue(SILValue value);
 
+  StringRef getName() const {
+    assert(getKind() != Kind::Invalid);
+    StringRef varName = "unknown";
+    if (auto varInfo = getVarInfo()) {
+      varName = varInfo->Name;
+    } else if (auto *decl = getDecl()) {
+      varName = decl->getBaseName().userFacingName();
+    }
+    return varName;
+  }
+
   /// Take in \p inst, a potentially invalid DebugVarCarryingInst, and returns a
   /// name for it. If we have an invalid value or don't find var info or a decl,
   /// return "unknown".
@@ -406,19 +529,26 @@ struct DebugVarCarryingInst {
   static StringRef getName(DebugVarCarryingInst inst) {
     if (!inst)
       return "unknown";
-    StringRef varName = "unknown";
-    if (auto varInfo = inst.getVarInfo()) {
-      varName = varInfo->Name;
-    } else if (auto *decl = inst.getDecl()) {
-      varName = decl->getBaseName().userFacingName();
-    }
-    return varName;
+    return inst.getName();
   }
 };
 
 inline DebugVarCarryingInst DebugVarCarryingInst::getFromValue(SILValue value) {
-  if (isa<AllocStackInst>(value) || isa<AllocBoxInst>(value))
-    return DebugVarCarryingInst(cast<SingleValueInstruction>(value));
+  if (auto *svi = dyn_cast<SingleValueInstruction>(value)) {
+    if (auto result = VarDeclCarryingInst(svi)) {
+      switch (result.getKind()) {
+      case VarDeclCarryingInst::Kind::Invalid:
+        llvm_unreachable("ShouldKind have never seen this");
+      case VarDeclCarryingInst::Kind::DebugValue:
+      case VarDeclCarryingInst::Kind::AllocStack:
+      case VarDeclCarryingInst::Kind::AllocBox:
+        return DebugVarCarryingInst(svi);
+      case VarDeclCarryingInst::Kind::GlobalAddr:
+      case VarDeclCarryingInst::Kind::RefElementAddr:
+        return DebugVarCarryingInst();
+      }
+    }
+  }
 
   if (auto *use = getSingleDebugUse(value))
     return DebugVarCarryingInst(use->getUser());
@@ -426,8 +556,8 @@ inline DebugVarCarryingInst DebugVarCarryingInst::getFromValue(SILValue value) {
   return DebugVarCarryingInst();
 }
 
-/// Attempt to discover a StringRef varName for the value \p value. If we fail,
-/// we return the name "unknown".
+/// Attempt to discover a StringRef varName for the value \p value based only
+/// off of debug var information. If we fail, we return the name "unknown".
 inline StringRef getDebugVarName(SILValue value) {
   auto inst = DebugVarCarryingInst::getFromValue(value);
   return DebugVarCarryingInst::getName(inst);

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableAddressesChecker.cpp
@@ -1508,7 +1508,7 @@ bool DataflowState::cleanupAllDestroyAddr(
           dbgValueInsertBuilder.setCurrentDebugScope(
               addressDebugInst->getDebugScope());
           dbgValueInsertBuilder.createDebugValue(
-              addressDebugInst.inst->getLoc(),
+              (*addressDebugInst)->getLoc(),
               SILUndef::get(address->getType(), dvi->getModule()), *varInfo,
               false,
               /*was moved*/ true);
@@ -1550,7 +1550,7 @@ bool DataflowState::cleanupAllDestroyAddr(
         // be defined before the value.
         SILBuilderWithScope reinitBuilder((*reinit)->getNextInstruction());
         reinitBuilder.setCurrentDebugScope(addressDebugInst->getDebugScope());
-        reinitBuilder.createDebugValue(addressDebugInst.inst->getLoc(), address,
+        reinitBuilder.createDebugValue((*addressDebugInst)->getLoc(), address,
                                        *varInfo, false,
                                        /*was moved*/ true);
       }


### PR DESCRIPTION
I discovered when working with improving the debug output of the move only address checker that I had a need for lightweight thing like DebugVarCarryingInst but that only could vend a VarDecl (unlike DebugVarCarryingInst which also can vend a SILDebugVariable). As an example, this lets one write a high level API that uses the standard API to loop over a bunch of instructions all that vend a VarDecl and construct a stringified path component list.

rdar://105293841
