### PR TITLE
Update the `rebranch` checkout scheme

### DIFF
--- a/utils/update_checkout/update-checkout-config.json
+++ b/utils/update_checkout/update-checkout-config.json
@@ -138,7 +138,7 @@
                 "llbuild": "main",
                 "swift-tools-support-core": "main",
                 "swiftpm": "main",
-                "swift-argument-parser": "1.1.4",
+                "swift-argument-parser": "1.2.2",
                 "swift-atomics": "1.0.2",
                 "swift-collections": "1.0.1",
                 "swift-crypto": "2.2.3",


### PR DESCRIPTION
The latest SwiftPM requires version 1.2.2 of the swift-argument-parser package to build correctly.
