### PR TITLE
Don't DCE lexical phis with only destroy users

### DIFF
--- a/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadCodeElimination.cpp
@@ -274,7 +274,13 @@ void DCE::markLive() {
         addReverseDependency(beginAccess, &I);
         break;
       }
-      case SILInstructionKind::DestroyValueInst:
+      case SILInstructionKind::DestroyValueInst: {
+        auto phi = PhiValue(I.getOperand(0));
+        if (phi && phi->isLexical()) {
+          markInstructionLive(&I);
+        }
+        break;
+      }
       case SILInstructionKind::EndBorrowInst:
       case SILInstructionKind::EndLifetimeInst: {
         // The instruction is live only if it's operand value is also live

--- a/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
+++ b/test/SILOptimizer/dead_code_elimination_nontrivial_ossa.sil
@@ -1150,3 +1150,28 @@ bb3(%phi3 : @guaranteed $Klass, %phi4 : @guaranteed $Wrapper1):
   return %9999 : $()
 }
 
+
+class C {}
+
+sil [ossa] @getC : $@convention(thin) () -> (@owned C)
+
+// CHECK-LABEL: sil [ossa] @dont_dce_lexical_phi :
+// CHECK: destroy_value
+// CHECK-LABEL: } // end sil function 'dont_dce_lexical_phi'
+sil [ossa] @dont_dce_lexical_phi : $() -> () {
+ entry:
+   %getC = function_ref @getC : $@convention(thin) () -> (@owned C)
+   cond_br undef, left, right
+ left:
+   %c1 = apply %getC() : $@convention(thin) () -> (@owned C)
+   %m1 = move_value [lexical] %c1 : $C
+   br exit(%m1 : $C)
+ right:
+   %c2 = apply %getC() : $@convention(thin) () -> (@owned C)
+   br exit(%c2 : $C)
+ exit(%cm : @owned $C):
+   destroy_value %cm : $C
+   %retval = tuple ()
+   return %retval : $()
+}
+


### PR DESCRIPTION
DCE treats an @owned phi with only destroy users as dead and moves the destroys to the end of its predecessors. Ban this on lexical phis.