### PR TITLE
Bump macOS deployment target for TSan to 10.13 for LLVM only preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -684,6 +684,12 @@ reconfigure
 verbose-build
 build-ninja
 
+# TODO: remove when we will transition from LLVM_TOOL_COMPILER_RT_BUILD
+# to LLVM_USE_RUNTIMES to build compiler-rt (#60993), so we can leverage
+# the value for SANITIZER_MIN_OSX_VERSION set in cmake_product.py
+extra-cmake-options=
+  -DCLANG_COMPILER_RT_CMAKE_ARGS:STRING="-DSANITIZER_MIN_OSX_VERSION:STRING=10.13"
+
 # Do not build swift or cmark
 skip-build-swift
 skip-build-cmark


### PR DESCRIPTION
This allows LLVM TSAN tests to pass when using Xcode 14.3.

Long term we want to switch to `LLVM_USE_RUNTIMES` to build compiler-rt, so we can leverage the value of `SANITIZER_MIN_OSX_VERSION` set in `cmake_product.py`.
In the meantime, we prefer enforcing the deployment in the only preset that needs this, since this currently requires leveraging an intermediate variable (`CLANG_COMPILER_RT_CMAKE_ARGS`) which cannot be easily augmented in presets mixins.

Addresses rdar://106441106