### PR TITLE
[Macros] Add executable plugin support

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -79,6 +79,7 @@ namespace swift {
   class DifferentiableAttr;
   class ExtensionDecl;
   struct ExternalSourceLocs;
+  class LoadedExecutablePlugin;
   class ForeignRepresentationInfo;
   class FuncDecl;
   class GenericContext;
@@ -91,6 +92,7 @@ namespace swift {
   class ModuleDependencyInfo;
   class PatternBindingDecl;
   class PatternBindingInitializer;
+  class PluginRegistry;
   class SourceFile;
   class SourceLoc;
   class Type;
@@ -1457,6 +1459,16 @@ public:
   void *getAddressOfSymbol(const char *name, void *libraryHandleHint = nullptr);
   
   Type getNamedSwiftType(ModuleDecl *module, StringRef name);
+
+  LoadedExecutablePlugin *
+  lookupExecutablePluginByModuleName(Identifier moduleName);
+
+  /// Get the plugin registry this ASTContext is using.
+  PluginRegistry *getPluginRegistry() const;
+
+  /// Set the plugin registory this ASTContext should use.
+  /// This should be called before any plugin is loaded.
+  void setPluginRegistry(PluginRegistry *newValue);
 
 private:
   friend Decl;

--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -13,8 +13,13 @@
 #ifndef SWIFT_C_AST_ASTBRIDGING_H
 #define SWIFT_C_AST_ASTBRIDGING_H
 
+#include "swift/Basic/CBasicBridging.h"
 #include "swift/Basic/Compiler.h"
+
 #include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
 
 #if __clang__
 // Provide macros to temporarily suppress warning about the use of
@@ -279,6 +284,31 @@ void Expr_dump(void *);
 void Decl_dump(void *);
 void Stmt_dump(void *);
 void Type_dump(void *);
+
+//===----------------------------------------------------------------------===//
+// Plugins
+//===----------------------------------------------------------------------===//
+
+/// Set a capability data to the plugin object. Since the data is just a opaque
+/// pointer, it's not used in AST at all.
+void Plugin_setCapability(void *handle, const void *data);
+
+/// Get a coapability data set by \c Plugin_setCapability .
+const void *_Nullable Plugin_getCapability(void *handle);
+
+/// Lock the plugin. Clients should lock it during sending and recving the
+/// response.
+void Plugin_lock(void *handle);
+
+/// Unlock the plugin.
+void Plugin_unlock(void *handle);
+
+/// Sends the message to the plugin, returns true if there was an error.
+/// Clients should receive the response  by \c Plugin_waitForNextMessage .
+_Bool Plugin_sendMessage(void *handle, const BridgedData data);
+
+/// Receive a message from the plugin.
+_Bool Plugin_waitForNextMessage(void *handle, BridgedData *data);
 
 #ifdef __cplusplus
 }

--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -289,26 +289,29 @@ void Type_dump(void *);
 // Plugins
 //===----------------------------------------------------------------------===//
 
+typedef void *PluginHandle;
+typedef const void *PluginCapabilityPtr;
+
 /// Set a capability data to the plugin object. Since the data is just a opaque
 /// pointer, it's not used in AST at all.
-void Plugin_setCapability(void *handle, const void *data);
+void Plugin_setCapability(PluginHandle handle, PluginCapabilityPtr data);
 
-/// Get a coapability data set by \c Plugin_setCapability .
-const void *_Nullable Plugin_getCapability(void *handle);
+/// Get a capability data set by \c Plugin_setCapability .
+PluginCapabilityPtr _Nullable Plugin_getCapability(PluginHandle handle);
 
 /// Lock the plugin. Clients should lock it during sending and recving the
 /// response.
-void Plugin_lock(void *handle);
+void Plugin_lock(PluginHandle handle);
 
 /// Unlock the plugin.
-void Plugin_unlock(void *handle);
+void Plugin_unlock(PluginHandle handle);
 
 /// Sends the message to the plugin, returns true if there was an error.
 /// Clients should receive the response  by \c Plugin_waitForNextMessage .
-_Bool Plugin_sendMessage(void *handle, const BridgedData data);
+_Bool Plugin_sendMessage(PluginHandle handle, const BridgedData data);
 
 /// Receive a message from the plugin.
-_Bool Plugin_waitForNextMessage(void *handle, BridgedData *data);
+_Bool Plugin_waitForNextMessage(PluginHandle handle, BridgedData *data);
 
 #ifdef __cplusplus
 }

--- a/include/swift/AST/MacroDefinition.h
+++ b/include/swift/AST/MacroDefinition.h
@@ -24,6 +24,11 @@ namespace swift {
 
 /// A reference to an external macro definition that is understood by ASTGen.
 struct ExternalMacroDefinition {
+  enum class PluginKind {
+    InProcess = 0,
+    Executable = 1,
+  };
+  PluginKind kind;
   /// ASTGen's notion of an macro definition, which is opaque to the C++ part
   /// of the compiler.
   void *opaqueHandle = nullptr;

--- a/include/swift/AST/PluginRegistry.h
+++ b/include/swift/AST/PluginRegistry.h
@@ -14,6 +14,7 @@
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Chrono.h"
+#include "llvm/Support/Error.h"
 #include "llvm/Support/Program.h"
 
 #include <mutex>
@@ -52,10 +53,10 @@ public:
   void unlock() { mtx.unlock(); }
 
   /// Send a message to the plugin.
-  bool sendMessage(llvm::StringRef message) const;
+  llvm::Error sendMessage(llvm::StringRef message) const;
 
   /// Wait for a message from plugin and returns it.
-  std::string waitForNextMessage() const;
+  llvm::Expected<std::string> waitForNextMessage() const;
 
   bool isInitialized() const { return bool(cleanup); }
   void setCleanup(std::function<void(void)> cleanup) {
@@ -77,9 +78,9 @@ class PluginRegistry {
       LoadedPluginExecutables;
 
 public:
-  bool loadLibraryPlugin(llvm::StringRef path, const char *&errorMsg);
-  LoadedExecutablePlugin *loadExecutablePlugin(llvm::StringRef path,
-                                               const char *&errorMsg);
+  llvm::Error loadLibraryPlugin(llvm::StringRef path);
+  llvm::Expected<LoadedExecutablePlugin *>
+  loadExecutablePlugin(llvm::StringRef path);
 
   const llvm::StringMap<void *> &getLoadedLibraryPlugins() const {
     return LoadedPluginLibraries;

--- a/include/swift/AST/PluginRegistry.h
+++ b/include/swift/AST/PluginRegistry.h
@@ -1,0 +1,89 @@
+//===--- PluginRegistry.h ---------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Chrono.h"
+#include "llvm/Support/Program.h"
+
+#include <mutex>
+#include <vector>
+
+namespace swift {
+
+class LoadedExecutablePlugin {
+  const llvm::sys::procid_t pid;
+  const llvm::sys::TimePoint<> LastModificationTime;
+  const int inputFileDescriptor;
+  const int outputFileDescriptor;
+
+  /// Opaque value of the protocol capability of the pluugin. This is a
+  /// value from ASTGen.
+  const void *capability = nullptr;
+
+  /// Cleanup function to call ASTGen.
+  std::function<void(void)> cleanup;
+
+  std::mutex mtx;
+
+  ssize_t write(const void *buf, size_t nbyte) const;
+  ssize_t read(void *buf, size_t nbyte) const;
+
+public:
+  LoadedExecutablePlugin(llvm::sys::procid_t pid,
+                         llvm::sys::TimePoint<> LastModificationTime,
+                         int inputFileDescriptor, int outputFileDescriptor);
+  ~LoadedExecutablePlugin();
+  llvm::sys::TimePoint<> getLastModificationTime() const {
+    return LastModificationTime;
+  }
+
+  void lock() { mtx.lock(); }
+  void unlock() { mtx.unlock(); }
+
+  /// Send a message to the plugin.
+  bool sendMessage(llvm::StringRef message) const;
+
+  /// Wait for a message from plugin and returns it.
+  std::string waitForNextMessage() const;
+
+  bool isInitialized() const { return bool(cleanup); }
+  void setCleanup(std::function<void(void)> cleanup) {
+    this->cleanup = cleanup;
+  }
+
+  llvm::sys::procid_t getPid() { return pid; }
+
+  const void *getCapability() { return capability; };
+  void setCapability(const void *newValue) { capability = newValue; };
+};
+
+class PluginRegistry {
+  /// Record of loaded plugin library modules.
+  llvm::StringMap<void *> LoadedPluginLibraries;
+
+  /// Record of loaded plugin executables.
+  llvm::StringMap<std::unique_ptr<LoadedExecutablePlugin>>
+      LoadedPluginExecutables;
+
+public:
+  bool loadLibraryPlugin(llvm::StringRef path, const char *&errorMsg);
+  LoadedExecutablePlugin *loadExecutablePlugin(llvm::StringRef path,
+                                               const char *&errorMsg);
+
+  const llvm::StringMap<void *> &getLoadedLibraryPlugins() const {
+    return LoadedPluginLibraries;
+  }
+};
+
+} // namespace swift

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3931,7 +3931,7 @@ public:
 /// Resolve an external macro given its module and type name.
 class ExternalMacroDefinitionRequest
     : public SimpleRequest<ExternalMacroDefinitionRequest,
-                           ExternalMacroDefinition(
+                           llvm::Optional<ExternalMacroDefinition>(
                                ASTContext *, Identifier, Identifier),
                            RequestFlags::Cached> {
 public:
@@ -3940,9 +3940,9 @@ public:
 private:
   friend SimpleRequest;
 
-  ExternalMacroDefinition evaluate(
-      Evaluator &evaluator, ASTContext *ctx, Identifier moduleName,
-      Identifier typeName
+  llvm::Optional<ExternalMacroDefinition> evaluate(
+      Evaluator &evaluator, ASTContext *ctx,
+      Identifier moduleName, Identifier typeName
   ) const;
 
 public:

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -426,7 +426,7 @@ SWIFT_REQUEST(TypeChecker, CompilerPluginLoadRequest,
               void *(ASTContext *, Identifier),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ExternalMacroDefinitionRequest,
-              ExternalMacroDefinition(ASTContext *, Identifier, Identifier),
+              Optional<ExternalMacroDefinition>(ASTContext *, Identifier, Identifier),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ExpandMacroExpansionDeclRequest,
               ArrayRef<Decl *>(MacroExpansionDecl *),

--- a/include/swift/Basic/Program.h
+++ b/include/swift/Basic/Program.h
@@ -13,6 +13,12 @@
 #ifndef SWIFT_BASIC_PROGRAM_H
 #define SWIFT_BASIC_PROGRAM_H
 
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Optional.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/ErrorOr.h"
+#include "llvm/Support/Program.h"
+
 namespace swift {
 
 /// This function executes the program using the arguments provided,
@@ -32,6 +38,31 @@ namespace swift {
 /// value indicating a failure to execute.
 int ExecuteInPlace(const char *Program, const char **args,
                    const char **env = nullptr);
+
+struct ChildProcessInfo {
+  llvm::sys::procid_t Pid;
+  int WriteFileDescriptor;
+  int ReadFileDescriptor;
+
+  ChildProcessInfo(llvm::sys::procid_t Pid, int WriteFileDescriptor,
+                   int ReadFileDescriptor)
+      : Pid(Pid), WriteFileDescriptor(WriteFileDescriptor),
+        ReadFileDescriptor(ReadFileDescriptor) {}
+};
+
+/// This function executes the program using the argument provided.
+/// Establish pipes between the current process and the spawned process.
+/// Returned a \c ChildProcessInfo where WriteFileDescriptor is piped to
+/// child's STDIN, and ReadFileDescriptor is piped from child's STDOUT.
+///
+/// \param program Path of the program to be executed
+/// \param args An array of strings that are passed to the program. The first
+/// element should be the name of the program.
+/// \param env An optional array of strings to use for the program's
+/// environment.
+llvm::ErrorOr<swift::ChildProcessInfo> ExecuteWithPipe(
+    llvm::StringRef program, llvm::ArrayRef<llvm::StringRef> args,
+    llvm::Optional<llvm::ArrayRef<llvm::StringRef>> env = llvm::None);
 
 } // end namespace swift
 

--- a/include/swift/Basic/Program.h
+++ b/include/swift/Basic/Program.h
@@ -58,7 +58,7 @@ struct ChildProcessInfo {
 /// \param program Path of the program to be executed
 /// \param args An array of strings that are passed to the program. The first
 /// element should be the name of the program.
-/// \param env An optional array of strings to use for the program's
+/// \param env An optional array of 'key=value 'strings to use for the program's
 /// environment.
 llvm::ErrorOr<swift::ChildProcessInfo> ExecuteWithPipe(
     llvm::StringRef program, llvm::ArrayRef<llvm::StringRef> args,

--- a/include/swift/Basic/Sandbox.h
+++ b/include/swift/Basic/Sandbox.h
@@ -1,0 +1,44 @@
+//===--- Sandbox.h ----------------------------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_SANDBOX_H
+#define SWIFT_BASIC_SANDBOX_H
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Allocator.h"
+
+namespace swift {
+namespace Sandbox {
+
+/// Applies a sandbox invocation to the given command line (if the platform
+/// supports it), and returns the modified command line. On platforms that don't
+/// support sandboxing, the command line is returned unmodified.
+///
+/// - Parameters:
+///   - command: The command line to sandbox (including executable as first
+///              argument)
+///   - strictness: The basic strictness level of the standbox.
+///   - writableDirectories: Paths under which writing should be allowed, even
+///     if they would otherwise be read-only based on the strictness or paths in
+///     `readOnlyDirectories`.
+///   - readOnlyDirectories: Paths under which writing should be denied, even if
+///     they would have otherwise been allowed by the rules implied by the
+///     strictness level.
+bool apply(llvm::SmallVectorImpl<llvm::StringRef> &command,
+           llvm::BumpPtrAllocator &Alloc);
+
+} // namespace Sandbox
+} // namespace swift
+
+#endif // SWIFT_BASIC_SANDBOX_H

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -531,7 +531,7 @@ struct ASTContext::Implementation {
   llvm::StringMap<void *> LoadedSymbols;
 
   /// Map a module name to an executable plugin path that provides the module.
-  llvm::DenseMap<Identifier, std::string> ExecutablePluginPaths;
+  llvm::DenseMap<Identifier, StringRef> ExecutablePluginPaths;
 
   /// The permanent arena.
   Arena Permanent;
@@ -6256,9 +6256,9 @@ void ASTContext::loadCompilerPlugins() {
       // TODO: Error messsage.
       Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, arg, "");
     }
-    auto pathstr = std::string(path);
+    auto pathStr = AllocateCopy(path);
     for (auto moduleName : modules) {
-      getImpl().ExecutablePluginPaths[getIdentifier(moduleName)] = pathstr;
+      getImpl().ExecutablePluginPaths[getIdentifier(moduleName)] = pathStr;
     }
   }
 }
@@ -6327,7 +6327,7 @@ ASTContext::lookupExecutablePluginByModuleName(Identifier moduleName) {
   if (found == execPluginPaths.end())
     return nullptr;
 
-  // Resolve the realpath.
+  // Let the VFS to map the path.
   auto &path = found->second;
   SmallString<128> resolvedPath;
   auto fs = this->SourceMgr.getFileSystem();

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -41,6 +41,7 @@
 #include "swift/AST/NameLookup.h"
 #include "swift/AST/PackConformance.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/PluginRegistry.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/PropertyWrappers.h"
 #include "swift/AST/ProtocolConformance.h"
@@ -62,17 +63,17 @@
 #include "clang/AST/Type.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/Statistic.h"
 #include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringSwitch.h"
-#include "llvm/ADT/STLExtras.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/Support/Allocator.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/FormatVariadic.h"
 #include <algorithm>
-#include <queue>
 #include <memory>
+#include <queue>
 
 #if !defined(_WIN32)
 #include <dlfcn.h>
@@ -522,11 +523,15 @@ struct ASTContext::Implementation {
 
   llvm::StringMap<OptionSet<SearchPathKind>> SearchPathsSet;
 
-  /// Record of loaded plugin modules.
-  std::vector<std::pair<std::string, void *>> LoadedPluginPaths;
+  /// Plugin registry. Lazily populated by get/setPluginRegistry().
+  /// NOTE: Do not reference this directly. Use ASTContext::getPluginRegistry().
+  PluginRegistry *Plugins = nullptr;
 
   /// Cache of loaded symbols.
   llvm::StringMap<void *> LoadedSymbols;
+
+  /// Map a module name to an executable plugin path that provides the module.
+  llvm::DenseMap<Identifier, std::string> ExecutablePluginPaths;
 
   /// The permanent arena.
   Arena Permanent;
@@ -584,8 +589,7 @@ struct ASTContext::Implementation {
 
 ASTContext::Implementation::Implementation()
     : IdentifierTable(Allocator),
-      IntrinsicScratchContext(new llvm::LLVMContext())
-      {}
+      IntrinsicScratchContext(new llvm::LLVMContext()) {}
 ASTContext::Implementation::~Implementation() {
   for (auto &cleanup : Cleanups)
     cleanup();
@@ -699,6 +703,7 @@ ASTContext::ASTContext(
   registerAccessRequestFunctions(evaluator);
   registerNameLookupRequestFunctions(evaluator);
 
+  // FIXME: Delay this so the client e.g. SourceKit can inject plugin registry.
   loadCompilerPlugins();
 }
 
@@ -6200,32 +6205,62 @@ BuiltinTupleType *ASTContext::getBuiltinTupleType() {
   return result;
 }
 
+void ASTContext::setPluginRegistry(PluginRegistry *newValue) {
+  assert(getImpl().Plugins == nullptr &&
+         "Too late to set a new plugin registry");
+  getImpl().Plugins = newValue;
+}
+
+PluginRegistry *ASTContext::getPluginRegistry() const {
+  PluginRegistry *&registry = getImpl().Plugins;
+
+  // Create a new one if it hasn't been set.
+  if (!registry) {
+    registry = new PluginRegistry();
+    const_cast<ASTContext *>(this)->addCleanup([registry]{
+      delete registry;
+    });
+  }
+
+  assert(registry != nullptr);
+  return registry;
+}
+
 void ASTContext::loadCompilerPlugins() {
+  const char *errorMsg = nullptr;
+  auto fs = this->SourceMgr.getFileSystem();
   for (auto &path : SearchPathOpts.getCompilerPluginLibraryPaths()) {
-    auto fs = this->SourceMgr.getFileSystem();
     SmallString<128> resolvedPath;
     if (auto err = fs->getRealPath(path, resolvedPath)) {
       Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
                      err.message());
       continue;
     }
-
-    void *lib = nullptr;
-#if !defined(_WIN32)
-    lib = dlopen(resolvedPath.c_str(), RTLD_LAZY|RTLD_LOCAL);
-#endif
-
-    if (!lib) {
-      const char *errorMsg = "Unsupported platform";
-#if !defined(_WIN32)
-      errorMsg = dlerror();
-#endif
+    if (getPluginRegistry()->loadLibraryPlugin(resolvedPath, errorMsg)) {
       Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
                      errorMsg);
-      continue;
     }
+  }
 
-    getImpl().LoadedPluginPaths.emplace_back(resolvedPath.str().str(), lib);
+  for (auto &arg : SearchPathOpts.getCompilerPluginExecutablePaths()) {
+    // 'arg' is '<path to executable>#<module names>' where the module names are
+    // comma separated.
+
+    // Create a moduleName -> pluginPath mapping.
+    StringRef path;
+    StringRef modulesStr;
+    std::tie(path, modulesStr) = StringRef(arg).rsplit('#');
+    SmallVector<StringRef, 1> modules;
+    modulesStr.split(modules, ',');
+
+    if (modules.empty() || path.empty()) {
+      // TODO: Error messsage.
+      Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, arg, "");
+    }
+    auto pathstr = std::string(path);
+    for (auto moduleName : modules) {
+      getImpl().ExecutablePluginPaths[getIdentifier(moduleName)] = pathstr;
+    }
   }
 }
 
@@ -6240,7 +6275,7 @@ void *ASTContext::getAddressOfSymbol(const char *name,
 
     // If we didn't know where to look, look specifically in each plugin.
     if (!address && !libraryHandleHint) {
-      for (const auto &plugin: getImpl().LoadedPluginPaths) {
+      for (const auto &plugin : getPluginRegistry()->getLoadedLibraryPlugins()) {
         address = dlsym(plugin.second, name);
         if (address)
           break;
@@ -6286,3 +6321,30 @@ Type ASTContext::getNamedSwiftType(ModuleDecl *module, StringRef name) {
   return decl->getDeclaredInterfaceType();
 }
 
+LoadedExecutablePlugin *
+ASTContext::lookupExecutablePluginByModuleName(Identifier moduleName) {
+  auto &execPluginPaths = getImpl().ExecutablePluginPaths;
+  auto found = execPluginPaths.find(moduleName);
+  if (found == execPluginPaths.end())
+    return nullptr;
+
+  // Resolve the realpath.
+  auto &path = found->second;
+  SmallString<128> resolvedPath;
+  auto fs = this->SourceMgr.getFileSystem();
+  if (auto err = fs->getRealPath(path, resolvedPath)) {
+    Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
+                   err.message());
+    return nullptr;
+  }
+
+  // Load the plugin.
+  const char *errorMsg;
+  auto plugin = getPluginRegistry()->loadExecutablePlugin(resolvedPath, errorMsg);
+  if (!plugin) {
+    Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
+                   errorMsg);
+  }
+
+  return plugin;
+}

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -651,7 +651,10 @@ void Plugin_unlock(PluginHandle handle) {
 bool Plugin_sendMessage(PluginHandle handle, const BridgedData data) {
   auto *plugin = static_cast<LoadedExecutablePlugin *>(handle);
   StringRef message(data.baseAddress, data.size);
-  return bool(plugin->sendMessage(message));
+  auto error = plugin->sendMessage(message);
+  bool hadError = bool(error);
+  llvm::consumeError(std::move(error));
+  return hadError;
 }
 
 bool Plugin_waitForNextMessage(PluginHandle handle, BridgedData *out) {

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -651,14 +651,19 @@ void Plugin_unlock(PluginHandle handle) {
 bool Plugin_sendMessage(PluginHandle handle, const BridgedData data) {
   auto *plugin = static_cast<LoadedExecutablePlugin *>(handle);
   StringRef message(data.baseAddress, data.size);
-  return plugin->sendMessage(message);
+  return bool(plugin->sendMessage(message));
 }
 
 bool Plugin_waitForNextMessage(PluginHandle handle, BridgedData *out) {
   auto *plugin = static_cast<LoadedExecutablePlugin *>(handle);
   auto result = plugin->waitForNextMessage();
-  auto outPtr = malloc(result.size());
-  memcpy(outPtr, result.data(), result.size());
-  *out = BridgedData{(const char *)outPtr, result.size()};
+  if (!result) {
+    return true;
+  }
+  auto &message = result.get();
+  auto size = message.size();
+  auto outPtr = malloc(size);
+  memcpy(outPtr, message.data(), size);
+  *out = BridgedData{(const char *)outPtr, size};
   return false;
 }

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -628,33 +628,33 @@ void Type_dump(void *expr) { ((TypeRepr *)expr)->dump(); }
 // Plugins
 //===----------------------------------------------------------------------===//
 
-const void *Plugin_getCapability(void *handle) {
+PluginCapabilityPtr Plugin_getCapability(PluginHandle handle) {
   auto *plugin = static_cast<LoadedExecutablePlugin *>(handle);
   return plugin->getCapability();
 }
 
-void Plugin_setCapability(void *handle, const void *data) {
+void Plugin_setCapability(PluginHandle handle, PluginCapabilityPtr data) {
   auto *plugin = static_cast<LoadedExecutablePlugin *>(handle);
   plugin->setCapability(data);
 }
 
-void Plugin_lock(void *handle) {
+void Plugin_lock(PluginHandle handle) {
   auto *plugin = static_cast<LoadedExecutablePlugin *>(handle);
   plugin->lock();
 }
 
-void Plugin_unlock(void *handle) {
+void Plugin_unlock(PluginHandle handle) {
   auto *plugin = static_cast<LoadedExecutablePlugin *>(handle);
   plugin->unlock();
 }
 
-bool Plugin_sendMessage(void *handle, const BridgedData data) {
+bool Plugin_sendMessage(PluginHandle handle, const BridgedData data) {
   auto *plugin = static_cast<LoadedExecutablePlugin *>(handle);
   StringRef message(data.baseAddress, data.size);
   return plugin->sendMessage(message);
 }
 
-bool Plugin_waitForNextMessage(void *handle, BridgedData *out) {
+bool Plugin_waitForNextMessage(PluginHandle handle, BridgedData *out) {
   auto *plugin = static_cast<LoadedExecutablePlugin *>(handle);
   auto result = plugin->waitForNextMessage();
   auto outPtr = malloc(result.size());

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -72,6 +72,7 @@ add_swift_host_library(swiftAST STATIC
   Parameter.cpp
   Pattern.cpp
   PlatformKind.cpp
+  PluginRegistry.cpp
   PrettyStackTrace.cpp
   ProtocolConformance.cpp
   ProtocolConformanceRef.cpp

--- a/lib/AST/PluginRegistry.cpp
+++ b/lib/AST/PluginRegistry.cpp
@@ -1,0 +1,211 @@
+//===--- PluginRegistry.cpp -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/PluginRegistry.h"
+
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/Program.h"
+#include "swift/Basic/Sandbox.h"
+#include "swift/Basic/StringExtras.h"
+#include "llvm/Support/Endian.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Config/config.h"
+
+
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+#if HAVE_UNISTD_H
+#include <unistd.h>
+#elif defined(_WIN32)
+#include <io.h>
+#endif
+
+extern "C" const void *swift_ASTGen_getCompilerPluginCapability(void *handle);
+extern "C" void swift_ASTGen_destroyCompilerPluginCapability(void *value);
+
+using namespace swift;
+
+bool PluginRegistry::loadLibraryPlugin(StringRef path, const char *&errorMsg) {
+  if (LoadedPluginLibraries.find(path) != LoadedPluginLibraries.end()) {
+    // Already loaded.
+    return false;
+  }
+  errorMsg = nullptr;
+  void *lib = nullptr;
+#if defined(_WIN32)
+  lib = LoadLibraryA(path.str().c_str());
+  if (!lib) {
+    errorMsg = "faild";
+    return true;
+  }
+#else
+  lib = dlopen(path.str().c_str(), RTLD_LAZY | RTLD_LOCAL);
+  if (!lib) {
+    errorMsg = "Unsupported platform";
+    return true;
+  }
+#endif
+  LoadedPluginLibraries.insert({path, lib});
+  return false;
+}
+
+LoadedExecutablePlugin *
+PluginRegistry::loadExecutablePlugin(StringRef path, const char *&errorMsg) {
+  llvm::sys::fs::file_status stat;
+  if (auto err = llvm::sys::fs::status(path, stat)) {
+    errorMsg = err.message().c_str();
+  }
+
+  // See if the plugin is already loaded.
+  auto &plugin = LoadedPluginExecutables[path];
+  if (plugin) {
+    // See if the loaded one is still usable.
+    if (plugin->getLastModificationTime() == stat.getLastModificationTime())
+      return plugin.get();
+
+    // The plugin is updated. Close the previously opened plugin.
+    plugin = nullptr;
+  }
+
+  if (!llvm::sys::fs::exists(stat)) {
+    errorMsg = "not found";
+    return nullptr;
+  }
+
+  if (!llvm::sys::fs::can_execute(path)) {
+    errorMsg = "not executable";
+    return nullptr;
+  }
+
+  // Create command line arguments.
+  SmallVector<StringRef, 4> command{path};
+
+  // Apply sandboxing.
+  llvm::BumpPtrAllocator Allocator;
+  Sandbox::apply(command, Allocator);
+
+  // Launch.
+  auto childInfo = ExecuteWithPipe(command[0], command);
+  if (!childInfo) {
+    errorMsg = "Failed to execute";
+    return nullptr;
+  }
+
+  plugin = std::unique_ptr<LoadedExecutablePlugin>(new LoadedExecutablePlugin(
+      childInfo->Pid, stat.getLastModificationTime(),
+      childInfo->ReadFileDescriptor, childInfo->WriteFileDescriptor));
+
+  return plugin.get();
+}
+
+LoadedExecutablePlugin::LoadedExecutablePlugin(
+    llvm::sys::procid_t pid, llvm::sys::TimePoint<> LastModificationTime,
+    int inputFileDescriptor, int outputFileDescriptor)
+    : pid(pid), LastModificationTime(LastModificationTime),
+      inputFileDescriptor(inputFileDescriptor),
+      outputFileDescriptor(outputFileDescriptor) {}
+
+LoadedExecutablePlugin::~LoadedExecutablePlugin() {
+  // Close the pipes.
+  close(inputFileDescriptor);
+  close(outputFileDescriptor);
+
+  // Let ASTGen to cleanup things.
+  this->cleanup();
+}
+
+ssize_t LoadedExecutablePlugin::read(void *buf, size_t nbyte) const {
+  ssize_t bytesToRead = nbyte;
+  void *ptr = buf;
+
+  while (bytesToRead > 0) {
+    ssize_t readingSize = std::min(ssize_t(INT32_MAX), bytesToRead);
+    ssize_t readSize = ::read(inputFileDescriptor, ptr, readingSize);
+    if (readSize == 0) {
+      break;
+    }
+    ptr = static_cast<char *>(ptr) + readSize;
+    bytesToRead -= readSize;
+  }
+
+  return nbyte - bytesToRead;
+}
+
+ssize_t LoadedExecutablePlugin::write(const void *buf, size_t nbyte) const {
+  ssize_t bytesToWrite = nbyte;
+  const void *ptr = buf;
+
+  while (bytesToWrite > 0) {
+    ssize_t writingSize = std::min(ssize_t(INT32_MAX), bytesToWrite);
+    ssize_t writtenSize = ::write(outputFileDescriptor, ptr, writingSize);
+    if (writtenSize == 0) {
+      break;
+    }
+    ptr = static_cast<const char *>(ptr) + writtenSize;
+    bytesToWrite -= writtenSize;
+  }
+  return nbyte - bytesToWrite;
+}
+
+bool LoadedExecutablePlugin::sendMessage(llvm::StringRef message) const {
+  ssize_t writtenSize = 0;
+
+  const char *data = message.data();
+  size_t size = message.size();
+
+  // Write header (message size).
+  uint64_t header = llvm::support::endian::byte_swap(
+      uint64_t(size), llvm::support::endianness::little);
+  writtenSize = write(&header, sizeof(header));
+  assert(writtenSize == sizeof(header) &&
+         "failed to write plugin message header");
+
+  // Write message.
+  writtenSize = write(data, size);
+  assert(writtenSize == ssize_t(size) && "failed to write plugin message data");
+
+  return false;
+}
+
+std::string LoadedExecutablePlugin::waitForNextMessage() const {
+  ssize_t readSize = 0;
+
+  // Read header (message size).
+  uint64_t header;
+  readSize = read(&header, sizeof(header));
+
+  // FIXME: Error handling. Disconnection, etc.
+  assert(readSize == sizeof(header) && "failed to read plugin message header");
+
+  size_t size = llvm::support::endian::read<uint64_t>(
+      &header, llvm::support::endianness::little);
+
+  // Read message.
+  std::string message;
+  message.reserve(size);
+  auto sizeToRead = size;
+  while (sizeToRead > 0) {
+    char buffer[4096];
+    readSize = read(buffer, std::min(sizeof(buffer), sizeToRead));
+    sizeToRead -= readSize;
+    message.append(buffer, readSize);
+  }
+
+  return message;
+}

--- a/lib/AST/PluginRegistry.cpp
+++ b/lib/AST/PluginRegistry.cpp
@@ -56,7 +56,7 @@ llvm::Error PluginRegistry::loadLibraryPlugin(StringRef path) {
 #else
   lib = dlopen(path.str().c_str(), RTLD_LAZY | RTLD_LOCAL);
   if (!lib) {
-    return llvm::createStringError(std::error_code(), dlerror());
+    return llvm::createStringError(llvm::inconvertibleErrorCode(), dlerror());
   }
 #endif
   LoadedPluginLibraries.insert({path, lib});

--- a/lib/AST/PluginRegistry.cpp
+++ b/lib/AST/PluginRegistry.cpp
@@ -50,14 +50,13 @@ llvm::Error PluginRegistry::loadLibraryPlugin(StringRef path) {
 #if defined(_WIN32)
   lib = LoadLibraryA(path.str().c_str());
   if (!lib) {
-    return llvm::createStringError(std::errc::not_supported, "failed");
-    return true;
+    std::error_code ec(GetLastError(), std::system_category());
+    return llvm::errorCodeToError(ec);
   }
 #else
   lib = dlopen(path.str().c_str(), RTLD_LAZY | RTLD_LOCAL);
   if (!lib) {
-    return llvm::createStringError(std::errc::not_supported,
-                                   "unsupported platform");
+    return llvm::createStringError(std::error_code(), dlerror());
   }
 #endif
   LoadedPluginLibraries.insert({path, lib});

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -28,6 +28,8 @@ if (SWIFT_SWIFT_PARSER)
     Sources/ASTGen/LLVMJSON.swift
     Sources/ASTGen/Macros.swift
     Sources/ASTGen/Misc.swift
+    Sources/ASTGen/PluginHost.swift
+    Sources/ASTGen/PluginMessages.swift
     Sources/ASTGen/SourceFile.swift
     Sources/ASTGen/SourceManager.swift
     Sources/ASTGen/SourceManager+MacroExpansionContext.swift

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -109,13 +109,13 @@ public func resolveExecutableMacro(
   moduleNameLength: Int,
   typeName: UnsafePointer<UInt8>,
   typeNameLength: Int,
-  pluginOpaqueHanle: UnsafeMutableRawPointer
+  pluginOpaqueHandle: UnsafeMutableRawPointer
 ) -> UnsafeRawPointer {
   let exportedPtr = UnsafeMutablePointer<ExportedExecutableMacro>.allocate(capacity: 1)
   exportedPtr.initialize(to: .init(
     moduleName: String(bufferStart: moduleName, count: moduleNameLength),
     typeName: String(bufferStart: typeName, count: typeNameLength),
-    plugin: CompilerPlugin(opaqueHandle: pluginOpaqueHanle)))
+    plugin: CompilerPlugin(opaqueHandle: pluginOpaqueHandle)))
   return UnsafeRawPointer(exportedPtr)
 }
 

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -205,18 +205,14 @@ func expandFreestandingMacro(
       diagEnginePtr: diagEnginePtr,
       macroSyntax: macroSyntax,
       sourceFilePtr: sourceFilePtr,
-      discriminator: discriminator,
-      expandedSourcePointer: expandedSourcePointer,
-      expandedSourceLength: expandedSourceLength)
+      discriminator: discriminator)
   case .Executable:
     expandedSource = expandFreestandingMacroIPC(
       macroPtr: macroPtr,
       diagEnginePtr: diagEnginePtr,
       macroSyntax: macroSyntax,
       sourceFilePtr: sourceFilePtr,
-      discriminator: discriminator,
-      expandedSourcePointer: expandedSourcePointer,
-      expandedSourceLength: expandedSourceLength)
+      discriminator: discriminator)
   }
 
   guard var expandedSource = expandedSource else {
@@ -243,9 +239,7 @@ func expandFreestandingMacroIPC(
   diagEnginePtr: UnsafeMutablePointer<UInt8>,
   macroSyntax: Syntax,
   sourceFilePtr: UnsafePointer<ExportedSourceFile>,
-  discriminator: String,
-  expandedSourcePointer: UnsafeMutablePointer<UnsafePointer<UInt8>?>,
-  expandedSourceLength: UnsafeMutablePointer<Int>
+  discriminator: String
 ) -> String? {
 
   let macroName: String
@@ -291,9 +285,7 @@ func expandFreestandingMacroInProcess(
   diagEnginePtr: UnsafeMutablePointer<UInt8>,
   macroSyntax: Syntax,
   sourceFilePtr: UnsafePointer<ExportedSourceFile>,
-  discriminator: String,
-  expandedSourcePointer: UnsafeMutablePointer<UnsafePointer<UInt8>?>,
-  expandedSourceLength: UnsafeMutablePointer<Int>
+  discriminator: String
 ) -> String? {
 
   // Create a source manager. This should probably persist and be given to us.
@@ -492,9 +484,7 @@ func expandAttachedMacro(
       declarationSourceFilePtr: declarationSourceFilePtr,
       attachedTo: declarationNode,
       parentDeclSourceFilePtr: parentDeclSourceFilePtr,
-      parentDeclNode: parentDeclNode,
-      expandedSourcePointer: expandedSourcePointer,
-      expandedSourceLength: expandedSourceLength)
+      parentDeclNode: parentDeclNode)
   case .InProcess:
     expandedSources = expandAttachedMacroInProcess(
       diagEnginePtr: diagEnginePtr,
@@ -506,9 +496,7 @@ func expandAttachedMacro(
       declarationSourceFilePtr: declarationSourceFilePtr,
       attachedTo: declarationNode,
       parentDeclSourceFilePtr: parentDeclSourceFilePtr,
-      parentDeclNode: parentDeclNode,
-      expandedSourcePointer: expandedSourcePointer,
-      expandedSourceLength: expandedSourceLength)
+      parentDeclNode: parentDeclNode)
   }
 
   guard let expandedSources = expandedSources else {
@@ -556,9 +544,7 @@ func expandAttachedMacroIPC(
   declarationSourceFilePtr: UnsafePointer<ExportedSourceFile>,
   attachedTo declarationNode: DeclSyntax,
   parentDeclSourceFilePtr: UnsafePointer<ExportedSourceFile>?,
-  parentDeclNode: DeclSyntax?,
-  expandedSourcePointer: UnsafeMutablePointer<UnsafePointer<UInt8>?>,
-  expandedSourceLength: UnsafeMutablePointer<Int>
+  parentDeclNode: DeclSyntax?
 ) -> [String]? {
   let macroName: String = customAttrNode.attributeName.description
   let macro = macroPtr.assumingMemoryBound(to: ExportedExecutableMacro.self).pointee
@@ -634,9 +620,7 @@ func expandAttachedMacroInProcess(
   declarationSourceFilePtr: UnsafePointer<ExportedSourceFile>,
   attachedTo declarationNode: DeclSyntax,
   parentDeclSourceFilePtr: UnsafePointer<ExportedSourceFile>?,
-  parentDeclNode: DeclSyntax?,
-  expandedSourcePointer: UnsafeMutablePointer<UnsafePointer<UInt8>?>,
-  expandedSourceLength: UnsafeMutablePointer<Int>
+  parentDeclNode: DeclSyntax?
 ) -> [String]? {
   // Get the macro.
   let macroPtr = macroPtr.bindMemory(to: ExportedMacro.self, capacity: 1)

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -1,3 +1,15 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2022-2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
 import SwiftDiagnostics
 import SwiftOperators
 import SwiftParser
@@ -32,6 +44,17 @@ struct ExportedMacro {
   var macro: Macro.Type
 }
 
+struct ExportedExecutableMacro {
+  var moduleName: String
+  var typeName: String
+  var plugin: CompilerPlugin
+}
+
+enum MacroPluginKind: UInt8 {
+  case InProcess = 0
+  case Executable = 1
+}
+
 enum MacroRole: UInt8 {
   case Expression = 0x01
   case FreestandingDeclaration = 0x02
@@ -39,6 +62,13 @@ enum MacroRole: UInt8 {
   case MemberAttribute = 0x08
   case Member = 0x10
   case Peer = 0x20
+}
+
+extension String {
+  public init(bufferStart: UnsafePointer<UInt8>?, count: Int) {
+    let buffer = UnsafeBufferPointer(start: bufferStart, count: count)
+    self.init(decoding: buffer, as: UTF8.self)
+  }
 }
 
 /// Resolve a reference to type metadata into a macro, if posible.
@@ -71,6 +101,31 @@ public func destroyMacro(
     macro.deinitialize(count: 1)
     macro.deallocate()
   }
+}
+
+@_cdecl("swift_ASTGen_resolveExecutableMacro")
+public func resolveExecutableMacro(
+  moduleName: UnsafePointer<UInt8>,
+  moduleNameLength: Int,
+  typeName: UnsafePointer<UInt8>,
+  typeNameLength: Int,
+  pluginOpaqueHanle: UnsafeMutableRawPointer
+) -> UnsafeRawPointer {
+  let exportedPtr = UnsafeMutablePointer<ExportedExecutableMacro>.allocate(capacity: 1)
+  exportedPtr.initialize(to: .init(
+    moduleName: String(bufferStart: moduleName, count: moduleNameLength),
+    typeName: String(bufferStart: typeName, count: typeNameLength),
+    plugin: CompilerPlugin(opaqueHandle: pluginOpaqueHanle)))
+  return UnsafeRawPointer(exportedPtr)
+}
+
+@_cdecl("swift_ASTGen_destroyExecutableMacro")
+public func destroyExecutableMacro(
+  macroPtr: UnsafeMutableRawPointer
+) {
+  let macroPtr = macroPtr.assumingMemoryBound(to: ExportedExecutableMacro.self)
+  macroPtr.deinitialize(count: 1)
+  macroPtr.deallocate()
 }
 
 /// Allocate a copy of the given string as a UTF-8 string.
@@ -107,11 +162,13 @@ fileprivate struct ThrownErrorDiagnostic: DiagnosticMessage {
   }
 }
 
+
 @_cdecl("swift_ASTGen_expandFreestandingMacro")
 @usableFromInline
 func expandFreestandingMacro(
   diagEnginePtr: UnsafeMutablePointer<UInt8>,
   macroPtr: UnsafeRawPointer,
+  macroKind: UInt8,
   discriminatorText: UnsafePointer<UInt8>,
   discriminatorTextLength: Int,
   sourceFilePtr: UnsafeRawPointer,
@@ -129,36 +186,123 @@ func expandFreestandingMacro(
   }
 
   let sourceFilePtr = sourceFilePtr.bindMemory(to: ExportedSourceFile.self, capacity: 1)
-  // Find the offset.
-  let buffer = sourceFilePtr.pointee.buffer
-  let offset = sourceLocationPtr - buffer.baseAddress!
-  if offset < 0 || offset >= buffer.count {
-    print("source location isn't inside this buffer")
-    return -1
-  }
 
-  let sf = sourceFilePtr.pointee.syntax
-  guard let token = sf.token(at: AbsolutePosition(utf8Offset: offset)) else {
-    print("couldn't find token at offset \(offset)")
-    return -1
+  guard let macroSyntax = findSyntaxNodeInSourceFile(
+    sourceFilePtr: sourceFilePtr, sourceLocationPtr: sourceLocationPtr, type: Syntax.self) else {
+    return 1
   }
-
-  // Create a source manager. This should probably persist and be given to us.
-  let sourceManager = SourceManager(cxxDiagnosticEngine: diagEnginePtr)
-  sourceManager.insert(sourceFilePtr)
 
   let discriminatorBuffer = UnsafeBufferPointer(
     start: discriminatorText, count: discriminatorTextLength
   )
   let discriminator = String(decoding: discriminatorBuffer, as: UTF8.self)
+
+  let expandedSource: String?
+  switch MacroPluginKind(rawValue: macroKind)! {
+  case .InProcess:
+    expandedSource = expandFreestandingMacroInProcess(
+      macroPtr: macroPtr,
+      diagEnginePtr: diagEnginePtr,
+      macroSyntax: macroSyntax,
+      sourceFilePtr: sourceFilePtr,
+      discriminator: discriminator,
+      expandedSourcePointer: expandedSourcePointer,
+      expandedSourceLength: expandedSourceLength)
+  case .Executable:
+    expandedSource = expandFreestandingMacroIPC(
+      macroPtr: macroPtr,
+      diagEnginePtr: diagEnginePtr,
+      macroSyntax: macroSyntax,
+      sourceFilePtr: sourceFilePtr,
+      discriminator: discriminator,
+      expandedSourcePointer: expandedSourcePointer,
+      expandedSourceLength: expandedSourceLength)
+  }
+
+  guard var expandedSource = expandedSource else {
+    return -1
+  }
+
+  // Form the result buffer for our caller.
+  expandedSource.withUTF8 { utf8 in
+    let evaluatedResultPtr = UnsafeMutablePointer<UInt8>.allocate(capacity: utf8.count + 1)
+    if let baseAddress = utf8.baseAddress {
+      evaluatedResultPtr.initialize(from: baseAddress, count: utf8.count)
+    }
+    evaluatedResultPtr[utf8.count] = 0
+
+    expandedSourcePointer.pointee = UnsafePointer(evaluatedResultPtr)
+    expandedSourceLength.pointee = utf8.count
+  }
+
+  return 0
+}
+
+func expandFreestandingMacroIPC(
+  macroPtr: UnsafeRawPointer,
+  diagEnginePtr: UnsafeMutablePointer<UInt8>,
+  macroSyntax: Syntax,
+  sourceFilePtr: UnsafePointer<ExportedSourceFile>,
+  discriminator: String,
+  expandedSourcePointer: UnsafeMutablePointer<UnsafePointer<UInt8>?>,
+  expandedSourceLength: UnsafeMutablePointer<Int>
+) -> String? {
+
+  let macroName: String
+  if let exprSyntax = macroSyntax.as(MacroExpansionExprSyntax.self) {
+    macroName = exprSyntax.macro.text
+  } else if let declSyntax = macroSyntax.as(MacroExpansionDeclSyntax.self) {
+    macroName = declSyntax.macro.text
+  } else {
+    fatalError("unknown syntax")
+  }
+
+  let macro = macroPtr.assumingMemoryBound(to: ExportedExecutableMacro.self).pointee
+
+  let message = HostToPluginMessage.expandFreestandingMacro(
+    macro: .init(moduleName: macro.moduleName, typeName: macro.typeName, name: macroName),
+    discriminator: discriminator,
+    syntax: PluginMessage.Syntax(syntax: macroSyntax, in: sourceFilePtr)!)
+
+  do {
+    let result = try macro.plugin.sendMessageAndWait(message)
+    switch result {
+    case .expandFreestandingMacroResult(var expandedSource, let diagnostics):
+      if !diagnostics.isEmpty {
+        let diagEngine = PluginDiagnosticsEngine(cxxDiagnosticEngine: diagEnginePtr)
+        diagEngine.add(exportedSourceFile: sourceFilePtr)
+
+        for diagnostic in diagnostics {
+          diagEngine.emit(diagnostic, messageSuffix: " (from macro '\(macroName)')")
+        }
+      }
+      return expandedSource
+
+    default:
+      fatalError("unexpected result")
+    }
+  } catch let error {
+    fatalError("\(error)")
+  }
+}
+
+func expandFreestandingMacroInProcess(
+  macroPtr: UnsafeRawPointer,
+  diagEnginePtr: UnsafeMutablePointer<UInt8>,
+  macroSyntax: Syntax,
+  sourceFilePtr: UnsafePointer<ExportedSourceFile>,
+  discriminator: String,
+  expandedSourcePointer: UnsafeMutablePointer<UnsafePointer<UInt8>?>,
+  expandedSourceLength: UnsafeMutablePointer<Int>
+) -> String? {
+
+  // Create a source manager. This should probably persist and be given to us.
+  let sourceManager = SourceManager(cxxDiagnosticEngine: diagEnginePtr)
+  sourceManager.insert(sourceFilePtr)
+
   let context = sourceManager.createMacroExpansionContext(
     discriminator: discriminator
   )
-
-  guard let parentSyntax = token.parent else {
-    print("not on a macro expansion node: \(token.recursiveDescription)")
-    return -1
-  }
 
   let macroPtr = macroPtr.bindMemory(to: ExportedMacro.self, capacity: 1)
 
@@ -168,11 +312,11 @@ func expandFreestandingMacro(
     switch macroPtr.pointee.macro {
     // Handle expression macro.
     case let exprMacro as ExpressionMacro.Type:
-      guard let parentExpansion = parentSyntax.asProtocol(
+      guard let parentExpansion = macroSyntax.asProtocol(
         FreestandingMacroExpansionSyntax.self
       ) else {
-        print("not on a macro expansion node: \(parentSyntax.recursiveDescription)")
-        return -1
+        print("not on a macro expansion node: \(macroSyntax.recursiveDescription)")
+        return nil
       }
 
       macroName = parentExpansion.macro.text
@@ -196,9 +340,9 @@ func expandFreestandingMacro(
     // Handle declaration macro. The resulting decls are wrapped in a
     // `CodeBlockItemListSyntax`.
     case let declMacro as DeclarationMacro.Type:
-      guard let parentExpansion = parentSyntax.as(MacroExpansionDeclSyntax.self) else {
-        print("not on a macro expansion node: \(token.recursiveDescription)")
-        return -1
+      guard let parentExpansion = macroSyntax.as(MacroExpansionDeclSyntax.self) else {
+        print("not on a macro expansion node: \(macroSyntax.recursiveDescription)")
+        return nil
       }
       macroName = parentExpansion.macro.text
       let decls = try declMacro.expansion(
@@ -213,18 +357,18 @@ func expandFreestandingMacro(
 
     default:
       print("not an expression macro or a freestanding declaration macro")
-      return -1
+      return nil
     }
   } catch {
     // Record the error
     sourceManager.diagnose(
       diagnostic: Diagnostic(
-        node: parentSyntax,
+        node: macroSyntax,
         message: ThrownErrorDiagnostic(message: String(describing: error))
       ),
       messageSuffix: " (from macro '\(macroName)')"
     )
-    return -1
+    return nil
   }
 
   // Emit diagnostics accumulated in the context.
@@ -235,19 +379,7 @@ func expandFreestandingMacro(
     )
   }
 
-  var evaluatedSyntaxStr = evaluatedSyntax.trimmedDescription
-  evaluatedSyntaxStr.withUTF8 { utf8 in
-    let evaluatedResultPtr = UnsafeMutablePointer<UInt8>.allocate(capacity: utf8.count + 1)
-    if let baseAddress = utf8.baseAddress {
-      evaluatedResultPtr.initialize(from: baseAddress, count: utf8.count)
-    }
-    evaluatedResultPtr[utf8.count] = 0
-
-    expandedSourcePointer.pointee = UnsafePointer(evaluatedResultPtr)
-    expandedSourceLength.pointee = utf8.count
-  }
-
-  return 0
+  return evaluatedSyntax.trimmedDescription
 }
 
 /// Retrieve a syntax node in the given source file, with the given type.
@@ -293,6 +425,7 @@ private func findSyntaxNodeInSourceFile<Node: SyntaxProtocol>(
 func expandAttachedMacro(
   diagEnginePtr: UnsafeMutablePointer<UInt8>,
   macroPtr: UnsafeRawPointer,
+  macroKind: UInt8,
   discriminatorText: UnsafePointer<UInt8>,
   discriminatorTextLength: Int,
   rawMacroRole: UInt8,
@@ -300,7 +433,7 @@ func expandAttachedMacro(
   customAttrSourceLocPointer: UnsafePointer<UInt8>?,
   declarationSourceFilePtr: UnsafeRawPointer,
   attachedTo declarationSourceLocPointer: UnsafePointer<UInt8>?,
-  parentDeclSourceFilePtr: UnsafeRawPointer,
+  parentDeclSourceFilePtr: UnsafeRawPointer?,
   parentDeclSourceLocPointer: UnsafePointer<UInt8>?,
   expandedSourcePointer: UnsafeMutablePointer<UnsafePointer<UInt8>?>,
   expandedSourceLength: UnsafeMutablePointer<Int>
@@ -328,34 +461,203 @@ func expandAttachedMacro(
     return 1
   }
 
+  var parentDeclNode: DeclSyntax?
+  if let parentDeclSourceFilePtr = parentDeclSourceFilePtr {
+    parentDeclNode = findSyntaxNodeInSourceFile(
+      sourceFilePtr: parentDeclSourceFilePtr,
+      sourceLocationPtr: parentDeclSourceLocPointer,
+      type: DeclSyntax.self
+    )
+  }
+
+  let customAttrSourceFilePtr = customAttrSourceFilePtr.bindMemory(to: ExportedSourceFile.self, capacity: 1)
+  let declarationSourceFilePtr = declarationSourceFilePtr.bindMemory(to: ExportedSourceFile.self, capacity: 1)
+  let parentDeclSourceFilePtr = parentDeclSourceFilePtr?.bindMemory(to: ExportedSourceFile.self, capacity: 1)
+
+  let discriminatorBuffer = UnsafeBufferPointer(
+    start: discriminatorText, count: discriminatorTextLength
+  )
+  let discriminator = String(decoding: discriminatorBuffer, as: UTF8.self)
+
+  let expandedSources: [String]?
+  switch MacroPluginKind(rawValue: macroKind)! {
+  case .Executable:
+    expandedSources = expandAttachedMacroIPC(
+      diagEnginePtr: diagEnginePtr,
+      macroPtr: macroPtr,
+      rawMacroRole: rawMacroRole,
+      discriminator: discriminator,
+      customAttrSourceFilePtr: customAttrSourceFilePtr,
+      customAttrNode: customAttrNode,
+      declarationSourceFilePtr: declarationSourceFilePtr,
+      attachedTo: declarationNode,
+      parentDeclSourceFilePtr: parentDeclSourceFilePtr,
+      parentDeclNode: parentDeclNode,
+      expandedSourcePointer: expandedSourcePointer,
+      expandedSourceLength: expandedSourceLength)
+  case .InProcess:
+    expandedSources = expandAttachedMacroInProcess(
+      diagEnginePtr: diagEnginePtr,
+      macroPtr: macroPtr,
+      rawMacroRole: rawMacroRole,
+      discriminator: discriminator,
+      customAttrSourceFilePtr: customAttrSourceFilePtr,
+      customAttrNode: customAttrNode,
+      declarationSourceFilePtr: declarationSourceFilePtr,
+      attachedTo: declarationNode,
+      parentDeclSourceFilePtr: parentDeclSourceFilePtr,
+      parentDeclNode: parentDeclNode,
+      expandedSourcePointer: expandedSourcePointer,
+      expandedSourceLength: expandedSourceLength)
+  }
+
+  guard let expandedSources = expandedSources else {
+    return -1
+  }
+
+  // Fixup the source.
+  var expandedSource: String
+  switch MacroRole(rawValue: rawMacroRole)! {
+  case .Accessor:
+    expandedSource = expandedSources.joined(separator: "\n\n")
+  case .Member:
+    expandedSource = expandedSources.joined(separator: "\n\n")
+  case .MemberAttribute:
+    expandedSource = expandedSources.joined(separator: " ")
+  case .Peer:
+    expandedSource = expandedSources.joined(separator: "\n\n")
+  case .Expression,
+      .FreestandingDeclaration:
+    fatalError("unreachable")
+  }
+
+  // Form the result buffer for our caller.
+  expandedSource.withUTF8 { utf8 in
+    let evaluatedResultPtr = UnsafeMutablePointer<UInt8>.allocate(capacity: utf8.count + 1)
+    if let baseAddress = utf8.baseAddress {
+      evaluatedResultPtr.initialize(from: baseAddress, count: utf8.count)
+    }
+    evaluatedResultPtr[utf8.count] = 0
+
+    expandedSourcePointer.pointee = UnsafePointer(evaluatedResultPtr)
+    expandedSourceLength.pointee = utf8.count
+  }
+
+  return 0
+}
+
+func expandAttachedMacroIPC(
+  diagEnginePtr: UnsafeMutablePointer<UInt8>,
+  macroPtr: UnsafeRawPointer,
+  rawMacroRole: UInt8,
+  discriminator: String,
+  customAttrSourceFilePtr: UnsafePointer<ExportedSourceFile>,
+  customAttrNode: AttributeSyntax,
+  declarationSourceFilePtr: UnsafePointer<ExportedSourceFile>,
+  attachedTo declarationNode: DeclSyntax,
+  parentDeclSourceFilePtr: UnsafePointer<ExportedSourceFile>?,
+  parentDeclNode: DeclSyntax?,
+  expandedSourcePointer: UnsafeMutablePointer<UnsafePointer<UInt8>?>,
+  expandedSourceLength: UnsafeMutablePointer<Int>
+) -> [String]? {
+  let macroName: String = customAttrNode.attributeName.description
+  let macro = macroPtr.assumingMemoryBound(to: ExportedExecutableMacro.self).pointee
+
+  // Map the macro role.
+  let macroRole: PluginMessage.MacroRole
+  switch MacroRole(rawValue: rawMacroRole) {
+  case .Accessor: macroRole = .accessor
+  case .Member: macroRole = .member
+  case .MemberAttribute: macroRole = .memberAttribute
+  case .Peer: macroRole = .peer
+  default:
+    preconditionFailure("unhandled macro role for attached macro")
+  }
+
+  // Prepare syntax nodes to transfer.
+  let customAttributeSyntax = PluginMessage.Syntax(
+    syntax: Syntax(customAttrNode), in: customAttrSourceFilePtr)!
+
+  let declSyntax = PluginMessage.Syntax(
+    syntax: Syntax(declarationNode), in: customAttrSourceFilePtr)!
+
+  let parentDeclSyntax: PluginMessage.Syntax?
+  if parentDeclNode != nil {
+    parentDeclSyntax = .init(syntax: Syntax(parentDeclNode!), in: parentDeclSourceFilePtr!)!
+  } else {
+    parentDeclSyntax = nil
+  }
+
+  let message = HostToPluginMessage.expandAttachedMacro(
+    macro: .init(moduleName: macro.moduleName, typeName: macro.typeName, name: macroName),
+    macroRole: macroRole,
+    discriminator: discriminator,
+    customAttributeSyntax: customAttributeSyntax,
+    declSyntax: declSyntax,
+    parentDeclSyntax: parentDeclSyntax)
+  do {
+    let result = try macro.plugin.sendMessageAndWait(message)
+    switch result {
+    case .expandAttachedMacroResult(let expandedSources, let diagnostics):
+      // Form the result buffer for our caller.
+
+      if !diagnostics.isEmpty {
+        let diagEngine = PluginDiagnosticsEngine(cxxDiagnosticEngine: diagEnginePtr)
+        diagEngine.add(exportedSourceFile: customAttrSourceFilePtr)
+        diagEngine.add(exportedSourceFile: declarationSourceFilePtr)
+        if let parentDeclSourceFilePtr = parentDeclSourceFilePtr {
+          diagEngine.add(exportedSourceFile: parentDeclSourceFilePtr)
+        }
+
+        for diagnostic in diagnostics {
+          diagEngine.emit(diagnostic, messageSuffix: " (from macro '\(macroName)')")
+        }
+
+      }
+      return expandedSources
+
+    default:
+      fatalError("unexpected result")
+    }
+  } catch let error {
+    fatalError("\(error)")
+  }
+}
+
+func expandAttachedMacroInProcess(
+  diagEnginePtr: UnsafeMutablePointer<UInt8>,
+  macroPtr: UnsafeRawPointer,
+  rawMacroRole: UInt8,
+  discriminator: String,
+  customAttrSourceFilePtr: UnsafePointer<ExportedSourceFile>,
+  customAttrNode: AttributeSyntax,
+  declarationSourceFilePtr: UnsafePointer<ExportedSourceFile>,
+  attachedTo declarationNode: DeclSyntax,
+  parentDeclSourceFilePtr: UnsafePointer<ExportedSourceFile>?,
+  parentDeclNode: DeclSyntax?,
+  expandedSourcePointer: UnsafeMutablePointer<UnsafePointer<UInt8>?>,
+  expandedSourceLength: UnsafeMutablePointer<Int>
+) -> [String]? {
   // Get the macro.
   let macroPtr = macroPtr.bindMemory(to: ExportedMacro.self, capacity: 1)
   let macro = macroPtr.pointee.macro
   let macroRole = MacroRole(rawValue: rawMacroRole)
 
-  let attributeSourceFile = customAttrSourceFilePtr.bindMemory(
-    to: ExportedSourceFile.self, capacity: 1
-  )
-  let declarationSourceFilePtr = declarationSourceFilePtr.bindMemory(
-    to: ExportedSourceFile.self, capacity: 1
-  )
-
   // Create a source manager covering the files we know about.
   let sourceManager = SourceManager(cxxDiagnosticEngine: diagEnginePtr)
-  sourceManager.insert(attributeSourceFile)
+  sourceManager.insert(customAttrSourceFilePtr)
   sourceManager.insert(declarationSourceFilePtr)
+  if let parentDeclSourceFilePtr = parentDeclSourceFilePtr {
+    sourceManager.insert(parentDeclSourceFilePtr)
+  }
 
   // Create an expansion context
-  let discriminatorBuffer = UnsafeBufferPointer(
-    start: discriminatorText, count: discriminatorTextLength
-  )
-  let discriminator = String(decoding: discriminatorBuffer, as: UTF8.self)
   let context = sourceManager.createMacroExpansionContext(
     discriminator: discriminator
   )
 
   let macroName = customAttrNode.attributeName.trimmedDescription
-  var evaluatedSyntaxStr: String
+  var expandedSources: [String]
   do {
     switch (macro, macroRole) {
     case (let attachedMacro as AccessorMacro.Type, .Accessor):
@@ -369,21 +671,17 @@ func expandAttachedMacro(
       )
 
       // Form a buffer of accessor declarations to return to the caller.
-      evaluatedSyntaxStr = accessors.map {
+      expandedSources = accessors.map {
         $0.trimmedDescription
-      }.joined(separator: "\n\n")
+      }
 
     case (let attachedMacro as MemberAttributeMacro.Type, .MemberAttribute):
       // Dig out the node for the parent declaration of the to-expand
       // declaration. Only member attribute macros need this.
-      guard let parentDeclNode = findSyntaxNodeInSourceFile(
-        sourceFilePtr: parentDeclSourceFilePtr,
-        sourceLocationPtr: parentDeclSourceLocPointer,
-        type: DeclSyntax.self
-      ),
+      guard let parentDeclNode = parentDeclNode,
             let parentDeclGroup = parentDeclNode.asProtocol(DeclGroupSyntax.self)
       else {
-        return 1
+        return nil
       }
 
       // Local function to expand a member atribute macro once we've opened up
@@ -407,14 +705,14 @@ func expandAttachedMacro(
       )
 
       // Form a buffer containing an attribute list to return to the caller.
-      evaluatedSyntaxStr = attributes.map {
+      expandedSources = attributes.map {
         $0.trimmedDescription
-      }.joined(separator: " ")
+      }
 
     case (let attachedMacro as MemberMacro.Type, .Member):
       guard let declGroup = declarationNode.asProtocol(DeclGroupSyntax.self)
       else {
-        return 1
+        return nil
       }
 
       // Local function to expand a member macro once we've opened up
@@ -435,9 +733,9 @@ func expandAttachedMacro(
       let members = try _openExistential(declGroup, do: expandMemberMacro)
 
       // Form a buffer of member declarations to return to the caller.
-      evaluatedSyntaxStr = members.map {
+      expandedSources = members.map {
         $0.trimmedDescription
-      }.joined(separator: "\n\n")
+      }
 
     case (let attachedMacro as PeerMacro.Type, .Peer):
       let peers = try attachedMacro.expansion(
@@ -453,13 +751,13 @@ func expandAttachedMacro(
       )
 
       // Form a buffer of peer declarations to return to the caller.
-      evaluatedSyntaxStr = peers.map {
+      expandedSources = peers.map {
         $0.trimmedDescription
-      }.joined(separator: "\n\n")
+      }
 
     default:
       print("\(macroPtr) does not conform to any known attached macro protocol")
-      return 1
+      return nil
     }
   } catch {
     // Record the error
@@ -472,7 +770,7 @@ func expandAttachedMacro(
       messageSuffix: " (from macro '\(macroName)')"
     )
 
-    return 1
+    return nil
   }
 
   // Emit diagnostics accumulated in the context.
@@ -483,17 +781,5 @@ func expandAttachedMacro(
     )
   }
 
-  // Form the result buffer for our caller.
-  evaluatedSyntaxStr.withUTF8 { utf8 in
-    let evaluatedResultPtr = UnsafeMutablePointer<UInt8>.allocate(capacity: utf8.count + 1)
-    if let baseAddress = utf8.baseAddress {
-      evaluatedResultPtr.initialize(from: baseAddress, count: utf8.count)
-    }
-    evaluatedResultPtr[utf8.count] = 0
-
-    expandedSourcePointer.pointee = UnsafePointer(evaluatedResultPtr)
-    expandedSourceLength.pointee = utf8.count
-  }
-
-  return 0
+  return expandedSources
 }

--- a/lib/ASTGen/Sources/ASTGen/PluginHost.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginHost.swift
@@ -1,0 +1,284 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import CASTBridging
+import CBasicBridging
+import SwiftSyntax
+
+struct PluginError: Error {}
+
+@_cdecl("swift_ASTGen_initializePlugin")
+public func _initializePlugin(
+  opaqueHandle: UnsafeMutableRawPointer
+) {
+  let plugin = CompilerPlugin(opaqueHandle: opaqueHandle)
+  plugin.initialize()
+}
+
+@_cdecl("swift_ASTGen_deinitializePlugin")
+public func _deinitializePlugin(
+  opaqueHandle: UnsafeMutableRawPointer
+) {
+  let plugin =  CompilerPlugin(opaqueHandle: opaqueHandle)
+  plugin.deinitialize()
+}
+
+struct CompilerPlugin {
+  let opaqueHandle: UnsafeMutableRawPointer
+
+  private func withLock<R>(_ body: () throws -> R) rethrows -> R {
+    Plugin_lock(opaqueHandle)
+    defer { Plugin_unlock(opaqueHandle) }
+    return try body()
+  }
+
+  private func sendMessage(_ message: HostToPluginMessage) throws {
+    let hadError = try LLVMJSON.encoding(message) { (data) -> Bool in
+//      // FIXME: Add -dump-plugin-message option?
+//      data.withMemoryRebound(to: UInt8.self) { buffer in
+//        print(">> " + String(decoding: buffer, as: UTF8.self))
+//      }
+      return Plugin_sendMessage(opaqueHandle, BridgedData(baseAddress: data.baseAddress, size: data.count))
+    }
+    if hadError {
+      throw PluginError()
+    }
+  }
+
+  private func waitForNextMessage() throws -> PluginToHostMessage {
+    var result: BridgedData = BridgedData()
+    let hadError = Plugin_waitForNextMessage(opaqueHandle, &result)
+    defer { BridgedData_free(result) }
+    guard !hadError else {
+      throw PluginError()
+    }
+    let data = UnsafeBufferPointer(start: result.baseAddress, count: result.size)
+//    // FIXME: Add -dump-plugin-message option?
+//    data.withMemoryRebound(to: UInt8.self) { buffer in
+//      print("<< " + String(decoding: buffer, as: UTF8.self))
+//    }
+    return try LLVMJSON.decode(PluginToHostMessage.self, from: data)
+  }
+
+  func sendMessageAndWait(_ message: HostToPluginMessage) throws -> PluginToHostMessage {
+    try self.withLock {
+      try sendMessage(message)
+      return try waitForNextMessage()
+    }
+  }
+
+  func initialize() {
+    self.withLock {
+      // Get capability.
+      let response: PluginToHostMessage
+      do {
+        try self.sendMessage(.getCapability)
+        response = try self.waitForNextMessage()
+      } catch {
+        assertionFailure(String(describing: error))
+        return
+      }
+      switch response {
+      case .getCapabilityResult(capability: let capability):
+        let ptr = UnsafeMutablePointer<PluginMessage.PluginCapability>.allocate(capacity: 1)
+        ptr.initialize(to: capability)
+        Plugin_setCapability(opaqueHandle, UnsafeRawPointer(ptr))
+      default:
+        assertionFailure("invalid response")
+      }
+    }
+  }
+  func deinitialize() {
+    self.withLock {
+      if let ptr = Plugin_getCapability(opaqueHandle) {
+        let capabilityPtr = UnsafeMutableRawPointer(mutating: ptr)
+          .assumingMemoryBound(to: PluginMessage.PluginCapability.self)
+        capabilityPtr.deinitialize(count: 1)
+        capabilityPtr.deallocate()
+      }
+    }
+  }
+
+  var capability: PluginMessage.PluginCapability {
+    if let ptr = Plugin_getCapability(opaqueHandle) {
+      return ptr.assumingMemoryBound(to: PluginMessage.PluginCapability.self).pointee
+    }
+    return PluginMessage.PluginCapability(protocolVersion: 0)
+  }
+}
+
+class PluginDiagnosticsEngine {
+  private let cxxDiagnosticEngine: UnsafeMutablePointer<UInt8>
+  private var exportedSourceFileByName: [String: UnsafePointer<ExportedSourceFile>] = [:]
+
+  init(cxxDiagnosticEngine: UnsafeMutablePointer<UInt8>) {
+    self.cxxDiagnosticEngine = cxxDiagnosticEngine
+  }
+
+  /// Register an 'ExportedSourceFile' to the engine. So the engine can get
+  /// C++ SourceLoc from a pair of filename and offset.
+  func add(exportedSourceFile: UnsafePointer<ExportedSourceFile>) {
+    exportedSourceFileByName[exportedSourceFile.pointee.fileName] = exportedSourceFile
+  }
+
+  /// Emit a diagnostic to C++ diagnostic engine. Note that one plugin
+  /// diagnostic can emits multiple C++ diagnostics.
+  func emit(
+    _ diagnostic: PluginMessage.Diagnostic,
+    messageSuffix: String? = nil
+  ) {
+
+    // Emit the main diagnostic.
+    emitSingle(
+      message: diagnostic.message + (messageSuffix ?? ""),
+      severity: diagnostic.severity,
+      position: diagnostic.position,
+      highlights: diagnostic.highlights)
+
+    // Emit Fix-Its.
+    for fixIt in diagnostic.fixIts {
+      emitSingle(
+        message: fixIt.message,
+        severity: .note,
+        position: diagnostic.position,
+        fixItChanges: fixIt.changes)
+    }
+
+    // Emit any notes as follow-ons.
+    for note in diagnostic.notes {
+      emitSingle(
+        message: note.message,
+        severity: .note,
+        position: note.position)
+    }
+  }
+  /// Emit single C++ diagnostic.
+  private func emitSingle(
+    message: String,
+    severity: PluginMessage.Diagnostic.Severity,
+    position: PluginMessage.Diagnostic.Position,
+    highlights: [PluginMessage.Diagnostic.PositionRange] = [],
+    fixItChanges: [PluginMessage.Diagnostic.FixIt.Change] = []
+  ) {
+    // Map severity
+    let bridgedSeverity: BridgedDiagnosticSeverity
+    switch severity {
+    case .error: bridgedSeverity = .error
+    case .note: bridgedSeverity = .note
+    case .warning: bridgedSeverity = .warning
+    }
+
+    // Emit the diagnostic
+    var mutableMessage = message
+    let diag = mutableMessage.withUTF8 { messageBuffer in
+      SwiftDiagnostic_create(
+        cxxDiagnosticEngine, bridgedSeverity,
+        cxxSourceLocation(at: position),
+        messageBuffer.baseAddress, messageBuffer.count)
+    }
+
+    // Emit highlights
+    for highlight in highlights {
+      guard let (startLoc, endLoc) = cxxSourceRange(for: highlight) else {
+        continue
+      }
+      SwiftDiagnostic_highlight(diag, startLoc, endLoc)
+    }
+
+    // Emit changes for a Fix-It.
+    for change in fixItChanges {
+      guard let (startLoc, endLoc) = cxxSourceRange(for: change.range) else {
+        continue
+      }
+      var newText = change.newText
+      newText.withUTF8 { textBuffer in
+        SwiftDiagnostic_fixItReplace(
+          diag, startLoc, endLoc, textBuffer.baseAddress, textBuffer.count)
+      }
+    }
+
+    SwiftDiagnostic_finish(diag)
+  }
+
+  /// Produce the C++ source location for a given position based on a
+  /// syntax node.
+  private func cxxSourceLocation(
+    at offset: Int, in fileName: String
+  ) -> CxxSourceLoc? {
+    // Find the corresponding exported source file.
+    guard let exportedSourceFile = exportedSourceFileByName[fileName]
+    else {
+      return nil
+    }
+
+    // Compute the resulting address.
+    guard let bufferBaseAddress = exportedSourceFile.pointee.buffer.baseAddress
+    else {
+      return nil
+    }
+    let address = bufferBaseAddress.advanced(by: offset)
+    return CxxSourceLoc(mutating: address)
+  }
+
+  /// C++ source location from a position value from a plugin.
+  private func cxxSourceLocation(
+    at position: PluginMessage.Diagnostic.Position
+  ) -> CxxSourceLoc? {
+    cxxSourceLocation(at: position.offset, in: position.fileName)
+  }
+
+  /// C++ source range from a range value from a plugin.
+  private func cxxSourceRange(
+    for range: PluginMessage.Diagnostic.PositionRange
+  ) -> (start: CxxSourceLoc, end: CxxSourceLoc)? {
+    guard
+      let start = cxxSourceLocation(at: range.startOffset, in: range.fileName),
+      let end = cxxSourceLocation(at: range.endOffset, in: range.fileName)
+    else {
+      return nil
+    }
+    return (start: start, end: end )
+  }
+}
+
+extension PluginMessage.Syntax {
+  init?(syntax: Syntax, in sourceFilePtr: UnsafePointer<ExportedSourceFile>) {
+    let kind: PluginMessage.Syntax.Kind
+    switch true {
+    case syntax.is(DeclSyntax.self): kind = .declaration
+    case syntax.is(ExprSyntax.self): kind = .expression
+    case syntax.is(StmtSyntax.self): kind = .statement
+    case syntax.is(TypeSyntax.self): kind = .type
+    case syntax.is(PatternSyntax.self): kind = .pattern
+    case syntax.is(AttributeSyntax.self): kind = .attribute
+    default: return nil
+    }
+    let source = syntax.description
+
+
+    let sourceStr = String(decoding: sourceFilePtr.pointee.buffer, as: UTF8.self)
+    let fileName = sourceFilePtr.pointee.fileName
+    let fileID = "\(sourceFilePtr.pointee.moduleName)/\(sourceFilePtr.pointee.fileName.basename)"
+    let converter = SourceLocationConverter(file: fileName, source: sourceStr)
+    let loc = converter.location(for: syntax.position)
+
+    self.init(
+      kind: kind,
+      source: source,
+      location: .init(
+        fileID: fileID,
+        fileName: fileName,
+        offset: loc.offset,
+        line: loc.line!,
+        column: loc.column!))
+  }
+}

--- a/lib/ASTGen/Sources/ASTGen/PluginMessages.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginMessages.swift
@@ -1,0 +1,126 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+internal enum HostToPluginMessage: Codable {
+  case getCapability
+
+  case expandFreestandingMacro(
+    macro: PluginMessage.MacroReference,
+    discriminator: String,
+    syntax: PluginMessage.Syntax)
+
+  case expandAttachedMacro(
+    macro: PluginMessage.MacroReference,
+    macroRole: PluginMessage.MacroRole,
+    discriminator: String,
+    customAttributeSyntax: PluginMessage.Syntax,
+    declSyntax: PluginMessage.Syntax,
+    parentDeclSyntax: PluginMessage.Syntax?)
+}
+
+internal enum PluginToHostMessage: Codable {
+  case expandFreestandingMacroResult(
+    expandedSource: String?,
+    diagnostics: [PluginMessage.Diagnostic])
+
+  case expandAttachedMacroResult(
+    expandedSources: [String]?,
+    diagnostics: [PluginMessage.Diagnostic])
+
+  case getCapabilityResult(capability: PluginMessage.PluginCapability)
+}
+
+/*namespace*/ internal enum PluginMessage {
+  static var PROTOCOL_VERSION_NUMBER: Int { 1 }
+
+  struct PluginCapability: Codable {
+    var protocolVersion: Int
+  }
+
+  static var capability: PluginCapability {
+    PluginCapability(protocolVersion: PluginMessage.PROTOCOL_VERSION_NUMBER)
+  }
+
+  struct MacroReference: Codable {
+    var moduleName: String
+    var typeName: String
+
+    // The name of 'macro' declaration the client is using.
+    var name: String
+  }
+
+  enum MacroRole: String, Codable {
+    case expression
+    case freeStandingDeclaration
+    case accessor
+    case memberAttribute
+    case member
+    case peer
+  }
+
+  struct SourceLocation: Codable {
+    var fileID: String
+    var fileName: String
+    var offset: Int
+    var line: Int
+    var column: Int
+  }
+
+  struct Diagnostic: Codable {
+    enum Severity: String, Codable {
+      case error
+      case warning
+      case note
+    }
+    struct Position: Codable {
+      var fileName: String
+      var offset: Int
+    }
+    struct PositionRange: Codable {
+      var fileName: String
+      var startOffset: Int
+      var endOffset: Int
+    }
+    struct Note: Codable {
+      var position: Position
+      var message: String
+    }
+    struct FixIt: Codable {
+      struct Change: Codable {
+        var range: PositionRange
+        var newText: String
+      }
+      var message: String
+      var changes: [Change]
+    }
+    var message: String
+    var severity: Severity
+    var position: Position
+    var highlights: [PositionRange]
+    var notes: [Note]
+    var fixIts: [FixIt]
+  }
+
+  struct Syntax: Codable {
+    enum Kind: String, Codable {
+      case declaration
+      case statement
+      case expression
+      case type
+      case pattern
+      case attribute
+    }
+    var kind: Kind
+    var source: String
+    var location: SourceLocation
+  }
+}

--- a/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
@@ -42,7 +42,7 @@ extension SourceManager {
 extension String {
   /// Retrieve the base name of a string that represents a path, removing the
   /// directory.
-  fileprivate var basename: String {
+  var basename: String {
     guard let lastSlash = lastIndex(of: "/") else {
       return self
     }

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -47,6 +47,7 @@ add_swift_host_library(swiftBasic STATIC
   Cache.cpp
   CBasicBridging.cpp
   ClusteredBitVector.cpp
+  CBasicBridging.cpp
   DiverseStack.cpp
   Edit.cpp
   EditorPlaceholder.cpp
@@ -66,6 +67,7 @@ add_swift_host_library(swiftBasic STATIC
   PrimitiveParsing.cpp
   Program.cpp
   QuotedString.cpp
+  Sandbox.cpp
   SourceLoc.cpp
   StableHasher.cpp
   Statistic.cpp

--- a/lib/Basic/Program.cpp
+++ b/lib/Basic/Program.cpp
@@ -59,7 +59,6 @@ toNullTerminatedCStringArray(ArrayRef<StringRef> array,
                              llvm::BumpPtrAllocator &Alloc) {
   size_t size = array.size();
   const char **result = Alloc.Allocate<const char *>(size + 1);
-  const char **ptr = result;
   for (size_t i = 0; i < size; ++i) {
     result[i] = NullTerminatedStringRef(array[i], Alloc).data();
   }
@@ -155,8 +154,7 @@ swift::ExecuteWithPipe(llvm::StringRef program,
     dup2(p2.write, STDOUT_FILENO);
 
     // Execute the program.
-    if (env.has_value()) {
-      const char **envp = toNullTerminatedCStringArray(*env, Alloc);
+    if (envp) {
       execve(progCStr, const_cast<char **>(argv), const_cast<char **>(envp));
     } else {
       execv(progCStr, const_cast<char **>(argv));

--- a/lib/Basic/Program.cpp
+++ b/lib/Basic/Program.cpp
@@ -11,16 +11,25 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Basic/Program.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/StringExtras.h"
 
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Config/config.h"
+#include "llvm/Support/Allocator.h"
 #include "llvm/Support/Program.h"
 
-#if LLVM_ON_UNIX
+#include <system_error>
+
+#if HAVE_POSIX_SPAWN
+#include <spawn.h>
+#endif
+
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif
-#endif
+
+using namespace swift;
 
 int swift::ExecuteInPlace(const char *Program, const char **args,
                           const char **env) {
@@ -44,3 +53,141 @@ int swift::ExecuteInPlace(const char *Program, const char **args,
   return result;
 #endif
 }
+
+static const char **
+toNullTerminatedCStringArray(ArrayRef<StringRef> array,
+                             llvm::BumpPtrAllocator &Alloc) {
+  size_t size = array.size();
+  const char **result = Alloc.Allocate<const char *>(size + 1);
+  const char **ptr = result;
+  for (size_t i = 0; i < size; ++i) {
+    result[i] = NullTerminatedStringRef(array[i], Alloc).data();
+  }
+  result[size] = nullptr;
+  return result;
+}
+
+#if HAVE_UNISTD_H
+
+namespace {
+struct Pipe {
+  int read;
+  int write;
+
+  Pipe() {
+    int fds[2];
+    if (pipe(fds) == -1) {
+      read = write = -1; // '-1' to inidicate the failure.
+    }
+    read = fds[0];
+    write = fds[1];
+  }
+
+  operator bool() const { return read != -1 || write != -1; }
+};
+} // namespace
+
+llvm::ErrorOr<swift::ChildProcessInfo>
+swift::ExecuteWithPipe(llvm::StringRef program,
+                       llvm::ArrayRef<llvm::StringRef> args,
+                       llvm::Optional<llvm::ArrayRef<llvm::StringRef>> env) {
+  Pipe p1; // Parent: write, child: read (child's STDIN).
+  if (!p1)
+    return std::error_code(errno, std::system_category());
+  Pipe p2; // Parent: read, child: write (child's STDOUT).
+  if (!p2)
+    return std::error_code(errno, std::system_category());
+
+  llvm::BumpPtrAllocator Alloc;
+  const char **argv = toNullTerminatedCStringArray(args, Alloc);
+  const char **envp = nullptr;
+  if (env.hasValue()) {
+    envp = toNullTerminatedCStringArray(*env, Alloc);
+  }
+  const char *progCStr = args[0] == program
+                             ? argv[0]
+                             : NullTerminatedStringRef(program, Alloc).data();
+
+  pid_t pid;
+
+#if HAVE_POSIX_SPAWN
+  posix_spawn_file_actions_t FileActions;
+  posix_spawn_file_actions_init(&FileActions);
+
+  posix_spawn_file_actions_adddup2(&FileActions, p1.read, STDIN_FILENO);
+  posix_spawn_file_actions_addclose(&FileActions, p1.write);
+
+  posix_spawn_file_actions_adddup2(&FileActions, p2.write, STDOUT_FILENO);
+  posix_spawn_file_actions_addclose(&FileActions, p2.read);
+
+  // Spawn the subtask.
+  int error = posix_spawn(&pid, progCStr, &FileActions, nullptr,
+                          const_cast<char **>(argv), const_cast<char **>(envp));
+
+  posix_spawn_file_actions_destroy(&FileActions);
+
+  close(p1.read);
+  close(p2.write);
+
+  if (error != 0 || pid == 0) {
+    close(p1.write);
+    close(p2.read);
+    return std::error_code(error, std::system_category());
+  }
+#else
+  // Create a child process.
+  switch (pid = fork()) {
+  // An error occurred:  Return to the caller.
+  case -1:
+    close(p1.read);
+    close(p1.write);
+    close(p2.read);
+    close(p2.write);
+    return std::error_code(errno, std::system_category());
+
+  // Child process.
+  case 0:
+    close(p1.write);
+    close(p2.read);
+
+    // Redirect file descriptors...
+    dup2(p1.read, STDIN_FILENO);
+    dup2(p2.write, STDOUT_FILENO);
+
+    // Execute the program.
+    if (env.has_value()) {
+      const char **envp = toNullTerminatedCStringArray(*env, Alloc);
+      execve(progCStr, const_cast<char **>(argv), const_cast<char **>(envp));
+    } else {
+      execv(progCStr, const_cast<char **>(argv));
+    }
+
+    // If the execv()/execve() failed, we should exit. Follow Unix protocol and
+    // return 127 if the executable was not found, and 126 otherwise. Use _exit
+    // rather than exit so that atexit functions and static object destructors
+    // cloned from the parent process aren't redundantly run, and so that any
+    // data buffered in stdio buffers cloned from the parent aren't redundantly
+    // written out.
+    _exit(errno == ENOENT ? 127 : 126);
+
+  // Parent process.
+  default:
+    break;
+  }
+#endif
+  close(p1.read);
+  close(p2.write);
+  return ChildProcessInfo(pid, p1.write, p2.read);
+}
+
+#else // HAVE_UNISTD_H
+
+llvm::ErrorOr<swift::ChildProcessInfo>
+swift::ExecuteWithPipe(llvm::StringRef program,
+                       llvm::ArrayRef<llvm::StringRef> args,
+                       llvm::Optional<llvm::ArrayRef<llvm::StringRef>> env) {
+  // Not supported.
+  return std::errc::not_supported;
+}
+
+#endif

--- a/lib/Basic/Sandbox.cpp
+++ b/lib/Basic/Sandbox.cpp
@@ -1,0 +1,41 @@
+#include "swift/Basic/Sandbox.h"
+#include "swift/Basic/LLVM.h"
+#include "swift/Basic/StringExtras.h"
+#include "llvm/ADT/SmallString.h"
+
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
+using namespace swift;
+using namespace Sandbox;
+
+#if defined(__APPLE__) && TARGET_OS_OSX
+static StringRef sandboxProfile(llvm::BumpPtrAllocator &Alloc) {
+  llvm::SmallString<256> contents;
+  contents += "(version 1)\n";
+
+  // Deny everything by default.
+  contents += "(deny default)\n";
+
+  // Import the system sandbox profile.
+  contents += "(import \"system.sb\")\n";
+
+  // Allow reading all files, we need to read various system files.
+  contents += "(allow file-read*)\n";
+
+  // This is required to launch any processes (execve(2)).
+  contents += "(allow process-exec*)\n";
+
+  return NullTerminatedStringRef(contents, Alloc);
+}
+#endif
+
+bool swift::Sandbox::apply(llvm::SmallVectorImpl<llvm::StringRef> &command,
+                           llvm::BumpPtrAllocator &Alloc) {
+#if defined(__APPLE__) && TARGET_OS_OSX
+  auto profile = sandboxProfile(Alloc);
+  command.insert(command.begin(), {"/usr/bin/sandbox-exec", "-p", profile});
+#endif
+  return false;
+}

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -81,16 +81,18 @@ if(SWIFT_FORCE_OPTIMIZED_TYPECHECKER)
   endif()
 endif()
 
+target_link_libraries(swiftSema PRIVATE
+  swiftAST
+  swiftParse
+  swiftSerialization)
+
 if (SWIFT_SWIFT_PARSER)
   target_compile_definitions(swiftSema
     PRIVATE
     SWIFT_SWIFT_PARSER
   )
+  target_link_libraries(swiftSema PRIVATE
+    $<TARGET_OBJECTS:swiftASTGen>)
 endif()
-
-target_link_libraries(swiftSema PRIVATE
-  swiftAST
-  swiftParse
-  swiftSerialization)
 
 set_swift_llvm_is_available(swiftSema)

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2036,10 +2036,8 @@ public:
       ExternalMacroDefinitionRequest request{
         &Ctx, external.moduleName, external.macroTypeName
       };
-      auto externalDef = evaluateOrDefault(
-          Ctx.evaluator, request, ExternalMacroDefinition()
-      );
-      if (!externalDef.opaqueHandle) {
+      auto externalDef = evaluateOrDefault(Ctx.evaluator, request, None);
+      if (!externalDef) {
         MD->diagnose(
             diag::external_macro_not_found,
             external.moduleName.str(),

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -20,8 +20,9 @@
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/Expr.h"
-#include "swift/AST/NameLookupRequests.h"
 #include "swift/AST/MacroDefinition.h"
+#include "swift/AST/NameLookupRequests.h"
+#include "swift/AST/PluginRegistry.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/TypeCheckRequests.h"
@@ -45,31 +46,31 @@
 using namespace swift;
 
 extern "C" void *swift_ASTGen_resolveMacroType(const void *macroType);
-
 extern "C" void swift_ASTGen_destroyMacro(void *macro);
 
+extern "C" void *swift_ASTGen_resolveExecutableMacro(
+    const char *moduleName, ptrdiff_t moduleNameLength,
+    const char *typeName, ptrdiff_t typeNameLength,
+    void * opaquePluginHandle);
+extern "C" void swift_ASTGen_destroyExecutableMacro(void *macro);
+
 extern "C" ptrdiff_t swift_ASTGen_expandFreestandingMacro(
-    void *diagEngine, void *macro,
-    const char *discriminator,
-    ptrdiff_t discriminatorLength,
-    void *sourceFile,
-    const void *sourceLocation,
-    const char **evaluatedSource, ptrdiff_t *evaluatedSourceLength);
+    void *diagEngine, void *macro, uint8_t externalKind,
+    const char *discriminator, ptrdiff_t discriminatorLength, void *sourceFile,
+    const void *sourceLocation, const char **evaluatedSource,
+    ptrdiff_t *evaluatedSourceLength);
 
 extern "C" ptrdiff_t swift_ASTGen_expandAttachedMacro(
-    void *diagEngine, void *macro,
-    const char *discriminator,
-    ptrdiff_t discriminatorLength,
-    uint32_t rawMacroRole,
-    void *customAttrSourceFile,
-    const void *customAttrSourceLocation,
-    void *declarationSourceFile,
-    const void *declarationSourceLocation,
-    void *parentDeclSourceFile,
-    const void *parentDeclSourceLocation,
-    const char **evaluatedSource,
-    ptrdiff_t *evaluatedSourceLength
-);
+    void *diagEngine, void *macro, uint8_t externalKind,
+    const char *discriminator, ptrdiff_t discriminatorLength,
+    uint8_t rawMacroRole,
+    void *customAttrSourceFile, const void *customAttrSourceLocation,
+    void *declarationSourceFile, const void *declarationSourceLocation,
+    void *parentDeclSourceFile, const void *parentDeclSourceLocation,
+    const char **evaluatedSource, ptrdiff_t *evaluatedSourceLength);
+
+extern "C" void swift_ASTGen_initializePlugin(void *handle);
+extern "C" void swift_ASTGen_deinitializePlugin(void *handle);
 
 /// Produce the mangled name for the nominal type descriptor of a type
 /// referenced by its module and type name.
@@ -346,19 +347,51 @@ resolveInProcessMacro(
         swift_ASTGen_destroyMacro(inProcess);
       });
 
-      return ExternalMacroDefinition{inProcess};
+      return ExternalMacroDefinition{
+          ExternalMacroDefinition::PluginKind::InProcess, inProcess};
     }
+  }
+#endif
+  return None;
+}
+
+static Optional<ExternalMacroDefinition>
+resolvExecutableMacro(ASTContext &ctx, Identifier moduleName,
+                      Identifier typeName) {
+#if SWIFT_SWIFT_PARSER
+  // Find macros in exectuable plugins.
+  auto *executablePlugin =
+      ctx.lookupExecutablePluginByModuleName(moduleName);
+  if (!executablePlugin)
+    return None;
+
+  // FIXME: Ideally this should be done right after invoking the plugin.
+  // But plugin loading is in libAST and it can't link ASTGen symbols.
+  if (!executablePlugin->isInitialized()) {
+    swift_ASTGen_initializePlugin(executablePlugin);
+    executablePlugin->setCleanup([executablePlugin] {
+      swift_ASTGen_deinitializePlugin(executablePlugin);
+    });
+  }
+
+  if (auto execMacro = swift_ASTGen_resolveExecutableMacro(
+          moduleName.str().data(), moduleName.str().size(),
+          typeName.str().data(), typeName.str().size(), executablePlugin)) {
+    // Make sure we clean up after the macro.
+    ctx.addCleanup(
+        [execMacro]() { swift_ASTGen_destroyExecutableMacro(execMacro); });
+    return ExternalMacroDefinition{
+        ExternalMacroDefinition::PluginKind::Executable, execMacro};
   }
 #endif
 
   return None;
 }
 
-ExternalMacroDefinition
-ExternalMacroDefinitionRequest::evaluate(
-    Evaluator &evaluator, ASTContext *ctx,
-    Identifier moduleName, Identifier typeName
-) const {
+Optional<ExternalMacroDefinition>
+ExternalMacroDefinitionRequest::evaluate(Evaluator &evaluator, ASTContext *ctx,
+                                         Identifier moduleName,
+                                         Identifier typeName) const {
   // Try to load a plugin module from the plugin search paths. If it
   // succeeds, resolve in-process from that plugin
   CompilerPluginLoadRequest loadRequest{ctx, moduleName};
@@ -373,7 +406,13 @@ ExternalMacroDefinitionRequest::evaluate(
   if (auto inProcess = resolveInProcessMacro(*ctx, moduleName, typeName))
     return *inProcess;
 
-  return ExternalMacroDefinition{nullptr};
+  // Try executable plugins.
+  if (auto executableMacro =
+          resolvExecutableMacro(*ctx, moduleName, typeName)) {
+    return executableMacro;
+  }
+
+  return None;
 }
 
 /// Adjust the given mangled name for a macro expansion to produce a valid
@@ -518,10 +557,8 @@ Expr *swift::expandMacroExpr(
     ExternalMacroDefinitionRequest request{
       &ctx, external.moduleName, external.macroTypeName
     };
-    auto externalDef = evaluateOrDefault(
-        ctx.evaluator, request, ExternalMacroDefinition()
-    );
-    if (!externalDef.opaqueHandle) {
+    auto externalDef = evaluateOrDefault(ctx.evaluator, request, None);
+    if (!externalDef) {
       ctx.Diags.diagnose(
          expr->getLoc(), diag::external_macro_not_found,
          external.moduleName.str(),
@@ -554,11 +591,11 @@ Expr *swift::expandMacroExpr(
     const char *evaluatedSourceAddress;
     ptrdiff_t evaluatedSourceLength;
     swift_ASTGen_expandFreestandingMacro(
-        &ctx.Diags,
-        externalDef.opaqueHandle,
-        discriminator.data(), discriminator.size(),
-        astGenSourceFile, expr->getStartLoc().getOpaquePointerValue(),
-        &evaluatedSourceAddress, &evaluatedSourceLength);
+        &ctx.Diags, externalDef->opaqueHandle,
+        static_cast<uint32_t>(externalDef->kind), discriminator.data(),
+        discriminator.size(), astGenSourceFile,
+        expr->getStartLoc().getOpaquePointerValue(), &evaluatedSourceAddress,
+        &evaluatedSourceLength);
     if (!evaluatedSourceAddress)
       return nullptr;
     evaluatedSource = NullTerminatedStringRef(evaluatedSourceAddress,
@@ -690,10 +727,8 @@ bool swift::expandFreestandingDeclarationMacro(
     ExternalMacroDefinitionRequest request{
         &ctx, external.moduleName, external.macroTypeName
     };
-    auto externalDef = evaluateOrDefault(
-        ctx.evaluator, request, ExternalMacroDefinition()
-    );
-    if (!externalDef.opaqueHandle) {
+    auto externalDef = evaluateOrDefault(ctx.evaluator, request, None);
+    if (!externalDef) {
       med->diagnose(diag::external_macro_not_found,
                     external.moduleName.str(),
                     external.macroTypeName.str(),
@@ -723,11 +758,11 @@ bool swift::expandFreestandingDeclarationMacro(
     const char *evaluatedSourceAddress;
     ptrdiff_t evaluatedSourceLength;
     swift_ASTGen_expandFreestandingMacro(
-        &ctx.Diags,
-        externalDef.opaqueHandle,
-        discriminator.data(), discriminator.size(),
-        astGenSourceFile, med->getStartLoc().getOpaquePointerValue(),
-        &evaluatedSourceAddress, &evaluatedSourceLength);
+        &ctx.Diags, externalDef->opaqueHandle,
+        static_cast<uint32_t>(externalDef->kind), discriminator.data(),
+        discriminator.size(), astGenSourceFile,
+        med->getStartLoc().getOpaquePointerValue(), &evaluatedSourceAddress,
+        &evaluatedSourceLength);
     if (!evaluatedSourceAddress)
       return false;
     evaluatedSource = NullTerminatedStringRef(evaluatedSourceAddress,
@@ -888,10 +923,8 @@ evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo, CustomAttr *attr,
     ExternalMacroDefinitionRequest request{
         &ctx, external.moduleName, external.macroTypeName
     };
-    auto externalDef = evaluateOrDefault(
-        ctx.evaluator, request, ExternalMacroDefinition()
-    );
-    if (!externalDef.opaqueHandle) {
+    auto externalDef = evaluateOrDefault(ctx.evaluator, request, None);
+    if (!externalDef) {
       attachedTo->diagnose(diag::external_macro_not_found,
                         external.moduleName.str(),
                         external.macroTypeName.str(),
@@ -941,14 +974,13 @@ evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo, CustomAttr *attr,
     const char *evaluatedSourceAddress;
     ptrdiff_t evaluatedSourceLength;
     swift_ASTGen_expandAttachedMacro(
-        &ctx.Diags,
-        externalDef.opaqueHandle,
-        discriminator.data(), discriminator.size(),
-        static_cast<uint32_t>(role),
-        astGenAttrSourceFile, attr->AtLoc.getOpaquePointerValue(),
-        astGenDeclSourceFile, searchDecl->getStartLoc().getOpaquePointerValue(),
-        astGenParentDeclSourceFile, parentDeclLoc,
-        &evaluatedSourceAddress, &evaluatedSourceLength);
+        &ctx.Diags, externalDef->opaqueHandle,
+        static_cast<uint32_t>(externalDef->kind), discriminator.data(),
+        discriminator.size(), static_cast<uint32_t>(role), astGenAttrSourceFile,
+        attr->AtLoc.getOpaquePointerValue(), astGenDeclSourceFile,
+        searchDecl->getStartLoc().getOpaquePointerValue(),
+        astGenParentDeclSourceFile, parentDeclLoc, &evaluatedSourceAddress,
+        &evaluatedSourceLength);
     if (!evaluatedSourceAddress)
       return nullptr;
     evaluatedSource = NullTerminatedStringRef(evaluatedSourceAddress,

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -356,7 +356,7 @@ resolveInProcessMacro(
 }
 
 static Optional<ExternalMacroDefinition>
-resolvExecutableMacro(ASTContext &ctx, Identifier moduleName,
+resolveExecutableMacro(ASTContext &ctx, Identifier moduleName,
                       Identifier typeName) {
 #if SWIFT_SWIFT_PARSER
   // Find macros in exectuable plugins.
@@ -374,7 +374,7 @@ resolvExecutableMacro(ASTContext &ctx, Identifier moduleName,
     });
   }
 
-  if (auto execMacro = swift_ASTGen_resolveExecutableMacro(
+  if (auto *execMacro = swift_ASTGen_resolveExecutableMacro(
           moduleName.str().data(), moduleName.str().size(),
           typeName.str().data(), typeName.str().size(), executablePlugin)) {
     // Make sure we clean up after the macro.
@@ -408,7 +408,7 @@ ExternalMacroDefinitionRequest::evaluate(Evaluator &evaluator, ASTContext *ctx,
 
   // Try executable plugins.
   if (auto executableMacro =
-          resolvExecutableMacro(*ctx, moduleName, typeName)) {
+          resolveExecutableMacro(*ctx, moduleName, typeName)) {
     return executableMacro;
   }
 

--- a/test/Macros/macro_plugin_basic.swift
+++ b/test/Macros/macro_plugin_basic.swift
@@ -1,0 +1,59 @@
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: sed -i '' -e 's#UTILS_DIR#%utils#' %t/plugin
+// RUN: sed -i '' -e 's#TEMP_DIR#%t#' %t/plugin
+// RUN: chmod +x %t/plugin
+
+// RUN: %swift-target-frontend -typecheck -verify -swift-version 5 -enable-experimental-feature Macros -load-plugin-executable %t/plugin#TestPlugin %t/test.swift
+
+//--- test.swift
+@freestanding(expression) macro testString(_: Any) -> String = #externalMacro(module: "TestPlugin", type: "TestStringMacro")
+@freestanding(expression) macro testStringWithError(_: Any) -> String = #externalMacro(module: "TestPlugin", type: "TestStringWithErrorMacro")
+
+func test() {
+  let _: String = #testString(123)
+  let _: String = #testStringWithError(321)
+  // expected-error @-1 {{message from plugin}} 
+}
+
+//--- plugin
+#!/usr/bin/env python3
+import sys
+sys.path.append('UTILS_DIR')
+
+import mock_plugin
+
+mock_plugin.TEST_SPEC = [
+  {
+    "expect": {"getCapability": {}},
+    "response": {"getCapabilityResult": {"capability": {"protocolVersion": 1}}},
+  },
+  {
+    "expect": {"expandFreestandingMacro": {
+                "macro": {"moduleName": "TestPlugin", "typeName": "TestStringMacro"},
+                "syntax": {"kind": "expression", "source": "#testString(123)"}}},
+    "response": {"expandFreestandingMacroResult": {"expandedSource": "\"123\"", "diagnostics": []}},
+  },
+  {
+    "expect": {"expandFreestandingMacro": {
+                "macro": {"moduleName": "TestPlugin", "typeName": "TestStringWithErrorMacro"},
+                "syntax": {"kind": "expression", "source": "#testStringWithError(321)"}}},
+    "response": {"expandFreestandingMacroResult": {
+                   "expandedSource": "\"123\"",
+                   "diagnostics": [
+                     {"severity": "error",
+                      "position": {"offset": "={req[expandFreestandingMacro][syntax][location][offset]}",
+                                   "fileName": "{req[expandFreestandingMacro][syntax][location][fileName]}"},
+                      "message":"message from plugin",
+                      "highlights": [],
+                      "notes": [],
+                      "fixIts": []}
+                   ]}},
+  },
+]
+
+mock_plugin.main()
+

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -22,6 +22,7 @@
 #include "SourceKit/Support/Tracing.h"
 #include "SwiftInterfaceGenContext.h"
 #include "swift/AST/DiagnosticConsumer.h"
+#include "swift/AST/PluginRegistry.h"
 #include "swift/Basic/ThreadSafeRefCounted.h"
 #include "swift/IDE/CancellableResult.h"
 #include "swift/IDE/Indenting.h"

--- a/utils/mock_plugin.py
+++ b/utils/mock_plugin.py
@@ -23,9 +23,9 @@
 #
 # where 'TEST_SPEC' is a list of pairs of an expected request and the result to
 # respond. For example:
-#   {'expected': {'testRequest': {'params': []}},
+#   {'expect': {'testRequest': {'params': []}},
 #    'response': {'testRequestResult': [1,2,"foo"]}}
-# this spec matches a request that is an object with 'testRequst' key with an
+# this spec matches a request that is an object with 'testRequest' key with an
 # object with 'params' key with an empty array. When the host system sends a
 # request matching, this mock plugin replies to it with the 'response' object.
 # ===-----------------------------------------------------------------------===#

--- a/utils/mock_plugin.py
+++ b/utils/mock_plugin.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# ===-----------------------------------------------------------------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2023 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ===-----------------------------------------------------------------------===#
+#
+# Helper python module to write a mock compiler plugin for testing compiler
+# plugin mechanism. Test plugins can be like
+#
+#   import sys
+#   sys.path.append('/path/to/utils')
+#   import mock_plugin
+#
+#   mock_plugin.TEST_SPEC = [ ... ]
+#   mock_plugin.main()
+#
+# where 'TEST_SPEC' is a list of pairs of an expected request and the result to
+# respond. For example:
+#   {'expected': {'testRequest': {'params': []}},
+#    'response': {'testRequestResult': [1,2,"foo"]}}
+# this spec matches a request that is an object with 'testRequst' key with an
+# object with 'params' key with an empty array. When the host system sends a
+# request matching, this mock plugin replies to it with the 'response' object.
+# ===-----------------------------------------------------------------------===#
+
+import json
+import struct
+import sys
+
+# This should be filled by the client.
+TEST_SPEC = []
+
+
+def match(value, expect):
+    if isinstance(value, dict) and isinstance(expect, dict):
+        # For dictionary, only check the expected keys. i.e. the value can
+        # contain extra items.
+        for key, expectVal in expect.items():
+            if key not in value:
+                return False
+            if not match(value[key], expectVal):
+                return False
+        return True
+
+    if isinstance(value, list) and isinstance(expect, list):
+        # Check all elements.
+        if len(value) != len(expect):
+            return False
+        for element, expectVal in zip(value, expect):
+            if not match(element, expectVal):
+                return False
+        return True
+
+    # Otherwise, just check the equality.
+    return value == expect
+
+
+def substitute(value, req):
+    if isinstance(value, str):
+        result = value.format(req=req)
+        # for "={req[...]}" format, covert it to integer.
+        if value.startswith('={') and value.endswith("}"):
+            return int(result[1:])
+        return result
+
+    if isinstance(value, dict):
+        result = {}
+        for key, value in value.items():
+            result[key] = substitute(value, req)
+        return result
+
+    if isinstance(value, list):
+        result = []
+        for value in value:
+            result.append(substitute(value, req))
+        return result
+
+    return value
+
+
+def handle_request(req):
+    for spec in TEST_SPEC:
+        if not match(req, spec['expect']):
+            continue
+        if spec.get('handled', False):
+            raise ValueError('already handled request')
+        spec['handled'] = True
+        return substitute(spec['response'], req)
+
+    raise ValueError('could not find matching request')
+
+
+def main():
+    # Message handling loop.
+    while True:
+        # Read request
+        request_header = sys.stdin.buffer.read(8)
+        if len(request_header) < 8:
+            break
+        request_size = struct.unpack('<Q', request_header)[0]
+        request_data = sys.stdin.buffer.read(request_size)
+        if len(request_data) != request_size:
+            break
+        request_object = json.loads(request_data)
+
+        # Handle request
+        response_object = handle_request(request_object)
+
+        # Write response
+        response_json = json.dumps(response_object)
+        response_data = response_json.encode('utf-8')
+        response_size = len(response_data)
+        response_header = struct.pack('<Q', response_size)
+        sys.stdout.buffer.write(response_header)
+        sys.stdout.buffer.write(response_data)
+        sys.stdout.buffer.flush()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Executable compiler plugins are programs invoked by the host compiler and communicate with the host with IPC via standard IO (stdin/stdout.) Each message is serialized in JSON, prefixed with a header which is a 64bit little-endian integer indicating the size of the message.

* `Basic/ExecuteWithPipe`: External program invocation. Like `llvm::sys::ExecuteNoWait()` but establishing pipes to the child's stdin/stdout
* `Basic/Sandbox`: Sandboxed execution helper. Mutates command line arguments to be executed in sandbox environment (similar to [SwiftPM's plugin sandbox](https://github.com/apple/swift-package-manager/blob/2975732421aff9da0c03c66d191710a7e37055d7/Sources/Basics/Sandbox.swift))
* `AST/PluginRepository`: ASTContext independent plugin manager.
* `ASTGen/PluginHost`: Communication with the plugin. Messages are serialized by `ASTGen/LLVMJSON` added in #63689 

This PR implements 3 messages (`ASTGen/PluginMessages`).
* `getCapability`: get plugin capability. currently it only returns fixed `protocolVersion` 1.
* `expandFreestandingMacro`: expand freestanding macros
* `expandAttachedMacro`: expand attached macros

rdar://101508815