### PR TITLE
[Macros] Ensure that overloading a type and macro doesn't break type references

### DIFF
--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -139,3 +139,17 @@ func testExternalMacroOutOfPlace() {
 public macro macroWithDefaults(_: Int = 17) = #externalMacro(module: "A", type: "B")
 // expected-error@-1{{default arguments are not allowed in macros}}
 // expected-warning@-2{{external macro implementation type 'A.B' could not be found for macro 'macroWithDefaults'}}
+
+// Make sure we don't allow macros to prevent type folding.
+@attached(member)
+public macro MacroOrType() = #externalMacro(module: "A", type: "MacroOrType")
+// expected-warning@-1{{external macro implementation type}}
+
+struct MacroOrType {
+  typealias Nested = Int
+}
+
+func test() {
+  let _: [MacroOrType.Nested] = []
+  _ = [MacroOrType.Nested]()
+}


### PR DESCRIPTION
Fixes rdar://106044286
