### PR TITLE
[Dependency Scanning] Record all bridging header module dependencies in the scanning result

### DIFF
--- a/lib/DependencyScan/ScanDependencies.cpp
+++ b/lib/DependencyScan/ScanDependencies.cpp
@@ -365,6 +365,7 @@ resolveDirectDependencies(CompilerInstance &instance, ModuleDependencyID module,
 
         assert(bridgingModuleDependencies);
         for (const auto &clangDep : *bridgingModuleDependencies) {
+          result.insert({clangDep, ModuleDependencyKind::Clang});
           findAllImportedClangModules(ctx, clangDep, cache, allClangModules,
                                       knownModules);
         }

--- a/test/ScanDependencies/separate_bridging_header_deps.swift
+++ b/test/ScanDependencies/separate_bridging_header_deps.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/clang-module-cache
+
+// RUN: %target-swift-frontend -scan-dependencies -module-cache-path %t/clang-module-cache %s -o %t/deps.json -I %S/Inputs/CHeaders -I %S/Inputs/Swift -import-objc-header %S/Inputs/CHeaders/Bridging.h -swift-version 4
+// RUN: %FileCheck %s < %t/deps.json
+
+import E
+
+// CHECK: "swift": "deps"
+// CHECK: "directDependencies": [
+// CHECK-NEXT: {
+// CHECK-DAG:          "swift": "E"
+// CHECK-DAG:          "swift": "Swift"
+// CHECK-DAG:          "swift": "SwiftOnoneSupport"
+// CHECK-DAG:          "swift": "_Concurrency"
+// CHECK-DAG:          "clang": "_SwiftConcurrencyShims"
+// CHECK-DAG:          "swift": "_StringProcessing"
+// The source of dependency on clang:F is the bridging header, ensure it is captured here
+// CHECK-DAG:          "clang": "F"
+// CHECK-DAG:          "swift": "F"
+
+// CHECK: "bridgingHeader": {
+// CHECK-NEXT:             "path": "{{.*}}Bridging.h",
+// CHECK-NEXT:            "sourceFiles": [
+// CHECK-NEXT:              "{{.*}}Bridging.h",
+// CHECK-NEXT:              "{{.*}}BridgingOther.h"
+// CHECK-NEXT:            ],
+// CHECK-NEXT:            "moduleDependencies": [
+// CHECK-NEXT:              "F"


### PR DESCRIPTION
Add them to the set of direct dependencies of the Swift module the bridging header belongs to, therefore also ensuiring that their module info will be contained in in the output graph.

Part of rdar://105742859