### PR TITLE
[Refactor] Allow expanding nested macros

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -892,8 +892,8 @@ public:
 
   /// Retrieve the discriminator for the given custom attribute that names
   /// an attached macro.
-  unsigned getAttachedMacroDiscriminator(
-      MacroRole role, const CustomAttr *attr) const;
+  unsigned getAttachedMacroDiscriminator(DeclBaseName macroName, MacroRole role,
+                                         const CustomAttr *attr) const;
 
   /// Returns the innermost enclosing decl with an availability annotation.
   const Decl *getInnermostDeclWithAvailability() const;
@@ -8318,24 +8318,23 @@ public:
 /// is used for parser recovery, e.g. when parsing a floating
 /// attribute list.
 class MissingDecl: public Decl {
-  MissingDecl(DeclContext *DC) : Decl(DeclKind::Missing, DC) {
+  /// The location that the decl would be if it wasn't missing.
+  SourceLoc Loc;
+
+  MissingDecl(DeclContext *DC, SourceLoc loc)
+      : Decl(DeclKind::Missing, DC), Loc(loc) {
     setImplicit();
   }
 
   friend class Decl;
-  SourceLoc getLocFromSource() const {
-    return SourceLoc();
-  }
+  SourceLoc getLocFromSource() const { return Loc; }
 
 public:
-  static MissingDecl *
-  create(ASTContext &ctx, DeclContext *DC) {
-    return new (ctx) MissingDecl(DC);
+  static MissingDecl *create(ASTContext &ctx, DeclContext *DC, SourceLoc loc) {
+    return new (ctx) MissingDecl(DC, loc);
   }
 
-  SourceRange getSourceRange() const {
-    return SourceRange();
-  }
+  SourceRange getSourceRange() const { return SourceRange(Loc); }
 
   static bool classof(const Decl *D) {
     return D->getKind() == DeclKind::Missing;

--- a/include/swift/Refactoring/Refactoring.h
+++ b/include/swift/Refactoring/Refactoring.h
@@ -33,7 +33,7 @@ enum class RefactoringKind : int8_t {
 };
 
 struct RangeConfig {
-  unsigned BufferId;
+  unsigned BufferID;
   unsigned Line;
   unsigned Column;
   unsigned Length;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -640,7 +640,9 @@ SourceFile *ModuleDecl::getSourceFileContainingLocation(SourceLoc loc) {
 
   auto foundSourceFile = *found;
   auto foundRange = sourceMgr.getRangeForBuffer(*foundSourceFile->getBufferID());
-  if (!foundRange.contains(adjustedLoc) && adjustedLoc != foundRange.getStart())
+  // Positions inside an empty file or at EOF should still be considered within
+  // this file.
+  if (!foundRange.contains(adjustedLoc) && adjustedLoc != foundRange.getEnd())
     return nullptr;
 
   // Update the last source file.

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -684,11 +684,13 @@ bool SemaAnnotator::handleCustomAttributes(Decl *D) {
     }
   }
 
-  // FIXME: This should be getSemanticAttrs if we want to walk macro
-  // expansions. We've just already typechecked and this list is mutable so...
-  for (auto *customAttr : D->getAttrs().getAttributes<CustomAttr, true>()) {
-    if (!shouldWalkMacroArgumentsAndExpansion().second &&
-        D->getModuleContext()->isInGeneratedBuffer(customAttr->getLocation()))
+  ModuleDecl *MD = D->getModuleContext();
+  for (auto *customAttr :
+       D->getSemanticAttrs().getAttributes<CustomAttr, true>()) {
+    SourceFile *SF =
+        MD->getSourceFileContainingLocation(customAttr->getLocation());
+    ASTNode expansion = SF ? SF->getMacroExpansion() : nullptr;
+    if (!shouldWalkMacroArgumentsAndExpansion().second && expansion)
       continue;
 
     if (auto *Repr = customAttr->getTypeRepr()) {
@@ -700,10 +702,12 @@ bool SemaAnnotator::handleCustomAttributes(Decl *D) {
       if (auto macroDecl = D->getResolvedMacro(mutableAttr)) {
         Type macroRefType = macroDecl->getDeclaredInterfaceType();
         if (!passReference(
-              macroDecl, macroRefType, DeclNameLoc(Repr->getStartLoc()),
-              ReferenceMetaData(SemaReferenceKind::DeclRef, None,
-                                /*isImplicit=*/false,
-                                std::make_pair(customAttr, D))))
+                macroDecl, macroRefType, DeclNameLoc(Repr->getStartLoc()),
+                ReferenceMetaData(
+                    SemaReferenceKind::DeclRef, None,
+                    /*isImplicit=*/false,
+                    std::make_pair(customAttr,
+                                   expansion ? expansion.get<Decl *>() : D))))
           return false;
       } else if (!Repr->walk(*this)) {
         return false;
@@ -865,9 +869,23 @@ bool SemaAnnotator::passCallArgNames(Expr *Fn, ArgumentList *ArgList) {
 }
 
 bool SemaAnnotator::shouldIgnore(Decl *D) {
+  if (!D->isImplicit())
+    return false;
+
   // TODO: There should really be a separate field controlling whether
   //       constructors are visited or not
-  return D->isImplicit() && !isa<ConstructorDecl>(D);
+  if (isa<ConstructorDecl>(D))
+    return false;
+
+  // Walk into missing decls to visit their attributes if they were generated
+  // by a member attribute expansion. Note that we would have already skipped
+  // this decl if we were ignoring expansions, so no need to check that.
+  if (auto *missing = dyn_cast<MissingDecl>(D)) {
+    if (D->isInGeneratedBuffer())
+      return false;
+  }
+
+  return true;
 }
 
 bool SourceEntityWalker::walk(SourceFile &SrcFile) {

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -7136,7 +7136,8 @@ void Parser::parseExpandedAttributeList(SmallVectorImpl<ASTNode> &items) {
 
   // Create a `MissingDecl` as a placeholder for the declaration the
   // macro will attach the attribute list to.
-  MissingDecl *missing = MissingDecl::create(Context, CurDeclContext);
+  MissingDecl *missing =
+      MissingDecl::create(Context, CurDeclContext, Tok.getLoc());
   missing->getAttrs() = attributes;
 
   items.push_back(ASTNode(missing));

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -138,13 +138,24 @@ struct S4 { }
 // ATTACHED_EXPAND: source.edit.kind.active:
 // ATTACHED_EXPAND-NEXT: 23:3-23:3 (@__swiftmacro_9MacroUser1SV13myTypeWrapperfMA_.swift) "@accessViaStorage "
 // ATTACHED_EXPAND-NEXT: source.edit.kind.active:
-// ATTACHED_EXPAND-NEXT: 24:3-24:3 (@__swiftmacro_9MacroUser1SV13myTypeWrapperfMA_.swift) "@accessViaStorage "
+// ATTACHED_EXPAND-NEXT: 24:3-24:3 (@__swiftmacro_9MacroUser1SV13myTypeWrapperfMA0_.swift) "@accessViaStorage "
 // ATTACHED_EXPAND-NEXT: source.edit.kind.active:
 // ATTACHED_EXPAND-NEXT: 22:11-22:11 (@__swiftmacro_9MacroUser1SV13myTypeWrapperfMm_.swift) "
 // ATTACHED_EXPAND-NEXT: private var _storage = _Storage()
 // ATTACHED_EXPAND-NEXT: "
 // ATTACHED_EXPAND-NEXT: source.edit.kind.active:
 // ATTACHED_EXPAND-NEXT: 21:1-21:15 ""
+
+//##-- Refactoring expanding the attribute expanded by @myTypeWrapper
+// RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=1:2 @__swiftmacro_9MacroUser1SV13myTypeWrapperfMA_.swift -primary-file %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=NESTED_ATTACHED_EXPAND %s
+// NESTED_ATTACHED_EXPAND: source.edit.kind.active:
+// NESTED_ATTACHED_EXPAND-NEXT: Macros/macro_basic.swift 23:13-23:13 (@__swiftmacro_9MacroUser1SV1xSivp16accessViaStoragefMa_.swift) "{
+// NESTED_ATTACHED_EXPAND-NEXT:  get { _storage.x }
+// NESTED_ATTACHED_EXPAND-EMPTY:
+// NESTED_ATTACHED_EXPAND-NEXT:  set { _storage.x = newValue }
+// NESTED_ATTACHED_EXPAND-NEXT: }"
+// NESTED_ATTACHED_EXPAND-NEXT: source.edit.kind.active:
+// NESTED_ATTACHED_EXPAND-NEXT: 1:1-1:18 ""
 
 //##-- Refactoring expanding the first accessor macro
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=30:4 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=ACCESSOR1_EXPAND %s

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -637,6 +637,10 @@ enum class SemanticRefactoringKind {
 
 struct SemanticRefactoringInfo {
   SemanticRefactoringKind Kind;
+  // The name of the source file to start the refactoring in. Empty if it is
+  // the primary file (in which case the primary file from the AST is used).
+  // This must match the buffer identifier stored in the source manager.
+  StringRef SourceFile;
   unsigned Line;
   unsigned Column;
   unsigned Length;
@@ -1045,7 +1049,7 @@ public:
                         SourceKitCancellationToken CancellationToken,
                         CategorizedRenameRangesReceiver Receiver) = 0;
 
-  virtual void semanticRefactoring(StringRef Filename,
+  virtual void semanticRefactoring(StringRef PrimaryFile,
                                    SemanticRefactoringInfo Info,
                                    ArrayRef<const char *> Args,
                                    SourceKitCancellationToken CancellationToken,

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -708,7 +708,7 @@ public:
       std::function<void(const RequestResult<VariableTypesInFile> &)> Receiver)
       override;
 
-  void semanticRefactoring(StringRef Filename, SemanticRefactoringInfo Info,
+  void semanticRefactoring(StringRef PrimaryFile, SemanticRefactoringInfo Info,
                            ArrayRef<const char *> Args,
                            SourceKitCancellationToken CancellationToken,
                            CategorizedEditsReceiver Receiver) override;

--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -20,6 +20,9 @@ def id : Separate<["-"], "id">,
   HelpText<"If this is an async request, an ID that can be used to cancel the request">;
 def id_EQ : Joined<["-"], "id=">, Alias<id>;
 
+def primary_file : Separate<["-"], "primary-file">,
+  HelpText<"Primary file path">;
+
 def offset : Separate<["-"], "offset">,
   HelpText<"byte offset">;
 def offset_EQ : Joined<["-"], "offset=">, Alias<offset>;

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -215,12 +215,16 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
       return true;
     }
 
-    case OPT_offset:
-      if (StringRef(InputArg->getValue()).getAsInteger(10, Offset)) {
+    case OPT_offset: {
+      unsigned offset;
+      if (StringRef(InputArg->getValue()).getAsInteger(10, offset)) {
         llvm::errs() << "error: expected integer for 'offset'\n";
         return true;
       }
+
+      Offset = offset;
       break;
+    }
 
     case OPT_length:
       if (StringRef(InputArg->getValue()).getAsInteger(10, Length)) {
@@ -333,6 +337,10 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
       SourceFile = InputArg->getValue();
       SourceText = llvm::None;
       Inputs.push_back(InputArg->getValue());
+      break;
+
+    case OPT_primary_file:
+      PrimaryFile = InputArg->getValue();
       break;
 
     case OPT_rename_spec:

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -77,7 +77,13 @@ enum class SourceKitRequest {
 struct TestOptions {
   SourceKitRequest Request = SourceKitRequest::None;
   std::vector<std::string> Inputs;
+  /// The name of the underlying \c SourceFile.
   std::string SourceFile;
+  /// The path to the primary file when building the AST, ie. when making a
+  /// request from inside a macro expansion, this would be the real file on
+  /// disk where as \c SourceFile is the name of the expansion's buffer.
+  /// Defaults to \c SourceFile when not given.
+  std::string PrimaryFile;
   std::string TextInputFile;
   std::string JsonRequestPath;
   std::string RenameSpecPath;
@@ -88,7 +94,7 @@ struct TestOptions {
   unsigned Col = 0;
   unsigned EndLine = 0;
   unsigned EndCol = 0;
-  unsigned Offset = 0;
+  llvm::Optional<unsigned> Offset;
   unsigned Length = 0;
   std::string SwiftVersion;
   bool PassVersionAsString = false;

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -524,17 +524,20 @@ static int handleTestInvocation(ArrayRef<const char *> Args,
 static void setRefactoringFields(sourcekitd_object_t &Req, TestOptions Opts,
                                  sourcekitd_uid_t RefactoringKind,
                                  llvm::MemoryBuffer *SourceBuf) {
-  if (Opts.Offset && !Opts.Line && !Opts.Col) {
-    auto LineCol = resolveToLineCol(Opts.Offset, SourceBuf);
-    Opts.Line = LineCol.first;
-    Opts.Col = LineCol.second;
+  unsigned line = Opts.Line;
+  unsigned col = Opts.Col;
+  if (SourceBuf && Opts.Offset && line == 0) {
+    std::tie(line, col) = resolveToLineCol(*Opts.Offset, SourceBuf);
   }
+
   sourcekitd_request_dictionary_set_uid(Req, KeyRequest,
                                         RequestSemanticRefactoring);
   sourcekitd_request_dictionary_set_uid(Req, KeyActionUID, RefactoringKind);
+  sourcekitd_request_dictionary_set_string(Req, KeyPrimaryFile,
+                                           Opts.PrimaryFile.c_str());
   sourcekitd_request_dictionary_set_string(Req, KeyName, Opts.Name.c_str());
-  sourcekitd_request_dictionary_set_int64(Req, KeyLine, Opts.Line);
-  sourcekitd_request_dictionary_set_int64(Req, KeyColumn, Opts.Col);
+  sourcekitd_request_dictionary_set_int64(Req, KeyLine, line);
+  sourcekitd_request_dictionary_set_int64(Req, KeyColumn, col);
   sourcekitd_request_dictionary_set_int64(Req, KeyLength, Opts.Length);
 }
 
@@ -572,15 +575,20 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
       Opts.Request == SourceKitRequest::MangleSimpleClasses)
     Opts.SourceFile.clear();
 
-  std::string SourceFile = Opts.SourceFile;
-  if (!SourceFile.empty()) {
+  if (!Opts.SourceFile.empty() && Opts.PrimaryFile.empty()) {
+    // Only canonicalize if primary file isn't set (since we expect sourcefile
+    // to be a relative name otherwise).
     llvm::SmallString<64> AbsSourceFile;
-    AbsSourceFile += SourceFile;
+    AbsSourceFile += Opts.SourceFile;
     llvm::sys::fs::make_absolute(AbsSourceFile);
     llvm::sys::path::native(AbsSourceFile);
-    SourceFile = std::string(AbsSourceFile.str());
+    Opts.SourceFile = std::string(AbsSourceFile.str());
+    if (Opts.PrimaryFile.empty()) {
+      Opts.PrimaryFile = Opts.SourceFile;
+    }
   }
-  std::string SemaName = !Opts.Name.empty() ? Opts.Name : SourceFile;
+  // FIXME: It's super confusing that we use name for the file sometimes.
+  std::string SemaName = !Opts.Name.empty() ? Opts.Name : Opts.SourceFile;
 
   if (!Opts.TextInputFile.empty()) {
     auto Buf = getBufferForFilename(Opts.TextInputFile, Opts.VFSFiles);
@@ -590,21 +598,29 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
   std::unique_ptr<llvm::MemoryBuffer> SourceBuf;
   if (Opts.SourceText.has_value()) {
     SourceBuf = llvm::MemoryBuffer::getMemBuffer(*Opts.SourceText, Opts.SourceFile);
-  } else if (!SourceFile.empty()) {
+  } else if (!Opts.SourceFile.empty() && Opts.PrimaryFile == Opts.SourceFile) {
+    // If we have a primary file, that implies that the source file is actually
+    // a generated buffer. In that case we can't get the text.
     SourceBuf = llvm::MemoryBuffer::getMemBuffer(
-        getBufferForFilename(SourceFile, Opts.VFSFiles)->getBuffer(),
-        SourceFile);
+        getBufferForFilename(Opts.SourceFile, Opts.VFSFiles)->getBuffer(),
+        Opts.SourceFile);
   }
 
-  // FIXME: we should detect if offset is required but not set.
-  unsigned ByteOffset = Opts.Offset;
-  if (Opts.Line != 0) {
-    ByteOffset = resolveFromLineCol(Opts.Line, Opts.Col, SourceBuf.get());
-  }
+  unsigned ByteOffset = Opts.Offset.value_or(0);
+  if (SourceBuf) {
+    // Fill in offset/length if we're able to, ie. we have access to the
+    // underlying sourcefile. Ideally we would error here if any of these
+    // are needed but not (or cannot) be set.
 
-  if (Opts.EndLine != 0) {
-    Opts.Length = resolveFromLineCol(Opts.EndLine, Opts.EndCol, SourceBuf.get()) -
-      ByteOffset;
+    if (!Opts.Offset && Opts.Line > 0) {
+      ByteOffset = resolveFromLineCol(Opts.Line, Opts.Col, SourceBuf.get());
+    }
+
+    if (Opts.Length == 0 && Opts.EndLine > 0) {
+      Opts.Length =
+          resolveFromLineCol(Opts.EndLine, Opts.EndCol, SourceBuf.get()) -
+          ByteOffset;
+    }
   }
 
   bool compilerArgsAreClang = false;
@@ -782,8 +798,8 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
     sourcekitd_request_dictionary_set_int64(Req, KeyOffset, ByteOffset);
     auto Length = Opts.Length;
     if (Opts.Length == 0 && Opts.EndLine > 0) {
-      auto EndOff = resolveFromLineCol(Opts.EndLine, Opts.EndCol, SourceFile,
-                                       Opts.VFSFiles);
+      auto EndOff = resolveFromLineCol(Opts.EndLine, Opts.EndCol,
+                                       Opts.SourceFile, Opts.VFSFiles);
       Length = EndOff - ByteOffset;
     }
     sourcekitd_request_dictionary_set_int64(Req, KeyLength, Length);
@@ -1095,14 +1111,14 @@ static int handleTestInvocation(TestOptions Opts, TestOptions &InitOpts) {
     break;
   }
 
-  if (!SourceFile.empty()) {
+  if (!Opts.SourceFile.empty()) {
     if (Opts.PassAsSourceText) {
-      auto Buf = getBufferForFilename(SourceFile, Opts.VFSFiles);
+      auto Buf = getBufferForFilename(Opts.SourceFile, Opts.VFSFiles);
       sourcekitd_request_dictionary_set_string(Req, KeySourceText,
                                                Buf->getBufferStart());
     }
     sourcekitd_request_dictionary_set_string(Req, KeySourceFile,
-                                             SourceFile.c_str());
+                                             Opts.SourceFile.c_str());
   }
 
   if (Opts.SourceText) {
@@ -2707,7 +2723,10 @@ static llvm::MemoryBuffer *
 getBufferForFilename(StringRef Filename,
                      const llvm::StringMap<TestOptions::VFSFile> &VFSFiles,
                      bool ExitOnError) {
-  auto VFSFileIt = VFSFiles.find(Filename);
+  llvm::SmallString<128> nativeName;
+  llvm::sys::path::native(Filename, nativeName);
+
+  auto VFSFileIt = VFSFiles.find(nativeName);
   auto MappedFilename =
       VFSFileIt == VFSFiles.end() ? Filename : StringRef(VFSFileIt->second.path);
 

--- a/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/Service/Requests.cpp
@@ -454,14 +454,33 @@ getInputBufForRequestOrEmitError(const RequestDict &Req,
   return buf;
 }
 
-/// Get 'key.sourcefile' value as a string. If it's missing, reply an error to
-/// \p Rec and return None.
+/// Get 'key.primary_file' value as a string. If it's missing, reply with an
+/// error and return \c None.
+///
+/// Fallsback to 'key.sourcefile' for compatibility.
 static Optional<StringRef>
-getSourceFileNameForRequestOrEmitError(const RequestDict &Req,
-                                       ResponseReceiver Rec) {
+getPrimaryFileForRequestOrEmitError(const RequestDict &Req,
+                                    ResponseReceiver Rec) {
+  Optional<StringRef> PrimaryFile = Req.getString(KeyPrimaryFile);
+  if (!PrimaryFile) {
+    // Fallback to the old key.sourcefile
+    PrimaryFile = Req.getString(KeySourceFile);
+    if (!PrimaryFile) {
+      Rec(createErrorRequestInvalid("missing 'key.primary_file'"));
+    }
+  }
+  return PrimaryFile;
+}
+
+/// Get 'key.source_file' value as a string. If it's missing, reply with an
+/// error and return \c None.
+static Optional<StringRef>
+getSourceFileForRequestOrEmitError(const RequestDict &Req,
+                                   ResponseReceiver Rec) {
   Optional<StringRef> SourceFile = Req.getString(KeySourceFile);
-  if (!SourceFile.has_value())
+  if (!SourceFile) {
     Rec(createErrorRequestInvalid("missing 'key.sourcefile'"));
+  }
   return SourceFile;
 }
 
@@ -1359,7 +1378,7 @@ static void handleRequestIndex(const RequestDict &Req,
     return;
 
   handleSemanticRequest(Req, Rec, [Req, Rec]() {
-    auto SourceFile = getSourceFileNameForRequestOrEmitError(Req, Rec);
+    auto SourceFile = getPrimaryFileForRequestOrEmitError(Req, Rec);
     if (!SourceFile)
       return;
     SmallVector<const char *, 8> Args;
@@ -1377,7 +1396,7 @@ handleRequestCursorInfo(const RequestDict &Req,
     LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
 
     Optional<VFSOptions> vfsOptions = getVFSOptions(Req);
-    auto SourceFile = getSourceFileNameForRequestOrEmitError(Req, Rec);
+    auto SourceFile = getPrimaryFileForRequestOrEmitError(Req, Rec);
     if (!SourceFile)
       return;
     SmallVector<const char *, 8> Args;
@@ -1427,7 +1446,7 @@ static void handleRequestRangeInfo(const RequestDict &Req,
 
   handleSemanticRequest(Req, Rec, [Req, CancellationToken, Rec]() {
     LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
-    auto SourceFile = getSourceFileNameForRequestOrEmitError(Req, Rec);
+    auto SourceFile = getPrimaryFileForRequestOrEmitError(Req, Rec);
     if (!SourceFile)
       return;
     SmallVector<const char *, 8> Args;
@@ -1462,8 +1481,8 @@ handleRequestSemanticRefactoring(const RequestDict &Req,
     return;
 
   handleSemanticRequest(Req, Rec, [Req, CancellationToken, Rec]() {
-    auto SourceFile = getSourceFileNameForRequestOrEmitError(Req, Rec);
-    if (!SourceFile)
+    auto PrimaryFile = getPrimaryFileForRequestOrEmitError(Req, Rec);
+    if (!PrimaryFile)
       return;
     SmallVector<const char *, 8> Args;
     if (getCompilerArgumentsForRequestOrEmitError(Req, Args, Rec))
@@ -1486,17 +1505,24 @@ handleRequestSemanticRefactoring(const RequestDict &Req,
     if (Info.Kind == SemanticRefactoringKind::None)
       return Rec(createErrorRequestInvalid("'key.actionuid' isn't recognized"));
 
+    auto SourceFile = getSourceFileForRequestOrEmitError(Req, Rec);
+    if (!SourceFile)
+      return;
+
     if (!Req.getInt64(KeyLine, Line, /*isOptional=*/false)) {
       if (!Req.getInt64(KeyColumn, Column, /*isOptional=*/false)) {
         Req.getInt64(KeyLength, Length, /*isOptional=*/true);
         if (auto N = Req.getString(KeyName))
           Info.PreferredName = *N;
         LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
+        if (*PrimaryFile != *SourceFile) {
+          Info.SourceFile = *SourceFile;
+        }
         Info.Line = Line;
         Info.Column = Column;
         Info.Length = Length;
         return Lang.semanticRefactoring(
-            *SourceFile, Info, Args, CancellationToken,
+            *PrimaryFile, Info, Args, CancellationToken,
             [Rec](const RequestResult<ArrayRef<CategorizedEdits>> &Result) {
               Rec(createCategorizedEditsResponse(Result));
             });
@@ -1515,7 +1541,7 @@ handleRequestCollectExpressionType(const RequestDict &Req,
 
   handleSemanticRequest(Req, Rec, [Req, CancellationToken, Rec]() {
     LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
-    auto SourceFile = getSourceFileNameForRequestOrEmitError(Req, Rec);
+    auto SourceFile = getPrimaryFileForRequestOrEmitError(Req, Rec);
     if (!SourceFile)
       return;
     SmallVector<const char *, 8> Args;
@@ -1547,7 +1573,7 @@ handleRequestCollectVariableType(const RequestDict &Req,
 
   handleSemanticRequest(Req, Rec, [Req, CancellationToken, Rec]() {
     LangSupport &Lang = getGlobalContext().getSwiftLangSupport();
-    auto SourceFile = getSourceFileNameForRequestOrEmitError(Req, Rec);
+    auto SourceFile = getPrimaryFileForRequestOrEmitError(Req, Rec);
     if (!SourceFile)
       return;
     SmallVector<const char *, 8> Args;
@@ -1575,7 +1601,7 @@ handleRequestFindLocalRenameRanges(const RequestDict &Req,
     return;
 
   handleSemanticRequest(Req, Rec, [Req, CancellationToken, Rec]() {
-    auto SourceFile = getSourceFileNameForRequestOrEmitError(Req, Rec);
+    auto SourceFile = getPrimaryFileForRequestOrEmitError(Req, Rec);
     if (!SourceFile)
       return;
     SmallVector<const char *, 8> Args;
@@ -1605,7 +1631,7 @@ handleRequestNameTranslation(const RequestDict &Req,
     return;
 
   handleSemanticRequest(Req, Rec, [Req, CancellationToken, Rec]() {
-    auto SourceFile = getSourceFileNameForRequestOrEmitError(Req, Rec);
+    auto SourceFile = getPrimaryFileForRequestOrEmitError(Req, Rec);
     if (!SourceFile)
       return;
     SmallVector<const char *, 8> Args;
@@ -1666,7 +1692,7 @@ handleRequestRelatedIdents(const RequestDict &Req,
     return;
 
   handleSemanticRequest(Req, Rec, [Req, CancellationToken, Rec]() {
-    auto SourceFile = getSourceFileNameForRequestOrEmitError(Req, Rec);
+    auto SourceFile = getPrimaryFileForRequestOrEmitError(Req, Rec);
     if (!SourceFile)
       return;
     SmallVector<const char *, 8> Args;
@@ -1694,7 +1720,7 @@ handleRequestActiveRegions(const RequestDict &Req,
     return;
 
   handleSemanticRequest(Req, Rec, [Req, CancellationToken, Rec]() {
-    auto SourceFile = getSourceFileNameForRequestOrEmitError(Req, Rec);
+    auto SourceFile = getSourceFileForRequestOrEmitError(Req, Rec);
     if (!SourceFile)
       return;
     SmallVector<const char *> Args;
@@ -1711,7 +1737,7 @@ handleRequestDiagnostics(const RequestDict &Req,
                          ResponseReceiver Rec) {
   handleSemanticRequest(Req, Rec, [Req, CancellationToken, Rec]() {
     Optional<VFSOptions> vfsOptions = getVFSOptions(Req);
-    auto SourceFile = getSourceFileNameForRequestOrEmitError(Req, Rec);
+    auto SourceFile = getPrimaryFileForRequestOrEmitError(Req, Rec);
     if (!SourceFile)
       return;
     SmallVector<const char *, 8> Args;

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -264,7 +264,7 @@ RangeConfig getRange(unsigned BufferID, SourceManager &SM,
     RangeConfig Range;
     SourceLoc EndLoc = SM.getLocForLineCol(BufferID, End.Line,
                                            End.Column);
-    Range.BufferId = BufferID;
+    Range.BufferID = BufferID;
     Range.Line = Start.Line;
     Range.Column = Start.Column;
     Range.Length = SM.getByteDistance(Range.getStart(SM), EndLoc);

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -50,6 +50,7 @@ UID_KEYS = [
     KEY('Length', 'key.length'),
     KEY('SourceFile', 'key.sourcefile'),
     KEY('SourceText', 'key.sourcetext'),
+    KEY('PrimaryFile', 'key.primary_file'),
     KEY('EnableSyntaxMap', 'key.enablesyntaxmap'),
     KEY('EnableStructure', 'key.enablesubstructure'),
     KEY('ID', 'key.id'),


### PR DESCRIPTION
This adds a new `primary_file` key, which defaults to `sourcefile`. For nested expansions, `primary_file` should be set to the containing file and `sourcefile` to the name of the macro expansion buffer.