### PR TITLE
sil-opt: introduce `-vfsoverlay` to support Windows

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -188,6 +188,10 @@ public:
     return SearchPathOpts.getFrameworkSearchPaths();
   }
 
+  void setVFSOverlays(const std::vector<std::string> &Overlays) {
+    SearchPathOpts.VFSOverlayFiles = Overlays;
+  }
+
   void setCompilerPluginLibraryPaths(const std::vector<std::string> &Paths) {
     SearchPathOpts.setCompilerPluginLibraryPaths(Paths);
   }

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -86,6 +86,9 @@ ImportPaths("I", llvm::cl::desc("add a directory to the import search path"));
 static llvm::cl::list<std::string>
 FrameworkPaths("F", llvm::cl::desc("add a directory to the framework search path"));
 
+static llvm::cl::list<std::string>
+VFSOverlays("vfsoverlay", llvm::cl::desc("add a VFS overlay"));
+
 static llvm::cl::opt<std::string>
 ModuleName("module-name", llvm::cl::desc("The name of the module if processing"
                                          " a module. Necessary for processing "
@@ -542,6 +545,9 @@ int main(int argc, char **argv) {
     FramePaths.push_back({path, /*isSystem=*/false});
   }
   Invocation.setFrameworkSearchPaths(FramePaths);
+
+  Invocation.setVFSOverlays(VFSOverlays);
+
   // Set the SDK path and target if given.
   if (SDKPath.getNumOccurrences() == 0) {
     const char *SDKROOT = getenv("SDKROOT");


### PR DESCRIPTION
Add an option to `sil-opt` to pass along VFS overlay files to the clang importer.  This is required to make the tests pass with the upcoming work to avoid modifying the Visual Studio installation and instead to prefer to inject the content via VFS overlays.