### PR TITLE
Introduce `-unavailable-decl-optimization`

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -105,6 +105,22 @@ namespace swift {
     TaskToThread,
   };
 
+  /// Describes the code size optimization behavior for code associated with
+  /// declarations that are marked unavailable.
+  enum class UnavailableDeclOptimization : uint8_t {
+    /// No optimization. Unavailable declarations will contribute to the
+    /// resulting binary by default in this mode.
+    None,
+
+    /// Avoid generating any code for unavailable declarations.
+    ///
+    /// NOTE: This optimization can be ABI breaking for a library evolution
+    /// enabled module because existing client binaries built with a
+    /// pre-Swift 5.9 compiler may depend on linkable symbols associated with
+    /// unavailable declarations.
+    Complete,
+  };
+
   /// A collection of options that affect the language dialect and
   /// provide compiler debugging facilities.
   class LangOptions final {
@@ -170,6 +186,10 @@ namespace swift {
 
     /// Disable API availability checking.
     bool DisableAvailabilityChecking = false;
+
+    /// Optimization mode for unavailable declarations.
+    UnavailableDeclOptimization UnavailableDeclOptimizationMode =
+        UnavailableDeclOptimization::None;
 
     /// Causes the compiler to use weak linkage for symbols belonging to
     /// declarations introduced at the deployment target.

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -490,6 +490,13 @@ def check_api_availability_only : Flag<["-"], "check-api-availability-only">,
   Flags<[HelpHidden, FrontendOption, NoInteractiveOption]>,
   HelpText<"Deprecated, has no effect">;
 
+def unavailable_decl_optimization_EQ : Joined<["-"], "unavailable-decl-optimization=">,
+  MetaVarName<"<complete,none>">,
+  Flags<[FrontendOption, NoInteractiveOption]>,
+  HelpText<"Specify the optimization mode for unavailable declarations. The "
+           "value may be 'none' (no optimization) or 'complete' (code is not "
+           "generated at all unavailable declarations)">;
+
 def library_level : Separate<["-"], "library-level">,
   MetaVarName<"<level>">,
   Flags<[HelpHidden, FrontendOption, ModuleInterfaceOption]>,

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -1078,8 +1078,22 @@ namespace Lowering {
 /// Determine whether the given class will be allocated/deallocated using the
 /// Objective-C runtime, i.e., +alloc and -dealloc.
 LLVM_LIBRARY_VISIBILITY bool usesObjCAllocator(ClassDecl *theClass);
+
+/// Returns true if SIL/IR lowering for the given declaration should be skipped.
+/// A declaration may not require lowering if, for example, it is annotated as
+/// unavailable and optimization settings allow it to be omitted.
+LLVM_LIBRARY_VISIBILITY bool shouldSkipLowering(Decl *D);
 } // namespace Lowering
 
+/// Apply the given function to each ABI member of \c D skipping the members
+/// that should be skipped according to \c shouldSkipLowering()
+template <typename F>
+void forEachMemberToLower(IterableDeclContext *D, F &&f) {
+  for (auto *member : D->getABIMembers()) {
+    if (!Lowering::shouldSkipLowering(member))
+      f(member);
+  }
+}
 } // namespace swift
 
 #endif

--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -141,8 +141,9 @@ protected:
     if (!theClass->hasKnownSwiftImplementation())
       return;
 
-    for (auto member : theClass->getABIMembers())
+    forEachMemberToLower(theClass, [&](Decl *member) {
       maybeAddMember(member);
+    });
   }
 };
 

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -181,6 +181,9 @@ AvailabilityInference::parentDeclForInferredAvailability(const Decl *D) {
       return NTD;
   }
 
+  if (auto *PBD = dyn_cast<PatternBindingDecl>(D))
+    return PBD->getAnchoringVarDecl(0);
+
   // Clang decls may be inaccurately parented rdar://53956555
   if (D->hasClangNode())
     return nullptr;

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -552,6 +552,20 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     Diags.diagnose(SourceLoc(), diag::warn_flag_deprecated,
                    "-check-api-availability-only");
 
+  if (const Arg *A = Args.getLastArg(OPT_unavailable_decl_optimization_EQ)) {
+    auto value =
+        llvm::StringSwitch<Optional<UnavailableDeclOptimization>>(A->getValue())
+            .Case("none", UnavailableDeclOptimization::None)
+            .Case("complete", UnavailableDeclOptimization::Complete)
+            .Default(None);
+
+    if (value)
+      Opts.UnavailableDeclOptimizationMode = *value;
+    else
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+  }
+
   Opts.WeakLinkAtTarget |= Args.hasArg(OPT_weak_link_at_target);
 
   if (auto A = Args.getLastArg(OPT_enable_conformance_availability_errors,

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2458,9 +2458,13 @@ void swift::irgen::disableAddressSanitizer(IRGenModule &IGM, llvm::GlobalVariabl
 
 /// Emit a global declaration.
 void IRGenModule::emitGlobalDecl(Decl *D) {
+  if (Lowering::shouldSkipLowering(D))
+    return;
+
   D->visitAuxiliaryDecls([&](Decl *decl) {
     emitGlobalDecl(decl);
   });
+
   switch (D->getKind()) {
   case DeclKind::Extension:
     return emitExtension(cast<ExtensionDecl>(D));

--- a/lib/IRGen/TBDGen.cpp
+++ b/lib/IRGen/TBDGen.cpp
@@ -414,6 +414,9 @@ void TBDGenVisitor::addSymbol(StringRef name, SymbolSource source,
 }
 
 bool TBDGenVisitor::willVisitDecl(Decl *D) {
+  if (Lowering::shouldSkipLowering(D))
+    return false;
+
   // A @_silgen_name("...") function without a body only exists to
   // forward-declare a symbol from another library.
   if (auto AFD = dyn_cast<AbstractFunctionDecl>(D))

--- a/lib/SIL/IR/SILModule.cpp
+++ b/lib/SIL/IR/SILModule.cpp
@@ -955,3 +955,13 @@ bool Lowering::usesObjCAllocator(ClassDecl *theClass) {
   // allocation methods because they may have been overridden.
   return theClass->getObjectModel() == ReferenceCounting::ObjC;
 }
+
+bool Lowering::shouldSkipLowering(Decl *D) {
+  if (D->getASTContext().LangOpts.UnavailableDeclOptimizationMode !=
+      UnavailableDeclOptimization::Complete)
+    return false;
+
+  // Unavailable declarations should be skipped if
+  // -unavailable-decl-optimization=complete is specified.
+  return D->getSemanticUnavailableAttr() != None;
+}

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -770,6 +770,13 @@ bool SILGenModule::hasFunction(SILDeclRef constant) {
   return emittedFunctions.count(constant);
 }
 
+void SILGenModule::visit(Decl *D) {
+  if (Lowering::shouldSkipLowering(D))
+    return;
+
+  ASTVisitor::visit(D);
+}
+
 void SILGenModule::visitFuncDecl(FuncDecl *fd) { emitFunction(fd); }
 
 void SILGenModule::emitFunctionDefinition(SILDeclRef constant, SILFunction *f) {

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -266,6 +266,8 @@ public:
   // Visitors for top-level forms
   //===--------------------------------------------------------------------===//
 
+  void visit(Decl *D);
+
   // These are either not allowed at global scope or don't require
   // code emission.
   void visitImportDecl(ImportDecl *d) {}

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -1085,8 +1085,9 @@ public:
   void emitType() {
     SGM.emitLazyConformancesForType(theType);
 
-    for (Decl *member : theType->getABIMembers())
+    forEachMemberToLower(theType, [&](Decl *member) {
       visit(member);
+    });
 
     // Build a vtable if this is a class.
     if (auto theClass = dyn_cast<ClassDecl>(theType)) {
@@ -1252,9 +1253,10 @@ public:
     // @_objcImplementation extension, but we don't actually need to do any of
     // the stuff that it currently does.
 
-    for (Decl *member : e->getABIMembers())
+    forEachMemberToLower(e, [&](Decl *member) {
       visit(member);
-    
+    });
+
     // If this is a main-interface @_objcImplementation extension and the class
     // has a synthesized destructor, emit it now.
     if (auto cd = dyn_cast_or_null<ClassDecl>(e->getImplementedObjCDecl())) {

--- a/test/IRGen/unavailable_decl_optimization.swift
+++ b/test/IRGen/unavailable_decl_optimization.swift
@@ -1,0 +1,194 @@
+// RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP
+
+// RUN: %target-swift-frontend -parse-as-library -module-name Test -validate-tbd-against-ir=missing -unavailable-decl-optimization=complete %s -emit-ir | %FileCheck %s --check-prefixes=CHECK,CHECK-STRIP
+
+// CHECK-NO-STRIP: s4Test14globalConstantSbvp
+// CHECK-NO-STRIP: s4Test14globalConstantSbvau
+// CHECK-STRIP-NOT: s4Test14globalConstantSbvp
+// CHECK-STRIP-NOT: s4Test14globalConstantSbvau
+@available(*, unavailable)
+public let globalConstant = true
+
+// CHECK-NO-STRIP: s4Test15unavailableFuncyyF
+// CHECK-STRIP-NOT: s4Test15unavailableFuncyyF
+@available(*, unavailable)
+public func unavailableFunc() {}
+
+@available(*, unavailable)
+public struct UnavailableStruct<T> {
+  // CHECK-NO-STRIP: s4Test17UnavailableStructV8propertyxvg
+  // CHECK-NO-STRIP: s4Test17UnavailableStructV8propertyxvs
+  // CHECK-NO-STRIP: s4Test17UnavailableStructV8propertyxvM
+  // CHECK-STRIP-NOT: s4Test17UnavailableStructV8propertyxvg
+  // CHECK-STRIP-NOT: s4Test17UnavailableStructV8propertyxvs
+  // CHECK-STRIP-NOT: s4Test17UnavailableStructV8propertyxvM
+  public var property: T
+
+  // CHECK-NO-STRIP: s4Test17UnavailableStructVyACyxGxcfC
+  // CHECK-NO-STRIP: s4Test17UnavailableStructVMa
+  // CHECK-STRIP-NOT: s4Test17UnavailableStructVyACyxGxcfC
+  // CHECK-STRIP-NOT: s4Test17UnavailableStructVMa
+  public init(_ t: T) {
+    self.property = t
+  }
+
+  // CHECK-NO-STRIP: s4Test17UnavailableStructV6methodyyF
+  // CHECK-STRIP-NOT: s4Test17UnavailableStructV6methodyyF
+  public func method() {}
+}
+
+@available(*, unavailable)
+extension UnavailableStruct {
+  // CHECK-NO-STRIP: s4Test17UnavailableStructV15extensionMethodyyF
+  // CHECK-STRIP-NOT: s4Test17UnavailableStructV15extensionMethodyyF
+  public func extensionMethod() {}
+}
+
+@available(*, unavailable)
+public enum UnavailableEnum {
+  case a, b
+
+  // CHECK-NO-STRIP: s4Test15UnavailableEnumO6methodyyF
+  // CHECK-STRIP-NOT: s4Test15UnavailableEnumO6methodyyF
+  public func method() {}
+
+  // CHECK-NO-STRIP: s4Test15UnavailableEnumO21__derived_enum_equalsySbAC_ACtFZ
+  // CHECK-NO-STRIP: s4Test15UnavailableEnumO4hash4intoys6HasherVz_tF
+  // CHECK-NO-STRIP: s4Test15UnavailableEnumO9hashValueSivg
+  // CHECK-STRIP-NOT: s4Test15UnavailableEnumO21__derived_enum_equalsySbAC_ACtFZ
+  // CHECK-STRIP-NOT: s4Test15UnavailableEnumO4hash4intoys6HasherVz_tF
+  // CHECK-STRIP-NOT: s4Test15UnavailableEnumO9hashValueSivg
+}
+
+@available(*, unavailable)
+public class UnavailableClass<T> {
+  // CHECK-NO-STRIP: s4Test16UnavailableClassC8propertyxvg
+  // CHECK-NO-STRIP: s4Test16UnavailableClassC8propertyxvs
+  // CHECK-NO-STRIP: s4Test16UnavailableClassC8propertyxvM
+  // CHECK-STRIP-NOT: s4Test16UnavailableClassC8propertyxvg
+  // CHECK-STRIP-NOT: s4Test16UnavailableClassC8propertyxvs
+  // CHECK-STRIP-NOT: s4Test16UnavailableClassC8propertyxvM
+  public var property: T
+
+  // CHECK-NO-STRIP: s4Test16UnavailableClassCyACyxGxcfC
+  // CHECK-NO-STRIP: s4Test16UnavailableClassCyACyxGxcfc
+  // CHECK-STRIP-NOT: s4Test16UnavailableClassCyACyxGxcfC
+  // CHECK-STRIP-NOT: s4Test16UnavailableClassCyACyxGxcfc
+  public init(_ t: T) {
+    self.property = t
+  }
+
+  // CHECK-NO-STRIP: s4Test16UnavailableClassCfd
+  // CHECK-NO-STRIP: s4Test16UnavailableClassCfD
+  // CHECK-STRIP-NOT: s4Test16UnavailableClassCfd
+  // CHECK-STRIP-NOT: s4Test16UnavailableClassCfD
+  deinit {}
+}
+
+public struct S<T> {
+  // CHECK-NO-STRIP: s4Test1SV19unavailablePropertyxvg
+  // CHECK-NO-STRIP: s4Test1SV19unavailablePropertyxvs
+  // CHECK-NO-STRIP: s4Test1SV19unavailablePropertyxvM
+  // CHECK-STRIP-NOT: s4Test1SV19unavailablePropertyxvg
+  // CHECK-STRIP-NOT: s4Test1SV19unavailablePropertyxvs
+  // CHECK-STRIP-NOT: s4Test1SV19unavailablePropertyxvM
+  @available(*, unavailable)
+  public var unavailableProperty: T
+
+  // CHECK-NO-STRIP: s4Test1SVyACyxGxcfC
+  // CHECK-STRIP-NOT: s4Test1SVyACyxGxcfC
+  @available(*, unavailable)
+  public init(_ t: T) { fatalError() }
+
+  // CHECK-NO-STRIP: s4Test1SV17unavailableMethodyyF
+  // CHECK-STRIP-NOT: s4Test1SV17unavailableMethodyyF
+  @available(*, unavailable)
+  public func unavailableMethod() {}
+}
+
+@available(*, unavailable)
+extension S {
+  // CHECK-NO-STRIP: s4Test1SV28methodInUnavailableExtensionyyF
+  // CHECK-STRIP-NOT: s4Test1SV28methodInUnavailableExtensionyyF
+  public func methodInUnavailableExtension() {}
+}
+
+public enum E {
+  case a
+
+  @available(*, unavailable)
+  case b
+
+  // CHECK-NO-STRIP: s4Test1EO17unavailableMethodyyF
+  // CHECK-STRIP-NOT: s4Test1EO17unavailableMethodyyF
+  @available(*, unavailable)
+  public func unavailableMethod() {}
+}
+
+public class C<T> {
+  // CHECK-NO-STRIP: s4Test1CC19unavailablePropertyxvg
+  // CHECK-NO-STRIP: s4Test1CC19unavailablePropertyxvs
+  // CHECK-NO-STRIP: s4Test1CC19unavailablePropertyxvM
+  // CHECK-STRIP-NOT: s4Test1CC19unavailablePropertyxvg
+  // CHECK-STRIP-NOT: s4Test1CC19unavailablePropertyxvs
+  // CHECK-STRIP-NOT: s4Test1CC19unavailablePropertyxvM
+  @available(*, unavailable)
+  public var unavailableProperty: T
+
+  // CHECK-NO-STRIP: s4Test1CCyACyxGxcfC
+  // CHECK-NO-STRIP: s4Test1CCyACyxGxcfc
+  // CHECK-STRIP-NOT: s4Test1CCyACyxGxcfC
+  // CHECK-STRIP-NOT: s4Test1CCyACyxGxcfc
+  @available(*, unavailable)
+  public init(_ t: T) { fatalError() }
+
+  // CHECK: s4Test1CCfd
+  // CHECK: s4Test1CCfD
+  deinit {}
+}
+
+public protocol P {
+  func requirement()
+}
+
+@available(*, unavailable)
+extension S: P {
+  // CHECK-NO-STRIP: s4Test1SV11requirementyyF
+  // CHECK-STRIP-NOT: s4Test1SV11requirementyyF
+  public func requirement() {}
+}
+
+// CHECK-NO-STRIP: s4Test29unavailableFuncWithNestedTypeyyF
+// CHECK-STRIP-NOT: s4Test29unavailableFuncWithNestedTypeyyF
+@available(*, unavailable)
+public func unavailableFuncWithNestedType() {
+  struct Nested {
+    // s4Test29unavailableFuncWithNestedTypeyyF0E0L_V6methodyyF
+    public func method() {}
+  }
+}
+
+// MARK: -
+
+// MARK: UnavailableEnum
+
+// CHECK-NO-STRIP: s4Test15UnavailableEnumOwug
+// CHECK-STRIP-NOT: s4Test15UnavailableEnumOwug
+
+// CHECK-NO-STRIP: s4Test15UnavailableEnumOMa
+// CHECK-STRIP-NOT: s4Test15UnavailableEnumOMa
+
+// MARK: UnavailableClass
+
+// CHECK-NO-STRIP: s4Test16UnavailableClassCMa
+// CHECK-STRIP-NOT: s4Test16UnavailableClassCMa
+
+// MARK: E
+
+// CHECK: s4Test1EOwug
+// CHECK: s4Test1EOMa
+
+// MARK: unavailableFuncWithNestedType().Nested
+
+// CHECK-NO-STRIP: s4Test29unavailableFuncWithNestedTypeyyF0E0L_VMa
+// CHECK-STRIP-NOT: s4Test29unavailableFuncWithNestedTypeyyF0E0L_VMa

--- a/test/SILGen/unavailable_decl_optimization.swift
+++ b/test/SILGen/unavailable_decl_optimization.swift
@@ -6,11 +6,10 @@
 // CHECK-NO-STRIP: s4Test14globalConstantSbvp
 // CHECK-NO-STRIP: s4Test14globalConstant_WZ
 // CHECK-NO-STRIP: s4Test14globalConstantSbvau
-// FIXME: global var isn't stripped
-// HECK-STRIP-NOT: s4Test14globalConstant_Wz
-// HECK-STRIP-NOT: s4Test14globalConstantSbvp
-// HECK-STRIP-NOT: s4Test14globalConstant_WZ
-// HECK-STRIP-NOT: s4Test14globalConstantSbvau
+// CHECK-STRIP-NOT: s4Test14globalConstant_Wz
+// CHECK-STRIP-NOT: s4Test14globalConstantSbvp
+// CHECK-STRIP-NOT: s4Test14globalConstant_WZ
+// CHECK-STRIP-NOT: s4Test14globalConstantSbvau
 @available(*, unavailable)
 public let globalConstant = true
 

--- a/test/SILGen/unavailable_decl_optimization.swift
+++ b/test/SILGen/unavailable_decl_optimization.swift
@@ -1,0 +1,228 @@
+// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP
+// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=none | %FileCheck %s --check-prefixes=CHECK,CHECK-NO-STRIP
+// RUN: %target-swift-emit-silgen -module-name Test -parse-as-library %s -verify -unavailable-decl-optimization=complete | %FileCheck %s --check-prefixes=CHECK,CHECK-STRIP
+
+// CHECK-NO-STRIP: s4Test14globalConstant_Wz
+// CHECK-NO-STRIP: s4Test14globalConstantSbvp
+// CHECK-NO-STRIP: s4Test14globalConstant_WZ
+// CHECK-NO-STRIP: s4Test14globalConstantSbvau
+// FIXME: global var isn't stripped
+// HECK-STRIP-NOT: s4Test14globalConstant_Wz
+// HECK-STRIP-NOT: s4Test14globalConstantSbvp
+// HECK-STRIP-NOT: s4Test14globalConstant_WZ
+// HECK-STRIP-NOT: s4Test14globalConstantSbvau
+@available(*, unavailable)
+public let globalConstant = true
+
+// CHECK-NO-STRIP: s4Test15unavailableFuncyyF
+// CHECK-STRIP-NOT: s4Test15unavailableFuncyyF
+@available(*, unavailable)
+public func unavailableFunc() {}
+
+@available(*, unavailable)
+public struct UnavailableStruct<T> {
+  // CHECK-NO-STRIP: s4Test17UnavailableStructV8propertyxvg
+  // CHECK-NO-STRIP: s4Test17UnavailableStructV8propertyxvs
+  // CHECK-NO-STRIP: s4Test17UnavailableStructV8propertyxvM
+  // CHECK-STRIP-NOT: s4Test17UnavailableStructV8propertyxvg
+  // CHECK-STRIP-NOT: s4Test17UnavailableStructV8propertyxvs
+  // CHECK-STRIP-NOT: s4Test17UnavailableStructV8propertyxvM
+  public var property: T
+
+  // CHECK-NO-STRIP: s4Test17UnavailableStructVyACyxGxcfC
+  // CHECK-STRIP-NOT: s4Test17UnavailableStructVyACyxGxcfC
+  public init(_ t: T) {
+    self.property = t
+  }
+
+  // CHECK-NO-STRIP: s4Test17UnavailableStructV6methodyyF
+  // CHECK-STRIP-NOT: s4Test17UnavailableStructV6methodyyF
+  public func method() {}
+}
+
+@available(*, unavailable)
+extension UnavailableStruct {
+  // CHECK-NO-STRIP: s4Test17UnavailableStructV15extensionMethodyyF
+  // CHECK-STRIP-NOT: s4Test17UnavailableStructV15extensionMethodyyF
+  public func extensionMethod() {}
+}
+
+@available(*, unavailable)
+public enum UnavailableEnum {
+  case a, b
+
+  // CHECK-NO-STRIP: s4Test15UnavailableEnumO6methodyyF
+  // CHECK-STRIP-NOT: s4Test15UnavailableEnumO6methodyyF
+  public func method() {}
+}
+
+@available(*, unavailable)
+public class UnavailableClass<T> {
+  // CHECK-NO-STRIP: s4Test16UnavailableClassC8propertyxvg
+  // CHECK-NO-STRIP: s4Test16UnavailableClassC8propertyxvs
+  // CHECK-NO-STRIP: s4Test16UnavailableClassC8propertyxvM
+  // CHECK-STRIP-NOT: s4Test16UnavailableClassC8propertyxvg
+  // CHECK-STRIP-NOT: s4Test16UnavailableClassC8propertyxvs
+  // CHECK-STRIP-NOT: s4Test16UnavailableClassC8propertyxvM
+  public var property: T
+
+  // CHECK-NO-STRIP: s4Test16UnavailableClassCyACyxGxcfC
+  // CHECK-NO-STRIP: s4Test16UnavailableClassCyACyxGxcfc
+  // CHECK-STRIP-NOT: s4Test16UnavailableClassCyACyxGxcfC
+  // CHECK-STRIP-NOT: s4Test16UnavailableClassCyACyxGxcfc
+  public init(_ t: T) {
+    self.property = t
+  }
+
+  // CHECK-NO-STRIP: s4Test16UnavailableClassCfd
+  // CHECK-NO-STRIP: s4Test16UnavailableClassCfD
+  // CHECK-STRIP-NOT: s4Test16UnavailableClassCfd
+  // CHECK-STRIP-NOT: s4Test16UnavailableClassCfD
+  deinit {}
+}
+
+public struct S<T> {
+  // CHECK-NO-STRIP: s4Test1SV19unavailablePropertyxvg
+  // CHECK-NO-STRIP: s4Test1SV19unavailablePropertyxvs
+  // CHECK-NO-STRIP: s4Test1SV19unavailablePropertyxvM
+  // CHECK-STRIP-NOT: s4Test1SV19unavailablePropertyxvg
+  // CHECK-STRIP-NOT: s4Test1SV19unavailablePropertyxvs
+  // CHECK-STRIP-NOT: s4Test1SV19unavailablePropertyxvM
+  @available(*, unavailable)
+  public var unavailableProperty: T
+
+  // CHECK-NO-STRIP: s4Test1SVyACyxGxcfC
+  // CHECK-STRIP-NOT: s4Test1SVyACyxGxcfC
+  @available(*, unavailable)
+  public init(_ t: T) {}
+
+  // CHECK-NO-STRIP: s4Test1SV17unavailableMethodyyF
+  // CHECK-STRIP-NOT: s4Test1SV17unavailableMethodyyF
+  @available(*, unavailable)
+  public func unavailableMethod() {}
+}
+
+@available(*, unavailable)
+extension S {
+  // CHECK-NO-STRIP: s4Test1SV28methodInUnavailableExtensionyyF
+  // CHECK-STRIP-NOT: s4Test1SV28methodInUnavailableExtensionyyF
+  public func methodInUnavailableExtension() {}
+}
+
+public enum E {
+  case a
+
+  @available(*, unavailable)
+  case b
+
+  // CHECK-NO-STRIP: s4Test1EO17unavailableMethodyyF
+  // CHECK-STRIP-NOT: s4Test1EO17unavailableMethodyyF
+  @available(*, unavailable)
+  public func unavailableMethod() {}
+}
+
+public class C<T> {
+  // CHECK-NO-STRIP: s4Test1CC19unavailablePropertyxvg
+  // CHECK-NO-STRIP: s4Test1CC19unavailablePropertyxvs
+  // CHECK-NO-STRIP: s4Test1CC19unavailablePropertyxvM
+  // CHECK-STRIP-NOT: s4Test1CC19unavailablePropertyxvg
+  // CHECK-STRIP-NOT: s4Test1CC19unavailablePropertyxvs
+  // CHECK-STRIP-NOT: s4Test1CC19unavailablePropertyxvM
+  @available(*, unavailable)
+  public var unavailableProperty: T
+
+  // CHECK-NO-STRIP: s4Test1CCyACyxGxcfC
+  // CHECK-NO-STRIP: s4Test1CCyACyxGxcfc
+  // CHECK-STRIP-NOT: s4Test1CCyACyxGxcfC
+  // CHECK-STRIP-NOT: s4Test1CCyACyxGxcfc
+  @available(*, unavailable)
+  public init(_ t: T) {}
+
+  // CHECK: s4Test1CCfd
+  // CHECK: s4Test1CCfD
+  deinit {}
+}
+
+public protocol P {
+  func requirement()
+}
+
+@available(*, unavailable)
+extension S: P {
+  // CHECK-NO-STRIP: s4Test1SV11requirementyyF
+  // CHECK-STRIP-NOT: s4Test1SV11requirementyyF
+  public func requirement() {}
+}
+
+// CHECK-NO-STRIP: s4Test29unavailableFuncWithNestedTypeyyF
+// CHECK-STRIP-NOT: s4Test29unavailableFuncWithNestedTypeyyF
+@available(*, unavailable)
+public func unavailableFuncWithNestedType() {
+  // NOTE: Check lines for this decl are below since local types are emitted
+  // after top level decls.
+  struct Nested {
+    // s4Test29unavailableFuncWithNestedTypeyyF0E0L_V6methodyyF
+    public func method() {}
+  }
+}
+
+
+// MARK: Local types SIL
+
+// CHECK-NO-STRIP: s4Test29unavailableFuncWithNestedTypeyyF0E0L_V6methodyyF
+// CHECK-STRIP-NOT: s4Test29unavailableFuncWithNestedTypeyyF0E0L_V6methodyyF
+
+// MARK: SIL vtables
+
+// CHECK-NO-STRIP: sil_vtable [serialized] UnavailableClass
+// CHECK-STRIP-NOT: sil_vtable [serialized] UnavailableClass
+
+// CHECK-NO-STRIP:      sil_vtable [serialized] C {
+// CHECK-NO-STRIP-NEXT:   #C.unavailableProperty!getter:
+// CHECK-NO-STRIP-NEXT:   #C.unavailableProperty!setter:
+// CHECK-NO-STRIP-NEXT:   #C.unavailableProperty!modify:
+// CHECK-NO-STRIP-NEXT:   #C.init!allocator:
+// CHECK-NO-STRIP-NEXT:   #C.deinit!deallocator:
+// CHECK-NO-STRIP-NEXT: }
+
+// CHECK-STRIP:     sil_vtable [serialized] C {
+// CHECK-STRIP-NOT:   #C.unavailableProperty!getter:
+// CHECK-STRIP-NOT:   #C.unavailableProperty!setter:
+// CHECK-STRIP-NOT:   #C.unavailableProperty!modify:
+// CHECK-STRIP-NOT:   #C.init!allocator:
+// CHECK-STRIP:       #C.deinit!deallocator:
+// CHECK-STRIP:     }
+
+// MARK: SIL witness tables
+
+// CHECK-NO-STRIP: sil_witness_table [serialized] UnavailableEnum: Equatable module Test
+// CHECK-STRIP-NOT: sil_witness_table [serialized] UnavailableEnum: Equatable module Test
+
+// CHECK-NO-STRIP: sil_witness_table [serialized] UnavailableEnum: Hashable module Test
+// CHECK-STRIP-NOT: sil_witness_table [serialized] UnavailableEnum: Hashable module Test
+
+// CHECK: sil_witness_table [serialized] E: Equatable module Test
+
+// CHECK: sil_witness_table [serialized] E: Hashable module Test
+
+// CHECK-NO-STRIP: sil_witness_table [serialized] <T> S<T>: P module Test
+// CHECK-STRIP-NOT: sil_witness_table [serialized] <T> S<T>: P module Test
+
+// MARK: SIL properties
+
+// CHECK-NO-STRIP: sil_property #UnavailableStruct.property<τ_0_0> ()
+// CHECK-STRIP-NOT: sil_property #UnavailableStruct.property<τ_0_0> ()
+
+// CHECK-NO-STRIP: sil_property #UnavailableEnum.hashValue ()
+// CHECK-STRIP-NOT: sil_property #UnavailableEnum.hashValue ()
+
+// CHECK-NO-STRIP: sil_property #UnavailableClass.property<τ_0_0> ()
+// CHECK-STRIP-NOT: sil_property #UnavailableClass.property<τ_0_0> ()
+
+// CHECK-NO-STRIP: sil_property #S.unavailableProperty<τ_0_0> ()
+// CHECK-STRIP-NOT: sil_property #S.unavailableProperty<τ_0_0> ()
+
+// CHECK: sil_property #E.hashValue ()
+
+// CHECK-NO-STRIP: sil_property #C.unavailableProperty<τ_0_0> ()
+// CHECK-STRIP-NOT: sil_property #C.unavailableProperty<τ_0_0> ()


### PR DESCRIPTION
Introduce the `-unavailable-decl-optimization` frontend flag which can be used to reduce the size of a compiled binary by removing machine code related to declarations that are marked unavailable with an `@available` attribute. Unavailable code is meant to be provably unreachable at runtime for a specific execution context and therefore including machine code for these declarations is wasteful.

In this iteration, the flag supports two modes:
- `none`: Does not remove any code related to unavailable declarations. This is the default.
- `complete`: Avoids generating any machine code for unavailable declarations. This will be the most aggressive optimization available.

The plan is to expand the available modes in the future with at least one more option, `stub`, which will cause unavailable functions to be emitted as stubs containing just `fatalError()`. This option will be needed by owners of resilient libraries to preserve ABI compatibility since existing clients may link against the symbols for unavailable declarations, even if they never execute them.

Resolves rdar://106674022