### PR TITLE
Updating the compat override section for Swift 5.9

### DIFF
--- a/stdlib/public/CompatibilityOverride/CompatibilityOverride.h
+++ b/stdlib/public/CompatibilityOverride/CompatibilityOverride.h
@@ -153,8 +153,8 @@ namespace swift {
 // Override section name computation. `COMPATIBILITY_OVERRIDE_SECTION_NAME` will
 // resolve to string literal containing the appropriate section name for the
 // current library.
-#define COMPATIBILITY_OVERRIDE_SECTION_NAME_swiftRuntime "__swift58_hooks"
-#define COMPATIBILITY_OVERRIDE_SECTION_NAME_swift_Concurrency "__s58async_hook"
+#define COMPATIBILITY_OVERRIDE_SECTION_NAME_swiftRuntime "__swift59_hooks"
+#define COMPATIBILITY_OVERRIDE_SECTION_NAME_swift_Concurrency "__s59async_hook"
 
 #define COMPATIBILITY_OVERRIDE_SECTION_NAME                                    \
   COMPATIBILITY_CONCAT(COMPATIBILITY_OVERRIDE_SECTION_NAME_,                   \


### PR DESCRIPTION
Incrementing the compatibility hook section name for Swift 5.9.