### PR TITLE
[Macros] Don't invoke `ResolveMacroRequest` for the same custom attribute with different `DeclContext`s.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -1702,10 +1702,6 @@ public:
   bool isArgUnsafe() const;
   void setArgIsUnsafe(bool unsafe) { isArgUnsafeBit = unsafe; }
 
-  /// Whether this custom attribute is a macro attached to the given
-  /// declaration.
-  bool isAttachedMacro(const Decl *decl) const;
-
   Expr *getSemanticInit() const { return semanticInit; }
   void setSemanticInit(Expr *expr) { semanticInit = expr; }
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -883,6 +883,10 @@ public:
   /// declaration.
   void forEachAttachedMacro(MacroRole role, MacroCallback) const;
 
+  /// Returns the resolved macro for the given custom attribute
+  /// attached to this declaration.
+  MacroDecl *getResolvedMacro(CustomAttr *attr) const;
+
   /// Retrieve the discriminator for the given custom attribute that names
   /// an attached macro.
   unsigned getAttachedMacroDiscriminator(

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -3801,12 +3801,7 @@ void ASTMangler::appendMacroExpansionContext(
     outerExpansionDC = decl->getDeclContext();
     discriminator = decl->getAttachedMacroDiscriminator(role, attr);
 
-    auto *macroDecl = evaluateOrDefault(
-        ctx.evaluator,
-        ResolveMacroRequest{const_cast<CustomAttr *>(attr),
-                            outerExpansionDC},
-        nullptr);
-    if (macroDecl)
+    if (auto *macroDecl = decl->getResolvedMacro(attr))
       baseName = macroDecl->getBaseName();
     else
       baseName = ctx.getIdentifier("__unknown_macro__");
@@ -3885,10 +3880,10 @@ std::string ASTMangler::mangleAttachedMacroExpansion(
     const Decl *decl, CustomAttr *attr, MacroRole role) {
   beginMangling();
 
-  DeclContext *macroDeclContext = decl->getDeclContext();
+  const Decl *attachedTo = decl;
   if (role == MacroRole::MemberAttribute) {
     appendContextOf(cast<ValueDecl>(decl));
-    macroDeclContext = decl->getDeclContext()->getParent();
+    attachedTo = decl->getDeclContext()->getAsDecl();
   } else if (auto valueDecl = dyn_cast<ValueDecl>(decl)) {
     appendAnyDecl(valueDecl);
   } else {
@@ -3896,11 +3891,7 @@ std::string ASTMangler::mangleAttachedMacroExpansion(
   }
 
   StringRef macroName;
-  auto *macroDecl = evaluateOrDefault(
-      decl->getASTContext().evaluator,
-      ResolveMacroRequest{attr, macroDeclContext},
-      nullptr);
-  if (macroDecl)
+  if (auto *macroDecl = attachedTo->getResolvedMacro(attr))
     macroName = macroDecl->getName().getBaseName().userFacingName();
   else
     macroName = "__unknown_macro__";

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2376,18 +2376,6 @@ bool CustomAttr::isArgUnsafe() const {
   return isArgUnsafeBit;
 }
 
-bool CustomAttr::isAttachedMacro(const Decl *decl) const {
-  auto &ctx = decl->getASTContext();
-  auto *dc = decl->getDeclContext();
-
-  auto *macroDecl = evaluateOrDefault(
-      ctx.evaluator,
-      ResolveMacroRequest{const_cast<CustomAttr *>(this), dc},
-      nullptr);
-
-  return macroDecl != nullptr;
-}
-
 MacroRoleAttr::MacroRoleAttr(SourceLoc atLoc, SourceRange range,
                              MacroSyntax syntax, SourceLoc lParenLoc,
                              MacroRole role,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -2378,7 +2378,7 @@ bool CustomAttr::isArgUnsafe() const {
 
 bool CustomAttr::isAttachedMacro(const Decl *decl) const {
   auto &ctx = decl->getASTContext();
-  auto *dc = decl->getInnermostDeclContext();
+  auto *dc = decl->getDeclContext();
 
   auto *macroDecl = evaluateOrDefault(
       ctx.evaluator,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -399,15 +399,9 @@ void Decl::visitAuxiliaryDecls(AuxiliaryDeclCallback callback) const {
 
 void Decl::forEachAttachedMacro(MacroRole role,
                                 MacroCallback macroCallback) const {
-  auto *dc = getDeclContext();
-  auto &ctx = dc->getASTContext();
-
   for (auto customAttrConst : getSemanticAttrs().getAttributes<CustomAttr>()) {
     auto customAttr = const_cast<CustomAttr *>(customAttrConst);
-    auto *macroDecl = evaluateOrDefault(
-        ctx.evaluator,
-        ResolveMacroRequest{customAttr, dc},
-        nullptr);
+    auto *macroDecl = getResolvedMacro(customAttr);
 
     if (!macroDecl)
       continue;
@@ -417,6 +411,13 @@ void Decl::forEachAttachedMacro(MacroRole role,
 
     macroCallback(customAttr, macroDecl);
   }
+}
+
+MacroDecl *Decl::getResolvedMacro(CustomAttr *customAttr) const {
+  return evaluateOrDefault(
+      getASTContext().evaluator,
+      ResolveMacroRequest{customAttr, getDeclContext()},
+      nullptr);
 }
 
 unsigned Decl::getAttachedMacroDiscriminator(

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -698,7 +698,7 @@ bool SemaAnnotator::handleCustomAttributes(Decl *D) {
       // If this attribute resolves to a macro, index that.
       ASTContext &ctx = D->getASTContext();
       ResolveMacroRequest req{const_cast<CustomAttr *>(customAttr),
-                              D->getInnermostDeclContext()};
+                              D->getDeclContext()};
       if (auto macroDecl = evaluateOrDefault(ctx.evaluator, req, nullptr)) {
         Type macroRefType = macroDecl->getDeclaredInterfaceType();
         if (!passReference(

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -696,10 +696,8 @@ bool SemaAnnotator::handleCustomAttributes(Decl *D) {
   for (auto *customAttr : D->getAttrs().getAttributes<CustomAttr, true>()) {
     if (auto *Repr = customAttr->getTypeRepr()) {
       // If this attribute resolves to a macro, index that.
-      ASTContext &ctx = D->getASTContext();
-      ResolveMacroRequest req{const_cast<CustomAttr *>(customAttr),
-                              D->getDeclContext()};
-      if (auto macroDecl = evaluateOrDefault(ctx.evaluator, req, nullptr)) {
+      auto *mutableAttr = const_cast<CustomAttr *>(customAttr);
+      if (auto macroDecl = D->getResolvedMacro(mutableAttr)) {
         Type macroRefType = macroDecl->getDeclaredInterfaceType();
         if (!passReference(
               macroDecl, macroRefType, DeclNameLoc(Repr->getStartLoc()),

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -3567,9 +3567,7 @@ void AttributeChecker::visitCustomAttr(CustomAttr *attr) {
 
   if (!nominal) {
     // Try resolving an attached macro attribute.
-    auto *macro = evaluateOrDefault(
-        Ctx.evaluator, ResolveMacroRequest{attr, dc},
-        nullptr);
+    auto *macro = D->getResolvedMacro(attr);
     if (macro || !attr->isValid())
       return;
 

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -458,10 +458,7 @@ static bool isFromExpansionOfMacro(SourceFile *sourceFile, MacroDecl *macro,
         return true;
     } else if (auto *macroAttr = sourceFile->getAttachedMacroAttribute()) {
       auto *decl = expansion.dyn_cast<Decl *>();
-      auto &ctx = decl->getASTContext();
-      auto *macroDecl = evaluateOrDefault(ctx.evaluator,
-          ResolveMacroRequest{macroAttr, decl->getDeclContext()},
-          nullptr);
+      auto *macroDecl = decl->getResolvedMacro(macroAttr);
       if (!macroDecl)
         return false;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2867,7 +2867,7 @@ class Serializer::DeclSerializer : public DeclVisitor<DeclSerializer> {
       auto theAttr = cast<CustomAttr>(DA);
 
       // Macro attributes are not serialized.
-      if (theAttr->isAttachedMacro(D))
+      if (D->getResolvedMacro(const_cast<CustomAttr *>(theAttr)))
         return;
 
       auto typeID = S.addTypeRef(theAttr->getType());

--- a/test/Serialization/Inputs/def_macros.swift
+++ b/test/Serialization/Inputs/def_macros.swift
@@ -11,3 +11,16 @@
 public struct S {
   public var value: Int
 }
+
+public struct Base {
+  public static func member() -> Base { .init() }
+}
+
+@attached(memberAttribute) public macro wrapAllProperties(
+  _ : Base
+) = #externalMacro(module: "MacroDefinition", type: "WrapAllProperties")
+
+@wrapAllProperties(.member())
+public struct TestMacroArgTypechecking {
+  public var value: Int
+}


### PR DESCRIPTION
Otherwise, double type checking of macro arguments ensues.