### PR TITLE
DNM: Add -Rmodule-interface-rebuild to startOnMainActor

### DIFF
--- a/test/Concurrency/Runtime/startOnMainActor.swift
+++ b/test/Concurrency/Runtime/startOnMainActor.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend -Rmodule-interface-rebuild -Xfrontend -disable-availability-checking %s -o %t/a.out
+// RUN: %target-build-swift -Xfrontend -Rmodule-interface-rebuild -Xfrontend -disable-availability-checking %s -o %t/a.out 1>&2
 // RUN: %target-codesign %t/a.out
 // RUN:  %target-run %t/a.out
 

--- a/test/Concurrency/Runtime/startOnMainActor.swift
+++ b/test/Concurrency/Runtime/startOnMainActor.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-build-swift -Xfrontend -disable-availability-checking %s -o %t/a.out
+// RUN: %target-build-swift -Xfrontend -Rmodule-interface-rebuild -Xfrontend -disable-availability-checking %s -o %t/a.out
 // RUN: %target-codesign %t/a.out
 // RUN:  %target-run %t/a.out
 


### PR DESCRIPTION
Add remark to see why we're rebuilding from the swiftinterface occasionally, instead of using the perfectly good swiftmodule for the stdlib.

This is starting to affect the Windows CI now. Hopefully I get lucky and can trigger the failure first try.


The other workaround is [here](https://github.com/apple/swift/pull/64587), to produce the `private.swiftinterface`. We're supposed to prefer digging things out of the swiftmodule for the stdlib though, so that fix will just mask the issue for now.