### PR TITLE
[move-only] Teach the checker how to handle ref_element_addr and global_addr with assignable_but_not_consumable semantics

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -748,6 +748,25 @@ ERROR(sil_moveonlychecker_exclusivity_violation, none,
 ERROR(sil_moveonlychecker_moveonly_field_consumed, none,
       "'%0' has a move only field that was consumed before later uses", (StringRef))
 
+ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed_classfield_let, none,
+      "'%0' was consumed but it is illegal to consume a noncopyable class let field. One can only read from it",
+      (StringRef))
+ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed_classfield_var, none,
+      "'%0' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it",
+      (StringRef))
+ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed_global_var, none,
+      "'%0' was consumed but it is illegal to consume a noncopyable global var. One can only read from it or assign to it",
+      (StringRef))
+ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed_global_let, none,
+      "'%0' was consumed but it is illegal to consume a noncopyable global let. One can only read from it",
+      (StringRef))
+ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed_escaping_let, none,
+      "'%0' was consumed but it is illegal to consume a noncopyable escaping immutable capture. One can only read from it",
+      (StringRef))
+ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed_escaping_var, none,
+      "'%0' was consumed but it is illegal to consume a noncopyable escaping mutable capture. One can only read from it or assign over it",
+      (StringRef))
+
 NOTE(sil_moveonlychecker_moveonly_field_consumed_here, none,
      "move only field consumed here", ())
 NOTE(sil_moveonlychecker_boundary_use, none,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2988,6 +2988,14 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
       // The only other case that should get here is a global variable.
       if (!address) {
         address = SGF.emitGlobalVariableRef(Loc, Storage, ActorIso);
+        if (address.getType().isMoveOnly()) {
+            auto checkKind =
+                MarkMustCheckInst::CheckKind::AssignableButNotConsumable;
+            if (isReadAccess(AccessKind)) {
+              checkKind = MarkMustCheckInst::CheckKind::NoConsumeOrAssign;
+            }
+            address = SGF.B.createMarkMustCheckInst(Loc, address, checkKind);
+        }
       } else {
         assert((!ActorIso || Storage->isTopLevelGlobal()) &&
                "local var should not be actor isolated!");

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -788,6 +788,17 @@ namespace {
         SGF.B.createRefElementAddr(loc, base.getUnmanagedValue(),
                                    Field, SubstFieldType);
 
+      // If we have a move only type...
+      if (result->getType().isMoveOnly()) {
+        auto checkKind =
+            MarkMustCheckInst::CheckKind::AssignableButNotConsumable;
+        if (isReadAccess(getAccessKind())) {
+          // Add a mark_must_check [no_consume_or_assign].
+          checkKind = MarkMustCheckInst::CheckKind::NoConsumeOrAssign;
+        }
+        result = SGF.B.createMarkMustCheckInst(loc, result, checkKind);
+      }
+
       // Avoid emitting access markers completely for non-accesses or immutable
       // declarations. Access marker verification is aware of these cases.
       if (!IsNonAccessing && !Field->isLet()) {

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
@@ -615,6 +615,15 @@ void UseState::initializeLiveness(
     liveness.initializeDef(address, liveness.getTopLevelSpan());
   }
 
+  // Check if our address is from a global_addr. In such a case, we treat the
+  // mark_must_check as the initialization.
+  if (auto *globalAddr = dyn_cast<GlobalAddrInst>(address->getOperand())) {
+    LLVM_DEBUG(llvm::dbgs() << "Found global_addr use... "
+                               "adding mark_must_check as init!\n");
+    initInsts.insert({address, liveness.getTopLevelSpan()});
+    liveness.initializeDef(address, liveness.getTopLevelSpan());
+  }
+
   // Now that we have finished initialization of defs, change our multi-maps
   // from their array form to their map form.
   liveness.finishedInitializationOfDefs();

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -103,6 +103,8 @@ public:
                                           Operand *consumingUse,
                                           Operand *nonConsumingUse);
 
+  void emitAddressInstLoadedAndConsumed(MarkMustCheckInst *markedValue);
+
 private:
   /// Emit diagnostics for the final consuming uses and consuming uses needing
   /// copy. If filter is non-null, allow for the caller to pre-process operands

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -1,43 +1,27 @@
-// RUN: %target-swift-emit-silgen -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-experimental-move-only %s | %FileCheck %s
 
 //////////////////
 // Declarations //
 //////////////////
 
 public final class CopyableKlass {
-    var k = Klass()
+    var fd = FD()
 }
 
 @_moveOnly
-public class Klass2 {}
-
-@_moveOnly
-public final class Klass {
-    var int: Int
-    var moveOnlyKlass: Klass2
-    var copyableKlass: CopyableKlass
-
-    // CHECK-LABEL: sil hidden [ossa] @$s8moveonly5KlassCACycfc : $@convention(method) (@owned Klass) -> @owned Klass {
-    // CHECK: bb0([[ARG:%.*]] : @owned $Klass):
-    // CHECK:   [[MARK_UNINIT:%.*]] = mark_uninitialized [rootself] [[ARG]]
-    // CHECK:   [[MARK_NO_IMP_COPY:%.*]] = mark_must_check [consumable_and_assignable] [[MARK_UNINIT]]
-    // CHECK: } // end sil function '$s8moveonly5KlassCACycfc'
-    init() {
-        moveOnlyKlass = Klass2()
-        int = 5
-        copyableKlass = CopyableKlass()
-    }
+public struct FD {
+    var copyableKlass = CopyableKlass()
 }
 
 @_moveOnly
 public struct NonTrivialStruct2 {
-    var moveOnlyKlass = Klass()
+    var fd = FD()
     var copyableKlass = CopyableKlass()
 }
 
 @_moveOnly
 public struct NonTrivialStruct {
-    var moveOnlyKlass = Klass()
+    var fd = FD()
     var nonTrivialStruct2 = NonTrivialStruct2()
     var copyableKlass = CopyableKlass()
     var nonTrivialCopyableStruct = NonTrivialCopyableStruct()
@@ -56,23 +40,21 @@ public struct NonTrivialCopyableStruct {
 @_moveOnly
 public enum NonTrivialEnum {
     case first
-    case second(Klass)
+    case second(CopyableKlass)
     case third(NonTrivialStruct)
 }
 
 public func borrowVal(_ e : NonTrivialEnum) {}
+public func borrowVal(_ e : FD) {}
 public func borrowVal(_ k: CopyableKlass) {}
-public func borrowVal(_ k: Klass) {}
-public func borrowVal(_ k: Klass2) {}
 public func borrowVal(_ k: NonTrivialCopyableStruct) {}
 public func borrowVal(_ k: NonTrivialCopyableStruct2) {}
 public func borrowVal(_ s: NonTrivialStruct) {}
 public func borrowVal(_ s: NonTrivialStruct2) {}
 
 public func consumeVal(_ e : __owned NonTrivialEnum) {}
+public func consumeVal(_ e : __owned FD) {}
 public func consumeVal(_ k: __owned CopyableKlass) {}
-public func consumeVal(_ k: __owned Klass) {}
-public func consumeVal(_ k: __owned Klass2) {}
 public func consumeVal(_ k: __owned NonTrivialCopyableStruct) {}
 public func consumeVal(_ k: __owned NonTrivialCopyableStruct2) {}
 public func consumeVal(_ s: __owned NonTrivialStruct) {}
@@ -86,31 +68,6 @@ public func consumeVal(_ s: __owned NonTrivialStruct2) {}
 // Function Arguments
 //
 
-// CHECK-LABEL: sil [ossa] @$s8moveonly8useKlassyyAA0C0CF : $@convention(thin) (@guaranteed Klass) -> () {
-// CHECK: bb0([[ARG:%.*]] : @guaranteed $Klass):
-// CHECK:   [[OWNED_ARG:%.*]] = copy_value [[ARG]]
-// CHECK:   [[MARKED_OWNED_ARG:%.*]] = mark_must_check [no_consume_or_assign] [[OWNED_ARG]]
-// CHECK: } // end sil function '$s8moveonly8useKlassyyAA0C0CF'
-public func useKlass(_ k: Klass) {
-    borrowVal(k)
-    let k2 = k
-    borrowVal(k)
-    let _ = k2
-}
-
-// CHECK-LABEL: sil [ossa] @$s8moveonly15useKlassConsumeyyAA0C0CnF : $@convention(thin) (@owned Klass) -> () {
-// CHECK: bb0([[ARG:%.*]] : @owned $Klass):
-// TODO: Is this move_value [lexical] necessary?
-// CHECK:   [[LEXICAL_MOVE:%.*]] = move_value [lexical] [[ARG]]
-// CHECK:   mark_must_check [consumable_and_assignable] [[LEXICAL_MOVE]]
-// CHECK: } // end sil function '$s8moveonly15useKlassConsumeyyAA0C0CnF'
-public func useKlassConsume(_ k: __owned Klass) {
-    borrowVal(k)
-    let k2 = k
-    borrowVal(k)
-    let _ = k2
-}
-
 // CHECK-LABEL: sil [ossa] @$s8moveonly19useNonTrivialStructyyAA0cdE0VF : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $NonTrivialStruct):
 // CHECK:   [[COPIED_ARG:%.*]] = copy_value [[ARG]]
@@ -119,7 +76,7 @@ public func useKlassConsume(_ k: __owned Klass) {
 public func useNonTrivialStruct(_ s: NonTrivialStruct) {
     borrowVal(s)
     let s2 = s
-    let k = s.moveOnlyKlass
+    let k = s.fd
     let _ = k
     borrowVal(s)
     let _ = s2
@@ -133,7 +90,7 @@ public func useNonTrivialStruct(_ s: NonTrivialStruct) {
 public func useNonTrivialOwnedStruct(_ s: __owned NonTrivialStruct) {
     borrowVal(s)
     let s2 = s
-    let k = s.moveOnlyKlass
+    let k = s.fd
     let _ = k
     borrowVal(s)
     let _ = s2
@@ -179,18 +136,6 @@ public func useNonTrivialOwnedEnum(_ s: __owned NonTrivialEnum) {
 // Self in Methods
 //
 
-extension Klass {
-    // CHECK-LABEL: sil hidden [ossa] @$s8moveonly5KlassC13testNoUseSelfyyF : $@convention(method) (@guaranteed Klass) -> () {
-    // CHECK: bb0([[ARG:%.*]] : @guaranteed $Klass):
-    // CHECK:   [[COPIED_ARG:%.*]] = copy_value [[ARG]]
-    // CHECK:   mark_must_check [no_consume_or_assign] [[COPIED_ARG]]
-    // CHECK: } // end sil function '$s8moveonly5KlassC13testNoUseSelfyyF'
-    func testNoUseSelf() {
-        let x = self
-        let _ = x
-    }
-}
-
 extension NonTrivialStruct {
     // CHECK-LABEL: sil hidden [ossa] @$s8moveonly16NonTrivialStructV13testNoUseSelfyyF : $@convention(method) (@guaranteed NonTrivialStruct) -> () {
     // CHECK: bb0([[ARG:%.*]] : @guaranteed $NonTrivialStruct):
@@ -220,7 +165,7 @@ extension NonTrivialEnum {
 ///////////////////////////////
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly27blackHoleLetInitialization1yyF : $@convention(thin) () -> () {
-// CHECK: [[FN:%.*]] = function_ref @$s8moveonly5KlassCACycfC : $@convention(method) (@thick Klass.Type) -> @owned Klass
+// CHECK: [[FN:%.*]] = function_ref @$s8moveonly2FDVACycfC :
 // CHECK: [[X:%.*]] = apply [[FN]](
 // CHECK: [[X_MV_LEXICAL:%.*]] = move_value [lexical] [[X]]
 // CHECK: [[X_MV_ONLY:%.*]] = mark_must_check [consumable_and_assignable] [[X_MV_LEXICAL]]
@@ -229,12 +174,12 @@ extension NonTrivialEnum {
 // CHECK: [[X_MV_ONLY_CONSUME:%.*]] = move_value [[X_MV_ONLY_COPY]]
 // CHECK: } // end sil function '$s8moveonly27blackHoleLetInitialization1yyF'
 func blackHoleLetInitialization1() {
-    let x = Klass()
+    let x = FD()
     let _ = x
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly27blackHoleLetInitialization2yyF : $@convention(thin) () -> () {
-// CHECK: [[FN:%.*]] = function_ref @$s8moveonly5KlassCACycfC : $@convention(method) (@thick Klass.Type) -> @owned Klass
+// CHECK: [[FN:%.*]] = function_ref @$s8moveonly2FDVACycfC :
 // CHECK: [[X:%.*]] = apply [[FN]](
 // CHECK: [[X_MV_LEXICAL:%.*]] = move_value [lexical] [[X]]
 // CHECK: [[X_MV_ONLY:%.*]] = mark_must_check [consumable_and_assignable] [[X_MV_LEXICAL]]
@@ -243,7 +188,7 @@ func blackHoleLetInitialization1() {
 // CHECK: [[X_MV_ONLY_CONSUME:%.*]] = move_value [[X_MV_ONLY_COPY]]
 // CHECK: } // end sil function '$s8moveonly27blackHoleLetInitialization2yyF'
 func blackHoleLetInitialization2() {
-    let x = Klass()
+    let x = FD()
     var _ = x
 }
 
@@ -252,7 +197,7 @@ func blackHoleLetInitialization2() {
 // CHECK: [[BOX_BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
 // CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
 // CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable] [[PROJECT_BOX]]
-// CHECK: [[FN:%.*]] = function_ref @$s8moveonly5KlassCACycfC : $@convention(method) (@thick Klass.Type) -> @owned Klass
+// CHECK: [[FN:%.*]] = function_ref @$s8moveonly2FDVACycfC :
 // CHECK: [[X:%.*]] = apply [[FN]](
 // CHECK: store [[X]] to [init] [[MARKED_ADDR]]
 // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
@@ -260,8 +205,8 @@ func blackHoleLetInitialization2() {
 // CHECK: [[CONSUME:%.*]] = move_value [[LD]]
 // CHECK: } // end sil function '$s8moveonly27blackHoleVarInitialization1yyF'
 func blackHoleVarInitialization1() {
-    var x = Klass()
-    x = Klass()
+    var x = FD()
+    x = FD()
     let _ = x
 }
 
@@ -270,7 +215,7 @@ func blackHoleVarInitialization1() {
 // CHECK: [[BOX_BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
 // CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
 // CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable] [[PROJECT_BOX]]
-// CHECK: [[FN:%.*]] = function_ref @$s8moveonly5KlassCACycfC : $@convention(method) (@thick Klass.Type) -> @owned Klass
+// CHECK: [[FN:%.*]] = function_ref @$s8moveonly2FDVACycfC :
 // CHECK: [[X:%.*]] = apply [[FN]](
 // CHECK: store [[X]] to [init] [[MARKED_ADDR]]
 // CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
@@ -278,9 +223,27 @@ func blackHoleVarInitialization1() {
 // CHECK: [[CONSUME:%.*]] = move_value [[LD]]
 // CHECK: } // end sil function '$s8moveonly27blackHoleVarInitialization2yyF'
 func blackHoleVarInitialization2() {
-    var x = Klass()
-    x = Klass()
+    var x = FD()
+    x = FD()
     var _ = x
+}
+
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly27blackHoleVarInitialization3yyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box
+// CHECK: [[BOX_BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
+// CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
+// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable] [[PROJECT_BOX]]
+// CHECK: [[FN:%.*]] = function_ref @$s8moveonly2FDVACycfC :
+// CHECK: [[X:%.*]] = apply [[FN]](
+// CHECK: store [[X]] to [init] [[MARKED_ADDR]]
+// CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
+// CHECK: [[LD:%.*]] = load [copy] [[READ]]
+// CHECK: [[CONSUME:%.*]] = move_value [[LD]]
+// CHECK: } // end sil function '$s8moveonly27blackHoleVarInitialization3yyF'
+func blackHoleVarInitialization3() {
+    var x = FD()
+    x = FD()
+    _ = x
 }
 
 ////////////////////////////////
@@ -290,62 +253,13 @@ func blackHoleVarInitialization2() {
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly24borrowObjectFunctionCallyyF : $@convention(thin) () -> () {
 // CHECK: [[CLS:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK: [[BORROW:%.*]] = begin_borrow [[CLS]]
-// CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA5KlassCF
+// CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA2FDVF :
 // CHECK: apply [[FN]]([[BORROW]])
 // CHECK: end_borrow [[BORROW]]
 // CHECK: } // end sil function '$s8moveonly24borrowObjectFunctionCallyyF'
 func borrowObjectFunctionCall() {
-    let k = Klass()
+    let k = FD()
     borrowVal(k)
-}
-
-// CHECK-LABEL: sil hidden [ossa] @$s8moveonly25borrowAddressFunctionCallyyF : $@convention(thin) () -> () {
-// CHECK: [[BOX:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[BOX]]
-// CHECK: [[BORROW:%.*]] = load_borrow [[ACCESS]]
-// CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA5KlassCF
-// CHECK: apply [[FN]]([[BORROW]])
-// CHECK: end_borrow [[BORROW]]
-// CHECK: end_access [[ACCESS]]
-// CHECK: } // end sil function '$s8moveonly25borrowAddressFunctionCallyyF'
-func borrowAddressFunctionCall() {
-    var k = Klass()
-    k = Klass()
-    borrowVal(k)
-}
-
-// We currently have the wrong behavior here since the class is treated by
-// LValue emission as a base. That being said, move only classes are not our
-// high order bit here, so I filed a bug. We might be able to do it in the future.
-//
-// CHECK-LABEL: sil hidden [ossa] @$s8moveonly31klassBorrowAddressFunctionCall2yyF : $@convention(thin) () -> () {
-// CHECK: [[MARK:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARK]]
-// CHECK: } // end sil function '$s8moveonly31klassBorrowAddressFunctionCall2yyF'
-func klassBorrowAddressFunctionCall2() {
-    var k = Klass()
-    k = Klass()
-    borrowVal(k.moveOnlyKlass)
-}
-
-// We copy here since we have a class as our base like the above.
-//
-// CHECK-LABEL: sil hidden [ossa] @$s8moveonly38klassBorrowCopyableAddressFunctionCallyyF : $@convention(thin) () -> () {
-// CHECK: bb0:
-// CHECK:  [[CLASS:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK:  [[ACCESS:%.*]] = begin_access [read] [unknown] [[CLASS]]
-// CHECK:  [[LOAD:%.*]] = load [copy] [[ACCESS]]
-// CHECK:  end_access [[ACCESS]]
-// CHECK:  [[BORROW_LOAD:%.*]] = begin_borrow [[LOAD]]
-// CHECK:  [[ADDR:%.*]] = ref_element_addr [[BORROW_LOAD]]
-// CHECK:  [[ACCESS_ADDR:%.*]] = begin_access [read] [dynamic] [[ADDR]]
-// CHECK:  [[BORROWED_COPY_CLASS:%.*]] = load_borrow [[ACCESS_ADDR]]
-// CHECK:  apply {{%.*}}([[BORROWED_COPY_CLASS]])
-// CHECK: } // end sil function '$s8moveonly38klassBorrowCopyableAddressFunctionCallyyF'
-func klassBorrowCopyableAddressFunctionCall() {
-    var k = Klass()
-    k = Klass()
-    borrowVal(k.copyableKlass)
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly29moveOnlyStructNonConsumingUseyyF : $@convention(thin) () -> () {
@@ -363,68 +277,6 @@ func moveOnlyStructNonConsumingUse() {
     borrowVal(k)
 }
 
-// CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMoveC20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK: [[STRUCT_EXT:%.*]] = struct_element_addr [[ACCESS]]
-// CHECK: [[BORROW:%.*]] = load_borrow [[STRUCT_EXT]]
-// CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA5KlassCF
-// CHECK: apply [[FN]]([[BORROW]])
-// CHECK: end_borrow [[BORROW]]
-// CHECK: end_access [[ACCESS]]
-// CHECK: } // end sil function '$s8moveonly018moveOnlyStructMoveC20KlassNonConsumingUseyyF'
-func moveOnlyStructMoveOnlyKlassNonConsumingUse() {
-    var k = NonTrivialStruct()
-    k = NonTrivialStruct()
-    borrowVal(k.moveOnlyKlass)
-}
-
-// We fail here b/c we are accessing through a class.
-//
-// CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovec5KlassecF15NonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK:   [[STRUCT_EXT:%.*]] = struct_element_addr [[ACCESS]]
-// CHECK:   [[STRUCT_EXT_COPY:%.*]] = load [copy] [[STRUCT_EXT]]
-// CHECK:   end_access [[ACCESS]]
-// CHECK:   [[STRUCT_EXT_COPY_BORROW:%.*]] = begin_borrow [[STRUCT_EXT_COPY]]
-// CHECK:   [[ELT_ADDR:%.*]] = ref_element_addr [[STRUCT_EXT_COPY_BORROW]]
-// CHECK:   [[ACCESS_ELT_ADDR:%.*]] = begin_access [read] [dynamic] [[ELT_ADDR]]
-// CHECK:   [[KLS:%.*]] = load_borrow [[ACCESS_ELT_ADDR]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA6Klass2CF
-// CHECK:   apply [[FN]]([[KLS]])
-// CHECK:   end_borrow [[KLS]]
-// CHECK:   destroy_value [[STRUCT_EXT_COPY]]
-// CHECK: } // end sil function '$s8moveonly018moveOnlyStructMovec5KlassecF15NonConsumingUseyyF'
-func moveOnlyStructMoveOnlyKlassMoveOnlyKlassNonConsumingUse() {
-    var k = NonTrivialStruct()
-    k = NonTrivialStruct()
-    borrowVal(k.moveOnlyKlass.moveOnlyKlass)
-}
-
-// We fail here b/c we are accessing through a class.
-//
-// CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovec13KlassCopyableF15NonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK:   [[STRUCT_EXT:%.*]] = struct_element_addr [[ACCESS]]
-// CHECK:   [[STRUCT_EXT_COPY:%.*]] = load [copy] [[STRUCT_EXT]]
-// CHECK:   end_access [[ACCESS]]
-// CHECK:   [[STRUCT_EXT_COPY_BORROW:%.*]] = begin_borrow [[STRUCT_EXT_COPY]]
-// CHECK:   [[FIELD:%.*]] = ref_element_addr [[STRUCT_EXT_COPY_BORROW]]
-// CHECK:   [[ACCESS:%.*]] = begin_access [read] [dynamic] [[FIELD]]
-// CHECK:   [[BORROWED_KLS:%.*]] = load_borrow [[ACCESS]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassCF
-// CHECK:   apply [[FN]]([[BORROWED_KLS]])
-// CHECK:   end_borrow [[BORROWED_KLS]]
-// CHECK:   destroy_value [[STRUCT_EXT_COPY]]
-// CHECK: } // end sil function '$s8moveonly018moveOnlyStructMovec13KlassCopyableF15NonConsumingUseyyF'
-func moveOnlyStructMoveOnlyKlassCopyableKlassNonConsumingUse() {
-    var k = NonTrivialStruct()
-    k = NonTrivialStruct()
-    borrowVal(k.moveOnlyKlass.copyableKlass)
-}
-
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovecD15NonConsumingUseyyF : $@convention(thin) () -> () {
 // CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
@@ -439,23 +291,6 @@ func moveOnlyStructMoveOnlyStructNonConsumingUse() {
     var k = NonTrivialStruct()
     k = NonTrivialStruct()
     borrowVal(k.nonTrivialStruct2)
-}
-
-// CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovecdeC20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
-// CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialStruct2, #NonTrivialStruct2.moveOnlyKlass
-// CHECK:   [[BORROW:%.*]] = load_borrow [[GEP2]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA5KlassCF : $@convention(thin) (@guaranteed Klass) -> ()
-// CHECK:   apply [[FN]]([[BORROW]])
-// CHECK:   end_borrow [[BORROW]]
-// CHECK:   end_access [[ACCESS]]
-// CHECK: } // end sil function '$s8moveonly018moveOnlyStructMovecdeC20KlassNonConsumingUseyyF'
-func moveOnlyStructMoveOnlyStructMoveOnlyKlassNonConsumingUse() {
-    var k = NonTrivialStruct()
-    k = NonTrivialStruct()
-    borrowVal(k.nonTrivialStruct2.moveOnlyKlass)
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovecD28CopyableKlassNonConsumingUseyyF : $@convention(thin) () -> () {
@@ -571,9 +406,10 @@ func moveOnlyStructCopyableStructCopyableStructCopyableKlassNonConsumingUse() {
 // CHECK:   end_access [[ACCESS]]
 // CHECK:   [[BORROWED_COPYABLE_KLASS:%.*]] = begin_borrow [[COPYABLE_KLASS]]
 // CHECK:   [[FIELD:%.*]] = ref_element_addr [[BORROWED_COPYABLE_KLASS]]
-// CHECK:   [[ACCESS:%.*]] = begin_access [read] [dynamic] [[FIELD]]
+// CHECK:   [[FIELD_MARK:%.*]] = mark_must_check [no_consume_or_assign] [[FIELD]]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [dynamic] [[FIELD_MARK]]
 // CHECK:   [[BORROWED_MOVEONLY_KLASS:%.*]] = load_borrow [[ACCESS]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA5KlassCF :
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA2FDVF :
 // CHECK:   apply [[FN]]([[BORROWED_MOVEONLY_KLASS]])
 // CHECK:   end_borrow [[BORROWED_MOVEONLY_KLASS]]
 // CHECK:   destroy_value [[COPYABLE_KLASS]]
@@ -581,7 +417,7 @@ func moveOnlyStructCopyableStructCopyableStructCopyableKlassNonConsumingUse() {
 func moveOnlyStructCopyableStructCopyableStructCopyableKlassMoveOnlyKlassNonConsumingUse() {
     var k = NonTrivialStruct()
     k = NonTrivialStruct()
-    borrowVal(k.nonTrivialCopyableStruct.nonTrivialCopyableStruct2.copyableKlass.k)
+    borrowVal(k.nonTrivialCopyableStruct.nonTrivialCopyableStruct2.copyableKlass.fd)
 }
 
 ///////////////////////
@@ -592,7 +428,7 @@ enum EnumSwitchTests {
     @_moveOnly
     enum E2 {
         case lhs(CopyableKlass)
-        case rhs(Klass)
+        case rhs(FD)
     }
 
     @_moveOnly

--- a/test/SILOptimizer/accesspath_unit.sil
+++ b/test/SILOptimizer/accesspath_unit.sil
@@ -12,6 +12,14 @@ class Klass {
   var f: S
 }
 
+struct S2 {
+  var f: S
+  var k: Klass
+}
+
+sil_global hidden @globalKlass : $Klass
+sil_global hidden @globalStruct : $S2
+
 // CHECK-LABEL: begin running test 1 of 2 on testRefElement: accesspath-base with: @trace[0]
 // CHECK: [[P1:%.*]] = ref_element_addr %0 : $Klass, #Klass.f
 // CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]] : $*S
@@ -20,7 +28,7 @@ class Klass {
 // CHECK: Access path base:  [[P1]] = ref_element_addr %0 : $Klass, #Klass.f
 // CHECK-NEXT: Exact Use:   %{{.*}} = load [trivial] [[A1]] : $*S
 // CHECK-NEXT: Exact Use:   end_access [[A1]] : $*S
-// CHECK-LABEL: end running test 1 of 2 on testRefElement: accesspath-base with: @trace[0]
+// CHECK: end running test 1 of 2 on testRefElement: accesspath-base with: @trace[0]
 
 // CHECK-LABEL: begin running test 2 of 2 on testRefElement: accesspath-base with: @trace[1]
 // CHECK: [[P1:%.*]] = ref_element_addr %0 : $Klass, #Klass.f
@@ -30,7 +38,7 @@ class Klass {
 // CHECK: Access path base:  [[P2]] = ref_element_addr %0 : $Klass, #Klass.f
 // CHECK-NEXT: Exact Use:   %{{.*}} = load [trivial] [[A2]] : $*S
 // CHECK-NEXT: Exact Use:   end_access [[A2]] : $*S
-// CHECK-LABEL: end running test 2 of 2 on testRefElement: accesspath-base with: @trace[1]
+// CHECK: end running test 2 of 2 on testRefElement: accesspath-base with: @trace[1]
 sil hidden [ossa] @testRefElement : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
   test_specification "accesspath-base @trace[0]"
@@ -47,4 +55,118 @@ bb0(%0 : @guaranteed $Klass):
   end_access %a2 : $*S
   %99 = tuple ()
   return %99 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 2 on testGlobalAddrKlass: accesspath-base with: @trace[0]
+// CHECK: [[P1:%.*]] = global_addr @globalKlass : $*Klass
+// CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]] : $*Klass
+// CHECK: [[P2:%.*]] = global_addr @globalKlass : $*Klass
+// CHECK: [[A2:%.*]] = begin_access [read] [dynamic] [[P2]] : $*Klass
+// CHECK: Access path base:  [[P1]] = global_addr @globalKlass : $*Klass
+// CHECK-NEXT: Exact Use:   %{{.*}} = load_borrow [[A1]]
+// CHECK-NEXT: Exact Use:   end_access [[A1]]
+// CHECK: end running test 1 of 2 on testGlobalAddrKlass: accesspath-base with: @trace[0]
+
+// CHECK-LABEL: begin running test 2 of 2 on testGlobalAddrKlass: accesspath-base with: @trace[1]
+// CHECK: [[P1:%.*]] = global_addr @globalKlass : $*Klass
+// CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]] : $*Klass
+// CHECK: [[P2:%.*]] = global_addr @globalKlass : $*Klass
+// CHECK: [[A2:%.*]] = begin_access [read] [dynamic] [[P2]] : $*Klass
+// CHECK: Access path base:  [[P2]] = global_addr @globalKlass : $*Klass
+// CHECK-NEXT: Exact Use:   %{{.*}} = load_borrow [[A2]]
+// CHECK-NEXT: Exact Use:   end_access [[A2]]
+// CHECK: end running test 2 of 2 on testGlobalAddrKlass: accesspath-base with: @trace[1]
+sil [ossa] @testGlobalAddrKlass : $@convention(thin) () -> () {
+bb0:
+  test_specification "accesspath-base @trace[0]"
+  %p1 = global_addr @globalKlass : $*Klass
+  debug_value [trace] %p1 : $*Klass
+  %a1 = begin_access [read] [dynamic] %p1 : $*Klass
+  %l1 = load_borrow %a1 : $*Klass
+  end_borrow %l1 : $Klass
+  end_access %a1 : $*Klass
+
+  test_specification "accesspath-base @trace[1]"
+  %p2 = global_addr @globalKlass : $*Klass
+  debug_value [trace] %p2 : $*Klass
+  %a2 = begin_access [read] [dynamic] %p2 : $*Klass
+  %l2 = load_borrow %a2 : $*Klass
+  end_borrow %l2 : $Klass
+  end_access %a2 : $*Klass
+
+  %9999 = tuple ()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[0]
+// CHECK: [[P1:%.*]] = global_addr @globalStruct
+// CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]]
+// CHECK: [[P2:%.*]] = global_addr @globalStruct
+// CHECK: [[A2:%.*]] = begin_access [read] [dynamic] [[P2]]
+// CHECK: [[GEP2:%.*]] = struct_element_addr [[A2]]
+// CHECK: [[P3:%.*]] = global_addr @globalStruct
+// CHECK: [[A3:%.*]] = begin_access [read] [dynamic] [[P3]]
+// CHECK: [[GEP3:%.*]] = struct_element_addr [[A3]]
+// CHECK: Access path base:  [[P1]] = global_addr @globalStruct
+// CHECK-NEXT: Exact Use:   %{{.*}} = load_borrow [[A1]]
+// CHECK-NEXT: Exact Use:   end_access [[A1]]
+// CHECK: end running test 1 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[0]
+
+// CHECK-LABEL: begin running test 2 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[1]
+// CHECK: [[P1:%.*]] = global_addr @globalStruct
+// CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]]
+// CHECK: [[P2:%.*]] = global_addr @globalStruct
+// CHECK: [[A2:%.*]] = begin_access [read] [dynamic] [[P2]]
+// CHECK: [[GEP2:%.*]] = struct_element_addr [[A2]]
+// CHECK: [[P3:%.*]] = global_addr @globalStruct
+// CHECK: [[A3:%.*]] = begin_access [read] [dynamic] [[P3]]
+// CHECK: [[GEP3:%.*]] = struct_element_addr [[A3]]
+// CHECK: Access path base:  [[P2]] = global_addr @globalStruct
+// CHECK-NEXT: Inner Use:   %{{.*}} = load_borrow [[GEP2]]
+// CHECK-NEXT: Exact Use:   end_access [[A2]]
+// CHECK: end running test 2 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[1]
+
+// CHECK-LABEL: begin running test 3 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[2]
+// CHECK: [[P1:%.*]] = global_addr @globalStruct
+// CHECK: [[A1:%.*]] = begin_access [read] [dynamic] [[P1]]
+// CHECK: [[P2:%.*]] = global_addr @globalStruct
+// CHECK: [[A2:%.*]] = begin_access [read] [dynamic] [[P2]]
+// CHECK: [[GEP2:%.*]] = struct_element_addr [[A2]]
+// CHECK: [[P3:%.*]] = global_addr @globalStruct
+// CHECK: [[A3:%.*]] = begin_access [read] [dynamic] [[P3]]
+// CHECK: [[GEP3:%.*]] = struct_element_addr [[A3]]
+// CHECK: Access path base:  [[P3]] = global_addr @globalStruct
+// CHECK-NEXT: Inner Use:   %{{.*}} = load_borrow [[GEP3]]
+// CHECK-NEXT: Exact Use:   end_access [[A3]]
+// CHECK: end running test 3 of 3 on testGlobalAddrStruct: accesspath-base with: @trace[2]
+sil [ossa] @testGlobalAddrStruct : $@convention(thin) () -> () {
+bb0:
+  test_specification "accesspath-base @trace[0]"
+  %p3 = global_addr @globalStruct : $*S2
+  debug_value [trace] %p3 : $*S2
+  %a3 = begin_access [read] [dynamic] %p3 : $*S2
+  %l3 = load_borrow %a3 : $*S2
+  end_borrow %l3 : $S2
+  end_access %a3 : $*S2
+
+  test_specification "accesspath-base @trace[1]"
+  %p4 = global_addr @globalStruct : $*S2
+  debug_value [trace] %p4 : $*S2
+  %a4 = begin_access [read] [dynamic] %p4 : $*S2
+  %gep4 = struct_element_addr %a4 : $*S2, #S2.k
+  %l4 = load_borrow %gep4 : $*Klass
+  end_borrow %l4 : $Klass
+  end_access %a4 : $*S2
+
+  test_specification "accesspath-base @trace[2]"
+  %p5 = global_addr @globalStruct : $*S2
+  debug_value [trace] %p5 : $*S2
+  %a5 = begin_access [read] [dynamic] %p5 : $*S2
+  %gep5 = struct_element_addr %a5 : $*S2, #S2.k
+  %l5 = load_borrow %gep5 : $*Klass
+  end_borrow %l5 : $Klass
+  end_access %a5 : $*S2
+
+  %9999 = tuple()
+  return %9999 : $()
 }

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -26,6 +26,8 @@ public struct NonTrivialStruct {
     var nonTrivialStruct2 = NonTrivialStruct2()
 }
 
+sil @useNonTrivialStruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+
 @_moveOnly
 public struct NonTrivialStructPair {
     var lhs: NonTrivialStruct
@@ -39,6 +41,10 @@ public struct NonTrivialStruct2 {
 
 @_moveOnly struct MyBufferView<T> {
   var ptr: UnsafeBufferPointer<T>
+}
+
+final class ClassContainingMoveOnly {
+  var value = NonTrivialStruct()
 }
 
 ///////////
@@ -339,4 +345,20 @@ bb0(%0 : $UnsafeBufferPointer<T>, %1 : $*MyBufferView<T>):
   end_access %5 : $*MyBufferView<T>
   %9 = tuple ()
   return %9 : $()
+}
+
+// Just make sure that we accept this and do not crash. There isn't any
+// transformation to perform.
+sil [ossa] @test_ref_element_addr_borrow_use : $@convention(thin) (@guaranteed ClassContainingMoveOnly) -> () {
+bb0(%0 : @guaranteed $ClassContainingMoveOnly):
+  %f = function_ref @useNonTrivialStruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  %1 = ref_element_addr %0 : $ClassContainingMoveOnly, #ClassContainingMoveOnly.value
+  %2 = mark_must_check [no_consume_or_assign] %1 : $*NonTrivialStruct
+  %3 = begin_access [read] [dynamic] %2 : $*NonTrivialStruct
+  %4 = load_borrow %3 : $*NonTrivialStruct
+  apply %f(%4) : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  end_borrow %4 : $NonTrivialStruct
+  end_access %3 : $*NonTrivialStruct
+  %9999 = tuple()
+  return %9999 : $()
 }

--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s | %FileCheck %s
+// RUN: %target-sil-opt -module-name moveonly_addresschecker -sil-move-only-address-checker -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s | %FileCheck %s
 
 sil_stage raw
 
@@ -39,6 +39,8 @@ public struct NonTrivialStruct2 {
     var copyableKlass = CopyableKlass()
 }
 
+sil @useNonTrivialStruct2 : $@convention(thin) (@guaranteed NonTrivialStruct2) -> ()
+
 @_moveOnly struct MyBufferView<T> {
   var ptr: UnsafeBufferPointer<T>
 }
@@ -46,6 +48,11 @@ public struct NonTrivialStruct2 {
 final class ClassContainingMoveOnly {
   var value = NonTrivialStruct()
 }
+
+@_hasStorage @_hasInitialValue var varGlobal: NonTrivialStruct { get set }
+@_hasStorage @_hasInitialValue let letGlobal: NonTrivialStruct { get }
+sil_global hidden @$s23moveonly_addresschecker9varGlobalAA16NonTrivialStructVvp : $NonTrivialStruct
+sil_global hidden [let] @$s23moveonly_addresschecker9letGlobalAA16NonTrivialStructVvp : $NonTrivialStruct
 
 ///////////
 // Tests //
@@ -347,8 +354,8 @@ bb0(%0 : $UnsafeBufferPointer<T>, %1 : $*MyBufferView<T>):
   return %9 : $()
 }
 
-// Just make sure that we accept this and do not crash. There isn't any
-// transformation to perform.
+// No transformation here, just make sure that we treat the mark_must_check as
+// the def so that we don't crash.
 sil [ossa] @test_ref_element_addr_borrow_use : $@convention(thin) (@guaranteed ClassContainingMoveOnly) -> () {
 bb0(%0 : @guaranteed $ClassContainingMoveOnly):
   %f = function_ref @useNonTrivialStruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
@@ -361,4 +368,43 @@ bb0(%0 : @guaranteed $ClassContainingMoveOnly):
   end_access %3 : $*NonTrivialStruct
   %9999 = tuple()
   return %9999 : $()
+}
+
+// No transformation here, just make sure that we treat the mark_must_check as
+// the def so that we don't crash.
+sil [ossa] @test_global_addr_borrow_use : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @$s23moveonly_addresschecker9varGlobalAA16NonTrivialStructVvp : $*NonTrivialStruct
+  %1 = mark_must_check [no_consume_or_assign] %0 : $*NonTrivialStruct
+  %2 = begin_access [read] [dynamic] %1 : $*NonTrivialStruct
+  %3 = load_borrow %2 : $*NonTrivialStruct
+  %4 = function_ref @useNonTrivialStruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  %5 = apply %4(%3) : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  end_borrow %3 : $NonTrivialStruct
+  end_access %2 : $*NonTrivialStruct
+  %8 = tuple ()
+  return %8 : $()
+}
+
+// Make sure that we do not emit any errors here.
+sil [ossa] @test_global_addr_multiple_borrow_uses : $@convention(thin) () -> () {
+bb0:
+  %0 = global_addr @$s23moveonly_addresschecker9varGlobalAA16NonTrivialStructVvp : $*NonTrivialStruct
+  %1 = mark_must_check [no_consume_or_assign] %0 : $*NonTrivialStruct
+  %2 = begin_access [read] [dynamic] %1 : $*NonTrivialStruct
+  %3 = load_borrow %2 : $*NonTrivialStruct
+  %4 = function_ref @useNonTrivialStruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  %5 = apply %4(%3) : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  end_borrow %3 : $NonTrivialStruct
+  end_access %2 : $*NonTrivialStruct
+  %0a = global_addr @$s23moveonly_addresschecker9varGlobalAA16NonTrivialStructVvp : $*NonTrivialStruct
+  %8 = begin_access [read] [dynamic] %0a : $*NonTrivialStruct
+  %9 = struct_element_addr %8 : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
+  %10 = load_borrow %9 : $*NonTrivialStruct2
+  %11 = function_ref @useNonTrivialStruct2 : $@convention(thin) (@guaranteed NonTrivialStruct2) -> ()
+  %12 = apply %11(%10) : $@convention(thin) (@guaranteed NonTrivialStruct2) -> ()
+  end_borrow %10 : $NonTrivialStruct2
+  end_access %8 : $*NonTrivialStruct
+  %15 = tuple ()
+  return %15 : $()
 }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -26,6 +26,7 @@ public func consumeVal(_ x: __owned AggStruct) {}
 public func consumeVal(_ x: __owned AggGenericStruct<CopyableKlass>) {}
 public func consumeVal<T>(_ x: __owned AggGenericStruct<T>) {}
 public func consumeVal(_ x: __owned EnumTy) {}
+public func consumeVal(_ x: __owned NonTrivialStruct) {}
 
 @_moveOnly
 public final class Klass {
@@ -72,6 +73,11 @@ public enum NonTrivialEnum {
 @_moveOnly
 public final class FinalKlass {
     var k: Klass = Klass()
+}
+
+public final class CopyableKlassWithMoveOnlyField {
+    var moveOnlyVarStruct = NonTrivialStruct()
+    let moveOnlyLetStruct = NonTrivialStruct()
 }
 
 ///////////
@@ -395,8 +401,10 @@ public func classAccessConsumeField(_ x: Klass) { // expected-error {{'x' has gu
     x2 = Klass()
     // Since a class is a reference type, we do not emit an error here.
     consumeVal(x2.k) // expected-note {{consuming use here}}
+    // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     for _ in 0..<1024 {
         consumeVal(x2.k) // expected-note {{consuming use here}}
+        // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     }
 }
 
@@ -405,8 +413,11 @@ public func classAccessConsumeFieldArg(_ x2: inout Klass) {
     // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     // Since a class is a reference type, we do not emit an error here.
     consumeVal(x2.k) // expected-note {{consuming use here}}
+    // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+
     for _ in 0..<1024 {
         consumeVal(x2.k) // expected-note {{consuming use here}}
+        // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     }
 }
 
@@ -695,8 +706,10 @@ public func finalClassConsumeField() {
     x2 = FinalKlass()
 
     consumeVal(x2.k) // expected-note {{consuming use here}}
+    // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     for _ in 0..<1024 {
         consumeVal(x2.k) // expected-note {{consuming use here}}
+        // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     }
 }
 
@@ -704,8 +717,10 @@ public func finalClassConsumeFieldArg(_ x2: inout FinalKlass) {
     // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     consumeVal(x2.k) // expected-note {{consuming use here}}
+    // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     for _ in 0..<1024 {
         consumeVal(x2.k) // expected-note {{consuming use here}}
+        // expected-error @-1 {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     }
 }
 
@@ -2097,9 +2112,8 @@ public func closureAndClosureCaptureClassUseAfterConsume() {
     // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
     // expected-error @-3 {{'x2' consumed more than once}}
     // expected-error @-4 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-5 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-6 {{'x2' consumed more than once}}
-    // expected-error @-7 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-5 {{'x2' consumed more than once}}
+    // expected-error @-6 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = Klass()
     let f = {
         let g = {
@@ -2125,8 +2139,7 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
     // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-4 {{'x2' consumed more than once}}
     // expected-error @-5 {{'x2' consumed more than once}}
-    // expected-error @-6 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-7 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-6 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = Klass()
     let f = {
         let g = {
@@ -2409,4 +2422,26 @@ func inoutAndConsumingUse(_ k: inout Klass) { // expected-error {{'k' used after
     // expected-note @-1 {{non-consuming use here}}
     // expected-note @-2 {{consuming use here}}
     // expected-note @-3 {{conflicting access is here}}
+}
+
+////////////////////////////
+// Ref Element Addr Tests //
+////////////////////////////
+
+func copyableKlassWithMoveOnlyFieldBorrowValue(_ x: CopyableKlassWithMoveOnlyField) {
+    borrowVal(x.moveOnlyVarStruct)
+    borrowVal(x.moveOnlyLetStruct)
+}
+
+func copyableKlassWithMoveOnlyFieldConsumeValue(_ x: CopyableKlassWithMoveOnlyField) {
+    consumeVal(x.moveOnlyVarStruct)
+    // expected-error @-1 {{'x.moveOnlyVarStruct' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
+
+    // TODO: We should place a note on x. We need to make the diagnostic part of
+    // this a little smarter.
+    consumeVal(x.moveOnlyLetStruct) // expected-error {{'x.moveOnlyLetStruct' was consumed but it is illegal to consume a noncopyable class let field. One can only read from it}}
+}
+
+func copyableKlassWithMoveOnlyFieldAssignValue(_ x: CopyableKlassWithMoveOnlyField) {
+    x.moveOnlyVarStruct = NonTrivialStruct()
 }

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -359,26 +359,23 @@ public func classAccessAccessFieldOwnedArg(_ x2: __owned Klass) {
 
 public func classAccessConsumeField(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // Since a class is a reference type, we do not emit an error here.
-    consumeVal(x2.k)
+    consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     for _ in 0..<1024 {
-        consumeVal(x2.k)
+        consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     }
 }
 
 public func classAccessConsumeFieldArg(_ x2: Klass) {
-    // Since a class is a reference type, we do not emit an error here.
-    consumeVal(x2.k)
+    consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     for _ in 0..<1024 {
-        consumeVal(x2.k)
+        consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     }
 }
 
 public func classAccessConsumeFieldOwnedArg(_ x2: __owned Klass) {
-    // Since a class is a reference type, we do not emit an error here.
-    consumeVal(x2.k)
+    consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     for _ in 0..<1024 {
-        consumeVal(x2.k)
+        consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     }
 }
 
@@ -696,30 +693,25 @@ public func finalClassAccessFieldOwnedArg(_ x2: __owned FinalKlass) {
 
 public func finalClassConsumeField(_ x: FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-
-    // No diagnostic here since class is a reference type and we are not copying
-    // the class, we are copying its field.
-    consumeVal(x2.k)
+    consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     for _ in 0..<1024 {
-        consumeVal(x2.k)
+        consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     }
 }
 
 public func finalClassConsumeFieldArg(_ x2: FinalKlass) {
-    // No diagnostic here since class is a reference type and we are not copying
-    // the class, we are copying its field.
-    consumeVal(x2.k)
+    consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     for _ in 0..<1024 {
-        consumeVal(x2.k)
+        consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     }
 }
 
 public func finalClassConsumeFieldArg(_ x2: __owned FinalKlass) {
     // No diagnostic here since class is a reference type and we are not copying
     // the class, we are copying its field.
-    consumeVal(x2.k)
+    consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     for _ in 0..<1024 {
-        consumeVal(x2.k)
+        consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     }
 }
 

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1402,11 +1402,10 @@ public func closureAndClosureCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
     // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-3 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-4 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-4 {{'x2' consumed more than once}}
     // expected-error @-5 {{'x2' consumed more than once}}
-    // expected-error @-6 {{'x2' consumed more than once}}
-    // expected-error @-7 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-6 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = NonTrivialStruct()
     let f = {
         let g = {
@@ -1429,11 +1428,10 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
     // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-3 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-4 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-4 {{'x2' consumed more than once}}
     // expected-error @-5 {{'x2' consumed more than once}}
-    // expected-error @-6 {{'x2' consumed more than once}}
-    // expected-error @-7 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-6 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = NonTrivialStruct()
     let f = {
         let g = {


### PR DESCRIPTION
Taking care of:

rdar://104874497
rdar://102794400