### PR TITLE
[NameLookup] Collect implicit opaque GenericParams

### DIFF
--- a/include/swift/AST/NameLookup.h
+++ b/include/swift/AST/NameLookup.h
@@ -45,7 +45,8 @@ class ASTScopeImpl;
 /// Walk the type representation recursively, collecting any
 /// \c OpaqueReturnTypeRepr, \c CompositionTypeRepr  or \c DeclRefTypeRepr
 /// nodes.
-CollectedOpaqueReprs collectOpaqueReturnTypeReprs(TypeRepr *, ASTContext &ctx, DeclContext *dc);
+CollectedOpaqueReprs collectOpaqueTypeReprs(TypeRepr *, ASTContext &ctx,
+                                            DeclContext *dc);
 
 /// LookupResultEntry - One result of unqualified lookup.
 struct LookupResultEntry {

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -408,7 +408,6 @@ public:
     return {getTrailingObjects<TypeRepr*>(),
             Bits.GenericIdentTypeRepr.NumGenericArgs};
   }
-
   SourceRange getAngleBrackets() const { return AngleBrackets; }
 
   static bool classof(const TypeRepr *T) {

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -125,7 +125,7 @@ public:
   }
 
   /// Is this type representation a protocol?
-  bool isProtocol(DeclContext *dc);
+  bool isProtocolOrProtocolComposition(DeclContext *dc);
 
   /// Is this type representation known to be invalid?
   bool isInvalid() const { return Bits.TypeRepr.Invalid; }
@@ -408,6 +408,7 @@ public:
     return {getTrailingObjects<TypeRepr*>(),
             Bits.GenericIdentTypeRepr.NumGenericArgs};
   }
+
   SourceRange getAngleBrackets() const { return AngleBrackets; }
 
   static bool classof(const TypeRepr *T) {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3301,9 +3301,8 @@ TypeRepr *ValueDecl::getOpaqueResultTypeRepr() const {
   if (returnRepr && returnRepr->hasOpaque()) {
     return returnRepr;
   } else if (returnRepr && ctx.LangOpts.hasFeature(Feature::ImplicitSome)) {
-    auto opaqueReprs = collectOpaqueReturnTypeReprs(returnRepr,
-                                                    getASTContext(),
-                                                    getDeclContext());
+    auto opaqueReprs =
+        collectOpaqueTypeReprs(returnRepr, getASTContext(), getDeclContext());
     return opaqueReprs.empty() ? nullptr : returnRepr;
   } else {
     return nullptr;

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2960,7 +2960,8 @@ createExtensionGenericParams(ASTContext &ctx,
   return toParams;
 }
 
-CollectedOpaqueReprs swift::collectOpaqueReturnTypeReprs(TypeRepr *r, ASTContext &ctx, DeclContext *d) {
+CollectedOpaqueReprs swift::collectOpaqueTypeReprs(TypeRepr *r, ASTContext &ctx,
+                                                   DeclContext *d) {
   class Walker : public ASTWalker {
     CollectedOpaqueReprs &Reprs;
     ASTContext &Ctx;
@@ -3045,7 +3046,7 @@ createOpaqueParameterGenericParams(GenericContext *genericContext, GenericParamL
 
     // Plain protocols should imply 'some' with experimetal feature
     CollectedOpaqueReprs typeReprs;
-    typeReprs = collectOpaqueReturnTypeReprs(typeRepr, ctx, dc);
+    typeReprs = collectOpaqueTypeReprs(typeRepr, ctx, dc);
 
     for (auto repr : typeReprs) {
    

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2924,7 +2924,7 @@ static bool declsAreAssociatedTypes(ArrayRef<TypeDecl *> decls) {
 /// Verify there is at least one protocols in the set of declarations.
 static bool declsAreProtocols(ArrayRef<TypeDecl *> decls) {
   if (decls.empty())
-    return false;
+    return false;  // Below, check outer type repr is a protocol, if not bail early
   return llvm::any_of(decls, [&](const TypeDecl *decl) {
     if (auto *alias = dyn_cast<TypeAliasDecl>(decl)) {
       auto ty = alias->getUnderlyingType();
@@ -2933,14 +2933,12 @@ static bool declsAreProtocols(ArrayRef<TypeDecl *> decls) {
         return false;
     }
     return isa<ProtocolDecl>(decl);
-  });;;
+  });
 }
 
-bool TypeRepr::isProtocol(DeclContext *dc){
+bool TypeRepr::isProtocolOrProtocolComposition(DeclContext *dc){
   auto &ctx = dc->getASTContext();
-  return findIf([&ctx, dc](TypeRepr *ty) {
-    return declsAreProtocols(directReferencesForTypeRepr(ctx.evaluator, ctx, ty, dc));
-  });
+    return declsAreProtocols(directReferencesForTypeRepr(ctx.evaluator, ctx, this, dc));
 }
 
 static GenericParamList *
@@ -2993,15 +2991,19 @@ CollectedOpaqueReprs swift::collectOpaqueReturnTypeReprs(TypeRepr *r, ASTContext
       
       if (auto existential = dyn_cast<ExistentialTypeRepr>(repr)) {
         return Action::SkipChildren();
-      } else if (auto compositionRepr = dyn_cast<CompositionTypeRepr>(repr)) {
-        if (!compositionRepr->isTypeReprAny())
-          Reprs.push_back(compositionRepr);
+      } else if (auto composition = dyn_cast<CompositionTypeRepr>(repr)) {
+        if (!composition->isTypeReprAny())
+          Reprs.push_back(composition);
         return Action::SkipChildren();
       } else if (auto generic = dyn_cast<GenericIdentTypeRepr>(repr)) {
+        if (generic->isProtocolOrProtocolComposition(dc)){
+          Reprs.push_back(generic);
+          return Action::SkipChildren();
+        }
         return Action::Continue();
-      } else if (auto declRefTR = dyn_cast<DeclRefTypeRepr>(repr)) {
-        if (declRefTR->isProtocol(dc))
-          Reprs.push_back(declRefTR);
+      } else if (auto declRef = dyn_cast<DeclRefTypeRepr>(repr)) {
+        if (declRef->isProtocolOrProtocolComposition(dc))
+          Reprs.push_back(declRef);
       }
       return Action::Continue();
     }

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -136,8 +136,8 @@ OpaqueResultTypeRequest::evaluate(Evaluator &evaluator,
       return nullptr;
     }
   } else {
-    opaqueReprs = collectOpaqueReturnTypeReprs(repr, ctx, dc);
-    
+    opaqueReprs = collectOpaqueTypeReprs(repr, ctx, dc);
+
     if (opaqueReprs.empty()) {
       return nullptr;
     }

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -704,7 +704,7 @@ validateTypedPattern(TypedPattern *TP, DeclContext *dc,
   auto *Repr = TP->getTypeRepr();
   if (Repr && (Repr->hasOpaque() ||
                (Context.LangOpts.hasFeature(Feature::ImplicitSome) &&
-                !collectOpaqueReturnTypeReprs(Repr, Context, dc).empty()))) {
+                !collectOpaqueTypeReprs(Repr, Context, dc).empty()))) {
     auto named = dyn_cast<NamedPattern>(
         TP->getSubPattern()->getSemanticsProvidingPattern());
     if (!named) {

--- a/test/type/implicit_some/opaque_parameters.swift
+++ b/test/type/implicit_some/opaque_parameters.swift
@@ -62,10 +62,9 @@ func consumingA(fn: (P) -> Void) { } // expected-error{{'some' cannot appear in 
 func consumingB(fn: FnType<P>) { } // expected-error{{'some' cannot appear in parameter position in parameter type '(P) -> Void'}}
 
 
-// TO-DO Handle plain generic opaque parameters
 func takePrimaryCollections(
-  _ strings:some Collection<String>,
-  _ ints : some Collection<Int>
+  _ strings: Collection<String>,
+  _ ints : Collection<Int>
 ) {
   for s in strings {
     let _: String = s
@@ -75,9 +74,8 @@ func takePrimaryCollections(
     let _: Int = i
   }
 }
-// TO-DO Handle plain generic opaque parameters
 func takeMatchedPrimaryCollections<T: Equatable>(
-  _ first: some Collection<T>, _ second: some Collection<T>
+  _ first: Collection<T>, _ second: Collection<T>
 ) -> Bool {
   first.elementsEqual(second)
 }

--- a/test/type/implicit_some/opaque_return.swift
+++ b/test/type/implicit_some/opaque_return.swift
@@ -125,3 +125,14 @@ enum E {
 protocol Q {
     func f() -> Int
 }
+
+func findBiggerCollection<T : Numeric>( _ first: Collection<T>, _ second: Collection<T>) -> Collection<T> {
+  // expected-error@-1 {{function declares an opaque return type 'Collection<T>', but the return statements in its body do not have matching underlying types}}
+  if (first.count > second.count) { return first } //expected-note {{return statement has underlying type 'Collection<T>'}}
+  return second //expected-note {{return statement has underlying type 'Collection<T>'}}
+}
+
+func createCollection() -> Collection<Int> {
+  let a = [9,2,0]
+  return a
+}


### PR DESCRIPTION
Plain protocols with generic type parameters should be collected as opaque types i.e.  `Collection<T>`

Fixes: rdar://101405496