### PR TITLE
[Observation] Refine the macro implementation for Observable

### DIFF
--- a/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
+++ b/lib/Macros/Sources/ObservationMacros/ObservableMacro.swift
@@ -255,7 +255,8 @@ extension VariableDeclSyntax {
     let patternBindings = bindings.compactMap { binding in
       binding.as(PatternBindingSyntax.self)
     }
-    let accessors = patternBindings.compactMap { patternBinding in
+    let accessors: [AccessorListSyntax.Element] 
+      = patternBindings.compactMap { patternBinding in
       switch patternBinding.accessor {
       case .accessors(let accessors):
         return accessors

--- a/stdlib/public/Observation/Sources/Observation/Macros.swift
+++ b/stdlib/public/Observation/Sources/Observation/Macros.swift
@@ -12,7 +12,7 @@
 #if $Macros && hasAttribute(attached)
 
 @available(SwiftStdlib 5.9, *)
-@attached(member, names: named(_registrar), named(changes), named(values), named(_Storage), named(_storage))
+@attached(member, names: named(_$observationRegistrar), named(changes), named(values), named(_$ObservationStorage), named(_$observationStorage), named(`init`))
 @attached(memberAttribute)
 @attached(conformance)
 public macro Observable() = 

--- a/test/stdlib/Observation/Observable.swift
+++ b/test/stdlib/Observation/Observable.swift
@@ -86,9 +86,9 @@ final class TestWithoutMacro: Observable {
 
 @available(SwiftStdlib 5.9, *)
 @Observable final class TestWithMacro {
-  var field1 = "test"
-  var field2 = "test"
-  var field3 = 0
+  var field1: String = "test"
+  var field2: String = "test"
+  var field3: Int = 0
 }
 
 extension AsyncSequence {


### PR DESCRIPTION
This alters the macro emission for `@Observable` to:
better handle initialization
produce sensible diagnostics when inferred types are used for properties
produce sensible diagnostics when actors are marked as `@Observable`
better names for member variables and types to avoid conflicting with users of `@Observable`
