### PR TITLE
[Parser|Sema] Accept access level on imports with experimental flag

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1395,6 +1395,12 @@ public:
   /// the decls it references. Otherwise, returns an empty array.
   ArrayRef<ValueDecl *> getDecls() const;
 
+  /// Access level of this import, either explicitly declared or implicit.
+  AccessLevel getAccessLevel() const;
+
+  /// Is the access level of this import implicit, aka a default import?
+  bool isAccessLevelImplicit() const;
+
   const clang::Module *getClangModule() const {
     return getClangNode().getClangModule();
   }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2044,6 +2044,16 @@ ERROR(spi_only_imports_not_enabled, none,
       "'@_spiOnly' requires setting the frontend flag '-experimental-spi-only-imports'",
       ())
 
+// Access level on imports
+ERROR(access_level_on_import_not_enabled, none,
+      "Access level on imports require '-enable-experimental-feature AccessLevelOnImport'",
+      ())
+ERROR(access_level_on_import_unsupported, none,
+      "The access level %0 is unsupported on imports: "
+      "only 'public', 'package', 'internal', 'fileprivate' and 'private' "
+      "are unsupported",
+      (DeclAttribute))
+
 // Opaque return types
 ERROR(opaque_type_invalid_constraint,none,
       "an 'opaque' type must specify only 'Any', 'AnyObject', protocols, "

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -115,7 +115,9 @@ EXPERIMENTAL_FEATURE(MoveOnlyClasses, true)
 EXPERIMENTAL_FEATURE(OneWayClosureParameters, false)
 EXPERIMENTAL_FEATURE(TypeWitnessSystemInference, false)
 EXPERIMENTAL_FEATURE(LayoutPrespecialization, true)
+
 EXPERIMENTAL_FEATURE(ModuleInterfaceExportAs, true)
+EXPERIMENTAL_FEATURE(AccessLevelOnImport, false)
 
 /// Whether to enable experimental differentiable programming features:
 /// `@differentiable` declaration attribute, etc.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3119,6 +3119,10 @@ static bool usesFeatureModuleInterfaceExportAs(Decl *decl) {
   return false;
 }
 
+static bool usesFeatureAccessLevelOnImport(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureNamedOpaqueTypes(Decl *decl) {
   return false;
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1343,6 +1343,28 @@ ArrayRef<ValueDecl *> ImportDecl::getDecls() const {
                            ScopedImportLookupRequest{mutableThis}, {});
 }
 
+AccessLevel ImportDecl::getAccessLevel() const {
+  if (auto attr = getAttrs().getAttribute<AccessControlAttr>()) {
+    return attr->getAccess();
+  }
+
+  auto &LangOpts = getASTContext().LangOpts;
+  if (LangOpts.isSwiftVersionAtLeast(6) &&
+      LangOpts.hasFeature(Feature::AccessLevelOnImport)) {
+    // Tentative Swift 6 mode where the default import is internal.
+    return AccessLevel::Internal;
+  } else {
+    return AccessLevel::Public;
+  }
+}
+
+bool ImportDecl::isAccessLevelImplicit() const {
+  if (auto attr = getAttrs().getAttribute<AccessControlAttr>()) {
+    return false;
+  }
+  return true;
+}
+
 void NominalTypeDecl::setConformanceLoader(LazyMemberLoader *lazyLoader,
                                            uint64_t contextData) {
   assert(!Bits.NominalTypeDecl.HasLazyConformances &&

--- a/lib/Sema/ImportResolution.cpp
+++ b/lib/Sema/ImportResolution.cpp
@@ -543,6 +543,11 @@ UnboundImport::UnboundImport(ImportDecl *ID)
   if (ID->getAttrs().hasAttribute<ImplementationOnlyAttr>())
     import.options |= ImportFlags::ImplementationOnly;
 
+  import.accessLevel = ID->getAccessLevel();
+  if (auto attr = ID->getAttrs().getAttribute<AccessControlAttr>()) {
+    import.accessLevelLoc = attr->getLocation();
+  }
+
   if (ID->getAttrs().hasAttribute<SPIOnlyAttr>())
     import.options |= ImportFlags::SPIOnly;
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -934,7 +934,7 @@ void AttributeChecker::visitLazyAttr(LazyAttr *attr) {
 bool AttributeChecker::visitAbstractAccessControlAttr(
     AbstractAccessControlAttr *attr) {
   // Access control attr may only be used on value decls and extensions.
-  if (!isa<ValueDecl>(D) && !isa<ExtensionDecl>(D)) {
+  if (!isa<ValueDecl>(D) && !isa<ExtensionDecl>(D) && !isa<ImportDecl>(D)) {
     diagnoseAndRemoveAttr(attr, diag::invalid_decl_modifier, attr);
     return true;
   }
@@ -958,6 +958,19 @@ bool AttributeChecker::visitAbstractAccessControlAttr(
     diagnoseAndRemoveAttr(attr, diag::access_control_in_protocol, attr);
     diagnose(attr->getLocation(), diag::access_control_in_protocol_detail);
     return true;
+  }
+
+  if (auto importDecl = dyn_cast<ImportDecl>(D)) {
+    if (!D->getASTContext().LangOpts.hasFeature(Feature::AccessLevelOnImport)) {
+      diagnoseAndRemoveAttr(attr, diag::access_level_on_import_not_enabled);
+      return true;
+    }
+
+    if (attr->getAccess() == AccessLevel::Open) {
+      diagnoseAndRemoveAttr(attr, diag::access_level_on_import_unsupported,
+                            attr);
+      return true;
+    }
   }
 
   return false;

--- a/test/Sema/access-level-import-flag-check.swift
+++ b/test/Sema/access-level-import-flag-check.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Build the libraries.
+// RUN: %target-swift-frontend -emit-module %t/PublicLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/PackageLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/InternalLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/FileprivateLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/PrivateLib.swift -o %t
+
+/// Check flag requirement, without and with the flag.
+// RUN: %target-swift-frontend -typecheck %t/ClientWithoutTheFlag.swift -I %t -verify
+// RUN: %target-swift-frontend -typecheck %t/ClientWithoutTheFlag.swift -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+
+//--- PublicLib.swift
+//--- PackageLib.swift
+//--- InternalLib.swift
+//--- FileprivateLib.swift
+//--- PrivateLib.swift
+
+//--- ClientWithoutTheFlag.swift
+public import PublicLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}
+package import PackageLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}
+internal import InternalLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}
+fileprivate import FileprivateLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}
+private import PrivateLib // expected-error@:1 {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport'}}

--- a/test/Sema/access-level-import-parsing.swift
+++ b/test/Sema/access-level-import-parsing.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Build the libraries.
+// RUN: %target-swift-frontend -emit-module %t/PublicLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/PackageLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/InternalLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/FileprivateLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/PrivateLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/OpenLib.swift -o %t
+
+/// Check that all access levels are accepted, except for 'open'.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+
+//--- PublicLib.swift
+//--- PackageLib.swift
+//--- InternalLib.swift
+//--- FileprivateLib.swift
+//--- PrivateLib.swift
+//--- OpenLib.swift
+
+//--- Client.swift
+public import PublicLib
+package import PackageLib
+internal import InternalLib
+fileprivate import FileprivateLib
+private import PrivateLib
+open import OpenLib // expected-error {{The access level 'open' is unsupported on imports: only 'public', 'package', 'internal', 'fileprivate' and 'private' are unsupported}}

--- a/test/attr/accessibility.swift
+++ b/test/attr/accessibility.swift
@@ -63,7 +63,7 @@ var unterminatedEmptySubject = 0
 duplicateAttr(1) // expected-error{{argument passed to call that takes no arguments}}
 
 // CHECK ALLOWED DECLS
-private import Swift // expected-error {{'private' modifier cannot be applied to this declaration}} {{1-9=}}
+private import Swift // expected-error {{Access level on imports require '-enable-experimental-feature AccessLevelOnImport}}
 private(set) infix operator ~~~ // expected-error {{'private' modifier cannot be applied to this declaration}} {{1-14=}}
 
 private typealias MyInt = Int

--- a/utils/gyb_syntax_support/AttributeKinds.py
+++ b/utils/gyb_syntax_support/AttributeKinds.py
@@ -825,7 +825,7 @@ DECL_MODIFIER_KINDS = [
                                   code=44),
     DeclAttribute('private', 'AccessControl',
                   OnFunc, OnAccessor, OnExtension, OnGenericType, OnVar, OnSubscript,
-                  OnConstructor, OnMacro,
+                  OnConstructor, OnMacro, OnImport,
                   DeclModifier,
                   NotSerialized,
                   ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,


### PR DESCRIPTION
This prepares the ground for the use of access level on imports as a proper language feature, replacing `@_implementationOnly`.

Future PRs will add related API type-checking and module interface support.