### PR TITLE
[Serialization] Pass up deserialization errors when reading generic type params

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -6323,9 +6323,12 @@ DESERIALIZE_TYPE(GENERIC_TYPE_PARAM_TYPE)(
       scratch, parameterPack, declIDOrDepth, indexPlusOne);
 
   if (indexPlusOne == 0) {
-    auto genericParam =
-        dyn_cast_or_null<GenericTypeParamDecl>(MF.getDecl(declIDOrDepth));
+    auto genericParamOrError = MF.getDeclChecked(declIDOrDepth);
+    if (!genericParamOrError)
+      return genericParamOrError.takeError();
 
+    auto genericParam =
+        dyn_cast_or_null<GenericTypeParamDecl>(genericParamOrError.get());
     if (!genericParam)
       return MF.diagnoseFatal();
 


### PR DESCRIPTION
There is no related test as we don't have reproducer code and we've seen it only in the debugger, but I believe the fix is sound on its own.

rdar://106430304