### PR TITLE
Check: Revert "Sema: Don't diagnose declarations more available than unavailable container."

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -5991,6 +5991,10 @@ ERROR(availability_decl_more_than_enclosing, none,
       "%0 cannot be more available than enclosing scope",
       (DescriptiveDeclKind))
 
+WARNING(availability_decl_more_than_unavailable_enclosing, none,
+        "%0 cannot be more available than unavailable enclosing scope",
+        (DescriptiveDeclKind))
+
 NOTE(availability_implicit_decl_here, none,
      "%0 implicitly declared here with availability of %1 %2 or newer",
      (DescriptiveDeclKind, StringRef, llvm::VersionTuple))

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -109,6 +109,15 @@ static AvailableAttr *createAvailableAttr(PlatformKind Platform,
   llvm::VersionTuple Obsoleted =
       Inferred.Obsoleted.value_or(llvm::VersionTuple());
 
+  // If a decl is unavailable then it cannot have any introduced, deprecated, or
+  // obsoleted version.
+  if (Inferred.PlatformAgnostic ==
+      PlatformAgnosticAvailabilityKind::Unavailable) {
+    Introduced = llvm::VersionTuple();
+    Deprecated = llvm::VersionTuple();
+    Obsoleted = llvm::VersionTuple();
+  }
+
   return new (Context)
       AvailableAttr(SourceLoc(), SourceRange(), Platform,
                     Message, Rename, RenameDecl,
@@ -158,6 +167,27 @@ void AvailabilityInference::applyInferredAvailableAttrs(
   }
 
   DeclAttributes &Attrs = ToDecl->getAttrs();
+
+  // Some kinds of platform agnostic availability supersede any platform
+  // specific availability.
+  auto InferredAgnostic = Inferred.find(PlatformKind::none);
+  if (InferredAgnostic != Inferred.end()) {
+    switch (InferredAgnostic->second.PlatformAgnostic) {
+    case PlatformAgnosticAvailabilityKind::Deprecated:
+    case PlatformAgnosticAvailabilityKind::UnavailableInSwift:
+    case PlatformAgnosticAvailabilityKind::Unavailable:
+      Attrs.add(createAvailableAttr(PlatformKind::none,
+                                    InferredAgnostic->second, Message, Rename,
+                                    RenameDecl, Context));
+      return;
+
+    case PlatformAgnosticAvailabilityKind::None:
+    case PlatformAgnosticAvailabilityKind::SwiftVersionSpecific:
+    case PlatformAgnosticAvailabilityKind::PackageDescriptionVersionSpecific:
+    case PlatformAgnosticAvailabilityKind::NoAsync:
+      break;
+    }
+  }
 
   // Create an availability attribute for each observed platform and add
   // to ToDecl.

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1945,7 +1945,17 @@ void AttributeChecker::visitAvailableAttr(AvailableAttr *attr) {
       AvailabilityInference::availableRange(attr, Ctx);
 
   if (auto *parent = getEnclosingDeclForDecl(D)) {
-    if (auto enclosingAvailable =
+    if (auto enclosingUnavailable = parent->getSemanticUnavailableAttr()) {
+      if (!AttrRange.isKnownUnreachable()) {
+        const Decl *enclosingDecl = enclosingUnavailable.value().second;
+        diagnose(D->isImplicit() ? enclosingDecl->getLoc()
+                                 : attr->getLocation(),
+                 diag::availability_decl_more_than_unavailable_enclosing,
+                 D->getDescriptiveKind());
+        diagnose(parent->getLoc(),
+                 diag::availability_decl_more_than_unavailable_enclosing_here);
+      }
+    } else if (auto enclosingAvailable =
                    parent->getSemanticAvailableRangeAttr()) {
       const AvailableAttr *enclosingAttr = enclosingAvailable.value().first;
       const Decl *enclosingDecl = enclosingAvailable.value().second;

--- a/test/ModuleInterface/actor_availability.swift
+++ b/test/ModuleInterface/actor_availability.swift
@@ -1,9 +1,7 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interfaces(%t/Library.swiftinterface, %t/Library.private.swiftinterface) %s -module-name Library -target %target-swift-abi-5.3-triple
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -target %target-swift-abi-5.3-triple
 // RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -module-name Library
-// RUN: %target-swift-typecheck-module-from-interface(%t/Library.private.swiftinterface) -module-name Library
-// RUN: %FileCheck %s --check-prefixes=CHECK,CHECK-PUBLIC < %t/Library.swiftinterface
-// RUN: %FileCheck %s --check-prefixes=CHECK,CHECK-PRIVATE < %t/Library.private.swiftinterface
+// RUN: %FileCheck %s < %t/Library.swiftinterface
 
 // REQUIRES: VENDOR=apple
 
@@ -35,7 +33,7 @@ public actor ActorWithExplicitAvailability {
 @available(macOS, unavailable)
 public actor UnavailableActor {
   // CHECK: @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-  // CHECK-NEXT: @available(macOS, unavailable, introduced: 10.15)
+  // CHECK-NEXT: @available(macOS, unavailable)
   // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
   // CHECK-NEXT:   get
   // CHECK-NEXT: }
@@ -74,39 +72,9 @@ extension Enum {
   @available(macOS, unavailable)
   public actor UnavailableExtensionNestedActor {
     // CHECK: @available(iOS 13.4, tvOS 13.4, watchOS 6.2, *)
-    // CHECK-NEXT: @available(macOS, unavailable, introduced: 10.15.4)
+    // CHECK-NEXT: @available(macOS, unavailable)
     // CHECK-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
     // CHECK-NEXT:   get
     // CHECK-NEXT: }
-  }
-}
-
-// CHECK-PUBLIC: @available(macOS, unavailable)
-// CHECK-PUBLIC-NEXT: @available(iOS, unavailable)
-// CHECK-PUBLIC-NEXT: @available(watchOS, unavailable)
-// CHECK-PUBLIC-NEXT: @available(tvOS, unavailable)
-// CHECK-PUBLIC-NEXT: public struct SPIAvailableStruct
-// CHECK-PRIVATE: @_spi_available(macOS, introduced: 10.15.4)
-// CHECK-PRIVATE-NEXT: @_spi_available(iOS, introduced: 13.4)
-// CHECK-PRIVATE-NEXT: @_spi_available(watchOS, introduced: 6.2)
-// CHECK-PRIVATE-NEXT: @_spi_available(tvOS, introduced: 13.4)
-// CHECK-PRIVATE-NEXT: public struct SPIAvailableStruct
-@_spi_available(SwiftStdlib 5.2, *)
-public struct SPIAvailableStruct {
-  // CHECK: #if compiler(>=5.3) && $Actors
-  // CHECK-NEXT: @_hasMissingDesignatedInitializers @available(macOS, unavailable)
-  // CHECK-NEXT: public actor UnavailableNestedActor
-  @available(macOS, unavailable)
-  public actor UnavailableNestedActor {
-    // CHECK-PUBLIC: @available(iOS, unavailable)
-    // CHECK-PUBLIC-NEXT: @available(tvOS, unavailable)
-    // CHECK-PUBLIC-NEXT: @available(watchOS, unavailable)
-    // CHECK-PUBLIC-NEXT: @available(macOS, unavailable)
-    // CHECK-PUBLIC-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
-    // CHECK-PRIVATE: @_spi_available(iOS, introduced: 13.4)
-    // CHECK-PRIVATE-NEXT: @_spi_available(tvOS, introduced: 13.4)
-    // CHECK-PRIVATE-NEXT: @_spi_available(watchOS, introduced: 6.2)
-    // CHECK-PRIVATE-NEXT: @_spi_available(macOS, unavailable, introduced: 10.15.4)
-    // CHECK-PRIVATE-NEXT: @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor
   }
 }

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1731,11 +1731,12 @@ struct HasUnavailableExtension {
 
 @available(OSX, unavailable)
 extension HasUnavailableExtension {
+    // expected-note@-1 {{enclosing scope has been explicitly marked unavailable here}}
 
   public func inheritsUnavailable() { }
       // expected-note@-1 {{'inheritsUnavailable()' has been explicitly marked unavailable here}}
 
-  @available(OSX 10.9, *)
+  @available(OSX 10.9, *) // expected-warning {{instance method cannot be more available than unavailable enclosing scope}}
   public func moreAvailableButStillUnavailable() { }
       // expected-note@-1 {{'moreAvailableButStillUnavailable()' has been explicitly marked unavailable here}}
 }

--- a/test/Sema/generalized_accessors_availability.swift
+++ b/test/Sema/generalized_accessors_availability.swift
@@ -131,20 +131,6 @@ func testButtNested(x: inout Butt.Nested) { // expected-error {{'Nested' is unav
   x.$wrapped_modify_more_available = 0 // expected-error {{is unavailable in macOS}}
 }
 
-@available(iOS, unavailable)
-@_spi_available(macOS, introduced: 10.51)
-extension Butt {
-  struct NestedInSPIAvailableExtension {
-    @available(macOS, unavailable)
-    public var unavailable: Int // expected-note {{'unavailable' has been explicitly marked unavailable here}}
-  }
-}
-
-@available(macOS, introduced: 10.51)
-func testButtNested(x: inout Butt.NestedInSPIAvailableExtension) {
-  x.unavailable = 0 // expected-error {{is unavailable in macOS}}
-}
-
 @available(macOS 11.0, *)
 struct LessAvailable {
   @SetterConditionallyAvailable

--- a/test/attr/attr_availability_transitive_osx.swift
+++ b/test/attr/attr_availability_transitive_osx.swift
@@ -105,6 +105,7 @@ extension Outer {
 }
 
 @available(OSX, unavailable)
+// expected-note@+1 {{enclosing scope has been explicitly marked unavailable here}}
 extension Outer {
   // expected-note@+1 {{'outer_osx_init_osx' has been explicitly marked unavailable here}}
   static var outer_osx_init_osx = osx() // OK
@@ -123,7 +124,7 @@ extension Outer {
   }
   
   // This @available should be ignored; inherited unavailability takes precedence
-  @available(OSX 999, *)
+  @available(OSX 999, *) // expected-warning {{instance method cannot be more available than unavailable enclosing scope}}
   // expected-note@+1 {{'osx_more_available_but_still_unavailable_call_osx()' has been explicitly marked unavailable here}}
   func osx_more_available_but_still_unavailable_call_osx() {
     osx() // OK


### PR DESCRIPTION
Check if https://github.com/apple/swift/pull/64515/ is what caused the issues mentioned below in https://github.com/apple/swift/pull/64517

I'm concurrently investigating if any of my executor PRs could have caused this.

```
/Users/ec2-user/jenkins/workspace/swift-PR-macos/branch-main/swift/test/ModuleInterface/actor_availability.swift:95:15: warning: symbols that are @_spi_available on all platforms should use @_spi instead
public struct SPIAvailableStruct {
              ^
/Users/ec2-user/jenkins/workspace/swift-PR-macos/branch-main/build/buildbot_incremental/swift-macosx-x86_64/test-iphonesimulator-x86_64/ModuleInterface/Output/actor_availability.swift.tmp/Library.swiftinterface:79:16: error: type 'SPIAvailableStruct.UnavailableNestedActor' does not conform to protocol 'Actor'
  public actor UnavailableNestedActor {
               ^
/Users/ec2-user/jenkins/workspace/swift-PR-macos/branch-main/build/buildbot_incremental/swift-macosx-x86_64/test-iphonesimulator-x86_64/ModuleInterface/Output/actor_availability.swift.tmp/Library.swiftinterface:85:62: error: unavailable property 'unownedExecutor' was used to satisfy a requirement of protocol 'Actor'
    @_semantics("defaultActor") nonisolated final public var unownedExecutor: _Concurrency.UnownedSerialExecutor {
                                                             ^
_Concurrency.Actor:3:21: note: requirement 'unownedExecutor' declared here
    nonisolated var unownedExecutor: UnownedSerialExecutor { get }
                    ^
/Users/ec2-user/jenkins/workspace/swift-PR-macos/branch-main/build/buildbot_incremental/swift-macosx-x86_64/test-iphonesimulator-x86_64/ModuleInterface/Output/actor_availability.swift.tmp/Library.swiftinterface:1:1: error: failed to verify module interface of 'Library' due to the errors above; the textual interface may be broken by project issues or a compiler bug
// swift-interface-format-version: 1.0
^
```

This reverts commit 620462ddf60ddeafb41a834091a50fa72ceac683.
