### PR TITLE
Disable owned to guaranteed phi transformation when the borrow introducers have a local scope

### DIFF
--- a/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
+++ b/lib/SILOptimizer/SemanticARC/CopyValueOpts.cpp
@@ -76,7 +76,7 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(
   SmallVector<BorrowedValue, 4> borrowScopeIntroducers;
 
   // Find all borrow introducers for our copy operand. If we are unable to find
-  // all of the reproducers (due to pattern matching failure), conservatively
+  // all of the introducers (due to pattern matching failure), conservatively
   // return false. We can not optimize.
   //
   // NOTE: We can get multiple introducers if our copy_value's operand
@@ -213,6 +213,17 @@ bool SemanticARCOptVisitor::performGuaranteedCopyValueOptimization(
 
       OwnershipLiveRange phiArgLR(value);
       if (bool(phiArgLR.hasUnknownConsumingUse())) {
+        return false;
+      }
+
+      // Replacing owned phi operands with a local borrow introducer can
+      // introduce reborrows. Since lifetime adjustment is not implemented for
+      // this case, disable here.
+      // Returning false here will make sure so this isn't populated in
+      // joinedOwnedIntroducerToConsumedOperands which is used by
+      // semanticarc::tryConvertOwnedPhisToGuaranteedPhis for transforming owned
+      // phi to guaranteed.
+      if (haveAnyLocalScopes) {
         return false;
       }
 

--- a/lib/SILOptimizer/SemanticARC/OwnedToGuaranteedPhiOpt.cpp
+++ b/lib/SILOptimizer/SemanticARC/OwnedToGuaranteedPhiOpt.cpp
@@ -128,6 +128,8 @@ static bool getIncomingJoinedLiveRangeOperands(
 //                            Top Level Entrypoint
 //===----------------------------------------------------------------------===//
 
+// This needs `SemanticARCOptVisitor::performGuaranteedCopyValueOptimization` to
+// run before so that joinedOwnedIntroducerToConsumedOperands is populated.
 bool swift::semanticarc::tryConvertOwnedPhisToGuaranteedPhis(Context &ctx) {
   bool madeChange = false;
 

--- a/test/SILOptimizer/semantic-arc-opt-owned-to-guaranteed-phi.sil
+++ b/test/SILOptimizer/semantic-arc-opt-owned-to-guaranteed-phi.sil
@@ -1,0 +1,108 @@
+// RUN: %target-sil-opt -semantic-arc-opts %s | %FileCheck %s
+
+class Klass {}
+
+// CHECK-LABEL: sil [ossa] @test_owned_to_guaranteed1 :
+// CHECK-NOT: copy_value 
+// CHECK-LABEL: } // end sil function 'test_owned_to_guaranteed1'
+sil [ossa] @test_owned_to_guaranteed1 : $@convention(thin) (@guaranteed Klass, @guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass, %1 : @guaranteed $Klass):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy1 = copy_value %0 : $Klass
+  br bb3(%copy1 : $Klass)
+
+bb2:
+  %copy2 = copy_value %1 : $Klass
+  br bb3(%copy2 : $Klass)
+
+bb3(%copy : @owned $Klass):
+  destroy_value %copy : $Klass
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_owned_to_guaranteed2 :
+// CHECK: bb3([[ARG1:%.*]] : @owned $Klass, [[ARG2:%.*]] : @guaranteed $Klass)
+// CHECK-LABEL: } // end sil function 'test_owned_to_guaranteed2'
+sil [ossa] @test_owned_to_guaranteed2 : $@convention(thin) (@owned Klass, @owned Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass):
+  cond_br undef, bb1, bb2
+
+bb1:
+  %borrow1 = begin_borrow %0 : $Klass
+  %copy1 = copy_value %borrow1 : $Klass
+  br bb3(%copy1 : $Klass, %borrow1 : $Klass)
+
+bb2:
+  %borrow2 = begin_borrow %1 : $Klass
+  %copy2 = copy_value %borrow2 : $Klass
+  br bb3(%copy2 : $Klass, %borrow2 : $Klass)
+
+bb3(%copy : @owned $Klass, %borrow : @guaranteed $Klass):
+  destroy_value %copy : $Klass
+  end_borrow %borrow : $Klass
+  destroy_value %0 : $Klass
+  destroy_value %1 : $Klass
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_owned_to_guaranteed3 :
+// CHECK: bb3([[ARG1:%.*]] : @owned $Klass)
+// CHECK-LABEL: } // end sil function 'test_owned_to_guaranteed3'
+sil [ossa] @test_owned_to_guaranteed3 : $@convention(thin) (@owned Klass, @owned Klass) -> () {
+bb0(%0 : @owned $Klass, %1 : @owned $Klass):
+  %borrow1 = begin_borrow %0 : $Klass
+  %borrow2 = begin_borrow %1 : $Klass
+  cond_br undef, bb1, bb2
+
+bb1:
+  %copy1 = copy_value %borrow1 : $Klass
+  br bb3(%copy1 : $Klass)
+
+bb2:
+  %copy2 = copy_value %borrow2 : $Klass
+  br bb3(%copy2 : $Klass)
+
+bb3(%copy : @owned $Klass):
+  destroy_value %copy : $Klass
+  end_borrow %borrow1 : $Klass
+  end_borrow %borrow2 : $Klass
+  destroy_value %0 : $Klass
+  destroy_value %1 : $Klass
+  %t = tuple ()
+  return %t : $()
+}
+
+// CHECK-LABEL: sil [ossa] @test_owned_to_guaranteed4 :
+// CHECK: bb3([[ARG1:%.*]] : @owned $Klass)
+// CHECK-LABEL: } // end sil function 'test_owned_to_guaranteed4'
+sil [ossa] @test_owned_to_guaranteed4 : $@convention(thin) (@in Klass) -> () {
+bb0(%0 : $*Klass):
+  %borrow = load_borrow %0 : $*Klass
+  %copy = copy_value %borrow : $Klass
+  cond_br undef, bb1, bb2
+
+bb1:
+  destroy_value %copy : $Klass
+  br bb4
+
+bb2:
+  br bb3(%copy : $Klass)
+
+bb3(%arg : @owned $Klass):
+  destroy_value %arg : $Klass
+  end_borrow %borrow : $Klass
+  br bbret
+
+bb4:
+  end_borrow %borrow : $Klass
+  br bbret
+
+bbret:
+  destroy_addr %0 : $*Klass
+  %t = tuple ()
+  return %t : $()
+}


### PR DESCRIPTION
In the absence of this bailout, reborrows can be introduced while replacing the @owned value with a local borrow introducer. Since lifetime adjustment for this case was not implemented, disable here.

rdar://106757446
