### PR TITLE
[Threading][Win32] Fix a warning.

### DIFF
--- a/include/swift/Threading/Impl/Win32/Win32Defs.h
+++ b/include/swift/Threading/Impl/Win32/Win32Defs.h
@@ -47,8 +47,7 @@ typedef struct _RTL_CONDITION_VARIABLE *PRTL_CONDITION_VARIABLE;
 typedef PRTL_CONDITION_VARIABLE PCONDITION_VARIABLE;
 
 // These have to be #defines, to avoid problems with <windows.h>
-#define RTL_SRWLOCK_INIT                                                       \
-  { 0 }
+#define RTL_SRWLOCK_INIT {0}
 #define SRWLOCK_INIT RTL_SRWLOCK_INIT
 #define FLS_OUT_OF_INDEXES ((DWORD)0xFFFFFFFF)
 


### PR DESCRIPTION
The `RTL_SRWLOCK_INIT` declaration got reformatted and doesn't exactly match what's in `windows.h`, so we're getting warnings during builds. Fix to match what it says in the system header.

rdar://105400572
