### PR TITLE
[SIL] Phi with incoming lexical value is lexical.

### DIFF
--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -291,7 +291,7 @@ public:
   ///
   /// Returns false when called on a non-phi and when the visitor returns false.
   bool visitTransitiveIncomingPhiOperands(
-      function_ref<bool(SILPhiArgument *, Operand *)> visitor);
+      function_ref<bool(SILPhiArgument *, Operand *)> visitor) const;
 
   /// Returns true if we were able to find a single terminator operand value for
   /// each predecessor of this arguments basic block. The found values are

--- a/include/swift/SIL/SILArgument.h
+++ b/include/swift/SIL/SILArgument.h
@@ -241,6 +241,9 @@ public:
   /// result.
   bool isPhi() const;
 
+  /// Whether any of the values incoming to this phi are lexical.
+  bool isLexical() const;
+
   /// Return true if this block argument is a terminator result.
   bool isTerminatorResult() const { return !isPhi(); }
 

--- a/lib/SIL/IR/SILArgument.cpp
+++ b/lib/SIL/IR/SILArgument.cpp
@@ -227,12 +227,12 @@ bool SILPhiArgument::getIncomingPhiValues(
 }
 
 bool SILPhiArgument::visitTransitiveIncomingPhiOperands(
-    function_ref<bool(SILPhiArgument *, Operand *)> visitor) {
+    function_ref<bool(SILPhiArgument *, Operand *)> visitor) const {
   if (!isPhi())
     return false;
 
   GraphNodeWorklist<SILPhiArgument *, 4> worklist;
-  worklist.initialize(this);
+  worklist.insert(const_cast<SILPhiArgument *>(this));
 
   while (auto *argument = worklist.pop()) {
     SmallVector<Operand *> operands;

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -434,6 +434,22 @@ struct IsDeinitBarrierTest : UnitTest {
   }
 };
 
+// Arguments:
+// - value
+// Dumps:
+// - value
+// - whether it's lexical
+struct IsLexicalTest : UnitTest {
+  IsLexicalTest(UnitTestRunner *pass) : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    auto value = arguments.takeValue();
+    auto isLexical = value->isLexical();
+    value->dump();
+    auto *boolString = isLexical ? "true" : "false";
+    llvm::errs() << boolString << "\n";
+  }
+};
+
 struct ShrinkBorrowScopeTest : UnitTest {
   ShrinkBorrowScopeTest(UnitTestRunner *pass) : UnitTest(pass) {}
   void invoke(Arguments &arguments) override {
@@ -759,6 +775,7 @@ void UnitTestRunner::withTest(StringRef name, Doit doit) {
     ADD_UNIT_TEST_SUBCLASS("function-get-self-argument-index", FunctionGetSelfArgumentIndex)
     ADD_UNIT_TEST_SUBCLASS("interior-liveness", InteriorLivenessTest)
     ADD_UNIT_TEST_SUBCLASS("is-deinit-barrier", IsDeinitBarrierTest)
+    ADD_UNIT_TEST_SUBCLASS("is-lexical", IsLexicalTest)
     ADD_UNIT_TEST_SUBCLASS("linear-liveness", LinearLivenessTest)
     ADD_UNIT_TEST_SUBCLASS("multidef-liveness", MultiDefLivenessTest)
     ADD_UNIT_TEST_SUBCLASS("pruned-liveness-boundary-with-list-of-last-users-insertion-points", PrunedLivenessBoundaryWithListOfLastUsersInsertionPointsTest)

--- a/test/SILOptimizer/copy_propagation_canonicalize_with_reborrows.sil
+++ b/test/SILOptimizer/copy_propagation_canonicalize_with_reborrows.sil
@@ -297,14 +297,15 @@ bb1(%4 : @guaranteed $X, %5 : @owned $X):
 // Lifetime analysis is successful; the copy/destroy in bb1 are removed. The
 // end_borrow/destroy maintain their position.
 //
-// CHECK-LABEL: sil [ossa] @reborrow_adjacent_to_consume : $@convention(thin) (@owned X) -> () {
+// CHECK-LABEL: sil [ossa] @reborrow_adjacent_to_consume : $@convention(thin) () -> () {
 // CHECK: bb1(%{{.*}} : @guaranteed $X, %{{.*}} : @owned $X):
 // CHECK-NEXT:   br bb2
 // CHECK: bb2(%{{.*}} : @guaranteed $X, %{{.*}} : @owned $X):
 // CHECK-NEXT:   end_borrow
 // CHECK-NEXT:   destroy_value
-sil [ossa] @reborrow_adjacent_to_consume : $@convention(thin) (@owned X) -> () {
-bb0(%0 : @owned $X):
+sil [ossa] @reborrow_adjacent_to_consume : $@convention(thin) () -> () {
+bb0:
+  %0 = apply undef() : $@convention(thin) () -> (@owned X)
   %1 = begin_borrow %0 : $X
   br bb1(%1 : $X, %0 : $X)
 
@@ -328,14 +329,15 @@ bb2(%6 : @guaranteed $X, %7 : @owned $X):
 //
 // Lifetime analysis is successful; the copy/destroy in bb2 are removed.
 //
-// CHECK-LABEL: sil [ossa] @reborrow_no_adjacent_consume : $@convention(thin) (@owned X) -> () {
+// CHECK-LABEL: sil [ossa] @reborrow_no_adjacent_consume : $@convention(thin) () -> () {
 // CHECK: bb1(%{{.*}} : @guaranteed $X, %{{.*}} : @owned $X):
 // CHECK-NEXT:   br bb2
 // CHECK: bb2(%{{.*}} : @guaranteed $X):
 // CHECK-NEXT:   end_borrow
 // CHECK-NEXT:   destroy_value
-sil [ossa] @reborrow_no_adjacent_consume : $@convention(thin) (@owned X) -> () {
-bb0(%0 : @owned $X):
+sil [ossa] @reborrow_no_adjacent_consume : $@convention(thin) () -> () {
+bb0:
+  %0 = apply undef() : $@convention(thin) () -> (@owned X)
   %1 = begin_borrow %0 : $X
   br bb1(%1 : $X, %0 : $X)
 

--- a/test/SILOptimizer/lexical_unit.sil
+++ b/test/SILOptimizer/lexical_unit.sil
@@ -1,0 +1,291 @@
+// RUN: %target-sil-opt -unit-test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+class C {}
+
+sil [ossa] @getC : $@convention(thin) () -> (@owned C)
+
+// CHECK-LABEL: begin running test 1 of 1 on phi_direct_no_lexical: is-lexical
+// CHECK: argument of bb3
+// CHECK: false
+// CHECK-LABEL: end running test 1 of 1 on phi_direct_no_lexical: is-lexical
+sil [ossa] @phi_direct_no_lexical : $() -> () {
+entry:
+  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+  cond_br undef, left, right
+left:
+  %c1 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br exit(%c1 : $C)
+right:
+  %c2 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br exit(%c2 : $C)
+exit(%cm : @owned $C):
+  test_specification "is-lexical @block.argument"
+  destroy_value %cm : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on phi_direct_first_lexical: is-lexical
+// CHECK: argument of bb3
+// CHECK: true
+// CHECK-LABEL: end running test 1 of 1 on phi_direct_first_lexical: is-lexical
+sil [ossa] @phi_direct_first_lexical : $() -> () {
+entry:
+  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+  cond_br undef, left, right
+left:
+  %c1 = apply %getC() : $@convention(thin) () -> (@owned C)
+  %m1 = move_value [lexical] %c1 : $C
+  br exit(%m1 : $C)
+right:
+  %c2 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br exit(%c2 : $C)
+exit(%cm : @owned $C):
+  test_specification "is-lexical @block.argument"
+  destroy_value %cm : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on phi_direct_second_lexical: is-lexical
+// CHECK: argument of bb3
+// CHECK: true
+// CHECK-LABEL: end running test 1 of 1 on phi_direct_second_lexical: is-lexical
+sil [ossa] @phi_direct_second_lexical : $() -> () {
+entry:
+  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+  cond_br undef, left, right
+left:
+  %c1 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br exit(%c1 : $C)
+right:
+  %c2 = apply %getC() : $@convention(thin) () -> (@owned C)
+  %m2 = move_value [lexical] %c2 : $C
+  br exit(%m2 : $C)
+exit(%cm : @owned $C):
+  test_specification "is-lexical @block.argument"
+  destroy_value %cm : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on phi_direct_both_lexical: is-lexical
+// CHECK: argument of bb3
+// CHECK: true
+// CHECK-LABEL: end running test 1 of 1 on phi_direct_both_lexical: is-lexical
+sil [ossa] @phi_direct_both_lexical : $() -> () {
+entry:
+  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+  cond_br undef, left, right
+left:
+  %c1 = apply %getC() : $@convention(thin) () -> (@owned C)
+  %m1 = move_value [lexical] %c1 : $C
+  br exit(%m1 : $C)
+right:
+  %c2 = apply %getC() : $@convention(thin) () -> (@owned C)
+  %m2 = move_value [lexical] %c2 : $C
+  br exit(%m2 : $C)
+exit(%cm : @owned $C):
+  test_specification "is-lexical @block.argument"
+  destroy_value %cm : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on phi_indirect_0000_lexical: is-lexical
+// CHECK: argument of bb9
+// CHECK: false
+// CHECK-LABEL: end running test 1 of 1 on phi_indirect_0000_lexical: is-lexical
+sil [ossa] @phi_indirect_0000_lexical : $() -> () {
+entry:
+  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+  cond_br undef, lt, rt
+
+lt:
+  cond_br undef, ll, lr
+ll:
+  %c1 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br lb(%c1 : $C)
+lr:
+  %c2 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br lb(%c2 : $C)
+lb(%cl : @owned $C):
+  br exit(%cl : $C)
+
+rt:
+  cond_br undef, rl, rr
+rl:
+  %c3 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br rb(%c3 : $C)
+rr:
+  %c4 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br rb(%c4 : $C)
+rb(%cr : @owned $C):
+  br exit(%cr : $C)
+
+exit(%cm : @owned $C):
+  test_specification "is-lexical @block.argument"
+  destroy_value %cm : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on phi_indirect_1000_lexical: is-lexical
+// CHECK: argument of bb9
+// CHECK: true
+// CHECK-LABEL: end running test 1 of 1 on phi_indirect_1000_lexical: is-lexical
+sil [ossa] @phi_indirect_1000_lexical : $() -> () {
+entry:
+  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+  cond_br undef, lt, rt
+
+lt:
+  cond_br undef, ll, lr
+ll:
+  %c1 = apply %getC() : $@convention(thin) () -> (@owned C)
+  %m1 = move_value [lexical] %c1 : $C
+  br lb(%m1 : $C)
+lr:
+  %c2 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br lb(%c2 : $C)
+lb(%cl : @owned $C):
+  br exit(%cl : $C)
+
+rt:
+  cond_br undef, rl, rr
+rl:
+  %c3 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br rb(%c3 : $C)
+rr:
+  %c4 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br rb(%c4 : $C)
+rb(%cr : @owned $C):
+  br exit(%cr : $C)
+
+exit(%cm : @owned $C):
+  test_specification "is-lexical @block.argument"
+  destroy_value %cm : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on phi_indirect_0100_lexical: is-lexical
+// CHECK: argument of bb9
+// CHECK: true
+// CHECK-LABEL: end running test 1 of 1 on phi_indirect_0100_lexical: is-lexical
+sil [ossa] @phi_indirect_0100_lexical : $() -> () {
+entry:
+  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+  cond_br undef, lt, rt
+
+lt:
+  cond_br undef, ll, lr
+ll:
+  %c1 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br lb(%c1 : $C)
+lr:
+  %c2 = apply %getC() : $@convention(thin) () -> (@owned C)
+  %m2 = move_value [lexical] %c2 : $C
+  br lb(%m2 : $C)
+lb(%cl : @owned $C):
+  br exit(%cl : $C)
+
+rt:
+  cond_br undef, rl, rr
+rl:
+  %c3 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br rb(%c3 : $C)
+rr:
+  %c4 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br rb(%c4 : $C)
+rb(%cr : @owned $C):
+  br exit(%cr : $C)
+
+exit(%cm : @owned $C):
+  test_specification "is-lexical @block.argument"
+  destroy_value %cm : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on phi_indirect_0010_lexical: is-lexical
+// CHECK: argument of bb9
+// CHECK: true
+// CHECK-LABEL: end running test 1 of 1 on phi_indirect_0010_lexical: is-lexical
+sil [ossa] @phi_indirect_0010_lexical : $() -> () {
+entry:
+  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+  cond_br undef, lt, rt
+
+lt:
+  cond_br undef, ll, lr
+ll:
+  %c1 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br lb(%c1 : $C)
+lr:
+  %c2 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br lb(%c2 : $C)
+lb(%cl : @owned $C):
+  br exit(%cl : $C)
+
+rt:
+  cond_br undef, rl, rr
+rl:
+  %c3 = apply %getC() : $@convention(thin) () -> (@owned C)
+  %m3 = move_value [lexical] %c3 : $C
+  br rb(%m3 : $C)
+rr:
+  %c4 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br rb(%c4 : $C)
+rb(%cr : @owned $C):
+  br exit(%cr : $C)
+
+exit(%cm : @owned $C):
+  test_specification "is-lexical @block.argument"
+  destroy_value %cm : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on phi_indirect_0001_lexical: is-lexical
+// CHECK: argument of bb9
+// CHECK: true
+// CHECK-LABEL: end running test 1 of 1 on phi_indirect_0001_lexical: is-lexical
+sil [ossa] @phi_indirect_0001_lexical : $() -> () {
+entry:
+  %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+  cond_br undef, lt, rt
+
+lt:
+  cond_br undef, ll, lr
+ll:
+  %c1 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br lb(%c1 : $C)
+lr:
+  %c2 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br lb(%c2 : $C)
+lb(%cl : @owned $C):
+  br exit(%cl : $C)
+
+rt:
+  cond_br undef, rl, rr
+rl:
+  %c3 = apply %getC() : $@convention(thin) () -> (@owned C)
+  br rb(%c3 : $C)
+rr:
+  %c4 = apply %getC() : $@convention(thin) () -> (@owned C)
+  %m4 = move_value [lexical] %c4 : $C
+  br rb(%m4 : $C)
+rb(%cr : @owned $C):
+  br exit(%cr : $C)
+
+exit(%cm : @owned $C):
+  test_specification "is-lexical @block.argument"
+  destroy_value %cm : $C
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
Added `SILPhiArgument::isLexical`.  It's true for phis which have an incoming value that's lexical.  Dispatch to this member from `ValueBase::isLexical`.
