### PR TITLE
[Dependency Scanning] Do not add extra search paths to the Clang's explicit PCM prebuild commands

### DIFF
--- a/lib/AST/ModuleDependencies.cpp
+++ b/lib/AST/ModuleDependencies.cpp
@@ -237,7 +237,7 @@ SwiftDependencyScanningService::SwiftDependencyScanningService()
                          /* CAS (llvm::cas::ObjectStore) */ nullptr,
                          /* Cache (llvm::cas::ActionCache) */ nullptr,
                          /* SharedFS */ nullptr,
-                         /* OptimizeArgs */ false) {
+                         /* OptimizeArgs */ true) {
     SharedFilesystemCache.emplace();
 }
 

--- a/lib/ClangImporter/ClangModuleDependencyScanner.cpp
+++ b/lib/ClangImporter/ClangModuleDependencyScanner.cpp
@@ -178,20 +178,6 @@ void ClangImporter::recordModuleDependencies(
     // Add args reported by the scanner.
     llvm::for_each(clangModuleDep.BuildArguments, addClangArg);
 
-    // Pass down search paths to the -emit-module action.
-    // Unlike building Swift modules, we need to include all search paths to
-    // the clang invocation to build PCMs because transitive headers can only
-    // be found via search paths. Passing these headers as explicit inputs can
-    // be quite challenging.
-    for (const auto &path :
-         Impl.SwiftContext.SearchPathOpts.getImportSearchPaths()) {
-      addClangArg("-I" + path);
-    }
-    for (const auto &path :
-         Impl.SwiftContext.SearchPathOpts.getFrameworkSearchPaths()) {
-      addClangArg((path.IsSystem ? "-Fsystem": "-F") + path.Path);
-    }
-
     // Module-level dependencies.
     llvm::StringSet<> alreadyAddedModules;
     auto dependencies = ModuleDependencyInfo::forClangModule(

--- a/test/ModuleInterface/clang-args-transitive-availability.swift
+++ b/test/ModuleInterface/clang-args-transitive-availability.swift
@@ -48,4 +48,4 @@ import ImportsMacroSpecificClangModule
 // CHECK-NEXT:          "contextHash": "{{.*}}",
 // CHECK-NEXT:          "commandLine": [
 
-// CHECK:                  "TANGERINE=1",
+// CHECK:                  "TANGERINE=1"

--- a/test/ScanDependencies/batch_module_scan.swift
+++ b/test/ScanDependencies/batch_module_scan.swift
@@ -28,7 +28,6 @@
 // CHECK-PCM-NEXT:    },
 // CHECK-PCM-NEXT:    {
 // CHECK-PCM-NEXT:      "modulePath": "{{.*}}{{/|\\}}F-{{.*}}.pcm",
-// CHECK-PCM: "-I
 
 // CHECK-SWIFT: {
 // CHECK-SWIFT-NEXT:  "mainModuleName": "F",

--- a/test/ScanDependencies/batch_module_scan_versioned.swift
+++ b/test/ScanDependencies/batch_module_scan_versioned.swift
@@ -33,7 +33,6 @@
 // CHECK-PCM109-NEXT:      "clang": "X"
 // CHECK-PCM109-NEXT:    }
 // CHECK-PCM109-NEXT:  ],
-// CHECK-PCM109: "-I
 
 // CHECK-PCM110: 		{
 // CHECK-PCM110-NEXT:  "mainModuleName": "G",
@@ -46,4 +45,3 @@
 // CHECK-PCM110:       "directDependencies": [
 // CHECK-PCM110-NEXT:  ],
 // CHECK-PCM110-NOT: "clang": "X"
-// CHECK-PCM110: "-I


### PR DESCRIPTION
Clang dependency scanner's output will be complete here w.r.t. the required search paths.

Also enable Clang scanner's search path and include path pruning.

Resolves rdar://107018240
