### PR TITLE
[DriverTool] LLVM removed implicit std::string conversion from StringRef

### DIFF
--- a/lib/DriverTool/swift_api_digester_main.cpp
+++ b/lib/DriverTool/swift_api_digester_main.cpp
@@ -2479,7 +2479,8 @@ public:
       Modules.insert(M);
     }
     for (auto M : PreferInterfaceForModules) {
-      InitInvoke.getFrontendOptions().PreferInterfaceForModules.push_back(M);
+      InitInvoke.getFrontendOptions().PreferInterfaceForModules
+        .push_back(std::string(M));
     }
     if (Modules.empty()) {
       llvm::errs() << "Need to specify -include-all or -module <name>\n";


### PR DESCRIPTION
`llvm::StringRef` no longer has an implicit `std::string` conversion; instead, it converts to `std::string_view`.  That's great, but it stops this code from building because we try to `push_back` a `StringRef` into an `std::vector<std::string>`, which fails.

rdar://106988258
