### PR TITLE
AST: Emit correct synthesized availability attributes for `unownedExecutor` property

### DIFF
--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -334,6 +334,10 @@ public:
 
 class AvailabilityInference {
 public:
+  /// Returns the decl that should be considered the parent decl of the given
+  /// decl when looking for inherited availability annotations.
+  static const Decl *parentDeclForInferredAvailability(const Decl *D);
+
   /// Infers the common availability required to access an array of
   /// declarations and adds attributes reflecting that availability
   /// to ToDecl.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -477,8 +477,12 @@ unsigned Decl::getAttachedMacroDiscriminator(
 }
 
 const Decl *Decl::getInnermostDeclWithAvailability() const {
-  if (auto attrAndDecl = getSemanticAvailableRangeAttr())
-    return attrAndDecl.value().second;
+  if (getAttrs().hasAttribute<AvailableAttr>())
+    return this;
+
+  if (auto parent =
+          AvailabilityInference::parentDeclForInferredAvailability(this))
+    return parent->getInnermostDeclWithAvailability();
 
   return nullptr;
 }

--- a/test/Concurrency/concurrency_availability.swift
+++ b/test/Concurrency/concurrency_availability.swift
@@ -3,6 +3,8 @@
 // RUN: %target-swift-frontend -parse-stdlib -target x86_64-apple-macosx12 -typecheck %s -DTARGET_MACOS_12
 // REQUIRES: OS=macosx
 
+import _Concurrency
+
 func f() async { } // expected-error{{concurrency is only available in}}
 // expected-note@-1{{add @available}}
 
@@ -13,19 +15,41 @@ actor A { }  // expected-error{{concurrency is only available in}}
 public func swift_deletedAsyncMethodError() async {
 }
 
-// Ensure that our synthesis of the actor's unownedExecutor does not cause
-// availability errors.
 @available(macOS 12.0, *)
 struct S {
-  actor A {
+  // Ensure that our synthesis of the actor's unownedExecutor does not cause
+  // availability errors.
+  actor NestedActor {
+  }
+
+  // The synthesized unownedExecutor inside this actor should inherit the
+  // un-availability of UnavailableActor.
+  @available(macOS, unavailable)
+  actor UnavailableActor {
   }
 }
 
+#if TARGET_MACOS_12
 // The synthesized unownedExecutor inside this extension on S should inherit
 // availability from S to avoid availability errors.
-#if TARGET_MACOS_12
 extension S {
-  actor A2 {
+  actor ExtensionNestedActor {
   }
+}
+#endif
+
+// Make sure that the conformances to Actor are actually being synthesized
+// since otherwise this test isn't actually testing what it is designed to test.
+@available(macOS 10.15, *)
+func takesExecutor(_ e: UnownedSerialExecutor) { }
+
+@available(macOS 12.0, *)
+func testNestedActorConformance(_ a: S.NestedActor) {
+  takesExecutor(a.unownedExecutor)
+}
+
+#if TARGET_MACOS_12
+func testExtensionNestedActorConformance(_ a: S.ExtensionNestedActor) {
+  takesExecutor(a.unownedExecutor)
 }
 #endif

--- a/test/ModuleInterface/actor_availability.swift
+++ b/test/ModuleInterface/actor_availability.swift
@@ -1,0 +1,68 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -target %target-swift-abi-5.3-triple
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
+// RUN: %FileCheck %s < %t/Library.swiftinterface
+
+// REQUIRES: VENDOR=apple
+
+// CHECK: #if compiler(>=5.3) && $Actors
+// CHECK-NEXT: public actor ActorWithImplicitAvailability {
+public actor ActorWithImplicitAvailability {
+  // CHECK: @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT: }
+}
+// CHECK: #endif
+
+// CHECK: #if compiler(>=5.3) && $Actors
+// CHECK-NEXT: @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
+// CHECK-NEXT: public actor ActorWithExplicitAvailability {
+@available(SwiftStdlib 5.2, *)
+public actor ActorWithExplicitAvailability {
+  // CHECK: @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
+  // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT: }
+}
+// CHECK: #endif
+
+// CHECK: #if compiler(>=5.3) && $Actors
+// CHECK-NEXT: @_hasMissingDesignatedInitializers @available(macOS, unavailable)
+// CHECK-NEXT: public actor UnavailableActor {
+@available(macOS, unavailable)
+public actor UnavailableActor {
+  // CHECK: @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+  // CHECK-NEXT: @available(macOS, unavailable)
+  // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+  // CHECK-NEXT:   get
+  // CHECK-NEXT: }
+}
+// CHECK: #endif
+
+// CHECK: @available(macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4, *)
+// CHECK-NEXT: public enum Enum {
+@available(SwiftStdlib 5.2, *)
+public enum Enum {
+  // CHECK:   #if compiler(>=5.3) && $Actors
+  // CHECK-NEXT: @_hasMissingDesignatedInitializers public actor NestedActor {
+  public actor NestedActor {
+    // CHECK: @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
+    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+    // CHECK-NEXT:   get
+    // CHECK-NEXT: }
+  }
+  // CHECK: #endif
+}
+
+// CHECK: extension Library.Enum {
+extension Enum {
+  // CHECK: #if compiler(>=5.3) && $Actors
+  // CHECK-NEXT: @_hasMissingDesignatedInitializers public actor ExtensionNestedActor {
+  public actor ExtensionNestedActor {
+    // CHECK: @available(iOS 13.4, tvOS 13.4, watchOS 6.2, macOS 10.15.4, *)
+    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+    // CHECK-NEXT:   get
+    // CHECK-NEXT: }
+  }
+}

--- a/test/ModuleInterface/actor_protocol.swift
+++ b/test/ModuleInterface/actor_protocol.swift
@@ -1,7 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -disable-availability-checking -module-name Library
-// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -disable-availability-checking -module-name Library
-// RUN: %FileCheck --check-prefix CHECK-EXTENSION %s <%t/Library.swiftinterface
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
 // RUN: %FileCheck --check-prefix CHECK %s <%t/Library.swiftinterface
 // REQUIRES: concurrency
 
@@ -10,7 +9,7 @@
 /// and not via some extension. The requirement is due to the unique
 /// optimizations applied to the implementation of actors.
 
-// CHECK-EXTENSION-NOT: extension {{.+}} : _Concurrency.Actor
+// CHECK-NOT: extension {{.+}} : _Concurrency.Actor
 
 // CHECK: public actor PlainActorClass {
 @available(SwiftStdlib 5.1, *)

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -426,15 +426,55 @@ swift_version = lit_config.params.get('swift-version',
 lit_config.note('Compiling with -swift-version ' + swift_version)
 config.swift_test_options = '-swift-version ' + swift_version
 
-# Load availability macros for known stdlib releases.
+# Loads availability macros for known stdlib releases.
 def load_availability_macros():
     path = os.path.join(os.path.dirname(__file__), "../utils/availability-macros.def")
     lines = open(path, 'r').read().splitlines()
     pattern = re.compile(r"\s*(#.*)?")
     return filter(lambda l: pattern.fullmatch(l) is None, lines)
+
+# Returns a tuple with the Swift ABI version (e.g. '5.0') and the corresponding
+# target triple (e.g. 'arm64-apple-ios12.2')
+def availability_macro_to_swift_abi_target_triple(macro):
+    # Use a regex and split to pull out the components of an availability macro
+    # that is formatted like this:
+    #    SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2
+    matches = re.search(r'^[\s]*SwiftStdlib[\s]+([0-9\.]+)[\s]*:[\s]*(.+)', macro)
+    stdlib_vers = matches.group(1)
+    vers_by_platform = {}
+    for platform_vers in matches.group(2).split(', '):
+        components = platform_vers.split(' ')
+        vers_by_platform[components[0]] = components[1]
+
+    platform = {
+        'macosx': 'macOS',
+        'ios': 'iOS',
+        'maccatalyst': 'iOS',
+        'tvos': 'tvOS',
+        'watchos': 'watchOS'
+    }.get(run_os)
+
+    if platform is None:
+        return stdlib_vers, config.variant_triple
+
+    os_vers = vers_by_platform.get(platform)
+    if os_vers is None:
+        return stdlib_vers, config.variant_triple
+
+    if run_os == 'maccatalyst':
+        return stdlib_vers, '%s-%s-ios%s-macabi' % (run_cpu, run_vendor, os_vers)
+
+    return stdlib_vers, '%s-%s-%s%s%s' % (run_cpu, run_vendor, run_os,
+                                          os_vers, run_environment)
+
+# Add availability macros to the default frontend/driver flags and create target
+# triple substitutions for each stdlib version.
 for macro in load_availability_macros():
     config.swift_frontend_test_options += " -define-availability '{0}'".format(macro)
     config.swift_driver_test_options += " -Xfrontend -define-availability -Xfrontend '{0}'".format(macro)
+    (stdlib_vers, triple) = availability_macro_to_swift_abi_target_triple(macro)
+    config.substitutions.append(('%target-swift-abi-{}-triple'.format(stdlib_vers), triple))
+
 
 differentiable_programming = lit_config.params.get('differentiable_programming', None)
 if differentiable_programming is not None:


### PR DESCRIPTION
When synthesizing a declaration and inferring its availability, the synthesized attribute should factor in unavailability of the parent declarations. This recently regressed with https://github.com/apple/swift/pull/63361. However, the previous implementation did not produce correct results, either, because the logic for merging availability attributes produced a non-sensical result when both `unavailable` and `introduced:` availability attributes were merged. For example, this was the result for the synthesized `unownedExecutor` property of an actor when the actor was marked unavailable:

```
@available(macOS, unavailable)
actor A {
  // Incorrectly synthesized availability for `unownedExecutor` which results from merging
  // the unavailability of the parent and the availability of the UnownedSerialExecutor type.
  @available(macOS, unavailable, introduced: macOS 10.15)
  @_semantics("defaultActor") nonisolated final var unownedExecutor: UnownedSerialExecutor { get }
}
```

This is fixed by omitting all version components from the synthesized attribute when the overall attribute kind is "unavailable".

Additionally, I discovered that the `concurrency_availability.swift` test case was no longer testing what it intended to test. The conformances to `Actor` for each `actor` in the test were no longer being synthesized and therefore `unownedExecutor` was not being synthesized. That was fixed by importing the `_Concurrency` module directly, which seems to be necessary because of the `-parse-stdlib` flag in the test.

Finally, this PR also introduces new `lit` substitutions that allow tests to specify that they want a deployment target corresponding a particular Swift release (e.g. Swift 5.3).

Resolves rdar://106055566