### PR TITLE
[Backtracing] Add support for building target executables into libexec.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -49,6 +49,11 @@ set(SWIFTLIB_DIR
 set(SWIFTSTATICLIB_DIR
     "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/lib/swift_static")
 
+# SWIFTLIBEXEC_DIR is the directory in the build tree where Swift auxiliary
+# executables should be placed.
+set(SWIFTLIBEXEC_DIR
+    "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/libexec/swift")
+
 function(_compute_lto_flag option out_var)
   string(TOLOWER "${option}" lowercase_option)
   if (lowercase_option STREQUAL "full")

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -2877,7 +2877,7 @@ function(add_swift_target_executable name)
       set(UNIVERSAL_NAME "${SWIFTLIBEXEC_DIR}/${library_subdir}/${name}")
     endif()
 
-    set(lipo_target "${name}")
+    set(lipo_target "${name}-${sdk}")
     if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
       set(codesign_arg CODESIGN)
     endif()

--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -2700,9 +2700,9 @@ function(add_swift_target_executable name)
   # All Swift executables depend on the swiftSwiftOnoneSupport library.
   list(APPEND SWIFTEXE_TARGET_SWIFT_MODULE_DEPENDS SwiftOnoneSupport)
 
-  set(THIN_INPUT_TARGETS)
-
   foreach(sdk ${SWIFT_SDKS})
+    set(THIN_INPUT_TARGETS)
+
     # Collect architecture agnostic SDK module dependencies
     set(swiftexe_module_depends_flattened ${SWIFTEXE_TARGET_SWIFT_MODULE_DEPENDS})
     if(${sdk} STREQUAL OSX)


### PR DESCRIPTION
We're going to add a program, `swift-backtrace`, that gets built alongside the stdlib and the runtime, and that needs to be installed in libexec/swift alongside the libraries in lib/swift.

It wants to be built with the stdlib/runtime because there's an internal interface between `swift-backtrace` and the runtime, so the program needs to stay in lock-step with the runtime library.

rdar://105390807