### PR TITLE
[5.8][Test] Better workaround for filelists.swift

### DIFF
--- a/test/Driver/filelists.swift
+++ b/test/Driver/filelists.swift
@@ -77,9 +77,8 @@
 // RUN: echo "int dummy;" >%t/a.cpp
 // RUN: %target-clang -c %t/a.cpp -o %t/a.o
 // RUN: %swiftc_driver -save-temps -driver-print-jobs %S/../Inputs/empty.swift %t/a.o -lto=llvm-full -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -o filelist 2>&1 | tee -a %t/forFilelistCapture | %FileCheck -check-prefix FILELIST %s
-// RUN: echo "# A comment so it's less likely this file will be 4096 in size\n" >> %t/forFilelistCapture
-// RUN: tail -3 %t/forFilelistCapture | head -1 | sed 's/.*-output-filelist //' | sed 's/ .*//' > %t/output-filelist
-// RUN: tail -2 %t/forFilelistCapture | head -1 | sed 's/.*-filelist //' | sed 's/ .*//' > %t/input-filelist
+// RUN: sed 's/.*-output-filelist //' %t/forFilelistCapture | sed 's/ .*//' | tail -2 | head -1 > %t/output-filelist
+// RUN: sed 's/.*-filelist //' %t/forFilelistCapture | sed 's/ .*//' | tail -1 | head -1 > %t/input-filelist
 // RUN: cat $(cat %t/output-filelist) | %FileCheck -check-prefix OUTPUT-FILELIST-CONTENTS %s
 // RUN: cat $(cat %t/input-filelist)  | %FileCheck -check-prefix INPUT-FILELIST-CONTENTS %s
 


### PR DESCRIPTION
bdf60152f097d2901d134300ae69019a9d0d4ef2 added some extra padding to
forFilelistCapture to avoid it being exactly 4096 bytes, triggering a
 tail bug. Rather than do that, just run the sed's first so that the
input is quite small (definitely under 4096 bytes).

Resolves rdar://105395733.