### PR TITLE
Backport compatibility macro fixes to 5.8

### DIFF
--- a/include/swift/PrintAsClang/ClangMacros.def
+++ b/include/swift/PrintAsClang/ClangMacros.def
@@ -133,7 +133,7 @@ CLANG_MACRO_BODY("SWIFT_CLASS", \
         "SWIFT_RUNTIME_NAME(SWIFT_NAME) __attribute__((objc_subclassing_restricted)) " \
         "SWIFT_CLASS_EXTRA\n" \
     "#  define SWIFT_CLASS_NAMED(SWIFT_NAME) " \
-        "__attribute((objc_subclassing_restricted)) SWIFT_COMPILE_NAME(SWIFT_NAME) " \
+        "__attribute__((objc_subclassing_restricted)) SWIFT_COMPILE_NAME(SWIFT_NAME) " \
         "SWIFT_CLASS_EXTRA\n" \
     "# else\n" \
     "#  define SWIFT_CLASS(SWIFT_NAME) " \

--- a/include/swift/PrintAsClang/ClangMacros.def
+++ b/include/swift/PrintAsClang/ClangMacros.def
@@ -197,7 +197,7 @@ CLANG_MACRO("SWIFT_DEPRECATED", , "__attribute__((deprecated))")
 CLANG_MACRO("SWIFT_DEPRECATED_MSG", "(...)", "__attribute__((deprecated(__VA_ARGS__)))")
 
 CLANG_MACRO_ALTERNATIVE("SWIFT_DEPRECATED_OBJC", "(Msg)", \
-                        "__has_feature(attribute_diagnost_if_objc)", \
+                        "__has_feature(attribute_diagnose_if_objc)", \
                         "__attribute__((diagnose_if(1, Msg, \"warning\")))", \
                         "SWIFT_DEPRECATED_MSG(Msg)")
 

--- a/include/swift/PrintAsClang/ClangMacros.def
+++ b/include/swift/PrintAsClang/ClangMacros.def
@@ -175,7 +175,7 @@ CLANG_MACRO_CONDITIONAL("SWIFT_ENUM_ATTR", "(_extensibility)", \
 CLANG_MACRO_BODY("SWIFT_ENUM", \
     "# define SWIFT_ENUM(_type, _name, _extensibility) " \
         "enum _name : _type _name; " \
-        "enum SWIFT_ENUM_ATTR(_extensibility) SWIFT_ENUM_EXTRA _name: _type\n" \
+        "enum SWIFT_ENUM_ATTR(_extensibility) SWIFT_ENUM_EXTRA _name : _type\n" \
     "# if __has_feature(generalized_swift_name)\n" \
     "#  define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME, _extensibility) " \
         "enum _name : _type _name SWIFT_COMPILE_NAME(SWIFT_NAME); " \


### PR DESCRIPTION
This PR backports the following changes onto `release/5.8`:

- https://github.com/apple/swift/pull/63338
- https://github.com/apple/swift/pull/63902
- https://github.com/apple/swift/pull/63976

**Explanation**: #59072 introduced an implementation change to the Objective-C compatibility header, but it also created a regression for projects that link against headers generated by different Swift versions, where their projects would encounter "macro redefined" errors.

**Scope**: Regression affecting projects with prebuilt dependencies built by older versions of Swift

**Issue**: rdar://106086816

**Risk**: Low. Projects that build all their code with the same compiler are unaffected. The change is isolated to the Objective-C compatibility header generation, and does not affect normal compilation.

**Testing**: Locally building a project that included a generated header from Swift 5.7 against a header generated with Swift 5.8. A future PR will implement an automated test to ensure that these "macro redefinition" errors are all handled.

**Reviewer**: @airspeedswift @beccadax 