### PR TITLE
unittests: attempt to repair the unified build

### DIFF
--- a/unittests/ClangImporter/CMakeLists.txt
+++ b/unittests/ClangImporter/CMakeLists.txt
@@ -1,4 +1,5 @@
-configure_file(${CMAKE_SOURCE_DIR}/stdlib/public/Cxx/std/libstdcxx.modulemap ${CMAKE_CURRENT_BINARY_DIR}/libstdcxx.modulemap COPYONLY)
+configure_file(${SWIFT_SOURCE_DIR}/stdlib/public/Cxx/std/libstdcxx.modulemap
+  ${CMAKE_CURRENT_BINARY_DIR}/libstdcxx.modulemap COPYONLY)
 
 add_swift_unittest(SwiftClangImporterTests
   ClangImporterTests.cpp


### PR DESCRIPTION
This is a speculative fix for the unified build which was broken by PR #64177 as the `CMAKE_SOURCE_DIR` is going to point to LLVM not Swift.