### PR TITLE
[Sema] Context validation checks for access-level on imports

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3160,6 +3160,18 @@ ERROR(error_public_import_of_private_module,none,
       "private module %0 is imported publicly from the public module %1",
       (Identifier, Identifier))
 
+ERROR(inconsistent_implicit_access_level_on_import,none,
+      "ambiguous implicit access level for import of %0; it is imported as "
+      "'%select{private|fileprivate|internal|package|public|%error}1' elsewhere",
+      (Identifier, AccessLevel))
+NOTE(inconsistent_implicit_access_level_on_import_here,none,
+     "imported "
+     "'%select{private|fileprivate|internal|package|public|%error}0' here",
+     (AccessLevel))
+FIXIT(inconsistent_implicit_access_level_on_import_fixit,
+     "%select{private|fileprivate|internal|package|public|%error}0 ",
+     (AccessLevel))
+
 ERROR(implementation_only_decl_non_override,none,
       "'@_implementationOnly' can only be used on overrides", ())
 ERROR(implementation_only_override_changed_type,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1011,10 +1011,10 @@ ERROR(import_restriction_conflict,none,
       "%select{implementation-only|SPI only|exported}2 ",
       (Identifier, unsigned, unsigned))
 
-WARNING(module_not_compiled_with_library_evolution,none,
-        "module %0 was not compiled with library evolution support; "
-        "using it means binary compatibility for %1 can't be guaranteed",
-        (Identifier, Identifier))
+ERROR(module_not_compiled_with_library_evolution,none,
+      "module %0 was not compiled with library evolution support; "
+      "using it means binary compatibility for %1 can't be guaranteed",
+      (Identifier, Identifier))
 
 ERROR(module_allowable_client_violation,none,
       "module %0 doesn't allow importation from module %1",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2057,6 +2057,9 @@ ERROR(access_level_on_import_unsupported, none,
       "only 'public', 'package', 'internal', 'fileprivate' and 'private' "
       "are unsupported",
       (DeclAttribute))
+ERROR(access_level_conflict_with_exported,none,
+      "'%0' is incompatible with %1; it can only be applied to public imports",
+      (DeclAttribute, DeclAttribute))
 
 // Opaque return types
 ERROR(opaque_type_invalid_constraint,none,

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -3367,6 +3367,27 @@ public:
   bool isCached() const { return true; }
 };
 
+/// Report default imports if other imports of the same target from this
+/// module have an explicitly defined access level. In such a case, all imports
+/// of the target module need an explicit access level or it may be made public
+/// by error. This applies only to pre-Swift 6 mode.
+class CheckInconsistentAccessLevelOnImport
+    : public SimpleRequest<CheckInconsistentAccessLevelOnImport,
+                           evaluator::SideEffect(SourceFile *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  evaluator::SideEffect evaluate(Evaluator &evaluator, SourceFile *mod) const;
+
+public:
+  // Cached.
+  bool isCached() const { return true; }
+};
+
 /// Checks to see if any of the imports in a module use \c @_weakLinked
 /// in one file and not in another.
 ///

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -35,6 +35,8 @@ SWIFT_REQUEST(TypeChecker, CheckInconsistentImplementationOnlyImportsRequest,
               evaluator::SideEffect(ModuleDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CheckInconsistentSPIOnlyImportsRequest,
               evaluator::SideEffect(SourceFile *), Cached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, CheckInconsistentAccessLevelOnImport,
+              evaluator::SideEffect(SourceFile *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CheckInconsistentWeakLinkedImportsRequest,
               evaluator::SideEffect(ModuleDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CheckRedeclarationRequest,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -970,6 +970,14 @@ bool AttributeChecker::visitAbstractAccessControlAttr(
                             attr);
       return true;
     }
+
+    if (attr->getAccess() != AccessLevel::Public) {
+      if (auto exportedAttr = D->getAttrs().getAttribute<ExportedAttr>()) {
+        diagnoseAndRemoveAttr(attr, diag::access_level_conflict_with_exported,
+                              exportedAttr, attr);
+        return true;
+      }
+    }
   }
 
   return false;

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1959,6 +1959,7 @@ public:
       if (target &&
           !ID->getAttrs().hasAttribute<ImplementationOnlyAttr>() &&
           !ID->getAttrs().hasAttribute<SPIOnlyAttr>() &&
+          ID->getAccessLevel() == AccessLevel::Public &&
           target->getLibraryLevel() == LibraryLevel::SPI) {
 
         auto &diags = ID->getASTContext().Diags;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -313,6 +313,13 @@ TypeCheckSourceFileRequest::evaluate(Evaluator &eval, SourceFile *SF) const {
       CheckInconsistentSPIOnlyImportsRequest{SF},
       {});
 
+  if (!Ctx.LangOpts.isSwiftVersionAtLeast(6)) {
+    evaluateOrDefault(
+      Ctx.evaluator,
+      CheckInconsistentAccessLevelOnImport{SF},
+      {});
+  }
+
   evaluateOrDefault(
       Ctx.evaluator,
       CheckInconsistentWeakLinkedImportsRequest{SF->getParentModule()}, {});

--- a/test/Sema/access-level-and-non-resilient-import.swift
+++ b/test/Sema/access-level-and-non-resilient-import.swift
@@ -1,0 +1,51 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Build the libraries.
+// RUN: %target-swift-frontend -emit-module %t/DefaultLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/PublicLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/PackageLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/InternalLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/FileprivateLib.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/PrivateLib.swift -o %t
+
+/// A resilient client will error on public imports.
+// RUN: %target-swift-frontend -typecheck %t/Client_Swift5.swift -I %t \
+// RUN:   -enable-library-evolution -swift-version 5 \
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+// RUN: %target-swift-frontend -typecheck %t/Client_Swift6.swift -I %t \
+// RUN:   -enable-library-evolution -swift-version 6 \
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+
+/// A non-resilient client doesn't complain.
+// RUN: %target-swift-frontend -typecheck %t/Client_Swift5.swift -I %t \
+// RUN:   -swift-version 5 \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -typecheck %t/Client_Swift6.swift -I %t \
+// RUN:   -swift-version 6 \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+
+//--- DefaultLib.swift
+//--- PublicLib.swift
+//--- PackageLib.swift
+//--- InternalLib.swift
+//--- FileprivateLib.swift
+//--- PrivateLib.swift
+
+//--- Client_Swift5.swift
+
+import DefaultLib // expected-error {{module 'DefaultLib' was not compiled with library evolution support; using it means binary compatibility for 'Client_Swift5' can't be guaranteed}} {{1-1=internal }}
+public import PublicLib // expected-error {{module 'PublicLib' was not compiled with library evolution support; using it means binary compatibility for 'Client_Swift5' can't be guaranteed}} {{1-7=internal}}
+package import PackageLib
+internal import InternalLib
+fileprivate import FileprivateLib
+private import PrivateLib
+
+//--- Client_Swift6.swift
+
+import DefaultLib
+public import PublicLib // expected-error {{module 'PublicLib' was not compiled with library evolution support; using it means binary compatibility for 'Client_Swift6' can't be guaranteed}} {{1-7=internal}}
+package import PackageLib
+internal import InternalLib
+fileprivate import FileprivateLib
+private import PrivateLib

--- a/test/Sema/access-level-and-non-resilient-import.swift
+++ b/test/Sema/access-level-and-non-resilient-import.swift
@@ -1,5 +1,10 @@
+/// Check diagnostics on a resilient modules importing publicly a
+/// a non-resilient module.
+
 // RUN: %empty-directory(%t)
 // RUN: split-file %s %t
+
+// REQUIRES: asserts
 
 /// Build the libraries.
 // RUN: %target-swift-frontend -emit-module %t/DefaultLib.swift -o %t

--- a/test/Sema/access-level-import-inconsistencies.swift
+++ b/test/Sema/access-level-import-inconsistencies.swift
@@ -1,0 +1,64 @@
+/// Import inconsistencies.
+///
+/// Swift 5 case, with slow adoption of access level on imports.
+/// Report default imports if any other import of the same module
+/// has an access level below public (the default).
+///
+/// Swift 6 case, with default imports as internal.
+/// Don't report any mismatch.
+///
+/// RUN: %empty-directory(%t)
+/// RUN: split-file %s %t
+
+/// Build the library.
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift -o %t
+
+/// Check diagnostics.
+
+//--- Lib.swift
+public struct LibType {}
+
+// RUN: %target-swift-frontend -typecheck %t/OneFile_AllExplicit.swift -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+//--- OneFile_AllExplicit.swift
+public import Lib
+package import Lib
+internal import Lib
+fileprivate import Lib
+private import Lib
+
+// RUN: %target-swift-frontend -typecheck %t/ManyFiles_AllExplicit_File?.swift -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+//--- ManyFiles_AllExplicit_FileA.swift
+public import Lib
+//--- ManyFiles_AllExplicit_FileB.swift
+package import Lib
+//--- ManyFiles_AllExplicit_FileC.swift
+internal import Lib
+//--- ManyFiles_AllExplicit_FileD.swift
+fileprivate import Lib
+//--- ManyFiles_AllExplicit_FileE.swift
+private import Lib
+
+// RUN: %target-swift-frontend -typecheck %t/ManyFiles_ImplicitVsInternal_FileB.swift -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
+// RUN:   -primary-file %t/ManyFiles_ImplicitVsInternal_FileA.swift
+//--- ManyFiles_ImplicitVsInternal_FileA.swift
+import Lib // expected-error {{ambiguous implicit access level for import of 'Lib'; it is imported as 'internal' elsewhere}}
+//--- ManyFiles_ImplicitVsInternal_FileB.swift
+internal import Lib // expected-note {{imported 'internal' here}}
+
+// RUN: %target-swift-frontend -typecheck %t/ManyFiles_ImplicitVsPackage_FileB.swift -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify \
+// RUN:   -primary-file %t/ManyFiles_ImplicitVsPackage_FileA.swift
+//--- ManyFiles_ImplicitVsPackage_FileA.swift
+import Lib // expected-error {{ambiguous implicit access level for import of 'Lib'; it is imported as 'package' elsewhere}}
+//--- ManyFiles_ImplicitVsPackage_FileB.swift
+package import Lib // expected-note {{imported 'package' here}} @:1
+
+// RUN: %target-swift-frontend -typecheck %t/ManyFiles_AmbiguitySwift6_File?.swift -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify -swift-version 6
+//--- ManyFiles_AmbiguitySwift6_FileA.swift
+import Lib
+//--- ManyFiles_AmbiguitySwift6_FileB.swift
+internal import Lib

--- a/test/Sema/access-level-import-inconsistencies.swift
+++ b/test/Sema/access-level-import-inconsistencies.swift
@@ -6,9 +6,11 @@
 ///
 /// Swift 6 case, with default imports as internal.
 /// Don't report any mismatch.
-///
-/// RUN: %empty-directory(%t)
-/// RUN: split-file %s %t
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// REQUIRES: asserts
 
 /// Build the library.
 // RUN: %target-swift-frontend -emit-module %t/Lib.swift -o %t

--- a/test/Sema/conflicting-import-restrictions.swift
+++ b/test/Sema/conflicting-import-restrictions.swift
@@ -35,3 +35,35 @@
 
 //--- SPIOnly_IOI_Exported.swift
 @_spiOnly @_implementationOnly @_exported import Lib // expected-error {{module 'Lib' cannot be both exported and implementation-only}}
+
+/// Access levels on imports
+// RUN: %target-swift-frontend -typecheck %t/Public_Exported.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -typecheck %t/Package_Exported.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -typecheck %t/Internal_Exported.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -typecheck %t/Fileprivate_Exported.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -typecheck %t/Private_Exported.swift -I %t -verify \
+// RUN:   -experimental-spi-only-imports -verify \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+
+//--- Public_Exported.swift
+@_exported public import Lib
+
+//--- Package_Exported.swift
+@_exported package import Lib // expected-error {{'@_exported' is incompatible with 'package'; it can only be applied to public imports}}
+
+//--- Internal_Exported.swift
+@_exported internal import Lib // expected-error {{'@_exported' is incompatible with 'internal'; it can only be applied to public imports}}
+
+//--- Fileprivate_Exported.swift
+@_exported fileprivate import Lib // expected-error {{'@_exported' is incompatible with 'fileprivate'; it can only be applied to public imports}}
+
+//--- Private_Exported.swift
+@_exported private import Lib // expected-error {{'@_exported' is incompatible with 'private'; it can only be applied to public imports}}

--- a/test/Sema/implementation-only-import-suggestion.swift
+++ b/test/Sema/implementation-only-import-suggestion.swift
@@ -92,3 +92,60 @@ import PublicClang_Private
 import FullyPrivateClang
 import LocalClang
 @_exported import MainLib
+
+// RUN: %target-swift-frontend -typecheck -sdk %t/sdk %t/InternalImports.swift \
+// RUN:   -enable-experimental-feature AccessLevelOnImport \
+// RUN:   -module-name MainLib -module-cache-path %t \
+// RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \
+// RUN:   -library-level api -verify
+//--- InternalImports.swift
+internal import PublicSwift
+internal import PrivateSwift
+
+internal import PublicClang
+internal import PublicClang_Private
+internal import FullyPrivateClang
+internal import LocalClang
+
+// RUN: %target-swift-frontend -typecheck -sdk %t/sdk %t/FileprivateImports.swift \
+// RUN:   -enable-experimental-feature AccessLevelOnImport \
+// RUN:   -module-name MainLib -module-cache-path %t \
+// RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \
+// RUN:   -library-level api -verify
+//--- FileprivateImports.swift
+fileprivate import PublicSwift
+fileprivate import PrivateSwift
+
+fileprivate import PublicClang
+fileprivate import PublicClang_Private
+fileprivate import FullyPrivateClang
+fileprivate import LocalClang
+
+// RUN: %target-swift-frontend -typecheck -sdk %t/sdk %t/PrivateImports.swift \
+// RUN:   -enable-experimental-feature AccessLevelOnImport \
+// RUN:   -module-name MainLib -module-cache-path %t \
+// RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \
+// RUN:   -library-level api -verify
+//--- PrivateImports.swift
+private import PublicSwift
+private import PrivateSwift
+
+private import PublicClang
+private import PublicClang_Private
+private import FullyPrivateClang
+private import LocalClang
+
+// RUN: %target-swift-frontend -typecheck -sdk %t/sdk %t/ExplicitlyPublicImports.swift \
+// RUN:   -enable-experimental-feature AccessLevelOnImport \
+// RUN:   -module-name MainLib -module-cache-path %t \
+// RUN:   -F %t/sdk/System/Library/PrivateFrameworks/ \
+// RUN:   -library-level api -verify
+//--- ExplicitlyPublicImports.swift
+public import PublicSwift
+public import PrivateSwift // expected-error{{private module 'PrivateSwift' is imported publicly from the public module 'MainLib'}}
+
+public import PublicClang
+public import PublicClang_Private // expected-error{{private module 'PublicClang_Private' is imported publicly from the public module 'MainLib'}}
+public import FullyPrivateClang // expected-error{{private module 'FullyPrivateClang' is imported publicly from the public module 'MainLib'}}
+public import LocalClang // expected-error{{private module 'LocalClang' is imported publicly from the public module 'MainLib'}}
+@_exported public import MainLib // expected-warning{{private module 'MainLib' is imported publicly from the public module 'MainLib'}}


### PR DESCRIPTION
1. Notify of a possible unintentional public import by raising errors on default imports when other imports of the same target module have an explicit access level. This diagnostic won't be necessary when (or if) we consider default imports to be internal in Swift 6.
2. Raise an error on `public import` of a non-resilient module from a resilient module, and silence it for any access level below `public`. Such an import is likely to prevent the swiftinterface to be buildable by a different compiler. Keep this diagnostic as a warning for `@_implementationOnly import`.
3. Raise an error on `public import` of a private module from a public module, and suggest a fixit inserting the `internal` keyword before the import.
4. Report conflicting use of `@_exported` and non-public imports.

This follows the parser changes in #63912. Exportability checks and module interface support will be added next.