### PR TITLE
[Sema] Introduce a couple of ExprPattern requests

### DIFF
--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -508,25 +508,29 @@ class EnumElementPattern : public Pattern {
   DeclNameRef Name;
   PointerUnion<EnumElementDecl *, Expr*> ElementDeclOrUnresolvedOriginalExpr;
   Pattern /*nullable*/ *SubPattern;
+  DeclContext *DC;
 
 public:
   EnumElementPattern(TypeExpr *ParentType, SourceLoc DotLoc,
                      DeclNameLoc NameLoc, DeclNameRef Name,
-                     EnumElementDecl *Element, Pattern *SubPattern)
+                     EnumElementDecl *Element, Pattern *SubPattern,
+                     DeclContext *DC)
       : Pattern(PatternKind::EnumElement), ParentType(ParentType),
         DotLoc(DotLoc), NameLoc(NameLoc), Name(Name),
-        ElementDeclOrUnresolvedOriginalExpr(Element), SubPattern(SubPattern) {
+        ElementDeclOrUnresolvedOriginalExpr(Element), SubPattern(SubPattern),
+        DC(DC) {
     assert(ParentType && "Missing parent type?");
   }
 
   /// Create an unresolved EnumElementPattern for a `.foo` pattern relying on
   /// contextual type.
   EnumElementPattern(SourceLoc DotLoc, DeclNameLoc NameLoc, DeclNameRef Name,
-                     Pattern *SubPattern, Expr *UnresolvedOriginalExpr)
+                     Pattern *SubPattern, Expr *UnresolvedOriginalExpr,
+                     DeclContext *DC)
       : Pattern(PatternKind::EnumElement), ParentType(nullptr), DotLoc(DotLoc),
         NameLoc(NameLoc), Name(Name),
         ElementDeclOrUnresolvedOriginalExpr(UnresolvedOriginalExpr),
-        SubPattern(SubPattern) {}
+        SubPattern(SubPattern), DC(DC) {}
 
   bool hasSubPattern() const { return SubPattern; }
 
@@ -539,6 +543,8 @@ public:
   }
 
   void setSubPattern(Pattern *p) { SubPattern = p; }
+
+  DeclContext *getDeclContext() const { return DC; }
 
   DeclNameRef getName() const { return Name; }
 

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -647,41 +647,57 @@ public:
 class ExprPattern : public Pattern {
   llvm::PointerIntPair<Expr *, 1, bool> SubExprAndIsResolved;
 
-  /// An expression constructed during type-checking that produces a call to the
-  /// '~=' operator comparing the match expression on the left to the matched
-  /// value on the right.
-  Expr *MatchExpr = nullptr;
+  DeclContext *DC;
 
-  /// An implicit variable used to represent the RHS value of the match.
-  VarDecl *MatchVar = nullptr;
+  /// A synthesized call to the '~=' operator comparing the match expression
+  /// on the left to the matched value on the right.
+  mutable Expr *MatchExpr = nullptr;
 
-  ExprPattern(Expr *E, bool isResolved)
-      : Pattern(PatternKind::Expr), SubExprAndIsResolved(E, isResolved) {}
+  /// An implicit variable used to represent the RHS value of the synthesized
+  /// match expression.
+  mutable VarDecl *MatchVar = nullptr;
+
+  ExprPattern(Expr *E, DeclContext *DC, bool isResolved)
+      : Pattern(PatternKind::Expr), SubExprAndIsResolved(E, isResolved),
+        DC(DC) {}
+
+  friend class ExprPatternMatchRequest;
 
 public:
   /// Create a new parsed unresolved ExprPattern.
-  static ExprPattern *createParsed(ASTContext &ctx, Expr *E);
+  static ExprPattern *createParsed(ASTContext &ctx, Expr *E, DeclContext *DC);
 
   /// Create a new resolved ExprPattern. This should be used in cases
   /// where a user-written expression should be treated as an ExprPattern.
-  static ExprPattern *createResolved(ASTContext &ctx, Expr *E);
+  static ExprPattern *createResolved(ASTContext &ctx, Expr *E, DeclContext *DC);
 
   /// Create a new implicit resolved ExprPattern.
-  static ExprPattern *createImplicit(ASTContext &ctx, Expr *E);
+  static ExprPattern *createImplicit(ASTContext &ctx, Expr *E, DeclContext *DC);
 
   Expr *getSubExpr() const { return SubExprAndIsResolved.getPointer(); }
   void setSubExpr(Expr *e) { SubExprAndIsResolved.setPointer(e); }
 
-  Expr *getMatchExpr() const { return MatchExpr; }
-  void setMatchExpr(Expr *e) {
-    assert(isResolved() && "cannot set match fn for unresolved expr patter");
-    MatchExpr = e;
-  }
+  DeclContext *getDeclContext() const { return DC; }
 
-  VarDecl *getMatchVar() const { return MatchVar; }
-  void setMatchVar(VarDecl *v) {
-    assert(isResolved() && "cannot set match var for unresolved expr patter");
-    MatchVar = v;
+  /// The match expression if it has been computed, \c nullptr otherwise.
+  /// Should only be used by the ASTDumper and ASTWalker.
+  Expr *getCachedMatchExpr() const { return MatchExpr; }
+
+  /// The match variable if it has been computed, \c nullptr otherwise.
+  /// Should only be used by the ASTDumper and ASTWalker.
+  VarDecl *getCachedMatchVar() const { return MatchVar; }
+
+  /// A synthesized call to the '~=' operator comparing the match expression
+  /// on the left to the matched value on the right.
+  Expr *getMatchExpr() const;
+
+  /// An implicit variable used to represent the RHS value of the synthesized
+  /// match expression.
+  VarDecl *getMatchVar() const;
+
+  void setMatchExpr(Expr *e) {
+    assert(MatchExpr && "Should only update an existing MatchExpr");
+    MatchExpr = e;
   }
 
   SourceLoc getLoc() const;
@@ -851,6 +867,9 @@ public:
 };
 
 void simple_display(llvm::raw_ostream &out, const ContextualPattern &pattern);
+void simple_display(llvm::raw_ostream &out, const Pattern *pattern);
+
+SourceLoc extractNearestSourceLoc(const Pattern *pattern);
 
 } // end namespace swift
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2219,6 +2219,52 @@ public:
   void cacheResult(NamedPattern *P) const;
 };
 
+class ExprPatternMatchResult {
+  VarDecl *MatchVar;
+  Expr *MatchExpr;
+
+  friend class ExprPattern;
+
+  // Should only be used as the default value for the request, as the caching
+  // logic assumes the request always produces a non-null result.
+  ExprPatternMatchResult(llvm::NoneType)
+      : MatchVar(nullptr), MatchExpr(nullptr) {}
+
+public:
+  ExprPatternMatchResult(VarDecl *matchVar, Expr *matchExpr)
+      : MatchVar(matchVar), MatchExpr(matchExpr) {
+    // Note the caching logic currently requires the request to produce a
+    // non-null result.
+    assert(matchVar && matchExpr);
+  }
+
+  VarDecl *getMatchVar() const { return MatchVar; }
+  Expr *getMatchExpr() const { return MatchExpr; }
+};
+
+/// Compute the match VarDecl and expression for an ExprPattern, which applies
+/// the \c ~= operator.
+class ExprPatternMatchRequest
+    : public SimpleRequest<ExprPatternMatchRequest,
+                           ExprPatternMatchResult(const ExprPattern *),
+                           RequestFlags::SeparatelyCached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  ExprPatternMatchResult evaluate(Evaluator &evaluator,
+                                  const ExprPattern *EP) const;
+
+public:
+  // Separate caching.
+  bool isCached() const { return true; }
+  Optional<ExprPatternMatchResult> getCachedResult() const;
+  void cacheResult(ExprPatternMatchResult result) const;
+};
+
 class InterfaceTypeRequest :
     public SimpleRequest<InterfaceTypeRequest,
                          Type (ValueDecl *),

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -2265,6 +2265,28 @@ public:
   void cacheResult(ExprPatternMatchResult result) const;
 };
 
+/// Creates a corresponding ExprPattern from the original Expr of an
+/// EnumElementPattern. This needs to be a cached request to ensure we don't
+/// generate multiple ExprPatterns along different constraint solver paths.
+class EnumElementExprPatternRequest
+    : public SimpleRequest<EnumElementExprPatternRequest,
+                           ExprPattern *(const EnumElementPattern *),
+                           RequestFlags::Cached> {
+public:
+  using SimpleRequest::SimpleRequest;
+
+private:
+  friend SimpleRequest;
+
+  // Evaluation.
+  ExprPattern *evaluate(Evaluator &evaluator,
+                        const EnumElementPattern *EEP) const;
+
+public:
+  // Cached.
+  bool isCached() const { return true; }
+};
+
 class InterfaceTypeRequest :
     public SimpleRequest<InterfaceTypeRequest,
                          Type (ValueDecl *),

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -228,6 +228,9 @@ SWIFT_REQUEST(TypeChecker, ModuleImplicitImportsRequest,
               ImplicitImportList(ModuleDecl *), Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, NamingPatternRequest,
               NamedPattern *(VarDecl *), SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, ExprPatternMatchRequest,
+              ExprPatternMatchResult(const ExprPattern *),
+              SeparatelyCached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, OpaqueReadOwnershipRequest,
               OpaqueReadOwnership(AbstractStorageDecl *), SeparatelyCached,
               NoLocationInfo)

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -231,6 +231,9 @@ SWIFT_REQUEST(TypeChecker, NamingPatternRequest,
 SWIFT_REQUEST(TypeChecker, ExprPatternMatchRequest,
               ExprPatternMatchResult(const ExprPattern *),
               SeparatelyCached, NoLocationInfo)
+SWIFT_REQUEST(TypeChecker, EnumElementExprPatternRequest,
+              ExprPattern *(const EnumElementPattern *),
+              Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, OpaqueReadOwnershipRequest,
               OpaqueReadOwnership(AbstractStorageDecl *), SeparatelyCached,
               NoLocationInfo)

--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -1629,6 +1629,14 @@ public:
     return None;
   }
 
+  Optional<SyntacticElementTarget>
+  getTargetFor(SyntacticElementTargetKey key) const {
+    auto known = targets.find(key);
+    if (known == targets.end())
+      return None;
+    return known->second;
+  }
+
   ConstraintLocator *getCalleeLocator(ConstraintLocator *locator,
                                       bool lookThroughApply = true) const;
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -472,7 +472,7 @@ namespace {
     void visitExprPattern(ExprPattern *P) {
       printCommon(P, "pattern_expr");
       OS << '\n';
-      if (auto m = P->getMatchExpr())
+      if (auto m = P->getCachedMatchExpr())
         printRec(m);
       else
         printRec(P->getSubExpr());

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -1980,8 +1980,8 @@ Pattern *Traversal::visitEnumElementPattern(EnumElementPattern *P) {
 Pattern *Traversal::visitExprPattern(ExprPattern *P) {
   // If the pattern has been type-checked, walk the match expression, which
   // includes the explicit subexpression.
-  if (P->getMatchExpr()) {
-    if (Expr *newMatch = doIt(P->getMatchExpr())) {
+  if (auto *match = P->getCachedMatchExpr()) {
+    if (Expr *newMatch = doIt(match)) {
       P->setMatchExpr(newMatch);
       return P;
     }

--- a/lib/AST/TypeCheckRequests.cpp
+++ b/lib/AST/TypeCheckRequests.cpp
@@ -1012,6 +1012,25 @@ void NamingPatternRequest::cacheResult(NamedPattern *value) const {
 }
 
 //----------------------------------------------------------------------------//
+// ExprPatternMatchRequest caching.
+//----------------------------------------------------------------------------//
+
+Optional<ExprPatternMatchResult>
+ExprPatternMatchRequest::getCachedResult() const {
+  auto *EP = std::get<0>(getStorage());
+  if (!EP->MatchVar)
+    return None;
+
+  return ExprPatternMatchResult(EP->MatchVar, EP->MatchExpr);
+}
+
+void ExprPatternMatchRequest::cacheResult(ExprPatternMatchResult result) const {
+  auto *EP = std::get<0>(getStorage());
+  EP->MatchVar = result.getMatchVar();
+  EP->MatchExpr = result.getMatchExpr();
+}
+
+//----------------------------------------------------------------------------//
 // InterfaceTypeRequest computation.
 //----------------------------------------------------------------------------//
 

--- a/lib/IDE/ArgumentCompletion.cpp
+++ b/lib/IDE/ArgumentCompletion.cpp
@@ -95,19 +95,18 @@ static bool isExpressionResultTypeUnconstrained(const Solution &S, Expr *E) {
       return true;
     }
   }
-  auto targetIt = S.targets.find(E);
-  if (targetIt == S.targets.end()) {
+  auto target = S.getTargetFor(E);
+  if (!target)
     return false;
-  }
-  auto target = targetIt->second;
-  assert(target.kind == SyntacticElementTarget::Kind::expression);
-  switch (target.getExprContextualTypePurpose()) {
+
+  assert(target->kind == SyntacticElementTarget::Kind::expression);
+  switch (target->getExprContextualTypePurpose()) {
   case CTP_Unused:
     // If we aren't using the contextual type, its unconstrained by definition.
     return true;
   case CTP_Initialization: {
     // let x = <expr> is unconstrained
-    auto contextualType = target.getExprContextualType();
+    auto contextualType = target->getExprContextualType();
     return !contextualType || contextualType->is<UnresolvedType>();
   }
   default:

--- a/lib/IDE/ExprContextAnalysis.cpp
+++ b/lib/IDE/ExprContextAnalysis.cpp
@@ -1185,11 +1185,15 @@ class ExprContextAnalyzer {
     switch (P->getKind()) {
     case PatternKind::Expr: {
       auto ExprPat = cast<ExprPattern>(P);
-      if (auto D = ExprPat->getMatchVar()) {
-        if (D->hasInterfaceType())
-          recordPossibleType(
-              D->getDeclContext()->mapTypeIntoContext(D->getInterfaceType()));
-      }
+      if (!ExprPat->isResolved())
+        break;
+
+      auto D = ExprPat->getMatchVar();
+      if (!D || !D->hasInterfaceType())
+        break;
+
+      auto *DC = D->getDeclContext();
+      recordPossibleType(DC->mapTypeIntoContext(D->getInterfaceType()));
       break;
     }
     default:

--- a/lib/IDE/PostfixCompletion.cpp
+++ b/lib/IDE/PostfixCompletion.cpp
@@ -52,11 +52,9 @@ getClosureActorIsolation(const Solution &S, AbstractClosureExpr *ACE) {
     // the contextual type might have a global actor attribute but because no
     // methods from that global actor are called in the closure, the closure has
     // a non-actor type.
-    auto target = S.targets.find(dyn_cast<ClosureExpr>(E));
-    if (target != S.targets.end()) {
-      if (auto Ty = target->second.getClosureContextualType()) {
+    if (auto target = S.getTargetFor(dyn_cast<ClosureExpr>(E))) {
+      if (auto Ty = target->getClosureContextualType())
         return Ty;
-      }
     }
     if (!S.hasType(E)) {
       return Type();

--- a/lib/IDE/TypeCheckCompletionCallback.cpp
+++ b/lib/IDE/TypeCheckCompletionCallback.cpp
@@ -165,9 +165,8 @@ bool swift::ide::isContextAsync(const constraints::Solution &S,
   //    closure that doesn't contain any async calles. Thus the closure is
   //    type-checked as non-async, but it might get converted to an async
   //    closure based on its contextual type
-  auto target = S.targets.find(dyn_cast<ClosureExpr>(DC));
-  if (target != S.targets.end()) {
-    if (auto ContextTy = target->second.getClosureContextualType()) {
+  if (auto target = S.getTargetFor(dyn_cast<ClosureExpr>(DC))) {
+    if (auto ContextTy = target->getClosureContextualType()) {
       if (auto ContextFuncTy =
               S.simplifyType(ContextTy)->getAs<AnyFunctionType>()) {
         return ContextFuncTy->isAsync();

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -1339,7 +1339,7 @@ ParserResult<Pattern> Parser::parseMatchingPattern(bool isExprBasic) {
   if (auto *UPE = dyn_cast<UnresolvedPatternExpr>(subExpr.get()))
     return makeParserResult(status, UPE->getSubPattern());
 
-  auto *EP = ExprPattern::createParsed(Context, subExpr.get());
+  auto *EP = ExprPattern::createParsed(Context, subExpr.get(), CurDeclContext);
   return makeParserResult(status, EP);
 }
 

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1095,7 +1095,8 @@ static void parseGuardedPattern(Parser &P, GuardedPattern &result,
   // Do some special-case code completion for the start of the pattern.
   if (P.Tok.is(tok::code_complete)) {
     auto CCE = new (P.Context) CodeCompletionExpr(P.Tok.getLoc());
-    result.ThePattern = ExprPattern::createParsed(P.Context, CCE);
+    result.ThePattern =
+        ExprPattern::createParsed(P.Context, CCE, P.CurDeclContext);
     if (P.IDECallbacks) {
       switch (parsingContext) {
       case GuardedPatternContext::Case:

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -9928,13 +9928,12 @@ static bool inferEnumMemberThroughTildeEqualsOperator(
   if (!pattern->hasUnresolvedOriginalExpr())
     return true;
 
-  auto &DC = cs.DC;
+  auto *DC = pattern->getDeclContext();
   auto &ctx = cs.getASTContext();
 
-  // Slots for expression and variable are going to be filled via
-  // synthesizing ~= operator application.
-  auto *EP = ExprPattern::createResolved(
-      ctx, pattern->getUnresolvedOriginalExpr(), DC);
+  // Retrieve a corresponding ExprPattern which we can solve with ~=.
+  auto *EP =
+      llvm::cantFail(ctx.evaluator(EnumElementExprPatternRequest{pattern}));
 
   // result of ~= operator is always a `Bool`.
   auto *matchCall = EP->getMatchExpr();

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -976,7 +976,7 @@ createEnumSwitch(ASTContext &C, DeclContext *DC, Expr *expr, EnumDecl *enumDecl,
               DC->mapTypeIntoContext(
                   targetElt->getParentEnum()->getDeclaredInterfaceType()),
               C),
-          SourceLoc(), DeclNameLoc(), DeclNameRef(), targetElt, subpattern);
+          SourceLoc(), DeclNameLoc(), DeclNameRef(), targetElt, subpattern, DC);
       pat->setImplicit();
 
       auto labelItem = CaseLabelItem(pat);

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -214,7 +214,8 @@ deriveBodyCodingKey_enum_stringValue(AbstractFunctionDecl *strValDecl, void *) {
     for (auto *elt : elements) {
       auto *baseTE = TypeExpr::createImplicit(enumType, C);
       auto *pat = new (C) EnumElementPattern(baseTE, SourceLoc(), DeclNameLoc(),
-                                             DeclNameRef(), elt, nullptr);
+                                             DeclNameRef(), elt, nullptr,
+                                             /*DC*/ strValDecl);
       pat->setImplicit();
 
       auto labelItem = CaseLabelItem(pat);

--- a/lib/Sema/DerivedConformanceCodingKey.cpp
+++ b/lib/Sema/DerivedConformanceCodingKey.cpp
@@ -277,7 +277,7 @@ deriveBodyCodingKey_init_stringValue(AbstractFunctionDecl *initDecl, void *) {
   for (auto *elt : elements) {
     auto *litExpr = new (C) StringLiteralExpr(elt->getNameStr(), SourceRange(),
                                               /*Implicit=*/true);
-    auto *litPat = ExprPattern::createImplicit(C, litExpr);
+    auto *litPat = ExprPattern::createImplicit(C, litExpr, /*DC*/ initDecl);
 
     auto labelItem = CaseLabelItem(litPat);
 

--- a/lib/Sema/DerivedConformanceComparable.cpp
+++ b/lib/Sema/DerivedConformanceComparable.cpp
@@ -116,9 +116,9 @@ deriveBodyComparable_enum_hasAssociatedValues_lt(AbstractFunctionDecl *ltDecl, v
     auto lhsSubpattern = DerivedConformance::enumElementPayloadSubpattern(elt, 'l', ltDecl,
                                                       lhsPayloadVars);
     auto *lhsBaseTE = TypeExpr::createImplicit(enumType, C);
-    auto lhsElemPat =
-        new (C) EnumElementPattern(lhsBaseTE, SourceLoc(), DeclNameLoc(),
-                                   DeclNameRef(), elt, lhsSubpattern);
+    auto lhsElemPat = new (C)
+        EnumElementPattern(lhsBaseTE, SourceLoc(), DeclNameLoc(), DeclNameRef(),
+                           elt, lhsSubpattern, /*DC*/ ltDecl);
     lhsElemPat->setImplicit();
 
     // .<elt>(let r0, let r1, ...)
@@ -126,9 +126,9 @@ deriveBodyComparable_enum_hasAssociatedValues_lt(AbstractFunctionDecl *ltDecl, v
     auto rhsSubpattern = DerivedConformance::enumElementPayloadSubpattern(elt, 'r', ltDecl,
                                                       rhsPayloadVars);
     auto *rhsBaseTE = TypeExpr::createImplicit(enumType, C);
-    auto rhsElemPat =
-        new (C) EnumElementPattern(rhsBaseTE, SourceLoc(), DeclNameLoc(),
-                                   DeclNameRef(), elt, rhsSubpattern);
+    auto rhsElemPat = new (C)
+        EnumElementPattern(rhsBaseTE, SourceLoc(), DeclNameLoc(), DeclNameRef(),
+                           elt, rhsSubpattern, /*DC*/ ltDecl);
     rhsElemPat->setImplicit();
 
     auto hasBoundDecls = !lhsPayloadVars.empty();

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -181,9 +181,9 @@ deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
     auto lhsSubpattern = DerivedConformance::enumElementPayloadSubpattern(elt, 'l', eqDecl,
                                                       lhsPayloadVars);
     auto *lhsBaseTE = TypeExpr::createImplicit(enumType, C);
-    auto lhsElemPat =
-        new (C) EnumElementPattern(lhsBaseTE, SourceLoc(), DeclNameLoc(),
-                                   DeclNameRef(), elt, lhsSubpattern);
+    auto lhsElemPat = new (C)
+        EnumElementPattern(lhsBaseTE, SourceLoc(), DeclNameLoc(), DeclNameRef(),
+                           elt, lhsSubpattern, /*DC*/ eqDecl);
     lhsElemPat->setImplicit();
 
     // .<elt>(let r0, let r1, ...)
@@ -191,9 +191,9 @@ deriveBodyEquatable_enum_hasAssociatedValues_eq(AbstractFunctionDecl *eqDecl,
     auto rhsSubpattern = DerivedConformance::enumElementPayloadSubpattern(elt, 'r', eqDecl,
                                                       rhsPayloadVars);
     auto *rhsBaseTE = TypeExpr::createImplicit(enumType, C);
-    auto rhsElemPat =
-        new (C) EnumElementPattern(rhsBaseTE, SourceLoc(), DeclNameLoc(),
-                                   DeclNameRef(), elt, rhsSubpattern);
+    auto rhsElemPat = new (C)
+        EnumElementPattern(rhsBaseTE, SourceLoc(), DeclNameLoc(), DeclNameRef(),
+                           elt, rhsSubpattern, /*DC*/ eqDecl);
     rhsElemPat->setImplicit();
 
     auto hasBoundDecls = !lhsPayloadVars.empty();
@@ -702,9 +702,10 @@ deriveBodyHashable_enum_hasAssociatedValues_hashInto(
 
     auto payloadPattern = DerivedConformance::enumElementPayloadSubpattern(elt, 'a', hashIntoDecl,
                                                        payloadVars);
-    auto pat = new (C) EnumElementPattern(
-        TypeExpr::createImplicit(enumType, C), SourceLoc(), DeclNameLoc(),
-        DeclNameRef(elt->getBaseIdentifier()), elt, payloadPattern);
+    auto pat = new (C)
+        EnumElementPattern(TypeExpr::createImplicit(enumType, C), SourceLoc(),
+                           DeclNameLoc(), DeclNameRef(elt->getBaseIdentifier()),
+                           elt, payloadPattern, /*DC*/ hashIntoDecl);
     pat->setImplicit();
 
     auto labelItem = CaseLabelItem(pat);

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -114,7 +114,8 @@ deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl, void *) {
   for (auto elt : enumDecl->getAllElements()) {
     auto pat = new (C)
         EnumElementPattern(TypeExpr::createImplicit(enumType, C), SourceLoc(),
-                           DeclNameLoc(), DeclNameRef(), elt, nullptr);
+                           DeclNameLoc(), DeclNameRef(), elt, nullptr,
+                           /*DC*/ toRawDecl);
     pat->setImplicit();
 
     auto labelItem = CaseLabelItem(pat);

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -323,7 +323,7 @@ deriveBodyRawRepresentable_init(AbstractFunctionDecl *initDecl, void *) {
       stringExprs.push_back(litExpr);
       litExpr = IntegerLiteralExpr::createFromUnsigned(C, Idx, SourceLoc()); 
     }
-    auto *litPat = ExprPattern::createImplicit(C, litExpr);
+    auto *litPat = ExprPattern::createImplicit(C, litExpr, /*DC*/ initDecl);
 
     /// Statements in the body of this case.
     SmallVector<ASTNode, 2> stmts;

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -737,7 +737,8 @@ DeclRefExpr *DerivedConformance::convertEnumToIndex(SmallVectorImpl<ASTNode> &st
     // generate: case .<Case>:
     auto pat = new (C)
         EnumElementPattern(TypeExpr::createImplicit(enumType, C), SourceLoc(),
-                           DeclNameLoc(), DeclNameRef(), elt, nullptr);
+                           DeclNameLoc(), DeclNameRef(), elt, nullptr,
+                           /*DC*/ funcDecl);
     pat->setImplicit();
     pat->setType(enumType);
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -781,10 +781,6 @@ ExprPatternMatchRequest::evaluate(Evaluator &evaluator,
       DeclNameLoc(EP->getLoc()));
   matchOp->setImplicit();
 
-  // FIXME: This matches what the previous code had, but it doesn't seems like
-  // it should be set to this.
-  matchOp->setFunctionRefKind(FunctionRefKind::Compound);
-
   // Note we use getEndLoc here to have the BinaryExpr source range be the same
   // as the expr pattern source range.
   auto *matchVarRef =

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -734,12 +734,6 @@ Pattern *coercePatternToType(ContextualPattern pattern, Type type,
                              TypeResolutionOptions options);
 bool typeCheckExprPattern(ExprPattern *EP, DeclContext *DC, Type type);
 
-/// Synthesize ~= operator application used to infer enum members
-/// in `case` patterns.
-Optional<std::pair<VarDecl *, BinaryExpr *>>
-synthesizeTildeEqualsOperatorApplication(ExprPattern *EP, DeclContext *DC,
-                                         Type enumType);
-
 /// Coerce the specified parameter list of a ClosureExpr to the specified
 /// contextual type.
 void coerceParameterListToType(ParameterList *P, AnyFunctionType *FN);

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -557,3 +557,10 @@ extension [EWithIdent<Int>] {
     }
   }
 }
+
+struct TestIUOMatchOp {
+  static func ~= (lhs: TestIUOMatchOp, rhs: TestIUOMatchOp) -> Bool! { nil }
+  func foo() {
+    if case self = self {}
+  }
+}


### PR DESCRIPTION
Introduce a request to synthesize the `~=` application for an ExprPattern, and a request to synthesize an ExprPattern for the fallback type-checking of an EnumElementPattern when we are unable to lookup its member. This has been split off #63963.