### PR TITLE
Bitcast fixed-sized packs after allocating them.

### DIFF
--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -1011,8 +1011,10 @@ StackAddress irgen::allocatePack(IRGenFunction &IGF, CanSILPackType packType) {
         IGF.IGM.OpaquePtrTy, elementCount);
 
     auto addr = IGF.createAlloca(allocType, IGF.IGM.getPointerAlignment());
-    IGF.Builder.CreateLifetimeStart(addr,
-                                elementSize * elementCount);
+    IGF.Builder.CreateLifetimeStart(addr, elementSize * elementCount);
+
+    // We have an [N x opaque*]*; we need an opaque**.
+    addr = IGF.Builder.CreateElementBitCast(addr, IGF.IGM.OpaquePtrTy);
     return addr;
   }
 

--- a/test/IRGen/variadic_generics.sil
+++ b/test/IRGen/variadic_generics.sil
@@ -131,6 +131,7 @@ exit:
 // CHECK-LABEL: define {{.*}}@test_pack_alloc_2_static
 // CHECK:         [[STACK:%[^,]+]] = alloca [2 x %swift.opaque*]
 // CHECK:         call void @llvm.lifetime.start.p0i8
+// CHECK:         [[CAST:%.*]] = bitcast [2 x %swift.opaque*]* [[STACK]] to %swift.opaque**
 // CHECK:         call void @llvm.lifetime.end.p0i8
 sil @test_pack_alloc_2_static : $<each T> () -> () {
   %addr = alloc_pack $Pack{Int, Int}


### PR DESCRIPTION
Clients expect a `%swift.opaque**`; without the cast, local GEPs will go off into the weeds.