### PR TITLE
[ASTGen] Adjustments because deprecated where clause in generic arguments has been removed in SwiftSyntax

### DIFF
--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -259,8 +259,7 @@ void *NamedOpaqueReturnTypeRepr_create(void *ctx, void *baseTy);
 void *OpaqueReturnTypeRepr_create(void *ctx, void *opaqueLoc, void *baseTy);
 void *ExistentialTypeRepr_create(void *ctx, void *anyLoc, void *baseTy);
 void *GenericParamList_create(void *ctx, void *lAngleLoc,
-                              BridgedArrayRef params, void *_Nullable whereLoc,
-                              BridgedArrayRef reqs, void *rAngleLoc);
+                              BridgedArrayRef params, void *rAngleLoc);
 void *GenericTypeParamDecl_create(void *ctx, void *declContext,
                                   BridgedIdentifier name, void *nameLoc,
                                   void *_Nullable ellipsisLoc, long index,

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -548,30 +548,12 @@ void *ExistentialTypeRepr_create(void *ctx, void *anyLoc, void *baseTy) {
 }
 
 void *GenericParamList_create(void *ctx, void *lAngleLoc,
-                              BridgedArrayRef params, void *_Nullable whereLoc,
-                              BridgedArrayRef reqs, void *rAngleLoc) {
+                              BridgedArrayRef params, void *rAngleLoc) {
   ASTContext &Context = *static_cast<ASTContext *>(ctx);
-  SmallVector<RequirementRepr> requirements;
-  for (auto req : getArrayRef<BridgedRequirementRepr>(reqs)) {
-    switch (req.Kind) {
-    case BridgedRequirementReprKindTypeConstraint:
-      requirements.push_back(RequirementRepr::getTypeConstraint(
-          (TypeRepr *)req.FirstType, getSourceLocFromPointer(req.SeparatorLoc),
-          (TypeRepr *)req.SecondType));
-      break;
-    case BridgedRequirementReprKindSameType:
-      requirements.push_back(RequirementRepr::getSameType(
-          (TypeRepr *)req.FirstType, getSourceLocFromPointer(req.SeparatorLoc),
-          (TypeRepr *)req.SecondType));
-      break;
-    case BridgedRequirementReprKindLayoutConstraint:
-      llvm_unreachable("cannot handle layout constraints!");
-    }
-  }
   return GenericParamList::create(Context, getSourceLocFromPointer(lAngleLoc),
                                   getArrayRef<GenericTypeParamDecl *>(params),
-                                  getSourceLocFromPointer(whereLoc),
-                                  requirements,
+                                  /*whereLoc=*/SourceLoc(),
+                                  /*requirements=*/{},
                                   getSourceLocFromPointer(rAngleLoc));
 }
 

--- a/lib/ASTGen/Sources/ASTGen/Generics.swift
+++ b/lib/ASTGen/Sources/ASTGen/Generics.swift
@@ -5,13 +5,10 @@ import SwiftSyntax
 extension ASTGenVisitor {
   func visit(_ node: GenericParameterClauseSyntax) -> ASTNode {
     let lAngleLoc = self.base.advanced(by: node.leftAngleBracket.position.utf8Offset).raw
-    let whereLoc = node.genericWhereClause.map {
-      self.base.advanced(by: $0.whereKeyword.position.utf8Offset).raw
-    }
     let rAngleLoc = self.base.advanced(by: node.rightAngleBracket.position.utf8Offset).raw
     return .misc(
-      self.withBridgedParametersAndRequirements(node) { params, reqs in
-        return GenericParamList_create(self.ctx, lAngleLoc, params, whereLoc, reqs, rAngleLoc)
+      self.withBridgedParametersAndRequirements(node) { params in
+        return GenericParamList_create(self.ctx, lAngleLoc, params, rAngleLoc)
       })
   }
 
@@ -33,10 +30,9 @@ extension ASTGenVisitor {
 extension ASTGenVisitor {
   private func withBridgedParametersAndRequirements<T>(
     _ node: GenericParameterClauseSyntax,
-    action: (BridgedArrayRef, BridgedArrayRef) -> T
+    action: (BridgedArrayRef) -> T
   ) -> T {
     var params = [UnsafeMutableRawPointer]()
-    var requirements = [BridgedRequirementRepr]()
     for param in node.genericParameterList {
       let loweredParameter = self.visit(param).rawValue
       params.append(loweredParameter)
@@ -49,38 +45,8 @@ extension ASTGenVisitor {
       GenericTypeParamDecl_setInheritedType(self.ctx, loweredParameter, loweredRequirement.rawValue)
     }
 
-    if let nodeRequirements = node.genericWhereClause?.requirementList {
-      for requirement in nodeRequirements {
-        switch requirement.body {
-        case .conformanceRequirement(let conformance):
-          let firstType = self.visit(conformance.leftTypeIdentifier).rawValue
-          let separatorLoc = self.base.advanced(by: conformance.colon.position.utf8Offset).raw
-          let secondType = self.visit(conformance.rightTypeIdentifier).rawValue
-          requirements.append(
-            BridgedRequirementRepr(
-              SeparatorLoc: separatorLoc,
-              Kind: .typeConstraint,
-              FirstType: firstType,
-              SecondType: secondType))
-        case .sameTypeRequirement(let sameType):
-          let firstType = self.visit(sameType.leftTypeIdentifier).rawValue
-          let separatorLoc = self.base.advanced(by: sameType.equalityToken.position.utf8Offset).raw
-          let secondType = self.visit(sameType.rightTypeIdentifier).rawValue
-          requirements.append(
-            BridgedRequirementRepr(
-              SeparatorLoc: separatorLoc,
-              Kind: .sameType,
-              FirstType: firstType,
-              SecondType: secondType))
-        case .layoutRequirement(_):
-          fatalError("Cannot handle layout requirements!")
-        }
-      }
-    }
     return params.withBridgedArrayRef { params in
-      return requirements.withBridgedArrayRef { reqs in
-        return action(params, reqs)
-      }
+      return action(params)
     }
   }
 }


### PR DESCRIPTION
Companion of https://github.com/apple/swift-syntax/pull/1127, which removes the where clause in the generic argument list because it hasn’t been supported for a few Swift releases.