### PR TITLE
[stdlib] Fix potentially undefined behavior in StringObject.nativeStorage and document Builtin.unsafeBitCast

### DIFF
--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -72,14 +72,23 @@ func _canBeClass<T>(_: T.Type) -> Int8 {
 ///   `unsafeBitCast(_:to:)` with class or pointer types; doing so may
 ///   introduce undefined behavior.
 ///
-/// - Warning: Calling this function breaks the guarantees of the Swift type
-///   system; use with extreme care.
+/// Warning: Calling this function breaks the guarantees of the Swift type
+/// system; use with extreme care.
 ///
-/// - Parameters:
+/// Warning: Casting from an integer or a pointer type to a reference type
+/// is undefined behavior. It may result in incorrect code in any future
+/// compiler release. To convert a bit pattern to a reference type:
+/// 1. convert the bit pattern to an UnsafeRawPointer.
+/// 2. create an unmanaged reference using Unmanaged.fromOpaque()
+/// 3. obtain a managed reference using Unmanaged.takeUnretainedValue()
+/// The programmer must ensure that the resulting reference has already been
+/// manually retained.
+///
+/// Parameters:
 ///   - x: The instance to cast to `type`.
 ///   - type: The type to cast `x` to. `type` and the type of `x` must have the
 ///     same size of memory representation and compatible memory layout.
-/// - Returns: A new instance of type `U`, cast from `x`.
+/// Returns: A new instance of type `U`, cast from `x`.
 @inlinable // unsafe-performance
 @_transparent
 public func unsafeBitCast<T, U>(_ x: T, to type: U.Type) -> U {

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -123,7 +123,7 @@ extension _StringGuts {
   // Whether this string has breadcrumbs
   internal var hasBreadcrumbs: Bool {
     return hasSharedStorage
-      || (hasNativeStorage && _object.nativeStorage.hasBreadcrumbs)
+      || (hasNativeStorage && _object.withNativeStorage { $0.hasBreadcrumbs })
   }
 }
 

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -249,12 +249,11 @@ extension _StringGuts {
   ) -> Int? {
     #if _runtime(_ObjC)
     // Currently, foreign  means NSString
-    if let res = _cocoaStringCopyUTF8(_object.cocoaObject,
-      into: UnsafeMutableRawBufferPointer(start: mbp.baseAddress,
-                                          count: mbp.count)) {
-      return res
+    let res = _object.withCocoaObject {
+      _cocoaStringCopyUTF8($0, into: UnsafeMutableRawBufferPointer(mbp))
     }
-    
+    if let res { return res }
+
     // If the NSString contains invalid UTF8 (e.g. unpaired surrogates), we
     // can get nil from cocoaStringCopyUTF8 in situations where a character by
     // character loop would get something more useful like repaired contents

--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -70,14 +70,14 @@ extension _StringGuts {
   internal mutating func updateNativeStorage<R>(
     _ body: (__StringStorage) -> R
   ) -> R {
-    let storage = self._object.nativeStorage
-    self = _StringGuts()
-    defer {
-      // We re-initialize from the modified storage to pick up new count, flags,
-      // etc.
-      self = _StringGuts(storage)
+    let (r, cf) = self._object.withNativeStorage {
+      let r = body($0)
+      let cf = $0._countAndFlags
+      return (r, cf)
     }
-    return body(storage)
+    // We need to pick up new count/flags from the modified storage.
+    self._object._setCountAndFlags(to: cf)
+    return r
   }
 
   @inlinable

--- a/stdlib/public/core/StringGutsRangeReplaceable.swift
+++ b/stdlib/public/core/StringGutsRangeReplaceable.swift
@@ -13,19 +13,29 @@
 // COW helpers
 extension _StringGuts {
   internal var nativeCapacity: Int? {
-    guard hasNativeStorage else { return nil }
-    return _object.withNativeStorage { $0.capacity }
+    @inline(never)
+    @_effects(releasenone)
+    get {
+      guard hasNativeStorage else { return nil }
+      return _object.withNativeStorage { $0.capacity }
+    }
   }
 
   internal var nativeUnusedCapacity: Int? {
-    guard hasNativeStorage else { return nil }
-    return _object.withNativeStorage { $0.unusedCapacity }
+    @inline(never)
+    @_effects(releasenone)
+    get {
+      guard hasNativeStorage else { return nil }
+      return _object.withNativeStorage { $0.unusedCapacity }
+    }
   }
 
   // If natively stored and uniquely referenced, return the storage's total
   // capacity. Otherwise, nil.
   internal var uniqueNativeCapacity: Int? {
-    @inline(__always) mutating get {
+    @inline(never)
+    @_effects(releasenone)
+    mutating get {
       guard isUniqueNative else { return nil }
       return _object.withNativeStorage { $0.capacity }
     }
@@ -34,7 +44,9 @@ extension _StringGuts {
   // If natively stored and uniquely referenced, return the storage's spare
   // capacity. Otherwise, nil.
   internal var uniqueNativeUnusedCapacity: Int? {
-    @inline(__always) mutating get {
+    @inline(never)
+    @_effects(releasenone)
+    mutating get {
       guard isUniqueNative else { return nil }
       return _object.withNativeStorage { $0.unusedCapacity }
     }

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -940,7 +940,10 @@ extension _StringObject {
     return _unsafeUncheckedDowncast(storage, to: __StringStorage.self)
 #else
     _internalInvariant(hasNativeStorage)
-    return Builtin.reinterpretCast(largeAddressBits)
+    let storageAddress =
+       UnsafeRawPointer(bitPattern:largeAddressBits)._unsafelyUnwrappedUnchecked
+    let unmanagedRef = Unmanaged<__StringStorage>.fromOpaque(storageAddress)
+    return unmanagedRef.takeUnretainedValue()
 #endif
   }
 

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -172,6 +172,17 @@ internal struct _StringObject {
     _internalInvariant(!isSmall)
     return CountAndFlags(rawUnchecked: _countAndFlagsBits)
   }
+
+  // FIXME: This ought to be the setter for property `_countAndFlags`.
+  @_alwaysEmitIntoClient
+  internal mutating func _setCountAndFlags(to value: CountAndFlags) {
+#if arch(i386) || arch(arm) || arch(arm64_32) || arch(wasm32)
+    self._count = value.count
+    self._flags = value.flags
+#else
+    self._countAndFlagsBits = value._storage
+#endif
+  }
 }
 
 // Raw

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -735,7 +735,7 @@ extension _StringGuts {
 
     let mutPtr: UnsafeMutablePointer<_StringBreadcrumbs?>
     if hasNativeStorage {
-      mutPtr = _object.nativeStorage._breadcrumbsAddress
+      mutPtr = _object.withNativeStorage { $0._breadcrumbsAddress }
     } else {
       mutPtr = UnsafeMutablePointer(
         Builtin.addressof(&_object.sharedStorage._breadcrumbs))

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -737,8 +737,9 @@ extension _StringGuts {
     if hasNativeStorage {
       mutPtr = _object.withNativeStorage { $0._breadcrumbsAddress }
     } else {
-      mutPtr = UnsafeMutablePointer(
-        Builtin.addressof(&_object.sharedStorage._breadcrumbs))
+      mutPtr = _object.withSharedStorage {
+        UnsafeMutablePointer(Builtin.addressof(&$0._breadcrumbs))
+      }
     }
 
     if let breadcrumbs = _stdlib_atomicAcquiringLoadARCRef(object: mutPtr) {

--- a/stdlib/public/core/StringUTF8View.swift
+++ b/stdlib/public/core/StringUTF8View.swift
@@ -541,10 +541,10 @@ extension String.UTF8View {
 
     #if _runtime(_ObjC)
     // Currently, foreign means NSString
-    if let count = _cocoaStringUTF8Count(
-      _guts._object.cocoaObject,
-      range: i._encodedOffset ..< j._encodedOffset
-    ) {
+    let count = _guts._object.withCocoaObject {
+      _cocoaStringUTF8Count($0, range: i._encodedOffset ..< j._encodedOffset)
+    }
+    if let count {
       // _cocoaStringUTF8Count gave us the scalar aligned count, but we still
       // need to compensate for sub-scalar indexing, e.g. if `i` is in the
       // middle of a two-byte UTF8 scalar.

--- a/stdlib/public/core/UnicodeHelpers.swift
+++ b/stdlib/public/core/UnicodeHelpers.swift
@@ -247,10 +247,10 @@ extension _StringGuts {
   @_effects(releasenone)
   private func _getForeignCodeUnit(at i: Int) -> UInt16 {
 #if _runtime(_ObjC)
-    // Currently, foreign  means NSString
-    return _cocoaStringSubscript(_object.cocoaObject, i)
+    // Currently, foreign means NSString
+    return _object.withCocoaObject { _cocoaStringSubscript($0, i) }
 #else
-  fatalError("No foreign strings on Linux in this version of Swift")
+    fatalError("No foreign strings on Linux in this version of Swift")
 #endif
   }
 
@@ -386,11 +386,13 @@ extension _StringGuts {
     return withUnsafeTemporaryAllocation(
       of: UInt16.self, capacity: count
     ) { buffer in
-      _cocoaStringCopyCharacters(
-        from: self._object.cocoaObject,
-        range: start..<end,
-        into: buffer.baseAddress._unsafelyUnwrappedUnchecked
-      )
+      self._object.withCocoaObject {
+        _cocoaStringCopyCharacters(
+          from: $0,
+          range: start..<end,
+          into: buffer.baseAddress._unsafelyUnwrappedUnchecked
+        )
+      }
       return Character(String._uncheckedFromUTF16(UnsafeBufferPointer(buffer)))
     }
 #else


### PR DESCRIPTION
This takes @atrick's excellent https://github.com/apple/swift/pull/63631 and extends it to some other instances of reinterpretCast misuse in `_StringObject`. 

It also incorporates a variant of #63634 that unifies in-place mutation mechanics for native large strings.

Additionally, this PR also attempts to fix the performance regressions uncovered in #63631 by eliminating newly introduced ARC traffic, by carefully juggling mutations and sprinkling some `_withUnsafeGuaranteedRef` onto read-only accesses.
(Caveat: I neither looked into the cause of regressions, nor verified that this change indeed does eliminate any retain/releases. This is just more guesswork.)

rdar://104751936