### PR TITLE
[5.9] Revert "Add a verify-di-hole assertion to SILBuilder." 

### DIFF
--- a/include/swift/SIL/PrunedLiveness.h
+++ b/include/swift/SIL/PrunedLiveness.h
@@ -191,10 +191,10 @@ private:
   SmallVectorImpl<SILBasicBlock *> *discoveredBlocks = nullptr;
 
   /// Only a clean bitfield can be initialized.
-  SWIFT_ASSERT_ONLY_DECL(bool cleanFlag = true);
+  bool cleanFlag = true;
 
   /// Once the first def has been initialized, uses can be added.
-  SWIFT_ASSERT_ONLY_DECL(bool initializedFlag = false);
+  bool initializedFlag = false;
 
 public:
   PrunedLiveBlocks(SILFunction *function,

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -106,16 +106,6 @@ class SILBuilder {
   /// are not auto-inserted.
   SILBasicBlock *BB;
   SILBasicBlock::iterator InsertPt;
-#ifndef NDEBUG
-  /// Used in the di-hole verifier assertion.
-  /// \{
-protected:
-  bool EnableDIHoleVerification = false;
-
-private:
-  const SILDebugScope *PrevDebugScope = nullptr;
-  /// \}
-#endif
   const SILDebugScope *CurDebugScope = nullptr;
   Optional<SILLocation> CurDebugLocOverride = None;
 
@@ -125,8 +115,7 @@ public:
 
   SILBuilder(SILFunction &F, SmallVectorImpl<SILInstruction *> *InsertedInstrs)
       : TempContext(F.getModule(), InsertedInstrs), C(TempContext), F(&F),
-        BB(nullptr) {
-  }
+        BB(nullptr) {}
 
   explicit SILBuilder(SILInstruction *I,
                       SmallVectorImpl<SILInstruction *> *InsertedInstrs = 0)
@@ -233,7 +222,7 @@ public:
     return getModule().Types.getTypeLowering(T, expansion);
   }
 
-  void setCurrentDebugScope(const SILDebugScope *DS);
+  void setCurrentDebugScope(const SILDebugScope *DS) { CurDebugScope = DS; }
   const SILDebugScope *getCurrentDebugScope() const { return CurDebugScope; }
 
   /// Apply a debug location override. If loc is None, the current override is
@@ -290,18 +279,10 @@ public:
 
   /// clearInsertionPoint - Clear the insertion point: created instructions will
   /// not be inserted into a block.
-  void clearInsertionPoint() {
-#ifndef NDEBUG
-    PrevDebugScope = nullptr;
-#endif
-    BB = nullptr;
-  }
+  void clearInsertionPoint() { BB = nullptr; }
 
   /// setInsertionPoint - Set the insertion point.
   void setInsertionPoint(SILBasicBlock *BB, SILBasicBlock::iterator insertPt) {
-#ifndef NDEBUG
-    PrevDebugScope = nullptr;
-#endif
     this->BB = BB;
     this->InsertPt = insertPt;
     assert(insertPt == BB->end() || insertPt->getParent() == BB);

--- a/include/swift/SIL/SILDebugScope.h
+++ b/include/swift/SIL/SILDebugScope.h
@@ -66,9 +66,6 @@ public:
   /// into.
   SILFunction *getParentFunction() const;
 
-  /// Determine whether other is an (indirect) parent of this scope.
-  bool isAncestor(const SILDebugScope *other) const;
-
   /// If this is a debug scope associated with an inlined call site, return the
   /// SILLocation associated with the call site resulting from the final
   /// inlining.

--- a/lib/SIL/IR/SILDebugScope.cpp
+++ b/lib/SIL/IR/SILDebugScope.cpp
@@ -37,17 +37,6 @@ SILDebugScope::SILDebugScope(SILLocation Loc, SILFunction *SILFn,
 SILDebugScope::SILDebugScope(SILLocation Loc)
     : Loc(Loc), InlinedCallSite(nullptr) {}
 
-bool SILDebugScope::isAncestor(const SILDebugScope *other) const {
-  while (other) {
-    auto Parent = other->Parent;
-    auto *ParentScope = Parent.dyn_cast<const SILDebugScope *>();
-    if (ParentScope == this)
-      return true;
-    other = ParentScope;
-  }
-  return false;
-}
-
 SILFunction *SILDebugScope::getInlinedFunction() const {
   if (Parent.isNull())
     return nullptr;

--- a/lib/SIL/Verifier/SILVerifier.cpp
+++ b/lib/SIL/Verifier/SILVerifier.cpp
@@ -6272,7 +6272,22 @@ public:
 
       // Otherwise, we're allowed to re-enter a scope only if
       // the scope is an ancestor of the scope we're currently leaving.
-      if (DS->isAncestor(LastSeenScope)) {
+      auto isAncestorScope = [](const SILDebugScope *Cur,
+                                const SILDebugScope *Previous) {
+        assert(Cur && "null current scope queried");
+        assert(Previous && "null previous scope queried");
+        const SILDebugScope *Tmp = Previous;
+        while (Tmp) {
+          auto Parent = Tmp->Parent;
+          auto *ParentScope = Parent.dyn_cast<const SILDebugScope *>();
+          if (ParentScope == Cur)
+            return true;
+          Tmp = ParentScope;
+        }
+        return false;
+      };
+
+      if (isAncestorScope(DS, LastSeenScope)) {
         LastSeenScope = DS;
         LastSeenScopeInst = &SI;
         continue;

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -1,5 +1,3 @@
-
-
 //===--- SILGenBuilder.cpp ------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
@@ -38,27 +36,15 @@ SILGenModule &SILGenBuilder::getSILGenModule() const { return SGF.SGM; }
 //===----------------------------------------------------------------------===//
 
 SILGenBuilder::SILGenBuilder(SILGenFunction &SGF)
-    : SILBuilder(SGF.F), SGF(SGF) {
-#ifndef NDEBUG
-    EnableDIHoleVerification = true;
-#endif
-}
+    : SILBuilder(SGF.F), SGF(SGF) {}
 
 SILGenBuilder::SILGenBuilder(SILGenFunction &SGF, SILBasicBlock *insertBB,
                              SmallVectorImpl<SILInstruction *> *insertedInsts)
-    : SILBuilder(insertBB, insertedInsts), SGF(SGF) {
-#ifndef NDEBUG
-    EnableDIHoleVerification = true;
-#endif
-}
+    : SILBuilder(insertBB, insertedInsts), SGF(SGF) {}
 
 SILGenBuilder::SILGenBuilder(SILGenFunction &SGF, SILBasicBlock *insertBB,
                              SILBasicBlock::iterator insertInst)
-    : SILBuilder(insertBB, insertInst), SGF(SGF) {
-#ifndef NDEBUG
-    EnableDIHoleVerification = true;
-#endif
-}
+    : SILBuilder(insertBB, insertInst), SGF(SGF) {}
 
 //===----------------------------------------------------------------------===//
 //                             Managed Value APIs

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -55,11 +55,7 @@ public:
   SILGenBuilder(SILGenBuilder &builder, SILBasicBlock *insertBB)
       : SILBuilder(insertBB, builder.getCurrentDebugScope(),
                    builder.getBuilderContext()),
-        SGF(builder.SGF) {
-#ifndef NDEBUG
-    EnableDIHoleVerification = true;
-#endif
-  }
+        SGF(builder.SGF) {}
 
   SILGenModule &getSILGenModule() const;
   SILGenFunction &getSILGenFunction() const { return SGF; }


### PR DESCRIPTION
It broke building the stdlib noasserts.

Cherry-pick of https://github.com/apple/swift/pull/64584 to 5.9.

rdar://107146237
