### PR TITLE
Add missed vjp / jvp functions for floating-point constructors

### DIFF
--- a/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
+++ b/stdlib/public/Differentiation/FloatingPointDifferentiation.swift.gyb
@@ -51,6 +51,26 @@ extension ${Self}: Differentiable {
 // Derivatives
 //===----------------------------------------------------------------------===//
 
+/// Derivatives of constructors.
+${Availability(bits)}
+extension ${Self} {
+  @inlinable
+  @_transparent
+  @derivative(of: init(_:))
+  static func _vjpInit(x: ${Self})
+    -> (value: ${Self}, pullback: (${Self}) -> ${Self}) {
+    return (x, { v in v })
+  }
+
+  @inlinable
+  @_transparent
+  @derivative(of: init(_:))
+  static func _jvpInit(x: ${Self})
+  -> (value: ${Self}, differential: (${Self}) -> ${Self}) {
+    return (x, { dx in dx })
+  }
+}
+
 /// Derivatives of standard unary operators.
 ${Availability(bits)}
 extension ${Self} {

--- a/test/AutoDiff/stdlib/floating_point.swift.gyb
+++ b/test/AutoDiff/stdlib/floating_point.swift.gyb
@@ -34,6 +34,14 @@ func expectEqualWithTolerance<T>(_ expected: TestLiteralType, _ actual: T,
 #if !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
 %end
 
+FloatingPointDerivativeTests.test("${Self}.init") {
+  expectEqual(1, gradient(at: ${Self}(4), of: ${Self}.init(_:)))
+  expectEqual(10, pullback(at: ${Self}(4), of: ${Self}.init(_:))(${Self}(10)))
+
+  expectEqual(1, derivative(at: ${Self}(4), of: ${Self}.init(_:)))
+  expectEqual(10, differential(at: ${Self}(4), of: ${Self}.init(_:))(${Self}(10)))
+}
+
 FloatingPointDerivativeTests.test("${Self}.+") {
   expectEqual((1, 1), gradient(at: ${Self}(4), ${Self}(5), of: +))
   expectEqual((10, 10), pullback(at: ${Self}(4), ${Self}(5), of: +)(${Self}(10)))


### PR DESCRIPTION
Fixes #64406