### PR TITLE
Add a MultiDefUseLivenessTest

### DIFF
--- a/include/swift/SILOptimizer/Utils/ParseTestSpecification.h
+++ b/include/swift/SILOptimizer/Utils/ParseTestSpecification.h
@@ -155,8 +155,8 @@ private:
   template <typename Subtype>
   typename Subtype::Stored getInstance(StringRef name, Argument &argument) {
     if (isa<Subtype>(argument)) {
-      auto string = cast<Subtype>(argument).getValue();
-      return string;
+      auto stored = cast<Subtype>(argument).getValue();
+      return stored;
     }
     llvm::errs() << "Attempting to take a " << name << " argument but have\n";
     argument.print(llvm::errs());

--- a/lib/SIL/Parser/ParseSIL.cpp
+++ b/lib/SIL/Parser/ParseSIL.cpp
@@ -3638,7 +3638,9 @@ bool SILParser::parseSpecificSILInstruction(SILBuilder &B,
       return true;
     }
     // Drop the double quotes.
-    auto ArgumentsSpecification = P.Tok.getText().drop_front().drop_back();
+    unsigned numQuotes = P.Tok.isMultilineString() ? 4 : 1;
+    auto ArgumentsSpecification =
+      P.Tok.getText().drop_front(numQuotes).drop_back(numQuotes).trim();
     P.consumeToken(tok::string_literal);
     ResultVal = B.createTestSpecificationInst(InstLoc, ArgumentsSpecification);
     break;

--- a/lib/SILOptimizer/UtilityPasses/ParseTestSpecification.cpp
+++ b/lib/SILOptimizer/UtilityPasses/ParseTestSpecification.cpp
@@ -568,7 +568,10 @@ public:
     specificationString.split(components, " ");
     for (unsigned long index = 0, size = components.size(); index < size;
          ++index) {
-      auto componentString = components[index];
+      auto componentString = components[index].trim();
+      if (componentString.empty())
+        continue;
+
       ParseArgumentSpecification parser(*this, componentString,
                                         specification.context);
       auto argument = parser.parse();

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -368,9 +368,12 @@ struct ScopedAddressLivenessTest : UnitTest {
 };
 
 // Arguments:
-// - variadic list of live-range defining values
+// - variadic list of live-range defining values or instructions
 // Dumps:
 // - the liveness result and boundary
+//
+// Computes liveness for the specified def nodes by finding all their direct SSA
+// uses. If the def is an instruction, then all results are considered.
 struct MultiDefLivenessTest : UnitTest {
   MultiDefLivenessTest(UnitTestRunner *pass) : UnitTest(pass) {}
 
@@ -380,11 +383,78 @@ struct MultiDefLivenessTest : UnitTest {
 
     llvm::outs() << "MultiDef lifetime analysis:\n";
     while (arguments.hasUntaken()) {
-      SILValue value = arguments.takeValue();
-      llvm::outs() << "  def: " << value;
-      liveness.initializeDef(value);
+      auto argument = arguments.takeArgument();
+      if (isa<InstructionArgument>(argument)) {
+        auto *instruction = cast<InstructionArgument>(argument).getValue();
+        llvm::outs() << "  def instruction: " << instruction;
+        liveness.initializeDef(instruction);
+      } else {
+        SILValue value = cast<ValueArgument>(argument).getValue();
+        llvm::outs() << "  def value: " << value;
+        liveness.initializeDef(value);
+      }
     }
     liveness.computeSimple();
+    liveness.print(llvm::outs());
+
+    PrunedLivenessBoundary boundary;
+    liveness.computeBoundary(boundary);
+    boundary.print(llvm::outs());
+  }
+};
+
+// Arguments:
+// - the string "defs:"
+// - list of live-range defining values or instructions
+// - the string "uses:"
+// - variadic list of live-range user instructions
+// Dumps:
+// - the liveness result and boundary
+//
+// Computes liveness for the specified def nodes by considering only the
+// specified uses. The actual uses of the def nodes are ignored.
+//
+// This is useful for testing non-ssa liveness, for example, of memory
+// locations. In that case, the def nodes may be stores and the uses may be
+// destroy_addrs.
+struct MultiDefUseLivenessTest : UnitTest {
+  MultiDefUseLivenessTest(UnitTestRunner *pass) : UnitTest(pass) {}
+
+  void invoke(Arguments &arguments) override {
+    SmallVector<SILBasicBlock *, 8> discoveredBlocks;
+    MultiDefPrunedLiveness liveness(getFunction(), &discoveredBlocks);
+
+    llvm::outs() << "MultiDef lifetime analysis:\n";
+    if (arguments.takeString() != "defs:") {
+      llvm::report_fatal_error(
+        "test specification expects the 'defs:' label\n");
+    }
+    while (true) {
+      auto argument = arguments.takeArgument();
+      if (isa<InstructionArgument>(argument)) {
+        auto *instruction = cast<InstructionArgument>(argument).getValue();
+        llvm::outs() << "  def instruction: " << *instruction;
+        liveness.initializeDef(instruction);
+        continue;
+      }
+      if (isa<ValueArgument>(argument)) {
+        SILValue value = cast<ValueArgument>(argument).getValue();
+        llvm::outs() << "  def value: " << value;
+        liveness.initializeDef(value);
+        continue;
+      }
+      if (cast<StringArgument>(argument).getValue() != "uses:") {
+        llvm::report_fatal_error(
+          "test specification expects the 'uses:' label\n");
+      }
+      break;
+    }
+    while (arguments.hasUntaken()) {
+      auto *inst = arguments.takeInstruction();
+      // lifetimeEnding has no effects on liveness, it's only a cache for the
+      // caller.
+      liveness.updateForUse(inst, /*lifetimeEnding*/false);
+    }
     liveness.print(llvm::outs());
 
     PrunedLivenessBoundary boundary;
@@ -815,6 +885,7 @@ void UnitTestRunner::withTest(StringRef name, Doit doit) {
     ADD_UNIT_TEST_SUBCLASS("is-lexical", IsLexicalTest)
     ADD_UNIT_TEST_SUBCLASS("linear-liveness", LinearLivenessTest)
     ADD_UNIT_TEST_SUBCLASS("multidef-liveness", MultiDefLivenessTest)
+    ADD_UNIT_TEST_SUBCLASS("multidefuse-liveness", MultiDefUseLivenessTest)
     ADD_UNIT_TEST_SUBCLASS("ossa-lifetime-completion", OSSALifetimeCompletionTest)
     ADD_UNIT_TEST_SUBCLASS("pruned-liveness-boundary-with-list-of-last-users-insertion-points", PrunedLivenessBoundaryWithListOfLastUsersInsertionPointsTest)
     ADD_UNIT_TEST_SUBCLASS("shrink-borrow-scope", ShrinkBorrowScopeTest)

--- a/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
+++ b/lib/SILOptimizer/UtilityPasses/UnitTestRunner.cpp
@@ -124,7 +124,11 @@ class UnitTestRunner : public SILFunctionTransform {
                  << name << " with: ";
     for (unsigned long index = 0, size = components.size(); index < size;
          ++index) {
-      llvm::errs() << components[index];
+      auto componentString = components[index].trim();
+      if (componentString.empty())
+        continue;
+
+      llvm::errs() << componentString;
       if (index != size - 1) {
         llvm::errs() << ", ";
       }

--- a/test/SILOptimizer/liveness_incomplete_unit.sil
+++ b/test/SILOptimizer/liveness_incomplete_unit.sil
@@ -78,8 +78,8 @@ bb0(%0 : @guaranteed $C):
 //
 // CHECK-LABEL: testDeadSelfKill: multidef-liveness
 // CHECK: MultiDef lifetime analysis:
-// CHECK: def: %1 = argument of bb1 : $C
-// CHECK: def: [[V:%.*]] = move_value %1 : $C
+// CHECK: def value: %1 = argument of bb1 : $C
+// CHECK: def value: [[V:%.*]] = move_value %1 : $C
 // CHECK: bb1: LiveWithin
 // CHECK: lifetime-ending user:   [[V]] = move_value %1 : $C
 // CHECK: last user:   [[V]] = move_value %1 : $C
@@ -129,8 +129,8 @@ bb0(%0 : @guaranteed $C, %1 : $@thick Never.Type):
 //
 // CHECK-LABEL: testMultiDefDeadDefBoundaryEdge: multidef-liveness
 // CHECK: MultiDef lifetime analysis:
-// CHECK:   def: [[CP0:%.*]] = copy_value %0 : $C
-// CHECK:   def: [[CP3:%.*]] = copy_value %0 : $C
+// CHECK:   def value: [[CP0:%.*]] = copy_value %0 : $C
+// CHECK:   def value: [[CP3:%.*]] = copy_value %0 : $C
 // CHECK: bb0: LiveOut
 // CHECK: bb1: LiveWithin
 // CHECK: bb2: LiveWithin

--- a/test/SILOptimizer/liveness_unit.sil
+++ b/test/SILOptimizer/liveness_unit.sil
@@ -79,8 +79,8 @@ bb3:
 //
 // CHECK-LABEL: testReborrow: multidef-liveness
 // CHECK: MultiDef lifetime analysis:
-// CHECK:   def:   [[B:%.*]] = begin_borrow %0 : $C
-// CHECK:   def:   [[RB:%.*]] = argument of bb3 : $C
+// CHECK:   def value:   [[B:%.*]] = begin_borrow %0 : $C
+// CHECK:   def value:   [[RB:%.*]] = argument of bb3 : $C
 // CHECK-NEXT: bb2: LiveWithin
 // CHECK-NEXT: bb3: LiveWithin
 // CHECK-NEXT: lifetime-ending user:   br bb3([[B]] : $C)
@@ -180,10 +180,10 @@ bb0(%0 : @guaranteed $D):
 //
 // CHECK-LABEL: testMultiDefLiveOutNoBoundary: multidef-liveness
 // CHECK: MultiDef lifetime analysis:
-// CHECK:   def: [[CP0:%.*]] = copy_value %0 : $C
-// CHECK:   def: %{{.*}} = copy_value %0 : $C
-// CHECK:   def: %{{.*}} = move_value [[CP0]] : $C
-// CHECK:   def: %{{.*}} = argument of bb4 : $C
+// CHECK:   def value: [[CP0:%.*]] = copy_value %0 : $C
+// CHECK:   def value: %{{.*}} = copy_value %0 : $C
+// CHECK:   def value: %{{.*}} = move_value [[CP0]] : $C
+// CHECK:   def value: %{{.*}} = argument of bb4 : $C
 // CHECK-NEXT: bb0: LiveOut
 // CHECK-NEXT: bb2: LiveWithin
 // CHECK-NEXT: bb3: LiveWithin
@@ -502,4 +502,46 @@ bb0(%0 : @guaranteed $C):
   %s29b = struct_extract %s29 : $PairC, #PairC.second
   %99 = tuple()
   return %99 : $()
+}
+
+// CHECK-LABEL: begin running test 1 of 1 on testMultiDefUseAddressReinit
+// CHECK: MultiDef lifetime analysis:
+// CHECK:   def instruction:   store %{{.*}} to [init] [[ADR:%.*]] : $*C
+// CHECK:   def instruction:   destroy_addr [[ADR]] : $*C
+// CHECK: bb0: LiveWithin
+// CHECK: bb1: LiveWithin
+// CHECK: regular user: %{{.*}} = load [copy] [[ADR]] : $*C
+// CHECK: last user:    %{{.*}} = load [copy] [[ADR]] : $*C
+//
+// FIXME: This store is not really a dead def!
+// CHECK: dead def:   store %2 to [init] %1 : $*C
+// CHECK: dead def:   destroy_addr %1 : $*C
+// CHECK-LABEL: end running test 1 of 1 on testMultiDefUseAddressReinit
+sil [ossa] @testMultiDefUseAddressReinit : $@convention(thin) (@owned C) -> () {
+bb0(%0: @owned $C):
+  %1 = alloc_stack $C
+  %2 = copy_value %0 : $C
+  test_specification """
+                     multidefuse-liveness defs: @instruction @block[1].instruction[1]
+                     uses: @block[1].instruction[0]
+                     """
+  store %2 to [init] %1 : $*C
+  cond_br undef, bb1, bb2
+
+bb1:
+  %5 = load [copy] %1 : $*C
+  destroy_addr %1 : $*C
+  store %0 to [init] %1 : $*C
+  destroy_value %5 : $C
+  br bb3
+
+bb2:
+  destroy_value %0 : $C
+  br bb3
+
+bb3:
+  destroy_addr %1 : $*C
+  dealloc_stack %1 : $*C
+  %9999 = tuple ()
+  return %9999 : $()
 }


### PR DESCRIPTION
 This provides a way to test liveness based on non-SSA values. The move
checker is now using pruned liveness this way. So we need a way to
test that liveness no longer makes any assumptions about SSA
values. These test cases need to explicitly specify all the def and
use instructions.