### PR TITLE
[Serialization] Don't fail the precise tag check if only the last digit doesn't match

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -804,9 +804,13 @@ ERROR(serialization_module_too_old,Fatal,
       "rebuild %0 and try again: %1",
       (Identifier, StringRef))
 ERROR(serialization_module_incompatible_revision,Fatal,
-      "compiled module was created by a different version of the compiler; "
-      "rebuild %0 and try again: %1",
-      (Identifier, StringRef))
+      "compiled module was created by a different version of the compiler '%0'; "
+      "rebuild %1 and try again: %2",
+      (StringRef, Identifier, StringRef))
+REMARK(serialization_module_problematic_revision, none,
+      "compiled module was created by a different version of the compiler '%0': "
+      "%1",
+      (StringRef, StringRef))
 ERROR(serialization_missing_single_dependency,Fatal,
       "missing required module '%0'", (StringRef))
 ERROR(serialization_missing_dependencies,Fatal,

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -167,8 +167,13 @@ StringRef getSwiftRevision();
 /// and \c getCurrentCompilerTag returns the version tuple in string format.
 bool isCurrentCompilerTagged();
 
-/// Retrieves the distribtion tag of the running compiler, if any.
+/// Retrieves the distribution tag of the running compiler, if any.
 StringRef getCurrentCompilerTag();
+
+/// Retrieves the distribution tag of the running compiler for serialization,
+/// if any. This can hold more information than \c getCurrentCompilerTag
+/// depending on the vendor.
+StringRef getCurrentCompilerSerializationTag();
 
 } // end namespace version
 } // end namespace swift

--- a/include/swift/Serialization/Validation.h
+++ b/include/swift/Serialization/Validation.h
@@ -91,6 +91,7 @@ struct ValidationInfo {
   version::Version compatibilityVersion = {};
   llvm::VersionTuple userModuleVersion;
   StringRef sdkName = {};
+  StringRef problematicRevision = {};
   size_t bytes = 0;
   Status status = Status::Malformed;
   std::vector<StringRef> allowableClients;

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -297,5 +297,13 @@ StringRef getCurrentCompilerTag() {
 #endif
 }
 
+StringRef getCurrentCompilerSerializationTag() {
+#ifdef SWIFT_COMPILER_VERSION
+  return SWIFT_COMPILER_VERSION;
+#else
+  return StringRef();
+#endif
+}
+
 } // end namespace version
 } // end namespace swift

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -370,7 +370,7 @@ static ValidationInfo validateControlBlock(
       if (forcedDebugRevision ||
           (requiresRevisionMatch && version::isCurrentCompilerTagged())) {
         StringRef compilerRevision = forcedDebugRevision ?
-          forcedDebugRevision : version::getCurrentCompilerTag();
+          forcedDebugRevision : version::getCurrentCompilerSerializationTag();
         if (moduleRevision != compilerRevision) {
           result.status = Status::RevisionIncompatible;
 

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -372,10 +372,18 @@ static ValidationInfo validateControlBlock(
         StringRef compilerRevision = forcedDebugRevision ?
           forcedDebugRevision : version::getCurrentCompilerSerializationTag();
         if (moduleRevision != compilerRevision) {
-          result.status = Status::RevisionIncompatible;
+          // The module versions are mismatching, record it and diagnose later.
+          result.problematicRevision = moduleRevision;
 
-          // We can't trust this module format at this point.
-          return result;
+          // Reject the module only it still mismatches without the last digit.
+          StringRef compilerRevisionHead = compilerRevision.rsplit('.').first;
+          StringRef moduleRevisionHead = moduleRevision.rsplit('.').first;
+          if (moduleRevisionHead != compilerRevisionHead) {
+            result.status = Status::RevisionIncompatible;
+
+            // We can't trust the module format at this point.
+            return result;
+          }
         }
       }
       break;

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -356,7 +356,7 @@ static ValidationInfo validateControlBlock(
       // Disable this restriction for compiler testing by setting this
       // env var to any value.
       static const char* ignoreRevision =
-        ::getenv("SWIFT_DEBUG_IGNORE_SWIFTMODULE_REVISION");
+        ::getenv("SWIFT_IGNORE_SWIFTMODULE_REVISION");
       if (ignoreRevision)
         break;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1011,7 +1011,7 @@ void Serializer::writeHeader(const SerializationOptions &options) {
     static const char* forcedDebugRevision =
       ::getenv("SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION");
     auto revision = forcedDebugRevision ?
-      forcedDebugRevision : version::getCurrentCompilerTag();
+      forcedDebugRevision : version::getCurrentCompilerSerializationTag();
     Revision.emit(ScratchRecord, revision);
 
     IsOSSA.emit(ScratchRecord, options.IsOSSA);

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -836,6 +836,13 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
     if (loadedModuleFile &&
         loadedModuleFile->mayHaveDiagnosticsPointingAtBuffer())
       OrphanedModuleFiles.push_back(std::move(loadedModuleFile));
+  } else {
+    // Report non-fatal compiler tag mismatch.
+    if (!loadInfo.problematicRevision.empty()) {
+      Ctx.Diags.diagnose(*diagLoc,
+                         diag::serialization_module_problematic_revision,
+                         loadInfo.problematicRevision, moduleBufferID);
+    }
   }
 
   // The -experimental-hermetic-seal-at-link flag turns on dead-stripping
@@ -896,7 +903,7 @@ void swift::serialization::diagnoseSerializedASTLoadFailure(
     break;
   case serialization::Status::RevisionIncompatible:
     Ctx.Diags.diagnose(diagLoc, diag::serialization_module_incompatible_revision,
-                       ModuleName, moduleBufferID);
+                       loadInfo.problematicRevision, ModuleName, moduleBufferID);
     break;
   case serialization::Status::Malformed:
     Ctx.Diags.diagnose(diagLoc, diag::serialization_malformed_module,

--- a/test/Serialization/restrict-swiftmodule-to-revision.swift
+++ b/test/Serialization/restrict-swiftmodule-to-revision.swift
@@ -9,7 +9,7 @@ public func foo() {}
 /// Build Lib as a resilient and non-resilient swiftmodule
 // RUN: %target-swift-frontend -emit-module %t/Lib.swift -swift-version 5 -o %t/build -parse-stdlib -module-cache-path %t/cache -module-name ResilientLib -enable-library-evolution
 // RUN: %target-swift-frontend -emit-module %t/Lib.swift -swift-version 5 -o %t/build -parse-stdlib -module-cache-path %t/cache -module-name NonResilientLib
-// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=my-revision \
+// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=1.0.0.0.1 \
 // RUN:   %target-swift-frontend -emit-module %t/Lib.swift -swift-version 5 -o %t/build -parse-stdlib -module-cache-path %t/cache -module-name TaggedLib -enable-library-evolution
 
 
@@ -19,9 +19,9 @@ import NonResilientLib
 foo()
 
 /// Building a NonResilientLib client should reject the import for a tagged compiler
-// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=my-revision \
+// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=1.0.0.0.1 \
 // RUN:   not %target-swift-frontend -typecheck %t/NonResilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache 2>&1 | %FileCheck -check-prefix=CHECK-NON-RESILIENT %s
-// CHECK-NON-RESILIENT: compiled module was created by a different version of the compiler; rebuild 'NonResilientLib' and try again: {{.*}}NonResilientLib.swiftmodule
+// CHECK-NON-RESILIENT: compiled module was created by a different version of the compiler ''; rebuild 'NonResilientLib' and try again: {{.*}}NonResilientLib.swiftmodule
 
 
 /// 3. Test importing the resilient untagged library
@@ -33,12 +33,12 @@ foo()
 // RUN: %target-swift-frontend -typecheck %t/ResilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
 
 /// Building a ResilientLib client should reject the import for a tagged compiler
-// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=not-a-revision \
+// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=1.0.0.0.1 \
 // RUN:   not %target-swift-frontend -typecheck %t/ResilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache 2>&1 | %FileCheck %s
-// CHECK: compiled module was created by a different version of the compiler; rebuild 'ResilientLib' and try again: {{.*}}ResilientLib.swiftmodule
+// CHECK: compiled module was created by a different version of the compiler ''; rebuild 'ResilientLib' and try again: {{.*}}ResilientLib.swiftmodule
 
 /// Building a ResilientLib client should succeed for a tagged compiler with SWIFT_IGNORE_SWIFTMODULE_REVISION
-// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=not-a-revision SWIFT_IGNORE_SWIFTMODULE_REVISION=true \
+// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=1.0.0.0.1 SWIFT_IGNORE_SWIFTMODULE_REVISION=true \
 // RUN:   %target-swift-frontend -typecheck %t/ResilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
 
 
@@ -47,12 +47,19 @@ foo()
 import TaggedLib
 foo()
 
-/// Importing TaggedLib should succeed with the same tag or a dev compiler
-// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=my-revision \
+/// Importing TaggedLib should succeed with the same tag.
+// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=1.0.0.0.1 \
 // RUN:   %target-swift-frontend -typecheck %t/TaggedClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
+
+/// Importing TaggedLib should succeed with a dev compiler
 // RUN: %target-swift-frontend -typecheck %t/TaggedClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
 
+/// Importing TaggedLib should succeed but remark on a last digit difference.
+// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=1.0.0.0.2 \
+// RUN:   %target-swift-frontend -typecheck %t/TaggedClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache 2>&1 | %FileCheck %s --check-prefix=CHECK-LAST-DIGIT
+// CHECK-LAST-DIGIT: remark: compiled module was created by a different version of the compiler '1.0.0.0.1': {{.*}}TaggedLib.swiftmodule
+
 /// Building a TaggedLib client should reject the import for a different tagged compiler
-// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=not-a-revision \
+// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=1.0.0.1.1 \
 // RUN:   not %target-swift-frontend -typecheck %t/TaggedClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache 2>&1 | %FileCheck %s --check-prefix=CHECK-TAGGED
-// CHECK-TAGGED: compiled module was created by a different version of the compiler; rebuild 'TaggedLib' and try again: {{.*}}TaggedLib.swiftmodule
+// CHECK-TAGGED: error: compiled module was created by a different version of the compiler '1.0.0.0.1'; rebuild 'TaggedLib' and try again: {{.*}}TaggedLib.swiftmodule

--- a/test/Serialization/restrict-swiftmodule-to-revision.swift
+++ b/test/Serialization/restrict-swiftmodule-to-revision.swift
@@ -37,8 +37,8 @@ foo()
 // RUN:   not %target-swift-frontend -typecheck %t/ResilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache 2>&1 | %FileCheck %s
 // CHECK: compiled module was created by a different version of the compiler; rebuild 'ResilientLib' and try again: {{.*}}ResilientLib.swiftmodule
 
-/// Building a ResilientLib client should succeed for a tagged compiler with SWIFT_DEBUG_IGNORE_SWIFTMODULE_REVISION
-// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=not-a-revision SWIFT_DEBUG_IGNORE_SWIFTMODULE_REVISION=true \
+/// Building a ResilientLib client should succeed for a tagged compiler with SWIFT_IGNORE_SWIFTMODULE_REVISION
+// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_REVISION=not-a-revision SWIFT_IGNORE_SWIFTMODULE_REVISION=true \
 // RUN:   %target-swift-frontend -typecheck %t/ResilientClient.swift -swift-version 5 -I %t/build -parse-stdlib -module-cache-path %t/cache
 
 


### PR DESCRIPTION
Weaken the precise tag check at loading swiftmodules to accept binary modules build by a compiler with a tag where only the last digit is different. This relies on the assumption that the other digits in the version should ensure compiler and stdlib compatibility. If the last digit doesn't match, raise a remark.

The new `getCurrentCompilerSerializationTag` can be used to add vendor-specific information in the tag.

The precise tag check can be disabled with the env var `SWIFT_IGNORE_SWIFTMODULE_REVISION`.

rdar://105158258