### PR TITLE
[borrow-operator] Make the borrow operator work for accessors

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6749,8 +6749,8 @@ ERROR(moveOnly_not_allowed_here,none,
       "'moveOnly' only applies to structs or enums", ())
 ERROR(move_expression_not_passed_lvalue,none,
       "'move' can only be applied to lvalues", ())
-ERROR(borrow_expression_not_passed_lvalue,none,
-      "'borrow' can only be applied to lvalues", ())
+ERROR(borrow_expression_not_passed_var,none,
+      "'borrow' can only be applied to var bindings", ())
 
 //------------------------------------------------------------------------------
 // MARK: #_hasSymbol

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3897,7 +3897,7 @@ getFunctionRecursiveProperties(ArrayRef<AnyFunctionType::Param> params,
   properties |= result->getRecursiveProperties();
   if (globalActor)
     properties |= globalActor->getRecursiveProperties();
-  properties &= ~RecursiveTypeProperties::IsLValue;
+  properties &= ~RecursiveTypeProperties::IsLValueMask;
   return properties;
 }
 
@@ -3922,7 +3922,7 @@ isAnyFunctionTypeCanonical(ArrayRef<AnyFunctionType::Param> params,
 static RecursiveTypeProperties
 getGenericFunctionRecursiveProperties(ArrayRef<AnyFunctionType::Param> params,
                                       Type result) {
-  static_assert(RecursiveTypeProperties::BitWidth == 15,
+  static_assert(RecursiveTypeProperties::BitWidth == 16,
                 "revisit this if you add new recursive type properties");
   RecursiveTypeProperties properties;
 
@@ -4568,7 +4568,7 @@ CanSILFunctionType SILFunctionType::get(
   void *mem = ctx.Allocate(bytes, alignof(SILFunctionType));
 
   RecursiveTypeProperties properties;
-  static_assert(RecursiveTypeProperties::BitWidth == 15,
+  static_assert(RecursiveTypeProperties::BitWidth == 16,
                 "revisit this if you add new recursive type properties");
   for (auto &param : params)
     properties |= param.getInterfaceType()->getRecursiveProperties();
@@ -4701,12 +4701,13 @@ BuiltinTupleType::BuiltinTupleType(BuiltinTupleDecl *TheDecl,
   : NominalType(TypeKind::BuiltinTuple, &Ctx, TheDecl, Type(),
                 RecursiveTypeProperties()) { }
 
-LValueType *LValueType::get(Type objectTy) {
+LValueType *LValueType::get(Type objectTy, bool isMutable) {
   assert(!objectTy->is<LValueType>() && !objectTy->is<InOutType>() &&
          "cannot have 'inout' or @lvalue wrapped inside an @lvalue");
 
-  auto properties = objectTy->getRecursiveProperties()
-                    | RecursiveTypeProperties::IsLValue;
+  auto properties = objectTy->getRecursiveProperties() |
+                    (isMutable ? RecursiveTypeProperties::IsMutableLValue
+                               : RecursiveTypeProperties::IsImmutableLValue);
   auto arena = getArena(properties);
 
   auto &C = objectTy->getASTContext();
@@ -4725,7 +4726,7 @@ InOutType *InOutType::get(Type objectTy) {
 
   auto properties = objectTy->getRecursiveProperties();
 
-  properties &= ~RecursiveTypeProperties::IsLValue;
+  properties &= ~RecursiveTypeProperties::IsLValueMask;
   auto arena = getArena(properties);
 
   auto &C = objectTy->getASTContext();

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -451,8 +451,19 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
 
       // Allow for a chain of member_ref exprs that end in a decl_ref expr.
       auto *subExpr = borrowExpr->getSubExpr();
-      while (auto *memberRef = dyn_cast<MemberRefExpr>(subExpr))
-        subExpr = memberRef->getBase();
+      while (true) {
+        if (auto *memberRef = dyn_cast<MemberRefExpr>(subExpr)) {
+          subExpr = memberRef->getBase();
+          continue;
+        }
+
+        auto *semanticsExpr = subExpr->getSemanticsProvidingExpr();
+        if (semanticsExpr != subExpr) {
+          subExpr = semanticsExpr;
+          continue;
+        }
+        break;
+      }
       auto *declRefExpr = dyn_cast<DeclRefExpr>(subExpr);
       if (!declRefExpr || !declRefExpr->getType()->hasLValueType()) {
         Ctx.Diags.diagnose(borrowExpr->getLoc(),

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -453,9 +453,10 @@ static void diagSyntacticUseRestrictions(const Expr *E, const DeclContext *DC,
       auto *subExpr = borrowExpr->getSubExpr();
       while (auto *memberRef = dyn_cast<MemberRefExpr>(subExpr))
         subExpr = memberRef->getBase();
-      if (!isa<DeclRefExpr>(subExpr)) {
+      auto *declRefExpr = dyn_cast<DeclRefExpr>(subExpr);
+      if (!declRefExpr || !declRefExpr->getType()->hasLValueType()) {
         Ctx.Diags.diagnose(borrowExpr->getLoc(),
-                           diag::borrow_expression_not_passed_lvalue);
+                           diag::borrow_expression_not_passed_var);
       }
     }
 

--- a/test/Parse/borrow_expr.swift
+++ b/test/Parse/borrow_expr.swift
@@ -7,7 +7,7 @@ func testGlobal() {
 
 func testLet() {
     let t = String()
-    let _ = _borrow t
+    let _ = _borrow t // expected-error {{}}
 }
 
 func testVar() {

--- a/test/Sema/borrow_expr.swift
+++ b/test/Sema/borrow_expr.swift
@@ -1,87 +1,114 @@
 // RUN: %target-typecheck-verify-swift  -disable-availability-checking -enable-experimental-move-only
 
 class Klass {
-    var k: Klass? = nil
+  var k: Klass? = nil
 }
 
 func useString(_ x: String) {}
 
 var global: String = "5"
 func testGlobal() {
-    useString(_borrow global)
+  useString(_borrow global)
 }
 
 func testLet() {
-    let t = String()
-    useString(_borrow t)
+  let t = String()
+  useString(_borrow t) // expected-error {{'borrow' can only be applied to var bindings}}
 }
 
 func testVar() {
-    var t = String()
-    t = String()
-    useString(_borrow t)
+  var t = String()
+  t = String()
+  useString(_borrow t)
 }
 
 struct S {
-    var k = Klass()
+  var k = Klass()
 
-    func test() {}
+  func test() {}
 
-    func test2() {
-        (_borrow self).test()
-    }
+  func test2() {
+    (_borrow self).test() // expected-error {{'borrow' can only be applied to var bindings}}
+  }
+
+  mutating func test3() {
+    (_borrow self).test()
+  }
 }
 
 func useApply() {
-    var s = S()
-    s = S()
-    (_borrow s).test()
+  var s = S()
+  s = S()
+  (_borrow s).test()
 }
 
 func testExprFailureLet() {
-    let t = 5
-    // Next line is parsed as move(t) + t
-    let _ = _borrow t + t
-    // Next line is parsed as move(t+t)
-    let _ = _borrow (t+t) // expected-error {{'borrow' can only be applied to lvalues}}
+  let t = 5
+  // Next line is parsed as move(t) + t
+  let _ = _borrow t + t // expected-error {{'borrow' can only be applied to var bindings}}
+  // Next line is parsed as move(t+t)
+  let _ = _borrow (t+t) // expected-error {{'borrow' can only be applied to var bindings}}
 }
 
 func testExprFailureVar() {
-    var t = 5
-    t = 5
-    // Next line is parsed as move(t) + t
-    let _ = _borrow t + t
-    // Next line is parsed as move(t+t)
-    let _ = _borrow (t+t) // expected-error {{'borrow' can only be applied to lvalues}}
+  var t = 5
+  t = 5
+  // Next line is parsed as move(t) + t
+  let _ = _borrow t + t
+  // Next line is parsed as move(t+t)
+  let _ = _borrow (t+t) // expected-error {{'borrow' can only be applied to var bindings}}
 }
 
 func letAddressOnly<T>(_ v: T) {
-    let t = v
-    let _ = _borrow t
+  let t = v
+  let _ = _borrow t // expected-error {{'borrow' can only be applied to var bindings}}
 }
 
 struct StructWithField {
-    var k: Klass? = nil
+  var k: Klass = Klass()
+
+  var computedK : Klass {
+    return k
+  }
+
+  var computedK2 : Klass {
+    _read {
+      yield k
+    }
+  }
 }
 
 func testLetStructAccessField() {
-    let t = StructWithField()
-    let _ = _borrow t.k
+  let t = StructWithField()
+  let _ = _borrow t.k // expected-error {{'borrow' can only be applied to var bindings}}
+  let _ = _borrow t.computedK // expected-error {{'borrow' can only be applied to var bindings}}
+  let _ = _borrow t.computedK2 // expected-error {{'borrow' can only be applied to var bindings}}
+  let _ = _borrow (_borrow t).computedK
+  // expected-error @-1:11 {{'borrow' can only be applied to var bindings}}
+  // expected-error @-2:20 {{'borrow' can only be applied to var bindings}}
+  let _ = _borrow (_borrow t).computedK2
+  // expected-error @-1:11 {{'borrow' can only be applied to var bindings}}
+  // expected-error @-2:20 {{'borrow' can only be applied to var bindings}}
 }
 
 func testVarStructAccessField() {
-    var t = StructWithField()
-    t = StructWithField()
-    let _ = _borrow t.k
+  var t = StructWithField()
+  t = StructWithField()
+  let _ = _borrow t.k
+  let _ = _borrow t.computedK // expected-error {{'borrow' can only be applied to var bindings}}
+  let _ = _borrow t.computedK2 // expected-error {{'borrow' can only be applied to var bindings}}
+  let _ = _borrow (_borrow t).computedK // expected-error {{'borrow' can only be applied to var bindings}}
+  let _ = _borrow (_borrow t).computedK2 // expected-error {{'borrow' can only be applied to var bindings}}
+
 }
 
 func testLetClassAccessField() {
-    let t = Klass()
-    let _ = _borrow t.k
+  let t = Klass()
+  let _ = _borrow t.k // expected-error {{'borrow' can only be applied to var bindings}}
 }
 
 func testVarClassAccessField() {
-    var t = Klass()
-    t = Klass()
-    let _ = _borrow t.k // expected-error {{'borrow' can only be applied to lvalues}}
+  var t = Klass()
+  t = Klass()
+  let _ = _borrow t.k // expected-error {{'borrow' can only be applied to var bindings}}
 }

--- a/test/Sema/borrow_expr.swift
+++ b/test/Sema/borrow_expr.swift
@@ -40,6 +40,7 @@ func useApply() {
   var s = S()
   s = S()
   (_borrow s).test()
+  (((_borrow s))).test()
 }
 
 func testExprFailureLet() {
@@ -72,9 +73,23 @@ struct StructWithField {
   }
 
   var computedK2 : Klass {
+    get {
+      return k
+    }
+    set {}
+  }
+
+  var computedK3 : Klass {
     _read {
       yield k
     }
+  }
+
+  var computedK4 : Klass {
+    _read {
+      yield k
+    }
+    set {}
   }
 }
 
@@ -95,10 +110,21 @@ func testVarStructAccessField() {
   var t = StructWithField()
   t = StructWithField()
   let _ = _borrow t.k
+
+  let _ = (_borrow t).computedK
+  let _ = (_borrow t).computedK2
+  let _ = (_borrow t).computedK3
+  let _ = (_borrow t).computedK4
+
   let _ = _borrow t.computedK // expected-error {{'borrow' can only be applied to var bindings}}
-  let _ = _borrow t.computedK2 // expected-error {{'borrow' can only be applied to var bindings}}
-  let _ = _borrow (_borrow t).computedK // expected-error {{'borrow' can only be applied to var bindings}}
-  let _ = _borrow (_borrow t).computedK2 // expected-error {{'borrow' can only be applied to var bindings}}
+  let _ = _borrow t.computedK2
+  let _ = _borrow t.computedK3 // expected-error {{'borrow' can only be applied to var bindings}}
+  let _ = _borrow t.computedK4
+
+  let _ = _borrow (_borrow t).computedK
+  let _ = _borrow (_borrow t).computedK2
+  let _ = _borrow (_borrow t).computedK3
+  let _ = _borrow (_borrow t).computedK4
 
 }
 


### PR DESCRIPTION
This PR does two things:

1. It makes it an error to _borrow a let.
2. It adds support for borrowing accessors.

It is not completely complete (I want to add some SILGen tests that validate that we setup coroutines correctly when we borrow).