### PR TITLE
[ASTGen] Separate JSON serialization module from ASTGen

### DIFF
--- a/cmake/modules/AddSwiftUnittests.cmake
+++ b/cmake/modules/AddSwiftUnittests.cmake
@@ -10,6 +10,8 @@ function(add_swift_unittest test_dirname)
   # function defined by AddLLVM.cmake.
   add_unittest(SwiftUnitTests ${test_dirname} ${ARGN})
 
+  set_target_properties(${test_dirname} PROPERTIES LINKER_LANGUAGE CXX)
+
   # TODO: _add_variant_c_compile_link_flags and these tests should share some
   # sort of logic.
   #

--- a/lib/ASTGen/CMakeLists.txt
+++ b/lib/ASTGen/CMakeLists.txt
@@ -1,3 +1,10 @@
+add_pure_swift_host_library(swiftLLVMJSON STATIC EMIT_MODULE
+  Sources/LLVMJSON/LLVMJSON.swift
+
+  DEPENDENCIES
+    swiftBasic
+)
+
 add_pure_swift_host_library(swiftASTGen STATIC
   Sources/ASTGen/ASTGen.swift
   Sources/ASTGen/Decls.swift
@@ -5,7 +12,6 @@ add_pure_swift_host_library(swiftASTGen STATIC
   Sources/ASTGen/Exprs.swift
   Sources/ASTGen/Generics.swift
   Sources/ASTGen/Literals.swift
-  Sources/ASTGen/LLVMJSON.swift
   Sources/ASTGen/Macros.swift
   Sources/ASTGen/Misc.swift
   Sources/ASTGen/PluginHost.swift
@@ -16,5 +22,8 @@ add_pure_swift_host_library(swiftASTGen STATIC
   Sources/ASTGen/Stmts.swift
   Sources/ASTGen/Types.swift
 
-  DEPENDENCIES swiftAST
+  DEPENDENCIES
+    swiftAST
+  SWIFT_DEPENDENCIES
+    swiftLLVMJSON
 )

--- a/lib/ASTGen/Package.swift
+++ b/lib/ASTGen/Package.swift
@@ -9,8 +9,15 @@
 
 import PackageDescription
 
+let swiftSetttings: [SwiftSetting] = [
+  .unsafeFlags([
+    "-I", "../../include/swift/",
+    "-I", "../../include",
+  ])
+]
+
 let package = Package(
-  name: "ASTGen",
+  name: "swiftSwiftCompiler",
   platforms: [
     .macOS(.v10_15)
   ],
@@ -29,14 +36,17 @@ let package = Package(
         .product(name: "SwiftOperators", package: "swift-syntax"),
         .product(name: "SwiftParser", package: "swift-syntax"),
         .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+        "swiftLLVMJSON"
       ],
-      path: ".",
+      path: "Sources/ASTGen",
       exclude: ["CMakeLists.txt"],
-      swiftSettings: [
-        .unsafeFlags([
-          "-I", "../../include/swift/",
-          "-I", "../../include",
-        ])
-      ])
+      swiftSettings: swiftSetttings
+    ),
+    .target(
+      name: "swiftLLVMJSON",
+      dependencies: [],
+      path: "Sources/LLVMJSON",
+      swiftSettings: swiftSetttings
+    ),
   ]
 )

--- a/lib/ASTGen/Sources/ASTGen/PluginHost.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginHost.swift
@@ -13,6 +13,7 @@
 import CASTBridging
 import CBasicBridging
 import SwiftSyntax
+import swiftLLVMJSON
 
 enum PluginError: Error {
   case failedToSendMessage

--- a/lib/ASTGen/Sources/LLVMJSON/LLVMJSON.swift
+++ b/lib/ASTGen/Sources/LLVMJSON/LLVMJSON.swift
@@ -21,10 +21,10 @@ extension String {
   }
 }
 
-struct LLVMJSON {
+public struct LLVMJSON {
   /// Encode an `Encodable` value to JSON data, and call `body` is the buffer.
   /// Note that the buffer is valid onlu in `body`.
-  static func encoding<T: Encodable, R>(_ value: T, body: (UnsafeBufferPointer<Int8>) -> R) throws -> R {
+  public static func encoding<T: Encodable, R>(_ value: T, body: (UnsafeBufferPointer<Int8>) -> R) throws -> R {
     let valuePtr = JSON_newValue()
     defer { JSON_value_delete(valuePtr) }
 
@@ -40,7 +40,7 @@ struct LLVMJSON {
   }
 
   /// Decode a JSON data to a Swift value.
-  static func decode<T: Decodable>(_ type: T.Type, from json: UnsafeBufferPointer<Int8>) throws -> T {
+  public static func decode<T: Decodable>(_ type: T.Type, from json: UnsafeBufferPointer<Int8>) throws -> T {
     let data = BridgedData(baseAddress: json.baseAddress, size: json.count)
     let valuePtr = JSON_deserializedValue(data)
     defer { JSON_value_delete(valuePtr) }

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -151,8 +151,15 @@ endfunction()
 # STATIC
 #   Build a static library.
 #
-# LLVM_LINK_COMPONENTS
-#   LLVM components this library depends on.
+# EMIT_MODULE
+#   Emit '.swiftmodule' to
+#
+# DEPENDENCIES
+#   Target names to pass target_link_library
+#
+# SWIFT_DEPENDENCIES
+#   Target names to pass force_target_link_library.
+#   TODO: Remove this and use DEPENDENCIES when CMake is fixed
 #
 # source1 ...
 #   Sources to add into this library.
@@ -165,10 +172,12 @@ function(add_pure_swift_host_library name)
   # Option handling
   set(options
         SHARED
-        STATIC)
+        STATIC
+        EMIT_MODULE)
   set(single_parameter_options)
   set(multiple_parameter_options
-        DEPENDENCIES)
+        DEPENDENCIES
+        SWIFT_DEPENDENCIES)
 
   cmake_parse_arguments(APSHL
                         "${options}"
@@ -254,10 +263,50 @@ function(add_pure_swift_host_library name)
   target_link_libraries(${name} PUBLIC
     ${APSHL_DEPENDENCIES}
   )
+  # TODO: Change to target_link_libraries when cmake is fixed
+  force_target_link_libraries(${name} PUBLIC
+    ${APSHL_SWIFT_DEPENDENCIES}
+  )
 
   # Make sure we can use the host libraries.
   target_include_directories(${name} PUBLIC
     ${SWIFT_HOST_LIBRARIES_DEST_DIR})
+
+  if(APSHL_EMIT_MODULE)
+    # Determine where Swift modules will be built and installed.
+
+    set(module_triple ${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${SWIFT_HOST_VARIANT_ARCH}_MODULE})
+    set(module_dir ${SWIFT_HOST_LIBRARIES_DEST_DIR})
+    set(module_base "${module_dir}/${name}.swiftmodule")
+    set(module_file "${module_base}/${module_triple}.swiftmodule")
+    set(module_interface_file "${module_base}/${module_triple}.swiftinterface")
+    set(module_sourceinfo_file "${module_base}/${module_triple}.swiftsourceinfo")
+
+    set_target_properties(${name} PROPERTIES
+        # Set the default module name to the target name.
+        Swift_MODULE_NAME ${name}
+        # Install the Swift module into the appropriate location.
+        Swift_MODULE_DIRECTORY ${module_dir}
+        # NOTE: workaround for CMake not setting up include flags.
+        INTERFACE_INCLUDE_DIRECTORIES ${module_dir})
+
+    # Create the module directory.
+    add_custom_command(
+        TARGET ${name}
+        PRE_BUILD
+        COMMAND "${CMAKE_COMMAND}" -E make_directory ${module_base}
+        COMMENT "Generating module directory for ${name}")
+
+    # Configure the emission of the Swift module files.
+    target_compile_options("${name}" PRIVATE
+        $<$<COMPILE_LANGUAGE:Swift>:
+        -module-name;$<TARGET_PROPERTY:${name},Swift_MODULE_NAME>;
+        -enable-library-evolution;
+        -emit-module-path;${module_file};
+        -emit-module-source-info-path;${module_sourceinfo_file};
+        -emit-module-interface-path;${module_interface_file}
+        >)
+  endif()
 
   # Export this target.
   set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${name})

--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -26,16 +26,6 @@ target_link_libraries(swiftParse PRIVATE
 )
 
 if (SWIFT_SWIFT_PARSER)
-  # Link against the SwiftSyntax parser and libraries it depends on. The actual
-  # formulation of this is a hack to work around a CMake bug in Ninja file
-  # generation that results in multiple Ninja targets producing the same file in
-  # a downstream SourceKit target. This should be expressed as:
-  #
-  #   target_link_libraries(swiftParse
-  #     PRIVATE
-  #     SwiftSyntax::SwiftParser
-  #     ...
-  #   )
   target_link_libraries(swiftParse
     PRIVATE
     SwiftSyntax::SwiftBasicFormat
@@ -46,7 +36,7 @@ if (SWIFT_SWIFT_PARSER)
     SwiftSyntax::SwiftOperators
     SwiftSyntax::SwiftSyntaxBuilder
     SwiftSyntax::SwiftSyntaxMacros
-    $<TARGET_OBJECTS:swiftASTGen>
+    swiftASTGen
   )
 
   add_dependencies(swiftParse

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -93,7 +93,7 @@ if (SWIFT_SWIFT_PARSER)
     SWIFT_SWIFT_PARSER
   )
   target_link_libraries(swiftSema PRIVATE
-    $<TARGET_OBJECTS:swiftASTGen>)
+    swiftASTGen)
 endif()
 
 set_swift_llvm_is_available(swiftSema)

--- a/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
+++ b/tools/SourceKit/cmake/modules/AddSwiftSourceKit.cmake
@@ -233,6 +233,8 @@ macro(add_sourcekit_library name)
   endif()
   llvm_update_compile_flags(${name})
 
+  set_target_properties(${name} PROPERTIES LINKER_LANGUAGE CXX)
+
   set_output_directory(${name}
       BINARY_DIR ${SOURCEKIT_RUNTIME_OUTPUT_INTDIR}
       LIBRARY_DIR ${SOURCEKIT_LIBRARY_OUTPUT_INTDIR})
@@ -334,6 +336,8 @@ macro(add_sourcekit_executable name)
   set_target_properties(${name} PROPERTIES FOLDER "SourceKit executables")
   add_sourcekit_default_compiler_flags("${name}")
 
+  set_target_properties(${name} PROPERTIES LINKER_LANGUAGE CXX)
+
   if(SWIFT_SWIFT_PARSER)
     set(SKEXEC_HAS_SWIFT_MODULES TRUE)
   else()
@@ -386,6 +390,8 @@ macro(add_sourcekit_framework name)
   llvm_process_sources(srcs ${srcs})
   add_library(${name} SHARED ${srcs})
   llvm_update_compile_flags(${name})
+
+  set_target_properties(${name} PROPERTIES LINKER_LANGUAGE CXX)
 
   set(headers)
   foreach(src ${srcs})
@@ -551,6 +557,8 @@ macro(add_sourcekit_xpc_service name framework_target)
 
   swift_common_llvm_config(${name} ${SOURCEKITXPC_LLVM_LINK_COMPONENTS})
   target_link_libraries(${name} PRIVATE ${LLVM_COMMON_LIBS})
+
+  set_target_properties(${name} PROPERTIES LINKER_LANGUAGE CXX)
 
   add_dependencies(${framework_target} ${name})
 


### PR DESCRIPTION
For future usage from other host libraries written in Swift

For CMake:
 * Explicitly specify `LINKER_LANGAGE` to `CXX` in existing components so that `swiftc` is _not_ used when linking with `swiftASTGen`
 * Add `EMIT_MODULE` argument to `add_pure_swift_host_library` to emit `.swiftmodule` usable from other Swift libraries.
