### PR TITLE
Improve functionality available for manipulating status records. 

### DIFF
--- a/include/swift/ABI/TaskStatus.h
+++ b/include/swift/ABI/TaskStatus.h
@@ -61,25 +61,10 @@ public:
 
   TaskStatusRecord *getParent() const { return Parent; }
 
-  /// Change the parent of this unregistered status record to the
-  /// given record.
-  ///
-  /// This should be used when the record has been previously initialized
-  /// without knowing what the true parent is.  If we decide to cache
-  /// important information (e.g. the earliest timeout) in the innermost
-  /// status record, this is the method that should fill that in
-  /// from the parent.
+  /// Change the parent of this status record to the given record.
   void resetParent(TaskStatusRecord *newParent) {
     Parent = newParent;
-    // TODO: cache
   }
-
-  /// Splice a record out of the status-record chain.
-  ///
-  /// Unlike resetParent, this assumes that it's just removing one or
-  /// more records from the chain and that there's no need to do any
-  /// extra cache manipulation.
-  void spliceParent(TaskStatusRecord *newParent) { Parent = newParent; }
 };
 
 /// A status record which states that a task has one or

--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -334,7 +334,7 @@ static void swift_asyncLet_endImpl(AsyncLet *alet) {
 
   // Remove the child record from the parent task
   auto record = asImpl(alet)->getTaskRecord();
-  removeStatusRecord(record);
+  removeStatusRecordFromSelf(record);
 
   // TODO: we need to implicitly await either before the end or here somehow.
 
@@ -362,7 +362,7 @@ static void asyncLet_finish_after_task_completion(SWIFT_ASYNC_CONTEXT AsyncConte
 
   // Remove the child record from the parent task
   auto record = asImpl(alet)->getTaskRecord();
-  removeStatusRecord(record);
+  removeStatusRecordFromSelf(record);
 
   // and finally, release the task and destroy the async-let
   assert(swift_task_getCurrent() && "async-let must have a parent task");

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1512,7 +1512,7 @@ swift_task_addCancellationHandlerImpl(
 SWIFT_CC(swift)
 static void swift_task_removeCancellationHandlerImpl(
     CancellationNotificationStatusRecord *record) {
-  removeStatusRecord(record);
+  removeStatusRecordFromSelf(record);
   swift_task_dealloc(record);
 }
 

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -985,7 +985,7 @@ void AccumulatingTaskGroup::destroy() {
   assert(this->isEmpty() && "Attempted to destroy non-empty task group!");
 
   // First, remove the group from the task and deallocate the record
-  removeStatusRecord(getTaskRecord());
+  removeStatusRecordFromSelf(getTaskRecord());
 
   // No need to drain our queue here, as by the time we call destroy,
   // all tasks inside the group must have been awaited on already.
@@ -1008,7 +1008,7 @@ void DiscardingTaskGroup::destroy() {
   assert(this->isEmpty() && "Attempted to destroy non-empty task group!");
 
   // First, remove the group from the task and deallocate the record
-  removeStatusRecord(getTaskRecord());
+  removeStatusRecordFromSelf(getTaskRecord());
 
   // No need to drain our queue here, as by the time we call destroy,
   // all tasks inside the group must have been awaited on already.


### PR DESCRIPTION
Provide updateStatusRecord function which allows clients to update a status record that is already registered with the task. Provide more versatile removeStatusRecord functions and update clients to use them

Radar-Id: rdar://problem/101864092
