### PR TITLE
EscapeUtils: add a computational limit to avoid quadratic complexity in some corner cases.

### DIFF
--- a/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Analysis/AliasAnalysis.swift
@@ -98,14 +98,14 @@ struct AliasAnalysis {
       },
 
       // isAddrVisibleFromObj
-      { (bridgedCtxt: BridgedPassContext, bridgedAddr: BridgedValue, bridgedObj: BridgedValue) -> Bool in
+      { (bridgedCtxt: BridgedPassContext, bridgedAddr: BridgedValue, bridgedObj: BridgedValue, complexityBudget: Int) -> Bool in
         let context = FunctionPassContext(_bridged: bridgedCtxt)
         let addr = bridgedAddr.value.at(AliasAnalysis.getPtrOrAddressPath(for: bridgedAddr.value))
 
         // This is similar to `canReferenceSameFieldFn`, except that all addresses of all objects are
         // considered which are transitively visible from `bridgedObj`.
         let anythingReachableFromObj = bridgedObj.value.at(SmallProjectionPath(.anything))
-        return addr.canAddressAlias(with: anythingReachableFromObj, context)
+        return addr.canAddressAlias(with: anythingReachableFromObj, complexityBudget: complexityBudget, context)
       },
 
       // canReferenceSameFieldFn

--- a/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
+++ b/SwiftCompilerSources/Sources/Optimizer/Utilities/OptUtils.swift
@@ -221,15 +221,15 @@ extension ProjectedValue {
   /// `%s`.canAddressAlias(with: `%2`) -> true
   /// `%1`.canAddressAlias(with: `%2`) -> false
   ///
-  func canAddressAlias(with rhs: ProjectedValue, _ context: some Context) -> Bool {
+  func canAddressAlias(with rhs: ProjectedValue, complexityBudget: Int = Int.max, _ context: some Context) -> Bool {
     // self -> rhs will succeed (= return false) if self is a non-escaping "local" object,
     // but not necessarily rhs.
-    if !isEscaping(using: EscapesToValueVisitor(target: rhs), context) {
+    if !isEscaping(using: EscapesToValueVisitor(target: rhs), complexityBudget: complexityBudget, context) {
       return false
     }
     // The other way round: rhs -> self will succeed if rhs is a non-escaping "local" object,
     // but not necessarily self.
-    if !rhs.isEscaping(using: EscapesToValueVisitor(target: self), context) {
+    if !rhs.isEscaping(using: EscapesToValueVisitor(target: self), complexityBudget: complexityBudget, context) {
       return false
     }
     return true

--- a/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/AliasAnalysis.h
@@ -105,6 +105,12 @@ private:
   /// scopes.
   llvm::SmallPtrSet<SILInstruction *, 16> immutableScopeComputed;
 
+  /// Used to limit complexity.
+  /// The side is computed lazily. Therefore the actual value depends on what
+  /// SIL modifications an optimization pass already performed when the size
+  /// is requested.
+  int estimatedFunctionSize = -1;
+
   AliasResult aliasAddressProjection(SILValue V1, SILValue V2,
                                      SILValue O1, SILValue O2);
 
@@ -209,6 +215,8 @@ public:
 
   /// Returns true if `lhs` can reference the same field as `rhs`.
   bool canReferenceSameField(SILValue lhs, SILValue rhs);
+
+  int getEstimatedFunctionSize(SILValue valueInFunction);
 };
 
 

--- a/include/swift/SILOptimizer/OptimizerBridging.h
+++ b/include/swift/SILOptimizer/OptimizerBridging.h
@@ -133,10 +133,12 @@ typedef bool (* _Nonnull AliasAnalysisEscaping2InstFn)(
       BridgedPassContext context, BridgedValue, BridgedInstruction);
 typedef bool (* _Nonnull AliasAnalysisEscaping2ValFn)(
       BridgedPassContext context, BridgedValue, BridgedValue);
+typedef bool (* _Nonnull AliasAnalysisEscaping2ValIntFn)(
+      BridgedPassContext context, BridgedValue, BridgedValue, SwiftInt);
 
 void AliasAnalysis_register(AliasAnalysisGetMemEffectFn getMemEffectsFn,
                             AliasAnalysisEscaping2InstFn isObjReleasedFn,
-                            AliasAnalysisEscaping2ValFn isAddrVisibleFromObjFn,
+                            AliasAnalysisEscaping2ValIntFn isAddrVisibleFromObjFn,
                             AliasAnalysisEscaping2ValFn mayPointToSameAddrFn);
 
 BridgedSlab PassContext_getNextSlab(BridgedSlab slab);

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -524,7 +524,7 @@ bool AliasAnalysis::typesMayAlias(SILType T1, SILType T2,
 // Bridging functions.
 static AliasAnalysisGetMemEffectFn getMemEffectsFunction = nullptr;
 static AliasAnalysisEscaping2InstFn isObjReleasedFunction = nullptr;
-static AliasAnalysisEscaping2ValFn isAddrVisibleFromObjFunction = nullptr;
+static AliasAnalysisEscaping2ValIntFn isAddrVisibleFromObjFunction = nullptr;
 static AliasAnalysisEscaping2ValFn canReferenceSameFieldFunction = nullptr;
 
 /// The main AA entry point. Performs various analyses on V1, V2 in an attempt
@@ -716,7 +716,7 @@ BridgedMemoryBehavior AliasAnalysis_getMemBehavior(BridgedAliasAnalysis aa,
 
 void AliasAnalysis_register(AliasAnalysisGetMemEffectFn getMemEffectsFn,
                             AliasAnalysisEscaping2InstFn isObjReleasedFn,
-                            AliasAnalysisEscaping2ValFn isAddrVisibleFromObjFn,
+                            AliasAnalysisEscaping2ValIntFn isAddrVisibleFromObjFn,
                             AliasAnalysisEscaping2ValFn canReferenceSameFieldFn) {
   getMemEffectsFunction = getMemEffectsFn;
   isObjReleasedFunction = isObjReleasedFn;
@@ -742,7 +742,16 @@ bool AliasAnalysis::isObjectReleasedByInst(SILValue obj, SILInstruction *inst) {
 
 bool AliasAnalysis::isAddrVisibleFromObject(SILValue addr, SILValue obj) {
   if (isAddrVisibleFromObjFunction) {
-    return isAddrVisibleFromObjFunction({PM->getSwiftPassInvocation()}, {addr}, {obj}) != 0;
+    // This function is called a lot from ARCSequenceOpt and ReleaseHoisting.
+    // To avoid quadratic complexity for large functions, we limit the amount
+    // of work what the EscapeUtils are allowed to to.
+    // This keeps the complexity linear.
+    //
+    // This arbitrary limit is good enough for almost all functions. It lets
+    // the EscapeUtils do several hundred up/down walks which is much more than
+    // needed in most cases.
+    SwiftInt complexityLimit = 1000000 / getEstimatedFunctionSize(addr);
+    return isAddrVisibleFromObjFunction({PM->getSwiftPassInvocation()}, {addr}, {obj}, complexityLimit) != 0;
   }
   return true;
 }
@@ -752,4 +761,16 @@ bool AliasAnalysis::canReferenceSameField(SILValue lhs, SILValue rhs) {
     return canReferenceSameFieldFunction({PM->getSwiftPassInvocation()}, {lhs}, {rhs}) != 0;
   }
   return true;
+}
+
+int AliasAnalysis::getEstimatedFunctionSize(SILValue valueInFunction) {
+  if (estimatedFunctionSize < 0) {
+    int numInsts = 0;
+    SILFunction *f = valueInFunction->getFunction();
+    for (SILBasicBlock &block : *f) {
+      numInsts += std::distance(block.begin(), block.end());
+    }
+    estimatedFunctionSize = numInsts;
+  }
+  return estimatedFunctionSize;
 }

--- a/validation-test/SILOptimizer/many_trys.swift
+++ b/validation-test/SILOptimizer/many_trys.swift
@@ -1,0 +1,160 @@
+// The compiler should finish in less than 5 seconds. To give some slack, specify a timeout of 30 seconds.
+// If the compiler needs more than that, there is probably a real problem.
+// So please don't just increase the timeout in case this fails.
+
+// RUN: %{python} %S/../../test/Inputs/timeout.py 30 %target-swift-frontend -O -parse-as-library -sil-verify-none %s -emit-sil | %FileCheck %s
+
+// REQUIRES: tools-release,no_asan
+
+public var gg = false
+
+enum SomeError : Error {
+  case E
+}
+
+public class X {
+  @inline(never)
+  init() throws {
+    if gg {
+      throw SomeError.E
+    }
+  }
+}
+
+// CHECK-LABEL: testit
+public func testit(_ i: Int) throws -> (Int, X) {
+  let arr: [(Int, X)] = [
+      (0, try X()),
+      (1, try X()),
+      (2, try X()),
+      (3, try X()),
+      (4, try X()),
+      (5, try X()),
+      (6, try X()),
+      (7, try X()),
+      (8, try X()),
+      (9, try X()),
+      (10, try X()),
+      (11, try X()),
+      (12, try X()),
+      (13, try X()),
+      (14, try X()),
+      (15, try X()),
+      (16, try X()),
+      (17, try X()),
+      (18, try X()),
+      (19, try X()),
+      (20, try X()),
+      (21, try X()),
+      (22, try X()),
+      (23, try X()),
+      (24, try X()),
+      (25, try X()),
+      (26, try X()),
+      (27, try X()),
+      (28, try X()),
+      (29, try X()),
+      (30, try X()),
+      (31, try X()),
+      (32, try X()),
+      (33, try X()),
+      (34, try X()),
+      (35, try X()),
+      (36, try X()),
+      (37, try X()),
+      (38, try X()),
+      (39, try X()),
+      (40, try X()),
+      (41, try X()),
+      (42, try X()),
+      (43, try X()),
+      (44, try X()),
+      (45, try X()),
+      (46, try X()),
+      (47, try X()),
+      (48, try X()),
+      (49, try X()),
+      (50, try X()),
+      (51, try X()),
+      (52, try X()),
+      (53, try X()),
+      (54, try X()),
+      (55, try X()),
+      (56, try X()),
+      (57, try X()),
+      (58, try X()),
+      (59, try X()),
+      (60, try X()),
+      (61, try X()),
+      (62, try X()),
+      (63, try X()),
+      (64, try X()),
+      (65, try X()),
+      (66, try X()),
+      (67, try X()),
+      (68, try X()),
+      (69, try X()),
+      (70, try X()),
+      (71, try X()),
+      (72, try X()),
+      (73, try X()),
+      (74, try X()),
+      (75, try X()),
+      (76, try X()),
+      (77, try X()),
+      (78, try X()),
+      (79, try X()),
+      (80, try X()),
+      (81, try X()),
+      (82, try X()),
+      (83, try X()),
+      (84, try X()),
+      (85, try X()),
+      (86, try X()),
+      (87, try X()),
+      (88, try X()),
+      (89, try X()),
+      (90, try X()),
+      (91, try X()),
+      (92, try X()),
+      (93, try X()),
+      (94, try X()),
+      (95, try X()),
+      (96, try X()),
+      (97, try X()),
+      (98, try X()),
+      (99, try X()),
+      (100, try X()),
+      (101, try X()),
+      (102, try X()),
+      (103, try X()),
+      (104, try X()),
+      (105, try X()),
+      (106, try X()),
+      (107, try X()),
+      (108, try X()),
+      (109, try X()),
+      (110, try X()),
+      (111, try X()),
+      (112, try X()),
+      (113, try X()),
+      (114, try X()),
+      (115, try X()),
+      (116, try X()),
+      (117, try X()),
+      (118, try X()),
+      (119, try X()),
+      (120, try X()),
+      (121, try X()),
+      (122, try X()),
+      (123, try X()),
+      (124, try X()),
+      (125, try X()),
+      (126, try X()),
+      (127, try X()),
+      (128, try X()),
+    ]
+
+  return arr[i]
+} 
+


### PR DESCRIPTION
The `isEscaping` function is called a lot from ARCSequenceOpt and ReleaseHoisting. To avoid quadratic complexity for large functions, limit the amount of work what the EscapeUtils are allowed to to. This keeps the complexity linear.

The arbitrary limit is good enough for almost all functions. It lets the EscapeUtils do several hundred up/down walks which is much more than needed in most cases.

Fixes a compiler hang
https://github.com/apple/swift/issues/63846
rdar://105795976
