### PR TITLE
[Basic] Add a compiler flag for experimental `is case` pattern matching feature

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -183,6 +183,9 @@ EXPERIMENTAL_FEATURE(GenerateBindingsForThrowingFunctionsInCXX, false)
 /// Enable reference bindings.
 EXPERIMENTAL_FEATURE(ReferenceBindings, false)
 
+/// Whether to enable the `is case` construct.
+EXPERIMENTAL_FEATURE(PatternMatchingBooleanExpression, false)
+
 #undef EXPERIMENTAL_FEATURE
 #undef UPCOMING_FEATURE
 #undef SUPPRESSIBLE_LANGUAGE_FEATURE

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3277,6 +3277,10 @@ static bool usesFeatureReferenceBindings(Decl *decl) {
   return vd && vd->getIntroducer() == VarDecl::Introducer::InOut;
 }
 
+static bool usesFeaturePatternMatchingBooleanExpression (Decl *decl) {
+  return false;
+}
+
 /// Suppress the printing of a particular feature.
 static void suppressingFeature(PrintOptions &options, Feature feature,
                                llvm::function_ref<void()> action) {


### PR DESCRIPTION
A flag for the [pitched](https://forums.swift.org/t/proposal-draft-for-is-case-pattern-match-boolean-expressions/58260) `is case` feature. It seems better to implement the whole thing PR by PR behind a flag, than to have everything in a big PR.