### PR TITLE
[Distributed] Bring back Derived id synthesis, as some cases still use it

### DIFF
--- a/lib/Sema/DerivedConformanceDistributedActor.cpp
+++ b/lib/Sema/DerivedConformanceDistributedActor.cpp
@@ -424,9 +424,30 @@ static FuncDecl *deriveDistributedActorSystem_invokeHandlerOnReturn(
 /******************************* PROPERTIES ***********************************/
 /******************************************************************************/
 
-// NOTE: There is no deriveDistributedActor_aid since it must be handled earlier
-//       due to the Identifiable Conformance it must fulfil as well.
-// TODO(distributed): try to bring back `id` synthesis from addImplicitDistributedActorIDProperty to Derived infra
+static ValueDecl *deriveDistributedActor_id(DerivedConformance &derived) {
+  assert(derived.Nominal->isDistributedActor());
+  auto &C = derived.Context;
+
+  // ```
+  // nonisolated let id: Self.ID // Self.ActorSystem.ActorID
+  // ```
+  auto propertyType = getDistributedActorIDType(derived.Nominal);
+
+  VarDecl *propDecl;
+  PatternBindingDecl *pbDecl;
+  std::tie(propDecl, pbDecl) = derived.declareDerivedProperty(
+      DerivedConformance::SynthesizedIntroducer::Let, C.Id_id, propertyType,
+      propertyType,
+      /*isStatic=*/false, /*isFinal=*/true);
+
+  // mark as nonisolated, allowing access to it from everywhere
+  propDecl->getAttrs().add(
+      new (C) NonisolatedAttr(/*IsImplicit=*/true));
+
+  derived.addMemberToConformanceContext(pbDecl, /*insertAtHead=*/true);
+  derived.addMemberToConformanceContext(propDecl, /*insertAtHead=*/true);
+  return propDecl;
+}
 
 static ValueDecl *deriveDistributedActor_actorSystem(
     DerivedConformance &derived) {
@@ -761,7 +782,9 @@ static void assertRequiredSynthesizedPropertyOrder(DerivedConformance &derived, 
 ValueDecl *DerivedConformance::deriveDistributedActor(ValueDecl *requirement) {
   if (auto var = dyn_cast<VarDecl>(requirement)) {
     ValueDecl *derivedValue = nullptr;
-    if (var->getName() == Context.Id_actorSystem) {
+    if (var->getName() == Context.Id_id) {
+      derivedValue = deriveDistributedActor_id(*this);
+    } else if (var->getName() == Context.Id_actorSystem) {
       derivedValue = deriveDistributedActor_actorSystem(*this);
     } else if (var->getName() == Context.Id_unownedExecutor) {
       derivedValue = deriveDistributedActor_unownedExecutor(*this);


### PR DESCRIPTION
**Summary:** Bring back code which was assumed to be dead, but isn't in cross-module cases.
**Description:**
During https://github.com/apple/swift/pull/64237/ I spotted that we had `// TODO(distributed): make use of this after all, but FORCE it?` above the `deriveDistributedActor_id` and a quick check uncovered that this code isn't hit in our tests and I removed it. The source compatibility suite uncovered that this caused a regression in the distributed cluster build.

This [removal](https://github.com/apple/swift/pull/64237/files#diff-4146b4ae4ecb8822ff4f69039afad1015bfa44f9013af79aa2f1778704a55693L426-L450) a day or two ago was incorrect and must be undone.

Turns out, this IS hit but during builds across modules only (!), and we should not remove it.

**Risk:** Low, this brings back code which was always here and was removed yesterday by a wrong assumption that it was not needed
**Testing:** 
- source compat suite caught regression in distributed cluster
- manually verified on the distributed cluster
- CI testing including the source compat suite confirm this is the fix. 
- I'm working on a way to test this within the swift build so we won't regress like this anymore