### PR TITLE
Swift Optimizer: fix a crash when simplifying same-metatype comparisons of function types

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
@@ -56,7 +56,7 @@ private extension BuiltinInst {
     let lhs = operands[0].value
     let rhs = operands[1].value
 
-    guard let equal = typesOfValuesAreEqual(lhs, rhs) else {
+    guard let equal = typesOfValuesAreEqual(lhs, rhs, in: parentFunction) else {
       return
     }
     let builder = Builder(before: self, context)
@@ -66,7 +66,7 @@ private extension BuiltinInst {
   }
 }
 
-private func typesOfValuesAreEqual(_ lhs: Value, _ rhs: Value) -> Bool? {
+private func typesOfValuesAreEqual(_ lhs: Value, _ rhs: Value, in function: Function) -> Bool? {
   if lhs == rhs {
     return true
   }
@@ -76,8 +76,8 @@ private func typesOfValuesAreEqual(_ lhs: Value, _ rhs: Value) -> Bool? {
     return nil
   }
 
-  let lhsTy = lhsExistential.operand.type.instanceTypeOfMetatype
-  let rhsTy = rhsExistential.operand.type.instanceTypeOfMetatype
+  let lhsTy = lhsExistential.operand.type.instanceTypeOfMetatype(in: function)
+  let rhsTy = rhsExistential.operand.type.instanceTypeOfMetatype(in: function)
 
   // Do we know the exact types? This is not the case e.g. if a type is passed as metatype
   // to the function.

--- a/SwiftCompilerSources/Sources/SIL/Type.swift
+++ b/SwiftCompilerSources/Sources/SIL/Type.swift
@@ -53,7 +53,9 @@ public struct Type : CustomStringConvertible, NoReflectionChildren {
     NominalFieldsArray(type: self, function: function)
   }
 
-  public var instanceTypeOfMetatype: Type { SILType_instanceTypeOfMetatype(bridged).type }
+  public func instanceTypeOfMetatype(in function: Function) -> Type {
+    SILType_instanceTypeOfMetatype(bridged, function.bridged).type
+  }
 
   public var isCalleeConsumedFunction: Bool { SILType_isCalleeConsumedFunction(bridged) }
   

--- a/include/swift/SIL/SILBridging.h
+++ b/include/swift/SIL/SILBridging.h
@@ -328,7 +328,7 @@ SwiftInt SILType_isTuple(BridgedType type);
 SwiftInt SILType_isEnum(BridgedType type);
 bool SILType_isFunction(BridgedType type);
 bool SILType_isMetatype(BridgedType type);
-BridgedType SILType_instanceTypeOfMetatype(BridgedType type);
+BridgedType SILType_instanceTypeOfMetatype(BridgedType type, BridgedFunction function);
 BridgedDecl SILType_getNominal(BridgedType type);
 bool SILType_isOrContainsObjectiveCClass(BridgedType type);
 bool SILType_isCalleeConsumedFunction(BridgedType type);

--- a/lib/SIL/Utils/SILBridging.cpp
+++ b/lib/SIL/Utils/SILBridging.cpp
@@ -545,10 +545,12 @@ bool SILType_isMetatype(BridgedType type) {
   return castToSILType(type).is<MetatypeType>();
 }
 
-BridgedType SILType_instanceTypeOfMetatype(BridgedType type) {
+BridgedType SILType_instanceTypeOfMetatype(BridgedType type, BridgedFunction function) {
   auto metaType = castToSILType(type).castTo<MetatypeType>();
-  SILType instanceTy = SILType::getPrimitiveObjectType(metaType.getInstanceType());
-  return {instanceTy.getOpaqueValue()};
+  CanType instanceTy = metaType.getInstanceType();
+  SILFunction *f = castToFunction(function);
+  auto &tl = f->getModule().Types.getTypeLowering(instanceTy, TypeExpansionContext(*f));
+  return {tl.getLoweredType().getOpaqueValue()};
 }
 
 BridgedDecl SILType_getNominal(BridgedType type) {

--- a/test/SILOptimizer/simplify_builtin.sil
+++ b/test/SILOptimizer/simplify_builtin.sil
@@ -220,3 +220,30 @@ bb0:
   return %4 : $Builtin.Int1
 }
 
+// CHECK-LABEL: sil @same_function_metatype
+// CHECK:         [[R:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:    return [[R]]
+// CHECK:       } // end sil function 'same_function_metatype'
+sil @same_function_metatype : $@convention(thin) () -> Builtin.Int1 {
+bb0:
+  %0 = metatype $@thick ((Int) -> Bool).Type
+  %1 = metatype $@thick ((Int) -> Bool).Type
+  %2 = init_existential_metatype %0 : $@thick ((Int) -> Bool).Type, $@thick Any.Type
+  %3 = init_existential_metatype %1 : $@thick ((Int) -> Bool).Type, $@thick Any.Type
+  %4 = builtin "is_same_metatype"(%2 : $@thick Any.Type, %3 : $@thick Any.Type) : $Builtin.Int1
+  return %4 : $Builtin.Int1
+}
+
+// CHECK-LABEL: sil @different_function_metatype
+// CHECK:         [[R:%.*]] = integer_literal $Builtin.Int1, 0
+// CHECK-NEXT:    return [[R]]
+// CHECK:       } // end sil function 'different_function_metatype'
+sil @different_function_metatype : $@convention(thin) () -> Builtin.Int1 {
+bb0:
+  %0 = metatype $@thick ((Int) -> Bool).Type
+  %1 = metatype $@thick ((Float) -> Bool).Type
+  %2 = init_existential_metatype %0 : $@thick ((Int) -> Bool).Type, $@thick Any.Type
+  %3 = init_existential_metatype %1 : $@thick ((Float) -> Bool).Type, $@thick Any.Type
+  %4 = builtin "is_same_metatype"(%2 : $@thick Any.Type, %3 : $@thick Any.Type) : $Builtin.Int1
+  return %4 : $Builtin.Int1
+}


### PR DESCRIPTION
The instance type of a metatype instruction is not necessarily a legal lowered SIL Type, e.g. a FunctionType and not a SILFunctionType.

rdar://105502403