### PR TITLE
Sema: Downgrade over-availability diagnostics to warnings for decls in extensions

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1964,7 +1964,9 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
       if (!AttrRange.isContainedIn(*EnclosingAnnotatedRange)) {
         // Members of extensions of nominal types with available ranges were
         // not diagnosed previously, so only emit a warning in that case.
-        auto limit = (enclosingDecl != parent && isa<ExtensionDecl>(parent))
+        bool inExtension = isa<ExtensionDecl>(
+            D->getDeclContext()->getTopmostDeclarationDeclContext());
+        auto limit = (enclosingDecl != parent && inExtension)
                          ? DiagnosticBehavior::Warning
                          : DiagnosticBehavior::Unspecified;
         diagnose(D->isImplicit() ? enclosingDecl->getLoc()

--- a/test/attr/attr_availability_osx.swift
+++ b/test/attr/attr_availability_osx.swift
@@ -81,7 +81,7 @@ func doSomethingDeprecatedOniOS() { }
 doSomethingDeprecatedOniOS() // okay
 
 @available(macOS 10.10, *)
-struct TestStruct {} // expected-note {{enclosing scope requires availability of macOS 10.10 or newer}}
+struct TestStruct {} // expected-note 2 {{enclosing scope requires availability of macOS 10.10 or newer}}
 
 @available(macOS 10.10, *)
 extension TestStruct { // expected-note {{enclosing scope requires availability of macOS 10.10 or newer}}
@@ -107,6 +107,11 @@ extension TestStruct { // expected-note {{enclosing scope requires availability 
 extension TestStruct {
   @available(macOS 10.9, *) // expected-warning {{instance method cannot be more available than enclosing scope}}
   func doFifthThing() {}
+
+  struct NestedStruct {
+    @available(macOS 10.9, *) // expected-warning {{instance method cannot be more available than enclosing scope}}
+    func doSixthThing() {}
+  }
 }
 
 @available(macOS 10.11, *)


### PR DESCRIPTION
Previously, the diagnostics were only downgraded to warnings when the direct parent was an extension which did not account for the case where the parent was itself nested in an extension.

Resolves rdar://106561656
