### PR TITLE
Implement `consume x` operator with the accepted SE-0366 syntax.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1360,9 +1360,12 @@ ERROR(expected_expr_after_try, none,
 ERROR(expected_expr_after_await, none,
       "expected expression after 'await'", ())
 ERROR(expected_expr_after_move, none,
-      "expected expression after '_move'", ())
+      "expected expression after 'consume'", ())
 ERROR(expected_expr_after_borrow, none,
       "expected expression after '_borrow'", ())
+
+WARNING(move_consume_final_spelling, none,
+        "'_move' has been renamed to 'consume', and the '_move' spelling will be removed shortly", ())
 
 // Cast expressions
 ERROR(expected_type_after_is,none,

--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -796,15 +796,15 @@ ERROR(sil_moveonlychecker_missed_copy, none,
 
 // move kills copyable values checker diagnostics
 ERROR(sil_movekillscopyablevalue_value_consumed_more_than_once, none,
-      "'%0' used after being moved", (StringRef))
+      "'%0' used after being consumed", (StringRef))
 NOTE(sil_movekillscopyablevalue_move_here, none,
-     "move here", ())
+     "consume here", ())
 NOTE(sil_movekillscopyablevalue_use_here, none,
      "use here", ())
 NOTE(sil_movekillscopyablevalue_value_consumed_in_loop, none,
-     "cyclic move here. move will occur multiple times in the loop", ())
+     "consume here would occur multiple times in loop", ())
 ERROR(sil_movekillscopyablevalue_move_applied_to_unsupported_move, none,
-      "_move applied to value that the compiler does not support checking",
+      "'consume' applied to value that the compiler does not support checking",
       ())
 
 #define UNDEFINE_DIAGNOSTIC_MACROS

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6805,7 +6805,7 @@ ERROR(concurrency_task_to_thread_model_global_actor_annotation,none,
 ERROR(moveOnly_not_allowed_here,none,
       "'moveOnly' only applies to structs or enums", ())
 ERROR(move_expression_not_passed_lvalue,none,
-      "'move' can only be applied to lvalues", ())
+      "'consume' can only be applied to lvalues", ())
 ERROR(borrow_expression_not_passed_lvalue,none,
       "'borrow' can only be applied to lvalues", ())
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -631,7 +631,8 @@ public:
       return false;
 
     // followed by either an identifier, `self`, or `Self`.
-    return peekToken().isAny(tok::identifier, tok::kw_self, tok::kw_Self);
+    return !peekToken().isAtStartOfLine()
+      && peekToken().isAny(tok::identifier, tok::kw_self, tok::kw_Self);
   }
   
   /// Read tokens until we get to one of the specified tokens, then

--- a/test/Constraints/moveonly_constraints.swift
+++ b/test/Constraints/moveonly_constraints.swift
@@ -101,7 +101,7 @@ func testBasic(_ mo: __shared MO) {
 func checkBasicBoxes() {
   let mo = MO()
 
-  let vb = ValBox(_move mo) // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
+  let vb = ValBox(consume mo) // expected-error 2{{move-only type 'MO' cannot be used with generics yet}}
   _ = vb.get()
   _ = vb.val
 

--- a/test/DebugInfo/move_function_dbginfo.swift
+++ b/test/DebugInfo/move_function_dbginfo.swift
@@ -80,7 +80,7 @@ public var falseValue: Bool { false }
 public func copyableValueTest() {
     let k = Klass()
     k.doSomething()
-    let m = _move k
+    let m = consume k
     m.doSomething()
 }
 
@@ -126,7 +126,7 @@ public func copyableValueTest() {
 // DWARF-NEXT: DW_AT_type	(
 public func copyableArgTest(_ k: __owned Klass) {
     k.doSomething()
-    let m = _move k
+    let m = consume k
     m.doSomething()
 }
 
@@ -168,7 +168,7 @@ public func copyableArgTest(_ k: __owned Klass) {
 public func copyableVarTest() {
     var k = Klass()
     k.doSomething()
-    let m = _move k
+    let m = consume k
     m.doSomething()
     k = Klass()
     k.doSomething()
@@ -211,7 +211,7 @@ public func copyableVarTest() {
 // DWARF-NEXT: DW_AT_type	(
 public func copyableVarArgTest(_ k: inout Klass) {
     k.doSomething()
-    let m = _move k
+    let m = consume k
     m.doSomething()
     k = Klass()
     k.doSomething()
@@ -261,7 +261,7 @@ public func copyableVarArgTest(_ k: inout Klass) {
 public func addressOnlyValueTest<T : P>(_ x: T) {
     let k = x
     k.doSomething()
-    let m = _move k
+    let m = consume k
     m.doSomething()
 }
 
@@ -303,7 +303,7 @@ public func addressOnlyValueTest<T : P>(_ x: T) {
 // DWARF-NEXT: DW_AT_type      (
 public func addressOnlyValueArgTest<T : P>(_ k: __owned T) {
     k.doSomething()
-    let m = _move k
+    let m = consume k
     m.doSomething()
 }
 
@@ -348,7 +348,7 @@ public func addressOnlyValueArgTest<T : P>(_ k: __owned T) {
 public func addressOnlyVarTest<T : P>(_ x: T) {
     var k = x
     k.doSomething()
-    let m = _move k
+    let m = consume k
     m.doSomething()
     k = x
     k.doSomething()
@@ -393,7 +393,7 @@ public func addressOnlyVarTest<T : P>(_ x: T) {
 // DWARF-NEXT: DW_AT_artificial        (true)
 public func addressOnlyVarArgTest<T : P>(_ k: inout T, _ x: T) {
     k.doSomething()
-    let m = _move k
+    let m = consume k
     m.doSomething()
     k = x
     k.doSomething()
@@ -416,7 +416,7 @@ public func copyableValueCCFlowTest() {
     let k = Klass()
     k.doSomething()
     if trueValue {
-        let m = _move k
+        let m = consume k
         m.doSomething()
     }
 }
@@ -433,7 +433,7 @@ public func copyableValueCCFlowTest() {
 public func copyableValueArgCCFlowTest(_ k: __owned Klass) {
     k.doSomething()
     if trueValue {
-        let m = _move k
+        let m = consume k
         m.doSomething()
     }
 }
@@ -463,7 +463,7 @@ public func copyableVarTestCCFlowReinitOutOfBlockTest() {
     var k = Klass()
     k.doSomething()
     if trueValue {
-        let m = _move k
+        let m = consume k
         m.doSomething()
     }
     k = Klass()
@@ -493,7 +493,7 @@ public func copyableVarTestCCFlowReinitOutOfBlockTest() {
 public func copyableVarArgTestCCFlowReinitOutOfBlockTest(_ k: inout Klass) {
     k.doSomething()
     if trueValue {
-        let m = _move k
+        let m = consume k
         m.doSomething()
     }
     k = Klass()
@@ -528,7 +528,7 @@ public func copyableVarTestCCFlowReinitInBlockTest() {
     var k = Klass()
     k.doSomething()
     if trueValue {
-        let m = _move k
+        let m = consume k
         m.doSomething()
         k = Klass()
     }
@@ -562,7 +562,7 @@ public func copyableVarTestCCFlowReinitInBlockTest() {
 public func copyableVarArgTestCCFlowReinitInBlockTest(_ k: inout Klass) {
     k.doSomething()
     if trueValue {
-        let m = _move k
+        let m = consume k
         m.doSomething()
         k = Klass()
     }
@@ -594,7 +594,7 @@ public func addressOnlyVarTestCCFlowReinitOutOfBlockTest<T : P>(_ x: T.Type) {
     var k = T.value
     k.doSomething()
     if trueValue {
-        let m = _move k
+        let m = consume k
         m.doSomething()
     }
     k = T.value
@@ -625,7 +625,7 @@ public func addressOnlyVarTestCCFlowReinitOutOfBlockTest<T : P>(_ x: T.Type) {
 public func addressOnlyVarArgTestCCFlowReinitOutOfBlockTest<T : P>(_ k: inout (any P), _ x: T.Type) {
     k.doSomething()
     if trueValue {
-        let m = _move k
+        let m = consume k
         m.doSomething()
     }
     k = T.value
@@ -659,7 +659,7 @@ public func addressOnlyVarTestCCFlowReinitInBlockTest<T : P>(_ x: T.Type) {
     var k = T.value
     k.doSomething()
     if trueValue {
-        let m = _move k
+        let m = consume k
         m.doSomething()
         k = T.value
     }
@@ -692,7 +692,7 @@ public func addressOnlyVarTestCCFlowReinitInBlockTest<T : P>(_ x: T.Type) {
 public func addressOnlyVarArgTestCCFlowReinitInBlockTest<T : P>(_ k: inout (any P), _ x: T.Type) {
     k.doSomething()
     if trueValue {
-        let m = _move k
+        let m = consume k
         m.doSomething()
         k = T.value
     }

--- a/test/DebugInfo/move_function_dbginfo_async.swift
+++ b/test/DebugInfo/move_function_dbginfo_async.swift
@@ -82,7 +82,7 @@ public func forceSplit5() async {}
 // DWARF-NEXT:            DW_AT_name	("msg")
 public func letSimpleTest<T>(_ msg: __owned T) async {
     await forceSplit()
-    use(_move msg)
+    use(consume msg)
 }
 
 // CHECK-LABEL: define swifttailcc void @"$s27move_function_dbginfo_async13varSimpleTestyyxz_xtYalF"(%swift.context* swiftasync %0, %swift.opaque* %1, %swift.opaque* noalias %2, %swift.type* %T)
@@ -146,7 +146,7 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 // DWARF: DW_TAG_formal_parameter
 // DWARF-NEXT: DW_AT_name ("msg")
 //
-// We reinitialize our value in this funclet and then _move it and then
+// We reinitialize our value in this funclet and then consume it and then
 // reinitialize it again. So we have two different live ranges. Sadly, we don't
 // validate that the first live range doesn't start at the beginning of the
 // function. But we have lldb tests to validate that.
@@ -161,7 +161,7 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 // DWARF-SAME:        DW_OP_entry_value([[ASYNC_REG]]), DW_OP_plus_uconst 0x[[MSG_LOC]], DW_OP_plus_uconst 0x8, DW_OP_deref
 // DWARF-NEXT: DW_AT_name	("msg")
 //
-// We did not _move the value again here, so we just get a normal entry value for
+// We did not consume the value again here, so we just get a normal entry value for
 // the entire function.
 //
 // DWARF: DW_AT_linkage_name	("$s3out13varSimpleTestyyxz_xtYalFTQ4_")
@@ -179,10 +179,10 @@ public func letSimpleTest<T>(_ msg: __owned T) async {
 // Change name to varSimpleTestArg
 public func varSimpleTest<T>(_ msg: inout T, _ msg2: T) async {
     await forceSplit()
-    use(_move msg)
+    use(consume msg)
     await forceSplit()
     msg = msg2
-    let msg3 = _move msg
+    let msg3 = consume msg
     let _ = msg3
     msg = msg2
     await forceSplit()
@@ -277,7 +277,7 @@ public func varSimpleTestVar() async {
     var k = Klass()
     k.doSomething()
     await forceSplit()
-    let m = _move k
+    let m = consume k
     m.doSomething()
     await forceSplit()
     k = Klass()
@@ -383,7 +383,7 @@ public func varSimpleTestVar() async {
 public func letArgCCFlowTrueTest<T>(_ msg: __owned T) async {
     await forceSplit1()
     if trueValue {
-        use(_move msg)
+        use(consume msg)
         await forceSplit2()
     } else {
         await forceSplit3()
@@ -534,7 +534,7 @@ public func letArgCCFlowTrueTest<T>(_ msg: __owned T) async {
 public func varArgCCFlowTrueTest<T : P>(_ msg: inout T) async {
     await forceSplit1()
     if trueValue {
-        use(_move msg)
+        use(consume msg)
         await forceSplit2()
     } else {
         await forceSplit3()

--- a/test/Interpreter/moveonly_bufferview.swift
+++ b/test/Interpreter/moveonly_bufferview.swift
@@ -31,7 +31,7 @@ extension Array {
 }
 
 func testBufferView(_ x: __owned [Int]) {
-    var y = _move x
+    var y = consume x
     // CHECK: 1
     // CHECK: 2
     // CHECK: 3
@@ -46,7 +46,7 @@ func testBufferView(_ x: __owned [Int]) {
 func getBool() -> Bool { return true }
 
 func testConditionalBufferView(_ x: __owned [Int]) {
-    (_move x).withUnsafeBufferPointer {
+    (consume x).withUnsafeBufferPointer {
         let y = BufferView(ptr: $0)
         // CHECK: 4
         // CHECK: 5

--- a/test/Parse/move_expr.swift
+++ b/test/Parse/move_expr.swift
@@ -2,18 +2,87 @@
 
 var global: Int = 5
 func testGlobal() {
-    let _ = _move global
+    let _ = consume global
 }
 
 func testLet() {
     let t = String()
-    let _ = _move t
+    let _ = consume t
 }
 
 func testVar() {
     var t = String()
     t = String()
-    let _ = _move t
+    let _ = consume t
 }
 
+func consume() {}
+func consume(_: String) {}
+func consume(_: String, _: Int) {}
+func consume(x: String, y: Int) {}
 
+// Ensure that we can still call a function named consume.
+
+func useConsumeFunc() {
+    var s = String()
+    var i = global
+
+    consume()
+    consume(s)
+    consume(i) // expected-error{{cannot convert value of type 'Int' to expected argument type 'String'}}
+    consume(s, i)
+    consume(i, s) // expected-error{{unnamed argument #2 must precede unnamed argument #1}}
+    consume(x: s, y: i)
+    consume(y: i, x: s) // expected-error{{argument 'x' must precede argument 'y'}}
+}
+
+// Ensure that we can still use a variable named consume.
+
+func useConsumeVar(consume: inout String) {
+    let s = consume
+    consume = s
+
+    // We can consume from a variable named `consume`
+    let t = consume consume
+    consume = t
+
+    // We can do member access and subscript a variable named `consume`
+    let i = consume.startIndex
+    let _ = consume[i]
+}
+
+// Temporary `_move` syntax is still parsed but raises a warning and fixit.
+func oldMoveSyntax(x: String) {
+    _ = _move x // expected-warning{{renamed to 'consume'}} {{9-14=consume}}
+}
+
+@propertyWrapper
+struct FooWrapper<T> {
+    var value: T
+
+    init(wrappedValue: T) { value = wrappedValue }
+
+    var wrappedValue: T {
+        get { value }
+        nonmutating set {}
+    }
+    var projectedValue: T {
+        get { value }
+        nonmutating set {}
+    }
+}
+
+struct Foo {
+    @FooWrapper var wrapperTest: String
+    
+    func consumeSelf() {
+        _ = consume self
+    }
+
+    func consumePropertyWrapper() {
+        // should still parse, even if it doesn't semantically work out
+        _ = consume wrapperTest // expected-error{{can only be applied to lvalues}}
+        _ = consume _wrapperTest // expected-error{{can only be applied to lvalues}}
+        _ = consume $wrapperTest // expected-error{{can only be applied to lvalues}}
+    }
+}

--- a/test/Parse/move_func_decl.swift
+++ b/test/Parse/move_func_decl.swift
@@ -3,7 +3,7 @@
 // rdar://100872195 (error: 'move' can only be applied to lvalues , error: Can not use feature when experimental move only is disabled!)
 //
 // Identifiers with a single underscore are not reserved for use by the language implementation. It is perfectly valid for a library to define its own '_move'.
-// The contextual _move keyword should only be parse when it is followed by an lvalue, so should *not* conflict with user-defined '_move' functions.
+// The contextual consume keyword should only be parse when it is followed by an lvalue, so should *not* conflict with user-defined '_move' functions.
 // https://github.com/apple/swift-evolution/blob/main/proposals/0366-move-function.md#source-compatibility
 
 func _move<T>(t: T) -> T { return t }

--- a/test/SILOptimizer/consume_operator_kills_copyable_addresses.sil
+++ b/test/SILOptimizer/consume_operator_kills_copyable_addresses.sil
@@ -14,13 +14,13 @@ sil hidden [ossa] @$s4test3fooyyAA5KlassCnF : $@convention(thin) (@owned Klass) 
 bb0(%0 : @owned $Klass):
   %1 = begin_borrow [lexical] %0 : $Klass
   debug_value %1 : $Klass, let, name "k", argno 1
-  %3 = alloc_stack [lexical] $Klass, var, name "k2" // expected-error {{'k2' used after being moved}}
+  %3 = alloc_stack [lexical] $Klass, var, name "k2" // expected-error {{'k2' used after being consumed}}
   %4 = copy_value %1 : $Klass
   %5 = move_value [allows_diagnostics] %4 : $Klass
   store %5 to [init] %3 : $*Klass
   %7 = begin_access [modify] [static] %3 : $*Klass
   %8 = alloc_stack $Klass
-  mark_unresolved_move_addr %7 to %8 : $*Klass // expected-note {{move here}}
+  mark_unresolved_move_addr %7 to %8 : $*Klass // expected-note {{consume here}}
   %10 = load [copy] %8 : $*Klass
   destroy_addr %8 : $*Klass
   end_access %7 : $*Klass

--- a/test/SILOptimizer/consume_operator_kills_copyable_addressonly_lets.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_addressonly_lets.swift
@@ -26,15 +26,15 @@ func nonConsumingUse<T>(_ k: T) {}
 //
 
 public func simpleLinearUse<T>(_ x: T) {
-    let y = x // expected-error {{'y' used after being moved}}
-    let _ = _move y // expected-note {{move here}}
+    let y = x // expected-error {{'y' used after being consumed}}
+    let _ = consume y // expected-note {{consume here}}
     nonConsumingUse(y) // expected-note {{use here}}
 }
 
 // We just emit an error today for the first error in a block.
 public func simpleLinearUse2<T>(_ x: T) {
-    let y = x // expected-error {{'y' used after being moved}}
-    let _ = _move y // expected-note {{move here}}
+    let y = x // expected-error {{'y' used after being consumed}}
+    let _ = consume y // expected-note {{consume here}}
     nonConsumingUse(y) // expected-note {{use here}}
     nonConsumingUse(y)
 }
@@ -42,15 +42,15 @@ public func simpleLinearUse2<T>(_ x: T) {
 public func conditionalUse1<T>(_ x: T) {
     let y = x
     if booleanValue {
-        let _ = _move y
+        let _ = consume y
     } else {
         nonConsumingUse(y)
     }
 }
 
 public func loopUse1<T>(_ x: T) {
-    let y = x  // expected-error {{'y' used after being moved}}
-    let _ = _move y // expected-note {{move here}}
+    let y = x  // expected-error {{'y' used after being consumed}}
+    let _ = consume y // expected-note {{consume here}}
     for _ in 0..<1024 {
         nonConsumingUse(y) // expected-note {{use here}}
     }
@@ -61,15 +61,15 @@ public func loopUse1<T>(_ x: T) {
 //
 
 public func simpleLinearConsumingUse<T>(_ x: T) {
-    let y = x // expected-error {{'y' used after being moved}}
-    let _ = _move y // expected-note {{move here}}
+    let y = x // expected-error {{'y' used after being consumed}}
+    let _ = consume y // expected-note {{consume here}}
     consumingUse(y) // expected-note {{use here}}
 }
 
 public func conditionalUseOk1<T>(_ x: T) {
     let y = x
     if booleanValue {
-        let _ = _move y
+        let _ = consume y
     } else {
         consumingUse(y)
     }
@@ -78,9 +78,9 @@ public func conditionalUseOk1<T>(_ x: T) {
 // This test makes sure that in the case where we have two consuming uses, with
 // different first level copies, we emit a single diagnostic.
 public func conditionalBadConsumingUse<T>(_ x: T) {
-    let y = x // expected-error {{'y' used after being moved}}
+    let y = x // expected-error {{'y' used after being consumed}}
     if booleanValue {
-        let _ = _move y // expected-note {{move here}}
+        let _ = consume y // expected-note {{consume here}}
         consumingUse(y) // expected-note {{use here}}
     } else {
         // We shouldn't get any diagnostic on this use.
@@ -93,9 +93,9 @@ public func conditionalBadConsumingUse<T>(_ x: T) {
 }
 
 public func conditionalBadConsumingUse2<T>(_ x: T) {
-    let y = x // expected-error {{'y' used after being moved}}
+    let y = x // expected-error {{'y' used after being consumed}}
     if booleanValue {
-        let _ = _move y // expected-note {{move here}}
+        let _ = consume y // expected-note {{consume here}}
     } else {
         // We shouldn't get any diagnostic on this use.
         consumingUse(y)
@@ -108,9 +108,9 @@ public func conditionalBadConsumingUse2<T>(_ x: T) {
 // This test makes sure that in the case where we have two consuming uses, with
 // different first level copies, we emit a single diagnostic.
 public func conditionalBadConsumingUseLoop<T>(_ x: T) {
-    let y = x // expected-error {{'y' used after being moved}}
+    let y = x // expected-error {{'y' used after being consumed}}
     if booleanValue {
-        let _ = _move y // expected-note {{move here}}
+        let _ = consume y // expected-note {{consume here}}
         consumingUse(y) // expected-note {{use here}}
     } else {
         // We shouldn't get any diagnostic on this use.
@@ -120,7 +120,7 @@ public func conditionalBadConsumingUseLoop<T>(_ x: T) {
     // But this one and the first consumingUse should get a diagnostic.
     //
     // We do not actually emit the diagnostic here since we emit only one
-    // diagnostic per _move at a time.
+    // diagnostic per consume at a time.
     for _ in 0..<1024 {
         consumingUse(y)
     }
@@ -129,9 +129,9 @@ public func conditionalBadConsumingUseLoop<T>(_ x: T) {
 // This test makes sure that in the case where we have two consuming uses, with
 // different first level copies, we emit a single diagnostic.
 public func conditionalBadConsumingUseLoop2<T>(_ x: T) {
-    let y = x // expected-error {{'y' used after being moved}}
+    let y = x // expected-error {{'y' used after being consumed}}
     if booleanValue {
-        let _ = _move y // expected-note {{move here}}
+        let _ = consume y // expected-note {{consume here}}
     } else {
         // We shouldn't get any diagnostic on this use.
         consumingUse(y)
@@ -147,56 +147,56 @@ public func conditionalBadConsumingUseLoop2<T>(_ x: T) {
 
 // This is ok, no uses after.
 public func simpleMoveOfParameter<T>(_ x: T) -> () {
-    let _ = _move x // expected-error {{_move applied to value that the compiler does not support checking}}
+    let _ = consume x // expected-error {{'consume' applied to value that the compiler does not support checking}}
 }
 
 public func simpleMoveOfOwnedParameter<T>(_ x: __owned T) -> () {
-    let _ = _move x
+    let _ = consume x
 }
 
-public func errorSimpleMoveOfParameter<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
-    let _ = _move x // expected-note {{use here}}
+public func errorSimpleMoveOfParameter<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
+    let _ = consume x // expected-note {{use here}}
 }
 
-public func errorSimple2MoveOfParameter<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func errorSimple2MoveOfParameter<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     let _ = consumingUse(x) // expected-note {{use here}}
 }
 
 // TODO: I wonder if we could do better for the 2nd error. At least we tell the
 // user it is due to the loop.
-public func errorLoopMultipleMove<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being moved}}
-                                                      // expected-error @-1 {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func errorLoopMultipleMove<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being consumed}}
+                                                      // expected-error @-1 {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     for _ in 0..<1024 {
-        let _ = _move x // expected-note {{move here}}
+        let _ = consume x // expected-note {{consume here}}
                          // expected-note @-1 {{use here}}
                          // expected-note @-2 {{use here}}
     }
 }
 
-public func errorLoopMoveOfParameter<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func errorLoopMoveOfParameter<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     for _ in 0..<1024 {
         consumingUse(x) // expected-note {{use here}}
     }
 }
 
-public func errorLoop2MoveOfParameter<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func errorLoop2MoveOfParameter<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     for _ in 0..<1024 {
         nonConsumingUse(x) // expected-note {{use here}}
     }
 }
 
-public func errorSimple2MoveOfParameterNonConsume<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func errorSimple2MoveOfParameterNonConsume<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     let _ = nonConsumingUse(x) // expected-note {{use here}}
 }
 
-public func errorLoopMoveOfParameterNonConsume<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func errorLoopMoveOfParameterNonConsume<T>(_ x: __owned T) -> () { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     for _ in 0..<1024 {
         nonConsumingUse(x) // expected-note {{use here}}
     }
@@ -207,8 +207,8 @@ public func errorLoopMoveOfParameterNonConsume<T>(_ x: __owned T) -> () { // exp
 ////////////////////////
 
 public func patternMatchIfCaseLet<T>(_ x: T?) {
-    if case let .some(y) = x { // expected-error {{'y' used after being moved}}
-        let _ = _move y // expected-note {{move here}}
+    if case let .some(y) = x { // expected-error {{'y' used after being consumed}}
+        let _ = consume y // expected-note {{consume here}}
         nonConsumingUse(y) // expected-note {{use here}}
     }
 }
@@ -217,27 +217,27 @@ public func patternMatchSwitchLet<T>(_ x: T?) {
     switch x {
     case .none:
         break
-    case .some(let y): // expected-error {{'y' used after being moved}}
-        let _ = _move y // expected-note {{move here}}
+    case .some(let y): // expected-error {{'y' used after being consumed}}
+        let _ = consume y // expected-note {{consume here}}
         nonConsumingUse(y) // expected-note {{use here}}
     }
 }
 
 public func patternMatchSwitchLet2<T>(_ x: (T?, T?)?) {
     switch x {
-    case .some((.some(let y), _)): // expected-error {{'y' used after being moved}}
-        let _ = _move y // expected-note {{move here}}
+    case .some((.some(let y), _)): // expected-error {{'y' used after being consumed}}
+        let _ = consume y // expected-note {{consume here}}
         nonConsumingUse(y) // expected-note {{use here}}
     default:
         break
     }
 }
 
-public func patternMatchSwitchLet3<T>(_ x: __owned (T?, T?)?) { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func patternMatchSwitchLet3<T>(_ x: __owned (T?, T?)?) { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     switch x { // expected-note {{use here}}
-    case .some((.some(_), .some(let z))): // expected-error {{'z' used after being moved}}
-        let _ = _move z // expected-note {{move here}}
+    case .some((.some(_), .some(let z))): // expected-error {{'z' used after being consumed}}
+        let _ = consume z // expected-note {{consume here}}
         nonConsumingUse(z) // expected-note {{use here}}
     default:
         break
@@ -258,9 +258,9 @@ public struct Pair<T> {
 // have invalidated a part of pair. We can be less restrictive in the future.
 //
 // TODO: Why are we emitting two uses here.
-public func performMoveOnOneEltOfPair<T>(_ p: __owned Pair<T>) { // expected-error {{'p' used after being moved}}
+public func performMoveOnOneEltOfPair<T>(_ p: __owned Pair<T>) { // expected-error {{'p' used after being consumed}}
     let _ = p.z // Make sure we don't crash when we access a trivial value from Pair.
-    let _ = _move p // expected-note {{move here}}
+    let _ = consume p // expected-note {{consume here}}
     nonConsumingUse(p.y) // expected-note {{use here}}
 }
 
@@ -272,7 +272,7 @@ public class TPair<T> {
 public func multipleVarsWithSubsequentBorrows<T : Equatable>(_ p: T) -> Bool {
     let k = p
     let k2 = k
-    let k3 = _move k
+    let k3 = consume k
     return k2 == k3
 }
 
@@ -280,23 +280,23 @@ public func multipleVarsWithSubsequentBorrows<T : Equatable>(_ p: T) -> Bool {
 // Cast Tests //
 ////////////////
 
-public func castTest0<T : SubP1>(_ x: __owned T) -> P { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func castTest0<T : SubP1>(_ x: __owned T) -> P { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     return x as P // expected-note {{use here}}
 }
 
-public func castTest1<T : P>(_ x: __owned T) -> SubP2 { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func castTest1<T : P>(_ x: __owned T) -> SubP2 { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     return x as! SubP2 // expected-note {{use here}}
 }
 
-public func castTest2<T : P>(_ x: __owned T) -> SubP1? { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func castTest2<T : P>(_ x: __owned T) -> SubP1? { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     return x as? SubP1 // expected-note {{use here}}
 }
 
-public func castTestSwitch1<T : P>(_ x: __owned T) { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func castTestSwitch1<T : P>(_ x: __owned T) { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     switch x { // expected-note {{use here}}
     case let k as SubP1:
         print(k)
@@ -305,8 +305,8 @@ public func castTestSwitch1<T : P>(_ x: __owned T) { // expected-error {{'x' use
     }
 }
 
-public func castTestSwitch2<T : P>(_ x: __owned T) { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func castTestSwitch2<T : P>(_ x: __owned T) { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     switch x { // expected-note {{use here}}
     case let k as SubP1:
         print(k)
@@ -317,8 +317,8 @@ public func castTestSwitch2<T : P>(_ x: __owned T) { // expected-error {{'x' use
     }
 }
 
-public func castTestSwitchInLoop<T : P>(_ x: __owned T) { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func castTestSwitchInLoop<T : P>(_ x: __owned T) { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
 
     for _ in 0..<1024 {
         switch x { // expected-note {{use here}}
@@ -330,8 +330,8 @@ public func castTestSwitchInLoop<T : P>(_ x: __owned T) { // expected-error {{'x
     }
 }
 
-public func castTestIfLet<T : P>(_ x: __owned T) { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func castTestIfLet<T : P>(_ x: __owned T) { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     if case let k as SubP1 = x { // expected-note {{use here}}
         print(k)
     } else {
@@ -339,8 +339,8 @@ public func castTestIfLet<T : P>(_ x: __owned T) { // expected-error {{'x' used 
     }
 }
 
-public func castTestIfLetInLoop<T : P>(_ x: __owned T) { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func castTestIfLetInLoop<T : P>(_ x: __owned T) { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     for _ in 0..<1024 {
         if case let k as SubP1 = x { // expected-note {{use here}}
             print(k)
@@ -355,8 +355,8 @@ public enum EnumWithKlass {
     case klass(P)
 }
 
-public func castTestIfLet2(_ x : __owned EnumWithKlass) { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func castTestIfLet2(_ x : __owned EnumWithKlass) { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     if case let .klass(k as SubP1) = x { // expected-note {{use here}}
         print(k)
     } else {
@@ -369,8 +369,8 @@ public func castTestIfLet2(_ x : __owned EnumWithKlass) { // expected-error {{'x
 /////////////////////////
 
 // Emit a better error here. At least we properly error.
-public func partialApplyTest<T>(_ x: __owned T) { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func partialApplyTest<T>(_ x: __owned T) { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     let f = { // expected-note {{use here}}
         nonConsumingUse(x)
     }
@@ -382,8 +382,8 @@ public func partialApplyTest<T>(_ x: __owned T) { // expected-error {{'x' used a
 /////////////////
 
 // TODO: Emit an error in the defer.
-public func deferTest<T>(_ x: __owned T) { // expected-error {{'x' used after being moved}}
-    let _ = _move x // expected-note {{move here}}
+public func deferTest<T>(_ x: __owned T) { // expected-error {{'x' used after being consumed}}
+    let _ = consume x // expected-note {{consume here}}
     defer { // expected-note {{use here}}
         nonConsumingUse(x)
     }

--- a/test/SILOptimizer/consume_operator_kills_copyable_addressonly_vars_crash.swift
+++ b/test/SILOptimizer/consume_operator_kills_copyable_addressonly_vars_crash.swift
@@ -14,7 +14,7 @@ public class Klass {
 public func copyableVarArgTestCCFlowReinitOutOfBlockTest(_ k: inout Klass) {
     k.doSomething()
     if booleanValue {
-        let m = _move k
+        let m = consume k
         m.doSomething()
     }
     k = Klass()

--- a/test/SILOptimizer/consume_operator_kills_copyable_values.sil
+++ b/test/SILOptimizer/consume_operator_kills_copyable_values.sil
@@ -22,10 +22,10 @@ case some(T)
 sil [ossa] @useInLoopWithDestroyOutOfLoop : $@convention(thin) (@guaranteed Klass) -> () {
 bb0(%0 : @guaranteed $Klass):
   debug_value %0 : $Klass, let, name "x", argno 1
-  %2 = begin_borrow [lexical] %0 : $Klass // expected-error {{'y' used after being moved}}
+  %2 = begin_borrow [lexical] %0 : $Klass // expected-error {{'y' used after being consumed}}
   debug_value %2 : $Klass, let, name "y"
   %4 = copy_value %2 : $Klass
-  %5 = move_value [allows_diagnostics] %4 : $Klass // expected-note {{move here}}
+  %5 = move_value [allows_diagnostics] %4 : $Klass // expected-note {{consume here}}
   destroy_value %5 : $Klass
   br bb1
 

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.swift
@@ -2147,8 +2147,8 @@ func moveOperatorTest(_ k: __owned Klass) {
     // expected-error @-2 {{'k2' consumed more than once}}
     // expected-error @-3 {{'k2' consumed more than once}}
     k2 = Klass()
-    let k3 = _move k2 // expected-note {{consuming use here}}
-    let _ = _move k2
+    let k3 = consume k2 // expected-note {{consuming use here}}
+    let _ = consume k2
     // expected-note @-1 {{consuming use here}}
     // expected-note @-2 {{consuming use here}}
     _ = k2

--- a/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
+++ b/test/SILOptimizer/moveonly_objectchecker_diagnostics.swift
@@ -2465,8 +2465,8 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(_ x2: __owned 
 
 func moveOperatorTest(_ k: __owned Klass) {
     let k2 = k // expected-error {{'k2' consumed more than once}}
-    let k3 = _move k2 // expected-note {{consuming use here}}
-    let _ = _move k2 // expected-note {{consuming use here}}
+    let k3 = consume k2 // expected-note {{consuming use here}}
+    let _ = consume k2 // expected-note {{consuming use here}}
     let _ = k3
 }
 

--- a/test/SILOptimizer/noimplicitcopy.swift
+++ b/test/SILOptimizer/noimplicitcopy.swift
@@ -2229,7 +2229,7 @@ public func closureAndClosureCaptureClassOwnedArgUseAfterConsume2(@_noImplicitCo
 
 func moveOperatorTest(_ k: __owned Klass) {
     @_noImplicitCopy let k2 = k // expected-error {{'k2' consumed more than once}}
-    @_noImplicitCopy let k3 = _move k2 // expected-note {{consuming use here}}
-    let _ = _move k2 // expected-note {{consuming use here}}
+    @_noImplicitCopy let k3 = consume k2 // expected-note {{consuming use here}}
+    let _ = consume k2 // expected-note {{consuming use here}}
     let _ = k3
 }

--- a/test/Sema/move_expr.swift
+++ b/test/Sema/move_expr.swift
@@ -6,40 +6,36 @@ class Klass {
 
 var global: Int = 5
 func testGlobal() {
-    let _ = _move global
+    let _ = consume global
 }
 
 func testLet() {
     let t = String()
-    let _ = _move t
+    let _ = consume t
 }
 
 func testVar() {
     var t = String()
     t = String()
-    let _ = _move t
+    let _ = consume t
 }
 
 func testExprFailureLet() {
     let t = 5
     // Next line is parsed as move(t) + t
-    let _ = _move t + t
-    // Next line is parsed as move(t+t)
-    let _ = _move (t+t) // expected-error {{'move' can only be applied to lvalues}}
+    let _ = consume t + t
 }
 
 func testExprFailureVar() {
     var t = 5
     t = 5
     // Next line is parsed as move(t) + t
-    let _ = _move t + t
-    // Next line is parsed as move(t+t)
-    let _ = _move (t+t) // expected-error {{'move' can only be applied to lvalues}}
+    let _ = consume t + t
 }
 
 func letAddressOnly<T>(_ v: T) {
     let t = v
-    let _ = _move t
+    let _ = consume t
 }
 
 struct StructWithField {
@@ -48,22 +44,22 @@ struct StructWithField {
 
 func testLetStructAccessField() {
     let t = StructWithField()
-    let _ = _move t.k  // expected-error {{'move' can only be applied to lvalues}}
+    let _ = consume t.k  // expected-error {{'consume' can only be applied to lvalues}}
 }
 
 func testVarStructAccessField() {
     var t = StructWithField()
     t = StructWithField()
-    let _ = _move t.k // expected-error {{'move' can only be applied to lvalues}}
+    let _ = consume t.k // expected-error {{'consume' can only be applied to lvalues}}
 }
 
 func testLetClassAccessField() {
     let t = Klass()
-    let _ = _move t.k  // expected-error {{'move' can only be applied to lvalues}}
+    let _ = consume t.k  // expected-error {{'consume' can only be applied to lvalues}}
 }
 
 func testVarClassAccessField() {
     var t = Klass()
     t = Klass()
-    let _ = _move t.k // expected-error {{'move' can only be applied to lvalues}}
+    let _ = consume t.k // expected-error {{'consume' can only be applied to lvalues}}
 }

--- a/test/stdlib/LifetimeManagement.swift
+++ b/test/stdlib/LifetimeManagement.swift
@@ -16,7 +16,7 @@ suite.test("copy") {
 suite.test("move") {
   let k = Klass()
   let k2 = k
-  expectTrue(k2 === _move k)
+  expectTrue(k2 === consume k)
 }
 
 runAllTests()

--- a/test/stdlib/move_function.swift
+++ b/test/stdlib/move_function.swift
@@ -53,7 +53,7 @@ extension Class {
         do {
             x = self.k2
         }
-        switch (_move x)[userHandle] {
+        switch (consume x)[userHandle] {
         case .foo:
             expectTrue(_isUnique(&self.k2))
         }
@@ -76,7 +76,7 @@ extension Class {
         do {
             x = self.array
         }
-        switch (_move x)[userHandle] {
+        switch (consume x)[userHandle] {
         case .foo:
             expectTrue(self.array._buffer.isUniquelyReferenced())
         }
@@ -96,7 +96,7 @@ tests.test("simpleArrayVarTest") {
 
     var y = x
     expectFalse(x._buffer.isUniquelyReferenced())
-    let _ = _move y
+    let _ = consume y
     expectTrue(x._buffer.isUniquelyReferenced())
     y = []
     expectTrue(x._buffer.isUniquelyReferenced())
@@ -106,7 +106,7 @@ tests.test("simpleArrayInoutVarTest") {
     func inOutTest(_ x: inout [Enum]) {
         var y = x
         expectFalse(x._buffer.isUniquelyReferenced())
-        let _ = _move y
+        let _ = consume y
         expectTrue(x._buffer.isUniquelyReferenced())
         y = []
         expectTrue(x._buffer.isUniquelyReferenced())


### PR DESCRIPTION
Implement it as a contextual operator that only parses as an operator when followed by an identifier.

Matching swift-syntax changes are https://github.com/apple/swift-syntax/pull/1379