### PR TITLE
[Unix] Move all ELF SDK runtime libraries into their own architecture-specific directories

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -539,7 +539,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
       # installed host toolchain.
       get_filename_component(swift_bin_dir ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
       get_filename_component(swift_dir ${swift_bin_dir} DIRECTORY)
-      set(host_lib_dir "${swift_dir}/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
+      set(host_lib_dir "${swift_dir}/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${SWIFT_HOST_VARIANT_ARCH}")
 
       target_link_libraries(${target} PRIVATE ${swiftrt})
       target_link_libraries(${target} PRIVATE "swiftCore")
@@ -548,7 +548,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
       if(ASRLF_BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
         set(swift_runtime_rpath "${host_lib_dir}")
       else()
-        set(swift_runtime_rpath "$ORIGIN/${relpath_to_lib_dir}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
+        set(swift_runtime_rpath "$ORIGIN/${relpath_to_lib_dir}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${SWIFT_HOST_VARIANT_ARCH}")
       endif()
 
     elseif(ASRLF_BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
@@ -563,7 +563,7 @@ function(_add_swift_runtime_link_flags target relpath_to_lib_dir bootstrapping)
 
       # At runtime link against the built swift libraries from the current
       # bootstrapping stage.
-      set(swift_runtime_rpath "$ORIGIN/${relpath_to_lib_dir}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
+      set(swift_runtime_rpath "$ORIGIN/${relpath_to_lib_dir}/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${SWIFT_HOST_VARIANT_ARCH}")
 
     elseif(ASRLF_BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")
       message(FATAL_ERROR "BOOTSTRAPPING_MODE 'BOOTSTRAPPING-WITH-HOSTLIBS' not supported on Linux")

--- a/cmake/modules/Libdispatch.cmake
+++ b/cmake/modules/Libdispatch.cmake
@@ -125,14 +125,6 @@ foreach(sdk ${DISPATCH_SDKS})
                           ${CMAKE_COMMAND} -E copy
                           <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
                           ${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${arch}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
-                        COMMAND
-                          ${CMAKE_COMMAND} -E copy
-                          <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
-                          ${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}dispatch${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
-                        COMMAND
-			  ${CMAKE_COMMAND} -E copy
-                          <INSTALL_DIR>/${LIBDISPATCH_RUNTIME_DIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
-                          ${SWIFTLIB_DIR}/${SWIFT_SDK_${sdk}_LIB_SUBDIR}/${SWIFT_SDK_${sdk}_SHARED_LIBRARY_PREFIX}BlocksRuntime${SWIFT_SDK_${sdk}_SHARED_LIBRARY_SUFFIX}
                         STEP_TARGETS
                           install
                         BUILD_BYPRODUCTS

--- a/cmake/modules/SwiftUtils.cmake
+++ b/cmake/modules/SwiftUtils.cmake
@@ -99,6 +99,9 @@ function(get_bootstrapping_swift_lib_dir bs_lib_dir bootstrapping)
   if(BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING")
     set(lib_dir
         "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
+    if(NOT ${SWIFT_HOST_VARIANT_SDK} IN_LIST SWIFT_DARWIN_PLATFORMS)
+      set(lib_dir "${lib_dir}/${SWIFT_HOST_VARIANT_ARCH}")
+    endif()
     # If building the stdlib with bootstrapping, the compiler has to pick up
     # the swift libraries of the previous bootstrapping level (because in the
     # current lib-directory they are not built yet.

--- a/docs/Android.md
+++ b/docs/Android.md
@@ -121,13 +121,13 @@ listed when you run the `adb devices` command - **currently this example works o
 commands to copy the Swift Android stdlib:
 
 ```
-$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libswiftCore.so /data/local/tmp
-$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libswiftGlibc.so /data/local/tmp
-$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libswiftSwiftOnoneSupport.so /data/local/tmp
-$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libswiftRemoteMirror.so /data/local/tmp
-$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libswift_Concurrency.so /data/local/tmp
-$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libdispatch.so /data/local/tmp
-$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/libBlocksRuntime.so /data/local/tmp
+$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/aarch64/libswiftCore.so /data/local/tmp
+$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/aarch64/libswiftGlibc.so /data/local/tmp
+$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/aarch64/libswiftSwiftOnoneSupport.so /data/local/tmp
+$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/aarch64/libswiftRemoteMirror.so /data/local/tmp
+$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/aarch64/libswift_Concurrency.so /data/local/tmp
+$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/aarch64/libdispatch.so /data/local/tmp
+$ adb push build/Ninja-ReleaseAssert/swift-linux-x86_64/lib/swift/android/aarch64/libBlocksRuntime.so /data/local/tmp
 ```
 
 In addition, you'll also need to copy the Android NDK's libc++:

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1452,6 +1452,11 @@ void ToolChain::getRuntimeLibraryPaths(SmallVectorImpl<std::string> &runtimeLibP
                                        StringRef SDKPath, bool shared) const {
   SmallString<128> scratchPath;
   getResourceDirPath(scratchPath, args, shared);
+  // Since only Darwin doesn't have separate libraries per architecture, link
+  // against the architecture-specific version of the library everywhere else.
+  if (!getTriple().isOSDarwin())
+    llvm::sys::path::append(scratchPath,
+                            swift::getMajorArchitectureName(getTriple()));
   runtimeLibPaths.push_back(std::string(scratchPath.str()));
 
   // If there's a secondary resource dir, add it too.

--- a/lib/Driver/WindowsToolChains.cpp
+++ b/lib/Driver/WindowsToolChains.cpp
@@ -118,10 +118,7 @@ toolchains::Windows::constructInvocation(const DynamicLinkJobAction &job,
 
   for (auto path : RuntimeLibPaths) {
     Arguments.push_back("-L");
-    // Since Windows has separate libraries per architecture, link against the
-    // architecture specific version of the static library.
-    Arguments.push_back(context.Args.MakeArgString(path + "/" +
-                                                   getTriple().getArchName()));
+    Arguments.push_back(context.Args.MakeArgString(path));
   }
 
   SmallString<128> SharedResourceDirPath;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -168,8 +168,11 @@ static void updateRuntimeLibraryPaths(SearchPathOptions &SearchPathOpts,
     LibSubDir = "maccatalyst";
 
   llvm::sys::path::append(LibPath, LibSubDir);
+  llvm::SmallString<128> runtimeLibPath = LibPath;
+  if (!Triple.isOSDarwin())
+    llvm::sys::path::append(runtimeLibPath, swift::getMajorArchitectureName(Triple));
   SearchPathOpts.RuntimeLibraryPaths.clear();
-  SearchPathOpts.RuntimeLibraryPaths.push_back(std::string(LibPath.str()));
+  SearchPathOpts.RuntimeLibraryPaths.push_back(std::string(runtimeLibPath.str()));
   if (Triple.isOSDarwin())
     SearchPathOpts.RuntimeLibraryPaths.push_back(DARWIN_OS_LIBRARY_PATH);
 

--- a/test/Driver/environment.swift
+++ b/test/Driver/environment.swift
@@ -4,5 +4,5 @@
 
 // RUN: %swift_driver_plain -sdk "" -target x86_64-unknown-gnu-linux -L/foo/ -driver-use-frontend-path %S/Inputs/print-var.sh %s LD_LIBRARY_PATH | %FileCheck -check-prefix=CHECK${LD_LIBRARY_PATH+_LAX} %s
 
-// CHECK: {{^/foo/:[^:]+/lib/swift/linux$}}
-// CHECK_LAX: {{^/foo/:[^:]+/lib/swift/linux}}
+// CHECK: {{^/foo/:[^:]+/lib/swift/linux/x86_64$}}
+// CHECK_LAX: {{^/foo/:[^:]+/lib/swift/linux/x86_64}}

--- a/test/Driver/options-interpreter.swift
+++ b/test/Driver/options-interpreter.swift
@@ -18,8 +18,8 @@
 // CHECK-RESOURCE-DIR-ONLY: # DYLD_LIBRARY_PATH=/RSRC/macosx{{$}}
 
 // RUN: %swift_driver_plain -sdk "" -### -target x86_64-unknown-linux-gnu -resource-dir /RSRC/ %s | %FileCheck -check-prefix=CHECK-RESOURCE-DIR-ONLY-LINUX${LD_LIBRARY_PATH+_LAX} %s
-// CHECK-RESOURCE-DIR-ONLY-LINUX: # LD_LIBRARY_PATH=/RSRC/linux{{$}}
-// CHECK-RESOURCE-DIR-ONLY-LINUX_LAX: # LD_LIBRARY_PATH=/RSRC/linux{{$|:}}
+// CHECK-RESOURCE-DIR-ONLY-LINUX: # LD_LIBRARY_PATH=/RSRC/linux/x86_64{{$}}
+// CHECK-RESOURCE-DIR-ONLY-LINUX_LAX: # LD_LIBRARY_PATH=/RSRC/linux/x86_64{{$|:}}
 
 // RUN: %swift_driver_plain -sdk "" -### -target x86_64-apple-macosx10.9 -L/foo/ %s | %FileCheck -check-prefix=CHECK-L %s
 // CHECK-L: # DYLD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/macosx$}}
@@ -59,9 +59,9 @@
 // CHECK-COMPLEX-DAG: DYLD_LIBRARY_PATH={{/foo2/:/bar2/:[^:]+/lib/swift/macosx:/sdkroot/usr/lib/swift($| )}}
 
 // RUN: %swift_driver_plain -sdk "" -### -target x86_64-unknown-linux-gnu -L/foo/ %s | %FileCheck -check-prefix=CHECK-L-LINUX${LD_LIBRARY_PATH+_LAX} %s
-// CHECK-L-LINUX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux$}}
-// CHECK-L-LINUX_LAX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux($|:)}}
+// CHECK-L-LINUX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux/x86_64$}}
+// CHECK-L-LINUX_LAX: # LD_LIBRARY_PATH={{/foo/:[^:]+/lib/swift/linux/x86_64($|:)}}
 
 // RUN: env LD_LIBRARY_PATH=/abc/ %swift_driver_plain -### -target x86_64-unknown-linux-gnu -L/foo/ -L/bar/ %s | %FileCheck -check-prefix=CHECK-LINUX-COMPLEX${LD_LIBRARY_PATH+_LAX} %s
-// CHECK-LINUX-COMPLEX: # LD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/linux:/abc/$}}
-// CHECK-LINUX-COMPLEX_LAX: # LD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/linux:/abc/($|:)}}
+// CHECK-LINUX-COMPLEX: # LD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/linux/x86_64:/abc/$}}
+// CHECK-LINUX-COMPLEX_LAX: # LD_LIBRARY_PATH={{/foo/:/bar/:[^:]+/lib/swift/linux/x86_64:/abc/($|:)}}

--- a/test/Reflection/conformance_descriptors.swift
+++ b/test/Reflection/conformance_descriptors.swift
@@ -9,7 +9,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift %S/Inputs/ConcreteTypes.swift %S/Inputs/GenericTypes.swift %S/Inputs/Protocols.swift %S/Inputs/Extensions.swift %S/Inputs/Closures.swift %S/Inputs/Conformances.swift -parse-as-library -emit-module -emit-library -module-name ConformanceCheck -o %t/Conformances
-// RUN: %target-swift-reflection-dump %t/Conformances %platform-module-dir/%target-library-name(swiftCore) | %FileCheck %s
+// RUN: %target-swift-reflection-dump %t/Conformances %platform-dylib-dir/%target-library-name(swiftCore) | %FileCheck %s
 
 // CHECK: CONFORMANCES:
 // CHECK: =============

--- a/test/Reflection/typeref_lowering.swift
+++ b/test/Reflection/typeref_lowering.swift
@@ -8,8 +8,8 @@
 // RUN: %target-build-swift -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift -parse-as-library -emit-module -emit-library -module-name TypeLowering -o %t/%target-library-name(TypesToReflect)
 // RUN: %target-build-swift -Xfrontend -disable-availability-checking %S/Inputs/TypeLowering.swift %S/Inputs/main.swift -emit-module -emit-executable -module-name TypeLowering -o %t/TypesToReflect
 
-// RUN: %target-swift-reflection-dump %t/%target-library-name(TypesToReflect) %platform-module-dir/%target-library-name(swiftCore) -dump-type-lowering < %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
-// RUN: %target-swift-reflection-dump %t/TypesToReflect %platform-module-dir/%target-library-name(swiftCore) -dump-type-lowering < %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-reflection-dump %t/%target-library-name(TypesToReflect) %platform-dylib-dir/%target-library-name(swiftCore) -dump-type-lowering < %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-reflection-dump %t/TypesToReflect %platform-dylib-dir/%target-library-name(swiftCore) -dump-type-lowering < %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
 
 12TypeLowering11BasicStructV
 // CHECK-64:      (struct TypeLowering.BasicStruct)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -2047,6 +2047,9 @@ if platform.system() != 'Darwin':
 platform_module_dir = make_path(test_resource_dir, config.target_sdk_name)
 
 platform_dylib_dir = platform_module_dir
+if platform.system() != 'Darwin':
+    platform_dylib_dir = make_path(test_resource_dir, relative_platform_module_dir_prefix)
+
 if run_os == 'maccatalyst' and config.darwin_maccatalyst_build_flavor == "ios-like":
     # When using the ios-macabi triple, look for module files
     # in the 'maccatalyst' compiler resource directory.

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -123,7 +123,7 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
       # installed host toolchain.
       get_filename_component(swift_bin_dir ${SWIFT_EXEC_FOR_SWIFT_MODULES} DIRECTORY)
       get_filename_component(swift_dir ${swift_bin_dir} DIRECTORY)
-      set(host_lib_dir "${swift_dir}/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
+      set(host_lib_dir "${swift_dir}/lib/swift/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${SWIFT_HOST_VARIANT_ARCH}")
 
       target_link_libraries(${target} PRIVATE ${swiftrt})
       target_link_libraries(${target} PRIVATE "swiftCore")
@@ -132,7 +132,7 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
       if(ASKD_BOOTSTRAPPING_MODE STREQUAL "HOSTTOOLS")
         list(APPEND RPATH_LIST "${host_lib_dir}")
       else()
-        file(RELATIVE_PATH relative_rtlib_path "${path}" "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
+        file(RELATIVE_PATH relative_rtlib_path "${path}" "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${SWIFT_HOST_VARIANT_ARCH}")
         list(APPEND RPATH_LIST "$ORIGIN/${relative_rtlib_path}")
       endif()
 
@@ -144,7 +144,7 @@ function(add_sourcekit_swift_runtime_link_flags target path HAS_SWIFT_MODULES)
 
       # At runtime link against the built swift libraries from the current
       # bootstrapping stage.
-      file(RELATIVE_PATH relative_rtlib_path "${path}" "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}")
+      file(RELATIVE_PATH relative_rtlib_path "${path}" "${SWIFTLIB_DIR}/${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}/${SWIFT_HOST_VARIANT_ARCH}")
       list(APPEND RPATH_LIST "$ORIGIN/${relative_rtlib_path}")
 
     elseif(ASKD_BOOTSTRAPPING_MODE STREQUAL "BOOTSTRAPPING-WITH-HOSTLIBS")

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3287,7 +3287,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 ICU_BUILD_DIR=$(build_directory ${host} ${product})
                 ICU_INSTALL_DIR="$(get_host_install_destdir ${host})$(get_host_install_prefix ${host})"
                 ICU_LIBDIR="$(build_directory ${host} swift)/lib/swift/${SWIFT_HOST_VARIANT}/${SWIFT_HOST_VARIANT_ARCH}"
-                LIBICU_DEST_DIR="${ICU_INSTALL_DIR}lib/swift/${SWIFT_HOST_VARIANT}"
+                LIBICU_DEST_DIR="${ICU_INSTALL_DIR}lib/swift/${SWIFT_HOST_VARIANT}/${SWIFT_HOST_VARIANT_ARCH}"
                 call mkdir -p ${LIBICU_DEST_DIR}
 
                 for l in uc i18n data
@@ -3298,7 +3298,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 done
 
                 if [ $(true_false "${BUILD_SWIFT_STATIC_STDLIB}") == "TRUE" ]; then
-                    LIBICU_DEST_DIR_STATIC="${ICU_INSTALL_DIR}lib/swift_static/${SWIFT_HOST_VARIANT}"
+                    LIBICU_DEST_DIR_STATIC="${ICU_INSTALL_DIR}lib/swift_static/${SWIFT_HOST_VARIANT}/${SWIFT_HOST_VARIANT_ARCH}"
                     call mkdir -p ${LIBICU_DEST_DIR_STATIC}
                     for l in uc i18n data
                     do

--- a/validation-test/execution/interpret-with-dependencies-unix.swift
+++ b/validation-test/execution/interpret-with-dependencies-unix.swift
@@ -1,4 +1,4 @@
-// REQUIRES: OS=linux-gnu
+// UNSUPPORTED: OS=macosx || OS=tvos || OS=ios || OS=watchos || OS=windows-msvc
 // RUN: %empty-directory(%t)
 
 // RUN: echo 'int abc = 42;' | %clang -x c - -shared -fPIC -o %t/libabc.so
@@ -8,9 +8,10 @@
 // CHECK: {{okay}}
 
 // Now test a dependency on a library in the compiler's resource directory.
-// RUN: %empty-directory(%t/rsrc/%target-sdk-name)
-// RUN: ln -s %t/libabc.so %t/rsrc/%target-sdk-name/
-// RUN: ln -s %platform-module-dir/* %t/rsrc/%target-sdk-name/
+// RUN: %empty-directory(%t/rsrc/%relative-platform-module-dir-prefix)
+// RUN: ln -s %t/libabc.so %t/rsrc/%relative-platform-module-dir-prefix/
+// RUN: ln -s %platform-module-dir/*.swiftmodule %t/rsrc/%target-sdk-name/
+// RUN: ln -s %test-resource-dir/%relative-platform-module-dir-prefix/* %t/rsrc/%relative-platform-module-dir-prefix/
 // RUN: ln -s %platform-module-dir/../shims %t/rsrc/
 // RUN: %empty-directory(%t/other)
 // RUN: ln -s %t/libfoo.so %t/other


### PR DESCRIPTION
This is needed for all platforms that don't have multi-architecture libraries like Darwin.

Resolves #63645

I built this with the Feb. 9 source snapshot natively on my Android phone and saw no regressions in the compiler validation suite. I couldn't test the bootstrapping changes on Android because of #60272, so I tried to build a more recent snapshot on linux x86_64 without this pull and that wouldn't build either. I didn't want to look into that issue with bootstrapping the compiler on linux, so I left it.

This pull will require additional small pulls for the corelibs and some SPM products, which I will submit next. In the meantime, let's see if this passes the compiler validation suite first. I've also submitted the swift-driver equivalent, apple/swift-driver#1294.

@Azoy, would you trigger the CI for me?