### PR TITLE
[Driver] Implement inference of `-plugin-path` arguments.

### DIFF
--- a/test/Driver/compiler_plugin_path.swift
+++ b/test/Driver/compiler_plugin_path.swift
@@ -1,7 +1,7 @@
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s 2>^1 | %FileCheck %s
 
 // CHECK: -plugin-path
-// CHECK-SAME: BUILD_DIR/lib/swift/host/plugins
+// CHECK-SAME: BUILD_DIR{{(\.\/)?}}lib{{(\.\/)}}swift{{(\.\/)}}host{{(\.\/)}}plugins
 
 // CHECK-SAME: -plugin-path
-// CHECK-SAME: BUILD_DIR/local/lib/swift/host/plugins
+// CHECK-SAME: BUILD_DIR{{(\.\/)?}}local{{(\.\/)}}lib{{(\.\/)}}swift{{(\.\/)}}host{{(\.\/)}}plugins

--- a/test/Driver/compiler_plugin_path.swift
+++ b/test/Driver/compiler_plugin_path.swift
@@ -1,7 +1,7 @@
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s 2>^1 | %FileCheck %s
 
 // CHECK: -plugin-path
-// CHECK-SAME: BUILD_DIR{{(\.\/)?}}lib{{(\.\/)}}swift{{(\.\/)}}host{{(\.\/)}}plugins
+// CHECK-SAME: BUILD_DIR{{(/|\\\\)}}lib{{(/|\\\\)}}swift{{(/|\\\\)}}host{{(/|\\\\)}}plugins
 
 // CHECK-SAME: -plugin-path
-// CHECK-SAME: BUILD_DIR{{(\.\/)?}}local{{(\.\/)}}lib{{(\.\/)}}swift{{(\.\/)}}host{{(\.\/)}}plugins
+// CHECK-SAME: BUILD_DIR{{(/|\\\\)}}local{{(/|\\\\)}}lib{{(/|\\\\)}}swift{{(/|\\\\)}}host{{(/|\\\\)}}plugins

--- a/test/Driver/compiler_plugin_path.swift
+++ b/test/Driver/compiler_plugin_path.swift
@@ -1,7 +1,7 @@
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s 2>^1 | %FileCheck %s
 
 // CHECK: -plugin-path
-// CHECK-SAME: BUILD_DIR{{(/|\\\\)}}lib{{(/|\\\\)}}swift{{(/|\\\\)}}host{{(/|\\\\)}}plugins
+// CHECK-SAME: {{(/|\\\\)}}lib{{(/|\\\\)}}swift{{(/|\\\\)}}host{{(/|\\\\)}}plugins
 
 // CHECK-SAME: -plugin-path
-// CHECK-SAME: BUILD_DIR{{(/|\\\\)}}local{{(/|\\\\)}}lib{{(/|\\\\)}}swift{{(/|\\\\)}}host{{(/|\\\\)}}plugins
+// CHECK-SAME: {{(/|\\\\)}}local{{(/|\\\\)}}lib{{(/|\\\\)}}swift{{(/|\\\\)}}host{{(/|\\\\)}}plugins

--- a/test/Driver/compiler_plugin_path.swift
+++ b/test/Driver/compiler_plugin_path.swift
@@ -1,0 +1,7 @@
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s 2>^1 | %FileCheck %s
+
+// CHECK: -plugin-path
+// CHECK-SAME: BUILD_DIR/lib/swift/host/plugins
+
+// CHECK-SAME: -plugin-path
+// CHECK-SAME: BUILD_DIR/local/lib/swift/host/plugins


### PR DESCRIPTION
This was previously implemented in the new driver; backport it to the existing driver, which is still used by SourceKit.

Fixes rdar://106790436.
