### PR TITLE
enable standard language features in LangOptions

### DIFF
--- a/include/swift/Basic/Feature.h
+++ b/include/swift/Basic/Feature.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_BASIC_FEATURES_H
 #define SWIFT_BASIC_FEATURES_H
 
+#include "swift/Basic/FixedBitSet.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -36,6 +37,9 @@ FeatureName,
   };
   return NumFeatures;
 }
+
+// A handy set datatype for all your feature-tracking needs!
+using BasicFeatureSet = FixedBitSet<numFeatures(), Feature>;
 
 /// Determine whether the given feature is suppressible.
 bool isSuppressibleFeature(Feature feature);

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -26,9 +26,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/SmallString.h"
-#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/Support/Regex.h"
@@ -377,8 +375,9 @@ namespace swift {
     /// behavior. This is a staging flag, and will be removed in the future.
     bool EnableNewOperatorLookup = false;
 
+
     /// The set of features that have been enabled.
-    llvm::SmallSet<Feature, 2> Features;
+    BasicFeatureSet Features;
 
     /// Temporary flag to support LLDB's transition to using \c Features.
     bool EnableBareSlashRegexLiterals = false;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3293,7 +3293,6 @@ static void suppressingFeature(PrintOptions &options, Feature feature,
   llvm_unreachable("exhaustive switch");
 }
 
-using BasicFeatureSet = FixedBitSet<numFeatures(), Feature>;
 
 class FeatureSet {
   BasicFeatureSet required;

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -29,8 +29,29 @@
 
 using namespace swift;
 
+static void
+insertDefaultEnabledFeatures(decltype(LangOptions::Features) &Features) {
+  // Default-on any full-fledged language features
+#define LANGUAGE_FEATURE(FeatureName, SENumber, Description, Option)           \
+  if (Option)                                                                  \
+    Features.insert(Feature::FeatureName);
+
+  // Don't default-on any other features.
+#define UPCOMING_FEATURE(FeatureName, SENumber, Version)
+#define SUPPRESSIBLE_LANGUAGE_FEATURE(FeatureName, SENumber, Description,      \
+                                      Option)
+#define EXPERIMENTAL_FEATURE(FeatureName, AvailableInProd)
+#include "swift/Basic/Features.def"
+#undef LANGUAGE_FEATURE
+#undef UPCOMING_FEATURE
+#undef SUPPRESSIBLE_LANGUAGE_FEATURE
+#undef EXPERIMENTAL_LANGUAGE_FEATURE
+}
+
 LangOptions::LangOptions() {
-  // Note: Introduce default-on language options here.
+  insertDefaultEnabledFeatures(Features);
+
+  // Features default-on only in asserts builds.
 #ifndef NDEBUG
   Features.insert(Feature::ParserRoundTrip);
   Features.insert(Feature::ParserValidation);


### PR DESCRIPTION
It's kind of odd how features that are unconditionally enabled, like `Feature::Actors` is not actually satisfying `LangOptions.hasFeature(Feature::Actors)`. This wasn't causing a problem elsewhere when parsing the feature in swiftinterface files because `EvaluateIfConfigCondition::visitUnresolvedDeclRefExpr` has its own switch over the features (rather than asking if it's enabled). Also, most of the time when someone enables a feature permanently, it's expected that all `hasFeature` queries are removed because "it's now always on". Now we actually _make sure_ the feature is always on.