### PR TITLE
[AST] Improve OptionalSomePattern a bit

### DIFF
--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -603,17 +603,24 @@ public:
   }
 };
 
-/// A pattern "x?" which matches ".Some(x)".
+/// A pattern "x?" which matches ".some(x)".
 class OptionalSomePattern : public Pattern {
+  const ASTContext &Ctx;
   Pattern *SubPattern;
   SourceLoc QuestionLoc;
-  EnumElementDecl *ElementDecl = nullptr;
+
+  OptionalSomePattern(const ASTContext &ctx, Pattern *subPattern,
+                      SourceLoc questionLoc)
+      : Pattern(PatternKind::OptionalSome), Ctx(ctx), SubPattern(subPattern),
+        QuestionLoc(questionLoc) {}
 
 public:
-  explicit OptionalSomePattern(Pattern *SubPattern,
-                               SourceLoc QuestionLoc)
-  : Pattern(PatternKind::OptionalSome), SubPattern(SubPattern),
-    QuestionLoc(QuestionLoc) { }
+  static OptionalSomePattern *create(ASTContext &ctx, Pattern *subPattern,
+                                     SourceLoc questionLoc);
+
+  static OptionalSomePattern *
+  createImplicit(ASTContext &ctx, Pattern *subPattern,
+                 SourceLoc questionLoc = SourceLoc());
 
   SourceLoc getQuestionLoc() const { return QuestionLoc; }
   SourceRange getSourceRange() const {
@@ -624,8 +631,8 @@ public:
   Pattern *getSubPattern() { return SubPattern; }
   void setSubPattern(Pattern *p) { SubPattern = p; }
 
-  EnumElementDecl *getElementDecl() const { return ElementDecl; }
-  void setElementDecl(EnumElementDecl *d) { ElementDecl = d; }
+  /// Retrieve the Optional.some enum element decl.
+  EnumElementDecl *getElementDecl() const;
 
   static bool classof(const Pattern *P) {
     return P->getKind() == PatternKind::OptionalSome;

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -306,6 +306,24 @@ bool Pattern::hasAnyMutableBindings() const {
   return HasMutable;
 }
 
+OptionalSomePattern *OptionalSomePattern::create(ASTContext &ctx,
+                                                 Pattern *subPattern,
+                                                 SourceLoc questionLoc) {
+  return new (ctx) OptionalSomePattern(ctx, subPattern, questionLoc);
+}
+
+OptionalSomePattern *
+OptionalSomePattern::createImplicit(ASTContext &ctx, Pattern *subPattern,
+                                    SourceLoc questionLoc) {
+  auto *P = OptionalSomePattern::create(ctx, subPattern, questionLoc);
+  P->setImplicit();
+  return P;
+}
+
+EnumElementDecl *OptionalSomePattern::getElementDecl() const {
+  return Ctx.getOptionalSomeDecl();
+}
+
 /// Return true if this is a non-resolved ExprPattern which is syntactically
 /// irrefutable.
 static bool isIrrefutableExprPattern(const ExprPattern *EP) {

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -444,8 +444,8 @@ public:
     }
 
     auto *subExpr = convertBindingsToOptionalSome(bindExpr->getSubExpr());
-    return new (Context)
-        OptionalSomePattern(subExpr, bindExpr->getQuestionLoc());
+    return OptionalSomePattern::create(Context, subExpr,
+                                       bindExpr->getQuestionLoc());
   }
 
   // Convert a x? to OptionalSome pattern.  In the AST form, this will look like
@@ -708,8 +708,7 @@ Pattern *TypeChecker::resolvePattern(Pattern *P, DeclContext *DC,
 
     // "if let" implicitly looks inside of an optional, so wrap it in an
     // OptionalSome pattern.
-    P = new (Context) OptionalSomePattern(P, P->getEndLoc());
-    P->setImplicit();
+    P = OptionalSomePattern::createImplicit(Context, P, P->getEndLoc());
   }
 
   return P;
@@ -1442,9 +1441,8 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
             if (lookupEnumMemberElement(dc,
                                         baseType->lookThroughAllOptionalTypes(),
                                         EEP->getName(), EEP->getLoc())) {
-              P = new (Context)
-                  OptionalSomePattern(EEP, EEP->getEndLoc());
-              P->setImplicit();
+              P = OptionalSomePattern::createImplicit(Context, EEP,
+                                                      EEP->getEndLoc());
               return coercePatternToType(
                   pattern.forSubPattern(P, /*retainTopLevel=*/true), type,
                   options);
@@ -1657,12 +1655,6 @@ Pattern *TypeChecker::coercePatternToType(ContextualPattern pattern,
       diags.diagnose(loc, diagID, type);
       return nullptr;
     }
-
-    EnumElementDecl *elementDecl = Context.getOptionalSomeDecl();
-    if (!elementDecl)
-      return nullptr;
-
-    OP->setElementDecl(elementDecl);
 
     Pattern *sub = OP->getSubPattern();
     auto newSubOptions = subOptions;

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1434,9 +1434,7 @@ synthesizeLazyGetterBody(AccessorDecl *Get, VarDecl *VD, VarDecl *Storage,
   Named->setType(Tmp1VD->getType());
   auto *Let = BindingPattern::createImplicit(Ctx, /*let*/ true, Named);
   Let->setType(Named->getType());
-  auto *Some = new (Ctx) OptionalSomePattern(Let, SourceLoc());
-  Some->setImplicit();
-  Some->setElementDecl(Ctx.getOptionalSomeDecl());
+  auto *Some = OptionalSomePattern::createImplicit(Ctx, Let);
   Some->setType(OptionalType::get(Let->getType()));
 
   auto *StoredValueExpr =

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1480,8 +1480,7 @@ namespace {
       }
       case PatternKind::OptionalSome: {
         auto *OSP = cast<OptionalSomePattern>(item);
-        auto &Ctx = OSP->getElementDecl()->getASTContext();
-        const Identifier name = Ctx.getOptionalSomeDecl()->getBaseIdentifier();
+        const Identifier name = OSP->getElementDecl()->getBaseIdentifier();
 
         auto subSpace = projectPattern(OSP->getSubPattern());
         // To match patterns like (_, _, ...)?, we must rewrite the underlying


### PR DESCRIPTION
Rather than having Sema set the same Optional some decl, let's just store a reference to the ASTContext and retrieve it on demand. Additionally, add `create` and `createImplicit` factory methods.