### PR TITLE
[CopyPropagation] Canonicalize moved-from values.

### DIFF
--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -282,13 +282,16 @@ static bool convertExtractsToDestructures(CanonicalDefWorklist &copiedDefs,
 /// the lifetime at it), replace its uses with uses of the moved-from value and
 /// delete it.
 static bool eliminateRedundantMove(MoveValueInst *mvi,
-                                   InstructionDeleter &deleter) {
+                                   InstructionDeleter &deleter,
+                                   CanonicalDefWorklist &defWorklist) {
   if (!isRedundantMoveValue(mvi))
     return false;
-  mvi->replaceAllUsesWith(mvi->getOperand());
+  auto original = mvi->getOperand();
+  mvi->replaceAllUsesWith(original);
   // Call InstructionDeleter::forceDeleteWithUsers to avoid "fixing up"
   // ownership of the moved-from value, i.e. inserting a destroy_value.
   deleter.forceDeleteWithUsers(mvi);
+  defWorklist.updateForCopy(original);
   return true;
 }
 
@@ -512,12 +515,12 @@ void CopyPropagation::run() {
           hoistDestroysOfOwnedLexicalValue(folded, *f, deleter, calleeAnalysis);
       // Keep running even if the new move's destroys can't be hoisted.
       (void)hoisted;
-      eliminateRedundantMove(folded, deleter);
+      eliminateRedundantMove(folded, deleter, defWorklist);
       firstRun = false;
     }
   }
   for (auto *mvi : moveValues) {
-    eliminateRedundantMove(mvi, deleter);
+    eliminateRedundantMove(mvi, deleter, defWorklist);
   }
   for (auto *argument : f->getArguments()) {
     if (argument->getOwnershipKind() == OwnershipKind::Owned) {

--- a/test/SILOptimizer/copy_propagation.sil
+++ b/test/SILOptimizer/copy_propagation.sil
@@ -874,6 +874,26 @@ entry:
   return %retval : $()
 }
 
+// Canonicalize the moved-from value when a move_value is deemed redundant and
+// eliminated.
+// CHECK-LABEL: sil [ossa] @canonicalize_source_of_redundant_move_value : {{.*}} {
+// CHECK:         [[GET_OWNED_C:%[^,]+]] = function_ref @getOwnedC
+// CHECK:         [[TAKE_OWNED_C:%[^,]+]] = function_ref @takeOwnedC
+// CHECK:         [[C:%[^,]+]] = apply [[GET_OWNED_C]]() : $@convention(thin) () -> @owned C
+// CHECK:         apply [[TAKE_OWNED_C]]([[C]]) : $@convention(thin) (@owned C) -> ()
+// CHECK-LABEL: } // end sil function 'canonicalize_source_of_redundant_move_value'
+sil [ossa] @canonicalize_source_of_redundant_move_value : $@convention(thin) () -> () {
+  %getOwnedC = function_ref @getOwnedC : $@convention(thin) () -> (@owned C)
+  %takeOwnedC = function_ref @takeOwnedC : $@convention(thin) (@owned C) -> ()
+  %c = apply %getOwnedC() : $@convention(thin) () -> (@owned C)
+  %c2 = move_value %c : $C
+  %c3 = copy_value %c2 : $C
+  apply %takeOwnedC(%c3) : $@convention(thin) (@owned C) -> ()
+  destroy_value %c2 : $C
+  %retval = tuple ()
+  return %retval : $()
+}
+
 // Verify that a dead copy_value is deleted.
 // CHECK-LABEL: sil [ossa] @delete_dead_reborrow_copy : {{.*}} {
 // CHECK-NOT:     copy_value


### PR DESCRIPTION
If a `move_value` is determined to be redundant and removed, take the opportunity its removal makes available to canonicalize the moved-from value without the obstruction of the `move_value`.

rdar://106996304