### PR TITLE
[stdlib] Rework String breadcrumbs initialization/loading

### DIFF
--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1779,8 +1779,6 @@ bool swift::visitForwardedGuaranteedOperands(
       || isa<OwnershipForwardingMultipleValueInstruction>(inst)
       || isa<MoveOnlyWrapperToCopyableValueInst>(inst)
       || isa<CopyableToMoveOnlyWrapperValueInst>(inst)) {
-    assert(inst->getNumRealOperands() == 1
-           && "forwarding instructions must have a single real operand");
     assert(!isa<SingleValueInstruction>(inst)
            || !BorrowedValue(cast<SingleValueInstruction>(inst))
                   && "forwarded operand cannot begin a borrow scope");

--- a/stdlib/public/core/StringStorageBridge.swift
+++ b/stdlib/public/core/StringStorageBridge.swift
@@ -48,6 +48,9 @@ extension _AbstractStringStorage {
   ) {
     _precondition(aRange.location >= 0 && aRange.length >= 0,
                   "Range out of bounds")
+    // Note: `count` is counting UTF-8 code units, while `aRange` is measured in
+    // UTF-16 offsets. This precondition is a necessary, but not sufficient test
+    // for validity. (More precise checks are done in UTF16View._nativeCopy.)
     _precondition(aRange.location + aRange.length <= Int(count),
                   "Range out of bounds")
 

--- a/validation-test/StdlibUnittest/AtomicInt.swift
+++ b/validation-test/StdlibUnittest/AtomicInt.swift
@@ -795,6 +795,103 @@ struct AtomicInitializeARCRefRaceTest : RaceTestWithPerTrialData {
   }
 }
 
+struct AtomicAcquiringARCRefRaceTest: RaceTestWithPerTrialData {
+  typealias DummyObject = AtomicInitializeARCRefRaceTest.DummyObject
+
+  class RaceData {
+    var _atomicReference: DummyObject? = nil
+
+    var atomicReferencePtr: UnsafeMutablePointer<DummyObject?> {
+      _getUnsafePointerToStoredProperties(self).assumingMemoryBound(
+        to: Optional<DummyObject>.self)
+    }
+
+    init() {}
+  }
+
+  typealias ThreadLocalData = _stdlib_ShardedAtomicCounter.PRNG
+  typealias Observation = Observation4UInt
+
+  func makeRaceData() -> RaceData {
+    RaceData()
+  }
+
+  func makeThreadLocalData() -> ThreadLocalData {
+    ThreadLocalData()
+  }
+
+  func thread1(
+    _ raceData: RaceData, _ threadLocalData: inout ThreadLocalData
+  ) -> Observation {
+    var observation = Observation4UInt(0, 0, 0, 0)
+    let initializerDestroyed = HeapBool(false)
+    do {
+      let object = DummyObject(
+        destroyedFlag: initializerDestroyed,
+        randomInt: threadLocalData.randomInt())
+      let value = Unmanaged.passUnretained(object)
+      let result = _stdlib_atomicAcquiringInitializeARCRef(
+        object: raceData.atomicReferencePtr, desired: object)
+      observation.data1 = (result.toOpaque() == value.toOpaque()  ? 1 : 0)
+      if let loaded =
+        _stdlib_atomicAcquiringLoadARCRef(object: raceData.atomicReferencePtr) {
+        observation.data2 = UInt(bitPattern: loaded.toOpaque())
+        observation.data3 = loaded._withUnsafeGuaranteedRef { $0.payload }
+      }
+    }
+    observation.data4 = initializerDestroyed.value ? 1 : 0
+    return observation
+  }
+
+  func evaluateObservations(
+    _ observations: [Observation],
+    _ sink: (RaceTestObservationEvaluation) -> Void
+  ) {
+    let ref = observations[0].data2
+    if observations.contains(where: { $0.data2 != ref }) {
+      for observation in observations {
+        sink(.failureInteresting("mismatched reference, expected \(ref): \(observation)"))
+      }
+      return
+    }
+    if observations.contains(where: { $0.data3 != 0x12345678 }) {
+      for observation in observations {
+        sink(.failureInteresting("wrong data: \(observation)"))
+      }
+      return
+    }
+
+    var wonRace = 0
+    var lostRace = 0
+    for observation in observations {
+      switch (observation.data1, observation.data4) {
+      case (1, 0):
+        // Won race, value not destroyed.
+        wonRace += 1
+      case (0, 1):
+        // Lost race, value destroyed.
+        lostRace += 1
+      default:
+        sink(.failureInteresting(String(describing: observation)))
+      }
+    }
+    if wonRace != 1 {
+      for observation in observations {
+        sink(.failureInteresting("zero or more than one thread won race: \(observation)"))
+      }
+      return
+    }
+    if lostRace < 1 {
+      for observation in observations {
+        sink(.failureInteresting("no thread lost race: \(observation)"))
+      }
+      return
+    }
+
+    sink(.pass)
+  }
+}
+
 var AtomicIntTestSuite = TestSuite("AtomicInt")
 
 AtomicIntTestSuite.test("fetchAndAdd/1") {
@@ -841,11 +938,16 @@ AtomicIntTestSuite.test("fetchAndXor/1") {
 
 var AtomicARCRefTestSuite = TestSuite("AtomicARCRef")
 
-AtomicARCRefTestSuite.test("initialize,load") {
+AtomicARCRefTestSuite.test("seqcst_initialize,load") {
   runRaceTest(AtomicInitializeARCRefRaceTest.self,
     operations: 25600, timeoutInSeconds: 60)
   expectEqual(0, dummyObjectCount.getSum())
 }
 
-runAllTests()
+AtomicARCRefTestSuite.test("acquire_initialize,load") {
+  runRaceTest(AtomicAcquiringARCRefRaceTest.self,
+    operations: 25600, timeoutInSeconds: 60)
+  expectEqual(0, dummyObjectCount.getSum())
+}
 
+runAllTests()


### PR DESCRIPTION
This is a wild guess at what might be causing our persistent, random String failures on the main branch:

```
  Swift(macosx-x86_64) :: Prototypes/CollectionTransformers.swift
  Swift(macosx-x86_64) :: stdlib/NSSlowString.swift
  Swift(macosx-x86_64) :: stdlib/NSStringAPI.swift
  Swift(macosx-x86_64) :: stdlib/StringIndex.swift
  Swift-validation(macosx-x86_64) :: stdlib/String.swift
  Swift-validation(macosx-x86_64) :: stdlib/StringBreadcrumbs.swift
  Swift-validation(macosx-x86_64) :: stdlib/StringUTF8.swift
```

FWIW, it appears this is *not* caused by https://github.com/apple/swift/pull/62717: that change has also landed on release/5.8, and I haven’t seen these issues on that branch.

Our atomic breadcrumbs initialization vs its non-atomic loading gives me an uneasy feeling that this may in fact be a long standing synchronization issue that is only now causing problems (for whatever reason). I am unable to reproduce these issues locally, so this guess may be (and probably is) wildly off the mark, but this PR is likely to be a good idea anyway, if only to rule out this possibility.

rdar://104751936
