### PR TITLE
Remove a confusing comment in Unmanaged.retain().

### DIFF
--- a/stdlib/public/core/Unmanaged.swift
+++ b/stdlib/public/core/Unmanaged.swift
@@ -221,11 +221,6 @@ public struct Unmanaged<Instance: AnyObject> {
   }
 
   /// Performs an unbalanced retain of the object.
-  ///
-  /// Note: Use Umanaged.passRetained(object) instead to ensure that
-  /// the reference to object is retained before it becomes
-  /// unmanaged. Once a reference is unmanaged, its underlying object
-  /// may be freed by the system.
   @_transparent
   public func retain() -> Unmanaged {
     Builtin.retain(_value)


### PR DESCRIPTION
Users should not do this:

    class C {
        func getRetained() {
            let unmanaged = Unmanaged.passUnretained(self)
            //... maybe some condition
            unmanaged.retain()
        }
    }

But that should be obvious, and apparently this comment doesn't help.

