### PR TITLE
[Backtracing] Disable the warning about not finding swift-backtrace.

### DIFF
--- a/stdlib/public/runtime/Backtrace.cpp
+++ b/stdlib/public/runtime/Backtrace.cpp
@@ -317,9 +317,10 @@ BacktraceInitializer::BacktraceInitializer() {
       = swift_copyAuxiliaryExecutablePath("swift-backtrace");
 
     if (!_swift_backtraceSettings.swiftBacktracePath) {
-      swift::warning(0,
+      // Disabled warning for now - rdar://106813646
+      /* swift::warning(0,
                      "swift runtime: unable to locate swift-backtrace; "
-                     "disabling backtracing.\n");
+                     "disabling backtracing.\n"); */
       _swift_backtraceSettings.enabled = OnOffTty::Off;
     }
   }


### PR DESCRIPTION
This needs to be disabled for now.  We'll re-enable it later.

rdar://106813646
