### PR TITLE
Make the interface type of a generic macro into a GenericFunctionType.

### DIFF
--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -1808,7 +1808,7 @@ void CompletionLookup::addMacroExpansion(const MacroDecl *MD,
   Type macroType = MD->getInterfaceType();
   if (MD->parameterList && MD->parameterList->size() > 0) {
     Builder.addLeftParen();
-    addCallArgumentPatterns(Builder, macroType->castTo<FunctionType>(),
+    addCallArgumentPatterns(Builder, macroType->castTo<AnyFunctionType>(),
                             MD->parameterList,
                             MD->getGenericSignature());
     Builder.addRightParen();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1673,13 +1673,12 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
 
     // Open any the generic types.
     OpenedTypeMap replacements;
-    openGeneric(macro->getParentModule(), macro->getGenericSignature(),
-                locator, replacements);
+    Type openedType = openFunctionType(
+        macroType->castTo<AnyFunctionType>(), locator, replacements,
+        macro->getDeclContext());
 
     // If we opened up any type variables, record the replacements.
     recordOpenedTypes(locator, replacements);
-
-    Type openedType = openType(macroType, replacements);
 
     // FIXME: Should we use replaceParamErrorTypeByPlaceholder() here?
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -2595,8 +2595,15 @@ InterfaceTypeRequest::evaluate(Evaluator &eval, ValueDecl *D) const {
 
     SmallVector<AnyFunctionType::Param, 4> paramTypes;
     macro->parameterList->getParams(paramTypes);
-    FunctionType::ExtInfo info;
-    return FunctionType::get(paramTypes, resultType, info);
+
+    if (auto genericSig = macro->getGenericSignature()) {
+      GenericFunctionType::ExtInfo info;
+      return GenericFunctionType::get(
+          genericSig, paramTypes, resultType, info);
+    } else {
+      FunctionType::ExtInfo info;
+      return FunctionType::get(paramTypes, resultType, info);
+    }
   }
   }
   llvm_unreachable("invalid decl kind");

--- a/test/Index/index_macros.swift
+++ b/test/Index/index_macros.swift
@@ -15,13 +15,13 @@ func test(x: Int) {
 
 // CHECK: 6:33 | macro/Swift | myLine() | s:14swift_ide_test6myLineSiycfm | Def | rel: 0
 // CHECK: 6:45 | struct/Swift | Int | s:Si | Ref | rel: 0
-// CHECK: 7:33 | macro/Swift | myFilename() | s:14swift_ide_test10myFilenamexycfm | Def | rel: 0
+// CHECK: 7:33 | macro/Swift | myFilename() | s:14swift_ide_test10myFilenamexycs26ExpressibleByStringLiteralRzlufm | Def | rel: 0
 // CHECK: 7:47 | protocol/Swift | ExpressibleByStringLiteral | s:s26ExpressibleByStringLiteralP | Ref | rel: 0
-// CHECK: 8:33 | macro/Swift | myStringify(_:) | s:14swift_ide_test11myStringifyyx_SStxcfm | Def | rel: 0
+// CHECK: 8:33 | macro/Swift | myStringify(_:) | s:14swift_ide_test11myStringifyyx_SStxclufm | Def | rel: 0
 
 // CHECK: 11:8 | macro/Swift | myLine() | s:14swift_ide_test6myLineSiycfm | Ref,RelCont | rel: 1
-// CHECK: 12:20 | macro/Swift | myFilename() | s:14swift_ide_test10myFilenamexycfm | Ref,RelCont | rel: 1
-// CHECK: 13:8 | macro/Swift | myStringify(_:) | s:14swift_ide_test11myStringifyyx_SStxcfm | Ref,RelCont | rel: 1
+// CHECK: 12:20 | macro/Swift | myFilename() | s:14swift_ide_test10myFilenamexycs26ExpressibleByStringLiteralRzlufm | Ref,RelCont | rel: 1
+// CHECK: 13:8 | macro/Swift | myStringify(_:) | s:14swift_ide_test11myStringifyyx_SStxclufm | Ref,RelCont | rel: 1
 // CHECK: 13:20 | param/Swift | x | s:14swift_ide_test0C01xySi_tFACL_Sivp | Ref,Read,RelCont | rel: 1
 // CHECK: 13:22 | static-method/infix-operator/Swift | +(_:_:) | s:Si1poiyS2i_SitFZ | Ref,Call,RelCall,RelCont | rel: 1
 // CHECK: 13:24 | param/Swift | x | s:14swift_ide_test0C01xySi_tFACL_Sivp | Ref,Read,RelCont | rel: 1

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -63,6 +63,15 @@ func overloaded1(_ p: Any) { }
 @freestanding(expression) macro notOverloaded1(_ p: P) = #externalMacro(module: "MissingModule", type: "MissingOtherType") // expected-error{{invalid redeclaration of 'notOverloaded1'}}
 // expected-warning@-1{{external macro implementation type}}
 
+// Overloading based on generic constraint.
+public protocol ResultBuilder {
+}
+
+@freestanding(expression) public macro ApplyBuilder<R: ResultBuilder>(resultBuilder: R.Type, to closure: () -> Void) -> (() -> String) = #externalMacro(module: "MacroExamplesPlugin", type: "ResultBuilderMacro")
+// expected-warning@-1{{external macro implementation type}}
+@freestanding(expression)  public macro ApplyBuilder<R>(resultBuilder: R.Type, to closure: () -> Void) -> (() -> String) = #externalMacro(module: "MacroExamplesPlugin", type: "ResultBuilderMacro2")
+// expected-warning@-1{{external macro implementation type}}
+
 @freestanding(expression) macro intIdentity(value: Int, _: Float) -> Int = #externalMacro(module: "MissingModule", type: "MissingType")
 // expected-note@-1{{'intIdentity(value:_:)' declared here}}
 // expected-warning@-2{{external macro implementation type}}

--- a/test/SourceKit/Macros/macro_basic.swift
+++ b/test/SourceKit/Macros/macro_basic.swift
@@ -93,7 +93,7 @@ struct S4 { }
 // CURSOR_MACRONAME-LABEL: SYMBOL GRAPH BEGIN
 // CURSOR_MACRONAME: "identifier": {
 // CURSOR_MACRONAME-NEXT:   "interfaceLanguage": "swift",
-// CURSOR_MACRONAME-NEXT:   "precise": "s:9MacroUser9stringifyyx_SStxcfm"
+// CURSOR_MACRONAME-NEXT:   "precise": "s:9MacroUser9stringifyyx_SStxclufm"
 // CURSOR_MACRONAME-NEXT: },
 // CURSOR_MACRONAME-NEXT: "kind": {
 // CURSOR_MACRONAME-NEXT:   "displayName": "Macro",


### PR DESCRIPTION
This correctly models their type in the type system, and fixes the redeclaration issue reported in rdar://104183961.
