### PR TITLE
[Observation] Add some behaviroal tests for changes, transactions, and tracking

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -54,12 +54,13 @@ public struct ObservationRegistrar<Subject: Observable>: Sendable {
   fileprivate struct Next {
     enum Kind {
       case transaction(TrackedProperties<Subject>)
+      case pendingTransaction(TrackedProperties<Subject>, UnsafeContinuation<TrackedProperties<Subject>?, Never>)
       case change(TrackedProperties<Subject>, UnsafeContinuation<Subject?, Never>)
       case tracking(TrackedProperties<Subject>, @Sendable () -> Void)
       case cancelled
     }
     
-    fileprivate let kind: Kind
+    fileprivate var kind: Kind
     fileprivate var collected: TrackedProperties<Subject>?
   }
   
@@ -139,8 +140,10 @@ extension ObservationRegistrar.Context {
     _ generation: Int, 
     isolation: isolated Delivery
   ) async -> TrackedProperties<Subject>? {
-    return state.withCriticalRegion { state in
-      state.complete(generation)
+    return await withUnsafeContinuation { continuation in
+      state.withCriticalRegion { state in
+        state.complete(generation, continuation: continuation)
+      }
     }
   }
   
@@ -218,8 +221,8 @@ extension ObservationRegistrar.Next {
 
 @available(SwiftStdlib 5.9, *)
 extension ObservationRegistrar.Next.Kind {
-  fileprivate func resume(
-    keyPath: PartialKeyPath<Subject>, 
+  fileprivate mutating func resume(
+    keyPath: PartialKeyPath<Subject>,
     phase: ObservationRegistrar.Phase, 
     collected: inout TrackedProperties<Subject>?
   ) -> ObservationRegistrar.ResumeAction? {
@@ -235,6 +238,20 @@ extension ObservationRegistrar.Next.Kind {
           collected = properties
         }
       }
+      return nil
+    case (.pendingTransaction(let observedTrackedProperties, let continuation), .willSet):
+      if observedTrackedProperties.contains(keyPath) {
+        if var properties = collected {
+          properties.insert(keyPath)
+          continuation.resume(returning: properties)
+        } else {
+          var properties = TrackedProperties<Subject>()
+          properties.insert(keyPath)
+          continuation.resume(returning: properties)
+        }
+        self = .transaction(observedTrackedProperties)
+      }
+      
       return nil
     case (.change(let observedTrackedProperties, let continuation), .didSet):
       if observedTrackedProperties.contains(keyPath) {
@@ -292,6 +309,8 @@ extension ObservationRegistrar.Next.Kind {
     switch self {
     case .transaction(let properties):
       invalidate(properties: properties, from: &lookup, generation: generation)
+    case .pendingTransaction(let properties, _):
+      invalidate(properties: properties, from: &lookup, generation: generation)
     case .change(let properties, _):
       invalidate(properties: properties, from: &lookup, generation: generation)
     case .tracking(let properties, _):
@@ -303,6 +322,8 @@ extension ObservationRegistrar.Next.Kind {
   
   fileprivate func deinitialize() {
     switch self {
+    case .pendingTransaction(_, let continuation):
+      continuation.resume(returning: nil)
     case .change(_, let continuation):
       continuation.resume(returning: nil)
     default:
@@ -383,17 +404,21 @@ extension ObservationRegistrar.State {
   }
   
   fileprivate mutating func complete(
-    _ generation: Int
-  ) -> TrackedProperties<Subject>? {
+    _ generation: Int,
+    continuation: UnsafeContinuation<TrackedProperties<Subject>?, Never>
+  ){
     if let existing = nexts.removeValue(forKey: generation) {
       switch existing.kind {
-      case .transaction:
-        return existing.collected
+      case .transaction(let properties):
+        if let collected = existing.collected {
+          continuation.resume(returning: collected)
+        } else {
+          nexts[generation] = ObservationRegistrar.Next(kind: .pendingTransaction(properties, continuation))
+        }
       default:
-        return nil
+        continuation.resume(returning: nil)
       }
     }
-    return nil
   }
   
   fileprivate mutating func willSet<Member>(

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -1,18 +1,274 @@
-// RUN: %target-run-simple-swift
+// RUN: %target-run-simple-swift( -Xfrontend -disable-availability-checking -parse-as-library -enable-experimental-feature Macros -Xfrontend -plugin-path -Xfrontend %swift-host-lib-dir/plugins)
+
 // REQUIRES: executable_test
 // REQUIRES: observation
+// REQUIRES: concurrency
 // REQUIRES: objc_interop
-// UNSUPPORTED: freestanding
+// REQUIRES: executable_test
 
 import StdlibUnittest
 import Observation
+import _Concurrency
 
-let suite = TestSuite("Observable")
+@usableFromInline
+@inline(never)
+func _blackHole<T>(_ value: T) { }
 
-if #available(SwiftStdlib 9999, *) {
-  suite.test("Basic") {
+final class UnsafeBox<Contents>: @unchecked Sendable {
+  var contents: Contents
 
+  init(_ contents: Contents) {
+    self.contents = contents
   }
 }
 
- runAllTests()
+@available(SwiftStdlib 5.9, *)
+final class TestWithoutMacro: Observable {
+  let _registrar = ObservationRegistrar<TestWithoutMacro>()
+
+  public nonisolated func transactions<Delivery>(
+    for properties: TrackedProperties<TestWithoutMacro>, 
+    isolation: Delivery
+  ) -> ObservedTransactions<TestWithoutMacro, Delivery> where Delivery: Actor {
+    _registrar.transactions(for: properties, isolation: isolation)
+  }
+
+  public nonisolated func changes<Member>(
+    for keyPath: KeyPath<TestWithoutMacro, Member>
+  ) -> ObservedChanges<TestWithoutMacro, Member> where Member: Sendable {
+    _registrar.changes(for: keyPath)
+  }
+
+  private struct _Storage {
+    var field1 = "test"
+    var field2 = "test"
+    var field3 = 0
+  }
+
+  private var _storage = _Storage()
+
+  var field1: String {
+    get {
+      _registrar.access(self, keyPath: \.field1)
+      return _storage.field1
+    }
+    set {
+      _registrar.withMutation(of: self, keyPath: \.field1) {
+        _storage.field1 = newValue
+      }
+    }
+  }
+
+  var field2: String {
+    get {
+      _registrar.access(self, keyPath: \.field2)
+      return _storage.field2
+    }
+    set {
+      _registrar.withMutation(of: self, keyPath: \.field2) {
+        _storage.field2 = newValue
+      }
+    }
+  }
+
+  var field3: Int {
+    get {
+      _registrar.access(self, keyPath: \.field3)
+      return _storage.field3
+    }
+    set {
+      _registrar.withMutation(of: self, keyPath: \.field3) {
+        _storage.field3 = newValue
+      }
+    }
+  }
+}
+
+@available(SwiftStdlib 5.9, *)
+@Observable final class TestWithMacro {
+  var field1 = "test"
+  var field2 = "test"
+  var field3 = 0
+}
+
+extension AsyncSequence {
+  func triggerIteration(
+    _ continuation: UnsafeContinuation<Void, Never>
+  ) -> TriggerSequence<Self> {
+    TriggerSequence(self, continuation: continuation)
+  }
+}
+
+struct TriggerSequence<Base: AsyncSequence> {
+  let base: Base
+  let continuation: UnsafeContinuation<Void, Never>
+
+  init(_ base: Base, continuation: UnsafeContinuation<Void, Never>) {
+    self.base = base
+    self.continuation = continuation
+  }
+}
+
+extension TriggerSequence: AsyncSequence {
+  typealias Element = Base.Element
+
+  struct Iterator: AsyncIteratorProtocol {
+    var continuation: UnsafeContinuation<Void, Never>?
+    var base: Base.AsyncIterator
+
+    init(
+      _ base: Base.AsyncIterator, 
+      continuation: UnsafeContinuation<Void, Never>
+    ) {
+      self.base = base
+      self.continuation = continuation
+    }
+
+    mutating func next() async rethrows -> Base.Element? {
+      if let continuation {
+        self.continuation = nil
+        continuation.resume()
+      }
+      return try await base.next()
+    }
+  }
+
+  func makeAsyncIterator() -> Iterator {
+    Iterator(base.makeAsyncIterator(), continuation: continuation)
+  }
+}
+
+@main struct Main {
+  @MainActor
+  static func main() async {
+    let suite = TestSuite("Observable")
+
+    suite.test("unobserved value changes (macro)") {
+      let subject = TestWithMacro()
+      for i in 0..<100 {
+        subject.field3 = i
+      }
+    }
+
+    suite.test("unobserved value changes (nonmacro)") {
+      let subject = TestWithoutMacro()
+      for i in 0..<100 {
+        subject.field3 = i
+      }
+    }
+
+    suite.test("changes emit values (macro)") { @MainActor in
+      let subject = TestWithMacro()
+      var t: Task<String?, Never>?
+      await withUnsafeContinuation { continuation in
+        t = Task { @MainActor in
+          // Note: this must be fully established 
+          // so we must await the trigger to fire
+          let changes = subject.changes(for: \.field1)
+            .triggerIteration(continuation)
+          for await value in changes {
+            return value
+          }
+          return nil
+        }
+      }
+      subject.field1 = "a"
+      let value = await t!.value
+      expectEqual(value, "a")
+    }
+
+    suite.test("changes emit values (nonmacro)") { @MainActor in
+      let subject = TestWithoutMacro()
+      var t: Task<String?, Never>?
+      await withUnsafeContinuation { continuation in
+        t = Task { @MainActor in
+          // Note: this must be fully established 
+          // so we must await the trigger to fire
+          let changes = subject.changes(for: \.field1)
+            .triggerIteration(continuation)
+          for await value in changes {
+            return value
+          }
+          return nil
+        }
+      }
+      subject.field1 = "a"
+      let value = await t!.value
+      expectEqual(value, "a")
+    }
+
+
+    suite.test("changes cancellation terminates") { @MainActor in
+      let subject = TestWithMacro()
+      var finished = false
+      let t = Task { @MainActor in
+        for await _ in subject.changes(for: \.field1) {
+
+        }
+        finished = true
+      }
+      try? await Task.sleep(for: .seconds(0.1))
+      expectEqual(finished, false)
+      t.cancel()
+      try? await Task.sleep(for: .seconds(0.1))
+      expectEqual(finished, true)
+    }
+
+    suite.test("transactions emit values (macro)") { @MainActor in
+      let subject = TestWithMacro()
+      var t: Task<TrackedProperties<TestWithMacro>?, Never>?
+      await withUnsafeContinuation { continuation in
+        t = Task { @MainActor in
+          // Note: this must be fully established 
+          // so we must await the trigger to fire
+          let transactions = subject.transactions(for: \.field1)
+            .triggerIteration(continuation)
+          for await value in transactions {
+            return value
+          }
+          return nil
+        }
+      }
+      subject.field1 = "a"
+      let value = await t!.value
+      expectEqual(value?.contains(\.field1), true)
+    }
+
+    suite.test("transactions emit values (nonmacro)") { @MainActor in
+      let subject = TestWithoutMacro()
+      var t: Task<TrackedProperties<TestWithoutMacro>?, Never>?
+      await withUnsafeContinuation { continuation in
+        t = Task { @MainActor in
+          // Note: this must be fully established 
+          // so we must await the trigger to fire
+          let transactions = subject.transactions(for: \.field1)
+            .triggerIteration(continuation)
+          for await value in transactions {
+            return value
+          }
+          return nil
+        }
+      }
+      subject.field1 = "a"
+      let value = await t!.value
+      expectEqual(value?.contains(\.field1), true)
+    }
+
+    suite.test("tracking") { @MainActor in
+      let subject = TestWithMacro()
+      let changed = UnsafeBox(false)
+      ObservationTracking.withTracking {
+        _blackHole(subject.field1)
+      } onChange: {
+        changed.contents = true
+      }
+      expectEqual(changed.contents, false)
+      subject.field2 = "asdf"
+      expectEqual(changed.contents, false)
+      subject.field1 = "asdf"
+      expectEqual(changed.contents, true)
+    }
+
+    await runAllTestsAsync()
+  }
+}


### PR DESCRIPTION
This adds the starts to some unit tests to validate observation (both manual and macro generated).