### PR TITLE
ensure decls using move-only types are feature-guarded

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3159,8 +3159,27 @@ static bool usesFeatureFlowSensitiveConcurrencyCaptures(Decl *decl) {
 }
 
 static bool usesFeatureMoveOnly(Decl *decl) {
-  if (auto nominal = dyn_cast<NominalTypeDecl>(decl))
-    return nominal->isMoveOnly();
+  if (auto *extension = dyn_cast<ExtensionDecl>(decl)) {
+    if (auto *nominal = extension->getSelfNominalTypeDecl())
+      if (nominal->isMoveOnly())
+        return true;
+  }
+
+  if (auto value = dyn_cast<ValueDecl>(decl)) {
+      if (value->isMoveOnly())
+        return true;
+
+    // Check for move-only types in the types of this declaration.
+    if (Type type = value->getInterfaceType()) {
+      bool hasMoveOnly = type.findIf([](Type type) {
+        return type->isPureMoveOnly();
+      });
+
+      if (hasMoveOnly)
+        return true;
+    }
+  }
+
   return false;
 }
 

--- a/test/ModuleInterface/moveonly_interface_flag.swift
+++ b/test/ModuleInterface/moveonly_interface_flag.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -enable-experimental-feature MoveOnly
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -I %t
+// RUN: %FileCheck %s < %t/Library.swiftinterface
+
+// this test makes sure that decls containing a move-only type are guarded by the $MoveOnly feature flag
+
+// CHECK: swift-module-flags-ignorable: -enable-experimental-feature MoveOnly
+
+// CHECK:       #if compiler(>=5.3) && $MoveOnly
+// CHECK-NEXT:    @_moveOnly public struct MoveOnlyStruct {
+
+// CHECK:      #if compiler(>=5.3) && $MoveOnly
+// CHECK-NEXT:   @_moveOnly public enum MoveOnlyEnum {
+
+// CHECK:      #if compiler(>=5.3) && $MoveOnly
+// CHECK-NEXT:   public func someFn() -> Library.MoveOnlyEnum
+
+// CHECK:     public class What {
+// CHECK:       #if compiler(>=5.3) && $MoveOnly
+// CHECK-NEXT:    public func diamonds(_ f: (borrowing Library.MoveOnlyStruct) -> Swift.Int)
+
+// CHECK: #if compiler(>=5.3) && $MoveOnly
+// CHECK-NEXT:  extension Library.MoveOnlyStruct {
+
+@_moveOnly public struct MoveOnlyStruct {
+  let x = 0
+}
+
+@_moveOnly public enum MoveOnlyEnum {
+  case depth
+}
+
+public func someFn() -> MoveOnlyEnum { return .depth }
+
+public class What {
+  public func diamonds(_ f: (borrowing MoveOnlyStruct) -> Int) {}
+}
+
+public extension MoveOnlyStruct {
+  func who() {}
+}
+
+


### PR DESCRIPTION
Make sure swiftinterface files that contain move-only types property guard those decls with `$MoveOnly` so that older compilers or ones without the feature enabled can still handle the interface file.

TODO: determine what should happen with the flag's setting in Features.def

rdar://106262652