### PR TITLE
Fix bug in Dispatch executor preventing long sleeps

### DIFF
--- a/stdlib/public/BackDeployConcurrency/DispatchGlobalExecutor.inc
+++ b/stdlib/public/BackDeployConcurrency/DispatchGlobalExecutor.inc
@@ -221,8 +221,15 @@ static void swift_task_enqueueGlobalWithDelayImpl(JobDelay delay,
   job->SchedulerPrivate[Job::DispatchQueueIndex] =
       DISPATCH_QUEUE_GLOBAL_EXECUTOR;
 
+  // dispatch_time(3): Overflow causes DISPATCH_TIME_FOREVER to be returned.
   dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, delay);
-  dispatch_after_f(when, queue, dispatchContext, dispatchFunction);
+  // dispatch_after(3): The result of passing DISPATCH_TIME_FOREVER as the when
+  // parameter to `dispatch_after_f` is undefined.
+  if (when != DISPATCH_TIME_FOREVER) {
+    dispatch_after_f(when, queue, dispatchContext, dispatchFunction);
+  } else {
+    // Leak the job, this is isomorphic to the job getting delayed "forever".
+  }
 }
 
 SWIFT_CC(swift)

--- a/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
+++ b/stdlib/public/Concurrency/DispatchGlobalExecutor.inc
@@ -247,8 +247,15 @@ static void swift_task_enqueueGlobalWithDelayImpl(JobDelay delay,
   job->SchedulerPrivate[Job::DispatchQueueIndex] =
       DISPATCH_QUEUE_GLOBAL_EXECUTOR;
 
+  // dispatch_time(3): Overflow causes DISPATCH_TIME_FOREVER to be returned.
   dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, delay);
-  dispatch_after_f(when, queue, dispatchContext, dispatchFunction);
+  // dispatch_after(3): The result of passing DISPATCH_TIME_FOREVER as the when
+  // parameter to `dispatch_after_f` is undefined.
+  if (when != DISPATCH_TIME_FOREVER) {
+    dispatch_after_f(when, queue, dispatchContext, dispatchFunction);
+  } else {
+    // Leak the job, this is isomorphic to the job getting delayed "forever".
+  }
 }
 
 #define DISPATCH_UP_OR_MONOTONIC_TIME_MASK  (1ULL << 63)


### PR DESCRIPTION
Dispatch executor's swift_task_enqueueGlobalWithDelayImpl adds the requested delay to the current time and enqueues the job to run at that time. This has a bug when using a very large delay on the order of 2^63 to 2^64 nanoseconds because dispatch_time(), which is used to preform the now + delay calculation, returns DISPATCH_TIME_FOREVER. However, dispatch_after(), which is used to actually enqueue the job, has undefined behavior for this time; the result in practice is that the job is immediately run.

This change resolves the bug by leaking the job if the result of dispatch_time is DISPATCH_TIME_FOREVER. This should effectively be the same as the job getting delayed forever.

Radar-Id: rdar://problem/89455918