### PR TITLE
Revert "Also visit auxiliary declarations of top-level decls"

### DIFF
--- a/lib/SIL/IR/SILSymbolVisitor.cpp
+++ b/lib/SIL/IR/SILSymbolVisitor.cpp
@@ -395,13 +395,6 @@ public:
       addMainIfNecessary(file);
 
       for (auto D : decls) {
-        D->visitAuxiliaryDecls([&](Decl *decl) {
-          if (Ctx.getOpts().LinkerDirectivesOnly && !requiresLinkerDirective(decl))
-            return;
-
-          visit(decl);
-        });
-
         if (Ctx.getOpts().LinkerDirectivesOnly && !requiresLinkerDirective(D))
           continue;
 

--- a/test/Macros/option_set.swift
+++ b/test/Macros/option_set.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-simple-swift(-Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins)
+// RUN: %target-run-simple-swift(-Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins -emit-tbd -emit-tbd-path %t.tbd)
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
 


### PR DESCRIPTION
We're already getting these declarations visited via other means. Revert my change here, and add a TBD generation test