### PR TITLE
[Backtracing] Mark withCurrentContext() as @_transparent.

### DIFF
--- a/stdlib/public/Backtracing/Context.swift
+++ b/stdlib/public/Backtracing/Context.swift
@@ -274,9 +274,11 @@ extension arm_gprs {
     throw NotYetImplemented()
   }
   #elseif arch(x86_64)
+  @usableFromInline
   @_silgen_name("_swift_get_cpu_context")
   static func _swift_get_cpu_context() -> X86_64Context
 
+  @_transparent
   public static func withCurrentContext<T>(fn: (X86_64Context) throws -> T) rethrows -> T {
     return try fn(_swift_get_cpu_context())
   }
@@ -429,9 +431,11 @@ extension arm_gprs {
     throw NotYetImplemented()
   }
   #elseif arch(i386)
+  @usableFromInline
   @_silgen_name("_swift_get_cpu_context")
   static func _swift_get_cpu_context() -> I386Context
 
+  @_transparent
   public static func withCurrentContext<T>(fn: (I386Context) throws -> T) rethrows -> T {
     return try fn(_swift_get_cpu_context())
   }
@@ -630,9 +634,11 @@ extension arm_gprs {
     throw NotYetImplemented()
   }
   #elseif arch(arm64) || arch(arm64_32)
+  @usableFromInline
   @_silgen_name("_swift_get_cpu_context")
   static func _swift_get_cpu_context() -> ARM64Context
 
+  @_transparent
   public static func withCurrentContext<T>(fn: (ARM64Context) throws -> T) rethrows -> T {
     return try fn(_swift_get_cpu_context())
   }
@@ -769,9 +775,11 @@ extension arm_gprs {
     throw NotYetImplemented()
   }
   #elseif arch(arm)
+  @usableFromInline
   @_silgen_name("_swift_get_cpu_context")
   static func _swift_get_cpu_context() -> ARMContext
 
+  @_transparent
   public static func withCurrentContext<T>(fn: (ARMContext) throws -> T) rethrows -> T {
     return try fn(_swift_get_cpu_context())
   }


### PR DESCRIPTION
The `withCurrentContext()` methods on the `Context` structs need to be inlined, even in debug builds, otherwise we would need to skip an extra frame at the top of the backtrace.

This fixes test failures in debug stdlib builds.

rdar://106276227
