### PR TITLE
Sema: Avoid emitting fixit to prefix import with `@preconcurrency` in swiftinterfaces

### DIFF
--- a/lib/Sema/TypeCheckConcurrency.h
+++ b/lib/Sema/TypeCheckConcurrency.h
@@ -399,6 +399,11 @@ bool diagnoseSendabilityErrorBasedOn(
     NominalTypeDecl *nominal, SendableCheckContext fromContext,
     llvm::function_ref<bool(DiagnosticBehavior)> diagnose);
 
+/// If any of the imports in this source file was @preconcurrency but
+/// there were no diagnostics downgraded or suppressed due to that
+/// @preconcurrency, suggest that the attribute be removed.
+void diagnoseUnnecessaryPreconcurrencyImports(SourceFile &sf);
+
 /// Given a set of custom attributes, pick out the global actor attributes
 /// and perform any necessary resolution and diagnostics, returning the
 /// global actor attribute and type it refers to (or \c None).

--- a/test/ModuleInterface/SilencePreconcurrency.swiftinterface
+++ b/test/ModuleInterface/SilencePreconcurrency.swiftinterface
@@ -2,8 +2,15 @@
 // swift-module-flags: -module-name SilencePreconcurrency
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -compile-module-from-interface -o %/t/SilencePreconcurrency.swiftmodule %s -verify
+// RUN: %target-swift-frontend -emit-module -o %t/Preconcurrency.swiftmodule -module-name Preconcurrency %S/Inputs/preconcurrency.swift
+// RUN: %target-swift-frontend -compile-module-from-interface -o %t/SilencePreconcurrency.swiftmodule %s -I %t -verify
 
 // REQUIRES: OS=macosx
 
 @preconcurrency import Swift
+import Preconcurrency
+
+@available(macOS 10.15, *)
+public enum SendableEnum: Sendable {
+  case caseWithNonSendablePayload(_ ns: NotSendable)
+}


### PR DESCRIPTION
Remarks like the following were being emitted when compiling modules from their interfaces:

```
remark: add '@preconcurrency' to suppress 'Sendable'-related warnings from module 'Preconcurrency'
```

This is a nuisance for clients of the module since they cannot influence whether this diagnostic is emitted.

Resolves rdar://105711934
