### PR TITLE
[reference-bindings] Put inout parsing behind a flag harder.

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -220,9 +220,11 @@ parse_operator:
       // this, because then we can produce a fixit to rewrite the && into a ,
       // if we're in a stmt-condition.
       if (Tok.getText() == "&&" &&
-          peekToken().isAny(tok::pound_available, tok::pound_unavailable,
-                            tok::pound__hasSymbol, tok::kw_let, tok::kw_var,
-                            tok::kw_case, tok::kw_inout))
+          (peekToken().isAny(tok::pound_available, tok::pound_unavailable,
+                             tok::pound__hasSymbol, tok::kw_let, tok::kw_var,
+                             tok::kw_case) ||
+           (Context.LangOpts.hasFeature(Feature::ReferenceBindings) &&
+            peekToken().isAny(tok::kw_inout))))
         goto done;
       
       // Parse the operator.

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -327,7 +327,10 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
     
     // If let or var is being used as an argument label, allow it but
     // generate a warning.
-    if (!isClosure && Tok.isAny(tok::kw_let, tok::kw_var, tok::kw_inout)) {
+    if (!isClosure &&
+        (Tok.isAny(tok::kw_let, tok::kw_var) ||
+         (Context.LangOpts.hasFeature(Feature::ReferenceBindings) &&
+          Tok.isAny(tok::kw_inout)))) {
       diagnose(Tok, diag::parameter_let_var_as_attr, Tok.getText())
         .fixItReplace(Tok.getLoc(), "`" + Tok.getText().str() + "`");
     }
@@ -1286,7 +1289,9 @@ ParserResult<Pattern> Parser::parseMatchingPattern(bool isExprBasic) {
   // through the expr parser for ambiguous productions.
 
   // Parse productions that can only be patterns.
-  if (Tok.isAny(tok::kw_var, tok::kw_let, tok::kw_inout)) {
+  if (Tok.isAny(tok::kw_var, tok::kw_let) ||
+      (Context.LangOpts.hasFeature(Feature::ReferenceBindings) &&
+       Tok.isAny(tok::kw_inout))) {
     assert(Tok.isAny(tok::kw_let, tok::kw_var, tok::kw_inout) && "expects var or let");
     auto newPatternBindingState = PatternBindingState(Tok);
     SourceLoc varLoc = consumeToken();
@@ -1373,7 +1378,9 @@ Parser::parseMatchingPatternAsBinding(PatternBindingState newState,
 }
 
 bool Parser::isOnlyStartOfMatchingPattern() {
-  return Tok.isAny(tok::kw_var, tok::kw_let, tok::kw_is, tok::kw_inout);
+  return Tok.isAny(tok::kw_var, tok::kw_let, tok::kw_is) ||
+         (Context.LangOpts.hasFeature(Feature::ReferenceBindings) &&
+          Tok.isAny(tok::kw_inout));
 }
 
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1568,7 +1568,9 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
 
   // Parse the basic expression case.  If we have a leading let/var/case
   // keyword or an assignment, then we know this is a binding.
-  if (Tok.isNot(tok::kw_let, tok::kw_var, tok::kw_case, tok::kw_inout)) {
+  if (Tok.isNot(tok::kw_let, tok::kw_var, tok::kw_case) &&
+      (!Context.LangOpts.hasFeature(Feature::ReferenceBindings) ||
+       Tok.isNot(tok::kw_inout))) {
     // If we lack it, then this is theoretically a boolean condition.
     // However, we also need to handle migrating from Swift 2 syntax, in
     // which a comma followed by an expression could actually be a pattern
@@ -1600,7 +1602,9 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
   }
 
   SourceLoc IntroducerLoc;
-  if (Tok.isAny(tok::kw_let, tok::kw_var, tok::kw_case, tok::kw_inout)) {
+  if (Tok.isAny(tok::kw_let, tok::kw_var, tok::kw_case) ||
+      (Context.LangOpts.hasFeature(Feature::ReferenceBindings) &&
+       Tok.isAny(tok::kw_inout))) {
     BindingKindStr = Tok.getText();
     IntroducerLoc = consumeToken();
   } else {

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -747,7 +747,9 @@ void Parser::skipListUntilDeclRBrace(SourceLoc startLoc, tok T1, tok T2) {
       
       // Could have encountered something like `_ var:` 
       // or `let foo:` or `var:`
-      if (Tok.isAny(tok::kw_var, tok::kw_let, tok::kw_inout)) {
+      if (Tok.isAny(tok::kw_var, tok::kw_let) ||
+          (Context.LangOpts.hasFeature(Feature::ReferenceBindings) &&
+           Tok.isAny(tok::kw_inout))) {
         if (possibleDeclStartsLine && !hasDelimiter) {
           break;
         }

--- a/test/Parse/matching_patterns.swift
+++ b/test/Parse/matching_patterns.swift
@@ -30,8 +30,8 @@ case var a:
   a = 1
 case let a:
   a = 1         // expected-error {{cannot assign}}
-case inout a:
-  a = 1
+case inout a: // expected-error {{'inout' may only be used on parameters}} expected-error {{'is' keyword required to pattern match against type name}}
+  a = 1 // expected-error {{cannot find 'a' in scope}}
 case var var a: // expected-error {{'var' cannot appear nested inside another 'var' or 'let' pattern}}
   a += 1
 case var let a: // expected-error {{'let' cannot appear nested inside another 'var' or 'let' pattern}}
@@ -52,14 +52,6 @@ case (var a, var a): // expected-error {{invalid redeclaration of 'a'}} expected
   fallthrough
 case _: // expected-warning {{case is already handled by previous patterns; consider removing it}}
   ()
-}
-
-switch (x,x) {
-case (inout a, inout a): // expected-error {{invalid redeclaration of 'a'}}
-    // expected-note @-1 {{'a' previously declared here}}
-    // xpected-warning @-2 {{variable 'a' was never used; consider replacing with '_' or removing it}}
-    // xpected-warning @-3 {{variable 'a' was never used; consider replacing with '_' or removing it}}
-  break
 }
 
 var e : Any = 0
@@ -128,12 +120,6 @@ if case let .Naught(value) = n {} // expected-error{{pattern with associated val
 if case let .Naught(value1, value2, value3) = n {} // expected-error{{pattern with associated values does not match enum case 'Naught'}}
                                                    // expected-note@-1 {{remove associated values to make the pattern match}} {{20-44=}}
 
-if case inout .Naught(value) = n {} // expected-error{{pattern with associated values does not match enum case 'Naught'}}
-                                  // expected-note@-1 {{remove associated values to make the pattern match}} {{22-29=}}
-if case inout .Naught(value1, value2, value3) = n {} // expected-error{{pattern with associated values does not match enum case 'Naught'}}
-                                                   // expected-note@-1 {{remove associated values to make the pattern match}} {{22-46=}}
-
-
 
 switch n {
 case Foo.A: // expected-error{{enum case 'A' is not a member of type 'Voluntary<Int>'}}
@@ -156,7 +142,7 @@ case Voluntary<Int>.Mere,
   ()
 case .Twain,
      .Twain(_), // expected-warning {{enum case 'Twain' has 2 associated values; matching them as a tuple is deprecated}}
-                // expected-note@-74 {{'Twain' declared here}}
+                // expected-note@-68 {{'Twain' declared here}}
      .Twain(_, _),
      .Twain(_, _, _): // expected-error{{tuple pattern has the wrong length for tuple type '(Int, Int)'}}
   ()
@@ -299,9 +285,6 @@ case (_, var e, 3) +++ (1, 2, 3):
 // expected-error@-1{{'_' can only appear in a pattern or on the left side of an assignment}}
   ()
 case (let (_, _, _)) + 1:
-// expected-error@-1 {{'_' can only appear in a pattern or on the left side of an assignment}}
-  ()
-case (inout (_, _, 2)) + 1:
 // expected-error@-1 {{'_' can only appear in a pattern or on the left side of an assignment}}
   ()
 }


### PR DESCRIPTION
In my earlier commit that attempted to do this I wasn't aggressive enough. In this commit, I was more aggressive in putting it behind a flag and as a result we reject all of the patterns in the tests I added into tree.

rdar://106262161