### PR TITLE
[stdlib] Update Codable.swift (API Digester)

### DIFF
--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -5544,8 +5544,7 @@ public protocol CodingKeyRepresentable {
 }
 
 @available(SwiftStdlib 5.6, *)
-extension RawRepresentable
-where Self: CodingKeyRepresentable, RawValue == String {
+extension RawRepresentable<String> where Self: CodingKeyRepresentable {
   @available(SwiftStdlib 5.6, *)
   public var codingKey: CodingKey {
     _DictionaryCodingKey(stringValue: rawValue)
@@ -5557,7 +5556,7 @@ where Self: CodingKeyRepresentable, RawValue == String {
 }
 
 @available(SwiftStdlib 5.6, *)
-extension RawRepresentable where Self: CodingKeyRepresentable, RawValue == Int {
+extension RawRepresentable<Int> where Self: CodingKeyRepresentable {
   @available(SwiftStdlib 5.6, *)
   public var codingKey: CodingKey {
     _DictionaryCodingKey(intValue: rawValue)

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -314,7 +314,7 @@ public protocol KeyedEncodingContainerProtocol {
   /// - parameter key: The key to associate the value with.
   /// - throws: `EncodingError.invalidValue` if the given value is invalid in
   ///   the current context for this format.
-  mutating func encode<T: Encodable>(_ value: T, forKey key: Key) throws
+  mutating func encode(_ value: some Encodable, forKey key: Key) throws
 
   /// Encodes a reference to the given object only if it is encoded
   /// unconditionally elsewhere in the payload (previously, or in the future).
@@ -326,8 +326,8 @@ public protocol KeyedEncodingContainerProtocol {
   /// - parameter key: The key to associate the object with.
   /// - throws: `EncodingError.invalidValue` if the given value is invalid in
   ///   the current context for this format.
-  mutating func encodeConditional<T: AnyObject & Encodable>(
-    _ object: T,
+  mutating func encodeConditional(
+    _ object: some AnyObject & Encodable,
     forKey key: Key
   ) throws
 
@@ -449,8 +449,8 @@ public protocol KeyedEncodingContainerProtocol {
   /// - parameter key: The key to associate the value with.
   /// - throws: `EncodingError.invalidValue` if the given value is invalid in
   ///   the current context for this format.
-  mutating func encodeIfPresent<T: Encodable>(
-    _ value: T?,
+  mutating func encodeIfPresent(
+    _ value: (some Encodable)?,
     forKey key: Key
   ) throws
 
@@ -671,8 +671,8 @@ public struct KeyedEncodingContainer<K: CodingKey> :
   /// - parameter key: The key to associate the value with.
   /// - throws: `EncodingError.invalidValue` if the given value is invalid in
   ///   the current context for this format.
-  public mutating func encode<T: Encodable>(
-    _ value: T,
+  public mutating func encode(
+    _ value: some Encodable,
     forKey key: Key
   ) throws {
     try _box.encode(value, forKey: key)
@@ -688,8 +688,8 @@ public struct KeyedEncodingContainer<K: CodingKey> :
   /// - parameter key: The key to associate the object with.
   /// - throws: `EncodingError.invalidValue` if the given value is invalid in
   ///   the current context for this format.
-  public mutating func encodeConditional<T: AnyObject & Encodable>(
-    _ object: T,
+  public mutating func encodeConditional(
+    _ object: some AnyObject & Encodable,
     forKey key: Key
   ) throws {
     try _box.encodeConditional(object, forKey: key)
@@ -883,8 +883,8 @@ public struct KeyedEncodingContainer<K: CodingKey> :
   /// - parameter key: The key to associate the value with.
   /// - throws: `EncodingError.invalidValue` if the given value is invalid in
   ///   the current context for this format.
-  public mutating func encodeIfPresent<T: Encodable>(
-    _ value: T?,
+  public mutating func encodeIfPresent(
+    _ value: (some Encodable)?,
     forKey key: Key
   ) throws {
     try _box.encodeIfPresent(value, forKey: key)
@@ -2240,7 +2240,7 @@ public protocol UnkeyedEncodingContainer {
   /// - parameter value: The value to encode.
   /// - throws: `EncodingError.invalidValue` if the given value is invalid in
   ///   the current context for this format.
-  mutating func encode<T: Encodable>(_ value: T) throws
+  mutating func encode(_ value: some Encodable) throws
 
   /// Encodes a reference to the given object only if it is encoded
   /// unconditionally elsewhere in the payload (previously, or in the future).
@@ -2254,7 +2254,7 @@ public protocol UnkeyedEncodingContainer {
   /// - parameter object: The object to encode.
   /// - throws: `EncodingError.invalidValue` if the given value is invalid in
   ///   the current context for this format.
-  mutating func encodeConditional<T: AnyObject & Encodable>(_ object: T) throws
+  mutating func encodeConditional(_ object: some AnyObject & Encodable) throws
 
   /// Encodes the elements of the given sequence.
   ///
@@ -2964,7 +2964,7 @@ public protocol SingleValueEncodingContainer {
   ///   the current context for this format.
   /// - precondition: May not be called after a previous `self.encode(_:)`
   ///   call.
-  mutating func encode<T: Encodable>(_ value: T) throws
+  mutating func encode(_ value: some Encodable) throws
 }
 
 /// A container that can support the storage and direct decoding of a single
@@ -5749,8 +5749,8 @@ extension Dictionary: Decodable where Key: Decodable, Value: Decodable {
 // Default implementation of encodeConditional(_:forKey:) in terms of
 // encode(_:forKey:)
 extension KeyedEncodingContainerProtocol {
-  public mutating func encodeConditional<T: AnyObject & Encodable>(
-    _ object: T,
+  public mutating func encodeConditional(
+    _ object: some AnyObject & Encodable,
     forKey key: Key
   ) throws {
     try encode(object, forKey: key)
@@ -5872,8 +5872,8 @@ extension KeyedEncodingContainerProtocol {
     try encode(value, forKey: key)
   }
 
-  public mutating func encodeIfPresent<T: Encodable>(
-    _ value: T?,
+  public mutating func encodeIfPresent(
+    _ value: (some Encodable)?,
     forKey key: Key
   ) throws {
     guard let value = value else { return }
@@ -6023,8 +6023,8 @@ extension KeyedDecodingContainerProtocol {
 // Default implementation of encodeConditional(_:) in terms of encode(_:),
 // and encode(contentsOf:) in terms of encode(_:) loop.
 extension UnkeyedEncodingContainer {
-  public mutating func encodeConditional<T: AnyObject & Encodable>(
-    _ object: T
+  public mutating func encodeConditional(
+    _ object: some AnyObject & Encodable
   ) throws {
     try self.encode(object)
   }

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -5540,7 +5540,7 @@ public protocol CodingKeyRepresentable {
   @available(SwiftStdlib 5.6, *)
   var codingKey: any CodingKey { get }
   @available(SwiftStdlib 5.6, *)
-  init?<T: CodingKey>(codingKey: T)
+  init?(codingKey: some CodingKey)
 }
 
 @available(SwiftStdlib 5.6, *)
@@ -5550,7 +5550,7 @@ extension RawRepresentable<String> where Self: CodingKeyRepresentable {
     _DictionaryCodingKey(stringValue: rawValue)
   }
   @available(SwiftStdlib 5.6, *)
-  public init?<T: CodingKey>(codingKey: T) {
+  public init?(codingKey: some CodingKey) {
     self.init(rawValue: codingKey.stringValue)
   }
 }
@@ -5562,7 +5562,7 @@ extension RawRepresentable<Int> where Self: CodingKeyRepresentable {
     _DictionaryCodingKey(intValue: rawValue)
   }
   @available(SwiftStdlib 5.6, *)
-  public init?<T: CodingKey>(codingKey: T) {
+  public init?(codingKey: some CodingKey) {
     if let intValue = codingKey.intValue {
       self.init(rawValue: intValue)
     } else {
@@ -5578,7 +5578,7 @@ extension Int: CodingKeyRepresentable {
     _DictionaryCodingKey(intValue: self)
   }
   @available(SwiftStdlib 5.6, *)
-  public init?<T: CodingKey>(codingKey: T) {
+  public init?(codingKey: some CodingKey) {
     if let intValue = codingKey.intValue {
       self = intValue
     } else {
@@ -5594,7 +5594,7 @@ extension String: CodingKeyRepresentable {
     _DictionaryCodingKey(stringValue: self)
   }
   @available(SwiftStdlib 5.6, *)
-  public init?<T: CodingKey>(codingKey: T) {
+  public init?(codingKey: some CodingKey) {
     self = codingKey.stringValue
   }
 }

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -3189,7 +3189,7 @@ public enum EncodingError: Error {
     public let debugDescription: String
 
     /// The underlying error which caused this error, if any.
-    public let underlyingError: Error?
+    public let underlyingError: (any Error)?
 
     /// Creates a new context with the given path of coding keys and a
     /// description of what went wrong.
@@ -3203,7 +3203,7 @@ public enum EncodingError: Error {
     public init(
       codingPath: [any CodingKey],
       debugDescription: String,
-      underlyingError: Error? = nil
+      underlyingError: (any Error)? = nil
     ) {
       self.codingPath = codingPath
       self.debugDescription = debugDescription
@@ -3272,7 +3272,7 @@ public enum DecodingError: Error {
     public let debugDescription: String
 
     /// The underlying error which caused this error, if any.
-    public let underlyingError: Error?
+    public let underlyingError: (any Error)?
 
     /// Creates a new context with the given path of coding keys and a
     /// description of what went wrong.
@@ -3286,7 +3286,7 @@ public enum DecodingError: Error {
     public init(
       codingPath: [any CodingKey],
       debugDescription: String,
-      underlyingError: Error? = nil
+      underlyingError: (any Error)? = nil
     ) {
       self.codingPath = codingPath
       self.debugDescription = debugDescription

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -5538,7 +5538,7 @@ internal struct _DictionaryCodingKey: CodingKey {
 @available(SwiftStdlib 5.6, *)
 public protocol CodingKeyRepresentable {
   @available(SwiftStdlib 5.6, *)
-  var codingKey: CodingKey { get }
+  var codingKey: any CodingKey { get }
   @available(SwiftStdlib 5.6, *)
   init?<T: CodingKey>(codingKey: T)
 }
@@ -5546,7 +5546,7 @@ public protocol CodingKeyRepresentable {
 @available(SwiftStdlib 5.6, *)
 extension RawRepresentable<String> where Self: CodingKeyRepresentable {
   @available(SwiftStdlib 5.6, *)
-  public var codingKey: CodingKey {
+  public var codingKey: any CodingKey {
     _DictionaryCodingKey(stringValue: rawValue)
   }
   @available(SwiftStdlib 5.6, *)
@@ -5558,7 +5558,7 @@ extension RawRepresentable<String> where Self: CodingKeyRepresentable {
 @available(SwiftStdlib 5.6, *)
 extension RawRepresentable<Int> where Self: CodingKeyRepresentable {
   @available(SwiftStdlib 5.6, *)
-  public var codingKey: CodingKey {
+  public var codingKey: any CodingKey {
     _DictionaryCodingKey(intValue: rawValue)
   }
   @available(SwiftStdlib 5.6, *)
@@ -5574,7 +5574,7 @@ extension RawRepresentable<Int> where Self: CodingKeyRepresentable {
 @available(SwiftStdlib 5.6, *)
 extension Int: CodingKeyRepresentable {
   @available(SwiftStdlib 5.6, *)
-  public var codingKey: CodingKey {
+  public var codingKey: any CodingKey {
     _DictionaryCodingKey(intValue: self)
   }
   @available(SwiftStdlib 5.6, *)
@@ -5590,7 +5590,7 @@ extension Int: CodingKeyRepresentable {
 @available(SwiftStdlib 5.6, *)
 extension String: CodingKeyRepresentable {
   @available(SwiftStdlib 5.6, *)
-  public var codingKey: CodingKey {
+  public var codingKey: any CodingKey {
     _DictionaryCodingKey(stringValue: self)
   }
   @available(SwiftStdlib 5.6, *)

--- a/stdlib/public/core/Codable.swift
+++ b/stdlib/public/core/Codable.swift
@@ -2260,113 +2260,113 @@ public protocol UnkeyedEncodingContainer {
   ///
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
-  mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == Bool
+  mutating func encode(
+    contentsOf sequence: some Sequence<Bool>
+  ) throws
 
   /// Encodes the elements of the given sequence.
   ///
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
-  mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == String
+  mutating func encode(
+    contentsOf sequence: some Sequence<String>
+  ) throws
 
   /// Encodes the elements of the given sequence.
   ///
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
-  mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == Double
+  mutating func encode(
+    contentsOf sequence: some Sequence<Double>
+  ) throws
 
   /// Encodes the elements of the given sequence.
   ///
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
-  mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == Float
+  mutating func encode(
+    contentsOf sequence: some Sequence<Float>
+  ) throws
 
   /// Encodes the elements of the given sequence.
   ///
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
-  mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == Int
+  mutating func encode(
+    contentsOf sequence: some Sequence<Int>
+  ) throws
 
   /// Encodes the elements of the given sequence.
   ///
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
-  mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == Int8
+  mutating func encode(
+    contentsOf sequence: some Sequence<Int8>
+  ) throws
 
   /// Encodes the elements of the given sequence.
   ///
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
-  mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == Int16
+  mutating func encode(
+    contentsOf sequence: some Sequence<Int16>
+  ) throws
 
   /// Encodes the elements of the given sequence.
   ///
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
-  mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == Int32
+  mutating func encode(
+    contentsOf sequence: some Sequence<Int32>
+  ) throws
 
   /// Encodes the elements of the given sequence.
   ///
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
-  mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == Int64
+  mutating func encode(
+    contentsOf sequence: some Sequence<Int64>
+  ) throws
 
   /// Encodes the elements of the given sequence.
   ///
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
-  mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == UInt
+  mutating func encode(
+    contentsOf sequence: some Sequence<UInt>
+  ) throws
 
   /// Encodes the elements of the given sequence.
   ///
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
-  mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == UInt8
+  mutating func encode(
+    contentsOf sequence: some Sequence<UInt8>
+  ) throws
 
   /// Encodes the elements of the given sequence.
   ///
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
-  mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == UInt16
+  mutating func encode(
+    contentsOf sequence: some Sequence<UInt16>
+  ) throws
 
   /// Encodes the elements of the given sequence.
   ///
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
-  mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == UInt32
+  mutating func encode(
+    contentsOf sequence: some Sequence<UInt32>
+  ) throws
 
   /// Encodes the elements of the given sequence.
   ///
   /// - parameter sequence: The sequences whose contents to encode.
   /// - throws: An error if any of the contained values throws an error.
-  mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == UInt64
+  mutating func encode(
+    contentsOf sequence: some Sequence<UInt64>
+  ) throws
 
   /// Encodes the elements of the given sequence.
   ///
@@ -6029,113 +6029,113 @@ extension UnkeyedEncodingContainer {
     try self.encode(object)
   }
 
-  public mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == Bool {
+  public mutating func encode(
+    contentsOf sequence: some Sequence<Bool>
+  ) throws {
     for element in sequence {
       try self.encode(element)
     }
   }
 
-  public mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == String {
+  public mutating func encode(
+    contentsOf sequence: some Sequence<String>
+  ) throws {
     for element in sequence {
       try self.encode(element)
     }
   }
 
-  public mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == Double {
+  public mutating func encode(
+    contentsOf sequence: some Sequence<Double>
+  ) throws {
     for element in sequence {
       try self.encode(element)
     }
   }
 
-  public mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == Float {
+  public mutating func encode(
+    contentsOf sequence: some Sequence<Float>
+  ) throws {
     for element in sequence {
       try self.encode(element)
     }
   }
 
-  public mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == Int {
+  public mutating func encode(
+    contentsOf sequence: some Sequence<Int>
+  ) throws {
     for element in sequence {
       try self.encode(element)
     }
   }
 
-  public mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == Int8 {
+  public mutating func encode(
+    contentsOf sequence: some Sequence<Int8>
+  ) throws {
     for element in sequence {
       try self.encode(element)
     }
   }
 
-  public mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == Int16 {
+  public mutating func encode(
+    contentsOf sequence: some Sequence<Int16>
+  ) throws {
     for element in sequence {
       try self.encode(element)
     }
   }
 
-  public mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == Int32 {
+  public mutating func encode(
+    contentsOf sequence: some Sequence<Int32>
+  ) throws {
     for element in sequence {
       try self.encode(element)
     }
   }
 
-  public mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == Int64 {
+  public mutating func encode(
+    contentsOf sequence: some Sequence<Int64>
+  ) throws {
     for element in sequence {
       try self.encode(element)
     }
   }
 
-  public mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == UInt {
+  public mutating func encode(
+    contentsOf sequence: some Sequence<UInt>
+  ) throws {
     for element in sequence {
       try self.encode(element)
     }
   }
 
-  public mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == UInt8 {
+  public mutating func encode(
+    contentsOf sequence: some Sequence<UInt8>
+  ) throws {
     for element in sequence {
       try self.encode(element)
     }
   }
 
-  public mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == UInt16 {
+  public mutating func encode(
+    contentsOf sequence: some Sequence<UInt16>
+  ) throws {
     for element in sequence {
       try self.encode(element)
     }
   }
 
-  public mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == UInt32 {
+  public mutating func encode(
+    contentsOf sequence: some Sequence<UInt32>
+  ) throws {
     for element in sequence {
       try self.encode(element)
     }
   }
 
-  public mutating func encode<T: Sequence>(
-    contentsOf sequence: T
-  ) throws where T.Element == UInt64 {
+  public mutating func encode(
+    contentsOf sequence: some Sequence<UInt64>
+  ) throws {
     for element in sequence {
       try self.encode(element)
     }

--- a/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
+++ b/test/api-digester/Outputs/stability-stdlib-source-x86_64.swift.expected
@@ -28,3 +28,44 @@ Func Unicode.UTF8.decode(_:) has generic signature change from <I where I : Swif
 Constructor Mirror.init(_:children:displayStyle:ancestorRepresentation:) has generic signature change from <Subject, C where C : Swift.Collection, C.Element == Swift.Mirror.Child> to <Subject, C where C : Swift.Collection, C.Element == (label: Swift.String?, value: Any)>
 
 Protocol SIMDScalar has generic signature change from <Self == Self.SIMD16Storage.Scalar, Self.SIMD16Storage : Swift.SIMDStorage, Self.SIMD2Storage : Swift.SIMDStorage, Self.SIMD32Storage : Swift.SIMDStorage, Self.SIMD4Storage : Swift.SIMDStorage, Self.SIMD64Storage : Swift.SIMDStorage, Self.SIMD8Storage : Swift.SIMDStorage, Self.SIMDMaskScalar : Swift.FixedWidthInteger, Self.SIMDMaskScalar : Swift.SIMDScalar, Self.SIMDMaskScalar : Swift.SignedInteger, Self.SIMD16Storage.Scalar == Self.SIMD2Storage.Scalar, Self.SIMD2Storage.Scalar == Self.SIMD32Storage.Scalar, Self.SIMD32Storage.Scalar == Self.SIMD4Storage.Scalar, Self.SIMD4Storage.Scalar == Self.SIMD64Storage.Scalar, Self.SIMD64Storage.Scalar == Self.SIMD8Storage.Scalar> to <Self == Self.SIMD16Storage.Scalar, Self.SIMD16Storage : Swift.SIMDStorage, Self.SIMD2Storage : Swift.SIMDStorage, Self.SIMD32Storage : Swift.SIMDStorage, Self.SIMD4Storage : Swift.SIMDStorage, Self.SIMD64Storage : Swift.SIMDStorage, Self.SIMD8Storage : Swift.SIMDStorage, Self.SIMDMaskScalar : Swift.FixedWidthInteger, Self.SIMDMaskScalar : Swift.SIMDScalar, Self.SIMDMaskScalar : Swift.SignedInteger, Self.SIMDMaskScalar == Self.SIMDMaskScalar.SIMDMaskScalar, Self.SIMD16Storage.Scalar == Self.SIMD2Storage.Scalar, Self.SIMD2Storage.Scalar == Self.SIMD32Storage.Scalar, Self.SIMD32Storage.Scalar == Self.SIMD4Storage.Scalar, Self.SIMD4Storage.Scalar == Self.SIMD64Storage.Scalar, Self.SIMD64Storage.Scalar == Self.SIMD8Storage.Scalar>
+
+// FIXME: `(any Error)?`
+Accessor DecodingError.Context.underlyingError.Get() has return type change from Swift.Error? to (Swift.Error)?
+Accessor EncodingError.Context.underlyingError.Get() has return type change from Swift.Error? to (Swift.Error)?
+Constructor DecodingError.Context.init(codingPath:debugDescription:underlyingError:) has parameter 2 type change from Swift.Error? to (Swift.Error)?
+Constructor EncodingError.Context.init(codingPath:debugDescription:underlyingError:) has parameter 2 type change from Swift.Error? to (Swift.Error)?
+Var DecodingError.Context.underlyingError has declared type change from Swift.Error? to (Swift.Error)?
+Var EncodingError.Context.underlyingError has declared type change from Swift.Error? to (Swift.Error)?
+
+// FIXME: `some Encodable`
+Func KeyedEncodingContainerProtocol.encode(_:forKey:) has generic signature change from <Self, T where Self : Swift.KeyedEncodingContainerProtocol, T : Swift.Encodable> to <Self where Self : Swift.KeyedEncodingContainerProtocol>
+Func KeyedEncodingContainer.encode(_:forKey:) has generic signature change from <K, T where K : Swift.CodingKey, T : Swift.Encodable> to <K where K : Swift.CodingKey>
+Func SingleValueEncodingContainer.encode(_:) has generic signature change from <Self, T where Self : Swift.SingleValueEncodingContainer, T : Swift.Encodable> to <Self where Self : Swift.SingleValueEncodingContainer>
+Func UnkeyedEncodingContainer.encode(_:) has generic signature change from <Self, T where Self : Swift.UnkeyedEncodingContainer, T : Swift.Encodable> to <Self where Self : Swift.UnkeyedEncodingContainer>
+
+// FIXME: `some AnyObject & Encodable`
+Func KeyedEncodingContainerProtocol.encodeConditional(_:forKey:) has generic signature change from <Self, T where Self : Swift.KeyedEncodingContainerProtocol, T : AnyObject, T : Swift.Encodable> to <Self where Self : Swift.KeyedEncodingContainerProtocol>
+Func KeyedEncodingContainer.encodeConditional(_:forKey:) has generic signature change from <K, T where K : Swift.CodingKey, T : AnyObject, T : Swift.Encodable> to <K where K : Swift.CodingKey>
+Func UnkeyedEncodingContainer.encodeConditional(_:) has generic signature change from <Self, T where Self : Swift.UnkeyedEncodingContainer, T : AnyObject, T : Swift.Encodable> to <Self where Self : Swift.UnkeyedEncodingContainer>
+
+// FIXME: `(some Encodable)?`
+Func KeyedEncodingContainerProtocol.encodeIfPresent(_:forKey:) has generic signature change from <Self, T where Self : Swift.KeyedEncodingContainerProtocol, T : Swift.Encodable> to <Self where Self : Swift.KeyedEncodingContainerProtocol>
+Func KeyedEncodingContainerProtocol.encodeIfPresent(_:forKey:) has parameter 0 type change from T? to (some Swift.Encodable)?
+Func KeyedEncodingContainer.encodeIfPresent(_:forKey:) has generic signature change from <K, T where K : Swift.CodingKey, T : Swift.Encodable> to <K where K : Swift.CodingKey>
+Func KeyedEncodingContainer.encodeIfPresent(_:forKey:) has parameter 0 type change from T? to (some Swift.Encodable)?
+
+// FIXME: `some Sequence<Element>`
+Func UnkeyedEncodingContainer.encode(contentsOf:) has generic signature change from <Self, T where Self : Swift.UnkeyedEncodingContainer, T : Swift.Sequence, T.Element == Swift.Bool> to <Self where Self : Swift.UnkeyedEncodingContainer>
+Func UnkeyedEncodingContainer.encode(contentsOf:) has generic signature change from <Self, T where Self : Swift.UnkeyedEncodingContainer, T : Swift.Sequence, T.Element == Swift.String> to <Self where Self : Swift.UnkeyedEncodingContainer>
+Func UnkeyedEncodingContainer.encode(contentsOf:) has generic signature change from <Self, T where Self : Swift.UnkeyedEncodingContainer, T : Swift.Sequence, T.Element == Swift.Double> to <Self where Self : Swift.UnkeyedEncodingContainer>
+Func UnkeyedEncodingContainer.encode(contentsOf:) has generic signature change from <Self, T where Self : Swift.UnkeyedEncodingContainer, T : Swift.Sequence, T.Element == Swift.Float> to <Self where Self : Swift.UnkeyedEncodingContainer>
+Func UnkeyedEncodingContainer.encode(contentsOf:) has generic signature change from <Self, T where Self : Swift.UnkeyedEncodingContainer, T : Swift.Sequence, T.Element == Swift.Int> to <Self where Self : Swift.UnkeyedEncodingContainer>
+Func UnkeyedEncodingContainer.encode(contentsOf:) has generic signature change from <Self, T where Self : Swift.UnkeyedEncodingContainer, T : Swift.Sequence, T.Element == Swift.Int8> to <Self where Self : Swift.UnkeyedEncodingContainer>
+Func UnkeyedEncodingContainer.encode(contentsOf:) has generic signature change from <Self, T where Self : Swift.UnkeyedEncodingContainer, T : Swift.Sequence, T.Element == Swift.Int16> to <Self where Self : Swift.UnkeyedEncodingContainer>
+Func UnkeyedEncodingContainer.encode(contentsOf:) has generic signature change from <Self, T where Self : Swift.UnkeyedEncodingContainer, T : Swift.Sequence, T.Element == Swift.Int32> to <Self where Self : Swift.UnkeyedEncodingContainer>
+Func UnkeyedEncodingContainer.encode(contentsOf:) has generic signature change from <Self, T where Self : Swift.UnkeyedEncodingContainer, T : Swift.Sequence, T.Element == Swift.Int64> to <Self where Self : Swift.UnkeyedEncodingContainer>
+Func UnkeyedEncodingContainer.encode(contentsOf:) has generic signature change from <Self, T where Self : Swift.UnkeyedEncodingContainer, T : Swift.Sequence, T.Element == Swift.UInt> to <Self where Self : Swift.UnkeyedEncodingContainer>
+Func UnkeyedEncodingContainer.encode(contentsOf:) has generic signature change from <Self, T where Self : Swift.UnkeyedEncodingContainer, T : Swift.Sequence, T.Element == Swift.UInt8> to <Self where Self : Swift.UnkeyedEncodingContainer>
+Func UnkeyedEncodingContainer.encode(contentsOf:) has generic signature change from <Self, T where Self : Swift.UnkeyedEncodingContainer, T : Swift.Sequence, T.Element == Swift.UInt16> to <Self where Self : Swift.UnkeyedEncodingContainer>
+Func UnkeyedEncodingContainer.encode(contentsOf:) has generic signature change from <Self, T where Self : Swift.UnkeyedEncodingContainer, T : Swift.Sequence, T.Element == Swift.UInt32> to <Self where Self : Swift.UnkeyedEncodingContainer>
+Func UnkeyedEncodingContainer.encode(contentsOf:) has generic signature change from <Self, T where Self : Swift.UnkeyedEncodingContainer, T : Swift.Sequence, T.Element == Swift.UInt64> to <Self where Self : Swift.UnkeyedEncodingContainer>


### PR DESCRIPTION
Follow-up to https://github.com/apple/swift/pull/63184#pullrequestreview-1314042142

Commits e6e877d67a88b654debe6f19172200530283e005 and 02b9a685d6dcf7f4ebde11040d641c8db1920973 can be reverted if in doubt.

API Digester issues:

* The "macos.json" baselines are outdated (x86_64) or non-existent (arm64).
* The "stability-stdlib-source" test has false positives for new syntax.