### PR TITLE
[move-only] add addtl coverage for when the moveonly type is not used during import

### DIFF
--- a/test/Serialization/Inputs/moveonly_deinit.swift
+++ b/test/Serialization/Inputs/moveonly_deinit.swift
@@ -17,3 +17,11 @@ public enum MoveOnlyEnum {
 
     deinit { }
 }
+
+public struct NormalStruct {
+  private let desc: Int
+
+  public init(desc: Int) {
+    self.desc = desc
+  }
+}

--- a/test/Serialization/moveonly_error_on_import_into_module_without_flag.swift
+++ b/test/Serialization/moveonly_error_on_import_into_module_without_flag.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
 // TODO: re-enable the simplification passes once rdar://104875010 is fixed
 // RUN: %target-swift-frontend -Xllvm -sil-disable-pass=simplification -emit-module -o %t/Library.swiftmodule -module-name Library %S/Inputs/moveonly_deinit.swift -enable-experimental-move-only
-// RUN: not %target-swift-frontend -I %t %s -emit-sil -o /dev/null 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -DUSE_MOVEONLY_TYPE -I %t %s -emit-sil -o /dev/null 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -I %t %s -emit-sil -verify -o /dev/null
 
 // This test makes sure that if we import a move only type and do not set the
 // experimental move only flag, we get a nice error.
@@ -10,5 +11,8 @@ import Library
 
 // CHECK: error: Can not import module 'Library' that uses move only features when experimental move only is disabled! Pass the frontend flag -enable-experimental-move-only to swift to enable the usage of this language feature
 
-func f(_ k: MoveOnlyStruct) {
-}
+#if USE_MOVEONLY_TYPE
+func f(_ k: MoveOnlyStruct) {}
+#endif
+
+func g(_ k: NormalStruct) {}


### PR DESCRIPTION
We want to ensure that the deserialization error added for this test doesn't trigger when the moveonly type is not used by the importing module.

part of rdar://106262652