### PR TITLE
Improve how we work with pack-expansion abstraction patterns in SILGen

### DIFF
--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -294,10 +294,26 @@ public:
 
   /// Map a contextual type containing parameter packs to a contextual
   /// type in the opened element generic context.
+  ///
+  /// This operation only makes sense if the generic environment that the
+  /// pack archetypes are contextual in matches the generic signature
+  /// of this environment.  That will be true for opened element
+  /// environments coming straight out of the type checker, such as
+  /// the one in a PackExpansionExpr, or opened element environments
+  /// created directly from the current environment.  It is not
+  /// reliable for opened element environments in arbitrary SIL functions.
   Type mapContextualPackTypeIntoElementContext(Type type) const;
 
   /// Map a contextual type containing parameter packs to a contextual
   /// type in the opened element generic context.
+  ///
+  /// This operation only makes sense if the generic environment that the
+  /// pack archetypes are contextual in matches the generic signature
+  /// of this environment.  That will be true for opened element
+  /// environments coming straight out of the type checker, such as
+  /// the one in a PackExpansionExpr, or opened element environments
+  /// created directly from the current environment.  It is not
+  /// reliable for opened element environments in arbitrary SIL functions.
   CanType mapContextualPackTypeIntoElementContext(CanType type) const;
 
   /// Map a type containing pack element type parameters to a contextual

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -129,6 +129,12 @@ private:
   /// generic signature.
   ArrayRef<Type> getContextTypes() const;
 
+  /// Retrieve the array of opened pack parameters for this opened-element
+  /// environment.  This is parallel to the array of element parameters,
+  /// i.e. the innermost generic context.
+  MutableArrayRef<Type> getOpenedPackParams();
+  ArrayRef<Type> getOpenedPackParams() const;
+
   /// Get the nested type storage, allocating it if required.
   NestedTypeStorage &getOrCreateNestedTypeStorage();
 
@@ -200,6 +206,9 @@ public:
 
   /// Retrieve the UUID for an opened element environment.
   UUID getOpenedElementUUID() const;
+
+  /// Return the number of opened pack parameters.
+  unsigned getNumOpenedPackParams() const;
 
   void forEachPackElementArchetype(
           llvm::function_ref<void(ElementArchetypeType*)> function) const;

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1488,6 +1488,30 @@ public:
   /// parameters in the pattern.
   unsigned getNumFunctionParams() const;
 
+  /// Perform a parallel visitation of the parameters of a function.
+  ///
+  /// If this is a function pattern, calls handleScalar or
+  /// handleExpansion as appropriate for each parameter of the
+  /// original function, in order.
+  ///
+  /// If this is not a function pattern, calls handleScalar for each
+  /// parameter of the substituted function type.  Functions with
+  /// pack expansions cannot be abstracted legally this way.
+  void forEachFunctionParam(AnyFunctionType::CanParamArrayRef substParams,
+                            bool ignoreFinalParam,
+           llvm::function_ref<void(unsigned origParamIndex,
+                                   unsigned substParamIndex,
+                                   ParameterTypeFlags origFlags,
+                                   AbstractionPattern origParamType,
+                                   AnyFunctionType::CanParam substParam)>
+               handleScalar,
+           llvm::function_ref<void(unsigned origParamIndex,
+                                   unsigned substParamIndex,
+                                   ParameterTypeFlags origFlags,
+                                   AbstractionPattern origExpansionType,
+                          AnyFunctionType::CanParamArrayRef substParams)>
+               handleExpansion) const;
+
   /// Given that the value being abstracted is optional, return the
   /// abstraction pattern for its object type.
   AbstractionPattern getOptionalObjectType() const;

--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -1543,18 +1543,14 @@ public:
   AbstractionPattern getObjCMethodAsyncCompletionHandlerType(
                                      CanType swiftCompletionHandlerType) const;
 
-  /// Given that this is a pack expansion, invoke the given callback for
-  /// each component of the substituted expansion of this pattern.  The
-  /// pattern will be for a pack expansion type over a contextual type if
-  /// the substituted component is still a pack expansion.  If there aren't
-  /// substitutions available, this will just invoke the callback with the
-  /// component.
-  void forEachPackExpandedComponent(
-      llvm::function_ref<void(AbstractionPattern pattern)> fn) const;
-
+  /// Given that this is a pack expansion, return the number of components
+  /// that it should expand to.  This, and the general correctness of
+  /// traversing variadically generic tuple and function types under
+  /// substitution, relies on substitutions having been  set properly
+  /// on the abstraction pattern; without that, AbstractionPattern assumes
+  /// that every component expands to a single pack expansion component,
+  /// which will generally only work in specific situations.
   size_t getNumPackExpandedComponents() const;
-
-  SmallVector<AbstractionPattern, 4> getPackExpandedComponents() const;
 
   /// If this pattern refers to a foreign ObjC method that was imported as 
   /// async, return the bridged-back-to-ObjC completion handler type.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -5164,10 +5164,12 @@ GenericEnvironment::forOpenedElement(GenericSignature signature,
 
   // Allocate and construct the new environment.
   unsigned numGenericParams = signature.getGenericParams().size();
+  unsigned numOpenedParams = signature.getInnermostGenericParams().size();
   size_t bytes = totalSizeToAlloc<OpaqueEnvironmentData,
                                   OpenedExistentialEnvironmentData,
-                                  OpenedElementEnvironmentData, Type>(
-      0, 0, 1, numGenericParams);
+                                  OpenedElementEnvironmentData,
+                                  Type>(
+      0, 0, 1, numGenericParams + numOpenedParams);
   void *mem = ctx.Allocate(bytes, alignof(GenericEnvironment));
   auto *genericEnv = new (mem) GenericEnvironment(signature,
                                                   uuid, shapeClass,

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -282,7 +282,7 @@ LayoutConstraint AbstractionPattern::getLayoutConstraint() const {
   }
 }
 
-bool AbstractionPattern::matchesTuple(CanTupleType substType) {
+bool AbstractionPattern::matchesTuple(CanTupleType substType) const {
   switch (getKind()) {
   case Kind::Invalid:
     llvm_unreachable("querying invalid abstraction pattern!");
@@ -311,26 +311,25 @@ bool AbstractionPattern::matchesTuple(CanTupleType substType) {
     LLVM_FALLTHROUGH;
   case Kind::Tuple: {
     size_t nextSubstIndex = 0;
-    auto nextComponentIsAcceptable =
-        [&](AbstractionPattern origComponentType) -> bool {
+    auto nextComponentIsAcceptable = [&](bool isPackExpansion) -> bool {
       if (nextSubstIndex == substType->getNumElements())
         return false;
       auto substComponentType = substType.getElementType(nextSubstIndex++);
-      return (origComponentType.isPackExpansion() ==
-              isa<PackExpansionType>(substComponentType));
+      return (isPackExpansion == isa<PackExpansionType>(substComponentType));
     };
-    for (size_t i = 0, n = getNumTupleElements(); i != n; ++i) {
-      auto elt = getTupleElementType(i);
-      if (elt.isPackExpansion()) {
-        bool fail = false;
-        elt.forEachPackExpandedComponent([&](AbstractionPattern component) {
-          if (!nextComponentIsAcceptable(component))
-            fail = true;
-        });
-        if (fail) return false;
-      } else {
-        if (!nextComponentIsAcceptable(elt))
-          return false;
+    for (auto elt : getTupleElementTypes()) {
+      bool isPackExpansion = elt.isPackExpansion();
+      if (isPackExpansion && elt.GenericSubs) {
+        auto origExpansion = cast<PackExpansionType>(elt.getType());
+        auto substShape = cast<PackType>(
+          origExpansion.getCountType().subst(elt.GenericSubs)
+            ->getCanonicalType());
+        for (auto shapeElt : substShape.getElementTypes()) {
+          if (!nextComponentIsAcceptable(isa<PackExpansionType>(shapeElt)))
+            return false;
+        }
+      } else if (!nextComponentIsAcceptable(isPackExpansion)) {
+        return false;
       }
     }
     return nextSubstIndex == substType->getNumElements();
@@ -469,6 +468,87 @@ bool AbstractionPattern::doesTupleContainPackExpansionType() const {
   llvm_unreachable("bad kind");
 }
 
+void AbstractionPattern::forEachTupleElement(CanTupleType substType,
+                      llvm::function_ref<void(unsigned origEltIndex,
+                                              unsigned substEltIndex,
+                                              AbstractionPattern origEltType,
+                                              CanType substEltType)>
+                        handleScalar,
+                      llvm::function_ref<void(unsigned origEltIndex,
+                                              unsigned substEltIndex,
+                                              AbstractionPattern origExpansionType,
+                                              CanTupleEltTypeArrayRef substEltTypes)>
+                        handleExpansion) const {
+  assert(isTuple() && "can only call on a tuple expansion");
+  assert(matchesTuple(substType));
+
+  size_t substEltIndex = 0;
+  auto substEltTypes = substType.getElementTypes();
+  for (size_t origEltIndex : range(getNumTupleElements())) {
+    auto origEltType = getTupleElementType(origEltIndex);
+    if (!origEltType.isPackExpansion()) {
+      handleScalar(origEltIndex, substEltIndex,
+                   origEltType, substEltTypes[substEltIndex]);
+      substEltIndex++;
+    } else {
+      auto numComponents = origEltType.getNumPackExpandedComponents();
+      handleExpansion(origEltIndex, substEltIndex, origEltType,
+                      substEltTypes.slice(substEltIndex, numComponents));
+      substEltIndex += numComponents;
+    }
+  }
+  assert(substEltIndex == substEltTypes.size());
+}
+
+void AbstractionPattern::forEachExpandedTupleElement(CanTupleType substType,
+                      llvm::function_ref<void(AbstractionPattern origEltType,
+                                              CanType substEltType,
+                                              const TupleTypeElt &elt)>
+                        handleElement) const {
+  assert(matchesTuple(substType));
+
+  auto substEltTypes = substType.getElementTypes();
+
+  // Handle opaque patterns by just iterating the substituted components.
+  if (!isTuple()) {
+    for (auto i : indices(substEltTypes)) {
+      handleElement(getTupleElementType(i), substEltTypes[i],
+                    substType->getElement(i));
+    }
+    return;
+  }
+
+  // For non-opaque patterns, we have to iterate the original components
+  // in order to match things up properly, but we'll still end up calling
+  // once per substituted element.
+  size_t substEltIndex = 0;
+  for (size_t origEltIndex : range(getNumTupleElements())) {
+    auto origEltType = getTupleElementType(origEltIndex);
+    if (!origEltType.isPackExpansion()) {
+      handleElement(origEltType, substEltTypes[substEltIndex],
+                    substType->getElement(substEltIndex));
+      substEltIndex++;
+    } else {
+      auto origPatternType = origEltType.getPackExpansionPatternType();
+      for (auto i : range(origEltType.getNumPackExpandedComponents())) {
+        (void) i;
+        auto substEltType = substEltTypes[substEltIndex];
+        // When the substituted type is a pack expansion, pass down
+        // the original element type so that it's *also* a pack expansion.
+        // Clients expect to look through this structure in parallel on
+        // both types.  The count is misleading, but normal usage won't
+        // access it, and there's nothing we could provide that *wouldn't*
+        // be misleading in one way or another.
+        handleElement(isa<PackExpansionType>(substEltType)
+                        ? origEltType : origPatternType,
+                      substEltType, substType->getElement(substEltIndex));
+        substEltIndex++;
+      }
+    }
+  }
+  assert(substEltIndex == substEltTypes.size());
+}
+
 static CanType getCanPackElementType(CanType type, unsigned index) {
   return cast<PackType>(type).getElementType(index);
 }
@@ -541,6 +621,17 @@ bool AbstractionPattern::matchesPack(CanPackType substType) {
   llvm_unreachable("bad kind");
 }
 
+AbstractionPattern
+AbstractionPattern::getPackExpansionComponentType(CanType substType) const {
+  return getPackExpansionComponentType(isa<PackExpansionType>(substType));
+}
+
+AbstractionPattern
+AbstractionPattern::getPackExpansionComponentType(bool isExpansion) const {
+  assert(isPackExpansion());
+  return isExpansion ? *this : getPackExpansionPatternType();
+}
+
 static CanType getPackExpansionPatternType(CanType type) {
   return cast<PackExpansionType>(type).getPatternType();
 }
@@ -584,49 +675,6 @@ AbstractionPattern AbstractionPattern::getPackExpansionPatternType() const {
   llvm_unreachable("bad kind");
 }
 
-static CanType getPackExpansionCountType(CanType type) {
-  return cast<PackExpansionType>(type).getCountType();
-}
-
-AbstractionPattern AbstractionPattern::getPackExpansionCountType() const {
-  switch (getKind()) {
-  case Kind::Invalid:
-    llvm_unreachable("querying invalid abstraction pattern!");
-  case Kind::ObjCMethodType:
-  case Kind::CurriedObjCMethodType:
-  case Kind::PartialCurriedObjCMethodType:
-  case Kind::CFunctionAsMethodType:
-  case Kind::CurriedCFunctionAsMethodType:
-  case Kind::PartialCurriedCFunctionAsMethodType:
-  case Kind::CXXMethodType:
-  case Kind::CurriedCXXMethodType:
-  case Kind::PartialCurriedCXXMethodType:
-  case Kind::Tuple:
-  case Kind::OpaqueFunction:
-  case Kind::OpaqueDerivativeFunction:
-  case Kind::ObjCCompletionHandlerArgumentsType:
-  case Kind::ClangType:
-    llvm_unreachable("pattern for function or tuple cannot be for "
-                     "pack expansion type");
-
-  case Kind::Opaque:
-    return *this;
-
-  case Kind::Type:
-    if (isTypeParameterOrOpaqueArchetype())
-      return AbstractionPattern::getOpaque();
-    return AbstractionPattern(getGenericSubstitutions(),
-                              getGenericSignature(),
-                              ::getPackExpansionCountType(getType()));
-
-  case Kind::Discard:
-    return AbstractionPattern::getDiscard(
-        getGenericSubstitutions(), getGenericSignature(),
-        ::getPackExpansionCountType(getType()));
-  }
-  llvm_unreachable("bad kind");
-}
-
 SmallVector<AbstractionPattern, 4>
 AbstractionPattern::getPackExpandedComponents() const {
   SmallVector<AbstractionPattern, 4> result;
@@ -634,6 +682,21 @@ AbstractionPattern::getPackExpandedComponents() const {
     result.push_back(pattern);
   });
   return result;
+}
+
+size_t AbstractionPattern::getNumPackExpandedComponents() const {
+  assert(isPackExpansion());
+  assert(getKind() == Kind::Type || getKind() == Kind::Discard);
+
+  // If we don't have substitutions, we should be walking parallel
+  // structure; take a single element.
+  if (!GenericSubs) return 1;
+
+  // Otherwise, substitute the expansion shape.
+  auto origExpansion = cast<PackExpansionType>(getType());
+  auto substShape = cast<PackType>(
+    origExpansion.getCountType().subst(GenericSubs)->getCanonicalType());
+  return substShape->getNumElements();
 }
 
 void AbstractionPattern::forEachPackExpandedComponent(
@@ -665,7 +728,7 @@ void AbstractionPattern::forEachPackExpandedComponent(
   }
 
   default:
-    return fn(*this);
+    llvm_unreachable("not a pack expansion");
   }
   llvm_unreachable("bad kind");
 }
@@ -692,8 +755,9 @@ AbstractionPattern AbstractionPattern::removingMoveOnlyWrapper() const {
     llvm_unreachable("not handled yet");
   case Kind::Discard:
     llvm_unreachable("operation not needed on discarded abstractions yet");
-  case Kind::Opaque:
   case Kind::Tuple:
+    llvm_unreachable("cannot apply move-only wrappers to open-coded patterns");
+  case Kind::Opaque:
   case Kind::Type:
     if (auto mvi = dyn_cast<SILMoveOnlyWrappedType>(getType())) {
       return AbstractionPattern(getGenericSubstitutions(),
@@ -727,8 +791,9 @@ AbstractionPattern AbstractionPattern::addingMoveOnlyWrapper() const {
     llvm_unreachable("not handled yet");
   case Kind::Discard:
     llvm_unreachable("operation not needed on discarded abstractions yet");
-  case Kind::Opaque:
   case Kind::Tuple:
+    llvm_unreachable("cannot add move only wrapper to open-coded pattern");
+  case Kind::Opaque:
   case Kind::Type:
     if (isa<SILMoveOnlyWrappedType>(getType()))
       return *this;
@@ -1686,7 +1751,7 @@ AbstractionPattern::operator==(const AbstractionPattern &other) const {
       }
     }
     return true;
-  
+
   case Kind::Type:
   case Kind::Discard:
     return OrigType == other.OrigType
@@ -1996,7 +2061,7 @@ public:
     auto substPatternType = visit(pack->getPatternType(),
                                   pattern.getPackExpansionPatternType());
     auto substCountType = visit(pack->getCountType(),
-                                pattern.getPackExpansionCountType());
+                                AbstractionPattern::getOpaque());
 
     SmallVector<Type> rootParameterPacks;
     substPatternType->getTypeParameterPacks(rootParameterPacks);

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1525,12 +1525,18 @@ private:
       origType.isTypeParameter()
         ? params.size()
         : origType.getNumFunctionParams();
-    unsigned nextParamIndex = 0;
 
+    // If we're importing a freestanding foreign function as a member
+    // function, the formal types (subst and orig) will conspire to
+    // pretend that there is a self parameter in the position Swift
+    // expects it: the end of the parameter lists.  In the lowered type,
+    // we need to put this in its proper place, which for static methods
+    // generally means dropping it entirely.
+    bool hasForeignSelf = Foreign.self.isImportAsMember();
+
+    // Is there a self parameter in the formal parameter lists?
     bool hasSelf =
-      (extInfoBuilder.hasSelfParam() || Foreign.self.isImportAsMember());
-    unsigned numOrigNonSelfParams =
-      (hasSelf ? numOrigParams - 1 : numOrigParams);
+      (extInfoBuilder.hasSelfParam() || hasForeignSelf);
 
     TopLevelOrigType = origType;
     // If we have a foreign self parameter, set up the ForeignSelfInfo
@@ -1538,7 +1544,7 @@ private:
     if (Foreign.self.isInstance()) {
       assert(hasSelf && numOrigParams > 0);
       ForeignSelf = ForeignSelfInfo{
-        origType.getFunctionParamType(numOrigNonSelfParams),
+        origType.getFunctionParamType(numOrigParams - 1),
         params.back()
       };
     }
@@ -1549,54 +1555,46 @@ private:
     maybeAddForeignParameters();
 
     // Process all the non-self parameters.
-    for (unsigned i = 0; i != numOrigNonSelfParams; ++i) {
-      auto origParamType = origType.getFunctionParamType(i);
-
+    origType.forEachFunctionParam(params, hasSelf,
+        [&](unsigned origParamIndex, unsigned substParamIndex,
+            ParameterTypeFlags origFlags,
+            AbstractionPattern origParamType,
+            AnyFunctionType::CanParam substParam) {
       // If the parameter is not a pack expansion, just pull off the
       // next parameter and destructure it in parallel with the abstraction
       // pattern for the type.
-      if (!origParamType.isPackExpansion()) {
-        visit(origParamType, params[nextParamIndex++], /*forSelf*/false);
-        continue;
+      visit(origParamType, substParam, /*forSelf*/false);
+    },  [&](unsigned origParamIndex, unsigned substParamIndex,
+            ParameterTypeFlags origFlags,
+            AbstractionPattern origExpansionType,
+            AnyFunctionType::CanParamArrayRef substParams) {
+      // Otherwise, collect the substituted components into a pack.
+      SmallVector<CanType, 8> packElts;
+      for (auto substParam : substParams) {
+        auto substParamType = substParam.getParameterType();
+        auto origParamType =
+          origExpansionType.getPackExpansionComponentType(substParamType);
+        auto loweredParamTy = TC.getLoweredRValueType(expansion,
+                                              origParamType, substParamType);
+        packElts.push_back(loweredParamTy);
       }
 
-      // Otherwise, collect the substituted components into a pack.
-
-      // If the parameter *is* a pack expansion, it must not be an
-      // opaque pattern, so we can safely call this.
-      auto origFlags = origType.getFunctionParamFlags(i);
-
-      SmallVector<CanType, 8> packElts;
-      origParamType.forEachPackExpandedComponent(
-          [&](AbstractionPattern origParamComponent) {
-        auto substParam = params[nextParamIndex++];
-        auto substParamType = substParam.getParameterType();
-
-        auto substTy = TC.getLoweredType(origParamType, substParamType,
-                                         expansion);
-        packElts.push_back(substTy.getASTType());
-      });
-
-      bool indirect = origParamType.arePackElementsPassedIndirectly(TC);
+      bool indirect = origExpansionType.arePackElementsPassedIndirectly(TC);
       SILPackType::ExtInfo extInfo(/*address*/ indirect);
       auto packTy = SILPackType::get(TC.Context, extInfo, packElts);
 
       addPackParameter(packTy, origFlags.getValueOwnership(),
                        origFlags.isNoDerivative());
-    }
+    });
 
-    // Process the self parameter.
-    if (hasSelf && Foreign.self.isImportAsMember()) {
-      // Drop the formal foreign self parameter at this point if we
-      // set it up earlier.
-      nextParamIndex++;
-    } else if (hasSelf) {
-      auto origParamType = origType.getFunctionParamType(numOrigNonSelfParams);
-      auto substParam = params[nextParamIndex++];
+    // Process the self parameter.  But if we have a formal foreign self
+    // parameter, we should have processed it earlier in a call to
+    // maybeAddForeignParameters().
+    if (hasSelf && !hasForeignSelf) {
+      auto origParamType = origType.getFunctionParamType(numOrigParams - 1);
+      auto substParam = params.back();
       visit(origParamType, substParam, /*forSelf*/true);
     }
-
-    assert(nextParamIndex == params.size());
 
     TopLevelOrigType = AbstractionPattern::getInvalid();
     ForeignSelf = None;

--- a/lib/SILGen/ResultPlan.h
+++ b/lib/SILGen/ResultPlan.h
@@ -93,7 +93,7 @@ struct ResultPlanBuilder {
                               AbstractionPattern origType,
                               CanTupleType substType);
   ResultPlanPtr buildForPackExpansion(MutableArrayRef<InitializationPtr> inits,
-                                      ArrayRef<AbstractionPattern> origTypes,
+                                      AbstractionPattern origPatternType,
                                       CanTupleEltTypeArrayRef substTypes);
   ResultPlanPtr buildPackExpansionIntoPack(SILValue packAddr,
                                            CanPackType formalPackType,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -2203,10 +2203,20 @@ static unsigned getFlattenedValueCount(AbstractionPattern origType,
 
   // Otherwise, add up the elements.
   unsigned count = 0;
-  for (auto i : indices(substTuple.getElementTypes())) {
-    count += getFlattenedValueCount(origType.getTupleElementType(i),
-                                    substTuple.getElementType(i));
-  }
+  origType.forEachTupleElement(substTuple,
+                              [&](unsigned origEltIndex,
+                                   unsigned substEltIndex,
+                                   AbstractionPattern origEltType,
+                                   CanType substEltType) {
+    // Recursively expand scalar components.
+    count += getFlattenedValueCount(origEltType, substEltType);
+  },                           [&](unsigned origEltIndex,
+                                   unsigned substEltIndex,
+                                   AbstractionPattern origExpansionType,
+                                   CanTupleEltTypeArrayRef substEltTypes) {
+    // Expansion components turn into a single parameter.
+    count++;
+  });
   return count;
 }
 


### PR DESCRIPTION
Before I get too much deeper into variadic reabstraction, I wanted to take the opportunity to rework the APIs I've been using for doing these walks over abstraction patterns with expansions, because I'm about to use them a lot more.  This centralizes the basic logic for doing parallel walking over expanded tuples and function parameter lists and makes the resulting code in different subsystems at least a little bit clearer.  It's definitely more successful at improving the tuple code than it is for calls, though: `self` really makes things complicated, and the argument code tends to gather argument types from a lot of disparate places rather than passing in substituted types.

This also includes fixes to `mapPackTypeIntoElementContext` and `mapContextualPackTypeIntoElementContext`.