### PR TITLE
[Backtracing][Freestanding] Add _stat to the list of expected symbols.

### DIFF
--- a/utils/check_freestanding_dependencies.py
+++ b/utils/check_freestanding_dependencies.py
@@ -49,6 +49,7 @@ common_expected_dependencies = [
     "_posix_memalign", "_putc", "_read", "_realloc", "_snprintf", "_strchr",
     "_strcmp", "_strdup", "_strlen", "_strncmp", "_strtod", "_strtof",
     "_strtol", "_strtold", "_vprintf", "_vsnprintf", "_write",
+    "_stat", "_stat$INODE64",
 ] + cxx_dependencies + math_dependencies
 vendor_apple_specific_dependencies = [
     "___stack_chk_fail", "___stack_chk_guard",


### PR DESCRIPTION
The code in `stdlib/runtime/Paths.cpp` will use `stat()` if it finds it, but not otherwise.  As a result, it can turn up in the symbols in the OSS freestanding build.

rdar://106529399
