### PR TITLE
[cxx-interop] Build `CxxStdlib` module when `SWIFT_BUILD_SDK_OVERLAY=NO`

### DIFF
--- a/stdlib/public/Cxx/CMakeLists.txt
+++ b/stdlib/public/Cxx/CMakeLists.txt
@@ -23,7 +23,5 @@ add_swift_target_library(swiftCxx ${SWIFT_CXX_LIBRARY_KIND} NO_LINK_NAME IS_STDL
     INSTALL_IN_COMPONENT compiler
     INSTALL_WITH_SHARED)
 
-if(SWIFT_BUILD_SDK_OVERLAY OR SWIFT_BUILD_TEST_SUPPORT_MODULES)
-  add_subdirectory(std)
-endif()
+add_subdirectory(std)
 add_subdirectory(cxxshim)


### PR DESCRIPTION
The C++ stdlib overlay binaries now a part of the toolchain, not the OS SDKs. This makes sure that these binaries are built when building the toolchain separately from the stdlib.

rdar://106002094