### PR TITLE
[5.9][CSSimplify] Account for the fact that variadic generic parameters co…

### DIFF
--- a/test/Constraints/pack-expansion-expressions.swift
+++ b/test/Constraints/pack-expansion-expressions.swift
@@ -271,3 +271,15 @@ func test_pack_expansions_with_closures() {
     takesVariadicFunction { y, z in fn(y, z) } // Ok
   }
 }
+
+// rdar://107151854 - crash on invalid due to specialized pack expansion
+func test_pack_expansion_specialization() {
+  struct Data<each T> {
+    init(_: repeat each T) {} // expected-note {{'init(_:)' declared here}}
+  }
+
+  _ = Data<Int>() // expected-error {{missing argument for parameter #1 in call}}
+  _ = Data<Int>(0) // Ok
+  _ = Data<Int, String>(42, "") // Ok
+  _ = Data<Int>(42, "") // expected-error {{extra argument in call}}
+}


### PR DESCRIPTION
…uld be specialized

Cherry-pick of https://github.com/apple/swift/pull/64601

---

If generic parameter comes from a variadic type declaration it's possible 
that it got specialized early and is no longer represented by a pack expansion
type. For example, consider expression - `Test<Int>(42)` where `Test<each T>`
and the initializer is declared as `init(_: repeat each T)`. Although declaration
based information reports parameter at index 0 as variadic generic the call site
specializes it to `Int`.

Resolves: rdar://107151854
(cherry picked from commit 65cfef655542184996b6d8bbec44941b63a48546)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/main/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
