### PR TITLE
build: avoid installing static libraries

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -472,6 +472,7 @@ cmake ^
 
   -G Ninja ^
   -S %SourceRoot%\Yams || (exit /b)
+cmake --build %BuildRoot%\10 || (exit /b)
 
 :: Build swift-driver
 cmake ^
@@ -527,6 +528,7 @@ cmake ^
 
   -G Ninja ^
   -S %SourceRoot%\swift-crypto || (exit /b)
+cmake --build %BuildRoot%\12 || (exit /b)
 
 :: Build swift-collections
 cmake ^
@@ -605,6 +607,7 @@ cmake ^
 
   -G Ninja ^
   -S %SourceRoot%\indexstore-db || (exit /b)
+cmake --build %BuildRoot%\15 || (exit /b)
 
 :: Build swift-syntax
 cmake ^

--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -472,8 +472,6 @@ cmake ^
 
   -G Ninja ^
   -S %SourceRoot%\Yams || (exit /b)
-cmake --build %BuildRoot%\10 || (exit /b)
-cmake --build %BuildRoot%\10 --target install || (exit /b)
 
 :: Build swift-driver
 cmake ^
@@ -529,8 +527,6 @@ cmake ^
 
   -G Ninja ^
   -S %SourceRoot%\swift-crypto || (exit /b)
-cmake --build %BuildRoot%\12 || (exit /b)
-cmake --build %BuildRoot%\12 --target install || (exit /b)
 
 :: Build swift-collections
 cmake ^
@@ -609,8 +605,6 @@ cmake ^
 
   -G Ninja ^
   -S %SourceRoot%\indexstore-db || (exit /b)
-cmake --build %BuildRoot%\15 || (exit /b)
-cmake --build %BuildRoot%\15 --target install || (exit /b)
 
 :: Build swift-syntax
 cmake ^


### PR DESCRIPTION
These are used as part of the internal build of the toolchain and not distributed, avoid spending the time copying the files.