### PR TITLE
IRGen: Hide type metadata records for noncopyable types from discovery by existing runtimes.

### DIFF
--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1243,8 +1243,12 @@ private:
   SmallVector<ProtocolDecl *, 4> SwiftProtocols;
   /// List of protocol conformances to generate descriptors for.
   std::vector<ConformanceDescription> ProtocolConformances;
-  /// List of types to generate runtime-resolvable metadata records for.
+  /// List of types to generate runtime-resolvable metadata records for that
+  /// are consumable for any Swift runtime.
   SmallVector<GenericTypeDecl *, 4> RuntimeResolvableTypes;
+  /// List of types to generate runtime-resolvable metadata records for that
+  /// are consumable for any Swift runtime aware of noncopyable types.
+  SmallVector<GenericTypeDecl *, 4> RuntimeResolvableTypes2;
   /// List of ExtensionDecls corresponding to the generated
   /// categories.
   SmallVector<ExtensionDecl*, 4> ObjCCategoryDecls;

--- a/stdlib/public/runtime/ImageInspectionCommon.h
+++ b/stdlib/public/runtime/ImageInspectionCommon.h
@@ -27,9 +27,12 @@
 /// The Mach-O section name for the section containing protocol conformances.
 /// This lives within SEG_TEXT.
 #define MachOProtocolConformancesSection "__swift5_proto"
-/// The Mach-O section name for the section containing type references.
+/// The Mach-O section name for the section containing copyable type references.
 /// This lives within SEG_TEXT.
 #define MachOTypeMetadataRecordSection "__swift5_types"
+/// The Mach-O section name for the section containing additional type references.
+/// This lives within SEG_TEXT.
+#define MachOExtraTypeMetadataRecordSection "__swift5_types2"
 /// The Mach-O section name for the section containing dynamic replacements.
 /// This lives within SEG_TEXT.
 #define MachODynamicReplacementSection "__swift5_replace"

--- a/test/IRGen/moveonly_deinit.sil
+++ b/test/IRGen/moveonly_deinit.sil
@@ -130,6 +130,20 @@ struct MOSingleRefcountLikeStructNoDeinit {
   var x: C
 }
 
+// Type metadata records for noncopyable types should be in a separate list
+// from copyable types.
+
+// CHECK-LABEL: @"$s{{.*}}1CCHn" = 
+// CHECK-SAME:  section "[[COPYABLE_SECTION_NAME:[^"]+]]"
+
+// CHECK-NOT: @"$s{{.*}}8MOStructVHn" = {{.*}} section "[[COPYABLE_SECTION_NAME]]"
+
+// CHECK-LABEL: @"$s{{.*}}8MOStructVHn" = 
+// CHECK-SAME:  section "[[NONCOPYABLE_SECTION_NAME:[^"]+]]"
+
+// CHECK-LABEL: @"$s{{.*}}6MOEnumOHn" = 
+// CHECK-SAME:  section "[[NONCOPYABLE_SECTION_NAME]]"
+
 // Very large structs will use indirect conventions for their deinit.
 
 @_moveOnly


### PR DESCRIPTION
We'd still like to try to be forwardly compatible with future runtimes that do properly handle noncopyable types, so emit them in a separate section from copyable type records for now. This should prevent the current noncopyable-unaware `_typeByName` from letting someone get a hold of a noncopyable type's metatype as a (copyable) `Any.Type` and then trying to use it to copy uncopyable values.