### PR TITLE
AST: Only treat `@backDeployed` functions as fragile on platforms with an active attribute

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -906,9 +906,13 @@ public:
   Optional<llvm::VersionTuple> getIntroducedOSVersion(PlatformKind Kind) const;
 
   /// Returns the OS version in which the decl became ABI as specified by the
-  /// @backDeployed attribute.
+  /// `@backDeployed` attribute.
   Optional<llvm::VersionTuple>
   getBackDeployedBeforeOSVersion(ASTContext &Ctx) const;
+
+  /// Returns true if the decl has an active `@backDeployed` attribute for the
+  /// given context.
+  bool isBackDeployed(ASTContext &Ctx) const;
 
   /// Returns the starting location of the entire declaration.
   SourceLoc getStartLoc() const { return getSourceRange().Start; }
@@ -1176,6 +1180,9 @@ public:
   // SPI groups are inherited from the parent contexts only if the local decl
   // doesn't declare any @_spi.
   ArrayRef<Identifier> getSPIGroups() const;
+
+  /// Returns true if this declaration has any `@backDeployed` attributes.
+  bool hasBackDeployedAttr() const;
 
   /// Emit a diagnostic tied to this declaration.
   template<typename ...ArgTypes>
@@ -6792,10 +6799,6 @@ public:
   /// \return the synthesized thunk, or null if the base of the call has
   ///         diagnosed errors during type checking.
   FuncDecl *getDistributedThunk() const;
-
-  /// Returns 'true' if the function has (or inherits) the `@backDeployed`
-  /// attribute.
-  bool isBackDeployed() const;
 
   PolymorphicEffectKind getPolymorphicEffectKind(EffectKind kind) const;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -492,6 +492,21 @@ Decl::getBackDeployedBeforeOSVersion(ASTContext &Ctx) const {
   return None;
 }
 
+bool Decl::isBackDeployed(ASTContext &Ctx) const {
+  return getBackDeployedBeforeOSVersion(Ctx) != None;
+}
+
+bool Decl::hasBackDeployedAttr() const {
+  if (getAttrs().hasAttribute<BackDeployedAttr>())
+    return true;
+
+  // Accessors may inherit `@backDeployed`.
+  if (auto *AD = dyn_cast<AccessorDecl>(this))
+    return AD->getStorage()->hasBackDeployedAttr();
+
+  return false;
+}
+
 llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS,
                                      StaticSpellingKind SSK) {
   switch (SSK) {
@@ -8152,19 +8167,6 @@ bool AbstractFunctionDecl::argumentNameIsAPIByDefault() const {
 
 bool AbstractFunctionDecl::isSendable() const {
   return getAttrs().hasAttribute<SendableAttr>();
-}
-
-bool AbstractFunctionDecl::isBackDeployed() const {
-  if (getAttrs().hasAttribute<BackDeployedAttr>())
-    return true;
-
-  // Property and subscript accessors inherit the attribute.
-  if (auto *AD = dyn_cast<AccessorDecl>(this)) {
-    if (AD->getStorage()->getAttrs().hasAttribute<BackDeployedAttr>())
-      return true;
-  }
-
-  return false;
 }
 
 BraceStmt *AbstractFunctionDecl::getBody(bool canSynthesize) const {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -478,7 +478,7 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
                 /*allowUsableFromInline=*/true};
       }
 
-      if (AFD->getAttrs().hasAttribute<BackDeployedAttr>()) {
+      if (AFD->isBackDeployed(context->getASTContext())) {
         return {FragileFunctionKind::BackDeploy,
                 /*allowUsableFromInline=*/true};
       }
@@ -495,7 +495,7 @@ swift::FragileFunctionKindRequest::evaluate(Evaluator &evaluator,
           return {FragileFunctionKind::AlwaysEmitIntoClient,
                   /*allowUsableFromInline=*/true};
         }
-        if (storage->getAttrs().hasAttribute<BackDeployedAttr>()) {
+        if (storage->isBackDeployed(context->getASTContext())) {
           return {FragileFunctionKind::BackDeploy,
                   /*allowUsableFromInline=*/true};
         }

--- a/lib/SIL/IR/SILDeclRef.cpp
+++ b/lib/SIL/IR/SILDeclRef.cpp
@@ -955,7 +955,7 @@ bool SILDeclRef::isBackDeployed() const {
 
   auto *decl = getDecl();
   if (auto afd = dyn_cast<AbstractFunctionDecl>(decl))
-    return afd->isBackDeployed();
+    return afd->isBackDeployed(getASTContext());
 
   return false;
 }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1405,7 +1405,7 @@ void SILGenModule::emitAbstractFuncDecl(AbstractFunctionDecl *AFD) {
                            getFunction(thunk, ForDefinition));
   }
 
-  if (AFD->isBackDeployed()) {
+  if (AFD->isBackDeployed(M.getASTContext())) {
     // Emit the fallback function that will be used when the original function
     // is unavailable at runtime.
     auto fallback = SILDeclRef(AFD).asBackDeploymentKind(

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1077,7 +1077,7 @@ public:
   }
 
   void processClassMethod(DeclRefExpr *e, AbstractFunctionDecl *afd) {
-    assert(!afd->isBackDeployed() &&
+    assert(!afd->hasBackDeployedAttr() &&
            "cannot back deploy dynamically dispatched methods");
 
     ArgumentSource selfArgSource(selfApply->getBase());

--- a/lib/SILOptimizer/UtilityPasses/SILSkippingChecker.cpp
+++ b/lib/SILOptimizer/UtilityPasses/SILSkippingChecker.cpp
@@ -78,7 +78,7 @@ static bool shouldHaveSkippedFunction(const SILFunction &F) {
   // second resilient SILFunction is also emitted for back deployed functions.
   // Since the body of the function as written was not skipped, it's expected
   // that we see the SILFunction for the resilient copy here.
-  if (func->isBackDeployed())
+  if (func->hasBackDeployedAttr())
     return false;
 
   // If none of those conditions trip, then this is something that _should_

--- a/test/ModuleInterface/back-deployed-attr.swift
+++ b/test/ModuleInterface/back-deployed-attr.swift
@@ -5,17 +5,19 @@
 // RUN: %target-swift-typecheck-module-from-interface(%t/Test.swiftinterface)
 // RUN: %FileCheck %s < %t/Test.swiftinterface
 
+// REQUIRES: OS=macosx
+
 public struct TopLevelStruct {
   // TODO: Print `@backDeployed` in swiftinterfaces (rdar://104920183)
   // CHECK: @_backDeploy(before: macOS 12.0)
-  // CHECK: public func backDeployedFunc_SinglePlatform() -> Swift.Int { return 42 }
+  // CHECK: public func backDeployedFunc_SinglePlatform() -> Swift.Int { return 41 }
   @backDeployed(before: macOS 12.0)
-  public func backDeployedFunc_SinglePlatform() -> Int { return 42 }
+  public func backDeployedFunc_SinglePlatform() -> Int { return 41 }
   
   // CHECK: @_backDeploy(before: macOS 12.0, iOS 15.0)
-  // CHECK: public func backDeployedFunc_MultiPlatform() -> Swift.Int { return 43 }
+  // CHECK: public func backDeployedFunc_MultiPlatform() -> Swift.Int { return 42 }
   @backDeployed(before: macOS 12.0, iOS 15.0)
-  public func backDeployedFunc_MultiPlatform() -> Int { return 43 }
+  public func backDeployedFunc_MultiPlatform() -> Int { return 42 }
 
   // CHECK: @_backDeploy(before: macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0)
   // CHECK: public func backDeployedFunc_MultiPlatformSeparate() -> Swift.Int { return 43 }
@@ -27,15 +29,15 @@ public struct TopLevelStruct {
 
   // CHECK: @_backDeploy(before: macOS 12.0)
   // CHECK: public var backDeployedComputedProperty: Swift.Int {
-  // CHECK:   get { 44 }
-  // CHECK: }
+  // CHECK-NEXT:   get { 44 }
+  // CHECK-NEXT: }
   @backDeployed(before: macOS 12.0)
   public var backDeployedComputedProperty: Int { 44 }
 
   // CHECK: @_backDeploy(before: macOS 12.0)
   // CHECK: public var backDeployedPropertyWithAccessors: Swift.Int {
-  // CHECK:   get { 45 }
-  // CHECK: }
+  // CHECK-NEXT:   get { 45 }
+  // CHECK-NEXT: }
   @backDeployed(before: macOS 12.0)
   public var backDeployedPropertyWithAccessors: Int {
     get { 45 }
@@ -43,27 +45,42 @@ public struct TopLevelStruct {
 
   // CHECK: @_backDeploy(before: macOS 12.0)
   // CHECK: public subscript(index: Swift.Int) -> Swift.Int {
-  // CHECK:   get { 46 }
-  // CHECK: }
+  // CHECK-NEXT:   get { 46 }
+  // CHECK-NEXT: }
   @backDeployed(before: macOS 12.0)
   public subscript(index: Int) -> Int {
     get { 46 }
   }
 }
 
+// CHECK: @_backDeploy(before: iOS 15.0)
+// CHECK: public func backDeployedFunc_iOSOnly() -> Swift.Int
+// CHECK-NOT: return 99
+@backDeployed(before: iOS 15.0)
+public func backDeployedFunc_iOSOnly() -> Int { return 99 }
+
 // CHECK: @_backDeploy(before: macOS 12.0)
-// CHECK: public func backDeployTopLevelFunc1() -> Swift.Int { return 47 }
+// CHECK: public func backDeployTopLevelFunc_macOS() -> Swift.Int {
+// CHECK-NEXT:   return 47
+// CHECK-NEXT: }
+// CHECK-NOT: fatalError()
 @backDeployed(before: macOS 12.0)
-public func backDeployTopLevelFunc1() -> Int { return 47 }
+public func backDeployTopLevelFunc_macOS() -> Int {
+#if os(macOS)
+  return 47
+#else
+  fatalError()
+#endif
+}
 
 // MARK: - Availability macros
 
 // CHECK: @_backDeploy(before: macOS 12.1)
-// CHECK: public func backDeployTopLevelFunc2() -> Swift.Int { return 48 }
+// CHECK: public func backDeployTopLevelFunc_macOS12_1() -> Swift.Int { return 48 }
 @backDeployed(before: _macOS12_1)
-public func backDeployTopLevelFunc2() -> Int { return 48 }
+public func backDeployTopLevelFunc_macOS12_1() -> Int { return 48 }
 
 // CHECK: @_backDeploy(before: macOS 12.1, iOS 15.1)
-// CHECK: public func backDeployTopLevelFunc3() -> Swift.Int { return 49 }
+// CHECK: public func backDeployTopLevelFunc_myProject() -> Swift.Int { return 49 }
 @backDeployed(before: _myProject 1.0)
-public func backDeployTopLevelFunc3() -> Int { return 49 }
+public func backDeployTopLevelFunc_myProject() -> Int { return 49 }

--- a/test/SILGen/back_deployed_attr.swift
+++ b/test/SILGen/back_deployed_attr.swift
@@ -6,8 +6,17 @@
 
 // REQUIRES: OS=macosx
 
+// CHECK: sil non_abi [serialized] [ossa] @$s11back_deploy8someFuncyyFTwB
+// CHECK: sil non_abi [serialized] [thunk] [ossa] @$s11back_deploy8someFuncyyFTwb
+// CHECK: sil [available 10.52] [ossa] @$s11back_deploy8someFuncyyF
 @backDeployed(before: macOS 10.52)
 public func someFunc() {}
+
+// CHECK-NOT: @$s11back_deploy0A13DeployedOniOSyyFTwB
+// CHECK-NOT: @$s11back_deploy0A13DeployedOniOSyyFTwb
+// CHECK: sil [ossa] @$s11back_deploy0A13DeployedOniOSyyF
+@backDeployed(before: iOS 13.13)
+public func backDeployedOniOS() {}
 
 public struct S<T> {
   @usableFromInline var _x: T
@@ -28,6 +37,8 @@ func resilientCaller(_ s: inout S<Z>) {
   // CHECK-BACK-DEPLOY: function_ref @$s11back_deploy8someFuncyyFTwb : $@convention(thin) () -> ()
   // CHECK-NATIVE: function_ref @$s11back_deploy8someFuncyyF : $@convention(thin) () -> ()
   someFunc()
+  // CHECK: function_ref @$s11back_deploy0A13DeployedOniOSyyF : $@convention(thin) () -> ()
+  backDeployedOniOS()
   // CHECK-BACK-DEPLOY: function_ref @$s11back_deploy1SV1xxvgTwb : $@convention(method) <τ_0_0> (@in_guaranteed S<τ_0_0>) -> @out τ_0_0
   // CHECK-NATIVE: function_ref @$s11back_deploy1SV1xxvg : $@convention(method) <τ_0_0> (@in_guaranteed S<τ_0_0>) -> @out τ_0_0
   _ = s.x
@@ -41,6 +52,8 @@ func resilientCaller(_ s: inout S<Z>) {
 func inlinableCaller(_ s: inout S<Z>) {
   // CHECK: function_ref @$s11back_deploy8someFuncyyFTwb : $@convention(thin) () -> ()
   someFunc()
+  // CHECK: function_ref @$s11back_deploy0A13DeployedOniOSyyF : $@convention(thin) () -> ()
+  backDeployedOniOS()
   // CHECK: function_ref @$s11back_deploy1SV1xxvgTwb : $@convention(method) <τ_0_0> (@in_guaranteed S<τ_0_0>) -> @out τ_0_0
   _ = s.x
   // CHECK: function_ref @$s11back_deploy1SV1xxvsTwb : $@convention(method) <τ_0_0> (@in τ_0_0, @inout S<τ_0_0>) -> ()
@@ -52,6 +65,8 @@ func inlinableCaller(_ s: inout S<Z>) {
 func aeicCaller(_ s: inout S<Z>) {
   // CHECK: function_ref @$s11back_deploy8someFuncyyFTwb : $@convention(thin) () -> ()
   someFunc()
+  // CHECK: function_ref @$s11back_deploy0A13DeployedOniOSyyF : $@convention(thin) () -> ()
+  backDeployedOniOS()
   // CHECK: function_ref @$s11back_deploy1SV1xxvgTwb : $@convention(method) <τ_0_0> (@in_guaranteed S<τ_0_0>) -> @out τ_0_0
   _ = s.x
   // CHECK: function_ref @$s11back_deploy1SV1xxvsTwb : $@convention(method) <τ_0_0> (@in τ_0_0, @inout S<τ_0_0>) -> ()
@@ -63,6 +78,8 @@ func aeicCaller(_ s: inout S<Z>) {
 public func backDeployedCaller(_ s: inout S<Z>) {
   // CHECK: function_ref @$s11back_deploy8someFuncyyFTwb : $@convention(thin) () -> ()
   someFunc()
+  // CHECK: function_ref @$s11back_deploy0A13DeployedOniOSyyF : $@convention(thin) () -> ()
+  backDeployedOniOS()
   // CHECK: function_ref @$s11back_deploy1SV1xxvgTwb : $@convention(method) <τ_0_0> (@in_guaranteed S<τ_0_0>) -> @out τ_0_0
   _ = s.x
   // CHECK: function_ref @$s11back_deploy1SV1xxvsTwb : $@convention(method) <τ_0_0> (@in τ_0_0, @inout S<τ_0_0>) -> ()

--- a/test/SILGen/opaque_values_silgen.swift
+++ b/test/SILGen/opaque_values_silgen.swift
@@ -637,11 +637,13 @@ func giveKeyPathString() {
   takeKeyPathString(\StructWithAReadableStringProperty.s)
 }
 
-// CHECK-LABEL: sil {{.*}}@$s20opaque_values_silgen29backDeployingReturningGenericyxxKlFTwb : {{.*}} <T> {{.*}} {
+#if os(macOS)
+// CHECK-OSX-LABEL: sil {{.*}}@$s20opaque_values_silgen29backDeployingReturningGenericyxxKlFTwb : {{.*}} <T> {{.*}} {
 // Ensure that there aren't any "normal" (in the sense of try_apply) blocks that
 // take unbound generic parameters (τ_0_0).
-// CHECK-NOT: {{bb[0-9]+}}({{%[^,]+}} : @owned $τ_0_0):
-// CHECK-LABEL: } // end sil function '$s20opaque_values_silgen29backDeployingReturningGenericyxxKlFTwb'
+// CHECK-OSX-NOT: {{bb[0-9]+}}({{%[^,]+}} : @owned $τ_0_0):
+// CHECK-OSX-LABEL: } // end sil function '$s20opaque_values_silgen29backDeployingReturningGenericyxxKlFTwb'
 @available(SwiftStdlib 5.1, *)
 @backDeployed(before: SwiftStdlib 5.8)
 public func backDeployingReturningGeneric<T>(_ t: T) throws -> T { t }
+#endif


### PR DESCRIPTION
Previously, typechecking and SILGen would treat a function body as fragile as long as the declaration had a `@backDeployed` attribute, regardless of the platform specified by the attribute. This was overly conservative since back deployed functions are only emitted into the client on specific platforms. Now a `@backDeployed` function can reference non-`public` declarations on the platforms it is resilient on:

```
@backDeployed(before: iOS 15)
public func foo() {
  #if os(iOS)
  // Fragile; this code may be emitted into the client.
  #else
  // Resilient; this code won't ever be exposed to clients.
  #endif
}
```

Resolves rdar://105298520
