### PR TITLE
[interop][cxx] skip not visible template specialization decls

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2741,6 +2741,12 @@ namespace {
         if (notInstantiated)
           return nullptr;
       }
+      if (!decl->isUnconditionallyVisible()) {
+        // Skip declarations present in imported clang modules
+        // which might be not visible in this context, as Clang might report
+        // a missing 'include' error.
+        return nullptr;
+      }
       if (!clangSema.isCompleteType(
               decl->getLocation(),
               Impl.getClangASTContext().getRecordType(decl))) {


### PR DESCRIPTION
This avoids some visibility errors emitted by Clang when it's checking template specialization visibility

I don't really know how to add a testcase for this yet, but we need it merged sooner. 