### PR TITLE
Use XCTEST_ROOT with sdk.wixproj in the Windows build

### DIFF
--- a/utils/build-windows-toolchain.bat
+++ b/utils/build-windows-toolchain.bat
@@ -940,7 +940,8 @@ msbuild %SourceRoot%\swift-installer-scripts\platforms\Windows\sdk.wixproj ^
   -p:OutputPath=%PackageRoot%\sdk\ ^
   -p:IntermediateOutputPath=%PackageRoot%\sdk\ ^
   -p:PLATFORM_ROOT=%PlatformRoot%\ ^
-  -p:SDK_ROOT=%SDKInstallRoot%\
+  -p:SDK_ROOT=%SDKInstallRoot%\ ^
+  -p:XCTEST_ROOT=%PlatformRoot%\Developer\Library\XCTest-development\
 :: TODO(compnerd) actually perform the code-signing
 :: signtool sign /f Apple_CodeSign.pfx /p Apple_CodeSign_Password /tr http://timestamp.digicert.com /fd sha256 %PackageRoot%\sdk\sdk.msi
 


### PR DESCRIPTION
Updates the Windows build script to account for https://github.com/apple/swift-installer-scripts/pull/180 , which enables us to override the location of the XCTest files to be packaged in the installer and helps with supporting multi-architecture builds.

Depends on https://github.com/apple/swift-installer-scripts/pull/180