### PR TITLE
[Concurrency] Distributed actor's unownedExecutor should be optional

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4533,6 +4533,7 @@ public:
 
   /// Fetch this class's unownedExecutor property, if it has one.
   const VarDecl *getUnownedExecutorProperty() const;
+  const VarDecl *getLocalUnownedExecutorProperty() const;
 
   /// Is this the NSObject class type?
   bool isNSObject() const;

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -232,6 +232,7 @@ IDENTIFIER(_defaultActorInitialize)
 IDENTIFIER(_defaultActorDestroy)
 IDENTIFIER(unownedExecutor)
 IDENTIFIER(localUnownedExecutor)
+IDENTIFIER(_unwrapLocalUnownedExecutor)
 
 IDENTIFIER_(ErrorType)
 IDENTIFIER(Code)

--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -231,6 +231,7 @@ IDENTIFIER(className)
 IDENTIFIER(_defaultActorInitialize)
 IDENTIFIER(_defaultActorDestroy)
 IDENTIFIER(unownedExecutor)
+IDENTIFIER(localUnownedExecutor)
 
 IDENTIFIER_(ErrorType)
 IDENTIFIER(Code)

--- a/include/swift/AST/KnownSDKDecls.def
+++ b/include/swift/AST/KnownSDKDecls.def
@@ -20,6 +20,7 @@
 #endif
 
 KNOWN_SDK_FUNC_DECL(Distributed, IsRemoteDistributedActor, "__isRemoteActor")
+KNOWN_SDK_FUNC_DECL(Distributed, IsLocalDistributedActor, "__isLocalActor")
 
 #undef KNOWN_SDK_FUNC_DECL
 

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -1273,6 +1273,7 @@ public:
   const SILBasicBlock *getEntryBlock() const { return &front(); }
 
   SILBasicBlock *createBasicBlock();
+  SILBasicBlock *createBasicBlock(llvm::StringRef debugName);
   SILBasicBlock *createBasicBlockAfter(SILBasicBlock *afterBB);
   SILBasicBlock *createBasicBlockBefore(SILBasicBlock *beforeBB);
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -9625,6 +9625,29 @@ const VarDecl *ClassDecl::getUnownedExecutorProperty() const {
   return nullptr;
 }
 
+const VarDecl *ClassDecl::getLocalUnownedExecutorProperty() const {
+  auto &C = getASTContext();
+
+  if (!isDistributedActor())
+    return nullptr;
+
+  llvm::SmallVector<ValueDecl *, 2> results;
+  this->lookupQualified(getSelfNominalTypeDecl(),
+                        DeclNameRef(C.Id_localUnownedExecutor),
+                        NL_ProtocolMembers,
+                        results);
+
+  for (auto candidate: results) {
+    if (isa<ProtocolDecl>(candidate->getDeclContext()))
+      continue;
+
+    if (VarDecl *var = dyn_cast<VarDecl>(candidate))
+      return var;
+  }
+
+  return nullptr;
+}
+
 bool ClassDecl::isRootDefaultActor() const {
   return isRootDefaultActor(getModuleContext(), ResilienceExpansion::Maximal);
 }

--- a/lib/SIL/IR/SILFunction.cpp
+++ b/lib/SIL/IR/SILFunction.cpp
@@ -533,6 +533,13 @@ SILBasicBlock *SILFunction::createBasicBlock() {
   return newBlock;
 }
 
+SILBasicBlock *SILFunction::createBasicBlock(llvm::StringRef debugName) {
+  SILBasicBlock *newBlock = new (getModule()) SILBasicBlock(this);
+  newBlock->setDebugName(debugName);
+  BlockList.push_back(newBlock);
+  return newBlock;
+}
+
 SILBasicBlock *SILFunction::createBasicBlockAfter(SILBasicBlock *afterBB) {
   SILBasicBlock *newBlock = new (getModule()) SILBasicBlock(this);
   BlockList.insertAfter(afterBB->getIterator(), newBlock);

--- a/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
+++ b/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
@@ -192,6 +192,7 @@ SILValue LowerHopToActor::emitGetExecutor(SILBuilderWithScope &B,
                      KnownProtocolKind::DistributedActor :
                      KnownProtocolKind::Actor;
     auto actorProtocol = ctx.getProtocol(actorKind);
+    bool optionalExecutor = false;
     auto req = getUnownedExecutorGetter(ctx, actorProtocol);
     assert(req && "Concurrency library broken");
     SILDeclRef fn(req, SILDeclRef::Kind::Func);
@@ -214,8 +215,6 @@ SILValue LowerHopToActor::emitGetExecutor(SILBuilderWithScope &B,
     auto executorDecl = ctx.getUnownedSerialExecutorDecl();
     auto executorProps = executorDecl->getStoredProperties();
     assert(executorProps.size() == 1);
-    fprintf(stderr, "[%s:%d](%s) executorProps = \n", __FILE_NAME__, __LINE__, __FUNCTION__);
-    executorProps[0]->dump();
     unmarkedExecutor =
       B.createStructExtract(loc, witnessCall, executorProps[0]);
   }

--- a/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
+++ b/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
@@ -154,6 +154,28 @@ static AccessorDecl *getUnownedExecutorGetter(ASTContext &ctx,
   return nullptr;
 }
 
+static AccessorDecl *getUnwrapLocalUnownedExecutorGetter(ASTContext &ctx,
+                                              ProtocolDecl *actorProtocol) {
+  for (auto member: actorProtocol->getAllMembers()) { // FIXME: remove this, just go to the extension
+    if (auto var = dyn_cast<VarDecl>(member)) {
+      if (var->getName() == ctx.Id__unwrapLocalUnownedExecutor)
+        return var->getAccessor(AccessorKind::Get);
+    }
+  }
+
+  for (auto extension: actorProtocol->getExtensions()) {
+    for (auto member: extension->getAllMembers()) {
+      if (auto var = dyn_cast<VarDecl>(member)) {
+        if (var->getName() == ctx.Id__unwrapLocalUnownedExecutor) {
+          return var->getAccessor(AccessorKind::Get);
+        }
+      }
+    }
+  }
+
+  return nullptr;
+}
+
 SILValue LowerHopToActor::emitGetExecutor(SILBuilderWithScope &B,
                                           SILLocation loc, SILValue actor,
                                           bool makeOptional) {
@@ -186,13 +208,37 @@ SILValue LowerHopToActor::emitGetExecutor(SILBuilderWithScope &B,
     unmarkedExecutor =
       B.createBuiltin(loc, builtinName, resultType, subs, {actor});
 
-  // Otherwise, go through (Distributed)Actor.unownedExecutor.
-  } else {
-    auto actorKind = actorType->isDistributedActor() ?
-                     KnownProtocolKind::DistributedActor :
-                     KnownProtocolKind::Actor;
+    // Otherwise, go through Actor.unownedExecutor.
+  } else if (actorType->isDistributedActor()) {
+    auto actorKind = KnownProtocolKind::DistributedActor;
     auto actorProtocol = ctx.getProtocol(actorKind);
-    bool optionalExecutor = false;
+    auto req = getUnwrapLocalUnownedExecutorGetter(ctx, actorProtocol);
+    assert(req && "Distributed library broken");
+    SILDeclRef fn(req, SILDeclRef::Kind::Func);
+
+    auto actorConf = module->lookupConformance(actorType, actorProtocol);
+    assert(actorConf &&
+           "hop_to_executor with distributed actor that doesn't conform to DistributedActor");
+
+    auto subs = SubstitutionMap::get(req->getGenericSignature(),
+                                     {actorType}, {actorConf});
+    auto fnType = F->getModule().Types.getConstantFunctionType(*F, fn);
+
+    auto witness =
+      B.createWitnessMethod(loc, actorType, actorConf, fn,
+                            SILType::getPrimitiveObjectType(fnType));
+    auto witnessCall = B.createApply(loc, witness, subs, {actor});
+
+    // The protocol requirement returns an Optional<UnownedSerialExecutor>;
+    // extract the Builtin.Executor from it.
+    auto executorDecl = ctx.getUnownedSerialExecutorDecl();
+    auto executorProps = executorDecl->getStoredProperties();
+    assert(executorProps.size() == 1);
+    unmarkedExecutor =
+      B.createStructExtract(loc, witnessCall, executorProps[0]);
+  } else {
+    auto actorKind = KnownProtocolKind::Actor;
+    auto actorProtocol = ctx.getProtocol(actorKind);
     auto req = getUnownedExecutorGetter(ctx, actorProtocol);
     assert(req && "Concurrency library broken");
     SILDeclRef fn(req, SILDeclRef::Kind::Func);

--- a/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
+++ b/lib/SILOptimizer/Mandatory/LowerHopToActor.cpp
@@ -186,7 +186,7 @@ SILValue LowerHopToActor::emitGetExecutor(SILBuilderWithScope &B,
     unmarkedExecutor =
       B.createBuiltin(loc, builtinName, resultType, subs, {actor});
 
-  // Otherwise, go through Actor.unownedExecutor.
+  // Otherwise, go through (Distributed)Actor.unownedExecutor.
   } else {
     auto actorKind = actorType->isDistributedActor() ?
                      KnownProtocolKind::DistributedActor :
@@ -214,6 +214,8 @@ SILValue LowerHopToActor::emitGetExecutor(SILBuilderWithScope &B,
     auto executorDecl = ctx.getUnownedSerialExecutorDecl();
     auto executorProps = executorDecl->getStoredProperties();
     assert(executorProps.size() == 1);
+    fprintf(stderr, "[%s:%d](%s) executorProps = \n", __FILE_NAME__, __LINE__, __FUNCTION__);
+    executorProps[0]->dump();
     unmarkedExecutor =
       B.createStructExtract(loc, witnessCall, executorProps[0]);
   }

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -674,6 +674,37 @@ GuardStmt *DerivedConformance::returnFalseIfNotEqualGuard(ASTContext &C,
   auto falseExpr = new (C) BooleanLiteralExpr(false, SourceLoc(), true);
   return returnIfNotEqualGuard(C, lhsExpr, rhsExpr, falseExpr);
 }
+/// Returns a generated guard statement that checks whether the given expr is true.
+/// If it is false, the else block for the guard returns `nil`.
+/// \p C The AST context.
+/// \p testExpr The expression that should be tested.
+/// \p baseType The wrapped type of the to-be-returned Optional<Wrapped>.
+GuardStmt *DerivedConformance::returnNilIfFalseGuardTypeChecked(ASTContext &C,
+                                        Expr *testExpr,
+                                        Type optionalWrappedType) {
+  auto trueExpr = new (C) BooleanLiteralExpr(true, SourceLoc(), /*implicit=*/true);
+  auto nilExpr = new (C) NilLiteralExpr(SourceLoc(), /*implicit=*/true);
+  nilExpr->setType(optionalWrappedType->wrapInOptionalType());
+
+  SmallVector<StmtConditionElement, 1> conditions;
+  SmallVector<ASTNode, 1> statements;
+
+  auto returnStmt = new (C) ReturnStmt(SourceLoc(), nilExpr);
+  statements.push_back(returnStmt);
+
+  // Next, generate the condition being checked.
+//  auto cmpFuncExpr = new (C) UnresolvedDeclRefExpr(
+//      DeclNameRef(C.Id_EqualsOperator), DeclRefKind::BinaryOperator,
+//      DeclNameLoc());
+//  auto *cmpExpr = BinaryExpr::create(C, lhsExpr, cmpFuncExpr, rhsExpr,
+//      /*implicit*/ true);
+  conditions.emplace_back(testExpr);
+
+  // Build and return the complete guard statement.
+  // guard lhs == rhs else { return lhs < rhs }
+  auto body = BraceStmt::create(C, SourceLoc(), statements, SourceLoc());
+  return new (C) GuardStmt(SourceLoc(), C.AllocateCopy(conditions), body);
+}
 /// Returns a generated guard statement that checks whether the given lhs and
 /// rhs expressions are equal. If not equal, the else block for the guard
 /// returns lhs < rhs.

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -335,11 +335,11 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
 
     // Actor.unownedExecutor
     if (name.isSimpleName(ctx.Id_unownedExecutor)) {
-      if (nominal->isDistributedActor()) {
-        return getRequirement(KnownProtocolKind::DistributedActor);
-      } else {
+//      if (nominal->isDistributedActor()) {
+//        return getRequirement(KnownProtocolKind::DistributedActor);
+//      } else {
         return getRequirement(KnownProtocolKind::Actor);
-      }
+//      }
     }
 
     // DistributedActor.id
@@ -349,6 +349,11 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
     // DistributedActor.actorSystem
     if (name.isSimpleName(ctx.Id_actorSystem))
       return getRequirement(KnownProtocolKind::DistributedActor);
+
+    // DistributedActor.localUnownedExecutor
+    if (name.isSimpleName(ctx.Id_localUnownedExecutor)) {
+      return getRequirement(KnownProtocolKind::DistributedActor);
+    }
 
     return nullptr;
   }
@@ -682,7 +687,6 @@ GuardStmt *DerivedConformance::returnFalseIfNotEqualGuard(ASTContext &C,
 GuardStmt *DerivedConformance::returnNilIfFalseGuardTypeChecked(ASTContext &C,
                                         Expr *testExpr,
                                         Type optionalWrappedType) {
-  auto trueExpr = new (C) BooleanLiteralExpr(true, SourceLoc(), /*implicit=*/true);
   auto nilExpr = new (C) NilLiteralExpr(SourceLoc(), /*implicit=*/true);
   nilExpr->setType(optionalWrappedType->wrapInOptionalType());
 

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -335,11 +335,7 @@ ValueDecl *DerivedConformance::getDerivableRequirement(NominalTypeDecl *nominal,
 
     // Actor.unownedExecutor
     if (name.isSimpleName(ctx.Id_unownedExecutor)) {
-//      if (nominal->isDistributedActor()) {
-//        return getRequirement(KnownProtocolKind::DistributedActor);
-//      } else {
-        return getRequirement(KnownProtocolKind::Actor);
-//      }
+      return getRequirement(KnownProtocolKind::Actor);
     }
 
     // DistributedActor.id

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -409,6 +409,12 @@ public:
   // return false
   static GuardStmt *returnFalseIfNotEqualGuard(ASTContext &C, Expr *lhsExpr,
                                                Expr *rhsExpr);
+
+  // Return `nil` is the `testExp` is `false`.
+  static GuardStmt *returnNilIfFalseGuardTypeChecked(ASTContext &C,
+                                                     Expr *testExpr,
+                                                     Type optionalWrappedType);
+
   // return lhs < rhs
   static GuardStmt *
   returnComparisonIfNotEqualGuard(ASTContext &C, Expr *lhsExpr, Expr *rhsExpr);

--- a/lib/Sema/TypeCheckDeclOverride.cpp
+++ b/lib/Sema/TypeCheckDeclOverride.cpp
@@ -2039,8 +2039,8 @@ static bool checkSingleOverride(ValueDecl *override, ValueDecl *base) {
               cast<ClassDecl>(prop->getDeclContext())->isActor() &&
               !prop->isStatic() &&
               prop->getName() == ctx.Id_unownedExecutor &&
-              prop->getInterfaceType()->getAnyNominal() ==
-                ctx.getUnownedSerialExecutorDecl());
+              prop->getName() == ctx.Id_localUnownedExecutor &&
+              prop->getInterfaceType()->getAnyNominal() == ctx.getUnownedSerialExecutorDecl());
     };
 
     if (isActorUnownedExecutor()) {

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -101,7 +101,8 @@ public struct UnownedSerialExecutor: Sendable {
   @usableFromInline
   internal var executor: Builtin.Executor
 
-  @_spi(ConcurrencyExecutors)
+  /// SPI: Do not use. Cannot be marked @_spi, since we need to use it from Distributed module
+  /// which needs to reach for this from an @_transparent function which prevents @_spi use.
   @available(SwiftStdlib 5.9, *)
   public var _executor: Builtin.Executor {
     self.executor

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -110,7 +110,6 @@ public struct UnownedSerialExecutor: Sendable {
   #endif
 
   @inlinable
-  // @_spi(ConcurrencyExecutors) // FIXME:!!!!
   public init(_ executor: Builtin.Executor) {
     #if compiler(>=5.5) && $BuiltinExecutor
     self.executor = executor

--- a/stdlib/public/Concurrency/Executor.swift
+++ b/stdlib/public/Concurrency/Executor.swift
@@ -110,7 +110,8 @@ public struct UnownedSerialExecutor: Sendable {
   #endif
 
   @inlinable
-  internal init(_ executor: Builtin.Executor) {
+  // @_spi(ConcurrencyExecutors) // FIXME:!!!!
+  public init(_ executor: Builtin.Executor) {
     #if compiler(>=5.5) && $BuiltinExecutor
     self.executor = executor
     #endif

--- a/stdlib/public/Distributed/DistributedActor.swift
+++ b/stdlib/public/Distributed/DistributedActor.swift
@@ -254,8 +254,11 @@ public protocol DistributedActor: AnyActor, Identifiable, Hashable
   /// eliminated, and rearranged with other work, and they may even
   /// be introduced when not strictly required.  Visible side effects
   /// are therefore strongly discouraged within this property.
+//  @available(SwiftStdlib 5.9, *)
+//  nonisolated var localUnownedExecutor: UnownedSerialExecutor? { get }
+
   @available(SwiftStdlib 5.9, *)
-  nonisolated var unownedExecutor: UnownedSerialExecutor { get }
+  nonisolated var unownedExecutor: UnownedSerialExecutor? { get }
 
   /// Resolves the passed in `id` against the `system`, returning
   /// either a local or remote actor reference.

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -11,13 +11,115 @@
 //===----------------------------------------------------------------------===//
 
 import Swift
-@_spi(ConcurrencyExecutors) import _Concurrency
+import _Concurrency
+
+// ==== -----------------------------------------------------------------------
+// MARK: Precondition APIs
+
+/// Unconditionally if the current task is executing on the serial executor of the passed in `actor`,
+/// and if not crash the program offering information about the executor mismatch.
+///
+/// This function's effect varies depending on the build flag used:
+///
+/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+///   configuration), stops program execution in a debuggable state after
+///   printing `message`.
+///
+/// * In `-O` builds (the default for Xcode's Release configuration), stops
+///   program execution.
+///
+/// * In `-Ounchecked` builds, the optimizer may assume that this function is
+///   never called. Failure to satisfy that assumption is a serious
+///   programming error.
+///
+/// - Parameter actor: the actor whose serial executor we expect to be the current executor
+@available(SwiftStdlib 5.9, *)
+public func preconditionOnExecutor(
+    of actor: some DistributedActor,
+    _ message: @autoclosure () -> String = String(),
+    file: StaticString = #fileID, line: UInt = #line
+) {
+  guard _isDebugAssertConfiguration() || _isReleaseAssertConfiguration() else {
+    return
+  }
+
+  guard __isLocalActor(actor) else {
+    return
+  }
+
+  guard let unownedExecutor = actor.unownedExecutor else {
+    preconditionFailure(
+        "Incorrect actor executor assumption; Distributed actor \(actor) is 'local' but has no executor!",
+        file: file, line: line)
+  }
+
+  let expectationCheck = _taskIsCurrentExecutor(unownedExecutor._executor) // FIXME: !!!!!!
+
+  // TODO: offer information which executor we actually got
+  precondition(expectationCheck,
+      // TODO: figure out a way to get the typed repr out of the unowned executor
+      "Incorrect actor executor assumption; Expected '\(unownedExecutor)' executor. \(message())",
+      file: file, line: line)
+}
+
+// ==== -----------------------------------------------------------------------
+// MARK: Assert APIs
+
+/// Performs an executor check in debug builds.
+///
+/// * In playgrounds and `-Onone` builds (the default for Xcode's Debug
+///   configuration): If `condition` evaluates to `false`, stop program
+///   execution in a debuggable state after printing `message`.
+///
+/// * In `-O` builds (the default for Xcode's Release configuration),
+///   `condition` is not evaluated, and there are no effects.
+///
+/// * In `-Ounchecked` builds, `condition` is not evaluated, but the optimizer
+///   may assume that it *always* evaluates to `true`. Failure to satisfy that
+///   assumption is a serious programming error.
+///
+///
+/// - Parameter actor: the actor whose serial executor we expect to be the current executor
+@available(SwiftStdlib 5.9, *)
+@_transparent
+public func assertOnExecutor(
+    of actor: some DistributedActor,
+    _ message: @autoclosure () -> String = String(),
+    file: StaticString = #fileID, line: UInt = #line
+) {
+  guard _isDebugAssertConfiguration() else {
+    return
+  }
+
+  guard __isLocalActor(actor) else {
+    return
+  }
+
+
+  guard let unownedExecutor = actor.unownedExecutor else {
+    preconditionFailure(
+        "Incorrect actor executor assumption; Distributed actor \(actor) is 'local' but has no executor!",
+        file: file, line: line)
+  }
+
+  guard _taskIsCurrentExecutor(unownedExecutor._executor) else { // FIXME: !!!!!
+    // TODO: offer information which executor we actually got
+    // TODO: figure out a way to get the typed repr out of the unowned executor
+    let msg = "Incorrect actor executor assumption; Expected '\(unownedExecutor)' executor. \(message())"
+    /// TODO: implement the logic in-place perhaps rather than delegating to precondition()?
+    assertionFailure(msg, file: file, line: line) // short-cut so we get the exact same failure reporting semantics
+    return
+  }
+}
+
+
+// ==== -----------------------------------------------------------------------
+// MARK: Assume APIs
 
 @available(SwiftStdlib 5.9, *)
 @_unavailableFromAsync(message: "express the closure as an explicit function declared on the specified 'distributed actor' instead")
-public
-func assumeOnLocalDistributedActorExecutor<Act: DistributedActor, T>(
-    _ actor: Act,
+public func assumeOnLocalDistributedActorExecutor<Act: DistributedActor, T>(
+    of actor: Act,
     _ operation: (isolated Act) throws -> T,
     file: StaticString = #fileID, line: UInt = #line
 ) rethrows -> T {
@@ -30,7 +132,9 @@ func assumeOnLocalDistributedActorExecutor<Act: DistributedActor, T>(
 
   /// This is guaranteed to be fatal if the check fails,
   /// as this is our "safe" version of this API.
-  let executor: Builtin.Executor = actor.unownedExecutor._executor
+  guard let executor: Builtin.Executor = actor.unownedExecutor?._executor else {
+    fatalError("Distributed local actor MUST have executor, but was nil")
+  }
   guard _taskIsCurrentExecutor(executor) else {
     // TODO: offer information which executor we actually got when
     fatalError("Incorrect actor executor assumption; Expected same executor as \(actor).", file: file, line: line)

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -101,7 +101,7 @@ public func assertOnExecutor(
         file: file, line: line)
   }
 
-  guard _taskIsCurrentExecutor(unownedExecutor._executor) else { // FIXME: !!!!!
+  guard _taskIsCurrentExecutor(unownedExecutor._executor) else {
     // TODO: offer information which executor we actually got
     // TODO: figure out a way to get the typed repr out of the unowned executor
     let msg = "Incorrect actor executor assumption; Expected '\(unownedExecutor)' executor. \(message())"

--- a/stdlib/public/Distributed/DistributedAssertions.swift
+++ b/stdlib/public/Distributed/DistributedAssertions.swift
@@ -47,13 +47,13 @@ public func preconditionOnExecutor(
     return
   }
 
-  guard let unownedExecutor = actor.unownedExecutor else {
+  guard let unownedExecutor = actor.localUnownedExecutor else {
     preconditionFailure(
         "Incorrect actor executor assumption; Distributed actor \(actor) is 'local' but has no executor!",
         file: file, line: line)
   }
 
-  let expectationCheck = _taskIsCurrentExecutor(unownedExecutor._executor) // FIXME: !!!!!!
+  let expectationCheck = _taskIsCurrentExecutor(unownedExecutor._executor)
 
   // TODO: offer information which executor we actually got
   precondition(expectationCheck,
@@ -95,8 +95,7 @@ public func assertOnExecutor(
     return
   }
 
-
-  guard let unownedExecutor = actor.unownedExecutor else {
+  guard let unownedExecutor = actor.localUnownedExecutor else {
     preconditionFailure(
         "Incorrect actor executor assumption; Distributed actor \(actor) is 'local' but has no executor!",
         file: file, line: line)
@@ -132,10 +131,10 @@ public func assumeOnLocalDistributedActorExecutor<Act: DistributedActor, T>(
 
   /// This is guaranteed to be fatal if the check fails,
   /// as this is our "safe" version of this API.
-  guard let executor: Builtin.Executor = actor.unownedExecutor?._executor else {
+  guard let executor = actor.localUnownedExecutor else {
     fatalError("Distributed local actor MUST have executor, but was nil")
   }
-  guard _taskIsCurrentExecutor(executor) else {
+  guard _taskIsCurrentExecutor(executor._executor) else {
     // TODO: offer information which executor we actually got when
     fatalError("Incorrect actor executor assumption; Expected same executor as \(actor).", file: file, line: line)
   }

--- a/test/Distributed/Runtime/distributed_actor_cross_module_final_class_adhoc_requirement_not_optimized_away.swift
+++ b/test/Distributed/Runtime/distributed_actor_cross_module_final_class_adhoc_requirement_not_optimized_away.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -parse-as-library -emit-library -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems %S/../Inputs/FakeDistributedActorSystems.swift -o %t/%target-library-name(FakeDistributedActorSystems)
-// RUN: %target-build-swift -target %target-cpu-apple-macosx10.15 -parse-as-library -lFakeDistributedActorSystems -module-name main -I %t -L %t %s -o %t/a.out
+// RUN: %target-build-swift -target %target-cpu-apple-macosx13.0 -parse-as-library -emit-library -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems %S/../Inputs/FakeDistributedActorSystems.swift -o %t/%target-library-name(FakeDistributedActorSystems)
+// RUN: %target-build-swift -target %target-cpu-apple-macosx13.0 -parse-as-library -lFakeDistributedActorSystems -module-name main -I %t -L %t %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --color
 
 // REQUIRES: OS=macosx && (CPU=x86_64 || CPU=arm64)

--- a/test/Distributed/Runtime/distributed_actor_custom_executor_basic.swift
+++ b/test/Distributed/Runtime/distributed_actor_custom_executor_basic.swift
@@ -22,7 +22,7 @@ import FakeDistributedActorSystems
 typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
 distributed actor Worker {
-  nonisolated var unownedExecutor: UnownedSerialExecutor {
+  nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
     print("get unowned executor")
     return MainActor.sharedUnownedExecutor
   }

--- a/test/Distributed/Runtime/distributed_actor_executor_asserts.swift
+++ b/test/Distributed/Runtime/distributed_actor_executor_asserts.swift
@@ -1,0 +1,80 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: freestanding
+
+// FIXME(distributed): Distributed actors currently have some issues on windows rdar://82593574
+// UNSUPPORTED: OS=windows-msvc
+
+//import StdlibUnittest
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+distributed actor MainWorker: Worker {
+  nonisolated var unownedExecutor: UnownedSerialExecutor? {
+    print("get unowned executor")
+    return MainActor.sharedUnownedExecutor
+  }
+}
+
+distributed actor NormalWorker: Worker {
+  // empty on purpose, default executor
+}
+
+protocol Worker: DistributedActor {
+}
+
+extension Worker {
+  distributed func preconditionSameExecutor(as other: some Worker) {
+    preconditionOnExecutor(of: other, "Expected for [\(self)] share executor with [\(other)]")
+  }
+}
+
+@main struct Main {
+  static func main() async {
+//    let tests = TestSuite("AssumeDistributedActorExecutor")
+
+//    if #available(SwiftStdlib 5.9, *) {
+      let system = DefaultDistributedActorSystem()
+
+      let normalLocalWorker = NormalWorker(actorSystem: system)
+      precondition(__isLocalActor(normalLocalWorker), "must be local")
+
+      let normalRemoteWorker = try! NormalWorker.resolve(id: normalLocalWorker.id, using: system)
+      precondition(__isRemoteActor(normalRemoteWorker), "must be remote")
+
+//      if #available(SwiftStdlib 5.9, *) {
+//        precondition(normalLocalWorker.id == normalRemoteWorker.id, "IDs must be equal")
+//
+//        tests.test("exactly the same actor") {
+//          try! await normalLocalWorker.preconditionSameExecutor(as: normalLocalWorker)
+//        }
+//
+//        tests.test("different normal local worker, not same executor") {
+//          expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected 'UnownedSerialExecutor(executor: (Opaque Value))' executor. Expected for [main.NormalWorker] share executor with main.NormalWorker")
+//          let other = NormalWorker(actorSystem: system)
+//          try! await normalLocalWorker.preconditionSameExecutor(as: other)
+//        }
+//
+//        tests.test("remote actor reference should have nil executor") {
+          precondition(normalRemoteWorker.unownedExecutor == nil,
+              "Expected nil executor but was: \(String(describing: normalRemoteWorker.unownedExecutor))")
+//        }
+//      }
+//    }
+//
+//    await runAllTestsAsync()
+  }
+}

--- a/test/Distributed/Runtime/distributed_actor_executor_asserts.swift
+++ b/test/Distributed/Runtime/distributed_actor_executor_asserts.swift
@@ -16,7 +16,7 @@
 // FIXME(distributed): Distributed actors currently have some issues on windows rdar://82593574
 // UNSUPPORTED: OS=windows-msvc
 
-//import StdlibUnittest
+import StdlibUnittest
 import Distributed
 import FakeDistributedActorSystems
 
@@ -44,9 +44,9 @@ extension Worker {
 
 @main struct Main {
   static func main() async {
-//    let tests = TestSuite("AssumeDistributedActorExecutor")
+    let tests = TestSuite("AssumeDistributedActorExecutor")
 
-//    if #available(SwiftStdlib 5.9, *) {
+    if #available(SwiftStdlib 5.9, *) {
       let system = DefaultDistributedActorSystem()
 
       let normalLocalWorker = NormalWorker(actorSystem: system)
@@ -55,26 +55,26 @@ extension Worker {
       let normalRemoteWorker = try! NormalWorker.resolve(id: normalLocalWorker.id, using: system)
       precondition(__isRemoteActor(normalRemoteWorker), "must be remote")
 
-//      if #available(SwiftStdlib 5.9, *) {
-//        precondition(normalLocalWorker.id == normalRemoteWorker.id, "IDs must be equal")
-//
-//        tests.test("exactly the same actor") {
-//          try! await normalLocalWorker.preconditionSameExecutor(as: normalLocalWorker)
-//        }
-//
-//        tests.test("different normal local worker, not same executor") {
-//          expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected 'UnownedSerialExecutor(executor: (Opaque Value))' executor. Expected for [main.NormalWorker] share executor with main.NormalWorker")
-//          let other = NormalWorker(actorSystem: system)
-//          try! await normalLocalWorker.preconditionSameExecutor(as: other)
-//        }
-//
-//        tests.test("remote actor reference should have nil executor") {
+      if #available(SwiftStdlib 5.9, *) {
+        precondition(normalLocalWorker.id == normalRemoteWorker.id, "IDs must be equal")
+
+        tests.test("exactly the same actor") {
+          try! await normalLocalWorker.preconditionSameExecutor(as: normalLocalWorker)
+        }
+
+        tests.test("different normal local worker, not same executor") {
+          expectCrashLater(withMessage: "Incorrect actor executor assumption; Expected 'UnownedSerialExecutor(executor: (Opaque Value))' executor. Expected for [main.NormalWorker] share executor with main.NormalWorker")
+          let other = NormalWorker(actorSystem: system)
+          try! await normalLocalWorker.preconditionSameExecutor(as: other)
+        }
+
+        tests.test("remote actor reference should have nil executor") {
           precondition(normalRemoteWorker.localUnownedExecutor == nil,
-              "Expected nil executor but was: \(String(describing: normalRemoteWorker.unownedExecutor))")
-//        }
-//      }
-//    }
-//
-//    await runAllTestsAsync()
+              "Expected nil executor but was: \(String(describing: normalRemoteWorker.localUnownedExecutor!))")
+        }
+      }
+    }
+
+    await runAllTestsAsync()
   }
 }

--- a/test/Distributed/Runtime/distributed_actor_executor_asserts.swift
+++ b/test/Distributed/Runtime/distributed_actor_executor_asserts.swift
@@ -23,7 +23,7 @@ import FakeDistributedActorSystems
 typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 
 distributed actor MainWorker: Worker {
-  nonisolated var unownedExecutor: UnownedSerialExecutor? {
+  nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
     print("get unowned executor")
     return MainActor.sharedUnownedExecutor
   }
@@ -69,7 +69,7 @@ extension Worker {
 //        }
 //
 //        tests.test("remote actor reference should have nil executor") {
-          precondition(normalRemoteWorker.unownedExecutor == nil,
+          precondition(normalRemoteWorker.localUnownedExecutor == nil,
               "Expected nil executor but was: \(String(describing: normalRemoteWorker.unownedExecutor))")
 //        }
 //      }

--- a/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_remoteChanged_asyncness.swift
+++ b/test/Distributed/Runtime/distributed_actor_func_calls_remoteCall_remoteChanged_asyncness.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
 // RUN: %target-build-swift -module-name main  -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
-// RUN: %target-run %t/a.out | %FileCheck %s --color --dump-input=always
+// RUN: %target-run %t/a.out | %FileCheck %s --color 
 
 // REQUIRES: executable_test
 // REQUIRES: concurrency

--- a/test/Distributed/Runtime/distributed_actor_hop_to.swift
+++ b/test/Distributed/Runtime/distributed_actor_hop_to.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s --color
 
@@ -26,7 +26,6 @@ protocol LifecycleWatch: DistributedActor where ActorSystem == FakeRoundtripActo
 
 extension LifecycleWatch {
   func watch<T: Codable>(x: Int, _ y: T) async throws {
-    // nothing here
     print("executed: \(#function) - x = \(x), y = \(y)")
   }
 

--- a/test/Distributed/SIL/distributed_actor_initialize_nondefault.swift
+++ b/test/Distributed/SIL/distributed_actor_initialize_nondefault.swift
@@ -14,13 +14,13 @@ typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
 // ==== ----------------------------------------------------------------------------------------------------------------
 
 distributed actor MyDistActor {
-    nonisolated var unownedExecutor: UnownedSerialExecutor {
+    nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
         return MainActor.sharedUnownedExecutor
     }
 
 // // MyDistActor.init(actorSystem:)
 // CHECK: sil hidden @$s14default_deinit11MyDistActorC11actorSystemAC015FakeDistributedE7Systems0h9RoundtripeG0C_tcfc : $@convention(method) (@owned FakeRoundtripActorSystem, @owned MyDistActor) -> @owned MyDistActor
-// CHECK-NOT: [[BAD:%[0-9]+]] = builtin "initializeDefaultActor"(%1 : $MyDistActor) : $()
+// CHECK-NOT: {{%[0-9]+}} = builtin "initializeDefaultActor"(%1 : $MyDistActor) : $()
 // CHECK: [[ACTOR_INSTANCE:%[0-9]+]] = builtin "initializeNonDefaultDistributedActor"(%1 : $MyDistActor) : $()
 }
 

--- a/test/Distributed/actor_protocols.swift
+++ b/test/Distributed/actor_protocols.swift
@@ -73,6 +73,9 @@ final class DA2: DistributedActor {
   nonisolated var actorSystem: ActorSystem {
     fatalError()
   }
+  nonisolated var localUnownedExecutor: UnownedSerialExecutor? {
+    fatalError()
+  }
 
   required init(system: FakeActorSystem) {
     fatalError()

--- a/test/Distributed/distributed_actor_custom_executor_from_id.swift
+++ b/test/Distributed/distributed_actor_custom_executor_from_id.swift
@@ -1,0 +1,56 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/../Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -enable-experimental-distributed -Xfrontend -disable-availability-checking -j2 -parse-as-library -I %t %s %S/../Inputs/FakeDistributedActorSystems.swift -o %t/a.out
+// RUN: %target-codesign %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s --color
+
+// REQUIRES: executable_test
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+
+// FIXME(distributed): Distributed actors currently have some issues on windows rdar://82593574
+// UNSUPPORTED: OS=windows-msvc
+
+
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+distributed actor Worker {
+  nonisolated var unownedExecutor: UnownedSerialExecutor {
+    print("get unowned executor")
+    self.id.executorPreference
+  }
+
+  distributed func test(x: Int) async throws {
+    print("executed: \(#function)")
+    assumeOnMainActorExecutor {
+      print("assume: this distributed actor shares executor with MainActor")
+    }
+    print("done executed: \(#function)")
+  }
+
+}
+
+@main struct Main {
+  static func main() async {
+    let worker = Worker(actorSystem: DefaultDistributedActorSystem())
+    // CHECK: | assign id
+    // CHECK: | actor ready
+
+    precondition(__isLocalActor(worker), "must be local")
+
+    try! await worker.test(x: 42)
+    // CHECK: get unowned executor
+    // CHECK: executed: test(x:)
+    // CHECK: assume: this distributed actor shares executor with MainActor
+    // CHECK: done executed: test(x:)
+
+    print("OK") // CHECK: OK
+  }
+}

--- a/test/Distributed/distributed_actor_executor_ast.swift
+++ b/test/Distributed/distributed_actor_executor_ast.swift
@@ -1,0 +1,55 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
+// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -typecheck -dump-ast -I %t %s %S/Inputs/FakeDistributedActorSystems.swift 2>&1 | %FileCheck %s --dump-input=always
+
+// REQUIRES: concurrency
+// REQUIRES: distributed
+
+// rdar://76038845
+// UNSUPPORTED: use_os_stdlib
+// UNSUPPORTED: back_deployment_runtime
+// UNSUPPORTED: freestanding
+
+// FIXME(distributed): Distributed actors currently have some issues on windows rdar://82593574
+// UNSUPPORTED: OS=windows-msvc
+
+import StdlibUnittest
+import Distributed
+import FakeDistributedActorSystems
+
+typealias DefaultDistributedActorSystem = FakeRoundtripActorSystem
+
+distributed actor DefaultWorker {
+  // empty on purpose, default executor
+}
+
+// CHECK:  (class_decl range=[{{.*}}] "DefaultWorker" interface type='DefaultWorker.Type' access=internal non-resilient actor
+// CHECK:    (var_decl implicit "unownedExecutor" type='Optional<UnownedSerialExecutor>' interface type='Optional<UnownedSerialExecutor>' access=internal final readImpl=getter immutable
+// CHECK:     (accessor_decl implicit 'anonname={{.*}}' interface type='(DefaultWorker) -> () -> Optional<UnownedSerialExecutor>' access=internal final get_for=unownedExecutor
+// CHECK:       (parameter "self" type='DefaultWorker' interface type='DefaultWorker')
+// CHECK:       (parameter_list)
+// CHECK:       (brace_stmt implicit
+// CHECK:         (return_stmt implicit
+// CHECK:           (inject_into_optional implicit type='Optional<UnownedSerialExecutor>'
+// CHECK:             (call_expr implicit type='UnownedSerialExecutor' nothrow
+// CHECK:               (constructor_ref_call_expr implicit type='(Builtin.Executor) -> UnownedSerialExecutor' nothrow
+// CHECK:                 (declref_expr implicit type='(UnownedSerialExecutor.Type) -> (Builtin.Executor) -> UnownedSerialExecutor' decl=_Concurrency.(file).UnownedSerialExecutor.init(_:) function_ref=unapplied)
+// CHECK:                 (argument_list implicit
+// CHECK:                   (argument
+// CHECK:                     (type_expr implicit type='UnownedSerialExecutor.Type' typerepr='<<NULL>>'))))
+// CHECK:               (argument_list implicit
+// CHECK:                 (argument
+// CHECK:                   (call_expr implicit type='Builtin.Executor' nothrow
+// CHECK:                     (declref_expr implicit type='(DefaultWorker) -> Builtin.Executor' decl=Builtin.(file).buildDefaultActorExecutorRef [with (substitution_map generic_signature=<T where T : AnyObject> (substitution T -> DefaultWorker))] function_ref=unapplied)
+// CHECK:                     (argument_list implicit
+// CHECK:                       (argument
+// CHECK:                         (declref_expr implicit type='DefaultWorker' decl=main.(file).DefaultWorker.<anonymous>.self function_ref=unapplied))))))))))))
+// CHECK:   (pattern_binding_decl implicit
+// CHECK:     (pattern_typed implicit type='Optional<UnownedSerialExecutor>'
+// CHECK:       (pattern_named implicit type='Optional<UnownedSerialExecutor>' 'unownedExecutor')))
+
+//distributed actor MainWorker: Worker {
+//  nonisolated var unownedExecutor: UnownedSerialExecutor? {
+//    return MainActor.sharedUnownedExecutor
+//  }
+//}

--- a/test/Distributed/distributed_actor_executor_ast.swift
+++ b/test/Distributed/distributed_actor_executor_ast.swift
@@ -23,12 +23,26 @@ distributed actor DefaultWorker {
   // empty on purpose, default executor
 }
 
+// Check DefaultWorker, the DefaultActor version of the synthesis:
 // CHECK:  (class_decl range=[{{.*}}] "DefaultWorker" interface type='DefaultWorker.Type' access=internal non-resilient actor
+// The unowned executor property:
 // CHECK:    (var_decl implicit "unownedExecutor" type='Optional<UnownedSerialExecutor>' interface type='Optional<UnownedSerialExecutor>' access=internal final readImpl=getter immutable
 // CHECK:     (accessor_decl implicit 'anonname={{.*}}' interface type='(DefaultWorker) -> () -> Optional<UnownedSerialExecutor>' access=internal final get_for=unownedExecutor
 // CHECK:       (parameter "self" type='DefaultWorker' interface type='DefaultWorker')
 // CHECK:       (parameter_list)
 // CHECK:       (brace_stmt implicit
+// We guard the rest of the body; we only return a default executor if the actor is local:
+// CHECK:       (guard_stmt implicit
+// CHECK:         (call_expr implicit type='Bool' nothrow
+// CHECK:           (declref_expr implicit type='@_NO_EXTINFO (AnyObject) -> Bool' decl=Distributed.(file).__isLocalActor function_ref=unapplied)
+// CHECK:           (argument_list implicit
+// CHECK:             (argument
+// CHECK:               (erasure_expr implicit type='AnyObject'
+// CHECK:                 (declref_expr implicit type='DefaultWorker' decl=main.(file).DefaultWorker.<anonymous>.self function_ref=unapplied)))))
+// CHECK:           (brace_stmt implicit
+// CHECK:             (return_stmt implicit
+// CHECK:               (nil_literal_expr implicit type='Optional<UnownedSerialExecutor>' initializer=**NULL**))))
+// If the actor is not local, we return a default executor for it, same as normal actors:
 // CHECK:         (return_stmt implicit
 // CHECK:           (inject_into_optional implicit type='Optional<UnownedSerialExecutor>'
 // CHECK:             (call_expr implicit type='UnownedSerialExecutor' nothrow

--- a/test/Distributed/distributed_actor_executor_ast.swift
+++ b/test/Distributed/distributed_actor_executor_ast.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend-emit-module -emit-module-path %t/FakeDistributedActorSystems.swiftmodule -module-name FakeDistributedActorSystems -disable-availability-checking %S/Inputs/FakeDistributedActorSystems.swift
-// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -typecheck -dump-ast -I %t %s %S/Inputs/FakeDistributedActorSystems.swift 2>&1 | %FileCheck %s --dump-input=always
+// RUN: %target-build-swift -module-name main -Xfrontend -disable-availability-checking -j2 -parse-as-library -typecheck -dump-ast -I %t %s %S/Inputs/FakeDistributedActorSystems.swift 2>&1 | %FileCheck %s --dump-input=fail
 
 // REQUIRES: concurrency
 // REQUIRES: distributed
@@ -26,8 +26,8 @@ distributed actor DefaultWorker {
 // Check DefaultWorker, the DefaultActor version of the synthesis:
 // CHECK:  (class_decl range=[{{.*}}] "DefaultWorker" interface type='DefaultWorker.Type' access=internal non-resilient actor
 // The unowned executor property:
-// CHECK:    (var_decl implicit "unownedExecutor" type='Optional<UnownedSerialExecutor>' interface type='Optional<UnownedSerialExecutor>' access=internal final readImpl=getter immutable
-// CHECK:     (accessor_decl implicit 'anonname={{.*}}' interface type='(DefaultWorker) -> () -> Optional<UnownedSerialExecutor>' access=internal final get_for=unownedExecutor
+// CHECK:    (var_decl implicit "localUnownedExecutor" type='Optional<UnownedSerialExecutor>' interface type='Optional<UnownedSerialExecutor>' access=internal final readImpl=getter immutable
+// CHECK:     (accessor_decl implicit 'anonname={{.*}}' interface type='(DefaultWorker) -> () -> Optional<UnownedSerialExecutor>' access=internal final get_for=localUnownedExecutor
 // CHECK:       (parameter "self" type='DefaultWorker' interface type='DefaultWorker')
 // CHECK:       (parameter_list)
 // CHECK:       (brace_stmt implicit
@@ -60,10 +60,5 @@ distributed actor DefaultWorker {
 // CHECK:                         (declref_expr implicit type='DefaultWorker' decl=main.(file).DefaultWorker.<anonymous>.self function_ref=unapplied))))))))))))
 // CHECK:   (pattern_binding_decl implicit
 // CHECK:     (pattern_typed implicit type='Optional<UnownedSerialExecutor>'
-// CHECK:       (pattern_named implicit type='Optional<UnownedSerialExecutor>' 'unownedExecutor')))
+// CHECK:       (pattern_named implicit type='Optional<UnownedSerialExecutor>' 'localUnownedExecutor')))
 
-//distributed actor MainWorker: Worker {
-//  nonisolated var unownedExecutor: UnownedSerialExecutor? {
-//    return MainActor.sharedUnownedExecutor
-//  }
-//}


### PR DESCRIPTION
Implements the Swift Evolution feedback that it'd be better to implement this customization point properly with an `UnownedSerialExecutor?` which makes it more logical (and possible!) to implement correctly.

@kavon's question https://forums.swift.org/t/se-0392-custom-actor-executors/63599/13
and my writeup: https://forums.swift.org/t/se-0392-custom-actor-executors/63599/16

Note that we _never_ shipped distributed actors that had an `unownedExecutor` synthesized, so we don't have to be compatible with past implementations which had it configurable or synthesized -- it never was.

The tests show various use-cases. 

I took care to not break compatibility with previous implementations and we still detect "is default actor" using the old synthesized method. Though previously ALL distributed actors were default actors, even if you had provided the method yourself.

I believe this yields the right semantics but would really really ask for a review if I got the default implementation of `unownedExecutor` right -- the availability dance there I was unsure of.