### PR TITLE
[Frontend] Add option to explicitly import Builtin

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -532,6 +532,9 @@ namespace swift {
     /// The model of concurrency to be used.
     ConcurrencyModel ActiveConcurrencyModel = ConcurrencyModel::Standard;
 
+    /// Allows the explicit 'import Builtin' within Swift modules.
+    bool EnableBuiltinModule = false;
+
     bool isConcurrencyModelTaskToThread() const {
       return ActiveConcurrencyModel == ConcurrencyModel::TaskToThread;
     }

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -1044,6 +1044,10 @@ def parse_stdlib : Flag<["-"], "parse-stdlib">,
   Flags<[FrontendOption, HelpHidden, ModuleInterfaceOption]>,
   HelpText<"Parse the input file(s) as the Swift standard library">;
 
+def enable_builtin_module : Flag<["-"], "enable-builtin-module">,
+  Flags<[FrontendOption, ModuleInterfaceOption]>,
+  HelpText<"Enables the explicit import of the Builtin module">;
+
 def modes_Group : OptionGroup<"<mode options>">, HelpText<"MODES">;
 
 class ModeOpt : Group<modes_Group>;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -307,6 +307,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddLastArg(arguments, options::OPT_enable_experimental_cxx_interop);
   inputArgs.AddLastArg(arguments, options::OPT_load_plugin_library);
   inputArgs.AddLastArg(arguments, options::OPT_load_plugin_executable);
+  inputArgs.AddLastArg(arguments, options::OPT_enable_builtin_module);
 
   // Pass on any build config options
   inputArgs.AddAllArgs(arguments, options::OPT_D);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1105,6 +1105,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
             .Default(ConcurrencyModel::Standard);
   }
 
+  Opts.EnableBuiltinModule = Args.hasArg(OPT_enable_builtin_module);
+
   return HadError || UnsupportedOS || UnsupportedArch;
 }
 

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -293,8 +293,14 @@ static void printImports(raw_ostream &out,
 
   for (auto import : allImports) {
     auto importedModule = import.importedModule;
-    if (importedModule->isOnoneSupportModule() ||
-        importedModule->isBuiltinModule()) {
+    if (importedModule->isOnoneSupportModule()) {
+      continue;
+    }
+
+    // Unless '-enable-builtin-module' was passed, do not print 'import Builtin'
+    // in the interface. '-parse-stdlib' still implicitly imports it however...
+    if (importedModule->isBuiltinModule() &&
+        !M->getASTContext().LangOpts.EnableBuiltinModule) {
       continue;
     }
 

--- a/test/Frontend/enable_builtin_module.swift
+++ b/test/Frontend/enable_builtin_module.swift
@@ -1,0 +1,16 @@
+// RUN: not %target-swift-frontend -typecheck -show-diagnostics-after-fatal -D BUILTIN_IMPORT %s 2>&1 | %FileCheck -check-prefix CHECK-NO-BUILTIN %s
+// RUN: not %target-swift-frontend -typecheck -show-diagnostics-after-fatal  -enable-builtin-module %s 2>&1 | %FileCheck -check-prefix CHECK-NO-BUILTIN-IMPORT %s
+// RUN: %target-swift-frontend -typecheck -enable-builtin-module -D BUILTIN_IMPORT %s
+
+// CHECK-NO-BUILTIN: no such module 'Builtin'
+
+#if BUILTIN_IMPORT
+import Builtin
+#endif
+
+// CHECK-NO-BUILTIN: cannot find type 'Builtin' in scope
+// CHECK-NO-BUILTIN-IMPORT: cannot find type 'Builtin' in scope
+
+func something(_: Builtin.RawPointer) {
+
+}

--- a/test/ModuleInterface/enable_builtin_module.swift
+++ b/test/ModuleInterface/enable_builtin_module.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-emit-module-interface(%t.swiftinterface) %s -enable-builtin-module
+// RUN: %target-swift-typecheck-module-from-interface(%t.swiftinterface)
+// RUN: %FileCheck %s < %t.swiftinterface
+
+// CHECK: -enable-builtin-module
+
+// CHECK: import Builtin
+// CHECK: import Swift
+// CHECK: import _Concurrency
+// CHECK: import _StringProcessing
+// CHECK: import _SwiftConcurrencyShims
+
+// CHECK: public func something(with x: Builtin.RawPointer)
+
+import Builtin
+
+public func something(with x: Builtin.RawPointer) {}


### PR DESCRIPTION
This PR adds a new frontend option, `-enable-builtin-module`, that enables a module to explicitly `import Builtin` when needed. As part of this, the explicit import gets emitted into interface files so that we no longer implicitly import this module. 

Motivation for this new flag includes the fact that standard library modules who are not the core sometimes need to access these builtins, but can only do so via `-parse-stdlib` who in itself bring along lots of other quirks that don't apply to these modules. The biggest is that the standard library is unconditionally built with `-assert-config Debug` even in release modes of the standard library. Modules using this flag and using stdlib APIs who have `_debugPrecondition`s must incur the code size and branch of these preconditions even though they may not want them in opaque parts of their libraries. With this new flag, those modules can explicitly `import Builtin` and remove their dependence on `-parse-stdlib` allowing them to 1. implicitly get `import Swift` like normal Swift code and 2. be built as normal Swift code. It would be nice if one day we sunsetted `-parse-stdlib` and all of the unique flags that come along with it were explicit in the stdlib's build settings.