### PR TITLE
[C++-Interop] Allow for calling automatically synthesized ctors of arc types

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1271,8 +1271,8 @@ static bool canBridgeTypes(ImportTypeKind importKind) {
   case ImportTypeKind::Variable:
   case ImportTypeKind::AuditedVariable:
   case ImportTypeKind::Enum:
-    return false;
   case ImportTypeKind::RecordField:
+    return false;
   case ImportTypeKind::Result:
   case ImportTypeKind::AuditedResult:
   case ImportTypeKind::Parameter:
@@ -1604,6 +1604,10 @@ static ImportedType adjustTypeForConcreteImport(
       // structs, at which point we should really be checking the lifetime
       // qualifiers.
       case clang::Qualifiers::OCL_Strong:
+        if (!impl.SwiftContext.LangOpts.EnableCXXInterop) {
+          return {Type(), false};
+        }
+        break;
       case clang::Qualifiers::OCL_Weak:
         return {Type(), false};
       case clang::Qualifiers::OCL_Autoreleasing:

--- a/test/Interop/Cxx/objc-correctness/Inputs/cxx-class-with-arc-fields-ctor.h
+++ b/test/Interop/Cxx/objc-correctness/Inputs/cxx-class-with-arc-fields-ctor.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+
+struct S {
+  NSString *_Nullable A;
+  NSString *_Nullable B;
+  NSString *_Nullable C;
+
+  void dump() const {
+    printf("%s\n", [A UTF8String]);
+    printf("%s\n", [B UTF8String]);
+    printf("%s\n", [C UTF8String]);
+  }
+};
+

--- a/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
+++ b/test/Interop/Cxx/objc-correctness/Inputs/module.modulemap
@@ -3,3 +3,9 @@ module ProtocolNamingConflict [extern_c] {
   requires objc
 }
 
+module CxxClassWithNSStringInit [extern_c] {
+  header "cxx-class-with-arc-fields-ctor.h"
+  requires objc
+  requires cplusplus
+}
+

--- a/test/Interop/Cxx/objc-correctness/call-to-generated-init-with-nsstring.swift
+++ b/test/Interop/Cxx/objc-correctness/call-to-generated-init-with-nsstring.swift
@@ -1,0 +1,25 @@
+// RUN: %target-swift-ide-test -print-module -module-to-print=CxxClassWithNSStringInit -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop | %FileCheck -check-prefix=CHECK-IDE-TEST %s
+// RUN: %target-swift-frontend -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s | %FileCheck %s
+
+
+// REQUIRES: objc_interop
+
+import Foundation
+import CxxClassWithNSStringInit
+
+// CHECK-IDE-TEST: struct S {
+// CHECK-IDE-TEST:   init()
+// CHECK-IDE-TEST:   init(A: NSString?, B: NSString?, C: NSString?)
+// CHECK-IDE-TEST:   var A: NSString?
+// CHECK-IDE-TEST:   var B: NSString?
+// CHECK-IDE-TEST:   var C: NSString?
+// CHECK-IDE-TEST: }
+
+var foo: NSString? = "foo"
+var bar: NSString? = "bar"
+var baz: NSString? = "baz"
+var s = S(A: foo, B: bar, C: baz)
+s.dump()
+
+// CHECK: call {{.*}} @_ZN1SC1ERKS_
+// CHECK: call {{.*}} @_ZNK1S4dumpEv


### PR DESCRIPTION
When instantiating C++ types who contain ARC types in the past either their default constructors are skipped or they are synthesized with Unmanged<> wrappers. This has made it more cumbersome to instantiate these from Swift and often requires a static C++ build method to manually shim the synthesized constructor. The following change drops the Unmanaged<> so that for the time being these types can be instantiated directly even if types like Swift -> NSString are not bridged completely.

