### PR TITLE
[Test] Rename substitution so it isn't incorrectly substituted

### DIFF
--- a/test/Driver/batch_mode_dependencies_make_wrong_order.swift
+++ b/test/Driver/batch_mode_dependencies_make_wrong_order.swift
@@ -4,17 +4,16 @@
 // RUN: echo 'class c : b {}' >%t/c.swift
 // RUN: echo 'class d : c {}' >%t/d.swift
 // RUN: echo 'public func main() {}' >%t/main.swift
-// REQUIRES: rdar106170241 
 
 // First prime the incremental state, but note that we're building in the d c b a (reverse-alphabetical) order.
-// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -incremental -output-file-map %S/Inputs/abcd_filemap.yaml -module-name main -j 1 d.swift c.swift b.swift a.swift main.swift
+// RUN: cd %t && %target-stdlib-swiftc_driver -enable-batch-mode -incremental -output-file-map %S/Inputs/abcd_filemap.yaml -module-name main -j 1 d.swift c.swift b.swift a.swift main.swift
 //
 // Now perturb the interface of a.swift and delete its output
 // RUN: echo 'class a { var x : Int = 10 }' >%t/a.swift
 // RUN: rm %t/a.o
 //
 // Now rebuild, which will rebuild a.swift then do a cascading dep-graph invalidation
-// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -incremental -output-file-map %S/Inputs/abcd_filemap.yaml -module-name main -j 1 d.swift c.swift b.swift a.swift main.swift -driver-show-incremental -driver-show-job-lifecycle >%t/out.txt 2>&1
+// RUN: cd %t && %target-stdlib-swiftc_driver -enable-batch-mode -incremental -output-file-map %S/Inputs/abcd_filemap.yaml -module-name main -j 1 d.swift c.swift b.swift a.swift main.swift -driver-show-incremental -driver-show-job-lifecycle >%t/out.txt 2>&1
 // RUN: %FileCheck %s <%t/out.txt
 //
 // Check that we saw invalidation happen in command-line argument order

--- a/test/Incremental/Fingerprints/class-fingerprint.swift
+++ b/test/Incremental/Fingerprints/class-fingerprint.swift
@@ -10,7 +10,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -24,13 +24,11 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 
 // RUN: %FileCheck -check-prefix=CHECK-MAINAB-RECOMPILED %s < %t/output4
-
-// REQUIRES: rdar106170343
 
 // CHECK-MAINAB-RECOMPILED: Queuing (initial): {compile: definesAB.o <= definesAB.swift}
 // CHECK-MAINAB-RECOMPILED: Queuing because of dependencies discovered later: {compile: usesA.o <= usesA.swift}

--- a/test/Incremental/Fingerprints/enum-fingerprint.swift
+++ b/test/Incremental/Fingerprints/enum-fingerprint.swift
@@ -10,7 +10,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -24,12 +24,11 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 
 // RUN: %FileCheck -check-prefix=CHECK-MAINAB-RECOMPILED %s < %t/output4
 
-// REQUIRES: rdar106170343
 // CHECK-MAINAB-RECOMPILED: Queuing (initial): {compile: definesAB.o <= definesAB.swift}
 // CHECK-MAINAB-RECOMPILED: Queuing because of dependencies discovered later: {compile: usesA.o <= usesA.swift}

--- a/test/Incremental/Fingerprints/extension-adds-member.swift
+++ b/test/Incremental/Fingerprints/extension-adds-member.swift
@@ -10,7 +10,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output3
+// RUN: cd %t && %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output3
 
 // Change one type, only uses of that type get recompiled
 
@@ -21,12 +21,10 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output4
+// RUN: cd %t && %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json  >& %t/output4
 
 // RUN: %FileCheck -check-prefix=CHECK-RECOMPILED-W %s < %t/output4
 // RUN: %FileCheck -check-prefix=CHECK-NOT-RECOMPILED-W %s < %t/output4
-
-// REQUIRES: rdar106170343
 
 // CHECK-RECOMPILED-W: {compile: definesAB.o <= definesAB.swift}
 // CHECK-RECOMPILED-W: {compile: usesA.o <= usesA.swift}

--- a/test/Incremental/Fingerprints/nested-enum-fingerprint.swift
+++ b/test/Incremental/Fingerprints/nested-enum-fingerprint.swift
@@ -10,7 +10,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -24,7 +24,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 

--- a/test/Incremental/Fingerprints/protocol-fingerprint.swift
+++ b/test/Incremental/Fingerprints/protocol-fingerprint.swift
@@ -10,7 +10,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -24,13 +24,11 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 
 // RUN: %FileCheck -check-prefix=CHECK-MAINAB-RECOMPILED %s < %t/output4
-
-// REQUIRES: rdar106170343
 
 // CHECK-MAINAB-RECOMPILED: Queuing (initial): {compile: definesAB.o <= definesAB.swift}
 // CHECK-MAINAB-RECOMPILED: Queuing because of dependencies discovered later: {compile: usesA.o <= usesA.swift}

--- a/test/Incremental/Fingerprints/struct-fingerprint.swift
+++ b/test/Incremental/Fingerprints/struct-fingerprint.swift
@@ -10,7 +10,7 @@
 // Seeing weird failure on CI, so set the mod times
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output3
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB3.swiftdeps
 
@@ -24,7 +24,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesAB.swift
 
-// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesAB.swift usesA.swift usesB.swift -module-name main -output-file-map ofm.json >&output4
 
 // only-run-for-debugging: cp %t/usesB.swiftdeps %t/usesB4.swiftdeps
 

--- a/test/Incremental/cross-file-failure.swift
+++ b/test/Incremental/cross-file-failure.swift
@@ -6,7 +6,7 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: cd %t
 
-// RUN: %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesA.swift usesA.swift -module-name main -output-file-map ofm.json >&output-baseline
+// RUN: %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesA.swift usesA.swift -module-name main -output-file-map ofm.json >&output-baseline
 
 // Change one type and cause a syntax error. This should cause _both_ files to
 // rebuild.
@@ -16,16 +16,14 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesA.swift
 
-// RUN: not %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesA.swift usesA.swift -module-name main -output-file-map ofm.json
+// RUN: not %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesA.swift usesA.swift -module-name main -output-file-map ofm.json
 
 // RUN: cp %t/definesA{-three,}.swift
 // RUN: touch -t 200401010101 %t/definesA.swift
 
-// RUN: not %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesA.swift usesA.swift -module-name main -output-file-map ofm.json >&output-incremental
+// RUN: not %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesA.swift usesA.swift -module-name main -output-file-map ofm.json >&output-incremental
 
 // RUN: %FileCheck -check-prefix=CHECK-RECOMPILED %s --dump-input=always < %t/output-incremental
-
-// REQUIRES: rdar106170343
 
 // CHECK-RECOMPILED: Queuing (initial): {compile: definesA.o <= definesA.swift}
 // CHECK-RECOMPILED: Queuing because of dependencies discovered later: {compile: usesA.o <= usesA.swift}

--- a/test/Incremental/superfluous-cascade.swift
+++ b/test/Incremental/superfluous-cascade.swift
@@ -5,7 +5,7 @@
 // RUN: cp %t/definesPoint{-before,}.swift
 // RUN: touch -t 200101010101 %t/*.swift
 
-// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesPoint.swift usesPoint.swift usesDisplay.swift -module-name main -output-file-map ofm.json >&output3
+// RUN: cd %t && %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesPoint.swift usesPoint.swift usesDisplay.swift -module-name main -output-file-map ofm.json >&output3
 
 // Change one type - now only the user of that type rebuilds
 
@@ -14,11 +14,9 @@
 // RUN: touch -t 200101010101 %t/*.swift
 // RUN: touch -t 200301010101 %t/definesPoint.swift
 
-// RUN: cd %t && %swiftc_driver-stdlib-target -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesPoint.swift usesPoint.swift usesDisplay.swift  -module-name main -output-file-map ofm.json >&output4
+// RUN: cd %t && %target-stdlib-swiftc_driver -enable-batch-mode -j2 -incremental -driver-show-incremental main.swift definesPoint.swift usesPoint.swift usesDisplay.swift  -module-name main -output-file-map ofm.json >&output4
 
 // RUN: %FileCheck -check-prefix=CHECK-RECOMPILED %s --dump-input=always < %t/output4
-
-// REQUIRES: rdar106170343
 
 // CHECK-RECOMPILED: Queuing because of dependencies discovered later: {compile: usesPoint.o <= usesPoint.swift}
 // CHECK-RECOMPILED-NOT: Queuing because of dependencies discovered later: {compile: usesDisplay.o <= usesDisplay.swift}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1329,7 +1329,7 @@ if run_vendor == 'apple':
          "-Xlinker -headerpad_max_install_names " +  
          "-Xlinker -rpath -Xlinker /usr/lib/swift %s ")%
         (xcrun_prefix, config.swiftc, target_options, config.swift_driver_test_options))
-    config.swiftc_driver_stdlib_target = config.target_swiftc_driver
+    config.target_stdlib_swiftc_driver = config.target_swiftc_driver
     config.target_clang = (
         "%s %s %s" %
         (xcrun_prefix, config.clangxx, config.target_cc_options))
@@ -1468,7 +1468,7 @@ elif run_os in ['windows-msvc']:
                                             config.resource_dir_opt, mcp_opt,    \
                                             config.swift_system_overlay_opt,     \
                                             config.swift_driver_test_options))
-    config.swiftc_driver_stdlib_target =                                         \
+    config.target_stdlib_swiftc_driver =                                         \
             ('%r -target %s %s %s %s' % (config.swiftc, config.variant_triple,   \
                                          config.resource_dir_opt, mcp_opt,       \
                                          config.swift_driver_test_options))
@@ -1599,7 +1599,7 @@ elif (run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'openbsd', 'windows-
     config.target_swiftc_driver = (
         "%s -target %s -toolchain-stdlib-rpath %s %s %s" %
         (config.swiftc, config.variant_triple, config.resource_dir_opt, mcp_opt, config.swift_driver_test_options))
-    config.swiftc_driver_stdlib_target = config.target_swiftc_driver
+    config.target_stdlib_swiftc_driver = config.target_swiftc_driver
     config.target_swift_modulewrap = (
         '%s -modulewrap -target %s' %
         (config.swiftc, config.variant_triple))
@@ -1718,7 +1718,7 @@ elif run_os == 'linux-androideabi' or run_os == 'linux-android':
         '-tools-directory', tools_directory,
         config.resource_dir_opt, mcp_opt,
         config.swift_driver_test_options])
-    config.swiftc_driver_stdlib_target = config.target_swiftc_driver
+    config.target_stdlib_swiftc_driver = config.target_swiftc_driver
     config.target_swift_modulewrap = ' '.join([
         config.swiftc, '-modulewrap',
         '-target', config.variant_triple])
@@ -1786,7 +1786,7 @@ elif run_os == 'wasi':
     config.target_swiftc_driver = (
         "%s -target %s -toolchain-stdlib-rpath %s %s" %
         (config.swiftc, config.variant_triple, config.resource_dir_opt, mcp_opt))
-    config.swiftc_driver_stdlib_target = config.target_swiftc_driver
+    config.target_stdlib_swiftc_driver = config.target_swiftc_driver
     config.target_swift_modulewrap = (
         '%s -modulewrap -target %s' %
         (config.swiftc, config.variant_triple))
@@ -2504,7 +2504,7 @@ config.substitutions.append(('%target-swift-reflection-test', config.target_swif
 
 config.substitutions.append(('%target-swift-reflection-dump', '{} {} {}'.format(config.swift_reflection_dump, '-arch', run_cpu)))
 config.substitutions.append(('%target-swiftc_driver', config.target_swiftc_driver))
-config.substitutions.append(('%swiftc_driver-stdlib-target', config.swiftc_driver_stdlib_target))
+config.substitutions.append(('%target-stdlib-swiftc_driver', config.target_stdlib_swiftc_driver))
 
 config.substitutions.append(('%target-swift-remoteast-test-with-sdk',
                              '%s %s -sdk %r' %


### PR DESCRIPTION
`%swiftc_driver` is a substitution already, which means `%swiftc_driver_stdlib_target` was actually being substituted as `%swiftc_driver` first with `-stdlib-target` tacked on the end.

Resolves rdar://106170241 and rdar://106170343.