### PR TITLE
[Code completion] Provide attached macro names after `@`

### DIFF
--- a/include/swift/IDE/CodeCompletionResultType.h
+++ b/include/swift/IDE/CodeCompletionResultType.h
@@ -28,6 +28,8 @@ enum class CustomAttributeKind : uint8_t {
   ResultBuilder = 1 << 1,
   /// A type that can be used as a global actor.
   GlobalActor = 1 << 2,
+  /// A macro can be used as a custom attribute.
+  Macro = 1 << 3,
 };
 
 /// The expected contextual type(s) for code-completion.

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1807,6 +1807,8 @@ void CodeCompletionCallbacksImpl::doneParsing(SourceFile *SrcFile) {
       ExpectedCustomAttributeKinds |= CustomAttributeKind::ResultBuilder;
       ExpectedCustomAttributeKinds |= CustomAttributeKind::GlobalActor;
     }
+    ExpectedCustomAttributeKinds |= CustomAttributeKind::Macro;
+
     Lookup.setExpectedTypes(/*Types=*/{},
                             /*isImplicitSingleExpressionReturn=*/false,
                             /*preferNonVoid=*/false,
@@ -1814,11 +1816,15 @@ void CodeCompletionCallbacksImpl::doneParsing(SourceFile *SrcFile) {
 
     // TypeName at attribute position after '@'.
     // - VarDecl: Property Wrappers.
-    // - ParamDecl/VarDecl/FuncDecl: Function Builders.
+    // - ParamDecl/VarDecl/FuncDecl: Result Builders.
     if (!AttTargetDK || *AttTargetDK == DeclKind::Var ||
         *AttTargetDK == DeclKind::Param || *AttTargetDK == DeclKind::Func)
       Lookup.getTypeCompletionsInDeclContext(
           P.Context.SourceMgr.getIDEInspectionTargetLoc());
+
+    // Macro name at attribute position after '@'.
+    Lookup.getToplevelCompletions(
+        /*OnlyTypes=*/false, /*OnlyMacros=*/true);
     break;
   }
   case CompletionKind::AttributeDeclParen: {

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -57,6 +57,8 @@ actor MyGenericGlobalActor<T> {
   static let shared = MyGenricGlobalActor<T>()
 }
 
+@attached(member)
+macro MyMacro() = #externalMacro(module: "Macros", type: "MyMacro")
 
 @available(#^AVAILABILITY1^#)
 
@@ -117,6 +119,7 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD2-DAG:              Decl[Struct]/CurrModule:            MyPropertyWrapper[#MyPropertyWrapper#]; name=MyPropertyWrapper
 // KEYWORD2-DAG:              Decl[Struct]/CurrModule/TypeRelation[Convertible]: MyResultBuilder[#MyResultBuilder#]; name=MyResultBuilder
 // KEYWORD2-DAG:              Decl[Actor]/CurrModule/TypeRelation[Convertible]: MyGlobalActor[#MyGlobalActor#]; name=MyGlobalActor
+// KEYWORD2-DAG:              Decl[Macro]/CurrModule: MyMacro[#Void#]; name=MyMacro
 // KEYWORD2:                  End completions
 
 @#^KEYWORD3^# class C {}
@@ -138,6 +141,7 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD3-NEXT:             Keyword/None:                       globalActor[#Class Attribute#]; name=globalActor
 // KEYWORD3-NEXT:             Keyword/None:                       preconcurrency[#Class Attribute#]; name=preconcurrency
 // KEYWORD3-NEXT:             Keyword/None:                       runtimeMetadata[#Class Attribute#]; name=runtimeMetadata
+// KEYWORD3-NEXT:             Decl[Macro]/CurrModule: MyMacro[#Void#]; name=MyMacro
 // KEYWORD3-NEXT:             End completions
 
 @#^KEYWORD3_2^#IB class C2 {}
@@ -157,6 +161,7 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD4-NEXT:             Keyword/None:                       globalActor[#Enum Attribute#]; name=globalActor
 // KEYWORD4-NEXT:             Keyword/None:                       preconcurrency[#Enum Attribute#]; name=preconcurrency
 // KEYWORD4-NEXT:             Keyword/None:                       runtimeMetadata[#Enum Attribute#]; name=runtimeMetadata
+// KEYWORD4-NEXT:             Decl[Macro]/CurrModule: MyMacro[#Void#]; name=MyMacro
 // KEYWORD4-NEXT:             End completions
 
 @#^KEYWORD5^# struct S{}
@@ -172,6 +177,7 @@ actor MyGenericGlobalActor<T> {
 // KEYWORD5-NEXT:             Keyword/None:                       globalActor[#Struct Attribute#]; name=globalActor
 // KEYWORD5-NEXT:             Keyword/None:                       preconcurrency[#Struct Attribute#]; name=preconcurrency
 // KEYWORD5-NEXT:             Keyword/None:                       runtimeMetadata[#Struct Attribute#]; name=runtimeMetadata
+// KEYWORD5-NEXT:             Decl[Macro]/CurrModule: MyMacro[#Void#]; name=MyMacro
 // KEYWORD5-NEXT:             End completions
 
 @#^ON_GLOBALVAR^# var globalVar


### PR DESCRIPTION
Add code completion support for attached macros, so they are provided as completions after a `@`