### PR TITLE
Ensure `#if $MoveOnly` feature guard evaluates to true.

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -98,6 +98,7 @@ SUPPRESSIBLE_LANGUAGE_FEATURE(
     FreestandingExpressionMacros, 382, "Expression macros",
     true)
 LANGUAGE_FEATURE(AttachedMacros, 389, "Attached macros", true)
+LANGUAGE_FEATURE(MoveOnly, 390, "noncopyable types", true)
 
 UPCOMING_FEATURE(ConciseMagicFile, 274, 6)
 UPCOMING_FEATURE(ForwardTrailingClosures, 286, 6)
@@ -108,7 +109,6 @@ EXPERIMENTAL_FEATURE(StaticAssert, false)
 EXPERIMENTAL_FEATURE(VariadicGenerics, false)
 EXPERIMENTAL_FEATURE(NamedOpaqueTypes, false)
 EXPERIMENTAL_FEATURE(FlowSensitiveConcurrencyCaptures, false)
-EXPERIMENTAL_FEATURE(MoveOnly, true)
 EXPERIMENTAL_FEATURE(FreestandingMacros, true)
 
 // FIXME: MoveOnlyClasses is not intended to be in production,

--- a/stdlib/public/Concurrency/PartialAsyncTask.swift
+++ b/stdlib/public/Concurrency/PartialAsyncTask.swift
@@ -111,7 +111,7 @@ extension UnownedJob: CustomStringConvertible {
 /// you don't generally interact with jobs directly.
 @available(SwiftStdlib 5.9, *)
 @frozen
-// @_moveOnly // FIXME(moveonly): rdar://107050387 Move-only types fail to be found sometimes, must fix or remove Job before shipping
+@_moveOnly
 public struct Job: Sendable {
   internal var context: Builtin.Job
 

--- a/test/Concurrency/Runtime/custom_executors_moveOnly_job.swift
+++ b/test/Concurrency/Runtime/custom_executors_moveOnly_job.swift
@@ -3,7 +3,7 @@
 // REQUIRES: concurrency
 // REQUIRES: executable_test
 
-// FIXME(moveonly): rdar://106849189 move-only types should be supported in freestanding mode
+// rdar://106849189 move-only types should be supported in freestanding mode
 // UNSUPPORTED: freestanding
 
 // FIXME: rdar://107112715 test failing on iOS simulator, investigating
@@ -13,11 +13,7 @@
 // REQUIRES: concurrency_runtime
 
 final class InlineExecutor: SerialExecutor, CustomStringConvertible {
-// FIXME(moveonly): rdar://107050387 Move-only types fail to be found sometimes, must fix or remove Job before shipping
-//  public func enqueue(_ job: __owned Job) {
-//    job.runSynchronously(on: self.asUnownedSerialExecutor())
-//  }
-  public func enqueue(_ job: UnownedJob) {
+  public func enqueue(_ job: __owned Job) {
     job.runSynchronously(on: self.asUnownedSerialExecutor())
   }
 

--- a/test/Concurrency/Runtime/custom_executors_priority.swift
+++ b/test/Concurrency/Runtime/custom_executors_priority.swift
@@ -13,12 +13,7 @@
 // REQUIRES: concurrency_runtime
 
 final class InlineExecutor: SerialExecutor {
-// FIXME(moveonly): rdar://107050387 Move-only types fail to be found sometimes, must fix or remove Job before shipping
-//  public func enqueue(_ job: __owned Job) {
-//    print("\(self): enqueue (priority: \(TaskPriority(job.priority)!))")
-//    job.runSynchronously(on: self.asUnownedSerialExecutor())
-//  }
-  public func enqueue(_ job: UnownedJob) {
+  public func enqueue(_ job: __owned Job) {
     print("\(self): enqueue (priority: \(TaskPriority(job.priority)!))")
     job.runSynchronously(on: self.asUnownedSerialExecutor())
   }

--- a/test/Concurrency/Runtime/custom_executors_protocol.swift
+++ b/test/Concurrency/Runtime/custom_executors_protocol.swift
@@ -38,17 +38,9 @@ final class NaiveQueueExecutor: SpecifiedExecutor, CustomStringConvertible {
     self.queue = queue
   }
 
-// FIXME(moveonly): rdar://107050387 Move-only types fail to be found sometimes, must fix or remove Job before shipping
-//  public func enqueue(_ job: __owned Job) {
-//    print("\(self): enqueue")
-//    let unowned = UnownedJob(job)
-//    queue.sync {
-//      unowned.runSynchronously(on: self.asUnownedSerialExecutor())
-//    }
-//    print("\(self): after run")
-//  }
-  public func enqueue(_ unowned: UnownedJob) {
+  public func enqueue(_ job: __owned Job) {
     print("\(self): enqueue")
+    let unowned = UnownedJob(job)
     queue.sync {
       unowned.runSynchronously(on: self.asUnownedSerialExecutor())
     }

--- a/test/Concurrency/custom_executor_enqueue_impls.swift
+++ b/test/Concurrency/custom_executor_enqueue_impls.swift
@@ -1,11 +1,8 @@
 // RUN: %target-typecheck-verify-swift -enable-experimental-move-only -disable-availability-checking
 // REQUIRES: concurrency
 
-// FIXME(moveonly): rdar://106849189 move-only types should be supported in freestanding mode
+// rdar://106849189 move-only types should be supported in freestanding mode
 // UNSUPPORTED: freestanding
-
-// FIXME(moveonly): rdar://107050387 Move-only types fail to be found sometimes, must fix or remove Job before shipping
-// REQUIRES: radr107050387
 
 // FIXME: rdar://107112715 test failing on iOS simulator, investigating
 // UNSUPPORTED: OS=ios

--- a/test/IRGen/async/builtin_executor.sil
+++ b/test/IRGen/async/builtin_executor.sil
@@ -1,11 +1,8 @@
 // RUN: %target-swift-frontend  -primary-file %s -module-name=test -disable-llvm-optzns -disable-swift-specific-llvm-optzns -emit-ir -sil-verify-all | %IRGenFileCheck %s
 
 // REQUIRES: concurrency
-// FIXME(moveonly): rdar://106849189 move-only types should be supported in freestanding mode
+// rdar://106849189 move-only types should be supported in freestanding mode
 // UNSUPPORTED: freestanding
-
-// FIXME(moveonly): rdar://107050387 Move-only types fail to be found sometimes, must fix or remove Job before shipping
-// REQUIRES: radr107050387
 
 sil_stage canonical
 

--- a/test/ModuleInterface/moveonly_interface_flag.swift
+++ b/test/ModuleInterface/moveonly_interface_flag.swift
@@ -1,11 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library -enable-experimental-feature MoveOnly
+// RUN: %target-swift-emit-module-interface(%t/Library.swiftinterface) %s -module-name Library
 // RUN: %target-swift-typecheck-module-from-interface(%t/Library.swiftinterface) -I %t
 // RUN: %FileCheck %s < %t/Library.swiftinterface
 
 // this test makes sure that decls containing a move-only type are guarded by the $MoveOnly feature flag
-
-// CHECK: swift-module-flags-ignorable: -enable-experimental-feature MoveOnly
 
 // CHECK:       #if compiler(>=5.3) && $MoveOnly
 // CHECK-NEXT:    @_moveOnly public struct MoveOnlyStruct {
@@ -40,5 +38,3 @@ public class What {
 public extension MoveOnlyStruct {
   func who() {}
 }
-
-

--- a/test/Sema/moveonly_experimental.swift
+++ b/test/Sema/moveonly_experimental.swift
@@ -31,6 +31,14 @@ func checkNoImplicitCopy2(_ x: SomeValue) {
   checkNoImplicitCopy2(y)
 }
 
+// coverage to ensure the feature flag is working
+#if $MoveOnly
+  func guardedFn() {}
+#endif
+
+func caller() {
+  guardedFn()
+}
 
 
 


### PR DESCRIPTION
There was a subtle issue with feature flags after I enabled move-only types by default. Turns out that the `$MoveOnly` feature guard wasn't _always_ evaluating to true when the `-enable-experimental-move-only` isn't provided. This change now ensures that's the case so that public noncopyable types compiled in different modules are picked up correctly.

There's a separate sort of oddity where `hasFeature(Feature::Something)` still evaluates to false, where `Something` is an always-on feature. That will be addressed in a separate PR here: https://github.com/apple/swift/pull/64602

resolves rdar://107050387