### PR TITLE
Runtime: Add swift_allocateMetadataPack() and swift_allocateWitnessTablePack()

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -429,6 +429,36 @@ bool swift_compareProtocolConformanceDescriptors(
     const ProtocolConformanceDescriptor *lhs,
     const ProtocolConformanceDescriptor *rhs);
 
+/// Allocate a metadata pack on the heap, unless this pack is already on the
+/// heap.
+///
+/// Metadata packs are uniqued by pointer equality on their elements.
+///
+/// \param pack A pack pointer, where the least significant bit indicates if
+/// it is already on the heap.
+/// \param count The number of metadata pointers in the pack.
+///
+/// \returns a metadata pack allocated on the heap, with the least significant
+/// bit set to true.
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+const Metadata * const *
+swift_allocateMetadataPack(const Metadata * const *pack, unsigned count);
+
+/// Allocate a witness table pack on the heap, unless this pack is already on
+/// the heap.
+///
+/// Witness table packs are not uniqued.
+///
+/// \param pack A pack pointer, where the least significant bit indicates if
+/// it is already on the heap.
+/// \param count The number of witness table pointers in the pack.
+///
+/// \returns a witness table pack allocated on the heap, with the least
+/// significant bit set to true.
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+const WitnessTable * const *
+swift_allocateWitnessTablePack(const WitnessTable * const *pack, unsigned count);
+
 /// Fetch a uniqued metadata for a function type.
 SWIFT_RUNTIME_EXPORT
 const FunctionTypeMetadata *

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -441,8 +441,8 @@ bool swift_compareProtocolConformanceDescriptors(
 /// \returns a metadata pack allocated on the heap, with the least significant
 /// bit set to true.
 SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
-const Metadata * const *
-swift_allocateMetadataPack(const Metadata * const *pack, unsigned count);
+MetadataPackPointer
+swift_allocateMetadataPack(MetadataPackPointer pack, unsigned count);
 
 /// Allocate a witness table pack on the heap, unless this pack is already on
 /// the heap.
@@ -456,8 +456,8 @@ swift_allocateMetadataPack(const Metadata * const *pack, unsigned count);
 /// \returns a witness table pack allocated on the heap, with the least
 /// significant bit set to true.
 SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
-const WitnessTable * const *
-swift_allocateWitnessTablePack(const WitnessTable * const *pack, unsigned count);
+WitnessTablePackPointer
+swift_allocateWitnessTablePack(WitnessTablePackPointer pack, unsigned count);
 
 /// Fetch a uniqued metadata for a function type.
 SWIFT_RUNTIME_EXPORT

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1125,6 +1125,119 @@ swift::swift_getObjCClassFromMetadataConditional(const Metadata *theMetadata) {
 #endif
 
 /***************************************************************************/
+/*** Metadata and witness table packs **************************************/
+/***************************************************************************/
+
+namespace {
+
+class MetadataPackCacheEntry {
+public:
+  unsigned Count;
+
+  const Metadata * const * getElements() const {
+    return reinterpret_cast<const Metadata * const *>(this + 1);
+  }
+
+  const Metadata ** getElements() {
+    return reinterpret_cast<const Metadata **>(this + 1);
+  }
+
+  struct Key {
+    const Metadata *const *Data;
+    const unsigned Count;
+
+    unsigned getCount() const {
+      return Count;
+    }
+
+    const Metadata *getElement(unsigned index) const {
+      assert(index < Count);
+      return Data[index];
+    }
+
+    friend llvm::hash_code hash_value(const Key &key) {
+      llvm::hash_code hash = 0;
+      for (unsigned i = 0; i != key.getCount(); ++i)
+        hash = llvm::hash_combine(hash, key.getElement(i));
+      return hash;
+    }
+  };
+
+  MetadataPackCacheEntry(const Key &key);
+
+  intptr_t getKeyIntValueForDump() {
+    return 0; // No single meaningful value here.
+  }
+
+  bool matchesKey(const Key &key) const {
+    if (key.getCount() != Count)
+      return false;
+    for (unsigned i = 0; i != Count; ++i) {
+      if (key.getElement(i) != getElements()[i])
+        return false;
+    }
+    return true;
+  }
+
+  friend llvm::hash_code hash_value(const MetadataPackCacheEntry &value) {
+    return hash_value(value.getElements());
+  }
+
+  static size_t getExtraAllocationSize(const Key &key) {
+    return getExtraAllocationSize(key.Count);
+  }
+
+  size_t getExtraAllocationSize() const {
+    return getExtraAllocationSize(Count);
+  }
+
+  static size_t getExtraAllocationSize(unsigned count) {
+    return count * sizeof(const Metadata * const *);
+  }
+};
+
+MetadataPackCacheEntry::MetadataPackCacheEntry(const Key &key) {
+  auto count = key.getCount();
+
+  for (unsigned i = 0; i < count; ++i)
+    getElements()[i] = key.getElement(i);
+}
+
+} // end anonymous namespace
+
+/// The uniquing structure for metadata packs.
+static SimpleGlobalCache<MetadataPackCacheEntry, MetadataPackTag> MetadataPacks;
+
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+const Metadata * const *
+swift_allocateMetadataPack(const Metadata * const *pack, unsigned count) {
+  if (reinterpret_cast<uintptr_t>(pack) & 1)
+    return pack;
+
+  MetadataPackCacheEntry::Key key{pack, count};
+  auto bytes = MetadataPacks.getOrInsert(key).first->getElements();
+
+  uintptr_t bytesWithLSBSet = reinterpret_cast<uintptr_t>(bytes) | 1;
+  return reinterpret_cast<const Metadata * const *>(bytesWithLSBSet);
+}
+
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+const WitnessTable * const *
+swift_allocateWitnessTablePack(const WitnessTable * const *pack, unsigned count) {
+  if (reinterpret_cast<uintptr_t>(pack) & 1)
+    return pack;
+
+  size_t totalSize = (size_t) count * sizeof(const WitnessTable *);
+
+  auto bytes = (char*) MetadataAllocator(WitnessTablePackTag)
+    .Allocate(totalSize, alignof(const WitnessTable *));
+  memcpy(bytes, pack, totalSize);
+
+  uintptr_t bytesWithLSBSet = reinterpret_cast<uintptr_t>(bytes) | 1;
+  return reinterpret_cast<const WitnessTable * const *>(bytesWithLSBSet);
+}
+
+/***************************************************************************/
 /*** Functions *************************************************************/
 /***************************************************************************/
 

--- a/stdlib/public/runtime/MetadataAllocatorTags.def
+++ b/stdlib/public/runtime/MetadataAllocatorTags.def
@@ -46,5 +46,7 @@ TAG(GlobalMetadataCache, 20)
 TAG(GlobalWitnessTableCache, 21)
 TAG(ExtendedExistentialTypes, 22)
 TAG(ExtendedExistentialTypeShapes, 23)
+TAG(MetadataPack, 24)
+TAG(WitnessTablePack, 25)
 
 #undef TAG


### PR DESCRIPTION
Both return the pack immediately if its already heap allocated, by checking the least significant bit of the pack pointer.

Then,
- swift_allocateMetadataPack() uniques the metadata pack by the pointer equality of elements.
- swift_allocateWitnessTablePack() does not unique the pack.

Both return a pack pointer with the least significant bit set, indicating heap allocation.