### PR TITLE
[IDE] Ignore score kinds that represent implicit conversions when solving for code completion

### DIFF
--- a/include/swift/IDE/PostfixCompletion.h
+++ b/include/swift/IDE/PostfixCompletion.h
@@ -25,11 +25,32 @@ namespace ide {
 /// type-checking.
 class PostfixCompletionCallback : public TypeCheckCompletionCallback {
   struct Result {
+    /// The type that we are completing on. Will never be null.
     Type BaseTy;
+
+    /// The decl that we are completing on. Is \c nullptr if we are completing
+    /// on an expression.
     ValueDecl *BaseDecl;
-    SmallVector<Type, 4> ExpectedTypes;
-    bool ExpectsNonVoid;
+
+    /// If the expression we are completing on statically refers to a metatype,
+    /// that is if it's something like 'MyType'. In such cases we want to offer
+    /// constructor call pattern completions and don't want to suggeste
+    /// operators that work on metatypes.
     bool BaseIsStaticMetaType;
+
+    /// The types that the completion is expected to produce.
+    SmallVector<Type, 4> ExpectedTypes;
+
+    /// Whether results that produce 'Void' should be disfavored. This happens
+    /// if the context is requiring a value. Once a completion produces 'Void',
+    /// we know that we can't retrieve a value from it anymore.
+    bool ExpectsNonVoid;
+
+    /// If the code completion expression occurs as a single statement in a
+    /// single-expression closure. In such cases we don't want to disfavor
+    /// results that produce 'Void' because the user might intend to make the
+    /// closure a multi-statment closure, in which case this expression is no
+    /// longer implicitly returned.
     bool IsImplicitSingleExpressionReturn;
 
     /// Whether the surrounding context is async and thus calling async
@@ -40,13 +61,24 @@ class PostfixCompletionCallback : public TypeCheckCompletionCallback {
     /// haven't been saved to the AST.
     llvm::DenseMap<AbstractClosureExpr *, ClosureActorIsolation>
         ClosureActorIsolations;
+
+    /// Checks whether this result has the same \c BaseTy and \c BaseDecl as
+    /// \p Other and if the two can thus be merged to be one value lookup in
+    /// \c deliverResults.
+    bool canBeMergedWith(const Result &Other, DeclContext &DC) const;
+
+    /// Merge this result with \p Other. Assumes that they can be merged.
+    void merge(const Result &Other, DeclContext &DC);
   };
 
   CodeCompletionExpr *CompletionExpr;
   DeclContext *DC;
 
   SmallVector<Result, 4> Results;
-  llvm::DenseMap<std::pair<Type, Decl *>, size_t> BaseToSolutionIdx;
+
+  /// Add a result to \c Results, merging it with an existing result, if
+  /// possible.
+  void addResult(const Result &Res);
 
   void sawSolutionImpl(const constraints::Solution &solution) override;
 

--- a/include/swift/IDE/UnresolvedMemberCompletion.h
+++ b/include/swift/IDE/UnresolvedMemberCompletion.h
@@ -32,6 +32,14 @@ class UnresolvedMemberTypeCheckCompletionCallback
     /// Whether the surrounding context is async and thus calling async
     /// functions is supported.
     bool IsInAsyncContext;
+
+    /// Checks whether this result has the same \c BaseTy and \c BaseDecl as
+    /// \p Other and if the two can thus be merged to be one value lookup in
+    /// \c deliverResults.
+    bool canBeMergedWith(const Result &Other, DeclContext &DC) const;
+
+    /// Merge this result with \p Other. Assumes that they can be merged.
+    void merge(const Result &Other, DeclContext &DC);
   };
 
   CodeCompletionExpr *CompletionExpr;
@@ -39,6 +47,10 @@ class UnresolvedMemberTypeCheckCompletionCallback
 
   SmallVector<Result, 4> ExprResults;
   SmallVector<Result, 1> EnumPatternTypes;
+
+  /// Add a result to \c Results, merging it with an existing result, if
+  /// possible.
+  void addExprResult(const Result &Res);
 
   void sawSolutionImpl(const constraints::Solution &solution) override;
 

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -928,6 +928,9 @@ enum ScoreKind: unsigned int {
   /// A reference to an @unavailable declaration.
   SK_Unavailable,
   /// A reference to an async function in a synchronous context.
+  ///
+  /// \note Any score kind after this is considered a conversion that doesn't
+  /// require fixing the source and will be ignored during code completion.
   SK_AsyncInSyncMismatch,
   /// Synchronous function in an asynchronous context or a conversion of
   /// a synchronous function to an asynchronous one.
@@ -5130,7 +5133,8 @@ private:
 public:
   /// Increase the score of the given kind for the current (partial) solution
   /// along the.
-  void increaseScore(ScoreKind kind, unsigned value = 1);
+  void increaseScore(ScoreKind kind, ConstraintLocatorBuilder Locator,
+                     unsigned value = 1);
 
   /// Determine whether this solution is guaranteed to be worse than the best
   /// solution found so far.

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2326,7 +2326,7 @@ bool TypeVariableBinding::attempt(ConstraintSystem &cs) const {
     }
     // Reflect in the score that this type variable couldn't be
     // resolved and had to be bound to a placeholder "hole" type.
-    cs.increaseScore(SK_Hole);
+    cs.increaseScore(SK_Hole, srcLocator);
 
     if (auto fix = fixForHole(cs)) {
       if (cs.recordFix(/*fix=*/fix->first, /*impact=*/fix->second))

--- a/lib/Sema/CSStep.cpp
+++ b/lib/Sema/CSStep.cpp
@@ -838,7 +838,7 @@ bool DisjunctionStep::attempt(const DisjunctionChoice &choice) {
           kind == ConstraintLocator::DynamicLookupResult) {
         assert(index == 0 || index == 1);
         if (index == 1)
-          CS.increaseScore(SK_ForceUnchecked);
+          CS.increaseScore(SK_ForceUnchecked, disjunctionLocator);
       }
     }
   }
@@ -1037,7 +1037,7 @@ StepResult ConjunctionStep::resume(bool prevFailed) {
                 ++numHoles;
               }
             }
-            CS.increaseScore(SK_Hole, numHoles);
+            CS.increaseScore(SK_Hole, Conjunction->getLocator(), numHoles);
           }
 
           if (CS.worseThanBestSolution())

--- a/lib/Sema/CSStep.h
+++ b/lib/Sema/CSStep.h
@@ -1033,8 +1033,10 @@ private:
   /// Restore best and current scores as they were before conjunction.
   void restoreCurrentScore(const Score &solutionScore) const {
     CS.CurrentScore = CurrentScore;
-    CS.increaseScore(SK_Fix, solutionScore.Data[SK_Fix]);
-    CS.increaseScore(SK_Hole, solutionScore.Data[SK_Hole]);
+    CS.increaseScore(SK_Fix, Conjunction->getLocator(),
+                     solutionScore.Data[SK_Fix]);
+    CS.increaseScore(SK_Hole, Conjunction->getLocator(),
+                     solutionScore.Data[SK_Hole]);
   }
 
   void restoreBestScore() const { CS.solverState->BestScore = BestScore; }

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -1419,3 +1419,65 @@ func testRdar89773376(arry: [Int]) {
 // RDAR89773376-DAG: Decl[Constructor]/CurrNominal/Flair[ArgLabels]: ['(']{#intVal: Int#}[')'][#Rdar89773376#];
 // RDAR89773376: End completions
 }
+
+func testOverloadedWithDefaultedArgument() {
+  struct Image {
+    init(_ name: Int) {}
+    func grame(maxWidth: Double? = nil) {}
+    func grame() {}
+  }
+
+  func test() {
+    Image(0)
+      .grame(maxWidth: .#^OVERLOADED_WITH_DEFAULT_ARG^#infinity)
+// OVERLOADED_WITH_DEFAULT_ARG: Begin completions
+// OVERLOADED_WITH_DEFAULT_ARG: Decl[StaticVar]/CurrNominal/Flair[ExprSpecific]/IsSystem/TypeRelation[Convertible]: infinity[#Double#];
+// OVERLOADED_WITH_DEFAULT_ARG: End completions
+  }
+}
+
+func testSubscriptWithExistingRhs(someString: String) {
+  var userInfo: [String: Any] = [:]
+  userInfo[#^SUBSCRIPT_WITH_EXISTING_RHS^#] = message
+
+// SUBSCRIPT_WITH_EXISTING_RHS: Begin completions
+// SUBSCRIPT_WITH_EXISTING_RHS-DAG: Pattern/CurrNominal/Flair[ArgLabels]: ['[']{#keyPath: KeyPath<[String : Any], Value>#}[']'][#Value#];
+// SUBSCRIPT_WITH_EXISTING_RHS-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]/IsSystem/TypeRelation[Convertible]: ['[']{#(key): String#}[']'][#@lvalue Any?#];
+// SUBSCRIPT_WITH_EXISTING_RHS-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]/IsSystem/TypeRelation[Convertible]: ['[']{#(key): String#}, {#default: Any#}[']'][#@lvalue Any#];
+// SUBSCRIPT_WITH_EXISTING_RHS-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: someString[#String#];
+// SUBSCRIPT_WITH_EXISTING_RHS: End completions
+}
+
+func testOptionalConversionFromSubscriptToCallArg() {
+  func takeOptionalInt(_ x: Int?) {}
+
+  func test(savedFilters: [Int], index: Int) {
+    takeOptionalInt(savedFilters[#^OPTIONAL_CONVERSION_FROM_SUBSCRIPT_TO_CALL_ARG^#index])
+// OPTIONAL_CONVERSION_FROM_SUBSCRIPT_TO_CALL_ARG: Begin completions
+// OPTIONAL_CONVERSION_FROM_SUBSCRIPT_TO_CALL_ARG-DAG: Pattern/CurrNominal/Flair[ArgLabels]/TypeRelation[Convertible]: ['[']{#keyPath: KeyPath<[Int], Value>#}[']'][#Value#];
+// OPTIONAL_CONVERSION_FROM_SUBSCRIPT_TO_CALL_ARG-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]/IsSystem/TypeRelation[Convertible]: ['[']{#(index): Int#}[']'][#Int#];
+// OPTIONAL_CONVERSION_FROM_SUBSCRIPT_TO_CALL_ARG-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: index[#Int#];
+// OPTIONAL_CONVERSION_FROM_SUBSCRIPT_TO_CALL_ARG: End completions
+  }
+}
+
+func testOptionalConversionInSrcOfAssignment(myArray: [Int]) {
+  var optInt: Int?
+  optInt = myArray[#^OPTIONAL_CONVERSION_IN_ASSIGNMENT^#]
+// OPTIONAL_CONVERSION_IN_ASSIGNMENT: Begin completions
+// OPTIONAL_CONVERSION_IN_ASSIGNMENT-DAG: Pattern/CurrNominal/Flair[ArgLabels]/TypeRelation[Convertible]: ['[']{#keyPath: KeyPath<[Int], Value>#}[']'][#Value#]; name=keyPath:
+// OPTIONAL_CONVERSION_IN_ASSIGNMENT-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]/IsSystem/TypeRelation[Convertible]: ['[']{#(index): Int#}[']'][#Int#]; name=:
+// OPTIONAL_CONVERSION_IN_ASSIGNMENT-DAG: Literal[Integer]/None/TypeRelation[Convertible]: 0[#Int#]; name=0
+// OPTIONAL_CONVERSION_IN_ASSIGNMENT: End completions
+}
+
+func testAnyConversionInDestOfAssignment(_ message: String) {
+  var userInfo: [String: Any] = [:]
+  userInfo[#^ANY_CONVERSION_IN_ASSIGNMENT^#] = message
+// ANY_CONVERSION_IN_ASSIGNMENT: Begin completions
+// ANY_CONVERSION_IN_ASSIGNMENT-DAG: Pattern/CurrNominal/Flair[ArgLabels]: ['[']{#keyPath: KeyPath<[String : Any], Value>#}[']'][#Value#]; name=keyPath:
+// ANY_CONVERSION_IN_ASSIGNMENT-DAG: Decl[Subscript]/CurrNominal/Flair[ArgLabels]/IsSystem/TypeRelation[Convertible]: ['[']{#(key): String#}, {#default: Any#}[']'][#@lvalue Any#]; name=:default:
+// ANY_CONVERSION_IN_ASSIGNMENT-DAG: Decl[LocalVar]/Local:               userInfo[#[String : Any]#]; name=userInfo
+// ANY_CONVERSION_IN_ASSIGNMENT-DAG: Decl[LocalVar]/Local/TypeRelation[Convertible]: message[#String#]; name=message
+// ANY_CONVERSION_IN_ASSIGNMENT: End completions
+}

--- a/test/IDE/complete_enum_elements.swift
+++ b/test/IDE/complete_enum_elements.swift
@@ -375,7 +375,7 @@ func testUnqualified1(x: QuxEnum) {
   // UNRESOLVED_2-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     Qux1[#QuxEnum#]; name=Qux1
   // UNRESOLVED_2-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]:     Qux2[#QuxEnum#]; name=Qux2
   // UNRESOLVED_2-DAG: Decl[TypeAlias]/CurrNominal:                                RawValue[#Int#]; name=RawValue
-  // UNRESOLVED_2-DAG: Decl[Constructor]/CurrNominal:                              init({#rawValue: Int#})[#QuxEnum?#]; name=init(rawValue:)
+  // UNRESOLVED_2-DAG: Decl[Constructor]/CurrNominal/TypeRelation[Convertible]:    init({#rawValue: Int#})[#QuxEnum?#]; name=init(rawValue:)
   // UNRESOLVED_2-DAG: Decl[InstanceMethod]/Super/IsSystem/TypeRelation[Invalid]:  hash({#(self): QuxEnum#})[#(into: inout Hasher) -> Void#]; name=hash(:)
   // UNRESOLVED_2: End completions
 

--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -37,14 +37,14 @@ typealias FooTypealias = Int
 // COMMON-DAG: Decl[TypeAlias]/CurrModule{{(/TypeRelation\[Convertible\])?}}:  FooTypealias[#Int#]{{; name=.+$}}
 // COMMON-DAG: Decl[GlobalVar]/CurrModule:  fooObject[#FooStruct#]{{; name=.+$}}
 // COMMON-DAG: Keyword[try]/None: try{{; name=.+$}}
-// COMMON-DAG: Literal[Boolean]/None: true[#Bool#]{{; name=.+$}}
-// COMMON-DAG: Literal[Boolean]/None: false[#Bool#]{{; name=.+$}}
+// COMMON-DAG: Literal[Boolean]/None{{(/TypeRelation\[Convertible\])?}}: true[#Bool#]{{; name=.+$}}
+// COMMON-DAG: Literal[Boolean]/None{{(/TypeRelation\[Convertible\])?}}: false[#Bool#]{{; name=.+$}}
 // COMMON-DAG: Literal[Nil]/None: nil{{; name=.+$}}
-// COMMON-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem:    Int8[#Int8#]{{; name=.+$}}
-// COMMON-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem:    Int16[#Int16#]{{; name=.+$}}
-// COMMON-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem:    Int32[#Int32#]{{; name=.+$}}
-// COMMON-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem:    Int64[#Int64#]{{; name=.+$}}
-// COMMON-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem:    Bool[#Bool#]{{; name=.+$}}
+// COMMON-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem{{(/TypeRelation\[Convertible\])?}}:    Int8[#Int8#]{{; name=.+$}}
+// COMMON-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem{{(/TypeRelation\[Convertible\])?}}:    Int16[#Int16#]{{; name=.+$}}
+// COMMON-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem{{(/TypeRelation\[Convertible\])?}}:    Int32[#Int32#]{{; name=.+$}}
+// COMMON-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem{{(/TypeRelation\[Convertible\])?}}:    Int64[#Int64#]{{; name=.+$}}
+// COMMON-DAG: Decl[Struct]/OtherModule[Swift]/IsSystem{{(/TypeRelation\[Convertible\])?}}:    Bool[#Bool#]{{; name=.+$}}
 // COMMON: End completions
 
 // NO_SELF-NOT: {{[[:<:]][Ss]elf[[:>:]]}}
@@ -65,7 +65,7 @@ func testExprPostfixBegin3(fooParam: FooStruct) {
 }
 
 func testExprPostfixBegin4(fooParam: FooStruct) {
-  "\(#^EXPR_POSTFIX_BEGIN_4?xfail=FIXME-64812321;check=COMMON^#)"
+  "\(#^EXPR_POSTFIX_BEGIN_4?check=COMMON^#)"
 }
 
 func testExprPostfixBegin5(fooParam: FooStruct) {

--- a/test/IDE/complete_in_result_builder.swift
+++ b/test/IDE/complete_in_result_builder.swift
@@ -97,7 +97,10 @@ func testStaticMemberLookup() {
   }
 
   @TupleBuilder<String> var x3 {
-    "hello: \(StringFactory.#^COMPLETE_STATIC_MEMBER_IN_STRING_LITERAL?check=COMPLETE_STATIC_MEMBER;xfail=rdar78015646^#)"
+    "hello: \(StringFactory.#^COMPLETE_STATIC_MEMBER_IN_STRING_LITERAL?xfail=rdar106720628^#)"
+// COMPLETE_STATIC_MEMBER_IN_STRING_LITERAL: Begin completions
+// COMPLETE_STATIC_MEMBER_IN_STRING_LITERAL: Decl[StaticMethod]/CurrNominal/TypeRelation[Convertible]:     makeString({#x: String#})[#String#];
+// COMPLETE_STATIC_MEMBER_IN_STRING_LITERAL: End completions
   }
 }
 
@@ -354,14 +357,13 @@ func testSwitchInResultBuilder() {
       Reduce2()
       Reduce2 { action in
         switch action {
-        case .#^SWITCH_IN_RESULT_BUILDER^# alertDismissed:
+        case .#^SWITCH_IN_RESULT_BUILDER?xfail=rdar106720462^# alertDismissed:
           return 0
         }
       }
     }
   }
-// SWITCH_IN_RESULT_BUILDER: Begin completions, 2 items
+// SWITCH_IN_RESULT_BUILDER: Begin completions, 1 item
 // SWITCH_IN_RESULT_BUILDER-DAG: Decl[EnumElement]/CurrNominal/Flair[ExprSpecific]/TypeRelation[Convertible]: alertDismissed[#Action#];
-// SWITCH_IN_RESULT_BUILDER-DAG: Decl[InstanceMethod]/CurrNominal/TypeRelation[Invalid]: hash({#(self): Action#})[#(into: inout Hasher) -> Void#];
 // SWITCH_IN_RESULT_BUILDER: End completions
 }

--- a/test/IDE/complete_rdar63965160.swift
+++ b/test/IDE/complete_rdar63965160.swift
@@ -25,11 +25,11 @@ struct Value {
 func test(values: [Value]) {
   _ = ForEach(values) { value in
     Text("foobar")
-    Text("value \(value.#^STRINGLITERAL^#)")
+    Text("value \(value.#^STRINGLITERAL?check=CHECK^#)")
   }
   _ = ForEach(values) { value in
     Text("foobar")
-    Text(value.#^NORMAL^#)
+    Text(value.#^NORMAL?check=CHECK^#)
   }
 }
 // CHECK: Begin completions, 2 items

--- a/test/IDE/complete_unresolved_members.swift
+++ b/test/IDE/complete_unresolved_members.swift
@@ -270,7 +270,7 @@ class C6 {
 
 class C6 {
   func f1(e: SomeEnum1) {
-    if let x = Optional(e) where x == .#^UNRESOLVED_25?check=UNRESOLVED_3^#
+    if let x = Optional(e) where x == .#^UNRESOLVED_25?check=UNRESOLVED_3_OPT^#
   }
 }
 class C7 {}

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1204,9 +1204,6 @@ func testTypeCheckWithUnsolvedVariables3() {
 // TC_UNSOLVED_VARIABLES_3-DAG: Decl[InstanceMethod]/CurrNominal: addString({#(s): String#})[#BuilderStyle<Int>#]{{; name=.+$}}
 // TC_UNSOLVED_VARIABLES_3-DAG: Decl[InstanceMethod]/CurrNominal: add({#(t): Int#})[#BuilderStyle<Int>#]{{; name=.+$}}
 // TC_UNSOLVED_VARIABLES_3-DAG: Decl[InstanceMethod]/CurrNominal: get()[#Int#]{{; name=.+$}}
-// TC_UNSOLVED_VARIABLES_3-DAG: Keyword[self]/CurrNominal: self[#BuilderStyle<Double>#]{{; name=.+$}}
-// TC_UNSOLVED_VARIABLES_3-DAG: Decl[InstanceMethod]/CurrNominal: addString({#(s): String#})[#BuilderStyle<Double>#]{{; name=.+$}}
-// TC_UNSOLVED_VARIABLES_3-DAG: Decl[InstanceMethod]/CurrNominal: add({#(t): Double#})[#BuilderStyle<Double>#]{{; name=.+$}}
 // TC_UNSOLVED_VARIABLES_3: End completions
 
 func testTypeCheckNil() {


### PR DESCRIPTION
Ignore conversion score increases during code completion to make sure we don't filter solutions that might start receiving the best score based on a choice of the code completion token.
