### PR TITLE
[Serialization] Remark on transitive dependencies and loading requirement

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1031,6 +1031,11 @@ REMARK(module_loaded,none,
        "%select{| (overlay for a clang dependency)}1"
        "; source: '%2', loaded: '%3'",
        (Identifier, unsigned, StringRef, StringRef))
+
+REMARK(transitive_dependency_behavior,none,
+       "%1 has %select{a required|an optional|an ignored}2 "
+       "transitive dependency on '%0'",
+       (StringRef, Identifier, unsigned))
        
 REMARK(explicit_interface_build_skipped,none,
        "Skipped rebuilding module at %0 - up-to-date",

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -17,6 +17,7 @@
 #include "ModuleFormat.h"
 #include "swift/Serialization/SerializationOptions.h"
 #include "swift/Subsystems.h"
+#include "swift/AST/DiagnosticsSema.h"
 #include "swift/AST/ASTContext.h"
 #include "swift/AST/ASTMangler.h"
 #include "swift/AST/GenericSignature.h"
@@ -196,6 +197,14 @@ Status ModuleFile::associateWithFileContext(FileUnit *file, SourceLoc diagLoc,
 
     ModuleLoadingBehavior transitiveBehavior =
       getTransitiveLoadingBehavior(dependency);
+
+    if (ctx.LangOpts.EnableModuleLoadingRemarks) {
+      ctx.Diags.diagnose(diagLoc,
+                         diag::transitive_dependency_behavior,
+                         dependency.Core.getPrettyPrintedPath(),
+                         M->getName(),
+                         unsigned(transitiveBehavior));
+    }
 
     // Skip this dependency?
     if (transitiveBehavior == ModuleLoadingBehavior::Ignored)

--- a/test/Index/index_only_sdk_system_modules.swift
+++ b/test/Index/index_only_sdk_system_modules.swift
@@ -58,3 +58,10 @@ module LocalSystemModule [system] { }
 
 @testable import LocalSystemModule // expected-error {{module 'LocalSystemModule' was not compiled for testing}}
 // expected-remark @-1 {{LocalSystemModule.swiftinterface}}
+// expected-remark @-2 {{'LocalSystemModule' has a required transitive dependency on 'LocalSystemModule'}}
+// expected-remark @-3 {{'LocalSystemModule' has a required transitive dependency on 'Swift'}}
+// expected-remark @-4 {{'LocalSystemModule' has a required transitive dependency on 'SwiftOnoneSupport'}}
+// expected-remark @-5 {{'LocalSystemModule' has a required transitive dependency on '_Concurrency'}}
+// expected-remark @-6 {{'LocalSystemModule' has a required transitive dependency on '_StringProcessing'}}
+// expected-remark @-7 {{'LocalSystemModule' has a required transitive dependency on '_SwiftConcurrencyShims'}}
+

--- a/test/ModuleInterface/loading-remarks.swift
+++ b/test/ModuleInterface/loading-remarks.swift
@@ -49,8 +49,10 @@ import SwiftDependency
 import SwiftNonResilientDependency
 import DirectMixedDependency
 
+// CHECK: remark: 'Swift' has a required transitive dependency on 'SwiftShims'
 // CHECK: remark: loaded module 'SwiftShims'; source: '{{.*}}module.modulemap', loaded: '{{.*}}SwiftShims-{{.*}}.pcm'
 // CHECK: remark: loaded module 'Swift'; source: '{{.*}}Swift.swiftmodule{{.*}}.swiftinterface', loaded: '{{.*}}Swift.swiftmodule{{.*}}.swiftmodule'
+// CHECK: remark: 'SwiftDependency' has a required transitive dependency on 'Swift'
 // CHECK: remark: loaded module 'SwiftDependency'; source: '{{.*}}SwiftDependency.swiftinterface', loaded: '{{.*}}SwiftDependency-{{.*}}.swiftmodule'
 // CHECK: remark: loaded module 'SwiftNonResilientDependency'; source: '{{.*}}SwiftNonResilientDependency.swiftmodule', loaded: '{{.*}}SwiftNonResilientDependency.swiftmodule'
 // CHECK: remark: loaded module 'IndirectMixedDependency' (overlay for a clang dependency); source: '{{.*}}IndirectMixedDependency.swiftinterface', loaded: '{{.*}}IndirectMixedDependency-{{.*}}.swiftmodule'

--- a/test/Serialization/package-dependencies.swift
+++ b/test/Serialization/package-dependencies.swift
@@ -25,13 +25,13 @@ package import PackageDep
 // RUN:   -package-name MyPackage -I %t \
 // RUN:   -enable-experimental-feature AccessLevelOnImport \
 // RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-PACKAGE-DEP %s
-// VISIBLE-PACKAGE-DEP: source: '{{.*}}PackageDep.swiftmodule'
+// VISIBLE-PACKAGE-DEP: loaded module 'PackageDep'
 
 // RUN: %target-swift-frontend -typecheck %t/ResilientClient.swift \
 // RUN:   -package-name NotMyPackage -I %t \
 // RUN:   -enable-experimental-feature AccessLevelOnImport \
 // RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=HIDDEN-PACKAGE-DEP %s
-// HIDDEN-PACKAGE-DEP-NOT: PackageDep
+// HIDDEN-PACKAGE-DEP-NOT: loaded module 'PackageDep'
 
 //--- ResilientClient.swift
 import ResilientDep


### PR DESCRIPTION
Add a remark to `-Rmodule-loading` mode about transitive dependencies before trying to load them, the previous remarks were all after loading the module. The remark shows if a dependency is required, optional, or ignored. 

Here's what the output looks like for the standard libraries where we see mostly required imports and a few implementation-only dependencies:
```
<unknown>:0: remark: transitive dependency on 'SwiftShims' for 'Swift' is required
<unknown>:0: remark: loaded module 'SwiftShims'; source: '.../lib/swift/shims/module.modulemap', loaded: '.../cache/2NSQLI4GBI520/SwiftShims-EESXXQTXCOAV.pcm'
<unknown>:0: remark: loaded module 'Swift'; source: '.../lib/swift/macosx/Swift.swiftmodule/arm64-apple-macos.private.swiftinterface', loaded: '.../Swift.swiftmodule/arm64-apple-macos.swiftmodule'
<unknown>:0: remark: transitive dependency on 'Swift' for '_StringProcessing' is required
<unknown>:0: remark: transitive dependency on '_RegexParser' for '_StringProcessing' is ignored
<unknown>:0: remark: loaded module '_StringProcessing'; source: '.../_StringProcessing.swiftmodule/arm64-apple-macos.private.swiftinterface', loaded: '.../_StringProcessing.swiftmodule/arm64-apple-macos.swiftmodule'
<unknown>:0: remark: loaded module '_SwiftConcurrencyShims'; source: '.../lib/swift/shims/module.modulemap', loaded: '.../cache/2NSQLI4GBI520/_SwiftConcurrencyShims-EESXXQTXCOAV.pcm'
<unknown>:0: remark: transitive dependency on 'Swift' for '_Concurrency' is required
<unknown>:0: remark: transitive dependency on 'SwiftShims' for '_Concurrency' is required
<unknown>:0: remark: transitive dependency on '_SwiftConcurrencyShims' for '_Concurrency' is ignored
<unknown>:0: remark: loaded module '_Concurrency'; source: '.../_Concurrency.swiftmodule/arm64-apple-macos.private.swiftinterface', loaded: '.../_Concurrency.swiftmodule/arm64-apple-macos.swiftmodule'
```