### PR TITLE
[5.8][CSGen] Detect nested out-of-scope variables in recursive declarations

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1351,6 +1351,13 @@ namespace {
     Type visitDeclRefExpr(DeclRefExpr *E) {
       auto locator = CS.getConstraintLocator(E);
 
+      auto invalidateReference = [&]() -> Type {
+        auto *hole = CS.createTypeVariable(locator, TVO_CanBindToHole);
+        (void)CS.recordFix(AllowRefToInvalidDecl::create(CS, locator));
+        CS.setType(E, hole);
+        return hole;
+      };
+
       Type knownType;
       if (auto *VD = dyn_cast<VarDecl>(E->getDecl())) {
         knownType = CS.getTypeIfAvailable(VD);
@@ -1358,13 +1365,27 @@ namespace {
           knownType = CS.getVarType(VD);
 
         if (knownType) {
+          // An out-of-scope type variable(s) could appear the type of
+          // a declaration only in diagnostic mode when invalid variable
+          // declaration is recursively referenced inside of a multi-statement
+          // closure located somewhere within its initializer e.g.:
+          // `let x = [<call>] { ... print(x) }`. It happens because the
+          // variable assumes the result type of its initializer unless
+          // its specified explicitly.
+          if (isa<ClosureExpr>(CurDC) && knownType->hasTypeVariable()) {
+            if (knownType.findIf([&](Type type) {
+                  auto *typeVar = type->getAs<TypeVariableType>();
+                  if (!typeVar || CS.getFixedType(typeVar))
+                    return false;
+
+                  return !CS.isActiveTypeVariable(typeVar);
+                }))
+              return invalidateReference();
+          }
+
           // If the known type has an error, bail out.
           if (knownType->hasError()) {
-            auto *hole = CS.createTypeVariable(locator, TVO_CanBindToHole);
-            (void)CS.recordFix(AllowRefToInvalidDecl::create(CS, locator));
-            if (!CS.hasType(E))
-              CS.setType(E, hole);
-            return hole;
+            return invalidateReference();
           }
 
           if (!knownType->hasPlaceholder()) {
@@ -1381,10 +1402,7 @@ namespace {
       // (in getTypeOfReference) so we can match non-error param types.
       if (!knownType && E->getDecl()->isInvalid() &&
           !CS.isForCodeCompletion()) {
-        auto *hole = CS.createTypeVariable(locator, TVO_CanBindToHole);
-        (void)CS.recordFix(AllowRefToInvalidDecl::create(CS, locator));
-        CS.setType(E, hole);
-        return hole;
+        return invalidateReference();
       }
 
       // Create an overload choice referencing this declaration and immediately

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -74,7 +74,7 @@ public:
     if (auto *DRE = dyn_cast<DeclRefExpr>(expr)) {
       auto *decl = DRE->getDecl();
 
-      if (auto type = CS.getTypeIfAvailable(DRE->getDecl())) {
+      if (auto type = CS.getTypeIfAvailable(decl)) {
         auto &ctx = CS.getASTContext();
         // If this is not one of the closure parameters which
         // is inferrable from the body, let's replace type


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/63566

---

- Explanation:

Follow-up to https://github.com/apple/swift/pull/63505

An out-of-scope type variable(s) could appear the type of
a declaration only in diagnostic mode when invalid variable
declaration is recursively referenced inside of a multi-statement
closure located somewhere within its initializer e.g.:
`let x = [<call>] { ... print(x) }`. It happens because the
variable assumes the result type of its initializer unless
its specified explicitly.

- Scope: Multi-statement closures with invalid recursive declarations.

- Main Branch PR: https://github.com/apple/swift/pull/63566

- Resolves: https://github.com/apple/swift/issues/63455

- Risk: Very low

- Reviewed By: @hborla

- Testing:  Added a regression test-case to the suite.

Resolves: https://github.com/apple/swift/issues/63455 
(cherry picked from commit 8e82f1d68bbe40b47e23366e36aad2f6ad141192)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
