### PR TITLE
test: adjust tests for mandatory tail calls on Win64

### DIFF
--- a/test/IRGen/async/hop_to_executor.sil
+++ b/test/IRGen/async/hop_to_executor.sil
@@ -20,8 +20,7 @@ import _Concurrency
 // CHECK-arm64e: call {{.*}} @llvm.coro.suspend.async{{.*}}(i32 0, i8* [[RESUME]], i8* bitcast (i8* (i8*)* @__swift_async_resume_get_context to i8*), i8* bitcast (void (i8*, [[INT]], [[INT]], %swift.context*)* @test_simple.1 to i8*), i8* [[RESUME]], [[INT]] %1, [[INT]] %2, %swift.context* {{%[0-9]+}})
 // CHECK: [[RET_CONTINUATION:%.*]] = bitcast void (%swift.context*)* {{.*}} to i8*
 // CHECK:  call i1 (i8*, i1, ...) @llvm.coro.end.async(i8* {{.*}}, i1 false, void (i8*, %swift.context*)* @[[TAIL_CALL_FUNC:.*]], i8* [[RET_CONTINUATION]]
-// CHECK-WIN: ret void
-// CHECK-SYSV: unreachable
+// CHECK: unreachable
 
 sil @test_simple : $@async (@guaranteed Optional<Builtin.Executor>) -> () {
 bb0(%0 : $Optional<Builtin.Executor>):

--- a/test/IRGen/async/non_musttail_target.sil
+++ b/test/IRGen/async/non_musttail_target.sil
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend -disable-legacy-type-info -parse-stdlib %s -disable-llvm-optzns -disable-swift-specific-llvm-optzns -disable-objc-interop -module-name main -emit-ir -o - | %FileCheck %s
 
 // REQUIRES: concurrency
-// REQUIRES: OS=wasi || OS=windows-msvc
+// REQUIRES: OS=wasi
 
 sil_stage canonical
 

--- a/test/IRGen/async/run-call-dynamic-void_to_void.swift
+++ b/test/IRGen/async/run-call-dynamic-void_to_void.swift
@@ -10,9 +10,6 @@
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime
 
-// Windows does not do swiftailcc
-// XFAIL: OS=windows-msvc
-
 import _Concurrency
 
 

--- a/test/IRGen/async_dynamic_replacement.swift
+++ b/test/IRGen/async_dynamic_replacement.swift
@@ -1,8 +1,5 @@
 // RUN: %target-swift-frontend %s -emit-ir -disable-availability-checking -disable-objc-interop | %FileCheck %s
 
-// Windows does not do swiftailcc
-// XFAIL: OS=windows-msvc
-
 // REQUIRES: concurrency
 
 public dynamic func number() async -> Int {


### PR DESCRIPTION
Since we are force enabling the mandatory tail calls on Windows x64, even at the expense of stack traces and debugging support, adjust the tests to account for the difference.

Resolves #57976