### PR TITLE
[move-only] Perform an exclusive borrow when passing a var to a consuming var.

### DIFF
--- a/include/swift/AST/StorageImpl.h
+++ b/include/swift/AST/StorageImpl.h
@@ -81,7 +81,7 @@ enum class AccessKind : uint8_t {
   Write,
 
   /// The access may require either reading or writing the current value.
-  ReadWrite
+  ReadWrite,
 };
 
 /// Produce the aggregate access kind of the combination of two accesses.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3951,6 +3951,10 @@ public:
     return getConvention() == ParameterConvention::Indirect_In_Guaranteed;
   }
 
+  bool isIndirectIn() const {
+    return getConvention() == ParameterConvention::Indirect_In;
+  }
+
   bool isIndirectInOut() const {
     return getConvention() == ParameterConvention::Indirect_Inout;
   }

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1777,6 +1777,24 @@ public:
   void emitDestructureAddressOperation(SILLocation loc, SILValue operand,
                                        SmallVectorImpl<SILValue> &result);
 
+  void emitDestructureAddressOperation(
+      SILLocation loc, SILValue operand,
+      function_ref<void(unsigned, SILValue)> result);
+
+  void emitDestructureOperation(SILLocation loc, SILValue operand,
+                                SmallVectorImpl<SILValue> &result) {
+    if (operand->getType().isAddress())
+      return emitDestructureAddressOperation(loc, operand, result);
+    return emitDestructureValueOperation(loc, operand, result);
+  }
+
+  void emitDestructureOperation(SILLocation loc, SILValue operand,
+                                function_ref<void(unsigned, SILValue)> result) {
+    if (operand->getType().isAddress())
+      return emitDestructureAddressOperation(loc, operand, result);
+    return emitDestructureValueOperation(loc, operand, result);
+  }
+
   ClassMethodInst *createClassMethod(SILLocation Loc, SILValue Operand,
                                      SILDeclRef Member, SILType MethodTy) {
     return insert(new (getModule()) ClassMethodInst(

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -188,6 +188,7 @@ public:
   using SILBuilder::createLoadBorrow;
   ManagedValue createLoadBorrow(SILLocation loc, ManagedValue base);
   ManagedValue createFormalAccessLoadBorrow(SILLocation loc, ManagedValue base);
+  ManagedValue createFormalAccessLoadTake(SILLocation loc, ManagedValue base);
 
   using SILBuilder::createStoreBorrow;
   ManagedValue createStoreBorrow(SILLocation loc, ManagedValue value,
@@ -394,6 +395,20 @@ public:
   void emitDestructureValueOperation(
       SILLocation loc, ManagedValue value,
       SmallVectorImpl<ManagedValue> &destructuredValues);
+
+  using SILBuilder::emitDestructureAddressOperation;
+  void emitDestructureAddressOperation(
+      SILLocation loc, ManagedValue value,
+      function_ref<void(unsigned, ManagedValue)> func);
+
+  using SILBuilder::emitDestructureOperation;
+  void
+  emitDestructureOperation(SILLocation loc, ManagedValue value,
+                           function_ref<void(unsigned, ManagedValue)> func) {
+    if (value.getType().isObject())
+      return emitDestructureValueOperation(loc, value, func);
+    return emitDestructureAddressOperation(loc, value, func);
+  }
 
   using SILBuilder::createProjectBox;
   ManagedValue createProjectBox(SILLocation loc, ManagedValue mv,

--- a/test/SILGen/moveonly_deinit_access.swift
+++ b/test/SILGen/moveonly_deinit_access.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-move-only %s | %FileCheck %s
+// RUN: %target-swift-emit-sil -enable-experimental-move-only %s | %FileCheck -check-prefix=SIL %s
+
+// This test makes sure that in various situations (ignoring errors), we
+// properly handle deinits with move only types.
+
+@_moveOnly
+public struct FD {
+    var i = 5
+}
+
+public func borrowVal(_ e : FD) {}
+public func consumeVal(_ s: __owned FD) {}
+
+// CHECK: sil hidden [ossa] @$s22moveonly_deinit_access0B17AccessConsumeTestyyAA2FDVzF : $@convention(thin) (@inout FD) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[ARG]]
+// CHECK:   [[ACCESS:%.*]] = begin_access [deinit] [unknown] [[MARK]]
+// CHECK:   [[TAKE:%.*]] = load [take] [[ACCESS]]
+// CHECK:   apply {{%.*}}([[TAKE]]) : $@convention(thin) (@owned FD) -> ()
+// CHECK:   end_access [[ACCESS]]
+// CHECK: } // end sil function '$s22moveonly_deinit_access0B17AccessConsumeTestyyAA2FDVzF'
+//
+// SIL: sil hidden @$s22moveonly_deinit_access0B17AccessConsumeTestyyAA2FDVzF : $@convention(thin) (@inout FD) -> () {
+// SIL:   begin_access [deinit] [static]
+// SIL: } // end sil function '$s22moveonly_deinit_access0B17AccessConsumeTestyyAA2FDVzF'
+func deinitAccessConsumeTest(_ x: inout FD) {
+    consumeVal(x)
+    x = FD()
+}
+


### PR DESCRIPTION
Consider the following example:

```
class Klass {}

@_moveOnly struct Butt {
  var k = Klass()
}

func mixedUse(_: inout Butt, _: __owned Butt) {}

func foo() {
    var y = Butt()
    mixedUse(&y, y)
}
```

In this case, we want to have an exclusivity violation. Before this patch, we did a by-value load [copy] of y and then performed the inout access. Since the access scopes did not overlap, we would not get an exclusivity violation. Additionally, since the checker assumes that exclusivity violations will be caught in such a situation, we convert the load [copy] to a load [take] causing a later memory lifetime violation as seen in the following SIL:

```
sil hidden [ossa] @$s4test3fooyyF : $@convention(thin) () -> () {
bb0:
  %0 = alloc_stack [lexical] $Butt, var, name "y" // users: %4, %5, %8, %12, %13
  %1 = metatype $@thin Butt.Type                  // user: %3
  // function_ref Butt.init()
  %2 = function_ref @$s4test4ButtVACycfC : $@convention(method) (@thin Butt.Type) -> @owned Butt // user: %3
  %3 = apply %2(%1) : $@convention(method) (@thin Butt.Type) -> @owned Butt // user: %4
  store %3 to [init] %0 : $*Butt                  // id: %4
  %5 = begin_access [modify] [static] %0 : $*Butt // users: %7, %6
  %6 = load [take] %5 : $*Butt                    // user: %10                // <————————— This was a load [copy].
  end_access %5 : $*Butt                          // id: %7
  %8 = begin_access [modify] [static] %0 : $*Butt // users: %11, %10
  // function_ref mixedUse2(_:_:)
  %9 = function_ref @$s4test9mixedUse2yyAA4ButtVz_ADntF : $@convention(thin) (@inout Butt, @owned Butt) -> () // user: %10
  %10 = apply %9(%8, %6) : $@convention(thin) (@inout Butt, @owned Butt) -> ()
  end_access %8 : $*Butt                          // id: %11
  destroy_addr %0 : $*Butt                        // id: %12
  dealloc_stack %0 : $*Butt                       // id: %13
  %14 = tuple ()                                  // user: %15
  return %14 : $()                                // id: %15
} // end sil function '$s4test3fooyyF'
```

Now, instead we create a [consume] access and get the nice exclusivity error we are looking for.

NOTE: As part of this I needed to tweak the verifier so that [deinit] accesses are now allowed to have any form of access enforcement before we are in LoweredSIL. I left in the original verifier error in LoweredSIL and additionally left in the original error in IRGen. The reason why I am doing this is that I need the deinit access to represent semantically what consuming from a ref_element_addr, global, or escaping mutable var look like at the SIL level so that the move checker can error upon it. Since we will error upon such consumptions in Canonical SIL, such code patterns will never actually hit Lowered/IRGen SIL, so it is safe to do so (and the verifier/errors will help us if we make any mistakes). In the case of a non-escaping var though, we will be able to use deinit statically and the move checker will make sure that it is not reused before it is reinitialized.

rdar://101767439
