### PR TITLE
Temporarily disable test stdlib/NSStringAPI.swift

### DIFF
--- a/test/stdlib/NSStringAPI.swift
+++ b/test/stdlib/NSStringAPI.swift
@@ -12,6 +12,9 @@
 // Tests for the NSString APIs as exposed by String
 //
 
+// Temporarily disabled as it is taking too long to execute.
+// REQUIRES: rdar106755810
+
 import StdlibUnittest
 
 


### PR DESCRIPTION
It is taking too long to execute.
___

Cherry pick of #64410.