### PR TITLE
[Sema] Enable AccessLevelOnImport in prod compilers

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -121,7 +121,7 @@ EXPERIMENTAL_FEATURE(TypeWitnessSystemInference, false)
 EXPERIMENTAL_FEATURE(LayoutPrespecialization, true)
 
 EXPERIMENTAL_FEATURE(ModuleInterfaceExportAs, true)
-EXPERIMENTAL_FEATURE(AccessLevelOnImport, false)
+EXPERIMENTAL_FEATURE(AccessLevelOnImport, true)
 
 /// Whether to enable experimental layout string value witnesses
 EXPERIMENTAL_FEATURE(LayoutStringValueWitnesses, true)


### PR DESCRIPTION
The feature is pretty much complete and some tests were already expecting this flag to be available in non-asserts build, so let's make it official.

rdar://106219959