### PR TITLE
[Concurrency] Freeze JobPriority, comment that Flags location is assumed

### DIFF
--- a/include/swift/ABI/Task.h
+++ b/include/swift/ABI/Task.h
@@ -72,9 +72,12 @@ public:
   // Reserved for the use of the scheduler.
   void *SchedulerPrivate[2];
 
+  /// WARNING: DO NOT MOVE.
+  /// Schedulers may assume the memory location of the Flags in order to avoid a runtime call
+  /// to get the priority of a job.
   JobFlags Flags;
 
-  // Derived classes can use this to store a Job Id.
+  /// Derived classes can use this to store a Job Id.
   uint32_t Id = 0;
 
   /// The voucher associated with the job. Note: this is currently unused on

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -63,6 +63,7 @@ public struct UnownedJob: Sendable {
 ///
 /// Conversions between the two priorities are available as initializers on the respective types.
 @available(SwiftStdlib 5.9, *)
+@frozen
 public struct JobPriority {
   public typealias RawValue = UInt8
 


### PR DESCRIPTION
The priority can be read without a runtime call if executors assume they know the layout of Job.
We can promise to not move around the Flags/priority.

Freeze the JobPriority while at it; sadly TaskPriority is not frozen.