### PR TITLE
Enable relative protocol witness tables on all mixin_stdlib_minimal configurations

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -2598,6 +2598,7 @@ swift-threading-package=none
 build-swift-stdlib-unicode-data=0
 build-swift-stdlib-static-print=1
 darwin-crash-reporter-client=0
+swift-stdlib-use-relative-protocol-witness-tables=1
 
 [preset: stdlib_S_standalone_minimal_macho_x86_64,build]
 mixin-preset=


### PR DESCRIPTION


So that we test the relative protocl witness table config on a bot
