### PR TITLE
[Macro] Fix macro role printing for declaration macros

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9893,7 +9893,7 @@ StringRef swift::getMacroRoleString(MacroRole role) {
     return "expression";
 
   case MacroRole::Declaration:
-    return "freestanding";
+    return "declaration";
 
   case MacroRole::Accessor:
     return "accessor";


### PR DESCRIPTION
A declaration macro attribute is currently printed as `@freestanding(freestanding)`, but should be `@freestanding(declaration)`.