### PR TITLE
[NFC] Remove stale debug code

### DIFF
--- a/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/PullbackCloner.cpp
@@ -2541,7 +2541,6 @@ void PullbackCloner::Implementation::visitSILBasicBlock(SILBasicBlock *bb) {
         auto concreteBBArgAdjCopy =
           builder.emitCopyValueOperation(pbLoc, concreteBBArgAdj);
         for (auto pair : incomingValues) {
-          pair.second->dump();
           auto *predBB = std::get<0>(pair);
           auto incomingValue = std::get<1>(pair);
           // Handle `switch_enum` on `Optional`.


### PR DESCRIPTION
Accidentally left in 869fc1792e8967227e84e583a2f529ecb5ce29ea