### PR TITLE
[Test] Change the -target line on some tests to use a minimum of macOS 10.13.

### DIFF
--- a/test/Concurrency/Backdeploy/linking.swift
+++ b/test/Concurrency/Backdeploy/linking.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -target %target-cpu-apple-macosx12 %s -o %t/linking_direct
 // RUN: %target-build-swift -target %target-cpu-apple-macosx11 %s -o %t/linking_rpath
-// RUN: %target-build-swift -target %target-cpu-apple-macosx10.10 %s -o %t/linking_rpath_old
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.13 %s -o %t/linking_rpath_old
 
 // RUN: otool -L %t/linking_direct | %FileCheck -check-prefix CHECK-DIRECT %s
 // RUN: otool -L %t/linking_rpath | %FileCheck -check-prefix CHECK-RPATH %s

--- a/test/Concurrency/Backdeploy/linking_maccatalyst.swift
+++ b/test/Concurrency/Backdeploy/linking_maccatalyst.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -target %target-cpu-apple-macosx12 %s -o %t/linking_direct
 // RUN: %target-build-swift -target %target-cpu-apple-macosx11 %s -o %t/linking_rpath
-// RUN: %target-build-swift -target %target-cpu-apple-macosx10.10 %s -o %t/linking_rpath_old
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.13 %s -o %t/linking_rpath_old
 
 // RUN: otool -L %t/linking_direct | %FileCheck -check-prefix CHECK-DIRECT %s
 // RUN: otool -L %t/linking_rpath | %FileCheck -check-prefix CHECK-RPATH %s

--- a/test/Runtime/stable-bit-backward-deployment.swift
+++ b/test/Runtime/stable-bit-backward-deployment.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // -- Deployment target is set to pre-10.14.4 so that we use the "old"
 //    Swift runtime bit in compiler-emitted classes
-// RUN: %target-build-swift -target %target-cpu-apple-macosx10.9 %s -module-name main -o %t/a.out
+// RUN: %target-build-swift -target %target-cpu-apple-macosx10.13 %s -module-name main -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s
 


### PR DESCRIPTION
These tests were targeting 10.9 or 10.10, but the minimum deployment target now supported by Xcode is 10.13. Bump them up to match:

test/Concurrency/Backdeploy/linking.swift
test/Concurrency/Backdeploy/linking_maccatalyst.swift
test/Runtime/stable-bit-backward-deployment.swift