### PR TITLE
[CSFix] Diagnose extraneous force unwraps in ambiguous context

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -1205,6 +1205,10 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
   static RemoveUnwrap *create(ConstraintSystem &cs, Type baseType,
                               ConstraintLocator *locator);
 

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -589,3 +589,13 @@ do {
     // expected-error@-1 {{argument type '(any BinaryInteger)?' does not conform to expected type 'P'}}
   }
 }
+
+// Diagnose extraneous force unwrap in ambiguous context
+do {
+  func test(_: Int) {} // expected-note {{found this candidate}}
+  func test(_: String) {} // expected-note {{found this candidate}}
+
+  var x: Double = 42
+  test(x!) // expected-error {{no exact matches in call to local function 'test'}}
+  // expected-error@-1 {{cannot force unwrap value of non-optional type 'Double'}}
+}

--- a/test/StringProcessing/Parse/forward-slash-regex.swift
+++ b/test/StringProcessing/Parse/forward-slash-regex.swift
@@ -121,6 +121,7 @@ do {
 } // expected-error {{expected expression after operator}}
 
 _ = /x/??/x/ // expected-error {{'/' is not a postfix unary operator}}
+// expected-error@-1 2 {{cannot use optional chaining on non-optional value of type 'Regex<Substring>'}}
 
 _ = /x/ ... /y/ // expected-error {{referencing operator function '...' on 'Comparable' requires that 'Regex<Substring>' conform to 'Comparable'}}
 


### PR DESCRIPTION
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
