### PR TITLE
[Macros] Emit loaded module trace for plugins loaded from search paths

### DIFF
--- a/include/swift/AST/PluginRegistry.h
+++ b/include/swift/AST/PluginRegistry.h
@@ -78,7 +78,7 @@ class PluginRegistry {
       LoadedPluginExecutables;
 
 public:
-  llvm::Error loadLibraryPlugin(llvm::StringRef path);
+  llvm::Expected<void *> loadLibraryPlugin(llvm::StringRef path);
   llvm::Expected<LoadedExecutablePlugin *>
   loadExecutablePlugin(llvm::StringRef path);
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6241,9 +6241,10 @@ void ASTContext::loadCompilerPlugins() {
                      err.message());
       continue;
     }
-    if (auto error = getPluginRegistry()->loadLibraryPlugin(resolvedPath)) {
+    auto loaded = getPluginRegistry()->loadLibraryPlugin(resolvedPath);
+    if (!loaded) {
       Diags.diagnose(SourceLoc(), diag::compiler_plugin_not_loaded, path,
-                     llvm::toString(std::move(error)));
+                     llvm::toString(loaded.takeError()));
     }
   }
 

--- a/lib/AST/PluginRegistry.cpp
+++ b/lib/AST/PluginRegistry.cpp
@@ -43,10 +43,11 @@ extern "C" void swift_ASTGen_destroyCompilerPluginCapability(void *value);
 
 using namespace swift;
 
-llvm::Error PluginRegistry::loadLibraryPlugin(StringRef path) {
-  if (LoadedPluginLibraries.find(path) != LoadedPluginLibraries.end()) {
+llvm::Expected<void *> PluginRegistry::loadLibraryPlugin(StringRef path) {
+  auto found = LoadedPluginLibraries.find(path);
+  if (found != LoadedPluginLibraries.end()) {
     // Already loaded.
-    return llvm::Error::success();
+    return found->second;
   }
   void *lib = nullptr;
 #if defined(_WIN32)
@@ -62,7 +63,7 @@ llvm::Error PluginRegistry::loadLibraryPlugin(StringRef path) {
   }
 #endif
   LoadedPluginLibraries.insert({path, lib});
-  return llvm::Error::success();
+  return lib;
 }
 
 llvm::Expected<LoadedExecutablePlugin *>

--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -15,6 +15,7 @@
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/AST/Module.h"
+#include "swift/AST/PluginRegistry.h"
 #include "swift/Basic/FileTypes.h"
 #include "swift/Basic/JSONSerialization.h"
 #include "swift/Frontend/FrontendOptions.h"
@@ -763,6 +764,11 @@ bool swift::emitLoadedModuleTraceIfNeeded(ModuleDecl *mainModule,
     pathToModuleDecl.insert(
         std::make_pair(loadedDecl->getModuleFilename(), loadedDecl));
   }
+
+  // Add compiler plugin libraries as dependencies.
+  auto *pluginRegistry = ctxt.getPluginRegistry();
+  for (auto &pluginEntry : pluginRegistry->getLoadedLibraryPlugins())
+    depTracker->addDependency(pluginEntry.getKey(), /*IsSystem*/ false);
 
   std::vector<SwiftModuleTraceInfo> swiftModules;
   computeSwiftModuleTraceInfo(ctxt, abiDependencies, pathToModuleDecl,

--- a/test/Macros/macro_expand.swift
+++ b/test/Macros/macro_expand.swift
@@ -5,8 +5,6 @@
 // Diagnostics testing
 // RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS
 
-// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-experimental-feature FreestandingMacros -plugin-path %t -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS
-
 // RUN: not %target-swift-frontend -swift-version 5 -typecheck -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -DTEST_DIAGNOSTICS -serialize-diagnostics-path %t/macro_expand.dia %s -emit-macro-expansion-files no-diagnostics > %t/macro-printing.txt
 // RUN: c-index-test -read-diagnostics %t/macro_expand.dia 2>&1 | %FileCheck -check-prefix CHECK-DIAGS %s
 
@@ -22,6 +20,12 @@
 // RUN: %target-build-swift -swift-version 5 -g -enable-experimental-feature FreestandingMacros -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -L %swift-host-lib-dir %s -o %t/main -module-name MacroUser
 // RUN: %target-run %t/main | %FileCheck %s
 // REQUIRES: executable_test
+
+// Plugin search path and loaded module trace testing
+// RUN: %target-swift-frontend -swift-version 5 -emit-sil -enable-experimental-feature FreestandingMacros -plugin-path %t -I %swift-host-lib-dir %s -module-name MacroUser -emit-loaded-module-trace -o %t/loaded_module_trace
+// RUN: %FileCheck -check-prefix=CHECK-MODULE-TRACE %s < %t/loaded_module_trace.trace.json
+
+// CHECK-MODULE-TRACE: {{libMacroDefinition.dylib|libMacroDefinition.so|MacroDefinition.dll}}
 
 // FIXME: Swift parser is not enabled on Linux CI yet.
 // REQUIRES: OS=macosx


### PR DESCRIPTION
When loading plugins from `-plugin-path`, use the global `PluginRegistry` to keep a record of what's loaded. Emit these dependencies to the loaded module trace.