### PR TITLE
add missing symbols to compatibility-symbols

### DIFF
--- a/include/swift/PrintAsClang/ClangMacros.def
+++ b/include/swift/PrintAsClang/ClangMacros.def
@@ -73,6 +73,8 @@
 #endif
 
 CLANG_MACRO_DEFINED("SWIFT_TYPEDEFS")
+CLANG_MACRO_DEFINED("char16_t")
+CLANG_MACRO_DEFINED("char32_t")
 
 #define MAP_SIMD_TYPE(C_TYPE, SCALAR_TYPE, _) \
     CLANG_MACRO_DEFINED("swift_" #C_TYPE "2") \
@@ -185,6 +187,7 @@ CLANG_MACRO_BODY("SWIFT_ENUM", \
     "#  define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME, _extensibility) " \
         "SWIFT_ENUM(_type, _name, _extensibility)\n" \
     "# endif")
+CLANG_MACRO_DEFINED("SWIFT_ENUM_NAMED")
 
 CLANG_MACRO("SWIFT_UNAVAILABLE", , "__attribute__((unavailable))")
 CLANG_MACRO("SWIFT_UNAVAILABLE_MSG", "(msg)", "__attribute__((unavailable(msg)))")

--- a/test/PrintAsObjC/compatibility-symbols.swift
+++ b/test/PrintAsObjC/compatibility-symbols.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %S/../Inputs/empty.swift -typecheck -emit-objc-header-path %t/empty.h
+// RUN: %clang -extract-api -o %t/empty.symbols.json --target=%target-triple -isysroot %clang-importer-sdk-path -F %clang-importer-sdk-path/frameworks --extract-api-ignores=%swift_obj_root/share/swift/compatibility-symbols -fmodules -x objective-c-header %t/empty.h
+// RUN: %FileCheck %s --input-file %t/empty.symbols.json
+
+// REQUIRES: objc_interop
+
+// Make sure that any macros or typedefs added to the Clang compatibility header are reflected in
+// the `comptibility-symbols` file that is installed in the toolchain.
+
+// CHECK: "symbols": []


### PR DESCRIPTION
Resolves rdar://104389344

`ClangMacros.def` was missing three symbols in comparison to the macros and typedefs parsed by clang extract-api. This PR adds these missing symbols, as well as a test that uses `clang -extract-api` on a generated header to ensure that compatibility-symbols is kept up-to-date moving forward.