### PR TITLE
Disable async-stream test in freestanding mode

### DIFF
--- a/test/Concurrency/Runtime/async_stream.swift
+++ b/test/Concurrency/Runtime/async_stream.swift
@@ -6,6 +6,7 @@
 
 // rdar://78109470
 // UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: freestanding
 
 import _Concurrency
 import StdlibUnittest


### PR DESCRIPTION
Resolves rdar://106529250 

These types don't exist in freestanding mode.