### PR TITLE
[CSSimplify] Don't enable `OneWayBindParam` for result builder transformed closures

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -10996,8 +10996,7 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
   // type as seen in the body of the closure and the external parameter
   // type.
   bool oneWayConstraints =
-    getASTContext().LangOpts.hasFeature(Feature::OneWayClosureParameters) ||
-    resultBuilderType;
+      getASTContext().LangOpts.hasFeature(Feature::OneWayClosureParameters);
 
   auto *paramList = closure->getParameters();
   SmallVector<AnyFunctionType::Param, 4> parameters;

--- a/test/Constraints/result_builder_diags.swift
+++ b/test/Constraints/result_builder_diags.swift
@@ -623,7 +623,7 @@ func wrapperifyInfer<T, U>(_ cond: Bool, @WrapperBuilder body: (U) -> T) -> T {
 }
 
 let intValue = 17
-wrapperifyInfer(true) { x in // expected-error{{unable to infer type of a closure parameter 'x' in the current context}}
+_ = wrapperifyInfer(true) { x in // Ok
   intValue + x
 }
 
@@ -999,5 +999,19 @@ func test_requirement_failure_in_buildBlock() {
         B()
       }
     }
+  }
+}
+
+func test_partially_resolved_closure_params() {
+  struct S<T> {
+    var a: String = ""
+  }
+
+  func test<T>(@TupleBuilder _: (S<T>) -> T) { // expected-note {{in call to function 'test'}}
+  }
+
+  test { // expected-error {{generic parameter 'T' could not be inferred}}
+    $0.a
+    42
   }
 }


### PR DESCRIPTION
This means two things:

- transformed closures behave just like regular multi-statement closures
- It's now possible to pass partially resolved parameter types into the closure which helps with diagnostics.

Re-landing https://github.com/apple/swift/pull/63140

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
