### PR TITLE
Disable `distributed_actor_assume_executor.swift`

### DIFF
--- a/test/Distributed/Runtime/distributed_actor_assume_executor.swift
+++ b/test/Distributed/Runtime/distributed_actor_assume_executor.swift
@@ -14,6 +14,9 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: freestanding
 
+// rdar://106822386
+// REQUIRES: rdar106822386
+
 import StdlibUnittest
 import Distributed
 import FakeDistributedActorSystems


### PR DESCRIPTION
It is failing due to a compiler assertion in IRGen on Windows:
```
0.	Program arguments: t:\\swift\\bin\\swiftc.exe -frontend -c -primary-file C:\\Users\\swift-ci\\jenkins\\workspace\\swift-PR-windows\\swift\\test\\Distributed\\Runtime\\distributed_actor_assume_executor.swift C:\\Users\\swift-ci\\jenkins\\workspace\\swift-PR-windows\\swift\\test\\Distributed\\Runtime/../Inputs/FakeDistributedActorSystems.swift -target x86_64-unknown-windows-msvc -disable-objc-interop -I T:\\swift\\test-windows-x86_64\\Distributed\\Runtime\\Output\\distributed_actor_assume_executor.swift.tmp -vfsoverlay T:/swift\\stdlib\\windows-vfs-overlay.yaml -swift-version 4 -define-availability "SwiftStdlib 9999:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999" -define-availability "SwiftStdlib 5.0:macOS 10.14.4, iOS 12.2, watchOS 5.2, tvOS 12.2" -define-availability "SwiftStdlib 5.1:macOS 10.15, iOS 13.0, watchOS 6.0, tvOS 13.0" -define-availability "SwiftStdlib 5.2:macOS 10.15.4, iOS 13.4, watchOS 6.2, tvOS 13.4" -define-availability "SwiftStdlib 5.3:macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0" -define-availability "SwiftStdlib 5.4:macOS 11.3, iOS 14.5, watchOS 7.4, tvOS 14.5" -define-availability "SwiftStdlib 5.5:macOS 12.0, iOS 15.0, watchOS 8.0, tvOS 15.0" -define-availability "SwiftStdlib 5.6:macOS 12.3, iOS 15.4, watchOS 8.5, tvOS 15.4" -define-availability "SwiftStdlib 5.7:macOS 13.0, iOS 16.0, watchOS 9.0, tvOS 16.0" -define-availability "SwiftStdlib 5.8:macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4" -define-availability "SwiftStdlib 5.9:macOS 9999, iOS 9999, watchOS 9999, tvOS 9999" -disable-availability-checking -autolink-library oldnames -autolink-library msvcrt -Xcc -D_MT -Xcc -D_DLL -parse-as-library -module-name a -o T:\\tmp\\lit-tmp-ev0tg5ng\\distributed_actor_assume_executor-80a30f.o

1.	Swift version 5.9-dev (LLVM f2296de74014c53, Swift 9b89a948d27c5ac)

2.	Compiling with effective version 4.1.50

3.	While evaluating request IRGenRequest(IR Generation for file "C:\Users\swift-ci\jenkins\workspace\swift-PR-windows\swift\test\Distributed\Runtime\distributed_actor_assume_executor.swift")

4.	While emitting IR for source file C:\Users\swift-ci\jenkins\workspace\swift-PR-windows\swift\test\Distributed\Runtime\distributed_actor_assume_executor.swift

5.	While emitting class metadata for 'MainFriend' (at C:\Users\swift-ci\jenkins\workspace\swift-PR-windows\swift\test\Distributed\Runtime\distributed_actor_assume_executor.swift:42:13)

6.	While emitting metadata for 'MainFriend' (at C:\Users\swift-ci\jenkins\workspace\swift-PR-windows\swift\test\Distributed\Runtime\distributed_actor_assume_executor.swift:42:13)
```