### PR TITLE
[BuilderTransform] Rework missing `buildWithLimitedAvailability` detection

### DIFF
--- a/test/Constraints/result_builder_availability.swift
+++ b/test/Constraints/result_builder_availability.swift
@@ -103,8 +103,6 @@ tuplify(true) { cond in
         globalFuncAvailableOn10_52()
       } else if false {
         globalFuncAvailableOn10_52()
-      } else {
-        globalFuncAvailableOn10_52()
       }
     }
   }
@@ -165,6 +163,11 @@ tuplifyWithAvailabilityErasure(true) { cond in
     cond
   } else {
     globalFuncAvailableOn10_52()
+  }
+
+  // https://github.com/apple/swift/issues/63764
+  if #unavailable(OSX 10.52) {
+    cond // Ok
   }
 }
 


### PR DESCRIPTION
Since all of the branches of an `if` statement are joined together and 
hence produce the same type, that type should be used to check 
whether `buildWithLimitedAvailability` is required but missing regardless of
availability condition kind.

Resolves: https://github.com/apple/swift/issues/63764

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
