### PR TITLE
Cleanup PrunedLiveBlocks

### DIFF
--- a/include/swift/SIL/OwnershipLiveness.h
+++ b/include/swift/SIL/OwnershipLiveness.h
@@ -178,7 +178,8 @@ protected:
   OSSALiveness &operator=(const OSSALiveness &) = delete;
 
 public:
-  OSSALiveness(SILValue def): ownershipDef(def), liveness(&discoveredBlocks) {}
+  OSSALiveness(SILValue def): ownershipDef(def),
+                              liveness(def->getFunction(), &discoveredBlocks) {}
 
   const SSAPrunedLiveness &getLiveness() const { return liveness; }
 

--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -479,8 +479,9 @@ class PrunedLiveness {
   llvm::SmallMapVector<SILInstruction *, bool, 8> users;
 
 public:
-  PrunedLiveness(SmallVectorImpl<SILBasicBlock *> *discoveredBlocks = nullptr)
-      : liveBlocks(1 /*num bits*/, discoveredBlocks) {}
+  PrunedLiveness(SILFunction *function,
+                 SmallVectorImpl<SILBasicBlock *> *discoveredBlocks = nullptr)
+      : liveBlocks(function, discoveredBlocks) {}
 
   bool empty() const {
     assert(!liveBlocks.empty() || users.empty());
@@ -745,8 +746,9 @@ class SSAPrunedLiveness : public PrunedLiveRange<SSAPrunedLiveness> {
 
 public:
   SSAPrunedLiveness(
+      SILFunction *function,
       SmallVectorImpl<SILBasicBlock *> *discoveredBlocks = nullptr)
-      : PrunedLiveRange(discoveredBlocks) {}
+      : PrunedLiveRange(function, discoveredBlocks) {}
 
   SILValue getDef() const { return def; }
 
@@ -815,8 +817,8 @@ public:
   MultiDefPrunedLiveness(
       SILFunction *function,
       SmallVectorImpl<SILBasicBlock *> *discoveredBlocks = nullptr)
-      : PrunedLiveRange(discoveredBlocks), defs(function), defBlocks(function) {
-  }
+      : PrunedLiveRange(function, discoveredBlocks), defs(function),
+        defBlocks(function) {}
 
   void clear() {
     llvm_unreachable("multi-def liveness cannot be reused");
@@ -886,10 +888,11 @@ class DiagnosticPrunedLiveness : public SSAPrunedLiveness {
 
 public:
   DiagnosticPrunedLiveness(
+      SILFunction *function,
       SmallVectorImpl<SILBasicBlock *> *discoveredBlocks = nullptr,
       SmallSetVector<SILInstruction *, 8> *nonLifetimeEndingUsesInLiveOut =
           nullptr)
-      : SSAPrunedLiveness(discoveredBlocks),
+      : SSAPrunedLiveness(function, discoveredBlocks),
         nonLifetimeEndingUsesInLiveOut(nonLifetimeEndingUsesInLiveOut) {}
 
   void clear() {

--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -155,14 +155,6 @@ class DeadEndBlocks;
 /// not dominated by a def block, then liveness will include the entry block,
 /// as if defined by a function argument
 ///
-/// We allow for multiple bits of liveness information to be tracked by
-/// internally using a SmallBitVector. The multiple bit tracking is useful when
-/// tracking state for multiple fields of the same root value. To do this, we
-/// actually track 2 bits per actual needed bit so we can represent 3 Dead,
-/// LiveOut, LiveWithin. This was previously unnecessary since we could just
-/// represent dead by not having liveness state for a block. With multiple bits
-/// possible this is no longer true.
-///
 /// TODO: For efficiency, use BasicBlockBitfield rather than SmallDenseMap.
 class PrunedLiveBlocks {
 public:
@@ -181,100 +173,49 @@ public:
   /// LiveOut blocks are live on at least one successor path. LiveOut blocks may
   /// or may not contain defs or uses.
   ///
-  /// NOTE: The values below for Dead, LiveWithin, LiveOut were picked to ensure
-  /// that given a 2 bit representation of the value, a value is Dead if the
-  /// first bit is 0 and is LiveOut if the second bit is set.
+  /// NOTE: The values below for Dead, LiveWithin, LiveOut were picked to
+  /// establish a lattice such that:
+  /// - Dead is the initial state (zero bitfield)
+  /// - Merging liveness information is a bitwise-or
   enum IsLive {
     Dead = 0,
     LiveWithin = 1,
     LiveOut = 3,
   };
 
-  /// A bit vector that stores information about liveness. This is composed
-  /// with SmallBitVector since it contains two bits per liveness so that it
-  /// can represent 3 states, Dead, LiveWithin, LiveOut. We take advantage of
-  /// their numeric values to make testing easier \see documentation on IsLive.
-  class LivenessSmallBitVector {
-    SmallBitVector bits;
-
-  public:
-    LivenessSmallBitVector() : bits() {}
-
-    void init(unsigned numBits) {
-      assert(bits.size() == 0);
-      assert(numBits != 0);
-      bits.resize(numBits * 2);
-    }
-
-    unsigned size() const { return bits.size() / 2; }
-
-    IsLive getLiveness(unsigned bitNo) const {
-      if (!bits[bitNo * 2])
-        return IsLive::Dead;
-      return bits[bitNo * 2 + 1] ? LiveOut : LiveWithin;
-    }
-
-    /// Returns the liveness in \p resultingFoundLiveness. We only return the
-    /// bits for endBitNo - startBitNo.
-    void getLiveness(unsigned startBitNo, unsigned endBitNo,
-                     SmallVectorImpl<IsLive> &resultingFoundLiveness) const {
-      unsigned actualStartBitNo = startBitNo * 2;
-      unsigned actualEndBitNo = endBitNo * 2;
-
-      for (unsigned i = actualStartBitNo, e = actualEndBitNo; i != e; i += 2) {
-        if (!bits[i]) {
-          resultingFoundLiveness.push_back(Dead);
-          continue;
-        }
-
-        resultingFoundLiveness.push_back(bits[i + 1] ? LiveOut : LiveWithin);
-      }
-    }
-
-    void setLiveness(unsigned startBitNo, unsigned endBitNo, IsLive isLive) {
-      for (unsigned i = startBitNo * 2, e = endBitNo * 2; i != e; i += 2) {
-        bits[i] = isLive & 1;
-        bits[i + 1] = isLive & 2;
-      }
-    }
-
-    void setLiveness(unsigned bitNo, IsLive isLive) {
-      setLiveness(bitNo, bitNo + 1, isLive);
-    }
-  };
-
 private:
-  /// Map all blocks in which current def is live to a SmallBitVector indicating
-  /// whether the value represented by said bit is also liveout of the block.
-  llvm::SmallDenseMap<SILBasicBlock *, LivenessSmallBitVector, 4> liveBlocks;
-
-  /// Number of bits of liveness to track. By default 1. Used to track multiple
-  /// liveness bits.
-  unsigned numBitsToTrack;
+  /// Map all blocks to an IsLive state.
+  BasicBlockBitfield liveBlocks;
 
   /// Optional vector of live blocks for clients that deterministically iterate.
-  SmallVectorImpl<SILBasicBlock *> *discoveredBlocks;
+  SmallVectorImpl<SILBasicBlock *> *discoveredBlocks = nullptr;
 
-  /// Once the first use has been seen, no definitions can be added.
-  SWIFT_ASSERT_ONLY_DECL(bool seenUse = false);
+  /// Only a clean bitfield can be initialized.
+  SWIFT_ASSERT_ONLY_DECL(bool cleanFlag = true);
+
+  /// Once the first def has been initialized, uses can be added.
+  SWIFT_ASSERT_ONLY_DECL(bool initializedFlag = false);
 
 public:
-  PrunedLiveBlocks(unsigned numBitsToTrack,
+  PrunedLiveBlocks(SILFunction *function,
                    SmallVectorImpl<SILBasicBlock *> *discoveredBlocks = nullptr)
-      : numBitsToTrack(numBitsToTrack), discoveredBlocks(discoveredBlocks) {
+      : liveBlocks(function, 2), discoveredBlocks(discoveredBlocks) {
     assert(!discoveredBlocks || discoveredBlocks->empty());
   }
 
-  unsigned getNumBitsToTrack() const { return numBitsToTrack; }
+  bool isInitialized() const { return initializedFlag; }
 
-  bool empty() const { return liveBlocks.empty(); }
-
-  void clear() {
-    liveBlocks.clear();
-    SWIFT_ASSERT_ONLY(seenUse = false);
+  void invalidate() {
+    initializedFlag = false;
+    cleanFlag = false;
   }
 
-  unsigned numLiveBlocks() const { return liveBlocks.size(); }
+  void initializeDiscoveredBlocks(
+      SmallVectorImpl<SILBasicBlock *> *discoveredBlocks) {
+    assert(!isInitialized() && "cannot reinitialize after blocks are live");
+
+    this->discoveredBlocks = discoveredBlocks;
+  }
 
   /// If the constructor was provided with a vector to populate, then this
   /// returns the list of all live blocks with no duplicates.
@@ -282,109 +223,51 @@ public:
     return *discoveredBlocks;
   }
 
-  void initializeDefBlock(SILBasicBlock *defBB, unsigned bitNo) {
-    markBlockLive(defBB, bitNo, LiveWithin);
-  }
-
-  void initializeDefBlock(SILBasicBlock *defBB, unsigned startBitNo,
-                          unsigned endBitNo) {
-    markBlockLive(defBB, startBitNo, endBitNo, LiveWithin);
+  void initializeDefBlock(SILBasicBlock *defBB) {
+    initializedFlag = true;
+    markBlockLive(defBB, LiveWithin);
   }
 
   /// Update this liveness result for a single use.
-  IsLive updateForUse(SILInstruction *user, unsigned bitNo) {
+  IsLive updateForUse(SILInstruction *user) {
+    assert(isInitialized() && "at least one definition must be initialized");
+
     auto *block = user->getParent();
-    auto liveness = getBlockLiveness(block, bitNo);
+    auto liveness = getBlockLiveness(block);
+    // If a block is already marked live, assume that liveness was propagated to
+    // its predecessors. This assumes that uses will never be added above a def
+    // in the same block.
     if (liveness != Dead)
       return liveness;
-    computeScalarUseBlockLiveness(block, bitNo);
-    return getBlockLiveness(block, bitNo);
+
+    computeUseBlockLiveness(block);
+    return getBlockLiveness(block);
   }
 
-  /// Update this range of liveness results for a single use.
-  void updateForUse(SILInstruction *user, unsigned startBitNo,
-                    unsigned endBitNo,
-                    SmallVectorImpl<IsLive> &resultingLiveness);
-
-  IsLive getBlockLiveness(SILBasicBlock *bb, unsigned bitNo) const {
-    auto liveBlockIter = liveBlocks.find(bb);
-    if (liveBlockIter == liveBlocks.end()) {
-      return Dead;
-    }
-
-    return liveBlockIter->second.getLiveness(bitNo);
-  }
-
-  /// FIXME: This API should directly return the live bitset. The live bitset
-  /// type should have an api for querying and iterating over the live fields.
-  void getBlockLiveness(SILBasicBlock *bb, unsigned startBitNo,
-                        unsigned endBitNo,
-                        SmallVectorImpl<IsLive> &foundLivenessInfo) const {
-    auto liveBlockIter = liveBlocks.find(bb);
-    if (liveBlockIter == liveBlocks.end()) {
-      for (unsigned i : range(endBitNo - startBitNo)) {
-        (void)i;
-        foundLivenessInfo.push_back(Dead);
-      }
-      return;
-    }
-
-    liveBlockIter->second.getLiveness(startBitNo, endBitNo, foundLivenessInfo);
+  IsLive getBlockLiveness(SILBasicBlock *bb) const {
+    assert(isInitialized());
+    return (IsLive)liveBlocks.get(bb);
   }
 
   llvm::StringRef getStringRef(IsLive isLive) const;
+
   void print(llvm::raw_ostream &OS) const;
+
   void dump() const;
 
 protected:
-  void markBlockLive(SILBasicBlock *bb, unsigned bitNo, IsLive isLive) {
+  void markBlockLive(SILBasicBlock *bb, IsLive isLive) {
     assert(isLive != Dead && "erasing live blocks isn't implemented.");
-    auto iterAndInserted =
-        liveBlocks.insert(std::make_pair(bb, LivenessSmallBitVector()));
-    if (iterAndInserted.second) {
-      // We initialize the size of the small bit vector here rather than in
-      // liveBlocks.insert above to prevent us from allocating upon failure if
-      // we have more than SmallBitVector's small size number of bits.
-      auto &insertedBV = iterAndInserted.first->getSecond();
-      insertedBV.init(numBitsToTrack);
-      insertedBV.setLiveness(bitNo, bitNo + 1, isLive);
+    auto state = (IsLive)liveBlocks.get(bb);
+    liveBlocks.set(bb, state | isLive);
+    if (state == IsLive::Dead) {
       if (discoveredBlocks)
         discoveredBlocks->push_back(bb);
-    } else {
-      // If we are dead, always update to the new liveness.
-      switch (iterAndInserted.first->getSecond().getLiveness(bitNo)) {
-      case Dead:
-        iterAndInserted.first->getSecond().setLiveness(bitNo, bitNo + 1,
-                                                       isLive);
-        break;
-      case LiveWithin:
-        if (isLive == LiveOut) {
-          // Update the existing entry to be live-out.
-          iterAndInserted.first->getSecond().setLiveness(bitNo, bitNo + 1,
-                                                         LiveOut);
-        }
-        break;
-      case LiveOut:
-        break;
-      }
-    }
-  }
-
-  void markBlockLive(SILBasicBlock *bb, unsigned startBitNo, unsigned endBitNo,
-                     IsLive isLive) {
-    for (unsigned index : range(startBitNo, endBitNo)) {
-      markBlockLive(bb, index, isLive);
     }
   }
 
 private:
-  /// A helper routine that as a fast path handles the scalar case. We do not
-  /// handle the mult-bit case today since the way the code is written today
-  /// assumes we process a bit at a time.
-  ///
-  /// TODO: Make a multi-bit query for efficiency reasons.
-  void computeScalarUseBlockLiveness(SILBasicBlock *userBB,
-                                     unsigned startBitNo);
+  void computeUseBlockLiveness(SILBasicBlock *userBB);
 };
 
 /// If inner borrows are 'Contained', then liveness is fully described by the
@@ -483,17 +366,19 @@ public:
                  SmallVectorImpl<SILBasicBlock *> *discoveredBlocks = nullptr)
       : liveBlocks(function, discoveredBlocks) {}
 
-  bool empty() const {
-    assert(!liveBlocks.empty() || users.empty());
-    return liveBlocks.empty();
-  }
+  bool isInitialized() const { return liveBlocks.isInitialized(); }
+
+  bool empty() const { return users.empty(); }
 
   void invalidate() {
     liveBlocks.invalidate();
     users.clear();
   }
 
-  unsigned numLiveBlocks() const { return liveBlocks.numLiveBlocks(); }
+  void initializeDiscoveredBlocks(
+      SmallVectorImpl<SILBasicBlock *> *discoveredBlocks) {
+    liveBlocks.initializeDiscoveredBlocks(discoveredBlocks);
+  }
 
   /// If the constructor was provided with a vector to populate, then this
   /// returns the list of all live blocks with no duplicates.
@@ -502,7 +387,7 @@ public:
   }
 
   void initializeDefBlock(SILBasicBlock *defBB) {
-    liveBlocks.initializeDefBlock(defBB, 0);
+    liveBlocks.initializeDefBlock(defBB);
   }
 
   /// For flexibility, \p lifetimeEnding is provided by the
@@ -527,7 +412,7 @@ public:
   void extendAcrossLiveness(PrunedLiveness &otherLiveness);
 
   PrunedLiveBlocks::IsLive getBlockLiveness(SILBasicBlock *bb) const {
-    return liveBlocks.getBlockLiveness(bb, 0);
+    return liveBlocks.getBlockLiveness(bb);
   }
 
   enum IsInterestingUser {
@@ -671,8 +556,9 @@ protected:
     return static_cast<const LivenessWithDefs &>(*this);
   }
 
-  PrunedLiveRange(SmallVectorImpl<SILBasicBlock *> *discoveredBlocks = nullptr)
-      : PrunedLiveness(discoveredBlocks) {}
+  PrunedLiveRange(SILFunction *function,
+                  SmallVectorImpl<SILBasicBlock *> *discoveredBlocks = nullptr)
+      : PrunedLiveness(function, discoveredBlocks) {}
 
   LiveRangeSummary recursivelyUpdateForDef(SILValue initialDef,
                                            ValueSet &visited,
@@ -821,8 +707,6 @@ public:
         defBlocks(function) {}
 
   void invalidate() {
-    defs.invalidate();
-    defBlocks.invalidate();
     PrunedLiveRange::invalidate();
   }
 

--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -488,8 +488,8 @@ public:
     return liveBlocks.empty();
   }
 
-  void clear() {
-    liveBlocks.clear();
+  void invalidate() {
+    liveBlocks.invalidate();
     users.clear();
   }
 
@@ -752,10 +752,10 @@ public:
 
   SILValue getDef() const { return def; }
 
-  void clear() {
+  void invalidate() {
     def = SILValue();
     defInst = nullptr;
-    PrunedLiveRange::clear();
+    PrunedLiveRange::invalidate();
   }
 
   void initializeDef(SILValue def) {
@@ -820,8 +820,10 @@ public:
       : PrunedLiveRange(function, discoveredBlocks), defs(function),
         defBlocks(function) {}
 
-  void clear() {
-    llvm_unreachable("multi-def liveness cannot be reused");
+  void invalidate() {
+    defs.invalidate();
+    defBlocks.invalidate();
+    PrunedLiveRange::invalidate();
   }
 
   void initializeDef(SILInstruction *defInst) {
@@ -895,8 +897,8 @@ public:
       : SSAPrunedLiveness(function, discoveredBlocks),
         nonLifetimeEndingUsesInLiveOut(nonLifetimeEndingUsesInLiveOut) {}
 
-  void clear() {
-    SSAPrunedLiveness::clear();
+  void invalidate() {
+    SSAPrunedLiveness::invalidate();
     if (nonLifetimeEndingUsesInLiveOut)
       nonLifetimeEndingUsesInLiveOut->clear();
   }

--- a/include/swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeBorrowScope.h
@@ -85,7 +85,8 @@ private:
   llvm::SmallDenseMap<SILBasicBlock *, CopyValueInst *, 4> persistentCopies;
 
 public:
-  CanonicalizeBorrowScope(InstructionDeleter &deleter) : deleter(deleter) {}
+  CanonicalizeBorrowScope(SILFunction *function, InstructionDeleter &deleter)
+    : liveness(function), deleter(deleter) {}
 
   BorrowedValue getBorrowedValue() const { return borrowedValue; }
 

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -302,10 +302,10 @@ public:
     liveness.initializeDef(def);
   }
 
-  void clearLiveness() {
+  void invalidateLiveness() {
     consumingBlocks.clear();
     debugValues.clear();
-    liveness.clear();
+    liveness.invalidate();
     discoveredBlocks.clear();
   }
 

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -223,9 +223,12 @@ private:
   // extendLivenessThroughOverlappingAccess is invoked.
   NonLocalAccessBlocks *accessBlocks = nullptr;
 
-  DominanceInfo *domTree;
+  DominanceInfo *domTree = nullptr;
 
   InstructionDeleter &deleter;
+
+  /// The SILValue to canonicalize.
+  SILValue currentDef;
 
   /// Original points in the CFG where the current value's lifetime is consumed
   /// or destroyed. For guaranteed values it remains empty. A backward walk from
@@ -250,7 +253,7 @@ private:
   /// Pruned liveness for the extended live range including copies. For this
   /// purpose, only consuming instructions are considered "lifetime
   /// ending". end_borrows do not end a liverange that may include owned copies.
-  SSAPrunedLiveness liveness;
+  BitfieldRef<SSAPrunedLiveness> liveness;
 
   /// The destroys of the value.  These are not uses, but need to be recorded so
   /// that we know when the last use in a consuming block is (without having to
@@ -280,32 +283,46 @@ public:
     }
   }
 
+  /// Stack-allocated liveness for a single SSA def.
+  struct LivenessState {
+    BitfieldRef<SSAPrunedLiveness>::StackState state;
+
+    LivenessState(CanonicalizeOSSALifetime &parent, SILValue def)
+        : state(parent.liveness, def->getFunction()) {
+      parent.initializeLiveness(def);
+    }
+  };
+
   CanonicalizeOSSALifetime(bool pruneDebugMode, bool maximizeLifetime,
                            SILFunction *function,
                            NonLocalAccessBlockAnalysis *accessBlockAnalysis,
                            DominanceInfo *domTree, InstructionDeleter &deleter)
       : pruneDebugMode(pruneDebugMode), maximizeLifetime(maximizeLifetime),
         accessBlockAnalysis(accessBlockAnalysis), domTree(domTree),
-        deleter(deleter),
-        liveness(function, maximizeLifetime ? &discoveredBlocks : nullptr) {}
+        deleter(deleter) {}
 
-  SILValue getCurrentDef() const { return liveness.getDef(); }
+  SILValue getCurrentDef() const { return currentDef; }
 
-  void initDef(SILValue def) {
-    assert(consumingBlocks.empty() && debugValues.empty() && liveness.empty());
+  void initializeLiveness(SILValue def) {
+    assert(consumingBlocks.empty() && debugValues.empty());
     // Clear the cached analysis pointer just in case the client invalidates the
     // analysis, freeing its memory.
     accessBlocks = nullptr;
     consumes.clear();
     destroys.clear();
 
-    liveness.initializeDef(def);
+    currentDef = def;
+
+    if (maximizeLifetime) {
+      liveness->initializeDiscoveredBlocks(&discoveredBlocks);
+    }
+    liveness->initializeDef(getCurrentDef());
   }
 
   void invalidateLiveness() {
     consumingBlocks.clear();
     debugValues.clear();
-    liveness.invalidate();
+    liveness->invalidate();
     discoveredBlocks.clear();
   }
 
@@ -328,19 +345,23 @@ public:
   ///
   /// The intention is that this is used if one wants to emit diagnostics using
   /// the liveness information before doing any rewriting.
-  bool computeLiveness(SILValue def);
+  ///
+  /// Requires an active on-stack instance of LivenessState.
+  ///
+  ///     LivenessState livenessState(*this, def);
+  ///
+  bool computeLiveness();
 
   /// Given the already computed liveness boundary for the given def, rewrite
   /// copies of def as appropriate.
   ///
-  /// NOTE: It is assumed that one passes the extended boundary from \see
-  /// computeLiveness.
-  ///
-  /// NOTE: It is assumed that one has emitted any diagnostics.
+  /// Requires an active on-stack instance of LivenessState.
   void rewriteLifetimes();
 
   /// Return the pure original boundary just based off of liveness information
   /// without maximizing or extending liveness.
+  ///
+  /// Requires an active on-stack instance of LivenessState.
   void findOriginalBoundary(PrunedLivenessBoundary &resultingOriginalBoundary);
 
   InstModCallbacks &getCallbacks() { return deleter.getCallbacks(); }
@@ -353,21 +374,21 @@ public:
   /// NOTE: Only call this after calling computeLivenessBoundary or the results
   /// will not be initialized.
   IsInterestingUser isInterestingUser(SILInstruction *user) const {
-    return liveness.isInterestingUser(user);
+    return liveness->isInterestingUser(user);
   }
 
   using LifetimeEndingUserRange = PrunedLiveness::LifetimeEndingUserRange;
   LifetimeEndingUserRange getLifetimeEndingUsers() const {
-    return liveness.getLifetimeEndingUsers();
+    return liveness->getLifetimeEndingUsers();
   }
 
   using NonLifetimeEndingUserRange = PrunedLiveness::NonLifetimeEndingUserRange;
   NonLifetimeEndingUserRange getNonLifetimeEndingUsers() const {
-    return liveness.getNonLifetimeEndingUsers();
+    return liveness->getNonLifetimeEndingUsers();
   }
 
   using UserRange = PrunedLiveness::ConstUserRange;
-  UserRange getUsers() const { return liveness.getAllUsers(); }
+  UserRange getUsers() const { return liveness->getAllUsers(); }
 
 private:
   void recordDebugValue(DebugValueInst *dvi) { debugValues.insert(dvi); }

--- a/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
+++ b/include/swift/SILOptimizer/Utils/CanonicalizeOSSALifetime.h
@@ -281,12 +281,13 @@ public:
   }
 
   CanonicalizeOSSALifetime(bool pruneDebugMode, bool maximizeLifetime,
+                           SILFunction *function,
                            NonLocalAccessBlockAnalysis *accessBlockAnalysis,
                            DominanceInfo *domTree, InstructionDeleter &deleter)
       : pruneDebugMode(pruneDebugMode), maximizeLifetime(maximizeLifetime),
         accessBlockAnalysis(accessBlockAnalysis), domTree(domTree),
         deleter(deleter),
-        liveness(maximizeLifetime ? &discoveredBlocks : nullptr) {}
+        liveness(function, maximizeLifetime ? &discoveredBlocks : nullptr) {}
 
   SILValue getCurrentDef() const { return liveness.getDef(); }
 

--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -115,9 +115,9 @@ public:
     : deleter(deleter), deBlocks(deBlocks),
       guaranteedLiveness(function), ownedLifetime(function) {}
 
-  void clear() {
-    guaranteedLiveness.clear();
-    ownedLifetime.clear();
+  void invalidate() {
+    guaranteedLiveness.invalidate();
+    ownedLifetime.invalidate();
     ownedConsumeBlocks.clear();
     beginBorrow = nullptr;
   }

--- a/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/OwnershipOptUtils.h
@@ -113,7 +113,7 @@ public:
   GuaranteedOwnershipExtension(InstructionDeleter &deleter,
                                DeadEndBlocks &deBlocks, SILFunction *function)
     : deleter(deleter), deBlocks(deBlocks),
-      guaranteedLiveness(function) {}
+      guaranteedLiveness(function), ownedLifetime(function) {}
 
   void clear() {
     guaranteedLiveness.clear();

--- a/lib/SIL/Utils/OwnershipUtils.cpp
+++ b/lib/SIL/Utils/OwnershipUtils.cpp
@@ -1213,7 +1213,7 @@ bool AddressOwnership::areUsesWithinLifetime(
   // --- A reference with no borrow scope! Currently happens for project_box.
 
   // Compute the reference value's liveness.
-  SSAPrunedLiveness liveness;
+  SSAPrunedLiveness liveness(root->getFunction());
   liveness.initializeDef(root);
   LiveRangeSummary summary = liveness.computeSimple();
   // Conservatively ignore InnerBorrowKind::Reborrowed and

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -2545,7 +2545,7 @@ public:
                     SI->getSrc()->getType(),
                     "Store operand type and dest type mismatch");
 
-    SSAPrunedLiveness scopedAddressLiveness;
+    SSAPrunedLiveness scopedAddressLiveness(SI->getFunction());
     ScopedAddressValue scopedAddress(SI);
     // FIXME: Reenable @test_load_borrow_store_borrow_nested in
     // store_borrow_verify_errors once computeLivess can successfully handle a

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -352,7 +352,7 @@ static bool isStoreCopy(SILValue value) {
   if (!storeInst)
     return false;
 
-  SSAPrunedLiveness liveness;
+  SSAPrunedLiveness liveness(copyInst->getFunction());
   auto isStoreOutOfRange = [&liveness, storeInst](SILValue root) {
     liveness.initializeDef(root);
     auto summary = liveness.computeSimple();
@@ -3366,7 +3366,7 @@ static void emitEndBorrows(SILValue value, AddressLoweringState &pass) {
   findInnerTransitiveGuaranteedUses(value, &usePoints);
 
   SmallVector<SILBasicBlock *, 4> discoveredBlocks;
-  SSAPrunedLiveness liveness(&discoveredBlocks);
+  SSAPrunedLiveness liveness(value->getFunction(), &discoveredBlocks);
   liveness.initializeDef(value);
   for (auto *use : usePoints) {
     assert(!use->isLifetimeEnding() || isa<EndBorrowInst>(use->getUser()));

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -78,7 +78,7 @@ struct CheckerLivenessInfo {
 
   void clear() {
     defUseWorklist.clear();
-    liveness.clear();
+    liveness.invalidate();
     consumingUse.clear();
     interiorPointerTransitiveUses.clear();
     nonLifetimeEndingUsesInLiveOut.clear();

--- a/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
+++ b/lib/SILOptimizer/Mandatory/ConsumeOperatorCopyableValuesChecker.cpp
@@ -60,9 +60,9 @@ struct CheckerLivenessInfo {
   SmallVector<Operand *, 8> interiorPointerTransitiveUses;
   DiagnosticPrunedLiveness liveness;
 
-  CheckerLivenessInfo()
+  CheckerLivenessInfo(SILFunction *fn)
       : nonLifetimeEndingUsesInLiveOut(),
-        liveness(nullptr, &nonLifetimeEndingUsesInLiveOut) {}
+        liveness(fn, nullptr, &nonLifetimeEndingUsesInLiveOut) {}
 
   void initDef(SILValue def) {
     liveness.initializeDef(def);
@@ -220,7 +220,7 @@ struct ConsumeOperatorCopyableValuesChecker {
   SILLoopInfo *loopInfoToUpdate;
 
   ConsumeOperatorCopyableValuesChecker(SILFunction *fn)
-      : fn(fn), livenessInfo(), dominanceToUpdate(nullptr),
+      : fn(fn), livenessInfo(fn), dominanceToUpdate(nullptr),
         loopInfoToUpdate(nullptr) {}
 
   void setDominanceToUpdate(DominanceInfo *newDFI) {

--- a/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
@@ -63,6 +63,8 @@ class DiagnoseLifetimeIssues {
   /// callgraphs, with pass down references.
   static constexpr int maxCallDepth = 8;
 
+  SILFunction *function = nullptr;
+
   /// The liveness of the object in question, computed in visitUses.
   SSAPrunedLiveness liveness;
 
@@ -84,9 +86,10 @@ class DiagnoseLifetimeIssues {
   void reportDeadStore(SILInstruction *allocationInst);
 
 public:
-  DiagnoseLifetimeIssues() {}
+  DiagnoseLifetimeIssues(SILFunction *function)
+    : function(function), liveness(function) {}
 
-  void diagnose(SILFunction *function);
+  void diagnose();
 };
 
 /// Returns true if def is an owned value resulting from an object allocation.
@@ -352,7 +355,7 @@ void DiagnoseLifetimeIssues::reportDeadStore(SILInstruction *allocationInst) {
 }
 
 /// Prints warnings for dead weak stores in \p function.
-void DiagnoseLifetimeIssues::diagnose(SILFunction *function) {
+void DiagnoseLifetimeIssues::diagnose() {
   for (SILBasicBlock &block : *function) {
     for (SILInstruction &inst : block) {
       // Only for allocations we know that a destroy will actually deallocate

--- a/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
@@ -326,7 +326,7 @@ static bool isOutOfLifetime(SILInstruction *inst, SSAPrunedLiveness &liveness) {
 /// Reports a warning if the stored object \p storedObj is never loaded within
 /// the lifetime of the stored object.
 void DiagnoseLifetimeIssues::reportDeadStore(SILInstruction *allocationInst) {
-  liveness.clear();
+  liveness.invalidate();
   weakStores.clear();
 
   SILValue storedDef = cast<SingleValueInstruction>(allocationInst);

--- a/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseLifetimeIssues.cpp
@@ -385,8 +385,8 @@ private:
     if (!function->hasOwnership())
       return;
 
-    DiagnoseLifetimeIssues diagnoser;
-    diagnoser.diagnose(function);
+    DiagnoseLifetimeIssues diagnoser(function);
+    diagnoser.diagnose();
   }
 };
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -2289,7 +2289,7 @@ bool MoveOnlyAddressCheckerPImpl::performSingleCheck(
   // to categorize the uses of this address into their ownership behavior (e.x.:
   // init, reinit, take, destroy, etc.).
   SmallVector<SILBasicBlock *, 32> gatherUsesDiscoveredBlocks;
-  SSAPrunedLiveness gatherUsesLiveness(&gatherUsesDiscoveredBlocks);
+  SSAPrunedLiveness gatherUsesLiveness(fn, &gatherUsesDiscoveredBlocks);
   GatherUsesVisitor visitor(*this, addressUseState, markedAddress,
                             diagnosticEmitter, gatherUsesLiveness);
   SWIFT_DEFER { visitor.clear(); };

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1049,6 +1049,8 @@ struct MoveOnlyAddressCheckerPImpl {
 
   SILFunction *fn;
 
+  DominanceInfo *domTree;
+
   /// A set of mark_must_check that we are actually going to process.
   SmallSetVector<MarkMustCheckInst *, 32> moveIntroducersToProcess;
 
@@ -1078,7 +1080,8 @@ struct MoveOnlyAddressCheckerPImpl {
       SILFunction *fn, DiagnosticEmitter &diagnosticEmitter,
       DominanceInfo *domTree, PostOrderAnalysis *poa,
       borrowtodestructure::IntervalMapAllocator &allocator)
-      : fn(fn), deleter(), canonicalizer(),
+      : fn(fn), domTree(domTree), deleter(),
+        canonicalizer(fn, domTree, deleter),
         diagnosticEmitter(diagnosticEmitter), poa(poa), allocator(allocator) {
     deleter.setCallbacks(std::move(
         InstModCallbacks().onDelete([&](SILInstruction *instToDelete) {
@@ -1086,7 +1089,6 @@ struct MoveOnlyAddressCheckerPImpl {
             moveIntroducersToProcess.remove(mvi);
           instToDelete->eraseFromParent();
         })));
-    canonicalizer.init(fn, domTree, deleter);
     diagnosticEmitter.initCanonicalizer(&canonicalizer);
   }
 
@@ -1466,7 +1468,9 @@ bool GatherUsesVisitor::visitUse(Operand *op, AccessUseType useTy) {
 
     if (li->getOwnershipQualifier() == LoadOwnershipQualifier::Copy ||
         li->getOwnershipQualifier() == LoadOwnershipQualifier::Take) {
-      SWIFT_DEFER { moveChecker.canonicalizer.clear(); };
+
+      OSSACanonicalizer::LivenessState livenessState(moveChecker.canonicalizer,
+                                                     li);
 
       // Before we do anything, run the borrow to destructure transform in case
       // we have a switch_enum user.
@@ -1495,7 +1499,7 @@ bool GatherUsesVisitor::visitUse(Operand *op, AccessUseType useTy) {
 
       // Canonicalize the lifetime of the load [take], load [copy].
       LLVM_DEBUG(llvm::dbgs() << "Running copy propagation!\n");
-      moveChecker.changed |= moveChecker.canonicalizer.canonicalize(li);
+      moveChecker.changed |= moveChecker.canonicalizer.canonicalize();
 
       // If we are asked to perform no_consume_or_assign checking or
       // assignable_but_not_consumable checking, if we found any consumes of our

--- a/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyAddressCheckerUtils.cpp
@@ -1292,7 +1292,7 @@ struct GatherUsesVisitor : public AccessUseVisitor {
 
   /// Returns true if we emitted an error.
   bool checkForExclusivityHazards(LoadInst *li) {
-    SWIFT_DEFER { liveness.clear(); };
+    SWIFT_DEFER { liveness.invalidate(); };
 
     LLVM_DEBUG(llvm::dbgs() << "Checking for exclusivity hazards for: " << *li);
 

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
@@ -1507,7 +1507,6 @@ void Implementation::cleanup() {
   // not actually completely consume.
   auto *fn = getMarkedValue()->getFunction();
   SmallVector<SILBasicBlock *, 8> discoveredBlocks;
-  SSAPrunedLiveness liveness(fn, &discoveredBlocks);
   PrunedLivenessBoundary boundary;
   while (!interface.createdDestructures.empty()) {
     auto *inst = interface.createdDestructures.pop_back_val();
@@ -1515,8 +1514,8 @@ void Implementation::cleanup() {
     for (auto result : inst->getResults()) {
       if (result->getType().isTrivial(*fn))
         continue;
+      SSAPrunedLiveness liveness(fn, &discoveredBlocks);
       SWIFT_DEFER {
-        liveness.invalidate();
         discoveredBlocks.clear();
         boundary.clear();
       };
@@ -1533,8 +1532,8 @@ void Implementation::cleanup() {
     if (arg->getType().isTrivial(*fn))
       continue;
 
+    SSAPrunedLiveness liveness(fn, &discoveredBlocks);
     SWIFT_DEFER {
-      liveness.invalidate();
       discoveredBlocks.clear();
       boundary.clear();
     };
@@ -1542,6 +1541,7 @@ void Implementation::cleanup() {
   }
 
   // And finally do the same thing for our initial copy_value.
+  SSAPrunedLiveness liveness(fn, &discoveredBlocks);
   addCompensatingDestroys(liveness, boundary, initialValue);
 }
 
@@ -1868,7 +1868,6 @@ bool BorrowToDestructureTransform::transform() {
       // copy_value in each destination block that we originally inserted.
       {
         SmallVector<SILBasicBlock *, 8> discoveredBlocks;
-        SSAPrunedLiveness liveness(fn, &discoveredBlocks);
         PrunedLivenessBoundary boundary;
 
         SILBuilderWithScope builder(s);
@@ -1887,8 +1886,8 @@ bool BorrowToDestructureTransform::transform() {
 
             // If we have a copyable type, we need to insert compensating
             // destroys.
+            SSAPrunedLiveness liveness(fn, &discoveredBlocks);
             SWIFT_DEFER {
-              liveness.invalidate();
               discoveredBlocks.clear();
               boundary.clear();
             };

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
@@ -1507,7 +1507,7 @@ void Implementation::cleanup() {
   // not actually completely consume.
   auto *fn = getMarkedValue()->getFunction();
   SmallVector<SILBasicBlock *, 8> discoveredBlocks;
-  SSAPrunedLiveness liveness(&discoveredBlocks);
+  SSAPrunedLiveness liveness(fn, &discoveredBlocks);
   PrunedLivenessBoundary boundary;
   while (!interface.createdDestructures.empty()) {
     auto *inst = interface.createdDestructures.pop_back_val();
@@ -1868,7 +1868,7 @@ bool BorrowToDestructureTransform::transform() {
       // copy_value in each destination block that we originally inserted.
       {
         SmallVector<SILBasicBlock *, 8> discoveredBlocks;
-        SSAPrunedLiveness liveness(&discoveredBlocks);
+        SSAPrunedLiveness liveness(fn, &discoveredBlocks);
         PrunedLivenessBoundary boundary;
 
         SILBuilderWithScope builder(s);

--- a/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyBorrowToDestructureUtils.cpp
@@ -1516,7 +1516,7 @@ void Implementation::cleanup() {
       if (result->getType().isTrivial(*fn))
         continue;
       SWIFT_DEFER {
-        liveness.clear();
+        liveness.invalidate();
         discoveredBlocks.clear();
         boundary.clear();
       };
@@ -1534,7 +1534,7 @@ void Implementation::cleanup() {
       continue;
 
     SWIFT_DEFER {
-      liveness.clear();
+      liveness.invalidate();
       discoveredBlocks.clear();
       boundary.clear();
     };
@@ -1888,7 +1888,7 @@ bool BorrowToDestructureTransform::transform() {
             // If we have a copyable type, we need to insert compensating
             // destroys.
             SWIFT_DEFER {
-              liveness.clear();
+              liveness.invalidate();
               discoveredBlocks.clear();
               boundary.clear();
             };

--- a/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/MoveOnlyDiagnostics.cpp
@@ -259,13 +259,12 @@ void DiagnosticEmitter::emitObjectOwnedDiagnostic(
   // not be identified as part of the boundary and instead we will identify a
   // boundary edge which does not provide us with something that we want to
   // error upon.
-  for (auto *user :
-       getCanonicalizer().canonicalizer->getLifetimeEndingUsers()) {
+  for (auto *user : getCanonicalizer().canonicalizer.getLifetimeEndingUsers()) {
     consumingUserSet.insert(user);
     consumingBlockToUserMap.try_emplace(user->getParent(), user);
   }
   for (auto *user :
-       getCanonicalizer().canonicalizer->getNonLifetimeEndingUsers()) {
+       getCanonicalizer().canonicalizer.getNonLifetimeEndingUsers()) {
     nonConsumingUserSet.insert(user);
     nonConsumingBlockToUserMap.try_emplace(user->getParent(), user);
   }

--- a/lib/SILOptimizer/Mandatory/ReferenceBindingTransform.cpp
+++ b/lib/SILOptimizer/Mandatory/ReferenceBindingTransform.cpp
@@ -164,7 +164,7 @@ static bool runTransform(SILFunction *fn) {
     // Ok, we have our initialization. Now gather our destroys of our value and
     // initialize an SSAPrunedLiveness, using our initInst as our def.
     SmallVector<SILBasicBlock *, 8> discoveredBlocks;
-    SSAPrunedLiveness liveness(&discoveredBlocks);
+    SSAPrunedLiveness liveness(fn, &discoveredBlocks);
     StackList<DestroyValueInst *> destroyValueInst(fn);
     liveness.initializeDef(mark);
     for (auto *consume : mark->getConsumingUses()) {

--- a/lib/SILOptimizer/SILCombiner/SILCombine.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombine.cpp
@@ -353,8 +353,9 @@ void SILCombiner::canonicalizeOSSALifetimes(SILInstruction *currentInst) {
   CanonicalizeOSSALifetime canonicalizer(
       false /*prune debug*/,
       !parentTransform->getFunction()->shouldOptimize() /*maximize lifetime*/,
-      NLABA, domTree, deleter);
-  CanonicalizeBorrowScope borrowCanonicalizer(deleter);
+      parentTransform->getFunction(), NLABA, domTree, deleter);
+  CanonicalizeBorrowScope borrowCanonicalizer(parentTransform->getFunction(),
+                                              deleter);
 
   while (!defsToCanonicalize.empty()) {
     SILValue def = defsToCanonicalize.pop_back_val();

--- a/lib/SILOptimizer/Transforms/CopyPropagation.cpp
+++ b/lib/SILOptimizer/Transforms/CopyPropagation.cpp
@@ -472,7 +472,7 @@ void CopyPropagation::run() {
   // don't need to explicitly check for changes.
   CanonicalizeOSSALifetime canonicalizer(
       pruneDebug, /*maximizeLifetime=*/!getFunction()->shouldOptimize(),
-      accessBlockAnalysis, domTree, deleter);
+      getFunction(), accessBlockAnalysis, domTree, deleter);
   auto *calleeAnalysis = getAnalysis<BasicCalleeAnalysis>();
 
   // NOTE: We assume that the function is in reverse post order so visiting the
@@ -536,7 +536,7 @@ void CopyPropagation::run() {
   }
   // borrowCanonicalizer performs all modifications through deleter's
   // callbacks, so we don't need to explicitly check for changes.
-  CanonicalizeBorrowScope borrowCanonicalizer(deleter);
+  CanonicalizeBorrowScope borrowCanonicalizer(f, deleter);
   // The utilities in this loop cannot delete borrows before they are popped
   // from the worklist.
   while (true) {

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -319,7 +319,7 @@ struct SSALivenessTest : UnitTest {
     llvm::outs() << "SSA lifetime analysis: " << value;
 
     SmallVector<SILBasicBlock *, 8> discoveredBlocks;
-    SSAPrunedLiveness liveness(&discoveredBlocks);
+    SSAPrunedLiveness liveness(value->getFunction(), &discoveredBlocks);
     liveness.initializeDef(value);
     LiveRangeSummary summary = liveness.computeSimple();
     if (summary.innerBorrowKind == InnerBorrowKind::Reborrowed)
@@ -354,7 +354,7 @@ struct ScopedAddressLivenessTest : UnitTest {
     assert(scopedAddress);
 
     SmallVector<SILBasicBlock *, 8> discoveredBlocks;
-    SSAPrunedLiveness liveness(&discoveredBlocks);
+    SSAPrunedLiveness liveness(value->getFunction(), &discoveredBlocks);
     scopedAddress.computeTransitiveLiveness(liveness);
     liveness.print(llvm::outs());
 
@@ -410,7 +410,7 @@ struct CanonicalizeOSSALifetimeTest : UnitTest {
     auto respectAccessScopes = arguments.takeBool();
     InstructionDeleter deleter;
     CanonicalizeOSSALifetime canonicalizer(
-        pruneDebug, maximizeLifetimes,
+        pruneDebug, maximizeLifetimes, getFunction(),
         respectAccessScopes ? accessBlockAnalysis : nullptr, domTree, deleter);
     auto value = arguments.takeValue();
     canonicalizer.canonicalizeValueLifetime(value);
@@ -429,7 +429,7 @@ struct CanonicalizeBorrowScopeTest : UnitTest {
     auto borrowedValue = BorrowedValue(value);
     assert(borrowedValue && "specified value isn't a BorrowedValue!?");
     InstructionDeleter deleter;
-    CanonicalizeBorrowScope canonicalizer(deleter);
+    CanonicalizeBorrowScope canonicalizer(value->getFunction(), deleter);
     canonicalizer.canonicalizeBorrowScope(borrowedValue);
     getFunction()->dump();
   }

--- a/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeBorrowScope.cpp
@@ -822,7 +822,7 @@ bool CanonicalizeBorrowScope::canonicalizeFunctionArgument(
 
   LLVM_DEBUG(llvm::dbgs() << "*** Canonicalize Borrow: " << borrowedValue);
 
-  SWIFT_DEFER { liveness.clear(); };
+  SWIFT_DEFER { liveness.invalidate(); };
 
   RewriteInnerBorrowUses innerRewriter(*this);
   beginVisitBorrowScopeUses(); // reset the def/use worklist
@@ -841,7 +841,7 @@ canonicalizeBorrowScope(BorrowedValue borrowedValue) {
 
   initBorrow(borrowedValue);
 
-  SWIFT_DEFER { liveness.clear(); };
+  SWIFT_DEFER { liveness.invalidate(); };
 
   if (!computeBorrowLiveness())
     return false;

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -1017,7 +1017,7 @@ bool CanonicalizeOSSALifetime::computeLiveness(SILValue def) {
   // Step 1: compute liveness
   if (!computeCanonicalLiveness()) {
     LLVM_DEBUG(llvm::errs() << "Failed to compute canonical liveness?!\n");
-    clearLiveness();
+    invalidateLiveness();
     return false;
   }
   if (accessBlockAnalysis) {
@@ -1051,7 +1051,7 @@ void CanonicalizeOSSALifetime::rewriteLifetimes() {
   // Step 6: rewrite copies and delete extra destroys
   rewriteCopies();
 
-  clearLiveness();
+  invalidateLiveness();
   consumes.clear();
 }
 

--- a/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
+++ b/lib/SILOptimizer/Utils/CanonicalizeOSSALifetime.cpp
@@ -144,7 +144,7 @@ bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {
         if (auto *dvi = dyn_cast<DebugValueInst>(user)) {
           // Only instructions potentially outside current pruned liveness are
           // interesting.
-          if (liveness.getBlockLiveness(dvi->getParent())
+          if (liveness->getBlockLiveness(dvi->getParent())
               != PrunedLiveBlocks::LiveOut) {
             recordDebugValue(dvi);
           }
@@ -165,23 +165,23 @@ bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {
       case OperandOwnership::InstantaneousUse:
       case OperandOwnership::UnownedInstantaneousUse:
       case OperandOwnership::BitwiseEscape:
-        liveness.updateForUse(user, /*lifetimeEnding*/ false);
+        liveness->updateForUse(user, /*lifetimeEnding*/ false);
         break;
       case OperandOwnership::ForwardingConsume:
         recordConsumingUse(use);
-        liveness.updateForUse(user, /*lifetimeEnding*/ true);
+        liveness->updateForUse(user, /*lifetimeEnding*/ true);
         break;
       case OperandOwnership::DestroyingConsume:
         if (isa<DestroyValueInst>(user)) {
           destroys.insert(user);
         } else {
           // destroy_value does not force pruned liveness (but store etc. does).
-          liveness.updateForUse(user, /*lifetimeEnding*/ true);
+          liveness->updateForUse(user, /*lifetimeEnding*/ true);
         }
         recordConsumingUse(use);
         break;
       case OperandOwnership::Borrow:
-        if (liveness.updateForBorrowingOperand(use)
+        if (liveness->updateForBorrowingOperand(use)
             != InnerBorrowKind::Contained) {
           return false;
         }
@@ -194,7 +194,7 @@ bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {
         // either dominates it or its lifetime ends at an outer adjacent
         // reborrow. Only instructions that end the reborrow lifetime should
         // actually affect liveness of the outer owned value.
-        liveness.updateForUse(user, /*lifetimeEnding*/ false);
+        liveness->updateForUse(user, /*lifetimeEnding*/ false);
         break;
       case OperandOwnership::Reborrow:
         BranchInst *branch = cast<BranchInst>(user);
@@ -206,11 +206,11 @@ bool CanonicalizeOSSALifetime::computeCanonicalLiveness() {
           // An adjacent phi consumes the value being reborrowed. Although this
           // use doesn't end the lifetime, this branch does end the lifetime by
           // consuming the owned value.
-          liveness.updateForUse(branch, /*lifetimeEnding*/ true);
+          liveness->updateForUse(branch, /*lifetimeEnding*/ true);
           break;
         }
         // No adjacent phi consumes the value.  This use is not lifetime ending.
-        liveness.updateForUse(branch, /*lifetimeEnding*/ false);
+        liveness->updateForUse(branch, /*lifetimeEnding*/ false);
         // This branch reborrows a guaranteed phi whose lifetime is dependent on
         // currentDef.  Uses of the reborrowing phi extend liveness.
         auto *reborrow = PhiOperand(use).getValue();
@@ -258,7 +258,7 @@ endsAccessOverlappingPrunedBoundary(SILInstruction *inst) {
   }
   auto *beginAccess = endAccess->getBeginAccess();
   SILBasicBlock *beginBB = beginAccess->getParent();
-  switch (liveness.getBlockLiveness(beginBB)) {
+  switch (liveness->getBlockLiveness(beginBB)) {
   case PrunedLiveBlocks::LiveOut:
     // Found partial overlap of the form:
     //     currentDef
@@ -277,9 +277,10 @@ endsAccessOverlappingPrunedBoundary(SILInstruction *inst) {
     //     endAccess
     if (std::find_if(std::next(beginAccess->getIterator()), beginBB->end(),
                      [this](SILInstruction &nextInst) {
-                       return liveness.isInterestingUser(&nextInst)
-                         != PrunedLiveness::NonUser;
-                     }) != beginBB->end()) {
+                       return liveness->isInterestingUser(&nextInst)
+                              != PrunedLiveness::NonUser;
+                     })
+        != beginBB->end()) {
       // An interesting use after the beginAccess means overlap.
       return true;
     }
@@ -362,7 +363,7 @@ void CanonicalizeOSSALifetime::extendLivenessThroughOverlappingAccess() {
       auto *bb = *iterator;
       // If the block isn't dead, then we won't need to extend liveness within
       // any of its predecessors (though we may within it).
-      if (liveness.getBlockLiveness(bb) != PrunedLiveBlocks::Dead)
+      if (liveness->getBlockLiveness(bb) != PrunedLiveBlocks::Dead)
         continue;
       // Continue searching upward to find the pruned liveness boundary.
       for (auto *predBB : bb->getPredecessorBlocks()) {
@@ -370,7 +371,7 @@ void CanonicalizeOSSALifetime::extendLivenessThroughOverlappingAccess() {
       }
     }
     for (auto *bb : blocksToVisit) {
-      auto blockLiveness = liveness.getBlockLiveness(bb);
+      auto blockLiveness = liveness->getBlockLiveness(bb);
       // Ignore blocks within pruned liveness.
       if (blockLiveness == PrunedLiveBlocks::LiveOut) {
         continue;
@@ -391,23 +392,24 @@ void CanonicalizeOSSALifetime::extendLivenessThroughOverlappingAccess() {
       // We need to avoid extending liveness over end_accesses that occur after
       // original liveness ended.
       bool findLastConsume =
-          consumingBlocks.contains(bb) &&
-          llvm::none_of(bb->getSuccessorBlocks(), [&](auto *successor) {
-            return blocksToVisit.contains(successor) &&
-                   liveness.getBlockLiveness(successor) ==
-                       PrunedLiveBlocks::Dead;
-          });
+          consumingBlocks.contains(bb)
+          && llvm::none_of(bb->getSuccessorBlocks(), [&](auto *successor) {
+               return blocksToVisit.contains(successor)
+                      && liveness->getBlockLiveness(successor)
+                             == PrunedLiveBlocks::Dead;
+             });
       for (auto &inst : llvm::reverse(*bb)) {
         if (findLastConsume) {
           findLastConsume = !destroys.contains(&inst);
           continue;
         }
         // Stop at the latest use. An earlier end_access does not overlap.
-        if (blockHasUse && liveness.isInterestingUser(&inst) != PrunedLiveness::NonUser) {
+        if (blockHasUse
+            && liveness->isInterestingUser(&inst) != PrunedLiveness::NonUser) {
           break;
         }
         if (endsAccessOverlappingPrunedBoundary(&inst)) {
-          liveness.updateForUse(&inst, /*lifetimeEnding*/ false);
+          liveness->updateForUse(&inst, /*lifetimeEnding*/ false);
           changed = true;
           break;
         }
@@ -429,7 +431,7 @@ void CanonicalizeOSSALifetime::findOriginalBoundary(
     PrunedLivenessBoundary &boundary) {
   assert(boundary.lastUsers.size() == 0 && boundary.boundaryEdges.size() == 0 &&
          boundary.deadDefs.size() == 0);
-  liveness.computeBoundary(boundary, consumingBlocks.getArrayRef());
+  liveness->computeBoundary(boundary, consumingBlocks.getArrayRef());
 }
 
 //===----------------------------------------------------------------------===//
@@ -477,7 +479,7 @@ void CanonicalizeOSSALifetime::extendUnconsumedLiveness(
     // uses and blocks that appear between them and the def.
     //
     // Seed the set with what it already discovered.
-    for (auto *discoveredBlock : liveness.getDiscoveredBlocks())
+    for (auto *discoveredBlock : liveness->getDiscoveredBlocks())
       originalLiveBlocks.insert(discoveredBlock);
 
     // Start the walk from the consuming blocks (which includes destroys as well
@@ -511,8 +513,8 @@ void CanonicalizeOSSALifetime::extendUnconsumedLiveness(
     for (auto *instruction : boundary.lastUsers) {
       if (dynCastToDestroyOf(instruction, getCurrentDef()))
         continue;
-      if (liveness.isInterestingUser(instruction) !=
-          PrunedLiveness::IsInterestingUser::LifetimeEndingUse)
+      if (liveness->isInterestingUser(instruction)
+          != PrunedLiveness::IsInterestingUser::LifetimeEndingUse)
         continue;
       worklist.push(instruction->getParent());
     }
@@ -537,11 +539,11 @@ void CanonicalizeOSSALifetime::extendUnconsumedLiveness(
       // Add "the instruction(s) before the terminator" of the predecessor to
       // liveness.
       if (auto *inst = predecessor->getTerminator()->getPreviousInstruction()) {
-        liveness.updateForUse(inst, /*lifetimeEnding*/ false);
+        liveness->updateForUse(inst, /*lifetimeEnding*/ false);
       } else {
         for (auto *grandPredecessor : predecessor->getPredecessorBlocks()) {
-          liveness.updateForUse(grandPredecessor->getTerminator(),
-                                /*lifetimeEnding*/ false);
+          liveness->updateForUse(grandPredecessor->getTerminator(),
+                                 /*lifetimeEnding*/ false);
         }
       }
     }
@@ -555,7 +557,7 @@ void CanonicalizeOSSALifetime::extendUnconsumedLiveness(
     // hoisting it would avoid a copy.
     if (consumedAtExitBlocks.contains(block))
       continue;
-    liveness.updateForUse(destroy, /*lifetimeEnding*/ true);
+    liveness->updateForUse(destroy, /*lifetimeEnding*/ true);
   }
 }
 
@@ -768,7 +770,7 @@ void CanonicalizeOSSALifetime::findExtendedBoundary(
     PrunedLivenessBoundary &boundary) {
   assert(boundary.lastUsers.size() == 0 && boundary.boundaryEdges.size() == 0 &&
          boundary.deadDefs.size() == 0);
-  ExtendBoundaryToDestroys extender(liveness, originalBoundary,
+  ExtendBoundaryToDestroys extender(*liveness, originalBoundary,
                                     getCurrentDef());
   extender.extend(boundary);
 }
@@ -808,7 +810,7 @@ void CanonicalizeOSSALifetime::insertDestroysOnBoundary(
       consumes.recordFinalConsume(dvi);
       continue;
     }
-    switch (liveness.isInterestingUser(instruction)) {
+    switch (liveness->isInterestingUser(instruction)) {
     case PrunedLiveness::IsInterestingUser::LifetimeEndingUse:
       consumes.recordFinalConsume(instruction);
       continue;
@@ -914,7 +916,7 @@ void CanonicalizeOSSALifetime::rewriteCopies() {
         // If this destroy was marked as a final destroy, add it to liveness so
         // that we don't delete any debug instructions that occur before it.
         // (Only relevant in pruneDebugMode).
-        liveness.updateForUse(destroy, /*lifetimeEnding*/ true);
+        liveness->updateForUse(destroy, /*lifetimeEnding*/ true);
       }
       return true;
     }
@@ -972,7 +974,7 @@ void CanonicalizeOSSALifetime::rewriteCopies() {
 
   if (pruneDebugMode) {
     for (auto *dvi : debugValues) {
-      if (!liveness.isWithinBoundary(dvi)) {
+      if (!liveness->isWithinBoundary(dvi)) {
         LLVM_DEBUG(llvm::dbgs() << "  Removing debug_value: " << *dvi);
         deleter.forceDelete(dvi);
       }
@@ -990,14 +992,14 @@ void CanonicalizeOSSALifetime::rewriteCopies() {
 //                            MARK: Top-Level API
 //===----------------------------------------------------------------------===//
 
-bool CanonicalizeOSSALifetime::computeLiveness(SILValue def) {
-  if (def->getOwnershipKind() != OwnershipKind::Owned)
+bool CanonicalizeOSSALifetime::computeLiveness() {
+  if (currentDef->getOwnershipKind() != OwnershipKind::Owned)
     return false;
 
-  if (def->isLexical())
+  if (currentDef->isLexical())
     return false;
 
-  LLVM_DEBUG(llvm::dbgs() << "  Canonicalizing: " << def);
+  LLVM_DEBUG(llvm::dbgs() << "  Canonicalizing: " << currentDef);
 
   // Note: There is no need to register callbacks with this utility. 'onDelete'
   // is the only one in use to handle dangling pointers, which could be done
@@ -1013,7 +1015,6 @@ bool CanonicalizeOSSALifetime::computeLiveness(SILValue def) {
   assert(!getCallbacks().notifyWillBeDeletedFunc
          && !getCallbacks().setUseValueFunc && "unsupported");
 
-  initDef(def);
   // Step 1: compute liveness
   if (!computeCanonicalLiveness()) {
     LLVM_DEBUG(llvm::errs() << "Failed to compute canonical liveness?!\n");
@@ -1057,8 +1058,10 @@ void CanonicalizeOSSALifetime::rewriteLifetimes() {
 
 /// Canonicalize a single extended owned lifetime.
 bool CanonicalizeOSSALifetime::canonicalizeValueLifetime(SILValue def) {
+  LivenessState livenessState(*this, def);
+
   // Step 1: Compute liveness.
-  if (!computeLiveness(def)) {
+  if (!computeLiveness()) {
     LLVM_DEBUG(llvm::dbgs() << "Failed to compute liveness boundary!\n");
     return false;
   }

--- a/lib/SILOptimizer/Utils/GenericCloner.cpp
+++ b/lib/SILOptimizer/Utils/GenericCloner.cpp
@@ -248,7 +248,7 @@ void GenericCloner::postFixUp(SILFunction *f) {
     // FIXME: Call OSSA lifetime fixup on all values used within the unreachable
     // code. This will recursively fixup nested scopes from the inside out so
     // that transitive liveness is not required.
-    SSAPrunedLiveness storeBorrowLiveness(&discoveredBlocks);
+    SSAPrunedLiveness storeBorrowLiveness(getCloned(), &discoveredBlocks);
     AddressUseKind useKind =
         scopedAddress.computeTransitiveLiveness(storeBorrowLiveness);
     if (useKind == AddressUseKind::NonEscaping) {

--- a/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/OwnershipOptUtils.cpp
@@ -141,7 +141,7 @@ bool swift::computeGuaranteedBoundary(SILValue value,
   bool noEscape = findInnerTransitiveGuaranteedUses(value, &usePoints);
 
   SmallVector<SILBasicBlock *, 4> discoveredBlocks;
-  SSAPrunedLiveness liveness(&discoveredBlocks);
+  SSAPrunedLiveness liveness(value->getFunction(), &discoveredBlocks);
   liveness.initializeDef(value);
   for (auto *use : usePoints) {
     assert(!use->isLifetimeEnding());
@@ -1857,7 +1857,7 @@ bool swift::extendStoreBorrow(StoreBorrowInst *sbi,
   ScopedAddressValue scopedAddress(sbi);
 
   SmallVector<SILBasicBlock *, 4> discoveredBlocks;
-  SSAPrunedLiveness storeBorrowLiveness(&discoveredBlocks);
+  SSAPrunedLiveness storeBorrowLiveness(sbi->getFunction(), &discoveredBlocks);
 
   // FIXME: if OSSA lifetimes are complete, then we don't need transitive
   // liveness here.

--- a/test/SILOptimizer/liveness_incomplete_unit.sil
+++ b/test/SILOptimizer/liveness_incomplete_unit.sil
@@ -131,9 +131,9 @@ bb0(%0 : @guaranteed $C, %1 : $@thick Never.Type):
 // CHECK: MultiDef lifetime analysis:
 // CHECK:   def: [[CP0:%.*]] = copy_value %0 : $C
 // CHECK:   def: [[CP3:%.*]] = copy_value %0 : $C
-// CHECK: bb0: LiveOut,
-// CHECK: bb1: LiveWithin,
-// CHECK: bb2: LiveWithin,
+// CHECK: bb0: LiveOut
+// CHECK: bb1: LiveWithin
+// CHECK: bb2: LiveWithin
 // CHECK: last user:   destroy_value [[CP0]] : $C
 // CHECK-NEXT: boundary edge: bb1
 // CHECK-NEXT: dead def: [[CP3]] = copy_value %0 : $C

--- a/test/SILOptimizer/liveness_unit.sil
+++ b/test/SILOptimizer/liveness_unit.sil
@@ -184,11 +184,11 @@ bb0(%0 : @guaranteed $D):
 // CHECK:   def: %{{.*}} = copy_value %0 : $C
 // CHECK:   def: %{{.*}} = move_value [[CP0]] : $C
 // CHECK:   def: %{{.*}} = argument of bb4 : $C
-// CHECK-NEXT: bb0: LiveOut,
-// CHECK-NEXT: bb2: LiveWithin,
-// CHECK-NEXT: bb3: LiveWithin,
-// CHECK-NEXT: bb4: LiveWithin,
-// CHECK-NEXT: bb1: LiveWithin,
+// CHECK-NEXT: bb0: LiveOut
+// CHECK-NEXT: bb2: LiveWithin
+// CHECK-NEXT: bb3: LiveWithin
+// CHECK-NEXT: bb4: LiveWithin
+// CHECK-NEXT: bb1: LiveWithin
 // CHECK: last user:   br bb4
 // CHECK-NEXT: last user:   br bb4
 // CHECK-NEXT: last user:   %{{.*}} = move_value [[CP0]] : $C
@@ -229,10 +229,10 @@ bb4(%phi : @owned $C):
 // CHECK-LABEL: testSSADeadRefElementAddr: ssa-liveness
 // CHECK: SSA lifetime analysis: %0 = argument of bb0 : $C
 // CHECK-NEXT: Incomplete liveness: Escaping address
-// CHECK-NEXT: bb0: LiveOut,
-// CHECK-NEXT: bb2: LiveOut,
-// CHECK-NEXT: bb3: LiveWithin,
-// CHECK-NEXT: bb1: LiveOut,
+// CHECK-NEXT: bb0: LiveOut
+// CHECK-NEXT: bb2: LiveOut
+// CHECK-NEXT: bb3: LiveWithin
+// CHECK-NEXT: bb1: LiveOut
 // CHECK: last user:
 // CHECK-SAME: ref_element_addr %6 : $D, #D.object
 // CHECK-NEXT-LABEL: end running test 1 of 1 on testSSADeadRefElementAddr: ssa-liveness
@@ -260,7 +260,7 @@ bb3(%phi : @guaranteed $D):
 // CHECK-LABEL: testSSAInnerReborrowedPhi: ssa-liveness
 // CHECK: SSA lifetime analysis: %0 = argument of bb0 : $C
 // CHECK-NEXT: Incomplete liveness: Reborrowed inner scope
-// CHECK-NEXT: bb0: LiveWithin,
+// CHECK-NEXT: bb0: LiveWithin
 // CHECK-NEXT: dead def: %0 = argument of bb0 : $C
 sil [ossa] @testSSAInnerReborrowedPhi : $@convention(thin) (@guaranteed C) -> () {
 bb0(%0 : @guaranteed $C):
@@ -288,9 +288,9 @@ bb1(%reborrow : @guaranteed $C, %phi : @guaranteed $PairC):
 //
 // CHECK-LABEL: testSSADeadGuaranteedPhi: ssa-liveness
 // CHECK: SSA lifetime analysis: %0 = argument of bb0 : $C
-// CHECK-NEXT: bb0: LiveOut,
-// CHECK-NEXT: bb2: LiveWithin,
-// CHECK-NEXT: bb1: LiveWithin,
+// CHECK-NEXT: bb0: LiveOut
+// CHECK-NEXT: bb2: LiveWithin
+// CHECK-NEXT: bb1: LiveWithin
 // CHECK-NEXT: regular user
 // CHECK: last user:
 // CHECK-SAME: br bb3
@@ -318,10 +318,10 @@ bb3(%deadPhi : @guaranteed $D):
 //
 // CHECK-LABEL: testSSADominatedPhi: ssa-liveness
 // CHECK: SSA lifetime analysis: %0 = argument of bb0 : $C
-// CHECK-NEXT: bb0: LiveOut,
-// CHECK-NEXT: bb2: LiveOut,
-// CHECK-NEXT: bb3: LiveWithin,
-// CHECK-NEXT: bb1: LiveOut,
+// CHECK-NEXT: bb0: LiveOut
+// CHECK-NEXT: bb2: LiveOut
+// CHECK-NEXT: bb3: LiveWithin
+// CHECK-NEXT: bb1: LiveOut
 // CHECK-NEXT: regular user:   %{{.*}} = unchecked_ref_cast %0 : $C to $D
 // CHECK-NEXT: regular user:   br bb3
 // CHECK-NEXT: regular user:   %{{.*}} = load
@@ -354,8 +354,8 @@ bb3(%phi : @guaranteed $D):
 //
 // CHECK-LABEL: testSSAPartialDominatedPhi: ssa-liveness
 // CHECK: SSA lifetime analysis: %0 = argument of bb0 : $C
-// CHECK-NEXT: bb0: LiveOut,
-// CHECK-NEXT: bb1: LiveWithin,
+// CHECK-NEXT: bb0: LiveOut
+// CHECK-NEXT: bb1: LiveWithin
 // CHECK: last user:
 // CHECK-SAME: load
 sil [ossa] @testSSAPartialDominatedPhi : $@convention(thin) (@guaranteed C, @guaranteed C) -> () {
@@ -381,7 +381,7 @@ bb1(%reborrow : @guaranteed $C, %phi : @guaranteed $PairC):
 //
 // CHECK-LABEL: testSSAReborrowedPhi: ssa-liveness
 // CHECK: SSA lifetime analysis: %{{.*}} = begin_borrow
-// CHECK-NEXT: bb0: LiveWithin,
+// CHECK-NEXT: bb0: LiveWithin
 // CHECK-NEXT: regular user: br bb1
 // CHECK-NEXT: regular user: %{{.*}} = struct
 // CHECK-NEXT: last user: br bb1


### PR DESCRIPTION
Use BasicBlockBitfield to record per-block liveness state. This has
been the intention since BasicBlockBitfield was first introduced.

    Remove the per-field bitfield from PrunedLiveBlocks. This
    (re)specializes the data structure for scalar liveness and drastically
    simplifies the implementation.

    This utility is fundamental to all ownership utilities. It will be on
    the critical path in many areas of the compiler, including at
    -Onone. It needs to be minimal and as easy as possible for compiler
    engineers to understand, investigate, and debug.

    This is in preparation for fixing bugs related to multi-def liveness
    as used by the move checker.