### PR TITLE
[5.8][BuilderTransform] Rework missing `buildWithLimitedAvailability` detection

### DIFF
--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -1891,7 +1891,7 @@ private:
   NullablePtr<Stmt> transformIf(IfStmt *ifStmt, TypeJoinExpr *join,
                                 unsigned index) {
     // FIXME: Turn this into a condition once warning is an error.
-    (void)diagnoseMissingBuildWithAvailability(ifStmt);
+    (void)diagnoseMissingBuildWithAvailability(ifStmt, join);
 
     auto *joinVar = join->getVar();
 
@@ -1993,7 +1993,8 @@ private:
   /// have had the chance to adopt buildLimitedAvailability(), we'll upgrade
   /// this warning to an error.
   LLVM_NODISCARD
-  bool diagnoseMissingBuildWithAvailability(IfStmt *ifStmt) {
+  bool diagnoseMissingBuildWithAvailability(IfStmt *ifStmt,
+                                            TypeJoinExpr *join) {
     auto findAvailabilityCondition =
         [](StmtCondition stmtCond) -> const StmtConditionElement * {
       for (const auto &cond : stmtCond) {
@@ -2017,27 +2018,10 @@ private:
       return false;
 
     SourceLoc loc = availabilityCond->getStartLoc();
-    Type bodyType;
-    if (availabilityCond->getAvailability()->isUnavailability()) {
-      BraceStmt *elseBody = nullptr;
-      // For #unavailable, we need to check the "else".
-      if (auto *innerIf = getAsStmt<IfStmt>(ifStmt->getElseStmt())) {
-        elseBody = castToStmt<BraceStmt>(innerIf->getThenStmt());
-      } else {
-        elseBody = castToStmt<BraceStmt>(ifStmt->getElseStmt());
-      }
-
-      Type elseBodyType =
-        solution.simplifyType(solution.getType(elseBody->getLastElement()));
-      bodyType = elseBodyType;
-    } else {
-      auto *thenBody = castToStmt<BraceStmt>(ifStmt->getThenStmt());
-      Type thenBodyType =
-          solution.simplifyType(solution.getType(thenBody->getLastElement()));
-      bodyType = thenBodyType;
-    }
-
     auto builderType = solution.simplifyType(Transform.builderType);
+    // Since all of the branches of `if` statement have to join into the same
+    // type we can just use the type of the join variable here.
+    Type bodyType = solution.getResolvedType(join->getVar());
 
     return bodyType.findIf([&](Type type) {
       auto nominal = type->getAnyNominal();

--- a/test/Constraints/result_builder_availability.swift
+++ b/test/Constraints/result_builder_availability.swift
@@ -103,8 +103,6 @@ tuplify(true) { cond in
         globalFuncAvailableOn10_52()
       } else if false {
         globalFuncAvailableOn10_52()
-      } else {
-        globalFuncAvailableOn10_52()
       }
     }
   }
@@ -165,6 +163,11 @@ tuplifyWithAvailabilityErasure(true) { cond in
     cond
   } else {
     globalFuncAvailableOn10_52()
+  }
+
+  // https://github.com/apple/swift/issues/63764
+  if #unavailable(OSX 10.52) {
+    cond // Ok
   }
 }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/63768

---

* Explanation:

Fixes a crash in diagnostic code that is trying to determine
whether `buildWithLimitedAvailability` should be added to
the result builder.

Since all of the branches of an `if` statement are joined
together and hence produce the same type, that type 
should be used to check whether `buildWithLimitedAvailability`
is required but missing regardless of availability condition kind.

- Scope: Result builder transformed closures/functions with `if #unavailable` statements without `else` branch.

- Main Branch PR: https://github.com/apple/swift/pull/63768

- Resolves: rdar://105734854

- Risk: Very Low

- Reviewed By: @hborla

- Testing:  Added a regression test-case to the suite.

Resolves: rdar://105734854
Resolves: https://github.com/apple/swift/issues/63764 (cherry picked from commit c4ea02c2d74583277d50b084d61397185f598335)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
