### PR TITLE
[Macros] Recovery after executable plugin crash

### DIFF
--- a/include/swift/AST/CASTBridging.h
+++ b/include/swift/AST/CASTBridging.h
@@ -307,6 +307,9 @@ void Plugin_lock(PluginHandle handle);
 /// Unlock the plugin.
 void Plugin_unlock(PluginHandle handle);
 
+/// Launch the plugin if it's not running.
+_Bool Plugin_spawnIfNeeded(PluginHandle handle);
+
 /// Sends the message to the plugin, returns true if there was an error.
 /// Clients should receive the response  by \c Plugin_waitForNextMessage .
 _Bool Plugin_sendMessage(PluginHandle handle, const BridgedData data);

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -528,6 +528,9 @@ struct ASTContext::Implementation {
   /// NOTE: Do not reference this directly. Use ASTContext::getPluginRegistry().
   PluginRegistry *Plugins = nullptr;
 
+  /// `Plugins` storage if this ASTContext owns it.
+  std::unique_ptr<PluginRegistry> OwnedPluginRegistry = nullptr;
+
   /// Cache of loaded symbols.
   llvm::StringMap<void *> LoadedSymbols;
 
@@ -6255,9 +6258,7 @@ PluginRegistry *ASTContext::getPluginRegistry() const {
   // Create a new one if it hasn't been set.
   if (!registry) {
     registry = new PluginRegistry();
-    const_cast<ASTContext *>(this)->addCleanup([registry]{
-      delete registry;
-    });
+    getImpl().OwnedPluginRegistry.reset(registry);
   }
 
   assert(registry != nullptr);

--- a/lib/AST/CASTBridging.cpp
+++ b/lib/AST/CASTBridging.cpp
@@ -649,6 +649,14 @@ void Plugin_unlock(PluginHandle handle) {
   plugin->unlock();
 }
 
+bool Plugin_spawnIfNeeded(PluginHandle handle) {
+  auto *plugin = static_cast<LoadedExecutablePlugin *>(handle);
+  auto error = plugin->spawnIfNeeded();
+  bool hadError(error);
+  llvm::consumeError(std::move(error));
+  return hadError;
+}
+
 bool Plugin_sendMessage(PluginHandle handle, const BridgedData data) {
   auto *plugin = static_cast<LoadedExecutablePlugin *>(handle);
   StringRef message(data.baseAddress, data.size);

--- a/test/Macros/Inputs/evil_macro_definitions.swift
+++ b/test/Macros/Inputs/evil_macro_definitions.swift
@@ -1,0 +1,17 @@
+import SwiftDiagnostics
+import SwiftOperators
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+
+public struct CrashingMacro: ExpressionMacro {
+  public static func expansion(
+    of macro: some FreestandingMacroExpansionSyntax,
+    in context: some MacroExpansionContext
+  ) -> ExprSyntax {
+    let arg: UInt = UInt(macro.argumentList.first!.expression.description)!
+    let zero: UInt = 0
+    return "\(raw: zero - arg).description"
+  }
+}

--- a/test/Macros/macro_plugin_error.swift
+++ b/test/Macros/macro_plugin_error.swift
@@ -29,8 +29,7 @@ func test() {
   let _: String = #fooMacro(2)
   // expected-error @-1 {{failedToReceiveMessage}}
   let _: String = #fooMacro(3)
-  // expected-error @-1 {{failedToSendMessage}}
-  //FIXME: ^ This should succeed. Error recovery is not implemented.
+  // ^ This should succeed.
 }
 
 //--- plugin.c
@@ -51,6 +50,6 @@ MOCK_PLUGIN([
     "expect": {"expandFreestandingMacro": {
                 "macro": {"moduleName": "TestPlugin", "typeName": "FooMacro"},
                 "syntax": {"kind": "expression", "source": "#fooMacro(3)"}}},
-    "response": {"expandFreestandingMacroResult": {"expandedSource": "3", "diagnostics": []}}
+    "response": {"expandFreestandingMacroResult": {"expandedSource": "3.description", "diagnostics": []}}
   }
 ])

--- a/test/Macros/macro_plugin_server.swift
+++ b/test/Macros/macro_plugin_server.swift
@@ -15,6 +15,16 @@
 // RUN:   %S/Inputs/syntax_macro_definitions.swift \
 // RUN:   -g -no-toolchain-stdlib-rpath
 
+// RUN: %target-build-swift \
+// RUN:   -swift-version 5 \
+// RUN:   -I %swift-host-lib-dir \
+// RUN:   -L %swift-host-lib-dir \
+// RUN:   -emit-library \
+// RUN:   -o %t/plugins/%target-library-name(EvilMacros) \
+// RUN:   -module-name=EvilMacros \
+// RUN:   %S/Inputs/evil_macro_definitions.swift \
+// RUN:   -g -no-toolchain-stdlib-rpath
+
 // RUN: %swift-target-frontend \
 // RUN:   -typecheck -verify \
 // RUN:   -swift-version 5 \
@@ -27,13 +37,23 @@
 
 
 @freestanding(expression) macro stringify<T>(_ value: T) -> (T, String) = #externalMacro(module: "MacroDefinition", type: "StringifyMacro")
+@freestanding(expression) macro evil(_ value: Int) -> String = #externalMacro(module: "EvilMacros", type: "CrashingMacro")
 
 func testStringify(a: Int, b: Int) {
-  let s: String = #stringify(a + b).1
-  print(s)
+  let s1: String = #stringify(a + b).1
+  print(s1)
+
+  let s2: String = #evil(42) // expected-error {{failedToReceiveMessage (from macro 'evil')}}
+  print(s2)
+
+  let s3: String = #stringify(b + a).1
+  print(s3)
 }
 
 // CHECK:      {{^}}------------------------------
 // CHECK-NEXT: {{^}}(a + b, "a + b")
 // CHECK-NEXT: {{^}}------------------------------
 
+// CHECK:      {{^}}------------------------------
+// CHECK-NEXT: {{^}}(b + a, "b + a")
+// CHECK-NEXT: {{^}}------------------------------


### PR DESCRIPTION
When executable plugins crashed or somehow decided to exit, the compiler
should relaunch the plugin executable before sending another message.

* `LoadedExecutablePlugin` is now a process manager of the plugin executable.
* `LoadedExecutabePlugin::PluginProcess` represents the actual plugin process
* `LoadedExecutablePlugin::spawnIfNeeded()` 