### PR TITLE
Re-enable test/Generics/requirement_machine_diagnostics.swift

### DIFF
--- a/test/Generics/requirement_machine_diagnostics.swift
+++ b/test/Generics/requirement_machine_diagnostics.swift
@@ -1,7 +1,5 @@
 // RUN: %target-typecheck-verify-swift -warn-redundant-requirements
 
-// REQUIRES: rdar106457182
-
 func testInvalidConformance() {
   // expected-error@+1 {{type 'T' constrained to non-protocol, non-class type 'Int'}}
   func invalidIntConformance<T>(_: T) where T: Int {}


### PR DESCRIPTION
The underlying issue should be fixed by https://github.com/apple/swift-syntax/pull/1399

rdar://106457182
