### PR TITLE
[CanonicalizeOSSALifetime] Run on lexical lifetimes.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/Reachability.h
+++ b/include/swift/SILOptimizer/Analysis/Reachability.h
@@ -761,7 +761,6 @@ bool IterativeBackwardReachability<Effects>::findBarrier(SILInstruction *from,
     if (!effect)
       continue;
     if (effect == Effect::Gen()) {
-      assert(false && "found gen (before kill) in reachable block");
       continue;
     }
     // effect == Effect::Kill

--- a/include/swift/SILOptimizer/Analysis/Reachability.h
+++ b/include/swift/SILOptimizer/Analysis/Reachability.h
@@ -243,7 +243,7 @@ public:
     BasicBlockSet unknownEndBlocks;
 
   public:
-    /// The blocks found between the gens and the defBlock into which
+    /// The blocks found between the gens and the initialBlocks into which
     /// reachability may extend.
     BasicBlockSetVector discoveredBlocks;
     /// The sublist of gens which are killed within the blocks where they occur.
@@ -296,15 +296,32 @@ public:
   };
 
   /// Construct a dataflow for the specified function to run from the gens
-  /// provided by \p effects to the specified def block.  So that the result
-  /// structure can be owned by the caller, it is taken by reference here.
+  /// provided by \p effects to the specified \p initialBlocks.  So that the
+  /// result structure can be owned by the caller, it is taken by reference
+  /// here.
   ///
-  /// If a nullptr defBlock is specified, the dataflow may run up to the begin
-  /// of the function.
-  IterativeBackwardReachability(SILFunction *function, SILBasicBlock *defBlock,
+  /// If \p initialBlocks is empty, the dataflow may run up to the begin of the
+  /// function.
+  IterativeBackwardReachability(SILFunction *function,
+                                ArrayRef<SILBasicBlock *> initialBlocks,
                                 Effects &effects, Result &result)
-      : function(function), defBlock(defBlock), effects(effects),
-        result(result), dataflowWorklist(function) {}
+      : function(function), initialBlocks(function), effects(effects),
+        result(result), dataflowWorklist(function) {
+    for (auto *block : initialBlocks) {
+      this->initialBlocks.insert(block);
+    }
+  }
+
+  /// Convenience constructor to pass a single initial block.
+  static IterativeBackwardReachability
+  untilInitialBlock(SILFunction *function, SILBasicBlock *initialBlock,
+                    Effects &effects, Result &result) {
+    using InitialBlocks = ArrayRef<SILBasicBlock *>;
+    InitialBlocks initialBlocks =
+        initialBlock ? InitialBlocks(initialBlock) : InitialBlocks();
+    return IterativeBackwardReachability(function, initialBlocks, effects,
+                                         result);
+  }
 
   /// Step 1: Prepare to run the global dataflow: discover and summarize the
   /// blocks in the relevant region.
@@ -358,9 +375,8 @@ private:
 
   /// The function in which the dataflow will run.
   SILFunction *function;
-  /// The block containing the def for the value--the dataflow will not
-  /// propagate beyond this block.
-  SILBasicBlock *defBlock;
+  /// The blocks beyond which the dataflow will not propagate.
+  BasicBlockSet initialBlocks;
 
   /// Input to the dataflow.
   Effects &effects;
@@ -375,9 +391,9 @@ private:
   /// Current activity of the dataflow.
   Stage stage = Stage::Unstarted;
 
-  /// Whether the def effectively occurs within the specified block.
-  bool isEffectiveDefBlock(SILBasicBlock *block) {
-    return defBlock ? block == defBlock : block == &*function->begin();
+  /// Whether dataflow continues beyond this block.
+  bool stopAtBlock(SILBasicBlock *block) {
+    return initialBlocks.contains(block) || &*function->begin() == block;
   }
 
   /// Form the meet of the end state of the provided predecessor with the begin
@@ -424,8 +440,8 @@ private:
 /// effect of each block for use by the dataflow.
 ///
 /// Starting from the gens, find all blocks which might be reached up to and
-/// including the defBlock.  Summarize the effects of these blocks along the
-/// way.
+/// including the initialBlocks.  Summarize the effects of these blocks along
+/// the way.
 template <typename Effects>
 void IterativeBackwardReachability<Effects>::initialize() {
   assert(stage == Stage::Unstarted);
@@ -454,9 +470,9 @@ void IterativeBackwardReachability<Effects>::initialize() {
       // adjacent successors.
       continue;
     }
-    if (isEffectiveDefBlock(block)) {
-      // If this block is the effective def block, dataflow mustn't propagate
-      // a reachable state through this block to its predecessors.
+    if (stopAtBlock(block)) {
+      // If dataflow is to stop at this block, it mustn't propagate a reachable
+      // state through this block to its predecessors.
       continue;
     }
     for (auto *predecessor : block->getPredecessorBlocks())
@@ -631,9 +647,9 @@ void IterativeBackwardReachability<Effects>::solve() {
 template <typename Effects>
 void IterativeBackwardReachability<Effects>::propagateIntoPredecessors(
     SILBasicBlock *successor) {
-  // State isn't tracked above the def block.  Don't propagate state changes
-  // into its predecessors.
-  if (isEffectiveDefBlock(successor))
+  // State isn't tracked above the blocks dataflow stops at.  Don't propagate
+  // state changes into its predecessors.
+  if (stopAtBlock(successor))
     return;
   assert(result.getBeginStateForBlock(successor) == State::Unreachable() &&
          "propagating unreachability into predecessors of block whose begin is "
@@ -776,7 +792,7 @@ bool IterativeBackwardReachability<Effects>::findBarrier(SILInstruction *from,
     }
   }
   assert(result.getEffectForBlock(block) != Effect::Kill());
-  if (isEffectiveDefBlock(block)) {
+  if (stopAtBlock(block)) {
     visitor.visitBarrierBlock(block);
     return true;
   }

--- a/include/swift/SILOptimizer/Analysis/Reachability.h
+++ b/include/swift/SILOptimizer/Analysis/Reachability.h
@@ -903,6 +903,41 @@ void IterativeBackwardReachability<Effects>::Result::setEffectForBlock(
   }
 }
 
+//===----------------------------------------------------------------------===//
+// MARK: findBarriersBackward
+//===----------------------------------------------------------------------===//
+
+using llvm::ArrayRef;
+using llvm::function_ref;
+
+struct ReachableBarriers final {
+  /// Instructions which are barriers.
+  llvm::SmallVector<SILInstruction *, 4> instructions;
+
+  /// Blocks one of whose phis is a barrier.
+  llvm::SmallVector<SILBasicBlock *, 4> phis;
+
+  /// Boundary edges; edges such that
+  /// (1) the target block is reachable-at-begin
+  /// (2) at least one adjacent edge's target is not reachable-at-begin.
+  llvm::SmallVector<SILBasicBlock *, 4> edges;
+
+  ReachableBarriers() {}
+  ReachableBarriers(ReachableBarriers const &) = delete;
+  ReachableBarriers &operator=(ReachableBarriers const &) = delete;
+};
+
+/// Walk backwards from the specified \p roots through at the earliest \p
+/// initialBlocks to populate \p barriers by querying \p isBarrier along the
+/// way.
+///
+/// If \p initialBlocks is empty, dataflow continues to the begin of the
+/// function.
+void findBarriersBackward(ArrayRef<SILInstruction *> roots,
+                          ArrayRef<SILBasicBlock *> initialBlocks,
+                          SILFunction &function, ReachableBarriers &barriers,
+                          function_ref<bool(SILInstruction *)> isBarrier);
+
 } // end namespace swift
 
 #endif

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -109,6 +109,8 @@
 
 namespace swift {
 
+class BasicCalleeAnalysis;
+
 extern llvm::Statistic NumCopiesAndMovesEliminated;
 extern llvm::Statistic NumCopiesGenerated;
 
@@ -225,6 +227,8 @@ private:
 
   DominanceInfo *domTree = nullptr;
 
+  BasicCalleeAnalysis *calleeAnalysis;
+
   InstructionDeleter &deleter;
 
   /// The SILValue to canonicalize.
@@ -296,10 +300,12 @@ public:
   CanonicalizeOSSALifetime(bool pruneDebugMode, bool maximizeLifetime,
                            SILFunction *function,
                            NonLocalAccessBlockAnalysis *accessBlockAnalysis,
-                           DominanceInfo *domTree, InstructionDeleter &deleter)
+                           DominanceInfo *domTree,
+                           BasicCalleeAnalysis *calleeAnalysis,
+                           InstructionDeleter &deleter)
       : pruneDebugMode(pruneDebugMode), maximizeLifetime(maximizeLifetime),
         accessBlockAnalysis(accessBlockAnalysis), domTree(domTree),
-        deleter(deleter) {}
+        calleeAnalysis(calleeAnalysis), deleter(deleter) {}
 
   SILValue getCurrentDef() const { return currentDef; }
 
@@ -404,6 +410,9 @@ private:
 
   void findExtendedBoundary(PrunedLivenessBoundary const &originalBoundary,
                             PrunedLivenessBoundary &boundary);
+
+  void findDestroysOutsideBoundary(SmallVectorImpl<SILInstruction *> &destroys);
+  void extendLivenessToDeinitBarriers();
 
   void extendUnconsumedLiveness(PrunedLivenessBoundary const &boundary);
 

--- a/lib/SILOptimizer/Analysis/CMakeLists.txt
+++ b/lib/SILOptimizer/Analysis/CMakeLists.txt
@@ -22,6 +22,7 @@ target_sources(swiftSILOptimizer PRIVATE
   NonLocalAccessBlockAnalysis.cpp
   PassManagerVerifierAnalysis.cpp
   ProtocolConformanceAnalysis.cpp
+  Reachability.cpp
   RCIdentityAnalysis.cpp
   SimplifyInstruction.cpp
   TypeExpansionAnalysis.cpp

--- a/lib/SILOptimizer/Analysis/Reachability.cpp
+++ b/lib/SILOptimizer/Analysis/Reachability.cpp
@@ -1,0 +1,109 @@
+//=----------- Reachability.cpp - Walking from roots to barriers. -----------=//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SILOptimizer/Analysis/Reachability.h"
+
+using namespace swift;
+
+/// Walks backwards from the specified roots to find barrier instructions, phis,
+/// and blocks via the isBarrier predicate.
+///
+/// Implements IterativeBackwardReachability::Effects
+/// Implements IterativeBackwardReachability::findBarriers::Visitor
+class FindBarriersBackwardDataflow final {
+  using Reachability =
+      IterativeBackwardReachability<FindBarriersBackwardDataflow>;
+  using Effect = Reachability::Effect;
+  ArrayRef<SILInstruction *> const roots;
+  function_ref<bool(SILInstruction *)> isBarrier;
+  ReachableBarriers &barriers;
+  Reachability::Result result;
+  Reachability reachability;
+
+public:
+  FindBarriersBackwardDataflow(SILFunction &function,
+                               ArrayRef<SILInstruction *> roots,
+                               ArrayRef<SILBasicBlock *> stopBlocks,
+                               ReachableBarriers &barriers,
+                               function_ref<bool(SILInstruction *)> isBarrier)
+      : roots(roots), isBarrier(isBarrier), barriers(barriers),
+        result(&function), reachability(&function, stopBlocks, *this, result) {}
+  FindBarriersBackwardDataflow(FindBarriersBackwardDataflow const &) = delete;
+  FindBarriersBackwardDataflow &
+  operator=(FindBarriersBackwardDataflow const &) = delete;
+
+  void run();
+
+private:
+  friend Reachability;
+
+  /// IterativeBackwardReachability::Effects
+
+  auto gens() { return roots; }
+
+  Effect effectForInstruction(SILInstruction *);
+  Effect effectForPhi(SILBasicBlock *);
+
+  auto localGens() { return result.localGens; }
+
+  bool isLocalGen(SILInstruction *instruction) {
+    return result.localGens.contains(instruction);
+  }
+
+  /// IterativeBackwardReachability::findBarriers::Visitor
+
+  void visitBarrierInstruction(SILInstruction *instruction) {
+    barriers.instructions.push_back(instruction);
+  }
+
+  void visitBarrierPhi(SILBasicBlock *block) { barriers.phis.push_back(block); }
+
+  void visitBarrierBlock(SILBasicBlock *block) {
+    barriers.edges.push_back(block);
+  }
+};
+
+FindBarriersBackwardDataflow::Effect
+FindBarriersBackwardDataflow::effectForInstruction(
+    SILInstruction *instruction) {
+  if (llvm::is_contained(roots, instruction))
+    return Effect::Gen();
+  auto barrier = isBarrier(instruction);
+  return barrier ? Effect::Kill() : Effect::NoEffect();
+}
+
+FindBarriersBackwardDataflow::Effect
+FindBarriersBackwardDataflow::effectForPhi(SILBasicBlock *block) {
+  assert(llvm::all_of(block->getArguments(),
+                      [&](auto argument) { return PhiValue(argument); }));
+
+  bool barrier =
+      llvm::any_of(block->getPredecessorBlocks(), [&](auto *predecessor) {
+        return isBarrier(predecessor->getTerminator());
+      });
+  return barrier ? Effect::Kill() : Effect::NoEffect();
+}
+
+void FindBarriersBackwardDataflow::run() {
+  reachability.initialize();
+  reachability.solve();
+  reachability.findBarriers(*this);
+}
+
+void swift::findBarriersBackward(
+    ArrayRef<SILInstruction *> roots, ArrayRef<SILBasicBlock *> initialBlocks,
+    SILFunction &function, ReachableBarriers &barriers,
+    function_ref<bool(SILInstruction *)> isBarrier) {
+  FindBarriersBackwardDataflow flow(function, roots, initialBlocks, barriers,
+                                    isBarrier);
+  flow.run();
+}

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.h
@@ -50,7 +50,8 @@ struct OSSACanonicalizer {
                     InstructionDeleter &deleter)
       : canonicalizer(false /*pruneDebugMode*/,
                       !fn->shouldOptimize() /*maximizeLifetime*/, fn,
-                      nullptr /*accessBlockAnalysis*/, domTree, deleter) {}
+                      nullptr /*accessBlockAnalysis*/, domTree,
+                      nullptr /*calleeAnalysis*/, deleter) {}
 
   void clear() {
     consumingUsesNeedingCopy.clear();

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -165,6 +165,7 @@ SILCombiner::SILCombiner(SILFunctionTransform *trans,
                          bool removeCondFails, bool enableCopyPropagation) :
   parentTransform(trans),
   AA(trans->getPassManager()->getAnalysis<AliasAnalysis>(trans->getFunction())),
+  CA(trans->getPassManager()->getAnalysis<BasicCalleeAnalysis>()),
   DA(trans->getPassManager()->getAnalysis<DominanceAnalysis>()),
   PCA(trans->getPassManager()->getAnalysis<ProtocolConformanceAnalysis>()),
   CHA(trans->getPassManager()->getAnalysis<ClassHierarchyAnalysis>()),
@@ -352,7 +353,7 @@ void SILCombiner::canonicalizeOSSALifetimes(SILInstruction *currentInst) {
   CanonicalizeOSSALifetime canonicalizer(
       false /*prune debug*/,
       !parentTransform->getFunction()->shouldOptimize() /*maximize lifetime*/,
-      parentTransform->getFunction(), NLABA, domTree, deleter);
+      parentTransform->getFunction(), NLABA, domTree, CA, deleter);
   CanonicalizeBorrowScope borrowCanonicalizer(parentTransform->getFunction(),
                                               deleter);
 

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -23,21 +23,22 @@
 
 #include "swift/Basic/Defer.h"
 #include "swift/SIL/BasicBlockUtils.h"
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILInstructionWorklist.h"
 #include "swift/SIL/SILValue.h"
 #include "swift/SIL/SILVisitor.h"
-#include "swift/SIL/InstructionUtils.h"
+#include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h"
 #include "swift/SILOptimizer/Analysis/NonLocalAccessBlockAnalysis.h"
 #include "swift/SILOptimizer/Analysis/ProtocolConformanceAnalysis.h"
 #include "swift/SILOptimizer/OptimizerBridging.h"
+#include "swift/SILOptimizer/PassManager/PassManager.h"
 #include "swift/SILOptimizer/Utils/CastOptimizer.h"
 #include "swift/SILOptimizer/Utils/Existential.h"
 #include "swift/SILOptimizer/Utils/InstOptUtils.h"
 #include "swift/SILOptimizer/Utils/OwnershipOptUtils.h"
-#include "swift/SILOptimizer/PassManager/PassManager.h"
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
@@ -54,6 +55,8 @@ class SILCombiner :
   SILFunctionTransform *parentTransform;
 
   AliasAnalysis *AA;
+
+  BasicCalleeAnalysis *CA;
 
   DominanceAnalysis *DA;
 

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -432,6 +432,7 @@ void CopyPropagation::run() {
   auto *postOrderAnalysis = getAnalysis<PostOrderAnalysis>();
   auto *accessBlockAnalysis = getAnalysis<NonLocalAccessBlockAnalysis>();
   auto *dominanceAnalysis = getAnalysis<DominanceAnalysis>();
+  auto *calleeAnalysis = getAnalysis<BasicCalleeAnalysis>();
   DominanceInfo *domTree = dominanceAnalysis->get(f);
 
   // Label for unit testing with debug output.
@@ -475,9 +476,7 @@ void CopyPropagation::run() {
   // don't need to explicitly check for changes.
   CanonicalizeOSSALifetime canonicalizer(
       pruneDebug, /*maximizeLifetime=*/!getFunction()->shouldOptimize(),
-      getFunction(), accessBlockAnalysis, domTree, deleter);
-  auto *calleeAnalysis = getAnalysis<BasicCalleeAnalysis>();
-
+      getFunction(), accessBlockAnalysis, domTree, calleeAnalysis, deleter);
   // NOTE: We assume that the function is in reverse post order so visiting the
   //       blocks and pushing begin_borrows as we see them and then popping them
   //       off the end will result in shrinking inner borrow scopes first.

--- a/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
+++ b/lib/SILOptimizer/Transforms/SSADestroyHoisting.cpp
@@ -275,10 +275,11 @@ private:
   public:
     DestroyReachability(DeinitBarriers &result)
         : result(result), reachability(result.knownUses.getFunction()),
-          dataflow(result.knownUses.getFunction(),
-                   result.storageDefInst ? result.storageDefInst->getParent()
-                                         : nullptr,
-                   *this, reachability) {}
+          dataflow(Dataflow::untilInitialBlock(
+              result.knownUses.getFunction(),
+              result.storageDefInst ? result.storageDefInst->getParent()
+                                    : nullptr,
+              *this, reachability)) {}
 
     void solve();
 

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -292,6 +292,23 @@ struct OwnershipUtilsHasPointerEscape : UnitTest {
 //===----------------------------------------------------------------------===//
 
 // Arguments:
+// - the lexical borrow to fold
+// Dumpts:
+// - the function
+struct LexicalDestroyFoldingTest : UnitTest {
+  LexicalDestroyFoldingTest(UnitTestRunner *pass) : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    auto *dominanceAnalysis = getAnalysis<DominanceAnalysis>();
+    DominanceInfo *domTree = dominanceAnalysis->get(getFunction());
+    auto value = arguments.takeValue();
+    auto *bbi = cast<BeginBorrowInst>(value);
+    InstructionDeleter deleter;
+    foldDestroysOfCopiedLexicalBorrow(bbi, *domTree, deleter);
+    getFunction()->dump();
+  }
+};
+
+// Arguments:
 // - variadic list of - instruction: a last user
 // Dumps:
 // - the insertion points

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -495,13 +495,15 @@ struct CanonicalizeOSSALifetimeTest : UnitTest {
     auto *accessBlockAnalysis = getAnalysis<NonLocalAccessBlockAnalysis>();
     auto *dominanceAnalysis = getAnalysis<DominanceAnalysis>();
     DominanceInfo *domTree = dominanceAnalysis->get(getFunction());
+    auto *calleeAnalysis = getAnalysis<BasicCalleeAnalysis>();
     auto pruneDebug = arguments.takeBool();
     auto maximizeLifetimes = arguments.takeBool();
     auto respectAccessScopes = arguments.takeBool();
     InstructionDeleter deleter;
     CanonicalizeOSSALifetime canonicalizer(
         pruneDebug, maximizeLifetimes, getFunction(),
-        respectAccessScopes ? accessBlockAnalysis : nullptr, domTree, deleter);
+        respectAccessScopes ? accessBlockAnalysis : nullptr, domTree,
+        calleeAnalysis, deleter);
     auto value = arguments.takeValue();
     canonicalizer.canonicalizeValueLifetime(value);
     getFunction()->dump();
@@ -900,6 +902,7 @@ void UnitTestRunner::withTest(StringRef name, Doit doit) {
     ADD_UNIT_TEST_SUBCLASS("interior-liveness", InteriorLivenessTest)
     ADD_UNIT_TEST_SUBCLASS("is-deinit-barrier", IsDeinitBarrierTest)
     ADD_UNIT_TEST_SUBCLASS("is-lexical", IsLexicalTest)
+    ADD_UNIT_TEST_SUBCLASS("lexical-destroy-folding", LexicalDestroyFoldingTest)
     ADD_UNIT_TEST_SUBCLASS("linear-liveness", LinearLivenessTest)
     ADD_UNIT_TEST_SUBCLASS("multidef-liveness", MultiDefLivenessTest)
     ADD_UNIT_TEST_SUBCLASS("multidefuse-liveness", MultiDefUseLivenessTest)

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -70,6 +70,8 @@
 #include "swift/SIL/NodeDatastructures.h"
 #include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/PrunedLiveness.h"
+#include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
+#include "swift/SILOptimizer/Analysis/Reachability.h"
 #include "swift/SILOptimizer/Utils/CFGOptUtils.h"
 #include "swift/SILOptimizer/Utils/DebugOptUtils.h"
 #include "swift/SILOptimizer/Utils/InstructionDeleter.h"
@@ -230,6 +232,45 @@ bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {
     }
   }
   return true;
+}
+
+void CanonicalizeOSSALifetime::findDestroysOutsideBoundary(
+    SmallVectorImpl<SILInstruction *> &outsideDestroys) {
+  for (auto destroy : destroys) {
+    if (liveness->isWithinBoundary(destroy))
+      continue;
+    outsideDestroys.push_back(destroy);
+  }
+}
+
+void CanonicalizeOSSALifetime::extendLivenessToDeinitBarriers() {
+  SmallVector<SILInstruction *, 4> outsideDestroys;
+  findDestroysOutsideBoundary(outsideDestroys);
+
+  auto *def = getCurrentDef()->getDefiningInstruction();
+  using InitialBlocks = ArrayRef<SILBasicBlock *>;
+  auto *defBlock = getCurrentDef()->getParentBlock();
+  auto initialBlocks = defBlock ? InitialBlocks(defBlock) : InitialBlocks();
+  ReachableBarriers barriers;
+  findBarriersBackward(outsideDestroys, initialBlocks,
+                       *getCurrentDef()->getFunction(), barriers,
+                       [&](auto *inst) {
+                         if (inst == def)
+                           return true;
+                         return isDeinitBarrier(inst, calleeAnalysis);
+                       });
+  for (auto *barrier : barriers.instructions) {
+    liveness->updateForUse(barrier, /*lifetimeEnding*/ false);
+  }
+  for (auto *barrier : barriers.phis) {
+    for (auto *predecessor : barrier->getPredecessorBlocks()) {
+      liveness->updateForUse(predecessor->getTerminator(),
+                             /*lifetimeEnding*/ false);
+    }
+  }
+  // Ignore barriers.edges.  The beginning of the targets of such edges should
+  // not be added to liveness.  These edges will be rediscovered when computing
+  // the liveness boundary.
 }
 
 // Return true if \p inst is an end_access whose access scope overlaps the end
@@ -1032,9 +1073,6 @@ bool CanonicalizeOSSALifetime::computeLiveness() {
   if (currentDef->getOwnershipKind() != OwnershipKind::Owned)
     return false;
 
-  if (currentDef->isLexical())
-    return false;
-
   LLVM_DEBUG(llvm::dbgs() << "  Canonicalizing: " << currentDef);
 
   // Note: There is no need to register callbacks with this utility. 'onDelete'
@@ -1056,6 +1094,9 @@ bool CanonicalizeOSSALifetime::computeLiveness() {
     LLVM_DEBUG(llvm::errs() << "Failed to compute canonical liveness?!\n");
     invalidateLiveness();
     return false;
+  }
+  if (currentDef->isLexical()) {
+    extendLivenessToDeinitBarriers();
   }
   if (accessBlockAnalysis) {
     extendLivenessThroughOverlappingAccess();

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -764,6 +764,18 @@ private:
         // before means it has multiple predecessors, so this must be \p block's
         // unique successor.
         assert(block->getSingleSuccessorBlock() == successor);
+        // When this merge point was encountered the first time, a
+        // destroy_value was sought from its top.  If one was found, it was
+        // added to the boundary. If no destroy_value was found, _that_ user
+        // (i.e. the one on behalf of which extendBoundaryFromTerminator was
+        // called which inserted successor into seenMergePoints) was added to
+        // the boundary.
+        //
+        // This time, if a destroy was found, it's already in the boundary.  If
+        // no destroy was found, though, _this_ user must be added to the
+        // boundary.
+        foundDestroy =
+            findDestroyFromBlockBegin(successor, currentDef, isDestroy);
         continue;
       }
       if (auto *dvi =

--- a/lib/SILOptimizer/Utils/LexicalDestroyHoisting.cpp
+++ b/lib/SILOptimizer/Utils/LexicalDestroyHoisting.cpp
@@ -141,7 +141,8 @@ public:
   Dataflow(Context const &context, Usage const &uses, DeinitBarriers &barriers)
       : context(context), uses(uses), barriers(barriers),
         result(&context.function),
-        reachability(&context.function, context.defBlock, *this, result) {}
+        reachability(Reachability::untilInitialBlock(
+            &context.function, context.defBlock, *this, result)) {}
   Dataflow(Dataflow const &) = delete;
   Dataflow &operator=(Dataflow const &) = delete;
 

--- a/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/ShrinkBorrowScope.cpp
@@ -167,7 +167,8 @@ public:
   Dataflow(Context const &context, Usage const &uses, DeinitBarriers &barriers)
       : context(context), uses(uses), barriers(barriers),
         result(&context.function),
-        reachability(&context.function, context.defBlock, *this, result) {}
+        reachability(Reachability::untilInitialBlock(
+            &context.function, context.defBlock, *this, result)) {}
   Dataflow(Dataflow const &) = delete;
   Dataflow &operator=(Dataflow const &) = delete;
 

--- a/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
+++ b/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
@@ -1,6 +1,7 @@
 // RUN: %target-sil-opt -unit-test-runner %s -o /dev/null 2>&1 | %FileCheck %s
 
 class C {}
+sil @getOwned : $@convention(thin) () -> @owned C
 
 // When access scopes are respected, the lifetime which previously extended
 // beyond the access scope still extends beyond it.
@@ -44,4 +45,32 @@ bb0(%addr : $*C):
   destroy_value %instance : $C
   %retval = tuple ()
   return %retval : $()
+}
+
+
+// CHECK-LABEL: begin running test 1 of 1 on reuse_destroy_after_barrier_phi: canonicalize-ossa-lifetime with: true, false, true, @trace
+// CHECK-LABEL: sil [ossa] @reuse_destroy_after_barrier_phi : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:       {{bb[0-9]+}}({{%[^,]+}}
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'reuse_destroy_after_barrier_phi'
+// CHECK-LABEL: end running test 1 of 1 on reuse_destroy_after_barrier_phi: canonicalize-ossa-lifetime with: true, false, true, @trace
+sil [ossa] @reuse_destroy_after_barrier_phi : $@convention(thin) (@owned C) -> @owned C {
+entry(%instance : @owned $C):
+  debug_value [trace] %instance : $C
+  test_specification "canonicalize-ossa-lifetime true false true @trace"
+  %get = function_ref @getOwned : $@convention(thin) () -> @owned C
+  cond_br undef, through, loop
+
+through:
+  %4 = copy_value %instance : $C
+  br exit(%4 : $C)
+
+loop:
+  %other = apply %get() : $@convention(thin) () -> @owned C
+  br exit(%other : $C)
+
+exit(%out : @owned $C):
+  destroy_value %instance : $C
+  return %out : $C
 }

--- a/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
+++ b/test/SILOptimizer/canonicalize_ossa_lifetime_unit.sil
@@ -2,6 +2,7 @@
 
 class C {}
 sil @getOwned : $@convention(thin) () -> @owned C
+sil @barrier : $@convention(thin) () -> ()
 
 // When access scopes are respected, the lifetime which previously extended
 // beyond the access scope still extends beyond it.
@@ -73,4 +74,44 @@ loop:
 exit(%out : @owned $C):
   destroy_value %instance : $C
   return %out : $C
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on store_arg_to_out_addr: canonicalize-ossa-lifetime with: true, false, true, @trace
+// CHECK-LABEL: sil [ossa] @store_arg_to_out_addr : $@convention(thin) (@owned C) -> @out C {
+// CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] : $*C, [[INSTANCE:%[^,]+]] :
+// CHECK:       store [[INSTANCE]] to [init] [[ADDR]]
+// CHECK-LABEL: } // end sil function 'store_arg_to_out_addr'
+// CHECK-LABEL: end running test 1 of 1 on store_arg_to_out_addr: canonicalize-ossa-lifetime with: true, false, true, @trace
+sil [ossa] @store_arg_to_out_addr : $@convention(thin) (@owned C) -> @out C {
+bb0(%0 : $*C, %instance : @owned $C):
+  debug_value [trace] %instance : $C
+  test_specification "canonicalize-ossa-lifetime true false true @trace"
+  %copy = copy_value %instance : $C
+  store %copy to [init] %0 : $*C
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on store_arg_to_out_addr_with_barrier: canonicalize-ossa-lifetime with: true, false, true, @trace
+// CHECK-LABEL: sil [ossa] @store_arg_to_out_addr_with_barrier : $@convention(thin) (@owned C) -> @out C {
+// CHECK:       {{bb[0-9]+}}([[ADDR:%[^,]+]] : $*C, [[INSTANCE:%[^,]+]] :
+// CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
+// CHECK:         [[REGISTER_3:%[^,]+]] = copy_value [[INSTANCE]]
+// CHECK:         store [[REGISTER_3]] to [init] [[ADDR]]
+// CHECK:         apply [[BARRIER]]()
+// CHECK:         destroy_value [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'store_arg_to_out_addr_with_barrier'
+// CHECK-LABEL: end running test 1 of 1 on store_arg_to_out_addr_with_barrier: canonicalize-ossa-lifetime with: true, false, true, @trace
+sil [ossa] @store_arg_to_out_addr_with_barrier : $@convention(thin) (@owned C) -> @out C {
+bb0(%0 : $*C, %instance : @owned $C):
+  %barrier = function_ref @barrier : $@convention(thin) () -> ()
+  debug_value [trace] %instance : $C
+  test_specification "canonicalize-ossa-lifetime true false true @trace"
+  %copy = copy_value %instance : $C
+  store %copy to [init] %0 : $*C
+  apply %barrier() : $@convention(thin) () -> ()
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
 }

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -917,10 +917,10 @@ exit:
 
 // CHECK-LABEL: sil [ossa] @dont_extend_beyond_nonoverlapping_end_access_after_store_in_consuming_block : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C
-// CHECK:         [[COPY:%[^,]+]] = copy_value [[INSTANCE]]
+// CHECK-NOT:     copy_value
 // CHECK:         begin_access
 // CHECK-NOT:     copy_value
-// CHECK:         store [[COPY]] to [init] {{%[^,]+}}
+// CHECK:         store [[INSTANCE]] to [init] {{%[^,]+}}
 // CHECK-LABEL: } // end sil function 'dont_extend_beyond_nonoverlapping_end_access_after_store_in_consuming_block'
 sil [ossa] @dont_extend_beyond_nonoverlapping_end_access_after_store_in_consuming_block : $@convention(thin) (@owned C) -> () {
 bb0(%instance : @owned $C):

--- a/test/SILOptimizer/copy_propagation_opaque.sil
+++ b/test/SILOptimizer/copy_propagation_opaque.sil
@@ -440,9 +440,7 @@ bb0:
 //
 // CHECK-LABEL: sil [ossa] @testCopyBorrow : $@convention(thin) <T> (@in T) -> () {
 // CHECK:       bb0(%0 : @owned $T):
-// CHECK:       [[COPY:%[^,]+]] = copy_value %0
 // CHECK:       destroy_value %0 : $T
-// CHECK:       destroy_value [[COPY]]
 // CHECK-NEXT:  tuple
 // CHECK-NEXT:  return
 // CHECK-LABEL: } // end sil function 'testCopyBorrow'

--- a/test/SILOptimizer/copy_propagation_value.sil
+++ b/test/SILOptimizer/copy_propagation_value.sil
@@ -26,18 +26,16 @@ class CompileError : Error {}
 // This test case used to have an invalid boundary extension.
 // CHECK-LABEL: sil [ossa] @canonicalize_borrow_of_copy_with_interesting_boundary : $@convention(thin) (@owned C) -> (@owned NonTrivialStruct, @error any Error) {
 // CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
-// CHECK:         [[COPY:%[^,]+]] = copy_value [[INSTANCE]]
-// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         cond_br undef, [[SUCCESS:bb[0-9]+]], [[FAILURE:bb[0-9]+]]
 // CHECK:       [[SUCCESS]]:
-// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[COPY]]
+// CHECK:         [[BORROW:%[^,]+]] = begin_borrow [[INSTANCE]]
 // CHECK:         [[STRUCT:%[^,]+]] = struct $NonTrivialStruct ([[BORROW]] : $C)
 // CHECK:         [[STRUCT_OUT:%[^,]+]] = copy_value [[STRUCT]]
 // CHECK:         end_borrow [[BORROW]]
-// CHECK:         destroy_value [[COPY]]
+// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         return [[STRUCT_OUT]]
 // CHECK:       [[FAILURE]]:
-// CHECK:         destroy_value [[COPY]]
+// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         [[BOX:%[^,]+]] = alloc_existential_box
 // CHECK:         throw [[BOX]]
 // CHECK-LABEL: } // end sil function 'canonicalize_borrow_of_copy_with_interesting_boundary'

--- a/test/SILOptimizer/lexical_destroy_folding.sil
+++ b/test/SILOptimizer/lexical_destroy_folding.sil
@@ -544,55 +544,6 @@ exit:
   return %retval : $()
 }
 
-// Fold apply when guaranteed lexical value used in one but not two branches
-// and the lexical scope ends before the use on the non-lexical branch.
-//
-// CHECK-LABEL: sil [ossa] @nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use : {{.*}} {
-// CHECK:         [[GET_OWNED:%[^,]+]] = function_ref @get_owned
-// CHECK:         [[INSTANCE:%[^,]+]] = apply [[GET_OWNED]]
-// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
-// CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
-// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
-// CHECK:       [[LEFT]]:
-// CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME]]
-// CHECK:         apply [[CALLEE_OWNED]]([[COPY]])
-// CHECK:         end_borrow [[LIFETIME]]
-// CHECK:         destroy_value [[INSTANCE]]
-// CHECK:         br [[EXIT:bb[0-9]+]]
-// CHECK:       [[RIGHT]]:
-// CHECK:         end_borrow [[LIFETIME]]
-// CHECK:         apply [[CALLEE_OWNED]]([[INSTANCE]])
-// CHECK:         br [[EXIT]]
-// CHECK:       [[EXIT]]:
-// CHECK-LABEL: } // end sil function 'nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use'
-sil [ossa] @nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use : $@convention(thin) () -> () {
-entry:
-  %get_owned = function_ref @get_owned : $@convention(thin) () -> (@owned C)
-  %instance = apply %get_owned() : $@convention(thin) () -> (@owned C)
-  %copy_2 = copy_value %instance : $C
-  %lifetime = begin_borrow [lexical] %instance : $C
-  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
-  cond_br undef, left, right
-
-left:
-  %copy_1 = copy_value %lifetime : $C
-  apply %callee_owned(%copy_1) : $@convention(thin) (@owned C) -> ()
-  end_borrow %lifetime : $C
-  destroy_value %instance : $C
-  destroy_value %copy_2 : $C
-  br exit
-
-right:
-  end_borrow %lifetime : $C
-  destroy_value %instance : $C
-  apply %callee_owned(%copy_2) : $@convention(thin) (@owned C) -> ()
-  br exit
-
-exit:
-  %retval = tuple ()
-  return %retval : $()
-}
-
 // Fold even if there is a noncanonicalized copy which is otherwise used.
 // CHECK-LABEL: sil [ossa] @fold_noncanonical_copy_with_other_use : {{.*}} {
 // CHECK:       {{bb[0-9]+}}:

--- a/test/SILOptimizer/lexical_destroy_folding_unit.sil
+++ b/test/SILOptimizer/lexical_destroy_folding_unit.sil
@@ -1,0 +1,52 @@
+// RUN: %target-sil-opt -unit-test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+class C {}
+sil [ossa] @callee_owned : $@convention(thin) (@owned C) -> ()
+
+// Fold apply when guaranteed lexical value used in one but not two branches
+// and the lexical scope ends before the use on the non-lexical branch.
+//
+// CHECK-LABEL: sil [ossa] @nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use : {{.*}} {
+// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[INSTANCE]]
+// CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
+// CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
+// CHECK:       [[LEFT]]:
+// CHECK:         apply [[CALLEE_OWNED]]([[MOVE]])
+// CHECK:         destroy_value [[COPY]]
+// CHECK:         br [[EXIT:bb[0-9]+]]
+// CHECK:       [[RIGHT]]:
+// CHECK:         destroy_value [[MOVE]]
+// CHECK:         apply [[CALLEE_OWNED]]([[COPY]])
+// CHECK:         br [[EXIT]]
+// CHECK:       [[EXIT]]:
+// CHECK-LABEL: } // end sil function 'nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use'
+sil [ossa] @nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use : $@convention(thin) (@owned C) -> () {
+entry(%instance : @owned $C):
+  test_specification "lexical-destroy-folding @trace[0]"
+  %copy_2 = copy_value %instance : $C
+  %lifetime = begin_borrow [lexical] %instance : $C
+  debug_value [trace] %lifetime : $C
+  %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
+  cond_br undef, left, right
+
+left:
+  %copy_1 = copy_value %lifetime : $C
+  apply %callee_owned(%copy_1) : $@convention(thin) (@owned C) -> ()
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  destroy_value %copy_2 : $C
+  br exit
+
+right:
+  end_borrow %lifetime : $C
+  destroy_value %instance : $C
+  apply %callee_owned(%copy_2) : $@convention(thin) (@owned C) -> ()
+  br exit
+
+exit:
+  %retval = tuple ()
+  return %retval : $()
+}
+

--- a/test/SILOptimizer/lexical_destroy_hoisting.sil
+++ b/test/SILOptimizer/lexical_destroy_hoisting.sil
@@ -332,10 +332,8 @@ exit:
 //
 // CHECK-LABEL: sil [ossa] @dont_hoist_over_apply_at_copy : {{.*}} {
 // CHECK:       {{bb[0-9]+}}([[REGISTER_0:%[^,]+]] :
-// CHECK:         [[COPY:%[^,]+]] = copy_value [[INSTANCE]]
 // CHECK:         apply
 // CHECK:         destroy_value [[INSTANCE]]
-// CHECK:         destroy_value [[COPY]]
 // CHECK-LABEL: } // end sil function 'dont_hoist_over_apply_at_copy'
 sil [ossa] @dont_hoist_over_apply_at_copy : $@convention(thin) (@owned C) -> () {
 entry(%instance : @owned $C):

--- a/test/SILOptimizer/ossa_rauw_tests.sil
+++ b/test/SILOptimizer/ossa_rauw_tests.sil
@@ -189,23 +189,21 @@ bb0(%0 : @owned $Klass):
 // CHECK-NOT: destroy_value
 //
 // CHECK: bb2:
-// CHECK-NEXT: [[COPY:%.*]] = copy_value [[ARG]]
 // CHECK-NEXT: cond_br undef, bb3, bb4
 //
 // CHECK: bb3:
-// CHECK-NEXT: destroy_value [[COPY]]
 // CHECK-NEXT: br bb2
 //
 // CHECK: bb4:
-// CHECK-NEXT: [[ENUM_SOME_RESULT:%.*]] = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, [[COPY]]
+// CHECK-NEXT: [[ENUM_SOME_RESULT:%.*]] = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt, [[ARG]]
 // CHECK-NEXT: br bb6([[ENUM_SOME_RESULT]] : $FakeOptional<Klass>)
 //
 // CHECK: bb5:
+// CHECK-NEXT: destroy_value [[ARG]]
 // CHECK-NEXT: [[ENUM_NONE_RESULT:%.*]] = enum $FakeOptional<Klass>, #FakeOptional.none!enumelt
 // CHECK-NEXT: br bb6([[ENUM_NONE_RESULT]] :
 //
 // CHECK: bb6([[RESULT:%.*]] : @owned $FakeOptional<Klass>):
-// CHECK-NEXT: destroy_value [[ARG]]
 // CHECK-NEXT: return [[RESULT]]
 // CHECK: } // end sil function 'unowned_to_owned_rauw_loop'
 sil [ossa] @unowned_to_owned_rauw_loop : $@convention(thin) (@owned Klass) -> @owned FakeOptional<Klass> {


### PR DESCRIPTION
Previously, the utility bailed out on lexical lifetimes because it didn't respect deinit barriers.  Here, deinit barriers are found and added to liveness if the value is lexical.  This enables copies to be propagated without hoisting destroys over deinit barriers.

rdar://104630103
