### PR TITLE
[interop][SwiftToCxx] do not emit _Concurrency APIs in the C++ sectio…

### DIFF
--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -239,6 +239,10 @@ bool swift::cxx_translation::isVisibleToCxx(const ValueDecl *VD,
                                             bool checkParent) {
   if (VD->isObjC())
     return false;
+  // Do not expose anything from _Concurrency module yet.
+  if (VD->getModuleContext()->ValueDecl::getName().getBaseIdentifier() ==
+      VD->getASTContext().Id_Concurrency)
+    return false;
   if (VD->getFormalAccess() >= minRequiredAccess) {
     return true;
   } else if (checkParent) {

--- a/test/Interop/SwiftToCxx/class/swift-actor-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/class/swift-actor-in-cxx.swift
@@ -4,6 +4,10 @@
 
 // RUN: %check-interop-cxx-header-in-clang(%t/actor.h)
 
+// RUN: %target-swift-frontend %s -typecheck -module-name Actor  -emit-clang-header-path %t/actor-public.h -enable-experimental-cxx-interop -disable-availability-checking
+// RN: %FileCheck %s < %t/actor-public.h
+// RUN: %check-interop-cxx-header-in-clang(%t/actor-public.h)
+
 // RUN: %target-swift-frontend %s -typecheck -module-name Actor -enable-library-evolution -clang-header-expose-decls=has-expose-attr -emit-clang-header-path %t/actor-evo.h -disable-availability-checking
 // RUN: %FileCheck %s < %t/actor-evo.h
 


### PR DESCRIPTION
…n of the generated header

Fixes an issue where actors exposed its unownedExecutor property with unsupported type.
