### PR TITLE
[Obj-C interop] Resolve FIXME

### DIFF
--- a/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
+++ b/test/Interop/CxxToSwiftToCxx/bridge-cxx-struct-back-to-cxx.swift
@@ -9,10 +9,6 @@
 
 // RUN: %FileCheck %s < %t/UseCxxTyExposeOnly.h
 
-// FIXME: remove once https://github.com/apple/swift/pull/60971 lands.
-// RUN: echo "#include \"header.h\"" > %t/full-cxx-swift-cxx-bridging.h
-// RUN: cat %t/UseCxxTy.h >> %t/full-cxx-swift-cxx-bridging.h
-
 // RUN: %check-interop-cxx-header-in-clang(%t/full-cxx-swift-cxx-bridging.h -Wno-reserved-identifier)
 
 // FIXME: test in C++ with modules (but libc++ modularization is preventing this)

--- a/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
+++ b/test/Interop/ObjCToSwiftToObjCxx/bridge-objc-types-back-to-objcxx.swift
@@ -9,10 +9,6 @@
 
 // RUN: %FileCheck %s < %t/UseObjCTyExposeOnly.h
 
-// FIXME: remove once https://github.com/apple/swift/pull/60971 lands.
-// RUN: echo "#include \"header.h\"" > %t/full-header.h
-// RUN: cat %t/UseObjCTy.h >> %t/full-header.h
-
 // RUN: %target-interop-build-clangxx -std=gnu++20 -fobjc-arc -c -x objective-c++-header %t/full-header.h -o %t/o.o
 
 // REQUIRES: objc_interop


### PR DESCRIPTION
https://github.com/apple/swift/pull/60971 has landed, so we can remove the temporary workarounds.