### PR TITLE
guard assume on executor API against task-to-thread runtimes

### DIFF
--- a/stdlib/public/Concurrency/Actor.cpp
+++ b/stdlib/public/Concurrency/Actor.cpp
@@ -1905,7 +1905,9 @@ static void swift_task_enqueueImpl(Job *job, ExecutorRef executor) {
 static void
 swift_actor_escalate(DefaultActorImpl *actor, AsyncTask *task, JobPriority newPriority)
 {
+#if !SWIFT_CONCURRENCY_ACTORS_AS_LOCKS
   return actor->enqueueStealer(task, newPriority);
+#endif
 }
 
 SWIFT_CC(swift)

--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -13,6 +13,7 @@
 import Swift
 import SwiftShims
 
+#if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 // ==== -----------------------------------------------------------------------
 // MARK: Precondition executors
 
@@ -245,3 +246,4 @@ func assumeOnActorExecutor<Act: Actor, T>(
 }
 
 // TODO(ktoso): implement assume for distributed actors as well
+#endif // not SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY

--- a/stdlib/public/Concurrency/Task.swift
+++ b/stdlib/public/Concurrency/Task.swift
@@ -186,6 +186,7 @@ extension Task: Equatable {
   }
 }
 
+#if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 @available(SwiftStdlib 5.9, *)
 extension Task where Failure == Error {
     @_spi(MainActorUtilities)
@@ -204,7 +205,9 @@ extension Task where Failure == Error {
         return Task<Success, Error>(task)
     }
 }
+#endif
 
+#if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
 @available(SwiftStdlib 5.9, *)
 extension Task where Failure == Never {
     @_spi(MainActorUtilities)
@@ -223,6 +226,7 @@ extension Task where Failure == Never {
         return Task(task)
     }
 }
+#endif
 
 // ==== Task Priority ----------------------------------------------------------
 


### PR DESCRIPTION
without these guards, building for minimal runtimes will fail with errors about global actors, which aren't permitted when compiling with the task-to-thread concurrency model.

rdar://106434422