### PR TITLE
[ModuleInterface] Hide non-public imports from a resilient module

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -757,7 +757,8 @@ public:
     Exported = 1 << 0,
     /// Include "regular" imports with no special annotation.
     Default = 1 << 1,
-    /// Include imports declared with `@_implementationOnly`.
+    /// Include imports declared with `@_implementationOnly` or with an
+    /// access-level of `package` or less.
     ImplementationOnly = 1 << 2,
     /// Include imports of SPIs declared with `@_spi`.
     SPIAccessControl = 1 << 3,

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1887,11 +1887,14 @@ SourceFile::getImportedModules(SmallVectorImpl<ImportedModule> &modules,
   if (!Imports)
     return;
 
+  bool moduleIsResilient = getParentModule()->getResilienceStrategy() ==
+                             ResilienceStrategy::Resilient;
   for (auto desc : *Imports) {
     ModuleDecl::ImportFilter requiredFilter;
     if (desc.options.contains(ImportFlags::Exported))
       requiredFilter |= ModuleDecl::ImportFilterKind::Exported;
-    else if (desc.options.contains(ImportFlags::ImplementationOnly))
+    else if (desc.options.contains(ImportFlags::ImplementationOnly) ||
+             (desc.accessLevel <= AccessLevel::Package && moduleIsResilient))
       requiredFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
     else if (desc.options.contains(ImportFlags::SPIOnly))
       requiredFilter |= ModuleDecl::ImportFilterKind::SPIOnly;

--- a/test/ModuleInterface/access-level-import-swiftinterfaces.swift
+++ b/test/ModuleInterface/access-level-import-swiftinterfaces.swift
@@ -1,0 +1,78 @@
+/// Check that only public imports are printed in modules interfaces,
+/// package imports and below are not.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Build the libraries.
+// RUN: %target-swift-frontend -emit-module %t/PublicLib.swift -o %t \
+// RUN:   -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/PackageLib.swift -o %t \
+// RUN:   -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/InternalLib.swift -o %t \
+// RUN:   -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/FileprivateLib.swift -o %t \
+// RUN:   -swift-version 5 -enable-library-evolution
+// RUN: %target-swift-frontend -emit-module %t/PrivateLib.swift -o %t \
+// RUN:   -swift-version 5 -enable-library-evolution
+
+/// Build client and generate swiftinterfaces.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -package-name TestPackage \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-interface-path %t/Client.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/Client.private.swiftinterface \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/Client.private.swiftinterface) -I %t \
+// RUN:   -module-name Client
+
+// RUN: %FileCheck -check-prefix=CHECK-PUBLIC %s < %t/Client.swiftinterface
+// RUN: %FileCheck -check-prefix=CHECK-PRIVATE %s < %t/Client.private.swiftinterface
+
+/// Build a client composed of many files.
+// RUN: %target-swift-frontend -typecheck %t/MultiFiles?.swift -I %t \
+// RUN:   -package-name TestPackage \
+// RUN:   -enable-library-evolution \
+// RUN:   -emit-module-interface-path %t/MultiFiles.swiftinterface \
+// RUN:   -emit-private-module-interface-path %t/MultiFiles.private.swiftinterface \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+
+// RUN: %target-swift-typecheck-module-from-interface(%t/MultiFiles.swiftinterface) -I %t
+// RUN: %target-swift-typecheck-module-from-interface(%t/MultiFiles.private.swiftinterface) -I %t \
+// RUN:   -module-name MultiFiles
+
+// RUN: %FileCheck -check-prefix=CHECK-PUBLIC %s < %t/MultiFiles.swiftinterface
+// RUN: %FileCheck -check-prefix=CHECK-PRIVATE %s < %t/MultiFiles.private.swiftinterface
+
+//--- PublicLib.swift
+//--- PackageLib.swift
+//--- InternalLib.swift
+//--- FileprivateLib.swift
+//--- PrivateLib.swift
+
+//--- Client.swift
+package import PackageLib
+// CHECK-PUBLIC-NOT: PackageLib
+// CHECK-PRIVATE-NOT: PackageLib
+
+internal import InternalLib
+// CHECK-PUBLIC-NOT: InternalLib
+// CHECK-PRIVATE-NOT: InternalLib
+
+fileprivate import FileprivateLib
+// CHECK-PUBLIC-NOT: FileprivateLib
+// CHECK-PRIVATE-NOT: FileprivateLib
+
+private import PrivateLib
+// CHECK-PUBLIC-NOT: PrivateLib
+// CHECK-PRIVATE-NOT: PrivateLib
+
+//--- MultiFilesA.swift
+public import PublicLib
+private import InternalLib
+
+//--- MultiFilesB.swift
+internal import PublicLib
+internal import InternalLib

--- a/test/Serialization/access-level-import-dependencies.swift
+++ b/test/Serialization/access-level-import-dependencies.swift
@@ -1,0 +1,74 @@
+/// Check that non-public dependencies are hidden from clients.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Prepare a module to hide or show depending on the import access-level.
+// RUN: %target-swift-frontend -emit-module %t/HiddenDep.swift -o %t \
+// RUN:   -swift-version 5 -enable-library-evolution
+
+//--- HiddenDep.swift
+
+//--- PublicDep.swift
+public import HiddenDep
+
+//--- PackageDep.swift
+package import HiddenDep
+
+//--- InternalDep.swift
+internal import HiddenDep
+
+//--- FileprivateDep.swift
+fileprivate import HiddenDep
+
+//--- PrivateDep.swift
+private import HiddenDep
+
+/// With resilience, non-public dependencies should be hidden.
+// RUN: %target-swift-frontend -emit-module %t/PublicDep.swift -o %t -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -emit-module %t/PackageDep.swift -o %t -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -emit-module %t/InternalDep.swift -o %t -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -emit-module %t/FileprivateDep.swift -o %t -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -emit-module %t/PrivateDep.swift -o %t -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+
+// RUN: %target-swift-frontend -typecheck %t/ClientOfPublic.swift -I %t \
+// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-PACKAGE-DEP %s
+// VISIBLE-PACKAGE-DEP: source: '{{.*}}HiddenDep.swiftmodule'
+//--- ClientOfPublic.swift
+import PublicDep
+
+// RUN: %target-swift-frontend -typecheck %t/ClientOfNonPublic.swift -I %t \
+// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=HIDDEN-PACKAGE-DEP %s
+// HIDDEN-PACKAGE-DEP-NOT: HiddenDep
+//--- ClientOfNonPublic.swift
+import PackageDep
+import InternalDep
+import FileprivateDep
+import PrivateDep
+
+/// Without resilience, all access-level dependencies are visible to clients.
+// RUN: %target-swift-frontend -emit-module %t/PublicDep.swift -o %t -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -emit-module %t/PackageDep.swift -o %t -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -emit-module %t/InternalDep.swift -o %t -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -emit-module %t/FileprivateDep.swift -o %t -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -emit-module %t/PrivateDep.swift -o %t -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+
+// RUN: %target-swift-frontend -typecheck %t/ClientOfPublic.swift -I %t \
+// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-PACKAGE-DEP %s
+// RUN: %target-swift-frontend -typecheck %t/ClientOfNonPublic.swift -I %t \
+// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-PACKAGE-DEP %s


### PR DESCRIPTION
When using access level on imports, consider non-public imports to be implementation details not exposed to clients. As such, a client loading a library doesn't need to load non-public transitive dependencies. To hide the dependency we don't print it in swiftinterfaces and mark it as implementation-only in binary swiftmodules files.

This behave like `@_implementationOnly import` at a module-wide level, but it is restricted to resilient modules only. All imports with any access-level in a non-resilient module remains visible to transitive clients.

---

The current behavior for package imports is somewhat undefined. A package dependency won't be imported automatically, but if a client does import it, the same client can use package decls relying on the dependency. This should be handled by deserialization recovery already. A future PR will clarify this behavior by loading transitive package dependencies only when the main module being build belongs to the same package.