### PR TITLE
build: bootstrap SwiftPM with forked and not host clang

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/swiftpm.py
+++ b/utils/swift_build_support/swift_build_support/products/swiftpm.py
@@ -48,6 +48,7 @@ class SwiftPM(product.Product):
 
         toolchain_path = self.native_toolchain_path(host_target)
         swiftc = os.path.join(toolchain_path, "bin", "swiftc")
+        clang = os.path.join(toolchain_path, "bin", "clang")
 
         # FIXME: We require llbuild build directory in order to build. Is
         # there a better way to get this?
@@ -67,7 +68,7 @@ class SwiftPM(product.Product):
 
         helper_cmd += [
             "--swiftc-path", swiftc,
-            "--clang-path", self.toolchain.cc,
+            "--clang-path", clang,
             "--cmake-path", self.toolchain.cmake,
             "--ninja-path", self.toolchain.ninja,
             "--build-dir", self.build_dir,


### PR DESCRIPTION
This was set in #28710 years ago, but didn't matter until apple/swift-package-manager#5894 a couple months ago, as the `--clang-path` flag was ignored before that. However, building Swift tools with the host clang can cause problems, [as seen on my Android CI since that SPM pull was merged in December](https://github.com/buttaface/swift-android-sdk/actions/runs/4526162457/jobs/7971153005#step:6:6905), so everything from the Swift stdlib onwards is built with the Swift-forked clang instead, so switch SPM here to use it too.

@MaxDesiatov and @neonichu, please review.