### PR TITLE
Fix potentially undefined behavior in StringObject.nativeStorage and document Builtin.unsafeBitCast

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -72,14 +72,23 @@ func _canBeClass<T>(_: T.Type) -> Int8 {
 ///   `unsafeBitCast(_:to:)` with class or pointer types; doing so may
 ///   introduce undefined behavior.
 ///
-/// - Warning: Calling this function breaks the guarantees of the Swift type
-///   system; use with extreme care.
+/// Warning: Calling this function breaks the guarantees of the Swift type
+/// system; use with extreme care.
 ///
-/// - Parameters:
+/// Warning: Casting from an integer or a pointer type to a reference type
+/// is undefined behavior. It may result in incorrect code in any future
+/// compiler release. To convert a bit pattern to a reference type:
+/// 1. convert the bit pattern to an UnsafeRawPointer.
+/// 2. create an unmanaged reference using Unmanaged.fromOpaque()
+/// 3. obtain a managed reference using Unmanaged.takeUnretainedValue()
+/// The programmer must ensure that the resulting reference has already been
+/// manually retained.
+///
+/// Parameters:
 ///   - x: The instance to cast to `type`.
 ///   - type: The type to cast `x` to. `type` and the type of `x` must have the
 ///     same size of memory representation and compatible memory layout.
-/// - Returns: A new instance of type `U`, cast from `x`.
+/// Returns: A new instance of type `U`, cast from `x`.
 @inlinable // unsafe-performance
 @_transparent
 public func unsafeBitCast<T, U>(_ x: T, to type: U.Type) -> U {

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -940,7 +940,10 @@ extension _StringObject {
     return _unsafeUncheckedDowncast(storage, to: __StringStorage.self)
 #else
     _internalInvariant(hasNativeStorage)
-    return Builtin.reinterpretCast(largeAddressBits)
+    let storageAddress =
+       UnsafeRawPointer(bitPattern:largeAddressBits)._unsafelyUnwrappedUnchecked
+    let unmanagedRef = Unmanaged<__StringStorage>.fromOpaque(storageAddress)
+    return unmanagedRef.takeUnretainedValue()
 #endif
   }
 


### PR DESCRIPTION
Speculatively fixing this to rule out potential miscompiles.

The compiler needs to know if a reference is being materialized out of thin air. The proper way to do that is with the Unmanaged API.

Under the hood, this forces the reference into an "unowned(unsafe)" variable which the reference must be reloaded from. That tells the compiler that it can't optimize some seemingly unrelated object which the reference may happen to refer to at runtime.

/// Warning: Casting from an integer or a pointer type to a reference type
/// is undefined behavior. It may result in incorrect code in any future 
/// compiler release. To convert a bit pattern to a reference type: 
/// 1. convert the bit pattern to an UnsafeRawPointer.
/// 2. create an unmanaged reference using Unmanaged.fromOpaque() 
/// 3. obtain a managed reference using Unmanaged.takeUnretainedValue() 
/// The programmer must ensure that the resulting reference has already been 
/// manually retained.
