### PR TITLE
build-script: Don't build LLVM testing tools when generating Xcode projects

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/llvm.py
+++ b/utils/swift_build_support/swift_build_support/products/llvm.py
@@ -230,9 +230,18 @@ class LLVM(cmake_product.CMakeProduct):
             build_targets = ['clean']
 
         if self.args.skip_build or not self.args.build_llvm:
+            # We can't skip the build completely because the standalone
+            # build of Swift depends on these.
             build_targets = ['llvm-tblgen', 'clang-resource-headers',
                              'intrinsics_gen', 'clang-tablegen-targets']
-            if not self.args.build_toolchain_only:
+
+            # If we are not performing a toolchain-only build or generating
+            # Xcode projects, then we also want to include the following
+            # targets for testing purposes.
+            if (
+                not self.args.build_toolchain_only
+                and self.args.cmake_generator != 'Xcode'
+            ):
                 build_targets.extend([
                     'FileCheck',
                     'not',

--- a/validation-test/BuildSystem/skip_build_xcode.test
+++ b/validation-test/BuildSystem/skip_build_xcode.test
@@ -11,4 +11,4 @@
 #
 # CHECK: --- Building llvm ---
 # CHECK: env {{.+}}/cmake --build {{.+}}/Xcode-ReleaseAssert/llvm-macosx-{{.+}} --config Release --target ZERO_CHECK{{$}}
-# CHECK-NEXT: env {{.+}}/cmake --build {{.+}}/Xcode-ReleaseAssert/llvm-macosx-{{.+}} --config Release --target ZERO_CHECK -- {{.*}}-target llvm-tblgen -target clang-resource-headers -target intrinsics_gen -target clang-tablegen-targets -target FileCheck -target not -target llvm-nm -target llvm-size{{$}}
+# CHECK-NEXT: env {{.+}}/cmake --build {{.+}}/Xcode-ReleaseAssert/llvm-macosx-{{.+}} --config Release --target ZERO_CHECK -- {{.*}}-target llvm-tblgen -target clang-resource-headers -target intrinsics_gen -target clang-tablegen-targets{{$}}


### PR DESCRIPTION
These tools are not used in the recommended workflow. (Tests are supposed to be run using a Ninja build)
