### PR TITLE
[interop] ensure IRGen reaches code referenced through destructor inv…

### DIFF
--- a/lib/IRGen/GenClangDecl.cpp
+++ b/lib/IRGen/GenClangDecl.cpp
@@ -67,6 +67,13 @@ public:
     return true;
   }
 
+  bool VisitCXXDeleteExpr(clang::CXXDeleteExpr *deleteExpr) {
+    if (auto cxxRecord = deleteExpr->getDestroyedType()->getAsCXXRecordDecl())
+      if (auto dtor = cxxRecord->getDestructor())
+        callback(dtor);
+    return true;
+  }
+
   bool VisitVarDecl(clang::VarDecl *VD) {
     if (auto cxxRecord = VD->getType()->getAsCXXRecordDecl())
       if (auto dtor = cxxRecord->getDestructor())

--- a/test/Interop/Cxx/class/delete-operator-destructor-ref-irgen.swift
+++ b/test/Interop/Cxx/class/delete-operator-destructor-ref-irgen.swift
@@ -1,0 +1,48 @@
+// RUN: rm -rf %t
+// RUN: split-file %s %t
+// RUN: %target-swiftxx-frontend -emit-ir -I %t/Inputs -validate-tbd-against-ir=none %t/test.swift | %FileCheck %s
+
+//--- Inputs/module.modulemap
+module DestroyedUsingDelete {
+  header "test.h"
+  requires cplusplus
+}
+//--- Inputs/test.h
+
+extern void referencedSymbol();
+inline void emittedIntoSwiftObject() { referencedSymbol(); }
+
+class BaseClass {
+public:
+    inline ~BaseClass() {
+        emittedIntoSwiftObject();
+    }
+
+    int x;
+};
+
+class Container {
+public:
+    Container() : pointer(new BaseClass) {}
+    ~Container() { delete pointer; }
+
+    inline int method() const {
+        return 42;
+    }
+private:
+    BaseClass *pointer;
+};
+
+
+//--- test.swift
+
+import DestroyedUsingDelete
+
+public func test() {
+  let i = Container()
+  i.method()
+}
+
+// Make sure we reach destructor accessible from `delete` statement.
+
+// CHECK: define linkonce_odr{{( dso_local)?}} void @{{_Z22emittedIntoSwiftObjectv|"\?emittedIntoSwiftObject@@YAXXZ"}}


### PR DESCRIPTION
…oked using the 'delete' statement in C++
