### PR TITLE
[CSSimplify] Propagate contextual result type into result builder tra…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -3532,27 +3532,8 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
     }
   }
 
-  auto resultMatchKind = subKind;
-  // Performance optimization: Propagate fully or partially resolved contextual
-  // type down into the body of result builder transformed closure by eagerly
-  // binding intermediate body result type to the contextual one. This helps to
-  // determine when closure body could be solved early.
-  //
-  // TODO: This could be extended to cover all multi-statement closures.
-  //
-  // See \c BindingSet::favoredOverConjunction for more details.
-  if (resultMatchKind >= ConstraintKind::Subtype &&
-      !func2->getResult()->isTypeVariableOrMember()) {
-    if (auto *closure = getAsExpr<ClosureExpr>(locator.trySimplifyToExpr())) {
-      if (!closure->hasExplicitResultType() &&
-          getAppliedResultBuilderTransform(closure)) {
-        resultMatchKind = ConstraintKind::Equal;
-      }
-    }
-  }
-
   // Result type can be covariant (or equal).
-  return matchTypes(func1->getResult(), func2->getResult(), resultMatchKind,
+  return matchTypes(func1->getResult(), func2->getResult(), subKind,
                     subflags,
                     locator.withPathElement(ConstraintLocator::FunctionResult));
 }
@@ -6645,6 +6626,40 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
               type2->is<AnyFunctionType>())
             return matchTypesBindTypeVar(typeVar1, type2, kind, flags, locator,
                                          formUnsolvedResult);
+        }
+
+        // Performance optimization: Propagate fully or partially resolved
+        // contextual type down into the body of result builder transformed
+        // closure by eagerly binding intermediate body result type to the
+        // contextual one. This helps to determine when closure body could be
+        // solved early.
+        //
+        // TODO: This could be extended to cover all multi-statement closures.
+        //
+        // See \c BindingSet::favoredOverConjunction for more details.
+        if (!typeVar2 && locator.endsWith<LocatorPathElt::FunctionResult>()) {
+          SmallVector<LocatorPathElt> path;
+          auto anchor = locator.getLocatorParts(path);
+
+          // Drop `FunctionResult` element.
+          path.pop_back();
+
+          ClosureExpr *closure = nullptr;
+          {
+            // This avoids a new locator allocation.
+            SourceRange range;
+            ArrayRef<LocatorPathElt> scratchPath(path);
+            simplifyLocator(anchor, scratchPath, range);
+
+            if (scratchPath.empty())
+              closure = getAsExpr<ClosureExpr>(anchor);
+          }
+
+          if (closure && !closure->hasExplicitResultType() &&
+              getAppliedResultBuilderTransform(closure)) {
+            return matchTypesBindTypeVar(typeVar1, type2, ConstraintKind::Equal,
+                                         flags, locator, formUnsolvedResult);
+          }
         }
       }
 


### PR DESCRIPTION
…nsformed closure

Propagate fully or partially resolved contextual type down into 
the body of result builder transformed closure by eagerly binding
intermediate body result type to the contextual one. This helps to
determine when closure body could be solved early.

This is an alternative approach to https://github.com/apple/swift/pull/64192,
the advantage of it being that the closure could gain the type as soon as
the contextual is bound.

Resolves: rdar://106364495

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
