### PR TITLE
[cxx-interop] Partially re-enable a test on Linux

### DIFF
--- a/test/Interop/Cxx/stdlib/use-std-map.swift
+++ b/test/Interop/Cxx/stdlib/use-std-map.swift
@@ -2,8 +2,7 @@
 //
 // REQUIRES: executable_test
 //
-// REQUIRES: OS=macosx
-// TODO: enable on Linux (rdar://105220600)
+// REQUIRES: OS=macosx || OS=linux-gnu
 
 import StdlibUnittest
 import StdMap
@@ -32,6 +31,7 @@ StdMapTestSuite.test("Map.subscript") {
   expectNil(m[5])
 }
 
+#if !os(Linux) // TODO: enable on Linux (rdar://105220600)
 StdMapTestSuite.test("UnorderedMap.subscript") {
   // This relies on the `std::unordered_map` conformance to `CxxDictionary` protocol.
   var m = initUnorderedMap()
@@ -41,5 +41,6 @@ StdMapTestSuite.test("UnorderedMap.subscript") {
   expectNil(m[-1])
   expectNil(m[5])
 }
+#endif
 
 runAllTests()


### PR DESCRIPTION
`std::map` conformance to `CxxDictionary` is synthesized properly, only the `std::unordered_map` conformance is problematic. Let's make sure we test the `std::map` conformance with libstdc++ on Linux.