### PR TITLE
Fix Unmanaged.passRetained

### DIFF
--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -64,7 +64,9 @@ public struct Unmanaged<Instance: AnyObject> {
   /// - Returns: An unmanaged reference to the object passed as `value`.
   @_transparent
   public static func passRetained(_ value: Instance) -> Unmanaged {
-    return Unmanaged(_private: value).retain()
+    // Retain 'value' before it becomes unmanaged. This may be its last use.
+    Builtin.retain(value)
+    return Unmanaged(_private: value)
   }
 
   /// Creates an unmanaged reference without performing an unbalanced
@@ -219,6 +221,11 @@ public struct Unmanaged<Instance: AnyObject> {
   }
 
   /// Performs an unbalanced retain of the object.
+  ///
+  /// Note: Use Umanaged.passRetained(object) instead to ensure that
+  /// the reference to object is retained before it becomes
+  /// unmanaged. Once a reference is unmanaged, its underlying object
+  /// may be freed by the system.
   @_transparent
   public func retain() -> Unmanaged {
     Builtin.retain(_value)


### PR DESCRIPTION
Unmanaged.passRetained was originally implemented as:
- store the passed referenced into an unowned(unsafe) reference
- (the reference will now be released if the store is the last use)
- reload the unowned(unsafe) reference
- retain the reloaded reference

It should be implemented as:
- retain the passed reference
- store the passed reference to an unowned(unsafe) reference

Fixes rdar://105609600
(🔥 non-deterministic miscompile in stdlib's
 _StringGuts.populateBreadcrumbs)