### PR TITLE
[Diagnostics] Switch swift-syntax diagnostic style to grouped diagnostics

### DIFF
--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -118,17 +118,18 @@ extern "C" {
 /// information and then must be finished via \c SwiftDiagnostic_finish.
 BridgedDiagnostic SwiftDiagnostic_create(
     void *diagnosticEngine, BridgedDiagnosticSeverity severity,
-    void *_Nullable sourceLoc,
+    const void *_Nullable sourceLoc,
     const uint8_t *_Nullable text, long textLen);
 
 /// Highlight a source range as part of the diagnostic.
 void SwiftDiagnostic_highlight(
-    BridgedDiagnostic diag, void *_Nullable startLoc, void *_Nullable endLoc);
+    BridgedDiagnostic diag, const void *_Nullable startLoc, const void *_Nullable endLoc);
 
 /// Add a Fix-It to replace a source range as part of the diagnostic.
 void SwiftDiagnostic_fixItReplace(
     BridgedDiagnostic diag,
-    void *_Nullable replaceStartLoc, void *_Nullable replaceEndLoc,
+    const void *_Nullable replaceStartLoc,
+    const void *_Nullable replaceEndLoc,
     const uint8_t *_Nullable newText, long newTextLen);
 
 /// Finish the given diagnostic and emit it.

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -41,6 +41,7 @@ namespace swift {
   class Decl;
   class DeclAttribute;
   class DiagnosticEngine;
+  class GeneratedSourceInfo;
   class SourceManager;
   class ValueDecl;
   class SourceFile;
@@ -1477,6 +1478,10 @@ namespace swift {
 /// This is correlated with diag::availability_deprecated and others.
 std::pair<unsigned, DeclName>
 getAccessorKindAndNameForDiagnostics(const ValueDecl *D);
+
+/// Retrieve the macro name for a generated source info that represents
+/// a macro expansion.
+DeclName getGeneratedSourceInfoMacroName(const GeneratedSourceInfo &info);
 
 } // end namespace swift
 

--- a/include/swift/Frontend/PrintingDiagnosticConsumer.h
+++ b/include/swift/Frontend/PrintingDiagnosticConsumer.h
@@ -22,6 +22,7 @@
 #include "swift/Basic/DiagnosticOptions.h"
 #include "swift/Basic/LLVM.h"
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/Process.h"
 
@@ -47,10 +48,14 @@ class PrintingDiagnosticConsumer : public DiagnosticConsumer {
   bool SuppressOutput = false;
 
   /// swift-syntax rendering
+
+  /// A queued up source file known to the queued diagnostics.
+  using QueuedBuffer = void *;
+
+  /// The queued diagnostics structure.
   void *queuedDiagnostics = nullptr;
-  void *queuedSourceFile = nullptr;
-  unsigned queuedDiagnosticsBufferID;
-  StringRef queuedBufferName;
+  llvm::DenseMap<unsigned, QueuedBuffer> queuedBuffers;
+  unsigned queuedDiagnosticsOutermostBufferID;
 
 public:
   PrintingDiagnosticConsumer(llvm::raw_ostream &stream = llvm::errs());
@@ -91,6 +96,7 @@ public:
   }
 
 private:
+  void queueBuffer(SourceManager &sourceMgr, unsigned bufferID);
   void printDiagnostic(SourceManager &SM, const DiagnosticInfo &Info);
 };
   

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -20,7 +20,7 @@ inline llvm::ArrayRef<T> getArrayRef(BridgedArrayRef bridged) {
   return {static_cast<const T *>(bridged.data), size_t(bridged.numElements)};
 }
 
-static SourceLoc getSourceLocFromPointer(void *loc) {
+static SourceLoc getSourceLocFromPointer(const void *loc) {
   auto smLoc = llvm::SMLoc::getFromPointer((const char *)loc);
   return SourceLoc(smLoc);
 }
@@ -46,7 +46,7 @@ namespace {
 
 BridgedDiagnostic SwiftDiagnostic_create(
     void *diagnosticEngine, BridgedDiagnosticSeverity severity,
-    void *sourceLocPtr,
+    const void *sourceLocPtr,
     const uint8_t *textPtr, long textLen
 ) {
   StringRef origText{
@@ -81,7 +81,7 @@ BridgedDiagnostic SwiftDiagnostic_create(
 
 /// Highlight a source range as part of the diagnostic.
 void SwiftDiagnostic_highlight(
-    BridgedDiagnostic diagPtr, void *startLocPtr, void *endLocPtr
+    BridgedDiagnostic diagPtr, const void *startLocPtr, const void *endLocPtr
 ) {
   SourceLoc startLoc = getSourceLocFromPointer(startLocPtr);
   SourceLoc endLoc = getSourceLocFromPointer(endLocPtr);
@@ -92,7 +92,8 @@ void SwiftDiagnostic_highlight(
 
 /// Add a Fix-It to replace a source range as part of the diagnostic.
 void SwiftDiagnostic_fixItReplace(
-    BridgedDiagnostic diagPtr, void *replaceStartLocPtr, void *replaceEndLocPtr,
+    BridgedDiagnostic diagPtr,
+    const void *replaceStartLocPtr, const void *replaceEndLocPtr,
     const uint8_t *newTextPtr, long newTextLen) {
 
   SourceLoc startLoc = getSourceLocFromPointer(replaceStartLocPtr);

--- a/lib/ASTGen/Sources/ASTGen/PluginHost.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginHost.swift
@@ -225,8 +225,7 @@ class PluginDiagnosticsEngine {
     else {
       return nil
     }
-    let address = bufferBaseAddress.advanced(by: offset)
-    return CxxSourceLoc(mutating: address)
+    return bufferBaseAddress.advanced(by: offset)
   }
 
   /// C++ source location from a position value from a plugin.

--- a/lib/ASTGen/Sources/ASTGen/SourceManager.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceManager.swift
@@ -3,7 +3,7 @@ import SwiftSyntax
 import SwiftSyntaxMacros
 
 /// A C++ source location.
-typealias CxxSourceLoc = UnsafeMutablePointer<UInt8>
+public typealias CxxSourceLoc = UnsafePointer<UInt8>
 
 /// A source manager that keeps track of the source files in the program.
 class SourceManager {
@@ -128,6 +128,6 @@ extension SourceManager {
       return nil
     }
     let address = bufferBaseAddress.advanced(by: offsetFromSourceFile)
-    return CxxSourceLoc(mutating: address)
+    return address
   }
 }


### PR DESCRIPTION
Use the new "grouped diagnostics" feature of the swift-syntax diagnostic rendering to emit printed diagnostics under the swift-syntax diagnostic style. This emits macro expansion buffers as text to the terminal, inset in a box where the macro was expanded, so that there is more context for understanding how the macro was expanded and what went wrong inside it.

This is better shown than told. Here's the `test/Macros/macro_expand.swift` diagnostic test case as rendered through the swift-syntax diagnostic style:

```
=== /Users/dgregor/Projects/swift/swift/test/Macros/macro_expand.swift ===
    ┆
 97 │   _ = #addBlocker(a * b * c)
 98 │ #if TEST_DIAGNOSTICS
 99 │   _ = #addBlocker(a + b * c)
    ∣                     ├─ error: blocked an add; did you mean to subtract? (from macro 'addBlocker')
    ∣                     ╰─ use '-'
100 │ 
101 │   _ = #addBlocker(oa + oa)
    ∣                      ├─ error: blocked an add; did you mean to subtract? (from macro 'addBlocker')
    ∣                      ╰─ use '-'
    ╭─── macro expansion #addBlocker ───────────────────────────────────
    │1 │ oa - oa
    │  ∣    ╰─ error: binary operator '-' cannot be applied to two 'OnlyAdds' operands
    ╰───────────────────────────────────────────────────────────────────
102 │ 
103 │ 
    ┆
110 │   _ = #addBlocker({
111 │       print("hello")
112 │       print(oa + oa)
    ∣                ├─ error: blocked an add; did you mean to subtract? (from macro 'addBlocker')
    ∣                ╰─ use '-'
113 │       print(oa + oa)
    ∣                ├─ error: blocked an add; did you mean to subtract? (from macro 'addBlocker')
    ∣                ╰─ use '-'
114 │     }())
    ╭─── macro expansion #addBlocker ───────────────────────────────────
    │1 │ {
    │2 │       print("hello")
    │3 │       print(oa - oa)
    │  ∣                ╰─ error: referencing operator function '-' on 'FloatingPoint' requires that 'OnlyAdds' conform to 'FloatingPoint'
    │4 │       print(oa - oa)
    │5 │     }()
    ╰───────────────────────────────────────────────────────────────────
115 │ 
116 │   // Check recursion.
```

<img width="1248" alt="grouped-diagnostics-macro-expansion" src="https://user-images.githubusercontent.com/989428/221500236-871cfcd7-3906-4848-b5c6-0066e7078233.png">
