### PR TITLE
Progress towards SILGen for variadic generic argument lowering

### DIFF
--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -38,8 +38,10 @@ class OpaqueTypeDecl;
 class ElementArchetypeType;
 class OpenedArchetypeType;
 class PackArchetypeType;
+class PackExpansionType;
 class SILModule;
 class SILType;
+template <class> class CanTypeWrapper;
 
 /// Query function suitable for use as a \c TypeSubstitutionFn that queries
 /// the mapping of interface types to archetypes.
@@ -309,6 +311,23 @@ public:
   void dump(raw_ostream &os) const;
 
   SWIFT_DEBUG_DUMP;
+};
+
+/// A pair of an opened-element generic signature and an opened-element
+/// generic environment.
+struct OpenedElementContext {
+  /// The opened-element environment for this expansion.
+  GenericEnvironment *environment;
+
+  /// The opened-element signature for this expansion.
+  CanGenericSignature signature;
+
+  /// Create a fresh opened element context from a contextual pack
+  /// expansion type.  This is useful when writing code that needs to
+  /// break down the components of a pack expansion.
+  static OpenedElementContext
+  createForContextualExpansion(ASTContext &ctx,
+                   CanTypeWrapper<PackExpansionType> expansionType);
 };
   
 } // end namespace swift

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6740,6 +6740,8 @@ private:
   }
 };
 BEGIN_CAN_TYPE_WRAPPER(PackType, Type)
+  static CanPackType get(const ASTContext &ctx, ArrayRef<CanType> elements);
+
   CanType getElementType(unsigned elementNo) const {
     return CanType(getPointer()->getElementType(elementNo));
   }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3302,6 +3302,11 @@ PackType *PackType::getEmpty(const ASTContext &C) {
   return cast<PackType>(CanType(C.TheEmptyPackType));
 }
 
+CanPackType CanPackType::get(const ASTContext &C, ArrayRef<CanType> elements) {
+  SmallVector<Type, 8> ncElements(elements.begin(), elements.end());
+  return CanPackType(PackType::get(C, ncElements));
+}
+
 PackType *PackType::get(const ASTContext &C, ArrayRef<Type> elements) {
   RecursiveTypeProperties properties;
   bool isCanonical = true;

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -709,3 +709,24 @@ GenericEnvironment::mapConformanceRefIntoContext(
   auto contextType = mapTypeIntoContext(conformingInterfaceType);
   return {contextType, contextConformance};
 }
+
+OpenedElementContext
+OpenedElementContext::createForContextualExpansion(ASTContext &ctx,
+                                       CanPackExpansionType expansionType) {
+  assert(!expansionType->hasTypeParameter() &&
+         "must be given a contextual type");
+
+  // Get the outer generic signature and environment.
+  auto *genericEnv = cast<ArchetypeType>(expansionType.getCountType())
+                         ->getGenericEnvironment();
+  auto subMap = genericEnv->getForwardingSubstitutionMap();
+
+  auto genericSig = genericEnv->getGenericSignature().getCanonicalSignature();
+  // Create an opened element signature and environment.
+  auto elementSig = ctx.getOpenedElementSignature(
+      genericSig, expansionType.getCountType());
+  auto *elementEnv = GenericEnvironment::forOpenedElement(
+      elementSig, UUID::fromTime(), expansionType.getCountType(), subMap);
+
+  return {elementEnv, elementSig};
+}

--- a/lib/SILGen/CMakeLists.txt
+++ b/lib/SILGen/CMakeLists.txt
@@ -28,6 +28,7 @@ add_swift_host_library(swiftSILGen STATIC
   SILGenGlobalVariable.cpp
   SILGenLazyConformance.cpp
   SILGenLValue.cpp
+  SILGenPack.cpp
   SILGenPattern.cpp
   SILGenPoly.cpp
   SILGenProlog.cpp

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -393,7 +393,8 @@ private:
       : kind(callDynamicallyReplaceableImpl
                  ? Kind::StandaloneFunctionDynamicallyReplaceableImpl
                  : Kind::StandaloneFunction),
-        Constant(standaloneFunction), OrigFormalInterfaceType(origFormalType),
+        Constant(standaloneFunction),
+        OrigFormalInterfaceType(origFormalType.withSubstitutions(subs)),
         SubstFormalInterfaceType(
             getSubstFormalInterfaceType(substFormalType, formalSubs)),
         Substitutions(subs), Loc(l) {}
@@ -404,6 +405,8 @@ private:
          AbstractionPattern origFormalType, CanAnyFunctionType substFormalType,
          SubstitutionMap subs, SILLocation l)
       : kind(methodKind), Constant(methodName),
+        // FIXME: use .withSubstitutions(subs) here when we figure out how
+        // to provide the right substitutions for overrides
         OrigFormalInterfaceType(origFormalType),
         SubstFormalInterfaceType(
             getSubstFormalInterfaceType(substFormalType, subs)),
@@ -526,7 +529,7 @@ public:
   }
 
   AbstractionPattern getOrigFormalType() const {
-    return AbstractionPattern(OrigFormalInterfaceType);
+    return OrigFormalInterfaceType;
   }
 
   CanFunctionType getSubstFormalType() const {
@@ -1993,9 +1996,12 @@ buildBuiltinLiteralArgs(SILGenFunction &SGF, SGFContext C,
 }
 
 static inline PreparedArguments
-buildBuiltinLiteralArgs(NilLiteralExpr *nilLiteral) {
+buildBuiltinLiteralArgs(SILGenFunction &SGF, SGFContext C,
+                        NilLiteralExpr *nilLiteral) {
+  CanType ty = SGF.getASTContext().TheEmptyTupleType;
   PreparedArguments builtinLiteralArgs;
-  builtinLiteralArgs.emplace({});
+  builtinLiteralArgs.emplace(AnyFunctionType::Param(ty));
+  builtinLiteralArgs.add(nilLiteral, RValue(SGF, {}, ty));
   return builtinLiteralArgs;
 }
 
@@ -2145,7 +2151,7 @@ static inline PreparedArguments buildBuiltinLiteralArgs(SILGenFunction &SGF,
   if (auto stringLiteral = dyn_cast<StringLiteralExpr>(literal)) {
     return buildBuiltinLiteralArgs(SGF, C, stringLiteral);
   } else if (auto nilLiteral = dyn_cast<NilLiteralExpr>(literal)) {
-    return buildBuiltinLiteralArgs(nilLiteral);
+    return buildBuiltinLiteralArgs(SGF, C, nilLiteral);
   } else if (auto booleanLiteral = dyn_cast<BooleanLiteralExpr>(literal)) {
     return buildBuiltinLiteralArgs(SGF, C, booleanLiteral);
   } else if (auto integerLiteral = dyn_cast<IntegerLiteralExpr>(literal)) {
@@ -3076,6 +3082,7 @@ namespace {
 
 class ArgEmitter {
   SILGenFunction &SGF;
+  SILLocation ApplyLoc;
   SILFunctionTypeRepresentation Rep;
   bool IsYield;
   bool IsForCoroutine;
@@ -3088,12 +3095,14 @@ class ArgEmitter {
   SmallVectorImpl<DelayedArgument> &DelayedArguments;
 
 public:
-  ArgEmitter(SILGenFunction &SGF, SILFunctionTypeRepresentation Rep,
+  ArgEmitter(SILGenFunction &SGF, SILLocation applyLoc,
+             SILFunctionTypeRepresentation Rep,
              bool isYield, bool isForCoroutine, ClaimedParamsRef paramInfos,
              SmallVectorImpl<ManagedValue> &args,
              SmallVectorImpl<DelayedArgument> &delayedArgs,
              const ForeignInfo &foreign)
-      : SGF(SGF), Rep(Rep), IsYield(isYield), IsForCoroutine(isForCoroutine),
+      : SGF(SGF), ApplyLoc(applyLoc),
+        Rep(Rep), IsYield(isYield), IsForCoroutine(isForCoroutine),
         Foreign(foreign), ParamInfos(paramInfos), Args(args),
         DelayedArguments(delayedArgs) {}
 
@@ -3130,10 +3139,38 @@ public:
     auto argSources = std::move(args).getSources();
 
     maybeEmitForeignArgument();
-    for (auto i : indices(argSources)) {
-      emitSingleArg(std::move(argSources[i]),
-                    origFormalType.getFunctionParamType(i));
+
+    size_t numOrigFormalParams =
+      origFormalType.isTypeParameter()
+        ? argSources.size()
+        : origFormalType.getNumFunctionParams();
+    size_t nextArgSourceIndex = 0;
+
+    for (size_t i = 0; i != numOrigFormalParams; ++i) {
+      auto origFormalParamType = origFormalType.getFunctionParamType(i);
+
+      // If the next pattern is not a pack expansion, just emit it as a
+      // single argument.
+      if (!origFormalParamType.isPackExpansion()) {
+        emitSingleArg(std::move(argSources[nextArgSourceIndex++]),
+                      origFormalParamType);
+
+      // Otherwise we need to emit a pack argument.
+      } else {
+        SmallVector<AbstractionPattern, 4> origPackEltPatterns;
+        origFormalParamType.forEachPackExpandedComponent(
+                              [&](AbstractionPattern pattern) {
+          origPackEltPatterns.push_back(pattern);
+        });
+
+        auto argSourcesSlice =
+          argSources.slice(nextArgSourceIndex, origPackEltPatterns.size());
+        emitPackArg(argSourcesSlice, origPackEltPatterns);
+        nextArgSourceIndex += origPackEltPatterns.size();
+      }
     }
+
+    assert(nextArgSourceIndex == argSources.size());
   }
 
 private:
@@ -3571,6 +3608,236 @@ private:
     Args.push_back(convertOwnershipConvention(value));
   }
 
+  void emitPackArg(MutableArrayRef<ArgumentSource> args,
+                   ArrayRef<AbstractionPattern> origFormalTypes) {
+    // Adjust for the foreign error or async argument if necessary.
+    maybeEmitForeignArgument();
+
+    // The substituted parameter type.  Might be different from the
+    // substituted argument type by abstraction and/or bridging.
+    auto paramSlice = claimNextParameters(1);
+    SILParameterInfo param = paramSlice.front();
+    assert(param.isPack() && "emitting pack argument into non-pack parameter");
+    auto packTy = cast<SILPackType>(param.getInterfaceType());
+
+    // TODO: if there's one argument, and it's a pack of the right
+    // type, try to simply forward it instead of allocating a new pack.
+
+    // Otherwise, allocate a pack.
+    auto pack = SGF.emitTemporaryPackAllocation(ApplyLoc,
+                                    SILType::getPrimitiveObjectType(packTy));
+
+    // We can't support inout pack expansions yet because SIL can't have
+    // a dynamic set of accesses in flight at once.
+    // TODO: we *could* support this if there aren't any expansions in the
+    // arguments
+    if (param.getConvention() == ParameterConvention::Pack_Inout) {
+      SGF.SGM.diagnose(ApplyLoc, diag::not_implemented,
+                       "inout pack argument emission");
+      Args.push_back(ManagedValue::forLValue(pack));
+      return;
+    }
+
+    auto formalPackType = getFormalPackType(args);
+
+    bool consumed = param.getConvention() == ParameterConvention::Pack_Owned;
+    emitIndirectIntoPack(args, origFormalTypes, pack, formalPackType,
+                         consumed);
+  }
+
+  CanPackType getFormalPackType(ArrayRef<ArgumentSource> args) {
+    SmallVector<CanType, 8> elts;
+    for (auto &arg : args) {
+      elts.push_back(arg.getSubstRValueType());
+    }
+    return CanPackType::get(SGF.getASTContext(), elts);
+  }
+
+  void emitIndirectIntoPack(MutableArrayRef<ArgumentSource> args,
+                            ArrayRef<AbstractionPattern> origFormalTypes,
+                            SILValue packAddr,
+                            CanPackType formalPackType,
+                            bool consumed) {
+    assert(args.size() == origFormalTypes.size());
+
+    auto packTy = packAddr->getType().castTo<SILPackType>();
+    assert(packTy->getNumElements() == args.size() &&
+           "wrong pack shape for arguments");
+
+    SmallVector<CleanupHandle, 8> eltCleanups;
+
+    for (auto i : indices(args)) {
+      ArgumentSource &&arg = std::move(args[i]);
+      const AbstractionPattern &origFormalType = origFormalTypes[i];
+      auto expectedEltTy = packTy->getSILElementType(i);
+
+      auto cleanup = CleanupHandle::invalid();
+      if (origFormalType.isPackExpansion()) {
+        cleanup =
+          emitPackExpansionIntoPack(std::move(arg), origFormalType,
+                                    expectedEltTy, consumed,
+                                    packAddr, formalPackType, i);
+      } else {
+        cleanup =
+          emitScalarIntoPack(std::move(arg), origFormalType,
+                             expectedEltTy, consumed,
+                             packAddr, formalPackType, i);
+      }
+      if (cleanup.isValid()) eltCleanups.push_back(cleanup);
+    }
+
+    if (!consumed) {
+      Args.push_back(ManagedValue::forBorrowedAddressRValue(packAddr));
+    } else if (eltCleanups.empty()) {
+      Args.push_back(ManagedValue::forTrivialAddressRValue(packAddr));
+    } else if (eltCleanups.size() == 1) {
+      Args.push_back(ManagedValue::forOwnedAddressRValue(packAddr,
+                                                         eltCleanups[0]));
+    } else {
+      // Args implicitly expects there to be <= 1 cleanup per argument,
+      // so to make this work, we need to deactivate all the existing
+      // cleanups and push a unified cleanup to destroy those values via
+      // the pack.
+      for (auto cleanup : eltCleanups)
+        SGF.Cleanups.forwardCleanup(cleanup);
+      auto packCleanup =
+        SGF.enterDestroyPackCleanup(packAddr, formalPackType);
+      Args.push_back(ManagedValue::forOwnedAddressRValue(packAddr,
+                                                         packCleanup));
+    }
+  }
+
+  CleanupHandle emitPackExpansionIntoPack(ArgumentSource &&arg,
+                                          AbstractionPattern origFormalType,
+                                          SILType expectedParamType,
+                                          bool consumed,
+                                          SILValue packAddr,
+                                          CanPackType formalPackType,
+                                          unsigned packComponentIndex) {
+    auto expansionLoweredType =
+      expectedParamType.castTo<PackExpansionType>();
+
+    // TODO: we'll need to handle already-emitted packs for things like
+    // subscripts
+    assert(arg.isExpr() && "emitting a non-expression pack expansion");
+    auto expr = std::move(arg).asKnownExpr();
+
+    auto expansionExpr =
+      cast<PackExpansionExpr>(expr->getSemanticsProvidingExpr());
+
+    // TODO: try to borrow the existing elements if we can do that within
+    // the limitations of the SIL representation.
+
+    // Allocate a tuple with a single component: the expected expansion type.
+    auto tupleTy =
+      SILType::getPrimitiveObjectType(
+        TupleType::get(TupleTypeElt(expectedParamType.getASTType()),
+                       SGF.getASTContext())->getCanonicalType());
+    auto &tupleTL = SGF.getTypeLowering(tupleTy);
+
+    auto tupleAddr = SGF.emitTemporaryAllocation(expansionExpr, tupleTy);
+
+    auto openedElementEnv = expansionExpr->getGenericEnvironment();
+    SGF.emitDynamicPackLoop(expansionExpr, formalPackType,
+                            packComponentIndex, /*limit*/ nullptr,
+                            openedElementEnv, /*reverse*/false,
+                            [&](SILValue indexWithinComponent,
+                                SILValue packExpansionIndex,
+                                SILValue packIndex) {
+      auto partialCleanup = CleanupHandle::invalid();
+      if (!tupleTL.isTrivial()) {
+        partialCleanup =
+          SGF.enterPartialDestroyPackCleanup(packAddr, formalPackType,
+                                             packComponentIndex,
+                                             indexWithinComponent);
+      }
+
+      // FIXME: push a partial-array cleanup to destroy the previous
+      // elements in this slice of the pack (then pop it before we exit
+      // this scope).
+
+      // Turn pack archetypes in the lowered pack expansion type into
+      // opened element archetypes.  This should work fine on SIL types
+      // since we're not changing any interesting structure.
+      auto expectedLoweredElementType =
+        openedElementEnv->mapPackTypeIntoElementContext(
+          expansionLoweredType.getPatternType())->getCanonicalType();
+
+      // Project the tuple element.  This projection uses the
+      // pack expansion index because the tuple is only for the
+      // projection elements.
+      auto eltAddr =
+        SGF.B.createTuplePackElementAddr(expansionExpr,
+                                         packExpansionIndex, tupleAddr,
+          SILType::getPrimitiveAddressType(expectedLoweredElementType));
+      auto &eltTL = SGF.getTypeLowering(eltAddr->getType());
+
+      // Evaluate the pattern expression into that address.
+      auto pattern = expansionExpr->getPatternExpr();
+      auto init = SGF.useBufferAsTemporary(eltAddr, eltTL);
+      SGF.emitExprInto(pattern, init.get());
+
+      // Deactivate any cleanup associated with that value.  In later
+      // iterations of this loop, we're managing this with our
+      // partial-array cleanup; after the loop, we're managing this
+      // with our full-tuple cleanup.
+      init->getManagedAddress().forward(SGF);
+
+      // Store the element address into the pack.
+      SGF.B.createPackElementSet(expansionExpr, eltAddr, packIndex,
+                                 packAddr);
+
+      // Deactivate the partial cleanup before we go out of scope.
+      if (partialCleanup.isValid())
+        SGF.Cleanups.forwardCleanup(partialCleanup);
+    });
+
+    // If the tuple is trivial, we don't need a cleanup.
+    if (tupleTL.isTrivial())
+      return CleanupHandle::invalid();
+
+    // Otherwise, push a full-tuple cleanup for it.
+    return SGF.enterDestroyCleanup(tupleAddr);
+  }
+
+  CleanupHandle emitScalarIntoPack(ArgumentSource &&arg,
+                                   AbstractionPattern origFormalType,
+                                   SILType expectedParamType,
+                                   bool consumed,
+                                   SILValue packAddr,
+                                   CanPackType formalPackType,
+                                   unsigned packComponentIndex) {
+    auto loc = arg.getLocation();
+
+    // TODO: make an effort to borrow the value if the parameter
+    // isn't consumed
+
+    // Create a temporary.
+    auto &paramTL = SGF.getTypeLowering(expectedParamType);
+    auto eltInit = SGF.emitTemporary(loc, paramTL);
+
+    // Emit the argument into the temporary within a scope.
+
+    FullExpr scope(SGF.Cleanups, CleanupLocation(loc));
+
+    std::move(arg).forwardInto(SGF, origFormalType, eltInit.get(), paramTL);
+
+    // Deactivate the destroy cleanup for the temporary itself within the
+    // scope, then pop the scope and recreate the cleanup.
+    auto eltAddr = eltInit->getManagedAddress().forward(SGF);
+    scope.pop();
+    auto cleanup = (paramTL.isTrivial()
+                      ? CleanupHandle::invalid()
+                      : SGF.enterDestroyCleanup(eltAddr));
+
+    // Store the address of the temporary into the pack.
+    auto packIndex = SGF.B.createScalarPackIndex(loc, packComponentIndex,
+                                                 formalPackType);
+    SGF.B.createPackElementSet(loc, eltAddr, packIndex, packAddr);
+
+    return cleanup;
+  }
+
   bool maybeEmitDelayed(Expr *expr, OriginalArgument original) {
     expr = expr->getSemanticsProvidingExpr();
 
@@ -3801,8 +4068,9 @@ void DelayedArgument::emitDefaultArgument(SILGenFunction &SGF,
 
   SmallVector<ManagedValue, 4> loweredArgs;
   SmallVector<DelayedArgument, 4> delayedArgs;
-  auto emitter = ArgEmitter(SGF, info.functionRepresentation, /*yield*/ false,
-                            /*coroutine*/ false, info.paramsToEmit, loweredArgs,
+  auto emitter = ArgEmitter(SGF, info.loc, info.functionRepresentation,
+                            /*yield*/ false, /*coroutine*/ false,
+                            info.paramsToEmit, loweredArgs,
                             delayedArgs, ForeignInfo{});
 
   emitter.emitSingleArg(ArgumentSource(info.loc, std::move(value)),
@@ -4039,17 +4307,32 @@ struct ParamLowering {
                                const ForeignInfo &foreign) {
     unsigned count = 0;
     if (!foreign.self.isStatic()) {
-      for (auto i : indices(substParams)) {
-        auto substParam = substParams[i];
-        if (substParam.isInOut()) {
-          count += 1;
-          continue;
+      size_t numOrigFormalParams =
+        (origFormalType.isTypeParameter()
+           ? substParams.size()
+           : origFormalType.getNumFunctionParams());
+
+      size_t nextSubstParamIndex = 0;
+      for (size_t i = 0; i != numOrigFormalParams; ++i) {
+        auto origParamType = origFormalType.getFunctionParamType(i);
+        if (origParamType.isPackExpansion()) {
+          count++;
+          origParamType.forEachPackExpandedComponent([&](AbstractionPattern) {
+            nextSubstParamIndex++;
+          });
+        } else {
+          auto substParam = substParams[nextSubstParamIndex++];
+          if (substParam.isInOut()) {
+            count += 1;
+          } else {
+            count += getFlattenedValueCount(
+                origParamType,
+                substParam.getParameterType()->getCanonicalType(),
+                ImportAsMemberStatus());
+          }
         }
-        count += getFlattenedValueCount(
-            origFormalType.getFunctionParamType(i),
-            substParam.getParameterType()->getCanonicalType(),
-            ImportAsMemberStatus());
       }
+      assert(nextSubstParamIndex == substParams.size());
     }
 
     if (foreign.error)
@@ -4150,7 +4433,7 @@ public:
             const ForeignInfo &foreign) && {
     auto params = lowering.claimParams(origFormalType, getParams(), foreign);
 
-    ArgEmitter emitter(SGF, lowering.Rep, /*yield*/ false,
+    ArgEmitter emitter(SGF, Loc, lowering.Rep, /*yield*/ false,
                        /*isForCoroutine*/ substFnType->isCoroutine(), params,
                        args, delayedArgs, foreign);
     emitter.emitPreparedArgs(std::move(Args), origFormalType);
@@ -4486,6 +4769,7 @@ RValue CallEmission::applyNormalCall(SGFContext C) {
 }
 
 static void emitPseudoFunctionArguments(SILGenFunction &SGF,
+                                        SILLocation applyLoc,
                                         AbstractionPattern origFnType,
                                         CanFunctionType substFnType,
                                         SmallVectorImpl<ManagedValue> &outVals,
@@ -4515,7 +4799,7 @@ RValue CallEmission::applyEnumElementConstructor(SGFContext C) {
 
   // Ignore metatype argument
   SmallVector<ManagedValue, 0> metatypeVal;
-  emitPseudoFunctionArguments(SGF,
+  emitPseudoFunctionArguments(SGF, uncurriedLoc,
                               AbstractionPattern(formalType),
                               formalType, metatypeVal,
                               std::move(*selfArg).forward());
@@ -4528,7 +4812,7 @@ RValue CallEmission::applyEnumElementConstructor(SGFContext C) {
     SmallVector<ManagedValue, 4> argVals;
     auto resultFnType = cast<FunctionType>(formalResultType);
 
-    emitPseudoFunctionArguments(SGF,
+    emitPseudoFunctionArguments(SGF, uncurriedLoc,
                                 AbstractionPattern(resultFnType),
                                 resultFnType, argVals,
                                 std::move(*callSite).forward());
@@ -5254,7 +5538,7 @@ void SILGenFunction::emitYield(SILLocation loc,
          origYield.getConvention()});
   }
 
-  ArgEmitter emitter(*this, fnType->getRepresentation(), /*yield*/ true,
+  ArgEmitter emitter(*this, loc, fnType->getRepresentation(), /*yield*/ true,
                      /*isForCoroutine*/ false, ClaimedParamsRef(substYieldTys),
                      yieldArgs, delayedArgs, ForeignInfo{});
 
@@ -6050,6 +6334,7 @@ static void collectFakeIndexParameters(SILGenFunction &SGF,
 }
 
 static void emitPseudoFunctionArguments(SILGenFunction &SGF,
+                                        SILLocation applyLoc,
                                         AbstractionPattern origFnType,
                                         CanFunctionType substFnType,
                                         SmallVectorImpl<ManagedValue> &outVals,
@@ -6065,7 +6350,7 @@ static void emitPseudoFunctionArguments(SILGenFunction &SGF,
   SmallVector<ManagedValue, 4> argValues;
   SmallVector<DelayedArgument, 2> delayedArgs;
 
-  ArgEmitter emitter(SGF, SILFunctionTypeRepresentation::Thin,
+  ArgEmitter emitter(SGF, applyLoc, SILFunctionTypeRepresentation::Thin,
                      /*yield*/ false,
                      /*isForCoroutine*/ false, ClaimedParamsRef(substParamTys),
                      argValues, delayedArgs, ForeignInfo{});
@@ -6080,7 +6365,8 @@ static void emitPseudoFunctionArguments(SILGenFunction &SGF,
 }
 
 PreparedArguments
-SILGenFunction::prepareSubscriptIndices(SubscriptDecl *subscript,
+SILGenFunction::prepareSubscriptIndices(SILLocation loc,
+                                        SubscriptDecl *subscript,
                                         SubstitutionMap subs,
                                         AccessStrategy strategy,
                                         ArgumentList *argList) {
@@ -6109,7 +6395,7 @@ SILGenFunction::prepareSubscriptIndices(SubscriptDecl *subscript,
 
   // Now, force it to be evaluated.
   SmallVector<ManagedValue, 4> argValues;
-  emitPseudoFunctionArguments(*this, origFnType, substFnType,
+  emitPseudoFunctionArguments(*this, loc, origFnType, substFnType,
                               argValues, std::move(args));
 
   // Finally, prepare the evaluated index expression. We might be calling
@@ -6739,7 +7025,8 @@ SILGenFunction::emitDynamicSubscriptGetterApply(SILLocation loc,
 }
 
 SmallVector<ManagedValue, 4> SILGenFunction::emitKeyPathSubscriptOperands(
-    SubscriptDecl *subscript, SubstitutionMap subs, ArgumentList *argList) {
+    SILLocation loc, SubscriptDecl *subscript,
+    SubstitutionMap subs, ArgumentList *argList) {
   Type interfaceType = subscript->getInterfaceType();
   CanFunctionType substFnType =
       subs ? cast<FunctionType>(interfaceType->castTo<GenericFunctionType>()
@@ -6753,14 +7040,14 @@ SmallVector<ManagedValue, 4> SILGenFunction::emitKeyPathSubscriptOperands(
 
   SmallVector<ManagedValue, 4> argValues;
   SmallVector<DelayedArgument, 2> delayedArgs;
-  ArgEmitter emitter(*this, fnType->getRepresentation(),
+  ArgEmitter emitter(*this, loc, fnType->getRepresentation(),
                      /*yield*/ false,
                      /*isForCoroutine*/ false,
                      ClaimedParamsRef(fnType->getParameters()), argValues,
                      delayedArgs, ForeignInfo{});
 
   auto prepared =
-      prepareSubscriptIndices(subscript, subs,
+      prepareSubscriptIndices(loc, subscript, subs,
                               // Strategy doesn't matter
                               AccessStrategy::getStorage(), argList);
   emitter.emitPreparedArgs(std::move(prepared), origFnType);

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -234,7 +234,7 @@ public:
 } // end anonymous namespace
 
 namespace {
-/// Cleanup to destroy an initialized variable.
+/// Cleanup to deallocate a now-uninitialized variable.
 class DeallocStackCleanup : public Cleanup {
   SILValue Addr;
 public:

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1072,6 +1072,15 @@ SILValue SILGenFunction::emitTemporaryAllocation(SILLocation loc, SILType ty,
   return alloc;
 }
 
+SILValue
+SILGenFunction::emitTemporaryPackAllocation(SILLocation loc, SILType ty) {
+  assert(ty.is<SILPackType>());
+  ty = ty.getObjectType();
+  auto *alloc = B.createAllocPack(loc, ty);
+  enterDeallocPackCleanup(alloc);
+  return alloc;
+}
+
 SILValue SILGenFunction::
 getBufferForExprResult(SILLocation loc, SILType ty, SGFContext C) {
   // If you change this, change manageBufferForExprResult below as well.
@@ -3969,7 +3978,8 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
 
       auto subscript = cast<SubscriptDecl>(decl);
       auto loweredArgs = SGF.emitKeyPathSubscriptOperands(
-          subscript, component.getDeclRef().getSubstitutions(),
+          E, subscript,
+          component.getDeclRef().getSubstitutions(),
           component.getSubscriptArgs());
 
       for (auto &arg : loweredArgs) {

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -3668,7 +3668,7 @@ LValue SILGenLValue::visitSubscriptExpr(SubscriptExpr *e,
     actorIso = getActorIsolation(decl);
 
   auto *argList = e->getArgs();
-  auto indices = SGF.prepareSubscriptIndices(decl, subs, strategy, argList);
+  auto indices = SGF.prepareSubscriptIndices(e, decl, subs, strategy, argList);
 
   CanType formalRValueType = getSubstFormalRValueType(e);
   lv.addMemberSubscriptComponent(SGF, e, decl, subs,

--- a/lib/SILGen/SILGenPack.cpp
+++ b/lib/SILGen/SILGenPack.cpp
@@ -1,0 +1,315 @@
+//===--- SILGenPack.cpp - Helper routines for lowering variadic packs -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "SILGenFunction.h"
+#include "Scope.h"
+#include "swift/AST/GenericEnvironment.h"
+
+using namespace swift;
+using namespace Lowering;
+
+namespace {
+/// Cleanup to deallocate a now-uninitialized pack.
+class DeallocPackCleanup : public Cleanup {
+  SILValue Addr;
+public:
+  DeallocPackCleanup(SILValue addr) : Addr(addr) {}
+
+  void emit(SILGenFunction &SGF, CleanupLocation l,
+            ForUnwind_t forUnwind) override {
+    SGF.B.createDeallocPack(l, Addr);
+  }
+
+  void dump(SILGenFunction &) const override {
+#ifndef NDEBUG
+    llvm::errs() << "DeallocPackCleanup\n"
+                 << "State:" << getState() << "\n"
+                 << "Addr:" << Addr << "\n";
+#endif
+  }
+};
+
+/// Cleanup to destroy all the values in a pack.
+class DestroyPackCleanup : public Cleanup {
+  SILValue Addr;
+  CanPackType FormalPackType;
+public:
+  DestroyPackCleanup(SILValue addr, CanPackType formalPackType)
+    : Addr(addr), FormalPackType(formalPackType) {}
+
+  void emit(SILGenFunction &SGF, CleanupLocation l,
+            ForUnwind_t forUnwind) override {
+    SGF.emitDestroyPack(l, Addr, FormalPackType);
+  }
+
+  void dump(SILGenFunction &) const override {
+#ifndef NDEBUG
+    llvm::errs() << "DestroyPackCleanup\n"
+                 << "State:" << getState() << "\n"
+                 << "Addr:" << Addr << "\n"
+                 << "FormalPackType:" << FormalPackType << "\n";
+#endif
+  }
+};
+
+/// Cleanup to destroy the preceding values in a pack-expansion
+/// component of a pack.
+class PartialDestroyPackCleanup : public Cleanup {
+  SILValue Addr;
+  unsigned PackComponentIndex;
+  SILValue LimitWithinComponent;
+  CanPackType FormalPackType;
+public:
+  PartialDestroyPackCleanup(SILValue addr,
+                            CanPackType formalPackType,
+                            unsigned packComponentIndex,
+                            SILValue limitWithinComponent)
+    : Addr(addr), PackComponentIndex(packComponentIndex),
+      LimitWithinComponent(limitWithinComponent),
+      FormalPackType(formalPackType) {}
+
+  void emit(SILGenFunction &SGF, CleanupLocation l,
+            ForUnwind_t forUnwind) override {
+    SGF.emitPartialDestroyPack(l, Addr, FormalPackType, PackComponentIndex,
+                               LimitWithinComponent);
+  }
+
+  void dump(SILGenFunction &) const override {
+#ifndef NDEBUG
+    llvm::errs() << "PartialDestroyPackCleanup\n"
+                 << "State:" << getState() << "\n"
+                 << "Addr:" << Addr << "\n"
+                 << "FormalPackType:" << FormalPackType << "\n"
+                 << "ComponentIndex:" << PackComponentIndex << "\n"
+                 << "LimitWithinComponent:" << LimitWithinComponent << "\n";
+#endif
+  }
+};
+} // end anonymous namespace
+
+CleanupHandle SILGenFunction::enterDeallocPackCleanup(SILValue temp) {
+  assert(temp->getType().isAddress() &&  "dealloc must have an address type");
+  assert(temp->getType().is<SILPackType>());
+  Cleanups.pushCleanup<DeallocPackCleanup>(temp);
+  return Cleanups.getTopCleanup();
+}
+
+CleanupHandle SILGenFunction::enterDestroyPackCleanup(SILValue addr,
+                                                   CanPackType formalPackType) {
+  Cleanups.pushCleanup<DestroyPackCleanup>(addr, formalPackType);
+  return Cleanups.getTopCleanup();
+}
+
+CleanupHandle
+SILGenFunction::enterPartialDestroyPackCleanup(SILValue addr,
+                                               CanPackType formalPackType,
+                                               unsigned packComponentIndex,
+                                               SILValue limitWithinComponent) {
+  Cleanups.pushCleanup<PartialDestroyPackCleanup>(addr, formalPackType,
+                                                  packComponentIndex,
+                                                  limitWithinComponent);
+  return Cleanups.getTopCleanup();
+}
+
+void SILGenFunction::emitDestroyPack(SILLocation loc, SILValue packAddr,
+                                     CanPackType formalPackType) {
+  auto packTy = packAddr->getType().castTo<SILPackType>();
+
+  // Destroy each of the elements of the pack.
+  for (auto componentIndex : indices(packTy->getElementTypes())) {
+    auto eltTy = packTy->getSILElementType(componentIndex);
+
+    // If it's an expansion component, emit a "partial"-destroy loop.
+    if (auto expansion = eltTy.getAs<PackExpansionType>()) {
+      // We can skip this if the whole thing is trivial.
+      auto &patternTypeTL = getTypeLowering(
+              SILType::getPrimitiveAddressType(expansion.getPatternType()));
+      if (patternTypeTL.isTrivial()) continue;
+
+      emitPartialDestroyPack(loc, packAddr, formalPackType, componentIndex,
+                             /*limit*/ nullptr);
+
+    // If it's a scalar component, project and destroy it.
+    } else {
+      // We can skip this if the element is trivial.
+      auto &eltTL = getTypeLowering(eltTy);
+      if (eltTL.isTrivial()) continue;
+
+      // Index into the pack and extract the component.
+      auto packIndex =
+        B.createScalarPackIndex(loc, componentIndex, formalPackType);
+      auto eltAddr =
+        B.createPackElementGet(loc, packIndex, packAddr, eltTy);
+      B.createDestroyAddr(loc, eltAddr);
+    }
+  }
+}
+
+static bool isPatternInvariantToExpansion(CanType patternType,
+                                          CanPackArchetypeType countArchetype) {
+  return patternType.findIf([&](CanType type) {
+    if (auto archetype = dyn_cast<PackArchetypeType>(type)) {
+      return archetype == countArchetype ||
+             archetype->getReducedShape() == countArchetype->getReducedShape();
+    }
+    return false;
+  });
+}
+
+static std::pair<GenericEnvironment*, SILType>
+deriveOpenedElementTypeForPackExpansion(SILGenModule &SGM,
+                                        CanPackExpansionType expansion) {
+  // If the pattern type is invariant to the expansion, we don't need
+  // to open anything.
+  auto countArchetype = cast<PackArchetypeType>(expansion.getCountType());
+  auto patternType = expansion.getPatternType();
+  if (isPatternInvariantToExpansion(patternType, countArchetype)) {
+    return std::make_pair(nullptr,
+                          SILType::getPrimitiveAddressType(patternType));
+  }
+
+  // Otherwise, make a new opened element environment for the signature
+  // of the archetype we're expanding over.
+  // TODO: consider minimizing this signature down to only what we need to
+  // destroy the elements
+  auto context =
+    OpenedElementContext::createForContextualExpansion(SGM.getASTContext(),
+                                                       expansion);
+  auto elementType =
+    context.environment->mapPackTypeIntoElementContext(patternType)
+                       ->getCanonicalType();
+  return std::make_pair(context.environment,
+                        SILType::getPrimitiveAddressType(elementType));
+}
+
+void SILGenFunction::emitPartialDestroyPack(SILLocation loc, SILValue packAddr,
+                                            CanPackType formalPackType,
+                                            unsigned componentIndex,
+                                            SILValue limitWithinComponent) {
+  auto packTy = packAddr->getType().castTo<SILPackType>();
+  auto packExpansionTy =
+    cast<PackExpansionType>(packTy->getElementType(componentIndex));
+
+  auto result = deriveOpenedElementTypeForPackExpansion(SGM, packExpansionTy);
+  auto elementEnv = result.first;
+  auto elementTy = result.second;
+
+  emitDynamicPackLoop(loc, formalPackType, componentIndex, limitWithinComponent,
+                      elementEnv, /*reverse*/ true,
+                      [&](SILValue indexWithinComponent,
+                          SILValue packExpansionIndex,
+                          SILValue packIndex) {
+    auto eltAddr = B.createPackElementGet(loc, packIndex, packAddr, elementTy);
+    B.createDestroyAddr(loc, eltAddr);
+  });
+}
+
+void SILGenFunction::emitDynamicPackLoop(SILLocation loc,
+                                         CanPackType formalPackType,
+                                         unsigned componentIndex,
+                                         SILValue limitWithinComponent,
+                                         GenericEnvironment *openedElementEnv,
+                                         bool reverse,
+                      llvm::function_ref<void(SILValue indexWithinComponent,
+                                              SILValue packExpansionIndex,
+                                              SILValue packIndex)> emitBody) {
+  assert(isa<PackExpansionType>(formalPackType.getElementType(componentIndex)));
+  ASTContext &ctx = SGM.getASTContext();
+
+  auto wordTy = SILType::getBuiltinWordType(ctx);
+  auto boolTy = SILType::getBuiltinIntegerType(1, ctx);
+  auto zero = B.createIntegerLiteral(loc, wordTy, 0);
+  auto one = B.createIntegerLiteral(loc, wordTy, 1);
+
+  // The formal type of the component of the pack that we're iterating over.
+  // If this isn't the entire pack, we'll dynamically index into just the
+  // expansion component and then compose that into an index into the larger
+  // pack.
+  CanPackType formalDynamicPackType = formalPackType;
+  bool needsSlicing = formalPackType->getNumElements() != 1;
+  if (needsSlicing) {
+    formalDynamicPackType =
+      CanPackType::get(ctx, formalPackType.getElementType(componentIndex));
+  }
+
+  // If the caller didn't give us a limit, use the full length of the
+  // pack expansion.
+  if (!limitWithinComponent) {
+    limitWithinComponent = B.createPackLength(loc, formalDynamicPackType);
+  }
+
+  // Branch to the loop condition block, passing the initial value
+  // (0 if forward, the limit if reverse).
+  auto condBB = createBasicBlock();
+  B.createBranch(loc, condBB, { reverse ? limitWithinComponent : zero });
+
+  // Condition block:
+  B.emitBlock(condBB);
+  auto incomingIndex = condBB->createPhiArgument(wordTy, OwnershipKind::None);
+
+  // Branch to the end block if the incoming index value is equal to the
+  // end index (the limit if forward, 0 if reverse).
+  auto atEnd =
+    B.createBuiltinBinaryFunction(loc, "cmp_eq", wordTy, boolTy,
+                                  { incomingIndex,
+                                    reverse ? zero : limitWithinComponent });
+  auto bodyBB = createBasicBlock();
+  auto endBB = createBasicBlockAfter(bodyBB);
+  B.createCondBranch(loc, atEnd, endBB, bodyBB);
+
+  // Body block:
+  B.emitBlock(bodyBB);
+
+  // The index to use in this iteration (the incoming index if forward,
+  // the incoming index - 1 if reverse)
+  SILValue curIndex = incomingIndex;
+  if (reverse) {
+    curIndex = B.createBuiltinBinaryFunction(loc, "sub", wordTy, wordTy,
+                                             { incomingIndex, one });
+  }
+
+  // Construct the dynamic pack index into the component.
+  SILValue packExpansionIndex =
+    B.createDynamicPackIndex(loc, curIndex, formalDynamicPackType);
+
+  // If there's an opened element environment, open it here.
+  if (openedElementEnv) {
+    B.createOpenPackElement(loc, packExpansionIndex, openedElementEnv);
+  }
+
+  // If there are multiple pack components in the overall pack, construct
+  // the overall pack index.
+  SILValue packIndex = packExpansionIndex;
+  if (needsSlicing) {
+    packIndex = B.createPackPackIndex(loc, componentIndex, packIndex,
+                                      formalPackType);
+  }
+
+  // Emit the loop body in a scope as a convenience, since it's necessary
+  // to avoid dominance problems anyway.
+  {
+    FullExpr scope(Cleanups, CleanupLocation(loc));
+    emitBody(curIndex, packExpansionIndex, packIndex);
+  }
+
+  // The index to pass to the loop condition block (the current index + 1
+  // if forward, the current index if reverse)
+  SILValue outgoingIndex = curIndex;
+  if (!reverse) {
+    outgoingIndex = B.createBuiltinBinaryFunction(loc, "add", wordTy, wordTy,
+                                                  { curIndex, one });
+  }
+  B.createBranch(loc, condBB, {outgoingIndex});
+
+  // End block:
+  B.emitBlock(endBB);
+}

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2198,6 +2198,11 @@ ParamSpecifierRequest::evaluate(Evaluator &evaluator,
   assert(typeRepr != nullptr && "Should call setSpecifier() on "
          "synthesized parameter declarations");
 
+  // Look through top-level pack expansions.  These specifiers are
+  // part of what's repeated.
+  if (auto expansion = dyn_cast<PackExpansionTypeRepr>(typeRepr))
+    typeRepr = expansion->getPatternType();
+
   // Look through parens here; other than parens, specifiers
   // must appear at the top level of a parameter type.
   auto *nestedRepr = typeRepr->getWithoutParens();

--- a/test/SILGen/variadic-generics.swift
+++ b/test/SILGen/variadic-generics.swift
@@ -1,0 +1,79 @@
+// RUN: %target-swift-emit-silgen -enable-experimental-feature VariadicGenerics %s | %FileCheck %s
+
+func receive_simple<T...>(_ args: repeat each T) {}
+func receive_simple_owned<T...>(_ args: repeat __owned each T) {}
+
+// CHECK-LABEL: @$s4main12scalar_test01i1f1sySi_SfSStF
+// CHECK:         [[PACK:%.*]] = alloc_pack $Pack{Int, Float, String}
+//   Copy i into a temporary and insert that into the pack.
+// CHECK-NEXT:    [[INT_TEMP:%.*]] = alloc_stack $Int
+// CHECK-NEXT:    store %0 to [trivial] [[INT_TEMP]] : $*Int
+// CHECK-NEXT:    [[INT_INDEX:%.*]] = scalar_pack_index 0 of $Pack{Int, Float, String}
+// CHECK-NEXT:    pack_element_set [[INT_TEMP]] : $*Int into [[INT_INDEX]] of [[PACK]] : $*Pack{Int, Float, String}
+//   Copy f into a temporary and insert that into the pack.
+// CHECK-NEXT:    [[FLOAT_TEMP:%.*]] = alloc_stack $Float
+// CHECK-NEXT:    store %1 to [trivial] [[FLOAT_TEMP]] : $*Float
+// CHECK-NEXT:    [[FLOAT_INDEX:%.*]] = scalar_pack_index 1 of $Pack{Int, Float, String}
+// CHECK-NEXT:    pack_element_set [[FLOAT_TEMP]] : $*Float into [[FLOAT_INDEX]] of [[PACK]] : $*Pack{Int, Float, String}
+//   Copy s into a temporary and insert that into the pack.
+//   TODO: do this with a borrow
+// CHECK-NEXT:    [[STRING_TEMP:%.*]] = alloc_stack $String
+// CHECK-NEXT:    [[STRING_COPY:%.*]] = copy_value %2 : $String
+// CHECK-NEXT:    store [[STRING_COPY]] to [init] [[STRING_TEMP]] : $*String
+// CHECK-NEXT:    [[STRING_INDEX:%.*]] = scalar_pack_index 2 of $Pack{Int, Float, String}
+// CHECK-NEXT:    pack_element_set [[STRING_TEMP]] : $*String into [[STRING_INDEX]] of [[PACK]] : $*Pack{Int, Float, String}
+//   Perform the call.
+// CHECK-NEXT:    // function_ref
+// CHECK-NEXT:    [[FN:%.*]] = function_ref @$s4main14receive_simpleyyxxQplF : $@convention(thin) <τ_0_0...> (@pack_guaranteed Pack{repeat each τ_0_0}) -> ()
+// CHECK-NEXT:    apply [[FN]]<Pack{Int, Float, String}>([[PACK]])
+//   Clean up.
+// CHECK-NEXT:    destroy_addr [[STRING_TEMP]] : $*String
+// CHECK-NEXT:    dealloc_stack [[STRING_TEMP]] : $*String
+// CHECK-NEXT:    dealloc_stack [[FLOAT_TEMP]] : $*Float
+// CHECK-NEXT:    dealloc_stack [[INT_TEMP]] : $*Int
+// CHECK-NEXT:    dealloc_pack [[PACK]] : $*Pack{Int, Float, String}
+func scalar_test0(i: Int, f: Float, s: String) {
+  receive_simple(i, f, s)
+}
+
+// CHECK-LABEL: @$s4main12scalar_test11i1f1sySi_SfSStF
+// CHECK:         [[PACK:%.*]] = alloc_pack $Pack{Int, Float, String}
+//   Copy i into a temporary and insert that into the pack.
+// CHECK-NEXT:    [[INT_TEMP:%.*]] = alloc_stack $Int
+// CHECK-NEXT:    store %0 to [trivial] [[INT_TEMP]] : $*Int
+// CHECK-NEXT:    [[INT_INDEX:%.*]] = scalar_pack_index 0 of $Pack{Int, Float, String}
+// CHECK-NEXT:    pack_element_set [[INT_TEMP]] : $*Int into [[INT_INDEX]] of [[PACK]] : $*Pack{Int, Float, String}
+//   Copy f into a temporary and insert that into the pack.
+// CHECK-NEXT:    [[FLOAT_TEMP:%.*]] = alloc_stack $Float
+// CHECK-NEXT:    store %1 to [trivial] [[FLOAT_TEMP]] : $*Float
+// CHECK-NEXT:    [[FLOAT_INDEX:%.*]] = scalar_pack_index 1 of $Pack{Int, Float, String}
+// CHECK-NEXT:    pack_element_set [[FLOAT_TEMP]] : $*Float into [[FLOAT_INDEX]] of [[PACK]] : $*Pack{Int, Float, String}
+//   Copy s into a temporary and insert that into the pack.
+//   TODO: do this with a borrow
+// CHECK-NEXT:    [[STRING_TEMP:%.*]] = alloc_stack $String
+// CHECK-NEXT:    [[STRING_COPY:%.*]] = copy_value %2 : $String
+// CHECK-NEXT:    store [[STRING_COPY]] to [init] [[STRING_TEMP]] : $*String
+// CHECK-NEXT:    [[STRING_INDEX:%.*]] = scalar_pack_index 2 of $Pack{Int, Float, String}
+// CHECK-NEXT:    pack_element_set [[STRING_TEMP]] : $*String into [[STRING_INDEX]] of [[PACK]] : $*Pack{Int, Float, String}
+//   Perform the call.
+// CHECK-NEXT:    // function_ref
+// CHECK-NEXT:    [[FN:%.*]] = function_ref  @$s4main20receive_simple_ownedyyxxQpnlF : $@convention(thin) <τ_0_0...> (@pack_owned Pack{repeat each τ_0_0}) -> ()
+// CHECK-NEXT:    apply [[FN]]<Pack{Int, Float, String}>([[PACK]])
+//   Clean up.
+// CHECK-NEXT:    dealloc_stack [[STRING_TEMP]] : $*String
+// CHECK-NEXT:    dealloc_stack [[FLOAT_TEMP]] : $*Float
+// CHECK-NEXT:    dealloc_stack [[INT_TEMP]] : $*Int
+// CHECK-NEXT:    dealloc_pack [[PACK]] : $*Pack{Int, Float, String}
+func scalar_test1(i: Int, f: Float, s: String) {
+  receive_simple_owned(i, f, s)
+}
+
+#if false
+func pack_test0<T...>(args: repeat each T) {
+  receive_simple(repeat each args)
+}
+
+func pack_test1<T...>(args: repeat each T) {
+  receive_simple_owned(repeat each args)
+}
+#endif


### PR DESCRIPTION
This PR sets up the basic representation necessary to handle pack expansions properly throughout SILGen, and it gets fully-concrete pack arguments working, at least in some cases.  It doesn't yet handle pack expansions in pack arguments, so no forwarding for now.  Still, it's pretty good incremental progress.