### PR TITLE
[SourceKit] Add an optional path and name to refactoring edits

### DIFF
--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -551,7 +551,15 @@ struct NoteRegion {
 };
 
 struct Replacement {
+  /// If the edit is outside of the originally request source file, the path
+  /// to the file it is editing.
+  StringRef Path;
+  /// Range to apply the replacement to, zero-width if making an addition.
   CharSourceRange Range;
+  /// If the edit is actually a file (which could be generated/from an
+  /// expansion), the name (or path) of that buffer.
+  StringRef BufferName;
+  /// The text to replace \c Range with.
   StringRef Text;
   ArrayRef<NoteRegion> RegionsWorthNote;
 };

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -107,7 +107,7 @@ struct S3 {
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=4:8 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=EXPAND %s
 
 // EXPAND: source.edit.kind.active:
-// EXPAND-NEXT: 4:7-4:24 "(a + b, "a + b")"
+// EXPAND-NEXT: 4:7-4:24 (@__swiftmacro_9MacroUser13testStringify1a1bySi_SitF9stringifyfMf_.swift) "(a + b, "a + b")"
 
 //##-- cursor-info at 'myTypeWrapper' position following @. We don't support
 // on the @ currently.
@@ -130,46 +130,51 @@ struct S3 {
 //##-- Refactoring expanding the attached macro
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=21:2 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ATTACHED_EXPAND %s
 // ATTACHED_EXPAND: source.edit.kind.active:
-// ATTACHED_EXPAND:   23:3-23:3 "@accessViaStorage "
-// ATTACHED_EXPAND: source.edit.kind.active:
-// ATTACHED_EXPAND:   24:3-24:3 "@accessViaStorage "
-// ATTACHED_EXPAND: source.edit.kind.active:
-// ATTACHED_EXPAND:   22:11-22:11 "
-// ATTACHED_EXPAND: private var _storage = _Storage()
-// ATTACHED_EXPAND: source.edit.kind.active:
-// ATTACHED_EXPAND:   21:1-21:15 ""
+// ATTACHED_EXPAND-NEXT: 23:3-23:3 (@__swiftmacro_9MacroUser1SV13myTypeWrapperfMA_.swift) "@accessViaStorage "
+// ATTACHED_EXPAND-NEXT: source.edit.kind.active:
+// ATTACHED_EXPAND-NEXT: 24:3-24:3 (@__swiftmacro_9MacroUser1SV13myTypeWrapperfMA_.swift) "@accessViaStorage "
+// ATTACHED_EXPAND-NEXT: source.edit.kind.active:
+// ATTACHED_EXPAND-NEXT: 22:11-22:11 (@__swiftmacro_9MacroUser1SV13myTypeWrapperfMm_.swift) "
+// ATTACHED_EXPAND-NEXT: private var _storage = _Storage()
+// ATTACHED_EXPAND-NEXT: "
+// ATTACHED_EXPAND-NEXT: source.edit.kind.active:
+// ATTACHED_EXPAND-NEXT: 21:1-21:15 ""
 
 //##-- Refactoring expanding the first accessor macro
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=30:4 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ACCESSOR1_EXPAND %s
 // ACCESSOR1_EXPAND: source.edit.kind.active:
-// ACCESSOR1_EXPAND:   31:13-31:13 "{
-// ACCESSOR1_EXPAND:  get { _storage.x }
-// ACCESSOR1_EXPAND:  set { _storage.x = newValue }
-// ACCESSOR1_EXPAND: }"
-// ACCESSOR1_EXPAND: source.edit.kind.active:
-// ACCESSOR1_EXPAND:   30:3-30:20 ""
+// ACCESSOR1_EXPAND-NEXT: 31:13-31:13 (@__swiftmacro_9MacroUser2S2V1xSivp16accessViaStoragefMa_.swift) "{
+// ACCESSOR1_EXPAND-NEXT:  get { _storage.x }
+// ACCESSOR1_EXPAND-EMPTY:
+// ACCESSOR1_EXPAND-NEXT:  set { _storage.x = newValue }
+// ACCESSOR1_EXPAND-NEXT: }"
+// ACCESSOR1_EXPAND-NEXT: source.edit.kind.active:
+// ACCESSOR1_EXPAND-NEXT: 30:3-30:20 ""
 
 //##-- Refactoring expanding the second accessor macro
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=33:13 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ACCESSOR2_EXPAND %s
 // ACCESSOR2_EXPAND: source.edit.kind.active:
-// ACCESSOR2_EXPAND:   34:14-34:18 "{
-// ACCESSOR2_EXPAND:  get { _storage.y }
-// ACCESSOR2_EXPAND:  set { _storage.y = newValue }
-// ACCESSOR2_EXPAND: }"
-// ACCESSOR2_EXPAND: source.edit.kind.active:
-// ACCESSOR2_EXPAND:   33:3-33:20 ""
+// ACCESSOR2_EXPAND-NEXT: 34:14-34:18 (@__swiftmacro_9MacroUser2S2V1ySivp16accessViaStoragefMa_.swift) "{
+// ACCESSOR2_EXPAND-NEXT:  get { _storage.y }
+// ACCESSOR2_EXPAND-EMPTY:
+// ACCESSOR2_EXPAND-NEXT:  set { _storage.y = newValue }
+// ACCESSOR2_EXPAND-NEXT: }"
+// ACCESSOR2_EXPAND-NEXT: source.edit.kind.active:
+// ACCESSOR2_EXPAND-NEXT: 33:3-33:20 ""
 
 //##-- Refactoring expanding the second accessor macro
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=42:5 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=PEER_EXPAND %s
 // PEER_EXPAND: source.edit.kind.active:
-// PEER_EXPAND:   45:4-45:4 "
-// PEER_EXPAND: func f(a: Int, for b: String, _ value: Double, completionHandler: @escaping (String) -> Void) {
-// PEER_EXPAND:  Task {
-// PEER_EXPAND:    completionHandler(await f(a: a, for: b, value))
-// PEER_EXPAND:  }
-// PEER_EXPAND: }
-// PEER_EXPAND: source.edit.kind.active:
-// PEER_EXPAND:   42:3-42:24 ""
+// PEER_EXPAND-NEXT: 45:4-45:4 (@__swiftmacro_9MacroUser2S3V1f1a3for_SSSi_SSSdtYaF20addCompletionHandlerfMp_.swift) "
+// PEER_EXPAND-EMPTY:
+// PEER_EXPAND-NEXT: func f(a: Int, for b: String, _ value: Double, completionHandler: @escaping (String) -> Void) {
+// PEER_EXPAND-NEXT:  Task {
+// PEER_EXPAND-NEXT:    completionHandler(await f(a: a, for: b, value))
+// PEER_EXPAND-NEXT:  }
+// PEER_EXPAND-NEXT: }
+// PEER_EXPAND-NEXT: "
+// PEER_EXPAND-NEXT: source.edit.kind.active:
+// PEER_EXPAND-NEXT: 42:3-42:24 ""
 
 //##-- Doc info, mostly just checking we don't crash because of the separate buffers
 // RUN: %sourcekitd-test -req=doc-info %s -- ${COMPILER_ARGS_WITHOUT_SOURCE[@]} | %FileCheck -check-prefix=DOCINFO %s

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -708,10 +708,16 @@ struct NoteRegion {
 };
 
 struct Edit {
+  /// If the edit is outside of the originally request source file, the path
+  /// to the file it is editing.
+  std::string Path;
   unsigned StartLine;
   unsigned StartColumn;
   unsigned EndLine;
   unsigned EndColumn;
+  /// If the edit is actually a file (which could be generated/from an
+  /// expansion), the name (or path) of that buffer.
+  std::string BufferName;
   std::string NewText;
   SmallVector<NoteRegion, 2> RegionsWithNote;
 };

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1287,8 +1287,9 @@ public:
                         R.EndColumn,
                         R.ArgIndex};
               });
-          return {Start.first, Start.second, End.first,
-                  End.second,  R.Text.str(), std::move(SubRanges)};
+          return {R.Path.str(), Start.first,         Start.second,
+                  End.first,    End.second,          R.BufferName.str(),
+                  R.Text.str(), std::move(SubRanges)};
         });
     unsigned End = AllEdits.size();
     StartEnds.emplace_back(Start, End);

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -2223,14 +2223,30 @@ static void printSyntacticRenameEdits(sourcekitd_variant_t Info,
     for(unsigned j = 0, je = sourcekitd_variant_array_get_count(Edits);
         j != je; ++j) {
       OS << "  "; // indent
+
       sourcekitd_variant_t Edit = sourcekitd_variant_array_get_value(Edits, j);
+
+      StringRef Path(
+          sourcekitd_variant_dictionary_get_string(Edit, KeyFilePath));
+      if (!Path.empty()) {
+        OS << Path << " ";
+      }
+
       int64_t Line = sourcekitd_variant_dictionary_get_int64(Edit, KeyLine);
       int64_t Column = sourcekitd_variant_dictionary_get_int64(Edit, KeyColumn);
       int64_t EndLine = sourcekitd_variant_dictionary_get_int64(Edit, KeyEndLine);
       int64_t EndColumn = sourcekitd_variant_dictionary_get_int64(Edit, KeyEndColumn);
-      OS << Line << ':' << Column << '-' << EndLine << ':' << EndColumn << " \"";
+      OS << Line << ':' << Column << '-' << EndLine << ':' << EndColumn << " ";
+
+      StringRef BufferName(
+          sourcekitd_variant_dictionary_get_string(Edit, KeyBufferName));
+      if (!BufferName.empty()) {
+        OS << "(" << BufferName << ") ";
+      }
+
       StringRef Text(sourcekitd_variant_dictionary_get_string(Edit, KeyText));
-      OS << Text << "\"\n";
+      OS << "\"" << Text << "\"\n";
+
       sourcekitd_variant_t NoteRanges =
         sourcekitd_variant_dictionary_get_value(Edit, KeyRangesWorthNote);
       if (unsigned e = sourcekitd_variant_array_get_count(NoteRanges)) {

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -3675,10 +3675,16 @@ createCategorizedEditsResponse(const RequestResult<ArrayRef<CategorizedEdits>> &
     auto Edits = Entry.setArray(KeyEdits);
     for(auto E: TheEdit.Edits) {
       auto Edit = Edits.appendDictionary();
+      if (!E.Path.empty()) {
+        Edit.set(KeyFilePath, E.Path);
+      }
       Edit.set(KeyLine, E.StartLine);
       Edit.set(KeyColumn, E.StartColumn);
       Edit.set(KeyEndLine, E.EndLine);
       Edit.set(KeyEndColumn, E.EndColumn);
+      if (!E.BufferName.empty()) {
+        Edit.set(KeyBufferName, E.BufferName);
+      }
       Edit.set(KeyText, E.NewText);
       if (!E.RegionsWithNote.empty()) {
         auto Notes = Edit.setArray(KeyRangesWorthNote);

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -202,6 +202,7 @@ UID_KEYS = [
     # in this time. For cancellation testing purposes.
     KEY('SimulateLongRequest', 'key.simulate_long_request'),
     KEY('IsSynthesized', 'key.is_synthesized'),
+    KEY('BufferName', 'key.buffer_name')
 ]
 
 


### PR DESCRIPTION
Add two new fields to refactoring edits:
  - A file path if the edit corresponds to a buffer other than the
    original file
  - A name when the edit is actually source of generated buffer

Macro expansions allow the former as a macro could expand to member
attributes, which may eg. add accessors to each member. The attribute
itself is inside the expansion, but the edit is to the member in the
original source.

The latter will later allow clients to send requests with these names to
allow semantic functionality inside synthesized buffers.