### PR TITLE
[Sema] Fix variable invalid optional chaining in if context diagnostic

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5920,7 +5920,7 @@ bool ConstraintSystem::repairFailures(
 
     if (repairViaOptionalUnwrap(*this, lhs, rhs, matchKind, conversionsOrFixes,
                                 locator))
-      break;
+      return true;
 
     // Let's wait until both sides are of the same optionality before
     // attempting `.rawValue` fix.
@@ -5967,7 +5967,7 @@ bool ConstraintSystem::repairFailures(
 
         if (repairViaOptionalUnwrap(*this, lhs, rhs, matchKind,
                                     conversionsOrFixes, locator))
-          break;
+          return true;
 
         conversionsOrFixes.push_back(
             IgnoreContextualType::create(*this, lhs, rhs, locator));
@@ -6193,7 +6193,7 @@ bool ConstraintSystem::repairFailures(
   case ConstraintLocator::Condition: {
     if (repairViaOptionalUnwrap(*this, lhs, rhs, matchKind, conversionsOrFixes,
                                 locator))
-      break;
+      return true;
 
     conversionsOrFixes.push_back(IgnoreContextualType::create(
         *this, lhs, rhs, getConstraintLocator(locator)));
@@ -6218,7 +6218,7 @@ bool ConstraintSystem::repairFailures(
 
     if (repairViaOptionalUnwrap(*this, lhs, rhs, matchKind, conversionsOrFixes,
                                 locator))
-      break;
+      return true;
 
     if (repairByTreatingRValueAsLValue(lhs, rhs))
       break;

--- a/test/Constraints/if_expr.swift
+++ b/test/Constraints/if_expr.swift
@@ -567,3 +567,9 @@ func builderInClosure() {
     }
   }
 }
+
+// https://github.com/apple/swift/issues/63796
+func testInvalidOptionalChainingInIfContext() {
+  let v63796 = 1
+  if v63796? {} // expected-error{{cannot use optional chaining on non-optional value of type 'Int'}}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
In constraint generation a `RemoveUnwrap` is recorded when adding `OptionalObject` for `BindOptionalExpr` but when adding contextual constraint and attempting to add the contextual conversion constraint we end up in attempting `repairViaOptionalUnwrap` which succeed because there is a `RemoveUnwrap` already but returns `false` because the fix was recorded on a previous constraint and is not on `conversionsAndFixes` list. This leaves the conversion constraint  as `failedConstraint` and solver stops without being able to form a solution and produce diagnostic. 
The fix is simply assume that if `repairViaOptionalUnwrap` is successful we assume fixed in `repairFailure` already because it either record a fix or bail because there is a fix already.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves https://github.com/apple/swift/issues/63796

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
