### PR TITLE
Fix existential parameterized protocol diagnostic

### DIFF
--- a/test/type/explicit_existential_swift6.swift
+++ b/test/type/explicit_existential_swift6.swift
@@ -145,10 +145,16 @@ protocol Collection<T> {
   associatedtype T
 }
 
+struct TestParameterizedProtocol<T> : Collection {
+  typealias T = T
+
+  let x : Collection<T> // expected-error {{use of protocol 'Collection<T>' as a type must be written 'any Collection<T>'}}
+}
+
 func acceptAny(_: Collection<Int>) {}
-// expected-error@-1 {{use of protocol 'Collection' as a type must be written 'any Collection'}}
+// expected-error@-1 {{use of protocol 'Collection<Int>' as a type must be written 'any Collection<Int>'}}
 func returnsAny() -> Collection<Int> {}
-// expected-error@-1 {{use of protocol 'Collection' as a type must be written 'any Collection'}}
+// expected-error@-1 {{use of protocol 'Collection<Int>' as a type must be written 'any Collection<Int>'}}
 
 func testInvalidAny() {
   struct S: HasAssoc {

--- a/test/type/parameterized_existential.swift
+++ b/test/type/parameterized_existential.swift
@@ -7,10 +7,10 @@ protocol Sequence<Element> { // expected-note {{'Sequence' declared here}}
 // 'any' is required here
 
 func takesSequenceOfInt1(_: Sequence<Int>) {}
-// expected-error@-1 {{use of protocol 'Sequence' as a type must be written 'any Sequence'}}
+// expected-error@-1 {{use of protocol 'Sequence<Int>' as a type must be written 'any Sequence<Int>'}}
 
 func returnsSequenceOfInt1() -> Sequence<Int> {}
-// expected-error@-1 {{use of protocol 'Sequence' as a type must be written 'any Sequence'}}
+// expected-error@-1 {{use of protocol 'Sequence<Int>' as a type must be written 'any Sequence<Int>'}}
 
 struct ConcreteSequence<Element> : Sequence {}
 
@@ -74,7 +74,7 @@ func saturation(_ dry: any Sponge, _ wet: any Sponge<Int, Int>) {
 
 func typeExpr() {
   _ = Sequence<Int>.self
-  // expected-error@-1 {{use of protocol 'Sequence' as a type must be written 'any Sequence'}}
+  // expected-error@-1 {{use of protocol 'Sequence<Int>' as a type must be written 'any Sequence<Int>'}}
 
   _ = any Sequence<Int>.self
   // expected-error@-1 {{'self' is not a member type of protocol 'parameterized_existential.Sequence<Swift.Int>'}}


### PR DESCRIPTION
Diagnostic message should include ParameterizedProtocolType when applicable i.e. `any P<T>` vs `any P`

Fixes rdar://103363771