### PR TITLE
Track  the executor that a task is enqueued in, in dependency records

### DIFF
--- a/include/swift/ABI/Executor.h
+++ b/include/swift/ABI/Executor.h
@@ -67,6 +67,7 @@ class ExecutorRef {
     : Identity(identity), Implementation(implementation) {}
 
 public:
+
   /// A generic execution environment.  When running in a generic
   /// environment, it's presumed to be okay to switch synchronously
   /// to an actor.  As an executor request, this represents a request

--- a/include/swift/ABI/TaskStatus.h
+++ b/include/swift/ABI/TaskStatus.h
@@ -61,25 +61,10 @@ public:
 
   TaskStatusRecord *getParent() const { return Parent; }
 
-  /// Change the parent of this unregistered status record to the
-  /// given record.
-  ///
-  /// This should be used when the record has been previously initialized
-  /// without knowing what the true parent is.  If we decide to cache
-  /// important information (e.g. the earliest timeout) in the innermost
-  /// status record, this is the method that should fill that in
-  /// from the parent.
+  /// Change the parent of this status record to the given record.
   void resetParent(TaskStatusRecord *newParent) {
     Parent = newParent;
-    // TODO: cache
   }
-
-  /// Splice a record out of the status-record chain.
-  ///
-  /// Unlike resetParent, this assumes that it's just removing one or
-  /// more records from the chain and that there's no need to do any
-  /// extra cache manipulation.
-  void spliceParent(TaskStatusRecord *newParent) { Parent = newParent; }
 };
 
 /// A status record which states that a task has one or

--- a/include/swift/ABI/TaskStatus.h
+++ b/include/swift/ABI/TaskStatus.h
@@ -22,6 +22,7 @@
 
 #include "swift/ABI/MetadataValues.h"
 #include "swift/ABI/Task.h"
+#include "swift/ABI/Executor.h"
 #include "swift/Runtime/HeapObject.h"
 
 namespace swift {
@@ -278,22 +279,23 @@ public:
 // This record is allocated for a task to record what it is dependent on before
 // the task can make progress again.
 class TaskDependencyStatusRecord : public TaskStatusRecord {
-  // A word sized storage which references what this task is suspended waiting
-  // for. Note that this is different from the waitQueue in the future fragment
-  // of a task since that denotes all the tasks which this specific task, will
-  // unblock.
+  // A word sized storage which references what this task is waiting for. Note
+  // that this is different from the waitQueue in the future fragment of a task
+  // since that denotes all the tasks which this specific task, will unblock.
   //
   // This field is only really pointing to something valid when the
-  // ActiveTaskStatus specifies that the task is suspended. It can be accessed
-  // asynchronous to the task during escalation which will therefore require the
-  // task status record lock for synchronization.
+  // ActiveTaskStatus specifies that the task is suspended or enqueued. It can
+  // be accessed asynchronous to the task during escalation which will therefore
+  // require the task status record lock for synchronization.
   //
   // When a task has TaskDependencyStatusRecord in the status record list, it
   // must be the innermost status record, barring the status record lock which
   // could be taken while this record is present.
   //
   // The type of thing we are waiting on, is specified in the enum below
-  union {
+  union Dependent {
+    constexpr Dependent() {}
+
     // This task is suspended waiting on another task. This could be an async
     // let child task or it could be another unstructured task.
     AsyncTask *Task;
@@ -310,35 +312,58 @@ class TaskDependencyStatusRecord : public TaskStatusRecord {
     // the duration of the wait. We do not need to take an additional +1 on this
     // task group in this dependency record.
     TaskGroup *TaskGroup;
-  } WaitingOn;
+
+    // The task is enqueued waiting on an executor. It could be any kind of
+    // executor - the generic executor, the default actor's executor, or an
+    // actor with a custom executor.
+    //
+    // This information is helpful to know *where* a task is enqueued into
+    // (potentially intrusively), so that the appropriate escalation effect
+    // (which may be different for each type of executor) can happen if a task
+    // is escalated while enqueued.
+    ExecutorRef Executor;
+  } DependentOn;
 
   // Enum specifying the type of dependency this task has
   enum DependencyKind {
     WaitingOnTask = 1,
     WaitingOnContinuation,
     WaitingOnTaskGroup,
+
+    EnqueuedOnExecutor,
   } DependencyKind;
 
+  // The task that has this task status record - ie a backpointer from the
+  // record to the task with the record. This is not its own +1, we rely on the
+  // fact that since this status record is linked into a task, the task is
+  // already alive and maintained by someone and we can safely borrow the
+  // reference.
+  AsyncTask *WaitingTask;
+
 public:
-  TaskDependencyStatusRecord(AsyncTask *task) :
+  TaskDependencyStatusRecord(AsyncTask *waitingTask, AsyncTask *task) :
     TaskStatusRecord(TaskStatusRecordKind::TaskDependency),
-        DependencyKind(WaitingOnTask) {
-      WaitingOn.Task = task;
+        DependencyKind(WaitingOnTask), WaitingTask(waitingTask) {
+      DependentOn.Task = task;
   }
 
-  TaskDependencyStatusRecord(ContinuationAsyncContext *context) :
+  TaskDependencyStatusRecord(AsyncTask *waitingTask, ContinuationAsyncContext *context) :
     TaskStatusRecord(TaskStatusRecordKind::TaskDependency),
-        DependencyKind(WaitingOnContinuation) {
-      WaitingOn.Continuation = context;
+        DependencyKind(WaitingOnContinuation), WaitingTask(waitingTask) {
+      DependentOn.Continuation = context;
   }
 
-  TaskDependencyStatusRecord(TaskGroup *taskGroup) :
+  TaskDependencyStatusRecord(AsyncTask *waitingTask, TaskGroup *taskGroup) :
     TaskStatusRecord(TaskStatusRecordKind::TaskDependency),
-        DependencyKind(WaitingOnTaskGroup) {
-      WaitingOn.TaskGroup = taskGroup;
+        DependencyKind(WaitingOnTaskGroup), WaitingTask(waitingTask){
+      DependentOn.TaskGroup = taskGroup;
   }
 
-  void destroy() { }
+  TaskDependencyStatusRecord(AsyncTask *waitingTask, ExecutorRef executor) :
+    TaskStatusRecord(TaskStatusRecordKind::TaskDependency),
+        DependencyKind(EnqueuedOnExecutor), WaitingTask(waitingTask) {
+      DependentOn.Executor = executor;
+  }
 
   static bool classof(const TaskStatusRecord *record) {
     return record->getKind() == TaskStatusRecordKind::TaskDependency;

--- a/include/swift/ABI/TaskStatus.h
+++ b/include/swift/ABI/TaskStatus.h
@@ -369,6 +369,11 @@ public:
     return record->getKind() == TaskStatusRecordKind::TaskDependency;
   }
 
+  void updateDependencyToEnqueuedOn(ExecutorRef executor) {
+    DependencyKind = EnqueuedOnExecutor;
+    DependentOn.Executor = executor;
+  }
+
   void performEscalationAction(JobPriority newPriority);
 };
 

--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1808,17 +1808,19 @@ static void swift_task_enqueueImpl(Job *job, ExecutorRef executor) {
     return swift_task_enqueueGlobal(job);
 
   if (executor.isDefaultActor()) {
-#if SWIFT_CONCURRENCY_ACTORS_AS_LOCKS
-    assert(false && "Should not enqueue tasks on actors in actors as locks model");
-#else
-    return asImpl(executor.getDefaultActor())->enqueue(job, job->getPriority());
-#endif
+    return swift_defaultActor_enqueue(job, executor.getDefaultActor());
   }
 
+  // For main actor or actors with custom executors
   auto wtable = executor.getSerialExecutorWitnessTable();
   auto executorObject = executor.getIdentity();
   auto executorType = swift_getObjectType(executorObject);
   _swift_task_enqueueOnExecutor(job, executorObject, executorType, wtable);
+}
+
+SWIFT_CC(swift)
+void swift::swift_executor_escalate(ExecutorRef executor, AsyncTask *task,
+  JobPriority newPriority) {
 }
 
 #define OVERRIDE_ACTOR COMPATIBILITY_OVERRIDE

--- a/stdlib/public/Concurrency/AsyncLet.cpp
+++ b/stdlib/public/Concurrency/AsyncLet.cpp
@@ -334,7 +334,7 @@ static void swift_asyncLet_endImpl(AsyncLet *alet) {
 
   // Remove the child record from the parent task
   auto record = asImpl(alet)->getTaskRecord();
-  removeStatusRecord(record);
+  removeStatusRecordFromSelf(record);
 
   // TODO: we need to implicitly await either before the end or here somehow.
 
@@ -362,7 +362,7 @@ static void asyncLet_finish_after_task_completion(SWIFT_ASYNC_CONTEXT AsyncConte
 
   // Remove the child record from the parent task
   auto record = asImpl(alet)->getTaskRecord();
-  removeStatusRecord(record);
+  removeStatusRecordFromSelf(record);
 
   // and finally, release the task and destroy the async-let
   assert(swift_task_getCurrent() && "async-let must have a parent task");

--- a/stdlib/public/Concurrency/Task.cpp
+++ b/stdlib/public/Concurrency/Task.cpp
@@ -1512,7 +1512,7 @@ swift_task_addCancellationHandlerImpl(
 SWIFT_CC(swift)
 static void swift_task_removeCancellationHandlerImpl(
     CancellationNotificationStatusRecord *record) {
-  removeStatusRecord(record);
+  removeStatusRecordFromSelf(record);
   swift_task_dealloc(record);
 }
 

--- a/stdlib/public/Concurrency/TaskGroup.cpp
+++ b/stdlib/public/Concurrency/TaskGroup.cpp
@@ -985,7 +985,7 @@ void AccumulatingTaskGroup::destroy() {
   assert(this->isEmpty() && "Attempted to destroy non-empty task group!");
 
   // First, remove the group from the task and deallocate the record
-  removeStatusRecord(getTaskRecord());
+  removeStatusRecordFromSelf(getTaskRecord());
 
   // No need to drain our queue here, as by the time we call destroy,
   // all tasks inside the group must have been awaited on already.
@@ -1008,7 +1008,7 @@ void DiscardingTaskGroup::destroy() {
   assert(this->isEmpty() && "Attempted to destroy non-empty task group!");
 
   // First, remove the group from the task and deallocate the record
-  removeStatusRecord(getTaskRecord());
+  removeStatusRecordFromSelf(getTaskRecord());
 
   // No need to drain our queue here, as by the time we call destroy,
   // all tasks inside the group must have been awaited on already.

--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -1063,7 +1063,6 @@ void AsyncTask::flagAsSuspended(TaskDependencyStatusRecord *dependencyStatusReco
 inline void AsyncTask::destroyTaskDependency(TaskDependencyStatusRecord *dependencyRecord) {
   assert(_private().dependencyRecord == dependencyRecord);
 
-  dependencyRecord->destroy();
   _swift_task_dealloc_specific(this, dependencyRecord);
 
   _private().dependencyRecord = nullptr;
@@ -1075,7 +1074,7 @@ inline void AsyncTask::flagAsSuspendedOnTask(AsyncTask *task) {
   assert(_private().dependencyRecord == nullptr);
 
   void *allocation = _swift_task_alloc_specific(this, sizeof(class TaskDependencyStatusRecord));
-  auto record = ::new (allocation) TaskDependencyStatusRecord(task);
+  auto record = ::new (allocation) TaskDependencyStatusRecord(this, task);
   SWIFT_TASK_DEBUG_LOG("[Dependency] Create a dependencyRecord %p for dependency on task %p", allocation, task);
   _private().dependencyRecord = record;
 
@@ -1086,7 +1085,7 @@ inline void AsyncTask::flagAsSuspendedOnContinuation(ContinuationAsyncContext *c
   assert(_private().dependencyRecord == nullptr);
 
   void *allocation = _swift_task_alloc_specific(this, sizeof(class TaskDependencyStatusRecord));
-  auto record = ::new (allocation) TaskDependencyStatusRecord(context);
+  auto record = ::new (allocation) TaskDependencyStatusRecord(this, context);
   SWIFT_TASK_DEBUG_LOG("[Dependency] Create a dependencyRecord %p for dependency on continuation %p", allocation, context);
   _private().dependencyRecord = record;
 
@@ -1097,7 +1096,7 @@ inline void AsyncTask::flagAsSuspendedOnTaskGroup(TaskGroup *taskGroup) {
   assert(_private().dependencyRecord == nullptr);
 
   void *allocation = _swift_task_alloc_specific(this, sizeof(class TaskDependencyStatusRecord));
-  auto record = ::new (allocation) TaskDependencyStatusRecord(taskGroup);
+  auto record = ::new (allocation) TaskDependencyStatusRecord(this, taskGroup);
   SWIFT_TASK_DEBUG_LOG("[Dependency] Create a dependencyRecord %p for dependency on taskGroup %p", allocation, taskGroup);
   _private().dependencyRecord = record;
 

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -479,6 +479,7 @@ void swift::updateStatusRecord(AsyncTask *task, TaskStatusRecord *record,
      ActiveTaskStatus& status,
      llvm::function_ref<void(ActiveTaskStatus, ActiveTaskStatus&)>fn) {
 
+  SWIFT_TASK_DEBUG_LOG("Updating status record %p of task %p", record, task);
   withStatusRecordLock(task, status, [&](ActiveTaskStatus lockedStatus) {
 #if NDEBUG
     bool foundRecord = false;
@@ -841,6 +842,7 @@ void TaskDependencyStatusRecord::performEscalationAction(JobPriority newPriority
     case EnqueuedOnExecutor:
       SWIFT_TASK_DEBUG_LOG("[Dependency] Escalate dependent executor %p noted in %p record",
         this->DependentOn.Executor, this);
+      swift_executor_escalate(this->DependentOn.Executor, this->WaitingTask, newPriority);
       break;
   }
 }

--- a/stdlib/public/Concurrency/TaskStatus.cpp
+++ b/stdlib/public/Concurrency/TaskStatus.cpp
@@ -820,19 +820,28 @@ static swift_task_escalateImpl(AsyncTask *task, JobPriority newPriority) {
 void TaskDependencyStatusRecord::performEscalationAction(JobPriority newPriority) {
   switch (this->DependencyKind) {
     case WaitingOnTask:
-      swift_task_escalate(this->WaitingOn.Task, newPriority);
+      SWIFT_TASK_DEBUG_LOG("[Dependency] Escalate dependent task %p noted in %p record",
+        this->DependentOn.Task, this);
+      swift_task_escalate(this->DependentOn.Task, newPriority);
       break;
     case WaitingOnContinuation:
       // We can't do anything meaningful to escalate this since we don't know
       // who will resume the continuation
+      SWIFT_TASK_DEBUG_LOG("[Dependency] Escalate dependent continuation %p noted in %p record -- do nothing",
+        this->DependentOn.Continuation, this);
       break;
-    case WaitingOnTaskGroup: {
+    case WaitingOnTaskGroup:
       // If a task is being escalated while waiting on a task group, the task
       // should also have a TaskGroupTaskStatusRecord and the escalation
       // action on that record should do the needful to propagate the
       // escalation to the child tasks. We can short-circuit here.
+      SWIFT_TASK_DEBUG_LOG("[Dependency] Escalate dependent taskgroup %p noted in %p record -- do nothing",
+        this->DependentOn.TaskGroup, this);
       break;
-    }
+    case EnqueuedOnExecutor:
+      SWIFT_TASK_DEBUG_LOG("[Dependency] Escalate dependent executor %p noted in %p record",
+        this->DependentOn.Executor, this);
+      break;
   }
 }
 


### PR DESCRIPTION
This tracks the executor that a task is enqueued into, in the TaskDependencyStatusRecord. 

This PR builds upon a few others:
* https://github.com/apple/swift/pull/63019
* https://github.com/apple/swift/pull/63800
* https://github.com/apple/swift/pull/63842
*  https://github.com/apple/swift/pull/63916

Note that this PR simply tracks the bookkeeping of the executor in the status record. There will be a follow on change to be able to do something useful when the TaskDependencyStatusRecord gets escalated. 

rdar://105932276