### PR TITLE
[⛔][CSSimplify] Allow `repairFailures` indicate that it is confused

### DIFF
--- a/include/swift/Sema/ConstraintSystem.h
+++ b/include/swift/Sema/ConstraintSystem.h
@@ -4391,10 +4391,11 @@ public:
   /// Attempt to repair typing failures and record fixes if needed.
   /// \return true if at least some of the failures has been repaired
   /// successfully, which allows type matcher to continue.
-  bool repairFailures(Type lhs, Type rhs, ConstraintKind matchKind,
-                      TypeMatchOptions flags,
-                      SmallVectorImpl<RestrictionOrFix> &conversionsOrFixes,
-                      ConstraintLocatorBuilder locator);
+  TypeMatchResult
+  repairFailures(Type lhs, Type rhs, ConstraintKind matchKind,
+                 TypeMatchOptions flags,
+                 SmallVectorImpl<RestrictionOrFix> &conversionsOrFixes,
+                 ConstraintLocatorBuilder locator);
 
   TypeMatchResult
   matchPackTypes(PackType *pack1, PackType *pack2,


### PR DESCRIPTION
Sometimes it's not possible to determine what fix to use if
involved types are not resolved enough. `repairFailures` needs
a way to indicate to `matchTypes` that the matching has to be
delayed until the solver has a change to infer more type
information.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
