### PR TITLE
[Compile Time Constant Extraction] Look through Optional injection and underlying-to-opaque conversions

### DIFF
--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -138,6 +138,8 @@ extractFunctionArguments(const ArgumentList *args) {
       if (decl->hasDefaultExpr()) {
         argExpr = decl->getTypeCheckedDefaultExpr();
       }
+    } else if (auto optionalInject = dyn_cast<InjectIntoOptionalExpr>(argExpr)) {
+      argExpr = optionalInject->getSubExpr();
     }
     parameters.push_back({label, type, extractCompileTimeValue(argExpr)});
   }

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -311,6 +311,25 @@ static std::shared_ptr<CompileTimeValue> extractCompileTimeValue(Expr *expr) {
       return extractCompileTimeValue(underlyingToOpaque->getSubExpr());
     }
 
+    case ExprKind::DefaultArgument: {
+      auto defaultArgExpr = cast<DefaultArgumentExpr>(expr);
+      auto *decl = defaultArgExpr->getParamDecl();
+      // If there is a default expr, we should have looked through to it
+      assert(!decl->hasDefaultExpr());
+      switch (decl->getDefaultArgumentKind()) {
+      case DefaultArgumentKind::NilLiteral:
+        return std::make_shared<RawLiteralValue>("nil");
+      case DefaultArgumentKind::EmptyArray:
+        return std::make_shared<ArrayValue>(
+            std::vector<std::shared_ptr<CompileTimeValue>>());
+      case DefaultArgumentKind::EmptyDictionary:
+        return std::make_shared<DictionaryValue>(
+            std::vector<std::shared_ptr<TupleValue>>());
+      default:
+        break;
+      }
+    } break;
+
     default: {
       break;
     }

--- a/lib/ConstExtract/ConstExtract.cpp
+++ b/lib/ConstExtract/ConstExtract.cpp
@@ -306,6 +306,11 @@ static std::shared_ptr<CompileTimeValue> extractCompileTimeValue(Expr *expr) {
       return std::make_shared<TypeValue>(dotSelfExpr->getType());
     }
 
+    case ExprKind::UnderlyingToOpaque: {
+      auto underlyingToOpaque = cast<UnderlyingToOpaqueExpr>(expr);
+      return extractCompileTimeValue(underlyingToOpaque->getSubExpr());
+    }
+
     default: {
       break;
     }

--- a/test/ConstExtraction/ExtractInjectOptional.swift
+++ b/test/ConstExtraction/ExtractInjectOptional.swift
@@ -1,0 +1,35 @@
+// RUN: %empty-directory(%t)
+// RUN: echo "[MyProto]" > %t/protocols.json
+
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractLiterals.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
+// RUN: cat %t/ExtractLiterals.swiftconstvalues 2>&1 | %FileCheck %s
+
+protocol MyProto {}
+struct InjectablePropertyStruct : MyProto {
+    let init1 = Bat(buz: "hello", fuz: 4)
+}
+
+public struct Bat {
+    let buz: String?
+    let fuz: Int
+
+    init(buz: String? = "", fuz: Int = 0) {
+        self.buz = buz
+        self.fuz = fuz
+    }
+}
+
+// CHECK:      "arguments": [
+// CHECK-NEXT: {
+// CHECK-NEXT:   "label": "buz",
+// CHECK-NEXT:   "type": "Swift.Optional<Swift.String>",
+// CHECK-NEXT:   "valueKind": "RawLiteral",
+// CHECK-NEXT:   "value": "hello"
+// CHECK-NEXT: },
+// CHECK-NEXT: {
+// CHECK-NEXT:   "label": "fuz",
+// CHECK-NEXT:   "type": "Swift.Int",
+// CHECK-NEXT:   "valueKind": "RawLiteral",
+// CHECK-NEXT:   "value": "4"
+// CHECK-NEXT: }
+// CHECK-NEXT: ]

--- a/test/ConstExtraction/ExtractUnderlyingToOpaque.swift
+++ b/test/ConstExtraction/ExtractUnderlyingToOpaque.swift
@@ -1,0 +1,33 @@
+// RUN: %empty-directory(%t)
+// RUN: echo "[MyProto]" > %t/protocols.json
+
+// RUN: %target-swift-frontend -typecheck -emit-const-values-path %t/ExtractLiterals.swiftconstvalues -const-gather-protocols-file %t/protocols.json -primary-file %s
+// RUN: cat %t/ExtractLiterals.swiftconstvalues 2>&1 | %FileCheck %s
+
+protocol MyProto {}
+protocol Bird {}
+struct UnderlyingToOpaquePropertyStruct : MyProto {
+    var warbler: some Bird {
+        Warbler("blue")
+    }
+}
+
+public struct Warbler : Bird {
+    let belly: String = "yellow"
+    init(_ color: String = "red") {
+        self.belly = color
+    }
+}
+
+// CHECK:             "valueKind": "InitCall",
+// CHECK-NEXT:        "value": {
+// CHECK-NEXT:          "type": "ExtractUnderlyingToOpaque.Warbler",
+// CHECK-NEXT:          "arguments": [
+// CHECK-NEXT:            {
+// CHECK-NEXT:              "label": "",
+// CHECK-NEXT:              "type": "Swift.String",
+// CHECK-NEXT:              "valueKind": "RawLiteral",
+// CHECK-NEXT:              "value": "blue"
+// CHECK-NEXT:            }
+// CHECK-NEXT:          ]
+// CHECK-NEXT:        }

--- a/test/ConstExtraction/ExtractUnderlyingToOpaque.swift
+++ b/test/ConstExtraction/ExtractUnderlyingToOpaque.swift
@@ -6,7 +6,10 @@
 
 protocol MyProto {}
 protocol Bird {}
+
+@available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
 struct UnderlyingToOpaquePropertyStruct : MyProto {
+    @available(iOS 13, macOS 10.15, tvOS 13, watchOS 6, *)
     var warbler: some Bird {
         Warbler("blue")
     }


### PR DESCRIPTION
`InjectIntoOptionalExpr` is an implicit cast that the extraction code may need to look through to get the underlying compile-time value.

Similarly, for computed properties of an opaque type, look through the `UnderlyingToOpaqueExpr`. 

Resolves rdar://106059663
Resolves rdar://106006689
