### PR TITLE
Avoid using separate '-D' + '...' flags in CFLAGS in CMake

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -376,7 +376,7 @@ function(_add_target_variant_c_compile_flags)
   endif()
 
   if(SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY)
-    list(APPEND result "-D" "SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY")
+    list(APPEND result "-DSWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY")
   endif()
 
   string(TOUPPER "${SWIFT_SDK_${CFLAGS_SDK}_THREADING_PACKAGE}" _threading_package)
@@ -407,7 +407,7 @@ function(_add_target_variant_c_compile_flags)
   endif()
 
   if(SWIFT_STDLIB_ENABLE_UNICODE_DATA)
-    list(APPEND result "-D" "SWIFT_STDLIB_ENABLE_UNICODE_DATA")
+    list(APPEND result "-DSWIFT_STDLIB_ENABLE_UNICODE_DATA")
   endif()
 
   if(SWIFT_STDLIB_CONCURRENCY_TRACING)


### PR DESCRIPTION
Please look at the code change, and think "how could this possibly be a significant change?". If you come up empty, like me when I originally hit this, then [click here](https://cmake.org/cmake/help/latest/command/target_compile_options.html#option-de-duplication) to reveal the solution. CMake 🤷