### PR TITLE
[ConstraintSystem] Allow type variables for pack expansion patterns to bind to `noescape`.

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3057,6 +3057,7 @@ namespace {
           CS.getConstraintLocator(expr, ConstraintLocator::PackExpansionPattern);
       auto patternTy = CS.createTypeVariable(patternLoc,
                                              TVO_CanBindToPack |
+                                             TVO_CanBindToNoEscape |
                                              TVO_CanBindToHole);
       auto elementResultType = CS.getType(expr->getPatternExpr());
       CS.addConstraint(ConstraintKind::PackElementOf, elementResultType,

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -196,3 +196,9 @@ func test_pack_expansion_materialization_from_lvalue_base() {
     }
   }
 }
+
+func takesFunctionPack<each T, R>(functions: repeat ((each T) -> R)) {}
+
+func forwardFunctionPack<each T>(functions: repeat (each T) -> Bool) {
+  takesFunctionPack(functions: repeat each functions)
+}


### PR DESCRIPTION
Otherwise, the constraint system will produce diagnostics when forwarding `noescape` function value packs, e.g.

```swift
func takesFunctionPack<each T, R>(functions: repeat ((each T) -> R)) {}

func forwardFunctionPack<each T>(functions: repeat (each T) -> Bool) {
  takesFunctionPack(functions: repeat each functions)
}
```