### PR TITLE
[interop][SwiftToCxx] hide swift::Error APIs by default in C++ Swift …

### DIFF
--- a/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
+++ b/lib/PrintAsClang/_SwiftStdlibCxxOverlay.h
@@ -124,6 +124,8 @@ SWIFT_INLINE_THUNK cxxOverlay::IterationEndSentinel end(const Array<T> &) {
   return {};
 }
 
+#ifdef SWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR
+
 extern "C" void *_Nonnull swift_errorRetain(void *_Nonnull swiftError) noexcept;
 
 extern "C" void swift_errorRelease(void *_Nonnull swiftError) noexcept;
@@ -405,5 +407,6 @@ template <class T> using ThrowingResult = swift::Expected<T>;
 #endif
 
 #endif // SWIFT_CXX_INTEROP_HIDE_SWIFT_ERROR
+#endif // SWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR
 
 #endif

--- a/test/Interop/SwiftToCxx/functions/swift-expected-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-expected-execution.cpp
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %S/swift-functions-errors.swift -typecheck -module-name Functions -Xcc -fno-exceptions -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -emit-clang-header-path %t/functions.h
 
-// RUN: %target-interop-build-clangxx -c %s -I %t -fno-exceptions -o %t/swift-expected-execution.o
+// RUN: %target-interop-build-clangxx -c %s -I %t -fno-exceptions -o %t/swift-expected-execution.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR
 // RUN: %target-interop-build-swift %S/swift-functions-errors.swift -o %t/swift-expected-execution -Xlinker %t/swift-expected-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX
 
 // RUN: %target-codesign %t/swift-expected-execution

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors-execution.cpp
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend %S/swift-functions-errors.swift -typecheck -module-name Functions -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -emit-clang-header-path %t/functions.h
 
-// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-functions-errors-execution.o
+// RUN: %target-interop-build-clangxx -c %s -I %t -o %t/swift-functions-errors-execution.o -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR
 // RUN: %target-interop-build-swift %S/swift-functions-errors.swift -o %t/swift-functions-errors-execution -Xlinker %t/swift-functions-errors-execution.o -module-name Functions -Xfrontend -entry-point-function-name -Xfrontend swiftMain -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX
 
 // RUN: %target-codesign %t/swift-functions-errors-execution

--- a/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
+++ b/test/Interop/SwiftToCxx/functions/swift-functions-errors.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swift-frontend %s -typecheck -module-name Functions -enable-experimental-cxx-interop -clang-header-expose-decls=has-expose-attr-or-stdlib -enable-experimental-feature GenerateBindingsForThrowingFunctionsInCXX -emit-clang-header-path %t/functions.h
 // RUN: %FileCheck %s < %t/functions.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -Wno-unused-function)
+// RUN: %check-interop-cxx-header-in-clang(%t/functions.h -DSWIFT_CXX_INTEROP_HIDE_STL_OVERLAY -DSWIFT_CXX_INTEROP_EXPERIMENTAL_SWIFT_ERROR -Wno-unused-function)
 
 // for experimental feature GenerateBindingsForThrowingFunctionsInCXX:
 // REQUIRES: asserts


### PR DESCRIPTION
…stdlib overlay

They're still experimental
