### PR TITLE
Remove unexpected rethrows from Async[Throwing]PrefixWhileSequence

### DIFF
--- a/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncPrefixWhileSequence.swift
@@ -14,6 +14,14 @@ import Swift
 
 @available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
+  @available(*, deprecated, renamed: "prefix(while:)")
+  @preconcurrency
+  @inlinable
+  public __consuming func prefix(
+    while predicate: @Sendable @escaping (Element) async -> Bool
+  ) rethrows -> AsyncPrefixWhileSequence<Self> {
+    return AsyncPrefixWhileSequence(self, predicate: predicate)
+  }
   /// Returns an asynchronous sequence, containing the initial, consecutive
   /// elements of the base sequence that satisfy the given predicate.
   ///
@@ -42,7 +50,7 @@ extension AsyncSequence {
   @inlinable
   public __consuming func prefix(
     while predicate: @Sendable @escaping (Element) async -> Bool
-  ) rethrows -> AsyncPrefixWhileSequence<Self> {
+  ) -> AsyncPrefixWhileSequence<Self> {
     return AsyncPrefixWhileSequence(self, predicate: predicate)
   }
 }

--- a/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
@@ -14,6 +14,14 @@ import Swift
 
 @available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
+  @ available(*, deprecated, renamed: "prefix(while:)")
+  @preconcurrency
+  @inlinable
+  public __consuming func prefix(
+    while predicate: @Sendable @escaping (Element) async throws -> Bool
+  ) rethrows -> AsyncThrowingPrefixWhileSequence<Self> {
+    return AsyncThrowingPrefixWhileSequence(self, predicate: predicate)
+  }
   /// Returns an asynchronous sequence, containing the initial, consecutive
   /// elements of the base sequence that satisfy the given error-throwing
   /// predicate.
@@ -54,7 +62,7 @@ extension AsyncSequence {
   @inlinable
   public __consuming func prefix(
     while predicate: @Sendable @escaping (Element) async throws -> Bool
-  ) rethrows -> AsyncThrowingPrefixWhileSequence<Self> {
+  ) -> AsyncThrowingPrefixWhileSequence<Self> {
     return AsyncThrowingPrefixWhileSequence(self, predicate: predicate)
   }
 }

--- a/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
+++ b/stdlib/public/Concurrency/AsyncThrowingPrefixWhileSequence.swift
@@ -14,7 +14,7 @@ import Swift
 
 @available(SwiftStdlib 5.1, *)
 extension AsyncSequence {
-  @ available(*, deprecated, renamed: "prefix(while:)")
+  @available(*, deprecated, renamed: "prefix(while:)")
   @preconcurrency
   @inlinable
   public __consuming func prefix(


### PR DESCRIPTION
The rethrows mechanism should handled by resulting sequence, not the method itself.

Resolves [SR-15494.](https://bugs.swift.org/browse/SR-15494)