### PR TITLE
[cxx-interop] Build the C++ stdlib overlay when `SWIFT_BUILD_SDK_OVERLAY=NO`

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -62,6 +62,7 @@ endif()
 
 add_subdirectory(SwiftShims/swift/shims)
 add_subdirectory(CommandLineSupport)
+add_subdirectory(Cxx)
 add_subdirectory(Threading)
 
 # This static library is shared across swiftCore and swiftRemoteInspection
@@ -159,7 +160,6 @@ endif()
 
 if(SWIFT_BUILD_SDK_OVERLAY OR SWIFT_BUILD_TEST_SUPPORT_MODULES)
   add_subdirectory(Platform)
-  add_subdirectory(Cxx)
 endif()
 
 if(SWIFT_BUILD_SDK_OVERLAY)

--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -22,5 +22,7 @@ add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDL
     INSTALL_IN_COMPONENT compiler
     INSTALL_WITH_SHARED)
 
-add_subdirectory(std)
+if(SWIFT_BUILD_SDK_OVERLAY OR SWIFT_BUILD_TEST_SUPPORT_MODULES)
+  add_subdirectory(std)
+endif()
 add_subdirectory(cxxshim)

--- a/stdlib/public/Cxx/cxxshim/CMakeLists.txt
+++ b/stdlib/public/Cxx/cxxshim/CMakeLists.txt
@@ -43,11 +43,11 @@ foreach(sdk ${SWIFT_SDKS})
 
     swift_install_in_component(FILES libcxxshim.modulemap libcxxshim.h
                                DESTINATION "lib/swift/${arch_subdir}"
-                               COMPONENT sdk-overlay)
+                               COMPONENT compiler)
     if(SWIFT_BUILD_STATIC_STDLIB)
       swift_install_in_component(FILES libcxxshim.modulemap libcxxshim.h
                                  DESTINATION "lib/swift_static/${arch_subdir}"
-                                 COMPONENT sdk-overlay)
+                                 COMPONENT compiler)
     endif()
   endforeach()
 endforeach()
@@ -55,3 +55,4 @@ endforeach()
 add_custom_target(libcxxshim_modulemap DEPENDS ${libcxxshim_modulemap_target_list})
 set_property(TARGET libcxxshim_modulemap PROPERTY FOLDER "Miscellaneous")
 add_dependencies(sdk-overlay libcxxshim_modulemap)
+add_dependencies(compiler libcxxshim_modulemap)


### PR DESCRIPTION
The C++ stdlib overlay binaries (`libswiftCxx` and `libswiftCxxStdlib`) are now a part of the toolchain, not the OS SDKs. This makes sure that these binaries are built when building the toolchain separately from the stdlib.

rdar://105799283