### PR TITLE
 [interop] C++ record should use AddressOnly type layout only when it's non-trivial for purpose of calls

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4294,6 +4294,12 @@ public:
     Bits.StructDecl.HasUnreferenceableStorage = v;
   }
 
+  /// Does this struct represent a non-trivial (for the purpose of calls, as
+  /// defined by Itanium ABI) C++ record. A C++ record is considered non-trivial
+  /// for the purpose of calls if either its constructor, copy-constructor, or
+  /// destructor is non-trivial. As such, a C++ record with a non-trivial
+  /// copy-assignment operator but other trivial members is considered to be
+  /// trivial.
   bool isCxxNonTrivial() const { return Bits.StructDecl.IsCxxNonTrivial; }
 
   void setIsCxxNonTrivial(bool v) { Bits.StructDecl.IsCxxNonTrivial = v; }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2394,9 +2394,15 @@ namespace {
       }
 
       if (cxxRecordDecl) {
+        auto isNonTrivialForPurposeOfCalls =
+            [](const clang::CXXRecordDecl *decl) -> bool {
+          return decl->hasNonTrivialCopyConstructor() ||
+                 decl->hasNonTrivialMoveConstructor() ||
+                 !decl->hasTrivialDestructor();
+        };
         if (auto structResult = dyn_cast<StructDecl>(result))
           structResult->setIsCxxNonTrivial(
-              !cxxRecordDecl->isTriviallyCopyable());
+              isNonTrivialForPurposeOfCalls(cxxRecordDecl));
 
         for (auto &getterAndSetter : Impl.GetterSetterMap) {
           auto getter = getterAndSetter.second.first;

--- a/test/Interop/Cxx/class/type-classification-loadable-silgen.swift
+++ b/test/Interop/Cxx/class/type-classification-loadable-silgen.swift
@@ -54,17 +54,17 @@ func pass(s: StructWithSubobjectDefaultedCopyConstructor) {
 
 // CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithCopyAssignment)
 func pass(s: StructWithCopyAssignment) {
-  // CHECK: bb0(%0 : $*StructWithCopyAssignment):
+  // CHECK: bb0(%0 : $StructWithCopyAssignment):
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithInheritedCopyAssignment)
 func pass(s: StructWithInheritedCopyAssignment) {
-  // CHECK: bb0(%0 : $*StructWithInheritedCopyAssignment):
+  // CHECK: bb0(%0 : $StructWithInheritedCopyAssignment):
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithSubobjectCopyAssignment)
 func pass(s: StructWithSubobjectCopyAssignment) {
-  // CHECK: bb0(%0 : $*StructWithSubobjectCopyAssignment):
+  // CHECK: bb0(%0 : $StructWithSubobjectCopyAssignment):
 }
 
 // CHECK-LABEL: sil hidden [ossa] @$s4main4pass{{.*[ (]}}StructWithDestructor)

--- a/test/Interop/Cxx/stdlib/Inputs/std-pair.h
+++ b/test/Interop/Cxx/stdlib/Inputs/std-pair.h
@@ -4,8 +4,22 @@
 
 using PairInts = std::pair<int, int>;
 
-// FIXME: return pair by value, but it causes IRGen crash atm.
-inline const PairInts &getIntPair() {
-    static PairInts value = { -5, 12 };
+inline const PairInts &getIntPairPointer() {
+    static PairInts value = { 4, 9 };
     return value;
+}
+
+inline PairInts getIntPair() {
+    return { -5, 12 };
+}
+
+struct StructInPair {
+    int x;
+    int y;
+};
+
+using PairStructInt = std::pair<StructInPair, int>;
+
+inline PairStructInt getPairStructInt(int x) {
+    return { { x * 2, -x}, x };
 }

--- a/test/Interop/Cxx/stdlib/use-std-pair.swift
+++ b/test/Interop/Cxx/stdlib/use-std-pair.swift
@@ -12,12 +12,25 @@ import Cxx
 var StdPairTestSuite = TestSuite("StdPair")
 
 StdPairTestSuite.test("StdPair.elements") {
-  var pi = getIntPair().pointee
+  var pi = getIntPair()
   expectEqual(pi.first, -5)
   expectEqual(pi.second, 12)
   pi.first = 11
   expectEqual(pi.first, 11)
   expectEqual(pi.second, 12)
+}
+
+StdPairTestSuite.test("StdPair.ref.elements") {
+  let pi = getIntPairPointer().pointee
+  expectEqual(pi.first, 4)
+  expectEqual(pi.second, 9)
+}
+
+StdPairTestSuite.test("PairStructInt.elements") {
+  let pair = getPairStructInt(11)
+  expectEqual(pair.first.x, 22)
+  expectEqual(pair.first.y, -11)
+  expectEqual(pair.second, 11)
 }
 
 runAllTests()


### PR DESCRIPTION
A record that's non trivial for purpose of calls, as defined in Itanium ABI, is allowed to have non-trivial copy/move assignment operators, but it must not have non-trivial constructors or destructors. This change ensures that a C++ record with a non-trivial copy assignment operator but trivial other members can be passed/returned directly by value, so that the compiler can accept the returned value correctly when calling a C++ function.