### PR TITLE
[interop][SwiftToCxx] explicitly tell the user that @objc decls can't…

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1609,6 +1609,8 @@ ERROR(expose_inside_unexposed_decl,none,
 ERROR(expose_invalid_name_pattern_init,none,
       "invalid declaration name '%0' specified in an @_expose attribute; "
       "exposed initializer name must start with 'init'", (StringRef))
+ERROR(expose_unsupported_objc_decl_to_cxx,none,
+      "@objc %0 %1 can not yet be exposed to C++", (DescriptiveDeclKind, ValueDecl *))
 ERROR(expose_unsupported_async_decl_to_cxx,none,
       "async %0 %1 can not be exposed to C++", (DescriptiveDeclKind, ValueDecl *))
 ERROR(expose_unsupported_actor_isolated_to_cxx,none,

--- a/include/swift/AST/SwiftNameTranslation.h
+++ b/include/swift/AST/SwiftNameTranslation.h
@@ -66,6 +66,7 @@ getNameForCxx(const ValueDecl *VD,
 enum RepresentationKind { Representable, Unsupported };
 
 enum RepresentationError {
+  UnrepresentableObjC,
   UnrepresentableAsync,
   UnrepresentableIsolatedInActor,
   UnrepresentableRequiresClientEmission,

--- a/lib/AST/SwiftNameTranslation.cpp
+++ b/lib/AST/SwiftNameTranslation.cpp
@@ -200,6 +200,8 @@ swift::cxx_translation::getNameForCxx(const ValueDecl *VD,
 
 swift::cxx_translation::DeclRepresentation
 swift::cxx_translation::getDeclRepresentation(const ValueDecl *VD) {
+  if (VD->isObjC())
+    return {Unsupported, UnrepresentableObjC};
   if (getActorIsolation(const_cast<ValueDecl *>(VD)).isActorIsolated())
     return {Unsupported, UnrepresentableIsolatedInActor};
   Optional<CanGenericSignature> genericSignature;
@@ -241,8 +243,6 @@ swift::cxx_translation::getDeclRepresentation(const ValueDecl *VD) {
 bool swift::cxx_translation::isVisibleToCxx(const ValueDecl *VD,
                                             AccessLevel minRequiredAccess,
                                             bool checkParent) {
-  if (VD->isObjC())
-    return false;
   // Do not expose anything from _Concurrency module yet.
   if (VD->getModuleContext()->ValueDecl::getName().getBaseIdentifier() ==
       VD->getASTContext().Id_Concurrency)

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2013,9 +2013,7 @@ void AttributeChecker::visitCDeclAttr(CDeclAttr *attr) {
 
 void AttributeChecker::visitExposeAttr(ExposeAttr *attr) {
   auto *VD = cast<ValueDecl>(D);
-  // Expose cannot be mixed with '@objc'/'@_cdecl' declarations.
-  if (VD->isObjC())
-    diagnose(attr->getLocation(), diag::expose_only_non_other_attr, "@objc");
+  // Expose cannot be mixed with '@_cdecl' declarations.
   if (VD->getAttrs().hasAttribute<CDeclAttr>())
     diagnose(attr->getLocation(), diag::expose_only_non_other_attr, "@_cdecl");
 
@@ -2038,6 +2036,10 @@ void AttributeChecker::visitExposeAttr(ExposeAttr *attr) {
   if (repr.isUnsupported()) {
     using namespace cxx_translation;
     switch (*repr.error) {
+    case UnrepresentableObjC:
+      diagnose(attr->getLocation(), diag::expose_unsupported_objc_decl_to_cxx,
+               VD->getDescriptiveKind(), VD);
+      break;
     case UnrepresentableAsync:
       diagnose(attr->getLocation(), diag::expose_unsupported_async_decl_to_cxx,
                VD->getDescriptiveKind(), VD);

--- a/test/Interop/SwiftToCxx/unsupported/unsupported-objc-decls-in-cxx.swift
+++ b/test/Interop/SwiftToCxx/unsupported/unsupported-objc-decls-in-cxx.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %s -typecheck -module-name Functions -verify -clang-header-expose-decls=has-expose-attr -disable-availability-checking -emit-clang-header-path %t/functions.h
+
+// RUN: cat %s | grep -v _expose > %t/clean.swift
+// RUN: %target-swift-frontend %t/clean.swift -typecheck -module-name Functions -clang-header-expose-decls=all-public -disable-availability-checking -emit-clang-header-path %t/header.h
+// RUN: %FileCheck %s < %t/header.h
+
+// REQUIRES: objc_interop
+
+// CHECK-NOT: Unsupported
+// CHECK: supported
+
+import Foundation
+
+public func supported() {}
+
+@objc
+@_expose(Cxx) // expected-error {{@objc class 'UnsupportedClass' can not yet be exposed to C++}}
+public class UnsupportedClass: NSObject {
+    override public init() {
+        x = 0
+    }
+
+    let x: Int
+}


### PR DESCRIPTION
… be yet exposed to C++
