### PR TITLE
[PreCheckExpr] Allow pack references when resolving types during `TypeExpr` folding.

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3078,6 +3078,12 @@ namespace {
         if (auto *elementExpr = getAsExpr<PackElementExpr>(pack)) {
           packType = CS.getType(elementExpr->getPackRefExpr());
         } else if (auto *elementType = getAsTypeRepr<PackElementTypeRepr>(pack)) {
+          // OpenPackElementType sets types for 'each T' type reprs in
+          // expressions. Some invalid code won't make it there, and
+          // the constraint system won't have recorded a type.
+          if (!CS.hasType(elementType->getPackType()))
+            return Type();
+
           packType = CS.getType(elementType->getPackType());
         } else {
           llvm_unreachable("unsupported pack reference ASTNode");

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1435,8 +1435,13 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
   // Fold 'T.U' into a nested type.
 
   // Resolve the TypeRepr to get the base type for the lookup.
+  TypeResolutionOptions options(TypeResolverContext::InExpression);
+  // Pre-check always allows pack references during TypeExpr folding.
+  // CSGen will diagnose cases that appear outside of pack expansion
+  // expressions.
+  options |= TypeResolutionFlags::AllowPackReferences;
   const auto BaseTy = TypeResolution::resolveContextualType(
-      InnerTypeRepr, DC, TypeResolverContext::InExpression,
+      InnerTypeRepr, DC, options,
       [](auto unboundTy) {
         // FIXME: Don't let unbound generic types escape type resolution.
         // For now, just return the unbound generic type.

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -70,6 +70,7 @@ func typeReprPacks<each T>(_ t: repeat each T) where each T: ExpressibleByIntege
 
   _ = Array<each T>() // expected-error {{pack reference 'T' can only appear in pack expansion or generic requirement}}
   _ = 1 as each T // expected-error {{pack reference 'T' can only appear in pack expansion or generic requirement}}
+  repeat Invalid<String, each T>("") // expected-error {{cannot find 'Invalid' in scope}}
 }
 
 func sameShapeDiagnostics<each T, each U>(t: repeat each T, u: repeat each U) {

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -105,3 +105,14 @@ func tupleExpansion<each T, each U>(
   _ = zip(repeat each tuple1.element, with: repeat each tuple2.element)
   // expected-error@-1 {{global function 'zip(_:with:)' requires the type packs 'U' and 'T' have the same shape}}
 }
+
+protocol Generatable {
+  static func generate() -> Self
+}
+
+func generateTuple<each T : Generatable>() -> (repeat each T) {
+  (each T).generate()
+  // expected-error@-1 {{pack reference 'T' can only appear in pack expansion or generic requirement}}
+
+  return (repeat (each T).generate())
+}


### PR DESCRIPTION
Pre-check should always allow pack references during `TypeExpr` folding. CSGen will diagnose cases that appear outside of pack expansion expressions.