### PR TITLE
[interop] ensure std::pair is imported into Swift

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2712,13 +2712,18 @@ namespace {
         return Impl.importDecl(decl->getSpecializedTemplate(),
                                Impl.CurrentVersion);
 
+      bool isPair = decl->getSpecializedTemplate()->isInStdNamespace() &&
+                    decl->getSpecializedTemplate()->getName() == "pair";
+
       // Before we go any further, check if we've already got tens of thousands
       // of specializations. If so, it means we're likely instantiating a very
       // deep/complex template, or we've run into an infinite loop. In either
       // case, its not worth the compile time, so bail.
       // TODO: this could be configurable at some point.
-      if (llvm::size(decl->getSpecializedTemplate()->specializations()) >
-          1000) {
+      size_t specializationLimit = !isPair ? 1000 : 10000;
+      if (!isPair &&
+          llvm::size(decl->getSpecializedTemplate()->specializations()) >
+              specializationLimit) {
         std::string name;
         llvm::raw_string_ostream os(name);
         decl->printQualifiedName(os);

--- a/test/Interop/Cxx/stdlib/Inputs/module.modulemap
+++ b/test/Interop/Cxx/stdlib/Inputs/module.modulemap
@@ -22,3 +22,8 @@ module StdSet {
   header "std-set.h"
   requires cplusplus
 }
+
+module StdPair {
+  header "std-pair.h"
+  requires cplusplus
+}

--- a/test/Interop/Cxx/stdlib/Inputs/std-pair.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-pair.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <utility>
+
+using PairInts = std::pair<int, int>;
+
+// FIXME: return pair by value, but it causes IRGen crash atm.
+inline const PairInts &getIntPair() {
+    static PairInts value = { -5, 12 };
+    return value;
+}

--- a/test/Interop/Cxx/stdlib/use-std-pair.swift
+++ b/test/Interop/Cxx/stdlib/use-std-pair.swift
@@ -1,0 +1,23 @@
+// RUN: %target-run-simple-swift(-I %S/Inputs -Xfrontend -enable-experimental-cxx-interop -Xfrontend -validate-tbd-against-ir=none)
+//
+// REQUIRES: executable_test
+//
+// REQUIRES: OS=macosx || OS=linux-gnu
+
+import StdlibUnittest
+import StdPair
+import CxxStdlib
+import Cxx
+
+var StdPairTestSuite = TestSuite("StdPair")
+
+StdPairTestSuite.test("StdPair.elements") {
+  var pi = getIntPair().pointee
+  expectEqual(pi.first, -5)
+  expectEqual(pi.second, 12)
+  pi.first = 11
+  expectEqual(pi.first, 11)
+  expectEqual(pi.second, 12)
+}
+
+runAllTests()


### PR DESCRIPTION
Returning it by value from function causes IRGen crash which I'll fix in a followup.