### PR TITLE
[Gardening] Fix typos across docs and codebase

### DIFF
--- a/SwiftCompilerSources/force_lib.c
+++ b/SwiftCompilerSources/force_lib.c
@@ -11,5 +11,5 @@
 //===----------------------------------------------------------------------===//
 
 /// Dummy source file to force CMake generated SwiftInTheCompiler.xcodeproj
-/// to sucessfully build static libraries conatining only object files used
+/// to successfully build static libraries conatining only object files used
 /// during "bootstrap" process to link Swift sources into the compiler.

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -434,7 +434,7 @@ NOTE(sdk_version_pbm_version,none,
 NOTE(compiled_module_ignored_reason,none,
      "compiled module '%0' was ignored because %select{%error"
      "|it belongs to a framework in the SDK"
-     "|loading from module interfaces is prefered}1",
+     "|loading from module interfaces is preferred}1",
      (StringRef, unsigned))
 NOTE(out_of_date_module_here,none,
      "%select{compiled|cached|forwarding|prebuilt}0 module is out of date: '%1'",

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -831,7 +831,7 @@ namespace swift {
 
     /// When building a PCM, rely on the Swift frontend's command-line -Xcc flags
     /// to build the Clang module via Clang frontend directly,
-    /// and completly bypass the Clang driver.
+    /// and completely bypass the Clang driver.
     bool DirectClangCC1ModuleBuild = false;
 
     /// Return a hash code of any components from these options that should

--- a/include/swift/IDE/CodeCompletionResult.h
+++ b/include/swift/IDE/CodeCompletionResult.h
@@ -337,7 +337,7 @@ class ContextFreeCodeCompletionResult {
   bool IsSystem : 1;
   bool IsAsync : 1;
   /// Whether the result has been annotated as having an async alternative that
-  /// should be prefered in async contexts.
+  /// should be preferred in async contexts.
   bool HasAsyncAlternative : 1;
   CodeCompletionString *CompletionString;
   NullTerminatedStringRef ModuleName;
@@ -355,7 +355,7 @@ class ContextFreeCodeCompletionResult {
   NullTerminatedStringRef FilterName;
 
   /// If the result represents a \c ValueDecl the name by which this decl should
-  /// be refered to in diagnostics.
+  /// be referred to in diagnostics.
   NullTerminatedStringRef NameForDiagnostics;
 
 public:

--- a/include/swift/Refactoring/RefactoringKinds.def
+++ b/include/swift/Refactoring/RefactoringKinds.def
@@ -26,11 +26,11 @@ REFACTORING(GlobalRename, "Global Rename", rename.global)
 /// (syntactically).
 REFACTORING(FindGlobalRenameRanges, "Find Global Rename Ranges", rename.global.find-ranges)
 
-/// Find and categorize all occurences of the file-local symbol at a given
+/// Find and categorize all occurrences of the file-local symbol at a given
 /// location.
 REFACTORING(FindLocalRenameRanges, "Find Local Rename Ranges", rename.local.find-ranges)
 
-/// Find and rename all occurences of the file-local symbol at a given
+/// Find and rename all occurrences of the file-local symbol at a given
 /// location.
 CURSOR_REFACTORING(LocalRename, "Local Rename", rename.local)
 

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -441,7 +441,7 @@ protected:
     else {
       // Create a new function with this mangled name with an empty
       // body. There won't be any IR generated for it (hence the linkage),
-      // but the symbol will be refered to by the debug info metadata.
+      // but the symbol will be referred to by the debug info metadata.
       ParentFunction = FuncBuilder.getOrCreateFunction(
           ParentFunction->getLocation(), MangledName, SILLinkage::Shared,
           ParentFunction->getLoweredFunctionType(), ParentFunction->isBare(),

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -925,7 +925,7 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     // will occur while building the Swift module because the overriding decl
     // doesn't override anything.
     // We couldn't skip every `override` keywords because they change the
-    // ABI if the overridden decl is also publically visible.
+    // ABI if the overridden decl is also publicly visible.
     // For public-override-internal case, having `override` doesn't have ABI
     // implication. Thus we can skip them.
     if (auto *VD = dyn_cast<ValueDecl>(D)) {

--- a/lib/AST/FineGrainedDependencies.cpp
+++ b/lib/AST/FineGrainedDependencies.cpp
@@ -143,7 +143,7 @@ SourceFileDepGraph::findExistingNodePairOrCreateAndAddIfNew(
   // But, if an arc is added for this, then *any* change that causes
   // a same-named interface to be dirty will dirty this implementation,
   // even if that interface is in another file.
-  // Therefor no such arc is added here, and any dirtying of either
+  // Therefore no such arc is added here, and any dirtying of either
   // the interface or implementation of this declaration will cause
   // the driver to recompile this source file.
   return nodePair;

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -5675,7 +5675,7 @@ llvm::Constant *IRGenModule::getAddrOfGlobalUTF16String(StringRef utf8) {
 
 /// Can not treat a treat the layout of a class as resilient if the current
 ///    class is defined in an external module and
-///    not publically accessible (e.g private or internal).
+///    not publicly accessible (e.g private or internal).
 /// This would normally not happen except if we compile theClass's module with
 /// enable-testing.
 /// Do we have to use resilient access patterns when working with this

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2001,7 +2001,7 @@ bool Lexer::isPotentialUnskippableBareSlashRegexLiteral(const Token &Tok) const 
   // We either don't have a regex literal, or we failed a heuristic. We now need
   // to make sure we don't have an unbalanced `{` or `}`, as that would have the
   // potential to change the range of a skipped body if we try to more
-  // agressively lex a regex literal during normal parsing. If we have balanced
+  // aggressively lex a regex literal during normal parsing. If we have balanced
   // `{` + `}`, we can proceed with skipping. Worst case scenario is we emit a
   // worse diagnostic.
   // FIXME: We ought to silence lexer diagnostics when skipping, this would

--- a/lib/Refactoring/Refactoring.cpp
+++ b/lib/Refactoring/Refactoring.cpp
@@ -997,7 +997,7 @@ public:
 ExtractCheckResult checkExtractConditions(const ResolvedRangeInfo &RangeInfo,
                                           DiagnosticEngine &DiagEngine) {
   SmallVector<CannotExtractReason, 2> AllReasons;
-  // If any declared declaration is refered out of the given range, return false.
+  // If any declared declaration is referred out of the given range, return false.
   auto Declared = RangeInfo.DeclaredDecls;
   auto It = std::find_if(Declared.begin(), Declared.end(),
                          [](DeclaredDecl DD) { return DD.ReferredAfterRange; });

--- a/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
@@ -20,7 +20,7 @@
 //
 // func test() {
 //   let k = Klass()
-//   // k is deallocated immediatly after the closure capture (a store_weak).
+//   // k is deallocated immediately after the closure capture (a store_weak).
 //   functionWithClosure({ [weak k] in
 //                         // crash!
 //                         k!.foo()

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressChecker.cpp
@@ -1374,7 +1374,7 @@ bool GlobalLivenessChecker::testInstVectorLiveness(
     if (!liveness.isWithinBoundary(takeInstAndValue.first,
                                    takeInstAndValue.second)) {
       // TODO: Today, we don't tell the user the actual field itself where the
-      // violation occured and just instead just shows the two instructions. We
+      // violation occurred and just instead just shows the two instructions. We
       // could be more specific though...
       LLVM_DEBUG(llvm::dbgs() << "        Not within the boundary.\n");
       continue;

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransform.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransform.cpp
@@ -606,7 +606,7 @@ struct TypeOffsetSizePair {
       }
 
       // At this point, we know that our type is not a subtype of this
-      // type. Some sort of logic error occured.
+      // type. Some sort of logic error occurred.
       llvm_unreachable("Not a child of this type?!");
     }
 
@@ -640,7 +640,7 @@ struct TypeOffsetSizePair {
       }
 
       // At this point, we know that our type is not a subtype of this
-      // type. Some sort of logic error occured.
+      // type. Some sort of logic error occurred.
       llvm_unreachable("Not a child of this type?!");
     }
 
@@ -699,7 +699,7 @@ struct TypeOffsetSizePair {
       }
 
       // At this point, we know that our type is not a subtype of this
-      // type. Some sort of logic error occured.
+      // type. Some sort of logic error occurred.
       llvm_unreachable("Not a child of this type?!");
     }
 
@@ -736,7 +736,7 @@ struct TypeOffsetSizePair {
       }
 
       // At this point, we know that our type is not a subtype of this
-      // type. Some sort of logic error occured.
+      // type. Some sort of logic error occurred.
       llvm_unreachable("Not a child of this type?!");
     }
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDeinitInsertion.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDeinitInsertion.cpp
@@ -12,7 +12,7 @@
 ///
 /// \file
 ///
-/// This pass runs after move only checking has occured and transforms last
+/// This pass runs after move only checking has occurred and transforms last
 /// destroy_value of move only types into a call to the move only types deinit.
 ///
 //===----------------------------------------------------------------------===//

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3848,7 +3848,7 @@ namespace {
         subExpr = subExpr->getValueProvidingExpr();
 
         // Diagnose if we find a 'try?'.
-        // FIXME: We could put up with occurences of 'try?' if they do not apply
+        // FIXME: We could put up with occurrences of 'try?' if they do not apply
         // directly to the called ctor, e.g. 'try? try self.init()', or if the
         // called ctor isn't throwing.
         if (auto *OTE = dyn_cast<OptionalTryExpr>(subExpr)) {

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2361,7 +2361,7 @@ struct PackTypeVariableCollector: TypeWalker {
 /// pack type. The original pack type is then matched against the instantiated
 /// pack type.
 ///
-/// As a side effect, it binds each pack type variable occuring in the pattern
+/// As a side effect, it binds each pack type variable occurring in the pattern
 /// type to a new pack with the same shape as the original pack, but where the
 /// elements are fresh type variables.
 ///

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -566,7 +566,7 @@ checkGenericArguments(ModuleDecl *module, ArrayRef<Requirement> requirements,
 /// \param module The module to use for conformance lookup.
 /// \param contextSig The generic signature that should be used to map
 /// \p parentTy into context. We pass a generic signature to secure on-demand
-/// computation of the associated generic enviroment.
+/// computation of the associated generic environment.
 ///
 /// \returns \c true on success.
 bool checkContextualRequirements(GenericTypeDecl *decl, Type parentTy,

--- a/lib/Serialization/SourceInfoFormat.h
+++ b/lib/Serialization/SourceInfoFormat.h
@@ -60,7 +60,7 @@ const uint32_t SWIFTSOURCEINFO_HASH_SEED = 5387;
 /// .swiftsourceinfo doesn't have consequences as serious as breaking the format
 /// of .swiftdoc, because .swiftsourceinfo file is for local development use only.
 ///
-/// When changing this block, backwards-compatible changes are prefered.
+/// When changing this block, backwards-compatible changes are preferred.
 /// You may need to update the version when you do so. See docs/StableBitcode.md
 /// for information on how to make backwards-compatible changes using the LLVM
 /// bitcode format.

--- a/stdlib/public/BackDeployConcurrency/Actor.cpp
+++ b/stdlib/public/BackDeployConcurrency/Actor.cpp
@@ -701,7 +701,7 @@ private:
 
   /// Schedule an inline processing job.  This can generally only be
   /// done if we know nobody else is trying to do it at the same time,
-  /// e.g. if this thread just sucessfully transitioned the actor from
+  /// e.g. if this thread just successfully transitioned the actor from
   /// Idle to Scheduled.
   void scheduleNonOverrideProcessJob(JobPriority priority,
                                      bool hasActiveInlineJob);

--- a/test/IRGen/weak_import_native_hoist.swift
+++ b/test/IRGen/weak_import_native_hoist.swift
@@ -7,7 +7,7 @@
 
 import weak_import_native_hoist_helper
 
-// We should not hoist the metadata accessor accross the version check.
+// We should not hoist the metadata accessor across the version check.
 
 // CHECK-LABEL: define {{.*}} void @"$s24weak_import_native_hoist09test_not_D14_weakly_linkedyyF"()
 // CHECK-NOT: 15ResilientStructVMa

--- a/utils/gen-unicode-data/Sources/GenScalarProps/GeneralCategory.swift
+++ b/utils/gen-unicode-data/Sources/GenScalarProps/GeneralCategory.swift
@@ -35,9 +35,9 @@ enum GeneralCategory: String {
   case currencySymbol = "Sc"
   case modifierSymbol = "Sk"
   case otherSymbol = "So"
-  case spaceSeperator = "Zs"
-  case lineSeperator = "Zl"
-  case paragraphSeperator = "Zp"
+  case spaceSeparator = "Zs"
+  case lineSeparator = "Zl"
+  case paragraphSeparator = "Zp"
   case control = "Cc"
   case format = "Cf"
   case surrogate = "Cs"
@@ -90,11 +90,11 @@ enum GeneralCategory: String {
       return 20
     case .otherSymbol:
       return 21
-    case .spaceSeperator:
+    case .spaceSeparator:
       return 22
-    case .lineSeperator:
+    case .lineSeparator:
       return 23
-    case .paragraphSeperator:
+    case .paragraphSeparator:
       return 24
     case .control:
       return 25


### PR DESCRIPTION
sucessfully -> successfully
acknowledgement -> acknowledgment
prefered -> preferred
refered -> referred
completly -> completely
occurences -> occurrences
occured -> occurred
occuring -> occurring
publically -> publicly
Therefor -> Therefore
agressively -> aggressively
immediatly -> immediately
enviroment -> environment
accross -> across
seperator -> separator