### PR TITLE
frontend: enable `shouldImportConcurrencyByDefault()` on FreeBSD

### DIFF
--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -830,6 +830,8 @@ static bool shouldImportConcurrencyByDefault(const llvm::Triple &target) {
     return true;
   if (target.isOSOpenBSD())
     return true;
+  if (target.isOSFreeBSD())
+    return true;
 #endif
   return false;
 }


### PR DESCRIPTION
Match OpenBSD and honor the SWIFT_IMPLICIT_CONCURRENCY_IMPORT build setting.
