### PR TITLE
[stdlib] refactor precondition() for consistency

### DIFF
--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -85,16 +85,18 @@ public func precondition(
   _ message: @autoclosure () -> String = String(),
   file: StaticString = #file, line: UInt = #line
 ) {
-  // Only check in debug and release mode. In release mode just trap.
-  if _isDebugAssertConfiguration() {
-    if !_fastPath(condition()) {
+  // Only check in debug and release mode.
+  if _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() {
+    if _fastPath(condition()) {
+      return
+    }
+    if _isDebugAssertConfiguration() {
       _assertionFailure("Precondition failed", message(), file: file, line: line,
         flags: _fatalErrorFlags())
+    } else { // In release mode just trap.
+      let message = StaticString("precondition failure")
+      Builtin.condfail_message(true._value, message.unsafeRawPointer)
     }
-  } else if _isReleaseAssertConfiguration() {
-    let error = !condition()
-    Builtin.condfail_message(error._value,
-      StaticString("precondition failure").unsafeRawPointer)
   }
 }
 

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -204,18 +204,21 @@ public func fatalError(
 /// and abort.
 @usableFromInline @_transparent
 internal func _precondition(
-  _ condition: @autoclosure () -> Bool, _ message: StaticString = StaticString(),
+  _ condition: @autoclosure () -> Bool,
+  _ message: StaticString = StaticString(),
   file: StaticString = #file, line: UInt = #line
 ) {
-  // Only check in debug and release mode. In release mode just trap.
-  if _isDebugAssertConfiguration() {
-    if !_fastPath(condition()) {
+  // Only check in debug and release mode.
+  if _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() {
+    if _fastPath(condition()) {
+      return
+    }
+    if _isDebugAssertConfiguration() {
       _assertionFailure("Fatal error", message, file: file, line: line,
         flags: _fatalErrorFlags())
+    } else { // In release mode just trap.
+      Builtin.condfail_message(true._value, message.unsafeRawPointer)
     }
-  } else if _isReleaseAssertConfiguration() {
-    let error = !condition()
-    Builtin.condfail_message(error._value, message.unsafeRawPointer)
   }
 }
 


### PR DESCRIPTION
The following simple function currently compiles differently in `-Onone` mode than in `-O` or `-Osize`:
```swift
func example(i: Int?) -> Int {
  if let i { return i }
  precondition(false)
}
```
Compilation succeeds in `-Onone`, and fails otherwise (with a missing return value error.)

This is due to the implementation of `precondition()` being `@_transparent`, and having two completely different implementations depending on whether it takes the `_isDebugAssertConfiguration()` branch or the `_isReleaseAssertConfiguration()` branch. The version of `precondition()` that is analyzed by the compiler after the mandatory inlining is simply different whether it occurs in debug mode or in release mode.

In debug mode, the precondition's condition is explicitly used for flow control, and `_assertionFailure` is called conditionally. In release mode, the precondition's condition result is saved in a variable, then `Builtin.condfail_message` is called unconditionally. In the particular case show above, where `precondition()` is called with a constant `false` argument, this difference in approaches causes a compilation error in release mode that doesn't occur in debug mode.

The solution is to use the condition for flow control before deciding on the specific way to trap.

Resolves rdar://106320129