### PR TITLE
[Concurrency] Complement assume... APIs with the assert and precondition ones

### DIFF
--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -11,6 +11,48 @@
 //===----------------------------------------------------------------------===//
 
 import Swift
+
+
+// ==== -----------------------------------------------------------------------
+// MARK: Executor Assertions
+
+/// Chec
+///
+/// - Parameter executor: the expected current executor
+@available(SwiftStdlib 5.9, *) // FIXME: use @backDeploy(before: SwiftStdlib 5.9)
+public
+func preconditionTaskOnExecutor(
+    _ executor: some SerialExecutor,
+    file: StaticString = #fileID, line: UInt = #line
+) {
+  guard _taskIsCurrentExecutor(executor.asUnownedSerialExecutor().executor) else {
+    // TODO: offer information which executor we actually got
+    let message = "Incorrect actor executor assumption; Expected '\(executor)' executor."
+    precondition(false, message, file: file, line: line) // short-cut so we get the exact same failure reporting semantics
+    return
+  }
+}
+
+/// Chec
+///
+/// - Parameter executor: the expected current executor
+@available(SwiftStdlib 5.9, *) // FIXME: use @backDeploy(before: SwiftStdlib 5.9)
+public
+func preconditionTaskOnActorExecutor(
+    _ actor: some Actor,
+    file: StaticString = #fileID, line: UInt = #line
+) {
+  guard _taskIsCurrentExecutor(actor.unownedExecutor.executor) else {
+    // TODO: offer information which executor we actually got
+    // TODO: figure out a way to get the typed repr out of the unowned executor
+    let message = "Incorrect actor executor assumption; Expected '\(actor.unownedExecutor)' executor."
+    precondition(false, message, file: file, line: line) // short-cut so we get the exact same failure reporting semantics
+    return
+  }
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: Assume Executor
 
 /// A safe way to synchronously assume that the current execution context belongs to the MainActor.
 ///

--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -40,6 +40,10 @@ func preconditionTaskOnExecutor(
     message: @autoclosure () -> String = String(),
     file: StaticString = #fileID, line: UInt = #line
 ) {
+  guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() else {
+    return
+  }
+
   let expectationCheck = _taskIsCurrentExecutor(executor.asUnownedSerialExecutor().executor)
 
   /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?

--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -11,42 +11,150 @@
 //===----------------------------------------------------------------------===//
 
 import Swift
-
+import SwiftShims
 
 // ==== -----------------------------------------------------------------------
-// MARK: Executor Assertions
+// MARK: Precondition executors
 
-/// Chec
+/// Unconditionally if the current task is executing on the expected serial executor,
+/// and if not crash the program offering information about the executor mismatch.
+///
+/// This function's effect varies depending on the build flag used:
+///
+/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+///   configuration), stops program execution in a debuggable state after
+///   printing `message`.
+///
+/// * In `-O` builds (the default for Xcode's Release configuration), stops
+///   program execution.
+///
+/// * In `-Ounchecked` builds, the optimizer may assume that this function is
+///   never called. Failure to satisfy that assumption is a serious
+///   programming error.
 ///
 /// - Parameter executor: the expected current executor
 @available(SwiftStdlib 5.9, *) // FIXME: use @backDeploy(before: SwiftStdlib 5.9)
 public
 func preconditionTaskOnExecutor(
     _ executor: some SerialExecutor,
+    message: @autoclosure () -> String = String(),
     file: StaticString = #fileID, line: UInt = #line
 ) {
-  guard _taskIsCurrentExecutor(executor.asUnownedSerialExecutor().executor) else {
-    // TODO: offer information which executor we actually got
-    let message = "Incorrect actor executor assumption; Expected '\(executor)' executor."
-    precondition(false, message, file: file, line: line) // short-cut so we get the exact same failure reporting semantics
-    return
-  }
+  let expectationCheck = _taskIsCurrentExecutor(executor.asUnownedSerialExecutor().executor)
+
+  /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?
+  precondition(expectationCheck,
+      // TODO: offer information which executor we actually got
+      "Incorrect actor executor assumption; Expected '\(executor)' executor. \(message())",
+      file: file, line: line) // short-cut so we get the exact same failure reporting semantics
 }
 
-/// Chec
+/// Unconditionally if the current task is executing on the serial executor of the passed in `actor`,
+/// and if not crash the program offering information about the executor mismatch.
 ///
-/// - Parameter executor: the expected current executor
+/// This function's effect varies depending on the build flag used:
+///
+/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+///   configuration), stops program execution in a debuggable state after
+///   printing `message`.
+///
+/// * In `-O` builds (the default for Xcode's Release configuration), stops
+///   program execution.
+///
+/// * In `-Ounchecked` builds, the optimizer may assume that this function is
+///   never called. Failure to satisfy that assumption is a serious
+///   programming error.
+///
+/// - Parameter actor: the actor whose serial executor we expect to be the current executor
 @available(SwiftStdlib 5.9, *) // FIXME: use @backDeploy(before: SwiftStdlib 5.9)
 public
 func preconditionTaskOnActorExecutor(
     _ actor: some Actor,
+    message: @autoclosure () -> String = String(),
     file: StaticString = #fileID, line: UInt = #line
 ) {
+  guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() else {
+    return
+  }
+
+  let expectationCheck = _taskIsCurrentExecutor(actor.unownedExecutor.executor)
+
+  // TODO: offer information which executor we actually got
+  precondition(expectationCheck,
+      // TODO: figure out a way to get the typed repr out of the unowned executor
+      "Incorrect actor executor assumption; Expected '\(actor.unownedExecutor)' executor. \(message())",
+      file: file, line: line)
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: Assert executors
+
+/// Performs an executor check in debug builds.
+///
+/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+///   configuration): If `condition` evaluates to `false`, stop program
+///   execution in a debuggable state after printing `message`.
+///
+/// * In `-O` builds (the default for Xcode's Release configuration),
+///   `condition` is not evaluated, and there are no effects.
+///
+/// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
+///   may assume that it *always* evaluates to `true`. Failure to satisfy that
+///   assumption is a serious programming error.
+///
+/// - Parameter executor: the expected current executor
+@available(SwiftStdlib 5.9, *) // FIXME: use @backDeploy(before: SwiftStdlib 5.9)
+public
+func assertTaskOnExecutor(
+    _ executor: some SerialExecutor,
+    _ message: @autoclosure () -> String = String(),
+    file: StaticString = #fileID, line: UInt = #line
+) {
+  guard _isDebugAssertConfiguration() else {
+    return
+  }
+
+  guard _taskIsCurrentExecutor(executor.asUnownedSerialExecutor().executor) else {
+    // TODO: offer information which executor we actually got
+    let msg = "Incorrect actor executor assumption; Expected '\(executor)' executor. \(message())"
+    /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?
+    assertionFailure(msg, file: file, line: line)
+    return
+  }
+}
+
+/// Performs an executor check in debug builds.
+///
+/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+///   configuration): If `condition` evaluates to `false`, stop program
+///   execution in a debuggable state after printing `message`.
+///
+/// * In `-O` builds (the default for Xcode's Release configuration),
+///   `condition` is not evaluated, and there are no effects.
+///
+/// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
+///   may assume that it *always* evaluates to `true`. Failure to satisfy that
+///   assumption is a serious programming error.
+///
+///
+/// - Parameter actor: the actor whose serial executor we expect to be the current executor
+@available(SwiftStdlib 5.9, *) // FIXME: use @backDeploy(before: SwiftStdlib 5.9)
+public
+func assertTaskOnActorExecutor(
+    _ actor: some Actor,
+    _ message: @autoclosure () -> String = String(),
+    file: StaticString = #fileID, line: UInt = #line
+) {
+  guard _isDebugAssertConfiguration() else {
+    return
+  }
+
   guard _taskIsCurrentExecutor(actor.unownedExecutor.executor) else {
     // TODO: offer information which executor we actually got
     // TODO: figure out a way to get the typed repr out of the unowned executor
-    let message = "Incorrect actor executor assumption; Expected '\(actor.unownedExecutor)' executor."
-    precondition(false, message, file: file, line: line) // short-cut so we get the exact same failure reporting semantics
+    let msg = "Incorrect actor executor assumption; Expected '\(actor.unownedExecutor)' executor. \(message())"
+    /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?
+    assertionFailure(msg, file: file, line: line) // short-cut so we get the exact same failure reporting semantics
     return
   }
 }

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -29,8 +29,9 @@ func _isDebugAssertConfiguration() -> Bool {
   return Int32(Builtin.assert_configuration()) == 0
 }
 
-@usableFromInline @_transparent
-internal func _isReleaseAssertConfiguration() -> Bool {
+@_transparent
+public // @testable, used in _Concurrency executor preconditions
+func _isReleaseAssertConfiguration() -> Bool {
   // The values for the assert_configuration call are:
   // 0: Debug
   // 1: Release

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
@@ -1,0 +1,91 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -Xfrontend -disable-availability-checking -parse-as-library %s -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN:  %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: concurrency_runtime
+
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: back_deploy_concurrency
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: freestanding
+
+import StdlibUnittest
+
+func checkPreconditionMainActor() /* synchronous! */ {
+  preconditionTaskOnActorExecutor(MainActor.shared)
+}
+
+func checkPreconditionFamousActor() /* synchronous! */ {
+  preconditionTaskOnActorExecutor(FamousActor.shared)
+}
+
+@MainActor
+func mainActorCallCheck() {
+  checkPreconditionMainActor()
+}
+
+@globalActor actor FamousActor: GlobalActor {
+  public static let shared = FamousActor()
+
+  func callCheckFamousActor() {
+    checkPreconditionFamousActor() // ok
+  }
+
+  func callCheckMainActor() {
+    checkPreconditionMainActor() // bad
+  }
+}
+
+actor MainFriend {
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
+    MainActor.sharedUnownedExecutor
+  }
+
+  func callCheckMainActor() {
+    checkPreconditionMainActor()
+  }
+}
+
+actor Someone {
+  func callCheckMainActor() {
+    checkPreconditionMainActor()
+  }
+}
+
+@main struct Main {
+  static func main() async {
+    let tests = TestSuite("AssertPreconditionActorExecutor")
+
+    if #available(SwiftStdlib 5.9, *) {
+      // === MainActor --------------------------------------------------------
+
+      tests.test("preconditionTaskOnActorExecutor(main): from 'main() async', with await") {
+        await checkPreconditionMainActor()
+      }
+
+      // FIXME: calling without await from main() should also succeed, we must set the executor while we're kicking off main
+
+      tests.test("preconditionTaskOnActorExecutor(main): from Main friend") {
+        await MainFriend().callCheckMainActor()
+      }
+
+      tests.test("preconditionTaskOnActorExecutor(main): wrongly assume the main executor, from actor on other executor") {
+        expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected 'MainActor' executor.")
+        await Someone().callCheckMainActor()
+      }
+
+      // === Global actor -----------------------------------------------------
+
+      tests.test("preconditionTaskOnActorExecutor(main): assume FamousActor, from FamousActor") {
+        await FamousActor.shared.callCheckFamousActor()
+      }
+
+
+    }
+
+    await runAllTestsAsync()
+  }
+}

--- a/test/SourceKit/Indexing/index_with_clang_module.swift
+++ b/test/SourceKit/Indexing/index_with_clang_module.swift
@@ -17,6 +17,9 @@ func foo(a: FooClassDerived) {
 // CHECK-NEXT: key.name: "_SwiftConcurrencyShims"
 
 // CHECK:      key.kind: source.lang.swift.import.module.clang
+// CHECK-NEXT: key.name: "SwiftShims"
+
+// CHECK:      key.kind: source.lang.swift.import.module.clang
 // CHECK-NEXT: key.name: "Foo"
 // CHECK-NEXT: key.filepath: "{{.*[/\\]}}Foo{{.*}}.pcm"
 


### PR DESCRIPTION
Follow up to https://github.com/apple/swift/pull/64030 which introduced "assume" APIs, these are the pure precondition and assert APIs which come together in a package.

These are going to offer better error messages than end-users are able to implement by themselfes since we're not going to make public APIs to "get current executor", but these APIs here will gain the ability to print what executor we were on.