### PR TITLE
[build-script] In symbol extraction, also codesign executables after 'strip' and not just dylibs

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3249,10 +3249,10 @@ for host in "${ALL_HOSTS[@]}"; do
               '(' -perm -0111 -or -name "*.a" ')' -type f -print | \
               xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool strip) -S
 
-            # Codesign dylibs after strip tool
+            # Codesign dylibs and executables in usr/bin after strip tool
             # rdar://45388785
             find "${CURRENT_INSTALL_DIR}${CURRENT_PREFIX}/" \
-              '(' -name "*.dylib" ')' -type f -print | \
+              '(' '(' -path "*/usr/bin/*" -and -perm -0111 ')' -or -name "*.dylib" ')' -type f -print | \
               xargs -n 1 -P ${BUILD_JOBS} $(xcrun_find_tool codesign) -f -s -
         fi
 


### PR DESCRIPTION
Builds that include symbol extraction (dsymutil) otherwise produce executables with invalid codesignatures. This is fine for x86 builds which are not codesigned by default, but for arm64 builds, the invalid codesignature makes the resulting binaries (e.g. swift-frontend) not work.