### PR TITLE
[Backtracing] Add support for building target executables into libexec.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -49,6 +49,11 @@ set(SWIFTLIB_DIR
 set(SWIFTSTATICLIB_DIR
     "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib/swift_static")
 
+# SWIFTLIBEXEC_DIR is the directory in the build tree where Swift auxiliary
+# executables should be placed.
+set(SWIFTLIBEXEC_DIR
+    "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/libexec/swift")
+
 function(_compute_lto_flag option out_var)
   string(TOLOWER "${option}" lowercase_option)
   if (lowercase_option STREQUAL "full")


### PR DESCRIPTION
We're going to add a program, `swift-backtrace`, that gets built alongside the stdlib and the runtime, and that needs to be installed in libexec/swift alongside the libraries in lib/swift.

It wants to be built with the stdlib/runtime because there's an internal interface between `swift-backtrace` and the runtime, so the program needs to stay in lock-step with the runtime library.

rdar://105390807
