### PR TITLE
Remove support for linking arclite

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -162,6 +162,9 @@ ERROR(cannot_find_migration_script, none,
 ERROR(error_darwin_static_stdlib_not_supported, none,
       "-static-stdlib is no longer supported on Apple platforms", ())
 
+WARNING(warn_darwin_link_objc_deprecated, none,
+      "-link-objc-runtime is no longer supported on Apple platforms", ())
+
 ERROR(error_darwin_only_supports_libcxx, none,
       "The only C++ standard library supported on Apple platforms is libc++",
       ())

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -812,11 +812,14 @@ def L_EQ : Joined<["-"], "L=">, Group<linker_option_Group>,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
   Alias<L>;
 
+// Accept but ignore these flags.  They were once used to control
+// linking of arclite, which is no longer used on Darwin.
 def link_objc_runtime : Flag<["-"], "link-objc-runtime">,
-  Flags<[DoesNotAffectIncrementalBuild]>;
+  Flags<[DoesNotAffectIncrementalBuild]>,
+  HelpText<"Deprecated">;
 def no_link_objc_runtime : Flag<["-"], "no-link-objc-runtime">,
   Flags<[HelpHidden, DoesNotAffectIncrementalBuild]>,
-  HelpText<"Don't link in additions to the Objective-C runtime">;
+  HelpText<"Deprecated">;
 
 def static_stdlib: Flag<["-"], "static-stdlib">,
   Flags<[DoesNotAffectIncrementalBuild]>,

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -854,6 +854,12 @@ toolchains::Darwin::validateArguments(DiagnosticEngine &diags,
     diags.diagnose(SourceLoc(), diag::error_darwin_static_stdlib_not_supported);
   }
 
+  // Validating darwin deprecated -link-objc-runtime.
+  if (args.hasArg(options::OPT_link_objc_runtime,
+		  options::OPT_no_link_objc_runtime)) {
+    diags.diagnose(SourceLoc(), diag::warn_darwin_link_objc_deprecated);
+  }
+
   // If a C++ standard library is specified, it has to be libc++.
   if (auto arg = args.getLastArg(options::OPT_experimental_cxx_stdlib)) {
     if (StringRef(arg->getValue()) != "libc++") {

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -221,27 +221,6 @@ static void addVersionString(const ArgList &inputArgs, ArgStringList &arguments,
   arguments.push_back(inputArgs.MakeArgString(os.str()));
 }
 
-/// Returns true if the compiler depends on features provided by the ObjC
-/// runtime that are not present on the deployment target indicated by
-/// \p triple.
-static bool wantsObjCRuntime(const llvm::Triple &triple) {
-  assert((!triple.isTvOS() || triple.isiOS()) &&
-         "tvOS is considered a kind of iOS");
-
-  // When updating the versions listed here, please record the most recent
-  // feature being depended on and when it was introduced:
-  //
-  // - Make assigning 'nil' to an NSMutableDictionary subscript delete the
-  //   entry, like it does for Swift.Dictionary, rather than trap.
-  if (triple.isiOS())
-    return triple.isOSVersionLT(9);
-  if (triple.isMacOSX())
-    return triple.isMacOSXVersionLT(10, 11);
-  if (triple.isWatchOS())
-    return false;
-  llvm_unreachable("unknown Darwin OS");
-}
-
 void
 toolchains::Darwin::addLinkerInputArgs(InvocationInfo &II,
                                        const JobContext &context) const {

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -31,9 +31,6 @@ protected:
   void addLinkerInputArgs(InvocationInfo &II,
                           const JobContext &context) const;
 
-  void addArgsToLinkARCLite(llvm::opt::ArgStringList &Arguments,
-                            const JobContext &context) const;
-
   void addSanitizerArgs(llvm::opt::ArgStringList &Arguments,
                         const DynamicLinkJobAction &job,
                         const JobContext &context) const;

--- a/test/Driver/linker-arclite.swift
+++ b/test/Driver/linker-arclite.swift
@@ -2,31 +2,14 @@
 // Note: This is really about the /host/ environment, but since there are RUN
 // lines for multiple targets anyway it doesn't make a huge difference.
 
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %S/../Inputs/empty.swift | %FileCheck %s
-
-// CHECK: bin/ld{{"? }}
-// CHECK-SAME: -force_load {{[^ ]+/lib/arc/libarclite_macosx.a}} -framework CoreFoundation
-// CHECK-SAME: -o {{[^ ]+}}
-
-
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios8.0-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix IOS_ARCLITE %s
-
-// IOS_ARCLITE: bin/ld{{"? }}
-// IOS_ARCLITE: -force_load {{[^ ]+/lib/arc/libarclite_iphonesimulator.a}}
-// IOS_ARCLITE: -o {{[^ ]+}}
-
+// The libarclite library is no longer used for any Darwin platform, so this now just verifies that we never request it
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.11 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_ARCLITE %s
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.10 %S/../Inputs/empty.swift | %FileCheck -check-prefix ANY_ARCLITE %s
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios9-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_ARCLITE %s
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-ios8-simulator %S/../Inputs/empty.swift | %FileCheck -check-prefix ANY_ARCLITE %s
 // RUN: %swiftc_driver -driver-print-jobs -target arm64-apple-tvos9 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_ARCLITE %s
 // RUN: %swiftc_driver -driver-print-jobs -target armv7k-apple-watchos2 %S/../Inputs/empty.swift | %FileCheck -check-prefix NO_ARCLITE %s
 
 // NO_ARCLITE: bin/ld{{"? }}
 // NO_ARCLITE-NOT: arclite
+// NO_ARCLITE-NOT: CoreFoundation
 // NO_ARCLITE: -o {{[^ ]+}}
-
-// ANY_ARCLITE: bin/ld{{"? }}
-// ANY_ARCLITE: -force_load {{[^ ]+}}/lib/arc/libarclite_{{.+}}.a
-// ANY_ARCLITE: -o {{[^ ]+}}

--- a/test/Driver/options-apple.swift
+++ b/test/Driver/options-apple.swift
@@ -1,0 +1,6 @@
+// REQUIRES: swift_interpreter
+// REQUIRES: OS=macosx
+
+// RUN: %swift_driver -link-objc-runtime %s 2>&1 | %FileCheck -check-prefix LINK_OBJC_RUNTIME_WARNING %s
+// RUN: %swift_driver -no-link-objc-runtime %s 2>&1 | %FileCheck -check-prefix LINK_OBJC_RUNTIME_WARNING %s
+// LINK_OBJC_RUNTIME_WARNING: warning: -link-objc-runtime is no longer supported on Apple platforms

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -28,7 +28,6 @@
 // CHECK-L2: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx$}}
 
 // RUN: env DYLD_LIBRARY_PATH=/abc/ SDKROOT=/sdkroot %swift_driver_plain -### -target x86_64-apple-macosx10.9 -L/foo/ -L/bar/ %s 2>&1 | %FileCheck -check-prefix=CHECK-L2-ENV %s 
-// CHECK-L2-ENV: warning: unable to find Objective-C runtime support library 'arclite'; pass '-no-link-objc-runtime' to silence this warning
 // CHECK-L2-ENV: # DYLD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/macosx:/sdkroot/usr/lib/swift:/abc/$}}
 
 // RUN: %swift_driver_plain -### -target x86_64-apple-macosx10.9 %s | %FileCheck -check-prefix=CHECK-NO-FRAMEWORKS %s
@@ -53,7 +52,6 @@
 // CHECK-F2-ENV: DYLD_FRAMEWORK_PATH=/foo/:/bar/:/abc/{{$}}
 
 // RUN: env DYLD_FRAMEWORK_PATH=/abc/ SDKROOT=/sdkroot %swift_driver_plain -### -target x86_64-apple-macosx10.9 -F/foo/ -F/bar/ -L/foo2/ -L/bar2/ %s 2>&1 | %FileCheck -check-prefix=CHECK-COMPLEX %s
-// CHECK-COMPLEX: warning: unable to find Objective-C runtime support library 'arclite'; pass '-no-link-objc-runtime' to silence this warning
 // CHECK-COMPLEX: -F /foo/
 // CHECK-COMPLEX: -F /bar/
 // CHECK-COMPLEX: #

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -131,7 +131,3 @@
 // RUN: %swift_driver -Fsystem %t/test.framework/ %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
 // RUN: %target-swiftc_driver -Fsystem %t/test.framework/ %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
 // SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION: warning: framework search path ends in ".framework"
-
-// RUN: %swift_driver -link-objc-runtime %s 2>&1 | %FileCheck -check-prefix LINK_OBJC_RUNTIME_WARNING %s
-// RUN: %swift_driver -no-link-objc-runtime %s 2>&1 | %FileCheck -check-prefix LINK_OBJC_RUNTIME_WARNING %s
-// LINK_OBJC_RUNTIME_WARNING: warning: -link-objc-runtime is no longer supported on Apple platforms

--- a/test/Driver/options.swift
+++ b/test/Driver/options.swift
@@ -131,3 +131,7 @@
 // RUN: %swift_driver -Fsystem %t/test.framework/ %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
 // RUN: %target-swiftc_driver -Fsystem %t/test.framework/ %s 2>&1 | %FileCheck -check-prefix SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION %s
 // SEARCH_PATH_INCLUDES_FRAMEWORK_EXTENSION: warning: framework search path ends in ".framework"
+
+// RUN: %swift_driver -link-objc-runtime %s 2>&1 | %FileCheck -check-prefix LINK_OBJC_RUNTIME_WARNING %s
+// RUN: %swift_driver -no-link-objc-runtime %s 2>&1 | %FileCheck -check-prefix LINK_OBJC_RUNTIME_WARNING %s
+// LINK_OBJC_RUNTIME_WARNING: warning: -link-objc-runtime is no longer supported on Apple platforms


### PR DESCRIPTION
Darwin no longer uses arclite and it's no longer distributed in the macOS SDKs.

This leaves the options -link-objc-runtime and -no-link-objc-runtime in place, but strips out all the logic that actually used them.

Resolves: rdar://105406972