### PR TITLE
Fix Test in Release Build

### DIFF
--- a/test/Distributed/SIL/distributed_actor_resolve_sil.swift
+++ b/test/Distributed/SIL/distributed_actor_resolve_sil.swift
@@ -20,7 +20,6 @@ distributed actor MyDistActor {
 // CHECK:  bb0([[ACTOR_ID_ARG:%[0-9]+]] : $ActorAddress, [[SYSTEM_ARG:%[0-9]+]] : $FakeRoundtripActorSystem, [[TYPE_ARG:%[0-9]+]] : $@thick MyDistActor.Type):
 // CHECK: [[SYS_RESOLVE_RESULT:%[0-9]+]] = function_ref @$s27FakeDistributedActorSystems0a9RoundtripC6SystemC7resolve2id2asxSgAA0C7AddressV_xmtK0B00bC0RzlF
 
-// CHECK: // makeProxyBB
 // CHECK: [[ACTOR_INSTANCE:%[0-9]+]] = builtin "initializeDistributedRemoteActor"(%7 : $@thick MyDistActor.Type) : $MyDistActor
 // CHECK: [[ID_PROPERTY:%[0-9]+]] = ref_element_addr [[ACTOR_INSTANCE]] : $MyDistActor, #MyDistActor.id
 // CHECK: retain_value [[ACTOR_ID_ARG]] : $ActorAddress

--- a/test/Distributed/SIL/distributed_id_system_ownership_verify_sil.swift
+++ b/test/Distributed/SIL/distributed_id_system_ownership_verify_sil.swift
@@ -38,7 +38,6 @@ distributed actor Greeter {
 // CHECK: bb0([[ADDRESS_ARG:%[0-9]+]] : $*NotLoadableActorAddress, [[SYSTEM_ARG:%[0-9]+]] : $FakeNotLoadableAddressActorSystem, [[TYPE_ARG:%[0-9]+]] : $@thick Greeter.Type):
 // CHECK: [[TYPE:%[0-9]+]] = metatype $@thick Greeter.Type
 
-// CHECK: // makeProxyBB
 // CHECK: [[INSTANCE:%[0-9]+]] = builtin "initializeDistributedRemoteActor"([[TYPE]] : $@thick Greeter.Type) : $Greeter
 // CHECK: [[ID_PROPERTY:%[0-9]+]] = ref_element_addr [[INSTANCE]] : $Greeter, #Greeter.id
 // Note specifically that we don't [take] in the below copy_addr:


### PR DESCRIPTION
This fixes `ninja check-swift-validation` in the Release+Distribution build as the block name is set under `#ifndef NDEBUG`.

