### PR TITLE
Exclude @objcImpl member impls from PrintAsObjC

### DIFF
--- a/test/PrintAsObjC/Inputs/custom-modules/module.map
+++ b/test/PrintAsObjC/Inputs/custom-modules/module.map
@@ -58,3 +58,8 @@ module EmitClangHeaderNonmodularIncludesStressTest {
   header "header_subdirectory/header-symlink.h"
   export *
 }
+
+module objc_implementation {
+  header "objc_implementation/objc_implementation.h"
+  export *
+}

--- a/test/PrintAsObjC/Inputs/custom-modules/objc_implementation/objc_implementation.h
+++ b/test/PrintAsObjC/Inputs/custom-modules/objc_implementation/objc_implementation.h
@@ -1,0 +1,8 @@
+#import <Foundation.h>
+
+@interface ObjCClass : NSObject
+
+- (nullable id)swiftMethod;
+
+@end
+

--- a/test/PrintAsObjC/objc_implementation.swift
+++ b/test/PrintAsObjC/objc_implementation.swift
@@ -1,0 +1,37 @@
+// Please keep this file in alphabetical order!
+
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t %S/../Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift -disable-objc-attr-requires-foundation-module
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/CoreGraphics.swift
+// RUN:  %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -o %t  %S/../Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -emit-module -I %S/Inputs/custom-modules -import-underlying-module -o %t %s -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -parse-as-library %t/objc_implementation.swiftmodule -typecheck -I %S/Inputs/custom-modules -emit-objc-header-path %t/objc_implementation-Swift.h -import-underlying-module -disable-objc-attr-requires-foundation-module
+// RUN: %FileCheck %s --input-file %t/objc_implementation-Swift.h
+// RUN: %FileCheck --check-prefix=NEGATIVE %s --input-file %t/objc_implementation-Swift.h
+// RUN: %check-in-clang -I %S/Inputs/custom-modules/ %t/objc_implementation-Swift.h
+// RUN: %check-in-clang -I %S/Inputs/custom-modules/ -fno-modules -Qunused-arguments %t/objc_implementation-Swift.h
+
+import Foundation
+
+extension ObjCClass {
+  // CHECK: - (id _Nullable)pureSwiftMethod SWIFT_WARN_UNUSED_RESULT;
+  @objc public func pureSwiftMethod() -> Any? { nil }
+}
+
+@_objcImplementation extension ObjCClass {
+  // NEGATIVE-NOT: )init{{ }}
+  // Implicit `override init()` to override superclass
+
+  // NEGATIVE-NOT: )swiftMethod{{ }}
+  @objc func swiftMethod() -> Any? { nil }
+
+  // NEGATIVE-NOT: )privateMethod{{ }}
+  @objc private func privateMethod() -> Any? { nil }
+}


### PR DESCRIPTION
PrintAsClang was not aware of `@objcImplementation`. Teach it to skip over both member implementations (which are declared in handwritten headers, so printing them would be a redeclaration) and overrides (which may not be valid in a category, if e.g. they are declaring a designated initializer).

Fixes rdar://106035578.