### PR TITLE
Swift SIL: let `var UnaryInstruction.operand` return an `Operand` and not a `Value`

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEscapeEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeEscapeEffects.swift
@@ -209,7 +209,7 @@ private struct IsExclusiveReturnEscapeVisitor : EscapeVisitorWithResult {
   var result = false
 
   func isExclusiveEscape(returnInst: ReturnInst, _ context: FunctionPassContext) -> Bool {
-    return returnInst.operand.at(returnPath).visit(using: self, context) ?? false
+    return returnInst.returnedValue.at(returnPath).visit(using: self, context) ?? false
   }
 
   mutating func visitUse(operand: Operand, path: EscapePath) -> UseResult {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ComputeSideEffects.swift
@@ -98,7 +98,7 @@ private struct CollectedEffects {
       addDestroyEffects(ofValue: inst.operands[0].value)
 
     case let da as DestroyAddrInst:
-      addDestroyEffects(ofAddress: da.operand)
+      addDestroyEffects(ofAddress: da.destroyedAddress)
 
     case let copy as CopyAddrInst:
       addEffects(.read, to: copy.source)
@@ -146,7 +146,7 @@ private struct CollectedEffects {
     case let fl as FixLifetimeInst:
       // A fix_lifetime instruction acts like a read on the operand to prevent
       // releases moving above the fix_lifetime.
-      addEffects(.read, to: fl.operand)
+      addEffects(.read, to: fl.operand.value)
 
       // Instructions which have effects defined in SILNodes.def, but those effects are
       // not relevant for our purpose.

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/MergeCondFails.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/MergeCondFails.swift
@@ -17,8 +17,8 @@ let mergeCondFailsPass = FunctionPass(name: "merge-cond_fails", runMergeCondFail
 /// Return true if the operand of the cond_fail instruction looks like
 /// the overflow bit of an arithmetic instruction.
 private func hasOverflowConditionOperand(_ cfi: CondFailInst) -> Bool {
-  if let tei = cfi.operand as? TupleExtractInst {
-    return tei.operand is BuiltinInst
+  if let tei = cfi.condition as? TupleExtractInst {
+    return tei.operand.value is BuiltinInst
   }
   return false
 }
@@ -73,10 +73,10 @@ private func mergeCondFails(_ condFailToMerge: inout Stack<CondFailInst>,
       mergedCond = builder.createBuiltinBinaryFunction(name: "or",
                                         operandType: prevCond.type,
                                         resultType: prevCond.type,
-                                        arguments: [prevCond, cfi.operand])
+                                        arguments: [prevCond, cfi.condition])
       didMerge = true
     } else {
-      mergedCond = cfi.operand
+      mergedCond = cfi.condition
     }
   }
   if !didMerge {

--- a/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ReleaseDevirtualizer.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/FunctionPasses/ReleaseDevirtualizer.swift
@@ -78,7 +78,7 @@ private func tryDevirtualizeReleaseOfObject(
   // Check if the release instruction right before the `dealloc_stack_ref` really releases
   // the allocated object (and not something else).
   var finder = FindAllocationOfRelease(allocation: allocRefInstruction)
-  if !finder.allocationIsRoot(of: release.operand) {
+  if !finder.allocationIsRoot(of: release.operand.value) {
     return
   }
 

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginCOWMutation.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBeginCOWMutation.swift
@@ -56,7 +56,7 @@ extension BeginCOWMutationInst : Simplifyable, SILCombineSimplifyable {
 private extension BeginCOWMutationInst {
 
   func optimizeEmptySingleton(_ context: SimplifyContext) {
-    if !isEmptyCOWSingleton(operand) {
+    if !isEmptyCOWSingleton(instance) {
       return
     }
     if uniquenessResult.nonDebugUses.isEmpty {
@@ -73,14 +73,14 @@ private extension BeginCOWMutationInst {
     if !uniquenessResult.nonDebugUses.isEmpty {
       return false
     }
-    let buffer = bufferResult
+    let buffer = instanceResult
     if buffer.nonDebugUses.contains(where: { !($0.instruction is EndCOWMutationInst) }) {
       return false
     }
 
     for use in buffer.nonDebugUses {
       let endCOW = use.instruction as! EndCOWMutationInst
-      endCOW.uses.replaceAll(with: operand, context)
+      endCOW.uses.replaceAll(with: instance, context)
       context.erase(instruction: endCOW)
     }
     context.erase(instructionIncludingDebugUses: self)
@@ -91,14 +91,14 @@ private extension BeginCOWMutationInst {
     if !uniquenessResult.nonDebugUses.isEmpty {
       return false
     }
-    guard let endCOW = operand as? EndCOWMutationInst else {
+    guard let endCOW = instance as? EndCOWMutationInst else {
       return false
     }
     if endCOW.nonDebugUses.contains(where: { $0.instruction != self }) {
       return false
     }
 
-    bufferResult.uses.replaceAll(with: endCOW.operand, context)
+    instanceResult.uses.replaceAll(with: endCOW.instance, context)
     context.erase(instructionIncludingDebugUses: self)
     context.erase(instructionIncludingDebugUses: endCOW)
     return true
@@ -114,7 +114,7 @@ private func isEmptyCOWSingleton(_ value: Value) -> Bool {
            is RawPointerToRefInst,
            is AddressToPointerInst,
            is CopyValueInst:
-        v = (v as! UnaryInstruction).operand
+        v = (v as! UnaryInstruction).operand.value
       case let globalAddr as GlobalAddrInst:
         let name = globalAddr.global.name
         return name == "_swiftEmptyArrayStorage" ||

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyBuiltin.swift
@@ -76,13 +76,13 @@ private func typesOfValuesAreEqual(_ lhs: Value, _ rhs: Value, in function: Func
     return nil
   }
 
-  let lhsTy = lhsExistential.operand.type.instanceTypeOfMetatype(in: function)
-  let rhsTy = rhsExistential.operand.type.instanceTypeOfMetatype(in: function)
+  let lhsTy = lhsExistential.metatype.type.instanceTypeOfMetatype(in: function)
+  let rhsTy = rhsExistential.metatype.type.instanceTypeOfMetatype(in: function)
 
   // Do we know the exact types? This is not the case e.g. if a type is passed as metatype
   // to the function.
-  let typesAreExact = lhsExistential.operand is MetatypeInst &&
-                      rhsExistential.operand is MetatypeInst
+  let typesAreExact = lhsExistential.metatype is MetatypeInst &&
+                      rhsExistential.metatype is MetatypeInst
 
   switch (lhsTy.typeKind, rhsTy.typeKind) {
   case (_, .unknown), (.unknown, _):

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyStrongRetainRelease.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyStrongRetainRelease.swift
@@ -14,7 +14,7 @@ import SIL
 
 extension StrongRetainInst : Simplifyable, SILCombineSimplifyable {
   func simplify(_ context: SimplifyContext) {
-    if isNotReferenceCounted(value: operand) {
+    if isNotReferenceCounted(value: instance) {
       context.erase(instruction: self)
       return
     }
@@ -34,7 +34,7 @@ extension StrongRetainInst : Simplifyable, SILCombineSimplifyable {
     // peephole.
     if let prev = previous {
       if let release = prev as? StrongReleaseInst {
-        if release.operand == operand {
+        if release.instance == self.instance {
           context.erase(instruction: self)
           context.erase(instruction: release)
           return
@@ -46,7 +46,7 @@ extension StrongRetainInst : Simplifyable, SILCombineSimplifyable {
 
 extension StrongReleaseInst : Simplifyable, SILCombineSimplifyable {
   func simplify(_ context: SimplifyContext) {
-    let op = operand
+    let op = instance
     if isNotReferenceCounted(value: op) {
       context.erase(instruction: self)
       return
@@ -56,7 +56,7 @@ extension StrongReleaseInst : Simplifyable, SILCombineSimplifyable {
     // release of the class, squish the conversion.
     if let ier = op as? InitExistentialRefInst {
       if ier.uses.isSingleUse {
-        setOperand(at: 0, to: ier.operand, context)
+        setOperand(at: 0, to: ier.instance, context)
         context.erase(instruction: ier)
         return
       }
@@ -69,11 +69,11 @@ extension StrongReleaseInst : Simplifyable, SILCombineSimplifyable {
 private func isNotReferenceCounted(value: Value) -> Bool {
   switch value {
     case let cfi as ConvertFunctionInst:
-      return isNotReferenceCounted(value: cfi.operand)
+      return isNotReferenceCounted(value: cfi.fromFunction)
     case let uci as UpcastInst:
-      return isNotReferenceCounted(value: uci.operand)
+      return isNotReferenceCounted(value: uci.fromInstance)
     case let urc as UncheckedRefCastInst:
-      return isNotReferenceCounted(value: urc.operand)
+      return isNotReferenceCounted(value: urc.fromInstance)
     case let gvi as GlobalValueInst:
       // Since Swift 5.1, statically allocated objects have "immortal" reference
       // counts. Therefore we can safely eliminate unbalanced retains and
@@ -90,8 +90,8 @@ private func isNotReferenceCounted(value: Value) -> Bool {
         //     %0 = global_addr @_swiftEmptyArrayStorage
         //     %1 = address_to_pointer %0
         //     %2 = raw_pointer_to_ref %1
-        if let atp = rptr.operand as? AddressToPointerInst {
-          return atp.operand is GlobalAddrInst
+        if let atp = rptr.pointer as? AddressToPointerInst {
+          return atp.address is GlobalAddrInst
         }
       }
       return false

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyStructExtract.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyStructExtract.swift
@@ -14,7 +14,7 @@ import SIL
 
 extension StructExtractInst : OnoneSimplifyable {
   func simplify(_ context: SimplifyContext) {
-    guard let structInst = operand as? StructInst else {
+    guard let structInst = self.struct as? StructInst else {
       return
     }
     context.tryReplaceRedundantInstructionPair(first: structInst, second: self,

--- a/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyUncheckedEnumData.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/InstructionSimplification/SimplifyUncheckedEnumData.swift
@@ -14,12 +14,12 @@ import SIL
 
 extension UncheckedEnumDataInst : OnoneSimplifyable {
   func simplify(_ context: SimplifyContext) {
-    guard let enumInst = operand as? EnumInst else {
+    guard let enumInst = self.enum as? EnumInst else {
       return
     }
     if caseIndex != enumInst.caseIndex {
       return
     }
-    context.tryReplaceRedundantInstructionPair(first: enumInst, second: self, with: enumInst.operand)
+    context.tryReplaceRedundantInstructionPair(first: enumInst, second: self, with: enumInst.payload!)
   }
 }

--- a/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/ModulePasses/StackProtection.swift
@@ -462,9 +462,9 @@ private extension AccessBase {
       case .box, .global:
         return .no
       case .class(let rea):
-        return .objectIfStackPromoted(rea.operand)
+        return .objectIfStackPromoted(rea.instance)
       case .tail(let rta):
-        return .objectIfStackPromoted(rta.operand)
+        return .objectIfStackPromoted(rta.instance)
       case .argument(let arg):
         return .decidedInCaller(arg)
       case .yield, .pointer:
@@ -493,7 +493,7 @@ private extension Instruction {
 
         // The result of an `address_to_pointer` may be used in any unsafe way, e.g.
         // passed to a C function.
-        baseAddr = atp.operand
+        baseAddr = atp.address
       case let ia as IndexAddrInst:
         if !ia.needsStackProtection {
           return nil

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/AccessDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/AccessDumper.swift
@@ -29,7 +29,7 @@ let accessDumper = FunctionPass(name: "dump-access", {
       case let st as StoreInst:
         printAccessInfo(address: st.destination)
       case let load as LoadInst:
-        printAccessInfo(address: load.operand)
+        printAccessInfo(address: load.address)
       case let apply as ApplyInst:
         guard let callee = apply.referencedFunction else {
           break

--- a/SwiftCompilerSources/Sources/Optimizer/TestPasses/EscapeInfoDumper.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/TestPasses/EscapeInfoDumper.swift
@@ -80,7 +80,7 @@ let addressEscapeInfoDumper = FunctionPass(name: "dump-addr-escape-info", {
   for inst in function.instructions {
     switch inst {
       case let fli as FixLifetimeInst:
-        valuesToCheck.append(fli.operand)
+        valuesToCheck.append(fli.operand.value)
       case is FullApplySite:
         applies.append(inst)
       default:

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/EscapeUtils.swift
@@ -687,10 +687,10 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
         //   %a = pointer_to_address %l           // the up-walk starts at %a
         return isEscaping
       }
-      return walkUp(address: (def as! UnaryInstruction).operand,
+      return walkUp(address: (def as! UnaryInstruction).operand.value,
                     path: path.with(followStores: true).with(knownType: nil))
     case let atp as AddressToPointerInst:
-      return walkUp(address: atp.operand, path: path.with(knownType: nil))
+      return walkUp(address: atp.address, path: path.with(knownType: nil))
     default:
       return isEscaping
     }
@@ -727,11 +727,11 @@ fileprivate struct EscapeWalker<V: EscapeVisitor> : ValueDefUseWalker,
     case is PointerToAddressInst, is IndexAddrInst:
       return walkUp(value: (def as! SingleValueInstruction).operands[0].value, path: path.with(knownType: nil))
     case let rta as RefTailAddrInst:
-      return walkUp(value: rta.operand, path: path.push(.tailElements, index: 0).with(knownType: nil))
+      return walkUp(value: rta.instance, path: path.push(.tailElements, index: 0).with(knownType: nil))
     case let rea as RefElementAddrInst:
-      return walkUp(value: rea.operand, path: path.push(.classField, index: rea.fieldIndex).with(knownType: nil))
+      return walkUp(value: rea.instance, path: path.push(.classField, index: rea.fieldIndex).with(knownType: nil))
     case let pb as ProjectBoxInst:
-      return walkUp(value: pb.operand, path: path.push(.classField, index: pb.fieldIndex).with(knownType: nil))
+      return walkUp(value: pb.box, path: path.push(.classField, index: pb.fieldIndex).with(knownType: nil))
     default:
       return isEscaping
     }

--- a/SwiftCompilerSources/Sources/SIL/Instruction.swift
+++ b/SwiftCompilerSources/Sources/SIL/Instruction.swift
@@ -206,11 +206,11 @@ public class MultipleValueInstruction : Instruction {
 /// Instructions, which have a single operand.
 public protocol UnaryInstruction : AnyObject {
   var operands: OperandArray { get }
-  var operand: Value { get }
+  var operand: Operand { get }
 }
 
 extension UnaryInstruction {
-  public var operand: Value { operands[0].value }
+  public var operand: Operand { operands[0] }
 }
 
 //===----------------------------------------------------------------------===//
@@ -262,7 +262,7 @@ final public class CopyAddrInst : Instruction {
 
 final public class EndAccessInst : Instruction, UnaryInstruction {
   public var beginAccess: BeginAccessInst {
-    return operand as! BeginAccessInst
+    return operand.value as! BeginAccessInst
   }
 }
 
@@ -270,18 +270,19 @@ final public class EndBorrowInst : Instruction, UnaryInstruction {}
 
 final public class DeallocStackInst : Instruction, UnaryInstruction {
   public var allocstack: AllocStackInst {
-    return operand as! AllocStackInst
+    return operand.value as! AllocStackInst
   }
 }
 
 final public class DeallocStackRefInst : Instruction, UnaryInstruction {
-  public var allocRef: AllocRefInstBase { operand as! AllocRefInstBase }
+  public var allocRef: AllocRefInstBase { operand.value as! AllocRefInstBase }
 }
 
 final public class MarkUninitializedInst : SingleValueInstruction, UnaryInstruction {
 }
 
 final public class CondFailInst : Instruction, UnaryInstruction {
+  public var condition: Value { operand.value }
   public override var mayTrap: Bool { true }
 
   public var message: String { CondFailInst_getMessage(bridged).string }
@@ -309,20 +310,26 @@ public class RefCountingInst : Instruction, UnaryInstruction {
 }
 
 final public class StrongRetainInst : RefCountingInst {
+  public var instance: Value { operand.value }
 }
 
 final public class RetainValueInst : RefCountingInst {
 }
 
 final public class StrongReleaseInst : RefCountingInst {
+  public var instance: Value { operand.value }
 }
 
 final public class ReleaseValueInst : RefCountingInst {
 }
 
-final public class DestroyValueInst : Instruction, UnaryInstruction {}
+final public class DestroyValueInst : Instruction, UnaryInstruction {
+  public var destroyedValue: Value { operand.value }
+}
 
-final public class DestroyAddrInst : Instruction, UnaryInstruction {}
+final public class DestroyAddrInst : Instruction, UnaryInstruction {
+  public var destroyedAddress: Value { operand.value }
+}
 
 final public class InjectEnumAddrInst : Instruction, UnaryInstruction, EnumInstruction {
   public var caseIndex: Int { InjectEnumAddrInst_caseIndex(bridged) }
@@ -340,6 +347,8 @@ final public class UnimplementedSingleValueInst : SingleValueInstruction {
 }
 
 final public class LoadInst : SingleValueInstruction, UnaryInstruction {
+  public var address: Value { operand.value }
+
   // must match with enum class LoadOwnershipQualifier
   public enum LoadOwnership: Int {
     case unqualified = 0, take = 1, copy = 2, trivial = 3
@@ -361,23 +370,33 @@ final public class BuiltinInst : SingleValueInstruction {
   }
 }
 
-final public class UpcastInst : SingleValueInstruction, UnaryInstruction {}
+final public class UpcastInst : SingleValueInstruction, UnaryInstruction {
+  public var fromInstance: Value { operand.value }
+}
 
 final public
-class UncheckedRefCastInst : SingleValueInstruction, UnaryInstruction {}
+class UncheckedRefCastInst : SingleValueInstruction, UnaryInstruction {
+  public var fromInstance: Value { operand.value }
+}
 
 final public
-class RawPointerToRefInst : SingleValueInstruction, UnaryInstruction {}
+class RawPointerToRefInst : SingleValueInstruction, UnaryInstruction {
+  public var pointer: Value { operand.value }
+}
 
 final public
 class AddressToPointerInst : SingleValueInstruction, UnaryInstruction {
+  public var address: Value { operand.value }
+
   public var needsStackProtection: Bool {
     AddressToPointerInst_needsStackProtection(bridged) != 0
   }
 }
 
 final public
-class PointerToAddressInst : SingleValueInstruction, UnaryInstruction {}
+class PointerToAddressInst : SingleValueInstruction, UnaryInstruction {
+  public var pointer: Value { operand.value }
+}
 
 final public
 class IndexAddrInst : SingleValueInstruction {
@@ -390,7 +409,9 @@ class IndexAddrInst : SingleValueInstruction {
 }
 
 final public
-class InitExistentialRefInst : SingleValueInstruction, UnaryInstruction {}
+class InitExistentialRefInst : SingleValueInstruction, UnaryInstruction {
+  public var instance: Value { operand.value }
+}
 
 final public
 class OpenExistentialRefInst : SingleValueInstruction, UnaryInstruction {}
@@ -414,7 +435,9 @@ final public
 class OpenExistentialBoxValueInst : SingleValueInstruction, UnaryInstruction {}
 
 final public
-class InitExistentialMetatypeInst : SingleValueInstruction, UnaryInstruction {}
+class InitExistentialMetatypeInst : SingleValueInstruction, UnaryInstruction {
+  public var metatype: Value { operand.value }
+}
 
 final public
 class OpenExistentialMetatypeInst : SingleValueInstruction, UnaryInstruction {}
@@ -468,11 +491,13 @@ final public class TupleInst : SingleValueInstruction {
 }
 
 final public class TupleExtractInst : SingleValueInstruction, UnaryInstruction {
+  public var `tuple`: Value { operand.value }
   public var fieldIndex: Int { TupleExtractInst_fieldIndex(bridged) }
 }
 
 final public
 class TupleElementAddrInst : SingleValueInstruction, UnaryInstruction {
+  public var `tuple`: Value { operand.value }
   public var fieldIndex: Int { TupleElementAddrInst_fieldIndex(bridged) }
 }
 
@@ -480,11 +505,13 @@ final public class StructInst : SingleValueInstruction {
 }
 
 final public class StructExtractInst : SingleValueInstruction, UnaryInstruction {
+  public var `struct`: Value { operand.value }
   public var fieldIndex: Int { StructExtractInst_fieldIndex(bridged) }
 }
 
 final public
 class StructElementAddrInst : SingleValueInstruction, UnaryInstruction {
+  public var `struct`: Value { operand.value }
   public var fieldIndex: Int { StructElementAddrInst_fieldIndex(bridged) }
 }
 
@@ -492,31 +519,38 @@ public protocol EnumInstruction : AnyObject {
   var caseIndex: Int { get }
 }
 
-final public class EnumInst : SingleValueInstruction, UnaryInstruction, EnumInstruction {
+final public class EnumInst : SingleValueInstruction, EnumInstruction {
   public var caseIndex: Int { EnumInst_caseIndex(bridged) }
 
-  public var operand: Value? { operands.first?.value }
+  public var operand: Operand? { operands.first }
+  public var payload: Value? { operand?.value }
 }
 
 final public class UncheckedEnumDataInst : SingleValueInstruction, UnaryInstruction, EnumInstruction {
+  public var `enum`: Value { operand.value }
   public var caseIndex: Int { UncheckedEnumDataInst_caseIndex(bridged) }
 }
 
 final public class InitEnumDataAddrInst : SingleValueInstruction, UnaryInstruction, EnumInstruction {
+  public var `enum`: Value { operand.value }
   public var caseIndex: Int { InitEnumDataAddrInst_caseIndex(bridged) }
 }
 
 final public class UncheckedTakeEnumDataAddrInst : SingleValueInstruction, UnaryInstruction, EnumInstruction {
+  public var `enum`: Value { operand.value }
   public var caseIndex: Int { UncheckedTakeEnumDataAddrInst_caseIndex(bridged) }
 }
 
 final public class RefElementAddrInst : SingleValueInstruction, UnaryInstruction {
+  public var instance: Value { operand.value }
   public var fieldIndex: Int { RefElementAddrInst_fieldIndex(bridged) }
 
   public var fieldIsLet: Bool { RefElementAddrInst_fieldIsLet(bridged) != 0 }
 }
 
-final public class RefTailAddrInst : SingleValueInstruction, UnaryInstruction {}
+final public class RefTailAddrInst : SingleValueInstruction, UnaryInstruction {
+  public var instance: Value { operand.value }
+}
 
 final public class KeyPathInst : SingleValueInstruction {
   public override func visitReferencedFunctions(_ cl: (Function) -> ()) {
@@ -542,7 +576,9 @@ class UnconditionalCheckedCastInst : SingleValueInstruction, UnaryInstruction {
 }
 
 final public
-class ConvertFunctionInst : SingleValueInstruction, UnaryInstruction {}
+class ConvertFunctionInst : SingleValueInstruction, UnaryInstruction {
+  public var fromFunction: Value { operand.value }
+}
 
 final public
 class ThinToThickFunctionInst : SingleValueInstruction, UnaryInstruction {}
@@ -603,21 +639,30 @@ extension BeginAccessInst : ScopedInstruction {
   }
 }
 
-final public class BeginBorrowInst : SingleValueInstruction, UnaryInstruction {}
+final public class BeginBorrowInst : SingleValueInstruction, UnaryInstruction {
+  public var borrowedValue: Value { operand.value }
+}
 
 final public class ProjectBoxInst : SingleValueInstruction, UnaryInstruction {
+  public var box: Value { operand.value }
   public var fieldIndex: Int { ProjectBoxInst_fieldIndex(bridged) }
 }
 
-final public class CopyValueInst : SingleValueInstruction, UnaryInstruction {}
+final public class CopyValueInst : SingleValueInstruction, UnaryInstruction {
+  public var fromValue: Value { operand.value }
+}
 
-final public class MoveValueInst : SingleValueInstruction, UnaryInstruction {}
+final public class MoveValueInst : SingleValueInstruction, UnaryInstruction {
+  public var fromValue: Value { operand.value }
+}
 
 final public class StrongCopyUnownedValueInst : SingleValueInstruction, UnaryInstruction {}
 
 final public class StrongCopyUnmanagedValueInst : SingleValueInstruction, UnaryInstruction  {}
 
-final public class EndCOWMutationInst : SingleValueInstruction, UnaryInstruction {}
+final public class EndCOWMutationInst : SingleValueInstruction, UnaryInstruction {
+  public var instance: Value { operand.value }
+}
 
 final public
 class ClassifyBridgeObjectInst : SingleValueInstruction, UnaryInstruction {}
@@ -707,14 +752,17 @@ final public class AllocExistentialBoxInst : SingleValueInstruction, Allocation 
 
 final public class BeginCOWMutationInst : MultipleValueInstruction,
                                           UnaryInstruction {
+  public var instance: Value { operand.value }
   public var uniquenessResult: Value { return getResult(index: 0) }
-  public var bufferResult: Value { return getResult(index: 1) }
+  public var instanceResult: Value { return getResult(index: 1) }
 }
 
 final public class DestructureStructInst : MultipleValueInstruction, UnaryInstruction {
+  public var `struct`: Value { operand.value }
 }
 
 final public class DestructureTupleInst : MultipleValueInstruction, UnaryInstruction {
+  public var `tuple`: Value { operand.value }
 }
 
 final public class BeginApplyInst : MultipleValueInstruction, FullApplySite {
@@ -739,10 +787,12 @@ final public class UnreachableInst : TermInst {
 }
 
 final public class ReturnInst : TermInst, UnaryInstruction {
+  public var returnedValue: Value { operand.value }
   public override var isFunctionExiting: Bool { true }
 }
 
 final public class ThrowInst : TermInst, UnaryInstruction {
+  public var thrownValue: Value { operand.value }
   public override var isFunctionExiting: Bool { true }
 }
 


### PR DESCRIPTION
To avoid confusion. Instead add specific getters for unary instructions with dedicated names.

NFC
