### PR TITLE
[CMake] Always disable string processing import

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -1819,10 +1819,7 @@ function(add_swift_target_library name)
   list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-disable-implicit-concurrency-module-import")
 
   # Turn off implicit import of _StringProcessing when building libraries
-  if(SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING)
-    list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS
-                      "-Xfrontend;-disable-implicit-string-processing-module-import")
-  endif()
+  list(APPEND SWIFTLIB_SWIFT_COMPILE_FLAGS "-Xfrontend;-disable-implicit-string-processing-module-import")
 
   # Turn off implicit import of _Backtracing when building libraries
   if(SWIFT_COMPILER_SUPPORTS_BACKTRACING)


### PR DESCRIPTION
The issue here is that a configuration that has `SWIFT_ENABLE_EXPERIMENTAL_STRING_PROCESSING` disabled doesn't pass the flag to implicitly disable the module import, but when building the stdlib modules on said configurations, the compiler will try to link them against string processing because, well, it's an implicit import. Just always disable the implicit import for every stdlib module now.

Resolves: rdar://106326062 & rdar://106374161