### PR TITLE
[Tests] Enable backtracing for crashing tests.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -411,6 +411,12 @@ foreach(SDK ${SWIFT_SDKS})
         endif()
 
         list(APPEND LIT_ARGS "--param" "threading=${SWIFT_SDK_${SDK}_THREADING_PACKAGE}")
+
+        # Enable on-crash backtracing if supported
+        if("${SDK}" STREQUAL "OSX" AND NOT SWIFT_ASAN_BUILD)
+          list(APPEND LIT_ARGS "--param" "backtrace_on_crash")
+        endif()
+
         foreach(test_subset ${TEST_SUBSETS})
           set(directories)
           set(dependencies ${test_dependencies})

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -489,6 +489,10 @@ backtracing = lit_config.params.get('backtracing', None)
 if backtracing is not None:
     config.available_features.add('backtracing')
 
+backtrace_on_crash = lit_config.params.get('backtrace_on_crash', None)
+if backtrace_on_crash is not None:
+    config.environment['SWIFT_BACKTRACE'] = 'enable=on,output-to=stderr'
+
 config.available_features.add('lld_lto')
 
 threading = lit_config.params.get('threading', 'none')


### PR DESCRIPTION
Enable the new Swift backtracer, which should result in backtraces appearing for tests that crash.

rdar://107131576