### PR TITLE
Add REQUIRES: distributed to runtime_discoverable_attrs_distributed.swift

### DIFF
--- a/test/type/runtime_discoverable_attrs_distributed.swift
+++ b/test/type/runtime_discoverable_attrs_distributed.swift
@@ -3,6 +3,7 @@
 // RUN: %target-typecheck-verify-swift -disable-availability-checking -enable-experimental-feature RuntimeDiscoverableAttrs -I %t
 
 // REQUIRES: asserts
+// REQUIRES: distributed
 
 import RuntimeAttrs
 import Distributed


### PR DESCRIPTION
The test is using the distributed capabilities, but it is not marked as such. If someone is not building with the distributed features enabled, the test will fail for them.