### PR TITLE
[CS] Add contextual Bool type to switch-case `where` clause 

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -5110,7 +5110,8 @@ public:
   /// \returns true if an error occurred, false otherwise.
   LLVM_NODISCARD
   bool generateConstraints(SolutionApplicationTarget &target,
-                           FreeTypeVariableBinding allowFreeTypeVariables);
+                           FreeTypeVariableBinding allowFreeTypeVariables =
+                               FreeTypeVariableBinding::Disallow);
 
   /// Generate constraints for the body of the given function or closure.
   ///

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -359,7 +359,7 @@ protected:
     // binding.
     if (cs) {
       SolutionApplicationTarget target(patternBinding);
-      if (cs->generateConstraints(target, FreeTypeVariableBinding::Disallow))
+      if (cs->generateConstraints(target))
         hadError = true;
     }
   }
@@ -661,7 +661,7 @@ protected:
       // FIXME: Add contextual type purpose for switch subjects?
       SolutionApplicationTarget target(subjectExpr, dc, CTP_Unused, Type(),
                                        /*isDiscarded=*/false);
-      if (cs->generateConstraints(target, FreeTypeVariableBinding::Disallow)) {
+      if (cs->generateConstraints(target)) {
         hadError = true;
         return nullptr;
       }
@@ -789,7 +789,7 @@ protected:
     auto target = SolutionApplicationTarget::forForEachStmt(
         forEachStmt, dc, /*bindPatternVarsOneWay=*/true);
     if (cs) {
-      if (cs->generateConstraints(target, FreeTypeVariableBinding::Disallow)) {
+      if (cs->generateConstraints(target)) {
         hadError = true;
         return nullptr;
       }
@@ -890,7 +890,7 @@ protected:
                                        CTP_ThrowStmt,
                                        ctx.getErrorExistentialType(),
                                        /*isDiscarded=*/false);
-      if (cs->generateConstraints(target, FreeTypeVariableBinding::Disallow))
+      if (cs->generateConstraints(target))
         hadError = true;
 
       cs->setSolutionApplicationTarget(throwStmt, target);

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -886,15 +886,15 @@ protected:
     }
 
     if (cs) {
-     SolutionApplicationTarget target(
-         throwStmt->getSubExpr(), dc, CTP_ThrowStmt,
-         ctx.getErrorExistentialType(),
-         /*isDiscarded=*/false);
-     if (cs->generateConstraints(target, FreeTypeVariableBinding::Disallow))
-       hadError = true;
+      SolutionApplicationTarget target(throwStmt->getSubExpr(), dc,
+                                       CTP_ThrowStmt,
+                                       ctx.getErrorExistentialType(),
+                                       /*isDiscarded=*/false);
+      if (cs->generateConstraints(target, FreeTypeVariableBinding::Disallow))
+        hadError = true;
 
-     cs->setSolutionApplicationTarget(throwStmt, target);
-   }
+      cs->setSolutionApplicationTarget(throwStmt, target);
+    }
 
     return nullptr;
   }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -9224,20 +9224,13 @@ ExprWalker::rewriteTarget(SolutionApplicationTarget target) {
     }
 
     // If there is a guard expression, coerce that.
-    if (auto guardExpr = info.guardExpr) {
-      guardExpr = guardExpr->walk(*this);
-      if (!guardExpr)
+    if (auto *guardExpr = info.guardExpr) {
+      auto target = *cs.getSolutionApplicationTarget(guardExpr);
+      auto resultTarget = rewriteTarget(target);
+      if (!resultTarget)
         return None;
 
-      // FIXME: Feels like we could leverage existing code more.
-      Type boolType = cs.getASTContext().getBoolType();
-      guardExpr = solution.coerceToType(
-          guardExpr, boolType, cs.getConstraintLocator(info.guardExpr));
-      if (!guardExpr)
-        return None;
-
-      (*caseLabelItem)->setGuardExpr(guardExpr);
-      solution.setExprTypes(guardExpr);
+      (*caseLabelItem)->setGuardExpr(resultTarget->getAsExpr());
     }
 
     return target;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4074,7 +4074,7 @@ namespace {
         auto &CS = CG.getConstraintSystem();
         for (const auto &capture : captureList->getCaptureList()) {
           SolutionApplicationTarget target(capture.PBD);
-          if (CS.generateConstraints(target, FreeTypeVariableBinding::Disallow))
+          if (CS.generateConstraints(target))
             return Action::Stop();
         }
       }
@@ -4327,8 +4327,7 @@ generateForEachStmtConstraints(
         TypeLoc::withoutLoc(sequenceProto->getDeclaredInterfaceType()),
         CTP_ForEachSequence);
 
-    if (cs.generateConstraints(makeIteratorTarget,
-                               FreeTypeVariableBinding::Disallow))
+    if (cs.generateConstraints(makeIteratorTarget))
       return None;
 
     forEachStmtInfo.makeIteratorVar = PB;
@@ -4613,7 +4612,7 @@ bool ConstraintSystem::generateConstraints(
                          : SolutionApplicationTarget::forUninitializedVar(
                                patternBinding, index, patternType);
 
-      if (generateConstraints(target, FreeTypeVariableBinding::Disallow)) {
+      if (generateConstraints(target)) {
         hadError = true;
         continue;
       }
@@ -4698,7 +4697,7 @@ bool ConstraintSystem::generateConstraints(StmtCondition condition,
       auto target = SolutionApplicationTarget(symbolExpr, dc, CTP_Unused,
                                               Type(), /*isDiscarded=*/false);
 
-      if (generateConstraints(target, FreeTypeVariableBinding::Disallow))
+      if (generateConstraints(target))
         return true;
 
       setSolutionApplicationTarget(&condElement, target);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -4768,9 +4768,15 @@ bool ConstraintSystem::generateConstraints(
     // Generate constraints for the guard expression, if there is one.
     Expr *guardExpr = caseLabelItem.getGuardExpr();
     if (guardExpr) {
-      guardExpr = generateConstraints(guardExpr, dc);
-      if (!guardExpr)
+      auto &ctx = dc->getASTContext();
+      SolutionApplicationTarget guardTarget(
+          guardExpr, dc, CTP_Condition, ctx.getBoolType(), /*discarded*/ false);
+
+      if (generateConstraints(guardTarget))
         return true;
+
+      guardExpr = guardTarget.getAsExpr();
+      setSolutionApplicationTarget(guardExpr, guardTarget);
     }
 
     // Save this info.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9869,7 +9869,7 @@ static bool inferEnumMemberThroughTildeEqualsOperator(
     }
   }
 
-  if (cs.generateConstraints(target, FreeTypeVariableBinding::Disallow))
+  if (cs.generateConstraints(target))
     return true;
 
   // Sub-expression associated with expression pattern is the enum element

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1684,7 +1684,7 @@ bool ConstraintSystem::solveForCodeCompletion(
         << "--- Code Completion ---\n";
   }
 
-  if (generateConstraints(target, FreeTypeVariableBinding::Disallow))
+  if (generateConstraints(target))
     return false;
 
   solveForCodeCompletion(solutions);

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -580,7 +580,7 @@ private:
         forEachStmt, context.getAsDeclContext(),
         /*bindTypeVarsOneWay=*/false);
 
-    if (cs.generateConstraints(target, FreeTypeVariableBinding::Disallow)) {
+    if (cs.generateConstraints(target)) {
       hadError = true;
       return;
     }
@@ -734,7 +734,7 @@ private:
     if (isPlaceholderVar(patternBinding))
       return;
 
-    if (cs.generateConstraints(*target, FreeTypeVariableBinding::Disallow)) {
+    if (cs.generateConstraints(*target)) {
       hadError = true;
       return;
     }
@@ -1128,7 +1128,7 @@ private:
                                      contextualResultInfo.getType(),
                                      /*isDiscarded=*/false);
 
-    if (cs.generateConstraints(target, FreeTypeVariableBinding::Disallow)) {
+    if (cs.generateConstraints(target)) {
       hadError = true;
       return;
     }
@@ -1430,7 +1430,7 @@ ConstraintSystem::simplifySyntacticElementConstraint(
                                      contextInfo.purpose, contextInfo.getType(),
                                      contextualTypeLoc, isDiscarded);
 
-    if (generateConstraints(target, FreeTypeVariableBinding::Disallow))
+    if (generateConstraints(target))
       return SolutionKind::Error;
 
     setSolutionApplicationTarget(expr, target);

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1531,6 +1531,22 @@ func testUnwrapFixIts(x: Int?) throws {
   let _: Int = try! .optionalThrowsMember ?? 0
 }
 
+// https://github.com/apple/swift/issues/63746
+func issue63746() {
+  let fn1 = {
+    switch 0 {
+      case 1 where 0: // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+        ()
+    }
+  }
+  let fn2 = {
+    switch 0 {
+      case 1 where 0: // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+        break
+    }
+  }
+}
+
 func rdar86611718(list: [Int]) {
   String(list.count())
   // expected-error@-1 {{cannot call value of non-function type 'Int'}}


### PR DESCRIPTION
Seems this was accidentally omitted, which would crash in CSApply for any non-Bool-convertible type.

Resolves #63746