### PR TITLE
[move-only] A few small changes in preparation for a larger patch

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -792,6 +792,8 @@ ERROR(sil_moveonlychecker_not_understand_consumable_and_assignable, none,
 ERROR(sil_moveonlychecker_not_understand_moveonly, none,
       "Usage of a move only type that the move checker does not know how to "
       "check!", ())
+ERROR(sil_moveonlychecker_missed_copy, none,
+      "copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug", ())
 
 // move kills copyable values checker diagnostics
 ERROR(sil_movekillscopyablevalue_value_consumed_more_than_once, none,

--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -556,11 +556,24 @@ inline DebugVarCarryingInst DebugVarCarryingInst::getFromValue(SILValue value) {
   return DebugVarCarryingInst();
 }
 
+static_assert(sizeof(DebugVarCarryingInst) == sizeof(VarDeclCarryingInst) &&
+                  alignof(DebugVarCarryingInst) == alignof(VarDeclCarryingInst),
+              "Expected debug var carrying inst to have the same "
+              "size/alignment/layout as VarDeclCarryingInst!");
+
 /// Attempt to discover a StringRef varName for the value \p value based only
 /// off of debug var information. If we fail, we return the name "unknown".
 inline StringRef getDebugVarName(SILValue value) {
   auto inst = DebugVarCarryingInst::getFromValue(value);
   return DebugVarCarryingInst::getName(inst);
+}
+
+inline StringRef getDiagnosticName(SILValue value) {
+  if (auto inst = DebugVarCarryingInst::getFromValue(value))
+    return inst.getName();
+  if (auto inst = VarDeclCarryingInst::getFromValue(value))
+    return inst.getName();
+  return "unknown";
 }
 
 } // end namespace swift

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -1254,6 +1254,8 @@ struct AccessPathWithBase {
     return AccessBase(base, accessPath.getStorage().getKind());
   }
 
+  bool isValid() const { return base && accessPath.isValid(); }
+
   bool operator==(AccessPathWithBase other) const {
     return accessPath == other.accessPath && base == other.base;
   }

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -439,6 +439,16 @@ public:
         ElementTypes, ElementCountOperands));
   }
 
+  /// Helper function that calls \p createAllocBox after constructing a
+  /// SILBoxType for \p fieldType.
+  AllocBoxInst *createAllocBox(SILLocation loc, SILType fieldType,
+                               Optional<SILDebugVariable> Var = None,
+                               bool hasDynamicLifetime = false,
+                               bool reflection = false) {
+    return createAllocBox(loc, SILBoxType::get(fieldType.getASTType()), Var,
+                          hasDynamicLifetime, reflection);
+  }
+
   AllocBoxInst *createAllocBox(SILLocation Loc, CanSILBoxType BoxType,
                                Optional<SILDebugVariable> Var = None,
                                bool hasDynamicLifetime = false,

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -695,7 +695,7 @@ public:
   ///
   /// \p field Return the type of the ith field of the box. Default set to 0
   /// since we only support one field today. This is just future proofing.
-  SILType getSILBoxFieldType(const SILFunction *f, unsigned field = 0);
+  SILType getSILBoxFieldType(const SILFunction *f, unsigned field = 0) const;
 
   /// Returns the hash code for the SILType.
   llvm::hash_code getHashCode() const {
@@ -707,6 +707,17 @@ public:
   /// type of its field, which it is guaranteed to have identical layout to.
   SILType getSingletonAggregateFieldType(SILModule &M,
                                          ResilienceExpansion expansion) const;
+
+  /// \returns true if this is a SILBoxType containing a noncopyable type.
+  bool isBoxedNonCopyableType(const SILFunction *fn) const {
+    if (!this->is<SILBoxType>())
+      return false;
+    return getSILBoxFieldType(fn).isMoveOnly();
+  }
+
+  bool isBoxedNonCopyableType(const SILFunction &fn) const {
+    return isBoxedNonCopyableType(&fn);
+  }
 
   //
   // Accessors for types used in SIL instructions:

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -665,6 +665,8 @@ struct SILConstantInfo {
 enum class CaptureKind {
   /// A local value captured as a mutable box.
   Box,
+  /// A local value captured as an immutable box.
+  ImmutableBox,
   /// A local value captured as a single pointer to storage (formed with
   /// @noescape closures).
   StorageAddress,
@@ -673,7 +675,6 @@ enum class CaptureKind {
   /// A let constant captured as a pointer to storage
   Immutable
 };
-
 
 /// TypeConverter - helper class for creating and managing TypeLowerings.
 class TypeConverter {

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1853,6 +1853,21 @@ lowerCaptureContextParameters(TypeConverter &TC, SILDeclRef function,
       inputs.push_back(param);
       break;
     }
+    case CaptureKind::ImmutableBox: {
+      // The type in the box is lowered in the minimal context.
+      auto minimalLoweredTy =
+          TC.getTypeLowering(AbstractionPattern(genericSig, canType), canType,
+                             TypeExpansionContext::minimal())
+              .getLoweredType();
+      // Lvalues are captured as a box that owns the captured value.
+      auto boxTy =
+          TC.getInterfaceBoxTypeForCapture(VD, minimalLoweredTy.getASTType(),
+                                           /*mutable*/ false);
+      auto convention = ParameterConvention::Direct_Guaranteed;
+      auto param = SILParameterInfo(boxTy, convention);
+      inputs.push_back(param);
+      break;
+    }
     case CaptureKind::StorageAddress: {
       // Non-escaping lvalues are captured as the address of the value.
       SILType ty = loweredTy.getAddressType();

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -861,7 +861,7 @@ bool SILType::isEffectivelyExhaustiveEnumType(SILFunction *f) {
                                        f->getResilienceExpansion());
 }
 
-SILType SILType::getSILBoxFieldType(const SILFunction *f, unsigned field) {
+SILType SILType::getSILBoxFieldType(const SILFunction *f, unsigned field) const {
   auto *boxTy = getASTType()->getAs<SILBoxType>();
   if (!boxTy)
     return SILType();

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1070,7 +1070,8 @@ swift::findTransitiveUsesForAddress(SILValue projectedAddress,
         isa<SwitchEnumAddrInst>(user) || isa<CheckedCastAddrBranchInst>(user) ||
         isa<SelectEnumAddrInst>(user) || isa<InjectEnumAddrInst>(user) ||
         isa<IsUniqueInst>(user) || isa<ValueMetatypeInst>(user) ||
-        isa<DebugValueInst>(user) || isa<EndBorrowInst>(user)) {
+        isa<DebugValueInst>(user) || isa<EndBorrowInst>(user) ||
+        isa<ExplicitCopyAddrInst>(user)) {
       leafUse(op);
       continue;
     }

--- a/lib/SILGen/ManagedValue.h
+++ b/lib/SILGen/ManagedValue.h
@@ -364,6 +364,11 @@ public:
     return bool(getValue()) || valueAndFlag.getInt();
   }
 
+  SILFunction *getFunction() const {
+    assert(getValue());
+    return getValue()->getFunction();
+  }
+
   void dump() const;
   void dump(raw_ostream &os, unsigned indent = 0) const;
   void print(raw_ostream &os) const;

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -1002,3 +1002,10 @@ ManagedValue SILGenBuilder::emitCopyValueOperation(SILLocation loc,
     return value;
   return SGF.emitManagedRValueWithCleanup(cvi);
 }
+
+void SILGenBuilder::emitCopyAddrOperation(SILLocation loc, SILValue srcAddr,
+                                          SILValue destAddr, IsTake_t isTake,
+                                          IsInitialization_t isInitialize) {
+  auto &lowering = getTypeLowering(srcAddr->getType());
+  lowering.emitCopyInto(*this, loc, srcAddr, destAddr, isTake, isInitialize);
+}

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -449,6 +449,10 @@ public:
 
   using SILBuilder::emitCopyValueOperation;
   ManagedValue emitCopyValueOperation(SILLocation Loc, ManagedValue v);
+
+  void emitCopyAddrOperation(SILLocation loc, SILValue srcAddr,
+                             SILValue destAddr, IsTake_t isTake,
+                             IsInitialization_t isInitialize);
 };
 
 } // namespace Lowering

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransform.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTransform.cpp
@@ -1275,9 +1275,11 @@ void Implementation::rewriteUses(InstructionDeleter *deleter) {
               first = builder.createOwnedMoveOnlyWrapperToCopyableValue(
                   getSafeLoc(inst), first);
             }
+            // NOTE: oldInst may be nullptr if our operand is a SILArgument
+            // which can happen with switch_enum.
             SILInstruction *oldInst = operand.get()->getDefiningInstruction();
             operand.set(first);
-            if (deleter)
+            if (oldInst && deleter)
               deleter->forceTrackAsDead(oldInst);
             continue;
           }
@@ -1309,9 +1311,11 @@ void Implementation::rewriteUses(InstructionDeleter *deleter) {
           // NOTE: This needs to be /after/the interior pointer operand usage
           // above so that we can use the end scope of our interior pointer base
           // value.
+          // NOTE: oldInst may be nullptr if our operand is a SILArgument
+          // which can happen with switch_enum.
           SILInstruction *oldInst = operand.get()->getDefiningInstruction();
           operand.set(innerValue);
-          if (deleter)
+          if (oldInst && deleter)
             deleter->forceTrackAsDead(oldInst);
           continue;
         }
@@ -1370,9 +1374,11 @@ void Implementation::rewriteUses(InstructionDeleter *deleter) {
                 borrowBuilder.createGuaranteedMoveOnlyWrapperToCopyableValue(
                     loc, value);
           }
+          // NOTE: oldInst may be nullptr if our operand is a SILArgument
+          // which can happen with switch_enum.
           auto *oldInst = operand.get()->getDefiningInstruction();
           operand.set(value);
-          if (deleter)
+          if (oldInst && deleter)
             deleter->forceTrackAsDead(oldInst);
 
           // If we have a terminator that is a trivial use (e.x.: we
@@ -1443,9 +1449,11 @@ void Implementation::rewriteUses(InstructionDeleter *deleter) {
           iterValue = consumeBuilder.createOwnedMoveOnlyWrapperToCopyableValue(
               loc, iterValue);
         }
+        // NOTE: oldInst may be nullptr if our operand is a SILArgument
+        // which can happen with switch_enum.
         auto *oldInst = operand.get()->getDefiningInstruction();
         operand.set(iterValue);
-        if (deleter)
+        if (oldInst && deleter)
           deleter->forceTrackAsDead(oldInst);
 
         // Then go through our available values and use the interval map to

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -168,6 +168,11 @@ void DiagnosticEmitter::emitCheckerDoesntUnderstandDiagnostic(
   emittedCheckerDoesntUnderstandDiagnostic = true;
 }
 
+void DiagnosticEmitter::emitCheckedMissedCopyError(SILInstruction *copyInst) {
+  diagnose(copyInst->getFunction()->getASTContext(), copyInst,
+           diag::sil_moveonlychecker_missed_copy);
+}
+
 //===----------------------------------------------------------------------===//
 //                          MARK: Object Diagnostics
 //===----------------------------------------------------------------------===//

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -71,6 +71,10 @@ public:
     return emittedCheckerDoesntUnderstandDiagnostic;
   }
 
+  /// Used at the end of the MoveOnlyAddressChecker to tell the user in a nice
+  /// way to file a bug.
+  void emitCheckedMissedCopyError(SILInstruction *copyInst);
+
   void emitCheckerDoesntUnderstandDiagnostic(MarkMustCheckInst *markedValue);
   void emitObjectGuaranteedDiagnostic(MarkMustCheckInst *markedValue);
   void emitObjectOwnedDiagnostic(MarkMustCheckInst *markedValue);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2261,17 +2261,24 @@ bool TypeResolver::diagnoseMoveOnly(TypeRepr *repr, Type genericArgTy) {
 bool TypeResolver::diagnoseMoveOnlyMissingOwnership(
                                               TypeRepr *repr,
                                               TypeResolutionOptions options) {
-  // only required on function inputs.
-  // we can ignore InoutFunctionInput since it's already got ownership.
+  // Though this is only required on function inputs... we can ignore
+  // InoutFunctionInput since it's already got ownership.
   if (!options.is(TypeResolverContext::FunctionInput))
     return false;
 
-  // enum cases don't need to specify ownership for associated values
+  // Enum cases don't need to specify ownership for associated values
   if (options.hasBase(TypeResolverContext::EnumElementDecl))
     return false;
 
-  // otherwise, we require ownership.
+  // Otherwise, we require ownership.
   if (options.contains(TypeResolutionFlags::HasOwnership))
+    return false;
+
+  // Do not run this on SIL files since there is currently a bug where we are
+  // trying to parse it in SILBoxes.
+  //
+  // To track what we want to do long term: rdar://105635373.
+  if (options.contains(TypeResolutionFlags::SILType))
     return false;
 
   diagnose(repr->getLoc(),

--- a/test/SILOptimizer/allocbox_to_stack_noncopyable.sil
+++ b/test/SILOptimizer/allocbox_to_stack_noncopyable.sil
@@ -1,0 +1,65 @@
+// RUN: %target-sil-opt -enable-experimental-move-only -enable-sil-verify-all %s -allocbox-to-stack -enable-copy-propagation=requested-passes-only -enable-lexical-borrow-scopes=false | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+
+@_moveOnly
+struct NonTrivialStruct {
+  var i: Builtin.Int32
+}
+
+sil @use_nontrivialstruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+
+sil [ossa] @host_markmustcheck_closure : $@convention(thin) (@guaranteed { var NonTrivialStruct }) -> () {
+bb0(%0 : @closureCapture @guaranteed ${ var NonTrivialStruct }):
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @hoist_markmustcheck : $@convention(thin) (@owned NonTrivialStruct) -> () {
+// CHECK: bb0([[ARG:%.*]] : @owned
+// CHECK-NEXT:   [[STACK1:%.*]] = alloc_stack $NonTrivialStruct
+// CHECK-NEXT:   [[MARKED1:%.*]] = mark_must_check [consumable_and_assignable] [[STACK1]]
+// CHECK-NEXT:   store [[ARG]] to [init] [[MARKED1]]
+// CHECK-NEXT:   [[LOADED_VALUE:%.*]] = load [take] [[MARKED1]]
+// CHECK-NEXT:   [[STACK2:%.*]] = alloc_stack $NonTrivialStruct
+// CHECK-NEXT:   [[MARKED2:%.*]] = mark_must_check [consumable_and_assignable] [[STACK2]]
+// CHECK-NEXT:   store [[LOADED_VALUE]] to [init] [[MARKED2]]
+// CHECK-NEXT:   // function_ref
+// CHECK-NEXT:   [[FUNC:%.*]] = function_ref @$s26host_markmustcheck_closureTf0s_n : $@convention(thin) (@inout_aliasable NonTrivialStruct) -> ()
+// CHECK-NEXT:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[FUNC]]([[MARKED2]]) : $@convention(thin) (@inout_aliasable NonTrivialStruct) -> ()
+// CHECK-NEXT:   apply [[PA]]()
+// CHECK-NEXT:   destroy_value [[PA]]
+// CHECK-NEXT:   destroy_addr [[MARKED2]]
+// CHECK-NEXT:   dealloc_stack [[STACK2]]
+// CHECK-NEXT:   dealloc_stack [[STACK1]]
+// CHECK-NEXT:   tuple ()
+// CHECK-NEXT:   return
+// CHECK: } // end sil function 'hoist_markmustcheck'
+sil [ossa] @hoist_markmustcheck : $@convention(thin) (@owned NonTrivialStruct) -> () {
+bb0(%0 : @owned $NonTrivialStruct):
+  %1 = alloc_box ${ var NonTrivialStruct }
+  %2 = project_box %1 : ${ var NonTrivialStruct }, 0
+  store %0 to [init] %2 : $*NonTrivialStruct
+
+  %3 = project_box %1 : ${ var NonTrivialStruct }, 0
+  %3a = mark_must_check [assignable_but_not_consumable] %3 : $*NonTrivialStruct
+  %3b = load [take] %3a : $*NonTrivialStruct
+
+  %4 = alloc_box ${ var NonTrivialStruct }
+  %4a = project_box %4 : ${ var NonTrivialStruct }, 0
+  %4b = mark_must_check [assignable_but_not_consumable] %4a : $*NonTrivialStruct
+  store %3b to [init] %4b : $*NonTrivialStruct
+
+  %f = function_ref @host_markmustcheck_closure : $@convention(thin) (@guaranteed { var NonTrivialStruct }) -> ()
+  %5c = copy_value %4 : ${ var NonTrivialStruct }
+  %g = partial_apply [callee_guaranteed] %f(%5c) : $@convention(thin) (@guaranteed { var NonTrivialStruct }) -> ()
+  apply %g() : $@callee_guaranteed () -> ()
+
+  destroy_value %g : $@callee_guaranteed () -> ()
+  destroy_value %4 : ${ var NonTrivialStruct }
+  dealloc_box %1 : ${ var NonTrivialStruct }
+  %9999 = tuple()
+  return %9999 : $()
+}

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -1,4 +1,5 @@
 // RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all %s -verify
+// RUN: %target-sil-opt -sil-move-only-address-checker -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses -enable-sil-verify-all -move-only-diagnostics-silently-emit-diagnostics %s | %FileCheck %s
 
 // TODO: Add FileCheck
 
@@ -202,3 +203,75 @@ bb0(%arg : @owned $NonTrivialStruct, %arg1 : @owned $NonTrivialStruct):
   %33 = tuple ()
   return %33 : $()
 }
+
+// In this case, we already emitted an object error earlier so all of the
+// copy_value are explicit_copy_value. We shouldn't crash when processing
+// this. We used to due to borrow to destructure trying to delete
+// %14->getOperand(Src)->getDefiningInstruction() and not handling the case
+// where %10 was an argument.
+sil [ossa] @enumPatternMatchSwitch : $@convention(thin) (@guaranteed EnumTy) -> () {
+bb0(%0 : @guaranteed $EnumTy):
+  %1 = explicit_copy_value %0 : $EnumTy
+  debug_value %1 : $EnumTy, let, name "x", argno 1
+  %3 = alloc_box ${ var EnumTy }, let, name "x2"
+  %4 = project_box %3 : ${ var EnumTy }, 0
+  %5 = mark_must_check [consumable_and_assignable] %4 : $*EnumTy // expected-error {{'x2' used after consume}}
+  store %1 to [init] %5 : $*EnumTy
+  %7 = load [copy] %5 : $*EnumTy // expected-note {{consuming use here}}
+  %8 = begin_borrow %7 : $EnumTy
+  switch_enum %8 : $EnumTy, case #EnumTy.klass!enumelt: bb1, case #EnumTy.int!enumelt: bb2
+
+bb1(%10 : @guaranteed $NonTrivialStruct):
+  %11 = alloc_box ${ var NonTrivialStruct }, let, name "k"
+  %12 = project_box %11 : ${ var NonTrivialStruct }, 0
+  %13 = mark_must_check [consumable_and_assignable] %12 : $*NonTrivialStruct
+  %14 = explicit_copy_value %10 : $NonTrivialStruct
+  store %14 to [init] %13 : $*NonTrivialStruct
+  debug_value %13 : $*NonTrivialStruct, let, name "k", expr op_deref
+  %17 = load_borrow %13 : $*NonTrivialStruct
+  %18 = function_ref @nontrivialstruct_use : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  %19 = apply %18(%17) : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  end_borrow %17 : $NonTrivialStruct
+  %21 = load_borrow %5 : $*EnumTy // expected-note {{non-consuming use here}}
+  %22 = function_ref @enumty_use : $@convention(thin) (@guaranteed EnumTy) -> ()
+  %23 = apply %22(%21) : $@convention(thin) (@guaranteed EnumTy) -> ()
+  end_borrow %21 : $EnumTy
+  destroy_value %11 : ${ var NonTrivialStruct }
+  end_borrow %8 : $EnumTy
+  destroy_value %7 : $EnumTy
+  br bb3
+
+bb2(%28 : $Builtin.Int32):
+  end_borrow %8 : $EnumTy
+  destroy_value %7 : $EnumTy
+  br bb3
+
+bb3:
+  destroy_value %3 : ${ var EnumTy }
+  %33 = tuple ()
+  return %33 : $()
+}
+
+///////////////////////////////////////////////////////////////////////
+// MARK: Tests that make sure we emit a nice error for missed copies //
+///////////////////////////////////////////////////////////////////////
+
+// CHECK-LABEL: sil [ossa] @missed_copy_diagnostic_test : $@convention(thin) (@guaranteed NonTrivialStruct, @in_guaranteed NonTrivialStruct) -> () {
+// CHECK: explicit_copy_value
+// CHECK: explicit_copy_value
+// CHECK: explicit_copy_addr
+// CHECK: } // end sil function 'missed_copy_diagnostic_test'
+sil [ossa] @missed_copy_diagnostic_test : $@convention(thin) (@guaranteed NonTrivialStruct, @in_guaranteed NonTrivialStruct) -> () {
+bb0(%arg0 : @guaranteed $NonTrivialStruct, %arg1 : $*NonTrivialStruct):
+  %1 = copy_value %arg0 : $NonTrivialStruct // expected-error {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
+  destroy_value %1 : $NonTrivialStruct
+  %2 = load [copy] %arg1 : $*NonTrivialStruct // expected-error {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
+  destroy_value %2 : $NonTrivialStruct
+  %3 = alloc_stack $NonTrivialStruct
+  copy_addr %arg1 to [init] %3 : $*NonTrivialStruct // expected-error {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
+  destroy_addr %3 : $*NonTrivialStruct
+  dealloc_stack %3 : $*NonTrivialStruct
+  %9999 = tuple ()
+  return %9999 : $()
+}
+

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -105,7 +105,7 @@ bb0(%arg : @owned $AggStruct):
   // expected-error @-1 {{'x2' consumed more than once}}
   // expected-error @-2 {{'x2' consumed by a use in a loop}}
   %9 = begin_access [modify] [static] %1 : $*AggStruct
-  store %arg to [assign] %9 : $*AggStruct
+  store %arg to [init] %9 : $*AggStruct
   end_access %9 : $*AggStruct
   %12 = begin_access [read] [static] %1 : $*AggStruct
   %13 = struct_element_addr %12 : $*AggStruct, #AggStruct.pair
@@ -200,54 +200,6 @@ bb0(%arg : @owned $NonTrivialStruct, %arg1 : @owned $NonTrivialStruct):
   %30 = apply %29(%27) : $@convention(thin) (@owned Klass) -> ()
   destroy_addr %1 : $*NonTrivialStruct
   dealloc_stack %0 : $*NonTrivialStruct
-  %33 = tuple ()
-  return %33 : $()
-}
-
-// In this case, we already emitted an object error earlier so all of the
-// copy_value are explicit_copy_value. We shouldn't crash when processing
-// this. We used to due to borrow to destructure trying to delete
-// %14->getOperand(Src)->getDefiningInstruction() and not handling the case
-// where %10 was an argument.
-sil [ossa] @enumPatternMatchSwitch : $@convention(thin) (@guaranteed EnumTy) -> () {
-bb0(%0 : @guaranteed $EnumTy):
-  %1 = explicit_copy_value %0 : $EnumTy
-  debug_value %1 : $EnumTy, let, name "x", argno 1
-  %3 = alloc_box ${ var EnumTy }, let, name "x2"
-  %4 = project_box %3 : ${ var EnumTy }, 0
-  %5 = mark_must_check [consumable_and_assignable] %4 : $*EnumTy // expected-error {{'x2' used after consume}}
-  store %1 to [init] %5 : $*EnumTy
-  %7 = load [copy] %5 : $*EnumTy // expected-note {{consuming use here}}
-  %8 = begin_borrow %7 : $EnumTy
-  switch_enum %8 : $EnumTy, case #EnumTy.klass!enumelt: bb1, case #EnumTy.int!enumelt: bb2
-
-bb1(%10 : @guaranteed $NonTrivialStruct):
-  %11 = alloc_box ${ var NonTrivialStruct }, let, name "k"
-  %12 = project_box %11 : ${ var NonTrivialStruct }, 0
-  %13 = mark_must_check [consumable_and_assignable] %12 : $*NonTrivialStruct
-  %14 = explicit_copy_value %10 : $NonTrivialStruct
-  store %14 to [init] %13 : $*NonTrivialStruct
-  debug_value %13 : $*NonTrivialStruct, let, name "k", expr op_deref
-  %17 = load_borrow %13 : $*NonTrivialStruct
-  %18 = function_ref @nontrivialstruct_use : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
-  %19 = apply %18(%17) : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
-  end_borrow %17 : $NonTrivialStruct
-  %21 = load_borrow %5 : $*EnumTy // expected-note {{non-consuming use here}}
-  %22 = function_ref @enumty_use : $@convention(thin) (@guaranteed EnumTy) -> ()
-  %23 = apply %22(%21) : $@convention(thin) (@guaranteed EnumTy) -> ()
-  end_borrow %21 : $EnumTy
-  destroy_value %11 : ${ var NonTrivialStruct }
-  end_borrow %8 : $EnumTy
-  destroy_value %7 : $EnumTy
-  br bb3
-
-bb2(%28 : $Builtin.Int32):
-  end_borrow %8 : $EnumTy
-  destroy_value %7 : $EnumTy
-  br bb3
-
-bb3:
-  destroy_value %3 : ${ var EnumTy }
   %33 = tuple ()
   return %33 : $()
 }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1896,9 +1896,8 @@ public func closureCaptureClassUseAfterConsume() {
     var x2 = Klass()
     // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-4 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-5 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = Klass()
     let f = {
         borrowVal(x2)
@@ -1916,9 +1915,8 @@ public func closureCaptureClassUseAfterConsume() {
 
 public func closureCaptureClassUseAfterConsume2() {
     var x2 = Klass()
-    // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = Klass()
     let f = {
         borrowVal(x2)
@@ -1931,13 +1929,13 @@ public func closureCaptureClassUseAfterConsume2() {
 
 public func closureCaptureClassUseAfterConsumeError() {
     var x2 = Klass()
-    // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-1 {{'x2' consumed more than once}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' consumed more than once}}
     // expected-error @-4 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-5 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = Klass()
-    let f = {
+    let f = { // expected-note {{consuming use here}}
         borrowVal(x2)
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
@@ -1949,7 +1947,7 @@ public func closureCaptureClassUseAfterConsumeError() {
         // expected-note @-4 {{consuming use here}}
     }
     f()
-    let x3 = x2
+    let x3 = x2 // expected-note {{consuming use here}}
     let _ = x3
 }
 
@@ -2017,9 +2015,8 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
 
 public func closureAndDeferCaptureClassUseAfterConsume() {
     var x2 = Klass()
-    // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-3 {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     x2 = Klass()
     let f = {
         defer {
@@ -2037,10 +2034,9 @@ public func closureAndDeferCaptureClassUseAfterConsume() {
 public func closureAndDeferCaptureClassUseAfterConsume2() {
     var x2 = Klass()
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-3 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    // expected-error @-3 {{'x2' used after consume}}
     // expected-error @-4 {{'x2' used after consume}}
-    // expected-error @-5 {{'x2' used after consume}}
     x2 = Klass()
     let f = {
         consumeVal(x2)
@@ -2063,12 +2059,12 @@ public func closureAndDeferCaptureClassUseAfterConsume2() {
 public func closureAndDeferCaptureClassUseAfterConsume3() {
     var x2 = Klass()
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' consumed more than once}}
     // expected-error @-4 {{'x2' used after consume}}
     // expected-error @-5 {{'x2' used after consume}}
     x2 = Klass()
-    let f = {
+    let f = { // expected-note {{consuming use here}}
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
@@ -2084,7 +2080,7 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
         print("foo")
     }
     f()
-    consumeVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
@@ -2110,11 +2106,10 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
 public func closureAndClosureCaptureClassUseAfterConsume() {
     var x2 = Klass()
     // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-error @-4 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-5 {{'x2' consumed more than once}}
-    // expected-error @-6 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-4 {{'x2' consumed more than once}}
+    // expected-error @-5 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = Klass()
     let f = {
         let g = {
@@ -2136,13 +2131,13 @@ public func closureAndClosureCaptureClassUseAfterConsume() {
 public func closureAndClosureCaptureClassUseAfterConsume2() {
     var x2 = Klass()
     // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-4 {{'x2' consumed more than once}}
     // expected-error @-5 {{'x2' consumed more than once}}
     // expected-error @-6 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = Klass()
-    let f = {
+    let f = { // expected-note {{consuming use here}}
         let g = {
             borrowVal(x2)
             consumeVal(x2)
@@ -2157,7 +2152,7 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
         g()
     }
     f()
-    consumeVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1200,11 +1200,10 @@ public func closureClassUseAfterConsumeArg(_ argX: inout NonTrivialStruct) {
 // We do not support captures of vars by closures today.
 public func closureCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-error @-4 {{'x2' consumed more than once}}
-    // expected-error @-5 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-4 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = NonTrivialStruct()
     let f = {
         borrowVal(x2)
@@ -1222,13 +1221,13 @@ public func closureCaptureClassUseAfterConsume() {
 
 public func closureCaptureClassUseAfterConsumeError() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-error @-4 {{'x2' consumed more than once}}
-    // expected-error @-5 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-4 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-5 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
-    let f = {
+    let f = { // expected-note {{consuming use here}}
         borrowVal(x2)
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
@@ -1240,7 +1239,7 @@ public func closureCaptureClassUseAfterConsumeError() {
         // expected-note @-4 {{consuming use here}}
     }
     f()
-    let x3 = x2
+    let x3 = x2 // expected-note {{consuming use here}}
     let _ = x3
 }
 
@@ -1308,9 +1307,8 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
 
 public func closureAndDeferCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-3 {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     x2 = NonTrivialStruct()
     let f = {
         defer {
@@ -1328,10 +1326,9 @@ public func closureAndDeferCaptureClassUseAfterConsume() {
 public func closureAndDeferCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-3 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    // expected-error @-3 {{'x2' used after consume}}
     // expected-error @-4 {{'x2' used after consume}}
-    // expected-error @-5 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
     let f = {
         consumeVal(x2)
@@ -1354,12 +1351,12 @@ public func closureAndDeferCaptureClassUseAfterConsume2() {
 public func closureAndDeferCaptureClassUseAfterConsume3() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' consumed more than once}}
     // expected-error @-4 {{'x2' used after consume}}
     // expected-error @-5 {{'x2' used after consume}}
     x2 = NonTrivialStruct()
-    let f = {
+    let f = { // expected-note {{consuming use here}}
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
         // expected-note @-2 {{consuming use here}}
@@ -1375,7 +1372,7 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
         print("foo")
     }
     f()
-    consumeVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
@@ -1401,11 +1398,10 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivial
 public func closureAndClosureCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-3 {{'x2' consumed more than once}}
     // expected-error @-4 {{'x2' consumed more than once}}
-    // expected-error @-5 {{'x2' consumed more than once}}
-    // expected-error @-6 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-5 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = NonTrivialStruct()
     let f = {
         let g = {
@@ -1427,13 +1423,13 @@ public func closureAndClosureCaptureClassUseAfterConsume() {
 public func closureAndClosureCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-2 {{Usage of a move only type that the move checker does not know how to check!}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-4 {{'x2' consumed more than once}}
     // expected-error @-5 {{'x2' consumed more than once}}
     // expected-error @-6 {{'x2' consumed in closure but not reinitialized before end of closure}}
     x2 = NonTrivialStruct()
-    let f = {
+    let f = { // expected-note {{consuming use here}}
         let g = {
             borrowVal(x2)
             consumeVal(x2)
@@ -1448,7 +1444,7 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
         g()
     }
     f()
-    consumeVal(x2)
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 


### PR DESCRIPTION
This PR contains a few small helper PRs and also enables by default a diagnostic error that is emitted if the checkers missed a copy. The diagnostic asks the user to file a bug. This is better than crashing the compiler.