### PR TITLE
Add a verify-di-hole assertion to SILBuilder.

### DIFF
--- a/include/swift/SIL/SILDebugScope.h
+++ b/include/swift/SIL/SILDebugScope.h
@@ -66,6 +66,9 @@ public:
   /// into.
   SILFunction *getParentFunction() const;
 
+  /// Determine whether other is an (indirect) parent of this scope.
+  bool isAncestor(const SILDebugScope *other) const;
+
   /// If this is a debug scope associated with an inlined call site, return the
   /// SILLocation associated with the call site resulting from the final
   /// inlining.

--- a/lib/SIL/IR/SILBuilder.cpp
+++ b/lib/SIL/IR/SILBuilder.cpp
@@ -28,6 +28,22 @@ SILBuilder::SILBuilder(SILGlobalVariable *GlobVar,
   setInsertionPoint(&GlobVar->StaticInitializerBlock);
 }
 
+void SILBuilder::setCurrentDebugScope(const SILDebugScope *DS) {
+#ifndef NDEBUG
+  if (EnableDIHoleVerification && DS != CurDebugScope) {
+    // Detect a situation where:
+    // PrevDebugScope = sil_scope(parent: CurDebugScope)
+    // CurDebugScope = sil_scope(parent:)
+    // DS = PrevDebugScope
+    if (DS && DS == PrevDebugScope)
+      assert(!CurDebugScope->isAncestor(PrevDebugScope) &&
+             "attempting to re-enter scope within same basic block");
+    PrevDebugScope = CurDebugScope;
+  }
+#endif
+  CurDebugScope = DS;
+}
+
 IntegerLiteralInst *SILBuilder::createIntegerLiteral(IntegerLiteralExpr *E) {
   return insert(IntegerLiteralInst::create(E, getSILDebugLocation(E),
                                            getModule()));
@@ -241,6 +257,9 @@ void SILBuilder::emitBlock(SILBasicBlock *BB, SILLocation BranchLoc) {
 /// instruction) then split the block at that instruction and return the
 /// continuation block.
 SILBasicBlock *SILBuilder::splitBlockForFallthrough() {
+#ifndef NDEBUG
+  PrevDebugScope = nullptr;
+#endif
   // If we are concatenating, just create and return a new block.
   if (insertingAtEndOfBlock()) {
     return getFunction().createBasicBlockAfter(BB);

--- a/lib/SIL/IR/SILDebugScope.cpp
+++ b/lib/SIL/IR/SILDebugScope.cpp
@@ -37,6 +37,17 @@ SILDebugScope::SILDebugScope(SILLocation Loc, SILFunction *SILFn,
 SILDebugScope::SILDebugScope(SILLocation Loc)
     : Loc(Loc), InlinedCallSite(nullptr) {}
 
+bool SILDebugScope::isAncestor(const SILDebugScope *other) const {
+  while (other) {
+    auto Parent = other->Parent;
+    auto *ParentScope = Parent.dyn_cast<const SILDebugScope *>();
+    if (ParentScope == this)
+      return true;
+    other = ParentScope;
+  }
+  return false;
+}
+
 SILFunction *SILDebugScope::getInlinedFunction() const {
   if (Parent.isNull())
     return nullptr;

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -6272,22 +6272,7 @@ public:
 
       // Otherwise, we're allowed to re-enter a scope only if
       // the scope is an ancestor of the scope we're currently leaving.
-      auto isAncestorScope = [](const SILDebugScope *Cur,
-                                const SILDebugScope *Previous) {
-        assert(Cur && "null current scope queried");
-        assert(Previous && "null previous scope queried");
-        const SILDebugScope *Tmp = Previous;
-        while (Tmp) {
-          auto Parent = Tmp->Parent;
-          auto *ParentScope = Parent.dyn_cast<const SILDebugScope *>();
-          if (ParentScope == Cur)
-            return true;
-          Tmp = ParentScope;
-        }
-        return false;
-      };
-
-      if (isAncestorScope(DS, LastSeenScope)) {
+      if (DS->isAncestor(LastSeenScope)) {
         LastSeenScope = DS;
         LastSeenScopeInst = &SI;
         continue;

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -1,3 +1,5 @@
+
+
 //===--- SILGenBuilder.cpp ------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
@@ -36,15 +38,27 @@ SILGenModule &SILGenBuilder::getSILGenModule() const { return SGF.SGM; }
 //===----------------------------------------------------------------------===//
 
 SILGenBuilder::SILGenBuilder(SILGenFunction &SGF)
-    : SILBuilder(SGF.F), SGF(SGF) {}
+    : SILBuilder(SGF.F), SGF(SGF) {
+#ifndef NDEBUG
+    EnableDIHoleVerification = true;
+#endif
+}
 
 SILGenBuilder::SILGenBuilder(SILGenFunction &SGF, SILBasicBlock *insertBB,
                              SmallVectorImpl<SILInstruction *> *insertedInsts)
-    : SILBuilder(insertBB, insertedInsts), SGF(SGF) {}
+    : SILBuilder(insertBB, insertedInsts), SGF(SGF) {
+#ifndef NDEBUG
+    EnableDIHoleVerification = true;
+#endif
+}
 
 SILGenBuilder::SILGenBuilder(SILGenFunction &SGF, SILBasicBlock *insertBB,
                              SILBasicBlock::iterator insertInst)
-    : SILBuilder(insertBB, insertInst), SGF(SGF) {}
+    : SILBuilder(insertBB, insertInst), SGF(SGF) {
+#ifndef NDEBUG
+    EnableDIHoleVerification = true;
+#endif
+}
 
 //===----------------------------------------------------------------------===//
 //                             Managed Value APIs

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -55,7 +55,11 @@ public:
   SILGenBuilder(SILGenBuilder &builder, SILBasicBlock *insertBB)
       : SILBuilder(insertBB, builder.getCurrentDebugScope(),
                    builder.getBuilderContext()),
-        SGF(builder.SGF) {}
+        SGF(builder.SGF) {
+#ifndef NDEBUG
+    EnableDIHoleVerification = true;
+#endif
+  }
 
   SILGenModule &getSILGenModule() const;
   SILGenFunction &getSILGenFunction() const { return SGF; }


### PR DESCRIPTION
The verify-di-hole SILVerifier pass is very useful in catching incorrectly set SILDebugScopes, but it can be very tedious to track down the root cause of a verification failure. This patch replicates much of its functionality inside an assertion in SILBuilder, which will result in a backtrace pointing directly to where the offending scope is being set.
