### PR TITLE
[interop][SwiftToCxx] incorporate argument labels into Stdlib API nam…

### DIFF
--- a/lib/PrintAsClang/DeclAndTypePrinter.cpp
+++ b/lib/PrintAsClang/DeclAndTypePrinter.cpp
@@ -2700,7 +2700,7 @@ static bool isStringNestedType(const ValueDecl *VD, StringRef Typename) {
 
 static bool hasExposeAttr(const ValueDecl *VD, bool isExtension = false) {
   if (isa<NominalTypeDecl>(VD) && VD->getModuleContext()->isStdlibModule()) {
-    if (VD == VD->getASTContext().getStringDecl() && !isExtension)
+    if (VD == VD->getASTContext().getStringDecl())
       return true;
     if (VD == VD->getASTContext().getArrayDecl())
       return true;
@@ -2721,47 +2721,24 @@ static bool hasExposeAttr(const ValueDecl *VD, bool isExtension = false) {
     // FIXME: Do not expose 'index' methods as the overloads are conflicting.
     // this should either be prohibited in the stdlib module, or the overloads
     // should be renamed automatically or using the expose attribute.
-    if (ED->getExtendedNominal() == VD->getASTContext().getArrayDecl()) {
-      if (isa<AbstractFunctionDecl>(VD) &&
-          !cast<AbstractFunctionDecl>(VD)
-               ->getName()
-               .getBaseName()
-               .isSpecial() &&
-          cast<AbstractFunctionDecl>(VD)
-              ->getName()
-              .getBaseName()
-              .getIdentifier()
-              .str()
-              .contains_insensitive("index"))
-        return false;
-    }
+    if ((ED->getExtendedNominal() == VD->getASTContext().getArrayDecl() ||
+         ED->getExtendedNominal() == VD->getASTContext().getStringDecl()) &&
+        (isa<AbstractFunctionDecl>(VD) &&
+         !cast<AbstractFunctionDecl>(VD)->getName().getBaseName().isSpecial() &&
+         cast<AbstractFunctionDecl>(VD)
+             ->getName()
+             .getBaseName()
+             .getIdentifier()
+             .str()
+             .contains_insensitive("index")))
+      return false;
+    // Limit exposition of String constructors as there's overloading conflict.
+    // FIXME: resolve it in some other way.
     if (ED->getExtendedNominal() == VD->getASTContext().getStringDecl()) {
-      if (isa<ValueDecl>(VD) &&
-          !cast<ValueDecl>(VD)->getName().getBaseName().isSpecial() &&
-          cast<ValueDecl>(VD)
-              ->getName()
-              .getBaseName()
-              .getIdentifier()
-              .str()
-              .contains_insensitive("utf8"))
-        return true;
-    }
-    if (isStringNestedType(ED->getExtendedNominal(), "UTF8View")) {
-      // Do not expose ambiguous 'index(after:' / 'index(before:' overloads.
-      if (isa<AbstractFunctionDecl>(VD) &&
-          cast<AbstractFunctionDecl>(VD)->getParameters()->size() == 1 &&
-          !cast<AbstractFunctionDecl>(VD)
-               ->getName()
-               .getBaseName()
-               .isSpecial() &&
-          cast<AbstractFunctionDecl>(VD)
-              ->getName()
-              .getBaseName()
-              .getIdentifier()
-              .str()
-              .contains_insensitive("index"))
+      if (isa<ConstructorDecl>(VD))
         return false;
     }
+
     return hasExposeAttr(ED->getExtendedNominal(), /*isExtension=*/true);
   }
   return false;

--- a/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
+++ b/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
@@ -63,7 +63,7 @@ SWIFT_INLINE_THUNK String::operator std::string() const {
   using IndexType = decltype(u.getStartIndex());
   for (auto s = u.getStartIndex().getEncodedOffset(),
             e = u.getEndIndex().getEncodedOffset();
-       s != e; s = u.index(IndexType::init(s), 1).getEncodedOffset()) {
+       s != e; s = u.indexOffsetBy(IndexType::init(s), 1).getEncodedOffset()) {
     result.push_back(u[IndexType::init(s)]);
   }
   return result;

--- a/test/Interop/SwiftToCxx/stdlib/array/array-execution.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/array/array-execution.cpp
@@ -53,7 +53,7 @@ int main() {
     assert(val.getCapacity() >= 1);
     auto zeroInt = val[0];
     assert(zeroInt == -11);
-    auto firstInt = val.remove(0);
+    auto firstInt = val.removeAt(0);
     assert(firstInt == -11);
     assert(val.getCount() == 0);
     UseArray::printArray(val);

--- a/test/Interop/SwiftToCxx/stdlib/string/string-in-cxx-execution.cpp
+++ b/test/Interop/SwiftToCxx/stdlib/string/string-in-cxx-execution.cpp
@@ -1,0 +1,43 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -typecheck %t/print-string.swift -typecheck -module-name Stringer -enable-experimental-cxx-interop -emit-clang-header-path %t/Stringer.h
+
+// RUN: %target-interop-build-clangxx -std=gnu++20 -c %t/string-conversions.cpp -I %t -o %t/swift-stdlib-execution.o
+// RUN: %target-build-swift %t/print-string.swift -o %t/swift-stdlib-execution -Xlinker %t/swift-stdlib-execution.o -module-name Stringer -Xfrontend -entry-point-function-name -Xfrontend swiftMain %target-cxx-lib
+// RUN: %target-codesign %t/swift-stdlib-execution
+// RUN: %target-run %t/swift-stdlib-execution | %FileCheck %s
+
+// REQUIRES: executable_test
+
+//--- print-string.swift
+
+@_expose(Cxx)
+public func printString(_ s: String) {
+    print("'''\(s)'''")
+}
+
+//--- string-conversions.cpp
+
+#include <cassert>
+#include "Stringer.h"
+
+int main() {
+  using namespace Swift;
+  using namespace Stringer;
+
+  {
+    auto s = String("Hello world");
+    assert(s.getCount() == 11);
+    printString(s);
+    s.append(String("!test"));
+    printString(s);
+    printString(s.lowercased());
+    printString(s.uppercased());
+  }
+// CHECK: '''Hello world'''
+// CHECK: '''Hello world!test'''
+// CHECK: '''hello world!test'''
+// CHECK: '''HELLO WORLD!TEST'''
+  return 0;
+}

--- a/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/stdlib/swift-stdlib-in-cxx.swift
@@ -35,7 +35,7 @@
 // CHECK: }
 // CHECK: static SWIFT_INLINE_THUNK Array<T_0_0> init() SWIFT_SYMBOL({{.*}});
 // CHECK: SWIFT_INLINE_THUNK void append(const T_0_0& newElement) SWIFT_SYMBOL({{.*}});
-// CHECK: SWIFT_INLINE_THUNK T_0_0 remove(swift::Int index) SWIFT_SYMBOL({{.*}});
+// CHECK: SWIFT_INLINE_THUNK T_0_0 removeAt(swift::Int index) SWIFT_SYMBOL({{.*}});
 // CHECK: SWIFT_INLINE_THUNK T_0_0 operator [](swift::Int index) const SWIFT_SYMBOL({{.*}});
 // CHECK: SWIFT_INLINE_THUNK swift::Int getCount() const SWIFT_SYMBOL({{.*}});
 // CHECK: SWIFT_INLINE_THUNK swift::Int getCapacity() const SWIFT_SYMBOL({{.*}});
@@ -73,10 +73,11 @@
 // CHECK:  }
 // CHECK-NEXT:  SWIFT_INLINE_THUNK String(String &&) { abort(); }
 // CHECK-NEXT:  static SWIFT_INLINE_THUNK String init() SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:  SWIFT_INLINE_THUNK UTF8View getUtf8() const SWIFT_SYMBOL({{.*}});
+// CHECK:  SWIFT_INLINE_THUNK void append(const String& other)
+// CHECK:  SWIFT_INLINE_THUNK UTF8View getUtf8() const SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT:  SWIFT_INLINE_THUNK void setUtf8(const UTF8View& newValue) SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:  SWIFT_INLINE_THUNK bool isContiguousUTF8() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:  #if defined(__OBJC__)
+// CHECK:  SWIFT_INLINE_THUNK bool isContiguousUTF8() const SWIFT_SYMBOL({{.*}});
+// CHECK:  #if defined(__OBJC__)
 // CHECK-NEXT:  SWIFT_INLINE_THUNK operator NSString * _Nonnull () const noexcept {
 // CHECK-NEXT:    return (__bridge_transfer NSString *)(_impl::$sSS10FoundationE19_bridgeToObjectiveCSo8NSStringCyF(_impl::swift_interop_passDirect_Swift_String(_getOpaquePointer())));
 // CHECK-NEXT:   }
@@ -106,10 +107,9 @@
 // CHECK:  SWIFT_INLINE_THUNK UTF8View(UTF8View &&) { abort(); }
 // CHECK-NEXT: SWIFT_INLINE_THUNK String_Index getStartIndex() const SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT:   SWIFT_INLINE_THUNK String_Index getEndIndex() const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:   SWIFT_INLINE_THUNK String_Index index(const String_Index& i, swift::Int n) const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:   SWIFT_INLINE_THUNK Swift::Optional<String_Index> index(const String_Index& i, swift::Int n, const String_Index& limit) const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT:   SWIFT_INLINE_THUNK swift::Int distance(const String_Index& i, const String_Index& j) const SWIFT_SYMBOL({{.*}});
-// CHECK-NEXT: SWIFT_INLINE_THUNK uint8_t operator [](const String_Index& i) const SWIFT_SYMBOL({{.*}});
+// CHECK:   SWIFT_INLINE_THUNK Swift::Optional<String_Index> indexOffsetByLimitedBy(const String_Index& i, swift::Int n, const String_Index& limit) const SWIFT_SYMBOL({{.*}});
+// CHECK:   SWIFT_INLINE_THUNK swift::Int distanceFromTo(const String_Index& i, const String_Index& j) const SWIFT_SYMBOL({{.*}});
+// CHECK: SWIFT_INLINE_THUNK uint8_t operator [](const String_Index& i) const SWIFT_SYMBOL({{.*}});
 // CHECK:   SWIFT_INLINE_THUNK String getDescription() const SWIFT_SYMBOL({{.*}});
 // CHECK:   SWIFT_INLINE_THUNK swift::Int getCount() const SWIFT_SYMBOL({{.*}});
 // CHECK-NEXT: private:


### PR DESCRIPTION
…es in C++

This allows easier use and more wider API exposure from the Swift stdlib

In the future, all functions and method should incorporate argument labels, but it's not yet clear how
