### PR TITLE
[ConstraintSystem] Add cache for conformance lookups

### DIFF
--- a/include/swift/Sema/CSBindings.h
+++ b/include/swift/Sema/CSBindings.h
@@ -195,8 +195,7 @@ struct LiteralRequirement {
   /// \param canBeNil The flag that determines whether given type
   /// variable requires all of its bindings to be optional.
   ///
-  /// \param useDC The declaration context in which this literal
-  /// requirement is used.
+  /// \param CS The constraint system this literal requirement belongs to.
   ///
   /// \returns a pair of bool and a type:
   ///    - bool, true if binding covers given literal protocol;
@@ -204,14 +203,14 @@ struct LiteralRequirement {
   ///      to cover given literal protocol;
   std::pair<bool, Type> isCoveredBy(const PotentialBinding &binding,
                                     bool canBeNil,
-                                    DeclContext *useDC) const;
+                                    ConstraintSystem &CS) const;
 
   /// Determines whether literal protocol associated with this
   /// meta-information is viable for inclusion as a defaultable binding.
   bool viableAsBinding() const { return !isCovered() && hasDefaultType(); }
 
 private:
-  bool isCoveredBy(Type type, DeclContext *useDC) const;
+  bool isCoveredBy(Type type, ConstraintSystem &CS) const;
 };
 
 struct PotentialBindings {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -425,8 +425,7 @@ namespace {
       // the literal.
       if (otherArgTy && otherArgTy->getAnyNominal()) {
         if (otherArgTy->isEqual(paramTy) &&
-            TypeChecker::conformsToProtocol(
-                otherArgTy, literalProto, CS.DC->getParentModule())) {
+            CS.lookupConformance(otherArgTy, literalProto)) {
           return true;
         }
       } else if (Type defaultType =

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8425,8 +8425,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
     }
 
     // Check whether this type conforms to the protocol.
-    auto conformance = DC->getParentModule()->lookupConformance(
-        type, protocol, /*allowMissing=*/true);
+    auto conformance = lookupConformance(type, protocol);
     if (conformance) {
       return recordConformance(conformance);
     }
@@ -8546,8 +8545,7 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyConformsToConstraint(
 
       if (auto rawValue = isRawRepresentable(*this, type)) {
         if (!rawValue->isTypeVariableOrMember() &&
-            TypeChecker::conformsToProtocol(rawValue, protocol,
-                                            DC->getParentModule())) {
+            lookupConformance(rawValue, protocol)) {
           auto *fix = UseRawValue::create(*this, type, protocolTy, loc);
           // Since this is a conformance requirement failure (where the
           // source is most likely an argument), let's increase its impact
@@ -8706,11 +8704,9 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyTransitivelyConformsTo(
 
   auto *protocol = protocolTy->castTo<ProtocolType>()->getDecl();
 
-  auto *M = DC->getParentModule();
-
   // First, let's check whether the type itself conforms,
   // if it does - we are done.
-  if (M->lookupConformance(resolvedTy, protocol))
+  if (lookupConformance(resolvedTy, protocol))
     return SolutionKind::Solved;
 
   // If the type doesn't conform, let's check whether
@@ -8782,10 +8778,9 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyTransitivelyConformsTo(
     }
   }
 
-  return llvm::any_of(typesToCheck,
-                      [&](Type type) {
-                        return bool(M->lookupConformance(type, protocol));
-                      })
+  return llvm::any_of(
+             typesToCheck,
+             [&](Type type) { return bool(lookupConformance(type, protocol)); })
              ? SolutionKind::Solved
              : SolutionKind::Error;
 }
@@ -9372,7 +9367,7 @@ static bool mayBeForKeyPathSubscriptWithoutLabel(ConstraintSystem &cs,
 /// This is useful to figure out whether it makes sense to
 /// perform dynamic member lookup or not.
 static bool
-allFromConditionalConformances(DeclContext *DC, Type baseTy,
+allFromConditionalConformances(ConstraintSystem &cs, Type baseTy,
                                ArrayRef<OverloadChoice> candidates) {
   auto *NTD = baseTy->getAnyNominal();
   if (!NTD)
@@ -9391,8 +9386,7 @@ allFromConditionalConformances(DeclContext *DC, Type baseTy,
     }
 
     if (auto *protocol = candidateDC->getSelfProtocolDecl()) {
-      auto conformance = DC->getParentModule()->lookupConformance(
-          baseTy, protocol);
+      auto conformance = cs.lookupConformance(baseTy, protocol);
       if (!conformance.isConcrete())
         return false;
 
@@ -10130,7 +10124,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclNameRef memberName,
     const auto &candidates = result.ViableCandidates;
 
     if ((candidates.empty() ||
-         allFromConditionalConformances(DC, instanceTy, candidates)) &&
+         allFromConditionalConformances(*this, instanceTy, candidates)) &&
         !isSelfRecursiveKeyPathDynamicMemberLookup(*this, baseTy,
                                                    memberLocator)) {
       auto &ctx = getASTContext();
@@ -10713,7 +10707,8 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
       // called within extensions to that type (usually adding 'clamp').
       bool treatAsViable =
           (member.isSimpleName("min") || member.isSimpleName("max")) &&
-          allFromConditionalConformances(DC, baseTy, result.ViableCandidates);
+          allFromConditionalConformances(*this, baseTy,
+                                         result.ViableCandidates);
 
       generateConstraints(
           candidates, memberTy, outerAlternatives, useDC, locator, llvm::None,
@@ -11121,8 +11116,7 @@ ConstraintSystem::simplifyValueWitnessConstraint(
   // conformance already?
   auto proto = requirement->getDeclContext()->getSelfProtocolDecl();
   assert(proto && "Value witness constraint for a non-requirement");
-  auto conformance = useDC->getParentModule()->lookupConformance(
-      baseObjectType, proto);
+  auto conformance = lookupConformance(baseObjectType, proto);
   if (!conformance)
     return fail();
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2175,8 +2175,7 @@ void DisjunctionChoiceProducer::partitionGenericOperators(
     if (auto *refined = dyn_cast<ProtocolDecl>(nominal))
       return refined->inheritsFrom(protocol);
 
-    return (bool)TypeChecker::conformsToProtocol(nominal->getDeclaredType(), protocol,
-                                                 CS.DC->getParentModule());
+    return bool(CS.lookupConformance(nominal->getDeclaredType(), protocol));
   };
 
   // Gather Numeric and Sequence overloads into separate buckets.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1196,9 +1196,8 @@ llvm::Optional<Type> ConstraintSystem::isSetType(Type type) {
   return llvm::None;
 }
 
-Type ConstraintSystem::getFixedTypeRecursive(Type type,
-                                             TypeMatchOptions &flags,
-                                             bool wantRValue) const {
+Type ConstraintSystem::getFixedTypeRecursive(Type type, TypeMatchOptions &flags,
+                                             bool wantRValue) {
 
   if (wantRValue)
     type = type->getRValueType();
@@ -3822,7 +3821,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
 namespace {
 
 struct TypeSimplifier {
-  const ConstraintSystem &CS;
+  ConstraintSystem &CS;
   llvm::function_ref<Type(TypeVariableType *)> GetFixedTypeFn;
 
   struct ActivePackExpansion {
@@ -3831,7 +3830,7 @@ struct TypeSimplifier {
   };
   SmallVector<ActivePackExpansion, 4> ActivePackExpansions;
 
-  TypeSimplifier(const ConstraintSystem &CS,
+  TypeSimplifier(ConstraintSystem &CS,
                  llvm::function_ref<Type(TypeVariableType *)> getFixedTypeFn)
     : CS(CS), GetFixedTypeFn(getFixedTypeFn) {}
 
@@ -3979,8 +3978,7 @@ struct TypeSimplifier {
       if (lookupBaseType->mayHaveMembers() ||
           lookupBaseType->is<PackType>()) {
         auto *proto = assocType->getProtocol();
-        auto conformance = CS.DC->getParentModule()->lookupConformance(
-          lookupBaseType, proto);
+        auto conformance = CS.lookupConformance(lookupBaseType, proto);
         if (!conformance) {
           // If the base type doesn't conform to the associatedtype's protocol,
           // there will be a missing conformance fix applied in diagnostic mode,
@@ -4011,11 +4009,11 @@ struct TypeSimplifier {
 } // end anonymous namespace
 
 Type ConstraintSystem::simplifyTypeImpl(Type type,
-    llvm::function_ref<Type(TypeVariableType *)> getFixedTypeFn) const {
+    llvm::function_ref<Type(TypeVariableType *)> getFixedTypeFn) {
   return type.transform(TypeSimplifier(*this, getFixedTypeFn));
 }
 
-Type ConstraintSystem::simplifyType(Type type) const {
+Type ConstraintSystem::simplifyType(Type type) {
   if (!type->hasTypeVariable())
     return type;
 
@@ -6098,15 +6096,12 @@ bool constraints::hasAppliedSelf(const OverloadChoice &choice,
 /// Check whether given type conforms to `RawRepresentable` protocol
 /// and return the witness type.
 Type constraints::isRawRepresentable(ConstraintSystem &cs, Type type) {
-  auto *DC = cs.DC;
-
   auto rawReprType = TypeChecker::getProtocol(
       cs.getASTContext(), SourceLoc(), KnownProtocolKind::RawRepresentable);
   if (!rawReprType)
     return Type();
 
-  auto conformance = TypeChecker::conformsToProtocol(type, rawReprType,
-                                                     DC->getParentModule());
+  auto conformance = cs.lookupConformance(type, rawReprType);
   if (conformance.isInvalid())
     return Type();
 
@@ -7342,6 +7337,21 @@ bool ConstraintSystem::participatesInInference(ClosureExpr *closure) const {
   return true;
 }
 
+ProtocolConformanceRef
+ConstraintSystem::lookupConformance(Type type, ProtocolDecl *protocol) {
+  auto cacheKey = std::make_pair(type.getPointer(), protocol);
+
+  auto cachedConformance = Conformances.find(cacheKey);
+  if (cachedConformance != Conformances.end())
+    return cachedConformance->second;
+
+  auto conformance =
+      DC->getParentModule()->lookupConformance(type, protocol,
+                                               /*allowMissing=*/true);
+  Conformances[cacheKey] = conformance;
+  return conformance;
+}
+
 TypeVarBindingProducer::TypeVarBindingProducer(BindingSet &bindings)
     : BindingProducer(bindings.getConstraintSystem(),
                       bindings.getTypeVariable()->getImpl().getLocator()),
@@ -7474,7 +7484,7 @@ bool TypeVarBindingProducer::requiresOptionalAdjustment(
     auto *proto = CS.getASTContext().getProtocol(
          KnownProtocolKind::ExpressibleByNilLiteral);
 
-    return !proto->getParentModule()->lookupConformance(type, proto);
+    return !CS.lookupConformance(type, proto);
   } else if (binding.isDefaultableBinding() && binding.BindingType->isAny()) {
     return true;
   }

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -358,6 +358,7 @@ protocol P { }
 struct PArray<T> { }
 
 extension PArray : ExpressibleByArrayLiteral where T: P {
+  // expected-note@-1 {{requirement from conditional conformance of 'PArray<String>' to 'ExpressibleByArrayLiteral'}}
   typealias ArrayLiteralElement = T
 
   init(arrayLiteral elements: T...) { }
@@ -367,7 +368,7 @@ extension Int: P { }
 
 func testConditional(i: Int, s: String) {
   let _: PArray<Int> = [i, i, i]
-  let _: PArray<String> = [s, s, s] // expected-error{{cannot convert value of type '[String]' to specified type 'PArray<String>'}}
+  let _: PArray<String> = [s, s, s] // expected-error{{generic struct 'PArray' requires that 'String' conform to 'P'}}
 }
 
 


### PR DESCRIPTION
`lookupConformance` request is not cached and constraint solver performs a lot of them for the same type
(i.e. during disjunction solving), let's try to cache previously performed requests to see whether additional
memory use is worth the performance benefit.


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
