### PR TITLE
AST: Improve accuracy of inferred availability for synthesized declarations

### DIFF
--- a/test/ModuleInterface/actor_availability.swift
+++ b/test/ModuleInterface/actor_availability.swift
@@ -65,4 +65,16 @@ extension Enum {
     // CHECK-NEXT:   get
     // CHECK-NEXT: }
   }
+
+  // CHECK: #if compiler(>=5.3) && $Actors
+  // CHECK-NEXT: @_hasMissingDesignatedInitializers @available(macOS, unavailable)
+  // CHECK-NEXT: public actor UnavailableExtensionNestedActor {
+  @available(macOS, unavailable)
+  public actor UnavailableExtensionNestedActor {
+    // CHECK: @available(iOS 13.4, tvOS 13.4, watchOS 6.2, *)
+    // CHECK-NEXT: @available(macOS, unavailable)
+    // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
+    // CHECK-NEXT:   get
+    // CHECK-NEXT: }
+  }
 }

--- a/test/Sema/generalized_accessors_availability.swift
+++ b/test/Sema/generalized_accessors_availability.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.9 -typecheck -verify %s
+// RUN: %target-swift-frontend -target %target-cpu-apple-macosx10.50 -typecheck -verify %s
 
 // REQUIRES: OS=macosx
 
@@ -8,14 +8,14 @@ struct SetterConditionallyAvailable<T> {
     var wrappedValue: T {
         get { fatalError() }
 
-        @available(macOS 10.10, *)
+        @available(macOS 10.51, *)
         set { fatalError() }
     }
 
     var projectedValue: T {
         get { fatalError() }
 
-        @available(macOS 10.10, *)
+        @available(macOS 10.51, *)
         set { fatalError() }
     }
 }
@@ -25,14 +25,14 @@ struct ModifyConditionallyAvailable<T> {
     var wrappedValue: T {
         get { fatalError() }
 
-        @available(macOS 10.10, *)
+        @available(macOS 10.51, *)
         _modify { fatalError() }
     }
 
     var projectedValue: T {
         get { fatalError() }
 
-        @available(macOS 10.10, *)
+        @available(macOS 10.51, *)
         _modify { fatalError() }
     }
 }
@@ -41,7 +41,7 @@ struct Butt {
     var modify_conditionally_available: Int {
         get { fatalError() }
 
-        @available(macOS 10.10, *)
+        @available(macOS 10.51, *)
         _modify { fatalError() }
     }
 
@@ -52,14 +52,14 @@ struct Butt {
     var wrapped_modify_conditionally_available: Int
 }
 
-func butt(x: inout Butt) { // expected-note*{{}}
-    x.modify_conditionally_available = 0 // expected-error{{only available in macOS 10.10 or newer}} expected-note{{}}
-    x.wrapped_setter_conditionally_available = 0 // expected-error{{only available in macOS 10.10 or newer}} expected-note{{}}
-    x.wrapped_modify_conditionally_available = 0 // expected-error{{only available in macOS 10.10 or newer}} expected-note{{}}
-    x.$wrapped_setter_conditionally_available = 0 // expected-error{{only available in macOS 10.10 or newer}} expected-note{{}}
-    x.$wrapped_modify_conditionally_available = 0 // expected-error{{only available in macOS 10.10 or newer}} expected-note{{}}
+func butt(x: inout Butt) { // expected-note * {{}}
+    x.modify_conditionally_available = 0 // expected-error {{only available in macOS 10.51 or newer}} expected-note{{}}
+    x.wrapped_setter_conditionally_available = 0 // expected-error {{only available in macOS 10.51 or newer}} expected-note{{}}
+    x.wrapped_modify_conditionally_available = 0 // expected-error {{only available in macOS 10.51 or newer}} expected-note{{}}
+    x.$wrapped_setter_conditionally_available = 0 // expected-error {{only available in macOS 10.51 or newer}} expected-note{{}}
+    x.$wrapped_modify_conditionally_available = 0 // expected-error {{only available in macOS 10.51 or newer}} expected-note{{}}
 
-    if #available(macOS 10.10, *) {
+    if #available(macOS 10.51, *) {
         x.modify_conditionally_available = 0
         x.wrapped_setter_conditionally_available = 0
         x.wrapped_modify_conditionally_available = 0

--- a/validation-test/Sema/SwiftUI/rdar106575142.swift
+++ b/validation-test/Sema/SwiftUI/rdar106575142.swift
@@ -1,0 +1,33 @@
+// RUN: %target-typecheck-verify-swift -target %target-cpu-apple-macosx12 -swift-version 5
+
+// REQUIRES: objc_interop
+// REQUIRES: OS=macosx
+
+import SwiftUI
+
+@available(macOS 12, *)
+struct S {}
+
+@available(iOS, unavailable)
+extension S {
+  class NestedOtherPlatformUnavailable {
+    @Published var x: Int = 0
+    @Binding var y: Bool
+
+    init(y: Binding<Bool>) {
+      _y = y
+    }
+  }
+}
+
+@available(*, unavailable)
+extension S {
+  class NestedAlwaysUnavailable {
+    @Published var x: Int = 0
+    @Binding var y: Bool
+
+    init(y: Binding<Bool>) {
+      _y = y
+    }
+  }
+}


### PR DESCRIPTION
Previously, when creating availability attributes for synthesized declarations we would identify some set of reference declarations that the synthesized declaration should be as-available-as. The availability attributes of the reference declarations would then be merged together to create the attributes for the synthesized declaration. The problem with this approach is that the reference declarations themselves may implicitly inherit availability from their enclosing scopes, so the resulting merged attributes could be incomplete. The fix is to walk though the enclosing scopes of the reference declarations, merging the availability attributes found at each level.
    
Additionally, the merging algorithm that produces inferred availability attributes failed to deal with conflicts between platform specific and platform agnostic availability. Now the merging algorithm notices when platform agnostic availability should take precedence and avoids generating conflicting platform specific attributes.
    
Resolves rdar://106575142
