### PR TITLE
[SILOptimizer] Add RedundantMoveValueElimination.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -122,6 +122,12 @@ inline bool isForwardingConsume(SILValue value) {
 
 bool hasPointerEscape(BorrowedValue value);
 
+/// Whether the specified OSSA-lifetime introducer has a pointer escape.
+///
+/// precondition: \p value introduces an OSSA-lifetime, either a BorrowedValue
+/// can be constructed from it or it's an owned value
+bool hasPointerEscape(SILValue value);
+
 /// Find leaf "use points" of \p guaranteedValue that determine its lifetime
 /// requirement. Return true if no PointerEscape use was found.
 ///

--- a/lib/SILOptimizer/SemanticARC/CMakeLists.txt
+++ b/lib/SILOptimizer/SemanticARC/CMakeLists.txt
@@ -8,4 +8,5 @@ target_sources(swiftSILOptimizer PRIVATE
   Context.cpp
   SemanticARCOptVisitor.cpp
   OwnershipConversionElimination.cpp
+  RedundantMoveValueElimination.cpp
   )

--- a/lib/SILOptimizer/SemanticARC/RedundantMoveValueElimination.cpp
+++ b/lib/SILOptimizer/SemanticARC/RedundantMoveValueElimination.cpp
@@ -1,0 +1,63 @@
+//===--- RedundantMoveValueElimination.cpp - Delete spurious move_values --===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// A move_value ends an owned lifetime and begins an owned lifetime.
+//
+// The new lifetime may have the same characteristics as the original lifetime
+// with regards to
+// - lexicality
+// - escaping
+//
+// If it has the same characteristics, there is no reason to have two separate
+// lifetimes--they are redundant.  This optimization deletes such redundant
+// move_values.
+//===----------------------------------------------------------------------===//
+
+#include "SemanticARC/SemanticARCOpts.h"
+#include "SemanticARCOptVisitor.h"
+#include "swift/SIL/LinearLifetimeChecker.h"
+
+using namespace swift;
+using namespace semanticarc;
+
+//===----------------------------------------------------------------------===//
+//                            Top Level Entrypoint
+//===----------------------------------------------------------------------===//
+
+bool SemanticARCOptVisitor::visitMoveValueInst(MoveValueInst *mvi) {
+  if (ctx.onlyMandatoryOpts)
+    return false;
+
+  if (!ctx.shouldPerform(ARCTransformKind::RedundantMoveValueElim))
+    return false;
+
+  auto original = mvi->getOperand();
+
+  // If the moved-from value has none ownership, hasPointerEscape can't handle
+  // it, so it can't be used to determine whether escaping matches.
+  if (original->getOwnershipKind() != OwnershipKind::Owned) {
+    return false;
+  }
+
+  // First, check whether lexicality matches, the cheaper check.
+  if (mvi->isLexical() != original->isLexical()) {
+    return false;
+  }
+
+  // Then, check whether escaping matches, the more expensive check.
+  if (hasPointerEscape(mvi) != hasPointerEscape(original)) {
+    return false;
+  }
+
+  // Both characteristics match.
+  eraseAndRAUWSingleValueInstruction(mvi, original);
+  return true;
+}

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOptVisitor.h
@@ -143,6 +143,7 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
   bool visitCopyValueInst(CopyValueInst *cvi);
   bool visitBeginBorrowInst(BeginBorrowInst *bbi);
   bool visitLoadInst(LoadInst *li);
+  bool visitMoveValueInst(MoveValueInst *mvi);
   bool
   visitUncheckedOwnershipConversionInst(UncheckedOwnershipConversionInst *uoci);
 
@@ -153,6 +154,7 @@ struct LLVM_LIBRARY_VISIBILITY SemanticARCOptVisitor
     case SILInstructionKind::CopyValueInst:
     case SILInstructionKind::BeginBorrowInst:
     case SILInstructionKind::LoadInst:
+    case SILInstructionKind::MoveValueInst:
     case SILInstructionKind::UncheckedOwnershipConversionInst:
       return true;
     }

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOpts.cpp
@@ -51,7 +51,11 @@ static llvm::cl::list<ARCTransformKind> TransformsToPerform(
                    "sil-semantic-arc-owned-to-guaranteed-phi",
                    "Perform Owned To Guaranteed Phi. NOTE: Seeded by peephole "
                    "optimizer for compile time saving purposes, so run this "
-                   "after running peepholes)")),
+                   "after running peepholes)"),
+        clEnumValN(ARCTransformKind::RedundantMoveValueElim,
+                   "sil-semantic-arc-redundant-move-value-elim",
+                   "Eliminate move_value which don't change owned lifetime "
+                   "characteristics.  (Escaping, Lexical).")),
     llvm::cl::desc(
         "For testing purposes only run the specified list of semantic arc "
         "optimization. If the list is empty, we run all transforms"));
@@ -86,6 +90,7 @@ struct SemanticARCOpts : SILFunctionTransform {
       case ARCTransformKind::LoadCopyToLoadBorrowPeephole:
       case ARCTransformKind::AllPeepholes:
       case ARCTransformKind::OwnershipConversionElimPeephole:
+      case ARCTransformKind::RedundantMoveValueElim:
         // We never assume we are at fixed point when running these transforms.
         if (performPeepholesWithoutFixedPoint(visitor)) {
           invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);

--- a/lib/SILOptimizer/SemanticARC/SemanticARCOpts.h
+++ b/lib/SILOptimizer/SemanticARC/SemanticARCOpts.h
@@ -31,12 +31,13 @@ enum class ARCTransformKind : uint64_t {
   RedundantCopyValueElimPeephole = 0x8,
   LifetimeJoiningPeephole = 0x10,
   OwnershipConversionElimPeephole = 0x20,
+  RedundantMoveValueElim = 0x40,
 
   AllPeepholes = LoadCopyToLoadBorrowPeephole |
                  RedundantBorrowScopeElimPeephole |
                  RedundantCopyValueElimPeephole | LifetimeJoiningPeephole |
                  OwnershipConversionElimPeephole,
-  All = AllPeepholes | OwnedToGuaranteedPhi,
+  All = AllPeepholes | OwnedToGuaranteedPhi | RedundantMoveValueElim,
 };
 
 inline ARCTransformKind operator&(ARCTransformKind lhs, ARCTransformKind rhs) {

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -71,6 +71,7 @@
 #include "swift/SIL/MemAccessUtils.h"
 #include "swift/SIL/OSSALifetimeCompletion.h"
 #include "swift/SIL/OwnershipLiveness.h"
+#include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/PrunedLiveness.h"
 #include "swift/SIL/SILArgumentArrayRef.h"
 #include "swift/SIL/SILBasicBlock.h"
@@ -264,6 +265,22 @@ struct TestSpecificationTest : UnitTest {
         llvm_unreachable("unknown field type was expected?!");
       }
     }
+  }
+};
+
+// Arguments:
+// - value: the value to check for escaping
+// Dumps:
+// - the value
+// - whether it has a pointer escape
+struct OwnershipUtilsHasPointerEscape : UnitTest {
+  OwnershipUtilsHasPointerEscape(UnitTestRunner *pass) : UnitTest(pass) {}
+  void invoke(Arguments &arguments) override {
+    auto value = arguments.takeValue();
+    auto has = hasPointerEscape(value);
+    value->print(llvm::errs());
+    auto *boolString = has ? "true" : "false";
+    llvm::errs() << boolString << "\n";
   }
 };
 
@@ -789,6 +806,7 @@ void UnitTestRunner::withTest(StringRef name, Doit doit) {
     ADD_UNIT_TEST_SUBCLASS("find-borrow-introducers", FindBorrowIntroducers)
     ADD_UNIT_TEST_SUBCLASS("find-enclosing-defs", FindEnclosingDefsTest)
     ADD_UNIT_TEST_SUBCLASS("function-get-self-argument-index", FunctionGetSelfArgumentIndex)
+    ADD_UNIT_TEST_SUBCLASS("has-pointer-escape", OwnershipUtilsHasPointerEscape)
     ADD_UNIT_TEST_SUBCLASS("interior-liveness", InteriorLivenessTest)
     ADD_UNIT_TEST_SUBCLASS("is-deinit-barrier", IsDeinitBarrierTest)
     ADD_UNIT_TEST_SUBCLASS("is-lexical", IsLexicalTest)

--- a/test/SILOptimizer/ownership-utils-unit.sil
+++ b/test/SILOptimizer/ownership-utils-unit.sil
@@ -1,0 +1,44 @@
+// RUN: %target-sil-opt -unit-test-runner %s -o /dev/null 2>&1 | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+class C {}
+
+sil @getOwned : $@convention(thin) () -> (@owned C)
+
+sil @borrow : $@convention(thin) (@guaranteed C) -> ()
+
+sil @useUnmanaged : $@convention(thin) (@sil_unmanaged C) -> ()
+
+sil [ossa] @test_escape_of_phi_transitive_incoming_value : $@convention(thin) () -> () {
+entry:
+  %getOwned = function_ref @getOwned : $@convention(thin) () -> (@owned C)
+  %useUnmanaged = function_ref @useUnmanaged : $@convention(thin) (@sil_unmanaged C) -> ()
+  cond_br undef, left, right
+left:
+  cond_br undef, left_left, left_right
+left_left:
+  %llinstance = apply %getOwned() : $@convention(thin) () -> (@owned C)
+  br left_bottom(%llinstance : $C)
+left_right:
+  %lrinstance = apply %getOwned() : $@convention(thin) () -> (@owned C)
+  %escape = ref_to_unmanaged %lrinstance : $C to $@sil_unmanaged C
+  apply %useUnmanaged(%escape) : $@convention(thin) (@sil_unmanaged C) -> ()
+  br left_bottom(%lrinstance : $C)
+left_bottom(%linstance : @owned $C):
+  br exit(%linstance : $C)
+right:
+  %rinstance = apply %getOwned() : $@convention(thin) () -> (@owned C)
+  br exit(%rinstance : $C)
+exit(%instance : @owned $C):
+// CHECK-LABEL: begin running test {{[0-9]+}} of {{[0-9]+}} on test_escape_of_phi_transitive_incoming_value: has-pointer-escape
+// CHECK:       %14 = argument of bb6 : $C
+// CHECK:       true
+// CHECK-LABEL: end running test {{[0-9]+}} of {{[0-9]+}} on test_escape_of_phi_transitive_incoming_value: has-pointer-escape with
+  test_specification "has-pointer-escape @block.argument"
+  destroy_value %instance : $C
+  %retval = tuple ()
+  return %retval : $()
+}

--- a/test/SILOptimizer/semantic-arc-opts-redundant-move-elimination.sil
+++ b/test/SILOptimizer/semantic-arc-opts-redundant-move-elimination.sil
@@ -1,0 +1,221 @@
+// RUN: %target-sil-opt -module-name Swift -enable-sil-verify-all -semantic-arc-opts -sil-semantic-arc-redundant-move-value-elim %s | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+
+class C {}
+
+enum FakeOptional<T> {
+case none
+case some(T)
+}
+
+sil @getOwned : $@convention(thin) () -> (@owned C)
+
+sil @borrow : $@convention(thin) (@guaranteed C) -> ()
+
+sil @useUnmanaged : $@convention(thin) (@sil_unmanaged C) -> ()
+
+// Test that move_value instructions are removed when they are "redundant".  A
+// move_value instruction is redundant when the lifetime it introduces has the
+// same characteristics as the lifetime that it ends along in the following two
+// aspects:
+// - lexicaliity
+// - escapingness
+
+// The tests are named as follows:
+//
+// @test_{old_characteristics}_{new_characteristics}
+// where both old_characteristics and new_characteristics are of the form
+//
+// {is_lexical}{has_escaping_use}
+//
+// and both is_lexical and has_escaping_use are 1 or 0 depending on whether each
+// is true.
+//
+// So for example, in @test_00_10, there is a move_value instruction which ends
+// a lifetime that is both neither lexical nor escaping and begins a lifetime
+// which is lexical but not escaping.  Since the characteristics of the old and
+// new lifetimes differ, the move_value should be preserved.
+
+// Note that these tests all have two move_values.  That's just to make it a bit
+// easier to specify the characteristics of the first lifetime.  The move_value
+// of real interest for the tests is the second.
+
+// Old: lexical    , non-escaping
+// New: lexical    , non-escaping
+// Same.  Redundant.  Remove move_value.
+//
+// CHECK-LABEL: sil [ossa] @test_10_10 : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         [[LIFETIME:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK-NOT:     move_value
+// CHECK-LABEL: } // end sil function 'test_10_10'
+sil [ossa] @test_10_10 : $@convention(thin) () -> () {
+  %getOwned = function_ref @getOwned : $@convention(thin) () -> (@owned C)
+  %borrow = function_ref @borrow : $@convention(thin) (@guaranteed C) -> ()
+  %instance = apply %getOwned() : $@convention(thin) () -> (@owned C)
+  %lifetime = move_value [lexical] %instance : $C
+  apply %borrow(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+  %lifetime2 = move_value [lexical] %lifetime : $C
+  apply %borrow(%lifetime2) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %lifetime2 : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Old: lexical    , non-escaping
+// New: non-lexical, non-escaping
+// Different.  Non-redundant.  Keep move_value.
+//
+// CHECK-LABEL: sil [ossa] @test_10_00 : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         [[LIFETIME:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         move_value [[LIFETIME]]
+// CHECK-LABEL: } // end sil function 'test_10_00'
+sil [ossa] @test_10_00 : $@convention(thin) () -> () {
+  %getOwned = function_ref @getOwned : $@convention(thin) () -> (@owned C)
+  %borrow = function_ref @borrow : $@convention(thin) (@guaranteed C) -> ()
+  %instance = apply %getOwned() : $@convention(thin) () -> (@owned C)
+  %lifetime = move_value [lexical] %instance : $C
+  apply %borrow(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+  %lifetime2 = move_value %lifetime : $C
+  apply %borrow(%lifetime2) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %lifetime2 : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Old: non-lexical, non-escaping
+// New: lexical    , non-escaping
+// Different.  Non-redundant.  Keep move_value.
+//
+// CHECK-LABEL: sil [ossa] @test_00_10 : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         move_value [lexical] [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'test_00_10'
+sil [ossa] @test_00_10 : $@convention(thin) () -> () {
+  %getOwned = function_ref @getOwned : $@convention(thin) () -> (@owned C)
+  %borrow = function_ref @borrow : $@convention(thin) (@guaranteed C) -> ()
+  %instance = apply %getOwned() : $@convention(thin) () -> (@owned C)
+  apply %borrow(%instance) : $@convention(thin) (@guaranteed C) -> ()
+  %lifetime2 = move_value [lexical] %instance : $C
+  apply %borrow(%lifetime2) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %lifetime2 : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Old: non-lexical, non-escaping
+// New: non-lexical, non-escaping
+// Same.  Redundant.  Remove move_value.
+//
+// CHECK-LABEL: sil [ossa] @test_00_00 : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK-NOT:     move_value
+// CHECK-LABEL: } // end sil function 'test_00_00'
+sil [ossa] @test_00_00 : $@convention(thin) () -> () {
+  %getOwned = function_ref @getOwned : $@convention(thin) () -> (@owned C)
+  %borrow = function_ref @borrow : $@convention(thin) (@guaranteed C) -> ()
+  %instance = apply %getOwned() : $@convention(thin) () -> (@owned C)
+  apply %borrow(%instance) : $@convention(thin) (@guaranteed C) -> ()
+  %lifetime2 = move_value %instance : $C
+  apply %borrow(%lifetime2) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %lifetime2 : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Old: lexical    , escaping
+// New: lexical    , escaping
+// Same.  Redundant.  Remove move_value.
+//
+// CHECK-LABEL: sil [ossa] @test_11_11 : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         move_value [lexical] [[INSTANCE]]
+// CHECK-NOT:     move_value
+// CHECK-LABEL: } // end sil function 'test_11_11'
+sil [ossa] @test_11_11 : $@convention(thin) () -> () {
+  %getOwned = function_ref @getOwned : $@convention(thin) () -> (@owned C)
+  %borrow = function_ref @borrow : $@convention(thin) (@guaranteed C) -> ()
+  %useUnmanaged = function_ref @useUnmanaged : $@convention(thin) (@sil_unmanaged C) -> ()
+  %instance = apply %getOwned() : $@convention(thin) () -> (@owned C)
+  %lifetime = move_value [lexical] %instance : $C
+  %escape = ref_to_unmanaged %lifetime : $C to $@sil_unmanaged C
+  apply %useUnmanaged(%escape) : $@convention(thin) (@sil_unmanaged C) -> ()
+  apply %borrow(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+  %lifetime2 = move_value [lexical] %lifetime : $C
+  %escape2 = ref_to_unmanaged %lifetime2 : $C to $@sil_unmanaged C
+  apply %useUnmanaged(%escape2) : $@convention(thin) (@sil_unmanaged C) -> ()
+  apply %borrow(%lifetime2) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %lifetime2 : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Old: lexical    , escaping
+// New: lexical    , non-escaping
+// Different.  Non-redundant.  Keep move_value.
+//
+// CHECK-LABEL: sil [ossa] @test_11_10 : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         [[LIFETIME:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         move_value [lexical] [[LIFETIME]]
+// CHECK-LABEL: } // end sil function 'test_11_10'
+sil [ossa] @test_11_10 : $@convention(thin) () -> () {
+  %getOwned = function_ref @getOwned : $@convention(thin) () -> (@owned C)
+  %borrow = function_ref @borrow : $@convention(thin) (@guaranteed C) -> ()
+  %useUnmanaged = function_ref @useUnmanaged : $@convention(thin) (@sil_unmanaged C) -> ()
+  %instance = apply %getOwned() : $@convention(thin) () -> (@owned C)
+  %lifetime = move_value [lexical] %instance : $C
+  %escape = ref_to_unmanaged %lifetime : $C to $@sil_unmanaged C
+  apply %useUnmanaged(%escape) : $@convention(thin) (@sil_unmanaged C) -> ()
+  apply %borrow(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+  %lifetime2 = move_value [lexical] %lifetime : $C
+  apply %borrow(%lifetime2) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %lifetime2 : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Old: lexical    , non-escaping
+// New: lexical    , escaping
+// Different.  Non-redundant.  Keep move_value.
+//
+// CHECK-LABEL: sil [ossa] @test_10_11 : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = apply
+// CHECK:         [[LIFETIME:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         move_value [lexical] [[LIFETIME]]
+// CHECK-LABEL: } // end sil function 'test_10_11'
+sil [ossa] @test_10_11 : $@convention(thin) () -> () {
+  %getOwned = function_ref @getOwned : $@convention(thin) () -> (@owned C)
+  %borrow = function_ref @borrow : $@convention(thin) (@guaranteed C) -> ()
+  %useUnmanaged = function_ref @useUnmanaged : $@convention(thin) (@sil_unmanaged C) -> ()
+  %instance = apply %getOwned() : $@convention(thin) () -> (@owned C)
+  %lifetime = move_value [lexical] %instance : $C
+  apply %borrow(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
+  %lifetime2 = move_value [lexical] %lifetime : $C
+  %escape = ref_to_unmanaged %lifetime2 : $C to $@sil_unmanaged C
+  apply %useUnmanaged(%escape) : $@convention(thin) (@sil_unmanaged C) -> ()
+  apply %borrow(%lifetime2) : $@convention(thin) (@guaranteed C) -> ()
+  destroy_value %lifetime2 : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
+// Moves from values with non-owned ownership cannot be removed.  Without owned
+// ownership, we can't determine whether the moved-from value has a pointer
+// escape.
+//
+// CHECK-LABEL: sil [ossa] @f_none_optional : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = enum $FakeOptional<C>, #FakeOptional.none!enumelt
+// CHECK:         [[LIFETIME:%[^,]+]] = move_value [[INSTANCE]]
+// CHECK-LABEL: } // end sil function 'f_none_optional'
+sil [ossa] @f_none_optional : $@convention(thin) () -> () {
+  %none = enum $FakeOptional<C>, #FakeOptional.none!enumelt
+  %lifetime = move_value %none : $FakeOptional<C>
+  destroy_value %lifetime : $FakeOptional<C>
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
Adds to `SemanticARCOpts` a new step of removing `move_value` instructions if they are redundant.  A `move_value` is redundant if it adds no new information or optimization opportunities.

An example of adding information: a lifetime becoming lexical.  The new lifetime's destroys cannot be hoisted over deinit barriers.

An example of adding an optimization opportunity: the original value escapes but the value produced by the `move_value` does not escape.  So destroys of the new value can be hoisted more aggressively.
