### PR TITLE
[cxx-interop] Object model: fix crash when importing explicitly owned…

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -6575,6 +6575,7 @@ bool IsSafeUseOfCxxDecl::evaluate(Evaluator &evaluator,
 
         if (!cxxRecordReturnType->hasUserDeclaredCopyConstructor() &&
             !cxxRecordReturnType->hasUserDeclaredMoveConstructor() &&
+            !hasOwnedValueAttr(cxxRecordReturnType) &&
             hasPointerInSubobjects(cxxRecordReturnType)) {
           return false;
         }

--- a/test/Interop/Cxx/class/invalid-unsafe-projection-errors.swift
+++ b/test/Interop/Cxx/class/invalid-unsafe-projection-errors.swift
@@ -10,6 +10,7 @@ module Test {
 
 //--- Inputs/test.h
 struct Ptr { int *p; };
+struct __attribute__((swift_attr("import_owned"))) StirngLiteral { const char *name; };
 
 struct M {
         int *_Nonnull test1() const;
@@ -17,6 +18,8 @@ struct M {
         Ptr test3() const;
 
         int *begin() const;
+
+        StirngLiteral stringLiteral() const { return StirngLiteral{"M"}; }
 };
 
 //--- test.swift
@@ -40,4 +43,7 @@ public func test(x: M) {
   // CHECK: note: C++ method 'begin' that returns an iterator is unavailable
   // CHECK: note: C++ methods that return iterators are potentially unsafe. Try re-writing to use Swift iterator APIs.
   x.begin()
+
+  // CHECK-NOT: error: value of type 'M' has no member 'stringLiteral'
+  x.stringLiteral()
 }


### PR DESCRIPTION
… type.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!--
If this pull request resolves any GitHub issues, link them.
For information about linking a pull request to an issue, see:
https://docs.github.com/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Resolves #NNNNN, fix apple/llvm-project#MMMMM.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
