### PR TITLE
AST: Print the custom attributes attached to `AttributedTypeRepr`

### DIFF
--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -218,6 +218,15 @@ void AttributedTypeRepr::printAttrs(ASTPrinter &Printer,
     Printer.printSimpleAttr("@autoclosure") << " ";
   if (hasAttr(TAK_escaping))
     Printer.printSimpleAttr("@escaping") << " ";
+
+  for (auto customAttr : Attrs.getCustomAttrs()) {
+    Printer.callPrintStructurePre(PrintStructureKind::BuiltinAttribute);
+    Printer << "@";
+    customAttr->getTypeRepr()->print(Printer, Options);
+    Printer.printStructurePost(PrintStructureKind::BuiltinAttribute);
+    Printer << " ";
+  }
+
   if (hasAttr(TAK_Sendable))
     Printer.printSimpleAttr("@Sendable") << " ";
   if (hasAttr(TAK_noDerivative))

--- a/test/ModuleInterface/concurrency.swift
+++ b/test/ModuleInterface/concurrency.swift
@@ -20,6 +20,11 @@ public func takesSendable(
   _ block: @Sendable @escaping () async throws -> Void
 ) { }
 
+@available(SwiftStdlib 5.5, *)
+public func takesMainActor(
+  _ block: @MainActor @escaping () -> Void
+) { }
+
 // RUN: %target-typecheck-verify-swift -enable-experimental-concurrency -I %t
 
 #else
@@ -31,12 +36,13 @@ func callFn() async {
 }
 #endif
 
-// RUN: %FileCheck %s <%t/Library.swiftinterface
+// RUN: %FileCheck %s < %t/Library.swiftinterface
 // CHECK: // swift-module-flags:{{.*}} -enable-experimental-concurrency
 // CHECK: public func fn() async
 // CHECK: public func reasyncFn(_: () async -> ()) reasync
 // CHECK: public func takesSendable(_ block: @escaping @Sendable () async throws ->
+// CHECK: public func takesMainActor(_ block: @escaping @{{_Concurrency.MainActor|MainActor}} () ->
 
-// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -enable-experimental-concurrency -DLIBRARY -module-name Library -module-interface-preserve-types-as-written
-// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -enable-experimental-concurrency
-// RUN: %FileCheck %s <%t/Library.swiftinterface
+// RUN: %target-swift-emit-module-interface(%t/LibraryPreserveTypesAsWritten.swiftinterface) %s -enable-experimental-concurrency -DLIBRARY -module-name LibraryPreserveTypesAsWritten -module-interface-preserve-types-as-written
+// RUN: %target-swift-typecheck-module-from-interface(%t/LibraryPreserveTypesAsWritten.swiftinterface) -enable-experimental-concurrency
+// RUN: %FileCheck %s < %t/LibraryPreserveTypesAsWritten.swiftinterface


### PR DESCRIPTION
This ensures that global actor attributes are included when printing a `TypeRepr` representing a global actor bound function type.

Resolves rdar://105475701
