### PR TITLE
[5.8][ClangImporter] Fix stack-use-after-scope in createClangInvocation

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1001,11 +1001,11 @@ std::unique_ptr<clang::CompilerInvocation> ClangImporter::createClangInvocation(
     // the diagnostic options here explicitly.
     std::unique_ptr<clang::DiagnosticOptions> clangDiagOpts =
         clang::CreateAndPopulateDiagOpts(invocationArgs);
-    ClangDiagnosticConsumer diagClient{importer->Impl, *clangDiagOpts,
-                                       importerOpts.DumpClangDiagnostics};
+    auto *diagClient = new ClangDiagnosticConsumer(
+        importer->Impl, *clangDiagOpts, importerOpts.DumpClangDiagnostics);
     clangDiags = clang::CompilerInstance::createDiagnostics(
-        clangDiagOpts.release(), &diagClient,
-        /*owned*/ false);
+        clangDiagOpts.release(), diagClient,
+        /*owned*/ true);
 
     // Finally, use the CC1 command-line and the diagnostic engine
     // to instantiate our Invocation.
@@ -1025,11 +1025,11 @@ std::unique_ptr<clang::CompilerInvocation> ClangImporter::createClangInvocation(
     llvm::IntrusiveRefCntPtr<clang::DiagnosticOptions> tempDiagOpts{
         new clang::DiagnosticOptions};
 
-    ClangDiagnosticConsumer tempDiagClient{importer->Impl, *tempDiagOpts,
-                                           importerOpts.DumpClangDiagnostics};
+    auto *tempDiagClient = new ClangDiagnosticConsumer(
+        importer->Impl, *tempDiagOpts, importerOpts.DumpClangDiagnostics);
     clangDiags = clang::CompilerInstance::createDiagnostics(tempDiagOpts.get(),
-                                                            &tempDiagClient,
-                                                            /*owned*/ false);
+                                                            tempDiagClient,
+                                                            /*owned*/ true);
     CI = clang::createInvocationFromCommandLine(invocationArgs, clangDiags, VFS,
                                                 false, CC1Args);
   }


### PR DESCRIPTION
(Cherry-pick #63881 into `release/5.8`)

* **Explanation**: There was a `stack-use-after-scope` in ClangImporter's `createClangInvocation()` function. When creating temporary diagnostic engine for creating invocation object, the consumer object is created inside `if...else` branches on the stack, but the pointer to it was used outside the scope. That can cause random unpredictable crashes, for example, if the clang compiler argument was malformed. This change resolves that by instantiating the diagnostic consumer on heap, then let the diagnostic engine take the ownership. 
* **Scope**: ClangImporter creation, while processing clang invocation arguments
* **Risk**: Low
* **Issues**: rdar://105801504
* **Testing**: Passes current test suite. Testing with ASAN locally.
* **Reviewers**: Artem Chikin (@artemcm)