### PR TITLE
[SymbolGraphGen] allow SourceKit to print declarations for private stdlib symbols

### DIFF
--- a/include/swift/SymbolGraphGen/SymbolGraphOptions.h
+++ b/include/swift/SymbolGraphGen/SymbolGraphOptions.h
@@ -57,6 +57,12 @@ struct SymbolGraphOptions {
   /// along with "extensionTo" relationships instead of directly associating
   /// members and conformances with the extended nominal.
   bool EmitExtensionBlockSymbols = false;
+
+  /// Whether to print information for private symbols in the standard library.
+  /// This should be left as `false` when printing a full-module symbol graph,
+  /// but SourceKit should be able to load the information when pulling symbol
+  /// information for individual queries.
+  bool PrintPrivateStdlibSymbols = false;
 };
 
 } // end namespace symbolgraphgen

--- a/lib/SymbolGraphGen/SymbolGraph.cpp
+++ b/lib/SymbolGraphGen/SymbolGraph.cpp
@@ -63,8 +63,8 @@ PrintOptions SymbolGraph::getDeclarationFragmentsPrintOptions() const {
   Opts.PrintFunctionRepresentationAttrs =
     PrintOptions::FunctionRepresentationMode::None;
   Opts.PrintUserInaccessibleAttrs = false;
-  Opts.SkipPrivateStdlibDecls = true;
-  Opts.SkipUnderscoredStdlibProtocols = true;
+  Opts.SkipPrivateStdlibDecls = !Walker.Options.PrintPrivateStdlibSymbols;
+  Opts.SkipUnderscoredStdlibProtocols = !Walker.Options.PrintPrivateStdlibSymbols;
   Opts.PrintGenericRequirements = true;
   Opts.PrintInherited = false;
   Opts.ExplodeEnumCaseDecls = true;

--- a/test/SourceKit/CursorInfo/issue-62457-symbol-graph-crash.swift
+++ b/test/SourceKit/CursorInfo/issue-62457-symbol-graph-crash.swift
@@ -1,0 +1,9 @@
+// RUN: %sourcekitd-test -req=cursor -req-opts=retrieve_symbol_graph=1 -pos=8:13 %s -- %s
+
+struct AnyError: Swift.Error {
+  let error: Swift.Error
+}
+
+func test(lhs: AnyError) {
+  lhs.error._code
+}

--- a/test/SourceKit/CursorInfo/issue-62457-symbol-graph-crash.swift
+++ b/test/SourceKit/CursorInfo/issue-62457-symbol-graph-crash.swift
@@ -1,9 +1,48 @@
-// RUN: %sourcekitd-test -req=cursor -req-opts=retrieve_symbol_graph=1 -pos=8:13 %s -- %s
-
 struct AnyError: Swift.Error {
   let error: Swift.Error
 }
 
 func test(lhs: AnyError) {
+  // RUN: %sourcekitd-test -req=cursor -req-opts=retrieve_symbol_graph=1 -pos=%(line + 1):13 %s -- %s | %FileCheck %s
   lhs.error._code
 }
+
+// CHECK: SYMBOL GRAPH BEGIN
+
+// CHECK:      "declarationFragments": [
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "keyword",
+// CHECK-NEXT:     "spelling": "var"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "text",
+// CHECK-NEXT:     "spelling": " "
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "identifier",
+// CHECK-NEXT:     "spelling": "_code"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "text",
+// CHECK-NEXT:     "spelling": ": "
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "typeIdentifier",
+// CHECK-NEXT:     "preciseIdentifier": "s:Si",
+// CHECK-NEXT:     "spelling": "Int"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "text",
+// CHECK-NEXT:     "spelling": " { "
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "keyword",
+// CHECK-NEXT:     "spelling": "get"
+// CHECK-NEXT:   },
+// CHECK-NEXT:   {
+// CHECK-NEXT:     "kind": "text",
+// CHECK-NEXT:     "spelling": " }"
+// CHECK-NEXT:   }
+// CHECK-NEXT: ]
+
+// CHECK: SYMBOL GRAPH END

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1020,6 +1020,7 @@ fillSymbolInfo(CursorSymbolInfo &Symbol, const DeclInfo &DInfo,
     Options.MinimumAccessLevel = AccessLevel::Private;
     Options.IncludeSPISymbols = true;
     Options.IncludeClangDocs = true;
+    Options.PrintPrivateStdlibSymbols = true;
 
     symbolgraphgen::printSymbolGraphForDecl(DInfo.VD, DInfo.BaseType,
                                             DInfo.InSynthesizedExtension,


### PR DESCRIPTION
Resolves rdar://103112656
Resolves #62457

When SourceKit gets a cursor symbol graph for an internal stdlib symbol, the declaration fragment printer hits an assertion because it hasn't actually printed anything. This is because the PrintOptions used by the printer sets `SkipPrivateStdlibDecls` and `SkipUnderscoredStdlibProtocols`. This is useful when generating a whole-module symbol graph, but is causing problems for SourceKit. This PR adds an option to SymbolGraphOptions that turns those options off for SourceKit, so that these symbols can get a symbol graph correctly generated.