### PR TITLE
SILGen: Closures within @inline(__always) functions should be always inlined, too

### DIFF
--- a/test/SILGen/inline_always.swift
+++ b/test/SILGen/inline_always.swift
@@ -4,6 +4,13 @@
 @inline(__always)
 func always_inline_callee() {}
 
+// CHECK-LABEL: sil hidden [always_inline] [ossa] @$s13inline_always11testClosureyyF
+@inline(__always)
+func testClosure() {
+  // CHECK-LABEL: sil private [always_inline] [ossa] @$s13inline_always11testClosureyyFyycfU_
+  _ = { }
+}
+
 protocol AlwaysInline {
   func alwaysInlined()
 }

--- a/test/SILOptimizer/inlinealways_and_closure.swift
+++ b/test/SILOptimizer/inlinealways_and_closure.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend  %s -O -module-name=test -emit-sil | %FileCheck %s
+
+// REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
+
+public protocol P {
+  func takePointer<T>(_ p: UnsafePointer<T>)
+}
+
+extension P {
+  @inline(__always)
+  func genericFunc<T>(_ x: inout T) {
+    withUnsafePointer(to: &x) {
+      takePointer($0)
+    }
+  }
+}
+
+// CHECK-LABEL: sil {{.*}}@$s4test6testityyAA1P_pF
+// CHECK-NOT:     function_ref
+// CHECK:         witness_method
+// CHECK:       } // end sil function '$s4test6testityyAA1P_pF' 
+public func testit(_ p: P) {
+  var x = 0
+  p.genericFunc(&x)
+}
+


### PR DESCRIPTION
rdar://106046747
