### PR TITLE
[Macros] Be deliberate about walking macro arguments vs. expansions

### DIFF
--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -79,6 +79,24 @@ enum class LazyInitializerWalking {
   InAccessor
 };
 
+/// Specifies the behavior for walking a macro expansion, whether we want to
+/// see the macro arguments, the expansion, or both.
+enum class MacroWalking {
+  /// Walk into the expansion of the macro, to see the semantic effect of
+  /// the macro expansion.
+  Expansion,
+
+  /// Walk into the arguments of the macro as written in the source code.
+  ///
+  /// The actual arguments walked may not make it into the program itself,
+  /// because they can be translated by the macro in arbitrary ways.
+  Arguments,
+
+  /// Walk into both the arguments of the macro as written in the source code
+  /// and also the macro expansion.
+  ArgumentsAndExpansion
+};
+
 /// An abstract class used to traverse an AST.
 class ASTWalker {
 public:
@@ -504,6 +522,24 @@ public:
     return LazyInitializerWalking::InPatternBinding;
   }
 
+  /// This method configures how the walker should walk into uses of macros.
+  virtual MacroWalking getMacroWalkingBehavior() const = 0;
+
+  /// Determine whether we should walk macro arguments (as they appear in
+  /// source) and the expansion (which is semantically part of the program).
+  std::pair<bool, bool> shouldWalkMacroArgumentsAndExpansion() const {
+    switch (getMacroWalkingBehavior()) {
+    case MacroWalking::Expansion:
+      return std::make_pair(false, true);
+
+    case MacroWalking::Arguments:
+      return std::make_pair(true, false);
+
+    case MacroWalking::ArgumentsAndExpansion:
+      return std::make_pair(true, true);
+    }
+  }
+
   /// This method configures whether the walker should visit the body of a
   /// closure that was checked separately from its enclosing expression.
   ///
@@ -540,10 +576,6 @@ public:
   ///
   /// TODO: Consider changing this to false by default.
   virtual bool shouldWalkSerializedTopLevelInternalDecls() { return true; }
-
-  /// Whether we should walk into expanded macros, whether it be from a
-  /// \c MacroExpansionExpr or declarations created by attached macros.
-  virtual bool shouldWalkMacroExpansions() { return true; }
 
   /// walkToParameterListPre - This method is called when first visiting a
   /// ParameterList, before walking into its parameters.

--- a/include/swift/AST/ASTWalker.h
+++ b/include/swift/AST/ASTWalker.h
@@ -523,7 +523,9 @@ public:
   }
 
   /// This method configures how the walker should walk into uses of macros.
-  virtual MacroWalking getMacroWalkingBehavior() const = 0;
+  virtual MacroWalking getMacroWalkingBehavior() const {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
 
   /// Determine whether we should walk macro arguments (as they appear in
   /// source) and the expansion (which is semantically part of the program).

--- a/include/swift/AST/TypeDeclFinder.h
+++ b/include/swift/AST/TypeDeclFinder.h
@@ -67,6 +67,10 @@ class TypeReprIdentFinder : public ASTWalker {
   /// The function to call when a \c IdentTypeRepr is seen.
   llvm::function_ref<bool(const IdentTypeRepr *)> Callback;
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Arguments;
+  }
+
   PostWalkAction walkToTypeReprPost(TypeRepr *TR) override;
 
 public:

--- a/include/swift/IDE/SourceEntityWalker.h
+++ b/include/swift/IDE/SourceEntityWalker.h
@@ -201,9 +201,10 @@ public:
 
   virtual bool shouldWalkIntoGenericParams() { return true; }
 
-  /// Whether we should walk into expanded macros, whether it be from a
-  /// \c MacroExpansionExpr or declarations created by attached macros.
-  virtual bool shouldWalkMacroExpansions() { return false; }
+  /// Only walk the arguments of a macro, to represent the source as written.
+  virtual MacroWalking getMacroWalkingBehavior() const {
+    return MacroWalking::Arguments;
+  }
 
 protected:
   SourceEntityWalker() = default;

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -368,6 +368,10 @@ class NameMatcher: public ASTWalker {
   bool handleCustomAttrs(Decl *D);
   ArgumentList *getApplicableArgsFor(Expr* E);
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Arguments;
+  }
+
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override;
   PostWalkResult<Expr *> walkToExprPost(Expr *E) override;
   PreWalkAction walkToDeclPre(Decl *D) override;

--- a/include/swift/Sema/CompletionContextFinder.h
+++ b/include/swift/Sema/CompletionContextFinder.h
@@ -49,6 +49,10 @@ class CompletionContextFinder : public ASTWalker {
   DeclContext *InitialDC;
 
 public:
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Arguments;
+  }
+
   /// Finder for completion contexts within the provided initial expression.
   CompletionContextFinder(ASTNode initialNode, DeclContext *DC)
       : InitialExpr(initialNode.dyn_cast<Expr *>()), InitialDC(DC) {

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -3376,6 +3376,11 @@ private:
     CacheExprTypes(Expr *expr, ConstraintSystem &cs, bool excludeRoot)
         : RootExpr(expr), CS(cs), ExcludeRoot(excludeRoot) {}
 
+    /// Walk everything in a macro
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
+
     PostWalkResult<Expr *> walkToExprPost(Expr *expr) override {
       if (ExcludeRoot && expr == RootExpr) {
         assert(!expr->getType() && "Unexpected type in root of expression!");
@@ -6953,6 +6958,10 @@ public:
   OverloadSetCounter(unsigned &overloads)
   : NumOverloads(overloads)
   {}
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Arguments;
+  }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
     if (auto applyExpr = dyn_cast<ApplyExpr>(expr)) {

--- a/lib/APIDigester/ModuleAnalyzerNodes.cpp
+++ b/lib/APIDigester/ModuleAnalyzerNodes.cpp
@@ -2405,6 +2405,11 @@ class ConstExtractor: public ASTWalker {
     }
     return false;
   }
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
+
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (E->isSemanticallyConstExpr()) {
       record(E, E);

--- a/lib/AST/ASTScopeCreation.cpp
+++ b/lib/AST/ASTScopeCreation.cpp
@@ -141,6 +141,10 @@ public:
       PreWalkAction walkToParameterListPre(ParameterList *PL) override {
         return Action::SkipChildren();
       }
+
+      MacroWalking getMacroWalkingBehavior() const override {
+        return MacroWalking::ArgumentsAndExpansion;
+      }
     };
 
     expr->walk(ClosureFinder(*this, parent));

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -271,6 +271,10 @@ public:
     return Verifier(topDC->getParentModule(), DC);
   }
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
+  }
+
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     switch (E->getKind()) {
 #define DISPATCH(ID) return dispatchVisitPreExpr(static_cast<ID##Expr*>(E))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7648,6 +7648,11 @@ swift::findWrappedValuePlaceholder(Expr *init) {
   public:
     PropertyWrapperValuePlaceholderExpr *placeholder = nullptr;
 
+    /// Only walk the arguments of a macro, to represent the source as written.
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
+
     virtual PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (placeholder)
         return Action::SkipChildren(E);
@@ -8342,6 +8347,11 @@ AbstractFunctionDecl::getBodyFingerprintIncludingLocalTypeMembers() const {
 
   public:
     HashCombiner(StableHasher &hasher) : hasher(hasher) {}
+
+    /// Only walk the arguments of a macro, to represent the source as written.
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
 
     PreWalkAction walkToDeclPre(Decl *D) override {
       if (D->isImplicit())

--- a/lib/AST/InlinableText.cpp
+++ b/lib/AST/InlinableText.cpp
@@ -49,6 +49,11 @@ class IsFeatureCheck : public ASTWalker {
 public:
   bool foundFeature = false;
 
+  /// Walk everything that's available.
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
+
   PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
     if (auto unresolved = dyn_cast<UnresolvedDeclRefExpr>(expr)) {
       if (unresolved->getName().getBaseName().userFacingName().startswith("$"))
@@ -109,6 +114,11 @@ bool anyClauseIsFeatureCheck(ArrayRef<IfConfigClause> clauses) {
 struct ExtractInactiveRanges : public ASTWalker {
   SmallVector<CharSourceRange, 4> ranges;
   SourceManager &sourceMgr;
+
+  /// Walk everything that's available.
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
 
   explicit ExtractInactiveRanges(SourceManager &sourceMgr)
     : sourceMgr(sourceMgr) {}

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2920,6 +2920,11 @@ CollectedOpaqueReprs swift::collectOpaqueReturnTypeReprs(TypeRepr *r, ASTContext
   public:
     explicit Walker(CollectedOpaqueReprs &reprs, ASTContext &ctx, DeclContext *d) : Reprs(reprs), Ctx(ctx), dc(d) {}
 
+    /// Walk everything that's available.
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
+
     PreWalkAction walkToTypeReprPre(TypeRepr *repr) override {
 
       // Don't allow variadic opaque parameter or return types.

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -167,6 +167,12 @@ namespace {
     WalkToVarDecls(const std::function<void(VarDecl*)> &fn)
     : fn(fn) {}
 
+    /// Walk everything that's available; there shouldn't be macro expansions
+    /// that matter anyway.
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
+
     PostWalkResult<Pattern *> walkToPatternPost(Pattern *P) override {
       // Handle vars.
       if (auto *Named = dyn_cast<NamedPattern>(P))

--- a/lib/AST/Stmt.cpp
+++ b/lib/AST/Stmt.cpp
@@ -245,6 +245,11 @@ ASTNode BraceStmt::findAsyncNode() {
   class FindInnerAsync : public ASTWalker {
     ASTNode AsyncNode;
 
+    /// Walk only the macro arguments.
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
+
     PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
       // If we've found an 'await', record it and terminate the traversal.
       if (isa<AwaitExpr>(expr)) {

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -83,6 +83,11 @@ bool TypeRepr::findIf(llvm::function_ref<bool(TypeRepr *)> pred) {
     explicit Walker(llvm::function_ref<bool(TypeRepr *)> pred)
         : Pred(pred), FoundIt(false) {}
 
+    /// Walk everything in a macro
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
+
     PreWalkAction walkToTypeReprPre(TypeRepr *ty) override {
       if (Pred(ty)) {
         FoundIt = true;

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -47,6 +47,10 @@ public:
       std::vector<NominalTypeDecl *> &ConformanceDecls)
       : Protocols(Protocols), ConformanceTypeDecls(ConformanceDecls) {}
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
+
   PreWalkAction walkToDeclPre(Decl *D) override {
     if (auto *NTD = llvm::dyn_cast<NominalTypeDecl>(D))
       if (!isa<ProtocolDecl>(NTD))

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -187,6 +187,11 @@ bool swift::ide::canDeclContextHandleAsync(const DeclContext *DC) {
       const ClosureExpr *Target;
       bool Result = false;
 
+      /// Walk everything in a macro.
+      MacroWalking getMacroWalkingBehavior() const override {
+        return MacroWalking::ArgumentsAndExpansion;
+      }
+
       AsyncClosureChecker(const ClosureExpr *Target) : Target(Target) {}
 
       PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
@@ -3229,6 +3234,11 @@ void CompletionLookup::getStmtLabelCompletions(SourceLoc Loc, bool isContinue) {
 
   public:
     SmallVector<Identifier, 2> Result;
+
+    /// Walk only the arguments of a macro.
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
 
     LabelFinder(SourceManager &SM, SourceLoc TargetLoc, bool IsContinue)
         : SM(SM), TargetLoc(TargetLoc), IsContinue(IsContinue) {}

--- a/lib/IDE/CursorInfo.cpp
+++ b/lib/IDE/CursorInfo.cpp
@@ -169,6 +169,10 @@ private:
     return getSourceMgr().containsRespectingReplacedRanges(Range, LocToResolve);
   }
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
+
   PreWalkAction walkToDeclPre(Decl *D) override {
     if (!rangeContainsLocToResolve(D->getSourceRangeIncludingAttrs())) {
       return PreWalkAction::SkipChildren;

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -119,6 +119,10 @@ public:
 
   Expr *get() const { return FoundExpr; }
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
+
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (TargetRange == E->getSourceRange() && !shouldIgnore(E)) {
       assert(!FoundExpr && "non-nullptr for found expr");
@@ -162,6 +166,10 @@ public:
   bool Removed = false;
 
   CCExprRemover(ASTContext &Ctx) : Ctx(Ctx) {}
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
 
   Expr *visitCallExpr(CallExpr *E) {
     auto *args = E->getArgs()->getOriginalArgs();
@@ -301,6 +309,10 @@ public:
   ExprParentFinder(Expr *ChildExpr,
                    std::function<bool(ParentTy, ParentTy)> Predicate)
       : ChildExpr(ChildExpr), Predicate(Predicate) {}
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     // Finish if we found the target. 'ChildExpr' might have been replaced

--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -475,6 +475,10 @@ private:
     return true;
   }
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Arguments;
+  }
+
   PreWalkAction walkToDeclPre(Decl *D) override {
     if (!walkCustomAttributes(D))
       return Action::SkipChildren();
@@ -1349,6 +1353,10 @@ private:
       }
     }
     return true;
+  }
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Arguments;
   }
 
   PreWalkAction walkToDeclPre(Decl *D) override {

--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -77,6 +77,10 @@ public:
   ResolvedCursorInfoPtr resolve(SourceLoc Loc);
   SourceManager &getSourceMgr() const;
 private:
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
+
   bool walkToExprPre(Expr *E) override;
   bool walkToExprPost(Expr *E) override;
   bool walkToDeclPre(Decl *D, CharSourceRange Range) override;

--- a/lib/IDE/IDERequests.cpp
+++ b/lib/IDE/IDERequests.cpp
@@ -102,11 +102,6 @@ private:
   bool visitSubscriptReference(ValueDecl *D, CharSourceRange Range,
                                ReferenceMetaData Data,
                                bool IsOpenBracket) override;
-
-  // We want to be able to resolve symbols within expansions
-  bool shouldWalkMacroExpansions() override {
-    return true;
-  }
 };
 
 SourceManager &CursorInfoResolver::getSourceMgr() const

--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -58,8 +58,8 @@ private:
     return false;
   }
 
-  bool shouldWalkMacroExpansions() override {
-    return SEWalker.shouldWalkMacroExpansions();
+  MacroWalking getMacroWalkingBehavior() const override {
+    return SEWalker.getMacroWalkingBehavior();
   }
 
   PreWalkAction walkToDeclPre(Decl *D) override;
@@ -687,7 +687,7 @@ bool SemaAnnotator::handleCustomAttributes(Decl *D) {
   // FIXME: This should be getSemanticAttrs if we want to walk macro
   // expansions. We've just already typechecked and this list is mutable so...
   for (auto *customAttr : D->getAttrs().getAttributes<CustomAttr, true>()) {
-    if (!shouldWalkMacroExpansions() &&
+    if (!shouldWalkMacroArgumentsAndExpansion().second &&
         D->getModuleContext()->isInGeneratedBuffer(customAttr->getLocation()))
       continue;
 

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -394,7 +394,10 @@ public:
   // FIXME: Remove this
   bool shouldWalkAccessorsTheOldWay() override { return true; }
 
-  bool shouldWalkMacroExpansions() override { return false; }
+  /// Only walk the arguments of a macro, to represent the source as written.
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Arguments;
+  }
 
   void visitSourceFile(SourceFile &SrcFile, ArrayRef<SyntaxNode> Tokens);
 
@@ -1201,6 +1204,10 @@ class IdRefWalker : public ASTWalker {
 
 public:
   IdRefWalker(const FnTy &Fn) : Fn(Fn) {}
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (auto DRE = dyn_cast<UnresolvedDeclRefExpr>(E)) {

--- a/lib/IRGen/TypeLayoutDumper.cpp
+++ b/lib/IRGen/TypeLayoutDumper.cpp
@@ -51,6 +51,10 @@ public:
   NominalTypeWalker(std::vector<NominalTypeDecl *> &Results)
     : Results(Results) {}
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
+  }
+
   PreWalkAction walkToDeclPre(Decl *D) override {
     if (auto *NTD = dyn_cast<NominalTypeDecl>(D))
       Results.push_back(NTD);

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -586,10 +586,9 @@ public:
     assert(Cancelled || Containers.empty());
   }
 
-  // FIXME: The index should walk expansions but give locations to the
-  // expansion site instead.
-  bool shouldWalkMacroExpansions() override {
-    return true;
+  /// Walk both the arguments and expansion of the macro, so we index both.Only walk the arguments of a macro, to represent the source as written.
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
   }
 
   void visitModule(ModuleDecl &Mod);

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -1368,6 +1368,12 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     llvm::StringSet<> &USRs;
     SuperRemoval(EditorAdapter &Editor, llvm::StringSet<> &USRs):
       Editor(Editor), USRs(USRs) {}
+
+    /// Walk everything in a macro.
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
+
     bool isSuperExpr(Expr *E) {
       if (E->isImplicit())
         return false;

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -2558,6 +2558,10 @@ struct FallthroughFinder : ASTWalker {
 
   FallthroughFinder() : result(nullptr) {}
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Arguments;
+  }
+
   // We walk through statements.  If we find a fallthrough, then we got what
   // we came for.
   PreWalkResult<Stmt *> walkToStmtPre(Stmt *s) override {

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -552,6 +552,10 @@ ParserResult<TypeRepr> Parser::parseTypeScalar(
     // Forget any generic parameters we saw in the type.
     class EraseTypeParamWalker : public ASTWalker {
     public:
+      MacroWalking getMacroWalkingBehavior() const override {
+        return MacroWalking::Arguments;
+      }
+
       PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
         if (auto ident = dyn_cast<IdentTypeRepr>(T)) {
           if (auto decl = ident->getBoundDecl()) {

--- a/lib/Refactoring/Refactoring.cpp
+++ b/lib/Refactoring/Refactoring.cpp
@@ -2404,6 +2404,10 @@ isApplicable(const ResolvedRangeInfo &Info, DiagnosticEngine &Diag) {
     bool ConditionUseOnlyAllowedFunctions = false;
     StringRef ExpectName;
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
+
     PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
       if (E->getKind() != ExprKind::DeclRef)
         return Action::Continue(E);
@@ -2502,6 +2506,10 @@ bool RefactoringActionConvertToSwitchStmt::performChange() {
   public:
     std::string VarName;
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
+
     PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
       if (E->getKind() != ExprKind::DeclRef)
         return Action::Continue(E);
@@ -2518,6 +2526,10 @@ bool RefactoringActionConvertToSwitchStmt::performChange() {
     ConditionalPatternFinder(SourceManager &SM) : SM(SM) {}
 
     SmallString<64> ConditionalPattern = SmallString<64>();
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
 
     PostWalkResult<Expr *> walkToExprPost(Expr *E) override {
       auto *BE = dyn_cast<BinaryExpr>(E);
@@ -3669,6 +3681,10 @@ private:
 public:
   SynthesizedCodablePrinter(ASTPrinter &Printer) : Printer(Printer) {}
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Arguments;
+  }
+
   PreWalkAction walkToDeclPre(Decl *D) override {
     auto *VD = dyn_cast<ValueDecl>(D);
     if (!VD)
@@ -3848,6 +3864,10 @@ static NumberLiteralExpr *getTrailingNumberLiteral(ResolvedCursorInfoPtr Tok) {
     NumberLiteralExpr *found = nullptr;
 
     explicit FindLiteralNumber(Expr *parent) : parent(parent) { }
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
 
     PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
       if (auto *literal = dyn_cast<NumberLiteralExpr>(expr)) {
@@ -5433,6 +5453,10 @@ private:
       explicit ErrUnwrapFinder(const ParamDecl *ErrParam)
           : ErrParam(ErrParam) {}
       bool foundUnwrap() const { return FoundUnwrap; }
+
+      MacroWalking getMacroWalkingBehavior() const override {
+        return MacroWalking::Arguments;
+      }
 
       PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
         // Don't walk into ternary conditionals as they may have additional

--- a/lib/SIL/IR/SILProfiler.cpp
+++ b/lib/SIL/IR/SILProfiler.cpp
@@ -269,6 +269,10 @@ struct MapRegionCounters : public ASTWalker {
     ++NextCounter;
   }
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
+  }
+
   PreWalkAction walkToDeclPre(Decl *D) override {
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
       return visitFunctionDecl(*this, AFD, [&] { mapRegion(AFD->getBody()); });
@@ -679,6 +683,10 @@ struct PGOMapping : public ASTWalker {
     return LazyInitializerWalking::InAccessor;
   }
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
+  }
+
   PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     unsigned parent = getParentCounter();
     auto parentCount = LoadedCounts.Counts[parent];
@@ -1024,6 +1032,10 @@ public:
     // We want to walk lazy initializers present in the synthesized getter for
     // a lazy variable.
     return LazyInitializerWalking::InAccessor;
+  }
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
   }
 
   /// Generate the coverage counter mapping regions from collected

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -1367,6 +1367,11 @@ void SILParser::bindSILGenericParams(TypeRepr *TyR) {
   public:
     HandleSILGenericParamsWalker(SourceFile *SF) : SF(SF) {}
 
+    /// Walk everything in a macro
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
+
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
       if (auto fnType = dyn_cast<FunctionTypeRepr>(T)) {
         if (auto *genericParams = fnType->getGenericParams()) {

--- a/lib/SILOptimizer/Analysis/ProtocolConformanceAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ProtocolConformanceAnalysis.cpp
@@ -34,6 +34,11 @@ public:
                     &ProtocolConformanceCache)
       : ProtocolConformanceCache(ProtocolConformanceCache) {}
 
+  /// Walk everything in a macro
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
+
   PreWalkAction walkToDeclPre(Decl *D) override {
     /// (1) Walk over all NominalTypeDecls to determine conformances.
     if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {

--- a/lib/Sema/BuilderTransform.cpp
+++ b/lib/Sema/BuilderTransform.cpp
@@ -2726,6 +2726,10 @@ public:
     return ResultBuilderBodyPreCheck::Okay;
   }
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Arguments;
+  }
+
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (SkipPrecheck)
       return Action::SkipChildren(E);

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -8364,6 +8364,10 @@ namespace {
     explicit SetExprTypes(const Solution &solution)
         : solution(solution) {}
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
+
     PostWalkResult<Expr *> walkToExprPost(Expr *expr) override {
       auto &cs = solution.getConstraintSystem();
       auto exprType = cs.getType(expr);
@@ -8481,6 +8485,10 @@ namespace {
       }
 
       return hadError;
+    }
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
     }
 
     PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
@@ -8962,6 +8970,10 @@ static Optional<SolutionApplicationTarget> applySolutionToForEachStmt(
 
         TryInjector(ASTContext &ctx, const Solution &solution)
             : C(ctx), S(solution) {}
+
+        MacroWalking getMacroWalkingBehavior() const override {
+          return MacroWalking::Expansion;
+        }
 
         PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
           if (ShouldStop)

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -1075,6 +1075,11 @@ bool AttributedFuncToTypeConversionFailure::
       return Action::VisitChildrenIf(FnRepr == nullptr);
     }
 
+    /// Walk macro arguments.
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
+
   public:
     FunctionTypeRepr *FnRepr;
     TopLevelFuncReprFinder() : FnRepr(nullptr) {}
@@ -1514,6 +1519,11 @@ class VarDeclMultipleReferencesChecker : public ASTWalker {
   DeclContext *DC;
   VarDecl *varDecl;
   int count;
+
+  /// Walk everything in a macro.
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (auto *DRE = dyn_cast<DeclRefExpr>(E)) {
@@ -5629,6 +5639,11 @@ bool ExtraneousArgumentsFailure::diagnoseAsError() {
           DiagnosticEngine &D;
           ParameterList *Params;
 
+          /// Walk everything in a macro.
+          MacroWalking getMacroWalkingBehavior() const override {
+            return MacroWalking::ArgumentsAndExpansion;
+          }
+
           ParamRefFinder(DiagnosticEngine &diags, ParameterList *params)
               : D(diags), Params(params) {}
 
@@ -6329,6 +6344,11 @@ bool MissingGenericArgumentsFailure::findArgumentLocations(
     AssociateMissingParams(ArrayRef<GenericTypeParamType *> params,
                            Callback callback)
         : Params(params.begin(), params.end()), Fn(callback) {}
+
+    /// Walk everything in a macro.
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
 
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
       if (Params.empty())

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -96,6 +96,10 @@ namespace {
     LinkedExprCollector(llvm::SmallVectorImpl<Expr *> &linkedExprs)
         : LinkedExprs(linkedExprs) {}
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
+
     PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
       if (isa<ClosureExpr>(expr))
         return Action::SkipChildren(expr);
@@ -158,7 +162,11 @@ namespace {
     
     LinkedExprAnalyzer(LinkedTypeInfo &lti, ConstraintSystem &cs) :
         LTI(lti), CS(cs) {}
-    
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
+
     PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
       if (isa<LiteralExpr>(expr)) {
         LTI.hasLiteral = true;
@@ -783,7 +791,11 @@ namespace {
     
     ConstraintOptimizer(ConstraintSystem &cs) :
       CS(cs) {}
-    
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
+
     PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
       if (CS.isArgumentIgnoredForCodeCompletion(expr)) {
         return Action::SkipChildren(expr);
@@ -2931,6 +2943,10 @@ namespace {
 
         bool shouldWalkCaptureInitializerExpressions() override { return true; }
 
+        MacroWalking getMacroWalkingBehavior() const override {
+          return MacroWalking::Arguments;
+        }
+
         PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
           // Retrieve type variables from references to var decls.
           if (auto *declRef = dyn_cast<DeclRefExpr>(expr)) {
@@ -4047,6 +4063,10 @@ namespace {
 
   public:
     ConstraintWalker(ConstraintGenerator &CG) : CG(CG) { }
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
 
     PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
       auto &CS = CG.getConstraintSystem();

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -976,6 +976,10 @@ void ConstraintSystem::shrink(Expr *expr) {
     ExprCollector(Expr *expr, ConstraintSystem &cs, DomainMap &domains)
         : PrimaryExpr(expr), CS(cs), Domains(domains) {}
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
+
     PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
       // A dictionary expression is just a set of tuples; try to solve ones
       // that have overload sets.

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -58,6 +58,10 @@ public:
       ClosureDCs.push_back(closure);
   }
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Arguments;
+  }
+
   PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
     if (auto *closure = dyn_cast<ClosureExpr>(expr)) {
       ClosureDCs.push_back(closure);
@@ -240,6 +244,10 @@ class UnresolvedVarCollector : public ASTWalker {
 
 public:
   UnresolvedVarCollector(ConstraintSystem &cs) : CS(cs) {}
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Arguments;
+  }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
     if (auto *DRE = dyn_cast<DeclRefExpr>(expr)) {

--- a/lib/Sema/ConstantnessSemaDiagnostics.cpp
+++ b/lib/Sema/ConstantnessSemaDiagnostics.cpp
@@ -339,6 +339,10 @@ void swift::diagnoseConstantArgumentRequirement(
   public:
     ConstantReqCallWalker(DeclContext *DC) : DC(DC), insideClosure(false) {}
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
+
     // Descend until we find a call expressions. Note that the input expression
     // could be an assign expression or another expression that contains the
     // call.

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -687,6 +687,10 @@ static void extendDepthMap(
         llvm::DenseMap<Expr *, std::pair<unsigned, Expr *>> &depthMap)
         : DepthMap(depthMap) {}
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
+
     // For argument lists, bump the depth of the arguments, as they are
     // effectively nested within the argument list. It's debatable whether we
     // should actually do this, as it doesn't reflect the true expression depth,
@@ -2949,6 +2953,10 @@ FunctionType::ExtInfo ClosureEffectsRequest::evaluate(
     DeclContext *DC;
     bool FoundThrow = false;
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Expansion;
+    }
+
     PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
       // If we've found a 'try', record it and terminate the traversal.
       if (isa<TryExpr>(expr)) {
@@ -5072,6 +5080,10 @@ static void extendPreorderIndexMap(
 
     explicit RecordingTraversal(llvm::DenseMap<Expr *, unsigned> &indexMap)
       : IndexMap(indexMap) { }
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
 
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       IndexMap[E] = Index;

--- a/lib/Sema/DebuggerTestingTransform.cpp
+++ b/lib/Sema/DebuggerTestingTransform.cpp
@@ -73,6 +73,10 @@ public:
         DebuggerTestingCheckExpectName(
             Ctx.getIdentifier("_debuggerTestingCheckExpect")) {}
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
+  }
+
   PreWalkAction walkToDeclPre(Decl *D) override {
     pushLocalDeclContext(D);
 

--- a/lib/Sema/InstrumenterSupport.cpp
+++ b/lib/Sema/InstrumenterSupport.cpp
@@ -54,6 +54,11 @@ class ErrorFinder : public ASTWalker {
 
 public:
   ErrorFinder() {}
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
+  }
+
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     if (isa<ErrorExpr>(E) || !E->getType() || E->getType()->hasError())
       error = true;

--- a/lib/Sema/InstrumenterSupport.h
+++ b/lib/Sema/InstrumenterSupport.h
@@ -61,6 +61,12 @@ protected:
 
   public:
     ClosureFinder(InstrumenterBase &Inst) : I(Inst) {}
+
+    /// Walk only the expansion of the macro.
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Expansion;
+    }
+
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
       if (isa<BraceStmt>(S)) {
         return Action::SkipChildren(S); // don't walk into brace statements; we

--- a/lib/Sema/MiscDiagnostics.h
+++ b/lib/Sema/MiscDiagnostics.h
@@ -140,6 +140,11 @@ class BaseDiagnosticWalker : public ASTWalker {
     return false;
   }
 
+  // Only emit diagnostics in the expansion of macros.
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
+  }
+
 private:
   static bool shouldWalkIntoDeclInClosureContext(Decl *D);
 };

--- a/lib/Sema/PCMacro.cpp
+++ b/lib/Sema/PCMacro.cpp
@@ -674,6 +674,10 @@ void swift::performPCMacro(SourceFile &SF) {
   public:
     ExpressionFinder() = default;
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Expansion;
+    }
+
     PreWalkAction walkToDeclPre(Decl *D) override {
       ASTContext &ctx = D->getASTContext();
       if (auto *FD = dyn_cast<AbstractFunctionDecl>(D)) {

--- a/lib/Sema/PlaygroundTransform.cpp
+++ b/lib/Sema/PlaygroundTransform.cpp
@@ -861,6 +861,10 @@ void swift::performPlaygroundTransform(SourceFile &SF, bool HighPerformance) {
     // FIXME: Remove this
     bool shouldWalkAccessorsTheOldWay() override { return true; }
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Expansion;
+    }
+
     PreWalkAction walkToDeclPre(Decl *D) override {
       if (auto *FD = dyn_cast<AbstractFunctionDecl>(D)) {
         if (!FD->isImplicit()) {

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -993,6 +993,10 @@ namespace {
 
     bool shouldWalkCaptureInitializerExpressions() override { return true; }
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
+
     VarDecl *getImplicitSelfDeclForSuperContext(SourceLoc Loc) ;
 
     PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
@@ -1537,6 +1541,10 @@ bool PreCheckExpression::correctInterpolationIfStrange(
 
   public:
     StrangeInterpolationRewriter(ASTContext &Ctx) : Context(Ctx) {}
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Expansion;
+    }
 
     virtual PreWalkAction walkToDeclPre(Decl *D) override {
       // We don't want to look inside decls.

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -119,6 +119,10 @@ class TypeAccessScopeDiagnoser : private ASTWalker {
   bool treatUsableFromInlineAsPublic;
   const IdentTypeRepr *offendingType = nullptr;
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
+
   PreWalkAction walkToTypeReprPre(TypeRepr *TR) override {
     auto ITR = dyn_cast<IdentTypeRepr>(TR);
     if (!ITR)

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -471,6 +471,10 @@ public:
   }
 
 private:
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
+
   PreWalkAction walkToDeclPre(Decl *D) override {
     PrettyStackTraceDecl trace(stackTraceAction(), D);
 
@@ -1414,6 +1418,10 @@ public:
   /// Returns the innermost node containing the target range that matches
   /// the predicate.
   Optional<ASTNode> getInnermostMatchingNode() { return InnermostMatchingNode; }
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
 
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     return getPreWalkActionFor(E);
@@ -3225,6 +3233,10 @@ public:
 
   bool shouldWalkIntoTapExpression() override { return false; }
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
+
   PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
     auto *DC = Where.getDeclContext();
 
@@ -3962,6 +3974,10 @@ public:
   TypeReprAvailabilityWalker(const ExportContext &where,
                              DeclAvailabilityFlags flags)
       : where(where), flags(flags) {}
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
 
   PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
     auto *declRefTR = dyn_cast<DeclRefTypeRepr>(T);

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -217,6 +217,10 @@ public:
     return LazyInitializerWalking::None;
   }
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
+  }
+
   PreWalkResult<Expr *> walkToDeclRefExpr(DeclRefExpr *DRE) {
     auto *D = DRE->getDecl();
 

--- a/lib/Sema/TypeCheckCodeCompletion.cpp
+++ b/lib/Sema/TypeCheckCodeCompletion.cpp
@@ -116,6 +116,10 @@ public:
   SanitizeExpr(ASTContext &C)
     : C(C) { }
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Arguments;
+  }
+
   PreWalkResult<ArgumentList *>
   walkToArgumentListPre(ArgumentList *argList) override {
     // Return the argument list to the state prior to being rewritten. This will

--- a/lib/Sema/TypeCheckConcurrency.cpp
+++ b/lib/Sema/TypeCheckConcurrency.cpp
@@ -1940,6 +1940,10 @@ namespace {
 
     bool shouldWalkIntoTapExpression() override { return true; }
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Expansion;
+    }
+
     PreWalkAction walkToDeclPre(Decl *decl) override {
       if (auto func = dyn_cast<AbstractFunctionDecl>(decl)) {
         contextStack.push_back(func);

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -290,6 +290,10 @@ class FunctionSyntacticDiagnosticWalker : public ASTWalker {
 public:
   FunctionSyntacticDiagnosticWalker(DeclContext *dc) { dcStack.push_back(dc); }
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
+  }
+
   PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
     performSyntacticExprDiagnostics(expr, dcStack.back(), /*isExprStmt=*/false);
 
@@ -1156,6 +1160,10 @@ TypeChecker::addImplicitLoadExpr(ASTContext &Context, Expr *expr,
         setType(E, ParenType::get(Ctx, getType(PE->getSubExpr())));
 
       return Action::Continue(E);
+    }
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
     }
 
   private:
@@ -2307,6 +2315,10 @@ void ConstraintSystem::forEachExpr(
     ChildWalker(ConstraintSystem &CS,
                 llvm::function_ref<Expr *(Expr *)> callback)
         : CS(CS), callback(callback) {}
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
 
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       auto *NewE = callback(E);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -499,6 +499,10 @@ BodyInitKindRequest::evaluate(Evaluator &evaluator,
                                ASTContext &ctx)
         : Decl(decl), ctx(ctx) { }
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Expansion;
+    }
+
     PreWalkAction walkToDeclPre(class Decl *D) override {
       // Don't walk into further nominal decls.
       return Action::SkipChildrenIf(isa<NominalTypeDecl>(D));

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -778,6 +778,10 @@ bool ClosureHasExplicitResultRequest::evaluate(Evaluator &evaluator,
     bool FoundResultReturn = false;
     bool FoundNoResultReturn = false;
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Expansion;
+    }
+
     PreWalkResult<Expr *> walkToExprPre(Expr *expr) override {
       return Action::SkipChildren(expr);
     }

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -233,7 +233,11 @@ namespace {
     
     UnresolvedPatternFinder(bool &HadUnresolvedPattern)
       : HadUnresolvedPattern(HadUnresolvedPattern) {}
-    
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
+
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       // If we find an UnresolvedPatternExpr, return true.
       if (isa<UnresolvedPatternExpr>(E)) {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -63,6 +63,10 @@ namespace {
   public:
     ContextualizeClosuresAndMacros(DeclContext *parent) : ParentDC(parent) {}
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
+
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       // Autoclosures need to be numbered and potentially reparented.
       // Reparenting is required with:
@@ -248,6 +252,10 @@ namespace {
       }
 
       return result;
+    }
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
     }
 
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
@@ -2115,6 +2123,10 @@ static void checkClassConstructorBody(ClassDecl *classDecl,
   public:
     ApplyExpr *Found = nullptr;
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Expansion;
+    }
+
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (auto apply = dyn_cast<ApplyExpr>(E)) {
         if (isa<OtherConstructorDeclRefExpr>(apply->getSemanticFn())) {
@@ -2236,6 +2248,10 @@ bool TypeCheckASTNodeAtLocRequest::evaluate(
       return *FoundNode;
     }
     DeclContext *getDeclContext() const { return DC; }
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
 
     PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
       if (auto *brace = dyn_cast<BraceStmt>(S)) {
@@ -2631,6 +2647,10 @@ class JumpOutOfContextFinder : public ASTWalker {
 
 public:
   JumpOutOfContextFinder(TinyPtrVector<Stmt *> &jumps) : Jumps(jumps) {}
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
+  }
 
   PreWalkResult<Stmt *> walkToStmtPre(Stmt *S) override {
     if (auto *LS = dyn_cast<LabeledStmt>(S))

--- a/lib/Sema/TypeCheckStorage.cpp
+++ b/lib/Sema/TypeCheckStorage.cpp
@@ -1369,6 +1369,10 @@ namespace {
   public:
     RecontextualizeClosures(DeclContext *NewDC) : NewDC(NewDC) {}
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
+
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       // If we find a closure, update its declcontext and do *not* walk into it.
       if (auto CE = dyn_cast<AbstractClosureExpr>(E)) {
@@ -3523,6 +3527,11 @@ bool SimpleDidSetRequest::evaluate(Evaluator &evaluator,
 
   public:
     OldValueFinder(const ParamDecl *param) : OldValueParam(param) {}
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::ArgumentsAndExpansion;
+    }
+
 
     virtual PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (!E)

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -5035,6 +5035,10 @@ public:
   ExistentialTypeVisitor(ASTContext &ctx, bool checkStatements)
     : Ctx(ctx), checkStatements(checkStatements), hitTopStmt(false) { }
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
+  }
+
   PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
     reprStack.push_back(T);
 

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -372,6 +372,10 @@ void swift::loadDerivativeConfigurations(SourceFile &SF) {
   public:
     DerivativeFinder() {}
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Expansion;
+    }
+
     PreWalkAction walkToDeclPre(Decl *D) override {
       if (auto *afd = dyn_cast<AbstractFunctionDecl>(D)) {
         for (auto *derAttr : afd->getAttrs().getAttributes<DerivativeAttr>()) {
@@ -449,6 +453,10 @@ namespace {
     BindGenericParamsWalker(DeclContext *dc,
                             GenericParamList *params)
         : dc(dc), params(params) {}
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Expansion;
+    }
 
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
     if (auto *declRefTR = dyn_cast<DeclRefTypeRepr>(T)) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1517,6 +1517,10 @@ class DiscriminatorFinder : public ASTWalker {
   unsigned NextDiscriminator = 0;
 
 public:
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
+  }
+
   PostWalkResult<Expr *> walkToExprPost(Expr *E) override;
 
   // Get the next available closure discriminator.

--- a/lib/Serialization/SerializeDoc.cpp
+++ b/lib/Serialization/SerializeDoc.cpp
@@ -414,6 +414,10 @@ static void writeDeclCommentTable(
                          SourceOrder++ });
     }
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Expansion;
+    }
+
     PreWalkAction walkToDeclPre(Decl *D) override {
       if (!shouldIncludeDecl(D, /*ExcludeDoubleUnderscore*/true))
         return Action::SkipChildren();
@@ -706,6 +710,10 @@ struct BasicDeclLocsTableWriter : public ASTWalker {
   }
   PreWalkAction walkToParameterListPre(ParameterList *PL) override {
     return Action::SkipChildren();
+  }
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
   }
 
   Optional<uint32_t> calculateNewUSRId(Decl *D) {

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -68,6 +68,19 @@ public struct StringifyMacro: ExpressionMacro {
   }
 }
 
+public struct StringifyAndTryMacro: ExpressionMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    guard let argument = macro.argumentList.first?.expression else {
+      fatalError("boom")
+    }
+
+    return "(try \(argument), \(StringLiteralExprSyntax(content: argument.description)))"
+  }
+}
+
 struct SimpleDiagnosticMessage: DiagnosticMessage {
   let message: String
   let diagnosticID: MessageID

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -969,8 +969,9 @@ public:
              llvm::MutableArrayRef<TextEntity*> FuncEnts)
     : SM(SM), BufferID(BufferID), FuncEnts(FuncEnts) {}
 
-  bool shouldWalkMacroExpansions() override {
-    return false;
+  /// Only walk the arguments of a macro, to represent the source as written.
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::ArgumentsAndExpansion;
   }
 
   PreWalkAction walkToDeclPre(Decl *D) override {

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -770,6 +770,10 @@ public:
     : SM(SM), BufferID(BufferID), References(References), Consumer(Consumer) {}
 
   bool walkToNodePre(SyntaxNode Node) override {
+    // Ignore things that don't come from this buffer.
+    if (!SM.getRangeForBuffer(BufferID).contains(Node.Range.getStart()))
+      return false;
+
     unsigned Offset = SM.getLocOffsetInBuffer(Node.Range.getStart(), BufferID);
     unsigned Length = Node.Range.getByteLength();
 
@@ -830,6 +834,11 @@ public:
       auto passAnnotation = [&](UIdent Kind, SourceLoc Loc, Identifier Name) {
         if (Loc.isInvalid())
           return;
+
+        // Ignore things that don't come from this buffer.
+        if (!SM.getRangeForBuffer(BufferID).contains(Loc))
+          return;
+
         unsigned Offset = SM.getLocOffsetInBuffer(Loc, BufferID);
         unsigned Length = Name.empty() ? 1 : Name.getLength();
         reportRefsUntil(Offset);
@@ -922,6 +931,10 @@ static void addParameters(ArrayRef<Identifier> &ArgNames,
       if (TypeRange.isInvalid())
         continue;
 
+      // Ignore things that don't come from this buffer.
+      if (!SM.getRangeForBuffer(BufferID).contains(TypeRange.Start))
+        continue;
+
       unsigned StartOffs = SM.getLocOffsetInBuffer(TypeRange.Start, BufferID);
       unsigned EndOffs =
         SM.getLocOffsetInBuffer(Lexer::getLocForEndOfToken(SM, TypeRange.End),
@@ -983,6 +996,10 @@ public:
 
     if (!isa<AbstractFunctionDecl>(D) && !isa<SubscriptDecl>(D))
       return Action::Continue();
+
+    // Ignore things that don't come from this buffer.
+    if (!SM.getRangeForBuffer(BufferID).contains(D->getLoc()))
+      return Action::SkipChildren();
 
     unsigned Offset = SM.getLocOffsetInBuffer(D->getLoc(), BufferID);
     auto Found = FuncEnts.end();
@@ -1137,6 +1154,11 @@ public:
       return true;
     if (isLocal(D))
       return true;
+
+    // Ignore things that don't come from this buffer.
+    if (!SM.getRangeForBuffer(BufferID).contains(D->getSourceRange().Start))
+      return false;
+
     TextRange TR = getTextRange(D->getSourceRange());
     unsigned LocOffset = getOffset(Range.getStart());
     EntitiesStack.emplace_back(D, TypeOrExtensionDecl(), nullptr, TR, LocOffset,
@@ -1162,6 +1184,10 @@ public:
                           ReferenceMetaData Data) override {
     if (Data.isImplicit || !Range.isValid())
       return true;
+    // Ignore things that don't come from this buffer.
+    if (!SM.getRangeForBuffer(BufferID).contains(Range.getStart()))
+      return false;
+
     unsigned StartOffset = getOffset(Range.getStart());
     References.emplace_back(D, StartOffset, Range.getByteLength(), Ty);
     return true;

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1525,6 +1525,10 @@ private:
     : PlaceholderLoc(PlaceholderLoc), Found(Found) {
     }
 
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
+
     PreWalkResult<Expr *> walkToExprPre(Expr *E) override {
       if (isa<EditorPlaceholderExpr>(E) && E->getStartLoc() == PlaceholderLoc) {
         Found = cast<EditorPlaceholderExpr>(E);
@@ -1557,6 +1561,10 @@ private:
     bool FoundFunctionTypeRepr = false;
     explicit ClosureTypeWalker(SourceManager &SM, ClosureInfo &Info) : SM(SM),
       Info(Info) { }
+
+    MacroWalking getMacroWalkingBehavior() const override {
+      return MacroWalking::Arguments;
+    }
 
     PreWalkAction walkToTypeReprPre(TypeRepr *T) override {
       if (auto *FTR = dyn_cast<FunctionTypeRepr>(T)) {

--- a/tools/swift-ast-script/ASTScriptEvaluator.cpp
+++ b/tools/swift-ast-script/ASTScriptEvaluator.cpp
@@ -37,6 +37,10 @@ public:
   ASTScriptWalker(const ASTScript &script, ProtocolDecl *viewProtocol)
     : Script(script), ViewProtocol(viewProtocol) {}
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
+  }
+
   PreWalkAction walkToDeclPre(Decl *D) override {
     visit(D);
     return Action::Continue();

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -3227,6 +3227,10 @@ public:
   ASTTypePrinter(SourceManager &SM, const PrintOptions &Options)
       : OS(llvm::outs()), SM(SM), Options(Options) {}
 
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
+  }
+
   PreWalkAction walkToDeclPre(Decl *D) override {
     if (auto *VD = dyn_cast<ValueDecl>(D)) {
       OS.indent(IndentLevel * 2);
@@ -3309,6 +3313,10 @@ class ASTDocCommentDumper : public ASTWalker {
   raw_ostream &OS;
 public:
   ASTDocCommentDumper() : OS(llvm::outs()) {}
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
+  }
 
   PreWalkAction walkToDeclPre(Decl *D) override {
     if (D->isImplicit())
@@ -3462,6 +3470,10 @@ public:
       OS << " CommentXMLInvalid=[libxml error]";
       break;
     }
+  }
+
+  MacroWalking getMacroWalkingBehavior() const override {
+    return MacroWalking::Expansion;
   }
 
   PreWalkAction walkToDeclPre(Decl *D) override {


### PR DESCRIPTION
Provide ASTWalker with a customization point to specify whether to check macro arguments (which are type checked but never emitted), the macro expansion (which is the result of applying the macro and is actually emitted into the source), or both. Provide answers for the ~115 different ASTWalker visitors throughout the code base.

Fixes rdar://104042945, which concerns checking of effects in macro arguments---which we shouldn't do.
