### PR TITLE
Sema: Allow member type expressions rooted on non-identifier qualifiers to omit `.self` until Swift 6

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -4188,7 +4188,8 @@ ERROR(value_of_module_type,none,
       "expected module member name after module name", ())
 
 ERROR(value_of_metatype_type,none,
-      "expected member name or constructor call after type name", ())
+      "expected member name or constructor call after type name%select{|; this "
+      "will be an error in Swift 6}0", (bool))
 
 NOTE(add_parens_to_type,none,
      "add arguments after the type to construct a value of the type", ())

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -454,11 +454,11 @@ func test_dynamic_subscript_accepts_type_name_argument() {
   }
 
   func test(a: AnyObject, optA: AnyObject?) {
-    let _ = a[A] // expected-warning {{expected member name or constructor call after type name}}
+    let _ = a[A] // expected-warning {{expected member name or constructor call after type name; this will be an error in Swift 6}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{16-16=()}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{16-16=.self}}
 
-    let _ = optA?[A] // expected-warning {{expected member name or constructor call after type name}}
+    let _ = optA?[A] // expected-warning {{expected member name or constructor call after type name; this will be an error in Swift 6}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{20-20=()}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{20-20=.self}}
   }

--- a/test/Constraints/subscript.swift
+++ b/test/Constraints/subscript.swift
@@ -230,11 +230,11 @@ func test_subscript_accepts_type_name_argument() {
   }
 
   func test(a: A, optA: A?) {
-    let _ = a[A] // expected-warning {{expected member name or constructor call after type name}}
+    let _ = a[A] // expected-warning {{expected member name or constructor call after type name; this will be an error in Swift 6}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{16-16=()}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{16-16=.self}}
 
-    let _ = optA?[A] // expected-warning {{expected member name or constructor call after type name}}
+    let _ = optA?[A] // expected-warning {{expected member name or constructor call after type name; this will be an error in Swift 6}}
     // expected-note@-1 {{add arguments after the type to construct a value of the type}} {{20-20=()}}
     // expected-note@-2 {{use '.self' to reference the type object}} {{20-20=.self}}
   }

--- a/test/type/nested_types.swift
+++ b/test/type/nested_types.swift
@@ -84,3 +84,33 @@ do {
   let _: (Int, Int).Undef // expected-error {{'Undef' is not a member type of type '(Swift.Int, Swift.Int)'}}
   let _: ((Int) -> Void).Undef // expected-error {{'Undef' is not a member type of type '(Swift.Int) -> Swift.Void'}}
 }
+
+// Accept member type expressions rooted on 'Self' or non-identifier qualifiers
+// until Swift 6.
+do {
+  struct Test {
+    enum E {}
+
+    func blackHole<T>(_: T.Type) {}
+
+    func test() {
+      blackHole(Self.E)
+      // expected-warning@-1 {{expected member name or constructor call after type name; this will be an error in Swift 6}}
+      // expected-note@-2 {{use '.self' to reference the type object}}
+      blackHole((Test).E)
+      // expected-warning@-1 {{expected member name or constructor call after type name; this will be an error in Swift 6}}
+      // expected-note@-2 {{use '.self' to reference the type object}}
+      blackHole([Test].Element)
+      // expected-warning@-1 {{expected member name or constructor call after type name; this will be an error in Swift 6}}
+      // expected-note@-2 {{use '.self' to reference the type object}}
+      // expected-note@-3 {{add arguments after the type to construct a value of the type}}
+      blackHole([Int : Test].Element)
+      // expected-warning@-1 {{expected member name or constructor call after type name; this will be an error in Swift 6}}
+      // expected-note@-2 {{use '.self' to reference the type object}}
+      blackHole(Test?.Wrapped)
+      // expected-warning@-1 {{expected member name or constructor call after type name; this will be an error in Swift 6}}
+      // expected-note@-2 {{use '.self' to reference the type object}}
+      // expected-note@-3 {{add arguments after the type to construct a value of the type}}
+    }
+  }
+}


### PR DESCRIPTION
Addresses #64220.