### PR TITLE
[CMake] Add correct sanitizer options to pure Swift libs/tools

### DIFF
--- a/cmake/modules/AddPureSwift.cmake
+++ b/cmake/modules/AddPureSwift.cmake
@@ -62,6 +62,7 @@ function(_add_host_swift_compile_options name)
     DEPLOYMENT_VERSION "${DEPLOYMENT_VERSION}")
 
   target_compile_options(${name} PRIVATE $<$<COMPILE_LANGUAGE:Swift>:-target;${target}>)
+  _add_host_variant_swift_sanitizer_flags(${name})
 endfunction()
 
 # Add a new "pure" Swift host library.


### PR DESCRIPTION
`add_pure_swift_host_library`/`add_pure_swift_host_tool` now respects sanitizer options.

It used to fail when linking with sanitizer enabled `.o` using `CMAKE_Swift_COMPILER`.

rdar://107056349
