### PR TITLE
Implement parameter arity reabstraction

### DIFF
--- a/include/swift/SIL/AbstractionPattern.h
+++ b/include/swift/SIL/AbstractionPattern.h
@@ -35,6 +35,7 @@ namespace clang {
 
 namespace swift {
 namespace Lowering {
+class FunctionParamGenerator;
 
 /// A pattern for the abstraction of a value.
 ///
@@ -1501,29 +1502,20 @@ public:
   /// parameters in the pattern.
   unsigned getNumFunctionParams() const;
 
-  /// Perform a parallel visitation of the parameters of a function.
-  ///
-  /// If this is a function pattern, calls handleScalar or
-  /// handleExpansion as appropriate for each parameter of the
-  /// original function, in order.
+  /// Traverses the parameters of a function, where this is the
+  /// abstraction pattern for the function (its "original type")
+  /// and the given parameters are the substituted formal parameters.
+  /// Calls the callback once for each parameter in the abstraction
+  /// pattern.
   ///
   /// If this is not a function pattern, calls handleScalar for each
-  /// parameter of the substituted function type.  Functions with
-  /// pack expansions cannot be abstracted legally this way.
+  /// parameter of the substituted function type.  Note that functions
+  /// with pack expansions cannot be legally abstracted this way; it
+  /// is not possible in Swift's ABI to support this without some sort
+  /// of dynamic argument-forwarding thunk.
   void forEachFunctionParam(AnyFunctionType::CanParamArrayRef substParams,
                             bool ignoreFinalParam,
-           llvm::function_ref<void(unsigned origParamIndex,
-                                   unsigned substParamIndex,
-                                   ParameterTypeFlags origFlags,
-                                   AbstractionPattern origParamType,
-                                   AnyFunctionType::CanParam substParam)>
-               handleScalar,
-           llvm::function_ref<void(unsigned origParamIndex,
-                                   unsigned substParamIndex,
-                                   ParameterTypeFlags origFlags,
-                                   AbstractionPattern origExpansionType,
-                          AnyFunctionType::CanParamArrayRef substParams)>
-               handleExpansion) const;
+    llvm::function_ref<void(FunctionParamGenerator &param)> function) const;
 
   /// Given that the value being abstracted is optional, return the
   /// abstraction pattern for its object type.

--- a/include/swift/SIL/AbstractionPatternGenerators.h
+++ b/include/swift/SIL/AbstractionPatternGenerators.h
@@ -1,0 +1,154 @@
+//===--- AbstractionPatternGenerators.h -------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines "generators" that can be used with an AbstractionPattern
+// to do certain kinds of traversal without using callbacks.
+// This can be useful when a traversal is required in parallel with
+// some other traversal.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_ABSTRACTIONPATTERNGENERATORS_H
+#define SWIFT_SIL_ABSTRACTIONPATTERNGENERATORS_H
+
+#include "swift/SIL/AbstractionPattern.h"
+
+namespace swift {
+namespace Lowering {
+
+/// A generator for traversing the formal function parameters of a type
+/// while properly respecting variadic generics.
+class FunctionParamGenerator {
+  // The steady state of the generator.
+
+  /// The abstraction pattern of the entire function type.  Set once
+  /// during construction.
+  AbstractionPattern origFunctionType;
+
+  /// The list of all substituted parameters to traverse.  Set once
+  /// during construction.
+  AnyFunctionType::CanParamArrayRef allSubstParams;
+
+  /// The number of orig parameters to traverse.  Set once during
+  /// construction.
+  unsigned numOrigParams;
+
+  /// The index of the current orig parameter.
+  /// Incremented during advance().
+  unsigned origParamIndex = 0;
+
+  /// The (start) index of the current subst parameters.
+  /// Incremented during advance().
+  unsigned substParamIndex = 0;
+
+  /// The number of subst parameters corresponding to the current
+  /// subst parameter.
+  unsigned numSubstParamsForOrigParam;
+
+  /// Whether the orig function type is opaque, i.e. does not permit us to
+  /// call getNumFunctionParams() and similar accessors.  Set once during
+  /// construction.
+  bool origFunctionTypeIsOpaque;
+
+  /// Whether the current orig parameter is a pack expansion.
+  bool origParamIsExpansion;
+
+  /// The abstraction pattern of the current orig parameter.
+  /// If it is a pack expansion, this is the expansion type, not the
+  /// pattern type.
+  AbstractionPattern origParamType = AbstractionPattern::getInvalid();
+
+  /// Load the informaton for the current orig parameter into the
+  /// fields above for it.
+  void loadParameter() {
+    origParamType = origFunctionType.getFunctionParamType(origParamIndex);
+    origParamIsExpansion = origParamType.isPackExpansion();
+    numSubstParamsForOrigParam =
+      (origParamIsExpansion
+         ? origParamType.getNumPackExpandedComponents()
+         : 1);
+  }
+
+public:
+  FunctionParamGenerator(AbstractionPattern origFunctionType,
+                         AnyFunctionType::CanParamArrayRef substParams,
+                         bool ignoreFinalParam);
+
+  /// Is the traversal finished?  If so, none of the getters below
+  /// are allowed to be called.
+  bool isFinished() const {
+    return origParamIndex == numOrigParams;
+  }
+
+  /// Advance to the next orig parameter.
+  void advance() {
+    assert(!isFinished());
+    origParamIndex++;
+    substParamIndex += numSubstParamsForOrigParam;
+    if (!isFinished()) loadParameter();
+  }
+
+  /// Return the index of the current orig parameter.
+  unsigned getOrigIndex() const {
+    assert(!isFinished());
+    return origParamIndex;
+  }
+
+  /// Return the index of the (first) subst parameter corresponding
+  /// to the current orig parameter.
+  unsigned getSubstIndex() const {
+    assert(!isFinished());
+    return origParamIndex;
+  }
+
+  /// Return the parameter flags for the current orig parameter.
+  ParameterTypeFlags getOrigFlags() const {
+    assert(!isFinished());
+    return (origFunctionTypeIsOpaque
+              ? allSubstParams[substParamIndex].getParameterFlags()
+              : origFunctionType.getFunctionParamFlags(origParamIndex));
+  }
+
+  /// Return the type of the current orig parameter.
+  const AbstractionPattern &getOrigType() const {
+    assert(!isFinished());
+    return origParamType;
+  }
+
+  /// Return whether the current orig parameter type is a pack expansion.
+  bool isPackExpansion() const {
+    assert(!isFinished());
+    return origParamIsExpansion;
+  }
+
+  /// Return the substituted parameters corresponding to the current
+  /// orig parameter type.  If the current orig parameter is not a
+  /// pack expansion, this will have exactly one element.
+  AnyFunctionType::CanParamArrayRef getSubstParams() const {
+    assert(!isFinished());
+    return allSubstParams.slice(substParamIndex, numSubstParamsForOrigParam);
+  }
+
+  /// Call this to finalize the traversal and assert that it was done
+  /// properly.
+  void finish() {
+    assert(isFinished() && "didn't finish the traversal");
+    assert(substParamIndex == allSubstParams.size() &&
+           "didn't exhaust subst parameters; possible missing subs on "
+           "orig function type");
+  }
+};
+
+} // end namespace Lowering
+} // end namespace swift
+
+#endif

--- a/include/swift/SIL/AbstractionPatternGenerators.h
+++ b/include/swift/SIL/AbstractionPatternGenerators.h
@@ -81,7 +81,7 @@ class FunctionParamGenerator {
 public:
   FunctionParamGenerator(AbstractionPattern origFunctionType,
                          AnyFunctionType::CanParamArrayRef substParams,
-                         bool ignoreFinalParam);
+                         bool ignoreFinalOrigParam);
 
   /// Is the traversal finished?  If so, none of the getters below
   /// are allowed to be called.

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -537,6 +537,13 @@ public:
     return SILType(castTo<TupleType>().getElementType(index), getCategory());
   }
 
+  /// Given that this is a pack type, return the lowered type of the
+  /// given pack element.  The result will have the same value
+  /// category as the base type.
+  SILType getPackElementType(unsigned index) const {
+    return SILType(castTo<SILPackType>()->getElementType(index), getCategory());
+  }
+
   /// Given that this is a pack expansion type, return the lowered type
   /// of the pattern type.  The result will have the same value category
   /// as the base type.

--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -1203,7 +1203,7 @@ unsigned AbstractionPattern::getNumFunctionParams() const {
 
 void AbstractionPattern::
 forEachFunctionParam(AnyFunctionType::CanParamArrayRef substParams,
-                     bool ignoreFinalParam,
+                     bool ignoreFinalOrigParam,
          llvm::function_ref<void(unsigned origParamIndex,
                                  unsigned substParamIndex,
                                  ParameterTypeFlags origFlags,
@@ -1216,7 +1216,7 @@ forEachFunctionParam(AnyFunctionType::CanParamArrayRef substParams,
                                  AbstractionPattern origExpansionType,
                         AnyFunctionType::CanParamArrayRef substParams)>
              handleExpansion) const {
-  FunctionParamGenerator generator(*this, substParams, ignoreFinalParam);
+  FunctionParamGenerator generator(*this, substParams, ignoreFinalOrigParam);
 
   for (; !generator.isFinished(); generator.advance()) {
     if (generator.isPackExpansion()) {
@@ -1239,7 +1239,7 @@ forEachFunctionParam(AnyFunctionType::CanParamArrayRef substParams,
 FunctionParamGenerator::FunctionParamGenerator(
                               AbstractionPattern origFunctionType,
                               AnyFunctionType::CanParamArrayRef substParams,
-                              bool ignoreFinalParam)
+                              bool ignoreFinalOrigParam)
     : origFunctionType(origFunctionType), allSubstParams(substParams) {
   origFunctionTypeIsOpaque =
     (origFunctionType.isTypeParameterOrOpaqueArchetype() ||
@@ -1249,11 +1249,8 @@ FunctionParamGenerator::FunctionParamGenerator(
     numOrigParams = allSubstParams.size();
   } else {
     numOrigParams = origFunctionType.getNumFunctionParams();
-  }
-
-  if (ignoreFinalParam) {
-    allSubstParams = allSubstParams.drop_back();
-    numOrigParams--;
+    if (ignoreFinalOrigParam)
+      numOrigParams--;
   }
 
   if (!isFinished()) loadParameter();

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -32,6 +32,7 @@
 #include "swift/ClangImporter/ClangImporter.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILType.h"
+#include "swift/SIL/AbstractionPatternGenerators.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Attr.h"
 #include "clang/AST/DeclCXX.h"
@@ -1571,21 +1572,20 @@ private:
     // Process all the non-self parameters.
     origType.forEachFunctionParam(params.drop_back(hasSelf ? 1 : 0),
                                   /*ignore final orig param*/ hasSelf,
-        [&](unsigned origParamIndex, unsigned substParamIndex,
-            ParameterTypeFlags origFlags,
-            AbstractionPattern origParamType,
-            AnyFunctionType::CanParam substParam) {
+                                  [&](FunctionParamGenerator &param) {
       // If the parameter is not a pack expansion, just pull off the
       // next parameter and destructure it in parallel with the abstraction
       // pattern for the type.
-      visit(origParamType, substParam, /*forSelf*/false);
-    },  [&](unsigned origParamIndex, unsigned substParamIndex,
-            ParameterTypeFlags origFlags,
-            AbstractionPattern origExpansionType,
-            AnyFunctionType::CanParamArrayRef substParams) {
+      if (!param.isPackExpansion()) {
+        visit(param.getOrigType(), param.getSubstParams()[0],
+              /*forSelf*/false);
+        return;
+      }
+
       // Otherwise, collect the substituted components into a pack.
+      auto origExpansionType = param.getOrigType();
       SmallVector<CanType, 8> packElts;
-      for (auto substParam : substParams) {
+      for (auto substParam : param.getSubstParams()) {
         auto substParamType = substParam.getParameterType();
         auto origParamType =
           origExpansionType.getPackExpansionComponentType(substParamType);
@@ -1598,6 +1598,7 @@ private:
       SILPackType::ExtInfo extInfo(/*address*/ indirect);
       auto packTy = SILPackType::get(TC.Context, extInfo, packElts);
 
+      auto origFlags = param.getOrigFlags();
       addPackParameter(packTy, origFlags.getValueOwnership(),
                        origFlags.isNoDerivative());
     });

--- a/lib/SIL/IR/SILFunctionType.cpp
+++ b/lib/SIL/IR/SILFunctionType.cpp
@@ -1569,7 +1569,8 @@ private:
     maybeAddForeignParameters();
 
     // Process all the non-self parameters.
-    origType.forEachFunctionParam(params, hasSelf,
+    origType.forEachFunctionParam(params.drop_back(hasSelf ? 1 : 0),
+                                  /*ignore final orig param*/ hasSelf,
         [&](unsigned origParamIndex, unsigned substParamIndex,
             ParameterTypeFlags origFlags,
             AbstractionPattern origParamType,

--- a/lib/SILGen/Cleanup.cpp
+++ b/lib/SILGen/Cleanup.cpp
@@ -444,3 +444,58 @@ CleanupCloner::cloneForTuplePackExpansionComponent(SILValue tupleAddr,
                                                  /*start at */ SILValue());
   return ManagedValue(tupleAddr, cleanup);
 }
+
+ManagedValue
+CleanupCloner::cloneForPackPackExpansionComponent(SILValue packAddr,
+                                                  CanPackType formalPackType,
+                                                  unsigned componentIndex) const {
+  if (isLValue) {
+    return ManagedValue::forLValue(packAddr);
+  }
+
+  if (!hasCleanup) {
+    return ManagedValue::forUnmanaged(packAddr);
+  }
+
+  assert(!writebackBuffer.has_value());
+  auto expansionTy = packAddr->getType().getPackElementType(componentIndex);
+  if (expansionTy.getPackExpansionPatternType().isTrivial(SGF.F))
+    return ManagedValue::forUnmanaged(packAddr);
+
+  auto cleanup =
+    SGF.enterPartialDestroyRemainingPackCleanup(packAddr, formalPackType,
+                                                componentIndex,
+                                                /*start at */ SILValue());
+  return ManagedValue(packAddr, cleanup);
+}
+
+ManagedValue
+CleanupCloner::cloneForRemainingPackComponents(SILValue packAddr,
+                                               CanPackType formalPackType,
+                                               unsigned firstComponentIndex) const {
+  if (isLValue) {
+    return ManagedValue::forLValue(packAddr);
+  }
+
+  if (!hasCleanup) {
+    return ManagedValue::forUnmanaged(packAddr);
+  }
+
+  assert(!writebackBuffer.has_value());
+  bool isTrivial = true;
+  auto packTy = packAddr->getType().castTo<SILPackType>();
+  for (auto eltTy : packTy->getElementTypes().slice(firstComponentIndex)) {
+    if (!SILType::getPrimitiveObjectType(eltTy).isTrivial(SGF.F)) {
+      isTrivial = false;
+      break;
+    }
+  }
+
+  if (isTrivial)
+    return ManagedValue::forUnmanaged(packAddr);
+
+  auto cleanup =
+    SGF.enterDestroyRemainingPackComponentsCleanup(packAddr, formalPackType,
+                                                   firstComponentIndex);
+  return ManagedValue(packAddr, cleanup);
+}

--- a/lib/SILGen/Cleanup.h
+++ b/lib/SILGen/Cleanup.h
@@ -342,6 +342,14 @@ public:
                                                    CanPackType inducedPackType,
                                                    unsigned componentIndex) const;
 
+  ManagedValue cloneForPackPackExpansionComponent(SILValue packAddr,
+                                                  CanPackType formalPackType,
+                                                  unsigned componentIndex) const;
+
+  ManagedValue cloneForRemainingPackComponents(SILValue packAddr,
+                                               CanPackType formalPackType,
+                                               unsigned firstComponentIndex) const;
+
   static void
   getClonersForRValue(SILGenFunction &SGF, const RValue &rvalue,
                       SmallVectorImpl<CleanupCloner> &resultingCloners);

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -780,7 +780,9 @@ class C : Abstractable {
 // CHECK-NEXT:   [[THUNK:%.*]] = function_ref @$sSiIegd_SiIegr_TR
 // CHECK-NEXT:   [[THUNKED_OLD_FN:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[OLD_FN]])
 // CHECK-NEXT:   [[CONVERTED_OLD_FN:%.*]] = convert_function [[THUNKED_OLD_FN]]
-// CHECK-NEXT:   store [[CONVERTED_OLD_FN]] to [init] [[TEMP]] :
+// CHECK-NEXT:   [[TEMP_ACCESS:%.*]] = begin_access [modify] [unsafe] [[TEMP]] :
+// CHECK-NEXT:   store [[CONVERTED_OLD_FN]] to [init] [[TEMP_ACCESS]] :
+// CHECK-NEXT:   end_access [[TEMP_ACCESS]]
 // CHECK-NEXT:   yield [[TEMP]] : {{.*}}, resume bb1, unwind bb2
 
 // CHECK:      bb1:


### PR DESCRIPTION
This is largely a matter of changing the main loop over subst params in `TranslateArguments` to use the generators I added, then plugging back into the general reabstraction infrastructure.
    
Because we don't have pack coroutines, we're kind of stuck in the code generation for pack reabstraction: we have to write +1 r-values into a temporary tuple and then write those tuple element addresses into the output pack.  It's not great.  We also have lifetime problems with things like non-escaping closures --- we have that problem outside of reabstraction thunks, too.
    
Other than that glaring problem, I'm feeling relatively good about the code here.  It's missing some peepholes, but it should work.  But that that's not to say that arity reabstraction works in general; my attempts to test it have been exposing some problems elsewhere, and in particular the closure case crashes, which is really bad.  But this gets a few more things working, and this PR is quite large already.