### PR TITLE
[ConstraintSystem] Diagnose pack expansion expressions in non-variadic contexts.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5316,6 +5316,12 @@ ERROR(vararg_not_allowed,none,
 ERROR(expansion_not_allowed,none,
       "pack expansion %0 can only appear in a function parameter list, "
       "tuple element, or generic argument list", (Type))
+ERROR(expansion_expr_not_allowed,none,
+      "value pack expansion can only appear inside a function argument list "
+      "or tuple element", ())
+ERROR(invalid_expansion_argument,none,
+      "cannot pass value pack expansion to non-pack parameter of type %0",
+      (Type))
 ERROR(expansion_not_variadic,none,
       "pack expansion %0 must contain at least one pack reference", (Type))
 ERROR(pack_reference_outside_expansion,none,

--- a/include/swift/Sema/CSFix.h
+++ b/include/swift/Sema/CSFix.h
@@ -431,6 +431,9 @@ enum class FixKind : uint8_t {
 
   /// Allow pack references outside of pack expansions.
   AllowInvalidPackReference,
+
+  /// Allow pack expansion expressions in a context that does not support them.
+  AllowInvalidPackExpansion,
 };
 
 class ConstraintFix {
@@ -2125,6 +2128,26 @@ public:
 
   static bool classof(const ConstraintFix *fix) {
     return fix->getKind() == FixKind::AllowInvalidPackReference;
+  }
+};
+
+class AllowInvalidPackExpansion final : public ConstraintFix {
+  AllowInvalidPackExpansion(ConstraintSystem &cs,
+                            ConstraintLocator *locator)
+      : ConstraintFix(cs, FixKind::AllowInvalidPackExpansion, locator) {}
+
+public:
+  std::string getName() const override {
+    return "allow invalid pack expansion";
+  }
+
+  bool diagnose(const Solution &solution, bool asNote = false) const override;
+
+  static AllowInvalidPackExpansion *create(ConstraintSystem &cs,
+                                           ConstraintLocator *locator);
+
+  static bool classof(const ConstraintFix *fix) {
+    return fix->getKind() == FixKind::AllowInvalidPackExpansion;
   }
 };
 

--- a/lib/Sema/CSDiagnostics.cpp
+++ b/lib/Sema/CSDiagnostics.cpp
@@ -6176,6 +6176,20 @@ bool InvalidPackReference::diagnoseAsError() {
   return true;
 }
 
+bool InvalidPackExpansion::diagnoseAsError() {
+  auto *locator = getLocator();
+  if (locator->isLastElement<LocatorPathElt::ApplyArgToParam>()) {
+    if (auto argInfo = getFunctionArgApplyInfo(locator)) {
+      emitDiagnostic(diag::invalid_expansion_argument,
+                     argInfo->getParamInterfaceType());
+      return true;
+    }
+  }
+
+  emitDiagnostic(diag::expansion_expr_not_allowed);
+  return true;
+}
+
 bool CollectionElementContextualFailure::diagnoseAsError() {
   auto anchor = getRawAnchor();
   auto *locator = getLocator();

--- a/lib/Sema/CSDiagnostics.h
+++ b/lib/Sema/CSDiagnostics.h
@@ -1875,6 +1875,17 @@ public:
   bool diagnoseAsError() override;
 };
 
+/// Diagnose pack expansion expressions appearing in contexts that do not
+/// accept a comma-separated list of values.
+class InvalidPackExpansion final : public FailureDiagnostic {
+public:
+  InvalidPackExpansion(const Solution &solution,
+                       ConstraintLocator *locator)
+      : FailureDiagnostic(solution, locator) {}
+
+  bool diagnoseAsError() override;
+};
+
 /// Diagnose a contextual mismatch between expected collection element type
 /// and the one provided (e.g. source of the assignment or argument to a call)
 /// e.g.:

--- a/lib/Sema/CSFix.cpp
+++ b/lib/Sema/CSFix.cpp
@@ -1429,6 +1429,18 @@ AllowInvalidPackReference::create(ConstraintSystem &cs, Type packType,
       AllowInvalidPackReference(cs, packType, locator);
 }
 
+bool AllowInvalidPackExpansion::diagnose(const Solution &solution,
+                                         bool asNote) const {
+  InvalidPackExpansion failure(solution, getLocator());
+  return failure.diagnose(asNote);
+}
+
+AllowInvalidPackExpansion *
+AllowInvalidPackExpansion::create(ConstraintSystem &cs,
+                                  ConstraintLocator *locator) {
+  return new (cs.getAllocator()) AllowInvalidPackExpansion(cs, locator);
+}
+
 bool CollectionElementContextualMismatch::diagnose(const Solution &solution,
                                                    bool asNote) const {
   CollectionElementContextualFailure failure(

--- a/test/type/pack_expansion.swift
+++ b/test/type/pack_expansion.swift
@@ -93,5 +93,5 @@ func packRefOutsideExpansion<each T>(_: each T.Type) {}
 // coverage to ensure a 'repeat each' type is considered Copyable
 func golden<Z>(_ z: Z) {}
 func hour<each T>(_ t: repeat each T)  {
-  _ = repeat golden(each t)
+  _ = (repeat golden(each t))
 }


### PR DESCRIPTION
Pack expansion expressions are only allowed in call/subscript arguments and tuple value elements. For argument lists, a pack expansion is only valid when passed to a function that accepts a parameter pack. All other uses of pack expansion expressions are invalid.