### PR TITLE
[Macros] Support @discardableResult on macro declarations.

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1828,6 +1828,16 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
     }
   }
 
+  // Check for macro expressions whose macros are marked as
+  // @discardableResult.
+  if (auto expansion = dyn_cast<MacroExpansionExpr>(valueE)) {
+    if (auto macro = expansion->getMacroRef().getDecl()) {
+      if (macro->getAttrs().hasAttribute<DiscardableResultAttr>()) {
+        return;
+      }
+    }
+  }
+
   // Complain about functions that aren't called.
   // TODO: What about tuples which contain functions by-value that are
   // dead?

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -92,6 +92,16 @@ testStringify(a: 1, b: 1)
 
 func maybeThrowing() throws -> Int { 5 }
 
+#if TEST_DIAGNOSTICS
+@freestanding(expression) @discardableResult
+macro discardableStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+
+func testDiscardableStringify(x: Int) {
+  #stringify(x + 1) // expected-warning{{expression of type '(Int, String)' is unused}}
+  #discardableStringify(x + 1)
+}
+#endif
+
 func testStringifyWithThrows() throws {
   // Okay, we can put the try inside or outside
   _ = try #stringify(maybeThrowing())

--- a/utils/gyb_syntax_support/AttributeKinds.py
+++ b/utils/gyb_syntax_support/AttributeKinds.py
@@ -378,7 +378,7 @@ DECL_ATTR_KINDS = [
                         ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=64),
     SimpleDeclAttribute('discardableResult', 'DiscardableResult',
-                        OnFunc, OnAccessor, OnConstructor,
+                        OnFunc, OnAccessor, OnConstructor, OnMacro,
                         LongAttribute,
                         ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,  # noqa: E501
                         code=65),


### PR DESCRIPTION
The result of an expansion of such macros can be silently ignored.

Fixes rdar://104040446