### PR TITLE
[SILGen] Use decl location for main's functions.

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1122,7 +1122,7 @@ void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {
 
     // TODO: Handle main SourceFile emission (currently done by
     // SourceFileScope).
-    auto loc = RegularLocation::getModuleLocation();
+    auto loc = constant.getAsRegularLocation();
     preEmitFunction(constant, f, loc);
     auto *decl = constant.getDecl();
     auto *dc = decl->getDeclContext();

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -775,7 +775,7 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
     // Emit a call to the main static function.
     // return Module.$main();
     auto *mainFunc = cast<FuncDecl>(mainDecl);
-    auto moduleLoc = RegularLocation::getModuleLocation();
+    auto moduleLoc = SILLocation(mainDecl);
     auto *entryBlock = B.getInsertionBB();
 
     SILDeclRef mainFunctionDeclRef(mainFunc, SILDeclRef::Kind::Func);
@@ -862,7 +862,7 @@ void SILGenFunction::emitArtificialTopLevel(Decl *mainDecl) {
 }
 
 void SILGenFunction::emitAsyncMainThreadStart(SILDeclRef entryPoint) {
-  auto moduleLoc = RegularLocation::getModuleLocation();
+  auto moduleLoc = entryPoint.getAsRegularLocation();
   auto *entryBlock = B.getInsertionBB();
   auto paramTypeIter = F.getConventions()
                            .getParameterSILTypes(getTypeExpansionContext())


### PR DESCRIPTION
Previously, the location used for functions corresponding to `@main` was just `RegularLocation::getModuleLocation()`.  Make that more specific by using the annotated type's location instead.

rdar://79508092
