### PR TITLE
Fix PrunedLiveness.empty() to consider the users.

### DIFF
--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -484,7 +484,9 @@ public:
 
   bool empty() const {
     assert(!liveBlocks.empty() || users.empty());
-    return liveBlocks.empty();
+    // There may be a liveBlock created by initializeDefBlock with no users. The
+    // true test of emptiness is whether there are any users.
+    return users.empty();
   }
 
   void clear() {

--- a/lib/SIL/Utils/OSSALifetimeCompletion.cpp
+++ b/lib/SIL/Utils/OSSALifetimeCompletion.cpp
@@ -15,8 +15,8 @@
 ///
 /// Interior liveness handles the following cases naturally:
 ///
-/// When completing the lifetime if the initial value, %v1, transitively
-/// include all dominated reborrows. %phi1 in this example:
+/// When completing the lifetime of the initial value, %v1, transitively
+/// include all uses of dominated reborrows as, such as %phi1 in this example:
 ///
 ///     %v1 = ...
 ///     cond_br bb1, bb2
@@ -31,8 +31,8 @@
 ///     end_borrow %phi1
 ///     %k1 = destroy_value %v1 // must be below end_borrow %phi1
 ///
-/// When completing the lifetime for a (%phi2) transitively include all inner
-/// adjacent reborrows (%phi1):
+/// When completing the lifetime for a phi (%phi2) transitively include all
+/// uses of inner adjacent reborrows, such as %phi1 in this example:
 ///
 ///   bb1:
 ///     %v1 = ...


### PR DESCRIPTION
I hit the issue with PrunedLiveness.empty() several months ago during development on a branch, but never had a test case. The comment explains why this is the obviously correct implementation though, so better to just fix it.