### PR TITLE
[ConstraintSystem] Dependent member simplification should be attempte…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1108,7 +1108,9 @@ Type ConstraintSystem::getFixedTypeRecursive(Type type,
     type = type->getRValueType();
 
   if (auto depMemType = type->getAs<DependentMemberType>()) {
-    if (!depMemType->getBase()->isTypeVariableOrMember()) return type;
+    auto baseTy = depMemType->getBase();
+    if (!baseTy->hasTypeVariable() && !baseTy->hasDependentMember())
+      return type;
 
     // FIXME: Perform a more limited simplification?
     Type newType = simplifyType(type);

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar105149979.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar105149979.swift
@@ -1,0 +1,32 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+// rdar://105149979
+
+protocol Component<Output> {
+  associatedtype Output
+}
+
+struct R<Output> : Component {
+}
+
+extension RangeReplaceableCollection where Element: Equatable {
+  func test<C: Collection, Replacement: Collection>(
+    _ other: C,
+    with replacement: Replacement,
+    maxReplacements: Int = .max
+  ) -> Self where C.Element == Element, Replacement.Element == Element {
+    return self
+  }
+}
+
+func test(str: inout String) {
+  let elt = R<Substring>()
+
+  _ = str.test {
+    elt
+    "+"
+    elt
+  } with: { match in
+    ""
+  }
+}


### PR DESCRIPTION
…d if it has type variable in any position

Current logic attempts simplification of the base type only if it's a type variable or a dependent member type. That's valid for correct code but not for invalid code e.g. `(($T) -> Void).Element` is not going to be simplified even if `$T` is bound, which causes crashes in diagnostic mode because `matchTypes` is going to re-introduce constraint with partially resolved dependent member types and by doing so make it stale forever which trips constraint system state verification logic.

Resolves: rdar://105149979

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
