### PR TITLE
[ConstraintSystem] Fix support for a single pack expansion parameter …

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1699,7 +1699,8 @@ namespace {
         if (!CS.getASTContext().isSwiftVersionAtLeast(6)) {
           auto paramTypeVar = CS.createTypeVariable(
               CS.getConstraintLocator(expr, ConstraintLocator::ApplyArgument),
-              TVO_CanBindToLValue | TVO_CanBindToInOut | TVO_CanBindToNoEscape);
+              TVO_CanBindToLValue | TVO_CanBindToInOut | TVO_CanBindToNoEscape |
+                  TVO_CanBindToPack);
           CS.addConstraint(ConstraintKind::BindTupleOfFunctionParams, methodTy,
                            paramTypeVar, CS.getConstraintLocator(expr));
         }

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4311,21 +4311,37 @@ ConstraintSystem::matchTypesBindTypeVar(
     return getTypeMatchFailure(locator);
   }
 
-  // Binding to a pack expansion type is always an error. This indicates
-  // that a pack expansion expression was used in a context that doesn't
-  // support it.
+  // Binding to a pack expansion type is always an error in Swift 6 mode.
+  // This indicates that a pack expansion expression was used in a context
+  // that doesn't support it.
+  //
+  // In Swift 5 and earlier initializer references are handled in a special
+  // way that uses a type variable to represent a type of the parameter
+  // list. Such type variables should be allowed to bind to a pack expansion
+  // type to support cases where initializer has a single unlabeled variadic
+  // generic parameter - `init(_ data: repeat each T)`.
+  //
+  // See BindTupleOfFunctionParams constraint for more details.
   if (type->is<PackExpansionType>()) {
-    if (!shouldAttemptFixes())
-      return getTypeMatchFailure(locator);
+    bool representsParameterList =
+        typeVar->getImpl()
+            .getLocator()
+            ->isLastElement<LocatorPathElt::ApplyArgument>();
 
-    auto *fix =
-        AllowInvalidPackExpansion::create(*this, getConstraintLocator(locator));
-    if (recordFix(fix))
-      return getTypeMatchFailure(locator);
+    if (!(typeVar->getImpl().canBindToPack() && representsParameterList) ||
+        getASTContext().isSwiftVersionAtLeast(6)) {
+      if (!shouldAttemptFixes())
+        return getTypeMatchFailure(locator);
 
-    // Don't allow the pack expansion type to propagate to other
-    // bindings.
-    type = PlaceholderType::get(typeVar->getASTContext(), typeVar);
+      auto *fix = AllowInvalidPackExpansion::create(
+          *this, getConstraintLocator(locator));
+      if (recordFix(fix))
+        return getTypeMatchFailure(locator);
+
+      // Don't allow the pack expansion type to propagate to other
+      // bindings.
+      type = PlaceholderType::get(typeVar->getASTContext(), typeVar);
+    }
   }
 
   // We do not allow keypaths to go through AnyObject. Let's create a fix
@@ -7860,7 +7876,8 @@ ConstraintSystem::simplifyConstructionConstraint(
   if (!getASTContext().isSwiftVersionAtLeast(6)) {
     auto paramTypeVar = createTypeVariable(
         getConstraintLocator(locator, ConstraintLocator::ApplyArgument),
-        TVO_CanBindToLValue | TVO_CanBindToInOut | TVO_CanBindToNoEscape);
+        TVO_CanBindToLValue | TVO_CanBindToInOut | TVO_CanBindToNoEscape |
+            TVO_CanBindToPack);
     addConstraint(ConstraintKind::BindTupleOfFunctionParams, memberType,
                   paramTypeVar, locator);
   }

--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -262,6 +262,27 @@ func invalidRepeat<each T>(t: repeat each T) {
   // expected-error@-1 {{value pack expansion can only appear inside a function argument list or tuple element}}
 }
 
+// Make sure that single parameter initializers are handled correctly because
+// the have special type-checking rules in Swift < 6.
+func test_init_refs_with_single_pack_expansion_param() {
+  struct Data<each V> {
+    init(_: repeat each V) {}
+  }
+
+  _ = Data() // Ok
+  _ = Data(42) // Ok
+  _ = Data(42, "") // Ok
+
+  struct EmptyAmbiguous<each V> {
+    init(_: repeat each V) {} // expected-note {{found this candidate}}
+    init(x: repeat each V) {} // expected-note {{found this candidate}}
+  }
+
+  _ = EmptyAmbiguous() // expected-error {{ambiguous use of 'init'}}
+  _ = EmptyAmbiguous(x: 42)
+  _ = EmptyAmbiguous(x: (42, "")) // Ok
+}
+
 func test_pack_expansions_with_closures() {
   func takesVariadicFunction<each T>(function: (repeat each T) -> Int) {}
 


### PR DESCRIPTION
…in `init` references

In Swift 5 and earlier initializer references are handled in a special way 
that uses a type variable to represent a type of the parameter list. 
Such type variables should be allowed to bind to a pack expansion type
to support cases where initializer has a single unlabeled variadic generic
parameter - `init(_ data: repeat each T)`.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
