### PR TITLE
[Option] Add compiler option to specify executable plugins

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -234,6 +234,10 @@ private:
   /// Compiler plugin library search paths.
   std::vector<std::string> CompilerPluginLibraryPaths;
 
+  /// Compiler plugin executable paths and providing module names.
+  /// Format: '<path>#<module names>'
+  std::vector<std::string> CompilerPluginExecutablePaths;
+
   /// Add a single import search path. Must only be called from
   /// \c ASTContext::addSearchPath.
   void addImportSearchPath(StringRef Path, llvm::vfs::FileSystem *FS) {
@@ -322,6 +326,16 @@ public:
 
   ArrayRef<std::string> getCompilerPluginLibraryPaths() const {
     return CompilerPluginLibraryPaths;
+  }
+
+  void setCompilerPluginExecutablePaths(
+      std::vector<std::string> NewCompilerPluginExecutablePaths) {
+    CompilerPluginExecutablePaths = NewCompilerPluginExecutablePaths;
+    Lookup.searchPathsDidChange();
+  }
+
+  ArrayRef<std::string> getCompilerPluginExecutablePaths() const {
+    return CompilerPluginExecutablePaths;
   }
 
   /// Path(s) to virtual filesystem overlay YAML files.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1753,4 +1753,11 @@ def load_plugin_library:
            "macros">,
   MetaVarName<"<path>">;
 
+def load_plugin_executable:
+  Separate<["-"], "load-plugin-executable">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
+  HelpText<"Path to an executable compiler plugins and providing module names "
+           "such as macros">,
+  MetaVarName<"<path>#<module-names>">;
+
 include "FrontendOptions.td"

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -306,6 +306,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_enable_bare_slash_regex);
   inputArgs.AddLastArg(arguments, options::OPT_enable_experimental_cxx_interop);
   inputArgs.AddLastArg(arguments, options::OPT_load_plugin_library);
+  inputArgs.AddLastArg(arguments, options::OPT_load_plugin_executable);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1474,6 +1474,15 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
   }
   Opts.setCompilerPluginLibraryPaths(CompilerPluginLibraryPaths);
 
+  std::vector<std::string> CompilerPluginExecutablePaths(
+      Opts.getCompilerPluginExecutablePaths());
+  for (const Arg *A : Args.filtered(OPT_load_plugin_executable)) {
+    // NOTE: The value has '#<module names>' after the path.
+    // But resolveSearchPath() works as long as the value starts with a path.
+    CompilerPluginExecutablePaths.push_back(resolveSearchPath(A->getValue()));
+  }
+  Opts.setCompilerPluginExecutablePaths(CompilerPluginExecutablePaths);
+
   return false;
 }
 


### PR DESCRIPTION
Add a compiler option `-load-plugin-executable <path>#<module names>`. Where `<path>` is a path to a plugin executable, `<module names>` is a comma-separated list of module names the plugin provides.

Nothing is using it at this point. Actual plugin infratructure are introduced in follow-up commits
