### PR TITLE
PrunedLiveness; remove SWIFT_ASSERT_ONLY_DECL

### DIFF
--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -191,10 +191,10 @@ private:
   SmallVectorImpl<SILBasicBlock *> *discoveredBlocks = nullptr;
 
   /// Only a clean bitfield can be initialized.
-  SWIFT_ASSERT_ONLY_DECL(bool cleanFlag = true);
+  bool cleanFlag = true;
 
   /// Once the first def has been initialized, uses can be added.
-  SWIFT_ASSERT_ONLY_DECL(bool initializedFlag = false);
+  bool initializedFlag = false;
 
 public:
   PrunedLiveBlocks(SILFunction *function,


### PR DESCRIPTION
There's no value in hiding this flag in release builds. I meant to remove SWIFT_ASSERT_ONLY_DECL in the previous commit.
