### PR TITLE
[SUA] Do not access the field descriptor when absent

### DIFF
--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -143,13 +143,15 @@ computeMallocTypeSummary(const HeapMetadata *heapMetadata) {
   summary.type_kind = MALLOC_TYPE_KIND_SWIFT;
 
   bool isGenericData = true;
-  for (auto &field : *typeDesc->Fields.get()) {
-    if (field.isIndirectCase()) {
-      isGenericData = false;
-      if (field.isVar())
-        summary.layout_semantics.data_pointer = true;
-      else
-        summary.layout_semantics.immutable_pointer = true;
+  if (auto *fieldDesc = typeDesc->Fields.get()) {
+    for (auto &field : *fieldDesc) {
+      if (field.isIndirectCase()) {
+        isGenericData = false;
+        if (field.isVar())
+          summary.layout_semantics.data_pointer = true;
+        else
+          summary.layout_semantics.immutable_pointer = true;
+      }
     }
   }
 


### PR DESCRIPTION
I've reproduced the original crash with a small example compiled with `-disable-reflection-metadata`.  This change guards access to the field descriptor to avoid accessing it when it is absent.

Radar-Id: rdar://105461946
