### PR TITLE
[Macros] Add missing scope keyword for target_link_libraries

### DIFF
--- a/tools/swift-plugin-server/CMakeLists.txt
+++ b/tools/swift-plugin-server/CMakeLists.txt
@@ -4,7 +4,7 @@ if (SWIFT_SWIFT_PARSER)
   add_swift_host_library(_swiftCSwiftPluginServer OBJECT
     Sources/CSwiftPluginServer/PluginServer.cpp
   )
-  target_link_libraries(_swiftCSwiftPluginServer
+  target_link_libraries(_swiftCSwiftPluginServer PRIVATE
     swiftDemangling
   )
   target_include_directories(_swiftCSwiftPluginServer PUBLIC


### PR DESCRIPTION
'target_link_libraries(_swiftCSwiftPluginServer ...)' didn't have it.
