### PR TITLE
Change experimental reflection lit feature to reflection_runtime

### DIFF
--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -141,7 +141,7 @@ if "@SWIFT_STDLIB_ENABLE_UNICODE_DATA" == "TRUE":
 if "@SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING@" == "TRUE":
     config.available_features.add('string_processing')
 if "@SWIFT_ENABLE_EXPERIMENTAL_REFLECTION@" == "TRUE":
-    config.available_features.add('reflection')
+    config.available_features.add('reflection_runtime')
 if "@SWIFT_STDLIB_ENABLE_DEBUG_PRECONDITIONS_IN_RELEASE@" == "TRUE":
     config.available_features.add('swift_stdlib_debug_preconditions_in_release')
 

--- a/test/stdlib/Reflection/PartialType.swift
+++ b/test/stdlib/Reflection/PartialType.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// REQUIRES: reflection
+// REQUIRES: reflection_runtime
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/test/stdlib/_Runtime/ContextDescriptor/StructDescriptor.swift
+++ b/test/stdlib/_Runtime/ContextDescriptor/StructDescriptor.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// REQUIRES: reflection
+// REQUIRES: reflection_runtime
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/test/stdlib/_Runtime/Metadata/FunctionMetadata.swift
+++ b/test/stdlib/_Runtime/Metadata/FunctionMetadata.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// REQUIRES: reflection
+// REQUIRES: reflection_runtime
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/test/stdlib/_Runtime/Metadata/Metadata.swift
+++ b/test/stdlib/_Runtime/Metadata/Metadata.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// REQUIRES: reflection
+// REQUIRES: reflection_runtime
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/test/stdlib/_Runtime/Metadata/MetatypeMetadata.swift
+++ b/test/stdlib/_Runtime/Metadata/MetatypeMetadata.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// REQUIRES: reflection
+// REQUIRES: reflection_runtime
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/test/stdlib/_Runtime/Metadata/StructMetadata.swift
+++ b/test/stdlib/_Runtime/Metadata/StructMetadata.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// REQUIRES: reflection
+// REQUIRES: reflection_runtime
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/test/stdlib/_Runtime/Metadata/TupleMetadata.swift
+++ b/test/stdlib/_Runtime/Metadata/TupleMetadata.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// REQUIRES: reflection
+// REQUIRES: reflection_runtime
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/test/stdlib/_Runtime/Metadata/TypeMetadata.swift
+++ b/test/stdlib/_Runtime/Metadata/TypeMetadata.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// REQUIRES: reflection
+// REQUIRES: reflection_runtime
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/test/stdlib/_Runtime/Metadata/ValueWitnessTable.swift
+++ b/test/stdlib/_Runtime/Metadata/ValueWitnessTable.swift
@@ -1,6 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
-// REQUIRES: reflection
+// REQUIRES: reflection_runtime
 // UNSUPPORTED: freestanding
 
 import StdlibUnittest

--- a/validation-test/lit.site.cfg.in
+++ b/validation-test/lit.site.cfg.in
@@ -128,7 +128,7 @@ if "@SWIFT_ENABLE_EXPERIMENTAL_DISTRIBUTED@" == "TRUE":
 if "@SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING@" == "TRUE":
     config.available_features.add('string_processing')
 if "@SWIFT_ENABLE_EXPERIMENTAL_REFLECTION@" == "TRUE":
-    config.available_features.add('reflection')
+    config.available_features.add('reflection_runtime')
 if "@SWIFT_STDLIB_ENABLE_DEBUG_PRECONDITIONS_IN_RELEASE@" == "TRUE":
     config.available_features.add('swift_stdlib_debug_preconditions_in_release')
 


### PR DESCRIPTION
The feature "reflection" was already used in the tests (enabled with SWIFT_ENABLE_REFLECTION). The new feature tests were triggered even if the experimental feature was not enabled in people builds.

Change the spelling to "reflection_runtime" to not clash with the existing feature. Change all the tests I found added lately that has the existing spelling.
