### PR TITLE
Guard the lifetime of StringObject.nativeStorage in mutating methods

### DIFF
--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -247,7 +247,10 @@ extension _StringGuts {
 
     // We re-initialize from the modified storage to pick up new count, flags,
     // etc.
-    self = _StringGuts(self._object.nativeStorage)
+    let object = self._object // keep object alive during self mutation
+    withExtendedLifetime(object) {
+      self = _StringGuts(object.nativeStorage)
+    }
   }
 
   @inline(never) // slow-path
@@ -260,7 +263,10 @@ extension _StringGuts {
 
     // We re-initialize from the modified storage to pick up new count, flags,
     // etc.
-    self = _StringGuts(self._object.nativeStorage)
+    let object = self._object // keep object alive during self mutation
+    withExtendedLifetime(object) {
+      self = _StringGuts(object.nativeStorage)
+    }
   }
 
   internal mutating func clear() {
@@ -271,7 +277,10 @@ extension _StringGuts {
 
     // Reset the count
     _object.nativeStorage.clear()
-    self = _StringGuts(_object.nativeStorage)
+    let object = self._object // keep object alive during self mutation
+    withExtendedLifetime(object) {
+      self = _StringGuts(object.nativeStorage)
+    }
   }
 
   internal mutating func remove(from lower: Index, to upper: Index) {
@@ -284,7 +293,10 @@ extension _StringGuts {
       _object.nativeStorage.remove(from: lowerOffset, to: upperOffset)
       // We re-initialize from the modified storage to pick up new count, flags,
       // etc.
-      self = _StringGuts(self._object.nativeStorage)
+      let object = self._object // keep object alive during self mutation
+      withExtendedLifetime(object) {
+        self = _StringGuts(object.nativeStorage)
+      }
       return
     }
 
@@ -413,7 +425,10 @@ extension _StringGuts {
     let start = bounds.lowerBound._encodedOffset
     let end = bounds.upperBound._encodedOffset
     _object.nativeStorage.replace(from: start, to: end, with: codeUnits)
-    self = _StringGuts(_object.nativeStorage)
+    let object = self._object // keep object alive during self mutation
+    withExtendedLifetime(object) {
+      self = _StringGuts(object.nativeStorage)
+    }
     return Range(_uncheckedBounds: (start, start + codeUnits.count))
   }
 
@@ -437,7 +452,10 @@ extension _StringGuts {
     let end = bounds.upperBound._encodedOffset
     _object.nativeStorage.replace(
       from: start, to: end, with: codeUnits, replacementCount: replCount)
-    self = _StringGuts(_object.nativeStorage)
+    let object = self._object // keep object alive during self mutation
+    withExtendedLifetime(object) {
+      self = _StringGuts(object.nativeStorage)
+    }
     return Range(_uncheckedBounds: (start, start + replCount))
   }
 


### PR DESCRIPTION
StringGuts has mutating methods that access StringObject.nativeStorage while modifying self as such:

  self = _StringGuts(self._object.nativeStorage)

`self._object` can be destroyed immediately after its last use. We can't rely on `self` having a lexical lifetime within a mutating method. This follows from the fact that `self` is effectively `inout` within this scope, and thus conceptually destroyed on function entry.

Since the nativeStorage property generates a new reference out of thin air (from an integer bitcast), `object` may be destroyed before the new reference is retained.

Fix this by creating a separate copy of object with its own lexical scope that covers the use of `nativeStorage`:

  var object = self._object
  self = _StringGuts(object.nativeStorage)

Additionally add an explicit `withExtendedLifetime` scope. This forces the compiler to keep 'object' alive even when the standard library is not compiled with "lexical lifetimes" enabled, or if we choose to optimize _StringObject using eager-consume semantics. We may decide to remove the withExtendedLifetime in the future.
