### PR TITLE
[Macros] Don't require a declaration of `#externalMacro`.

### DIFF
--- a/test/Macros/external-macro-without-decl.swift
+++ b/test/Macros/external-macro-without-decl.swift
@@ -1,0 +1,68 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5 -module-name Swift -parse-stdlib
+
+// expected-warning@+2{{@expression has been removed in favor of @freestanding(expression)}}
+// expected-warning@+1{{external macro implementation type 'A.B' could not be found for macro 'myMacro()'; the type must be public and provided via '-load-plugin-library'}}
+@expression macro myMacro() = #externalMacro(module: "A", type: "B")
+
+// Protocols needed for string literals to work
+public protocol ExpressibleByUnicodeScalarLiteral {
+  associatedtype UnicodeScalarLiteralType: _ExpressibleByBuiltinUnicodeScalarLiteral
+
+  init(unicodeScalarLiteral value: UnicodeScalarLiteralType)
+}
+
+public protocol _ExpressibleByBuiltinExtendedGraphemeClusterLiteral
+  : _ExpressibleByBuiltinUnicodeScalarLiteral {
+
+  init(
+    _builtinExtendedGraphemeClusterLiteral start: Builtin.RawPointer,
+    utf8CodeUnitCount: Builtin.Word,
+    isASCII: Builtin.Int1)
+}
+
+public protocol ExpressibleByExtendedGraphemeClusterLiteral
+  : ExpressibleByUnicodeScalarLiteral {
+
+  associatedtype ExtendedGraphemeClusterLiteralType
+    : _ExpressibleByBuiltinExtendedGraphemeClusterLiteral
+
+  init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType)
+}
+
+extension ExpressibleByExtendedGraphemeClusterLiteral
+  where ExtendedGraphemeClusterLiteralType == UnicodeScalarLiteralType {
+
+  @_transparent
+  public init(unicodeScalarLiteral value: ExtendedGraphemeClusterLiteralType) {
+    self.init(extendedGraphemeClusterLiteral: value)
+  }
+}
+
+public protocol _ExpressibleByBuiltinStringLiteral
+  : _ExpressibleByBuiltinExtendedGraphemeClusterLiteral {
+
+  init(
+    _builtinStringLiteral start: Builtin.RawPointer,
+    utf8CodeUnitCount: Builtin.Word,
+    isASCII: Builtin.Int1)
+}
+
+public protocol ExpressibleByStringLiteral
+  : ExpressibleByExtendedGraphemeClusterLiteral {
+  associatedtype StringLiteralType: _ExpressibleByBuiltinStringLiteral
+
+  init(stringLiteral value: StringLiteralType)
+}
+
+extension ExpressibleByStringLiteral
+  where StringLiteralType == ExtendedGraphemeClusterLiteralType {
+
+  @_transparent
+  public init(extendedGraphemeClusterLiteral value: StringLiteralType) {
+    self.init(stringLiteral: value)
+  }
+}
+
+public protocol _ExpressibleByBuiltinUnicodeScalarLiteral {
+  init(_builtinUnicodeScalarLiteral value: Builtin.Int32)
+}

--- a/test/Macros/macros_diagnostics.swift
+++ b/test/Macros/macros_diagnostics.swift
@@ -14,7 +14,7 @@ protocol P { }
 
 @freestanding(expression) macro tryToHide<T: P>(_: T) -> some P = #externalMacro(module: "BuiltinMacros", type: "Blah")
 // expected-error@-1{{some' types are only permitted in properties, subscripts, and functions}}
-// expected-error@-2{{generic parameter 'T' could not be inferred}}
+// expected-warning@-2{{external macro implementation type}}
 
 internal struct X { } // expected-note{{type declared here}}
 


### PR DESCRIPTION
To enable the declaration and use of macros from a newer Swift compiler, when the standard library is from an older Swift compiler that doesn't provide a declaration of `externalMacro`, short-circuit the type-checking of `#externalMacro(module: "A", type: "B")` when it is used to declare a new macro.
