### PR TITLE
[ConstraintSystem] Handle invalid pack element bindings during `PackElementOf` simplification.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8804,12 +8804,21 @@ ConstraintSystem::simplifyPackElementOfConstraint(Type first, Type second,
 
   // This constraint only exists to vend bindings.
   auto *packEnv = DC->getGenericEnvironmentOfContext();
-  if ((!elementType->hasElementArchetype() && packType->isEqual(elementType)) ||
-      packType->isEqual(packEnv->mapElementTypeIntoPackContext(elementType))) {
-    return SolutionKind::Solved;
-  } else {
-    return SolutionKind::Error;
+
+  // Map element archetypes to the pack context to check for equality.
+  if (elementType->hasElementArchetype()) {
+    auto mappedPack = packEnv->mapElementTypeIntoPackContext(elementType);
+    return (packType->isEqual(mappedPack) ?
+            SolutionKind::Solved : SolutionKind::Error);
   }
+
+  // Pack expansions can have concrete pattern types. In this case, the pack
+  // type and element type will be equal.
+  if (packType->isEqual(elementType)) {
+    return SolutionKind::Solved;
+  }
+
+  return SolutionKind::Error;
 }
 
 static bool isForKeyPathSubscript(ConstraintSystem &cs,

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -117,3 +117,7 @@ func generateTuple<each T : Generatable>() -> (repeat each T) {
 
   return (repeat (each T).generate())
 }
+
+func packElementInvalidBinding<each T>(_ arg: repeat each T) {
+  _ = (repeat print(each arg))
+}


### PR DESCRIPTION
`mapElementTypeIntoPackContext` asserts if the given type does not contain any element archetypes, so `simplifyPackElementOfConstraint` needs to gate the call behind a check for `hasElementArchetype()`. This allows simplification to gracefully fail when given an invalid pack element binding.