### PR TITLE
[CSSimplify] Make "force optional unwrap" fix less aggressive

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4600,6 +4600,14 @@ repairViaOptionalUnwrap(ConstraintSystem &cs, Type fromType, Type toType,
     if (type->getOptionalObjectType())
       fromType = type;
 
+    // Don't attempt the fix until sub-expression is resolved
+    // if chain is not using leading-dot syntax. This is better
+    // than attempting to propagate type information down optional
+    // chain which is hard to diagnose.
+    if (type->isTypeVariableOrMember() &&
+        !isa<UnresolvedMemberChainResultExpr>(subExpr))
+      return false;
+
     // If this is a conversion from optional chain to some
     // other type e.g. contextual type or a parameter type,
     // let's use `Bind` to match object types because

--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -802,3 +802,16 @@ func test_leading_dot_syntax_unknown_base_ambiguity() {
 
   fn("", value: .member) // expected-error {{cannot infer contextual base in reference to member 'member'}}
 }
+
+// rdar://105348781 - failed to produce a diagnostic when passing optional to unrelated type.
+func test_mismatch_between_param_and_optional_chain() {
+  func fn(_: String) {}
+
+  struct Test {
+    var data: [Int]?
+
+    func test() {
+      fn(data?.first) // expected-error {{cannot convert value of type 'Int?' to expected argument type 'String'}}
+    }
+  }
+}


### PR DESCRIPTION
Don't attempt the fix until sub-expression is resolved
if chain is not using leading-dot syntax. This is better
than attempting to propagate type information down
optional chain which is hard to diagnose.

Resolves: rdar://105348781

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
