### PR TITLE
[Sema] Improve the note on imports with an access-level when it causes an error

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2111,6 +2111,11 @@ ERROR(access_level_conflict_with_exported,none,
 NOTE(module_imported_here,none,
      "module %0 imported as '%select{private|fileprivate|internal|package|%ERROR|%ERROR}1' here",
      (Identifier, AccessLevel))
+NOTE(decl_import_via_here,none,
+     "%0 %1 imported as "
+     "'%select{private|fileprivate|internal|package|%ERROR|%ERROR}2' "
+     "from %3 here",
+     (DescriptiveDeclKind, DeclName, AccessLevel, Identifier))
 
 // Opaque return types
 ERROR(opaque_type_invalid_constraint,none,

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -124,9 +124,10 @@ bool TypeChecker::diagnoseInlinableDeclRefAccess(SourceLoc loc,
   if (problematicImport.has_value() &&
       diagAccessLevel == importAccessLevel) {
     Context.Diags.diagnose(problematicImport->accessLevelLoc,
-                           diag::module_imported_here,
-                           problematicImport->module.importedModule->getName(),
-                           problematicImport->accessLevel);
+                           diag::decl_import_via_here,
+                           D->getDescriptiveKind(), diagName,
+                           problematicImport->accessLevel,
+                           problematicImport->module.importedModule->getName());
   }
 
   return (downgradeToWarning == DowngradeToWarning::No);

--- a/test/Sema/access-level-import-diag-priority.swift
+++ b/test/Sema/access-level-import-diag-priority.swift
@@ -33,10 +33,10 @@ public struct PrivateImportType {}
 
 //--- Client.swift
 public import PublicLib
-package import PackageLib // expected-note {{module 'PackageLib' imported as 'package' here}}
-internal import InternalLib // expected-note {{module 'InternalLib' imported as 'internal' here}}
-fileprivate import FileprivateLib // expected-note 2 {{module 'FileprivateLib' imported as 'fileprivate' here}}
-private import PrivateLib // expected-note 2 {{module 'PrivateLib' imported as 'private' here}}
+package import PackageLib // expected-note {{type 'PackageImportType' imported as 'package' from 'PackageLib' here}}
+internal import InternalLib // expected-note {{type 'InternalImportType' imported as 'internal' from 'InternalLib' here}}
+fileprivate import FileprivateLib // expected-note 2 {{type 'FileprivateImportType' imported as 'fileprivate' from 'FileprivateLib' here}}
+private import PrivateLib // expected-note 2 {{type 'PrivateImportType' imported as 'private' from 'PrivateLib' here}}
 
 /// Simple ordering
 public func publicFuncUsesPrivate(_ a: PublicImportType, b: PackageImportType, c: InternalImportType, d: FileprivateImportType, e: PrivateImportType) { // expected-error {{function cannot be declared public because its parameter uses a private type}}
@@ -64,7 +64,7 @@ public func publicFuncUsesPrivateScambled(_ a: PublicImportType, d: FileprivateI
 //--- LocalVsImportClient.swift
 public import PublicLib
 internal import InternalLib
-fileprivate import FileprivateLib // expected-note 1 {{module 'FileprivateLib' imported as 'fileprivate' here}}
+fileprivate import FileprivateLib // expected-note {{type 'FileprivateImportType' imported as 'fileprivate' from 'FileprivateLib' here}}
 
 fileprivate struct LocalType {} // expected-note 3 {{type declared here}}
 public func localVsImportedType1(a: LocalType, b: InternalImportType) {} // expected-error {{function cannot be declared public because its parameter uses a fileprivate type}}

--- a/test/Sema/access-level-import-exportability.swift
+++ b/test/Sema/access-level-import-exportability.swift
@@ -17,7 +17,7 @@
 // RUN: %target-swift-frontend -typecheck %t/MinimalClient.swift -I %t \
 // RUN:   -package-name TestPackage -swift-version 5 \
 // RUN:   -enable-experimental-feature AccessLevelOnImport -verify
-// RUN: %target-swift-frontend -typecheck %t/CompletnessClient.swift -I %t \
+// RUN: %target-swift-frontend -typecheck %t/CompletenessClient.swift -I %t \
 // RUN:   -package-name TestPackage -swift-version 5 \
 // RUN:   -enable-experimental-feature AccessLevelOnImport -verify
 
@@ -26,7 +26,7 @@
 // RUN:   -package-name TestPackage -swift-version 5 \
 // RUN:   -enable-library-evolution \
 // RUN:   -enable-experimental-feature AccessLevelOnImport -verify
-// RUN: %target-swift-frontend -typecheck %t/CompletnessClient.swift -I %t \
+// RUN: %target-swift-frontend -typecheck %t/CompletenessClient.swift -I %t \
 // RUN:   -package-name TestPackage -swift-version 5 \
 // RUN:   -enable-library-evolution \
 // RUN:   -enable-experimental-feature AccessLevelOnImport -verify
@@ -121,8 +121,8 @@ public struct PrivateLibWrapper<T> {
 //--- MinimalClient.swift
 public import PublicLib
 package import PackageLib
-internal import InternalLib // expected-note@:1 {{module 'InternalLib' imported as 'internal' here}}
-fileprivate import FileprivateLib // expected-note@:1 1 {{module 'FileprivateLib' imported as 'fileprivate' here}}
+internal import InternalLib // expected-note@:1 {{type 'InternalImportType' imported as 'internal' from 'InternalLib' here}}
+fileprivate import FileprivateLib // expected-note@:1 {{type 'FileprivateImportClass' imported as 'fileprivate' from 'FileprivateLib' here}}
 private import PrivateLib
 
 public func PublicFuncUsesInternal(_: InternalImportType) { // expected-error {{function cannot be declared public because its parameter uses an internal type}}
@@ -132,12 +132,16 @@ public func PublicFuncUsesInternal(_: InternalImportType) { // expected-error {{
 public class PublicSubclassFilepriovate : FileprivateImportClass {} // expected-error {{class cannot be declared public because its superclass is fileprivate}}
 
 /// More complete test.
-//--- CompletnessClient.swift
+//--- CompletenessClient.swift
 public import PublicLib
 package import PackageLib // expected-note * {{module 'PackageLib' imported as 'package' here}}
+// expected-note@-1 * {{imported as 'package' from 'PackageLib' here}}
 internal import InternalLib // expected-note * {{module 'InternalLib' imported as 'internal' here}}
+// expected-note@-1 * {{imported as 'internal' from 'InternalLib' here}}
 fileprivate import FileprivateLib // expected-note * {{module 'FileprivateLib' imported as 'fileprivate' here}}
+// expected-note@-1 * {{imported as 'fileprivate' from 'FileprivateLib' here}}
 private import PrivateLib // expected-note * {{module 'PrivateLib' imported as 'private' here}}
+// expected-note@-1 * {{imported as 'private' from 'PrivateLib' here}}
 
 // Public use sites
 public func PublicFuncUsesPublic(_: PublicImportType) {

--- a/test/Sema/access-level-import-inlinable.swift
+++ b/test/Sema/access-level-import-inlinable.swift
@@ -71,10 +71,23 @@ public struct PrivateImportType {
 
 //--- Client.swift
 public import PublicLib
-package import PackageLib // expected-note 2 {{module 'PackageLib' imported as 'package' here}}
-internal import InternalLib // expected-note 12 {{module 'InternalLib' imported as 'internal' here}}
-fileprivate import FileprivateLib // expected-note 6 {{module 'FileprivateLib' imported as 'fileprivate' here}}
-private import PrivateLib // expected-note 6 {{module 'PrivateLib' imported as 'private' here}}
+
+package import PackageLib
+// expected-note@-1 2 {{struct 'PackageImportType' imported as 'package' from 'PackageLib' here}}
+
+internal import InternalLib
+// expected-note@-1 6 {{struct 'InternalImportType' imported as 'internal' from 'InternalLib' here}}
+// expected-note@-2 4 {{protocol 'InternalImportProto' imported as 'internal' from 'InternalLib' here}}
+// expected-note@-3 2 {{global function 'InternalFunc()' imported as 'internal' from 'InternalLib' here}}
+
+fileprivate import FileprivateLib
+// expected-note@-1 2 {{generic struct 'FileprivateImportWrapper' imported as 'fileprivate' from 'FileprivateLib' here}}
+// expected-note@-2 2 {{initializer 'init(wrappedValue:)' imported as 'fileprivate' from 'FileprivateLib' here}}
+// expected-note@-3 2 {{protocol 'FileprivateImportProto' imported as 'fileprivate' from 'FileprivateLib' here}}
+
+private import PrivateLib
+// expected-note@-1 4 {{struct 'PrivateImportType' imported as 'private' from 'PrivateLib' here}}
+ // expected-note@-2 2 {{initializer 'init()' imported as 'private' from 'PrivateLib' here}}
 
 public struct GenericType<T, U> {}
 


### PR DESCRIPTION
Using an access-level on an import downgrades imported decl from public to the import's access-level. When we can identify which decl is problematic, name it in the note displayed on the import. When using an IDE, the added context should help understanding the effect of the import's access level on the decl causing an error further down in the source file.