### PR TITLE
IRGen: order properties on SwiftAsyncCC to be uniform

### DIFF
--- a/lib/IRGen/GenConcurrency.cpp
+++ b/lib/IRGen/GenConcurrency.cpp
@@ -330,8 +330,8 @@ llvm::Function *IRGenModule::getAwaitAsyncContinuationFn() {
   llvm::Value *context = suspendFn->getArg(0);
   auto *call =
       Builder.CreateCall(getContinuationAwaitFunctionPointer(), {context});
-  call->setDoesNotThrow();
   call->setCallingConv(SwiftAsyncCC);
+  call->setDoesNotThrow();
   call->setTailCallKind(AsyncTailCallKind);
 
   Builder.CreateRetVoid();

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -2541,8 +2541,8 @@ llvm::Function *IRGenFunction::createAsyncSuspendFn() {
   auto *suspendCall = Builder.CreateCall(
       IGM.getTaskSwitchFuncFunctionPointer(),
       {context, resumeFunction, targetExecutorFirst, targetExecutorSecond});
-  suspendCall->setDoesNotThrow();
   suspendCall->setCallingConv(IGM.SwiftAsyncCC);
+  suspendCall->setDoesNotThrow();
   suspendCall->setTailCallKind(IGM.AsyncTailCallKind);
 
   llvm::AttributeList attrs = suspendCall->getAttributes();


### PR DESCRIPTION
Adjust the IRGen to always set the calling convention and then the noexcept bit.  This makes it easier to quickly scan through the attributes for the async calls which was useful for some Concurrency related work on Windows.