### PR TITLE
[Backtracing] Don't run tests when testing OS stdlib.

### DIFF
--- a/test/Backtracing/BacktraceWithLimit.swift
+++ b/test/Backtracing/BacktraceWithLimit.swift
@@ -3,6 +3,8 @@
 // RUN: %target-codesign %t/BacktraceWithLimit
 // RUN: %target-run %t/BacktraceWithLimit | %FileCheck %s
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx

--- a/test/Backtracing/BacktraceWithLimitAndTop.swift
+++ b/test/Backtracing/BacktraceWithLimitAndTop.swift
@@ -3,6 +3,8 @@
 // RUN: %target-codesign %t/BacktraceWithLimitAndTop
 // RUN: %target-run %t/BacktraceWithLimitAndTop | %FileCheck %s
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx

--- a/test/Backtracing/Crash.swift
+++ b/test/Backtracing/Crash.swift
@@ -13,6 +13,8 @@
 // RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashOpt || true) | %FileCheck %s --check-prefix OPTIMIZED
 // RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashOptNoDebug || true) | %FileCheck %s --check-prefix OPTNODEBUG
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx
@@ -50,13 +52,13 @@ struct Crash {
 
 // CHECK: Thread 0 crashed:
 
-// CHECK: 0               0x{{[0-9a-f]+}} level5() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:39:15
-// CHECK-NEXT: 1 [ra]          0x{{[0-9a-f]+}} level4() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:33:3
-// CHECK-NEXT: 2 [ra]          0x{{[0-9a-f]+}} level3() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:29:3
-// CHECK-NEXT: 3 [ra]          0x{{[0-9a-f]+}} level2() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:25:3
-// CHECK-NEXT: 4 [ra]          0x{{[0-9a-f]+}} level1() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:21:3
-// CHECK-NEXT: 5 [ra]          0x{{[0-9a-f]+}} static Crash.main() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:45:5
-// CHECK-NEXT: 6 [ra] [system] 0x{{[0-9a-f]+}} static Crash.$main() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:42:1
+// CHECK: 0               0x{{[0-9a-f]+}} level5() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:41:15
+// CHECK-NEXT: 1 [ra]          0x{{[0-9a-f]+}} level4() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:35:3
+// CHECK-NEXT: 2 [ra]          0x{{[0-9a-f]+}} level3() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:31:3
+// CHECK-NEXT: 3 [ra]          0x{{[0-9a-f]+}} level2() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:27:3
+// CHECK-NEXT: 4 [ra]          0x{{[0-9a-f]+}} level1() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:23:3
+// CHECK-NEXT: 5 [ra]          0x{{[0-9a-f]+}} static Crash.main() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:47:5
+// CHECK-NEXT: 6 [ra] [system] 0x{{[0-9a-f]+}} static Crash.$main() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:44:1
 // CHECK-NEXT: 7 [ra] [system] 0x{{[0-9a-f]+}} main + {{[0-9]+}} in Crash at {{.*}}/Crash.swift
 
 // CHECK: Registers:
@@ -69,59 +71,59 @@ struct Crash {
 
 // FRIENDLY: Thread 0 crashed:
 
-// FRIENDLY: 0 level5() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:39:15
+// FRIENDLY: 0 level5() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:41:15
 
-// FRIENDLY: 37|   print("About to crash")
-// FRIENDLY-NEXT: 38|   let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
-// FRIENDLY-NEXT: 39|   ptr.pointee = 42
+// FRIENDLY: 39|   print("About to crash")
+// FRIENDLY-NEXT: 40|   let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
+// FRIENDLY-NEXT: 41|   ptr.pointee = 42
 // FRIENDLY-NEXT:   |               ^
-// FRIENDLY-NEXT: 40| }
-// FRIENDLY-NEXT: 41|
+// FRIENDLY-NEXT: 42| }
+// FRIENDLY-NEXT: 43|
 
-// FRIENDLY: 1 level4() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:33:3
+// FRIENDLY: 1 level4() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:35:3
 
-// FRIENDLY: 31|
-// FRIENDLY-NEXT: 32| func level4() {
-// FRIENDLY-NEXT: 33|   level5()
+// FRIENDLY: 33|
+// FRIENDLY-NEXT: 34| func level4() {
+// FRIENDLY-NEXT: 35|   level5()
 // FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 34| }
-// FRIENDLY-NEXT: 35|
+// FRIENDLY-NEXT: 36| }
+// FRIENDLY-NEXT: 37|
 
-// FRIENDLY: 2 level3() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:29:3
+// FRIENDLY: 2 level3() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:31:3
 
-// FRIENDLY: 27|
-// FRIENDLY-NEXT: 28| func level3() {
-// FRIENDLY-NEXT: 29|   level4()
+// FRIENDLY: 29|
+// FRIENDLY-NEXT: 30| func level3() {
+// FRIENDLY-NEXT: 31|   level4()
 // FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 30| }
-// FRIENDLY-NEXT: 31|
+// FRIENDLY-NEXT: 32| }
+// FRIENDLY-NEXT: 33|
 
-// FRIENDLY: 3 level2() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:25:3
+// FRIENDLY: 3 level2() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:27:3
 
-// FRIENDLY: 23|
-// FRIENDLY-NEXT: 24| func level2() {
-// FRIENDLY-NEXT: 25|   level3()
+// FRIENDLY: 25|
+// FRIENDLY-NEXT: 26| func level2() {
+// FRIENDLY-NEXT: 27|   level3()
 // FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 26| }
-// FRIENDLY-NEXT: 27|
+// FRIENDLY-NEXT: 28| }
+// FRIENDLY-NEXT: 29|
 
-// FRIENDLY: 4 level1() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:21:3
+// FRIENDLY: 4 level1() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:23:3
 
-// FRIENDLY:  19|
-// FRIENDLY-NEXT: 20| func level1() {
-// FRIENDLY-NEXT: 21|   level2()
+// FRIENDLY:  21|
+// FRIENDLY-NEXT: 22| func level1() {
+// FRIENDLY-NEXT: 23|   level2()
 // FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 22| }
-// FRIENDLY-NEXT: 23|
+// FRIENDLY-NEXT: 24| }
+// FRIENDLY-NEXT: 25|
 
-// FRIENDLY: 5 static Crash.main() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:45:5
+// FRIENDLY: 5 static Crash.main() + {{[0-9]+}} in Crash at {{.*}}/Crash.swift:47:5
 
-// FRIENDLY: 43| struct Crash {
-// FRIENDLY-NEXT: 44|   static func main() {
-// FRIENDLY-NEXT: 45|     level1()
+// FRIENDLY: 45| struct Crash {
+// FRIENDLY-NEXT: 46|   static func main() {
+// FRIENDLY-NEXT: 47|     level1()
 // FRIENDLY-NEXT:   |     ^
-// FRIENDLY-NEXT: 46|   }
-// FRIENDLY-NEXT: 47| }
+// FRIENDLY-NEXT: 48|   }
+// FRIENDLY-NEXT: 49| }
 
 // NODEBUG: *** Program crashed: Bad pointer dereference at 0x{{0*}}4 ***
 
@@ -146,13 +148,13 @@ struct Crash {
 
 // OPTIMIZED: Thread 0 crashed:
 
-// OPTIMIZED: 0 [inlined]          0x{{[0-9a-f]+}} level5() in CrashOpt at {{.*}}/Crash.swift:39:15
-// OPTIMIZED-NEXT: 1 [inlined]          0x{{[0-9a-f]+}} level4() in CrashOpt at {{.*}}/Crash.swift:33:3
-// OPTIMIZED-NEXT: 2 [inlined]          0x{{[0-9a-f]+}} level3() in CrashOpt at {{.*}}/Crash.swift:29:3
-// OPTIMIZED-NEXT: 3 [inlined]          0x{{[0-9a-f]+}} level2() in CrashOpt at {{.*}}/Crash.swift:25:3
-// OPTIMIZED-NEXT: 4 [inlined]          0x{{[0-9a-f]+}} level1() in CrashOpt at {{.*}}/Crash.swift:21:3
-// OPTIMIZED-NEXT: 5 [inlined]          0x{{[0-9a-f]+}} static Crash.main() in CrashOpt at {{.*}}/Crash.swift:45:5
-// OPTIMIZED-NEXT: 6 [inlined] [system] 0x{{[0-9a-f]+}} static Crash.$main() in CrashOpt at {{.*}}/Crash.swift:42:1
+// OPTIMIZED: 0 [inlined]          0x{{[0-9a-f]+}} level5() in CrashOpt at {{.*}}/Crash.swift:41:15
+// OPTIMIZED-NEXT: 1 [inlined]          0x{{[0-9a-f]+}} level4() in CrashOpt at {{.*}}/Crash.swift:35:3
+// OPTIMIZED-NEXT: 2 [inlined]          0x{{[0-9a-f]+}} level3() in CrashOpt at {{.*}}/Crash.swift:31:3
+// OPTIMIZED-NEXT: 3 [inlined]          0x{{[0-9a-f]+}} level2() in CrashOpt at {{.*}}/Crash.swift:27:3
+// OPTIMIZED-NEXT: 4 [inlined]          0x{{[0-9a-f]+}} level1() in CrashOpt at {{.*}}/Crash.swift:23:3
+// OPTIMIZED-NEXT: 5 [inlined]          0x{{[0-9a-f]+}} static Crash.main() in CrashOpt at {{.*}}/Crash.swift:47:5
+// OPTIMIZED-NEXT: 6 [inlined] [system] 0x{{[0-9a-f]+}} static Crash.$main() in CrashOpt at {{.*}}/Crash.swift:44:1
 // OPTIMIZED-NEXT: 7 [system]           0x{{[0-9a-f]+}} main + {{[0-9]+}} in CrashOpt at {{.*}}/Crash.swift
 
 // OPTIMIZED: Registers:

--- a/test/Backtracing/CrashWithThunk.swift
+++ b/test/Backtracing/CrashWithThunk.swift
@@ -4,6 +4,8 @@
 // RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/CrashWithThunk || true) | %FileCheck %s
 // RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/CrashWithThunk || true) | %FileCheck %s --check-prefix FRIENDLY
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx
@@ -31,10 +33,10 @@ struct CrashWithThunk {
 
 // CHECK: Thread 0 crashed:
 
-// CHECK: 0                       0x{{[0-9a-f]+}} crash() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:18:15
+// CHECK: 0                       0x{{[0-9a-f]+}} crash() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:20:15
 // CHECK-NEXT: 1 [ra] [thunk] [system] 0x{{[0-9a-f]+}} thunk for @escaping @callee_guaranteed () -> () + {{[0-9]+}} in CrashWithThunk at {{.*}}/Backtracing/<compiler-generated>
-// CHECK-NEXT: 2 [ra]                  0x{{[0-9a-f]+}} static CrashWithThunk.main() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:26:9
-// CHECK-NEXT: 3 [ra] [system]         0x{{[0-9a-f]+}} static CrashWithThunk.$main() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:21:1
+// CHECK-NEXT: 2 [ra]                  0x{{[0-9a-f]+}} static CrashWithThunk.main() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:28:9
+// CHECK-NEXT: 3 [ra] [system]         0x{{[0-9a-f]+}} static CrashWithThunk.$main() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:23:1
 // CHECK-NEXT: 4 [ra] [system]         0x{{[0-9a-f]+}} main + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift
 
 // CHECK: Registers:
@@ -47,20 +49,20 @@ struct CrashWithThunk {
 
 // FRIENDLY: Thread 0 crashed:
 
-// FRIENDLY: 0 crash() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:18:15
+// FRIENDLY: 0 crash() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:20:15
 
-// FRIENDLY: 16|   print("I'm going to crash here")
-// FRIENDLY-NEXT: 17|   let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
-// FRIENDLY-NEXT: 18|   ptr.pointee = 42
+// FRIENDLY: 18|   print("I'm going to crash here")
+// FRIENDLY-NEXT: 19|   let ptr = UnsafeMutablePointer<Int>(bitPattern: 4)!
+// FRIENDLY-NEXT: 20|   ptr.pointee = 42
 // FRIENDLY-NEXT:   |               ^
-// FRIENDLY-NEXT: 19| }
-// FRIENDLY-NEXT: 20|
+// FRIENDLY-NEXT: 21| }
+// FRIENDLY-NEXT: 22|
 
-// FRIENDLY: 1 static CrashWithThunk.main() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:26:9
+// FRIENDLY: 1 static CrashWithThunk.main() + {{[0-9]+}} in CrashWithThunk at {{.*}}/CrashWithThunk.swift:28:9
 
-// FRIENDLY: 24|     let foo = Foo(value: crash)
-// FRIENDLY-NEXT: 25|
-// FRIENDLY-NEXT: 26|     foo.value()
+// FRIENDLY: 26|     let foo = Foo(value: crash)
+// FRIENDLY-NEXT: 27|
+// FRIENDLY-NEXT: 28|     foo.value()
 // FRIENDLY-NEXT:   |         ^
-// FRIENDLY-NEXT: 27|   }
-// FRIENDLY-NEXT: 28| }
+// FRIENDLY-NEXT: 29|   }
+// FRIENDLY-NEXT: 30| }

--- a/test/Backtracing/Overflow.swift
+++ b/test/Backtracing/Overflow.swift
@@ -4,6 +4,8 @@
 // RUN: (env SWIFT_BACKTRACE=enable=yes,cache=no %target-run %t/Overflow || true) | %FileCheck %s
 // RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/Overflow || true) | %FileCheck %s --check-prefix FRIENDLY
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx
@@ -43,13 +45,13 @@ struct Overflow {
 // CHECK: Thread 0 crashed:
 
 // CHECK:      0 [inlined] [system] 0x{{[0-9a-f]+}} Swift runtime failure: arithmetic overflow in Overflow at {{.*}}/<compiler-generated>
-// CHECK-NEXT: 1                    0x{{[0-9a-f]+}} level5() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:31:5
-// CHECK-NEXT: 2 [ra]               0x{{[0-9a-f]+}} level4() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:25:3
-// CHECK-NEXT: 3 [ra]               0x{{[0-9a-f]+}} level3() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:21:3
-// CHECK-NEXT: 4 [ra]               0x{{[0-9a-f]+}} level2() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:17:3
-// CHECK-NEXT: 5 [ra]               0x{{[0-9a-f]+}} level1() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:13:3
-// CHECK-NEXT: 6 [ra]               0x{{[0-9a-f]+}} static Overflow.main() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:37:5
-// CHECK-NEXT: 7 [ra] [system]      0x{{[0-9a-f]+}} static Overflow.$main() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:34:1
+// CHECK-NEXT: 1                    0x{{[0-9a-f]+}} level5() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:33:5
+// CHECK-NEXT: 2 [ra]               0x{{[0-9a-f]+}} level4() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:27:3
+// CHECK-NEXT: 3 [ra]               0x{{[0-9a-f]+}} level3() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:23:3
+// CHECK-NEXT: 4 [ra]               0x{{[0-9a-f]+}} level2() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:19:3
+// CHECK-NEXT: 5 [ra]               0x{{[0-9a-f]+}} level1() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:15:3
+// CHECK-NEXT: 6 [ra]               0x{{[0-9a-f]+}} static Overflow.main() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:39:5
+// CHECK-NEXT: 7 [ra] [system]      0x{{[0-9a-f]+}} static Overflow.$main() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:36:1
 // CHECK-NEXT: 8 [ra] [system]      0x{{[0-9a-f]+}} main + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift
 
 // CHECK: Registers:
@@ -62,49 +64,49 @@ struct Overflow {
 
 // FRIENDLY: Thread 0 crashed:
 
-// FRIENDLY: 0 level5() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:31:5
+// FRIENDLY: 0 level5() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:33:5
 
-// FRIENDLY: 29|   print("About to overflow")
-// FRIENDLY-NEXT: 30|
-// FRIENDLY-NEXT: 31|   x -= 1
+// FRIENDLY: 31|   print("About to overflow")
+// FRIENDLY-NEXT: 32|
+// FRIENDLY-NEXT: 33|   x -= 1
 // FRIENDLY-NEXT:   |     ^
-// FRIENDLY-NEXT: 32| }
+// FRIENDLY-NEXT: 34| }
 
-// FRIENDLY: 1 level4() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:25:3
+// FRIENDLY: 1 level4() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:27:3
 
-// FRIENDLY: 23|
-// FRIENDLY-NEXT: 24| func level4() {
-// FRIENDLY-NEXT: 25|   level5()
+// FRIENDLY: 25|
+// FRIENDLY-NEXT: 26| func level4() {
+// FRIENDLY-NEXT: 27|   level5()
 // FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 26| }
-// FRIENDLY-NEXT: 27|
+// FRIENDLY-NEXT: 28| }
+// FRIENDLY-NEXT: 29|
 
-// FRIENDLY: 2 level3() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:21:3
+// FRIENDLY: 2 level3() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:23:3
 
-// FRIENDLY: 19|
-// FRIENDLY-NEXT: 20| func level3() {
-// FRIENDLY-NEXT: 21|   level4()
+// FRIENDLY: 21|
+// FRIENDLY-NEXT: 22| func level3() {
+// FRIENDLY-NEXT: 23|   level4()
 // FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 22| }
-// FRIENDLY-NEXT: 23|
+// FRIENDLY-NEXT: 24| }
+// FRIENDLY-NEXT: 25|
 
-// FRIENDLY: 3 level2() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:17:3
+// FRIENDLY: 3 level2() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:19:3
 
-// FRIENDLY: 15|
-// FRIENDLY-NEXT: 16| func level2() {
-// FRIENDLY-NEXT: 17|   level3()
+// FRIENDLY: 17|
+// FRIENDLY-NEXT: 18| func level2() {
+// FRIENDLY-NEXT: 19|   level3()
 // FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 18| }
-// FRIENDLY-NEXT: 19|
+// FRIENDLY-NEXT: 20| }
+// FRIENDLY-NEXT: 21|
 
-// FRIENDLY: 4 level1() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:13:3
+// FRIENDLY: 4 level1() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift:15:3
 
-// FRIENDLY: 11|
-// FRIENDLY-NEXT: 12| func level1() {
-// FRIENDLY-NEXT: 13|   level2()
+// FRIENDLY: 13|
+// FRIENDLY-NEXT: 14| func level1() {
+// FRIENDLY-NEXT: 15|   level2()
 // FRIENDLY-NEXT:   |   ^
-// FRIENDLY-NEXT: 14| }
-// FRIENDLY-NEXT: 15|
+// FRIENDLY-NEXT: 16| }
+// FRIENDLY-NEXT: 17|
 
 // FRIENDLY: 5 static Overflow.main() + {{[0-9]+}} in Overflow at {{.*}}/Overflow.swift
 

--- a/test/Backtracing/SimpleAsyncBacktrace.swift
+++ b/test/Backtracing/SimpleAsyncBacktrace.swift
@@ -9,6 +9,7 @@
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx
 
+// UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: back_deployment_runtime
 
 import _Backtracing

--- a/test/Backtracing/SimpleBacktrace.swift
+++ b/test/Backtracing/SimpleBacktrace.swift
@@ -7,6 +7,9 @@
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
 func level1() {
   level2()
 }

--- a/test/Backtracing/StackOverflow.swift
+++ b/test/Backtracing/StackOverflow.swift
@@ -5,6 +5,8 @@
 // RUN: (env SWIFT_BACKTRACE=limit=16,top=4,enable=yes,cache=no %target-run %t/StackOverflow || true) | %FileCheck %s --check-prefix LIMITED
 // RUN: (env SWIFT_BACKTRACE=preset=friendly,enable=yes,cache=no %target-run %t/StackOverflow || true) | %FileCheck %s --check-prefix FRIENDLY
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx
@@ -32,67 +34,67 @@ struct StackOverflow {
 // CHECK: Thread 0 crashed:
 
 // CHECK:     0               0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:{{[0-9]+}}
-// CHECK-NEXT:     1 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:     2 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:     3 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:     4 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:     5 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:     6 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:     7 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:     8 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:     9 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    10 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    11 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    12 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    13 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    14 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    15 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    16 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    17 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    18 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    19 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    20 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    21 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    22 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    23 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    24 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    25 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    26 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    27 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    28 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    29 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    30 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    31 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    32 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    33 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    34 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    35 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    36 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    37 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    38 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    39 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    40 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    41 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    42 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    43 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    44 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    45 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT:    46 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
+// CHECK-NEXT:     1 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:     2 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:     3 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:     4 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:     5 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:     6 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:     7 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:     8 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:     9 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    10 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    11 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    12 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    13 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    14 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    15 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    16 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    17 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    18 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    19 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    20 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    21 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    22 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    23 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    24 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    25 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    26 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    27 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    28 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    29 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    30 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    31 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    32 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    33 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    34 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    35 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    36 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    37 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    38 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    39 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    40 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    41 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    42 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    43 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    44 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    45 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT:    46 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
 // CHECK-NEXT:   ...
-// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} static StackOverflow.main() + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:22:5
-// CHECK-NEXT: {{[0-9]+}} [ra] [system] 0x{{[0-9a-f]+}} static StackOverflow.$main() + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:19:1
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// CHECK-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} static StackOverflow.main() + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:24:5
+// CHECK-NEXT: {{[0-9]+}} [ra] [system] 0x{{[0-9a-f]+}} static StackOverflow.$main() + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:21:1
 // CHECK-NEXT: {{[0-9]+}} [ra] [system] 0x{{[0-9a-f]+}} main + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift
 
 // CHECK: Registers:
@@ -106,19 +108,19 @@ struct StackOverflow {
 // LIMITED: Thread 0 crashed:
 
 // LIMITED:     0               0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift
-// LIMITED-NEXT:     1 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// LIMITED-NEXT:     2 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// LIMITED-NEXT:     3 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// LIMITED-NEXT:     4 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// LIMITED-NEXT:     5 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// LIMITED-NEXT:     6 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// LIMITED-NEXT:     7 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// LIMITED-NEXT:     8 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// LIMITED-NEXT:     9 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// LIMITED-NEXT:    10 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
+// LIMITED-NEXT:     1 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// LIMITED-NEXT:     2 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// LIMITED-NEXT:     3 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// LIMITED-NEXT:     4 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// LIMITED-NEXT:     5 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// LIMITED-NEXT:     6 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// LIMITED-NEXT:     7 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// LIMITED-NEXT:     8 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// LIMITED-NEXT:     9 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// LIMITED-NEXT:    10 [ra]          0x{{[0-9a-f]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
 // LIMITED-NEXT:   ...
-// LIMITED-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} static StackOverflow.main() + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:22:5
-// LIMITED-NEXT: {{[0-9]+}} [ra] [system] 0x{{[0-9a-f]+}} static StackOverflow.$main() + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:19:1
+// LIMITED-NEXT: {{[0-9]+}} [ra]          0x{{[0-9a-f]+}} static StackOverflow.main() + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:24:5
+// LIMITED-NEXT: {{[0-9]+}} [ra] [system] 0x{{[0-9a-f]+}} static StackOverflow.$main() + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:21:1
 // LIMITED-NEXT: {{[0-9]+}} [ra] [system] 0x{{[0-9a-f]+}} main + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift
 
 // FRIENDLY: *** Program crashed: Bad pointer dereference at 0x{{[0-9a-f]+}} ***
@@ -134,7 +136,7 @@ struct StackOverflow {
 // SKIP-FRIENDLY-NEXT:       │ ▲
 // SKIP-FRIENDLY-NEXT:     13│   if level % 100000 == 0 {
 
-// FRIENDLY:    1 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
+// FRIENDLY:    1 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
 
 // SKIP-FRIENDLY:     13│   if level % 100000 == 0 {
 // SKIP-FRIENDLY-NEXT:     14│     print(level)
@@ -143,65 +145,65 @@ struct StackOverflow {
 // SKIP-FRIENDLY-NEXT:       │   ▲
 // SKIP-FRIENDLY-NEXT:     17│ }
 
-// FRIENDLY:     2 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:     3 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:     4 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:     5 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:     6 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:     7 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:     8 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:     9 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    10 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    11 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    12 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    13 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    14 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    15 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    16 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    17 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    18 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    19 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    20 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    21 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    22 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    23 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    24 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    25 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    26 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    27 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    28 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    29 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    30 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    31 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    32 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    33 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    34 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    35 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    36 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    37 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    38 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    39 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    40 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    41 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    42 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    43 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    44 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    45 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT:    46 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
+// FRIENDLY:     2 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:     3 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:     4 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:     5 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:     6 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:     7 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:     8 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:     9 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    10 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    11 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    12 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    13 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    14 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    15 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    16 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    17 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    18 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    19 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    20 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    21 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    22 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    23 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    24 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    25 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    26 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    27 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    28 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    29 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    30 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    31 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    32 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    33 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    34 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    35 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    36 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    37 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    38 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    39 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    40 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    41 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    42 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    43 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    44 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    45 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT:    46 recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
 // FRIENDLY-NEXT:   ...
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:16:3
-// FRIENDLY-NEXT: {{[0-9]+}} static StackOverflow.main() + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:22:5
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT: {{[0-9]+}} recurse(_:) + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:18:3
+// FRIENDLY-NEXT: {{[0-9]+}} static StackOverflow.main() + {{[0-9]+}} in StackOverflow at {{.*}}/StackOverflow.swift:24:5
 
 // SKIP-FRIENDLY:     19│ @main
 // SKIP-FRIENDLY-NEXT:     20│ struct StackOverflow {

--- a/test/Backtracing/SymbolicatedBacktrace.swift
+++ b/test/Backtracing/SymbolicatedBacktrace.swift
@@ -3,6 +3,8 @@
 // RUN: %target-codesign %t/SymbolicatedBacktrace
 // RUN: %target-run %t/SymbolicatedBacktrace | %FileCheck %s
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx

--- a/test/Backtracing/SymbolicatedBacktraceInline.swift
+++ b/test/Backtracing/SymbolicatedBacktraceInline.swift
@@ -3,6 +3,8 @@
 // RUN: %target-codesign %t/SymbolicatedBacktraceInline
 // RUN: %target-run %t/SymbolicatedBacktraceInline | %FileCheck %s
 
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
 // REQUIRES: executable_test
 // REQUIRES: backtracing
 // REQUIRES: OS=macosx


### PR DESCRIPTION
We need a symbol from the standard library that isn't in the older versions of the stdlib.

rdar://106293913
