### PR TITLE
Fix a bunch of problems with SILGen of tuples with pack expansions

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2456,15 +2456,30 @@ BEGIN_CAN_TYPE_WRAPPER(TupleType, Type)
     return containsPackExpansionTypeImpl(*this);
   }
 
+  /// Induce a pack type from the elements of this tuple type.
+  inline CanTypeWrapper<PackType> getInducedPackType() const;
+
   /// Induce a pack type from a range of the elements of this tuple type.
   inline CanTypeWrapper<PackType>
   getInducedPackType(unsigned start, unsigned count) const;
+
+  /// Induce a formal pack type with the same shape as the elements
+  /// of this lowered tuple type, making a best effort to use the same
+  /// element types.
+  inline CanTypeWrapper<PackType>
+  getInducedApproximateFormalPackType() const;
 
 private:
   static bool containsPackExpansionTypeImpl(CanTupleType tuple);
 
   static CanTypeWrapper<PackType>
+  getInducedPackTypeImpl(CanTupleType tuple);
+
+  static CanTypeWrapper<PackType>
   getInducedPackTypeImpl(CanTupleType tuple, unsigned start, unsigned count);
+
+  static CanTypeWrapper<PackType>
+  getInducedApproximateFormalPackTypeImpl(CanTupleType tuple);
 END_CAN_TYPE_WRAPPER(TupleType, Type)
 
 /// UnboundGenericType - Represents a generic type where the type arguments have
@@ -5355,6 +5370,11 @@ public:
   /// as the shape, not a SIL pack type.
   CanTypeWrapper<PackType> getReducedShape() const;
 
+  /// Construct a formal pack type with the same shape as this
+  /// lowered pack type, making a best effort to use the same element
+  /// types.
+  CanTypeWrapper<PackType> getApproximateFormalPackType() const;
+
   bool containsPackExpansionType() const;
 
   void Profile(llvm::FoldingSetNodeID &ID) const {
@@ -6841,9 +6861,18 @@ BEGIN_CAN_TYPE_WRAPPER(PackType, Type)
   }
 END_CAN_TYPE_WRAPPER(PackType, Type)
 
+inline CanPackType CanTupleType::getInducedPackType() const {
+  return getInducedPackTypeImpl(*this);
+}
+
 inline CanPackType
 CanTupleType::getInducedPackType(unsigned start, unsigned end) const {
   return getInducedPackTypeImpl(*this, start, end);
+}
+
+inline CanPackType
+CanTupleType::getInducedApproximateFormalPackType() const {
+  return getInducedApproximateFormalPackTypeImpl(*this);
 }
 
 /// PackExpansionType - The interface type of the explicit expansion of a

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1333,6 +1333,8 @@ public:
     llvm_unreachable("bad kind");
   }
 
+  bool doesTupleContainPackExpansionType() const;
+
   static AbstractionPattern
   projectTupleElementType(const AbstractionPattern *base, size_t index) {
     return base->getTupleElementType(index);

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1675,6 +1675,9 @@ public:
                                                SILValue Operand,
                                                unsigned FieldNo,
                                                SILType ResultTy) {
+    assert(!Operand->getType().castTo<TupleType>().containsPackExpansionType()
+           && "tuples with pack expansions must be indexed with "
+              "tuple_pack_element_addr");
     return insert(new (getModule()) TupleElementAddrInst(
         getSILDebugLocation(Loc), Operand, FieldNo, ResultTy));
   }

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -531,6 +531,14 @@ public:
     return SILType(castTo<TupleType>().getElementType(index), getCategory());
   }
 
+  /// Given that this is a pack expansion type, return the lowered type
+  /// of the pattern type.  The result will have the same value category
+  /// as the base type.
+  SILType getPackExpansionPatternType() const {
+    return SILType(castTo<PackExpansionType>().getPatternType(),
+                   getCategory());
+  }
+
   /// Return the immediate superclass type of this type, or null if
   /// it's the most-derived type.
   SILType getSuperclass() const {

--- a/lib/IRGen/GenPack.cpp
+++ b/lib/IRGen/GenPack.cpp
@@ -1023,8 +1023,10 @@ StackAddress irgen::allocatePack(IRGenFunction &IGF, CanSILPackType packType) {
         IGF.IGM.OpaquePtrTy, elementCount);
 
     auto addr = IGF.createAlloca(allocType, IGF.IGM.getPointerAlignment());
-    IGF.Builder.CreateLifetimeStart(addr,
-                                elementSize * elementCount);
+    IGF.Builder.CreateLifetimeStart(addr, elementSize * elementCount);
+
+    // We have an [N x opaque*]*; we need an opaque**.
+    addr = IGF.Builder.CreateElementBitCast(addr, IGF.IGM.OpaquePtrTy);
     return addr;
   }
 

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -430,6 +430,40 @@ AbstractionPattern::getTupleElementType(unsigned index) const {
   llvm_unreachable("bad kind");
 }
 
+bool AbstractionPattern::doesTupleContainPackExpansionType() const {
+  switch (getKind()) {
+  case Kind::Invalid:
+    llvm_unreachable("querying invalid abstraction pattern!");
+  case Kind::Opaque:
+  case Kind::PartialCurriedObjCMethodType:
+  case Kind::CurriedObjCMethodType:
+  case Kind::CFunctionAsMethodType:
+  case Kind::CurriedCFunctionAsMethodType:
+  case Kind::PartialCurriedCFunctionAsMethodType:
+  case Kind::ObjCMethodType:
+  case Kind::CXXMethodType:
+  case Kind::CurriedCXXMethodType:
+  case Kind::PartialCurriedCXXMethodType:
+  case Kind::OpaqueFunction:
+  case Kind::OpaqueDerivativeFunction:
+    llvm_unreachable("pattern is not a tuple");
+  case Kind::Tuple: {
+    for (auto &elt : llvm::makeArrayRef(OrigTupleElements,
+                                        getNumTupleElements_Stored())) {
+      if (elt.isPackExpansion())
+        return true;
+    }
+    return true;
+  }
+  case Kind::ObjCCompletionHandlerArgumentsType:
+  case Kind::Type:
+  case Kind::Discard:
+  case Kind::ClangType:
+    return cast<TupleType>(getType()).containsPackExpansionType();
+  }
+  llvm_unreachable("bad kind");
+}
+
 static CanType getCanPackElementType(CanType type, unsigned index) {
   return cast<PackType>(type).getElementType(index);
 }

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1705,7 +1705,7 @@ private:
           packElts.push_back(eltTy.getASTType());
         });
 
-        bool indirect = origType.arePackElementsPassedIndirectly(TC);
+        bool indirect = origEltType.arePackElementsPassedIndirectly(TC);
         SILPackType::ExtInfo extInfo(/*address*/ indirect);
         auto packTy = SILPackType::get(TC.Context, extInfo, packElts);
 

--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -338,6 +338,10 @@ public:
 
   ManagedValue clone(SILValue value) const;
 
+  ManagedValue cloneForTuplePackExpansionComponent(SILValue value,
+                                                   CanPackType inducedPackType,
+                                                   unsigned componentIndex) const;
+
   static void
   getClonersForRValue(SILGenFunction &SGF, const RValue &rvalue,
                       SmallVectorImpl<CleanupCloner> &resultingCloners);

--- a/lib/SILGen/Initialization.h
+++ b/lib/SILGen/Initialization.h
@@ -330,13 +330,16 @@ public:
 /// An initialization which accumulates several other initializations
 /// into a tuple.
 class TupleInitialization : public Initialization {
+  CanTupleType FormalTupleType;
+
 public:
   /// The sub-Initializations aggregated by this tuple initialization.
   /// The TupleInitialization object takes ownership of Initializations pushed
   /// here.
   SmallVector<InitializationPtr, 4> SubInitializations;
-    
-  TupleInitialization() {}
+
+  TupleInitialization(CanTupleType formalTupleType)
+    : FormalTupleType(formalTupleType) {}
 
   bool canSplitIntoTupleElements() const override {
     return true;

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -506,9 +506,7 @@ public:
 
     // Loop over the pack, initializing each value with the appropriate
     // element.
-    SGF.emitDynamicPackLoop(loc, FormalPackType, ComponentIndex,
-                            /*limit*/SILValue(), openedEnv,
-                            /*reverse*/false,
+    SGF.emitDynamicPackLoop(loc, FormalPackType, ComponentIndex, openedEnv,
                             [&](SILValue indexWithinComponent,
                                 SILValue expansionIndex,
                                 SILValue packIndex) {
@@ -1203,9 +1201,7 @@ ResultPlanBuilder::buildPackExpansionIntoPack(SILValue packAddr,
   // If the expansion addresses can just be forwarded into the pack,
   // we can emit a dynamic loop to do that now.
   if (init->canPerformInPlacePackInitialization(openedEnv, eltTy)) {
-    SGF.emitDynamicPackLoop(loc, formalPackType, componentIndex,
-                            /*limit*/ SILValue(), openedEnv,
-                            /*reverse*/ false,
+    SGF.emitDynamicPackLoop(loc, formalPackType, componentIndex, openedEnv,
                             [&](SILValue indexWithinComponent,
                                 SILValue expansionPackIndex,
                                 SILValue packIndex) {
@@ -1226,8 +1222,7 @@ ResultPlanBuilder::buildPackExpansionIntoPack(SILValue packAddr,
   auto tupleAddr = SGF.emitTemporaryAllocation(loc,
                                     SILType::getPrimitiveObjectType(tupleTy));
 
-  SGF.emitDynamicPackLoop(loc, formalPackType, componentIndex,
-                          /*limit*/ SILValue(), openedEnv, /*reverse*/ false,
+  SGF.emitDynamicPackLoop(loc, formalPackType, componentIndex, openedEnv,
                           [&](SILValue indexWithinComponent,
                               SILValue expansionPackIndex,
                               SILValue packIndex) {

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3809,8 +3809,7 @@ private:
 
     auto openedElementEnv = expansionExpr->getGenericEnvironment();
     SGF.emitDynamicPackLoop(expansionExpr, formalPackType,
-                            packComponentIndex, /*limit*/ nullptr,
-                            openedElementEnv, /*reverse*/false,
+                            packComponentIndex, openedElementEnv,
                             [&](SILValue indexWithinComponent,
                                 SILValue packExpansionIndex,
                                 SILValue packIndex) {

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1062,7 +1062,8 @@ emitMemberInit(SILGenFunction &SGF, VarDecl *selfDecl, Pattern *pattern) {
                           cast<ParenPattern>(pattern)->getSubPattern());
 
   case PatternKind::Tuple: {
-    TupleInitialization *init = new TupleInitialization();
+    TupleInitialization *init = new TupleInitialization(
+        cast<TupleType>(pattern->getType()->getCanonicalType()));
     auto tuple = cast<TuplePattern>(pattern);
     for (auto &elt : tuple->getElements()) {
       init->SubInitializations.push_back(

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1541,8 +1541,7 @@ RValueEmitter::visitPackExpansionExpr(PackExpansionExpr *E,
   auto formalPackType = CanPackType::get(SGF.getASTContext(), {type});
 
   SGF.emitDynamicPackLoop(E, formalPackType, /*component index*/ 0,
-                          /*limit within component*/ SILValue(),
-                          E->getGenericEnvironment(), /*reverse*/ false,
+                          E->getGenericEnvironment(),
                           [&](SILValue indexWithinComponent,
                               SILValue packExpansionIndex,
                               SILValue packIndex) {
@@ -6210,8 +6209,7 @@ static void emitIgnoredPackExpansion(SILGenFunction &SGF,
   auto formalPackType = CanPackType::get(SGF.getASTContext(), expansionType);
   auto openedElementEnv = E->getGenericEnvironment();
   SGF.emitDynamicPackLoop(E, formalPackType, /*component index*/ 0,
-                          /*limit*/ SILValue(), openedElementEnv,
-                          /*reverse*/ false,
+                          openedElementEnv,
                           [&](SILValue indexWithinComponent,
                               SILValue packExpansionIndex,
                               SILValue packIndex) {

--- a/lib/SILGen/SILGenStmt.cpp
+++ b/lib/SILGen/SILGenStmt.cpp
@@ -587,7 +587,7 @@ prepareIndirectResultInit(SILGenFunction &SGF, SILLocation loc,
   // Recursively decompose tuple abstraction patterns.
   if (origResultType.isTuple()) {
     auto resultTupleType = cast<TupleType>(resultType);
-    auto tupleInit = new TupleInitialization();
+    auto tupleInit = new TupleInitialization(resultTupleType);
     tupleInit->SubInitializations.reserve(resultTupleType->getNumElements());
 
     size_t nextResultEltIndex = 0;

--- a/test/IRGen/variadic_generics.sil
+++ b/test/IRGen/variadic_generics.sil
@@ -131,6 +131,7 @@ exit:
 // CHECK-LABEL: define {{.*}}@test_pack_alloc_2_static
 // CHECK:         [[STACK:%[^,]+]] = alloca [2 x %swift.opaque*]
 // CHECK:         call void @llvm.lifetime.start.p0i8
+// CHECK:         [[CAST:%.*]] = bitcast [2 x %swift.opaque*]* [[STACK]] to %swift.opaque**
 // CHECK:         call void @llvm.lifetime.end.p0i8
 sil @test_pack_alloc_2_static : $<each T> () -> () {
   %addr = alloc_pack $Pack{Int, Int}

--- a/test/SILGen/variadic-generic-tuples.swift
+++ b/test/SILGen/variadic-generic-tuples.swift
@@ -33,3 +33,82 @@ func takeAny(_ arg: Any) {}
 func testIgnoredTuple<each T>(_ args: repeat each T) {
   (repeat takeAny(each args))
 }
+
+public struct Stored<Value> {}
+
+public struct Container<each T> {
+  public var storage: (repeat Stored<each T>)
+
+  public init() {
+    self.storage = (repeat Stored<each T>())
+  }
+}
+
+//   Getter for Container.storage
+// CHECK-LABEL: sil {{.*}}@$s4main9ContainerV7storageAA6StoredVyxGxQp_tvg
+// CHECK-SAME:    $@convention(method) <each T> (@in_guaranteed Container<repeat each T>) -> @pack_out Pack{repeat Stored<each T>}
+// CHECK:         [[FIELD:%.*]] = struct_element_addr %1 : $*Container<repeat each T>, #Container.storage
+//   Copy the field into a temporary for some reason?
+// CHECK-NEXT:    [[FIELD_COPY:%.*]] = alloc_stack $(repeat Stored<each T>)
+// CHECK-NEXT:    copy_addr [[FIELD]] to [init] [[FIELD_COPY]] : $*(repeat Stored<each T>)
+//   Pack loop to copy into the @pack_out parameter.
+// CHECK-NEXT:    [[ZERO:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK-NEXT:    [[ONE:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK-NEXT:    [[LEN:%.*]] = pack_length $Pack{repeat each T}
+// CHECK-NEXT:    br bb1([[ZERO]] : $Builtin.Word)
+// CHECK:       bb1([[IDX:%.*]] : $Builtin.Word)
+// CHECK-NEXT:    [[IDX_EQ_LEN:%.*]] = builtin "cmp_eq_Word"([[IDX]] : $Builtin.Word, [[LEN]] : $Builtin.Word) : $Builtin.Int1
+// CHECK-NEXT:     cond_br [[IDX_EQ_LEN]], bb3, bb2
+// CHECK:       bb2:
+// CHECK-NEXT:    [[INDEX:%.*]] = dynamic_pack_index [[IDX]] of $Pack{repeat Stored<each T>}
+// CHECK-NEXT:    open_pack_element [[INDEX]] of <each T> at <Pack{repeat each T}>, shape $T, uuid [[UUID:".*"]]
+// CHECK-NEXT:    [[OUT_ELT_ADDR:%.*]] = pack_element_get [[INDEX]] of %0 : $*Pack{repeat Stored<each T>} as $*Stored<@pack_element([[UUID]]) T>
+// CHECK-NEXT:    [[FIELD_ELT_ADDR:%.*]] = tuple_pack_element_addr [[INDEX]] of [[FIELD_COPY]] : $*(repeat Stored<each T>) as $*Stored<@pack_element([[UUID]]) T>
+// CHECK-NEXT:    [[ELT_VALUE:%.*]] = load [trivial] [[FIELD_ELT_ADDR]] : $*Stored<@pack_element([[UUID]]) T>
+// CHECK-NEXT:    store [[ELT_VALUE]] to [trivial] [[OUT_ELT_ADDR]] : $*Stored<@pack_element([[UUID]]) T>
+// CHECK-NEXT:    [[NEXT_IDX:%.*]] = builtin "add_Word"([[IDX]] : $Builtin.Word, [[ONE]] : $Builtin.Word) : $Builtin.Word
+// CHECK-NEXT:    br bb1([[NEXT_IDX]] : $Builtin.Word)
+// CHECK:       bb3:
+//   Clean up.
+// CHECK-NEXT:    dealloc_stack [[FIELD_COPY]] : $*(repeat Stored<each T>)
+// CHECK-NEXT:    [[RET:%.*]] = tuple ()
+// CHECK-NEXT:    return [[RET]] : $()
+
+//   Setter for Container.storage
+// CHECK-LABEL: sil {{.*}}@$s4main9ContainerV7storageAA6StoredVyxGxQp_tvs
+// CHECK-SAME:    $@convention(method) <each T> (@pack_owned Pack{repeat Stored<each T>}, @inout Container<repeat each T>) -> () 
+//   Materialize the pack into a local tuple.
+// CHECK:         [[ARG_COPY:%.*]] = alloc_stack $(repeat Stored<each T>), let,
+// CHECK-NEXT:    [[ZERO:%.*]] = integer_literal $Builtin.Word, 0
+// CHECK-NEXT:    [[ONE:%.*]] = integer_literal $Builtin.Word, 1
+// CHECK-NEXT:    [[LEN:%.*]] = pack_length $Pack{repeat each T}
+// CHECK-NEXT:    br bb1([[ZERO]] : $Builtin.Word)
+// CHECK:       bb1([[IDX:%.*]] : $Builtin.Word)
+// CHECK-NEXT:    [[IDX_EQ_LEN:%.*]] = builtin "cmp_eq_Word"([[IDX]] : $Builtin.Word, [[LEN]] : $Builtin.Word) : $Builtin.Int1
+// CHECK-NEXT:     cond_br [[IDX_EQ_LEN]], bb3, bb2
+// CHECK:       bb2:
+// CHECK-NEXT:    [[INDEX:%.*]] = dynamic_pack_index [[IDX]] of $Pack{repeat Stored<each T>}
+// CHECK-NEXT:    open_pack_element [[INDEX]] of <each T> at <Pack{repeat each T}>, shape $T, uuid [[UUID:".*"]]
+// CHECK-NEXT:    [[ARG_COPY_ELT_ADDR:%.*]] = tuple_pack_element_addr [[INDEX]] of [[ARG_COPY]] : $*(repeat Stored<each T>) as $*Stored<@pack_element([[UUID]]) T>
+// CHECK-NEXT:    [[PACK_ELT_ADDR:%.*]] = pack_element_get [[INDEX]] of %0 : $*Pack{repeat Stored<each T>} as $*Stored<@pack_element([[UUID]]) T>
+// CHECK-NEXT:    [[ELT_VALUE:%.*]] = load [trivial] [[PACK_ELT_ADDR]] : $*Stored<@pack_element([[UUID]]) T>
+// CHECK-NEXT:    store [[ELT_VALUE]] to [trivial] [[ARG_COPY_ELT_ADDR]] : $*Stored<@pack_element([[UUID]]) T>
+// CHECK-NEXT:    [[NEXT_IDX:%.*]] = builtin "add_Word"([[IDX]] : $Builtin.Word, [[ONE]] : $Builtin.Word) : $Builtin.Word
+// CHECK-NEXT:    br bb1([[NEXT_IDX]] : $Builtin.Word)
+// CHECK:       bb3:
+// CHECK-NEXT:    debug_value
+//   Copy the local tuple for some reason?
+// CHECK-NEXT:    [[COPY2:%.*]] = alloc_stack $(repeat Stored<each T>)
+// CHECK-NEXT:    copy_addr [[ARG_COPY]] to [init] [[COPY2]] : $*(repeat Stored<each T>)
+//   Finally, the actual assignment.
+// CHECK-NEXT:    [[ACCESS:%.*]] = begin_access [modify] [unknown] %1 :
+// CHECK-NEXT:    [[FIELD:%.*]] = struct_element_addr [[ACCESS]] : $*Container<repeat each T>, #Container.storage
+// CHECK-NEXT:    copy_addr [take] [[COPY2]] to [[FIELD]] : $*(repeat Stored<each T>)
+// CHECK-NEXT:    end_access [[ACCESS]]
+//   Clean up.
+// CHECK-NEXT:    dealloc_stack [[COPY2]]
+// CHECK-NEXT:    dealloc_stack [[ARG_COPY]]
+// CHECK-NEXT:    [[RET:%.*]] = tuple ()
+// CHECK-NEXT:    return [[RET]] : $()
+
+// CHECK-LABEL: sil {{.*}}@$s4main9ContainerV7storageAA6StoredVyxGxQp_tvM


### PR DESCRIPTION
There are two main bugs being fixed in this PR:

- The first is that the `RValue` abstraction in SILGen was trying to eagerly expand these tuples, which really doesn't work — not only are the instructions it's using not really appropriate for these tuples, there's also just no simple value representation of a pack expansion that can stand in here.  Maybe in the long term we'll have value representations, but in the short term, the only reasonable choice seems to be to prevent this expansion.  I don't hate that anyway; I've never been a fan of the eager expansion.

- The second is that the way we were binding parameters didn't work for tuples that contain pack expansions.  The current CC recursively expands these tuples and passes expansions as value packs, and the parameter-binding code has to glue everything back together as a tuple.  That gluing-together did not know about pack expansions and the different code patterns that have to be used with them.  So there was quite a bit of infrastructure that needed to be fleshed out here.