### PR TITLE
[Serialization] Remark only on stderr when loading a mismatching swiftmodule

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -811,10 +811,6 @@ ERROR(serialization_module_incompatible_revision,Fatal,
       "compiled module was created by a different version of the compiler '%0'; "
       "rebuild %1 and try again: %2",
       (StringRef, Identifier, StringRef))
-REMARK(serialization_module_problematic_revision, none,
-      "compiled module was created by a different version of the compiler '%0': "
-      "%1",
-      (StringRef, StringRef))
 ERROR(serialization_missing_single_dependency,Fatal,
       "missing required module '%0'", (StringRef))
 ERROR(serialization_missing_dependencies,Fatal,

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -846,11 +846,13 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
         loadedModuleFile->mayHaveDiagnosticsPointingAtBuffer())
       OrphanedModuleFiles.push_back(std::move(loadedModuleFile));
   } else {
-    // Report non-fatal compiler tag mismatch.
+    // Report non-fatal compiler tag mismatch on stderr only to avoid
+    // polluting the IDE UI.
     if (!loadInfo.problematicRevision.empty()) {
-      Ctx.Diags.diagnose(*diagLoc,
-                         diag::serialization_module_problematic_revision,
-                         loadInfo.problematicRevision, moduleBufferID);
+      llvm::errs() << "remark: compiled module was created by a different " <<
+                      "version of the compiler '" <<
+                      loadInfo.problematicRevision <<
+                      "': " << moduleBufferID << "\n";
     }
   }
 


### PR DESCRIPTION
Swiftmodules built by a mismatching compiler are loaded if the mismatch is only on the last digit of the compiler version. In such a case, write a remark directly to stderr to avoid showing this error in IDE while keeping it for debugging purposes.

rdar://105881894