### PR TITLE
[Macros] Call `visitAuxiliaryDecls` on every decl in `ASTWalker`

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -876,8 +876,10 @@ public:
   /// invoking the given callback with each auxiliary decl.
   ///
   /// Auxiliary declarations can be property wrapper backing variables,
-  /// backing variables for 'lazy' vars, or peer macro expansions.
-  void visitAuxiliaryDecls(AuxiliaryDeclCallback callback) const;
+  /// backing variables for 'lazy' vars, or expansions of freestanding, peer or
+  /// conformance macros.
+  void visitAuxiliaryDecls(AuxiliaryDeclCallback callback,
+                           bool includeMacroExpansions = true) const;
 
   using MacroCallback = llvm::function_ref<void(CustomAttr *, MacroDecl *)>;
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -380,11 +380,17 @@ DeclAttributes Decl::getSemanticAttrs() const {
   return getAttrs();
 }
 
-void Decl::visitAuxiliaryDecls(AuxiliaryDeclCallback callback) const {
+void Decl::visitAuxiliaryDecls(AuxiliaryDeclCallback callback,
+                               bool includeMacroExpansions) const {
   auto &ctx = getASTContext();
   auto *mutableThis = const_cast<Decl *>(this);
   SourceManager &sourceMgr = ctx.SourceMgr;
   auto *moduleDecl = getModuleContext();
+
+  // FIXME: fold VarDecl::visitAuxiliaryDecls into this.
+
+  if (!includeMacroExpansions)
+    return;
 
   auto peerBuffers =
       evaluateOrDefault(ctx.evaluator,
@@ -422,8 +428,6 @@ void Decl::visitAuxiliaryDecls(AuxiliaryDeclCallback callback) const {
         callback(decl);
     }
   }
-
-  // FIXME: fold VarDecl::visitAuxiliaryDecls into this.
 }
 
 void Decl::forEachAttachedMacro(MacroRole role,

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1792,9 +1792,7 @@ void SILGenModule::visitMacroDecl(MacroDecl *d) {
 }
 
 void SILGenModule::visitMacroExpansionDecl(MacroExpansionDecl *d) {
-  d->visitAuxiliaryDecls([&](Decl *decl) {
-    visit(decl);
-  });
+  // Expansions already visited as auxiliary decls.
 }
 
 bool


### PR DESCRIPTION
Hoist `visitAuxiliaryDecl` from `ASTWalker::visitMacroExpansionDecl` to `ASTWalker::doIt` to make sure all auxiliary decls are covered.

Because not all auxiliary decls are macro expansions, we need to add a `includeMacroExpansions` parameter to disable macro expansions when the walker is asked not to walk macro expansions. This cannot be done via checking in the closure body of `visitAuxiliaryDecl`, because expanding a macro needs parent contexts' local discriminators, which do not exist when it's inside of a `#if false`; in order words, we need to prevent expanding a macro instead of skipping a visit.