### PR TITLE
[AutoDiff] Fix use after free when pullback is used multiple times

### DIFF
--- a/include/swift/SILOptimizer/Differentiation/LinearMapInfo.h
+++ b/include/swift/SILOptimizer/Differentiation/LinearMapInfo.h
@@ -86,14 +86,15 @@ private:
   llvm::DenseMap<std::pair<SILBasicBlock *, SILBasicBlock *>, EnumElementDecl *>
       branchingTraceEnumCases;
 
-  /// Blocks in a loop.
-  llvm::SmallSetVector<SILBasicBlock *, 4> blocksInLoop;
-
   /// A synthesized file unit.
   SynthesizedFileUnit &synthesizedFile;
 
   /// A type converter, used to compute struct/enum SIL types.
   Lowering::TypeConverter &typeConverter;
+
+  /// True, if a heap-allocated context is required. For example, when there are
+  /// any loops
+  bool heapAllocatedContext = false;
 
 private:
   /// Remaps the given type into the derivative function's context.
@@ -193,12 +194,8 @@ public:
     return getLinearMapTupleType(ai->getParentBlock())->getElement(idx).getType();
   }
 
-  bool hasLoops() const {
-    return !blocksInLoop.empty();
-  }
-
-  ArrayRef<SILBasicBlock *> getBlocksInLoop() const {
-    return blocksInLoop.getArrayRef();
+  bool hasHeapAllocatedContext() const {
+    return heapAllocatedContext;
   }
 };
 

--- a/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
+++ b/lib/SILOptimizer/Differentiation/LinearMapInfo.cpp
@@ -138,11 +138,9 @@ void LinearMapInfo::populateBranchingTraceDecl(SILBasicBlock *originalBB,
     // indirectly referenced in memory owned by the context object. The payload
     // is just a raw pointer.
     if (loopInfo->getLoopFor(predBB)) {
-      blocksInLoop.insert(predBB);
+      heapAllocatedContext = true;
       decl->setInterfaceType(astCtx.TheRawPointerType);
-    }
-    // Otherwise the payload is the linear map tuple.
-    else {
+    } else { // Otherwise the payload is the linear map tuple.
       auto linearMapStructTy = getLinearMapTupleType(predBB)->getCanonicalType();
       decl->setInterfaceType(
           linearMapStructTy->hasArchetype()

--- a/lib/SILOptimizer/Differentiation/VJPCloner.cpp
+++ b/lib/SILOptimizer/Differentiation/VJPCloner.cpp
@@ -110,7 +110,7 @@ class VJPCloner::Implementation final
 
   /// Initializes a context object if needed.
   void emitLinearMapContextInitializationIfNeeded() {
-    if (!pullbackInfo.hasLoops())
+    if (!pullbackInfo.hasHeapAllocatedContext())
       return;
  
     // Get linear map struct size.
@@ -937,7 +937,7 @@ SILFunction *VJPCloner::Implementation::createEmptyPullback() {
     pbParams.push_back(inoutParamTanParam);
   }
 
-  if (pullbackInfo.hasLoops()) {
+  if (pullbackInfo.hasHeapAllocatedContext()) {
     // Accept a `AutoDiffLinarMapContext` heap object if there are loops.
     pbParams.push_back({
       getASTContext().TheNativeObjectType,

--- a/test/AutoDiff/validation-test/issue-64257-use-after-free.swift
+++ b/test/AutoDiff/validation-test/issue-64257-use-after-free.swift
@@ -1,0 +1,50 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import _Differentiation
+public func simWithPullback(params: MinParams) -> (value: Output, pullback: (Output.TangentVector) -> (MinParams.TangentVector)){
+    let simulationValueAndPullback = valueWithPullback(at: params, of: run)
+    return (value: simulationValueAndPullback.value, pullback: simulationValueAndPullback.pullback)
+}
+
+@differentiable(reverse)
+public func run(params: MinParams) -> Output {
+    for t in 0 ... 1 {
+    }
+
+    let res = MiniLoop(other: params._twoDArray).results
+    return Output(results: res)
+}
+
+struct MiniLoop: Differentiable {
+    var results: Float
+    var twoDArray: Float
+  
+    @differentiable(reverse)
+    init(results: Float = 146, other: Float = 123) {self.results = results; self.twoDArray = other}
+}
+
+public struct Output: Differentiable {
+    public var results: Float
+    @differentiable(reverse)
+    public init(results: Float) {self.results = results}
+}
+
+public struct MinParams: Differentiable {
+    public var _twoDArray: Float
+    public init(foo: Float = 42) { _twoDArray = foo }
+}
+
+func test() {
+    let valueAndPullback = simWithPullback(params: MinParams())
+    let output = valueAndPullback.value
+    let resultOnes = Float(1.0)
+    var grad = valueAndPullback.pullback(Output.TangentVector(results: resultOnes))
+    print(grad)
+    grad = valueAndPullback.pullback(Output.TangentVector(results: resultOnes))
+    print(grad)
+    grad = valueAndPullback.pullback(Output.TangentVector(results: resultOnes))
+    print(grad)
+}
+
+test()


### PR DESCRIPTION
Linear maps are captured in vjp routine via callee-guaranteed partial apply and are passed as `@owned` references to the enclosing pullback that finally consumes them. Necessary retains are inserted by a partial apply forwarder.

However, this is not the case when the function being differentiated contains loops as heap-allocated context is used and bare pointer is captured by the pullback partial apply. As a result, partial apply forwarder does not retain the linear maps that are owned by a heap-allocated context, however, they are still treated as `@owned` references and therefore are released in the pullback after the first call. As a result, subsequent pullback calls release linear maps and we'd end with possible use-after-free.

Ensure we retain values when we load values from the context.

Reproducible only when:
  - Loops (so, heap-allocated context)
  - Pullbacks of thick functions (so context is non-zero)
  - Multiple pullback calls

Some cleanup while there

Fixes #64257