### PR TITLE
[Concurrency] Memory order of success must be >= failure path in exchange

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -1585,7 +1585,7 @@ reevaluate_if_taskgroup_has_results:;
     auto newStatus = TaskGroupStatus{assumedStatus};
     if (status.compare_exchange_strong(
         assumedStatus, newStatus.completingPendingReadyWaiting(this).status,
-        /*success*/ std::memory_order_relaxed,
+        /*success*/ std::memory_order_release,
         /*failure*/ std::memory_order_acquire)) {
 
       // We're going back to running the task, so if we suspended before,


### PR DESCRIPTION
This triggers a C++ stdlib assertion and must be fixed. We don't rely on the status as a barrier here, because we didn't get to a fully lockless task group yet and the group is protected with a lock. Either way, changing from relaxed to release here would be stronger and not weaker, so it is safe to do either way.

