### PR TITLE
[Tests] NFC: Adjust REQUIRES declaration for UnsafeBufferPointerSlice…

### DIFF
--- a/validation-test/stdlib/UnsafeBufferPointerSlices.swift
+++ b/validation-test/stdlib/UnsafeBufferPointerSlices.swift
@@ -1,7 +1,8 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// REQUIRES: rdar://106656555
+// rdar://106656555
+// REQUIRES: rdar106656555
 
 import StdlibUnittest
 


### PR DESCRIPTION
…s validation test
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
