### PR TITLE
Add a test for a macro introducing members to an enum

### DIFF
--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -1082,3 +1082,17 @@ public struct DelegatedConformanceMacro: ConformanceMacro, MemberMacro {
     return [requirement]
   }
 }
+
+public struct ExtendableEnum: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    let unknownDecl: DeclSyntax =
+    """
+    func unknown() -> Int { 34 } // or something like: `case unknown`
+    """
+    return [unknownDecl]
+  }
+}

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -171,6 +171,17 @@ func testNestedDeclInExpr() {
 @freestanding(declaration, names: named(A), named(B), named(foo), named(addOne))
 macro defineDeclsWithKnownNames() = #externalMacro(module: "MacroDefinition", type: "DefineDeclsWithKnownNamesMacro")
 
+// Macros adding to an enum
+@attached(member, names: named(unknown), arbitrary)
+public macro ExtendableEnum() = #externalMacro(module: "MacroDefinition", type: "ExtendableEnum")
+
+@ExtendableEnum
+enum ElementType {
+case paper
+}
+
+print(ElementType.paper.unknown())
+
 // FIXME: Declaration macro expansions in BraceStmt don't work yet.
 //#bitwidthNumberedStructs("MyIntGlobal")
 


### PR DESCRIPTION
There was a short time where this was broken. Add a test to make sure we don't regress it later. rdar://105228228
