### PR TITLE
[move-only] Implement escaping closure semantics part 1

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -760,12 +760,11 @@ ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed_global_var, 
 ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed_global_let, none,
       "'%0' was consumed but it is illegal to consume a noncopyable global let. One can only read from it",
       (StringRef))
-ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed_escaping_let, none,
-      "'%0' was consumed but it is illegal to consume a noncopyable escaping immutable capture. One can only read from it",
-      (StringRef))
 ERROR(sil_moveonlychecker_notconsumable_but_assignable_was_consumed_escaping_var, none,
-      "'%0' was consumed but it is illegal to consume a noncopyable escaping mutable capture. One can only read from it or assign over it",
+      "'%0' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it",
       (StringRef))
+ERROR(sil_moveonlychecker_let_capture_consumed, none,
+      "'%0' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it", (StringRef))
 
 NOTE(sil_moveonlychecker_moveonly_field_consumed_here, none,
      "move only field consumed here", ())

--- a/include/swift/AST/SemanticAttrs.def
+++ b/include/swift/AST/SemanticAttrs.def
@@ -120,5 +120,9 @@ SEMANTICS_ATTR(LIFETIMEMANAGEMENT_COPY, "lifetimemanagement.copy")
 
 SEMANTICS_ATTR(NO_PERFORMANCE_ANALYSIS, "no_performance_analysis")
 
+// A flag used to turn off moveonly diagnostics on functions that allocbox to
+// stack specialized.
+SEMANTICS_ATTR(NO_MOVEONLY_DIAGNOSTICS, "sil.optimizer.moveonly.diagnostic.ignore")
+
 #undef SEMANTICS_ATTR
 

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -112,15 +112,25 @@ CaptureKind TypeConverter::getDeclCaptureKind(CapturedValue capture,
   assert(var->hasStorage() &&
          "should not have attempted to directly capture this variable");
 
+  auto &lowering = getTypeLowering(
+      var->getType(), TypeExpansionContext::noOpaqueTypeArchetypesSubstitution(
+                          expansion.getResilienceExpansion()));
+
+  // If this is a noncopyable 'let' constant that is not a shared paramdecl,
+  // then we know it is boxed and want to pass it in its boxed form so we can
+  // obey Swift's capture reference semantics.
+  if (!var->supportsMutation() && lowering.getLoweredType().isPureMoveOnly()) {
+      auto *param = dyn_cast<ParamDecl>(var);
+      if (!param || param->getValueOwnership() != ValueOwnership::Shared) {
+        return CaptureKind::ImmutableBox;
+      }
+  }
+
   // If this is a non-address-only stored 'let' constant, we can capture it
   // by value.  If it is address-only, then we can't load it, so capture it
   // by its address (like a var) instead.
-  if (!var->supportsMutation() &&
-      !getTypeLowering(var->getType(),
-                       TypeExpansionContext::noOpaqueTypeArchetypesSubstitution(
-                           expansion.getResilienceExpansion()))
-           .isAddressOnly())
-    return CaptureKind::Constant;
+  if (!var->supportsMutation() && !lowering.isAddressOnly())
+      return CaptureKind::Constant;
 
   // In-out parameters are captured by address.
   if (auto *param = dyn_cast<ParamDecl>(var)) {

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -116,10 +116,11 @@ CaptureKind TypeConverter::getDeclCaptureKind(CapturedValue capture,
       var->getType(), TypeExpansionContext::noOpaqueTypeArchetypesSubstitution(
                           expansion.getResilienceExpansion()));
 
-  // If this is a noncopyable 'let' constant that is not a shared paramdecl,
-  // then we know it is boxed and want to pass it in its boxed form so we can
-  // obey Swift's capture reference semantics.
-  if (!var->supportsMutation() && lowering.getLoweredType().isPureMoveOnly()) {
+  // If this is a noncopyable 'let' constant that is not a shared paramdecl or
+  // used by a noescape capture, then we know it is boxed and want to pass it in
+  // its boxed form so we can obey Swift's capture reference semantics.
+  if (!var->supportsMutation() && lowering.getLoweredType().isPureMoveOnly() &&
+      !capture.isNoEscape()) {
       auto *param = dyn_cast<ParamDecl>(var);
       if (!param || param->getValueOwnership() != ValueOwnership::Shared) {
         return CaptureKind::ImmutableBox;

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -351,13 +351,13 @@ public:
            "can't emit a local var for a non-local var decl");
     assert(decl->hasStorage() && "can't emit storage for a computed variable");
     assert(!SGF.VarLocs.count(decl) && "Already have an entry for this decl?");
+
     // The box type's context is lowered in the minimal resilience domain.
+    auto instanceType = SGF.SGM.Types.getLoweredRValueType(
+        TypeExpansionContext::minimal(), decl->getType());
     auto boxType = SGF.SGM.Types.getContextBoxTypeForCapture(
-        decl,
-        SGF.SGM.Types.getLoweredRValueType(TypeExpansionContext::minimal(),
-                                           decl->getType()),
-        SGF.F.getGenericEnvironment(),
-        /*mutable*/ true);
+        decl, instanceType, SGF.F.getGenericEnvironment(),
+        /*mutable*/ !instanceType->isPureMoveOnly() || !decl->isLet());
 
     // The variable may have its lifetime extended by a closure, heap-allocate
     // it using a box.

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -383,7 +383,7 @@ void SILGenFunction::emitCaptures(SILLocation loc,
     case CaptureKind::Constant: {
       // let declarations.
       auto &tl = getTypeLowering(valueType);
-      SILValue Val = Entry.value;
+      SILValue Val = Entry.getValueOrBoxedValue(*this);
       bool eliminateMoveOnlyWrapper =
           Val->getType().isMoveOnlyWrapped() &&
           !vd->getInterfaceType()->is<SILMoveOnlyWrappedType>();

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -410,6 +410,11 @@ void SILGenFunction::emitCaptures(SILLocation loc,
       } else {
         // If we have a mutable binding for a 'let', such as 'self' in an
         // 'init' method, load it.
+        if (Val->getType().isMoveOnly()) {
+          Val = B.createMarkMustCheckInst(
+              loc, Val,
+              MarkMustCheckInst::CheckKind::AssignableButNotConsumable);
+        }
         Val = emitLoad(loc, Val, tl, SGFContext(), IsNotTake).forward(*this);
       }
 

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1075,7 +1075,8 @@ namespace {
       Value(value),
       Enforcement(enforcement),
       IsRValue(isRValue) {
-        assert(IsRValue || value.getType().isAddress());
+      assert(IsRValue || value.getType().isAddress() ||
+             value.getType().isBoxedNonCopyableType(value.getFunction()));
     }
 
     virtual bool isLoadingPure() const override { return true; }
@@ -1084,8 +1085,26 @@ namespace {
                          ManagedValue base) && override {
       assert(!base && "value component must be root of lvalue path");
 
+      // See if we have a noncopyable address from a project_box or global, we
+      // always eagerly reproject out.
+      if (Value.getType().isAddress() && Value.getType().isMoveOnly()) {
+        SILValue addr = Value.getValue();
+        if (isa<ProjectBoxInst>(addr) || isa<GlobalAddrInst>(addr)) {
+          if (Enforcement)
+            addr = enterAccessScope(SGF, loc, base, addr, getTypeData(),
+                                    getAccessKind(), *Enforcement,
+                                    takeActorIsolation());
+          addr = SGF.B.createMarkMustCheckInst(
+              loc, addr,
+              MarkMustCheckInst::CheckKind::AssignableButNotConsumable);
+          return ManagedValue::forLValue(addr);
+        }
+      }
+
       if (!Enforcement)
         return Value;
+
+      assert(Value.getType().isAddress() && "Must have an address here?!");
 
       SILValue addr = Value.getLValueAddress();
       addr =
@@ -2985,23 +3004,20 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
       auto astAccessKind = mapAccessKind(this->AccessKind);
       auto address = SGF.maybeEmitValueOfLocalVarDecl(Storage, astAccessKind);
 
-      // The only other case that should get here is a global variable.
+      // The only other case that should get here is a global variable or a
+      // noncopyable value in a box.
       if (!address) {
-        address = SGF.emitGlobalVariableRef(Loc, Storage, ActorIso);
-        if (address.getType().isMoveOnly()) {
-            auto checkKind =
-                MarkMustCheckInst::CheckKind::AssignableButNotConsumable;
-            if (isReadAccess(AccessKind)) {
-              checkKind = MarkMustCheckInst::CheckKind::NoConsumeOrAssign;
-            }
-            address = SGF.B.createMarkMustCheckInst(Loc, address, checkKind);
-        }
+        address = SGF.maybeEmitAddressForBoxOfLocalVarDecl(Loc, Storage);
+        if (!address)
+          address = SGF.emitGlobalVariableRef(Loc, Storage, ActorIso);
       } else {
         assert((!ActorIso || Storage->isTopLevelGlobal()) &&
                "local var should not be actor isolated!");
       }
+
       assert(address.isLValue() &&
-             "physical lvalue decl ref must evaluate to an address");
+             "Must have a physical copyable lvalue decl ref that "
+             "evaluates to an address");
 
       Optional<SILAccessEnforcement> enforcement;
       if (!Storage->isLet()) {
@@ -3036,13 +3052,40 @@ void LValue::addNonMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
 }
 
 ManagedValue
+SILGenFunction::maybeEmitAddressForBoxOfLocalVarDecl(SILLocation loc,
+                                                     VarDecl *var) {
+  auto It = VarLocs.find(var);
+
+  // Wasn't a box.
+  if (It == VarLocs.end())
+    return ManagedValue();
+
+  SILValue value = It->second.value;
+  SILValue box = It->second.box;
+
+  // We only want to do this if we only have a box without a value.
+  if (!box || value)
+    return ManagedValue();
+
+  SILValue addr = B.createProjectBox(loc, box, 0);
+  return ManagedValue::forLValue(addr);
+}
+
+ManagedValue
 SILGenFunction::maybeEmitValueOfLocalVarDecl(
     VarDecl *var, AccessKind accessKind) {
   // For local decls, use the address we allocated or the value if we have it.
   auto It = VarLocs.find(var);
   if (It != VarLocs.end()) {
-    // If this has an address, return it.  By-value let's have no address.
     SILValue ptr = It->second.value;
+
+    // If we do not have an actual value stored, then we must have a box.
+    if (!ptr) {
+      assert(It->second.box);
+      return ManagedValue();
+    }
+
+    // If this has an address, return it.  By-value let's have no address.
     if (ptr->getType().isAddress())
       return ManagedValue::forLValue(ptr);
 
@@ -3053,7 +3096,7 @@ SILGenFunction::maybeEmitValueOfLocalVarDecl(
     return ManagedValue::forUnmanaged(ptr);
   }
 
-  // Otherwise, it's non-local or not stored.
+  // Otherwise, it's non-local, not stored, or a box.
   return ManagedValue();
 }
 
@@ -3068,6 +3111,8 @@ SILGenFunction::emitAddressOfLocalVarDecl(SILLocation loc, VarDecl *var,
   assert(!var->isAsyncLet() && "async let does not have an address");
   
   auto address = maybeEmitValueOfLocalVarDecl(var, astAccessKind);
+  if (!address)
+    address = maybeEmitAddressForBoxOfLocalVarDecl(loc, var);
   assert(address);
   assert(address.isLValue());
   return address;
@@ -3088,7 +3133,15 @@ RValue SILGenFunction::emitRValueForNonMemberVarDecl(SILLocation loc,
     return RValue(*this, loc, formalRValueType,
                   emitReadAsyncLetBinding(loc, var));
   }
-  auto localValue = maybeEmitValueOfLocalVarDecl(var, AccessKind::Read);
+
+  // If our localValue is a closure captured box of a noncopyable type, project
+  // it out eagerly and insert a no_consume_or_assign constraint.
+  ManagedValue localValue;
+  if (auto localAddr = maybeEmitAddressForBoxOfLocalVarDecl(loc, var)) {
+    localValue = localAddr;
+  } else {
+    localValue = maybeEmitValueOfLocalVarDecl(var, AccessKind::Read);
+  }
 
   // If this VarDecl is represented as an address, emit it as an lvalue, then
   // perform a load to get the rvalue.
@@ -3109,6 +3162,22 @@ RValue SILGenFunction::emitRValueForNonMemberVarDecl(SILLocation loc,
     SILValue destAddr = localValue.getLValueAddress();
     SILValue accessAddr = UnenforcedFormalAccess::enter(*this, loc, destAddr,
                                                         SILAccessKind::Read);
+
+    if (accessAddr->getType().isMoveOnly()) {
+      bool needCheck = true;
+      SILValue tmp = destAddr;
+      if (auto *mmci = dyn_cast<MarkMustCheckInst>(tmp))
+        tmp = mmci->getOperand();
+      if (auto *pbi = dyn_cast<ProjectBoxInst>(tmp)) {
+        auto boxType = pbi->getOperand()->getType().castTo<SILBoxType>();
+        needCheck = boxType->getLayout()->getFields()[0].isMutable();
+      }
+      if (needCheck)
+        accessAddr = B.createMarkMustCheckInst(
+            loc, accessAddr,
+            MarkMustCheckInst::CheckKind::AssignableButNotConsumable);
+    }
+
     auto propagateRValuePastAccess = [&](RValue &&rvalue) {
       // Check if a new begin_access was emitted and returned as the
       // RValue. This means that the load did not actually load. If so, then
@@ -4388,6 +4457,28 @@ void SILGenFunction::emitSemanticStore(SILLocation loc,
   // also handle address only lets.
   if (rvalue->getType().isMoveOnlyWrapped() && rvalue->getType().isObject()) {
     rvalue = B.createOwnedMoveOnlyWrapperToCopyableValue(loc, rvalue);
+  }
+
+  // See if our rvalue is a box whose boxed type matches the destTL type. In
+  // that case, emit a project_box eagerly. This can happen for escaping
+  // captured move only arguments.
+  if (auto boxType = rvalue->getType().getAs<SILBoxType>()) {
+    auto fieldType = rvalue->getType().getSILBoxFieldType(&F, 0);
+    assert(fieldType.isMoveOnly());
+    if (fieldType.getObjectType() == destTL.getLoweredType()) {
+      SILValue box = rvalue;
+      rvalue = B.createProjectBox(loc, rvalue, 0);
+      // If we have a let, we rely on the typechecker to error if we attempt to
+      // assign to it.
+      bool isMutable = boxType->getLayout()->getFields()[0].isMutable();
+      if (isMutable)
+        rvalue = B.createMarkMustCheckInst(
+            loc, rvalue,
+            MarkMustCheckInst::CheckKind::AssignableButNotConsumable);
+      B.emitCopyAddrOperation(loc, rvalue, dest, IsNotTake, isInit);
+      B.emitDestroyValueOperation(loc, box);
+      return;
+    }
   }
 
   // Easy case: the types match.

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3164,18 +3164,9 @@ RValue SILGenFunction::emitRValueForNonMemberVarDecl(SILLocation loc,
                                                         SILAccessKind::Read);
 
     if (accessAddr->getType().isMoveOnly()) {
-      bool needCheck = true;
-      SILValue tmp = destAddr;
-      if (auto *mmci = dyn_cast<MarkMustCheckInst>(tmp))
-        tmp = mmci->getOperand();
-      if (auto *pbi = dyn_cast<ProjectBoxInst>(tmp)) {
-        auto boxType = pbi->getOperand()->getType().castTo<SILBoxType>();
-        needCheck = boxType->getLayout()->getFields()[0].isMutable();
-      }
-      if (needCheck)
-        accessAddr = B.createMarkMustCheckInst(
-            loc, accessAddr,
-            MarkMustCheckInst::CheckKind::AssignableButNotConsumable);
+      accessAddr = B.createMarkMustCheckInst(
+          loc, accessAddr,
+          MarkMustCheckInst::CheckKind::AssignableButNotConsumable);
     }
 
     auto propagateRValuePastAccess = [&](RValue &&rvalue) {

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2708,7 +2708,7 @@ static void switchCaseStmtSuccessCallback(SILGenFunction &SGF,
           // Emit a debug description for the variable, nested within a scope
           // for the pattern match.
           SILDebugVariable dbgVar(vd->isLet(), /*ArgNo=*/0);
-          SGF.B.emitDebugDescription(vd, v.value, dbgVar);
+          SGF.B.emitDebugDescription(vd, v.getValueOrBoxedValue(SGF), dbgVar);
         }
       }
     }
@@ -2748,7 +2748,7 @@ static void switchCaseStmtSuccessCallback(SILGenFunction &SGF,
       if (!var->hasName() || var->getName() != expected->getName())
         continue;
 
-      SILValue value = SGF.VarLocs[var].value;
+      SILValue value = SGF.VarLocs[var].getValueOrBoxedValue(SGF);
       SILType type = value->getType();
 
       // If we have an address-only type, initialize the temporary
@@ -3008,7 +3008,7 @@ void SILGenFunction::emitSwitchFallthrough(FallthroughStmt *S) {
       }
 
       auto varLoc = VarLocs[var];
-      SILValue value = varLoc.value;
+      SILValue value = varLoc.getValueOrBoxedValue(*this);
 
       if (value->getType().isAddressOnly(F)) {
         context->Emission.emitAddressOnlyInitialization(expected, value);
@@ -3074,7 +3074,7 @@ void SILGenFunction::emitCatchDispatch(DoCatchStmt *S, ManagedValue exn,
             // Emit a debug description of the incoming arg, nested within the scope
             // for the pattern match.
             SILDebugVariable dbgVar(vd->isLet(), /*ArgNo=*/0);
-            B.emitDebugDescription(vd, v.value, dbgVar);
+            B.emitDebugDescription(vd, v.getValueOrBoxedValue(*this), dbgVar);
           }
         }
       }
@@ -3121,7 +3121,7 @@ void SILGenFunction::emitCatchDispatch(DoCatchStmt *S, ManagedValue exn,
         if (!var->hasName() || var->getName() != expected->getName())
           continue;
 
-        SILValue value = VarLocs[var].value;
+        SILValue value = VarLocs[var].getValueOrBoxedValue(*this);
         SILType type = value->getType();
 
         // If we have an address-only type, initialize the temporary

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerTester.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerTester.cpp
@@ -94,7 +94,7 @@ class MoveOnlyAddressCheckerTesterPass : public SILFunctionTransform {
     DominanceInfo *domTree = dominanceAnalysis->get(fn);
     auto *poa = getAnalysis<PostOrderAnalysis>();
 
-    DiagnosticEmitter diagnosticEmitter;
+    DiagnosticEmitter diagnosticEmitter(fn);
     SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
     searchForCandidateAddressMarkMustChecks(fn, moveIntroducersToProcess,
                                             diagnosticEmitter);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.h
@@ -28,7 +28,7 @@ class DiagnosticEmitter;
 void searchForCandidateAddressMarkMustChecks(
     SILFunction *fn,
     SmallSetVector<MarkMustCheckInst *, 32> &moveIntroducersToProcess,
-    DiagnosticEmitter &diagnosticEmitter) __attribute__((optnone));
+    DiagnosticEmitter &diagnosticEmitter);
 
 struct MoveOnlyAddressChecker {
   SILFunction *fn;

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.h
@@ -28,7 +28,7 @@ class DiagnosticEmitter;
 void searchForCandidateAddressMarkMustChecks(
     SILFunction *fn,
     SmallSetVector<MarkMustCheckInst *, 32> &moveIntroducersToProcess,
-    DiagnosticEmitter &diagnosticEmitter);
+    DiagnosticEmitter &diagnosticEmitter) __attribute__((optnone));
 
 struct MoveOnlyAddressChecker {
   SILFunction *fn;

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTester.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureTester.cpp
@@ -89,7 +89,7 @@ class MoveOnlyBorrowToDestructureTransformPass : public SILFunctionTransform {
     auto *postOrderAnalysis = getAnalysis<PostOrderAnalysis>();
 
     SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
-    DiagnosticEmitter diagnosticEmitter;
+    DiagnosticEmitter diagnosticEmitter(getFunction());
 
     unsigned diagCount = diagnosticEmitter.getDiagnosticCount();
     bool madeChange = searchForCandidateObjectMarkMustChecks(

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
@@ -1574,7 +1574,13 @@ static bool gatherBorrows(SILValue rootValue,
       if (!use->get()->getType().isMoveOnly())
         continue;
 
+      // Do not look through apply sites.
+      if (ApplySite::isa(use->getUser()))
+        continue;
+
       // Search through forwarding consumes.
+      //
+      // TODO: Can this just not return a forwarded value for ApplySites?
       ForwardingOperand(use).visitForwardedValues([&](SILValue value) -> bool {
         for (auto *use : value->getUses())
           worklist.push_back(use);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
@@ -15,6 +15,7 @@
 #include "swift/AST/AccessScope.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsSIL.h"
+#include "swift/AST/SemanticAttrs.h"
 #include "swift/Basic/Debug.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/FrozenMultiMap.h"
@@ -155,6 +156,14 @@ class MoveOnlyCheckerPass : public SILFunctionTransform {
 
     assert(fn->getModule().getStage() == SILStage::Raw &&
            "Should only run on Raw SIL");
+
+    // If allocbox to stack told use to not emit diagnostics for this function,
+    // clean up any copies, invalidate the analysis, and return early.
+    if (getFunction()->hasSemanticsAttr(semantics::NO_MOVEONLY_DIAGNOSTICS)) {
+      if (cleanupNonCopyableCopiesAfterEmittingDiagnostic(getFunction()))
+        invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+      return;
+    }
 
     LLVM_DEBUG(llvm::dbgs()
                << "===> MoveOnly Checker. Visiting: " << fn->getName() << '\n');

--- a/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyChecker.cpp
@@ -81,7 +81,8 @@ struct MoveOnlyChecker {
 
   MoveOnlyChecker(SILFunction *fn, DominanceInfo *domTree,
                   PostOrderAnalysis *poa)
-      : fn(fn), domTree(domTree), poa(poa) {}
+      : diagnosticEmitter(fn), fn(fn), domTree(domTree), poa(poa) {
+  }
 
   void checkObjects();
   void checkAddresses();

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -159,9 +159,8 @@ static void getVariableNameForValue(SILValue value2,
   }
 }
 
-
 static void getVariableNameForValue(MarkMustCheckInst *mmci,
-                                    SmallString<64> &resultingString) __attribute__((optnone)) {
+                                    SmallString<64> &resultingString) {
   return getVariableNameForValue(mmci, mmci->getOperand(), resultingString);
 }
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -106,8 +106,9 @@ static void getVariableNameForValue(SILValue value2,
     // Otherwise, try to see if we have a single value instruction we can look
     // through.
     if (isa<BeginBorrowInst>(searchValue) || isa<LoadInst>(searchValue) ||
-        isa<BeginAccessInst>(searchValue) || isa<MarkMustCheckInst>(searchValue) ||
-        isa<ProjectBoxInst>(searchValue)) {
+        isa<LoadBorrowInst>(searchValue) || isa<BeginAccessInst>(searchValue) ||
+        isa<MarkMustCheckInst>(searchValue) ||
+        isa<ProjectBoxInst>(searchValue) || isa<CopyValueInst>(searchValue)) {
       searchValue = cast<SingleValueInstruction>(searchValue)->getOperand(0);
       continue;
     }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -59,6 +59,17 @@ static void diagnose(ASTContext &context, SILInstruction *inst, Diag<T...> diag,
   context.Diags.diagnose(loc.getSourceLoc(), diag, std::forward<U>(args)...);
 }
 
+template <typename... T, typename... U>
+static void diagnose(ASTContext &context, SourceLoc loc, Diag<T...> diag,
+                     U &&...args) {
+  // If for testing reasons we want to return that we emitted an error but not
+  // emit the actual error itself, return early.
+  if (SilentlyEmitDiagnostics)
+    return;
+
+  context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
+}
+
 /// Helper function that actually implements getVariableNameForValue. Do not
 /// call it directly! Call the unary variants instead.
 static void getVariableNameForValue(SILValue value2,
@@ -75,7 +86,8 @@ static void getVariableNameForValue(SILValue value2,
   }
 
   // Otherwise, we need to look at our mark_must_check's operand.
-  StackList<SILInstruction *> variableNamePath(value2->getFunction());
+  StackList<llvm::PointerUnion<SILInstruction *, SILValue>> variableNamePath(
+      value2->getFunction());
   while (true) {
     if (auto *allocInst = dyn_cast<AllocationInst>(searchValue)) {
       variableNamePath.push_back(allocInst);
@@ -91,6 +103,11 @@ static void getVariableNameForValue(SILValue value2,
       variableNamePath.push_back(rei);
       searchValue = rei->getOperand();
       continue;
+    }
+
+    if (auto *fArg = dyn_cast<SILFunctionArgument>(searchValue)) {
+      variableNamePath.push_back({fArg});
+      break;
     }
 
     // If we do not do an exact match, see if we can find a debug_var inst. If
@@ -121,12 +138,18 @@ static void getVariableNameForValue(SILValue value2,
 
   // Walk backwards, constructing our string.
   while (true) {
-    auto *next = variableNamePath.pop_back_val();
+    auto next = variableNamePath.pop_back_val();
 
-    if (auto i = DebugVarCarryingInst(next)) {
-      resultingString += i.getName();
-    } else if (auto i = VarDeclCarryingInst(next)) {
-      resultingString += i.getName();
+    if (auto *inst = next.dyn_cast<SILInstruction *>()) {
+      if (auto i = DebugVarCarryingInst(inst)) {
+        resultingString += i.getName();
+      } else if (auto i = VarDeclCarryingInst(inst)) {
+        resultingString += i.getName();
+      }
+    } else {
+      auto value = next.get<SILValue>();
+      if (auto *fArg = dyn_cast<SILFunctionArgument>(value))
+        resultingString += fArg->getDecl()->getBaseName().userFacingName();
     }
 
     if (variableNamePath.empty())
@@ -637,7 +660,7 @@ void DiagnosticEmitter::emitObjectInstConsumesAndUsesValue(
   registerDiagnosticEmitted(markedValue);
 }
 
-void DiagnosticEmitter::emitAddressInstLoadedAndConsumed(
+void DiagnosticEmitter::emitAddressEscapingClosureCaptureLoadedAndConsumed(
     MarkMustCheckInst *markedValue) {
   SmallString<64> varName;
   getVariableNameForValue(markedValue, varName);
@@ -648,7 +671,13 @@ void DiagnosticEmitter::emitAddressInstLoadedAndConsumed(
       decltype(diag::
                    sil_moveonlychecker_notconsumable_but_assignable_was_consumed_classfield_let);
   Optional<DiagType> diag;
-  if (auto *reai = dyn_cast<RefElementAddrInst>(operand)) {
+
+  if (markedValue->getCheckKind() ==
+      MarkMustCheckInst::CheckKind::NoConsumeOrAssign) {
+    // We only use no consume or assign if we have a promoted let box.
+    diag = diag::
+        sil_moveonlychecker_notconsumable_but_assignable_was_consumed_classfield_let;
+  } else if (auto *reai = dyn_cast<RefElementAddrInst>(operand)) {
     auto *field = reai->getField();
     if (field->isLet()) {
       diag = diag::
@@ -657,8 +686,7 @@ void DiagnosticEmitter::emitAddressInstLoadedAndConsumed(
       diag = diag::
           sil_moveonlychecker_notconsumable_but_assignable_was_consumed_classfield_var;
     }
-  } else if (auto *globalAddr =
-                 dyn_cast<GlobalAddrInst>(operand)) {
+  } else if (auto *globalAddr = dyn_cast<GlobalAddrInst>(operand)) {
     auto inst = VarDeclCarryingInst(globalAddr);
     if (auto *decl = inst.getDecl()) {
       if (decl->isLet()) {
@@ -675,8 +703,21 @@ void DiagnosticEmitter::emitAddressInstLoadedAndConsumed(
       diag = diag::
           sil_moveonlychecker_notconsumable_but_assignable_was_consumed_escaping_var;
     } else {
+      diag = diag::sil_moveonlychecker_let_capture_consumed;
+    }
+  } else if (auto *fArg = dyn_cast<SILFunctionArgument>(operand)) {
+    if (auto boxType = fArg->getType().getAs<SILBoxType>()) {
+      if (boxType->getLayout()->isMutable()) {
+        diag = diag::
+            sil_moveonlychecker_notconsumable_but_assignable_was_consumed_escaping_var;
+      } else {
+        diag = diag::sil_moveonlychecker_let_capture_consumed;
+      }
+    } else if (fArg->getType().isAddress() &&
+               markedValue->getCheckKind() ==
+                   MarkMustCheckInst::CheckKind::AssignableButNotConsumable) {
       diag = diag::
-          sil_moveonlychecker_notconsumable_but_assignable_was_consumed_escaping_let;
+          sil_moveonlychecker_notconsumable_but_assignable_was_consumed_escaping_var;
     }
   }
 
@@ -689,4 +730,30 @@ void DiagnosticEmitter::emitAddressInstLoadedAndConsumed(
   diagnose(markedValue->getModule().getASTContext(), markedValue, *diag,
            varName);
   registerDiagnosticEmitted(markedValue);
+}
+
+void DiagnosticEmitter::emitPromotedBoxArgumentError(
+    MarkMustCheckInst *markedValue, SILFunctionArgument *arg) {
+  auto &astContext = fn->getASTContext();
+  SmallString<64> varName;
+  getVariableNameForValue(markedValue, varName);
+
+  registerDiagnosticEmitted(markedValue);
+
+  auto diag = diag::sil_moveonlychecker_let_capture_consumed;
+  if (markedValue->getCheckKind() ==
+      MarkMustCheckInst::CheckKind::AssignableButNotConsumable)
+    diag = diag::
+        sil_moveonlychecker_notconsumable_but_assignable_was_consumed_escaping_var;
+
+  diagnose(astContext, arg->getDecl()->getLoc(), diag, varName);
+
+  // Now for each consuming use that needs a copy...
+  for (auto *user : getCanonicalizer().consumingUsesNeedingCopy) {
+    diagnose(astContext, user, diag::sil_moveonlychecker_consuming_use_here);
+  }
+
+  for (auto *user : getCanonicalizer().consumingBoundaryUsers) {
+    diagnose(astContext, user, diag::sil_moveonlychecker_consuming_use_here);
+  }
 }

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -106,7 +106,10 @@ public:
                                           Operand *consumingUse,
                                           Operand *nonConsumingUse);
 
-  void emitAddressInstLoadedAndConsumed(MarkMustCheckInst *markedValue);
+  void emitAddressEscapingClosureCaptureLoadedAndConsumed(
+      MarkMustCheckInst *markedValue);
+  void emitPromotedBoxArgumentError(MarkMustCheckInst *markedValue,
+                                    SILFunctionArgument *arg);
 
 private:
   /// Emit diagnostics for the final consuming uses and consuming uses needing

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -53,8 +53,9 @@ class DiagnosticEmitter {
   bool emittedCheckerDoesntUnderstandDiagnostic = false;
 
 public:
-  void init(SILFunction *inputFn, OSSACanonicalizer *inputCanonicalizer) {
-    fn = inputFn;
+  DiagnosticEmitter(SILFunction *inputFn) : fn(inputFn) {}
+
+  void initCanonicalizer(OSSACanonicalizer *inputCanonicalizer) {
     canonicalizer = inputCanonicalizer;
   }
 
@@ -75,7 +76,7 @@ public:
   /// way to file a bug.
   void emitCheckedMissedCopyError(SILInstruction *copyInst);
 
-  void emitCheckerDoesntUnderstandDiagnostic(MarkMustCheckInst *markedValue);
+  void emitCheckerDoesntUnderstandDiagnostic(MarkMustCheckInst *markedValue) __attribute__((optnone));
   void emitObjectGuaranteedDiagnostic(MarkMustCheckInst *markedValue);
   void emitObjectOwnedDiagnostic(MarkMustCheckInst *markedValue);
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.h
@@ -76,7 +76,7 @@ public:
   /// way to file a bug.
   void emitCheckedMissedCopyError(SILInstruction *copyInst);
 
-  void emitCheckerDoesntUnderstandDiagnostic(MarkMustCheckInst *markedValue) __attribute__((optnone));
+  void emitCheckerDoesntUnderstandDiagnostic(MarkMustCheckInst *markedValue);
   void emitObjectGuaranteedDiagnostic(MarkMustCheckInst *markedValue);
   void emitObjectOwnedDiagnostic(MarkMustCheckInst *markedValue);
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerTester.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerTester.cpp
@@ -93,7 +93,7 @@ class MoveOnlyObjectCheckerTesterPass : public SILFunctionTransform {
     DominanceInfo *domTree = dominanceAnalysis->get(fn);
     auto *poa = getAnalysis<PostOrderAnalysis>();
 
-    DiagnosticEmitter diagnosticEmitter;
+    DiagnosticEmitter diagnosticEmitter(fn);
     borrowtodestructure::IntervalMapAllocator allocator;
 
     unsigned diagCount = diagnosticEmitter.getDiagnosticCount();

--- a/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyObjectCheckerUtils.cpp
@@ -520,7 +520,7 @@ void MoveOnlyObjectCheckerPImpl::check(DominanceInfo *domTree,
   InstructionDeleter deleter(std::move(callbacks));
   OSSACanonicalizer canonicalizer;
   canonicalizer.init(fn, domTree, deleter);
-  diagnosticEmitter.init(fn, &canonicalizer);
+  diagnosticEmitter.initCanonicalizer(&canonicalizer);
 
   unsigned initialDiagCount = diagnosticEmitter.getDiagnosticCount();
 

--- a/test/IRGen/moveonly_deinits.swift
+++ b/test/IRGen/moveonly_deinits.swift
@@ -63,16 +63,26 @@ var value: Bool { false }
 //////////////////
 
 // IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits24testIntPairWithoutDeinityyF"()
-// IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
+// IR:   [[ALLOCA:%.*]] = alloca [[TYPE:%T16moveonly_deinits20IntPairWithoutDeinitV]]
+// IR:   br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
 //
 // IR: [[BB1]]:
-// IR-NEXT:   call swiftcc void @"$s16moveonly_deinits27consumeIntPairWithoutDeinityyAA0defG0VnF"
+// IR-NEXT:   [[GEP:%.*]] = getelementptr inbounds [[TYPE]], [[TYPE]]* [[ALLOCA]], i32 0, i32 0
+// IR-NEXT:   [[GEP2:%.*]] = getelementptr inbounds %TSi, %TSi* [[GEP]], i32 0, i32 0
+// IR-NEXT:   [[LHS:%.*]] = load i64, i64* [[GEP2]]
+// IR-NEXT:   [[GEP:%.*]] = getelementptr inbounds [[TYPE]], [[TYPE]]* [[ALLOCA]], i32 0, i32 1
+// IR-NEXT:   [[GEP2:%.*]] = getelementptr inbounds %TSi, %TSi* [[GEP]], i32 0, i32 0
+// IR-NEXT:   [[RHS:%.*]] = load i64, i64* [[GEP2]]
+// IR-NEXT:   call swiftcc void @"$s16moveonly_deinits27consumeIntPairWithoutDeinityyAA0defG0VnF"(i64 [[LHS]], i64 [[RHS]])
 // IR-NEXT:   br label %[[CONT:[0-9]+]]
 //
 // IR: [[BB2]]:
+// IR-NEXT:   call [[TYPE]]* @"$s16moveonly_deinits20IntPairWithoutDeinitVWOh"([[TYPE]]* [[ALLOCA]])
 // IR-NEXT:   br label %[[CONT]]
 //
 // IR: [[CONT]]:
+// IR-NEXT: bitcast
+// IR-NEXT: @llvm.lifetime.end
 // IR-NEXT: ret void
 // IR-NEXT: }
 public func testIntPairWithoutDeinit() {
@@ -83,17 +93,32 @@ public func testIntPairWithoutDeinit() {
 }
 
 // IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits21testIntPairWithDeinityyF"()
+// IR: [[ALLOCA:%.*]] = alloca [[TYPE:%T16moveonly_deinits17IntPairWithDeinitV]]
 // IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
 //
 // IR: [[BB1]]:
+// IR-NEXT:   [[GEP:%.*]] = getelementptr inbounds [[TYPE]], [[TYPE]]* [[ALLOCA]], i32 0, i32 0
+// IR-NEXT:   [[GEP2:%.*]] = getelementptr inbounds %TSi, %TSi* [[GEP]], i32 0, i32 0
+// IR-NEXT:   [[LHS:%.*]] = load i64, i64* [[GEP2]]
+// IR-NEXT:   [[GEP:%.*]] = getelementptr inbounds [[TYPE]], [[TYPE]]* [[ALLOCA]], i32 0, i32 1
+// IR-NEXT:   [[GEP2:%.*]] = getelementptr inbounds %TSi, %TSi* [[GEP]], i32 0, i32 0
+// IR-NEXT:   [[RHS:%.*]] = load i64, i64* [[GEP2]]
 // IR-NEXT:  call swiftcc void @"$s16moveonly_deinits24consumeIntPairWithDeinityyAA0defG0VnF"(
 // IR-NEXT:  br label %[[CONT:[0-9]+]]
 //
 // IR: [[BB2]]:
-// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits17IntPairWithDeinitVfD"(
+// IR-NEXT:   [[GEP:%.*]] = getelementptr inbounds [[TYPE]], [[TYPE]]* [[ALLOCA]], i32 0, i32 0
+// IR-NEXT:   [[GEP2:%.*]] = getelementptr inbounds %TSi, %TSi* [[GEP]], i32 0, i32 0
+// IR-NEXT:   [[LHS:%.*]] = load i64, i64* [[GEP2]]
+// IR-NEXT:   [[GEP:%.*]] = getelementptr inbounds [[TYPE]], [[TYPE]]* [[ALLOCA]], i32 0, i32 1
+// IR-NEXT:   [[GEP2:%.*]] = getelementptr inbounds %TSi, %TSi* [[GEP]], i32 0, i32 0
+// IR-NEXT:   [[RHS:%.*]] = load i64, i64* [[GEP2]]
+// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits17IntPairWithDeinitVfD"(i64 [[LHS]], i64 [[RHS]])
 // IR-NEXT:  br label %[[CONT]]
 //
 // IR: [[CONT]]
+// IR-NEXT: bitcast
+// IR-NEXT: @llvm.lifetime.end
 // IR-NEXT: ret void
 // IR-NEXT: }
 public func testIntPairWithDeinit() {
@@ -104,18 +129,24 @@ public func testIntPairWithDeinit() {
 }
 
 // IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits26testKlassPairWithoutDeinityyF"()
-// IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
+// IR:   [[ALLOCA:%.*]] = alloca [[TYPE:%T16moveonly_deinits22KlassPairWithoutDeinitV]]
+// IR:   br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
 //
 // IR: [[BB1]]:
-// IR-NEXT:   call swiftcc void @"$s16moveonly_deinits29consumeKlassPairWithoutDeinityyAA0defG0VnF"
+// IR-NEXT:   [[GEP:%.*]] = getelementptr inbounds [[TYPE]], [[TYPE]]* [[ALLOCA]], i32 0, i32 0
+// IR-NEXT:   [[LHS:%.*]] = load [[KLASS:%T16moveonly_deinits5KlassC]]*, [[KLASS]]** [[GEP]]
+// IR-NEXT:   [[GEP:%.*]] = getelementptr inbounds [[TYPE]], [[TYPE]]* [[ALLOCA]], i32 0, i32 1
+// IR-NEXT:   [[RHS:%.*]] = load [[KLASS]]*, [[KLASS]]** [[GEP]]
+// IR-NEXT:   call swiftcc void @"$s16moveonly_deinits29consumeKlassPairWithoutDeinityyAA0defG0VnF"([[KLASS]]* [[LHS]], [[KLASS]]* [[RHS]])
 // IR-NEXT:   br label %[[CONT:[0-9]+]]
 //
 // IR: [[BB2]]:
-// IR-NEXT:   call void bitcast {{.*}} @swift_release
-// IR-NEXT:   call void bitcast {{.*}} @swift_release
+// IR-NEXT:   call [[TYPE]]* @"$s16moveonly_deinits22KlassPairWithoutDeinitVWOh"([[TYPE]]* [[ALLOCA]])
 // IR-NEXT:   br label %[[CONT]]
 //
 // IR: [[CONT]]:
+// IR-NEXT: bitcast
+// IR-NEXT: call void
 // IR-NEXT: ret void
 // IR-NEXT: }
 public func testKlassPairWithoutDeinit() {
@@ -126,17 +157,28 @@ public func testKlassPairWithoutDeinit() {
 }
 
 // IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits23testKlassPairWithDeinityyF"()
-// IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
+// IR:   [[ALLOCA:%.*]] = alloca [[TYPE:%T16moveonly_deinits19KlassPairWithDeinitV]]
+// IR:   br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
 //
 // IR: [[BB1]]:
-// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits26consumeKlassPairWithDeinityyAA0defG0VnF"(
+// IR-NEXT:   [[GEP:%.*]] = getelementptr inbounds [[TYPE]], [[TYPE]]* [[ALLOCA]], i32 0, i32 0
+// IR-NEXT:   [[LHS:%.*]] = load [[KLASS:%T16moveonly_deinits5KlassC]]*, [[KLASS]]** [[GEP]]
+// IR-NEXT:   [[GEP:%.*]] = getelementptr inbounds [[TYPE]], [[TYPE]]* [[ALLOCA]], i32 0, i32 1
+// IR-NEXT:   [[RHS:%.*]] = load [[KLASS]]*, [[KLASS]]** [[GEP]]
+// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits26consumeKlassPairWithDeinityyAA0defG0VnF"([[KLASS]]* [[LHS]], [[KLASS]]* [[RHS]])
 // IR-NEXT:  br label %[[CONT:[0-9]+]]
 //
 // IR: [[BB2]]:
-// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits19KlassPairWithDeinitVfD"(
+// IR-NEXT:   [[GEP:%.*]] = getelementptr inbounds [[TYPE]], [[TYPE]]* [[ALLOCA]], i32 0, i32 0
+// IR-NEXT:   [[LHS:%.*]] = load [[KLASS:%T16moveonly_deinits5KlassC]]*, [[KLASS]]** [[GEP]]
+// IR-NEXT:   [[GEP:%.*]] = getelementptr inbounds [[TYPE]], [[TYPE]]* [[ALLOCA]], i32 0, i32 1
+// IR-NEXT:   [[RHS:%.*]] = load [[KLASS]]*, [[KLASS]]** [[GEP]]
+// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits19KlassPairWithDeinitVfD"([[KLASS]]* [[LHS]], [[KLASS]]* [[RHS]])
 // IR-NEXT:  br label %[[CONT]]
 //
 // IR: [[CONT]]
+// IR-NEXT: bitcast
+// IR-NEXT: @llvm.lifetime.end
 // IR-NEXT: ret void
 // IR-NEXT: }
 public func testKlassPairWithDeinit() {
@@ -192,16 +234,25 @@ func consumeKlassEnumPairWithDeinit(_ x: __owned KlassEnumPairWithDeinit) { }
 ////////////////
 
 // IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits28testIntEnumPairWithoutDeinityyF"()
-// IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
+// IR:   [[ALLOCA:%.*]] = alloca [[TYPE:%T16moveonly_deinits24IntEnumPairWithoutDeinitO]]
+// IR:   br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
 //
 // IR: [[BB1]]:
-// IR-NEXT:   call swiftcc void @"$s16moveonly_deinits31consumeIntEnumPairWithoutDeinityyAA0defgH0OnF"
+// IR-NEXT:  [[CAST:%.*]] = bitcast [[TYPE]]* [[ALLOCA]] to i64*
+// IR-NEXT:  [[LHS:%.*]] = load i64, i64* [[CAST]]
+// IR-NEXT:  [[GEP:%.*]] = getelementptr inbounds [[TYPE]], [[TYPE]]* [[ALLOCA]], i32 0, i32 1
+// IR-NEXT:  [[BITCAST:%.*]] = bitcast [1 x i8]* [[GEP]] to i1*
+// IR-NEXT:  [[RHS:%.*]] = load i1, i1* [[BITCAST]]
+// IR-NEXT:  [[RHS_ZEXT:%.*]] = zext i1 [[RHS]]
+// IR-NEXT:   call swiftcc void @"$s16moveonly_deinits31consumeIntEnumPairWithoutDeinityyAA0defgH0OnF"(i64 [[LHS]], i8 [[RHS_ZEXT]])
 // IR-NEXT:   br label %[[CONT:[0-9]+]]
 //
 // IR: [[BB2]]:
 // IR-NEXT:   br label %[[CONT]]
 //
 // IR: [[CONT]]:
+// IR-NEXT: bitcast
+// IR-NEXT: call void @llvm.lifetime.end
 // IR-NEXT: ret void
 // IR-NEXT: }
 public func testIntEnumPairWithoutDeinit() {
@@ -212,17 +263,32 @@ public func testIntEnumPairWithoutDeinit() {
 }
 
 // IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits25testIntEnumPairWithDeinityyF"()
-// IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
+// IR:   [[ALLOCA:%.*]] = alloca [[TYPE:%T16moveonly_deinits21IntEnumPairWithDeinitO]]
+// IR:   br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
 //
 // IR: [[BB1]]:
-// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits28consumeIntEnumPairWithDeinityyAA0defgH0OnF"(
+// IR-NEXT:  [[CAST:%.*]] = bitcast [[TYPE]]* [[ALLOCA]] to i64*
+// IR-NEXT:  [[LHS:%.*]] = load i64, i64* [[CAST]]
+// IR-NEXT:  [[GEP:%.*]] = getelementptr inbounds [[TYPE]], [[TYPE]]* [[ALLOCA]], i32 0, i32 1
+// IR-NEXT:  [[BITCAST:%.*]] = bitcast [1 x i8]* [[GEP]] to i1*
+// IR-NEXT:  [[RHS:%.*]] = load i1, i1* [[BITCAST]]
+// IR-NEXT:  [[RHS_ZEXT:%.*]] = zext i1 [[RHS]]
+// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits28consumeIntEnumPairWithDeinityyAA0defgH0OnF"(i64 [[LHS]], i8 [[RHS_ZEXT]])
 // IR-NEXT:  br label %[[CONT:[0-9]+]]
 //
 // IR: [[BB2]]:
-// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits21IntEnumPairWithDeinitOfD"(
+// IR-NEXT:  [[CAST:%.*]] = bitcast [[TYPE]]* [[ALLOCA]] to i64*
+// IR-NEXT:  [[LHS:%.*]] = load i64, i64* [[CAST]]
+// IR-NEXT:  [[GEP:%.*]] = getelementptr inbounds [[TYPE]], [[TYPE]]* [[ALLOCA]], i32 0, i32 1
+// IR-NEXT:  [[BITCAST:%.*]] = bitcast [1 x i8]* [[GEP]] to i1*
+// IR-NEXT:  [[RHS:%.*]] = load i1, i1* [[BITCAST]]
+// IR-NEXT:  [[RHS_ZEXT:%.*]] = zext i1 [[RHS]]
+// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits21IntEnumPairWithDeinitOfD"(i64 [[LHS]], i8 [[RHS_ZEXT]])
 // IR-NEXT:  br label %[[CONT]]
 //
 // IR: [[CONT]]
+// IR-NEXT: bitcast
+// IR-NEXT: @llvm.lifetime.end
 // IR-NEXT: ret void
 // IR-NEXT: }
 public func testIntEnumPairWithDeinit() {
@@ -233,19 +299,22 @@ public func testIntEnumPairWithDeinit() {
 }
 
 // IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits30testKlassEnumPairWithoutDeinityyF"()
-// IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
+// IR:   [[ALLOCA:%.*]] = alloca [[TYPE:%T16moveonly_deinits26KlassEnumPairWithoutDeinitO]]
+// IR:   br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
 //
 // IR: [[BB1]]:
-// IR-NEXT:   call swiftcc void @"$s16moveonly_deinits33consumeKlassEnumPairWithoutDeinityyAA0defgH0OnF"
-// IR-NEXT:   br label %[[CONT:[0-9]+]]
+// IR-NEXT:  [[CAST:%.*]] = bitcast [[TYPE]]* [[ALLOCA]] to i64*
+// IR-NEXT:  [[VALUE:%.*]] = load i64, i64* [[CAST]]
+// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits33consumeKlassEnumPairWithoutDeinityyAA0defgH0OnF"(i64 [[VALUE]])
+// IR-NEXT:  br label %[[CONT:[0-9]+]]
 //
 // IR: [[BB2]]:
-// IR-NEXT:   and i64
-// IR-NEXT:   inttoptr i64
-// IR-NEXT:   call void{{.*}} @swift_release
+// IR-NEXT: call [[TYPE]]* @"$s16moveonly_deinits26KlassEnumPairWithoutDeinitOWOh"([[TYPE]]* [[ALLOCA]])
 // IR-NEXT:   br label %[[CONT]]
 //
 // IR: [[CONT]]:
+// IR-NEXT: bitcast
+// IR-NEXT: @llvm.lifetime.end
 // IR-NEXT: ret void
 // IR-NEXT: }
 public func testKlassEnumPairWithoutDeinit() {
@@ -292,17 +361,24 @@ public func testKlassEnumPairWithoutDeinit() {
 // SIL: } // end sil function '$s16moveonly_deinits27testKlassEnumPairWithDeinityyF'
 
 // IR-LABEL: define {{.*}}swiftcc void @"$s16moveonly_deinits27testKlassEnumPairWithDeinityyF"()
-// IR: br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
+// IR:  [[ALLOCA:%.*]] = alloca [[TYPE:%T16moveonly_deinits23KlassEnumPairWithDeinitO]]
+// IR:  br i1 {{%.*}}, label %[[BB1:[0-9]+]], label %[[BB2:[0-9]+]]
 //
 // IR: [[BB1]]:
-// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits30consumeKlassEnumPairWithDeinityyAA0defgH0OnF"(
+// IR-NEXT:  [[CAST:%.*]] = bitcast [[TYPE]]* [[ALLOCA]] to i64*
+// IR-NEXT:  [[LOAD:%.*]] = load i64, i64* [[CAST]]
+// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits30consumeKlassEnumPairWithDeinityyAA0defgH0OnF"(i64 [[LOAD]])
 // IR-NEXT:  br label %[[CONT:[0-9]+]]
 //
 // IR: [[BB2]]:
-// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits23KlassEnumPairWithDeinitOfD"(
+// IR-NEXT:  [[CAST:%.*]] = bitcast [[TYPE]]* [[ALLOCA]] to i64*
+// IR-NEXT:  [[LOAD:%.*]] = load i64, i64* [[CAST]]
+// IR-NEXT:  call swiftcc void @"$s16moveonly_deinits23KlassEnumPairWithDeinitOfD"(i64 [[LOAD]])
 // IR-NEXT:  br label %[[CONT]]
 //
 // IR: [[CONT]]
+// IR-NEXT: bitcast
+// IR-NEXT: @llvm.lifetime.end
 // IR-NEXT: ret void
 // IR-NEXT: }
 public func testKlassEnumPairWithDeinit() {

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -168,13 +168,17 @@ extension NonTrivialEnum {
 ///////////////////////////////
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly27blackHoleLetInitialization1yyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box
+// CHECK: [[BORROWED_BOX:%.*]] = begin_borrow [lexical] [[BOX]]
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly2FDVACycfC :
 // CHECK: [[X:%.*]] = apply [[FN]](
-// CHECK: [[X_MV_LEXICAL:%.*]] = move_value [lexical] [[X]]
-// CHECK: [[X_MV_ONLY:%.*]] = mark_must_check [consumable_and_assignable] [[X_MV_LEXICAL]]
-// CHECK: [[X_MV_ONLY_BORROW:%.*]] = begin_borrow [[X_MV_ONLY]]
-// CHECK: [[X_MV_ONLY_COPY:%.*]] = copy_value [[X_MV_ONLY_BORROW]]
-// CHECK: [[X_MV_ONLY_CONSUME:%.*]] = move_value [[X_MV_ONLY_COPY]]
+// CHECK: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// CHECK: store [[X]] to [init] [[PROJECT]]
+//
+// CHECK: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// CHECK: [[MARKED:%.*]] = mark_must_check [assignable_but_not_consumable] [[PROJECT]]
+// CHECK: [[VALUE:%.*]] = load [copy] [[MARKED]]
+// CHECK: move_value [[VALUE]]
 // CHECK: } // end sil function '$s8moveonly27blackHoleLetInitialization1yyF'
 func blackHoleLetInitialization1() {
     let x = FD()
@@ -182,13 +186,17 @@ func blackHoleLetInitialization1() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly27blackHoleLetInitialization2yyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box
+// CHECK: [[BORROWED_BOX:%.*]] = begin_borrow [lexical] [[BOX]]
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly2FDVACycfC :
 // CHECK: [[X:%.*]] = apply [[FN]](
-// CHECK: [[X_MV_LEXICAL:%.*]] = move_value [lexical] [[X]]
-// CHECK: [[X_MV_ONLY:%.*]] = mark_must_check [consumable_and_assignable] [[X_MV_LEXICAL]]
-// CHECK: [[X_MV_ONLY_BORROW:%.*]] = begin_borrow [[X_MV_ONLY]]
-// CHECK: [[X_MV_ONLY_COPY:%.*]] = copy_value [[X_MV_ONLY_BORROW]]
-// CHECK: [[X_MV_ONLY_CONSUME:%.*]] = move_value [[X_MV_ONLY_COPY]]
+// CHECK: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// CHECK: store [[X]] to [init] [[PROJECT]]
+//
+// CHECK: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// CHECK: [[MARKED:%.*]] = mark_must_check [assignable_but_not_consumable] [[PROJECT]]
+// CHECK: [[VALUE:%.*]] = load [copy] [[MARKED]]
+// CHECK: move_value [[VALUE]]
 // CHECK: } // end sil function '$s8moveonly27blackHoleLetInitialization2yyF'
 func blackHoleLetInitialization2() {
     let x = FD()
@@ -274,8 +282,15 @@ func blackHoleVarInitialization3() {
 ////////////////////////////////
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly24borrowObjectFunctionCallyyF : $@convention(thin) () -> () {
-// CHECK: [[CLS:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK: [[BORROW:%.*]] = begin_borrow [[CLS]]
+// CHECK: [[BOX:%.*]] = alloc_box
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical] [[BOX]]
+//
+// CHECK: [[PROJECT:%.*]] = project_box [[BORROW_BOX]]
+// CHECK: store {{%.*}} to [init] [[PROJECT]]
+//
+// CHECK: [[PROJECT:%.*]] = project_box [[BORROW_BOX]]
+// CHECK: [[CLS:%.*]] = mark_must_check [assignable_but_not_consumable] [[PROJECT]]
+// CHECK: [[BORROW:%.*]] = load_borrow [[CLS]]
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA2FDVhF :
 // CHECK: apply [[FN]]([[BORROW]])
 // CHECK: end_borrow [[BORROW]]
@@ -565,8 +580,11 @@ var booleanGuard2: Bool { false }
 // CHECK:   br [[BB_CONT:bb[0-9]+]]
 //
 // CHECK: [[BB_E_2]]([[BBARG:%.*]] : @guaranteed
+// CHECK:   [[NEW_BOX:%.*]] = alloc_box
+// CHECK:   [[NEW_BOX_BORROW:%.*]] = begin_borrow [lexical] [[NEW_BOX]]
+// CHECK:   [[NEW_BOX_PROJECT:%.*]] = project_box [[NEW_BOX_BORROW]]
 // CHECK:   [[BBARG_COPY:%.*]] = copy_value [[BBARG]]
-// CHECK:   [[NEW_VAL:%.*]] = move_value [lexical] [[BBARG_COPY]]
+// CHECK:   store [[BBARG_COPY]] to [init] [[NEW_BOX_PROJECT]]
 // CHECK:   end_borrow [[BORROWED_VALUE]]
 // CHECK:   br [[BB_CONT]]
 //
@@ -597,8 +615,11 @@ var booleanGuard2: Bool { false }
 //
 // Move only case.
 // CHECK: [[BB_E2_RHS]]([[BBARG:%.*]] : @guaranteed
+// CHECK:   [[NEW_BOX:%.*]] = alloc_box
+// CHECK:   [[NEW_BOX_BORROW:%.*]] = begin_borrow [lexical] [[NEW_BOX]]
+// CHECK:   [[NEW_BOX_PROJECT:%.*]] = project_box [[NEW_BOX_BORROW]]
 // CHECK:   [[BBARG_COPY:%.*]] = copy_value [[BBARG]]
-// CHECK:   move_value [lexical] [[BBARG_COPY]]
+// CHECK:   store [[BBARG_COPY]] to [init] [[NEW_BOX_PROJECT]]
 // CHECK:   end_borrow [[BORROWED_VALUE]]
 // CHECK:   br [[BB_CONT]]
 //

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -772,3 +772,25 @@ func testGlobalAssign() {
     varGlobal.nonTrivialStruct2 = NonTrivialStruct2()
     varGlobal.nonTrivialStruct2 = NonTrivialStruct2()
 }
+
+/////////////////////////////////
+// MARK: Closure Capture Tests //
+/////////////////////////////////
+
+// Make sure that we insert a mark_must_check on the capture value.
+// CHECK-LABEL: sil hidden [ossa] @$s8moveonly28checkMarkMustCheckOnCaptured1xyAA2FDVn_tF : $@convention(thin) (@owned FD) -> () {
+// CHECK: bb0([[ARG:%.*]] : @owned
+// CHECK:   [[BOX:%.*]] = alloc_box
+// CHECK:   [[PROJECT:%.*]] = project_box [[BOX]]
+// CHECK:   store [[ARG]] to [init] [[PROJECT]]
+//
+// CHECK:   [[FN:%.*]] = function_ref @$s8moveonly28checkMarkMustCheckOnCaptured1xyAA2FDVn_tFyyXEfU_ : $@convention(thin) @substituted <τ_0_0> (@guaranteed FD) -> @out τ_0_0 for <()>
+// CHECK:   [[PROJECT:%.*]] = project_box [[BOX]]
+// CHECK:   [[MARK:%.*]] = mark_must_check [assignable_but_not_consumable] [[PROJECT]]
+// CHECK:   [[VALUE:%.*]] = load [copy] [[MARK]]
+// CHECK:   [[CLOSURE:%.*]] = partial_apply [callee_guaranteed] [[FN]]([[VALUE]])
+// CHECK: } // end sil function '$s8moveonly28checkMarkMustCheckOnCaptured1xyAA2FDVn_tF'
+func checkMarkMustCheckOnCaptured(x: __owned FD) {
+    func clodger<T>(_: () -> T) {}
+    clodger({ consumeVal(x) })
+}

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -199,12 +199,18 @@ func blackHoleLetInitialization2() {
 // CHECK: [[BOX:%.*]] = alloc_box
 // CHECK: [[BOX_BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
 // CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
-// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable] [[PROJECT_BOX]]
+// CHECK: store {{%.*}} to [init] [[PROJECT_BOX]]
+// CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly2FDVACycfC :
 // CHECK: [[X:%.*]] = apply [[FN]](
-// CHECK: store [[X]] to [init] [[MARKED_ADDR]]
-// CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK: [[LD:%.*]] = load [copy] [[READ]]
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT_BOX]]
+// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: assign [[X]] to [[MARKED_ADDR]]
+//
+// CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
+// CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PROJECT_BOX]]
+// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [assignable_but_not_consumable] [[READ]]
+// CHECK: [[LD:%.*]] = load [copy] [[MARKED_ADDR]]
 // CHECK: [[CONSUME:%.*]] = move_value [[LD]]
 // CHECK: } // end sil function '$s8moveonly27blackHoleVarInitialization1yyF'
 func blackHoleVarInitialization1() {
@@ -217,12 +223,19 @@ func blackHoleVarInitialization1() {
 // CHECK: [[BOX:%.*]] = alloc_box
 // CHECK: [[BOX_BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
 // CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
-// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable] [[PROJECT_BOX]]
+// CHECK: store {{%.*}} to [init] [[PROJECT_BOX]]
+//
+// CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly2FDVACycfC :
 // CHECK: [[X:%.*]] = apply [[FN]](
-// CHECK: store [[X]] to [init] [[MARKED_ADDR]]
-// CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK: [[LD:%.*]] = load [copy] [[READ]]
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT_BOX]]
+// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: assign [[X]] to [[MARKED_ADDR]]
+//
+// CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
+// CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PROJECT_BOX]]
+// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [assignable_but_not_consumable] [[READ]]
+// CHECK: [[LD:%.*]] = load [copy] [[MARKED_ADDR]]
 // CHECK: [[CONSUME:%.*]] = move_value [[LD]]
 // CHECK: } // end sil function '$s8moveonly27blackHoleVarInitialization2yyF'
 func blackHoleVarInitialization2() {
@@ -235,12 +248,19 @@ func blackHoleVarInitialization2() {
 // CHECK: [[BOX:%.*]] = alloc_box
 // CHECK: [[BOX_BORROW:%.*]] = begin_borrow [lexical] [[BOX]]
 // CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
-// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable] [[PROJECT_BOX]]
+// CHECK: store {{%.*}} to [init] [[PROJECT_BOX]]
+//
+// CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly2FDVACycfC :
 // CHECK: [[X:%.*]] = apply [[FN]](
-// CHECK: store [[X]] to [init] [[MARKED_ADDR]]
-// CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK: [[LD:%.*]] = load [copy] [[READ]]
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT_BOX]]
+// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: assign [[X]] to [[MARKED_ADDR]]
+//
+// CHECK: [[PROJECT_BOX:%.*]] = project_box [[BOX_BORROW]]
+// CHECK: [[READ:%.*]] = begin_access [read] [unknown] [[PROJECT_BOX]]
+// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [assignable_but_not_consumable] [[READ]]
+// CHECK: [[LD:%.*]] = load [copy] [[MARKED_ADDR]]
 // CHECK: [[CONSUME:%.*]] = move_value [[LD]]
 // CHECK: } // end sil function '$s8moveonly27blackHoleVarInitialization3yyF'
 func blackHoleVarInitialization3() {
@@ -266,9 +286,22 @@ func borrowObjectFunctionCall() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly29moveOnlyStructNonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK: [[BORROW:%.*]] = load_borrow [[ACCESS]]
+// CHECK: [[BOX:%.*]] = alloc_box
+// CHECK: [[BORROWED_BOX:%.*]] = begin_borrow [lexical] [[BOX]]
+//
+// TODO: We should have a begin_access [init] here probably.
+// CHECK: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// CHECK: store {{%.*}} to [init] [[PROJECT]]
+//
+// CHECK: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJECT]]
+// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [assignable_but_not_consumable]
+// CHECK: assign {{%.*}} to [[MARKED_ADDR]]
+//
+// CHECK: [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK: [[MARKED_ADDR:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: [[BORROW:%.*]] = load_borrow [[MARKED_ADDR]]
 // CHECK: [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA16NonTrivialStructVhF :
 // CHECK: apply [[FN]]([[BORROW]])
 // CHECK: end_borrow [[BORROW]]
@@ -281,9 +314,18 @@ func moveOnlyStructNonConsumingUse() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovecD15NonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
+// CHECK: [[BOX:%.*]] = alloc_box
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical]
+//
+// CHECK: project_box
+// CHECK: store
+// CHECK: project_box
+// CHECK: assign
+//
+// CHECK:   [[PROJECT:%.*]] = project_box [[BORROW_BOX]]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[MARKED_ADDR]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP]]
 // CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA17NonTrivialStruct2VhF : $@convention(thin) (@guaranteed NonTrivialStruct2) -> ()
 // CHECK:   apply [[FN]]([[BORROW]])
@@ -297,9 +339,18 @@ func moveOnlyStructMoveOnlyStructNonConsumingUse() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly018moveOnlyStructMovecD28CopyableKlassNonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
+// CHECK: [[BOX:%.*]] = alloc_box
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical]
+//
+// CHECK: project_box
+// CHECK: store
+// CHECK: project_box
+// CHECK: assign
+//
+// CHECK:   [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK:   [[GEP1:%.*]] = struct_element_addr [[MARKED_ADDR]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialStruct2
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialStruct2, #NonTrivialStruct2.copyableKlass
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP2]]
 // CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassChF : $@convention(thin) (@guaranteed CopyableKlass) -> ()
@@ -314,9 +365,18 @@ func moveOnlyStructMoveOnlyStructCopyableKlassNonConsumingUse() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly42moveOnlyStructCopyableKlassNonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.copyableKlass
+// CHECK: [[BOX:%.*]] = alloc_box
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical]
+//
+// CHECK: project_box
+// CHECK: store
+// CHECK: project_box
+// CHECK: assign
+//
+// CHECK:   [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[MARKED_ADDR]] : $*NonTrivialStruct, #NonTrivialStruct.copyableKlass
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP]]
 // CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassChF : $@convention(thin) (@guaranteed CopyableKlass) -> ()
 // CHECK:   apply [[FN]]([[BORROW]])
@@ -330,9 +390,18 @@ func moveOnlyStructCopyableKlassNonConsumingUse() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyableD15NonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
+// CHECK: [[BOX:%.*]] = alloc_box
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical]
+//
+// CHECK: project_box
+// CHECK: store
+// CHECK: project_box
+// CHECK: assign
+//
+// CHECK:   [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[MARKED_ADDR]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP]]
 // CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA24NonTrivialCopyableStructVhF :
 // CHECK:   apply [[FN]]([[BORROW]])
@@ -346,9 +415,18 @@ func moveOnlyStructCopyableStructNonConsumingUse() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyabledE20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
+// CHECK: [[BOX:%.*]] = alloc_box
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical]
+//
+// CHECK: project_box
+// CHECK: store
+// CHECK: project_box
+// CHECK: assign
+//
+// CHECK:   [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK:   [[GEP1:%.*]] = struct_element_addr [[MARKED_ADDR]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.copyableKlass
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP2]]
 // CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA13CopyableKlassChF :
@@ -363,9 +441,18 @@ func moveOnlyStructCopyableStructCopyableKlassNonConsumingUse() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyabledeD15NonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
+// CHECK: [[BOX:%.*]] = alloc_box
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical]
+//
+// CHECK: project_box
+// CHECK: store
+// CHECK: project_box
+// CHECK: assign
+//
+// CHECK:   [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK:   [[GEP1:%.*]] = struct_element_addr [[MARKED_ADDR]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.nonTrivialCopyableStruct2
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP2]]
 // CHECK:   [[FN:%.*]] = function_ref @$s8moveonly9borrowValyyAA25NonTrivialCopyableStruct2VhF :
@@ -380,9 +467,18 @@ func moveOnlyStructCopyableStructCopyableStructNonConsumingUse() {
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyablededE20KlassNonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
+// CHECK: [[BOX:%.*]] = alloc_box
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical]
+//
+// CHECK: project_box
+// CHECK: store
+// CHECK: project_box
+// CHECK: assign
+//
+// CHECK:   [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK:   [[GEP1:%.*]] = struct_element_addr [[MARKED_ADDR]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.nonTrivialCopyableStruct2
 // CHECK:   [[GEP3:%.*]] = struct_element_addr [[GEP2]] : $*NonTrivialCopyableStruct2, #NonTrivialCopyableStruct2.copyableKlass
 // CHECK:   [[BORROW:%.*]] = load_borrow [[GEP3]]
@@ -400,9 +496,18 @@ func moveOnlyStructCopyableStructCopyableStructCopyableKlassNonConsumingUse() {
 // We fail here b/c we are accessing through a class.
 //
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly022moveOnlyStructCopyabledede9KlassMovecF15NonConsumingUseyyF : $@convention(thin) () -> () {
-// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [consumable_and_assignable]
-// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[MARKED_ADDR]]
-// CHECK:   [[GEP1:%.*]] = struct_element_addr [[ACCESS]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
+// CHECK: [[BOX:%.*]] = alloc_box
+// CHECK: [[BORROW_BOX:%.*]] = begin_borrow [lexical]
+//
+// CHECK: project_box
+// CHECK: store
+// CHECK: project_box
+// CHECK: assign
+//
+// CHECK:   [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// CHECK:   [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJECT]]
+// CHECK:   [[MARKED_ADDR:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK:   [[GEP1:%.*]] = struct_element_addr [[MARKED_ADDR]] : $*NonTrivialStruct, #NonTrivialStruct.nonTrivialCopyableStruct
 // CHECK:   [[GEP2:%.*]] = struct_element_addr [[GEP1]] : $*NonTrivialCopyableStruct, #NonTrivialCopyableStruct.nonTrivialCopyableStruct2
 // CHECK:   [[GEP3:%.*]] = struct_element_addr [[GEP2]] : $*NonTrivialCopyableStruct2, #NonTrivialCopyableStruct2.copyableKlass
 // CHECK:   [[COPYABLE_KLASS:%.*]] = load [copy] [[GEP3]]
@@ -528,30 +633,30 @@ func enumSwitchTest1(_ e: __shared EnumSwitchTests.E) {
 // Make sure that we emit a new global_addr for each use.
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly16testGlobalBorrowyyF : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s8moveonly9varGlobalAA16NonTrivialStructVvp :
-// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [no_consume_or_assign] [[GLOBAL]]
-// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[MARKED_GLOBAL]]
-// CHECK: [[LOADED_VAL:%.*]] = load_borrow [[ACCESS]]
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[GLOBAL]]
+// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: [[LOADED_VAL:%.*]] = load_borrow [[MARKED_GLOBAL]]
 // CHECK: apply {{%.*}}([[LOADED_VAL]])
 // CHECK: end_borrow [[LOADED_VAL]]
 // CHECK: end_access [[ACCESS]]
 //
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s8moveonly9varGlobalAA16NonTrivialStructVvp :
-// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [no_consume_or_assign] [[GLOBAL]]
-// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[MARKED_GLOBAL]]
-// CHECK: [[GEP:%.*]] = struct_element_addr [[ACCESS]]
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[GLOBAL]]
+// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: [[GEP:%.*]] = struct_element_addr [[MARKED_GLOBAL]]
 // CHECK: [[LOADED_VAL:%.*]] = load_borrow [[GEP]]
 // CHECK: apply {{%.*}}([[LOADED_VAL]])
 // CHECK: end_borrow [[LOADED_VAL]]
 // CHECK: end_access [[ACCESS]]
 //
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s8moveonly9letGlobalAA16NonTrivialStructVvp :
-// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [no_consume_or_assign] [[GLOBAL]]
+// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[GLOBAL]]
 // CHECK: [[LOADED_VAL:%.*]] = load [copy] [[MARKED_GLOBAL]]
 // CHECK: apply {{%.*}}([[LOADED_VAL]])
 // CHECK: destroy_value [[LOADED_VAL]]
 //
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s8moveonly9letGlobalAA16NonTrivialStructVvp :
-// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [no_consume_or_assign] [[GLOBAL]]
+// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[GLOBAL]]
 // CHECK: [[LOADED_VAL:%.*]] = load [copy] [[MARKED_GLOBAL]]
 // CHECK: [[LOADED_BORROWED_VAL:%.*]] = begin_borrow [[LOADED_VAL]]
 // CHECK: [[LOADED_GEP:%.*]] = struct_extract [[LOADED_BORROWED_VAL]]
@@ -570,27 +675,27 @@ func testGlobalBorrow() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly17testGlobalConsumeyyF : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s8moveonly9varGlobalAA16NonTrivialStructVvp :
-// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[GLOBAL]]
-// CHECK: [[ACCESS:%.*]] = begin_access [deinit] [dynamic] [[MARKED_GLOBAL]]
+// CHECK: [[ACCESS:%.*]] = begin_access [deinit] [dynamic] [[GLOBAL]]
+// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
 // CHECK: [[LOADED_VAL:%.*]] = load [take]
 // CHECK: apply {{%.*}}([[LOADED_VAL]])
 // CHECK: end_access [[ACCESS]]
 //
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s8moveonly9varGlobalAA16NonTrivialStructVvp :
-// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[GLOBAL]]
-// CHECK: [[ACCESS:%.*]] = begin_access [deinit] [dynamic] [[MARKED_GLOBAL]]
-// CHECK: [[GEP:%.*]] = struct_element_addr [[ACCESS]]
+// CHECK: [[ACCESS:%.*]] = begin_access [deinit] [dynamic] [[GLOBAL]]
+// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: [[GEP:%.*]] = struct_element_addr [[MARKED_GLOBAL]]
 // CHECK: [[LOADED_VAL:%.*]] = load [take] [[GEP]]
 // CHECK: apply {{%.*}}([[LOADED_VAL]])
 // CHECK: end_access [[ACCESS]]
 //
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s8moveonly9letGlobalAA16NonTrivialStructVvp :
-// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [no_consume_or_assign] [[GLOBAL]]
+// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[GLOBAL]]
 // CHECK: [[LOADED_VAL:%.*]] = load [copy] [[MARKED_GLOBAL]]
 // CHECK: apply {{%.*}}([[LOADED_VAL]])
 //
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s8moveonly9letGlobalAA16NonTrivialStructVvp :
-// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [no_consume_or_assign] [[GLOBAL]]
+// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[GLOBAL]]
 // CHECK: [[LOADED_VAL:%.*]] = load [copy] [[MARKED_GLOBAL]]
 // CHECK: [[LOADED_BORROWED_VAL:%.*]] = begin_borrow [[LOADED_VAL]]
 // CHECK: [[LOADED_GEP:%.*]] = struct_extract [[LOADED_BORROWED_VAL]]
@@ -609,28 +714,28 @@ func testGlobalConsume() {
 
 // CHECK-LABEL: sil hidden [ossa] @$s8moveonly16testGlobalAssignyyF : $@convention(thin) () -> () {
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s8moveonly9varGlobalAA16NonTrivialStructVvp :
-// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[GLOBAL]]
-// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[MARKED_GLOBAL]]
-// CHECK: assign {{%.*}} to [[ACCESS]]
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]]
+// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: assign {{%.*}} to [[MARKED_GLOBAL]]
 // CHECK: end_access [[ACCESS]]
 //
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s8moveonly9varGlobalAA16NonTrivialStructVvp :
-// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[GLOBAL]]
-// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[MARKED_GLOBAL]]
-// CHECK: assign {{%.*}} to [[ACCESS]]
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]]
+// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: assign {{%.*}} to [[MARKED_GLOBAL]]
 // CHECK: end_access [[ACCESS]]
 //
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s8moveonly9varGlobalAA16NonTrivialStructVvp :
-// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[GLOBAL]]
-// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[MARKED_GLOBAL]]
-// CHECK: [[GEP:%.*]] = struct_element_addr [[ACCESS]]
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]]
+// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: [[GEP:%.*]] = struct_element_addr [[MARKED_GLOBAL]]
 // CHECK: assign {{%.*}} to [[GEP]]
 // CHECK: end_access [[ACCESS]]
 //
 // CHECK: [[GLOBAL:%.*]] = global_addr @$s8moveonly9varGlobalAA16NonTrivialStructVvp :
-// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[GLOBAL]]
-// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[MARKED_GLOBAL]]
-// CHECK: [[GEP:%.*]] = struct_element_addr [[ACCESS]]
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[GLOBAL]]
+// CHECK: [[MARKED_GLOBAL:%.*]] = mark_must_check [assignable_but_not_consumable] [[ACCESS]]
+// CHECK: [[GEP:%.*]] = struct_element_addr [[MARKED_GLOBAL]]
 // CHECK: assign {{%.*}} to [[GEP]]
 // CHECK: end_access [[ACCESS]]
 // CHECK: } // end sil function '$s8moveonly16testGlobalAssignyyF'

--- a/test/SILGen/moveonly.swift
+++ b/test/SILGen/moveonly.swift
@@ -87,8 +87,11 @@ public func useNonTrivialStruct(_ s: __shared NonTrivialStruct) {
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly24useNonTrivialOwnedStructyyAA0cdF0VnF : $@convention(thin) (@owned NonTrivialStruct) -> () {
 // CHECK: bb0([[ARG:%.*]] : @owned $NonTrivialStruct):
-// CHECK:   [[MOVED_ARG:%.*]] = move_value [lexical] [[ARG]]
-// CHECK:   mark_must_check [consumable_and_assignable] [[MOVED_ARG]]
+// CHECK:   [[BOX:%.*]] = alloc_box
+// CHECK:   [[PROJECT:%.*]] = project_box [[BOX]]
+// CHECK:   store [[ARG]] to [init] [[PROJECT]]
+// CHECK:   [[PROJECT:%.*]] = project_box [[BOX]]
+// CHECK:   mark_must_check [assignable_but_not_consumable] [[PROJECT]]
 // CHECK: } // end sil function '$s8moveonly24useNonTrivialOwnedStructyyAA0cdF0VnF'
 public func useNonTrivialOwnedStruct(_ s: __owned NonTrivialStruct) {
     borrowVal(s)
@@ -117,8 +120,11 @@ public func useNonTrivialEnum(_ s: __shared NonTrivialEnum) {
 
 // CHECK-LABEL: sil [ossa] @$s8moveonly22useNonTrivialOwnedEnumyyAA0cdF0OnF : $@convention(thin) (@owned NonTrivialEnum) -> () {
 // CHECK: bb0([[ARG:%.*]] : @owned $NonTrivialEnum):
-// CHECK:   [[MOVED_ARG:%.*]] = move_value [lexical] [[ARG]]
-// CHECK:   mark_must_check [consumable_and_assignable] [[MOVED_ARG]]
+// CHECK:   [[BOX:%.*]] = alloc_box
+// CHECK:   [[PROJECT:%.*]] = project_box [[BOX]]
+// CHECK:   store [[ARG]] to [init] [[PROJECT]]
+// CHECK:   [[PROJECT:%.*]] = project_box [[BOX]]
+// CHECK:   mark_must_check [assignable_but_not_consumable] [[PROJECT]]
 // CHECK: } // end sil function '$s8moveonly22useNonTrivialOwnedEnumyyAA0cdF0OnF'
 public func useNonTrivialOwnedEnum(_ s: __owned NonTrivialEnum) {
     borrowVal(s)

--- a/test/SILGen/moveonly_deinits.swift
+++ b/test/SILGen/moveonly_deinits.swift
@@ -59,39 +59,46 @@ var value: Bool { false }
 //////////////////
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits24testIntPairWithoutDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
+// SILGEN: [[BOX:%.*]] = alloc_box
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:
+// SILGEN:   [[PROJECT:%.*]] = project_box [[BOX]]
+// SILGEN:   [[MARKED:%.*]] = mark_must_check [assignable_but_not_consumable] [[PROJECT]]
+// SILGEN:   [[LOAD:%.*]] = load [copy] [[MARKED]]
+// SILGEN:   apply {{%.*}}([[LOAD]])
 // SILGEN:   br bb3
 //
 // SILGEN: bb2:
 // SILGEN:   br bb3
 //
 // SILGEN: bb3:
-// SILGEN:   destroy_value [[VALUE]]
+// SILGEN:   destroy_value [[BOX]]
 // SILGEN: } // end sil function '$s16moveonly_deinits24testIntPairWithoutDeinityyF'
 
 // SIL-LABEL: sil @$s16moveonly_deinits24testIntPairWithoutDeinityyF : $@convention(thin) () -> () {
+// SIL: [[STACK:%.*]] = alloc_stack
 // SIL: [[CONSTRUCTOR:%[^,]+]] = function_ref @$s16moveonly_deinits20IntPairWithoutDeinitVACycfC
 // SIL: [[VALUE:%.*]] = apply [[CONSTRUCTOR]]
+// SIL: store [[VALUE]] to [[STACK]]
 // SIL: cond_br {{%.*}}, bb1, bb2
 //
 // SIL: bb1:
+// SIL:   [[LOADED_VALUE:%.*]] = load [[STACK]]
 // SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits27consumeIntPairWithoutDeinityyAA0defG0VnF : $@convention(thin) (@owned IntPairWithoutDeinit) -> ()
-// SIL:   apply [[FUNC_REF]]([[VALUE]])
-// SIL-NOT: release_value
+// SIL:   apply [[FUNC_REF]]([[LOADED_VALUE]])
+// SIL-NOT: destroy_addr
 // SIL-NOT: apply
 // SIL:   br bb3
 //
 // SIL: bb2:
 // SIL-NOT: apply
-// SIL:   release_value [[VALUE]]
+// SIL:   destroy_addr [[STACK]]
 // SIL-NOT: apply
 // SIL:   br bb3
 //
 // SIL: bb3:
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL: } // end sil function '$s16moveonly_deinits24testIntPairWithoutDeinityyF'
 public func testIntPairWithoutDeinit() {
     let f = IntPairWithoutDeinit()
@@ -101,40 +108,48 @@ public func testIntPairWithoutDeinit() {
 }
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits21testIntPairWithDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
+// SILGEN: [[BOX:%.*]] = alloc_box
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:
+// SILGEN:   [[PROJECT:%.*]] = project_box [[BOX]]
+// SILGEN:   [[MARKED:%.*]] = mark_must_check [assignable_but_not_consumable] [[PROJECT]]
+// SILGEN:   [[LOAD:%.*]] = load [copy] [[MARKED]]
+// SILGEN:   apply {{%.*}}([[LOAD]])
 // SILGEN:   br bb3
 //
 // SILGEN: bb2:
 // SILGEN:   br bb3
 //
 // SILGEN: bb3:
-// SILGEN:   destroy_value [[VALUE]]
+// SILGEN:   destroy_value [[BOX]]
 // SILGEN: } // end sil function '$s16moveonly_deinits21testIntPairWithDeinityyF'
 
 // SIL-LABEL: sil @$s16moveonly_deinits21testIntPairWithDeinityyF : $@convention(thin) () -> () {
+// SIL: [[STACK:%.*]] = alloc_stack
 // SIL: [[CONSTRUCTOR:%[^,]+]] = function_ref @$s16moveonly_deinits17IntPairWithDeinitVACycfC
 // SIL: [[VALUE:%.*]] = apply [[CONSTRUCTOR]]
+// SIL: store [[VALUE]] to [[STACK]]
 // SIL: cond_br {{%.*}}, bb1, bb2
 //
 // SIL: bb1:
+// SIL:   [[VALUE:%.*]] = load [[STACK]]
 // SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits24consumeIntPairWithDeinityyAA0defG0VnF : $@convention(thin) (@owned IntPairWithDeinit) -> ()
 // SIL:   apply [[FUNC_REF]]([[VALUE]])
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL-NOT: apply
 // SIL:   br bb3
 //
 // SIL: bb2:
-// SIL: [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits17IntPairWithDeinitVfD : $@convention(method) (@owned IntPairWithDeinit) -> ()
-// SIL: apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned IntPairWithDeinit) -> ()
+// SIL:   [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits17IntPairWithDeinitVfD : $@convention(method) (@owned IntPairWithDeinit) -> ()
+// SIL:   [[VALUE:%.*]] = load [[STACK]]
+// SIL:   apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned IntPairWithDeinit) -> ()
 // SIL-NOT: apply
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL:   br bb3
 //
 // SIL: bb3:
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL: } // end sil function '$s16moveonly_deinits21testIntPairWithDeinityyF'
 public func testIntPairWithDeinit() {
     let f = IntPairWithDeinit()
@@ -144,39 +159,47 @@ public func testIntPairWithDeinit() {
 }
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits26testKlassPairWithoutDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
+// SILGEN: [[BOX:%.*]] = alloc_box
+// SILGEN: [[BORROWED_BOX:%.*]] = begin_borrow [lexical] [[BOX]]
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:
+// SILGEN:   [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// SILGEN:   [[MARKED:%.*]] = mark_must_check [assignable_but_not_consumable] [[PROJECT]]
+// SILGEN:   [[LOAD:%.*]] = load [copy] [[MARKED]]
+// SILGEN:   apply {{%.*}}([[LOAD]])
 // SILGEN:   br bb3
 //
 // SILGEN: bb2:
 // SILGEN:   br bb3
 //
 // SILGEN: bb3:
-// SILGEN:   destroy_value [[VALUE]]
+// SILGEN:   destroy_value [[BOX]]
 // SILGEN: } // end sil function '$s16moveonly_deinits26testKlassPairWithoutDeinityyF'
 
 // SIL-LABEL: sil @$s16moveonly_deinits26testKlassPairWithoutDeinityyF : $@convention(thin) () -> () {
+// SIL: [[STACK:%.*]] = alloc_stack
 // SIL: [[CONSTRUCTOR:%[^,]+]] = function_ref @$s16moveonly_deinits22KlassPairWithoutDeinitVACycfC
 // SIL: [[VALUE:%.*]] = apply [[CONSTRUCTOR]]
+// SIL: store [[VALUE]] to [[STACK]]
 // SIL: cond_br {{%.*}}, bb1, bb2
 //
 // SIL: bb1:
+// SIL:   [[VALUE:%.*]] = load [[STACK]]
 // SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits29consumeKlassPairWithoutDeinityyAA0defG0VnF : $@convention(thin) (@owned KlassPairWithoutDeinit) -> ()
 // SIL:   apply [[FUNC_REF]]([[VALUE]])
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL-NOT: apply
 // SIL:   br bb3
 //
 // SIL: bb2:
 // SIL-NOT: apply
-// SIL:   release_value [[VALUE]]
+// SIL:   destroy_addr [[STACK]]
 // SIL-NOT: apply
 // SIL:   br bb3
 //
 // SIL: bb3:
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL: } // end sil function '$s16moveonly_deinits26testKlassPairWithoutDeinityyF'
 public func testKlassPairWithoutDeinit() {
     let f = KlassPairWithoutDeinit()
@@ -186,40 +209,48 @@ public func testKlassPairWithoutDeinit() {
 }
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits23testKlassPairWithDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
+// SILGEN: [[BOX:%.*]] = alloc_box
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:
+// SILGEN:   [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// SILGEN:   [[MARKED:%.*]] = mark_must_check [assignable_but_not_consumable] [[PROJECT]]
+// SILGEN:   [[LOAD:%.*]] = load [copy] [[MARKED]]
+// SILGEN:   apply {{%.*}}([[LOAD]])
 // SILGEN:   br bb3
 //
 // SILGEN: bb2:
 // SILGEN:   br bb3
 //
 // SILGEN: bb3:
-// SILGEN:   destroy_value [[VALUE]]
+// SILGEN:   destroy_value [[BOX]]
 // SILGEN: } // end sil function '$s16moveonly_deinits23testKlassPairWithDeinityyF'
 
 // SIL-LABEL: sil @$s16moveonly_deinits23testKlassPairWithDeinityyF : $@convention(thin) () -> () {
+// SIL: [[STACK:%.*]] = alloc_stack
 // SIL: [[CONSTRUCTOR:%[^,]+]] = function_ref @$s16moveonly_deinits19KlassPairWithDeinitVACycfC
 // SIL: [[VALUE:%.*]] = apply [[CONSTRUCTOR]]
+// SIL: store [[VALUE]] to [[STACK]]
 // SIL: cond_br {{%.*}}, bb1, bb2
 //
 // SIL: bb1:
+// SIL:   [[VALUE:%.*]] = load [[STACK]]
 // SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits26consumeKlassPairWithDeinityyAA0defG0VnF : $@convention(thin) (@owned KlassPairWithDeinit) -> ()
 // SIL:   apply [[FUNC_REF]]([[VALUE]])
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL-NOT: apply
 // SIL:   br bb3
 //
 // SIL: bb2:
-// SIL: [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits19KlassPairWithDeinitVfD : $@convention(method) (@owned KlassPairWithDeinit) -> ()
-// SIL: apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned KlassPairWithDeinit) -> ()
+// SIL:   [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits19KlassPairWithDeinitVfD : $@convention(method) (@owned KlassPairWithDeinit) -> ()
+// SIL:   [[VALUE:%.*]] = load [[STACK]]
+// SIL:   apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned KlassPairWithDeinit) -> ()
 // SIL-NOT: apply
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL:   br bb3
 //
 // SIL: bb3:
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL: } // end sil function '$s16moveonly_deinits23testKlassPairWithDeinityyF'
 public func testKlassPairWithDeinit() {
     let f = KlassPairWithDeinit()
@@ -274,38 +305,45 @@ func consumeKlassEnumPairWithDeinit(_ x: __owned KlassEnumPairWithDeinit) { }
 ////////////////
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits28testIntEnumPairWithoutDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
+// SILGEN: [[BOX:%.*]] = alloc_box
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:
+// SILGEN:   [[PROJECT:%.*]] = project_box [[BOX]]
+// SILGEN:   [[MARKED:%.*]] = mark_must_check [assignable_but_not_consumable] [[PROJECT]]
+// SILGEN:   [[LOAD:%.*]] = load [copy] [[MARKED]]
+// SILGEN:   apply {{%.*}}([[LOAD]])
 // SILGEN:   br bb3
 //
 // SILGEN: bb2:
 // SILGEN:   br bb3
 //
 // SILGEN: bb3:
-// SILGEN:   destroy_value [[VALUE]]
+// SILGEN:   destroy_value [[BOX]]
 // SILGEN: } // end sil function '$s16moveonly_deinits28testIntEnumPairWithoutDeinityyF'
 
 // SIL-LABEL: sil @$s16moveonly_deinits28testIntEnumPairWithoutDeinityyF : $@convention(thin) () -> () {
+// SIL: [[STACK:%.*]] = alloc_stack
 // SIL: [[VALUE:%.*]] = enum $IntEnumPairWithoutDeinit
+// SIL: store [[VALUE]] to [[STACK]]
 // SIL: cond_br {{%.*}}, bb1, bb2
 //
 // SIL: bb1:
+// SIL:   [[VALUE:%.*]] = load [[STACK]]
 // SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits31consumeIntEnumPairWithoutDeinityyAA0defgH0OnF : $@convention(thin) (@owned IntEnumPairWithoutDeinit) -> ()
 // SIL:   apply [[FUNC_REF]]([[VALUE]])
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL-NOT: apply
 // SIL:   br bb3
 //
 // SIL: bb2:
 // SIL-NOT: apply
-// SIL:   release_value [[VALUE]]
+// SIL:   destroy_addr [[STACK]]
 // SIL-NOT: apply
 // SIL:   br bb3
 //
 // SIL: bb3:
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL: } // end sil function '$s16moveonly_deinits28testIntEnumPairWithoutDeinityyF'
 public func testIntEnumPairWithoutDeinit() {
     let f = IntEnumPairWithoutDeinit.lhs(5)
@@ -315,39 +353,47 @@ public func testIntEnumPairWithoutDeinit() {
 }
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits25testIntEnumPairWithDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
+// SILGEN: [[BOX:%.*]] = alloc_box
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:
+// SILGEN:   [[PROJECT:%.*]] = project_box [[BOX]]
+// SILGEN:   [[MARKED:%.*]] = mark_must_check [assignable_but_not_consumable] [[PROJECT]]
+// SILGEN:   [[LOAD:%.*]] = load [copy] [[MARKED]]
+// SILGEN:   apply {{%.*}}([[LOAD]])
 // SILGEN:   br bb3
 //
 // SILGEN: bb2:
 // SILGEN:   br bb3
 //
 // SILGEN: bb3:
-// SILGEN:   destroy_value [[VALUE]]
+// SILGEN:   destroy_value [[BOX]]
 // SILGEN: } // end sil function '$s16moveonly_deinits25testIntEnumPairWithDeinityyF'
 
 // SIL-LABEL: sil @$s16moveonly_deinits25testIntEnumPairWithDeinityyF : $@convention(thin) () -> () {
+// SIL: [[STACK:%.*]] = alloc_stack
 // SIL: [[VALUE:%.*]] = enum $IntEnumPairWithDeinit
+// SIL: store [[VALUE]] to [[STACK]]
 // SIL: cond_br {{%.*}}, bb1, bb2
 //
 // SIL: bb1:
+// SIL:   [[VALUE:%.*]] = load [[STACK]]
 // SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits28consumeIntEnumPairWithDeinityyAA0defgH0OnF : $@convention(thin) (@owned IntEnumPairWithDeinit) -> ()
 // SIL:   apply [[FUNC_REF]]([[VALUE]])
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL-NOT: apply
 // SIL:   br bb3
 //
 // SIL: bb2:
-// SIL: [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits21IntEnumPairWithDeinitOfD : $@convention(method) (@owned IntEnumPairWithDeinit) -> ()
-// SIL: apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned IntEnumPairWithDeinit) -> ()
+// SIL:   [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits21IntEnumPairWithDeinitOfD : $@convention(method) (@owned IntEnumPairWithDeinit) -> ()
+// SIL:   [[VALUE:%.*]] = load [[STACK]]
+// SIL:   apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned IntEnumPairWithDeinit) -> ()
 // SIL-NOT: apply
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL:   br bb3
 //
 // SIL: bb3:
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL: } // end sil function '$s16moveonly_deinits25testIntEnumPairWithDeinityyF'
 public func testIntEnumPairWithDeinit() {
     let f = IntEnumPairWithDeinit.rhs(6)
@@ -357,38 +403,45 @@ public func testIntEnumPairWithDeinit() {
 }
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits30testKlassEnumPairWithoutDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
+// SILGEN: [[BOX:%.*]] = alloc_box
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:
+// SILGEN:   [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// SILGEN:   [[MARKED:%.*]] = mark_must_check [assignable_but_not_consumable] [[PROJECT]]
+// SILGEN:   [[LOAD:%.*]] = load [copy] [[MARKED]]
+// SILGEN:   apply {{%.*}}([[LOAD]])
 // SILGEN:   br bb3
 //
 // SILGEN: bb2:
 // SILGEN:   br bb3
 //
 // SILGEN: bb3:
-// SILGEN:   destroy_value [[VALUE]]
+// SILGEN:   destroy_value [[BOX]]
 // SILGEN: } // end sil function '$s16moveonly_deinits30testKlassEnumPairWithoutDeinityyF'
 
 // SIL-LABEL: sil @$s16moveonly_deinits30testKlassEnumPairWithoutDeinityyF : $@convention(thin) () -> () {
+// SIL: [[STACK:%.*]] = alloc_stack
 // SIL: [[VALUE:%.*]] = enum $KlassEnumPairWithoutDeinit
+// SIL: store [[VALUE]] to [[STACK]]
 // SIL: cond_br {{%.*}}, bb1, bb2
 //
 // SIL: bb1:
+// SIL:   [[VALUE:%.*]] = load [[STACK]]
 // SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits33consumeKlassEnumPairWithoutDeinityyAA0defgH0OnF : $@convention(thin) (@owned KlassEnumPairWithoutDeinit) -> ()
 // SIL:   apply [[FUNC_REF]]([[VALUE]])
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL-NOT: apply
 // SIL:   br bb3
 //
 // SIL: bb2:
 // SIL-NOT: apply
-// SIL:   release_value [[VALUE]]
+// SIL:   destroy_addr [[STACK]]
 // SIL-NOT: apply
 // SIL:   br bb3
 //
 // SIL: bb3:
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL: } // end sil function '$s16moveonly_deinits30testKlassEnumPairWithoutDeinityyF'
 public func testKlassEnumPairWithoutDeinit() {
     let f = KlassEnumPairWithoutDeinit.lhs(Klass())
@@ -398,39 +451,47 @@ public func testKlassEnumPairWithoutDeinit() {
 }
 
 // SILGEN-LABEL: sil [ossa] @$s16moveonly_deinits27testKlassEnumPairWithDeinityyF : $@convention(thin) () -> () {
-// SILGEN: [[VALUE:%.*]] = mark_must_check [consumable_and_assignable] {{%.*}}
+// SILGEN: [[BOX:%.*]] = alloc_box
 // SILGEN: cond_br {{%.*}}, bb1, bb2
 //
 // SILGEN: bb1:
+// SILGEN:   [[PROJECT:%.*]] = project_box [[BORROWED_BOX]]
+// SILGEN:   [[MARKED:%.*]] = mark_must_check [assignable_but_not_consumable] [[PROJECT]]
+// SILGEN:   [[LOAD:%.*]] = load [copy] [[MARKED]]
+// SILGEN:   apply {{%.*}}([[LOAD]])
 // SILGEN:   br bb3
 //
 // SILGEN: bb2:
 // SILGEN:   br bb3
 //
 // SILGEN: bb3:
-// SILGEN:   destroy_value [[VALUE]]
+// SILGEN:   destroy_value [[BOX]]
 // SILGEN: } // end sil function '$s16moveonly_deinits27testKlassEnumPairWithDeinityyF'
 
 // SIL-LABEL: sil @$s16moveonly_deinits27testKlassEnumPairWithDeinityyF : $@convention(thin) () -> () {
+// SIL: [[STACK:%.*]] = alloc_stack
 // SIL: [[VALUE:%.*]] = enum $KlassEnumPairWithDeinit
+// SIL: store [[VALUE]] to [[STACK]]
 // SIL: cond_br {{%.*}}, bb1, bb2
 //
 // SIL: bb1:
+// SIL:   [[VALUE:%.*]] = load [[STACK]]
 // SIL:   [[FUNC_REF:%.*]] = function_ref @$s16moveonly_deinits30consumeKlassEnumPairWithDeinityyAA0defgH0OnF : $@convention(thin) (@owned KlassEnumPairWithDeinit) -> ()
 // SIL:   apply [[FUNC_REF]]([[VALUE]])
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL-NOT: apply
 // SIL:   br bb3
 //
 // SIL: bb2:
-// SIL: [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits23KlassEnumPairWithDeinitOfD : $@convention(method) (@owned KlassEnumPairWithDeinit) -> ()
-// SIL: apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned KlassEnumPairWithDeinit) -> ()
+// SIL:   [[DEINIT:%.*]] = function_ref @$s16moveonly_deinits23KlassEnumPairWithDeinitOfD : $@convention(method) (@owned KlassEnumPairWithDeinit) -> ()
+// SIL:   [[VALUE:%.*]] = load [[STACK]]
+// SIL:   apply [[DEINIT]]([[VALUE]]) : $@convention(method) (@owned KlassEnumPairWithDeinit) -> ()
 // SIL-NOT: apply
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL:   br bb3
 //
 // SIL: bb3:
-// SIL-NOT: release_value
+// SIL-NOT: destroy_addr
 // SIL: } // end sil function '$s16moveonly_deinits27testKlassEnumPairWithDeinityyF'
 public func testKlassEnumPairWithDeinit() {
     let f = KlassEnumPairWithDeinit.rhs(Klass())

--- a/test/SILGen/moveonly_enum_literal.swift
+++ b/test/SILGen/moveonly_enum_literal.swift
@@ -14,10 +14,13 @@ func consumeMoveIntPair(_ x: __owned MoveOnlyIntPair) {}
 var value: Bool { false }
 
 // CHECK-LABEL: sil hidden [ossa] @$s21moveonly_enum_literal4testyyF : $@convention(thin) () -> () {
+// CHECK: [[BOX:%.*]] = alloc_box
 // CHECK: [[VALUE:%.*]] = enum $MoveOnlyIntPair, #MoveOnlyIntPair.lhs!enumelt,
-// CHECK: [[MV:%.*]] = move_value [lexical] [[VALUE]]
-// CHECK: [[MARKED_VALUE:%.*]] = mark_must_check [consumable_and_assignable] [[MV]]
-// CHECK: debug_value [[MARKED_VALUE]]
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+// CHECK: store [[VALUE]] to [init] [[PROJECT]]
+//
+// CHECK: [[PROJECT:%.*]] = project_box [[BOX]]
+// CHECK: [[MARKED_VALUE:%.*]] = mark_must_check [assignable_but_not_consumable] [[PROJECT]]
 // CHECK: } // end sil function '$s21moveonly_enum_literal4testyyF'
 func test() {
     let x = MoveOnlyIntPair.lhs(5)

--- a/test/SILOptimizer/allocbox_to_stack.sil
+++ b/test/SILOptimizer/allocbox_to_stack.sil
@@ -398,7 +398,7 @@ bb0(%0 : $Int):
 }
 
 // CHECK-LABEL: sil private @$s6struct8useStack1tySi_tFSiycfU_Tf0s_n
-// CHECK-LABEL: sil private @$s6struct8useStack1tySi_tFSiycfU_
+// CHECK-LABEL: sil private [_semantics "sil.optimizer.moveonly.diagnostic.ignore"] @$s6struct8useStack1tySi_tFSiycfU_
 // struct.(useStack (t : Swift.Int) -> ()).(closure #1)
 sil private @$s6struct8useStack1tySi_tFSiycfU_ : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int {
 bb0(%0 : $<τ_0_0> { var τ_0_0 } <Int>):
@@ -651,7 +651,7 @@ bb0(%0 : $Int, %1 : $*S<T>):
   return %9 : $Bool
 }
 
-// CHECK-LABEL: sil shared @closure1
+// CHECK-LABEL: sil shared [_semantics "sil.optimizer.moveonly.diagnostic.ignore"] @closure1
 sil shared @closure1 : $@convention(thin) <T where T : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <T>) -> Bool {
 // CHECK: bb0
 bb0(%0 : $Int, %1 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>):
@@ -673,7 +673,7 @@ bb0(%0 : $Int, %1 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>):
 // CHECK: return
 // CHECK-NOT: bb1
 
-// CHECK-LABEL: sil shared @closure2
+// CHECK-LABEL: sil shared [_semantics "sil.optimizer.moveonly.diagnostic.ignore"] @closure2
 sil shared @closure2 : $@convention(thin) <T where T : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <T>) -> Bool {
 // CHECK: bb0
 bb0(%0 : $Int, %1 : $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>):

--- a/test/SILOptimizer/allocbox_to_stack_noncopyable.sil
+++ b/test/SILOptimizer/allocbox_to_stack_noncopyable.sil
@@ -10,6 +10,8 @@ struct NonTrivialStruct {
 }
 
 sil @use_nontrivialstruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+sil @consume_nontrivialstruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
+sil @get_nontrivialstruct : $@convention(thin) () -> @owned NonTrivialStruct
 
 sil [ossa] @host_markmustcheck_closure : $@convention(thin) (@guaranteed { var NonTrivialStruct }) -> () {
 bb0(%0 : @closureCapture @guaranteed ${ var NonTrivialStruct }):
@@ -62,4 +64,99 @@ bb0(%0 : @owned $NonTrivialStruct):
   dealloc_box %1 : ${ var NonTrivialStruct }
   %9999 = tuple()
   return %9999 : $()
+}
+
+// MARK: Test that we properly handle let alloc_box.
+//
+// CHECK-LABEL: sil hidden [ossa] @captured_let_allocstack_caller : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK:   [[STACK:%.*]] = alloc_stack
+// CHECK:   [[MARK:%.*]] = mark_must_check [consumable_and_assignable] [[STACK]]
+// CHECK:   partial_apply [callee_guaranteed] {{%.*}}([[MARK]]) : $@convention(thin) (@inout_aliasable NonTrivialStruct) -> ()
+// CHECK: } // end sil function 'captured_let_allocstack_caller'
+
+// CHECK-LABEL: sil private [ossa] @$s31captured_let_allocstack_closureTf0s_n : $@convention(thin) (@inout_aliasable NonTrivialStruct) -> () {
+// CHECK: // [[ARG:.*]]{{ .*}}// user: [[MARK:%[0-9][0-9]*]]
+// CHECK: bb0([[ARG]] : @closureCapture $*NonTrivialStruct):
+// CHECK:   [[MARK]] = mark_must_check [no_consume_or_assign] [[ARG]]
+// CHECK:   [[LOAD:%.*]] = load [copy] [[MARK]]
+// CHECK:   [[VALUE:%.*]] = move_value [[LOAD]]
+// CHECK:   destroy_value [[VALUE]]
+// CHECK:   [[LOAD:%.*]] = load [copy] [[MARK]]
+// CHECK:   [[VALUE:%.*]] = move_value [[LOAD]]
+// CHECK:   destroy_value [[VALUE]]
+// CHECK:   cond_br undef, [[LHS:bb[0-9]+]], [[RHS:bb[0-9]+]]
+//
+// CHECK: [[LHS]]:
+// CHECK:   [[VALUE:%.*]] = load [copy] [[MARK]]
+// CHECK:   apply {{%.*}}([[VALUE]]) : $@convention(thin) (@owned NonTrivialStruct) -> ()
+// CHECK:   [[VALUE:%.*]] = load_borrow [[MARK]]
+// CHECK:   apply {{%.*}}([[VALUE]]) : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+// CHECK: } // end sil function 'captured_let_allocstack_closure'
+sil hidden [ossa] @captured_let_allocstack_caller : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_box ${ let NonTrivialStruct }, let, name "x"
+  %2 = function_ref @get_nontrivialstruct : $@convention(thin) () -> @owned NonTrivialStruct
+  %3 = apply %2() : $@convention(thin) () -> @owned NonTrivialStruct
+  %4 = project_box %0 : ${ let NonTrivialStruct }, 0
+  store %3 to [init] %4 : $*NonTrivialStruct
+  %6 = function_ref @captured_let_allocstack_closure : $@convention(thin) (@guaranteed { let NonTrivialStruct }) -> ()
+  %7 = project_box %0 : ${ let NonTrivialStruct }, 0
+  %8 = copy_value %0 : ${ let NonTrivialStruct }
+  mark_function_escape %7 : $*NonTrivialStruct
+  %10 = partial_apply [callee_guaranteed] %6(%8) : $@convention(thin) (@guaranteed { let NonTrivialStruct }) -> ()
+  %11 = begin_borrow [lexical] %10 : $@callee_guaranteed () -> ()
+  debug_value %11 : $@callee_guaranteed () -> (), let, name "f"
+  %13 = project_box %0 : ${ let NonTrivialStruct }, 0
+  %13a = mark_must_check [assignable_but_not_consumable] %13 : $*NonTrivialStruct
+  %14 = load_borrow %13a : $*NonTrivialStruct
+  %15 = function_ref @use_nontrivialstruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  %16 = apply %15(%14) : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  end_borrow %14 : $NonTrivialStruct
+  %18 = project_box %0 : ${ let NonTrivialStruct }, 0
+  %18a = mark_must_check [assignable_but_not_consumable] %18 : $*NonTrivialStruct
+  %19 = load [copy] %18a : $*NonTrivialStruct
+  %20 = function_ref @consume_nontrivialstruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  %21 = apply %20(%19) : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  end_borrow %11 : $@callee_guaranteed () -> ()
+  destroy_value %10 : $@callee_guaranteed () -> ()
+  destroy_value %0 : ${ let NonTrivialStruct }
+  %25 = tuple ()
+  return %25 : $()
+}
+
+sil private [ossa] @captured_let_allocstack_closure : $@convention(thin) (@guaranteed { let NonTrivialStruct }) -> () {
+bb0(%0 : @closureCapture @guaranteed ${ let NonTrivialStruct }):
+  %1 = project_box %0 : ${ let NonTrivialStruct }, 0
+  %2 = mark_must_check [assignable_but_not_consumable] %1 : $*NonTrivialStruct
+  %3 = load [copy] %2 : $*NonTrivialStruct
+  %4 = move_value %3 : $NonTrivialStruct
+  destroy_value %4 : $NonTrivialStruct
+  %6 = project_box %0 : ${ let NonTrivialStruct }, 0
+  %7 = mark_must_check [assignable_but_not_consumable] %6 : $*NonTrivialStruct
+  %8 = load [copy] %7 : $*NonTrivialStruct
+  %9 = move_value %8 : $NonTrivialStruct
+  destroy_value %9 : $NonTrivialStruct
+  cond_br undef, bb1, bb2
+
+bb1:
+  %17 = project_box %0 : ${ let NonTrivialStruct }, 0
+  %18 = mark_must_check [assignable_but_not_consumable] %17 : $*NonTrivialStruct
+  %19 = load [copy] %18 : $*NonTrivialStruct
+  %20 = function_ref @consume_nontrivialstruct : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  %21 = apply %20(%19) : $@convention(thin) (@owned NonTrivialStruct) -> ()
+  %22 = project_box %0 : ${ let NonTrivialStruct }, 0
+  %23 = mark_must_check [assignable_but_not_consumable] %22 : $*NonTrivialStruct
+  %24 = load_borrow %23 : $*NonTrivialStruct
+  %25 = function_ref @use_nontrivialstruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  %26 = apply %25(%24) : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  end_borrow %24 : $NonTrivialStruct
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %30 = tuple ()
+  return %30 : $()
 }

--- a/test/SILOptimizer/allocbox_to_stack_ownership.sil
+++ b/test/SILOptimizer/allocbox_to_stack_ownership.sil
@@ -394,7 +394,7 @@ bb0(%0 : $Int):
 }
 
 // CHECK-LABEL: sil private [transparent] [ossa] @$s6struct8useStack1tySi_tFSiycfU_Tf0s_n
-// CHECK-LABEL: sil private [transparent] [ossa] @$s6struct8useStack1tySi_tFSiycfU_
+// CHECK-LABEL: sil private [transparent] [_semantics "sil.optimizer.moveonly.diagnostic.ignore"] [ossa] @$s6struct8useStack1tySi_tFSiycfU_
 // struct.(useStack (t : Swift.Int) -> ()).(closure #1)
 sil private [transparent] [ossa] @$s6struct8useStack1tySi_tFSiycfU_ : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <Int>) -> Int {
 bb0(%0 : @owned $<τ_0_0> { var τ_0_0 } <Int>):
@@ -751,7 +751,7 @@ bb0(%0 : $Int, %1 : $*S<T>):
   return %9 : $Bool
 }
 
-// CHECK-LABEL: sil shared [ossa] @closure1
+// CHECK-LABEL: sil shared [_semantics "sil.optimizer.moveonly.diagnostic.ignore"] [ossa] @closure1
 sil shared [ossa] @closure1 : $@convention(thin) <T where T : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <T>) -> Bool {
 // CHECK: bb0
 bb0(%0 : $Int, %1 : @owned $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>):
@@ -773,7 +773,7 @@ bb0(%0 : $Int, %1 : @owned $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>)
 // CHECK: return
 // CHECK-NOT: bb1
 
-// CHECK-LABEL: sil shared [ossa] @closure2
+// CHECK-LABEL: sil shared [_semantics "sil.optimizer.moveonly.diagnostic.ignore"] [ossa] @closure2
 sil shared [ossa] @closure2 : $@convention(thin) <T where T : Count> (Int, @owned <τ_0_0 : Count> { var S<τ_0_0> } <T>) -> Bool {
 // CHECK: bb0
 bb0(%0 : $Int, %1 : @owned $<τ_0_0 where τ_0_0 : Count> { var S<τ_0_0> } <T>):

--- a/test/SILOptimizer/move_only_checker_addressonly_fail.swift
+++ b/test/SILOptimizer/move_only_checker_addressonly_fail.swift
@@ -9,6 +9,9 @@ struct GenericAggregate<T> {
 
 func test1<T>(_ x: T) {
     @_noImplicitCopy let x2 = x // expected-error {{@_noImplicitCopy can not be used on a generic or existential typed binding or a nominal type containing such typed things}}
-    consumeValue(x2)
-    consumeValue(x2)
+
+    // We are ok with the checker not supporting this today as long as we emit
+    // the error msg above.
+    consumeValue(x2) // expected-error {{Usage of @noImplicitCopy that the move checker does not know how to check!}}
+    consumeValue(x2) // expected-error {{Usage of @noImplicitCopy that the move checker does not know how to check!}}
 }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -61,6 +61,7 @@ public struct AggStruct {
 
 sil @get_aggstruct : $@convention(thin) () -> @owned AggStruct
 sil @nonConsumingUseKlass : $@convention(thin) (@guaranteed Klass) -> ()
+sil @nonConsumingUseNonTrivialStruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
 sil @classConsume : $@convention(thin) (@owned Klass) -> () // user: %18
 sil @copyableClassConsume : $@convention(thin) (@owned CopyableKlass) -> () // user: %24
 sil @copyableClassUseMoveOnlyWithoutEscaping : $@convention(thin) (@guaranteed CopyableKlass) -> () // user: %16
@@ -125,7 +126,7 @@ bb2(%55 : $Int):
   %58 = struct_element_addr %57 : $*KlassPair, #KlassPair.lhs
   %59 = load [copy] %58 : $*Klass
   // expected-note @-1 {{consuming use here}}
-  // expected-note @-2 {{consuming use here}}  
+  // expected-note @-2 {{consuming use here}}
   end_access %56 : $*AggStruct
   %61 = function_ref @classConsume : $@convention(thin) (@owned Klass) -> ()
   %62 = apply %61(%59) : $@convention(thin) (@owned Klass) -> ()
@@ -227,3 +228,36 @@ bb0(%arg0 : @guaranteed $NonTrivialStruct, %arg1 : $*NonTrivialStruct):
   return %9999 : $()
 }
 
+// Make sure that we do not emit a "Compiler doesn't understand error on this
+// piece of code".
+sil [ossa] @closureCaptureClassUseAfterConsumeError : $@convention(thin) (@owned NonTrivialStruct) -> () {
+bb0(%0 : @owned $NonTrivialStruct):
+  %1 = move_value [lexical] %0 : $NonTrivialStruct
+  debug_value %1 : $NonTrivialStruct, let, name "x", argno 1
+  %3 = alloc_stack $NonTrivialStruct, let, name "x2"
+  %4 = mark_must_check [consumable_and_assignable] %3 : $*NonTrivialStruct // expected-error {{'x2' consumed more than once}}
+  store %1 to [init] %4 : $*NonTrivialStruct
+  %6 = function_ref @nonConsumingUseNonTrivialStruct : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  %7 = load [copy] %4 : $*NonTrivialStruct // expected-note {{consuming use here}}
+  %8 = partial_apply [callee_guaranteed] %6(%7) : $@convention(thin) (@guaranteed NonTrivialStruct) -> ()
+  %9 = begin_borrow [lexical] %8 : $@callee_guaranteed () -> ()
+  debug_value %9 : $@callee_guaranteed () -> (), let, name "f"
+  %11 = copy_value %9 : $@callee_guaranteed () -> ()
+  %12 = apply %11() : $@callee_guaranteed () -> ()
+  destroy_value %11 : $@callee_guaranteed () -> ()
+  %14 = alloc_stack $NonTrivialStruct, let, name "x3"
+  %15 = mark_must_check [consumable_and_assignable] %14 : $*NonTrivialStruct
+  %16 = load [copy] %4 : $*NonTrivialStruct // expected-note {{consuming use here}}
+  store %16 to [init] %15 : $*NonTrivialStruct
+  %18 = load [copy] %15 : $*NonTrivialStruct
+  %19 = move_value %18 : $NonTrivialStruct
+  destroy_value %19 : $NonTrivialStruct
+  destroy_addr %15 : $*NonTrivialStruct
+  dealloc_stack %14 : $*NonTrivialStruct
+  end_borrow %9 : $@callee_guaranteed () -> ()
+  destroy_value %8 : $@callee_guaranteed () -> ()
+  destroy_addr %4 : $*NonTrivialStruct
+  dealloc_stack %3 : $*NonTrivialStruct
+  %27 = tuple ()
+  return %27 : $()
+}

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -2475,3 +2475,30 @@ func moveOnlyGlobalAssignValue() {
     varGlobal = NonTrivialStruct()
     varGlobal.nonTrivialStruct2 = NonTrivialStruct2()
 }
+
+///////////////////
+// InOut Capture //
+///////////////////
+
+func inoutCaptureTest() -> (() -> ()) {
+    var x = NonTrivialStruct() // expected-error {{'x' consumed in closure but not reinitialized before end of closure}}
+    x = NonTrivialStruct()
+
+    func useInOut(_ x: inout NonTrivialStruct) {}
+    let f = {
+        useInOut(&x)
+    }
+
+    borrowVal(x)
+    consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable escaping mutable capture. One can only read from it or assign over it}}
+    x = NonTrivialStruct()
+
+    let g = {
+        x = NonTrivialStruct()
+        useInOut(&x)
+        consumeVal(x) // expected-note {{consuming use here}}
+    }
+    g()
+
+    return f
+}

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1938,17 +1938,12 @@ public func closureCaptureClassUseAfterConsumeError() {
 
 public func closureCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-note @-4 {{'x2' is declared 'inout'}}
+    // expected-note @-2 {{'x2' is declared 'inout'}}
     let f = { // expected-note {{consuming use here}}
         // expected-error @-1 {{escaping closure captures 'inout' parameter 'x2'}}
         borrowVal(x2) // expected-note {{captured here}}
         consumeVal(x2) // expected-note {{captured here}}
-        // expected-note @-1 {{consuming use here}}
         consumeVal(x2) // expected-note {{captured here}}
-        // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
     }
     f()
 }
@@ -2121,28 +2116,21 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
 
 public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-4 {{'x2' consumed more than once}}
-    // expected-note @-5 {{'x2' is declared 'inout'}}
-    // expected-note @-6 {{'x2' is declared 'inout'}}
+    // expected-note @-2 {{'x2' is declared 'inout'}}
+    // expected-note @-3 {{'x2' is declared 'inout'}}
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
               // expected-note @-1 {{consuming use here}}
         let g = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
-            // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{captured indirectly by this call}}
+            // expected-note @-1 {{captured indirectly by this call}}
             borrowVal(x2)
             // expected-note @-1 {{captured here}}
             // expected-note @-2 {{captured here}}
             consumeVal(x2)
             // expected-note @-1 {{captured here}}
             // expected-note @-2 {{captured here}}
-            // expected-note @-3 {{consuming use here}}
             consumeVal(x2)
             // expected-note @-1 {{captured here}}
             // expected-note @-2 {{captured here}}
-            // expected-note @-3 {{consuming use here}}
-            // expected-note @-4 {{consuming use here}}
         }
         g()
     }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -1893,36 +1893,27 @@ public func closureClassUseAfterConsumeArg(_ argX: inout Klass) {
 //
 // TODO: Why are we erroring for the same variable twice?
 public func closureCaptureClassUseAfterConsume() {
-    var x2 = Klass()
-    // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-4 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    var x2 = Klass() // expected-error {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
     x2 = Klass()
     let f = {
         borrowVal(x2)
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
-        // expected-note @-3 {{consuming use here}}
-        // expected-note @-4 {{consuming use here}}
     }
     f()
 }
 
 public func closureCaptureClassUseAfterConsume2() {
     var x2 = Klass()
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
     x2 = Klass()
     let f = {
         borrowVal(x2)
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
     }
     f()
 }
@@ -1930,21 +1921,15 @@ public func closureCaptureClassUseAfterConsume2() {
 public func closureCaptureClassUseAfterConsumeError() {
     var x2 = Klass()
     // expected-error @-1 {{'x2' consumed more than once}}
-    // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-error @-4 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-5 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-2 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    // expected-error @-3 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
     x2 = Klass()
     let f = { // expected-note {{consuming use here}}
         borrowVal(x2)
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
-        // expected-note @-3 {{consuming use here}}
-        // expected-note @-4 {{consuming use here}}
     }
     f()
     let x3 = x2 // expected-note {{consuming use here}}
@@ -2035,16 +2020,12 @@ public func closureAndDeferCaptureClassUseAfterConsume2() {
     var x2 = Klass()
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{'x2' used after consume}}
-    // expected-error @-4 {{'x2' used after consume}}
+    // expected-error @-3 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
     x2 = Klass()
     let f = {
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
         defer {
-            // expected-note @-1 {{non-consuming use here}}
-            // expected-note @-2 {{non-consuming use here}}
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
             consumeVal(x2)
@@ -2061,16 +2042,12 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-error @-4 {{'x2' used after consume}}
-    // expected-error @-5 {{'x2' used after consume}}
+    // expected-error @-4 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
     x2 = Klass()
     let f = { // expected-note {{consuming use here}}
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
         defer {
-            // expected-note @-1 {{non-consuming use here}}
-            // expected-note @-2 {{non-consuming use here}}
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
             consumeVal(x2)
@@ -2105,23 +2082,16 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout Klass) {
 
 public func closureAndClosureCaptureClassUseAfterConsume() {
     var x2 = Klass()
-    // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-4 {{'x2' consumed more than once}}
-    // expected-error @-5 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    // expected-error @-2 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
     x2 = Klass()
     let f = {
         let g = {
             borrowVal(x2)
             consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{consuming use here}}
             consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{consuming use here}}
-            // expected-note @-3 {{consuming use here}}
-            // expected-note @-4 {{consuming use here}}
         }
         g()
     }
@@ -2130,24 +2100,17 @@ public func closureAndClosureCaptureClassUseAfterConsume() {
 
 public func closureAndClosureCaptureClassUseAfterConsume2() {
     var x2 = Klass()
-    // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-4 {{'x2' consumed more than once}}
-    // expected-error @-5 {{'x2' consumed more than once}}
-    // expected-error @-6 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    // expected-error @-3 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
     x2 = Klass()
     let f = { // expected-note {{consuming use here}}
         let g = {
             borrowVal(x2)
             consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{consuming use here}}
             consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{consuming use here}}
-            // expected-note @-3 {{consuming use here}}
-            // expected-note @-4 {{consuming use here}}
         }
         g()
     }
@@ -2481,7 +2444,7 @@ func moveOnlyGlobalAssignValue() {
 ///////////////////
 
 func inoutCaptureTest() -> (() -> ()) {
-    var x = NonTrivialStruct() // expected-error {{'x' consumed in closure but not reinitialized before end of closure}}
+    var x = NonTrivialStruct()
     x = NonTrivialStruct()
 
     func useInOut(_ x: inout NonTrivialStruct) {}
@@ -2490,13 +2453,15 @@ func inoutCaptureTest() -> (() -> ()) {
     }
 
     borrowVal(x)
-    consumeVal(x) // expected-error {{'x' was consumed but it is illegal to consume a noncopyable escaping mutable capture. One can only read from it or assign over it}}
+    consumeVal(x)
+    // expected-error @-1 {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
     x = NonTrivialStruct()
 
     let g = {
         x = NonTrivialStruct()
         useInOut(&x)
-        consumeVal(x) // expected-note {{consuming use here}}
+        consumeVal(x)
+        // expected-error @-1 {{'x' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
     }
     g()
 

--- a/test/SILOptimizer/moveonly_deinits.swift
+++ b/test/SILOptimizer/moveonly_deinits.swift
@@ -21,7 +21,8 @@ struct MoveOnlyStruct {
         // expected-note @-2 {{consuming use here}}
         // We get an infinite recursion since we are going to call our own
         // deinit here. We are just testing diagnostics here though.
-        _ = y // expected-warning {{function call causes an infinite recursion}}
+        // expected-warning @-6 {{function call causes an infinite recursion}}
+        _ = y
         // expected-note @-1 {{consuming use here}}
         let z = y // expected-note {{consuming use here}}
         let _ = z
@@ -46,7 +47,7 @@ enum MoveOnlyEnum {
         // expected-note @-1 {{consuming use here}}
         // We get an infinite recursion since we are going to call our own
         // deinit here. We are just testing diagnostics here though.
-        // expected-warning @-4 {{function call causes an infinite recursion}}
+        // expected-warning @-5 {{function call causes an infinite recursion}}
         _ = y 
         globalMoveOnlyEnum = self // expected-note {{consuming use here}}
         // expected-note @-1 {{consuming use here}}

--- a/test/SILOptimizer/moveonly_nonescaping_closures.swift
+++ b/test/SILOptimizer/moveonly_nonescaping_closures.swift
@@ -58,6 +58,8 @@ func c(x: __owned M) {
 
 func d(x: __owned M) { // expected-error{{}}
     clodger({ consume(x) }) // expected-note{{}}
+    // TODO: This will go away once the box capture support is there.
+    // expected-error @-2 {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
 }
 
 func e(x: inout M) {

--- a/test/SILOptimizer/moveonly_nonescaping_closures.swift
+++ b/test/SILOptimizer/moveonly_nonescaping_closures.swift
@@ -60,8 +60,7 @@ func c(x: __owned M) {
 
 func d(x: __owned M) { // expected-error {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     clodger({ consume(x) })
-    // expected-error @-1 {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
-    // expected-note @-2 {{consuming use here}}
+    // expected-note @-1 {{consuming use here}}
 }
 
 func e(x: inout M) {

--- a/test/SILOptimizer/moveonly_nonescaping_closures.swift
+++ b/test/SILOptimizer/moveonly_nonescaping_closures.swift
@@ -46,20 +46,21 @@ func a(x: __shared M) {
     borrow(x)
 }
 
-func b(x: __owned M) { // expected-error{{}}
-    clodger({ borrow(x) }, consume: x) // expected-note{{}} expected-note{{}}
+func b(x: __owned M) {
+    clodger({ borrow(x) }, consume: x)
+    // expected-error @-1 {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
 }
 
 func c(x: __owned M) {
     clodger({ borrow(x) })
     borrow(x)
     consume(x)
+    // expected-error @-1 {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
 }
 
-func d(x: __owned M) { // expected-error{{}}
-    clodger({ consume(x) }) // expected-note{{}}
-    // TODO: This will go away once the box capture support is there.
-    // expected-error @-2 {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
+func d(x: __owned M) {
+    clodger({ consume(x) })
+    // expected-error @-1 {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
 }
 
 func e(x: inout M) {

--- a/test/SILOptimizer/moveonly_nonescaping_closures.swift
+++ b/test/SILOptimizer/moveonly_nonescaping_closures.swift
@@ -46,21 +46,22 @@ func a(x: __shared M) {
     borrow(x)
 }
 
-func b(x: __owned M) {
+func b(x: __owned M) { // expected-error {{'x' used after consume}}
     clodger({ borrow(x) }, consume: x)
-    // expected-error @-1 {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    // expected-note @-1:25 {{non-consuming use here}}
+    // expected-note @-2:37 {{consuming use here}}
 }
 
 func c(x: __owned M) {
     clodger({ borrow(x) })
     borrow(x)
     consume(x)
-    // expected-error @-1 {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
 }
 
-func d(x: __owned M) {
+func d(x: __owned M) { // expected-error {{'x' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     clodger({ consume(x) })
-    // expected-error @-1 {{'x' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    // expected-error @-1 {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
+    // expected-note @-2 {{consuming use here}}
 }
 
 func e(x: inout M) {

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -142,7 +142,7 @@ public func classLoopConsume(_ x: __shared Klass) { // expected-error {{'x' has 
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -192,7 +192,7 @@ public func classDiamondInLoop(_ x: __shared Klass) { // expected-error {{'x' ha
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -482,7 +482,7 @@ public func finalClassLoopConsume(_ x: __shared FinalKlass) { // expected-error 
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -532,7 +532,7 @@ public func finalClassDiamondInLoop(_ x: __shared FinalKlass) { // expected-erro
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -825,7 +825,7 @@ public func aggStructLoopConsume(_ x: __shared AggStruct) { // expected-error {{
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -875,7 +875,7 @@ public func aggStructDiamondInLoop(_ x: __shared AggStruct) { // expected-error 
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -926,11 +926,12 @@ public func aggStructAccessFieldOwnedArg(_ x2: __owned AggStruct) {
 
 public func aggStructConsumeField(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
 }
 
@@ -976,11 +977,12 @@ public func aggStructAccessGrandFieldOwnedArg(_ x2: __owned AggStruct) {
 
 public func aggStructConsumeGrandField(_ x: __shared AggStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
 }
 
@@ -1138,7 +1140,7 @@ public func aggGenericStructLoopConsume(_ x: __shared AggGenericStruct<String>) 
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -1188,7 +1190,7 @@ public func aggGenericStructDiamondInLoop(_ x: __shared AggGenericStruct<String>
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -1239,11 +1241,12 @@ public func aggGenericStructAccessFieldOwnedArg(_ x2: __owned AggGenericStruct<S
 
 public func aggGenericStructConsumeField(_ x: __shared AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
 }
 
@@ -1289,11 +1292,12 @@ public func aggGenericStructAccessGrandFieldOwnedArg(_ x2: __owned AggGenericStr
 
 public func aggGenericStructConsumeGrandField(_ x: __shared AggGenericStruct<String>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
 }
 
@@ -1411,7 +1415,7 @@ public func aggGenericStructLoopConsume<T>(_ x: __shared AggGenericStruct<T>) { 
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -1461,7 +1465,7 @@ public func aggGenericStructDiamondInLoop<T>(_ x: __shared AggGenericStruct<T>) 
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -1512,11 +1516,12 @@ public func aggGenericStructAccessFieldOwnedArg<T>(_ x2: __owned AggGenericStruc
 
 public func aggGenericStructConsumeField<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
 }
 
@@ -1562,11 +1567,12 @@ public func aggGenericStructAccessGrandFieldOwnedArg<T>(_ x2: __owned AggGeneric
 
 public func aggGenericStructConsumeGrandField<T>(_ x: __shared AggGenericStruct<T>) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
 }
 
@@ -1692,7 +1698,7 @@ public func enumLoopConsume(_ x: __shared EnumTy) { // expected-error {{'x' has 
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -1742,7 +1748,7 @@ public func enumDiamondInLoop(_ x: __shared EnumTy) { // expected-error {{'x' ha
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -1912,7 +1918,7 @@ public func enumPatternMatchIfLet2(_ x: __shared EnumTy) { // expected-error {{'
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming in loop use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
             borrowVal(x)
         }
     }

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -154,7 +154,7 @@ public func classLoopConsumeArg(_ x2: __shared Klass) { // expected-error {{'x2'
 
 public func classLoopConsumeOwnedArg(_ x2: __owned Klass) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -214,7 +214,7 @@ public func classDiamondInLoopOwnedArg(_ x2: __owned Klass) { // expected-error 
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -494,7 +494,7 @@ public func finalClassLoopConsumeArg(_ x2: __shared FinalKlass) { // expected-er
 
 public func finalClassLoopConsumeOwnedArg(_ x2: __owned FinalKlass) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -554,7 +554,7 @@ public func finalClassDiamondInLoopOwnedArg(_ x2: __owned FinalKlass) { // expec
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -837,7 +837,7 @@ public func aggStructLoopConsumeArg(_ x2: __shared AggStruct) { // expected-erro
 
 public func aggStructLoopConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -897,7 +897,7 @@ public func aggStructDiamondInLoopOwnedArg(_ x2: __owned AggStruct) { // expecte
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -945,11 +945,12 @@ public func aggStructConsumeFieldArg(_ x2: __shared AggStruct) {
 }
 
 public func aggStructConsumeFieldOwnedArg(_ x2: __owned AggStruct) {
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
 }
 
@@ -996,11 +997,12 @@ public func aggStructConsumeGrandFieldArg(_ x2: __shared AggStruct) {
 }
 
 public func aggStructConsumeGrandFieldOwnedArg(_ x2: __owned AggStruct) {
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
 }
 
@@ -1014,13 +1016,13 @@ public func aggStructConsumeFieldNoError(_ x2: __owned AggStruct) {
 }
 
 public func aggStructConsumeFieldError(_ x2: __owned AggStruct) {
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
+    // expected-error @-1 {{'x2' used after consume}}
     if boolValue {
         consumeVal(x2.lhs)
     } else {
         consumeVal(x2.pair.rhs) // expected-note {{consuming use here}}
     }
-    borrowVal(x2.pair) // expected-note {{boundary use here}}
+    borrowVal(x2.pair) // expected-note {{non-consuming use here}}
 }
 
 public func aggStructConsumeFieldError2(_ x2: __owned AggStruct) {
@@ -1152,7 +1154,7 @@ public func aggGenericStructLoopConsumeArg(_ x2: __shared AggGenericStruct<Strin
 
 public func aggGenericStructLoopConsumeOwnedArg(_ x2: __owned AggGenericStruct<String>) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -1212,7 +1214,7 @@ public func aggGenericStructDiamondInLoopOwnedArg(_ x2: __owned AggGenericStruct
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -1260,11 +1262,12 @@ public func aggGenericStructConsumeFieldArg(_ x2: __shared AggGenericStruct<Stri
 }
 
 public func aggGenericStructConsumeFieldOwnedArg(_ x2: __owned AggGenericStruct<String>) {
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
 }
 
@@ -1311,11 +1314,12 @@ public func aggGenericStructConsumeGrandFieldArg(_ x2: __shared AggGenericStruct
 }
 
 public func aggGenericStructConsumeGrandFieldOwnedArg(_ x2: __owned AggGenericStruct<String>) {
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
 }
 
@@ -1427,7 +1431,7 @@ public func aggGenericStructLoopConsumeArg<T>(_ x2: __shared AggGenericStruct<T>
 
 public func aggGenericStructLoopConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -1487,7 +1491,7 @@ public func aggGenericStructDiamondInLoopOwnedArg<T>(_ x2: __owned AggGenericStr
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -1535,11 +1539,12 @@ public func aggGenericStructConsumeFieldArg<T>(_ x2: __shared AggGenericStruct<T
 }
 
 public func aggGenericStructConsumeFieldOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.lhs) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
 }
 
@@ -1586,11 +1591,12 @@ public func aggGenericStructConsumeGrandFieldArg<T>(_ x2: __shared AggGenericStr
 }
 
 public func aggGenericStructConsumeGrandFieldOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) {
-    // expected-error @-1 {{'x2' has a move only field that was consumed before later uses}}
-    // expected-error @-2 {{'x2' has a move only field that was consumed before later uses}}
+    // expected-error @-1 {{'x2' consumed by a use in a loop}}
+    // expected-error @-2 {{'x2' consumed more than once}}
     consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
     for _ in 0..<1024 {
         consumeVal(x2.pair.lhs) // expected-note {{consuming use here}}
+        // expected-note @-1 {{consuming use here}}
     }
 }
 
@@ -1710,7 +1716,7 @@ public func enumLoopConsumeArg(_ x2: __shared EnumTy) { // expected-error {{'x2'
 
 public func enumLoopConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -1770,7 +1776,7 @@ public func enumDiamondInLoopOwnedArg(_ x2: __owned EnumTy) { // expected-error 
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -1934,7 +1940,7 @@ public func enumPatternMatchIfLet2Arg(_ x2: __shared EnumTy) { // expected-error
 
 public func enumPatternMatchIfLet2OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming in loop use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
             borrowVal(x)
         }
     }
@@ -2154,7 +2160,12 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: __shared Klass) {
 
 public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
-    let f = {
+
+    let f = {        
+        // NOTE: This errors will go away once I change to pass these by box in
+        // a commit later in this PR.
+        //
+        // expected-error @-4 {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2213,6 +2224,10 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: __shared Klass) {
 public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     defer {
+        // NOTE: This errors will go away once I change to pass these by box in
+        // a commit later in this PR.
+        //
+        // expected-error @-4 {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -2296,6 +2311,10 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: __shared Klass) 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Klass) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
+        // NOTE: This errors will go away once I change to pass these by box in
+        // a commit later in this PR.
+        //
+        // expected-error @-4 {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
         defer {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
@@ -2373,6 +2392,10 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned K
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = {
+        // NOTE: This errors will go away once I change to pass these by box in
+        // a commit later in this PR.
+        //
+        // expected-error @-4 {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
         let g = { // expected-note {{closure capture here}}
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
@@ -2426,12 +2449,16 @@ func blackHoleTestCase(_ k: __owned Klass) {
 
 func sameCallSiteTestConsumeTwice(_ k: __owned Klass) { // expected-error {{'k' consumed more than once}}
     func consumeKlassTwice(_ k: __owned Klass, _ k2: __owned Klass) {}
-    consumeKlassTwice(k, k) // expected-note {{two consuming uses here}}
+    consumeKlassTwice(k, k)
+    // expected-note @-1 {{consuming use here}}
+    // expected-note @-2 {{consuming use here}}
 }
 
-func sameCallSiteConsumeAndUse(_ k: __owned Klass) { // expected-error {{'k' consumed and used at the same time}}
+func sameCallSiteConsumeAndUse(_ k: __owned Klass) { // expected-error {{'k' used after consume}}
     func consumeKlassAndUseKlass(_ k: __owned Klass, _ k2: __shared Klass) {}
-    consumeKlassAndUseKlass(k, k) // expected-note {{consuming and non-consuming uses here}}
+    consumeKlassAndUseKlass(k, k)
+    // expected-note @-1 {{consuming use here}}
+    // expected-note @-2 {{non-consuming use here}}
 }
 
 ////////////////////////////////

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1233,17 +1233,12 @@ public func closureCaptureClassUseAfterConsumeError() {
 
 public func closureCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-note @-4 {{'x2' is declared 'inout'}}
+    // expected-note @-2 {{'x2' is declared 'inout'}}
     let f = { // expected-note {{consuming use here}}
         // expected-error @-1 {{escaping closure captures 'inout' parameter 'x2'}}
         borrowVal(x2) // expected-note {{captured here}}
         consumeVal(x2) // expected-note {{captured here}}
-        // expected-note @-1 {{consuming use here}}
         consumeVal(x2) // expected-note {{captured here}}
-        // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
     }
     f()
 }
@@ -1416,28 +1411,21 @@ public func closureAndClosureCaptureClassUseAfterConsume2() {
 
 public func closureAndClosureCaptureClassArgUseAfterConsume(_ x2: inout NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed but not reinitialized before end of function}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-4 {{'x2' consumed more than once}}
-    // expected-note @-5 {{'x2' is declared 'inout'}}
-    // expected-note @-6 {{'x2' is declared 'inout'}}
+    // expected-note @-2 {{'x2' is declared 'inout'}}
+    // expected-note @-3 {{'x2' is declared 'inout'}}
     let f = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
               // expected-note @-1 {{consuming use here}}
         let g = { // expected-error {{escaping closure captures 'inout' parameter 'x2'}}
-            // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{captured indirectly by this call}}
+            // expected-note @-1 {{captured indirectly by this call}}
             borrowVal(x2)
             // expected-note @-1 {{captured here}}
             // expected-note @-2 {{captured here}}
             consumeVal(x2)
             // expected-note @-1 {{captured here}}
             // expected-note @-2 {{captured here}}
-            // expected-note @-3 {{consuming use here}}
             consumeVal(x2)
             // expected-note @-1 {{captured here}}
             // expected-note @-2 {{captured here}}
-            // expected-note @-3 {{consuming use here}}
-            // expected-note @-4 {{consuming use here}}
         }
         g()
     }

--- a/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_addresschecker_diagnostics.swift
@@ -1200,43 +1200,31 @@ public func closureClassUseAfterConsumeArg(_ argX: inout NonTrivialStruct) {
 // We do not support captures of vars by closures today.
 public func closureCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-error @-4 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    // expected-error @-2 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
     x2 = NonTrivialStruct()
     let f = {
         borrowVal(x2)
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
-        // expected-note @-3 {{consuming use here}}
-        // expected-note @-4 {{consuming use here}}
     }
     f()
 }
 
 public func closureCaptureClassUseAfterConsumeError() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-error @-4 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-5 {{'x2' consumed more than once}}
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    // expected-error @-3 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
     x2 = NonTrivialStruct()
     let f = { // expected-note {{consuming use here}}
         borrowVal(x2)
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
-        // expected-note @-3 {{consuming use here}}
-        // expected-note @-4 {{consuming use here}}
     }
     f()
     let x3 = x2 // expected-note {{consuming use here}}
@@ -1327,16 +1315,12 @@ public func closureAndDeferCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{'x2' used after consume}}
-    // expected-error @-4 {{'x2' used after consume}}
+    // expected-error @-3 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
     x2 = NonTrivialStruct()
     let f = {
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
         defer {
-            // expected-note @-1 {{non-consuming use here}}
-            // expected-note @-2 {{non-consuming use here}}
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
             consumeVal(x2)
@@ -1353,16 +1337,12 @@ public func closureAndDeferCaptureClassUseAfterConsume3() {
     // expected-error @-1 {{'x2' consumed in closure but not reinitialized before end of closure}}
     // expected-error @-2 {{'x2' consumed more than once}}
     // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-error @-4 {{'x2' used after consume}}
-    // expected-error @-5 {{'x2' used after consume}}
+    // expected-error @-4 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
     x2 = NonTrivialStruct()
     let f = { // expected-note {{consuming use here}}
         consumeVal(x2)
         // expected-note @-1 {{consuming use here}}
-        // expected-note @-2 {{consuming use here}}
         defer {
-            // expected-note @-1 {{non-consuming use here}}
-            // expected-note @-2 {{non-consuming use here}}
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
             consumeVal(x2)
@@ -1397,23 +1377,16 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: inout NonTrivial
 
 public func closureAndClosureCaptureClassUseAfterConsume() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-2 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-3 {{'x2' consumed more than once}}
-    // expected-error @-4 {{'x2' consumed more than once}}
-    // expected-error @-5 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    // expected-error @-2 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
     x2 = NonTrivialStruct()
     let f = {
         let g = {
             borrowVal(x2)
             consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{consuming use here}}
             consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{consuming use here}}
-            // expected-note @-3 {{consuming use here}}
-            // expected-note @-4 {{consuming use here}}
         }
         g()
     }
@@ -1422,24 +1395,17 @@ public func closureAndClosureCaptureClassUseAfterConsume() {
 
 public func closureAndClosureCaptureClassUseAfterConsume2() {
     var x2 = NonTrivialStruct()
-    // expected-error @-1 {{Usage of a move only type that the move checker does not know how to check!}}
-    // expected-error @-2 {{'x2' consumed more than once}}
-    // expected-error @-3 {{'x2' consumed in closure but not reinitialized before end of closure}}
-    // expected-error @-4 {{'x2' consumed more than once}}
-    // expected-error @-5 {{'x2' consumed more than once}}
-    // expected-error @-6 {{'x2' consumed in closure but not reinitialized before end of closure}}
+    // expected-error @-1 {{'x2' consumed more than once}}
+    // expected-error @-2 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
+    // expected-error @-3 {{'x2' was consumed but it is illegal to consume a noncopyable mutable capture of an escaping closure. One can only read from it or assign over it}}
     x2 = NonTrivialStruct()
     let f = { // expected-note {{consuming use here}}
         let g = {
             borrowVal(x2)
             consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{consuming use here}}
             consumeVal(x2)
             // expected-note @-1 {{consuming use here}}
-            // expected-note @-2 {{consuming use here}}
-            // expected-note @-3 {{consuming use here}}
-            // expected-note @-4 {{consuming use here}}
         }
         g()
     }

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -150,7 +150,7 @@ public func aggStructLoopConsume(_ x: __shared AggStruct) { // expected-error {{
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -200,7 +200,7 @@ public func aggStructDiamondInLoop(_ x: __shared AggStruct) { // expected-error 
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -420,7 +420,7 @@ public func aggGenericStructLoopConsume(_ x: __shared AggGenericStruct<CopyableK
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -470,7 +470,7 @@ public func aggGenericStructDiamondInLoop(_ x: __shared AggGenericStruct<Copyabl
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -681,7 +681,7 @@ public func aggGenericStructLoopConsume<T>(_ x: __shared AggGenericStruct<T>) { 
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -731,7 +731,7 @@ public func aggGenericStructDiamondInLoop<T>(_ x: __shared AggGenericStruct<T>) 
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -950,7 +950,7 @@ public func enumLoopConsume(_ x: __shared EnumTy) { // expected-error {{'x' has 
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -1000,7 +1000,7 @@ public func enumDiamondInLoop(_ x: __shared EnumTy) { // expected-error {{'x' ha
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -1172,7 +1172,7 @@ public func enumPatternMatchIfLet2(_ x: __shared EnumTy) { // expected-error {{'
     let x2 = x // expected-error {{'x2' consumed by a use in a loop}}
                // expected-note @-1 {{consuming use here}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming in loop use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
             borrowVal(x)
         }
     }

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -1438,12 +1438,11 @@ public func closureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivial
 
 public func deferCaptureClassUseAfterConsume(_ x: __shared NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     defer {
         borrowVal(x2)
-        consumeVal(x2)
-        // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x2)
-        // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     consumeVal(x) // expected-note {{consuming use here}}
 }
@@ -1451,15 +1450,14 @@ public func deferCaptureClassUseAfterConsume(_ x: __shared NonTrivialStruct) { /
 public func deferCaptureClassUseAfterConsume2(_ x: __shared NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x
     // expected-note @-1 {{consuming use here}}
-    defer {
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-3 {{'x2' used after consume}}
+    defer { // expected-note {{non-consuming use here}}
         borrowVal(x2)
-        consumeVal(x2)
-        // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x2)
-        // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
-    let x3 = x2
-    // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    let x3 = x2 // expected-note {{consuming use here}}
     let _ = x3
 }
 
@@ -1475,38 +1473,35 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: __shared NonTrivialStruct)
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     defer {
         borrowVal(x2)
-        consumeVal(x2)
-        // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x2)
-        // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
     consumeVal("foo")
 }
 
 public func deferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialStruct) {
-    defer {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' used after consume}}
+    defer { // expected-note {{non-consuming use here}}
         borrowVal(x2)
-        consumeVal(x2)
-        // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-        consumeVal(x2)
-        // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
-    consumeVal(x2)
-    // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func closureAndDeferCaptureClassUseAfterConsume(_ x: __shared NonTrivialStruct) {
     // expected-error @-1 {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2)
-            // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2)
-            // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         consumeVal("foo")
     }
@@ -1515,15 +1510,14 @@ public func closureAndDeferCaptureClassUseAfterConsume(_ x: __shared NonTrivialS
 
 public func closureAndDeferCaptureClassUseAfterConsume2(_ x: __shared NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
     let x2 = x // expected-note {{consuming use here}}
+    // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    // expected-error @-2 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
-        consumeVal(x2)
-        // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+        consumeVal(x2) // expected-note {{consuming use here}}
         defer {
             borrowVal(x2)
-            consumeVal(x2)
-            // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2)
-            // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         consumeVal("foo")
     }
@@ -1531,23 +1525,21 @@ public func closureAndDeferCaptureClassUseAfterConsume2(_ x: __shared NonTrivial
 }
 
 public func closureAndDeferCaptureClassUseAfterConsume3(_ x: __shared NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}
-    let x2 = x
+    let x2 = x // expected-error {{'x2' consumed more than once}}
     // expected-note @-1 {{consuming use here}}
-    let f = {
-        consumeVal(x2)
-        // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    // expected-error @-2 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    // expected-error @-3 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    let f = { // expected-note {{consuming use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
         defer {
             borrowVal(x2)
-            consumeVal(x2)
-            // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2)
-            // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         consumeVal("foo")
     }
     f()
-    consumeVal(x2)
-    // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: __shared NonTrivialStruct) { // expected-error {{'x2' has guaranteed ownership but was consumed}}
@@ -1564,13 +1556,12 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: __shared NonTriv
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
         defer {
             borrowVal(x2)
-            consumeVal(x2)
-            // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2)
-            // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         consumeVal("foo")
     }
@@ -1578,19 +1569,18 @@ public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned Non
 }
 
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned NonTrivialStruct) {
-    let f = {
+    // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
+    // expected-error @-2 {{'x2' consumed more than once}}
+    let f = { // expected-note {{consuming use here}}
         defer {
             borrowVal(x2)
-            consumeVal(x2)
-            // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
-            consumeVal(x2)
-            // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+            consumeVal(x2) // expected-note {{consuming use here}}
+            consumeVal(x2) // expected-note {{consuming use here}}
         }
         consumeVal("foo")
     }
     f()
-    consumeVal(x2)
-    // expected-error @-1 {{'x2' was consumed but it is illegal to consume a noncopyable immutable capture of an escaping closure. One can only read from it}}
+    consumeVal(x2) // expected-note {{consuming use here}}
 }
 
 public func closureAndClosureCaptureClassUseAfterConsume(_ x: __shared NonTrivialStruct) { // expected-error {{'x' has guaranteed ownership but was consumed}}

--- a/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_trivial_objectchecker_diagnostics.swift
@@ -162,7 +162,7 @@ public func aggStructLoopConsumeArg(_ x2: __shared AggStruct) { // expected-erro
 
 public func aggStructLoopConsumeOwnedArg(_ x2: __owned AggStruct) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -222,7 +222,7 @@ public func aggStructDiamondInLoopOwnedArg(_ x2: __owned AggStruct) { // expecte
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -432,7 +432,7 @@ public func aggGenericStructLoopConsumeArg(_ x2: __shared AggGenericStruct<Copya
 
 public func aggGenericStructLoopConsumeOwnedArg(_ x2: __owned AggGenericStruct<CopyableKlass>) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -491,8 +491,8 @@ public func aggGenericStructDiamondInLoopOwnedArg(_ x2: __owned AggGenericStruct
       if boolValue {
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
-          consumeVal(x2) // expected-note {{other consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          consumeVal(x2) // expected-note {{consuming use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -693,7 +693,7 @@ public func aggGenericStructLoopConsumeArg<T>(_ x2: __shared AggGenericStruct<T>
 
 public func aggGenericStructLoopConsumeOwnedArg<T>(_ x2: __owned AggGenericStruct<T>) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}}
+        consumeVal(x2) // expected-note {{consuming use here}}
     }
 }
 
@@ -753,7 +753,7 @@ public func aggGenericStructDiamondInLoopOwnedArg<T>(_ x2: __owned AggGenericStr
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -962,7 +962,7 @@ public func enumLoopConsumeArg(_ x2: __shared EnumTy) { // expected-error {{'x2'
 
 public func enumLoopConsumeOwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        consumeVal(x2) // expected-note {{consuming in loop use here}};
+        consumeVal(x2) // expected-note {{consuming use here}};
     }
 }
 
@@ -1022,7 +1022,7 @@ public func enumDiamondInLoopOwnedArg(_ x2: __owned EnumTy) { // expected-error 
           consumeVal(x2) // expected-note {{consuming use here}}
       } else {
           consumeVal(x2) // expected-note {{consuming use here}}
-          // expected-note @-1 {{consuming in loop use here}}
+          // expected-note @-1 {{consuming use here}}
       }
     }
 }
@@ -1188,7 +1188,7 @@ public func enumPatternMatchIfLet2Arg(_ x2: __shared EnumTy) { // expected-error
 
 public func enumPatternMatchIfLet2OwnedArg(_ x2: __owned EnumTy) { // expected-error {{'x2' consumed by a use in a loop}}
     for _ in 0..<1024 {
-        if case let .klass(x) = x2 {  // expected-note {{consuming in loop use here}}
+        if case let .klass(x) = x2 {  // expected-note {{consuming use here}}
             borrowVal(x)
         }
     }
@@ -1410,6 +1410,10 @@ public func closureCaptureClassArgUseAfterConsume(_ x2: __shared NonTrivialStruc
 public func closureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
+        // NOTE: This errors will go away once I change to pass these by box in
+        // a commit later in this PR.
+        //
+        // expected-error @-4 {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1468,6 +1472,10 @@ public func deferCaptureClassArgUseAfterConsume(_ x2: __shared NonTrivialStruct)
 public func deferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     defer {
+        // NOTE: This errors will go away once I change to pass these by box in
+        // a commit later in this PR.
+        //
+        // expected-error @-4 {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
         borrowVal(x2)
         consumeVal(x2) // expected-note {{consuming use here}}
         consumeVal(x2) // expected-note {{consuming use here}}
@@ -1551,6 +1559,10 @@ public func closureAndDeferCaptureClassArgUseAfterConsume(_ x2: __shared NonTriv
 public func closureAndDeferCaptureClassOwnedArgUseAfterConsume(_ x2: __owned NonTrivialStruct) {
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     let f = {
+        // NOTE: This errors will go away once I change to pass these by box in
+        // a commit later in this PR.
+        //
+        // expected-error @-4 {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
         defer {
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}
@@ -1627,6 +1639,10 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume(_ x2: __owned N
     // expected-error @-1 {{'x2' consumed in closure. This is illegal since if the closure is invoked more than once the binding will be uninitialized on later invocations}}
     // expected-error @-2 {{'x2' has guaranteed ownership but was consumed due to being captured by a closure}}
     let f = {
+        // NOTE: This errors will go away once I change to pass these by box in
+        // a commit later in this PR.
+        //
+        // expected-error @-4 {{copy of noncopyable typed value. This is a compiler bug. Please file a bug with a small example of the bug}}
         let g = { // expected-note {{closure capture here}}
             borrowVal(x2)
             consumeVal(x2) // expected-note {{consuming use here}}


### PR DESCRIPTION
This patch series does a bunch of things:

1. Patch 1 changes SILGen/MoveCheckers to emit vars in a boxed eagerly retroject manner.
2. Patch 2 changes "" to also emit lets to be emitted as boxes like vars.
3. Patch 3 changes "" to emit owned arguments again as boxed.
4. Part 4 implements on top of this escaping closure semantics.

This basically required me to rewrite a large part of SILGen for non copyable types and redesign parts of the checker as well. I also had to do a bunch of work in alloc box to stack to massage its output since it semantically is what controls whether we use non-escaping or escaping semantics when we emit these errors.