### PR TITLE
[Macros] Use the original attribute list when gathering possible macro-generated names in the source lookup cache.

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -350,7 +350,7 @@ void SourceLookupCache::populateAuxiliaryDeclCache() {
     // macro does not produce the requested name, so the only impact is possibly
     // expanding earlier than needed / unnecessarily looking in the top-level
     // auxiliary decl cache.
-    for (auto attrConst : decl->getSemanticAttrs().getAttributes<CustomAttr>()) {
+    for (auto attrConst : decl->getAttrs().getAttributes<CustomAttr>()) {
       auto *attr = const_cast<CustomAttr *>(attrConst);
       UnresolvedMacroReference macroRef(attr);
       auto macroName = macroRef.getMacroName().getBaseIdentifier();

--- a/test/Concurrency/global_actor_function_types.swift
+++ b/test/Concurrency/global_actor_function_types.swift
@@ -386,3 +386,13 @@ func test_global_actor_mismatch() {
     let _: @MainActor () -> T = fn // expected-error{{cannot convert value actor-isolated to 'GA' to specified type actor-isolated to 'MainActor'}}
   }
 }
+
+struct GlobalType {}
+
+@_Concurrency.MainActor
+extension global_actor_function_types.GlobalType {
+  @_Concurrency.MainActor static func ==(
+    lhs: global_actor_function_types.GlobalType,
+    rhs: global_actor_function_types.GlobalType
+  ) -> Bool { true }
+}


### PR DESCRIPTION
Invoking macro expansion while populating the source lookup cache is deliberately avoided because it's prone to circularity. This applies to member attribute expansion, which is requested via `getSemanticAttrs()`. Populating the auxiliary decl cache should use the original attribute list, because global declarations and other declarations found via global lookup, such as macro and operator decls, cannot have member-attributes expanded by their parent context.

Resolves: rdar://106665522