### PR TITLE
Disable stack protection by default

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -129,7 +129,7 @@ public:
   bool EnablePerformanceAnnotations = false;
 
   /// Enables the emission of stack protectors in functions.
-  bool EnableStackProtection = true;
+  bool EnableStackProtection = false;
 
   /// Like `EnableStackProtection` and also enables moving of values to
   /// temporaries for stack protection.

--- a/test/SILOptimizer/stack_protection.swift
+++ b/test/SILOptimizer/stack_protection.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-frontend -module-name=test -emit-sil %s -O | %FileCheck %s --check-prefix=CHECK --check-prefix=DEFAULT
 // RUN: %target-swift-frontend -module-name=test -enable-move-inout-stack-protector -emit-sil %s -O -enable-stack-protector | %FileCheck %s --check-prefix=CHECK --check-prefix=MOVE
 
+// temporarily disabled: rdar://105231457
+// XFAIL: *
+
 // REQUIRES: swift_in_compiler
 
 @_silgen_name("potentiallyBadCFunction")


### PR DESCRIPTION
Background:  Stack protection was added to the `main` branch a few months ago and has not yet been in any shipping version of Swift.

We expect stack checks to impair performance somewhat, but we've recently found some cases where the stack checks were being inserted in places where they don't actually do any good.  These led to unnecessary performance regressions, so we're disabling them in the 5.8 branch.

We'll leave it enabled in `main` while we work to avoid the extra unnecessary stack checks.

Resolves rdar://105231457
