### PR TITLE
[Compile Time Constant Extraction] Extract DotSelf Type Expressions

### DIFF
--- a/include/swift/AST/ConstTypeInfo.h
+++ b/include/swift/AST/ConstTypeInfo.h
@@ -36,6 +36,7 @@ public:
     Array,
     Tuple,
     Enum,
+    Type,
     Runtime
   };
 
@@ -181,6 +182,21 @@ public:
 private:
   std::string Identifier;
   llvm::Optional<std::vector<FunctionParameter>> Parameters;
+};
+
+/// An type value representation
+class TypeValue : public CompileTimeValue {
+public:
+  TypeValue(swift::Type Type) : CompileTimeValue(ValueKind::Type), Type(Type) {}
+
+  swift::Type getType() const { return Type; }
+
+  static bool classof(const CompileTimeValue *T) {
+    return T->getKind() == ValueKind::Type;
+  }
+
+private:
+  swift::Type Type;
 };
 
 /// A representation of an arbitrary value that does not fall under

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -299,6 +299,11 @@ static std::shared_ptr<CompileTimeValue> extractCompileTimeValue(Expr *expr) {
       return extractCompileTimeValue(coerceExpr->getSubExpr());
     }
 
+    case ExprKind::DotSelf: {
+      auto dotSelfExpr = cast<DotSelfExpr>(expr);
+      return std::make_shared<TypeValue>(dotSelfExpr->getType());
+    }
+
     default: {
       break;
     }
@@ -582,6 +587,16 @@ void writeValue(llvm::json::OStream &JSON,
           }
         });
       }
+    });
+    break;
+  }
+
+  case CompileTimeValue::ValueKind::Type: {
+    auto typeValue = cast<TypeValue>(value);
+    JSON.attribute("valueKind", "Type");
+    JSON.attributeObject("value", [&]() {
+      JSON.attribute("type",
+                     toFullyQualifiedTypeNameString(typeValue->getType()));
     });
     break;
   }

--- a/test/ConstExtraction/ExtractTypes.swift
+++ b/test/ConstExtraction/ExtractTypes.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: echo "[MyProto]" > %t/protocols.json
+
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractTypes.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
+// RUN: cat %t/ExtractTypes.swiftconstvalues 2>&1 | %FileCheck %s
+
+protocol MyProto {}
+protocol ContainerType {}
+
+struct TypeA: ContainerType {}
+enum TypeB: ContainerType {}
+final class TypeC: ContainerType {}
+
+public struct Types : MyProto {
+    static var types1: [ContainerType.Type] = [
+        TypeA.self,
+        TypeB.self,
+        TypeC.self
+    ]
+}
+
+// CHECK:       "label": "types1",
+// CHECK-NEXT:  "type": "Swift.Array<ExtractTypes.ContainerType.Type>",
+// CHECK:       "valueKind": "Array",
+// CHECK-NEXT:  "value": [
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "valueKind": "Type",
+// CHECK-NEXT:      "value": {
+// CHECK-NEXT:        "type": "ExtractTypes.TypeA.Type"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "valueKind": "Type",
+// CHECK-NEXT:      "value": {
+// CHECK-NEXT:        "type": "ExtractTypes.TypeB.Type"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    },
+// CHECK-NEXT:    {
+// CHECK-NEXT:      "valueKind": "Type",
+// CHECK-NEXT:      "value": {
+// CHECK-NEXT:        "type": "ExtractTypes.TypeC.Type"
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  ]


### PR DESCRIPTION
Add support for compile time extracting `DotSelf` expressions e.g. `var types = [TypeA.self]`.