### PR TITLE
Remove gyb from swift-syntax

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftsyntax.py
@@ -74,23 +74,6 @@ class SwiftSyntax(product.Product):
         return True
 
     def build(self, host_target):
-        if self.args.swiftsyntax_verify_generated_files:
-            build_cmd = [
-                os.path.join(self.source_dir, 'build-script.py'),
-                'verify-source-code',
-                '--toolchain', self.install_toolchain_path(host_target),
-                # Verifying the files generated using SwiftSyntaxBuilder requires
-                # internet access to pull the pinned SwiftSyntaxBuilder version. Since
-                # we don't have internet access in CI, don't verify these files.
-                # This is not a huge deal because only SwiftSyntaxBuilder is generated
-                # in terms of itself and it will most likely fail to compile if it isn't
-                # re-generated after gyb files have been updated.
-                '--gyb-only'
-            ]
-            if self.args.verbose_build:
-                build_cmd.append('--verbose')
-            shell.call(build_cmd)
-
         self.run_swiftsyntax_build_script(target=host_target,
                                           command='build')
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
In SwiftSyntax we are removing gyb in favour of SwiftSyntaxBuilder in https://github.com/apple/swift-syntax/pull/1388
