### PR TITLE
[Backtracing] Add support for looking up paths for auxiliary executables

### DIFF
--- a/include/swift/Runtime/EnvironmentVariables.h
+++ b/include/swift/Runtime/EnvironmentVariables.h
@@ -24,6 +24,10 @@ void initialize(void *);
 
 extern swift::once_t initializeToken;
 
+// Define a typedef "string" in swift::runtime::environment to make string
+// environment variables work
+using string = const char *;
+
 // Declare backing variables.
 #define VARIABLE(name, type, defaultValue, help) extern type name ## _variable;
 #include "../../../stdlib/public/runtime/EnvironmentVariables.def"

--- a/include/swift/Runtime/Paths.h
+++ b/include/swift/Runtime/Paths.h
@@ -1,0 +1,77 @@
+//===--- Paths.h - Swift Runtime path utility functions ---------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Functions that obtain paths that might be useful within the runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_UTILS_H
+#define SWIFT_RUNTIME_UTILS_H
+
+#include "swift/Runtime/Config.h"
+
+/// Return the path of the libswiftCore library.
+///
+/// This can be used to locate files that are installed alongside the Swift
+/// runtime library.
+///
+/// \return A string containing the full path to libswiftCore.  The string is
+///         owned by the runtime and should not be freed.
+SWIFT_RUNTIME_EXPORT
+const char *
+swift_getRuntimePath();
+
+/// Return the path of the Swift root.
+///
+/// If the path to libswiftCore is `/usr/local/swift/lib/libswiftCore.dylib`,
+/// this function would return `/usr/local/swift`.
+///
+/// The path returned here can be overridden by setting the environment variable
+/// SWIFT_ROOT.
+///
+/// \return A string containing the full path to the Swift root directory, based
+///         either on the location of the Swift runtime, or on the `SWIFT_ROOT`
+///         environment variable if set.
+SWIFT_RUNTIME_EXPORT
+const char *
+swift_getRootPath();
+
+/// Return the path of the specified auxiliary executable.
+///
+/// This function will search for the auxiliary executable in the following
+/// paths:
+///
+///   <swift-root>/libexec/swift/<platform>/<name>
+///   <swift-root>/libexec/swift/<name>
+///   <swift-root>/bin/<name>
+///   <swift-root>/<name>
+///
+/// It will return the first of those that exists, but it does not test that
+/// the file is indeed executable.
+///
+/// On Windows, it will automatically add `.exe` to the name, which means you
+/// do not need to special case the name for Windows.
+///
+/// If you are using this function to locate a utility program for use by the
+/// runtime, you should provide a way to override its location using an
+/// environment variable.
+///
+/// If the executable cannot be found, it will return nullptr.
+///
+/// \param name      The name of the executable to locate.
+///
+/// \return A string containing the full path to the executable.
+SWIFT_RUNTIME_EXPORT
+const char *
+swift_getAuxiliaryExecutablePath(const char *name);
+
+#endif // SWIFT_RUNTIME_PATHS_H

--- a/include/swift/Runtime/Paths.h
+++ b/include/swift/Runtime/Paths.h
@@ -28,7 +28,7 @@
 ///         owned by the runtime and should not be freed.
 SWIFT_RUNTIME_EXPORT
 const char *
-swift_getRuntimePath();
+swift_getRuntimeLibraryPath();
 
 /// Return the path of the Swift root.
 ///
@@ -40,7 +40,8 @@ swift_getRuntimePath();
 ///
 /// \return A string containing the full path to the Swift root directory, based
 ///         either on the location of the Swift runtime, or on the `SWIFT_ROOT`
-///         environment variable if set.
+///         environment variable if set.  The string is owned by the runtime
+///         and should not be freed.
 SWIFT_RUNTIME_EXPORT
 const char *
 swift_getRootPath();
@@ -73,6 +74,6 @@ swift_getRootPath();
 ///         should be released with `free()` when no longer required.
 SWIFT_RUNTIME_EXPORT
 const char *
-swift_getAuxiliaryExecutablePath(const char *name);
+swift_copyAuxiliaryExecutablePath(const char *name);
 
 #endif // SWIFT_RUNTIME_PATHS_H

--- a/include/swift/Runtime/Paths.h
+++ b/include/swift/Runtime/Paths.h
@@ -69,7 +69,8 @@ swift_getRootPath();
 ///
 /// \param name      The name of the executable to locate.
 ///
-/// \return A string containing the full path to the executable.
+/// \return A string containing the full path to the executable.  This string
+///         should be released with `free()` when no longer required.
 SWIFT_RUNTIME_EXPORT
 const char *
 swift_getAuxiliaryExecutablePath(const char *name);

--- a/include/swift/Runtime/Paths.h
+++ b/include/swift/Runtime/Paths.h
@@ -73,7 +73,7 @@ swift_getRootPath();
 /// \return A string containing the full path to the executable.  This string
 ///         should be released with `free()` when no longer required.
 SWIFT_RUNTIME_EXPORT
-const char *
+char *
 swift_copyAuxiliaryExecutablePath(const char *name);
 
 #endif // SWIFT_RUNTIME_PATHS_H

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -62,6 +62,7 @@ set(swift_runtime_sources
     MetadataLookup.cpp
     Numeric.cpp
     Once.cpp
+    Paths.cpp
     Portability.cpp
     ProtocolConformance.cpp
     RefCount.cpp

--- a/stdlib/public/runtime/EnvironmentVariables.cpp
+++ b/stdlib/public/runtime/EnvironmentVariables.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/Runtime/Debug.h"
+#include "swift/Runtime/Paths.h"
 #include "swift/Runtime/EnvironmentVariables.h"
 
 #include <string.h>
@@ -23,6 +24,12 @@
 using namespace swift;
 
 namespace {
+
+// This is required to make the macro machinery work correctly; we can't
+// declare a VARIABLE(..., const char *, ...) because then the token-pasted
+// names won't work properly.  It *does* mean that if you want to use std::string
+// somewhere in this file, you'll have to fully qualify the name.
+typedef const char *string;
 
 // Require all environment variable names to start with SWIFT_
 static constexpr bool hasSwiftPrefix(const char *str) {
@@ -122,6 +129,14 @@ static uint32_t parse_uint32_t(const char *name,
   }
 
   return n;
+}
+
+static string parse_string(const char *name,
+                           const char *value,
+                           string defaultValue) {
+  if (!value || value[0] == 0)
+    return strdup(defaultValue);
+  return strdup(value);
 }
 
 // Print a list of all the environment variables. Lazy initialization makes

--- a/stdlib/public/runtime/EnvironmentVariables.def
+++ b/stdlib/public/runtime/EnvironmentVariables.def
@@ -81,4 +81,9 @@ VARIABLE(SWIFT_BINARY_COMPATIBILITY_VERSION, uint32_t, 0,
 VARIABLE(SWIFT_DEBUG_FAILED_TYPE_LOOKUP, bool, false,
          "Enable warnings when we fail to look up a type by name.")
 
+VARIABLE(SWIFT_ROOT, string, "",
+         "Overrides the root directory of the Swift installation. "
+         "This is used to locate auxiliary files relative to the runtime "
+         "itself.")
+
 #undef VARIABLE

--- a/stdlib/public/runtime/Paths.cpp
+++ b/stdlib/public/runtime/Paths.cpp
@@ -1,0 +1,554 @@
+//===--- Paths.cpp - Swift Runtime path utility functions -------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Functions that obtain paths that might be useful within the runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Config.h"
+#include "swift/Runtime/EnvironmentVariables.h"
+#include "swift/Runtime/Debug.h"
+#include "swift/Runtime/Paths.h"
+#include "swift/Runtime/Win32.h"
+#include "swift/Threading/Once.h"
+
+#include <filesystem>
+
+#if !defined(_WIN32) || defined(__CYGWIN__)
+#include <sys/stat.h>
+
+#include <dlfcn.h>
+#else
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#include <psapi.h>
+#endif
+
+#include <cerrno>
+#include <cstdlib>
+#include <cstring>
+
+namespace {
+
+swift::once_t runtimePathToken;
+const char *runtimePath;
+
+swift::once_t rootPathToken;
+const char *rootPath;
+
+void _swift_initRuntimePath(void *);
+void _swift_initRootPath(void *);
+const char *_swift_getDefaultRootPath();
+char *_swift_getAuxExePathIn(const char *path, const char *name);
+const char *_swift_tryAuxExePath(const char *name, const char *path, ...);
+
+bool _swift_isPathSep(char ch) {
+#ifdef _WIN32
+  return ch == '/' || ch == '\\';
+#else
+  return ch == '/';
+#endif
+}
+
+bool _swift_exists(const char *path);
+
+#if !defined(_WIN32) || defined(__CYGWIN__)
+#define PATHSEP_STR "/"
+#define PATHSEP_CHR '/'
+#else
+#define PATHSEP_STR "\\"
+#define PATHSEP_CHR '\\'
+#endif
+
+}
+
+SWIFT_RUNTIME_EXPORT
+const char *
+swift_getRuntimePath()
+{
+  swift::once(runtimePathToken, _swift_initRuntimePath, nullptr);
+  return runtimePath;
+}
+
+SWIFT_RUNTIME_EXPORT
+const char *
+swift_getRootPath()
+{
+  swift::once(rootPathToken, _swift_initRootPath, nullptr);
+  return rootPath;
+}
+
+namespace {
+
+bool
+_swift_lookingAtLibSwift(const char *ptr, const char *base)
+{
+  // /some/path/to/some/thing/lib/swift/libswiftCore.dylib
+  //                         ^         ^
+  //                         |         +---- ptr
+  //                         +-------------- ptr - 10
+
+  return (ptr - base >= 10
+          && _swift_isPathSep(ptr[-10])
+          && std::strncmp(ptr - 9, "lib", 3) == 0
+          && _swift_isPathSep(ptr[-6])
+          && std::strncmp(ptr - 5, "swift", 5) == 0);
+}
+
+bool
+_swift_lookingAtBin(const char *ptr, const char *base)
+{
+  // C:\some\path\to\some\thing\bin\libswiftCore.dylib
+  //                           ^   ^
+  //                           |   +---- ptr
+  //                           +-------- ptr - 4
+
+  return (ptr - base > 4
+          && _swift_isPathSep(ptr[-4])
+          && std::strncmp(ptr - 3, "bin", 3) == 0);
+}
+
+const char *
+_swift_getDefaultRootPath()
+{
+  const char *runtimePath = swift_getRuntimePath();
+  size_t runtimePathLen = std::strlen(runtimePath);
+
+  // Scan backwards until we find a path separator
+  const char *ptr = runtimePath + runtimePathLen;
+  while (ptr > runtimePath && !_swift_isPathSep(*--ptr));
+
+  if (_swift_lookingAtLibSwift(ptr, runtimePath)) {
+    // /some/path/to/some/thing/lib/swift/libswiftCore.dylib
+    //                         ^         ^
+    //                         |         +---- ptr
+    //                         +-------------- ptr - 10
+    ptr -= 10;
+  } else {
+    // We *might* be in a <platform> or <platform>/<arch> directory, so scan
+    // backwards for that too
+    bool found = false;
+    const char *platform = ptr;
+
+    for (unsigned n = 0; n < 2; ++n) {
+      while (platform > runtimePath && !_swift_isPathSep(*--platform));
+
+      if (_swift_lookingAtLibSwift(platform, runtimePath)) {
+
+        // When we get here, we have:
+        //
+        //      /some/path/to/some/thing/lib/swift/macosx/libswiftCore.dylib
+        //                              ^         ^      ^
+        //                              |         |      +---- ptr
+        //                              |         +----------- platform
+        //                              +--------------------- platform - 10
+
+        ptr = platform - 10;
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) {
+      // We *might* also be in a bin directory, for instance on Windows, so
+      // check if we should remove that also.
+      if (_swift_lookingAtBin(ptr, runtimePath)) {
+        // C:\some\path\to\some\thing\bin\libswiftCore.dylib
+        //                           ^   ^
+        //                           |   +---- ptr
+        //                           +-------- ptr - 4
+        ptr -= 4;
+      }
+    }
+  }
+
+  // If the result is empty, return "./" or ".\\"
+  if (ptr == runtimePath) {
+    return "." PATHSEP_STR;
+  }
+
+  // Duplicate the string up to and including ptr
+  size_t len = ptr - runtimePath + 1;
+  char *thePath = (char *)malloc(len + 1);
+  std::memcpy(thePath, runtimePath, len);
+  thePath[len] = 0;
+
+  return thePath;
+}
+
+// Join paths together
+char *
+_swift_joinPathsV(const char *path, va_list val)
+{
+  va_list val2;
+  size_t baseLen = 0;
+  size_t totalLen = 0;
+  const char *pathSeg;
+
+  va_copy(val2, val);
+
+  baseLen = std::strlen(path);
+  while (baseLen && _swift_isPathSep(path[baseLen - 1]))
+    --baseLen;
+
+  if (!baseLen)
+    totalLen = 1;
+  else
+    totalLen = baseLen;
+
+  while ((pathSeg = va_arg(val2, const char *))) {
+    size_t len = std::strlen(pathSeg);
+    while (len && _swift_isPathSep(pathSeg[len - 1]))
+      --len;
+    if (len)
+      totalLen += 1 + len;
+  }
+
+  char *buffer = static_cast<char *>(std::malloc(totalLen + 1));
+  char *ptr = buffer;
+
+  if (!baseLen)
+    *ptr++ = PATHSEP_CHR;
+  else {
+    std::memcpy(ptr, path, baseLen);
+    ptr += baseLen;
+  }
+
+  while ((pathSeg = va_arg(val, const char *))) {
+    size_t len = std::strlen(pathSeg);
+    while (len && _swift_isPathSep(pathSeg[len - 1]))
+      --len;
+    if (len) {
+      *ptr++ = PATHSEP_CHR;
+      std::memcpy(ptr, pathSeg, len);
+      ptr += len;
+    }
+  }
+  buffer[totalLen] = 0;
+
+  return buffer;
+}
+
+char *
+_swift_joinPaths(const char *path, ...)
+{
+  va_list val;
+  char *result;
+
+  va_start(val, path);
+  result = _swift_joinPathsV(path, val);
+  va_end(val);
+
+  return result;
+}
+
+void
+_swift_initRootPath(void *)
+{
+  // SWIFT_ROOT overrides the path returned by this function
+  const char *swiftRoot = swift::runtime::environment::SWIFT_ROOT();
+
+  if (!swiftRoot || !*swiftRoot) {
+    rootPath = _swift_getDefaultRootPath();
+    return;
+  }
+
+  size_t len = std::strlen(swiftRoot);
+
+  // Ensure that there's a trailing slash
+  if (_swift_isPathSep(swiftRoot[len - 1])) {
+    rootPath = swiftRoot;
+  } else {
+    char *thePath = (char *)malloc(len + 2);
+    std::memcpy(thePath, swiftRoot, len);
+    thePath[len] = PATHSEP_CHR;
+    thePath[len + 1] = 0;
+
+    rootPath = thePath;
+  }
+}
+
+#if _WIN32
+/// Map an NT-style filename to a Win32 filename.
+///
+/// We can't use GetFinalPathNameByHandle() because there's no way to obtain
+/// a handle (at least, not without using the internal NtCreateFile() API, which
+/// we aren't supposed to be using).  Additionally, that function would resolve
+/// symlinks, which we don't want to do here.
+///
+/// As a result, we use the approach demonstrated here:
+///
+///  https://learn.microsoft.com/en-us/windows/win32/memory/obtaining-a-file-name-from-a-file-handle
+///
+/// @param pszFilename The NT-style filename to convert.
+///
+/// @result A string, allocated using std::malloc(), containing the Win32-style
+///         filename.
+LPWSTR
+_swift_win32NameFromNTName(LPWSTR pszFilename) {
+  DWORD dwLen = GetLogicalDriveStringsW(0, NULL);
+  if (!dwLen)
+    return NULL;
+
+  LPWSTR lpDriveStrings = (LPWSTR)std::malloc(dwLen * sizeof(WCHAR));
+  if (!lpDriveStrings)
+    return NULL;
+
+  DWORD dwRet = GetLogicalDriveStringsW(dwLen, lpDriveStrings);
+  if (!dwRet)
+    return NULL;
+
+  LPWSTR pszDrive = lpDriveStrings;
+  while (*pszDrive) {
+    size_t len = wcslen(pszDrive);
+    if (len && pszDrive[len - 1] == '\\')
+      pszDrive[len - 1] = 0;
+
+    WCHAR ntPath[4096];
+    dwRet = QueryDosDeviceW(pszDrive, ntPath, 4096);
+    if (dwRet) {
+      size_t ntLen = wcslen(ntPath);
+
+      if (_wcsnicmp(pszFilename, ntPath, ntLen) == 0
+          && pszFilename[ntLen] == '\\') {
+        size_t fnLen = wcslen(pszFilename);
+        size_t driveLen = wcslen(pszDrive);
+        size_t pathLen = fnLen - ntLen;
+        size_t newLen = driveLen + pathLen + 1;
+        LPWSTR pszWin32Name = (LPWSTR)std::malloc(newLen * sizeof(WCHAR));
+        if (!pszWin32Name) {
+          std::free(lpDriveStrings);
+          return NULL;
+        }
+
+        LPWSTR ptr = pszWin32Name;
+        memcpy(ptr, pszDrive, driveLen * sizeof(WCHAR));
+        ptr += driveLen;
+        memcpy(ptr, pszFilename + ntLen, pathLen * sizeof(WCHAR));
+        ptr += pathLen;
+        *ptr = 0;
+
+        std::free(lpDriveStrings);
+
+        return pszWin32Name;
+      }
+    }
+
+    pszDrive += len + 1;
+  }
+
+  std::free(lpDriveStrings);
+
+  return _wcsdup(pszFilename);
+}
+#endif
+
+} // namespace
+
+SWIFT_RUNTIME_EXPORT
+const char *
+swift_getAuxiliaryExecutablePath(const char *name)
+{
+  const char *rootPath = swift_getRootPath();
+
+  const char *platformName = SWIFT_LIB_SUBDIR;
+  const char *archName = SWIFT_ARCH;
+
+  // <rootPath>/libexec/swift/<platformName>
+  if (const char *result = _swift_tryAuxExePath(name,
+                                                rootPath,
+                                                "libexec", "swift",
+                                                platformName, nullptr)) {
+    return result;
+  }
+
+  // <rootPath>/libexec/swift/<platformName>/<arch>
+  if (const char *result = _swift_tryAuxExePath(name,
+                                                rootPath,
+                                                "libexec", "swift",
+                                                platformName,
+                                                archName, nullptr)) {
+    return result;
+  }
+
+  // <rootPath>/libexec/swift
+  if (const char *result = _swift_tryAuxExePath(name,
+                                                rootPath,
+                                                "libexec", "swift",
+                                                nullptr)) {
+    return result;
+  }
+
+  // <rootPath>/libexec/swift/<arch>
+  if (const char *result = _swift_tryAuxExePath(name,
+                                                rootPath,
+                                                "libexec", "swift",
+                                                archName, nullptr)) {
+    return result;
+  }
+
+  // <rootPath>/bin
+  if (const char *result = _swift_tryAuxExePath(name,
+                                                rootPath,
+                                                "bin", nullptr)) {
+    return result;
+  }
+
+  // <rootPath>/bin/<arch>
+  if (const char *result = _swift_tryAuxExePath(name,
+                                                rootPath,
+                                                "bin",
+                                                archName, nullptr)) {
+    return result;
+  }
+
+  // Otherwise, look in the root itself
+  return _swift_tryAuxExePath(name, rootPath, nullptr);
+}
+
+namespace {
+
+char *
+_swift_getAuxExePathIn(const char *path, const char *name)
+{
+#ifdef _WIN32
+  size_t nameLen = std::strlen(name);
+  char *nameWithSuffix = nullptr;
+  if (nameLen > 4 && strcmp(name + nameLen - 4, ".exe") != 0) {
+    nameWithSuffix = (char *)std::malloc(nameLen + 4 + 1);
+    std::memcpy(nameWithSuffix, name, nameLen);
+    std::memcpy(nameWithSuffix + nameLen, ".exe", 4 + 1);
+
+    name = nameWithSuffix;
+  }
+#endif
+
+  char *fullPath = _swift_joinPaths(path, name, nullptr);
+
+#ifdef _WIN32
+  if (nameWithSuffix)
+    std::free(nameWithSuffix);
+#endif
+
+  return fullPath;
+}
+
+const char *
+_swift_tryAuxExePath(const char *name, const char *path, ...)
+{
+  va_list val;
+  char *fullPath;
+  va_start(val, path);
+  fullPath = _swift_joinPathsV(path, val);
+  va_end(val);
+
+  if (_swift_exists(fullPath)) {
+    char *result = _swift_getAuxExePathIn(fullPath, name);
+
+    if (_swift_exists(result)) {
+      std::free(fullPath);
+
+      return result;
+    }
+
+    std::free(result);
+  }
+
+  std::free(fullPath);
+
+  return nullptr;
+}
+
+#if !defined(_WIN32) || defined(__CYGWIN__)
+void
+_swift_initRuntimePath(void *) {
+  const char *path;
+
+#if APPLE_OS_SYSTEM
+  path = dyld_image_path_containing_address(_swift_initRuntimePath);
+#else
+  Dl_info dli;
+  int ret = ::dladdr((void *)_swift_initRuntimePath, &dli);
+
+  if (!ret) {
+    swift::fatalError(/* flags = */ 0,
+                      "Unable to obtain Swift runtime path\n");
+  }
+
+  path = dli.dli_fname;
+#endif
+
+  runtimePath = ::strdup(path);
+}
+#else
+
+void
+_swift_initRuntimePath(void *) {
+  const DWORD dwBufSize = 4096;
+  LPWSTR lpFilename = (LPWSTR)std::malloc(dwBufSize * sizeof(WCHAR));
+
+  // Again, we can't use GetFinalPathNameByHandle for the reasons given
+  // above.
+
+  DWORD dwRet = GetMappedFileNameW(GetCurrentProcess(),
+                                   (void *)_swift_initRuntimePath,
+                                   lpFilename,
+                                   dwBufSize);
+  if (!dwRet) {
+    swift::fatalError(/* flags = */ 0,
+                      "Unable to obtain Swift runtime path\n");
+  }
+
+  // GetMappedFileNameW() returns an NT-style path, not a Win32 path; that is,
+  // it starts with \Device\DeviceName rather than a drive letter.
+  LPWSTR lpWin32Filename = _swift_win32NameFromNTName(lpFilename);
+  if (!lpWin32Filename) {
+    swift::fatalError(/* flags = */ 0,
+                      "Unable to obtain Win32 path for Swift runtime\n");
+  }
+
+  std::free(lpFilename);
+
+  runtimePath = _swift_win32_copyUTF8FromWide(lpWin32Filename);
+  if (!runtimePath) {
+    swift::fatalError(/* flags = */ 0,
+                      "Unable to convert Swift runtime path to UTF-8: %lx, %d\n",
+                      ::GetLastError(), errno);
+  }
+
+  std::free(lpWin32Filename);
+}
+#endif
+
+/// Return true if a file exists at path.
+///
+/// On Windows, path will be in UTF-8 so can't be passed to _stat() or any
+/// of the ANSI functions.
+///
+/// @param path The path to check
+///
+/// @result true iff there is a file at @a path
+bool _swift_exists(const char *path)
+{
+#if !defined(_WIN32)
+  struct stat st;
+  return stat(path, &st) == 0;
+#else
+  wchar_t *wszPath = _swift_win32_copyWideFromUTF8(path);
+  bool result = GetFileAttributesW(wszPath) != INVALID_FILE_ATTRIBUTES;
+  free(wszPath);
+  return result;
+#endif // defined(_WIN32)
+}
+
+}

--- a/stdlib/public/runtime/Paths.cpp
+++ b/stdlib/public/runtime/Paths.cpp
@@ -74,7 +74,7 @@ bool _swift_exists(const char *path);
 
 SWIFT_RUNTIME_EXPORT
 const char *
-swift_getRuntimePath()
+swift_getRuntimeLibraryPath()
 {
   swift::once(runtimePathToken, _swift_initRuntimePath, nullptr);
   return runtimePath;
@@ -121,7 +121,7 @@ _swift_lookingAtBin(const char *ptr, const char *base)
 const char *
 _swift_getDefaultRootPath()
 {
-  const char *runtimePath = swift_getRuntimePath();
+  const char *runtimePath = swift_getRuntimeLibraryPath();
   size_t runtimePathLen = std::strlen(runtimePath);
 
   // Scan backwards until we find a path separator
@@ -357,7 +357,7 @@ _swift_win32NameFromNTName(LPWSTR pszFilename) {
 
 SWIFT_RUNTIME_EXPORT
 const char *
-swift_getAuxiliaryExecutablePath(const char *name)
+swift_copyAuxiliaryExecutablePath(const char *name)
 {
   const char *rootPath = swift_getRootPath();
 

--- a/stdlib/public/runtime/Paths.cpp
+++ b/stdlib/public/runtime/Paths.cpp
@@ -356,7 +356,7 @@ _swift_win32NameFromNTName(LPWSTR pszFilename) {
 } // namespace
 
 SWIFT_RUNTIME_EXPORT
-const char *
+char *
 swift_copyAuxiliaryExecutablePath(const char *name)
 {
   const char *rootPath = swift_getRootPath();

--- a/stdlib/public/runtime/Paths.cpp
+++ b/stdlib/public/runtime/Paths.cpp
@@ -365,50 +365,50 @@ swift_copyAuxiliaryExecutablePath(const char *name)
   const char *archName = SWIFT_ARCH;
 
   // <rootPath>/libexec/swift/<platformName>
-  if (const char *result = _swift_tryAuxExePath(name,
-                                                rootPath,
-                                                "libexec", "swift",
-                                                platformName, nullptr)) {
+  if (char *result = _swift_tryAuxExePath(name,
+                                          rootPath,
+                                          "libexec", "swift",
+                                          platformName, nullptr)) {
     return result;
   }
 
   // <rootPath>/libexec/swift/<platformName>/<arch>
-  if (const char *result = _swift_tryAuxExePath(name,
-                                                rootPath,
-                                                "libexec", "swift",
-                                                platformName,
-                                                archName, nullptr)) {
+  if (char *result = _swift_tryAuxExePath(name,
+                                          rootPath,
+                                          "libexec", "swift",
+                                          platformName,
+                                          archName, nullptr)) {
     return result;
   }
 
   // <rootPath>/libexec/swift
-  if (const char *result = _swift_tryAuxExePath(name,
-                                                rootPath,
-                                                "libexec", "swift",
-                                                nullptr)) {
+  if (char *result = _swift_tryAuxExePath(name,
+                                          rootPath,
+                                          "libexec", "swift",
+                                          nullptr)) {
     return result;
   }
 
   // <rootPath>/libexec/swift/<arch>
-  if (const char *result = _swift_tryAuxExePath(name,
-                                                rootPath,
-                                                "libexec", "swift",
-                                                archName, nullptr)) {
+  if (char *result = _swift_tryAuxExePath(name,
+                                          rootPath,
+                                          "libexec", "swift",
+                                          archName, nullptr)) {
     return result;
   }
 
   // <rootPath>/bin
-  if (const char *result = _swift_tryAuxExePath(name,
-                                                rootPath,
-                                                "bin", nullptr)) {
+  if (char *result = _swift_tryAuxExePath(name,
+                                          rootPath,
+                                          "bin", nullptr)) {
     return result;
   }
 
   // <rootPath>/bin/<arch>
-  if (const char *result = _swift_tryAuxExePath(name,
-                                                rootPath,
-                                                "bin",
-                                                archName, nullptr)) {
+  if (char *result = _swift_tryAuxExePath(name,
+                                          rootPath,
+                                          "bin",
+                                          archName, nullptr)) {
     return result;
   }
 

--- a/stdlib/public/runtime/Paths.cpp
+++ b/stdlib/public/runtime/Paths.cpp
@@ -50,7 +50,7 @@ void _swift_initRuntimePath(void *);
 void _swift_initRootPath(void *);
 const char *_swift_getDefaultRootPath();
 char *_swift_getAuxExePathIn(const char *path, const char *name);
-const char *_swift_tryAuxExePath(const char *name, const char *path, ...);
+char *_swift_tryAuxExePath(const char *name, const char *path, ...);
 
 bool _swift_isPathSep(char ch) {
 #ifdef _WIN32
@@ -443,7 +443,7 @@ _swift_getAuxExePathIn(const char *path, const char *name)
   return fullPath;
 }
 
-const char *
+char *
 _swift_tryAuxExePath(const char *name, const char *path, ...)
 {
   va_list val;

--- a/test/Runtime/Paths.cpp
+++ b/test/Runtime/Paths.cpp
@@ -97,7 +97,7 @@ int main(void) {
 
   printf("aux path: %s\n", auxPath ? auxPath : "<NULL>");
 
-  free(auxPath);
+  free((void *)auxPath);
 
   return 0;
 }

--- a/test/Runtime/Paths.cpp
+++ b/test/Runtime/Paths.cpp
@@ -22,6 +22,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -60,7 +61,7 @@ containsLibSwift(const char *path) {
 }
 
 int main(void) {
-  const char *runtimePath = swift_getRuntimePath();
+  const char *runtimePath = swift_getRuntimeLibraryPath();
 
   // Runtime path must point to libswiftCore and must be a file.
 
@@ -89,12 +90,14 @@ int main(void) {
   printf("root path contains /lib/swift/: %s\n",
          containsLibSwift(rootPath) ? "yes" : "no");
 
-  const char *auxPath = swift_getAuxiliaryExecutablePath("Foo");
+  const char *auxPath = swift_copyAuxiliaryExecutablePath("Foo");
 
   // CHECK: aux path: <NULL>
   // CHECK-FR: aux path: {{.*[\\/]libexec[\\/]swift[\\/]Foo(\.exe)?}}
 
   printf("aux path: %s\n", auxPath ? auxPath : "<NULL>");
+
+  free(auxPath);
 
   return 0;
 }

--- a/test/Runtime/Paths.cpp
+++ b/test/Runtime/Paths.cpp
@@ -1,0 +1,100 @@
+// RUN: %empty-directory(%t)
+
+// RUN: mkdir -p %t/swift-root/libexec/swift %t/swift-root/bin
+// RUN: touch %t/swift-root/libexec/swift/Foo
+// RUN: touch %t/swift-root/libexec/swift/Foo.exe
+// RUN: touch %t/swift-root/bin/Foo.exe
+
+// RUN: %target-clang %s -std=c++11 -I %swift_src_root/include -I %swift_src_root/stdlib/public/SwiftShims -I %clang-include-dir -isysroot %sdk -L%swift_obj_root/lib/swift/%target-sdk-name/%target-arch -lswiftCore -o %t/paths-test
+// RUN: %target-codesign %t/paths-test
+// RUN: %target-run %t/paths-test | %FileCheck %s
+// RUN: env %env-SWIFT_ROOT=%t/swift-root %target-run %t/paths-test | %FileCheck %s --check-prefix CHECK-FR
+// REQUIRES: executable_test
+// UNSUPPORTED: remote_run
+
+// This can't be done in unittests, because that statically links the runtime
+// so we get the wrong paths.  We explicitly want to test that we get the
+// path we expect (that is, the path to the runtime, and paths relative to
+// that).
+
+#include "swift/Runtime/Paths.h"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <stdio.h>
+#include <string.h>
+
+#if defined(_WIN32) && !defined(__CYGWIN)
+#define stat _stat
+#define S_IFDIR _S_IFDIR
+#endif
+
+static bool
+exists(const char *path) {
+  struct stat st;
+
+  return stat(path, &st) == 0;
+}
+
+static bool
+isfile(const char *path) {
+  struct stat st;
+
+  return stat(path, &st) == 0 && !(st.st_mode & S_IFDIR);
+}
+
+static bool
+isdir(const char *path) {
+  struct stat st;
+
+  return stat(path, &st) == 0 && (st.st_mode & S_IFDIR);
+}
+
+static bool
+containsLibSwift(const char *path) {
+  const char *posix = "/lib/swift/";
+  const char *windows = "\\lib\\swift\\";
+
+  return strstr(path, posix) || strstr(path, windows);
+}
+
+int main(void) {
+  const char *runtimePath = swift_getRuntimePath();
+
+  // Runtime path must point to libswiftCore and must be a file.
+
+  // CHECK: runtime path: {{.*[\\/](lib)?}}swiftCore.{{so|dylib|dll}}
+  // CHECK-NEXT: runtime is a file: yes
+
+  // CHECK-FR: runtime path: {{.*[\\/](lib)?}}swiftCore.{{so|dylib|dll}}
+  // CHECK-FR-NEXT: runtime is a file: yes
+  printf("runtime path: %s\n", runtimePath ? runtimePath: "<NULL>");
+  printf("runtime is a file: %s\n", isfile(runtimePath) ? "yes" : "no");
+
+  const char *rootPath = swift_getRootPath();
+
+  // Root path must end in a separator and must be a directory
+
+  // CHECK: root path: {{.*[\\/]$}}
+  // CHECK-NEXT: root is a directory: yes
+
+  // CHECK-FR: root path: {{.*[\\/]$}}
+  // CHECK-FR-NEXT: root is a directory: yes
+  printf("root path: %s\n", rootPath ? rootPath : "<NULL>");
+  printf("root is a directory: %s\n", isdir(rootPath) ? "yes" : "no");
+
+  // CHECK: root path contains /lib/swift/: no
+  // CHECK-FR: root path contains /lib/swift/: no
+  printf("root path contains /lib/swift/: %s\n",
+         containsLibSwift(rootPath) ? "yes" : "no");
+
+  const char *auxPath = swift_getAuxiliaryExecutablePath("Foo");
+
+  // CHECK: aux path: <NULL>
+  // CHECK-FR: aux path: {{.*[\\/]libexec[\\/]swift[\\/]Foo(\.exe)?}}
+
+  printf("aux path: %s\n", auxPath ? auxPath : "<NULL>");
+
+  return 0;
+}

--- a/test/Runtime/environment_variables.swift
+++ b/test/Runtime/environment_variables.swift
@@ -18,6 +18,7 @@
 // CHECK-DAG:    bool SWIFT_DETERMINISTIC_HASHING [default: false] - Disable randomized hash seeding.
 // CHECK-DAG:    bool SWIFT_ENABLE_MANGLED_NAME_VERIFICATION [default: false] - Enable verification that metadata can roundtrip through a mangled name each time metadata is instantiated.
 // CHECK-DAG:    bool SWIFT_DEBUG_ENABLE_MALLOC_SCRIBBLE [default: false] - Scribble on runtime allocations such as metadata allocations.
+// CHECK-DAG:  string SWIFT_ROOT [default: "{{[^"]*}}"] - Overrides the root directory of the Swift installation. This is used to locate auxiliary files relative to the runtime itself.
 
 // We need to do this because the DAG checks require a non-DAG check as an
 // anchor:

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1759,6 +1759,9 @@ config.substitutions.append(('%module-target-future', target_future))
 # Add 'target-sdk-name' as the name for platform-specific directories
 config.substitutions.append(('%target-sdk-name', config.target_sdk_name))
 
+# Also add 'target-arch' so we can locate some things inside the build tree
+config.substitutions.append(('%target-arch', target_arch))
+
 # Add 'stdlib_dir' as the path to the stdlib resource directory
 stdlib_dir = os.path.join(config.swift_lib_dir, "swift")
 if run_os == 'maccatalyst':


### PR DESCRIPTION
We need to be able to locate swift-backtrace relative to the current location of the runtime library.

This needs to work:

In a Swift build directory.
On Darwin, where we're installed in /usr/lib/swift and /usr/libexec/swift.
On Linux, where we're in /usr/lib/swift/linux and /usr/libexec/swift/linux.
On Windows, where we may be in a flat directory layout (because of limitations of Windows DLL lookups).

rdar://103071801