### PR TITLE
[Dependency Scanner] Update for clang API change

### DIFF
--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -234,9 +234,9 @@ SwiftDependencyScanningService::SwiftDependencyScanningService()
   : ClangScanningService(clang::tooling::dependencies::ScanningMode::DependencyDirectivesScan,
                          clang::tooling::dependencies::ScanningOutputFormat::Full,
                          clang::CASOptions(),
+                         /* CAS (llvm::cas::ObjectStore) */ nullptr,
                          /* Cache (llvm::cas::ActionCache) */ nullptr,
                          /* SharedFS */ nullptr,
-                         /* ReuseFileManager */ false,
                          /* OptimizeArgs */ false) {
     SharedFilesystemCache.emplace();
 }


### PR DESCRIPTION
* Service takes a CAS parameter now
* Also remove a flag that has been removed for a while now (the flags are OptimizeArgs and EagerLoad now).
