### PR TITLE
[IDE] Check whether an AST node contains the IDE inspection point based on `CharSourceRange`

### DIFF
--- a/include/swift/Basic/SourceManager.h
+++ b/include/swift/Basic/SourceManager.h
@@ -214,6 +214,13 @@ public:
            (isBeforeInBuffer(R.Start, Loc) && isBeforeInBuffer(Loc, R.End));
   }
 
+  /// Returns true if range \c R contains the location \c Loc.  The location
+  /// \c Loc should point at the beginning of the token.
+  bool rangeContainsTokenLoc(CharSourceRange R, SourceLoc Loc) const {
+    return Loc == R.getStart() || (isBeforeInBuffer(R.getStart(), Loc) &&
+                                   isBeforeInBuffer(Loc, R.getEnd()));
+  }
+
   /// Returns true if range \c Enclosing contains the range \c Inner.
   bool rangeContains(SourceRange Enclosing, SourceRange Inner) const {
     return rangeContainsTokenLoc(Enclosing, Inner.Start) &&
@@ -221,10 +228,11 @@ public:
   }
 
   /// Returns true if range \p R contains the code-completion location, if any.
-  bool rangeContainsIDEInspectionTarget(SourceRange R) const {
-    return IDEInspectionTargetBufferID
-               ? rangeContainsTokenLoc(R, getIDEInspectionTargetLoc())
-               : false;
+  bool rangeContainsIDEInspectionTarget(CharSourceRange R) const {
+    if (!IDEInspectionTargetBufferID) {
+      return false;
+    }
+    return rangeContainsTokenLoc(R, getIDEInspectionTargetLoc());
   }
 
   /// Returns the buffer ID for the specified *valid* location.

--- a/include/swift/Sema/CompletionContextFinder.h
+++ b/include/swift/Sema/CompletionContextFinder.h
@@ -126,6 +126,14 @@ private:
   }
 };
 
+
+/// Returns \c true if \p range is valid and contains the IDE inspection
+/// target. This performs the underlying check based on \c CharSourceRange
+/// to make sure we correctly return \c true if the ide inspection target
+/// is inside a string literal that's the last token in \p range.
+bool containsIDEInspectionTarget(SourceRange range,
+                                 const SourceManager &SourceMgr);
+
 } // end namespace swift
 
 #endif // SWIFT_SEMA_COMPLETIONCONTEXTFINDER_H

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -8166,8 +8166,15 @@ BraceStmt *AbstractFunctionDecl::getBody(bool canSynthesize) const {
 
   // Don't allow getBody() to trigger parsing of an unparsed body containing the
   // IDE inspection location.
+  // FIXME: We should be properly constructing the range of the the body as a
+  // CharSourceRange but we can't because we don't have access to the lexer
+  // here. Using the end location of the SourceRange works good enough here
+  // because the last token is a '}' and the IDE inspection point is not inside
+  // the closing brace.
   if (getBodyKind() == BodyKind::Unparsed &&
-      ctx.SourceMgr.rangeContainsIDEInspectionTarget(getBodySourceRange())) {
+      ctx.SourceMgr.rangeContainsIDEInspectionTarget(
+          CharSourceRange(ctx.SourceMgr, getBodySourceRange().Start,
+                          getBodySourceRange().End))) {
     return nullptr;
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7986,8 +7986,10 @@ void Parser::parseAbstractFunctionBody(AbstractFunctionDecl *AFD) {
   auto BodyPreviousLoc = PreviousLoc;
   SourceRange BodyRange(Tok.getLoc());
   auto setIDEInspectionDelayedDeclStateIfNeeded = [&] {
+    auto CharBodyRange =
+        Lexer::getCharSourceRangeFromSourceRange(SourceMgr, BodyRange);
     if (!isIDEInspectionFirstPass() ||
-        !SourceMgr.rangeContainsIDEInspectionTarget(BodyRange)) {
+        !SourceMgr.rangeContainsIDEInspectionTarget(CharBodyRange)) {
       return;
     }
     if (State->hasIDEInspectionDelayedDeclState())

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1433,7 +1433,9 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
       assert(activeElements.size() == 1 && activeElements[0].is<Expr *>());
       auto expr = activeElements[0].get<Expr *>();
       ParserStatus status(ICD);
-      if (SourceMgr.rangeContainsIDEInspectionTarget(expr->getSourceRange()) &&
+      auto charRange = Lexer::getCharSourceRangeFromSourceRange(
+          SourceMgr, expr->getSourceRange());
+      if (SourceMgr.rangeContainsIDEInspectionTarget(charRange) &&
           L->isCodeCompletion())
         status.setHasCodeCompletion();
       hasBindOptional |= exprsWithBindOptional.contains(expr);
@@ -2826,7 +2828,9 @@ ParserResult<Expr> Parser::parseExprClosure() {
   SmallVector<ASTNode, 4> bodyElements;
   Status |= parseBraceItems(bodyElements, BraceItemListKind::Brace);
 
-  if (SourceMgr.rangeContainsIDEInspectionTarget({leftBrace, PreviousLoc})) {
+  if (SourceMgr.rangeContainsIDEInspectionTarget(
+          Lexer::getCharSourceRangeFromSourceRange(SourceMgr,
+                                                   {leftBrace, PreviousLoc}))) {
     // Ignore 'IDEInspectionDelayedDeclState' inside closures.
     // Completions inside functions body inside closures at top level should
     // be considered top-level completions.

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -16,9 +16,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "MiscDiagnostics.h"
-#include "TypeChecker.h"
 #include "TypeCheckAvailability.h"
-#include "swift/Sema/IDETypeChecking.h"
+#include "TypeChecker.h"
 #include "swift/AST/ASTPrinter.h"
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
@@ -27,14 +26,15 @@
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Sema/ConstraintSystem.h"
+#include "swift/Sema/IDETypeChecking.h"
 #include "swift/Sema/SolutionResult.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"
 #include <iterator>
 #include <map>
 #include <memory>
-#include <utility>
 #include <tuple>
+#include <utility>
 
 using namespace swift;
 using namespace constraints;

--- a/lib/Sema/CompletionContextFinder.cpp
+++ b/lib/Sema/CompletionContextFinder.cpp
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Sema/CompletionContextFinder.h"
+#include "swift/Parse/Lexer.h"
 
 using namespace swift;
 using Fallback = CompletionContextFinder::Fallback;
@@ -131,4 +132,12 @@ Optional<Fallback> CompletionContextFinder::getFallbackCompletionExpr() const {
   if (getCompletionExpr() != InitialExpr)
     return Fallback{getCompletionExpr(), fallbackDC, separatePrecheck};
   return None;
+}
+
+bool swift::containsIDEInspectionTarget(SourceRange range,
+                                        const SourceManager &SourceMgr) {
+  if (range.isInvalid())
+    return false;
+  auto charRange = Lexer::getCharSourceRangeFromSourceRange(SourceMgr, range);
+  return SourceMgr.rangeContainsIDEInspectionTarget(charRange);
 }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -31,6 +31,7 @@
 #include "swift/Basic/Statistic.h"
 #include "swift/Sema/CSFix.h"
 #include "swift/Sema/ConstraintGraph.h"
+#include "swift/Sema/IDETypeChecking.h"
 #include "swift/Sema/SolutionResult.h"
 #include "llvm/ADT/SetVector.h"
 #include "llvm/ADT/SmallSet.h"
@@ -353,18 +354,14 @@ ConstraintSystem::getAlternativeLiteralTypes(KnownProtocolKind kind,
 }
 
 bool ConstraintSystem::containsIDEInspectionTarget(ASTNode node) const {
-  SourceRange range = node.getSourceRange();
-  if (range.isInvalid())
-    return false;
-  return Context.SourceMgr.rangeContainsIDEInspectionTarget(range);
+  return swift::containsIDEInspectionTarget(node.getSourceRange(),
+                                            Context.SourceMgr);
 }
 
 bool ConstraintSystem::containsIDEInspectionTarget(
     const ArgumentList *args) const {
-  SourceRange range = args->getSourceRange();
-  if (range.isInvalid())
-    return false;
-  return Context.SourceMgr.rangeContainsIDEInspectionTarget(range);
+  return swift::containsIDEInspectionTarget(args->getSourceRange(),
+                                            Context.SourceMgr);
 }
 
 ConstraintLocator *ConstraintSystem::getConstraintLocator(

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -14,14 +14,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Subsystems.h"
-#include "TypeChecker.h"
-#include "TypeCheckObjC.h"
-#include "TypeCheckType.h"
 #include "CodeSynthesis.h"
 #include "MiscDiagnostics.h"
-#include "swift/AST/ASTWalker.h"
+#include "TypeCheckObjC.h"
+#include "TypeCheckType.h"
+#include "TypeChecker.h"
 #include "swift/AST/ASTVisitor.h"
+#include "swift/AST/ASTWalker.h"
 #include "swift/AST/Attr.h"
 #include "swift/AST/DiagnosticSuppression.h"
 #include "swift/AST/ExistentialLayout.h"
@@ -37,13 +36,15 @@
 #include "swift/AST/Type.h"
 #include "swift/AST/TypeCheckRequests.h"
 #include "swift/Basic/Defer.h"
-#include "swift/Basic/Statistic.h"
 #include "swift/Basic/STLExtras.h"
+#include "swift/Basic/Statistic.h"
+#include "swift/Parse/IDEInspectionCallbacks.h"
 #include "swift/Parse/Lexer.h"
-#include "swift/Sema/IDETypeChecking.h"
-#include "swift/Sema/ConstraintSystem.h"
 #include "swift/Sema/CompletionContextFinder.h"
+#include "swift/Sema/ConstraintSystem.h"
+#include "swift/Sema/IDETypeChecking.h"
 #include "swift/Strings.h"
+#include "swift/Subsystems.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/SmallSet.h"
@@ -565,7 +566,7 @@ bool TypeChecker::typeCheckForCodeCompletion(
   {
     auto range = target.getSourceRange();
     if (range.isInvalid() ||
-        !Context.SourceMgr.rangeContainsIDEInspectionTarget(range))
+        !containsIDEInspectionTarget(range, Context.SourceMgr))
       return false;
   }
 


### PR DESCRIPTION
This fixes an issue if the range ends with a string literal that contains the IDE inspection target. In that case the end of the range will point to the start of the string literal but the IDE inspection target is inside the string literal and thus after the range’s end.