### PR TITLE
Only mangle `borrowing`/`consuming` when they would change ABI.

### DIFF
--- a/include/swift/AST/AnyFunctionRef.h
+++ b/include/swift/AST/AnyFunctionRef.h
@@ -304,8 +304,8 @@ private:
           if (mapIntoContext)
             valueTy = AD->mapTypeIntoContext(valueTy);
           YieldTypeFlags flags(AD->getAccessorKind() == AccessorKind::Modify
-                                 ? ValueOwnership::InOut
-                                 : ValueOwnership::Shared);
+                                 ? ParamSpecifier::InOut
+                                 : ParamSpecifier::LegacyShared);
           buffer.push_back(AnyFunctionType::Yield(valueTy, flags));
           return buffer;
         }

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -5986,29 +5986,6 @@ public:
   }
 };
 
-/// The various spellings of ownership modifier that can be used in source.
-enum class ParamSpecifier : uint8_t {
-  /// No explicit ownership specifier was provided. The parameter will use the
-  /// default ownership convention for the declaration.
-  Default = 0,
-
-  /// `inout`, indicating exclusive mutable access to the argument for the
-  /// duration of a call.
-  InOut = 1,
-
-  /// `borrowing`, indicating nonexclusive access to the argument for the
-  /// duration of a call.
-  Borrowing = 2,
-  /// `consuming`, indicating ownership transfer of the argument from caller
-  /// to callee.
-  Consuming = 3,
-
-  /// `__shared`, a legacy spelling of `borrowing`.
-  LegacyShared = 4,
-  /// `__owned`, a legacy spelling of `consuming`.
-  LegacyOwned = 5,
-};
-
 /// A function parameter declaration.
 class ParamDecl : public VarDecl {
   friend class DefaultArgumentInitContextRequest;
@@ -6373,6 +6350,16 @@ public:
   /// Get the source code spelling of a parameter specifier value as a string.
   static StringRef getSpecifierSpelling(Specifier spec);
 };
+  
+inline ValueOwnership
+ParameterTypeFlags::getValueOwnership() const {
+  return ParamDecl::getValueOwnershipForSpecifier(getOwnershipSpecifier());
+}
+  
+inline ValueOwnership
+YieldTypeFlags::getValueOwnership() const {
+  return ParamDecl::getValueOwnershipForSpecifier(getOwnershipSpecifier());
+}
   
 /// Describes the kind of subscripting used in Objective-C.
 enum class ObjCSubscriptKind {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3488,11 +3488,13 @@ AnyFunctionType::Param swift::computeSelfParam(AbstractFunctionDecl *AFD,
   auto flags = ParameterTypeFlags().withIsolated(isIsolated);
   switch (selfAccess) {
   case SelfAccessKind::LegacyConsuming:
+    flags = flags.withOwnershipSpecifier(ParamSpecifier::LegacyOwned);
+    break;
   case SelfAccessKind::Consuming:
-    flags = flags.withValueOwnership(ValueOwnership::Owned);
+    flags = flags.withOwnershipSpecifier(ParamSpecifier::Consuming);
     break;
   case SelfAccessKind::Borrowing:
-    flags = flags.withValueOwnership(ValueOwnership::Shared);
+    flags = flags.withOwnershipSpecifier(ParamSpecifier::Borrowing);
     break;
   case SelfAccessKind::Mutating:
     flags = flags.withInOut(true);

--- a/lib/AST/ASTDemangler.cpp
+++ b/lib/AST/ASTDemangler.cpp
@@ -380,9 +380,10 @@ Type ASTBuilder::createFunctionType(
 
     auto label = Ctx.getIdentifier(param.getLabel());
     auto flags = param.getFlags();
-    auto ownership = flags.getValueOwnership();
+    auto ownership =
+      ParamDecl::getParameterSpecifierForValueOwnership(flags.getValueOwnership());
     auto parameterFlags = ParameterTypeFlags()
-                              .withValueOwnership(ownership)
+                              .withOwnershipSpecifier(ownership)
                               .withVariadic(flags.isVariadic())
                               .withAutoClosure(flags.isAutoClosure())
                               .withNoDerivative(flags.isNoDerivative());

--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -693,9 +693,9 @@ namespace {
 
     template <class G>
     void addParameter(const G &generator,
-                      ValueOwnership ownership = ValueOwnership::Default) {
+                      ParamSpecifier ownership = ParamSpecifier::Default) {
       Type gTyIface = generator.build(*this);
-      auto flags = ParameterTypeFlags().withValueOwnership(ownership);
+      auto flags = ParameterTypeFlags().withOwnershipSpecifier(ownership);
       InterfaceParams.emplace_back(gTyIface, Identifier(), flags);
     }
 
@@ -1097,20 +1097,20 @@ static ValueDecl *getAtomicStoreOperation(ASTContext &ctx, Identifier id,
 static ValueDecl *getNativeObjectCast(ASTContext &Context, Identifier Id,
                                       BuiltinValueKind BV) {
 
-  ValueOwnership ownership;
+  ParamSpecifier ownership;
   Type builtinTy;
   switch (BV) {
   case BuiltinValueKind::CastToNativeObject:
   case BuiltinValueKind::UnsafeCastToNativeObject:
   case BuiltinValueKind::CastFromNativeObject:
     builtinTy = Context.TheNativeObjectType;
-    ownership = ValueOwnership::Owned;
+    ownership = ParamSpecifier::LegacyOwned;
     break;
 
   case BuiltinValueKind::BridgeToRawPointer:
   case BuiltinValueKind::BridgeFromRawPointer:
     builtinTy = Context.TheRawPointerType;
-    ownership = ValueOwnership::Default;
+    ownership = ParamSpecifier::Default;
     break;
 
   default:
@@ -1208,7 +1208,7 @@ static ValueDecl *getCastReferenceOperation(ASTContext &ctx,
   // <T, U> T -> U
   // SILGen and IRGen check additional constraints during lowering.
   BuiltinFunctionBuilder builder(ctx, 2);
-  builder.addParameter(makeGenericParam(0), ValueOwnership::Owned);
+  builder.addParameter(makeGenericParam(0), ParamSpecifier::LegacyOwned);
   builder.setResult(makeGenericParam(1));
   return builder.build(name);
 }
@@ -1218,7 +1218,7 @@ static ValueDecl *getReinterpretCastOperation(ASTContext &ctx,
   // <T, U> T -> U
   // SILGen and IRGen check additional constraints during lowering.
   BuiltinFunctionBuilder builder(ctx, 2);
-  builder.addParameter(makeGenericParam(0), ValueOwnership::Owned);
+  builder.addParameter(makeGenericParam(0), ParamSpecifier::LegacyOwned);
   builder.setResult(makeGenericParam(1));
   return builder.build(name);
 }
@@ -1388,7 +1388,7 @@ static ValueDecl *getConvertStrongToUnownedUnsafe(ASTContext &ctx,
   // builtin, so we can crash.
   BuiltinFunctionBuilder builder(ctx, 2);
   builder.addParameter(makeGenericParam(0));
-  builder.addParameter(makeGenericParam(1), ValueOwnership::InOut);
+  builder.addParameter(makeGenericParam(1), ParamSpecifier::InOut);
   builder.setResult(makeConcrete(TupleType::getEmpty(ctx)));
   return builder.build(id);
 }
@@ -1404,7 +1404,7 @@ static ValueDecl *getConvertUnownedUnsafeToGuaranteed(ASTContext &ctx,
   // builtin, so we can crash.
   BuiltinFunctionBuilder builder(ctx, 3);
   builder.addParameter(makeGenericParam(0));                        // Base
-  builder.addParameter(makeGenericParam(1), ValueOwnership::InOut); // Unmanaged
+  builder.addParameter(makeGenericParam(1), ParamSpecifier::InOut); // Unmanaged
   builder.setResult(makeGenericParam(2)); // Guaranteed Result
   return builder.build(id);
 }
@@ -1632,7 +1632,7 @@ static ValueDecl *getTSanInoutAccess(ASTContext &Context, Identifier Id) {
 static ValueDecl *getAddressOfOperation(ASTContext &Context, Identifier Id) {
   // <T> (@inout T) -> RawPointer
   BuiltinFunctionBuilder builder(Context);
-  builder.addParameter(makeGenericParam(), ValueOwnership::InOut);
+  builder.addParameter(makeGenericParam(), ParamSpecifier::InOut);
   builder.setResult(makeConcrete(Context.TheRawPointerType));
   return builder.build(Id);
 }
@@ -1659,7 +1659,7 @@ static ValueDecl *getTypeJoinInoutOperation(ASTContext &Context,
                                             Identifier Id) {
   // <T,U,V> (inout T, U.Type) -> V.Type
   BuiltinFunctionBuilder builder(Context, 3);
-  builder.addParameter(makeGenericParam(0), ValueOwnership::InOut);
+  builder.addParameter(makeGenericParam(0), ParamSpecifier::InOut);
   builder.addParameter(makeMetatype(makeGenericParam(1)));
   builder.setResult(makeMetatype(makeGenericParam(2)));
   return builder.build(Id);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -7500,7 +7500,7 @@ AnyFunctionType::Param ParamDecl::toFunctionParam(Type type) const {
   auto internalLabel = getParameterName();
   auto flags = ParameterTypeFlags::fromParameterType(
       type, isVariadic(), isAutoClosure(), isNonEphemeral(),
-      getValueOwnership(), isIsolated(), /*isNoDerivative*/ false,
+      getSpecifier(), isIsolated(), /*isNoDerivative*/ false,
       isCompileTimeConst());
   return AnyFunctionType::Param(type, label, flags, internalLabel);
 }

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -3314,7 +3314,7 @@ static CanAnyFunctionType getPropertyWrapperBackingInitializerInterfaceType(
 
   AnyFunctionType::Param param(
       inputType, Identifier(),
-      ParameterTypeFlags().withValueOwnership(ValueOwnership::Owned));
+      ParameterTypeFlags().withOwnershipSpecifier(ParamSpecifier::LegacyOwned));
   // FIXME: Verify ExtInfo state is correct, not working by accident.
   CanAnyFunctionType::ExtInfo info;
   return CanAnyFunctionType::get(getCanonicalSignatureOrNull(sig), {param},

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3201,8 +3201,8 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       // we've already ensured that the destination function is not
       // @differentiable.
       auto flags = param.getParameterFlags();
-      flags = flags.withValueOwnership(
-          param.isInOut() ? ValueOwnership::InOut : ValueOwnership::Default);
+      flags = flags.withOwnershipSpecifier(
+          param.isInOut() ? ParamSpecifier::InOut : ParamSpecifier::Default);
       flags = flags.withNonEphemeral(false)
                    .withNoDerivative(false);
       if (!flags.isNone())

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3352,7 +3352,7 @@ TypeResolver::resolveASTFunctionTypeParams(TupleTypeRepr *inputRepr,
     // must appear at the top level of a parameter type.
     auto *nestedRepr = eltTypeRepr->getWithoutParens();
 
-    ValueOwnership ownership = ValueOwnership::Default;
+    ParamSpecifier ownership = ParamSpecifier::Default;
 
     bool isolated = false;
     bool compileTimeConst = false;
@@ -3360,7 +3360,7 @@ TypeResolver::resolveASTFunctionTypeParams(TupleTypeRepr *inputRepr,
       if (auto *specifierRepr = dyn_cast<SpecifierTypeRepr>(nestedRepr)) {
         switch (specifierRepr->getKind()) {
         case TypeReprKind::Ownership:
-          ownership = cast<OwnershipTypeRepr>(specifierRepr)->getValueOwnership();
+          ownership = cast<OwnershipTypeRepr>(specifierRepr)->getSpecifier();
           nestedRepr = specifierRepr->getBase();
           continue;
         case TypeReprKind::Isolated:

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5724,23 +5724,6 @@ getActualReferenceOwnership(serialization::ReferenceOwnership raw) {
   return None;
 }
 
-/// Translate from the serialization ValueOwnership enumerators, which are
-/// guaranteed to be stable, to the AST ones.
-static Optional<swift::ValueOwnership>
-getActualValueOwnership(serialization::ValueOwnership raw) {
-  switch (raw) {
-#define CASE(ID) \
-  case serialization::ValueOwnership::ID: \
-    return swift::ValueOwnership::ID;
-  CASE(Default)
-  CASE(InOut)
-  CASE(Shared)
-  CASE(Owned)
-#undef CASE
-  }
-  return None;
-}
-
 /// Translate from the serialization ParameterConvention enumerators,
 /// which are guaranteed to be stable, to the AST ones.
 static
@@ -6114,8 +6097,8 @@ detail::function_deserializer::deserialize(ModuleFile &MF,
         isNonEphemeral, rawOwnership, isIsolated, isNoDerivative,
         isCompileTimeConst);
 
-    auto ownership =
-        getActualValueOwnership((serialization::ValueOwnership)rawOwnership);
+    auto ownership = getActualParamDeclSpecifier(
+      (serialization::ParamDeclSpecifier)rawOwnership);
     if (!ownership)
       return MF.diagnoseFatal();
 

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 749; // added DeclContextKind::Package used by Serialization
+const uint16_t SWIFTMODULE_VERSION_MINOR = 750; // serialize param specifiers into ParamTypeFlags
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -484,16 +484,6 @@ enum ReferenceOwnership : uint8_t {
   Unmanaged,
 };
 using ReferenceOwnershipField = BCFixed<2>;
-
-// These IDs must \em not be renumbered or reordered without incrementing
-// the module version.
-enum ValueOwnership : uint8_t {
-  Default = 0,
-  InOut,
-  Shared,
-  Owned
-};
-using ValueOwnershipField = BCFixed<2>;
 
 // These IDs must \em not be renumbered or reordered without incrementing
 // the module version.
@@ -1163,7 +1153,7 @@ namespace decls_block {
     BCFixed<1>,          // vararg?
     BCFixed<1>,          // autoclosure?
     BCFixed<1>,          // non-ephemeral?
-    ValueOwnershipField, // inout, shared or owned?
+    ParamDeclSpecifierField, // inout, shared or owned?
     BCFixed<1>,          // isolated
     BCFixed<1>,          // noDerivative?
     BCFixed<1>           // compileTimeConst

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -4785,18 +4785,6 @@ getRawStableReferenceOwnership(swift::ReferenceOwnership ownership) {
   }
   llvm_unreachable("bad ownership kind");
 }
-/// Translate from the AST ownership enum to the Serialization enum
-/// values, which are guaranteed to be stable.
-static uint8_t getRawStableValueOwnership(swift::ValueOwnership ownership) {
-  switch (ownership) {
-  SIMPLE_CASE(ValueOwnership, Default)
-  SIMPLE_CASE(ValueOwnership, InOut)
-  SIMPLE_CASE(ValueOwnership, Shared)
-  SIMPLE_CASE(ValueOwnership, Owned)
-  }
-  llvm_unreachable("bad ownership kind");
-}
-
 /// Translate from the AST ParameterConvention enum to the
 /// Serialization enum values, which are guaranteed to be stable.
 static uint8_t getRawStableParameterConvention(swift::ParameterConvention pc) {
@@ -5153,7 +5141,7 @@ public:
     for (auto &param : fnTy->getParams()) {
       auto paramFlags = param.getParameterFlags();
       auto rawOwnership =
-          getRawStableValueOwnership(paramFlags.getValueOwnership());
+          getRawStableParamDeclSpecifier(paramFlags.getOwnershipSpecifier());
       FunctionParamLayout::emitRecord(
           S.Out, S.ScratchRecord, abbrCode,
           S.addDeclBaseNameRef(param.getLabel()),

--- a/test/SILGen/ownership_specifier_mangling.swift
+++ b/test/SILGen/ownership_specifier_mangling.swift
@@ -1,0 +1,90 @@
+// RUN: %target-swift-emit-silgen %s | %FileCheck %s
+
+// The internal `__shared` and `__owned` modifiers would always affect
+// symbol mangling, even if they don't have a concrete impact on ABI. The
+// The public `borrowing` and `consuming` modifiers are only supposed to
+// affect symbol mangling when they would change the default ABI behavior.
+
+// CHECK-LABEL: @$s28ownership_specifier_mangling17officialModifiersyySS_SStF
+func officialModifiers(_: String, _: String) {}
+// CHECK-LABEL: @$s28ownership_specifier_mangling17officialModifiersyySS_SSntF
+func officialModifiers(_: borrowing String, _: consuming String) {}
+// CHECK-LABEL: @$s28ownership_specifier_mangling17officialModifiersyySSn_SStF
+func officialModifiers(_: consuming String, _: borrowing String) {}
+
+// CHECK-LABEL: @$s28ownership_specifier_mangling15legacyModifiersyySS_SStF
+func legacyModifiers(_: String, _: String) {}
+// CHECK-LABEL: @$s28ownership_specifier_mangling15legacyModifiersyySSh_SSntF
+func legacyModifiers(_: __shared String, _: __owned String) {}
+// CHECK-LABEL: @$s28ownership_specifier_mangling15legacyModifiersyySSn_SShtF
+func legacyModifiers(_: __owned String, _: __shared String) {}
+
+class Foo {
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC17officialModifiers_ACSS_SStcfc
+    init(officialModifiers: String, _: String) {}
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC17officialModifiers_ACSSh_SStcfc
+    init(officialModifiers: borrowing String, _: consuming String) {}
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC17officialModifiers_ACSS_SShtcfc
+    init(officialModifiers: consuming String, _: borrowing String) {}
+
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC15legacyModifiers_ACSS_SStcfc
+    init(legacyModifiers: String, _: String) {}
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC15legacyModifiers_ACSSh_SSntcfc
+    init(legacyModifiers: __shared String, _: __owned String) {}
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC15legacyModifiers_ACSSn_SShtcfc
+    init(legacyModifiers: __owned String, _: __shared String) {}
+
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC26officialModifiersInClosureyyySS_SStXEF
+    func officialModifiersInClosure(_: (String, String) -> ()) {}
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC26officialModifiersInClosure2bcyySS_SSntXE_tF
+    func officialModifiersInClosure(bc: (borrowing String, consuming String) -> ()) {}
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC26officialModifiersInClosure2cbyySSn_SStXE_tF
+    func officialModifiersInClosure(cb: (consuming String, borrowing String) -> ()) {}
+
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC24legacyModifiersInClosureyyySS_SStXEF
+    func legacyModifiersInClosure(_: (String, String) -> ()) {}
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC24legacyModifiersInClosure2bcyySSh_SSntXE_tF
+    func legacyModifiersInClosure(bc: (__shared String, __owned String) -> ()) {}
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC24legacyModifiersInClosure2cbyySSn_SShtXE_tF
+    func legacyModifiersInClosure(cb: (__owned String, __shared String) -> ()) {}
+
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC26officialModifiersInClosureACySS_SStXE_tcfc
+    init(officialModifiersInClosure: (String, String) -> ()) {}
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC29officialModifiersInClosure_bcACySS_SSntXE_tcfc
+    init(officialModifiersInClosure_bc: (borrowing String, consuming String) -> ()) {}
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC29officialModifiersInClosure_cbACySSn_SStXE_tcfc
+    init(officialModifiersInClosure_cb: (consuming String, borrowing String) -> ()) {}
+
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC24legacyModifiersInClosureACySS_SStXE_tcfc
+    init(legacyModifiersInClosure: (String, String) -> ()) {}
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC27legacyModifiersInClosure_bcACySSh_SSntXE_tcfc
+    init(legacyModifiersInClosure_bc: (__shared String, __owned String) -> ()) {}
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC27legacyModifiersInClosure_cbACySSn_SShtXE_tcfc
+    init(legacyModifiersInClosure_cb: (__owned String, __shared String) -> ()) {}
+
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC26officialModifiersInClosureyySS_SStcvg
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC26officialModifiersInClosureyySS_SStcvs
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC26officialModifiersInClosureyySS_SStcvM
+    var officialModifiersInClosure: (String, String) -> () = {_,_ in}
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC29officialModifiersInClosure_bcyySS_SSntcvg
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC29officialModifiersInClosure_bcyySS_SSntcvs
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC29officialModifiersInClosure_bcyySS_SSntcvM
+    var officialModifiersInClosure_bc: (borrowing String, consuming String) -> () = {_,_ in}
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC29officialModifiersInClosure_cbyySSn_SStcvg
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC29officialModifiersInClosure_cbyySSn_SStcvs
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC29officialModifiersInClosure_cbyySSn_SStcvM
+    var officialModifiersInClosure_cb: (consuming String, borrowing String) -> () = {_,_ in}
+
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC24legacyModifiersInClosureyySS_SStcvg
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC24legacyModifiersInClosureyySS_SStcvs
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC24legacyModifiersInClosureyySS_SStcvM
+    var legacyModifiersInClosure: (String, String) -> () = {_,_ in}
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC27legacyModifiersInClosure_bcyySSh_SSntcvg
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC27legacyModifiersInClosure_bcyySSh_SSntcvs
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC27legacyModifiersInClosure_bcyySSh_SSntcvM
+    var legacyModifiersInClosure_bc: (__shared String, __owned String) -> () = {_,_ in}
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC27legacyModifiersInClosure_cbyySSn_SShtcvg
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC27legacyModifiersInClosure_cbyySSn_SShtcvs
+    // CHECK-LABEL: @$s28ownership_specifier_mangling3FooC27legacyModifiersInClosure_cbyySSn_SShtcvM
+    var legacyModifiersInClosure_cb: (__owned String, __shared String) -> () = {_,_ in}
+}


### PR DESCRIPTION
`__shared` and `__owned` would always get mangled, even when they don't have any effect on ABI, making it unnecessarily ABI-breaking to apply them to existing API to make calling conventions explicit. Avoid this issue by only mangling them in cases where they change the ABI from the default.