### PR TITLE
Fix calls to add_custom_target_command

### DIFF
--- a/SwiftCompilerSources/CMakeLists.txt
+++ b/SwiftCompilerSources/CMakeLists.txt
@@ -176,20 +176,21 @@ function(add_swift_compiler_modules_library name)
     endforeach()
 
     # Compile the module into an object file
-    add_custom_command_target(dep_target OUTPUT ${module_obj_file}
+    add_custom_command_target(dep_target
+      COMMAND ${ALS_SWIFT_EXEC} "-c" "-o" ${module_obj_file}
+        ${sdk_option}
+        "-target" ${target}
+        "-module-name" ${module} "-emit-module"
+        "-emit-module-path" "${build_dir}/${module}.swiftmodule"
+        "-parse-as-library" ${sources}
+        "-wmo" ${swift_compile_options}
+        ${c_include_paths_args}
+        # Generated swift modules.
+        "-I" "${build_dir}"
+      OUTPUT ${module_obj_file}
       WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
       DEPENDS ${sources} ${deps} ${ALS_DEPENDS}
         importedHeaderDependencies
-      COMMAND ${ALS_SWIFT_EXEC} "-c" "-o" ${module_obj_file}
-              ${sdk_option}
-              "-target" ${target}
-              "-module-name" ${module} "-emit-module"
-              "-emit-module-path" "${build_dir}/${module}.swiftmodule"
-              "-parse-as-library" ${sources}
-              "-wmo" ${swift_compile_options}
-              ${c_include_paths_args}
-              # Generated swift modules.
-              "-I" "${build_dir}"
       COMMENT "Building swift module ${module}")
 
     set("${module}_dep_target" ${dep_target})

--- a/tools/swift-compatibility-symbols/CMakeLists.txt
+++ b/tools/swift-compatibility-symbols/CMakeLists.txt
@@ -7,11 +7,11 @@ add_swift_host_tool(swift-compatibility-symbols
 set(syms_file "${CMAKE_BINARY_DIR}/share/swift/compatibility-symbols")
 
 add_custom_command_target(copy_compat_target
-  OUTPUT
-    ${syms_file}
   COMMAND
     "${SWIFT_NATIVE_SWIFT_TOOLS_PATH}/swift-compatibility-symbols"
-      --output-filename ${syms_file}
+    --output-filename ${syms_file}
+  OUTPUT
+    ${syms_file}
   DEPENDS
     swift-compatibility-symbols
 )


### PR DESCRIPTION
`add_custom_target_command` has a note in its documentation that ask for all the `COMMAND` arguments to immediately follow the first argument, or the function will misbehave.

In the two cases below, the `COMMAND` arguments were after the `OUTPUT` multivalue, and ended by mistake inside the `OUTPUT` parameter. This kinda works because CMake will interpolate those back, but causes problems for dependency resolution, marking many targets as dirty. When one of those targets is dependent by the compiler, this can create a huge cascade rebuild.

Fix the two cases I found where `add_custom_target_command` was used incorrectly. This removes cascade rebuilds in my working directory, and hope it applies to everybody.