### PR TITLE
disable MoveOnly and MoveOnlyClasses feature flags

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -108,13 +108,10 @@ EXPERIMENTAL_FEATURE(StaticAssert, false)
 EXPERIMENTAL_FEATURE(VariadicGenerics, false)
 EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)
 EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures, false)
-EXPERIMENTAL_FEATURE(MoveOnly, true)
+EXPERIMENTAL_FEATURE(MoveOnly, false)
 EXPERIMENTAL_FEATURE(FreestandingMacros, true)
 
-// FIXME: MoveOnlyClasses is not intended to be in production,
-// but our tests currently rely on it, and we want to run those
-// tests in non-asserts builds too.
-EXPERIMENTAL_FEATURE(MoveOnlyClasses, true)
+EXPERIMENTAL_FEATURE(MoveOnlyClasses, false)
 
 EXPERIMENTAL_FEATURE(OneWayClosureParameters, false)
 EXPERIMENTAL_FEATURE(TypeWitnessSystemInference, false)


### PR DESCRIPTION
We don't want production compilers having
these features enabled when they are not
able to handle future swiftinterface files
that have these types in them.

part of rdar://106262652