### PR TITLE
[cxx-interop] Do not auto-complete unsafe underscored methods

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -257,6 +257,10 @@ struct PrintOptions {
   /// Protocols marked with @_show_in_interface are still printed.
   bool SkipUnderscoredStdlibProtocols = false;
 
+  /// Whether to skip unsafe C++ class methods that were renamed
+  /// (e.g. __fooUnsafe). See IsSafeUseOfCxxDecl.
+  bool SkipUnsafeCXXMethods = false;
+
   /// Whether to skip extensions that don't add protocols or no members.
   bool SkipEmptyExtensionDecls = true;
 
@@ -639,6 +643,7 @@ struct PrintOptions {
     result.SkipSwiftPrivateClangDecls = true;
     result.SkipPrivateStdlibDecls = true;
     result.SkipUnderscoredStdlibProtocols = true;
+    result.SkipUnsafeCXXMethods = true;
     result.SkipDeinit = true;
     result.EmptyLineBetweenMembers = true;
     result.CascadeDocComment = true;
@@ -753,6 +758,7 @@ struct PrintOptions {
     PO.PrintDocumentationComments = false;
     PO.ExcludeAttrList.push_back(DAK_Available);
     PO.SkipPrivateStdlibDecls = true;
+    PO.SkipUnsafeCXXMethods = true;
     PO.ExplodeEnumCaseDecls = true;
     PO.ShouldQualifyNestedDeclarations = QualifyNestedDeclarations::TypesOnly;
     PO.PrintParameterSpecifiers = true;

--- a/test/Interop/Cxx/class/type-classification-completion.swift
+++ b/test/Interop/Cxx/class/type-classification-completion.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=METHOD -I %S/Inputs | %FileCheck %s -check-prefix=CHECK-METHOD
+
+import TypeClassification
+
+func foo(x: HasMethodThatReturnsIterator) {
+  x.#^METHOD^#
+}
+// CHECK-METHOD-NOT: getIterator
+// CHECK-METHOD-NOT: __getIteratorUnsafe

--- a/test/Interop/Cxx/class/type-classification-module-interface.swift
+++ b/test/Interop/Cxx/class/type-classification-module-interface.swift
@@ -1,4 +1,5 @@
 // RUN: %target-swift-ide-test -print-module -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s
+// RUN: %target-swift-ide-test -print-module -skip-unsafe-cxx-methods -module-to-print=TypeClassification -I %S/Inputs -source-filename=x -enable-experimental-cxx-interop | %FileCheck %s -check-prefix=CHECK-SKIP-UNSAFE
 
 // Make sure we don't import objects that we can't copy or destroy.
 // CHECK-NOT: StructWithPrivateDefaultedCopyConstructor
@@ -24,6 +25,7 @@
 
 // CHECK: struct HasMethodThatReturnsIterator {
 // CHECK:   func __getIteratorUnsafe() -> Iterator
+// CHECK-SKIP-UNSAFE-NOT: func __getIteratorUnsafe() -> Iterator
 // CHECK: }
 
 // CHECK: struct IteratorBox {
@@ -31,4 +33,5 @@
 
 // CHECK: struct HasMethodThatReturnsIteratorBox {
 // CHECK:   func __getIteratorBoxUnsafe() -> IteratorBox
+// CHECK-SKIP-UNSAFE-NOT: func __getIteratorBoxUnsafe() -> IteratorBox
 // CHECK: }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -682,6 +682,12 @@ SkipUnderscoredStdlibProtocols("skip-underscored-stdlib-protocols",
     llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
+SkipUnsafeCXXMethods("skip-unsafe-cxx-methods",
+    llvm::cl::desc("Don't print unsafe C++ class methods that were renamed as unsafe"),
+    llvm::cl::cat(Category),
+    llvm::cl::init(false));
+
+static llvm::cl::opt<bool>
 SkipDocumentationComments("skip-print-doc-comments",
     llvm::cl::desc("Don't print documentation comments from clang module headers"),
     llvm::cl::cat(Category),
@@ -4506,6 +4512,7 @@ int main(int argc, char *argv[]) {
     PrintOpts.PrintDocumentationComments = !options::SkipDocumentationComments;
     PrintOpts.PrintRegularClangComments = options::PrintRegularComments;
     PrintOpts.SkipPrivateStdlibDecls = options::SkipPrivateStdlibDecls;
+    PrintOpts.SkipUnsafeCXXMethods = options::SkipUnsafeCXXMethods;
     PrintOpts.SkipUnavailable = options::SkipUnavailable;
     PrintOpts.SkipDeinit = options::SkipDeinit;
     PrintOpts.SkipImports = options::SkipImports;


### PR DESCRIPTION
e.g. `__beginUnsafe()` or `__endUnsafe()` which return iterators

rdar://103252957