### PR TITLE
Tie Swift backtracing pieces together in build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -647,6 +647,10 @@ option(SWIFT_ENABLE_MACCATALYST
   "Build the Standard Library and overlays with MacCatalyst support"
   FALSE)
 
+option(SWIFT_ENABLE_BACKTRACING
+  "Build backtracing runtime support"
+  FALSE)
+
 set(SWIFT_DARWIN_DEPLOYMENT_VERSION_MACCATALYST "14.5" CACHE STRING
   "Minimum deployment target version for macCatalyst")
 

--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -159,7 +159,9 @@ if(SWIFT_BUILD_STDLIB)
     add_subdirectory(Observation)
   endif()
 
-  add_subdirectory(Backtracing)
+  if(SWIFT_ENABLE_BACKTRACING)
+    add_subdirectory(Backtracing)
+  endif()
 endif()
 
 if(SWIFT_BUILD_REMOTE_MIRROR)


### PR DESCRIPTION
This patch ties the runtime and stdlib backtracing pieces together. The `__swift_isThunkFunction` SPI is provided in the backtracing runtime, which is gated behind `SWIFT_ENABLE_BACKTRACING`. If that flag is turned off, the `Backtracing` part of the stdlib fails to build because the symbols are missing, causing a build failure.

I've also added the explicit `option(SWIFT_ENABLE_BACKTRACING` option so that incremental re-runs of CMake get the flag added with a nice comment and a boolean value. The option is defaulted to OFF, though build-script is defaulting it to ON.