### PR TITLE
[Macros] Add swift-plugin-server executable

### DIFF
--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -137,6 +137,9 @@ function(add_pure_swift_host_library name)
   add_library(${name} ${libkind} ${APSHL_SOURCES})
   _add_host_swift_compile_options(${name})
 
+  set_property(TARGET ${name}
+    PROPERTY BUILD_WITH_INSTALL_RPATH YES)
+
   # Respect LLVM_COMMON_DEPENDS if it is set.
   #
   # LLVM_COMMON_DEPENDS if a global variable set in ./lib that provides targets
@@ -256,6 +259,13 @@ function(add_pure_swift_host_tool name)
   # Create the library.
   add_executable(${name} ${APSHT_SOURCES})
   _add_host_swift_compile_options(${name})
+
+  set_property(TARGET ${name}
+    APPEND PROPERTY INSTALL_RPATH
+      "@executable_path/../lib/swift/host")
+
+  set_property(TARGET ${name}
+    PROPERTY BUILD_WITH_INSTALL_RPATH YES)
 
   # Respect LLVM_COMMON_DEPENDS if it is set.
   #

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1467,8 +1467,24 @@ public:
   
   Type getNamedSwiftType(ModuleDecl *module, StringRef name);
 
-  LoadedExecutablePlugin *
-  lookupExecutablePluginByModuleName(Identifier moduleName);
+  /// Lookup an executable plugin that is declared to handle \p moduleName
+  /// module by '-load-plugin-executable'. Note that the returned path might be
+  /// in the current VFS. i.e. use FS.getRealPath() to get the real path.
+  Optional<StringRef> lookupExecutablePluginByModuleName(Identifier moduleName);
+
+  /// From paths '-external-plugin-path', look for dylib file that has
+  /// 'lib${moduleName}.dylib' (or equialent depending on the platform) and
+  /// return the found dylib path and the path to the "plugin server" for that.
+  /// Note that the returned path might be in the current VFS.
+  Optional<std::pair<std::string, std::string>>
+  lookupExternalLibraryPluginByModuleName(Identifier moduleName);
+
+  /// Launch the specified executable plugin path resolving the path with the
+  /// current VFS. If it fails to load the plugin, a diagnostic is emitted, and
+  /// returns a nullptr.
+  /// NOTE: This method is idempotent. If the plugin is already loaded, the same
+  /// instance is simply returned.
+  LoadedExecutablePlugin *loadExecutablePlugin(StringRef path);
 
   /// Get the plugin registry this ASTContext is using.
   PluginRegistry *getPluginRegistry() const;

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -1468,14 +1468,15 @@ public:
   Type getNamedSwiftType(ModuleDecl *module, StringRef name);
 
   /// Lookup an executable plugin that is declared to handle \p moduleName
-  /// module by '-load-plugin-executable'. Note that the returned path might be
-  /// in the current VFS. i.e. use FS.getRealPath() to get the real path.
+  /// module by '-load-plugin-executable'.
+  /// The path is valid within the VFS, use `FS.getRealPath()` for the
+  /// underlying path.
   Optional<StringRef> lookupExecutablePluginByModuleName(Identifier moduleName);
 
-  /// From paths '-external-plugin-path', look for dylib file that has
-  /// 'lib${moduleName}.dylib' (or equialent depending on the platform) and
-  /// return the found dylib path and the path to the "plugin server" for that.
-  /// Note that the returned path might be in the current VFS.
+  /// Look for dynamic libraries in paths from `-external-plugin-path` and
+  /// return a pair of `(library path, plugin server executable)` if found.
+  /// These paths are valid within the VFS, use `FS.getRealPath()` for their
+  /// underlying path.
   Optional<std::pair<std::string, std::string>>
   lookupExternalLibraryPluginByModuleName(Identifier moduleName);
 

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -174,6 +174,13 @@ public:
                             llvm::vfs::FileSystem *FS, bool IsOSDarwin);
 };
 
+/// Pair of a plugin search path and the corresponding plugin server executable
+/// path.
+struct ExternalPluginSearchPathAndServerPath {
+  std::string SearchPath;
+  std::string ServerPath;
+};
+
 /// Options for controlling search path behavior.
 class SearchPathOptions {
   /// To call \c addImportSearchPath and \c addFrameworkSearchPath from
@@ -382,10 +389,11 @@ public:
   /// macro implementations.
   std::vector<std::string> PluginSearchPaths;
 
-  /// Paths that contain compiler plugins and the path to the plugin server
-  /// executable.
-  /// e.g. '/path/to/usr/lib/swift/host/plugins#/path/to/usr/bin/plugin-server'.
-  std::vector<std::string> ExternalPluginSearchPaths;
+  /// Pairs of external compiler plugin search paths and the corresponding
+  /// plugin server executables.
+  /// e.g. {"/path/to/usr/lib/swift/host/plugins",
+  ///       "/path/to/usr/bin/plugin-server"}
+  std::vector<ExternalPluginSearchPathAndServerPath> ExternalPluginSearchPaths;
 
   /// Don't look in for compiler-provided modules.
   bool SkipRuntimeLibraryImportPaths = false;

--- a/include/swift/AST/SearchPathOptions.h
+++ b/include/swift/AST/SearchPathOptions.h
@@ -382,6 +382,11 @@ public:
   /// macro implementations.
   std::vector<std::string> PluginSearchPaths;
 
+  /// Paths that contain compiler plugins and the path to the plugin server
+  /// executable.
+  /// e.g. '/path/to/usr/lib/swift/host/plugins#/path/to/usr/bin/plugin-server'.
+  std::vector<std::string> ExternalPluginSearchPaths;
+
   /// Don't look in for compiler-provided modules.
   bool SkipRuntimeLibraryImportPaths = false;
 

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -49,6 +49,7 @@ struct ExternalMacroDefinition;
 class ClosureExpr;
 class GenericParamList;
 class LabeledStmt;
+class LoadedExecutablePlugin;
 class MacroDefinition;
 class PrecedenceGroupDecl;
 class PropertyWrapperInitializerInfo;
@@ -4000,19 +4001,51 @@ public:
 /// Load a plugin module with the given name.
 ///
 ///
+class LoadedCompilerPlugin {
+  enum class PluginKind : uint8_t {
+    None,
+    InProcess,
+    Executable,
+  };
+  PluginKind kind;
+  void *ptr;
+
+  LoadedCompilerPlugin(PluginKind kind, void *ptr) : kind(kind), ptr(ptr) {
+    assert(ptr != nullptr || kind == PluginKind::None);
+  }
+
+public:
+  LoadedCompilerPlugin(std::nullptr_t) : kind(PluginKind::None), ptr(nullptr) {}
+
+  static LoadedCompilerPlugin inProcess(void *ptr) {
+    return {PluginKind::InProcess, ptr};
+  }
+  static LoadedCompilerPlugin executable(LoadedExecutablePlugin *ptr) {
+    return {PluginKind::Executable, ptr};
+  }
+
+  void *getAsInProcessPlugin() const {
+    return kind == PluginKind::InProcess ? static_cast<void *>(ptr) : nullptr;
+  }
+  LoadedExecutablePlugin *getAsExecutablePlugin() const {
+    return kind == PluginKind::Executable
+               ? static_cast<LoadedExecutablePlugin *>(ptr)
+               : nullptr;
+  }
+};
+
 class CompilerPluginLoadRequest
-  : public SimpleRequest<CompilerPluginLoadRequest,
-                         void *(ASTContext *, Identifier),
-                         RequestFlags::Cached> {
+    : public SimpleRequest<CompilerPluginLoadRequest,
+                           LoadedCompilerPlugin(ASTContext *, Identifier),
+                           RequestFlags::Cached> {
 public:
   using SimpleRequest::SimpleRequest;
 
 private:
   friend SimpleRequest;
 
-  void *evaluate(
-      Evaluator &evaluator, ASTContext *ctx, Identifier moduleName
-  ) const;
+  LoadedCompilerPlugin evaluate(Evaluator &evaluator, ASTContext *ctx,
+                                Identifier moduleName) const;
 
 public:
   // Source location

--- a/include/swift/AST/TypeCheckRequests.h
+++ b/include/swift/AST/TypeCheckRequests.h
@@ -4025,7 +4025,7 @@ public:
   }
 
   void *getAsInProcessPlugin() const {
-    return kind == PluginKind::InProcess ? static_cast<void *>(ptr) : nullptr;
+    return kind == PluginKind::InProcess ? ptr : nullptr;
   }
   LoadedExecutablePlugin *getAsExecutablePlugin() const {
     return kind == PluginKind::Executable

--- a/include/swift/AST/TypeCheckerTypeIDZone.def
+++ b/include/swift/AST/TypeCheckerTypeIDZone.def
@@ -431,7 +431,7 @@ SWIFT_REQUEST(TypeChecker, MacroDefinitionRequest,
               MacroDefinition(MacroDecl *),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, CompilerPluginLoadRequest,
-              void *(ASTContext *, Identifier),
+              LoadedCompilerPlugin(ASTContext *, Identifier),
               Cached, NoLocationInfo)
 SWIFT_REQUEST(TypeChecker, ExternalMacroDefinitionRequest,
               Optional<ExternalMacroDefinition>(ASTContext *, Identifier, Identifier),

--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -725,6 +725,12 @@ bool isFunctionAttr(Node::Kind kind);
 /// contain symbolic references.
 llvm::StringRef makeSymbolicMangledNameStringRef(const char *base);
 
+/// Produce the mangled name for the nominal type descriptor of a type
+/// referenced by its module and type name.
+std::string mangledNameForTypeMetadataAccessor(llvm::StringRef moduleName,
+                                               llvm::StringRef typeName,
+                                               Node::Kind typeKind);
+
 SWIFT_END_INLINE_NAMESPACE
 } // end namespace Demangle
 } // end namespace swift

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -303,6 +303,11 @@ def plugin_path : Separate<["-"], "plugin-path">,
   Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
   HelpText<"Add directory to the plugin search path">;
 
+def external_plugin_path : Separate<["-"], "external-plugin-path">,
+  Flags<[FrontendOption, ArgumentIsPath, SwiftAPIExtractOption, SwiftSymbolGraphExtractOption, SwiftAPIDigesterOption]>,
+  HelpText<"Add directory to the plugin search path with a plugin server executable">,
+  MetaVarName<"<path>#<plugin-server-path>">;
+
 def import_underlying_module : Flag<["-"], "import-underlying-module">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Implicitly imports the Objective-C half of a module">;

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -6358,15 +6358,11 @@ Optional<std::pair<std::string, std::string>>
 ASTContext::lookupExternalLibraryPluginByModuleName(Identifier moduleName) {
   auto fs = this->SourceMgr.getFileSystem();
   for (auto &pair : SearchPathOpts.ExternalPluginSearchPaths) {
-    StringRef searchPath;
-    StringRef serverPath;
-    std::tie(searchPath, serverPath) = StringRef(pair).split('#');
-
-    SmallString<128> fullPath(searchPath);
+    SmallString<128> fullPath(pair.SearchPath);
     llvm::sys::path::append(fullPath, "lib" + moduleName.str() + LTDL_SHLIB_EXT);
 
     if (fs->exists(fullPath)) {
-      return {{std::string(fullPath), serverPath.str()}};
+      return {{std::string(fullPath), pair.ServerPath}};
     }
   }
   return None;

--- a/lib/ASTGen/Package.swift
+++ b/lib/ASTGen/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
     .macOS(.v10_15)
   ],
   products: [
-    .library(name: "swiftASTGen", targets: ["swiftASTGen"])
+    .library(name: "swiftASTGen", targets: ["swiftASTGen"]),
+    .library(name: "swiftLLVMJSON", targets: ["swiftLLVMJSON"]),
   ],
   dependencies: [
     .package(path: "../../../swift-syntax")

--- a/lib/ASTGen/Sources/ASTGen/Macros.swift
+++ b/lib/ASTGen/Sources/ASTGen/Macros.swift
@@ -112,6 +112,9 @@ public func resolveExecutableMacro(
   typeNameLength: Int,
   pluginOpaqueHandle: UnsafeMutableRawPointer
 ) -> UnsafeRawPointer {
+  // NOTE: This doesn't actually resolve anything.
+  // Executable plugins is "trusted" to have the macro implementation. If not,
+  // the actual expansion fails.
   let exportedPtr = UnsafeMutablePointer<ExportedExecutableMacro>.allocate(capacity: 1)
   exportedPtr.initialize(to: .init(
     moduleName: String(bufferStart: moduleName, count: moduleNameLength),

--- a/lib/ASTGen/Sources/ASTGen/PluginHost.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginHost.swift
@@ -46,7 +46,7 @@ func swift_ASTGen_pluginServerLoadLibraryPlugin(
   cxxDiagnosticEngine: UnsafeMutablePointer<UInt8>
 ) -> Bool {
   let plugin =  CompilerPlugin(opaqueHandle: opaqueHandle)
-  assert(plugin.capability.features?.contains("loadPluginLibrary") == true)
+  assert(plugin.capability?.features.contains(.loadPluginLibrary) == true)
   let libraryPath = String(cString: libraryPath)
   let moduleName = String(cString: moduleName)
   let diagEngine = PluginDiagnosticsEngine(cxxDiagnosticEngine: cxxDiagnosticEngine)
@@ -67,6 +67,24 @@ func swift_ASTGen_pluginServerLoadLibraryPlugin(
 }
 
 struct CompilerPlugin {
+  struct Capability {
+    enum Feature: String {
+      case loadPluginLibrary = "load-plugin-library"
+    }
+
+    var protocolVersion: Int
+    var features: Set<Feature>
+
+    init(_ message: PluginMessage.PluginCapability) {
+      self.protocolVersion = message.protocolVersion
+      if let features = message.features {
+        self.features = Set(features.compactMap(Feature.init(rawValue:)))
+      } else {
+        self.features = []
+      }
+    }
+  }
+
   let opaqueHandle: UnsafeMutableRawPointer
 
   private func withLock<R>(_ body: () throws -> R) rethrows -> R {
@@ -111,26 +129,26 @@ struct CompilerPlugin {
   }
 
   func initialize() {
-    self.withLock {
-      // Get capability.
-      let response: PluginToHostMessage
-      do {
+    // Don't use `sendMessageAndWait` because we want to keep the lock until
+    // setting the returned value.
+    do {
+      try self.withLock {
+        // Get capability.
         try self.sendMessage(.getCapability)
-        response = try self.waitForNextMessage()
-      } catch {
-        assertionFailure(String(describing: error))
-        return
-      }
-      switch response {
-      case .getCapabilityResult(capability: let capability):
-        let ptr = UnsafeMutablePointer<PluginMessage.PluginCapability>.allocate(capacity: 1)
-        ptr.initialize(to: capability)
+        let response = try self.waitForNextMessage()
+        guard case .getCapabilityResult(let capability) = response else {
+          throw PluginError.invalidReponseKind
+        }
+        let ptr = UnsafeMutablePointer<Capability>.allocate(capacity: 1)
+        ptr.initialize(to: .init(capability))
         Plugin_setCapability(opaqueHandle, UnsafeRawPointer(ptr))
-      default:
-        assertionFailure("invalid response")
       }
+    } catch {
+      assertionFailure(String(describing: error))
+      return
     }
   }
+
   func deinitialize() {
     self.withLock {
       if let ptr = Plugin_getCapability(opaqueHandle) {
@@ -142,11 +160,11 @@ struct CompilerPlugin {
     }
   }
 
-  var capability: PluginMessage.PluginCapability {
+  var capability: Capability? {
     if let ptr = Plugin_getCapability(opaqueHandle) {
-      return ptr.assumingMemoryBound(to: PluginMessage.PluginCapability.self).pointee
+      return ptr.assumingMemoryBound(to: Capability.self).pointee
     }
-    return PluginMessage.PluginCapability(protocolVersion: 0)
+    return nil
   }
 }
 

--- a/lib/ASTGen/Sources/ASTGen/PluginMessages.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginMessages.swift
@@ -71,7 +71,7 @@ internal enum PluginToHostMessage: Codable {
     var protocolVersion: Int
 
     /// Optional features this plugin provides.
-    ///  * resolveLibraryMacro: 'resolveLibraryMacro' message is implemented.
+    ///  * loadPluginLibrary: 'loadPluginLibrary' message is implemented.
     var features: [String]?
   }
 

--- a/lib/ASTGen/Sources/ASTGen/PluginMessages.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginMessages.swift
@@ -71,7 +71,7 @@ internal enum PluginToHostMessage: Codable {
     var protocolVersion: Int
 
     /// Optional features this plugin provides.
-    ///  * loadPluginLibrary: 'loadPluginLibrary' message is implemented.
+    ///  * 'load-plugin-library': 'loadPluginLibrary' message is implemented.
     var features: [String]?
   }
 

--- a/lib/ASTGen/Sources/ASTGen/PluginMessages.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginMessages.swift
@@ -14,14 +14,17 @@
 // NOTE: Types in this file should be self-contained and should not depend on any non-stdlib types.
 
 internal enum HostToPluginMessage: Codable {
+  /// Get capability of this plugin.
   case getCapability
 
+  /// Expand a '@freestanding' macro.
   case expandFreestandingMacro(
     macro: PluginMessage.MacroReference,
     discriminator: String,
     syntax: PluginMessage.Syntax
   )
 
+  /// Expand an '@attached' macro.
   case expandAttachedMacro(
     macro: PluginMessage.MacroReference,
     macroRole: PluginMessage.MacroRole,
@@ -30,9 +33,21 @@ internal enum HostToPluginMessage: Codable {
     declSyntax: PluginMessage.Syntax,
     parentDeclSyntax: PluginMessage.Syntax?
   )
+
+  /// Optionally implemented message to load a dynamic link library.
+  /// 'moduleName' can be used as a hint indicating that the library
+  /// provides the specified module.
+  case loadPluginLibrary(
+    libraryPath: String,
+    moduleName: String
+  )
 }
 
 internal enum PluginToHostMessage: Codable {
+  case getCapabilityResult(
+    capability: PluginMessage.PluginCapability
+  )
+
   case expandFreestandingMacroResult(
     expandedSource: String?,
     diagnostics: [PluginMessage.Diagnostic]
@@ -43,18 +58,21 @@ internal enum PluginToHostMessage: Codable {
     diagnostics: [PluginMessage.Diagnostic]
   )
 
-  case getCapabilityResult(capability: PluginMessage.PluginCapability)
+  case loadPluginLibraryResult(
+    loaded: Bool,
+    diagnostics: [PluginMessage.Diagnostic]
+  )
 }
 
 /*namespace*/ internal enum PluginMessage {
-  static var PROTOCOL_VERSION_NUMBER: Int { 3 }  // Renamed 'customAttributeSyntax' to 'attributeSyntax'.
+  static var PROTOCOL_VERSION_NUMBER: Int { 4 }  // Added 'loadPluginLibrary'.
 
   struct PluginCapability: Codable {
     var protocolVersion: Int
-  }
 
-  static var capability: PluginCapability {
-    PluginCapability(protocolVersion: PluginMessage.PROTOCOL_VERSION_NUMBER)
+    /// Optional features this plugin provides.
+    ///  * resolveLibraryMacro: 'resolveLibraryMacro' message is implemented.
+    var features: [String]?
   }
 
   struct MacroReference: Codable {

--- a/lib/ASTGen/Sources/LLVMJSON/LLVMJSON.swift
+++ b/lib/ASTGen/Sources/LLVMJSON/LLVMJSON.swift
@@ -24,7 +24,7 @@ extension String {
 public struct LLVMJSON {
   /// Encode an `Encodable` value to JSON data, and call `body` is the buffer.
   /// Note that the buffer is valid onlu in `body`.
-  public static func encoding<T: Encodable, R>(_ value: T, body: (UnsafeBufferPointer<Int8>) -> R) throws -> R {
+  public static func encoding<T: Encodable, R>(_ value: T, body: (UnsafeBufferPointer<Int8>) throws -> R) throws -> R {
     let valuePtr = JSON_newValue()
     defer { JSON_value_delete(valuePtr) }
 
@@ -36,7 +36,7 @@ public struct LLVMJSON {
     assert(data.baseAddress != nil)
     defer { BridgedData_free(data) }
     let buffer = UnsafeBufferPointer(start: data.baseAddress, count: data.size)
-    return body(buffer)
+    return try body(buffer)
   }
 
   /// Decode a JSON data to a Swift value.

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -28,6 +28,7 @@ if (SWIFT_SWIFT_PARSER)
     SwiftOperators
     SwiftSyntaxBuilder
     SwiftSyntaxMacros
+    SwiftCompilerPluginMessageHandling
   )
 
   # Compute the list of SwiftSyntax targets that we will link against.

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -237,6 +237,7 @@ void ToolChain::addCommonFrontendArgs(const OutputInfo &OI,
   inputArgs.AddAllArgs(arguments, options::OPT_F, options::OPT_Fsystem);
   inputArgs.AddAllArgs(arguments, options::OPT_vfsoverlay);
   inputArgs.AddAllArgs(arguments, options::OPT_plugin_path);
+  inputArgs.AddAllArgs(arguments, options::OPT_external_plugin_path);
 
   inputArgs.AddLastArg(arguments, options::OPT_AssertConfig);
   inputArgs.AddLastArg(arguments, options::OPT_autolink_force_load);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1494,11 +1494,12 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
 
   for (const Arg *A : Args.filtered(OPT_external_plugin_path)) {
     // '<plugin directory>#<plugin server executable path>'.
+    // FIXME: '#' can be used in the paths.
     StringRef dylibPath;
     StringRef serverPath;
     std::tie(dylibPath, serverPath) = StringRef(A->getValue()).split('#');
     Opts.ExternalPluginSearchPaths.push_back(
-        resolveSearchPath(dylibPath) + "#" + resolveSearchPath(serverPath));
+        {resolveSearchPath(dylibPath), resolveSearchPath(serverPath)});
   }
 
   for (const Arg *A : Args.filtered(OPT_L)) {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -1492,6 +1492,15 @@ static bool ParseSearchPathArgs(SearchPathOptions &Opts,
     Opts.PluginSearchPaths.push_back(resolveSearchPath(A->getValue()));
   }
 
+  for (const Arg *A : Args.filtered(OPT_external_plugin_path)) {
+    // '<plugin directory>#<plugin server executable path>'.
+    StringRef dylibPath;
+    StringRef serverPath;
+    std::tie(dylibPath, serverPath) = StringRef(A->getValue()).split('#');
+    Opts.ExternalPluginSearchPaths.push_back(
+        resolveSearchPath(dylibPath) + "#" + resolveSearchPath(serverPath));
+  }
+
   for (const Arg *A : Args.filtered(OPT_L)) {
     Opts.LibrarySearchPaths.push_back(resolveSearchPath(A->getValue()));
   }

--- a/test/Macros/macro_plugin_server.swift
+++ b/test/Macros/macro_plugin_server.swift
@@ -1,0 +1,39 @@
+// FIXME: Swift parser is not enabled on Linux CI yet.
+// REQUIRES: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/plugins)
+//
+//== Build the plugin library
+// RUN: %target-build-swift \
+// RUN:   -swift-version 5 \
+// RUN:   -I %swift-host-lib-dir \
+// RUN:   -L %swift-host-lib-dir \
+// RUN:   -emit-library \
+// RUN:   -o %t/plugins/%target-library-name(MacroDefinition) \
+// RUN:   -module-name=MacroDefinition \
+// RUN:   %S/Inputs/syntax_macro_definitions.swift \
+// RUN:   -g -no-toolchain-stdlib-rpath
+
+// RUN: %swift-target-frontend \
+// RUN:   -typecheck -verify \
+// RUN:   -swift-version 5 \
+// RUN:   -external-plugin-path %t/plugins#%swift-plugin-server \
+// RUN:   -dump-macro-expansions \
+// RUN:   %s \
+// RUN:   2>&1 | tee %t/macro-expansions.txt
+
+// RUN: %FileCheck -strict-whitespace %s < %t/macro-expansions.txt
+
+
+@freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+
+func testStringify(a: Int, b: Int) {
+  let s: String = #stringify(a + b).1
+  print(s)
+}
+
+// CHECK:      {{^}}------------------------------
+// CHECK-NEXT: {{^}}(a + b, "a + b")
+// CHECK-NEXT: {{^}}------------------------------
+

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -343,6 +343,7 @@ config.benchmark_o = inferSwiftBinary('Benchmark_O')
 config.benchmark_driver = inferSwiftBinary('Benchmark_Driver')
 config.wasmer = inferSwiftBinary('wasmer')
 config.wasm_ld = inferSwiftBinary('wasm-ld')
+config.swift_plugin_server = inferSwiftBinary('swift-plugin-server')
 
 config.swift_utils = make_path(config.swift_src_root, 'utils')
 config.line_directive = make_path(config.swift_utils, 'line-directive')
@@ -573,6 +574,7 @@ config.substitutions.append( ('%Benchmark_Driver', config.benchmark_driver) )
 config.substitutions.append( ('%llvm-strings', config.llvm_strings) )
 config.substitutions.append( ('%target-ptrauth', run_ptrauth ) )
 config.substitutions.append( ('%swift-path', config.swift) )
+config.substitutions.append( ('%swift-plugin-server', config.swift_plugin_server) )
 
 # This must come after all substitutions containing "%swift".
 config.substitutions.append(

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -34,6 +34,7 @@ add_swift_tool_subdirectory(swift-refactor)
 add_swift_tool_subdirectory(libSwiftScan)
 add_swift_tool_subdirectory(libStaticMirror)
 add_swift_tool_subdirectory(libMockPlugin)
+add_swift_tool_subdirectory(swift-plugin-server)
 
 if(SWIFT_INCLUDE_TESTS OR SWIFT_INCLUDE_TEST_BINARIES)
   add_swift_tool_subdirectory(swift-ide-test)

--- a/tools/swift-plugin-server/CMakeLists.txt
+++ b/tools/swift-plugin-server/CMakeLists.txt
@@ -1,0 +1,32 @@
+if (SWIFT_SWIFT_PARSER)
+  # _swiftCSwiftPluginServer is just a C support library for  wift-plugin-server
+  # Don't bother to create '.a' for that.
+  add_swift_host_library(_swiftCSwiftPluginServer OBJECT
+    Sources/CSwiftPluginServer/PluginServer.cpp
+  )
+  target_link_libraries(_swiftCSwiftPluginServer
+    swiftDemangling
+  )
+  target_include_directories(_swiftCSwiftPluginServer PUBLIC
+    Sources/CSwiftPluginServer/include
+  )
+
+  add_pure_swift_host_tool(swift-plugin-server
+    Sources/swift-plugin-server/swift-plugin-server.swift
+    DEPENDENCIES
+      swiftDemangling
+      $<TARGET_OBJECTS:_swiftCSwiftPluginServer>
+    SWIFT_DEPENDENCIES
+      SwiftSyntax::SwiftSyntaxMacros
+      SwiftSyntax::SwiftCompilerPluginMessageHandling
+      swiftLLVMJSON
+  )
+  target_include_directories(swift-plugin-server PRIVATE
+    Sources/CSwiftPluginServer/include
+  )
+  swift_install_in_component(TARGETS swift-plugin-server
+    RUNTIME
+      DESTINATION bin
+      COMPONENT compiler
+  )
+endif()

--- a/tools/swift-plugin-server/CMakeLists.txt
+++ b/tools/swift-plugin-server/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (SWIFT_SWIFT_PARSER)
-  # _swiftCSwiftPluginServer is just a C support library for  wift-plugin-server
+  # _swiftCSwiftPluginServer is just a C support library for swift-plugin-server
   # Don't bother to create '.a' for that.
   add_swift_host_library(_swiftCSwiftPluginServer OBJECT
     Sources/CSwiftPluginServer/PluginServer.cpp

--- a/tools/swift-plugin-server/Package.swift
+++ b/tools/swift-plugin-server/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version: 5.6
+
+import PackageDescription
+
+let package = Package(
+  name: "swift-plugin-server",
+  platforms: [
+    .macOS(.v10_15)
+  ],
+  dependencies: [
+    .package(path: "../../../swift-syntax"),
+    .package(path: "../../lib/ASTGen"),
+  ],
+  targets: [
+    .target(
+      name: "CSwiftPluginServer",
+      cxxSettings: [
+        .unsafeFlags([
+          "-I", "../../include",
+          "-I", "../../../llvm-project/llvm/include",
+        ])
+      ]
+    ),
+    .executableTarget(
+      name: "swift-plugin-server",
+      dependencies: [
+        .product(name: "swiftLLVMJSON", package: "ASTGen"),
+        .product(name: "SwiftCompilerPluginMessageHandling", package: "swift-syntax"),
+        .product(name: "SwiftDiagnostics", package: "swift-syntax"),
+        .product(name: "SwiftSyntax", package: "swift-syntax"),
+        .product(name: "SwiftOperators", package: "swift-syntax"),
+        .product(name: "SwiftParser", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+        "CSwiftPluginServer"
+      ]
+    ),
+    
+  ]
+)

--- a/tools/swift-plugin-server/Sources/CSwiftPluginServer/PluginServer.cpp
+++ b/tools/swift-plugin-server/Sources/CSwiftPluginServer/PluginServer.cpp
@@ -1,0 +1,123 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "PluginServer.h"
+#include "swift/ABI/MetadataValues.h"
+#include "swift/Demangling/Demangle.h"
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+
+using namespace swift;
+
+namespace {
+struct ConnectionHandle {
+  int inputFD;
+  int outputFD;
+
+  ConnectionHandle(int inputFD, int outputFD)
+      : inputFD(inputFD), outputFD(outputFD) {}
+};
+} // namespace
+
+const void *PluginServer_createConnection(const char **errorMessage) {
+  // Duplicate the `stdin` file descriptor, which we will then use for
+  // receiving messages from the plugin host.
+  auto inputFD = dup(STDIN_FILENO);
+  if (inputFD < 0) {
+    *errorMessage = strerror(errno);
+    return nullptr;
+  }
+
+  // Having duplicated the original standard-input descriptor, we close
+  // `stdin` so that attempts by the plugin to read console input (which
+  // are usually a mistake) return errors instead of blocking.
+  if (close(STDIN_FILENO) < 0) {
+    *errorMessage = strerror(errno);
+    return nullptr;
+  }
+
+  // Duplicate the `stdout` file descriptor, which we will then use for
+  // sending messages to the plugin host.
+  auto outputFD = dup(STDOUT_FILENO);
+  if (outputFD < 0) {
+    *errorMessage = strerror(errno);
+    return nullptr;
+  }
+
+  // Having duplicated the original standard-output descriptor, redirect
+  // `stdout` to `stderr` so that all free-form text output goes there.
+  if (dup2(STDERR_FILENO, STDOUT_FILENO) < 0) {
+    *errorMessage = strerror(errno);
+    return nullptr;
+  }
+
+  // Open a message channel for communicating with the plugin host.
+  return new ConnectionHandle(inputFD, outputFD);
+}
+
+void PluginServer_destroyConnection(const void *connHandle) {
+  const auto *conn = static_cast<const ConnectionHandle *>(connHandle);
+  delete conn;
+}
+
+ssize_t PluginServer_read(const void *connHandle, void *data, size_t nbyte) {
+  const auto *conn = static_cast<const ConnectionHandle *>(connHandle);
+  return ::read(conn->inputFD, data, nbyte);
+}
+
+ssize_t PluginServer_write(const void *connHandle, const void *data,
+                           size_t nbyte) {
+  const auto *conn = static_cast<const ConnectionHandle *>(connHandle);
+  return ::write(conn->outputFD, data, nbyte);
+}
+
+void *PluginServer_dlopen(const char *filename, const char **errorMessage) {
+  auto *handle = ::dlopen(filename, RTLD_LAZY | RTLD_LOCAL);
+  if (!handle) {
+    *errorMessage = dlerror();
+  }
+  return handle;
+}
+
+const void *PluginServer_lookupMacroTypeMetadataByExternalName(
+    const char *moduleName, const char *typeName, void *libraryHint,
+    const char **errorMessage) {
+
+  // Look up the type metadata accessor as a struct, enum, or class.
+  const Demangle::Node::Kind typeKinds[] = {
+      Demangle::Node::Kind::Structure,
+      Demangle::Node::Kind::Enum,
+      Demangle::Node::Kind::Class,
+  };
+
+  void *accessorAddr = nullptr;
+  for (auto typeKind : typeKinds) {
+    auto symbolName =
+        mangledNameForTypeMetadataAccessor(moduleName, typeName, typeKind);
+
+    auto *handle = libraryHint ? libraryHint : RTLD_DEFAULT;
+    accessorAddr = ::dlsym(handle, symbolName.c_str());
+    if (accessorAddr)
+      break;
+  }
+
+  if (!accessorAddr)
+    return nullptr;
+
+  // Call the accessor to form type metadata.
+  using MetadataAccessFunc = const void *(MetadataRequest);
+  auto accessor = reinterpret_cast<MetadataAccessFunc*>(accessorAddr);
+  return accessor(MetadataRequest(MetadataState::Complete));
+}

--- a/tools/swift-plugin-server/Sources/CSwiftPluginServer/include/PluginServer.h
+++ b/tools/swift-plugin-server/Sources/CSwiftPluginServer/include/PluginServer.h
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_PLUGINSERVER_PLUGINSERVER_H
+#define SWIFT_PLUGINSERVER_PLUGINSERVER_H
+
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//===----------------------------------------------------------------------===//
+// Inter-process communication.
+//===----------------------------------------------------------------------===//
+
+/// Create an IPC communication handle.
+const void *PluginServer_createConnection(const char **errorMessage);
+
+/// Destroy an IPC communication handle created by
+/// 'PluginServer_createConnection'.
+void PluginServer_destroyConnection(const void *connHandle);
+
+/// Read bytes from the IPC communication handle.
+ssize_t PluginServer_read(const void *connHandle, void *data, size_t nbyte);
+
+/// Write bytes to the IPC communication handle.
+ssize_t PluginServer_write(const void *connHandle, const void *data,
+                           size_t nbyte);
+
+//===----------------------------------------------------------------------===//
+// Dynamic link
+//===----------------------------------------------------------------------===//
+
+/// Load a dynamic link library, and return the handle.
+void *PluginServer_dlopen(const char *filename, const char **errorMessage);
+
+/// Resolve a type metadata by a pair of the module name and the type name.
+/// 'libraryHint' is a
+const void *PluginServer_lookupMacroTypeMetadataByExternalName(
+    const char *moduleName, const char *typeName, void *libraryHint,
+    const char **errorMessage);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SWIFT_PLUGINSERVER_PLUGINSERVER_H */

--- a/tools/swift-plugin-server/Sources/CSwiftPluginServer/include/module.modulemap
+++ b/tools/swift-plugin-server/Sources/CSwiftPluginServer/include/module.modulemap
@@ -1,0 +1,4 @@
+module CSwiftPluginServer {
+  header "PluginServer.h"
+  export *
+}

--- a/tools/swift-plugin-server/Sources/swift-plugin-server/swift-plugin-server.swift
+++ b/tools/swift-plugin-server/Sources/swift-plugin-server/swift-plugin-server.swift
@@ -1,0 +1,206 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift open source project
+//
+// Copyright (c) 2023 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftCompilerPluginMessageHandling
+import SwiftSyntaxMacros
+import swiftLLVMJSON
+import CSwiftPluginServer
+
+@main
+final class SwiftPluginServer {
+  struct MacroRef: Hashable {
+    var moduleName: String
+    var typeName: String
+    init(_ moduleName: String, _ typeName: String) {
+      self.moduleName = moduleName
+      self.typeName = typeName
+    }
+  }
+
+  /// Loaded dylib handles associated with the module name.
+  var loadedLibraryPlugins: [String: UnsafeMutableRawPointer] = [:]
+
+  /// Resolved cached macros.
+  var resolvedMacros: [MacroRef: Macro.Type] = [:]
+
+  /// @main entry point.
+  static func main() throws {
+    let connection = try PluginHostConnection()
+    let messageHandler = CompilerPluginMessageHandler(
+      connection: connection,
+      provider: self.init()
+    )
+    try messageHandler.main()
+  }
+}
+
+extension SwiftPluginServer: PluginProvider {
+  /// Load a macro implementation from the dynamic link library.
+  func loadPluginLibrary(libraryPath: String, moduleName: String) throws {
+    var errorMessage: UnsafePointer<CChar>?
+    guard let dlHandle = PluginServer_dlopen(libraryPath, &errorMessage) else {
+      throw PluginServerError(message: String(cString: errorMessage!))
+    }
+    loadedLibraryPlugins[moduleName] = dlHandle
+  }
+
+  /// Lookup a loaded macro by a pair of module name and type name.
+  func resolveMacro(moduleName: String, typeName: String) -> Macro.Type? {
+    if let resolved = resolvedMacros[.init(moduleName, typeName)] {
+      return resolved
+    }
+
+    // Find 'dlopen'ed library for the module name.
+    guard let dlHandle = loadedLibraryPlugins[moduleName] else {
+      return nil
+    }
+
+    // Lookup the type metadata.
+    var errorMessage: UnsafePointer<CChar>?
+    guard let macroTypePtr = PluginServer_lookupMacroTypeMetadataByExternalName(
+      moduleName, typeName, dlHandle, &errorMessage
+    ) else {
+      // FIXME: Propagate error message?
+      return nil
+    }
+
+    // THe type must be a 'Macro' type.
+    let macroType = unsafeBitCast(macroTypePtr, to: Any.Type.self)
+    guard let macro = macroType as? Macro.Type else {
+      return nil
+    }
+
+    // Cache the resolved type.
+    resolvedMacros[.init(moduleName, typeName)] = macro
+    return macro
+  }
+
+  /// This 'PluginProvider' implements 'loadLibraryMacro()'.
+  var features: [SwiftCompilerPluginMessageHandling.PluginFeature] {
+    [.loadPluginLibrary]
+  }
+}
+
+final class PluginHostConnection: MessageConnection {
+  let handle: UnsafeRawPointer
+  init() throws {
+    var errorMessage: UnsafePointer<CChar>? = nil
+    guard let handle = PluginServer_createConnection(&errorMessage) else {
+      throw PluginServerError(message: String(cString: errorMessage!))
+    }
+    self.handle = handle
+  }
+
+  deinit {
+    PluginServer_destroyConnection(self.handle)
+  }
+
+  func sendMessage<TX: Encodable>(_ message: TX) throws {
+    try LLVMJSON.encoding(message) { buffer in
+      try self.sendMessageData(buffer)
+    }
+  }
+
+  func waitForNextMessage<RX: Decodable>(_ type: RX.Type) throws -> RX? {
+    return try self.withReadingMessageData { jsonData in
+      try LLVMJSON.decode(RX.self, from: jsonData)
+    }
+  }
+
+  /// Send a serialized message data to the message channel.
+  private func sendMessageData(_ data: UnsafeBufferPointer<Int8>) throws {
+    // Write the header (a 64-bit length field in little endian byte order).
+    var header: UInt64 = UInt64(data.count).littleEndian
+    let writtenSize = try Swift.withUnsafeBytes(of: &header) { buffer in
+      try self.write(data: UnsafeRawBufferPointer(buffer))
+    }
+    guard writtenSize == 8 else {
+      throw PluginServerError(message: "failed to write message header")
+    }
+
+    // Write the body.
+    guard try self.write(data: UnsafeRawBufferPointer(data)) == data.count else {
+      throw PluginServerError(message: "failed to write message data")
+    }
+  }
+
+  /// Read a serialized message data from the message channel and call the 'body'
+  /// with the data.
+  private func withReadingMessageData<R>(_ body: (UnsafeBufferPointer<Int8>) throws -> R) throws -> R? {
+    // Read the header.
+    var header: UInt64 = 0
+    let readSize = try Swift.withUnsafeMutableBytes(of: &header) { buffer in
+      try self.read(into: UnsafeMutableRawBufferPointer(buffer))
+    }
+    if readSize == 0 {
+      // The host closed the pipe.
+      return nil
+    }
+    guard readSize == 8 else {
+      throw PluginServerError(message: "failed to read message header")
+    }
+
+    // Read the body.
+    let count = Int(UInt64(littleEndian: header))
+    let data = UnsafeMutableBufferPointer<Int8>.allocate(capacity: count)
+    defer { data.deallocate() }
+    guard try self.read(into: UnsafeMutableRawBufferPointer(data)) == count else {
+      throw PluginServerError(message: "failed to read message data")
+    }
+
+    // Invoke the handler.
+    return try body(UnsafeBufferPointer(data))
+  }
+
+  /// Write the 'data' to the message channel.
+  /// Returns the number of bytes succeeded to write.
+  private func write(data: UnsafeRawBufferPointer) throws -> Int {
+    var bytesToWrite = data.count
+    var ptr = data.baseAddress!
+
+    while (bytesToWrite > 0) {
+      let writtenSize = PluginServer_write(handle, ptr, bytesToWrite)
+      if (writtenSize <= 0) {
+        // error e.g. broken pipe.
+        break
+      }
+      ptr = ptr.advanced(by: writtenSize)
+      bytesToWrite -= writtenSize
+    }
+    return data.count - bytesToWrite
+  }
+
+  /// Read data from the message channel into the 'buffer' up to 'buffer.count' bytes.
+  /// Returns the number of bytes succeeded to read.
+  private func read(into buffer: UnsafeMutableRawBufferPointer) throws -> Int {
+    var bytesToRead = buffer.count
+    var ptr = buffer.baseAddress!
+
+    while bytesToRead > 0 {
+      let readSize = PluginServer_read(handle, ptr, bytesToRead)
+      if (readSize <= 0) {
+        // 0: EOF (the host closed), -1: Broken pipe (the host crashed?)
+        break;
+      }
+      ptr = ptr.advanced(by: readSize)
+      bytesToRead -= readSize
+    }
+    return buffer.count - bytesToRead
+  }
+}
+
+struct PluginServerError: Error, CustomStringConvertible {
+  var description: String
+  init(message: String) {
+    self.description = message
+  }
+}


### PR DESCRIPTION
(depends on https://github.com/apple/swift-syntax/pull/1411)

Add `tools/swift-plugin-server`. This executable is intended to be installed in the toolchain and act as an executable compiler plugin just like other 'macro' plugins.

This plugin server has an optional method `loadPluginLibrary` that dynamically loads dylib plugins.
The compiler has a newly added option `-external-plugin-path`. This option receives a pair of the plugin library search path (just like `-plugin-path`) and the corresponding "plugin server" path, separated by `#`. i.e.

```
  -external-plugin-path
    <plugin library search path>#<plugin server exectuable path>
```

For exmaple, when there's a macro decl:

```swift
  @freestanding(expression)
  macro stringify<T>(T) -> (T, String) =
      #externalMacro(module: "BasicMacro", type: "StringifyMacro")
```

The compiler look for `libBasicMacro.dylib` in `-plugin-path` paths first, if not found, it falls back to `-external-plugin-path` and tries to find `libBasicMacro.dylib` in them. If it's found, the "plugin server" path is launched just like an executable plugin, then `loadPluginLibrary` method is invoked via IPC, which `dlopen` the library path in the plugin server. At the actual macro expansion, the mangled name for `BasicMacro.SinglifyMacro` is used to resolve the macro just like dylib plugins in the compiler.

This is useful for
 * Isolating the plugin process, so the plugin crashes doesn't result the compiler crash
 * Being able to use library plugins linked with other `swift-syntax` versions

rdar://105104850
