### PR TITLE
ABIChecker: consider adding/removing @_predatesConcurrency ABI-safe

### DIFF
--- a/test/api-digester/stability-concurrency-abi.test
+++ b/test/api-digester/stability-concurrency-abi.test
@@ -53,15 +53,8 @@
 // UNSUPPORTED: swift_evolve
 
 // *** DO NOT DISABLE OR XFAIL THIS TEST. *** (See comment above.)
-Func AsyncSequence.compactMap(_:) is now with @preconcurrency
-Func AsyncSequence.drop(while:) is now with @preconcurrency
-Func AsyncSequence.filter(_:) is now with @preconcurrency
-Func AsyncSequence.flatMap(_:) is now with @preconcurrency
-Func AsyncSequence.map(_:) is now with @preconcurrency
-Func AsyncSequence.prefix(while:) is now with @preconcurrency
 Func MainActor.run(resultType:body:) has generic signature change from <T where T : Swift.Sendable> to <T>
 Func MainActor.run(resultType:body:) has mangled name changing from 'static Swift.MainActor.run<A where A: Swift.Sendable>(resultType: A.Type, body: @Swift.MainActor @Sendable () throws -> A) async throws -> A' to 'static Swift.MainActor.run<A>(resultType: A.Type, body: @Swift.MainActor @Sendable () throws -> A) async throws -> A'
-Func _runAsyncMain(_:) is now with @preconcurrency
 Func _asyncLet_get(_:_:) has mangled name changing from '_Concurrency._asyncLet_get(Builtin.RawPointer, Builtin.RawPointer) async -> Builtin.RawPointer' to '_Concurrency._asyncLet_get(Builtin.RawPointer, Builtin.RawPointer) async -> ()'
 Func _asyncLet_get(_:_:) has return type change from Builtin.RawPointer to ()
 Func _asyncLet_get_throwing(_:_:) has mangled name changing from '_Concurrency._asyncLet_get_throwing(Builtin.RawPointer, Builtin.RawPointer) async throws -> Builtin.RawPointer' to '_Concurrency._asyncLet_get_throwing(Builtin.RawPointer, Builtin.RawPointer) async throws -> ()'

--- a/utils/gyb_syntax_support/AttributeKinds.py
+++ b/utils/gyb_syntax_support/AttributeKinds.py
@@ -661,7 +661,7 @@ DECL_ATTR_KINDS = [
     SimpleDeclAttribute('preconcurrency', 'Preconcurrency',
                         OnFunc, OnConstructor, OnProtocol, OnGenericType, OnVar, OnSubscript,  # noqa: E501
                         OnEnumElement, OnImport,
-                        ABIBreakingToAdd, ABIBreakingToRemove, APIBreakingToAdd, APIBreakingToRemove,  # noqa: E501
+                        ABIStableToAdd, ABIBreakingToRemove, APIBreakingToAdd, APIBreakingToRemove,  # noqa: E501
                         code=125),
 
     DeclAttribute('_unavailableFromAsync', 'UnavailableFromAsync',


### PR DESCRIPTION
We shouldn't diagnose changes of `@_predatesConcurrency` without considering the context because the attribute itself is for ABI-preserving purposes.

rdar://90738915
