### PR TITLE
[CSSimplify] Don't rely on `ParameterListInfo`  to indicate that parameter is variadic generic

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3651,7 +3651,6 @@ struct ParameterListInfo {
   SmallBitVector propertyWrappers;
   SmallBitVector implicitSelfCapture;
   SmallBitVector inheritActorContext;
-  SmallBitVector variadicGenerics;
 
 public:
   ParameterListInfo() { }
@@ -3680,8 +3679,6 @@ public:
 
   /// Whether there is any contextual information set on this parameter list.
   bool anyContextualInfo() const;
-
-  bool isVariadicGenericParameter(unsigned paramIdx) const;
 
   /// Retrieve the number of non-defaulted parameters.
   unsigned numNonDefaultedParameters() const {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1304,7 +1304,6 @@ ParameterListInfo::ParameterListInfo(
   propertyWrappers.resize(params.size());
   implicitSelfCapture.resize(params.size());
   inheritActorContext.resize(params.size());
-  variadicGenerics.resize(params.size());
 
   // No parameter owner means no parameter list means no default arguments
   // - hand back the zeroed bitvector.
@@ -1364,10 +1363,6 @@ ParameterListInfo::ParameterListInfo(
     if (param->getAttrs().hasAttribute<InheritActorContextAttr>()) {
       inheritActorContext.set(i);
     }
-
-    if (param->getInterfaceType()->is<PackExpansionType>()) {
-      variadicGenerics.set(i);
-    }
   }
 }
 
@@ -1401,13 +1396,6 @@ bool ParameterListInfo::inheritsActorContext(unsigned paramIdx) const {
 bool ParameterListInfo::anyContextualInfo() const {
   return implicitSelfCapture.any() || inheritActorContext.any();
 }
-
-bool ParameterListInfo::isVariadicGenericParameter(unsigned paramIdx) const {
-  return paramIdx < variadicGenerics.size()
-      ? variadicGenerics[paramIdx]
-      : false;
-}
-
 
 /// Turn a param list into a symbolic and printable representation that does not
 /// include the types, something like (_:, b:, c:)

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -271,3 +271,15 @@ func test_pack_expansions_with_closures() {
     takesVariadicFunction { y, z in fn(y, z) } // Ok
   }
 }
+
+// rdar://107151854 - crash on invalid due to specialized pack expansion
+func test_pack_expansion_specialization() {
+  struct Data<each T> {
+    init(_: repeat each T) {} // expected-note {{'init(_:)' declared here}}
+  }
+
+  _ = Data<Int>() // expected-error {{missing argument for parameter #1 in call}}
+  _ = Data<Int>(0) // Ok
+  _ = Data<Int, String>(42, "") // Ok
+  _ = Data<Int>(42, "") // expected-error {{extra argument in call}}
+}


### PR DESCRIPTION
Check type of the parameter instead because reference type could
be specialized and that creates a mismatch between actual type of
the parameter and the expected one.

Resolves: rdar://107151854

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
