### PR TITLE
[Sema] FixIt for `override func` that should be `override var` and vice-versa

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3475,8 +3475,12 @@ ERROR(override_of_non_open,none,
 
 ERROR(method_does_not_override,none,
       "method does not override any method from its %select{parent protocol|superclass}0", (bool))
+NOTE(override_property_not_method,none,
+      "did you mean to override the property %0", (Identifier))
 ERROR(property_does_not_override,none,
       "property does not override any property from its %select{parent protocol|superclass}0", (bool))
+NOTE(override_method_not_property,none,
+      "did you mean to override the method %0", (Identifier))
 ERROR(subscript_does_not_override,none,
       "subscript does not override any subscript from its %select{parent protocol|superclass}0", (bool))
 ERROR(initializer_does_not_override,none,

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -2674,6 +2674,7 @@ public:
           } else {
             VD->diagnose(diag::property_does_not_override, isClassContext)
                 .highlight(OA->getLocation());
+            diagnoseOverridenProperty(VD, DC, OA);
           }
           OA->setInvalid();
         }
@@ -2738,6 +2739,32 @@ public:
               SD->diagnose(diag::attr_static_exclusive_only_type_nonmutating,
                            SD->getDeclaredInterfaceType());
             });
+      }
+    }
+  }
+
+  static void diagnoseOverridenProperty(VarDecl *VD, DeclContext *DC,
+                                        OverrideAttr *OA) {
+    auto declName = VD->getBaseName();
+    auto declType = VD->getInterfaceType()->getRValueType();
+
+    auto inherited = DC->getSelfClassDecl()->getInherited();
+    if (!inherited.empty()) {
+      auto superClassType = inherited.getResolvedType(0);
+      auto lookupResult =
+          TypeChecker::lookupMember(DC, superClassType, DeclNameRef(declName));
+      for (auto &candidate : lookupResult) {
+        auto *valueDecl = candidate.getValueDecl();
+        if (auto funcDecl = dyn_cast<FuncDecl>(valueDecl)) {
+          if (funcDecl->getBaseName() == declName &&
+              funcDecl->getParameters()->size() == 0) {
+            std::string funcDeclTypeStr = " -> " + declType.getString();
+            VD->diagnose(diag::override_method_not_property,
+                         funcDecl->getBaseName().getIdentifier())
+                .highlight(OA->getLocation())
+                .fixItReplace(getFixItLocForVarToLet(VD), "func");
+          }
+        }
       }
     }
   }
@@ -3714,6 +3741,7 @@ public:
           } else {
             FD->diagnose(diag::method_does_not_override, isClassContext)
                 .highlight(OA->getLocation());
+            diagnoseOverridenMethod(FD, DC, OA);
           }
           OA->setInvalid();
         }
@@ -3802,6 +3830,37 @@ public:
     }
 
     TypeChecker::checkObjCImplementation(FD);
+  }
+
+  static void diagnoseOverridenMethod(FuncDecl *FD, DeclContext *DC,
+                                      OverrideAttr *OA) {
+    if (FD->getParameters()->size() == 0) {
+      auto declName = FD->getBaseName();
+      auto declRetType = FD->getResultInterfaceType()->getRValueType();
+
+      auto inherited = DC->getSelfClassDecl()->getInherited();
+      if (!inherited.empty()) {
+        auto superClassType = inherited.getResolvedType(0);
+        auto lookupResult = TypeChecker::lookupMember(DC, superClassType,
+                                                      DeclNameRef(declName));
+        for (auto &candidate : lookupResult) {
+          auto *valueDecl = candidate.getValueDecl();
+          if (auto vardecl = dyn_cast<VarDecl>(valueDecl)) {
+            if (vardecl->getBaseName() == declName) {
+              std::string varDeclTypeStr = ": " + declRetType.getString();
+              FD->diagnose(diag::override_property_not_method,
+                           vardecl->getBaseName().getIdentifier())
+                  .highlight(OA->getLocation())
+                  .fixItReplace(FD->getFuncLoc(), "var")
+                  .fixItReplaceChars(
+                      FD->getParameters()->getLParenLoc(),
+                      FD->getBody()->getLBraceLoc().getAdvancedLoc(-1),
+                      varDeclTypeStr);
+            }
+          }
+        }
+      }
+    }
   }
 
   void visitModuleDecl(ModuleDecl *) { }

--- a/test/decl/inherit/override.swift
+++ b/test/decl/inherit/override.swift
@@ -86,3 +86,20 @@ class ObjCSub : ObjCSuper {
 
   @objc(method3:withInt:) func method3(_ x: Sub, with y: Int) { } // expected-error{{method3(_:with:)' with Objective-C selector 'method3:withInt:' conflicts with method 'method3(_:withInt:)' from superclass 'ObjCSuper' with the same Objective-C selector}}
 }
+
+class C {
+  var v1: Bool {
+    return false
+  }
+
+  func f1() -> Int { }
+}
+
+class D: C {
+  override func v1() -> Bool { } // expected-error{{method does not override any method from its superclass}}
+  // expected-note@-1{{did you mean to override the property 'v1'}} {{12-16=var}} {{19-29=: Bool}}
+
+  override var f1: Int { // expected-error{{property does not override any property from its superclass}}
+    return 0 // expected-note@-1{{did you mean to override the method 'f1'}} {{12-15=func}}
+  }
+}


### PR DESCRIPTION
Fixes #57499 

This adds `override_property_not_method` and `override_method_not_property` notes by performing
a member lookup for the respective diagnostics.