### PR TITLE
Revert "PreCheckExpr: Recognize non-identifier type qualifiers in type expressions"

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -1340,9 +1340,9 @@ public:
                                        TypeDecl *Decl);
 
   /// Create a \c TypeExpr for a member \c TypeDecl of the given parent
-  /// \c TypeRepr.
-  static TypeExpr *createForMemberDecl(TypeRepr *ParentTR, DeclNameLoc NameLoc,
-                                       TypeDecl *Decl);
+  /// \c DeclRefTypeRepr.
+  static TypeExpr *createForMemberDecl(DeclRefTypeRepr *ParentTR,
+                                       DeclNameLoc NameLoc, TypeDecl *Decl);
 
   /// Create a \c TypeExpr from an \c DeclRefTypeRepr with the given arguments
   /// applied at the specified location.

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2255,29 +2255,24 @@ TypeExpr *TypeExpr::createForMemberDecl(DeclNameLoc ParentNameLoc,
   return new (C) TypeExpr(TR);
 }
 
-TypeExpr *TypeExpr::createForMemberDecl(TypeRepr *ParentTR, DeclNameLoc NameLoc,
-                                        TypeDecl *Decl) {
+TypeExpr *TypeExpr::createForMemberDecl(DeclRefTypeRepr *ParentTR,
+                                        DeclNameLoc NameLoc, TypeDecl *Decl) {
   ASTContext &C = Decl->getASTContext();
+
+  // Create a new list of components.
+  SmallVector<IdentTypeRepr *, 2> Components;
+  if (auto *MemberTR = dyn_cast<MemberTypeRepr>(ParentTR)) {
+    auto MemberComps = MemberTR->getMemberComponents();
+    Components.append(MemberComps.begin(), MemberComps.end());
+  }
 
   // Add a new component for the member we just found.
   auto *NewComp = new (C) SimpleIdentTypeRepr(NameLoc, Decl->createNameRef());
   NewComp->setValue(Decl, nullptr);
+  Components.push_back(NewComp);
 
-  TypeRepr *TR = nullptr;
-  if (auto *DeclRefTR = dyn_cast<DeclRefTypeRepr>(ParentTR)) {
-    // Create a new list of components.
-    SmallVector<IdentTypeRepr *, 4> Components;
-    if (auto *MemberTR = dyn_cast<MemberTypeRepr>(ParentTR)) {
-      auto MemberComps = MemberTR->getMemberComponents();
-      Components.append(MemberComps.begin(), MemberComps.end());
-    }
-
-    Components.push_back(NewComp);
-    TR = MemberTypeRepr::create(C, DeclRefTR->getBaseComponent(), Components);
-  } else {
-    TR = MemberTypeRepr::create(C, ParentTR, NewComp);
-  }
-
+  auto *TR =
+      MemberTypeRepr::create(C, ParentTR->getBaseComponent(), Components);
   return new (C) TypeExpr(TR);
 }
 

--- a/lib/Sema/PreCheckExpr.cpp
+++ b/lib/Sema/PreCheckExpr.cpp
@@ -1467,36 +1467,39 @@ TypeExpr *PreCheckExpression::simplifyNestedTypeExpr(UnresolvedDotExpr *UDE) {
   }
 
   // Fold 'T.U' into a nested type.
+  if (auto *DeclRefTR = dyn_cast<DeclRefTypeRepr>(InnerTypeRepr)) {
+    // Resolve the TypeRepr to get the base type for the lookup.
+    TypeResolutionOptions options(TypeResolverContext::InExpression);
+    // Pre-check always allows pack references during TypeExpr folding.
+    // CSGen will diagnose cases that appear outside of pack expansion
+    // expressions.
+    options |= TypeResolutionFlags::AllowPackReferences;
+    // Resolve the TypeRepr to get the base type for the lookup.
+    const auto BaseTy = TypeResolution::resolveContextualType(
+        InnerTypeRepr, DC, options,
+        [](auto unboundTy) {
+          // FIXME: Don't let unbound generic types escape type resolution.
+          // For now, just return the unbound generic type.
+          return unboundTy;
+        },
+        // FIXME: Don't let placeholder types escape type resolution.
+        // For now, just return the placeholder type.
+        PlaceholderType::get,
+        // TypeExpr pack elements are opened in CSGen.
+        /*packElementOpener*/ nullptr);
 
-  // Resolve the TypeRepr to get the base type for the lookup.
-  TypeResolutionOptions options(TypeResolverContext::InExpression);
-  // Pre-check always allows pack references during TypeExpr folding.
-  // CSGen will diagnose cases that appear outside of pack expansion
-  // expressions.
-  options |= TypeResolutionFlags::AllowPackReferences;
-  const auto BaseTy = TypeResolution::resolveContextualType(
-      InnerTypeRepr, DC, options,
-      [](auto unboundTy) {
-        // FIXME: Don't let unbound generic types escape type resolution.
-        // For now, just return the unbound generic type.
-        return unboundTy;
-      },
-      // FIXME: Don't let placeholder types escape type resolution.
-      // For now, just return the placeholder type.
-      PlaceholderType::get,
-      // TypeExpr pack elements are opened in CSGen.
-      /*packElementOpener*/ nullptr);
+    if (BaseTy->mayHaveMembers()) {
+      // See if there is a member type with this name.
+      auto Result =
+          TypeChecker::lookupMemberType(DC, BaseTy, Name,
+                                        defaultMemberLookupOptions);
 
-  if (BaseTy->mayHaveMembers()) {
-    // See if there is a member type with this name.
-    auto Result = TypeChecker::lookupMemberType(DC, BaseTy, Name,
-                                                defaultMemberLookupOptions);
-
-    // If there is no nested type with this name, we have a lookup of
-    // a non-type member, so leave the expression as-is.
-    if (Result.size() == 1) {
-      return TypeExpr::createForMemberDecl(InnerTypeRepr, UDE->getNameLoc(),
-                                           Result.front().Member);
+      // If there is no nested type with this name, we have a lookup of
+      // a non-type member, so leave the expression as-is.
+      if (Result.size() == 1) {
+        return TypeExpr::createForMemberDecl(DeclRefTR, UDE->getNameLoc(),
+                                             Result.front().Member);
+      }
     }
   }
 

--- a/lib/Sema/TypeCheckRuntimeMetadataAttr.cpp
+++ b/lib/Sema/TypeCheckRuntimeMetadataAttr.cpp
@@ -78,7 +78,12 @@ static TypeRepr *buildTypeRepr(DeclContext *typeContext,
   // Reverse the components to form a valid outer-to-inner name sequence.
   std::reverse(components.begin(), components.end());
 
-  TypeRepr *typeRepr = MemberTypeRepr::create(ctx, components);
+  TypeRepr *typeRepr = nullptr;
+  if (components.size() == 1) {
+    typeRepr = components.front();
+  } else {
+    typeRepr = MemberTypeRepr::create(ctx, components);
+  }
 
   if (forMetatype)
     return new (ctx) MetatypeTypeRepr(typeRepr, /*MetaLoc=*/SourceLoc());

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -344,10 +344,18 @@ func compositionType() {
 
   CheckType<P1 & P2>.matches(((P1) & (P2)).self)
   CheckType<P1 & P2>.matches((Foo.P1 & Foo.P2).self)
+  // FIXME: Teach Sema to recognize this type expression.
+  // expected-error@+1 {{binary operator '&' cannot be applied to operands of type '(any (Foo).P1).Type' (aka '(any P1).Type') and '(any (Foo).P2).Type' (aka '(any P2).Type')}}
   CheckType<P1 & P2>.matches(((Foo).P1 & (Foo).P2).self)
   CheckType<P1 & P2>.matches((Gen<Foo>.P1 & Gen<Foo>.P2).self)
+  // FIXME: Teach Sema to recognize this type expression.
+  // expected-error@+1 {{binary operator '&' cannot be applied to operands of type '(any Optional<Foo>.P1).Type' (aka '(any P1).Type') and '(any Optional<Foo>.P2).Type' (aka '(any P2).Type')}}
   CheckType<P1 & P2>.matches((Foo?.P1 & Foo?.P2).self)
+  // FIXME: Teach Sema to recognize this type expression.
+  // expected-error@+1 {{binary operator '&' cannot be applied to operands of type '(any Array<Foo>.P1).Type' (aka '(any P1).Type') and '(any Array<Foo>.P2).Type' (aka '(any P2).Type')}}
   CheckType<P1 & P2>.matches(([Foo].P1 & [Foo].P2).self)
+  // FIXME: Teach Sema to recognize this type expression.
+  // expected-error@+1 {{binary operator '&' cannot be applied to operands of type '(any Dictionary<Int, Foo>.P1).Type' (aka '(any P1).Type') and '(any Dictionary<Int, Foo>.P2).Type' (aka '(any P2).Type')}}
   CheckType<P1 & P2>.matches(([Int : Foo].P1 & [Int : Foo].P2).self)
 }
 
@@ -367,6 +375,8 @@ func tupleType() {
   CheckType<(Foo, Foo)>.matches(((Foo), (Foo)).self)
 
   CheckType<(Foo.Bar, Foo.Bar)>.matches((Foo.Bar, Foo.Bar).self)
+  // FIXME: Teach Sema to recognize this type expression.
+  // expected-error@+1 {{cannot convert value of type '((Foo).Bar.Type, (Foo).Bar.Type)' to expected argument type '(Foo.Bar, Foo.Bar).Type'}}
   CheckType<(Foo.Bar, Foo.Bar)>.matches(((Foo).Bar, (Foo).Bar).self)
 
   CheckType<(Gen<Foo>, Gen<Foo>)>.matches((Gen<Foo>, Gen<Foo>).self)
@@ -375,8 +385,14 @@ func tupleType() {
   CheckType<([Int : Foo], [Int : Foo])>.matches(([Int : Foo], [Int : Foo]).self)
 
   CheckType<(Gen<Foo>.Bar, Gen<Foo>.Bar)>.matches((Gen<Foo>.Bar, Gen<Foo>.Bar).self)
+  // FIXME: Teach Sema to recognize this type expression.
+  // expected-error@+1 {{cannot convert value of type '(Optional<Foo>.Wrapped.Type, Optional<Foo>.Wrapped.Type)' (aka '(Foo.Type, Foo.Type)') to expected argument type '(Foo, Foo).Type'}}
   CheckType<(Foo, Foo)>.matches((Foo?.Wrapped, Foo?.Wrapped).self)
+  // FIXME: Teach Sema to recognize this type expression.
+  // expected-error@+1 {{cannot convert value of type '(Array<Foo>.Element.Type, Array<Foo>.Element.Type)' (aka '(Foo.Type, Foo.Type)') to expected argument type '(Foo, Foo).Type'}}
   CheckType<(Foo, Foo)>.matches(([Foo].Element, [Foo].Element).self)
+  // FIXME: Teach Sema to recognize this type expression.
+  // expected-error@+1 {{cannot convert value of type '(Dictionary<Int, Foo>.Value.Type, Dictionary<Int, Foo>.Value.Type)' (aka '(Foo.Type, Foo.Type)') to expected argument type '(Foo, Foo).Type'}}
   CheckType<(Foo, Foo)>.matches(([Int : Foo].Value, [Int : Foo].Value).self)
 
   CheckType<(Foo.Type, Foo.Type)>.matches((Foo.Type, Foo.Type).self)
@@ -385,6 +401,7 @@ func tupleType() {
   CheckType<(P1 & P2, P1 & P2)>.matches((P1 & P2, P1 & P2).self)
 
   // Trade exhaustivity for one complex test case.
+  // FIXME: Replace this with the next test once we make it succeed.
   CheckType<
     (
       (Gen<Foo>.Bar) -> P1 & P2,
@@ -394,7 +411,24 @@ func tupleType() {
     )
   >.matches(
     (
-      (Gen<Foo>.Bar) -> (P1) & Foo?.P2,
+      (Gen<Foo>.Bar) -> (P1) & Optional<Foo>.P2,
+      (Foo.Bar, [Int : Foo?].Type),
+      [Gen<Foo>.Bar],
+      Array<Foo.Bar.Baz>.Element
+    ).self
+  )
+
+  // FIXME: Teach Sema to recognize this type expression.
+  CheckType<
+    (
+      (Gen<Foo>.Bar) -> P1 & P2,
+      (Foo.Bar, [Int : Foo?].Type),
+      [Gen<Foo>.Bar],
+      Foo.Bar.Baz
+    )
+  >.matches(
+    ( // expected-error {{cannot convert value of type '(_.Type, (Foo.Bar, Dictionary<Int, Optional<Foo>>.Type).Type, Array<(Gen<Foo>).Bar.Type>, Array<Foo.Bar.Baz>.Element.Type)' (aka '(_.Type, (Foo.Bar, Dictionary<Int, Optional<Foo>>.Type).Type, Array<(Gen<Foo>).Bar.Type>, Foo.Bar.Baz.Type)') to expected argument type '((Gen<Foo>.Bar) -> any P1 & P2, (Foo.Bar, [Int : Foo?].Type), [Gen<Foo>.Bar], Foo.Bar.Baz).Type'}}
+      (Gen<Foo>.Bar) -> (P1) & Foo?.P2, // expected-error {{expected type after '->'}}
       (Foo.Bar, [Int : Foo?].Type),
       [(Gen<Foo>).Bar],
       [Foo.Bar.Baz].Element
@@ -432,6 +466,8 @@ func functionType() {
   CheckType<(Foo) -> Foo>.matches((((Foo)) -> (Foo)).self)
 
   CheckType<(Foo.Bar) -> Foo.Bar>.matches(((Foo.Bar) -> Foo.Bar).self)
+  // FIXME: Teach Sema to recognize this type expression.
+  // expected-error@+1 {{expected type before '->'}} expected-error@+1 {{expected type after '->'}}
   CheckType<(Foo.Bar) -> Foo.Bar>.matches((((Foo).Bar) -> (Foo).Bar).self)
 
   CheckType<(Gen<Foo>) -> Gen<Foo>>.matches(((Gen<Foo>) -> Gen<Foo>).self)
@@ -440,8 +476,14 @@ func functionType() {
   CheckType<([Int : Foo]) -> [Int : Foo]>.matches((([Int : Foo]) -> [Int : Foo]).self)
 
   CheckType<(Gen<Foo>.Bar) -> Gen<Foo>.Bar>.matches(((Gen<Foo>.Bar) -> Gen<Foo>.Bar).self)
+  // FIXME: Teach Sema to recognize this type expression.
+  // expected-error@+1 {{expected type before '->'}} expected-error@+1 {{expected type after '->'}}
   CheckType<(Foo) -> Foo>.matches(((Foo?.Wrapped) -> Foo?.Wrapped).self)
+  // FIXME: Teach Sema to recognize this type expression.
+  // expected-error@+1 {{expected type before '->'}} expected-error@+1 {{expected type after '->'}}
   CheckType<(Foo) -> Foo>.matches((([Foo].Element) -> [Foo].Element).self)
+  // FIXME: Teach Sema to recognize this type expression.
+  // expected-error@+1 {{expected type before '->'}} expected-error@+1 {{expected type after '->'}}
   CheckType<(Foo) -> Foo>.matches((([Int : Foo].Value) -> [Int : Foo].Value).self)
 
   CheckType<(Foo.Type) -> Foo.Type>.matches(((Foo.Type) -> Foo.Type).self)
@@ -453,6 +495,7 @@ func functionType() {
       .matches(((P1 & P2) -> (P3 & P2) -> P1 & Any).self)
 
   // Trade exhaustivity for one complex test case.
+  // FIXME: Replace this with the next test once we make it succeed.
   CheckType<
     (
       P1 & P2,
@@ -464,12 +507,33 @@ func functionType() {
   >.matches(
     (
       (
+        (P1) & Optional<Foo>.P2,
+        Gen<Foo>.Bar,
+        (Foo, [Int : Foo?].Type)
+      ) -> (
+        [Foo.Bar]
+      ) -> Array<Foo>.Element
+    ).self
+  )
+
+  // FIXME: Teach Sema to recognize this type expression.
+  CheckType<
+    (
+      P1 & P2,
+      Gen<Foo>.Bar,
+      (Foo, [Int : Foo?].Type)
+    ) -> (
+      [Foo.Bar]
+    ) -> Foo
+  >.matches(
+    (
+      ( // expected-error {{expected type before '->'}}
         (P1) & Foo?.P2,
         Gen<Foo>.Bar,
         (Foo, [Int : Foo?].Type)
       ) -> (
-        [(Foo).Bar]
-      ) -> [Foo].Element
+        [(Foo).Bar] // expected-error {{expected type before '->'}}
+      ) -> [Foo].Element // expected-error {{expected type after '->'}}
     ).self
   )
 }

--- a/test/SILGen/default_arguments.swift
+++ b/test/SILGen/default_arguments.swift
@@ -446,11 +446,11 @@ enum E {
   // CHECK-LABEL: sil hidden [ossa] @$s17default_arguments1EO4testyyFZ : $@convention(method) (@thin E.Type) -> ()
   static func test() {
     // CHECK: function_ref @$s17default_arguments1EO6ResultV4name9platformsAESS_SaySiGtcfcfA0_ : $@convention(thin) () -> @owned Array<Int>
-    // CHECK: function_ref @$s17default_arguments1EO6ResultV4name9platformsAESS_SaySiGtcfC : $@convention(method) (@owned String, @owned Array<Int>, @thin E.Result.Type) -> @owned E.Result
+    // CHECK: function_ref @$s17default_arguments1EO4testyyFZAC6ResultVSS_SaySiGtcfu_ : $@convention(thin) (@guaranteed String, @guaranteed Array<Int>) -> @owned E.Result
 
+    // CHECK-LABEL: sil private [ossa] @$s17default_arguments1EO4testyyFZAC6ResultVSS_SaySiGtcfu_ : $@convention(thin) (@guaranteed String, @guaranteed Array<Int>) -> @owned E.Result
     var result = Self.Result(name: "")
   }
-  // CHECK: end sil function '$s17default_arguments1EO4testyyFZ'
 }
 
 // FIXME: Arguably we shouldn't allow calling a constructor like this, as

--- a/test/type/nested_types.swift
+++ b/test/type/nested_types.swift
@@ -84,3 +84,16 @@ do {
   let _: (Int, Int).Undef // expected-error {{'Undef' is not a member type of type '(Swift.Int, Swift.Int)'}}
   let _: ((Int) -> Void).Undef // expected-error {{'Undef' is not a member type of type '(Swift.Int) -> Swift.Void'}}
 }
+
+// rdar://106446740 - source compatibility break - reference to inner type without `.self` used to work
+func test_inner_types_dont_require_self() {
+  struct Test {
+    enum E {}
+
+    func decode<T>(_: T.Type) {}
+
+    func test() {
+      decode(Self.E) // Ok
+    }
+  }
+}


### PR DESCRIPTION
Reverts https://github.com/apple/swift/pull/63784 because it cased a source compatibility regression.

I've also added a new test-case to make sure that this doesn't happen in the future.

Resolves: rdar://106446740

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
