### PR TITLE
PredictableMemOpt: fix a wrong debug info location type

### DIFF
--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -1219,7 +1219,7 @@ void AvailableValueAggregator::addHandOffCopyDestroysForPhis(
     // Otherwise, we need to insert one last destroy after the load for our phi.
     auto next = std::next(load->getIterator());
     SILBuilderWithScope builder(next);
-    builder.emitDestroyValueOperation(next->getLoc(), phi);
+    builder.emitDestroyValueOperation(RegularLocation(next->getLoc()), phi);
   }
 
   // Alright! In summary, we just lifetime extended all of our phis,
@@ -1251,7 +1251,7 @@ void AvailableValueAggregator::addMissingDestroysForCopiedValues(
         assert(li->getParent() == load->getParent());
         auto next = std::next(load->getIterator());
         SILBuilderWithScope builder(next);
-        builder.emitDestroyValueOperation(next->getLoc(), li);
+        builder.emitDestroyValueOperation(RegularLocation(next->getLoc()), li);
         continue;
       }
     }
@@ -1301,7 +1301,7 @@ void AvailableValueAggregator::addMissingDestroysForCopiedValues(
     // Otherwise, we need to insert one last destroy after the load for our phi.
     auto next = std::next(load->getIterator());
     SILBuilderWithScope builder(next);
-    builder.emitDestroyValueOperation(next->getLoc(), cvi);
+    builder.emitDestroyValueOperation(RegularLocation(next->getLoc()), cvi);
   }
 }
 


### PR DESCRIPTION
Fixes a crash in the debug info verification

rdar://106594725
