### PR TITLE
[Macros] Rename `createUniqueName` to `makeUniqueName`

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
@@ -53,7 +53,7 @@ extension String {
 
 extension SourceManager.MacroExpansionContext: MacroExpansionContext {
   /// Generate a unique name for use in the macro.
-  public func createUniqueName(_ providedName: String) -> TokenSyntax {
+  public func makeUniqueName(_ providedName: String) -> TokenSyntax {
     // If provided with an empty name, substitute in something.
     let name = providedName.isEmpty ? "__local" : providedName
 

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -214,8 +214,8 @@ public struct DefineBitwidthNumberedStructsMacro: DeclarationMacro {
         """
 
         struct \(raw: prefix) {
-          func \(context.createUniqueName("method"))() { return 0 }
-          func \(context.createUniqueName("method"))() { return 1 }
+          func \(context.makeUniqueName("method"))() { return 0 }
+          func \(context.makeUniqueName("method"))() { return 1 }
         }
         """
       ]
@@ -225,8 +225,8 @@ public struct DefineBitwidthNumberedStructsMacro: DeclarationMacro {
       """
 
       struct \(raw: prefix)\(raw: String(bitwidth)) {
-        func \(context.createUniqueName("method"))() { }
-        func \(context.createUniqueName("method"))() { }
+        func \(context.makeUniqueName("method"))() { }
+        func \(context.makeUniqueName("method"))() { }
       }
       """
     }
@@ -242,15 +242,15 @@ public struct DefineDeclsWithKnownNamesMacro: DeclarationMacro {
       """
 
       struct A {
-        func \(context.createUniqueName("method"))() { }
-        func \(context.createUniqueName("method"))() { }
+        func \(context.makeUniqueName("method"))() { }
+        func \(context.makeUniqueName("method"))() { }
       }
       """,
       """
 
       struct B {
-        func \(context.createUniqueName("method"))() { }
-        func \(context.createUniqueName("method"))() { }
+        func \(context.makeUniqueName("method"))() { }
+        func \(context.makeUniqueName("method"))() { }
       }
       """,
       """
@@ -780,7 +780,7 @@ public struct WrapInType: PeerMacro {
       funcDecl
       .with(
         \.identifier,
-         "\(context.createUniqueName(funcDecl.identifier.text))"
+         "\(context.makeUniqueName(funcDecl.identifier.text))"
       )
       .with(
         \.signature,
@@ -801,7 +801,7 @@ public struct WrapInType: PeerMacro {
 
     let structType: DeclSyntax =
       """
-      struct \(context.createUniqueName(funcDecl.identifier.text)) {
+      struct \(context.makeUniqueName(funcDecl.identifier.text)) {
         \(method)
       }
       """


### PR DESCRIPTION
As per Evolution comment: https://forums.swift.org/t/se-0382-second-review-expression-macros/63064/20