### PR TITLE
[interop][SwiftToCxx] do not expose APIs with imported declarations w…

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -413,6 +413,16 @@ public:
   /// header.
   llvm::Optional<ClangHeaderExposeBehavior> ClangHeaderExposedDecls;
 
+  struct ClangHeaderExposedImportedModule {
+    std::string moduleName;
+    std::string headerName;
+  };
+
+  /// Indicates which imported modules have a generated header associated with
+  /// them that can be imported into the generated header for the current
+  /// module.
+  std::vector<ClangHeaderExposedImportedModule> clangHeaderExposedImports;
+
   /// \return true if the given action only parses without doing other compilation steps.
   static bool shouldActionOnlyParse(ActionType);
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -1106,6 +1106,12 @@ def clang_header_expose_decls:
   Flags<[FrontendOption, HelpHidden]>,
   MetaVarName<"all-public|has-expose-attr">;
 
+def clang_header_expose_module:
+  Separate<["-"], "clang-header-expose-module">,
+  HelpText<"Allow the compiler to assume that APIs from the specified module are exposed to C/C++/Objective-C in another generated header, so that APIs in the current module that depend on declarations from the specified module can be exposed in the generated header.">,
+  Flags<[FrontendOption, HelpHidden]>,
+  MetaVarName<"<imported-module-name>=<generated-header-name>">;
+
 def weak_link_at_target :
   Flag<["-"], "weak-link-at-target">,
   HelpText<"Weakly link symbols for declarations that were introduced at the "

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -313,7 +313,16 @@ bool ArgsToFrontendOptionsConverter::convert(
                       HasExposeAttrOrImplicitDeps)
             .Default(llvm::None);
   }
-  
+  for (const auto &arg :
+       Args.getAllArgValues(options::OPT_clang_header_expose_module)) {
+    auto splitArg = StringRef(arg).split('=');
+    if (splitArg.second.empty()) {
+      continue;
+    }
+    Opts.clangHeaderExposedImports.push_back(
+        {splitArg.first.str(), splitArg.second.str()});
+  }
+
   Opts.StrictImplicitModuleContext = Args.hasArg(OPT_strict_implicit_module_context,
                                                  OPT_no_strict_implicit_module_context,
                                                  false);

--- a/lib/PrintAsClang/DeclAndTypePrinter.h
+++ b/lib/PrintAsClang/DeclAndTypePrinter.h
@@ -18,6 +18,7 @@
 #include "swift/AST/Type.h"
 // for OptionalTypeKind
 #include "swift/ClangImporter/ClangImporter.h"
+#include "llvm/ADT/StringSet.h"
 
 namespace clang {
   class NamedDecl;
@@ -48,6 +49,7 @@ private:
   SwiftToClangInteropContext &interopContext;
   AccessLevel minRequiredAccess;
   bool requiresExposedAttribute;
+  llvm::StringSet<> &exposedModules;
   OutputLanguageMode outputLang;
 
   /// The name 'CFTypeRef'.
@@ -64,13 +66,14 @@ public:
                      PrimitiveTypeMapping &typeMapping,
                      SwiftToClangInteropContext &interopContext,
                      AccessLevel access, bool requiresExposedAttribute,
+                     llvm::StringSet<> &exposedModules,
                      OutputLanguageMode outputLang)
       : M(mod), os(out), prologueOS(prologueOS),
         outOfLineDefinitionsOS(outOfLineDefinitionsOS), delayedMembers(delayed),
         typeMapping(typeMapping), interopContext(interopContext),
         minRequiredAccess(access),
         requiresExposedAttribute(requiresExposedAttribute),
-        outputLang(outputLang) {}
+        exposedModules(exposedModules), outputLang(outputLang) {}
 
   SwiftToClangInteropContext &getInteropContext() { return interopContext; }
 

--- a/lib/PrintAsClang/ModuleContentsWriter.h
+++ b/lib/PrintAsClang/ModuleContentsWriter.h
@@ -17,6 +17,7 @@
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/PointerUnion.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/StringSet.h"
 
 namespace clang {
   class Module;
@@ -46,10 +47,9 @@ struct EmittedClangHeaderDependencyInfo {
 /// Prints the declarations of \p M to \p os in C++ language mode.
 ///
 /// \returns Dependencies required by this module.
-EmittedClangHeaderDependencyInfo printModuleContentsAsCxx(raw_ostream &os,
-                              ModuleDecl &M,
-                              SwiftToClangInteropContext &interopContext,
-                              bool requiresExposedAttribute);
+EmittedClangHeaderDependencyInfo printModuleContentsAsCxx(
+    raw_ostream &os, ModuleDecl &M, SwiftToClangInteropContext &interopContext,
+    bool requiresExposedAttribute, llvm::StringSet<> &exposedModules);
 
 } // end namespace swift
 

--- a/test/Interop/SwiftToCxx/cross-module-refs/do-not-expose-imported-api-by-default.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/do-not-expose-imported-api-by-default.swift
@@ -1,0 +1,27 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/Inputs/structs.swift -module-name Structs -emit-module -emit-module-path %t/Structs.swiftmodule
+
+// RUN: %target-swift-frontend %s -typecheck -module-name UsesStructs -I %t -clang-header-expose-decls=all-public -emit-clang-header-path %t/uses-structs.h
+
+// RUN: %check-interop-cxx-header-in-clang(%t/uses-structs.h)
+// RUN: %FileCheck %s < %t/uses-structs.h
+
+import Structs
+
+public struct StructExposed {
+    public func availableInHeader() -> Int {
+        return 0
+    }
+
+    public func unavailableInHeader(_ y: StructSeveralI64) -> StructSeveralI64 {
+        return y
+    }
+
+    public let unavailableInHeaderProp: StructSeveralI64
+}
+
+public func unavailableInHeaderFunc(_ x: StructSeveralI64) -> StructSeveralI64 {
+    return Structs.passThroughStructSeveralI64(i: 0, x, j: 2)
+}
+
+// CHECK-NOT: unavailableInHeaderFunc

--- a/test/Interop/SwiftToCxx/cross-module-refs/imported-enum-refs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/imported-enum-refs-in-cxx.swift
@@ -1,15 +1,11 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/enums.swift -module-name Enums -emit-module -emit-module-path %t/Enums.swiftmodule -clang-header-expose-decls=all-public -emit-clang-header-path %t/enums.h
 
-// RUN: %target-swift-frontend %s -typecheck -module-name UsesEnums -I %t -clang-header-expose-decls=all-public -emit-clang-header-path %t/uses-enums.h
-
-// FIXME: add import automatically?
-// RUN: echo '#include "enums.h"' > %t/fixed-uses-enums.h
-// RUN: cat %t/uses-enums.h     >> %t/fixed-uses-enums.h
+// RUN: %target-swift-frontend %s -typecheck -module-name UsesEnums -I %t -clang-header-expose-decls=all-public -emit-clang-header-path %t/uses-enums.h -clang-header-expose-module Enums=enums.h
 
 // RUN: %FileCheck %s < %t/uses-enums.h
 
-// RUN: %check-interop-cxx-header-in-clang(%t/fixed-uses-enums.h)
+// RUN: %check-interop-cxx-header-in-clang(-I %t %t/uses-enums.h)
 
 import Enums
 

--- a/test/Interop/SwiftToCxx/cross-module-refs/imported-struct-refs-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/imported-struct-refs-in-cxx.swift
@@ -1,17 +1,17 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/structs.swift -module-name Structs -emit-module -emit-module-path %t/Structs.swiftmodule -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
 
-// RUN: %target-swift-frontend %s -typecheck -module-name UsesStructs -I %t -clang-header-expose-decls=all-public -emit-clang-header-path %t/uses-structs.h
-
-// FIXME: add import automatically?
-// RUN: echo '#include "structs.h"' > %t/fixed-uses-structs.h
-// RUN: cat %t/uses-structs.h     >> %t/fixed-uses-structs.h
+// RUN: %target-swift-frontend %s -typecheck -module-name UsesStructs -I %t -clang-header-expose-decls=all-public -emit-clang-header-path %t/uses-structs.h -clang-header-expose-module Structs=structs.h
 
 // RUN: %FileCheck %s < %t/uses-structs.h
+// RUN: %check-interop-cxx-header-in-clang(-I %t %t/uses-structs.h)
 
-// RUN: %check-interop-cxx-header-in-clang(%t/fixed-uses-structs.h)
+// RUN: %target-swift-frontend %s -typecheck -module-name UsesStructs -I %t -cxx-interoperability-mode=swift-5.9 -emit-clang-header-path %t/uses-structs-default.h -clang-header-expose-module Structs=structs.h
+// RUN: %check-interop-cxx-header-in-clang(-I %t %t/uses-structs-default.h)
 
 import Structs
+
+// CHECK: #include <structs.h>
 
 public struct UsesStructsStruct {
     public func passThroughStructSeveralI64(_ y: StructSeveralI64) -> StructSeveralI64 {

--- a/test/Interop/SwiftToCxx/cross-module-refs/not-referenced-cross-module-import.swift
+++ b/test/Interop/SwiftToCxx/cross-module-refs/not-referenced-cross-module-import.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/Inputs/structs.swift -module-name Structs -emit-module -emit-module-path %t/Structs.swiftmodule -clang-header-expose-decls=all-public -emit-clang-header-path %t/structs.h
+
+// RUN: %target-swift-frontend %s -typecheck -module-name UsesStructs -I %t -clang-header-expose-decls=all-public -emit-clang-header-path %t/uses-structs.h -clang-header-expose-module Structs=structs.h
+
+// RUN: %FileCheck %s < %t/uses-structs.h
+// RUN: %check-interop-cxx-header-in-clang(-I %t %t/uses-structs.h)
+
+import Structs
+
+// CHECK-NOT: structs.h
+// CHECK: doesNotUseStructAPIs
+
+fileprivate func usesStructsAPIsButNotExposed(_ x: StructSeveralI64) -> StructSeveralI64 {
+    return Structs.passThroughStructSeveralI64(i: 0, x, j: 2)
+}
+
+public func doesNotUseStructAPIs() {
+}


### PR DESCRIPTION
…hose modules do not have a generated header as specified by the user

The frontend option '-clang-header-expose-module' allows the user to specify that APIs from an imported module have been exposed in another generated header, and thus APIs that depend on them can be safely exposed in the current generated header.