### PR TITLE
Allow @usableFromInline and @inlinable to package decls

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2439,10 +2439,10 @@ WARNING(protocol_access_warn,none,
         (bool, AccessLevel, bool, AccessLevel, bool, DescriptiveDeclKind))
 ERROR(protocol_usable_from_inline,none,
       "protocol %select{refined|used}0 by '@usableFromInline' protocol "
-      "must be '@usableForInline' or public", (bool))
+      "must be '@usableFromInline' or public", (bool))
 WARNING(protocol_usable_from_inline_warn,none,
         "protocol %select{refined|used}0 by '@usableFromInline' protocol "
-        "should be '@usableForInline' or public", (bool))
+        "should be '@usableFromInline' or public", (bool))
 ERROR(protocol_property_must_be_computed_var,none,
       "protocols cannot require properties to be immutable; declare read-only "
       "properties by using 'var' with a '{ get }' specifier", ())
@@ -6162,7 +6162,7 @@ ERROR(frozen_attr_on_internal_type,
       (DeclName, AccessLevel))
 
 ERROR(usable_from_inline_attr_with_explicit_access,
-      none, "'@usableFromInline' attribute can only be applied to internal "
+      none, "'@usableFromInline' attribute can only be applied to internal or package "
       "declarations, but %0 is %select{private|fileprivate|%error|package|public|open}1",
       (DeclName, AccessLevel))
 

--- a/lib/Sema/TypeCheckAccess.cpp
+++ b/lib/Sema/TypeCheckAccess.cpp
@@ -1268,7 +1268,8 @@ public:
       : AccessControlCheckerBase(/*checkUsableFromInline=*/true) {}
 
   static bool shouldSkipChecking(const ValueDecl *VD) {
-    if (VD->getFormalAccess() != AccessLevel::Internal)
+    if (VD->getFormalAccess() != AccessLevel::Internal &&
+        VD->getFormalAccess() != AccessLevel::Package)
       return true;
     return !VD->isUsableFromInline();
   };

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2886,8 +2886,9 @@ void AttributeChecker::visitUsableFromInlineAttr(UsableFromInlineAttr *attr) {
     return;
   }
 
-  // @usableFromInline can only be applied to internal declarations.
-  if (VD->getFormalAccess() != AccessLevel::Internal) {
+  // @usableFromInline can only be applied to internal or package declarations.
+  if (VD->getFormalAccess() != AccessLevel::Internal &&
+      VD->getFormalAccess() != AccessLevel::Package) {
     diagnoseAndRemoveAttr(attr,
                           diag::usable_from_inline_attr_with_explicit_access,
                           VD->getName(), VD->getFormalAccess());

--- a/test/Compatibility/attr_usableFromInline_swift4.swift
+++ b/test/Compatibility/attr_usableFromInline_swift4.swift
@@ -2,10 +2,10 @@
 // RUN: %target-typecheck-verify-swift -enable-testing -swift-version 4 -disable-objc-attr-requires-foundation-module -enable-objc-interop
 
 @usableFromInline private func privateVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'privateVersioned()' is private}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'privateVersioned()' is private}}
 
 @usableFromInline fileprivate func fileprivateVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'fileprivateVersioned()' is fileprivate}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'fileprivateVersioned()' is fileprivate}}
 
 @usableFromInline internal func internalVersioned() {}
 // OK
@@ -14,11 +14,11 @@
 // OK
 
 @usableFromInline public func publicVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'publicVersioned()' is public}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'publicVersioned()' is public}}
 
 internal class InternalClass {
   @usableFromInline public func publicVersioned() {}
-  // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'publicVersioned()' is public}}
+  // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'publicVersioned()' is public}}
 }
 
 fileprivate class filePrivateClass {

--- a/test/Compatibility/attr_usableFromInline_swift42.swift
+++ b/test/Compatibility/attr_usableFromInline_swift42.swift
@@ -2,10 +2,10 @@
 // RUN: %target-typecheck-verify-swift -enable-testing -swift-version 4.2 -disable-objc-attr-requires-foundation-module -enable-objc-interop
 
 @usableFromInline private func privateVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'privateVersioned()' is private}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'privateVersioned()' is private}}
 
 @usableFromInline fileprivate func fileprivateVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'fileprivateVersioned()' is fileprivate}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'fileprivateVersioned()' is fileprivate}}
 
 @usableFromInline internal func internalVersioned() {}
 // OK
@@ -14,12 +14,12 @@
 // OK
 
 @usableFromInline public func publicVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'publicVersioned()' is public}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'publicVersioned()' is public}}
 
 internal class InternalClass {
   // expected-note@-1 2{{type declared here}}
   @usableFromInline public func publicVersioned() {}
-  // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'publicVersioned()' is public}}
+  // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'publicVersioned()' is public}}
 }
 
 fileprivate class filePrivateClass {
@@ -119,7 +119,7 @@ where T : InternalProtocol,
 
 @usableFromInline
 protocol BadProtocol : InternalProtocol {
-  // expected-warning@-1 {{protocol refined by '@usableFromInline' protocol should be '@usableForInline' or public}}
+  // expected-warning@-1 {{protocol refined by '@usableFromInline' protocol should be '@usableFromInline' or public}}
   associatedtype X : InternalProtocol
   // expected-warning@-1 {{type referenced from a requirement of an associated type in a '@usableFromInline' protocol should be '@usableFromInline' or public}}
   associatedtype Y = InternalStruct
@@ -128,7 +128,7 @@ protocol BadProtocol : InternalProtocol {
 
 @usableFromInline
 protocol AnotherBadProtocol where Self.T : InternalProtocol {
-  // expected-warning@-1 {{protocol used by '@usableFromInline' protocol should be '@usableForInline' or public}}
+  // expected-warning@-1 {{protocol used by '@usableFromInline' protocol should be '@usableFromInline' or public}}
   associatedtype T
 }
 

--- a/test/SPI/local_spi_decls.swift
+++ b/test/SPI/local_spi_decls.swift
@@ -1,10 +1,10 @@
 // Checks for SPI declarations and limited exportability.
 
 // RUN: %empty-directory(%t)
-// RUN: %target-typecheck-verify-swift -I %t -verify-ignore-unknown -enable-library-evolution -swift-version 5
+// RUN: %target-typecheck-verify-swift -I %t -verify-ignore-unknown -enable-library-evolution -swift-version 5 -package-name myPkg
 
 // Without -enable-library-evolution the exportability check looks at struct internal properties.
-// RUN: %target-typecheck-verify-swift -I %t -verify-ignore-unknown -swift-version 5
+// RUN: %target-typecheck-verify-swift -I %t -verify-ignore-unknown -swift-version 5 -package-name myPkg
 
 // SPI declarations
 @_spi(MySPI) public func spiFunc() {}
@@ -120,3 +120,7 @@ public func inlinableSPI() {
   spiFunc()
   let _ = SPIClass()
 }
+
+@_spi(S) func internalFunc() {} // expected-error {{internal global function cannot be declared '@_spi' because only public and open declarations can be '@_spi'}}
+
+@_spi(S) package func packageFunc() {} // expected-error {{package global function cannot be declared '@_spi' because only public and open declarations can be '@_spi'}}

--- a/test/Sema/accessibility_package.swift
+++ b/test/Sema/accessibility_package.swift
@@ -4,45 +4,116 @@
 // RUN: %target-swift-frontend -module-name Utils %t/Utils.swift -emit-module -emit-module-path %t/Utils.swiftmodule -package-name myLib
 // RUN: test -f %t/Utils.swiftmodule
 
-// RUN: %target-swift-frontend -module-name Lib %t/Lib.swift -emit-module -emit-module-path %t/Lib.swiftmodule -package-name myLib -I %t
-// RUN: test -f %t/Lib.swiftmodule
+// RUN: %target-swift-frontend -module-name LibGood %t/LibGood.swift -emit-module -emit-module-path %t/LibGood.swiftmodule -package-name myLib -I %t
+// RUN: test -f %t/LibGood.swiftmodule
 
-// RUN: not %target-swift-frontend -typecheck %t/Lib.swift -package-name "otherLib" -I %t 2>&1 | %FileCheck %s
-// CHECK: error: cannot find type 'PackageProto' in scope
-// CHECK: error: 'pkgFunc' is inaccessible due to 'package' protection level
-// CHECK: error: cannot find 'PackageKlass' in scope
+// RUN: not %target-swift-frontend -module-name Client %t/Client.swift -emit-module -emit-module-path %t/Client.swiftmodule -package-name client -I %t 2> %t/resultClient.output
+// RUN: %FileCheck %s -input-file %t/resultClient.output -check-prefix CHECK-CLIENT
+// CHECK-CLIENT: error: 'pkgVar' is inaccessible due to 'package' protection level
+// CHECK-CLIENT: error: 'pkgFunc' is inaccessible due to 'package' protection level
+
+// RUN: not %target-swift-frontend -typecheck %t/Lib.swift -package-name myLib -I %t 2> %t/result1.output
+// RUN: %FileCheck %s -input-file %t/result1.output -check-prefix CHECK-1
+// CHECK-1: error: overriding non-open instance method outside of its defining module
+// CHECK-1: error: overriding non-open instance method outside of its defining module
+// CHECK-1: error: cannot inherit from non-open class 'PublicKlass' outside of its defining module
+// CHECK-1: error: cannot inherit from non-open class 'PackageKlass' outside of its defining module
+// CHECK-1: error: cannot assign to property: 'publicGetInternal' setter is inaccessible
+// CHECK-1: error: cannot assign to property: 'pkgVar' setter is inaccessible
+
+// RUN: not %target-swift-frontend -typecheck %t/Lib.swift -package-name "otherLib" -I %t 2> %t/result2.output
+// %FileCheck %s -input-file %t/result2.output -check-prefix CHECK-2
+// CHECK-2: error: cannot find type 'PackageProto' in scope
+// CHECK-2: error: 'pkgFunc' is inaccessible due to 'package' protection level
+// CHECK-2: error: cannot find 'PackageKlass' in scope
 
 
 // BEGIN Utils.swift
 package protocol PackageProto {
-  var pkgVar: String { get set }
+  var pkgVar: Double { get set }
+  func pkgFunc()
 }
 
 package class PackageKlass {
   package init() {}
+  package private(set) var pkgVar: Double = 1.0
   package func pkgFunc() {}
 }
 
+class InternalKlass {}
+
 public class PublicKlass {
   public init() {}
+  public var publicVar: Int = 1
+  public package(set) var publicGetPkg: Int = 2
+  public internal(set) var publicGetInternal: Int = 3
   public func publicFunc() {}
   package func pkgFunc() {}
 }
 
+open class OpenKlass {
+  public init() {}
+  open var openVar: String = ""
+  open func openFunc() {}
+  public func publicFunc() {}
+  package func packageFunc() {}
+}
 
 // BEGIN Lib.swift
 import Utils
 
-public func start() {
+// Test accessing public and package decls
+public func test() {
   let x = PublicKlass()
   x.publicFunc()
-  x.pkgFunc()
+  x.pkgFunc() // Allowed if in same package
+  x.publicGetPkg = 3 // Allowed if in same package
+  x.publicGetInternal = 4 // Not allowed
 
-  let y = PackageKlass()
-  y.pkgFunc()
+  let y = PackageKlass() // Allowed if in same package
+  y.pkgVar = 1.5 // Not allowed
+  y.pkgFunc() // Allowed if in same package
 }
 
-package struct LibStruct : PackageProto {
-  package var pkgVar: String = "lib"
+// Test conformance to a package protocol
+package struct LibStruct : PackageProto { // Allowed if in same package
+  package var pkgVar: Double = 1.0
+  package func pkgFunc() {}
 }
 
+// Test subclassing / overrides
+class SubOpenKlass: OpenKlass {
+  override open func openFunc() {}
+  override public func publicFunc() {}
+  override package func packageFunc() {}
+}
+class SubPublicKlass: PublicKlass {} // Not allowed
+class SubPackageKlass: PackageKlass {} // Not allowed
+
+
+
+// BEGIN LibGood.swift
+import Utils
+
+public func libFunc() {
+  _ = LibStruct()
+}
+
+public struct LibStruct: PackageProto {
+  public init() {}
+  package var pkgVar: Double = 1.0
+  package func pkgFunc() {}
+  public var publicVar: String = ""
+  public func publicFunc() {}
+}
+
+// BEGIN Client.swift
+import LibGood
+
+func clientFunc() {
+  let lib = LibStruct()
+  _ = lib.pkgVar // Not allowed
+  _ = lib.publicVar
+  lib.pkgFunc() // Not allowed
+  lib.publicFunc()
+}

--- a/test/Sema/accessibility_package_inline.swift
+++ b/test/Sema/accessibility_package_inline.swift
@@ -1,0 +1,180 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -module-name UtilsGood %t/UtilsGood.swift -emit-module -emit-module-path %t/UtilsGood.swiftmodule -package-name myLib
+// RUN: test -f %t/UtilsGood.swiftmodule
+
+// RUN: not %target-swift-frontend -typecheck %t/Utils.swift -package-name myLib -I %t 2> %t/resultUtils.output
+// RUN: %FileCheck %s -input-file %t/resultUtils.output -check-prefix CHECK-UTILS
+// CHECK-UTILS: error: class 'PackageKlass' is package and cannot be referenced from an '@inlinable' function
+// CHECK-UTILS:   let a = PackageKlass()
+// CHECK-UTILS:           ^
+// CHECK-UTILS: note: class 'PackageKlass' is not '@usableFromInline' or public
+// CHECK-UTILS: package class PackageKlass {
+// CHECK-UTILS:               ^
+// CHECK-UTILS: error: initializer 'init()' is package and cannot be referenced from an '@inlinable' function
+// CHECK-UTILS:  let a = PackageKlass() // should error
+// CHECK-UTILS:          ^
+// CHECK-UTILS: note: initializer 'init()' is not '@usableFromInline' or public
+// CHECK-UTILS:  package init() {}
+// CHECK-UTILS:          ^
+// CHECK-UTILS: error: class 'InternalKlass' is internal and cannot be referenced from an '@inlinable' function
+// CHECK-UTILS:  let b = InternalKlass() // should error
+// CHECK-UTILS:          ^
+// CHECK-UTILS: note: class 'InternalKlass' is not '@usableFromInline' or public
+// CHECK-UTILS: class InternalKlass {
+// CHECK-UTILS:       ^
+// CHECK-UTILS: error: initializer 'init()' is internal and cannot be referenced from an '@inlinable' function
+// CHECK-UTILS:  let b = InternalKlass() // should error
+// CHECK-UTILS:          ^
+// CHECK-UTILS: note: initializer 'init()' is not '@usableFromInline' or public
+// CHECK-UTILS:  init() {}
+// CHECK-UTILS:  ^
+
+// RUN: not %target-swift-frontend -typecheck %t/Lib.swift -package-name "otherLib" -I %t 2> %t/resultLib.output
+// %FileCheck %s -input-file %t/resultLib.output -check-prefix CHECK-LIB
+// CHECK-LIB: error: cannot find 'packageFunc' in scope
+// CHECK-LIB: packageFunc()
+// CHECK-LIB: ^~~~~~~~~~~
+
+// RUN: %target-swift-frontend -module-name Lib %t/Lib.swift -emit-module -emit-module-path %t/Lib.swiftmodule -package-name myLib -I %t
+// RUN: test -f %t/Lib.swiftmodule
+
+// BEGIN Utils.swift
+package protocol PackageProto {
+  var pkgVar: Double { get set }
+  func pkgFunc()
+}
+
+package class PackageKlass {
+  package init() {}
+  package private(set) var pkgVar: Double = 1.0
+  package func pkgFunc() {}
+}
+
+@usableFromInline
+package class PackageKlassProto: PackageProto {
+  @usableFromInline
+  package init() {}
+  @usableFromInline
+  package var pkgVar = 1.0
+  package func pkgFunc() {}
+}
+
+@usableFromInline
+package class PackageKlassForInline {
+  @usableFromInline
+  package init() {}
+}
+
+protocol InternalProto {
+  var internalVar: Double { get set }
+  func internalFunc()
+}
+class InternalKlass {
+  init() {}
+}
+@usableFromInline
+class InternalKlassProto: InternalProto {
+  @usableFromInline
+  init() {}
+  var internalVar = 1.0
+  func internalFunc() {}
+}
+
+@usableFromInline
+class InternalKlassForInline {
+  @usableFromInline
+  init() {}
+}
+
+@inlinable
+public func publicFunc() {
+  let a = PackageKlass() // should error
+  let b = InternalKlass() // should error
+  let c = PackageKlassProto()
+  let d = InternalKlassProto()
+  let e = PackageKlassForInline()
+  let f = InternalKlassForInline()
+  print(a, b, c, d, e, f)
+}
+
+@inlinable
+func internalFunc() {
+  let a = PackageKlass() // should error
+  let b = InternalKlass() // should error
+  let c = PackageKlassProto()
+  let d = InternalKlassProto()
+  let e = PackageKlassForInline()
+  let f = InternalKlassForInline()
+  print(a, b, c, d, e, f)
+}
+
+@inlinable
+package func packageFunc() {
+  let a = PackageKlass() // should error
+  let b = InternalKlass() // should error
+  let c = PackageKlassProto()
+  let d = InternalKlassProto()
+  let e = PackageKlassForInline()
+  let f = InternalKlassForInline()
+  print(a, b, c, d, e, f)
+}
+
+// BEGIN UtilsGood.swift
+package protocol PackageProto {
+  var pkgVar: Double { get set }
+  func pkgFunc()
+}
+
+package class PackageKlass {
+  package init() {}
+  package private(set) var pkgVar: Double = 1.0
+  package func pkgFunc() {}
+}
+
+@usableFromInline
+package class PackageKlassForInline {
+  @usableFromInline
+  package init() {}
+}
+
+class InternalKlass {
+  init() {}
+}
+
+@usableFromInline
+class InternalKlassForInline {
+  @usableFromInline
+  init() {}
+}
+
+@inlinable
+public func publicFunc() {
+  let x = PackageKlassForInline()
+  let y = InternalKlassForInline()
+  print(x, y)
+}
+
+@inlinable
+func internalFunc() {
+  let x = PackageKlassForInline()
+  let y = InternalKlassForInline()
+  print(x, y)
+}
+
+@inlinable
+package func packageFunc() {
+  let x = PackageKlassForInline()
+  let y = InternalKlassForInline()
+  print(x, y)
+}
+
+// BEGIN Lib.swift
+import UtilsGood
+
+@inlinable
+public func libFunc() {
+  publicFunc()
+  packageFunc() // Allowed if in same package
+}

--- a/test/Sema/accessibility_package_inline_interface.swift
+++ b/test/Sema/accessibility_package_inline_interface.swift
@@ -1,0 +1,145 @@
+// RUN: %empty-directory(%t)
+// RUN: %{python} %utils/split_file.py -o %t %s
+
+// RUN: %target-swift-frontend -module-name Utils1 %t/Utils.swift -emit-module -emit-module-path %t/Utils1.swiftmodule -package-name myLib -swift-version 5
+// RUN: test -f %t/Utils1.swiftmodule
+
+// RUN: %target-swift-frontend -module-name Utils %t/Utils.swift -emit-module -emit-module-interface-path %t/Utils.swiftinterface -package-name myLib -enable-library-evolution -swift-version 5
+// RUN: test -f %t/Utils.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/Utils.swiftinterface) -I%t
+
+// RUN: %FileCheck %s -check-prefix CHECK-UTILS < %t/Utils.swiftinterface
+// CHECK-UTILS: -module-name Utils -enable-library-evolution
+// CHECK-UTILS: swift-module-flags-ignorable: -package-name myLib
+// CHECK-UTILS: @usableFromInline
+// CHECK-UTILS: package class PackageKlassProto {
+// CHECK-UTILS:   @usableFromInline
+// CHECK-UTILS:   package init()
+// CHECK-UTILS:   @usableFromInline
+// CHECK-UTILS:   package var pkgVar: Swift.Double
+// CHECK-UTILS:   @objc @usableFromInline
+// CHECK-UTILS:   deinit
+// CHECK-UTILS: }
+// CHECK-UTILS: @usableFromInline
+// CHECK-UTILS: package class PackageKlassForInline {
+// CHECK-UTILS:   @usableFromInline
+// CHECK-UTILS:   package init()
+// CHECK-UTILS:   @usableFromInline
+// CHECK-UTILS:   package func foo1()
+// CHECK-UTILS:   @objc @usableFromInline
+// CHECK-UTILS:   deinit
+// CHECK-UTILS: }
+// CHECK-UTILS: @usableFromInline
+// CHECK-UTILS: internal class InternalKlassProto {
+// CHECK-UTILS:   @usableFromInline
+// CHECK-UTILS:   internal init()
+// CHECK-UTILS:   @usableFromInline
+// CHECK-UTILS:   internal var internalVar: Swift.Double
+// CHECK-UTILS:   @objc @usableFromInline
+// CHECK-UTILS:   deinit
+// CHECK-UTILS: }
+// CHECK-UTILS: @usableFromInline
+// CHECK-UTILS: internal class InternalKlassForInline {
+// CHECK-UTILS:   @usableFromInline
+// CHECK-UTILS:   internal init()
+// CHECK-UTILS:   @usableFromInline
+// CHECK-UTILS:   internal func bar1()
+// CHECK-UTILS:   @objc @usableFromInline
+// CHECK-UTILS:   deinit
+// CHECK-UTILS: }
+// CHECK-UTILS: @inlinable public func publicFunc() {
+// CHECK-UTILS:   let a = PackageKlassProto().pkgVar
+// CHECK-UTILS:   let b = InternalKlassProto().internalVar
+// CHECK-UTILS:   PackageKlassForInline().foo1()
+// CHECK-UTILS:   InternalKlassForInline().bar1()
+// CHECK-UTILS:   print(a, b)
+// CHECK-UTILS: }
+// CHECK-UTILS: @inlinable internal func internalFunc() {
+// CHECK-UTILS:   let a = PackageKlassProto().pkgVar
+// CHECK-UTILS:   let b = InternalKlassProto().internalVar
+// CHECK-UTILS:   PackageKlassForInline().foo1()
+// CHECK-UTILS:   InternalKlassForInline().bar1()
+// CHECK-UTILS:   print(a, b)
+// CHECK-UTILS: }
+// CHECK-UTILS: @inlinable package func packageFunc() {
+// CHECK-UTILS:   let a = PackageKlassProto().pkgVar
+// CHECK-UTILS:   let b = InternalKlassProto().internalVar
+// CHECK-UTILS:   PackageKlassForInline().foo1()
+// CHECK-UTILS:   InternalKlassForInline().bar1()
+// CHECK-UTILS:   print(a, b)
+// CHECK-UTILS: }
+
+
+// BEGIN Utils.swift
+package protocol PackageProto {
+  var pkgVar: Double { get set }
+  func pkgFunc()
+}
+
+package class PackageKlass {
+  package init() {}
+  package private(set) var pkgVar: Double = 1.0
+  package func pkgFunc() {}
+}
+
+@usableFromInline
+package class PackageKlassProto: PackageProto {
+  @usableFromInline package init() {}
+  @usableFromInline package var pkgVar = 1.0
+  package func pkgFunc() {}
+}
+
+@usableFromInline
+package class PackageKlassForInline {
+  @usableFromInline package init() {}
+  @usableFromInline package func foo1() {}
+  package func foo2() {}
+}
+
+protocol InternalProto {
+  var internalVar: Double { get set }
+  func internalFunc()
+}
+class InternalKlass {
+  init() {}
+}
+@usableFromInline
+class InternalKlassProto: InternalProto {
+  @usableFromInline init() {}
+  @usableFromInline var internalVar = 1.0
+  func internalFunc() {}
+}
+
+@usableFromInline
+class InternalKlassForInline {
+  @usableFromInline init() {}
+  @usableFromInline func bar1() {}
+  func bar2() {}
+}
+
+@inlinable
+public func publicFunc() {
+  let a = PackageKlassProto().pkgVar
+  let b = InternalKlassProto().internalVar
+  PackageKlassForInline().foo1()
+  InternalKlassForInline().bar1()
+  print(a, b)
+}
+
+@inlinable
+func internalFunc() {
+  let a = PackageKlassProto().pkgVar
+  let b = InternalKlassProto().internalVar
+  PackageKlassForInline().foo1()
+  InternalKlassForInline().bar1()
+  print(a, b)
+}
+
+@inlinable
+package func packageFunc() {
+  let a = PackageKlassProto().pkgVar
+  let b = InternalKlassProto().internalVar
+  PackageKlassForInline().foo1()
+  InternalKlassForInline().bar1()
+  print(a, b)
+}

--- a/test/Sema/accessibility_package_inline_interface.swift
+++ b/test/Sema/accessibility_package_inline_interface.swift
@@ -17,7 +17,7 @@
 // CHECK-UTILS:   package init()
 // CHECK-UTILS:   @usableFromInline
 // CHECK-UTILS:   package var pkgVar: Swift.Double
-// CHECK-UTILS:   @objc @usableFromInline
+// CHECK-UTILS:   @usableFromInline
 // CHECK-UTILS:   deinit
 // CHECK-UTILS: }
 // CHECK-UTILS: @usableFromInline
@@ -26,7 +26,7 @@
 // CHECK-UTILS:   package init()
 // CHECK-UTILS:   @usableFromInline
 // CHECK-UTILS:   package func foo1()
-// CHECK-UTILS:   @objc @usableFromInline
+// CHECK-UTILS:   @usableFromInline
 // CHECK-UTILS:   deinit
 // CHECK-UTILS: }
 // CHECK-UTILS: @usableFromInline
@@ -35,7 +35,7 @@
 // CHECK-UTILS:   internal init()
 // CHECK-UTILS:   @usableFromInline
 // CHECK-UTILS:   internal var internalVar: Swift.Double
-// CHECK-UTILS:   @objc @usableFromInline
+// CHECK-UTILS:   @usableFromInline
 // CHECK-UTILS:   deinit
 // CHECK-UTILS: }
 // CHECK-UTILS: @usableFromInline
@@ -44,7 +44,7 @@
 // CHECK-UTILS:   internal init()
 // CHECK-UTILS:   @usableFromInline
 // CHECK-UTILS:   internal func bar1()
-// CHECK-UTILS:   @objc @usableFromInline
+// CHECK-UTILS:   @usableFromInline
 // CHECK-UTILS:   deinit
 // CHECK-UTILS: }
 // CHECK-UTILS: @inlinable public func publicFunc() {

--- a/test/attr/attr_fixed_layout_property_wrapper.swift
+++ b/test/attr/attr_fixed_layout_property_wrapper.swift
@@ -1,8 +1,21 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 5 -package-name myPkg
 
 private class PrivateType {} // expected-note {{class 'PrivateType' is not '@usableFromInline' or public}}
 // expected-note@-1 {{initializer 'init()' is not '@usableFromInline' or public}}
 // expected-note@-2 {{type declared here}}
+
+package class PackageType {
+  // expected-note@-1 {{class 'PackageType' is not '@usableFromInline' or public}}
+  // expected-note@-2 {{type declared here}}
+  package init() {}
+  // expected-note@-1 {{initializer 'init()' is not '@usableFromInline' or public}}
+}
+
+@usableFromInline
+package class PackageTypeForInline {
+  @usableFromInline
+  package init() {}
+}
 
 @propertyWrapper
 public struct Wrapper<T> {
@@ -19,4 +32,15 @@ public struct Wrapper<T> {
   // expected-error@-1 {{class 'PrivateType' is private and cannot be referenced from a property initializer in a '@frozen' type}}
   // expected-error@-2 {{initializer 'init()' is private and cannot be referenced from a property initializer in a '@frozen' type}}
   // expected-error@-3 {{type referenced from a stored property with inferred type 'PrivateType' in a '@frozen' struct must be '@usableFromInline' or public}}
+
+  @Wrapper private var x1: PackageType
+  // expected-error@-1 {{type referenced from a stored property in a '@frozen' struct must be '@usableFromInline' or public}}
+
+  @Wrapper private var x2 = PackageType()
+  // expected-error@-1 {{class 'PackageType' is package and cannot be referenced from a property initializer in a '@frozen' type}}
+  // expected-error@-2 {{initializer 'init()' is package and cannot be referenced from a property initializer in a '@frozen' type}}
+  // expected-error@-3 {{type referenced from a stored property with inferred type 'PackageType' in a '@frozen' struct must be '@usableFromInline' or public}}
+
+  @Wrapper private var z1: PackageTypeForInline
+  @Wrapper private var z2 = PackageTypeForInline()
 }

--- a/test/attr/attr_usableFromInline.swift
+++ b/test/attr/attr_usableFromInline.swift
@@ -1,29 +1,72 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -disable-objc-attr-requires-foundation-module -enable-objc-interop
-// RUN: %target-typecheck-verify-swift -swift-version 5 -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-testing
+// RUN: %target-typecheck-verify-swift -swift-version 5 -disable-objc-attr-requires-foundation-module -enable-objc-interop -package-name myPkg
+// RUN: %target-typecheck-verify-swift -swift-version 5 -disable-objc-attr-requires-foundation-module -enable-objc-interop -enable-testing -package-name myPkg
 
 @usableFromInline private func privateVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'privateVersioned()' is private}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'privateVersioned()' is private}}
 
 @usableFromInline fileprivate func fileprivateVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'fileprivateVersioned()' is fileprivate}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'fileprivateVersioned()' is fileprivate}}
 
 @usableFromInline internal func internalVersioned() {}
+// OK
+
+@usableFromInline package func packageVersioned() {}
 // OK
 
 @usableFromInline func implicitInternalVersioned() {}
 // OK
 
 @usableFromInline public func publicVersioned() {}
-// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'publicVersioned()' is public}}
+// expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'publicVersioned()' is public}}
+
+// expected-note@+1 3{{global function 'internalFunc()' is not '@usableFromInline' or public}}
+internal func internalFunc() {}
+// expected-note@+1 3{{global function 'packageFunc()' is not '@usableFromInline' or public}}
+package func packageFunc() {}
+public func publicFunc() {}
+
+@inlinable
+public func publicInlinableFunc() {
+  internalVersioned() // OK
+  internalFunc() // expected-error {{global function 'internalFunc()' is internal and cannot be referenced from an '@inlinable' function}}
+  packageVersioned() // OK
+  packageFunc() // expected-error {{global function 'packageFunc()' is package and cannot be referenced from an '@inlinable' function}}
+  publicFunc() // OK
+}
+
+@inlinable
+func internalInlinableFunc() {
+  internalVersioned() // OK
+  internalFunc() // expected-error {{global function 'internalFunc()' is internal and cannot be referenced from an '@inlinable' function}}
+  packageVersioned() // OK
+  packageFunc() // expected-error {{global function 'packageFunc()' is package and cannot be referenced from an '@inlinable' function}}
+  publicFunc() // OK
+}
+
+@inlinable
+package func packageInlinableFunc() {
+  internalVersioned() // OK
+  internalFunc() // expected-error {{global function 'internalFunc()' is internal and cannot be referenced from an '@inlinable' function}}
+  packageVersioned() // OK
+  packageFunc() // expected-error {{global function 'packageFunc()' is package and cannot be referenced from an '@inlinable' function}}
+  publicFunc() // OK
+}
+
+package class PackageClass {
+  // expected-note@-1 *{{type declared here}}
+  @usableFromInline public func publicVersioned() {}
+  // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'publicVersioned()' is public}}
+}
 
 internal class InternalClass {
   // expected-note@-1 2{{type declared here}}
   @usableFromInline public func publicVersioned() {}
-  // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal declarations, but 'publicVersioned()' is public}}
+  // expected-error@-1 {{'@usableFromInline' attribute can only be applied to internal or package declarations, but 'publicVersioned()' is public}}
 }
 
 fileprivate class filePrivateClass {
   @usableFromInline internal func internalVersioned() {}
+  @usableFromInline package func packageVersioned() {}
 }
 
 @usableFromInline struct S {
@@ -34,8 +77,31 @@ fileprivate class filePrivateClass {
 @usableFromInline extension S {}
 // expected-error@-1 {{'@usableFromInline' attribute cannot be applied to this declaration}}
 
+@usableFromInline package struct Pkg {
+  var x: Int
+  @usableFromInline var y: Int
+  @usableFromInline package var z: Int
+}
+
+@usableFromInline extension Pkg {}
+// expected-error@-1 {{'@usableFromInline' attribute cannot be applied to this declaration}}
+
 @usableFromInline
 protocol VersionedProtocol {
+  associatedtype T
+
+  func requirement() -> T
+
+  public func publicRequirement() -> T
+  // expected-error@-1 {{'public' modifier cannot be used in protocols}}
+  // expected-note@-2 {{protocol requirements implicitly have the same access as the protocol itself}}
+
+  @usableFromInline func versionedRequirement() -> T
+  // expected-error@-1 {{'@usableFromInline' attribute cannot be used in protocols}}
+}
+
+@usableFromInline
+package protocol PkgVersionedProtocol {
   associatedtype T
 
   func requirement() -> T
@@ -53,9 +119,17 @@ protocol VersionedProtocol {
 internal enum EqEnum {
   case foo
 }
+@usableFromInline
+package enum PkgEqEnum {
+  case foo
+}
 
 @usableFromInline
 internal enum RawEnum : Int {
+  case foo = 0
+}
+@usableFromInline
+package enum PkgRawEnum : Int {
   case foo = 0
 }
 
@@ -66,12 +140,21 @@ public func usesEqEnum() -> Bool {
 
   _ = RawEnum.foo.rawValue
   _ = RawEnum(rawValue: 0)
+
+  _ = (PkgEqEnum.foo == .foo)
+  _ = PkgEqEnum.foo.hashValue
+
+  _ = PkgRawEnum.foo.rawValue
+  _ = PkgRawEnum(rawValue: 0)
 }
 
 public class DynamicMembers {
   @usableFromInline @objc dynamic init() {}
   @usableFromInline @objc dynamic func foo() {}
   @usableFromInline @objc dynamic var bar: Int = 0
+  @usableFromInline @objc dynamic package init(arg: Int) {}
+  @usableFromInline @objc dynamic package func baz() {}
+  @usableFromInline @objc dynamic package var cat: Int = 0
 }
 
 internal struct InternalStruct {}
@@ -85,6 +168,19 @@ internal struct InternalStruct {}
 
 @usableFromInline typealias BadAlias = InternalStruct
 // expected-error@-1 {{type referenced from the underlying type of a '@usableFromInline' type alias must be '@usableFromInline' or public}}
+
+package struct PackageStruct {}
+// expected-note@-1 *{{type declared here}}
+
+@usableFromInline var globalInferredPkg = PackageStruct()
+// expected-error@-1 {{type referenced from a '@usableFromInline' variable with inferred type 'PackageStruct' must be '@usableFromInline' or public}}
+
+@usableFromInline var globalDeclaredPkg: PackageStruct = PackageStruct()
+// expected-error@-1 {{type referenced from a '@usableFromInline' variable must be '@usableFromInline' or public}}
+
+@usableFromInline typealias BadAliasPkg = PackageStruct
+// expected-error@-1 {{type referenced from the underlying type of a '@usableFromInline' type alias must be '@usableFromInline' or public}}
+
 
 protocol InternalProtocol {
   // expected-note@-1 * {{type declared here}}
@@ -125,7 +221,7 @@ where T : InternalProtocol,
 
 @usableFromInline
 protocol BadProtocol : InternalProtocol {
-  // expected-error@-1 {{protocol refined by '@usableFromInline' protocol must be '@usableForInline' or public}}
+  // expected-error@-1 {{protocol refined by '@usableFromInline' protocol must be '@usableFromInline' or public}}
   associatedtype X : InternalProtocol
   // expected-error@-1 {{type referenced from a requirement of an associated type in a '@usableFromInline' protocol must be '@usableFromInline' or public}}
   associatedtype Y = InternalStruct
@@ -134,9 +230,63 @@ protocol BadProtocol : InternalProtocol {
 
 @usableFromInline
 protocol AnotherBadProtocol where Self.T : InternalProtocol {
-  // expected-error@-1 {{protocol used by '@usableFromInline' protocol must be '@usableForInline' or public}}
+  // expected-error@-1 {{protocol used by '@usableFromInline' protocol must be '@usableFromInline' or public}}
   associatedtype T
 }
+
+
+package protocol PackageProtocol {
+  // expected-note@-1 * {{type declared here}}
+  associatedtype T
+}
+
+@usableFromInline
+package struct PkgBadStruct<T, U>
+// expected-error@-1 {{type referenced from a generic requirement of a '@usableFromInline' generic struct must be '@usableFromInline' or public}}
+where T : PackageProtocol,
+      T : Sequence,
+      T.Element == PackageStruct {
+  @usableFromInline init(x: PackageStruct) {}
+  // expected-error@-1 {{the parameter of a '@usableFromInline' initializer must be '@usableFromInline' or public}}
+
+  @usableFromInline func foo(x: PackageStruct) -> PackageClass {}
+  // expected-error@-1 {{the parameter of a '@usableFromInline' method must be '@usableFromInline' or public}}
+  // expected-error@-2 {{the result of a '@usableFromInline' method must be '@usableFromInline' or public}}
+
+  @usableFromInline var propertyInferred = PackageStruct()
+  // expected-error@-1 {{type referenced from a '@usableFromInline' property with inferred type 'PackageStruct' must be '@usableFromInline' or public}}
+
+  @usableFromInline var propertyDeclared: PackageStruct = PackageStruct()
+  // expected-error@-1 {{type referenced from a '@usableFromInline' property must be '@usableFromInline' or public}}
+
+  @usableFromInline subscript(x: PackageStruct) -> Int {
+    // expected-error@-1 {{index type of a '@usableFromInline' subscript must be '@usableFromInline' or public}}
+    get {}
+    set {}
+  }
+
+  @usableFromInline subscript(x: Int) -> PackageStruct {
+    // expected-error@-1 {{element type of a '@usableFromInline' subscript must be '@usableFromInline' or public}}
+    get {}
+    set {}
+  }
+}
+
+@usableFromInline
+package protocol PkgBadProtocol : PackageProtocol {
+  // expected-error@-1 {{protocol refined by '@usableFromInline' protocol must be '@usableFromInline' or public}}
+  associatedtype X : PackageProtocol
+  // expected-error@-1 {{type referenced from a requirement of an associated type in a '@usableFromInline' protocol must be '@usableFromInline' or public}}
+  associatedtype Y = PackageProtocol
+  // expected-error@-1 {{type referenced from a default definition of an associated type in a '@usableFromInline' protocol must be '@usableFromInline' or public}}
+}
+
+@usableFromInline
+package protocol PkgAnotherBadProtocol where Self.T : PackageProtocol {
+  // expected-error@-1 {{protocol used by '@usableFromInline' protocol must be '@usableFromInline' or public}}
+  associatedtype T
+}
+
 
 @usableFromInline
 enum BadEnum {
@@ -145,21 +295,42 @@ enum BadEnum {
 }
 
 @usableFromInline
+package enum PkgBadEnum {
+  case bad(PackageStruct)
+  // expected-error@-1 {{type of enum case in '@usableFromInline' enum must be '@usableFromInline' or public}}
+}
+
+@usableFromInline
 class BadClass : InternalClass {}
+// expected-error@-1 {{type referenced from the superclass of a '@usableFromInline' class must be '@usableFromInline' or public}}
+
+@usableFromInline
+package class PkgBadClass : PackageClass {}
 // expected-error@-1 {{type referenced from the superclass of a '@usableFromInline' class must be '@usableFromInline' or public}}
 
 public struct TestGenericSubscripts {
   @usableFromInline subscript<T: InternalProtocol>(_: T) -> Int { return 0 } // expected-warning {{type referenced from a generic parameter of a '@usableFromInline' subscript should be '@usableFromInline' or public}}
   @usableFromInline subscript<T>(where _: T) -> Int where T: InternalProtocol { return 0 } // expected-warning {{type referenced from a generic requirement of a '@usableFromInline' subscript should be '@usableFromInline' or public}}
+  @usableFromInline package subscript<T: PackageProtocol>(_: T) -> Int { return 0 } // expected-warning {{type referenced from a generic parameter of a '@usableFromInline' subscript should be '@usableFromInline' or public}}
+  @usableFromInline package subscript<T>(where _: T) -> Int where T: PackageProtocol { return 0 } // expected-warning {{type referenced from a generic requirement of a '@usableFromInline' subscript should be '@usableFromInline' or public}}
 }
 
 @usableFromInline typealias TestGenericAlias<T: InternalProtocol> = T // expected-warning {{type referenced from a generic parameter of a '@usableFromInline' type alias should be '@usableFromInline' or public}}
 @usableFromInline typealias TestGenericAliasWhereClause<T> = T where T: InternalProtocol // expected-warning {{type referenced from a generic requirement of a '@usableFromInline' type alias should be '@usableFromInline' or public}}
+
+@usableFromInline typealias PkgTestGenericAlias<T: PackageProtocol> = T // expected-warning {{type referenced from a generic parameter of a '@usableFromInline' type alias should be '@usableFromInline' or public}}
+@usableFromInline typealias PkgTestGenericAliasWhereClause<T> = T where T: PackageProtocol // expected-warning {{type referenced from a generic requirement of a '@usableFromInline' type alias should be '@usableFromInline' or public}}
 
 @usableFromInline struct GenericStruct<T> {
   @usableFromInline struct Nested where T : InternalProtocol {}
   // expected-error@-1 {{type referenced from a generic requirement of a '@usableFromInline' struct must be '@usableFromInline' or public}}
 
   @usableFromInline func nonGenericWhereClause() where T : InternalProtocol {}
+  // expected-error@-1 {{type referenced from a generic requirement of a '@usableFromInline' instance method must be '@usableFromInline' or public}}
+
+  @usableFromInline package struct PkgNested where T : PackageProtocol {}
+  // expected-error@-1 {{type referenced from a generic requirement of a '@usableFromInline' struct must be '@usableFromInline' or public}}
+
+  @usableFromInline package func pkgNonGenericWhereClause() where T : PackageProtocol {}
   // expected-error@-1 {{type referenced from a generic requirement of a '@usableFromInline' instance method must be '@usableFromInline' or public}}
 }

--- a/test/decl/protocol/conforms/access_corner_case.swift
+++ b/test/decl/protocol/conforms/access_corner_case.swift
@@ -1,10 +1,14 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -package-name myPkg
 
 
 // Protocol requirement is witnessed from a member of a
 // less-visible extension
 public protocol P {
   func publicRequirement()
+}
+
+package protocol Pkg: P {
+  func packageRequirement()
 }
 
 protocol Q : P {
@@ -31,9 +35,35 @@ extension S {
   private func privateRequirementCannotWork() {}
 }
 
-
 public struct T : S {}
 // expected-error@-1 {{type 'T' does not conform to protocol 'S'}}
+
+protocol Qpkg : Pkg {
+  func internalRequirement()
+}
+
+fileprivate protocol Rpkg : Qpkg {
+  func fileprivateRequirement()
+}
+private protocol Spkg : Rpkg {
+  func privateRequirement()
+  func privateRequirementCannotWork()
+  // expected-note@-1 {{protocol requires function 'privateRequirementCannotWork()' with type '() -> ()'; do you want to add a stub?}}
+}
+
+extension Spkg {
+  public func publicRequirement() {}
+  package func packageRequirement() {}
+  internal func internalRequirement() {}
+  fileprivate func fileprivateRequirement() {}
+  fileprivate func privateRequirement() {}
+
+  // Cannot witness requirement in another protocol!
+  private func privateRequirementCannotWork() {}
+}
+
+public struct Tpkg : Spkg {}
+// expected-error@-1 {{type 'Tpkg' does not conform to protocol 'Spkg'}}
 
 // This is also OK
 @usableFromInline
@@ -44,6 +74,16 @@ extension U {
 }
 
 public struct SS : U {}
+
+@usableFromInline
+package protocol Upkg : P {}
+
+extension Upkg {
+  public func publicRequirement() {}
+}
+
+public struct SSpkg : Upkg {}
+
 
 // Currently this is banned
 public protocol P2 {
@@ -59,3 +99,13 @@ extension Q2 {
 }
 
 public struct T2 : Q2 {} // expected-error {{method 'publicRequirement()' must be declared public because it matches a requirement in public protocol 'P2'}}
+
+package protocol Q2pkg : P2 {}
+
+extension Q2pkg {
+  // note: not public
+  func publicRequirement() {}
+  // expected-note@-1 {{mark the instance method as 'public' to satisfy the requirement}} {{3-3=public }}
+}
+
+public struct T2pkg : Q2pkg {} // expected-error {{method 'publicRequirement()' must be declared public because it matches a requirement in public protocol 'P2'}}

--- a/test/decl/protocol/special/coding/struct_codable_member_type_lookup.swift
+++ b/test/decl/protocol/special/coding/struct_codable_member_type_lookup.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -package-name myPkg
 
 // A top-level CodingKeys type to fall back to in lookups below.
 public enum CodingKeys : String, CodingKey {
@@ -17,6 +17,7 @@ struct SynthesizedStruct : Codable {
 
   // Qualified type lookup should always be unambiguous.
   public func qualifiedFoo(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared public because its parameter uses a private type}}
+  package func qualifiedPkg(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared package because its parameter uses a private type}}
   internal func qualifiedBar(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared internal because its parameter uses a private type}}
   fileprivate func qualifiedBaz(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared fileprivate because its parameter uses a private type}}
   private func qualifiedQux(_ key: SynthesizedStruct.CodingKeys) {}
@@ -24,6 +25,10 @@ struct SynthesizedStruct : Codable {
   // Unqualified lookups should find the synthesized CodingKeys type instead
   // of the top-level type above.
   public func unqualifiedFoo(_ key: CodingKeys) { // expected-error {{method cannot be declared public because its parameter uses a private type}}
+    print(CodingKeys.value) // Not found on top-level.
+  }
+
+  package func unqualifiedPkg(_ key: CodingKeys) { // expected-error {{method cannot be declared package because its parameter uses a private type}}
     print(CodingKeys.value) // Not found on top-level.
   }
 
@@ -51,6 +56,19 @@ struct SynthesizedStruct : Codable {
     }
 
     foo(CodingKeys.nested)
+  }
+
+  package func nestedUnqualifiedPkg(_ key: CodingKeys) { // expected-error {{method cannot be declared package because its parameter uses a private type}}
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func pkg(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    pkg(CodingKeys.nested)
   }
 
   internal func nestedUnqualifiedBar(_ key: CodingKeys) { // expected-error {{method cannot be declared internal because its parameter uses a private type}}
@@ -96,6 +114,7 @@ struct SynthesizedStruct : Codable {
   struct Nested {
     // Qualified lookup should remain as-is.
     public func qualifiedFoo(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared public because its parameter uses a private type}}
+    package func qualifiedPkg(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared package because its parameter uses a private type}}
     internal func qualifiedBar(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared internal because its parameter uses a private type}}
     fileprivate func qualifiedBaz(_ key: SynthesizedStruct.CodingKeys) {} // expected-error {{method cannot be declared fileprivate because its parameter uses a private type}}
     private func qualifiedQux(_ key: SynthesizedStruct.CodingKeys) {}
@@ -103,6 +122,10 @@ struct SynthesizedStruct : Codable {
     // Unqualified lookups should find the SynthesizedStruct's synthesized
     // CodingKeys type instead of the top-level type above.
     public func unqualifiedFoo(_ key: CodingKeys) { // expected-error {{method cannot be declared public because its parameter uses a private type}}
+      print(CodingKeys.value) // Not found on top-level.
+    }
+
+    package func unqualifiedPkg(_ key: CodingKeys) { // expected-error {{method cannot be declared package because its parameter uses a private type}}
       print(CodingKeys.value) // Not found on top-level.
     }
 
@@ -130,6 +153,19 @@ struct SynthesizedStruct : Codable {
       }
 
       foo(CodingKeys.nested)
+    }
+
+    package func nestedUnqualifiedPkg(_ key: CodingKeys) { // expected-error {{method cannot be declared package because its parameter uses a private type}}
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func pkg(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      pkg(CodingKeys.nested)
     }
 
     internal func nestedUnqualifiedBar(_ key: CodingKeys) { // expected-error {{method cannot be declared internal because its parameter uses a private type}}
@@ -177,7 +213,7 @@ struct SynthesizedStruct : Codable {
 
 // Structs which don't get synthesized Codable implementations should expose the
 // appropriate CodingKeys type.
-struct NonSynthesizedStruct : Codable { // expected-note 4 {{'NonSynthesizedStruct' declared here}}
+struct NonSynthesizedStruct : Codable { // expected-note * {{'NonSynthesizedStruct' declared here}}
   // No synthesized type since we implemented both methods.
   init(from decoder: Decoder) throws {}
   func encode(to encoder: Encoder) throws {}
@@ -185,12 +221,14 @@ struct NonSynthesizedStruct : Codable { // expected-note 4 {{'NonSynthesizedStru
   // Qualified type lookup should clearly fail -- we shouldn't get a synthesized
   // type here.
   public func qualifiedFoo(_ key: NonSynthesizedStruct.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of struct 'struct_codable_member_type_lookup.NonSynthesizedStruct'}}
+  package func qualifiedPkg(_ key: NonSynthesizedStruct.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of struct 'struct_codable_member_type_lookup.NonSynthesizedStruct'}}
   internal func qualifiedBar(_ key: NonSynthesizedStruct.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of struct 'struct_codable_member_type_lookup.NonSynthesizedStruct'}}
   fileprivate func qualifiedBaz(_ key: NonSynthesizedStruct.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of struct 'struct_codable_member_type_lookup.NonSynthesizedStruct'}}
   private func qualifiedQux(_ key: NonSynthesizedStruct.CodingKeys) {} // expected-error {{'CodingKeys' is not a member type of struct 'struct_codable_member_type_lookup.NonSynthesizedStruct'}}
 
   // Unqualified lookups should find the public top-level CodingKeys type.
   public func unqualifiedFoo(_ key: CodingKeys) { print(CodingKeys.topLevel) }
+  package func unqualifiedPkg(_ key: CodingKeys) { print(CodingKeys.topLevel) }
   internal func unqualifiedBar(_ key: CodingKeys) { print(CodingKeys.topLevel) }
   fileprivate func unqualifiedBaz(_ key: CodingKeys) { print(CodingKeys.topLevel) }
   private func unqualifiedQux(_ key: CodingKeys) { print(CodingKeys.topLevel) }
@@ -207,6 +245,19 @@ struct NonSynthesizedStruct : Codable { // expected-note 4 {{'NonSynthesizedStru
     }
 
     foo(CodingKeys.nested)
+  }
+
+  package func nestedUnqualifiedPkg(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func pkg(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    pkg(CodingKeys.nested)
   }
 
   internal func nestedUnqualifiedBar(_ key: CodingKeys) {
@@ -267,6 +318,7 @@ struct ExplicitStruct : Codable {
 
   // Qualified type lookup should always be unambiguous.
   public func qualifiedFoo(_ key: ExplicitStruct.CodingKeys) {}
+  package func qualifiedPkg(_ key: ExplicitStruct.CodingKeys) {}
   internal func qualifiedBar(_ key: ExplicitStruct.CodingKeys) {}
   fileprivate func qualifiedBaz(_ key: ExplicitStruct.CodingKeys) {}
   private func qualifiedQux(_ key: ExplicitStruct.CodingKeys) {}
@@ -274,6 +326,10 @@ struct ExplicitStruct : Codable {
   // Unqualified lookups should find the synthesized CodingKeys type instead
   // of the top-level type above.
   public func unqualifiedFoo(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  package func unqualifiedPkg(_ key: CodingKeys) {
     print(CodingKeys.a) // Not found on top-level.
   }
 
@@ -301,6 +357,19 @@ struct ExplicitStruct : Codable {
     }
 
     foo(CodingKeys.nested)
+  }
+
+  package func nestedUnqualifiedPkg(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func pkg(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    pkg(CodingKeys.nested)
   }
 
   internal func nestedUnqualifiedBar(_ key: CodingKeys) {
@@ -346,6 +415,7 @@ struct ExplicitStruct : Codable {
   struct Nested {
     // Qualified lookup should remain as-is.
     public func qualifiedFoo(_ key: ExplicitStruct.CodingKeys) {}
+    package func qualifiedPkg(_ key: ExplicitStruct.CodingKeys) {}
     internal func qualifiedBar(_ key: ExplicitStruct.CodingKeys) {}
     fileprivate func qualifiedBaz(_ key: ExplicitStruct.CodingKeys) {}
     private func qualifiedQux(_ key: ExplicitStruct.CodingKeys) {}
@@ -353,6 +423,10 @@ struct ExplicitStruct : Codable {
     // Unqualified lookups should find the ExplicitStruct's synthesized
     // CodingKeys type instead of the top-level type above.
     public func unqualifiedFoo(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    package func unqualifiedPkg(_ key: CodingKeys) {
       print(CodingKeys.a) // Not found on top-level.
     }
 
@@ -380,6 +454,19 @@ struct ExplicitStruct : Codable {
       }
 
       foo(CodingKeys.nested)
+    }
+
+    package func nestedUnqualifiedPkg(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func pkg(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      pkg(CodingKeys.nested)
     }
 
     internal func nestedUnqualifiedBar(_ key: CodingKeys) {
@@ -436,6 +523,7 @@ struct ExtendedStruct : Codable {
 
   // Qualified type lookup should always be unambiguous.
   public func qualifiedFoo(_ key: ExtendedStruct.CodingKeys) {}
+  package func qualifiedPkg(_ key: ExplicitStruct.CodingKeys) {}
   internal func qualifiedBar(_ key: ExtendedStruct.CodingKeys) {}
   fileprivate func qualifiedBaz(_ key: ExtendedStruct.CodingKeys) {}
   private func qualifiedQux(_ key: ExtendedStruct.CodingKeys) {}
@@ -443,6 +531,10 @@ struct ExtendedStruct : Codable {
   // Unqualified lookups should find the synthesized CodingKeys type instead
   // of the top-level type above.
   public func unqualifiedFoo(_ key: CodingKeys) {
+    print(CodingKeys.a) // Not found on top-level.
+  }
+
+  package func unqualifiedPkg(_ key: CodingKeys) {
     print(CodingKeys.a) // Not found on top-level.
   }
 
@@ -470,6 +562,19 @@ struct ExtendedStruct : Codable {
     }
 
     foo(CodingKeys.nested)
+  }
+
+  package func nestedUnqualifiedPkg(_ key: CodingKeys) {
+    enum CodingKeys : String, CodingKey {
+      case nested
+    }
+
+    // CodingKeys should refer to the local unqualified enum.
+    func pkg(_ key: CodingKeys) {
+      print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+    }
+
+    pkg(CodingKeys.nested)
   }
 
   internal func nestedUnqualifiedBar(_ key: CodingKeys) {
@@ -515,6 +620,7 @@ struct ExtendedStruct : Codable {
   struct Nested {
     // Qualified lookup should remain as-is.
     public func qualifiedFoo(_ key: ExtendedStruct.CodingKeys) {}
+    package func qualifiedPkg(_ key: ExplicitStruct.CodingKeys) {}
     internal func qualifiedBar(_ key: ExtendedStruct.CodingKeys) {}
     fileprivate func qualifiedBaz(_ key: ExtendedStruct.CodingKeys) {}
     private func qualifiedQux(_ key: ExtendedStruct.CodingKeys) {}
@@ -522,6 +628,10 @@ struct ExtendedStruct : Codable {
     // Unqualified lookups should find the ExtendedStruct's synthesized
     // CodingKeys type instead of the top-level type above.
     public func unqualifiedFoo(_ key: CodingKeys) {
+      print(CodingKeys.a) // Not found on top-level.
+    }
+
+    package func unqualifiedPkg(_ key: CodingKeys) {
       print(CodingKeys.a) // Not found on top-level.
     }
 
@@ -549,6 +659,19 @@ struct ExtendedStruct : Codable {
       }
 
       foo(CodingKeys.nested)
+    }
+
+    package func nestedUnqualifiedPkg(_ key: CodingKeys) {
+      enum CodingKeys : String, CodingKey {
+        case nested
+      }
+
+      // CodingKeys should refer to the local unqualified enum.
+      func pkg(_ key: CodingKeys) {
+        print(CodingKeys.nested) // Not found on synthesized type or top-level type.
+      }
+
+      pkg(CodingKeys.nested)
     }
 
     internal func nestedUnqualifiedBar(_ key: CodingKeys) {

--- a/test/decl/var/property_wrappers.swift
+++ b/test/decl/var/property_wrappers.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 5 -package-name myPkg
 
 // ---------------------------------------------------------------------------
 // Property wrapper type definitions
@@ -617,6 +617,21 @@ public struct HasUsableFromInlineWrapper<T> {
   @InternalWrapper
   @usableFromInline
   var y: [T] = []
+  // expected-error@-1{{property wrapper type referenced from a '@usableFromInline' property must be '@usableFromInline' or public}}
+}
+
+public struct HasUsableFromInlinePackageWrapper<T> {
+  @propertyWrapper
+  package struct PackageWrapper<U> { // expected-note{{type declared here}}
+    package var wrappedValue: U
+    package init(wrappedValue initialValue: U) {
+      self.wrappedValue = initialValue
+    }
+  }
+
+  @PackageWrapper
+  @usableFromInline
+  package var y: [T] = []
   // expected-error@-1{{property wrapper type referenced from a '@usableFromInline' property must be '@usableFromInline' or public}}
 }
 


### PR DESCRIPTION
Allow @usableFromInline and @inlinable to package decls
Add tests 
Resolves rdar://104617133

This PR allows the following (similar to how the attributes works with internal/public decls): 

```
@usableFromInline package func foo() {}
@inlinable package func bar() { 
    foo() 
}
@inlinable public func baz() { 
    foo() 
}
```