### PR TITLE
Don't let reflection handle noncopyable types yet.

### DIFF
--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -300,6 +300,7 @@ mangleSymbolNameForSymbolicMangling(const SymbolicMangling &mangling,
     prefix = "default assoc type ";
     break;
 
+  case MangledTypeRefRole::FieldMetadata:
   case MangledTypeRefRole::Metadata:
   case MangledTypeRefRole::Reflection:
     prefix = "symbolic ";

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -575,6 +575,10 @@ public:
 
 /// Describes the role of a mangled type reference string.
 enum class MangledTypeRefRole {
+  /// The mangled type reference is used for field metadata, which is used
+  /// by both in-process and out-of-process reflection, so still requires
+  /// referenced types' metadata to be fully emitted.
+  FieldMetadata,
   /// The mangled type reference is used for normal metadata.
   Metadata,
   /// The mangled type reference is used for reflection metadata.

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -377,6 +377,7 @@ llvm::Constant *IRGenModule::getAddrOfStringForTypeRef(
 
   case MangledTypeRefRole::Metadata:
   case MangledTypeRefRole::Reflection:
+  case MangledTypeRefRole::FieldMetadata:
     break;
   }
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -75,6 +75,19 @@ extern "C" void _objc_setClassCopyFixupHandler(void (* _Nonnull newFixupHandler)
 using namespace swift;
 using namespace metadataimpl;
 
+#if defined(__APPLE__)
+// Binaries using noncopyable types check the address of the symbol
+// `swift_runtimeSupportsNoncopyableTypes` before exposing any noncopyable
+// type metadata through in-process reflection, to prevent existing code
+// that expects all types to be copyable from crashing or causing bad behavior
+// by copying noncopyable types. The runtime does not yet support noncopyable
+// types, so we explicitly define this symbol to be zero for now. Binaries
+// weak-import this symbol so they will resolve it to a zero address on older
+// runtimes as well.
+__asm__("  .globl _swift_runtimeSupportsNoncopyableTypes\n");
+__asm__(".set _swift_runtimeSupportsNoncopyableTypes, 0\n");
+#endif
+
 // GenericParamDescriptor is a single byte, so while it's difficult to
 // imagine needing even a quarter this many generic params, there's very
 // little harm in doing it.

--- a/test/Interpreter/moveonly_field_in_class_reflection.swift
+++ b/test/Interpreter/moveonly_field_in_class_reflection.swift
@@ -1,0 +1,44 @@
+// RUN: %target-run-simple-swift(-Xfrontend -enable-experimental-move-only)
+// REQUIRES: executable_test
+
+// Verify that iterating through the fields of an object whose class has
+// a move-only field does not trap from trying to reflect and copy those
+// move-only fields.
+
+@_moveOnly
+public struct MO {
+    var x: Int8 = 0
+    var y: Int8 = 0
+    var z: Int8 = 0
+
+    deinit { print("destroyed MO") }
+}
+
+public class MOHaver {
+    var s: String = "hello"
+    var mo: MO = MO()
+    var b: Int8 = 42
+    var c: Any.Type = MOHaver.self
+}
+
+// CHECK-LABEL: doing nongeneric
+print("doing nongeneric")
+do {
+    let k = MOHaver()
+
+    let mirror = Mirror(reflecting: k)
+    // CHECK-NEXT: s: hello
+    // Whether this actually prints the value of `k.mo` or not is irrelevant
+    // to the test; we care that attempting to reflect the field does not trap
+    // copying a noncopyable field.
+    // CHECK-NEXT: mo:
+    // CHECK-NEXT: b: 42
+    // CHECK-NEXT: c: {{.*}}.MOHaver
+    for c in mirror.children {
+        print("\(c.label!): \(c.value)")
+    }
+    // CHECK-NEXT: destroyed MO
+}
+// CHECK-NEXT: done with nongeneric
+print("done with nongeneric")
+


### PR DESCRIPTION
We don't have any language or runtime support for noncopyable types as generic or dynamic types yet, and existing reflection code almost certainly assumes it can copy the values it's working with, and will trap or corrupt state if it does so with noncopyable types. But a class can have noncopyable fields while the type itself is copyable, and existing code assumes that it can use `Mirror` or other reflection mechanisms to safely traverse the contents of an arbitrary class.

Allow this sort of code to continue working, while still preparing for forward compatibility with future runtimes that do support noncopyable generics, by emitting the type references for fields using a function that probes the address of a new symbol in the Swift runtime. The symbol will either be missing or defined with an absolute address of zero in current or previous runtime versions, but can be changed to a non-null address in the future. If the symbol is missing or zero, then lie to the requester and say that the field has empty tuple type, so that they hopefully pass over the field without being able to do anything with the value.