### PR TITLE
Require parameters of noncopyable type to specify ownership

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6864,6 +6864,10 @@ ERROR(moveonly_cannot_conform_to_type, none,
      (DescriptiveDeclKind, DeclName, Type))
 ERROR(moveonly_non_final_class_cannot_contain_moveonly_field, none,
      "non-final classes containing move only fields is not yet supported", ())
+ERROR(moveonly_parameter_missing_ownership, none,
+      "noncopyable parameter must specify its ownership", ())
+NOTE(moveonly_parameter_ownership_suggestion, none,
+      "add '%0' %1", (StringRef, StringRef))
 
 //------------------------------------------------------------------------------
 // MARK: Runtime discoverable attributes (@runtimeMetadata)

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -607,13 +607,10 @@ mapParsedParameters(Parser &parser,
           if (auto *STR = dyn_cast<SpecifierTypeRepr>(unwrappedType)) {
             if (isa<IsolatedTypeRepr>(STR))
               param->setIsolated(true);
-            unwrappedType = STR->getBase();
-            continue;
-          }
+            else if (isa<CompileTimeConstTypeRepr>(STR))
+              param->setCompileTimeConst(true);
 
-          if (auto *CTR = dyn_cast<CompileTimeConstTypeRepr>(unwrappedType)) {
-            param->setCompileTimeConst(true);
-            unwrappedType = CTR->getBase();
+            unwrappedType = STR->getBase();
             continue;
           }
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -653,12 +653,16 @@ GenericSignatureRequest::evaluate(Evaluator &evaluator,
       for (auto param : *params) {
         auto *typeRepr = param->getTypeRepr();
         if (typeRepr == nullptr)
-          continue;
+            continue;
 
         auto paramOptions = baseOptions;
 
-        if (auto *specifier = dyn_cast<SpecifierTypeRepr>(typeRepr))
+        if (auto *specifier = dyn_cast<SpecifierTypeRepr>(typeRepr)) {
+          if (isa<OwnershipTypeRepr>(specifier))
+            paramOptions |= TypeResolutionFlags::HasOwnership;
+
           typeRepr = specifier->getBase();
+        }
 
         if (auto *packExpansion = dyn_cast<VarargTypeRepr>(typeRepr)) {
           paramOptions.setContext(TypeResolverContext::VariadicFunctionInput);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1990,6 +1990,8 @@ namespace {
     }
 
     bool diagnoseMoveOnly(TypeRepr *repr, Type genericArgTy);
+    bool diagnoseMoveOnlyMissingOwnership(TypeRepr *repr,
+                                          TypeResolutionOptions options);
     
     bool diagnoseDisallowedExistential(TypeRepr *repr);
     
@@ -2044,7 +2046,7 @@ namespace {
                                 Optional<SILResultInfo> &errorResult);
     NeverNullType resolveDeclRefTypeRepr(DeclRefTypeRepr *repr,
                                          TypeResolutionOptions options);
-    NeverNullType resolveSpecifierTypeRepr(SpecifierTypeRepr *repr,
+    NeverNullType resolveOwnershipTypeRepr(OwnershipTypeRepr *repr,
                                            TypeResolutionOptions options);
     NeverNullType resolveIsolatedTypeRepr(IsolatedTypeRepr *repr,
                                           TypeResolutionOptions options);
@@ -2250,6 +2252,51 @@ bool TypeResolver::diagnoseMoveOnly(TypeRepr *repr, Type genericArgTy) {
   return false;
 }
 
+/// Assuming this repr has resolved to a move-only / noncopyable type, checks
+/// to see if that resolution happened in a context requiring an ownership
+/// annotation. If it did and there was no ownership specified, emits a
+/// diagnostic.
+///
+/// \returns true if an error diagnostic was emitted
+bool TypeResolver::diagnoseMoveOnlyMissingOwnership(
+                                              TypeRepr *repr,
+                                              TypeResolutionOptions options) {
+  // only required on function inputs.
+  // we can ignore InoutFunctionInput since it's already got ownership.
+  if (!options.is(TypeResolverContext::FunctionInput))
+    return false;
+
+  // enum cases don't need to specify ownership for associated values
+  if (options.hasBase(TypeResolverContext::EnumElementDecl))
+    return false;
+
+  // otherwise, we require ownership.
+  if (options.contains(TypeResolutionFlags::HasOwnership))
+    return false;
+
+  diagnose(repr->getLoc(),
+           diag::moveonly_parameter_missing_ownership);
+
+  // FIXME: this should be 'borrowing'
+  diagnose(repr->getLoc(), diag::moveonly_parameter_ownership_suggestion,
+           "__shared", "for an immutable reference")
+      .fixItInsert(repr->getStartLoc(), "__shared ");
+
+  diagnose(repr->getLoc(), diag::moveonly_parameter_ownership_suggestion,
+           "inout", "for a mutable reference")
+      .fixItInsert(repr->getStartLoc(), "inout ");
+
+  // FIXME: this should be 'consuming'
+  diagnose(repr->getLoc(), diag::moveonly_parameter_ownership_suggestion,
+           "__owned", "to take the value from callers")
+      .fixItInsert(repr->getStartLoc(), "__owned ");
+
+  // to avoid duplicate diagnostics
+  repr->setInvalid();
+
+  return true;
+}
+
 NeverNullType TypeResolver::resolveType(TypeRepr *repr,
                                         TypeResolutionOptions options) {
   assert(repr && "Cannot validate null TypeReprs!");
@@ -2284,7 +2331,7 @@ NeverNullType TypeResolver::resolveType(TypeRepr *repr,
   case TypeReprKind::InOut:
   case TypeReprKind::Shared:
   case TypeReprKind::Owned:
-    return resolveSpecifierTypeRepr(cast<SpecifierTypeRepr>(repr), options);
+    return resolveOwnershipTypeRepr(cast<OwnershipTypeRepr>(repr), options);
 
   case TypeReprKind::Isolated:
     return resolveIsolatedTypeRepr(cast<IsolatedTypeRepr>(repr), options);
@@ -4146,6 +4193,10 @@ TypeResolver::resolveDeclRefTypeRepr(DeclRefTypeRepr *repr,
     }
   }
 
+  // move-only types must have an ownership specifier when used as a parameter of a function.
+  if (result->isPureMoveOnly())
+    diagnoseMoveOnlyMissingOwnership(repr, options);
+
   // Hack to apply context-specific @escaping to a typealias with an underlying
   // function type.
   if (result->is<FunctionType>())
@@ -4155,9 +4206,9 @@ TypeResolver::resolveDeclRefTypeRepr(DeclRefTypeRepr *repr,
 }
 
 NeverNullType
-TypeResolver::resolveSpecifierTypeRepr(SpecifierTypeRepr *repr,
+TypeResolver::resolveOwnershipTypeRepr(OwnershipTypeRepr *repr,
                                        TypeResolutionOptions options) {
-  // inout is only valid for (non-Subscript and non-EnumCaseDecl)
+  // ownership is only valid for (non-Subscript and non-EnumCaseDecl)
   // function parameters.
   if (!options.is(TypeResolverContext::FunctionInput) ||
       options.hasBase(TypeResolverContext::SubscriptDecl) ||
@@ -4177,10 +4228,10 @@ TypeResolver::resolveSpecifierTypeRepr(SpecifierTypeRepr *repr,
       name = "inout";
       break;
     case TypeReprKind::Shared:
-      name = "__shared";
+      name = "__shared"; // FIXME: use 'borrowing'
       break;
     case TypeReprKind::Owned:
-      name = "__owned";
+      name = "__owned";  // FIXME: use 'consuming'
       break;
     default:
       llvm_unreachable("unknown SpecifierTypeRepr kind");
@@ -4194,6 +4245,9 @@ TypeResolver::resolveSpecifierTypeRepr(SpecifierTypeRepr *repr,
     // Anything within an inout isn't a parameter anymore.
     options.setContext(TypeResolverContext::InoutFunctionInput);
   }
+
+  // Remember that we've seen an ownership specifier for this base type.
+  options |= TypeResolutionFlags::HasOwnership;
 
   return resolveType(repr->getBase(), options);
 }

--- a/lib/Sema/TypeCheckType.h
+++ b/lib/Sema/TypeCheckType.h
@@ -81,6 +81,9 @@ enum class TypeResolutionFlags : uint16_t {
 
   /// Whether this is a resolution based on a pack reference.
   FromPackReference = 1 << 12,
+
+  /// Whether this resolution happens under an explicit ownership specifier.
+  HasOwnership = 1 << 13,
 };
 
 /// Type resolution contexts that require special handling.

--- a/test/Constraints/moveonly_constraints.swift
+++ b/test/Constraints/moveonly_constraints.swift
@@ -42,7 +42,7 @@ enum Maybe<T> {
   case just(T)
 }
 
-func takeConcrete(_ m: MO) {}
+func takeConcrete(_ m: __shared MO) {}
 func takeGeneric<T>(_ t: T) {}
 func takeGenericSendable<T>(_ t: T) where T: Sendable {}
 func takeMaybe<T>(_ m: Maybe<T>) {}
@@ -71,7 +71,7 @@ func testAny() {
   takeAny(MO()) // expected-error {{move-only type 'MO' cannot be used with generics yet}}
 }
 
-func testBasic(_ mo: MO) {
+func testBasic(_ mo: __shared MO) {
   takeConcrete(globalMO)
   takeConcrete(MO())
 
@@ -139,7 +139,7 @@ func checkMethodCalls() {
   takeMaybe(true ? .none : .just(MO())) // expected-error 3{{move-only type 'MO' cannot be used with generics yet}}
 }
 
-func checkCasting(_ b: any Box, _ mo: MO, _ a: Any) {
+func checkCasting(_ b: any Box, _ mo: __shared MO, _ a: Any) {
   // casting dynamically is allowed, but should always fail since you can't
   // construct such a type.
   let box = b as! ValBox<MO> // expected-error {{move-only type 'MO' cannot be used with generics yet}}
@@ -221,7 +221,7 @@ func checkCasting(_ b: any Box, _ mo: MO, _ a: Any) {
 
 }
 
-func checkStdlibTypes(_ mo: MO) {
+func checkStdlibTypes(_ mo: __shared MO) {
   let _: [MO] = // expected-error {{move-only type 'MO' cannot be used with generics yet}}
       [MO(), MO()]
   let _: [MO] = // expected-error {{move-only type 'MO' cannot be used with generics yet}}

--- a/test/Interpreter/moveonly_bufferview.swift
+++ b/test/Interpreter/moveonly_bufferview.swift
@@ -23,7 +23,7 @@ public struct BufferView<T> {
 }
 
 extension Array {
-    public mutating func withBufferView<U>(_ f: (BufferView<Element>) -> U) -> U {
+    public mutating func withBufferView<U>(_ f: (__shared BufferView<Element>) -> U) -> U {
         return withUnsafeBufferPointer {
             return f(BufferView(ptr: $0))
         }

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -47,13 +47,13 @@ public enum NonTrivialEnum {
 var varGlobal = NonTrivialStruct()
 let letGlobal = NonTrivialStruct()
 
-public func borrowVal(_ e : NonTrivialEnum) {}
-public func borrowVal(_ e : FD) {}
-public func borrowVal(_ k: CopyableKlass) {}
-public func borrowVal(_ k: NonTrivialCopyableStruct) {}
-public func borrowVal(_ k: NonTrivialCopyableStruct2) {}
-public func borrowVal(_ s: NonTrivialStruct) {}
-public func borrowVal(_ s: NonTrivialStruct2) {}
+public func borrowVal(_ e : __shared NonTrivialEnum) {}
+public func borrowVal(_ e : __shared FD) {}
+public func borrowVal(_ k: __shared CopyableKlass) {}
+public func borrowVal(_ k: __shared NonTrivialCopyableStruct) {}
+public func borrowVal(_ k: __shared NonTrivialCopyableStruct2) {}
+public func borrowVal(_ s: __shared NonTrivialStruct) {}
+public func borrowVal(_ s: __shared NonTrivialStruct2) {}
 
 public func consumeVal(_ e : __owned NonTrivialEnum) {}
 public func consumeVal(_ e : __owned FD) {}
@@ -71,12 +71,12 @@ public func consumeVal(_ s: __owned NonTrivialStruct2) {}
 // Function Arguments
 //
 
-// CHECK-LABEL: sil [ossa] @$s8moveonly19useNonTrivialStructyyAA0cdE0VF : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
+// CHECK-LABEL: sil [ossa] @$s8moveonly19useNonTrivialStructyyAA0cdE0VhF : $@convention(thin) (@guaranteed NonTrivialStruct) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $NonTrivialStruct):
 // CHECK:   [[COPIED_ARG:%.*]] = copy_value [[ARG]]
 // CHECK:   mark_must_check [no_consume_or_assign] [[COPIED_ARG]]
-// CHECK: } // end sil function '$s8moveonly19useNonTrivialStructyyAA0cdE0VF'
-public func useNonTrivialStruct(_ s: NonTrivialStruct) {
+// CHECK: } // end sil function '$s8moveonly19useNonTrivialStructyyAA0cdE0VhF'
+public func useNonTrivialStruct(_ s: __shared NonTrivialStruct) {
     borrowVal(s)
     let s2 = s
     let k = s.fd
@@ -99,12 +99,12 @@ public func useNonTrivialOwnedStruct(_ s: __owned NonTrivialStruct) {
     let _ = s2
 }
 
-// CHECK-LABEL: sil [ossa] @$s8moveonly17useNonTrivialEnumyyAA0cdE0OF : $@convention(thin) (@guaranteed NonTrivialEnum) -> () {
+// CHECK-LABEL: sil [ossa] @$s8moveonly17useNonTrivialEnumyyAA0cdE0OhF : $@convention(thin) (@guaranteed NonTrivialEnum) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed $NonTrivialEnum):
 // CHECK:   [[COPIED_ARG:%.*]] = copy_value [[ARG]]
 // CHECK:   mark_must_check [no_consume_or_assign] [[COPIED_ARG]]
-// CHECK: } // end sil function '$s8moveonly17useNonTrivialEnumyyAA0cdE0OF'
-public func useNonTrivialEnum(_ s: NonTrivialEnum) {
+// CHECK: } // end sil function '$s8moveonly17useNonTrivialEnumyyAA0cdE0OhF'
+public func useNonTrivialEnum(_ s: __shared NonTrivialEnum) {
     borrowVal(s)
     let s2 = s
     switch s {
@@ -256,7 +256,7 @@ func blackHoleVarInitialization3() {
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly24borrowObjectFunctionCallyyF : $@convention(thin) () -> () {
 // CHECK: [[CLS:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK: [[BORROW:%.*]] = begin_borrow [[CLS]]
-// CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA2FDVF :
+// CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA2FDVhF :
 // CHECK: apply [[FN]]([[BORROW]])
 // CHECK: end_borrow [[BORROW]]
 // CHECK: } // end sil function '$s8moveonly24borrowObjectFunctionCallyyF'
@@ -269,7 +269,7 @@ func borrowObjectFunctionCall() {
 // CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
 // CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK: [[BORROW:%.*]] = load_borrow [[ACCESS]]
-// CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA16NonTrivialStructVF :
+// CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA16NonTrivialStructVhF :
 // CHECK: apply [[FN]]([[BORROW]])
 // CHECK: end_borrow [[BORROW]]
 // CHECK: end_access [[ACCESS]]
@@ -285,7 +285,7 @@ func moveOnlyStructNonConsumingUse() {
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA17NonTrivialStruct2VF : $@convention(thin) (@guaranteed NonTrivialStruct2) -> ()
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA17NonTrivialStruct2VhF : $@convention(thin) (@guaranteed NonTrivialStruct2) -> ()
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
@@ -302,7 +302,7 @@ func moveOnlyStructMoveOnlyStructNonConsumingUse() {
 // CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialStruct2, #NonTrivialStruct2.copyableKlass
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP2]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassCF : $@convention(thin) (@guaranteed CopyableKlass) -> ()
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassChF : $@convention(thin) (@guaranteed CopyableKlass) -> ()
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
@@ -318,7 +318,7 @@ func moveOnlyStructMoveOnlyStructCopyableKlassNonConsumingUse() {
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.copyableKlass
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassCF : $@convention(thin) (@guaranteed CopyableKlass) -> ()
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassChF : $@convention(thin) (@guaranteed CopyableKlass) -> ()
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
@@ -334,7 +334,7 @@ func moveOnlyStructCopyableKlassNonConsumingUse() {
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
 // CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA24NonTrivialCopyableStructVF : 
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA24NonTrivialCopyableStructVhF :
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
@@ -351,7 +351,7 @@ func moveOnlyStructCopyableStructNonConsumingUse() {
 // CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.copyableKlass
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP2]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassCF :
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassChF :
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
@@ -368,7 +368,7 @@ func moveOnlyStructCopyableStructCopyableKlassNonConsumingUse() {
 // CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.nonTrivialCopyableStruct2
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP2]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA25NonTrivialCopyableStruct2VF :
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA25NonTrivialCopyableStruct2VhF :
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
@@ -386,7 +386,7 @@ func moveOnlyStructCopyableStructCopyableStructNonConsumingUse() {
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.nonTrivialCopyableStruct2
 // CHECK:   [[GEP3:%.*]] = struct_element_addr [[GEP2]] : $*NonTrivialCopyableStruct2, #NonTrivialCopyableStruct2.copyableKlass
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP3]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassCF :
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassChF :
 // CHECK:   apply [[FN]]([[BORROW]])
 // CHECK:   end_borrow [[BORROW]]
 // CHECK:   end_access [[ACCESS]]
@@ -412,7 +412,7 @@ func moveOnlyStructCopyableStructCopyableStructCopyableKlassNonConsumingUse() {
 // CHECK:   [[FIELD_MARK:%.*]] = mark_must_check [no_consume_or_assign] [[FIELD]]
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [dynamic] [[FIELD_MARK]]
 // CHECK:   [[BORROWED_MOVEONLY_KLASS:%.*]] = load_borrow [[ACCESS]]
-// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA2FDVF :
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA2FDVhF :
 // CHECK:   apply [[FN]]([[BORROWED_MOVEONLY_KLASS]])
 // CHECK:   end_borrow [[BORROWED_MOVEONLY_KLASS]]
 // CHECK:   destroy_value [[COPYABLE_KLASS]]
@@ -448,7 +448,7 @@ func consumeVal(_ e: __owned EnumSwitchTests.E2) {}
 var booleanGuard: Bool { false }
 var booleanGuard2: Bool { false }
 
-// CHECK-LABEL: sil hidden [ossa] @$s8moveonly15enumSwitchTest1yyAA04EnumC5TestsO1EOF : $@convention(thin) (@guaranteed EnumSwitchTests.E) -> () {
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly15enumSwitchTest1yyAA04EnumC5TestsO1EOhF : $@convention(thin) (@guaranteed EnumSwitchTests.E) -> () {
 // CHECK: bb0([[ARG:%.*]] : @guaranteed
 // CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
 // CHECK:   [[MARKED_VALUE:%.*]] = mark_must_check [no_consume_or_assign] [[COPY_ARG]]
@@ -499,8 +499,8 @@ var booleanGuard2: Bool { false }
 //
 // CHECK: [[BB_CONT]]:
 // CHECK:   destroy_value [[MARKED_VALUE]]
-// CHECK: } // end sil function '$s8moveonly15enumSwitchTest1yyAA04EnumC5TestsO1EOF'
-func enumSwitchTest1(_ e: EnumSwitchTests.E) {
+// CHECK: } // end sil function '$s8moveonly15enumSwitchTest1yyAA04EnumC5TestsO1EOhF'
+func enumSwitchTest1(_ e: __shared EnumSwitchTests.E) {
     switch e {
     case .first:
         break

--- a/test/SILGen/moveonly_deinit_access.swift
+++ b/test/SILGen/moveonly_deinit_access.swift
@@ -9,7 +9,7 @@ public struct FD {
     var i = 5
 }
 
-public func borrowVal(_ e : FD) {}
+public func borrowVal(_ e : __shared FD) {}
 public func consumeVal(_ s: __owned FD) {}
 
 // CHECK: sil hidden [ossa] @$s22moveonly_deinit_access0B17AccessConsumeTestyyAA2FDVzF : $@convention(thin) (@inout FD) -> () {

--- a/test/SILGen/moveonly_var.swift
+++ b/test/SILGen/moveonly_var.swift
@@ -24,7 +24,7 @@ public class Klass {
     }
 }
 
-public func nonConsumingUseKlass(_ k: Klass) {}
+public func nonConsumingUseKlass(_ k: __shared Klass) {}
 
 ///////////
 // Tests //

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -89,7 +89,7 @@ public final class CopyableKlassWithMoveOnlyField {
 // Class Tests //
 /////////////////
 
-public func classSimpleChainTest(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classSimpleChainTest(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-note {{consuming use here}}
                // expected-error @-1 {{'x2' consumed more than once}}
     x2 = x // expected-note {{consuming use here}}
@@ -110,7 +110,7 @@ public func classSimpleChainArgTest(_ x2: inout Klass) {
     borrowVal(k2)
 }
 
-public func classSimpleNonConsumingUseTest(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classSimpleNonConsumingUseTest(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
@@ -120,7 +120,7 @@ public func classSimpleNonConsumingUseArgTest(_ x2: inout Klass) {
     borrowVal(x2)
 }
 
-public func classMultipleNonConsumingUseTest(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classMultipleNonConsumingUseTest(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
@@ -159,7 +159,7 @@ public func classMultipleNonConsumingUseArgTest4(_ x2: inout Klass) { // expecte
 }
 
 
-public func classUseAfterConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classUseAfterConsume(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = x // expected-note {{consuming use here}}
@@ -176,7 +176,7 @@ public func classUseAfterConsumeArg(_ x2: inout Klass) { // expected-error {{'x2
                    // expected-note @-1 {{consuming use here}}
 }
 
-public func classDoubleConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classDoubleConsume(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     x2 = Klass()
@@ -191,7 +191,7 @@ public func classDoubleConsumeArg(_ x2: inout Klass) { // expected-error {{'x2' 
                      // expected-note @-1 {{consuming use here}}
 }
 
-public func classLoopConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classLoopConsume(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     x2 = Klass()
@@ -213,7 +213,7 @@ public func classLoopConsumeArg2(_ x2: inout Klass) { // expected-error {{'x2' c
     x2 = Klass()
 }
 
-public func classDiamond(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classDiamond(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = Klass()
     if boolValue {
@@ -232,7 +232,7 @@ public func classDiamondArg(_ x2: inout Klass) { // expected-error {{'x2' consum
     }
 }
 
-public func classDiamondInLoop(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classDiamondInLoop(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-error @-1 {{'x2' consumed more than once}}
                // expected-note @-2 {{consuming use here}}
@@ -271,7 +271,7 @@ public func classDiamondInLoopArg2(_ x2: inout Klass) { // expected-error {{'x2'
     x2 = Klass()
 }
 
-public func classAssignToVar1(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar1(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = Klass()
@@ -290,7 +290,7 @@ public func classAssignToVar1Arg(_ x2: inout Klass) { // expected-error {{'x2' c
     consumeVal(x3)
 }
 
-public func classAssignToVar2(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar2(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = Klass()
@@ -307,7 +307,7 @@ public func classAssignToVar2Arg(_ x2: inout Klass) { // expected-error {{'x2' c
     borrowVal(x3)
 }
 
-public func classAssignToVar3(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar3(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-note {{consuming use here}}
     x2 = Klass()
     var x3 = x2
@@ -315,21 +315,21 @@ public func classAssignToVar3(_ x: Klass) { // expected-error {{'x' has guarante
     consumeVal(x3)
 }
 
-public func classAssignToVar3Arg(_ x: Klass, _ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func classAssignToVar3Arg(_ x: __shared Klass, _ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
                                                             // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func classAssignToVar3Arg2(_ x: Klass, _ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
+public func classAssignToVar3Arg2(_ x: __shared Klass, _ x2: inout Klass) { // expected-error {{'x2' consumed but not reinitialized before end of function}}
                                                                    // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func classAssignToVar4(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar4(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     x2 = Klass()
@@ -357,7 +357,7 @@ public func classAssignToVar5() {
     consumeVal(x3)
 }
 
-public func classAssignToVar5Arg(_ x: Klass, _ x2: inout Klass) {
+public func classAssignToVar5Arg(_ x: __shared Klass, _ x2: inout Klass) {
     // expected-error @-1 {{'x2' used after consume}}
     // expected-error @-2 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -366,7 +366,7 @@ public func classAssignToVar5Arg(_ x: Klass, _ x2: inout Klass) {
     consumeVal(x3)
 }
 
-public func classAssignToVar5Arg2(_ x: Klass, _ x2: inout Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar5Arg2(_ x: __shared Klass, _ x2: inout Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
                                                                    // expected-error @-1 {{'x2' used after consume}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
@@ -375,7 +375,7 @@ public func classAssignToVar5Arg2(_ x: Klass, _ x2: inout Klass) { // expected-e
     x2 = Klass()
 }
 
-public func classAccessAccessField(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAccessAccessField(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
@@ -395,7 +395,7 @@ public func classAccessAccessFieldArg(_ x2: inout Klass) {
     }
 }
 
-public func classAccessConsumeField(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAccessConsumeField(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
     // expected-error @-2 {{'x2' has consuming use that cannot be eliminated due to a tight exclusivity scope}}
@@ -2409,7 +2409,7 @@ func sameCallSiteTestConsumeTwice(_ k: inout Klass) { // expected-error {{'k' co
 }
 
 func sameCallSiteConsumeAndUse(_ k: inout Klass) { // expected-error {{'k' used after consume}}
-    func consumeKlassAndUseKlass(_ k: __owned Klass, _ k2: Klass) {}
+    func consumeKlassAndUseKlass(_ k: __owned Klass, _ k2: __shared Klass) {}
     consumeKlassAndUseKlass(k, k) // expected-error {{overlapping accesses to 'k', but deinitialization requires exclusive access; consider copying to a local variable}}
     // expected-note @-1 {{consuming use here}}
     // expected-note @-2 {{non-consuming use here}}

--- a/test/SILOptimizer/moveonly_lifetime.swift
+++ b/test/SILOptimizer/moveonly_lifetime.swift
@@ -10,7 +10,7 @@ func getC() -> C
 func takeC(_ c: __owned C)
 
 @_silgen_name("borrowC")
-func borrowC(_ c: C)
+func borrowC(_ c: __shared C)
 
 @_silgen_name("something")
 func something()

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -25,7 +25,7 @@ public func borrowVal(_ x: __shared AggStruct) {}
 public func borrowVal(_ x: __shared KlassPair) {}
 public func borrowVal(_ x: __shared AggGenericStruct<String>) {}
 public func borrowVal<T>(_ x: __shared AggGenericStruct<T>) {}
-public func borrowVal(_ x: EnumTy) {}
+public func borrowVal(_ x: __shared EnumTy) {}
 
 public func consumeVal(_ x: __owned Klass) {}
 public func consumeVal(_ x: __owned FinalKlass) {}
@@ -47,7 +47,7 @@ public final class FinalKlass {
 // Class Tests //
 /////////////////
 
-public func classSimpleChainTest(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classSimpleChainTest(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
                // expected-error @-1 {{'x2' consumed more than once}}
     let y2 = x2 // expected-note {{consuming use here}}
@@ -57,7 +57,7 @@ public func classSimpleChainTest(_ x: Klass) { // expected-error {{'x' has guara
     borrowVal(k2)
 }
 
-public func classSimpleChainArgTest(_ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classSimpleChainArgTest(_ x2: __shared Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -69,12 +69,12 @@ public func classSimpleChainOwnedArgTest(_ x2: __owned Klass) {
     borrowVal(k2)
 }
 
-public func classSimpleNonConsumingUseTest(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classSimpleNonConsumingUseTest(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
 
-public func classSimpleNonConsumingUseArgTest(_ x2: Klass) {
+public func classSimpleNonConsumingUseArgTest(_ x2: __shared Klass) {
     borrowVal(x2)
 }
 
@@ -82,14 +82,14 @@ public func classSimpleNonConsumingUseOwnedArgTest(_ x2: __owned Klass) {
     borrowVal(x2)
 }
 
-public func classMultipleNonConsumingUseTest(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classMultipleNonConsumingUseTest(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func classMultipleNonConsumingUseArgTest(_ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classMultipleNonConsumingUseArgTest(_ x2: __shared Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -101,7 +101,7 @@ public func classMultipleNonConsumingUseOwnedArgTest(_ x2: __owned Klass) {
     consumeVal(x2)
 }
 
-public func classUseAfterConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classUseAfterConsume(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -109,7 +109,7 @@ public func classUseAfterConsume(_ x: Klass) { // expected-error {{'x' has guara
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func classUseAfterConsumeArg(_ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classUseAfterConsumeArg(_ x2: __shared Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -121,14 +121,14 @@ public func classUseAfterConsumeOwnedArg(_ x2: __owned Klass) { // expected-erro
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func classDoubleConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classDoubleConsume(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func classDoubleConsumeArg(_ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classDoubleConsumeArg(_ x2: __shared Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -138,7 +138,7 @@ public func classDoubleConsumeOwnedArg(_ x2: __owned Klass) { // expected-error 
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func classLoopConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classLoopConsume(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -146,7 +146,7 @@ public func classLoopConsume(_ x: Klass) { // expected-error {{'x' has guarantee
     }
 }
 
-public func classLoopConsumeArg(_ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classLoopConsumeArg(_ x2: __shared Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -158,7 +158,7 @@ public func classLoopConsumeOwnedArg(_ x2: __owned Klass) { // expected-error {{
     }
 }
 
-public func classDiamond(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classDiamond(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -167,7 +167,7 @@ public func classDiamond(_ x: Klass) { // expected-error {{'x' has guaranteed ow
     }
 }
 
-public func classDiamondArg(_ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classDiamondArg(_ x2: __shared Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -183,7 +183,7 @@ public func classDiamondOwnedArg(_ x2: __owned Klass) {
     }
 }
 
-public func classDiamondInLoop(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classDiamondInLoop(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed more than once}}
@@ -197,7 +197,7 @@ public func classDiamondInLoop(_ x: Klass) { // expected-error {{'x' has guarant
     }
 }
 
-public func classDiamondInLoopArg(_ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classDiamondInLoopArg(_ x2: __shared Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -219,7 +219,7 @@ public func classDiamondInLoopOwnedArg(_ x2: __owned Klass) { // expected-error 
     }
 }
 
-public func classAssignToVar1(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar1(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -228,7 +228,7 @@ public func classAssignToVar1(_ x: Klass) { // expected-error {{'x' has guarante
     consumeVal(x3)
 }
 
-public func classAssignToVar1Arg(_ x: Klass, _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classAssignToVar1Arg(_ x: __shared Klass, _ x2: __shared Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
                 // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
@@ -239,7 +239,7 @@ public func classAssignToVar1Arg(_ x: Klass, _ x2: Klass) { // expected-error {{
 // NOTE: consumeVal(x3) shouldn't be marked! This is most likely due to some form of
 // load forwarding. We may need to make predictable mem opts more conservative
 // with move only var.
-public func classAssignToVar1OwnedArg(_ x: Klass, _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
+public func classAssignToVar1OwnedArg(_ x: __shared Klass, _ x2: __owned Klass) { // expected-error {{'x2' consumed more than once}}
     // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
@@ -247,7 +247,7 @@ public func classAssignToVar1OwnedArg(_ x: Klass, _ x2: __owned Klass) { // expe
     consumeVal(x3)
 }
 
-public func classAssignToVar2(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar2(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -255,7 +255,7 @@ public func classAssignToVar2(_ x: Klass) { // expected-error {{'x' has guarante
     borrowVal(x3)
 }
 
-public func classAssignToVar2Arg(_ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classAssignToVar2Arg(_ x2: __shared Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x3)
@@ -268,7 +268,7 @@ public func classAssignToVar2OwnedArg(_ x2: __owned Klass) { // expected-error {
 }
 
 // NOTE: consumeVal(x3) should not be marked.
-public func classAssignToVar3(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar3(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
@@ -276,7 +276,7 @@ public func classAssignToVar3(_ x: Klass) { // expected-error {{'x' has guarante
 }
 
 // NOTE: consumeVal(x3) is a bug.
-public func classAssignToVar3Arg(_ x: Klass, _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classAssignToVar3Arg(_ x: __shared Klass, _ x2: __shared Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
                                                             // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
@@ -284,13 +284,13 @@ public func classAssignToVar3Arg(_ x: Klass, _ x2: Klass) { // expected-error {{
 }
 
 // This is a bug around consumeVal(x3)
-public func classAssignToVar3OwnedArg(_ x: Klass, _ x2: __owned Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar3OwnedArg(_ x: __shared Klass, _ x2: __owned Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func classAssignToVar4(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar4(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     let x3 = x2 // expected-note {{consuming use here}}
@@ -298,7 +298,7 @@ public func classAssignToVar4(_ x: Klass) { // expected-error {{'x' has guarante
     consumeVal(x3)
 }
 
-public func classAssignToVar4Arg(_ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classAssignToVar4Arg(_ x2: __shared Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x3)
@@ -310,7 +310,7 @@ public func classAssignToVar4OwnedArg(_ x2: __owned Klass) { // expected-error {
     consumeVal(x3)
 }
 
-public func classAssignToVar5(_ x: Klass) {  // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAssignToVar5(_ x: __shared Klass) {  // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
     // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -319,7 +319,7 @@ public func classAssignToVar5(_ x: Klass) {  // expected-error {{'x' has guarant
     consumeVal(x3)
 }
 
-public func classAssignToVar5Arg(_ x: Klass, _ x2: Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func classAssignToVar5Arg(_ x: __shared Klass, _ x2: __shared Klass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
                                                             // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2)
@@ -327,7 +327,7 @@ public func classAssignToVar5Arg(_ x: Klass, _ x2: Klass) { // expected-error {{
     consumeVal(x3)
 }
 
-public func classAssignToVar5OwnedArg(_ x: Klass, _ x2: __owned Klass) { // expected-error {{'x2' used after consume}}
+public func classAssignToVar5OwnedArg(_ x: __shared Klass, _ x2: __owned Klass) { // expected-error {{'x2' used after consume}}
                                                                          // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
@@ -335,7 +335,7 @@ public func classAssignToVar5OwnedArg(_ x: Klass, _ x2: __owned Klass) { // expe
     consumeVal(x3)
 }
 
-public func classAccessAccessField(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAccessAccessField(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.k)
     for _ in 0..<1024 {
@@ -343,7 +343,7 @@ public func classAccessAccessField(_ x: Klass) { // expected-error {{'x' has gua
     }
 }
 
-public func classAccessAccessFieldArg(_ x2: Klass) {
+public func classAccessAccessFieldArg(_ x2: __shared Klass) {
     borrowVal(x2.k)
     for _ in 0..<1024 {
         borrowVal(x2.k)
@@ -357,7 +357,7 @@ public func classAccessAccessFieldOwnedArg(_ x2: __owned Klass) {
     }
 }
 
-public func classAccessConsumeField(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func classAccessConsumeField(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     for _ in 0..<1024 {
@@ -365,7 +365,7 @@ public func classAccessConsumeField(_ x: Klass) { // expected-error {{'x' has gu
     }
 }
 
-public func classAccessConsumeFieldArg(_ x2: Klass) {
+public func classAccessConsumeFieldArg(_ x2: __shared Klass) {
     consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     for _ in 0..<1024 {
         consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
@@ -390,14 +390,14 @@ extension Klass {
 // Final Class //
 /////////////////
 
-public func finalClassSimpleChainTest(_ x: FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassSimpleChainTest(_ x: __shared FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func finalClassSimpleChainTestArg(_ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassSimpleChainTestArg(_ x2: __shared FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -409,12 +409,12 @@ public func finalClassSimpleChainTestOwnedArg(_ x2: __owned FinalKlass) {
     borrowVal(k2)
 }
 
-public func finalClassSimpleNonConsumingUseTest(_ x: FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassSimpleNonConsumingUseTest(_ x: __shared FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
 
-public func finalClassSimpleNonConsumingUseTestArg(_ x2: FinalKlass) {
+public func finalClassSimpleNonConsumingUseTestArg(_ x2: __shared FinalKlass) {
     borrowVal(x2)
 }
 
@@ -422,14 +422,14 @@ public func finalClassSimpleNonConsumingUseTestOwnedArg(_ x2: __owned FinalKlass
     borrowVal(x2)
 }
 
-public func finalClassMultipleNonConsumingUseTest(_ x: FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassMultipleNonConsumingUseTest(_ x: __shared FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func finalClassMultipleNonConsumingUseTestArg(_ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassMultipleNonConsumingUseTestArg(_ x2: __shared FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -441,7 +441,7 @@ public func finalClassMultipleNonConsumingUseTestownedArg(_ x2: __owned FinalKla
     consumeVal(x2)
 }
 
-public func finalClassUseAfterConsume(_ x: FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassUseAfterConsume(_ x: __shared FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -449,7 +449,7 @@ public func finalClassUseAfterConsume(_ x: FinalKlass) { // expected-error {{'x'
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func finalClassUseAfterConsumeArg(_ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassUseAfterConsumeArg(_ x2: __shared FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -461,14 +461,14 @@ public func finalClassUseAfterConsumeOwnedArg(_ x2: __owned FinalKlass) { // exp
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func finalClassDoubleConsume(_ x: FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassDoubleConsume(_ x: __shared FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func finalClassDoubleConsumeArg(_ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassDoubleConsumeArg(_ x2: __shared FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -478,7 +478,7 @@ public func finalClassDoubleConsumeownedArg(_ x2: __owned FinalKlass) { // expec
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func finalClassLoopConsume(_ x: FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassLoopConsume(_ x: __shared FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -486,7 +486,7 @@ public func finalClassLoopConsume(_ x: FinalKlass) { // expected-error {{'x' has
     }
 }
 
-public func finalClassLoopConsumeArg(_ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassLoopConsumeArg(_ x2: __shared FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -498,7 +498,7 @@ public func finalClassLoopConsumeOwnedArg(_ x2: __owned FinalKlass) { // expecte
     }
 }
 
-public func finalClassDiamond(_ x: FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassDiamond(_ x: __shared FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -507,7 +507,7 @@ public func finalClassDiamond(_ x: FinalKlass) { // expected-error {{'x' has gua
     }
 }
 
-public func finalClassDiamondArg(_ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassDiamondArg(_ x2: __shared FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -523,7 +523,7 @@ public func finalClassDiamondOwnedArg(_ x2: __owned FinalKlass) {
     }
 }
 
-public func finalClassDiamondInLoop(_ x: FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassDiamondInLoop(_ x: __shared FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -537,7 +537,7 @@ public func finalClassDiamondInLoop(_ x: FinalKlass) { // expected-error {{'x' h
     }
 }
 
-public func finalClassDiamondInLoopArg(_ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassDiamondInLoopArg(_ x2: __shared FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -559,7 +559,7 @@ public func finalClassDiamondInLoopOwnedArg(_ x2: __owned FinalKlass) { // expec
     }
 }
 
-public func finalClassAssignToVar1(_ x: FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar1(_ x: __shared FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -568,7 +568,7 @@ public func finalClassAssignToVar1(_ x: FinalKlass) { // expected-error {{'x' ha
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar1Arg(_ x: FinalKlass, _ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar1Arg(_ x: __shared FinalKlass, _ x2: __shared FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
                                                                            // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
@@ -576,7 +576,7 @@ public func finalClassAssignToVar1Arg(_ x: FinalKlass, _ x2: FinalKlass) { // ex
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar1OwnedArg(_ x: FinalKlass, _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
+public func finalClassAssignToVar1OwnedArg(_ x: __shared FinalKlass, _ x2: __owned FinalKlass) { // expected-error {{'x2' consumed more than once}}
                                                                                         // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
@@ -584,7 +584,7 @@ public func finalClassAssignToVar1OwnedArg(_ x: FinalKlass, _ x2: __owned FinalK
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar2(_ x: FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar2(_ x: __shared FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -592,7 +592,7 @@ public func finalClassAssignToVar2(_ x: FinalKlass) { // expected-error {{'x' ha
     borrowVal(x3)
 }
 
-public func finalClassAssignToVar2Arg(_ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar2Arg(_ x2: __shared FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x3)
@@ -604,27 +604,27 @@ public func finalClassAssignToVar2OwnedArg(_ x2: __owned FinalKlass) { // expect
     borrowVal(x3)
 }
 
-public func finalClassAssignToVar3(_ x: FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar3(_ x: __shared FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar3Arg(_ x: FinalKlass, _ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar3Arg(_ x: __shared FinalKlass, _ x2: __shared FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
                                                                            // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar3OwnedArg(_ x: FinalKlass, _ x2: __owned FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar3OwnedArg(_ x: __shared FinalKlass, _ x2: __owned FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar4(_ x: FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar4(_ x: __shared FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     let x3 = x2 // expected-note {{consuming use here}}
@@ -632,7 +632,7 @@ public func finalClassAssignToVar4(_ x: FinalKlass) { // expected-error {{'x' ha
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar4Arg(_ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar4Arg(_ x2: __shared FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x3)
@@ -644,7 +644,7 @@ public func finalClassAssignToVar4OwnedArg(_ x2: __owned FinalKlass) { // expect
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar5(_ x: FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar5(_ x: __shared FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -653,7 +653,7 @@ public func finalClassAssignToVar5(_ x: FinalKlass) { // expected-error {{'x' ha
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar5Arg(_ x: FinalKlass, _ x2: FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func finalClassAssignToVar5Arg(_ x: __shared FinalKlass, _ x2: __shared FinalKlass) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
                                                                            // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2)
@@ -661,7 +661,7 @@ public func finalClassAssignToVar5Arg(_ x: FinalKlass, _ x2: FinalKlass) { // ex
     consumeVal(x3)
 }
 
-public func finalClassAssignToVar5OwnedArg(_ x: FinalKlass, _ x2: __owned FinalKlass) { // expected-error {{'x2' used after consume}}
+public func finalClassAssignToVar5OwnedArg(_ x: __shared FinalKlass, _ x2: __owned FinalKlass) { // expected-error {{'x2' used after consume}}
                                                                                         // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
@@ -669,7 +669,7 @@ public func finalClassAssignToVar5OwnedArg(_ x: FinalKlass, _ x2: __owned FinalK
     consumeVal(x3)
 }
 
-public func finalClassAccessField(_ x: FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassAccessField(_ x: __shared FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.k)
     for _ in 0..<1024 {
@@ -677,7 +677,7 @@ public func finalClassAccessField(_ x: FinalKlass) { // expected-error {{'x' has
     }
 }
 
-public func finalClassAccessFieldArg(_ x2: FinalKlass) {
+public func finalClassAccessFieldArg(_ x2: __shared FinalKlass) {
     borrowVal(x2.k)
     for _ in 0..<1024 {
         borrowVal(x2.k)
@@ -691,7 +691,7 @@ public func finalClassAccessFieldOwnedArg(_ x2: __owned FinalKlass) {
     }
 }
 
-public func finalClassConsumeField(_ x: FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func finalClassConsumeField(_ x: __shared FinalKlass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     for _ in 0..<1024 {
@@ -699,7 +699,7 @@ public func finalClassConsumeField(_ x: FinalKlass) { // expected-error {{'x' ha
     }
 }
 
-public func finalClassConsumeFieldArg(_ x2: FinalKlass) {
+public func finalClassConsumeFieldArg(_ x2: __shared FinalKlass) {
     consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
     for _ in 0..<1024 {
         consumeVal(x2.k) // expected-error {{'x2.k' was consumed but it is illegal to consume a noncopyable class var field. One can only read from it or assign to it}}
@@ -733,14 +733,14 @@ public struct AggStruct {
     var pair: KlassPair
 }
 
-public func aggStructSimpleChainTest(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructSimpleChainTest(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func aggStructSimpleChainTestArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructSimpleChainTestArg(_ x2: __shared AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -752,12 +752,12 @@ public func aggStructSimpleChainTestOwnedArg(_ x2: __owned AggStruct) {
     borrowVal(k2)
 }
 
-public func aggStructSimpleNonConsumingUseTest(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructSimpleNonConsumingUseTest(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
 
-public func aggStructSimpleNonConsumingUseTestArg(_ x2: AggStruct) {
+public func aggStructSimpleNonConsumingUseTestArg(_ x2: __shared AggStruct) {
     borrowVal(x2)
 }
 
@@ -765,14 +765,14 @@ public func aggStructSimpleNonConsumingUseTestOwnedArg(_ x2: __owned AggStruct) 
     borrowVal(x2)
 }
 
-public func aggStructMultipleNonConsumingUseTest(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructMultipleNonConsumingUseTest(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func aggStructMultipleNonConsumingUseTestArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructMultipleNonConsumingUseTestArg(_ x2: __shared AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -784,7 +784,7 @@ public func aggStructMultipleNonConsumingUseTestOwnedArg(_ x2: __owned AggStruct
     consumeVal(x2)
 }
 
-public func aggStructUseAfterConsume(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructUseAfterConsume(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -792,7 +792,7 @@ public func aggStructUseAfterConsume(_ x: AggStruct) { // expected-error {{'x' h
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructUseAfterConsumeArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructUseAfterConsumeArg(_ x2: __shared AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -804,14 +804,14 @@ public func aggStructUseAfterConsumeOwnedArg(_ x2: __owned AggStruct) { // expec
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructDoubleConsume(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructDoubleConsume(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructDoubleConsumeArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDoubleConsumeArg(_ x2: __shared AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -821,7 +821,7 @@ public func aggStructDoubleConsumeOwnedArg(_ x2: __owned AggStruct) { // expecte
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructLoopConsume(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructLoopConsume(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -829,7 +829,7 @@ public func aggStructLoopConsume(_ x: AggStruct) { // expected-error {{'x' has g
     }
 }
 
-public func aggStructLoopConsumeArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructLoopConsumeArg(_ x2: __shared AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -841,7 +841,7 @@ public func aggStructLoopConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-
     }
 }
 
-public func aggStructDiamond(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructDiamond(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -850,7 +850,7 @@ public func aggStructDiamond(_ x: AggStruct) { // expected-error {{'x' has guara
     }
 }
 
-public func aggStructDiamondArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDiamondArg(_ x2: __shared AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -866,7 +866,7 @@ public func aggStructDiamondOwnedArg(_ x2: __owned AggStruct) {
     }
 }
 
-public func aggStructDiamondInLoop(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructDiamondInLoop(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -880,7 +880,7 @@ public func aggStructDiamondInLoop(_ x: AggStruct) { // expected-error {{'x' has
     }
 }
 
-public func aggStructDiamondInLoopArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDiamondInLoopArg(_ x2: __shared AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -902,7 +902,7 @@ public func aggStructDiamondInLoopOwnedArg(_ x2: __owned AggStruct) { // expecte
     }
 }
 
-public func aggStructAccessField(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructAccessField(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
@@ -910,7 +910,7 @@ public func aggStructAccessField(_ x: AggStruct) { // expected-error {{'x' has g
     }
 }
 
-public func aggStructAccessFieldArg(_ x2: AggStruct) {
+public func aggStructAccessFieldArg(_ x2: __shared AggStruct) {
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.lhs)
@@ -924,7 +924,7 @@ public func aggStructAccessFieldOwnedArg(_ x2: __owned AggStruct) {
     }
 }
 
-public func aggStructConsumeField(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructConsumeField(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
     // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
@@ -934,7 +934,7 @@ public func aggStructConsumeField(_ x: AggStruct) { // expected-error {{'x' has 
     }
 }
 
-public func aggStructConsumeFieldArg(_ x2: AggStruct) {
+public func aggStructConsumeFieldArg(_ x2: __shared AggStruct) {
     // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
     // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
@@ -952,7 +952,7 @@ public func aggStructConsumeFieldOwnedArg(_ x2: __owned AggStruct) {
     }
 }
 
-public func aggStructAccessGrandField(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructAccessGrandField(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -960,7 +960,7 @@ public func aggStructAccessGrandField(_ x: AggStruct) { // expected-error {{'x' 
     }
 }
 
-public func aggStructAccessGrandFieldArg(_ x2: AggStruct) {
+public func aggStructAccessGrandFieldArg(_ x2: __shared AggStruct) {
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.pair.lhs)
@@ -974,7 +974,7 @@ public func aggStructAccessGrandFieldOwnedArg(_ x2: __owned AggStruct) {
     }
 }
 
-public func aggStructConsumeGrandField(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructConsumeGrandField(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
     // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
@@ -984,7 +984,7 @@ public func aggStructConsumeGrandField(_ x: AggStruct) { // expected-error {{'x'
     }
 }
 
-public func aggStructConsumeGrandFieldArg(_ x2: AggStruct) {
+public func aggStructConsumeGrandFieldArg(_ x2: __shared AggStruct) {
     // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
     // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
@@ -1046,14 +1046,14 @@ public struct AggGenericStruct<T> { // FIXME: for better test coverage this shou
     var pair: KlassPair
 }
 
-public func aggGenericStructSimpleChainTest(_ x: AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTest(_ x: __shared AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg(_ x2: AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTestArg(_ x2: __shared AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -1065,12 +1065,12 @@ public func aggGenericStructSimpleChainTestOwnedArg(_ x2: __owned AggGenericStru
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTest(_ x: AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleNonConsumingUseTest(_ x: __shared AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTestArg(_ x2: AggGenericStruct<String>) {
+public func aggGenericStructSimpleNonConsumingUseTestArg(_ x2: __shared AggGenericStruct<String>) {
     borrowVal(x2)
 }
 
@@ -1078,14 +1078,14 @@ public func aggGenericStructSimpleNonConsumingUseTestOwnedArg(_ x2: __owned AggG
     borrowVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTest(_ x: AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTest(_ x: __shared AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: __shared AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1097,7 +1097,7 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg(_ x2: __owned Ag
     consumeVal(x2)
 }
 
-public func aggGenericStructUseAfterConsume(_ x: AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsume(_ x: __shared AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -1105,7 +1105,7 @@ public func aggGenericStructUseAfterConsume(_ x: AggGenericStruct<String>) { // 
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructUseAfterConsumeArg(_ x2: AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsumeArg(_ x2: __shared AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1117,14 +1117,14 @@ public func aggGenericStructUseAfterConsumeOwnedArg(_ x2: __owned AggGenericStru
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsume(_ x: AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsume(_ x: __shared AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsumeArg(_ x2: AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsumeArg(_ x2: __shared AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -1134,7 +1134,7 @@ public func aggGenericStructDoubleConsumeOwnedArg(_ x2: __owned AggGenericStruct
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructLoopConsume(_ x: AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsume(_ x: __shared AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -1142,7 +1142,7 @@ public func aggGenericStructLoopConsume(_ x: AggGenericStruct<String>) { // expe
     }
 }
 
-public func aggGenericStructLoopConsumeArg(_ x2: AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsumeArg(_ x2: __shared AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -1154,7 +1154,7 @@ public func aggGenericStructLoopConsumeOwnedArg(_ x2: __owned AggGenericStruct<S
     }
 }
 
-public func aggGenericStructDiamond(_ x: AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamond(_ x: __shared AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -1163,7 +1163,7 @@ public func aggGenericStructDiamond(_ x: AggGenericStruct<String>) { // expected
     }
 }
 
-public func aggGenericStructDiamondArg(_ x2: AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondArg(_ x2: __shared AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -1179,7 +1179,7 @@ public func aggGenericStructDiamondOwnedArg(_ x2: __owned AggGenericStruct<Strin
     }
 }
 
-public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoop(_ x: __shared AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -1193,7 +1193,7 @@ public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<String>) { // ex
     }
 }
 
-public func aggGenericStructDiamondInLoopArg(_ x2: AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoopArg(_ x2: __shared AggGenericStruct<String>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -1215,7 +1215,7 @@ public func aggGenericStructDiamondInLoopOwnedArg(_ x2: __owned AggGenericStruct
     }
 }
 
-public func aggGenericStructAccessField(_ x: AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessField(_ x: __shared AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
@@ -1223,7 +1223,7 @@ public func aggGenericStructAccessField(_ x: AggGenericStruct<String>) { // expe
     }
 }
 
-public func aggGenericStructAccessFieldArg(_ x2: AggGenericStruct<String>) {
+public func aggGenericStructAccessFieldArg(_ x2: __shared AggGenericStruct<String>) {
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.lhs)
@@ -1237,7 +1237,7 @@ public func aggGenericStructAccessFieldOwnedArg(_ x2: __owned AggGenericStruct<S
     }
 }
 
-public func aggGenericStructConsumeField(_ x: AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeField(_ x: __shared AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
     // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
@@ -1247,7 +1247,7 @@ public func aggGenericStructConsumeField(_ x: AggGenericStruct<String>) { // exp
     }
 }
 
-public func aggGenericStructConsumeFieldArg(_ x2: AggGenericStruct<String>) {
+public func aggGenericStructConsumeFieldArg(_ x2: __shared AggGenericStruct<String>) {
     // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
     // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
@@ -1265,7 +1265,7 @@ public func aggGenericStructConsumeFieldOwnedArg(_ x2: __owned AggGenericStruct<
     }
 }
 
-public func aggGenericStructAccessGrandField(_ x: AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessGrandField(_ x: __shared AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -1273,7 +1273,7 @@ public func aggGenericStructAccessGrandField(_ x: AggGenericStruct<String>) { //
     }
 }
 
-public func aggGenericStructAccessGrandFieldArg(_ x2: AggGenericStruct<String>) {
+public func aggGenericStructAccessGrandFieldArg(_ x2: __shared AggGenericStruct<String>) {
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.pair.lhs)
@@ -1287,7 +1287,7 @@ public func aggGenericStructAccessGrandFieldOwnedArg(_ x2: __owned AggGenericStr
     }
 }
 
-public func aggGenericStructConsumeGrandField(_ x: AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeGrandField(_ x: __shared AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
     // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
@@ -1297,7 +1297,7 @@ public func aggGenericStructConsumeGrandField(_ x: AggGenericStruct<String>) { /
     }
 }
 
-public func aggGenericStructConsumeGrandFieldArg(_ x2: AggGenericStruct<String>) {
+public func aggGenericStructConsumeGrandFieldArg(_ x2: __shared AggGenericStruct<String>) {
     // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
     // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
@@ -1319,14 +1319,14 @@ public func aggGenericStructConsumeGrandFieldOwnedArg(_ x2: __owned AggGenericSt
 // Aggregate Generic Struct + Generic But Body is Trivial //
 ////////////////////////////////////////////////////////////
 
-public func aggGenericStructSimpleChainTest<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTest<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTestArg<T>(_ x2: __shared AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -1338,12 +1338,12 @@ public func aggGenericStructSimpleChainTestOwnedArg<T>(_ x2: __owned AggGenericS
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTest<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleNonConsumingUseTest<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTestArg<T>(_ x2: AggGenericStruct<T>) {
+public func aggGenericStructSimpleNonConsumingUseTestArg<T>(_ x2: __shared AggGenericStruct<T>) {
     borrowVal(x2)
 }
 
@@ -1351,14 +1351,14 @@ public func aggGenericStructSimpleNonConsumingUseTestOwnedArg<T>(_ x2: __owned A
     borrowVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: AggGenericStruct<T>) { //expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: __shared AggGenericStruct<T>) { //expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1370,7 +1370,7 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg<T>(_ x2: __owned
     consumeVal(x2)
 }
 
-public func aggGenericStructUseAfterConsume<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsume<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -1378,7 +1378,7 @@ public func aggGenericStructUseAfterConsume<T>(_ x: AggGenericStruct<T>) { // ex
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructUseAfterConsumeArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsumeArg<T>(_ x2: __shared AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1390,14 +1390,14 @@ public func aggGenericStructUseAfterConsumeOwnedArg<T>(_ x2: __owned AggGenericS
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsume<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsume<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsumeArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsumeArg<T>(_ x2: __shared AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -1407,7 +1407,7 @@ public func aggGenericStructDoubleConsumeOwnedArg<T>(_ x2: __owned AggGenericStr
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsume<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -1415,7 +1415,7 @@ public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) { // expect
     }
 }
 
-public func aggGenericStructLoopConsumeArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsumeArg<T>(_ x2: __shared AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -1427,7 +1427,7 @@ public func aggGenericStructLoopConsumeOwnedArg<T>(_ x2: __owned AggGenericStruc
     }
 }
 
-public func aggGenericStructDiamond<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamond<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -1436,7 +1436,7 @@ public func aggGenericStructDiamond<T>(_ x: AggGenericStruct<T>) { // expected-e
     }
 }
 
-public func aggGenericStructDiamondArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondArg<T>(_ x2: __shared AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -1452,7 +1452,7 @@ public func aggGenericStructDiamondOwnedArg<T>(_ x2: __owned AggGenericStruct<T>
     }
 }
 
-public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoop<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -1466,7 +1466,7 @@ public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) { // expe
     }
 }
 
-public func aggGenericStructDiamondInLoopArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoopArg<T>(_ x2: __shared AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -1488,7 +1488,7 @@ public func aggGenericStructDiamondInLoopOwnedArg<T>(_ x2: __owned AggGenericStr
     }
 }
 
-public func aggGenericStructAccessField<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessField<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
@@ -1496,7 +1496,7 @@ public func aggGenericStructAccessField<T>(_ x: AggGenericStruct<T>) { // expect
     }
 }
 
-public func aggGenericStructAccessFieldArg<T>(_ x2: AggGenericStruct<T>) {
+public func aggGenericStructAccessFieldArg<T>(_ x2: __shared AggGenericStruct<T>) {
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.lhs)
@@ -1510,7 +1510,7 @@ public func aggGenericStructAccessFieldOwnedArg<T>(_ x2: __owned AggGenericStruc
     }
 }
 
-public func aggGenericStructConsumeField<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeField<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
     // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
@@ -1520,7 +1520,7 @@ public func aggGenericStructConsumeField<T>(_ x: AggGenericStruct<T>) { // expec
     }
 }
 
-public func aggGenericStructConsumeFieldArg<T>(_ x2: AggGenericStruct<T>) {
+public func aggGenericStructConsumeFieldArg<T>(_ x2: __shared AggGenericStruct<T>) {
     // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
     // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
@@ -1538,7 +1538,7 @@ public func aggGenericStructConsumeFieldOwnedArg<T>(_ x2: __owned AggGenericStru
     }
 }
 
-public func aggGenericStructAccessGrandField<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessGrandField<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -1546,7 +1546,7 @@ public func aggGenericStructAccessGrandField<T>(_ x: AggGenericStruct<T>) { // e
     }
 }
 
-public func aggGenericStructAccessGrandFieldArg<T>(_ x2: AggGenericStruct<T>) {
+public func aggGenericStructAccessGrandFieldArg<T>(_ x2: __shared AggGenericStruct<T>) {
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.pair.lhs)
@@ -1560,7 +1560,7 @@ public func aggGenericStructAccessGrandFieldOwnedArg<T>(_ x2: __owned AggGeneric
     }
 }
 
-public func aggGenericStructConsumeGrandField<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeGrandField<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
     // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
@@ -1570,7 +1570,7 @@ public func aggGenericStructConsumeGrandField<T>(_ x: AggGenericStruct<T>) { // 
     }
 }
 
-public func aggGenericStructConsumeGrandFieldArg<T>(_ x2: AggGenericStruct<T>) {
+public func aggGenericStructConsumeGrandFieldArg<T>(_ x2: __shared AggGenericStruct<T>) {
     // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
     // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
@@ -1600,14 +1600,14 @@ public enum EnumTy {
     func doSomething() -> Bool { true }
 }
 
-public func enumSimpleChainTest(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumSimpleChainTest(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func enumSimpleChainTestArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumSimpleChainTestArg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -1619,12 +1619,12 @@ public func enumSimpleChainTestOwnedArg(_ x2: __owned EnumTy) {
     borrowVal(k2)
 }
 
-public func enumSimpleNonConsumingUseTest(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumSimpleNonConsumingUseTest(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
 
-public func enumSimpleNonConsumingUseTestArg(_ x2: EnumTy) {
+public func enumSimpleNonConsumingUseTestArg(_ x2: __shared EnumTy) {
     borrowVal(x2)
 }
 
@@ -1632,14 +1632,14 @@ public func enumSimpleNonConsumingUseTestOwnedArg(_ x2: __owned EnumTy) {
     borrowVal(x2)
 }
 
-public func enumMultipleNonConsumingUseTest(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumMultipleNonConsumingUseTest(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func enumMultipleNonConsumingUseTestArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumMultipleNonConsumingUseTestArg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1651,7 +1651,7 @@ public func enumMultipleNonConsumingUseTestOwnedArg(_ x2: __owned EnumTy) {
     consumeVal(x2)
 }
 
-public func enumUseAfterConsume(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumUseAfterConsume(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -1659,7 +1659,7 @@ public func enumUseAfterConsume(_ x: EnumTy) { // expected-error {{'x' has guara
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func enumUseAfterConsumeArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumUseAfterConsumeArg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -1671,14 +1671,14 @@ public func enumUseAfterConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-erro
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func enumDoubleConsume(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumDoubleConsume(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func enumDoubleConsumeArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumDoubleConsumeArg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -1688,7 +1688,7 @@ public func enumDoubleConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error 
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func enumLoopConsume(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumLoopConsume(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -1696,7 +1696,7 @@ public func enumLoopConsume(_ x: EnumTy) { // expected-error {{'x' has guarantee
     }
 }
 
-public func enumLoopConsumeArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumLoopConsumeArg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -1708,7 +1708,7 @@ public func enumLoopConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{
     }
 }
 
-public func enumDiamond(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumDiamond(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -1717,7 +1717,7 @@ public func enumDiamond(_ x: EnumTy) { // expected-error {{'x' has guaranteed ow
     }
 }
 
-public func enumDiamondArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumDiamondArg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -1733,7 +1733,7 @@ public func enumDiamondOwnedArg(_ x2: __owned EnumTy) {
     }
 }
 
-public func enumDiamondInLoop(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumDiamondInLoop(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -1747,7 +1747,7 @@ public func enumDiamondInLoop(_ x: EnumTy) { // expected-error {{'x' has guarant
     }
 }
 
-public func enumDiamondInLoopArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumDiamondInLoopArg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -1769,7 +1769,7 @@ public func enumDiamondInLoopOwnedArg(_ x2: __owned EnumTy) { // expected-error 
     }
 }
 
-public func enumAssignToVar1(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar1(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -1778,7 +1778,7 @@ public func enumAssignToVar1(_ x: EnumTy) { // expected-error {{'x' has guarante
     consumeVal(x3)
 }
 
-public func enumAssignToVar1Arg(_ x: EnumTy, _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar1Arg(_ x: __shared EnumTy, _ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
                                                              // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
@@ -1786,7 +1786,7 @@ public func enumAssignToVar1Arg(_ x: EnumTy, _ x2: EnumTy) { // expected-error {
     consumeVal(x3)
 }
 
-public func enumAssignToVar1OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
+public func enumAssignToVar1OwnedArg(_ x: __shared EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
                                                                           // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
@@ -1794,7 +1794,7 @@ public func enumAssignToVar1OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // exp
     consumeVal(x3)
 }
 
-public func enumAssignToVar2(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar2(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -1802,7 +1802,7 @@ public func enumAssignToVar2(_ x: EnumTy) { // expected-error {{'x' has guarante
     borrowVal(x3)
 }
 
-public func enumAssignToVar2Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar2Arg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x3)
@@ -1814,27 +1814,27 @@ public func enumAssignToVar2OwnedArg(_ x2: __owned EnumTy) { // expected-error {
     borrowVal(x3)
 }
 
-public func enumAssignToVar3(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar3(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumAssignToVar3Arg(_ x: EnumTy, _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar3Arg(_ x: __shared EnumTy, _ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
                                                              // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumAssignToVar3OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar3OwnedArg(_ x: __shared EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumAssignToVar4(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar4(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     let x3 = x2 // expected-note {{consuming use here}}
@@ -1842,7 +1842,7 @@ public func enumAssignToVar4(_ x: EnumTy) { // expected-error {{'x' has guarante
     consumeVal(x3)
 }
 
-public func enumAssignToVar4Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar4Arg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x3)
@@ -1854,7 +1854,7 @@ public func enumAssignToVar4OwnedArg(_ x2: __owned EnumTy) { // expected-error {
     consumeVal(x3)
 }
 
-public func enumAssignToVar5(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar5(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -1863,7 +1863,7 @@ public func enumAssignToVar5(_ x: EnumTy) { // expected-error {{'x' has guarante
     consumeVal(x3)
 }
 
-public func enumAssignToVar5Arg(_ x: EnumTy, _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar5Arg(_ x: __shared EnumTy, _ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
                                                              // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2)
@@ -1871,7 +1871,7 @@ public func enumAssignToVar5Arg(_ x: EnumTy, _ x2: EnumTy) { // expected-error {
     consumeVal(x3)
 }
 
-public func enumAssignToVar5OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
+public func enumAssignToVar5OwnedArg(_ x: __shared EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
                                                                           // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
@@ -1879,7 +1879,7 @@ public func enumAssignToVar5OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // exp
     consumeVal(x3)
 }
 
-public func enumPatternMatchIfLet1(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet1(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     if case let .klass(x) = x2 { // expected-note {{consuming use here}}
@@ -1890,7 +1890,7 @@ public func enumPatternMatchIfLet1(_ x: EnumTy) { // expected-error {{'x' has gu
     }
 }
 
-public func enumPatternMatchIfLet1Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet1Arg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if case let .klass(x) = x2 { // expected-note {{consuming use here}}
         borrowVal(x)
     }
@@ -1908,7 +1908,7 @@ public func enumPatternMatchIfLet1OwnedArg(_ x2: __owned EnumTy) { // expected-e
     }
 }
 
-public func enumPatternMatchIfLet2(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet2(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -1918,7 +1918,7 @@ public func enumPatternMatchIfLet2(_ x: EnumTy) { // expected-error {{'x' has gu
     }
 }
 
-public func enumPatternMatchIfLet2Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet2Arg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
         if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
             borrowVal(x)
@@ -1934,7 +1934,7 @@ public func enumPatternMatchIfLet2OwnedArg(_ x2: __owned EnumTy) { // expected-e
     }
 }
 
-public func enumPatternMatchSwitch1(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch1(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     switch x2 { // expected-note {{consuming use here}}
@@ -1946,7 +1946,7 @@ public func enumPatternMatchSwitch1(_ x: EnumTy) { // expected-error {{'x' has g
     }
 }
 
-public func enumPatternMatchSwitch1Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch1Arg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
         borrowVal(k)
@@ -1968,7 +1968,7 @@ public func enumPatternMatchSwitch1OwnedArg(_ x2: __owned EnumTy) { // expected-
     }
 }
 
-public func enumPatternMatchSwitch2(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     switch x2 {
     case let .klass(k):
@@ -1978,7 +1978,7 @@ public func enumPatternMatchSwitch2(_ x: EnumTy) { // expected-error {{'x' has g
     }
 }
 
-public func enumPatternMatchSwitch2Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2Arg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
         borrowVal(k)
@@ -1997,7 +1997,7 @@ public func enumPatternMatchSwitch2OwnedArg(_ x2: __owned EnumTy) {
 }
 
 // QOI: We can do better here. We should also flag x2
-public func enumPatternMatchSwitch2WhereClause(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClause(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     switch x2 { // expected-note {{consuming use here}}
@@ -2011,7 +2011,7 @@ public func enumPatternMatchSwitch2WhereClause(_ x: EnumTy) { // expected-error 
     }
 }
 
-public func enumPatternMatchSwitch2WhereClauseArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClauseArg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
            where x2.doSomething():
@@ -2035,7 +2035,7 @@ public func enumPatternMatchSwitch2WhereClauseOwnedArg(_ x2: __owned EnumTy) { /
     }
 }
 
-public func enumPatternMatchSwitch2WhereClause2(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClause2(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     switch x2 {
     case let .klass(k)
@@ -2048,7 +2048,7 @@ public func enumPatternMatchSwitch2WhereClause2(_ x: EnumTy) { // expected-error
     }
 }
 
-public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
            where boolValue:
@@ -2076,7 +2076,7 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg(_ x2: __owned EnumTy) {
 // Closure and Defer Tests //
 /////////////////////////////
 
-public func closureClassUseAfterConsume1(_ x: Klass) {
+public func closureClassUseAfterConsume1(_ x: __shared Klass) {
     // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     // expected-error @-2 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = { // expected-note {{closure capture here}}
@@ -2089,8 +2089,8 @@ public func closureClassUseAfterConsume1(_ x: Klass) {
     f()
 }
 
-public func closureClassUseAfterConsume2(_ argX: Klass) {
-    let f = { (_ x: Klass) in // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureClassUseAfterConsume2(_ argX: __shared Klass) {
+    let f = { (_ x: __shared Klass) in // expected-error {{'x' has guaranteed ownership but was consumed}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
                    // expected-note @-1 {{consuming use here}}
         borrowVal(x2)
@@ -2100,8 +2100,8 @@ public func closureClassUseAfterConsume2(_ argX: Klass) {
     f(argX)
 }
 
-public func closureClassUseAfterConsumeArg(_ argX: Klass) {
-    let f = { (_ x2: Klass) in // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func closureClassUseAfterConsumeArg(_ argX: __shared Klass) {
+    let f = { (_ x2: __shared Klass) in // expected-error {{'x2' has guaranteed ownership but was consumed}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2109,7 +2109,7 @@ public func closureClassUseAfterConsumeArg(_ argX: Klass) {
     f(argX)
 }
 
-public func closureCaptureClassUseAfterConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureCaptureClassUseAfterConsume(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
@@ -2120,7 +2120,7 @@ public func closureCaptureClassUseAfterConsume(_ x: Klass) { // expected-error {
     f()
 }
 
-public func closureCaptureClassUseAfterConsumeError(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureCaptureClassUseAfterConsumeError(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
@@ -2135,7 +2135,7 @@ public func closureCaptureClassUseAfterConsumeError(_ x: Klass) { // expected-er
     let _ = x3
 }
 
-public func closureCaptureClassArgUseAfterConsume(_ x2: Klass) {
+public func closureCaptureClassArgUseAfterConsume(_ x2: __shared Klass) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{closure capture here}}
@@ -2169,7 +2169,7 @@ public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) {
     let _ = x3
 }
 
-public func deferCaptureClassUseAfterConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func deferCaptureClassUseAfterConsume(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     defer {
@@ -2180,7 +2180,7 @@ public func deferCaptureClassUseAfterConsume(_ x: Klass) { // expected-error {{'
     consumeVal(x) // expected-note {{consuming use here}}
 }
 
-public func deferCaptureClassUseAfterConsume2(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func deferCaptureClassUseAfterConsume2(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
@@ -2193,7 +2193,7 @@ public func deferCaptureClassUseAfterConsume2(_ x: Klass) { // expected-error {{
     let _ = x3
 }
 
-public func deferCaptureClassArgUseAfterConsume(_ x2: Klass) {
+public func deferCaptureClassArgUseAfterConsume(_ x2: __shared Klass) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     borrowVal(x2)
     defer {
@@ -2225,7 +2225,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Klass) {
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func closureAndDeferCaptureClassUseAfterConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureAndDeferCaptureClassUseAfterConsume(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
@@ -2239,7 +2239,7 @@ public func closureAndDeferCaptureClassUseAfterConsume(_ x: Klass) { // expected
     f()
 }
 
-public func closureAndDeferCaptureClassUseAfterConsume2(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureAndDeferCaptureClassUseAfterConsume2(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
@@ -2255,7 +2255,7 @@ public func closureAndDeferCaptureClassUseAfterConsume2(_ x: Klass) { // expecte
     f()
 }
 
-public func closureAndDeferCaptureClassUseAfterConsume3(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureAndDeferCaptureClassUseAfterConsume3(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
@@ -2273,7 +2273,7 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: Klass) { // expecte
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: Klass) {
+public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: __shared Klass) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{closure capture here}}
@@ -2315,7 +2315,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned Kl
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func closureAndClosureCaptureClassUseAfterConsume(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureAndClosureCaptureClassUseAfterConsume(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
@@ -2330,7 +2330,7 @@ public func closureAndClosureCaptureClassUseAfterConsume(_ x: Klass) { // expect
     f()
 }
 
-public func closureAndClosureCaptureClassUseAfterConsume2(_ x: Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureAndClosureCaptureClassUseAfterConsume2(_ x: __shared Klass) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
@@ -2348,7 +2348,7 @@ public func closureAndClosureCaptureClassUseAfterConsume2(_ x: Klass) { // expec
 }
 
 
-public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: Klass) {
+public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: __shared Klass) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
@@ -2424,7 +2424,7 @@ func sameCallSiteTestConsumeTwice(_ k: __owned Klass) { // expected-error {{'k' 
 }
 
 func sameCallSiteConsumeAndUse(_ k: __owned Klass) { // expected-error {{'k' consumed and used at the same time}}
-    func consumeKlassAndUseKlass(_ k: __owned Klass, _ k2: Klass) {}
+    func consumeKlassAndUseKlass(_ k: __owned Klass, _ k2: __shared Klass) {}
     consumeKlassAndUseKlass(k, k) // expected-note {{consuming and non-consuming uses here}}
 }
 

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -58,14 +58,14 @@ public struct AggStruct {
     var pair: MOIntPair
 }
 
-public func aggStructSimpleChainTest(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructSimpleChainTest(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func aggStructSimpleChainTestArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructSimpleChainTestArg(_ x2: __shared AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -77,12 +77,12 @@ public func aggStructSimpleChainTestOwnedArg(_ x2: __owned AggStruct) {
     borrowVal(k2)
 }
 
-public func aggStructSimpleNonConsumingUseTest(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructSimpleNonConsumingUseTest(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
 
-public func aggStructSimpleNonConsumingUseTestArg(_ x2: AggStruct) {
+public func aggStructSimpleNonConsumingUseTestArg(_ x2: __shared AggStruct) {
     borrowVal(x2)
 }
 
@@ -90,14 +90,14 @@ public func aggStructSimpleNonConsumingUseTestOwnedArg(_ x2: __owned AggStruct) 
     borrowVal(x2)
 }
 
-public func aggStructMultipleNonConsumingUseTest(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructMultipleNonConsumingUseTest(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func aggStructMultipleNonConsumingUseTestArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructMultipleNonConsumingUseTestArg(_ x2: __shared AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -109,7 +109,7 @@ public func aggStructMultipleNonConsumingUseTestOwnedArg(_ x2: __owned AggStruct
     consumeVal(x2)
 }
 
-public func aggStructUseAfterConsume(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructUseAfterConsume(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -117,7 +117,7 @@ public func aggStructUseAfterConsume(_ x: AggStruct) { // expected-error {{'x' h
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructUseAfterConsumeArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructUseAfterConsumeArg(_ x2: __shared AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -129,14 +129,14 @@ public func aggStructUseAfterConsumeOwnedArg(_ x2: __owned AggStruct) { // expec
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructDoubleConsume(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructDoubleConsume(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructDoubleConsumeArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDoubleConsumeArg(_ x2: __shared AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -146,7 +146,7 @@ public func aggStructDoubleConsumeOwnedArg(_ x2: __owned AggStruct) { // expecte
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggStructLoopConsume(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructLoopConsume(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -154,7 +154,7 @@ public func aggStructLoopConsume(_ x: AggStruct) { // expected-error {{'x' has g
     }
 }
 
-public func aggStructLoopConsumeArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructLoopConsumeArg(_ x2: __shared AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -166,7 +166,7 @@ public func aggStructLoopConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-
     }
 }
 
-public func aggStructDiamond(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructDiamond(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -175,7 +175,7 @@ public func aggStructDiamond(_ x: AggStruct) { // expected-error {{'x' has guara
     }
 }
 
-public func aggStructDiamondArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDiamondArg(_ x2: __shared AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -191,7 +191,7 @@ public func aggStructDiamondOwnedArg(_ x2: __owned AggStruct) {
     }
 }
 
-public func aggStructDiamondInLoop(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructDiamondInLoop(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -205,7 +205,7 @@ public func aggStructDiamondInLoop(_ x: AggStruct) { // expected-error {{'x' has
     }
 }
 
-public func aggStructDiamondInLoopArg(_ x2: AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggStructDiamondInLoopArg(_ x2: __shared AggStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -227,7 +227,7 @@ public func aggStructDiamondInLoopOwnedArg(_ x2: __owned AggStruct) { // expecte
     }
 }
 
-public func aggStructAccessField(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructAccessField(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
@@ -235,7 +235,7 @@ public func aggStructAccessField(_ x: AggStruct) { // expected-error {{'x' has g
     }
 }
 
-public func aggStructAccessFieldArg(_ x2: AggStruct) {
+public func aggStructAccessFieldArg(_ x2: __shared AggStruct) {
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.lhs)
@@ -249,7 +249,7 @@ public func aggStructAccessFieldOwnedArg(_ x2: __owned AggStruct) {
     }
 }
 
-public func aggStructConsumeField(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructConsumeField(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     consumeVal(x2.lhs)
     for _ in 0..<1024 {
@@ -258,7 +258,7 @@ public func aggStructConsumeField(_ x: AggStruct) { // expected-error {{'x' has 
 }
 
 // TODO: We should error here!
-public func aggStructConsumeFieldArg(_ x2: AggStruct) {
+public func aggStructConsumeFieldArg(_ x2: __shared AggStruct) {
     consumeVal(x2.lhs)
     for _ in 0..<1024 {
         consumeVal(x2.lhs)
@@ -272,7 +272,7 @@ public func aggStructConsumeFieldOwnedArg(_ x2: __owned AggStruct) {
     }
 }
 
-public func aggStructAccessGrandField(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructAccessGrandField(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -280,7 +280,7 @@ public func aggStructAccessGrandField(_ x: AggStruct) { // expected-error {{'x' 
     }
 }
 
-public func aggStructAccessGrandFieldArg(_ x2: AggStruct) {
+public func aggStructAccessGrandFieldArg(_ x2: __shared AggStruct) {
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.pair.lhs)
@@ -294,7 +294,7 @@ public func aggStructAccessGrandFieldOwnedArg(_ x2: __owned AggStruct) {
     }
 }
 
-public func aggStructConsumeGrandField(_ x: AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggStructConsumeGrandField(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -303,7 +303,7 @@ public func aggStructConsumeGrandField(_ x: AggStruct) { // expected-error {{'x'
 }
 
 // TODO: This needs to error.
-public func aggStructConsumeGrandFieldArg(_ x2: AggStruct) {
+public func aggStructConsumeGrandFieldArg(_ x2: __shared AggStruct) {
     consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs)
@@ -328,14 +328,14 @@ public struct AggGenericStruct<T> {
     var pair: MOIntPair
 }
 
-public func aggGenericStructSimpleChainTest(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTest(_ x: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg(_ x2: AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTestArg(_ x2: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -347,12 +347,12 @@ public func aggGenericStructSimpleChainTestOwnedArg(_ x2: __owned AggGenericStru
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTest(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleNonConsumingUseTest(_ x: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTestArg(_ x2: AggGenericStruct<CopyableKlass>) {
+public func aggGenericStructSimpleNonConsumingUseTestArg(_ x2: __shared AggGenericStruct<CopyableKlass>) {
     borrowVal(x2)
 }
 
@@ -360,14 +360,14 @@ public func aggGenericStructSimpleNonConsumingUseTestOwnedArg(_ x2: __owned AggG
     borrowVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTest(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTest(_ x: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTestArg(_ x2: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -379,7 +379,7 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg(_ x2: __owned Ag
     consumeVal(x2)
 }
 
-public func aggGenericStructUseAfterConsume(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsume(_ x: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -387,7 +387,7 @@ public func aggGenericStructUseAfterConsume(_ x: AggGenericStruct<CopyableKlass>
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructUseAfterConsumeArg(_ x2: AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsumeArg(_ x2: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -399,14 +399,14 @@ public func aggGenericStructUseAfterConsumeOwnedArg(_ x2: __owned AggGenericStru
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsume(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsume(_ x: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsumeArg(_ x2: AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsumeArg(_ x2: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -416,7 +416,7 @@ public func aggGenericStructDoubleConsumeOwnedArg(_ x2: __owned AggGenericStruct
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructLoopConsume(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsume(_ x: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -424,7 +424,7 @@ public func aggGenericStructLoopConsume(_ x: AggGenericStruct<CopyableKlass>) { 
     }
 }
 
-public func aggGenericStructLoopConsumeArg(_ x2: AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsumeArg(_ x2: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -436,7 +436,7 @@ public func aggGenericStructLoopConsumeOwnedArg(_ x2: __owned AggGenericStruct<C
     }
 }
 
-public func aggGenericStructDiamond(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamond(_ x: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -445,7 +445,7 @@ public func aggGenericStructDiamond(_ x: AggGenericStruct<CopyableKlass>) { // e
     }
 }
 
-public func aggGenericStructDiamondArg(_ x2: AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondArg(_ x2: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -461,7 +461,7 @@ public func aggGenericStructDiamondOwnedArg(_ x2: __owned AggGenericStruct<Copya
     }
 }
 
-public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoop(_ x: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -475,7 +475,7 @@ public func aggGenericStructDiamondInLoop(_ x: AggGenericStruct<CopyableKlass>) 
     }
 }
 
-public func aggGenericStructDiamondInLoopArg(_ x2: AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoopArg(_ x2: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -497,7 +497,7 @@ public func aggGenericStructDiamondInLoopOwnedArg(_ x2: __owned AggGenericStruct
     }
 }
 
-public func aggGenericStructAccessField(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessField(_ x: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
@@ -505,7 +505,7 @@ public func aggGenericStructAccessField(_ x: AggGenericStruct<CopyableKlass>) { 
     }
 }
 
-public func aggGenericStructAccessFieldArg(_ x2: AggGenericStruct<CopyableKlass>) {
+public func aggGenericStructAccessFieldArg(_ x2: __shared AggGenericStruct<CopyableKlass>) {
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.lhs)
@@ -519,7 +519,7 @@ public func aggGenericStructAccessFieldOwnedArg(_ x2: __owned AggGenericStruct<C
     }
 }
 
-public func aggGenericStructConsumeField(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeField(_ x: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     consumeVal(x2.lhs)
     for _ in 0..<1024 {
@@ -527,7 +527,7 @@ public func aggGenericStructConsumeField(_ x: AggGenericStruct<CopyableKlass>) {
     }
 }
 
-public func aggGenericStructConsumeFieldArg(_ x2: AggGenericStruct<CopyableKlass>) {
+public func aggGenericStructConsumeFieldArg(_ x2: __shared AggGenericStruct<CopyableKlass>) {
     consumeVal(x2.lhs)
     for _ in 0..<1024 {
         consumeVal(x2.lhs)
@@ -541,7 +541,7 @@ public func aggGenericStructConsumeFieldOwnedArg(_ x2: __owned AggGenericStruct<
     }
 }
 
-public func aggGenericStructAccessGrandField(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessGrandField(_ x: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -549,7 +549,7 @@ public func aggGenericStructAccessGrandField(_ x: AggGenericStruct<CopyableKlass
     }
 }
 
-public func aggGenericStructAccessGrandFieldArg(_ x2: AggGenericStruct<CopyableKlass>) {
+public func aggGenericStructAccessGrandFieldArg(_ x2: __shared AggGenericStruct<CopyableKlass>) {
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.pair.lhs)
@@ -563,7 +563,7 @@ public func aggGenericStructAccessGrandFieldOwnedArg(_ x2: __owned AggGenericStr
     }
 }
 
-public func aggGenericStructConsumeGrandField(_ x: AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeGrandField(_ x: __shared AggGenericStruct<CopyableKlass>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -571,7 +571,7 @@ public func aggGenericStructConsumeGrandField(_ x: AggGenericStruct<CopyableKlas
     }
 }
 
-public func aggGenericStructConsumeGrandFieldArg(_ x2: AggGenericStruct<CopyableKlass>) {
+public func aggGenericStructConsumeGrandFieldArg(_ x2: __shared AggGenericStruct<CopyableKlass>) {
     consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs)
@@ -589,14 +589,14 @@ public func aggGenericStructConsumeGrandFieldOwnedArg(_ x2: __owned AggGenericSt
 // Aggregate Generic Struct + Generic But Body is Trivial //
 ////////////////////////////////////////////////////////////
 
-public func aggGenericStructSimpleChainTest<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTest<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleChainTestArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleChainTestArg<T>(_ x2: __shared AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -608,12 +608,12 @@ public func aggGenericStructSimpleChainTestOwnedArg<T>(_ x2: __owned AggGenericS
     borrowVal(k2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTest<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructSimpleNonConsumingUseTest<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
 
-public func aggGenericStructSimpleNonConsumingUseTestArg<T>(_ x2: AggGenericStruct<T>) {
+public func aggGenericStructSimpleNonConsumingUseTestArg<T>(_ x2: __shared AggGenericStruct<T>) {
     borrowVal(x2)
 }
 
@@ -621,14 +621,14 @@ public func aggGenericStructSimpleNonConsumingUseTestOwnedArg<T>(_ x2: __owned A
     borrowVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTest<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: AggGenericStruct<T>) { //expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructMultipleNonConsumingUseTestArg<T>(_ x2: __shared AggGenericStruct<T>) { //expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -640,7 +640,7 @@ public func aggGenericStructMultipleNonConsumingUseTestOwnedArg<T>(_ x2: __owned
     consumeVal(x2)
 }
 
-public func aggGenericStructUseAfterConsume<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsume<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -648,7 +648,7 @@ public func aggGenericStructUseAfterConsume<T>(_ x: AggGenericStruct<T>) { // ex
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructUseAfterConsumeArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructUseAfterConsumeArg<T>(_ x2: __shared AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -660,14 +660,14 @@ public func aggGenericStructUseAfterConsumeOwnedArg<T>(_ x2: __owned AggGenericS
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsume<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsume<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructDoubleConsumeArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDoubleConsumeArg<T>(_ x2: __shared AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -677,7 +677,7 @@ public func aggGenericStructDoubleConsumeOwnedArg<T>(_ x2: __owned AggGenericStr
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsume<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -685,7 +685,7 @@ public func aggGenericStructLoopConsume<T>(_ x: AggGenericStruct<T>) { // expect
     }
 }
 
-public func aggGenericStructLoopConsumeArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructLoopConsumeArg<T>(_ x2: __shared AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -697,7 +697,7 @@ public func aggGenericStructLoopConsumeOwnedArg<T>(_ x2: __owned AggGenericStruc
     }
 }
 
-public func aggGenericStructDiamond<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamond<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -706,7 +706,7 @@ public func aggGenericStructDiamond<T>(_ x: AggGenericStruct<T>) { // expected-e
     }
 }
 
-public func aggGenericStructDiamondArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondArg<T>(_ x2: __shared AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -722,7 +722,7 @@ public func aggGenericStructDiamondOwnedArg<T>(_ x2: __owned AggGenericStruct<T>
     }
 }
 
-public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoop<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -736,7 +736,7 @@ public func aggGenericStructDiamondInLoop<T>(_ x: AggGenericStruct<T>) { // expe
     }
 }
 
-public func aggGenericStructDiamondInLoopArg<T>(_ x2: AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func aggGenericStructDiamondInLoopArg<T>(_ x2: __shared AggGenericStruct<T>) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -758,7 +758,7 @@ public func aggGenericStructDiamondInLoopOwnedArg<T>(_ x2: __owned AggGenericStr
     }
 }
 
-public func aggGenericStructAccessField<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessField<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
@@ -766,7 +766,7 @@ public func aggGenericStructAccessField<T>(_ x: AggGenericStruct<T>) { // expect
     }
 }
 
-public func aggGenericStructAccessFieldArg<T>(_ x2: AggGenericStruct<T>) {
+public func aggGenericStructAccessFieldArg<T>(_ x2: __shared AggGenericStruct<T>) {
     borrowVal(x2.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.lhs)
@@ -780,7 +780,7 @@ public func aggGenericStructAccessFieldOwnedArg<T>(_ x2: __owned AggGenericStruc
     }
 }
 
-public func aggGenericStructConsumeField<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeField<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     consumeVal(x2.lhs)
     for _ in 0..<1024 {
@@ -788,7 +788,7 @@ public func aggGenericStructConsumeField<T>(_ x: AggGenericStruct<T>) { // expec
     }
 }
 
-public func aggGenericStructConsumeFieldArg<T>(_ x2: AggGenericStruct<T>) {
+public func aggGenericStructConsumeFieldArg<T>(_ x2: __shared AggGenericStruct<T>) {
     consumeVal(x2.lhs)
     for _ in 0..<1024 {
         consumeVal(x2.lhs)
@@ -802,7 +802,7 @@ public func aggGenericStructConsumeFieldOwnedArg<T>(_ x2: __owned AggGenericStru
     }
 }
 
-public func aggGenericStructAccessGrandField<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructAccessGrandField<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -810,7 +810,7 @@ public func aggGenericStructAccessGrandField<T>(_ x: AggGenericStruct<T>) { // e
     }
 }
 
-public func aggGenericStructAccessGrandFieldArg<T>(_ x2: AggGenericStruct<T>) {
+public func aggGenericStructAccessGrandFieldArg<T>(_ x2: __shared AggGenericStruct<T>) {
     borrowVal(x2.pair.lhs)
     for _ in 0..<1024 {
         borrowVal(x2.pair.lhs)
@@ -824,7 +824,7 @@ public func aggGenericStructAccessGrandFieldOwnedArg<T>(_ x2: __owned AggGeneric
     }
 }
 
-public func aggGenericStructConsumeGrandField<T>(_ x: AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func aggGenericStructConsumeGrandField<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
@@ -832,7 +832,7 @@ public func aggGenericStructConsumeGrandField<T>(_ x: AggGenericStruct<T>) { // 
     }
 }
 
-public func aggGenericStructConsumeGrandFieldArg<T>(_ x2: AggGenericStruct<T>) {
+public func aggGenericStructConsumeGrandFieldArg<T>(_ x2: __shared AggGenericStruct<T>) {
     consumeVal(x2.pair.lhs)
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs)
@@ -858,14 +858,14 @@ public enum EnumTy {
     func doSomething() -> Bool { true }
 }
 
-public func enumSimpleChainTest(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumSimpleChainTest(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     let y2 = x2
     let k2 = y2
     borrowVal(k2)
 }
 
-public func enumSimpleChainTestArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumSimpleChainTestArg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let y2 = x2 // expected-note {{consuming use here}}
     let k2 = y2
     borrowVal(k2)
@@ -877,12 +877,12 @@ public func enumSimpleChainTestOwnedArg(_ x2: __owned EnumTy) {
     borrowVal(k2)
 }
 
-public func enumSimpleNonConsumingUseTest(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumSimpleNonConsumingUseTest(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
 }
 
-public func enumSimpleNonConsumingUseTestArg(_ x2: EnumTy) {
+public func enumSimpleNonConsumingUseTestArg(_ x2: __shared EnumTy) {
     borrowVal(x2)
 }
 
@@ -890,14 +890,14 @@ public func enumSimpleNonConsumingUseTestOwnedArg(_ x2: __owned EnumTy) {
     borrowVal(x2)
 }
 
-public func enumMultipleNonConsumingUseTest(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumMultipleNonConsumingUseTest(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2)
 }
 
-public func enumMultipleNonConsumingUseTestArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumMultipleNonConsumingUseTestArg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -909,7 +909,7 @@ public func enumMultipleNonConsumingUseTestOwnedArg(_ x2: __owned EnumTy) {
     consumeVal(x2)
 }
 
-public func enumUseAfterConsume(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumUseAfterConsume(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     borrowVal(x2)
@@ -917,7 +917,7 @@ public func enumUseAfterConsume(_ x: EnumTy) { // expected-error {{'x' has guara
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func enumUseAfterConsumeArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumUseAfterConsumeArg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     borrowVal(x2)
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
@@ -929,14 +929,14 @@ public func enumUseAfterConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-erro
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func enumDoubleConsume(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumDoubleConsume(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x  // expected-error {{'x2' consumed more than once}}
                 // expected-note @-1 {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func enumDoubleConsumeArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumDoubleConsumeArg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
 }
@@ -946,7 +946,7 @@ public func enumDoubleConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error 
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func enumLoopConsume(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumLoopConsume(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -954,7 +954,7 @@ public func enumLoopConsume(_ x: EnumTy) { // expected-error {{'x' has guarantee
     }
 }
 
-public func enumLoopConsumeArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumLoopConsumeArg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
         consumeVal(x2) // expected-note {{consuming use here}}
     }
@@ -966,7 +966,7 @@ public func enumLoopConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{
     }
 }
 
-public func enumDiamond(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumDiamond(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     if boolValue {
         consumeVal(x2)
@@ -975,7 +975,7 @@ public func enumDiamond(_ x: EnumTy) { // expected-error {{'x' has guaranteed ow
     }
 }
 
-public func enumDiamondArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumDiamondArg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if boolValue {
         consumeVal(x2) // expected-note {{consuming use here}}
     } else {
@@ -991,7 +991,7 @@ public func enumDiamondOwnedArg(_ x2: __owned EnumTy) {
     }
 }
 
-public func enumDiamondInLoop(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumDiamondInLoop(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed by a use in a loop}}
@@ -1005,7 +1005,7 @@ public func enumDiamondInLoop(_ x: EnumTy) { // expected-error {{'x' has guarant
     }
 }
 
-public func enumDiamondInLoopArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumDiamondInLoopArg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
@@ -1027,7 +1027,7 @@ public func enumDiamondInLoopOwnedArg(_ x2: __owned EnumTy) { // expected-error 
     }
 }
 
-public func enumAssignToVar1(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar1(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -1036,7 +1036,7 @@ public func enumAssignToVar1(_ x: EnumTy) { // expected-error {{'x' has guarante
     consumeVal(x3)
 }
 
-public func enumAssignToVar1Arg(_ x: EnumTy, _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar1Arg(_ x: __shared EnumTy, _ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
                                                              // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
@@ -1044,7 +1044,7 @@ public func enumAssignToVar1Arg(_ x: EnumTy, _ x2: EnumTy) { // expected-error {
     consumeVal(x3)
 }
 
-public func enumAssignToVar1OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
+public func enumAssignToVar1OwnedArg(_ x: __shared EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' consumed more than once}}
                                                                           // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
@@ -1052,7 +1052,7 @@ public func enumAssignToVar1OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // exp
     consumeVal(x3)
 }
 
-public func enumAssignToVar2(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar2(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -1060,7 +1060,7 @@ public func enumAssignToVar2(_ x: EnumTy) { // expected-error {{'x' has guarante
     borrowVal(x3)
 }
 
-public func enumAssignToVar2Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar2Arg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x3)
@@ -1072,27 +1072,27 @@ public func enumAssignToVar2OwnedArg(_ x2: __owned EnumTy) { // expected-error {
     borrowVal(x3)
 }
 
-public func enumAssignToVar3(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar3(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumAssignToVar3Arg(_ x: EnumTy, _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar3Arg(_ x: __shared EnumTy, _ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
                                                              // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumAssignToVar3OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar3OwnedArg(_ x: __shared EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2
     x3 = x // expected-note {{consuming use here}}
     consumeVal(x3)
 }
 
-public func enumAssignToVar4(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar4(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     let x3 = x2 // expected-note {{consuming use here}}
@@ -1100,7 +1100,7 @@ public func enumAssignToVar4(_ x: EnumTy) { // expected-error {{'x' has guarante
     consumeVal(x3)
 }
 
-public func enumAssignToVar4Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar4Arg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     let x3 = x2 // expected-note {{consuming use here}}
     consumeVal(x2) // expected-note {{consuming use here}}
     consumeVal(x3)
@@ -1112,7 +1112,7 @@ public func enumAssignToVar4OwnedArg(_ x2: __owned EnumTy) { // expected-error {
     consumeVal(x3)
 }
 
-public func enumAssignToVar5(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumAssignToVar5(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     var x3 = x2 // expected-note {{consuming use here}}
@@ -1121,7 +1121,7 @@ public func enumAssignToVar5(_ x: EnumTy) { // expected-error {{'x' has guarante
     consumeVal(x3)
 }
 
-public func enumAssignToVar5Arg(_ x: EnumTy, _ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumAssignToVar5Arg(_ x: __shared EnumTy, _ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
                                                              // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     // TODO: Need to mark this as the lifetime extending use. We fail
@@ -1131,7 +1131,7 @@ public func enumAssignToVar5Arg(_ x: EnumTy, _ x2: EnumTy) { // expected-error {
     consumeVal(x3)
 }
 
-public func enumAssignToVar5OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
+public func enumAssignToVar5OwnedArg(_ x: __shared EnumTy, _ x2: __owned EnumTy) { // expected-error {{'x2' used after consume}}
                                                                           // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     var x3 = x2 // expected-note {{consuming use here}}
     borrowVal(x2) // expected-note {{non-consuming use here}}
@@ -1139,7 +1139,7 @@ public func enumAssignToVar5OwnedArg(_ x: EnumTy, _ x2: __owned EnumTy) { // exp
     consumeVal(x3)
 }
 
-public func enumPatternMatchIfLet1(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet1(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
     if case let .klass(x) = x2 { // expected-note {{consuming use here}}
@@ -1150,7 +1150,7 @@ public func enumPatternMatchIfLet1(_ x: EnumTy) { // expected-error {{'x' has gu
     }
 }
 
-public func enumPatternMatchIfLet1Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet1Arg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     if case let .klass(x) = x2 { // expected-note {{consuming use here}}
         borrowVal(x.i)
     }
@@ -1168,7 +1168,7 @@ public func enumPatternMatchIfLet1OwnedArg(_ x2: __owned EnumTy) { // expected-e
     }
 }
 
-public func enumPatternMatchIfLet2(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet2(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
@@ -1178,7 +1178,7 @@ public func enumPatternMatchIfLet2(_ x: EnumTy) { // expected-error {{'x' has gu
     }
 }
 
-public func enumPatternMatchIfLet2Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchIfLet2Arg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     for _ in 0..<1024 {
         if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
             borrowVal(x)
@@ -1195,7 +1195,7 @@ public func enumPatternMatchIfLet2OwnedArg(_ x2: __owned EnumTy) { // expected-e
 }
 
 // TODO: This is wrong.
-public func enumPatternMatchSwitch1(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch1(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     switch x2 { // expected-note {{consuming use here}}
@@ -1207,7 +1207,7 @@ public func enumPatternMatchSwitch1(_ x: EnumTy) { // expected-error {{'x' has g
     }
 }
 
-public func enumPatternMatchSwitch1Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch1Arg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
         borrowVal(k)
@@ -1229,7 +1229,7 @@ public func enumPatternMatchSwitch1OwnedArg(_ x2: __owned EnumTy) { // expected-
     }
 }
 
-public func enumPatternMatchSwitch2(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     switch x2 {
     case let .klass(k):
@@ -1239,7 +1239,7 @@ public func enumPatternMatchSwitch2(_ x: EnumTy) { // expected-error {{'x' has g
     }
 }
 
-public func enumPatternMatchSwitch2Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2Arg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k):
         borrowVal(k)
@@ -1258,7 +1258,7 @@ public func enumPatternMatchSwitch2OwnedArg(_ x2: __owned EnumTy) {
 }
 
 // TODO: We can do better here. We should also flag x2
-public func enumPatternMatchSwitch2WhereClause(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClause(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
                // expected-note @-1 {{consuming use here}}
     switch x2 { // expected-note {{consuming use here}}
@@ -1272,7 +1272,7 @@ public func enumPatternMatchSwitch2WhereClause(_ x: EnumTy) { // expected-error 
     }
 }
 
-public func enumPatternMatchSwitch2WhereClauseArg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClauseArg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
            where x2.doSomething():
@@ -1296,7 +1296,7 @@ public func enumPatternMatchSwitch2WhereClauseOwnedArg(_ x2: __owned EnumTy) { /
     }
 }
 
-public func enumPatternMatchSwitch2WhereClause2(_ x: EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClause2(_ x: __shared EnumTy) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     switch x2 {
     case let .klass(k)
@@ -1309,7 +1309,7 @@ public func enumPatternMatchSwitch2WhereClause2(_ x: EnumTy) { // expected-error
     }
 }
 
-public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func enumPatternMatchSwitch2WhereClause2Arg(_ x2: __shared EnumTy) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     switch x2 { // expected-note {{consuming use here}}
     case let .klass(k)
            where boolValue:
@@ -1337,7 +1337,7 @@ public func enumPatternMatchSwitch2WhereClause2OwnedArg(_ x2: __owned EnumTy) {
 // Closure and Defer Tests //
 /////////////////////////////
 
-public func closureClassUseAfterConsume1(_ x: NonTrivialStruct) {
+public func closureClassUseAfterConsume1(_ x: __shared NonTrivialStruct) {
     // expected-error @-1 {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{closure capture here}}
@@ -1350,8 +1350,8 @@ public func closureClassUseAfterConsume1(_ x: NonTrivialStruct) {
     f()
 }
 
-public func closureClassUseAfterConsume2(_ argX: NonTrivialStruct) {
-    let f = { (_ x: NonTrivialStruct) in // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureClassUseAfterConsume2(_ argX: __shared NonTrivialStruct) {
+    let f = { (_ x: __shared NonTrivialStruct) in // expected-error {{'x' has guaranteed ownership but was consumed}}
         let x2 = x // expected-error {{'x2' consumed more than once}}
                    // expected-note @-1 {{consuming use here}}
         borrowVal(x2)
@@ -1361,9 +1361,9 @@ public func closureClassUseAfterConsume2(_ argX: NonTrivialStruct) {
     f(argX)
 }
 
-public func closureClassUseAfterConsumeArg(_ argX: NonTrivialStruct) {
+public func closureClassUseAfterConsumeArg(_ argX: __shared NonTrivialStruct) {
     // TODO: Fix this
-    let f = { (_ x2: NonTrivialStruct) in // expected-error {{'x2' has guaranteed ownership but was consumed}}
+    let f = { (_ x2: __shared NonTrivialStruct) in // expected-error {{'x2' has guaranteed ownership but was consumed}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1371,7 +1371,7 @@ public func closureClassUseAfterConsumeArg(_ argX: NonTrivialStruct) {
     f(argX)
 }
 
-public func closureCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureCaptureClassUseAfterConsume(_ x: __shared NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
@@ -1382,7 +1382,7 @@ public func closureCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expec
     f()
 }
 
-public func closureCaptureClassUseAfterConsumeError(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureCaptureClassUseAfterConsumeError(_ x: __shared NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
@@ -1396,7 +1396,7 @@ public func closureCaptureClassUseAfterConsumeError(_ x: NonTrivialStruct) { // 
     let _ = x3
 }
 
-public func closureCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) {
+public func closureCaptureClassArgUseAfterConsume(_ x2: __shared NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = { // expected-note {{closure capture here}}
@@ -1430,7 +1430,7 @@ public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivial
     let _ = x3
 }
 
-public func deferCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func deferCaptureClassUseAfterConsume(_ x: __shared NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     defer {
@@ -1441,7 +1441,7 @@ public func deferCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expecte
     consumeVal(x) // expected-note {{consuming use here}}
 }
 
-public func deferCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func deferCaptureClassUseAfterConsume2(_ x: __shared NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' used after consume}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
@@ -1454,7 +1454,7 @@ public func deferCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) { // expect
     let _ = x3
 }
 
-public func deferCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) {
+public func deferCaptureClassArgUseAfterConsume(_ x2: __shared NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     borrowVal(x2)
     defer {
@@ -1486,7 +1486,7 @@ public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialSt
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func closureAndDeferCaptureClassUseAfterConsume(_ x: NonTrivialStruct) {
+public func closureAndDeferCaptureClassUseAfterConsume(_ x: __shared NonTrivialStruct) {
     // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
@@ -1501,7 +1501,7 @@ public func closureAndDeferCaptureClassUseAfterConsume(_ x: NonTrivialStruct) {
     f()
 }
 
-public func closureAndDeferCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureAndDeferCaptureClassUseAfterConsume2(_ x: __shared NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
@@ -1517,7 +1517,7 @@ public func closureAndDeferCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) {
     f()
 }
 
-public func closureAndDeferCaptureClassUseAfterConsume3(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureAndDeferCaptureClassUseAfterConsume3(_ x: __shared NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
     // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
@@ -1535,7 +1535,7 @@ public func closureAndDeferCaptureClassUseAfterConsume3(_ x: NonTrivialStruct) {
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
+public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: __shared NonTrivialStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = { // expected-note {{closure capture here}}
         defer {
@@ -1575,7 +1575,7 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned No
     consumeVal(x2) // expected-note {{consuming use here}}
 }
 
-public func closureAndClosureCaptureClassUseAfterConsume(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureAndClosureCaptureClassUseAfterConsume(_ x: __shared NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
@@ -1590,7 +1590,7 @@ public func closureAndClosureCaptureClassUseAfterConsume(_ x: NonTrivialStruct) 
     f()
 }
 
-public func closureAndClosureCaptureClassUseAfterConsume2(_ x: NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
+public func closureAndClosureCaptureClassUseAfterConsume2(_ x: __shared NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-error {{'x2' consumed more than once}}
                // expected-note @-1 {{consuming use here}}
                // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
@@ -1608,7 +1608,7 @@ public func closureAndClosureCaptureClassUseAfterConsume2(_ x: NonTrivialStruct)
 }
 
 
-public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: NonTrivialStruct) {
+public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: __shared NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     // expected-error @-3 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}

--- a/test/Sema/moveonly_require_ownership_specifier.swift
+++ b/test/Sema/moveonly_require_ownership_specifier.swift
@@ -1,0 +1,86 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-move-only
+
+// Coverage for check that requires some ownership specifier to be written
+// when a move-only / noncopyable type appears as a parameter of a function.
+
+@_moveOnly
+struct MO {
+    var x = 0
+}
+
+struct Box<T> { var val: T }
+
+@_moveOnly
+public struct NoncopyableWrapper<T> {
+  var x: T
+}
+
+class Inspector {
+  func inspect(_ hasIt: inout MO, _ mo: MO, _ hasItAgain: __owned MO) {}
+  // expected-error@-1 {{noncopyable parameter must specify its ownership}}
+  // expected-note@-2 {{add '__shared' for an immutable reference}}{{41-41=__shared }}
+  // expected-note@-3 {{add 'inout' for a mutable reference}}{{41-41=inout }}
+  // expected-note@-4 {{add '__owned' to take the value from callers}}{{41-41=__owned }}
+}
+
+// expected-error@+4 {{noncopyable parameter must specify its ownership}}
+// expected-note@+3 {{add '__shared' for an immutable reference}}{{20-20=__shared }}
+// expected-note@+2 {{add 'inout' for a mutable reference}}{{20-20=inout }}
+// expected-note@+1 {{add '__owned' to take the value from callers}}{{20-20=__owned }}
+func applier(_ f: (MO) -> (),
+             _ v: MO) {}
+// expected-error@-1 {{noncopyable parameter must specify its ownership}}
+// expected-note@-2 {{add '__shared' for an immutable reference}}{{19-19=__shared }}
+// expected-note@-3 {{add 'inout' for a mutable reference}}{{19-19=inout }}
+// expected-note@-4 {{add '__owned' to take the value from callers}}{{19-19=__owned }}
+
+func caller() {
+  let f = { (_ mo1: MO, _ mo2: MO) in () }
+  // expected-error@-1 2{{noncopyable parameter must specify its ownership}}
+  // expected-note@-2 {{add '__shared' for an immutable reference}}{{21-21=__shared }}
+  // expected-note@-3 {{add '__shared' for an immutable reference}}{{32-32=__shared }}
+  // expected-note@-4 {{add 'inout' for a mutable reference}}{{21-21=inout }}
+  // expected-note@-5 {{add 'inout' for a mutable reference}}{{32-32=inout }}
+  // expected-note@-6 {{add '__owned' to take the value from callers}}{{21-21=__owned }}
+  // expected-note@-7 {{add '__owned' to take the value from callers}}{{32-32=__owned }}
+
+  let g: (MO, MO) -> () = f
+  // expected-error@-1 2{{noncopyable parameter must specify its ownership}}
+  // expected-note@-2 {{add '__shared' for an immutable reference}}{{11-11=__shared }}
+  // expected-note@-3 {{add '__shared' for an immutable reference}}{{15-15=__shared }}
+  // expected-note@-4 {{add 'inout' for a mutable reference}}{{11-11=inout }}
+  // expected-note@-5 {{add 'inout' for a mutable reference}}{{15-15=inout }}
+  // expected-note@-6 {{add '__owned' to take the value from callers}}{{11-11=__owned }}
+  // expected-note@-7 {{add '__owned' to take the value from callers}}{{15-15=__owned }}
+
+  let partialG = { g($0, MO()) }
+
+  let _: Box<(MO) -> ()> = Box(val: partialG)
+  // expected-error@-1 {{noncopyable parameter must specify its ownership}}
+  // expected-note@-2 {{add '__shared' for an immutable reference}}{{15-15=__shared }}
+  // expected-note@-3 {{add 'inout' for a mutable reference}}{{15-15=inout }}
+  // expected-note@-4 {{add '__owned' to take the value from callers}}{{15-15=__owned }}
+
+  let _: Box<(inout MO) -> ()>? = nil
+  let _: Box<(__shared MO) -> ()>? = nil
+
+  let _: Box<(MO) -> ()>? = nil
+  // expected-error@-1 {{noncopyable parameter must specify its ownership}}
+  // expected-note@-2 {{add '__shared' for an immutable reference}}{{15-15=__shared }}
+  // expected-note@-3 {{add 'inout' for a mutable reference}}{{15-15=inout }}
+  // expected-note@-4 {{add '__owned' to take the value from callers}}{{15-15=__owned }}
+
+  applier(partialG, MO())
+}
+
+func takeGeneric<T>(_ x: NoncopyableWrapper<T>) {}
+// expected-error@-1 {{noncopyable parameter must specify its ownership}}
+// expected-note@-2 {{add '__shared' for an immutable reference}}{{26-26=__shared }}
+// expected-note@-3 {{add 'inout' for a mutable reference}}{{26-26=inout }}
+// expected-note@-4 {{add '__owned' to take the value from callers}}{{26-26=__owned }}
+
+func takeInstantiated(_ x: NoncopyableWrapper<Int>) {}
+// expected-error@-1 {{noncopyable parameter must specify its ownership}}
+// expected-note@-2 {{add '__shared' for an immutable reference}}{{28-28=__shared }}
+// expected-note@-3 {{add 'inout' for a mutable reference}}{{28-28=inout }}
+// expected-note@-4 {{add '__owned' to take the value from callers}}{{28-28=__owned }}

--- a/test/Sema/moveonly_sendable.swift
+++ b/test/Sema/moveonly_sendable.swift
@@ -27,11 +27,11 @@ func invalidFile() async -> FileDescriptor {
   return FileDescriptor(id: -1)
 }
 
-func takeNotSendable(_ nsmo: NotSendableMO) async {}
+func takeNotSendable(_ nsmo: __shared NotSendableMO) async {}
 
 actor A {
-  init(_ t: FileDescriptor) {}
-  init (_ t: MaybeFile) {}
+  init(_ t: __owned FileDescriptor) {}
+  init (_ t: __owned MaybeFile) {}
   func takeFileDescriptor(_ fd: __owned FileDescriptor) {}
   func takeMaybeFile(_ mfd: __owned MaybeFile) {}
   func giveFileDescriptor() -> MaybeFile {
@@ -42,7 +42,7 @@ actor A {
 }
 
 @MainActor
-func processFiles(_ a: A, _ anotherFile: FileDescriptor) async {
+func processFiles(_ a: A, _ anotherFile: __shared FileDescriptor) async {
   let file = await invalidFile()
   await a.takeFileDescriptor(file)
 
@@ -96,7 +96,7 @@ func takeSomeSendable(_ s: some Sendable) {}
 // expected-error@+1 {{move-only type 'FileDescriptor' cannot be used with generics yet}}
 func mkSendable() -> Sendable { return FileDescriptor(id: 0) }
 
-func tryToCastIt(_ fd: FileDescriptor) {
+func tryToCastIt(_ fd: __shared FileDescriptor) {
   let _: any Sendable = fd // expected-error {{move-only type 'FileDescriptor' cannot be used with generics yet}}
   let _: Sendable = fd // expected-error {{move-only type 'FileDescriptor' cannot be used with generics yet}}
 
@@ -145,7 +145,7 @@ class Container<T> where T:Sendable {
   init(_ t: T) { self.elm = t }
 }
 
-func createContainer(_ fd: FileDescriptor) {
+func createContainer(_ fd: __shared FileDescriptor) {
   let _: Container<Sendable> = Container(fd) // expected-error {{move-only type 'FileDescriptor' cannot be used with generics yet}}
   let _: Container<Sendable> = Container(CopyableStruct())
 }
@@ -158,7 +158,7 @@ extension Sendable {
   }
 }
 
-func tryToDupe(_ fd: FileDescriptor) {
+func tryToDupe(_ fd: __shared FileDescriptor) {
   fd.doIllegalThings() // expected-error {{move-only type 'FileDescriptor' cannot be used with generics yet}}
 }
 

--- a/test/Sema/noimplicitcopy_attr.swift
+++ b/test/Sema/noimplicitcopy_attr.swift
@@ -144,11 +144,11 @@ struct MoveOnly {
     var k = Klass()
 }
 
-func useMoveOnly(@_noImplicitCopy _ x: MoveOnly) -> MoveOnly { // expected-error {{'@_noImplicitCopy' has no effect when applied to a move only type}}
+func useMoveOnly(@_noImplicitCopy _ x: __shared MoveOnly) -> MoveOnly { // expected-error {{'@_noImplicitCopy' has no effect when applied to a move only type}}
     return x
 }
 
-func useMoveOnly2(_ x: MoveOnly) {
+func useMoveOnly2(_ x: __shared MoveOnly) {
     @_noImplicitCopy let y = x // expected-error {{'@_noImplicitCopy' has no effect when applied to a move only type}}
     let _ = y
 }


### PR DESCRIPTION
Per the [proposal](https://github.com/jckarter/swift-evolution/blob/noncopyable-structs-and-enums/proposals/NNNN-noncopyable-structs-and-enums.md#declaring-functions-and-methods-with-noncopyable-parameters), if a noncopyable type appears as a parameter, then the ownership specifier must be provided:

> When noncopyable types are used as function parameters, the ownership convention becomes a much more important part of the API contract. As such, when a function parameter is declared with an noncopyable type, it must declare whether the parameter uses the borrowing, consuming, or inout convention:

Those specifiers are suppose to be one of `inout`, `consuming`, or `borrowing`, but the latter two haven't gotten their blessed names yet, so for now this PR just asks to add `__owned` or `__shared`.

Bonus: This commit includes a fix to make `CompileTimeConstTypeRepr` a proper `isa<>` subtype of `SpecifierTypeRepr`, since we forgot to add it to that type's `classof` function. Wish I could have had that fix in a separate commit but I don't feel like doing commit surgery to undo it right now.

resolves rdar://105480354

