### PR TITLE
[Rename] Allow renaming of symbols from another module

### DIFF
--- a/lib/Refactoring/Refactoring.cpp
+++ b/lib/Refactoring/Refactoring.cpp
@@ -8811,7 +8811,7 @@ void swift::ide::collectRenameAvailabilityInfo(
     AvailKind = RenameAvailableKind::Unavailable_system_symbol;
   } else if (VD->getClangDecl()) {
     AvailKind = RenameAvailableKind::Unavailable_decl_from_clang;
-  } else if (VD->getStartLoc().isInvalid()) {
+  } else if (VD->getLoc().isInvalid()) {
     AvailKind = RenameAvailableKind::Unavailable_has_no_location;
   } else if (!VD->hasName()) {
     AvailKind = RenameAvailableKind::Unavailable_has_no_name;

--- a/test/SourceKit/Refactoring/rename-across-modules.swift
+++ b/test/SourceKit/Refactoring/rename-across-modules.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/build)
+// RUN: split-file --leading-lines %s %t
+
+// RUN: %target-swift-frontend -emit-module -module-name MyModule -emit-module-path %t/build/MyModule.swiftmodule -emit-module-source-info-path %t/build/MyModule.swiftsourceinfo %t/Action.swift
+
+//--- Action.swift
+public protocol Action {}
+
+//--- test.swift
+import MyModule
+
+// RUN: %sourcekitd-test -req=cursor -pos=%(line+1):19 -length=6 -cursor-action %t/test.swift -- %t/test.swift -I %t/build | %FileCheck %s
+func test(action: Action) { }
+// CHECK: ACTIONS BEGIN
+// CHECK-NEXT: source.refactoring.kind.rename.global
+// CHECK-NEXT: Global Rename
+// CHECK-NOT: cannot be renamed


### PR DESCRIPTION
Retrieve the serialized location when checking rename availablity so that global rename works on references outside the module it was declared in.

Resolves rdar://94671287.