### PR TITLE
[CSGen] SE-0213: Literal initialization via coercion shouldn't try br…

### DIFF
--- a/test/Constraints/init_literal_via_coercion.swift
+++ b/test/Constraints/init_literal_via_coercion.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend %s -typecheck -debug-constraints -swift-version 4 2>%t.err
+// RUN: %FileCheck %s < %t.err
+
+// SE-0213. `UInt32(0)` and similar expressions that get transformed into
+// `0 as <#Type#>` should get literal bound early via equality constraint.
+
+// CHECK: ---Constraint solving at [{{.*}}:12:1 - line:12:13]---
+// CHECK: (integer_literal_expr type='[[LITERAL_VAR:\$T[0-9]+]]' {{.*}}
+// CHECK: Type Variables:
+// CHECK: [[LITERAL_VAR]] [allows bindings to: {{.*}}] as UInt32 {{.*}}
+// CHECK-NOT: disjunction (remembered) \[\[locator@{{.*}} [Coerce@{{.*}}\]\]]:
+_ = UInt32(0)
+
+// CHECK: ---Constraint solving at [{{.*}}22:1 - line:22:13]---
+// CHECK: (coerce_expr implicit type='[[CAST_TYPE:\$T[0-9]+]]' {{.*}}
+// CHECK-NEXT: (nil_literal_expr type='[[LITERAL_VAR:\$T[0-9]+]]' {{.*}}
+// CHECK: Type Variables:
+// CHECK: [[LITERAL_VAR]] [allows bindings to: {{.*}}] as Int? {{.*}}
+// CHECK: disjunction (remembered) {{.*}}
+// CHECK-NEXT: >  [favored]  [[CAST_TYPE]] bind Int?
+// CHECK-NEXT: >             [[CAST_TYPE]] bind Int
+_ = Int!(nil)


### PR DESCRIPTION
…idging

`addExplicitConversionConstraint` generates a disjunction to
check whether type could be coerced via bridging. That is not
useful for literal initialization which could use direct equality if
the type of cast is valid because necessary conformance checks
have been performed before the transformation.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
