### PR TITLE
Make Zip2Sequence sendable

### DIFF
--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -153,3 +153,8 @@ extension Zip2Sequence: Sequence {
     )
   }
 }
+
+extension Zip2Sequence: Sendable where Sequence1: Sendable,
+                                       Sequence2: Sendable { }
+extension Zip2Sequence.Iterator: Sendable where Sequence1.Iterator: Sendable,
+                                                Sequence2.Iterator: Sendable { }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This change makes `Zip2Sequence` sendable when its underlying sequences are sendable.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves rdar://103840319.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
