### PR TITLE
[Macros] Return a `ConcreteDeclRef` from `ResolveMacroRequest`.

### DIFF
--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3181,8 +3181,8 @@ void simple_display(llvm::raw_ostream &out,
 /// Resolve a given custom attribute to an attached macro declaration.
 class ResolveMacroRequest
     : public SimpleRequest<ResolveMacroRequest,
-                           MacroDecl *(UnresolvedMacroReference,
-                                       DeclContext *),
+                           ConcreteDeclRef(UnresolvedMacroReference,
+                                           DeclContext *),
                            RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
@@ -3190,7 +3190,7 @@ public:
 private:
   friend SimpleRequest;
 
-  MacroDecl *
+  ConcreteDeclRef
   evaluate(Evaluator &evaluator, UnresolvedMacroReference macroRef,
            DeclContext *dc) const;
 

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -341,7 +341,7 @@ SWIFT_REQUEST(TypeChecker, ResolveImplicitMemberRequest,
               evaluator::SideEffect(NominalTypeDecl *, ImplicitMemberAction),
               Uncached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveMacroRequest,
-              MacroDecl *(CustomAttr *, DeclContext *),
+              ConcreteDeclRef(UnresolvedMacroReference, DeclContext *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ResolveTypeEraserTypeRequest,
               Type(ProtocolDecl *, TypeEraserAttr *),

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -418,10 +418,12 @@ void Decl::forEachAttachedMacro(MacroRole role,
 }
 
 MacroDecl *Decl::getResolvedMacro(CustomAttr *customAttr) const {
-  return evaluateOrDefault(
+  auto declRef = evaluateOrDefault(
       getASTContext().evaluator,
       ResolveMacroRequest{customAttr, getDeclContext()},
-      nullptr);
+      ConcreteDeclRef());
+
+  return dyn_cast_or_null<MacroDecl>(declRef.getDecl());
 }
 
 unsigned Decl::getAttachedMacroDiscriminator(

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1522,9 +1522,10 @@ populateLookupTableEntryFromMacroExpansions(ASTContext &ctx,
     auto *med = dyn_cast<MacroExpansionDecl>(member);
     if (!med)
       continue;
-    auto macro = evaluateOrDefault(
+    auto declRef = evaluateOrDefault(
         ctx.evaluator, ResolveMacroRequest{med, dc},
         nullptr);
+    auto *macro = dyn_cast_or_null<MacroDecl>(declRef.getDecl());
     if (!macro)
       continue;
     auto *attr = macro->getMacroRoleAttr(MacroRole::Declaration);

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3779,22 +3779,9 @@ ExpandMacroExpansionDeclRequest::evaluate(Evaluator &evaluator,
     return {};
   }
   // Resolve macro candidates.
-  MacroDecl *macro;
-  if (auto *args = MED->getArgs()) {
-    macro = evaluateOrDefault(
-        ctx.evaluator, ResolveMacroRequest{MED, dc},
-        nullptr);
-  }
-  else {
-    if (foundMacros.size() > 1) {
-      MED->diagnose(diag::ambiguous_decl_ref, MED->getMacroName())
-          .highlight(MED->getMacroNameLoc().getSourceRange());
-      for (auto *candidate : foundMacros)
-        candidate->diagnose(diag::found_candidate);
-      return {};
-    }
-    macro = foundMacros.front();
-  }
+  auto macro = evaluateOrDefault(
+      ctx.evaluator, ResolveMacroRequest{MED, dc},
+      ConcreteDeclRef());
   if (!macro)
     return {};
   MED->setMacroRef(macro);


### PR DESCRIPTION
This allows callers to access inferred generic arguments for macro expansion invocations.