### PR TITLE
[move-only] When emitting a deinit for a move only struct with only trivial fields, use an end_lifetime instead of a destructure_struct.

### DIFF
--- a/test/Interpreter/moveonly.swift
+++ b/test/Interpreter/moveonly.swift
@@ -1,0 +1,23 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-move-only -Xfrontend -sil-verify-all) | %FileCheck %s
+
+// REQUIRES: executable_test
+
+// CHECK: MyInt: 5
+@inline(never)
+func printInt(_ x: Int) { print("MyInt: \(x)") }
+
+@_moveOnly
+struct FD {
+    var i = 5
+
+    deinit {
+        printInt(i)
+    }
+}
+
+func main() {
+    let x = FD()
+    let _ = x
+}
+
+main()


### PR DESCRIPTION
rdar://104875010
