### PR TITLE
[Serialization] Allow rebuilding modules from the resource dir on SDK mismatch

### DIFF
--- a/lib/Frontend/ModuleInterfaceLoader.cpp
+++ b/lib/Frontend/ModuleInterfaceLoader.cpp
@@ -790,7 +790,9 @@ class ModuleInterfaceLoaderImpl {
           UsableModulePath = adjacentMod;
           return std::make_error_code(std::errc::not_supported);
         } else if (isInResourceDir(adjacentMod) &&
-                   loadMode == ModuleLoadingMode::PreferSerialized) {
+                   loadMode == ModuleLoadingMode::PreferSerialized &&
+                   rebuildInfo.getOrInsertCandidateModule(adjacentMod).serializationStatus !=
+                     serialization::Status::SDKMismatch) {
           // Special-case here: If we're loading a .swiftmodule from the resource
           // dir adjacent to the compiler, defer to the serialized loader instead
           // of falling back. This is mainly to support development of Swift,
@@ -798,6 +800,8 @@ class ModuleInterfaceLoaderImpl {
           // recompile the standard library. If that happens, don't fall back
           // and silently recompile the standard library -- instead, error like
           // we used to.
+          // Still accept modules built with a different SDK, allowing the use
+          // of one toolchain against a different SDK.
           LLVM_DEBUG(llvm::dbgs() << "Found out-of-date module in the "
                                      "resource-dir at "
                                   << adjacentMod

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -544,7 +544,7 @@ ValidationInfo serialization::validateSerializedAST(
           requiresOSSAModules, requiresRevisionMatch,
           requiredSDK,
           extendedInfo, localObfuscator);
-      if (result.status == Status::Malformed)
+      if (result.status != Status::Valid)
         return result;
     } else if ((dependencies || searchPaths) &&
                result.status == Status::Valid &&

--- a/test/Serialization/restrict-swiftmodule-to-sdk.swift
+++ b/test/Serialization/restrict-swiftmodule-to-sdk.swift
@@ -34,6 +34,20 @@
 // RUN:   -Rmodule-interface-rebuild 2>&1 | %FileCheck %s -check-prefix=CHECK-AvsB-REBUILD
 // CHECK-AvsB-REBUILD: remark: rebuilding module 'Lib' from interface
 
+/// Modules loaded from the resource dir are not usually rebuilt from
+/// the swiftinterface as it would indicate a configuration problem.
+/// Lift that behavior for SDK mismatch and still rebuild them.
+// RUN: %empty-directory(%t/cache)
+// RUN: %target-swift-frontend -emit-module %t/Lib.swift \
+// RUN:   -swift-version 5 -enable-library-evolution \
+// RUN:   -target-sdk-name A -parse-stdlib -module-cache-path %t/cache \
+// RUN:   -o %t/build -emit-module-interface-path %t/build/Lib.swiftinterface
+// RUN: env SWIFT_DEBUG_FORCE_SWIFTMODULE_PER_SDK=true \
+// RUN:   %target-swift-frontend -typecheck %t/Client.swift \
+// RUN:   -target-sdk-name B -resource-dir %t/build -I %t/build \
+// RUN:   -parse-stdlib -module-cache-path %t/cache \
+// RUN:   -Rmodule-interface-rebuild 2>&1 | %FileCheck %s -check-prefix=CHECK-AvsB-REBUILD
+
 // BEGIN Lib.swift
 public func foo() {}
 


### PR DESCRIPTION
Modules loaded from the resource dir are not usually rebuilt from the swiftinterface as it would indicate a configuration problem. Lift that behavior for SDK mismatch and still rebuild them.

This use case applies when a toolchain is used with a different SDK than the one use to build the modules in the toolchain.

rdar://106101760