### PR TITLE
[ConstraintSystem] Don't propagate errors for invalid `DeclRef`s in the pattern of a pack expansion.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -8820,8 +8820,8 @@ ConstraintSystem::simplifyPackElementOfConstraint(Type first, Type second,
 
   if (shouldAttemptFixes()) {
     auto *loc = getConstraintLocator(locator);
-    auto *fix = AllowInvalidPackElement::create(*this, packType, loc);
-    if (!recordFix(fix))
+    if (elementType->isPlaceholder() ||
+        !recordFix(AllowInvalidPackElement::create(*this, packType, loc)))
       return SolutionKind::Solved;
   }
 
@@ -12919,6 +12919,10 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyShapeOfConstraint(
 
     return SolutionKind::Unsolved;
   };
+
+  // Don't try computing the shape of a type variable.
+  if (type1->isTypeVariableOrMember())
+    return formUnsolved();
 
   // We can't compute a reduced shape if the input type still
   // contains type variables that might bind to pack archetypes.

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -125,3 +125,14 @@ func packElementInvalidBinding<each T>(_ arg: repeat each T) {
   repeat print(each x)
   // expected-error@-1 {{'each' cannot be applied to non-pack type 'Int'}}
 }
+
+func copyIntoTuple<each T>(_ arg: repeat each T) -> (repeat each T) {
+  return (repeat each arg)
+}
+func callCopyAndBind<T>(_ arg: repeat each T) {
+  // expected-error@-1 {{'each' cannot be applied to non-pack type 'T'}}
+  // expected-error@-2 {{variadic expansion 'T' must contain at least one variadic generic parameter}}
+
+  // Don't propagate errors for invalid declaration reference
+  let result = copyIntoTuple(repeat each arg)
+}


### PR DESCRIPTION
This avoids an assertion when simplifying a `ShapeOf` constraint, and avoids propagating errors when simplifying a `PackElementOf` constraint when the pack type is a hole.