### PR TITLE
Fix a use-after-free in IRGenSIL.

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1104,10 +1104,10 @@ public:
           llvm::Value *Shape = emitPackShapeExpression(t);
           if (PackShapeExpressions.insert(Shape).second) {
               llvm::SmallString<8> Buf;
-              llvm::raw_svector_ostream OS(Buf);
               unsigned Position = PackShapeExpressions.size() - 1;
-              OS << "$pack_count_" << Position;
-              SILDebugVariable Var(OS.str(), true, 0);
+              llvm::raw_svector_ostream(Buf) << "$pack_count_" << Position;
+              auto Name = IGM.Context.getIdentifier(Buf.str());
+              SILDebugVariable Var(Name.str(), true, 0);
               Shape = emitShadowCopyIfNeeded(Shape, getDebugScope(), Var, false,
                                              false /*was move*/);
               if (IGM.DebugInfo)


### PR DESCRIPTION
A StringRef of the name is used as key into a DenseMap.

https://ci.swift.org/job/apple-llvm-project-pr-macos/2857/consoleFull#985524163d6fdb6cb-f376-4f2e-8bce-d31c7304698b