### PR TITLE
[move-only] Remove misguided handling of inout.

### DIFF
--- a/test/SILOptimizer/moveonly_addresschecker.sil
+++ b/test/SILOptimizer/moveonly_addresschecker.sil
@@ -339,7 +339,14 @@ bb0(%0 : @owned $Klass, %1 : @owned $Klass):
 }
 
 // CHECK-LABEL: sil [ossa] @myBufferViewSetter : $@convention(method) <T> (UnsafeBufferPointer<T>, @inout MyBufferView<T>) -> () {
-// CHECK-NOT: destroy_addr
+// CHECK: bb0([[ARG0:%.*]] : ${{.*}}, [[ARG1:%.*]] :
+// CHECK:   debug_value [[ARG0]]
+// CHECK:   debug_value [[ARG1]]
+// CHECK:   destroy_addr [[ARG1]]
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [static] [[ARG1]]
+// CHECK:   [[GEP:%.*]] = struct_element_addr [[ACCESS]]
+// CHECK:   store [[ARG0]] to [trivial] [[GEP]]
+// CHECK:   end_access [[ACCESS]]
 // CHECK: } // end sil function 'myBufferViewSetter'
 sil [ossa] @myBufferViewSetter : $@convention(method) <T> (UnsafeBufferPointer<T>, @inout MyBufferView<T>) -> () {
 bb0(%0 : $UnsafeBufferPointer<T>, %1 : $*MyBufferView<T>):
@@ -407,4 +414,26 @@ bb0:
   end_access %8 : $*NonTrivialStruct
   %15 = tuple ()
   return %15 : $()
+}
+
+// CHECK-LABEL: sil [ossa] @classSimpleChainArgTestHoistDebugValue : $@convention(thin) (@inout Klass) -> () {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK-NEXT: debug_value [[ARG]]
+sil [ossa] @classSimpleChainArgTestHoistDebugValue : $@convention(thin) (@inout Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = mark_must_check [consumable_and_assignable] %0 : $*Klass
+  %3 = alloc_stack [lexical] $Klass, var, name "y2"
+  %4 = mark_must_check [consumable_and_assignable] %3 : $*Klass
+  %5 = begin_access [read] [static] %1 : $*Klass
+  copy_addr %5 to [init] %4 : $*Klass
+  end_access %5 : $*Klass
+  // If we do not hoist this to %1, we should crash. Make sure we dont!
+  debug_value %1 : $*Klass, var, name "x2", argno 1, expr op_deref
+  destroy_addr %4 : $*Klass
+  dealloc_stack %3 : $*Klass
+  %f = function_ref @get_klass : $@convention(thin) () -> @owned Klass
+  %newArg = apply %f() : $@convention(thin) () -> @owned Klass
+  store %newArg to [init] %1 : $*Klass
+  %27 = tuple ()
+  return %27 : $()
 }

--- a/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
+++ b/test/SILOptimizer/moveonly_addresschecker_diagnostics.sil
@@ -279,3 +279,40 @@ bb0(%0 : @owned $NonTrivialStruct):
   %11 = tuple ()
   return %11 : $()
 }
+
+
+sil [ossa] @classSimpleChainArgTest : $@convention(thin) (@inout Klass) -> () {
+bb0(%0 : $*Klass):
+  %1 = mark_must_check [consumable_and_assignable] %0 : $*Klass
+  // expected-error @-1 {{'x2' consumed more than once}}
+  // expected-error @-2 {{'x2' consumed but not reinitialized before end of function}}
+  debug_value %1 : $*Klass, var, name "x2", argno 1, expr op_deref
+  %3 = alloc_stack [lexical] $Klass, var, name "y2"
+  %4 = mark_must_check [consumable_and_assignable] %3 : $*Klass
+  %5 = begin_access [read] [static] %1 : $*Klass
+  copy_addr %5 to [init] %4 : $*Klass // expected-note {{consuming use here}}
+  end_access %5 : $*Klass
+  %8 = begin_access [read] [static] %1 : $*Klass
+  %9 = load [copy] %8 : $*Klass
+  // expected-note @-1 {{consuming use here}}
+  // expected-note @-2 {{consuming use here}}
+  end_access %8 : $*Klass
+  %11 = begin_access [modify] [static] %4 : $*Klass
+  store %9 to [assign] %11 : $*Klass
+  end_access %11 : $*Klass
+  %14 = alloc_stack [lexical] $Klass, let, name "k2"
+  %15 = mark_must_check [consumable_and_assignable] %14 : $*Klass
+  %16 = begin_access [read] [static] %4 : $*Klass
+  copy_addr %16 to [init] %15 : $*Klass
+  end_access %16 : $*Klass
+  %19 = load_borrow %15 : $*Klass
+  %20 = function_ref @nonConsumingUseKlass : $@convention(thin) (@guaranteed Klass) -> ()
+  %21 = apply %20(%19) : $@convention(thin) (@guaranteed Klass) -> ()
+  end_borrow %19 : $Klass
+  destroy_addr %15 : $*Klass
+  dealloc_stack %14 : $*Klass
+  destroy_addr %4 : $*Klass
+  dealloc_stack %3 : $*Klass
+  %27 = tuple ()
+  return %27 : $()
+}


### PR DESCRIPTION
I think this was just an incorrect fix. The actual issue is that the memory
lifetime verifier views debug_value as requiring a live address... but at the
same time, we do not want to emit diagnostics for a debug_value... we want to do
it for other things. So my solution is to add debug_value to the final liveness
computation, but not use it earlier when we use said liveness to compute
diagnostics.

rdar://106442224

