### PR TITLE
[CSFix] Diagnose an invalid member reference in ambiguous contexts

### DIFF
--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -1474,6 +1474,8 @@ public:
   ValueDecl *getMember() const { return Member; }
 
   DeclNameRef getMemberName() const { return Name; }
+
+  bool diagnoseForAmbiguity(CommonFixesArray commonFixes) const override;
 };
 
 class AllowMemberRefOnExistential final : public AllowInvalidMemberRef {

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -947,6 +947,21 @@ bool AllowMemberRefOnExistential::diagnose(const Solution &solution,
   return failure.diagnose(asNote);
 }
 
+bool AllowInvalidMemberRef::diagnoseForAmbiguity(
+    CommonFixesArray commonFixes) const {
+  auto *primaryFix =
+      static_cast<const AllowInvalidMemberRef *>(commonFixes.front().second);
+
+  Type baseTy = primaryFix->getBaseType();
+  for (const auto &entry : commonFixes) {
+    auto *memberFix = static_cast<const AllowInvalidMemberRef *>(entry.second);
+    if (!baseTy->isEqual(memberFix->getBaseType()))
+      return false;
+  }
+
+  return diagnose(*commonFixes.front().first);
+}
+
 bool AllowTypeOrInstanceMember::diagnose(const Solution &solution,
                                          bool asNote) const {
   AllowTypeOrInstanceMemberFailure failure(solution, getBaseType(), getMember(),

--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -471,3 +471,18 @@ func testAnyObjectConstruction(_ x: AnyObject) {
   // FIXME: This should also be rejected.
   _ = type(of: x).init()
 }
+
+// rdar://102412006 - failed to produce a diagnostic for invalid member ref
+class AmbiguityA : NSObject {
+  @objc class var testProp: A { get { A() } }
+}
+
+
+class AmbuguityB : NSObject {
+  @objc class var testProp: B { get { B() } }
+}
+
+do {
+  func test(_: AnyObject?) {}
+  test(.testProp) // expected-error {{static member 'testProp' cannot be used on protocol metatype '(any AnyObject).Type'}}
+}


### PR DESCRIPTION
For example @objc lookup could find multiple instance members on `AnyObject`. 
It should be allowed to diagnose issues with that as non-ambiguous if all fixes 
have the same kind/base type.

Resolves: rdar://102412006

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
