### PR TITLE
[Serialization] Load non-public dependencies of modules when testing is enabled

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -857,16 +857,20 @@ public:
     Exported = 1 << 0,
     /// Include "regular" imports with an access-level of `public`.
     Default = 1 << 1,
-    /// Include imports declared with `@_implementationOnly` or with an
-    /// access-level of `package` or less.
+    /// Include imports declared with `@_implementationOnly`.
     ImplementationOnly = 1 << 2,
     /// Include imports declared with `package import`.
     PackageOnly = 1 << 3,
+    /// Include imports marked `internal` or lower. These differs form
+    /// implementation-only imports by stricter type-checking and loading
+    /// policies. At this moment, we can group them under the same category
+    /// as they have the same loading behavior.
+    InternalOrBelow = 1 << 4,
     /// Include imports declared with `@_spiOnly`.
-    SPIOnly = 1 << 4,
+    SPIOnly = 1 << 5,
     /// Include imports shadowed by a cross-import overlay. Unshadowed imports
     /// are included whether or not this flag is specified.
-    ShadowedByCrossImportOverlay = 1 << 5
+    ShadowedByCrossImportOverlay = 1 << 6
   };
   /// \sa getImportedModules
   using ImportFilter = OptionSet<ImportFilterKind>;
@@ -877,6 +881,7 @@ public:
             ImportFilterKind::Default,
             ImportFilterKind::ImplementationOnly,
             ImportFilterKind::PackageOnly,
+            ImportFilterKind::InternalOrBelow,
             ImportFilterKind::SPIOnly,
             ImportFilterKind::ShadowedByCrossImportOverlay};
   }
@@ -890,6 +895,7 @@ public:
             ImportFilterKind::Default,
             ImportFilterKind::ImplementationOnly,
             ImportFilterKind::PackageOnly,
+            ImportFilterKind::InternalOrBelow,
             ImportFilterKind::SPIOnly};
   }
 

--- a/lib/AST/ImportCache.cpp
+++ b/lib/AST/ImportCache.cpp
@@ -195,6 +195,7 @@ ImportSet &ImportCache::getImportSet(const DeclContext *dc) {
     file->getImportedModules(imports,
                              {ModuleDecl::ImportFilterKind::Default,
                               ModuleDecl::ImportFilterKind::ImplementationOnly,
+                              ModuleDecl::ImportFilterKind::InternalOrBelow,
                               ModuleDecl::ImportFilterKind::PackageOnly,
                               ModuleDecl::ImportFilterKind::SPIOnly});
   }
@@ -280,6 +281,7 @@ ImportCache::getAllAccessPathsNotShadowedBy(const ModuleDecl *mod,
     file->getImportedModules(stack,
                              {ModuleDecl::ImportFilterKind::Default,
                               ModuleDecl::ImportFilterKind::ImplementationOnly,
+                              ModuleDecl::ImportFilterKind::InternalOrBelow,
                               ModuleDecl::ImportFilterKind::PackageOnly,
                               ModuleDecl::ImportFilterKind::SPIOnly});
   }

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -2124,7 +2124,7 @@ SourceFile::getImportedModules(SmallVectorImpl<ImportedModule> &modules,
     else if (desc.options.contains(ImportFlags::ImplementationOnly) ||
              (desc.accessLevel <= AccessLevel::Internal && moduleIsResilient))
       requiredFilter |= ModuleDecl::ImportFilterKind::ImplementationOnly;
-    else if (desc.accessLevel <= AccessLevel::Package && moduleIsResilient)
+    else if (desc.accessLevel <= AccessLevel::Package)
       requiredFilter |= ModuleDecl::ImportFilterKind::PackageOnly;
     else if (desc.options.contains(ImportFlags::SPIOnly))
       requiredFilter |= ModuleDecl::ImportFilterKind::SPIOnly;

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -468,6 +468,10 @@ void ModuleFile::getImportedModules(SmallVectorImpl<ImportedModule> &results,
         continue;
       }
 
+    } else if (dep.isInternalOrBelow()) {
+      if (!filter.contains(ModuleDecl::ImportFilterKind::InternalOrBelow))
+        continue;
+
     } else if (dep.isPackageOnly()) {
       if (!filter.contains(ModuleDecl::ImportFilterKind::PackageOnly))
         continue;

--- a/lib/Serialization/ModuleFile.h
+++ b/lib/Serialization/ModuleFile.h
@@ -107,6 +107,9 @@ public:
     bool isImplementationOnly() const {
       return Core.isImplementationOnly();
     }
+    bool isInternalOrBelow() const {
+      return Core.isInternalOrBelow();
+    }
     bool isPackageOnly() const {
       return Core.isPackageOnly();
     }

--- a/lib/Serialization/ModuleFileSharedCore.cpp
+++ b/lib/Serialization/ModuleFileSharedCore.cpp
@@ -1694,6 +1694,8 @@ ModuleFileSharedCore::getTransitiveLoadingBehavior(
     return ModuleLoadingBehavior::Required;
   }
 
+  bool moduleIsResilient = getResilienceStrategy() ==
+                             ResilienceStrategy::Resilient;
   if (dependency.isImplementationOnly()) {
     // Implementation-only dependencies are not usually loaded from
     // transitive imports.
@@ -1712,7 +1714,8 @@ ModuleFileSharedCore::getTransitiveLoadingBehavior(
   if (dependency.isPackageOnly()) {
     // Package dependencies are usually loaded only for import from the same
     // package.
-    if (!packageName.empty() && packageName == getModulePackageName()) {
+    if ((!packageName.empty() && packageName == getModulePackageName()) ||
+        !moduleIsResilient) {
       return ModuleLoadingBehavior::Required;
     } else if (debuggerMode) {
       return ModuleLoadingBehavior::Optional;

--- a/lib/Serialization/ModuleFileSharedCore.h
+++ b/lib/Serialization/ModuleFileSharedCore.h
@@ -119,7 +119,7 @@ public:
 
   private:
     using ImportFilterKind = ModuleDecl::ImportFilterKind;
-    const unsigned RawImportControl : 2;
+    const unsigned RawImportControl : 3;
     const unsigned IsHeader : 1;
     const unsigned IsScoped : 1;
 
@@ -158,6 +158,9 @@ public:
     }
     bool isImplementationOnly() const {
       return getImportControl() == ImportFilterKind::ImplementationOnly;
+    }
+    bool isInternalOrBelow() const {
+      return getImportControl() == ImportFilterKind::InternalOrBelow;
     }
     bool isPackageOnly() const {
       return getImportControl() == ImportFilterKind::PackageOnly;
@@ -571,6 +574,16 @@ public:
 
   StringRef getModulePackageName() const {
     return ModulePackageName;
+  }
+
+  /// Is the module built with testing enabled?
+  bool isTestable() const {
+     return Bits.IsTestable;
+   }
+
+  /// Whether the module is resilient. ('-enable-library-evolution')
+  ResilienceStrategy getResilienceStrategy() const {
+    return ResilienceStrategy(Bits.ResilienceStrategy);
   }
 
   /// Returns the list of modules this module depends on.

--- a/lib/Serialization/ModuleFormat.h
+++ b/lib/Serialization/ModuleFormat.h
@@ -58,7 +58,7 @@ const uint16_t SWIFTMODULE_VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t SWIFTMODULE_VERSION_MINOR = 754; // allocbox move debug info
+const uint16_t SWIFTMODULE_VERSION_MINOR = 755; // InternalOrBelow dependency
 
 /// A standard hash seed used for all string hashes in a serialized module.
 ///
@@ -583,12 +583,14 @@ enum class ImportControl : uint8_t {
   Normal = 0,
   /// `@_exported import FooKit`
   Exported,
-  /// `@_uncheckedImplementationOnly import FooKit`
+  /// `@_implementationOnly import FooKit`
   ImplementationOnly,
+  /// `internal import FooKit` or more restrictive.
+  InternalOrBelow,
   /// `package import FooKit`
-  PackageOnly
+  PackageOnly,
 };
-using ImportControlField = BCFixed<2>;
+using ImportControlField = BCFixed<3>;
 
 // These IDs must \em not be renumbered or reordered without incrementing
 // the module version.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1218,6 +1218,8 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
       getImportsAsSet(M, ModuleDecl::ImportFilterKind::Default);
   ImportSet packageOnlyImportSet =
       getImportsAsSet(M, ModuleDecl::ImportFilterKind::PackageOnly);
+  ImportSet internalOrBelowImportSet =
+      getImportsAsSet(M, ModuleDecl::ImportFilterKind::InternalOrBelow);
 
   auto clangImporter =
     static_cast<ClangImporter *>(M->getASTContext().getClangModuleLoader());
@@ -1267,6 +1269,8 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
       stableImportControl = ImportControl::Normal;
     else if (packageOnlyImportSet.count(import))
       stableImportControl = ImportControl::PackageOnly;
+    else if (internalOrBelowImportSet.count(import))
+      stableImportControl = ImportControl::InternalOrBelow;
     else
       stableImportControl = ImportControl::ImplementationOnly;
 

--- a/test/Serialization/access-level-import-dependencies.swift
+++ b/test/Serialization/access-level-import-dependencies.swift
@@ -42,15 +42,15 @@ private import HiddenDep
 // RUN:   -enable-experimental-feature AccessLevelOnImport
 
 // RUN: %target-swift-frontend -typecheck %t/ClientOfPublic.swift -I %t \
-// RUN:   -enable-library-evolution -package-name MyOtherPackage \
-// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-HIDDEN-DEP %s
-// VISIBLE-HIDDEN-DEP: source: '{{.*}}HiddenDep.swiftmodule'
+// RUN:   -package-name MyOtherPackage \
+// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-DEP %s
+// VISIBLE-DEP: loaded module 'HiddenDep'
 //--- ClientOfPublic.swift
 import PublicDep
 
 // RUN: %target-swift-frontend -typecheck %t/ClientOfNonPublic.swift -I %t \
-// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=HIDDEN-HIDDEN-DEP %s
-// HIDDEN-HIDDEN-DEP-NOT: HiddenDep
+// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=HIDDEN-DEP %s
+// HIDDEN-DEP-NOT: loaded module 'HiddenDep'
 //--- ClientOfNonPublic.swift
 import PackageDep
 import InternalDep
@@ -70,7 +70,29 @@ import PrivateDep
 // RUN:   -enable-experimental-feature AccessLevelOnImport
 
 // RUN: %target-swift-frontend -typecheck %t/ClientOfPublic.swift -I %t \
-// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-HIDDEN-DEP %s
+// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-DEP %s
 // RUN: %target-swift-frontend -typecheck %t/ClientOfNonPublic.swift -I %t \
-// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-HIDDEN-DEP %s
+// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-DEP %s
 
+/// Even with resilience, all access-level dependencies are visible to clients
+/// for modules with testing enabled.
+// RUN: %target-swift-frontend -emit-module %t/PublicDep.swift -o %t -I %t \
+// RUN:   -enable-library-evolution -enable-testing \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -emit-module %t/PackageDep.swift -o %t -I %t \
+// RUN:   -enable-library-evolution -enable-testing -package-name MyPackage \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -emit-module %t/InternalDep.swift -o %t -I %t \
+// RUN:   -enable-library-evolution -enable-testing \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -emit-module %t/FileprivateDep.swift -o %t -I %t \
+// RUN:   -enable-library-evolution -enable-testing \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+// RUN: %target-swift-frontend -emit-module %t/PrivateDep.swift -o %t -I %t \
+// RUN:   -enable-library-evolution -enable-testing \
+// RUN:   -enable-experimental-feature AccessLevelOnImport
+
+// RUN: %target-swift-frontend -typecheck %t/ClientOfPublic.swift -I %t \
+// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-DEP %s
+// RUN: %target-swift-frontend -typecheck %t/ClientOfNonPublic.swift -I %t \
+// RUN:   -Rmodule-loading 2>&1 | %FileCheck -check-prefix=VISIBLE-DEP %s


### PR DESCRIPTION
Non-public dependencies may be referenced from internal decls in a module with testing enabled. If that module is imported as testable by a client, the client can access those internal decls and references for which it needs to load the dependencies.

Ensure that we load transitive non-public dependencies from modules that enabled testing. To do so, we differentiate `internal` and `fileprivate` imports from implementation-only imports at the module-wide level to offer a different module loading strategy.

rdar://106514965

---

I'm suggesting something similar for implementation-only imports in https://github.com/apple/swift/pull/64509, where the dependency can only be optional as adding them as required could break projects.