### PR TITLE
[AccessScope] Treat PackageUnit as enclosing scope of ModuleDecl

### DIFF
--- a/include/swift/AST/AccessScope.h
+++ b/include/swift/AST/AccessScope.h
@@ -28,14 +28,14 @@ class AccessScope {
   /// <DeclContext*, bool> pair to determine the scope, as shown
   /// in the table below.
   ///
-  /// <DeclContext*, bool>     AccessScope      AccessLevel
-  /// --------------------------------------------
-  ///  <nullptr, false>                Public             public or open
-  ///  <nullptr, true>                  Public             public `@_spi`
-  ///  <PackageUnit*, _>             Package             package
-  ///  <ModuleDecl*, _>                Module               internal
-  ///  <FileUnit*, false>           FileScope           fileprivate
-  ///  <FileUnit*, true>              Private               private
+  /// <DeclContext*, bool>          AccessScope        AccessLevel
+  /// ----------------------------------------------------------------
+  ///  <nullptr, false>              Public           public or open
+  ///  <nullptr, true>               Public           public `@_spi`
+  ///  <PackageUnit*, _>             Package            package
+  ///  <ModuleDecl*, _>              Module             internal
+  ///  <FileUnit*, false>            FileScope        fileprivate
+  ///  <FileUnit*, true>             Private            private
   ///
   /// For example, if a decl with `public` access level is referenced outside of
   /// its defining module, it will be maped to the <nullptr, false> pair during
@@ -84,8 +84,8 @@ public:
   /// child of the other.
   /// 2. This function does _not_ check the restrictiveness of the _access
   /// level_ between two decls.
-  /// 3. The DeclContext of this (use site) may not be null even if the use site has
-  /// a `public` access level.
+  /// 3. The DeclContext of this (use site) may not be null even if the use site
+  /// has a `public` access level.
   ///
   /// Here's an example while typechecking a file with the following code.
   ///
@@ -96,12 +96,12 @@ public:
   /// public func myFunc(_ arg: OtherModule.Foo) {}
   /// ```
   ///
-  /// The use site of `Foo`is a function `myFunc`, and its DeclContext is non-null
-  /// (FileUnit) even though the function decl itself has a `public` access level.
-  /// When `isChildOf` is called, the argument passed in is a pair <nullptr,
-  /// false> created in \c getAccessScopeForFormalAccess based on the access
-  /// level of the decl `Foo`. Since FileUnit is a child of nullptr in the DeclContext
-  /// hierarchy (described above), it returns true.
+  /// The use site of `Foo`is a function `myFunc`, and its DeclContext is
+  /// non-null (FileUnit) even though the function decl itself has a `public`
+  /// access level. When `isChildOf` is called, the argument passed in is a pair
+  /// <nullptr, false> created in \c getAccessScopeForFormalAccess based on the
+  /// access level of the decl `Foo`. Since FileUnit is a child of nullptr in
+  /// the DeclContext hierarchy (described above), it returns true.
   ///
   /// \see AccessScope::getAccessScopeForFormalAccess
   /// \see AccessScope::checkAccessUsingAccessScope
@@ -114,7 +114,7 @@ public:
         return allowsPrivateAccess(getDeclContext(), AS.getDeclContext());
       else
         return AS.isPublic();
-    } else {// It's public, so can't be a child of the argument scope
+    } else { // It's public, so can't be a child of the argument scope
       return false;
     }
   }

--- a/include/swift/AST/AccessScope.h
+++ b/include/swift/AST/AccessScope.h
@@ -20,40 +20,39 @@
 
 namespace swift {
 
-/// Used to provide the kind of scope limitation in AccessScope::Value
-enum class AccessLimitKind : uint8_t { None = 0, Private, Package };
-
 /// The wrapper around the outermost DeclContext from which
 /// a particular declaration can be accessed.
 class AccessScope {
-  /// The declaration context along with an enum indicating the level of
-  /// scope limitation.
-  /// If the declaration context is set, and the limit kind is Private, the
-  /// access level is considered 'private'. Whether it's 'internal' or
-  /// 'fileprivate' is determined by what the declaration context casts to. If
-  /// the declaration context is null, and the limit kind is None, the access
-  /// level is considered 'public'. If the limit kind is Private, the access
-  /// level is considered SPI. If it's Package, the access level is considered
-  /// 'package'. Below is a table showing the combinations.
+  /// To validate access of a decl, access scope check for both decl site
+  /// and use site needs to be done. The underlying mechanism uses a
+  /// <DeclContext*, bool> pair to determine the scope, as shown
+  /// in the table below.
   ///
-  /// AccessLimitKind       DC == nullptr               DC != nullptr
-  /// ---------------------------------------------------------------------------
-  ///  None                    public                  fileprivate or internal (check DC to tell which)
-  ///  Private               `@_spi` public                private
-  ///  Package                 package                    (unused)
-
-  llvm::PointerIntPair<const DeclContext *, 2, AccessLimitKind> Value;
+  /// <DeclContext*, bool>     AccessScope      AccessLevel
+  /// --------------------------------------------
+  ///  <nullptr, false>                Public             public or open
+  ///  <nullptr, true>                  Public             public `@_spi`
+  ///  <PackageUnit*, _>             Package             package
+  ///  <ModuleDecl*, _>                Module               internal
+  ///  <FileUnit*, false>           FileScope           fileprivate
+  ///  <FileUnit*, true>              Private               private
+  ///
+  /// For example, if a decl with `public` access level is referenced outside of
+  /// its defining module, it will be maped to the <nullptr, false> pair during
+  /// the access scope check. This pair is determined based on the decl's access
+  /// level in  \c getAccessScopeForFormalAccess and passed to
+  /// \c checkAccessUsingAccessScope which compares access scope of the
+  /// use site and decl site.
+  ///
+  /// \see AccessScope::getAccessScopeForFormalAccess
+  /// \see AccessScope::checkAccessUsingAccessScope
+  /// \see DeclContext::ASTHierarchy
+  llvm::PointerIntPair<const DeclContext *, 1, bool> Value;
 
 public:
-  AccessScope(const DeclContext *DC,
-              AccessLimitKind limitKind = AccessLimitKind::None);
+  AccessScope(const DeclContext *DC, bool isPrivate = false);
 
-  static AccessScope getPublic() {
-    return AccessScope(nullptr, AccessLimitKind::None);
-  }
-  static AccessScope getPackage() {
-    return AccessScope(nullptr, AccessLimitKind::Package);
-  }
+  static AccessScope getPublic() { return AccessScope(nullptr, false); }
 
   /// Check if private access is allowed. This is a lexical scope check in Swift
   /// 3 mode. In Swift 4 mode, declarations and extensions of the same type will
@@ -66,63 +65,60 @@ public:
   bool operator==(AccessScope RHS) const { return Value == RHS.Value; }
   bool operator!=(AccessScope RHS) const { return !(*this == RHS); }
   bool hasEqualDeclContextWith(AccessScope RHS) const {
-    if (isPublic())
-      return RHS.isPublic();
-    if (isPackage())
-      return RHS.isPackage();
     return getDeclContext() == RHS.getDeclContext();
   }
 
-  bool isPublic() const {
-    return !Value.getPointer() && Value.getInt() == AccessLimitKind::None;
-  }
-  bool isPrivate() const {
-    return Value.getPointer() && Value.getInt() == AccessLimitKind::Private;
-  }
+  bool isPublic() const { return !Value.getPointer(); }
+  bool isPrivate() const { return Value.getPointer() && Value.getInt(); }
   bool isFileScope() const;
   bool isInternal() const;
-  bool isPackage() const {
-    return !Value.getPointer() && Value.getInt() == AccessLimitKind::Package;
-  }
+  bool isPackage() const;
 
-  /// Returns true if the context of this (use site) is more restrictive than
-  /// the argument context (decl site). This function does _not_ check the
-  /// restrictiveness of the access level between this and the argument. \see
-  /// AccessScope::isInContext
+  /// Checks if the DeclContext of this (use site) access scope is more
+  /// restrictive than that of the argument (decl site) based on the DeclContext
+  /// hierarchy: (most to least restrictive)
+  /// decl/expr (e.g. ClassDecl) -> FileUnit -> ModuleDecl -> PackageUnit -> nullptr
+  ///
+  /// A few things to note:
+  /// 1. If both have the same DeclContext, returns false as one is _not_ a
+  /// child of the other.
+  /// 2. This function does _not_ check the restrictiveness of the _access
+  /// level_ between two decls.
+  /// 3. The DeclContext of this (use site) may not be null even if the use site has
+  /// a `public` access level.
+  ///
+  /// Here's an example while typechecking a file with the following code.
+  ///
+  /// ```
+  /// import OtherModule
+  ///
+  /// // `Foo` is a `public` struct defined in `OtherModule`
+  /// public func myFunc(_ arg: OtherModule.Foo) {}
+  /// ```
+  ///
+  /// The use site of `Foo`is a function `myFunc`, and its DeclContext is non-null
+  /// (FileUnit) even though the function decl itself has a `public` access level.
+  /// When `isChildOf` is called, the argument passed in is a pair <nullptr,
+  /// false> created in \c getAccessScopeForFormalAccess based on the access
+  /// level of the decl `Foo`. Since FileUnit is a child of nullptr in the DeclContext
+  /// hierarchy (described above), it returns true.
+  ///
+  /// \see AccessScope::getAccessScopeForFormalAccess
+  /// \see AccessScope::checkAccessUsingAccessScope
+  /// \see DeclContext::ASTHierarchy
   bool isChildOf(AccessScope AS) const {
-    if (isInContext()) {
+    if (isPackage()) { // This needs to be checked first before isInContext
+      return AS.isPublic();
+    } else if (isInContext()) {
       if (AS.isInContext())
         return allowsPrivateAccess(getDeclContext(), AS.getDeclContext());
       else
-        return AS.isPackage() || AS.isPublic();
+        return AS.isPublic();
+    } else {// It's public, so can't be a child of the argument scope
+      return false;
     }
-    if (isPackage())
-      return AS.isPublic();
-    // If this is public, it can't be less than access level of AS
-    // so return false
-    return false;
   }
 
-  /// Result depends on whether it's called at a use site or a decl site:
-  ///
-  /// For example,
-  ///
-  /// ```
-  /// public func foo(_ arg: bar) {} // `bar` is a `package` decl in another
-  /// module
-  /// ```
-  ///
-  /// The meaning of \c isInContext changes whether it's at the use site or the
-  /// decl site.
-  ///
-  /// The use site of \c bar, i.e. \c foo, is "in context" (decl context is
-  /// non-null), regardless of the access level of \c foo (\c public in this
-  /// case).
-  ///
-  /// The decl site of \c bar is only "in context" if the access level of the
-  /// decl is \c internal or more restrictive. The context at the decl site is\c
-  /// FileUnit if the decl is \c fileprivate or \c private; \c ModuleDecl if \c
-  /// internal, and null if \c package or \c public.
   bool isInContext() const { return getDeclContext() != nullptr; }
 
   /// Returns the associated access level for diagnostic purposes.

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -230,14 +230,14 @@ struct FragileFunctionKind {
 /// macro context, please see GenericContext for how to minimize new entries in
 /// the ASTHierarchy enum below.
 ///
-/// The hierarchy between DeclContext subclasses is set in their ctors. For example,
-/// FileUnit ctor takes ModuleDecl as its parent DeclContext. The hierarchy from the most
-/// to least restrictive order is:
-///  decl/expr (e.g. ClassDecl) -> FileUnit -> ModuleDecl -> PackageUnit -> nullptr
+/// The hierarchy between DeclContext subclasses is set in their ctors. For
+/// example, FileUnit ctor takes ModuleDecl as its parent DeclContext. The
+/// hierarchy from the most to least restrictive order is:
+/// decl/expr (e.g. ClassDecl) -> FileUnit -> ModuleDecl -> PackageUnit -> nullptr
 ///
-/// There's an exception, however; the parent of ModuleDecl is set nullptr, not set to
-/// PackageUnit; ModuleDecl has a pointer to PackageUnit as its field, and it is treated as
-/// the enclosing scope of ModuleDecl.
+/// There's an exception, however; the parent of ModuleDecl is set nullptr, not
+/// set to PackageUnit; ModuleDecl has a pointer to PackageUnit as its field,
+/// and it is treated as the enclosing scope of ModuleDecl.
 class alignas(1 << DeclContextAlignInBits) DeclContext
     : public ASTAllocated<DeclContext> {
   enum class ASTHierarchy : unsigned {
@@ -332,7 +332,7 @@ public:
   bool isLocalContext() const {
     return getContextKind() <= DeclContextKind::Last_LocalDeclContextKind;
   }
-  
+
   /// \returns true if this is a package context
   LLVM_READONLY
   bool isPackageContext() const; // see swift/AST/Module.h

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -229,6 +229,15 @@ struct FragileFunctionKind {
 /// and therefore can safely access trailing memory. If you need to create a
 /// macro context, please see GenericContext for how to minimize new entries in
 /// the ASTHierarchy enum below.
+///
+/// The hierarchy between DeclContext subclasses is set in their ctors. For example,
+/// FileUnit ctor takes ModuleDecl as its parent DeclContext. The hierarchy from the most
+/// to least restrictive order is:
+///  decl/expr (e.g. ClassDecl) -> FileUnit -> ModuleDecl -> PackageUnit -> nullptr
+///
+/// There's an exception, however; the parent of ModuleDecl is set nullptr, not set to
+/// PackageUnit; ModuleDecl has a pointer to PackageUnit as its field, and it is treated as
+/// the enclosing scope of ModuleDecl.
 class alignas(1 << DeclContextAlignInBits) DeclContext
     : public ASTAllocated<DeclContext> {
   enum class ASTHierarchy : unsigned {
@@ -324,11 +333,7 @@ public:
     return getContextKind() <= DeclContextKind::Last_LocalDeclContextKind;
   }
   
-  /// \returns true if this is a context with package-wide scope, e.g. a package,
-  /// a module, or a source file.
-  LLVM_READONLY
-  bool isPackageScopeContext() const; // see swift/AST/Module.h
-
+  /// \returns true if this is a package context
   LLVM_READONLY
   bool isPackageContext() const; // see swift/AST/Module.h
 
@@ -512,9 +517,11 @@ public:
     return false;
   }
 
-  /// Returns the package context of the parent module.
+  /// Returns the package unit of this context.
+  /// \p lookupIfNotCurrent If the current decl context is not PackageUnit, look
+  /// it up via parent module
   LLVM_READONLY
-  PackageUnit *getParentModulePackage() const;
+  PackageUnit *getPackageContext(bool lookupIfNotCurrent = false) const;
 
   /// Returns the module context that contains this context.
   LLVM_READONLY

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1679,6 +1679,7 @@ ERROR(access_control_open_bad_decl,none,
 WARNING(access_control_non_objc_open_member,none,
       "non-'@objc' %0 in extensions cannot be overridden; use 'public' instead",
       (DescriptiveDeclKind))
+ERROR(access_control_requires_package_name, none, "decl has a package access level but no -package-name was passed", ())
 
 ERROR(invalid_decl_attribute,none,
       "'%0' attribute cannot be applied to this declaration", (DeclAttribute))

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -343,8 +343,8 @@ public:
     return new (ctx) ModuleDecl(name, ctx, importInfo);
   }
 
-  static ModuleDecl *
-  createMainModule(ASTContext &ctx, Identifier name, ImplicitImportInfo iinfo) {
+  static ModuleDecl *createMainModule(ASTContext &ctx, Identifier name,
+                                      ImplicitImportInfo iinfo) {
     auto *Mod = ModuleDecl::create(name, ctx, iinfo);
     Mod->Bits.ModuleDecl.IsMainModule = true;
     return Mod;

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -963,12 +963,6 @@ public:
       if (D->hasAccess()) {
         PrettyStackTraceDecl debugStack("verifying access", D);
         if (!D->getASTContext().isAccessControlDisabled()) {
-          if (D->getFormalAccessScope().isPackage() &&
-              D->getFormalAccess() < AccessLevel::Package) {
-            Out << "non-package decl has no formal access scope\n";
-            D->dump(Out);
-            abort();
-          }
           if (D->getFormalAccessScope().isPublic() &&
               D->getFormalAccess() < AccessLevel::Public) {
             Out << "non-public decl has no formal access scope\n";

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3926,7 +3926,7 @@ getAccessScopeForFormalAccess(const ValueDecl *VD,
   case AccessLevel::Internal:
     return AccessScope(resultDC->getParentModule());
   case AccessLevel::Package: {
-    auto pkg = resultDC->getPackageContext(/*lookupIfNotCurrent*/true);
+    auto pkg = resultDC->getPackageContext(/*lookupIfNotCurrent*/ true);
     if (!pkg) {
       auto &d = VD->getASTContext().Diags;
       d.diagnose(VD->getLoc(), diag::access_control_requires_package_name);
@@ -3966,18 +3966,19 @@ ValueDecl::getFormalAccessScope(const DeclContext *useDC,
 /// The use site of `Foo`is a function `myFunc`, and its DeclContext (useDC)
 /// is FileUnit. The call \c getAccessScopeForFormalAccess inside this function
 /// to get the access scope of`Foo` returns a public scope based on its `public`
-/// access level, which is a wrapper around a nullptr DeclContext. Note that the useDC
-/// is still non-null (FileUnit) even though the use site itself also has a `public` acess
-/// level.
+/// access level, which is a wrapper around a nullptr DeclContext. Note that the
+/// useDC is still non-null (FileUnit) even though the use site itself also has
+/// a `public` acess level.
 ///
-/// The `isChildOf` call compares the DeclContext hierarchy of the use site (useDC)
-/// and the decl (VD) site, and returns true in this case, since FileUnit is a child of nullptr
-/// based on the DeclContext hierarchy. The hierarchy is created when subclasses of
-/// DeclContext such as FileUnit or ModuleDecl are constructed. For example, FileUnit
-/// ctor takes ModuleDecl as its parent DeclContext. There's an exception, however; the
-/// parent of ModuleDecl is nullptr, not set to PackageUnit; ModuleDecl has a pointer to
-/// PackageUnit as its field, and it is treated as the enclosing scope of ModuleDecl in the
-/// `isChildOf` call.
+/// The `isChildOf` call compares the DeclContext hierarchy of the use site
+/// (useDC) and the decl (VD) site, and returns true in this case, since
+/// FileUnit is a child of nullptr based on the DeclContext hierarchy. The
+/// hierarchy is created when subclasses of DeclContext such as FileUnit or
+/// ModuleDecl are constructed. For example, FileUnit ctor takes ModuleDecl as
+/// its parent DeclContext. There's an exception, however; the parent of
+/// ModuleDecl is nullptr, not set to PackageUnit; ModuleDecl has a pointer to
+/// PackageUnit as its field, and it is treated as the enclosing scope of
+/// ModuleDecl in the `isChildOf` call.
 ///
 /// \see DeclContext::ASTHierarchy
 /// \see AccessScope::getAccessScopeForFormalAccess
@@ -4113,8 +4114,8 @@ static bool checkAccess(const DeclContext *useDC, const ValueDecl *VD,
     return useSF && useSF->hasTestableOrPrivateImport(access, sourceModule);
   }
   case AccessLevel::Package: {
-    auto srcPkg = sourceDC->getPackageContext(/*lookupIfNotCurrent*/true);
-    auto usePkg = useDC->getPackageContext(/*lookupIfNotCurrent*/true);
+    auto srcPkg = sourceDC->getPackageContext(/*lookupIfNotCurrent*/ true);
+    auto usePkg = useDC->getPackageContext(/*lookupIfNotCurrent*/ true);
     return usePkg->isSamePackageAs(srcPkg);
   }
   case AccessLevel::Public:

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3773,6 +3773,10 @@ static AccessLevel getAdjustedFormalAccess(const ValueDecl *VD,
   }
 
   if (useDC) {
+    // If the use site decl context is PackageUnit, just return
+    // the access level that's passed in
+    if (auto usePkg = useDC->getPackageContext())
+      return access;
     // Check whether we need to modify the access level based on
     // @testable/@_private import attributes.
     auto *useSF = dyn_cast<SourceFile>(useDC->getModuleScopeContext());
@@ -3883,13 +3887,11 @@ getAccessScopeForFormalAccess(const ValueDecl *VD,
   while (!resultDC->isModuleScopeContext()) {
     if (isa<TopLevelCodeDecl>(resultDC)) {
       return AccessScope(resultDC->getModuleScopeContext(),
-                         access == AccessLevel::Private
-                             ? AccessLimitKind::Private
-                             : AccessLimitKind::None);
+                         access == AccessLevel::Private);
     }
 
     if (resultDC->isLocalContext() || access == AccessLevel::Private)
-      return AccessScope(resultDC, AccessLimitKind::Private);
+      return AccessScope(resultDC, /*private*/ true);
 
     if (auto enclosingNominal = dyn_cast<GenericTypeDecl>(resultDC)) {
       auto enclosingAccess =
@@ -3920,13 +3922,17 @@ getAccessScopeForFormalAccess(const ValueDecl *VD,
   case AccessLevel::Private:
   case AccessLevel::FilePrivate:
     assert(resultDC->isModuleScopeContext());
-    return AccessScope(resultDC, access == AccessLevel::Private
-                                     ? AccessLimitKind::Private
-                                     : AccessLimitKind::None);
+    return AccessScope(resultDC, access == AccessLevel::Private);
   case AccessLevel::Internal:
     return AccessScope(resultDC->getParentModule());
-  case AccessLevel::Package:
-    return AccessScope::getPackage();
+  case AccessLevel::Package: {
+    auto pkg = resultDC->getPackageContext(/*lookupIfNotCurrent*/true);
+    if (!pkg) {
+      auto &d = VD->getASTContext().Diags;
+      d.diagnose(VD->getLoc(), diag::access_control_requires_package_name);
+    }
+    return AccessScope(pkg);
+  }
   case AccessLevel::Public:
   case AccessLevel::Open:
     return AccessScope::getPublic();
@@ -3948,7 +3954,34 @@ ValueDecl::getFormalAccessScope(const DeclContext *useDC,
 /// Whenever the enclosing context of \p VD is usable from \p useDC, this
 /// should compute the same result as checkAccess, below, but more slowly.
 ///
-/// See ValueDecl::isAccessibleFrom for a description of \p forConformance.
+/// Here's an example while typechecking a file with the following code.
+///
+/// ```
+/// import OtherModule
+///
+/// // `Foo` is a `public` struct defined in `OtherModule`
+/// public func myFunc(_ arg: OtherModule.Foo) {}
+/// ```
+///
+/// The use site of `Foo`is a function `myFunc`, and its DeclContext (useDC)
+/// is FileUnit. The call \c getAccessScopeForFormalAccess inside this function
+/// to get the access scope of`Foo` returns a public scope based on its `public`
+/// access level, which is a wrapper around a nullptr DeclContext. Note that the useDC
+/// is still non-null (FileUnit) even though the use site itself also has a `public` acess
+/// level.
+///
+/// The `isChildOf` call compares the DeclContext hierarchy of the use site (useDC)
+/// and the decl (VD) site, and returns true in this case, since FileUnit is a child of nullptr
+/// based on the DeclContext hierarchy. The hierarchy is created when subclasses of
+/// DeclContext such as FileUnit or ModuleDecl are constructed. For example, FileUnit
+/// ctor takes ModuleDecl as its parent DeclContext. There's an exception, however; the
+/// parent of ModuleDecl is nullptr, not set to PackageUnit; ModuleDecl has a pointer to
+/// PackageUnit as its field, and it is treated as the enclosing scope of ModuleDecl in the
+/// `isChildOf` call.
+///
+/// \see DeclContext::ASTHierarchy
+/// \see AccessScope::getAccessScopeForFormalAccess
+/// \see ValueDecl::isAccessibleFrom for a description of \p forConformance.
 static bool checkAccessUsingAccessScopes(const DeclContext *useDC,
                                          const ValueDecl *VD,
                                          AccessLevel access,
@@ -3964,10 +3997,6 @@ static bool checkAccessUsingAccessScopes(const DeclContext *useDC,
 
   // useDC is null only when caller wants to skip non-public type checks.
   if (!useDC) return true;
-
-  // Check package access; accessing package decl should not be allowed if package names are different
-  if (accessScope.isPackage())
-    return VD->getDeclContext()->getParentModule()->getPackageName() == useDC->getParentModule()->getPackageName();
 
   // Check SPI access
   if (!VD->isSPI()) return true;
@@ -4083,7 +4112,11 @@ static bool checkAccess(const DeclContext *useDC, const ValueDecl *VD,
     auto *useSF = dyn_cast<SourceFile>(useFile);
     return useSF && useSF->hasTestableOrPrivateImport(access, sourceModule);
   }
-  case AccessLevel::Package:
+  case AccessLevel::Package: {
+    auto srcPkg = sourceDC->getPackageContext(/*lookupIfNotCurrent*/true);
+    auto usePkg = useDC->getPackageContext(/*lookupIfNotCurrent*/true);
+    return usePkg->isSamePackageAs(srcPkg);
+  }
   case AccessLevel::Public:
   case AccessLevel::Open:
     return true;

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -274,15 +274,31 @@ DeclContext *DeclContext::getParentForLookup() const {
   return getParent();
 }
 
-PackageUnit *DeclContext::getParentModulePackage() const {
-  auto parentModule = getParentModule();
-  auto pkg = parentModule->getParent();
-  if (pkg)
-    return const_cast<PackageUnit *>(cast<PackageUnit>(pkg));
+PackageUnit *DeclContext::getPackageContext(bool lookupIfNotCurrent) const {
+  // Current decl context might be PackageUnit, which is not in the
+  // DeclContext hierarchy, so check for it first
+  if (isPackageContext())
+    return const_cast<PackageUnit *>(cast<PackageUnit>(this));
+
+  // If the current context is not PackageUnit, look it up via
+  // the parent module if needed
+  if (lookupIfNotCurrent) {
+    auto mdecl = getParentModule();
+    return mdecl->getPackage();
+  }
   return nullptr;
 }
 
 ModuleDecl *DeclContext::getParentModule() const {
+  // If the current context is PackageUnit, return the module
+  // decl context pointing to the current context. This check
+  // needs to be done first as PackageUnit is not in the DeclContext
+  // hierarchy.
+  if (auto pkg = getPackageContext()) {
+    auto &mdecl = pkg->getSourceModule();
+    return &mdecl;
+  }
+
   const DeclContext *DC = this;
   while (!DC->isModuleContext())
     DC = DC->getParent();
@@ -292,7 +308,7 @@ ModuleDecl *DeclContext::getParentModule() const {
 SourceFile *DeclContext::getParentSourceFile() const {
   const DeclContext *DC = this;
   SourceLoc loc;
-  while (!DC->isModuleScopeContext()) {
+  while (DC && !DC->isModuleScopeContext()) {
     // If we don't have a source location yet, try to grab one from this
     // context.
     if (loc.isInvalid()) {
@@ -323,6 +339,9 @@ SourceFile *DeclContext::getParentSourceFile() const {
     DC = DC->getParent();
   }
 
+  if (!DC)
+    return nullptr;
+
   auto fallbackSF = const_cast<SourceFile *>(dyn_cast<SourceFile>(DC));
   if (auto module = DC->getParentModule()) {
     if (auto sf = module->getSourceFileContainingLocation(loc))
@@ -345,15 +364,24 @@ SourceFile *DeclContext::getOutermostParentSourceFile() const {
 }
 
 DeclContext *DeclContext::getModuleScopeContext() const {
-  auto DC = const_cast<DeclContext*>(this);
+  // If the current context is PackageUnit, return the module
+  // decl context pointing to the current context. This check
+  // needs to be done first as PackageUnit is not in the DeclContext
+  // hierarchy.
+  if (auto pkg = getPackageContext()) {
+    auto &mdecl = pkg->getSourceModule();
+    return &mdecl;
+  }
 
+  auto DC = const_cast<DeclContext *>(this);
   while (true) {
     if (DC->ParentAndKind.getInt() == ASTHierarchy::FileUnit)
       return DC;
     if (auto NextDC = DC->getParent()) {
       DC = NextDC;
     } else {
-      assert(isa<ModuleDecl>(DC->getAsDecl()));
+      assert(DC && isa<ModuleDecl>(DC->getAsDecl()) &&
+             "no module decl context found!");
       return DC;
     }
   }
@@ -1213,13 +1241,11 @@ getPrivateDeclContext(const DeclContext *DC, const SourceFile *useSF) {
   return lastExtension ? lastExtension : DC;
 }
 
-AccessScope::AccessScope(const DeclContext *DC, AccessLimitKind limitKind)
-    : Value(DC, limitKind) {
-  auto isPrivate = false;
-  if (limitKind == AccessLimitKind::Private) {
+AccessScope::AccessScope(const DeclContext *DC, bool isPrivate)
+    : Value(DC, isPrivate) {
+  if (isPrivate) {
     DC = getPrivateDeclContext(DC, DC->getParentSourceFile());
     Value.setPointer(DC);
-    isPrivate = true;
   }
   if (!DC || isa<ModuleDecl>(DC) || isa<PackageUnit>(DC))
     assert(!isPrivate && "public, package, or internal scope can't be private");
@@ -1233,6 +1259,11 @@ bool AccessScope::isFileScope() const {
 bool AccessScope::isInternal() const {
   auto DC = getDeclContext();
   return DC && isa<ModuleDecl>(DC);
+}
+
+bool AccessScope::isPackage() const {
+  auto DC = getDeclContext();
+  return DC && isa<PackageUnit>(DC);
 }
 
 AccessLevel AccessScope::accessLevelForDiagnostics() const {
@@ -1254,6 +1285,14 @@ bool AccessScope::allowsPrivateAccess(const DeclContext *useDC, const DeclContex
   if (useDC->isChildContextOf(sourceDC))
     return true;
 
+  // If the decl site has package acl, but the use site
+  // has internal or less acl, check if it belongs to
+  // the same package as the decl site's to allow access.
+  if (auto srcPkg = sourceDC->getPackageContext()) {
+    if (auto usePkg = useDC->getPackageContext(/*lookupIfNotCurrent*/true)) {
+      return usePkg->isSamePackageAs(srcPkg);
+    }
+  }
   // Do not allow access if the sourceDC is in a different file
   auto useSF = useDC->getParentSourceFile();
   if (useSF != sourceDC->getParentSourceFile())

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -1289,7 +1289,7 @@ bool AccessScope::allowsPrivateAccess(const DeclContext *useDC, const DeclContex
   // has internal or less acl, check if it belongs to
   // the same package as the decl site's to allow access.
   if (auto srcPkg = sourceDC->getPackageContext()) {
-    if (auto usePkg = useDC->getPackageContext(/*lookupIfNotCurrent*/true)) {
+    if (auto usePkg = useDC->getPackageContext(/*lookupIfNotCurrent*/ true)) {
       return usePkg->isSamePackageAs(srcPkg);
     }
   }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -543,19 +543,13 @@ void SourceLookupCache::invalidate() {
   (void)SameSizeSmallVector{std::move(AllVisibleValues)};
 }
 
-PackageUnit::PackageUnit(Identifier name)
-  : DeclContext(DeclContextKind::Package, nullptr) {
-    PackageName = name;
-}
-
 //===----------------------------------------------------------------------===//
 // Module Implementation
 //===----------------------------------------------------------------------===//
 
 ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx,
-                       ImplicitImportInfo importInfo,
-                       PackageUnit *pkg = nullptr)
-    : DeclContext(DeclContextKind::Module, pkg),
+                       ImplicitImportInfo importInfo)
+    : DeclContext(DeclContextKind::Module, nullptr),
       TypeDecl(DeclKind::Module, &ctx, name, SourceLoc(), {}),
       ImportInfo(importInfo) {
 
@@ -3066,6 +3060,10 @@ SourceFile::getImportAccessLevel(const ModuleDecl *targetModule) const {
   }
 
   return restrictiveImport;
+}
+
+void ModuleDecl::setPackageName(Identifier name) {
+  Package = PackageUnit::create(name, *this, getASTContext());
 }
 
 bool ModuleDecl::isImportedImplementationOnly(const ModuleDecl *module) const {

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2285,7 +2285,8 @@ static void checkExtensionGenericParamAccess(const ExtensionDecl *ED) {
     desiredAccessScope = AccessScope(ED->getModuleContext());
     break;
   case AccessLevel::Package:
-    desiredAccessScope = AccessScope(ED->getPackageContext(/*lookupIfNotCurrent*/true));
+    desiredAccessScope =
+        AccessScope(ED->getPackageContext(/*lookupIfNotCurrent*/ true));
     break;
   case AccessLevel::Public:
   case AccessLevel::Open:

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -2278,15 +2278,14 @@ static void checkExtensionGenericParamAccess(const ExtensionDecl *ED) {
   case AccessLevel::FilePrivate: {
     const DeclContext *DC = ED->getModuleScopeContext();
     bool isPrivate = (userSpecifiedAccess == AccessLevel::Private);
-    desiredAccessScope = AccessScope(DC, isPrivate ? AccessLimitKind::Private
-                                                   : AccessLimitKind::None);
+    desiredAccessScope = AccessScope(DC, isPrivate);
     break;
   }
   case AccessLevel::Internal:
     desiredAccessScope = AccessScope(ED->getModuleContext());
     break;
   case AccessLevel::Package:
-    desiredAccessScope = AccessScope::getPackage();
+    desiredAccessScope = AccessScope(ED->getPackageContext(/*lookupIfNotCurrent*/true));
     break;
   case AccessLevel::Public:
   case AccessLevel::Open:

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -enable-objc-interop -disable-objc-attr-requires-foundation-module -swift-version 5
+// RUN: %target-typecheck-verify-swift -enable-objc-interop -disable-objc-attr-requires-foundation-module -swift-version 5 -package-name mylib
 
 /// Test structs with protocols and extensions
 public protocol PublicProto {
@@ -1021,8 +1021,8 @@ public struct PublicWithInternalSettersConformPublic : PublicMutationOperations 
 }
 
 public struct PublicWithPackageSettersConformPublic : PublicMutationOperations {
-  public package(set) var size = 0 // FIXME: rdar://104987295 this should error
-  public package(set) subscript (_: Int) -> Int { // FIXME: rdar://104987295 this should error
+  public package(set) var size = 0 // expected-error {{setter for property 'size' must be declared public because it matches a requirement in public protocol 'PublicMutationOperations'}} {{none}} expected-note {{mark the property as 'public' to satisfy the requirement}} {{10-23=}}
+  public package(set) subscript (_: Int) -> Int { // expected-error {{subscript setter must be declared public because it matches a requirement in public protocol 'PublicMutationOperations'}} {{none}} expected-note {{mark the subscript as 'public' to satisfy the requirement}} {{10-23=}}
     get { return 42 }
     set {}
   }


### PR DESCRIPTION
* Create PackageUnit when package-name input is non-nil as a property of ModuleDecl  
* Treat PackageUnit as the enclosing scope of ModuleDecl 
* Create an access scope with PackageUnit as context for the `package` access level 
* Add a PackageUnit context check in access scope functions
* Return Module Decl from PackageUnit context (weakly referenced) in `DeclContext::getModuleScopeContext` and `DeclContext::getParentModule` to avoid breaking existing code
* Add doc comments and fix tests

Resolves rdar://104987295,  rdar://105187216, rdar://104723918
