### PR TITLE
[Observation] Add names for attached member names for Observable macro

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/Macros.swift
+++ b/stdlib/public/Observation/Sources/Observation/Macros.swift
@@ -12,7 +12,7 @@
 #if SWIFT_OBSERVATION_MACROS
 #if compiler(>=5.8) && hasAttribute(attached)
 @available(SwiftStdlib 5.9, *)
-@attached(member)
+@attached(member, names: named(_registrar), named(transactions), named(changes), named(_Storage), named(_storage))
 @attached(memberAttribute)
 @attached(conformance)
 public macro Observable() = 


### PR DESCRIPTION
The attached member macro requires a list of provided names - this adjusts the macro to declare those explicitly in the definition of the macro.