### PR TITLE
[5.8][Build] Limit Ubuntu 18.04 LSAN CI to 12 link jobs

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1197,6 +1197,9 @@ reconfigure
 [preset: buildbot_incremental_linux,lsan,tools=RDA,stdlib=DA,test=no]
 build-subdir=buildbot_incremental_lsan
 
+llvm-cmake-options=-DLLVM_PARALLEL_LINK_JOBS=12
+swift-cmake-options=-DSWIFT_PARALLEL_LINK_JOBS=12
+
 release-debuginfo
 assertions
 enable-lsan


### PR DESCRIPTION
Cherry-pick https://github.com/apple/swift/pull/63546/commits/a705ee26f03cebce7ae4bd61e682f8fb2aef5007 to release/5.8.

It's currently running out of memory, likely due to the machine's high core count and linking many jobs at once. Limit to 12 only.