### PR TITLE
EscapeUtils: add test cases and an assert for addresses escaping to to a closure

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -444,6 +444,13 @@ public:
     return isObject() && isClassOrClassMetatype(getASTType());
   }
 
+  bool isFunctionTypeWithContext() const {
+    if (auto *fTy = getASTType()->getAs<SILFunctionType>()) {
+      return fTy->getExtInfo().hasContext();
+    }
+    return false;
+  }
+
   /// True if the type involves any archetypes.
   bool hasArchetype() const { return getASTType()->hasArchetype(); }
 

--- a/lib/SIL/IR/SILType.cpp
+++ b/lib/SIL/IR/SILType.cpp
@@ -121,7 +121,10 @@ bool SILType::isOrContainsRawPointer(const SILFunction &F) const {
 bool SILType::isNonTrivialOrContainsRawPointer(const SILFunction &F) const {
   auto contextType = hasTypeParameter() ? F.mapTypeIntoContext(*this) : *this;
   const TypeLowering &tyLowering = F.getTypeLowering(contextType);
-  return !tyLowering.isTrivial() || tyLowering.isOrContainsRawPointer();
+  bool result = !tyLowering.isTrivial() || tyLowering.isOrContainsRawPointer();
+  assert((result || !isFunctionTypeWithContext()) &&
+         "a function type with context must either be non trivial or marked as containing a pointer");
+  return result;
 }
 
 bool SILType::isEmpty(const SILFunction &F) const {

--- a/test/SILOptimizer/addr_escape_info.sil
+++ b/test/SILOptimizer/addr_escape_info.sil
@@ -606,3 +606,30 @@ bb0:
   %11 = tuple ()
   return %11 : $()
 }
+
+sil @call_closure : $@convention(method) (@noescape @callee_guaranteed () -> ()) -> ()
+sil @closure : $@convention(thin) (@inout_aliasable Int) -> ()
+
+// CHECK-LABEL: Address escape information for test_closure_capturing_address:
+// CHECK:      value:  %0 = alloc_stack $Int
+// CHECK-NEXT:   ==>   %7 = apply %6(%4) : $@convention(method) (@noescape @callee_guaranteed () -> ()) -> ()
+// CHECK:      End function test_closure_capturing_address
+sil @test_closure_capturing_address : $@convention(thin) () -> Int {
+bb0:
+  %0 = alloc_stack $Int
+  %1 = integer_literal $Builtin.Int64, 0
+  %2 = struct $Int (%1 : $Builtin.Int64)
+
+  %3 = function_ref @closure : $@convention(thin) (@inout_aliasable Int) -> ()
+  %4 = partial_apply [callee_guaranteed] [on_stack] %3(%0) : $@convention(thin) (@inout_aliasable Int) -> ()
+  store %2 to %0 : $*Int
+
+  %6 = function_ref @call_closure : $@convention(method) (@noescape @callee_guaranteed () -> ()) -> ()
+  %7 = apply %6(%4) : $@convention(method) (@noescape @callee_guaranteed () -> ()) -> ()
+  dealloc_stack %4 : $@noescape @callee_guaranteed () -> ()
+  fix_lifetime %0 : $*Int
+  %9 = load %0 : $*Int
+  dealloc_stack %0 : $*Int
+  return %9 : $Int
+}
+

--- a/test/SILOptimizer/redundant_load_elim.sil
+++ b/test/SILOptimizer/redundant_load_elim.sil
@@ -1268,3 +1268,28 @@ bb1:
   return %r : $()
 }
 
+sil @call_closure : $@convention(method) (@noescape @callee_guaranteed () -> ()) -> ()
+sil @closure : $@convention(thin) (@inout_aliasable Int) -> ()
+
+// CHECK-LABEL: sil @test_closure_capturing_address :
+// CHECK:         [[L:%[0-9]+]] = load
+// CHECK:         return [[L]]
+// CHECK-LABEL: } // end sil function 'test_closure_capturing_address'
+sil @test_closure_capturing_address : $@convention(thin) () -> Int {
+bb0:
+  %0 = alloc_stack $Int
+  %1 = integer_literal $Builtin.Int64, 0
+  %2 = struct $Int (%1 : $Builtin.Int64)
+
+  %3 = function_ref @closure : $@convention(thin) (@inout_aliasable Int) -> ()
+  %4 = partial_apply [callee_guaranteed] [on_stack] %3(%0) : $@convention(thin) (@inout_aliasable Int) -> ()
+  store %2 to %0 : $*Int
+
+  %6 = function_ref @call_closure : $@convention(method) (@noescape @callee_guaranteed () -> ()) -> ()
+  %7 = apply %6(%4) : $@convention(method) (@noescape @callee_guaranteed () -> ()) -> ()
+  dealloc_stack %4 : $@noescape @callee_guaranteed () -> ()
+  %9 = load %0 : $*Int
+  dealloc_stack %0 : $*Int
+  return %9 : $Int
+}
+


### PR DESCRIPTION
It's essential that a non-escaping closure will be treated as having a relevant type for escape analysis. Because if it's capturing an (inout) address it's like it's storing a pointer to the captured variable in its context.

Adds test cases for rdar://105676825
