### PR TITLE
Sema: Don't diagnose declarations more available than unavailable container

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5990,10 +5990,6 @@ ERROR(availability_decl_more_than_enclosing, none,
       "%0 cannot be more available than enclosing scope",
       (DescriptiveDeclKind))
 
-WARNING(availability_decl_more_than_unavailable_enclosing, none,
-        "%0 cannot be more available than unavailable enclosing scope",
-        (DescriptiveDeclKind))
-
 NOTE(availability_implicit_decl_here, none,
      "%0 implicitly declared here with availability of %1 %2 or newer",
      (DescriptiveDeclKind, StringRef, llvm::VersionTuple))

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1945,17 +1945,7 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
       AvailabilityInference::availableRange(attr, Ctx);
 
   if (auto *parent = getEnclosingDeclForDecl(D)) {
-    if (auto enclosingUnavailable = parent->getSemanticUnavailableAttr()) {
-      if (!AttrRange.isKnownUnreachable()) {
-        const Decl *enclosingDecl = enclosingUnavailable.value().second;
-        diagnose(D->isImplicit() ? enclosingDecl->getLoc()
-                                 : attr->getLocation(),
-                 diag::availability_decl_more_than_unavailable_enclosing,
-                 D->getDescriptiveKind());
-        diagnose(parent->getLoc(),
-                 diag::availability_decl_more_than_unavailable_enclosing_here);
-      }
-    } else if (auto enclosingAvailable =
+    if (auto enclosingAvailable =
                    parent->getSemanticAvailableRangeAttr()) {
       const AvailableAttr *enclosingAttr = enclosingAvailable.value().first;
       const Decl *enclosingDecl = enclosingAvailable.value().second;

--- a/test/ModuleInterface/actor_availability.swift
+++ b/test/ModuleInterface/actor_availability.swift
@@ -1,7 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -target %target-swift-abi-5.3-triple
+// RUN: %target-swift-emit-module-interfaces(%t/Library.swiftinterface, %t/Library.private.swiftinterface) %s -module-name Library -target %target-swift-abi-5.3-triple
 // RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
-// RUN: %FileCheck %s < %t/Library.swiftinterface
+// RUN: %target-swift-typecheck-module-from-interface(%t/Library.private.swiftinterface) -module-name Library
+// RUN: %FileCheck %s --check-prefixes=CHECK,CHECK-PUBLIC < %t/Library.swiftinterface
+// RUN: %FileCheck %s --check-prefixes=CHECK,CHECK-PRIVATE < %t/Library.private.swiftinterface
 
 // REQUIRES: VENDOR=apple
 
@@ -33,7 +35,7 @@ public actor ActorWithExplicitAvailability {
 @available(macOS, unavailable)
 public actor UnavailableActor {
   // CHECK: @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-  // CHECK-NEXT: @available(macOS, unavailable)
+  // CHECK-NEXT: @available(macOS, unavailable, introduced: 10.15)
   // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
@@ -72,9 +74,39 @@ extension Enum {
   @available(macOS, unavailable)
   public actor UnavailableExtensionNestedActor {
     // CHECK: @available(iOS 13.4, tvOS 13.4, watchOS 6.2, *)
-    // CHECK-NEXT: @available(macOS, unavailable)
+    // CHECK-NEXT: @available(macOS, unavailable, introduced: 10.15.4)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
     // CHECK-NEXT:   get
     // CHECK-NEXT: }
+  }
+}
+
+// CHECK-PUBLIC: @available(macOS, unavailable)
+// CHECK-PUBLIC-NEXT: @available(iOS, unavailable)
+// CHECK-PUBLIC-NEXT: @available(watchOS, unavailable)
+// CHECK-PUBLIC-NEXT: @available(tvOS, unavailable)
+// CHECK-PUBLIC-NEXT: public struct SPIAvailableStruct
+// CHECK-PRIVATE: @_spi_available(macOS, introduced: 10.15.4)
+// CHECK-PRIVATE-NEXT: @_spi_available(iOS, introduced: 13.4)
+// CHECK-PRIVATE-NEXT: @_spi_available(watchOS, introduced: 6.2)
+// CHECK-PRIVATE-NEXT: @_spi_available(tvOS, introduced: 13.4)
+// CHECK-PRIVATE-NEXT: public struct SPIAvailableStruct
+@_spi_available(SwiftStdlib 5.2, *)
+public struct SPIAvailableStruct {
+  // CHECK: #if compiler(>=5.3) && $Actors
+  // CHECK-NEXT: @_hasMissingDesignatedInitializers @available(macOS, unavailable)
+  // CHECK-NEXT: public actor UnavailableNestedActor
+  @available(macOS, unavailable)
+  public actor UnavailableNestedActor {
+    // CHECK-PUBLIC: @available(iOS, unavailable)
+    // CHECK-PUBLIC-NEXT: @available(tvOS, unavailable)
+    // CHECK-PUBLIC-NEXT: @available(watchOS, unavailable)
+    // CHECK-PUBLIC-NEXT: @available(macOS, unavailable)
+    // CHECK-PUBLIC-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
+    // CHECK-PRIVATE: @_spi_available(iOS, introduced: 13.4)
+    // CHECK-PRIVATE-NEXT: @_spi_available(tvOS, introduced: 13.4)
+    // CHECK-PRIVATE-NEXT: @_spi_available(watchOS, introduced: 6.2)
+    // CHECK-PRIVATE-NEXT: @_spi_available(macOS, unavailable, introduced: 10.15.4)
+    // CHECK-PRIVATE-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
   }
 }

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1731,12 +1731,11 @@ struct HasUnavailableExtension {
 
 @available(OSX, unavailable)
 extension HasUnavailableExtension {
-    // expected-note@-1 {{enclosing scope has been explicitly marked unavailable here}}
 
   public func inheritsUnavailable() { }
       // expected-note@-1 {{'inheritsUnavailable()' has been explicitly marked unavailable here}}
 
-  @available(OSX 10.9, *) // expected-warning {{instance method cannot be more available than unavailable enclosing scope}}
+  @available(OSX 10.9, *)
   public func moreAvailableButStillUnavailable() { }
       // expected-note@-1 {{'moreAvailableButStillUnavailable()' has been explicitly marked unavailable here}}
 }

--- a/test/Sema/generalized_accessors_availability.swift
+++ b/test/Sema/generalized_accessors_availability.swift
@@ -131,6 +131,20 @@ func testButtNested(x: inout Butt.Nested) { // expected-error {{'Nested' is unav
   x.$wrapped_modify_more_available = 0 // expected-error {{is unavailable in macOS}}
 }
 
+@available(iOS, unavailable)
+@_spi_available(macOS, introduced: 10.51)
+extension Butt {
+  struct NestedInSPIAvailableExtension {
+    @available(macOS, unavailable)
+    public var unavailable: Int // expected-note {{'unavailable' has been explicitly marked unavailable here}}
+  }
+}
+
+@available(macOS, introduced: 10.51)
+func testButtNested(x: inout Butt.NestedInSPIAvailableExtension) {
+  x.unavailable = 0 // expected-error {{is unavailable in macOS}}
+}
+
 @available(macOS 11.0, *)
 struct LessAvailable {
   @SetterConditionallyAvailable

--- a/test/attr/attr_availability_transitive_osx.swift
+++ b/test/attr/attr_availability_transitive_osx.swift
@@ -105,7 +105,6 @@ extension Outer {
 }
 
 @available(OSX, unavailable)
-// expected-note@+1 {{enclosing scope has been explicitly marked unavailable here}}
 extension Outer {
   // expected-note@+1 {{'outer_osx_init_osx' has been explicitly marked unavailable here}}
   static var outer_osx_init_osx = osx() // OK
@@ -124,7 +123,7 @@ extension Outer {
   }
   
   // This @available should be ignored; inherited unavailability takes precedence
-  @available(OSX 999, *) // expected-warning {{instance method cannot be more available than unavailable enclosing scope}}
+  @available(OSX 999, *)
   // expected-note@+1 {{'osx_more_available_but_still_unavailable_call_osx()' has been explicitly marked unavailable here}}
   func osx_more_available_but_still_unavailable_call_osx() {
     osx() // OK


### PR DESCRIPTION
It turns out that we must allow declarations with `introduced:` availability nested inside of other declarations that are `unavailable` in order to influence weak linking. Stop diagnosing declarations as being more available than their unavailable containers and revert some changes to availability inference that were designed to avoid creating these nestings but caused regressions for declarations marked `@_spi_available.`

Reverts parts of https://github.com/apple/swift/pull/64310, https://github.com/apple/swift/pull/64015, and https://github.com/apple/swift/pull/62900.
