### PR TITLE
[Sema] Eliminate single-element tuples after parameter pack substitution.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5289,6 +5289,9 @@ ERROR(dot_protocol_on_non_existential,none,
       "cannot use 'Protocol' with non-protocol type %0", (Type))
 ERROR(tuple_single_element,none,
       "cannot create a single-element tuple with an element label", ())
+ERROR(tuple_pack_element_label,none,
+      "cannot use label with pack expansion tuple element",
+      ())
 ERROR(vararg_not_allowed,none,
       "variadic parameter cannot appear outside of a function parameter list",
       ())

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2395,7 +2395,7 @@ public:
   
   bool containsPackExpansionType() const;
 
-  TupleType *flattenPackTypes();
+  Type flattenPackTypes();
 
 private:
   TupleType(ArrayRef<TupleTypeElt> elements, const ASTContext *CanCtx,

--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -158,7 +158,7 @@ bool TupleType::containsPackExpansionType() const {
 }
 
 /// (W, {X, Y}..., Z) => (W, X, Y, Z)
-TupleType *TupleType::flattenPackTypes() {
+Type TupleType::flattenPackTypes() {
   bool anyChanged = false;
   SmallVector<TupleTypeElt, 4> elts;
 
@@ -192,6 +192,15 @@ TupleType *TupleType::flattenPackTypes() {
 
   if (!anyChanged)
     return this;
+
+  // If pack substitution yields a single-element tuple, the tuple
+  // structure is flattened to produce the element type.
+  if (elts.size() == 1) {
+    auto type = elts.front().getType();
+    if (!type->is<PackExpansionType>() && !type->is<TypeVariableType>()) {
+      return type;
+    }
+  }
 
   return TupleType::get(elts, getASTContext());
 }

--- a/test/Constraints/one_element_tuple.swift
+++ b/test/Constraints/one_element_tuple.swift
@@ -3,10 +3,29 @@
 // REQUIRES: asserts
 
 let t1: (_: Int) = (_: 3)
+
+// FIXME: diag::tuple_single_element should be diagnosed in the constraint system
+// instead of MiscDiagnostics, which will allow the compiler to emit that
+// error instead of bogus type mismatches for tuple expressions.
 let t2: (x: Int) = (x: 3)
+// expected-error@-1{{cannot create a single-element tuple with an element label}}
+// expected-error@-2 {{cannot convert value of type '(x: Int)' to specified type 'Int'}}
 
 let i1: Int = t1.0
+// expected-error@-1 {{value of type 'Int' has no member '0'}}
+
 let i2: Int = t2.x
+// expected-error@-1 {{value of type 'Int' has no member 'x'}}
 
 let m1: (_: Int).Type = (_: Int).self
 let m2: (x: Int).Type = (x: Int).self
+// expected-error@-1 2 {{cannot create a single-element tuple with an element label}}
+
+struct S<each T> {
+  var t: (repeat each T)
+}
+
+func packSubstitution() -> Int {
+  let s = S<Int>(t: 1)
+  return s.t
+}

--- a/test/Constraints/pack_expansion_types.swift
+++ b/test/Constraints/pack_expansion_types.swift
@@ -9,38 +9,44 @@ func returnTuple2<each T>() -> (Int, repeat each T) { fatalError() }
 // expected-note@-1 3 {{in call to function 'returnTuple2()'}}
 
 func returnTupleLabel1<each T>() -> (x: repeat each T) { fatalError() }
-// expected-note@-1 2 {{in call to function 'returnTupleLabel1()'}}
+// expected-error@-1 {{cannot use label with pack expansion tuple element}}
 
 func returnTupleLabel2<each T>() -> (Int, x: repeat each T) { fatalError() }
-// expected-note@-1 2 {{in call to function 'returnTupleLabel2()'}}
+// expected-error@-1 {{cannot use label with pack expansion tuple element}}
 
 func returnTupleLabel3<each T>() -> (Int, repeat each T, y: Float) { fatalError() }
 // expected-note@-1 3 {{in call to function 'returnTupleLabel3()'}}
 
 func returnTupleLabel4<each T>() -> (Int, x: repeat each T, y: Float) { fatalError() }
-// expected-note@-1 2 {{in call to function 'returnTupleLabel4()'}}
+// expected-error@-1 {{cannot use label with pack expansion tuple element}}
 
 func returnTupleLabel5<each T, each U>() -> (Int, repeat each T, y: repeat each U) { fatalError() }
-// expected-note@-1 3 {{in call to function 'returnTupleLabel5()'}}
+// expected-error@-1 {{cannot use label with pack expansion tuple element}}
 
 func returnTupleLabel6<each T, each U>() -> (Int, x: repeat each T, y: repeat each U) { fatalError() }
-// expected-note@-1 {{in call to function 'returnTupleLabel6()'}}
+// expected-error@-1 2 {{cannot use label with pack expansion tuple element}}
 
 func concreteReturnTupleValid() {
   let _: () = returnTuple1()
-  let _: (_: Int) = returnTuple1()
+  // FIXME: consider propagating 'Int' through the conversion constraint
+  // as a binding for the parameter pack expanded in the tuple return type.
+  let _: Int = returnTuple1()
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-2 {{cannot convert value of type '(repeat each T)' to specified type 'Int'}}
   let _: (Int, String) = returnTuple1()
 
-  let _: (_: Int) = returnTuple2()
+  let _: Int = returnTuple2()
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-2 {{cannot convert value of type '(Int, repeat each T)' to specified type 'Int'}}
   let _: (Int, String) = returnTuple2()
   let _: (Int, String, Float) = returnTuple2()
 
   let _: () = returnTupleLabel1()
-  let _: (x: Int) = returnTupleLabel1()
+  let _: Int = returnTupleLabel1()
   let _: (x: Int, String) = returnTupleLabel1()
   let _: (x: Int, String, Float) = returnTupleLabel1()
 
-  let _: (_: Int) = returnTupleLabel2()
+  let _: Int = returnTupleLabel2()
   let _: (Int, x: Int) = returnTupleLabel2()
   let _: (Int, x: Int, String) = returnTupleLabel2()
   let _: (Int, x: Int, String, Float) = returnTupleLabel2()
@@ -53,13 +59,13 @@ func concreteReturnTupleValid() {
   let _: (Int, x: Int, y: Float) = returnTupleLabel4()
   let _: (Int, x: Int, String, y: Float) = returnTupleLabel4()
 
-  let _: (_: Int) = returnTupleLabel5()
+  let _: Int = returnTupleLabel5()
   let _: (Int, Int) = returnTupleLabel5()
   let _: (Int, Int, String) = returnTupleLabel5()
   let _: (Int, y: Double, Float) = returnTupleLabel5()
   let _: (Int, Int, String, Float, y: Double) = returnTupleLabel5()
 
-  let _: (_: Int) = returnTupleLabel6()
+  let _: Int = returnTupleLabel6()
   let _: (Int, x: Int) = returnTupleLabel6()
   let _: (Int, x: Int, String) = returnTupleLabel6()
   let _: (Int, y: Double, Float) = returnTupleLabel6()
@@ -67,26 +73,20 @@ func concreteReturnTupleValid() {
 }
 
 func concreteReturnTypeInvalid() {
-  let _: (x: Int) = returnTuple1()
-  // expected-error@-1 {{cannot convert value of type '(repeat each T)' to specified type '(x: Int)'}}
+  let _: Int = returnTuple1()
+  // expected-error@-1 {{cannot convert value of type '(repeat each T)' to specified type 'Int'}}
   // expected-error@-2 {{generic parameter 'T' could not be inferred}}
 
   let _: () = returnTuple2()
   // expected-error@-1 {{'(Int, repeat each T)' is not convertible to '()', tuples have a different number of elements}}
   // expected-error@-2 {{generic parameter 'T' could not be inferred}}
 
-  let _: (x: Int) = returnTupleLabel3()
-  // expected-error@-1 {{'(Int, repeat each T, y: Float)' is not convertible to '(x: Int)', tuples have a different number of elements}}
+  let _: Int = returnTupleLabel3()
+  // expected-error@-1 {{cannot convert value of type '(Int, repeat each T, y: Float)' to specified type 'Int'}}
   // expected-error@-2 {{generic parameter 'T' could not be inferred}}
 
-  let _: (Int, Int, y: Float) = returnTupleLabel4()
-  // expected-error@-1 {{cannot convert value of type '(Int, x: repeat each T, y: Float)' to specified type '(Int, Int, y: Float)'}}
-  // expected-error@-2 {{generic parameter 'T' could not be inferred}}
-
-  let _: () = returnTupleLabel5()
-  // expected-error@-1 {{'(Int, repeat each T, y: repeat each U)' is not convertible to '()', tuples have a different number of elements}}
-  // expected-error@-2 {{generic parameter 'T' could not be inferred}}
-  // expected-error@-3 {{generic parameter 'U' could not be inferred}}
+  let _: (Int, Int, y: Float) = returnTupleLabel4() // error at declaration
+  let _: () = returnTupleLabel5()  // error at declaration
 }
 
 func genericReturnTupleValid<each T>(_: repeat each T) {
@@ -97,56 +97,58 @@ func genericReturnTupleValid<each T>(_: repeat each T) {
   let _: (Int, String, repeat each T) = returnTuple2()
 
   let _: (x: repeat each T) = returnTupleLabel1()
+  // expected-error@-1 {{cannot use label with pack expansion tuple element}}
+
   let _: (x: Int, repeat each T) = returnTupleLabel1()
 
   let _: (Int, x: repeat each T) = returnTupleLabel2()
+  // expected-error@-1 {{cannot use label with pack expansion tuple element}}
+
   let _: (Int, x: String, repeat each T) = returnTupleLabel2()
 
   let _: (Int, repeat each T, y: Float) = returnTupleLabel3()
   let _: (Int, String, repeat each T, y: Float) = returnTupleLabel3()
 
   let _: (Int, x: repeat each T, y: Float) = returnTupleLabel4()
+  // expected-error@-1 {{cannot use label with pack expansion tuple element}}
+
   let _: (Int, x: String, repeat each T, y: Float) = returnTupleLabel4()
 
   let _: (Int, repeat each T, y: repeat each T) = returnTupleLabel5()
+  // expected-error@-1 {{cannot use label with pack expansion tuple element}}
+
   let _: (Int, String, repeat each T, y: Float, repeat each T) = returnTupleLabel5()
 
   let _: (Int, x: repeat each T, y: repeat each T) = returnTupleLabel6()
+  // expected-error@-1 2 {{cannot use label with pack expansion tuple element}}
+
   let _: (Int, x: String, repeat each T, y: Float, repeat each T) = returnTupleLabel6()
 }
 
 func genericReturnTupleInvalid<each T>(_: repeat each T) {
   let _: (x: repeat each T) = returnTuple1()
-  // expected-error@-1 {{cannot convert value of type '(repeat each T)' to specified type '(x: repeat each T)'}}
-  // expected-error@-2 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-1 {{cannot use label with pack expansion tuple element}}
 
   let _: (x: Int, repeat each T) = returnTuple1()
   // expected-error@-1 {{'(repeat each T)' is not convertible to '(x: Int, repeat each T)', tuples have a different number of elements}}
   // expected-error@-2 {{generic parameter 'T' could not be inferred}}
 
   let _: (Int, x: repeat each T) = returnTuple2()
-  // expected-error@-1 {{cannot convert value of type '(Int, repeat each T)' to specified type '(Int, x: repeat each T)'}}
-  // expected-error@-2 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-1 {{cannot use label with pack expansion tuple element}}
 
   let _: (Int, x: String, repeat each T) = returnTuple2()
   // expected-error@-1 {{'(Int, repeat each T)' is not convertible to '(Int, x: String, repeat each T)', tuples have a different number of elements}}
   // expected-error@-2 {{generic parameter 'T' could not be inferred}}
 
   let _: (y: repeat each T) = returnTupleLabel1()
-  // expected-error@-1 {{cannot convert value of type '(x: repeat each T)' to specified type '(y: repeat each T)'}}
-  // expected-error@-2 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-1 {{cannot use label with pack expansion tuple element}}
 
-  let _: (y: Int, repeat each T) = returnTupleLabel1()
-  // expected-error@-1 {{'(x: repeat each T)' is not convertible to '(y: Int, repeat each T)', tuples have a different number of elements}}
-  // expected-error@-2 {{generic parameter 'T' could not be inferred}}
+  let _: (y: Int, repeat each T) = returnTupleLabel1() // error at declaration
 
   let _: (x: repeat each T) = returnTupleLabel2()
-  // expected-error@-1 {{'(Int, x: repeat each T)' is not convertible to '(x: repeat each T)', tuples have a different number of elements}}
-  // expected-error@-2 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-1 {{cannot use label with pack expansion tuple element}}
 
-  let _: (Int, y: String, repeat each T) = returnTupleLabel2()
-  // expected-error@-1 {{'(Int, x: repeat each T)' is not convertible to '(Int, y: String, repeat each T)', tuples have a different number of elements}}
-  // expected-error@-2 {{generic parameter 'T' could not be inferred}}
+  let _: (Int, y: String, repeat each T) = returnTupleLabel2() // error at declaration
 
   let _: (repeat each T, y: Float) = returnTupleLabel3()
   // expected-error@-1 {{'(Int, repeat each T, y: Float)' is not convertible to '(repeat each T, y: Float)', tuples have a different number of elements}}
@@ -156,24 +158,17 @@ func genericReturnTupleInvalid<each T>(_: repeat each T) {
   // expected-error@-1 {{'(Int, repeat each T, y: Float)' is not convertible to '(Int, String, repeat each T, x: Float)', tuples have a different number of elements}}
   // expected-error@-2 {{generic parameter 'T' could not be inferred}}
 
-  let _: (repeat each T, y: Float) = returnTupleLabel4() // expected-error {{'(Int, x: repeat each T, y: Float)' is not convertible to '(repeat each T, y: Float)', tuples have a different number of elements}}
-  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  let _: (repeat each T, y: Float) = returnTupleLabel4() // error at declaration
 
-  let _: (Int, x: String, y: repeat each T) = returnTupleLabel4() // expected-error {{cannot convert value of type '(Int, x: String, y: Float)' to specified type '(Int, x: String, y: repeat each T)'}}
+  let _: (Int, x: String, y: repeat each T) = returnTupleLabel4()
+  // expected-error@-1 {{cannot use label with pack expansion tuple element}}
 
   let _: (Int, repeat each T, x: repeat each T) = returnTupleLabel5()
-  // expected-error@-1 {{cannot convert value of type '(Int, repeat each T, y: repeat each U)' to specified type '(Int, repeat each T, x: repeat each T)'}}
-  // expected-error@-2 {{generic parameter 'T' could not be inferred}}
-  // expected-error@-3 {{generic parameter 'U' could not be inferred}}
+  // expected-error@-1 {{cannot use label with pack expansion tuple element}}
 
-  let _: (repeat each T, y: Float, repeat each T) = returnTupleLabel5()
-  // expected-error@-1 {{cannot convert value of type '(Int, repeat each T, y: repeat each U)' to specified type '(repeat each T, y: Float, repeat each T)'}}
-  // expected-error@-2 {{generic parameter 'T' could not be inferred}}
-  // expected-error@-3 {{generic parameter 'U' could not be inferred}}
+  let _: (repeat each T, y: Float, repeat each T) = returnTupleLabel5() // error at declaration
 
-  let _: (repeat each T, y: Int) = returnTupleLabel6() // expected-error {{'(Int, x: repeat each T, y: repeat each U)' is not convertible to '(repeat each T, y: Int)', tuples have a different number of elements}}
-  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
-  // expected-error@-2 {{generic parameter 'U' could not be inferred}}
+  let _: (repeat each T, y: Int) = returnTupleLabel6() // error at declaration
 }
 
 func returnFunction1<each T>() -> (repeat each T) -> () {}
@@ -224,20 +219,29 @@ func concreteReturnFunctionInvalid() {
   let _: (Float, Int) -> () = returnFunction4() // expected-error {{cannot convert value of type '(Int, Float) -> ()' to specified type '(Float, Int) -> ()'}}
 }
 
-func patternInstantiationTupleTest1<each T>() -> (repeat Array<each T>) {} // expected-note {{in call to function 'patternInstantiationTupleTest1()'}}
+func patternInstantiationTupleTest1<each T>() -> (repeat Array<each T>) {}
+// expected-note@-1 3 {{in call to function 'patternInstantiationTupleTest1()'}}
 func patternInstantiationTupleTest2<each T, each U>() -> (repeat Dictionary<each T, each U>) {}
+// expected-note@-1 {{in call to function 'patternInstantiationTupleTest2()'}}
 
 func patternInstantiationFunctionTest1<each T>() -> (repeat Array<each T>) -> () {}
 func patternInstantiationFunctionTest2<each T, each U>() -> (repeat Dictionary<each T, each U>) -> () {}
 
 func patternInstantiationConcreteValid() {
   let _: () = patternInstantiationTupleTest1()
-  let _: (_: Array<Int>) = patternInstantiationTupleTest1()
+  // FIXME
+  let _: Array<Int> = patternInstantiationTupleTest1()
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-2 {{cannot convert value of type '(repeat Array<each T>)' to specified type 'Array<Int>'}}
   let _: (Array<Int>, Array<String>) = patternInstantiationTupleTest1()
   let _: (Array<Int>, Array<String>, Array<Float>) = patternInstantiationTupleTest1()
 
   let _: () = patternInstantiationTupleTest2()
-  let _: (_: Dictionary<Int, String>) = patternInstantiationTupleTest2()
+  // FIXME
+  let _: Dictionary<Int, String> = patternInstantiationTupleTest2()
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-2 {{generic parameter 'U' could not be inferred}}
+  // expected-error@-3 {{cannot convert value of type '(repeat Dictionary<each T, each U>)' to specified type 'Dictionary<Int, String>'}}
   let _: (Dictionary<Int, String>, Dictionary<Float, Bool>) = patternInstantiationTupleTest2()
   let _: (Dictionary<Int, String>, Dictionary<Float, Bool>, Dictionary<Double, Character>) = patternInstantiationTupleTest2()
 
@@ -253,7 +257,10 @@ func patternInstantiationConcreteValid() {
 }
 
 func patternInstantiationConcreteInvalid() {
-  let _: (_: Set<Int>) = patternInstantiationTupleTest1() // expected-error {{type of expression is ambiguous without more context}}
+  let _: Set<Int> = patternInstantiationTupleTest1()
+  // expected-error@-1 {{generic parameter 'T' could not be inferred}}
+  // expected-error@-2 {{cannot convert value of type '(repeat Array<each T>)' to specified type 'Set<Int>'}}
+
   let _: (Array<Int>, Set<String>) = patternInstantiationTupleTest1() // expected-error {{type of expression is ambiguous without more context}}
 }
 

--- a/test/Constraints/variadic_generic_functions.swift
+++ b/test/Constraints/variadic_generic_functions.swift
@@ -32,7 +32,7 @@ func call() {
   }
   multipleParameters()
 
-  let x: (_: String) = multipleParameters(xs: "", ys: "")
+  let x: String = multipleParameters(xs: "", ys: "")
   let (one, two) = multipleParameters(xs: "", 5.0, ys: "", 5.0)
   multipleParameters(xs: "", 5.0, ys: 5.0, "") // expected-error {{type of expression is ambiguous without more context}}
 


### PR DESCRIPTION
If applying a parameter pack substitution produces a single-element tuple, unwrap the tuple structure to produce the element itself:

```swift
func tuplify<each T>(_ t: repeat each T) -> (repeat each T) { ... }

let t: Int = tuplify(1) // 👍🏻
```

For now, the constraint system does not support inferring element bindings through conversion constraints to tuples, e.g. the following code will fail to compile:

```swift
func returnTuple1<each T>() -> (repeat each T) { ... }

let _: Int = returnTuple1() // error: cannot infer generic parameter 'T'
```

This changes also prohibits declaring tuples with pack expansion elements with labels:

```swift
func makeTuple<each T>() -> (x: repeat each T) { ... } 
                          // ^~ error: cannot use label with pack expansion tuple element
```