### PR TITLE
[CSDiagnostics] Ignore placeholder types that appear in editor placeh…

### DIFF
--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -8176,6 +8176,13 @@ bool CouldNotInferPlaceholderType::diagnoseAsError() {
     }
   }
 
+  // When placeholder type appears in an editor placeholder i.e.
+  // `<#T##() -> _#>` we rely on the parser to produce a diagnostic
+  // about editor placeholder and glance over all placeholder type
+  // inference issues.
+  if (isExpr<EditorPlaceholderExpr>(getAnchor()))
+    return true;
+
   return false;
 }
 

--- a/test/Sema/placeholder_type.swift
+++ b/test/Sema/placeholder_type.swift
@@ -270,3 +270,16 @@ func deferredInit(_ c: Bool) {
 // https://github.com/apple/swift/issues/63130
 let _: _  = nil // expected-error{{'nil' requires a contextual type}}
 let _: _? = nil // expected-error{{'nil' requires a contextual type}}
+
+// rdar://106621760 - failed to produce a diagnostic when placeholder type appears in editor placeholder
+do {
+  struct X<T> {
+    init(content: () -> T) {}
+  }
+
+  func test(_: () -> Void) {}
+
+  test {
+    _ = X(content: <#T##() -> _#>) // expected-error {{editor placeholder in source file}}
+  }
+}


### PR DESCRIPTION
…older expressions

When placeholder type appears in an editor placeholder i.e. `<#T##() -> _#>` 
we rely on the parser to produce a diagnostic about editor placeholder and 
glance over all placeholder type inference issues.

Resolves: rdar://106621760

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
