### PR TITLE
Conformance macro fixes

### DIFF
--- a/lib/Refactoring/Refactoring.cpp
+++ b/lib/Refactoring/Refactoring.cpp
@@ -8549,6 +8549,14 @@ getMacroExpansionBuffers(MacroDecl *macro, const CustomAttr *attr, Decl *decl) {
     allBufferIDs.append(bufferIDs.begin(), bufferIDs.end());
   }
 
+  if (roles.contains(MacroRole::Conformance)) {
+    if (auto nominal = dyn_cast<NominalTypeDecl>(decl)) {
+      auto bufferIDs = evaluateOrDefault(
+          ctx.evaluator, ExpandConformanceMacros{nominal}, { });
+      allBufferIDs.append(bufferIDs.begin(), bufferIDs.end());
+    }
+  }
+
   // Drop any buffers that come from other macros. We could eliminate this
   // step by adding more fine-grained requests above, which only expand for a
   // single custom attribute.

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1037,6 +1037,17 @@ public struct EquatableMacro: ConformanceMacro {
   }
 }
 
+public struct HashableMacro: ConformanceMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingConformancesOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [(TypeSyntax, GenericWhereClauseSyntax?)] {
+    let protocolName: TypeSyntax = "Hashable"
+    return [(protocolName, nil)]
+  }
+}
+
 public struct DelegatedConformanceMacro: ConformanceMacro, MemberMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/macro_expand_conformances.swift
+++ b/test/Macros/macro_expand_conformances.swift
@@ -13,18 +13,31 @@
 @attached(conformance)
 macro Equatable() = #externalMacro(module: "MacroDefinition", type: "EquatableMacro")
 
+@attached(conformance)
+macro Hashable() = #externalMacro(module: "MacroDefinition", type: "HashableMacro")
+
 func requireEquatable(_ value: some Equatable) {
   print(value == value)
 }
 
+func requireHashable(_ value: some Hashable) {
+  print(value.hashValue)
+}
+
 @Equatable
 struct S {}
+
+@Hashable
+struct S2 {}
 
 // CHECK-DUMP: @__swiftmacro_25macro_expand_conformances1SV9EquatablefMc_.swift
 // CHECK-DUMP: extension S : Equatable  {}
 
 // CHECK: true
 requireEquatable(S())
+
+requireEquatable(S2())
+requireHashable(S2())
 
 @attached(conformance)
 @attached(member)

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -45,6 +45,12 @@ struct S3 {
   }
 }
 
+@attached(conformance)
+macro Hashable() = #externalMacro(module: "MacroDefinition", type: "HashableMacro")
+
+@Hashable
+struct S4 { }
+
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx
 
@@ -162,7 +168,7 @@ struct S3 {
 // ACCESSOR2_EXPAND-NEXT: source.edit.kind.active:
 // ACCESSOR2_EXPAND-NEXT: 33:3-33:20 ""
 
-//##-- Refactoring expanding the second accessor macro
+//##-- Refactoring expanding the addCompletionHandler macro.
 // RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=42:5 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=PEER_EXPAND %s
 // PEER_EXPAND: source.edit.kind.active:
 // PEER_EXPAND-NEXT: 45:4-45:4 (@__swiftmacro_9MacroUser2S3V1f1a3for_SSSi_SSSdtYaF20addCompletionHandlerfMp_.swift) "
@@ -175,6 +181,16 @@ struct S3 {
 // PEER_EXPAND-NEXT: "
 // PEER_EXPAND-NEXT: source.edit.kind.active:
 // PEER_EXPAND-NEXT: 42:3-42:24 ""
+
+//##-- Refactoring expanding a conformance macro.
+// RUN: %sourcekitd-test -req=refactoring.expand.macro -pos=51:5 %s -- ${COMPILER_ARGS[@]} | %FileCheck -check-prefix=CONFORMANCE_EXPAND %s
+// CONFORMANCE_EXPAND: source.edit.kind.active:
+// CONFORMANCE_EXPAND-NEXT: 52:14-52:14 (@__swiftmacro_9MacroUser2S4V8HashablefMc_.swift) "
+// CONFORMANCE_EXPAND-EMPTY:
+// CONFORMANCE_EXPAND-NEXT: extension S4 : Hashable {}
+// CONFORMANCE_EXPAND-NEXT: "
+// CONFORMANCE_EXPAND-NEXT: source.edit.kind.active:
+// CONFORMANCE_EXPAND-NEXT: 51:1-51:10 ""
 
 //##-- Doc info, mostly just checking we don't crash because of the separate buffers
 // RUN: %sourcekitd-test -req=doc-info %s -- ${COMPILER_ARGS_WITHOUT_SOURCE[@]} | %FileCheck -check-prefix=DOCINFO %s


### PR DESCRIPTION
Implement two fixes needed for conformance macros to get `OptionSet` working the way we want:

* Register the extension for a conformance macro fully. This ensures that we handle the extensions used to register conformances from conformance macros uniformly throughout.
* Add macro expansion support for conformance macros.
