### PR TITLE
[5.8][stdlib] Define OS versions for the stdlib in Swift 5.8

### DIFF
--- a/utils/availability-macros.def
+++ b/utils/availability-macros.def
@@ -32,7 +32,7 @@ SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5
 SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0
 SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4
 SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0
-SwiftStdlib 5.8:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999
+SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4
 
 # Local Variables:
 # mode: conf-unix


### PR DESCRIPTION
Cherry picked from https://github.com/apple/swift/pull/63722.

The current macOS 13.3, iOS 16.4, watchOS 9.4 and tvOS 16.4 beta releases include the Swift 5.8 Standard Library. This PR updates availability declarations in the stdlib to match the version number of these releases, syncing with the stdlib that ships in the new SDKs.

(As usual, one consequence of this change is that 5.8 APIs will no longer be exercised by tests on macOS until ci.swift.org hosts get updated to the eventual releases. Until then, these APIs will continue to get exercised on Linux and Windows, if their tests support those platforms.)
