### PR TITLE
Make sure we visit auxiliary declarations for all SIL symbol visitation

### DIFF
--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -573,6 +573,20 @@ public:
     visitAbstractStorageDecl(SD);
   }
 
+  template<typename NominalOrExtension>
+  void visitMembers(NominalOrExtension *D) {
+    if (!Ctx.getOpts().VisitMembers)
+      return;
+
+    for (auto member : D->getMembers()) {
+      member->visitAuxiliaryDecls([&](Decl *decl) {
+        visit(decl);
+      });
+
+      visit(member);
+    }
+  }
+
   void visitNominalTypeDecl(NominalTypeDecl *NTD) {
     auto declaredType = NTD->getDeclaredType()->getCanonicalType();
 
@@ -591,9 +605,7 @@ public:
 
     addRuntimeDiscoverableAttrGenerators(NTD);
 
-    if (Ctx.getOpts().VisitMembers)
-      for (auto member : NTD->getMembers())
-        visit(member);
+    visitMembers(NTD);
   }
 
   void visitClassDecl(ClassDecl *CD) {
@@ -682,9 +694,7 @@ public:
       addConformances(ED);
     }
 
-    if (Ctx.getOpts().VisitMembers)
-      for (auto member : ED->getMembers())
-        visit(member);
+    visitMembers(ED);
   }
 
 #ifndef NDEBUG

--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -395,6 +395,13 @@ public:
       addMainIfNecessary(file);
 
       for (auto D : decls) {
+        D->visitAuxiliaryDecls([&](Decl *decl) {
+          if (Ctx.getOpts().LinkerDirectivesOnly && !requiresLinkerDirective(decl))
+            return;
+
+          visit(decl);
+        });
+
         if (Ctx.getOpts().LinkerDirectivesOnly && !requiresLinkerDirective(D))
           continue;
 

--- a/test/Macros/macro_expand_peers.swift
+++ b/test/Macros/macro_expand_peers.swift
@@ -7,6 +7,9 @@
 // RUN: %target-build-swift -swift-version 5 -Xfrontend -disable-availability-checking -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser
 // RUN: %target-run %t/main | %FileCheck %s -check-prefix=CHECK-EXEC
 
+// Emit module while skipping function bodies
+// RUN: %target-swift-frontend -swift-version 5 -emit-module -load-plugin-library %t/%target-library-name(MacroDefinition) -parse-as-library -I %swift-host-lib-dir %s -disable-availability-checking -o %t/macro_expand_peers.swiftmodule -experimental-skip-non-inlinable-function-bodies-without-types
+
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx
 


### PR DESCRIPTION
Addresses IRGen, TBD generation, and so on
