### PR TITLE
[android][test] Disable a SwiftToCxx Interop test that fails with clang 14 in the current LTS NDK 25

### DIFF
--- a/test/Interop/SwiftToCxx/core/unsigned-return-type-no-zext.cpp
+++ b/test/Interop/SwiftToCxx/core/unsigned-return-type-no-zext.cpp
@@ -4,6 +4,7 @@
 // RUN: %FileCheck %s < %t/ir.ll
 
 // UNSUPPORTED: OS=windows-msvc
+// XFAIL: OS=linux-android, OS=linux-androideabi
 
 unsigned char getEnumTagi8(void *p);
 unsigned getEnumTagi32(void *p);


### PR DESCRIPTION
Marking as expected to fail so it's enabled again once we update the NDK and have a new clang

As explained in #64172, this fails since the rebranch updated this test to work with a newer clang, so disabling to get [the Android community CI passing again](https://ci-external.swift.org/job/oss-swift-RA-linux-ubuntu-16.04-android-arm64/lastFailedBuild/console), and we can reenable once the NDK has a compatible clang later.

@hyp or @drodriguez, please review.