### PR TITLE
Enable LoopRotate on header blocks with forwarding instructions

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LoopRotate.cpp
@@ -79,11 +79,6 @@ canDuplicateOrMoveToPreheader(SILLoop *loop, SILBasicBlock *preheader,
     if (isa<DeallocStackInst>(inst)) {
       return false;
     }
-    OwnershipForwardingMixin *ofm = nullptr;
-    if ((ofm = OwnershipForwardingMixin::get(inst)) &&
-        ofm->getForwardingOwnershipKind() == OwnershipKind::Guaranteed) {
-      return false;
-    }
     if (isa<FunctionRefInst>(inst)) {
       moves.push_back(inst);
       invariants.insert(inst);

--- a/test/SILOptimizer/looprotate_nontrivial_ossa.sil
+++ b/test/SILOptimizer/looprotate_nontrivial_ossa.sil
@@ -203,7 +203,7 @@ exit:
 // A guaranteed value whose ownership has been forwarded must not be reborrowed. 
 //
 // CHECK-LABEL: sil [ossa] @forwarded_borrow_cant_be_reborrowed : $@convention(thin) (@owned BoxStruct) -> () {
-// CHECK-NOT:   {{bb[0-9]+}}({{%[^,]+}} : @guaranteed $BoxStruct, {{%[^,]+}} : @guaranteed $Klass):
+// CHECK:   {{bb[0-9]+}}({{%[^,]+}} : @guaranteed $BoxStruct, {{%[^,]+}} : @guaranteed $Klass):
 // CHECK-LABEL: } // end sil function 'forwarded_borrow_cant_be_reborrowed'
 sil [ossa] @forwarded_borrow_cant_be_reborrowed : $@convention(thin) (@owned BoxStruct) -> () {
 bb0(%0 : @owned $BoxStruct):


### PR DESCRIPTION
Loop rotate was disable when there were forwarding instructions in the loop header, because we could end up with guaranteed forwarding phis. We now have support for guaranteed forwarding phis, so enable this case.

Fixes rdar://86210259

