### PR TITLE
[Workaround][Concurrency] Mark Job as NOT moveonly until we fix moveonly use in stdlib

### DIFF
--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -105,13 +105,13 @@ extension UnownedJob: CustomStringConvertible {
 }
 
 #if !SWIFT_STDLIB_TASK_TO_THREAD_MODEL_CONCURRENCY
-//// A unit of scheduleable work.
+/// A unit of scheduleable work.
 ///
 /// Unless you're implementing a scheduler,
 /// you don't generally interact with jobs directly.
 @available(SwiftStdlib 5.9, *)
 @frozen
-@_moveOnly
+// @_moveOnly // FIXME(moveonly): rdar://107050387 Move-only types fail to be found sometimes, must fix or remove Job before shipping
 public struct Job: Sendable {
   internal var context: Builtin.Job
 

--- a/test/Concurrency/Runtime/custom_executors_moveOnly_job.swift
+++ b/test/Concurrency/Runtime/custom_executors_moveOnly_job.swift
@@ -3,14 +3,18 @@
 // REQUIRES: concurrency
 // REQUIRES: executable_test
 
-// rdar://106849189 move-only types should be supported in freestanding mode
+// FIXME(moveonly): rdar://106849189 move-only types should be supported in freestanding mode
 // UNSUPPORTED: freestanding
 
 // UNSUPPORTED: back_deployment_runtime
 // REQUIRES: concurrency_runtime
 
 final class InlineExecutor: SerialExecutor, CustomStringConvertible {
-  public func enqueue(_ job: __owned Job) {
+// FIXME(moveonly): rdar://107050387 Move-only types fail to be found sometimes, must fix or remove Job before shipping
+//  public func enqueue(_ job: __owned Job) {
+//    job.runSynchronously(on: self.asUnownedSerialExecutor())
+//  }
+  public func enqueue(_ job: UnownedJob) {
     job.runSynchronously(on: self.asUnownedSerialExecutor())
   }
 

--- a/test/Concurrency/Runtime/custom_executors_priority.swift
+++ b/test/Concurrency/Runtime/custom_executors_priority.swift
@@ -10,7 +10,12 @@
 // REQUIRES: concurrency_runtime
 
 final class InlineExecutor: SerialExecutor {
-  public func enqueue(_ job: __owned Job) {
+// FIXME(moveonly): rdar://107050387 Move-only types fail to be found sometimes, must fix or remove Job before shipping
+//  public func enqueue(_ job: __owned Job) {
+//    print("\(self): enqueue (priority: \(TaskPriority(job.priority)!))")
+//    job.runSynchronously(on: self.asUnownedSerialExecutor())
+//  }
+  public func enqueue(_ job: UnownedJob) {
     print("\(self): enqueue (priority: \(TaskPriority(job.priority)!))")
     job.runSynchronously(on: self.asUnownedSerialExecutor())
   }

--- a/test/Concurrency/Runtime/custom_executors_protocol.swift
+++ b/test/Concurrency/Runtime/custom_executors_protocol.swift
@@ -35,9 +35,17 @@ final class NaiveQueueExecutor: SpecifiedExecutor, CustomStringConvertible {
     self.queue = queue
   }
 
-  public func enqueue(_ job: __owned Job) {
+// FIXME(moveonly): rdar://107050387 Move-only types fail to be found sometimes, must fix or remove Job before shipping
+//  public func enqueue(_ job: __owned Job) {
+//    print("\(self): enqueue")
+//    let unowned = UnownedJob(job)
+//    queue.sync {
+//      unowned.runSynchronously(on: self.asUnownedSerialExecutor())
+//    }
+//    print("\(self): after run")
+//  }
+  public func enqueue(_ unowned: UnownedJob) {
     print("\(self): enqueue")
-    let unowned = UnownedJob(job)
     queue.sync {
       unowned.runSynchronously(on: self.asUnownedSerialExecutor())
     }

--- a/test/Concurrency/custom_executor_enqueue_impls.swift
+++ b/test/Concurrency/custom_executor_enqueue_impls.swift
@@ -1,8 +1,11 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-move-only -disable-availability-checking
 // REQUIRES: concurrency
 
-// rdar://106849189 move-only types should be supported in freestanding mode
+// FIXME(moveonly): rdar://106849189 move-only types should be supported in freestanding mode
 // UNSUPPORTED: freestanding
+
+// FIXME(moveonly): rdar://107050387 Move-only types fail to be found sometimes, must fix or remove Job before shipping
+// REQUIRES: radr107050387
 
 // Such type may be encountered since Swift 5.5 (5.1 backdeployed) if someone implemented the
 // not documented, but public Executor types back then already.

--- a/test/IRGen/async/builtin_executor.sil
+++ b/test/IRGen/async/builtin_executor.sil
@@ -1,8 +1,11 @@
 // RUN: %target-swift-frontend  -primary-file %s -module-name=test -disable-llvm-optzns -disable-swift-specific-llvm-optzns -emit-ir -sil-verify-all | %IRGenFileCheck %s
 
 // REQUIRES: concurrency
-// rdar://106849189 move-only types should be supported in freestanding mode
+// FIXME(moveonly): rdar://106849189 move-only types should be supported in freestanding mode
 // UNSUPPORTED: freestanding
+
+// FIXME(moveonly): rdar://107050387 Move-only types fail to be found sometimes, must fix or remove Job before shipping
+// REQUIRES: radr107050387
 
 sil_stage canonical
 


### PR DESCRIPTION
Moveonly types in stdlib, the only instance of which is `Job`, are somehow broken and sometimes fail to look up like this:

```
custom_executors_priority.swift:13:38: error: cannot find type 'Job' in scope
  public func enqueue(_ job: __owned Job) {
                                     ^~~
```

This can be worked around by doing a clean build and it _sometimes_ just works. 
It seems to be caused by moveonly, and not other configuration issues.

In order to get CI into a workable state until this issue is fixed, this PR removes the annotation and disables (or works-around) tests using this type.

⚠️ We must either fix moveonly types and revert his PR, or remove `Job` before shipping. ⚠️ 
⚠️ This PR is a temporary state to allow debugging the issue. ⚠️ 