### PR TITLE
Allow TypeInfoProviders to identify themselves

### DIFF
--- a/include/swift/Remote/TypeInfoProvider.h
+++ b/include/swift/Remote/TypeInfoProvider.h
@@ -17,6 +17,7 @@
 #ifndef SWIFT_REMOTE_TYPEINFOPROVIDER_H
 #define SWIFT_REMOTE_TYPEINFOPROVIDER_H
 
+#include <stdint.h>
 namespace swift {
 namespace reflection {
 class TypeInfo;
@@ -25,6 +26,8 @@ namespace remote {
 
 /// An abstract interface for providing external type layout information.
 struct TypeInfoProvider {
+  using IdType = void *;
+
   virtual ~TypeInfoProvider() = default;
 
   /// Attempt to read type information about (Clang)imported types that are not
@@ -32,6 +35,13 @@ struct TypeInfoProvider {
   /// info, for example.
   virtual const reflection::TypeInfo *
   getTypeInfo(llvm::StringRef mangledName) = 0;
+
+  /// A key that can be used to identify the type info provider (for example, 
+  /// for caching purposes).
+  virtual IdType getId() {
+    // Default implementation is the instance's ID.
+    return (void *) this;
+  }
 };
 
 } // namespace remote

--- a/include/swift/RemoteInspection/TypeLowering.h
+++ b/include/swift/RemoteInspection/TypeLowering.h
@@ -328,7 +328,7 @@ public:
 class TypeConverter {
   TypeRefBuilder &Builder;
   std::vector<std::unique_ptr<const TypeInfo>> Pool;
-  llvm::DenseMap<std::pair<const TypeRef *, remote::TypeInfoProvider *>,
+  llvm::DenseMap<std::pair<const TypeRef *, remote::TypeInfoProvider::IdType>,
                  const TypeInfo *> Cache;
   llvm::DenseSet<const TypeRef *> RecursionCheck;
   llvm::DenseMap<std::pair<unsigned, unsigned>,

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -2584,8 +2584,10 @@ TypeConverter::getTypeInfo(const TypeRef *TR,
     return nullptr;
   }
 
+  auto ExternalTypeInfoId =
+      ExternalTypeInfo ? ExternalTypeInfo->getId() : 0;
   // See if we already computed the result
-  auto found = Cache.find({TR, ExternalTypeInfo});
+  auto found = Cache.find({TR, ExternalTypeInfoId});
   if (found != Cache.end())
     return found->second;
 
@@ -2598,7 +2600,7 @@ TypeConverter::getTypeInfo(const TypeRef *TR,
 
   // Compute the result and cache it
   auto *TI = LowerType(*this, ExternalTypeInfo).visit(TR);
-  Cache.insert({{TR, ExternalTypeInfo}, TI});
+  Cache.insert({{TR, ExternalTypeInfoId}, TI});
 
   RecursionCheck.erase(TR);
 


### PR DESCRIPTION
TypeInfoProvider's address was used as part of the key to cache type infos. This can cause the unnecessary recomputation of type infos, as different instances of TypeInfoProviders may provide the exact same type infos. Allow TypeInfoProviders to provide an id which can be used for caching purposes.

rdar://80001304
