### PR TITLE
Relax overly strict assert

### DIFF
--- a/stdlib/public/Concurrency/TaskPrivate.h
+++ b/stdlib/public/Concurrency/TaskPrivate.h
@@ -527,7 +527,6 @@ public:
     assert(!dispatch_lock_is_locked(ExecutionLock));
     return ActiveTaskStatus(Record, Flags, dispatch_lock_value_for_self());
   } else {
-    assert(dispatch_lock_is_locked_by_self(ExecutionLock));
     return ActiveTaskStatus(Record, Flags, ExecutionLock & ~DLOCK_OWNER_MASK);
   }
 #else


### PR DESCRIPTION
Remove overly strict assert that only the thread which was previously running the task, can mark the task as no-longer running.
