### PR TITLE
[Clang importer] Restore historical definition of "Boolean for Objective-C"

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -155,9 +155,6 @@ static bool isErrorOutParameter(const clang::ParmVarDecl *param,
 
 static bool isBoolType(clang::ASTContext &ctx, clang::QualType type) {
   do {
-    if (type->isBooleanType())
-      return true;
-
     // Check whether we have a typedef for "BOOL" or "Boolean".
     if (auto typedefType = dyn_cast<clang::TypedefType>(type.getTypePtr())) {
       auto typedefDecl = typedefType->getDecl();
@@ -1857,7 +1854,7 @@ ImportedName NameImporter::importNameImpl(const clang::NamedDecl *D,
       return ImportedName();
     auto toType = conversionDecl->getConversionType();
     // Only import `operator bool()` for now.
-    if (isBoolType(clangSema.Context, toType)) {
+    if (toType->isBooleanType()) {
       isFunction = true;
       baseName = "__convertToBool";
       addEmptyArgNamesForClangFunction(conversionDecl, argumentNames);

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -333,6 +333,11 @@ func customAccessors(_ hive: Hive, bee: Bee) {
   hive.`guard` = bee // no-warning
 }
 
+// Properties with bool don't use the getter.
+func boolProperties(_ hive: Hive) {
+  markUsed(hive.empty)
+}
+
 // instancetype/Dynamic Self invocation.
 func testDynamicSelf(_ queen: Bee, wobbler: NSWobbling) {
   var hive = Hive()

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -7,6 +7,7 @@
 #import <CoreFoundation.h>
 #import <CoreGraphics.h>
 #endif
+#import <stdbool.h>
 
 #define NS_DESIGNATED_INITIALIZER __attribute__((objc_designated_initializer))
 
@@ -262,6 +263,7 @@ __attribute__((warn_unused_result)) NSString *NSStringToNSString(NSString *str);
 @property (nonnull) NSDictionary<id <NSCopying>, Bee *> *anythingToBees;
 
 @property(getter=isMakingHoney) BOOL makingHoney;
+@property(readonly,getter=isEmpty) bool empty;
 @property(setter=assignGuard:) id guard;
 
 + (instancetype)hiveWithQueen:(Bee *)queen;


### PR DESCRIPTION
The `isBoolType` operation within the Clang importer has a historical definition that excludes the C++ `bool` and its use in C as an extension. Retain that definition, and check for the actual `bool` when importing C++ conversion functions into Swift.

Fixes two regressions in the Clang importer:

1. We started to import `bool`-typed Objective-C properties with their getter names.
2. We started importing `bool`-typed Objective-C methods with an NSError** parameter as `throws`.

Both of these changes could be considered improvements, but they cannot be made without breaking source compatibility, so roll those changes back to maintain source compatibility.

We should have a separate discussion about enabling this behavior for Swift >= 6.

Fixes rdar://106665264
