### PR TITLE
Prefer std::copy_n over std::copy where appropriate.

### DIFF
--- a/include/swift/Basic/StableHasher.h
+++ b/include/swift/Basic/StableHasher.h
@@ -122,14 +122,14 @@ public:
     if (nhead == sizeof(byteBuffer)) {
       // We have headroom available for all 64 bits. Eagerly compress the
       // now-full buffer into our state.
-      std::copy(bits, bits + sizeof(byteBuffer), byteBuffer);
+      std::copy_n(bits, sizeof(byteBuffer), byteBuffer);
     } else if (N >= available) {
       // There was some excess - append as many bytes as we can hold and
       // compress the buffer into our state.
-      std::copy(bits, bits + nhead, byteBuffer + bufLen);
+      std::copy_n(bits, nhead, byteBuffer + bufLen);
     } else {
       // We have headroom available for these bits.
-      std::copy(bits, bits + N, byteBuffer + bufLen);
+      std::copy_n(bits, N, byteBuffer + bufLen);
       return setBufferLength(bufLen + N);
     }
 
@@ -138,7 +138,7 @@ public:
 
     // Now reseed the buffer with the remaining bytes.
     const uint64_t remainder = N - available;
-    std::copy(bits + available, bits + N, byteBuffer);
+    std::copy_n(bits + available, remainder, byteBuffer);
     return setBufferLength(remainder);
   }
 

--- a/lib/AST/RequirementMachine/Term.cpp
+++ b/lib/AST/RequirementMachine/Term.cpp
@@ -194,7 +194,7 @@ MutableTerm::compare(const MutableTerm &other, RewriteContext &ctx) const {
 /// Replace the subterm in the range [from,to) of this term with \p rhs.
 void MutableTerm::rewriteSubTerm(Symbol *from, Symbol *to, Term rhs) {
   auto oldSize = size();
-  unsigned lhsLength = (unsigned)(to - from);
+  size_t lhsLength = (size_t)(to - from);
 
   if (lhsLength == rhs.size()) {
     // Copy the RHS to the LHS.
@@ -213,7 +213,7 @@ void MutableTerm::rewriteSubTerm(Symbol *from, Symbol *to, Term rhs) {
     assert(lhsLength < rhs.size());
 
     // Copy the LHS-sized prefix of RHS to the LHS.
-    auto newTo = std::copy(rhs.begin(), rhs.begin() + lhsLength, from);
+    auto newTo = std::copy_n(rhs.begin(), lhsLength, from);
     assert(newTo == to);
 
     // Insert the remainder of the RHS term.

--- a/stdlib/include/llvm/ADT/SmallVector.h
+++ b/stdlib/include/llvm/ADT/SmallVector.h
@@ -983,7 +983,7 @@ SmallVectorImpl<T> &SmallVectorImpl<T>::
     // Assign common elements.
     iterator NewEnd;
     if (RHSSize)
-      NewEnd = std::copy(RHS.begin(), RHS.begin()+RHSSize, this->begin());
+      NewEnd = std::copy_n(RHS.begin(), RHSSize, this->begin());
     else
       NewEnd = this->begin();
 
@@ -1005,7 +1005,7 @@ SmallVectorImpl<T> &SmallVectorImpl<T>::
     this->grow(RHSSize);
   } else if (CurSize) {
     // Otherwise, use assignment for the already-constructed elements.
-    std::copy(RHS.begin(), RHS.begin()+CurSize, this->begin());
+    std::copy_n(RHS.begin(), CurSize, this->begin());
   }
 
   // Copy construct the new elements in place.

--- a/stdlib/public/LLVMSupport/SmallPtrSet.cpp
+++ b/stdlib/public/LLVMSupport/SmallPtrSet.cpp
@@ -192,7 +192,7 @@ void SmallPtrSetImplBase::MoveHelper(unsigned SmallSize,
   if (RHS.isSmall()) {
     // Copy a small RHS rather than moving.
     CurArray = SmallArray;
-    std::copy(RHS.CurArray, RHS.CurArray + RHS.NumNonEmpty, CurArray);
+    std::copy_n(RHS.CurArray, RHS.NumNonEmpty, CurArray);
   } else {
     CurArray = RHS.CurArray;
     RHS.CurArray = RHS.SmallArray;
@@ -228,7 +228,7 @@ void SmallPtrSetImplBase::swap(SmallPtrSetImplBase &RHS) {
   // from LHS to RHS.
   if (!this->isSmall() && RHS.isSmall()) {
     assert(RHS.CurArray == RHS.SmallArray);
-    std::copy(RHS.CurArray, RHS.CurArray + RHS.NumNonEmpty, this->SmallArray);
+    std::copy_n(RHS.CurArray, RHS.NumNonEmpty, this->SmallArray);
     std::swap(RHS.CurArraySize, this->CurArraySize);
     std::swap(this->NumNonEmpty, RHS.NumNonEmpty);
     std::swap(this->NumTombstones, RHS.NumTombstones);
@@ -241,7 +241,7 @@ void SmallPtrSetImplBase::swap(SmallPtrSetImplBase &RHS) {
   // from RHS to LHS.
   if (this->isSmall() && !RHS.isSmall()) {
     assert(this->CurArray == this->SmallArray);
-    std::copy(this->CurArray, this->CurArray + this->NumNonEmpty,
+    std::copy_n(this->CurArray, this->NumNonEmpty,
               RHS.SmallArray);
     std::swap(RHS.CurArraySize, this->CurArraySize);
     std::swap(RHS.NumNonEmpty, this->NumNonEmpty);

--- a/stdlib/toolchain/Compatibility51/Concurrent.h
+++ b/stdlib/toolchain/Compatibility51/Concurrent.h
@@ -434,7 +434,7 @@ public:
       auto newCapacity = std::max((size_t)16, count * 2);
       auto *newStorage = Storage::allocate(newCapacity);
       if (storage) {
-        std::copy(storage->data(), storage->data() + count, newStorage->data());
+        std::copy_n(storage->data(), count, newStorage->data());
         newStorage->Count.store(count, std::memory_order_relaxed);
         FreeList.push_back(storage);
       }

--- a/tools/swift-stdlib-tool/swift-stdlib-tool.cpp
+++ b/tools/swift-stdlib-tool/swift-stdlib-tool.cpp
@@ -760,7 +760,7 @@ std::vector<uint8_t> readToEOF(int fd) {
   ssize_t readSize = 0;
   while ((readSize = read(fd, readBuffer, BUFFER_SIZE)) > 0) {
     retData.reserve(retData.size() + readSize);
-    std::copy(readBuffer, readBuffer + readSize, std::back_inserter(retData));
+    std::copy_n(readBuffer, readSize, std::back_inserter(retData));
   }
   return retData;
 }


### PR DESCRIPTION
std::copy_n saves us from having to do the addition manually.