### PR TITLE
[Macros] Fix `MacroDecl` serialization crash with custom parameter attributes

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8418,6 +8418,9 @@ public:
   /// Retrieve the definition of this macro.
   MacroDefinition getDefinition() const;
 
+  /// Retrieve the parameter list of this macro.
+  ParameterList *getParameterList() const { return parameterList; }
+
   /// Retrieve the builtin macro kind for this macro, or \c None if it is a
   /// user-defined macro with no special semantics.
   Optional<BuiltinMacroKind> getBuiltinKind() const;

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1174,7 +1174,6 @@ public:
   UNINTERESTING(Destructor) // Always correct.
   UNINTERESTING(Accessor) // Handled by the Var or Subscript.
   UNINTERESTING(OpaqueType) // Handled by the Var or Subscript.
-  UNINTERESTING(Macro)
 
   /// If \p VD's layout is exposed by a @frozen struct or class, return said
   /// struct or class.
@@ -1567,6 +1566,10 @@ public:
         highlightOffendingType(diag, complainRepr);
       });
     }
+  }
+
+  void visitMacroDecl(MacroDecl *MD) {
+    // FIXME: Check access of macro generic parameters, parameters and result
   }
 
   void visitEnumElementDecl(EnumElementDecl *EED) {

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2019,6 +2019,8 @@ public:
     if (!MD->getAttrs().hasAttribute<MacroRoleAttr>(/*AllowInvalid*/ true))
       MD->diagnose(diag::macro_without_role, MD->getName());
 
+    TypeChecker::checkParameterList(MD->getParameterList(), MD);
+
     // Check the macro definition.
     switch (auto macroDef = MD->getDefinition()) {
     case MacroDefinition::Kind::Undefined:

--- a/test/Serialization/Inputs/def_macros.swift
+++ b/test/Serialization/Inputs/def_macros.swift
@@ -24,3 +24,10 @@ public struct Base {
 public struct TestMacroArgTypechecking {
   public var value: Int
 }
+
+@resultBuilder
+public struct Builder {
+  static func buildBlock(_: Int...) -> Void {}
+}
+@freestanding(expression)
+public macro macroWithBuilderArgs(@Builder _: () -> Void) = #externalMacro(module: "A", type: "B")

--- a/test/Serialization/macros.swift
+++ b/test/Serialization/macros.swift
@@ -5,6 +5,8 @@
 // RUN: %target-build-swift -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/def_macro_plugin.swift -g -no-toolchain-stdlib-rpath
 // RUN: %target-swift-frontend -emit-module -o %t/def_macros.swiftmodule %S/Inputs/def_macros.swift -module-name def_macros -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir
 // RUN: %target-swift-frontend -typecheck -I%t -verify %s -verify-ignore-unknown  -enable-experimental-feature Macros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir
+// RUN: llvm-bcanalyzer %t/def_macros.swiftmodule | %FileCheck %s
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -module-to-print=def_macros -I %t -source-filename=%s | %FileCheck -check-prefix=CHECK-PRINT %s
 // REQUIRES: OS=macosx
 
 import def_macros
@@ -19,3 +21,9 @@ func test(a: Int, b: Int) {
 struct TestStruct {
   @myWrapper var x: Int
 }
+
+// CHECK: MACRO_DECL
+
+// CHECK-NOT: UnknownCode
+
+// CHECK-PRINT-DAG: macro macroWithBuilderArgs(@Builder _: () -> Void)


### PR DESCRIPTION
Type-check `MacroDecl`'s parameter list so that custom attributes on parameters will have a type. Fixes a serialization crash.