### PR TITLE
[Macros] Diagnose macro expansions containing invalid declarations.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -8463,6 +8463,11 @@ public:
   void getIntroducedNames(MacroRole role, ValueDecl *attachedTo,
                           SmallVectorImpl<DeclName> &names) const;
 
+  /// Returns a DeclName that represents arbitrary names.
+  static DeclName getArbitraryName() {
+    return DeclName();
+  }
+
   /// Retrieve the definition of this macro.
   MacroDefinition getDefinition() const;
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6910,7 +6910,7 @@ ERROR(external_macro_arg_not_type_name,none,
 ERROR(attached_declaration_macro_not_supported,none,
       "attached declaration macros are not yet supported", ())
 ERROR(invalid_decl_in_macro_expansion,none,
-      "macro expansion cannot introduce %1",
+      "macro expansion cannot introduce %0",
       (DescriptiveDeclKind))
 ERROR(invalid_main_type_in_macro_expansion,none,
       "macro expansion cannot introduce '@main' type'",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6909,6 +6909,15 @@ ERROR(external_macro_arg_not_type_name,none,
       "the external macro's %select{module|type}0", (unsigned))
 ERROR(attached_declaration_macro_not_supported,none,
       "attached declaration macros are not yet supported", ())
+ERROR(invalid_decl_in_macro_expansion,none,
+      "macro expansion cannot introduce %1",
+      (DescriptiveDeclKind))
+ERROR(invalid_main_type_in_macro_expansion,none,
+      "macro expansion cannot introduce '@main' type'",
+      ())
+ERROR(invalid_macro_introduced_name,none,
+      "declaration name %0 is not covered by macro %1",
+      (DeclName, DeclName))
 
 //------------------------------------------------------------------------------
 // MARK: Move Only Errors

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6913,8 +6913,11 @@ ERROR(invalid_decl_in_macro_expansion,none,
       "macro expansion cannot introduce %0",
       (DescriptiveDeclKind))
 ERROR(invalid_main_type_in_macro_expansion,none,
-      "macro expansion cannot introduce '@main' type'",
+      "macro expansion cannot introduce '@main' type",
       ())
+ERROR(literal_type_in_macro_expansion,none,
+      "macro expansion cannot introduce default literal type %0",
+      (Identifier))
 ERROR(invalid_macro_introduced_name,none,
       "declaration name %0 is not covered by macro %1",
       (DeclName, DeclName))

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -10110,7 +10110,7 @@ void MacroDecl::getIntroducedNames(MacroRole role, ValueDecl *attachedTo,
     }
 
     case MacroIntroducedDeclNameKind::Arbitrary:
-      // FIXME: Indicate that the macro covers arbitrary names.
+      names.push_back(MacroDecl::getArbitraryName());
       break;
     }
   }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -538,10 +538,13 @@ static void validateMacroExpansion(SourceFile *expansionBuffer,
         continue;
       }
 
-      if (!coversName.count(baseName)) {
-        value->diagnose(diag::invalid_macro_introduced_name,
-                        baseName, macro->getBaseName());
+      if (coversName.count(baseName) ||
+          coversName.count(MacroDecl::getArbitraryName())) {
+        continue;
       }
+
+      value->diagnose(diag::invalid_macro_introduced_name,
+                      baseName, macro->getBaseName());
     }
   }
 }

--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -476,6 +476,76 @@ ExpandPeerMacroRequest::evaluate(Evaluator &evaluator, Decl *decl) const {
   return decl->getASTContext().AllocateCopy(bufferIDs);
 }
 
+/// Diagnose macro expansions that produce any of the following declarations:
+///   - Import declarations
+///   - Operator and precedence group declarations
+///   - Macro declarations
+///   - Extensions
+///   - Types with `@main` attributes
+///   - Top-level default literal type overrides
+///   - Value decls with names not covered by the macro declaration.
+static void validateMacroExpansion(SourceFile *expansionBuffer,
+                                   MacroDecl *macro,
+                                   ValueDecl *attachedTo,
+                                   MacroRole role) {
+  // Gather macro-introduced names
+  llvm::SmallVector<DeclName, 2> introducedNames;
+  macro->getIntroducedNames(role, attachedTo, introducedNames);
+
+  llvm::SmallDenseSet<DeclName, 2> coversName(introducedNames.begin(),
+                                              introducedNames.end());
+
+  for (auto *decl : expansionBuffer->getTopLevelDecls()) {
+    auto &ctx = decl->getASTContext();
+
+    // Certain macro roles can generate special declarations.
+    if ((isa<AccessorDecl>(decl) && role == MacroRole::Accessor) ||
+        (isa<ExtensionDecl>(decl) && role == MacroRole::Conformance)) {
+      continue;
+    }
+
+    // Diagnose invalid declaration kinds.
+    if (isa<ImportDecl>(decl) ||
+        isa<OperatorDecl>(decl) ||
+        isa<PrecedenceGroupDecl>(decl) ||
+        isa<MacroDecl>(decl) ||
+        isa<ExtensionDecl>(decl)) {
+      decl->diagnose(diag::invalid_decl_in_macro_expansion,
+                     decl->getDescriptiveKind());
+    }
+
+    // Diagnose `@main` types.
+    if (auto *typeDecl = dyn_cast<TypeDecl>(decl)) {
+      if (typeDecl->getAttrs().hasAttribute<MainTypeAttr>()) {
+        typeDecl->diagnose(diag::invalid_main_type_in_macro_expansion);
+      }
+    }
+
+    // Diagnose default literal type overrides.
+    if (auto *typeAlias = dyn_cast<TypeAliasDecl>(decl)) {
+      // TODO
+    }
+
+    // Diagnose value decls with names not covered by the macro
+    if (auto *value = dyn_cast<ValueDecl>(decl)) {
+      auto baseName = value->getBaseName();
+      if (baseName.isSpecial()) {
+        baseName = ctx.getIdentifier(baseName.userFacingName());
+      }
+
+      // $-prefixed names are unique names. These are always allowed.
+      if (baseName.getIdentifier().hasDollarPrefix()) {
+        continue;
+      }
+
+      if (!coversName.count(baseName)) {
+        value->diagnose(diag::invalid_macro_introduced_name,
+                        baseName, macro->getBaseName());
+      }
+    }
+  }
+}
+
 /// Determine whether the given source file is from an expansion of the given
 /// macro.
 static bool isFromExpansionOfMacro(SourceFile *sourceFile, MacroDecl *macro,
@@ -1102,6 +1172,8 @@ evaluateAttachedMacro(MacroDecl *macro, Decl *attachedTo, CustomAttr *attr,
       /*parsingOpts=*/{}, /*isPrimary=*/false);
   macroSourceFile->setImports(declSourceFile->getImports());
 
+  validateMacroExpansion(macroSourceFile, macro,
+                         dyn_cast<ValueDecl>(attachedTo), role);
   return macroSourceFile;
 }
 

--- a/stdlib/public/core/Macros.swift
+++ b/stdlib/public/core/Macros.swift
@@ -86,7 +86,7 @@ public macro dsohandle() -> UnsafeRawPointer = Builtin.DSOHandleMacro
 ///         case standard
 ///       }
 ///     }
-@attached(member)
+@attached(member, names: named(RawValue), named(rawValue), named(`init`), arbitrary)
 @attached(conformance)
 public macro OptionSet<RawType>() =
   #externalMacro(module: "SwiftMacros", type: "OptionSetMacro")

--- a/test/Macros/Inputs/macro_library.swift
+++ b/test/Macros/Inputs/macro_library.swift
@@ -23,7 +23,10 @@ public struct ObservationRegistrar<Subject: Observable> {
   public func register<Value>(observable: Subject, didSet: KeyPath<Subject, Value>) {}
 }
 
-@attached(member)
+@attached(
+  member,
+  names: named(_registrar), named(addObserver), named(removeObserver), named(withTransaction), named(Storage), named(_storage)
+)
 @attached(memberAttribute)
 public macro Observable() = #externalMacro(module: "MacroDefinition", type: "ObservableMacro")
 

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -764,6 +764,27 @@ public struct AddCompletionHandler: PeerMacro {
   }
 }
 
+public struct InvalidMacro: PeerMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingPeersOf declaration: some DeclSyntaxProtocol,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      "import Swift",
+      "precedencegroup MyPrecedence {}",
+      "@attached(member) macro myMacro()",
+      "extension Int {}",
+      """
+      @main
+      struct MyMain {
+        static func main() {}
+      }
+      """,
+    ]
+  }
+}
+
 public struct WrapInType: PeerMacro {
   public static func expansion(
     of node: AttributeSyntax,

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -781,6 +781,17 @@ public struct InvalidMacro: PeerMacro {
         static func main() {}
       }
       """,
+      "typealias Array = Void",
+      "typealias Dictionary = Void",
+      "typealias BooleanLiteralType = Void",
+      "typealias ExtendedGraphemeClusterType = Void",
+      "typealias FloatLiteralType = Void",
+      "typealias IntegerLiteralType = Void",
+      "typealias StringLiteralType = Void",
+      "typealias UnicodeScalarType = Void",
+      "typealias _ColorLiteralType = Void",
+      "typealias _ImageLiteralType = Void",
+      "typealias _FileReferenceLiteralType = Void",
     ]
   }
 }

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -494,6 +494,25 @@ public struct AddMembers: MemberMacro {
   }
 }
 
+public struct AddArbitraryMembers: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf decl: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let identified = decl.asProtocol(IdentifiedDeclSyntax.self) else {
+      return []
+    }
+
+    let parentName = identified.identifier.trimmed
+    return [
+      "struct \(parentName)1 {}",
+      "struct \(parentName)2 {}",
+      "struct \(parentName)3 {}",
+    ]
+  }
+}
+
 /// Implementation of the `wrapStoredProperties` macro, which can be
 /// used to apply an attribute to all of the stored properties of a type.
 ///

--- a/test/Macros/composed_macro.swift
+++ b/test/Macros/composed_macro.swift
@@ -10,7 +10,7 @@
 // REQUIRES: OS=macosx
 
 @attached(memberAttribute)
-@attached(member)
+@attached(member, names: named(_storage))
 macro myTypeWrapper() = #externalMacro(module: "MacroDefinition", type: "TypeWrapperMacro")
 @attached(accessor) macro accessViaStorage() = #externalMacro(module: "MacroDefinition", type: "AccessViaStorageMacro")
 

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -32,31 +32,47 @@ macro Invalid() = #externalMacro(module: "MacroDefinition", type: "InvalidMacro"
 
 @Invalid
 struct Bad {}
-// expected-note@-1 7 {{in expansion of macro 'Invalid' here}}
+// expected-note@-1 18 {{in expansion of macro 'Invalid' here}}
 
 // CHECK-DIAGS: error: macro expansion cannot introduce import
+// CHECK-DIAGS: error: macro expansion cannot introduce precedence group
+// CHECK-DIAGS: error: macro expansion cannot introduce macro
+// CHECK-DIAGS: error: macro expansion cannot introduce extension
+// CHECK-DIAGS: error: macro expansion cannot introduce '@main' type
+// CHECK-DIAGS: error: declaration name 'MyMain' is not covered by macro 'Invalid'
+// CHECK-DIAGS: error: declaration name 'Array' is not covered by macro 'Invalid'
+// CHECK-DIAGS: error: declaration name 'Dictionary' is not covered by macro 'Invalid'
+// CHECK-DIAGS: error: macro expansion cannot introduce default literal type 'BooleanLiteralType'
+// CHECK-DIAGS: error: macro expansion cannot introduce default literal type 'ExtendedGraphemeClusterType'
+// CHECK-DIAGS: error: macro expansion cannot introduce default literal type 'FloatLiteralType'
+// CHECK-DIAGS: error: macro expansion cannot introduce default literal type 'IntegerLiteralType'
+// CHECK-DIAGS: error: macro expansion cannot introduce default literal type 'StringLiteralType'
+// CHECK-DIAGS: error: macro expansion cannot introduce default literal type 'UnicodeScalarType'
+// CHECK-DIAGS: error: macro expansion cannot introduce default literal type '_ColorLiteralType'
+// CHECK-DIAGS: error: macro expansion cannot introduce default literal type '_ImageLiteralType'
+// CHECK-DIAGS: error: macro expansion cannot introduce default literal type '_FileReferenceLiteralType'
+
 // CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser3BadV7InvalidfMp_.swift
 // CHECK-DIAGS: import Swift
-
-// CHECK-DIAGS: error: macro expansion cannot introduce precedence group
-// CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser3BadV7InvalidfMp_.swift
 // CHECK-DIAGS: precedencegroup MyPrecedence {}
-
-// CHECK-DIAGS: error: macro expansion cannot introduce macro
-// CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser3BadV7InvalidfMp_.swift
 // CHECK-DIAGS: @attached(member) macro myMacro()
-
-// CHECK-DIAGS: error: macro expansion cannot introduce extension
-// CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser3BadV7InvalidfMp_.swift
 // CHECK-DIAGS: extension Int {}
-
-// CHECK-DIAGS: error: macro expansion cannot introduce '@main' type'
-// CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser3BadV7InvalidfMp_.swift
 // CHECK-DIAGS: @main
-
-// CHECK-DIAGS: error: declaration name 'MyMain' is not covered by macro 'Invalid'
-// CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser3BadV7InvalidfMp_.swift
 // CHECK-DIAGS: struct MyMain {
+// CHECK-DIAGS:   static func main() {}
+// CHECK-DIAGS: }
+// CHECK-DIAGS: typealias Array = Void
+// CHECK-DIAGS: typealias Dictionary = Void
+// CHECK-DIAGS: typealias BooleanLiteralType = Void
+// CHECK-DIAGS: typealias ExtendedGraphemeClusterType = Void
+// CHECK-DIAGS: typealias FloatLiteralType = Void
+// CHECK-DIAGS: typealias IntegerLiteralType = Void
+// CHECK-DIAGS: typealias StringLiteralType = Void
+// CHECK-DIAGS: typealias UnicodeScalarType = Void
+// CHECK-DIAGS: typealias _ColorLiteralType = Void
+// CHECK-DIAGS: typealias _ImageLiteralType = Void
+// CHECK-DIAGS: typealias _FileReferenceLiteralType = Void
+// CHECK-DIAGS: END CONTENTS OF FILE
 #endif
 
 @freestanding(expression) macro customFileID() -> String = #externalMacro(module: "MacroDefinition", type: "FileIDMacro")

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -26,6 +26,39 @@
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx
 
+#if TEST_DIAGNOSTICS
+@attached(peer)
+macro Invalid() = #externalMacro(module: "MacroDefinition", type: "InvalidMacro")
+
+@Invalid
+struct Bad {}
+// expected-note@-1 7 {{in expansion of macro 'Invalid' here}}
+
+// CHECK-DIAGS: error: macro expansion cannot introduce import
+// CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser3BadV7InvalidfMp_.swift
+// CHECK-DIAGS: import Swift
+
+// CHECK-DIAGS: error: macro expansion cannot introduce precedence group
+// CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser3BadV7InvalidfMp_.swift
+// CHECK-DIAGS: precedencegroup MyPrecedence {}
+
+// CHECK-DIAGS: error: macro expansion cannot introduce macro
+// CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser3BadV7InvalidfMp_.swift
+// CHECK-DIAGS: @attached(member) macro myMacro()
+
+// CHECK-DIAGS: error: macro expansion cannot introduce extension
+// CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser3BadV7InvalidfMp_.swift
+// CHECK-DIAGS: extension Int {}
+
+// CHECK-DIAGS: error: macro expansion cannot introduce '@main' type'
+// CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser3BadV7InvalidfMp_.swift
+// CHECK-DIAGS: @main
+
+// CHECK-DIAGS: error: declaration name 'MyMain' is not covered by macro 'Invalid'
+// CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser3BadV7InvalidfMp_.swift
+// CHECK-DIAGS: struct MyMain {
+#endif
+
 @freestanding(expression) macro customFileID() -> String = #externalMacro(module: "MacroDefinition", type: "FileIDMacro")
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
 @freestanding(expression) macro fileID<T: ExpressibleByStringLiteral>() -> T = #externalMacro(module: "MacroDefinition", type: "FileIDMacro")

--- a/test/Macros/macro_expand_conformances.swift
+++ b/test/Macros/macro_expand_conformances.swift
@@ -40,7 +40,7 @@ requireEquatable(S2())
 requireHashable(S2())
 
 @attached(conformance)
-@attached(member)
+@attached(member, names: named(requirement))
 macro DelegatedConformance() = #externalMacro(module: "MacroDefinition", type: "DelegatedConformanceMacro")
 
 protocol P {

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -29,6 +29,19 @@ let s = S()
 // CHECK: Storage
 s.useSynthesized()
 
+@attached(member, names: arbitrary)
+macro addArbitraryMembers() = #externalMacro(module: "MacroDefinition", type: "AddArbitraryMembers")
+
+@addArbitraryMembers
+struct MyType {}
+
+// CHECK: MyType1
+// CHECK: MyType2
+// CHECK: MyType3
+print(MyType.MyType1.self)
+print(MyType.MyType2.self)
+print(MyType.MyType3.self)
+
 @attached(
   member,
   names: named(RawValue), named(rawValue), named(`init`)

--- a/test/Macros/macro_expand_synthesized_members.swift
+++ b/test/Macros/macro_expand_synthesized_members.swift
@@ -9,7 +9,11 @@
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx
 
-@attached(member) macro addMembers() = #externalMacro(module: "MacroDefinition", type: "AddMembers")
+@attached(
+  member,
+  names: named(Storage), named(storage), named(getStorage), named(method), named(`init`)
+)
+macro addMembers() = #externalMacro(module: "MacroDefinition", type: "AddMembers")
 
 @addMembers
 struct S {


### PR DESCRIPTION
Diagnose macro expansions that produce any of the following declarations:
 - Import declarations
 - Operator and precedence group declarations
 - Macro declarations
 - Extensions
 - Types with `@main` attributes
 - Top-level default literal type overrides
 - Value decls with names not covered by the macro declaration.

Resolves: rdar://105022807