### PR TITLE
[interop][SwiftToCxx] fix vtable offset computation & dispatch virtual Swift methods using a relative offset into the vtable for classes deriving from resilient classes

### DIFF
--- a/include/swift/IRGen/IRABIDetailsProvider.h
+++ b/include/swift/IRGen/IRABIDetailsProvider.h
@@ -271,15 +271,15 @@ public:
     }
 
     static MethodDispatchInfo indirectVTableStaticOffset(
-        size_t bitOffset, Optional<PointerAuthDiscriminator> discriminator) {
-      return MethodDispatchInfo(Kind::IndirectVTableStaticOffset, bitOffset, "",
+        size_t offset, Optional<PointerAuthDiscriminator> discriminator) {
+      return MethodDispatchInfo(Kind::IndirectVTableStaticOffset, offset, "",
                                 discriminator);
     }
 
     static MethodDispatchInfo indirectVTableRelativeOffset(
-        size_t bitOffset, std::string symbolName,
+        size_t offset, std::string symbolName,
         Optional<PointerAuthDiscriminator> discriminator) {
-      return MethodDispatchInfo(Kind::IndirectVTableRelativeOffset, bitOffset,
+      return MethodDispatchInfo(Kind::IndirectVTableRelativeOffset, offset,
                                 symbolName, discriminator);
     }
 
@@ -289,11 +289,11 @@ public:
 
     Kind getKind() const { return kind; }
 
-    /// Return the bit offset into the vtable from which the method pointer
+    /// Return the byte offset into the vtable from which the method pointer
     /// should be loaded.
-    size_t getStaticBitOffset() const {
+    size_t getStaticOffset() const {
       assert(kind == Kind::IndirectVTableStaticOffset);
-      return bitOffset;
+      return offset;
     }
     Optional<PointerAuthDiscriminator> getPointerAuthDiscriminator() const {
       assert(kind == Kind::IndirectVTableStaticOffset ||
@@ -305,11 +305,11 @@ public:
       return symbolName;
     }
 
-    /// Return the bit offset relative to base offset value into the vtable from
-    /// which the method pointer should be loaded.
-    size_t getRelativeBitOffset() const {
+    /// Return the byte offset relative to base offset value into the vtable
+    /// from which the method pointer should be loaded.
+    size_t getRelativeOffset() const {
       assert(kind == Kind::IndirectVTableRelativeOffset);
-      return bitOffset;
+      return offset;
     }
 
     /// Return the external symbol from which the relative base offset should be
@@ -320,13 +320,13 @@ public:
     }
 
   private:
-    MethodDispatchInfo(Kind kind, size_t bitOffset, std::string symbolName = "",
+    MethodDispatchInfo(Kind kind, size_t offset, std::string symbolName = "",
                        Optional<PointerAuthDiscriminator> discriminator = None)
-        : kind(kind), bitOffset(bitOffset), symbolName(symbolName),
+        : kind(kind), offset(offset), symbolName(symbolName),
           discriminator(discriminator) {}
 
     Kind kind;
-    size_t bitOffset;
+    size_t offset;
     std::string symbolName;
     Optional<PointerAuthDiscriminator> discriminator;
   };

--- a/lib/IRGen/IRABIDetailsProvider.cpp
+++ b/lib/IRGen/IRABIDetailsProvider.cpp
@@ -256,9 +256,18 @@ public:
             /*bitOffset=*/mi->TheOffset.getStaticOffset().getValue(),
             getMethodPointerAuthInfo(funcDecl, silDecl));
       }
-      return {};
+      assert(mi->TheOffset.isDynamic());
+      return MethodDispatchInfo::indirectVTableRelativeOffset(
+          mi->TheOffset.getRelativeOffset().getValue(),
+          LinkEntity::forClassMetadataBaseOffset(parentClass).mangleAsString(),
+          getMethodPointerAuthInfo(funcDecl, silDecl));
     }
     llvm_unreachable("invalid kind");
+  }
+
+  Type getClassBaseOffsetSymbolType() const {
+    return *getPrimitiveTypeFromLLVMType(
+        silMod->getASTContext(), IGM.ClassMetadataBaseOffsetTy->elements()[0]);
   }
 
   Lowering::TypeConverter typeConverter;
@@ -469,4 +478,8 @@ Optional<IRABIDetailsProvider::MethodDispatchInfo>
 IRABIDetailsProvider::getMethodDispatchInfo(
     const AbstractFunctionDecl *funcDecl) {
   return impl->getMethodDispatchInfo(funcDecl);
+}
+
+Type IRABIDetailsProvider::getClassBaseOffsetSymbolType() const {
+  return impl->getClassBaseOffsetSymbolType();
 }

--- a/lib/IRGen/IRABIDetailsProvider.cpp
+++ b/lib/IRGen/IRABIDetailsProvider.cpp
@@ -253,12 +253,13 @@ public:
     case ClassMetadataLayout::MethodInfo::Kind::Offset:
       if (mi->TheOffset.isStatic()) {
         return MethodDispatchInfo::indirectVTableStaticOffset(
-            /*bitOffset=*/mi->TheOffset.getStaticOffset().getValue(),
+            /*offset=*/mi->TheOffset.getStaticOffset().getValue(),
             getMethodPointerAuthInfo(funcDecl, silDecl));
       }
       assert(mi->TheOffset.isDynamic());
       return MethodDispatchInfo::indirectVTableRelativeOffset(
-          mi->TheOffset.getRelativeOffset().getValue(),
+          /*offset=*/mi->TheOffset.getRelativeOffset().getValue(),
+          /*symbolName=*/
           LinkEntity::forClassMetadataBaseOffset(parentClass).mangleAsString(),
           getMethodPointerAuthInfo(funcDecl, silDecl));
     }

--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ClangSyntaxPrinter.h"
+#include "PrimitiveTypeMapping.h"
 #include "swift/ABI/MetadataValues.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/Decl.h"
@@ -423,4 +424,14 @@ void ClangSyntaxPrinter::printSymbolUSRAttribute(const ValueDecl *D) const {
   if (result.empty())
     return;
   os << " SWIFT_SYMBOL(\"" << result << "\")";
+}
+
+void ClangSyntaxPrinter::printKnownCType(
+    Type t, PrimitiveTypeMapping &typeMapping) const {
+  auto info =
+      typeMapping.getKnownCTypeInfo(t->getNominalOrBoundGenericNominal());
+  assert(info.has_value() && "not a known type");
+  os << info->name;
+  if (info->canBeNullable)
+    os << " _Null_unspecified";
 }

--- a/lib/PrintAsClang/ClangSyntaxPrinter.h
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.h
@@ -13,9 +13,10 @@
 #ifndef SWIFT_PRINTASCLANG_CLANGSYNTAXPRINTER_H
 #define SWIFT_PRINTASCLANG_CLANGSYNTAXPRINTER_H
 
-#include "swift/IRGen/GenericRequirement.h"
+#include "swift/AST/Type.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/ClangImporter/ClangImporter.h"
+#include "swift/IRGen/GenericRequirement.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -25,6 +26,7 @@ class CanGenericSignature;
 class GenericTypeParamType;
 class ModuleDecl;
 class NominalTypeDecl;
+class PrimitiveTypeMapping;
 
 namespace cxx_synthesis {
 
@@ -224,6 +226,9 @@ public:
   /// Print the macro that applies Clang's `external_source_symbol` attribute
   /// on the generated declaration.
   void printSymbolUSRAttribute(const ValueDecl *D) const;
+
+  /// Print the given **known** type as a C type.
+  void printKnownCType(Type t, PrimitiveTypeMapping &typeMapping) const;
 
 protected:
   raw_ostream &os;

--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -1443,6 +1443,21 @@ private:
               FD, funcABI, resultTy, funcTy, dispatchInfo->getThunkSymbolName(),
               "dispatch thunk for");
           assert(!thunkRepresentation.isUnsupported());
+        } else if (dispatchInfo->getKind() ==
+                   IRABIDetailsProvider::MethodDispatchInfo::Kind::
+                       IndirectVTableRelativeOffset) {
+          // Emit the C signature for the class metadata base offset.
+          owningPrinter.interopContext.runIfStubForDeclNotEmitted(
+              dispatchInfo->getBaseOffsetSymbolName(), [&] {
+                auto baseClassOffsetType =
+                    owningPrinter.interopContext.getIrABIDetails()
+                        .getClassBaseOffsetSymbolType();
+                os << "SWIFT_EXTERN ";
+                ClangSyntaxPrinter(os).printKnownCType(
+                    baseClassOffsetType, owningPrinter.typeMapping);
+                os << ' ' << dispatchInfo->getBaseOffsetSymbolName()
+                   << "; // class metadata base offset\n";
+              });
         }
       }
     }

--- a/lib/PrintAsClang/PrintClangClassType.cpp
+++ b/lib/PrintAsClang/PrintClangClassType.cpp
@@ -50,8 +50,6 @@ void ClangClassTypePrinter::printClassTypeDecl(
     ClangSyntaxPrinter(baseQualNameOS)
         .printModuleNamespaceQualifiersIfNeeded(parentClass->getModuleContext(),
                                                 typeDecl->getModuleContext());
-    if (!baseQualNameOS.str().empty())
-      baseQualNameOS << "::";
     baseQualNameOS << baseNameOS.str();
   } else {
     baseClassName = "RefCountedClass";

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -1129,13 +1129,12 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
       os << "FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ "
             "+ ";
       if (dispatchInfo->getKind() == DispatchKindTy::IndirectVTableStaticOffset)
-        os << (dispatchInfo->getStaticBitOffset() / 8);
+        os << dispatchInfo->getStaticOffset();
       else
         os << '(' << cxx_synthesis::getCxxImplNamespaceName()
-           << "::" << dispatchInfo->getBaseOffsetSymbolName()
-           << " / sizeof(void *)) + "
-           << (dispatchInfo->getRelativeBitOffset() / 8);
-      os << ");\n";
+           << "::" << dispatchInfo->getBaseOffsetSymbolName() << " + "
+           << dispatchInfo->getRelativeOffset() << ')';
+      os << " / sizeof(void *));\n";
       indirectFunctionVar = StringRef("fptrptr_->func");
       break;
     case DispatchKindTy::Thunk:

--- a/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
+++ b/lib/PrintAsClang/PrintSwiftToClangCoreScaffold.cpp
@@ -23,16 +23,6 @@
 
 using namespace swift;
 
-static void printKnownCType(Type t, PrimitiveTypeMapping &typeMapping,
-                            raw_ostream &os) {
-  auto info =
-      typeMapping.getKnownCTypeInfo(t->getNominalOrBoundGenericNominal());
-  assert(info.has_value() && "not a known type");
-  os << info->name;
-  if (info->canBeNullable)
-    os << " _Null_unspecified";
-}
-
 static void printKnownStruct(
     PrimitiveTypeMapping &typeMapping, raw_ostream &os, StringRef name,
     const IRABIDetailsProvider::TypeRecordABIRepresentation &typeRecord) {
@@ -40,7 +30,7 @@ static void printKnownStruct(
   os << "struct " << name << " {\n";
   for (const auto &ty : llvm::enumerate(typeRecord.getMembers())) {
     os << "  ";
-    printKnownCType(ty.value(), typeMapping, os);
+    ClangSyntaxPrinter(os).printKnownCType(ty.value(), typeMapping);
     os << " _" << ty.index() << ";\n";
   }
   os << "};\n";
@@ -51,7 +41,8 @@ static void printKnownTypedef(
     const IRABIDetailsProvider::TypeRecordABIRepresentation &typeRecord) {
   assert(typeRecord.getMembers().size() == 1);
   os << "typedef ";
-  printKnownCType(typeRecord.getMembers()[0], typeMapping, os);
+  ClangSyntaxPrinter(os).printKnownCType(typeRecord.getMembers()[0],
+                                         typeMapping);
   os << " " << name << ";\n";
 }
 

--- a/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch.swift
@@ -124,7 +124,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT: struct FTypeAddress {
 // CHECK-NEXT: decltype(_impl::$s5Class04BaseA0C13virtualMethodyyF) * func;
 // CHECK-NEXT: };
-// CHECK-NEXT: FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1:]]);
+// CHECK-NEXT: FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1:]] / sizeof(void *));
 // CHECK-NEXT: return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
 
@@ -138,7 +138,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT: struct FTypeAddress {
 // CHECK-NEXT: decltype(_impl::$s5Class04BaseA0C016virtualMethodIntE0yS2iF) * func;
 // CHECK-NEXT: };
-// CHECK-NEXT: FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1 + 1]]);
+// CHECK-NEXT: FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM2:]] / sizeof(void *));
 // CHECK-NEXT:   return (* fptrptr_->func)(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
@@ -156,7 +156,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   struct FTypeAddress {
 // CHECK-NEXT:   decltype(_impl::$s5Class04BaseA0C19virtualComputedPropSivg) * func;
 // CHECK-NEXT:   };
-// CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1 + 2]]);
+// CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM3:]] / sizeof(void *));
 // CHECK-NEXT:     return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
@@ -170,7 +170,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   struct FTypeAddress {
 // CHECK-NEXT:   decltype(_impl::$s5Class04BaseA0C21virtualComputedGetSets5Int64Vvg) * func;
 // CHECK-NEXT:   };
-// CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1 + 3]]);
+// CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM4:]] / sizeof(void *));
 // CHECK-NEXT:     return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
@@ -184,7 +184,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   struct FTypeAddress {
 // CHECK-NEXT:   decltype(_impl::$s5Class04BaseA0C21virtualComputedGetSets5Int64Vvs) * func;
 // CHECK-NEXT:   };
-// CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1 + 4]]);
+// CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM5:]] / sizeof(void *));
 // CHECK-NEXT:   return (* fptrptr_->func)(newValue, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
@@ -198,7 +198,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   struct FTypeAddress {
 // CHECK-NEXT:   decltype(_impl::$s5Class04BaseA0C10storedPropSivg) * func;
 // CHECK-NEXT:   };
-// CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1 + 6]]);
+// CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM7:]] / sizeof(void *));
 // CHECK-NEXT:   return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
@@ -212,7 +212,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   struct FTypeAddress {
 // CHECK-NEXT:   decltype(_impl::$s5Class04BaseA0C10storedPropSivs) * func;
 // CHECK-NEXT:   };
-// CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1 + 7]]);
+// CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM8:]] / sizeof(void *));
 // CHECK-NEXT:     return (* fptrptr_->func)(value, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
@@ -226,7 +226,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:    struct FTypeAddress {
 // CHECK-NEXT:    decltype(_impl::$s5Class04BaseA0CyS2icig) * func;
 // CHECK-NEXT:    };
-// CHECK-NEXT:    FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1 + 9]]);
+// CHECK-NEXT:    FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM10:]] / sizeof(void *));
 // CHECK-NEXT:    return (* fptrptr_->func)(i, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:    }
 
@@ -240,7 +240,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   struct FTypeAddress {
 // CHECK-NEXT:   decltype(_impl::$s5Class07DerivedA0C13virtualMethodyyF) * func;
 // CHECK-NEXT:   };
-// CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1]]);
+// CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1]] / sizeof(void *));
 // CHECK-NEXT:   return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:   }
 
@@ -254,7 +254,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     struct FTypeAddress {
 // CHECK-NEXT:     decltype(_impl::$s5Class07DerivedA0C016virtualMethodIntE0yS2iF) * func;
 // CHECK-NEXT:     };
-// CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1 + 1]]);
+// CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM2]] / sizeof(void *));
 // CHECK-NEXT:     return (* fptrptr_->func)(x, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     }
 
@@ -268,7 +268,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:   struct FTypeAddress {
 // CHECK-NEXT:   decltype(_impl::$s5Class07DerivedA0C015virtualMethodInB0yAA04BaseA0CAFF) * func;
 // CHECK-NEXT:   };
-// CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1 + 10]]);
+// CHECK-NEXT:   FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM11:]] / sizeof(void *));
 // CHECK-NEXT:   return _impl::_impl_BaseClass::makeRetained((* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(x), ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this)));
 // CHECK-NEXT:   }
 
@@ -282,7 +282,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     struct FTypeAddress {
 // CHECK-NEXT:     decltype(_impl::$s5Class07DerivedA0C19virtualComputedPropSivg) * func;
 // CHECK-NEXT:     };
-// CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1 + 2]]);
+// CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM3]] / sizeof(void *));
 // CHECK-NEXT:       return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:       }
 
@@ -296,7 +296,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     struct FTypeAddress {
 // CHECK-NEXT:     decltype(_impl::$s5Class07DerivedA0C21virtualComputedGetSets5Int64Vvg) * func;
 // CHECK-NEXT:     };
-// CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1 + 3]]);
+// CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM4]] / sizeof(void *));
 // CHECK-NEXT:     return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     }
 
@@ -310,7 +310,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     struct FTypeAddress {
 // CHECK-NEXT:     decltype(_impl::$s5Class07DerivedA0C21virtualComputedGetSets5Int64Vvs) * func;
 // CHECK-NEXT:     };
-// CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1 + 4]]);
+// CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM5]] / sizeof(void *));
 // CHECK-NEXT:     return (* fptrptr_->func)(newValue, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     }
 
@@ -324,7 +324,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     struct FTypeAddress {
 // CHECK-NEXT:     decltype(_impl::$s5Class07DerivedA0C10storedPropSivg) * func;
 // CHECK-NEXT:     };
-// CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1 + 6]]);
+// CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM7]] / sizeof(void *));
 // CHECK-NEXT:       return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:       }
 
@@ -338,7 +338,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:     struct FTypeAddress {
 // CHECK-NEXT:     decltype(_impl::$s5Class07DerivedA0C10storedPropSivs) * func;
 // CHECK-NEXT:     };
-// CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1 + 7]]);
+// CHECK-NEXT:     FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM8]] / sizeof(void *));
 // CHECK-NEXT:     return (* fptrptr_->func)(newValue, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT:     }
 
@@ -352,7 +352,7 @@ public func returnDerivedDerivedClass() -> DerivedDerivedClass {
 // CHECK-NEXT:    struct FTypeAddress {
 // CHECK-NEXT:    decltype(_impl::$s5Class07DerivedA0CyS2icig) * func;
 // CHECK-NEXT:    };
-// CHECK-NEXT:    FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM1 + 9]]);
+// CHECK-NEXT:    FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + [[#VM10]] / sizeof(void *));
 // CHECK-NEXT:      return (* fptrptr_->func)(i, ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 
 // CHECK:        void DerivedDerivedClass::virtualMethod() {

--- a/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch-execution.cpp
+++ b/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch-execution.cpp
@@ -1,0 +1,62 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/swift-subclass-of-resilient-class-virtual-method-dispatch.swift -D RESILIENT_MODULE -module-name Class -emit-module -emit-module-path %t/Class.swiftmodule -enable-library-evolution -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
+
+// RUN: %target-swift-frontend %S/swift-subclass-of-resilient-class-virtual-method-dispatch.swift -I %t -typecheck -module-name UseClass -clang-header-expose-decls=all-public -emit-clang-header-path %t/useclass.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-class-execution.o
+
+// RUN: %target-interop-build-swift -c %S/swift-subclass-of-resilient-class-virtual-method-dispatch.swift -D RESILIENT_MODULE -o %t/class.o -module-name Class -enable-library-evolution -Xfrontend -entry-point-function-name -Xfrontend swiftMain2
+
+// RUN: %target-interop-build-swift %S/swift-subclass-of-resilient-class-virtual-method-dispatch.swift -I %t -o %t/swift-class-execution -Xlinker %t/swift-class-execution.o -Xlinker %t/class.o  -module-name UseClass -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-class-execution
+// RUN: %target-run %t/swift-class-execution | %FileCheck %s
+
+#include "class.h"
+#include "useclass.h"
+#include <assert.h>
+
+using namespace UseClass;
+
+int main() {
+  auto derived = createCrossModuleDerivedClass();
+  Class::BaseClass derivedAsBase = derived;
+  auto derivedDerived = createCrossModuleDerivedDerivedClass();
+  CrossModuleDerivedClass derivedDerivedAsDerived = derivedDerived;
+
+  {
+    derived.virtualMethod();
+    assert(derived.getComputedProp() == -56);
+// CHECK: CrossModuleDerivedClass.virtualMethod
+  }
+
+  {
+    derived.virtualMethodInDerived();
+// CHECK-NEXT: CrossModuleDerivedClass.virtualMethodInDerived
+    derivedDerived.virtualMethodInDerived();
+// CHECK-NEXT: CrossModuleDerivedDerivedClass.virtualMethodInDerived
+    derivedDerivedAsDerived.virtualMethodInDerived();
+// CHECK-NEXT: CrossModuleDerivedDerivedClass.virtualMethodInDerived
+  }
+
+  {
+    derived.virtualMethod2InDerived();
+// CHECK-NEXT: CrossModuleDerivedClass.virtualMethod2InDerived
+    derivedDerived.virtualMethod2InDerived();
+// CHECK-NEXT: CrossModuleDerivedDerivedClass.virtualMethod2InDerived
+    derivedDerivedAsDerived.virtualMethod2InDerived();
+// CHECK-NEXT: CrossModuleDerivedDerivedClass.virtualMethod2InDerived
+  }
+
+  {
+    swift::Int x;
+    x = derived.getDerivedComputedProp();
+    assert(x == 23);
+    x = derivedDerived.getDerivedComputedProp();
+    assert(x == -95);
+    x = derivedDerivedAsDerived.getDerivedComputedProp();
+    assert(x == -95);
+  }
+  return 0;
+}

--- a/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch-execution.cpp
+++ b/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch-execution.cpp
@@ -13,6 +13,8 @@
 // RUN: %target-codesign %t/swift-class-execution
 // RUN: %target-run %t/swift-class-execution | %FileCheck %s
 
+// REQUIRES: executable_test
+
 #include "class.h"
 #include "useclass.h"
 #include <assert.h>

--- a/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift
@@ -1,0 +1,113 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -D RESILIENT_MODULE -module-name Class -emit-module -emit-module-path %t/Class.swiftmodule -enable-library-evolution -clang-header-expose-decls=all-public -emit-clang-header-path %t/class.h
+
+// RUN: %target-swift-frontend %s -I %t -typecheck -module-name UseClass -clang-header-expose-decls=all-public -emit-clang-header-path %t/useclass.h
+
+// RUN: %FileCheck %s < %t/useclass.h
+
+// FIXME: add import automatically?
+// RUN: echo '#include "class.h"' > %t/fixed-useclass.h
+// RUN: cat %t/useclass.h     >> %t/fixed-useclass.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/fixed-useclass.h)
+
+#if RESILIENT_MODULE
+
+open class BaseClass {
+  var field: Int64
+
+  public init() {
+    field = 0
+  }
+  open func virtualMethod() {
+    print("BaseClass.virtualMethod")
+  }
+  open var computedProp: Int {
+    return 11
+  }
+}
+
+#else
+
+import Class
+
+public class CrossModuleDerivedClass: BaseClass {
+  override public init() {}
+  override public func virtualMethod() {
+    print("CrossModuleDerivedClass.virtualMethod")
+  }
+  override public var computedProp: Int {
+    return -56
+  }
+
+  public func virtualMethodInDerived() {
+    print("CrossModuleDerivedClass.virtualMethodInDerived")
+  }
+  public var derivedComputedProp: Int {
+    return 23
+  }
+  public func virtualMethod2InDerived() {
+    print("CrossModuleDerivedClass.virtualMethod2InDerived")
+  }
+}
+
+public class CrossModuleDerivedDerivedClass: CrossModuleDerivedClass {
+  override public init() {}
+  override public func virtualMethodInDerived() {
+    print("CrossModuleDerivedDerivedClass.virtualMethodInDerived")
+  }
+  override public var derivedComputedProp: Int {
+    return -95
+  }
+  override public final func virtualMethod2InDerived() {
+    print("CrossModuleDerivedDerivedClass.virtualMethod2InDerived")
+  }
+}
+
+public func createCrossModuleDerivedClass() -> CrossModuleDerivedClass {
+    return CrossModuleDerivedClass()
+}
+
+public func createCrossModuleDerivedDerivedClass() -> CrossModuleDerivedDerivedClass {
+    return CrossModuleDerivedDerivedClass()
+}
+
+#endif
+
+// CHECK: SWIFT_EXTERN void $s8UseClass018CrossModuleDerivedB0C015virtualMethodInE0yyF(SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // virtualMethodInDerived()
+// CHECK-NEXT: SWIFT_EXTERN uint64_t $s8UseClass018CrossModuleDerivedB0CMo; // class metadata base offset
+// CHECK-NEXT: SWIFT_EXTERN ptrdiff_t $s8UseClass018CrossModuleDerivedB0C19derivedComputedPropSivg(SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL;
+// CHECK-NEXT: SWIFT_EXTERN void $s8UseClass018CrossModuleDerivedB0C016virtualMethod2InE0yyF(SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // virtualMethod2InDerived()
+
+
+// CHECK:      void CrossModuleDerivedClass::virtualMethod() {
+// CHECK-NEXT: return _impl::$s5Class04BaseA0C13virtualMethodyyFTj(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+
+// CHECK:      void CrossModuleDerivedClass::virtualMethodInDerived() {
+// CHECK-NEXT: void ***selfPtr_ = reinterpret_cast<void ***>( ::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT: #ifdef __arm64e__
+// CHECK-NEXT: void **vtable_ = ptrauth_auth_data(*selfPtr_, ptrauth_key_process_independent_data, ptrauth_blend_discriminator(selfPtr_,27361));
+// CHECK-NEXT: #else
+// CHECK-NEXT: void **vtable_ = *selfPtr_;
+// CHECK-NEXT: #endif
+// CHECK-NEXT: struct FTypeAddress {
+// CHECK-NEXT: decltype(_impl::$s8UseClass018CrossModuleDerivedB0C015virtualMethodInE0yyF) * func;
+// CHECK-NEXT: };
+// CHECK-NEXT: FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo / sizeof(void *)) + 0);
+// CHECK-NEXT: return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
+// CHECK-NEXT: }
+
+// CHECK:      swift::Int CrossModuleDerivedClass::getDerivedComputedProp() {
+// CHECK:      FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo / sizeof(void *)) + 1);
+
+// CHECK:      void CrossModuleDerivedClass::virtualMethod2InDerived() {
+// CHECK:      FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo / sizeof(void *)) + 2);
+
+// CHECK:      void CrossModuleDerivedDerivedClass::virtualMethodInDerived() {
+// CHECK:      FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo / sizeof(void *)) + 0);
+
+// CHECK:      swift::Int CrossModuleDerivedDerivedClass::getDerivedComputedProp() {
+// CHECK:      FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo / sizeof(void *)) + 1);
+
+// CHECK:      void CrossModuleDerivedDerivedClass::virtualMethod2InDerived() {
+// CHECK-NEXT: return _impl::$s8UseClass018CrossModuleDerivedeB0C016virtualMethod2InE0yyF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));

--- a/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift
@@ -75,7 +75,7 @@ public func createCrossModuleDerivedDerivedClass() -> CrossModuleDerivedDerivedC
 #endif
 
 // CHECK: SWIFT_EXTERN void $s8UseClass018CrossModuleDerivedB0C015virtualMethodInE0yyF(SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // virtualMethodInDerived()
-// CHECK-NEXT: SWIFT_EXTERN uint64_t $s8UseClass018CrossModuleDerivedB0CMo; // class metadata base offset
+// CHECK-NEXT: SWIFT_EXTERN uint[[#NUM:]]_t $s8UseClass018CrossModuleDerivedB0CMo; // class metadata base offset
 // CHECK-NEXT: SWIFT_EXTERN ptrdiff_t $s8UseClass018CrossModuleDerivedB0C19derivedComputedPropSivg(SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL;
 // CHECK-NEXT: SWIFT_EXTERN void $s8UseClass018CrossModuleDerivedB0C016virtualMethod2InE0yyF(SWIFT_CONTEXT void * _Nonnull _self) SWIFT_NOEXCEPT SWIFT_CALL; // virtualMethod2InDerived()
 

--- a/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift
@@ -93,21 +93,21 @@ public func createCrossModuleDerivedDerivedClass() -> CrossModuleDerivedDerivedC
 // CHECK-NEXT: struct FTypeAddress {
 // CHECK-NEXT: decltype(_impl::$s8UseClass018CrossModuleDerivedB0C015virtualMethodInE0yyF) * func;
 // CHECK-NEXT: };
-// CHECK-NEXT: FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo / sizeof(void *)) + 0);
+// CHECK-NEXT: FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo + 0) / sizeof(void *));
 // CHECK-NEXT: return (* fptrptr_->func)(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));
 // CHECK-NEXT: }
 
 // CHECK:      swift::Int CrossModuleDerivedClass::getDerivedComputedProp() {
-// CHECK:      FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo / sizeof(void *)) + 1);
+// CHECK:      FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo + [[#VM1:]]) / sizeof(void *));
 
 // CHECK:      void CrossModuleDerivedClass::virtualMethod2InDerived() {
-// CHECK:      FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo / sizeof(void *)) + 2);
+// CHECK:      FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo + [[#VM2:]]) / sizeof(void *));
 
 // CHECK:      void CrossModuleDerivedDerivedClass::virtualMethodInDerived() {
-// CHECK:      FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo / sizeof(void *)) + 0);
+// CHECK:      FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo + 0) / sizeof(void *));
 
 // CHECK:      swift::Int CrossModuleDerivedDerivedClass::getDerivedComputedProp() {
-// CHECK:      FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo / sizeof(void *)) + 1);
+// CHECK:      FTypeAddress *fptrptr_ = reinterpret_cast<FTypeAddress *>(vtable_ + (_impl::$s8UseClass018CrossModuleDerivedB0CMo + [[#VM1]]) / sizeof(void *));
 
 // CHECK:      void CrossModuleDerivedDerivedClass::virtualMethod2InDerived() {
 // CHECK-NEXT: return _impl::$s8UseClass018CrossModuleDerivedeB0C016virtualMethod2InE0yyF(::swift::_impl::_impl_RefCountedClass::getOpaquePointer(*this));


### PR DESCRIPTION
This should wrap up vtable dispatch support.