### PR TITLE
[CMake] Don't add an extraneous rpath to the swift-frontend

### DIFF
--- a/tools/driver/CMakeLists.txt
+++ b/tools/driver/CMakeLists.txt
@@ -73,8 +73,6 @@ target_link_libraries(swift-frontend
 
 add_swift_parser_link_libraries(swift-frontend)
 
-_add_swift_runtime_link_flags(swift-frontend "../../lib" "")
-
 # Create a `swift-driver` executable adjacent to the `swift-frontend` executable
 # to ensure that `swiftc` forwards to the standalone driver when invoked.
 swift_create_early_driver_copies(swift-frontend)


### PR DESCRIPTION
When checking rpaths for #63782, I just noticed these incorrect runpaths on linux:
```
> readelf -d swift*-DEVELOPMENT-SNAPSHOT-2023-0*-a-ubuntu20.04/usr/bin/swift-frontend | ag "File:|runpath"
File: swift-5.8-DEVELOPMENT-SNAPSHOT-2023-02-23-a-ubuntu20.04/usr/bin/swift-frontend
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib/swift/linux:$ORIGIN/../../lib/swift/linux]
File: swift-DEVELOPMENT-SNAPSHOT-2023-03-01-a-ubuntu20.04/usr/bin/swift-frontend
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib/swift/linux:$ORIGIN/../../lib/swift/linux]
```
It looks like this line was incorrectly added in #60943, then incorporated into #61426 and merged.

This line is unused on Darwin because the CI builds with [`BOOTSTRAPPING-WITH-HOSTLIBS`](https://github.com/apple/swift/blob/41a903c425f8cce18de75cb306649abdc06b785b/cmake/modules/AddSwift.cmake#L491), but [the incorrect runpath should show up on macOS too if a full bootstrap were done](https://github.com/apple/swift/blob/41a903c425f8cce18de75cb306649abdc06b785b/cmake/modules/AddSwift.cmake#L514).

@zoecarver and @DougGregor, let me know what you think. 


