### PR TITLE
[Macros] Ensure that we escape macro declared names in printing.

### DIFF
--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -406,6 +406,10 @@ void printWithCompatibilityFeatureChecks(ASTPrinter &printer,
                                          Decl *decl,
                                          llvm::function_ref<void()> printBody);
 
+/// Determine whether we need to escape the given keyword within the
+/// given context, by wrapping it in backticks.
+bool escapeKeywordInContext(StringRef keyword, PrintNameContext context);
+
 } // namespace swift
 
 #endif // LLVM_SWIFT_AST_ASTPRINTER_H

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -489,8 +489,10 @@ ASTPrinter &operator<<(ASTPrinter &printer, tok keyword) {
 }
 
 /// Determine whether to escape the given keyword in the given context.
-static bool escapeKeywordInContext(StringRef keyword, PrintNameContext context){
-
+bool swift::escapeKeywordInContext(
+    StringRef keyword,
+    PrintNameContext context
+) {
   bool isKeyword = llvm::StringSwitch<bool>(keyword)
 #define KEYWORD(KW) \
       .Case(#KW, true)

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1365,7 +1365,16 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
           [&](MacroIntroducedDeclName name) {
             Printer << getMacroIntroducedDeclNameString(name.getKind());
             if (macroIntroducedNameRequiresArgument(name.getKind())) {
-              Printer << "(" << name.getIdentifier() << ")";
+              StringRef nameText = name.getIdentifier().str();
+              bool shouldEscape = escapeKeywordInContext(
+                  nameText, PrintNameContext::Normal) || nameText == "$";
+              Printer << "(";
+              if (shouldEscape)
+                Printer << "`";
+              Printer << nameText;
+              if (shouldEscape)
+                Printer << "`";
+              Printer << ")";
             }
           },
           [&] {

--- a/test/ModuleInterface/macros.swift
+++ b/test/ModuleInterface/macros.swift
@@ -21,5 +21,10 @@
 // CHECK-NEXT: #endif
 @attached(accessor) public macro myWrapper() = #externalMacro(module: "SomeModule", type: "Wrapper")
 
+// CHECK: #if compiler(>=5.3) && $Macros && $AttachedMacros
+// CHECK: @attached(member, names: named(`init`), prefixed(`$`)) public macro MemberwiseInit() -> () = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
+// CHECK-NEXT: #endif
+@attached(member, names: named(`init`), prefixed(`$`)) public macro MemberwiseInit() -> () = #externalMacro(module: "SomeModule", type: "MemberwiseInitMacro")
+
 // CHECK-NOT: internalStringify
 @freestanding(expression) macro internalStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")


### PR DESCRIPTION
Fixes an issue where we couldn't round-trip macro declared names
