### PR TITLE
[5.9][RemoteMirror] Fix getEmptyTypeInfo() not allocating a BuiltinTypeInfo.

### DIFF
--- a/include/swift/RemoteInspection/TypeLowering.h
+++ b/include/swift/RemoteInspection/TypeLowering.h
@@ -176,6 +176,16 @@ public:
   explicit BuiltinTypeInfo(TypeRefBuilder &builder,
                            RemoteRef<BuiltinTypeDescriptor> descriptor);
 
+  /// Construct an empty builtin type info.
+  BuiltinTypeInfo()
+      : TypeInfo(TypeInfoKind::Builtin,
+                 /*Size=*/0,
+                 /*Alignment=*/1,
+                 /*Stride=*/1,
+                 /*ExtraInhabitants=*/0,
+                 /*BitwiseTakable=*/true),
+        Name("") {}
+
   const std::string &getMangledTypeName() const {
     return Name;
   }

--- a/stdlib/public/RemoteInspection/TypeLowering.cpp
+++ b/stdlib/public/RemoteInspection/TypeLowering.cpp
@@ -1683,12 +1683,7 @@ const TypeInfo *TypeConverter::getEmptyTypeInfo() {
   if (EmptyTI != nullptr)
     return EmptyTI;
 
-  EmptyTI = makeTypeInfo<TypeInfo>(TypeInfoKind::Builtin,
-                                   /*Size=*/0,
-                                   /*Alignment=*/1,
-                                   /*Stride=*/1,
-                                   /*ExtraInhabitants=*/0,
-                                   /*BitwiseTakable=*/true);
+  EmptyTI = makeTypeInfo<BuiltinTypeInfo>();
   return EmptyTI;
 }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/64436 to `release/5.9`.

Allocate an empty BuiltinTypeInfo. The code previously allocated a TypeInfo but set its kind to Builtin, which led to calling code doing an incorrect cast and reading an invalid value for the Name field.

rdar://106563125