### PR TITLE
[5.8🍒] Use -strict-concurrency=minimal as the default for Swift 5.x mode.

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -331,7 +331,7 @@ namespace swift {
     bool UseMalloc = false;
 
     /// Specifies how strict concurrency checking will be.
-    StrictConcurrency StrictConcurrencyLevel = StrictConcurrency::Targeted;
+    StrictConcurrency StrictConcurrencyLevel = StrictConcurrency::Minimal;
 
     /// Enable experimental concurrency model.
     bool EnableExperimentalConcurrency = false;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -788,8 +788,8 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   } else if (Args.hasArg(OPT_warn_concurrency)) {
     Opts.StrictConcurrencyLevel = StrictConcurrency::Complete;
   } else {
-    // Default to "limited" checking in Swift 5.x.
-    Opts.StrictConcurrencyLevel = StrictConcurrency::Targeted;
+    // Default to minimal checking in Swift 5.x.
+    Opts.StrictConcurrencyLevel = StrictConcurrency::Minimal;
   }
 
   Opts.WarnImplicitOverrides =

--- a/test/Concurrency/strict_concurrency_minimal.swift
+++ b/test/Concurrency/strict_concurrency_minimal.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift -strict-concurrency=minimal
+// RUN: %target-typecheck-verify-swift
 // REQUIRES: concurrency
 
 class C1 { }


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/63785

rdar://105637789