### PR TITLE
Update build-windows.bat

### DIFF
--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -89,8 +89,10 @@ call :build_libdispatch %exitOnError%
 path %install_directory%\bin;%build_root%\swift\bin;%build_root%\swift\libdispatch-prefix\bin;%PATH%
 
 if %RunTest%==1 (
-  call :test_swift %exitOnError%
-  call :test_libdispatch %exitOnError%
+  call :test_swift
+  IF %ERRORLEVEL% NEQ 0 (exit /b)
+  call :test_libdispatch
+  IF %ERRORLEVEL% NEQ 0 (exit /b)
 )
 
 goto :end


### PR DESCRIPTION
Repair the exit on test failure.  We should not continue on test failures.