### PR TITLE
[Runtime] Remove a few uses of operator new/delete.

### DIFF
--- a/stdlib/public/runtime/SwiftTLSContext.cpp
+++ b/stdlib/public/runtime/SwiftTLSContext.cpp
@@ -30,10 +30,10 @@ SwiftTLSContext &SwiftTLSContext::get() {
 
   static swift::once_t token;
   swift::tls_init_once(token, swift::tls_key::runtime, [](void *pointer) {
-    delete static_cast<SwiftTLSContext *>(pointer);
+    swift_cxx_deleteObject(static_cast<SwiftTLSContext *>(pointer));
   });
 
-  ctx = new SwiftTLSContext();
+  ctx = swift_cxx_newObject<SwiftTLSContext>();
   swift::tls_set(swift::tls_key::runtime, ctx);
   return *ctx;
 
@@ -51,7 +51,7 @@ SwiftTLSContext &SwiftTLSContext::get() {
   static swift::once_t token;
 
   swift::tls_alloc_once(token, runtimeKey, [](void *pointer) {
-    delete static_cast<SwiftTLSContext *>(pointer);
+    swift_cxx_deleteObject(static_cast<SwiftTLSContext *>(pointer));
   });
 
   SwiftTLSContext *ctx =
@@ -59,7 +59,7 @@ SwiftTLSContext &SwiftTLSContext::get() {
   if (ctx)
     return *ctx;
 
-  ctx = new SwiftTLSContext();
+  ctx = swift_cxx_newObject<SwiftTLSContext>();
   swift::tls_set(runtimeKey, ctx);
   return *ctx;
 


### PR DESCRIPTION
Replace them with swift_cxx_newObject/swift_cxx_deleteObject to avoid calling overridden global operators. Overridden global operators can sometimes fail when called from places the authors didn't expect.

The particular uses being changed here are:

1. Creation of new SingletonMetadataCacheEntry objects.
2. Allocation of the _globalIvarOffsets array in initGenericObjCClass.
3. Creation/destruction of SwiftTLSContext objects.

rdar://106238547
