### PR TITLE
[CMake] Add lib to swift host libraries link directories

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -692,6 +692,8 @@ function(add_swift_host_library name)
 
   add_library(${name} ${libkind} ${ASHL_SOURCES})
 
+  target_link_directories(${name} PUBLIC ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+
   # Respect LLVM_COMMON_DEPENDS if it is set.
   #
   # LLVM_COMMON_DEPENDS if a global variable set in ./lib that provides targets


### PR DESCRIPTION
Our libraries have a `LC_LINKER_OPTION` for eg. `-lswiftLLVMJSON`. This is resolved (probably just based on the actual libswiftLLVMJSON.a added to the link command) by ld, but not by lld. Add in a link directory so that these libraries can be found.