### PR TITLE
Remove an assert from visitForwardedGuaranteedOperands

### DIFF
--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1779,8 +1779,6 @@ bool swift::visitForwardedGuaranteedOperands(
       || isa<OwnershipForwardingMultipleValueInstruction>(inst)
       || isa<MoveOnlyWrapperToCopyableValueInst>(inst)
       || isa<CopyableToMoveOnlyWrapperValueInst>(inst)) {
-    assert(inst->getNumRealOperands() == 1
-           && "forwarding instructions must have a single real operand");
     assert(!isa<SingleValueInstruction>(inst)
            || !BorrowedValue(cast<SingleValueInstruction>(inst))
                   && "forwarded operand cannot begin a borrow scope");

--- a/test/SILOptimizer/borrow_introducer_unit.sil
+++ b/test/SILOptimizer/borrow_introducer_unit.sil
@@ -222,3 +222,29 @@ exit:
   %retval = tuple ()
   return %retval : $()
 }
+
+// CHECK-LABEL: begin running test 1 of 1 on introducer_dependence: find-borrow-introducers with: @trace[0]
+// CHECK: Introducers:
+// CHECK: %0 = argument of bb0 : $C
+// CHECK-LABEL: end running test 1 of 1 on introducer_dependence: find-borrow-introducers with: @trace[0]
+sil [ossa] @introducer_dependence : $@convention(thin) (@guaranteed C, @guaranteed Builtin.NativeObject) -> () {
+entry(%0 : @guaranteed $C, %1 : @guaranteed $Builtin.NativeObject):
+  test_specification "find-borrow-introducers @trace[0]"
+  %dependent = mark_dependence %0 : $C on %1 : $Builtin.NativeObject
+  debug_value [trace] %dependent : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on introducer_bridge: find-borrow-introducers with: @trace[0]
+// CHECK: Introducers:
+// CHECK: %0 = argument of bb0 : $C
+// CHECK-LABEL: end running test 1 of 1 on introducer_bridge: find-borrow-introducers with: @trace[0]
+sil [ossa] @introducer_bridge : $@convention(thin) (@guaranteed C, Builtin.Word) -> () {
+entry(%0 : @guaranteed $C, %1 : $Builtin.Word):
+  test_specification "find-borrow-introducers @trace[0]"
+  %bridge = ref_to_bridge_object %0 : $C, %1 : $Builtin.Word
+  debug_value [trace] %bridge : $Builtin.BridgeObject
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
Some guaranteed forwarding instructions have multiple operands: mark_dependence, ref_to_bridge_object.

The corresponding instruction types checked here already have documentation that the forwarded operand is the first operand. The assert is overly cautious, and checking for indiviudal opcodes would be tedious maintenance.
