### PR TITLE
[Sema] Reenable two access-level on imports tests

### DIFF
--- a/test/ModuleInterface/access-level-import-swiftinterfaces.swift
+++ b/test/ModuleInterface/access-level-import-swiftinterfaces.swift
@@ -46,8 +46,6 @@
 // RUN: %FileCheck %s < %t/MultiFiles.swiftinterface
 // RUN: %FileCheck %s < %t/MultiFiles.private.swiftinterface
 
-// REQUIRES: rdar106219959
-
 //--- PublicLib.swift
 //--- PackageLib.swift
 //--- InternalLib.swift

--- a/test/Serialization/access-level-import-dependencies.swift
+++ b/test/Serialization/access-level-import-dependencies.swift
@@ -74,4 +74,3 @@ import PrivateDep
 // RUN: %target-swift-frontend -typecheck %t/ClientOfNonPublic.swift -I %t \
 // RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-HIDDEN-DEP %s
 
-// REQUIRES: rdar106219959


### PR DESCRIPTION
These were fixed in #64140 but I missed reenabling them.

rdar://106219959