### PR TITLE
[IDE] Set solution-specific variable types as interface types

### DIFF
--- a/lib/IDE/ArgumentCompletion.cpp
+++ b/lib/IDE/ArgumentCompletion.cpp
@@ -351,6 +351,13 @@ void ArgumentTypeCheckCompletionCallback::deliverResults(
   }
 
   if (shouldPerformGlobalCompletion) {
+    llvm::SmallDenseMap<const VarDecl *, Type> SolutionSpecificVarTypes;
+    if (!Results.empty()) {
+      SolutionSpecificVarTypes = Results[0].SolutionSpecificVarTypes;
+    }
+
+    WithSolutionSpecificVarTypesRAII VarTypes(SolutionSpecificVarTypes);
+
     for (auto &Result : Results) {
       ExpectedTypes.push_back(Result.ExpectedType);
       Lookup.setSolutionSpecificVarTypes(Result.SolutionSpecificVarTypes);

--- a/lib/IDE/ExprCompletion.cpp
+++ b/lib/IDE/ExprCompletion.cpp
@@ -105,6 +105,8 @@ void ExprTypeCheckCompletionCallback::deliverResults(
   Lookup.shouldCheckForDuplicates(Results.size() > 1);
 
   for (auto &Result : Results) {
+    WithSolutionSpecificVarTypesRAII VarTypes(Result.SolutionSpecificVarTypes);
+
     Lookup.setExpectedTypes(ExpectedTypes,
                             Result.IsImplicitSingleExpressionReturn);
     Lookup.setCanCurrDeclContextHandleAsync(Result.IsInAsyncContext);

--- a/lib/IDE/TypeCheckCompletionCallback.cpp
+++ b/lib/IDE/TypeCheckCompletionCallback.cpp
@@ -136,6 +136,11 @@ void swift::ide::getSolutionSpecificVarTypes(
   }
 }
 
+void WithSolutionSpecificVarTypesRAII::setInterfaceType(VarDecl *VD, Type Ty) {
+  VD->getASTContext().evaluator.cacheOutput(InterfaceTypeRequest{VD},
+                                            std::move(Ty));
+}
+
 bool swift::ide::isImplicitSingleExpressionReturn(ConstraintSystem &CS,
                                                   Expr *CompletionExpr) {
   Expr *ParentExpr = CS.getParentExpr(CompletionExpr);

--- a/test/IDE/complete_in_closures.swift
+++ b/test/IDE/complete_in_closures.swift
@@ -496,3 +496,16 @@ func testCompleteInMatchOfAssociatedValueInSwitchCase() {
 }
 
 }
+
+func testReferenceToVariableDefinedInClosure() {
+  func takeClosure(_ x: () -> Void) {}
+
+  takeClosure {
+    let item = "\(1)"
+    #^VARIABLE_DEFINED_IN_CLOSURE^#
+  }
+  // VARIABLE_DEFINED_IN_CLOSURE: Begin completions
+  // VARIABLE_DEFINED_IN_CLOSURE: Decl[LocalVar]/Local:               item[#String#]; name=item
+  // VARIABLE_DEFINED_IN_CLOSURE: End completions
+}
+

--- a/test/SourceKit/TypeContextInfo/typecontext_in_closure.swift
+++ b/test/SourceKit/TypeContextInfo/typecontext_in_closure.swift
@@ -1,0 +1,14 @@
+// import SwiftUI
+
+struct ProgressView {
+  @ViewBuilder var body: Int {
+    // RUN: %sourcekitd-test -req=typecontextinfo -pos=%(line + 1):35 %s -- %s
+    grame(width: max(12345678901, 2))
+  }
+}
+
+func grame(width: Int?) -> Int {}
+
+@resultBuilder struct ViewBuilder {
+  public static func buildBlock(_ content: Int) -> Int
+}


### PR DESCRIPTION
Setting the interface type of a variable, just to reset it to a null type is actually really gross. But quite a few methods further down in the generation of code completion results (such as USR generation) need to get a variable’s type and passing them along in a separate map would be really invasive. So this seems like the least bad solution to me.