### PR TITLE
[build] Remove runpath from build host from shared ICU libraries on linux

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2567,12 +2567,13 @@ for host in "${ALL_HOSTS[@]}"; do
                     fi
 
                     with_pushd "${LIBICU_BUILD_DIR}" \
-                        call env CXXFLAGS=-fPIC "${LIBICU_SOURCE_DIR}"/icu4c/source/runConfigureICU Linux \
+                        call env CXXFLAGS=-fPIC LDFLAGS='-Wl,-rpath=\$$ORIGIN' \
+                        "${LIBICU_SOURCE_DIR}"/icu4c/source/runConfigureICU Linux \
                         ${icu_build_variant_arg} --prefix=${ICU_TMPINSTALL} \
                         ${libicu_enable_debug} \
                         --enable-renaming --with-library-suffix=swift \
                         --libdir=${ICU_TMPLIBDIR} \
-                        --enable-shared --enable-static --enable-rpath \
+                        --enable-shared --enable-static \
                         --enable-strict --disable-icuio \
                         --disable-plugins --disable-dyload --disable-extras \
                         --disable-samples --disable-layoutex --with-data-packaging=auto


### PR DESCRIPTION
I suggested the `--enable-rpath` flag in #40340 to add `$ORIGIN` more than a year ago, but I didn't realize it also adds the `libdir` to the runpath:
```
> find swift-DEVELOPMENT-SNAPSHOT-2023-03-10-a-ubuntu20.04/usr/ -name "lib*\.so*"|xargs readelf -d|ag "File:|runpath"|ag /home/ -B1
File: swift-DEVELOPMENT-SNAPSHOT-2023-03-10-a-ubuntu20.04/usr/lib/liblldb.so.13.0.0git
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib:/home/build-user/build/buildbot_linux/llvm-linux-x86_64/./lib:/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux:$ORIGIN/../lib/swift/linux]
File: swift-DEVELOPMENT-SNAPSHOT-2023-03-10-a-ubuntu20.04/usr/lib/liblldb.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib:/home/build-user/build/buildbot_linux/llvm-linux-x86_64/./lib:/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux:$ORIGIN/../lib/swift/linux]
File: swift-DEVELOPMENT-SNAPSHOT-2023-03-10-a-ubuntu20.04/usr/lib/swift/linux/libicuucswift.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux/x86_64]
File: swift-DEVELOPMENT-SNAPSHOT-2023-03-10-a-ubuntu20.04/usr/lib/swift/linux/libicuucswift.so.65
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux/x86_64]
File: swift-DEVELOPMENT-SNAPSHOT-2023-03-10-a-ubuntu20.04/usr/lib/swift/linux/libicudataswift.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux/x86_64]
File: swift-DEVELOPMENT-SNAPSHOT-2023-03-10-a-ubuntu20.04/usr/lib/swift/linux/libicui18nswift.so.65.1
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux/x86_64]
File: swift-DEVELOPMENT-SNAPSHOT-2023-03-10-a-ubuntu20.04/usr/lib/swift/linux/libicui18nswift.so.65
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux/x86_64]
File: swift-DEVELOPMENT-SNAPSHOT-2023-03-10-a-ubuntu20.04/usr/lib/swift/linux/libicudataswift.so.65.1
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux/x86_64]
File: swift-DEVELOPMENT-SNAPSHOT-2023-03-10-a-ubuntu20.04/usr/lib/swift/linux/libicudataswift.so.65
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux/x86_64]
File: swift-DEVELOPMENT-SNAPSHOT-2023-03-10-a-ubuntu20.04/usr/lib/swift/linux/libicuucswift.so.65.1
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux/x86_64]
File: swift-DEVELOPMENT-SNAPSHOT-2023-03-10-a-ubuntu20.04/usr/lib/swift/linux/libicui18nswift.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN:/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux/x86_64]
File: swift-DEVELOPMENT-SNAPSHOT-2023-03-10-a-ubuntu20.04/usr/lib/liblldb.so.13git
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib:/home/build-user/build/buildbot_linux/llvm-linux-x86_64/./lib:/home/build-user/build/buildbot_linux/swift-linux-x86_64/lib/swift/linux:$ORIGIN/../lib/swift/linux]
File: swift-DEVELOPMENT-SNAPSHOT-2023-03-10-a-ubuntu20.04/usr/lib/clang/13.0.0/lib/linux/libclang_rt.memprof-x86_64.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib:/home/build-user/build/buildbot_linux/llvm-linux-x86_64/./lib]
File: swift-DEVELOPMENT-SNAPSHOT-2023-03-10-a-ubuntu20.04/usr/lib/clang/13.0.0/lib/linux/libclang_rt.ubsan_minimal-x86_64.so
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/../lib:/home/build-user/build/buildbot_linux/llvm-linux-x86_64/./lib
```
See if this fixes it by using the more traditional `LDFLAGS` instead.

@bnbarham, please run the CI on this and I'll check that it works.