### PR TITLE
[Diagnostics] Replace the phrase "variadic expansion" with "pack expansion" in error messages.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5307,10 +5307,10 @@ ERROR(vararg_not_allowed,none,
       "variadic parameter cannot appear outside of a function parameter list",
       ())
 ERROR(expansion_not_allowed,none,
-      "variadic expansion %0 cannot appear outside of a function parameter list, "
-      "function result, tuple element or generic argument list", (Type))
+      "pack expansion %0 cannot appear outside of a function parameter list, "
+      "tuple element, or generic argument list", (Type))
 ERROR(expansion_not_variadic,none,
-      "variadic expansion %0 must contain at least one variadic generic parameter", (Type))
+      "pack expansion pattern %0 must contain at least one parameter pack", (Type))
 ERROR(pack_reference_outside_expansion,none,
       "pack reference %0 can only appear in pack expansion or generic requirement",
       (Type))
@@ -5326,7 +5326,7 @@ ERROR(multiple_ellipsis_in_tuple,none,
       "only a single element can be variadic", ())
 
 ERROR(expansion_not_same_shape,none,
-      "variadic expansion %0 requires that %1 and %2 have the same shape",
+      "pack expansion %0 requires that %1 and %2 have the same shape",
       (Type, Type, Type))
 ERROR(expansion_expr_not_same_shape,none,
       "pack expansion requires that %0 and %1 have the same shape",

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4548,9 +4548,11 @@ NeverNullType TypeResolver::resolvePackExpansionType(PackExpansionTypeRepr *repr
     return ErrorType::get(ctx);
   }
 
-  // We might not allow variadic expansions here at all.
+  auto expansion = PackExpansionType::get(patternType, rootParameterPacks[0]);
+
+  // We might not allow pack expansions here at all.
   if (!options.isPackExpansionSupported(getDeclContext())) {
-    diagnose(repr->getLoc(), diag::expansion_not_allowed, patternType);
+    diagnose(repr->getLoc(), diag::expansion_not_allowed, expansion);
     return ErrorType::get(ctx);
   }
 
@@ -4568,7 +4570,7 @@ NeverNullType TypeResolver::resolvePackExpansionType(PackExpansionTypeRepr *repr
     return result;
   }
 
-  return PackExpansionType::get(patternType, rootParameterPacks[0]);
+  return expansion;
 }
 
 NeverNullType TypeResolver::resolvePackElement(PackElementTypeRepr *repr,

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -87,7 +87,7 @@ func sameShapeDiagnostics<each T, each U>(t: repeat each T, u: repeat each U) {
   _ = repeat (Array<each T>(), each u) // expected-error {{pack expansion requires that 'U' and 'T' have the same shape}}
 }
 
-func returnPackExpansionType<each T>(_ t: repeat each T) -> repeat each T { // expected-error {{variadic expansion 'T' cannot appear outside of a function parameter list, function result, tuple element or generic argument list}}
+func returnPackExpansionType<each T>(_ t: repeat each T) -> repeat each T { // expected-error {{pack expansion 'repeat each T' cannot appear outside of a function parameter list, tuple element, or generic argument list}}
   fatalError()
 }
 
@@ -99,13 +99,13 @@ func returnRepeatTuple<each T>(_ t: repeat each T) -> (repeat T) { // expected-e
   fatalError()
 }
 
-func parameterAsPackTypeWithoutExpansion<each T>(_ t: T) -> repeat each T { // expected-error {{variadic expansion 'T' cannot appear outside of a function parameter list, function result, tuple element or generic argument list}}
+func parameterAsPackTypeWithoutExpansion<each T>(_ t: T) -> repeat each T { // expected-error {{pack expansion 'repeat each T' cannot appear outside of a function parameter list, tuple element, or generic argument list}}
   fatalError()
 }
 
 func expansionOfNonPackType<T>(_ t: repeat each T) {}
 // expected-error@-1 {{'each' cannot be applied to non-pack type 'T'}}{{29-29=each }}
-// expected-error@-2 {{variadic expansion 'T' must contain at least one variadic generic parameter}}
+// expected-error@-2 {{pack expansion pattern 'T' must contain at least one parameter pack}}
 
 func tupleExpansion<each T, each U>(
   _ tuple1: (repeat each T),
@@ -143,7 +143,7 @@ func copyIntoTuple<each T>(_ arg: repeat each T) -> (repeat each T) {
 }
 func callCopyAndBind<T>(_ arg: repeat each T) {
   // expected-error@-1 {{'each' cannot be applied to non-pack type 'T'}}
-  // expected-error@-2 {{variadic expansion 'T' must contain at least one variadic generic parameter}}
+  // expected-error@-2 {{pack expansion pattern 'T' must contain at least one parameter pack}}
 
   // Don't propagate errors for invalid declaration reference
   let result = copyIntoTuple(repeat each arg)

--- a/test/Constraints/variadic_generic_functions.swift
+++ b/test/Constraints/variadic_generic_functions.swift
@@ -22,8 +22,8 @@ func min<each T: Comparable>(_ values: repeat each T) -> T? {
 
 func invalidPacks() {
   func monovariadic1() -> (each String) {} // expected-error {{'each' cannot be applied to non-pack type 'String'}}
-  func monovariadic2<T>() -> (repeat T) {} // expected-error {{variadic expansion 'T' must contain at least one variadic generic parameter}}
-  func monovariadic3<T, U>() -> (T, repeat U) {} // expected-error {{variadic expansion 'U' must contain at least one variadic generic parameter}}
+  func monovariadic2<T>() -> (repeat T) {} // expected-error {{pack expansion pattern 'T' must contain at least one parameter pack}}
+  func monovariadic3<T, U>() -> (T, repeat U) {} // expected-error {{pack expansion pattern 'U' must contain at least one parameter pack}}
 }
 
 func call() {

--- a/test/Constraints/variadic_generic_types.swift
+++ b/test/Constraints/variadic_generic_types.swift
@@ -21,6 +21,6 @@ func g<each T>(_: repeat each T) {
   _ = ((Int, repeat Array<each T>) -> ()).self
 
   _ = (repeat each Int).self
-  // expected-error@-1 {{variadic expansion 'Int' must contain at least one variadic generic parameter}}
+  // expected-error@-1 {{pack expansion pattern 'Int' must contain at least one parameter pack}}
   // expected-error@-2 {{'each' cannot be applied to non-pack type 'Int'}}
 }

--- a/test/type/pack_expansion.swift
+++ b/test/type/pack_expansion.swift
@@ -3,7 +3,7 @@
 // REQUIRES: asserts
 
 func f1<each T>() -> repeat each T {}
-// expected-error@-1 {{variadic expansion 'T' cannot appear outside of a function parameter list, function result, tuple element or generic argument list}}
+// expected-error@-1 {{pack expansion 'repeat each T' cannot appear outside of a function parameter list, tuple element, or generic argument list}}
 
 func f2<each T>() -> (repeat each T) {}
 // okay
@@ -19,12 +19,12 @@ protocol P<T> {
 func f4<each T>() -> any P<repeat each T> {}
 
 typealias T1<each T> = repeat each T
-// expected-error@-1 {{variadic expansion 'T' cannot appear outside of a function parameter list, function result, tuple element or generic argument list}}
+// expected-error@-1 {{pack expansion 'repeat each T' cannot appear outside of a function parameter list, tuple element, or generic argument list}}
 
 typealias T2<each T> = (repeat each T)
 
 func f4<each T>() -> repeat () -> each T {}
-// expected-error@-1 {{variadic expansion '() -> T' cannot appear outside of a function parameter list, function result, tuple element or generic argument list}}
+// expected-error@-1 {{pack expansion 'repeat () -> each T' cannot appear outside of a function parameter list, tuple element, or generic argument list}}
 
 func f5<each T>() -> () -> (repeat each T) {}
 
@@ -36,24 +36,24 @@ enum E<each T> {
   case f2(_: G<repeat each T>)
 
   var x: repeat each T { fatalError() }
-  // expected-error@-1 {{variadic expansion 'T' cannot appear outside of a function parameter list, function result, tuple element or generic argument list}}
+  // expected-error@-1 {{pack expansion 'repeat each T' cannot appear outside of a function parameter list, tuple element, or generic argument list}}
 
   var x: (repeat each T) { fatalError() }
 
   subscript(_: repeat each T) -> Int { fatalError() }
 
   subscript() -> repeat each T { fatalError() }
-  // expected-error@-1 {{variadic expansion 'T' cannot appear outside of a function parameter list, function result, tuple element or generic argument list}}
+  // expected-error@-1 {{pack expansion 'repeat each T' cannot appear outside of a function parameter list, tuple element, or generic argument list}}
 
   subscript() -> (repeat each T) { fatalError() }
 }
 
 func withWhereClause<each T>(_ x: repeat each T) where repeat each T: P {}
-// expected-error@-1 {{variadic expansion 'T' cannot appear outside of a function parameter list, function result, tuple element or generic argument list}}
+// expected-error@-1 {{pack expansion 'repeat each T' cannot appear outside of a function parameter list, tuple element, or generic argument list}}
 
 struct Outer<each T> {
   struct Bad<each U> {
-    typealias Value = (repeat (each T, each U)) // expected-error {{variadic expansion 'repeat (each T, each U)' requires that 'T' and 'U' have the same shape}}
+    typealias Value = (repeat (each T, each U)) // expected-error {{pack expansion 'repeat (each T, each U)' requires that 'T' and 'U' have the same shape}}
   }
 
   struct Good<each U> where (repeat (each T, each U)): Any {


### PR DESCRIPTION
We aren't really using the term "variadic" in the parameter packs terminology outside of the general feature family called "variadic generics", and the term "variadic" is easily confusable with old-style variadic parameters.