### PR TITLE
[TypeLowering] NFC: Fix lexicality check for packs.

### DIFF
--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -544,6 +544,17 @@ static CanType getCanPackElementType(CanType type, unsigned index) {
   return cast<PackType>(type).getElementType(index);
 }
 
+static CanType getCanSILPackElementType(CanType type, unsigned index) {
+  return cast<SILPackType>(type).getElementType(index);
+}
+
+static CanType getAnyCanPackElementType(CanType type, unsigned index) {
+  if (isa<PackType>(type)) {
+    return getCanPackElementType(type, index);
+  }
+  return getCanSILPackElementType(type, index);
+}
+
 AbstractionPattern
 AbstractionPattern::getPackElementType(unsigned index) const {
   switch (getKind()) {
@@ -573,7 +584,7 @@ AbstractionPattern::getPackElementType(unsigned index) const {
       return AbstractionPattern::getOpaque();
     return AbstractionPattern(getGenericSubstitutions(),
                               getGenericSignature(),
-                              getCanPackElementType(getType(), index)); 
+                              getAnyCanPackElementType(getType(), index)); 
   }
   llvm_unreachable("bad kind");
 }


### PR DESCRIPTION
In asserts builds, the lexicality of packs is verified via an alternative code-path that walks into aggregates.  That walk needs to proceed through packs.

rdar://107283101
