### PR TITLE
[Sema] Intro common sets of import filters to simplify calls to `getImportedModules`

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -871,6 +871,28 @@ public:
   /// \sa getImportedModules
   using ImportFilter = OptionSet<ImportFilterKind>;
 
+  /// Returns an \c ImportFilter with all elements of \c ImportFilterKind.
+  constexpr static ImportFilter getImportFilterAll() {
+    return {ImportFilterKind::Exported,
+            ImportFilterKind::Default,
+            ImportFilterKind::ImplementationOnly,
+            ImportFilterKind::PackageOnly,
+            ImportFilterKind::SPIOnly,
+            ImportFilterKind::ShadowedByCrossImportOverlay};
+  }
+
+  /// Import kinds visible to the module declaring them.
+  ///
+  /// This leaves out \c ShadowedByCrossImportOverlay as even if present in
+  /// the sources it's superseded by the cross-overlay as the local import.
+  constexpr static ImportFilter getImportFilterLocal() {
+    return {ImportFilterKind::Exported,
+            ImportFilterKind::Default,
+            ImportFilterKind::ImplementationOnly,
+            ImportFilterKind::PackageOnly,
+            ImportFilterKind::SPIOnly};
+  }
+
   /// Looks up which modules are imported by this module.
   ///
   /// \p filter controls whether public, private, or any imports are included

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4434,14 +4434,8 @@ namespace {
         llvm::SmallVector<ValueDecl *> results;
         llvm::SmallVector<ImportedModule> importedModules;
 
-        ModuleDecl::ImportFilter moduleImportFilter = ModuleDecl::ImportFilterKind::Default;
-        moduleImportFilter |= ModuleDecl::ImportFilterKind::Exported;
-        moduleImportFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
-        moduleImportFilter |= ModuleDecl::ImportFilterKind::PackageOnly;
-        moduleImportFilter |= ModuleDecl::ImportFilterKind::SPIOnly;
-        moduleImportFilter |= ModuleDecl::ImportFilterKind::ShadowedByCrossImportOverlay;
-
-        mainModule->getImportedModules(importedModules, moduleImportFilter);
+        mainModule->getImportedModules(importedModules,
+                                       ModuleDecl::getImportFilterAll());
 
         for (auto &import : importedModules) {
           if (import.importedModule->isNonSwiftModule())

--- a/lib/FrontendTool/ImportedModules.cpp
+++ b/lib/FrontendTool/ImportedModules.cpp
@@ -83,11 +83,7 @@ bool swift::emitImportedModules(ModuleDecl *mainModule,
     if (!clangImporter->importBridgingHeader(implicitHeaderPath, mainModule)) {
       SmallVector<ImportedModule, 16> imported;
       clangImporter->getImportedHeaderModule()->getImportedModules(
-          imported, {ModuleDecl::ImportFilterKind::Exported,
-                     ModuleDecl::ImportFilterKind::Default,
-                     ModuleDecl::ImportFilterKind::ImplementationOnly,
-                     ModuleDecl::ImportFilterKind::PackageOnly,
-                     ModuleDecl::ImportFilterKind::SPIOnly});
+          imported, ModuleDecl::getImportFilterLocal());
 
       for (auto IM : imported) {
         if (auto clangModule = IM.importedModule->findUnderlyingClangModule())

--- a/lib/FrontendTool/LoadedModuleTrace.cpp
+++ b/lib/FrontendTool/LoadedModuleTrace.cpp
@@ -110,13 +110,7 @@ static bool contains(const SetLike &setLike, Item item) {
 /// By default, all imports are included.
 static void getImmediateImports(
     ModuleDecl *module, SmallPtrSetImpl<ModuleDecl *> &imports,
-    ModuleDecl::ImportFilter importFilter = {
-        ModuleDecl::ImportFilterKind::Exported,
-        ModuleDecl::ImportFilterKind::Default,
-        ModuleDecl::ImportFilterKind::ImplementationOnly,
-        ModuleDecl::ImportFilterKind::PackageOnly,
-        ModuleDecl::ImportFilterKind::SPIOnly,
-        ModuleDecl::ImportFilterKind::ShadowedByCrossImportOverlay}) {
+    ModuleDecl::ImportFilter importFilter = ModuleDecl::getImportFilterAll()) {
   SmallVector<ImportedModule, 8> importList;
   module->getImportedModules(importList, importFilter);
 

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1284,9 +1284,7 @@ void swift::ide::deliverCompletionResults(
   {
     // Collect modules directly imported in this SourceFile.
     SmallVector<ImportedModule, 4> directImport;
-    SF.getImportedModules(directImport,
-                          {ModuleDecl::ImportFilterKind::Default,
-                           ModuleDecl::ImportFilterKind::ImplementationOnly});
+    SF.getImportedModules(directImport, ModuleDecl::getImportFilterLocal());
     for (auto import : directImport)
       explictlyImportedModules.insert(import.importedModule);
 
@@ -1383,14 +1381,7 @@ void swift::ide::deliverCompletionResults(
 
       // Add results for all imported modules.
       SmallVector<ImportedModule, 4> Imports;
-      SF.getImportedModules(
-          Imports, {
-                       ModuleDecl::ImportFilterKind::Exported,
-                       ModuleDecl::ImportFilterKind::Default,
-                       ModuleDecl::ImportFilterKind::ImplementationOnly,
-                       ModuleDecl::ImportFilterKind::PackageOnly,
-                       ModuleDecl::ImportFilterKind::SPIOnly,
-                   });
+      SF.getImportedModules(Imports, ModuleDecl::getImportFilterLocal());
 
       for (auto Imported : Imports) {
         for (auto Import : namelookup::getAllImports(Imported.importedModule))

--- a/lib/IDE/CompletionLookup.cpp
+++ b/lib/IDE/CompletionLookup.cpp
@@ -306,9 +306,7 @@ void CompletionLookup::collectImportedModules(
   SmallVector<ImportedModule, 16> Imported;
   SmallVector<ImportedModule, 16> FurtherImported;
   CurrDeclContext->getParentSourceFile()->getImportedModules(
-      Imported, {ModuleDecl::ImportFilterKind::Exported,
-                 ModuleDecl::ImportFilterKind::Default,
-                 ModuleDecl::ImportFilterKind::ImplementationOnly});
+      Imported, ModuleDecl::getImportFilterLocal());
 
   for (ImportedModule &imp : Imported)
     directImportedModules.insert(imp.importedModule->getNameStr());

--- a/lib/IDE/ImportDepth.cpp
+++ b/lib/IDE/ImportDepth.cpp
@@ -34,12 +34,8 @@ ImportDepth::ImportDepth(ASTContext &context,
     auxImports.insert(pair.first);
 
   // Private imports from this module.
-  // FIXME: only the private imports from the current source file.
-  // FIXME: ImportFilterKind::ShadowedByCrossImportOverlay?
   SmallVector<ImportedModule, 16> mainImports;
-  main->getImportedModules(mainImports,
-                           {ModuleDecl::ImportFilterKind::Default,
-                            ModuleDecl::ImportFilterKind::ImplementationOnly});
+  main->getImportedModules(mainImports, ModuleDecl::getImportFilterLocal());
   for (auto &import : mainImports) {
     uint8_t depth = 1;
     if (auxImports.count(import.importedModule->getName().str()))

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -2046,10 +2046,8 @@ void IRGenDebugInfoImpl::finalize() {
   // Get the list of imported modules (which may actually be different
   // from all ImportDecls).
   SmallVector<ImportedModule, 8> ModuleWideImports;
-  IGM.getSwiftModule()->getImportedModules(
-      ModuleWideImports, {ModuleDecl::ImportFilterKind::Exported,
-                          ModuleDecl::ImportFilterKind::Default,
-                          ModuleDecl::ImportFilterKind::ImplementationOnly});
+  IGM.getSwiftModule()->getImportedModules(ModuleWideImports,
+                                           ModuleDecl::getImportFilterLocal());
   for (auto M : ModuleWideImports)
     if (!ImportedModules.count(M.importedModule))
       createImportedModule(MainFile, M, MainFile, 0);

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -129,10 +129,8 @@ public:
 
   void
   getImportedModules(SmallVectorImpl<ImportedModule> &Modules) const {
-    constexpr ModuleDecl::ImportFilter ImportFilter = {
-        ModuleDecl::ImportFilterKind::Exported,
-        ModuleDecl::ImportFilterKind::Default,
-        ModuleDecl::ImportFilterKind::ImplementationOnly};
+    constexpr ModuleDecl::ImportFilter ImportFilter =
+      ModuleDecl::getImportFilterLocal();
 
     if (auto *SF = SFOrMod.dyn_cast<SourceFile *>()) {
       SF->getImportedModules(Modules, ImportFilter);

--- a/lib/Index/IndexRecord.cpp
+++ b/lib/Index/IndexRecord.cpp
@@ -898,10 +898,8 @@ recordSourceFileUnit(SourceFile *primarySourceFile, StringRef indexUnitToken,
 
   // Module dependencies.
   SmallVector<ImportedModule, 8> imports;
-  primarySourceFile->getImportedModules(
-      imports, {ModuleDecl::ImportFilterKind::Exported,
-                ModuleDecl::ImportFilterKind::Default,
-                ModuleDecl::ImportFilterKind::ImplementationOnly});
+  primarySourceFile->getImportedModules(imports,
+                                        ModuleDecl::getImportFilterLocal());
   StringScratchSpace moduleNameScratch;
   addModuleDependencies(imports, indexStorePath, indexClangModules,
                         indexSystemModules, skipStdlib, includeLocals,

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1206,13 +1206,9 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   if (!options.ModuleInterface.empty())
     ModuleInterface.emit(ScratchRecord, options.ModuleInterface);
 
-  SmallVector<ImportedModule, 8> allImports;
-  M->getImportedModules(allImports,
-                        {ModuleDecl::ImportFilterKind::Exported,
-                         ModuleDecl::ImportFilterKind::Default,
-                         ModuleDecl::ImportFilterKind::ImplementationOnly,
-                         ModuleDecl::ImportFilterKind::PackageOnly});
-  ImportedModule::removeDuplicates(allImports);
+  SmallVector<ImportedModule, 8> allLocalImports;
+  M->getImportedModules(allLocalImports, ModuleDecl::getImportFilterLocal());
+  ImportedModule::removeDuplicates(allLocalImports);
 
   // Collect the public and private imports as a subset so that we can
   // distinguish them.
@@ -1232,7 +1228,7 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   // Make sure the bridging header module is always at the top of the import
   // list, mimicking how it is processed before any module imports when
   // compiling source files.
-  if (llvm::is_contained(allImports, bridgingHeaderImport)) {
+  if (llvm::is_contained(allLocalImports, bridgingHeaderImport)) {
     off_t importedHeaderSize = 0;
     time_t importedHeaderModTime = 0;
     std::string contents;
@@ -1252,7 +1248,7 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   }
 
   ModuleDecl *theBuiltinModule = M->getASTContext().TheBuiltinModule;
-  for (auto import : allImports) {
+  for (auto import : allLocalImports) {
     if (import.importedModule == theBuiltinModule ||
         import.importedModule == bridgingHeaderModule) {
       continue;


### PR DESCRIPTION
To get the imports from a module we need to call `getImportedModules` with the kind of imports we want. With the recent addition of new kinds of imports this has become cumbersome. In most case we either want all imports or all imports from the local module. Let's simplify this logic by offering common sets of imports. Advanced call sites can still list the desired imports as needed.