### PR TITLE
Omnibus fixes to IRGen for variadic generic type metadata

### DIFF
--- a/include/swift/IRGen/GenericRequirement.h
+++ b/include/swift/IRGen/GenericRequirement.h
@@ -82,6 +82,12 @@ public:
   }
 
   bool isMetadata() const {
+    return kind == Kind::Metadata;
+  }
+  bool isMetadataPack() const {
+    return kind == Kind::MetadataPack;
+  }
+  bool isAnyMetadata() const {
     return kind == Kind::Metadata || kind == Kind::MetadataPack;
   }
 
@@ -94,6 +100,12 @@ public:
   }
 
   bool isWitnessTable() const {
+    return kind == Kind::WitnessTable;
+  }
+  bool isWitnessTablePack() const {
+    return kind == Kind::WitnessTablePack;
+  }
+  bool isAnyWitnessTable() const {
     return kind == Kind::WitnessTable || kind == Kind::WitnessTablePack;
   }
 

--- a/lib/IRGen/Fulfillment.cpp
+++ b/lib/IRGen/Fulfillment.cpp
@@ -179,6 +179,46 @@ bool FulfillmentMap::searchTypeMetadata(IRGenModule &IGM, CanType type,
   return false;
 }
 
+static CanType getSingletonPackExpansionParameter(CanPackType packType,
+                    const FulfillmentMap::InterestingKeysCallback &keys,
+                    Optional<unsigned> &packExpansionComponent) {
+  if (packType->getNumElements() != 1)
+    return CanType();
+  auto expansion = dyn_cast<PackExpansionType>(packType.getElementType(0));
+  if (!expansion || !keys.isInterestingPackExpansion(expansion))
+    return CanType();
+
+  packExpansionComponent = 0;
+  return expansion.getPatternType();
+}
+
+bool FulfillmentMap::searchTypeMetadataPack(IRGenModule &IGM,
+                                            CanPackType packType,
+                                            IsExact_t isExact,
+                                            MetadataState metadataState,
+                                            unsigned source,
+                                            MetadataPath &&path,
+                                      const InterestingKeysCallback &keys) {
+  // We can fulfill pack parameters if the pack is a singleton pack
+  // expansion over one.
+  // TODO: we can also fulfill pack expansions if we can slice away
+  // constant-sized prefixes and suffixes.
+  Optional<unsigned> packExpansionComponent;
+  if (auto parameter = getSingletonPackExpansionParameter(packType, keys,
+                                                    packExpansionComponent)) {
+    MetadataPath singletonPath = path;
+    singletonPath.addPackExpansionPatternComponent(*packExpansionComponent);
+    return addFulfillment(GenericRequirement::forMetadata(parameter),
+                          source, std::move(singletonPath), metadataState);
+  }
+
+  // TODO: fulfill non-expansion metadata out of the pack
+
+  // TODO: fulfill the pack type itself
+
+  return false;
+}
+
 bool FulfillmentMap::searchConformance(
     IRGenModule &IGM, const ProtocolConformance *conformance,
     unsigned sourceIndex, MetadataPath &&path,
@@ -297,10 +337,8 @@ bool FulfillmentMap::searchNominalTypeMetadata(IRGenModule &IGM,
       MetadataPath argPath = path;
       argPath.addNominalTypeArgumentShapeComponent(reqtIndex);
 
-      // Add the fulfillment.
-      hadFulfillment |= addFulfillment(GenericRequirement::forShape(arg),
-                                       source, std::move(argPath),
-                                       MetadataState::Complete);
+      hadFulfillment |= searchShapeRequirement(IGM, arg, source,
+                                               std::move(argPath));
       break;
     }
     case GenericRequirement::Kind::Metadata:
@@ -310,28 +348,77 @@ bool FulfillmentMap::searchNominalTypeMetadata(IRGenModule &IGM,
           getPresumedMetadataStateForTypeArgument(metadataState);
       MetadataPath argPath = path;
       argPath.addNominalTypeArgumentComponent(reqtIndex);
-      hadFulfillment |= searchTypeMetadata(
-          IGM, arg, IsExact, argState, source, std::move(argPath), keys);
+
+      if (requirement.getKind() == GenericRequirement::Kind::Metadata)
+        hadFulfillment |=
+          searchTypeMetadata(IGM, arg, IsExact, argState,
+                              source, std::move(argPath), keys);
+      else
+        hadFulfillment |=
+          searchTypeMetadataPack(IGM, cast<PackType>(arg), IsExact, argState,
+                                 source, std::move(argPath), keys);
       break;
     }
-    case GenericRequirement::Kind::WitnessTable:
-    case GenericRequirement::Kind::WitnessTablePack: {
-      // Ignore it unless the type itself is interesting.
-      if (!keys.isInterestingType(arg))
-        continue;
+    case GenericRequirement::Kind::WitnessTablePack:
+    case GenericRequirement::Kind::WitnessTable: {
+      Optional<unsigned> packExpansionComponent;
+      if (requirement.getKind() == GenericRequirement::Kind::WitnessTable) {
+        // Ignore it unless the type itself is interesting.
+        if (!keys.isInterestingType(arg))
+          continue;
+      } else {
+        // Ignore it unless the pack is a singleton pack expansion of a
+        // type parameter, in which case use that type below.
+        auto param =
+            getSingletonPackExpansionParameter(cast<PackType>(arg), keys,
+                                               packExpansionComponent);
+        if (!param) continue;
+        arg = param;
+      }
 
       // Refine the path.
       MetadataPath argPath = path;
       argPath.addNominalTypeArgumentConformanceComponent(reqtIndex);
+      if (packExpansionComponent)
+        argPath.addPackExpansionPatternComponent(*packExpansionComponent);
 
-      hadFulfillment |= searchWitnessTable(IGM, arg, requirement.getProtocol(),
-                                           source, std::move(argPath), keys);
+      // This code just handles packs directly.
+      hadFulfillment |=
+        searchWitnessTable(IGM, arg, requirement.getProtocol(),
+                           source, std::move(argPath), keys);
       break;
     }
     }
   }
 
   return hadFulfillment;
+}
+
+bool FulfillmentMap::searchShapeRequirement(IRGenModule &IGM, CanType argType,
+                                            unsigned source, MetadataPath &&path) {
+  // argType is the substitution for a pack parameter, so it should always
+  // be a pack.
+  auto packType = cast<PackType>(argType);
+
+  // For now, don't try to fulfill shapes if this isn't a singleton
+  // pack containing a pack expansion.  In theory, though, as long as
+  // there aren't expansions over pack parameters with different shapes,
+  // we should always be able to turn this into the equation
+  // `ax + b = <fulfilled count>` and then solve that.
+  if (packType->getNumElements() != 1)
+    return false;
+  auto expansion =
+    dyn_cast<PackExpansionType>(packType.getElementType(0));
+  if (!expansion)
+    return false;
+
+  path.addPackExpansionCountComponent(0);
+
+  auto parameter = expansion.getCountType();
+  
+  // Add the fulfillment.
+  return addFulfillment(GenericRequirement::forShape(parameter),
+                        source, std::move(path), MetadataState::Complete);
 }
 
 /// Testify that there's a fulfillment at the given path.

--- a/lib/IRGen/Fulfillment.h
+++ b/lib/IRGen/Fulfillment.h
@@ -62,6 +62,10 @@ public:
     /// It's okay to conservatively return true here.
     virtual bool hasInterestingType(CanType type) const = 0;
 
+    /// Is the given pack expansion a simple expansion of an interesting
+    /// type?
+    virtual bool isInterestingPackExpansion(CanPackExpansionType type) const = 0;
+
     /// Are we only interested in a subset of the conformances for a
     /// given type?
     virtual bool hasLimitedInterestingConformances(CanType type) const = 0;
@@ -98,6 +102,15 @@ public:
                           unsigned sourceIndex, MetadataPath &&path,
                           const InterestingKeysCallback &interestingKeys);
 
+  /// Search the given type metadata pack for useful fulfillments.
+  ///
+  /// \return true if any fulfillments were added by this search.
+  bool searchTypeMetadataPack(IRGenModule &IGM, CanPackType type,
+                              IsExact_t isExact,
+                              MetadataState metadataState,
+                              unsigned sourceIndex, MetadataPath &&path,
+                              const InterestingKeysCallback &interestingKeys);
+
   bool searchConformance(IRGenModule &IGM,
                          const ProtocolConformance *conformance,
                          unsigned sourceIndex, MetadataPath &&path,
@@ -109,6 +122,10 @@ public:
   bool searchWitnessTable(IRGenModule &IGM, CanType type, ProtocolDecl *protocol,
                           unsigned sourceIndex, MetadataPath &&path,
                           const InterestingKeysCallback &interestingKeys);
+
+  /// Consider a shape requirement for the given type.
+  bool searchShapeRequirement(IRGenModule &IGM, CanType type,
+                              unsigned sourceIndex, MetadataPath &&path);
 
   /// Register a fulfillment for the given key.
   ///

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -442,13 +442,13 @@ withOpaqueTypeGenericArgs(IRGenFunction &IGF,
         [&](GenericRequirement reqt) {
           auto ty = reqt.getTypeParameter().subst(archetype->getSubstitutions())
                         ->getReducedType(opaqueDecl->getGenericSignature());
-          if (reqt.isWitnessTable()) {
+          if (reqt.isAnyWitnessTable()) {
             auto ref =
                 ProtocolConformanceRef(reqt.getProtocol())
                     .subst(reqt.getTypeParameter(), archetype->getSubstitutions());
             args.push_back(emitWitnessTableRef(IGF, ty, ref));
           } else {
-            assert(reqt.isMetadata());
+            assert(reqt.isAnyMetadata());
             args.push_back(IGF.emitAbstractTypeMetadataRef(ty));
           }
           types.push_back(args.back()->getType());

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -896,12 +896,12 @@ emitKeyPathComponent(IRGenModule &IGM,
                 return None;
               })->getCanonicalType();
 
-              if (reqt.isMetadata()) {
+              if (reqt.isAnyMetadata()) {
                 // Type requirement.
                 externalSubArgs.push_back(emitMetadataTypeRefForKeyPath(
                     IGM, substType, componentCanSig));
               } else {
-                assert(reqt.isWitnessTable());
+                assert(reqt.isAnyWitnessTable());
 
                 // Protocol requirement.
                 auto conformance = subs.lookupConformance(

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -4432,7 +4432,7 @@ namespace {
     }
 
     void addGenericRequirement(GenericRequirement requirement) {
-      if (requirement.isMetadata()) {
+      if (requirement.isAnyMetadata()) {
         auto t = requirement.getTypeParameter().subst(genericSubstitutions());
         ConstantReference ref = IGM.getAddrOfTypeMetadata(
             CanType(t), SymbolReferenceKind::Relative_Direct);
@@ -4440,7 +4440,7 @@ namespace {
         return;
       }
 
-      assert(requirement.isWitnessTable());
+      assert(requirement.isAnyWitnessTable());
       auto conformance = genericSubstitutions().lookupConformance(
           requirement.getTypeParameter()->getCanonicalType(),
           requirement.getProtocol());

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -130,6 +130,15 @@ namespace irgen {
                                            unsigned reqtIndex,
                                            llvm::Value *metadata);
 
+  /// Given a reference to nominal type metadata of the given type,
+  /// derive a reference to a the pack shape stored in the nth
+  /// requirement slot.  The type must have generic arguments.
+  llvm::Value *emitArgumentPackShapeRef(IRGenFunction &IGF,
+                                        NominalTypeDecl *theDecl,
+                                        const GenericTypeRequirements &reqts,
+                                        unsigned reqtIndex,
+                                        llvm::Value *metadata);
+
   /// Given a metatype value, read its instance type.
   llvm::Value *emitMetatypeInstanceType(IRGenFunction &IGF,
                                         llvm::Value *metatypeMetadata);

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -122,6 +122,15 @@ namespace irgen {
                                        llvm::Value *metadata);
 
   /// Given a reference to nominal type metadata of the given type,
+  /// derive a reference to the type metadata pack stored in the nth
+  /// requirement slot.  The type must have generic arguments.
+  llvm::Value *emitArgumentMetadataPackRef(IRGenFunction &IGF,
+                                           NominalTypeDecl *theDecl,
+                                           const GenericTypeRequirements &reqts,
+                                           unsigned reqtIndex,
+                                           llvm::Value *metadata);
+
+  /// Given a reference to nominal type metadata of the given type,
   /// derive a reference to a protocol witness table stored in the nth
   /// requirement slot.  The type must have generic arguments.
   llvm::Value *emitArgumentWitnessTableRef(IRGenFunction &IGF,
@@ -129,6 +138,15 @@ namespace irgen {
                                            const GenericTypeRequirements &reqts,
                                            unsigned reqtIndex,
                                            llvm::Value *metadata);
+
+  /// Given a reference to nominal type metadata of the given type,
+  /// derive a reference to a protocol witness table pack stored in the nth
+  /// requirement slot.  The type must have generic arguments.
+  llvm::Value *emitArgumentWitnessTablePackRef(IRGenFunction &IGF,
+                                               NominalTypeDecl *theDecl,
+                                           const GenericTypeRequirements &reqts,
+                                               unsigned reqtIndex,
+                                               llvm::Value *metadata);
 
   /// Given a reference to nominal type metadata of the given type,
   /// derive a reference to a the pack shape stored in the nth

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -1174,11 +1174,11 @@ public:
 
     auto &Bindings = Layout.getBindings();
     for (unsigned i = 0; i < Bindings.size(); ++i) {
-      // Skip protocol requirements (FIXME: for now?)
-      if (Bindings[i].isWitnessTable())
+      // Skip protocol requirements and counts.  It shouldn't be possible
+      // to get an opened existential type in a conformance requirement
+      // without having one in the generic arguments.
+      if (!Bindings[i].isAnyMetadata())
         continue;
-
-      assert(Bindings[i].isMetadata());
 
       if (Bindings[i].getTypeParameter()->hasOpenedExistential())
         return true;
@@ -1221,10 +1221,11 @@ public:
     auto &Bindings = Layout.getBindings();
     for (unsigned i = 0; i < Bindings.size(); ++i) {
       // Skip protocol requirements (FIXME: for now?)
-      if (Bindings[i].isWitnessTable())
+      if (Bindings[i].isAnyWitnessTable())
         continue;
 
-      assert(Bindings[i].isMetadata());
+      // FIXME: bind pack counts in the source map
+      assert(Bindings[i].isAnyMetadata());
 
       auto Source = SourceBuilder.createClosureBinding(i);
       auto BindingType = Bindings[i].getTypeParameter();

--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -289,7 +289,10 @@ LocalTypeDataCache::tryGet(IRGenFunction &IGF, LocalTypeDataKey key,
     auto response = entry->follow(IGF, source, request);
 
     // Following the path automatically caches at every point along it,
-    // including the end.
+    // including the end.  If you hit the second assertion here, it's
+    // probably because MetadataPath::followComponent isn't updating
+    // sourceKey correctly to lead back to the same key you originally
+    // looked up.
     assert(chain.Root->DefinitionPoint == IGF.getActiveDominancePoint());
     assert(isa<ConcreteCacheEntry>(chain.Root));
 
@@ -496,6 +499,9 @@ void LocalTypeDataCache::addAbstractForTypeMetadata(IRGenFunction &IGF,
     }
     bool hasInterestingType(CanType type) const override {
       return true;
+    }
+    bool isInterestingPackExpansion(CanPackExpansionType type) const override {
+      return isa<PackArchetypeType>(type.getPatternType());
     }
     bool hasLimitedInterestingConformances(CanType type) const override {
       return false;

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -217,9 +217,23 @@ llvm::Value *irgen::emitArgumentMetadataRef(IRGenFunction &IGF,
                                       const GenericTypeRequirements &reqts,
                                             unsigned reqtIndex,
                                             llvm::Value *metadata) {
-  assert(reqts.getRequirements()[reqtIndex].isMetadata());
+  assert(reqts.getRequirements()[reqtIndex].getKind()
+           == GenericRequirement::Kind::Metadata);
   return emitLoadOfGenericRequirement(IGF, metadata, decl, reqtIndex,
                                       IGF.IGM.TypeMetadataPtrTy);
+}
+
+/// Given a reference to nominal type metadata of the given type,
+/// derive a reference to the nth argument metadata pack.  The type must
+/// have generic arguments.
+llvm::Value *irgen::emitArgumentMetadataPackRef(IRGenFunction &IGF,
+                                                NominalTypeDecl *decl,
+                                      const GenericTypeRequirements &reqts,
+                                                unsigned reqtIndex,
+                                                llvm::Value *metadata) {
+  assert(reqts.getRequirements()[reqtIndex].isMetadataPack());
+  return emitLoadOfGenericRequirement(IGF, metadata, decl, reqtIndex,
+                                      IGF.IGM.TypeMetadataPtrPtrTy);
 }
 
 /// Given a reference to nominal type metadata of the given type,
@@ -230,9 +244,23 @@ llvm::Value *irgen::emitArgumentWitnessTableRef(IRGenFunction &IGF,
                                           const GenericTypeRequirements &reqts,
                                                 unsigned reqtIndex,
                                                 llvm::Value *metadata) {
-  assert(reqts.getRequirements()[reqtIndex].isWitnessTable());
+  assert(reqts.getRequirements()[reqtIndex].getKind()
+           == GenericRequirement::Kind::WitnessTable);
   return emitLoadOfGenericRequirement(IGF, metadata, decl, reqtIndex,
                                       IGF.IGM.WitnessTablePtrTy);
+}
+
+/// Given a reference to nominal type metadata of the given type,
+/// derive a reference to a protocol witness table pack for the nth
+/// argument metadata.  The type must have generic arguments.
+llvm::Value *irgen::emitArgumentWitnessTablePackRef(IRGenFunction &IGF,
+                                                    NominalTypeDecl *decl,
+                                          const GenericTypeRequirements &reqts,
+                                                    unsigned reqtIndex,
+                                                    llvm::Value *metadata) {
+  assert(reqts.getRequirements()[reqtIndex].isWitnessTablePack());
+  return emitLoadOfGenericRequirement(IGF, metadata, decl, reqtIndex,
+                                      IGF.IGM.WitnessTablePtrPtrTy);
 }
 
 /// Given a reference to nominal type metadata of the given type,

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -235,6 +235,19 @@ llvm::Value *irgen::emitArgumentWitnessTableRef(IRGenFunction &IGF,
                                       IGF.IGM.WitnessTablePtrTy);
 }
 
+/// Given a reference to nominal type metadata of the given type,
+/// derive a reference to the pack shape for the nth argument
+/// metadata.  The type must have generic arguments.
+llvm::Value *irgen::emitArgumentPackShapeRef(IRGenFunction &IGF,
+                                             NominalTypeDecl *decl,
+                                       const GenericTypeRequirements &reqts,
+                                             unsigned reqtIndex,
+                                             llvm::Value *metadata) {
+  assert(reqts.getRequirements()[reqtIndex].isShape());
+  return emitLoadOfGenericRequirement(IGF, metadata, decl, reqtIndex,
+                                      IGF.IGM.SizeTy);
+}
+
 Address irgen::emitAddressOfFieldOffsetVector(IRGenFunction &IGF,
                                               llvm::Value *metadata,
                                               NominalTypeDecl *decl) {

--- a/lib/IRGen/MetadataPath.h
+++ b/lib/IRGen/MetadataPath.h
@@ -57,6 +57,9 @@ class MetadataPath {
       /// Witness table at requirement index P of a generic nominal type.
       NominalTypeArgumentConformance,
 
+      /// Pack length at requirement index P of a generic nominal type.
+      NominalTypeArgumentShape,
+
       /// Type metadata at requirement index P of a generic nominal type.
       NominalTypeArgument,
 
@@ -104,6 +107,7 @@ class MetadataPath {
       switch (getKind()) {
       case Kind::OutOfLineBaseProtocol:
       case Kind::NominalTypeArgumentConformance:
+      case Kind::NominalTypeArgumentShape:
       case Kind::NominalTypeArgument:
       case Kind::ConditionalConformance:
         return OperationCost::Load;
@@ -157,6 +161,13 @@ public:
   /// stored at requirement index n in a generic type metadata.
   void addNominalTypeArgumentConformanceComponent(unsigned index) {
     Path.push_back(Component(Component::Kind::NominalTypeArgumentConformance,
+                             index));
+  }
+
+  /// Add a step to this path which gets the pack length stored at
+  /// requirement index n in a generic type metadata.
+  void addNominalTypeArgumentShapeComponent(unsigned index) {
+    Path.push_back(Component(Component::Kind::NominalTypeArgumentShape,
                              index));
   }
 

--- a/lib/IRGen/MetadataPath.h
+++ b/lib/IRGen/MetadataPath.h
@@ -66,7 +66,14 @@ class MetadataPath {
       /// Conditional conformance at index P (i.e. the P'th element) of a
       /// conformance.
       ConditionalConformance,
-      LastWithPrimaryIndex = ConditionalConformance,
+
+      /// The pattern type of a pack expansion at index P in a pack.
+      PackExpansionPattern,
+
+      /// The count type of a pack expansion at index P in a pack.
+      PackExpansionCount,
+
+      LastWithPrimaryIndex = PackExpansionCount,
 
       // Everything past this point has no index.
 
@@ -114,6 +121,10 @@ class MetadataPath {
 
       case Kind::AssociatedConformance:
         return OperationCost::Call;
+
+      case Kind::PackExpansionPattern:
+      case Kind::PackExpansionCount:
+        return OperationCost::Arithmetic;
 
       case Kind::Impossible:
         llvm_unreachable("cannot compute cost of an impossible path");
@@ -189,6 +200,14 @@ public:
 
   void addConditionalConformanceComponent(unsigned index) {
     Path.push_back(Component(Component::Kind::ConditionalConformance, index));
+  }
+
+  void addPackExpansionPatternComponent(unsigned index) {
+    Path.push_back(Component(Component::Kind::PackExpansionPattern, index));
+  }
+
+  void addPackExpansionCountComponent(unsigned index) {
+    Path.push_back(Component(Component::Kind::PackExpansionCount, index));
   }
 
   /// Return an abstract measurement of the cost of this path.

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2488,10 +2488,10 @@ irgen::emitCanonicalSpecializedGenericTypeMetadataAccessFunction(
   auto substitutions =
       theType->getContextSubstitutionMap(IGF.IGM.getSwiftModule(), nominal);
   for (auto requirement : requirements.getRequirements()) {
-    if (requirement.isWitnessTable()) {
+    if (requirement.isAnyWitnessTable()) {
       continue;
     }
-    assert(requirement.isMetadata());
+    assert(requirement.isMetadata()); // FIXME: packs and counts
     auto parameter = requirement.getTypeParameter();
     auto noncanonicalArgument = parameter.subst(substitutions);
     auto argument = noncanonicalArgument->getCanonicalType();

--- a/lib/PrintAsClang/ClangSyntaxPrinter.cpp
+++ b/lib/PrintAsClang/ClangSyntaxPrinter.cpp
@@ -346,7 +346,8 @@ void ClangSyntaxPrinter::printGenericSignatureParams(
 
 void ClangSyntaxPrinter::printGenericRequirementInstantiantion(
     const GenericRequirement &requirement) {
-  assert(requirement.isMetadata() && "protocol requirements not supported yet!");
+  assert(requirement.isAnyMetadata() &&
+         "protocol requirements not supported yet!");
   auto *gtpt = requirement.getTypeParameter()->getAs<GenericTypeParamType>();
   assert(gtpt && "unexpected generic param type");
   os << "swift::TypeMetadataTrait<";

--- a/lib/PrintAsClang/PrintClangFunction.cpp
+++ b/lib/PrintAsClang/PrintClangFunction.cpp
@@ -878,10 +878,10 @@ ClangRepresentation DeclAndTypeClangFunctionPrinter::printFunctionSignature(
           emitNewParam();
           os << "void * _Nonnull ";
           auto reqt = genericRequirementParam.getRequirement();
-          if (reqt.isWitnessTable())
+          if (reqt.isAnyWitnessTable())
             ClangSyntaxPrinter(os).printBaseName(reqt.getProtocol());
           else
-            assert(reqt.isMetadata());
+            assert(reqt.isAnyMetadata());
         },
         [&](const LoweredFunctionSignature::MetadataSourceParameter
                 &metadataSrcParam) {
@@ -1215,7 +1215,7 @@ void DeclAndTypeClangFunctionPrinter::printCxxThunkBody(
           emitNewParam();
           auto genericRequirement = genericRequirementParam.getRequirement();
           // FIXME: Add protocol requirement support.
-          assert(genericRequirement.isMetadata());
+          assert(genericRequirement.isAnyMetadata());
           if (auto *gtpt = genericRequirement.getTypeParameter()
                                ->getAs<GenericTypeParamType>()) {
             os << "swift::TypeMetadataTrait<";

--- a/test/IRGen/variadic_generic_fulfillments.sil
+++ b/test/IRGen/variadic_generic_fulfillments.sil
@@ -1,0 +1,54 @@
+// RUN: %target-swift-frontend -emit-ir -primary-file %s -enable-experimental-feature VariadicGenerics | %IRGenFileCheck %s
+
+// Because of -enable-experimental-feature VariadicGenerics
+// REQUIRES: asserts
+
+import Builtin
+import Swift
+
+struct A<each T> {}
+struct B<each T> {}
+
+struct C<each T : Collection> {}
+struct D<each T : Collection> {}
+
+sil @use_metadata : $<T> () -> ()
+
+// CHECK-LABEL: define{{.*}} void @test_simple_fulfillment(%swift.type* %0)
+sil @test_simple_fulfillment : $<each T> (@thick A<repeat each T>.Type) -> () {
+bb0(%0: $@thick A<repeat each T>.Type):
+  %use_metadata = function_ref @use_metadata : $@convention(thin) <T> () -> ()
+
+  // CHECK: [[T0:%.*]] = bitcast %swift.type* %0 to [[INT]]*
+  // CHECK: [[T1:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[T0]], [[INT]] 2
+  // CHECK: [[COUNT:%.*]] = load [[INT]], [[INT]]* [[T1]], align
+  // CHECK: [[T0:%.*]] = bitcast %swift.type* %0 to %swift.type***
+  // CHECK: [[T1:%.*]] = getelementptr inbounds %swift.type**, %swift.type*** [[T0]], [[INT]] 3
+  // CHECK: [[PACK:%.*]] = load %swift.type**, %swift.type*** [[T1]], align
+  // CHECK: call swiftcc %swift.metadata_response @"$s29variadic_generic_fulfillments1BVMa"([[INT]] 0, [[INT]] [[COUNT]], %swift.type** [[PACK]])
+  apply %use_metadata<B<repeat each T>>() : $@convention(thin) <T> () -> ()
+
+  %ret = tuple ()
+  return %ret : $()
+}
+
+// CHECK-LABEL: define{{.*}} void @test_simple_fulfillment_constrained(%swift.type* %0)
+sil @test_simple_fulfillment_constrained : $<each T : Collection> (@thick C<repeat each T>.Type) -> () {
+bb0(%0: $@thick C<repeat each T>.Type):
+  %use_metadata = function_ref @use_metadata : $@convention(thin) <T> () -> ()
+
+  // CHECK: [[T0:%.*]] = bitcast %swift.type* %0 to [[INT]]*
+  // CHECK: [[T1:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[T0]], [[INT]] 2
+  // CHECK: [[COUNT:%.*]] = load [[INT]], [[INT]]* [[T1]], align
+  // CHECK: [[T0:%.*]] = bitcast %swift.type* %0 to %swift.type***
+  // CHECK: [[T1:%.*]] = getelementptr inbounds %swift.type**, %swift.type*** [[T0]], [[INT]] 3
+  // CHECK: [[PACK:%.*]] = load %swift.type**, %swift.type*** [[T1]], align
+  // CHECK: [[T0:%.*]] = bitcast %swift.type* %0 to i8****
+  // CHECK: [[T1:%.*]] = getelementptr inbounds i8***, i8**** [[T0]], [[INT]] 4
+  // CHECK: [[WTABLE_PACK:%.*]] = load i8***, i8**** [[T1]], align
+  // CHECK: call swiftcc %swift.metadata_response @"$s29variadic_generic_fulfillments1DVMa"([[INT]] 0, [[INT]] [[COUNT]], %swift.type** [[PACK]], i8*** [[WTABLE_PACK]])
+  apply %use_metadata<D<repeat each T>>() : $@convention(thin) <T> () -> ()
+
+  %ret = tuple ()
+  return %ret : $()
+}


### PR DESCRIPTION
This PR takes over @slavapestov's #64163 and adds a number of fixes around the local type data and fulfillment subsystems.