### PR TITLE
[CodeCompletion] Collection of minor changes to prepare migrating remaining completion kinds to solver-based

### DIFF
--- a/include/swift/AST/ASTNode.h
+++ b/include/swift/AST/ASTNode.h
@@ -107,6 +107,19 @@ namespace llvm {
       return LHS.getOpaqueValue() == RHS.getOpaqueValue();
     }
   };
+
+  // A ASTNode is "pointer like".
+  template <>
+  struct PointerLikeTypeTraits<ASTNode> {
+  public:
+    static inline void *getAsVoidPointer(ASTNode N) {
+      return (void *)N.getOpaqueValue();
+    }
+    static inline ASTNode getFromVoidPointer(void *P) {
+      return ASTNode::getFromOpaqueValue(P);
+    }
+    enum { NumLowBitsAvailable = swift::TypeAlignInBits };
+  };
 }
 
 #endif // LLVM_SWIFT_AST_AST_NODE_H

--- a/include/swift/IDE/ArgumentCompletion.h
+++ b/include/swift/IDE/ArgumentCompletion.h
@@ -72,6 +72,11 @@ class ArgumentTypeCheckCompletionCallback : public TypeCheckCompletionCallback {
 
   void sawSolutionImpl(const constraints::Solution &solution) override;
 
+  /// Populates \p ShadowedDecls with all \c FuncD in \p Results that are
+  /// defined in protocol extensions but redeclared on a nominal type and thus
+  /// cannot be accessed
+  void computeShadowedDecls(SmallPtrSetImpl<ValueDecl *> &ShadowedDecls);
+
 public:
   ArgumentTypeCheckCompletionCallback(CodeCompletionExpr *CompletionExpr,
                                       DeclContext *DC)

--- a/include/swift/IDE/ArgumentCompletion.h
+++ b/include/swift/IDE/ArgumentCompletion.h
@@ -25,6 +25,8 @@ class ArgumentTypeCheckCompletionCallback : public TypeCheckCompletionCallback {
   struct Result {
     /// The type associated with the code completion expression itself.
     Type ExpectedType;
+    /// The expected return type of the function call.
+    Type ExpectedCallType;
     /// True if this is a subscript rather than a function call.
     bool IsSubscript;
     /// The FuncDecl or SubscriptDecl associated with the call.

--- a/lib/IDE/ArgumentCompletion.cpp
+++ b/lib/IDE/ArgumentCompletion.cpp
@@ -115,6 +115,9 @@ void ArgumentTypeCheckCompletionCallback::sawSolutionImpl(const Solution &S) {
   auto *CalleeLocator = S.getCalleeLocator(CallLocator);
 
   auto Info = getSelectedOverloadInfo(S, CalleeLocator);
+  if (Info.Value && Info.Value->shouldHideFromEditor()) {
+    return;
+  }
 
   // Find the parameter the completion was bound to (if any), as well as which
   // parameters are already bound (so we don't suggest them even when the args

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1441,8 +1441,12 @@ bool CodeCompletionCallbacksImpl::trySolverCompletion(bool MaybeFuncBody) {
     // switch case where there control expression is invalid). Having normal
     // typechecking still resolve even these cases would be beneficial for
     // tooling in general though.
-    if (!Lookup.gotCallback())
+    if (!Lookup.gotCallback()) {
+      if (Context.TypeCheckerOpts.DebugConstraintSolver) {
+        llvm::errs() << "--- Fallback typecheck for code completion ---\n";
+      }
       Lookup.fallbackTypeCheck(CurDeclContext);
+    }
   };
 
   switch (Kind) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9171,12 +9171,17 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
 
       // Only try and favor monomorphic unary initializers.
       if (!ctor->isGenericContext()) {
-        auto args = ctor->getMethodInterfaceType()
-                        ->castTo<FunctionType>()->getParams();
-        if (args.size() == 1 && !args[0].hasLabel() &&
-            args[0].getPlainType()->isEqual(favoredType)) {
-          if (!isDeclUnavailable(decl, memberLocator))
-            result.FavoredChoice = result.ViableCandidates.size();
+        if (!ctor->getMethodInterfaceType()->hasError()) {
+          // The constructor might have an error type because we don't skip
+          // invalid decls for code completion
+          auto args = ctor->getMethodInterfaceType()
+                          ->castTo<FunctionType>()
+                          ->getParams();
+          if (args.size() == 1 && !args[0].hasLabel() &&
+              args[0].getPlainType()->isEqual(favoredType)) {
+            if (!isDeclUnavailable(decl, memberLocator))
+              result.FavoredChoice = result.ViableCandidates.size();
+          }
         }
       }
     }

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -623,6 +623,7 @@ bool TypeChecker::typeCheckForCodeCompletion(
 
     // If solve failed to generate constraints or with some other
     // issue, we need to fallback to type-checking a sub-expression.
+    cs.setSolutionApplicationTarget(target.getAsExpr(), target);
     if (!cs.solveForCodeCompletion(target, solutions))
       return CompletionResult::Fallback;
 

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -1231,7 +1231,7 @@ private extension Sequence {
   func SubstitutableBaseTyOfSubscript<T: Comparable>(by keyPath: KeyPath<Element, T>) -> [Element] {
     return sorted { a, b in a[#^GENERICBASE_SUB^#] }
     // GENERICBASE_SUB: Begin completions, 1 item
-    // GENERICBASE_SUB: Pattern/CurrNominal/Flair[ArgLabels]: ['[']{#keyPath: KeyPath<Self.Element, Value>#}[']'][#Value#];
+    // GENERICBASE_SUB: Pattern/CurrNominal/Flair[ArgLabels]/TypeRelation[Convertible]: ['[']{#keyPath: KeyPath<Self.Element, Value>#}[']'][#Value#];
     // GENERICBASE_SUB: End completions
   }
 }

--- a/test/IDE/complete_subscript.swift
+++ b/test/IDE/complete_subscript.swift
@@ -162,7 +162,7 @@ func testSubcscriptTuple(val: (x: Int, String)) {
 }
 
 struct HasSettableSub {
-    subscript(a: String) -> Any {
+    subscript(a: String) -> Int {
         get { return 1 }
         set { }
     }
@@ -174,6 +174,6 @@ func testSettableSub(x: inout HasSettableSub) {
 }
 // SETTABLE_SUBSCRIPT: Begin completions
 // SETTABLE_SUBSCRIPT-DAG: Pattern/CurrNominal/Flair[ArgLabels]: ['[']{#keyPath: KeyPath<HasSettableSub, Value>#}[']'][#Value#];
-// SETTABLE_SUBSCRIPT-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]: ['[']{#(a): String#}[']'][#@lvalue Any#];
+// SETTABLE_SUBSCRIPT-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]/TypeRelation[Convertible]: ['[']{#(a): String#}[']'][#@lvalue Int#];
 // SETTABLE_SUBSCRIPT-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: local[#String#]; name=local
 // SETTABLE_SUBSCRIPT: End completions

--- a/validation-test/IDE/crashers_2_fixed/0037-constructor-with-error-type.swift
+++ b/validation-test/IDE/crashers_2_fixed/0037-constructor-with-error-type.swift
@@ -1,0 +1,12 @@
+// Make sure we don't crash
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token COMPLETE
+
+public struct AnyError {
+
+  public init(_ error: Swift.
+
+extension AnyError {
+  public static func error(from error: Error) -> AnyError {
+    return AnyError(error)#^COMPLETE^#
+  }
+}


### PR DESCRIPTION
Not all of these commits fix any current test case but I think all of them make sense as standalone commits. I’m putting them in this PR to make the PR that migrates the remaining completion kinds to solver-based a little smaller and easier to review.