### PR TITLE
[SourceKit] Implement macro expansion for attached macros

### DIFF
--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -47,9 +47,17 @@ struct ReferenceMetaData {
   SemaReferenceKind Kind;
   llvm::Optional<AccessKind> AccKind;
   bool isImplicit = false;
-  ReferenceMetaData(SemaReferenceKind Kind, llvm::Optional<AccessKind> AccKind,
-                    bool isImplicit = false)
-      : Kind(Kind), AccKind(AccKind), isImplicit(isImplicit) {}
+
+  /// When non-none, this is a custom attribute reference.
+  Optional<std::pair<const CustomAttr *, Decl *>> CustomAttrRef;
+
+  ReferenceMetaData(
+      SemaReferenceKind Kind, llvm::Optional<AccessKind> AccKind,
+      bool isImplicit = false,
+      Optional<std::pair<const CustomAttr *, Decl *>> customAttrRef
+        = None
+  ) : Kind(Kind), AccKind(AccKind), isImplicit(isImplicit),
+      CustomAttrRef(customAttrRef) {}
 };
 
 /// Specifies how the initialization expression of a \c lazy variable should be

--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -24,6 +24,7 @@ class ArgumentList;
 class Decl;
 class Expr;
 class ClosureExpr;
+class CustomAttr;
 class ModuleDecl;
 class Stmt;
 class Pattern;

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3825,6 +3825,26 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Expand all accessor macros attached to the given declaration.
+///
+/// Produces the set of macro expansion buffer IDs.
+class ExpandAccessorMacros
+    : public SimpleRequest<ExpandAccessorMacros,
+                           ArrayRef<unsigned>(AbstractStorageDecl *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  ArrayRef<unsigned> evaluate(
+      Evaluator &evaluator, AbstractStorageDecl *storage) const;
+
+public:
+  bool isCached() const { return true; }
+};
+
 /// Expand all member attribute macros attached to the given
 /// declaration.
 ///

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3911,7 +3911,7 @@ public:
 /// Expand peer macros attached to the given declaration.
 class ExpandPeerMacroRequest
     : public SimpleRequest<ExpandPeerMacroRequest,
-                           bool(Decl *),
+                           ArrayRef<unsigned>(Decl *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -3919,7 +3919,7 @@ public:
 private:
   friend SimpleRequest;
 
-  bool evaluate(Evaluator &evaluator, Decl *decl) const;
+  ArrayRef<unsigned> evaluate(Evaluator &evaluator, Decl *decl) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3827,9 +3827,11 @@ public:
 
 /// Expand all member attribute macros attached to the given
 /// declaration.
+///
+/// Produces the set of macro expansion buffer IDs.
 class ExpandMemberAttributeMacros
     : public SimpleRequest<ExpandMemberAttributeMacros,
-                           bool(Decl *),
+                           ArrayRef<unsigned>(Decl *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -3837,16 +3839,18 @@ public:
 private:
   friend SimpleRequest;
 
-  bool evaluate(Evaluator &evaluator, Decl *decl) const;
+  ArrayRef<unsigned> evaluate(Evaluator &evaluator, Decl *decl) const;
 
 public:
   bool isCached() const { return true; }
 };
 
 /// Expand synthesized member macros attached to the given declaration.
+///
+/// Produces the set of macro expansion buffer IDs.
 class ExpandSynthesizedMemberMacroRequest
     : public SimpleRequest<ExpandSynthesizedMemberMacroRequest,
-                           bool(Decl *),
+                           ArrayRef<unsigned>(Decl *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -3854,7 +3858,7 @@ public:
 private:
   friend SimpleRequest;
 
-  bool evaluate(Evaluator &evaluator, Decl *decl) const;
+  ArrayRef<unsigned> evaluate(Evaluator &evaluator, Decl *decl) const;
 
 public:
   bool isCached() const { return true; }

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -432,10 +432,10 @@ SWIFT_REQUEST(TypeChecker, ExpandMacroExpansionDeclRequest,
               ArrayRef<Decl *>(MacroExpansionDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ExpandMemberAttributeMacros,
-              bool(Decl *),
+              ArrayRef<unsigned>(Decl *),
               Cached, NoLocationInfo)
-SWIFT_REQUEST(TypeCHecker, ExpandSynthesizedMemberMacroRequest,
-              bool(Decl *),
+SWIFT_REQUEST(TypeChecker, ExpandSynthesizedMemberMacroRequest,
+              ArrayRef<unsigned>(Decl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ExpandPeerMacroRequest,
               bool(Decl *),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -434,6 +434,9 @@ SWIFT_REQUEST(TypeChecker, ExpandMacroExpansionDeclRequest,
 SWIFT_REQUEST(TypeChecker, ExpandMemberAttributeMacros,
               ArrayRef<unsigned>(Decl *),
               Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ExpandAccessorMacros,
+              ArrayRef<unsigned>(AbstractStorageDecl *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ExpandSynthesizedMemberMacroRequest,
               ArrayRef<unsigned>(Decl *),
               Cached, NoLocationInfo)

--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -63,12 +63,12 @@ public:
   /// which source code was generated. Conceptually, one can think of the
   /// buffer described by a \c GeneratedSource instance as replacing the
   /// code in the \c originalSourceRange.
-  SourceRange originalSourceRange;
+  CharSourceRange originalSourceRange;
 
   /// The source range in the generated-source buffer where the generated
   /// code exists. This might be a subrange of the buffer containing the
   /// generated source, but it will never be from a different buffer.
-  SourceRange generatedSourceRange;
+  CharSourceRange generatedSourceRange;
 
   /// The opaque pointer for an ASTNode for which this buffer was generated.
   void *astNode;

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -151,6 +151,8 @@ protected:
     bool IsRef = true;
     Type Ty;
     Type ContainerType;
+    Optional<std::pair<const CustomAttr *, Decl *>> CustomAttrRef = None;
+
     bool IsKeywordArgument = false;
     /// It this is a ref, whether it is "dynamic". See \c ide::isDynamicRef.
     bool IsDynamic = false;
@@ -260,6 +262,13 @@ struct ResolvedValueRefCursorInfo : public ResolvedCursorInfo {
   ValueDecl *typeOrValue() {
     return ValueRefInfo.CtorTyRef ? ValueRefInfo.CtorTyRef
                                   : ValueRefInfo.ValueD;
+  }
+
+  Optional<std::pair<const CustomAttr *, Decl *>> getCustomAttrRef() const {
+    return ValueRefInfo.CustomAttrRef;
+  }
+  void setCustomAttrRef(Optional<std::pair<const CustomAttr *, Decl *>> ref) {
+    ValueRefInfo.CustomAttrRef = ref;
   }
 
   static bool classof(const ResolvedCursorInfo *Info) {

--- a/lib/AST/ASTScopeSourceRange.cpp
+++ b/lib/AST/ASTScopeSourceRange.cpp
@@ -75,12 +75,11 @@ void ASTScopeImpl::checkSourceRangeBeforeAddingChild(ASTScopeImpl *child,
     if (!generatedInfo)
       return false;
 
-    SourceRange expansionRange = generatedInfo->originalSourceRange;
+    CharSourceRange expansionRange = generatedInfo->originalSourceRange;
     if (expansionRange.isInvalid())
       return false;
 
-    return containedInParent(
-        Lexer::getCharSourceRangeFromSourceRange(sourceMgr, expansionRange));
+    return containedInParent(expansionRange);
   };
 
   auto childCharRange = child->getCharSourceRangeOfScope(sourceMgr);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -369,9 +369,9 @@ StringRef Decl::getDescriptiveKindName(DescriptiveDeclKind K) {
 
 DeclAttributes Decl::getSemanticAttrs() const {
   auto mutableThis = const_cast<Decl *>(this);
-  evaluateOrDefault(getASTContext().evaluator,
-                    ExpandMemberAttributeMacros{mutableThis},
-                    false);
+  (void)evaluateOrDefault(getASTContext().evaluator,
+                          ExpandMemberAttributeMacros{mutableThis},
+                          { });
 
   return getAttrs();
 }

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -1241,11 +1241,8 @@ DiagnosticEngine::diagnosticInfoForDiagnostic(const Diagnostic &diagnostic) {
             bufferID,
             GeneratedSourceInfo{
               GeneratedSourceInfo::PrettyPrinted,
-              SourceRange(),
-              SourceRange(
-                  memBufferStartLoc,
-                  memBufferStartLoc.getAdvancedLoc(buffer.size())
-              ),
+              CharSourceRange(),
+              CharSourceRange(memBufferStartLoc, buffer.size()),
               ASTNode(const_cast<Decl *>(ppDecl)).getOpaqueValue(),
               nullptr
             }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2082,9 +2082,9 @@ QualifiedLookupRequest::evaluate(Evaluator &eval, const DeclContext *DC,
 
     // Expand synthesized member macros.
     auto &ctx = current->getASTContext();
-    evaluateOrDefault(ctx.evaluator,
-                      ExpandSynthesizedMemberMacroRequest{current},
-                      false);
+    (void)evaluateOrDefault(ctx.evaluator,
+                            ExpandSynthesizedMemberMacroRequest{current},
+                            false);
 
     // Look for results within the current nominal type and its extensions.
     bool currentIsProtocol = isa<ProtocolDecl>(current);

--- a/lib/Basic/SourceLoc.cpp
+++ b/lib/Basic/SourceLoc.cpp
@@ -223,7 +223,7 @@ SourceManager::~SourceManager() {
 static Optional<std::string>
 dumpBufferToFile(const llvm::MemoryBuffer *buffer,
                  const SourceManager &sourceMgr,
-                 SourceRange originalSourceRange) {
+                 CharSourceRange originalSourceRange) {
   // Create file in the system temporary directory.
   SmallString<128> outputFileName;
   llvm::sys::path::system_temp_directory(true, outputFileName);
@@ -250,14 +250,15 @@ dumpBufferToFile(const llvm::MemoryBuffer *buffer,
           out << "\n";
 
           auto originalFilename =
-            sourceMgr.getDisplayNameForLoc(originalSourceRange.Start, true);
+            sourceMgr.getDisplayNameForLoc(originalSourceRange.getStart(),
+                                           true);
           unsigned startLine, startColumn, endLine, endColumn;
           std::tie(startLine, startColumn) =
               sourceMgr.getPresumedLineAndColumnForLoc(
-                originalSourceRange.Start);
+                originalSourceRange.getStart());
           std::tie(endLine, endColumn) =
               sourceMgr.getPresumedLineAndColumnForLoc(
-                originalSourceRange.End);
+                originalSourceRange.getEnd());
           out << "// original-source-range: "
               << originalFilename
               << ":" << startLine << ":" << startColumn
@@ -383,7 +384,11 @@ void SourceManager::setGeneratedSourceInfo(
 
   case GeneratedSourceInfo::ReplacedFunctionBody:
     // Keep track of the replaced range.
-    ReplacedRanges[info.originalSourceRange] = info.generatedSourceRange;
+    SourceRange orig(info.originalSourceRange.getStart(),
+                     info.originalSourceRange.getEnd());
+    ReplacedRanges[orig] =
+        SourceRange(info.generatedSourceRange.getStart(),
+                    info.generatedSourceRange.getEnd());
     break;
   }
 }

--- a/lib/Frontend/SerializedDiagnosticConsumer.cpp
+++ b/lib/Frontend/SerializedDiagnosticConsumer.cpp
@@ -262,11 +262,10 @@ unsigned SerializedDiagnosticConsumer::getEmitFile(
   // The source range that this buffer was generated from, expressed as
   // offsets into the original buffer.
   if (generatedInfo->originalSourceRange.isValid()) {
-    auto originalFilename = SM.getDisplayNameForLoc(generatedInfo->originalSourceRange.Start,
+    auto originalFilename = SM.getDisplayNameForLoc(generatedInfo->originalSourceRange.getStart(),
                                 EmitMacroExpansionFiles);
     addRangeToRecord(
-        Lexer::getCharSourceRangeFromSourceRange(
-            SM, generatedInfo->originalSourceRange),
+        generatedInfo->originalSourceRange,
         SM, originalFilename, Record
     );
   } else {

--- a/lib/IDETool/CompileInstance.cpp
+++ b/lib/IDETool/CompileInstance.cpp
@@ -195,7 +195,7 @@ void retypeCheckFunctionBody(AbstractFunctionDecl *func,
         GeneratedSourceInfo::ReplacedFunctionBody,
         Lexer::getCharSourceRangeFromSourceRange(
           origSM, func->getOriginalBodySourceRange()),
-        Lexer::getCharSourceRangeFromSourceRange(newSM, newRange),
+        Lexer::getCharSourceRangeFromSourceRange(origSM, newRange),
         func,
         nullptr
       }

--- a/lib/IDETool/CompileInstance.cpp
+++ b/lib/IDETool/CompileInstance.cpp
@@ -193,8 +193,9 @@ void retypeCheckFunctionBody(AbstractFunctionDecl *func,
       sliceBufferID,
       GeneratedSourceInfo{
         GeneratedSourceInfo::ReplacedFunctionBody,
-        func->getOriginalBodySourceRange(),
-        newRange,
+        Lexer::getCharSourceRangeFromSourceRange(
+          origSM, func->getOriginalBodySourceRange()),
+        Lexer::getCharSourceRangeFromSourceRange(newSM, newRange),
         func,
         nullptr
       }

--- a/lib/IDETool/IDEInspectionInstance.cpp
+++ b/lib/IDETool/IDEInspectionInstance.cpp
@@ -346,8 +346,9 @@ bool IDEInspectionInstance::performCachedOperationIfPossible(
         newBufferID,
         GeneratedSourceInfo{
           GeneratedSourceInfo::ReplacedFunctionBody,
-          AFD->getOriginalBodySourceRange(),
-          newBodyRange,
+          Lexer::getCharSourceRangeFromSourceRange(
+              SM, AFD->getOriginalBodySourceRange()),
+          Lexer::getCharSourceRangeFromSourceRange(SM, newBodyRange),
           AFD,
           nullptr
         }

--- a/lib/Refactoring/Refactoring.cpp
+++ b/lib/Refactoring/Refactoring.cpp
@@ -8514,6 +8514,12 @@ getMacroExpansionBuffers(MacroDecl *macro, const CustomAttr *attr, Decl *decl) {
     allBufferIDs.append(bufferIDs.begin(), bufferIDs.end());
   }
 
+  if (roles.contains(MacroRole::Peer)) {
+    auto bufferIDs = evaluateOrDefault(
+        ctx.evaluator, ExpandPeerMacroRequest{decl}, { });
+    allBufferIDs.append(bufferIDs.begin(), bufferIDs.end());
+  }
+
   // Drop any buffers that come from other macros. We could eliminate this
   // step by adding more fine-grained requests above, which only expand for a
   // single custom attribute.

--- a/lib/Sema/LookupVisibleDecls.cpp
+++ b/lib/Sema/LookupVisibleDecls.cpp
@@ -607,9 +607,9 @@ static void synthesizeMemberDeclsForLookup(NominalTypeDecl *NTD,
 
   // Expand synthesized member macros.
   auto &ctx = NTD->getASTContext();
-  evaluateOrDefault(ctx.evaluator,
-                    ExpandSynthesizedMemberMacroRequest{NTD},
-                    false);
+  (void)evaluateOrDefault(ctx.evaluator,
+                          ExpandSynthesizedMemberMacroRequest{NTD},
+                          false);
 
   // Expand peer macros.
   for (auto *member : NTD->getMembers()) {

--- a/lib/Sema/TypeCheckMacros.h
+++ b/lib/Sema/TypeCheckMacros.h
@@ -70,8 +70,8 @@ expandMembers(CustomAttr *attr, MacroDecl *macro, Decl *decl);
 /// Expand the peer declarations for the given declaration based on
 /// the custom attribute that references the given macro.
 ///
-/// Returns \c true if the macro added new peers, \c false otherwise.
-bool expandPeers(CustomAttr *attr, MacroDecl *macro, Decl *decl);
+/// If expansion occurred, returns the macro expansion buffer ID.
+Optional<unsigned> expandPeers(CustomAttr *attr, MacroDecl *macro, Decl *decl);
 
 } // end namespace swift
 

--- a/lib/Sema/TypeCheckMacros.h
+++ b/lib/Sema/TypeCheckMacros.h
@@ -49,7 +49,7 @@ bool expandFreestandingDeclarationMacro(
 
 /// Expand the accessors for the given storage declaration based on the
 /// custom attribute that references the given macro.
-void expandAccessors(
+Optional<unsigned> expandAccessors(
     AbstractStorageDecl *storage, CustomAttr *attr, MacroDecl *macro
 );
 

--- a/lib/Sema/TypeCheckMacros.h
+++ b/lib/Sema/TypeCheckMacros.h
@@ -55,14 +55,17 @@ void expandAccessors(
 
 /// Expand the attributes for the given member declaration based
 /// on the custom attribute that references the given macro.
-bool expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member);
+///
+/// If expansion occurred, returns the macro expansion buffer ID.
+Optional<unsigned>
+expandAttributes(CustomAttr *attr, MacroDecl *macro, Decl *member);
 
 /// Expand the synthesized members for the given declaration based on
 /// the custom attribute that references the given macro.
 ///
-/// Returns \c true if the macro added new synthesized members, \c false
-/// otherwise.
-bool expandMembers(CustomAttr *attr, MacroDecl *macro, Decl *decl);
+/// If expansion occurred, returns the macro expansion buffer ID.
+Optional<unsigned>
+expandMembers(CustomAttr *attr, MacroDecl *macro, Decl *decl);
 
 /// Expand the peer declarations for the given declaration based on
 /// the custom attribute that references the given macro.

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -3414,10 +3414,7 @@ StorageImplInfoRequest::evaluate(Evaluator &evaluator,
   }
 
   // Expand any attached accessor macros.
-  storage->forEachAttachedMacro(MacroRole::Accessor,
-      [&](CustomAttr *customAttr, MacroDecl *macro) {
-        expandAccessors(storage, customAttr, macro);
-      });
+  (void)evaluateOrDefault(evaluator, ExpandAccessorMacros{storage}, { });
 
   bool hasWillSet = storage->getParsedAccessor(AccessorKind::WillSet);
   bool hasDidSet = storage->getParsedAccessor(AccessorKind::DidSet);

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -110,9 +110,9 @@ static void computeLoweredStoredProperties(NominalTypeDecl *decl,
                                            IterableDeclContext *implDecl) {
   // Expand synthesized member macros.
   auto &ctx = decl->getASTContext();
-  evaluateOrDefault(ctx.evaluator,
-                    ExpandSynthesizedMemberMacroRequest{decl},
-                    false);
+  (void)evaluateOrDefault(ctx.evaluator,
+                          ExpandSynthesizedMemberMacroRequest{decl},
+                          false);
 
   // Just walk over the members of the type, forcing backing storage
   // for lazy properties and property wrappers to be synthesized.

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -24,6 +24,16 @@ struct S {
   var y: Int
 }
 
+struct S2 {
+  private var _storage = _Storage()
+
+  @accessViaStorage
+  var x: Int
+
+  @accessViaStorage
+  var y: Int = 17
+}
+
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx
 
@@ -92,3 +102,23 @@ struct S {
 // ATTACHED_EXPAND:   22:11-22:11 "private var _storage = _Storage()"
 // ATTACHED_EXPAND: source.edit.kind.active:
 // ATTACHED_EXPAND:   21:1-21:15 ""
+
+//##-- Refactoring expanding the first accessor macro
+// RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=30:4 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ACCESSOR1_EXPAND %s
+// ACCESSOR1_EXPAND: source.edit.kind.active:
+// ACCESSOR1_EXPAND:   31:13-31:13 "{
+// ACCESSOR1_EXPAND:  get { _storage.x }
+// ACCESSOR1_EXPAND:  set { _storage.x = newValue }
+// ACCESSOR1_EXPAND: }"
+// ACCESSOR1_EXPAND: source.edit.kind.active:
+// ACCESSOR1_EXPAND:   30:3-30:20 ""
+
+//##-- Refactoring expanding the first accessor macro
+// RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=33:13 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ACCESSOR2_EXPAND %s
+// ACCESSOR2_EXPAND: source.edit.kind.active:
+// ACCESSOR2_EXPAND:   34:14-34:18 "{
+// ACCESSOR2_EXPAND:  get { _storage.y }
+// ACCESSOR2_EXPAND:  set { _storage.y = newValue }
+// ACCESSOR2_EXPAND: }"
+// ACCESSOR2_EXPAND: source.edit.kind.active:
+// ACCESSOR2_EXPAND:   33:3-33:20 ""

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -918,11 +918,11 @@ static void setLocationInfo(const ValueDecl *VD,
         // function body and which we created while reusing the ASTContext for
         // the rest of the file. Map the location back to the original file.
         unsigned OriginalBufID = SM.findBufferContainingLoc(
-            GeneratedSourceInfo->originalSourceRange.Start);
+            GeneratedSourceInfo->originalSourceRange.getStart());
         auto OriginalStartOffset = SM.getLocOffsetInBuffer(
-            GeneratedSourceInfo->originalSourceRange.Start, OriginalBufID);
+            GeneratedSourceInfo->originalSourceRange.getStart(), OriginalBufID);
         auto GeneratedStartOffset = SM.getLocOffsetInBuffer(
-            GeneratedSourceInfo->generatedSourceRange.Start, DeclBufID);
+            GeneratedSourceInfo->generatedSourceRange.getStart(), DeclBufID);
         Location.Offset += OriginalStartOffset - GeneratedStartOffset;
         assert(SM.findBufferContainingLoc(Loc) == DeclBufID);
         std::tie(Location.Line, Location.Column) =


### PR DESCRIPTION
Extend the macro-expansion refactoring to work with attached macros. These expansions can return several different changes, e.g., adding new members, sprinkling member attributes around, and so on.