### PR TITLE
[Frontend] Relaxed flag combination check.

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1809,16 +1809,6 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     return true;
   }
 
-  if (Args.hasArg(OPT_enable_experimental_move_only) &&
-      !enableLexicalLifetimesFlag.value_or(true)) {
-    // Error if move-only is enabled and lexical lifetimes--on which it
-    // depends--has been disabled.
-    Diags.diagnose(SourceLoc(), diag::error_invalid_arg_combination,
-                   "enable-experimental-move-only",
-                   "enable-lexical-lifetimes=false");
-    return true;
-  }
-
   // Unless overridden below, enabling copy propagation means enabling lexical
   // lifetimes.
   if (Opts.CopyPropagation == CopyPropagationOption::On) {


### PR DESCRIPTION
Previously, combining `-enable-lexical-lifetimes=false` with `-enable-experimental-move-only` resulted in an error.  But this is a valid combination: the former sets the `LexicalLifetimes` option to `DiagnosticMarkersOnly`, which is what `-enable-experimental-move-only` relies on.