### PR TITLE
don't assert when a module re-exports a module and one of its symbols

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1358,6 +1358,9 @@ void ModuleDecl::getDisplayDecls(SmallVectorImpl<Decl*> &Results, bool Recursive
     llvm::SmallDenseMap<ModuleDecl *, SmallPtrSet<Decl *, 4>, 4> QualifiedImports;
     collectParsedExportedImports(this, Modules, QualifiedImports);
     for (const auto &QI : QualifiedImports) {
+      auto Module = QI.getFirst();
+      if (Modules.contains(Module)) continue;
+
       auto &Decls = QI.getSecond();
       Results.append(Decls.begin(), Decls.end());
     }

--- a/test/SymbolGraph/Module/DuplicateExportedImport.swift
+++ b/test/SymbolGraph/Module/DuplicateExportedImport.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend %S/Inputs/DuplicateExportedImport/A.swift -module-name A -emit-module -emit-module-path %t/A.swiftmodule
+// RUN: %target-swift-frontend %s -module-name DuplicateExportedImport -emit-module -emit-module-path /dev/null -I %t -emit-symbol-graph -emit-symbol-graph-dir %t/
+// RUN: %FileCheck %s --input-file %t/DuplicateExportedImport.symbols.json
+
+// REQUIRES: asserts
+
+// CHECK-COUNT-1: "precise":"s:1A8ClassTwoC"
+
+@_exported import A
+@_exported import class A.ClassTwo

--- a/test/SymbolGraph/Module/Inputs/DuplicateExportedImport/A.swift
+++ b/test/SymbolGraph/Module/Inputs/DuplicateExportedImport/A.swift
@@ -1,0 +1,3 @@
+public class ClassOne {}
+
+public class ClassTwo {}


### PR DESCRIPTION
Resolves rdar://106807038

SymbolGraphGen currently asserts if a module includes re-exports like the following:

```swift
@_exported import OtherModule
@_exported import class OtherModule.SomeClass
```

This is because there's a validity check in the code that handles re-exports to ensure that duplicate symbol data does not end up in the symbol graph. However, this is valid Swift and should be treated as such.

This PR updates the exported-import handler to skip qualified re-exports that come from a module that is also being re-exported as a whole. The qualified symbol in question should already be counted because it is in the module being blanket exported.