### PR TITLE
[Backtracing] Add `swift-backtrace` to the build.

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -172,3 +172,5 @@ if(SWIFT_BUILD_SDK_OVERLAY)
     add_subdirectory(Windows)
   endif()
 endif()
+
+add_subdirectory(libexec)

--- a/stdlib/public/libexec/CMakeLists.txt
+++ b/stdlib/public/libexec/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(swift-backtrace)

--- a/stdlib/public/libexec/README.txt
+++ b/stdlib/public/libexec/README.txt
@@ -1,0 +1,8 @@
+What is this?
+=============
+
+The libexec directory contains the source code for auxiliary executables that
+ship with the Swift runtime, as opposed to being part of the toolchain.
+
+On UNIX-like platforms, if the runtime is installed in /usr/lib/swift (for
+instance), these are things that you would expect to find in /usr/libexec/swift.

--- a/stdlib/public/libexec/swift-backtrace/AnsiColor.swift
+++ b/stdlib/public/libexec/swift-backtrace/AnsiColor.swift
@@ -1,0 +1,159 @@
+//===--- AnsiColor.swift - ANSI formatting control codes ------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Provides ANSI support via Swift string interpolation.
+//
+//===----------------------------------------------------------------------===//
+
+enum AnsiColor {
+  case normal
+  case black
+  case red
+  case green
+  case yellow
+  case blue
+  case magenta
+  case cyan
+  case white
+  case gray
+  case brightRed
+  case brightGreen
+  case brightYellow
+  case brightBlue
+  case brightMagenta
+  case brightCyan
+  case brightWhite
+  case rgb(r: Int, g: Int, b: Int)
+  case grayscale(Int)
+
+  var foregroundCode: String {
+    switch self {
+      case .normal:        return "39"
+      case .black:         return "30"
+      case .red:           return "31"
+      case .green:         return "32"
+      case .yellow:        return "33"
+      case .blue:          return "34"
+      case .cyan:          return "35"
+      case .magenta:       return "36"
+      case .white:         return "37"
+      case .gray:          return "90"
+      case .brightRed:     return "91"
+      case .brightGreen:   return "92"
+      case .brightYellow:  return "93"
+      case .brightBlue:    return "94"
+      case .brightCyan:    return "95"
+      case .brightMagenta: return "96"
+      case .brightWhite:   return "97"
+      case let .rgb(r, g, b):
+        let ndx = 16 + 36 * r + 6 * g + b
+        return "38;5;\(ndx)"
+      case let .grayscale(g):
+        let ndx = 232 + g
+        return "38;5;\(ndx)"
+    }
+  }
+
+  var backgroundCode: String {
+    switch self {
+      case .normal:        return "49"
+      case .black:         return "40"
+      case .red:           return "41"
+      case .green:         return "42"
+      case .yellow:        return "43"
+      case .blue:          return "44"
+      case .cyan:          return "45"
+      case .magenta:       return "46"
+      case .white:         return "47"
+      case .gray:          return "100"
+      case .brightRed:     return "101"
+      case .brightGreen:   return "102"
+      case .brightYellow:  return "103"
+      case .brightBlue:    return "104"
+      case .brightCyan:    return "105"
+      case .brightMagenta: return "106"
+      case .brightWhite:   return "107"
+      case let .rgb(r, g, b):
+        let ndx = 16 + 36 * r + 6 * g + b
+        return "48;5;\(ndx)"
+      case let .grayscale(g):
+        let ndx = 232 + g
+        return "48;5;\(ndx)"
+    }
+  }
+}
+
+enum AnsiWeight {
+  case normal
+  case bold
+  case faint
+
+  var code: String {
+    switch self {
+      case .normal: return "22"
+      case .bold: return "1"
+      case .faint: return "2"
+    }
+  }
+}
+
+enum AnsiAttribute {
+  case fg(AnsiColor)
+  case bg(AnsiColor)
+  case weight(AnsiWeight)
+  case inverse(Bool)
+}
+
+extension DefaultStringInterpolation {
+  mutating func appendInterpolation(ansi attrs: AnsiAttribute...) {
+    var code = "\u{1b}["
+    var first = true
+    for attr in attrs {
+      if first {
+        first = false
+      } else {
+        code += ";"
+      }
+
+      switch attr {
+        case let .fg(color):
+          code += color.foregroundCode
+        case let .bg(color):
+          code += color.backgroundCode
+        case let .weight(weight):
+          code += weight.code
+        case let .inverse(enabled):
+          if enabled {
+            code += "7"
+          } else {
+            code += "27"
+          }
+      }
+    }
+    code += "m"
+
+    appendInterpolation(code)
+  }
+
+  mutating func appendInterpolation(fg: AnsiColor) {
+    return appendInterpolation(ansi: .fg(fg))
+  }
+  mutating func appendInterpolation(bg: AnsiColor) {
+    return appendInterpolation(ansi: .bg(bg))
+  }
+  mutating func appendInterpolation(weight: AnsiWeight) {
+    return appendInterpolation(ansi: .weight(weight))
+  }
+  mutating func appendInterpolation(inverse: Bool) {
+    return appendInterpolation(ansi: .inverse(inverse))
+  }
+}

--- a/stdlib/public/libexec/swift-backtrace/CMakeLists.txt
+++ b/stdlib/public/libexec/swift-backtrace/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_swift_target_executable(swift-backtrace BUILD_WITH_STDLIB
+  main.swift
+  AnsiColor.swift
+  Target.swift
+  Themes.swift
+  Utils.swift
+
+  SWIFT_MODULE_DEPENDS
+    _Backtracing
+
+  INSTALL_IN_COMPONENT stdlib
+  COMPILE_FLAGS -parse-as-library)

--- a/stdlib/public/libexec/swift-backtrace/Target.swift
+++ b/stdlib/public/libexec/swift-backtrace/Target.swift
@@ -1,0 +1,350 @@
+//===--- Target.swift - Represents a process we are inspecting ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Defines `Target`, which represents the process we are inspecting.
+//  There are a lot of system specifics in this file!
+//
+//===----------------------------------------------------------------------===//
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+
+import Darwin
+import Darwin.Mach
+
+import _Backtracing
+@_spi(Internal) import _Backtracing
+@_spi(Contexts) import _Backtracing
+@_spi(MemoryReaders) import _Backtracing
+
+import _SwiftBacktracingShims
+
+#if arch(x86_64)
+typealias MContext = darwin_x86_64_mcontext
+#elseif arch(arm64) || arch(arm64_32)
+typealias MContext = darwin_arm64_mcontext
+#else
+#error("You need to define MContext for this architecture")
+#endif
+
+extension thread_extended_info {
+  var pth_swiftName: String {
+    withUnsafePointer(to: pth_name) { ptr in
+      let len = strnlen(ptr, Int(MAXTHREADNAMESIZE))
+      return ptr.withMemoryRebound(to: UInt8.self,
+                                   capacity: Int(MAXTHREADNAMESIZE)) {
+        u8ptr in
+        return String(decoding: UnsafeBufferPointer(start: u8ptr, count: Int(len)),
+                      as: UTF8.self)
+      }
+    }
+  }
+}
+
+struct TargetThread {
+  typealias ThreadID = UInt64
+
+  var id: ThreadID
+  var context: HostContext?
+  var name: String
+  var backtrace: SymbolicatedBacktrace
+}
+
+class Target {
+  typealias Address = UInt64
+
+  var pid: pid_t
+  var name: String
+  var signal: UInt64
+  var faultAddress: Address
+  var crashingThread: TargetThread.ThreadID
+
+  var task: mach_port_t
+  var images: [Backtrace.Image] = []
+  var sharedCacheInfo: Backtrace.SharedCacheInfo
+
+  var threads: [TargetThread] = []
+  var crashingThreadNdx: Int = -1
+
+  var signalName: String {
+    switch signal {
+      case UInt64(SIGQUIT): return "SIGQUIT"
+      case UInt64(SIGABRT): return "SIGABRT"
+      case UInt64(SIGBUS):  return "SIGBUS"
+      case UInt64(SIGFPE): return "SIGFPE"
+      case UInt64(SIGILL): return "SIGILL"
+      case UInt64(SIGSEGV): return "SIGSEGV"
+      case UInt64(SIGTRAP): return "SIGTRAP"
+      default: return "\(signal)"
+    }
+  }
+
+  var signalDescription: String {
+    switch signal {
+      case UInt64(SIGQUIT): return "Terminated"
+      case UInt64(SIGABRT): return "Aborted"
+      case UInt64(SIGBUS): return "Bus error"
+      case UInt64(SIGFPE): return "Floating point exception"
+      case UInt64(SIGILL): return "Illegal instruction"
+      case UInt64(SIGSEGV): return "Bad pointer dereference"
+      case UInt64(SIGTRAP): return "System trap"
+      default:
+        return "Signal \(signal)"
+    }
+  }
+
+  var reader: RemoteMemoryReader
+
+  var mcontext: MContext
+
+  static func getParentTask() -> mach_port_t? {
+    var ports: mach_port_array_t? = nil
+    var portCount: mach_msg_type_number_t = 0
+
+    // For some reason, we can't pass a task read port this way, but we
+    // *can* pass the control port.  So do that and then ask for a read port
+    // before immediately dropping the control port from this process.
+
+    let kr = mach_ports_lookup(mach_task_self_, &ports, &portCount)
+    if kr != KERN_SUCCESS {
+      return nil
+    }
+
+    if let ports = ports, portCount != 0 {
+      var taskPort: mach_port_t = 0
+      let kr = task_get_special_port(ports[0], TASK_READ_PORT, &taskPort)
+      if kr != KERN_SUCCESS {
+        mach_port_deallocate(mach_task_self_, ports[0])
+        return nil
+      }
+      mach_port_deallocate(mach_task_self_, ports[0])
+      return taskPort
+    } else {
+      return nil
+    }
+  }
+
+  static func getProcessName(pid: pid_t) -> String {
+    let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: 4096)
+    defer {
+      buffer.deallocate()
+    }
+    let ret = proc_name(pid, buffer.baseAddress, UInt32(buffer.count))
+    if ret <= 0 {
+      return "<unknown>"
+    } else {
+      return String(decoding: buffer[0..<Int(ret)], as: UTF8.self)
+    }
+  }
+
+  init(crashInfoAddr: UInt64, limit: Int?, top: Int) {
+    pid = getppid()
+    if let parentTask = Self.getParentTask() {
+      task = parentTask
+    } else {
+      print("swift-backtrace: couldn't fetch parent task")
+      exit(1)
+    }
+
+    reader = RemoteMemoryReader(task: task)
+
+    name = Self.getProcessName(pid: pid)
+
+    let crashInfo: CrashInfo
+    do {
+      crashInfo = try reader.fetch(from: crashInfoAddr, as: CrashInfo.self)
+    } catch {
+      print("swift-backtrace: unable to fetch crash info.")
+      exit(1)
+    }
+
+    crashingThread = crashInfo.crashing_thread
+    signal = crashInfo.signal
+    faultAddress = crashInfo.fault_address
+
+    guard let mctx: MContext = try? reader.fetch(from: crashInfo.mctx,
+                                                 as: MContext.self) else {
+      print("swift-backtrace: unable to fetch mcontext.")
+      exit(1)
+    }
+
+    mcontext = mctx
+
+    images = Backtrace.captureImages(for: task)
+    sharedCacheInfo = Backtrace.captureSharedCacheInfo(for: task)
+
+    fetchThreads(limit: limit, top: top)
+  }
+
+  func fetchThreads(limit: Int?, top: Int) {
+    var threadPorts: thread_act_array_t? = nil
+    var threadCount: mach_msg_type_number_t = 0
+    let kr = task_threads(task,
+                          &threadPorts,
+                          &threadCount)
+
+    if kr != KERN_SUCCESS {
+      print("swift-backtrace: failed to enumerate threads - \(kr)")
+      exit(1)
+    }
+
+    guard let ports = threadPorts else {
+      print("swift-backtrace: thread array is nil")
+      exit(1)
+    }
+
+    for ndx in 0..<threadCount {
+      var threadIdInfo: thread_identifier_info_data_t? = nil
+      var kr = mach_thread_info(ports[Int(ndx)], THREAD_IDENTIFIER_INFO,
+                                &threadIdInfo)
+      if kr != KERN_SUCCESS {
+        print("swift-backtrace: unable to get thread info for thread \(ndx) - \(kr)")
+        exit(1)
+      }
+
+      guard let info = threadIdInfo else {
+        print("swift-backtrace: thread info is nil")
+        exit(1)
+      }
+
+      var extInfo = thread_extended_info_data_t()
+
+      let threadName: String
+
+      kr = mach_thread_info(ports[Int(ndx)],
+                            THREAD_EXTENDED_INFO,
+                            &extInfo)
+      if kr == KERN_SUCCESS {
+        threadName = extInfo.pth_swiftName
+      } else {
+        print("unable to fetch ext info \(kr)")
+        threadName = ""
+      }
+
+      let ctx: HostContext
+
+      if info.thread_id == crashingThread {
+        ctx = HostContext.fromHostMContext(mcontext)
+        crashingThreadNdx = Int(ndx)
+      } else {
+        guard let threadCtx = HostContext.fromHostThread(ports[Int(ndx)]) else {
+          // This can happen legitimately, e.g. when looking at a Rosetta 2
+          // process, where there are ARM64 threads AS WELL AS the x86_64 ones.
+          continue
+        }
+        ctx = threadCtx
+      }
+
+      guard let backtrace = try? Backtrace.capture(from: ctx,
+                                                   using: reader,
+                                                   limit: limit,
+                                                   top: top) else {
+        print("unable to capture backtrace from context for thread \(ndx)")
+        exit(1)
+      }
+
+      guard let symbolicated = backtrace.symbolicated(with: images,
+                                                      sharedCacheInfo: sharedCacheInfo) else {
+        print("unable to symbolicate backtrace from context for thread \(ndx)")
+        exit(1)
+      }
+
+      threads.append(TargetThread(id: info.thread_id,
+                                  context: ctx,
+                                  name: threadName,
+                                  backtrace: symbolicated))
+
+      mach_port_deallocate(mach_task_self_, ports[Int(ndx)])
+    }
+  }
+
+  public func redoBacktraces(limit: Int?, top: Int) {
+    for (ndx, thread) in threads.enumerated() {
+      guard let context = thread.context else {
+        continue
+      }
+
+      guard let backtrace = try? Backtrace.capture(from: context,
+                                                   using: reader,
+                                                   limit: limit,
+                                                   top: top) else {
+        print("unable to capture backtrace from context for thread \(ndx)")
+        continue
+      }
+
+      guard let symbolicated = backtrace.symbolicated(with: images,
+                                                      sharedCacheInfo: sharedCacheInfo) else {
+        print("unable to symbolicate backtrace from context for thread \(ndx)")
+        continue
+      }
+
+      threads[ndx].backtrace = symbolicated
+    }
+  }
+
+  public func withDebugger(_ body: () -> ()) throws {
+    #if os(macOS)
+    return try withTemporaryDirectory(pattern: "/tmp/backtrace.XXXXXXXX") {
+      tmpdir in
+
+      let cmdfile = "\(tmpdir)/lldb.command"
+      guard let fp = fopen(cmdfile, "wt") else {
+        throw PosixError(errno: errno)
+      }
+      if fputs("""
+                 #!/bin/bash
+                 clear
+                 echo "Once LLDB has attached, return to the other window and press any key"
+                 echo ""
+                 xcrun lldb --attach-pid \(pid) -o c
+                 """, fp) == EOF {
+        throw PosixError(errno: errno)
+      }
+      if fclose(fp) != 0 {
+        throw PosixError(errno: errno)
+      }
+      if chmod(cmdfile, S_IXUSR|S_IRUSR) != 0 {
+        throw PosixError(errno: errno)
+      }
+
+      try spawn("/usr/bin/open", args: ["open", cmdfile])
+
+      body()
+    }
+    #else
+    print("""
+            From another shell, please run
+
+            lldb --attach-pid \(target.pid) -o c
+            """)
+    body()
+    #endif
+  }
+}
+
+private func mach_thread_info<T>(_ thread: thread_t,
+                                 _ flavor: CInt,
+                                 _ result: inout T) -> kern_return_t {
+  var count: mach_msg_type_number_t
+    = mach_msg_type_number_t(MemoryLayout<T>.stride
+                               / MemoryLayout<natural_t>.stride)
+
+  return withUnsafeMutablePointer(to: &result) { ptr in
+    ptr.withMemoryRebound(to: natural_t.self, capacity: Int(count)) { intPtr in
+      return thread_info(thread,
+                         thread_flavor_t(flavor),
+                         intPtr,
+                         &count)
+    }
+  }
+}
+
+#endif // os(macOS) || os(iOS) || os(watchOS) || os(tvOS)

--- a/stdlib/public/libexec/swift-backtrace/Themes.swift
+++ b/stdlib/public/libexec/swift-backtrace/Themes.swift
@@ -1,0 +1,169 @@
+//===--- Themes.swift - Represents a process we are inspecting ------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  Defines the `Theme` struct that we use for color support.
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(Formatting) import _Backtracing
+
+protocol ErrorAndWarningTheme {
+  func crashReason(_ s: String) -> String
+  func error(_ s: String) -> String
+  func warning(_ s: String) -> String
+  func info(_ s: String) -> String
+}
+
+extension ErrorAndWarningTheme {
+  public func crashReason(_ s: String) -> String { return "*** \(s) ***" }
+  public func error(_ s: String) -> String { return   "!!! error: \(s)" }
+  public func warning(_ s: String) -> String { return "/!\\ warning: \(s)" }
+  public func info(_ s: String) -> String { return "(i) \(s)" }
+}
+
+protocol PromptTheme {
+  func prompt(_ s: String) -> String
+}
+
+extension PromptTheme {
+  public func prompt(_ s: String) -> String { return s }
+}
+
+protocol MemoryDumpTheme {
+  func address(_ s: String) -> String
+  func data(_ s: String) -> String
+  func printable(_ s: String) -> String
+  func nonPrintable(_ s: String) -> String
+}
+
+extension MemoryDumpTheme {
+  public func address(_ s: String) -> String { return s }
+  public func data(_ s: String) -> String { return s }
+  public func printable(_ s: String) -> String { return s }
+  public func nonPrintable(_ s: String) -> String { return s }
+}
+
+protocol RegisterDumpTheme : MemoryDumpTheme {
+  func register(_ s: String) -> String
+  func hexValue(_ s: String) -> String
+  func decimalValue(_ s: String) -> String
+  func flags(_ s: String) -> String
+}
+
+extension RegisterDumpTheme {
+  public func register(_ s: String) -> String { return s }
+  public func hexValue(_ s: String) -> String { return s }
+  public func decimalValue(_ s: String) -> String { return s }
+  public func flags(_ s: String) -> String { return s }
+}
+
+typealias Theme = BacktraceFormattingTheme & ErrorAndWarningTheme &
+  PromptTheme & MemoryDumpTheme & RegisterDumpTheme
+
+enum Themes {
+
+  struct Plain: Theme {
+  }
+
+  struct Color: Theme {
+    public func frameIndex(_ s: String) -> String {
+      return "\(fg: .gray)\(s)\(fg: .normal)"
+    }
+    public func programCounter(_ s: String) -> String {
+      return "\(fg: .green)\(s)\(fg: .normal)"
+    }
+    public func frameAttribute(_ s: String) -> String {
+      return "\(fg: .blue)[\(s)]\(fg: .normal)"
+    }
+
+    public func symbol(_ s: String) -> String {
+      return "\(fg: .brightMagenta)\(s)\(fg: .normal)"
+    }
+    public func offset(_ s: String) -> String {
+      return "\(fg: .white)\(s)\(fg: .normal)"
+    }
+    public func sourceLocation(_ s: String) -> String {
+      return "\(fg: .yellow)\(s)\(fg: .normal)"
+    }
+    public func lineNumber(_ s: String) -> String {
+      return "\(fg: .gray)\(s)\(fg: .normal)"
+    }
+    public func code(_ s: String) -> String {
+      return "\(s)"
+    }
+    public func crashedLine(_ s: String) -> String {
+      return "\(bg: .grayscale(2))\(s)\(bg: .normal)"
+    }
+    public func crashLocation(_ s: String) -> String {
+      return "\(fg: .brightRed)\(s)\(fg: .normal)"
+    }
+    public func imageName(_ s: String) -> String {
+      return "\(fg: .cyan)\(s)\(fg: .normal)"
+    }
+    public func imageAddressRange(_ s: String) -> String {
+      return "\(fg: .green)\(s)\(fg: .normal)"
+    }
+    public func imageBuildID(_ s: String) -> String {
+      return "\(fg: .white)\(s)\(fg: .normal)"
+    }
+    public func imagePath(_ s: String) -> String {
+      return "\(fg: .gray)\(s)\(fg: .normal)"
+    }
+
+    public func prompt(_ s: String) -> String {
+      return "\(fg: .gray)\(s)\(fg: .normal)"
+    }
+
+    public func address(_ s: String) -> String {
+      return "\(fg: .green)\(s)\(fg: .normal)"
+    }
+    public func data(_ s: String) -> String {
+      return s
+    }
+    public func printable(_ s: String) -> String {
+      return s
+    }
+    public func nonPrintable(_ s: String) -> String {
+      return "\(fg: .gray)\(s)\(fg: .normal)"
+    }
+
+    public func register(_ s: String) -> String {
+      return s
+    }
+    public func hexValue(_ s: String) -> String {
+      return "\(fg: .green)\(s)\(fg: .normal)"
+    }
+    public func decimalValue(_ s: String) -> String {
+      return "\(fg: .green)\(s)\(fg: .normal)"
+    }
+    public func flags(_ s: String) -> String {
+      return "\(fg: .magenta)\(s)\(fg: .normal)"
+    }
+
+    public func crashReason(_ s: String) -> String {
+      return "💣 \(fg: .brightRed)\(s)\(fg: .normal)"
+    }
+    public func error(_ s: String) -> String {
+      return "🛑 \(fg: .brightRed)error: \(s)\(fg: .normal)"
+    }
+    public func warning(_ s: String) -> String {
+      return "⚠️ \(fg: .brightYellow)warning: \(s)\(fg: .normal)"
+    }
+    public func info(_ s: String) -> String {
+      return "ℹ️ \(s)"
+    }
+  }
+
+  static let plain = Plain()
+  static let color = Color()
+
+}

--- a/stdlib/public/libexec/swift-backtrace/Utils.swift
+++ b/stdlib/public/libexec/swift-backtrace/Utils.swift
@@ -1,0 +1,142 @@
+//===--- Utils.swift - Utility functions ----------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Utility functions that are used in the swift-backtrace program.
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin.C
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(MSVCRT)
+import MSVCRT
+#endif
+
+import Swift
+
+internal func hex<T: FixedWidthInteger>(_ value: T,
+                                        withPrefix: Bool = true) -> String {
+  let digits = String(value, radix: 16)
+  let padTo = value.bitWidth / 4
+  let padding = digits.count >= padTo ? "" : String(repeating: "0",
+                                                    count: padTo - digits.count)
+  let prefix = withPrefix ? "0x" : ""
+
+  return "\(prefix)\(padding)\(digits)"
+}
+
+internal func hex(_ bytes: [UInt8]) -> String {
+  return bytes.map{ hex($0, withPrefix: false) }.joined(separator: "")
+}
+
+internal func parseUInt64<S: StringProtocol>(_ s: S) -> UInt64? {
+  if s.hasPrefix("0x") {
+    return UInt64(s.dropFirst(2), radix: 16)
+  } else if s.hasPrefix("0b") {
+    return UInt64(s.dropFirst(2), radix: 2)
+  } else if s.hasPrefix("0o") {
+    return UInt64(s.dropFirst(2), radix: 8)
+  } else {
+    return UInt64(s, radix: 10)
+  }
+}
+
+struct PosixError: Error {
+  var errno: Int32
+
+  var desription: String {
+    return String(cString: strerror(self.errno))
+  }
+}
+
+internal func recursiveRemoveContents(_ dir: String) throws {
+  guard let dirp = opendir(dir) else {
+    throw PosixError(errno: errno)
+  }
+  defer {
+    closedir(dirp)
+  }
+  while let dp = readdir(dirp) {
+    let name: String =
+      withUnsafePointer(to: &dp.pointee.d_name) {
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        let len = Int(dp.pointee.d_namlen)
+#else
+        let len = Int(strlen($0))
+#endif
+        return $0.withMemoryRebound(to: UInt8.self,
+                                    capacity: len) {
+          return String(decoding: UnsafeBufferPointer(start: $0,
+                                                      count: len),
+                        as: UTF8.self)
+        }
+      }
+    if name == "." || name == ".." {
+      continue
+    }
+    let fullPath = "\(dir)/\(name)"
+    if dp.pointee.d_type == DT_DIR {
+      try recursiveRemove(fullPath)
+    } else {
+      if unlink(fullPath) != 0 {
+        throw PosixError(errno: errno)
+      }
+    }
+  }
+}
+
+internal func recursiveRemove(_ dir: String) throws {
+  try recursiveRemoveContents(dir)
+
+  if rmdir(dir) != 0 {
+    throw PosixError(errno: errno)
+  }
+}
+
+internal func withTemporaryDirectory(pattern: String, shouldDelete: Bool = true,
+                                     body: (String) throws -> ()) throws {
+  var buf = Array<UInt8>(pattern.utf8)
+  buf.append(0)
+
+  guard let dir = buf.withUnsafeMutableBufferPointer({
+    if let ptr = mkdtemp($0.baseAddress!) {
+      return String(cString: ptr)
+    }
+    return nil
+  }) else {
+    throw PosixError(errno: errno)
+  }
+
+  defer {
+    if shouldDelete {
+      try? recursiveRemove(dir)
+    }
+  }
+
+  try body(dir)
+}
+
+internal func spawn(_ path: String, args: [String]) throws {
+  var cargs = args.map{ strdup($0) }
+  cargs.append(nil)
+  let result = cargs.withUnsafeBufferPointer{
+    posix_spawn(nil, path, nil, nil, $0.baseAddress!, nil)
+  }
+  for arg in cargs {
+    free(arg)
+  }
+  if result != 0 {
+    throw PosixError(errno: errno)
+  }
+}
+

--- a/stdlib/public/libexec/swift-backtrace/main.swift
+++ b/stdlib/public/libexec/swift-backtrace/main.swift
@@ -1,0 +1,1109 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if os(macOS)
+
+#if canImport(Darwin)
+import Darwin.C
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(MSVCRT)
+import MSVCRT
+#endif
+
+@_spi(Formatting) import _Backtracing
+@_spi(Contexts) import _Backtracing
+@_spi(Registers) import _Backtracing
+@_spi(MemoryReaders) import _Backtracing
+
+@main
+internal struct SwiftBacktrace {
+  enum UnwindAlgorithm {
+    case fast
+    case precise
+  }
+
+  enum Preset {
+    case none
+    case friendly
+    case medium
+    case full
+  }
+
+  enum ImagesToShow {
+    case none
+    case all
+    case mentioned
+  }
+
+  enum RegistersToShow {
+    case none
+    case all
+    case crashedOnly
+  }
+
+  struct Arguments {
+    var unwindAlgorithm: UnwindAlgorithm = .precise
+    var demangle = false
+    var interactive = false
+    var color = false
+    var timeout = 30
+    var preset: Preset = .none
+    var threads: Bool? = nil
+    var registers: RegistersToShow? = nil
+    var crashInfo: UInt64? = nil
+    var showImages: ImagesToShow? = nil
+    var limit: Int? = 64
+    var top = 16
+    var sanitize: Bool? = nil
+  }
+
+  static var args = Arguments()
+  static var formattingOptions = BacktraceFormattingOptions()
+
+  static var target: Target? = nil
+  static var currentThread: Int = 0
+
+  static var theme: any Theme {
+    if args.color {
+      return Themes.color
+    } else {
+      return Themes.plain
+    }
+  }
+
+  static func usage() {
+    print("""
+usage: swift-backtrace [--unwind <algorithm>] [--demangle [<bool>]] [--interactive [<bool>]] [--color [<bool>]] [--timeout <seconds>] [--preset <preset>] [--threads [<bool>]] [--registers <registers>] [--images <images>] --crashinfo <addr>
+
+Generate a backtrace for the parent process.
+
+--unwind <algorithm>
+-u <algorithm>          Set the unwind algorithm to use.  Supported algorithms
+                        are "fast" and "precise".
+
+--demangle [<bool>]
+-d [<bool>]             Set whether or not to demangle identifiers.
+
+--interactive [<bool>]
+-i [<bool>]             Set whether to be interactive.
+
+--color [<bool>]
+-c [<bool>]             Set whether to use ANSI color in the output.
+
+--timeout <seconds>
+-t <seconds>            Set how long to wait for interaction.
+
+--preset <preset>
+-p <preset>             Set the backtrace format (by preset).  Options are
+                        "friendly", "medium" and "full".
+
+--threads [<bool>]
+-h [<bool>]             Set whether or not to show all threads.
+
+--registers <registers>
+-r <registers>          Set which registers dumps to show.  Options are "none",
+                        "all" and "crashed".
+
+--images <images>
+-m <images>             Set which images to list.  Options are "none", "all"
+                        and "mentioned".
+
+--limit <count>
+-l <count>              Set the limit on the number of frames to capture.
+                        Can be set to "none" to disable the limit.
+
+--top <count>
+-T <count>              Set the minimum number of frames to capture at the top
+                        of the stack.  This is used with limit to ensure that
+                        you capture sufficient frames to understand deep traces.
+
+--sanitize [<bool>]
+-s [<bool>]             Set whether or not to sanitize paths.
+
+--crashinfo <addr>
+-a <addr>               Provide a pointer to a platform specific CrashInfo
+                        structure.  <addr> should be in hexadecimal.
+""")
+  }
+
+  static func parseBool(_ s: some StringProtocol) -> Bool {
+    let lowered = s.lowercased()
+    return lowered == "yes" || lowered == "y" ||
+      lowered == "true" || lowered == "t" || lowered == "on"
+  }
+
+  static func handleArgument(_ arg: String, value: String?) {
+    switch arg {
+      case "-?", "--help":
+        usage()
+        exit(0)
+      case "-u", "--unwind":
+        if let v = value {
+          switch v.lowercased() {
+            case "fast":
+              args.unwindAlgorithm = .fast
+            case "precise":
+              args.unwindAlgorithm = .precise
+            default:
+              print("swift-backtrace: unknown unwind algorithm '\(v)'")
+              usage()
+              exit(1)
+          }
+        } else {
+          print("swift-backtrace: missing unwind algorithm")
+          usage()
+          exit(1)
+        }
+      case "-d", "--demangle":
+        if let v = value {
+          args.demangle = parseBool(v)
+        } else {
+          args.demangle = true
+        }
+      case "-i", "--interactive":
+        if let v = value {
+          args.interactive = parseBool(v)
+        } else {
+          args.interactive = true
+        }
+      case "-c", "--color":
+        if let v = value {
+          args.color = parseBool(v)
+        } else {
+          args.color = true
+        }
+      case "-t", "--timeout":
+        if let v = value {
+          if let secs = Int(v), secs >= 0 {
+            args.timeout = secs
+          } else {
+            print("swift-backtrace: bad timeout '\(v)'")
+          }
+        } else {
+          print("swift-backtrace: missing timeout value")
+          usage()
+          exit(1)
+        }
+      case "-p", "--preset":
+        if let v = value {
+          switch v.lowercased() {
+            case "friendly":
+              args.preset = .friendly
+            case "medium":
+              args.preset = .medium
+            case "full":
+              args.preset = .full
+            default:
+              print("swift-backtrace: unknown preset '\(v)'")
+              usage()
+              exit(1)
+          }
+        } else {
+          print("swift-backtrace: missing preset name")
+          usage()
+          exit(1)
+        }
+      case "-h", "--threads":
+        if let v = value {
+          if v.lowercased() != "preset" {
+            args.threads = parseBool(v)
+          }
+        } else {
+          args.threads = true
+        }
+      case "-r", "--registers":
+        if let v = value {
+          switch v.lowercased() {
+            case "preset":
+              break
+            case "none":
+              args.registers = RegistersToShow.none
+            case "all":
+              args.registers = .all
+            case "crashed":
+              args.registers = .crashedOnly
+            default:
+              print("swift-backtrace: unknown registers setting '\(v)'")
+              usage()
+              exit(1)
+          }
+        } else {
+          print("swift-backtrace: missing registers setting")
+          usage()
+          exit(1)
+        }
+      case "-m", "--images":
+        if let v = value {
+          switch v.lowercased() {
+            case "preset":
+              break
+            case "none":
+              args.showImages = ImagesToShow.none
+            case "all":
+              args.showImages = .all
+            case "mentioned":
+              args.showImages = .mentioned
+            default:
+              print("swift-backtrace: unknown images setting '\(v)'")
+              usage()
+              exit(1)
+          }
+        } else {
+          print("swift-backtrace: missing images setting")
+          usage()
+          exit(1)
+        }
+      case "-l", "--limit":
+        if let v = value {
+          if v.lowercased() == "none" {
+            args.limit = nil
+          } else if let limit = Int(v), limit > 0 {
+            args.limit = limit
+          } else {
+            print("swift-backtrace: bad limit value \(v)")
+          }
+        } else {
+          print("swift-backtrace: missing limit value")
+          usage()
+          exit(1)
+        }
+      case "-T", "--top":
+        if let v = value {
+          if let top = Int(v), top >= 0 {
+            args.top = top
+          } else {
+            print("swift-backtrace: bad top value \(v)")
+          }
+        } else {
+          print("swift-backtrace: missing top value")
+          usage()
+          exit(1)
+        }
+      case "-s", "--sanitize":
+        if let v = value {
+          args.sanitize = parseBool(v)
+        } else {
+          args.sanitize = true
+        }
+      case "-a", "--crashinfo":
+        if let v = value {
+          if let a = UInt64(v, radix: 16) {
+            args.crashInfo = a
+          } else {
+            print("swift-backtrace: bad pointer '\(v)'")
+            usage()
+            exit(1)
+          }
+        } else {
+          print("swift-backtrace: missing pointer value")
+          usage()
+          exit(1)
+        }
+      default:
+        print("swift-backtrace: unknown argument '\(arg)'")
+        usage()
+        exit(1)
+    }
+  }
+
+  static func main() {
+    parseArguments()
+
+    guard let crashInfoAddr = args.crashInfo else {
+      print("swift-backtrace: --crashinfo is not optional")
+      usage()
+      exit(1)
+    }
+
+    // Set-up the backtrace formatting options
+    switch args.preset {
+      case .friendly, .none:
+        formattingOptions =
+          .skipRuntimeFailures(true)
+          .showAddresses(false)
+          .showSourceCode(true)
+          .showFrameAttributes(false)
+          .sanitizePaths(args.sanitize ?? false)
+        if args.threads == nil {
+          args.threads = false
+        }
+        if args.registers == nil {
+          args.registers = RegistersToShow.none
+        }
+        if args.showImages == nil {
+          args.showImages = ImagesToShow.none
+        }
+      case .medium:
+        formattingOptions =
+          .skipRuntimeFailures(true)
+          .showSourceCode(true)
+          .showFrameAttributes(true)
+          .sanitizePaths(args.sanitize ?? true)
+        if args.threads == nil {
+          args.threads = false
+        }
+        if args.registers == nil {
+          args.registers = .crashedOnly
+        }
+        if args.showImages == nil {
+          args.showImages = .mentioned
+        }
+      case .full:
+        formattingOptions =
+          .skipRuntimeFailures(false)
+          .skipThunkFunctions(false)
+          .skipSystemFrames(false)
+          .sanitizePaths(args.sanitize ?? true)
+        if args.threads == nil {
+          args.threads = true
+        }
+        if args.registers == nil {
+          args.registers = .crashedOnly
+        }
+        if args.showImages == nil {
+          args.showImages = .mentioned
+        }
+    }
+    formattingOptions = formattingOptions.demangle(args.demangle)
+
+    // We never use the showImages option; if we're going to show images, we
+    // want to do it *once* for all the backtraces we showed.
+    formattingOptions = formattingOptions.showImages(.none)
+
+    target = Target(crashInfoAddr: crashInfoAddr,
+                    limit: args.limit, top: args.top)
+
+    currentThread = target!.crashingThreadNdx
+
+    printCrashLog()
+
+    print("")
+
+    if args.interactive {
+      // Make sure we're line buffered
+      setvbuf(stdout, nil, _IOLBF, 0)
+
+      while let ch = waitForKey("Press space to interact, D to debug, or any other key to quit",
+                                timeout: args.timeout) {
+        switch UInt8(ch) {
+          case UInt8(ascii: " "):
+            interactWithUser()
+            exit(0)
+          case UInt8(ascii: "D"), UInt8(ascii: "d"):
+            startDebugger()
+          default:
+            exit(0)
+        }
+      }
+    }
+
+  }
+
+  // Parse the command line arguments; we can't use swift-argument-parser
+  // from here because that would create a dependency problem, so we do
+  // it manually.
+  static func parseArguments() {
+    var currentArg: String? = nil
+    for arg in CommandLine.arguments[1...] {
+      if arg.hasPrefix("-") {
+        if let key = currentArg {
+          handleArgument(key, value: nil)
+        }
+        currentArg = arg
+      } else {
+        if let key = currentArg {
+          handleArgument(key, value: arg)
+          currentArg = nil
+        } else if arg != "" {
+          print("swift-backtrace: unexpected argument '\(arg)'")
+          usage()
+          exit(1)
+        }
+      }
+    }
+    if let key = currentArg {
+      handleArgument(key, value: nil)
+    }
+  }
+
+  #if os(Linux) || os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+  static func setRawMode() -> termios {
+    var oldAttrs = termios()
+    tcgetattr(0, &oldAttrs)
+
+    var newAttrs = oldAttrs
+    newAttrs.c_lflag &= ~(UInt(ICANON) | UInt(ECHO))
+    tcsetattr(0, TCSANOW, &newAttrs)
+
+    return oldAttrs
+  }
+
+  static func resetInputMode(mode: termios) {
+    var theMode = mode
+    tcsetattr(0, TCSANOW, &theMode)
+  }
+
+  static func waitForKey(_ message: String, timeout: Int?) -> Int32? {
+    let oldMode = setRawMode()
+
+    defer {
+      print("\r\u{1b}[0K", terminator: "")
+      fflush(stdout)
+      resetInputMode(mode: oldMode)
+    }
+
+    if let timeout = timeout {
+    var remaining = timeout
+
+    while true {
+      print("\r\(message) (\(remaining)s) ", terminator: "")
+      fflush(stdout)
+
+      var pfd = pollfd(fd: 0, events: Int16(POLLIN), revents: 0)
+
+      let ret = poll(&pfd, 1, 1000)
+      if ret == 0 {
+        remaining -= 1
+        if remaining == 0 {
+          break
+        }
+        continue
+      } else if ret < 0 {
+        break
+      }
+
+      return getchar()
+    }
+    } else {
+      print("\r\(message)", terminator: "")
+      fflush(stdout)
+      return getchar()
+    }
+
+    return nil
+  }
+  #elseif os(Windows)
+  static func waitForKey(_ message: String, timeout: Int?) -> Int32? {
+    // ###TODO
+    return nil
+  }
+  #endif
+
+  static func backtraceFormatter() -> BacktraceFormatter {
+    var terminalSize = winsize(ws_row: 24, ws_col: 80,
+                               ws_xpixel: 1024, ws_ypixel: 768)
+    _ = ioctl(0, TIOCGWINSZ, &terminalSize)
+
+    return BacktraceFormatter(formattingOptions
+                              .theme(theme)
+                              .width(Int(terminalSize.ws_col)))
+  }
+
+  static func printCrashLog() {
+    guard let target = target else {
+      print("swift-backtrace: unable to get target")
+      return
+    }
+
+    let crashingThread = target.threads[target.crashingThreadNdx]
+
+    let description: String
+
+    if let failure = crashingThread.backtrace.swiftRuntimeFailure {
+      description = failure
+    } else {
+      description = "Program crashed: \(target.signalDescription) at \(hex(target.faultAddress))"
+    }
+
+    print("")
+    print(theme.crashReason(description))
+    print("")
+
+    var mentionedImages = Set<Int>()
+    let formatter = backtraceFormatter()
+
+    func dump(ndx: Int, thread: TargetThread) {
+      let crashed = thread.id == target.crashingThread ? " crashed" : ""
+      let name = !thread.name.isEmpty ? " \"\(thread.name)\"" : ""
+      print("Thread \(ndx)\(name)\(crashed):\n")
+
+      if args.registers! == .all {
+        if let context = thread.context {
+          showRegisters(context)
+        } else {
+          print("  " + theme.info("no context for thread \(ndx)"))
+        }
+        print("")
+      }
+
+      let formatted = formatter.format(backtrace: thread.backtrace)
+
+      print(formatted)
+
+      if args.showImages! == .mentioned {
+        for frame in thread.backtrace.frames {
+          if formatter.shouldSkip(frame) {
+            continue
+          }
+          if let symbol = frame.symbol, symbol.imageIndex >= 0 {
+            mentionedImages.insert(symbol.imageIndex)
+          }
+        }
+      }
+    }
+
+    if args.threads! {
+      for (ndx, thread) in target.threads.enumerated() {
+        dump(ndx: ndx, thread: thread)
+      }
+    } else {
+      dump(ndx: target.crashingThreadNdx, thread: crashingThread)
+    }
+
+    if args.registers! == .crashedOnly {
+      print("\n\nRegisters:\n")
+
+      if let context = target.threads[target.crashingThreadNdx].context {
+        showRegisters(context)
+      } else {
+        print(theme.info("no context for thread \(target.crashingThreadNdx)"))
+      }
+    }
+
+    switch args.showImages! {
+      case .none:
+        break
+      case .mentioned:
+        let images = mentionedImages.sorted().map{ target.images[$0] }
+        let omitted = target.images.count - images.count
+        if omitted > 0 {
+          print("\n\nImages (\(omitted) omitted):\n")
+        } else {
+          print("\n\nImages:\n")
+        }
+        print(formatter.format(images: images))
+      case .all:
+        print("\n\nImages:\n")
+        print(formatter.format(images: target.images))
+    }
+  }
+
+  static func startDebugger() {
+    guard let target = target else {
+      return
+    }
+
+    do {
+      try target.withDebugger {
+
+        if let ch = waitForKey("Press any key once LLDB is attached, or A to abort", timeout: nil),
+           ch != UInt8(ascii: "A") && ch != UInt8(ascii: "a") {
+          exit(0)
+        }
+      }
+    } catch {
+      print(theme.error("unable to spawn debugger"))
+    }
+  }
+
+  static func interactWithUser() {
+    guard let target = target else {
+      return
+    }
+
+    while true {
+      fflush(stdout)
+      print(theme.prompt(">>> "), terminator: "")
+      guard let input = readLine() else {
+        print("")
+        break
+      }
+
+      let cmd = input.split(whereSeparator: { $0.isWhitespace })
+
+      if cmd.count < 1 {
+        continue
+      }
+
+      // ###TODO: We should really replace this with something a little neater
+      switch cmd[0].lowercased() {
+        case "exit", "quit":
+          return
+        case "debug":
+          startDebugger()
+        case "bt", "backtrace":
+          let formatter = backtraceFormatter()
+          let backtrace = target.threads[currentThread].backtrace
+          let formatted = formatter.format(backtrace: backtrace)
+
+          print(formatted)
+        case "thread":
+          if cmd.count >= 2 {
+            if let newThreadNdx = Int(cmd[1]),
+               newThreadNdx >= 0 && newThreadNdx < target.threads.count {
+              currentThread = newThreadNdx
+            } else {
+              print(theme.error("Bad thread index '\(cmd[1])'"))
+              break
+            }
+          }
+
+          let crashed: String
+          if currentThread == target.crashingThreadNdx {
+            crashed = " (crashed)"
+          } else {
+            crashed = ""
+          }
+
+          let thread = target.threads[currentThread]
+          let backtrace = thread.backtrace
+          let name = thread.name.isEmpty ? "" : " \(thread.name)"
+          print("Thread \(currentThread) id=\(thread.id)\(name)\(crashed)\n")
+
+          if let frame = backtrace.frames.drop(while: {
+            $0.isSwiftRuntimeFailure
+          }).first {
+            let formatter = backtraceFormatter()
+            let formatted = formatter.format(frame: frame)
+            print("\(formatted)")
+          }
+          break
+        case "reg", "registers":
+          if let context = target.threads[currentThread].context {
+            showRegisters(context)
+          } else {
+            print(theme.info("no context for thread \(currentThread)"))
+          }
+          break
+        case "mem", "memory":
+          if cmd.count != 2 && cmd.count != 3 {
+            print("memory <start-address> [<end-address>|+<byte-count>]")
+            break
+          }
+
+          guard let startAddress = parseUInt64(cmd[1]) else {
+            print(theme.error("bad start address \(cmd[1])"))
+            break
+          }
+
+          let count: UInt64
+          if cmd.count == 3 {
+            if cmd[2].hasPrefix("+") {
+              guard let theCount = parseUInt64(cmd[2].dropFirst()) else {
+                print(theme.error("bad byte count \(cmd[2])"))
+                break
+              }
+              count = theCount
+            } else {
+              guard let addr = parseUInt64(cmd[2]) else {
+                print(theme.error("bad end address \(cmd[2])"))
+                break
+              }
+              if addr < startAddress {
+                print("End address must be after start address")
+                break
+              }
+              count = addr - startAddress
+            }
+          } else {
+            count = 256
+          }
+
+          dumpMemory(at: startAddress, count: count)
+          break
+        case "process", "threads":
+          print("Process \(target.pid) \"\(target.name)\" has \(target.threads.count) thread(s):\n")
+
+          let formatter = backtraceFormatter()
+
+          var rows: [BacktraceFormatter.TableRow] = []
+          for (n, thread) in target.threads.enumerated() {
+            let backtrace = thread.backtrace
+
+            let crashed: String
+            if n == target.crashingThreadNdx {
+              crashed = " (crashed)"
+            } else {
+              crashed = ""
+            }
+
+            let selected = currentThread == n ? "▶︎" : " "
+            let name = thread.name.isEmpty ? "" : " \(thread.name)"
+
+            rows.append(.columns([ selected,
+                                   "\(n)",
+                                   "id=\(thread.id)\(name)\(crashed)" ]))
+            if let frame = backtrace.frames.drop(while: {
+              $0.isSwiftRuntimeFailure
+            }).first {
+
+              rows += formatter.formatRows(frame: frame).map{ row in
+                switch row {
+                  case let .columns(columns):
+                    return .columns([ "", "" ] + columns)
+                  default:
+                    return row
+                }
+              }
+            }
+          }
+
+          let output = BacktraceFormatter.formatTable(rows,
+                                                      alignments: [
+                                                        .left,
+                                                        .right
+                                                      ])
+          print(output)
+        case "images":
+          let formatter = backtraceFormatter()
+          let images = target.threads[currentThread].backtrace.images
+          let output = formatter.format(images: images)
+
+          print(output)
+        case "set":
+          if cmd.count == 1 {
+            let limit: String
+            if let lim = args.limit {
+              limit = "\(lim)"
+            } else {
+              limit = "none"
+            }
+            let top = "\(args.top)"
+
+            print("""
+                    addresses      = \(formattingOptions.shouldShowAddresses)
+                    demangle       = \(formattingOptions.shouldDemangle)
+                    frame-attrs    = \(formattingOptions.shouldShowFrameAttributes)
+                    image-names    = \(formattingOptions.shouldShowImageNames)
+                    limit          = \(limit)
+                    sanitize       = \(formattingOptions.shouldSanitizePaths)
+                    source         = \(formattingOptions.shouldShowSourceCode)
+                    source-context = \(formattingOptions.sourceContextLines)
+                    system-frames  = \(!formattingOptions.shouldSkipSystemFrames)
+                    thunks         = \(!formattingOptions.shouldSkipThunkFunctions)
+                    top            = \(top)
+                    """)
+          } else {
+            for optval in cmd[1...] {
+              let parts = optval.split(separator: "=", maxSplits: 1,
+                                       omittingEmptySubsequences: false)
+              if parts.count == 1 {
+                let option = parts[0]
+
+                switch option {
+                  case "addresses":
+                    print("addresses = \(formattingOptions.shouldShowAddresses)")
+                  case "demangle":
+                    print("demangle = \(formattingOptions.shouldDemangle)")
+                  case "frame-attrs":
+                    print("frame-attrs = \(formattingOptions.shouldShowFrameAttributes)")
+                  case "image-names":
+                    print("image-names = \(formattingOptions.shouldShowImageNames)")
+                  case "limit":
+                    if let limit = args.limit {
+                      print("limit = \(limit)")
+                    } else {
+                      print("limit = none")
+                    }
+                  case "sanitize":
+                    print("sanitize = \(formattingOptions.shouldSanitizePaths)")
+                  case "source":
+                    print("source = \(formattingOptions.shouldShowSourceCode)")
+                  case "source-context":
+                    print("source-context = \(formattingOptions.sourceContextLines)")
+                  case "system-frames":
+                    print("system-frames = \(!formattingOptions.shouldSkipSystemFrames)")
+                  case "thunks":
+                    print("thunks = \(!formattingOptions.shouldSkipThunkFunctions)")
+                  case "top":
+                    print("top = \(args.top)")
+
+                  default:
+                    print(theme.error("unknown option '\(option)'"))
+                }
+              } else {
+                let option = parts[0]
+                let value = parts[1]
+                var changedBacktrace = false
+
+                switch option {
+                  case "limit":
+                    if value == "none" {
+                      args.limit = nil
+                      changedBacktrace = true
+                    } else if let limit = Int(value), limit > 0 {
+                      args.limit = limit
+                      changedBacktrace = true
+                    } else {
+                      print(theme.error("bad limit value '\(value)'"))
+                    }
+
+                  case "top":
+                    if let top = Int(value), top >= 0 {
+                      args.top = top
+                      changedBacktrace = true
+                    } else {
+                      print(theme.error("bad top value '\(value)'"))
+                    }
+
+                  case "source":
+                    formattingOptions =
+                      formattingOptions.showSourceCode(parseBool(value),
+                                                       contextLines: formattingOptions.sourceContextLines)
+
+                  case "source-context":
+                    if let lines = Int(value), lines >= 0 {
+                      formattingOptions =
+                        formattingOptions.showSourceCode(formattingOptions.shouldShowSourceCode,
+                                                         contextLines: lines)
+                    } else {
+                      print(theme.error("bad source-context value '\(value)'"))
+                    }
+
+                  case "thunks":
+                    formattingOptions =
+                      formattingOptions.skipThunkFunctions(!parseBool(value))
+
+                  case "system-frames":
+                    formattingOptions =
+                      formattingOptions.skipSystemFrames(!parseBool(value))
+
+                  case "frame-attrs":
+                    formattingOptions =
+                      formattingOptions.showFrameAttributes(parseBool(value))
+
+                  case "addresses":
+                    formattingOptions =
+                      formattingOptions.showAddresses(parseBool(value))
+
+                  case "sanitize":
+                    formattingOptions =
+                      formattingOptions.sanitizePaths(parseBool(value))
+
+                  case "demangle":
+                    formattingOptions =
+                      formattingOptions.demangle(parseBool(value))
+
+                  case "image-names":
+                    formattingOptions =
+                      formattingOptions.showImageNames(parseBool(value))
+
+                  default:
+                    print(theme.error("unknown option '\(option)'"))
+                }
+
+                if changedBacktrace {
+                  target.redoBacktraces(limit: args.limit, top: args.top)
+                }
+              }
+            }
+          }
+        case "help":
+          print("""
+                  Available commands:
+
+                  backtrace  Display a backtrace.
+                  bt         Synonym for backtrace.
+                  debug      Attach the debugger.
+                  exit       Exit interaction, allowing program to crash normally.
+                  help       Display help.
+                  images     List images loaded by the program.
+                  mem        Synonym for memory.
+                  memory     Inspect memory.
+                  process    Show information about the process.
+                  quit       Synonym for exit.
+                  reg        Synonym for registers.
+                  registers  Display the registers.
+                  set        Set or show options.
+                  thread     Show or set the current thread.
+                  threads    Synonym for process.
+                  """)
+        default:
+          print(theme.error("unknown command '\(cmd[0])'"))
+      }
+
+      print("")
+    }
+  }
+
+  static func printableBytes(from bytes: some Sequence<UInt8>) -> String {
+    // It would be nice to join these with ZWNJs to prevent ligature processing,
+    // but sadly Terminal displays ZWNJ as a space character.
+    return bytes.map{ byte in
+      switch byte {
+        case 0..<32, 127, 0x80..<0xa0:
+          return theme.nonPrintable("·")
+        default:
+          return theme.printable(String(Unicode.Scalar(byte)))
+      }
+    }.joined(separator:"")
+  }
+
+  static func dumpMemory(at address: UInt64, count: UInt64) {
+    guard let bytes = try? target!.reader.fetch(
+            from: RemoteMemoryReader.Address(address),
+            count: Int(count),
+            as: UInt8.self) else {
+      print("Unable to read memory")
+      return
+    }
+
+    let startAddress = HostContext.stripPtrAuth(address: address)
+    var ndx = 0
+    while ndx < bytes.count {
+      let addr = startAddress + UInt64(ndx)
+      let remaining = bytes.count - ndx
+      let lineChunk = 16
+      let todo = min(remaining, lineChunk)
+      let formattedBytes = theme.data(bytes[ndx..<ndx+todo].map{
+        hex($0, withPrefix: false)
+      }.joined(separator: " "))
+      let printedBytes = printableBytes(from: bytes[ndx..<ndx+todo])
+      let padding = String(repeating: " ",
+                           count: (lineChunk - todo) * 3)
+
+      let hexAddr = theme.address(hex(addr, withPrefix: false))
+      print("\(hexAddr)  \(formattedBytes)\(padding)  \(printedBytes)")
+
+      ndx += todo
+    }
+  }
+
+  static func showRegister<T: FixedWidthInteger>(name: String, value: T) {
+    let hexValue = theme.hexValue(hex(value))
+
+    // Pad the register name
+    let regPad = String(repeating: " ", count: max(3 - name.count, 0))
+    let reg = theme.register(regPad + name)
+
+    // Grab 16 bytes at each address if possible
+    if let bytes = try? target!.reader.fetch(
+         from: RemoteMemoryReader.Address(value),
+         count: 16,
+         as: UInt8.self) {
+      let formattedBytes = theme.data(bytes.map{
+        hex($0, withPrefix: false)
+      }.joined(separator: " "))
+      let printedBytes = printableBytes(from: bytes)
+      print("\(reg) \(hexValue)  \(formattedBytes)  \(printedBytes)")
+    } else {
+      let decValue = theme.decimalValue("\(value)")
+      print("\(reg) \(hexValue)  \(decValue)")
+    }
+  }
+
+  static func showGPR<C: Context>(name: String, context: C, register: C.Register) {
+    // Get the register contents
+    let value = context.getRegister(register)!
+
+    showRegister(name: name, value: value)
+  }
+
+  static func showGPRs<C: Context, Rs: Sequence>(_ context: C, range: Rs) where Rs.Element == C.Register {
+    for reg in range {
+      showGPR(name: "\(reg)", context: context, register: reg)
+    }
+  }
+
+  static func x86StatusFlags<T: FixedWidthInteger>(_ flags: T) -> String {
+    var status: [String] = []
+
+    if (flags & 0x400) != 0 {
+      status.append("OF")
+    }
+    if (flags & 0x80) != 0 {
+      status.append("SF")
+    }
+    if (flags & 0x40) != 0 {
+      status.append("ZF")
+    }
+    if (flags & 0x10) != 0 {
+      status.append("AF")
+    }
+    if (flags & 0x4) != 0 {
+      status.append("PF")
+    }
+    if (flags & 0x1) != 0 {
+      status.append("CF")
+    }
+
+    return status.joined(separator: " ")
+  }
+
+  static func showRegisters(_ context: X86_64Context) {
+    showGPRs(context, range: .rax ... .r15)
+    showRegister(name: "rip", value: context.programCounter)
+
+    let rflags = context.getRegister(.rflags)!
+    let cs = theme.hexValue(hex(UInt16(context.getRegister(.cs)!)))
+    let fs = theme.hexValue(hex(UInt16(context.getRegister(.fs)!)))
+    let gs = theme.hexValue(hex(UInt16(context.getRegister(.gs)!)))
+
+    let hexFlags = theme.hexValue(hex(rflags))
+    let status = theme.flags(x86StatusFlags(rflags))
+
+    print("")
+    print("\(theme.register("rflags")) \(hexFlags)  \(status)")
+    print("")
+    print("\(theme.register("cs")) \(cs)  \(theme.register("fs")) \(fs)  \(theme.register("gs")) \(gs)")
+  }
+
+  static func showRegisters(_ context: I386Context) {
+    showGPRs(context, range: .eax ... .edi)
+    showRegister(name: "eip", value: context.programCounter)
+
+    let eflags = UInt32(context.getRegister(.eflags)!)
+    let es = theme.hexValue(hex(UInt16(context.getRegister(.es)!)))
+    let cs = theme.hexValue(hex(UInt16(context.getRegister(.cs)!)))
+    let ss = theme.hexValue(hex(UInt16(context.getRegister(.ss)!)))
+    let ds = theme.hexValue(hex(UInt16(context.getRegister(.ds)!)))
+    let fs = theme.hexValue(hex(UInt16(context.getRegister(.fs)!)))
+    let gs = theme.hexValue(hex(UInt16(context.getRegister(.gs)!)))
+
+    let hexFlags = theme.hexValue(hex(eflags))
+    let status = theme.flags(x86StatusFlags(eflags))
+
+    print("")
+    print("\(theme.register("eflags")) \(hexFlags)  \(status)")
+    print("")
+    print("\(theme.register("es")): \(es) \(theme.register("cs")): \(cs) \(theme.register("ss")): \(ss) \(theme.register("ds")): \(ds) \(theme.register("fs")): \(fs)) \(theme.register("gs")): \(gs)")
+  }
+
+  static func showRegisters(_ context: ARM64Context) {
+    showGPRs(context, range: .x0 ..< .x29)
+    showGPR(name: "fp", context: context, register: .x29)
+    showGPR(name: "lr", context: context, register: .x30)
+    showGPR(name: "sp", context: context, register: .sp)
+    showGPR(name: "pc", context: context, register: .pc)
+  }
+
+  static func showRegisters(_ context: ARMContext) {
+    showGPRs(context, range: .r0 ... .r10)
+    showGPR(name: "fp", context: context, register: .r11)
+    showGPR(name: "ip", context: context, register: .r12)
+    showGPR(name: "sp", context: context, register: .r13)
+    showGPR(name: "lr", context: context, register: .r14)
+    showGPR(name: "pc", context: context, register: .r15)
+  }
+}
+
+#else
+
+@main
+internal struct SwiftBacktrace {
+  static public func main() {
+    print("swift-backtrace: not supported on this platform.")
+  }
+}
+
+#endif // os(macOS)

--- a/test/Backtracing/Crash.swift
+++ b/test/Backtracing/Crash.swift
@@ -1,0 +1,178 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/Crash
+// RUN: %target-build-swift %s -parse-as-library -Onone -o %t/CrashNoDebug
+// RUN: %target-build-swift %s -parse-as-library -O -g -o %t/CrashOpt
+// RUN: %target-build-swift %s -parse-as-library -O -o %t/CrashOptNoDebug
+// RUN: %target-codesign %t/Crash
+// RUN: %target-codesign %t/CrashNoDebug
+// RUN: %target-codesign %t/CrashOpt
+// RUN: %target-codesign %t/CrashOptNoDebug
+// RUN: (env SWIFT_BACKTRACE=enable=yes %target-run %t/Crash || true) | %FileCheck %s
+// RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes %target-run %t/Crash || true) | %FileCheck %s --check-prefix FRIENDLY
+// RUN: (env SWIFT_BACKTRACE=enable=yes %target-run %t/CrashNoDebug || true) | %FileCheck %s --check-prefix NODEBUG
+// RUN: (env SWIFT_BACKTRACE=enable=yes %target-run %t/CrashOpt || true) | %FileCheck %s --check-prefix OPTIMIZED
+// RUN: (env SWIFT_BACKTRACE=enable=yes %target-run %t/CrashOptNoDebug || true) | %FileCheck %s --check-prefix OPTNODEBUG
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+
+func level1() {
+  level2()
+}
+
+func level2() {
+  level3()
+}
+
+func level3() {
+  level4()
+}
+
+func level4() {
+  level5()
+}
+
+func level5() {
+  print("About to crash")
+  let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
+  ptr.pointee = 42
+}
+
+@main
+struct Crash {
+  static func main() {
+    level1()
+  }
+}
+
+// CHECK: *** Program crashed: Bad pointer dereference at 0x{{0+}}4 ***
+
+// CHECK: Thread 0 crashed:
+
+// CHECK: 0               0x{{[0-9a-f]+}} level5() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:38:15
+// CHECK-NEXT: 1 [ra]          0x{{[0-9a-f]+}} level4() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:32:3
+// CHECK-NEXT: 2 [ra]          0x{{[0-9a-f]+}} level3() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:28:3
+// CHECK-NEXT: 3 [ra]          0x{{[0-9a-f]+}} level2() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:24:3
+// CHECK-NEXT: 4 [ra]          0x{{[0-9a-f]+}} level1() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:20:3
+// CHECK-NEXT: 5 [ra]          0x{{[0-9a-f]+}} static Crash.main() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:44:5
+// CHECK-NEXT: 6 [ra] [system] 0x{{[0-9a-f]+}} static Crash.$main() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:41:1
+// CHECK-NEXT: 7 [ra] [system] 0x{{[0-9a-f]+}} main + {{[0-9]+}} in Crash at {{.*}}/Crash.swift
+// CHECK-NEXT: 8 [ra] [system] 0x{{[0-9a-f]+}} start + {{[0-9]+}} in dyld
+
+// CHECK: Registers:
+
+// CHECK: Images ({{[0-9]+}} omitted):
+
+// CHECK: {{0x[0-9a-f]+}}–{{0x[0-9a-f]+}}{{ +}}{{[0-9a-f]+}}{{ +}}Crash{{ +}}{{.*}}/Crash
+
+// FRIENDLY: *** Program crashed: Bad pointer dereference at 0x{{0+}}4 ***
+
+// FRIENDLY: Thread 0 crashed:
+
+// FRIENDLY: 0 level5() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:38:15
+
+// FRIENDLY: 36│   print("About to crash")
+// FRIENDLY-NEXT: 37│   let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
+// FRIENDLY-NEXT: 38│   ptr.pointee = 42
+// FRIENDLY-NEXT:   │               ▲
+// FRIENDLY-NEXT: 39│ }
+// FRIENDLY-NEXT: 40│
+
+// FRIENDLY: 1 level4() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:32:3
+
+// FRIENDLY: 30│
+// FRIENDLY-NEXT: 31│ func level4() {
+// FRIENDLY-NEXT: 32│   level5()
+// FRIENDLY-NEXT:   │   ▲
+// FRIENDLY-NEXT: 33│ }
+// FRIENDLY-NEXT: 34│
+
+// FRIENDLY: 2 level3() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:28:3
+
+// FRIENDLY: 26│
+// FRIENDLY-NEXT: 27│ func level3() {
+// FRIENDLY-NEXT: 28│   level4()
+// FRIENDLY-NEXT:   │   ▲
+// FRIENDLY-NEXT: 29│ }
+// FRIENDLY-NEXT: 30│
+
+// FRIENDLY: 3 level2() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:24:3
+
+// FRIENDLY: 22│
+// FRIENDLY-NEXT: 23│ func level2() {
+// FRIENDLY-NEXT: 24│   level3()
+// FRIENDLY-NEXT:   │   ▲
+// FRIENDLY-NEXT: 25│ }
+// FRIENDLY-NEXT: 26│
+
+// FRIENDLY: 4 level1() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:20:3
+
+// FRIENDLY:  18│
+// FRIENDLY-NEXT: 19│ func level1() {
+// FRIENDLY-NEXT: 20│   level2()
+// FRIENDLY-NEXT:   │   ▲
+// FRIENDLY-NEXT: 21│ }
+// FRIENDLY-NEXT: 22│
+
+// FRIENDLY: 5 static Crash.main() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:44:5
+
+// FRIENDLY: 42│ struct Crash {
+// FRIENDLY-NEXT: 43│   static func main() {
+// FRIENDLY-NEXT: 44│     level1()
+// FRIENDLY-NEXT:   │     ▲
+// FRIENDLY-NEXT: 45│   }
+// FRIENDLY-NEXT: 46│ }
+
+// NODEBUG: *** Program crashed: Bad pointer dereference at 0x{{0*}}4 ***
+
+// NODEBUG: Thread 0 crashed:
+
+// NODEBUG: 0               0x{{[0-9a-f]+}} level5() + {{[0-9]+}} in CrashNoDebug
+// NODEBUG: 1 [ra]          0x{{[0-9a-f]+}} level4() + {{[0-9]+}} in CrashNoDebug
+// NODEBUG: 2 [ra]          0x{{[0-9a-f]+}} level3() + {{[0-9]+}} in CrashNoDebug
+// NODEBUG: 3 [ra]          0x{{[0-9a-f]+}} level2() + {{[0-9]+}} in CrashNoDebug
+// NODEBUG: 4 [ra]          0x{{[0-9a-f]+}} level1() + {{[0-9]+}} in CrashNoDebug
+// NODEBUG: 5 [ra]          0x{{[0-9a-f]+}} static Crash.main() + {{[0-9]+}} in CrashNoDebug
+// NODEBUG: 6 [ra] [system] 0x{{[0-9a-f]+}} static Crash.$main() + {{[0-9]+}} in CrashNoDebug
+// NODEBUG: 7 [ra]          0x{{[0-9a-f]+}} main + {{[0-9]+}} in CrashNoDebug
+// NODEBUG: 8 [ra] [system] 0x{{[0-9a-f]+}} start + {{[0-9]+}} in dyld
+
+// NODEBUG: Registers:
+
+// NODEBUG: Images ({{[0-9]+}} omitted):
+
+// NODEBUG: {{0x[0-9a-f]+}}–{{0x[0-9a-f]+}}{{ +}}{{[0-9a-f]+}}{{ +}}CrashNoDebug{{ +}}{{.*}}/CrashNoDebug
+
+// OPTIMIZED: *** Program crashed: Bad pointer dereference at 0x{{0+}}4 ***
+
+// OPTIMIZED: Thread 0 crashed:
+
+// OPTIMIZED: 0 [inlined]          0x{{[0-9a-f]+}} level5() in CrashOpt at {{.*}}/Crash.swift:38:15
+// OPTIMIZED-NEXT: 1 [inlined]          0x{{[0-9a-f]+}} level4() in CrashOpt at {{.*}}/Crash.swift:32:3
+// OPTIMIZED-NEXT: 2 [inlined]          0x{{[0-9a-f]+}} level3() in CrashOpt at {{.*}}/Crash.swift:28:3
+// OPTIMIZED-NEXT: 3 [inlined]          0x{{[0-9a-f]+}} level2() in CrashOpt at {{.*}}/Crash.swift:24:3
+// OPTIMIZED-NEXT: 4 [inlined]          0x{{[0-9a-f]+}} level1() in CrashOpt at {{.*}}/Crash.swift:20:3
+// OPTIMIZED-NEXT: 5 [inlined]          0x{{[0-9a-f]+}} static Crash.main() in CrashOpt at {{.*}}/Crash.swift:44:5
+// OPTIMIZED-NEXT: 6 [inlined] [system] 0x{{[0-9a-f]+}} static Crash.$main() in CrashOpt at {{.*}}/Crash.swift:41:1
+// OPTIMIZED-NEXT: 7 [system]           0x{{[0-9a-f]+}} main + {{[0-9]+}} in CrashOpt at {{.*}}/Crash.swift
+// OPTIMIZED-NEXT: 8 [ra] [system]      0x{{[0-9a-f]+}} start + {{[0-9]+}} in dyld
+
+// OPTIMIZED: Registers:
+
+// OPTIMIZED: Images ({{[0-9]+}} omitted):
+
+// OPTIMIZED: {{0x[0-9a-f]+}}–{{0x[0-9a-f]+}}{{ +}}{{[0-9a-f]+}}{{ +}}CrashOpt{{ +}}{{.*}}/CrashOpt
+
+// OPTNODEBUG: *** Program crashed: Bad pointer dereference at 0x{{0*}}4 ***
+
+// OPTNODEBUG: Thread 0 crashed:
+
+// OPTNODEBUG: 0               0x{{[0-9a-f]+}} main + {{[0-9]+}} in CrashOptNoDebug
+// OPTNODEBUG-NEXT: 1 [ra] [system] 0x{{[0-9a-f]+}} start + {{[0-9]+}} in dyld
+
+// OPTNODEBUG: Registers:
+
+// OPTNODEBUG: Images ({{[0-9]+}} omitted):
+
+// OPTNODEBUG: {{0x[0-9a-f]+}}–{{0x[0-9a-f]+}}{{ +}}{{[0-9a-f]+}}{{ +}}CrashOptNoDebug{{ +}}{{.*}}/CrashOptNoDebug
+

--- a/test/Backtracing/CrashWithThunk.swift
+++ b/test/Backtracing/CrashWithThunk.swift
@@ -1,0 +1,66 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/CrashWithThunk
+// RUN: %target-codesign %t/CrashWithThunk
+// RUN: (env SWIFT_BACKTRACE=enable=yes %target-run %t/CrashWithThunk || true) | %FileCheck %s
+// RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes %target-run %t/CrashWithThunk || true) | %FileCheck %s --check-prefix FRIENDLY
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+
+struct Foo<T> {
+  var value: T
+}
+
+func crash() {
+  print("I'm going to crash here")
+  let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
+  ptr.pointee = 42
+}
+
+@main
+struct CrashWithThunk {
+  static func main() {
+    let foo = Foo(value: crash)
+
+    foo.value()
+  }
+}
+
+// CHECK: *** Program crashed: Bad pointer dereference at 0x{{0+}}4 ***
+
+// CHECK: Thread 0 crashed:
+
+// CHECK: 0                       0x{{[0-9a-f]+}} crash() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:17:15
+// CHECK-NEXT: 1 [ra] [thunk] [system] 0x{{[0-9a-f]+}} thunk for @escaping @callee_guaranteed () -> () + {{[0-9]+}} in CrashWithThunk at {{.*}}/Backtracing/<compiler-generated>
+// CHECK-NEXT: 2 [ra]                  0x{{[0-9a-f]+}} static CrashWithThunk.main() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:25:9
+// CHECK-NEXT: 3 [ra] [system]         0x{{[0-9a-f]+}} static CrashWithThunk.$main() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:20:1
+// CHECK-NEXT: 4 [ra] [system]         0x{{[0-9a-f]+}} main + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift
+// CHECK-NEXT: 5 [ra] [system]         0x{{[0-9a-f]+}} start + {{[0-9]+}} in dyld
+
+// CHECK: Registers:
+
+// CHECK: Images ({{[0-9]+}} omitted):
+
+// CHECK: {{0x[0-9a-f]+}}–{{0x[0-9a-f]+}}{{ +}}{{[0-9a-f]+}}{{ +}}CrashWithThunk{{ +}}{{.*}}/CrashWithThunk
+
+// FRIENDLY: *** Program crashed: Bad pointer dereference at 0x{{0+}}4 ***
+
+// FRIENDLY: Thread 0 crashed:
+
+// FRIENDLY: 0 crash() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:17:15
+
+// FRIENDLY: 15│   print("I'm going to crash here")
+// FRIENDLY-NEXT: 16│   let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
+// FRIENDLY-NEXT: 17│   ptr.pointee = 42
+// FRIENDLY-NEXT:   │               ▲
+// FRIENDLY-NEXT: 18│ }
+// FRIENDLY-NEXT: 19│
+
+// FRIENDLY: 1 static CrashWithThunk.main() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:25:9
+
+// FRIENDLY: 23│     let foo = Foo(value: crash)
+// FRIENDLY-NEXT: 24│
+// FRIENDLY-NEXT: 25│     foo.value()
+// FRIENDLY-NEXT:   │         ▲
+// FRIENDLY-NEXT: 26│   }
+// FRIENDLY-NEXT: 27│ }

--- a/test/Backtracing/Overflow.swift
+++ b/test/Backtracing/Overflow.swift
@@ -1,0 +1,110 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/Overflow
+// RUN: %target-codesign %t/Overflow
+// RUN: (env SWIFT_BACKTRACE=enable=yes %target-run %t/Overflow || true) | %FileCheck %s
+// RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes %target-run %t/Overflow || true) | %FileCheck %s --check-prefix FRIENDLY
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+var x: UInt = 0
+
+func level1() {
+  level2()
+}
+
+func level2() {
+  level3()
+}
+
+func level3() {
+  level4()
+}
+
+func level4() {
+  level5()
+}
+
+func level5() {
+  print("About to overflow")
+
+  x -= 1
+}
+
+@main
+struct Overflow {
+  static func main() {
+    level1()
+  }
+}
+
+// CHECK: *** Swift runtime failure: arithmetic overflow ***
+
+// CHECK: Thread 0 crashed:
+
+// CHECK:      0 [inlined] [system] 0x{{[0-9a-f]+}} Swift runtime failure: arithmetic overflow in Overflow at {{.*}}/<compiler-generated>
+// CHECK-NEXT: 1                    0x{{[0-9a-f]+}} level5() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:{{30|29}}:5
+// CHECK-NEXT: 2 [ra]               0x{{[0-9a-f]+}} level4() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:{{24|23}}:3
+// CHECK-NEXT: 3 [ra]               0x{{[0-9a-f]+}} level3() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:{{20|19}}:3
+// CHECK-NEXT: 4 [ra]               0x{{[0-9a-f]+}} level2() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:{{16|15}}:3
+// CHECK-NEXT: 5 [ra]               0x{{[0-9a-f]+}} level1() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:{{12|11}}:3
+// CHECK-NEXT: 6 [ra]               0x{{[0-9a-f]+}} static Overflow.main() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:36:5
+// CHECK-NEXT: 7 [ra] [system]      0x{{[0-9a-f]+}} static Overflow.$main() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:33:1
+// CHECK-NEXT: 8 [ra] [system]      0x{{[0-9a-f]+}} main + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift
+// CHECK-NEXT: 9 [ra] [system]      0x{{[0-9a-f]+}} start + {{[0-9]+}} in dyld
+
+// CHECK: Registers:
+
+// CHECK: Images ({{[0-9]+}} omitted):
+
+// CHECK: {{0x[0-9a-f]+}}–{{0x[0-9a-f]+}}{{ +}}{{[0-9a-f]+}}{{ +}}Overflow{{ +}}{{.*}}/Overflow
+
+// FRIENDLY: *** Swift runtime failure: arithmetic overflow ***
+
+// FRIENDLY: Thread 0 crashed:
+
+// FRIENDLY: 0 level5() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:30:5
+
+// FRIENDLY: 28│   print("About to overflow")
+// FRIENDLY-NEXT: 29│
+// FRIENDLY-NEXT: 30│   x -= 1
+// FRIENDLY-NEXT:   │     ▲
+// FRIENDLY-NEXT: 31│ }
+
+// FRIENDLY: 1 level4() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:24:3
+
+// FRIENDLY: 22│
+// FRIENDLY-NEXT: 23│ func level4() {
+// FRIENDLY-NEXT: 24│   level5()
+// FRIENDLY-NEXT:   │   ▲
+// FRIENDLY-NEXT: 25│ }
+// FRIENDLY-NEXT: 26│
+
+// FRIENDLY: 2 level3() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:20:3
+
+// FRIENDLY: 18│
+// FRIENDLY-NEXT: 19│ func level3() {
+// FRIENDLY-NEXT: 20│   level4()
+// FRIENDLY-NEXT:   │   ▲
+// FRIENDLY-NEXT: 21│ }
+// FRIENDLY-NEXT: 22│
+
+// FRIENDLY: 3 level2() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:16:3
+
+// FRIENDLY: 14│
+// FRIENDLY-NEXT: 15│ func level2() {
+// FRIENDLY-NEXT: 16│   level3()
+// FRIENDLY-NEXT:   │   ▲
+// FRIENDLY-NEXT: 17│ }
+// FRIENDLY-NEXT: 18│
+
+// FRIENDLY: 4 level1() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:12:3
+
+// FRIENDLY: 10│
+// FRIENDLY-NEXT: 11│ func level1() {
+// FRIENDLY-NEXT: 12│   level2()
+// FRIENDLY-NEXT:   │   ▲
+// FRIENDLY-NEXT: 13│ }
+// FRIENDLY-NEXT: 14│
+
+// FRIENDLY: 5 static Overflow.main() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift
+

--- a/test/Backtracing/StackOverflow.swift
+++ b/test/Backtracing/StackOverflow.swift
@@ -1,0 +1,212 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -parse-as-library -Onone -g -o %t/StackOverflow
+// RUN: %target-codesign %t/StackOverflow
+// RUN: (env SWIFT_BACKTRACE=enable=yes %target-run %t/StackOverflow || true) | %FileCheck %s
+// RUN: (env SWIFT_BACKTRACE=limit=16,top=4,enable=yes %target-run %t/StackOverflow || true) | %FileCheck %s --check-prefix LIMITED
+// RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes %target-run %t/StackOverflow || true) | %FileCheck %s --check-prefix FRIENDLY
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+
+func recurse(_ level: Int) {
+  if level % 100000 == 0 {
+    print(level)
+  }
+  recurse(level + 1)
+}
+
+@main
+struct StackOverflow {
+  static func main() {
+    recurse(1)
+  }
+}
+
+// FIXME: We have to allow all the line numbers below to be off-by-one because
+// of a CoreSymbolication bug.  This also means we have to skip checking the
+// source code output because currently, it's pointing at the wrong line :-(
+
+// CHECK: *** Program crashed: Bad pointer dereference at 0x{{[0-9a-f]+}} ***
+
+// CHECK: Thread 0 crashed:
+
+// CHECK:     0               0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{[0-9]+}}
+// CHECK-NEXT:     1 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:     2 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:     3 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:     4 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:     5 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:     6 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:     7 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:     8 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:     9 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    10 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    11 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    12 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    13 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    14 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    15 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    16 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    17 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    18 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    19 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    20 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    21 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    22 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    23 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    24 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    25 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    26 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    27 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    28 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    29 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    30 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    31 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    32 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    33 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    34 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    35 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    36 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    37 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    38 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    39 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    40 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    41 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    42 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    43 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    44 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    45 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:    46 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT:   ...
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} static StackOverflow.main() + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{21|20}}:5
+// CHECK-NEXT: {{[0-9]+}} [ra] [system] 0x{{[0-9a-f]+}} static StackOverflow.$main() + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{18|17}}:1
+// CHECK-NEXT: {{[0-9]+}} [ra] [system] 0x{{[0-9a-f]+}} main + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift
+// CHECK-NEXT: {{[0-9]+}} [ra] [system] 0x{{[0-9a-f]+}} start + {{[0-9]+}} in dyld
+
+// CHECK: Registers:
+
+// CHECK: Images ({{[0-9]+}} omitted):
+
+// CHECK: {{0x[0-9a-f]+}}–{{0x[0-9a-f]+}}{{ +}}{{[0-9a-f]+}}{{ +}}StackOverflow{{ +}}{{.*}}/StackOverflow
+
+// LIMITED: *** Program crashed: Bad pointer dereference at 0x{{[0-9a-f]+}} ***
+
+// LIMITED: Thread 0 crashed:
+
+// LIMITED:     0               0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{[0-9]+}}
+// LIMITED-NEXT:     1 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// LIMITED-NEXT:     2 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// LIMITED-NEXT:     3 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// LIMITED-NEXT:     4 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// LIMITED-NEXT:     5 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// LIMITED-NEXT:     6 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// LIMITED-NEXT:     7 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// LIMITED-NEXT:     8 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// LIMITED-NEXT:     9 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// LIMITED-NEXT:    10 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// LIMITED-NEXT:   ...
+// LIMITED-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} static StackOverflow.main() + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{21|20}}:5
+// LIMITED-NEXT: {{[0-9]+}} [ra] [system] 0x{{[0-9a-f]+}} static StackOverflow.$main() + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{18|17}}:1
+// LIMITED-NEXT: {{[0-9]+}} [ra] [system] 0x{{[0-9a-f]+}} main + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift
+// LIMITED-NEXT: {{[0-9]+}} [ra] [system] 0x{{[0-9a-f]+}} start + {{[0-9]+}} in dyld
+
+// FRIENDLY: *** Program crashed: Bad pointer dereference at 0x{{[0-9a-f]+}} ***
+
+// FRIENDLY: Thread 0 crashed:
+
+// FRIENDLY:     0 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{[0-9]+}}
+
+// SKIP-FRIENDLY:      8│ // REQUIRES: executable_test
+// SKIP-FRIENDLY-NEXT:      9│ // REQUIRES: OS=macosx
+// SKIP-FRIENDLY-NEXT:     10│
+// SKIP-FRIENDLY-NEXT:     11│ func recurse(_ level: Int) {
+// SKIP-FRIENDLY-NEXT:       │ ▲
+// SKIP-FRIENDLY-NEXT:     12│   if level % 100000 == 0 {
+
+// FRIENDLY:     1 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+
+// SKIP-FRIENDLY:     12│   if level % 100000 == 0 {
+// SKIP-FRIENDLY-NEXT:     13│     print(level)
+// SKIP-FRIENDLY-NEXT:     14│   }
+// SKIP-FRIENDLY-NEXT:     15│   recurse(level + 1)
+// SKIP-FRIENDLY-NEXT:       │   ▲
+// SKIP-FRIENDLY-NEXT:     16│ }
+
+// FRIENDLY:     2 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:     3 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:     4 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:     5 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:     6 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:     7 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:     8 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:     9 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    10 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    11 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    12 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    13 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    14 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    15 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    16 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    17 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    18 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    19 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    20 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    21 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    22 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    23 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    24 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    25 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    26 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    27 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    28 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    29 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    30 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    31 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    32 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    33 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    34 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    35 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    36 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    37 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    38 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    39 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    40 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    41 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    42 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    43 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    44 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    45 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:    46 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT:   ...
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{15|14}}:3
+// FRIENDLY-NEXT: {{[0-9]+}} static StackOverflow.main() + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{21|20}}:5
+
+// SKIP-FRIENDLY:     18│ @main
+// SKIP-FRIENDLY-NEXT:     19│ struct StackOverflow {
+// SKIP-FRIENDLY-NEXT:     20│   static func main() {
+// SKIP-FRIENDLY-NEXT:     21│     recurse(1)
+// SKIP-FRIENDLY-NEXT:       │     ▲
+// SKIP-FRIENDLY-NEXT:     22│   }

--- a/test/Backtracing/SymbolicatedBacktrace.swift
+++ b/test/Backtracing/SymbolicatedBacktrace.swift
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -parse-as-library -g -Onone -o %t/SymbolicatedBacktrace
+// RUN: %target-codesign %t/SymbolicatedBacktrace
+// RUN: %target-run %t/SymbolicatedBacktrace | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=ios || OS=watchOS || OS=tvOS
+
+import _Backtracing
+
+func kablam() {
+  kerpow()
+}
+
+func kerpow() {
+  whap()
+}
+
+func whap() {
+  zonk()
+}
+
+func zonk() {
+  splat()
+}
+
+func splat() {
+  pow()
+}
+
+func pow() {
+  let backtrace = try! Backtrace.capture().symbolicated()!
+
+  // CHECK:      0{{[ \t]+}}0x{{[0-9a-f]+}} [ra] [0] SymbolicatedBacktrace pow()
+  // CHECK:      1{{[ \t]+}}0x{{[0-9a-f]+}} [ra] [0] SymbolicatedBacktrace splat()
+  // CHECK:      2{{[ \t]+}}0x{{[0-9a-f]+}} [ra] [0] SymbolicatedBacktrace zonk()
+  // CHECK:      3{{[ \t]+}}0x{{[0-9a-f]+}} [ra] [0] SymbolicatedBacktrace whap()
+  // CHECK:      4{{[ \t]+}}0x{{[0-9a-f]+}} [ra] [0] SymbolicatedBacktrace kerpow()
+  // CHECK:      5{{[ \t]+}}0x{{[0-9a-f]+}} [ra] [0] SymbolicatedBacktrace kablam()
+  // CHECK:      6{{[ \t]+}}0x{{[0-9a-f]+}} [ra] [0] SymbolicatedBacktrace static SymbolicatedBacktrace.main()
+
+  print(backtrace)
+}
+
+@main
+struct SymbolicatedBacktrace {
+  static func main() {
+    kablam()
+  }
+}

--- a/test/Backtracing/SymbolicatedBacktraceInline.swift
+++ b/test/Backtracing/SymbolicatedBacktraceInline.swift
@@ -1,0 +1,50 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -parse-as-library -g -O -o %t/SymbolicatedBacktraceInline
+// RUN: %target-codesign %t/SymbolicatedBacktraceInline
+// RUN: %target-run %t/SymbolicatedBacktraceInline | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx || OS=ios || OS=watchOS || OS=tvOS
+
+import _Backtracing
+
+func kablam() {
+  kerpow()
+}
+
+func kerpow() {
+  whap()
+}
+
+func whap() {
+  zonk()
+}
+
+func zonk() {
+  splat()
+}
+
+func splat() {
+  pow()
+}
+
+func pow() {
+  let backtrace = try! Backtrace.capture().symbolicated()!
+
+  // CHECK:      0{{[ \t]+}}0x{{[0-9a-f]+}} [ra] [0] SymbolicatedBacktraceInline pow()
+  // CHECK:      1{{[ \t]+}}0x{{[0-9a-f]+}} [ra] [inlined] [0] SymbolicatedBacktraceInline splat()
+  // CHECK:      2{{[ \t]+}}0x{{[0-9a-f]+}} [ra] [inlined] [0] SymbolicatedBacktraceInline zonk()
+  // CHECK:      3{{[ \t]+}}0x{{[0-9a-f]+}} [ra] [inlined] [0] SymbolicatedBacktraceInline whap()
+  // CHECK:      4{{[ \t]+}}0x{{[0-9a-f]+}} [ra] [inlined] [0] SymbolicatedBacktraceInline kerpow()
+  // CHECK:      5{{[ \t]+}}0x{{[0-9a-f]+}} [ra] [inlined] [0] SymbolicatedBacktraceInline kablam()
+  // CHECK:      6{{[ \t]+}}0x{{[0-9a-f]+}} [ra] [inlined] [0] SymbolicatedBacktraceInline static SymbolicatedBacktraceInline.main()
+
+  print(backtrace)
+}
+
+@main
+struct SymbolicatedBacktraceInline {
+  static func main() {
+    kablam()
+  }
+}


### PR DESCRIPTION
This is Swift's external backtracer.  It's written in Swift, and it's responsible for generating nice backtraces when Swift programs crash. It makes use of the new `_Backtracing` library, which is also (mostly, aside from some assembly language) implemented in Swift.

rdar://103442000
