### PR TITLE
[Reflection] Use bytes in lock size

### DIFF
--- a/stdlib/public/Reflection/Sources/_Runtime/Utils/Lock.cpp
+++ b/stdlib/public/Reflection/Sources/_Runtime/Utils/Lock.cpp
@@ -17,13 +17,13 @@ using namespace swift;
 
 extern "C" SWIFT_CC(swift)
 size_t _swift_reflection_lock_size() {
-  size_t words = sizeof(Mutex) / sizeof(void *);
+  size_t bytes = sizeof(Mutex);
 
-  if (words < 1) {
+  if (bytes < 1) {
     return 1;
   }
 
-  return words;
+  return bytes;
 }
 
 extern "C" SWIFT_CC(swift)


### PR DESCRIPTION
I thought I had committed this in https://github.com/apple/swift/pull/63535 but apparently not unfortunately. `Lock` creates a managed buffer of `UInt8` elements who's capacity is determined by `_lockSize()`, thus this function needs to return the number of bytes to initialize and not words.