### PR TITLE
[ModuleInterface] Print the @_spiOnly attribute in private swiftinterfaces without comments

### DIFF
--- a/lib/Frontend/ModuleInterfaceSupport.cpp
+++ b/lib/Frontend/ModuleInterfaceSupport.cpp
@@ -329,7 +329,7 @@ static void printImports(raw_ostream &out,
       // compatible swiftinterfaces and we can live without
       // checking the generate code for a while.
       if (spiOnlyImportSet.count(import))
-        out << "/*@_spiOnly*/ ";
+        out << "@_spiOnly ";
 
       // List of imported SPI groups for local use.
       for (auto spiName : spis)

--- a/test/SPI/spi_only_import_swiftinterfaces.swift
+++ b/test/SPI/spi_only_import_swiftinterfaces.swift
@@ -52,17 +52,17 @@
 
 @_spiOnly @_spi(SomeSPIGroup) import A_SPIOnlyImported
 // CHECK-PUBLIC-NOT: A_SPIOnlyImported
-// CHECK-PRIVATE: {{^}}/*@_spiOnly*/ @_spi(SomeSPIGroup) import A_SPIOnlyImported
+// CHECK-PRIVATE: {{^}}@_spiOnly @_spi(SomeSPIGroup) import A_SPIOnlyImported
 
 /// This is also imported as SPI only via FileB.swift
 @_spiOnly import ConstantSPIOnly
 // CHECK-PUBLIC-NOT: ConstantSPIOnly
-// CHECK-PRIVATE: {{^}}/*@_spiOnly*/ import ConstantSPIOnly
+// CHECK-PRIVATE: {{^}}@_spiOnly import ConstantSPIOnly
 
 /// This is also imported as SPI only via FileB.swift
 @_implementationOnly import InconsistentIOI
 // CHECK-PUBLIC-NOT: InconsistentIOI
-// CHECK-PRIVATE: {{^}}/*@_spiOnly*/ import InconsistentIOI
+// CHECK-PRIVATE: {{^}}@_spiOnly import InconsistentIOI
 
 /// This is also imported as SPI only via FileB.swift
 import InconsistentPublic


### PR DESCRIPTION
This attribute was commented out in the private swiftinterface for backwards compatibility with older compilers unaware of the attribute. This scenario shouldn't be a problem anymore and without that attribute some imports can raise errors. Let's print the attribute as it was written in the sources without commenting it out.