### PR TITLE
5.9: [TypeLowering] NFC: Fix lexicality check for packs.

### DIFF
--- a/lib/SIL/IR/AbstractionPattern.cpp
+++ b/lib/SIL/IR/AbstractionPattern.cpp
@@ -554,6 +554,17 @@ static CanType getCanPackElementType(CanType type, unsigned index) {
   return cast<PackType>(type).getElementType(index);
 }
 
+static CanType getCanSILPackElementType(CanType type, unsigned index) {
+  return cast<SILPackType>(type).getElementType(index);
+}
+
+static CanType getAnyCanPackElementType(CanType type, unsigned index) {
+  if (isa<PackType>(type)) {
+    return getCanPackElementType(type, index);
+  }
+  return getCanSILPackElementType(type, index);
+}
+
 AbstractionPattern
 AbstractionPattern::getPackElementType(unsigned index) const {
   switch (getKind()) {
@@ -583,7 +594,7 @@ AbstractionPattern::getPackElementType(unsigned index) const {
       return AbstractionPattern::getOpaque();
     return AbstractionPattern(getGenericSubstitutions(),
                               getGenericSignature(),
-                              getCanPackElementType(getType(), index)); 
+                              getAnyCanPackElementType(getType(), index)); 
   }
   llvm_unreachable("bad kind");
 }

--- a/lib/SIL/IR/TypeLowering.cpp
+++ b/lib/SIL/IR/TypeLowering.cpp
@@ -2733,7 +2733,7 @@ bool TypeConverter::visitAggregateLeaves(
     return {ty->getCanonicalType(), origTy, field, index};
   };
   auto isAggregate = [](Type ty) {
-    return ty->is<TupleType>() || ty->getEnumOrBoundGenericEnum() ||
+    return ty->is<SILPackType>() || ty->is<TupleType>() || ty->getEnumOrBoundGenericEnum() ||
            ty->getStructOrBoundGenericStruct();
   };
   insertIntoWorklist(substType, origType, nullptr, llvm::None);
@@ -2744,7 +2744,17 @@ bool TypeConverter::visitAggregateLeaves(
     Optional<unsigned> index;
     std::tie(ty, origTy, field, index) = popFromWorklist();
     if (isAggregate(ty) && !isLeafAggregate(ty, origTy, field, index)) {
-      if (auto tupleTy = ty->getAs<TupleType>()) {
+      if (auto packTy = ty->getAs<SILPackType>()) {
+        for (auto packIndex : indices(packTy->getElementTypes())) {
+          auto origElementTy = origTy.getPackElementType(packIndex);
+          auto substElementTy =
+              packTy->getElementType(packIndex)->getCanonicalType();
+          substElementTy =
+              computeLoweredRValueType(context, origElementTy, substElementTy);
+          insertIntoWorklist(substElementTy, origElementTy, nullptr,
+                             packIndex);
+        }
+      } else if (auto tupleTy = ty->getAs<TupleType>()) {
         for (unsigned tupleIndex = 0, num = tupleTy->getNumElements();
              tupleIndex < num; ++tupleIndex) {
           auto origElementTy = origTy.getTupleElementType(tupleIndex);
@@ -2822,9 +2832,9 @@ void TypeConverter::verifyLowering(const TypeLowering &lowering,
           // The field's type is an aggregate.  Treat it as a leaf if it
           // has a lifetime annotation.
 
-          // If it's a field of a tuple or the top-level type, there's no value
-          // decl on which to look for an attribute.  It's a leaf iff the type
-          // has a lifetime annotation.
+          // If it's a field of a tuple, pack or the top-level type, there's no
+          // value decl on which to look for an attribute.  It's a leaf iff the
+          // type has a lifetime annotation.
           if (index || !field)
             return getLifetimeAnnotation(ty).isSome();
 


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/64649 to release/5.9.

In asserts builds, the lexicality of packs is verified via an alternative code-path that walks into aggregates.  That walk needs to proceed through packs.

rdar://107283101
