### PR TITLE
[cmake] Modify libedit target name to match LLVM's FindLibEdit

### DIFF
--- a/cmake/modules/FindLibEdit.cmake
+++ b/cmake/modules/FindLibEdit.cmake
@@ -61,9 +61,9 @@ else()
                                       LibEdit_VERSION_STRING)
 endif()
 
-if(LibEdit_FOUND AND NOT TARGET libedit)
-  add_library(libedit UNKNOWN IMPORTED)
-  set_target_properties(libedit PROPERTIES
+if(LibEdit_FOUND AND NOT TARGET LibEdit::LibEdit)
+  add_library(LibEdit::LibEdit UNKNOWN IMPORTED)
+  set_target_properties(LibEdit::LibEdit PROPERTIES
     IMPORTED_LOCATION ${LibEdit_LIBRARIES}
     INTERFACE_INCLUDE_DIRECTORIES ${LibEdit_INCLUDE_DIRS})
 endif()

--- a/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
+++ b/tools/SourceKit/tools/sourcekitd-repl/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
     BlocksRuntime)
 endif()
 target_link_libraries(sourcekitd-repl PRIVATE
-  libedit)
+  LibEdit::LibEdit)
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
   set_target_properties(sourcekitd-repl PROPERTIES


### PR DESCRIPTION
For unified builds, LLVM with the update to stable/20221013 includes its own FindLibEdit, which shares many of the same names than Swift's FindLibEdit, except that they differ in the target name.

Match both LLVM and Swift target names, so unified builds can find LibEdit::LibEdit correctly and not try to link against libedit mistakenly.

This should not affect Darwin/Linux builds from upstream Swift, since they build non-unified in most people setups (including CI).

/cc @compnerd, you created the original FindLibEdit.cmake in #29404.

https://reviews.llvm.org/D124673 is the LLVM review that added FindLibEdit.cmake in their repository. It was not in stable/20220421, but it is in stable/20221013.