### PR TITLE
Do not load modules of the same package if built from interface

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1005,6 +1005,11 @@ ERROR(module_not_testable,Fatal,
 ERROR(module_not_compiled_for_private_import,none,
       "module %0 was not compiled for private import", (Identifier))
 
+ERROR(in_package_module_not_compiled_from_source,Fatal,
+      "module %0 is in package '%1' but was built from interface '%2'; "
+      "modules of the same package can only be loaded if built from source",
+      (Identifier, StringRef, StringRef))
+
 ERROR(import_restriction_conflict,none,
       "module %0 cannot be both "
       "%select{implementation-only|SPI only|exported}1 and "

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -798,8 +798,18 @@ LoadedFile *SerializedModuleLoaderBase::loadAST(
       M.setABIName(Ctx.getIdentifier(loadedModuleFile->getModuleABIName()));
     if (loadedModuleFile->isConcurrencyChecked())
       M.setIsConcurrencyChecked();
-    if (!loadedModuleFile->getModulePackageName().empty())
+    if (!loadedModuleFile->getModulePackageName().empty()) {
+      if (loadedModuleFile->isBuiltFromInterface() &&
+          loadedModuleFile->getModulePackageName().str() == Ctx.LangOpts.PackageName) {
+        Ctx.Diags.diagnose(SourceLoc(),
+                           diag::in_package_module_not_compiled_from_source,
+                           M.getBaseIdentifier(),
+                           Ctx.LangOpts.PackageName,
+                           loadedModuleFile->getModuleSourceFilename()
+                           );
+      }
       M.setPackageName(Ctx.getIdentifier(loadedModuleFile->getModulePackageName()));
+    }
     M.setUserModuleVersion(loadedModuleFile->getUserModuleVersion());
     for (auto name: loadedModuleFile->getAllowableClientNames()) {
       M.addAllowableClientName(Ctx.getIdentifier(name));

--- a/test/Serialization/load_package_module.swift
+++ b/test/Serialization/load_package_module.swift
@@ -1,0 +1,40 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// RUN: %target-swift-frontend -module-name LibFromInterface -emit-module -emit-module-interface-path %t/LibFromInterface.swiftinterface -parse-as-library %t/Lib.swift -enable-library-evolution -package-name mypkg -swift-version 5
+// RUN: test -f %t/LibFromInterface.swiftinterface
+// RUN: %FileCheck %s -check-prefix CHECK-LIB < %t/LibFromInterface.swiftinterface
+// CHECK-LIB: -package-name mypkg
+// CHECK-LIB-NOT: func log(level: Int)
+
+// RUN: not %target-swift-frontend -module-name ClientInSamePkg %t/ClientLoadInterfaceModule.swift -emit-module -emit-module-path %t/ClientInSamePkg.swiftmodule -package-name mypkg -I %t 2> %t/resultA.output
+// RUN: %FileCheck %s -check-prefix CHECK-A < %t/resultA.output
+// CHECK-A: error: module 'LibFromInterface' is in package 'mypkg' but was built from interface '{{.*}}LibFromInterface.swiftinterface'; modules of the same package can only be loaded if built from source
+
+// RUN: not %target-swift-frontend -module-name ClientInDiffPkg %t/ClientLoadInterfaceModule.swift -emit-module -emit-module-path %t/ClientInDiffPkg.swiftmodule -package-name otherPkg -I %t 2> %t/resultB.output
+// RUN: %FileCheck %s -check-prefix CHECK-B < %t/resultB.output
+// CHECK-B: error: cannot find 'log' in scope
+
+// RUN: %target-swift-frontend -module-name LibFromSource -emit-module -emit-module-path %t/LibFromSource.swiftmodule -parse-as-library %t/Lib.swift -package-name mypkg
+// RUN: test -f %t/LibFromSource.swiftmodule
+
+// RUN: %target-swift-frontend -module-name ClientInSamePkgSrc %t/ClientLoadSourceModule.swift -emit-module -emit-module-path %t/ClientInSamePkgSrc.swiftmodule -package-name mypkg -I %t
+// RUN: test -f %t/ClientInSamePkgSrc.swiftmodule
+
+//--- Lib.swift
+package func log(level: Int) {}
+
+//--- ClientLoadInterfaceModule.swift
+import LibFromInterface
+
+func someFun() {
+  log(level: 1)
+}
+
+//--- ClientLoadSourceModule.swift
+import LibFromSource
+
+func someFun() {
+  log(level: 1)
+}
+


### PR DESCRIPTION
- Do not load modules of the same package if built from interface
- Show diagnostics with an interface path
Resolves rdar://104617990
