### PR TITLE
[DNM] Revert "[Sema] Record opaque type decls for type reconstruction after creation instead of in the parser"

### DIFF
--- a/include/swift/AST/SourceFile.h
+++ b/include/swift/AST/SourceFile.h
@@ -143,19 +143,12 @@ private:
   /// The scope map that describes this source file.
   NullablePtr<ASTScope> Scope = nullptr;
 
-   /// The set of parsed decls with opaque return types that have not yet
-   /// been validated.
-   llvm::SetVector<ValueDecl *> UnvalidatedDeclsWithOpaqueReturnTypes;
-  
   /// The set of validated opaque return type decls in the source file.
   llvm::SmallVector<OpaqueTypeDecl *, 4> OpaqueReturnTypes;
   llvm::StringMap<OpaqueTypeDecl *> ValidatedOpaqueReturnTypes;
-  /// The set of opaque type decls that have not yet been validated.
-  ///
-  /// \note This is populated as opaque type decls are created. Validation
-  /// requires mangling the naming decl, which would lead to circularity
-  /// if it were done from OpaqueResultTypeRequest.
-  llvm::SetVector<OpaqueTypeDecl *> UnvalidatedOpaqueReturnTypes;
+  /// The set of parsed decls with opaque return types that have not yet
+  /// been validated.
+  llvm::SetVector<ValueDecl *> UnvalidatedDeclsWithOpaqueReturnTypes;
 
   /// The set of declarations with valid runtime discoverable attributes
   /// located in the source file.
@@ -673,10 +666,6 @@ public:
   /// to something that won't be in the ASTScope tree.
   void addUnvalidatedDeclWithOpaqueResultType(ValueDecl *vd) {
     UnvalidatedDeclsWithOpaqueReturnTypes.insert(vd);
-  }
-
-  void addOpaqueResultTypeDecl(OpaqueTypeDecl *decl) {
-    UnvalidatedOpaqueReturnTypes.insert(decl);
   }
 
   ArrayRef<OpaqueTypeDecl *> getOpaqueReturnTypeDecls();

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -172,7 +172,9 @@ public:
 
   bool InPoundLineEnvironment = false;
   bool InPoundIfEnvironment = false;
-  /// ASTScopes are not created in inactive clauses and lookups to decls will fail.
+  /// Do not call \c addUnvalidatedDeclWithOpaqueResultType when in an inactive
+  /// clause because ASTScopes are not created in those contexts and lookups to
+  /// those decls will fail.
   bool InInactiveClauseEnvironment = false;
   bool InSwiftKeyPath = false;
 

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -262,13 +262,6 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
 
   auto metatype = MetatypeType::get(interfaceType);
   opaqueDecl->setInterfaceType(metatype);
-
-  // Record the opaque return type decl in the parent source file,
-  // which will be used in IRGen to emit all opaque type decls
-  // in a Swift module for type reconstruction.
-  if (auto *sourceFile = dc->getParentSourceFile())
-    sourceFile->addOpaqueResultTypeDecl(opaqueDecl);
-
   return opaqueDecl;
 }
 

--- a/test/IRGen/Inputs/implicit_some_b.swift
+++ b/test/IRGen/Inputs/implicit_some_b.swift
@@ -1,3 +1,0 @@
-func bar() {
-  let x = foo()
-}

--- a/test/IRGen/implicit_some_a.swift
+++ b/test/IRGen/implicit_some_a.swift
@@ -1,6 +1,0 @@
-// RUN: %target-swift-frontend -emit-ir -disable-availability-checking -primary-file %s %S/Inputs/implicit_some_b.swift -enable-experimental-feature ImplicitSome
-
-protocol P {}
-struct S: P {}
-
-func foo() -> P { return S() }

--- a/test/type/implicit_some/opaque_parameters.swift
+++ b/test/type/implicit_some/opaque_parameters.swift
@@ -64,7 +64,7 @@ func consumingB(fn: FnType<P>) { } // expected-error{{'some' cannot appear in pa
 
 // TO-DO Handle plain generic opaque parameters
 func takePrimaryCollections(
-  _ strings:some Collection<String>,
+  _ strings:some  Collection<String>,
   _ ints : some Collection<Int>
 ) {
   for s in strings {


### PR DESCRIPTION
Reverts apple/swift#63468

Testing to see whether this is the change that regressed RxSwift and distributed actors.