### PR TITLE
[Compile Time Constant Extraction] Extract explicit cast property init values

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -294,6 +294,11 @@ static std::shared_ptr<CompileTimeValue> extractCompileTimeValue(Expr *expr) {
           placeholderExpr->getOriginalWrappedValue());
     }
 
+    case ExprKind::Coerce: {
+      auto coerceExpr = cast<CoerceExpr>(expr);
+      return extractCompileTimeValue(coerceExpr->getSubExpr());
+    }
+
     default: {
       break;
     }

--- a/test/ConstExtraction/ExtractCoerce.swift
+++ b/test/ConstExtraction/ExtractCoerce.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: echo "[MyProto]" > %t/protocols.json
+
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractLiterals.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
+// RUN: cat %t/ExtractLiterals.swiftconstvalues 2>&1 | %FileCheck %s
+
+struct CoercableThing : ExpressibleByStringLiteral {
+    let thing: String
+    public init(unicodeScalarLiteral value: String) {
+        self.init(stringLiteral: value)
+    }
+
+    init(stringLiteral: String) {
+        self.thing = stringLiteral
+    }
+}
+
+protocol MyProto {}
+public struct TestStruct : MyProto {
+    let foo: CoercableThing = "foo"
+    let bar: CoercableThing = CoercableThing("bar")
+}
+
+// CHECK:             "label": "foo",
+// CHECK:             "valueKind": "RawLiteral",
+// CHECK:             "value": "foo"
+// CHECK:             "label": "bar",
+// CHECK:             "valueKind": "RawLiteral",
+// CHECK:             "value": "bar"


### PR DESCRIPTION
For some types which are e.g. ExpressibleByStringLiteral, we may encounter a coerce expression with a compile-time-knowable parameter/sub-expression.
