### PR TITLE
Print the Swift mangled name as a field in C++ interop generated classes

### DIFF
--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -435,3 +435,14 @@ void ClangSyntaxPrinter::printKnownCType(
   if (info->canBeNullable)
     os << " _Null_unspecified";
 }
+
+void ClangSyntaxPrinter::printSwiftMangledNameForDebugger(
+    const NominalTypeDecl *typeDecl) {
+  auto mangled_name =
+      mangler.mangleTypeForDebugger(typeDecl->getDeclaredInterfaceType(), nullptr);
+  if (!mangled_name.empty()) {
+    os << "  typedef char " << mangled_name << ";\n";
+    os << "  static inline constexpr " << mangled_name
+       << " __swift_mangled_name = 0;\n";
+  }
+}

--- a/lib/PrintAsClang/ClangSyntaxPrinter.h
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_PRINTASCLANG_CLANGSYNTAXPRINTER_H
 #define SWIFT_PRINTASCLANG_CLANGSYNTAXPRINTER_H
 
+#include "swift/AST/ASTMangler.h"
 #include "swift/AST/Type.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/ClangImporter/ClangImporter.h"
@@ -230,8 +231,14 @@ public:
   /// Print the given **known** type as a C type.
   void printKnownCType(Type t, PrimitiveTypeMapping &typeMapping) const;
 
+  /// Print the nominal type's Swift mangled name as a typedef from a char to
+  /// the mangled name, and a static constexpr variable declaration, whose type
+  /// is the aforementioned typedef, and whose name is known to the debugger.
+  void printSwiftMangledNameForDebugger(const NominalTypeDecl *typeDecl);
+
 protected:
   raw_ostream &os;
+  swift::Mangle::ASTMangler mangler;
 };
 
 } // end namespace swift

--- a/lib/PrintAsClang/PrintClangClassType.cpp
+++ b/lib/PrintAsClang/PrintClangClassType.cpp
@@ -77,6 +77,9 @@ void ClangClassTypePrinter::printClassTypeDecl(
   os << "  friend class " << cxx_synthesis::getCxxImplNamespaceName() << "::";
   printCxxImplClassName(os, typeDecl);
   os << ";\n";
+
+  printer.printSwiftMangledNameForDebugger(typeDecl);
+
   os << "};\n\n";
 
   // Print out the "hidden" _impl class.

--- a/lib/PrintAsClang/PrintClangValueType.cpp
+++ b/lib/PrintAsClang/PrintClangValueType.cpp
@@ -383,6 +383,9 @@ void ClangValueTypePrinter::printValueTypeDecl(
   printCxxImplClassName(os, typeDecl);
   printGenericParamRefs(os);
   os << ";\n";
+
+  printer.printSwiftMangledNameForDebugger(typeDecl);
+
   os << "};\n";
   os << '\n';
 


### PR DESCRIPTION
Print the Swift mangled name as a constexpr static char as a field in compiler generated types so LLDB can display them nicely to users.

The LLDB counterpart is https://github.com/apple/llvm-project/pull/6305