### PR TITLE
Frontend: Add a rebuild diagnostic explaining why the adjacent swiftmodule was ignored

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -431,6 +431,11 @@ REMARK(rebuilding_module_from_interface,none,
 NOTE(sdk_version_pbm_version,none,
      "SDK build version is '%0'; prebuilt modules were "
      "built using SDK build version: '%1'", (StringRef, StringRef))
+NOTE(compiled_module_ignored_reason,none,
+     "compiled module '%0' was ignored because %select{%error"
+     "|it belongs to a framework in the SDK"
+     "|loading from module interfaces is prefered}1",
+     (StringRef, unsigned))
 NOTE(out_of_date_module_here,none,
      "%select{compiled|cached|forwarding|prebuilt}0 module is out of date: '%1'",
      (unsigned, StringRef))

--- a/test/ModuleInterface/ignore-adjacent-swiftmodules.swift
+++ b/test/ModuleInterface/ignore-adjacent-swiftmodules.swift
@@ -29,6 +29,7 @@
 // RUN:   -verify -Rmodule-interface-rebuild
 
 import PublicSwift // expected-remark {{rebuilding module 'PublicSwift' from interface}}
+// expected-note @-1 {{was ignored because it belongs to a framework in the SDK}}
 
 // The private adjacent module under PrivateFrameworks should still be tried first, and then rebuilt.
 import PrivateSwift


### PR DESCRIPTION
In https://github.com/apple/swift/pull/42486 new behavior was introduced to ignore adjacent .swiftmodule files in the SDK. This behavior has caught a few people off guard so it seems like there should be diagnostics clarifying why a rebuild is occurring in this scenario.

Resolves rdar://105477473