### PR TITLE
[SIL] Add assertions to check assumptions about owned noescape closures.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8193,6 +8193,10 @@ public:
   void setPoisonRefs(bool poisonRefs = true) {
     sharedUInt8().DestroyValueInst.poisonRefs = poisonRefs;
   }
+  
+  /// If the value being destroyed is a stack allocation of a nonescaping
+  /// closure, then return the PartialApplyInst that allocated the closure.
+  PartialApplyInst *getNonescapingClosureAllocation() const;
 };
 
 class MoveValueInst


### PR DESCRIPTION
- Assert that there are no unexpected forwarding instructions when tracing a DestroyValueInst to its matching PartialApply [stack].
- Assert that, when tracing a PartialApplyInst the other way to its DestroyValueInsts, that forwarding instructions all produce one result and don't cause exponential traversal.