### PR TITLE
SILOptimizer: add complexity limit in ARCCodeMotion and DeadStoreElimination

### DIFF
--- a/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
+++ b/lib/SILOptimizer/Transforms/ARCCodeMotion.cpp
@@ -254,6 +254,17 @@ bool CodeMotionContext::run() {
   // Initialize the data flow.
   initializeCodeMotionDataFlow();
 
+  if (RCRootVault.size() > 500) {
+    // Emergency exit to avoid bad compile time problems in rare corner cases.
+    // This limit is more than enough for "real world" code.
+    // Even large functions have < 100 locations.
+    // But in some corner cases - especially in generated code - we can run
+    // into quadratic complexity for large functions.
+    // TODO: eventually the ARCCodeMotion passes will be replaced by OSSA
+    //       optimizations which shouldn't have this problem.
+    return false;
+  }
+
   // Converge the BBSetOut with iterative data flow.
   if (MultiIteration) {
     initializeCodeMotionBBMaxSet();

--- a/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
+++ b/lib/SILOptimizer/Transforms/DeadStoreElimination.cpp
@@ -1204,6 +1204,17 @@ bool DSEContext::run() {
   //
   // Initialize the BBToLocState mapping.
   unsigned LocationNum = this->getLocationVault().size();
+
+  if (LocationNum > 500) {
+    // Emergency exit to avoid bad compile time problems in rare corner cases.
+    // This limit is more than enough for "real world" code.
+    // Even large functions have < 100 locations.
+    // But in some corner cases - especially in generated code - we can run
+    // into quadratic complexity for large functions.
+    // TODO: implement DSE with a better (non-quadratic) algorithm
+    return false;
+  }
+
   for (auto bs : BBToLocState) {
     bs.data.init(&bs.block, LocationNum, Optimistic);
     bs.data.initStoreSetAtEndOfBlock(*this);


### PR DESCRIPTION
Add an emergency exit to avoid bad compile time problems in rare corner cases. The introduced limit is more than enough for "real world" code. Even large functions have < 100 locations. But in some corner cases - especially in generated code - we can run into quadratic complexity for large functions without that limit.

Fixes a compile time problem.
Unfortunately I don't have isolated test cases for these problems.

rdar://106516360
