### PR TITLE
[cxx-interop] Disable support for dependent types.

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -920,8 +920,6 @@ namespace {
     ImportResult Visit##KIND##Type(const clang::KIND##Type *type) {            \
       if (type->isSugared())                                                   \
         return Visit(type->desugar());                                         \
-      if (type->isDependentType())                                             \
-        return Impl.SwiftContext.getAnyExistentialType();                      \
       return Type();                                                           \
     }
     MAYBE_SUGAR_TYPE(TypeOfExpr)

--- a/test/Interop/Cxx/templates/dependent-types-module-interface.swift
+++ b/test/Interop/Cxx/templates/dependent-types-module-interface.swift
@@ -1,3 +1,6 @@
+// Waiting for support for dependent types to be added back: rdar://103530256&90587703&89090706&89090631&89034704&89034440&83406001&83367285
+// XFAIL: *
+
 // RUN: %target-swift-ide-test -print-module -module-to-print=DependentTypes -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
 
 // CHECK: func differentDependentArgAndRet<T, U>(_ a: Any, T: T.Type, U: U.Type) -> Any

--- a/test/Interop/Cxx/templates/dependent-types-silgen.swift
+++ b/test/Interop/Cxx/templates/dependent-types-silgen.swift
@@ -1,3 +1,6 @@
+// Waiting for support for dependent types to be added back: rdar://103530256&90587703&89090706&89090631&89034704&89034440&83406001&83367285
+// XFAIL: *
+
 // RUN: %target-swift-emit-silgen %s -I %S/Inputs -enable-experimental-cxx-interop -disable-availability-checking | %FileCheck %s
 
 import DependentTypes

--- a/test/Interop/Cxx/templates/dependent-types.swift
+++ b/test/Interop/Cxx/templates/dependent-types.swift
@@ -1,3 +1,6 @@
+// Waiting for support for dependent types to be added back: rdar://103530256&90587703&89090706&89090631&89034704&89034440&83406001&83367285
+// XFAIL: *
+
 // RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none -Xfrontend -disable-availability-checking)
 //
 // REQUIRES: executable_test


### PR DESCRIPTION
We should not use this hack for dependent types. We need to add proper support for dependent types (we can't just use `Any`).