### PR TITLE
Ensure the install of the libObservationMacros.dylib is housed in lib/swift/host/plugins

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/CMakeLists.txt
+++ b/lib/Macros/Sources/ObservationMacros/CMakeLists.txt
@@ -118,15 +118,15 @@ if (SWIFT_SWIFT_PARSER)
   # Ensure the install directory exists before everything gets started
   add_custom_command(
       TARGET ObservationMacros PRE_BUILD
-      COMMAND ${CMAKE_COMMAND} -E make_directory "lib${LLVM_LIBDIR_SUFFIX}/host/plugins"
+      COMMAND ${CMAKE_COMMAND} -E make_directory "lib${LLVM_LIBDIR_SUFFIX}/swift/host/plugins"
   )
 
   swift_install_in_component(TARGETS ObservationMacros
     LIBRARY
-      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/host/plugins"
+      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/plugins"
       COMPONENT compiler
     ARCHIVE
-      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/host/plugins"
+      DESTINATION "lib${LLVM_LIBDIR_SUFFIX}/swift/host/plugins"
       COMPONENT compiler)
 
   set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ObservationMacros)


### PR DESCRIPTION
There was a slight misstep in the cmake install phase for the ObservationMacros compiler plugin that was attempting to install to lib/host/plugins instead of lib/swift/host/plugins. This corrects that by using one parameter for the install path.