### PR TITLE
[interop] add itanium ABI support for trapping on uncaught exceptions when making a foreign call

### DIFF
--- a/lib/IRGen/Callee.h
+++ b/lib/IRGen/Callee.h
@@ -331,6 +331,10 @@ namespace irgen {
     llvm::Type *awaitSignature = nullptr;
     bool useSignature = false;
 
+    // True when this function pointer points to a non-throwing foreign
+    // function.
+    bool isForeignNoThrow = false;
+
     explicit FunctionPointer(Kind kind, llvm::Value *value,
                              const Signature &signature)
         : FunctionPointer(kind, value, PointerAuthInfo(), signature) {}
@@ -490,6 +494,12 @@ namespace irgen {
     }
     bool shouldSuppressPolymorphicArguments() const {
       return kind.shouldSuppressPolymorphicArguments();
+    }
+
+    void setForeignNoThrow() { isForeignNoThrow = true; }
+
+    bool canThrowForeignException() const {
+      return getForeignInfo().canThrow && !isForeignNoThrow;
     }
   };
 

--- a/lib/IRGen/Callee.h
+++ b/lib/IRGen/Callee.h
@@ -335,6 +335,10 @@ namespace irgen {
     // function.
     bool isForeignNoThrow = false;
 
+    // True when this function pointer points to a foreign function that traps
+    // on exception in the always_inline thunk.
+    bool foreignCallCatchesExceptionInThunk = false;
+
     explicit FunctionPointer(Kind kind, llvm::Value *value,
                              const Signature &signature)
         : FunctionPointer(kind, value, PointerAuthInfo(), signature) {}
@@ -500,6 +504,18 @@ namespace irgen {
 
     bool canThrowForeignException() const {
       return getForeignInfo().canThrow && !isForeignNoThrow;
+    }
+
+    void setForeignCallCatchesExceptionInThunk() {
+      foreignCallCatchesExceptionInThunk = true;
+    }
+
+    bool doesForeignCallCatchExceptionInThunk() {
+      return foreignCallCatchesExceptionInThunk;
+    }
+
+    bool shouldUseInvoke() const {
+      return canThrowForeignException() && !foreignCallCatchesExceptionInThunk;
     }
   };
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3257,13 +3257,14 @@ llvm::Constant *swift::irgen::emitCXXConstructorThunkIfNeeded(
     if (fpt->isNothrow())
       canThrow = false;
   }
-  if (canThrow)
+  if (canThrow) {
+    IGM.emittedForeignFunctionThunksWithExceptionTraps.insert(thunk);
     subIGF.createExceptionTrapScope([&](llvm::BasicBlock *invokeNormalDest,
                                         llvm::BasicBlock *invokeUnwindDest) {
       subIGF.Builder.createInvoke(ctorFnType, ctorAddress, Args,
                                   invokeNormalDest, invokeUnwindDest);
     });
-  else
+  } else
     subIGF.Builder.CreateCall(ctorFnType, ctorAddress, Args);
 
   subIGF.Builder.CreateRetVoid();

--- a/lib/IRGen/GenDecl.h
+++ b/lib/IRGen/GenDecl.h
@@ -29,6 +29,7 @@ namespace llvm {
   class AttributeList;
   class Function;
   class FunctionType;
+  class CallBase;
 }
 namespace swift {
 namespace irgen {
@@ -69,6 +70,12 @@ namespace irgen {
   emitCXXConstructorThunkIfNeeded(IRGenModule &IGM, Signature signature,
                                   const clang::CXXConstructorDecl *ctor,
                                   StringRef name, llvm::Constant *ctorAddress);
+
+  llvm::CallBase *emitCXXConstructorCall(IRGenFunction &IGF,
+                                         const clang::CXXConstructorDecl *ctor,
+                                         llvm::FunctionType *ctorFnType,
+                                         llvm::Constant *ctorAddress,
+                                         llvm::ArrayRef<llvm::Value *> args);
 }
 }
 

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -648,12 +648,12 @@ namespace {
           canThrow = true;
       }
       if (canThrow) {
-        auto *invokeNormalDest = IGF.createBasicBlock("invoke.cont");
-        auto *invokeUnwindDest = IGF.createExceptionUnwindBlock();
-        IGF.Builder.createInvoke(destructorFnAddr->getFunctionType(),
-                                 destructorFnAddr, args, invokeNormalDest,
-                                 invokeUnwindDest);
-        IGF.Builder.emitBlock(invokeNormalDest);
+        IGF.createExceptionTrapScope([&](llvm::BasicBlock *invokeNormalDest,
+                                         llvm::BasicBlock *invokeUnwindDest) {
+          IGF.Builder.createInvoke(destructorFnAddr->getFunctionType(),
+                                   destructorFnAddr, args, invokeNormalDest,
+                                   invokeUnwindDest);
+        });
         return;
       }
 

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -642,10 +642,12 @@ namespace {
         args.push_back(implicitParam);
       }
       bool canThrow = false;
-      if (auto *fpt =
-              destructor->getType()->getAs<clang::FunctionProtoType>()) {
-        if (!fpt->isNothrow())
-          canThrow = true;
+      if (IGF.IGM.isForeignExceptionHandlingEnabled()) {
+        if (auto *fpt =
+                destructor->getType()->getAs<clang::FunctionProtoType>()) {
+          if (!fpt->isNothrow())
+            canThrow = true;
+        }
       }
       if (canThrow) {
         IGF.createExceptionTrapScope([&](llvm::BasicBlock *invokeNormalDest,

--- a/lib/IRGen/IRBuilder.h
+++ b/lib/IRGen/IRBuilder.h
@@ -52,7 +52,7 @@ private:
   // Set calling convention of the call instruction using
   // the same calling convention as the callee function.
   // This ensures that they are always compatible.
-  void setCallingConvUsingCallee(llvm::CallInst *Call) {
+  void setCallingConvUsingCallee(llvm::CallBase *Call) {
     auto CalleeFn = Call->getCalledFunction();
     if (CalleeFn) {
       auto CC = CalleeFn->getCallingConv();
@@ -335,6 +335,17 @@ public:
     auto Call = IRBuilderBase::CreateCall(FTy, Callee, Args, Name, FPMathTag);
     setCallingConvUsingCallee(Call);
     return Call;
+  }
+
+  llvm::InvokeInst *
+  createInvoke(llvm::FunctionType *fTy, llvm::Constant *callee,
+               ArrayRef<llvm::Value *> args, llvm::BasicBlock *invokeNormalDest,
+               llvm::BasicBlock *invokeUnwindDest, const Twine &name = "") {
+    assert((!DebugInfo || getCurrentDebugLocation()) && "no debugloc on call");
+    auto call = IRBuilderBase::CreateInvoke(fTy, callee, invokeNormalDest,
+                                            invokeUnwindDest, args, name);
+    setCallingConvUsingCallee(call);
+    return call;
   }
 
   llvm::CallBase *CreateCallOrInvoke(const FunctionPointer &fn,

--- a/lib/IRGen/IRBuilder.h
+++ b/lib/IRGen/IRBuilder.h
@@ -337,6 +337,11 @@ public:
     return Call;
   }
 
+  llvm::CallBase *CreateCallOrInvoke(const FunctionPointer &fn,
+                                     ArrayRef<llvm::Value *> args,
+                                     llvm::BasicBlock *invokeNormalDest,
+                                     llvm::BasicBlock *invokeUnwindDest);
+
   llvm::CallInst *CreateCall(const FunctionPointer &fn,
                              ArrayRef<llvm::Value *> args);
 

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -105,6 +105,10 @@ public:
 
   llvm::BasicBlock *createExceptionUnwindBlock();
 
+  void createExceptionTrapScope(
+      llvm::function_ref<void(llvm::BasicBlock *, llvm::BasicBlock *)>
+          invokeEmitter);
+
   void emitAllExtractValues(llvm::Value *aggValue, llvm::StructType *type,
                             Explosion &out);
 

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -103,6 +103,8 @@ public:
   void emitBBForReturn();
   bool emitBranchToReturnBB();
 
+  llvm::BasicBlock *createExceptionUnwindBlock();
+
   void emitAllExtractValues(llvm::Value *aggValue, llvm::StructType *type,
                             Explosion &out);
 
@@ -195,6 +197,10 @@ private:
 
   /// The unique block that calls @llvm.coro.end.
   llvm::BasicBlock *CoroutineExitBlock = nullptr;
+
+  /// The blocks that handle thrown exceptions from all throwing foreign calls
+  /// in this function.
+  llvm::SmallVector<llvm::BasicBlock *, 4> ExceptionUnwindBlocks;
 
 public:
   void emitCoroutineOrAsyncExit();

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -105,6 +105,10 @@ public:
 
   llvm::BasicBlock *createExceptionUnwindBlock();
 
+  void setCallsThunksWithForeignExceptionTraps() {
+    callsAnyAlwaysInlineThunksWithForeignExceptionTraps = true;
+  }
+
   void createExceptionTrapScope(
       llvm::function_ref<void(llvm::BasicBlock *, llvm::BasicBlock *)>
           invokeEmitter);
@@ -205,6 +209,10 @@ private:
   /// The blocks that handle thrown exceptions from all throwing foreign calls
   /// in this function.
   llvm::SmallVector<llvm::BasicBlock *, 4> ExceptionUnwindBlocks;
+
+  /// True if this function calls any always inline thunks that have a foreign
+  /// exception trap.
+  bool callsAnyAlwaysInlineThunksWithForeignExceptionTraps = false;
 
 public:
   void emitCoroutineOrAsyncExit();

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -959,9 +959,13 @@ private:
   /// module.
   llvm::Function *foreignExceptionHandlingPersonalityFunc = nullptr;
 
+public:
+  /// The set of emitted foreign function thunks that trap on exception in the
+  /// underlying call that the thunk dispatches.
+  llvm::SmallPtrSet<llvm::Function *, 4>
+      emittedForeignFunctionThunksWithExceptionTraps;
 
 //--- Types -----------------------------------------------------------------
-public:
   const ProtocolInfo &getProtocolInfo(ProtocolDecl *D, ProtocolInfoKind kind);
 
   // Not strictly a type operation, but similar.

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -955,6 +955,10 @@ private:
   // emitted.
   llvm::DenseMap<llvm::GlobalVariable*, llvm::CallInst*> AsyncCoroIDsForPadding;
 
+  /// The personality function used for foreign exception handling in this
+  /// module.
+  llvm::Function *foreignExceptionHandlingPersonalityFunc = nullptr;
+
 
 //--- Types -----------------------------------------------------------------
 public:
@@ -1800,6 +1804,8 @@ public:
   /// the SIL function is correctly lowered even if the lowering passes do not
   /// run on the SIL module that owns this function.
   void lowerSILFunction(SILFunction *f);
+
+  llvm::Function *getForeignExceptionHandlingPersonalityFunc();
 
 private:
   llvm::Constant *

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1807,6 +1807,8 @@ public:
 
   llvm::Function *getForeignExceptionHandlingPersonalityFunc();
 
+  bool isForeignExceptionHandlingEnabled() const;
+
 private:
   llvm::Constant *
   getAddrOfSharedContextDescriptor(LinkEntity entity,

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2739,6 +2739,8 @@ void IRGenSILFunction::visitFunctionRefBaseInst(FunctionRefBaseInst *i) {
           fp.setForeignNoThrow();
       }
     }
+    if (IGM.emittedForeignFunctionThunksWithExceptionTraps.count(fnPtr))
+      fp.setForeignCallCatchesExceptionInThunk();
   }
   // Store the function as a FunctionPointer so we can avoid bitcasting
   // or thunking if we don't need to.

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2731,7 +2731,15 @@ void IRGenSILFunction::visitFunctionRefBaseInst(FunctionRefBaseInst *i) {
   }
   FunctionPointer fp =
       FunctionPointer::forDirect(fpKind, value, secondaryValue, sig);
-
+  // Update the foreign no-throw information if needed.
+  if (const auto *cd = fn->getClangDecl()) {
+    if (auto *cfd = dyn_cast<clang::FunctionDecl>(cd)) {
+      if (auto *cft = cfd->getType()->getAs<clang::FunctionProtoType>()) {
+        if (cft->isNothrow())
+          fp.setForeignNoThrow();
+      }
+    }
+  }
   // Store the function as a FunctionPointer so we can avoid bitcasting
   // or thunking if we don't need to.
   setLoweredFunctionPointer(i, fp);

--- a/lib/IRGen/Signature.h
+++ b/lib/IRGen/Signature.h
@@ -53,6 +53,8 @@ class TypeInfo;
 class ForeignFunctionInfo {
 public:
   const clang::CodeGen::CGFunctionInfo *ClangInfo = nullptr;
+  /// True if the foreign function can throw an Objective-C / C++ exception.
+  bool canThrow = false;
 };
 
 /// An encapsulation of the extra lowering information we might want to

--- a/test/ClangImporter/cxx_interop_ir.swift
+++ b/test/ClangImporter/cxx_interop_ir.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftxx-frontend -module-name cxx_ir -I %S/Inputs/custom-modules -emit-ir -o - -primary-file %s | %FileCheck %s
+// RUN: %target-swiftxx-frontend -module-name cxx_ir -I %S/Inputs/custom-modules -emit-ir -o - -primary-file %s -Xcc -fignore-exceptions | %FileCheck %s
 
 // https://github.com/apple/swift/issues/55575
 // We can't yet call member functions correctly on Windows.

--- a/test/Interop/Cxx/class/constructors-copy-irgen-macosx.swift
+++ b/test/Interop/Cxx/class/constructors-copy-irgen-macosx.swift
@@ -1,6 +1,6 @@
 // Target-specific tests for C++ copy constructor code generation.
 
-// RUN: %swift -module-name MySwift -target x86_64-apple-macosx10.9 -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_X64
+// RUN: %swift -module-name MySwift -target x86_64-apple-macosx10.9 -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info -Xcc -fignore-exceptions | %FileCheck %s -check-prefix=ITANIUM_X64
 
 // REQUIRES: OS=macosx
 // REQUIRES: CPU=x86_64

--- a/test/Interop/Cxx/class/constructors-irgen-macosx.swift
+++ b/test/Interop/Cxx/class/constructors-irgen-macosx.swift
@@ -1,6 +1,6 @@
 // Target-specific tests for C++ constructor call code generation.
 
-// RUN: %swift -module-name MySwift -target x86_64-apple-macosx10.9 -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_X64
+// RUN: %swift -module-name MySwift -target x86_64-apple-macosx10.9 -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info -Xcc -fignore-exceptions | %FileCheck %s -check-prefix=ITANIUM_X64
 
 // REQUIRES: OS=macosx
 // REQUIRES: CPU=x86_64

--- a/test/Interop/Cxx/class/constructors-objc-irgen.swift
+++ b/test/Interop/Cxx/class/constructors-objc-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -Xcc -fignore-exceptions | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/Interop/Cxx/class/protocol-conformance-irgen.swift
+++ b/test/Interop/Cxx/class/protocol-conformance-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s -Xcc -fignore-exceptions | %FileCheck %s
 
 import ProtocolConformance
 

--- a/test/Interop/Cxx/class/type-classification-non-trivial-irgen.swift
+++ b/test/Interop/Cxx/class/type-classification-non-trivial-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swiftxx-frontend -I %S/Inputs %s -emit-ir | %FileCheck %s
+// RUN: %target-swiftxx-frontend -I %S/Inputs %s -emit-ir -Xcc -fignore-exceptions | %FileCheck %s
 
 // Verify that non-trivial/address-only C++ classes are constructed and accessed
 // correctly. Make sure that we correctly IRGen functions that construct

--- a/test/Interop/Cxx/exceptions/exceptions-disabled-exception-irgen.swift
+++ b/test/Interop/Cxx/exceptions/exceptions-disabled-exception-irgen.swift
@@ -24,6 +24,13 @@ inline int freeFunctionNoThrow(int x) noexcept {
   return -x;
 }
 
+class ClassWithThrowingCopyConstructor {
+public:
+  int m = 0;
+  inline ClassWithThrowingCopyConstructor() noexcept {}
+  inline ClassWithThrowingCopyConstructor(const ClassWithThrowingCopyConstructor &) { (void)freeFunctionThrows(0); }
+};
+
 //--- test.swift
 
 import CxxModule
@@ -43,8 +50,15 @@ func testFreeFunctionCalls() -> CInt {
   return p
 }
 
+func testClassWithThrowingCopyConstructor() -> CInt {
+  let p1 = ClassWithThrowingCopyConstructor()
+  let p2 = p1
+  return p2.m
+}
+
 let _ = testFreeFunctionNoThrowOnly()
 let _ = testFreeFunctionCalls()
+let _ = testClassWithThrowingCopyConstructor()
 
 // CHECK: define {{.*}} @"$s4test0A23FreeFunctionNoThrowOnlys5Int32VyF"() #[[#SWIFTMETA:]] {
 // CHECK-NEXT: :
@@ -60,3 +74,7 @@ let _ = testFreeFunctionCalls()
 // CHECK: call i32 @{{_Z18freeFunctionThrowsi|"\?freeFunctionThrows@@YAHH@Z"}}(i32
 // CHECK: ret i32
 // CHECK-NEXT: }
+
+// CHECK: define {{.*}} @"$s4test0A32ClassWithThrowingCopyConstructors5Int32VyF"() #[[#SWIFTMETA]] {
+// CHECK-NOT: invoke
+// CHECK: }

--- a/test/Interop/Cxx/exceptions/exceptions-disabled-exception-irgen.swift
+++ b/test/Interop/Cxx/exceptions/exceptions-disabled-exception-irgen.swift
@@ -31,6 +31,12 @@ public:
   inline ClassWithThrowingCopyConstructor(const ClassWithThrowingCopyConstructor &) { (void)freeFunctionThrows(0); }
 };
 
+class ClassWithThrowingConstructor {
+public:
+  int m = 0;
+  inline ClassWithThrowingConstructor() { }
+};
+
 //--- test.swift
 
 import CxxModule
@@ -56,9 +62,15 @@ func testClassWithThrowingCopyConstructor() -> CInt {
   return p2.m
 }
 
+func testClassWithThrowingConstructor() -> CInt {
+  let obj = ClassWithThrowingConstructor()
+  return obj.m
+}
+
 let _ = testFreeFunctionNoThrowOnly()
 let _ = testFreeFunctionCalls()
 let _ = testClassWithThrowingCopyConstructor()
+let _ = testClassWithThrowingConstructor()
 
 // CHECK: define {{.*}} @"$s4test0A23FreeFunctionNoThrowOnlys5Int32VyF"() #[[#SWIFTMETA:]] {
 // CHECK-NEXT: :
@@ -76,5 +88,9 @@ let _ = testClassWithThrowingCopyConstructor()
 // CHECK-NEXT: }
 
 // CHECK: define {{.*}} @"$s4test0A32ClassWithThrowingCopyConstructors5Int32VyF"() #[[#SWIFTMETA]] {
+// CHECK-NOT: invoke
+// CHECK: }
+
+// CHECK: define {{.*}} @"$s4test0A28ClassWithThrowingConstructors5Int32VyF"() #[[#SWIFTMETA]] {
 // CHECK-NOT: invoke
 // CHECK: }

--- a/test/Interop/Cxx/exceptions/exceptions-disabled-exception-irgen.swift
+++ b/test/Interop/Cxx/exceptions/exceptions-disabled-exception-irgen.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %S/trap-on-exception-irgen-itanium.swift %t
+
+// RUN: %target-swift-emit-ir %t/test.swift -I %t -enable-experimental-cxx-interop -Xcc -fignore-exceptions | %FileCheck %s
+
+// note: The test sources are in 'trap-on-exception-irgen-itanium.swift'
+
+// CHECK: define {{.*}} @"$s4test0A23FreeFunctionNoThrowOnlys5Int32VyF"() #[[#SWIFTMETA:]] {
+// CHECK-NEXT: :
+// CHECK-NEXT:  call swiftcc i32 @"$s4test8makeCInts5Int32VyF"()
+// CHECK-NEXT:  call i32 @{{_Z19freeFunctionNoThrowi|"\?freeFunctionNoThrow@@YAHH@Z"}}(i32 {{.*}})
+// CHECK-NEXT:  ret i32
+// CHECK-NEXT: }
+
+// CHECK: define {{.*}} @"$s4test0A17FreeFunctionCallss5Int32VyF"() #[[#SWIFTMETA]] {
+// CHECK: call i32 @{{_Z18freeFunctionThrowsi|"\?freeFunctionThrows@@YAHH@Z"}}(i32 0)
+// CHECK: call i32 @{{_Z19freeFunctionNoThrowi|"\?freeFunctionNoThrow@@YAHH@Z"}}(i32 1)
+// CHECK: call swiftcc i32 @"$s4test8makeCInts5Int32VyF"()
+// CHECK: call i32 @{{_Z18freeFunctionThrowsi|"\?freeFunctionThrows@@YAHH@Z"}}(i32
+// CHECK: ret i32
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/exceptions/exceptions-disabled-exception-irgen.swift
+++ b/test/Interop/Cxx/exceptions/exceptions-disabled-exception-irgen.swift
@@ -1,9 +1,50 @@
 // RUN: %empty-directory(%t)
-// RUN: split-file %S/trap-on-exception-irgen-itanium.swift %t
+// RUN: split-file %s %t
 
-// RUN: %target-swift-emit-ir %t/test.swift -I %t -enable-experimental-cxx-interop -Xcc -fignore-exceptions | %FileCheck %s
+// RUN: %target-swift-emit-ir %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop -Xcc -fignore-exceptions | %FileCheck %s
+// RUN: %target-swift-emit-ir %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop -Xcc -fno-exceptions -Xcc -fno-objc-exceptions  -Xcc -DNOEXCEPTION | %FileCheck %s
 
-// note: The test sources are in 'trap-on-exception-irgen-itanium.swift'
+//--- Inputs/module.modulemap
+module CxxModule {
+    header "cxxHeader.h"
+    requires cplusplus
+}
+
+//--- Inputs/cxxHeader.h
+
+inline int freeFunctionThrows(int x) {
+#ifndef NOEXCEPTION
+  if (x > 0)
+    throw 2;
+#endif
+  return -x;
+}
+
+inline int freeFunctionNoThrow(int x) noexcept {
+  return -x;
+}
+
+//--- test.swift
+
+import CxxModule
+
+func makeCInt() -> CInt {
+  return 42
+}
+
+func testFreeFunctionNoThrowOnly() -> CInt {
+  return freeFunctionNoThrow(makeCInt())
+}
+
+func testFreeFunctionCalls() -> CInt {
+  let p = freeFunctionThrows(0)
+  freeFunctionNoThrow(1)
+  freeFunctionThrows(makeCInt())
+  return p
+}
+
+let _ = testFreeFunctionNoThrowOnly()
+let _ = testFreeFunctionCalls()
 
 // CHECK: define {{.*}} @"$s4test0A23FreeFunctionNoThrowOnlys5Int32VyF"() #[[#SWIFTMETA:]] {
 // CHECK-NEXT: :

--- a/test/Interop/Cxx/exceptions/objc-trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/objc-trap-on-exception-irgen-itanium.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-emit-ir %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+
+// REQUIRES: objc_interop
+// UNSUPPORTED: OS=windows-msvc
+
+//--- Inputs/module.modulemap
+module ObjCXXModule {
+    header "objCXXHeader.h"
+}
+
+//--- Inputs/objCXXHeader.h
+
+@interface ObjCInterface
+
+- (void)method;
+
+@end
+
+ObjCInterface * _Nonnull retObjCInterface() noexcept;
+
+//--- test.swift
+
+import ObjCXXModule
+
+func testObjCMethodCall() {
+  let obj = retObjCInterface();
+  obj.method();
+}
+
+testObjCMethodCall()
+
+// CHECK: define {{.*}} @"$s4test0A14ObjCMethodCallyyF"() #[[#UWATTR:]] personality
+// CHECK: invoke void {{.*}} @objc_msgSend
+// CHECK-NEXT: to label %[[CONT1:.*]] unwind label %[[UNWIND1:.*]]
+// CHECK-EMPTY:
+// CHECK-NEXT: [[CONT1]]:
+// CHECK:  ret
+// CHECK-EMPTY:
+// CHECK-NEXT: [[UNWIND1]]:
+// CHECK-NEXT: landingpad { i8*, i32 }
+// CHECK-NEXT:    catch i8* null
+// CHECK-NEXT: call void @llvm.trap()
+// CHECK-NEXT: unreachable
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/exceptions/trap-on-exception-execution.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-execution.swift
@@ -9,7 +9,7 @@
 // RUN: %target-codesign %t/trap-exceptions-no-debug
 // RUN: %target-run %t/trap-exceptions-no-debug
 
-// RUN: %target-build-swift %s -I %t/Inputs -o %t/trap-exceptions-opt -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -O
+// RUN: %target-build-swift %s -I %t/Inputs -o %t/trap-exceptions-opt -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -O -DOPTIMIZE
 // RUN: %target-codesign %t/trap-exceptions-opt
 // RUN: %target-run %t/trap-exceptions-opt
 
@@ -92,5 +92,15 @@ TrapOnExecutionTestSuite.test("TestClassWithThrowingDestructor") {
   expectCrashLater()
   let _ = ClassWithThrowingDestructor()
 }
+
+#if OPTIMIZE
+#else
+TrapOnExecutionTestSuite.test("TestClassWithThrowingCopyConstructor") {
+  expectCrashLater()
+  let p1 = ClassWithThrowingCopyConstructor()
+  let p2 = p1
+  expectEqual(p2.m, 0)
+}
+#endif
 
 runAllTests()

--- a/test/Interop/Cxx/exceptions/trap-on-exception-execution.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-execution.swift
@@ -67,4 +67,25 @@ TrapOnExecutionTestSuite.test("TestTemplateBoolDependentNoExceptMethod") {
   v.dependentNoExceptMethod()
 }
 
+protocol MethodProtocol {
+  func method(_ x: CInt) -> CInt
+}
+
+extension TestClass: MethodProtocol {
+}
+
+TrapOnExecutionTestSuite.test("TestProtocolConformanceThunkInvoke") {
+  let v = TestClass()
+  let p: MethodProtocol = v
+  expectCrashLater()
+  let _ = p.method(2)
+}
+
+TrapOnExecutionTestSuite.test("TestClassWithSubscript") {
+  let v = ClassWithSubscript()
+  expectEqual(v[0], 0)
+  expectCrashLater()
+  let _ = v[1]
+}
+
 runAllTests()

--- a/test/Interop/Cxx/exceptions/trap-on-exception-execution.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-execution.swift
@@ -1,0 +1,70 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %S/trap-on-exception-irgen-itanium.swift %t
+
+// RUN: %target-build-swift %s -I %t -o %t/trap-exceptions -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -g
+// RUN: %target-codesign %t/trap-exceptions
+// RUN: %target-run %t/trap-exceptions
+
+// RUN: %target-build-swift %s -I %t -o %t/trap-exceptions-no-debug -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none
+// RUN: %target-codesign %t/trap-exceptions-no-debug
+// RUN: %target-run %t/trap-exceptions-no-debug
+
+// RUN: %target-build-swift %s -I %t -o %t/trap-exceptions-opt -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -O
+// RUN: %target-codesign %t/trap-exceptions-opt
+// RUN: %target-run %t/trap-exceptions-opt
+
+// REQUIRES: executable_test
+
+// FIXME: Support MSVC exceptions.
+// UNSUPPORTED: OS=windows-msvc
+
+import CxxModule
+import StdlibUnittest
+
+func makeCInt() -> CInt {
+  return 42
+}
+
+var TrapOnExecutionTestSuite = TestSuite("TrapOnExecution")
+
+TrapOnExecutionTestSuite.test("freeFunctionNoThrow") {
+  expectEqual(freeFunctionNoThrow(makeCInt()), -42)
+}
+
+TrapOnExecutionTestSuite.test("freeFunctionThrows") {
+  expectCrashLater()
+  let _ = freeFunctionThrows(2)
+}
+
+TrapOnExecutionTestSuite.test("freeFunctionThrowsNoException") {
+  expectEqual(freeFunctionThrows(-1), 1)
+}
+
+TrapOnExecutionTestSuite.test("freeFunctionCatchesException") {
+  expectEqual(freeFunctionCatchesException(-1), 1)
+  expectEqual(freeFunctionCatchesException(2), 2)
+}
+
+TrapOnExecutionTestSuite.test("TestClassMethodThrows") {
+  expectCrashLater()
+  let v = TestClass()
+  v.method(2)
+}
+
+TrapOnExecutionTestSuite.test("TestClassNoExceptMethod") {
+  var v = TestClass()
+  expectEqual(v.noExceptMethod(1), -1)
+}
+
+TrapOnExecutionTestSuite.test("TestTemplateIntDependentNoExceptMethod") {
+  var v = TestTemplateInt()
+  v.dependentNoExceptMethod()
+}
+
+TrapOnExecutionTestSuite.test("TestTemplateBoolDependentNoExceptMethod") {
+  expectCrashLater()
+  var v = TestTemplateBool()
+  v.dependentNoExceptMethod()
+}
+
+runAllTests()

--- a/test/Interop/Cxx/exceptions/trap-on-exception-execution.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-execution.swift
@@ -9,7 +9,7 @@
 // RUN: %target-codesign %t/trap-exceptions-no-debug
 // RUN: %target-run %t/trap-exceptions-no-debug
 
-// RUN: %target-build-swift %s -I %t/Inputs -o %t/trap-exceptions-opt -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -O -DOPTIMIZE
+// RUN: %target-build-swift %s -I %t/Inputs -o %t/trap-exceptions-opt -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -O
 // RUN: %target-codesign %t/trap-exceptions-opt
 // RUN: %target-run %t/trap-exceptions-opt
 
@@ -93,15 +93,15 @@ TrapOnExecutionTestSuite.test("TestClassWithThrowingDestructor") {
   let _ = ClassWithThrowingDestructor()
 }
 
-#if OPTIMIZE
-#else
 TrapOnExecutionTestSuite.test("TestClassWithThrowingCopyConstructor") {
   expectCrashLater()
   let p1 = ClassWithThrowingCopyConstructor()
-  let p2 = p1
+  var p2 = p1
   expectEqual(p2.m, 0)
+  p2.m = 1
+  expectEqual(p2.m, 1)
+  expectEqual(p1.m, 0)
 }
-#endif
 
 TrapOnExecutionTestSuite.test("ClassWithThrowingConstructor") {
   expectCrashLater()

--- a/test/Interop/Cxx/exceptions/trap-on-exception-execution.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-execution.swift
@@ -1,15 +1,15 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %S/trap-on-exception-irgen-itanium.swift %t
 
-// RUN: %target-build-swift %s -I %t -o %t/trap-exceptions -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -g
+// RUN: %target-build-swift %s -I %t/Inputs -o %t/trap-exceptions -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -g
 // RUN: %target-codesign %t/trap-exceptions
 // RUN: %target-run %t/trap-exceptions
 
-// RUN: %target-build-swift %s -I %t -o %t/trap-exceptions-no-debug -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none
+// RUN: %target-build-swift %s -I %t/Inputs -o %t/trap-exceptions-no-debug -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none
 // RUN: %target-codesign %t/trap-exceptions-no-debug
 // RUN: %target-run %t/trap-exceptions-no-debug
 
-// RUN: %target-build-swift %s -I %t -o %t/trap-exceptions-opt -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -O
+// RUN: %target-build-swift %s -I %t/Inputs -o %t/trap-exceptions-opt -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -O
 // RUN: %target-codesign %t/trap-exceptions-opt
 // RUN: %target-run %t/trap-exceptions-opt
 

--- a/test/Interop/Cxx/exceptions/trap-on-exception-execution.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-execution.swift
@@ -103,4 +103,14 @@ TrapOnExecutionTestSuite.test("TestClassWithThrowingCopyConstructor") {
 }
 #endif
 
+TrapOnExecutionTestSuite.test("ClassWithThrowingConstructor") {
+  expectCrashLater()
+  let _ = ClassWithThrowingConstructor()
+}
+
+TrapOnExecutionTestSuite.test("ClassWithNoThrowingConstructor") {
+  let obj = ClassWithNoThrowingConstructor()
+  expectEqual(obj.m, 0)
+}
+
 runAllTests()

--- a/test/Interop/Cxx/exceptions/trap-on-exception-execution.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-execution.swift
@@ -88,4 +88,9 @@ TrapOnExecutionTestSuite.test("TestClassWithSubscript") {
   let _ = v[1]
 }
 
+TrapOnExecutionTestSuite.test("TestClassWithThrowingDestructor") {
+  expectCrashLater()
+  let _ = ClassWithThrowingDestructor()
+}
+
 runAllTests()

--- a/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
@@ -369,19 +369,15 @@ let _ = testClassWithNoThrowingConstructor()
 // CHECK-NOT: invoke
 // CHECK: }
 
-// CHECK: define {{.*}} @"$s4test0A32ClassWithThrowingCopyConstructors5Int32VyF"() #[[#SWIFTMETA]] personality
+// CHECK: define {{.*}} @"$s4test0A32ClassWithThrowingCopyConstructors5Int32VyF"() #[[#SWIFTUWMETA]] personality
 // CHECK: invoke {{.*}} @_ZN32ClassWithThrowingCopyConstructorC1ERKS_(
 // CHECK-NEXT:  to label %[[CONT41:.*]] unwind label %[[UNWIND41:.*]]
-// CHECK-EMPTY:
-// CHECK-NEXT: [[UNWIND41]]:
+
+// CHECK: [[UNWIND41]]:
 // CHECK-NEXT: landingpad { i8*, i32 }
 // CHECK-NEXT:    catch i8* null
 // CHECK-NEXT: call void @llvm.trap()
 // CHECK-NEXT: unreachable
-// CHECK-EMPTY:
-// CHECK: [[CONT41]]:
-// CHECK: ret i32
-// CHECK-NEXT: }
 
 // CHECK: define {{.*}} @"$s4test0A28ClassWithThrowingConstructors5Int32VyF"() #[[#SWIFTUWMETA]] personality
 // CHECK: invoke {{.*}} @_ZN28ClassWithThrowingConstructorC{{.*}}(

--- a/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
 
-// RUN: %target-swift-emit-ir %t/test.swift -I %t -enable-experimental-cxx-interop | %FileCheck %s
-// RUN: %target-swift-emit-ir %t/test.swift -I %t -enable-experimental-cxx-interop -g | %FileCheck --check-prefix=DEBUG %s
+// RUN: %target-swift-emit-ir %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop -g | %FileCheck --check-prefix=DEBUG %s
 
 // UNSUPPORTED: OS=windows-msvc
 

--- a/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
@@ -370,7 +370,7 @@ let _ = testClassWithNoThrowingConstructor()
 // CHECK: }
 
 // CHECK: define {{.*}} @"$s4test0A32ClassWithThrowingCopyConstructors5Int32VyF"() #[[#SWIFTUWMETA]] personality
-// CHECK: invoke {{.*}} @_ZN32ClassWithThrowingCopyConstructorC1ERKS_(
+// CHECK: invoke {{.*}} @_ZN32ClassWithThrowingCopyConstructorC{{1|2}}ERKS_(
 // CHECK-NEXT:  to label %[[CONT41:.*]] unwind label %[[UNWIND41:.*]]
 
 // CHECK: [[UNWIND41]]:
@@ -380,18 +380,14 @@ let _ = testClassWithNoThrowingConstructor()
 // CHECK-NEXT: unreachable
 
 // CHECK: define {{.*}} @"$s4test0A28ClassWithThrowingConstructors5Int32VyF"() #[[#SWIFTUWMETA]] personality
-// CHECK: invoke {{.*}} @_ZN28ClassWithThrowingConstructorC{{.*}}(
+// CHECK: invoke {{.*}} @_ZN28ClassWithThrowingConstructorC{{.*}}(%{{.*}}* %[[#CONSTRUCTORTHIS:]])
 // CHECK-NEXT:  to label %[[CONT42:.*]] unwind label %[[UNWIND42:.*]]
-// CHECK-EMPTY:
-// CHECK-NEXT: [[UNWIND42]]:
+
+// CHECK: [[UNWIND42]]:
 // CHECK-NEXT: landingpad { i8*, i32 }
 // CHECK-NEXT:    catch i8* null
 // CHECK-NEXT: call void @llvm.trap()
 // CHECK-NEXT: unreachable
-// CHECK-EMPTY:
-// CHECK-NEXT: [[CONT42]]:
-// CHECK: ret i32
-// CHECK-NEXT: }
 
 // CHECK: define {{.*}} @"$s4test0A30ClassWithNoThrowingConstructors5Int32VyF"() #[[#SWIFTMETA]]
 // CHECK-NOT: invoke

--- a/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
@@ -81,6 +81,14 @@ CFreeFunctionTy getCFreeFunctionPointer() noexcept;
 
 }
 
+class ClassWithSubscript {
+  int m = 0;
+public:
+  int operator[](int x) const {
+    return freeFunctionThrows(x);
+  }
+};
+
 //--- test.swift
 
 import CxxModule
@@ -142,6 +150,11 @@ func testProtocolConformanceThunkInvoke() {
   let _ = p.method(2)
 }
 
+func testSubscriptThunkInvoke() -> CInt {
+  let v = ClassWithSubscript()
+  return v[0]
+}
+
 let _ = testFreeFunctionNoThrowOnly()
 let _ = testFreeFunctionCalls()
 let _ = testMethodCalls()
@@ -149,6 +162,7 @@ testTemplateCalls()
 testFuncPtrCall()
 testCFuncPtrCall()
 testProtocolConformanceThunkInvoke()
+let _ = testSubscriptThunkInvoke()
 
 // CHECK: define {{.*}} @"$s4test0A23FreeFunctionNoThrowOnlys5Int32VyF"() #[[#SWIFTMETA:]] {
 // CHECK-NEXT: :
@@ -252,6 +266,9 @@ testProtocolConformanceThunkInvoke()
 // CHECK: define {{.*}} @"$s4test0A30ProtocolConformanceThunkInvokeyyF"() #[[#SWIFTMETA]]
 // CHECK-NOT: invoke
 // CHECK: }
+
+// CHECK: define {{.*}} @"$s4test0A20SubscriptThunkInvokes5Int32VyF"() #[[#SWIFTUWMETA]]
+// CHECK: invoke i32 @_ZNK18ClassWithSubscriptixEi
 
 // CHECK: i32 @__gxx_personality_v0(...)
 

--- a/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
@@ -119,6 +119,18 @@ public:
   inline ClassWithThrowingCopyConstructor(const ClassWithThrowingCopyConstructor &) { throw 2; }
 };
 
+class ClassWithThrowingConstructor {
+public:
+  int m = 0;
+  inline ClassWithThrowingConstructor() { throw 2; }
+};
+
+class ClassWithNoThrowingConstructor {
+public:
+  int m = 0;
+  inline ClassWithNoThrowingConstructor() noexcept {}
+};
+
 //--- test.swift
 
 import CxxModule
@@ -205,6 +217,16 @@ func testClassWithThrowingCopyConstructor() -> CInt {
   return p2.m
 }
 
+func testClassWithThrowingConstructor() -> CInt {
+  let obj = ClassWithThrowingConstructor()
+  return obj.m
+}
+
+func testClassWithNoThrowingConstructor() -> CInt {
+  let obj = ClassWithNoThrowingConstructor()
+  return obj.m
+}
+
 let _ = testFreeFunctionNoThrowOnly()
 let _ = testFreeFunctionCalls()
 let _ = testMethodCalls()
@@ -217,6 +239,8 @@ testClassWithDestructor()
 testClassWithThrowingDestructor()
 let _ = testClassWithCopyConstructor()
 let _ = testClassWithThrowingCopyConstructor()
+let _ = testClassWithThrowingConstructor()
+let _ = testClassWithNoThrowingConstructor()
 
 // CHECK: define {{.*}} @"$s4test0A23FreeFunctionNoThrowOnlys5Int32VyF"() #[[#SWIFTMETA:]] {
 // CHECK-NEXT: :
@@ -358,6 +382,24 @@ let _ = testClassWithThrowingCopyConstructor()
 // CHECK: [[CONT41]]:
 // CHECK: ret i32
 // CHECK-NEXT: }
+
+// CHECK: define {{.*}} @"$s4test0A28ClassWithThrowingConstructors5Int32VyF"() #[[#SWIFTUWMETA]] personality
+// CHECK: invoke {{.*}} @_ZN28ClassWithThrowingConstructorC{{.*}}(
+// CHECK-NEXT:  to label %[[CONT42:.*]] unwind label %[[UNWIND42:.*]]
+// CHECK-EMPTY:
+// CHECK-NEXT: [[UNWIND42]]:
+// CHECK-NEXT: landingpad { i8*, i32 }
+// CHECK-NEXT:    catch i8* null
+// CHECK-NEXT: call void @llvm.trap()
+// CHECK-NEXT: unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: [[CONT42]]:
+// CHECK: ret i32
+// CHECK-NEXT: }
+
+// CHECK: define {{.*}} @"$s4test0A30ClassWithNoThrowingConstructors5Int32VyF"() #[[#SWIFTMETA]]
+// CHECK-NOT: invoke
+// CHECK: }
 
 // CHECK: i32 @__gxx_personality_v0(...)
 

--- a/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
@@ -129,12 +129,26 @@ func testCFuncPtrCall() {
   funcPtr()
 }
 
+protocol TestMethodProtocol {
+  func method(_ x: CInt) -> CInt
+}
+
+extension TestClass: TestMethodProtocol {
+}
+
+func testProtocolConformanceThunkInvoke() {
+  let v = TestClass()
+  let p: TestMethodProtocol = v
+  let _ = p.method(2)
+}
+
 let _ = testFreeFunctionNoThrowOnly()
 let _ = testFreeFunctionCalls()
 let _ = testMethodCalls()
 testTemplateCalls()
 testFuncPtrCall()
 testCFuncPtrCall()
+testProtocolConformanceThunkInvoke()
 
 // CHECK: define {{.*}} @"$s4test0A23FreeFunctionNoThrowOnlys5Int32VyF"() #[[#SWIFTMETA:]] {
 // CHECK-NEXT: :
@@ -221,6 +235,23 @@ testCFuncPtrCall()
 // CHECK-NEXT: to label %[[CONT21:.*]] unwind label %{{.*}}
 // CHECK: [[CONT21]]:
 // CHECK-NEXT: ret void
+
+// CHECK: define {{.*}} @"$sSo9TestClassV4test0A14MethodProtocolA2cDP6methodys5Int32VAHFTW"({{.*}}) #[[#SWIFTUWMETA]] personality
+// CHECK: invoke i32 @_ZNK9TestClass6methodEi({{.*}})
+// CHECK-NEXT:  to label %[[CONT30:.*]] unwind label %[[UNWIND30:.*]]
+// CHECK: [[CONT30]]:
+// CHECK-NEXT: ret i32
+// CHECK-EMPTY:
+// CHECK-NEXT: [[UNWIND30]]:
+// CHECK-NEXT: %4 = landingpad { i8*, i32 }
+// CHECK-NEXT:    catch i8* null
+// CHECK-NEXT: call void @llvm.trap()
+// CHECK-NEXT: unreachable
+// CHECK-NEXT: }
+
+// CHECK: define {{.*}} @"$s4test0A30ProtocolConformanceThunkInvokeyyF"() #[[#SWIFTMETA]]
+// CHECK-NOT: invoke
+// CHECK: }
 
 // CHECK: i32 @__gxx_personality_v0(...)
 

--- a/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-irgen-itanium.swift
@@ -1,0 +1,222 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-emit-ir %t/test.swift -I %t -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %t/test.swift -I %t -enable-experimental-cxx-interop -g | %FileCheck --check-prefix=DEBUG %s
+
+// UNSUPPORTED: OS=windows-msvc
+
+//--- Inputs/module.modulemap
+module CxxModule {
+    header "cxxHeader.h"
+    requires cplusplus
+}
+
+//--- Inputs/cxxHeader.h
+
+inline int freeFunctionThrows(int x) {
+  if (x > 0)
+    throw 2;
+  return -x;
+}
+
+inline int freeFunctionNoThrow(int x) noexcept {
+  return -x;
+}
+
+inline int freeFunctionCatchesException(int x) {
+  try {
+    return freeFunctionThrows(x);
+  } catch (...) {
+    return x;
+  }
+}
+
+class TestClass {
+  int m = 0;
+public:
+  int method(int x) const {
+    return freeFunctionThrows(x);
+  }
+  int noExceptMethod(int x) noexcept {
+    return freeFunctionNoThrow(x);
+  }
+};
+
+template<class T>
+struct IsNoExcept { const static bool value = false; };
+
+template<>
+struct IsNoExcept<int> { const static bool value = true; };
+
+template<class T>
+class TestTemplate {
+  int m = 0;
+public:
+  void method(T x) const {
+    throw x;
+  }
+  void noExceptMethod() noexcept {
+  }
+  void dependentNoExceptMethod() noexcept(IsNoExcept<T>::value) {
+    if (!IsNoExcept<T>::value)
+      throw 2;
+  }
+};
+
+using TestTemplateInt = TestTemplate<int>;
+using TestTemplateBool = TestTemplate<bool>;
+
+//--- test.swift
+
+import CxxModule
+
+func makeCInt() -> CInt {
+  return 42
+}
+
+func testFreeFunctionNoThrowOnly() -> CInt {
+  return freeFunctionNoThrow(makeCInt())
+}
+
+func testFreeFunctionCalls() -> CInt {
+  let p = freeFunctionThrows(0)
+  freeFunctionNoThrow(1)
+  freeFunctionThrows(makeCInt())
+  return p
+}
+
+func testMethodCalls() -> CInt {
+  var v = TestClass()
+  let p = v.method(makeCInt())
+  v.noExceptMethod(1)
+  v.method(0)
+  return p
+}
+
+func testTemplateCalls() {
+  var v1 = TestTemplateInt()
+  v1.method(2)
+  v1.noExceptMethod()
+  v1.dependentNoExceptMethod()
+  var v2 = TestTemplateBool()
+  v2.method(false)
+  v2.noExceptMethod()
+  v2.dependentNoExceptMethod()
+}
+
+let _ = testFreeFunctionNoThrowOnly()
+let _ = testFreeFunctionCalls()
+let _ = testMethodCalls()
+testTemplateCalls()
+
+// CHECK: define {{.*}} @"$s4test0A23FreeFunctionNoThrowOnlys5Int32VyF"() #[[#SWIFTMETA:]] {
+// CHECK-NEXT: :
+// CHECK-NEXT:  call swiftcc i32 @"$s4test8makeCInts5Int32VyF"()
+// CHECK-NEXT:  call i32 @_Z19freeFunctionNoThrowi(i32 {{.*}})
+// CHECK-NEXT:  ret i32
+// CHECK-NEXT: }
+
+// CHECK: define {{.*}} @"$s4test0A17FreeFunctionCallss5Int32VyF"() #[[#SWIFTUWMETA:]] personality i32 (...)* @__gxx_personality_v0
+// CHECK:   invoke i32 @_Z18freeFunctionThrowsi(i32 0)
+// CHECK-NEXT:  to label %[[CONT1:.*]] unwind label %[[UNWIND1:.*]]
+// CHECK-EMPTY:
+// CHECK: [[CONT1]]:
+// CHECK: call i32 @_Z19freeFunctionNoThrowi(i32 1)
+// CHECK-NEXT: %[[V1:.*]] = call swiftcc i32 @"$s4test8makeCInts5Int32VyF"()
+// CHECK-NEXT: invoke i32 @_Z18freeFunctionThrowsi(i32 %[[V1]])
+// CHECK-NEXT:    to label %[[CONT2:.*]] unwind label %[[UNWIND2:.*]]
+// CHECK-EMPTY:
+// CHECK: [[CONT2]]:
+// CHECK:  ret
+// CHECK-EMPTY:
+// CHECK-NEXT: [[UNWIND1]]:
+// CHECK-NEXT: landingpad { i8*, i32 }
+// CHECK-NEXT:    catch i8* null
+// CHECK-NEXT: call void @llvm.trap()
+// CHECK-NEXT: unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: [[UNWIND2]]:
+// CHECK-NEXT: landingpad { i8*, i32 }
+// CHECK-NEXT:    catch i8* null
+// CHECK-NEXT: call void @llvm.trap()
+// CHECK-NEXT: unreachable
+// CHECK-NEXT: }
+
+// CHECK: define {{.*}} @"$s4test0A11MethodCallss5Int32VyF"() #[[#SWIFTUWMETA]] personality
+// CHECK: call swiftcc i32 @"$s4test8makeCInts5Int32VyF"()
+// CHECK: invoke i32 @_ZNK9TestClass6methodEi
+// CHECK-NEXT:  to label %[[CONT3:.*]] unwind label %[[UNWIND3:.*]]
+// CHECK: [[CONT3]]:
+// CHECK: call i32 @_ZN9TestClass14noExceptMethodEi
+// CHECK: invoke i32 @_ZNK9TestClass6methodEi
+// CHECK-NEXT: to label %[[CONT4:.*]] unwind label %[[UNWIND4:.*]]
+// CHECK: [[CONT4]]:
+// CHECK: ret
+// CHECK-EMPTY:
+// CHECK-NEXT: [[UNWIND3]]:
+// CHECK-NEXT: landingpad { i8*, i32 }
+// CHECK-NEXT:    catch i8* null
+// CHECK-NEXT: call void @llvm.trap()
+// CHECK-NEXT: unreachable
+// CHECK-EMPTY:
+// CHECK-NEXT: [[UNWIND4]]:
+// CHECK-NEXT: landingpad { i8*, i32 }
+// CHECK-NEXT:    catch i8* null
+// CHECK-NEXT: call void @llvm.trap()
+// CHECK-NEXT: unreachable
+// CHECK-NEXT: }
+
+// CHECK: define {{.*}} @"$s4test0A13TemplateCallsyyF"() #[[#SWIFTUWMETA]] personality
+// CHECK: invoke void @_ZNK12TestTemplateIiE6methodEi
+// CHECK-NEXT:  to label %[[CONT10:.*]] unwind label
+// CHECK: [[CONT10]]:
+// CHECK: call void @_ZN12TestTemplateIiE14noExceptMethodEv
+// CHECK: call void @_ZN12TestTemplateIiE23dependentNoExceptMethodEv
+// CHECK: invoke void @_ZNK12TestTemplateIbE6methodEb
+// CHECK-NEXT:  to label %[[CONT11:.*]] unwind label
+// CHECK: [[CONT11]]:
+// CHECK: call void @_ZN12TestTemplateIbE14noExceptMethodEv
+// CHECK: invoke void @_ZN12TestTemplateIbE23dependentNoExceptMethodEv
+// CHECK-NEXT:  to label %[[CONT12:.*]] unwind label
+// CHECK: [[CONT12]]:
+// CHECK: ret
+
+// CHECK: i32 @__gxx_personality_v0(...)
+
+// CHECK: attributes #[[#SWIFTMETA]] = {
+// CHECK-NOT: uwtable
+// CHECK: attributes #[[#SWIFTUWMETA]] = {
+// CHECK-SAME: uwtable
+
+// DEBUG: define {{.*}} @"$s4test0A17FreeFunctionCallss5Int32VyF"()
+// DEBUG:   invoke i32 @_Z18freeFunctionThrowsi(i32 0)
+// DEBUG-NEXT:  to label %[[CONT1:.*]] unwind label %[[UNWIND1:.*]], !dbg ![[#DEBUGLOC_FREEFUNCTIONTHROWS1:]]
+// DEBUG-EMPTY:
+// DEBUG: [[CONT1]]:
+// DEBUG: call i32 @_Z19freeFunctionNoThrowi(i32 1)
+// DEBUG-NEXT: %[[V1:.*]] = call swiftcc i32 @"$s4test8makeCInts5Int32VyF"()
+// DEBUG-NEXT: invoke i32 @_Z18freeFunctionThrowsi(i32 %[[V1]])
+// DEBUG-NEXT:    to label %[[CONT2:.*]] unwind label %[[UNWIND2:.*]], !dbg ![[#DEBUGLOC_FREEFUNCTIONTHROWS2:]]
+// DEBUG-EMPTY:
+// DEBUG: [[CONT2]]:
+// DEBUG:  ret
+// DEBUG-EMPTY:
+// DEBUG-NEXT: [[UNWIND1]]:
+// DEBUG-NEXT: landingpad { i8*, i32 }
+// DEBUG-NEXT:    catch i8* null, !dbg ![[#DEBUGLOC_FREEFUNCTIONTHROWS1]]
+// DEBUG-NEXT: call void @llvm.trap(), !dbg ![[#DEBUGLOC_TRAP1:]]
+// DEBUG-NEXT: unreachable, !dbg ![[#DEBUGLOC_TRAP1]]
+// DEBUG-EMPTY:
+// DEBUG-NEXT: [[UNWIND2]]:
+// DEBUG-NEXT: landingpad { i8*, i32 }
+// DEBUG-NEXT:    catch i8* null, !dbg ![[#DEBUGLOC_FREEFUNCTIONTHROWS2]]
+// DEBUG-NEXT: call void @llvm.trap(), !dbg ![[#DEBUGLOC_TRAP2:]]
+// DEBUG-NEXT: unreachable, !dbg ![[#DEBUGLOC_TRAP2]]
+// DEBUG-NEXT: }
+
+// DEBUG: ![[#DEBUGLOC_FREEFUNCTIONTHROWS1]] = !DILocation(line: 13, column: 11,
+// DEBUG: ![[#DEBUGLOC_FREEFUNCTIONTHROWS2]] = !DILocation(line: 15, column: 3,
+// DEBUG: ![[#DEBUGLOC_TRAP1]] = !DILocation(line: 0, scope: ![[#TRAPSCOPE:]], inlinedAt: ![[#DEBUGLOC_FREEFUNCTIONTHROWS1]])
+// DEBUG: ![[#TRAPSCOPE]] = distinct !DISubprogram(name: "Swift runtime failure: unhandled C++{{ / Objective-C | }}exception"
+// DEBUG: ![[#DEBUGLOC_TRAP2]] = !DILocation(line: 0, scope: ![[#TRAPSCOPE]], inlinedAt: ![[#DEBUGLOC_FREEFUNCTIONTHROWS2]])

--- a/test/Interop/Cxx/exceptions/trap-on-exception-irgen-msvc.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-irgen-msvc.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: split-file %S/trap-on-exception-irgen-itanium.swift %t
 
-// RUN: %target-swift-emit-ir %t/test.swift -I %t -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %t/test.swift -I %t/Inputs -enable-experimental-cxx-interop | %FileCheck %s
 
 // REQUIRES: OS=windows-msvc
 

--- a/test/Interop/Cxx/exceptions/trap-on-exception-irgen-msvc.swift
+++ b/test/Interop/Cxx/exceptions/trap-on-exception-irgen-msvc.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %S/trap-on-exception-irgen-itanium.swift %t
+
+// RUN: %target-swift-emit-ir %t/test.swift -I %t -enable-experimental-cxx-interop | %FileCheck %s
+
+// REQUIRES: OS=windows-msvc
+
+// note: The test sources are in 'trap-on-exception-irgen-itanium.swift'
+
+// CHECK: define {{.*}} @"$s4test0A23FreeFunctionNoThrowOnlys5Int32VyF"() #[[#SWIFTMETA:]] {
+// CHECK-NEXT: :
+// CHECK-NEXT:  call swiftcc i32 @"$s4test8makeCInts5Int32VyF"()
+// CHECK-NEXT:  call {{.*}}i32 @"?freeFunctionNoThrow@@YAHH@Z"(i32 {{.*}})
+// CHECK-NEXT:  ret i32
+// CHECK-NEXT: }
+
+// CHECK: define {{.*}} @"$s4test0A17FreeFunctionCallss5Int32VyF"() #[[#SWIFTMETA]] {
+// CHECK: call {{.*}}i32 @"?freeFunctionThrows@@YAHH@Z"
+// CHECK: call {{.*}}i32 @"?freeFunctionNoThrow@@YAHH@Z"
+// CHECK: call swiftcc i32 @"$s4test8makeCInts5Int32VyF"()
+// CHECK: call {{.*}}i32 @"?freeFunctionThrows@@YAHH@Z"
+// CHECK: ret i32 %1
+// CHECK-NEXT: }

--- a/test/Interop/Cxx/foreign-reference/move-only-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/move-only-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions | %FileCheck %s
 //
 // XFAIL: OS=linux-android, OS=linux-androideabi
 

--- a/test/Interop/Cxx/foreign-reference/pod-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/pod-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions | %FileCheck %s
 //
 // XFAIL: OS=linux-android, OS=linux-androideabi
 

--- a/test/Interop/Cxx/foreign-reference/singleton-irgen.swift
+++ b/test/Interop/Cxx/foreign-reference/singleton-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -validate-tbd-against-ir=none -disable-llvm-verify -Xcc -fignore-exceptions | %FileCheck %s
 //
 // XFAIL: OS=linux-android, OS=linux-androideabi
 

--- a/test/Interop/Cxx/namespace/class-inline-namespace-irgen.swift
+++ b/test/Interop/Cxx/namespace/class-inline-namespace-irgen.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-emit-ir -I %t/Inputs -enable-experimental-cxx-interop %t/test.swift | %FileCheck %t/test.swift
+// RUN: %target-swift-emit-ir -I %t/Inputs -enable-experimental-cxx-interop %t/test.swift -Xcc -fignore-exceptions | %FileCheck %t/test.swift
 
 
 //--- Inputs/module.modulemap

--- a/test/Interop/Cxx/namespace/classes-irgen.swift
+++ b/test/Interop/Cxx/namespace/classes-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s -Xcc -fignore-exceptions | %FileCheck %s
 
 import Classes
 

--- a/test/Interop/Cxx/namespace/free-functions-irgen.swift
+++ b/test/Interop/Cxx/namespace/free-functions-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s -Xcc -fignore-exceptions | %FileCheck %s
 
 import FreeFunctions
 

--- a/test/Interop/Cxx/namespace/function-overload-in-namespace-extension-irgen.swift
+++ b/test/Interop/Cxx/namespace/function-overload-in-namespace-extension-irgen.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t
 // RUN: split-file %s %t
-// RUN: %target-swift-emit-ir -I %t/Inputs -enable-experimental-cxx-interop %t/test.swift | %FileCheck %t/test.swift
+// RUN: %target-swift-emit-ir -I %t/Inputs -enable-experimental-cxx-interop %t/test.swift -Xcc -fignore-exceptions | %FileCheck %t/test.swift
 
 
 //--- Inputs/module.modulemap

--- a/test/Interop/Cxx/namespace/templates-irgen.swift
+++ b/test/Interop/Cxx/namespace/templates-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s -Xcc -fignore-exceptions | %FileCheck %s
 
 import Templates
 

--- a/test/Interop/Cxx/objc-correctness/call-to-generated-init-with-nsstring.swift
+++ b/test/Interop/Cxx/objc-correctness/call-to-generated-init-with-nsstring.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=CxxClassWithNSStringInit -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop -enable-objc-interop | %FileCheck -check-prefix=CHECK-IDE-TEST %s
-// RUN: %target-swift-frontend -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -Xcc -fignore-exceptions | %FileCheck %s
 
 
 // REQUIRES: objc_interop

--- a/test/Interop/Cxx/operators/member-inline-irgen.swift
+++ b/test/Interop/Cxx/operators/member-inline-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -Xcc -fignore-exceptions | %FileCheck %s
 //
 // We should be able to support windows now. We will remove XFAIL in follow up
 // XFAIL: windows

--- a/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/member-out-of-line-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -Xcc -fignore-exceptions | %FileCheck %s
 //
 // We should be able to support windows now. We will remove XFAIL in follow up
 // XFAIL: windows

--- a/test/Interop/Cxx/operators/non-member-out-of-line-irgen.swift
+++ b/test/Interop/Cxx/operators/non-member-out-of-line-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -Xcc -fignore-exceptions | %FileCheck %s
 
 import NonMemberOutOfLine
 

--- a/test/Interop/Cxx/reference/reference-irgen.swift
+++ b/test/Interop/Cxx/reference/reference-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s | %FileCheck %s
+// RUN: %target-swift-emit-ir -I %S/Inputs -enable-experimental-cxx-interop %s -Xcc -fignore-exceptions | %FileCheck %s
 
 import Reference
 

--- a/test/Interop/Cxx/static/static-member-func-irgen.swift
+++ b/test/Interop/Cxx/static/static-member-func-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -Xcc -fignore-exceptions | %FileCheck %s
 
 import StaticMemberFunc
 

--- a/test/Interop/Cxx/templates/class-template-uninstantiatable-members-irgen.swift
+++ b/test/Interop/Cxx/templates/class-template-uninstantiatable-members-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -disable-availability-checking | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -disable-availability-checking -Xcc -fignore-exceptions | %FileCheck %s
 
 import ClassTemplateInstantiationErrors
 

--- a/test/Interop/Cxx/templates/function-template-irgen.swift
+++ b/test/Interop/Cxx/templates/function-template-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-emit-ir %s -I %S/Inputs -enable-experimental-cxx-interop -Xcc -fignore-exceptions | %FileCheck %s
 
 import FunctionTemplates
 

--- a/test/Interop/Cxx/union/anonymous-union-partly-invalid.swift
+++ b/test/Interop/Cxx/union/anonymous-union-partly-invalid.swift
@@ -1,4 +1,4 @@
-// RUN: %swift -I %S/Inputs -enable-experimental-cxx-interop -enable-objc-interop -emit-ir %s | %FileCheck %s
+// RUN: %swift -I %S/Inputs -enable-experimental-cxx-interop -enable-objc-interop -emit-ir %s -Xcc -fignore-exceptions | %FileCheck %s
 
 import AnonymousUnionPartlyInvalid
 

--- a/test/Interop/Cxx/value-witness-table/copy-constructors-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/copy-constructors-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-cxx-interop -I %S/Inputs %s -emit-ir -Xcc -fignore-exceptions | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/Interop/Cxx/value-witness-table/witness-lifetime-operations-irgen.swift
+++ b/test/Interop/Cxx/value-witness-table/witness-lifetime-operations-irgen.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -enable-experimental-cxx-interop -I %S/Inputs %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -enable-experimental-cxx-interop -I %S/Inputs %s -emit-ir -Xcc -fignore-exceptions | %FileCheck %s
 
 // Temporarily restrict to x86 (rdar://89908618)
 // REQUIRES: CPU=x86_64


### PR DESCRIPTION
Enabled when C++ interop is enabled, unless Clang args disable exceptions. Still needs MSVC eh support. I'm planning to add it in a follow-up after doing some refactorings in Clang. 