### PR TITLE
[Interop][SwiftToCxx] Support using indirect Swift enum in C++

### DIFF
--- a/docs/CppInteroperability/CppInteroperabilityStatus.md
+++ b/docs/CppInteroperability/CppInteroperabilityStatus.md
@@ -173,7 +173,7 @@ Swift functions can be called from C++, with some restrictions. See this table f
 | Creation                     | Yes                                                      |
 | Enums with associated values | POD, structs, enums and classes are supported            |
 | Enums with raw values        | Yes                                                      |
-| Indirect enums               | Partially; only extracting values from an indirect enum  |
+| Indirect enums               | Yes                                                      |
 
 **Class types**
 

--- a/docs/CppInteroperability/CppInteroperabilityStatus.md
+++ b/docs/CppInteroperability/CppInteroperabilityStatus.md
@@ -171,9 +171,9 @@ Swift functions can be called from C++, with some restrictions. See this table f
 | Resilient / opaque enums     | Yes                                                      |
 | Copy and destroy semantics   | Yes                                                      |
 | Creation                     | Yes                                                      |
-| Enums with associated values | Partially: only support structs and enums                |
-| Enums with raw values        | Yes                                                       |
-| Indirect enums               | No                                                       |
+| Enums with associated values | POD, structs, enums and classes are supported            |
+| Enums with raw values        | Yes                                                      |
+| Indirect enums               | Partially; only extracting values from an indirect enum  |
 
 **Class types**
 

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -453,6 +453,14 @@ void ClangValueTypePrinter::printValueTypeDecl(
         os << "    vwTable->initializeWithTake(destStorage, srcStorage, "
               "metadata._0);\n";
         os << "  }\n";
+        // Print out helper function for initializeWithCopy
+        os << "  static inline void initializeWithCopy(char * _Nonnull "
+              "destStorage, char * _Nonnull srcStorage) {\n";
+        ClangValueTypePrinter::printValueWitnessTableAccessAsVariable(
+            os, typeMetadataFuncName, typeMetadataFuncGenericParams);
+        os << "    vwTable->initializeWithCopy(destStorage, srcStorage, "
+              "metadata._0);\n";
+        os << "  }\n";
         os << "};\n";
       });
 

--- a/lib/PrintAsClang/_SwiftCxxInteroperability.h
+++ b/lib/PrintAsClang/_SwiftCxxInteroperability.h
@@ -76,6 +76,13 @@ extern "C" void *_Nonnull swift_retain(void *_Nonnull) noexcept;
 
 extern "C" void swift_release(void *_Nonnull) noexcept;
 
+struct AllocBoxReturnTy {
+  void *_Null_unspecified refCountedPtr;
+  void *_Null_unspecified opaquePtr;
+};
+
+extern "C" AllocBoxReturnTy swift_allocBox(void *_Nonnull) noexcept SWIFT_CALL;
+
 extern "C" void *_Nonnull swift_projectBox(void *_Nonnull) noexcept;
 
 SWIFT_INLINE_THUNK void *_Nonnull opaqueAlloc(size_t size,

--- a/lib/PrintAsClang/_SwiftCxxInteroperability.h
+++ b/lib/PrintAsClang/_SwiftCxxInteroperability.h
@@ -76,6 +76,8 @@ extern "C" void *_Nonnull swift_retain(void *_Nonnull) noexcept;
 
 extern "C" void swift_release(void *_Nonnull) noexcept;
 
+extern "C" void *_Nonnull swift_projectBox(void *_Nonnull) noexcept;
+
 SWIFT_INLINE_THUNK void *_Nonnull opaqueAlloc(size_t size,
                                               size_t align) noexcept {
 #if defined(_WIN32)

--- a/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.cpp
+++ b/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.cpp
@@ -50,6 +50,11 @@ int main() {
         extracted.setX(5678);
         assert(extracted.getX() == 5678);
         assert(c.getX() == 5678);
+
+        auto e2 = e;
+        assert(e2.isC());
+        assert(e2.getC().getX() == 5678);
+        assert(getRetainCount(c) == 4);
     }
 
     assert(getRetainCount(c) == 1);

--- a/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-associated-value-class-type-cxx.swift
@@ -16,8 +16,8 @@ public enum E {
 
 // CHECK:      SWIFT_INLINE_THUNK E E::_impl_c::operator()(const C& val) const {
 // CHECK-NEXT:   auto result = E::_make();
-// CHECK-NEXT:   auto op = swift::_impl::_impl_RefCountedClass::copyOpaquePointer(val);
-// CHECK-NEXT:   memcpy(result._getOpaquePointer(), &op, sizeof(op));
+// CHECK-NEXT:   auto src = swift::_impl::_impl_RefCountedClass::copyOpaquePointer(val);
+// CHECK-NEXT:   memcpy(result._getOpaquePointer(), &src, sizeof(src));
 // CHECK-NEXT:   result._destructiveInjectEnumTag(0);
 // CHECK-NEXT:   return result;
 // CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/enum-indirect-creation-from-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/enums/enum-indirect-creation-from-cxx-execution.cpp
@@ -1,0 +1,83 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/enum-indirect-creation-from-cxx.swift -typecheck -module-name Enums -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/enums.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-enums-execution.o
+// RUN: %target-interop-build-swift %S/enum-indirect-creation-from-cxx.swift -o %t/swift-enums-execution -Xlinker %t/swift-enums-execution.o -module-name Enums -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-enums-execution
+// RUN: %target-run %t/swift-enums-execution
+
+// RUN: %empty-directory(%t-evo)
+
+// RUN: %target-swift-frontend %S/enum-indirect-creation-from-cxx.swift -typecheck -module-name Enums -clang-header-expose-decls=has-expose-attr -enable-library-evolution -emit-clang-header-path %t-evo/enums.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t-evo -o %t-evo/swift-enums-execution.o
+// RUN: %target-interop-build-swift %S/enum-indirect-creation-from-cxx.swift -o %t-evo/swift-enums-execution -Xlinker %t-evo/swift-enums-execution.o -module-name Enums -enable-library-evolution -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t-evo/swift-enums-execution
+// RUN: %target-run %t-evo/swift-enums-execution
+
+// REQUIRES: executable_test
+
+#include <cassert>
+#include "enums.h"
+
+using namespace Enums;
+
+extern "C" size_t swift_retainCount(void * _Nonnull obj) noexcept;
+
+size_t getRetainCount(const C& obj) {
+  void *p = swift::_impl::_impl_RefCountedClass::getOpaquePointer(obj);
+  return swift_retainCount(p);
+}
+
+int main() {
+    {
+        auto e = IndirectEnum::empty();
+        assert(e.isEmpty());
+    }
+    {
+        auto e = IndirectEnum::ui64(1234);
+        assert(e.isUi64());
+        assert(e.getUi64() == 1234);
+    }
+    {
+        auto e = IndirectEnum::d(3.14159);
+        assert(e.isD());
+        assert(e.getD() == 3.14159);
+    }
+    {
+        auto e = IndirectEnum::s(S::init(5678));
+        assert(e.isS());
+        assert(e.getS().getX() == 5678);
+    }
+
+    auto c = C::init(9876);
+    assert(getRetainCount(c) == 1);
+    {
+        auto e1 = IndirectEnum::c(c);
+        assert(e1.isC());
+        assert(e1.getC().getX() == 9876);
+        assert(getRetainCount(c) == 2);
+
+        auto e2 = e1;
+        assert(e2.isC());
+        assert(e2.getC().getX() == 9876);
+        assert(getRetainCount(c) == 2);  // refCount of the box got +1, not the actual object
+
+        e2.getC().setX(1111);
+        assert(e2.getC().getX() == 1111);
+        assert(e1.getC().getX() == 1111);
+        assert(c.getX() == 1111);
+
+        auto e3 = IndirectEnum::ie(e2);
+        assert(e3.isIe());
+        assert(e3.getIe().isC());
+        assert(e3.getIe().getC().getX() == 1111);
+        assert(getRetainCount(c) == 2);
+    }
+    assert(getRetainCount(c) == 1);
+
+    return 0;
+}

--- a/test/Interop/SwiftToCxx/enums/enum-indirect-creation-from-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-indirect-creation-from-cxx.swift
@@ -1,0 +1,84 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/enums.h
+// RUN: %FileCheck %s < %t/enums.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
+
+@_expose(Cxx)
+public class C {
+    public var x: UInt64
+    public init(x: UInt64) { self.x = x }
+}
+
+@_expose(Cxx)
+public struct S {
+    public var x: UInt64
+    public init(x: UInt64) { self.x = x }
+}
+
+@_expose(Cxx)
+public indirect enum IndirectEnum {
+    case empty
+    case ui64(UInt64)
+    case d(Double)
+    case s(S)
+    case c(C)
+    case ie(IndirectEnum)
+}
+
+// CHECK:      SWIFT_INLINE_THUNK IndirectEnum IndirectEnum::_impl_ui64::operator()(uint64_t val) const {
+// CHECK-NEXT:   auto result = IndirectEnum::_make();
+// CHECK-NEXT:   auto metadata = swift::TypeMetadataTrait<uint64_t>::getTypeMetadata();
+// CHECK-NEXT:   auto allocBoxResult = swift::_impl::swift_allocBox(metadata);
+// CHECK-NEXT:   auto src = val;
+// CHECK-NEXT:   memcpy(allocBoxResult.opaquePtr, &src, sizeof(src));
+// CHECK-NEXT:   memcpy(result._getOpaquePointer(), &allocBoxResult.refCountedPtr, sizeof(allocBoxResult.refCountedPtr));
+// CHECK-NEXT:   result._destructiveInjectEnumTag(0);
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+
+// CHECK:      SWIFT_INLINE_THUNK IndirectEnum IndirectEnum::_impl_d::operator()(double val) const {
+// CHECK-NEXT:   auto result = IndirectEnum::_make();
+// CHECK-NEXT:   auto metadata = swift::TypeMetadataTrait<double>::getTypeMetadata();
+// CHECK-NEXT:   auto allocBoxResult = swift::_impl::swift_allocBox(metadata);
+// CHECK-NEXT:   auto src = val;
+// CHECK-NEXT:   memcpy(allocBoxResult.opaquePtr, &src, sizeof(src));
+// CHECK-NEXT:   memcpy(result._getOpaquePointer(), &allocBoxResult.refCountedPtr, sizeof(allocBoxResult.refCountedPtr));
+// CHECK-NEXT:   result._destructiveInjectEnumTag(1);
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+
+// CHECK:      SWIFT_INLINE_THUNK IndirectEnum IndirectEnum::_impl_s::operator()(const S& val) const {
+// CHECK-NEXT:   auto result = IndirectEnum::_make();
+// CHECK-NEXT:   auto metadata = swift::TypeMetadataTrait<S>::getTypeMetadata();
+// CHECK-NEXT:   auto allocBoxResult = swift::_impl::swift_allocBox(metadata);
+// CHECK-NEXT:   alignas(S) unsigned char buffer[sizeof(S)];
+// CHECK-NEXT:   auto *valCopy = new(buffer) S(val);
+// CHECK-NEXT:   swift::_impl::implClassFor<S>::type::initializeWithTake(static_cast<char * _Nonnull>(allocBoxResult.opaquePtr), swift::_impl::implClassFor<S>::type::getOpaquePointer(*valCopy));
+// CHECK-NEXT:   memcpy(result._getOpaquePointer(), &allocBoxResult.refCountedPtr, sizeof(allocBoxResult.refCountedPtr));
+// CHECK-NEXT:   result._destructiveInjectEnumTag(2);
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+
+// CHECK:      SWIFT_INLINE_THUNK IndirectEnum IndirectEnum::_impl_c::operator()(const C& val) const {
+// CHECK-NEXT:   auto result = IndirectEnum::_make();
+// CHECK-NEXT:   auto metadata = swift::TypeMetadataTrait<C>::getTypeMetadata();
+// CHECK-NEXT:   auto allocBoxResult = swift::_impl::swift_allocBox(metadata);
+// CHECK-NEXT:   auto src = swift::_impl::_impl_RefCountedClass::copyOpaquePointer(val);
+// CHECK-NEXT:   memcpy(allocBoxResult.opaquePtr, &src, sizeof(src));
+// CHECK-NEXT:   memcpy(result._getOpaquePointer(), &allocBoxResult.refCountedPtr, sizeof(allocBoxResult.refCountedPtr));
+// CHECK-NEXT:   result._destructiveInjectEnumTag(3);
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }
+
+// CHECK:      SWIFT_INLINE_THUNK IndirectEnum IndirectEnum::_impl_ie::operator()(const IndirectEnum& val) const {
+// CHECK-NEXT:   auto result = IndirectEnum::_make();
+// CHECK-NEXT:   auto metadata = swift::TypeMetadataTrait<IndirectEnum>::getTypeMetadata();
+// CHECK-NEXT:   auto allocBoxResult = swift::_impl::swift_allocBox(metadata);
+// CHECK-NEXT:   alignas(IndirectEnum) unsigned char buffer[sizeof(IndirectEnum)];
+// CHECK-NEXT:   auto *valCopy = new(buffer) IndirectEnum(val);
+// CHECK-NEXT:   swift::_impl::implClassFor<IndirectEnum>::type::initializeWithTake(static_cast<char * _Nonnull>(allocBoxResult.opaquePtr), swift::_impl::implClassFor<IndirectEnum>::type::getOpaquePointer(*valCopy));
+// CHECK-NEXT:   memcpy(result._getOpaquePointer(), &allocBoxResult.refCountedPtr, sizeof(allocBoxResult.refCountedPtr));
+// CHECK-NEXT:   result._destructiveInjectEnumTag(4);
+// CHECK-NEXT:   return result;
+// CHECK-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/enum-indirect-get-value-from-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/enums/enum-indirect-get-value-from-cxx-execution.cpp
@@ -1,0 +1,92 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/enum-indirect-get-value-from-cxx.swift -typecheck -module-name Enums -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/enums.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-enums-execution.o
+// RUN: %target-interop-build-swift %S/enum-indirect-get-value-from-cxx.swift -o %t/swift-enums-execution -Xlinker %t/swift-enums-execution.o -module-name Enums -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t/swift-enums-execution
+// RUN: %target-run %t/swift-enums-execution
+
+// RUN: %empty-directory(%t-evo)
+
+// RUN: %target-swift-frontend %S/enum-indirect-get-value-from-cxx.swift -typecheck -module-name Enums -clang-header-expose-decls=has-expose-attr -enable-library-evolution -emit-clang-header-path %t-evo/enums.h
+
+// RUN: %target-interop-build-clangxx -c %s -I %t-evo -o %t-evo/swift-enums-execution.o
+// RUN: %target-interop-build-swift %S/enum-indirect-get-value-from-cxx.swift -o %t-evo/swift-enums-execution -Xlinker %t-evo/swift-enums-execution.o -module-name Enums -enable-library-evolution -Xfrontend -entry-point-function-name -Xfrontend swiftMain
+
+// RUN: %target-codesign %t-evo/swift-enums-execution
+// RUN: %target-run %t-evo/swift-enums-execution
+
+// REQUIRES: executable_test
+
+#include <cassert>
+#include "enums.h"
+
+using namespace Enums;
+
+extern "C" size_t swift_retainCount(void * _Nonnull obj) noexcept;
+
+size_t getRetainCount(const C& obj) {
+  void *p = swift::_impl::_impl_RefCountedClass::getOpaquePointer(obj);
+  return swift_retainCount(p);
+}
+
+int main() {
+    {
+        auto e = getIndirectEnum(0);
+        assert(e.isEmpty());
+    }
+
+    {
+        auto e = getIndirectEnum(1);
+        assert(e.isUi64());
+        assert(e.getUi64() == 1234);
+    }
+
+    {
+        auto e = getIndirectEnum(2);
+        assert(e.isD());
+        assert(e.getD() == 3.14159);
+    }
+
+    {
+        auto e = getIndirectEnum(3);
+        assert(e.isS());
+        assert(e.getS().getX() == 5678);
+    }
+
+    auto c = C::init(9876);
+    assert(getRetainCount(c) == 1);
+    {
+        auto e1 = getIndirectEnumFromClass(c);
+        assert(e1.isC());
+        assert(getRetainCount(c) == 2);
+
+        auto e2 = e1;
+        assert(e2.isC());
+        assert(getRetainCount(c) == 2);  // refCount of the box got +1, not the actual object
+
+        auto e3 = getIndirectEnumFromIndirectEnum(e2);
+        assert(e3.isIe());
+        assert(e3.getIe().isC());
+        assert(getRetainCount(c) == 2);  // instead of actual object +1 refCount, we have 2 boxes now :)
+
+        {
+            auto extracted = e1.getC();
+            assert(extracted.getX() == 9876);
+            assert(getRetainCount(c) == 3);
+
+            extracted.setX(8765);
+            assert(c.getX() == 8765);
+            assert(e2.getC().getX() == 8765);
+            assert(e3.getIe().getC().getX() == 8765);
+
+            assert(getRetainCount(c) == 3);
+        }
+        assert(getRetainCount(c) == 2);
+    }
+    assert(c.getX() == 8765);
+    assert(getRetainCount(c) == 1);
+    return 0;
+}

--- a/test/Interop/SwiftToCxx/enums/enum-indirect-get-value-from-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-indirect-get-value-from-cxx.swift
@@ -24,7 +24,7 @@ public enum E {
     indirect case e(E)
 }
 
-// CHECK:       inline E E::getE() const {
+// CHECK:       SWIFT_INLINE_THUNK E E::getE() const {
 // CHECK-NEXT:    if (!isE()) abort();
 // CHECK-NEXT:    alignas(E) unsigned char buffer[sizeof(E)];
 // CHECK-NEXT:    auto *thisCopy = new(buffer) E(*this);
@@ -48,7 +48,7 @@ public indirect enum IndirectEnum {
     case ie(IndirectEnum)
 }
 
-// CHECK:       inline uint64_t IndirectEnum::getUi64() const {
+// CHECK:       SWIFT_INLINE_THUNK uint64_t IndirectEnum::getUi64() const {
 // CHECK-NEXT:    if (!isUi64()) abort();
 // CHECK-NEXT:    alignas(IndirectEnum) unsigned char buffer[sizeof(IndirectEnum)];
 // CHECK-NEXT:    auto *thisCopy = new(buffer) IndirectEnum(*this);
@@ -61,7 +61,7 @@ public indirect enum IndirectEnum {
 // CHECK-NEXT:    return result;
 // CHECK-NEXT:  }
 
-// CHECK:       inline double IndirectEnum::getD() const {
+// CHECK:       SWIFT_INLINE_THUNK double IndirectEnum::getD() const {
 // CHECK-NEXT:    if (!isD()) abort();
 // CHECK-NEXT:    alignas(IndirectEnum) unsigned char buffer[sizeof(IndirectEnum)];
 // CHECK-NEXT:    auto *thisCopy = new(buffer) IndirectEnum(*this);
@@ -74,7 +74,7 @@ public indirect enum IndirectEnum {
 // CHECK-NEXT:    return result;
 // CHECK-NEXT:  }
 
-// CHECK:       inline S IndirectEnum::getS() const {
+// CHECK:       SWIFT_INLINE_THUNK S IndirectEnum::getS() const {
 // CHECK-NEXT:    if (!isS()) abort();
 // CHECK-NEXT:    alignas(IndirectEnum) unsigned char buffer[sizeof(IndirectEnum)];
 // CHECK-NEXT:    auto *thisCopy = new(buffer) IndirectEnum(*this);
@@ -88,7 +88,7 @@ public indirect enum IndirectEnum {
 // CHECK-NEXT:    return toReturn;
 // CHECK-NEXT:  }
 
-// CHECK:       inline C IndirectEnum::getC() const {
+// CHECK:       SWIFT_INLINE_THUNK C IndirectEnum::getC() const {
 // CHECK-NEXT:    if (!isC()) abort();
 // CHECK-NEXT:    alignas(IndirectEnum) unsigned char buffer[sizeof(IndirectEnum)];
 // CHECK-NEXT:    auto *thisCopy = new(buffer) IndirectEnum(*this);
@@ -102,7 +102,7 @@ public indirect enum IndirectEnum {
 // CHECK-NEXT:    return toReturn;
 // CHECK-NEXT:  }
 
-// CHECK:       inline IndirectEnum IndirectEnum::getIe() const {
+// CHECK:       SWIFT_INLINE_THUNK IndirectEnum IndirectEnum::getIe() const {
 // CHECK-NEXT:    if (!isIe()) abort();
 // CHECK-NEXT:    alignas(IndirectEnum) unsigned char buffer[sizeof(IndirectEnum)];
 // CHECK-NEXT:    auto *thisCopy = new(buffer) IndirectEnum(*this);

--- a/test/Interop/SwiftToCxx/enums/enum-indirect-get-value-from-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/enum-indirect-get-value-from-cxx.swift
@@ -1,0 +1,141 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Enums -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/enums.h
+// RUN: %FileCheck %s < %t/enums.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/enums.h -Wno-unused-private-field -Wno-unused-function)
+
+@_expose(Cxx)
+public class C {
+    public var x: UInt64
+    public init(x: UInt64) { self.x = x }
+}
+
+@_expose(Cxx)
+public struct S {
+    public var x: UInt64
+    public init(x: UInt64) { self.x = x}
+}
+
+@_expose(Cxx)
+public enum E {
+    case empty
+    case ui64(UInt64)
+    case c(C)
+    indirect case e(E)
+}
+
+// CHECK:       inline E E::getE() const {
+// CHECK-NEXT:    if (!isE()) abort();
+// CHECK-NEXT:    alignas(E) unsigned char buffer[sizeof(E)];
+// CHECK-NEXT:    auto *thisCopy = new(buffer) E(*this);
+// CHECK-NEXT:    char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
+// CHECK-NEXT:    void ** _Nonnull refCountedBox = reinterpret_cast<void ** _Nonnull>(payloadFromDestruction);
+// CHECK-NEXT:    void * _Nonnull actualPayload = ::swift::_impl::swift_projectBox(*refCountedBox);
+// CHECK-NEXT:    auto toReturn = swift::_impl::implClassFor<E>::type::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:      swift::_impl::implClassFor<E>::type::initializeWithCopy(result, static_cast<char * _Nonnull>(actualPayload));
+// CHECK-NEXT:    });
+// CHECK-NEXT:    ::swift::_impl::swift_release(*refCountedBox);
+// CHECK-NEXT:    return toReturn;
+// CHECK-NEXT:  }
+
+@_expose(Cxx)
+public indirect enum IndirectEnum {
+    case empty
+    case ui64(UInt64)
+    case d(Double)
+    case s(S)
+    case c(C)
+    case ie(IndirectEnum)
+}
+
+// CHECK:       inline uint64_t IndirectEnum::getUi64() const {
+// CHECK-NEXT:    if (!isUi64()) abort();
+// CHECK-NEXT:    alignas(IndirectEnum) unsigned char buffer[sizeof(IndirectEnum)];
+// CHECK-NEXT:    auto *thisCopy = new(buffer) IndirectEnum(*this);
+// CHECK-NEXT:    char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
+// CHECK-NEXT:    void ** _Nonnull refCountedBox = reinterpret_cast<void ** _Nonnull>(payloadFromDestruction);
+// CHECK-NEXT:    void * _Nonnull actualPayload = ::swift::_impl::swift_projectBox(*refCountedBox);
+// CHECK-NEXT:    uint64_t result;
+// CHECK-NEXT:    memcpy(&result, actualPayload, sizeof(result));
+// CHECK-NEXT:    ::swift::_impl::swift_release(*refCountedBox);
+// CHECK-NEXT:    return result;
+// CHECK-NEXT:  }
+
+// CHECK:       inline double IndirectEnum::getD() const {
+// CHECK-NEXT:    if (!isD()) abort();
+// CHECK-NEXT:    alignas(IndirectEnum) unsigned char buffer[sizeof(IndirectEnum)];
+// CHECK-NEXT:    auto *thisCopy = new(buffer) IndirectEnum(*this);
+// CHECK-NEXT:    char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
+// CHECK-NEXT:    void ** _Nonnull refCountedBox = reinterpret_cast<void ** _Nonnull>(payloadFromDestruction);
+// CHECK-NEXT:    void * _Nonnull actualPayload = ::swift::_impl::swift_projectBox(*refCountedBox);
+// CHECK-NEXT:    double result;
+// CHECK-NEXT:    memcpy(&result, actualPayload, sizeof(result));
+// CHECK-NEXT:    ::swift::_impl::swift_release(*refCountedBox);
+// CHECK-NEXT:    return result;
+// CHECK-NEXT:  }
+
+// CHECK:       inline S IndirectEnum::getS() const {
+// CHECK-NEXT:    if (!isS()) abort();
+// CHECK-NEXT:    alignas(IndirectEnum) unsigned char buffer[sizeof(IndirectEnum)];
+// CHECK-NEXT:    auto *thisCopy = new(buffer) IndirectEnum(*this);
+// CHECK-NEXT:    char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
+// CHECK-NEXT:    void ** _Nonnull refCountedBox = reinterpret_cast<void ** _Nonnull>(payloadFromDestruction);
+// CHECK-NEXT:    void * _Nonnull actualPayload = ::swift::_impl::swift_projectBox(*refCountedBox);
+// CHECK-NEXT:    auto toReturn = swift::_impl::implClassFor<S>::type::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:      swift::_impl::implClassFor<S>::type::initializeWithCopy(result, static_cast<char * _Nonnull>(actualPayload));
+// CHECK-NEXT:    });
+// CHECK-NEXT:    ::swift::_impl::swift_release(*refCountedBox);
+// CHECK-NEXT:    return toReturn;
+// CHECK-NEXT:  }
+
+// CHECK:       inline C IndirectEnum::getC() const {
+// CHECK-NEXT:    if (!isC()) abort();
+// CHECK-NEXT:    alignas(IndirectEnum) unsigned char buffer[sizeof(IndirectEnum)];
+// CHECK-NEXT:    auto *thisCopy = new(buffer) IndirectEnum(*this);
+// CHECK-NEXT:    char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
+// CHECK-NEXT:    void ** _Nonnull refCountedBox = reinterpret_cast<void ** _Nonnull>(payloadFromDestruction);
+// CHECK-NEXT:    void * _Nonnull actualPayload = ::swift::_impl::swift_projectBox(*refCountedBox);
+// CHECK-NEXT:    void * _Nonnull actualObject = *reinterpret_cast<void ** _Nonnull>(actualPayload);
+// CHECK-NEXT:    ::swift::_impl::swift_retain(actualObject);
+// CHECK-NEXT:    auto toReturn = swift::_impl::implClassFor<C>::type::makeRetained(actualObject);
+// CHECK-NEXT:    ::swift::_impl::swift_release(*refCountedBox);
+// CHECK-NEXT:    return toReturn;
+// CHECK-NEXT:  }
+
+// CHECK:       inline IndirectEnum IndirectEnum::getIe() const {
+// CHECK-NEXT:    if (!isIe()) abort();
+// CHECK-NEXT:    alignas(IndirectEnum) unsigned char buffer[sizeof(IndirectEnum)];
+// CHECK-NEXT:    auto *thisCopy = new(buffer) IndirectEnum(*this);
+// CHECK-NEXT:    char * _Nonnull payloadFromDestruction = thisCopy->_destructiveProjectEnumData();
+// CHECK-NEXT:    void ** _Nonnull refCountedBox = reinterpret_cast<void ** _Nonnull>(payloadFromDestruction);
+// CHECK-NEXT:    void * _Nonnull actualPayload = ::swift::_impl::swift_projectBox(*refCountedBox);
+// CHECK-NEXT:    auto toReturn = swift::_impl::implClassFor<IndirectEnum>::type::returnNewValue([&](char * _Nonnull result) {
+// CHECK-NEXT:      swift::_impl::implClassFor<IndirectEnum>::type::initializeWithCopy(result, static_cast<char * _Nonnull>(actualPayload));
+// CHECK-NEXT:    });
+// CHECK-NEXT:    ::swift::_impl::swift_release(*refCountedBox);
+// CHECK-NEXT:    return toReturn;
+// CHECK-NEXT:  }
+
+@_expose(Cxx)
+public func getIndirectEnum(_ x: Int) -> IndirectEnum {
+    switch x {
+    case 1:
+        return .ui64(1234)
+    case 2:
+        return .d(3.14159)
+    case 3:
+        return .s(S(x: 5678))
+    default:
+        return .empty
+    }
+}
+
+@_expose(Cxx)
+public func getIndirectEnumFromClass(_ c: C) -> IndirectEnum {
+    return .c(c)
+}
+
+@_expose(Cxx)
+public func getIndirectEnumFromIndirectEnum(_ ie: IndirectEnum) -> IndirectEnum {
+    return .ie(ie)
+}

--- a/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/enums/resilient-enum-in-cxx.swift
@@ -85,13 +85,15 @@ public enum Empty {
 // CHECK-NEXT:    }
 // CHECK:         SWIFT_INLINE_THUNK Foo Foo::_impl_a::operator()(double val) const {
 // CHECK-NEXT:      auto result = Foo::_make();
-// CHECK-NEXT:      memcpy(result._getOpaquePointer(), &val, sizeof(val));
+// CHECK-NEXT:      auto src = val;
+// CHECK-NEXT:      memcpy(result._getOpaquePointer(), &src, sizeof(src));
 // CHECK-NEXT:      result._destructiveInjectEnumTag(_impl::$s5Enums3FooO1ayACSdcACmFWC);
 // CHECK-NEXT:      return result;
 // CHECK-NEXT:    }
 // NEW_CASE:      SWIFT_INLINE_THUNK Foo Foo::_impl_b::operator()(swift::Int val) const {
 // NEW_CASE-NEXT:   auto result = Foo::_make();
-// NEW_CASE-NEXT:   memcpy(result._getOpaquePointer(), &val, sizeof(val));
+// NEW_CASE-NEXT:   auto src = val;
+// NEW_CASE-NEXT:   memcpy(result._getOpaquePointer(), &src, sizeof(src));
 // NEW_CASE-NEXT:   result._destructiveInjectEnumTag(_impl::$s5Enums3FooO1byACSicACmFWC);
 // NEW_CASE-NEXT:   return result;
 // NEW_CASE-NEXT: }

--- a/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
+++ b/test/Interop/SwiftToCxx/enums/swift-enum-implementation.swift
@@ -169,7 +169,8 @@ public struct S {
 // CHECK:      namespace Enums __attribute__((swift_private)) SWIFT_SYMBOL_MODULE("Enums") {
 // CHECK:        SWIFT_INLINE_THUNK E E::_impl_x::operator()(double val) const {
 // CHECK-NEXT:     auto result = E::_make();
-// CHECK-NEXT:     memcpy(result._getOpaquePointer(), &val, sizeof(val));
+// CHECK-NEXT:     auto src = val;
+// CHECK-NEXT:     memcpy(result._getOpaquePointer(), &src, sizeof(src));
 // CHECK-NEXT:     result._destructiveInjectEnumTag(0);
 // CHECK-NEXT:     return result;
 // CHECK-NEXT:   }
@@ -187,7 +188,8 @@ public struct S {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   SWIFT_INLINE_THUNK E E::_impl_y::operator()(void const * _Nullable val) const {
 // CHECK-NEXT:     auto result = E::_make();
-// CHECK-NEXT:     memcpy(result._getOpaquePointer(), &val, sizeof(val));
+// CHECK-NEXT:     auto src = val;
+// CHECK-NEXT:     memcpy(result._getOpaquePointer(), &src, sizeof(src));
 // CHECK-NEXT:     result._destructiveInjectEnumTag(1);
 // CHECK-NEXT:     return result;
 // CHECK-NEXT:   }
@@ -225,7 +227,8 @@ public struct S {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   SWIFT_INLINE_THUNK E E::_impl_w::operator()(swift::Int val) const {
 // CHECK-NEXT:     auto result = E::_make();
-// CHECK-NEXT:     memcpy(result._getOpaquePointer(), &val, sizeof(val));
+// CHECK-NEXT:     auto src = val;
+// CHECK-NEXT:     memcpy(result._getOpaquePointer(), &src, sizeof(src));
 // CHECK-NEXT:     result._destructiveInjectEnumTag(3);
 // CHECK-NEXT:     return result;
 // CHECK-NEXT:   }
@@ -243,7 +246,8 @@ public struct S {
 // CHECK-NEXT:   }
 // CHECK-NEXT:   SWIFT_INLINE_THUNK E E::_impl_auto::operator()(void * _Nonnull val) const {
 // CHECK-NEXT:     auto result = E::_make();
-// CHECK-NEXT:     memcpy(result._getOpaquePointer(), &val, sizeof(val));
+// CHECK-NEXT:     auto src = val;
+// CHECK-NEXT:     memcpy(result._getOpaquePointer(), &src, sizeof(src));
 // CHECK-NEXT:     result._destructiveInjectEnumTag(4);
 // CHECK-NEXT:     return result;
 // CHECK-NEXT:   }

--- a/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/structs/swift-struct-in-cxx.swift
@@ -71,6 +71,16 @@
 // CHECK-NEXT: #endif
 // CHECK-NEXT:   vwTable->initializeWithTake(destStorage, srcStorage, metadata._0);
 // CHECK-NEXT: }
+// CHECK-NEXT: static inline void initializeWithCopy(char * _Nonnull destStorage, char * _Nonnull srcStorage) {
+// CHECK-NEXT:   auto metadata = _impl::$s7Structs18StructWithIntFieldVMa(0);
+// CHECK-NEXT:   auto *vwTableAddr = reinterpret_cast<swift::_impl::ValueWitnessTable **>(metadata._0) - 1;
+// CHECK-NEXT: #ifdef __arm64e__
+// CHECK-NEXT:   auto *vwTable = reinterpret_cast<swift::_impl::ValueWitnessTable *>(ptrauth_auth_data(reinterpret_cast<void *>(*vwTableAddr), ptrauth_key_process_independent_data, ptrauth_blend_discriminator(vwTableAddr, 11839)));
+// CHECK-NEXT: #else
+// CHECK-NEXT:   auto *vwTable = *vwTableAddr;
+// CHECK-NEXT: #endif
+// CHECK-NEXT:   vwTable->initializeWithCopy(destStorage, srcStorage, metadata._0);
+// CHECK-NEXT: }
 // CHECK-NEXT: };
 // CHECK-EMPTY:
 // CHECK-NEXT: }


### PR DESCRIPTION
This pull request adds support of creating indirect enums from C++ as well as extracting associated values from indirect enums in C++.