### PR TITLE
IRGen: correct Twine handling

### DIFF
--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -86,14 +86,13 @@ namespace {
     auto slot = IGF.Builder.CreateInBoundsGEP(IGF.IGM.TupleTypeMetadataTy,
                                               asTuple, indices);
 
-    Twine name = [&]() -> Twine {
-      if (auto *constantIndex = dyn_cast<llvm::ConstantInt>(index)) {
-        return metadata->getName() + "." +
-               Twine(constantIndex->getValue().getLimitedValue()) + ".offset";
-      } else {
-        return metadata->getName() + ".dynamic.offset";
-      }
-    }();
+    std::string name;
+    if (auto *constantIndex = dyn_cast<llvm::ConstantInt>(index))
+      name = (metadata->getName() + "." +
+              Twine(constantIndex->getValue().getLimitedValue()) + ".offset")
+                .str();
+    else
+      name = (metadata->getName() + ".dynamic.offset").str();
 
     return IGF.Builder.CreateLoad(slot, IGF.IGM.Int32Ty,
                                   IGF.IGM.getPointerAlignment(), name);


### PR DESCRIPTION
Twine is an intermediate reference and should not be constructed to hold the value.  An unowned string piece should be referenced by `StringRef`.  This now provides storage for the name.  We would previously see invalid memory usage due to the Twine being destroyed before the use in the `CreateLoad` invocation.