### PR TITLE
[cxx-interop] Do not auto-complete unsafe underscored methods, part 2

### DIFF
--- a/include/swift/AST/ClangModuleLoader.h
+++ b/include/swift/AST/ClangModuleLoader.h
@@ -33,6 +33,7 @@ namespace swift {
 
 class ConcreteDeclRef;
 class Decl;
+class FuncDecl;
 class VarDecl;
 class DeclContext;
 class EffectiveClangContext;
@@ -266,6 +267,8 @@ public:
                                  SubstitutionMap subst) = 0;
 
   virtual bool isCXXMethodMutating(const clang::CXXMethodDecl *method) = 0;
+
+  virtual bool isUnsafeCXXMethod(const FuncDecl *func) = 0;
 
   virtual Type importFunctionReturnType(const clang::FunctionDecl *clangDecl,
                                         DeclContext *dc) = 0;

--- a/include/swift/ClangImporter/ClangImporter.h
+++ b/include/swift/ClangImporter/ClangImporter.h
@@ -532,6 +532,8 @@ public:
 
   bool isCXXMethodMutating(const clang::CXXMethodDecl *method) override;
 
+  bool isUnsafeCXXMethod(const FuncDecl *func) override;
+
   bool isAnnotatedWith(const clang::CXXMethodDecl *method, StringRef attr);
 
   /// Find the lookup table that corresponds to the given Clang module.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1952,19 +1952,11 @@ bool ShouldPrintChecker::shouldPrint(const Decl *D,
       D->isPrivateStdlibDecl(!Options.SkipUnderscoredStdlibProtocols))
     return false;
 
-  auto isUnsafeCxxMethod = [](const Decl* decl) {
-    if (!decl->hasClangNode()) return false;
-    auto clangDecl = decl->getClangNode().getAsDecl();
-    if (!clangDecl) return false;
-    auto cxxMethod = dyn_cast<clang::CXXMethodDecl>(clangDecl);
-    if (!cxxMethod) return false;
-    auto func = dyn_cast<FuncDecl>(decl);
-    if (!func || !func->hasName()) return false;
-    auto id = func->getBaseIdentifier().str();
-    return id.startswith("__") && id.endswith("Unsafe");
-  };
-  if (Options.SkipUnsafeCXXMethods && isUnsafeCxxMethod(D))
-    return false;
+  auto &ctx = D->getASTContext();
+  if (Options.SkipUnsafeCXXMethods)
+    if (auto func = dyn_cast<FuncDecl>(D))
+      if (ctx.getClangModuleLoader()->isUnsafeCXXMethod(func))
+        return false;
 
   if (Options.SkipEmptyExtensionDecls && isa<ExtensionDecl>(D)) {
     auto Ext = cast<ExtensionDecl>(D);

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6199,6 +6199,21 @@ bool ClangImporter::isCXXMethodMutating(const clang::CXXMethodDecl *method) {
   return false;
 }
 
+bool ClangImporter::isUnsafeCXXMethod(const FuncDecl *func) {
+  if (!func->hasClangNode())
+    return false;
+  auto clangDecl = func->getClangNode().getAsDecl();
+  if (!clangDecl)
+    return false;
+  auto cxxMethod = dyn_cast<clang::CXXMethodDecl>(clangDecl);
+  if (!cxxMethod)
+    return false;
+  if (!func->hasName())
+    return false;
+  auto id = func->getBaseIdentifier().str();
+  return id.startswith("__") && id.endswith("Unsafe");
+}
+
 bool ClangImporter::isAnnotatedWith(const clang::CXXMethodDecl *method,
                                     StringRef attr) {
   return method->hasAttrs() &&

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -1471,6 +1471,10 @@ void CompletionLookup::addMethodCall(const FuncDecl *FD,
       Builder.addFlair(CodeCompletionFlairBit::ExpressionSpecific);
   };
 
+  // Do not add imported C++ methods that are treated as unsafe in Swift.
+  if (Importer->isUnsafeCXXMethod(FD))
+    return;
+
   if (!AFT || IsImplicitlyCurriedInstanceMethod) {
     addMethodImpl();
   } else {

--- a/test/Interop/Cxx/class/type-classification-completion.swift
+++ b/test/Interop/Cxx/class/type-classification-completion.swift
@@ -1,9 +1,13 @@
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=METHOD -I %S/Inputs | %FileCheck %s -check-prefix=CHECK-METHOD
+// RUN: %target-swift-ide-test -code-completion -enable-experimental-cxx-interop -source-filename %s -code-completion-token=METHOD -I %S/Inputs | %FileCheck %s -check-prefix=CHECK-METHOD
 
 import TypeClassification
 
 func foo(x: HasMethodThatReturnsIterator) {
   x.#^METHOD^#
 }
+// CHECK-METHOD: Begin completions
 // CHECK-METHOD-NOT: getIterator
+// CHECK-METHOD-NOT: Decl[InstanceMethod]/CurrNominal:   getIterator
 // CHECK-METHOD-NOT: __getIteratorUnsafe
+// CHECK-METHOD-NOT: Decl[InstanceMethod]/CurrNominal:   __getIteratorUnsafe
+// CHECK-METHOD: End completions


### PR DESCRIPTION
Previous patch removed unsafe C++ methods from the module interface, but not from auto-completion results.

rdar://103252957