### PR TITLE
stdlib: remove VS injection for Swift development

### DIFF
--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -24,6 +24,20 @@ else()
   set(SWIFT_BUILD_TEST_SUPPORT_MODULES_default FALSE)
 endif()
 
+# TODO(compnerd) use a target to avoid re-creating this file all the time
+function(generate_windows_vfs_overlay)
+  file(TO_CMAKE_PATH ${VCToolsInstallDir} VCToolsInstallDir)
+  file(TO_CMAKE_PATH ${UniversalCRTSdkDir} UniversalCRTSdkDir)
+  configure_file("${PROJECT_SOURCE_DIR}/cmake/WindowsVFS.yaml.in"
+                 "${CMAKE_CURRENT_BINARY_DIR}/windows-vfs-overlay.yaml"
+                 @ONLY)
+endfunction()
+if(WINDOWS IN_LIST SWIFT_SDKS)
+  generate_windows_vfs_overlay()
+  file(TO_CMAKE_PATH "${CMAKE_CURRENT_BINARY_DIR}/windows-vfs-overlay.yaml"
+       SWIFT_WINDOWS_VFS_OVERLAY)
+endif()
+
 #
 # User-configurable options for the standard library.
 #

--- a/stdlib/cmake/WindowsVFS.yaml.in
+++ b/stdlib/cmake/WindowsVFS.yaml.in
@@ -1,0 +1,27 @@
+---
+version: 0
+case-sensitive: false
+use-external-names: false
+roots:
+  - name: "@UniversalCRTSdkDir@\\Include\\@UCRTVersion@\\um"
+    type: directory
+    contents:
+      - name: module.modulemap
+        type: file
+        external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\winsdk.modulemap"
+  - name: "@UniversalCRTSdkDir@\\Include\\@UCRTVersion@\\ucrt"
+    type: directory
+    contents:
+      - name: module.modulemap
+        type: file
+        external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\ucrt.modulemap"
+  - name: "@VCToolsInstallDir@\\include"
+    type: directory
+    contents:
+      - name: module.modulemap
+        type: file
+        external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\vcruntime.modulemap"
+      - name: vcruntime.apinotes
+        type: file
+        external-contents: "@PROJECT_SOURCE_DIR@\\public\\Platform\\vcruntime.apinotes"
+

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -875,6 +875,8 @@ function(add_swift_target_library_single target name)
       list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS
         -Xcc;-Xclang;-Xcc;-ivfsoverlay;-Xcc;-Xclang;-Xcc;${SWIFTLIB_SINGLE_VFS_OVERLAY})
     endif()
+    list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS
+      -vfsoverlay;"${SWIFT_WINDOWS_VFS_OVERLAY}")
     swift_windows_include_for_arch(${SWIFTLIB_SINGLE_ARCHITECTURE} SWIFTLIB_INCLUDE)
     foreach(directory ${SWIFTLIB_INCLUDE})
       list(APPEND SWIFTLIB_SINGLE_SWIFT_COMPILE_FLAGS -Xcc;-isystem;-Xcc;${directory})

--- a/test/Driver/batch_mode_dependencies_make_wrong_order.swift
+++ b/test/Driver/batch_mode_dependencies_make_wrong_order.swift
@@ -6,14 +6,14 @@
 // RUN: echo 'public func main() {}' >%t/main.swift
 //
 // First prime the incremental state, but note that we're building in the d c b a (reverse-alphabetical) order.
-// RUN: cd %t && %target-swiftc_driver -enable-batch-mode -incremental -output-file-map %S/Inputs/abcd_filemap.yaml -module-name main -j 1 d.swift c.swift b.swift a.swift main.swift
+// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -incremental -output-file-map %S/Inputs/abcd_filemap.yaml -module-name main -j 1 d.swift c.swift b.swift a.swift main.swift
 //
 // Now perturb the interface of a.swift and delete its output
 // RUN: echo 'class a { var x : Int = 10 }' >%t/a.swift
 // RUN: rm %t/a.o
 //
 // Now rebuild, which will rebuild a.swift then do a cascading dep-graph invalidation
-// RUN: cd %t && %target-swiftc_driver -enable-batch-mode -incremental -output-file-map %S/Inputs/abcd_filemap.yaml -module-name main -j 1 d.swift c.swift b.swift a.swift main.swift -driver-show-incremental -driver-show-job-lifecycle >%t/out.txt 2>&1
+// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -incremental -output-file-map %S/Inputs/abcd_filemap.yaml -module-name main -j 1 d.swift c.swift b.swift a.swift main.swift -driver-show-incremental -driver-show-job-lifecycle >%t/out.txt 2>&1
 // RUN: %FileCheck %s <%t/out.txt
 //
 // Check that we saw invalidation happen in command-line argument order

--- a/test/Incremental/Fingerprints/class-fingerprint.swift
+++ b/test/Incremental/Fingerprints/class-fingerprint.swift
@@ -10,7 +10,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -24,7 +24,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 

--- a/test/Incremental/Fingerprints/enum-fingerprint.swift
+++ b/test/Incremental/Fingerprints/enum-fingerprint.swift
@@ -10,7 +10,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -24,7 +24,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 

--- a/test/Incremental/Fingerprints/extension-adds-member.swift
+++ b/test/Incremental/Fingerprints/extension-adds-member.swift
@@ -10,7 +10,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output3
+// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output3
 
 // Change one type, only uses of that type get recompiled
 
@@ -21,7 +21,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output4
+// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output4
 
 // RUN: %FileCheck -check-prefix=CHECK-RECOMPILED-W %s < %t/output4
 // RUN: %FileCheck -check-prefix=CHECK-NOT-RECOMPILED-W %s < %t/output4

--- a/test/Incremental/Fingerprints/nested-enum-fingerprint.swift
+++ b/test/Incremental/Fingerprints/nested-enum-fingerprint.swift
@@ -10,7 +10,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -24,7 +24,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 

--- a/test/Incremental/Fingerprints/protocol-fingerprint.swift
+++ b/test/Incremental/Fingerprints/protocol-fingerprint.swift
@@ -10,7 +10,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -24,7 +24,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 

--- a/test/Incremental/Fingerprints/struct-fingerprint.swift
+++ b/test/Incremental/Fingerprints/struct-fingerprint.swift
@@ -10,7 +10,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -24,7 +24,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %target-swiftc_driver  -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 

--- a/test/Incremental/cross-file-failure.swift
+++ b/test/Incremental/cross-file-failure.swift
@@ -6,7 +6,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: cd %t
 
-// RUN: %target-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesA.swift usesA.swift -module-name main -output-file-map ofm.json >&output-baseline
+// RUN: %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesA.swift usesA.swift -module-name main -output-file-map ofm.json >&output-baseline
 
 // Change one type and cause a syntax error. This should cause _both_ files to
 // rebuild.
@@ -16,12 +16,12 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesA.swift
 
-// RUN: not %target-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesA.swift usesA.swift -module-name main -output-file-map ofm.json
+// RUN: not %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesA.swift usesA.swift -module-name main -output-file-map ofm.json
 
 // RUN: cp %t/definesA{-three,}.swift
 // RUN: touch -t 200401010101 %t/definesA.swift
 
-// RUN: not %target-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesA.swift usesA.swift -module-name main -output-file-map ofm.json >&output-incremental
+// RUN: not %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesA.swift usesA.swift -module-name main -output-file-map ofm.json >&output-incremental
 
 // RUN: %FileCheck -check-prefix=CHECK-RECOMPILED %s --dump-input=always < %t/output-incremental
 

--- a/test/Incremental/superfluous-cascade.swift
+++ b/test/Incremental/superfluous-cascade.swift
@@ -5,7 +5,7 @@
 // RUN: cp %t/definesPoint{-before,}.swift
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %target-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesPoint.swift usesPoint.swift usesDisplay.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesPoint.swift usesPoint.swift usesDisplay.swift -module-name main -output-file-map ofm.json >&output3
 
 // Change one type - now only the user of that type rebuilds
 
@@ -14,7 +14,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesPoint.swift
 
-// RUN: cd %t && %target-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesPoint.swift usesPoint.swift usesDisplay.swift  -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesPoint.swift usesPoint.swift usesDisplay.swift  -module-name main -output-file-map ofm.json >&output4
 
 // RUN: %FileCheck -check-prefix=CHECK-RECOMPILED %s --dump-input=always < %t/output4
 

--- a/test/ModuleInterface/ModuleCache/Inputs/check-is-forwarding-module.py
+++ b/test/ModuleInterface/ModuleCache/Inputs/check-is-forwarding-module.py
@@ -1,8 +1,8 @@
 import sys
 
 for input_path in sys.argv[1:]:
-    with open(input_path, 'r') as yaml_file:
+    with open(input_path, 'rb') as yaml_file:
         # Forwarding files are YAML files that start with '---'
-        if yaml_file.read(3) != '---':
+        if yaml_file.read(3) != b'---':
             print("swiftmodule '%s' is not a forwarding module!" % input_path)
             sys.exit(1)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -364,6 +364,15 @@ if test_resource_dir:
    config.resource_dir_opt = ("-resource-dir %s" % test_resource_dir)
 else:
     test_resource_dir = make_path(config.swift_lib_dir, 'swift')
+config.swift_system_overlay_opt = ""
+config.clang_system_overlay_opt = ""
+if kIsWindows:
+    config.swift_system_overlay_opt = "-vfsoverlay {}".format(
+        os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
+    )
+    config.clang_system_overlay_opt = "-Xcc -ivfsoverlay -Xcc {}".format(
+        os.path.join(config.swift_obj_root, "stdlib", "windows-vfs-overlay.yaml")
+    )
 stdlib_resource_dir_opt = config.resource_dir_opt
 sourcekitd_framework_dir = config.swift_lib_dir
 config.substitutions.append( ('%test-resource-dir', test_resource_dir) )
@@ -1279,6 +1288,7 @@ if run_vendor == 'apple':
          "-Xlinker -headerpad_max_install_names " +  
          "-Xlinker -rpath -Xlinker /usr/lib/swift %s ")%
         (xcrun_prefix, config.swiftc, target_options, config.swift_driver_test_options))
+    config.swiftc_driver_stdlib_target = config.target_swiftc_driver
     config.target_clang = (
         "%s %s %s" %
         (xcrun_prefix, config.clangxx, config.target_cc_options))
@@ -1355,8 +1365,9 @@ elif run_os in ['windows-msvc']:
     config.target_env_prefix = ''
 
     config.target_build_swift =                                                  \
-            ('%r -target %s %s %s %s %s -libc %s' %                              \
-                    (config.swiftc, config.variant_triple, config.resource_dir_opt,     \
+            ('%r -target %s %s %s %s %s %s -libc %s' %                           \
+                    (config.swiftc, config.variant_triple,                       \
+                     config.resource_dir_opt, config.swift_system_overlay_opt,   \
                      config.swift_test_options, config.swift_driver_test_options,\
                      swift_execution_tests_extra_flags,                          \
                      config.swift_stdlib_msvc_runtime))
@@ -1364,11 +1375,12 @@ elif run_os in ['windows-msvc']:
     config.target_run = ''
 
     config.target_swift_frontend =                                               \
-            ('%r -target %s %s %s %s %s' % (config.swift_frontend,             \
-                                                      config.variant_triple,     \
-                                                      config.resource_dir_opt, mcp_opt, \
-                                                      config.swift_test_options, \
-                                                      config.swift_frontend_test_options))
+            ('%r -target %s %s %s %s %s %s' % (config.swift_frontend,            \
+                                               config.variant_triple,            \
+                                               config.resource_dir_opt, mcp_opt, \
+                                               config.swift_system_overlay_opt,  \
+                                               config.swift_test_options,        \
+                                               config.swift_frontend_test_options))
 
     config.target_codesign = 'echo'
 
@@ -1387,9 +1399,11 @@ elif run_os in ['windows-msvc']:
             ('%r -libpath:%s' % (config.link, os.path.join(test_resource_dir,    \
                                                            config.target_sdk_name)))
     config.target_sil_opt =                                                      \
-            ('%r -target %s %s %s %s' % (config.sil_opt, config.variant_triple,  \
-                                         config.resource_dir_opt, mcp_opt,              \
-                                         config.sil_test_options))
+            ('%r -target %s %s %s %s %s' % (config.sil_opt,                      \
+                                            config.variant_triple,               \
+                                            config.resource_dir_opt, mcp_opt,    \
+                                            config.swift_system_overlay_opt,     \
+                                            config.sil_test_options))
     subst_target_sil_opt_mock_sdk = config.target_sil_opt
     subst_target_sil_opt_mock_sdk_after = ''
     config.target_swift_symbolgraph_extract =                                    \
@@ -1409,9 +1423,14 @@ elif run_os in ['windows-msvc']:
     subst_target_swift_ide_test_mock_sdk_after = ''
 
     config.target_swiftc_driver =                                                \
+            ('%r -target %s %s %s %s %s' % (config.swiftc, config.variant_triple,\
+                                            config.resource_dir_opt, mcp_opt,    \
+                                            config.swift_system_overlay_opt,     \
+                                            config.swift_driver_test_options))
+    config.swiftc_driver_stdlib_target =                                         \
             ('%r -target %s %s %s %s' % (config.swiftc, config.variant_triple,   \
-                                      config.resource_dir_opt, mcp_opt,                 \
-                                      config.swift_driver_test_options))
+                                         config.resource_dir_opt, mcp_opt,       \
+                                         config.swift_driver_test_options))
     config.target_swift_modulewrap =                                             \
             ('%r -modulewrap -target %s' % (config.swiftc, config.variant_triple))
     config.target_swift_emit_pcm =                                               \
@@ -1539,6 +1558,7 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
     config.target_swiftc_driver = (
         "%s -target %s -toolchain-stdlib-rpath %s %s %s" %
         (config.swiftc, config.variant_triple, config.resource_dir_opt, mcp_opt, config.swift_driver_test_options))
+    config.swiftc_driver_stdlib_target = config.target_swiftc_driver
     config.target_swift_modulewrap = (
         '%s -modulewrap -target %s' %
         (config.swiftc, config.variant_triple))
@@ -1657,6 +1677,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         '-tools-directory', tools_directory,
         config.resource_dir_opt, mcp_opt,
         config.swift_driver_test_options])
+    config.swiftc_driver_stdlib_target = config.target_swiftc_driver
     config.target_swift_modulewrap = ' '.join([
         config.swiftc, '-modulewrap',
         '-target', config.variant_triple])
@@ -1724,6 +1745,7 @@ elif run_os == 'wasi':
     config.target_swiftc_driver = (
         "%s -target %s -toolchain-stdlib-rpath %s %s" %
         (config.swiftc, config.variant_triple, config.resource_dir_opt, mcp_opt))
+    config.swiftc_driver_stdlib_target = config.target_swiftc_driver
     config.target_swift_modulewrap = (
         '%s -modulewrap -target %s' %
         (config.swiftc, config.variant_triple))
@@ -2416,7 +2438,10 @@ config.substitutions.append(('%target-swift-ide-test\(mock-sdk:([^)]+)\)',
                                  escape_for_substitute_captures(subst_target_swift_ide_test_mock_sdk),
                                  escape_for_substitute_captures(subst_target_swift_ide_test_mock_sdk_after),
                                  escape_for_substitute_captures(swift_version)))))
-config.substitutions.append(('%target-swift-ide-test', "%s -swift-version %s" % (config.target_swift_ide_test, swift_version)))
+config.substitutions.append(('%target-swift-ide-test',
+                             "%s -swift-version %s %s" % (config.target_swift_ide_test,
+                                                          swift_version,
+                                                          config.clang_system_overlay_opt)))
 
 config.substitutions.append(('%target-swift-symbolgraph-extract', config.target_swift_symbolgraph_extract))
 config.substitutions.append(('%target-swift-api-extract', config.target_swift_api_extract))
@@ -2428,6 +2453,7 @@ config.substitutions.append(('%target-swift-reflection-test', config.target_swif
 
 config.substitutions.append(('%target-swift-reflection-dump', '{} {} {}'.format(config.swift_reflection_dump, '-arch', run_cpu)))
 config.substitutions.append(('%target-swiftc_driver', config.target_swiftc_driver))
+config.substitutions.append(('%swiftc_driver-stdlib-target', config.swiftc_driver_stdlib_target))
 
 config.substitutions.append(('%target-swift-remoteast-test-with-sdk',
                              '%s %s -sdk %r' %

--- a/utils/build-windows.bat
+++ b/utils/build-windows.bat
@@ -78,7 +78,6 @@ path %PATH%;%install_directory%\bin
 
 call :build_cmark %exitOnError%
 
-call :prepare_platform_modules %exitOnError%
 call :build_swift %exitOnError%
 
 call :build_lldb %exitOnError%
@@ -160,22 +159,6 @@ curl -L -O "https://www.sqlite.org/2021/%file_name%" %exitOnError%
 goto :eof
 endlocal
 
-
-:prepare_platform_modules
-:: Create files into the right places of the Windows SDK to the files in the
-:: swift repository, in order to consider the headers of the Windows SDK a
-:: module to compile Swift code against them.
-setlocal enableextensions enabledelayedexpansion
-
-copy /y "%source_root%\swift\stdlib\public\Platform\ucrt.modulemap" "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap" %exitOnError%
-copy /y "%source_root%\swift\stdlib\public\Platform\winsdk.modulemap" "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap" %exitOnError%
-copy /y "%source_root%\swift\stdlib\public\Platform\vcruntime.modulemap" "%VCToolsInstallDir%\include\module.modulemap" %exitOnError%
-copy /y "%source_root%\swift\stdlib\public\Platform\vcruntime.apinotes" "%VCToolsInstallDir%\include\vcruntime.apinotes" %exitOnError%
-
-goto :eof
-endlocal
-
-
 :build_llvm
 :: Configures, builds, and installs LLVM
 setlocal enableextensions enabledelayedexpansion
@@ -244,6 +227,12 @@ endlocal
 :build_swift
 :: Configures, builds, and installs Swift and the Swift Standard Library
 setlocal enableextensions enabledelayedexpansion
+
+:: Clean up old deployments as that breaks the tests
+del /f /q "%UniversalCRTSdkDir%\Include\%UCRTVersion%\ucrt\module.modulemap"
+del /f /q "%UniversalCRTSdkDir%\Include\%UCRTVersion%\um\module.modulemap"
+del /f /q "%VCToolsInstallDir%\include\module.modulemap"
+del /f /q "%VCToolsInstallDir%\include\vcruntime.apinotes"
 
 :: SWIFT_PARALLEL_LINK_JOBS=8 allows the build machine to use as many CPU as
 :: possible, while not exhausting the RAM.
@@ -340,6 +329,7 @@ endlocal
 setlocal enableextensions enabledelayedexpansion
 
 for /f "delims=" %%O in ('cygpath -m %install_directory%\lib\swift') do set RESOURCE_DIR=%%O
+for /f "delims=" %%O in ('cygpath -m %build_root%\swift\stdlib\windows-vfs-overlay.yaml') do set VFS_OVERLAY=%%O
 
 cmake^
     -B "%build_root%\swift-corelibs-libdispatch"^
@@ -360,8 +350,7 @@ cmake^
     -DCMAKE_EXE_LINKER_FLAGS:STRING="/INCREMENTAL:NO"^
     -DCMAKE_SHARED_LINKER_FLAGS:STRING="/INCREMENTAL:NO"^
     -DCMAKE_Swift_COMPILER_TARGET:STRING=x86_64-unknown-windows-msvc^
-    -DCMAKE_Swift_FLAGS:STRING="-resource-dir \"%RESOURCE_DIR%\""^
-    -DCMAKE_Swift_LINK_FLAGS:STRING="-resource-dir \"%RESOURCE_DIR%\""^
+    -DCMAKE_Swift_FLAGS:STRING="-resource-dir \"%RESOURCE_DIR%\" -vfsoverlay %VFS_OVERLAY%"^
     -S "%source_root%\swift-corelibs-libdispatch" %exitOnError%
 
 cmake --build "%build_root%\swift-corelibs-libdispatch" %exitOnError%


### PR DESCRIPTION
Inject the necessary module maps and apinotes via the VFS.  This cleans
up the developer build in preparation for a secondary change to remove
this need for deployed scenarios as well.  Injecting the content via the
VFS will enable us restore the ability to work with a pristine
installation of Visual Studio, dropping the custom action for the Swift
installer, and open the pathway to per-user installation of Swift.

Thanks to @bnbarham for the help and discussion in resolving the test
issues.