### PR TITLE
Add the remaining toolchain-distributed runtime libs to autolink-extract

### DIFF
--- a/lib/DriverTool/autolink_extract_main.cpp
+++ b/lib/DriverTool/autolink_extract_main.cpp
@@ -243,7 +243,7 @@ int autolink_extract_main(ArrayRef<const char *> Args, const char *Argv0,
   std::vector<std::string> LinkerFlags;
 
   // Keep track of whether we've already added the common
-  // Swift libraries that ususally have autolink directives
+  // Swift libraries that usually have autolink directives
   // in most object files
   std::unordered_map<std::string, bool> SwiftRuntimeLibraries = {
       // Common Swift runtime libs

--- a/lib/DriverTool/autolink_extract_main.cpp
+++ b/lib/DriverTool/autolink_extract_main.cpp
@@ -246,6 +246,8 @@ int autolink_extract_main(ArrayRef<const char *> Args, const char *Argv0,
   // Swift libraries that usually have autolink directives
   // in most object files
   std::unordered_map<std::string, bool> SwiftRuntimeLibraries = {
+      // XCTest runtime libs (must be first due to http://github.com/apple/swift-corelibs-xctest/issues/432)
+      {"-lXCTest", false},
       // Common Swift runtime libs
       {"-lswiftSwiftOnoneSupport", false},
       {"-lswiftCore", false},
@@ -269,8 +271,6 @@ int autolink_extract_main(ArrayRef<const char *> Args, const char *Argv0,
       {"-lcurl", false},
       {"-lxml2", false},
       {"-luuid", false},
-      // XCTest runtime libs (due to an RPATH bug, this must come after Foundation)
-      {"-lXCTest", false},
       // ICU Swift runtime libs
       {"-licui18nswift", false},
       {"-licuucswift", false},

--- a/lib/DriverTool/autolink_extract_main.cpp
+++ b/lib/DriverTool/autolink_extract_main.cpp
@@ -244,14 +244,41 @@ int autolink_extract_main(ArrayRef<const char *> Args, const char *Argv0,
 
   // Keep track of whether we've already added the common
   // Swift libraries that ususally have autolink directives
-  // in most object fiels
+  // in most object files
   std::unordered_map<std::string, bool> SwiftRuntimeLibraries = {
+      // Common Swift runtime libs
       {"-lswiftSwiftOnoneSupport", false},
       {"-lswiftCore", false},
       {"-lswift_Concurrency", false},
       {"-lswift_StringProcessing", false},
+      {"-lswift_RegexBuilder", false},
       {"-lswift_RegexParser", false},
       {"-lswift_Backtracing", false},
+      {"-lswiftGlibc", false},
+      {"-lBlocksRuntime", false},
+      // Dispatch-specific Swift runtime libs
+      {"-ldispatch", false},
+      {"-lDispatchStubs", false},
+      {"-lswiftDispatch", false},
+      // CoreFoundation and Foundation Swift runtime libs
+      {"-lCoreFoundation", false},
+      {"-lFoundation", false},
+      {"-lFoundationNetworking", false},
+      {"-lFoundationXML", false},
+      // Foundation support libs
+      {"-lcurl", false},
+      {"-lxml2", false},
+      {"-luuid", false},
+      // ICU Swift runtime libs
+      {"-licui18nswift", false},
+      {"-licuucswift", false},
+      {"-licudataswift", false},
+      // Common-use ordering-agnostic Linux system libs
+      {"-lm", false},
+      {"-lpthread", false},
+      {"-lutil", false},
+      {"-ldl", false},
+      {"-lz", false},
   };
 
   // Extract the linker flags from the objects.

--- a/lib/DriverTool/autolink_extract_main.cpp
+++ b/lib/DriverTool/autolink_extract_main.cpp
@@ -247,8 +247,6 @@ int autolink_extract_main(ArrayRef<const char *> Args, const char *Argv0,
   // in most object files
 
   std::vector<std::string> SwiftRuntimeLibsOrdered = {
-      // XCTest runtime libs (must be first due to http://github.com/apple/swift-corelibs-xctest/issues/432)
-      "-lXCTest",
       // Common Swift runtime libs
       "-lswiftSwiftOnoneSupport",
       "-lswiftCore",
@@ -272,6 +270,8 @@ int autolink_extract_main(ArrayRef<const char *> Args, const char *Argv0,
       "-lcurl",
       "-lxml2",
       "-luuid",
+      // XCTest runtime libs (must be first due to http://github.com/apple/swift-corelibs-xctest/issues/432)
+      "-lXCTest",
       // ICU Swift runtime libs
       "-licui18nswift",
       "-licuucswift",

--- a/lib/DriverTool/autolink_extract_main.cpp
+++ b/lib/DriverTool/autolink_extract_main.cpp
@@ -245,43 +245,48 @@ int autolink_extract_main(ArrayRef<const char *> Args, const char *Argv0,
   // Keep track of whether we've already added the common
   // Swift libraries that usually have autolink directives
   // in most object files
-  std::unordered_map<std::string, bool> SwiftRuntimeLibraries = {
+
+  std::vector<std::string> SwiftRuntimeLibsOrdered = {
       // XCTest runtime libs (must be first due to http://github.com/apple/swift-corelibs-xctest/issues/432)
-      {"-lXCTest", false},
+      "-lXCTest",
       // Common Swift runtime libs
-      {"-lswiftSwiftOnoneSupport", false},
-      {"-lswiftCore", false},
-      {"-lswift_Concurrency", false},
-      {"-lswift_StringProcessing", false},
-      {"-lswift_RegexBuilder", false},
-      {"-lswift_RegexParser", false},
-      {"-lswift_Backtracing", false},
-      {"-lswiftGlibc", false},
-      {"-lBlocksRuntime", false},
+      "-lswiftSwiftOnoneSupport",
+      "-lswiftCore",
+      "-lswift_Concurrency",
+      "-lswift_StringProcessing",
+      "-lswift_RegexBuilder",
+      "-lswift_RegexParser",
+      "-lswift_Backtracing",
+      "-lswiftGlibc",
+      "-lBlocksRuntime",
       // Dispatch-specific Swift runtime libs
-      {"-ldispatch", false},
-      {"-lDispatchStubs", false},
-      {"-lswiftDispatch", false},
+      "-ldispatch",
+      "-lDispatchStubs",
+      "-lswiftDispatch",
       // CoreFoundation and Foundation Swift runtime libs
-      {"-lCoreFoundation", false},
-      {"-lFoundation", false},
-      {"-lFoundationNetworking", false},
-      {"-lFoundationXML", false},
+      "-lCoreFoundation",
+      "-lFoundation",
+      "-lFoundationNetworking",
+      "-lFoundationXML",
       // Foundation support libs
-      {"-lcurl", false},
-      {"-lxml2", false},
-      {"-luuid", false},
+      "-lcurl",
+      "-lxml2",
+      "-luuid",
       // ICU Swift runtime libs
-      {"-licui18nswift", false},
-      {"-licuucswift", false},
-      {"-licudataswift", false},
+      "-licui18nswift",
+      "-licuucswift",
+      "-licudataswift",
       // Common-use ordering-agnostic Linux system libs
-      {"-lm", false},
-      {"-lpthread", false},
-      {"-lutil", false},
-      {"-ldl", false},
-      {"-lz", false},
+      "-lm",
+      "-lpthread",
+      "-lutil",
+      "-ldl",
+      "-lz",
   };
+  std::unordered_map<std::string, bool> SwiftRuntimeLibraries;
+  for (const auto &RuntimeLib : SwiftRuntimeLibsOrdered) {
+    SwiftRuntimeLibraries[RuntimeLib] = false;
+  }
 
   // Extract the linker flags from the objects.
   for (const auto &BinaryFileName : Invocation.getInputFilenames()) {
@@ -318,9 +323,11 @@ int autolink_extract_main(ArrayRef<const char *> Args, const char *Argv0,
     OutOS << Flag << '\n';
   }
 
-  for (const auto &RuntimeLib : SwiftRuntimeLibraries) {
-    if (RuntimeLib.second)
-      OutOS << RuntimeLib.first << '\n';
+  for (const auto &RuntimeLib : SwiftRuntimeLibsOrdered) {
+    auto entry = SwiftRuntimeLibraries.find(RuntimeLib);
+    if (entry != SwiftRuntimeLibraries.end() && entry->second) {
+      OutOS << entry->first << '\n';
+    }
   }
 
 

--- a/lib/DriverTool/autolink_extract_main.cpp
+++ b/lib/DriverTool/autolink_extract_main.cpp
@@ -269,6 +269,8 @@ int autolink_extract_main(ArrayRef<const char *> Args, const char *Argv0,
       {"-lcurl", false},
       {"-lxml2", false},
       {"-luuid", false},
+      // XCTest runtime libs (due to an RPATH bug, this must come after Foundation)
+      {"-lXCTest", false},
       // ICU Swift runtime libs
       {"-licui18nswift", false},
       {"-licuucswift", false},


### PR DESCRIPTION
This is a potential workaround for the issues reported in #58380. In testing, this change resulted in a 90% reduction in both link time and linker RAM usage with no measurable impact on the output of the build.

(I call it a workaround rather than a fix because the underlying behavior is arguably  `ld.gold`'s fault, not Swift's.)

Fixes #58380.