### PR TITLE
Minor mistake in group docs comment docs comment snippet

### DIFF
--- a/stdlib/public/Concurrency/TaskGroup.swift
+++ b/stdlib/public/Concurrency/TaskGroup.swift
@@ -632,6 +632,7 @@ public struct ThrowingTaskGroup<ChildTaskResult: Sendable, Failure: Error> {
   ///     } catch {
   ///         // other errors though we print and cancel the group,
   ///         // and all of the remaining child tasks within it.
+  ///         print("Error: \(error)")
   ///         group.cancelAll()
   ///     }
   /// }


### PR DESCRIPTION
We say in a comment here that we print the error and cancel, but we don't actually have the print below. This PR adds that missing print in the docs snippet.
