### PR TITLE
[Remote Mirror] Only build under the control of SWIFT_BUILD_REMOTE_MIRROR

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -162,7 +162,7 @@ if(SWIFT_BUILD_STDLIB)
   add_subdirectory(Backtracing)
 endif()
 
-if(SWIFT_BUILD_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)
+if(SWIFT_BUILD_REMOTE_MIRROR)
   add_subdirectory(RemoteInspection)
   add_subdirectory(SwiftRemoteMirror)
 endif()


### PR DESCRIPTION
Remote Mirror should be building under the control of its own flag, not trying to hijack the standard library build flags.  If presets want (or do not want) remote mirror, they should set its build flag appropriately.

(The default is to build it, so mostly this means some things should be disabling it.  I'd already done the work for that as part of previous PRs, but apparently stopped short of completely dissociating it from `SWIFT_BUILD_STDLIB`, which was an error as it means that the minimal preset and things based on it are currently slightly broken.)

rdar://106415217
