### PR TITLE
[Sema] Handle FunctionArgument anchored in coerce expr in getCalleeLocator

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -622,6 +622,12 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
   if (isExpr<ObjectLiteralExpr>(anchor))
     return getConstraintLocator(anchor, ConstraintLocator::ConstructorMember);
 
+  if (locator->isLastElement<LocatorPathElt::FunctionArgument>()) {
+    if (auto *CE = getAsExpr<CoerceExpr>(anchor)) {
+      return getConstraintLocator(CE->getSubExpr());
+    }
+  }
+
   return getConstraintLocator(anchor);
 }
 

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -285,3 +285,9 @@ func rdar97396399() {
     }
   }
 }
+
+// https://github.com/apple/swift/issues/63834
+func f63834(int: Int, string: String) {} // expected-note{{found candidate with type '(Int, String) -> ()'}}
+func f63834(int: Int, string: Bool) {} // expected-note{{found candidate with type '(Int, Bool) -> ()'}}
+
+let a = f63834(int:string:) as (Int, Int) -> Void // expected-error{{no exact matches in reference to global function 'f63834'}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Handle `CoerceExpr` in `getCalledLocator` for `FunctionArgument` locator to return in a locator anchored on subexpr.  
`diagnoseAmbiguityWithFixes` can properly diagnose this overload ambiguity by callee locator.
<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves https://github.com/apple/swift/issues/63834.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
