### PR TITLE
[Test] Add new visible symbols on Linux

### DIFF
--- a/test/stdlib/symbol-visibility-linux.test-sh
+++ b/test/stdlib/symbol-visibility-linux.test-sh
@@ -241,6 +241,7 @@
 // RUN:             -e _ZNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEpLEc \
 // RUN:             -e _ZStplIcSt11char_traitsIcESaIcEENSt7__cxx1112basic_stringIT_T0_T1_EES5_RKS8_ \
 // RUN:             -e _ZStplIcSt11char_traitsIcESaIcEESbIT_T0_T1_ERKS6_S8_ \
+// RUN:             -e _ZNSt6vectorIjSaIjEE12emplace_backIJjEEERjDpOT_ \
 // RUN:   > %t/swiftCore-all.txt
 // RUN: %llvm-nm --defined-only --extern-only --no-weak %platform-dylib-dir/%target-library-name(swiftCore) > %t/swiftCore-no-weak.txt
 // RUN: diff -u %t/swiftCore-all.txt %t/swiftCore-no-weak.txt
@@ -478,6 +479,9 @@
 // RUN:             -e _ZNSsC2EPKcRKSaIcE \
 // RUN:             -e _ZSteqIcSt11char_traitsIcESaIcEEbRKSbIT_T0_T1_EPKS3_ \
 // RUN:             -e _ZStplIcSt11char_traitsIcESaIcEESbIT_T0_T1_EPKS3_RKS6_ \
+// RUN:             -e _ZNSt6vectorIjSaIjEE12emplace_backIJjEEERjDpOT_ \
+// RUN:             -e _ZNSt6vectorImSaImEE12emplace_backIJiEEERmDpOT_ \
+// RUN:             -e _ZNSt6vectorImSaImEE12emplace_backIJmEEERmDpOT_ \
 // RUN:   > %t/swiftRemoteMirror-all.txt
 // RUN: %llvm-nm --defined-only --extern-only --no-weak %platform-dylib-dir/%target-library-name(swiftRemoteMirror) > %t/swiftRemoteMirror-no-weak.txt
 // RUN: diff -u %t/swiftRemoteMirror-all.txt %t/swiftRemoteMirror-no-weak.txt


### PR DESCRIPTION
Enabling the C++ stdlib assertions seems to have added even more symbols (this time from `emplace_back`). Add them to the filter.