### PR TITLE
[ConstraintSystem] A couple of improvements to ambiguity diagnostics

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -529,6 +529,10 @@ public:
 
   bool diagnose(const Solution &solution, bool asNote = false) const override;
 
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override {
+    return diagnose(*commonFixes.front().first);
+  }
+
   static UnwrapOptionalBase *create(ConstraintSystem &cs, DeclNameRef member,
                                     Type memberBaseType,
                                     ConstraintLocator *locator);

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -4674,10 +4674,16 @@ static bool diagnoseAmbiguity(
       auto noteLoc =
           decl->getLoc().isInvalid() ? getLoc(commonAnchor) : decl->getLoc();
 
-      if (solution.Fixes.size() == 1) {
-        diagnosed &=
-            solution.Fixes.front()->diagnose(solution, /*asNote*/ true);
-      } else if (llvm::all_of(solution.Fixes, [&](ConstraintFix *fix) {
+      SmallVector<const ConstraintFix *, 4> fixes;
+      for (const auto &entry : aggregateFix) {
+        if (entry.first == &solution)
+          fixes.push_back(entry.second);
+      }
+
+      if (fixes.size() == 1) {
+        diagnosed &= fixes.front()->diagnose(solution, /*asNote*/ true);
+      } else if (!fixes.empty() &&
+                 llvm::all_of(fixes, [&](const ConstraintFix *fix) {
                    return fix->getLocator()
                        ->findLast<LocatorPathElt::ApplyArgument>()
                        .has_value();
@@ -4691,8 +4697,7 @@ static bool diagnoseAmbiguity(
             type->lookThroughAllOptionalTypes()->getAs<AnyFunctionType>();
         assert(fn);
 
-        auto *argList =
-            solution.getArgumentList(solution.Fixes.front()->getLocator());
+        auto *argList = solution.getArgumentList(fixes.front()->getLocator());
         assert(argList);
 
         if (fn->getNumParams() == 1 && argList->isUnary()) {

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -592,8 +592,8 @@ do {
 
 // Diagnose extraneous force unwrap in ambiguous context
 do {
-  func test(_: Int) {} // expected-note {{found this candidate}}
-  func test(_: String) {} // expected-note {{found this candidate}}
+  func test(_: Int) {} // expected-note {{candidate expects value of type 'Int' for parameter #1 (got 'Double')}}
+  func test(_: String) {} // expected-note {{candidate expects value of type 'String' for parameter #1 (got 'Double')}}
 
   var x: Double = 42
   test(x!) // expected-error {{no exact matches in call to local function 'test'}}

--- a/test/Generics/function_defs.swift
+++ b/test/Generics/function_defs.swift
@@ -123,7 +123,7 @@ protocol Subscriptable {
   func getIndex() -> Index
   func getValue() -> Value
 
-  subscript (index : Index) -> Value { get set } // expected-note {{found this candidate}}
+  subscript (index : Index) -> Value { get set } // expected-note {{candidate expects value of type 'T.Index' for parameter #1 (got 'T.Value')}}
 }
 
 protocol IntSubscriptable {
@@ -131,7 +131,7 @@ protocol IntSubscriptable {
 
   func getElement() -> ElementType
 
-  subscript (index : Int) -> ElementType { get  } // expected-note {{found this candidate}}
+  subscript (index : Int) -> ElementType { get  } // expected-note {{candidate expects value of type 'Int' for parameter #1 (got 'T.Value')}}
 }
 
 func subscripting<T : Subscriptable & IntSubscriptable>(_ t: T) {

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -148,8 +148,8 @@ do {
   }
 }
 do {
-  func f1(_ u: Int) -> String {} // expected-note {{found this candidate}} expected-note {{candidate expects value of type 'Int' for parameter #1 (got 'Double')}}
-  func f1(_ u: String) -> Double {} // expected-note {{found this candidate}} expected-note {{candidate expects value of type 'String' for parameter #1 (got 'Double')}}
+  func f1(_ u: Int) -> String {} // expected-note 2 {{candidate expects value of type 'Int' for parameter #1 (got 'Double')}}
+  func f1(_ u: String) -> Double {} // expected-note 2 {{candidate expects value of type 'String' for parameter #1 (got 'Double')}}
   func f2(_ u: Int) {}
 
   f2(f1(1 as Double)) // expected-error {{no exact matches in call to local function 'f1'}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -749,7 +749,6 @@ func invalidDictionaryLiteral() {
 
 [4].joined(separator: [1])
 // expected-error@-1 {{no exact matches in call to instance method 'joined'}}
-// expected-note@-2 {{found candidate with type '(String) -> String'}}
 // There is one more note here - candidate requires that 'Int' conform to 'Sequence' (requirement specified as 'Self.Element' : 'Sequence') pointing to Sequence extension
 
 [4].joined(separator: [[[1]]])

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -1067,8 +1067,8 @@ func f_56996() {
 // https://github.com/apple/swift/issues/55805
 // Key-path missing optional crashes compiler: Inactive constraints left over?
 func f_55805() {
-  let _: KeyPath<String?, Int?> = \.utf8.count // expected-error {{no exact matches in reference to property 'count'}}
-  // expected-note@-1 {{found candidate with type 'Int'}}
+  let _: KeyPath<String?, Int?> = \.utf8.count // expected-error {{value of optional type 'String.UTF8View?' must be unwrapped to refer to member 'count' of wrapped base type 'String.UTF8View'}}
+  // expected-note@-1 {{chain the optional using '?' to access member 'count' only for non-'nil' base values}}
 }
 
 // rdar://74711236 - crash due to incorrect member access in key path


### PR DESCRIPTION
- Produce ambiguity notes based on the fix aggregate
- Diagnose missing base type unwrap in ambiguous contexts

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
