### PR TITLE
[Runtime] Remove spurious include of <filesystem>.

### DIFF
--- a/stdlib/public/runtime/Paths.cpp
+++ b/stdlib/public/runtime/Paths.cpp
@@ -21,8 +21,6 @@
 #include "swift/Runtime/Win32.h"
 #include "swift/Threading/Once.h"
 
-#include <filesystem>
-
 #if !defined(_WIN32) || defined(__CYGWIN__)
 #include <sys/stat.h>
 


### PR DESCRIPTION
This was added when Saleem suggested using <filesystem> to avoid having to do lots of string manipulation, but it turns out we can't use it on macOS because of minimum deployment versions, and we also can't use it on Ubuntu 18.04 because it doesn't exist there.

The code related to it was backed out already, but I missed the include.

rdar://106183273
