### PR TITLE
Add --enable-asan option in swift-driver

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/earlyswiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/earlyswiftdriver.py
@@ -152,6 +152,10 @@ def run_build_script_helper(action, host_target, product, args):
         helper_cmd += [
             '--lit-test-dir', lit_test_dir
         ]
+
+    if args.enable_asan:
+        helper_cmd.append('--enable-asan')
+
     if args.verbose_build:
         helper_cmd.append('--verbose')
 

--- a/utils/swift_build_support/swift_build_support/products/swiftdriver.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftdriver.py
@@ -142,6 +142,10 @@ def run_build_script_helper(action, host_target, product, args):
                     host_target).platform.swiftpm_config(
                     args, output_dir=build_toolchain_path,
                     swift_toolchain=toolchain_path, resource_path=resource_dir)]
+
+    if args.enable_asan:
+        helper_cmd.append('--enable-asan')
+
     if args.verbose_build:
         helper_cmd.append('--verbose')
 


### PR DESCRIPTION
This is to support building the swift-driver with -sanitize=address when the Swift build preset specifies enable-asan. Without this option and with enable-asan in picture the entire Swift build fails due to ASAN initialization failure in swift-driver. This commit is dependent on https://github.com/apple/swift-driver/pull/1310 being merged first

rdar://104661463
