### PR TITLE
[CS] Fix locator simplification with 'Member' path element

### DIFF
--- a/include/swift/Sema/ConstraintLocator.h
+++ b/include/swift/Sema/ConstraintLocator.h
@@ -313,6 +313,11 @@ public:
   /// branch, and if so, the kind of branch.
   Optional<SingleValueStmtBranchKind> isForSingleValueStmtBranch() const;
 
+  /// Returns true if \p locator is ending with either of the following
+  ///  - Member
+  ///  - Member -> KeyPathDynamicMember
+  bool isMemberRef() const;
+
   /// Determine whether this locator points directly to a given expression.
   template <typename E> bool directlyAt() const {
     if (auto *expr = getAnchor().dyn_cast<Expr *>())

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -534,9 +534,19 @@ public:
   bool diagnoseAsNote() override;
 };
 
+/// A diagnostic that will be emitted on the base if its locator points to a
+/// member access.
+class MemberReferenceFailure : public FailureDiagnostic {
+public:
+  MemberReferenceFailure(const Solution &solution, ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
+
+  ASTNode getAnchor() const override;
+};
+
 /// Diagnose failures related to attempting member access on optional base
 /// type without optional chaining or force-unwrapping it first.
-class MemberAccessOnOptionalBaseFailure final : public FailureDiagnostic {
+class MemberAccessOnOptionalBaseFailure final : public MemberReferenceFailure {
   DeclNameRef Member;
   Type MemberBaseType;
   bool ResultTypeIsOptional;
@@ -544,10 +554,9 @@ class MemberAccessOnOptionalBaseFailure final : public FailureDiagnostic {
 public:
   MemberAccessOnOptionalBaseFailure(const Solution &solution,
                                     ConstraintLocator *locator,
-                                    DeclNameRef memberName,
-                                    Type memberBaseType,
+                                    DeclNameRef memberName, Type memberBaseType,
                                     bool resultOptional)
-      : FailureDiagnostic(solution, locator), Member(memberName),
+      : MemberReferenceFailure(solution, locator), Member(memberName),
         MemberBaseType(resolveType(memberBaseType)),
         ResultTypeIsOptional(resultOptional) {}
 
@@ -1127,6 +1136,8 @@ public:
       : ContextualFailure(solution, base, wrapper, locator), Property(property),
         UsingProjection(usingProjection) {}
 
+  ASTNode getAnchor() const override;
+
   VarDecl *getProperty() const { return Property; }
 
   Identifier getPropertyName() const { return Property->getName(); }
@@ -1201,14 +1212,14 @@ public:
   bool diagnoseAsNote() override;
 };
 
-class InvalidMemberRefFailure : public FailureDiagnostic {
+class InvalidMemberRefFailure : public MemberReferenceFailure {
   Type BaseType;
   DeclNameRef Name;
 
 public:
   InvalidMemberRefFailure(const Solution &solution, Type baseType,
                           DeclNameRef memberName, ConstraintLocator *locator)
-      : FailureDiagnostic(solution, locator),
+      : MemberReferenceFailure(solution, locator),
         BaseType(baseType->getRValueType()), Name(memberName) {}
 
 protected:
@@ -1334,7 +1345,7 @@ public:
 ///
 /// }
 /// ```
-class AllowTypeOrInstanceMemberFailure final : public FailureDiagnostic {
+class AllowTypeOrInstanceMemberFailure final : public MemberReferenceFailure {
   Type BaseType;
   ValueDecl *Member;
   DeclNameRef Name;
@@ -1343,7 +1354,7 @@ public:
   AllowTypeOrInstanceMemberFailure(const Solution &solution, Type baseType,
                                    ValueDecl *member, DeclNameRef name,
                                    ConstraintLocator *locator)
-      : FailureDiagnostic(solution, locator),
+      : MemberReferenceFailure(solution, locator),
         BaseType(baseType->getRValueType()), Member(member), Name(name) {
     assert(member);
   }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10538,7 +10538,9 @@ ConstraintSystem::SolutionKind ConstraintSystem::simplifyMemberConstraint(
         // let's return, otherwise let's fall-through and report
         // this problem as a missing member.
         if (result == SolutionKind::Solved)
-          return recordFix(InsertExplicitCall::create(*this, locator))
+          return recordFix(InsertExplicitCall::create(
+                     *this, getConstraintLocator(
+                                locator, ConstraintLocator::MemberRefBase)))
                      ? SolutionKind::Error
                      : SolutionKind::Solved;
       }

--- a/lib/Sema/ConstraintLocator.cpp
+++ b/lib/Sema/ConstraintLocator.cpp
@@ -662,6 +662,19 @@ ConstraintLocator::isForSingleValueStmtBranch() const {
   return SingleValueStmtBranchKind::Regular;
 }
 
+bool ConstraintLocator::isMemberRef() const {
+  if (isLastElement<LocatorPathElt::Member>()) {
+    return true;
+  } else if (isLastElement<LocatorPathElt::KeyPathDynamicMember>()) {
+    auto path = getPath();
+    if (path.size() >= 2 &&
+        path[path.size() - 2].is<LocatorPathElt::Member>()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 GenericTypeParamType *ConstraintLocator::getGenericParameter() const {
   // Check whether we have a path that terminates at a generic parameter.
   return isForGenericParameter() ?

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -5469,6 +5469,15 @@ void constraints::simplifyLocator(ASTNode &anchor,
       LLVM_FALLTHROUGH;
 
     case ConstraintLocator::Member:
+      if (auto UDE = getAsExpr<UnresolvedDotExpr>(anchor)) {
+        path = path.slice(1);
+        continue;
+      }
+      if (anchor.is<Pattern *>()) {
+        path = path.slice(1);
+        continue;
+      }
+      break;
     case ConstraintLocator::MemberRefBase:
       if (auto UDE = getAsExpr<UnresolvedDotExpr>(anchor)) {
         range = UDE->getNameLoc().getSourceRange();

--- a/test/Constraints/rdar46544601.swift
+++ b/test/Constraints/rdar46544601.swift
@@ -22,9 +22,9 @@ extension P {
 func crash(_ p: P, payload: [UInt8]) throws {
   p.foo(data: payload).then { _ in
     return Future<(D, [D])>()
-  }.then { (id, arr) in // expected-error {{generic parameter 'U' could not be inferred}}
+  }.then { (id, arr) in
     p.foo(arr: arr, data: []).and(result: (id, arr))
-  }.then { args0 in
+  }.then { args0 in // expected-error {{generic parameter 'U' could not be inferred}}
     let (parentID, args1) = args0
     p.bar(root: parentID, from: p).and(result: args1)
   }.whenFailure { _ in }

--- a/test/Misc/serialized-diagnostics-prettyprint.swift
+++ b/test/Misc/serialized-diagnostics-prettyprint.swift
@@ -6,7 +6,7 @@
 // RUN: %FileCheck --input-file=%t.deserialized_diagnostics.txt %s
 
 var x = String.init // expected-error{{ambiguous use of 'init'}}
-// CHECK: {{.*[/\\]}}serialized-diagnostics-prettyprint.swift:[[@LINE-1]]:9: error: ambiguous use of 'init'
+// CHECK: {{.*[/\\]}}serialized-diagnostics-prettyprint.swift:[[@LINE-1]]:16: error: ambiguous use of 'init'
 
 // CHECK: Swift.String:2:23: note: found this candidate
 // CHECK: CONTENTS OF FILE Swift.String:


### PR DESCRIPTION
Previously, a `Member` path element in a `ConstraintLocator` was simplified to the base on which the member was accessed. This is incorrect.
