### PR TITLE
[test] Suppresses Pylint warnings in lit config scripts.

### DIFF
--- a/test/AutoDiff/compiler_crashers/lit.local.cfg
+++ b/test/AutoDiff/compiler_crashers/lit.local.cfg
@@ -1,2 +1,11 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 if 'asserts' not in config.available_features:
     config.unsupported = True

--- a/test/AutoDiff/compiler_crashers_fixed/lit.local.cfg
+++ b/test/AutoDiff/compiler_crashers_fixed/lit.local.cfg
@@ -1,2 +1,11 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 if 'asserts' not in config.available_features:
     config.unsupported = True

--- a/test/AutoDiff/lit.local.cfg
+++ b/test/AutoDiff/lit.local.cfg
@@ -1,2 +1,11 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 if 'differentiable_programming' not in config.available_features:
     config.unsupported = True

--- a/test/AutoDiff/stdlib/lit.local.cfg
+++ b/test/AutoDiff/stdlib/lit.local.cfg
@@ -1,3 +1,12 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 # AutoDiff is not shipped in any OS and does not support backdeployment
 if 'use_os_stdlib' in config.available_features or \
    'back_deployment_runtime' in config.available_features:

--- a/test/AutoDiff/validation-test/lit.local.cfg
+++ b/test/AutoDiff/validation-test/lit.local.cfg
@@ -1,3 +1,12 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 # AutoDiff is not shipped in any OS and does not support backdeployment
 if 'use_os_stdlib' in config.available_features or \
    'back_deployment_runtime' in config.available_features:

--- a/test/Demangle/lit.local.cfg
+++ b/test/Demangle/lit.local.cfg
@@ -1,3 +1,12 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes.add('.test')
 config.suffixes.add('.cpp')

--- a/test/Distributed/lit.local.cfg
+++ b/test/Distributed/lit.local.cfg
@@ -1,3 +1,12 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 # Make a local copy of the substitutions.
 config.substitutions = list(config.substitutions)
 

--- a/test/Driver/LegacyDriver/lit.local.cfg
+++ b/test/Driver/LegacyDriver/lit.local.cfg
@@ -1,3 +1,12 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 # Make a local copy of the environment.
 config.environment = dict(config.environment)
 

--- a/test/IRGen/lit.local.cfg
+++ b/test/IRGen/lit.local.cfg
@@ -1,3 +1,14 @@
+import os
+
+from lit.TestingConfig import SubstituteCaptures
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 # Make a local copy of the substitutions.
 config.substitutions = list(config.substitutions)
 

--- a/test/Interop/CxxToSwiftToCxx/lit.local.cfg
+++ b/test/Interop/CxxToSwiftToCxx/lit.local.cfg
@@ -1,1 +1,10 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 config.suffixes = ['.swift', '.cpp', '.mm']

--- a/test/Interop/ObjCToSwiftToObjCxx/lit.local.cfg
+++ b/test/Interop/ObjCToSwiftToObjCxx/lit.local.cfg
@@ -1,1 +1,10 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 config.suffixes = ['.swift', '.cpp', '.mm']

--- a/test/Interop/SwiftToC/lit.local.cfg
+++ b/test/Interop/SwiftToC/lit.local.cfg
@@ -1,1 +1,10 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 config.suffixes = ['.swift', '.c']

--- a/test/Interop/SwiftToCxx/lit.local.cfg
+++ b/test/Interop/SwiftToCxx/lit.local.cfg
@@ -1,1 +1,10 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 config.suffixes = ['.swift', '.cpp', '.mm']

--- a/test/Interop/lit.local.cfg
+++ b/test/Interop/lit.local.cfg
@@ -1,3 +1,14 @@
+import os
+
+from lit.TestingConfig import SubstituteCaptures
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 # Make a local copy of the substitutions.
 config.substitutions = list(config.substitutions)
 

--- a/test/Macros/lit.local.cfg
+++ b/test/Macros/lit.local.cfg
@@ -1,3 +1,12 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 # '-enable-experimental-feature Macros' requires an asserts build.
 if 'asserts' not in config.available_features:
     config.unsupported = True

--- a/test/ModuleInterface/lit.local.cfg
+++ b/test/ModuleInterface/lit.local.cfg
@@ -1,3 +1,13 @@
+import os
+import sys
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 # Make a local copy of the substitutions.
 config.substitutions = list(config.substitutions)
 

--- a/test/PrintAsObjC/lit.local.cfg
+++ b/test/PrintAsObjC/lit.local.cfg
@@ -1,3 +1,12 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 # Make a local copy of the substitutions.
 config.substitutions = list(config.substitutions)
 

--- a/test/SILGen/lit.local.cfg
+++ b/test/SILGen/lit.local.cfg
@@ -1,3 +1,12 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 # Make a local copy of the substitutions.
 config.substitutions = list(config.substitutions)
 

--- a/test/Sanitizers/lit.local.cfg
+++ b/test/Sanitizers/lit.local.cfg
@@ -1,2 +1,11 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 if 'no_asan' not in config.available_features:
     config.unsupported = True

--- a/test/SourceKit/lit.local.cfg
+++ b/test/SourceKit/lit.local.cfg
@@ -1,6 +1,13 @@
 import os
 import pipes
+import sys
 
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
 
 if 'sourcekit' not in config.available_features:
     config.unsupported = True
@@ -19,4 +26,3 @@ else:
     config.substitutions.append( ('%complete-test', '%s -module-cache-path=%r' % (config.complete_test, config.clang_module_cache_path)) )
     config.substitutions.append( ('%swiftlib_dir', config.swiftlib_dir) )
     config.substitutions.append( ('%sed_clean', '%s %s' % (pipes.quote(sys.executable), sk_path_sanitize) ) )
-

--- a/test/StringProcessing/lit.local.cfg
+++ b/test/StringProcessing/lit.local.cfg
@@ -1,2 +1,11 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 if 'string_processing' not in config.available_features:
     config.unsupported = True

--- a/test/Unit/lit.cfg
+++ b/test/Unit/lit.cfg
@@ -13,6 +13,13 @@ import os
 import lit.formats
 import lit.util
 
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 ###
 
 # Check that the object root is known.

--- a/test/api-digester/lit.local.cfg
+++ b/test/api-digester/lit.local.cfg
@@ -1,1 +1,10 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 config.suffixes.add('.test')

--- a/test/benchmark/lit.local.cfg
+++ b/test/benchmark/lit.local.cfg
@@ -1,2 +1,11 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes.add('.md')

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -33,6 +33,14 @@ from distutils.sysconfig import get_python_lib
 import lit
 import lit.formats
 import lit.util
+from lit.TestingConfig import SubstituteCaptures
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
 
 import site
 site.addsitedir(os.path.dirname(__file__))
@@ -1557,22 +1565,9 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
                                            target_specific_module_triple)
     config.variant_triple = re.sub(r'androideabi', 'android', config.variant_triple)
     config.target_cc_options = "-fPIE"
-    def get_architecture_value(**kwargs):
-        result = kwargs[run_cpu]
-        if result is None:
-          if run_cpu.startswith("armv7"):
-            result = kwargs["armv7"]
-          elif run_cpu == "arm64":
-            result = kwards["aarch64"]
-        return result
-
     config.target_cxx_lib = "-lstdc++"
     config.target_pic_opt = "-fPIC"
 
-    ndk_platform_tuple = get_architecture_value(armv7="armeabi-v7a",
-                                                aarch64="arm64-v8a")
-    ndk_platform_triple = get_architecture_value(armv7="arm-linux-androideabi",
-                                                 aarch64="aarch64-linux-android")
     if platform.system() == 'Linux':
         prebuilt_directory = 'linux-x86_64'
     elif platform.system() == 'Darwin':

--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -11,8 +11,13 @@
 # -----------------------------------------------------------------------------
 
 import os
-import platform
-import sys
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
 
 config.cmake = "@CMAKE_COMMAND@"
 config.llvm_src_root = "@LLVM_MAIN_SRC_DIR@"

--- a/test/refactoring/lit.local.cfg
+++ b/test/refactoring/lit.local.cfg
@@ -1,2 +1,11 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 config.substitutions.append((r'%refactor-check-compiles', f'{config.python} {config.refactor_check_compiles} -swift-refactor {config.swift_refactor} -swift-frontend {config.swift_frontend} -temp-dir %t {config.resource_dir_opt}'))
 config.substitutions.append((r'%refactor', f'{config.swift_refactor} {config.resource_dir_opt}'))

--- a/test/remote-run/lit.local.cfg
+++ b/test/remote-run/lit.local.cfg
@@ -1,3 +1,13 @@
+import os
+import sys
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 # Make a local copy of the substitutions.
 config.substitutions = list(config.substitutions)
 

--- a/validation-test/ParseableInterface/lit.local.cfg
+++ b/validation-test/ParseableInterface/lit.local.cfg
@@ -1,2 +1,11 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes.add('.py')

--- a/validation-test/SIL/lit.local.cfg
+++ b/validation-test/SIL/lit.local.cfg
@@ -1,2 +1,11 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes.add('.py')

--- a/validation-test/compiler_crashers/lit.local.cfg
+++ b/validation-test/compiler_crashers/lit.local.cfg
@@ -1,3 +1,12 @@
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+  from lit.LitConfig import LitConfig
+  from lit.TestingConfig import TestingConfig
+  config = TestingConfig()
+  lit_config = LitConfig()
+
 if "asan" in config.available_features:
     config.unsupported = True
 if "asserts" not in config.available_features:

--- a/validation-test/lit.cfg
+++ b/validation-test/lit.cfg
@@ -10,8 +10,12 @@
 #
 # -----------------------------------------------------------------------------
 
-import sys
-import platform
+import os
+
+# Tell pylint that we know config and lit_config exist somewhere.
+if 'PYLINT_IMPORT' in os.environ:
+    config = object()
+    lit_config = object()
 
 # Let the main config do the real work.
 lit_config.load_config(config,


### PR DESCRIPTION
Suppresses Pylint/Pylance warnings in lit config scripts which caused by `lit_config`, `config` and `SubstituteCaptures` is not defined in the script.

Moreover, this pull request removes unnecessary code in `test/lit.cfg` which spotted by Pylance.

Resolves #63907 
