### PR TITLE
Driver: introduce additional Windows controls

### DIFF
--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -265,6 +265,11 @@ private:
                            FrameworkSearchPaths.size() - 1);
   }
 
+  llvm::Optional<StringRef> WinSDKRoot = llvm::None;
+  llvm::Optional<StringRef> WinSDKVersion = llvm::None;
+  llvm::Optional<StringRef> VCToolsRoot = llvm::None;
+  llvm::Optional<StringRef> VCToolsVersion = llvm::None;
+
 public:
   StringRef getSDKPath() const { return SDKPath; }
 
@@ -281,6 +286,26 @@ public:
                                           frameworksScratch.str().str()};
 
     Lookup.searchPathsDidChange();
+  }
+
+  llvm::Optional<StringRef> getWinSDKRoot() const { return WinSDKRoot; }
+  void setWinSDKRoot(StringRef root) {
+    WinSDKRoot = root;
+  }
+
+  llvm::Optional<StringRef> getWinSDKVersion() const { return WinSDKVersion; }
+  void setWinSDKVersion(StringRef version) {
+    WinSDKVersion = version;
+  }
+
+  llvm::Optional<StringRef> getVCToolsRoot() const { return VCToolsRoot; }
+  void setVCToolsRoot(StringRef root) {
+    VCToolsRoot = root;
+  }
+
+  llvm::Optional<StringRef> getVCToolsVersion() const { return VCToolsVersion; }
+  void setVCToolsVersion(StringRef version) {
+    VCToolsVersion = version;
   }
 
   ArrayRef<std::string> getImportSearchPaths() const {

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -224,6 +224,25 @@ def parseable_output : Flag<["-"], "parseable-output">,
   Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit textual output in a parseable format">;
 
+// Windows Options
+
+def windows_sdk_root : Separate<["-"], "windows-sdk-root">,
+  Flags<[ArgumentIsPath, FrontendOption, SwiftAPIExtractOption,
+         SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
+  HelpText<"Windows SDK Root">, MetaVarName<"<root>">;
+def windows_sdk_version : Separate<["-"], "windows-sdk-version">,
+  Flags<[ArgumentIsPath, FrontendOption, SwiftAPIExtractOption,
+         SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
+  HelpText<"Windows SDK Version">, MetaVarName<"<version>">;
+def visualc_tools_root : Separate<["-"], "visualc-tools-root">,
+  Flags<[ArgumentIsPath, FrontendOption, SwiftAPIExtractOption,
+         SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
+  HelpText<"VisualC++ Tools Root">, MetaVarName<"<root>">;
+def visualc_tools_version : Separate<["-"], "visualc-tools-version">,
+  Flags<[ArgumentIsPath, FrontendOption, SwiftAPIExtractOption,
+         SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
+  HelpText<"VisualC++ ToolSet Version">, MetaVarName<"<version>">;
+
 // Standard Options
 def _DASH_DASH : Option<["--"], "", KIND_REMAINING_ARGS>,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>;

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -774,6 +774,23 @@ importer::addCommonInvocationArguments(
     invocationArgStrs.push_back("-mcx16");
   }
 
+  if (llvm::Optional<StringRef> R = ctx.SearchPathOpts.getWinSDKRoot()) {
+    invocationArgStrs.emplace_back("-Xmicrosoft-windows-sdk-root");
+    invocationArgStrs.emplace_back(*R);
+  }
+  if (llvm::Optional<StringRef> V = ctx.SearchPathOpts.getWinSDKVersion()) {
+    invocationArgStrs.emplace_back("-Xmicrosoft-windows-sdk-version");
+    invocationArgStrs.emplace_back(*V);
+  }
+  if (llvm::Optional<StringRef> R = ctx.SearchPathOpts.getVCToolsRoot()) {
+    invocationArgStrs.emplace_back("-Xmicrosoft-visualc-tools-root");
+    invocationArgStrs.emplace_back(*R);
+  }
+  if (llvm::Optional<StringRef> V = ctx.SearchPathOpts.getVCToolsVersion()) {
+    invocationArgStrs.emplace_back("-Xmicrosoft-visualc-tools-version");
+    invocationArgStrs.emplace_back(*V);
+  }
+
   if (!importerOpts.Optimization.empty()) {
     invocationArgStrs.push_back(importerOpts.Optimization);
   }

--- a/lib/ClangImporter/ClangIncludePaths.cpp
+++ b/lib/ClangImporter/ClangIncludePaths.cpp
@@ -339,7 +339,8 @@ GetWindowsFileMappings(ASTContext &Context) {
     std::string LibraryVersion;
     int MajorVersion;
   } WindowsSDK;
-  if (llvm::getWindowsSDKDir(VFS, {}, {}, {},
+  if (llvm::getWindowsSDKDir(VFS, SearchPathOpts.getWinSDKRoot(),
+                             SearchPathOpts.getWinSDKVersion(), {},
                              WindowsSDK.Path, WindowsSDK.MajorVersion,
                              WindowsSDK.IncludeVersion,
                              WindowsSDK.LibraryVersion)) {
@@ -358,7 +359,8 @@ GetWindowsFileMappings(ASTContext &Context) {
     std::string Path;
     std::string Version;
   } UCRTSDK;
-  if (llvm::getUniversalCRTSdkDir(VFS, {}, {}, {},
+  if (llvm::getUniversalCRTSdkDir(VFS, SearchPathOpts.getWinSDKRoot(),
+                                  SearchPathOpts.getWinSDKVersion(), {},
                                   UCRTSDK.Path, UCRTSDK.Version)) {
     llvm::SmallString<261> UCRTInjection{UCRTSDK.Path};
     llvm::sys::path::append(UCRTInjection, "Include", UCRTSDK.Version, "ucrt");
@@ -373,9 +375,13 @@ GetWindowsFileMappings(ASTContext &Context) {
     std::string Path;
     llvm::ToolsetLayout Layout;
   } VCTools;
-  if (llvm::findVCToolChainViaCommandLine(VFS, {}, {}, {}, VCTools.Path, VCTools.Layout) ||
+  if (llvm::findVCToolChainViaCommandLine(VFS, SearchPathOpts.getVCToolsRoot(),
+                                          SearchPathOpts.getVCToolsVersion(),
+                                          {}, VCTools.Path, VCTools.Layout) ||
       llvm::findVCToolChainViaEnvironment(VFS, VCTools.Path, VCTools.Layout) ||
-      llvm::findVCToolChainViaSetupConfig(VFS, VCTools.Path, VCTools.Layout)) {
+      llvm::findVCToolChainViaSetupConfig(VFS,
+                                          SearchPathOpts.getVCToolsVersion(),
+                                          VCTools.Path, VCTools.Layout)) {
     assert(VCTools.Layout == llvm::ToolsetLayout::VS2017OrNewer &&
            "unsupported toolset layout (VS2017+ required)");
 

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -211,6 +211,24 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
     arguments.push_back(inputArgs.MakeArgString(OI.SDKPath));
   }
 
+  if (const Arg *A = inputArgs.getLastArg(options::OPT_windows_sdk_root)) {
+    arguments.push_back("-windows-sdk-root");
+    arguments.push_back(inputArgs.MakeArgString(A->getValue()));
+  }
+  if (const Arg *A = inputArgs.getLastArg(options::OPT_windows_sdk_version)) {
+    arguments.push_back("-windows-sdk-version");
+    arguments.push_back(inputArgs.MakeArgString(A->getValue()));
+  }
+  if (const Arg *A = inputArgs.getLastArg(options::OPT_visualc_tools_root)) {
+    arguments.push_back("-visualc-tools-root");
+    arguments.push_back(inputArgs.MakeArgString(A->getValue()));
+  }
+  if (const Arg *A = inputArgs.getLastArg(options::OPT_visualc_tools_version)) {
+    arguments.push_back("-visualc-tools-version");
+    arguments.push_back(inputArgs.MakeArgString(A->getValue()));
+  }
+
+
   if (llvm::sys::Process::StandardErrHasColors()) {
     arguments.push_back("-color-diagnostics");
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1461,6 +1461,15 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
   if (const Arg *A = Args.getLastArg(OPT_sdk))
     Opts.setSDKPath(A->getValue());
 
+  if (const Arg *A = Args.getLastArg(OPT_windows_sdk_root))
+    Opts.setWinSDKRoot(A->getValue());
+  if (const Arg *A = Args.getLastArg(OPT_windows_sdk_version))
+    Opts.setWinSDKVersion(A->getValue());
+  if (const Arg *A = Args.getLastArg(OPT_visualc_tools_root))
+    Opts.setVCToolsRoot(A->getValue());
+  if (const Arg *A = Args.getLastArg(OPT_visualc_tools_version))
+    Opts.setVCToolsVersion(A->getValue());
+
   if (const Arg *A = Args.getLastArg(OPT_resource_dir))
     Opts.RuntimeResourcePath = A->getValue();
 


### PR DESCRIPTION
This adds the following four new options:
  - `-windows-sdk-root`
  - `-windows-sdk-version`
  - `-visualc-tools-root`
  - `-visualc-tools-version`

Together these options make one the master of Windows SDK selection for the Swift compilation.  This is important as now that the injection is no longer done by the user, we need to ensure that we have enough control over the paths so that the synthesized overlay is going to map the files to the proper location.