### PR TITLE
[CXX-Interop] Fix NS_OPTION related label transformations and assertion failures

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -5756,7 +5756,8 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
         assert(clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
                typedefType->getCanonicalTypeInternal());
         if (auto swiftEnum = Impl.importDecl(*clangEnum, Impl.CurrentVersion)) {
-          importedType = {cast<NominalTypeDecl>(swiftEnum)->getDeclaredType(), false};
+          importedType = {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(),
+                          false};
         }
       }
     }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2134,7 +2134,7 @@ ImportedType ClangImporter::Implementation::importFunctionReturnType(
         assert(clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
                typedefType->getCanonicalTypeInternal());
         if (auto swiftEnum = importDecl(*clangEnum, CurrentVersion)) {
-          return {cast<NominalTypeDecl>(swiftEnum)->getDeclaredType(), false};
+          return {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(), false};
         }
       }
     }
@@ -2200,7 +2200,8 @@ ImportedType ClangImporter::Implementation::importFunctionParamsAndReturnType(
         assert(clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
                typedefType->getCanonicalTypeInternal());
         if (auto swiftEnum = importDecl(*clangEnum, CurrentVersion)) {
-          importedType = {cast<NominalTypeDecl>(swiftEnum)->getDeclaredType(), false};
+          importedType = {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(),
+                          false};
         }
       }
     }
@@ -2301,7 +2302,7 @@ ClangImporter::Implementation::importParameterType(
                    ->getCanonicalTypeInternal() ==
                typedefType->getCanonicalTypeInternal());
         if (auto swiftEnum = importDecl(*clangEnum, CurrentVersion)) {
-          swiftParamTy = cast<NominalTypeDecl>(swiftEnum)->getDeclaredType();
+          swiftParamTy = cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType();
         }
       }
     }
@@ -2892,7 +2893,8 @@ ImportedType ClangImporter::Implementation::importMethodParamsAndReturnType(
         assert(clangEnum.value()->getIntegerType()->getCanonicalTypeInternal() ==
                typedefType->getCanonicalTypeInternal());
         if (auto swiftEnum = importDecl(*clangEnum, CurrentVersion)) {
-          importedType = {cast<NominalTypeDecl>(swiftEnum)->getDeclaredType(), false};
+          importedType = {cast<TypeDecl>(swiftEnum)->getDeclaredInterfaceType(),
+                          false};
         }
       }
     }

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -2589,7 +2589,11 @@ ArgumentAttrs ClangImporter::Implementation::inferDefaultArgument(
       // behave like a C enum in the presence of C++.
       auto enumName = typedefType->getDecl()->getName();
       ArgumentAttrs argumentAttrs(DefaultArgumentKind::None, true, enumName);
-      for (auto word : llvm::reverse(camel_case::getWords(enumName))) {
+      auto camelCaseWords = camel_case::getWords(enumName);
+      for (auto it = camelCaseWords.rbegin(); it != camelCaseWords.rend();
+           ++it) {
+        auto word = *it;
+        auto next = std::next(it);
         if (camel_case::sameWordIgnoreFirstCase(word, "options")) {
           argumentAttrs.argumentKind = DefaultArgumentKind::EmptyArray;
           return argumentAttrs;
@@ -2600,13 +2604,17 @@ ArgumentAttrs ClangImporter::Implementation::inferDefaultArgument(
           return argumentAttrs;
         if (camel_case::sameWordIgnoreFirstCase(word, "action"))
           return argumentAttrs;
-        if (camel_case::sameWordIgnoreFirstCase(word, "controlevents"))
+        if (camel_case::sameWordIgnoreFirstCase(word, "events") &&
+            next != camelCaseWords.rend() &&
+            camel_case::sameWordIgnoreFirstCase(*next, "control"))
           return argumentAttrs;
         if (camel_case::sameWordIgnoreFirstCase(word, "state"))
           return argumentAttrs;
         if (camel_case::sameWordIgnoreFirstCase(word, "unit"))
           return argumentAttrs;
-        if (camel_case::sameWordIgnoreFirstCase(word, "scrollposition"))
+        if (camel_case::sameWordIgnoreFirstCase(word, "position") &&
+            next != camelCaseWords.rend() &&
+            camel_case::sameWordIgnoreFirstCase(*next, "scroll"))
           return argumentAttrs;
         if (camel_case::sameWordIgnoreFirstCase(word, "edge"))
           return argumentAttrs;

--- a/test/Interop/Cxx/enum/Inputs/CenumsNSOptions.apinotes
+++ b/test/Interop/Cxx/enum/Inputs/CenumsNSOptions.apinotes
@@ -11,8 +11,12 @@ Enumerators:
 Tags:
 - Name: UIPrinterJobTypes
   SwiftName: UIPrinter.JobTypes
+- Name: Baz
+  SwiftName: CurrentBazVersion
 SwiftVersions:
 - Version: 4
   Tags:
   - Name: UIPrinterJobTypes
     SwiftName: UIPrinterJobTypes
+  - Name: Baz
+    SwiftName: BazVersion4

--- a/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-NS_OPTIONS.h
@@ -78,3 +78,13 @@ typedef NS_OPTIONS(NSUInteger, Bar) {
   API_NOTES_NAMED_OptionFour = API_NOTES_NAMED_OptionOne |
                                API_NOTES_NAMED_OptionTwo
 };
+
+typedef NS_OPTIONS(NSUInteger, Baz) { Baz1, Baz2 };
+
+Baz CFunctionReturningNSOption();
+void CFunctionTakingNSOption(Baz);
+
+@interface NSOptionTypeCheckTest
++ (Baz)methodReturningNSOption;
++ (void)methodTakingNSOption:(Baz)baz;
+@end

--- a/test/Interop/Cxx/enum/Inputs/c-enums-withOptions-omit.h
+++ b/test/Interop/Cxx/enum/Inputs/c-enums-withOptions-omit.h
@@ -28,6 +28,19 @@ enum : UIControlState { UIControlState1, UIControlState2 };
 typedef int __attribute__((availability(swift, unavailable))) UITableViewCellStateMask;
 enum : UITableViewCellStateMask { UITableViewCellStateMask1, UITableViewCellStateMask2 };
 
+typedef int __attribute__((availability(swift, unavailable))) UIControlEvents;
+enum : UIControlEvents { UIControlEvents1, UIControlEvents2 };
+
+typedef int __attribute__((availability(swift, unavailable)))
+UITableViewScrollPosition;
+enum : UITableViewScrollPosition {
+  UITableViewScrollPosition1,
+  UITableViewScrollPosition2
+};
+
+@interface NSIndexPath
+@end
+
 @interface TestsForEnhancedOmitNeedlessWords
 - (void)differenceFromArray:(int)other withOptions:(NSOrderedCollectionDifferenceCalculationOptions)options ;
 - (unsigned)minimumRangeOfUnit:(NSCalendarUnit)unit;
@@ -35,4 +48,9 @@ enum : UITableViewCellStateMask { UITableViewCellStateMask1, UITableViewCellStat
 - (unsigned)layoutManager:(unsigned)layoutManager shouldUseAction:(NSControlCharacterAction)action ;
 - (void)setBackButtonBackgroundImage:(unsigned)backgroundImage forState:(UIControlState)state ;
 - (void)willTransitionToState:(UITableViewCellStateMask)state ;
+- (void)addTarget:(nullable id)target
+              action:(SEL)action
+    forControlEvents:(UIControlEvents)controlEvents;
+- (void)scrollToRowAtIndexPath:(NSIndexPath *)indexPath
+              atScrollPosition:(UITableViewScrollPosition)scrollPosition;
 @end

--- a/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-typecheck-name-differs-between-versions.swift
+++ b/test/Interop/Cxx/enum/c-enums-NS_OPTIONS-typecheck-name-differs-between-versions.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -I %S/Inputs -enable-experimental-cxx-interop -typecheck %s
+// REQUIRES: objc_interop
+
+import CenumsNSOptions
+
+let foo = CFunctionReturningNSOption()
+CFunctionTakingNSOption(foo)
+let foo2 = NSOptionTypeCheckTest.methodReturningNSOption()
+NSOptionTypeCheckTest.methodTakingNSOption(foo)

--- a/test/Interop/Cxx/enum/c-enums-withOptions-omit.swift
+++ b/test/Interop/Cxx/enum/c-enums-withOptions-omit.swift
@@ -57,3 +57,19 @@ import CenumsWithOptionsOmit
 // CHECK-NEXT: class func willTransitionToState(_ state: UITableViewCellStateMask)
 // CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "willTransition(to:)")
 // CHECK-NEXT: func willTransitionToState(_ state: UITableViewCellStateMask)
+
+// Tests for forControlEvents -> 'for controlEvents'
+// CHECK-NEXT: class func addTarget(_ target: Any?, action: OpaquePointer!, for controlEvents: UIControlEvents)
+// CHECK-NEXT: func addTarget(_ target: Any?, action: OpaquePointer!, for controlEvents: UIControlEvents)
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "addTarget(_:action:for:)")
+// CHECK-NEXT: class func addTarget(_ target: Any?, action: OpaquePointer!, forControlEvents controlEvents: UIControlEvents)
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "addTarget(_:action:for:)")
+// CHECK-NEXT: func addTarget(_ target: Any?, action: OpaquePointer!, forControlEvents controlEvents: UIControlEvents)
+
+// Tests for atScrollPosition -> 'at atScrollPosition'
+// CHECK-NEXT: class func scrollToRow(at indexPath: NSIndexPath!, at scrollPosition: UITableViewScrollPosition)
+// CHECK-NEXT: func scrollToRow(at indexPath: NSIndexPath!, at scrollPosition: UITableViewScrollPosition)
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "scrollToRow(at:at:)")
+// CHECK-NEXT: class func scrollToRowAtIndexPath(_ indexPath: NSIndexPath!, atScrollPosition scrollPosition: UITableViewScrollPosition)
+// CHECK-NEXT: @available(swift, obsoleted: 3, renamed: "scrollToRow(at:at:)")
+// CHECK-NEXT: func scrollToRowAtIndexPath(_ indexPath: NSIndexPath!, atScrollPosition scrollPosition: UITableViewScrollPosition)


### PR DESCRIPTION
This patch resolves https://github.com/apple/swift/issues/63671. 

The issue turned out to be two issues, and I've included a commit for each issue. The commit messages provide a more detailed explanation, but in short the issues were:

- We were assuming enums are always imported as `NominalTypeDecl`s, which isn't the case
- The logic for "trimming" of parameter labels based on NS_OPTION parameter types needed adjusting
