### PR TITLE
Disable variadic_generic_types.swift in backward-deployment tests

### DIFF
--- a/test/Interpreter/variadic_generic_types.swift
+++ b/test/Interpreter/variadic_generic_types.swift
@@ -7,6 +7,9 @@
 // Because of -enable-experimental-feature VariadicGenerics
 // REQUIRES: asserts
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 import StdlibUnittest
 
 var types = TestSuite("VariadicGenericTypes")


### PR DESCRIPTION
Fixes rdar://106294162.