### PR TITLE
[Sema] Diagnose function coercion ambiguity 

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1403,10 +1403,13 @@ WARNING(unlabeled_trailing_closure_deprecated,Deprecation,
 NOTE(decl_multiple_defaulted_closure_parameters,none,
      "%0 contains defaulted closure parameters %1 and %2",
      (DeclName, Identifier, Identifier))
+NOTE(candidate_with_extraneous_args_closure,none,
+     "candidate %0 requires %1 argument%s1, "
+     "but %2 %select{were|was}3 used in closure body",
+     (Type, unsigned, unsigned, bool))
 NOTE(candidate_with_extraneous_args,none,
-      "candidate %0 requires %1 argument%s1, "
-      "but %2 %select{were|was}3 %select{provided|used in closure body}4",
-      (Type, unsigned, unsigned, bool, bool))
+     "candidate %0 has %1 parameter%s1, but context %2 has %3",
+     (Type, unsigned, Type, unsigned))
 
 ERROR(no_accessible_initializers,none,
       "%0 cannot be constructed because it has no accessible initializers",

--- a/include/swift/Sema/ConstraintLocatorPathElts.def
+++ b/include/swift/Sema/ConstraintLocatorPathElts.def
@@ -265,6 +265,9 @@ ABSTRACT_LOCATOR_PATH_ELT(PatternDecl)
 /// A function type global actor.
 SIMPLE_LOCATOR_PATH_ELT(GlobalActorType)
 
+/// A type coercion operand.
+SIMPLE_LOCATOR_PATH_ELT(CoercionOperand)
+
 #undef LOCATOR_PATH_ELT
 #undef CUSTOM_LOCATOR_PATH_ELT
 #undef SIMPLE_LOCATOR_PATH_ELT

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3249,12 +3249,6 @@ public:
   ConstraintLocator *
   getConstraintLocator(const ConstraintLocatorBuilder &builder);
 
-  /// Retrieves a locator that identifies where an overload ambiguity may be
-  /// present. In most cases this is a no-op, but may simplify locator e.g
-  /// coercions for ambiguities in the expression operand.
-  ConstraintLocator *
-  getConstraintLocatorForAmbiguity(ConstraintLocator *locator);
-
   /// Compute a constraint locator for an implicit value-to-value
   /// conversion rooted at the given location.
   ConstraintLocator *

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3249,6 +3249,12 @@ public:
   ConstraintLocator *
   getConstraintLocator(const ConstraintLocatorBuilder &builder);
 
+  /// Retrieves a locator that identifies where an overload ambiguity may be
+  /// present. In most cases this is a no-op, but may simplify locator e.g
+  /// coercions for ambiguities in the expression operand.
+  ConstraintLocator *
+  getConstraintLocatorForAmbiguity(ConstraintLocator *locator);
+
   /// Compute a constraint locator for an implicit value-to-value
   /// conversion rooted at the given location.
   ConstraintLocator *

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4275,8 +4275,15 @@ namespace {
     bool hasForcedOptionalResult(ExplicitCastExpr *expr) {
       const auto *const TR = expr->getCastTypeRepr();
       if (TR && TR->getKind() == TypeReprKind::ImplicitlyUnwrappedOptional) {
-        auto *locator = cs.getConstraintLocator(
-            expr, ConstraintLocator::ImplicitlyUnwrappedDisjunctionChoice);
+        ConstraintLocator *locator;
+        if (isExpr<CoerceExpr>(expr)) {
+          locator = cs.getConstraintLocator(
+              expr, {LocatorPathElt::CoercionOperand(),
+                     ConstraintLocator::ImplicitlyUnwrappedDisjunctionChoice});
+        } else {
+          locator = cs.getConstraintLocator(
+              expr, ConstraintLocator::ImplicitlyUnwrappedDisjunctionChoice);
+        }
         return solution.getDisjunctionChoice(locator);
       }
       return false;
@@ -4349,7 +4356,8 @@ namespace {
       // If we weren't explicitly told by the caller which disjunction choice,
       // get it from the solution to determine whether we've picked a coercion
       // or a bridging conversion.
-      auto *locator = cs.getConstraintLocator(expr);
+      auto *locator =
+          cs.getConstraintLocator(expr, LocatorPathElt::CoercionOperand());
       auto choice = solution.getDisjunctionChoice(locator);
 
       // Handle the coercion/bridging of the underlying subexpression, where

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4275,15 +4275,8 @@ namespace {
     bool hasForcedOptionalResult(ExplicitCastExpr *expr) {
       const auto *const TR = expr->getCastTypeRepr();
       if (TR && TR->getKind() == TypeReprKind::ImplicitlyUnwrappedOptional) {
-        ConstraintLocator *locator;
-        if (isExpr<CoerceExpr>(expr)) {
-          locator = cs.getConstraintLocator(
-              expr, {LocatorPathElt::CoercionOperand(),
-                     ConstraintLocator::ImplicitlyUnwrappedDisjunctionChoice});
-        } else {
-          locator = cs.getConstraintLocator(
-              expr, ConstraintLocator::ImplicitlyUnwrappedDisjunctionChoice);
-        }
+        auto *locator = cs.getConstraintLocator(
+            expr, ConstraintLocator::ImplicitlyUnwrappedDisjunctionChoice);
         return solution.getDisjunctionChoice(locator);
       }
       return false;
@@ -4357,7 +4350,7 @@ namespace {
       // get it from the solution to determine whether we've picked a coercion
       // or a bridging conversion.
       auto *locator =
-          cs.getConstraintLocator(expr, LocatorPathElt::CoercionOperand());
+          cs.getConstraintLocator(expr, ConstraintLocator::CoercionOperand);
       auto choice = solution.getDisjunctionChoice(locator);
 
       // Handle the coercion/bridging of the underlying subexpression, where

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -282,6 +282,9 @@ ValueDecl *RequirementFailure::getDeclRef() const {
     return getAffectedDeclFromType(contextualTy);
   }
 
+  if (getLocator()->isFirstElement<LocatorPathElt::CoercionOperand>())
+    return getAffectedDeclFromType(getOwnerType());
+
   if (auto overload = getCalleeOverloadChoiceIfAvailable(getLocator())) {
     // If there is a declaration associated with this
     // failure e.g. an overload choice of the call

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -5735,9 +5735,15 @@ bool ExtraneousArgumentsFailure::diagnoseAsNote() {
 
   auto *decl = overload->choice.getDecl();
   auto numArgs = getTotalNumArguments();
-  emitDiagnosticAt(decl, diag::candidate_with_extraneous_args, ContextualType,
-                   ContextualType->getNumParams(), numArgs, (numArgs == 1),
-                   isExpr<ClosureExpr>(getAnchor()));
+  if (isExpr<ClosureExpr>(getAnchor())) {
+    emitDiagnosticAt(decl, diag::candidate_with_extraneous_args_closure,
+                    ContextualType, ContextualType->getNumParams(), numArgs,
+                    (numArgs == 1));
+  } else {
+    emitDiagnosticAt(decl, diag::candidate_with_extraneous_args,
+                     decl->getInterfaceType(), numArgs, ContextualType,
+                     ContextualType->getNumParams());
+  }
   return true;
 }
 

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -90,11 +90,6 @@ public:
 
   ConstraintLocator *getLocator() const { return Locator; }
 
-  ConstraintLocator *getAmbiguityLocator() const {
-    auto &cs = getConstraintSystem();
-    return cs.getConstraintLocatorForAmbiguity(Locator);
-  }
-
   Type getType(ASTNode node, bool wantRValue = true) const;
 
   /// Get type associated with a given ASTNode without resolving it,
@@ -2181,6 +2176,8 @@ public:
         UseConditionalCast(useConditionalCast) {}
 
   ASTNode getAnchor() const override;
+
+  SourceLoc getLoc() const override;
 
   bool diagnoseAsError() override;
 };

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -90,6 +90,11 @@ public:
 
   ConstraintLocator *getLocator() const { return Locator; }
 
+  ConstraintLocator *getAmbiguityLocator() const {
+    auto &cs = getConstraintSystem();
+    return cs.getConstraintLocatorForAmbiguity(Locator);
+  }
+
   Type getType(ASTNode node, bool wantRValue = true) const;
 
   /// Get type associated with a given ASTNode without resolving it,

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3329,9 +3329,8 @@ namespace {
       // bindings for the result of the coercion.
       if (repr &&
           repr->getKind() == TypeReprKind::ImplicitlyUnwrappedOptional) {
-        auto *locatorIUO = CS.getConstraintLocator(expr);
-        return createTypeVariableAndDisjunctionForIUOCoercion(toType,
-                                                              locatorIUO);
+        return createTypeVariableAndDisjunctionForIUOCoercion(
+            toType, CS.getConstraintLocator(expr));
       }
 
       return toType;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3307,7 +3307,7 @@ namespace {
 
       auto fromType = CS.getType(expr->getSubExpr());
       auto locator =
-          CS.getConstraintLocator(expr, LocatorPathElt::CoercionOperand());
+          CS.getConstraintLocator(expr, ConstraintLocator::CoercionOperand);
 
       // Literal initialization (e.g. `UInt32(0)`) doesn't require
       // a conversion because the literal is supposed to assume the
@@ -3327,8 +3327,12 @@ namespace {
 
       // If the result type was declared IUO, add a disjunction for
       // bindings for the result of the coercion.
-      if (repr && repr->getKind() == TypeReprKind::ImplicitlyUnwrappedOptional)
-        return createTypeVariableAndDisjunctionForIUOCoercion(toType, locator);
+      if (repr &&
+          repr->getKind() == TypeReprKind::ImplicitlyUnwrappedOptional) {
+        auto *locatorIUO = CS.getConstraintLocator(expr);
+        return createTypeVariableAndDisjunctionForIUOCoercion(toType,
+                                                              locatorIUO);
+      }
 
       return toType;
     }

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3306,7 +3306,8 @@ namespace {
       if (repr) CS.setType(repr, toType);
 
       auto fromType = CS.getType(expr->getSubExpr());
-      auto locator = CS.getConstraintLocator(expr);
+      auto locator =
+          CS.getConstraintLocator(expr, LocatorPathElt::CoercionOperand());
 
       // Literal initialization (e.g. `UInt32(0)`) doesn't require
       // a conversion because the literal is supposed to assume the

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -5065,63 +5065,6 @@ bool ConstraintSystem::repairFailures(
     if (!anchor)
       return false;
 
-    if (auto *coercion = getAsExpr<CoerceExpr>(anchor)) {
-      // Coercion from T.Type to T.Protocol.
-      if (hasConversionOrRestriction(
-              ConversionRestrictionKind::MetatypeToExistentialMetatype))
-        return false;
-
-      if (hasConversionOrRestriction(ConversionRestrictionKind::Superclass))
-        return false;
-
-      // Let's check whether the sub-expression is an optional type which
-      // is possible to unwrap (either by force or `??`) to satisfy the cast,
-      // otherwise we'd have to fallback to force downcast.
-      if (repairViaOptionalUnwrap(*this, lhs, rhs, matchKind,
-                                  conversionsOrFixes,
-                                  getConstraintLocator(coercion->getSubExpr())))
-        return true;
-
-      // If the result type of the coercion has an value to optional conversion
-      // we can instead suggest the conditional downcast as it is safer in
-      // situations like conditional binding.
-      auto useConditionalCast =
-          llvm::any_of(ConstraintRestrictions, [&](const auto &restriction) {
-            Type type1, type2;
-            std::tie(type1, type2) = restriction.first;
-            auto restrictionKind = restriction.second;
-
-            if (restrictionKind != ConversionRestrictionKind::ValueToOptional)
-              return false;
-
-            return rhs->isEqual(type1);
-          });
-
-      // Repair a coercion ('as') with a runtime checked cast ('as!' or 'as?').
-      if (auto *coerceToCheckCastFix =
-              CoerceToCheckedCast::attempt(*this, lhs, rhs, useConditionalCast,
-                                           getConstraintLocator(locator))) {
-        conversionsOrFixes.push_back(coerceToCheckCastFix);
-        return true;
-      }
-
-      // If it has a deep equality restriction, defer the diagnostic to
-      // GenericMismatch.
-      if (hasConversionOrRestriction(ConversionRestrictionKind::DeepEquality) &&
-          !hasConversionOrRestriction(
-              ConversionRestrictionKind::OptionalToOptional)) {
-        return false;
-      }
-
-      if (hasConversionOrRestriction(ConversionRestrictionKind::Existential))
-        return false;
-
-      auto *fix = ContextualMismatch::create(*this, lhs, rhs,
-                                             getConstraintLocator(locator));
-      conversionsOrFixes.push_back(fix);
-      return true;
-    }
-
     // This could be:
     // - `InOutExpr` used with r-value e.g. `foo(&x)` where `x` is a `let`.
     // - `ForceValueExpr` e.g. `foo.bar! = 42` where `bar` or `foo` are
@@ -6456,6 +6399,64 @@ bool ConstraintSystem::repairFailures(
     break;
   }
 
+  case ConstraintLocator::CoercionOperand: {
+    auto *coercion = castToExpr<CoerceExpr>(anchor);
+
+    // Coercion from T.Type to T.Protocol.
+    if (hasConversionOrRestriction(
+            ConversionRestrictionKind::MetatypeToExistentialMetatype))
+      return false;
+
+    if (hasConversionOrRestriction(ConversionRestrictionKind::Superclass))
+      return false;
+
+    // Let's check whether the sub-expression is an optional type which
+    // is possible to unwrap (either by force or `??`) to satisfy the cast,
+    // otherwise we'd have to fallback to force downcast.
+    if (repairViaOptionalUnwrap(*this, lhs, rhs, matchKind,
+                                conversionsOrFixes,
+                                getConstraintLocator(coercion->getSubExpr())))
+      return true;
+
+    // If the result type of the coercion has an value to optional conversion
+    // we can instead suggest the conditional downcast as it is safer in
+    // situations like conditional binding.
+    auto useConditionalCast =
+        llvm::any_of(ConstraintRestrictions, [&](const auto &restriction) {
+          Type type1, type2;
+          std::tie(type1, type2) = restriction.first;
+          auto restrictionKind = restriction.second;
+
+          if (restrictionKind != ConversionRestrictionKind::ValueToOptional)
+            return false;
+
+          return rhs->isEqual(type1);
+        });
+
+    // Repair a coercion ('as') with a runtime checked cast ('as!' or 'as?').
+    if (auto *coerceToCheckCastFix =
+            CoerceToCheckedCast::attempt(*this, lhs, rhs, useConditionalCast,
+                                         getConstraintLocator(locator))) {
+      conversionsOrFixes.push_back(coerceToCheckCastFix);
+      return true;
+    }
+
+    // If it has a deep equality restriction, defer the diagnostic to
+    // GenericMismatch.
+    if (hasConversionOrRestriction(ConversionRestrictionKind::DeepEquality) &&
+        !hasConversionOrRestriction(
+            ConversionRestrictionKind::OptionalToOptional)) {
+      return false;
+    }
+
+    if (hasConversionOrRestriction(ConversionRestrictionKind::Existential))
+      return false;
+
+    auto *fix = ContextualMismatch::create(*this, lhs, rhs,
+                                           getConstraintLocator(locator));
+    conversionsOrFixes.push_back(fix);
+    return true;
+  }
   default:
     break;
   }
@@ -6974,7 +6975,8 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
                                    ArrayRef<LocatorPathElt> path) {
           // E.g. contextual conversion from coercion/cast
           // to some other type.
-          if (!path.empty())
+          if (!(path.empty() ||
+                path.back().is<LocatorPathElt::CoercionOperand>()))
             return false;
 
           return isExpr<CoerceExpr>(anchor) || isExpr<IsExpr>(anchor) ||
@@ -11339,7 +11341,7 @@ ConstraintSystem::simplifyBridgingConstraint(Type type1,
 
     SmallVector<LocatorPathElt, 4> elts;
     auto anchor = locator.getLocatorParts(elts);
-    if (!elts.empty())
+    if (elts.empty() || !elts.back().is<LocatorPathElt::CoercionOperand>())
       return false;
 
     auto *coercion = getAsExpr<CoerceExpr>(anchor);

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -105,6 +105,7 @@ unsigned LocatorPathElt::getNewSummaryFlags() const {
   case ConstraintLocator::SingleValueStmtBranch:
   case ConstraintLocator::AnyPatternDecl:
   case ConstraintLocator::GlobalActorType:
+  case ConstraintLocator::CoercionOperand:
     return 0;
 
   case ConstraintLocator::FunctionArgument:
@@ -496,6 +497,11 @@ void LocatorPathElt::dump(raw_ostream &out) const {
     out << "global actor type";
     break;
   }
+
+  case ConstraintLocator::CoercionOperand: {
+    out << "coercion operand";
+    break;
+  }
   }
 }
 
@@ -601,7 +607,7 @@ bool ConstraintLocator::isForAssignment() const {
 }
 
 bool ConstraintLocator::isForCoercion() const {
-  return directlyAt<CoerceExpr>();
+  return isLastElement<LocatorPathElt::CoercionOperand>();
 }
 
 bool ConstraintLocator::isForOptionalTry() const {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -622,12 +622,6 @@ ConstraintLocator *ConstraintSystem::getCalleeLocator(
   if (isExpr<ObjectLiteralExpr>(anchor))
     return getConstraintLocator(anchor, ConstraintLocator::ConstructorMember);
 
-  if (locator->isLastElement<LocatorPathElt::FunctionArgument>()) {
-    if (auto *CE = getAsExpr<CoerceExpr>(anchor)) {
-      return getConstraintLocator(CE->getSubExpr());
-    }
-  }
-
   return getConstraintLocator(anchor);
 }
 

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4687,10 +4687,25 @@ static bool diagnoseAmbiguity(
           fixes.push_back(entry.second);
       }
 
+      auto emitGeneralFoundCandidateNote = [&]() {
+        // Emit a general "found candidate" note
+        if (decl->getLoc().isInvalid()) {
+          if (candidateTypes.insert(type->getCanonicalType()).second)
+            DE.diagnose(getLoc(commonAnchor), diag::found_candidate_type, type);
+        } else {
+          DE.diagnose(noteLoc, diag::found_candidate);
+        }
+      };
+
       if (fixes.size() == 1) {
         diagnosed &= fixes.front()->diagnose(solution, /*asNote*/ true);
       } else if (!fixes.empty() &&
                  llvm::all_of(fixes, [&](const ConstraintFix *fix) {
+                   // Ignore coercion fixes in this context, to
+                   // focus on the argument mismatches.
+                   if (fix->getLocator()->isForCoercion())
+                     return true;
+
                    return fix->getLocator()
                        ->findLast<LocatorPathElt::ApplyArgument>()
                        .has_value();
@@ -4704,28 +4719,34 @@ static bool diagnoseAmbiguity(
             type->lookThroughAllOptionalTypes()->getAs<AnyFunctionType>();
         assert(fn);
 
-        auto *argList = solution.getArgumentList(fixes.front()->getLocator());
-        assert(argList);
+        auto first = llvm::find_if(fixes, [&](const ConstraintFix *fix) {
+          return fix->getLocator()
+              ->findLast<LocatorPathElt::ApplyArgument>()
+              .has_value();
+        });
 
-        if (fn->getNumParams() == 1 && argList->isUnary()) {
-          const auto &param = fn->getParams()[0];
-          auto argTy = solution.getResolvedType(argList->getUnaryExpr());
+        if (first != fixes.end()) {
+          auto *argList = solution.getArgumentList((*first)->getLocator());
+          assert(argList);
 
-          DE.diagnose(noteLoc, diag::candidate_has_invalid_argument_at_position,
-                      solution.simplifyType(param.getPlainType()),
-                      /*position=*/1, param.isInOut(), argTy);
+          if (fn->getNumParams() == 1 && argList->isUnary()) {
+            const auto &param = fn->getParams()[0];
+            auto argTy = solution.getResolvedType(argList->getUnaryExpr());
+
+            DE.diagnose(noteLoc,
+                        diag::candidate_has_invalid_argument_at_position,
+                        solution.simplifyType(param.getPlainType()),
+                        /*position=*/1, param.isInOut(), argTy);
+          } else {
+            DE.diagnose(noteLoc, diag::candidate_partial_match,
+                        fn->getParamListAsString(fn->getParams()));
+          }
         } else {
-          DE.diagnose(noteLoc, diag::candidate_partial_match,
-                      fn->getParamListAsString(fn->getParams()));
+          // Only coercion ambiguity fixes.
+          emitGeneralFoundCandidateNote();
         }
       } else {
-        // Emit a general "found candidate" note
-        if (decl->getLoc().isInvalid()) {
-          if (candidateTypes.insert(type->getCanonicalType()).second)
-            DE.diagnose(getLoc(commonAnchor), diag::found_candidate_type, type);
-        } else {
-          DE.diagnose(noteLoc, diag::found_candidate);
-        }
+        emitGeneralFoundCandidateNote();
       }
     }
 

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -324,3 +324,8 @@ func f63834_D(_ x: Int = 0) {}
 func f63834_D(_ x: String) {}
 
 (f63834_D as Magic)() // expected-error{{missing argument for parameter #1 in call}}
+
+func fn63834_3() -> String {} // expected-note {{found candidate with type 'String'}}
+func fn63834_3() -> Double {} // expected-note {{found candidate with type 'Double'}}
+
+fn63834_3() as Int // expected-error {{no exact matches in call to global function 'fn63834_3'}}

--- a/test/Constraints/overload.swift
+++ b/test/Constraints/overload.swift
@@ -287,7 +287,40 @@ func rdar97396399() {
 }
 
 // https://github.com/apple/swift/issues/63834
-func f63834(int: Int, string: String) {} // expected-note{{found candidate with type '(Int, String) -> ()'}}
-func f63834(int: Int, string: Bool) {} // expected-note{{found candidate with type '(Int, Bool) -> ()'}}
+func f63834(int: Int, string: String) {} // expected-note 3{{found candidate with type '(Int, String) -> ()'}}
+func f63834(int: Int, string: Bool) {} // expected-note 3{{found candidate with type '(Int, Bool) -> ()'}}
 
-let a = f63834(int:string:) as (Int, Int) -> Void // expected-error{{no exact matches in reference to global function 'f63834'}}
+func f63834_1(int: Int, string: Bool) {} // expected-note{{candidate '(Int, Bool) -> ()' has 2 parameters, but context '(Int) -> Void' has 1}}
+func f63834_1(int: Int, string: String) {} // expected-note{{candidate '(Int, String) -> ()' has 2 parameters, but context '(Int) -> Void' has 1}}
+
+// FIXME: We can mention candidate type.
+func f63834_2(int: Int, string: Bool) {} // expected-note {{found this candidate}}
+func f63834_2(int: Int, string: String) {} // expected-note {{found this candidate}}
+
+// One function argument mismatch
+let _ = f63834(int:string:) as (Int, Int) -> Void // expected-error{{no exact matches in reference to global function 'f63834'}}
+// Contextual mismatch
+let _ = f63834(int:string:) as Int // expected-error{{no exact matches in reference to global function 'f63834'}}
+let _ = (f63834(int:string:)) as Int // expected-error{{no exact matches in reference to global function 'f63834'}}
+
+// Missing function argument
+let _ = f63834_1(int:string:) as (Int) -> Void // expected-error{{no exact matches in reference to global function 'f63834_1'}}
+// None of the function argument types matches
+let _ = f63834_2(int:string:) as (Double, Double) -> Void // expected-error{{no exact matches in reference to global function 'f63834_2'}}
+let _ = { i, j in } as (Int) -> Void // expected-error{{contextual closure type '(Int) -> Void' expects 1 argument, but 2 were used in closure body}}
+
+struct A63834 {
+  static func fn(int: Int, string: String) {} // expected-note{{candidate '(Int, String) -> ()' has 2 parameters, but context '(Int) -> Void' has 1}}
+  static func fn(int: Int, string: Bool) {}  // expected-note{{candidate '(Int, Bool) -> ()' has 2 parameters, but context '(Int) -> Void' has 1}}
+
+  static func fn1(int: Int, string: String) {} // expected-note{{found candidate with type '(Int, String) -> ()'}}
+  static func fn1(int: Int, string: Bool) {}  // expected-note{{found candidate with type '(Int, Bool) -> ()'}}
+}
+let _ = A63834.fn1(int:string:) as Int // expected-error {{no exact matches in reference to static method 'fn1'}}
+let _ = A63834.fn(int:string:) as (Int) -> Void // expected-error{{no exact matches in reference to static method 'fn'}}
+
+typealias Magic<T> = T
+func f63834_D(_ x: Int = 0) {}
+func f63834_D(_ x: String) {}
+
+(f63834_D as Magic)() // expected-error{{missing argument for parameter #1 in call}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
In previous PR was handling only failures located in argument mismatch, but ambiguity of overload in coerce subexpr can come from other fixes as well e.g. contextual mismatch, not only located in `FunctionArgument`. So is a more general approach look for the overload subexpr. 

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves https://github.com/apple/swift/issues/63834

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
