### PR TITLE
[Macros] Validate freestanding macro expansions.

### DIFF
--- a/lib/Sema/TypeCheckMacros.cpp
+++ b/lib/Sema/TypeCheckMacros.cpp
@@ -908,6 +908,10 @@ swift::expandFreestandingDeclarationMacro(MacroExpansionDecl *med) {
       /*parsingOpts=*/{}, /*isPrimary=*/false);
   macroSourceFile->setImports(sourceFile->getImports());
 
+  validateMacroExpansion(macroSourceFile, macro,
+                         /*attachedTo*/nullptr,
+                         MacroRole::Declaration);
+
   PrettyStackTraceDecl debugStack(
       "type checking expanded declaration macro", med);
 

--- a/test/Macros/Inputs/syntax_macro_definitions.swift
+++ b/test/Macros/Inputs/syntax_macro_definitions.swift
@@ -764,7 +764,7 @@ public struct AddCompletionHandler: PeerMacro {
   }
 }
 
-public struct InvalidMacro: PeerMacro {
+public struct InvalidMacro: PeerMacro, DeclarationMacro {
   public static func expansion(
     of node: AttributeSyntax,
     providingPeersOf declaration: some DeclSyntaxProtocol,
@@ -792,6 +792,15 @@ public struct InvalidMacro: PeerMacro {
       "typealias _ColorLiteralType = Void",
       "typealias _ImageLiteralType = Void",
       "typealias _FileReferenceLiteralType = Void",
+    ]
+  }
+
+  public static func expansion(
+    of node: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    return [
+      "var value: Int"
     ]
   }
 }

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -27,6 +27,19 @@
 // REQUIRES: OS=macosx
 
 #if TEST_DIAGNOSTICS
+@freestanding(declaration)
+macro NotCovered() = #externalMacro(module: "MacroDefinition", type: "InvalidMacro")
+
+struct MemberNotCovered {
+  #NotCovered
+  // expected-note@-1 {{in expansion of macro 'NotCovered' here}}
+
+  // CHECK-DIAGS: error: declaration name 'value' is not covered by macro 'NotCovered'
+  // CHECK-DIAGS: CONTENTS OF FILE @__swiftmacro_9MacroUser16MemberNotCoveredV0dE0fMf0_.swift
+  // CHECK-DIAGS: var value: Int
+  // CHECK-DIAGS: END CONTENTS OF FILE
+}
+
 @attached(peer)
 macro Invalid() = #externalMacro(module: "MacroDefinition", type: "InvalidMacro")
 


### PR DESCRIPTION
Diagnose freestanding macro expansions that contain invalid declarations.