### PR TITLE
[Sema] Playground transform should also log function and closure parameter values

### DIFF
--- a/lib/Sema/InstrumenterSupport.h
+++ b/lib/Sema/InstrumenterSupport.h
@@ -49,6 +49,7 @@ protected:
   virtual ~InstrumenterBase() = default;
   virtual void anchor();
   virtual BraceStmt *transformBraceStmt(BraceStmt *BS,
+                                        const ParameterList *PL = nullptr,
                                         bool TopLevel = false) = 0;
 
   /// Create an expression which retrieves a valid ModuleIdentifier or
@@ -73,7 +74,8 @@ protected:
       if (auto *CE = dyn_cast<ClosureExpr>(E)) {
         BraceStmt *B = CE->getBody();
         if (B) {
-          BraceStmt *NB = I.transformBraceStmt(B);
+          const ParameterList *PL = CE->getParameters();
+          BraceStmt *NB = I.transformBraceStmt(B, PL);
           CE->setBody(NB, false);
           // just with the entry and exit logging this is going to
           // be more than a single expression!

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -337,7 +337,8 @@ public:
       return D;
     if (auto *FD = dyn_cast<FuncDecl>(D)) {
       if (BraceStmt *B = FD->getBody()) {
-        BraceStmt *NB = transformBraceStmt(B);
+        const ParameterList *PL = FD->getParameters();
+        BraceStmt *NB = transformBraceStmt(B, PL);
         // Since it would look strange going straight to the first line in a
         // function body, we throw in a before/after pointing at the function
         // decl at the start of the transformed body
@@ -366,7 +367,9 @@ public:
     return D;
   }
 
-  BraceStmt *transformBraceStmt(BraceStmt *BS, bool TopLevel = false) override {
+  BraceStmt *transformBraceStmt(BraceStmt *BS,
+                                const ParameterList *PL = nullptr,
+                                bool TopLevel = false) override {
     ArrayRef<ASTNode> OriginalElements = BS->getElements();
     SmallVector<swift::ASTNode, 3> Elements(OriginalElements.begin(),
                                             OriginalElements.end());
@@ -688,7 +691,7 @@ void swift::performPCMacro(SourceFile &SF) {
         if (!TLCD->isImplicit()) {
           if (BraceStmt *Body = TLCD->getBody()) {
             Instrumenter I(ctx, TLCD, TmpNameIndex);
-            BraceStmt *NewBody = I.transformBraceStmt(Body, true);
+            BraceStmt *NewBody = I.transformBraceStmt(Body, nullptr, true);
             if (NewBody != Body) {
               TLCD->setBody(NewBody);
               TypeChecker::checkTopLevelEffects(TLCD);

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -290,8 +290,9 @@ public:
       return D;
     if (auto *FD = dyn_cast<FuncDecl>(D)) {
       if (BraceStmt *B = FD->getBody()) {
+        const ParameterList *PL = FD->getParameters();
         TargetKindSetter TKS(BracePairs, BracePair::TargetKinds::Return);
-        BraceStmt *NB = transformBraceStmt(B);
+        BraceStmt *NB = transformBraceStmt(B, PL);
         if (NB != B) {
           FD->setBody(NB, AbstractFunctionDecl::BodyKind::TypeChecked);
           TypeChecker::checkFunctionEffects(FD);
@@ -380,7 +381,9 @@ public:
     return uniqueRef;
   }
 
-  BraceStmt *transformBraceStmt(BraceStmt *BS, bool TopLevel = false) override {
+  BraceStmt *transformBraceStmt(BraceStmt *BS,
+                                const ParameterList *PL = nullptr,
+                                bool TopLevel = false) override {
     ArrayRef<ASTNode> OriginalElements = BS->getElements();
     using ElementVector = SmallVector<swift::ASTNode, 3>;
     ElementVector Elements(OriginalElements.begin(), OriginalElements.end());
@@ -589,6 +592,24 @@ public:
           }
         } else {
           transformDecl(D);
+        }
+      }
+    }
+
+    // If we were given any parameters that apply to this brace block, we insert
+    // log calls for them now (before any of the other statements).
+    if (PL) {
+      size_t EI = 0;
+      for (const auto &PD : *PL) {
+        DeclBaseName Name = PD->getName();
+        Expr *PVVarRef =
+            new (Context) DeclRefExpr(PD, DeclNameLoc(), /*implicit=*/true,
+                                      AccessSemantics::Ordinary, PD->getType());
+        Added<Stmt *> Log(buildLoggerCall(PVVarRef, PD->getSourceRange(),
+                                          Name.getIdentifier().str()));
+        if (*Log) {
+          Elements.insert(Elements.begin() + EI, *Log);
+          EI++;
         }
       }
     }
@@ -865,8 +886,9 @@ void swift::performPlaygroundTransform(SourceFile &SF, bool HighPerformance) {
       if (auto *FD = dyn_cast<AbstractFunctionDecl>(D)) {
         if (!FD->isImplicit()) {
           if (BraceStmt *Body = FD->getBody()) {
+            const ParameterList *PL = FD->getParameters();
             Instrumenter I(ctx, FD, RNG, HighPerformance, TmpNameIndex);
-            BraceStmt *NewBody = I.transformBraceStmt(Body);
+            BraceStmt *NewBody = I.transformBraceStmt(Body, PL);
             if (NewBody != Body) {
               FD->setBody(NewBody, AbstractFunctionDecl::BodyKind::TypeChecked);
               TypeChecker::checkFunctionEffects(FD);
@@ -878,7 +900,7 @@ void swift::performPlaygroundTransform(SourceFile &SF, bool HighPerformance) {
         if (!TLCD->isImplicit()) {
           if (BraceStmt *Body = TLCD->getBody()) {
             Instrumenter I(ctx, TLCD, RNG, HighPerformance, TmpNameIndex);
-            BraceStmt *NewBody = I.transformBraceStmt(Body, true);
+            BraceStmt *NewBody = I.transformBraceStmt(Body, nullptr, true);
             if (NewBody != Body) {
               TLCD->setBody(NewBody);
               TypeChecker::checkTopLevelEffects(TLCD);

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -601,15 +601,18 @@ public:
     if (PL) {
       size_t EI = 0;
       for (const auto &PD : *PL) {
-        DeclBaseName Name = PD->getName();
-        Expr *PVVarRef =
-            new (Context) DeclRefExpr(PD, DeclNameLoc(), /*implicit=*/true,
-                                      AccessSemantics::Ordinary, PD->getType());
-        Added<Stmt *> Log(buildLoggerCall(PVVarRef, PD->getSourceRange(),
-                                          Name.getIdentifier().str()));
-        if (*Log) {
-          Elements.insert(Elements.begin() + EI, *Log);
-          EI++;
+        // Skip parameters that don't have a name (such as `_` in a closure).
+        if (PD->hasName()) {
+          DeclBaseName Name = PD->getName();
+          Expr *PVVarRef = new (Context)
+              DeclRefExpr(PD, DeclNameLoc(), /*implicit=*/true,
+                          AccessSemantics::Ordinary, PD->getType());
+          Added<Stmt *> Log(buildLoggerCall(PVVarRef, PD->getSourceRange(),
+                                            Name.getIdentifier().str()));
+          if (*Log) {
+            Elements.insert(Elements.begin() + EI, *Log);
+            EI++;
+          }
         }
       }
     }

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -597,11 +597,11 @@ public:
     }
 
     // If we were given any parameters that apply to this brace block, we insert
-    // log calls for them now (before any of the other statements).
+    // log calls for them now (before any of the other statements). We only log
+    // named parameters (not `{ _ in ... }`, for example).
     if (PL && !HighPerformance) {
       size_t EI = 0;
       for (const auto &PD : *PL) {
-        // Only log named parameters (not `{ _ in }` closures for example.
         if (PD->hasName()) {
           DeclBaseName Name = PD->getName();
           Expr *PVVarRef = new (Context)

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -601,7 +601,7 @@ public:
     if (PL && !HighPerformance) {
       size_t EI = 0;
       for (const auto &PD : *PL) {
-        // Skip parameters that don't have a name (such as `_` in a closure).
+        // Only log named parameters (not `{ _ in }` closures for example.
         if (PD->hasName()) {
           DeclBaseName Name = PD->getName();
           Expr *PVVarRef = new (Context)

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -598,7 +598,7 @@ public:
 
     // If we were given any parameters that apply to this brace block, we insert
     // log calls for them now (before any of the other statements).
-    if (PL) {
+    if (PL && !HighPerformance) {
       size_t EI = 0;
       for (const auto &PD : *PL) {
         // Skip parameters that don't have a name (such as `_` in a closure).

--- a/test/IRGen/playground.swift
+++ b/test/IRGen/playground.swift
@@ -9,10 +9,13 @@ import Swift
 
 @objc class C { }
 
-private func __builtin_log_scope_entry(_ startLine: Int, _ startColumn: Int,
-  _ endLine: Int, _ endColumn: Int, _ moduleID: Int, _ fileID: Int) { }
-private func __builtin_log_scope_exit(_ startLine: Int, _ startColumn: Int,
-  _ endLine: Int, _ endColumn: Int, _ moduleID: Int, _ fileID: Int) { }
+private func __builtin_log_with_id<T>(_ object: T, _ name: String, _ id: Int,
+  _ startLine: Int, _ endLine: Int, _ startColumn: Int, _ endColumn: Int,
+  _ moduleId : Int, _ fileId : Int) -> AnyObject? { return .none }
+private func __builtin_log_scope_entry(_ startLine: Int, _ endLine: Int,
+  _ startColumn: Int, _ endColumn: Int, _ moduleID: Int, _ fileID: Int) { }
+private func __builtin_log_scope_exit(_ startLine: Int, _ endLine: Int,
+  _ startColumn: Int, _ endColumn: Int, _ moduleID: Int, _ fileID: Int) { }
 private func __builtin_send_data<T>(_ object: T) { }
 
 public func anchor() {}

--- a/test/PCMacro/pc_and_log.swift
+++ b/test/PCMacro/pc_and_log.swift
@@ -20,6 +20,7 @@ foo(1)
 [1,2,3].map(foo)
 
 // CHECK: [19:1-19:7] pc before
+// CHECK-NEXT: [15:10-15:18] __builtin_log[x='1']
 // CHECK-NEXT: [15:1-15:27] pc before
 // CHECK-NEXT: [15:1-15:27] pc after
 // CHECK-NEXT: [16:3-16:16] pc before
@@ -30,18 +31,21 @@ foo(1)
 // CHECK-NEXT: [19:1-19:7] pc after
 // now for the array
 // CHECK-NEXT: [20:1-20:17] pc before
+// CHECK-NEXT: [15:10-15:18] __builtin_log[x='1']
 // CHECK-NEXT: [15:1-15:27] pc before
 // CHECK-NEXT: [15:1-15:27] pc after
 // CHECK-NEXT: [16:3-16:16] pc before
 // CHECK-NEXT: [16:3-16:16] pc after
 // this next result is unexpected...
 // CHECK-NEXT: [16:10-16:11] __builtin_log[='true']
+// CHECK-NEXT: [15:10-15:18] __builtin_log[x='2']
 // CHECK-NEXT: [15:1-15:27] pc before
 // CHECK-NEXT: [15:1-15:27] pc after
 // CHECK-NEXT: [16:3-16:16] pc before
 // CHECK-NEXT: [16:3-16:16] pc after
 // this next result is unexpected...
 // CHECK-NEXT: [16:10-16:11] __builtin_log[='false']
+// CHECK-NEXT: [15:10-15:18] __builtin_log[x='3']
 // CHECK-NEXT: [15:1-15:27] pc before
 // CHECK-NEXT: [15:1-15:27] pc after
 // CHECK-NEXT: [16:3-16:16] pc before

--- a/test/PCMacro/pc_and_log.swift
+++ b/test/PCMacro/pc_and_log.swift
@@ -20,7 +20,6 @@ foo(1)
 [1,2,3].map(foo)
 
 // CHECK: [19:1-19:7] pc before
-// CHECK-NEXT: [15:10-15:18] __builtin_log[x='1']
 // CHECK-NEXT: [15:1-15:27] pc before
 // CHECK-NEXT: [15:1-15:27] pc after
 // CHECK-NEXT: [16:3-16:16] pc before
@@ -31,21 +30,18 @@ foo(1)
 // CHECK-NEXT: [19:1-19:7] pc after
 // now for the array
 // CHECK-NEXT: [20:1-20:17] pc before
-// CHECK-NEXT: [15:10-15:18] __builtin_log[x='1']
 // CHECK-NEXT: [15:1-15:27] pc before
 // CHECK-NEXT: [15:1-15:27] pc after
 // CHECK-NEXT: [16:3-16:16] pc before
 // CHECK-NEXT: [16:3-16:16] pc after
 // this next result is unexpected...
 // CHECK-NEXT: [16:10-16:11] __builtin_log[='true']
-// CHECK-NEXT: [15:10-15:18] __builtin_log[x='2']
 // CHECK-NEXT: [15:1-15:27] pc before
 // CHECK-NEXT: [15:1-15:27] pc after
 // CHECK-NEXT: [16:3-16:16] pc before
 // CHECK-NEXT: [16:3-16:16] pc after
 // this next result is unexpected...
 // CHECK-NEXT: [16:10-16:11] __builtin_log[='false']
-// CHECK-NEXT: [15:10-15:18] __builtin_log[x='3']
 // CHECK-NEXT: [15:1-15:27] pc before
 // CHECK-NEXT: [15:1-15:27] pc after
 // CHECK-NEXT: [16:3-16:16] pc before

--- a/test/PlaygroundTransform/closure_parameters.swift
+++ b/test/PlaygroundTransform/closure_parameters.swift
@@ -13,6 +13,8 @@ import PlaygroundSupport
 
 let foo = [1, 2, 3, 4, 5].filter { $0 % 2 == 1 }.map { x in "\(x)" }
 
+["A", "B", "C"].map { _ in 1 }
+
 // CHECK:      {{.*}} __builtin_log_scope_entry
 // CHECK-NEXT: {{.*}} __builtin_log[$0='1']
 // CHECK-NEXT: {{.*}} __builtin_log[='true']

--- a/test/PlaygroundTransform/closure_parameters.swift
+++ b/test/PlaygroundTransform/closure_parameters.swift
@@ -1,0 +1,56 @@
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main2 -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main2
+// RUN: %target-run %t/main2 | %FileCheck %s
+// REQUIRES: executable_test
+
+import PlaygroundSupport
+
+let foo = [1, 2, 3, 4, 5].filter { $0 % 2 == 1 }.map { x in "\(x)" }
+
+// CHECK:      {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[$0='1']
+// CHECK-NEXT: {{.*}} __builtin_log[='true']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[$0='2']
+// CHECK-NEXT: {{.*}} __builtin_log[='false']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[$0='3']
+// CHECK-NEXT: {{.*}} __builtin_log[='true']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[$0='4']
+// CHECK-NEXT: {{.*}} __builtin_log[='false']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[$0='5']
+// CHECK-NEXT: {{.*}} __builtin_log[='true']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[x='1']
+// CHECK-NEXT: {{.*}} __builtin_log[='1']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[x='3']
+// CHECK-NEXT: {{.*}} __builtin_log[='3']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[x='5']
+// CHECK-NEXT: {{.*}} __builtin_log[='5']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log[foo='["1", "3", "5"]']

--- a/test/PlaygroundTransform/closure_parameters.swift
+++ b/test/PlaygroundTransform/closure_parameters.swift
@@ -11,8 +11,10 @@
 
 import PlaygroundSupport
 
+// Both implicitly named and explicitly named parameters are logged.
 let foo = [1, 2, 3, 4, 5].filter { $0 % 2 == 1 }.map { x in "\(x)" }
 
+// Unnamed parameters do are not logged.
 ["A", "B", "C"].map { _ in 1 }
 
 // CHECK:      {{.*}} __builtin_log_scope_entry

--- a/test/PlaygroundTransform/function_parameters.swift
+++ b/test/PlaygroundTransform/function_parameters.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: cp %s %t/main.swift
+// RUN: %target-build-swift -whole-module-optimization -module-name PlaygroundSupport -emit-module-path %t/PlaygroundSupport.swiftmodule -parse-as-library -c -o %t/PlaygroundSupport.o %S/Inputs/SilentPCMacroRuntime.swift %S/Inputs/PlaygroundsRuntime.swift
+// RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+// RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground -Xfrontend -debugger-support -o %t/main2 -I=%t %t/PlaygroundSupport.o %t/main.swift
+// RUN: %target-codesign %t/main2
+// RUN: %target-run %t/main2 | %FileCheck %s
+// REQUIRES: executable_test
+
+import PlaygroundSupport
+
+func f(x: Int, _ y: Float = 7.62, z: String...) -> Int {
+    func g(w: (Int, Int)) -> Int {
+        func h(v: Int) -> Int {
+            return v + 1
+        }
+        return h(v: w.0) + h(v: w.1) + 1
+    }
+    return x + z.count + g(w: (1, 2))
+}
+
+let foo = f(x: 42, z: "hello", "world")
+
+// CHECK:      {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[x='42']
+// CHECK-NEXT: {{.*}} __builtin_log[y='7.62']
+// CHECK-NEXT: {{.*}} __builtin_log[z='["hello", "world"]']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[w='(1, 2)']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[v='1']
+// CHECK-NEXT: {{.*}} __builtin_log[='2']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[v='2']
+// CHECK-NEXT: {{.*}} __builtin_log[='3']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log[='6']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log[='50']
+// CHECK-NEXT: {{.*}} __builtin_log_scope_exit
+// CHECK-NEXT: {{.*}} __builtin_log[foo='50']

--- a/test/PlaygroundTransform/function_parameters.swift
+++ b/test/PlaygroundTransform/function_parameters.swift
@@ -11,6 +11,7 @@
 
 import PlaygroundSupport
 
+// Labeled, unlabeled, and multi-value parameters are logged.
 func f(x: Int, _ y: Float = 7.62, z: String...) -> Int {
     func g(w: (Int, Int)) -> Int {
         func h(v: Int) -> Int {
@@ -20,8 +21,13 @@ func f(x: Int, _ y: Float = 7.62, z: String...) -> Int {
     }
     return x + z.count + g(w: (1, 2))
 }
-
 let foo = f(x: 42, z: "hello", "world")
+
+// Unnamed parameters do are not logged.
+func f(_: Int) -> Int {
+    return 42
+}
+let bar = f(21)
 
 // CHECK:      {{.*}} __builtin_log_scope_entry
 // CHECK-NEXT: {{.*}} __builtin_log[x='42']

--- a/test/PlaygroundTransform/generics.swift
+++ b/test/PlaygroundTransform/generics.swift
@@ -21,18 +21,21 @@ for i in 0..<3 {
 
 // CHECK:      __builtin_log_scope_entry
 // CHECK-NEXT: __builtin_log_scope_entry
+// CHECK-NEXT: __builtin_log[t='0']
 // CHECK-NEXT: __builtin_log[='0']
 // CHECK-NEXT: __builtin_log_scope_exit
 // CHECK-NEXT: __builtin_log[='0']
 // CHECK-NEXT: __builtin_log_scope_exit
 // CHECK-NEXT: __builtin_log_scope_entry
 // CHECK-NEXT: __builtin_log_scope_entry
+// CHECK-NEXT: __builtin_log[t='1']
 // CHECK-NEXT: __builtin_log[='1']
 // CHECK-NEXT: __builtin_log_scope_exit
 // CHECK-NEXT: __builtin_log[='1']
 // CHECK-NEXT: __builtin_log_scope_exit
 // CHECK-NEXT: __builtin_log_scope_entry
 // CHECK-NEXT: __builtin_log_scope_entry
+// CHECK-NEXT: __builtin_log[t='2']
 // CHECK-NEXT: __builtin_log[='2']
 // CHECK-NEXT: __builtin_log_scope_exit
 // CHECK-NEXT: __builtin_log[='2']

--- a/test/PlaygroundTransform/implicit_return_func_binaryoperation_args.swift
+++ b/test/PlaygroundTransform/implicit_return_func_binaryoperation_args.swift
@@ -16,6 +16,8 @@ func add<I : SignedNumeric>(_ lhs: I, _ rhs: I) -> I {
 }
 add(3, 4)
 // CHECK: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[lhs='3']
+// CHECK-NEXT: {{.*}} __builtin_log[rhs='4']
 // CHECK-NEXT: {{.*}} __builtin_log[='7']
 // CHECK-NEXT: {{.*}} __builtin_log_scope_exit
 // CHECK-NEXT: {{.*}} __builtin_log[='7']

--- a/test/PlaygroundTransform/implicit_return_func_is.swift
+++ b/test/PlaygroundTransform/implicit_return_func_is.swift
@@ -17,10 +17,14 @@ func iss<T>(_ instance: Any, anInstanceOf type: T.Type) -> Bool {
 iss("hello", anInstanceOf: String.self)
 iss(57, anInstanceOf: String.self)
 // CHECK: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[instance='hello']
+// CHECK-NEXT: {{.*}} __builtin_log[type='String']
 // CHECK-NEXT: {{.*}} __builtin_log[='true']
 // CHECK-NEXT: {{.*}} __builtin_log_scope_exit
 // CHECK-NEXT: {{.*}} __builtin_log[='true']
 // CHECK: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[instance='57']
+// CHECK-NEXT: {{.*}} __builtin_log[type='String']
 // CHECK-NEXT: {{.*}} __builtin_log[='false']
 // CHECK-NEXT: {{.*}} __builtin_log_scope_exit
 // CHECK-NEXT: {{.*}} __builtin_log[='false']

--- a/test/PlaygroundTransform/implicit_return_subscript_chain.swift
+++ b/test/PlaygroundTransform/implicit_return_subscript_chain.swift
@@ -33,15 +33,19 @@ s[13]
 // CHECK-NEXT: {{.*}} __builtin_log_scope_exit
 
 // CHECK: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[newValue='Optional(33)']
+// CHECK-NEXT: {{.*}} __builtin_log[int='13']
 // CHECK-NEXT: {{.*}} __builtin_log[='Optional(Optional(33))']
 // CHECK-NEXT: {{.*}} __builtin_log_scope_exit
 
 // CHECK: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[int='14']
 // CHECK-NEXT: {{.*}} __builtin_log[='Optional(14)']
 // CHECK-NEXT: {{.*}} __builtin_log_scope_exit
 // CHECK-NEXT: {{.*}} __builtin_log[='Optional(14)']
 
 // CHECK: {{.*}} __builtin_log_scope_entry
+// CHECK-NEXT: {{.*}} __builtin_log[int='13']
 // CHECK-NEXT: {{.*}} __builtin_log[='Optional(33)']
 // CHECK-NEXT: {{.*}} __builtin_log_scope_exit
 // CHECK-NEXT: {{.*}} __builtin_log[='Optional(33)']


### PR DESCRIPTION
Add logging of function and closure parameter values when the playground transform is enabled.

### MOTIVATION
The goal of the optional "playground transform" step in Sema is to instrument the code by inserting calls to `__builtin_log()` and similar log functions, in order to record the execution of the compiled code.  Some IDEs (such as Xcode) enable this transform by passing `-playground` and provide implementations of the logger functions that record information that can then be shown in the IDE.

The playground transform currently logs variable assignments and return statements, but it doesn't log the input parameters received by functions and closures.  Knowing these values can be very useful in order to understand the behaviour of functions and closures.

### CHANGES
- add a `ParameterList` parameter to `InstrumenterSupport::transformBraceStmt()`
   - this is an optional parameter list that, if given, specifies the parameters that should be logged at the start of the brace statement
   - this has to be passed into the function because it comes from the owner of the `BraceStmt`
- adjust _PlaygroundTransform.cpp_ to make use of this list
   - the transform will insert calls to `__builtin_log()` for each of the parameters, in order
- adjust _PCMacro.cpp_ to accept the parameter, though this instrumenter doesn't currently make use of the new information
- add two new unit tests (one for functions and one for closures)
- adjust four existing unit tests to account for the new log calls

### REMARKS
- this is currently guarded by the existing "high performance" option (parameter logging is omitted in that case)
- this is the first of a series of log calls I plan to add to the playground transform, and so it might be useful to control them using some kind of organized option set — I will put up a separate PR for discussion with a suggestion for how we might do that

rdar://104974072