### PR TITLE
[Sema/Tests] NFC: Limit a couple of perf tests to macOS

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/rdar32998180.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar32998180.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
 // REQUIRES: tools-release,no_asan
+// REQUIRES: OS=macosx
 
 func rdar32998180(value: UInt16) -> UInt16 {
   let result = ((((value >> 1) ^ (value >> 1) ^ (value >> 1) ^ (value >> 1)) & 1) << 1)

--- a/validation-test/Sema/type_checker_perf/fast/rdar36838495.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar36838495.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
 // REQUIRES: tools-release,no_asan
+// REQUIRES: OS=macosx
 
 struct T {
   enum B {


### PR DESCRIPTION
Helps to avoid flakiness on simulators/devices.

Resolves: rdar://105752467

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
