### PR TITLE
[move-only] Prepare for handling ref_element_addr/global_addr/escaping closure captured params

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -2660,7 +2660,7 @@ which codegens to the following SIL::
   bb0(%0 : @noImplicitCopy $Klass):
     %1 = copyable_to_moveonlywrapper [guaranteed] %0 : $@moveOnly Klass
     %2 = copy_value %1 : $@moveOnly Klass
-    %3 = mark_must_check [no_copy] %2 : $@moveOnly Klass
+    %3 = mark_must_check [no_consume_or_assign] %2 : $@moveOnly Klass
     debug_value %3 : $@moveOnly Klass, let, name "x", argno 1
     %4 = begin_borrow %3 : $@moveOnly Klass
     %5 = function_ref @$s4test5KlassC11doSomethingyyF : $@convention(method) (@guaranteed Klass) -> ()
@@ -7824,7 +7824,7 @@ mark_must_check
                       '[' sil-optimizer-analysis-marker ']'
 
   sil-optimizer-analysis-marker ::= 'no_implicit_copy'
-                                ::= 'no_copy'
+                                ::= 'no_consume_or_assign'
 
 A canary value inserted by a SIL generating frontend to signal to the move
 checker to check a specific value.  Valid only in Raw SIL. The relevant checkers
@@ -7835,8 +7835,8 @@ instruction by varying the kind.
 
 If the sil optimizer analysis marker is ``no_implicit_copy`` then the move
 checker is told to check that the result of this instruction is consumed at most
-once. If the marker is ``no_copy``, then the move checker will validate that the
-result of this instruction is never consumed.
+once. If the marker is ``no_consume_or_assign``, then the move checker will
+validate that the result of this instruction is never consumed or assigned over.
 
 No Implicit Copy and No Escape Value Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -2730,7 +2730,7 @@ Today this codegens to the following Swift::
   bb0(%0 : @noImplicitCopy $Int):
     %1 = copyable_to_moveonlywrapper [owned] %0 : $Int
     %2 = move_value [lexical] %1 : $@moveOnly Int
-    %3 = mark_must_check [no_implicit_copy] %2 : $@moveOnly Int
+    %3 = mark_must_check [consumable_and_assignable] %2 : $@moveOnly Int
     %5 = begin_borrow %3 : $@moveOnly Int
     %6 = begin_borrow %3 : $@moveOnly Int
     %7 = function_ref @addIntegers : $@convention(method) (Int, Int Int.Type) -> Int
@@ -2789,7 +2789,7 @@ A hypothetical SILGen for this code is as follows::
     %3 = begin_borrow [lexical] %0 : $Klass
     %4 = copy_value %3 : $Klass
     %5 = copyable_to_moveonlywrapper [owned] %4 : $Klass
-    %6 = mark_must_check [no_implicit_copy] %5 : $@moveOnly Klass
+    %6 = mark_must_check [consumable_and_assignable] %5 : $@moveOnly Klass
     debug_value %6 : $@moveOnly Klass, let, name "value"
     %8 = begin_borrow %6 : $@moveOnly Klass
     %9 = copy_value %8 : $@moveOnly Klass
@@ -7823,7 +7823,7 @@ mark_must_check
   sil-instruction ::= 'mark_must_check'
                       '[' sil-optimizer-analysis-marker ']'
 
-  sil-optimizer-analysis-marker ::= 'no_implicit_copy'
+  sil-optimizer-analysis-marker ::= 'consumable_and_assignable'
                                 ::= 'no_consume_or_assign'
 
 A canary value inserted by a SIL generating frontend to signal to the move
@@ -7833,7 +7833,7 @@ relevant diagnostic. The idea here is that instead of needing to introduce
 multiple "flagging" instructions for the optimizer, we can just reuse this one
 instruction by varying the kind.
 
-If the sil optimizer analysis marker is ``no_implicit_copy`` then the move
+If the sil optimizer analysis marker is ``consumable_and_assignable`` then the move
 checker is told to check that the result of this instruction is consumed at most
 once. If the marker is ``no_consume_or_assign``, then the move checker will
 validate that the result of this instruction is never consumed or assigned over.

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -767,7 +767,7 @@ NOTE(sil_moveonlychecker_nonconsuming_use_here, none,
 NOTE(sil_movekillscopyablevalue_value_cyclic_consumed_in_loop_here, none,
      "consuming in loop use here", ())
 
-ERROR(sil_moveonlychecker_not_understand_no_implicit_copy, none,
+ERROR(sil_moveonlychecker_not_understand_consumable_and_assignable, none,
       "Usage of @noImplicitCopy that the move checker does not know how to "
       "check!", ())
 ERROR(sil_moveonlychecker_not_understand_moveonly, none,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8208,10 +8208,12 @@ public:
   enum class CheckKind : unsigned {
     Invalid = 0,
 
-    // A signal to the move only checker to perform no implicit copy checking on
-    // the result of this instruction. This implies that the result can be
-    // consumed at most once.
-    NoImplicitCopy,
+    // A signal to the move only checker to perform checking that allows for
+    // this value to be consumed along its boundary (in the case of let/var
+    // semantics) and also written over in the case of var semantics. NOTE: Of
+    // course this still implies the value cannot be copied and can be consumed
+    // only once along all program paths.
+    ConsumableAndAssignable,
 
     // A signal to the move only checker to perform no consume or assign
     // checking. This forces the result of this instruction owned value to never
@@ -8240,7 +8242,7 @@ public:
     switch (kind) {
     case CheckKind::Invalid:
       return false;
-    case CheckKind::NoImplicitCopy:
+    case CheckKind::ConsumableAndAssignable:
     case CheckKind::NoConsumeOrAssign:
       return true;
     }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8213,10 +8213,11 @@ public:
     // consumed at most once.
     NoImplicitCopy,
 
-    // A signal to the move only checker ot perform no copy checking. This
-    // forces the result of this instruction owned value to never be consumed
-    // (still allowing for non-consuming uses of course).
-    NoCopy,
+    // A signal to the move only checker to perform no consume or assign
+    // checking. This forces the result of this instruction owned value to never
+    // be consumed (for let/var semantics) or assigned over (for var
+    // semantics). Of course, we still allow for non-consuming uses.
+    NoConsumeOrAssign,
   };
 
 private:
@@ -8240,7 +8241,7 @@ public:
     case CheckKind::Invalid:
       return false;
     case CheckKind::NoImplicitCopy:
-    case CheckKind::NoCopy:
+    case CheckKind::NoConsumeOrAssign:
       return true;
     }
   }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8208,18 +8208,26 @@ public:
   enum class CheckKind : unsigned {
     Invalid = 0,
 
-    // A signal to the move only checker to perform checking that allows for
-    // this value to be consumed along its boundary (in the case of let/var
-    // semantics) and also written over in the case of var semantics. NOTE: Of
-    // course this still implies the value cannot be copied and can be consumed
-    // only once along all program paths.
+    /// A signal to the move only checker to perform checking that allows for
+    /// this value to be consumed along its boundary (in the case of let/var
+    /// semantics) and also written over in the case of var semantics. NOTE: Of
+    /// course this still implies the value cannot be copied and can be consumed
+    /// only once along all program paths.
     ConsumableAndAssignable,
 
-    // A signal to the move only checker to perform no consume or assign
-    // checking. This forces the result of this instruction owned value to never
-    // be consumed (for let/var semantics) or assigned over (for var
-    // semantics). Of course, we still allow for non-consuming uses.
+    /// A signal to the move only checker to perform no consume or assign
+    /// checking. This forces the result of this instruction owned value to never
+    /// be consumed (for let/var semantics) or assigned over (for var
+    /// semantics). Of course, we still allow for non-consuming uses.
     NoConsumeOrAssign,
+
+    /// A signal to the move checker that the given value cannot be consumed,
+    /// but is allowed to be assigned over. This is used for situations like
+    /// global_addr/ref_element_addr/closure escape where we do not want to
+    /// allow for the user to take the value (leaving the memory in an
+    /// uninitialized state), but we are ok with the user assigning a new value,
+    /// completely assigning over the value at once.
+    AssignableButNotConsumable,
   };
 
 private:
@@ -8244,6 +8252,7 @@ public:
       return false;
     case CheckKind::ConsumableAndAssignable:
     case CheckKind::NoConsumeOrAssign:
+    case CheckKind::AssignableButNotConsumable:
       return true;
     }
   }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1992,8 +1992,8 @@ public:
     switch (I->getCheckKind()) {
     case CheckKind::Invalid:
       llvm_unreachable("Invalid?!");
-    case CheckKind::NoImplicitCopy:
-      *this << "[no_implicit_copy] ";
+    case CheckKind::ConsumableAndAssignable:
+      *this << "[consumable_and_assignable] ";
       break;
     case CheckKind::NoConsumeOrAssign:
       *this << "[no_consume_or_assign] ";

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1998,6 +1998,9 @@ public:
     case CheckKind::NoConsumeOrAssign:
       *this << "[no_consume_or_assign] ";
       break;
+    case CheckKind::AssignableButNotConsumable:
+      *this << "[assignable_but_not_consumable] ";
+      break;
     }
     *this << getIDAndType(I->getOperand());
   }

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -1995,8 +1995,8 @@ public:
     case CheckKind::NoImplicitCopy:
       *this << "[no_implicit_copy] ";
       break;
-    case CheckKind::NoCopy:
-      *this << "[no_copy] ";
+    case CheckKind::NoConsumeOrAssign:
+      *this << "[no_consume_or_assign] ";
       break;
     }
     *this << getIDAndType(I->getOperand());

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3666,6 +3666,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
             .Case("consumable_and_assignable",
                   CheckKind::ConsumableAndAssignable)
             .Case("no_consume_or_assign", CheckKind::NoConsumeOrAssign)
+            .Case("assignable_but_not_consumable", CheckKind::AssignableButNotConsumable)
             .Default(CheckKind::Invalid);
 
     if (CKind == CheckKind::Invalid) {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3663,7 +3663,7 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     using CheckKind = MarkMustCheckInst::CheckKind;
     CheckKind CKind = llvm::StringSwitch<CheckKind>(AttrName)
                           .Case("no_implicit_copy", CheckKind::NoImplicitCopy)
-                          .Case("no_copy", CheckKind::NoCopy)
+                          .Case("no_consume_or_assign", CheckKind::NoConsumeOrAssign)
                           .Default(CheckKind::Invalid);
 
     if (CKind == CheckKind::Invalid) {

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3661,10 +3661,12 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
     }
 
     using CheckKind = MarkMustCheckInst::CheckKind;
-    CheckKind CKind = llvm::StringSwitch<CheckKind>(AttrName)
-                          .Case("no_implicit_copy", CheckKind::NoImplicitCopy)
-                          .Case("no_consume_or_assign", CheckKind::NoConsumeOrAssign)
-                          .Default(CheckKind::Invalid);
+    CheckKind CKind =
+        llvm::StringSwitch<CheckKind>(AttrName)
+            .Case("consumable_and_assignable",
+                  CheckKind::ConsumableAndAssignable)
+            .Case("no_consume_or_assign", CheckKind::NoConsumeOrAssign)
+            .Default(CheckKind::Invalid);
 
     if (CKind == CheckKind::Invalid) {
       auto diag = diag::sil_markmustcheck_invalid_attribute;

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -839,7 +839,8 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
       if (selfArg.getType().isMoveOnly()) {
         assert(selfArg.getOwnershipKind() == OwnershipKind::Owned);
         selfArg = B.createMarkMustCheckInst(
-            selfDecl, selfArg, MarkMustCheckInst::CheckKind::NoImplicitCopy);
+            selfDecl, selfArg,
+            MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
       }
       VarLocs[selfDecl] = VarLoc::get(selfArg.getValue());
     }

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -380,7 +380,7 @@ public:
     if (Addr->getType().isMoveOnly()) {
       // TODO: Handle no implicit copy here.
       Addr = SGF.B.createMarkMustCheckInst(
-          decl, Addr, MarkMustCheckInst::CheckKind::NoImplicitCopy);
+          decl, Addr, MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
     }
 
     // Push a cleanup to destroy the local variable.  This has to be
@@ -580,7 +580,8 @@ public:
       if (value->getType().isPureMoveOnly()) {
         value = SGF.B.createMoveValue(PrologueLoc, value, /*isLexical*/ true);
         return SGF.B.createMarkMustCheckInst(
-            PrologueLoc, value, MarkMustCheckInst::CheckKind::NoImplicitCopy);
+            PrologueLoc, value,
+            MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
       }
 
       // Otherwise, if we don't have a no implicit copy trivial type, just
@@ -594,7 +595,8 @@ public:
           SGF.B.createOwnedCopyableToMoveOnlyWrapperValue(PrologueLoc, value);
       value = SGF.B.createMoveValue(PrologueLoc, value, /*isLexical*/ true);
       return SGF.B.createMarkMustCheckInst(
-          PrologueLoc, value, MarkMustCheckInst::CheckKind::NoImplicitCopy);
+          PrologueLoc, value,
+          MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
     }
 
     // Then if we don't have move only, just perform a lexical borrow if the
@@ -636,7 +638,8 @@ public:
         !value->getType().isMoveOnlyWrapped()) {
       value = SGF.B.createMoveValue(PrologueLoc, value, true /*isLexical*/);
       return SGF.B.createMarkMustCheckInst(
-          PrologueLoc, value, MarkMustCheckInst::CheckKind::NoImplicitCopy);
+          PrologueLoc, value,
+          MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
     }
 
     // Otherwise, if we do not have a no implicit copy variable, just follow
@@ -655,7 +658,8 @@ public:
     value = SGF.B.createCopyValue(PrologueLoc, value);
     value = SGF.B.createOwnedCopyableToMoveOnlyWrapperValue(PrologueLoc, value);
     return SGF.B.createMarkMustCheckInst(
-        PrologueLoc, value, MarkMustCheckInst::CheckKind::NoImplicitCopy);
+        PrologueLoc, value,
+        MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
   }
 
   void bindValue(SILValue value, SILGenFunction &SGF, bool wasPlusOne) {

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -49,7 +49,8 @@ SILValue SILGenFunction::emitSelfDeclForDestructor(VarDecl *selfDecl) {
     // they cannot escape.
     if (selfValue->getOwnershipKind() == OwnershipKind::Owned) {
       selfValue = B.createMarkMustCheckInst(
-          selfDecl, selfValue, MarkMustCheckInst::CheckKind::NoImplicitCopy);
+          selfDecl, selfValue,
+          MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
     }
   }
 
@@ -129,7 +130,7 @@ public:
       // check ownership.
       if (mv.getType().isMoveOnly() && !mv.getType().isMoveOnlyWrapped())
         mv = SGF.B.createMarkMustCheckInst(
-            loc, mv, MarkMustCheckInst::CheckKind::NoImplicitCopy);
+            loc, mv, MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
       return mv;
     }
 
@@ -322,7 +323,7 @@ struct ArgumentInitHelper {
         value = SGF.B.createMoveValue(loc, argrv.forward(SGF),
                                       /*isLexical*/ true);
         value = SGF.B.createMarkMustCheckInst(
-            loc, value, MarkMustCheckInst::CheckKind::NoImplicitCopy);
+            loc, value, MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
         SGF.emitManagedRValueWithCleanup(value);
         return value;
       }
@@ -343,7 +344,7 @@ struct ArgumentInitHelper {
       // use no copy.
       auto kind = MarkMustCheckInst::CheckKind::NoConsumeOrAssign;
       if (pd->isOwned())
-        kind = MarkMustCheckInst::CheckKind::NoImplicitCopy;
+        kind = MarkMustCheckInst::CheckKind::ConsumableAndAssignable;
       value = SGF.B.createMarkMustCheckInst(loc, value, kind);
       SGF.emitManagedRValueWithCleanup(value);
       return value;
@@ -365,7 +366,7 @@ struct ArgumentInitHelper {
           loc, argrv.forward(SGF));
       value = SGF.B.createMoveValue(loc, value, true /*is lexical*/);
       value = SGF.B.createMarkMustCheckInst(
-          loc, value, MarkMustCheckInst::CheckKind::NoImplicitCopy);
+          loc, value, MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
       SGF.emitManagedRValueWithCleanup(value);
       return value;
     }
@@ -585,7 +586,7 @@ static void emitCaptureArguments(SILGenFunction &SGF,
     SILValue addr = SGF.B.createProjectBox(VD, box, 0);
     if (addr->getType().isMoveOnly())
       addr = SGF.B.createMarkMustCheckInst(
-          VD, addr, MarkMustCheckInst::CheckKind::NoImplicitCopy);
+          VD, addr, MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
     SGF.VarLocs[VD] = SILGenFunction::VarLoc::get(addr, box);
     SILDebugVariable DbgVar(VD->isLet(), ArgNo);
     SGF.B.createDebugValueAddr(Loc, addr, DbgVar);
@@ -608,7 +609,7 @@ static void emitCaptureArguments(SILGenFunction &SGF,
     SILValue arg = SILValue(fArg);
     if (isInOut && (ty.isMoveOnly() && !ty.isMoveOnlyWrapped())) {
       arg = SGF.B.createMarkMustCheckInst(
-          Loc, arg, MarkMustCheckInst::CheckKind::NoImplicitCopy);
+          Loc, arg, MarkMustCheckInst::CheckKind::ConsumableAndAssignable);
     }
     SGF.VarLocs[VD] = SILGenFunction::VarLoc::get(arg);
     SILDebugVariable DbgVar(VD->isLet(), ArgNo);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
@@ -1081,7 +1081,8 @@ bool GatherUsesVisitor::visitUse(Operand *op, AccessUseType useTy) {
     assert(op->getOperandNumber() == CopyAddrInst::Src &&
            "Should have dest above in memInstMust{Rei,I}nitialize");
 
-    if (markedValue->getCheckKind() == MarkMustCheckInst::CheckKind::NoCopy) {
+    if (markedValue->getCheckKind() ==
+        MarkMustCheckInst::CheckKind::NoConsumeOrAssign) {
       LLVM_DEBUG(llvm::dbgs()
                  << "Found mark must check [nocopy] error: " << *user);
       diagnosticEmitter.emitAddressDiagnosticNoCopy(markedValue, copyAddr);
@@ -1159,7 +1160,8 @@ bool GatherUsesVisitor::visitUse(Operand *op, AccessUseType useTy) {
       // If we are asked to perform guaranteed checking, emit an error if we
       // have /any/ consuming uses. This is a case that can always be converted
       // to a load_borrow if we pass the check.
-      if (markedValue->getCheckKind() == MarkMustCheckInst::CheckKind::NoCopy) {
+      if (markedValue->getCheckKind() ==
+          MarkMustCheckInst::CheckKind::NoConsumeOrAssign) {
         if (!moveChecker.canonicalizer.foundAnyConsumingUses()) {
           LLVM_DEBUG(llvm::dbgs()
                      << "Found mark must check [nocopy] error: " << *user);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -95,8 +95,9 @@ void DiagnosticEmitter::emitCheckerDoesntUnderstandDiagnostic(
   // that copy propagation did not understand. Emit a we did not understand
   // error.
   if (markedValue->getType().isMoveOnlyWrapped()) {
-    diagnose(fn->getASTContext(), markedValue,
-             diag::sil_moveonlychecker_not_understand_no_implicit_copy);
+    diagnose(
+        fn->getASTContext(), markedValue,
+        diag::sil_moveonlychecker_not_understand_consumable_and_assignable);
   } else {
     diagnose(fn->getASTContext(), markedValue,
              diag::sil_moveonlychecker_not_understand_moveonly);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectChecker.cpp
@@ -94,7 +94,7 @@ bool swift::siloptimizer::searchForCandidateObjectMarkMustChecks(
       // This is forming a let or an argument.
       // bb0:
       //   %1 = move_value [lexical] %0
-      //   %2 = mark_must_check [no_implicit_copy] %1
+      //   %2 = mark_must_check [consumable_and_assignable] %1
       //
       // This occurs when SILGen materializes a temporary move only value?
       // bb0:
@@ -170,7 +170,7 @@ bool swift::siloptimizer::searchForCandidateObjectMarkMustChecks(
       // bb0(%0 : $Trivial):
       //  %1 = copyable_to_moveonlywrapper [owned] %0
       //  %2 = move_value [lexical] %1
-      //  %3 = mark_must_check [no_implicit_copy] %2
+      //  %3 = mark_must_check [consumable_and_assignable] %2
       //
       // *OR*
       //
@@ -202,7 +202,7 @@ bool swift::siloptimizer::searchForCandidateObjectMarkMustChecks(
       // bb0(%0 : @owned $T):
       //   %1 = copyable_to_moveonlywrapper [owned] %0
       //   %2 = move_value [lexical] %1
-      //   %3 = mark_must_check [no_implicit_copy_owned] %2
+      //   %3 = mark_must_check [consumable_and_assignable_owned] %2
       if (auto *mvi = dyn_cast<MoveValueInst>(mmci->getOperand())) {
         if (mvi->isLexical()) {
           if (auto *cvt = dyn_cast<CopyableToMoveOnlyWrapperValueInst>(
@@ -224,7 +224,7 @@ bool swift::siloptimizer::searchForCandidateObjectMarkMustChecks(
       //  %1 = begin_borrow [lexical] %0
       //  %2 = copy_value %1
       //  %3 = copyable_to_moveonlywrapper [owned] %2
-      //  %4 = mark_must_check [no_implicit_copy]
+      //  %4 = mark_must_check [consumable_and_assignable]
       //
       // Or for a move only type, we look for a move_value [lexical].
       if (auto *mvi = dyn_cast<CopyableToMoveOnlyWrapperValueInst>(
@@ -245,7 +245,7 @@ bool swift::siloptimizer::searchForCandidateObjectMarkMustChecks(
       //
       // %1 = copyable_to_moveonlywrapper [owned] %0
       // %2 = move_value [lexical] %1
-      // %3 = mark_must_check [no_implicit_copy] %2
+      // %3 = mark_must_check [consumable_and_assignable] %2
       if (auto *cvi = dyn_cast<ExplicitCopyValueInst>(mmci->getOperand())) {
         if (auto *bbi = dyn_cast<BeginBorrowInst>(cvi->getOperand())) {
           if (bbi->isLexical()) {

--- a/test/IRGen/moveonly_deinits.swift
+++ b/test/IRGen/moveonly_deinits.swift
@@ -256,7 +256,7 @@ public func testKlassEnumPairWithoutDeinit() {
 }
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits27testKlassEnumPairWithDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:

--- a/test/SIL/Parser/basic2_moveonly.sil
+++ b/test/SIL/Parser/basic2_moveonly.sil
@@ -11,13 +11,13 @@ class Klass {}
 }
 
 // CHECK-LABEL: sil [ossa] @testMarkMustCheckInst : $@convention(thin) (@guaranteed Klass) -> () {
-// CHECK: mark_must_check [no_implicit_copy] %{{[0-9]+}} : $*MoveOnlyPair
+// CHECK: mark_must_check [consumable_and_assignable] %{{[0-9]+}} : $*MoveOnlyPair
 // CHECK: } // end sil function 'testMarkMustCheckInst'
 sil [ossa] @testMarkMustCheckInst : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
   %1 = alloc_box ${ var MoveOnlyPair }
   %2 = project_box %1 : ${ var MoveOnlyPair }, 0
-  %3 = mark_must_check [no_implicit_copy] %2 : $*MoveOnlyPair
+  %3 = mark_must_check [consumable_and_assignable] %2 : $*MoveOnlyPair
   %3c = begin_access [modify] [static] %3 : $*MoveOnlyPair
   %3a = struct_element_addr %3c : $*MoveOnlyPair, #MoveOnlyPair.lhs
   %3b = struct_element_addr %3c : $*MoveOnlyPair, #MoveOnlyPair.rhs

--- a/test/SIL/Parser/function_argument_lifetime_annotation.sil
+++ b/test/SIL/Parser/function_argument_lifetime_annotation.sil
@@ -14,10 +14,10 @@ bb0(%instance : @_eagerMove @owned $C):
   return %retval : $()
 }
 
-// CHECK-LABEL: sil [ossa] @one_arg_eager_move_and_no_implicit_copy : {{.*}} {
+// CHECK-LABEL: sil [ossa] @one_arg_eager_move_and_consumable_and_assignable : {{.*}} {
 // CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @noImplicitCopy @_eagerMove @owned $C):
-// CHECK-LABEL: } // end sil function 'one_arg_eager_move_and_no_implicit_copy'
-sil [ossa] @one_arg_eager_move_and_no_implicit_copy : $(@owned C) -> () {
+// CHECK-LABEL: } // end sil function 'one_arg_eager_move_and_consumable_and_assignable'
+sil [ossa] @one_arg_eager_move_and_consumable_and_assignable : $(@owned C) -> () {
 bb0(%instance : @noImplicitCopy @_eagerMove @owned $C):
   destroy_value %instance : $C
   %retval = tuple()
@@ -34,10 +34,10 @@ bb0(%instance : @_lexical @owned $C):
   return %retval : $()
 }
 
-// CHECK-LABEL: sil [ossa] @one_arg_lexical_and_no_implicit_copy : {{.*}} {
+// CHECK-LABEL: sil [ossa] @one_arg_lexical_and_consumable_and_assignable : {{.*}} {
 // CHECK:       {{bb[0-9]+}}({{%[^,]+}} : @noImplicitCopy @_lexical @owned $C):
-// CHECK-LABEL: } // end sil function 'one_arg_lexical_and_no_implicit_copy'
-sil [ossa] @one_arg_lexical_and_no_implicit_copy : $@convention(thin) (@owned C) -> () {
+// CHECK-LABEL: } // end sil function 'one_arg_lexical_and_consumable_and_assignable'
+sil [ossa] @one_arg_lexical_and_consumable_and_assignable : $@convention(thin) (@owned C) -> () {
 bb0(%instance : @noImplicitCopy @_lexical @owned $C):
   destroy_value %instance : $C
   %retval = tuple()

--- a/test/SIL/Serialization/basic2_moveonly.sil
+++ b/test/SIL/Serialization/basic2_moveonly.sil
@@ -14,13 +14,13 @@ class Klass {}
 }
 
 // CHECK-LABEL: sil [ossa] @testMarkMustCheckInst : $@convention(thin) (@guaranteed Klass) -> () {
-// CHECK: mark_must_check [no_implicit_copy] %{{[0-9]+}} : $*MoveOnlyPair
+// CHECK: mark_must_check [consumable_and_assignable] %{{[0-9]+}} : $*MoveOnlyPair
 // CHECK: } // end sil function 'testMarkMustCheckInst'
 sil [ossa] @testMarkMustCheckInst : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
   %1 = alloc_box ${ var MoveOnlyPair }
   %2 = project_box %1 : ${ var MoveOnlyPair }, 0
-  %3 = mark_must_check [no_implicit_copy] %2 : $*MoveOnlyPair
+  %3 = mark_must_check [consumable_and_assignable] %2 : $*MoveOnlyPair
   %3c = begin_access [modify] [static] %3 : $*MoveOnlyPair
   %3a = struct_element_addr %3c : $*MoveOnlyPair, #MoveOnlyPair.lhs
   %3b = struct_element_addr %3c : $*MoveOnlyPair, #MoveOnlyPair.rhs

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -89,7 +89,7 @@ public func consumeVal(_ s: __owned NonTrivialStruct2) {}
 // CHECK-LABEL: sil [ossa] @$s8moveonly8useKlassyyAA0C0CF : $@convention(thin) (@guaranteed Klass) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $Klass):
 // CHECK:   [[OWNED_ARG:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_OWNED_ARG:%.*]] = mark_must_check [no_copy] [[OWNED_ARG]]
+// CHECK:   [[MARKED_OWNED_ARG:%.*]] = mark_must_check [no_consume_or_assign] [[OWNED_ARG]]
 // CHECK: } // end sil function '$s8moveonly8useKlassyyAA0C0CF'
 public func useKlass(_ k: Klass) {
     borrowVal(k)
@@ -114,7 +114,7 @@ public func useKlassConsume(_ k: __owned Klass) {
 // CHECK-LABEL: sil [ossa] @$s8moveonly19useNonTrivialStructyyAA0cdE0VF : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $NonTrivialStruct):
 // CHECK:   [[COPIED_ARG:%.*]] = copy_value [[ARG]]
-// CHECK:   mark_must_check [no_copy] [[COPIED_ARG]]
+// CHECK:   mark_must_check [no_consume_or_assign] [[COPIED_ARG]]
 // CHECK: } // end sil function '$s8moveonly19useNonTrivialStructyyAA0cdE0VF'
 public func useNonTrivialStruct(_ s: NonTrivialStruct) {
     borrowVal(s)
@@ -142,7 +142,7 @@ public func useNonTrivialOwnedStruct(_ s: __owned NonTrivialStruct) {
 // CHECK-LABEL: sil [ossa] @$s8moveonly17useNonTrivialEnumyyAA0cdE0OF : $@convention(thin) (@guaranteed NonTrivialEnum) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $NonTrivialEnum):
 // CHECK:   [[COPIED_ARG:%.*]] = copy_value [[ARG]]
-// CHECK:   mark_must_check [no_copy] [[COPIED_ARG]]
+// CHECK:   mark_must_check [no_consume_or_assign] [[COPIED_ARG]]
 // CHECK: } // end sil function '$s8moveonly17useNonTrivialEnumyyAA0cdE0OF'
 public func useNonTrivialEnum(_ s: NonTrivialEnum) {
     borrowVal(s)
@@ -183,7 +183,7 @@ extension Klass {
     // CHECK-LABEL: sil hidden [ossa] @$s8moveonly5KlassC13testNoUseSelfyyF : $@convention(method) (@guaranteed Klass) -> () {
     // CHECK: bb0([[ARG:%.*]] : @guaranteed $Klass):
     // CHECK:   [[COPIED_ARG:%.*]] = copy_value [[ARG]]
-    // CHECK:   mark_must_check [no_copy] [[COPIED_ARG]]
+    // CHECK:   mark_must_check [no_consume_or_assign] [[COPIED_ARG]]
     // CHECK: } // end sil function '$s8moveonly5KlassC13testNoUseSelfyyF'
     func testNoUseSelf() {
         let x = self
@@ -195,7 +195,7 @@ extension NonTrivialStruct {
     // CHECK-LABEL: sil hidden [ossa] @$s8moveonly16NonTrivialStructV13testNoUseSelfyyF : $@convention(method) (@guaranteed NonTrivialStruct) -> () {
     // CHECK: bb0([[ARG:%.*]] : @guaranteed $NonTrivialStruct):
     // CHECK:   [[COPIED_ARG:%.*]] = copy_value [[ARG]]
-    // CHECK:   mark_must_check [no_copy] [[COPIED_ARG]]
+    // CHECK:   mark_must_check [no_consume_or_assign] [[COPIED_ARG]]
     // CHECK: } // end sil function '$s8moveonly16NonTrivialStructV13testNoUseSelfyyF'
     func testNoUseSelf() {
         let x = self
@@ -207,7 +207,7 @@ extension NonTrivialEnum {
     // CHECK-LABEL: sil hidden [ossa] @$s8moveonly14NonTrivialEnumO13testNoUseSelfyyF : $@convention(method) (@guaranteed NonTrivialEnum) -> () {
     // CHECK: bb0([[ARG:%.*]] : @guaranteed $NonTrivialEnum):
     // CHECK:   [[COPIED_ARG:%.*]] = copy_value [[ARG]]
-    // CHECK:   mark_must_check [no_copy] [[COPIED_ARG]]
+    // CHECK:   mark_must_check [no_consume_or_assign] [[COPIED_ARG]]
     // CHECK: } // end sil function '$s8moveonly14NonTrivialEnumO13testNoUseSelfyyF'
     func testNoUseSelf() {
         let x = self
@@ -612,7 +612,7 @@ var booleanGuard2: Bool { false }
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly15enumSwitchTest1yyAA04EnumC5TestsO1EOF : $@convention(thin) (@guaranteed EnumSwitchTests.E) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed
 // CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[COPY_ARG]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[COPY_ARG]]
 // CHECK:   [[BORROWED_VALUE:%.*]] = begin_borrow [[MARKED_VALUE]]
 // CHECK:   switch_enum [[BORROWED_VALUE]] : $EnumSwitchTests.E, case #EnumSwitchTests.E.first!enumelt: [[BB_E_1:bb[0-9]+]], case #EnumSwitchTests.E.second!enumelt: [[BB_E_2:bb[0-9]+]], case #EnumSwitchTests.E.third!enumelt: [[BB_E_3:bb[0-9]+]], case #EnumSwitchTests.E.fourth!enumelt: [[BB_E_4:bb[0-9]+]]
 //

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -20,7 +20,7 @@ public final class Klass {
     // CHECK-LABEL: sil hidden [ossa] @$s8moveonly5KlassCACycfc : $@convention(method) (@owned Klass) -> @owned Klass {
     // CHECK: bb0([[ARG:%.*]] : @owned $Klass):
     // CHECK:   [[MARK_UNINIT:%.*]] = mark_uninitialized [rootself] [[ARG]]
-    // CHECK:   [[MARK_NO_IMP_COPY:%.*]] = mark_must_check [no_implicit_copy] [[MARK_UNINIT]]
+    // CHECK:   [[MARK_NO_IMP_COPY:%.*]] = mark_must_check [consumable_and_assignable] [[MARK_UNINIT]]
     // CHECK: } // end sil function '$s8moveonly5KlassCACycfc'
     init() {
         moveOnlyKlass = Klass2()
@@ -102,7 +102,7 @@ public func useKlass(_ k: Klass) {
 // CHECK: bb0([[ARG:%.*]] : @owned $Klass):
 // TODO: Is this move_value [lexical] necessary?
 // CHECK:   [[LEXICAL_MOVE:%.*]] = move_value [lexical] [[ARG]]
-// CHECK:   mark_must_check [no_implicit_copy] [[LEXICAL_MOVE]]
+// CHECK:   mark_must_check [consumable_and_assignable] [[LEXICAL_MOVE]]
 // CHECK: } // end sil function '$s8moveonly15useKlassConsumeyyAA0C0CnF'
 public func useKlassConsume(_ k: __owned Klass) {
     borrowVal(k)
@@ -128,7 +128,7 @@ public func useNonTrivialStruct(_ s: NonTrivialStruct) {
 // CHECK-LABEL: sil [ossa] @$s8moveonly24useNonTrivialOwnedStructyyAA0cdF0VnF : $@convention(thin) (@owned NonTrivialStruct) -> () {
 // CHECK: bb0([[ARG:%.*]] : @owned $NonTrivialStruct):
 // CHECK:   [[MOVED_ARG:%.*]] = move_value [lexical] [[ARG]]
-// CHECK:   mark_must_check [no_implicit_copy] [[MOVED_ARG]]
+// CHECK:   mark_must_check [consumable_and_assignable] [[MOVED_ARG]]
 // CHECK: } // end sil function '$s8moveonly24useNonTrivialOwnedStructyyAA0cdF0VnF'
 public func useNonTrivialOwnedStruct(_ s: __owned NonTrivialStruct) {
     borrowVal(s)
@@ -158,7 +158,7 @@ public func useNonTrivialEnum(_ s: NonTrivialEnum) {
 // CHECK-LABEL: sil [ossa] @$s8moveonly22useNonTrivialOwnedEnumyyAA0cdF0OnF : $@convention(thin) (@owned NonTrivialEnum) -> () {
 // CHECK: bb0([[ARG:%.*]] : @owned $NonTrivialEnum):
 // CHECK:   [[MOVED_ARG:%.*]] = move_value [lexical] [[ARG]]
-// CHECK:   mark_must_check [no_implicit_copy] [[MOVED_ARG]]
+// CHECK:   mark_must_check [consumable_and_assignable] [[MOVED_ARG]]
 // CHECK: } // end sil function '$s8moveonly22useNonTrivialOwnedEnumyyAA0cdF0OnF'
 public func useNonTrivialOwnedEnum(_ s: __owned NonTrivialEnum) {
     borrowVal(s)
@@ -223,7 +223,7 @@ extension NonTrivialEnum {
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly5KlassCACycfC : $@convention(method) (@thick Klass.Type) -> @owned Klass
 // CHECK: [[X:%.*]] = apply [[FN]](
 // CHECK: [[X_MV_LEXICAL:%.*]] = move_value [lexical] [[X]]
-// CHECK: [[X_MV_ONLY:%.*]] = mark_must_check [no_implicit_copy] [[X_MV_LEXICAL]]
+// CHECK: [[X_MV_ONLY:%.*]] = mark_must_check [consumable_and_assignable] [[X_MV_LEXICAL]]
 // CHECK: [[X_MV_ONLY_BORROW:%.*]] = begin_borrow [[X_MV_ONLY]]
 // CHECK: [[X_MV_ONLY_COPY:%.*]] = copy_value [[X_MV_ONLY_BORROW]]
 // CHECK: [[X_MV_ONLY_CONSUME:%.*]] = move_value [[X_MV_ONLY_COPY]]
@@ -237,7 +237,7 @@ func blackHoleLetInitialization1() {
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly5KlassCACycfC : $@convention(method) (@thick Klass.Type) -> @owned Klass
 // CHECK: [[X:%.*]] = apply [[FN]](
 // CHECK: [[X_MV_LEXICAL:%.*]] = move_value [lexical] [[X]]
-// CHECK: [[X_MV_ONLY:%.*]] = mark_must_check [no_implicit_copy] [[X_MV_LEXICAL]]
+// CHECK: [[X_MV_ONLY:%.*]] = mark_must_check [consumable_and_assignable] [[X_MV_LEXICAL]]
 // CHECK: [[X_MV_ONLY_BORROW:%.*]] = begin_borrow [[X_MV_ONLY]]
 // CHECK: [[X_MV_ONLY_COPY:%.*]] = copy_value [[X_MV_ONLY_BORROW]]
 // CHECK: [[X_MV_ONLY_CONSUME:%.*]] = move_value [[X_MV_ONLY_COPY]]
@@ -251,7 +251,7 @@ func blackHoleLetInitialization2() {
 // CHECK: [[BOX:%.*]] = alloc_box
 // CHECK: [[BOX_BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
 // CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
-// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy] [[PROJECT_BOX]]
+// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable] [[PROJECT_BOX]]
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly5KlassCACycfC : $@convention(method) (@thick Klass.Type) -> @owned Klass
 // CHECK: [[X:%.*]] = apply [[FN]](
 // CHECK: store [[X]] to [init] [[MARKED_ADDR]]
@@ -269,7 +269,7 @@ func blackHoleVarInitialization1() {
 // CHECK: [[BOX:%.*]] = alloc_box
 // CHECK: [[BOX_BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
 // CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
-// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy] [[PROJECT_BOX]]
+// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable] [[PROJECT_BOX]]
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly5KlassCACycfC : $@convention(method) (@thick Klass.Type) -> @owned Klass
 // CHECK: [[X:%.*]] = apply [[FN]](
 // CHECK: store [[X]] to [init] [[MARKED_ADDR]]
@@ -288,7 +288,7 @@ func blackHoleVarInitialization2() {
 ////////////////////////////////
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly24borrowObjectFunctionCallyyF : $@convention(thin) () -> () {
-// CHECK: [[CLS:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK: [[CLS:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK: [[BORROW:%.*]] = begin_borrow [[CLS]]
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA5KlassCF
 // CHECK: apply [[FN]]([[BORROW]])
@@ -300,7 +300,7 @@ func borrowObjectFunctionCall() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly25borrowAddressFunctionCallyyF : $@convention(thin) () -> () {
-// CHECK: [[BOX:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK: [[BOX:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[BOX]]
 // CHECK: [[BORROW:%.*]] = load_borrow [[ACCESS]]
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA5KlassCF
@@ -319,7 +319,7 @@ func borrowAddressFunctionCall() {
 // high order bit here, so I filed a bug. We might be able to do it in the future.
 //
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly31klassBorrowAddressFunctionCall2yyF : $@convention(thin) () -> () {
-// CHECK: [[MARK:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK: [[MARK:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARK]]
 // CHECK: } // end sil function '$s8moveonly31klassBorrowAddressFunctionCall2yyF'
 func klassBorrowAddressFunctionCall2() {
@@ -332,7 +332,7 @@ func klassBorrowAddressFunctionCall2() {
 //
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly38klassBorrowCopyableAddressFunctionCallyyF : $@convention(thin) () -> () {
 // CHECK: bb0:
-// CHECK:  [[CLASS:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:  [[CLASS:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK:  [[ACCESS:%.*]] = begin_access [read] [unknown] [[CLASS]]
 // CHECK:  [[LOAD:%.*]] = load [copy] [[ACCESS]]
 // CHECK:  end_access [[ACCESS]]
@@ -349,7 +349,7 @@ func klassBorrowCopyableAddressFunctionCall() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly29moveOnlyStructNonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK: [[BORROW:%.*]] = load_borrow [[ACCESS]]
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA16NonTrivialStructVF :
@@ -364,7 +364,7 @@ func moveOnlyStructNonConsumingUse() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMoveC20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK: [[STRUCT_EXT:%.*]] = struct_element_addr [[ACCESS]]
 // CHECK: [[BORROW:%.*]] = load_borrow [[STRUCT_EXT]]
@@ -382,7 +382,7 @@ func moveOnlyStructMoveOnlyKlassNonConsumingUse() {
 // We fail here b/c we are accessing through a class.
 //
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovec5KlassecF15NonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[STRUCT_EXT:%.*]] = struct_element_addr [[ACCESS]]
 // CHECK:   [[STRUCT_EXT_COPY:%.*]] = load [copy] [[STRUCT_EXT]]
@@ -405,7 +405,7 @@ func moveOnlyStructMoveOnlyKlassMoveOnlyKlassNonConsumingUse() {
 // We fail here b/c we are accessing through a class.
 //
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovec13KlassCopyableF15NonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[STRUCT_EXT:%.*]] = struct_element_addr [[ACCESS]]
 // CHECK:   [[STRUCT_EXT_COPY:%.*]] = load [copy] [[STRUCT_EXT]]
@@ -426,7 +426,7 @@ func moveOnlyStructMoveOnlyKlassCopyableKlassNonConsumingUse() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovecD15NonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP]]
@@ -442,7 +442,7 @@ func moveOnlyStructMoveOnlyStructNonConsumingUse() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovecdeC20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialStruct2, #NonTrivialStruct2.moveOnlyKlass
@@ -459,7 +459,7 @@ func moveOnlyStructMoveOnlyStructMoveOnlyKlassNonConsumingUse() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovecD28CopyableKlassNonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialStruct2, #NonTrivialStruct2.copyableKlass
@@ -476,7 +476,7 @@ func moveOnlyStructMoveOnlyStructCopyableKlassNonConsumingUse() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly42moveOnlyStructCopyableKlassNonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.copyableKlass
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP]]
@@ -492,7 +492,7 @@ func moveOnlyStructCopyableKlassNonConsumingUse() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyableD15NonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP]]
@@ -508,7 +508,7 @@ func moveOnlyStructCopyableStructNonConsumingUse() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyabledE20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.copyableKlass
@@ -525,7 +525,7 @@ func moveOnlyStructCopyableStructCopyableKlassNonConsumingUse() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyabledeD15NonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.nonTrivialCopyableStruct2
@@ -542,7 +542,7 @@ func moveOnlyStructCopyableStructCopyableStructNonConsumingUse() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyablededE20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.nonTrivialCopyableStruct2
@@ -562,7 +562,7 @@ func moveOnlyStructCopyableStructCopyableStructCopyableKlassNonConsumingUse() {
 // We fail here b/c we are accessing through a class.
 //
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyabledede9KlassMovecF15NonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [no_implicit_copy]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.nonTrivialCopyableStruct2

--- a/test/SILGen/moveonly_deinits.swift
+++ b/test/SILGen/moveonly_deinits.swift
@@ -59,7 +59,7 @@ var value: Bool { false }
 //////////////////
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits24testIntPairWithoutDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:
@@ -101,7 +101,7 @@ public func testIntPairWithoutDeinit() {
 }
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits21testIntPairWithDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:
@@ -144,7 +144,7 @@ public func testIntPairWithDeinit() {
 }
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits26testKlassPairWithoutDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:
@@ -186,7 +186,7 @@ public func testKlassPairWithoutDeinit() {
 }
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits23testKlassPairWithDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:
@@ -274,7 +274,7 @@ func consumeKlassEnumPairWithDeinit(_ x: __owned KlassEnumPairWithDeinit) { }
 ////////////////
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits28testIntEnumPairWithoutDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:
@@ -315,7 +315,7 @@ public func testIntEnumPairWithoutDeinit() {
 }
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits25testIntEnumPairWithDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:
@@ -357,7 +357,7 @@ public func testIntEnumPairWithDeinit() {
 }
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits30testKlassEnumPairWithoutDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:
@@ -398,7 +398,7 @@ public func testKlassEnumPairWithoutDeinit() {
 }
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits27testKlassEnumPairWithDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [no_implicit_copy] {{%.*}}
+// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:

--- a/test/SILGen/moveonly_enum_literal.swift
+++ b/test/SILGen/moveonly_enum_literal.swift
@@ -16,7 +16,7 @@ var value: Bool { false }
 // CHECK-LABEL: sil hidden [ossa] @$s21moveonly_enum_literal4testyyF : $@convention(thin) () -> () {
 // CHECK: [[VALUE:%.*]] = enum $MoveOnlyIntPair, #MoveOnlyIntPair.lhs!enumelt,
 // CHECK: [[MV:%.*]] = move_value [lexical] [[VALUE]]
-// CHECK: [[MARKED_VALUE:%.*]] = mark_must_check [no_implicit_copy] [[MV]]
+// CHECK: [[MARKED_VALUE:%.*]] = mark_must_check [consumable_and_assignable] [[MV]]
 // CHECK: debug_value [[MARKED_VALUE]]
 // CHECK: } // end sil function '$s21moveonly_enum_literal4testyyF'
 func test() {

--- a/test/SILGen/noimplicitcopy.swift
+++ b/test/SILGen/noimplicitcopy.swift
@@ -46,7 +46,7 @@ func print2(_ x: Int) {
 // CHECK-LABEL: sil hidden [ossa] @$s14noimplicitcopy8printIntyyF : $@convention(thin) () -> () {
 // CHECK:   [[X_MOVEONLY:%.*]] = copyable_to_moveonlywrapper [owned] {{%.*}} : $Int
 // CHECK:   [[X:%.*]] = move_value [lexical] [[X_MOVEONLY]]
-// CHECK:   [[X_MOVEONLYWRAPPED_MARKED:%.*]] = mark_must_check [no_implicit_copy] [[X]]
+// CHECK:   [[X_MOVEONLYWRAPPED_MARKED:%.*]] = mark_must_check [consumable_and_assignable] [[X]]
 // CHECK:   [[BORROWED_X_MOVEONLYWRAPPED_MARKED_1:%.*]] = begin_borrow [[X_MOVEONLYWRAPPED_MARKED]]
 // CHECK:   [[BORROWED_X_MOVEONLYWRAPPED_MARKED_2:%.*]] = begin_borrow [[X_MOVEONLYWRAPPED_MARKED]]
 // CHECK:   [[FUNC:%.*]] = function_ref @$sSi1poiyS2i_SitFZ : $@convention(method) (Int, Int, @thin Int.Type) -> Int
@@ -120,7 +120,7 @@ func callPrintIntArg() {
 // CHECK: bb0([[ARG:%.*]] : @noImplicitCopy $Int):
 // CHECK:   [[ARG_WRAPPED:%.*]] = copyable_to_moveonlywrapper [owned] [[ARG]]
 // CHECK:   [[LEXICAL_ARG:%.*]] = move_value [lexical] [[ARG_WRAPPED]]
-// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_implicit_copy] [[LEXICAL_ARG]]
+// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [consumable_and_assignable] [[LEXICAL_ARG]]
 // CHECK:   [[BORROWED_MARKED_ARG_1:%.*]] = begin_borrow [[MARKED_ARG]]
 // CHECK:   [[BORROWED_MARKED_ARG_2:%.*]] = begin_borrow [[MARKED_ARG]]
 // CHECK:   [[FUNC:%.*]] = function_ref @$sSi1poiyS2i_SitFZ : $@convention(method) (Int, Int, @thin Int.Type) -> Int
@@ -296,7 +296,7 @@ func callClosureInt() {
 // CHECK: bb0([[ARG:%.*]] : @noImplicitCopy $Int):
 // CHECK:   [[WRAPPED_ARG:%.*]] = copyable_to_moveonlywrapper [owned] [[ARG]]
 // CHECK:   [[MOVED_ARG:%.*]] = move_value [lexical] [[WRAPPED_ARG]]
-// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_implicit_copy] [[MOVED_ARG]]
+// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [consumable_and_assignable] [[MOVED_ARG]]
 // CHECK:   [[BORROWED_ARG_MARKED_1:%.*]] = begin_borrow [[MARKED_ARG]]
 // CHECK:   [[BORROWED_ARG_MARKED_2:%.*]] = begin_borrow [[MARKED_ARG]]
 // CHECK:   [[FUNC:%.*]] = function_ref @$sSi1poiyS2i_SitFZ : $@convention(method) (Int, Int, @thin Int.Type) -> Int
@@ -336,7 +336,7 @@ func callClosureIntOwned() {
 // CHECK:   [[X:%.*]] = begin_borrow [lexical] {{%[0-9]+}} : $Klass
 // CHECK:   [[X_COPY:%.*]] = copy_value [[X]]
 // CHECK:   [[X_MOVEONLYWRAPPED:%.*]] = copyable_to_moveonlywrapper [owned] [[X_COPY]]
-// CHECK:   [[X_MOVEONLYWRAPPED_MARKED:%.*]] = mark_must_check [no_implicit_copy] [[X_MOVEONLYWRAPPED]]
+// CHECK:   [[X_MOVEONLYWRAPPED_MARKED:%.*]] = mark_must_check [consumable_and_assignable] [[X_MOVEONLYWRAPPED]]
 // CHECK:   [[BORROWED_X_MOVEONLYWRAPPED_MARKED:%.*]] = begin_borrow [[X_MOVEONLYWRAPPED_MARKED]]
 // CHECK:   [[FUNC:%.*]] = class_method [[BORROWED_X_MOVEONLYWRAPPED_MARKED]]
 // CHECK:   [[GUARANTEED_ESCAPED_X:%.*]] = moveonlywrapper_to_copyable [guaranteed] [[BORROWED_X_MOVEONLYWRAPPED_MARKED]]
@@ -393,7 +393,7 @@ func callPrintKlassArg() {
 // CHECK: bb0([[ARG:%.*]] : @noImplicitCopy @owned $Klass):
 // CHECK:   [[WRAPPED_ARG:%.*]] = copyable_to_moveonlywrapper [owned] [[ARG]]
 // CHECK:   [[MOVED_ARG:%.*]] = move_value [lexical] [[WRAPPED_ARG]]
-// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_implicit_copy] [[MOVED_ARG]]
+// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [consumable_and_assignable] [[MOVED_ARG]]
 // CHECK: } // end sil function '$s14noimplicitcopy18printKlassOwnedArgyyAA0C0CnF'
 //
 // SIL-LABEL: sil hidden @$s14noimplicitcopy18printKlassOwnedArgyyAA0C0CnF : $@convention(thin) (@owned Klass) -> () {
@@ -447,7 +447,7 @@ func callPrintKlassArgThrows() throws {
 // CHECK: bb0([[ARG:%.*]] : @noImplicitCopy @owned $Klass):
 // CHECK:   [[WRAPPED_ARG:%.*]] = copyable_to_moveonlywrapper [owned] [[ARG]]
 // CHECK:   [[MOVED_ARG:%.*]] = move_value [lexical] [[WRAPPED_ARG]]
-// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_implicit_copy] [[MOVED_ARG]]
+// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [consumable_and_assignable] [[MOVED_ARG]]
 // CHECK:   [[BORROWED_MARKED_ARG:%.*]] = begin_borrow [[MARKED_ARG]]
 // CHECK:   [[UNWRAPPED_ARG:%.*]] = moveonlywrapper_to_copyable [guaranteed] [[BORROWED_MARKED_ARG]]
 // CHECK:   apply {{%.*}}([[UNWRAPPED_ARG]]) :
@@ -479,7 +479,7 @@ func callPrintKlassOwnedOwnedArgThrows() throws {
 // CHECK: bb0([[ARG:%.*]] : $Trivial):
 // CHECK:   [[WRAPPED:%.*]] = copyable_to_moveonlywrapper [owned] [[ARG]]
 // CHECK:   [[MV_WRAPPED:%.*]] = move_value [lexical] [[WRAPPED]]
-// CHECK:   [[MARKED:%.*]] = mark_must_check [no_implicit_copy] [[MV_WRAPPED]]
+// CHECK:   [[MARKED:%.*]] = mark_must_check [consumable_and_assignable] [[MV_WRAPPED]]
 // CHECK:   [[BORROW:%.*]] = begin_borrow [[MARKED]]
 // CHECK:   [[EXT:%.*]] = struct_extract [[BORROW]]
 // CHECK:   [[UNWRAPPED:%.*]] = moveonlywrapper_to_copyable [guaranteed] [[EXT]]

--- a/test/SILGen/noimplicitcopy.swift
+++ b/test/SILGen/noimplicitcopy.swift
@@ -71,7 +71,7 @@ func printInt() {
 // CHECK: bb0([[ARG:%.*]] : @noImplicitCopy $Int):
 // CHECK:   [[ARG_WRAPPED:%.*]] = copyable_to_moveonlywrapper [owned] [[ARG]]
 // CHECK:   [[LEXICAL_ARG:%.*]] = move_value [lexical] [[ARG_WRAPPED]]
-// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_copy] [[LEXICAL_ARG]]
+// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_consume_or_assign] [[LEXICAL_ARG]]
 // CHECK:   [[BORROWED_MARKED_ARG_1:%.*]] = begin_borrow [[MARKED_ARG]]
 // CHECK:   [[BORROWED_MARKED_ARG_2:%.*]] = begin_borrow [[MARKED_ARG]]
 // CHECK:   [[FUNC:%.*]] = function_ref @$sSi1poiyS2i_SitFZ : $@convention(method) (Int, Int, @thin Int.Type) -> Int
@@ -169,7 +169,7 @@ func callPrintIntOwnedArg() {
 // CHECK: bb0([[ARG:%.*]] : @noImplicitCopy $Int):
 // CHECK:   [[ARG_WRAPPED:%.*]] = copyable_to_moveonlywrapper [owned] [[ARG]]
 // CHECK:   [[LEXICAL_ARG:%.*]] = move_value [lexical] [[ARG_WRAPPED]]
-// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_copy] [[LEXICAL_ARG]]
+// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_consume_or_assign] [[LEXICAL_ARG]]
 // CHECK:   [[BORROWED_MARKED_ARG_1:%.*]] = begin_borrow [[MARKED_ARG]]
 // CHECK:   [[BORROWED_MARKED_ARG_2:%.*]] = begin_borrow [[MARKED_ARG]]
 // CHECK:   [[FUNC:%.*]] = function_ref @$sSi1poiyS2i_SitFZ : $@convention(method) (Int, Int, @thin Int.Type) -> Int
@@ -262,7 +262,7 @@ func useClosureInt(_ f: (Int) -> ()) {}
 // CHECK: bb0([[X:%.*]] : @noImplicitCopy $Int):
 // CHECK:   [[WRAPPED_X:%.*]] = copyable_to_moveonlywrapper [owned] [[X]]
 // CHECK:   [[MOVED_X:%.*]] = move_value [lexical] [[WRAPPED_X]]
-// CHECK:   [[MARKED_X:%.*]] = mark_must_check [no_copy] [[MOVED_X]]
+// CHECK:   [[MARKED_X:%.*]] = mark_must_check [no_consume_or_assign] [[MOVED_X]]
 // CHECK:   [[BORROWED_X_MARKED_1:%.*]] = begin_borrow [[MARKED_X]]
 // CHECK:   [[BORROWED_X_MARKED_2:%.*]] = begin_borrow [[MARKED_X]]
 // CHECK:   [[FUNC:%.*]] = function_ref @$sSi1poiyS2i_SitFZ : $@convention(method) (Int, Int, @thin Int.Type) -> Int
@@ -367,7 +367,7 @@ func printKlass() {
 // CHECK: bb0([[ARG:%.*]] : @noImplicitCopy @guaranteed $Klass):
 // CHECK:   [[WRAPPED_ARG:%.*]] = copyable_to_moveonlywrapper [guaranteed] [[ARG]]
 // CHECK:   [[COPIED_WRAPPED_ARG:%.*]] = copy_value [[WRAPPED_ARG]]
-// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_copy] [[COPIED_WRAPPED_ARG]]
+// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_consume_or_assign] [[COPIED_WRAPPED_ARG]]
 // CHECK: } // end sil function '$s14noimplicitcopy13printKlassArgyyAA0C0CF'
 //
 // SIL-LABEL: sil hidden @$s14noimplicitcopy13printKlassArgyyAA0C0CF : $@convention(thin) (@guaranteed Klass) -> () {
@@ -419,7 +419,7 @@ func callPrintKlassOwnedArg() {
 // CHECK: bb0([[ARG:%.*]] : @noImplicitCopy @guaranteed $Klass):
 // CHECK:   [[WRAPPED_ARG:%.*]] = copyable_to_moveonlywrapper [guaranteed] [[ARG]]
 // CHECK:   [[COPIED_ARG:%.*]] = copy_value [[WRAPPED_ARG]]
-// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_copy] [[COPIED_ARG]]
+// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_consume_or_assign] [[COPIED_ARG]]
 // CHECK:   [[BORROWED_MARKED_ARG:%.*]] = begin_borrow [[MARKED_ARG]]
 // CHECK:   [[UNWRAPPED_ARG:%.*]] = moveonlywrapper_to_copyable [guaranteed] [[BORROWED_MARKED_ARG]]
 // CHECK:   apply {{%.*}}([[UNWRAPPED_ARG]]) :

--- a/test/SILOptimizer/accessutils_raw.sil
+++ b/test/SILOptimizer/accessutils_raw.sil
@@ -38,7 +38,7 @@ sil [ossa] @testMarkMustCheckInst : $@convention(thin) (@guaranteed List) -> () 
 bb0(%0 : @guaranteed $List):
   %1 = alloc_box ${ var MoveOnlyPair }
   %2 = project_box %1 : ${ var MoveOnlyPair }, 0
-  %3 = mark_must_check [no_implicit_copy] %2 : $*MoveOnlyPair
+  %3 = mark_must_check [consumable_and_assignable] %2 : $*MoveOnlyPair
   %3c = begin_access [modify] [static] %3 : $*MoveOnlyPair
   %3a = struct_element_addr %3c : $*MoveOnlyPair, #MoveOnlyPair.lhs
   %3b = struct_element_addr %3c : $*MoveOnlyPair, #MoveOnlyPair.rhs

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -56,7 +56,7 @@ public struct NonTrivialStruct2 {
 sil [ossa] @simpleInitReturn : $@convention(thin) (@owned NonTrivialStruct) -> @owned NonTrivialStruct {
 bb0(%0 : @owned $NonTrivialStruct):
   %1 = alloc_stack [lexical] $NonTrivialStruct
-  %2 = mark_must_check [no_implicit_copy] %1 : $*NonTrivialStruct
+  %2 = mark_must_check [consumable_and_assignable] %1 : $*NonTrivialStruct
   store %0 to [init] %2 : $*NonTrivialStruct
   %3 = load [copy] %2 : $*NonTrivialStruct
   destroy_addr %2 : $*NonTrivialStruct
@@ -67,7 +67,7 @@ bb0(%0 : @owned $NonTrivialStruct):
 sil [ossa] @simpleInitReturn2 : $@convention(thin) (@owned NonTrivialStruct, @owned NonTrivialStruct) -> @owned NonTrivialStructPair {
 bb0(%arg1 : @owned $NonTrivialStruct, %arg2 : @owned $NonTrivialStruct):
   %1 = alloc_stack [lexical] $NonTrivialStruct
-  %2 = mark_must_check [no_implicit_copy] %1 : $*NonTrivialStruct
+  %2 = mark_must_check [consumable_and_assignable] %1 : $*NonTrivialStruct
   store %arg1 to [init] %2 : $*NonTrivialStruct
   %3 = load [copy] %2 : $*NonTrivialStruct
   destroy_addr %2 : $*NonTrivialStruct
@@ -96,7 +96,7 @@ bb0(%arg1 : @owned $NonTrivialStruct, %arg2 : @owned $NonTrivialStruct):
 sil [ossa] @simpleInitReturnMoveOnlyField : $@convention(thin) (@owned NonTrivialStruct) -> @owned Klass {
 bb0(%0 : @owned $NonTrivialStruct):
   %1 = alloc_stack [lexical] $NonTrivialStruct
-  %2 = mark_must_check [no_implicit_copy] %1 : $*NonTrivialStruct
+  %2 = mark_must_check [consumable_and_assignable] %1 : $*NonTrivialStruct
   store %0 to [init] %2 : $*NonTrivialStruct
   %3a = struct_element_addr %2 : $*NonTrivialStruct, #NonTrivialStruct.k
   %3 = load [copy] %3a : $*Klass
@@ -132,7 +132,7 @@ bb0(%0 : @owned $NonTrivialStruct):
 sil [ossa] @simpleInitReturnMoveOnlyFieldMultiBlock : $@convention(thin) (@owned NonTrivialStruct) -> @owned Klass {
 bb0(%0 : @owned $NonTrivialStruct):
   %1 = alloc_stack [lexical] $NonTrivialStruct
-  %2 = mark_must_check [no_implicit_copy] %1 : $*NonTrivialStruct
+  %2 = mark_must_check [consumable_and_assignable] %1 : $*NonTrivialStruct
   store %0 to [init] %2 : $*NonTrivialStruct
   cond_br undef, bb1, bb2
 
@@ -182,7 +182,7 @@ bb3(%5 : @owned $Klass):
 sil [ossa] @simpleInitReturnMoveOnlyFieldMultiBlock2 : $@convention(thin) (@owned NonTrivialStruct) -> @owned Klass {
 bb0(%0 : @owned $NonTrivialStruct):
   %1 = alloc_stack [lexical] $NonTrivialStruct
-  %2 = mark_must_check [no_implicit_copy] %1 : $*NonTrivialStruct
+  %2 = mark_must_check [consumable_and_assignable] %1 : $*NonTrivialStruct
   store %0 to [init] %2 : $*NonTrivialStruct
   cond_br undef, bb1, bb2
 
@@ -235,7 +235,7 @@ bb3(%5 : @owned $Klass):
 sil [ossa] @simpleInitReturnMoveOnlyFieldMultiBlock3 : $@convention(thin) (@owned NonTrivialStruct) -> @owned Klass {
 bb0(%0 : @owned $NonTrivialStruct):
   %1 = alloc_stack [lexical] $NonTrivialStruct
-  %2 = mark_must_check [no_implicit_copy] %1 : $*NonTrivialStruct
+  %2 = mark_must_check [consumable_and_assignable] %1 : $*NonTrivialStruct
   store %0 to [init] %2 : $*NonTrivialStruct
   cond_br undef, bb1, bb2
 
@@ -269,7 +269,7 @@ bb3(%5 : @owned $Klass):
 sil [ossa] @useVarKlassNoErrorSimple : $@convention(thin) (@owned Klass) -> () {
 bb0(%arg : @owned $Klass):
   %0 = alloc_stack [lexical] $Klass, var, name "k"
-  %1 = mark_must_check [no_implicit_copy] %0 : $*Klass
+  %1 = mark_must_check [consumable_and_assignable] %0 : $*Klass
   store %arg to [init] %1 : $*Klass
   %12 = begin_access [read] [static] %1 : $*Klass
   %13 = load_borrow %12 : $*Klass
@@ -281,7 +281,7 @@ bb0(%arg : @owned $Klass):
   %19 = load [copy] %18 : $*Klass
   end_access %18 : $*Klass
   %21 = move_value [lexical] %19 : $Klass
-  %22 = mark_must_check [no_implicit_copy] %21 : $Klass
+  %22 = mark_must_check [consumable_and_assignable] %21 : $Klass
   debug_value %22 : $Klass, let, name "k2"
   %25 = move_value %22 : $Klass
   destroy_value %25 : $Klass
@@ -308,7 +308,7 @@ bb0(%arg : @owned $Klass):
 sil [ossa] @classSimpleNonConsumingUseTest : $@convention(thin) (@owned Klass, @owned Klass) -> () {
 bb0(%0 : @owned $Klass, %1 : @owned $Klass):
   %4 = alloc_stack [lexical] $Klass, var, name "x2"
-  %5 = mark_must_check [no_implicit_copy] %4 : $*Klass
+  %5 = mark_must_check [consumable_and_assignable] %4 : $*Klass
   store %0 to [init] %5 : $*Klass
   %9 = begin_access [modify] [static] %5 : $*Klass
   store %1 to [assign] %9 : $*Klass
@@ -331,7 +331,7 @@ bb0(%0 : @owned $Klass, %1 : @owned $Klass):
 sil [ossa] @myBufferViewSetter : $@convention(method) <T> (UnsafeBufferPointer<T>, @inout MyBufferView<T>) -> () {
 bb0(%0 : $UnsafeBufferPointer<T>, %1 : $*MyBufferView<T>):
   debug_value %0 : $UnsafeBufferPointer<T>, let, name "value", argno 1, implicit
-  %3 = mark_must_check [no_implicit_copy] %1 : $*MyBufferView<T>
+  %3 = mark_must_check [consumable_and_assignable] %1 : $*MyBufferView<T>
   debug_value %3 : $*MyBufferView<T>, var, name "self", argno 2, implicit, expr op_deref
   %5 = begin_access [modify] [static] %3 : $*MyBufferView<T>
   %6 = struct_element_addr %5 : $*MyBufferView<T>, #MyBufferView.ptr

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -71,7 +71,7 @@ sil @copyableClassUseMoveOnlyWithoutEscaping : $@convention(thin) (@guaranteed C
 sil hidden [ossa] @initWithSplitStores : $@convention(thin) (Int) -> @owned AggStruct {
 bb0(%0 : $Int):
   %2 = alloc_stack [lexical] $AggStruct, var, name "self", implicit
-  %3 = mark_must_check [no_implicit_copy] %2 : $*AggStruct // expected-error {{'self' consumed more than once}}
+  %3 = mark_must_check [consumable_and_assignable] %2 : $*AggStruct // expected-error {{'self' consumed more than once}}
   debug_value %0 : $Int, let, name "myInit3", argno 1
   %5 = function_ref @get_aggstruct : $@convention(thin) () -> @owned AggStruct
   %6 = apply %5() : $@convention(thin) () -> @owned AggStruct
@@ -85,7 +85,7 @@ bb0(%0 : $Int):
   %14 = load [copy] %13 : $*Klass // expected-note {{consuming use here}}
   end_access %12 : $*AggStruct
   %16 = move_value [lexical] %14 : $Klass
-  %17 = mark_must_check [no_implicit_copy] %16 : $Klass
+  %17 = mark_must_check [consumable_and_assignable] %16 : $Klass
   debug_value %17 : $Klass, let, name "x"
   %19 = copy_value %17 : $Klass
   %20 = move_value %19 : $Klass
@@ -100,7 +100,7 @@ bb0(%0 : $Int):
 sil [ossa] @aggStructConsumeGrandField : $@convention(thin) (@owned AggStruct) -> () {
 bb0(%arg : @owned $AggStruct):
   %0 = alloc_stack [lexical] $AggStruct, var, name "x2"
-  %1 = mark_must_check [no_implicit_copy] %0 : $*AggStruct
+  %1 = mark_must_check [consumable_and_assignable] %0 : $*AggStruct
   // expected-error @-1 {{'x2' consumed more than once}}
   // expected-error @-2 {{'x2' consumed by a use in a loop}}
   %9 = begin_access [modify] [static] %1 : $*AggStruct
@@ -140,7 +140,7 @@ bb3:
 sil hidden [ossa] @copyableKlassInAMoveOnlyStruct2 : $@convention(thin) (@owned NonTrivialStruct, @owned NonTrivialStruct) -> () {
 bb0(%arg : @owned $NonTrivialStruct, %arg1 : @owned $NonTrivialStruct):
   %0 = alloc_stack [lexical] $NonTrivialStruct, var, name "a"
-  %1 = mark_must_check [no_implicit_copy] %0 : $*NonTrivialStruct
+  %1 = mark_must_check [consumable_and_assignable] %0 : $*NonTrivialStruct
   store %arg to [init] %1 : $*NonTrivialStruct
   %9 = begin_access [modify] [static] %1 : $*NonTrivialStruct
   store %arg1 to [assign] %9 : $*NonTrivialStruct
@@ -173,7 +173,7 @@ bb0(%arg : @owned $NonTrivialStruct, %arg1 : @owned $NonTrivialStruct):
 sil [ossa] @moveOnlyKlassInAMoveOnlyStruct2 : $@convention(thin) (@owned NonTrivialStruct, @owned NonTrivialStruct) -> () {
 bb0(%arg : @owned $NonTrivialStruct, %arg1 : @owned $NonTrivialStruct):
   %0 = alloc_stack [lexical] $NonTrivialStruct, var, name "a"
-  %1 = mark_must_check [no_implicit_copy] %0 : $*NonTrivialStruct // expected-error {{'a' consumed more than once}}
+  %1 = mark_must_check [consumable_and_assignable] %0 : $*NonTrivialStruct // expected-error {{'a' consumed more than once}}
   store %arg to [init] %1 : $*NonTrivialStruct
   %9 = begin_access [modify] [static] %1 : $*NonTrivialStruct
   store %arg1 to [assign] %9 : $*NonTrivialStruct

--- a/test/SILOptimizer/moveonly_borrow_to_destructure_transform.sil
+++ b/test/SILOptimizer/moveonly_borrow_to_destructure_transform.sil
@@ -71,7 +71,7 @@ sil @builtin32_use : $@convention(thin) (Builtin.Int32) -> ()
 // CHECK-LABEL: sil [ossa] @test_access_single_child_field_consume : $@convention(method) (@guaranteed AggStruct) -> @owned KlassPair {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $AggStruct):
 // CHECK:   [[INIT_COPY:%.*]] = copy_value [[ARG]] : $AggStruct
-// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[INIT_COPY]] : $AggStruct
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[INIT_COPY]] : $AggStruct
 // CHECK:   [[DESTRUCTURE_COPY:%.*]] = copy_value [[MARKED_VALUE]] : $AggStruct
 // CHECK:   debug_value [[MARKED_VALUE]] : $AggStruct, let, name "self", argno 1, implicit
 // CHECK:   destroy_value [[MARKED_VALUE]] : $AggStruct
@@ -81,7 +81,7 @@ sil @builtin32_use : $@convention(thin) (Builtin.Int32) -> ()
 sil [ossa] @test_access_single_child_field_consume : $@convention(method) (@guaranteed AggStruct) -> @owned KlassPair {
 bb0(%0 : @guaranteed $AggStruct):
   %1 = copy_value %0 : $AggStruct
-  %2 = mark_must_check [no_copy] %1 : $AggStruct
+  %2 = mark_must_check [no_consume_or_assign] %1 : $AggStruct
   debug_value %2 : $AggStruct, let, name "self", argno 1, implicit
   %4 = begin_borrow %2 : $AggStruct
   %5 = struct_extract %4 : $AggStruct, #AggStruct.pair
@@ -94,7 +94,7 @@ bb0(%0 : @guaranteed $AggStruct):
 // CHECK-LABEL: sil [ossa] @test_access_grandfield_consume : $@convention(method) (@guaranteed AggStruct) -> @owned MoveOnlyKlass {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $AggStruct):
 // CHECK:   [[INIT_COPY:%.*]] = copy_value [[ARG]] : $AggStruct
-// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[INIT_COPY]] : $AggStruct
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[INIT_COPY]] : $AggStruct
 // CHECK:   [[DESTRUCTURE_COPY:%.*]] = copy_value [[MARKED_VALUE]] : $AggStruct
 // CHECK:   debug_value [[MARKED_VALUE]] : $AggStruct, let, name "self", argno 1, implicit
 // CHECK:   destroy_value [[MARKED_VALUE]] : $AggStruct
@@ -106,7 +106,7 @@ bb0(%0 : @guaranteed $AggStruct):
 sil [ossa] @test_access_grandfield_consume : $@convention(method) (@guaranteed AggStruct) -> @owned MoveOnlyKlass {
 bb0(%0 : @guaranteed $AggStruct):
   %1 = copy_value %0 : $AggStruct
-  %2 = mark_must_check [no_copy] %1 : $AggStruct
+  %2 = mark_must_check [no_consume_or_assign] %1 : $AggStruct
   debug_value %2 : $AggStruct, let, name "self", argno 1, implicit
   %4 = begin_borrow %2 : $AggStruct
   %5 = struct_extract %4 : $AggStruct, #AggStruct.pair
@@ -145,7 +145,7 @@ bb0(%0 : @owned $MoveOnlyKlass):
 // CHECK-LABEL: sil [ossa] @test_return_of_extracted_trivial_type : $@convention(thin) (@guaranteed SingleIntContainingStruct) -> Builtin.Int32 {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_consume_or_assign] [[ARG_COPY]]
 // CHECK:   [[MARKED_ARG_COPY:%.*]] = copy_value [[MARKED_ARG]]
 // CHECK:   [[MISC_USE:%.*]] = function_ref @misc_use : $@convention(thin) () -> ()
 // CHECK:   apply [[MISC_USE]]()
@@ -158,7 +158,7 @@ bb0(%0 : @owned $MoveOnlyKlass):
 sil [ossa] @test_return_of_extracted_trivial_type : $@convention(thin) (@guaranteed SingleIntContainingStruct) -> Builtin.Int32 {
 bb0(%0 : @guaranteed $SingleIntContainingStruct):
   %1 = copy_value %0 : $SingleIntContainingStruct
-  %2 = mark_must_check [no_copy] %1 : $SingleIntContainingStruct
+  %2 = mark_must_check [no_consume_or_assign] %1 : $SingleIntContainingStruct
   debug_value %2 : $SingleIntContainingStruct, let, name "x", argno 1
   %4 = begin_borrow %2 : $SingleIntContainingStruct
   %5 = struct_extract %4 : $SingleIntContainingStruct, #SingleIntContainingStruct.value
@@ -250,7 +250,7 @@ struct MultiLevelSingleFieldStructGrandParent {
 // CHECK-LABEL: sil [ossa] @grandParentToPrimitiveField : $@convention(thin) (@guaranteed MultiLevelSingleFieldStructGrandParent) -> @owned MoveOnlyKlass {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $MultiLevelSingleFieldStructGrandParent):
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[ARG_COPY]]
 // CHECK:   [[COPY_MARKED_VALUE:%.*]] = copy_value [[MARKED_VALUE]]
 // CHECK:   destroy_value [[MARKED_VALUE]]
 // CHECK:   [[DESTRUCTURE_1:%.*]] = destructure_struct [[COPY_MARKED_VALUE]]
@@ -261,7 +261,7 @@ struct MultiLevelSingleFieldStructGrandParent {
 sil [ossa] @grandParentToPrimitiveField : $@convention(thin) (@guaranteed MultiLevelSingleFieldStructGrandParent) -> @owned MoveOnlyKlass {
 bb0(%0 : @guaranteed $MultiLevelSingleFieldStructGrandParent):
   %1 = copy_value %0 : $MultiLevelSingleFieldStructGrandParent
-  %2 = mark_must_check [no_copy] %1 : $MultiLevelSingleFieldStructGrandParent
+  %2 = mark_must_check [no_consume_or_assign] %1 : $MultiLevelSingleFieldStructGrandParent
   debug_value %2 : $MultiLevelSingleFieldStructGrandParent, let, name "p", argno 1
   %4 = begin_borrow %2 : $MultiLevelSingleFieldStructGrandParent
   %5 = struct_extract %4 : $MultiLevelSingleFieldStructGrandParent, #MultiLevelSingleFieldStructGrandParent.f
@@ -284,7 +284,7 @@ bb0(%0 : @guaranteed $MultiLevelSingleFieldStructGrandParent):
 // CHECK-LABEL: sil hidden [ossa] @grandParentToChildField : $@convention(thin) (@guaranteed MultiLevelSingleFieldStructGrandParent) -> @owned MultiLevelSingleFieldStructChild {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $MultiLevelSingleFieldStructGrandParent):
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[ARG_COPY]]
 // CHECK:   [[COPY_MARKED_VALUE:%.*]] = copy_value [[MARKED_VALUE]]
 // CHECK:   destroy_value [[MARKED_VALUE]]
 // CHECK:   [[DESTRUCTURE_1:%.*]] = destructure_struct [[COPY_MARKED_VALUE]]
@@ -294,7 +294,7 @@ bb0(%0 : @guaranteed $MultiLevelSingleFieldStructGrandParent):
 sil hidden [ossa] @grandParentToChildField : $@convention(thin) (@guaranteed MultiLevelSingleFieldStructGrandParent) -> @owned MultiLevelSingleFieldStructChild {
 bb0(%0 : @guaranteed $MultiLevelSingleFieldStructGrandParent):
   %1 = copy_value %0 : $MultiLevelSingleFieldStructGrandParent
-  %2 = mark_must_check [no_copy] %1 : $MultiLevelSingleFieldStructGrandParent
+  %2 = mark_must_check [no_consume_or_assign] %1 : $MultiLevelSingleFieldStructGrandParent
   debug_value %2 : $MultiLevelSingleFieldStructGrandParent, let, name "p", argno 1
   %4 = begin_borrow %2 : $MultiLevelSingleFieldStructGrandParent
   %5 = struct_extract %4 : $MultiLevelSingleFieldStructGrandParent, #MultiLevelSingleFieldStructGrandParent.f
@@ -312,7 +312,7 @@ bb0(%0 : @guaranteed $MultiLevelSingleFieldStructGrandParent):
 // CHECK-LABEL: sil [ossa] @singlefield_grandparent_to_singlefield_parent : $@convention(thin) (@guaranteed MultiLevelSingleFieldStructGrandParent) -> @owned MultiLevelSingleFieldStructParent {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $MultiLevelSingleFieldStructGrandParent):
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[ARG_COPY]]
 // CHECK:   [[COPY_MARKED_VALUE:%.*]] = copy_value [[MARKED_VALUE]]
 // CHECK:   destroy_value [[MARKED_VALUE]]
 // CHECK:   [[DESTRUCTURE_1:%.*]] = destructure_struct [[COPY_MARKED_VALUE]]
@@ -321,7 +321,7 @@ bb0(%0 : @guaranteed $MultiLevelSingleFieldStructGrandParent):
 sil [ossa] @singlefield_grandparent_to_singlefield_parent : $@convention(thin) (@guaranteed MultiLevelSingleFieldStructGrandParent) -> @owned MultiLevelSingleFieldStructParent {
 bb0(%0 : @guaranteed $MultiLevelSingleFieldStructGrandParent):
   %1 = copy_value %0 : $MultiLevelSingleFieldStructGrandParent
-  %2 = mark_must_check [no_copy] %1 : $MultiLevelSingleFieldStructGrandParent
+  %2 = mark_must_check [no_consume_or_assign] %1 : $MultiLevelSingleFieldStructGrandParent
   debug_value %2 : $MultiLevelSingleFieldStructGrandParent, let, name "p", argno 1
   %4 = begin_borrow %2 : $MultiLevelSingleFieldStructGrandParent
   %5 = struct_extract %4 : $MultiLevelSingleFieldStructGrandParent, #MultiLevelSingleFieldStructGrandParent.f
@@ -333,7 +333,7 @@ bb0(%0 : @guaranteed $MultiLevelSingleFieldStructGrandParent):
 
 // CHECK-LABEL: sil [ossa] @singlefield_grandparent_to_singlefield_grandparent : $@convention(thin) (@guaranteed MultiLevelSingleFieldStructGrandParent) -> @owned MultiLevelSingleFieldStructGrandParent {
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[ARG_COPY]]
 // CHECK:   [[COPY_MARKED_VALUE:%.*]] = copy_value [[MARKED_VALUE]]
 // CHECK:   destroy_value [[MARKED_VALUE]]
 // CHECK:   return [[COPY_MARKED_VALUE]]
@@ -341,7 +341,7 @@ bb0(%0 : @guaranteed $MultiLevelSingleFieldStructGrandParent):
 sil [ossa] @singlefield_grandparent_to_singlefield_grandparent : $@convention(thin) (@guaranteed MultiLevelSingleFieldStructGrandParent) -> @owned MultiLevelSingleFieldStructGrandParent {
 bb0(%0 : @guaranteed $MultiLevelSingleFieldStructGrandParent):
   %1 = copy_value %0 : $MultiLevelSingleFieldStructGrandParent
-  %2 = mark_must_check [no_copy] %1 : $MultiLevelSingleFieldStructGrandParent
+  %2 = mark_must_check [no_consume_or_assign] %1 : $MultiLevelSingleFieldStructGrandParent
   debug_value %2 : $MultiLevelSingleFieldStructGrandParent, let, name "p", argno 1
   %4 = copy_value %2 : $MultiLevelSingleFieldStructGrandParent
   destroy_value %2 : $MultiLevelSingleFieldStructGrandParent
@@ -378,7 +378,7 @@ struct ChildMultiFieldStruct {
 // CHECK-LABEL: sil [ossa] @access_primitive_field_trampolining_from_multifield_through_singlefield : $@convention(thin) (@guaranteed GrandParentMultiFieldStruct) -> @owned MoveOnlyKlass {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[ARG_COPY]]
 // CHECK:   [[COPY_MARKED_VALUE:%.*]] = copy_value [[MARKED_VALUE]]
 // CHECK:   destroy_value [[MARKED_VALUE]]
 // CHECK:   ([[GP_LHS:%.*]], [[GP_TARGET:%.*]], [[GP_RHS:%.*]]) = destructure_struct [[COPY_MARKED_VALUE]]
@@ -392,7 +392,7 @@ struct ChildMultiFieldStruct {
 sil [ossa] @access_primitive_field_trampolining_from_multifield_through_singlefield : $@convention(thin) (@guaranteed GrandParentMultiFieldStruct) -> @owned MoveOnlyKlass {
 bb0(%0 : @guaranteed $GrandParentMultiFieldStruct):
   %1 = copy_value %0 : $GrandParentMultiFieldStruct
-  %2 = mark_must_check [no_copy] %1 : $GrandParentMultiFieldStruct
+  %2 = mark_must_check [no_consume_or_assign] %1 : $GrandParentMultiFieldStruct
   debug_value %2 : $GrandParentMultiFieldStruct, let, name "p", argno 1
   %4 = begin_borrow %2 : $GrandParentMultiFieldStruct
   %5 = struct_extract %4 : $GrandParentMultiFieldStruct, #GrandParentMultiFieldStruct.second
@@ -415,7 +415,7 @@ bb0(%0 : @guaranteed $GrandParentMultiFieldStruct):
 // CHECK-LABEL: sil [ossa] @access_primitive_field_trampolining_from_multifield_through_singlefield_2 : $@convention(thin) (@guaranteed GrandParentMultiFieldStruct) -> @owned MoveOnlyKlass {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[ARG_COPY]]
 // CHECK:   [[COPY_MARKED_VALUE:%.*]] = copy_value [[MARKED_VALUE]]
 // CHECK:   destroy_value [[MARKED_VALUE]]
 // CHECK:   ([[GP_LHS:%.*]], [[GP_TARGET:%.*]], [[GP_RHS:%.*]]) = destructure_struct [[COPY_MARKED_VALUE]]
@@ -429,7 +429,7 @@ bb0(%0 : @guaranteed $GrandParentMultiFieldStruct):
 sil [ossa] @access_primitive_field_trampolining_from_multifield_through_singlefield_2 : $@convention(thin) (@guaranteed GrandParentMultiFieldStruct) -> @owned MoveOnlyKlass {
 bb0(%0 : @guaranteed $GrandParentMultiFieldStruct):
   %1 = copy_value %0 : $GrandParentMultiFieldStruct
-  %2 = mark_must_check [no_copy] %1 : $GrandParentMultiFieldStruct
+  %2 = mark_must_check [no_consume_or_assign] %1 : $GrandParentMultiFieldStruct
   debug_value %2 : $GrandParentMultiFieldStruct, let, name "p", argno 1
   %4 = begin_borrow %2 : $GrandParentMultiFieldStruct
   %5 = struct_extract %4 : $GrandParentMultiFieldStruct, #GrandParentMultiFieldStruct.second
@@ -452,7 +452,7 @@ bb0(%0 : @guaranteed $GrandParentMultiFieldStruct):
 // CHECK-LABEL: sil [ossa] @access_primitive_field_trampolining_from_multifield_through_singlefield_with_tuple : $@convention(thin) (@guaranteed GrandParentMultiFieldStruct) -> (@owned MoveOnlyKlass, @owned MoveOnlyKlass) {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[ARG_COPY]]
 // CHECK:   [[COPY_MARKED_VALUE:%.*]] = copy_value [[MARKED_VALUE]]
 // CHECK:   destroy_value [[MARKED_VALUE]]
 // CHECK:   ([[GP_LHS:%.*]], [[GP_TARGET:%.*]], [[GP_RHS:%.*]]) = destructure_struct [[COPY_MARKED_VALUE]]
@@ -466,7 +466,7 @@ bb0(%0 : @guaranteed $GrandParentMultiFieldStruct):
 sil [ossa] @access_primitive_field_trampolining_from_multifield_through_singlefield_with_tuple : $@convention(thin) (@guaranteed GrandParentMultiFieldStruct) -> (@owned MoveOnlyKlass, @owned MoveOnlyKlass) {
 bb0(%0 : @guaranteed $GrandParentMultiFieldStruct):
   %1 = copy_value %0 : $GrandParentMultiFieldStruct
-  %2 = mark_must_check [no_copy] %1 : $GrandParentMultiFieldStruct
+  %2 = mark_must_check [no_consume_or_assign] %1 : $GrandParentMultiFieldStruct
   debug_value %2 : $GrandParentMultiFieldStruct, let, name "p", argno 1
   %4 = begin_borrow %2 : $GrandParentMultiFieldStruct
   %5 = struct_extract %4 : $GrandParentMultiFieldStruct, #GrandParentMultiFieldStruct.first
@@ -507,7 +507,7 @@ bb0(%0 : @guaranteed $GrandParentMultiFieldStruct):
 // CHECK-lABEL: sil [ossa] @consume_field_in_one_side_of_diamond : $@convention(thin) (@guaranteed GrandParentMultiFieldStruct) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_consume_or_assign] [[ARG_COPY]]
 // CHECK:   [[DESTRUCTURE_COPY:%.*]] = copy_value [[MARKED_ARG]]
 // CHECK:   cond_br undef, bb1, bb2
 //
@@ -530,7 +530,7 @@ bb0(%0 : @guaranteed $GrandParentMultiFieldStruct):
 sil [ossa] @consume_field_in_one_side_of_diamond : $@convention(thin) (@guaranteed GrandParentMultiFieldStruct) -> () {
 bb0(%0 : @guaranteed $GrandParentMultiFieldStruct):
   %1 = copy_value %0 : $GrandParentMultiFieldStruct
-  %2 = mark_must_check [no_copy] %1 : $GrandParentMultiFieldStruct
+  %2 = mark_must_check [no_consume_or_assign] %1 : $GrandParentMultiFieldStruct
   debug_value %2 : $GrandParentMultiFieldStruct, let, name "p", argno 1
   cond_br undef, bb1, bb2
 
@@ -574,7 +574,7 @@ bb3:
 // CHECK-LABEL: sil [ossa] @test_consumes_in_both_sides_of_diamond_with_cont_consume : $@convention(thin) (@guaranteed GrandParentMultiFieldStruct) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_consume_or_assign] [[ARG_COPY]]
 // CHECK:   [[DESTRUCTURE_COPY:%.*]] = copy_value [[MARKED_ARG]]
 // CHECK:   cond_br undef, bb1, bb2
 //
@@ -602,7 +602,7 @@ bb3:
 sil [ossa] @test_consumes_in_both_sides_of_diamond_with_cont_consume : $@convention(thin) (@guaranteed GrandParentMultiFieldStruct) -> () {
 bb0(%0 : @guaranteed $GrandParentMultiFieldStruct):
   %1 = copy_value %0 : $GrandParentMultiFieldStruct
-  %2 = mark_must_check [no_copy] %1 : $GrandParentMultiFieldStruct
+  %2 = mark_must_check [no_consume_or_assign] %1 : $GrandParentMultiFieldStruct
   debug_value %2 : $GrandParentMultiFieldStruct, let, name "p", argno 1
   cond_br undef, bb1, bb2
 
@@ -649,7 +649,7 @@ bb3:
 // CHECK-LABEL: sil [ossa] @switch_enum_without_destructure : $@convention(thin) (@guaranteed E) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[ARG_COPY]]
 // CHECK:   [[MARKED_COPY:%.*]] = copy_value [[MARKED_VALUE]]
 // CHECK:   switch_enum [[MARKED_COPY:%.*]] : $E, case #E.first!enumelt: [[BB_E_FIRST:bb[0-9]+]], case #E.second!enumelt: [[BB_E_SECOND:bb[0-9]+]], case #E.third!enumelt: [[BB_E_THIRD:bb[0-9]+]], case #E.fourth!enumelt: [[BB_E_FOURTH:bb[0-9]+]]
 //
@@ -675,7 +675,7 @@ bb3:
 sil [ossa] @switch_enum_without_destructure : $@convention(thin) (@guaranteed E) -> () {
 bb0(%0 : @guaranteed $E):
   %1 = copy_value %0 : $E
-  %2 = mark_must_check [no_copy] %1 : $E
+  %2 = mark_must_check [no_consume_or_assign] %1 : $E
   %3 = begin_borrow %2 : $E
   switch_enum %3 : $E, case #E.first!enumelt: bb1, case #E.second!enumelt: bb2, case #E.third!enumelt: bb3, case #E.fourth!enumelt: bb4
 
@@ -701,7 +701,7 @@ bbCont:
 // CHECK-LABEL: sil [ossa] @switch_enum_with_destructure : $@convention(thin) (@guaranteed E) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[ARG_COPY]]
 // CHECK:   [[MARKED_COPY:%.*]] = copy_value [[MARKED_VALUE]]
 // CHECK:   switch_enum [[MARKED_COPY:%.*]] : $E, case #E.first!enumelt: [[BB_E_FIRST:bb[0-9]+]], case #E.second!enumelt: [[BB_E_SECOND:bb[0-9]+]], case #E.third!enumelt: [[BB_E_THIRD:bb[0-9]+]], case #E.fourth!enumelt: [[BB_E_FOURTH:bb[0-9]+]]
 //
@@ -733,7 +733,7 @@ bbCont:
 sil [ossa] @switch_enum_with_destructure : $@convention(thin) (@guaranteed E) -> () {
 bb0(%0 : @guaranteed $E):
   %1 = copy_value %0 : $E
-  %2 = mark_must_check [no_copy] %1 : $E
+  %2 = mark_must_check [no_consume_or_assign] %1 : $E
   %3 = begin_borrow %2 : $E
   switch_enum %3 : $E, case #E.first!enumelt: bb1, case #E.second!enumelt: bb2, case #E.third!enumelt: bb3, case #E.fourth!enumelt: bb4
 
@@ -766,7 +766,7 @@ bbCont:
 // CHECK-LABEL: sil [ossa] @switch_enum_with_destructure_recursive : $@convention(thin) (@guaranteed E2) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[ARG_COPY]]
 // CHECK:   [[MARKED_COPY:%.*]] = copy_value [[MARKED_VALUE]]
 // CHECK:   switch_enum [[MARKED_COPY:%.*]] : $E2, case #E2.lhs!enumelt: [[BB_E2_LHS:bb[0-9]+]], case #E2.rhs!enumelt: [[BB_E2_RHS:bb[0-9]+]]
 //
@@ -805,7 +805,7 @@ bbCont:
 sil [ossa] @switch_enum_with_destructure_recursive : $@convention(thin) (@guaranteed E2) -> () {
 bb0(%0 : @guaranteed $E2):
   %1 = copy_value %0 : $E2
-  %2 = mark_must_check [no_copy] %1 : $E2
+  %2 = mark_must_check [no_consume_or_assign] %1 : $E2
   %3 = begin_borrow %2 : $E2
   switch_enum %3 : $E2, case #E2.lhs!enumelt: bbN1, case #E2.rhs!enumelt: bbN2
 
@@ -844,7 +844,7 @@ bbCont:
 // CHECK-LABEL: sil [ossa] @switch_enum_with_destructure_recursive_2 : $@convention(thin) (@guaranteed E2) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[ARG_COPY]]
 // CHECK:   [[MARKED_COPY:%.*]] = copy_value [[MARKED_VALUE]]
 // CHECK:   switch_enum [[MARKED_COPY:%.*]] : $E2, case #E2.lhs!enumelt: [[BB_E2_LHS:bb[0-9]+]], case #E2.rhs!enumelt: [[BB_E2_RHS:bb[0-9]+]]
 //
@@ -887,7 +887,7 @@ bbCont:
 sil [ossa] @switch_enum_with_destructure_recursive_2 : $@convention(thin) (@guaranteed E2) -> () {
 bb0(%0 : @guaranteed $E2):
   %1 = copy_value %0 : $E2
-  %2 = mark_must_check [no_copy] %1 : $E2
+  %2 = mark_must_check [no_consume_or_assign] %1 : $E2
   %3 = begin_borrow %2 : $E2
   switch_enum %3 : $E2, case #E2.lhs!enumelt: bbN1, case #E2.rhs!enumelt: bbN2
 
@@ -931,7 +931,7 @@ bbCont:
 // CHECK-LABEL: sil [ossa] @switch_enum_with_destructure_recursive_3 : $@convention(thin) (@guaranteed E2) -> () {
 // CHECK: bb0([[ARG:%.*]] :
 // CHECK:   [[ARG_COPY:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_copy] [[ARG_COPY]]
+// CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[ARG_COPY]]
 // CHECK:   [[MARKED_COPY:%.*]] = copy_value [[MARKED_VALUE]]
 // CHECK:   switch_enum [[MARKED_COPY:%.*]] : $E2, case #E2.lhs!enumelt: [[BB_E2_LHS:bb[0-9]+]], case #E2.rhs!enumelt: [[BB_E2_RHS:bb[0-9]+]]
 //
@@ -980,7 +980,7 @@ bbCont:
 sil [ossa] @switch_enum_with_destructure_recursive_3 : $@convention(thin) (@guaranteed E2) -> () {
 bb0(%0 : @guaranteed $E2):
   %1 = copy_value %0 : $E2
-  %2 = mark_must_check [no_copy] %1 : $E2
+  %2 = mark_must_check [no_consume_or_assign] %1 : $E2
   %3 = begin_borrow %2 : $E2
   switch_enum %3 : $E2, case #E2.lhs!enumelt: bbN1, case #E2.rhs!enumelt: bbN2
 

--- a/test/SILOptimizer/moveonly_borrow_to_destructure_transform.sil
+++ b/test/SILOptimizer/moveonly_borrow_to_destructure_transform.sil
@@ -123,7 +123,7 @@ bb0(%0 : @guaranteed $AggStruct):
 
 // CHECK-LABEL: sil [ossa] @test_ref_element_addr : $@convention(thin) (@owned MoveOnlyKlass) -> @owned MoveOnlyKlass {
 // CHECK: bb0([[ARG:%.*]] :
-// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [no_implicit_copy] [[ARG]]
+// CHECK:   [[MARKED_ARG:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
 // CHECK:   [[COPY_MARKED_ARG:%.*]] = copy_value [[MARKED_ARG]]
 // CHECK:   [[BORROW_MARKED_ARG:%.*]] = begin_borrow [[COPY_MARKED_ARG]]
 // CHECK:   ref_element_addr [[BORROW_MARKED_ARG]]
@@ -133,7 +133,7 @@ bb0(%0 : @guaranteed $AggStruct):
 // CHECK: } // end sil function 'test_ref_element_addr'
 sil [ossa] @test_ref_element_addr : $@convention(thin) (@owned MoveOnlyKlass) -> @owned MoveOnlyKlass {
 bb0(%0 : @owned $MoveOnlyKlass):
-  %1 = mark_must_check [no_implicit_copy] %0 : $MoveOnlyKlass
+  %1 = mark_must_check [consumable_and_assignable] %0 : $MoveOnlyKlass
   %2 = begin_borrow %1 : $MoveOnlyKlass
   %3 = ref_element_addr %2 : $MoveOnlyKlass, #MoveOnlyKlass.value
   %4 = integer_literal $Builtin.Int32, 1
@@ -179,7 +179,7 @@ bb0(%0 : @guaranteed $SingleIntContainingStruct):
 sil [ossa] @phis_are_cleaned_up : $@convention(thin) (@owned AggStruct2) -> () {
 bb0(%0 : @owned $AggStruct2):
   %1 = move_value [lexical] %0 : $AggStruct2
-  %2 = mark_must_check [no_implicit_copy] %1 : $AggStruct2
+  %2 = mark_must_check [consumable_and_assignable] %1 : $AggStruct2
   debug_value %2 : $AggStruct2, let, name "x2", argno 1
   cond_br undef, bb1, bb2
 
@@ -539,7 +539,7 @@ bb1:
   %9 = struct_extract %8 : $GrandParentMultiFieldStruct, #GrandParentMultiFieldStruct.first
   %10 = copy_value %9 : $MoveOnlyKlass
   %11 = move_value [lexical] %10 : $MoveOnlyKlass
-  %12 = mark_must_check [no_implicit_copy] %11 : $MoveOnlyKlass
+  %12 = mark_must_check [consumable_and_assignable] %11 : $MoveOnlyKlass
   debug_value %12 : $MoveOnlyKlass, let, name "x"
   end_borrow %8 : $GrandParentMultiFieldStruct
   %15 = copy_value %12 : $MoveOnlyKlass
@@ -592,7 +592,7 @@ bb3:
 //
 // CHECK: bb3([[CONT_ARG:%.*]] : @owned
 // CHECK:   [[MOVED_CONT_ARG:%.*]] = move_value [lexical] [[CONT_ARG]]
-// CHECK-NEXT:   mark_must_check [no_implicit_copy] [[MOVED_CONT_ARG]]
+// CHECK-NEXT:   mark_must_check [consumable_and_assignable] [[MOVED_CONT_ARG]]
 // CHECK-NEXT:   debug_value
 // CHECK-NEXT:   destroy_value
 // CHECK-NEXT:   destroy_value [[MARKED_ARG]]
@@ -611,7 +611,7 @@ bb1:
   %9 = struct_extract %8 : $GrandParentMultiFieldStruct, #GrandParentMultiFieldStruct.first
   %10 = copy_value %9 : $MoveOnlyKlass
   %11 = move_value [lexical] %10 : $MoveOnlyKlass
-  %12 = mark_must_check [no_implicit_copy] %11 : $MoveOnlyKlass
+  %12 = mark_must_check [consumable_and_assignable] %11 : $MoveOnlyKlass
   debug_value %12 : $MoveOnlyKlass, let, name "x"
   end_borrow %8 : $GrandParentMultiFieldStruct
   destroy_value %12 : $MoveOnlyKlass
@@ -622,7 +622,7 @@ bb2:
   %18 = struct_extract %17 : $GrandParentMultiFieldStruct, #GrandParentMultiFieldStruct.second
   %19 = copy_value %18 : $SingleFieldParentOfMultiFieldChild
   %20 = move_value [lexical] %19 : $SingleFieldParentOfMultiFieldChild
-  %21 = mark_must_check [no_implicit_copy] %20 : $SingleFieldParentOfMultiFieldChild
+  %21 = mark_must_check [consumable_and_assignable] %20 : $SingleFieldParentOfMultiFieldChild
   debug_value %21 : $SingleFieldParentOfMultiFieldChild, let, name "x"
   end_borrow %17 : $GrandParentMultiFieldStruct
   destroy_value %21 : $SingleFieldParentOfMultiFieldChild
@@ -633,7 +633,7 @@ bb3:
   %27 = struct_extract %26 : $GrandParentMultiFieldStruct, #GrandParentMultiFieldStruct.third
   %28 = copy_value %27 : $MoveOnlyKlass
   %29 = move_value [lexical] %28 : $MoveOnlyKlass
-  %30 = mark_must_check [no_implicit_copy] %29 : $MoveOnlyKlass
+  %30 = mark_must_check [consumable_and_assignable] %29 : $MoveOnlyKlass
   debug_value %30 : $MoveOnlyKlass, let, name "x"
   end_borrow %26 : $GrandParentMultiFieldStruct
   destroy_value %30 : $MoveOnlyKlass

--- a/test/SILOptimizer/moveonly_borrow_to_destructure_transform_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_borrow_to_destructure_transform_diagnostics.sil
@@ -129,11 +129,11 @@ bb0(%0 : @guaranteed $AggStruct2):
 sil [ossa] @test_loop_error : $@convention(thin) (@owned AggStruct2) -> () {
 bb0(%0 : @owned $AggStruct2):
   %1 = move_value [lexical] %0 : $AggStruct2
-  %2 = mark_must_check [no_implicit_copy] %1 : $AggStruct2
+  %2 = mark_must_check [consumable_and_assignable] %1 : $AggStruct2
   debug_value %2 : $AggStruct2, let, name "x", argno 1
   %4 = copy_value %2 : $AggStruct2
   %5 = move_value [lexical] %4 : $AggStruct2
-  %6 = mark_must_check [no_implicit_copy] %5 : $AggStruct2
+  %6 = mark_must_check [consumable_and_assignable] %5 : $AggStruct2
   // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
   // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
   debug_value %6 : $AggStruct2, let, name "x2"

--- a/test/SILOptimizer/moveonly_borrow_to_destructure_transform_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_borrow_to_destructure_transform_diagnostics.sil
@@ -63,7 +63,7 @@ sil @klass_use : $@convention(thin) (@guaranteed Klass) -> ()
 sil [ossa] @test_access_single_child_field_consume : $@convention(method) (@guaranteed AggStruct2) -> () {
 bb0(%0 : @guaranteed $AggStruct2):
   %1 = copy_value %0 : $AggStruct2
-  %2 = mark_must_check [no_copy] %1 : $AggStruct2 // expected-error {{'self' has a move only field that was consumed before later uses}}
+  %2 = mark_must_check [no_consume_or_assign] %1 : $AggStruct2 // expected-error {{'self' has a move only field that was consumed before later uses}}
   debug_value %2 : $AggStruct2, let, name "self", argno 1, implicit
   %4 = begin_borrow %2 : $AggStruct2
   %5 = struct_extract %4 : $AggStruct2, #AggStruct2.pair
@@ -86,7 +86,7 @@ bb0(%0 : @guaranteed $AggStruct2):
 sil [ossa] @test_access_single_child_field_consume2 : $@convention(method) (@guaranteed AggStruct2) -> @owned KlassPair2 {
 bb0(%0 : @guaranteed $AggStruct2):
   %1 = copy_value %0 : $AggStruct2
-  %2 = mark_must_check [no_copy] %1 : $AggStruct2 // expected-error {{'self' consumed more than once}}
+  %2 = mark_must_check [no_consume_or_assign] %1 : $AggStruct2 // expected-error {{'self' consumed more than once}}
   debug_value %2 : $AggStruct2, let, name "self", argno 1, implicit
   %4 = begin_borrow %2 : $AggStruct2
   %5 = struct_extract %4 : $AggStruct2, #AggStruct2.pair
@@ -106,7 +106,7 @@ bb0(%0 : @guaranteed $AggStruct2):
 sil [ossa] @test_access_single_child_field_consume3 : $@convention(method) (@guaranteed AggStruct2) -> () {
 bb0(%0 : @guaranteed $AggStruct2):
   %1 = copy_value %0 : $AggStruct2
-  %2 = mark_must_check [no_copy] %1 : $AggStruct2 // expected-error {{'self' consumed and used at the same time}}
+  %2 = mark_must_check [no_consume_or_assign] %1 : $AggStruct2 // expected-error {{'self' consumed and used at the same time}}
   debug_value %2 : $AggStruct2, let, name "self", argno 1, implicit
   %4 = begin_borrow %2 : $AggStruct2
   %5 = struct_extract %4 : $AggStruct2, #AggStruct2.pair

--- a/test/SILOptimizer/moveonly_objectchecker.sil
+++ b/test/SILOptimizer/moveonly_objectchecker.sil
@@ -17,7 +17,7 @@ sil @classUseMoveOnlyWithoutEscaping : $@convention(thin) (@guaranteed Klass) ->
 sil [ossa] @chainErrorTest : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
   %1 = copy_value %0 : $Klass
-  %2 = mark_must_check [no_copy] %1 : $Klass
+  %2 = mark_must_check [no_consume_or_assign] %1 : $Klass
   debug_value %2 : $Klass, let, name "x", argno 1
   %4 = copy_value %2 : $Klass
   %5 = move_value [lexical] %4 : $Klass

--- a/test/SILOptimizer/moveonly_objectchecker.sil
+++ b/test/SILOptimizer/moveonly_objectchecker.sil
@@ -21,19 +21,19 @@ bb0(%0 : @guaranteed $Klass):
   debug_value %2 : $Klass, let, name "x", argno 1
   %4 = copy_value %2 : $Klass
   %5 = move_value [lexical] %4 : $Klass
-  %6 = mark_must_check [no_implicit_copy] %5 : $Klass
+  %6 = mark_must_check [consumable_and_assignable] %5 : $Klass
   debug_value %6 : $Klass, let, name "x2"
   %8 = copy_value %6 : $Klass
   %9 = move_value [lexical] %8 : $Klass
-  %10 = mark_must_check [no_implicit_copy] %9 : $Klass
+  %10 = mark_must_check [consumable_and_assignable] %9 : $Klass
   debug_value %10 : $Klass, let, name "y2"
   %12 = copy_value %10 : $Klass
   %13 = move_value [lexical] %12 : $Klass
-  %14 = mark_must_check [no_implicit_copy] %13 : $Klass
+  %14 = mark_must_check [consumable_and_assignable] %13 : $Klass
   debug_value %14 : $Klass, let, name "k2"
   %16 = copy_value %6 : $Klass
   %17 = move_value [lexical] %16 : $Klass
-  %18 = mark_must_check [no_implicit_copy] %17 : $Klass
+  %18 = mark_must_check [consumable_and_assignable] %17 : $Klass
   debug_value %18 : $Klass, let, name "k3"
   %20 = copy_value %18 : $Klass
   %21 = move_value %20 : $Klass

--- a/test/SILOptimizer/noimplicitcopy.sil
+++ b/test/SILOptimizer/noimplicitcopy.sil
@@ -18,7 +18,7 @@ sil [ossa] @test_remove_early_copyvalue : $@convention(thin) (@guaranteed Klass)
 bb0(%0 : @noImplicitCopy @guaranteed $Klass):
   %1 = copyable_to_moveonlywrapper [guaranteed] %0 : $Klass
   %2 = copy_value %1 : $@moveOnly Klass
-  %3 = mark_must_check [no_copy] %2 : $@moveOnly Klass
+  %3 = mark_must_check [no_consume_or_assign] %2 : $@moveOnly Klass
   debug_value %3 : $@moveOnly Klass, let, name "x2", argno 1
   %5 = begin_borrow %3 : $@moveOnly Klass
   %6 = function_ref @classUseMoveOnlyWithoutEscaping : $@convention(thin) (@guaranteed Klass) -> ()

--- a/test/SILOptimizer/noimplicitcopy_borrow_to_destructure_transform_diagnostics.sil
+++ b/test/SILOptimizer/noimplicitcopy_borrow_to_destructure_transform_diagnostics.sil
@@ -26,7 +26,7 @@ bb0(%0 : @guaranteed $AggStruct):
   %3 = begin_borrow [lexical] %2 : $AggStruct
   %4 = copy_value %3 : $AggStruct
   %5 = copyable_to_moveonlywrapper [owned] %4 : $AggStruct
-  %6 = mark_must_check [no_implicit_copy] %5 : $@moveOnly AggStruct
+  %6 = mark_must_check [consumable_and_assignable] %5 : $@moveOnly AggStruct
   debug_value %6 : $@moveOnly AggStruct, let, name "x2"
   %8 = begin_borrow %6 : $@moveOnly AggStruct
   %9 = struct_extract %8 : $@moveOnly AggStruct, #AggStruct.lhs


### PR DESCRIPTION
Specifically, I am going to be adding a new form of semantics where one is allowed to read from an address, assign into an address, but not consume an address. This works for ref_element_addr, global_addr, and no_escaping_closure.

Just slicing off parts of a larger patch.

This is part of rdar://102794400, rdar://104874497, and rdar://105294941