### PR TITLE
[Test] Disable some failing tests on ARM64e.

### DIFF
--- a/test/IRGen/ptrauth-foreign.sil
+++ b/test/IRGen/ptrauth-foreign.sil
@@ -2,6 +2,7 @@
 
 // REQUIRES: CPU=arm64e
 // REQUIRES: OS=ios
+// REQUIRES: rdar105176187
 
 sil @test0 : $() -> () {
 bb0:

--- a/test/IRGen/ptrauth_field_fptr_import.swift
+++ b/test/IRGen/ptrauth_field_fptr_import.swift
@@ -1,6 +1,7 @@
 // RUN: %swift-frontend %s -enable-import-ptrauth-field-function-pointers -emit-ir -target arm64e-apple-ios13.0 -I %S/Inputs/ -validate-tbd-against-ir=none | %FileCheck %s
 // REQUIRES: CPU=arm64e
 // REQUIRES: OS=ios
+// REQUIRES: rdar105176187
 
 import PointerAuth
 

--- a/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch-arm64e.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch-arm64e.swift
@@ -7,6 +7,8 @@
 // REQUIRES: CPU=arm64e
 // REQUIRES: OS=ios
 
+// REQUIRES: rdar105396625
+
 // note: uses swift-class-virtual-method-dispatch.swift
 
 // CHECK:      void BaseClass::virtualMethod() {

--- a/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch.swift
@@ -4,9 +4,12 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/class.h)
 
+// rdar://105396625
+// UNSUPPORTED: CPU=arm64e
+
 public class BaseClass {
   var field: Int64
-    
+
   init() {
     field = 0
   }

--- a/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift
+++ b/test/Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift
@@ -11,6 +11,9 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/fixed-useclass.h)
 
+// rdar://105396625
+// UNSUPPORTED: CPU=arm64e
+
 #if RESILIENT_MODULE
 
 open class BaseClass {


### PR DESCRIPTION
Disabling these tests:
    IRGen/ptrauth-foreign.sil
    IRGen/ptrauth_field_fptr_import.swift
    Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch-arm64e.swift
    Interop/SwiftToCxx/class/swift-class-virtual-method-dispatch.swift
    Interop/SwiftToCxx/class/swift-subclass-of-resilient-class-virtual-method-dispatch.swift