### PR TITLE
[ClangImporter] Probe for a PCH when the header is missing

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1051,6 +1051,7 @@ std::unique_ptr<clang::CompilerInvocation> ClangImporter::createClangInvocation(
     CIOpts.Diags = clangDiags;
     CIOpts.RecoverOnError = false;
     CIOpts.CC1Args = CC1Args;
+    CIOpts.ProbePrecompiled = true;
     CI = clang::createInvocation(invocationArgs, std::move(CIOpts));
   }
 

--- a/lib/IDETool/CompilerInvocation.cpp
+++ b/lib/IDETool/CompilerInvocation.cpp
@@ -280,6 +280,7 @@ bool ide::initInvocationByClangArguments(ArrayRef<const char *> ArgList,
   // Create a new Clang compiler invocation.
   clang::CreateInvocationOptions CIOpts;
   CIOpts.Diags = ClangDiags;
+  CIOpts.ProbePrecompiled = true;
   std::unique_ptr<clang::CompilerInvocation> ClangInvok =
       clang::createInvocation(ClangArgList, std::move(CIOpts));
   if (!ClangInvok || ClangDiags->hasErrorOccurred()) {

--- a/test/ClangImporter/pch-loaded-from-header-name.swift
+++ b/test/ClangImporter/pch-loaded-from-header-name.swift
@@ -1,0 +1,23 @@
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/pch)
+// RUN: split-file %s %t
+
+// Precompile a header into a separate directory and check that it can be
+// loaded via its original header name, even if the header isn't adjacent
+// to the PCH. This used to be the default, but was changed in clang 16
+// (see `CreateInvocationOptions::ProbePrecompiled`).
+
+// RUN: %target-swift-frontend -emit-pch %t/header.h -o %t/pch/header.h.pch
+// RUN: %target-swift-frontend -verify -typecheck %t/use.swift -Xcc -include -Xcc %t/pch/header.h -import-objc-header %t/empty.h
+
+//--- empty.h
+
+//--- header.h
+void headerFunc();
+
+//--- use.swift
+func useHeaderFunc() {
+  headerFunc()
+}


### PR DESCRIPTION
The default for `ProbePrecompiled` was changed in rebranch. Set it back to `true` to avoid breaking existing clients.

Resolves rdar://106966024.