### PR TITLE
Fix minimal stdlib builds with noncopyable types

### DIFF
--- a/include/swift/Basic/Features.def
+++ b/include/swift/Basic/Features.def
@@ -115,6 +115,8 @@ EXPERIMENTAL_FEATURE(FreestandingMacros, true)
 // but our tests currently rely on it, and we want to run those
 // tests in non-asserts builds too.
 EXPERIMENTAL_FEATURE(MoveOnlyClasses, true)
+EXPERIMENTAL_FEATURE(NoImplicitCopy, true)
+EXPERIMENTAL_FEATURE(OldOwnershipOperatorSpellings, true)
 
 EXPERIMENTAL_FEATURE(OneWayClosureParameters, false)
 EXPERIMENTAL_FEATURE(TypeWitnessSystemInference, false)

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3212,6 +3212,14 @@ static bool usesFeatureMoveOnlyClasses(Decl *decl) {
   return isa<ClassDecl>(decl) && usesFeatureMoveOnly(decl);
 }
 
+static bool usesFeatureNoImplicitCopy(Decl *decl) {
+  return decl->isNoImplicitCopy();
+}
+
+static bool usesFeatureOldOwnershipOperatorSpellings(Decl *decl) {
+  return false;
+}
+
 static bool usesFeatureOneWayClosureParameters(Decl *decl) {
   return false;
 }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -721,8 +721,12 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Opts.Features.insert(Feature::NamedOpaqueTypes);
   if (Args.hasArg(OPT_enable_experimental_flow_sensitive_concurrent_captures))
     Opts.Features.insert(Feature::FlowSensitiveConcurrencyCaptures);
-  if (Args.hasArg(OPT_enable_experimental_move_only))
+  if (Args.hasArg(OPT_enable_experimental_move_only)) {
+    // FIXME: drop addition of Feature::MoveOnly once its queries are gone.
     Opts.Features.insert(Feature::MoveOnly);
+    Opts.Features.insert(Feature::NoImplicitCopy);
+    Opts.Features.insert(Feature::OldOwnershipOperatorSpellings);
+  }
   if (Args.hasArg(OPT_experimental_one_way_closure_params))
     Opts.Features.insert(Feature::OneWayClosureParameters);
   if (Args.hasArg(OPT_enable_experimental_associated_type_inference))

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -422,7 +422,7 @@ ParserResult<Expr> Parser::parseExprSequenceElement(Diag<> message,
     return sub;
   }
 
-  if (Context.LangOpts.hasFeature(Feature::MoveOnly)) {
+  if (Context.LangOpts.hasFeature(Feature::OldOwnershipOperatorSpellings)) {
     if (Tok.isContextualKeyword("_move")) {
       Tok.setKind(tok::contextual_keyword);
       SourceLoc awaitLoc = consumeToken();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -349,7 +349,7 @@ public:
 void AttributeChecker::visitNoImplicitCopyAttr(NoImplicitCopyAttr *attr) {
   // Only allow for this attribute to be used when experimental move only is
   // enabled.
-  if (!D->getASTContext().LangOpts.hasFeature(Feature::MoveOnly)) {
+  if (!D->getASTContext().LangOpts.hasFeature(Feature::NoImplicitCopy)) {
     auto error =
         diag::experimental_moveonly_feature_can_only_be_used_when_enabled;
     diagnoseAndRemoveAttr(attr, error);

--- a/stdlib/public/Concurrency/CMakeLists.txt
+++ b/stdlib/public/Concurrency/CMakeLists.txt
@@ -149,6 +149,7 @@ add_swift_target_library(swift_Concurrency ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} I
     ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
     -parse-stdlib
     -Xfrontend -enable-experimental-concurrency
+    -enable-experimental-feature MoveOnly
     -diagnostic-style swift
     ${SWIFT_RUNTIME_CONCURRENCY_SWIFT_FLAGS}
   ${swift_concurrency_options}

--- a/test/stdlib/move_function.swift
+++ b/test/stdlib/move_function.swift
@@ -1,4 +1,4 @@
-// RUN: %target-run-stdlib-swift(-O)
+// RUN: %target-run-stdlib-swift(-O -enable-experimental-feature MoveOnly)
 
 // REQUIRES: executable_test
 

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -581,8 +581,13 @@ int main(int argc, char **argv) {
     EnableExperimentalConcurrency;
   Optional<bool> enableExperimentalMoveOnly =
       toOptionalBool(EnableExperimentalMoveOnly);
-  if (enableExperimentalMoveOnly && *enableExperimentalMoveOnly)
+  if (enableExperimentalMoveOnly && *enableExperimentalMoveOnly) {
+    // FIXME: drop addition of Feature::MoveOnly once its queries are gone.
     Invocation.getLangOptions().Features.insert(Feature::MoveOnly);
+    Invocation.getLangOptions().Features.insert(Feature::NoImplicitCopy);
+    Invocation.getLangOptions().Features.insert(
+        Feature::OldOwnershipOperatorSpellings);
+  }
   for (auto &featureName : ExperimentalFeatures) {
     if (auto feature = getExperimentalFeature(featureName)) {
       Invocation.getLangOptions().Features.insert(*feature);


### PR DESCRIPTION
This PR does a few things:
1. give unofficial features in the area of noncopyable types their own feature flags, rather than piggybacking on `MoveOnly`.
2. Add `-enable-experimental-feature MoveOnly` to the `_Concurrency` lib build and one test.

(2) is really just a temporary measure until toolchains and any other bespoke configurations catch up, since the stdlib is built with older compilers that expect the flag to be passed to it. I think after maybe a month of smooth sailing we can just revert the bits of (2)

resolves rdar://106849189