### PR TITLE
Fix the minimal/lto configuration

### DIFF
--- a/stdlib/cmake/modules/AddSwiftStdlib.cmake
+++ b/stdlib/cmake/modules/AddSwiftStdlib.cmake
@@ -137,6 +137,9 @@ function(_add_target_variant_c_compile_link_flags)
   _compute_lto_flag("${CFLAGS_ENABLE_LTO}" _lto_flag_out)
   if (_lto_flag_out)
     list(APPEND result "${_lto_flag_out}")
+    # Disable opaque pointers in lto mode.
+    list(APPEND result "-Xclang")
+    list(APPEND result "-no-opaque-pointers")
   endif()
 
   set("${CFLAGS_RESULT_VAR_NAME}" "${result}" PARENT_SCOPE)


### PR DESCRIPTION
We need to disable opaque pointers when we compiler the runtime the linker complains:

```
  ld: Opaque pointers are only supported in -opaque-pointers mode
```

Alternatively, we could pass the opaque-pointers flag to the linker but then it would complain about the swiftc generated files which still use typed pointers.
Until swiftc is fixed, disable opaque pointers for .cpp runtime files.

rdar://106515243