### PR TITLE
SIL: add type-dependent operands to the `keypath` instruction

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3867,7 +3867,8 @@ class KeyPathInst final
   friend TrailingObjects;
   
   KeyPathPattern *Pattern;
-  unsigned NumOperands;
+  unsigned numPatternOperands;
+  unsigned numTypeDependentOperands;
   SubstitutionMap Substitutions;
   
   static KeyPathInst *create(SILDebugLocation Loc,
@@ -3880,11 +3881,12 @@ class KeyPathInst final
   KeyPathInst(SILDebugLocation Loc,
               KeyPathPattern *Pattern,
               SubstitutionMap Subs,
-              ArrayRef<SILValue> Args,
+              ArrayRef<SILValue> allOperands,
+              unsigned numPatternOperands,
               SILType Ty);
   
   size_t numTrailingObjects(OverloadToken<Operand>) const {
-    return NumOperands;
+    return numPatternOperands + numTypeDependentOperands;
   }
   
 public:
@@ -3895,6 +3897,23 @@ public:
     return const_cast<KeyPathInst*>(this)->getAllOperands();
   }
   MutableArrayRef<Operand> getAllOperands();
+
+  ArrayRef<Operand> getPatternOperands() const {
+    return getAllOperands().slice(0, numPatternOperands);
+  }
+
+  MutableArrayRef<Operand> getPatternOperands() {
+    return getAllOperands().slice(0, numPatternOperands);
+  }
+
+
+  ArrayRef<Operand> getTypeDependentOperands() const {
+    return getAllOperands().slice(numPatternOperands);
+  }
+
+  MutableArrayRef<Operand> getTypeDependentOperands() {
+    return getAllOperands().slice(numPatternOperands);
+  }
 
   SubstitutionMap getSubstitutions() const { return Substitutions; }
 

--- a/lib/SIL/IR/SILPrinter.cpp
+++ b/lib/SIL/IR/SILPrinter.cpp
@@ -2673,10 +2673,10 @@ public:
       *this << ' ';
       printSubstitutions(KPI->getSubstitutions());
     }
-    if (!KPI->getAllOperands().empty()) {
+    if (!KPI->getPatternOperands().empty()) {
       *this << " (";
       
-      interleave(KPI->getAllOperands(),
+      interleave(KPI->getPatternOperands(),
         [&](const Operand &operand) {
           *this << Ctx.getID(operand.get());
         }, [&]{

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -5240,7 +5240,7 @@ public:
           baseTy,
           leafTy,
           component,
-          KPI->getAllOperands(),
+          KPI->getPatternOperands(),
           KPI->getPattern()->getGenericSignature(),
           KPI->getSubstitutions(),
           /*property descriptor*/false,

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -73,7 +73,7 @@ static SILInstruction *getConstant(SILValue V) {
     // mangling scheme.
     // But currently it's not worth it because we do not optimize subscript
     // keypaths in SILCombine.
-    if (kp->getNumOperands() != 0)
+    if (kp->getPatternOperands().size() != 0)
       return nullptr;
     if (!kp->hasPattern())
       return nullptr;

--- a/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadObjectElimination.cpp
@@ -882,7 +882,7 @@ bool DeadObjectElimination::processKeyPath(KeyPathInst *KPI) {
 
   // For simplicity just bail if the keypath has a non-trivial operands.
   // TODO: don't bail but insert compensating destroys for such operands.
-  for (const Operand &Op : KPI->getAllOperands()) {
+  for (const Operand &Op : KPI->getPatternOperands()) {
     if (!Op.get()->getType().isTrivial(*KPI->getFunction()))
       return false;
   }

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2490,7 +2490,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       writeKeyPathPatternComponent(component, ListOfValues);
     }
     
-    for (auto &operand : KPI->getAllOperands()) {
+    for (auto &operand : KPI->getPatternOperands()) {
       auto value = operand.get();
       ListOfValues.push_back(addValueRef(value));
       ListOfValues.push_back(S.addTypeRef(value->getType().getASTType()));

--- a/test/SILOptimizer/inline_keypath.swift
+++ b/test/SILOptimizer/inline_keypath.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend -O -emit-sil %s | %FileCheck %s
+
+public protocol P {}
+
+// CHECK-LABEL: sil @$s14inline_keypath6testitySbAA1P_pXp_s14PartialKeyPathCyxGtSlRzlF
+// CHECK:         [[T:%[0-9]+]] = open_existential_metatype %0
+// CHECK:         = keypath {{.*}}@opened{{.*}} type-defs: [[T]]
+// CHECK:       } // end sil function '$s14inline_keypath6testitySbAA1P_pXp_s14PartialKeyPathCyxGtSlRzlF'
+public func testit<C: Collection>(_ t: any P.Type, _ kp: PartialKeyPath<C>) -> Bool {
+  return tyFunc(t, kp)
+}
+
+@inline(__always)
+func tyFunc<C: Collection, H: P>(_ h: H.Type, _ kp: PartialKeyPath<C>) -> Bool {
+  return kp == \Array<H>.count
+}
+
+


### PR DESCRIPTION
It's need to correctly maintain dependencies from an open-existential instruction to a `keypath` instruction which uses the opened type. Fixes a SILVerifier crash.

rdar://105517521
