### PR TITLE
Add back `createUniqueName` to ASTGen

### DIFF
--- a/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
+++ b/lib/ASTGen/Sources/ASTGen/SourceManager+MacroExpansionContext.swift
@@ -52,6 +52,10 @@ extension String {
 }
 
 extension SourceManager.MacroExpansionContext: MacroExpansionContext {
+  public func createUniqueName(_ providedName: String) -> TokenSyntax {
+    makeUniqueName(providedName)
+  }
+
   /// Generate a unique name for use in the macro.
   public func makeUniqueName(_ providedName: String) -> TokenSyntax {
     // If provided with an empty name, substitute in something.


### PR DESCRIPTION
Add back `createUniqueName` to ASTGen to work around an incremental build failure introduced by #1367 and #63962.