### PR TITLE
Checking requirements of variadic generic types (compile-time and runtime)

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2272,12 +2272,14 @@ NOTE(candidate_types_equal_requirement,none,
      (Type, Type, Type, Type))
 NOTE(candidate_types_same_shape_requirement,none,
      "candidate requires that the type packs %0 and %1 have the same shape "
-     "(requirement specified as %2.shape == %3.shape)",
+     "(same-shape requirement inferred between %2 and %3)",
      (Type, Type, Type, Type))
 NOTE(candidate_types_inheritance_requirement,none,
      "candidate requires that %1 inherit from %2 "
      "(requirement specified as %2 : %3)",
      (Type, Type, Type, Type))
+NOTE(same_shape_requirement,none,
+     "same-shape requirement inferred between %0 and %1%2", (Type, Type, StringRef))
 NOTE(types_not_equal_requirement,none,
      "requirement specified as %0 == %1%2", (Type, Type, StringRef))
 ERROR(type_is_not_a_class,none,

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -27,6 +27,24 @@
 
 namespace swift {
 
+/// Return type of Requirement::checkRequirement().
+enum class CheckRequirementResult : uint8_t {
+  /// The requirement was fully satisfied.
+  Success,
+
+  /// The subject type conforms conditionally; the sub-requirements are
+  /// conditional requirements which must be checked.
+  ConditionalConformance,
+
+  /// The requirement cannot ever be satisfied.
+  RequirementFailure,
+
+  /// Some other requirement is expected to fail, or there was an invalid
+  /// conformance and an error should be diagnosed elsewhere, so this
+  /// requirement does not need to be diagnosed.
+  SubstitutionFailure
+};
+
 /// A single requirement placed on the type parameters (or associated
 /// types thereof) of a
 class Requirement {
@@ -155,11 +173,12 @@ public:
 
   /// Determines if this substituted requirement is satisfied.
   ///
-  /// \param conditionalRequirements An out parameter initialized to an
-  /// array of requirements that the caller must check to ensure this
+  /// \param subReqs An out parameter initialized to a list of simpler
+  /// requirements which the caller must check to ensure this
   /// requirement is completely satisfied.
-  bool isSatisfied(ArrayRef<Requirement> &conditionalRequirements,
-                   bool allowMissing = false) const;
+  CheckRequirementResult checkRequirement(
+      SmallVectorImpl<Requirement> &subReqs,
+      bool allowMissing = false) const;
 
   /// Determines if this substituted requirement can ever be satisfied,
   /// possibly with additional substitutions.

--- a/include/swift/AST/Requirement.h
+++ b/include/swift/AST/Requirement.h
@@ -36,6 +36,10 @@ enum class CheckRequirementResult : uint8_t {
   /// conditional requirements which must be checked.
   ConditionalConformance,
 
+  /// The subject type is a pack type; the sub-requirements are the
+  /// element-wise requirements which must be checked.
+  PackRequirement,
+
   /// The requirement cannot ever be satisfied.
   RequirementFailure,
 

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -414,6 +414,11 @@ bool GenericSignatureImpl::isRequirementSatisfied(
     // FIXME: Need to check conditional requirements here.
     return true;
 
+  case CheckRequirementResult::PackRequirement:
+    // FIXME
+    assert(false && "Refactor this");
+    return true;
+
   case CheckRequirementResult::RequirementFailure:
   case CheckRequirementResult::SubstitutionFailure:
     return false;

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -405,10 +405,19 @@ bool GenericSignatureImpl::isRequirementSatisfied(
         LookUpConformanceInSignature(this));
   }
 
-  // FIXME: Need to check conditional requirements here.
-  ArrayRef<Requirement> conditionalRequirements;
+  SmallVector<Requirement, 2> subReqs;
+  switch (requirement.checkRequirement(subReqs, allowMissing)) {
+  case CheckRequirementResult::Success:
+    return true;
 
-  return requirement.isSatisfied(conditionalRequirements, allowMissing);
+  case CheckRequirementResult::ConditionalConformance:
+    // FIXME: Need to check conditional requirements here.
+    return true;
+
+  case CheckRequirementResult::RequirementFailure:
+  case CheckRequirementResult::SubstitutionFailure:
+    return false;
+  }
 }
 
 SmallVector<Requirement, 4>

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -344,16 +344,25 @@ struct SynthesizedExtensionAnalyzer::Implementation {
             return type;
           },
           LookUpConformanceInModule(M));
-        if (SubstReq.hasError())
+
+        SmallVector<Requirement, 2> subReqs;
+        switch (SubstReq.checkRequirement(subReqs)) {
+        case CheckRequirementResult::Success:
+          break;
+
+        case CheckRequirementResult::ConditionalConformance:
+          // FIXME: Need to handle conditional requirements here!
+          break;
+
+        case CheckRequirementResult::SubstitutionFailure:
           return true;
 
-        // FIXME: Need to handle conditional requirements here!
-        ArrayRef<Requirement> conditionalRequirements;
-        if (!SubstReq.isSatisfied(conditionalRequirements)) {
+        case CheckRequirementResult::RequirementFailure:
           if (!SubstReq.canBeSatisfied())
             return true;
 
           MergeInfo.addRequirement(Req);
+          break;
         }
       }
       return false;

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -354,6 +354,11 @@ struct SynthesizedExtensionAnalyzer::Implementation {
           // FIXME: Need to handle conditional requirements here!
           break;
 
+        case CheckRequirementResult::PackRequirement:
+          // FIXME
+          assert(false && "Refactor this");
+          return true;
+
         case CheckRequirementResult::SubstitutionFailure:
           return true;
 

--- a/test/Generics/variadic_generic_requirements.swift
+++ b/test/Generics/variadic_generic_requirements.swift
@@ -1,0 +1,39 @@
+// RUN: %target-typecheck-verify-swift -enable-experimental-feature VariadicGenerics
+
+// REQUIRES: asserts
+
+struct Conformance<each T: Equatable> {}
+
+_ = Conformance<Int, String>.self  // ok
+_ = Conformance<AnyObject, Character>.self  // expected-error {{type 'AnyObject' does not conform to protocol 'Equatable'}}
+
+class Class {}
+class OtherClass {}
+class Subclass: Class {}
+
+struct Superclass<each T: Class> {}  // expected-note {{requirement specified as 'T' : 'Class' [with each T = OtherClass]}}
+
+_ = Superclass<Class, Subclass>.self  // ok
+_ = Superclass<OtherClass>.self  // expected-error {{'Superclass' requires that 'OtherClass' inherit from 'Class'}}
+
+struct Layout<each T: AnyObject> {}  // expected-note {{requirement specified as 'T' : 'AnyObject' [with each T = Int, String]}}
+
+_ = Layout<Class, Subclass>.self  // ok
+_ = Layout<Int, String>.self  // expected-error {{'Layout' requires that 'Int' be a class type}}
+
+struct Outer<each T: Sequence> {
+  struct Inner<each U: Sequence> where each T.Element == each U.Element {}
+  // expected-note@-1 {{requirement specified as 'T.Element' == 'U.Element' [with each T = Array<Int>, Array<String>; each U = Set<String>, Set<Int>]}}
+  // expected-note@-2 {{requirement specified as 'T.Element' == 'U.Element' [with each T = Array<Int>; each U = Set<Int>, Set<String>]}}
+
+  struct InnerShape<each U: Sequence> where (repeat (each T, each U)): Any {}
+  // expected-note@-1 {{same-shape requirement inferred between 'T' and 'U' [with each T = Array<Int>; each U = Set<Int>, Set<String>]}}
+
+}
+
+_ = Outer<Array<Int>, Array<String>>.Inner<Set<Int>, Set<String>>.self  // ok
+_ = Outer<Array<Int>, Array<String>>.Inner<Set<String>, Set<Int>>.self  // expected-error {{'Outer<Array<Int>, Array<String>>.Inner' requires the types 'Pack{Int, String}' and 'Pack{String, Int}' be equivalent}}
+_ = Outer<Array<Int>>.Inner<Set<Int>, Set<String>>.self  // expected-error {{'Outer<Array<Int>>.Inner' requires the types 'Pack{Int}' and 'Pack{Int, String}' be equivalent}}
+
+_ = Outer<Array<Int>, Array<String>>.InnerShape<Set<String>, Set<Int>>.self  // ok
+_ = Outer<Array<Int>>.InnerShape<Set<Int>, Set<String>>.self  // expected-error {{'Outer<Array<Int>>.InnerShape' requires the type packs 'Pack{Array<Int>}' and 'Pack{Set<Int>, Set<String>}' have the same shape}}

--- a/test/Interpreter/variadic_generic_types.swift
+++ b/test/Interpreter/variadic_generic_types.swift
@@ -90,7 +90,16 @@ types.test("LayoutReq") {
   expectEqual("main.LayoutReq<Pack{Swift.AnyObject, main.Base}>", _typeName(LayoutReq<AnyObject, Base>.self))
 }
 
-// FIXME: Test same-type pack requirements once more stuff is plumbed through
+public struct OuterSeq<each T: Sequence> {
+  public struct InnerSeq<each U: Sequence> where each T.Element == each U.Element {}
+}
+
+types.test("SameTypeReq") {
+  expectEqual("main.OuterSeq<Pack{}>.InnerSeq<Pack{}>", _typeName(OuterSeq< >.InnerSeq< >.self))
+  expectEqual("main.OuterSeq<Pack{Swift.Array<Swift.Int>}>.InnerSeq<Pack{Swift.Set<Swift.Int>}>", _typeName(OuterSeq<Array<Int>>.InnerSeq<Set<Int>>.self))
+  expectEqual("main.OuterSeq<Pack{Swift.Array<Swift.Int>, Swift.Set<Swift.String>}>.InnerSeq<Pack{Swift.Set<Swift.Int>, Swift.Array<Swift.String>}>", _typeName(OuterSeq<Array<Int>, Set<String>>.InnerSeq<Set<Int>, Array<String>>.self))
+}
+
 
 //
 // Stored property layout tests

--- a/test/Interpreter/variadic_generic_types.swift
+++ b/test/Interpreter/variadic_generic_types.swift
@@ -71,7 +71,18 @@ types.test("ConformanceReq") {
   expectEqual("main.ConformanceReq<Pack{Swift.Int, Swift.String, Swift.Float}>", _typeName(ConformanceReq<Int, String, Float>.self))
 }
 
-// FIXME: Test superclass, layout and same-type pack requirements once more stuff is plumbed through
+public class Base {}
+public class Derived: Base {}
+
+public struct SuperclassReq<each T: Base> {}
+
+types.test("SuperclassReq") {
+  expectEqual("main.SuperclassReq<Pack{}>", _typeName(SuperclassReq< >.self))
+  expectEqual("main.SuperclassReq<Pack{main.Base}>", _typeName(SuperclassReq<Base>.self))
+  expectEqual("main.SuperclassReq<Pack{main.Derived, main.Base}>", _typeName(SuperclassReq<Derived, Base>.self))
+}
+
+// FIXME: Test layout and same-type pack requirements once more stuff is plumbed through
 
 //
 // Stored property layout tests

--- a/test/Interpreter/variadic_generic_types.swift
+++ b/test/Interpreter/variadic_generic_types.swift
@@ -82,7 +82,15 @@ types.test("SuperclassReq") {
   expectEqual("main.SuperclassReq<Pack{main.Derived, main.Base}>", _typeName(SuperclassReq<Derived, Base>.self))
 }
 
-// FIXME: Test layout and same-type pack requirements once more stuff is plumbed through
+public struct LayoutReq<each T: AnyObject> {}
+
+types.test("LayoutReq") {
+  expectEqual("main.LayoutReq<Pack{}>", _typeName(LayoutReq< >.self))
+  expectEqual("main.LayoutReq<Pack{Swift.AnyObject}>", _typeName(LayoutReq<AnyObject>.self))
+  expectEqual("main.LayoutReq<Pack{Swift.AnyObject, main.Base}>", _typeName(LayoutReq<AnyObject, Base>.self))
+}
+
+// FIXME: Test same-type pack requirements once more stuff is plumbed through
 
 //
 // Stored property layout tests


### PR DESCRIPTION
Previously we only supported conformance and same-shape requirements here. Now plumb through superclass, layout and same-type, as well as runtime support for requirements where the subject type is a dependent member type.