### PR TITLE
Add constraint disabling test which hangs with asan/x86_64

### DIFF
--- a/validation-test/stdlib/UnsafeBufferPointerSlices.swift
+++ b/validation-test/stdlib/UnsafeBufferPointerSlices.swift
@@ -1,5 +1,8 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+
+// rdar://106875095
+// UNSUPPORTED: asan && target={{(x86_64|x86_64h)-.*}}
 // END.
 
 import StdlibUnittest

--- a/validation-test/stdlib/UnsafeBufferPointerSlices.swift
+++ b/validation-test/stdlib/UnsafeBufferPointerSlices.swift
@@ -1,8 +1,8 @@
 // RUN: %target-run-simple-swift
-// REQUIRES: executable_test
+// REQUIRES: ( executable_test && !target={{(amd64|x86_64|x86_64h)-.*}} ) || ( executable_test && !asan )
 
 // rdar://106875095
-// UNSUPPORTED: asan && target={{(x86_64|x86_64h)-.*}}
+// __UNSUPPORTED: asan && target={{(x86_64|x86_64h)-.*}}
 // END.
 
 import StdlibUnittest


### PR DESCRIPTION
The UnsafeBufferPointerSlices test hangs when running on x86_64 CPU (in the ci.swift.org) when Swift is compiled with ASAN preset It does work on arm64 machine  - hence disabling x86/asan test combination


