### PR TITLE
[ConstraintSystem] Enforce `TVO_CanBindToPack`, and diagnose pack references outside of pack expansion expressions.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5317,8 +5317,9 @@ ERROR(expansion_not_allowed,none,
 ERROR(expansion_not_variadic,none,
       "pack expansion %0 must contain at least one pack reference", (Type))
 ERROR(pack_reference_outside_expansion,none,
-      "pack reference %0 can only appear in pack expansion or generic requirement",
-      (Type))
+      "pack reference %0 can only appear in pack expansion "
+      "%select{or generic requirement|}1",
+      (Type, /*inExpression*/ bool))
 ERROR(each_non_pack,none,
       "'each' cannot be applied to non-pack type %0",
       (Type))

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -428,6 +428,9 @@ enum class FixKind : uint8_t {
 
   /// Allow 'each' applied to a non-pack type.
   AllowInvalidPackElement,
+
+  /// Allow pack references outside of pack expansions.
+  AllowInvalidPackReference,
 };
 
 class ConstraintFix {
@@ -2096,6 +2099,30 @@ public:
 
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::AllowInvalidPackElement;
+  }
+};
+
+class AllowInvalidPackReference final : public ConstraintFix {
+  Type packType;
+
+  AllowInvalidPackReference(ConstraintSystem &cs, Type packType,
+                            ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowInvalidPackReference, locator),
+        packType(packType) {}
+
+public:
+  std::string getName() const override {
+    return "allow pack outside pack expansion";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static AllowInvalidPackReference *create(ConstraintSystem &cs,
+                                           Type packType,
+                                           ConstraintLocator *locator);
+
+  static bool classof(const ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowInvalidPackReference;
   }
 };
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6146,6 +6146,12 @@ bool InvalidPackElement::diagnoseAsError() {
   return true;
 }
 
+bool InvalidPackReference::diagnoseAsError() {
+  emitDiagnostic(diag::pack_reference_outside_expansion,
+                 packType, /*inExpression*/true);
+  return true;
+}
+
 bool CollectionElementContextualFailure::diagnoseAsError() {
   auto anchor = getRawAnchor();
   auto *locator = getLocator();

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1851,6 +1851,19 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose pack references outside of pack expansion expressions.
+class InvalidPackReference final : public FailureDiagnostic {
+  Type packType;
+
+public:
+  InvalidPackReference(const Solution &solution, Type packType,
+                       ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator),
+        packType(packType) {}
+
+  bool diagnoseAsError() override;
+};
+
 /// Diagnose a contextual mismatch between expected collection element type
 /// and the one provided (e.g. source of the assignment or argument to a call)
 /// e.g.:

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1401,6 +1401,19 @@ AllowInvalidPackElement::create(ConstraintSystem &cs,
       AllowInvalidPackElement(cs, packElementType, locator);
 }
 
+bool AllowInvalidPackReference::diagnose(const Solution &solution,
+                                         bool asNote) const {
+  InvalidPackReference failure(solution, packType, getLocator());
+  return failure.diagnose(asNote);
+}
+
+AllowInvalidPackReference *
+AllowInvalidPackReference::create(ConstraintSystem &cs, Type packType,
+                                  ConstraintLocator *locator) {
+  return new (cs.getAllocator())
+      AllowInvalidPackReference(cs, packType, locator);
+}
+
 bool CollectionElementContextualMismatch::diagnose(const Solution &solution,
                                                    bool asNote) const {
   CollectionElementContextualFailure failure(

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -923,9 +923,14 @@ namespace {
             CS.getConstraintLocator(expr, ConstraintLocator::Member),
             TVO_CanBindToHole);
       }
+      unsigned options = (TVO_CanBindToLValue |
+                          TVO_CanBindToNoEscape);
+      if (!PackElementEnvironments.empty())
+        options |= TVO_CanBindToPack;
+
       auto tv = CS.createTypeVariable(
                   CS.getConstraintLocator(expr, ConstraintLocator::Member),
-                  TVO_CanBindToLValue | TVO_CanBindToNoEscape);
+                  options);
       SmallVector<OverloadChoice, 4> outerChoices;
       for (auto decl : outerAlternatives) {
         outerChoices.push_back(OverloadChoice(Type(), decl, functionRefKind));
@@ -1419,11 +1424,14 @@ namespace {
         return invalidateReference();
       }
 
+      unsigned options = (TVO_CanBindToLValue |
+                          TVO_CanBindToNoEscape);
+      if (!PackElementEnvironments.empty())
+        options |= TVO_CanBindToPack;
+
       // Create an overload choice referencing this declaration and immediately
       // resolve it. This records the overload for use later.
-      auto tv = CS.createTypeVariable(locator,
-                                      TVO_CanBindToLValue |
-                                      TVO_CanBindToNoEscape);
+      auto tv = CS.createTypeVariable(locator, options);
 
       OverloadChoice choice =
           OverloadChoice(Type(), E->getDecl(), E->getFunctionRefKind());
@@ -3099,8 +3107,15 @@ namespace {
     Type visitPackElementExpr(PackElementExpr *expr) {
       auto packType = CS.getType(expr->getPackRefExpr());
 
-      if (PackElementEnvironments.empty())
-        return Type();
+      // If 'each t' is written outside of a pack expansion expression, allow the
+      // type to bind to a hole. The invalid pack reference will be diagnosed when
+      // attempting to bind the type variable for the underlying pack reference to
+      // a pack type without TVO_CanBindToPack.
+      if (PackElementEnvironments.empty()) {
+        return CS.createTypeVariable(CS.getConstraintLocator(expr),
+                                     TVO_CanBindToHole |
+                                     TVO_CanBindToNoEscape);
+      }
 
       // The type of a PackElementExpr is the opened pack element archetype
       // of the pack reference.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -4598,7 +4598,7 @@ NeverNullType TypeResolver::resolvePackElement(PackElementTypeRepr *repr,
   if (!options.contains(TypeResolutionFlags::AllowPackReferences)) {
     ctx.Diags.diagnose(repr->getLoc(),
                        diag::pack_reference_outside_expansion,
-                       packReference);
+                       packReference, /*inExpression*/false);
     return ErrorType::get(ctx);
   }
 

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -202,3 +202,25 @@ func takesFunctionPack<each T, R>(functions: repeat ((each T) -> R)) {}
 func forwardFunctionPack<each T>(functions: repeat (each T) -> Bool) {
   takesFunctionPack(functions: repeat each functions)
 }
+
+func packOutsideExpansion<each T>(_ t: repeat each T) {
+  _ = t
+  // expected-error@-1{{pack reference 'T' can only appear in pack expansion}}
+
+  forward(t)
+  // expected-error@-1{{pack reference 'T' can only appear in pack expansion}}
+
+  _ = each t
+  // expected-error@-1{{pack reference 'T' can only appear in pack expansion}}
+
+  forward(each t)
+  // expected-error@-1{{pack reference 'T' can only appear in pack expansion}}
+
+  let tuple = (repeat each t)
+
+  _ = tuple.element
+  // expected-error@-1{{pack reference 'T' can only appear in pack expansion}}
+
+  _ = each tuple.element
+  // expected-error@-1{{pack reference 'T' can only appear in pack expansion}}
+}


### PR DESCRIPTION
This changes catches the mistake of referencing a value pack without any keywords or with `each` outside of a pack expansion expression:

```swift
func packOutsideExpansion<each T>(_ t: repeat each T) {
  _ = t // error: pack reference 'T' can only appear in pack expansion
  _ = each t // error: pack reference 'T' can only appear in pack expansion
}
```

This is done by enforcing `TVO_CanBindToPack` when binding a type variable to a fixed type. If the binding is a `PackType` or a `PackArchetypeType`, solving the constraint will either fail, or apply a constraint fix in diagnostic mode for the invalid pack reference. During CSGen, type variables for decl refs and unresolved dot refs will be marked as `TVO_CanBindToPack` if there is an enclosing pack expansion expression.

This subsumes https://github.com/apple/swift/pull/61777