### PR TITLE
[cxx-interop] Treat C++ structs that store iterators as unsafe

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6274,6 +6274,9 @@ static bool hasPointerInSubobjects(const clang::CXXRecordDecl *decl) {
             hasUnsafeAPIAttr(cxxRecord))
           return false;
 
+        if (hasIteratorAPIAttr(cxxRecord) || isIterator(cxxRecord))
+          return true;
+
         if (hasPointerInSubobjects(cxxRecord))
           return true;
       }

--- a/test/Interop/Cxx/class/Inputs/type-classification.h
+++ b/test/Interop/Cxx/class/Inputs/type-classification.h
@@ -197,4 +197,20 @@ struct HasUnsupportedUsingShadow : DependentParent<int> {
   using typename DependentParent<int>::Child;
 };
 
+struct __attribute__((swift_attr("import_iterator"))) Iterator {
+  int idx;
+};
+
+struct HasMethodThatReturnsIterator {
+  Iterator getIterator() const;
+};
+
+struct IteratorBox {
+  Iterator it;
+};
+
+struct HasMethodThatReturnsIteratorBox {
+  IteratorBox getIteratorBox() const;
+};
+
 #endif // TEST_INTEROP_CXX_CLASS_INPUTS_TYPE_CLASSIFICATION_H

--- a/test/Interop/Cxx/class/type-classification-module-interface.swift
+++ b/test/Interop/Cxx/class/type-classification-module-interface.swift
@@ -18,3 +18,17 @@
 // CHECK-NOT: StructWithDeletedDestructor
 // CHECK-NOT: StructWithInheritedDeletedDestructor
 // CHECK-NOT: StructWithSubobjectDeletedDestructor
+
+// CHECK: struct Iterator {
+// CHECK: }
+
+// CHECK: struct HasMethodThatReturnsIterator {
+// CHECK:   func __getIteratorUnsafe() -> Iterator
+// CHECK: }
+
+// CHECK: struct IteratorBox {
+// CHECK: }
+
+// CHECK: struct HasMethodThatReturnsIteratorBox {
+// CHECK:   func __getIteratorBoxUnsafe() -> IteratorBox
+// CHECK: }


### PR DESCRIPTION
C++ types that store pointers as fields are treated as unsafe in Swift. Types that store other types that in turn store pointers are also treated as unsafe.

Types that store raw C++ iterators are also treated as unsafe in Swift. However, a type that stores another type that stores a raw iterator was previously imported as safe. This change fixes that.

rdar://105493479