### PR TITLE
[CMake] Workaround stale object files causing rebuilds

### DIFF
--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -85,6 +85,15 @@ if (SWIFT_SWIFT_PARSER)
     endforeach()
   endfunction()
 
+  # Workaround to touch the library and its objects so that we don't continually rebuild (again, see
+  # corresponding change in swift-syntax).
+  add_custom_command(
+      TARGET swiftASTGen
+      POST_BUILD
+      COMMAND "${CMAKE_COMMAND}" -E touch_nocreate $<TARGET_FILE:swiftASTGen> $<TARGET_OBJECTS:swiftASTGen>
+      COMMAND_EXPAND_LISTS
+      COMMENT "Update mtime of library outputs workaround")
+
   set(SWIFT_SYNTAX_MODULES
     SwiftBasicFormat
     SwiftParser


### PR DESCRIPTION
Consider the case of A -> B. The previous workaround will add a forced-B-dep.swift to A that is touched if B rebuilds. So if B is rebuilt, A is also rebuilt. But A itself has no real changes, and so none of its object files are built and none of the mtimes are updated.

Thus, A is then rebuilt again on the next run because its input (forced-B-dep.swift) is newer than the corresponding object file. To prevent this, update the mtime for the library and object files after the build (which is actually a link step that both compiles and links).