### PR TITLE
[CSSimplify] Variadics: Allow unlabeled matching after pack expansion…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -549,13 +549,6 @@ static bool matchCallArgumentsImpl(
       // Record the first argument for the variadic.
       parameterBindings[paramIdx].push_back(*claimed);
 
-      // If the argument is itself variadic, we're forwarding varargs
-      // with a VarargExpansionExpr; don't collect any more arguments.
-      if (args[*claimed].isVariadic() ||
-          args[*claimed].getPlainType()->is<PackExpansionType>()) {
-        return;
-      }
-
       auto currentNextArgIdx = nextArgIdx;
       {
         nextArgIdx = *claimed;

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -144,3 +144,33 @@ func callCopyAndBind<T>(_ arg: repeat each T) {
   // Don't propagate errors for invalid declaration reference
   let result = copyIntoTuple(repeat each arg)
 }
+
+do {
+  struct TestArgMatching {
+    subscript<each T>(data arg: repeat each T) -> Int {
+      get { 42 }
+      set {}
+    }
+  }
+
+  func test_that_variadic_generics_claim_unlabeled_arguments<each T>(_ args: repeat each T, test: inout TestArgMatching) {
+    func testLabeled<each U>(data: repeat each U) {}
+    func testUnlabeled<each U>(_: repeat each U) {}
+    func testInBetween<each U>(_: repeat each U, other: String) {}
+
+    testLabeled(data: repeat each args) // Ok
+    testLabeled(data: repeat each args, 1) // Ok
+    testLabeled(data: repeat each args, 1, 2, 3) // Ok
+
+    testUnlabeled(repeat each args) // Ok
+    testUnlabeled(repeat each args, 1) // Ok
+    testUnlabeled(repeat each args, 1, 2, 3) // Ok
+
+    testInBetween(repeat each args, 1, 2.0, other: "") // Ok
+
+    _ = test[data: repeat each args]
+    _ = test[data: repeat each args, 0, ""]
+
+    test[data: repeat each args, "", 42] = 0
+  }
+}


### PR DESCRIPTION
… argument

Remove a bit of logic from `matchCallArgumentsImpl` that prevented 
unlabeled argument matching after pack expansion argument until next
labeled argument because it incorrectly assumed that it represents 
variadic forwarding.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
