### PR TITLE
Enable Concurrency ABI verifier test on apple silicon

### DIFF
--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -42,7 +42,10 @@
 // https://github.com/apple/swift/issues/55803
 // We currently only have a baseline for Intel CPUs on macOS.
 // REQUIRES: OS=macosx
-// REQUIRES: CPU=x86_64
+// REQUIRES: CPU=x86_64 || CPU=arm64
+// NOTE: This test runs both on intel and arm, and so far no differences have been spotted,
+//       so for better developer experience on apple silicon macs at desk we don't require a specific architecture.
+//       If there were to be a case where it fails on one of the platforms, we'd have to potentially split out into an arm baseline file.
 // REQUIRES: concurrency
 
 // The digester can incorrectly register a generic signature change when


### PR DESCRIPTION
There's no good reason not to run this test on apple silicon macs; and by doing so, we make it easier to catch issues before submitting a CI test run.

It seems that the results are exactly the same on apple silicon so I did not have to create a separate baseline - works just fine. If I'm missing something let me know though.

Resolves rdar://106030660