### PR TITLE
Don't use tsd_private.h in compatibility libraries for ARM64_32.

### DIFF
--- a/include/swift/Threading/Impl/Darwin.h
+++ b/include/swift/Threading/Impl/Darwin.h
@@ -186,7 +186,7 @@ inline void once_impl(once_t &predicate, void (*fn)(void *), void *context) {
 // On Darwin, we want to use the reserved keys
 #define SWIFT_THREADING_USE_RESERVED_TLS_KEYS 1
 
-#if !(SWIFT_THREADING_IS_COMPATIBILITY_LIBRARY && __ARM_ARCH_7K__) && __has_include(<pthread/tsd_private.h>)
+#if !(SWIFT_THREADING_IS_COMPATIBILITY_LIBRARY && (__ARM_ARCH_7K__ || __ARM64_ARCH_8_32__)) && __has_include(<pthread/tsd_private.h>)
 } // namespace threading_impl
 } // namespace swift
 


### PR DESCRIPTION
Apparently this issue also affects ARM64_32.

rdar://105768086
