### PR TITLE
Implement the caller side of return types containing variadic packs

### DIFF
--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -277,9 +277,17 @@ public:
   /// Map a generic parameter type to a contextual type.
   Type mapTypeIntoContext(GenericTypeParamType *type) const;
 
-  /// Map a type containing parameter packs to a contextual type
-  /// in the opened element generic context.
+  /// Map an interface type containing parameter packs to a contextual
+  /// type in the opened element generic context.
   Type mapPackTypeIntoElementContext(Type type) const;
+
+  /// Map a contextual type containing parameter packs to a contextual
+  /// type in the opened element generic context.
+  Type mapContextualPackTypeIntoElementContext(Type type) const;
+
+  /// Map a contextual type containing parameter packs to a contextual
+  /// type in the opened element generic context.
+  CanType mapContextualPackTypeIntoElementContext(CanType type) const;
 
   /// Map a type containing pack element type parameters to a contextual
   /// type in the pack generic context.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -6829,6 +6829,7 @@ private:
 };
 BEGIN_CAN_TYPE_WRAPPER(PackType, Type)
   static CanPackType get(const ASTContext &ctx, ArrayRef<CanType> elements);
+  static CanPackType get(const ASTContext &ctx, CanTupleEltTypeArrayRef elts);
 
   CanType getElementType(unsigned elementNo) const {
     return CanType(getPointer()->getElementType(elementNo));

--- a/include/swift/Basic/IndexedViewRange.h
+++ b/include/swift/Basic/IndexedViewRange.h
@@ -1,0 +1,100 @@
+//===- IndexedViewRange.h - Iterators for indexed projections ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines IndexedViewRange, a template class which makes it
+//  easy to define a range for a "collection" that is normally just vended
+//  with an indexed accessor.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_INDEXEDVIEWRANGE_H
+#define SWIFT_BASIC_INDEXEDVIEWRANGE_H
+
+#include <iterator>
+#include <memory>
+#include "llvm/ADT/iterator_range.h"
+
+namespace swift {
+
+/// An iterator over a range of values provided by an indexed accessor
+/// on a base type.
+template <class BaseType, class ProjectedType,
+          ProjectedType (&Project)(BaseType, size_t)>
+class IndexedViewIterator {
+public:
+  using value_type = ProjectedType;
+  using reference = ProjectedType;
+  using pointer = void;
+  using difference_type = ptrdiff_t;
+  using iterator_category = std::random_access_iterator_tag;
+private:
+  BaseType Base;
+  size_t Index;
+public:
+  IndexedViewIterator(BaseType base, size_t index)
+    : Base(base), Index(index) {}
+public:
+  ProjectedType operator*() const { return Project(Base, Index); }
+  ProjectedType operator->() const { return Project(Base, Index); }
+  IndexedViewIterator &operator++() { Index++; return *this; }
+  IndexedViewIterator operator++(int) { return iterator(Base, Index++); }
+  IndexedViewIterator &operator--() { Index--; return *this; }
+  IndexedViewIterator operator--(int) { return iterator(Base, Index--); }
+  bool operator==(IndexedViewIterator rhs) const { return Index == rhs.Index; }
+  bool operator!=(IndexedViewIterator rhs) const { return Index != rhs.Index; }
+
+  IndexedViewIterator &operator+=(difference_type i) {
+    Index += i;
+    return *this;
+  }
+  IndexedViewIterator operator+(difference_type i) const {
+    return IndexedViewIterator(Base, Index + i);
+  }
+  friend IndexedViewIterator operator+(difference_type i,
+                                       IndexedViewIterator rhs) {
+    return IndexedViewIterator(rhs.Base, rhs.Index + i);
+  }
+  IndexedViewIterator &operator-=(difference_type i) {
+    Index -= i;
+    return *this;
+  }
+  IndexedViewIterator operator-(difference_type i) const {
+    return IndexedViewIterator(Base, Index - i);
+  }
+  difference_type operator-(IndexedViewIterator rhs) const {
+    return Index - rhs.Index;
+  }
+  ProjectedType operator[](difference_type i) const {
+    return Project(Base, Index + i);
+  }
+  bool operator<(IndexedViewIterator rhs) const {
+    return Index < rhs.Index;
+  }
+  bool operator<=(IndexedViewIterator rhs) const {
+    return Index <= rhs.Index;
+  }
+  bool operator>(IndexedViewIterator rhs) const {
+    return Index > rhs.Index;
+  }
+  bool operator>=(IndexedViewIterator rhs) const {
+    return Index >= rhs.Index;
+  }
+};
+
+template <class BaseType, class ProjectedType,
+          ProjectedType (&Project)(BaseType, size_t)>
+using IndexedViewRange =
+  llvm::iterator_range<IndexedViewIterator<BaseType, ProjectedType, Project>>;
+
+} // end namespace swift
+
+#endif // SWIFT_BASIC_INDEXEDVIEWRANGE_H

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -18,6 +18,7 @@
 #ifndef SWIFT_SIL_ABSTRACTIONPATTERN_H
 #define SWIFT_SIL_ABSTRACTIONPATTERN_H
 
+#include "swift/Basic/IndexedViewRange.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Types.h"
 
@@ -1332,6 +1333,17 @@ public:
     llvm_unreachable("bad kind");
   }
 
+  static AbstractionPattern
+  projectTupleElementType(const AbstractionPattern *base, size_t index) {
+    return base->getTupleElementType(index);
+  }
+
+  IndexedViewRange<const AbstractionPattern *, AbstractionPattern,
+                   projectTupleElementType> getTupleElementTypes() const {
+    assert(isTuple());
+    return { { this, 0 }, { this, getNumTupleElements() } };
+  }
+
   /// Is the given pack type a valid substitution of this abstraction
   /// pattern?
   bool matchesPack(CanPackType substType);
@@ -1471,6 +1483,8 @@ public:
   /// component.
   void forEachPackExpandedComponent(
       llvm::function_ref<void(AbstractionPattern pattern)> fn) const;
+
+  SmallVector<AbstractionPattern, 4> getPackExpandedComponents() const;
 
   /// If this pattern refers to a foreign ObjC method that was imported as 
   /// async, return the bridged-back-to-ObjC completion handler type.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3303,6 +3303,12 @@ CanPackType CanPackType::get(const ASTContext &C, ArrayRef<CanType> elements) {
   return CanPackType(PackType::get(C, ncElements));
 }
 
+CanPackType CanPackType::get(const ASTContext &C,
+                             CanTupleEltTypeArrayRef elements) {
+  SmallVector<Type, 8> ncElements(elements.begin(), elements.end());
+  return CanPackType(PackType::get(C, ncElements));
+}
+
 PackType *PackType::get(const ASTContext &C, ArrayRef<Type> elements) {
   RecursiveTypeProperties properties;
   bool isCanonical = true;

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -584,6 +584,29 @@ Type GenericEnvironment::mapTypeIntoContext(GenericTypeParamType *type) const {
 }
 
 Type
+GenericEnvironment::mapContextualPackTypeIntoElementContext(Type type) const {
+  if (!type->hasArchetype()) return type;
+
+  // FIXME: this is potentially wrong if there are multiple
+  // openings in play at once, because we really shouldn't touch
+  // other element archetypes.
+  return mapPackTypeIntoElementContext(type->mapTypeOutOfContext());
+}
+
+CanType
+GenericEnvironment::mapContextualPackTypeIntoElementContext(CanType type) const {
+  if (!type->hasArchetype()) return type;
+
+  // FIXME: this is potentially wrong if there are multiple
+  // openings in play at once, because we really shouldn't touch
+  // other element archetypes.
+  // FIXME: if we do this properly, there's no way for this rewrite
+  // to produce a non-canonical type.
+  return mapPackTypeIntoElementContext(type->mapTypeOutOfContext())
+           ->getCanonicalType();
+}
+
+Type
 GenericEnvironment::mapPackTypeIntoElementContext(Type type) const {
   assert(getKind() == Kind::OpenedElement);
   assert(!type->hasArchetype());

--- a/lib/AST/ParameterPack.cpp
+++ b/lib/AST/ParameterPack.cpp
@@ -478,13 +478,6 @@ bool SILPackType::containsPackExpansionType() const {
 CanPackType
 CanTupleType::getInducedPackTypeImpl(CanTupleType tuple, unsigned start, unsigned count) {
   assert(start + count <= tuple->getNumElements() && "range out of range");
-
   auto &ctx = tuple->getASTContext();
-  if (count == 0) return CanPackType::get(ctx, {});
-
-  SmallVector<CanType, 4> eltTypes;
-  eltTypes.reserve(count);
-  for (unsigned i = start, e = start + count; i != e; ++i)
-    eltTypes.push_back(tuple.getElementType(i));
-  return CanPackType::get(ctx, eltTypes);
+  return CanPackType::get(ctx, tuple.getElementTypes().slice(start, count));
 }

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -328,8 +328,7 @@ static llvm::Value *emitPackExpansionElementMetadata(
   // Replace pack archetypes with element archetypes in the pattern type.
   auto instantiatedPatternTy =
       context.environment
-          ->mapPackTypeIntoElementContext(patternTy->mapTypeOutOfContext())
-          ->getCanonicalType();
+          ->mapContextualPackTypeIntoElementContext(patternTy);
 
   // Emit the element metadata.
   auto element = IGF.emitTypeMetadataRef(instantiatedPatternTy, request)
@@ -505,9 +504,7 @@ static llvm::Value *emitPackExpansionElementWitnessTable(
 
   // Replace pack archetypes with element archetypes in the pattern type.
   auto instantiatedPatternTy =
-      context.environment
-          ->mapPackTypeIntoElementContext(patternTy->mapTypeOutOfContext())
-          ->getCanonicalType();
+      context.environment->mapContextualPackTypeIntoElementContext(patternTy);
   auto instantiatedConformance =
       context.environment->getGenericSignature()->lookupConformance(
           instantiatedPatternTy, conformance.getRequirement());

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -588,6 +588,15 @@ AbstractionPattern AbstractionPattern::getPackExpansionCountType() const {
   llvm_unreachable("bad kind");
 }
 
+SmallVector<AbstractionPattern, 4>
+AbstractionPattern::getPackExpandedComponents() const {
+  SmallVector<AbstractionPattern, 4> result;
+  forEachPackExpandedComponent([&](AbstractionPattern pattern) {
+    result.push_back(pattern);
+  });
+  return result;
+}
+
 void AbstractionPattern::forEachPackExpandedComponent(
           llvm::function_ref<void (AbstractionPattern)> fn) const {
   assert(isPackExpansion());

--- a/lib/SILGen/Initialization.h
+++ b/lib/SILGen/Initialization.h
@@ -122,6 +122,31 @@ public:
     llvm_unreachable("Must implement if canPerformPackExpansionInitialization"
                      "returns true");
   }
+
+  /// Given that this supports pack expansion initialization, can it
+  /// perform *in place* pack expansion initialization by producing
+  /// a pack element of the given type?
+  ///
+  /// The dominance relationship gets a little screwed up here; only
+  /// return true if it's okay for the address to be written into a
+  /// pack and then initialized later.
+  virtual bool
+  canPerformInPlacePackInitialization(GenericEnvironment *env,
+                                      SILType eltAddrTy) const {
+    return false;
+  }
+
+  /// Given that this supports in-place pack expansion initialization,
+  /// return the address of the storage.
+  ///
+  /// For convenience, the same element type that was accepted before
+  /// is passed again.
+  virtual SILValue getAddressForInPlacePackInitialization(SILGenFunction &SGF,
+                                                          SILLocation loc,
+                                                          SILType eltAddrTy) {
+    llvm_unreachable("Must implement if canPerformInPlacePackInitialization"
+                     "returns true");
+  }
   
   /// Return true if we can get the addresses of elements with the
   /// 'splitIntoTupleElements' method.  Subclasses can override this to
@@ -364,6 +389,13 @@ public:
                                           SILLocation loc,
                                           SILValue indexWithinComponent,
                   llvm::function_ref<void(Initialization *into)> fn) override;
+
+  bool canPerformInPlacePackInitialization(GenericEnvironment *env,
+                                           SILType eltAddrTy) const override;
+
+  SILValue getAddressForInPlacePackInitialization(SILGenFunction &SGF,
+                                                  SILLocation loc,
+                                                  SILType eltAddrTy) override;
 
   virtual CanPackExpansionType getLoweredExpansionType() const = 0;
   virtual CleanupHandle enterPartialDestroyCleanup(SILGenFunction &SGF,

--- a/lib/SILGen/ResultPlan.h
+++ b/lib/SILGen/ResultPlan.h
@@ -15,6 +15,7 @@
 
 #include "Callee.h"
 #include "ExecutorBreadcrumb.h"
+#include "Initialization.h"
 #include "ManagedValue.h"
 #include "swift/AST/Types.h"
 #include "swift/Basic/LLVM.h"
@@ -38,7 +39,7 @@ class CalleeTypeInfo;
 /// An abstract class for working with results.of applies.
 class ResultPlan {
 public:
-  virtual RValue finish(SILGenFunction &SGF, SILLocation loc, CanType substType,
+  virtual RValue finish(SILGenFunction &SGF, SILLocation loc,
                         ArrayRef<ManagedValue> &directResults,
                         SILValue bridgedForeignError) = 0;
   virtual ~ResultPlan() = default;
@@ -84,9 +85,26 @@ struct ResultPlanBuilder {
 
   ResultPlanPtr build(Initialization *emitInto, AbstractionPattern origType,
                       CanType substType);
+  ResultPlanPtr buildForScalar(Initialization *emitInto,
+                               AbstractionPattern origType,
+                               CanType substType,
+                               SILResultInfo result);
   ResultPlanPtr buildForTuple(Initialization *emitInto,
                               AbstractionPattern origType,
                               CanTupleType substType);
+  ResultPlanPtr buildForPackExpansion(MutableArrayRef<InitializationPtr> inits,
+                                      ArrayRef<AbstractionPattern> origTypes,
+                                      CanTupleEltTypeArrayRef substTypes);
+  ResultPlanPtr buildPackExpansionIntoPack(SILValue packAddr,
+                                           CanPackType formalPackType,
+                                           unsigned componentIndex,
+                                           Initialization *init,
+                                           AbstractionPattern origType);
+  ResultPlanPtr buildScalarIntoPack(SILValue packAddr,
+                                    CanPackType formalPackType,
+                                    unsigned componentIndex,
+                                    Initialization *init,
+                                    AbstractionPattern origType);
 
   static ResultPlanPtr computeResultPlan(SILGenFunction &SGF,
                                          const CalleeTypeInfo &calleeTypeInfo,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3229,11 +3229,8 @@ public:
 
       // Otherwise we need to emit a pack argument.
       } else {
-        SmallVector<AbstractionPattern, 4> origPackEltPatterns;
-        origFormalParamType.forEachPackExpandedComponent(
-                              [&](AbstractionPattern pattern) {
-          origPackEltPatterns.push_back(pattern);
-        });
+        auto origPackEltPatterns =
+          origFormalParamType.getPackExpandedComponents();
 
         auto argSourcesSlice =
           argSources.slice(nextArgSourceIndex, origPackEltPatterns.size());

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5038,7 +5038,7 @@ CallEmission::applySpecializedEmitter(SpecializedEmitter &specializedEmitter,
   // Then finish our value.
   if (resultPlan.has_value()) {
     return std::move(*resultPlan)
-        ->finish(SGF, loc, formalResultType, directResultsFinal, SILValue());
+        ->finish(SGF, loc, directResultsFinal, SILValue());
   } else {
     return RValue(
         SGF, *uncurriedLoc, formalResultType, directResultsFinal[0]);
@@ -5245,7 +5245,6 @@ RValue SILGenFunction::emitApply(
     ApplyOptions options, SGFContext evalContext,
     Optional<ActorIsolation> implicitActorHopTarget) {
   auto substFnType = calleeTypeInfo.substFnType;
-  auto substResultType = calleeTypeInfo.substResultType;
 
   // Create the result plan.
   SmallVector<SILValue, 4> indirectResultAddrs;
@@ -5497,8 +5496,8 @@ RValue SILGenFunction::emitApply(
   }
 
   auto directResultsArray = makeArrayRef(directResults);
-  RValue result = resultPlan->finish(*this, loc, substResultType,
-                                     directResultsArray, bridgedForeignError);
+  RValue result = resultPlan->finish(*this, loc, directResultsArray,
+                                     bridgedForeignError);
   assert(directResultsArray.empty() && "didn't claim all direct results");
 
   return result;

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3837,8 +3837,8 @@ private:
         auto loweredPatternType =
           expectedParamType.castTo<PackExpansionType>().getPatternType();
         auto loweredElementType =
-          openedElementEnv->mapPackTypeIntoElementContext(
-            loweredPatternType->mapTypeOutOfContext())->getCanonicalType();
+          openedElementEnv->mapContextualPackTypeIntoElementContext(
+            loweredPatternType);
         return SILType::getPrimitiveAddressType(loweredElementType);
       }();
 

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -2532,6 +2532,12 @@ public:
     return SGM.getAccessorDeclRef(accessor, F.getResilienceExpansion());
   }
 
+  /// Given a lowered pack expansion type, produce a generic environment
+  /// sufficient for doing value operations on it and map the type into
+  /// the environment.
+  std::pair<GenericEnvironment*, SILType>
+  createOpenedElementValueEnvironment(SILType packExpansionTy);
+
   /// Emit a dynamic loop over a single pack-expansion component of a pack.
   ///
   /// \param formalPackType - a pack type with the right shape for the

--- a/lib/SILGen/SILGenPack.cpp
+++ b/lib/SILGen/SILGenPack.cpp
@@ -290,9 +290,7 @@ deriveOpenedElementTypeForPackExpansion(SILGenModule &SGM,
     OpenedElementContext::createForContextualExpansion(SGM.getASTContext(),
                                                        expansion);
   auto elementType =
-    context.environment->mapPackTypeIntoElementContext(
-                           patternType->mapTypeOutOfContext())
-                       ->getCanonicalType();
+    context.environment->mapContextualPackTypeIntoElementContext(patternType);
   return std::make_pair(context.environment,
                         SILType::getPrimitiveAddressType(elementType));
 }
@@ -485,8 +483,7 @@ void InPlacePackExpansionInitialization::
     // This AST-level transformation is fine on lowered types because
     // we're just replacing pack archetypes with element archetypes.
     loweredPatternTy =
-      env->mapPackTypeIntoElementContext(
-        loweredPatternTy->mapTypeOutOfContext())->getCanonicalType();
+      env->mapContextualPackTypeIntoElementContext(loweredPatternTy);
   }
   auto eltAddrTy = SILType::getPrimitiveAddressType(loweredPatternTy);
 

--- a/lib/SILGen/SILGenPack.cpp
+++ b/lib/SILGen/SILGenPack.cpp
@@ -573,7 +573,7 @@ TuplePackExpansionInitialization::create(SILGenFunction &SGF,
 
 CanPackExpansionType
 TuplePackExpansionInitialization::getLoweredExpansionType() const {
-  auto loweredTupleTy = TupleAddr->getType().castTo<SILPackType>();
+  auto loweredTupleTy = TupleAddr->getType().castTo<TupleType>();
   auto loweredComponentTy = loweredTupleTy.getElementType(ComponentIndex);
   return cast<PackExpansionType>(loweredComponentTy);
 }

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -504,11 +504,7 @@ preparePackResultInit(SILGenFunction &SGF, SILLocation loc,
                       SmallVectorImpl<CleanupHandle> &cleanups,
                       SmallVectorImpl<InitializationPtr> &inits) {
   assert(origExpansionType.isPackExpansion());
-  SmallVector<AbstractionPattern, 4> origComponentTypes;
-  origExpansionType.forEachPackExpandedComponent(
-      [&](AbstractionPattern component) {
-    origComponentTypes.push_back(component);
-  });
+  auto origComponentTypes = origExpansionType.getPackExpandedComponents();
 
   auto loweredPackType = packAddr->getType().castTo<SILPackType>();
   assert(loweredPackType->getNumElements() == origComponentTypes.size() &&


### PR DESCRIPTION
This is all relatively nicely abstracted, which is not to say that it didn't take an awful lot of plumbing to get it to work.  The basic problem here is inherent: we need to do component-specific setup and teardown, and unfortunately in the current representation we have to do that with separate loops and without any dominance relationships.  (This is the same thing preventing us from doing borrows in the general case.)  The result is that the general case of result emission is to emit every element of the expansion into a temporary tuple (requiring a pack loop before the call to initialize the pack), then process those elements in the body of a second pack loop after the call.  And that's terrible enough that we really have to do the work to try to avoid it, which makes all the APIs more complicated.
    
Anyway, most of the way through the basic plumbing for variadic generics now.  Next is reabstraction, I think, which I hope will mostly mean fixing bugs in the infrastructure I've already written.