### PR TITLE
[CMake] Fix swift_supports_implicit_module failure

### DIFF
--- a/cmake/modules/SwiftImplicitImport.cmake
+++ b/cmake/modules/SwiftImplicitImport.cmake
@@ -5,6 +5,7 @@ function(swift_supports_implicit_module module_name out_var)
     COMMAND
       "${CMAKE_Swift_COMPILER}"
       -Xfrontend -disable-implicit-${module_name}-module-import
+      -Xfrontend -parse-stdlib
       -c - -o /dev/null
     INPUT_FILE
       "${CMAKE_BINARY_DIR}/tmp/empty-check-${module_name}.swift"


### PR DESCRIPTION
`swift_supports_implicit_module` invokes `/path/to/toolchain/usr/bin/swiftc` directly without using `xcrun`. That fails to set necessary environmental variables to make `swiftc` infer the SDK path. Because of that `swift_supports_implicit_module` used to fail because the test compilation command fails to load the stdlib. This PR workaround it by passing `-parse-stdlib` to avoid implicit stdlib loading.
