### PR TITLE
Sema: Support optional promotion of tuple patterns

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4635,8 +4635,9 @@ WARNING(found_one_pattern_for_several_associated_values,Deprecation,
 WARNING(converting_tuple_into_several_associated_values,none,
         "enum case '%0' has %1 associated values", (StringRef, unsigned))
 WARNING(converting_several_associated_values_into_tuple,none,
-        "enum case '%0' has one associated value that is a tuple of %1 "
-        "elements",(StringRef, unsigned))
+        "enum case '%0' has one associated value that is a %select{|optional }1"
+        "tuple of %2 elements",
+        (StringRef, bool, unsigned))
 ERROR(closure_argument_list_tuple,none,
       "contextual closure type %0 expects %1 argument%s1, "
       "but %2 %select{were|was}3 used in closure body", (Type, unsigned, unsigned, bool))

--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -158,6 +158,11 @@ enum class ConstraintKind : char {
   /// The first type is an optional type whose object type is the second
   /// type, preserving lvalue-ness.
   OptionalObject,
+  /// The first type is an optional of non-negative depth of the second type,
+  /// ignoring lvalueness (because the constraint is currently applied only to
+  /// pattern types, which are always rvalue). For example, given a RHS of
+  /// 'Int', a LHS of 'Int' or 'Int??' would satisfy this constraint.
+  EqualOrOptional,
   /// The first type is the same function type as the second type, but
   /// made @escaping.
   EscapableFunctionOf,
@@ -696,6 +701,7 @@ public:
     case ConstraintKind::DynamicCallableApplicableFunction:
     case ConstraintKind::BindOverload:
     case ConstraintKind::OptionalObject:
+    case ConstraintKind::EqualOrOptional:
     case ConstraintKind::OneWayEqual:
     case ConstraintKind::OneWayBindParam:
     case ConstraintKind::DefaultClosureType:

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4693,6 +4693,12 @@ private:
                                           TypeMatchOptions flags,
                                           ConstraintLocatorBuilder locator);
 
+  /// Attempt to simplify an equal-or-optional constraint.
+  SolutionKind
+  simplifyEqualOrOptionalConstraint(Type first, Type second,
+                                    TypeMatchOptions flags,
+                                    ConstraintLocatorBuilder locator);
+
   /// Attempt to simplify the BridgingConversion constraint.
   SolutionKind simplifyBridgingConstraint(Type type1,
                                          Type type2,

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -1440,6 +1440,7 @@ void PotentialBindings::infer(Constraint *constraint) {
   case ConstraintKind::ArgumentConversion:
   case ConstraintKind::OperatorArgumentConversion:
   case ConstraintKind::OptionalObject:
+  case ConstraintKind::EqualOrOptional:
   case ConstraintKind::UnresolvedMemberChainBase: {
     auto binding = inferFromRelational(constraint);
     if (!binding)

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2244,6 +2244,7 @@ ConstraintSystem::matchTupleTypes(TupleType *tuple1, TupleType *tuple2,
   case ConstraintKind::KeyPathApplication:
   case ConstraintKind::LiteralConformsTo:
   case ConstraintKind::OptionalObject:
+  case ConstraintKind::EqualOrOptional:
   case ConstraintKind::SelfObjectOfProtocol:
   case ConstraintKind::UnresolvedValueMember:
   case ConstraintKind::ValueMember:
@@ -2619,6 +2620,7 @@ static bool matchFunctionRepresentations(FunctionType::ExtInfo einfo1,
   case ConstraintKind::KeyPathApplication:
   case ConstraintKind::LiteralConformsTo:
   case ConstraintKind::OptionalObject:
+  case ConstraintKind::EqualOrOptional:
   case ConstraintKind::SelfObjectOfProtocol:
   case ConstraintKind::UnresolvedValueMember:
   case ConstraintKind::ValueMember:
@@ -3126,6 +3128,7 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
   case ConstraintKind::KeyPathApplication:
   case ConstraintKind::LiteralConformsTo:
   case ConstraintKind::OptionalObject:
+  case ConstraintKind::EqualOrOptional:
   case ConstraintKind::SelfObjectOfProtocol:
   case ConstraintKind::UnresolvedValueMember:
   case ConstraintKind::ValueMember:
@@ -6732,6 +6735,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
     case ConstraintKind::KeyPathApplication:
     case ConstraintKind::LiteralConformsTo:
     case ConstraintKind::OptionalObject:
+    case ConstraintKind::EqualOrOptional:
     case ConstraintKind::SelfObjectOfProtocol:
     case ConstraintKind::UnresolvedValueMember:
     case ConstraintKind::ValueMember:
@@ -8870,6 +8874,60 @@ ConstraintSystem::simplifyOptionalObjectConstraint(
 
   // Equate it to the other type in the constraint.
   addConstraint(ConstraintKind::Bind, objectTy, second, locator);
+  return SolutionKind::Solved;
+}
+
+ConstraintSystem::SolutionKind
+ConstraintSystem::simplifyEqualOrOptionalConstraint(
+    Type first, Type second, TypeMatchOptions flags,
+    ConstraintLocatorBuilder locator) {
+  // Reify all the type variables we can.
+  first = getFixedTypeRecursive(first, flags, /*wantRValue=*/false);
+  second = getFixedTypeRecursive(second, flags, /*wantRValue=*/false);
+
+  assert(!first->hasLValueType() && !second->hasLValueType() &&
+         "Unexpected lvalue; constraint operand is not a pattern type?");
+
+  if (first->isEqual(second)) {
+    return SolutionKind::Solved;
+  }
+
+  // Unwrap both types simultaneously until one of them is no longer optional.
+  while (true) {
+    if (auto firstObject = first->getOptionalObjectType()) {
+      if (auto secondObject = second->getOptionalObjectType()) {
+        first = firstObject;
+        second = secondObject;
+        continue;
+      }
+    }
+
+    break;
+  }
+
+  const Type firstUnwrapped = first->lookThroughAllOptionalTypes();
+
+  // At this point at most one of the two types is a known optional. The
+  // constraint can be reduced to an equation between the fully unwrapped LHS
+  // and the RHS — and thus solved — if the following conditions are met:
+  // 1. The fully unwrapped LHS is not a type variable.
+  // 2. Either the LHS is not optional to begin with, or the RHS is not a
+  //    type variable.
+
+  if (firstUnwrapped->isTypeVariableOrMember() ||
+      (first->isOptional() && second->isTypeVariableOrMember())) {
+    if (!flags.contains(TMF_GenerateConstraints)) {
+      return SolutionKind::Unsolved;
+    }
+
+    addUnsolvedConstraint(
+        Constraint::create(*this, ConstraintKind::EqualOrOptional, first,
+                           second, getConstraintLocator(locator)));
+    return SolutionKind::Solved;
+  }
+
+  addConstraint(ConstraintKind::Bind, firstUnwrapped, second, locator);
+
   return SolutionKind::Solved;
 }
 
@@ -14528,6 +14586,9 @@ ConstraintSystem::addConstraintImpl(ConstraintKind kind, Type first,
   case ConstraintKind::OptionalObject:
     return simplifyOptionalObjectConstraint(first, second, subflags, locator);
 
+  case ConstraintKind::EqualOrOptional:
+    return simplifyEqualOrOptionalConstraint(first, second, subflags, locator);
+
   case ConstraintKind::Defaultable:
     return simplifyDefaultableConstraint(first, second, subflags, locator);
 
@@ -15074,7 +15135,12 @@ ConstraintSystem::simplifyConstraint(const Constraint &constraint) {
                                             constraint.getSecondType(),
                                             /*flags*/ None,
                                             constraint.getLocator());
-      
+
+  case ConstraintKind::EqualOrOptional:
+    return simplifyEqualOrOptionalConstraint(
+        constraint.getFirstType(), constraint.getSecondType(),
+        /*flags*/ None, constraint.getLocator());
+
   case ConstraintKind::ValueMember:
   case ConstraintKind::UnresolvedValueMember:
     return simplifyMemberConstraint(constraint.getKind(),

--- a/lib/Sema/CSSyntacticElement.cpp
+++ b/lib/Sema/CSSyntacticElement.cpp
@@ -624,8 +624,8 @@ private:
       return;
     }
 
-    // Convert the contextual type to the pattern, which establishes the
-    // bindings.
+    // Require a conversion from the contextual type to the pattern type, which
+    // establishes the bindings.
     cs.addConstraint(ConstraintKind::Conversion, context.getType(), patternType,
                      locator);
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -74,6 +74,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second,
   case ConstraintKind::EscapableFunctionOf:
   case ConstraintKind::OpenedExistentialOf:
   case ConstraintKind::OptionalObject:
+  case ConstraintKind::EqualOrOptional:
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
   case ConstraintKind::UnresolvedMemberChainBase:
@@ -152,6 +153,7 @@ Constraint::Constraint(ConstraintKind Kind, Type First, Type Second, Type Third,
   case ConstraintKind::EscapableFunctionOf:
   case ConstraintKind::OpenedExistentialOf:
   case ConstraintKind::OptionalObject:
+  case ConstraintKind::EqualOrOptional:
   case ConstraintKind::ApplicableFunction:
   case ConstraintKind::DynamicCallableApplicableFunction:
   case ConstraintKind::ValueMember:
@@ -309,6 +311,7 @@ Constraint *Constraint::clone(ConstraintSystem &cs) const {
   case ConstraintKind::SelfObjectOfProtocol:
   case ConstraintKind::DynamicCallableApplicableFunction:
   case ConstraintKind::OptionalObject:
+  case ConstraintKind::EqualOrOptional:
   case ConstraintKind::Defaultable:
   case ConstraintKind::OneWayEqual:
   case ConstraintKind::OneWayBindParam:
@@ -493,6 +496,9 @@ void Constraint::print(llvm::raw_ostream &Out, SourceManager *sm,
       break;
   case ConstraintKind::OptionalObject:
       Out << " optional with object type "; break;
+  case ConstraintKind::EqualOrOptional:
+    Out << " equal to or optional of ";
+    break;
   case ConstraintKind::BindOverload: {
     Out << " bound to ";
     auto overload = getOverloadChoice();
@@ -727,6 +733,7 @@ gatherReferencedTypeVars(Constraint *constraint,
   case ConstraintKind::EscapableFunctionOf:
   case ConstraintKind::OpenedExistentialOf:
   case ConstraintKind::OptionalObject:
+  case ConstraintKind::EqualOrOptional:
   case ConstraintKind::Defaultable:
   case ConstraintKind::SubclassOf:
   case ConstraintKind::ConformsTo:

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -564,3 +564,19 @@ struct TestIUOMatchOp {
     if case self = self {}
   }
 }
+
+// Tuple patterns cannot match existentials without an explicit cast pattern.
+do {
+  enum E {
+    case e
+  }
+
+  let a: Any
+  let i: Int
+
+  // FIXME: Bad diagnostic when matching tuple pattern to existential (https://github.com/apple/swift/issues/65243)
+  if case (i, i) = a {} // expected-error {{type of expression is ambiguous without more context}}
+  if case (0, 0) = a {} // expected-error {{type of expression is ambiguous without more context}}
+
+  if case (E.e, E.e) = a {} // expected-error {{cannot convert value of type 'Any' to specified type '(E, E)'}}
+}

--- a/test/SILGen/pattern_matching_optional_promotion.swift.gyb
+++ b/test/SILGen/pattern_matching_optional_promotion.swift.gyb
@@ -1,0 +1,243 @@
+// RUN: %empty-directory(%t)
+// RUN: %gyb -D EXPLICIT=1 %s -o %t/generated.swift
+// RUN: %target-swift-emit-silgen -module-name m %t/generated.swift > %t/explicit.sil
+// RUN: %gyb -D EXPLICIT=0 %s -o %t/generated.swift
+// RUN: %target-swift-emit-silgen -module-name m %t/generated.swift > %t/implicit.sil
+// RUN: %diff -u %t/explicit.sil %t/implicit.sil
+
+// Test that implicitly optional-promoted patterns produce the same SIL as their
+// explicit counterparts.
+
+%{
+  explicit = int(EXPLICIT) != 0
+  contexts = ['do_block', 'closure', 'result_builder_closure']
+  question = '?' if explicit else ''
+
+  def get_test_case_introducer(context):
+    if context == 'do_block':
+      return 'do'
+    elif context == 'closure':
+      return 'let _: () -> Void ='
+    elif context == 'result_builder_closure':
+      return '@DummyBuilder var x: Void'
+
+    assert False, 'unhandled context!'
+}%
+
+indirect enum E {
+  case a
+  case b(e: E)
+  case ot((E, E)?)
+  case oot((((E, E))?)?)
+}
+
+@resultBuilder
+struct DummyBuilder {
+  static func buildBlock(_ components: Void...) -> Void { () }
+  static func buildOptional(_ component: Void?) -> Void { () }
+  static func buildEither(first: Void) -> Void { () }
+  static func buildEither(second: Void) -> Void { () }
+  static func buildArray(_ components: [Void]) -> Void { () }
+}
+
+// Enum element patterns.
+func enumElementPatterns(oe: E?, ooe: E??) {
+% for context in contexts:
+%   for case in ['.a', '.b', '.b(e: .a)']:
+  do {
+    ${get_test_case_introducer(context)} {
+      if case ${case}${question} = oe {}
+      if case ${case}${question}${question} = ooe {}
+      if case ${case}?${question} = ooe {}
+      if case .some(${case}${question}) = ooe {}
+
+%     if context != 'result_builder_closure':
+      guard case ${case}${question} = oe else {}
+      guard case ${case}${question}${question} = ooe else {}
+      guard case ${case}?${question} = ooe else {}
+      guard case .some(${case}${question}) = ooe else {}
+
+      while case ${case}${question} = oe {}
+      while case ${case}${question}${question} = ooe {}
+      while case ${case}?${question} = ooe {}
+      while case .some(${case}${question}) = ooe {}
+%     end
+
+      for case ${case}${question} in [oe] {}
+      for case ${case}${question}${question} in [ooe] {}
+      for case ${case}?${question} in [ooe] {}
+      for case .some(${case}${question}) in [ooe] {}
+
+      switch oe {
+        case ${case}${question}: ()
+        default: ()
+      }
+      switch ooe {
+        case ${case}${question}${question}: ()
+        default: ()
+      }
+      switch ooe {
+        case ${case}?${question}: ()
+        default: ()
+      }
+      switch ooe {
+        case .some(${case}${question}): ()
+        default: ()
+      }
+    }
+  }
+
+%   end
+% end
+}
+
+// Tuple patterns.
+func tuplePatterns(ot: (E, E)?, oot: (E, E)??, tot: ((E, E)?, E), splat: E) {
+% for context in contexts:
+  ${get_test_case_introducer(context)} {
+    if case (.a, .a)${question} = ot {}
+    if case let (x, y)${question} = ot {}
+    if case (.a, .a)${question}${question} = oot {}
+    if case (.a, .a)?${question} = oot {}
+    if case ((.a, .a)${question}, .a) = tot {}
+    if case .ot(${'(.a, .a)?' if explicit else '.a, .a'}) = splat {}
+    if case .oot(${'(.a, .a)?' if explicit else '.a, .a'}) = splat {}
+
+%   if context != 'result_builder_closure':
+    guard case (.a, .a)${question} = ot else {}
+    guard case let (x, y)${question} = ot else {}
+    guard case (.a, .a)${question}${question} = oot else {}
+    guard case (.a, .a)?${question} = oot else {}
+    guard case ((.a, .a)${question}, .a) = tot else {}
+    guard case .ot(${'(.a, .a)?' if explicit else '.a, .a'}) = splat else {}
+    guard case .oot(${'(.a, .a)?' if explicit else '.a, .a'}) = splat else {}
+
+    while case (.a, .a)${question} = ot {}
+    while case let (x, y)${question} = ot {}
+    while case (.a, .a)${question}${question} = oot {}
+    while case (.a, .a)?${question} = oot {}
+    while case ((.a, .a)${question}, .a) = tot {}
+    while case .ot(${'(.a, .a)?' if explicit else '.a, .a'}) = splat {}
+    while case .oot(${'(.a, .a)?' if explicit else '.a, .a'}) = splat {}
+%   end
+
+    // FIXME: Make these for-in loops work directly with array literals.
+    let otArr = [ot]
+    let ootArr = [oot]
+    let totArr = [tot]
+    let splatArr = [splat]
+
+    for case (.a, .a)${question} in otArr {}
+    for case let (x, y)${question} in otArr {}
+    for case (.a, .a)${question}${question} in ootArr {}
+    for case (.a, .a)?${question} in ootArr {}
+    for case ((.a, .a)${question}, .a) in totArr {}
+    for case .ot(${'(.a, .a)?' if explicit else '.a, .a'}) in splatArr {}
+    for case .oot(${'(.a, .a)?' if explicit else '.a, .a'}) in splatArr {}
+
+    switch ot {
+      case (.a, .a)${question}: ()
+      default: ()
+    }
+    switch ot {
+      case let (x, y)${question}: ()
+      default: ()
+    }
+    switch oot {
+      case (.a, .a)${question}${question}: ()
+      default: ()
+    }
+    switch oot {
+      case (.a, .a)?${question}: ()
+      default: ()
+    }
+    switch tot {
+      case ((.a, .a)${question}, .a): ()
+      default: ()
+    }
+    switch splat {
+      case .ot(${'(.a, .a)?' if explicit else '.a, .a'}): ()
+      default: ()
+    }
+    switch splat {
+      case .oot(${'(.a, .a)?' if explicit else '.a, .a'}): ()
+      default: ()
+    }
+  }
+
+% end
+}
+
+class A {}
+class B: A {}
+
+// 'is' patterns.
+func isPatterns(oa: A?, ooa: A??, oaooa: (A?, A??)) {
+% for context in contexts:
+  ${get_test_case_introducer(context)} {
+    if case (is B)${question} = oa {}
+    if case (is B)${question}${question} = ooa {}
+    if case (is B)?${question} = ooa {}
+    if case .some((is B)${question}) = ooa {}
+    if case ((is B)${question}, (is B)${question}${question}) = oaooa {}
+    if case ((is B)${question}, (is B)?${question}) = oaooa {}
+    if case ((is B)${question}, .some((is B)${question})) = oaooa {}
+
+%   if context != 'result_builder_closure':
+    guard case (is B)${question} = oa else {}
+    guard case (is B)${question}${question} = ooa else {}
+    guard case (is B)?${question} = ooa else {}
+    guard case .some((is B)${question}) = ooa else {}
+    guard case ((is B)${question}, (is B)${question}${question}) = oaooa else {}
+    guard case ((is B)${question}, (is B)?${question}) = oaooa else {}
+    guard case ((is B)${question}, .some((is B)${question})) = oaooa else {}
+
+    while case (is B)${question} = oa {}
+    while case (is B)${question}${question} = ooa {}
+    while case (is B)?${question} = ooa {}
+    while case .some((is B)${question}) = ooa {}
+    while case ((is B)${question}, (is B)${question}${question}) = oaooa {}
+    while case ((is B)${question}, (is B)?${question}) = oaooa {}
+    while case ((is B)${question}, .some((is B)${question})) = oaooa {}
+%   end
+
+    for case (is B)${question} in [oa] {}
+    for case (is B)${question}${question} in [ooa] {}
+    for case (is B)?${question} in [ooa] {}
+    for case .some((is B)${question}) in [ooa] {}
+    for case ((is B)${question}, (is B)${question}${question}) in [oaooa] {}
+    for case ((is B)${question}, (is B)?${question}) in [oaooa] {}
+    for case ((is B)${question}, .some((is B)${question})) in [oaooa] {}
+
+    switch oa {
+      case (is B)${question}: ()
+      default: ()
+    }
+    switch ooa {
+      case (is B)${question}${question}: ()
+      default: ()
+    }
+    switch ooa {
+      case (is B)?${question}: ()
+      default: ()
+    }
+    switch ooa {
+      case .some((is B)${question}): ()
+      default: ()
+    }
+    switch oaooa {
+      case ((is B)${question}, (is B)${question}${question}): ()
+      default: ()
+    }
+    switch oaooa {
+      case ((is B)${question}, (is B)?${question}): ()
+      default: ()
+    }
+    switch oaooa {
+      case ((is B)${question}, .some((is B)${question})): ()
+      default: ()
+    }
+  }
+
+% end
+}

--- a/test/Sema/pattern_matching_optional_promotion.swift.gyb
+++ b/test/Sema/pattern_matching_optional_promotion.swift.gyb
@@ -1,0 +1,308 @@
+// RUN: %empty-directory(%t)
+// RUN: %gyb %s -o %t/generated.swift
+// RUN: %target-swift-frontend -typecheck -verify %t/generated.swift
+
+// Test that implicit optional promotion works for refutable patterns in
+// statement conditions and 'switch' case items. In 'switch' statements, rely on
+// redundant case diagnostics (if applicable) to additionally verify that an
+// implicitly promoted pattern has the same space projection as the explicit
+// counterpart.
+//
+// Note: We do not test 'catch' statements because patterns there are always
+// matched against a non-optional.
+
+%{
+  contexts = ['do_block', 'closure', 'result_builder_closure']
+  def get_test_case_introducer(context):
+    if context == 'do_block':
+      return 'do'
+    elif context == 'closure':
+      return 'let _: () -> Void ='
+    elif context == 'result_builder_closure':
+      return '@DummyBuilder var x: Void'
+
+    assert False, 'unhandled context!'
+}%
+
+indirect enum E {
+  case a
+  case b(e: E)
+  case ot((E, E)?)       // expected-note 13 {{'ot' declared here}}
+  case oot((((E, E))?)?) // expected-note 13 {{'oot' declared here}}
+}
+
+@resultBuilder
+struct DummyBuilder {
+  static func buildBlock(_ components: Void...) -> Void { () }
+  static func buildOptional(_ component: Void?) -> Void { () }
+  static func buildEither(first: Void) -> Void { () }
+  static func buildEither(second: Void) -> Void { () }
+  static func buildArray(_ components: [Void]) -> Void { () }
+}
+
+// Enum element patterns.
+do {
+  let oe: E?
+  let ooe: E??
+
+% for context in contexts:
+%   test_case_introducer = get_test_case_introducer(context)
+%   for case in ['.a', '.b', '.b(e: .a)']:
+  do {
+    ${test_case_introducer} {
+      if case ${case} = oe {}
+      if case ${case} = ooe {}
+      if case ${case}? = ooe {}
+      if case .some(${case}) = ooe {}
+
+%     if context != 'result_builder_closure':
+      guard case ${case} = oe else {}
+      guard case ${case} = ooe else {}
+      guard case ${case}? = ooe else {}
+      guard case .some(${case}) = ooe else {}
+
+      while case ${case} = oe {}
+      while case ${case} = ooe {}
+      while case ${case}? = ooe {}
+      while case .some(${case}) = ooe {}
+%     end
+
+      for case ${case} in [oe] {}
+      for case ${case} in [ooe] {}
+      for case ${case}? in [ooe] {}
+      for case .some(${case}) in [ooe] {}
+
+      switch oe {
+        case ${case}?: ()
+        case ${case}: () // expected-warning {{case is already handled}}
+        default: ()
+      }
+      switch ooe {
+        case ${case}??: ()
+        case ${case}?: () // expected-warning {{case is already handled}}
+        case .some(${case}): () // expected-warning {{case is already handled}}
+        case ${case}: () // expected-warning {{case is already handled}}
+        default: ()
+      }
+    }
+  }
+%   end
+
+  do {
+    ${test_case_introducer} {
+      switch oe {
+        // FIXME: '.a' is OK but 'E.a' is not?
+        case E.a: () // expected-error {{enum case 'a' is not a member of type 'E?'}}
+        default: ()
+      }
+    }
+  }
+
+% end
+}
+
+// Tuple patterns.
+do {
+  let ot: (E, E)?
+  let oot: (E, E)??
+  let tot: ((E, E)?, E)
+  let splat: E
+
+% for context in contexts:
+%   test_case_introducer = get_test_case_introducer(context)
+  do {
+    // FIXME: This should compile.
+    ${test_case_introducer} {
+      for case (.a, .a) in [ot] {}
+%   if context == 'do_block':
+      // expected-error@-2 {{conflicting arguments to generic parameter 'Elements' ('[(E, E)?]' vs. '[(E, E)]')}}
+      // expected-error@-3 {{conflicting arguments to generic parameter 'Element' ('(E, E)?' vs. '(E, E)')}}
+      // expected-error@-4 {{conflicting arguments to generic parameter 'Self' ('[(E, E)?]' vs. '[(E, E)]')}}
+%   else:
+      // expected-error@-2 {{cannot convert value of type '(E, E)?' to expected element type '(E, E)'}}
+%   end
+    }
+  }
+
+  do {
+    ${test_case_introducer} {
+      if case (.a, .a) = ot {}
+      if case let (x, y) = ot {}
+      if case (.a, .a) = oot {}
+      if case (.a, .a)? = oot {}
+      if case ((.a, .a), .a) = tot {}
+      if case .ot(.a, .a) = splat {}
+      // expected-warning@-1 {{enum case 'ot' has one associated value that is a optional tuple of 2 elements}}
+      if case .oot(.a, .a) = splat {}
+      // expected-warning@-1 {{enum case 'oot' has one associated value that is a optional tuple of 2 elements}}
+
+%   if context != 'result_builder_closure':
+      guard case (.a, .a) = ot else {}
+      guard case let (x, y) = ot else {}
+      guard case (.a, .a) = oot else {}
+      guard case (.a, .a)? = oot else {}
+      guard case ((.a, .a), .a) = tot else {}
+      guard case .ot(.a, .a) = splat else {}
+      // expected-warning@-1 {{enum case 'ot' has one associated value that is a optional tuple of 2 elements}}
+      guard case .oot(.a, .a) = splat else {}
+      // expected-warning@-1 {{enum case 'oot' has one associated value that is a optional tuple of 2 elements}}
+
+      while case (.a, .a) = ot {}
+      while case let (x, y) = ot {}
+      while case (.a, .a) = oot {}
+      while case (.a, .a)? = oot {}
+      while case ((.a, .a), .a) = tot {}
+      while case .ot(.a, .a) = splat {}
+      // expected-warning@-1 {{enum case 'ot' has one associated value that is a optional tuple of 2 elements}}
+      while case .oot(.a, .a) = splat {}
+      // expected-warning@-1 {{enum case 'oot' has one associated value that is a optional tuple of 2 elements}}
+%   end
+
+      // FIXME: Make these for-in loops work directly with array literals.
+      let otArr = [ot]
+      let ootArr = [oot]
+      let totArr = [tot]
+      let splatArr = [splat]
+
+      for case (.a, .a) in otArr {}
+      for case let (x, y) in otArr {}
+      for case (.a, .a) in ootArr {}
+      for case (.a, .a)? in ootArr {}
+      for case ((.a, .a), .a) in totArr {}
+      for case .ot(.a, .a) in splatArr {}
+      // expected-warning@-1 {{enum case 'ot' has one associated value that is a optional tuple of 2 elements}}
+      for case .oot(.a, .a) in splatArr {}
+      // expected-warning@-1 {{enum case 'oot' has one associated value that is a optional tuple of 2 elements}}
+
+      switch ot {
+        case (.a, .a)?: ()
+        case (.a, .a): () // expected-warning {{case is already handled}}
+        default: ()
+      }
+      switch ot {
+        case let (x, y)?: ()
+        case let (x, y): () // expected-warning {{case is already handled}}
+        default: ()
+      }
+      switch oot {
+        case (.a, .a)??: ()
+        case (.a, .a)?: () // expected-warning {{case is already handled}}
+        case .some((.a, .a)): () // expected-warning {{case is already handled}}
+        case (.a, .a): () // expected-warning {{case is already handled}}
+        default: ()
+      }
+      switch tot {
+        case ((.a, .a)?, .a): ()
+        case ((.a, .a), .a): () // expected-warning {{case is already handled}}
+        default: ()
+      }
+      switch splat {
+        case .ot((.a, .a)?): ()
+        case .ot(.a, .a): () // expected-warning {{case is already handled}}
+        // expected-warning@-1 {{enum case 'ot' has one associated value that is a optional tuple of 2 elements}}
+        default: ()
+      }
+      switch splat {
+        case .oot((.a, .a)??): ()
+        case .oot(.a, .a): () // expected-warning {{case is already handled}}
+        // expected-warning@-1 {{enum case 'oot' has one associated value that is a optional tuple of 2 elements}}
+        default: ()
+      }
+    }
+  }
+
+% end
+}
+
+// Boolean patterns.
+do {
+  let ob: Bool?
+
+% for context in contexts:
+%   test_case_introducer = get_test_case_introducer(context)
+  do {
+    ${test_case_introducer} {
+      // FIXME: Works but the literal resolves to an expression pattern.
+      if case true = ob {}
+
+      // FIXME(https://github.com/apple/swift/issues/61817): This should be exhaustive
+      switch ob { // expected-error {{switch must be exhaustive}}
+        // expected-note@-1 {{add missing case: '.some(_)'}}
+        case nil: ()
+        case true: ()
+        case false: ()
+      }
+    }
+  }
+
+% end
+}
+
+// 'is' patterns.
+do {
+  class A {}
+  class B: A {}
+
+  let oa: A?
+  let ooa: A??
+  let oaooa: (A?, A??)
+
+% for context in contexts:
+  ${get_test_case_introducer(context)} {
+    if case is B = oa {}
+    if case is B = ooa {}
+    if case (is B)? = ooa {}
+    if case .some(is B) = ooa {}
+    if case (is B, is B) = oaooa {}
+    if case (is B, (is B)?) = oaooa {}
+    if case (is B, .some(is B)) = oaooa {}
+
+%   if context != 'result_builder_closure':
+    guard case is B = oa else {}
+    guard case is B = ooa else {}
+    guard case (is B)? = ooa else {}
+    guard case .some(is B) = ooa else {}
+    guard case (is B, is B) = oaooa else {}
+    guard case (is B, (is B)?) = oaooa else {}
+    guard case (is B, .some(is B)) = oaooa else {}
+
+    while case is B = oa {}
+    while case is B = ooa {}
+    while case (is B)? = ooa {}
+    while case .some(is B) = ooa {}
+    while case (is B, is B) = oaooa {}
+    while case (is B, (is B)?) = oaooa {}
+    while case (is B, .some(is B)) = oaooa {}
+%   end
+
+    for case is B in [oa] {}
+    for case is B in [ooa] {}
+    for case (is B)? in [ooa] {}
+    for case .some(is B) in [ooa] {}
+    for case (is B, is B) in [oaooa] {}
+    for case (is B, (is B)?) in [oaooa] {}
+    for case (is B, .some(is B)) in [oaooa] {}
+
+    switch oa {
+      case (is B)?: ()
+      case is B: ()
+      default: ()
+    }
+    switch ooa {
+      case (is B)??: ()
+      case .some(is B): ()
+      case (is B)?: ()
+      case is B: ()
+      default: ()
+    }
+    switch oaooa {
+      case ((is B)?, (is B)??): ()
+      case (is B, .some(is B)): ()
+      case (is B, (is B)?): ()
+      case (is B, is B): ()
+      default: ()
+    }
+  }
+
+% end
+}

--- a/test/decl/var/variables.swift
+++ b/test/decl/var/variables.swift
@@ -138,3 +138,30 @@ func patternBindingWithTwoEntries() {
   let x2 = 1, (_, _) = (1, 2)
   // expected-warning@-1 {{immutable value 'x2' was never used; consider replacing with '_' or removing it}}
 }
+
+// Optional promotion in patterns is allowed only when pattern matching is
+// allowed to fail.
+do {
+  let (_, _): (Int, Int)? // expected-error {{tuple pattern cannot match values of the non-tuple type '(Int, Int)?'}}
+  let (a1, a2): (Int, Int)? // expected-error {{tuple pattern cannot match values of the non-tuple type '(Int, Int)?'}}
+  let (b1, b2): (Int, Int)?? // expected-error {{tuple pattern cannot match values of the non-tuple type '(Int, Int)??'}}
+  let (c1, (c2, c3)): (Int, (Int, Int)?) // expected-error {{tuple pattern cannot match values of the non-tuple type '(Int, Int)?'}}
+  let (x: d1, y: d2): (Int, Int)? // expected-error {{tuple pattern cannot match values of the non-tuple type '(Int, Int)?'}}
+}
+
+// Pattern binding oddities.
+do {
+  let (x: a1): Bool // FIXME: OK?
+  // FIXME: Not OK?
+  let (x: a2) = true // expected-error {{cannot convert value of type 'Bool' to specified type '(x: _)'}}
+
+  let (x: a3): (Int, Int) // FIXME: OK?
+
+  // FIXME: Suggested fix does not parse
+  let (b1, x: b2): (Int, Int) // expected-error {{tuple pattern element label 'x' must be '_'}}
+  let (b3, _: b4): (Int, Int) // expected-error {{expected ',' separator}} expected-error{{expected pattern}}
+
+  let (c1, c2): (x: Int, y: Int) // OK
+  let (c3, c4) = (true, x: true) // OK
+  let (x: c5, y: c6) = (true, true) // OK
+}


### PR DESCRIPTION
As with enum element patterns — at least the unqualified ones — this allows tuple patterns to omit syntactic noise in the form of enclosing `.some(...)` or trailing `?`.

```swift
enum E { case a }

let t: (E, E)?
switch t {
  case nil: break
  case (.a, .a): break
}
```
