### PR TITLE
[Sema] Improving integer literal as boolean diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3893,6 +3893,9 @@ ERROR(optional_used_as_boolean,none,
 ERROR(integer_used_as_boolean,none,
      "type %0 cannot be used as a boolean; "
      "test for '%select{!|=}1= 0' instead", (Type, bool))
+ERROR(integer_used_as_boolean_literal,none,
+     "integer literal value '%0' cannot be used as a boolean; "
+     "did you mean '%select{false|true}1'?", (StringRef, bool))
 
 ERROR(interpolation_missing_proto,none,
       "string interpolation requires the protocol 'ExpressibleByStringInterpolation' to be defined",

--- a/test/Constraints/argument_matching.swift
+++ b/test/Constraints/argument_matching.swift
@@ -531,13 +531,13 @@ struct PositionsAroundDefaultsAndVariadics {
     // expected-error@-1 {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}
     
     f1(b: "2", 1) // expected-error {{incorrect argument labels in call (have 'b:_:', expected '_:_:c:_:')}}
-    // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    // expected-error@-1 {{integer literal value '1' cannot be used as a boolean; did you mean 'true'?}}
 
     f1(b: "2", [3], 1) // expected-error {{incorrect argument labels in call (have 'b:_:_:', expected '_:_:c:_:')}}
     // expected-error@-1 {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}
 
     f1(b: "2", 1, [3]) // expected-error {{incorrect argument labels in call (have 'b:_:_:', expected '_:_:c:_:')}}
-    // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    // expected-error@-1 {{integer literal value '1' cannot be used as a boolean; did you mean 'true'?}}
     // expected-error@-2 {{cannot convert value of type '[Int]' to expected argument type 'Int'}}
   }
 
@@ -574,11 +574,11 @@ struct PositionsAroundDefaultsAndVariadics {
     f2(true, 21, 22, [4]) // expected-error {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
     // expected-note@-1 {{remove brackets to pass array elements directly}}
 
-    f2(21, 22, 23, c: "3", [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    f2(21, 22, 23, c: "3", [4]) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Bool'}}
 
-    f2(21, 22, c: "3", [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    f2(21, 22, c: "3", [4]) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Bool'}}
 
-    f2(21, c: "3", [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    f2(21, c: "3", [4]) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Bool'}}
 
     f2(c: "3", [4])
     f2(c: "3")
@@ -591,15 +591,15 @@ struct PositionsAroundDefaultsAndVariadics {
     // expected-error@-2 {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}
 
     f2(c: "3", [4], 21) // expected-error {{incorrect argument labels in call (have 'c:_:_:', expected '_:_:c:_:')}}
-    // expected-error@-1 {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    // expected-error@-1 {{cannot convert value of type 'Int' to expected argument type 'Bool'}}
 
     f2([4]) // expected-error {{cannot convert value of type '[Int]' to expected argument type 'Bool'}}
 
-    f2(21, [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    f2(21, [4]) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Bool'}}
     // expected-error@-1 {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
     // expected-note@-2 {{remove brackets to pass array elements directly}}
 
-    f2(21, 22, [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    f2(21, 22, [4]) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Bool'}}
     // expected-error@-1 {{cannot pass array of type '[Int]' as variadic arguments of type 'Int'}}
     // expected-note@-2 {{remove brackets to pass array elements directly}}
   }
@@ -690,7 +690,7 @@ struct PositionsAroundDefaultsAndVariadics {
     f4(b: "2", 31, d: [4])
     f4(b: "2", d: [4])
 
-    f4(31, b: "2", d: [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    f4(31, b: "2", d: [4]) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Bool'}}
 
     f4(b: "2", d: [4], 31) // expected-error {{unnamed argument #3 must precede argument 'b'}}
 
@@ -700,13 +700,13 @@ struct PositionsAroundDefaultsAndVariadics {
 
     f4()
     
-    f4(31) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    f4(31) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Bool'}}
 
-    f4(31, d: [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    f4(31, d: [4]) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Bool'}}
 
-    f4(31, 32) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    f4(31, 32) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Bool'}}
 
-    f4(31, 32, d: [4]) // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+    f4(31, 32, d: [4]) // expected-error {{cannot convert value of type 'Int' to expected argument type 'Bool'}}
   }
 
   // labeled variadics after labeled parameter

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1535,13 +1535,13 @@ func testUnwrapFixIts(x: Int?) throws {
 func issue63746() {
   let fn1 = {
     switch 0 {
-      case 1 where 0: // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+      case 1 where 0: // expected-error {{integer literal value '0' cannot be used as a boolean; did you mean 'false'?}}
         ()
     }
   }
   let fn2 = {
     switch 0 {
-      case 1 where 0: // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+      case 1 where 0: // expected-error {{integer literal value '0' cannot be used as a boolean; did you mean 'false'?}}
         break
     }
   }

--- a/test/Constraints/ternary_expr.swift
+++ b/test/Constraints/ternary_expr.swift
@@ -51,7 +51,7 @@ useD1(i) // expected-error{{cannot convert value of type 'B' to expected argumen
 useD2(i) // expected-error{{cannot convert value of type 'B' to expected argument type 'D2'}}
 
 var x = true ? 1 : 0
-var y = 22 ? 1 : 0 // expected-error{{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+var y = 22 ? 1 : 0 // expected-error{{cannot convert value of type 'Int' to expected condition type 'Bool'}}
 
 _ = x ? x : x // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
 _ = true ? x : 1.2 // expected-error {{result values in '? :' expression have mismatching types 'Int' and 'Double'}}

--- a/test/ImportResolution/import-resolution-overload.swift
+++ b/test/ImportResolution/import-resolution-overload.swift
@@ -32,7 +32,7 @@ ambiguousWithVar(true)   // no-warning
 
 var localVar : Bool
 localVar = false
-localVar = 42 // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+localVar = 42 // expected-error {{cannot assign value of type 'Int' to type 'Bool'}}
 localVar(42)  // expected-error {{cannot call value of non-function type 'Bool'}}
 var _ : localVar // should still work
 

--- a/test/Misc/misc_diagnostics.swift
+++ b/test/Misc/misc_diagnostics.swift
@@ -26,8 +26,8 @@ let total = 15.0
 let count = 7
 let median = total / count // expected-error {{binary operator '/' cannot be applied to operands of type 'Double' and 'Int'}} expected-note {{overloads for '/' exist with these partially matching parameter lists:}}
 
-if (1) {} // expected-error{{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
-if 1 {} // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+if (1) {} // expected-error{{integer literal value '1' cannot be used as a boolean; did you mean 'true'?}} {{5-6=true}}
+if 1 {} // expected-error {{integer literal value '1' cannot be used as a boolean; did you mean 'true'?}} {{4-5=true}}
 
 var a: [String] = [1] // expected-error{{cannot convert value of type 'Int' to expected element type 'String'}}
 var b: Int = [1, 2, 3] // expected-error{{cannot convert value of type '[Int]' to specified type 'Int'}}

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -64,7 +64,7 @@ case _ where x % 2 == 0,
   x = 1
 case var y where y % 2 == 0:
   x = y + 1
-case _ where 0: // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+case _ where 0: // expected-error {{integer literal value '0' cannot be used as a boolean; did you mean 'false'?}}
   x = 0
 default:
   x = 1

--- a/test/Sema/diag_integer_literals.swift
+++ b/test/Sema/diag_integer_literals.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift 
+
+// https://github.com/apple/swift/issues/63753
+
+if 0 {} // expected-error{{integer literal value '0' cannot be used as a boolean; did you mean 'false'?}} {{4-5=false}}
+if (0) {} // expected-error{{integer literal value '0' cannot be used as a boolean; did you mean 'false'?}} {{5-6=false}}
+if 1 {} // expected-error{{integer literal value '1' cannot be used as a boolean; did you mean 'true'?}} {{4-5=true}}
+if (1) {} // expected-error{{integer literal value '1' cannot be used as a boolean; did you mean 'true'?}} {{5-6=true}}
+if 12 {} // expected-error{{cannot convert value of type 'Int' to expected condition type 'Bool'}}
+if (12) {} // expected-error{{cannot convert value of type 'Int' to expected condition type 'Bool'}}
+
+if 0? {} // expected-error {{cannot use optional chaining on non-optional value of type 'Int'}}
+// expected-error@-1{{cannot convert value of type 'Int?' to expected condition type 'Bool'}}
+if (0?) {} // expected-error {{cannot use optional chaining on non-optional value of type 'Int'}}
+// expected-error@-1{{cannot convert value of type 'Int?' to expected condition type 'Bool'}}
+if 0?? {} // expected-error 2{{cannot use optional chaining on non-optional value of type 'Int'}}
+// expected-error@-1{{cannot convert value of type 'Int?' to expected condition type 'Bool'}}
+
+let _ = 0? as Int? // expected-error {{cannot use optional chaining on non-optional value of type 'Int'}}
+let _ = nil? as Int? // expected-error {{'?' must be followed by a call, member lookup, or subscript}}
+let _ = ""? as String? // expected-error {{cannot use optional chaining on non-optional value of type 'String'}}

--- a/test/Sema/pound_assert.swift
+++ b/test/Sema/pound_assert.swift
@@ -8,6 +8,6 @@
 
 #assert(false, "error message")
 
-#assert(123) // expected-error{{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+#assert(123) // expected-error{{cannot convert value of type 'Int' to expected condition type 'Bool'}}
 
-#assert(123, "error message") // expected-error{{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+#assert(123, "error message") // expected-error{{cannot convert value of type 'Int' to expected condition type 'Bool'}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -36,7 +36,7 @@ func basictest() {
 
   var x4 : Bool = true
   var x5 : Bool =
-        4 // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+        4 // expected-error {{cannot convert value of type 'Int' to specified type 'Bool'}}
 
   //var x6 : Float = 4+5
 
@@ -297,7 +297,7 @@ func fib(_ n: Int) -> Int {
 
 // FIXME: Should warn about integer constants being too large <rdar://problem/14070127>
 var
-   il_a: Bool = 4  // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+   il_a: Bool = 4  // expected-error {{cannot convert value of type 'Int' to specified type 'Bool'}}
 var il_b: Int8
    = 123123
 var il_c: Int8 = 4  // ok

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -525,7 +525,7 @@ func fn(x: Int) {
 }
 
 func bad_if() {
-  if 1 {} // expected-error {{type 'Int' cannot be used as a boolean; test for '!= 0' instead}}
+  if 1 {} // expected-error {{integer literal value '1' cannot be used as a boolean; did you mean 'true'?}} {{6-7=true}}
   if (x: false) {} // expected-error {{cannot convert value of type '(x: Bool)' to expected condition type 'Bool'}}
   if (x: 1) {} // expected-error {{cannot convert value of type '(x: Int)' to expected condition type 'Bool'}}
   if nil {} // expected-error {{'nil' is not compatible with expected condition type 'Bool'}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Improving integer literal diagnostics to avoid `test for '!= 0' instead` as they don't make sense in a literal context.
Also additionally covering cases where we currently produce a `Optional type 'Int?' cannot be used as a boolean; test for '!= nil' instead` on contextual mismatch in situations like `if 0? {}` in the same way.

There is an extra case to cover on this 
```swift
let variable = 0
if variable? {} // type of expression is ambiguous without more context
```
but that is a separate situation and is covered in another issue.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves https://github.com/apple/swift/issues/63753

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
