### PR TITLE
[android][test] Fix two C++ Interop tests that were recently updated on macOS

### DIFF
--- a/test/Interop/Cxx/class/constructors-copy-irgen-android.swift
+++ b/test/Interop/Cxx/class/constructors-copy-irgen-android.swift
@@ -1,6 +1,6 @@
 // Target-specific tests for C++ copy constructor code generation.
 
-// RUN: %swift -module-name MySwift -target aarch64-unknown-linux-android -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
+// RUN: %swift -module-name MySwift -target aarch64-unknown-linux-android -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info -Xcc -fignore-exceptions | %FileCheck %s -check-prefix=ITANIUM_ARM
 
 // REQUIRES: OS=linux-android
 // REQUIRES: CPU=aarch64

--- a/test/Interop/Cxx/class/constructors-irgen-android.swift
+++ b/test/Interop/Cxx/class/constructors-irgen-android.swift
@@ -1,6 +1,6 @@
 // Target-specific tests for C++ constructor call code generation.
 
-// RUN: %swift -module-name MySwift -target aarch64-unknown-linux-android -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info | %FileCheck %s -check-prefix=ITANIUM_ARM
+// RUN: %swift -module-name MySwift -target aarch64-unknown-linux-android -dump-clang-diagnostics -I %S/Inputs -enable-experimental-cxx-interop -emit-ir %s -parse-stdlib -parse-as-library -disable-legacy-type-info -Xcc -fignore-exceptions | %FileCheck %s -check-prefix=ITANIUM_ARM
 
 // REQUIRES: OS=linux-android
 // REQUIRES: CPU=aarch64


### PR DESCRIPTION
These flags were recently added to the macOS versions of these tests in #63809.

@hyp, adding these for Android to try and fix the community CI, as mentioned on that pull.

I'm also seeing [`Interop/SwiftToCxx/core/unsigned-return-type-no-zext.cpp` failing on both the AArch64](https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/lastFailedBuild/consoleText) and armv7 CI lately, though that test wasn't updated recently:
```
/home/ubuntu/jenkins/workspace/oss-swift-RA-linux-ubuntu-16.04-android-arm64/swift/test/Interop/SwiftToCxx/core/unsigned-return-type-no-zext.cpp:18:11: error: CHECK: expected string not found in input
// CHECK: declare{{( noundef)?}}{{( zeroext)?}} i8 @_Z12getEnumTagi8Pv(ptr noundef)
          ^
<stdin>:1:1: note: scanning from here
; ModuleID = 'SOURCE_DIR/test/Interop/SwiftToCxx/core/unsigned-return-type-no-zext.cpp'
^
<stdin>:17:1: note: possible intended match here
declare noundef i8 @_Z12getEnumTagi8Pv(i8* noundef) #1
^
```
I cannot reproduce this one with the last March 2 trunk snapshot tag, which produces that identical last line in the test IR but passes.

Possible that the LLVM rebranch enabled some new strict lit testing mode? That's the only difference I can think of.

@drodriguez, trying to get the Android CI green again.