### PR TITLE
[IDE] Report solutions from a result builder transform to a SolutionCallback

### DIFF
--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -2365,6 +2365,24 @@ Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
   SmallVector<Solution, 4> solutions;
   bool solvingFailed = cs.solve(solutions);
 
+  auto reportSolutionsToSolutionCallback = [&](const SolutionResult &result) {
+    if (!cs.getASTContext().SolutionCallback) {
+      return;
+    }
+    switch (result.getKind()) {
+    case SolutionResult::Success:
+      cs.getASTContext().SolutionCallback->sawSolution(result.getSolution());
+      break;
+    case SolutionResult::Ambiguous:
+      for (auto &solution : result.getAmbiguousSolutions()) {
+        cs.getASTContext().SolutionCallback->sawSolution(solution);
+      }
+      break;
+    default:
+      break;
+    }
+  };
+
   if (solvingFailed || solutions.size() != 1) {
     // Try to fix the system or provide a decent diagnostic.
     auto salvagedResult = cs.salvage();
@@ -2376,14 +2394,17 @@ Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
 
     case SolutionResult::Kind::Error:
     case SolutionResult::Kind::Ambiguous:
+      reportSolutionsToSolutionCallback(salvagedResult);
       return nullptr;
 
     case SolutionResult::Kind::UndiagnosedError:
+      reportSolutionsToSolutionCallback(salvagedResult);
       cs.diagnoseFailureFor(SolutionApplicationTarget(func));
       salvagedResult.markAsDiagnosed();
       return nullptr;
 
     case SolutionResult::Kind::TooComplex:
+      reportSolutionsToSolutionCallback(salvagedResult);
       func->diagnose(diag::expression_too_complex)
         .highlight(func->getBodySourceRange());
       salvagedResult.markAsDiagnosed();
@@ -2399,6 +2420,13 @@ Optional<BraceStmt *> TypeChecker::applyResultBuilderBodyTransform(
     log << "--- Applying Solution ---\n";
     solutions.front().dump(log, indent);
     log << '\n';
+  }
+
+  if (cs.getASTContext().SolutionCallback) {
+    for (auto &solution : solutions) {
+      cs.getASTContext().SolutionCallback->sawSolution(solution);
+    }
+    return nullptr;
   }
 
   // FIXME: Shouldn't need to do this.

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -2372,7 +2372,7 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
       auto optBody = TypeChecker::applyResultBuilderBodyTransform(
           func, builderType,
           /*ClosuresInResultBuilderDontParticipateInInference=*/
-              ctx.CompletionCallback == nullptr);
+              ctx.CompletionCallback == nullptr && ctx.SolutionCallback == nullptr);
       if (optBody && *optBody) {
         // Wire up the function body now.
         func->setBody(*optBody, AbstractFunctionDecl::BodyKind::TypeChecked);


### PR DESCRIPTION
Previously, we were relying on the second type-check of the body further below in `TypeCheckASTNodeAtLocRequest::evaluate` to call the `SolutionCallback`. It’s not really necessary to wait for that.