### PR TITLE
IRGen: Fix edge case where we emit debug info type with the wrong generic signature

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -621,7 +621,11 @@ private:
     case DeclContextKind::MacroDecl:
       return getOrCreateContext(DC->getParent());
     case DeclContextKind::GenericTypeDecl: {
+      // The generic signature of this nominal type has no relation to the current
+      // function's generic signature.
       auto *NTD = cast<NominalTypeDecl>(DC);
+      GenericContextScope scope(IGM, NTD->getGenericSignature().getCanonicalSignature());
+
       auto Ty = NTD->getDeclaredInterfaceType();
       // Create a Forward-declared type.
       auto DbgTy = DebugTypeInfo::getForwardDecl(Ty);
@@ -673,9 +677,6 @@ private:
     // The function return type is the first element in the list.
     createParameterType(Parameters, getResultTypeForDebugInfo(IGM, FnTy));
 
-    // Actually, the input type is either a single type or a tuple
-    // type. We currently represent a function with one n-tuple argument
-    // as an n-ary function.
     for (auto Param : FnTy->getParameters())
       createParameterType(
           Parameters, IGM.silConv.getSILType(

--- a/test/DebugInfo/issue-63869.swift
+++ b/test/DebugInfo/issue-63869.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -emit-ir -g %s
+
+public protocol P {
+  associatedtype Element
+}
+
+public struct G<T, U> {
+  public struct Nested {}
+
+  public init(_: (Nested) -> ()) {}
+}
+
+public extension P {
+    var values: G<Element, Int> {
+        G<Element, Int> { x in }
+    }
+}


### PR DESCRIPTION
PR #63789 introduced verification of the generic parameters appearing in debug info, but I missed an edge case where we have to push a different generic signature.

Fixes #63869.