### PR TITLE
CopyPropagation: Compute side-effects first.

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -594,6 +594,7 @@ static void addPerfEarlyModulePassPipeline(SILPassPipelinePlan &P) {
   P.addTempRValueOpt();
   // Cleanup after SILGen: remove unneeded borrows/copies.
   if (P.getOptions().CopyPropagation == CopyPropagationOption::On) {
+    P.addComputeSideEffects();
     P.addCopyPropagation();
   }
   P.addSemanticARCOpts();

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -35,6 +35,16 @@
 /// TODO: Cleanup the resulting SIL by deleting instructions that produce dead
 /// values (after removing its copies).
 ///
+/// PASS DEPENDENCIES:
+/// - ComputeSideEffects
+///
+/// ANALYSES USED:
+/// - BasicCalleeAnalysis
+/// - DeadEndBlocksAnalysis
+/// - DominanceAnalysis
+/// - NonLocalAccessBlockAnalysis
+/// - PostOrderAnalysis
+///
 /// ===----------------------------------------------------------------------===
 
 #define DEBUG_TYPE "copy-propagation"

--- a/test/SILOptimizer/copy_propagation.swift
+++ b/test/SILOptimizer/copy_propagation.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend -primary-file %s -O -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
+
+// REQUIRES: swift_in_compiler
+
+class C {}
+
+@_silgen_name("non_barrier")
+@inline(never)
+func non_barrier() {}
+
+@_silgen_name("borrow")
+@inline(never)
+func borrow(_ c: C)
+
+// CHECK-LABEL: sil {{.*}}@test_hoist_over_non_barrier : {{.*}} {
+// CHECK:         [[INSTANCE:%[^,]+]] = alloc_ref
+// CHECK:         [[BORROW:%[^,]+]] = function_ref @borrow
+// CHECK:         apply [[BORROW]]([[INSTANCE]])
+// CHECK:         strong_release [[INSTANCE]]
+// CHECK:         [[NON_BARRIER:%[^,]+]] = function_ref @non_barrier
+// CHECK:         apply [[NON_BARRIER]]()
+// CHECK-LABEL: } // end sil function 'test_hoist_over_non_barrier'
+@_silgen_name("test_hoist_over_non_barrier")
+func test_hoist_over_non_barrier() {
+  let c = C()
+  borrow(c)
+  non_barrier()
+}
+


### PR DESCRIPTION
Add a run of `ComputeSideEffects` before the first run of `CopyPropagation`.  Allow hoisting over applies of functions that are able to be analyzed not to be deinit barriers at this early point.
