### PR TITLE
add AST printer support for _documentation attribute

### DIFF
--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -1394,6 +1394,32 @@ bool DeclAttribute::printImpl(ASTPrinter &Printer, const PrintOptions &Options,
     break;
   }
 
+  case DAK_Documentation: {
+    auto *attr = cast<DocumentationAttr>(this);
+
+    Printer.printAttrName("@_documentation");
+    Printer << "(";
+
+    bool needs_comma = !attr->Metadata.empty() && attr->Visibility;
+
+    if (attr->Visibility) {
+      Printer << "visibility: ";
+      Printer << getAccessLevelSpelling(*attr->Visibility);
+    }
+
+    if (needs_comma) {
+      Printer << ", ";
+    }
+
+    if (!attr->Metadata.empty()) {
+      Printer << "metadata: ";
+      Printer << attr->Metadata;
+    }
+
+    Printer << ")";
+    break;
+  }
+
   case DAK_Count:
     llvm_unreachable("exceed declaration attribute kinds");
 

--- a/test/SourceKit/CursorInfo/doc_attr.swift
+++ b/test/SourceKit/CursorInfo/doc_attr.swift
@@ -1,0 +1,9 @@
+@_documentation(visibility: public)
+enum E
+{
+}
+
+// The @_documentation attribute caused sourcekit-lsp to crash
+// cf. https://github.com/apple/swift/issues/64309
+
+// RUN: %sourcekitd-test -req=cursor -pos=2:6 %s -- %s

--- a/test/SourceKit/CursorInfo/doc_attr.swift
+++ b/test/SourceKit/CursorInfo/doc_attr.swift
@@ -6,7 +6,4 @@ enum E
 // The @_documentation attribute caused sourcekit-lsp to crash
 // cf. https://github.com/apple/swift/issues/64309
 
-// RUN: %sourcekitd-test -req=cursor -pos=2:6 %s -- %s | %FileCheck %s
-
-// CHECK: <Declaration>@_documentation(visibility: public) enum E</Declaration>
-// CHECK: <decl.enum><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@_documentation</syntaxtype.attribute.name>(visibility: public)</syntaxtype.attribute.builtin> <syntaxtype.keyword>enum</syntaxtype.keyword> <decl.name>E</decl.name></decl.enum>
+// RUN: %sourcekitd-test -req=cursor -pos=2:6 %s -- %s

--- a/test/SourceKit/CursorInfo/doc_attr.swift
+++ b/test/SourceKit/CursorInfo/doc_attr.swift
@@ -6,4 +6,7 @@ enum E
 // The @_documentation attribute caused sourcekit-lsp to crash
 // cf. https://github.com/apple/swift/issues/64309
 
-// RUN: %sourcekitd-test -req=cursor -pos=2:6 %s -- %s
+// RUN: %sourcekitd-test -req=cursor -pos=2:6 %s -- %s | %FileCheck %s
+
+// CHECK: <Declaration>@_documentation(visibility: public) enum E</Declaration>
+// CHECK: <decl.enum><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@_documentation</syntaxtype.attribute.name>(visibility: public)</syntaxtype.attribute.builtin> <syntaxtype.keyword>enum</syntaxtype.keyword> <decl.name>E</decl.name></decl.enum>


### PR DESCRIPTION
fixes #64309
fixes rdar://106657906

When the `@_documentation` attribute was added in https://github.com/apple/swift/pull/60242, i neglected to add a printer implementation for it. This didn't affect SymbolGraphGen, since it doesn't print `UserInaccessible` attributes in its declarations. However, sourcekit-lsp does print these attributes, which trips an assertion. This PR adds a printer implementation for the `@_documentation` attribute, allowing SourceKit to properly collect cursor info.