### PR TITLE
don't split attribute fragments with a separate typeIdentifier fragment

### DIFF
--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
@@ -136,8 +136,13 @@ void DeclarationFragmentPrinter::printStructurePre(PrintStructureKind Kind,
 void DeclarationFragmentPrinter::printTypeRef(Type T, const TypeDecl *RefTo,
     Identifier Name,
     PrintNameContext NameContext) {
-  if (Kind != FragmentKind::Attribute)
+  if (Kind != FragmentKind::Attribute) {
     openFragment(FragmentKind::TypeIdentifier);
+  } else {
+    // create a separate fragment so that only the attribute name is linkable
+    closeFragment();
+    openFragment(FragmentKind::Attribute);
+  }
   printText(Name.str());
   USR.clear();
 

--- a/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
+++ b/lib/SymbolGraphGen/DeclarationFragmentPrinter.cpp
@@ -136,7 +136,8 @@ void DeclarationFragmentPrinter::printStructurePre(PrintStructureKind Kind,
 void DeclarationFragmentPrinter::printTypeRef(Type T, const TypeDecl *RefTo,
     Identifier Name,
     PrintNameContext NameContext) {
-  openFragment(FragmentKind::TypeIdentifier);
+  if (Kind != FragmentKind::Attribute)
+    openFragment(FragmentKind::TypeIdentifier);
   printText(Name.str());
   USR.clear();
 

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/CustomAttr.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/CustomAttr.swift
@@ -32,7 +32,11 @@ public func wrapped(@SomeWrapper arg: Int) {}
 // CHECK-NEXT:  },
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "kind": "attribute",
-// CHECK-NEXT:    "spelling": "@SomeWrapper",
+// CHECK-NEXT:    "spelling": "@"
+// CHECK-NEXT:  },
+// CHECK-NEXT:  {
+// CHECK-NEXT:    "kind": "attribute",
+// CHECK-NEXT:    "spelling": "SomeWrapper",
 // CHECK-NEXT:    "preciseIdentifier": "s:10CustomAttr11SomeWrapperV"
 // CHECK-NEXT:  },
 // CHECK-NEXT:  {

--- a/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/CustomAttr.swift
+++ b/test/SymbolGraph/Symbols/Mixins/DeclarationFragments/Full/CustomAttr.swift
@@ -32,11 +32,7 @@ public func wrapped(@SomeWrapper arg: Int) {}
 // CHECK-NEXT:  },
 // CHECK-NEXT:  {
 // CHECK-NEXT:    "kind": "attribute",
-// CHECK-NEXT:    "spelling": "@"
-// CHECK-NEXT:  },
-// CHECK-NEXT:  {
-// CHECK-NEXT:    "kind": "typeIdentifier",
-// CHECK-NEXT:    "spelling": "SomeWrapper",
+// CHECK-NEXT:    "spelling": "@SomeWrapper",
 // CHECK-NEXT:    "preciseIdentifier": "s:10CustomAttr11SomeWrapperV"
 // CHECK-NEXT:  },
 // CHECK-NEXT:  {


### PR DESCRIPTION
Resolves rdar://104930571

When SymbolGraphGen renders a custom attribute which it knows the USR for, it splits the declaration fragment for that attribute into two: one with the `@` sign with kind `attribute`, and one with the name of the attribute with name `typeIdentifier` and a reference to the attribute definition USR. SymbolGraphGen forces any fragment with a link USR needs to be of kind `typeIdentifier` due to an implementation detail of Swift-DocC-Render; however, this produces an awkward rendering where the attribute appears in two colors because of the differing fragment kinds.

This PR changes the rendering code to keep `attribute` fragments intact when printing a type reference, instead of breaking off a separate `typeIdentifier` fragment.