### PR TITLE
[5.9] Warns if a module loaded is a package module but loaded from SDK

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1007,10 +1007,15 @@ ERROR(module_not_testable,Fatal,
 ERROR(module_not_compiled_for_private_import,none,
       "module %0 was not compiled for private import", (Identifier))
 
-ERROR(in_package_module_not_compiled_from_source,Fatal,
-      "module %0 is in package '%1' but was built from interface '%2'; "
-      "modules of the same package can only be loaded if built from source",
+ERROR(in_package_module_not_compiled_from_source,none,
+      "module %0 is in package '%1' but was built from interface; "
+      "modules of the same package can only be loaded if built from source: %2",
       (Identifier, StringRef, StringRef))
+
+WARNING(in_package_module_not_compiled_locally,none,
+        "module %0 is in package %1 but was loaded from SDK; "
+        "modules of the same package should be built locally from source only: %2",
+        (Identifier, Identifier, StringRef))
 
 ERROR(import_restriction_conflict,none,
       "module %0 cannot be both "

--- a/lib/Sema/TypeCheckDeclPrimary.cpp
+++ b/lib/Sema/TypeCheckDeclPrimary.cpp
@@ -1960,9 +1960,25 @@ public:
     // diagnostics.
     (void)ID->getDecls();
 
+    auto target = ID->getModule();
+    if (!getASTContext().LangOpts.PackageName.empty() &&
+        getASTContext().LangOpts.PackageName == target->getPackageName().str() &&
+        !target->isNonSwiftModule() && // target is a Swift module
+        target->isNonUserModule()) { // target module is in distributed SDK
+      // If reached here, a binary module (.swiftmodule) instead of interface of the
+      // target was loaded for the main module, where both belong to the same package;
+      // this is an expected behavior, but it should have been loaded from the local
+      // build directory, not from distributed SDK. In such case, we show a warning.
+      auto &diags = ID->getASTContext().Diags;
+      diags.diagnose(ID,
+                     diag::in_package_module_not_compiled_locally,
+                     target->getBaseIdentifier(),
+                     target->getPackageName(),
+                     target->getModuleFilename());
+    }
+
     // Report the public import of a private module.
     if (ID->getASTContext().LangOpts.LibraryLevel == LibraryLevel::API) {
-      auto target = ID->getModule();
       auto importer = ID->getModuleContext();
       if (target &&
           !ID->getAttrs().hasAttribute<ImplementationOnlyAttr>() &&

--- a/test/Sema/import_package_module_from_sdk.swift
+++ b/test/Sema/import_package_module_from_sdk.swift
@@ -1,0 +1,41 @@
+// RUN: %empty-directory(%t)
+// RUN: split-file %s %t
+
+// --- Prepare SDK (.swiftmodule).
+// RUN: %empty-directory(%t/SDK)
+// RUN: mkdir -p %t/SDK/Frameworks/LibInSDK.framework/Modules/LibInSDK.swiftmodule
+// RUN: %target-swift-frontend \
+// RUN:     -emit-module \
+// RUN:     -module-name LibInSDK \
+// RUN:     -package-name libPkg \
+// RUN:     -o %t/SDK/Frameworks/LibInSDK.framework/Modules/LibInSDK.swiftmodule/%module-target-triple.swiftmodule \
+// RUN:     -swift-version 5 \
+// RUN:     %t/Lib.swift
+
+// RUN: test -f %t/SDK/Frameworks/LibInSDK.framework/Modules/LibInSDK.swiftmodule/%module-target-triple.swiftmodule
+
+// RUN: %target-swift-frontend -typecheck -verify -verify-ignore-unknown %t/Client1.swift -package-name libPkg -sdk %t/SDK -I %t -I %t/SDK/Frameworks/LibInSDK.framework/Modules
+
+// RUN: %target-swift-frontend -module-name LibLocal -emit-module -emit-module-path %t/LibLocal.swiftmodule -parse-as-library %t/Lib.swift -package-name libPkg
+// RUN: test -f %t/LibLocal.swiftmodule
+
+// RUN: %target-swift-frontend -typecheck -verify %t/Client2.swift -package-name libPkg -I %t
+
+//--- Lib.swift
+package func log(level: Int) {}
+
+//--- Client1.swift
+import LibInSDK // expected-warning {{module 'LibInSDK' is in package 'libPkg' but was loaded from SDK; modules of the same package should be built locally from source only}}
+
+func someFunc() {
+  log(level: 1)
+}
+
+//--- Client2.swift
+import LibLocal
+
+func someFunc() {
+  log(level: 1)
+}
+
+

--- a/test/Serialization/load_package_module.swift
+++ b/test/Serialization/load_package_module.swift
@@ -9,7 +9,7 @@
 
 // RUN: not %target-swift-frontend -module-name ClientInSamePkg %t/ClientLoadInterfaceModule.swift -emit-module -emit-module-path %t/ClientInSamePkg.swiftmodule -package-name mypkg -I %t 2> %t/resultA.output
 // RUN: %FileCheck %s -check-prefix CHECK-A < %t/resultA.output
-// CHECK-A: error: module 'LibFromInterface' is in package 'mypkg' but was built from interface '{{.*}}LibFromInterface.swiftinterface'; modules of the same package can only be loaded if built from source
+// CHECK-A: error: module 'LibFromInterface' is in package 'mypkg' but was built from interface; modules of the same package can only be loaded if built from source: {{.*}}LibFromInterface.swiftinterface
 
 // RUN: not %target-swift-frontend -module-name ClientInDiffPkg %t/ClientLoadInterfaceModule.swift -emit-module -emit-module-path %t/ClientInDiffPkg.swiftmodule -package-name otherPkg -I %t 2> %t/resultB.output
 // RUN: %FileCheck %s -check-prefix CHECK-B < %t/resultB.output


### PR DESCRIPTION
* Warns if a module loaded is a package module but not locally built.
* Update a related diagnostic
Resolves rdar://107074380