### PR TITLE
[SILOptimizer] hop_to_executor may synchronize.

### DIFF
--- a/lib/SIL/Utils/MemAccessUtils.cpp
+++ b/lib/SIL/Utils/MemAccessUtils.cpp
@@ -427,7 +427,8 @@ bool swift::mayLoadWeakOrUnowned(SILInstruction *instruction) {
 bool swift::maySynchronizeNotConsideringSideEffects(SILInstruction *instruction) {
   return FullApplySite::isa(instruction) 
       || isa<EndApplyInst>(instruction)
-      || isa<AbortApplyInst>(instruction);
+      || isa<AbortApplyInst>(instruction)
+      || isa<HopToExecutorInst>(instruction);
 }
 
 bool swift::mayBeDeinitBarrierNotConsideringSideEffects(SILInstruction *instruction) {

--- a/test/SILOptimizer/deinit_barrier.sil
+++ b/test/SILOptimizer/deinit_barrier.sil
@@ -85,3 +85,21 @@ entry:
   return %retval : $()
 }
 
+actor A {}
+
+sil @getA : $() -> (@owned A)
+sil @borrowA : $@yield_once @convention(thin) () -> @yields @guaranteed A
+
+// CHECK-LABEL: begin running test 1 of 1 on test_hop_to_executor: is-deinit-barrier
+// CHECK:  hop_to_executor
+// CHECK:  true
+// CHECK-LABEL: end running test 1 of 1 on test_hop_to_executor: is-deinit-barrier
+sil [ossa] @test_hop_to_executor : $@convention(thin) () -> () {
+  %borrowA = function_ref @borrowA : $@yield_once @convention(thin) () -> @yields @guaranteed A
+  (%a, %token) = begin_apply %borrowA() : $@yield_once @convention(thin) () -> @yields @guaranteed A
+  test_specification "is-deinit-barrier @instruction"
+  hop_to_executor %a : $A
+  end_apply %token
+  %retval = tuple ()
+  return %retval : $()
+}


### PR DESCRIPTION
If a deinitializer has an external side-effect, it should execute after any other tasks have executed on the same actor with potentially external side effects.

rdar://98542036
