### PR TITLE
Expand conformance macros within the conformance lookup table

### DIFF
--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -25,6 +25,7 @@
 #include "swift/AST/SourceFile.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/ProtocolConformanceRef.h"
+#include "swift/AST/TypeCheckRequests.h"
 #include "llvm/Support/SaveAndRestore.h"
 
 using namespace swift;
@@ -280,6 +281,11 @@ void ConformanceLookupTable::updateLookupTable(NominalTypeDecl *nominal,
         [&](NominalTypeDecl *nominal) {
           addInheritedProtocols(nominal,
                                 ConformanceSource::forExplicit(nominal));
+
+          // Expand conformance macros.
+          ASTContext &ctx = nominal->getASTContext();
+          (void)evaluateOrDefault(
+              ctx.evaluator, ExpandConformanceMacros{nominal}, { });
         },
         [&](ExtensionDecl *ext,
             ArrayRef<ConformanceConstructionInfo> protos) {

--- a/test/Macros/Inputs/macro_expand_conformances_other.swift
+++ b/test/Macros/Inputs/macro_expand_conformances_other.swift
@@ -1,0 +1,3 @@
+struct STest {
+  var x = requireEquatable(S())
+}

--- a/test/Macros/macro_expand_conformances_multi.swift
+++ b/test/Macros/macro_expand_conformances_multi.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -swift-version 5 -I %swift-host-lib-dir -L %swift-host-lib-dir -emit-library -o %t/%target-library-name(MacroDefinition) -module-name=MacroDefinition %S/Inputs/syntax_macro_definitions.swift -g -no-toolchain-stdlib-rpath
+
+// Make sure we see the conformances from another file.
+// RUN: %target-typecheck-verify-swift -swift-version 5 -load-plugin-library %t/%target-library-name(MacroDefinition) -I %swift-host-lib-dir -module-name MacroUser -swift-version 5 -primary-file %S/Inputs/macro_expand_conformances_other.swift -DDISABLE_TOP_LEVEL_CODE
+
+
+// REQUIRES: executable_test
+
+// FIXME: Swift parser is not enabled on Linux CI yet.
+// REQUIRES: OS=macosx
+
+@attached(conformance)
+macro Equatable() = #externalMacro(module: "MacroDefinition", type: "EquatableMacro")
+
+@attached(conformance)
+macro Hashable() = #externalMacro(module: "MacroDefinition", type: "HashableMacro")
+
+func requireEquatable(_ value: some Equatable) -> Int {
+  print(value == value)
+  return 0
+}
+
+func requireHashable(_ value: some Hashable) {
+  print(value.hashValue)
+}
+
+@Equatable
+struct S {}
+


### PR DESCRIPTION
The conformance lookup table is the central point of truth to establish which protocols a nominal type conforms to. Ensure that we expand conformance macros into that table.

Fixes rdar://106886651.
