### PR TITLE
[interop] do not stop traversal when looking for clang symbols to IRG…

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -104,10 +104,12 @@ public:
   // Do not traverse unevaluated expressions. Doing to might result in compile
   // errors if we try to instantiate an un-instantiatable template.
 
-  bool VisitCXXNoexceptExpr(clang::CXXNoexceptExpr *NEE) { return false; }
+  bool TraverseCXXNoexceptExpr(clang::CXXNoexceptExpr *NEE) { return true; }
 
-  bool VisitCXXTypeidExpr(clang::CXXTypeidExpr *TIE) {
-    return TIE->isPotentiallyEvaluated();
+  bool TraverseCXXTypeidExpr(clang::CXXTypeidExpr *TIE) {
+    if (TIE->isPotentiallyEvaluated())
+      clang::RecursiveASTVisitor<ClangDeclFinder>::TraverseCXXTypeidExpr(TIE);
+    return true;
   }
 
   bool shouldVisitTemplateInstantiations() const { return true; }

--- a/test/Interop/Cxx/templates/Inputs/unevaluated-context.h
+++ b/test/Interop/Cxx/templates/Inputs/unevaluated-context.h
@@ -16,12 +16,17 @@ auto declval() noexcept -> decltype(__declval<_Tp>(0)) {
   return __declval<_Tp>(0);
 }
 
+inline void stillCalled() {
+    static int x = 0;
+}
+
 template <class T>
 class Vec {
 public:
   void push_back(const T &__x) {
     if (!noexcept(declval<T *>()))
       ;
+    stillCalled();
   }
 };
 


### PR DESCRIPTION
…en when hitting noexcept expression
