### PR TITLE
[test] Update new reflection tests with REQUIRES

### DIFF
--- a/test/stdlib/_Runtime/ContextDescriptor/StructDescriptor.swift
+++ b/test/stdlib/_Runtime/ContextDescriptor/StructDescriptor.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-
+// REQUIRES: reflection
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/test/stdlib/_Runtime/Metadata/FunctionMetadata.swift
+++ b/test/stdlib/_Runtime/Metadata/FunctionMetadata.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-
+// REQUIRES: reflection
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/test/stdlib/_Runtime/Metadata/Metadata.swift
+++ b/test/stdlib/_Runtime/Metadata/Metadata.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-
+// REQUIRES: reflection
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/test/stdlib/_Runtime/Metadata/MetatypeMetadata.swift
+++ b/test/stdlib/_Runtime/Metadata/MetatypeMetadata.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-
+// REQUIRES: reflection
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/test/stdlib/_Runtime/Metadata/StructMetadata.swift
+++ b/test/stdlib/_Runtime/Metadata/StructMetadata.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-
+// REQUIRES: reflection
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/test/stdlib/_Runtime/Metadata/TupleMetadata.swift
+++ b/test/stdlib/_Runtime/Metadata/TupleMetadata.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-
+// REQUIRES: reflection
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/test/stdlib/_Runtime/Metadata/TypeMetadata.swift
+++ b/test/stdlib/_Runtime/Metadata/TypeMetadata.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-
+// REQUIRES: reflection
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/test/stdlib/_Runtime/Metadata/ValueWitnessTable.swift
+++ b/test/stdlib/_Runtime/Metadata/ValueWitnessTable.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-
+// REQUIRES: reflection
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest


### PR DESCRIPTION
These tests need to be marked `REQUIRES: reflection` because, well, they require reflection 😜 