### PR TITLE
Revert "Revert "[cxx-interop] Add conversions between `std::u16string` and `Swift.String`""

### DIFF
--- a/stdlib/public/Cxx/std/String.swift
+++ b/stdlib/public/Cxx/std/String.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// MARK: Initializing C++ string from a Swift String
+
 extension std.string {
   /// Creates a C++ string having the same content as the given Swift string.
   ///
@@ -23,7 +25,29 @@ extension std.string {
   }
 }
 
+extension std.u16string {
+  /// Creates a C++ UTF-16 string having the same content as the given Swift
+  /// string.
+  ///
+  /// - Complexity: O(*n*), where *n* is the number of UTF-16 code units in the
+  ///   Swift string.
+  public init(_ string: String) {
+    self.init()
+    for char in string.utf16 {
+      self.push_back(char)
+    }
+  }
+}
+
+// MARK: Initializing C++ string from a Swift String literal
+
 extension std.string: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) {
+    self.init(value)
+  }
+}
+
+extension std.u16string: ExpressibleByStringLiteral {
   public init(stringLiteral value: String) {
     self.init(value)
   }
@@ -41,6 +65,8 @@ extension std.string: CustomStringConvertible {
   }
 }
 
+// MARK: Initializing Swift String from a C++ string
+
 extension String {
   /// Creates a String having the same content as the given C++ string.
   ///
@@ -57,5 +83,21 @@ extension String {
       String(decoding: $0, as: UTF8.self)
     }
     withExtendedLifetime(cxxString) {}
+  }
+
+  /// Creates a String having the same content as the given C++ UTF-16 string.
+  ///
+  /// If `cxxString` contains ill-formed UTF-16 code unit sequences, this
+  /// initializer replaces them with the Unicode replacement character
+  /// (`"\u{FFFD}"`).
+  ///
+  /// - Complexity: O(*n*), where *n* is the number of bytes in the C++ UTF-16
+  ///   string.
+  public init(_ cxxU16String: std.u16string) {
+    let buffer = UnsafeBufferPointer<UInt16>(
+      start: cxxU16String.__dataUnsafe(),
+      count: cxxU16String.size())
+    self = String(decoding: buffer, as: UTF16.self)
+    withExtendedLifetime(cxxU16String) {}
   }
 }

--- a/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
+++ b/test/Interop/Cxx/stdlib/overlay/std-string-overlay.swift
@@ -45,6 +45,36 @@ StdStringOverlayTestSuite.test("std::string <=> Swift.String") {
   expectEqual(swift7, "���")
 }
 
+StdStringOverlayTestSuite.test("std::u16string <=> Swift.String") {
+  let cxx1 = std.u16string()
+  let swift1 = String(cxx1)
+  expectEqual(swift1, "")
+
+  let cxx2 = std.u16string("something123")
+  expectEqual(cxx2.size(), 12)
+  let swift2 = String(cxx2)
+  expectEqual(swift2, "something123")
+
+  let cxx3: std.u16string = "literal"
+  expectEqual(cxx3.size(), 7)
+
+  let cxx4: std.u16string = "тест"
+  expectEqual(cxx4.size(), 4)
+  let swift4 = String(cxx4)
+  expectEqual(swift4, "тест")
+
+  // Emojis are represented by more than one CWideChar.
+  let cxx5: std.u16string = "emoji_🤖"
+  expectEqual(cxx5.size(), 8)
+  let swift5 = String(cxx5)
+  expectEqual(swift5, "emoji_🤖")
+
+  let cxx6 = std.u16string("xyz\0abc")
+  expectEqual(cxx6.size(), 7)
+  let swift6 = String(cxx6)
+  expectEqual(swift6, "xyz\0abc")
+}
+
 StdStringOverlayTestSuite.test("std::string as Swift.CustomDebugStringConvertible") {
   let cxx1 = std.string()
   expectEqual(cxx1.debugDescription, "std.string()")


### PR DESCRIPTION
This re-lands https://github.com/apple/swift/pull/61695 since the linker error on CentOS has been fixed in https://github.com/apple/swift/pull/63058.

This reverts commit e97b1c8e