### PR TITLE
[TypeChecker] SE-0324: Extend Swift -> C pointer conversions to arrays

### DIFF
--- a/include/swift/Sema/Constraint.h
+++ b/include/swift/Sema/Constraint.h
@@ -282,6 +282,8 @@ enum class ConversionRestrictionKind {
   InoutToCPointer,
   /// Array-to-pointer conversion.
   ArrayToPointer,
+  /// Converting from array to a C pointer has `PointerToCPointer` semantics.
+  ArrayToCPointer,
   /// String-to-pointer conversion.
   StringToPointer,
   /// Pointer-to-pointer conversion.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6879,7 +6879,8 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       return result;
     }
 
-    case ConversionRestrictionKind::ArrayToPointer: {
+    case ConversionRestrictionKind::ArrayToPointer:
+    case ConversionRestrictionKind::ArrayToCPointer: {
       bool isOptional = false;
       Type unwrappedTy = toType;
       if (Type unwrapped = toType->getOptionalObjectType()) {

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -7367,7 +7367,8 @@ void NonEphemeralConversionFailure::emitSuggestionNotes() const {
 
   // Then try to find a suitable alternative.
   switch (ConversionKind) {
-  case ConversionRestrictionKind::ArrayToPointer: {
+  case ConversionRestrictionKind::ArrayToPointer:
+  case ConversionRestrictionKind::ArrayToCPointer: {
     // Don't suggest anything for optional arrays, as there's currently no
     // direct alternative.
     if (getArgType()->getOptionalObjectType())

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -13436,6 +13436,9 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
   case ConversionRestrictionKind::PointerToCPointer:
     return simplifyPointerToCPointerRestriction(type1, type2, flags, locator);
 
+  case ConversionRestrictionKind::ArrayToCPointer:
+    llvm_unreachable("not yet implemented");
+
   case ConversionRestrictionKind::InoutToCPointer: {
     SmallVector<Type, 2> optionals;
 

--- a/lib/Sema/Constraint.cpp
+++ b/lib/Sema/Constraint.cpp
@@ -656,6 +656,8 @@ StringRef swift::constraints::getName(ConversionRestrictionKind kind) {
     return "[protocol-metatype-to-object]";
   case ConversionRestrictionKind::ArrayToPointer:
     return "[array-to-pointer]";
+  case ConversionRestrictionKind::ArrayToCPointer:
+    return "[array-to-c-pointer]";
   case ConversionRestrictionKind::StringToPointer:
     return "[string-to-pointer]";
   case ConversionRestrictionKind::InoutToPointer:

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -6238,6 +6238,7 @@ ConstraintSystem::isConversionEphemeral(ConversionRestrictionKind conversion,
                                         ConstraintLocatorBuilder locator) {
   switch (conversion) {
   case ConversionRestrictionKind::ArrayToPointer:
+  case ConversionRestrictionKind::ArrayToCPointer:
   case ConversionRestrictionKind::StringToPointer:
     // Always ephemeral.
     return ConversionEphemeralness::Ephemeral;

--- a/test/Constraints/swift_to_c_pointer_conversions.swift.gyb
+++ b/test/Constraints/swift_to_c_pointer_conversions.swift.gyb
@@ -296,3 +296,37 @@ func test_inout_to_pointer_conversion() {
   const_opt_uint_${Size}_ptr_func(&x${Size}) // OK
 % end
 }
+
+func test_array_to_pointer_conversion() {
+% for Size in ['16', '32', '64']:
+  var x${Size}: [Int${Size}] = []
+
+  void_ptr_func(&x${Size}) // Ok
+  const_void_ptr_func(x${Size}) // Ok
+  opt_void_ptr_func(x${Size})
+  // expected-error@-1 {{cannot convert value of type '[Int${Size}]' to expected argument type 'UnsafeMutableRawPointer?'}}
+
+  char_ptr_func(x${Size})
+  // expected-error@-1 {{cannot convert value of type '[Int${Size}]' to expected argument type 'UnsafeMutablePointer<CChar>' (aka 'UnsafeMutablePointer<Int8>')}}
+  opt_char_ptr_func(x${Size})
+  // expected-error@-1 {{cannot convert value of type '[Int${Size}]' to expected argument type 'UnsafeMutablePointer<CChar>?' (aka 'Optional<UnsafeMutablePointer<Int8>>')}}
+
+  const_char_ptr_func(x${Size}) // Ok
+  const_opt_char_ptr_func(x${Size}) // Ok
+
+  int_${Size}_ptr_func(x${Size})
+  // expected-error@-1 {{cannot convert value of type '[Int${Size}]' to expected argument type 'UnsafeMutablePointer<Int${Size}>'}}
+  uint_${Size}_ptr_func(x${Size})
+  // expected-error@-1 {{cannot convert value of type '[Int${Size}]' to expected argument type 'UnsafeMutablePointer<UInt${Size}>'}}
+
+  opt_int_${Size}_ptr_func(x${Size})
+  // expected-error@-1 {{cannot convert value of type '[Int${Size}]' to expected argument type 'UnsafeMutablePointer<Int${Size}>?'}}
+  opt_uint_${Size}_ptr_func(x${Size})
+  // expected-error@-1 {{cannot convert value of type '[Int${Size}]' to expected argument type 'UnsafeMutablePointer<UInt${Size}>?'}}
+
+  const_int_${Size}_ptr_func(x${Size}) // OK
+  const_uint_${Size}_ptr_func(x${Size}) // OK
+  const_opt_int_${Size}_ptr_func(x${Size}) // OK
+  const_opt_uint_${Size}_ptr_func(x${Size}) // OK
+% end
+}

--- a/test/SILGen/diagnose_implicit_raw_conversion_unsupported.swift
+++ b/test/SILGen/diagnose_implicit_raw_conversion_unsupported.swift
@@ -40,44 +40,25 @@ func test_unsupported<T>(arg: T) {
                           // expected-note@-1 {{arguments to generic parameter 'Pointee' ('UInt8' and 'Int8') are expected to be equal}}
 }
 
-// These implicit casts should work according to
-// [SE-0324: Relax diagnostics for pointer arguments to C functions]
-// (https://github.com/apple/swift-evolution/blob/main/proposals/0324-c-lang-pointer-arg-conversion.md)
-// They currently raise a "cannot convert value" error because of
-// the `UInt8` vs. `Int8` mismatch.
-//
-// If we decide to support these as bug-fixes for SE-0324, then the
-// implicit inout-to-raw conversion should also accept them.
-func test_se0324_accept() {
+// Array<T> to C pointer conversion is supported under SE-0324
+func test_array_to_c_pointer_concrete() {
     let constIntArray: [Int8] = [0]
-    read_uchar(constIntArray) // expected-error {{cannot convert value of type 'UnsafePointer<Int8>' to expected argument type 'UnsafePointer<UInt8>'}}
-                              // expected-note@-1 {{arguments to generic parameter 'Pointee' ('Int8' and 'UInt8') are expected to be equal}}
+    read_uchar(constIntArray)
 
     let constUIntArray: [UInt8] = [0]
-    read_char(constUIntArray) // expected-error {{cannot convert value of type 'UnsafePointer<UInt8>' to expected argument type 'UnsafePointer<CChar>' (aka 'UnsafePointer<Int8>')}}
-                              // expected-note@-1 {{arguments to generic parameter 'Pointee' ('UInt8' and 'CChar' (aka 'Int8')) are expected to be equal}}
+    read_char(constUIntArray)
 
-    var intArray: [Int8] = [0]
-    read_uchar(intArray) // expected-error {{cannot convert value of type 'UnsafePointer<Int8>' to expected argument type 'UnsafePointer<UInt8>'}}
-                         // expected-note@-1 {{arguments to generic parameter 'Pointee' ('Int8' and 'UInt8') are expected to be equal}}
+    var intArray: [Int8] = [0] // expected-warning {{variable 'intArray' was never mutated; consider changing to 'let' constant}}
+    read_uchar(intArray)
 
-    var uintArray: [UInt8] = [0]
-    read_char(uintArray) // expected-error {{cannot convert value of type 'UnsafePointer<UInt8>' to expected argument type 'UnsafePointer<CChar>' (aka 'UnsafePointer<Int8>')}}
-                         // expected-note@-1 {{arguments to generic parameter 'Pointee' ('UInt8' and 'CChar' (aka 'Int8')) are expected to be equal}}
+    var uintArray: [UInt8] = [0] // expected-warning {{variable 'uintArray' was never mutated; consider changing to 'let' constant}}
+    read_char(uintArray)
 
 }
 
-// These implicit casts should work according to
-// SE-0324: Relax diagnostics for pointer arguments to C functions]
-// They currently raise a "cannot convert value" error because of
-// the `UInt8` vs. `Int8` mismatch.
-//
-// If we decide to support these as bug-fixes for SE-0324, then the
-// implicit inout-to-raw conversion should issue a warning instead.
-func test_se0324_error<T>(arg: T) {
+// Array<T> to C pointer conversion is supported under SE-0324
+func test_array_to_c_pointer_generic<T>(arg: T) {
     let constArray: [T] = [arg]
-    read_char(constArray) // expected-error {{cannot convert value of type 'UnsafePointer<T>' to expected argument type 'UnsafePointer<CChar>' (aka 'UnsafePointer<Int8>')}}
-                           // expected-note@-1 {{arguments to generic parameter 'Pointee' ('T' and 'CChar' (aka 'Int8')) are expected to be equal}}
-    read_uchar(constArray) // expected-error {{cannot convert value of type 'UnsafePointer<T>' to expected argument type 'UnsafePointer<UInt8>'}}
-                           // expected-note@-1 {{arguments to generic parameter 'Pointee' ('T' and 'UInt8') are expected to be equal}}
+    read_char(constArray)
+    read_uchar(constArray)
 }


### PR DESCRIPTION
Extends implementation to support conversions between arrays
and pointers (when element type is an (un-)signed integer) that are
allowed by the SE-0324 proposal.

Resolved: rdar://99089335
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
