### PR TITLE
[NFC] Renamed DestroyAddrHoisting.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -59,10 +59,10 @@ enum class CopyPropagationOption : uint8_t {
 };
 
 enum class DestroyHoistingOption : uint8_t {
-  // Do not run SSADestroyHoisting.
+  // Do not run DestroyAddrHoisting.
   Off = 0,
 
-  // Run SSADestroyHoisting pass after AllocBoxToStack in the function passes.
+  // Run DestroyAddrHoisting pass after AllocBoxToStack in the function passes.
   On = 1
 };
 
@@ -98,7 +98,7 @@ public:
   /// When this is 'On' the pipeline has default behavior.
   CopyPropagationOption CopyPropagation = CopyPropagationOption::On;
 
-  /// Whether to run the SSADestroyHoisting pass.
+  /// Whether to run the DestroyAddrHoisting pass.
   ///
   /// When this 'On' the pipeline has the default behavior.
   DestroyHoistingOption DestroyHoisting = DestroyHoistingOption::On;

--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -182,7 +182,7 @@ PASS(DefiniteInitialization, "definite-init",
      "Definite Initialization for Diagnostics")
 PASS(DestroyHoisting, "destroy-hoisting",
      "Hoisting of value destroys")
-PASS(SSADestroyHoisting, "ssa-destroy-hoisting",
+PASS(DestroyAddrHoisting, "destroy-addr-hoisting",
      "Hoist destroy_addr for uniquely identified values")
 PASS(Devirtualizer, "devirtualizer",
      "Indirect Call Devirtualization")

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -382,7 +382,7 @@ void addFunctionPasses(SILPassPipelinePlan &P,
   P.addAllocBoxToStack();
 
   if (P.getOptions().DestroyHoisting == DestroyHoistingOption::On) {
-    P.addSSADestroyHoisting();
+    P.addDestroyAddrHoisting();
   }
 
   // Propagate copies through stack locations.  Should run after

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -33,7 +33,7 @@ target_sources(swiftSILOptimizer PRIVATE
   SILLowerAggregateInstrs.cpp
   SILMem2Reg.cpp
   SILSROA.cpp
-  SSADestroyHoisting.cpp
+  DestroyAddrHoisting.cpp
   SimplifyCFG.cpp
   Sink.cpp
   SpeculativeDevirtualizer.cpp

--- a/test/SILOptimizer/disable-copy-propagation-frontend-flag.swift
+++ b/test/SILOptimizer/disable-copy-propagation-frontend-flag.swift
@@ -74,30 +74,30 @@
 // RUN: 2>&1 | %FileCheck -check-prefix CHECK-CPON-DHON %s
 
 // CHECK-CPUNSPEC-DHUNSPEC: copy-propagation
-// CHECK-CPUNSPEC-DHUNSPEC: ssa-destroy-hoisting
+// CHECK-CPUNSPEC-DHUNSPEC: destroy-addr-hoisting
 
 // CHECK-CPUNSPEC-DHOFF: copy-propagation
-// CHECK-CPUNSPEC-DHOFF-NOT: ssa-destroy-hoisting
+// CHECK-CPUNSPEC-DHOFF-NOT: destroy-addr-hoisting
 
 // CHECK-CPUNSPEC-DHON: copy-propagation
-// CHECK-CPUNSPEC-DHON: ssa-destroy-hoisting
+// CHECK-CPUNSPEC-DHON: destroy-addr-hoisting
 
 // CHECK-CPOFF-DHUNSPEC-NOT: copy-propagation
-// CHECK-CPOFF-DHUNSPEC-NOT: ssa-destroy-hoisting
+// CHECK-CPOFF-DHUNSPEC-NOT: destroy-addr-hoisting
 
 // CHECK-CPOFF-DHOFF-NOT: copy-propagation
-// CHECK-CPOFF-DHOFF-NOT: ssa-destroy-hoisting
+// CHECK-CPOFF-DHOFF-NOT: destroy-addr-hoisting
 
 // CHECK-CPOFF-DHON-NOT: copy-propagation
-// CHECK-CPOFF-DHON: ssa-destroy-hoisting
+// CHECK-CPOFF-DHON: destroy-addr-hoisting
 
 // CHECK-CPON-DHUNSPEC: copy-propagation
-// CHECK-CPON-DHUNSPEC: ssa-destroy-hoisting
+// CHECK-CPON-DHUNSPEC: destroy-addr-hoisting
 
 // CHECK-CPON-DHOFF: copy-propagation
-// CHECK-CPON-DHOFF-NOT: ssa-destroy-hoisting
+// CHECK-CPON-DHOFF-NOT: destroy-addr-hoisting
 
 // CHECK-CPON-DHON: copy-propagation
-// CHECK-CPON-DHON: ssa-destroy-hoisting
+// CHECK-CPON-DHON: destroy-addr-hoisting
 
 func foo() {}

--- a/test/SILOptimizer/hoist_destroy_addr.sil
+++ b/test/SILOptimizer/hoist_destroy_addr.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -opt-mode=none  -enable-sil-verify-all %s -compute-side-effects -ssa-destroy-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKDEB --check-prefix=CHECK-DEB
-// RUN: %target-sil-opt -opt-mode=speed -enable-sil-verify-all %s -compute-side-effects -ssa-destroy-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKOPT --check-prefix=CHECK-OPT
+// RUN: %target-sil-opt -opt-mode=none  -enable-sil-verify-all %s -compute-side-effects -destroy-addr-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKDEB --check-prefix=CHECK-DEB
+// RUN: %target-sil-opt -opt-mode=speed -enable-sil-verify-all %s -compute-side-effects -destroy-addr-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKOPT --check-prefix=CHECK-OPT
 //
 // TODO: migrate the remaining tests from destroy_hoisting.sil.
 

--- a/test/SILOptimizer/hoist_destroy_addr_loop.sil
+++ b/test/SILOptimizer/hoist_destroy_addr_loop.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -opt-mode=none  -enable-sil-verify-all %s -ssa-destroy-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKDEB
-// RUN: %target-sil-opt -opt-mode=speed -enable-sil-verify-all %s -ssa-destroy-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKOPT
+// RUN: %target-sil-opt -opt-mode=none  -enable-sil-verify-all %s -destroy-addr-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKDEB
+// RUN: %target-sil-opt -opt-mode=speed -enable-sil-verify-all %s -destroy-addr-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKOPT
 
 sil_stage canonical
 

--- a/test/SILOptimizer/hoist_destroy_addr_resilient.sil
+++ b/test/SILOptimizer/hoist_destroy_addr_resilient.sil
@@ -3,7 +3,7 @@
 // RUN:   -emit-module-path=%t/resilient_struct.swiftmodule \
 // RUN:   -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
 
-// RUN: %target-sil-opt -I %t -opt-mode=speed -enable-sil-verify-all %s -ssa-destroy-hoisting | %FileCheck %s --check-prefix=CHECK
+// RUN: %target-sil-opt -I %t -opt-mode=speed -enable-sil-verify-all %s -destroy-addr-hoisting | %FileCheck %s --check-prefix=CHECK
 
 import resilient_struct
 

--- a/validation-test/SILOptimizer/hoist_destroy_addr.sil
+++ b/validation-test/SILOptimizer/hoist_destroy_addr.sil
@@ -1,5 +1,5 @@
-// RUN: %target-sil-opt -opt-mode=none  -enable-sil-verify-all %s -ssa-destroy-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKDEB
-// RUN: %target-sil-opt -opt-mode=speed -enable-sil-verify-all %s -ssa-destroy-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKOPT
+// RUN: %target-sil-opt -opt-mode=none  -enable-sil-verify-all %s -destroy-addr-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKDEB
+// RUN: %target-sil-opt -opt-mode=speed -enable-sil-verify-all %s -destroy-addr-hoisting | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECKOPT
 
 // REQUIRES: rdar98890125
 // REQUIRES: long_test


### PR DESCRIPTION
It was previously named `SSADestroyHoisting` which is rather misleading considering that it deals with addresses and hoists destroy_addrs.
