### PR TITLE
IRGen: correct field counting for distributed actors

### DIFF
--- a/lib/IRGen/StructLayout.cpp
+++ b/lib/IRGen/StructLayout.cpp
@@ -446,7 +446,7 @@ unsigned irgen::getNumFields(const NominalTypeDecl *target) {
   if (auto cls = dyn_cast<ClassDecl>(target)) {
     if (cls->isRootDefaultActor()) {
       numFields++;
-    } else if (cls->isRootDefaultActor()) {
+    } else if (cls->isNonDefaultExplicitDistributedActor()) {
       numFields++;
     }
   }

--- a/test/Distributed/Runtime/distributed_actor_assume_executor.swift
+++ b/test/Distributed/Runtime/distributed_actor_assume_executor.swift
@@ -14,9 +14,6 @@
 // UNSUPPORTED: use_os_stdlib
 // UNSUPPORTED: freestanding
 
-// rdar://106822386
-// REQUIRES: rdar106822386
-
 import StdlibUnittest
 import Distributed
 import FakeDistributedActorSystems


### PR DESCRIPTION
Correct the counting between `forEachField` and `getNumFields` to correctly enumerate the synthesized fields.  We would previously fail to count the non-root default actor resulting in a mismatch on the stored field counts.  Fortunately, we were able to catch this by means of an assertion in the compiler which triggered on Windows.

Special thanks to @etcwilde for the help in tracking this down!

rdar://106822386