### PR TITLE
[CopyPropagation] Eliminate redundant moves.

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -1347,6 +1347,14 @@ void visitTransitiveEndBorrows(
 /// - the value is itself a begin_borrow [lexical]
 bool isNestedLexicalBeginBorrow(BeginBorrowInst *bbi);
 
+/// Whether specified move_value is redundant.
+///
+/// A move_value is redundant if the lifetimes that it separates both have the
+/// same characteristics with respect to
+/// - lexicality
+/// - escaping
+bool isRedundantMoveValue(MoveValueInst *mvi);
+
 } // namespace swift
 
 #endif

--- a/lib/SILOptimizer/SemanticARC/RedundantMoveValueElimination.cpp
+++ b/lib/SILOptimizer/SemanticARC/RedundantMoveValueElimination.cpp
@@ -39,25 +39,10 @@ bool SemanticARCOptVisitor::visitMoveValueInst(MoveValueInst *mvi) {
   if (!ctx.shouldPerform(ARCTransformKind::RedundantMoveValueElim))
     return false;
 
-  auto original = mvi->getOperand();
-
-  // If the moved-from value has none ownership, hasPointerEscape can't handle
-  // it, so it can't be used to determine whether escaping matches.
-  if (original->getOwnershipKind() != OwnershipKind::Owned) {
+  if (!isRedundantMoveValue(mvi))
     return false;
-  }
-
-  // First, check whether lexicality matches, the cheaper check.
-  if (mvi->isLexical() != original->isLexical()) {
-    return false;
-  }
-
-  // Then, check whether escaping matches, the more expensive check.
-  if (hasPointerEscape(mvi) != hasPointerEscape(original)) {
-    return false;
-  }
 
   // Both characteristics match.
-  eraseAndRAUWSingleValueInstruction(mvi, original);
+  eraseAndRAUWSingleValueInstruction(mvi, mvi->getOperand());
   return true;
 }

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -42,6 +42,7 @@
 #include "swift/SIL/BasicBlockDatastructures.h"
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/SILUndef.h"
 #include "swift/SILOptimizer/Analysis/BasicCalleeAnalysis.h"
 #include "swift/SILOptimizer/Analysis/DeadEndBlocksAnalysis.h"
@@ -264,6 +265,24 @@ static bool convertExtractsToDestructures(CanonicalDefWorklist &copiedDefs,
 }
 
 //===----------------------------------------------------------------------===//
+//                MARK: Eliminate redundant moves
+//===----------------------------------------------------------------------===//
+
+/// If the specified move_value is redundant (there's no benefit to separating
+/// the lifetime at it), replace its uses with uses of the moved-from value and
+/// delete it.
+static bool eliminateRedundantMove(MoveValueInst *mvi,
+                                   InstructionDeleter &deleter) {
+  if (!isRedundantMoveValue(mvi))
+    return false;
+  mvi->replaceAllUsesWith(mvi->getOperand());
+  // Call InstructionDeleter::forceDeleteWithUsers to avoid "fixing up"
+  // ownership of the moved-from value, i.e. inserting a destroy_value.
+  deleter.forceDeleteWithUsers(mvi);
+  return true;
+}
+
+//===----------------------------------------------------------------------===//
 //                   MARK: Sink owned forwarding operations
 //===----------------------------------------------------------------------===//
 
@@ -420,6 +439,7 @@ void CopyPropagation::run() {
   bool changed = false;
 
   StackList<BeginBorrowInst *> beginBorrowsToShrink(f);
+  StackList<MoveValueInst *> moveValues(f);
 
   // Driver: Find all copied or borrowed defs.
   for (auto &bb : *f) {
@@ -428,6 +448,8 @@ void CopyPropagation::run() {
         defWorklist.updateForCopy(copy);
       } else if (auto *borrow = dyn_cast<BeginBorrowInst>(&i)) {
         beginBorrowsToShrink.push_back(borrow);
+      } else if (auto *move = dyn_cast<MoveValueInst>(&i)) {
+        moveValues.push_back(move);
       } else if (canonicalizeAll) {
         if (auto *destroy = dyn_cast<DestroyValueInst>(&i)) {
           defWorklist.updateForCopy(destroy->getOperand());
@@ -480,8 +502,12 @@ void CopyPropagation::run() {
           hoistDestroysOfOwnedLexicalValue(folded, *f, deleter, calleeAnalysis);
       // Keep running even if the new move's destroys can't be hoisted.
       (void)hoisted;
+      eliminateRedundantMove(folded, deleter);
       firstRun = false;
     }
+  }
+  for (auto *mvi : moveValues) {
+    eliminateRedundantMove(mvi, deleter);
   }
   for (auto *argument : f->getArguments()) {
     if (argument->getOwnershipKind() == OwnershipKind::Owned) {

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -851,7 +851,8 @@ bb0(%0 : @owned $C):
 // Test that copy propagation doesn't hoist a destroy_value corresponding to
 // a move value [lexical] over a barrier.
 // CHECK-LABEL: sil [ossa] @dont_hoist_move_value_lexical_destroy_over_barrier_apply : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] : @owned $C):
+// CHECK:         [[GET_OWNED_C:%.*]] = function_ref @getOwnedC
+// CHECK:         [[INSTANCE:%.*]] = apply [[GET_OWNED_C]]
 // CHECK:         [[LIFETIME:%[^,]+]] = move_value [lexical] [[INSTANCE]]
 // CHECK:         [[BARRIER:%[^,]+]] = function_ref @barrier
 // CHECK:         [[TAKE_GUARANTEED_C:%[^,]+]] = function_ref @takeGuaranteedC
@@ -859,8 +860,10 @@ bb0(%0 : @owned $C):
 // CHECK:         apply [[BARRIER]]()
 // CHECK:         destroy_value [[LIFETIME]]
 // CHECK-LABEL: } // end sil function 'dont_hoist_move_value_lexical_destroy_over_barrier_apply'
-sil [ossa] @dont_hoist_move_value_lexical_destroy_over_barrier_apply : $@convention(thin) (@owned C) -> () {
-entry(%instance : @owned $C):
+sil [ossa] @dont_hoist_move_value_lexical_destroy_over_barrier_apply : $@convention(thin) () -> () {
+entry:
+  %getOwnedC = function_ref @getOwnedC : $@convention(thin) () -> (@owned C)
+  %instance = apply %getOwnedC() : $@convention(thin) () -> (@owned C)
   %lifetime = move_value [lexical] %instance : $C
   %barrier = function_ref @barrier : $@convention(thin) () -> ()
   %takeGuaranteedC = function_ref @takeGuaranteedC : $@convention(thin) (@guaranteed C) -> ()

--- a/test/SILOptimizer/lexical_destroy_folding.sil
+++ b/test/SILOptimizer/lexical_destroy_folding.sil
@@ -28,13 +28,15 @@ sil [ossa] @get_owned : $@convention(thin) () -> @owned C
 // with an apply.
 //
 // CHECK-LABEL: sil [ossa] @fold_simplest : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[GET_OWNED:%[^,]+]] = function_ref @get_owned
+// CHECK:         [[INSTANCE:%[^,]+]] = apply [[GET_OWNED]]
 // CHECK:         [[CALEE_OWNED:%[^,]+]] = function_ref @callee_owned
 // CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
 // CHECK:         apply [[CALEE_OWNED]]([[MOVE]])
 // CHECK-LABEL: } // end sil function 'fold_simplest'
-sil [ossa] @fold_simplest : $@convention(thin) (@owned C) -> () {
-entry(%instance : @owned $C):
+sil [ossa] @fold_simplest : $@convention(thin) () -> () {
+  %get_owned = function_ref @get_owned : $@convention(thin) () -> (@owned C)
+  %instance = apply %get_owned() : $@convention(thin) () -> (@owned C)
   %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
   %lifetime = begin_borrow [lexical] %instance : $C
   %copy = copy_value %lifetime : $C
@@ -83,7 +85,8 @@ entry(%instance : @owned $C):
 // borrowee intact on other paths.
 //
 // CHECK-LABEL: sil [ossa] @fold_left_only : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[GET_OWNED:%[^,]+]] = function_ref @get_owned
+// CHECK:         [[INSTANCE:%[^,]+]] = apply [[GET_OWNED]]
 // CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
 // CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
 // CHECK:       [[LEFT]]:
@@ -95,8 +98,10 @@ entry(%instance : @owned $C):
 // CHECK:         br [[EXIT]]
 // CHECK:       [[EXIT]]:
 // CHECK-LABEL: } // end sil function 'fold_left_only'
-sil [ossa] @fold_left_only : $@convention(thin) (@owned C) -> () {
-entry(%instance : @owned $C):
+sil [ossa] @fold_left_only : $@convention(thin) () -> () {
+entry:
+  %get_owned = function_ref @get_owned : $@convention(thin) () -> (@owned C)
+  %instance = apply %get_owned() : $@convention(thin) () -> (@owned C)
   %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
   cond_br undef, left, right
 
@@ -122,7 +127,8 @@ exit:
 // independents owned lexical scopes.
 //
 // CHECK-LABEL: sil [ossa] @fold_two_independent_scopes : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[GET_OWNED:%[^,]+]] = function_ref @get_owned
+// CHECK:         [[INSTANCE:%[^,]+]] = apply [[GET_OWNED]]
 // CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
 // CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
 // CHECK:       [[LEFT]]:
@@ -135,8 +141,10 @@ exit:
 // CHECK:         br [[EXIT]]
 // CHECK:       [[EXIT]]:
 // CHECK-LABEL: } // end sil function 'fold_two_independent_scopes'
-sil [ossa] @fold_two_independent_scopes : $@convention(thin) (@owned C) -> () {
-entry(%instance : @owned $C):
+sil [ossa] @fold_two_independent_scopes : $@convention(thin) () -> () {
+entry:
+  %get_owned = function_ref @get_owned : $@convention(thin) () -> (@owned C)
+  %instance = apply %get_owned() : $@convention(thin) () -> (@owned C)
   %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
   cond_br undef, left, right
 
@@ -211,7 +219,8 @@ exit:
 // within a single owned lexical scope.
 //
 // CHECK-LABEL: sil [ossa] @fold_two_parallel_applies___canonical_destroys : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[GET_OWNED:%[^,]+]] = function_ref @get_owned
+// CHECK:         [[INSTANCE:%[^,]+]] = apply [[GET_OWNED]]
 // CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
 // CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]] : $C
 // CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
@@ -223,8 +232,10 @@ exit:
 // CHECK:         br [[EXIT]]
 // CHECK:       [[EXIT]]:
 // CHECK-LABEL: } // end sil function 'fold_two_parallel_applies___canonical_destroys'
-sil [ossa] @fold_two_parallel_applies___canonical_destroys : $@convention(thin) (@owned C) -> () {
-entry(%instance : @owned $C):
+sil [ossa] @fold_two_parallel_applies___canonical_destroys : $@convention(thin) () -> () {
+entry:
+  %get_owned = function_ref @get_owned : $@convention(thin) () -> (@owned C)
+  %instance = apply %get_owned() : $@convention(thin) () -> (@owned C)
   %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
   %lifetime = begin_borrow [lexical] %instance : $C
   cond_br undef, left, right
@@ -253,7 +264,8 @@ exit:
 // borrowee that is not within the scope.
 //
 // CHECK-LABEL: sil [ossa] @fold_multiblock_borrow_single_apply_with_parallel_use : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[GET_OWNED:%[^,]+]] = function_ref @get_owned
+// CHECK:         [[INSTANCE:%[^,]+]] = apply [[GET_OWNED]]
 // CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
 // CHECK:         cond_br undef, [[LEFT1:bb[0-9]+]], [[RIGHT:bb[0-9]+]]                         
 // CHECK:       [[LEFT1]]:                                              
@@ -270,8 +282,10 @@ exit:
 // CHECK:         br [[EXIT]]                                          
 // CHECK:       [[EXIT]]:                                              
 // CHECK-LABEL: } // end sil function 'fold_multiblock_borrow_single_apply_with_parallel_use'
-sil [ossa] @fold_multiblock_borrow_single_apply_with_parallel_use : $@convention(thin) (@owned C) -> () {
-entry(%instance : @owned $C):
+sil [ossa] @fold_multiblock_borrow_single_apply_with_parallel_use : $@convention(thin) () -> () {
+entry:
+  %get_owned = function_ref @get_owned : $@convention(thin) () -> (@owned C)
+  %instance = apply %get_owned() : $@convention(thin) () -> (@owned C)
   %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
   cond_br undef, left1, right
 
@@ -306,7 +320,8 @@ exit:
 // borrowee that is not within the scope.
 //
 // CHECK-LABEL: sil [ossa] @fold_multiblock_borrow_single_apply_and_parallel_singleblock_borrow : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[GET_OWNED:%[^,]+]] = function_ref @get_owned
+// CHECK:         [[INSTANCE:%[^,]+]] = apply [[GET_OWNED]]
 // CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
 // CHECK:         cond_br undef, [[LEFT1:bb[0-9]+]], [[RIGHT:bb[0-9]+]]                         
 // CHECK:       [[LEFT1]]:                                              
@@ -324,8 +339,10 @@ exit:
 // CHECK:         br [[EXIT]]                                          
 // CHECK:       [[EXIT]]:                                              
 // CHECK-LABEL: } // end sil function 'fold_multiblock_borrow_single_apply_and_parallel_singleblock_borrow'
-sil [ossa] @fold_multiblock_borrow_single_apply_and_parallel_singleblock_borrow : $@convention(thin) (@owned C) -> () {
-entry(%instance : @owned $C):
+sil [ossa] @fold_multiblock_borrow_single_apply_and_parallel_singleblock_borrow : $@convention(thin) () -> () {
+entry:
+  %get_owned = function_ref @get_owned : $@convention(thin) () -> (@owned C)
+  %instance = apply %get_owned() : $@convention(thin) () -> (@owned C)
   %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
   cond_br undef, left1, right
 
@@ -364,7 +381,8 @@ exit:
 // guaranteed lifetime remains.
 //
 // CHECK-LABEL: sil [ossa] @fold_single_block_one_apply_double_use_all_owned : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[GET_OWNED:%[^,]+]] = function_ref @get_owned
+// CHECK:         [[INSTANCE:%[^,]+]] = apply [[GET_OWNED]]
 // CHECK:         [[LIFETIME:%[^,]+]] = move_value [lexical] [[INSTANCE]]
 // CHECK:         [[LIFETIME_GUARANTEED:%[^,]+]] = begin_borrow [lexical] [[LIFETIME]]
 // CHECK:         [[CALLEE_GUARANTEED:%[^,]+]] = function_ref @callee_guaranteed
@@ -374,8 +392,10 @@ exit:
 // CHECK:         [[CALLEE_OWNED_OWNED:%[^,]+]] = function_ref @callee_owned_owned
 // CHECK:         apply [[CALLEE_OWNED_OWNED]]([[LIFETIME]], [[COPY]])
 // CHECK-LABEL: } // end sil function 'fold_single_block_one_apply_double_use_all_owned'
-sil [ossa] @fold_single_block_one_apply_double_use_all_owned : $@convention(thin) (@owned C) -> () {
-entry(%instance : @owned $C):
+sil [ossa] @fold_single_block_one_apply_double_use_all_owned : $@convention(thin) () -> () {
+entry:
+  %get_owned = function_ref @get_owned : $@convention(thin) () -> (@owned C)
+  %instance = apply %get_owned() : $@convention(thin) () -> (@owned C)
   %lifetime = begin_borrow [lexical] %instance : $C
   %callee_guaranteed = function_ref @callee_guaranteed : $@convention(thin) (@guaranteed C) -> ()
   apply %callee_guaranteed(%lifetime) : $@convention(thin) (@guaranteed C) -> ()
@@ -393,14 +413,17 @@ entry(%instance : @owned $C):
 // guaranteed lifetime remains.
 //
 // CHECK-LABEL: sil [ossa] @fold_single_block_one_apply_double_use_all_owned__no_remaining_uses : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[GET_OWNED:%[^,]+]] = function_ref @get_owned
+// CHECK:         [[INSTANCE:%[^,]+]] = apply [[GET_OWNED]]
 // CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
 // CHECK:         [[COPY:%[^,]+]] = copy_value [[MOVE]]
 // CHECK:         [[CALLEE_OWNED_OWNED:%[^,]+]] = function_ref @callee_owned_owned
 // CHECK:         apply [[CALLEE_OWNED_OWNED]]([[MOVE]], [[COPY]])
 // CHECK-LABEL: } // end sil function 'fold_single_block_one_apply_double_use_all_owned__no_remaining_uses'
-sil [ossa] @fold_single_block_one_apply_double_use_all_owned__no_remaining_uses : $@convention(thin) (@owned C) -> () {
-entry(%instance : @owned $C):
+sil [ossa] @fold_single_block_one_apply_double_use_all_owned__no_remaining_uses : $@convention(thin) () -> () {
+entry:
+  %get_owned = function_ref @get_owned : $@convention(thin) () -> (@owned C)
+  %instance = apply %get_owned() : $@convention(thin) () -> (@owned C)
   %lifetime = begin_borrow [lexical] %instance : $C
   %copy_1 = copy_value %lifetime : $C
   %copy_2 = copy_value %lifetime : $C
@@ -464,7 +487,8 @@ entry(%instance : @owned $C):
 // Fold with the last consuming use but not with a previous consuming use.
 //
 // CHECK-LABEL: sil [ossa] @fold_single_block_two_applies_first_only : {{.*}} {
-// CHECK:       bb0([[INSTANCE:%[^,]+]] :
+// CHECK:         [[GET_OWNED:%[^,]+]] = function_ref @get_owned
+// CHECK:         [[INSTANCE:%[^,]+]] = apply [[GET_OWNED]]
 // CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
 // CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[MOVE]]
 // CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
@@ -474,8 +498,9 @@ entry(%instance : @owned $C):
 // CHECK:         tuple ()
 // CHECK:         apply [[CALLEE_OWNED]]([[MOVE]])
 // CHECK-LABEL: } // end sil function 'fold_single_block_two_applies_first_only'
-sil [ossa] @fold_single_block_two_applies_first_only : $@convention(thin) (@owned C) -> () {
-entry(%instance : @owned $C):
+sil [ossa] @fold_single_block_two_applies_first_only : $@convention(thin) () -> () {
+  %get_owned = function_ref @get_owned : $@convention(thin) () -> (@owned C)
+  %instance = apply %get_owned() : $@convention(thin) () -> (@owned C)
   %lifetime = begin_borrow [lexical] %instance : $C
   %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
   %copy_1 = copy_value %lifetime : $C
@@ -523,23 +548,27 @@ exit:
 // and the lexical scope ends before the use on the non-lexical branch.
 //
 // CHECK-LABEL: sil [ossa] @nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
-// CHECK:         [[COPY:%[^,]+]] = copy_value [[INSTANCE]]
-// CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
+// CHECK:         [[GET_OWNED:%[^,]+]] = function_ref @get_owned
+// CHECK:         [[INSTANCE:%[^,]+]] = apply [[GET_OWNED]]
+// CHECK:         [[LIFETIME:%[^,]+]] = begin_borrow [lexical] [[INSTANCE]]
 // CHECK:         [[CALLEE_OWNED:%[^,]+]] = function_ref @callee_owned
 // CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
 // CHECK:       [[LEFT]]:
-// CHECK:         apply [[CALLEE_OWNED]]([[MOVE]])
-// CHECK:         destroy_value [[COPY]]
+// CHECK:         [[COPY:%[^,]+]] = copy_value [[LIFETIME]]
+// CHECK:         apply [[CALLEE_OWNED]]([[COPY]])
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         destroy_value [[INSTANCE]]
 // CHECK:         br [[EXIT:bb[0-9]+]]
 // CHECK:       [[RIGHT]]:
-// CHECK:         destroy_value [[MOVE]]
-// CHECK:         apply [[CALLEE_OWNED]]([[COPY]])
+// CHECK:         end_borrow [[LIFETIME]]
+// CHECK:         apply [[CALLEE_OWNED]]([[INSTANCE]])
 // CHECK:         br [[EXIT]]
 // CHECK:       [[EXIT]]:
 // CHECK-LABEL: } // end sil function 'nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use'
-sil [ossa] @nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use : $@convention(thin) (@owned C) -> () {
-entry(%instance : @owned $C):
+sil [ossa] @nofold_two_parallel_owned_uses_one_lexical___scope_ends_before_use : $@convention(thin) () -> () {
+entry:
+  %get_owned = function_ref @get_owned : $@convention(thin) () -> (@owned C)
+  %instance = apply %get_owned() : $@convention(thin) () -> (@owned C)
   %copy_2 = copy_value %instance : $C
   %lifetime = begin_borrow [lexical] %instance : $C
   %callee_owned = function_ref @callee_owned : $@convention(thin) (@owned C) -> ()
@@ -618,7 +647,8 @@ exit:
 // use of %original_borrowee in that unreachable-terminated branch.
 //
 // CHECK-LABEL: sil [ossa] @fold_unreachable : {{.*}} {
-// CHECK:       {{bb[0-9]+}}([[INSTANCE:%[^,]+]] :
+// CHECK:         [[GET_OWNED:%[^,]+]] = function_ref @get_owned
+// CHECK:         [[INSTANCE:%[^,]+]] = apply [[GET_OWNED]]
 // CHECK:         [[MOVE:%[^,]+]] = move_value [lexical] [[INSTANCE]]
 // CHECK:         cond_br undef, [[LEFT:bb[0-9]+]], [[RIGHT:bb[0-9]+]]
 // CHECK:       [[LEFT]]:
@@ -629,8 +659,10 @@ exit:
 // CHECK:         br [[EXIT:bb[0-9]+]]
 // CHECK:       [[EXIT]]:
 // CHECK-LABEL: } // end sil function 'fold_unreachable'
-sil [ossa] @fold_unreachable : $@convention(thin) (@owned C) -> () {
-entry(%instance : @owned $C):
+sil [ossa] @fold_unreachable : $@convention(thin) () -> () {
+entry:
+  %get_owned = function_ref @get_owned : $@convention(thin) () -> (@owned C)
+  %instance = apply %get_owned() : $@convention(thin) () -> (@owned C)
   %lifetime = begin_borrow [lexical] %instance : $C
   cond_br undef, left, right
 

--- a/test/SILOptimizer/shrink_borrow_scope.sil
+++ b/test/SILOptimizer/shrink_borrow_scope.sil
@@ -556,9 +556,9 @@ exit:
 // CHECK:         [[COPY_C:%[^,]+]] = copy_value [[LIFETIME_C]]
 // CHECK:         [[LIFETIME_D:%[^,]+]] = begin_borrow [[INSTANCE_D]]
 // CHECK:         struct $CDCase ([[LIFETIME_C]] : $C, [[LIFETIME_D]] : $D)
-// CHECK:         end_borrow [[LIFETIME_C]]
 // CHECK:         end_borrow [[LIFETIME_D]]
 // CHECK:         destroy_value [[INSTANCE_D]]
+// CHECK:         end_borrow [[LIFETIME_C]]
 // CHECK:         return [[COPY_C]]
 // CHECK-LABEL: } // end sil function 'hoist_over_struct'
 sil [ossa] @hoist_over_struct : $@convention(thin) (@owned C, @owned D) -> @owned C {


### PR DESCRIPTION
`SemanticARCOpts` already eliminates `move_value`s that are redundant that block its optimizations.  But it's always run after `CopyPropagation`.

Because `move_value`s divide copy-extended lifetimes, move_values obstruct lifetime canonicalization.  If a `move_value` isn't separating lifetimes with different characteristics (specifically: lexicallity, escaping), then it is only obstructing lifetime canonicalization.  Remove it before canonicalizing the lifetime of the moved-from value.

rdar://106834481
