### PR TITLE
fix bad expansion of SWIFT_ENUM

### DIFF
--- a/include/swift/PrintAsClang/ClangMacros.def
+++ b/include/swift/PrintAsClang/ClangMacros.def
@@ -175,7 +175,7 @@ CLANG_MACRO_CONDITIONAL("SWIFT_ENUM_ATTR", "(_extensibility)", \
 CLANG_MACRO_BODY("SWIFT_ENUM", \
     "# define SWIFT_ENUM(_type, _name, _extensibility) " \
         "enum _name : _type _name; " \
-        "enum SWIFT_ENUM_ATTR(_extensibility) SWIFT_ENUM_EXTRA _name: _type\n" \
+        "enum SWIFT_ENUM_ATTR(_extensibility) SWIFT_ENUM_EXTRA _name : _type\n" \
     "# if __has_feature(generalized_swift_name)\n" \
     "#  define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME, _extensibility) " \
         "enum _name : _type _name SWIFT_COMPILE_NAME(SWIFT_NAME); " \


### PR DESCRIPTION
Fixes #63837

When i introduced the data-driven creation of the Objective-C compatibility header, i accidentally introduced a difference in the macro expansion for `SWIFT_ENUM`. This PR fixes this.