### PR TITLE
[CSSimplify] Propagate contextual result type into result builder tra…

### DIFF
--- a/test/Constraints/result_builder.swift
+++ b/test/Constraints/result_builder.swift
@@ -1383,3 +1383,22 @@ testOptionalIfElseSequences()
 // CHECK-NEXT: second(Optional(main.B()), nil)
 // CHECK-NEXT: second(nil, Optional(main.Either<main.C, main.D>.first(main.C())))
 // CHECK-NEXT: second(nil, Optional(main.Either<main.C, main.D>.second(main.D())))
+
+// rdar://106364495 - ambiguous use of `buildFinalResult`
+func testBuildFinalResultDependentOnContextualType() {
+  @resultBuilder
+  struct MyBuilder {
+    static func buildBlock(_ v: Int) -> Int { v }
+    static func buildFinalResult(_ v: Int) -> Int { v }
+    static func buildFinalResult(_ v: Int) -> String { "" }
+  }
+
+  func test(@MyBuilder _ fn: () -> Int?) { print(fn()) }
+
+  test {
+    42
+  }
+}
+
+testBuildFinalResultDependentOnContextualType()
+// CHECK: Optional(42)


### PR DESCRIPTION
…nsformed closure

Propagate fully or partially resolved contextual type down into the body 
of result builder transformed closure by eagerly binding intermediate 
body result type to the contextual one. This helps to determine when 
closure body could be solved early.

Resolves: rdar://106364495

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
