### PR TITLE
[Test] Re-enable and cleanup some cursor info tests

### DIFF
--- a/test/SourceKit/CursorInfo/cursor_in_top_level_closure.swift
+++ b/test/SourceKit/CursorInfo/cursor_in_top_level_closure.swift
@@ -1,24 +1,19 @@
-// RUN: %empty-directory(%t/split)
-// RUN: %{python} %utils/split_file.py -o %t/split %s
-// RUN: %empty-directory(%t/build)
-// RUN: %sourcekitd-test -req=cursor -pos=5:9 %t/split/MovieRow.swift -- %t/split/MovieRow.swift %t/split/Color.swift | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: split-file --leading-lines %s %t
 
-// BEGIN Color.swift
-
+//--- Color.swift
 extension Invalid {}
 
-// BEGIN MovieRow.swift
-
+//--- MovieRow.swift
 struct Bar {}
 
 fileprivate let bar: Bar = {
-    let bar = Bar()
-    return bar
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):7 %t/MovieRow.swift -- %t/MovieRow.swift %t/Color.swift | %FileCheck %s
+  let bar = Bar()
+  // CHECK: source.lang.swift.decl.var.local ([[@LINE-1]]:7-[[@LINE-1]]:10)
+  // CHECK-NEXT: bar
+  // CHECK: RELATED BEGIN
+  // CHECK-NEXT: <RelatedName usr="s:4main3bar33_F48676AE0C86F007C79C860E40EDA2D3LLAA3BarVvp">bar</RelatedName>
+  // CHECK-NEXT: RELATED END
+  return bar
 }()
-
-
-// CHECK: source.lang.swift.decl.var.local (5:9-5:12)
-// CHECK-NEXT: bar
-// CHECK: RELATED BEGIN
-// CHECK-NEXT: <RelatedName usr="s:4main3bar33_F48676AE0C86F007C79C860E40EDA2D3LLAA3BarVvp">bar</RelatedName>
-// CHECK-NEXT: RELATED END

--- a/test/SourceKit/CursorInfo/cursor_info_concurrency.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_concurrency.swift
@@ -1,25 +1,9 @@
-// BEGIN MyModule.swift
-public actor MyActor {
-  public func asyncFunc(fn: () async -> Void) async throws {}
-}
-
-func test(act: MyActor) async throws {
-    try await act.asyncFunc {}
-}
-
-// BEGIN App.swift
-import MyModule
-
-func test(act: MyActor) async throws {
-    try await act.asyncFunc {}
-}
-
 // REQUIRES: concurrency
 
 // RUN: %empty-directory(%t)
-// RUN: %{python} %utils/split_file.py -o %t %s
-
 // RUN: %empty-directory(%t/Modules)
+// RUN: split-file %s %t
+
 // RUN: %target-swift-frontend -emit-module -o %t/Modules/MyModule.swiftmodule -module-name MyModule %t/MyModule.swift  -disable-availability-checking
 
 // RUN: %sourcekitd-test -req=cursor -pos=1:15 %t/MyModule.swift -- %t/MyModule.swift -target %target-triple  | %FileCheck -check-prefix=ACTOR %s
@@ -41,3 +25,19 @@ func test(act: MyActor) async throws {
 
 // FUNC_XMOD: <Declaration>func asyncFunc(fn: () async -&gt; <Type usr="s:s4Voida">Void</Type>) async throws</Declaration>
 // FUNC_XMOD: <decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>asyncFunc</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>fn</decl.var.parameter.argument_label>: <decl.var.parameter.type>() <syntaxtype.keyword>async</syntaxtype.keyword> -&gt; <decl.function.returntype><ref.typealias usr="s:s4Voida">Void</ref.typealias></decl.function.returntype></decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>async</syntaxtype.keyword> <syntaxtype.keyword>throws</syntaxtype.keyword></decl.function.method.instance>
+
+//--- MyModule.swift
+public actor MyActor {
+  public func asyncFunc(fn: () async -> Void) async throws {}
+}
+
+func test(act: MyActor) async throws {
+    try await act.asyncFunc {}
+}
+
+//--- App.swift
+import MyModule
+
+func test(act: MyActor) async throws {
+    try await act.asyncFunc {}
+}

--- a/test/SourceKit/CursorInfo/cursor_swiftonly_systemmodule.swift
+++ b/test/SourceKit/CursorInfo/cursor_swiftonly_systemmodule.swift
@@ -1,17 +1,5 @@
-// BEGIN SomeModule.swift
-
-/// Doc comment for 'someFunc()'
-public func someFunc() {}
-
-// BEGIN main.swift
-import SomeModule
-
-func test() {
-  someFunc()
-}
-
 // RUN: %empty-directory(%t)
-// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: split-file %s %t
 
 // RUN: mkdir -p %t/SDK/Frameworks/SomeModule.framework/Modules/SomeModule.swiftmodule
 // RUN: %target-swift-frontend \
@@ -38,3 +26,14 @@ func test() {
 // CHECK-NEXT: SYSTEM
 // CHECK-NEXT: <Declaration>func someFunc()</Declaration>
 // CHECK-NEXT: <decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>someFunc</decl.name>()</decl.function.free>
+
+//--- SomeModule.swift
+/// Doc comment for 'someFunc()'
+public func someFunc() {}
+
+//--- main.swift
+import SomeModule
+
+func test() {
+  someFunc()
+}

--- a/test/SourceKit/CursorInfo/cursor_uses_swiftsourceinfo.swift
+++ b/test/SourceKit/CursorInfo/cursor_uses_swiftsourceinfo.swift
@@ -1,25 +1,27 @@
-// RUN: %empty-directory(%t/split)
-// RUN: %{python} %utils/split_file.py -o %t/split %s
+// RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/build)
-// RUN: %target-swift-frontend -emit-module -module-name MyModule -emit-module-path %t/build/MyModule.swiftmodule -emit-module-source-info-path %t/build/MyModule.swiftsourceinfo %t/split/Action.swift
-// RUN: %sourcekitd-test -req=cursor -req-opts=retrieve_symbol_graph=1 -pos=5:14 %t/split/test.swift -- %t/split/test.swift -I %t/build -target %target-triple | %FileCheck %s
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -emit-module -module-name MyModule -emit-module-path %t/build/MyModule.swiftmodule -emit-module-source-info-path %t/build/MyModule.swiftsourceinfo %t/Action.swift
+// RUN: %sourcekitd-test -req=cursor -req-opts=retrieve_symbol_graph=1 -pos=5:14 %t/test.swift -- %t/test.swift -I %t/build -target %target-triple | %FileCheck %s
 
 // We should also get source doc info if we execute a code completion request (which doesn't need source doc info) first
 // RUN: %sourcekitd-test \
-// RUN: -req=complete %t/split/test.swift -pos=5:14 -- %t/split/test.swift -I %t/build -target %target-triple == \
-// RUN: -req=cursor -req-opts=retrieve_symbol_graph=1 -pos=5:14 %t/split/test.swift -- %t/split/test.swift -I %t/build -target %target-triple
+// RUN: -req=complete %t/test.swift -pos=5:14 -- %t/test.swift -I %t/build -target %target-triple == \
+// RUN: -req=cursor -req-opts=retrieve_symbol_graph=1 -pos=5:14 %t/test.swift -- %t/test.swift -I %t/build -target %target-triple
 
-// BEGIN Action.swift
+// CHECK: REFERENCED DECLS BEGIN
+// CHECK-NEXT: s:8MyModule6ActionP | public | {{.*}}Action.swift | MyModule | User | NonSPI | source.lang.swift
+// CHECK-NEXT: Action swift.protocol s:8MyModule6ActionP
+// CHECK-NEXT: REFERENCED DECLS END
+
+//--- Action.swift
 public protocol Action {}
 
-// BEGIN test.swift
+//--- test.swift
 import MyModule
 
 func test(action: Action) {
     switch action {
     case let action
 
-// CHECK: REFERENCED DECLS BEGIN
-// CHECK-NEXT: s:8MyModule6ActionP | public | {{.*}}/split/Action.swift | MyModule | User | NonSPI | source.lang.swift
-// CHECK-NEXT: Action swift.protocol s:8MyModule6ActionP
-// CHECK-NEXT: REFERENCED DECLS END

--- a/test/SourceKit/CursorInfo/cursor_with_file_replacement.swift
+++ b/test/SourceKit/CursorInfo/cursor_with_file_replacement.swift
@@ -1,91 +1,80 @@
-// BEGIN State1.swift
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
 
+// RUN: %sourcekitd-test \
+// RUN:   -shell -- echo '## State 1' == \
+// RUN:   -req=cursor -pos=3:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -shell -- echo '## State 2' == \
+// RUN:   -shell -- cp %t/State2.swift %t/file.swift == \
+// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -shell -- echo '## State 3' == \
+// RUN:   -shell -- cp %t/State3.swift %t/file.swift == \
+// RUN:   -req=cursor -pos=2:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -shell -- echo '## State 4' == \
+// RUN:   -shell -- cp %t/State4.swift %t/file.swift == \
+// RUN:   -req=cursor -pos=2:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -shell -- echo '## State 5' == \
+// RUN:   -shell -- cp %t/State5.swift %t/file.swift == \
+// RUN:   -req=cursor -pos=2:7 %t/file.swift -- %t/file.swift == \
+// RUN:   -shell -- echo '## State 6' == \
+// RUN:   -shell -- cp %t/State6.swift %t/file.swift == \
+// RUN:   -req=cursor -pos=2:7 %t/file.swift -- %t/file.swift > %t/response.txt
+// RUN: %FileCheck %s < %t/response.txt
+
+// CHECK-LABEL: ## State 1
+// CHECK: source.lang.swift.decl.var.local (3:7-3:18)
+// CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
+// CHECK: DID REUSE AST CONTEXT: 0
+// CHECK-LABEL: ## State 2
+// CHECK: source.lang.swift.decl.var.local (4:7-4:18)
+// CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
+// CHECK: DID REUSE AST CONTEXT: 1
+// CHECK-LABEL: ## State 3
+// CHECK: source.lang.swift.decl.var.local (2:7-2:18)
+// CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
+// CHECK: DID REUSE AST CONTEXT: 1
+// CHECK-LABEL: ## State 4
+// CHECK: source.lang.swift.decl.var.local (2:7-2:16)
+// CHECK: <Declaration>let myNewName: <Type usr="s:SS">String</Type></Declaration>
+// CHECK: DID REUSE AST CONTEXT: 1
+// CHECK-LABEL: ## State 5
+// CHECK: source.lang.swift.decl.var.local (2:7-2:16)
+// CHECK: <Declaration>let myNewName: <Type usr="s:SS">String</Type></Declaration>
+// CHECK: DID REUSE AST CONTEXT: 0
+// CHECK-LABEL: ## State 6
+// CHECK: source.lang.swift.decl.var.local (2:7-2:16)
+// CHECK: <Declaration>let myNewName: <Type usr="s:Si">Int</Type></Declaration>
+// CHECK: DID REUSE AST CONTEXT: 1
+
+//--- file.swift
 func foo() {
   let inFunctionA = 1
   let inFunctionB = "hi"
 }
 
-// BEGIN State2.swift
-
+//--- State2.swift
 func foo() {
   let newlyAddedMember = 3
   let inFunctionA = 1
   let inFunctionB = "hi"
 }
 
-// BEGIN State3.swift
-
+//--- State3.swift
 func foo() {
   let inFunctionB = "hi"
 }
 
-// BEGIN State4.swift
-
+//--- State4.swift
 func foo() {
   let myNewName = "hi"
 }
 
-// BEGIN State5.swift
-
+//--- State5.swift
 func foo(param: Int) {
   let myNewName = "hi"
 }
 
-// BEGIN State6.swift
-
+//--- State6.swift
 func foo(param: Int) {
   let myNewName = 7
 }
-
-
-// BEGIN Dummy.swift
-
-// RUN: %empty-directory(%t)
-// RUN: %{python} %utils/split_file.py -o %t %s
-
-// RUN: cp %t/State1.swift %t/file.swift
-
-// RUN: %sourcekitd-test \
-// RUN:   -shell -- echo '## State 1' == \
-// RUN:   -req=cursor -pos=4:7 %t/file.swift -- %t/file.swift == \
-// RUN:   -shell -- echo '## State 2' == \
-// RUN:   -shell -- cp %t/State2.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=5:7 %t/file.swift -- %t/file.swift == \
-// RUN:   -shell -- echo '## State 3' == \
-// RUN:   -shell -- cp %t/State3.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=3:7 %t/file.swift -- %t/file.swift == \
-// RUN:   -shell -- echo '## State 4' == \
-// RUN:   -shell -- cp %t/State4.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=3:7 %t/file.swift -- %t/file.swift == \
-// RUN:   -shell -- echo '## State 5' == \
-// RUN:   -shell -- cp %t/State5.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=3:7 %t/file.swift -- %t/file.swift == \
-// RUN:   -shell -- echo '## State 6' == \
-// RUN:   -shell -- cp %t/State6.swift %t/file.swift == \
-// RUN:   -req=cursor -pos=3:7 %t/file.swift -- %t/file.swift > %t/response.txt
-// RUN: %FileCheck %s < %t/response.txt
-
-// CHECK-LABEL: ## State 1
-// CHECK: source.lang.swift.decl.var.local (4:7-4:18)
-// CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
-// CHECK: DID REUSE AST CONTEXT: 0
-// CHECK-LABEL: ## State 2
-// CHECK: source.lang.swift.decl.var.local (5:7-5:18)
-// CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
-// CHECK: DID REUSE AST CONTEXT: 1
-// CHECK-LABEL: ## State 3
-// CHECK: source.lang.swift.decl.var.local (3:7-3:18)
-// CHECK: <Declaration>let inFunctionB: <Type usr="s:SS">String</Type></Declaration>
-// CHECK: DID REUSE AST CONTEXT: 1
-// CHECK-LABEL: ## State 4
-// CHECK: source.lang.swift.decl.var.local (3:7-3:16)
-// CHECK: <Declaration>let myNewName: <Type usr="s:SS">String</Type></Declaration>
-// CHECK: DID REUSE AST CONTEXT: 1
-// CHECK-LABEL: ## State 5
-// CHECK: source.lang.swift.decl.var.local (3:7-3:16)
-// CHECK: <Declaration>let myNewName: <Type usr="s:SS">String</Type></Declaration>
-// CHECK: DID REUSE AST CONTEXT: 0
-// CHECK-LABEL: ## State 6
-// CHECK: source.lang.swift.decl.var.local (3:7-3:16)
-// CHECK: <Declaration>let myNewName: <Type usr="s:Si">Int</Type></Declaration>
-// CHECK: DID REUSE AST CONTEXT: 1

--- a/test/SourceKit/CursorInfo/rdar_41593893.swift
+++ b/test/SourceKit/CursorInfo/rdar_41593893.swift
@@ -1,11 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %{python} %utils/split_file.py -o %t %s
+// RUN: split-file %s %t
+
 // RUN: %sourcekitd-test -req=cursor -pos=8:37 %t/first.swift -- %t/first.swift %t/second.swift | %FileCheck %s
 
 // CHECK: source.lang.swift.ref.var.instance (6:9-6:12)
 
-
-// BEGIN first.swift
+//--- first.swift
 protocol ChatDataSourceDelegateProtocol {
     func chatDataSourceDidUpdate()
 }
@@ -17,7 +17,7 @@ class BaseChatViewController {
     }
 }
 
-// BEGIN second.swift
+//--- second.swift
 extension BaseChatViewController: ChatDataSourceDelegateProtocol {
     func chatDataSourceDidUpdate() { fatalError() }
 }

--- a/test/SourceKit/CursorInfo/static_vs_class_spelling.swift
+++ b/test/SourceKit/CursorInfo/static_vs_class_spelling.swift
@@ -1,39 +1,31 @@
-// REQUIRES: rdar105287822
-
 // RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/Modules)
-// RUN: %{python} %utils/split_file.py -o %t %s
-
-
-// BEGIN MyModule.swift
-
-public class UserCollection {
-  public static let sharedStatic = UserCollection()
-  public class var sharedComputedClass: UserCollection { UserCollection() }
-}
+// RUN: split-file --leading-lines %s %t
 
 // RUN: %target-swift-frontend \
 // RUN:     -emit-module \
 // RUN:     -module-name MyModule \
 // RUN:     -emit-module-path %t/Modules/MyModule.swiftmodule \
-// RUN:     -emit-module-doc-path %t/Modules/MyModule.swiftdoc \
 // RUN:     %t/MyModule.swift
 
-// BEGIN test.swift
+//--- MyModule.swift
+public class UserCollection {
+  public static let sharedStatic = UserCollection()
+  public class var sharedComputedClass: UserCollection { UserCollection() }
+}
+
+//--- test.swift
 import MyModule
 
 func application() {
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):18 %t/test.swift -- %t/test.swift -I %t/Modules -target %target-triple | %FileCheck %s --check-prefix=SHARED_STATIC
   UserCollection.sharedStatic
+  // FIXME: This should be reported as 'static var' rdar://105239467
+  // SHARED_STATIC: <Declaration>class let sharedStatic: <Type usr="s:8MyModule14UserCollectionC">UserCollection</Type></Declaration>
+  // SHARED_STATIC: <decl.var.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>sharedStatic</decl.name>: <decl.var.type><ref.class usr="s:8MyModule14UserCollectionC">UserCollection</ref.class></decl.var.type></decl.var.class>
+
+  // RUN: %sourcekitd-test -req=cursor -pos=%(line+1):18 %t/test.swift -- %t/test.swift -I %t/Modules -target %target-triple | %FileCheck %s --check-prefix=SHARED_COMPUTED_CLASS
   UserCollection.sharedComputedClass
+  // SHARED_COMPUTED_CLASS: <Declaration>class var sharedComputedClass: <Type usr="s:8MyModule14UserCollectionC">UserCollection</Type> { get }</Declaration>
+  // SHARED_COMPUTED_CLASS: <decl.var.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>sharedComputedClass</decl.name>: <decl.var.type><ref.class usr="s:8MyModule14UserCollectionC">UserCollection</ref.class></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.class>
 }
-
-// RUN: %sourcekitd-test -req=cursor -pos=4:18 %t/test.swift -- %t/test.swift -I %t/Modules | %FileCheck %s --check-prefix=SHARED_STATIC
-
-// FIXME: This should be reported as 'static var' rdar://105239467
-// SHARED_STATIC: <Declaration>class let sharedStatic: <Type usr="s:8MyModule14UserCollectionC">UserCollection</Type></Declaration>
-// SHARED_STATIC: <decl.var.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>sharedStatic</decl.name>: <decl.var.type><ref.class usr="s:8MyModule14UserCollectionC">UserCollection</ref.class></decl.var.type></decl.var.class>
-
-// RUN: %sourcekitd-test -req=cursor -pos=5:18 %t/test.swift -- %t/test.swift -I %t/Modules| %FileCheck %s --check-prefix=SHARED_COMPUTED_CLASS
-
-// SHARED_COMPUTED_CLASS: <Declaration>class var sharedComputedClass: <Type usr="s:8MyModule14UserCollectionC">UserCollection</Type> { get }</Declaration>
-// SHARED_COMPUTED_CLASS: <decl.var.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>sharedComputedClass</decl.name>: <decl.var.type><ref.class usr="s:8MyModule14UserCollectionC">UserCollection</ref.class></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.class>


### PR DESCRIPTION
Re-enable `static_vs_class_spelling.swift` - it was just missing the `-target` in the `sourcekitd-test` lines.

While here, cleanup all the cursor info tests that used `split_file` to use `split-file` instead.

Resolves rdar://105287822.