### PR TITLE
[ConstraintSystem] Handle pack expansion materialization on l-value base

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3415,6 +3415,14 @@ namespace {
       }
 
       case OverloadChoiceKind::MaterializePack: {
+        auto baseTy = solution.getResolvedType(base);
+
+        // Load the base tuple if necessary, materialization
+        // operates on r-value types only.
+        if (baseTy->is<LValueType>())
+          base = coerceToType(base, baseTy->getRValueType(),
+                              cs.getConstraintLocator(base));
+
         auto packType = solution.getResolvedType(expr);
         return cs.cacheType(
             MaterializePackExpr::create(cs.getASTContext(),

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -3506,7 +3506,13 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
     break;
 
   case OverloadChoiceKind::MaterializePack: {
-    auto *tuple = choice.getBaseType()->castTo<TupleType>();
+    // Since `.element` is only applicable to single element tuples at the
+    // moment we can just look through l-value base to load it.
+    //
+    // In the future, _if_ the syntax allows for multiple expansions
+    // this code would have to be adjusted to project l-value from the
+    // base type just like TupleIndex does.
+    auto tuple = choice.getBaseType()->getRValueType()->castTo<TupleType>();
     auto *expansion = tuple->getElementType(0)->castTo<PackExpansionType>();
     adjustedRefType = expansion->getPatternType();
     refType = adjustedRefType;

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -178,3 +178,21 @@ do {
     test[data: repeat each args, "", 42] = 0
   }
 }
+
+func test_pack_expansion_materialization_from_lvalue_base() {
+  struct Data<Value> {}
+
+  struct Test<each T> {
+    var data: (repeat Data<each T>)
+
+    init() {
+      self.data = (repeat Data<each T>())
+      _ = (repeat each data.element) // Ok
+
+      var tmp = (repeat Data<each T>()) // expected-warning {{never mutated}}
+      _ = (repeat each tmp.element) // Ok
+
+      // TODO: Add subscript test-case when syntax is supported.
+    }
+  }
+}


### PR DESCRIPTION
If the base tuple of `.element` is l-value, it has to be loaded
before pack expansion could be materialized.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
