### PR TITLE
IRGen: consider deployment target when emitting $ld$previous symbols

### DIFF
--- a/test/IRGen/original-defined-attr-linker-directives-fail.swift
+++ b/test/IRGen/original-defined-attr-linker-directives-fail.swift
@@ -6,6 +6,8 @@
 // RUN: not %target-swift-frontend -swift-version 4 -enforce-exclusivity=checked %s -emit-ir -module-name CurrentModule -D CURRENT_MODULE -previous-module-installname-map-file %t/nil.json >& %t/error.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-ERROR < %t/error.txt
 
+// RUN: %target-swift-frontend -target x86_64-apple-macosx10.6 -swift-version 4 -enforce-exclusivity=checked %s -emit-ir -module-name CurrentModule -D CURRENT_MODULE -previous-module-installname-map-file %t/install-name.json | %FileCheck %s -check-prefix=CHECK-SYMBOLS-LOW-TARGET
+
 @available(OSX 10.8, *)
 @_originallyDefinedIn(module: "OriginalModule", macOS 10.10)
 public struct Entity {
@@ -18,5 +20,11 @@ public struct Entity {
 // CHECK-SYMBOLS: $ld$previous$/System/OriginalModule.dylib$$1$10.8$10.10$_$s14OriginalModule6EntityVN$
 // CHECK-SYMBOLS: $ld$previous$/System/OriginalModule.dylib$$1$10.8$10.10$_$s14OriginalModule6EntityVMa$
 // CHECK-SYMBOLS: $ld$previous$/System/OriginalModule.dylib$$1$10.8$10.10$_$s14OriginalModule6EntityV06removeC0yyACF$
+
+// CHECK-SYMBOLS-LOW-TARGET: $ld$previous$/System/OriginalModule.dylib$$1$1.0$10.10$_$s14OriginalModule6EntityVMn$
+// CHECK-SYMBOLS-LOW-TARGET: $ld$previous$/System/OriginalModule.dylib$$1$1.0$10.10$_$s14OriginalModule6EntityV03addC0yyACF$
+// CHECK-SYMBOLS-LOW-TARGET: $ld$previous$/System/OriginalModule.dylib$$1$1.0$10.10$_$s14OriginalModule6EntityVN$
+// CHECK-SYMBOLS-LOW-TARGET: $ld$previous$/System/OriginalModule.dylib$$1$1.0$10.10$_$s14OriginalModule6EntityVMa$
+// CHECK-SYMBOLS-LOW-TARGET: $ld$previous$/System/OriginalModule.dylib$$1$1.0$10.10$_$s14OriginalModule6EntityV06removeC0yyACF$
 
 // CHECK-ERROR: cannot open previous install name map


### PR DESCRIPTION
Minimum deployment target can be set before the introduction of a moved symbol. When that happens, using the introductory version in the `$ld$previous` symbol could lead to ld not redirecting the linkage path to the original dylib, which is a mistake when running the App on newer OSs when the original dylib does exist.

rdar://105181824
