### PR TITLE
cmake: extract version string and add `PrintVersion.cmake`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,12 +304,7 @@ endif()
 set(SWIFT_ANALYZE_CODE_COVERAGE FALSE CACHE STRING
     "Build Swift with code coverage instrumenting enabled [FALSE, NOT-MERGED, MERGED]")
 
-# SWIFT_VERSION is deliberately /not/ cached so that an existing build directory
-# can be reused when a new version of Swift comes out (assuming the user hasn't
-# manually set it as part of their own CMake configuration).
-set(SWIFT_VERSION_MAJOR 5)
-set(SWIFT_VERSION_MINOR 9)
-set(SWIFT_VERSION "${SWIFT_VERSION_MAJOR}.${SWIFT_VERSION_MINOR}")
+include(${CMAKE_CURRENT_LIST_DIR}/cmake/SwiftVersion.cmake)
 
 set(SWIFT_VENDOR "" CACHE STRING
     "The vendor name of the Swift compiler")

--- a/cmake/PrintVersion.cmake
+++ b/cmake/PrintVersion.cmake
@@ -1,0 +1,2 @@
+include(${CMAKE_CURRENT_LIST_DIR}/SwiftVersion.cmake)
+message(${SWIFT_VERSION})

--- a/cmake/SwiftVersion.cmake
+++ b/cmake/SwiftVersion.cmake
@@ -1,0 +1,7 @@
+# SWIFT_VERSION is deliberately /not/ cached so that an existing build directory
+# can be reused when a new version of Swift comes out (assuming the user hasn't
+# manually set it as part of their own CMake configuration).
+set(SWIFT_VERSION_MAJOR 5)
+set(SWIFT_VERSION_MINOR 9)
+set(SWIFT_VERSION "${SWIFT_VERSION_MAJOR}.${SWIFT_VERSION_MINOR}")
+

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -101,6 +101,7 @@ target_link_libraries(swiftBasic PUBLIC
 target_link_libraries(swiftBasic PRIVATE
   ${UUID_LIBRARIES})
 
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/SwiftVersion.cmake)
 message(STATUS "Swift version: ${SWIFT_VERSION}")
 message(STATUS "Swift vendor: ${SWIFT_VENDOR}")
 


### PR DESCRIPTION
Add a helper to allow us to programatically extract the Swift version string during the build.  This is particularly useful for injection into the packaging stages.