### PR TITLE
Separate parsing out Swift and Clang modules from the explicit modulemap

### DIFF
--- a/include/swift/Serialization/ModuleDependencyScanner.h
+++ b/include/swift/Serialization/ModuleDependencyScanner.h
@@ -84,8 +84,10 @@ namespace swift {
       /// Scan the given placeholder module map
       void parsePlaceholderModuleMap(StringRef fileName) {
         ExplicitModuleMapParser parser(Allocator);
+        llvm::StringMap<ExplicitClangModuleInputInfo> ClangDependencyModuleMap;
         auto result =
-          parser.parseSwiftExplicitModuleMap(fileName, PlaceholderDependencyModuleMap);
+          parser.parseSwiftExplicitModuleMap(fileName, PlaceholderDependencyModuleMap,
+                                             ClangDependencyModuleMap);
         if (result == std::errc::invalid_argument) {
           Ctx.Diags.diagnose(SourceLoc(),
                              diag::placeholder_dependency_module_map_corrupted,
@@ -98,7 +100,7 @@ namespace swift {
         }
       }
 
-      llvm::StringMap<ExplicitModuleInfo> PlaceholderDependencyModuleMap;
+      llvm::StringMap<ExplicitSwiftModuleInputInfo> PlaceholderDependencyModuleMap;
       llvm::BumpPtrAllocator Allocator;
 
     public:

--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -1859,13 +1859,15 @@ InterfaceSubContextDelegateImpl::runInSubCompilerInstance(StringRef moduleName,
 struct ExplicitSwiftModuleLoader::Implementation {
   ASTContext &Ctx;
   llvm::BumpPtrAllocator Allocator;
-  llvm::StringMap<ExplicitModuleInfo> ExplicitModuleMap;
+  llvm::StringMap<ExplicitSwiftModuleInputInfo> ExplicitModuleMap;
   Implementation(ASTContext &Ctx) : Ctx(Ctx) {}
 
   void parseSwiftExplicitModuleMap(StringRef fileName) {
     ExplicitModuleMapParser parser(Allocator);
+    llvm::StringMap<ExplicitClangModuleInputInfo> ExplicitClangModuleMap;
     auto result =
-        parser.parseSwiftExplicitModuleMap(fileName, ExplicitModuleMap);
+        parser.parseSwiftExplicitModuleMap(fileName, ExplicitModuleMap,
+                                           ExplicitClangModuleMap);
     if (result == std::errc::invalid_argument)
       Ctx.Diags.diagnose(SourceLoc(), diag::explicit_swift_module_map_corrupted,
                          fileName);
@@ -1877,8 +1879,8 @@ struct ExplicitSwiftModuleLoader::Implementation {
     // we've seen so that we don't generate duplicate flags.
     std::set<std::string> moduleMapsSeen;
     std::vector<std::string> &extraClangArgs = Ctx.ClangImporterOpts.ExtraArgs;
-    for (auto &entry : ExplicitModuleMap) {
-      const auto &moduleMapPath = entry.getValue().clangModuleMapPath;
+    for (auto &entry : ExplicitClangModuleMap) {
+      const auto &moduleMapPath = entry.getValue().moduleMapPath;
       if (!moduleMapPath.empty() &&
           moduleMapsSeen.find(moduleMapPath) == moduleMapsSeen.end()) {
         moduleMapsSeen.insert(moduleMapPath);
@@ -1886,7 +1888,7 @@ struct ExplicitSwiftModuleLoader::Implementation {
             (Twine("-fmodule-map-file=") + moduleMapPath).str());
       }
 
-      const auto &modulePath = entry.getValue().clangModulePath;
+      const auto &modulePath = entry.getValue().modulePath;
       if (!modulePath.empty()) {
         extraClangArgs.push_back(
             (Twine("-fmodule-file=") + entry.getKey() + "=" + modulePath)
@@ -1899,8 +1901,7 @@ struct ExplicitSwiftModuleLoader::Implementation {
       const std::vector<std::pair<std::string, std::string>>
           &commandLineExplicitInputs) {
     for (const auto &moduleInput : commandLineExplicitInputs) {
-      ExplicitModuleInfo entry;
-      entry.modulePath = moduleInput.second;
+      ExplicitSwiftModuleInputInfo entry(moduleInput.second, {}, {});
       ExplicitModuleMap.try_emplace(moduleInput.first, std::move(entry));
     }
   }
@@ -1938,16 +1939,6 @@ bool ExplicitSwiftModuleLoader::findModule(
     return false;
   }
   auto &moduleInfo = it->getValue();
-
-  // If this is only a Clang module with no paired Swift module, return false
-  // now so that we don't emit diagnostics about it being missing. This gives
-  // ClangImporter an opportunity to import it.
-  bool hasClangModule = !moduleInfo.clangModuleMapPath.empty() ||
-                        !moduleInfo.clangModulePath.empty();
-  bool hasSwiftModule = !moduleInfo.modulePath.empty();
-  if (hasClangModule && !hasSwiftModule) {
-    return false;
-  }
 
   // Set IsFramework bit according to the moduleInfo
   IsFramework = moduleInfo.isFramework;
@@ -1990,14 +1981,14 @@ bool ExplicitSwiftModuleLoader::findModule(
   *ModuleBuffer = std::move(moduleBuf.get());
 
   // Open .swiftdoc file
-  if (!moduleInfo.moduleDocPath.empty()) {
-    auto moduleDocBuf = fs.getBufferForFile(moduleInfo.moduleDocPath);
+  if (moduleInfo.moduleDocPath.has_value()) {
+    auto moduleDocBuf = fs.getBufferForFile(moduleInfo.moduleDocPath.value());
     if (moduleBuf)
       *ModuleDocBuffer = std::move(moduleDocBuf.get());
   }
   // Open .swiftsourceinfo file
-  if (!moduleInfo.moduleSourceInfoPath.empty()) {
-    auto moduleSourceInfoBuf = fs.getBufferForFile(moduleInfo.moduleSourceInfoPath);
+  if (moduleInfo.moduleSourceInfoPath.has_value()) {
+    auto moduleSourceInfoBuf = fs.getBufferForFile(moduleInfo.moduleSourceInfoPath.value());
     if (moduleSourceInfoBuf)
       *ModuleSourceInfoBuffer = std::move(moduleSourceInfoBuf.get());
   }

--- a/lib/Serialization/ModuleDependencyScanner.cpp
+++ b/lib/Serialization/ModuleDependencyScanner.cpp
@@ -83,8 +83,11 @@ bool PlaceholderSwiftModuleScanner::findModule(
   }
   auto &moduleInfo = it->getValue();
   auto dependencies = ModuleDependencyInfo::forPlaceholderSwiftModuleStub(
-      moduleInfo.modulePath, moduleInfo.moduleDocPath,
-      moduleInfo.moduleSourceInfoPath);
+      moduleInfo.modulePath,
+      moduleInfo.moduleDocPath.has_value() ?
+            moduleInfo.moduleDocPath.value() : "",
+      moduleInfo.moduleSourceInfoPath.has_value() ?
+            moduleInfo.moduleSourceInfoPath.value() : "");
   this->dependencies = std::move(dependencies);
   return true;
 }

--- a/test/ScanDependencies/explicit-module-map-clang-and-swift.swift
+++ b/test/ScanDependencies/explicit-module-map-clang-and-swift.swift
@@ -3,6 +3,7 @@
 // RUN: mkdir -p %t/inputs
 // RUN: echo "public func anotherFuncA() {}" > %t/A.swift
 // RUN: %target-swift-frontend -emit-module -emit-module-path %t/inputs/A.swiftmodule -emit-module-doc-path %t/inputs/A.swiftdoc -emit-module-source-info -emit-module-source-info-path %t/inputs/A.swiftsourceinfo -import-underlying-module -I%S/Inputs/CHeaders -module-cache-path %t.module-cache %t/A.swift -module-name A
+// RUN: %target-swift-emit-pcm -module-name A -o %t/inputs/A.pcm %S/Inputs/CHeaders/module.modulemap
 
 // RUN: echo "[{" > %/t/inputs/map.json
 // RUN: echo "\"moduleName\": \"A\"," >> %/t/inputs/map.json
@@ -10,6 +11,10 @@
 // RUN: echo "\"docPath\": \"%/t/inputs/A.swiftdoc\"," >> %/t/inputs/map.json
 // RUN: echo "\"sourceInfoPath\": \"%/t/inputs/A.swiftsourceinfo\"," >> %/t/inputs/map.json
 // RUN: echo "\"isFramework\": false," >> %/t/inputs/map.json
+// RUN: echo "}," >> %/t/inputs/map.json
+// RUN: echo "{" >> %/t/inputs/map.json
+// RUN: echo "\"moduleName\": \"A\"," >> %/t/inputs/map.json
+// RUN: echo "\"clangModulePath\": \"%/t/inputs/A.pcm\"," >> %/t/inputs/map.json
 // RUN: echo "\"clangModuleMapPath\": \"%/S/Inputs/CHeaders/module.modulemap\"" >> %/t/inputs/map.json
 // RUN: echo "}," >> %/t/inputs/map.json
 // RUN: echo "{" >> %/t/inputs/map.json
@@ -33,7 +38,9 @@
 // RUN: echo "\"isFramework\": false" >> %/t/inputs/map.json
 // RUN: echo "}]" >> %/t/inputs/map.json
 
-// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Foo.swiftmodule -module-cache-path %t.module-cache -explicit-swift-module-map-file %t/inputs/map.json %s
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/Foo.swiftmodule -disable-implicit-swift-modules -module-cache-path %t.module-cache -explicit-swift-module-map-file %t/inputs/map.json -Rmodule-loading -Xcc -Rmodule-import %s 2>&1 | %FileCheck %s
+
+// CHECK: <unknown>:0: remark: importing module 'A' from {{.*}}{{/|\\}}explicit-module-map-clang-and-swift.swift.tmp{{/|\\}}inputs{{/|\\}}A.pcm'
 
 import A
 


### PR DESCRIPTION
Since https://github.com/apple/swift/pull/63178 added support for Clang modules in the explicit module map, it used the convention of specifying artifacts of a Swift module with a given name and a Clang module with the same name under the same entry. This change separates an individual entry to represent an individual module, even if they have the same name (but one is Swift and one is Clang).

The current parsing logic just overwrites the corresponding entry module in a hashmap so we always only preserved the module that comes last, with the same name. This change separates the parsing of the modulemap JSON file to produce a separate Swift module map and Clang module map. The Swift one is used by the `ExplicitSwiftModuleLoader`, as before, and the Clang one is only used to populate the ClangArgs with the requried `-fmodule-...` flags and discarded.
