### PR TITLE
Update PartialType.swift

### DIFF
--- a/test/stdlib/Reflection/PartialType.swift
+++ b/test/stdlib/Reflection/PartialType.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// REQUIRES: reflection
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest


### PR DESCRIPTION
Mark the test as requiring reflection as it uses the new `_Runtime` module.