### PR TITLE
Support initial values for stored properties of `@_objcImplementation`.

### DIFF
--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1332,8 +1332,13 @@ public:
   void visitPatternBindingDecl(PatternBindingDecl *pd) {
     // Emit initializers for static variables.
     for (auto i : range(pd->getNumPatternEntries())) {
-      if (pd->getExecutableInit(i) && pd->isStatic()) {
-        SGM.emitGlobalInitialization(pd, i);
+      if (pd->getExecutableInit(i)) {
+        if (pd->isStatic())
+          SGM.emitGlobalInitialization(pd, i);
+        else if (isa<ExtensionDecl>(pd->getDeclContext()) &&
+                 cast<ExtensionDecl>(pd->getDeclContext())
+                     ->isObjCImplementation())
+          SGM.emitStoredPropertyInitialization(pd, i);
       }
     }
   }

--- a/test/Interpreter/Inputs/objc_implementation.h
+++ b/test/Interpreter/Inputs/objc_implementation.h
@@ -7,6 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 
 @property (assign) NSInteger implProperty;
+@property (assign) NSInteger defaultIntProperty;
 
 + (void)runTests;
 - (nonnull NSString *)someMethod;

--- a/test/Interpreter/objc_implementation.swift
+++ b/test/Interpreter/objc_implementation.swift
@@ -27,6 +27,8 @@ class LastWords {
 
   @objc var implProperty: Int
   final var object: LastWords
+  final weak var defaultNilProperty: AnyObject?
+  @objc var defaultIntProperty: Int = 17
 
   @objc class func runTests() {
     do {
@@ -35,6 +37,7 @@ class LastWords {
       print("implProperty =", impl.implProperty)
       impl.implProperty = 42
       print("implProperty =", impl.implProperty)
+      print("defaultIntProperty =", impl.defaultIntProperty)
       print("description =", impl.description)
     }
 
@@ -44,6 +47,7 @@ class LastWords {
       print("implProperty =", swiftSub.implProperty)
       swiftSub.implProperty = 42
       print("implProperty =", swiftSub.implProperty)
+      print("defaultIntProperty =", swiftSub.defaultIntProperty)
 
       print("otherProperty =", swiftSub.otherProperty)
       swiftSub.otherProperty = 13
@@ -75,11 +79,13 @@ ImplClass.runTests()
 // CHECK: someMethod = ImplClass.someMethod()
 // CHECK: implProperty = 0
 // CHECK: implProperty = 42
+// CHECK: defaultIntProperty = 17
 // CHECK: description = ImplClass(implProperty: 42, object: main.LastWords)
 // CHECK: ImplClass It's better to burn out than to fade away.
 // CHECK: someMethod = SwiftSubclass.someMethod()
 // CHECK: implProperty = 0
 // CHECK: implProperty = 42
+// CHECK: defaultIntProperty = 17
 // CHECK: otherProperty = 1
 // CHECK: otherProperty = 13
 // CHECK: implProperty = 42


### PR DESCRIPTION
Fixes rdar://106108285.
