### PR TITLE
Sema: Allow unavailable decls to witness requirements in more conformances

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1701,7 +1701,7 @@ RequirementCheck WitnessChecker::checkWitness(ValueDecl *requirement,
       }
 
       if (auto adoptingNominal = DC->getSelfNominalTypeDecl()) {
-        if (adoptingNominal->getAttrs().isUnavailable(getASTContext()))
+        if (adoptingNominal->getSemanticUnavailableAttr())
           return true;
       }
 

--- a/test/ModuleInterface/actor_availability.swift
+++ b/test/ModuleInterface/actor_availability.swift
@@ -7,9 +7,6 @@
 
 // REQUIRES: VENDOR=apple
 
-// FIXME: rdar://107052715 temporarily disabled the test; fails on ios simulator
-// REQUIRES: rdar107052715
-
 // CHECK: #if compiler(>=5.3) && $Actors
 // CHECK-NEXT: public actor ActorWithImplicitAvailability {
 public actor ActorWithImplicitAvailability {

--- a/test/decl/protocol/req/unavailable.swift
+++ b/test/decl/protocol/req/unavailable.swift
@@ -64,6 +64,14 @@ extension ConformsToP5: P {
   func foo(bar: Foo) { }
 }
 
+@available(*, unavailable)
+enum UnavailableEnum {
+  struct ConformsToP6: P {
+    @available(*, unavailable)
+    func foo(bar: Foo) { }
+  }
+}
+
 // Include message string from @available attribute if provided
 protocol Unavail {
   associatedtype T


### PR DESCRIPTION
In https://github.com/apple/swift/pull/63898 conformance requirement typechecking was relaxed to allow unavailable decls to witness conformance requirements as long as the conforming nominal was also unavailable. However, only nominals that were directly marked unavailable were accepted. Nominals that are declared in unavailable scopes should also be allowed to have unavailable wintesses.

Resolves rdar://107052715
