### PR TITLE
disallow failable initializers for noncopyable types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -6748,6 +6748,8 @@ ERROR(moveonly_enums_do_not_support_indirect,none,
       "move-only enum %0 cannot be marked indirect or have indirect cases yet", (Identifier))
 ERROR(moveonly_cast,none,
       "move-only types cannot be conditionally cast", ())
+ERROR(moveonly_failable_init,none,
+      "move-only types cannot have failable initializers yet", ())
 
 //------------------------------------------------------------------------------
 // MARK: Type inference from default expressions

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -3608,6 +3608,16 @@ public:
       addDelayedFunction(CD);
     }
 
+    // a move-only / noncopyable type cannot have a failable initializer, since
+    // that would require the ability to wrap one inside an optional
+    if (CD->isFailable()) {
+      if (auto *nom = CD->getDeclContext()->getSelfNominalTypeDecl()) {
+        if (nom->isMoveOnly()) {
+          CD->diagnose(diag::moveonly_failable_init);
+        }
+      }
+    }
+
     checkDefaultArguments(CD->getParameters());
     checkVariadicParameters(CD->getParameters(), CD);
   }

--- a/test/Sema/moveonly_restrictions.swift
+++ b/test/Sema/moveonly_restrictions.swift
@@ -1,10 +1,17 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-move-only -enable-experimental-feature MoveOnlyClasses
 
 class CopyableKlass {}
+
 @_moveOnly
-class MoveOnlyKlass {}
+class MoveOnlyKlass {
+    init?() {} // expected-error {{move-only types cannot have failable initializers yet}}
+}
+
 @_moveOnly
-class MoveOnlyStruct {}
+class MoveOnlyStruct {
+    init?(one: Bool) {} // expected-error {{move-only types cannot have failable initializers yet}}
+    init!(two: Bool) {} // expected-error {{move-only types cannot have failable initializers yet}}
+}
 
 class C {
     var copyable: CopyableKlass? = nil
@@ -57,6 +64,16 @@ enum E { // expected-error {{enum 'E' cannot contain a move-only type without al
 enum EMoveOnly {
     case lhs(CopyableKlass)
     case rhs(MoveOnlyKlass)
+
+    init?() {} // expected-error {{move-only types cannot have failable initializers yet}}
+}
+
+extension EMoveOnly {
+    init!(three: Bool) {} // expected-error {{move-only types cannot have failable initializers yet}}
+}
+
+extension MoveOnlyStruct {
+    convenience init?(three: Bool) {} // expected-error {{move-only types cannot have failable initializers yet}}
 }
 
 func foo() {


### PR DESCRIPTION
These initializers implicitly return an optional of the nominal type, but we can't wrap move-only / noncopyable types inside of optionals at the moment, because that would permit copying.

resolves rdar://106120881