### PR TITLE
[IRGen] Emit type layout string for enums with generic context when t…

### DIFF
--- a/lib/IRGen/TypeLayout.cpp
+++ b/lib/IRGen/TypeLayout.cpp
@@ -2232,7 +2232,7 @@ bool EnumTypeLayoutEntry::refCountString(IRGenModule &IGM,
   case CopyDestroyStrategy::ForwardToPayload:
     return cases[0]->refCountString(IGM, B, genericSig);
   case CopyDestroyStrategy::Normal: {
-    if (genericSig || !isFixedSize(IGM)) {
+    if (!isFixedSize(IGM)) {
       //      B.addResilientRefCount(accessor);
       return false;
     }


### PR DESCRIPTION
…hey are fixed size

rdar://106033865

As long as the enum itself is fixed size, a layout string can be generated for it. The surrounding context can be generic, but the enum may not contain any generics.
