### PR TITLE
[Sema] Compiler should diagnose non-unique raw values without crashing

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1342,9 +1342,7 @@ EnumRawValuesRequest::evaluate(Evaluator &eval, EnumDecl *ED,
 
     // Diagnose the duplicate value.
     Diags.diagnose(diagLoc, diag::enum_raw_value_not_unique);
-    assert(lastExplicitValueElt &&
-           "should not be able to have non-unique raw values when "
-           "relying on autoincrement");
+    
     if (lastExplicitValueElt != elt &&
         valueKind == AutomaticEnumValueKind::Integer) {
       Diags.diagnose(uncheckedRawValueOf(lastExplicitValueElt)->getLoc(),
@@ -1356,6 +1354,7 @@ EnumRawValuesRequest::evaluate(Evaluator &eval, EnumDecl *ED,
     diagLoc = uncheckedRawValueOf(foundElt)->isImplicit()
         ? foundElt->getLoc() : uncheckedRawValueOf(foundElt)->getLoc();
     Diags.diagnose(diagLoc, diag::enum_raw_value_used_here);
+    
     if (foundElt != prevSource.lastExplicitValueElt &&
         valueKind == AutomaticEnumValueKind::Integer) {
       if (prevSource.lastExplicitValueElt)

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -364,6 +364,25 @@ enum DuplicateMembers7 : String { // expected-error {{'DuplicateMembers7' declar
   case Foo = "Bar" // expected-error {{invalid redeclaration of 'Foo'}}
 }
 
+enum DuplicateMembers8 : String { // expected-error {{'DuplicateMembers8' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}}
+  case Foo // expected-note {{'Foo' previously declared here}}
+  // expected-note@-1 {{raw value previously used here}}
+  case Foo // expected-error {{invalid redeclaration of 'Foo'}}
+  // expected-error@-1 {{raw value for enum case is not unique}}
+}
+
+enum DuplicateMembers9 : String { // expected-error {{'DuplicateMembers9' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}}
+  case Foo = "Foo" // expected-note {{'Foo' previously declared here}}
+  // expected-note@-1 {{raw value previously used here}}
+  case Foo = "Foo"// expected-error {{invalid redeclaration of 'Foo'}}
+  // expected-error@-1 {{raw value for enum case is not unique}}
+}
+
+enum DuplicateMembers10 : String {
+  case Foo // expected-note {{raw value previously used here}}
+  case Bar = "Foo" // expected-error {{raw value for enum case is not unique}}
+}
+
 // Refs to duplicated enum cases shouldn't crash the compiler.
 // rdar://problem/20922401
 func check20922401() -> String {


### PR DESCRIPTION
Enums with raw type `: String ` use the case name as the raw value if the case is undefined. So two identical case names causes a "raw value for enum case is not unique" error. Additionally, identical case names will always cause a separate redeclaration error regardless of the declared enum raw type. 

```
enum Foo : String {
    case Bar
    case Bar // two errors:  non-unique raw value error and invalid redeclaration of 'Bar'
    case Bar = "FooBar" // one error: invalid redeclaration of 'Bar' because raw value is FooBar instead of Bar
}
```

This second error gets diagnosed in CheckRedeclarationRequest in the DeclVisitor. We could add a special case for this situation to ignore the raw value error and defer diagnosing to the DeclVisitor since fixing that error is most correct. For now, I'll fix the crash and let the compiler diagnose both errors.

Fixes rdar://105761206
Fixes #63829

