### PR TITLE
[Serialization] Package imports

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -794,13 +794,11 @@ public:
     /// Include imports declared with `@_implementationOnly` or with an
     /// access-level of `package` or less.
     ImplementationOnly = 1 << 2,
-    /// Include imports of SPIs declared with `@_spi`.
-    SPIAccessControl = 1 << 3,
     /// Include imports declared with `@_spiOnly`.
-    SPIOnly = 1 << 4,
+    SPIOnly = 1 << 3,
     /// Include imports shadowed by a cross-import overlay. Unshadowed imports
     /// are included whether or not this flag is specified.
-    ShadowedByCrossImportOverlay = 1 << 5
+    ShadowedByCrossImportOverlay = 1 << 4
   };
   /// \sa getImportedModules
   using ImportFilter = OptionSet<ImportFilterKind>;

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -789,16 +789,18 @@ public:
   enum class ImportFilterKind {
     /// Include imports declared with `@_exported`.
     Exported = 1 << 0,
-    /// Include "regular" imports with no special annotation.
+    /// Include "regular" imports with an access-level of `public`.
     Default = 1 << 1,
     /// Include imports declared with `@_implementationOnly` or with an
     /// access-level of `package` or less.
     ImplementationOnly = 1 << 2,
+    /// Include imports declared with `package import`.
+    PackageOnly = 1 << 3,
     /// Include imports declared with `@_spiOnly`.
-    SPIOnly = 1 << 3,
+    SPIOnly = 1 << 4,
     /// Include imports shadowed by a cross-import overlay. Unshadowed imports
     /// are included whether or not this flag is specified.
-    ShadowedByCrossImportOverlay = 1 << 4
+    ShadowedByCrossImportOverlay = 1 << 5
   };
   /// \sa getImportedModules
   using ImportFilter = OptionSet<ImportFilterKind>;

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -396,6 +396,9 @@ namespace swift {
     /// Access or distribution level of the whole module being parsed.
     LibraryLevel LibraryLevel = LibraryLevel::Other;
 
+    /// The name of the package this module belongs to.
+    std::string PackageName;
+
     /// Warn about cases where Swift 3 would infer @objc but later versions
     /// of Swift do not.
     Swift3ObjCInferenceWarnings WarnSwift3ObjCInference =

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -64,9 +64,6 @@ public:
   /// The name of the library to link against when using this module.
   std::string ModuleLinkName;
 
-  /// The name of the package this module belongs to.
-  std::string PackageName;
-
   /// Module name to use when referenced in clients module interfaces.
   std::string ExportAsName;
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -5544,7 +5544,6 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
     // For the current module, consider both private and public imports.
     ModuleDecl::ImportFilter Filter = ModuleDecl::ImportFilterKind::Exported;
     Filter |= ModuleDecl::ImportFilterKind::Default;
-    Filter |= ModuleDecl::ImportFilterKind::SPIAccessControl;
     SmallVector<ImportedModule, 4> Imports;
     Options.CurrentModule->getImportedModules(Imports, Filter);
 

--- a/lib/AST/ImportCache.cpp
+++ b/lib/AST/ImportCache.cpp
@@ -195,6 +195,7 @@ ImportSet &ImportCache::getImportSet(const DeclContext *dc) {
     file->getImportedModules(imports,
                              {ModuleDecl::ImportFilterKind::Default,
                               ModuleDecl::ImportFilterKind::ImplementationOnly,
+                              ModuleDecl::ImportFilterKind::PackageOnly,
                               ModuleDecl::ImportFilterKind::SPIOnly});
   }
 
@@ -279,6 +280,7 @@ ImportCache::getAllAccessPathsNotShadowedBy(const ModuleDecl *mod,
     file->getImportedModules(stack,
                              {ModuleDecl::ImportFilterKind::Default,
                               ModuleDecl::ImportFilterKind::ImplementationOnly,
+                              ModuleDecl::ImportFilterKind::PackageOnly,
                               ModuleDecl::ImportFilterKind::SPIOnly});
   }
 

--- a/lib/AST/ImportCache.cpp
+++ b/lib/AST/ImportCache.cpp
@@ -195,8 +195,7 @@ ImportSet &ImportCache::getImportSet(const DeclContext *dc) {
     file->getImportedModules(imports,
                              {ModuleDecl::ImportFilterKind::Default,
                               ModuleDecl::ImportFilterKind::ImplementationOnly,
-                              ModuleDecl::ImportFilterKind::SPIOnly,
-                              ModuleDecl::ImportFilterKind::SPIAccessControl});
+                              ModuleDecl::ImportFilterKind::SPIOnly});
   }
 
   auto &result = getImportSet(ctx, imports);
@@ -280,8 +279,7 @@ ImportCache::getAllAccessPathsNotShadowedBy(const ModuleDecl *mod,
     file->getImportedModules(stack,
                              {ModuleDecl::ImportFilterKind::Default,
                               ModuleDecl::ImportFilterKind::ImplementationOnly,
-                              ModuleDecl::ImportFilterKind::SPIOnly,
-                              ModuleDecl::ImportFilterKind::SPIAccessControl});
+                              ModuleDecl::ImportFilterKind::SPIOnly});
   }
 
   SmallVector<ImportPath::Access, 4> accessPaths;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1906,8 +1906,6 @@ SourceFile::getImportedModules(SmallVectorImpl<ImportedModule> &modules,
       requiredFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
     else if (desc.options.contains(ImportFlags::SPIOnly))
       requiredFilter |= ModuleDecl::ImportFilterKind::SPIOnly;
-    else if (desc.options.contains(ImportFlags::SPIAccessControl))
-      requiredFilter |= ModuleDecl::ImportFilterKind::SPIAccessControl;
     else
       requiredFilter |= ModuleDecl::ImportFilterKind::Default;
 
@@ -2271,8 +2269,7 @@ SourceFile::collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const
 
   ModuleDecl::ImportFilter filter = {
       ModuleDecl::ImportFilterKind::Exported,
-      ModuleDecl::ImportFilterKind::Default,
-      ModuleDecl::ImportFilterKind::SPIAccessControl};
+      ModuleDecl::ImportFilterKind::Default};
 
   auto *topLevel = getParentModule();
 
@@ -2985,7 +2982,6 @@ bool ModuleDecl::isImportedImplementationOnly(const ModuleDecl *module) const {
   ModuleDecl::ImportFilter filter = {
     ModuleDecl::ImportFilterKind::Exported,
     ModuleDecl::ImportFilterKind::Default,
-    ModuleDecl::ImportFilterKind::SPIAccessControl,
     ModuleDecl::ImportFilterKind::ShadowedByCrossImportOverlay};
   SmallVector<ImportedModule, 4> results;
   getImportedModules(results, filter);
@@ -3011,8 +3007,7 @@ canBeUsedForCrossModuleOptimization(DeclContext *ctxt) const {
   // @_implementationOnly or @_spi.
   ModuleDecl::ImportFilter filter = {
     ModuleDecl::ImportFilterKind::ImplementationOnly,
-    ModuleDecl::ImportFilterKind::SPIOnly,
-    ModuleDecl::ImportFilterKind::SPIAccessControl
+    ModuleDecl::ImportFilterKind::SPIOnly
   };
   SmallVector<ImportedModule, 4> results;
   getImportedModules(results, filter);

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1902,8 +1902,10 @@ SourceFile::getImportedModules(SmallVectorImpl<ImportedModule> &modules,
     if (desc.options.contains(ImportFlags::Exported))
       requiredFilter |= ModuleDecl::ImportFilterKind::Exported;
     else if (desc.options.contains(ImportFlags::ImplementationOnly) ||
-             (desc.accessLevel <= AccessLevel::Package && moduleIsResilient))
+             (desc.accessLevel <= AccessLevel::Internal && moduleIsResilient))
       requiredFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
+    else if (desc.accessLevel <= AccessLevel::Package && moduleIsResilient)
+      requiredFilter |= ModuleDecl::ImportFilterKind::PackageOnly;
     else if (desc.options.contains(ImportFlags::SPIOnly))
       requiredFilter |= ModuleDecl::ImportFilterKind::SPIOnly;
     else
@@ -2275,6 +2277,7 @@ SourceFile::collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const
 
   ModuleDecl::ImportFilter topLevelFilter = filter;
   topLevelFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
+  topLevelFilter |= ModuleDecl::ImportFilterKind::PackageOnly,
   topLevelFilter |= ModuleDecl::ImportFilterKind::SPIOnly;
   topLevel->getImportedModules(stack, topLevelFilter);
 
@@ -2982,6 +2985,8 @@ bool ModuleDecl::isImportedImplementationOnly(const ModuleDecl *module) const {
   ModuleDecl::ImportFilter filter = {
     ModuleDecl::ImportFilterKind::Exported,
     ModuleDecl::ImportFilterKind::Default,
+    ModuleDecl::ImportFilterKind::PackageOnly,
+    ModuleDecl::ImportFilterKind::SPIOnly,
     ModuleDecl::ImportFilterKind::ShadowedByCrossImportOverlay};
   SmallVector<ImportedModule, 4> results;
   getImportedModules(results, filter);
@@ -3004,9 +3009,10 @@ canBeUsedForCrossModuleOptimization(DeclContext *ctxt) const {
     return true;
 
   // See if context is imported in a "regular" way, i.e. not with
-  // @_implementationOnly or @_spi.
+  // @_implementationOnly, `package import` or @_spiOnly.
   ModuleDecl::ImportFilter filter = {
     ModuleDecl::ImportFilterKind::ImplementationOnly,
+    ModuleDecl::ImportFilterKind::PackageOnly,
     ModuleDecl::ImportFilterKind::SPIOnly
   };
   SmallVector<ImportedModule, 4> results;

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -269,16 +269,6 @@ bool ArgsToFrontendOptionsConverter::convert(
   if (const Arg *A = Args.getLastArg(OPT_module_link_name))
     Opts.ModuleLinkName = A->getValue();
 
-  if (const Arg *A = Args.getLastArg(OPT_package_name)) {
-    auto pkgName = A->getValue();
-    if (!Lexer::isIdentifier(pkgName))
-      Diags.diagnose(SourceLoc(), diag::error_bad_package_name, pkgName);
-    else if (pkgName == STDLIB_NAME)
-      Diags.diagnose(SourceLoc(), diag::error_stdlib_package_name, pkgName);
-    else
-      Opts.PackageName = pkgName;
-  }
-
   if (const Arg *A = Args.getLastArg(OPT_export_as)) {
     auto exportAs = A->getValue();
     if (!Lexer::isIdentifier(exportAs))

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -739,6 +739,16 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  if (const Arg *A = Args.getLastArg(OPT_package_name)) {
+    auto pkgName = A->getValue();
+    if (!Lexer::isIdentifier(pkgName))
+      Diags.diagnose(SourceLoc(), diag::error_bad_package_name, pkgName);
+    else if (pkgName == STDLIB_NAME)
+      Diags.diagnose(SourceLoc(), diag::error_stdlib_package_name, pkgName);
+    else
+      Opts.PackageName = pkgName;
+  }
+
   if (const Arg *A = Args.getLastArg(OPT_require_explicit_availability_EQ)) {
     StringRef diagLevel = A->getValue();
     if (diagLevel == "warn") {

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -1088,9 +1088,9 @@ ModuleDecl *CompilerInstance::getMainModule() const {
       MainModule->setABIName(getASTContext().getIdentifier(
           Invocation.getFrontendOptions().ModuleABIName));
     }
-    if (!Invocation.getFrontendOptions().PackageName.empty()) {
+    if (!Invocation.getLangOptions().PackageName.empty()) {
       MainModule->setPackageName(getASTContext().getIdentifier(
-          Invocation.getFrontendOptions().PackageName));
+          Invocation.getLangOptions().PackageName));
     }
     if (!Invocation.getFrontendOptions().ExportAsName.empty()) {
       MainModule->setExportAsName(getASTContext().getIdentifier(

--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -70,8 +70,7 @@ static void printToolVersionAndFlagsComment(raw_ostream &out,
            moduleName << "=" << moduleName;
 
     ModuleDecl::ImportFilter filter = {ModuleDecl::ImportFilterKind::Default,
-                           ModuleDecl::ImportFilterKind::Exported,
-                           ModuleDecl::ImportFilterKind::SPIAccessControl};
+                                       ModuleDecl::ImportFilterKind::Exported};
     if (Opts.PrintPrivateInterfaceContent)
       filter |= ModuleDecl::ImportFilterKind::SPIOnly;
 
@@ -228,8 +227,7 @@ static void printImports(raw_ostream &out,
   // it's not obvious what higher-level optimization would be factored out here.
   ModuleDecl::ImportFilter allImportFilter = {
       ModuleDecl::ImportFilterKind::Exported,
-      ModuleDecl::ImportFilterKind::Default,
-      ModuleDecl::ImportFilterKind::SPIAccessControl};
+      ModuleDecl::ImportFilterKind::Default};
 
   // With -experimental-spi-imports:
   // When printing the private swiftinterface file, print implementation-only

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -85,8 +85,7 @@ bool swift::emitImportedModules(ModuleDecl *mainModule,
       clangImporter->getImportedHeaderModule()->getImportedModules(
           imported, {ModuleDecl::ImportFilterKind::Exported,
                      ModuleDecl::ImportFilterKind::Default,
-                     ModuleDecl::ImportFilterKind::ImplementationOnly,
-                     ModuleDecl::ImportFilterKind::SPIAccessControl});
+                     ModuleDecl::ImportFilterKind::ImplementationOnly});
 
       for (auto IM : imported) {
         if (auto clangModule = IM.importedModule->findUnderlyingClangModule())

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -85,7 +85,9 @@ bool swift::emitImportedModules(ModuleDecl *mainModule,
       clangImporter->getImportedHeaderModule()->getImportedModules(
           imported, {ModuleDecl::ImportFilterKind::Exported,
                      ModuleDecl::ImportFilterKind::Default,
-                     ModuleDecl::ImportFilterKind::ImplementationOnly});
+                     ModuleDecl::ImportFilterKind::ImplementationOnly,
+                     ModuleDecl::ImportFilterKind::PackageOnly,
+                     ModuleDecl::ImportFilterKind::SPIOnly});
 
       for (auto IM : imported) {
         if (auto clangModule = IM.importedModule->findUnderlyingClangModule())

--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -113,7 +113,6 @@ static void getImmediateImports(
         ModuleDecl::ImportFilterKind::Exported,
         ModuleDecl::ImportFilterKind::Default,
         ModuleDecl::ImportFilterKind::ImplementationOnly,
-        ModuleDecl::ImportFilterKind::SPIAccessControl,
         ModuleDecl::ImportFilterKind::ShadowedByCrossImportOverlay}) {
   SmallVector<ImportedModule, 8> importList;
   module->getImportedModules(importList, importFilter);

--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -113,6 +113,8 @@ static void getImmediateImports(
         ModuleDecl::ImportFilterKind::Exported,
         ModuleDecl::ImportFilterKind::Default,
         ModuleDecl::ImportFilterKind::ImplementationOnly,
+        ModuleDecl::ImportFilterKind::PackageOnly,
+        ModuleDecl::ImportFilterKind::SPIOnly,
         ModuleDecl::ImportFilterKind::ShadowedByCrossImportOverlay}) {
   SmallVector<ImportedModule, 8> importList;
   module->getImportedModules(importList, importFilter);

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1388,7 +1388,6 @@ void swift::ide::deliverCompletionResults(
                        ModuleDecl::ImportFilterKind::Exported,
                        ModuleDecl::ImportFilterKind::Default,
                        ModuleDecl::ImportFilterKind::ImplementationOnly,
-                       ModuleDecl::ImportFilterKind::SPIAccessControl,
                    });
 
       for (auto Imported : Imports) {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1388,6 +1388,8 @@ void swift::ide::deliverCompletionResults(
                        ModuleDecl::ImportFilterKind::Exported,
                        ModuleDecl::ImportFilterKind::Default,
                        ModuleDecl::ImportFilterKind::ImplementationOnly,
+                       ModuleDecl::ImportFilterKind::PackageOnly,
+                       ModuleDecl::ImportFilterKind::SPIOnly,
                    });
 
       for (auto Imported : Imports) {

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1810,7 +1810,6 @@ swift::getDisallowedOriginKind(const Decl *decl,
     auto filter = ModuleDecl::ImportFilter(
         {ModuleDecl::ImportFilterKind::Exported,
          ModuleDecl::ImportFilterKind::Default,
-         ModuleDecl::ImportFilterKind::SPIAccessControl,
          ModuleDecl::ImportFilterKind::ShadowedByCrossImportOverlay});
     SmallVector<ImportedModule, 4> sfImportedModules;
     SF->getImportedModules(sfImportedModules, filter);

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -209,6 +209,10 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc,
       continue;
     }
 
+    if (dependency.isPackageOnly() &&
+        ctx.LangOpts.PackageName != this->getModulePackageName())
+      continue;
+
     ImportPath::Builder builder(ctx, dependency.Core.RawPath,
                                 /*separator=*/'\0');
     for (const auto &elem : builder) {

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -107,6 +107,9 @@ public:
     bool isImplementationOnly() const {
       return Core.isImplementationOnly();
     }
+    bool isPackageOnly() const {
+      return Core.isPackageOnly();
+    }
 
     bool isHeader() const { return Core.isHeader(); }
     bool isScoped() const { return Core.isScoped(); }

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -1021,6 +1021,8 @@ getActualImportControl(unsigned rawValue) {
     return ModuleDecl::ImportFilterKind::Exported;
   case static_cast<unsigned>(serialization::ImportControl::ImplementationOnly):
     return ModuleDecl::ImportFilterKind::ImplementationOnly;
+  case static_cast<unsigned>(serialization::ImportControl::PackageOnly):
+    return ModuleDecl::ImportFilterKind::PackageOnly;
   default:
     return None;
   }

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -150,6 +150,9 @@ public:
     bool isImplementationOnly() const {
       return getImportControl() == ImportFilterKind::ImplementationOnly;
     }
+    bool isPackageOnly() const {
+      return getImportControl() == ImportFilterKind::PackageOnly;
+    }
 
     bool isHeader() const { return IsHeader; }
     bool isScoped() const { return IsScoped; }
@@ -555,6 +558,10 @@ public:
   /// The name of the module.
   StringRef getName() const {
     return Name;
+  }
+
+  StringRef getModulePackageName() const {
+    return ModulePackageName;
   }
 
   /// Returns the list of modules this module depends on.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 750; // serialize param specifiers into ParamTypeFlags
+const uint16_t SWIFTMODULE_VERSION_MINOR = 751; // package only import
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -584,7 +584,9 @@ enum class ImportControl : uint8_t {
   /// `@_exported import FooKit`
   Exported,
   /// `@_uncheckedImplementationOnly import FooKit`
-  ImplementationOnly
+  ImplementationOnly,
+  /// `package import FooKit`
+  PackageOnly
 };
 using ImportControlField = BCFixed<2>;
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1214,8 +1214,7 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   M->getImportedModules(allImports,
                         {ModuleDecl::ImportFilterKind::Exported,
                          ModuleDecl::ImportFilterKind::Default,
-                         ModuleDecl::ImportFilterKind::ImplementationOnly,
-                         ModuleDecl::ImportFilterKind::SPIAccessControl});
+                         ModuleDecl::ImportFilterKind::ImplementationOnly});
   ImportedModule::removeDuplicates(allImports);
 
   // Collect the public and private imports as a subset so that we can
@@ -1224,8 +1223,6 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
       getImportsAsSet(M, ModuleDecl::ImportFilterKind::Exported);
   ImportSet privateImportSet =
       getImportsAsSet(M, ModuleDecl::ImportFilterKind::Default);
-  ImportSet spiImportSet =
-      getImportsAsSet(M, ModuleDecl::ImportFilterKind::SPIAccessControl);
 
   auto clangImporter =
     static_cast<ClangImporter *>(M->getASTContext().getClangModuleLoader());
@@ -1271,7 +1268,7 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
     // form here.
     if (publicImportSet.count(import))
       stableImportControl = ImportControl::Exported;
-    else if (privateImportSet.count(import) || spiImportSet.count(import))
+    else if (privateImportSet.count(import))
       stableImportControl = ImportControl::Normal;
     else
       stableImportControl = ImportControl::ImplementationOnly;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1214,7 +1214,8 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   M->getImportedModules(allImports,
                         {ModuleDecl::ImportFilterKind::Exported,
                          ModuleDecl::ImportFilterKind::Default,
-                         ModuleDecl::ImportFilterKind::ImplementationOnly});
+                         ModuleDecl::ImportFilterKind::ImplementationOnly,
+                         ModuleDecl::ImportFilterKind::PackageOnly});
   ImportedModule::removeDuplicates(allImports);
 
   // Collect the public and private imports as a subset so that we can
@@ -1223,6 +1224,8 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
       getImportsAsSet(M, ModuleDecl::ImportFilterKind::Exported);
   ImportSet privateImportSet =
       getImportsAsSet(M, ModuleDecl::ImportFilterKind::Default);
+  ImportSet packageOnlyImportSet =
+      getImportsAsSet(M, ModuleDecl::ImportFilterKind::PackageOnly);
 
   auto clangImporter =
     static_cast<ClangImporter *>(M->getASTContext().getClangModuleLoader());
@@ -1270,6 +1273,8 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
       stableImportControl = ImportControl::Exported;
     else if (privateImportSet.count(import))
       stableImportControl = ImportControl::Normal;
+    else if (packageOnlyImportSet.count(import))
+      stableImportControl = ImportControl::PackageOnly;
     else
       stableImportControl = ImportControl::ImplementationOnly;
 

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -426,6 +426,10 @@ llvm::ErrorOr<ModuleDependencyInfo> SerializedModuleLoaderBase::scanModuleFile(
     if (dependency.isImplementationOnly())
       continue;
 
+    if (dependency.isPackageOnly() &&
+        Ctx.LangOpts.PackageName != loadedModuleFile->getModulePackageName())
+      continue;
+
     // Find the top-level module name.
     auto modulePathStr = dependency.getPrettyPrintedPath();
     StringRef moduleName = modulePathStr;

--- a/test/Sema/package-only-references.swift
+++ b/test/Sema/package-only-references.swift
@@ -1,0 +1,56 @@
+/// Simple use case of a package only import.
+
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Build the libraries.
+// RUN: %target-swift-frontend -emit-module %t/PackageImportedLib.swift -o %t \
+// RUN:   -swift-version 5 -enable-library-evolution \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -emit-module %t/PackageLib.swift -o %t \
+// RUN:   -swift-version 5 -enable-library-evolution -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport \
+// RUN:   -package-name MyPackage
+
+/// A client in the same package builds fine.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -package-name MyPackage -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+
+/// A client outside of the package raises errors.
+// RUN: %target-swift-frontend -typecheck %t/Client.swift -I %t \
+// RUN:   -package-name NotMyPackage -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport -verify
+
+//--- PackageImportedLib.swift
+public struct IndirectType {
+    public init() {}
+    public func someMethod() {}
+}
+public protocol IndirectProtocol {}
+
+//--- PackageLib.swift
+package import PackageImportedLib
+
+package func getIndirectType() -> IndirectType {
+    return IndirectType()
+}
+
+package func packageFunc(a: IndirectType) {
+}
+
+package struct PackageStruct : IndirectProtocol {
+    package init() {}
+
+    package var a = IndirectType()
+}
+
+//--- Client.swift
+public import PackageLib
+
+let t = getIndirectType() // expected-error {{cannot find 'getIndirectType' in scope}}
+t.someMethod()
+packageFunc(a: t) // expected-error {{cannot find 'packageFunc' in scope}}
+
+let s = PackageStruct() // expected-error {{cannot find 'PackageStruct' in scope}}
+s.a.someMethod()

--- a/test/Serialization/access-level-import-dependencies.swift
+++ b/test/Serialization/access-level-import-dependencies.swift
@@ -29,7 +29,7 @@ private import HiddenDep
 // RUN:   -enable-library-evolution \
 // RUN:   -enable-experimental-feature AccessLevelOnImport
 // RUN: %target-swift-frontend -emit-module %t/PackageDep.swift -o %t -I %t \
-// RUN:   -enable-library-evolution \
+// RUN:   -enable-library-evolution -package-name MyPackage \
 // RUN:   -enable-experimental-feature AccessLevelOnImport
 // RUN: %target-swift-frontend -emit-module %t/InternalDep.swift -o %t -I %t \
 // RUN:   -enable-library-evolution \
@@ -42,6 +42,7 @@ private import HiddenDep
 // RUN:   -enable-experimental-feature AccessLevelOnImport
 
 // RUN: %target-swift-frontend -typecheck %t/ClientOfPublic.swift -I %t \
+// RUN:   -enable-library-evolution -package-name MyOtherPackage \
 // RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-HIDDEN-DEP %s
 // VISIBLE-HIDDEN-DEP: source: '{{.*}}HiddenDep.swiftmodule'
 //--- ClientOfPublic.swift

--- a/test/Serialization/package-dependencies.swift
+++ b/test/Serialization/package-dependencies.swift
@@ -1,0 +1,47 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+/// Prepare the module imported as package, and two middle modules.
+// RUN: %target-swift-frontend -emit-module %t/PackageDep.swift -o %t
+// RUN: %target-swift-frontend -emit-module %t/ResilientDep.swift -o %t \
+// RUN:   -package-name MyPackage -I %t \
+// RUN:   -enable-library-evolution \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -emit-module %t/NonResilientDep.swift -o %t \
+// RUN:   -package-name MyPackage -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+
+//--- PackageDep.swift
+
+//--- ResilientDep.swift
+package import PackageDep
+
+//--- NonResilientDep.swift
+package import PackageDep
+
+/// When the middle module is library-evolution enabled, the package import
+/// is only visible to modules from the same package.
+// RUN: %target-swift-frontend -typecheck %t/ResilientClient.swift \
+// RUN:   -package-name MyPackage -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport \
+// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-PACKAGE-DEP %s
+// VISIBLE-PACKAGE-DEP: source: '{{.*}}PackageDep.swiftmodule'
+
+// RUN: %target-swift-frontend -typecheck %t/ResilientClient.swift \
+// RUN:   -package-name NotMyPackage -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport \
+// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=HIDDEN-PACKAGE-DEP %s
+// HIDDEN-PACKAGE-DEP-NOT: PackageDep
+
+//--- ResilientClient.swift
+import ResilientDep
+
+/// When the middle module isn't library-evolution enabled, all clients
+/// see the package dependency.
+// RUN: %target-swift-frontend -typecheck %t/NonResilientClient.swift \
+// RUN:   -package-name NotMyPackage -I %t \
+// RUN:   -enable-experimental-feature AccessLevelOnImport \
+// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-PACKAGE-DEP %s
+
+//--- NonResilientClient.swift
+import NonResilientDep


### PR DESCRIPTION
This PR completes the support for package-only imports, aka package imports as it's spelled in source code with `package import SomePackageDependency`. Package imports allow modules from a same package to have a shared dependency on a package-internal module, which enables `package` decls to refer to types from that module.

Previous PRs have added exportability checks for package imported decls (#64014 & #64033) and #63974 ensured that package imports are not printed in swiftinterfaces. This PR adds support for package imported dependencies in swiftmodule files.

The new behavior applies when loading a swiftmodule, let's say for module A, the compiler reads its package membership information to tell if the current client should load A's dependencies imported by a package import. Only clients belonging to the same package as A should load those dependencies, clients outside of the package likely don't have access to those dependencies. This applies only if A enabled library-evolution, without it all clients load the package dependencies.

See the following test for a typical use case of package import: [test/Sema/package-only-references.swift](https://github.com/apple/swift/compare/main...xymus:swift:package-only-imports?expand=1#diff-f2291a4bc2bde7a393f1ceb3287cc67d08a80eb627f5741a5e30bf4654bc4e88)

rdar://106164813