### PR TITLE
[DNM] Getting Alamofire to compile in Swift6.

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -127,6 +127,8 @@ ERROR(sdk_node_unrecognized_decl_kind,none,
       "unrecognized declaration kind '%0' in SDK node", (StringRef))
 ERROR(sdk_node_unrecognized_accessor_kind,none,
       "unrecognized accessor kind '%0' in SDK node", (StringRef))
+NOTE(missing_any,none, "any/some will be required here", ())
+NOTE(used_any,none, "any in use", ())
 
 // Emitted from ModuleDecl::computeFileIDMap()
 WARNING(source_location_creates_file_id_conflicts,none,

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2977,6 +2977,33 @@ CollectedOpaqueReprs swift::collectOpaqueReturnTypeReprs(TypeRepr *r, ASTContext
     }
 
     PreWalkAction walkToTypeReprPre(TypeRepr *repr) override {
+        #if 01
+        if (const char *ep = (const char *)
+            repr->getEndLoc().getOpaquePointerValue()) {
+            while (isalnum(*ep))
+                ep++;
+//            fprintf(stderr, "[[%.100s\n", ep-10);
+            if (*ep == '\n' || *ep == '>' || *ep++ == ' ' &&
+                (*ep++ == '=' && *ep++ == ' ' || *ep--) &&
+                *ep++ == '{')
+                return Action::SkipChildren();
+
+            if (const char *line = strrchr(ep, '\n')) {
+                if (const char *objc = strstr(line, "@objc"))
+                    if (objc-line < 10)
+                        return Action::SkipChildren();
+                if (const char *over = strstr(line, "override"))
+                    if (over-line < 10)
+                        return Action::SkipChildren();
+            }
+        }
+        #endif
+
+        if (isa<DictionaryTypeRepr>(repr) ||
+            isa<ArrayTypeRepr>(repr) ||
+            isa<FunctionTypeRepr>(repr) ||
+            isa<OptionalTypeRepr>(repr))
+          return Action::SkipChildren();
 
       // Don't allow variadic opaque parameter or return types.
       if (isa<PackExpansionTypeRepr>(repr) || isa<VarargTypeRepr>(repr))

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -2977,68 +2977,6 @@ CollectedOpaqueReprs swift::collectOpaqueReturnTypeReprs(TypeRepr *r, ASTContext
     }
 
     PreWalkAction walkToTypeReprPre(TypeRepr *repr) override {
-        #if 01
-        if (const char *ep = (const char *)
-            repr->getEndLoc().getOpaquePointerValue()) {
-            const char *save = ep;
-            // skip to end of identifier
-            while (isalnum(*ep) || *ep == '.')
-                ep++;
-            // exlucde system protocols used in conformances
-            if (strncmp(save, "Codeable", ep-save) == 0 ||
-                strncmp(save, "Encoder", ep-save) == 0 ||
-                strncmp(save, "Decoder", ep-save) == 0 ||
-                strncmp(save, "Encodable", ep-save) == 0 ||
-                strncmp(save, "Decodable", ep-save) == 0 ||
-                strncmp(save, "Subscription", ep-save) == 0 ||
-                strncmp(save, "Swift.Error", ep-save) == 0 ||
-                strncmp(save, "Error", ep-save) == 0 ||
-                // exclude meta-types
-                strncmp(ep-9, ".Protocol", 9) == 0 ||
-                strncmp(ep-5, ".Type", 5) == 0)
-                return Action::SkipChildren();
-
-//            fprintf(stderr, "[[%.100s\n", ep-10);
-            if (*ep == '\n' || // unitialised properties
-                *ep == '>' || // protocols in containers
-                *ep == '<' || // "" w/ associated types
-                save[-2] == '&' || // combined with &
-                *ep++ == ' ' && // exclude initialised
-                (*ep++ == '=' && *ep++ == ' ' || *ep--) &&
-                // with numbers, closures, or combined with &
-                (isdigit(*ep) || *ep++ == '{' || *ep++ == '&'))
-                return Action::SkipChildren();
-
-            // exclude return types
-            if (strncmp(save-3, "-> ", 3) == 0)
-                return Action::SkipChildren();
-
-            // exlcude methods marked @objc
-            const char *line = save;
-            for (int i=0; i<100; i++, line--)
-                if (*line == '\n')
-                    break;
-            if (strncmp(line-5, "@objc", 5) == 0)
-                return Action::SkipChildren();
-            if (const char *objc = strstr(line, "@objc"))
-                if (objc-line < 10)
-                    return Action::SkipChildren();
-
-//            if (const char *over = strstr(line, "override"))
-//                if (over-line < 10)
-//                    return Action::SkipChildren();
-//            if (const char *over = strstr(line, "init("))
-//                if (over-line < 10)
-//                    return Action::SkipChildren();
-        }
-
-        // exclude all containers
-        if (isa<DictionaryTypeRepr>(repr) ||
-            isa<ArrayTypeRepr>(repr) ||
-            isa<FunctionTypeRepr>(repr) ||
-            isa<OptionalTypeRepr>(repr))
-          return Action::SkipChildren();
-        #endif
 
       // Don't allow variadic opaque parameter or return types.
       if (isa<PackExpansionTypeRepr>(repr) || isa<VarargTypeRepr>(repr))
@@ -3053,6 +2991,74 @@ CollectedOpaqueReprs swift::collectOpaqueReturnTypeReprs(TypeRepr *r, ASTContext
       if (!Ctx.LangOpts.hasFeature(Feature::ImplicitSome))
         return Action::Continue();
       
+      if (getenv("ImplicitMix")) {
+        if (const char *ep = (const char *)
+            repr->getEndLoc().getOpaquePointerValue()) {
+            const char *save = ep;
+            // skip to end of identifier
+            while (isalnum(*ep) || *ep == '.')
+                ep++;
+            // exlucde system protocols used in conformances
+            if (strncmp(save, "Codeable", ep-save) == 0 ||
+                strncmp(save, "Encoder", ep-save) == 0 ||
+                strncmp(save, "Decoder", ep-save) == 0 ||
+                strncmp(save, "Encodable", ep-save) == 0 ||
+                strncmp(save, "Decodable", ep-save) == 0 ||
+                strncmp(save, "Disposable", ep-save) == 0 ||
+                strncmp(save, "Swift.Error", ep-save) == 0 ||
+                strncmp(save, "Error", ep-save) == 0 ||
+                // exclude meta-types
+                strncmp(ep-9, ".Protocol", 9) == 0 ||
+                strncmp(ep-5, ".Type", 5) == 0)
+                return Action::Continue();
+
+//            fprintf(stderr, "[[%.100s\n", ep-10);
+            if (save[-2] == '&' || // combined with &
+//                save[-2] == ',' || // closures
+//                save[-1] == '(' || // closures
+                *ep == '\n' || // unitialised properties
+                *ep == '>' || // protocols in containers
+                *ep == ']' || // protocols in containers
+                *ep == '?' || // protocols in containers
+                *ep == '<' || // "" w/ associated types
+                *ep++ == ' ' && // exclude initialised
+                (*ep++ == '=' && *ep++ == ' ' || *ep--) &&
+                // with numbers, closures, or combined with &
+                (isdigit(*ep) || *ep == '{' || *ep == '&' || *ep == '/'))
+                return Action::Continue();
+
+            // exclude return types
+            if (strncmp(save-3, "-> ", 3) == 0)
+                return Action::SkipChildren();
+
+            // exlcude methods marked @objc
+            const char *line = save;
+            for (int i=0; i<100; i++, line--)
+                if (*line == '\n')
+                    break;
+            if (strncmp(line-5, "@objc", 5) == 0)
+                return Action::Continue();
+            if (const char *objc = strstr(line, "@objc"))
+                if (objc-line < 10)
+                    return Action::Continue();
+
+//            if (const char *over = strstr(line, "override"))
+//                if (over-line < 10)
+//                    return Action::SkipChildren();
+//            if (const char *over = strstr(line, "init("))
+//                if (over-line < 10)
+//                    return Action::SkipChildren();
+        }
+
+        // exclude all containers
+        if (isa<DictionaryTypeRepr>(repr) ||
+            isa<ArrayTypeRepr>(repr) ||
+            isa<FunctionTypeRepr>(repr) ||
+            isa<OptionalTypeRepr>(repr) ||
+            isa<TupleTypeRepr>(repr))
+          return Action::SkipChildren();
+      }
+
       if (auto existential = dyn_cast<ExistentialTypeRepr>(repr)) {
         return Action::SkipChildren();
       } else if (auto compositionRepr = dyn_cast<CompositionTypeRepr>(repr)) {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1226,6 +1226,26 @@ void SILGenModule::postEmitFunction(SILDeclRef constant,
   F->verifyIncompleteOSSA();
 
   emitDifferentiabilityWitnessesForFunction(constant, F);
+    if (!constant.hasDecl()) return;
+    if (auto AF = dyn_cast<AbstractFunctionDecl>(constant.getDecl()))
+      for (auto p : *AF->getParameters()) {
+        if (!p->getStartLoc().isValid()) continue;
+          char const *ty = nullptr;
+          if (auto r = p->getTypeRepr())
+              ty = (char const  *)r->getStartLoc().getOpaquePointerValue();
+        auto bufferID = getASTContext().SourceMgr.findBufferContainingLoc(p->getStartLoc());
+          if (strncmp(F->getASTContext().SourceMgr.getLLVMSourceMgr()
+              .getMemoryBuffer(bufferID)->getBufferIdentifier().str().c_str(), "/Volumes/Data2/some", 19))
+              return;
+          static std::map<const void *,int> anys, nanys;
+          if (ty && p->getType()->getCanonicalType()->isExistentialType() &&
+              !(strncmp(ty, "some ", 5) == 0 || (strncmp(ty, "__owned ", 8) == 0 && (ty += 8) || true) && strncmp(ty, "any ", 4) == 0 && strncmp(ty, "Any", 3) != 0) && !nanys[p->getTypeRepr()->getStartLoc().getOpaquePointerValue()]++)
+              F->getASTContext().Diags.diagnose(p->getTypeRepr()->getStartLoc(), diag::missing_any);
+          if (ty && p->getType()->getCanonicalType()->isExistentialType() &&
+              ((strncmp(ty, "__owned ", 8) == 0 && (ty += 8) || true) && strncmp(ty, "any ", 4) == 0 && strncmp(ty, "Any", 3) != 0) && !anys[p->getTypeRepr()->getStartLoc().getOpaquePointerValue()]++)
+              F->getASTContext().Diags.diagnose(p->getTypeRepr()->getStartLoc(), diag::used_any);
+          fflush(stdout);
+      }
 }
 
 void SILGenModule::emitDifferentiabilityWitnessesForFunction(


### PR DESCRIPTION
Hi Apple,

This is the secret sauce I've been using to perform experiments in moderating the eliding to `some` being discussed at the moment on the forums S/E https://forums.swift.org/t/pitch-elide-some-in-swift-6/63737/68 related to compiling https://github.com/Alamofire/Alamofire. I should say it would compile but it runs into this issue: https://github.com/apple/swift/issues/64481. This proves it is eliding to `some` but not excessively and is intended as a demonstration it is possible minimise source breaking while delivering a principle engineering benefit sited in SE-0335. Don't look too closely at the code as it will make your brain hurt; I did say I was experimenting in a naive way. cc @angela-laar, @hborla 

Good luck with your pitch!
