### PR TITLE
[Observation] Update the SPI entries for SwiftUI for direct tracking access

### DIFF
--- a/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
+++ b/stdlib/public/Observation/Sources/Observation/ObservationRegistrar.swift
@@ -80,9 +80,9 @@ extension ObservationRegistrar {
     keyPath: KeyPath<Subject, Member>
   ) {
     if let trackingPtr = _ThreadLocal.value?
-      .assumingMemoryBound(to: ObservationTracking.AccessList?.self) {
+      .assumingMemoryBound(to: ObservationTracking._AccessList?.self) {
       if trackingPtr.pointee == nil {
-        trackingPtr.pointee = ObservationTracking.AccessList()
+        trackingPtr.pointee = ObservationTracking._AccessList()
       }
       trackingPtr.pointee?.addAccess(keyPath: keyPath, context: context)
     }


### PR DESCRIPTION
The SwiftUI entry point for direct tracking access had a potential flaw with the lifetime of the AccessList storage - this change alters the signatures to provide the type for storage for direct access to SwiftUI as SPI. That SPI is just a deconstructed version of the public API. 