### PR TITLE
[Macros] Add env variable option to dump exectuable plugin messagings

### DIFF
--- a/include/swift/AST/PluginRegistry.h
+++ b/include/swift/AST/PluginRegistry.h
@@ -64,6 +64,9 @@ class LoadedExecutablePlugin {
   /// Callbacks to be called when the connection is restored.
   llvm::SmallVector<std::function<void(void)> *, 0> onReconnect;
 
+  /// Flag to dump plugin messagings.
+  bool dumpMessaging = false;
+
   /// Cleanup function to call ASTGen.
   std::function<void(void)> cleanup;
 
@@ -121,6 +124,8 @@ public:
 
   const void *getCapability() { return capability; };
   void setCapability(const void *newValue) { capability = newValue; };
+
+  void setDumpMessaging(bool flag) { dumpMessaging = flag; }
 };
 
 class PluginRegistry {
@@ -131,7 +136,12 @@ class PluginRegistry {
   llvm::StringMap<std::unique_ptr<LoadedExecutablePlugin>>
       LoadedPluginExecutables;
 
+  /// Flag to dump plugin messagings.
+  bool dumpMessaging = false;
+
 public:
+  PluginRegistry();
+
   /// Load a dynamic link library specified by \p path.
   /// If \p path plugin is already loaded, this returns the cached object.
   llvm::Expected<void *> loadLibraryPlugin(llvm::StringRef path);

--- a/lib/ASTGen/Sources/ASTGen/PluginHost.swift
+++ b/lib/ASTGen/Sources/ASTGen/PluginHost.swift
@@ -103,10 +103,6 @@ struct CompilerPlugin {
 
   private func sendMessage(_ message: HostToPluginMessage) throws {
     let hadError = try LLVMJSON.encoding(message) { (data) -> Bool in
-//      // FIXME: Add -dump-plugin-message option?
-//      data.withMemoryRebound(to: UInt8.self) { buffer in
-//        print(">> " + String(decoding: buffer, as: UTF8.self))
-//      }
       return Plugin_sendMessage(opaqueHandle, BridgedData(baseAddress: data.baseAddress, size: data.count))
     }
     if hadError {
@@ -122,10 +118,6 @@ struct CompilerPlugin {
       throw PluginError.failedToReceiveMessage
     }
     let data = UnsafeBufferPointer(start: result.baseAddress, count: result.size)
-//    // FIXME: Add -dump-plugin-message option?
-//    data.withMemoryRebound(to: UInt8.self) { buffer in
-//      print("<< " + String(decoding: buffer, as: UTF8.self))
-//    }
     return try LLVMJSON.decode(PluginToHostMessage.self, from: data)
   }
 

--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -11,12 +11,25 @@
 // RUN:  -o %t/mock-plugin \
 // RUN:  %t/plugin.c
 
-// RUN: %swift-target-frontend \
+// RUN: SWIFT_DUMP_PLUGIN_MESSAGING=1 %swift-target-frontend \
 // RUN:   -typecheck -verify \
 // RUN:   -swift-version 5 -enable-experimental-feature Macros \
 // RUN:   -load-plugin-executable %t/mock-plugin#TestPlugin \
-// RUN:   -dump-macro-expansions \
-// RUN:   %t/test.swift
+// RUN:   -module-name MyApp \
+// RUN:   %t/test.swift \
+// RUN:   2>&1 | tee %t/macro-expansions.txt
+
+// RUN: %FileCheck -strict-whitespace %s < %t/macro-expansions.txt
+
+// CHECK: ->(plugin:[[#PID1:]]) {"getCapability":{}}
+// CHECK-NEXT: <-(plugin:[[#PID1]]) {"getCapabilityResult":{"capability":{"protocolVersion":1}}}
+// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":6,"offset":200},"source":"#fooMacro(1)"}}}
+// CHECK-NEXT: <-(plugin:[[#PID1]]) {"invalidResponse":{}}
+// CHECK-NEXT: ->(plugin:[[#PID1]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":8,"offset":304},"source":"#fooMacro(2)"}}}
+// ^ This messages causes the mock plugin exit because there's no matching expected message.
+
+// CHECK: ->(plugin:[[#PID2:]]) {"expandFreestandingMacro":{"discriminator":"$s{{.+}}","macro":{"moduleName":"TestPlugin","name":"fooMacro","typeName":"FooMacro"},"syntax":{"kind":"expression","location":{"column":19,"fileID":"MyApp/test.swift","fileName":"BUILD_DIR{{.+}}test.swift","line":10,"offset":386},"source":"#fooMacro(3)"}}}
+// CHECK-NEXT: <-(plugin:[[#PID2:]]) {"expandFreestandingMacroResult":{"diagnostics":[],"expandedSource":"3.description"}}
 
 //--- test.swift
 @freestanding(expression) macro fooMacro(_: Any) -> String = #externalMacro(module: "TestPlugin", type: "FooMacro")


### PR DESCRIPTION
Set `SWIFT_DUMP_PLUGIN_MESSAGING` env variable to enable it.
Not a compiler option because a plugin can be reused between multiple compiler invocations.