### PR TITLE
[Test] Require asserts for experimental feature.

### DIFF
--- a/test/IRGen/implicit_some_a.swift
+++ b/test/IRGen/implicit_some_a.swift
@@ -1,5 +1,8 @@
 // RUN: %target-swift-frontend -emit-ir -disable-availability-checking -primary-file %s %S/Inputs/implicit_some_b.swift -enable-experimental-feature ImplicitSome
 
+// Because of -enable-experimental-feature ImplicitSome
+// REQUIRES: asserts
+
 protocol P {}
 struct S: P {}
 


### PR DESCRIPTION
On non-asserts compilers, the following error is emitted:

```
<unknown>:0: error: experimental feature '<FEATURE>' cannot be enabled in a production compiler
```
