### PR TITLE
some refactoring in Effects and ComputeEscapeEffects

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEscapeEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEscapeEffects.swift
@@ -155,12 +155,12 @@ func addArgEffects(_ arg: FunctionArgument, argPath ap: SmallProjectionPath,
   case .toReturn(let toPath):
     let exclusive = isExclusiveEscapeToReturn(fromArgument: arg, fromPath: argPath,
                                               toPath: toPath, returnInst: returnInst, context)
-    effect = EscapeEffects.ArgumentEffect(.escapingToReturn(toPath, exclusive),
+    effect = EscapeEffects.ArgumentEffect(.escapingToReturn(toPath: toPath, isExclusive: exclusive),
                                           argumentIndex: arg.index, pathPattern: argPath)
   case .toArgument(let toArgIdx, let toPath):
     // Exclusive argument -> argument effects cannot appear because such an effect would
     // involve a store which is not permitted for exclusive escapes.
-    effect = EscapeEffects.ArgumentEffect(.escapingToArgument(toArgIdx, toPath, /*exclusive*/ false),
+    effect = EscapeEffects.ArgumentEffect(.escapingToArgument(toArgumentIndex: toArgIdx, toPath: toPath, isExclusive: false),
                                           argumentIndex: arg.index, pathPattern: argPath)
   }
   newEffects.append(effect)

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEscapeEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEscapeEffects.swift
@@ -85,61 +85,7 @@ func addArgEffects(_ arg: FunctionArgument, argPath ap: SmallProjectionPath,
   // containing one or more references.
   let argPath = arg.type.isClass ? ap : ap.push(.anyValueFields)
   
-  struct ArgEffectsVisitor : EscapeVisitorWithResult {
-    enum EscapeDestination {
-      case notSet
-      case toReturn(SmallProjectionPath)
-      case toArgument(Int, SmallProjectionPath) // argument index, path
-    }
-    var result = EscapeDestination.notSet
-    
-    mutating func visitUse(operand: Operand, path: EscapePath) -> UseResult {
-      if operand.instruction is ReturnInst {
-        // The argument escapes to the function return
-        if path.followStores {
-          // The escaping path must not introduce a followStores.
-          return .abort
-        }
-        switch result {
-          case .notSet:
-            result = .toReturn(path.projectionPath)
-          case .toReturn(let oldPath):
-            result = .toReturn(oldPath.merge(with: path.projectionPath))
-          case .toArgument:
-            return .abort
-        }
-        return .ignore
-      }
-      if isOperandOfRecursiveCall(operand) {
-        return .ignore
-      }
-      return .continueWalk
-    }
-    
-    mutating func visitDef(def: Value, path: EscapePath) -> DefResult {
-      guard let destArg = def as? FunctionArgument else {
-        return .continueWalkUp
-      }
-      // The argument escapes to another argument (e.g. an out or inout argument)
-      if path.followStores {
-        // The escaping path must not introduce a followStores.
-        return .abort
-      }
-      let argIdx = destArg.index
-      switch result {
-        case .notSet:
-          result = .toArgument(argIdx, path.projectionPath)
-        case .toArgument(let oldArgIdx, let oldPath) where oldArgIdx == argIdx:
-          result = .toArgument(argIdx, oldPath.merge(with: path.projectionPath))
-        default:
-          return .abort
-      }
-      return .walkDown
-    }
-  }
-  
-  guard let result = arg.at(argPath).visitByWalkingDown(using: ArgEffectsVisitor(),
-                                                        context) else {
+  guard let result = arg.at(argPath).visitByWalkingDown(using: ArgEffectsVisitor(), context) else {
     return false
   }
   
@@ -152,11 +98,13 @@ func addArgEffects(_ arg: FunctionArgument, argPath ap: SmallProjectionPath,
   switch result {
   case .notSet:
     effect = EscapeEffects.ArgumentEffect(.notEscaping, argumentIndex: arg.index, pathPattern: argPath)
+
   case .toReturn(let toPath):
-    let exclusive = isExclusiveEscapeToReturn(fromArgument: arg, fromPath: argPath,
-                                              toPath: toPath, returnInst: returnInst, context)
+    let visitor = IsExclusiveReturnEscapeVisitor(argument: arg, argumentPath: argPath, returnPath: toPath)
+    let exclusive = visitor.isExclusiveEscape(returnInst: returnInst, context)
     effect = EscapeEffects.ArgumentEffect(.escapingToReturn(toPath: toPath, isExclusive: exclusive),
                                           argumentIndex: arg.index, pathPattern: argPath)
+
   case .toArgument(let toArgIdx, let toPath):
     // Exclusive argument -> argument effects cannot appear because such an effect would
     // involve a store which is not permitted for exclusive escapes.
@@ -199,55 +147,105 @@ private func isOperandOfRecursiveCall(_ op: Operand) -> Bool {
   return false
 }
 
-/// Returns true if when walking up from the `returnInst`, the `fromArgument` is the one
-/// and only argument which is reached - with a matching `fromPath`.
-private
-func isExclusiveEscapeToReturn(fromArgument: Argument, fromPath: SmallProjectionPath,
-                               toPath: SmallProjectionPath,
-                               returnInst: ReturnInst, _ context: FunctionPassContext) -> Bool {
-  struct IsExclusiveReturnEscapeVisitor : EscapeVisitorWithResult {
-    let fromArgument: Argument
-    let fromPath: SmallProjectionPath
-    let toPath: SmallProjectionPath
-    var result = false
-    
-    mutating func visitUse(operand: Operand, path: EscapePath) -> UseResult {
-      switch operand.instruction {
-      case is ReturnInst:
-        if path.followStores { return .abort }
-        if path.projectionPath.matches(pattern: toPath) {
-          return .ignore
-        }
+private struct ArgEffectsVisitor : EscapeVisitorWithResult {
+  enum EscapeDestination {
+    case notSet
+    case toReturn(SmallProjectionPath)
+    case toArgument(Int, SmallProjectionPath) // argument index, path
+  }
+  var result = EscapeDestination.notSet
+
+  mutating func visitUse(operand: Operand, path: EscapePath) -> UseResult {
+    if operand.instruction is ReturnInst {
+      // The argument escapes to the function return
+      if path.followStores {
+        // The escaping path must not introduce a followStores.
         return .abort
-      case let si as StoringInstruction:
-        // Don't allow store instructions because this allows the EscapeUtils to walk up
-        // an apply result with `followStores`.
-        if operand == si.destinationOperand {
-          return .abort
-        }
-      case let ca as CopyAddrInst:
-        // `copy_addr` is like a store.
-        if operand == ca.destinationOperand {
-          return .abort
-        }
-      default:
-        break
       }
-      return .continueWalk
+      switch result {
+        case .notSet:
+          result = .toReturn(path.projectionPath)
+        case .toReturn(let oldPath):
+          result = .toReturn(oldPath.merge(with: path.projectionPath))
+        case .toArgument:
+          return .abort
+      }
+      return .ignore
     }
-    
-    mutating func visitDef(def: Value, path: EscapePath) -> DefResult {
-      guard let arg = def as? FunctionArgument else {
-        return .continueWalkUp
-      }
-      if path.followStores { return .abort }
-      if arg == fromArgument && path.projectionPath.matches(pattern: fromPath) {
-        result = true
-        return .walkDown
-      }
+    if isOperandOfRecursiveCall(operand) {
+      return .ignore
+    }
+    return .continueWalk
+  }
+
+  mutating func visitDef(def: Value, path: EscapePath) -> DefResult {
+    guard let destArg = def as? FunctionArgument else {
+      return .continueWalkUp
+    }
+    // The argument escapes to another argument (e.g. an out or inout argument)
+    if path.followStores {
+      // The escaping path must not introduce a followStores.
       return .abort
     }
+    let argIdx = destArg.index
+    switch result {
+      case .notSet:
+        result = .toArgument(argIdx, path.projectionPath)
+      case .toArgument(let oldArgIdx, let oldPath) where oldArgIdx == argIdx:
+        result = .toArgument(argIdx, oldPath.merge(with: path.projectionPath))
+      default:
+        return .abort
+    }
+    return .walkDown
   }
-  let visitor = IsExclusiveReturnEscapeVisitor(fromArgument: fromArgument, fromPath: fromPath, toPath: toPath)
-  return returnInst.operand.at(toPath).visit(using: visitor, context) ?? false
+}
+
+/// Returns true if when walking up from the return instruction, the `fromArgument`
+/// is the one and only argument which is reached - with a matching `fromPath`.
+private struct IsExclusiveReturnEscapeVisitor : EscapeVisitorWithResult {
+  let argument: Argument
+  let argumentPath: SmallProjectionPath
+  let returnPath: SmallProjectionPath
+  var result = false
+
+  func isExclusiveEscape(returnInst: ReturnInst, _ context: FunctionPassContext) -> Bool {
+    return returnInst.operand.at(returnPath).visit(using: self, context) ?? false
+  }
+
+  mutating func visitUse(operand: Operand, path: EscapePath) -> UseResult {
+    switch operand.instruction {
+    case is ReturnInst:
+      if path.followStores { return .abort }
+      if path.projectionPath.matches(pattern: returnPath) {
+        return .ignore
+      }
+      return .abort
+    case let si as StoringInstruction:
+      // Don't allow store instructions because this allows the EscapeUtils to walk up
+      // an apply result with `followStores`.
+      if operand == si.destinationOperand {
+        return .abort
+      }
+    case let ca as CopyAddrInst:
+      // `copy_addr` is like a store.
+      if operand == ca.destinationOperand {
+        return .abort
+      }
+    default:
+      break
+    }
+    return .continueWalk
+  }
+
+  mutating func visitDef(def: Value, path: EscapePath) -> DefResult {
+    guard let arg = def as? FunctionArgument else {
+      return .continueWalkUp
+    }
+    if path.followStores { return .abort }
+    if arg == argument && path.projectionPath.matches(pattern: argumentPath) {
+      result = true
+      return .walkDown
+    }
+    return .abort
+  }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEscapeEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEscapeEffects.swift
@@ -160,7 +160,7 @@ func addArgEffects(_ arg: FunctionArgument, argPath ap: SmallProjectionPath,
   case .toArgument(let toArgIdx, let toPath):
     // Exclusive argument -> argument effects cannot appear because such an effect would
     // involve a store which is not permitted for exclusive escapes.
-    effect = EscapeEffects.ArgumentEffect(.escapingToArgument(toArgumentIndex: toArgIdx, toPath: toPath, isExclusive: false),
+    effect = EscapeEffects.ArgumentEffect(.escapingToArgument(toArgumentIndex: toArgIdx, toPath: toPath),
                                           argumentIndex: arg.index, pathPattern: argPath)
   }
   newEffects.append(effect)
@@ -176,8 +176,10 @@ private func getArgIndicesWithDefinedEscapingEffects(of function: Function) -> S
 
     argsWithDefinedEffects.insert(effect.argumentIndex)
     switch effect.kind {
-      case .notEscaping, .escapingToReturn:         break
-      case .escapingToArgument(let toArgIdx, _, _): argsWithDefinedEffects.insert(toArgIdx)
+    case .notEscaping, .escapingToReturn:
+      break
+    case .escapingToArgument(let toArgIdx, _):
+      argsWithDefinedEffects.insert(toArgIdx)
     }
   }
   return argsWithDefinedEffects

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -594,7 +594,7 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
     var matched = false
     for effect in effects.escapeEffects.arguments {
       switch effect.kind {
-      case .escapingToArgument(let toArgIdx, let toPath, _):
+      case .escapingToArgument(let toArgIdx, let toPath):
         // Note: exclusive argument -> argument effects cannot appear, so we don't need to handle them here.
         if effect.matches(calleeArgIdx, argPath.projectionPath) {
           guard let callerToIdx = apply.callerArgIndex(calleeArgIndex: toArgIdx) else {

--- a/test/SILGen/effectsattr.swift
+++ b/test/SILGen/effectsattr.swift
@@ -20,7 +20,7 @@
 @_effects(notEscaping t.**) @_silgen_name("func5") func func5<T>(_ t: T) { }
 
 //CHECK-LABEL: sil hidden [ossa] @func6
-//CHECK-NEXT:  [%1: escape! v**.c* => %0.v**]
+//CHECK-NEXT:  [%1: escape! v**.c* -> %0.v**]
 //CHECK-NEXT:  {{^[^[]}}
 @_effects(escaping t.value**.class* => return.value**) @_silgen_name("func6") func func6<T>(_ t: T) -> T { }
 

--- a/test/SILOptimizer/escape_effects.sil
+++ b/test/SILOptimizer/escape_effects.sil
@@ -197,7 +197,7 @@ bb0(%0 : @guaranteed $Z, %1 : @owned $Y):
 }
 
 sil [ossa] @self_arg_callee : $@convention(thin) (@inout Str) -> () {
-[%0: escape v** => %0.v**] 
+[%0: escape v** -> %0.v**] 
 }
 
 // CHECK-LABEL: sil [ossa] @test_self_arg_escape

--- a/test/SILOptimizer/escape_info.sil
+++ b/test/SILOptimizer/escape_info.sil
@@ -1011,11 +1011,11 @@ sil @closure3 : $@convention(thin) (@guaranteed Z) -> () {
 [%0: noescape **]
 }
 sil [ossa] @closure4 : $@convention(thin) (@guaranteed X, @guaranteed Y) -> () {
-[%0: escape => %1]
+[%0: escape -> %1]
 [%1: noescape]
 }
 sil [ossa] @closure5 : $@convention(thin) (@guaranteed Y, @guaranteed X) -> () {
-[%1: escape => %0, noescape]
+[%1: escape -> %0, noescape]
 }
 
 sil [ossa] @closure6 : $@convention(thin) (@guaranteed Y, @guaranteed Y) -> @owned Y {

--- a/test/SILOptimizer/specialize_reabstraction.sil
+++ b/test/SILOptimizer/specialize_reabstraction.sil
@@ -136,10 +136,10 @@ bb0(%0 : $Bool):
 }
 
 // CHECK-LABEL: sil shared @$s21arg_escapes_to_return4main1XC_Tg5
-// CHECK-NEXT:  [%0: escape => %r]
+// CHECK-NEXT:  [%0: escape -> %r]
 // CHECK-NEXT:  {{^[^[]}}
 sil @arg_escapes_to_return : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
-[%1: escape => %0] 
+[%1: escape -> %0] 
 bb0(%0 : $*T, %1 : $*T):
   copy_addr %1 to [init] %0 : $*T
   %4 = tuple ()
@@ -147,10 +147,10 @@ bb0(%0 : $*T, %1 : $*T):
 }
 
 // CHECK-LABEL: sil shared @$s015arg_escapes_to_A04main1XC_Tg5
-// CHECK-NEXT:  [%1: escape => %0]
+// CHECK-NEXT:  [%1: escape -> %0]
 // CHECK-NEXT:  {{^[^[]}}
 sil @arg_escapes_to_arg : $@convention(thin) <T> (@inout T, @in_guaranteed T) -> () {
-[%1: escape => %0] 
+[%1: escape -> %0] 
 bb0(%0 : $*T, %1 : $*T):
   copy_addr %1 to %0 : $*T
   %4 = tuple ()


### PR DESCRIPTION
* Effects: add some comments and add enum argument labels
* Effects: remove the `isExclusive` flag from the `escapingToArgument` effect
* ComputeEscapeEffects: mostly source-code restructuring to make the source easier to read