### PR TITLE
Demangling: remove stray `llvm` forward declaration

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -30,10 +30,6 @@
 #include <memory>
 #include <string>
 
-namespace llvm {
-  class raw_ostream;
-}
-
 namespace swift {
 namespace Demangle {
 SWIFT_BEGIN_INLINE_NAMESPACE


### PR DESCRIPTION
Remove the forward declaration for `llvm::raw_ostream` as this creates ambiguity for `__swift::__runtime::llvm::StringRef` and `llvm::StringRef` as now `llvm` is made visible to the namespace lookup rules.