### PR TITLE
[Macros] Treat FreestandingExpressionMacros as a suppressible feature

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -315,6 +315,9 @@ struct PrintOptions {
   /// for class layout
   bool PrintClassLayoutName = false;
 
+  /// Replace @freestanding(expression) with @expression.
+  bool SuppressingFreestandingExpression = false;
+
   /// Suppress emitting @available(*, noasync)
   bool SuppressNoAsyncAvailabilityAttr = false;
 

--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -94,7 +94,7 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(UnavailableFromAsync, 0, "@_unavailableFromAsync",
 SUPPRESSIBLE_LANGUAGE_FEATURE(NoAsyncAvailability, 340, "@available(*, noasync)", true)
 LANGUAGE_FEATURE(BuiltinIntLiteralAccessors, 368, "Builtin.IntLiteral accessors", true)
 LANGUAGE_FEATURE(Macros, 0, "Macros", true)
-LANGUAGE_FEATURE(
+SUPPRESSIBLE_LANGUAGE_FEATURE(
     FreestandingExpressionMacros, 382, "Expression macros",
     true)
 LANGUAGE_FEATURE(AttachedMacros, 389, "Attached macros", true)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3238,6 +3238,14 @@ static bool usesFeatureFreestandingExpressionMacros(Decl *decl) {
 }
 
 static void
+suppressingFeatureFreestandingExpressionMacros(PrintOptions &options,
+                                        llvm::function_ref<void()> action) {
+  llvm::SaveAndRestore<PrintOptions> orignalOptions(options);
+  options.SuppressingFreestandingExpression = true;
+  action();
+}
+
+static void
 suppressingFeatureNoAsyncAvailability(PrintOptions &options,
                                       llvm::function_ref<void()> action) {
   llvm::SaveAndRestore<PrintOptions> orignalOptions(options);

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1347,6 +1347,14 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
 
   case DAK_MacroRole: {
     auto Attr = cast<MacroRoleAttr>(this);
+
+    if (Options.SuppressingFreestandingExpression &&
+        Attr->getMacroSyntax() == MacroSyntax::Freestanding &&
+        Attr->getMacroRole() == MacroRole::Expression) {
+      Printer.printAttrName("@expression");
+      break;
+    }
+
     switch (Attr->getMacroSyntax()) {
     case MacroSyntax::Freestanding:
       Printer.printAttrName("@freestanding");

--- a/test/ModuleInterface/macros.swift
+++ b/test/ModuleInterface/macros.swift
@@ -6,13 +6,21 @@
 // RUN: %FileCheck %s < %t/Macros.swiftinterface --check-prefix CHECK
 // RUN: %target-swift-frontend -compile-module-from-interface %t/Macros.swiftinterface -o %t/Macros.swiftmodule
 
-// CHECK: #if compiler(>=5.3) && $Macros && $FreestandingExpressionMacros
+// CHECK: #if compiler(>=5.3) && $Macros
+// CHECK-NEXT: #if $FreestandingExpressionMacros
 // CHECK-NEXT: @freestanding(expression) public macro publicStringify<T>(_ value: T) -> (T, Swift.String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")
+// CHECK-NEXT: #else
+// CHECK-NEXT: @expression public macro publicStringify<T>(_ value: T) -> (T, Swift.String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")
+// CHECK-NEXT: #endif
 // CHECK-NEXT: #endif
 @freestanding(expression) public macro publicStringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "SomeModule", type: "StringifyMacro")
 
-// CHECK: #if compiler(>=5.3) && $Macros && $FreestandingExpressionMacros
+// CHECK: #if compiler(>=5.3) && $Macros
+// CHECK-NEXT: #if $FreestandingExpressionMacros
 // CHECK: @freestanding(expression) public macro publicLine<T>() -> T = #externalMacro(module: "SomeModule", type: "Line") where T : Swift.ExpressibleByIntegerLiteral
+// CHECK-NEXT: #else
+// CHECK: @expression public macro publicLine<T>() -> T = #externalMacro(module: "SomeModule", type: "Line") where T : Swift.ExpressibleByIntegerLiteral
+// CHECK-NEXT: #endif
 // CHECK-NEXT: #endif
 @freestanding(expression) public macro publicLine<T: ExpressibleByIntegerLiteral>() -> T = #externalMacro(module: "SomeModule", type: "Line")
 


### PR DESCRIPTION
When the feature isn't available, use the older `@expression` syntax to work around limitations of older compilers.
