### PR TITLE
[SourceKit] Stop using `isSystemModule` to represent "non-user" modules

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -630,7 +630,7 @@ protected:
     HasAnyUnavailableValues : 1
   );
 
-  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1,
+  SWIFT_INLINE_BITFIELD(ModuleDecl, TypeDecl, 1+1+1+1+1+1+1+1+1+1+1+1+1+1+1+1,
     /// If the module is compiled as static library.
     StaticLibrary : 1,
 
@@ -680,7 +680,11 @@ protected:
 
     /// If the map from @objc provided name to top level swift::Decl in this
     /// module is populated
-    ObjCNameLookupCachePopulated : 1
+    ObjCNameLookupCachePopulated : 1,
+
+    /// Whether the module is contained in the SDK or stdlib, or its a system
+    /// module and no SDK was specified.
+    IsNonUserModule : 1
   );
 
   SWIFT_INLINE_BITFIELD(PrecedenceGroupDecl, Decl, 1+2,

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -630,10 +630,20 @@ public:
   bool isSystemModule() const {
     return Bits.ModuleDecl.IsSystemModule;
   }
-  void setIsSystemModule(bool flag = true) {
-    Bits.ModuleDecl.IsSystemModule = flag;
-  }
+  void setIsSystemModule(bool flag = true);
 
+  /// \returns true if this module is part of the stdlib or contained within
+  /// the SDK. If no SDK was specified, also falls back to whether the module
+  /// was specified as a system module (ie. it's on the system search path).
+  bool isNonUserModule() const { return Bits.ModuleDecl.IsNonUserModule; }
+
+private:
+  /// Update whether this module is a non-user module, see \c isNonUserModule.
+  /// \p newUnit is the added unit that caused this update, or \c nullptr if
+  /// the update wasn't caused by adding a new unit.
+  void updateNonUserModule(FileUnit *newUnit);
+
+public:
   /// Returns true if the module was rebuilt from a module interface instead
   /// of being built from the full source.
   bool isBuiltFromInterface() const {
@@ -946,10 +956,6 @@ public:
   /// applicable.
   StringRef getModuleLoadedFilename() const;
 
-  /// \returns true if this module is defined under the SDK path.
-  /// If no SDK path is defined, this always returns false.
-  bool isSDKModule() const;
-
   /// \returns true if this module is the "swift" standard library module.
   bool isStdlibModule() const;
 
@@ -1074,6 +1080,7 @@ public:
   std::string getFullName(bool useRealNameIfAliased = false) const;
 
   bool isSystemModule() const;
+  bool isNonUserModule() const;
   bool isBuiltinModule() const;
   const ModuleDecl *getAsSwiftModule() const;
   const clang::Module *getAsClangModule() const;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -5730,8 +5730,7 @@ class TypePrinter : public TypeVisitor<TypePrinter> {
     // Don't print qualifiers for types from the standard library.
     if (M->isStdlibModule() ||
         M->getRealName() == M->getASTContext().Id_ObjectiveC ||
-        M->isSystemModule() ||
-        isLLDBExpressionModule(M))
+        M->isNonUserModule() || isLLDBExpressionModule(M))
       return false;
 
     // Don't print qualifiers for imported types.

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -611,6 +611,49 @@ ModuleDecl::ModuleDecl(Identifier name, ASTContext &ctx,
   Bits.ModuleDecl.HasHermeticSealAtLink = 0;
   Bits.ModuleDecl.IsConcurrencyChecked = 0;
   Bits.ModuleDecl.ObjCNameLookupCachePopulated = 0;
+  Bits.ModuleDecl.IsNonUserModule = 0;
+}
+
+void ModuleDecl::setIsSystemModule(bool flag) {
+  Bits.ModuleDecl.IsSystemModule = flag;
+  updateNonUserModule(/*newFile=*/nullptr);
+}
+
+static bool prefixMatches(StringRef prefix, StringRef path) {
+  auto i = llvm::sys::path::begin(prefix), e = llvm::sys::path::end(prefix);
+  for (auto pi = llvm::sys::path::begin(path), pe = llvm::sys::path::end(path);
+       i != e && pi != pe; ++i, ++pi) {
+    if (*i != *pi)
+      return false;
+  }
+  return i == e;
+}
+
+void ModuleDecl::updateNonUserModule(FileUnit *newUnit) {
+  if (isNonUserModule())
+    return;
+
+  SearchPathOptions searchPathOpts = getASTContext().SearchPathOpts;
+  StringRef sdkPath = searchPathOpts.getSDKPath();
+
+  if (isStdlibModule() || (sdkPath.empty() && isSystemModule())) {
+    Bits.ModuleDecl.IsNonUserModule = true;
+    return;
+  }
+
+  // If we loaded a serialized module, check if it was compiler adjacent or in
+  // the SDK.
+
+  auto *LF = dyn_cast_or_null<LoadedFile>(newUnit);
+  if (!LF)
+    return;
+
+  StringRef runtimePath = searchPathOpts.RuntimeResourcePath;
+  StringRef modulePath = LF->getSourceFilename();
+  if ((!runtimePath.empty() && prefixMatches(runtimePath, modulePath)) ||
+      (!sdkPath.empty() && prefixMatches(sdkPath, modulePath))) {
+    Bits.ModuleDecl.IsNonUserModule = true;
+  }
 }
 
 ImplicitImportList ModuleDecl::getImplicitImports() const {
@@ -632,6 +675,8 @@ void ModuleDecl::addFile(FileUnit &newFile) {
          cast<SourceFile>(newFile).Kind == SourceFileKind::SIL);
   Files.push_back(&newFile);
   clearLookupCache();
+
+  updateNonUserModule(&newFile);
 }
 
 void ModuleDecl::addAuxiliaryFile(SourceFile &sourceFile) {
@@ -2282,23 +2327,6 @@ StringRef ModuleDecl::getModuleLoadedFilename() const {
     }
   }
   return StringRef();
-}
-
-bool ModuleDecl::isSDKModule() const {
-  auto sdkPath = getASTContext().SearchPathOpts.getSDKPath();
-  if (sdkPath.empty())
-    return false;
-
-  auto modulePath = getModuleSourceFilename();
-  auto si = llvm::sys::path::begin(sdkPath),
-       se = llvm::sys::path::end(sdkPath);
-  for (auto mi = llvm::sys::path::begin(modulePath),
-       me = llvm::sys::path::end(modulePath);
-       si != se && mi != me; ++si, ++mi) {
-    if (*si != *mi)
-      return false;
-  }
-  return si == se;
 }
 
 bool ModuleDecl::isStdlibModule() const {
@@ -4063,6 +4091,14 @@ bool ModuleEntity::isSystemModule() const {
   assert(!Mod.isNull());
   if (auto SwiftMod = Mod.dyn_cast<const ModuleDecl*>())
     return SwiftMod->isSystemModule();
+  return getClangModule(Mod)->IsSystem;
+}
+
+bool ModuleEntity::isNonUserModule() const {
+  assert(!Mod.isNull());
+  if (auto *SwiftMod = Mod.dyn_cast<const ModuleDecl *>())
+    return SwiftMod->isNonUserModule();
+  // TODO: Should handle clang modules as well
   return getClangModule(Mod)->IsSystem;
 }
 

--- a/lib/IDE/CodeCompletionResult.cpp
+++ b/lib/IDE/CodeCompletionResult.cpp
@@ -293,7 +293,7 @@ ContextFreeCodeCompletionResult::getCodeCompletionDeclKind(const Decl *D) {
 }
 
 bool ContextFreeCodeCompletionResult::getDeclIsSystem(const Decl *D) {
-  return D->getModuleContext()->isSystemModule();
+  return D->getModuleContext()->isNonUserModule();
 }
 
 // MARK: - CodeCompletionResult

--- a/lib/IDE/CodeCompletionStringPrinter.cpp
+++ b/lib/IDE/CodeCompletionStringPrinter.cpp
@@ -131,7 +131,7 @@ void CodeCompletionStringPrinter::printTypeRef(Type T, const TypeDecl *TD,
                                                Identifier Name,
                                                PrintNameContext NameContext) {
 
-  NextChunkKind = TD->getModuleContext()->isSystemModule()
+  NextChunkKind = TD->getModuleContext()->isNonUserModule()
                       ? ChunkKind::TypeIdSystem
                       : ChunkKind::TypeIdUser;
 

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -1073,7 +1073,7 @@ private:
 
 void IndexSwiftASTWalker::visitDeclContext(DeclContext *Context) {
   IsModuleFile = false;
-  isSystemModule = Context->getParentModule()->isSystemModule();
+  isSystemModule = Context->getParentModule()->isNonUserModule();
   auto accessor = dyn_cast<AccessorDecl>(Context);
   if (accessor)
     ManuallyVisitedAccessorStack.push_back(accessor);
@@ -1101,7 +1101,7 @@ void IndexSwiftASTWalker::visitModule(ModuleDecl &Mod) {
     walk(*SrcFile);
   } else {
     IsModuleFile = true;
-    isSystemModule = Mod.isSystemModule();
+    isSystemModule = Mod.isNonUserModule();
     if (!handleSourceOrModuleFile(Mod))
       return;
     walk(Mod);
@@ -1178,7 +1178,7 @@ bool IndexSwiftASTWalker::visitImports(
       ModuleName = Declaring->getNameStr();
 
     if (!IdxConsumer.startDependency(ModuleName, Path, IsClangModule,
-                                     Mod->isSystemModule()))
+                                     Mod->isNonUserModule()))
       return false;
     if (!IsClangModule)
       if (!visitImports(*Mod, Visited))

--- a/lib/Refactoring/Refactoring.cpp
+++ b/lib/Refactoring/Refactoring.cpp
@@ -611,15 +611,15 @@ public:
 };
 
 static const ValueDecl *getRelatedSystemDecl(const ValueDecl *VD) {
-  if (VD->getModuleContext()->isSystemModule())
+  if (VD->getModuleContext()->isNonUserModule())
     return VD;
   for (auto *Req : VD->getSatisfiedProtocolRequirements()) {
-    if (Req->getModuleContext()->isSystemModule())
+    if (Req->getModuleContext()->isNonUserModule())
       return Req;
   }
   for (auto Over = VD->getOverriddenDecl(); Over;
        Over = Over->getOverriddenDecl()) {
-    if (Over->getModuleContext()->isSystemModule())
+    if (Over->getModuleContext()->isNonUserModule())
       return Over;
   }
   return nullptr;

--- a/test/Index/Store/ignore-system-clang-modules.swift
+++ b/test/Index/Store/ignore-system-clang-modules.swift
@@ -2,18 +2,18 @@
 
 // Make a basic clang framework to import
 //
-// RUN: %empty-directory(%t/MySystemFramework.framework/Headers)
-// RUN: %empty-directory(%t/MySystemFramework.framework/Modules)
-// RUN: echo 'void someSystemFunc(int arg);' > %t/MySystemFramework.framework/Headers/MySystemFramework.h
-// RUN: echo 'framework module MySystemFramework { umbrella header "MySystemFramework.h" export * }' > %t/MySystemFramework.framework/Modules/module.modulemap
+// RUN: %empty-directory(%t/sdk/MySystemFramework.framework/Headers)
+// RUN: %empty-directory(%t/sdk/MySystemFramework.framework/Modules)
+// RUN: echo 'void someSystemFunc(int arg);' > %t/sdk/MySystemFramework.framework/Headers/MySystemFramework.h
+// RUN: echo 'framework module MySystemFramework { umbrella header "MySystemFramework.h" export * }' > %t/sdk/MySystemFramework.framework/Modules/module.modulemap
 
 import MySystemFramework
 someSystemFunc(2)
 
 // Index this file with and without ignoring system frameworks
 //
-// RUN: %target-swiftc_driver -index-store-path %t/idx1 -o %t/file.o -Fsystem %t -typecheck %s
-// RUN: %target-swiftc_driver -index-store-path %t/idx2 -o %t/file.o -index-ignore-system-modules -Fsystem %t -typecheck %s
+// RUN: %target-swiftc_driver -index-store-path %t/idx1 -o %t/file.o -Fsystem %t/sdk -sdk %t/sdk -typecheck %s
+// RUN: %target-swiftc_driver -index-store-path %t/idx2 -o %t/file.o -index-ignore-system-modules -Fsystem %t/sdk -sdk %t/sdk -typecheck %s
 // RUN: c-index-test core -print-unit %t/idx1 | %FileCheck --check-prefixes=ALLOWSYSTEM,BOTH %s
 // RUN: c-index-test core -print-unit %t/idx2 | %FileCheck --check-prefixes=IGNORESYSTEM,BOTH %s
 

--- a/test/Interop/Cxx/symbolic-imports/indexing-emit-libcxx-symbolic-module-interface.swift
+++ b/test/Interop/Cxx/symbolic-imports/indexing-emit-libcxx-symbolic-module-interface.swift
@@ -32,11 +32,10 @@ import CxxStdlib
 import CxxModule
 
 // REMARK_NEW: remark: emitting symbolic interface at {{.*}}/interfaces/std-{{.*}}.pcm.symbolicswiftinterface{{$}}
-// REMARK_NEW-NEXT: remark: emitting symbolic interface at {{.*}}/interfaces/CxxModule-{{.*}}.pcm.symbolicswiftinterface{{$}}
-// REMARK_NEW-NEXT: EOF
+// REMARK_NEW: remark: emitting symbolic interface at {{.*}}/interfaces/CxxModule-{{.*}}.pcm.symbolicswiftinterface{{$}}
 
-// REMARK_NO_UPDATE: remark: emitting symbolic interface at {{.*}}/interfaces/std-{{.*}}.pcm.symbolicswiftinterface; skipping because it's up to date{{$}}
-// REMARK_NO_UPDATE: remark: emitting symbolic interface at {{.*}}/interfaces/CxxModule-{{.*}}.pcm.symbolicswiftinterface; skipping because it's up to date{{$}}
+// REMARK_NO_UPDATE-NOT: remark: emitting symbolic interface at {{.*}}/interfaces/std-{{.*}}.pcm.symbolicswiftinterface{{$}}
+// REMARK_NO_UPDATE-NOT: remark: emitting symbolic interface at {{.*}}/interfaces/CxxModule-{{.*}}.pcm.symbolicswiftinterface{{$}}
 
 // FILES: CxxModule-{{.*}}.pcm.symbolicswiftinterface
 // FILES: std-{{.*}}.pcm.symbolicswiftinterface

--- a/test/SourceKit/CursorInfo/cursor_stdlib.swift
+++ b/test/SourceKit/CursorInfo/cursor_stdlib.swift
@@ -34,7 +34,6 @@ func foo3(a: Float, b: Bool) {}
 // CHECK-OVERLAY-NEXT: UInt
 // CHECK-OVERLAY-NEXT: $sSuD
 // CHECK-OVERLAY-NEXT: Foundation
-// CHECK-OVERLAY-NEXT: SYSTEM
 // CHECK-OVERLAY-NEXT: <Declaration>let NSUTF8StringEncoding: <Type usr="s:Su">UInt</Type></Declaration>
 
 // RUN: %sourcekitd-test -req=cursor -pos=5:13 %s -- %s -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-ITERATOR %s

--- a/test/SourceKit/CursorInfo/cursor_swiftonly_systemmodule.swift
+++ b/test/SourceKit/CursorInfo/cursor_swiftonly_systemmodule.swift
@@ -1,4 +1,7 @@
+// Check whether we correctly specify `someFunc` as part of a system module.
+
 // RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/EmptySDK)
 // RUN: split-file %s %t
 
 // RUN: mkdir -p %t/SDK/Frameworks/SomeModule.framework/Modules/SomeModule.swiftmodule
@@ -9,12 +12,29 @@
 // RUN:     -swift-version 5 \
 // RUN:     %t/SomeModule.swift
 
+// Doesn't matter whether the framework is system or not, SomeModule is part
+// of the mock SDK.
 // RUN: %sourcekitd-test -req=cursor -pos=4:3 %t/main.swift -- \
 // RUN:     -sdk %t/SDK \
+// RUN:     -F %t/SDK/Frameworks \
+// RUN:     -target %target-triple \
+// RUN:     %t/main.swift \
+// RUN: | %FileCheck %s
+
+// No SDK, fallback to checking whether the search path is system or not
+// RUN: %sourcekitd-test -req=cursor -pos=4:3 %t/main.swift -- \
 // RUN:     -Fsystem %t/SDK/Frameworks \
 // RUN:     -target %target-triple \
 // RUN:     %t/main.swift \
 // RUN: | %FileCheck %s
+
+// Empty SDK, so shouldn't be a system module any more.
+// RUN: %sourcekitd-test -req=cursor -pos=4:3 %t/main.swift -- \
+// RUN:     -sdk %t/EmptySDK \
+// RUN:     -Fsystem %t/SDK/Frameworks \
+// RUN:     -target %target-triple \
+// RUN:     %t/main.swift \
+// RUN: | %FileCheck %s --check-prefix=NOSYS
 
 // CHECK: source.lang.swift.ref.function.free ()
 // CHECK-NEXT: someFunc()
@@ -26,6 +46,10 @@
 // CHECK-NEXT: SYSTEM
 // CHECK-NEXT: <Declaration>func someFunc()</Declaration>
 // CHECK-NEXT: <decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>someFunc</decl.name>()</decl.function.free>
+
+// NOSYS: someFunc()
+// NOSYS: SomeModule
+// NOSYS-NOT: SYSTEM
 
 //--- SomeModule.swift
 /// Doc comment for 'someFunc()'

--- a/test/SourceKit/InterfaceGen/Inputs/Foo2.swift
+++ b/test/SourceKit/InterfaceGen/Inputs/Foo2.swift
@@ -2,7 +2,7 @@
 // Keep this line
 
 import Foundation
-import Darwin
+
 public class NewLineAfterImport {
 }
 /// This is the class base

--- a/test/SourceKit/InterfaceGen/gen_swift_source.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_source.swift
@@ -7,7 +7,7 @@
 // RUN: %diff -u %s.response %t.response
 
 // RUN: %sourcekitd-test -req=interface-gen-open %S/Inputs/Foo2.swift -- %S/Inputs/Foo2.swift -target %target-triple %clang-importer-sdk-nosource -I %t \
-// RUN: == -req=cursor -pos=18:49 | %FileCheck -check-prefix=CHECK1 %s
+// RUN: == -req=cursor -pos=17:49 | %FileCheck -check-prefix=CHECK1 %s
 // The cursor points to 'FooOverlayClassBase' inside the list of base classes, see 'gen_swift_source.swift.response'
 
 // CHECK1: FooOverlayClassBase

--- a/test/SourceKit/InterfaceGen/gen_swift_source.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_source.swift.response
@@ -2,7 +2,6 @@
 // Keep this line
 
 import Foundation
-import Darwin
 
 public class NewLineAfterImport {
 }
@@ -65,244 +64,244 @@ internal enum Colors {
     key.length: 10
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 87,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 94,
-    key.length: 6
-  },
-  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 102,
+    key.offset: 88,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 109,
+    key.offset: 95,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 115,
+    key.offset: 101,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 139,
+    key.offset: 125,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 166,
+    key.offset: 152,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 173,
+    key.offset: 159,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 179,
+    key.offset: 165,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 206,
+    key.offset: 192,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 213,
+    key.offset: 199,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 218,
+    key.offset: 204,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 227,
+    key.offset: 213,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 236,
+    key.offset: 222,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 240,
+    key.offset: 226,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 247,
+    key.offset: 233,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 254,
+    key.offset: 240,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 261,
+    key.offset: 247,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 267,
+    key.offset: 253,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 292,
+    key.offset: 278,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 319,
+    key.offset: 305,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 328,
+    key.offset: 314,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 335,
+    key.offset: 321,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 340,
+    key.offset: 326,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 348,
+    key.offset: 334,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 357,
+    key.offset: 343,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 363,
+    key.offset: 349,
     key.length: 20
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 389,
+    key.offset: 375,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 398,
+    key.offset: 384,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 404,
+    key.offset: 390,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 432,
+    key.offset: 418,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 441,
+    key.offset: 427,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 447,
+    key.offset: 433,
     key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 473,
+    key.offset: 459,
     key.length: 22
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 499,
+    key.offset: 485,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 508,
+    key.offset: 494,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 512,
+    key.offset: 498,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 518,
+    key.offset: 504,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.doccomment,
-    key.offset: 527,
+    key.offset: 513,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 550,
+    key.offset: 536,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 559,
+    key.offset: 545,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 564,
+    key.offset: 550,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 568,
+    key.offset: 554,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 574,
+    key.offset: 560,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 579,
+    key.offset: 565,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 587,
+    key.offset: 573,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 596,
+    key.offset: 582,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 601,
+    key.offset: 587,
     key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 601,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 606,
+    key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -312,16 +311,6 @@ internal enum Colors {
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 620,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 629,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 634,
     key.length: 4
   }
 ]
@@ -333,37 +322,31 @@ internal enum Colors {
     key.is_system: 1
   },
   {
-    key.kind: source.lang.swift.ref.module,
-    key.offset: 94,
-    key.length: 6,
-    key.is_system: 1
-  },
-  {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 247,
+    key.offset: 233,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 292,
+    key.offset: 278,
     key.length: 19
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 518,
+    key.offset: 504,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 574,
+    key.offset: 560,
     key.length: 3,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
-    key.offset: 579,
+    key.offset: 565,
     key.length: 3,
     key.is_system: 1
   }
@@ -373,15 +356,15 @@ internal enum Colors {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "NewLineAfterImport",
-    key.offset: 109,
+    key.offset: 95,
     key.length: 28,
-    key.nameoffset: 115,
+    key.nameoffset: 101,
     key.namelength: 18,
-    key.bodyoffset: 135,
+    key.bodyoffset: 121,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 102,
+        key.offset: 88,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -391,17 +374,17 @@ internal enum Colors {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassBase",
-    key.offset: 173,
+    key.offset: 159,
     key.length: 79,
-    key.nameoffset: 179,
+    key.nameoffset: 165,
     key.namelength: 19,
-    key.bodyoffset: 200,
+    key.bodyoffset: 186,
     key.bodylength: 51,
-    key.docoffset: 139,
+    key.docoffset: 125,
     key.doclength: 27,
     key.attributes: [
       {
-        key.offset: 166,
+        key.offset: 152,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -411,13 +394,13 @@ internal enum Colors {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 213,
+        key.offset: 199,
         key.length: 8,
-        key.nameoffset: 218,
+        key.nameoffset: 204,
         key.namelength: 3,
         key.attributes: [
           {
-            key.offset: 206,
+            key.offset: 192,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -428,14 +411,14 @@ internal enum Colors {
         key.accessibility: source.lang.swift.accessibility.internal,
         key.setter_accessibility: source.lang.swift.accessibility.internal,
         key.name: "Range",
-        key.offset: 236,
+        key.offset: 222,
         key.length: 14,
         key.typename: "Int",
-        key.nameoffset: 240,
+        key.nameoffset: 226,
         key.namelength: 5,
         key.attributes: [
           {
-            key.offset: 227,
+            key.offset: 213,
             key.length: 8,
             key.attribute: source.decl.attribute.internal
           }
@@ -447,11 +430,11 @@ internal enum Colors {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "FooOverlayClassDerived",
-    key.offset: 261,
+    key.offset: 247,
     key.length: 84,
-    key.nameoffset: 267,
+    key.nameoffset: 253,
     key.namelength: 22,
-    key.bodyoffset: 313,
+    key.bodyoffset: 299,
     key.bodylength: 31,
     key.inheritedtypes: [
       {
@@ -460,7 +443,7 @@ internal enum Colors {
     ],
     key.attributes: [
       {
-        key.offset: 254,
+        key.offset: 240,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -468,7 +451,7 @@ internal enum Colors {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 292,
+        key.offset: 278,
         key.length: 19
       }
     ],
@@ -477,18 +460,18 @@ internal enum Colors {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "f()",
-        key.offset: 335,
+        key.offset: 321,
         key.length: 8,
-        key.nameoffset: 340,
+        key.nameoffset: 326,
         key.namelength: 3,
         key.attributes: [
           {
-            key.offset: 328,
+            key.offset: 314,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           },
           {
-            key.offset: 319,
+            key.offset: 305,
             key.length: 8,
             key.attribute: source.decl.attribute.override
           }
@@ -500,15 +483,15 @@ internal enum Colors {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "InternalClassVisible",
-    key.offset: 357,
+    key.offset: 343,
     key.length: 30,
-    key.nameoffset: 363,
+    key.nameoffset: 349,
     key.namelength: 20,
-    key.bodyoffset: 385,
+    key.bodyoffset: 371,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 348,
+        key.offset: 334,
         key.length: 8,
         key.attribute: source.decl.attribute.internal
       }
@@ -518,15 +501,15 @@ internal enum Colors {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "IgnoreBigWhiteSpaceGap",
-    key.offset: 398,
+    key.offset: 384,
     key.length: 32,
-    key.nameoffset: 404,
+    key.nameoffset: 390,
     key.namelength: 22,
-    key.bodyoffset: 428,
+    key.bodyoffset: 414,
     key.bodylength: 1,
     key.attributes: [
       {
-        key.offset: 389,
+        key.offset: 375,
         key.length: 8,
         key.attribute: source.decl.attribute.internal
       }
@@ -536,15 +519,15 @@ internal enum Colors {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "PropWithDocComment",
-    key.offset: 441,
+    key.offset: 427,
     key.length: 144,
-    key.nameoffset: 447,
+    key.nameoffset: 433,
     key.namelength: 18,
-    key.bodyoffset: 467,
+    key.bodyoffset: 453,
     key.bodylength: 117,
     key.attributes: [
       {
-        key.offset: 432,
+        key.offset: 418,
         key.length: 8,
         key.attribute: source.decl.attribute.internal
       }
@@ -555,16 +538,16 @@ internal enum Colors {
         key.accessibility: source.lang.swift.accessibility.internal,
         key.setter_accessibility: source.lang.swift.accessibility.internal,
         key.name: "prop",
-        key.offset: 508,
+        key.offset: 494,
         key.length: 13,
         key.typename: "Int",
-        key.nameoffset: 512,
+        key.nameoffset: 498,
         key.namelength: 4,
-        key.docoffset: 473,
+        key.docoffset: 459,
         key.doclength: 22,
         key.attributes: [
           {
-            key.offset: 499,
+            key.offset: 485,
             key.length: 8,
             key.attribute: source.decl.attribute.internal
           }
@@ -575,16 +558,16 @@ internal enum Colors {
         key.accessibility: source.lang.swift.accessibility.internal,
         key.setter_accessibility: source.lang.swift.accessibility.internal,
         key.name: "p1",
-        key.offset: 559,
+        key.offset: 545,
         key.length: 24,
         key.typename: "(Int, Int)",
-        key.nameoffset: 564,
+        key.nameoffset: 550,
         key.namelength: 2,
-        key.docoffset: 527,
+        key.docoffset: 513,
         key.doclength: 19,
         key.attributes: [
           {
-            key.offset: 550,
+            key.offset: 536,
             key.length: 8,
             key.attribute: source.decl.attribute.internal
           }
@@ -595,16 +578,16 @@ internal enum Colors {
         key.accessibility: source.lang.swift.accessibility.internal,
         key.setter_accessibility: source.lang.swift.accessibility.internal,
         key.name: "p2",
-        key.offset: 559,
+        key.offset: 545,
         key.length: 24,
         key.typename: "(Int, Int)",
-        key.nameoffset: 568,
+        key.nameoffset: 554,
         key.namelength: 2,
-        key.docoffset: 527,
+        key.docoffset: 513,
         key.doclength: 19,
         key.attributes: [
           {
-            key.offset: 550,
+            key.offset: 536,
             key.length: 8,
             key.attribute: source.decl.attribute.internal
           }
@@ -616,15 +599,15 @@ internal enum Colors {
     key.kind: source.lang.swift.decl.enum,
     key.accessibility: source.lang.swift.accessibility.internal,
     key.name: "Colors",
-    key.offset: 596,
+    key.offset: 582,
     key.length: 44,
-    key.nameoffset: 601,
+    key.nameoffset: 587,
     key.namelength: 6,
-    key.bodyoffset: 609,
+    key.bodyoffset: 595,
     key.bodylength: 30,
     key.attributes: [
       {
-        key.offset: 587,
+        key.offset: 573,
         key.length: 8,
         key.attribute: source.decl.attribute.internal
       }
@@ -632,32 +615,32 @@ internal enum Colors {
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 615,
+        key.offset: 601,
         key.length: 8,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.internal,
             key.name: "Red",
-            key.offset: 620,
+            key.offset: 606,
             key.length: 3,
-            key.nameoffset: 620,
+            key.nameoffset: 606,
             key.namelength: 3
           }
         ]
       },
       {
         key.kind: source.lang.swift.decl.enumcase,
-        key.offset: 629,
+        key.offset: 615,
         key.length: 9,
         key.substructure: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.accessibility: source.lang.swift.accessibility.internal,
             key.name: "Blue",
-            key.offset: 634,
+            key.offset: 620,
             key.length: 4,
-            key.nameoffset: 634,
+            key.nameoffset: 620,
             key.namelength: 4
           }
         ]

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -974,7 +974,7 @@ public:
     unsigned ByteOffset = SM.getLocOffsetInBuffer(Range.getStart(), BufferID);
     unsigned Length = Range.getByteLength();
     auto Kind = ContextFreeCodeCompletionResult::getCodeCompletionDeclKind(D);
-    bool IsSystem = D->getModuleContext()->isSystemModule();
+    bool IsSystem = D->getModuleContext()->isNonUserModule();
     SemaToks.emplace_back(Kind, ByteOffset, Length, IsRef, IsSystem);
   }
 };

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -252,10 +252,10 @@ static void reportSemanticAnnotations(const SourceTextInfo &IFaceInfo,
     bool IsSystem;
     if (Ref.Mod) {
       Kind = SwiftLangSupport::getUIDForModuleRef();
-      IsSystem = Ref.Mod.isSystemModule();
+      IsSystem = Ref.Mod.isNonUserModule();
     } else if (Ref.Dcl) {
       Kind = SwiftLangSupport::getUIDForDecl(Ref.Dcl, /*IsRef=*/true);
-      IsSystem = Ref.Dcl->getModuleContext()->isSystemModule();
+      IsSystem = Ref.Dcl->getModuleContext()->isNonUserModule();
     }
     if (Kind.isInvalid())
       continue;
@@ -505,7 +505,7 @@ bool SwiftInterfaceGenContext::matches(StringRef ModuleName,
   if (Invok.getSDKPath() != Impl.Invocation.getSDKPath())
     return false;
 
-  if (Impl.Mod->isSystemModule())
+  if (Impl.Mod->isNonUserModule())
     return true;
 
   const SearchPathOptions &SPOpts = Invok.getSearchPathOptions();

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -689,7 +689,7 @@ static bool passCursorInfoForModule(ModuleEntity Mod,
   Symbol.ModuleName = FullName;
   if (auto IFaceGenRef = IFaceGenContexts.find(Symbol.ModuleName, Invok))
     Symbol.ModuleInterfaceName = IFaceGenRef->getDocumentName();
-  Symbol.IsSystem = Mod.isSystemModule();
+  Symbol.IsSystem = Mod.isNonUserModule();
   if (auto MD = Mod.getAsSwiftModule()) {
     ide::collectModuleGroups(const_cast<ModuleDecl *>(MD), ModuleGroups);
     Symbol.ModuleGroupArray = llvm::makeArrayRef(ModuleGroups);
@@ -1064,8 +1064,7 @@ fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
           SwiftLangSupport::getUIDForDeclLanguage(FI.VD),
           swift::getAccessLevelSpelling(FI.VD->getFormalAccess()), Filename,
           getModuleName(FI.VD, Allocator),
-          FI.VD->getModuleContext()->isSystemModule(),
-          FI.VD->isSPI(),
+          FI.VD->getModuleContext()->isNonUserModule(), FI.VD->isSPI(),
           copyArray(Allocator, llvm::makeArrayRef(FIParents)));
     }
     Symbol.ReferencedSymbols = copyArray(Allocator,
@@ -1143,7 +1142,7 @@ fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
   }
   Symbol.ReceiverUSRs = copyAndClearArray(Allocator, Strings);
 
-  Symbol.IsSystem = DInfo.VD->getModuleContext()->isSystemModule();
+  Symbol.IsSystem = DInfo.VD->getModuleContext()->isNonUserModule();
   Symbol.IsDynamic = DInfo.IsDynamic;
   Symbol.IsSynthesized = DInfo.VD->isImplicit();
 

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2375,7 +2375,7 @@ private:
     bool IsInSystemModule = false;
     ValueDecl *D = Entity.Dcl;
     if (D) {
-      IsInSystemModule = D->getModuleContext()->isSystemModule();
+      IsInSystemModule = D->getModuleContext()->isNonUserModule();
       if (IsInSystemModule)
         OS << 'i';
       if (isa<ConstructorDecl>(D) && Entity.IsRef) {
@@ -2393,7 +2393,7 @@ private:
       }
 
     } else {
-      if (Entity.Mod.isSystemModule())
+      if (Entity.Mod.isNonUserModule())
         OS << 'i';
       OS << "Mod";
     }
@@ -2415,7 +2415,7 @@ private:
       }
 
     } else {
-      if (Entity.Mod.isSystemModule())
+      if (Entity.Mod.isNonUserModule())
         OS << 'i';
       OS << "Mod";
     }


### PR DESCRIPTION
Rather than using `ModuleDecl::isSystemModule()` to determine whether a module is not a user module, instead check whether the module was defined adjacent to the compiler or if it's part of the SDK.

If no SDK path was given, then `isSystemModule` is still used as a fallback.

Resolves rdar://89253201.