### PR TITLE
IRGen: Use `deinit` to destroy move-only structs that have them.

### DIFF
--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -419,7 +419,7 @@ public:
   virtual void loadAsTake(IRGenFunction &IGF, Address addr,
                           Explosion &e) const = 0;
   virtual void assign(IRGenFunction &IGF, Explosion &e, Address addr,
-                      bool isOutlined) const = 0;
+                      bool isOutlined, SILType T) const = 0;
   virtual void initialize(IRGenFunction &IGF, Explosion &e, Address addr,
                           bool isOutlined) const = 0;
   virtual void reexplode(IRGenFunction &IGF, Explosion &src,
@@ -427,7 +427,7 @@ public:
   virtual void copy(IRGenFunction &IGF, Explosion &src,
                     Explosion &dest, Atomicity atomicity) const = 0;
   virtual void consume(IRGenFunction &IGF, Explosion &src,
-                       Atomicity atomicity) const = 0;
+                       Atomicity atomicity, SILType T) const = 0;
   virtual void fixLifetime(IRGenFunction &IGF, Explosion &src) const = 0;
   virtual void packIntoEnumPayload(IRGenFunction &IGF,
                                    EnumPayload &payload,

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -450,7 +450,7 @@ namespace {
     }
 
     void assign(IRGenFunction &IGF, Explosion &e, Address address,
-                bool isOutlined) const override {
+                bool isOutlined, SILType T) const override {
       // Assign the value.
       Address instanceAddr = asDerived().projectValue(IGF, address);
       llvm::Value *old = IGF.Builder.CreateLoad(instanceAddr);
@@ -483,7 +483,8 @@ namespace {
       src.transferInto(dest, getNumStoredProtocols());
     }
 
-    void consume(IRGenFunction &IGF, Explosion &src, Atomicity atomicity)
+    void consume(IRGenFunction &IGF, Explosion &src, Atomicity atomicity,
+                 SILType T)
     const override {
       // Copy the instance pointer.
       llvm::Value *value = src.claimNext();

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -379,6 +379,24 @@ TypeLayoutEntry *buildTypeLayoutEntryForFields(IRGenModule &IGM, SILType T,
       fields, minimumAlignment, true);
 }
 
+/// Emit a call to the deinit for T to destroy the value at the given address,
+/// if a deinit is available.
+///
+/// Returns true if the deinit call was emitted, or false if there is no deinit.
+/// No code emission occurs if the function returns false.
+bool tryEmitDestroyUsingDeinit(IRGenFunction &IGF,
+                               Address address,
+                               SILType T);
+                               
+/// Emit a call to the deinit for T to destroy the value in the given explosion,
+/// if a deinit is available.
+///
+/// Returns true if the deinit call was emitted, or false if there is no deinit.
+/// No code emission occurs if the function returns false.
+bool tryEmitConsumeUsingDeinit(IRGenFunction &IGF,
+                               Explosion &explosion,
+                               SILType T);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -4677,10 +4677,13 @@ void IRGenSILFunction::visitSetDeallocatingInst(SetDeallocatingInst *i) {
 }
 
 void IRGenSILFunction::visitReleaseValueInst(swift::ReleaseValueInst *i) {
-  Explosion in = getLoweredExplosion(i->getOperand());
-  cast<LoadableTypeInfo>(getTypeInfo(i->getOperand()->getType()))
+  auto operand = i->getOperand();
+  auto ty = operand->getType();
+  Explosion in = getLoweredExplosion(operand);
+  cast<LoadableTypeInfo>(getTypeInfo(ty))
       .consume(*this, in, i->isAtomic() ? irgen::Atomicity::Atomic
-                                        : irgen::Atomicity::NonAtomic);
+                                        : irgen::Atomicity::NonAtomic,
+               ty);
 }
 
 void IRGenSILFunction::visitReleaseValueAddrInst(
@@ -4701,9 +4704,11 @@ void IRGenSILFunction::visitReleaseValueAddrInst(
 }
 
 void IRGenSILFunction::visitDestroyValueInst(swift::DestroyValueInst *i) {
-  Explosion in = getLoweredExplosion(i->getOperand());
-  cast<LoadableTypeInfo>(getTypeInfo(i->getOperand()->getType()))
-      .consume(*this, in, getDefaultAtomicity());
+  auto operand = i->getOperand();
+  auto ty = operand->getType();
+  Explosion in = getLoweredExplosion(operand);
+  cast<LoadableTypeInfo>(getTypeInfo(ty))
+      .consume(*this, in, getDefaultAtomicity(), ty);
 }
 
 void IRGenSILFunction::visitStructInst(swift::StructInst *i) {
@@ -4887,7 +4892,7 @@ void IRGenSILFunction::visitStoreInst(swift::StoreInst *i) {
     typeInfo.initialize(*this, source, dest, false);
     break;
   case StoreOwnershipQualifier::Assign:
-    typeInfo.assign(*this, source, dest, false);
+    typeInfo.assign(*this, source, dest, false, objType);
     break;
   }
 }

--- a/lib/IRGen/LoadableTypeInfo.h
+++ b/lib/IRGen/LoadableTypeInfo.h
@@ -97,7 +97,7 @@ public:
   /// Assign a set of exploded values into an address.  The values are
   /// consumed out of the explosion.
   virtual void assign(IRGenFunction &IGF, Explosion &explosion, Address addr,
-                      bool isOutlined) const = 0;
+                      bool isOutlined, SILType T) const = 0;
 
   /// Initialize an address by consuming values out of an explosion.
   virtual void initialize(IRGenFunction &IGF, Explosion &explosion,
@@ -121,7 +121,8 @@ public:
   
   /// Release reference counts or other resources owned by the explosion.
   virtual void consume(IRGenFunction &IGF, Explosion &explosion,
-                       Atomicity atomicity) const = 0;
+                       Atomicity atomicity,
+                       SILType T) const = 0;
 
   /// Fix the lifetime of the source explosion by creating opaque calls to
   /// swift_fixLifetime for all reference types in the explosion.

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -449,7 +449,7 @@ IRGenModule::getOrCreateReleaseFunction(const TypeInfo &ti,
                      loadableTI->getFixedAlignment());
         Explosion loaded;
         loadableTI->loadAsTake(IGF, addr, loaded);
-        loadableTI->consume(IGF, loaded, atomicity);
+        loadableTI->consume(IGF, loaded, atomicity, t);
         IGF.Builder.CreateRet(addr.getAddress());
       },
       true /*setIsNoInline*/);

--- a/lib/IRGen/ScalarPairTypeInfo.h
+++ b/lib/IRGen/ScalarPairTypeInfo.h
@@ -98,7 +98,7 @@ public:
   }
 
   void assign(IRGenFunction &IGF, Explosion &e, Address address,
-              bool isOutlined) const override {
+              bool isOutlined, SILType T) const override {
     // Store the function pointer.
     Address firstAddr = projectFirstElement(IGF, address);
     asDerived().emitAssignFirstElement(IGF, e.claimNext(), firstAddr);
@@ -128,7 +128,7 @@ public:
   }
 
   void consume(IRGenFunction &IGF, Explosion &src,
-               Atomicity atomicity) const override {
+               Atomicity atomicity, SILType T) const override {
     auto first = src.claimNext();
     asDerived().emitReleaseFirstElement(IGF, first, atomicity);
 

--- a/lib/IRGen/ScalarTypeInfo.h
+++ b/lib/IRGen/ScalarTypeInfo.h
@@ -58,14 +58,14 @@ public:
                       bool isOutlined) const override {
     Explosion temp;
     asDerived().Derived::loadAsCopy(IGF, src, temp);
-    asDerived().Derived::assign(IGF, temp, dest, isOutlined);
+    asDerived().Derived::assign(IGF, temp, dest, isOutlined, T);
   }
 
   void assignWithTake(IRGenFunction &IGF, Address dest, Address src, SILType T,
                       bool isOutlined) const override {
     Explosion temp;
     asDerived().Derived::loadAsTake(IGF, src, temp);
-    asDerived().Derived::assign(IGF, temp, dest, isOutlined);
+    asDerived().Derived::assign(IGF, temp, dest, isOutlined, T);
   }
 
   void reexplode(IRGenFunction &IGF, Explosion &in,
@@ -161,7 +161,7 @@ public:
   }
 
   void assign(IRGenFunction &IGF, Explosion &src, Address dest,
-              bool isOutlined) const override {
+              bool isOutlined, SILType T) const override {
     // Project down.
     dest = asDerived().projectScalar(IGF, dest);
 
@@ -188,7 +188,7 @@ public:
   }
 
   void consume(IRGenFunction &IGF, Explosion &in,
-               Atomicity atomicity) const override {
+               Atomicity atomicity, SILType T) const override {
     llvm::Value *value = in.claimNext();
     asDerived().emitScalarRelease(IGF, value, atomicity);
   }

--- a/test/IRGen/moveonly_deinit.sil
+++ b/test/IRGen/moveonly_deinit.sil
@@ -1,0 +1,179 @@
+// RUN: %target-swift-frontend -enable-experimental-move-only -emit-ir %s | %FileCheck %s
+
+import Builtin
+import Swift
+
+// Check that box destructor invokes deinit for a captured move-only value.
+// CHECK: @[[BOX_STRUCT_METADATA:[A-Za-z0-9_.]+]] = {{.*}} constant %swift.full_boxmetadata { void (%swift.refcounted*)* @[[BOX_STRUCT_DESTRUCTOR:[A-Za-z0-9_.]+]]
+
+sil_stage canonical
+
+class C {}
+
+@_moveOnly
+struct MOStruct {
+  var x: Int
+  var y: C
+
+  deinit
+}
+
+@_moveOnly
+enum MOEnum {
+  case x(Int)
+  case y(C)
+
+  deinit
+}
+
+@_moveOnly
+struct MOComboStruct {
+  var a: MOStruct
+  var b: MOEnum
+  var c: C
+}
+
+@_moveOnly
+enum MOComboEnum {
+  case a(MOStruct)
+  case b(MOEnum)
+  case c(C)
+}
+
+// Move-only types should not share value witnesses or box metadata with
+// common layout types.
+@_moveOnly
+struct MOIntLikeStruct {
+  var x: Int
+
+  deinit
+}
+
+@_moveOnly
+struct MOSingleRefcountLikeStruct {
+  var x: C
+
+  deinit
+}
+
+
+// CHECK-LABEL: define{{.*}}@destroy_struct_value(
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    call{{.*}}@destroy_struct(
+// CHECK-NEXT:    ret void
+sil @destroy_struct_value : $@convention(thin) (@owned MOStruct) -> () {
+entry(%b : $MOStruct):
+  release_value %b : $MOStruct
+  return undef : $()
+}
+
+// CHECK-LABEL: define{{.*}}@destroy_struct_value_indirect(
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    getelementptr
+// CHECK-NEXT:    getelementptr
+// CHECK-NEXT:    load
+// CHECK-NEXT:    getelementptr
+// CHECK-NEXT:    load
+// CHECK-NEXT:    call{{.*}}@destroy_struct(
+// CHECK-NEXT:    ret void
+sil @destroy_struct_value_indirect : $@convention(thin) (@in MOStruct) -> () {
+entry(%b : $*MOStruct):
+  destroy_addr %b : $*MOStruct
+  return undef : $()
+}
+
+sil @destroy_enum_value : $@convention(thin) (@owned MOEnum) -> () {
+entry(%b : $MOEnum):
+  release_value %b : $MOEnum
+  return undef : $()
+}
+
+sil @destroy_enum_value_indirect : $@convention(thin) (@in MOEnum) -> () {
+entry(%b : $*MOEnum):
+  destroy_addr %b : $*MOEnum
+  return undef : $()
+}
+
+// CHECK-LABEL: define{{.*}}@destroy_combo_struct_value(
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:   call {{.*}} @[[COMBO_STRUCT_OUTLINED_DESTROY:"\$.*13MOComboStructVWOs"]](
+// CHECK-NEXT:   ret void
+sil @destroy_combo_struct_value : $@convention(thin) (@owned MOComboStruct) -> () {
+entry(%b : $MOComboStruct):
+  release_value %b : $MOComboStruct
+  return undef : $()
+}
+
+// CHECK: define{{.*}}@[[COMBO_STRUCT_OUTLINED_DESTROY]](
+// CHECK:   call {{.*}} @destroy_struct
+// CH/ECK:   call {{.*}} @destroy_enum
+// CHECK:   call {{.*}} @swift_release
+// CHECK:   ret {{.*}} %0
+
+
+// CHECK-LABEL: define{{.*}}@destroy_combo_enum_value(
+// CHECK-NEXT:  entry:
+// CHECK:         call {{.*}} @[[COMBO_ENUM_OUTLINED_DESTROY:"\$.*11MOComboEnumOWOe"]](
+// CHECK-NEXT:    ret void
+sil @destroy_combo_enum_value : $@convention(thin) (@owned MOComboEnum) -> () {
+entry(%b : $MOComboEnum):
+  release_value %b : $MOComboEnum
+  return undef : $()
+}
+
+// CHECK:      define{{.*}}@[[COMBO_ENUM_OUTLINED_DESTROY]](
+// CHECK:        switch
+// CHECK-NEXT:     i8 0, label %[[STRUCT:[0-9]+]]
+// CHECK-NEXT:     i8 1, label %[[ENUM:[0-9]+]]
+// CHECK-NEXT:     i8 2, label %[[CLASS:[0-9]+]]
+// CHECK:      [[STRUCT]]:
+// CHECK:        call {{.*}} @destroy_struct
+// CHECK:      [[ENUM]]:
+// C/HECK:        call {{.*}} @destroy_enum
+// CHECK:      [[CLASS]]:
+// CHECK:        call {{.*}} @swift_release
+
+// CHECK-LABEL: define{{.*}}@box_struct(
+// CHECK:         call {{.*}} @swift_allocObject({{.*}} %swift.full_boxmetadata* @[[BOX_STRUCT_METADATA]],
+
+// CHECK:       define{{.*}}@[[BOX_STRUCT_DESTRUCTOR]](
+// CHECK:        call {{.*}} @destroy_struct
+// C/HECK:        call {{.*}} @destroy_enum
+// CHECK:        call {{.*}} @swift_release
+sil @box_struct : $@convention(thin) (@owned MOComboStruct) -> Builtin.NativeObject {
+entry(%0 : $MOComboStruct):
+  %b = alloc_box ${ var MOComboStruct }
+  %p = project_box %b : ${ var MOComboStruct }, 0
+  store %0 to %p : $*MOComboStruct
+  %r = unchecked_ref_cast %b : ${ var MOComboStruct } to $Builtin.NativeObject
+  return %r : $Builtin.NativeObject
+}
+
+sil @destroy_struct : $@convention(method) (@owned MOStruct) -> ()
+sil @destroy_enum : $@convention(method) (@owned MOEnum) -> ()
+sil @destroy_intlike_struct : $@convention(method) (@owned MOIntLikeStruct) -> ()
+sil @destroy_single_refcount_like_struct : $@convention(method) (@owned MOSingleRefcountLikeStruct) -> ()
+
+sil_vtable C {}
+
+sil_moveonlydeinit MOStruct { @destroy_struct }
+sil_moveonlydeinit MOEnum { @destroy_enum }
+sil_moveonlydeinit MOIntLikeStruct { @destroy_intlike_struct }
+sil_moveonlydeinit MOSingleRefcountLikeStruct { @destroy_single_refcount_like_struct }
+
+// Check that destroy value witnesses invoke the deinit function, either
+// indirectly or directly.
+
+// CHECK-LABEL: define {{.*}} @"{{.*}}8MOStructVwxx"
+// CHECK:         call {{.*}} @destroy_struct(
+// CHECK-LABEL: define {{.*}} @"{{.*}}6MOEnumOwxx"
+// C/HECK:         call {{.*}} @destroy_enum(
+// CHECK-LABEL: define {{.*}} @"{{.*}}13MOComboStructVwxx"
+// CHECK:         call {{.*}} @destroy_struct(
+// C/HECK:         call {{.*}} @destroy_enum(
+// CHECK:         call {{.*}} @swift_retain(
+// CHECK-LABEL: define {{.*}} @"{{.*}}11MOComboEnumOwxx"
+// CHECK:         call {{.*}} @[[COMBO_ENUM_OUTLINED_DESTROY]]
+
+// C/HECK-LABEL: define {{.*}} @"{{.*}}15MOIntLikeStructVwxx"
+// C/HECK-LABEL: define {{.*}} @"{{.*}}26MOSingleRefcountLikeStructVwxx"

--- a/test/Interpreter/moveonly_escaping_capture.swift
+++ b/test/Interpreter/moveonly_escaping_capture.swift
@@ -1,0 +1,54 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-move-only) | %FileCheck %s
+// REQUIRES: executable_test
+// TODO: SIL optimizations cause a miscompile of deinit rdar://105798769
+// REQUIRES: swift_test_mode_optimize_none
+
+class C {
+    var value: Int
+    init(value: Int) { self.value = value }
+
+    deinit { print("C died \(value)") }
+}
+
+@_moveOnly
+struct Butt {
+    static var myButt: () -> () = {}
+
+    init(value: Int) { self._value = C(value: value) }
+
+    // TODO: work around crash when move-only type has a deinit and no
+    // nontrivial fields by putting a class here
+
+    // TODO: work around crash when we export a setter from a move-only type
+    // by making this stored property private
+    private var _value: C
+
+    // TODO: prevent IRGen from reusing value witnesses or box metadata
+    // for the common single-refcounted layout
+    private var _x: Bool = false
+
+    var value: Int { return _value.value }
+
+    deinit { print("Butt died \(value)") }
+}
+
+func foo() {
+    let butt = Butt(value: 42)
+
+    Butt.myButt = { print(butt.value) }
+}
+
+func bar() {
+    // CHECK: 42
+    Butt.myButt()
+    // CHECK-NEXT: done calling
+    print("done calling")
+    // CHECK-NEXT: Butt died 42
+    // CHECK-NEXT: C died 42
+    Butt.myButt = {}
+    // CHECK-NEXT: done replacing closure
+    print("done replacing closure")
+}
+
+foo()
+bar()


### PR DESCRIPTION
The `deinit` takes full responsibility for destroying the value, using the user-defined deinit body and implicitly destroying any remaining resources not consumed during the deinit.

Remaining to do after this patch:

- Run the deinit for enums
- Pass generic arguments for generic move-only types
- Handle deinits that take their parameter indirectly
- Teach value witness layout about when types are move-only and/or have deinits, so that we don't attempt to give move-only types standard value witness tables or share box metadata with copyable payloads