### PR TITLE
[Macros] Disallow `self` and `Self` as macro names

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1716,6 +1716,11 @@ public:
 
     /// If passed, compound names with empty argument lists are allowed.
     AllowZeroArgCompoundNames = AllowCompoundNames | 1 << 5,
+
+    /// If passed, \c self and \c Self are allowed as basenames. In a lot of
+    /// cases this doesn't actually make sense but we need to accept them for
+    /// backwards compatibility.
+    AllowLowercaseAndUppercaseSelf = 1 << 6,
   };
   using DeclNameOptions = OptionSet<DeclNameFlag>;
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -850,7 +850,8 @@ bool Parser::parseSpecializeAttributeArguments(
               loc, diag::attr_specialize_expected_function,
               DeclNameFlag::AllowZeroArgCompoundNames |
                   DeclNameFlag::AllowKeywordsUsingSpecialNames |
-                  DeclNameFlag::AllowOperators);
+                  DeclNameFlag::AllowOperators |
+                  DeclNameFlag::AllowLowercaseAndUppercaseSelf);
         }
       }
       if (ParamLabel == "spiModule") {
@@ -1137,10 +1138,11 @@ Parser::parseImplementsAttribute(SourceLoc AtLoc, SourceLoc Loc) {
     }
 
     if (!Status.isErrorOrHasCompletion()) {
-      MemberName = parseDeclNameRef(MemberNameLoc,
-          diag::attr_implements_expected_member_name,
+      MemberName = parseDeclNameRef(
+          MemberNameLoc, diag::attr_implements_expected_member_name,
           DeclNameFlag::AllowZeroArgCompoundNames |
-          DeclNameFlag::AllowOperators);
+              DeclNameFlag::AllowOperators |
+              DeclNameFlag::AllowLowercaseAndUppercaseSelf);
       if (!MemberName) {
         Status.setIsParseError();
       }
@@ -1505,7 +1507,8 @@ static bool parseQualifiedDeclName(Parser &P, Diag<> nameParseError,
         original.Loc, nameParseError,
         Parser::DeclNameFlag::AllowZeroArgCompoundNames |
             Parser::DeclNameFlag::AllowKeywordsUsingSpecialNames |
-            Parser::DeclNameFlag::AllowOperators);
+            Parser::DeclNameFlag::AllowOperators |
+            Parser::DeclNameFlag::AllowLowercaseAndUppercaseSelf);
     // The base type is optional, but the final unqualified declaration name is
     // not. If name could not be parsed, return true for error.
     if (!original.Name)
@@ -3207,11 +3210,12 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       consumeToken(tok::colon);
       {
         DeclNameLoc loc;
-        replacedFunction = parseDeclNameRef(loc,
-            diag::attr_dynamic_replacement_expected_function,
+        replacedFunction = parseDeclNameRef(
+            loc, diag::attr_dynamic_replacement_expected_function,
             DeclNameFlag::AllowZeroArgCompoundNames |
-            DeclNameFlag::AllowKeywordsUsingSpecialNames |
-            DeclNameFlag::AllowOperators);
+                DeclNameFlag::AllowKeywordsUsingSpecialNames |
+                DeclNameFlag::AllowOperators |
+                DeclNameFlag::AllowLowercaseAndUppercaseSelf);
       }
     }
 
@@ -3920,8 +3924,9 @@ bool Parser::parseConventionAttributeInternal(
     }
 
     DeclNameLoc unusedLoc;
-    convention.WitnessMethodProtocol = parseDeclNameRef(unusedLoc,
-        diag::convention_attribute_witness_method_expected_protocol, {});
+    convention.WitnessMethodProtocol = parseDeclNameRef(
+        unusedLoc, diag::convention_attribute_witness_method_expected_protocol,
+        DeclNameFlag::AllowLowercaseAndUppercaseSelf);
   }
   
   // Parse the ')'.  We can't use parseMatchingToken if we're in

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -812,7 +812,8 @@ ParserResult<IdentTypeRepr> Parser::parseTypeIdentifier() {
   // component.
   DeclNameLoc Loc;
   DeclNameRef Name =
-      parseDeclNameRef(Loc, diag::expected_identifier_in_dotted_type, {});
+      parseDeclNameRef(Loc, diag::expected_identifier_in_dotted_type,
+                       DeclNameFlag::AllowLowercaseAndUppercaseSelf);
   if (!Name)
     return makeParserError();
 

--- a/test/Macros/macro_self.swift
+++ b/test/Macros/macro_self.swift
@@ -1,0 +1,27 @@
+// RUN: %target-swift-frontend -parse %s -verify
+
+@freestanding(expression) // expected-error {{expected expression}}
+macro self() = #externalMacro(module: "MacroDefinition", type: "InvalidMacro")
+
+func sync() {}
+
+@freestanding(expression) // expected-error {{expected expression}}
+macro Self() = #externalMacro(module: "MacroDefinition", type: "InvalidMacro")
+
+func testSelfAsFreestandingMacro() {
+  _ = #self // expected-error {{expected a macro identifier for a pound literal expression}}
+}
+
+func testCapitalSelfAsFreestandingMacro() {
+  _ = #Self // expected-error {{expected a macro identifier for a pound literal expression}}
+}
+ 
+func testSelfAsAttachedMacro() {
+  @self // expected-error {{expected expression}}
+  struct Foo {}
+}
+
+func testCapitalSelfAsAttachedMacro() {
+  @Self // expected-error {{expected expression}}
+  struct Foo {}
+}


### PR DESCRIPTION
We were allowing `self` and `Self` as freestanding macro names, which we don’t want.

Change `parseDeclNameRef` so that you need to explicitly request parsing of `self` or `Self` as the declaration’s base name, and adjust all call sites except those for macros to pass that flag.
