### PR TITLE
SILGen: Don't DI the box for `consuming` parameters.

### DIFF
--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -445,8 +445,9 @@ struct ArgumentInitHelper {
     } else if (!pd->isImmutableInFunctionBody()) {
       // If it's a locally mutable parameter, then we need to move the argument
       // value into a local box to hold the mutated value.
+      // We don't need to mark_uninitialized since we immediately initialize.
       auto mutableBox = SGF.emitLocalVariableWithCleanup(pd,
-                                                    MarkUninitializedInst::Var);
+                                                   /*uninitialized kind*/ None);
       argrv.ensurePlusOne(SGF, loc).forwardInto(SGF, loc, mutableBox.get());
       return;
     }

--- a/test/SILGen/consuming_parameter.swift
+++ b/test/SILGen/consuming_parameter.swift
@@ -6,8 +6,7 @@ func bar(_: String) {}
 func foo(y: consuming String, z: String) -> () -> String {
     // CHECK: bb0(%0 : @owned $String, %1 : @guaranteed $String):
     // CHECK:   [[BOX:%.*]] = alloc_box ${ var String }
-    // CHECK:   [[BOX0:%.*]] = mark_uninitialized [var] [[BOX]]
-    // CHECK:   [[BOX1:%.*]] = begin_borrow [lexical] [[BOX0]]
+    // CHECK:   [[BOX1:%.*]] = begin_borrow [lexical] [[BOX]]
     // CHECK:   [[Y:%.*]] = project_box [[BOX1]]
     // CHECK:   store %0 to [init] [[Y]]
 
@@ -37,8 +36,7 @@ struct Butt {
     consuming func merged(with other: Butt) -> () -> Butt {
         // CHECK: bb0(%0 : @guaranteed $Butt, %1 : @owned $Butt):
         // CHECK:   [[BOX:%.*]] = alloc_box ${ var Butt }
-        // CHECK:   [[BOX0:%.*]] = mark_uninitialized [var] [[BOX]]
-        // CHECK:   [[BOX1:%.*]] = begin_borrow [lexical] [[BOX0]]
+        // CHECK:   [[BOX1:%.*]] = begin_borrow [lexical] [[BOX]]
         // CHECK:   [[SELF:%.*]] = project_box [[BOX1]]
         // CHECK:   store %1 to [init] [[SELF]]
 


### PR DESCRIPTION
It's always immediately initialized, so there's no need. This also sidesteps an issue with DI and escaped move-only boxes (rdar://106049211).