### PR TITLE
Add a missing check for a corner case with package use site / internal decl site

### DIFF
--- a/include/swift/IDE/CodeCompletionString.h
+++ b/include/swift/IDE/CodeCompletionString.h
@@ -32,7 +32,7 @@ class CodeCompletionStringChunk {
 
 public:
   enum class ChunkKind {
-    /// "open", "public", "internal", "fileprivate", or "private".
+    /// "open", "public", "package", "internal", "fileprivate", or "private".
     AccessControlKeyword,
 
     /// such as @"available".

--- a/include/swift/IDE/CompletionOverrideLookup.h
+++ b/include/swift/IDE/CompletionOverrideLookup.h
@@ -53,6 +53,7 @@ public:
     hasAccessModifier = isKeywordSpecified("private") ||
                         isKeywordSpecified("fileprivate") ||
                         isKeywordSpecified("internal") ||
+                        isKeywordSpecified("package") ||
                         isKeywordSpecified("public") ||
                         isKeywordSpecified("open");
     hasOverride = isKeywordSpecified("override");

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4112,6 +4112,11 @@ static bool checkAccess(const DeclContext *useDC, const ValueDecl *VD,
     }
     return true;
   case AccessLevel::Internal: {
+    // Invalid if the use site is > Internal.
+    // E.g. extension containing a member of a protocol it conforms to has
+    // `package` access level but the member is `internal`
+    if (useDC->getContextKind() == DeclContextKind::Package)
+      return false;
     const ModuleDecl *sourceModule = sourceDC->getParentModule();
     const DeclContext *useFile = useDC->getModuleScopeContext();
     if (useFile->getParentModule() == sourceModule)

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -1471,7 +1471,11 @@ public class DerivedFromInternalConcreteGenericComposition : InternalConcreteGen
   public func publicReq() {}
 }
 
-// FIXME: rdar://104987455 should have expected note and error 'class cannot be declared public because its superclass is internal'
+fileprivate typealias FilePrivateConcreteGenericCompositionPkg = InternalGenericClass<Int> & InternalProto
+public class DerivedFromFilePrivateConcreteGenericCompositionPkg : FilePrivateConcreteGenericCompositionPkg { // expected-error {{class cannot be declared public because its superclass uses an internal type as a generic parameter}}
+  public func internalReq() {}
+}
+
 internal typealias InternalConcreteGenericCompositionPkg = PackageGenericClass<Int> & PackageProto
 public class DerivedFromInternalConcreteGenericCompositionPkg : InternalConcreteGenericCompositionPkg { // expected-error {{class cannot be declared public because its superclass uses a package type as a generic parameter}}
   public func packageReq() {}

--- a/test/attr/accessibility_proto.swift
+++ b/test/attr/accessibility_proto.swift
@@ -243,3 +243,29 @@ package protocol PkgEmptyInit {
 public struct PkgBuggy: PkgEmptyInit {
   // expected-error@-1 {{initializer 'init()' must be declared package because it matches a requirement in package protocol 'PkgEmptyInit'}}
 }
+
+package protocol PkgReqProvider {}
+extension PkgReqProvider {
+  fileprivate func foo() {}
+  // expected-note@-1 {{mark the instance method as 'package' to satisfy the requirement}} {{3-14=package}}
+  typealias AssocB = String
+  // expected-note@-1 {{mark the type alias as 'package' to satisfy the requirement}} {{3-3=package }}
+}
+package struct PkgAdoptViaProtocol : PkgProtoWithReqs, PkgReqProvider {
+  // expected-error@-1 {{method 'foo()' must be declared package because it matches a requirement in package protocol 'PkgProtoWithReqs'}} {{none}}
+  // expected-error@-2 {{type alias 'AssocB' must be declared package because it matches a requirement in package protocol 'PkgProtoWithReqs'}} {{none}}
+  package typealias AssocA = Int
+}
+
+package protocol PkgReqProvider2 {}
+extension PkgProtoWithReqs where Self : PkgReqProvider2 {
+  func foo() {}
+  // expected-note@-1 {{mark the instance method as 'package' to satisfy the requirement}} {{3-3=package }}
+  typealias AssocB = String
+  // expected-note@-1 {{mark the type alias as 'package' to satisfy the requirement}} {{3-3=package }}
+}
+package struct PkgAdoptViaCombinedProtocol : PkgProtoWithReqs, PkgReqProvider2 {
+  // expected-error@-1 {{method 'foo()' must be declared package because it matches a requirement in package protocol 'PkgProtoWithReqs'}} {{none}}
+  // expected-error@-2 {{type alias 'AssocB' must be declared package because it matches a requirement in package protocol 'PkgProtoWithReqs'}} {{none}}
+  public typealias AssocA = Int
+}


### PR DESCRIPTION
* Add a missing check for a corner case with package use site / internal decl site
* Add package keyword to the code completion override lookup
* Update tests
Resolves rdar://106732804, rdar://104987455
