### PR TITLE
[Build] Stop CMake from de-duplicating -Xfrontend options (take 2).

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -209,13 +209,13 @@ function(add_pure_swift_host_library name)
   # Avoid introducing an implicit dependency on the string-processing library.
   if(SWIFT_SUPPORTS_DISABLE_IMPLICIT_STRING_PROCESSING_MODULE_IMPORT)
     target_compile_options(${name} PRIVATE
-      $<$<COMPILE_LANGUAGE:Swift>:"SHELL:-Xfrontend -disable-implicit-string-processing-module-import">)
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-string-processing-module-import>")
   endif()
 
   # Same for backtracing
   if (SWIFT_SUPPORTS_DISABLE_IMPLICIT_BACKTRACING_MODULE_IMPORT)
     target_compile_options(${name} PRIVATE
-      $<$<COMPILE_LANGUAGE:Swift>:"SHELL:-Xfrontend -disable-implicit-backtracing-module-import">)
+      "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -disable-implicit-backtracing-module-import>")
   endif()
 
   # The compat56 library is not available in current toolchains. The stage-0


### PR DESCRIPTION
CMake has a misfeature wherein it tries to de-duplicate command line options. This caused it to omit an `-Xfrontend` option when using `add_pure_swift_host_library`.

(I got the quotes in the wrong place the first time around.)

rdar://106547267
