### PR TITLE
[Concurrency] Rename assertion/precondition APIs a little bit

### DIFF
--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -34,11 +34,11 @@ import SwiftShims
 ///   programming error.
 ///
 /// - Parameter executor: the expected current executor
-@available(SwiftStdlib 5.9, *) 
-public
-func preconditionTaskOnExecutor(
+@available(SwiftStdlib 5.9, *)
+@_transparent // for the is debug/release mode checks to detect the appropriate configuration
+public func preconditionOnExecutor(
     _ executor: some SerialExecutor,
-    message: @autoclosure () -> String = String(),
+    _ message: @autoclosure () -> String = String(),
     file: StaticString = #fileID, line: UInt = #line
 ) {
   guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() else {
@@ -47,7 +47,6 @@ func preconditionTaskOnExecutor(
 
   let expectationCheck = _taskIsCurrentExecutor(executor.asUnownedSerialExecutor().executor)
 
-  /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?
   precondition(expectationCheck,
       // TODO: offer information which executor we actually got
       "Incorrect actor executor assumption; Expected '\(executor)' executor. \(message())",
@@ -71,11 +70,11 @@ func preconditionTaskOnExecutor(
 ///   programming error.
 ///
 /// - Parameter actor: the actor whose serial executor we expect to be the current executor
-@available(SwiftStdlib 5.9, *) 
-public
-func preconditionTaskOnActorExecutor(
-    _ actor: some Actor,
-    message: @autoclosure () -> String = String(),
+@available(SwiftStdlib 5.9, *)
+@_transparent // for the is debug/release mode checks to detect the appropriate configuration
+public func preconditionOnExecutor(
+    of actor: some Actor,
+    _ message: @autoclosure () -> String = String(),
     file: StaticString = #fileID, line: UInt = #line
 ) {
   guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() else {
@@ -108,9 +107,9 @@ func preconditionTaskOnActorExecutor(
 ///   assumption is a serious programming error.
 ///
 /// - Parameter executor: the expected current executor
-@available(SwiftStdlib 5.9, *) 
-public
-func assertTaskOnExecutor(
+@available(SwiftStdlib 5.9, *)
+@_transparent // for the is debug/release mode checks to detect the appropriate configuration
+public func assertOnExecutor(
     _ executor: some SerialExecutor,
     _ message: @autoclosure () -> String = String(),
     file: StaticString = #fileID, line: UInt = #line
@@ -143,10 +142,10 @@ func assertTaskOnExecutor(
 ///
 ///
 /// - Parameter actor: the actor whose serial executor we expect to be the current executor
-@available(SwiftStdlib 5.9, *) 
-public
-func assertTaskOnActorExecutor(
-    _ actor: some Actor,
+@available(SwiftStdlib 5.9, *)
+@_transparent // for the is debug/release mode checks to detect the appropriate configuration
+public func assertOnExecutor(
+    of actor: some Actor,
     _ message: @autoclosure () -> String = String(),
     file: StaticString = #fileID, line: UInt = #line
 ) {
@@ -180,10 +179,9 @@ func assertTaskOnActorExecutor(
 /// if another actor uses the same serial executor--by using ``MainActor/sharedUnownedExecutor``
 /// as its own ``Actor/unownedExecutor``--this check will succeed, as from a concurrency safety
 /// perspective, the serial executor guarantees mutual exclusion of those two actors.
-@available(SwiftStdlib 5.9, *) 
+@available(SwiftStdlib 5.9, *)
 @_unavailableFromAsync(message: "await the call to the @MainActor closure directly")
-public
-func assumeOnMainActorExecutor<T>(
+public func assumeOnMainActorExecutor<T>(
     _ operation: @MainActor () throws -> T,
     file: StaticString = #fileID, line: UInt = #line
 ) rethrows -> T {
@@ -220,9 +218,8 @@ func assumeOnMainActorExecutor<T>(
 /// perspective, the serial executor guarantees mutual exclusion of those two actors.
 @available(SwiftStdlib 5.9, *)
 @_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'actor' instead")
-public
-func assumeOnActorExecutor<Act: Actor, T>(
-    _ actor: Act,
+public func assumeOnExecutor<Act: Actor, T>(
+    of actor: Act,
     _ operation: (isolated Act) throws -> T,
     file: StaticString = #fileID, line: UInt = #line
 ) rethrows -> T {

--- a/stdlib/public/Concurrency/ExecutorAssertions.swift
+++ b/stdlib/public/Concurrency/ExecutorAssertions.swift
@@ -205,6 +205,9 @@ public func assumeOnMainActorExecutor<T>(
 
 /// A safe way to synchronously assume that the current execution context belongs to the passed in actor.
 ///
+/// This method cannot be used in an asynchronous context. Instead, prefer implementing
+/// a method on the distributed actor and calling it from your asynchronous context.
+///
 /// This API should only be used as last resort, when it is not possible to express the current
 /// execution context definitely belongs to the specified actor in other ways. E.g. one may need to use
 /// this in a delegate style API, where a synchronous method is guaranteed to be called by the

--- a/stdlib/public/Concurrency/SourceCompatibilityShims.swift
+++ b/stdlib/public/Concurrency/SourceCompatibilityShims.swift
@@ -566,3 +566,81 @@ public typealias UnsafeThrowingContinuation<T> = UnsafeContinuation<T, Error>
 @available(SwiftStdlib 5.1, *)
 @available(*, deprecated, renamed: "UnownedJob")
 public typealias PartialAsyncTask = UnownedJob
+
+#if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
+@available(SwiftStdlib 5.9, *)
+@available(*, deprecated, renamed: "preconditionOnExecutor(_:_:file:line:)")
+@_transparent // for the is debug/release mode checks to detect the appropriate configuration
+public func preconditionTaskOnExecutor(
+    _ executor: some SerialExecutor,
+    message: @autoclosure () -> String = String(),
+    file: StaticString = #fileID, line: UInt = #line
+) {
+  preconditionOnExecutor(
+      executor,
+      message(),
+      file: file, line: line
+  )
+}
+
+@available(SwiftStdlib 5.9, *)
+@available(*, deprecated, renamed: "preconditionOnExecutor(of:_:file:line:)")
+@_transparent // for the is debug/release mode checks to detect the appropriate configuration
+public func preconditionTaskOnActorExecutor(
+    _ actor: some Actor,
+    message: @autoclosure () -> String = String(),
+    file: StaticString = #fileID, line: UInt = #line
+) {
+  preconditionOnExecutor(
+      of: actor,
+      message(),
+      file: file, line: line
+  )
+}
+
+@available(SwiftStdlib 5.9, *)
+@available(*, deprecated, renamed: "assertOnExecutor(_:_:file:line:)")
+@_transparent // for the is debug/release mode checks to detect the appropriate configuration
+public func assertTaskOnExecutor(
+    _ executor: some SerialExecutor,
+    _ message: @autoclosure () -> String = String(),
+    file: StaticString = #fileID, line: UInt = #line
+) {
+  assertOnExecutor(
+      executor,
+      message(),
+      file: file, line: line
+  )
+}
+
+@available(SwiftStdlib 5.9, *)
+@available(*, deprecated, renamed: "assertOnExecutor(of:_:file:line:)")
+@_transparent // for the is debug/release mode checks to detect the appropriate configuration
+public func assertTaskOnActorExecutor(
+    of actor: some Actor,
+    _ message: @autoclosure () -> String = String(),
+    file: StaticString = #fileID, line: UInt = #line
+) {
+  assertOnExecutor(
+      of: actor,
+      message(),
+      file: file, line: line
+  )
+}
+
+@available(SwiftStdlib 5.9, *)
+@available(*, deprecated, renamed: "assumeOnExecutor(of:_:file:line:)")
+@_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'actor' instead")
+@_alwaysEmitIntoClient
+public func assumeOnActorExecutor<Act: Actor, T>(
+    _ actor: Act,
+    _ operation: (isolated Act) throws -> T,
+    file: StaticString = #fileID, line: UInt = #line
+) rethrows -> T {
+  try assumeOnExecutor(
+      of: actor,
+      operation,
+      file: file, line: line
+  )
+}
+#endif // !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -115,9 +115,32 @@ public func assertOnExecutor(
 // ==== -----------------------------------------------------------------------
 // MARK: Assume APIs
 
+/// A safe way to synchronously assume that the current execution context belongs to the passed in `distributed actor`.
+///
+/// This method requires that the passed in `actor` is a local distributed actor reference.
+/// If the passed in reference is *remote*, this function will crash because it is not possible
+/// to obtain an `isolated DistributedActor` reference for a remote object as the memory used for
+/// a "complete" distributed actor object may not even have been allocated or initialized.
+///
+/// This method cannot be used in an asynchronous context. Instead, prefer implementing
+/// a method on the distributed actor and calling it from your asynchronous context.
+///
+/// This API should only be used as last resort, when it is not possible to express the current
+/// execution context definitely belongs to the main actor in other ways. E.g. one may need to use
+/// this in a delegate style API, where a synchronous method is guaranteed to be called by the
+/// main actor, however it is not possible to move some function implementation onto the target
+/// `distributed actor` for some reason.
+///
+/// - Warning: If the current executor is *not* the actor's serial executor, and the actor is local, this function will crash.
+///
+/// - Parameters:
+///   - actor: the actor whose executor is to be compared
+///   - operation: the operation that will run if the actor was local, and the current executor is the same as of the passed in actors
+/// - Returns: the result of the operation
+/// - Throws: the error the operation has thrown
 @available(SwiftStdlib 5.9, *)
 @_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'distributed actor' instead")
-public func assumeOnLocalDistributedActorExecutor<Act: DistributedActor, T>(
+public func assumeOnExecutor<Act: DistributedActor, T>(
     of actor: Act,
     _ operation: (isolated Act) throws -> T,
     file: StaticString = #fileID, line: UInt = #line

--- a/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
+++ b/test/Concurrency/Runtime/actor_assert_precondition_executor.swift
@@ -15,11 +15,11 @@
 import StdlibUnittest
 
 func checkPreconditionMainActor() /* synchronous! */ {
-  preconditionTaskOnActorExecutor(MainActor.shared)
+  preconditionOnExecutor(of: MainActor.shared)
 }
 
 func checkPreconditionFamousActor() /* synchronous! */ {
-  preconditionTaskOnActorExecutor(FamousActor.shared)
+  preconditionOnExecutor(of: FamousActor.shared)
 }
 
 @MainActor

--- a/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
+++ b/test/Concurrency/Runtime/async_taskgroup_throw_rethrow.swift
@@ -4,8 +4,6 @@
 // REQUIRES: concurrency
 // REQUIRES: reflection
 
-// REQUIRES: rdar104762037
-
 // rdar://76038845
 // REQUIRES: concurrency_runtime
 // UNSUPPORTED: back_deployment_runtime


### PR DESCRIPTION
Given good input from swift evolution, rename the precondition APIs. https://forums.swift.org/t/se-0392-custom-actor-executors/63599/14

Even though we did not ship the previous APIs, I added source compatibility shims just in case someone was using snapshots already. 