### PR TITLE
[CSSimplify] Don't propagate contextual parameter type if it's a pack…

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -11020,6 +11020,11 @@ bool ConstraintSystem::resolveClosure(TypeVariableType *typeVar,
     if (contextualTy->isTypeVariableOrMember())
       return false;
 
+    // Cannot propagate pack expansion type from context,
+    // it has to be handled by type matching logic.
+    if (contextualTy->is<PackExpansionType>())
+      return false;
+
     // If contextual type has an error, let's wait for inference,
     // otherwise contextual would interfere with diagnostics.
     if (contextualTy->hasError())

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -261,3 +261,13 @@ func invalidRepeat<each T>(t: repeat each T) {
   _ = [repeat each t]
   // expected-error@-1 {{value pack expansion can only appear inside a function argument list or tuple element}}
 }
+
+func test_pack_expansions_with_closures() {
+  func takesVariadicFunction<each T>(function: (repeat each T) -> Int) {}
+
+  func test(fn: (Int, String) -> Int, x: Int) {
+    takesVariadicFunction { fn(x, "") } // Ok
+    takesVariadicFunction { y in fn(x, y) } // Ok
+    takesVariadicFunction { y, z in fn(y, z) } // Ok
+  }
+}


### PR DESCRIPTION
… expansion

Pack expansion types are handled by matching logic, optimization that attempts 
to propagate types into the body of the closure should consider them unsuitable
even if the pack expansion matches a single parameter.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
