### PR TITLE
[Macros] Add #ifs around macro declarations in standard library

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -720,11 +720,13 @@ void NormalProtocolConformance::setWitness(ValueDecl *requirement,
   assert(getProtocol() == cast<ProtocolDecl>(requirement->getDeclContext()) &&
          "requirement in wrong protocol");
   assert(Mapping.count(requirement) == 0 && "Witness already known");
+#if false
   assert((!isComplete() || isInvalid() ||
           requirement->getAttrs().hasAttribute<OptionalAttr>() ||
           requirement->getAttrs().isUnavailable(
                                         requirement->getASTContext())) &&
          "Conformance already complete?");
+#endif
   Mapping[requirement] = witness;
 }
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -720,13 +720,11 @@ void NormalProtocolConformance::setWitness(ValueDecl *requirement,
   assert(getProtocol() == cast<ProtocolDecl>(requirement->getDeclContext()) &&
          "requirement in wrong protocol");
   assert(Mapping.count(requirement) == 0 && "Witness already known");
-#if false
   assert((!isComplete() || isInvalid() ||
           requirement->getAttrs().hasAttribute<OptionalAttr>() ||
           requirement->getAttrs().isUnavailable(
                                         requirement->getASTContext())) &&
          "Conformance already complete?");
-#endif
   Mapping[requirement] = witness;
 }
 

--- a/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
+++ b/stdlib/public/Observation/Sources/Observation/CMakeLists.txt
@@ -27,6 +27,7 @@ add_swift_target_library(swiftObservation ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS
 
   SWIFT_COMPILE_FLAGS
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
+    "-enable-experimental-feature" "Macros"
 
   C_COMPILE_FLAGS
     ${swift_runtime_library_compile_flags}

--- a/stdlib/public/Observation/Sources/Observation/Macros.swift
+++ b/stdlib/public/Observation/Sources/Observation/Macros.swift
@@ -9,7 +9,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if hasFeature(Macros) && hasAttribute(attached)
+#if $Macros && hasAttribute(attached)
 
 @available(SwiftStdlib 5.9, *)
 @attached(member, names: named(_registrar), named(transactions), named(changes), named(_Storage), named(_storage))

--- a/stdlib/public/Observation/Sources/Observation/Macros.swift
+++ b/stdlib/public/Observation/Sources/Observation/Macros.swift
@@ -9,6 +9,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if hasFeature(Macros) && hasAttribute(attached)
+
 @available(SwiftStdlib 5.9, *)
 @attached(member, names: named(_registrar), named(transactions), named(changes), named(_Storage), named(_storage))
 @attached(memberAttribute)
@@ -20,3 +22,5 @@ public macro Observable() =
 @attached(accessor)
 public macro ObservableProperty() = 
   #externalMacro(module: "ObservationMacros", type: "ObservablePropertyMacro")
+
+#endif

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -289,6 +289,8 @@ endif()
 # STAGING: Temporarily avoids having to write #fileID in Swift.swiftinterface.
 list(APPEND swift_stdlib_compile_flags "-Xfrontend" "-enable-experimental-concise-pound-file")
 
+list(APPEND swift_stdlib_compile_flags "-enable-experimental-feature" "Macros")
+
 if(SWIFT_CHECK_ESSENTIAL_STDLIB)
   add_swift_target_library(swift_stdlib_essential ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_STDLIB_CORE
       INSTALL_IN_COMPONENT never_install

--- a/stdlib/public/core/Macros.swift
+++ b/stdlib/public/core/Macros.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if hasFeature(Macros) && hasAttribute(attached)
+
 /// Specifies the module and type name for an externally-defined macro, which
 /// must conform to the appropriate set of `Macro` protocols.
 ///
@@ -90,3 +92,5 @@ public macro dsohandle() -> UnsafeRawPointer = Builtin.DSOHandleMacro
 @attached(conformance)
 public macro OptionSet<RawType>() =
   #externalMacro(module: "SwiftMacros", type: "OptionSetMacro")
+
+#endif

--- a/stdlib/public/core/Macros.swift
+++ b/stdlib/public/core/Macros.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if hasFeature(Macros) && hasAttribute(attached)
+#if $Macros && hasAttribute(attached)
 
 /// Specifies the module and type name for an externally-defined macro, which
 /// must conform to the appropriate set of `Macro` protocols.


### PR DESCRIPTION
Older toolchain compilers don't have macros enabled by default, so we need to keep these around longer.
